### PR TITLE
Allow composite aggregation to be a sub agg of the random sampler

### DIFF
--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/composite/CompositeAggregationBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/composite/CompositeAggregationBuilder.java
@@ -18,6 +18,7 @@ import org.elasticsearch.search.aggregations.AggregatorFactories;
 import org.elasticsearch.search.aggregations.AggregatorFactory;
 import org.elasticsearch.search.aggregations.bucket.filter.FilterAggregatorFactory;
 import org.elasticsearch.search.aggregations.bucket.nested.NestedAggregatorFactory;
+import org.elasticsearch.search.aggregations.bucket.sampler.random.RandomSamplerAggregatorFactory;
 import org.elasticsearch.search.aggregations.support.AggregationContext;
 import org.elasticsearch.search.aggregations.support.ValuesSourceRegistry;
 import org.elasticsearch.xcontent.ConstructingObjectParser;
@@ -176,11 +177,13 @@ public class CompositeAggregationBuilder extends AbstractAggregationBuilder<Comp
     private AggregatorFactory validateParentAggregations(AggregatorFactory factory) {
         if (factory == null) {
             return null;
-        } else if (factory instanceof NestedAggregatorFactory || factory instanceof FilterAggregatorFactory) {
-            return validateParentAggregations(factory.getParent());
-        } else {
-            return factory;
-        }
+        } else if (factory instanceof NestedAggregatorFactory
+            || factory instanceof FilterAggregatorFactory
+            || factory instanceof RandomSamplerAggregatorFactory) {
+                return validateParentAggregations(factory.getParent());
+            } else {
+                return factory;
+            }
     }
 
     private static void validateSources(List<CompositeValuesSourceBuilder<?>> sources) {

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/sampler/random/RandomSamplerAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/sampler/random/RandomSamplerAggregator.java
@@ -115,8 +115,8 @@ public class RandomSamplerAggregator extends BucketsAggregator implements Single
                     collectBucket(sub, docIt.docID(), 0);
                 }
             }
-        // This collector could throw `CollectionTerminatedException` if the last leaf collector has stopped collecting
-        // So, catch here and indicate no-op
+            // This collector could throw `CollectionTerminatedException` if the last leaf collector has stopped collecting
+            // So, catch here and indicate no-op
         } catch (CollectionTerminatedException e) {
             return LeafBucketCollector.NO_OP_COLLECTOR;
         }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/sampler/random/RandomSamplerAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/sampler/random/RandomSamplerAggregator.java
@@ -107,14 +107,16 @@ public class RandomSamplerAggregator extends BucketsAggregator implements Single
         }
         final DocIdSetIterator docIt = scorer.iterator();
         final Bits liveDocs = ctx.reader().getLiveDocs();
-        // Iterate every document provided by the scorer iterator
         try {
+            // Iterate every document provided by the scorer iterator
             for (int docId = docIt.nextDoc(); docId != DocIdSetIterator.NO_MORE_DOCS; docId = docIt.nextDoc()) {
                 // If liveDocs is null, that means that every doc is a live doc, no need to check if it has been deleted or not
                 if (liveDocs == null || liveDocs.get(docIt.docID())) {
                     collectBucket(sub, docIt.docID(), 0);
                 }
             }
+        // This collector could throw `CollectionTerminatedException` if the last leaf collector has stopped collecting
+        // So, catch here and indicate no-op
         } catch (CollectionTerminatedException e) {
             return LeafBucketCollector.NO_OP_COLLECTOR;
         }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/sampler/random/RandomSamplerAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/sampler/random/RandomSamplerAggregator.java
@@ -9,6 +9,7 @@
 package org.elasticsearch.search.aggregations.bucket.sampler.random;
 
 import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.search.CollectionTerminatedException;
 import org.apache.lucene.search.DocIdSetIterator;
 import org.apache.lucene.search.Scorer;
 import org.apache.lucene.search.Weight;
@@ -107,11 +108,15 @@ public class RandomSamplerAggregator extends BucketsAggregator implements Single
         final DocIdSetIterator docIt = scorer.iterator();
         final Bits liveDocs = ctx.reader().getLiveDocs();
         // Iterate every document provided by the scorer iterator
