### PR TITLE
Re-add content from removed Security-specific snapshot pages

### DIFF
--- a/docs/reference/snapshot-restore/index.asciidoc
+++ b/docs/reference/snapshot-restore/index.asciidoc
@@ -46,6 +46,7 @@ Snapshots don't contain or back up:
 * Transient cluster settings
 * Registered snapshot repositories
 * Node configuration files
+* <<security-files,Security configuration files>>
 
 [discrete]
 [[feature-state]]
@@ -209,19 +210,6 @@ they were when you took the backup.
 
 Additionally, snapshots may contain security-sensitive information, which you
 may wish to <<cluster-state-snapshots,store in a dedicated repository>>.
-
-[discrete]
-[[snapshot-important-files]]
-=== Important Files Not Included in Snapshots
-
-Some Elasticsearch configuration is not included in snapshots. This includes
-any settings configured via `elasticsearch.yml` or the Elasticsearch keystore,
-as well as <<security-files,file-based Security configuration>>. These settings
-may contain references to other files within the <<config-files-location,`ES_PATH_CONF` directory>>,
-such as TLS keys, certificates for HTTP client and inter-node communication,
-and private key files for <<ref-saml-settings, SAML>>, <<ref-oidc-settings, OIDC>>
-and <ref-kerberos-settings, Kerberos>> realms. These files should be backed up
-separately from snapshots, as snapshots do not include these files.
 
 include::register-repository.asciidoc[]
 include::take-snapshot.asciidoc[]

--- a/docs/reference/snapshot-restore/index.asciidoc
+++ b/docs/reference/snapshot-restore/index.asciidoc
@@ -207,6 +207,34 @@ contents.
 . When you have finished restoring the repository its contents are exactly as
 they were when you took the backup.
 
+Additionally, if the repository is used to backup the `security` feature state,
+the repository will contain sensitive data such as user names and password hashes.
+Because passwords are stored using <<hashing-settings, cryptographic hashes>>,
+the disclosure of a snapshot would not automatically enable a third party to
+authenticate as one of your users or use API keys. However, it would disclose
+confidential information.
+
+It is also important that you protect the integrity of these backups in case
+you ever need to restore them. If a third party is able to modify the stored
+backups, they may be able to install a back door that would grant access if the
+snapshot is loaded into an {es} cluster.
+
+Therefore, you may wish to back up the `security` feature state to a dedicated
+repository where read and write access is restricted and audited.
+
+[discrete]
+[[snapshot-important-files]]
+=== Important Files Not Included in Snapshots
+
+Some Elasticsearch configuration is not included in snapshots. This includes
+any settings configured via `elasticsearch.yml` or the Elasticsearch keystore,
+as well as <<security-files,file-based Security configuration>>. These settings
+may contain references to other files within the <<config-files-location,`ES_PATH_CONF` directory>>,
+such as TLS keys, certificates for HTTP client and inter-node communication,
+and private key files for <<ref-saml-settings, SAML>>, <<ref-oidc-settings, OIDC>>
+and <ref-kerberos-settings, Kerberos>> realms. These files should be backed up
+separately from snapshots, as snapshots do not include these files.
+
 include::register-repository.asciidoc[]
 include::take-snapshot.asciidoc[]
 include::restore-snapshot.asciidoc[]

--- a/docs/reference/snapshot-restore/index.asciidoc
+++ b/docs/reference/snapshot-restore/index.asciidoc
@@ -207,20 +207,8 @@ contents.
 . When you have finished restoring the repository its contents are exactly as
 they were when you took the backup.
 
-Additionally, if the repository is used to backup the `security` feature state,
-the repository will contain sensitive data such as user names and password hashes.
-Because passwords are stored using <<hashing-settings, cryptographic hashes>>,
-the disclosure of a snapshot would not automatically enable a third party to
-authenticate as one of your users or use API keys. However, it would disclose
-confidential information.
-
-It is also important that you protect the integrity of these backups in case
-you ever need to restore them. If a third party is able to modify the stored
-backups, they may be able to install a back door that would grant access if the
-snapshot is loaded into an {es} cluster.
-
-Therefore, you may wish to back up the `security` feature state to a dedicated
-repository where read and write access is restricted and audited.
+Additionally, snapshots may contain security-sensitive information, which you
+may wish to <<cluster-state-snapshots,store in a dedicated repository>>.
 
 [discrete]
 [[snapshot-important-files]]

--- a/docs/reference/snapshot-restore/take-snapshot.asciidoc
+++ b/docs/reference/snapshot-restore/take-snapshot.asciidoc
@@ -377,12 +377,15 @@ snapshot doesn't delete files used by other snapshots.
 === Back up configuration files
 
 If you run {es} on your own hardware, we recommend that, in addition to backups,
-you take regular backups of the files in each node's `$ES_PATH_CONF` directory
-using the file backup software of your choice. Snapshots don't back up these
-files.
+you take regular backups of the files in each node's
+<<config-files-location,`$ES_PATH_CONF` directory>> using the file backup software
+of your choice. Snapshots don't back up these files. Also note that these files will
+differ on each node, so each node's files should be backed up individually.
 
-Depending on your setup, some of these configuration files may contain sensitive
-data, such as passwords or keys. If so, consider encrypting your file backups.
+IMPORTANT: The `elasticsearch.keystore`, TLS keys, and <<ref-saml-settings, SAML>>,
+<<ref-oidc-settings, OIDC>>, and <<ref-kerberos-settings, Kerberos>>
+realms private key files contain sensitive information. Consider encrypting
+your backups of these files.
 
 [discrete]
 [[back-up-specific-feature-state]]

--- a/docs/reference/snapshot-restore/take-snapshot.asciidoc
+++ b/docs/reference/snapshot-restore/take-snapshot.asciidoc
@@ -467,7 +467,11 @@ API>>'s response under both `indices` and `feature_states`.
 
 Some feature states contain sensitive data. For example, the `security` feature
 state includes system indices that may contain user names and encrypted password
-hashes.
+hashes. Because passwords are stored using <<hashing-settings, cryptographic hashes>>,
+the disclosure of a snapshot would not automatically enable a third party to
+authenticate as one of your users or use API keys. However, it would disclose
+confidential information, and if a third party can modify snapshots, they could
+install a back door.
 
 To better protect this data, consider creating a dedicated repository and
 {slm-init} policy for snapshots of the cluster state. This lets you strictly


### PR DESCRIPTION
This commit adds back some notes which were lost when we consolidated
the snapshot/restore documentation into a single location.

The notes in question are that:
1) If a Snapshot repository contains Security's feature state, then
   that repository contains security-sensitive information. This may
   be obvious to some, but is good to state explicitly.
2) Some files, such as the keystore and TLS keys, are not included in
   snapshots and are important to back up via other means.

Relates to #79081, which is the PR that consolidated the snapshot/restore docs.