### PR TITLE
Fix Vector tiles search docs for features.id

### DIFF
--- a/docs/reference/search/search-vector-tile-api.asciidoc
+++ b/docs/reference/search/search-vector-tile-api.asciidoc
@@ -727,7 +727,6 @@ tile contains the following data:
           "name": "NEMO Science Museum",
           "price": 1750
         },
-        "id": 0,
         "type": 1
       },
       {
@@ -744,7 +743,6 @@ tile contains the following data:
           "name": "Nederlands Scheepvaartmuseum",
           "price": 1650
         },
-        "id": 0,
         "type": 1
       },
       {
@@ -761,7 +759,6 @@ tile contains the following data:
           "name": "Amsterdam Centre for Architecture",
           "price": 0
         },
-        "id": 0,
         "type": 1
       }
     ]
@@ -804,7 +801,6 @@ tile contains the following data:
           "min_price.value": 0.0,
           "avg_price.value": 1133.3333333333333
         },
-        "id": 0,
         "type": 3
       }
     ]
@@ -872,7 +868,6 @@ tile contains the following data:
           "timed_out": false,
           "took": 2
         },
-        "id": 0,
         "type": 3
       }
     ]

--- a/docs/reference/search/search-vector-tile-api.asciidoc
+++ b/docs/reference/search/search-vector-tile-api.asciidoc
@@ -257,7 +257,7 @@ calculate a final precision as follows:
 `<zoom> + grid_precision`
 
 This precision determines the https://h3geo.org/docs/core-library/restable[H3
-resolution of the hexagonal cells] produced by the `geohex` aggregation. The 
+resolution of the hexagonal cells] produced by the `geohex` aggregation. The
 following table maps the H3 resolution for each precision.
 
 For example, if `<zoom>` is `3` and `grid_precision` is `3`, the precision is
@@ -479,11 +479,6 @@ value that matches the `geo_bounding_box` query.
 `<field>`::
 Field value. Only returned for fields in the `fields` parameter.
 ======
-// tag::feature-id[]
-`id`::
-(integer) Unique ID for the feature within the layer.
-// end::feature-id[]
-
 // tag::feature-type[]
 `type`::
 (integer) Identifier for the feature's geometry type. Values are:
@@ -530,8 +525,6 @@ include::search-vector-tile-api.asciidoc[tag=geometry]
 Sub-aggregation results for the cell. Only returned for sub-aggregations in the
 `aggs` parameter.
 ======
-include::search-vector-tile-api.asciidoc[tag=feature-id]
-
 include::search-vector-tile-api.asciidoc[tag=feature-type]
 =====
 ====
@@ -628,8 +621,6 @@ partial or empty.
 (integer) Milliseconds it took {es} to run the search. See the search API's
 <<search-api-took,`took`>> response property.
 ======
-include::search-vector-tile-api.asciidoc[tag=feature-id]
-
 include::search-vector-tile-api.asciidoc[tag=feature-type]
 =====
 ====


### PR DESCRIPTION
Vector tiles search documentation claims that the final vector tiles contains for each feature and identifier as an integer in the form of `feature.id`. This is part of the standard and those ids are numeric.

Elasticsearch document ids are not numeric but strings and therefore we are not using the ids from the standards but adding ES ids as a properties of the feature. In the case of the hits layer, each feature contains an `_id` property and for the aggs layer, each feature contains a `_key` property. 

This PR removes the reference to the integer identifier from the docs.

https://elasticsearch_85067.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/search-vector-tile-api.html