### PR TITLE
Add delete privilege to kibana_system for APM

### DIFF
--- a/docs/changelog/85085.yaml
+++ b/docs/changelog/85085.yaml
@@ -1,0 +1,5 @@
+pr: 85085
+summary: Add delete privilege to `kibana_system` for APM
+area: Authorization
+type: bug
+issues: []

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStore.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStore.java
@@ -774,7 +774,7 @@ public class ReservedRolesStore implements BiConsumer<Set<String>, ActionListene
                         ".logs-endpoint.diagnostic.collection-*",
                         "logs-apm-*", "logs-apm.*",
                         "metrics-apm-*", "metrics-apm.*",
-                        "traces-apm-*", "traces-apm.*",
+                        "traces-apm-*", "traces-apm.*"
                     )
                     .privileges(DeleteIndexAction.NAME)
                     .build(),

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStore.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStore.java
@@ -772,9 +772,12 @@ public class ReservedRolesStore implements BiConsumer<Set<String>, ActionListene
                 RoleDescriptor.IndicesPrivileges.builder()
                     .indices(
                         ".logs-endpoint.diagnostic.collection-*",
-                        "logs-apm-*", "logs-apm.*",
-                        "metrics-apm-*", "metrics-apm.*",
-                        "traces-apm-*", "traces-apm.*"
+                        "logs-apm-*",
+                        "logs-apm.*",
+                        "metrics-apm-*",
+                        "metrics-apm.*",
+                        "traces-apm-*",
+                        "traces-apm.*"
                     )
                     .privileges(DeleteIndexAction.NAME)
                     .build(),

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStore.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStore.java
@@ -773,11 +773,11 @@ public class ReservedRolesStore implements BiConsumer<Set<String>, ActionListene
                     .indices(
                         ".logs-endpoint.diagnostic.collection-*",
                         "logs-apm-*",
-                        "logs-apm.*",
+                        "logs-apm.*-*",
                         "metrics-apm-*",
-                        "metrics-apm.*",
+                        "metrics-apm.*-*",
                         "traces-apm-*",
-                        "traces-apm.*"
+                        "traces-apm.*-*"
                     )
                     .privileges(DeleteIndexAction.NAME)
                     .build(),

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStore.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStore.java
@@ -770,7 +770,17 @@ public class ReservedRolesStore implements BiConsumer<Set<String>, ActionListene
                     .build(),
                 // For ILM policy for APM & Endpoint packages that have delete action
                 RoleDescriptor.IndicesPrivileges.builder()
