### PR TITLE
Fix GeoGridTestCase#toXContent

### DIFF
--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/geogrid/GeoGridTestCase.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/geogrid/GeoGridTestCase.java
@@ -56,14 +56,19 @@ public abstract class GeoGridTestCase<B extends InternalGeoGridBucket, T extends
         final int precision = randomPrecision();
         int size = randomNumberOfBuckets();
         List<InternalGeoGridBucket> buckets = new ArrayList<>(size);
+        final List<Long> seen = new ArrayList<>(size);
+        int finalSize = 0;
         for (int i = 0; i < size; i++) {
             double latitude = randomDoubleBetween(-90.0, 90.0, false);
             double longitude = randomDoubleBetween(-180.0, 180.0, false);
-
             long hashAsLong = longEncode(longitude, latitude, precision);
-            buckets.add(createInternalGeoGridBucket(hashAsLong, randomInt(IndexWriter.MAX_DOCS), aggregations));
+            if (seen.contains(hashAsLong) == false) { // make sure we don't add twice the same bucket
+                buckets.add(createInternalGeoGridBucket(hashAsLong, randomInt(IndexWriter.MAX_DOCS), aggregations));
+                seen.add(hashAsLong);
+                finalSize++;
+            }
         }
-        return createInternalGeoGrid(name, size, buckets, metadata);
+        return createInternalGeoGrid(name, finalSize, buckets, metadata);
     }
 
     @Override


### PR DESCRIPTION
This change make sure we create a valid random instance for GeoGridTestCase. The current issue is that we can generate two buckets with the same key which is invalid an makes the test fail.

Note that this change was already done in master when developing the GeoHexGridAggregation https://github.com/elastic/elasticsearch/pull/82924

fixes #85086