### PR TITLE
[Transform] Allow retrying non-fatal errors indefinitely

### DIFF
--- a/docs/reference/settings/transform-settings.asciidoc
+++ b/docs/reference/settings/transform-settings.asciidoc
@@ -35,5 +35,6 @@ effect.
 (<<cluster-update-settings,Dynamic>>) The number of times that a {transform}
 retries when it experiences a non-fatal error. Once the number of retries is
 exhausted, the {transform} task is marked as `failed`. The default value is `10`
-with a valid minimum of `0` and maximum of `100`. If a {transform} is already
-running, it has to be restarted to use the changed setting.
+with a valid minimum of `-1` and maximum of `100`. `-1` is a special value that
+makes the transform retry a non-fatal error indefinitely. If a {transform} is
+already running, it has to be restarted to use the changed setting.

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/Transform.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/Transform.java
@@ -131,15 +131,16 @@ public class Transform extends Plugin implements SystemIndexPlugin, PersistentTa
     private final Settings settings;
     private final SetOnce<TransformServices> transformServices = new SetOnce<>();
 
-    public static final int DEFAULT_FAILURE_RETRIES = 10;
     public static final Integer DEFAULT_INITIAL_MAX_PAGE_SEARCH_SIZE = Integer.valueOf(500);
     public static final TimeValue DEFAULT_TRANSFORM_FREQUENCY = TimeValue.timeValueMillis(60000);
 
-    // How many times the transform task can retry on an non-critical failure
+    public static final int DEFAULT_FAILURE_RETRIES = 10;
+    // How many times the transform task can retry on a non-critical failure
+    // -1 means "retry indefinitely"
     public static final Setting<Integer> NUM_FAILURE_RETRIES_SETTING = Setting.intSetting(
         "xpack.transform.num_transform_failure_retries",
         DEFAULT_FAILURE_RETRIES,
-        0,
+        -1,
         100,
         Setting.Property.NodeScope,
         Setting.Property.Dynamic

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/TransformIndexer.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/TransformIndexer.java
@@ -949,7 +949,8 @@ public abstract class TransformIndexer extends AsyncTwoPhaseIndexer<TransformInd
             return;
         }
 
-        if (context.getAndIncrementFailureCount() > context.getNumFailureRetries()) {
+        // We fail the indexer if the numFailureRetries is finite and the current failure makes the failure count exceed this finite limit.
+        if (context.getNumFailureRetries() > -1 && context.getAndIncrementFailureCount() > context.getNumFailureRetries()) {
             failIndexer(
                 "task encountered more than "
                     + context.getNumFailureRetries()


### PR DESCRIPTION
This PR implements the possibility of retrying non-fatal error indefinitely (without limit).
Such a behavior is achieved by setting `xpack.transform.num_transform_failure_retries` to `-1`.

Relates https://github.com/elastic/elasticsearch/issues/85016