-        for (int docId = docIt.nextDoc(); docId != DocIdSetIterator.NO_MORE_DOCS; docId = docIt.nextDoc()) {
-            // If liveDocs is null, that means that every doc is a live doc, no need to check if it has been deleted or not
-            if (liveDocs == null || liveDocs.get(docIt.docID())) {
-                collectBucket(sub, docIt.docID(), 0);
+        try {
+            for (int docId = docIt.nextDoc(); docId != DocIdSetIterator.NO_MORE_DOCS; docId = docIt.nextDoc()) {
+                // If liveDocs is null, that means that every doc is a live doc, no need to check if it has been deleted or not
+                if (liveDocs == null || liveDocs.get(docIt.docID())) {
+                    collectBucket(sub, docIt.docID(), 0);
+                }
             }
+        } catch (CollectionTerminatedException e) {
+            return LeafBucketCollector.NO_OP_COLLECTOR;
         }
         // Since we have done our own collection, there is nothing for the leaf collector to do
         return LeafBucketCollector.NO_OP_COLLECTOR;

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/composite/CompositeAggregatorTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/composite/CompositeAggregatorTests.java
@@ -60,9 +60,11 @@ import org.elasticsearch.index.mapper.TimeSeriesIdFieldMapper;
 import org.elasticsearch.index.mapper.Uid;
 import org.elasticsearch.index.query.MatchAllQueryBuilder;
 import org.elasticsearch.search.DocValueFormat;
+import org.elasticsearch.search.aggregations.AggregationBuilder;
 import org.elasticsearch.search.aggregations.AggregationBuilders;
 import org.elasticsearch.search.aggregations.Aggregator;
 import org.elasticsearch.search.aggregations.AggregatorTestCase;
+import org.elasticsearch.search.aggregations.InternalAggregation;
 import org.elasticsearch.search.aggregations.bucket.InternalSingleBucketAggregation;
 import org.elasticsearch.search.aggregations.bucket.filter.FilterAggregationBuilder;
 import org.elasticsearch.search.aggregations.bucket.geogrid.GeoTileGridAggregationBuilder;
@@ -70,6 +72,7 @@ import org.elasticsearch.search.aggregations.bucket.geogrid.GeoTileUtils;
 import org.elasticsearch.search.aggregations.bucket.histogram.DateHistogramAggregationBuilder;
 import org.elasticsearch.search.aggregations.bucket.histogram.DateHistogramInterval;
 import org.elasticsearch.search.aggregations.bucket.nested.NestedAggregationBuilder;
+import org.elasticsearch.search.aggregations.bucket.sampler.random.InternalRandomSampler;
 import org.elasticsearch.search.aggregations.bucket.sampler.random.RandomSamplerAggregationBuilder;
 import org.elasticsearch.search.aggregations.bucket.terms.StringTerms;
 import org.elasticsearch.search.aggregations.bucket.terms.TermsAggregationBuilder;
@@ -104,9 +107,15 @@ import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 import static org.elasticsearch.search.aggregations.bucket.nested.NestedAggregatorTests.nestedObject;
+import static org.hamcrest.Matchers.anyOf;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.lessThan;
+import static org.hamcrest.Matchers.nullValue;
 
 public class CompositeAggregatorTests extends AggregatorTestCase {
     private static MappedFieldType[] FIELD_TYPES;
@@ -167,7 +176,7 @@ public class CompositeAggregatorTests extends AggregatorTestCase {
             Arrays.asList(new MatchAllDocsQuery(), new DocValuesFieldExistsQuery("keyword")),
             dataset,
             () -> new CompositeAggregationBuilder("name", Arrays.asList(new TermsValuesSourceBuilder("unmapped").field("unmapped"))),
-            (result) -> { assertEquals(0, result.getBuckets().size()); }
+            (InternalComposite result) -> { assertEquals(0, result.getBuckets().size()); }
         );
 
         testSearchCase(
@@ -177,7 +186,7 @@ public class CompositeAggregatorTests extends AggregatorTestCase {
                 "name",
                 Arrays.asList(new TermsValuesSourceBuilder("unmapped").field("unmapped").missingBucket(true))
             ),
-            (result) -> {
+            (InternalComposite result) -> {
                 assertEquals(1, result.getBuckets().size());
                 assertEquals("{unmapped=null}", result.afterKey().toString());
                 assertEquals("{unmapped=null}", result.getBuckets().get(0).getKeyAsString());
@@ -192,7 +201,7 @@ public class CompositeAggregatorTests extends AggregatorTestCase {
                 "name",
                 Arrays.asList(new TermsValuesSourceBuilder("unmapped").field("unmapped").missingBucket(true))
             ).aggregateAfter(Collections.singletonMap("unmapped", null)),
-            (result) -> { assertEquals(0, result.getBuckets().size()); }
+            (InternalComposite result) -> { assertEquals(0, result.getBuckets().size()); }
         );
 
         testSearchCase(
@@ -205,7 +214,7 @@ public class CompositeAggregatorTests extends AggregatorTestCase {
                     new TermsValuesSourceBuilder("unmapped").field("unmapped")
                 )
             ),
-            (result) -> { assertEquals(0, result.getBuckets().size()); }
+            (InternalComposite result) -> { assertEquals(0, result.getBuckets().size()); }
         );
 
         testSearchCase(
@@ -218,7 +227,7 @@ public class CompositeAggregatorTests extends AggregatorTestCase {
                     new TermsValuesSourceBuilder("unmapped").field("unmapped").missingBucket(true)
                 )
             ),
-            (result) -> {
+            (InternalComposite result) -> {
                 assertEquals(3, result.getBuckets().size());
                 assertEquals("{keyword=d, unmapped=null}", result.afterKey().toString());
                 assertEquals("{keyword=a, unmapped=null}", result.getBuckets().get(0).getKeyAsString());
@@ -249,7 +258,7 @@ public class CompositeAggregatorTests extends AggregatorTestCase {
             Arrays.asList(new MatchAllDocsQuery(), new DocValuesFieldExistsQuery(mappedFieldName)),
             dataset,
             () -> new CompositeAggregationBuilder("name", Arrays.asList(new GeoTileGridValuesSourceBuilder("unmapped").field("unmapped"))),
-            (result) -> assertEquals(0, result.getBuckets().size())
+            (InternalComposite result) -> assertEquals(0, result.getBuckets().size())
         );
 
         // unmapped missing bucket = one result
@@ -260,7 +269,7 @@ public class CompositeAggregatorTests extends AggregatorTestCase {
                 "name",
                 Arrays.asList(new GeoTileGridValuesSourceBuilder("unmapped").field("unmapped").missingBucket(true))
             ),
-            (result) -> {
+            (InternalComposite result) -> {
                 assertEquals(1, result.getBuckets().size());
                 assertEquals("{unmapped=null}", result.afterKey().toString());
                 assertEquals("{unmapped=null}", result.getBuckets().get(0).getKeyAsString());
@@ -279,7 +288,7 @@ public class CompositeAggregatorTests extends AggregatorTestCase {
                     new GeoTileGridValuesSourceBuilder("unmapped").field("unmapped")
                 )
             ),
-            (result) -> assertEquals(0, result.getBuckets().size())
+            (InternalComposite result) -> assertEquals(0, result.getBuckets().size())
         );
 
         // field + unmapped with missing bucket = multiple results
@@ -293,7 +302,7 @@ public class CompositeAggregatorTests extends AggregatorTestCase {
                     new GeoTileGridValuesSourceBuilder("unmapped").field("unmapped").missingBucket(true)
                 )
             ),
-            (result) -> {
+            (InternalComposite result) -> {
                 assertEquals(2, result.getBuckets().size());
                 assertEquals("{geo_point=7/64/56, unmapped=null}", result.afterKey().toString());
                 assertEquals("{geo_point=7/32/56, unmapped=null}", result.getBuckets().get(0).getKeyAsString());
@@ -326,7 +335,7 @@ public class CompositeAggregatorTests extends AggregatorTestCase {
                 "name",
                 Arrays.asList(new HistogramValuesSourceBuilder("unmapped").field("unmapped").interval(10))
             ),
-            (result) -> assertEquals(0, result.getBuckets().size())
+            (InternalComposite result) -> assertEquals(0, result.getBuckets().size())
         );
         // unmapped missing bucket = one result
         testSearchCase(
@@ -336,7 +345,7 @@ public class CompositeAggregatorTests extends AggregatorTestCase {
                 "name",
                 Arrays.asList(new HistogramValuesSourceBuilder("unmapped").field("unmapped").interval(10).missingBucket(true))
             ),
-            (result) -> {
+            (InternalComposite result) -> {
                 assertEquals(1, result.getBuckets().size());
                 assertEquals("{unmapped=null}", result.afterKey().toString());
                 assertEquals("{unmapped=null}", result.getBuckets().get(0).getKeyAsString());
@@ -355,7 +364,7 @@ public class CompositeAggregatorTests extends AggregatorTestCase {
                     new HistogramValuesSourceBuilder("unmapped").field("unmapped").interval(10)
                 )
             ),
-            (result) -> assertEquals(0, result.getBuckets().size())
+            (InternalComposite result) -> assertEquals(0, result.getBuckets().size())
         );
 
         // field + unmapped with missing bucket = multiple results
@@ -369,7 +378,7 @@ public class CompositeAggregatorTests extends AggregatorTestCase {
                     new HistogramValuesSourceBuilder("unmapped").field("unmapped").interval(10).missingBucket(true)
                 )
             ),
-            (result) -> {
+            (InternalComposite result) -> {
                 assertEquals(3, result.getBuckets().size());
                 assertEquals("{price=100.0, unmapped=null}", result.afterKey().toString());
                 assertEquals("{price=20.0, unmapped=null}", result.getBuckets().get(0).getKeyAsString());
@@ -404,7 +413,7 @@ public class CompositeAggregatorTests extends AggregatorTestCase {
                     new DateHistogramValuesSourceBuilder("unmapped").field("unmapped").calendarInterval(DateHistogramInterval.days(1))
                 )
             ),
-            (result) -> assertEquals(0, result.getBuckets().size())
+            (InternalComposite result) -> assertEquals(0, result.getBuckets().size())
         );
         // unmapped missing bucket = one result
         testSearchCase(
@@ -418,7 +427,7 @@ public class CompositeAggregatorTests extends AggregatorTestCase {
                         .missingBucket(true)
                 )
             ),
-            (result) -> {
+            (InternalComposite result) -> {
                 assertEquals(1, result.getBuckets().size());
                 assertEquals("{unmapped=null}", result.afterKey().toString());
                 assertEquals("{unmapped=null}", result.getBuckets().get(0).getKeyAsString());
@@ -437,7 +446,7 @@ public class CompositeAggregatorTests extends AggregatorTestCase {
                     new DateHistogramValuesSourceBuilder("unmapped").field("unmapped").calendarInterval(DateHistogramInterval.days(1))
                 )
             ),
-            (result) -> assertEquals(0, result.getBuckets().size())
+            (InternalComposite result) -> assertEquals(0, result.getBuckets().size())
         );
 
         // field + unmapped with missing bucket = multiple results
@@ -454,7 +463,7 @@ public class CompositeAggregatorTests extends AggregatorTestCase {
                         .missingBucket(true)
                 )
             ),
-            (result) -> {
+            (InternalComposite result) -> {
                 assertEquals(3, result.getBuckets().size());
                 assertEquals("{date=1508457600000, unmapped=null}", result.afterKey().toString());
                 assertEquals("{date=1474329600000, unmapped=null}", result.getBuckets().get(0).getKeyAsString());
@@ -483,7 +492,7 @@ public class CompositeAggregatorTests extends AggregatorTestCase {
             Arrays.asList(new MatchAllDocsQuery(), new DocValuesFieldExistsQuery("long")),
             dataset,
             () -> new CompositeAggregationBuilder("name", Arrays.asList(new TermsValuesSourceBuilder("unmapped").field("unmapped"))),
-            (result) -> { assertEquals(0, result.getBuckets().size()); }
+            (InternalComposite result) -> { assertEquals(0, result.getBuckets().size()); }
         );
 
         testSearchCase(
@@ -493,7 +502,7 @@ public class CompositeAggregatorTests extends AggregatorTestCase {
                 "name",
                 Arrays.asList(new TermsValuesSourceBuilder("unmapped").field("unmapped").missingBucket(true))
             ),
-            (result) -> {
+            (InternalComposite result) -> {
                 assertEquals(1, result.getBuckets().size());
                 assertEquals("{unmapped=null}", result.afterKey().toString());
                 assertEquals("{unmapped=null}", result.getBuckets().get(0).getKeyAsString());
@@ -508,7 +517,7 @@ public class CompositeAggregatorTests extends AggregatorTestCase {
                 "name",
                 Arrays.asList(new TermsValuesSourceBuilder("unmapped").field("unmapped").missingBucket(true))
             ).aggregateAfter(Collections.singletonMap("unmapped", null)),
-            (result) -> { assertEquals(0, result.getBuckets().size()); }
+            (InternalComposite result) -> { assertEquals(0, result.getBuckets().size()); }
         );
 
         testSearchCase(
@@ -521,7 +530,7 @@ public class CompositeAggregatorTests extends AggregatorTestCase {
                     new TermsValuesSourceBuilder("unmapped").field("unmapped")
                 )
             ),
-            (result) -> { assertEquals(0, result.getBuckets().size()); }
+            (InternalComposite result) -> { assertEquals(0, result.getBuckets().size()); }
         );
 
         testSearchCase(
@@ -534,7 +543,7 @@ public class CompositeAggregatorTests extends AggregatorTestCase {
                     new TermsValuesSourceBuilder("unmapped").field("unmapped").missingBucket(true)
                 )
             ),
-            (result) -> {
+            (InternalComposite result) -> {
                 assertEquals(3, result.getBuckets().size());
                 assertEquals("{long=4, unmapped=null}", result.afterKey().toString());
                 assertEquals("{long=1, unmapped=null}", result.getBuckets().get(0).getKeyAsString());
@@ -556,7 +565,7 @@ public class CompositeAggregatorTests extends AggregatorTestCase {
                     new TermsValuesSourceBuilder("unmapped").field("unmapped").missingBucket(true)
                 )
             ).aggregateAfter(Map.of("long", 1, "unmapped", randomFrom(randomBoolean(), 1, "b"))),
-            (result) -> {
+            (InternalComposite result) -> {
                 assertEquals(2, result.getBuckets().size());
                 assertEquals("{long=4, unmapped=null}", result.afterKey().toString());
                 assertEquals("{long=3, unmapped=null}", result.getBuckets().get(0).getKeyAsString());
@@ -581,7 +590,7 @@ public class CompositeAggregatorTests extends AggregatorTestCase {
         testSearchCase(Arrays.asList(new MatchAllDocsQuery(), new DocValuesFieldExistsQuery("keyword")), dataset, () -> {
             TermsValuesSourceBuilder terms = new TermsValuesSourceBuilder("keyword").field("keyword");
             return new CompositeAggregationBuilder("name", Collections.singletonList(terms));
-        }, (result) -> {
+        }, (InternalComposite result) -> {
             assertEquals(3, result.getBuckets().size());
             assertEquals("{keyword=d}", result.afterKey().toString());
             assertEquals("{keyword=a}", result.getBuckets().get(0).getKeyAsString());
@@ -597,7 +606,7 @@ public class CompositeAggregatorTests extends AggregatorTestCase {
             return new CompositeAggregationBuilder("name", Collections.singletonList(terms)).aggregateAfter(
                 Collections.singletonMap("keyword", "a")
             );
-        }, (result) -> {
+        }, (InternalComposite result) -> {
             assertEquals(2, result.getBuckets().size());
             assertEquals("{keyword=d}", result.afterKey().toString());
             assertEquals("{keyword=c}", result.getBuckets().get(0).getKeyAsString());
@@ -762,7 +771,7 @@ public class CompositeAggregatorTests extends AggregatorTestCase {
         testSearchCase(Arrays.asList(new MatchAllDocsQuery()), dataset, () -> {
             TermsValuesSourceBuilder terms = new TermsValuesSourceBuilder("keyword").field("keyword").missingBucket(true);
             return new CompositeAggregationBuilder("name", Collections.singletonList(terms));
-        }, (result) -> {
+        }, (InternalComposite result) -> {
             assertEquals(4, result.getBuckets().size());
             assertEquals("{keyword=d}", result.afterKey().toString());
             assertEquals("{keyword=null}", result.getBuckets().get(0).getKeyAsString());
@@ -781,7 +790,7 @@ public class CompositeAggregatorTests extends AggregatorTestCase {
                 .missingBucket(true)
                 .order(SortOrder.DESC);
             return new CompositeAggregationBuilder("name", Collections.singletonList(terms));
-        }, (result) -> {
+        }, (InternalComposite result) -> {
             assertEquals(4, result.getBuckets().size());
             assertEquals("{keyword=null}", result.afterKey().toString());
             assertEquals("{keyword=null}", result.getBuckets().get(3).getKeyAsString());
@@ -799,7 +808,7 @@ public class CompositeAggregatorTests extends AggregatorTestCase {
             return new CompositeAggregationBuilder("name", Collections.singletonList(terms)).aggregateAfter(
                 Collections.singletonMap("keyword", null)
             );
-        }, (result) -> {
+        }, (InternalComposite result) -> {
             assertEquals(3, result.getBuckets().size());
             assertEquals("{keyword=d}", result.afterKey().toString());
             assertEquals("{keyword=a}", result.getBuckets().get(0).getKeyAsString());
@@ -817,7 +826,7 @@ public class CompositeAggregatorTests extends AggregatorTestCase {
             return new CompositeAggregationBuilder("name", Collections.singletonList(terms)).aggregateAfter(
                 Collections.singletonMap("keyword", null)
             );
-        }, (result) -> {
+        }, (InternalComposite result) -> {
             assertEquals(0, result.getBuckets().size());
             assertNull(result.afterKey());
         });
@@ -838,7 +847,7 @@ public class CompositeAggregatorTests extends AggregatorTestCase {
         testSearchCase(Arrays.asList(new MatchAllDocsQuery(), new DocValuesFieldExistsQuery("keyword")), dataset, () -> {
             TermsValuesSourceBuilder terms = new TermsValuesSourceBuilder("keyword").field("keyword");
             return new CompositeAggregationBuilder("name", Collections.singletonList(terms));
-        }, (result) -> {
+        }, (InternalComposite result) -> {
             assertEquals(4, result.getBuckets().size());
             assertEquals("{keyword=zoo}", result.afterKey().toString());
             assertEquals("{keyword=bar}", result.getBuckets().get(0).getKeyAsString());
@@ -856,7 +865,7 @@ public class CompositeAggregatorTests extends AggregatorTestCase {
             return new CompositeAggregationBuilder("name", Collections.singletonList(terms)).aggregateAfter(
                 Collections.singletonMap("keyword", "car")
             );
-        }, (result) -> {
+        }, (InternalComposite result) -> {
             assertEquals(3, result.getBuckets().size());
             assertEquals("{keyword=zoo}", result.afterKey().toString());
             assertEquals("{keyword=delta}", result.getBuckets().get(0).getKeyAsString());
@@ -872,7 +881,7 @@ public class CompositeAggregatorTests extends AggregatorTestCase {
             return new CompositeAggregationBuilder("name", Collections.singletonList(terms)).aggregateAfter(
                 Collections.singletonMap("keyword", "mar")
             );
-        }, (result) -> {
+        }, (InternalComposite result) -> {
             assertEquals(3, result.getBuckets().size());
             assertEquals("{keyword=bar}", result.afterKey().toString());
             assertEquals("{keyword=foo}", result.getBuckets().get(0).getKeyAsString());
@@ -898,7 +907,7 @@ public class CompositeAggregatorTests extends AggregatorTestCase {
         testSearchCase(Arrays.asList(new MatchAllDocsQuery(), new DocValuesFieldExistsQuery("keyword")), dataset, () -> {
             TermsValuesSourceBuilder terms = new TermsValuesSourceBuilder("keyword").field("keyword").order(SortOrder.DESC);
             return new CompositeAggregationBuilder("name", Collections.singletonList(terms));
-        }, (result) -> {
+        }, (InternalComposite result) -> {
             assertEquals(3, result.getBuckets().size());
             assertEquals("{keyword=a}", result.afterKey().toString());
             assertEquals("{keyword=a}", result.getBuckets().get(2).getKeyAsString());
@@ -915,7 +924,7 @@ public class CompositeAggregatorTests extends AggregatorTestCase {
                 Collections.singletonMap("keyword", "c")
             );
 
-        }, (result) -> {
+        }, (InternalComposite result) -> {
             assertEquals(result.afterKey().toString(), "{keyword=a}");
             assertEquals("{keyword=a}", result.afterKey().toString());
             assertEquals(1, result.getBuckets().size());
@@ -940,7 +949,7 @@ public class CompositeAggregatorTests extends AggregatorTestCase {
             TermsValuesSourceBuilder terms = new TermsValuesSourceBuilder("keyword").field("keyword");
             return new CompositeAggregationBuilder("name", Collections.singletonList(terms));
 
-        }, (result) -> {
+        }, (InternalComposite result) -> {
             assertEquals(5, result.getBuckets().size());
             assertEquals("{keyword=z}", result.afterKey().toString());
             assertEquals("{keyword=a}", result.getBuckets().get(0).getKeyAsString());
@@ -961,7 +970,7 @@ public class CompositeAggregatorTests extends AggregatorTestCase {
                 Collections.singletonMap("keyword", "b")
             );
 
-        }, (result) -> {
+        }, (InternalComposite result) -> {
             assertEquals(3, result.getBuckets().size());
             assertEquals("{keyword=z}", result.afterKey().toString());
             assertEquals("{keyword=c}", result.getBuckets().get(0).getKeyAsString());
@@ -989,7 +998,7 @@ public class CompositeAggregatorTests extends AggregatorTestCase {
             TermsValuesSourceBuilder terms = new TermsValuesSourceBuilder("keyword").field("keyword").order(SortOrder.DESC);
             return new CompositeAggregationBuilder("name", Collections.singletonList(terms));
 
-        }, (result) -> {
+        }, (InternalComposite result) -> {
             assertEquals(5, result.getBuckets().size());
             assertEquals("{keyword=a}", result.afterKey().toString());
             assertEquals("{keyword=a}", result.getBuckets().get(4).getKeyAsString());
@@ -1010,7 +1019,7 @@ public class CompositeAggregatorTests extends AggregatorTestCase {
                 Collections.singletonMap("keyword", "c")
             );
 
-        }, (result) -> {
+        }, (InternalComposite result) -> {
             assertEquals(2, result.getBuckets().size());
             assertEquals("{keyword=a}", result.afterKey().toString());
             assertEquals("{keyword=a}", result.getBuckets().get(1).getKeyAsString());
@@ -1040,7 +1049,7 @@ public class CompositeAggregatorTests extends AggregatorTestCase {
                 "name",
                 Arrays.asList(new TermsValuesSourceBuilder("keyword").field("keyword"), new TermsValuesSourceBuilder("long").field("long"))
             ),
-            (result) -> {
+            (InternalComposite result) -> {
                 assertEquals(4, result.getBuckets().size());
                 assertEquals("{keyword=d, long=10}", result.afterKey().toString());
                 assertEquals("{keyword=a, long=0}", result.getBuckets().get(0).getKeyAsString());
@@ -1061,7 +1070,7 @@ public class CompositeAggregatorTests extends AggregatorTestCase {
                 "name",
                 Arrays.asList(new TermsValuesSourceBuilder("keyword").field("keyword"), new TermsValuesSourceBuilder("long").field("long"))
             ).aggregateAfter(createAfterKey("keyword", "a", "long", 100L)),
-            (result) -> {
+            (InternalComposite result) -> {
                 assertEquals(2, result.getBuckets().size());
                 assertEquals("{keyword=d, long=10}", result.afterKey().toString());
                 assertEquals("{keyword=c, long=100}", result.getBuckets().get(0).getKeyAsString());
@@ -1083,7 +1092,7 @@ public class CompositeAggregatorTests extends AggregatorTestCase {
                         new TermsValuesSourceBuilder("long").field("long")
                     )
                 ).aggregateAfter(createAfterKey("keyword", 0L, "long", 100L)),
-                (result) -> {}
+                (InternalComposite result) -> {}
             )
         );
         assertThat(
@@ -1118,7 +1127,7 @@ public class CompositeAggregatorTests extends AggregatorTestCase {
                     new TermsValuesSourceBuilder("long").field("long").order(SortOrder.DESC)
                 )
             ),
-            (result) -> {
+            (InternalComposite result) -> {
                 assertEquals(4, result.getBuckets().size());
                 assertEquals("{keyword=a, long=0}", result.afterKey().toString());
                 assertEquals("{keyword=a, long=0}", result.getBuckets().get(3).getKeyAsString());
@@ -1142,7 +1151,7 @@ public class CompositeAggregatorTests extends AggregatorTestCase {
                     new TermsValuesSourceBuilder("long").field("long").order(SortOrder.DESC)
                 )
             ).aggregateAfter(createAfterKey("keyword", "d", "long", 10L)),
-            (result) -> {
+            (InternalComposite result) -> {
                 assertEquals(3, result.getBuckets().size());
                 assertEquals("{keyword=a, long=0}", result.afterKey().toString());
                 assertEquals("{keyword=a, long=0}", result.getBuckets().get(2).getKeyAsString());
@@ -1180,7 +1189,7 @@ public class CompositeAggregatorTests extends AggregatorTestCase {
                     new TermsValuesSourceBuilder("long").field("long").missingBucket(true)
                 )
             ),
-            (result) -> {
+            (InternalComposite result) -> {
                 assertEquals(7, result.getBuckets().size());
                 assertEquals("{keyword=d, long=10}", result.afterKey().toString());
                 assertEquals("{keyword=null, long=null}", result.getBuckets().get(0).getKeyAsString());
@@ -1210,7 +1219,7 @@ public class CompositeAggregatorTests extends AggregatorTestCase {
                     new TermsValuesSourceBuilder("long").field("long").missingBucket(true)
                 )
             ).aggregateAfter(createAfterKey("keyword", "c", "long", null)),
-            (result) -> {
+            (InternalComposite result) -> {
                 assertEquals(2, result.getBuckets().size());
                 assertEquals("{keyword=d, long=10}", result.afterKey().toString());
                 assertEquals("{keyword=c, long=100}", result.getBuckets().get(0).getKeyAsString());
@@ -1220,7 +1229,7 @@ public class CompositeAggregatorTests extends AggregatorTestCase {
             }
         );
 
-        Consumer<InternalComposite> verifyMissingFirst = (result) -> {
+        Consumer<InternalComposite> verifyMissingFirst = (InternalComposite result) -> {
             assertEquals(7, result.getBuckets().size());
             assertEquals("{keyword=null, long=null}", result.getBuckets().get(0).getKeyAsString());
             assertEquals("{keyword=null, long=100}", result.getBuckets().get(1).getKeyAsString());
@@ -1258,7 +1267,7 @@ public class CompositeAggregatorTests extends AggregatorTestCase {
             verifyMissingFirst
         );
 
-        Consumer<InternalComposite> verifyMissingLast = (result) -> {
+        Consumer<InternalComposite> verifyMissingLast = (InternalComposite result) -> {
             assertEquals(7, result.getBuckets().size());
             assertEquals("{keyword=null, long=100}", result.getBuckets().get(5).getKeyAsString());
             assertEquals("{keyword=null, long=null}", result.getBuckets().get(6).getKeyAsString());
@@ -1376,7 +1385,7 @@ public class CompositeAggregatorTests extends AggregatorTestCase {
             Arrays.asList(new MatchAllDocsQuery(), new DocValuesFieldExistsQuery("const")),
             dataset,
             () -> new CompositeAggregationBuilder("name", Collections.singletonList(sourceBuilder)),
-            (result) -> {
+            (InternalComposite result) -> {
                 if (expectedMissingIndex == null) {
                     for (InternalComposite.InternalBucket bucket : result.getBuckets()) {
                         assertFalse(bucket.getKey().containsValue(null));
@@ -1410,7 +1419,7 @@ public class CompositeAggregatorTests extends AggregatorTestCase {
                         .order(SortOrder.ASC)
                 )
             ).aggregateAfter(createAfterKey("keyword", null)),
-            (result) -> {
+            (InternalComposite result) -> {
                 assertEquals(2, result.getBuckets().size());
                 assertEquals("{keyword=a}", result.getBuckets().get(0).getKeyAsString());
                 assertEquals("{keyword=b}", result.getBuckets().get(1).getKeyAsString());
@@ -1430,7 +1439,7 @@ public class CompositeAggregatorTests extends AggregatorTestCase {
                     new TermsValuesSourceBuilder("long").field("long")
                 )
             ).aggregateAfter(createAfterKey("keyword", null, "long", 1)),
-            (result) -> {
+            (InternalComposite result) -> {
                 assertEquals(1, result.getBuckets().size());
                 assertEquals("{keyword=null, long=2}", result.getBuckets().get(0).getKeyAsString());
             }
@@ -1448,7 +1457,7 @@ public class CompositeAggregatorTests extends AggregatorTestCase {
                         .order(SortOrder.ASC)
                 )
             ).aggregateAfter(createAfterKey("keyword", null)),
-            (result) -> { assertEquals(0, result.getBuckets().size()); }
+            (InternalComposite result) -> { assertEquals(0, result.getBuckets().size()); }
         );
 
         testSearchCase(
@@ -1464,7 +1473,7 @@ public class CompositeAggregatorTests extends AggregatorTestCase {
                     new TermsValuesSourceBuilder("long").field("long")
                 )
             ).aggregateAfter(createAfterKey("keyword", null, "long", 1)),
-            (result) -> {
+            (InternalComposite result) -> {
                 assertEquals(1, result.getBuckets().size());
                 assertEquals("{keyword=null, long=2}", result.getBuckets().get(0).getKeyAsString());
             }
@@ -1492,7 +1501,7 @@ public class CompositeAggregatorTests extends AggregatorTestCase {
                         .order(SortOrder.ASC)
                 )
             ).aggregateAfter(createAfterKey("hist", null)),
-            (result) -> {
+            (InternalComposite result) -> {
                 assertEquals(2, result.getBuckets().size());
                 assertEquals("{hist=1.0}", result.getBuckets().get(0).getKeyAsString());
                 assertEquals("{hist=2.0}", result.getBuckets().get(1).getKeyAsString());
@@ -1513,7 +1522,7 @@ public class CompositeAggregatorTests extends AggregatorTestCase {
                     new TermsValuesSourceBuilder("keyword").field("keyword")
                 )
             ).aggregateAfter(createAfterKey("hist", null, "keyword", "a")),
-            (result) -> {
+            (InternalComposite result) -> {
                 assertEquals(1, result.getBuckets().size());
                 assertEquals("{hist=null, keyword=b}", result.getBuckets().get(0).getKeyAsString());
             }
@@ -1532,7 +1541,7 @@ public class CompositeAggregatorTests extends AggregatorTestCase {
                         .order(SortOrder.ASC)
                 )
             ).aggregateAfter(createAfterKey("hist", null)),
-            (result) -> { assertEquals(0, result.getBuckets().size()); }
+            (InternalComposite result) -> { assertEquals(0, result.getBuckets().size()); }
         );
 
         testSearchCase(
@@ -1549,7 +1558,7 @@ public class CompositeAggregatorTests extends AggregatorTestCase {
                     new TermsValuesSourceBuilder("keyword").field("keyword")
                 )
             ).aggregateAfter(createAfterKey("hist", null, "keyword", "a")),
-            (result) -> {
+            (InternalComposite result) -> {
                 assertEquals(1, result.getBuckets().size());
                 assertEquals("{hist=null, keyword=b}", result.getBuckets().get(0).getKeyAsString());
             }
@@ -1576,7 +1585,7 @@ public class CompositeAggregatorTests extends AggregatorTestCase {
                 "name",
                 Arrays.asList(new TermsValuesSourceBuilder("keyword").field("keyword"), new TermsValuesSourceBuilder("long").field("long"))
             ),
-            (result) -> {
+            (InternalComposite result) -> {
                 assertEquals(10, result.getBuckets().size());
                 assertEquals("{keyword=z, long=0}", result.afterKey().toString());
                 assertEquals("{keyword=a, long=0}", result.getBuckets().get(0).getKeyAsString());
@@ -1609,7 +1618,7 @@ public class CompositeAggregatorTests extends AggregatorTestCase {
                 "name",
                 Arrays.asList(new TermsValuesSourceBuilder("keyword").field("keyword"), new TermsValuesSourceBuilder("long").field("long"))
             ).aggregateAfter(createAfterKey("keyword", "c", "long", 10L)),
-            (result) -> {
+            (InternalComposite result) -> {
                 assertEquals(6, result.getBuckets().size());
                 assertEquals("{keyword=z, long=100}", result.afterKey().toString());
                 assertEquals("{keyword=c, long=100}", result.getBuckets().get(0).getKeyAsString());
@@ -1651,7 +1660,7 @@ public class CompositeAggregatorTests extends AggregatorTestCase {
                     new TermsValuesSourceBuilder("long").field("long").order(SortOrder.DESC)
                 )
             ).aggregateAfter(createAfterKey("keyword", "z", "long", 100L)),
-            (result) -> {
+            (InternalComposite result) -> {
                 assertEquals(10, result.getBuckets().size());
                 assertEquals("{keyword=a, long=0}", result.afterKey().toString());
                 assertEquals("{keyword=a, long=0}", result.getBuckets().get(9).getKeyAsString());
@@ -1687,7 +1696,7 @@ public class CompositeAggregatorTests extends AggregatorTestCase {
                     new TermsValuesSourceBuilder("long").field("long").order(SortOrder.DESC)
                 )
             ).aggregateAfter(createAfterKey("keyword", "b", "long", 100L)),
-            (result) -> {
+            (InternalComposite result) -> {
                 assertEquals(2, result.getBuckets().size());
                 assertEquals("{keyword=a, long=0}", result.afterKey().toString());
                 assertEquals("{keyword=a, long=0}", result.getBuckets().get(1).getKeyAsString());
@@ -1729,7 +1738,7 @@ public class CompositeAggregatorTests extends AggregatorTestCase {
                     new TermsValuesSourceBuilder("double").field("double")
                 )
             ),
-            (result) -> {
+            (InternalComposite result) -> {
                 assertEquals(10, result.getBuckets().size());
                 assertEquals("{keyword=c, long=100, double=0.4}", result.afterKey().toString());
                 assertEquals("{keyword=a, long=0, double=0.09}", result.getBuckets().get(0).getKeyAsString());
@@ -1766,7 +1775,7 @@ public class CompositeAggregatorTests extends AggregatorTestCase {
                     new TermsValuesSourceBuilder("double").field("double")
                 )
             ).aggregateAfter(createAfterKey("keyword", "a", "long", 100L, "double", 0.4d)),
-            (result) -> {
+            (InternalComposite result) -> {
                 assertEquals(10, result.getBuckets().size());
                 assertEquals("{keyword=z, long=0, double=0.09}", result.afterKey().toString());
                 assertEquals("{keyword=b, long=100, double=0.4}", result.getBuckets().get(0).getKeyAsString());
@@ -1803,7 +1812,7 @@ public class CompositeAggregatorTests extends AggregatorTestCase {
                     new TermsValuesSourceBuilder("double").field("double")
                 )
             ).aggregateAfter(createAfterKey("keyword", "z", "long", 100L, "double", 0.4d)),
-            (result) -> {
+            (InternalComposite result) -> {
                 assertEquals(0, result.getBuckets().size());
                 assertNull(result.afterKey());
             }
@@ -1834,7 +1843,7 @@ public class CompositeAggregatorTests extends AggregatorTestCase {
                     .calendarInterval(DateHistogramInterval.days(1));
                 return new CompositeAggregationBuilder("name", Collections.singletonList(histo));
             },
-            (result) -> {
+            (InternalComposite result) -> {
                 assertEquals(3, result.getBuckets().size());
                 assertEquals("{date=1508457600000}", result.afterKey().toString());
                 assertEquals("{date=1474329600000}", result.getBuckets().get(0).getKeyAsString());
@@ -1861,7 +1870,7 @@ public class CompositeAggregatorTests extends AggregatorTestCase {
                 );
 
             },
-            (result) -> {
+            (InternalComposite result) -> {
                 assertEquals(2, result.getBuckets().size());
                 assertEquals("{date=1508457600000}", result.afterKey().toString());
                 assertEquals("{date=1508371200000}", result.getBuckets().get(0).getKeyAsString());
@@ -1891,7 +1900,7 @@ public class CompositeAggregatorTests extends AggregatorTestCase {
                 );
 
             },
-            (result) -> {
+            (InternalComposite result) -> {
                 assertEquals(3, result.getBuckets().size());
                 assertEquals("{date=1508472000000}", result.afterKey().toString());
                 assertEquals("{date=1474344000000}", result.getBuckets().get(0).getKeyAsString());
@@ -1923,7 +1932,7 @@ public class CompositeAggregatorTests extends AggregatorTestCase {
                 );
 
             },
-            (result) -> {
+            (InternalComposite result) -> {
                 assertEquals(3, result.getBuckets().size());
                 assertEquals("{date=1508472000000}", result.afterKey().toString());
                 assertEquals("{date=1474344000000}", result.getBuckets().get(0).getKeyAsString());
@@ -1956,7 +1965,7 @@ public class CompositeAggregatorTests extends AggregatorTestCase {
                 );
 
             },
-            (result) -> {
+            (InternalComposite result) -> {
                 assertEquals(3, result.getBuckets().size());
                 assertEquals("{date=1508410800000}", result.afterKey().toString());
                 assertEquals("{date=1474369200000}", result.getBuckets().get(0).getKeyAsString());
@@ -1992,7 +2001,7 @@ public class CompositeAggregatorTests extends AggregatorTestCase {
                 TermsValuesSourceBuilder histo = new TermsValuesSourceBuilder("date").field("date");
                 return new CompositeAggregationBuilder("name", Collections.singletonList(histo));
             },
-            (result) -> {
+            (InternalComposite result) -> {
                 assertEquals(5, result.getBuckets().size());
                 assertEquals("{date=1508479764000}", result.afterKey().toString());
                 assertThat(result.getBuckets().get(0).getKey().get("date"), instanceOf(Long.class));
@@ -2027,7 +2036,7 @@ public class CompositeAggregatorTests extends AggregatorTestCase {
                 .fixedInterval(DateHistogramInterval.days(1))
                 .format("yyyy-MM-dd");
             return new CompositeAggregationBuilder("name", Collections.singletonList(histo));
-        }, (result) -> {
+        }, (InternalComposite result) -> {
             assertEquals(3, result.getBuckets().size());
             assertEquals("{date=2017-10-20}", result.afterKey().toString());
             assertEquals("{date=2016-09-20}", result.getBuckets().get(0).getKeyAsString());
@@ -2046,7 +2055,7 @@ public class CompositeAggregatorTests extends AggregatorTestCase {
                 createAfterKey("date", "2016-09-20")
             );
 
-        }, (result) -> {
+        }, (InternalComposite result) -> {
             assertEquals(2, result.getBuckets().size());
             assertEquals("{date=2017-10-20}", result.afterKey().toString());
             assertEquals("{date=2017-10-19}", result.getBuckets().get(0).getKeyAsString());
@@ -2070,7 +2079,7 @@ public class CompositeAggregatorTests extends AggregatorTestCase {
                         createAfterKey("date", "now")
                     );
                 },
-                (result) -> {}
+                (InternalComposite result) -> {}
             )
         );
         assertThat(exc.getCause(), instanceOf(IllegalArgumentException.class));
@@ -2089,7 +2098,7 @@ public class CompositeAggregatorTests extends AggregatorTestCase {
                         createAfterKey("date", "1474329600000")
                     );
                 },
-                (result) -> {}
+                (InternalComposite result) -> {}
             )
         );
         assertThat(exc.getMessage(), containsString("failed to parse date field [1474329600000]"));
@@ -2121,7 +2130,7 @@ public class CompositeAggregatorTests extends AggregatorTestCase {
                     new TermsValuesSourceBuilder("keyword").field("keyword")
                 )
             ),
-            (result) -> {
+            (InternalComposite result) -> {
                 assertEquals(7, result.getBuckets().size());
                 assertEquals("{date=1508457600000, keyword=d}", result.afterKey().toString());
                 assertEquals("{date=1474329600000, keyword=b}", result.getBuckets().get(0).getKeyAsString());
@@ -2155,7 +2164,7 @@ public class CompositeAggregatorTests extends AggregatorTestCase {
                     new TermsValuesSourceBuilder("keyword").field("keyword")
                 )
             ).aggregateAfter(createAfterKey("date", 1508371200000L, "keyword", "g")),
-            (result) -> {
+            (InternalComposite result) -> {
                 assertEquals(3, result.getBuckets().size());
                 assertEquals("{date=1508457600000, keyword=d}", result.afterKey().toString());
                 assertEquals("{date=1508457600000, keyword=a}", result.getBuckets().get(0).getKeyAsString());
@@ -2190,7 +2199,7 @@ public class CompositeAggregatorTests extends AggregatorTestCase {
                     new HistogramValuesSourceBuilder("price").field("price").interval(10)
                 )
             ),
-            (result) -> {
+            (InternalComposite result) -> {
                 assertEquals(7, result.getBuckets().size());
                 assertEquals("{keyword=z, price=50.0}", result.afterKey().toString());
                 assertEquals("{keyword=a, price=100.0}", result.getBuckets().get(0).getKeyAsString());
@@ -2220,7 +2229,7 @@ public class CompositeAggregatorTests extends AggregatorTestCase {
                     new HistogramValuesSourceBuilder("price").field("price").interval(10)
                 )
             ).aggregateAfter(createAfterKey("keyword", "c", "price", 50.0)),
-            (result) -> {
+            (InternalComposite result) -> {
                 assertEquals(4, result.getBuckets().size());
                 assertEquals("{keyword=z, price=50.0}", result.afterKey().toString());
                 assertEquals("{keyword=c, price=100.0}", result.getBuckets().get(0).getKeyAsString());
@@ -2262,7 +2271,7 @@ public class CompositeAggregatorTests extends AggregatorTestCase {
                     new TermsValuesSourceBuilder("keyword").field("keyword")
                 )
             ),
-            (result) -> {
+            (InternalComposite result) -> {
                 assertEquals(8, result.getBuckets().size());
                 assertEquals("{histo=0.9, keyword=d}", result.afterKey().toString());
                 assertEquals("{histo=0.4, keyword=a}", result.getBuckets().get(0).getKeyAsString());
@@ -2294,7 +2303,7 @@ public class CompositeAggregatorTests extends AggregatorTestCase {
                     new TermsValuesSourceBuilder("keyword").field("keyword")
                 )
             ).aggregateAfter(createAfterKey("histo", 0.8d, "keyword", "b")),
-            (result) -> {
+            (InternalComposite result) -> {
                 assertEquals(3, result.getBuckets().size());
                 assertEquals("{histo=0.9, keyword=d}", result.afterKey().toString());
                 assertEquals("{histo=0.8, keyword=z}", result.getBuckets().get(0).getKeyAsString());
@@ -2329,7 +2338,7 @@ public class CompositeAggregatorTests extends AggregatorTestCase {
                     new DateHistogramValuesSourceBuilder("date_histo").field("date").fixedInterval(DateHistogramInterval.days(1))
                 )
             ),
-            (result) -> {
+            (InternalComposite result) -> {
                 assertEquals(7, result.getBuckets().size());
                 assertEquals("{keyword=z, date_histo=1474329600000}", result.afterKey().toString());
                 assertEquals("{keyword=a, date_histo=1508457600000}", result.getBuckets().get(0).getKeyAsString());
@@ -2359,7 +2368,7 @@ public class CompositeAggregatorTests extends AggregatorTestCase {
                     new DateHistogramValuesSourceBuilder("date_histo").field("date").fixedInterval(DateHistogramInterval.days(1))
                 )
             ).aggregateAfter(createAfterKey("keyword", "c", "date_histo", 1474329600000L)),
-            (result) -> {
+            (InternalComposite result) -> {
                 assertEquals(4, result.getBuckets().size());
                 assertEquals("{keyword=z, date_histo=1474329600000}", result.afterKey().toString());
                 assertEquals("{keyword=c, date_histo=1508457600000}", result.getBuckets().get(0).getKeyAsString());
@@ -2390,7 +2399,7 @@ public class CompositeAggregatorTests extends AggregatorTestCase {
             return new CompositeAggregationBuilder("name", Collections.singletonList(terms)).subAggregation(
                 new TopHitsAggregationBuilder("top_hits").storedField("_none_")
             );
-        }, (result) -> {
+        }, (InternalComposite result) -> {
             assertEquals(3, result.getBuckets().size());
             assertEquals("{keyword=a}", result.getBuckets().get(0).getKeyAsString());
             assertEquals(2L, result.getBuckets().get(0).getDocCount());
@@ -2417,7 +2426,7 @@ public class CompositeAggregatorTests extends AggregatorTestCase {
             return new CompositeAggregationBuilder("name", Collections.singletonList(terms)).aggregateAfter(
                 Collections.singletonMap("keyword", "a")
             ).subAggregation(new TopHitsAggregationBuilder("top_hits").storedField("_none_"));
-        }, (result) -> {
+        }, (InternalComposite result) -> {
             assertEquals(2, result.getBuckets().size());
             assertEquals("{keyword=c}", result.getBuckets().get(0).getKeyAsString());
             assertEquals(2L, result.getBuckets().get(0).getDocCount());
@@ -2449,7 +2458,7 @@ public class CompositeAggregatorTests extends AggregatorTestCase {
                             .subAggregation(new MaxAggregationBuilder("max").field("long"))
                     );
                 },
-                (result) -> { assertEquals(0, result.getBuckets().size()); }
+                (InternalComposite result) -> { assertEquals(0, result.getBuckets().size()); }
             );
         }
 
@@ -2472,7 +2481,7 @@ public class CompositeAggregatorTests extends AggregatorTestCase {
                         .collectMode(mode)
                         .subAggregation(new MaxAggregationBuilder("max").field("long"))
                 );
-            }, (result) -> {
+            }, (InternalComposite result) -> {
                 assertEquals(3, result.getBuckets().size());
 
                 assertEquals("{keyword=a}", result.getBuckets().get(0).getKeyAsString());
@@ -2596,7 +2605,7 @@ public class CompositeAggregatorTests extends AggregatorTestCase {
                 return new CompositeAggregationBuilder("name", Collections.singletonList(source)).subAggregation(
                     new TopHitsAggregationBuilder("top_hits").storedField("_none_")
                 ).aggregateAfter(afterKey).size(size);
-            }, (result) -> {
+            }, (InternalComposite result) -> {
                 if (result.getBuckets().size() == 0) {
                     finish.set(true);
                 }
@@ -2624,7 +2633,7 @@ public class CompositeAggregatorTests extends AggregatorTestCase {
         testSearchCase(Arrays.asList(new MatchAllDocsQuery(), new DocValuesFieldExistsQuery("ip")), dataset, () -> {
             TermsValuesSourceBuilder terms = new TermsValuesSourceBuilder("ip").field("ip");
             return new CompositeAggregationBuilder("name", Collections.singletonList(terms));
-        }, (result) -> {
+        }, (InternalComposite result) -> {
             assertEquals(3, result.getBuckets().size());
             assertEquals("{ip=192.168.0.1}", result.afterKey().toString());
             assertEquals("{ip=::1}", result.getBuckets().get(0).getKeyAsString());
@@ -2640,7 +2649,7 @@ public class CompositeAggregatorTests extends AggregatorTestCase {
             return new CompositeAggregationBuilder("name", Collections.singletonList(terms)).aggregateAfter(
                 Collections.singletonMap("ip", "::1")
             );
-        }, (result) -> {
+        }, (InternalComposite result) -> {
             assertEquals(2, result.getBuckets().size());
             assertEquals("{ip=192.168.0.1}", result.afterKey().toString());
             assertEquals("{ip=127.0.0.1}", result.getBuckets().get(0).getKeyAsString());
@@ -2664,7 +2673,7 @@ public class CompositeAggregatorTests extends AggregatorTestCase {
         testSearchCase(Arrays.asList(new MatchAllDocsQuery(), new DocValuesFieldExistsQuery("geo_point")), dataset, () -> {
             GeoTileGridValuesSourceBuilder geoTile = new GeoTileGridValuesSourceBuilder("geo_point").field("geo_point");
             return new CompositeAggregationBuilder("name", Collections.singletonList(geoTile));
-        }, (result) -> {
+        }, (InternalComposite result) -> {
             assertEquals(2, result.getBuckets().size());
             assertEquals("{geo_point=7/64/56}", result.afterKey().toString());
             assertEquals("{geo_point=7/32/56}", result.getBuckets().get(0).getKeyAsString());
@@ -2678,7 +2687,7 @@ public class CompositeAggregatorTests extends AggregatorTestCase {
             return new CompositeAggregationBuilder("name", Collections.singletonList(geoTile)).aggregateAfter(
                 Collections.singletonMap("geo_point", "7/32/56")
             );
-        }, (result) -> {
+        }, (InternalComposite result) -> {
             assertEquals(1, result.getBuckets().size());
             assertEquals("{geo_point=7/64/56}", result.afterKey().toString());
             assertEquals("{geo_point=7/64/56}", result.getBuckets().get(0).getKeyAsString());
@@ -2702,7 +2711,7 @@ public class CompositeAggregatorTests extends AggregatorTestCase {
             List.of(new MatchAllDocsQuery(), new DocValuesFieldExistsQuery("_tsid")),
             dataset,
             () -> new CompositeAggregationBuilder("name", Collections.singletonList(new TermsValuesSourceBuilder("tsid").field("_tsid"))),
-            (result) -> {
+            (InternalComposite result) -> {
                 assertEquals(4, result.getBuckets().size());
                 assertEquals("{tsid={dim1=foo, dim2=200}}", result.afterKey().toString());
 
@@ -2722,7 +2731,7 @@ public class CompositeAggregatorTests extends AggregatorTestCase {
             return new CompositeAggregationBuilder("name", Collections.singletonList(terms)).aggregateAfter(
                 Collections.singletonMap("tsid", createTsid(Map.of("dim1", "bar", "dim2", 200)))
             );
-        }, (result) -> {
+        }, (InternalComposite result) -> {
             assertEquals(2, result.getBuckets().size());
             assertEquals("{tsid={dim1=foo, dim2=200}}", result.afterKey().toString());
             assertEquals("{tsid={dim1=foo, dim2=100}}", result.getBuckets().get(0).getKeyAsString());
@@ -2754,7 +2763,7 @@ public class CompositeAggregatorTests extends AggregatorTestCase {
                     new DateHistogramValuesSourceBuilder("date_histo").field("date").fixedInterval(DateHistogramInterval.days(1))
                 )
             ),
-            (result) -> {
+            (InternalComposite result) -> {
                 assertEquals(4, result.getBuckets().size());
                 assertEquals("{tsid={dim1=foo, dim2=200}, date_histo=1634688000000}", result.afterKey().toString());
 
@@ -2779,7 +2788,7 @@ public class CompositeAggregatorTests extends AggregatorTestCase {
                     new DateHistogramValuesSourceBuilder("date_histo").field("date").fixedInterval(DateHistogramInterval.days(1))
                 )
             ).aggregateAfter(createAfterKey("tsid", createTsid(Map.of("dim1", "foo", "dim2", 100)), "date_histo", 1634688000000L)),
-            (result) -> {
+            (InternalComposite result) -> {
                 assertEquals(2, result.getBuckets().size());
                 assertEquals("{tsid={dim1=foo, dim2=200}, date_histo=1634688000000}", result.afterKey().toString());
                 assertEquals("{tsid={dim1=foo, dim2=200}, date_histo=1632096000000}", result.getBuckets().get(0).getKeyAsString());
@@ -2818,7 +2827,7 @@ public class CompositeAggregatorTests extends AggregatorTestCase {
                 "name",
                 Arrays.asList(new TermsValuesSourceBuilder("keyword").field("keyword"), new TermsValuesSourceBuilder("long").field("long"))
             ).aggregateAfter(createAfterKey("keyword", "b", "long", 10L)).size(2),
-            (result) -> {
+            (InternalComposite result) -> {
                 assertEquals(2, result.getBuckets().size());
                 assertEquals("{keyword=c, long=100}", result.afterKey().toString());
                 assertEquals("{keyword=c, long=10}", result.getBuckets().get(0).getKeyAsString());
@@ -2843,7 +2852,7 @@ public class CompositeAggregatorTests extends AggregatorTestCase {
                     new TermsValuesSourceBuilder("long").field("long").order(SortOrder.DESC)
                 )
             ).aggregateAfter(createAfterKey("keyword", "c", "long", 10L)).size(2),
-            (result) -> {
+            (InternalComposite result) -> {
                 assertEquals(2, result.getBuckets().size());
                 assertEquals("{keyword=a, long=100}", result.afterKey().toString());
                 assertEquals("{keyword=b, long=10}", result.getBuckets().get(0).getKeyAsString());
@@ -2884,7 +2893,7 @@ public class CompositeAggregatorTests extends AggregatorTestCase {
                         new TermsValuesSourceBuilder("keyword").field("keyword")
                     )
                 ).size(3),
-                (result) -> {
+                (InternalComposite result) -> {
                     assertEquals(3, result.getBuckets().size());
                     assertEquals("{date=1591142400000, keyword=31640}", result.afterKey().toString());
                     assertEquals("{date=1591142400000, keyword=11640}", result.getBuckets().get(0).getKeyAsString());
@@ -2910,7 +2919,7 @@ public class CompositeAggregatorTests extends AggregatorTestCase {
                         new TermsValuesSourceBuilder("keyword").field("keyword")
                     )
                 ).aggregateAfter(createAfterKey("date", 1591142400000L, "keyword", "31640")).size(3),
-                (result) -> {
+                (InternalComposite result) -> {
                     assertEquals(3, result.getBuckets().size());
                     assertEquals("{date=1591142400000, keyword=91640}", result.afterKey().toString());
                     assertEquals("{date=1591142400000, keyword=37640}", result.getBuckets().get(0).getKeyAsString());
@@ -2966,11 +2975,144 @@ public class CompositeAggregatorTests extends AggregatorTestCase {
         }
     }
 
-    private void testSearchCase(
+    public void testCompositeWithSampling() throws Exception {
+        final int numDocsPerBucket = 1_000;
+        final List<Map<String, List<Object>>> dataset = new ArrayList<>(numDocsPerBucket * 8);
+        for (int i = 0; i < numDocsPerBucket; i++) {
+            dataset.addAll(
+                List.of(
+                    createDocument("keyword", "a", "long", 100L, "foo", "bar"),
+                    createDocument("keyword", "c", "long", 100L, "foo", "bar"),
+                    createDocument("keyword", "a", "long", 0L, "foo", "bar"),
+                    createDocument("keyword", "d", "long", 10L, "foo", "bar"),
+                    createDocument("keyword", "b", "long", 10L, "foo", "bar"),
+                    createDocument("keyword", "c", "long", 10L, "foo", "bar"),
+                    createDocument("keyword", "e", "long", 100L, "foo", "bar"),
+                    createDocument("keyword", "e", "long", 10L, "foo", "bar")
+                )
+            );
+        }
+        double probability = 0.5;
+        double errorRate = Math.pow(1.0 / (probability * numDocsPerBucket), 0.35);
+
+        List<CompositeValuesSourceBuilder<?>> sources = List.of(
+            new TermsValuesSourceBuilder("keyword").field("keyword"),
+            new TermsValuesSourceBuilder("long").field("long")
+        );
+        testSearchCase(
+            List.of(new MatchAllDocsQuery()),
+            dataset,
+            sources,
+            List.of(
+                () -> new RandomSamplerAggregationBuilder("sampler").setProbability(probability)
+                    .subAggregation(AggregationBuilders.composite("composite", sources).size(2)),
+                () -> new RandomSamplerAggregationBuilder("sampler").setProbability(probability)
+                    .subAggregation(
+                        AggregationBuilders.composite("composite", sources).aggregateAfter(createAfterKey("keyword", "a", "long", 100L))
+                    ),
+                (Supplier<RandomSamplerAggregationBuilder>) () -> new RandomSamplerAggregationBuilder("sampler").setProbability(probability)
+                    .subAggregation(
+                        AggregationBuilders.composite("composite", sources).aggregateAfter(createAfterKey("keyword", "e", "long", 100L))
+                    )
+            ),
+            List.of((InternalRandomSampler sampler) -> {
+                InternalComposite composite = sampler.getAggregations().get("composite");
+                assertThat(composite.afterKey(), equalTo(createAfterKey("keyword", "a", "long", 100L)));
+                assertThat(composite.getBuckets(), hasSize(2));
+                for (var bucket : composite.getBuckets()) {
+                    assertThat(
+                        bucket.getDocCount(),
+                        anyOf(greaterThan((long) (numDocsPerBucket - errorRate)), lessThan((long) (numDocsPerBucket - errorRate + 0.5)))
+                    );
+                }
+            }, (InternalRandomSampler sampler) -> {
+                InternalComposite composite = sampler.getAggregations().get("composite");
+                assertThat(composite.afterKey(), equalTo(createAfterKey("keyword", "e", "long", 100L)));
+                assertThat(composite.getBuckets(), hasSize(6));
+                for (var bucket : composite.getBuckets()) {
+                    assertThat(
+                        bucket.getDocCount(),
+                        anyOf(greaterThan((long) (numDocsPerBucket - errorRate)), lessThan((long) (numDocsPerBucket - errorRate + 0.5)))
+                    );
+                }
+            }, (Consumer<InternalRandomSampler>) (InternalRandomSampler sampler) -> {
+                InternalComposite composite = sampler.getAggregations().get("composite");
+                assertThat(composite.afterKey(), is(nullValue()));
+                assertThat(composite.getBuckets(), hasSize(0));
+            })
+        );
+    }
+
+    public void testCompositeWithSamplingAndOneSmallBucket() throws Exception {
+        final int numDocsPerBucket = 1_000;
+        final List<Map<String, List<Object>>> dataset = new ArrayList<>(numDocsPerBucket * 3 + 10);
+        for (int i = 0; i < numDocsPerBucket; i++) {
+            dataset.addAll(
+                List.of(
+                    createDocument("keyword", "a", "long", 100L, "foo", "bar"),
+                    createDocument("keyword", "b", "long", 10L, "foo", "bar"),
+                    createDocument("keyword", "c", "long", 10L, "foo", "bar")
+                )
+            );
+        }
+        String smallBucketKeyword = "e";
+        long smallBucketLong = 10L;
+        for (int i = 0; i < 10; i++) {
+            dataset.addAll(List.of(createDocument("keyword", smallBucketKeyword, "long", smallBucketLong, "foo", "bar")));
+        }
+        // Right on the edge of it maybe getting the small bucket docs or not
+        final double probability = 0.08;
+        final List<CompositeValuesSourceBuilder<?>> sources = List.of(
+            new TermsValuesSourceBuilder("keyword").field("keyword"),
+            new TermsValuesSourceBuilder("long").field("long")
+        );
+        testSearchCase(
+            List.of(new MatchAllDocsQuery()),
+            dataset,
+            sources,
+            List.of(
+                () -> new RandomSamplerAggregationBuilder("sampler").setProbability(probability)
+                    .subAggregation(AggregationBuilders.composite("composite", sources).size(5)),
+                () -> new RandomSamplerAggregationBuilder("sampler").setProbability(probability)
+                    .subAggregation(
+                        AggregationBuilders.composite("composite", sources).aggregateAfter(createAfterKey("keyword", "c", "long", 10L))
+                    ),
+                (Supplier<RandomSamplerAggregationBuilder>) () -> new RandomSamplerAggregationBuilder("sampler").setProbability(probability)
+                    .subAggregation(
+                        AggregationBuilders.composite("composite", sources).aggregateAfter(createAfterKey("keyword", "e", "long", 10L))
+                    )
+            ),
+            List.of((InternalRandomSampler sampler) -> {
+                InternalComposite composite = sampler.getAggregations().get("composite");
+                assertThat(composite.getBuckets(), anyOf(hasSize(4), hasSize(3)));
+                // Sampling Missed last bucket
+                if (composite.getBuckets().size() == 3) {
+                    assertThat(composite.afterKey(), equalTo(createAfterKey("keyword", "c", "long", 10L)));
+                } else {
+                    assertThat(composite.afterKey(), equalTo(createAfterKey("keyword", "e", "long", 10L)));
+                }
+            }, (InternalRandomSampler sampler) -> {
+                InternalComposite composite = sampler.getAggregations().get("composite");
+                assertThat(composite.getBuckets(), anyOf(hasSize(1), hasSize(0)));
+                // Sampling Missed last bucket
+                if (composite.getBuckets().size() == 0) {
+                    assertThat(composite.afterKey(), is(nullValue()));
+                } else {
+                    assertThat(composite.afterKey(), equalTo(createAfterKey("keyword", "e", "long", 10L)));
+                }
+            }, (Consumer<InternalRandomSampler>) (InternalRandomSampler sampler) -> {
+                InternalComposite composite = sampler.getAggregations().get("composite");
+                assertThat(composite.getBuckets(), hasSize(0));
+                assertThat(composite.afterKey(), is(nullValue()));
+            })
+        );
+    }
+
+    private <T extends AggregationBuilder, V extends InternalAggregation> void testSearchCase(
         List<Query> queries,
         List<Map<String, List<Object>>> dataset,
-        Supplier<CompositeAggregationBuilder> create,
-        Consumer<InternalComposite> verify
+        Supplier<T> create,
+        Consumer<V> verify
     ) throws IOException {
         for (Query query : queries) {
             executeTestCase(false, false, query, dataset, create, verify);
@@ -2978,18 +3120,55 @@ public class CompositeAggregatorTests extends AggregatorTestCase {
         }
     }
 
-    private void executeTestCase(
+    private <T extends AggregationBuilder, V extends InternalAggregation> void testSearchCase(
+        List<Query> queries,
+        List<Map<String, List<Object>>> dataset,
+        List<CompositeValuesSourceBuilder<?>> sources,
+        List<Supplier<T>> create,
+        List<Consumer<V>> verify
+    ) throws IOException {
+        for (Query query : queries) {
+            executeTestCase(false, false, query, dataset, sources, create, verify);
+            executeTestCase(false, true, query, dataset, sources, create, verify);
+        }
+    }
+
+    private <T extends AggregationBuilder, V extends InternalAggregation> void executeTestCase(
         boolean forceMerge,
         boolean useIndexSort,
         Query query,
         List<Map<String, List<Object>>> dataset,
-        Supplier<CompositeAggregationBuilder> create,
-        Consumer<InternalComposite> verify
+        Supplier<T> create,
+        Consumer<V> verify
     ) throws IOException {
+        AggregationBuilder aggregationBuilder = create.get();
+        List<CompositeValuesSourceBuilder<?>> sources;
+        if (aggregationBuilder instanceof CompositeAggregationBuilder compositeAggregationBuilder) {
+            sources = compositeAggregationBuilder.sources();
+        } else {
+            CompositeAggregationBuilder compositeAggregationBuilder = (CompositeAggregationBuilder) aggregationBuilder.getSubAggregations()
+                .stream()
+                .filter(agg -> agg instanceof CompositeAggregationBuilder)
+                .findAny()
+                .orElseThrow();
+            sources = compositeAggregationBuilder.sources();
+        }
+        executeTestCase(forceMerge, useIndexSort, query, dataset, sources, List.of(create), List.of(verify));
+    }
+
+    private <T extends AggregationBuilder, V extends InternalAggregation> void executeTestCase(
+        boolean forceMerge,
+        boolean useIndexSort,
+        Query query,
+        List<Map<String, List<Object>>> dataset,
+        List<CompositeValuesSourceBuilder<?>> sources,
+        List<Supplier<T>> create,
+        List<Consumer<V>> verify
+    ) throws IOException {
+        assert create.size() == verify.size() : "create and verify should be the same size";
         Map<String, MappedFieldType> types = Arrays.stream(FIELD_TYPES)
             .collect(Collectors.toMap(MappedFieldType::name, Function.identity()));
-        CompositeAggregationBuilder aggregationBuilder = create.get();
-        Sort indexSort = useIndexSort ? buildIndexSort(aggregationBuilder.sources(), types) : null;
+        Sort indexSort = useIndexSort ? buildIndexSort(sources, types) : null;
         IndexSettings indexSettings = createIndexSettings(indexSort);
         try (Directory directory = newDirectory()) {
             IndexWriterConfig config = newIndexWriterConfig(random(), new MockAnalyzer(random()));
@@ -3028,8 +3207,9 @@ public class CompositeAggregatorTests extends AggregatorTestCase {
             }
             try (IndexReader indexReader = DirectoryReader.open(directory)) {
                 IndexSearcher indexSearcher = new IndexSearcher(indexReader);
-                InternalComposite composite = searchAndReduce(indexSettings, indexSearcher, query, aggregationBuilder, FIELD_TYPES);
-                verify.accept(composite);
+                for (int i = 0; i < create.size(); i++) {
+                    verify.get(i).accept(searchAndReduce(indexSettings, indexSearcher, query, create.get(i).get(), FIELD_TYPES));
+                }
             }
         }
     }


### PR DESCRIPTION
composite aggregations are supported within a sampling context. Consequently, composite aggs need to allow themselves to be a sub-agg of a random sampler aggregation.