### PR TITLE
Cleanup CommonStats.toXContent

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/admin/indices/stats/CommonStats.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/stats/CommonStats.java
@@ -40,9 +40,6 @@ import org.elasticsearch.xcontent.ToXContentFragment;
 import org.elasticsearch.xcontent.XContentBuilder;
 
 import java.io.IOException;
-import java.util.Arrays;
-import java.util.Objects;
-import java.util.stream.Stream;
 
 public class CommonStats implements Writeable, ToXContentFragment {
 
@@ -471,30 +468,30 @@ public class CommonStats implements Writeable, ToXContentFragment {
     // note, requires a wrapping object
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
-        final Stream<ToXContent> stream = Arrays.stream(
-            new ToXContent[] {
-                docs,
-                shards,
-                store,
-                indexing,
-                get,
-                search,
-                merge,
-                refresh,
-                flush,
-                warmer,
-                queryCache,
-                fieldData,
-                completion,
-                segments,
-                translog,
-                requestCache,
-                recoveryStats,
-                bulk }
-        ).filter(Objects::nonNull);
-        for (ToXContent toXContent : ((Iterable<ToXContent>) stream::iterator)) {
+        addIfNonNull(builder, params, docs);
+        addIfNonNull(builder, params, shards);
+        addIfNonNull(builder, params, store);
+        addIfNonNull(builder, params, indexing);
+        addIfNonNull(builder, params, get);
+        addIfNonNull(builder, params, search);
+        addIfNonNull(builder, params, merge);
+        addIfNonNull(builder, params, refresh);
+        addIfNonNull(builder, params, flush);
+        addIfNonNull(builder, params, warmer);
+        addIfNonNull(builder, params, queryCache);
+        addIfNonNull(builder, params, fieldData);
+        addIfNonNull(builder, params, completion);
+        addIfNonNull(builder, params, segments);
+        addIfNonNull(builder, params, translog);
+        addIfNonNull(builder, params, requestCache);
+        addIfNonNull(builder, params, recoveryStats);
+        addIfNonNull(builder, params, bulk);
+        return builder;
+    }
+
+    private static void addIfNonNull(XContentBuilder builder, Params params, @Nullable ToXContent toXContent) throws IOException {
+        if (toXContent != null) {
             toXContent.toXContent(builder, params);
         }
-        return builder;
     }
 }

--- a/server/src/main/java/org/elasticsearch/index/engine/SegmentsStats.java
+++ b/server/src/main/java/org/elasticsearch/index/engine/SegmentsStats.java
@@ -160,14 +160,13 @@ public class SegmentsStats implements Writeable, ToXContentFragment {
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
         builder.startObject(Fields.SEGMENTS);
         builder.field(Fields.COUNT, count);
-        final ByteSizeValue zeroBytes = new ByteSizeValue(0);
-        builder.humanReadableField(Fields.MEMORY_IN_BYTES, Fields.MEMORY, zeroBytes);
-        builder.humanReadableField(Fields.TERMS_MEMORY_IN_BYTES, Fields.TERMS_MEMORY, zeroBytes);
-        builder.humanReadableField(Fields.STORED_FIELDS_MEMORY_IN_BYTES, Fields.STORED_FIELDS_MEMORY, zeroBytes);
-        builder.humanReadableField(Fields.TERM_VECTORS_MEMORY_IN_BYTES, Fields.TERM_VECTORS_MEMORY, zeroBytes);
-        builder.humanReadableField(Fields.NORMS_MEMORY_IN_BYTES, Fields.NORMS_MEMORY, zeroBytes);
-        builder.humanReadableField(Fields.POINTS_MEMORY_IN_BYTES, Fields.POINTS_MEMORY, zeroBytes);
-        builder.humanReadableField(Fields.DOC_VALUES_MEMORY_IN_BYTES, Fields.DOC_VALUES_MEMORY, zeroBytes);
+        builder.humanReadableField(Fields.MEMORY_IN_BYTES, Fields.MEMORY, ByteSizeValue.ZERO);
+        builder.humanReadableField(Fields.TERMS_MEMORY_IN_BYTES, Fields.TERMS_MEMORY, ByteSizeValue.ZERO);
+        builder.humanReadableField(Fields.STORED_FIELDS_MEMORY_IN_BYTES, Fields.STORED_FIELDS_MEMORY, ByteSizeValue.ZERO);
+        builder.humanReadableField(Fields.TERM_VECTORS_MEMORY_IN_BYTES, Fields.TERM_VECTORS_MEMORY, ByteSizeValue.ZERO);
+        builder.humanReadableField(Fields.NORMS_MEMORY_IN_BYTES, Fields.NORMS_MEMORY, ByteSizeValue.ZERO);
+        builder.humanReadableField(Fields.POINTS_MEMORY_IN_BYTES, Fields.POINTS_MEMORY, ByteSizeValue.ZERO);
+        builder.humanReadableField(Fields.DOC_VALUES_MEMORY_IN_BYTES, Fields.DOC_VALUES_MEMORY, ByteSizeValue.ZERO);
         builder.humanReadableField(Fields.INDEX_WRITER_MEMORY_IN_BYTES, Fields.INDEX_WRITER_MEMORY, getIndexWriterMemory());
         builder.humanReadableField(Fields.VERSION_MAP_MEMORY_IN_BYTES, Fields.VERSION_MAP_MEMORY, getVersionMapMemory());
         builder.humanReadableField(Fields.FIXED_BIT_SET_MEMORY_IN_BYTES, Fields.FIXED_BIT_SET, getBitsetMemory());


### PR DESCRIPTION
Just saw this show up hot in an SDH (likely as a result of being hit concurrently), not a big speedup here obviously but no need to make common stats serialization artificially complex and hard to profile if it turns out we have a problem here somewhere.
