### PR TITLE
Revert "[ML] Only one of `inference_threads` and `model_threads` may …

### DIFF
--- a/docs/changelog/84794.yaml
+++ b/docs/changelog/84794.yaml
@@ -1,5 +1,0 @@
-pr: 84794
-summary: Only one of `inference_threads` and `model_threads` may be greater than one
-area: Machine Learning
-type: bug
-issues: []

--- a/docs/reference/ml/trained-models/apis/start-trained-model-deployment.asciidoc
+++ b/docs/reference/ml/trained-models/apis/start-trained-model-deployment.asciidoc
@@ -57,9 +57,8 @@ Defaults to 1.
 
 [NOTE]
 =============================================
-Either one of `inference_threads` and `model_threads` may be greater than one, not both.
-Increase `inference_threads` to optimize for latency. Increase `model_threads` to optimize
-for throughput.
+If the sum of `inference_threads` and `model_threads` is greater than the number of
+hardware threads then the number of `inference_threads` will be reduced.
 =============================================
 
 `queue_capacity`::

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/action/StartTrainedModelDeploymentTaskParamsTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/action/StartTrainedModelDeploymentTaskParamsTests.java
@@ -14,8 +14,6 @@ import org.elasticsearch.xpack.core.ml.action.StartTrainedModelDeploymentAction.
 
 import java.io.IOException;
 
-import static org.hamcrest.Matchers.equalTo;
-
 public class StartTrainedModelDeploymentTaskParamsTests extends AbstractSerializingTestCase<TaskParams> {
 
     @Override
@@ -34,33 +32,12 @@ public class StartTrainedModelDeploymentTaskParamsTests extends AbstractSerializ
     }
 
     public static StartTrainedModelDeploymentAction.TaskParams createRandom() {
-        boolean canModelThreadsBeGreaterThanOne = randomBoolean();
-        boolean canInferenceThreadsBeGreaterThanOne = canModelThreadsBeGreaterThanOne == false;
-
         return new TaskParams(
             randomAlphaOfLength(10),
             randomNonNegativeLong(),
-            canInferenceThreadsBeGreaterThanOne ? randomIntBetween(1, 8) : 1,
-            canModelThreadsBeGreaterThanOne ? randomIntBetween(1, 8) : 1,
+            randomIntBetween(1, 8),
+            randomIntBetween(1, 8),
             randomIntBetween(1, 10000)
         );
-    }
-
-    public void testCtor_GivenBothModelAndInferenceThreadsGreaterThanOne_AndMoreModelThreads() {
-        TaskParams taskParams = new TaskParams(randomAlphaOfLength(10), randomNonNegativeLong(), 4, 5, randomIntBetween(1, 10000));
-        assertThat(taskParams.getModelThreads(), equalTo(9));
-        assertThat(taskParams.getInferenceThreads(), equalTo(1));
-    }
-
-    public void testCtor_GivenBothModelAndInferenceThreadsGreaterThanOne_AndMoreInferenceThreads() {
-        TaskParams taskParams = new TaskParams(randomAlphaOfLength(10), randomNonNegativeLong(), 3, 2, randomIntBetween(1, 10000));
-        assertThat(taskParams.getModelThreads(), equalTo(1));
-        assertThat(taskParams.getInferenceThreads(), equalTo(5));
-    }
-
-    public void testCtor_GivenBothModelAndInferenceThreadsGreaterThanOne_AndTie() {
-        TaskParams taskParams = new TaskParams(randomAlphaOfLength(10), randomNonNegativeLong(), 4, 4, randomIntBetween(1, 10000));
-        assertThat(taskParams.getModelThreads(), equalTo(8));
-        assertThat(taskParams.getInferenceThreads(), equalTo(1));
     }
 }


### PR DESCRIPTION
…be great… (#84794)"

This reverts commit 4eaedb265dfddd1020e6e39d0797d378b8ce62a1.

On further investigation of how to improve allocation of trained models,
we concluded that being able to set `inference_threads` in combination with
`model_threads` is fundamental for scalability.