-                    .indices(".logs-endpoint.diagnostic.collection-*", "traces-apm.sampled-*")
+                    .indices(
+                        ".logs-endpoint.diagnostic.collection-*",
+                        "logs-apm.app-*",
+                        "logs-apm.error-*",
+                        "metrics-apm.app.*",
+                        "metrics-apm.internal-*",
+                        "metrics-apm.profiling-*",
+                        "traces-apm-*",
+                        "traces-apm.rum-*",
+                        "traces-apm.sampled-*"
+                    )
                     .privileges(DeleteIndexAction.NAME)
                     .build(),
                 // For src/dest indices of the Endpoint package that ships a transform

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStore.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStore.java
@@ -772,14 +772,9 @@ public class ReservedRolesStore implements BiConsumer<Set<String>, ActionListene
                 RoleDescriptor.IndicesPrivileges.builder()
                     .indices(
                         ".logs-endpoint.diagnostic.collection-*",
-                        "logs-apm.app-*",
-                        "logs-apm.error-*",
-                        "metrics-apm.app.*",
-                        "metrics-apm.internal-*",
-                        "metrics-apm.profiling-*",
-                        "traces-apm-*",
-                        "traces-apm.rum-*",
-                        "traces-apm.sampled-*"
+                        "logs-apm-*", "logs-apm.*",
+                        "metrics-apm-*", "metrics-apm.*",
+                        "traces-apm-*", "traces-apm.*",
                     )
                     .privileges(DeleteIndexAction.NAME)
                     .build(),

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStoreTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStoreTests.java
@@ -935,12 +935,12 @@ public class ReservedRolesStoreTests extends ESTestCase {
         // Ensure privileges necessary for ILM policies in APM & Endpoint packages
         Arrays.asList(
             ".logs-endpoint.diagnostic.collection-" + randomAlphaOfLengthBetween(3, 8),
-            "logs-apm-*" + randomAlphaOfLengthBetween(3, 8),
-            "logs-apm.*" + randomAlphaOfLengthBetween(3, 8),
-            "metrics-apm-*" + randomAlphaOfLengthBetween(3, 8),
-            "metrics-apm.*" + randomAlphaOfLengthBetween(3, 8),
-            "traces-apm-*" + randomAlphaOfLengthBetween(3, 8),
-            "traces-apm.*" + randomAlphaOfLengthBetween(3, 8)
+            "logs-apm-" + randomAlphaOfLengthBetween(3, 8),
+            "logs-apm." + randomAlphaOfLengthBetween(3, 8) + "-" + randomAlphaOfLengthBetween(3, 8),
+            "metrics-apm-" + randomAlphaOfLengthBetween(3, 8),
+            "metrics-apm." + randomAlphaOfLengthBetween(3, 8) + "-" + randomAlphaOfLengthBetween(3, 8),
+            "traces-apm-" + randomAlphaOfLengthBetween(3, 8),
+            "traces-apm." + randomAlphaOfLengthBetween(3, 8) + "-" + randomAlphaOfLengthBetween(3, 8)
         ).forEach(indexName -> {
             logger.info("index name [{}]", indexName);
             final IndexAbstraction indexAbstraction = mockIndexAbstraction(indexName);

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStoreTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStoreTests.java
@@ -865,8 +865,15 @@ public class ReservedRolesStoreTests extends ESTestCase {
             assertThat(kibanaRole.indices().allowedIndicesMatcher(SearchAction.NAME).test(indexAbstraction), is(isAlsoReadIndex));
             assertThat(kibanaRole.indices().allowedIndicesMatcher(MultiSearchAction.NAME).test(indexAbstraction), is(isAlsoReadIndex));
 
-            // Endpoint diagnostic and sampled traces data streams also have an ILM policy with a delete action, all others should not.
+            // Endpoint diagnostic and APM data streams also have an ILM policy with a delete action, all others should not.
             final boolean isAlsoIlmDeleteIndex = indexName.startsWith(".logs-endpoint.diagnostic.collection-")
+                || indexName.startsWith("logs-apm.app-")
+                || indexName.startsWith("logs-apm.error-")
+                || indexName.startsWith("metrics-apm.app.")
+                || indexName.startsWith("metrics-apm.internal-")
+                || indexName.startsWith("metrics-apm.profiling-")
+                || indexName.startsWith("traces-apm-")
+                || indexName.startsWith("traces-apm.rum-")
                 || indexName.startsWith("traces-apm.sampled-");
             assertThat(kibanaRole.indices().allowedIndicesMatcher(DeleteIndexAction.NAME).test(indexAbstraction), is(isAlsoIlmDeleteIndex));
         });
@@ -929,20 +936,14 @@ public class ReservedRolesStoreTests extends ESTestCase {
 
         // Ensure privileges necessary for ILM policies in APM & Endpoint packages
         Arrays.asList(
-            "metrics-apm.app-" + randomAlphaOfLengthBetween(3, 8),
-            "metrics-apm.internal-" + randomAlphaOfLengthBetween(3, 8),
-            "metrics-apm.profiling-" + randomAlphaOfLengthBetween(3, 8),
-            "logs-apm.error_logs-" + randomAlphaOfLengthBetween(3, 8),
-            "traces-apm-" + randomAlphaOfLengthBetween(3, 8)
-        ).forEach(indexName -> {
-            logger.info("index name [{}]", indexName);
-            final IndexAbstraction indexAbstraction = mockIndexAbstraction(indexName);
-
-            assertThat(kibanaRole.indices().allowedIndicesMatcher(UpdateSettingsAction.NAME).test(indexAbstraction), is(true));
-            assertThat(kibanaRole.indices().allowedIndicesMatcher(RolloverAction.NAME).test(indexAbstraction), is(true));
-        });
-        Arrays.asList(
             ".logs-endpoint.diagnostic.collection-" + randomAlphaOfLengthBetween(3, 8),
+            "logs-apm.app-*" + randomAlphaOfLengthBetween(3, 8),
+            "logs-apm.error-*" + randomAlphaOfLengthBetween(3, 8),
+            "metrics-apm.app.*" + randomAlphaOfLengthBetween(3, 8),
+            "metrics-apm.internal-*" + randomAlphaOfLengthBetween(3, 8),
+            "metrics-apm.profiling-*" + randomAlphaOfLengthBetween(3, 8),
+            "traces-apm-*" + randomAlphaOfLengthBetween(3, 8),
+            "traces-apm.rum-*" + randomAlphaOfLengthBetween(3, 8),
             "traces-apm.sampled-" + randomAlphaOfLengthBetween(3, 8)
         ).forEach(indexName -> {
             logger.info("index name [{}]", indexName);
@@ -950,6 +951,7 @@ public class ReservedRolesStoreTests extends ESTestCase {
 
             assertThat(kibanaRole.indices().allowedIndicesMatcher(DeleteIndexAction.NAME).test(indexAbstraction), is(true));
             assertThat(kibanaRole.indices().allowedIndicesMatcher(RolloverAction.NAME).test(indexAbstraction), is(true));
+            assertThat(kibanaRole.indices().allowedIndicesMatcher(UpdateSettingsAction.NAME).test(indexAbstraction), is(true));
         });
     }
 

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStoreTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStoreTests.java
@@ -867,14 +867,12 @@ public class ReservedRolesStoreTests extends ESTestCase {
 
             // Endpoint diagnostic and APM data streams also have an ILM policy with a delete action, all others should not.
             final boolean isAlsoIlmDeleteIndex = indexName.startsWith(".logs-endpoint.diagnostic.collection-")
-                || indexName.startsWith("logs-apm.app-")
-                || indexName.startsWith("logs-apm.error-")
-                || indexName.startsWith("metrics-apm.app.")
-                || indexName.startsWith("metrics-apm.internal-")
-                || indexName.startsWith("metrics-apm.profiling-")
+                || indexName.startsWith("logs-apm-")
+                || indexName.startsWith("logs-apm.")
+                || indexName.startsWith("metrics-apm-")
+                || indexName.startsWith("metrics-apm.")
                 || indexName.startsWith("traces-apm-")
-                || indexName.startsWith("traces-apm.rum-")
-                || indexName.startsWith("traces-apm.sampled-");
+                || indexName.startsWith("traces-apm.");
             assertThat(kibanaRole.indices().allowedIndicesMatcher(DeleteIndexAction.NAME).test(indexAbstraction), is(isAlsoIlmDeleteIndex));
         });
 
@@ -937,14 +935,12 @@ public class ReservedRolesStoreTests extends ESTestCase {
         // Ensure privileges necessary for ILM policies in APM & Endpoint packages
         Arrays.asList(
             ".logs-endpoint.diagnostic.collection-" + randomAlphaOfLengthBetween(3, 8),
-            "logs-apm.app-*" + randomAlphaOfLengthBetween(3, 8),
-            "logs-apm.error-*" + randomAlphaOfLengthBetween(3, 8),
-            "metrics-apm.app.*" + randomAlphaOfLengthBetween(3, 8),
-            "metrics-apm.internal-*" + randomAlphaOfLengthBetween(3, 8),
-            "metrics-apm.profiling-*" + randomAlphaOfLengthBetween(3, 8),
+            "logs-apm-*" + randomAlphaOfLengthBetween(3, 8),
+            "logs-apm.*" + randomAlphaOfLengthBetween(3, 8),
+            "metrics-apm-*" + randomAlphaOfLengthBetween(3, 8),
+            "metrics-apm.*" + randomAlphaOfLengthBetween(3, 8),
             "traces-apm-*" + randomAlphaOfLengthBetween(3, 8),
-            "traces-apm.rum-*" + randomAlphaOfLengthBetween(3, 8),
-            "traces-apm.sampled-" + randomAlphaOfLengthBetween(3, 8)
+            "traces-apm.*" + randomAlphaOfLengthBetween(3, 8)
         ).forEach(indexName -> {
             logger.info("index name [{}]", indexName);
             final IndexAbstraction indexAbstraction = mockIndexAbstraction(indexName);


### PR DESCRIPTION
Extend the `kibana_system` privileges to allow deletion of all APM indices.

This is a followup to https://github.com/elastic/elasticsearch/pull/81811. Delete phases were added to all APM data stream ILM policies in 8.0.

Closes https://github.com/elastic/kibana/issues/128014 https://github.com/elastic/apm-server/issues/7568