### PR TITLE
[8.1] [ML] Fixes for multi-line start patterns in text structure endpoint (#85066)

### DIFF
--- a/docs/changelog/85066.yaml
+++ b/docs/changelog/85066.yaml
@@ -1,0 +1,5 @@
+pr: 85066
+summary: Fixes for multi-line start patterns in text structure endpoint
+area: Machine Learning
+type: bug
+issues: []

--- a/x-pack/plugin/text-structure/src/main/java/org/elasticsearch/xpack/textstructure/structurefinder/DelimitedTextStructureFinder.java
+++ b/x-pack/plugin/text-structure/src/main/java/org/elasticsearch/xpack/textstructure/structurefinder/DelimitedTextStructureFinder.java
@@ -28,6 +28,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Random;
+import java.util.Set;
 import java.util.SortedMap;
 import java.util.stream.Collectors;
 
@@ -37,6 +38,8 @@ public class DelimitedTextStructureFinder implements TextStructureFinder {
     static final String REGEX_NEEDS_ESCAPE_PATTERN = "([\\\\|()\\[\\]{}^$.+*?])";
     private static final int MAX_LEVENSHTEIN_COMPARISONS = 100;
     private static final int LONG_FIELD_THRESHOLD = 100;
+    private static final int LOW_CARDINALITY_MAX_SIZE = 5;
+    private static final int LOW_CARDINALITY_MIN_RATIO = 3;
     private final List<String> sampleMessages;
     private final TextStructure structure;
 
@@ -180,11 +183,14 @@ public class DelimitedTextStructureFinder implements TextStructureFinder {
                         explanation,
                         columnNamesList,
                         maxLinesPerMessage,
+                        delimiter,
                         delimiterPattern,
                         quotePattern,
                         fieldMappings,
+                        sampleRecords,
                         timeField.v1(),
-                        timeField.v2()
+                        timeField.v2(),
+                        timeoutChecker
                     )
                 );
 
@@ -207,11 +213,14 @@ public class DelimitedTextStructureFinder implements TextStructureFinder {
                     explanation,
                     columnNamesList,
                     maxLinesPerMessage,
+                    delimiter,
                     delimiterPattern,
                     quotePattern,
                     fieldMappings,
+                    sampleRecords,
                     null,
-                    null
+                    null,
+                    timeoutChecker
                 )
             );
         }
@@ -744,11 +753,14 @@ public class DelimitedTextStructureFinder implements TextStructureFinder {
         List<String> explanation,
         List<String> columnNames,
         int maxLinesPerMessage,
+        char delimiter,
         String delimiterPattern,
         String quotePattern,
         Map<String, Object> fieldMappings,
+        List<Map<String, ?>> sampleRecords,
         String timeFieldName,
-        TimestampFormatFinder timeFieldFormat
+        TimestampFormatFinder timeFieldFormat,
+        TimeoutChecker timeoutChecker
     ) {
 
         assert columnNames.isEmpty() == false;
@@ -781,6 +793,7 @@ public class DelimitedTextStructureFinder implements TextStructureFinder {
                         case "boolean" -> "(?:true|false)";
                         case "byte", "short", "integer", "long" -> "[+-]?\\d+";
                         case "half_float", "float", "double" -> "[+-]?(?:\\d+(?:\\.\\d+)?|\\.\\d+)(?:[eE][+-]?\\d+)?";
+                        case "keyword" -> findLowCardinalityKeywordPattern(columnName, sampleRecords, timeoutChecker);
                         default -> null;
                     };
                     if (columnPattern != null) {
@@ -797,13 +810,122 @@ public class DelimitedTextStructureFinder implements TextStructureFinder {
                     }
                 }
             }
-            builder.append(".*?").append(delimiterPattern);
+            // We need to be strict about how many delimiters precede the chosen field,
+            // so if it's not the first then we cannot tolerate the preceding fields
+            // containing the delimiter. Additionally, there's no point choosing a field
+            // after a field that sometimes contains line breaks to identify the first
+            // line.
+            if (columnValueContainsDelimiterOrLineBreak(columnName, delimiter, sampleRecords, timeoutChecker)) {
+                throw new IllegalArgumentException(
+                    "Cannot create a multi-line start pattern. "
+                        + "No suitable column to match exists before the first column whose values contain line breaks or delimiters ["
+                        + columnName
+                        + "]. If the timestamp format was not identified correctly adding an override for this may help."
+                );
+            }
+            builder.append("[^");
+            // Within a negated character class we don't want to escape special regex
+            // characters like dot, hence shouldn't use the pre-built pattern
+            if (delimiter == '\t') {
+                builder.append("\\t");
+            } else {
+                builder.append(delimiter);
+            }
+            builder.append("]*?").append(delimiterPattern);
         }
         // TODO: if this happens a lot then we should try looking for the a multi-line END pattern instead of a start pattern.
         // But this would require changing the find_structure response, and the file upload UI, and would make creating Filebeat
         // configs from the find_structure response more complex, so let's wait to see if there's significant demand.
         explanation.add("Failed to create a suitable multi-line start pattern");
         return null;
+    }
+
+    /**
+     * @return <code>true</code> if the value of the field {@code columnName} in any record in the {@code sampleRecords}
+     *         contains the {@code delimiter} or a line break.
+     */
+    static boolean columnValueContainsDelimiterOrLineBreak(
+        String columnName,
+        char delimiter,
+        List<Map<String, ?>> sampleRecords,
+        TimeoutChecker timeoutChecker
+    ) {
+        for (Map<String, ?> sampleRecord : sampleRecords) {
+            timeoutChecker.check("delimiter search in multi-line start pattern determination");
+            Object value = sampleRecord.get(columnName);
+            if (value != null) {
+                String str = value.toString();
+                if (str.indexOf(delimiter) >= 0 || str.indexOf('\n') >= 0) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Try to find a regular expression that will match any of the values of a keyword field, providing:
+     * 1. There are only a small number of distinct values of that keyword field
+     * 2. The number of sampled records is several times bigger than the number of distinct values
+     * 3. None of the values is empty or contains a line break
+     * 4. None of the values matches the last line of a value of some other field in the sampled records
+     * @return A regular expression that will match the small number of distinct values of the keyword field, or
+     *         <code>null</code> if a suitable regular expression could not be found.
+     */
+    static String findLowCardinalityKeywordPattern(String columnName, List<Map<String, ?>> sampleRecords, TimeoutChecker timeoutChecker) {
+
+        int maxCardinality = Math.min(LOW_CARDINALITY_MAX_SIZE, sampleRecords.size() / LOW_CARDINALITY_MIN_RATIO);
+
+        // Find the distinct values of the column, aborting if there are too many or if any contain newlines.
+        Set<String> values = new HashSet<>();
+        for (Map<String, ?> sampleRecord : sampleRecords) {
+            Object value = sampleRecord.get(columnName);
+            if (value == null) {
+                return null;
+            }
+            String str = value.toString();
+            if (str.isEmpty() || str.indexOf('\n') >= 0) {
+                return null;
+            }
+            values.add(str);
+            if (values.size() > maxCardinality) {
+                return null;
+            }
+        }
+
+        // Check that none of the values exist in other columns.
+        // In the case of field values that span multiple lines, it's the part after the last newline that matters.
+        for (Map<String, ?> sampleRecord : sampleRecords) {
+            timeoutChecker.check("keyword-based multi-line start pattern determination");
+            if (sampleRecord.entrySet()
+                .stream()
+                .anyMatch(entry -> entry.getKey().equals(columnName) == false && containsLastLine(values, entry.getValue()))) {
+                return null;
+            }
+        }
+
+        return values.stream()
+            .map(value -> value.replaceAll(REGEX_NEEDS_ESCAPE_PATTERN, "\\\\$1"))
+            .sorted()
+            .collect(Collectors.joining("|", "(?:", ")"));
+    }
+
+    /**
+     * @param set A set of strings.
+     * @param obj An object whose string representation may or may not contain line breaks.
+     * @return true if {@code set} contains the last line of {@code str} (i.e. the whole of {@code str} if it has no line breaks).
+     */
+    static boolean containsLastLine(Set<String> set, Object obj) {
+        if (obj == null) {
+            return false;
+        }
+        String str = obj.toString();
+        int lastNewline = str.lastIndexOf('\n');
+        if (lastNewline >= 0) {
+            return set.contains(str.substring(lastNewline + 1));
+        } else {
+            return set.contains(str);
+        }
     }
 
     /**

--- a/x-pack/plugin/text-structure/src/test/java/org/elasticsearch/xpack/textstructure/structurefinder/DelimitedTextStructureFinderTests.java
+++ b/x-pack/plugin/text-structure/src/test/java/org/elasticsearch/xpack/textstructure/structurefinder/DelimitedTextStructureFinderTests.java
@@ -15,8 +15,10 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.BitSet;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.TreeMap;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -28,8 +30,10 @@ import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.endsWith;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasKey;
+import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.lessThanOrEqualTo;
 import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.Matchers.startsWith;
 
 public class DelimitedTextStructureFinderTests extends TextStructureTestCase {
@@ -1034,11 +1038,14 @@ public class DelimitedTextStructureFinderTests extends TextStructureTestCase {
                 explanation,
                 columnNames,
                 1,
+                ',',
                 ",",
                 "\"",
                 mappings,
+                List.of(),
                 timeFieldName,
-                timeFieldFormat
+                timeFieldFormat,
+                NOOP_TIMEOUT_CHECKER
             )
         );
         assertThat(explanation, contains("Not creating a multi-line start pattern as no sampled message spanned multiple lines"));
@@ -1052,16 +1059,19 @@ public class DelimitedTextStructureFinderTests extends TextStructureTestCase {
         TimestampFormatFinder timeFieldFormat = new TimestampFormatFinder(explanation, true, true, true, NOOP_TIMEOUT_CHECKER);
         timeFieldFormat.addSample("2020-01-30T15:05:09");
         Map<String, Object> mappings = new TreeMap<>();
+        Map<String, Object> sampleRecord = new HashMap<>();
         for (String columnName : columnNames) {
             if (columnName.equals(timeFieldName)) {
                 mappings.put(columnName, Collections.singletonMap(TextStructureUtils.MAPPING_TYPE_SETTING, "date"));
+                sampleRecord.put(columnName, "2020-01-30T15:05:09");
             } else {
-                mappings.put(columnName, Collections.singletonMap(TextStructureUtils.MAPPING_TYPE_SETTING, randomFrom("text", "keyword")));
+                mappings.put(columnName, Collections.singletonMap(TextStructureUtils.MAPPING_TYPE_SETTING, "text"));
+                sampleRecord.put(columnName, randomAlphaOfLength(10));
             }
         }
 
         String expected = "^"
-            + Stream.generate(() -> ".*?,").limit(timeFieldColumnIndex).collect(Collectors.joining())
+            + Stream.generate(() -> "[^,]*?,").limit(timeFieldColumnIndex).collect(Collectors.joining())
             + "\"?\\d{4}-\\d{2}-\\d{2}[T ]\\d{2}:\\d{2}";
         assertEquals(
             expected,
@@ -1069,11 +1079,14 @@ public class DelimitedTextStructureFinderTests extends TextStructureTestCase {
                 explanation,
                 columnNames,
                 2,
+                ',',
                 ",",
                 "\"",
                 mappings,
+                List.of(sampleRecord),
                 timeFieldName,
-                timeFieldFormat
+                timeFieldFormat,
+                NOOP_TIMEOUT_CHECKER
             )
         );
         assertThat(explanation, contains("Created a multi-line start pattern based on timestamp column [" + timeFieldName + "]"));
@@ -1087,20 +1100,24 @@ public class DelimitedTextStructureFinderTests extends TextStructureTestCase {
             "(?:true|false)",
             "[+-]?\\d+",
             "[+-]?(?:\\d+(?:\\.\\d+)?|\\.\\d+)(?:[eE][+-]?\\d+)?" }[randomIndex];
+        String sampleValue = new String[] { "true", "42", "3.1415927" }[randomIndex];
         List<String> columnNames = Stream.generate(() -> randomAlphaOfLengthBetween(5, 10)).limit(10).collect(Collectors.toList());
         int chosenFieldColumnIndex = randomIntBetween(0, columnNames.size() - 2);
         String chosenField = columnNames.get(chosenFieldColumnIndex);
         Map<String, Object> mappings = new TreeMap<>();
+        Map<String, Object> sampleRecord = new HashMap<>();
         for (String columnName : columnNames) {
             if (columnName.equals(chosenField)) {
                 mappings.put(columnName, Collections.singletonMap(TextStructureUtils.MAPPING_TYPE_SETTING, type));
+                sampleRecord.put(columnName, sampleValue);
             } else {
-                mappings.put(columnName, Collections.singletonMap(TextStructureUtils.MAPPING_TYPE_SETTING, randomFrom("text", "keyword")));
+                mappings.put(columnName, Collections.singletonMap(TextStructureUtils.MAPPING_TYPE_SETTING, "text"));
+                sampleRecord.put(columnName, randomAlphaOfLength(10));
             }
         }
 
         String expected = "^"
-            + Stream.generate(() -> ".*?,").limit(chosenFieldColumnIndex).collect(Collectors.joining())
+            + Stream.generate(() -> "[^,]*?,").limit(chosenFieldColumnIndex).collect(Collectors.joining())
             + "(?:"
             + expectedTypePattern
             + "|\""
@@ -1108,9 +1125,65 @@ public class DelimitedTextStructureFinderTests extends TextStructureTestCase {
             + "\"),";
         assertEquals(
             expected,
-            DelimitedTextStructureFinder.makeMultilineStartPattern(explanation, columnNames, 2, ",", "\"", mappings, null, null)
+            DelimitedTextStructureFinder.makeMultilineStartPattern(
+                explanation,
+                columnNames,
+                2,
+                ',',
+                ",",
+                "\"",
+                mappings,
+                List.of(sampleRecord),
+                null,
+                null,
+                NOOP_TIMEOUT_CHECKER
+            )
         );
         assertThat(explanation, contains("Created a multi-line start pattern based on [" + type + "] column [" + chosenField + "]"));
+    }
+
+    public void testMultilineStartPatternFromKeywordField() {
+
+        List<String> columnNames = Stream.generate(() -> randomAlphaOfLengthBetween(5, 10)).limit(10).collect(Collectors.toList());
+        int chosenFieldColumnIndex = randomIntBetween(0, columnNames.size() - 2);
+        String chosenFieldName = columnNames.get(chosenFieldColumnIndex);
+        Map<String, Object> mappings = new TreeMap<>();
+        List<Map<String, ?>> sampleRecords = new ArrayList<>();
+        for (int record = 0; record < 100; ++record) {
+            Map<String, Object> sampleRecord = new HashMap<>();
+            for (String columnName : columnNames) {
+                if (record == 0) {
+                    mappings.put(columnName, Collections.singletonMap(TextStructureUtils.MAPPING_TYPE_SETTING, "keyword"));
+                }
+                if (columnName.equals(chosenFieldName)) {
+                    sampleRecord.put(columnName, randomFrom("A1", "B2", "C3"));
+                } else {
+                    sampleRecord.put(columnName, randomAlphaOfLength(5));
+                }
+            }
+            sampleRecords.add(sampleRecord);
+        }
+
+        String expected = "^"
+            + Stream.generate(() -> "[^,]*?,").limit(chosenFieldColumnIndex).collect(Collectors.joining())
+            + "(?:(?:A1|B2|C3)|\"(?:A1|B2|C3)\"),";
+        assertEquals(
+            expected,
+            DelimitedTextStructureFinder.makeMultilineStartPattern(
+                explanation,
+                columnNames,
+                2,
+                ',',
+                ",",
+                "\"",
+                mappings,
+                sampleRecords,
+                null,
+                null,
+                NOOP_TIMEOUT_CHECKER
+            )
+        );
+        assertThat(explanation, contains("Created a multi-line start pattern based on [keyword] column [" + chosenFieldName + "]"));
     }
 
     public void testMultilineStartPatternDeterminationTooHard() {
@@ -1118,11 +1191,94 @@ public class DelimitedTextStructureFinderTests extends TextStructureTestCase {
         List<String> columnNames = Stream.generate(() -> randomAlphaOfLengthBetween(5, 10)).limit(10).collect(Collectors.toList());
         Map<String, Object> mappings = new TreeMap<>();
         for (String columnName : columnNames) {
-            mappings.put(columnName, Collections.singletonMap(TextStructureUtils.MAPPING_TYPE_SETTING, randomFrom("text", "keyword")));
+            mappings.put(columnName, Collections.singletonMap(TextStructureUtils.MAPPING_TYPE_SETTING, "text"));
         }
 
-        assertNull(DelimitedTextStructureFinder.makeMultilineStartPattern(explanation, columnNames, 2, ",", "\"", mappings, null, null));
+        assertNull(
+            DelimitedTextStructureFinder.makeMultilineStartPattern(
+                explanation,
+                columnNames,
+                2,
+                ',',
+                ",",
+                "\"",
+                mappings,
+                List.of(),
+                null,
+                null,
+                NOOP_TIMEOUT_CHECKER
+            )
+        );
         assertThat(explanation, contains("Failed to create a suitable multi-line start pattern"));
+    }
+
+    public void testColumnValueContainsDelimiterOrLineBreak() {
+
+        int failingRecord = randomIntBetween(0, 99);
+        List<Map<String, ?>> sampleRecords = new ArrayList<>();
+        for (int record = 0; record < 100; ++record) {
+            Map<String, String> sampleRecord = new HashMap<>();
+            for (int column = 0; column < 3; ++column) {
+                sampleRecord.put(
+                    "col" + column,
+                    (record == failingRecord && column == 1) ? "a" + randomFrom(",", "\n") + "b" : randomAlphaOfLength(3)
+                );
+            }
+            sampleRecords.add(sampleRecord);
+        }
+
+        assertFalse(DelimitedTextStructureFinder.columnValueContainsDelimiterOrLineBreak("col0", ',', sampleRecords, NOOP_TIMEOUT_CHECKER));
+        assertTrue(DelimitedTextStructureFinder.columnValueContainsDelimiterOrLineBreak("col1", ',', sampleRecords, NOOP_TIMEOUT_CHECKER));
+        assertFalse(DelimitedTextStructureFinder.columnValueContainsDelimiterOrLineBreak("col2", ',', sampleRecords, NOOP_TIMEOUT_CHECKER));
+    }
+
+    public void testFindLowCardinalityKeywordPatternSucceeds() {
+
+        List<Map<String, ?>> sampleRecords = new ArrayList<>();
+        for (int record = 0; record < 100; ++record) {
+            Map<String, String> sampleRecord = new HashMap<>();
+            for (int column = 0; column < 10; ++column) {
+                sampleRecord.put("col" + column, (column == 1) ? randomFrom("A1", "B.", "C?") : randomAlphaOfLength(3));
+            }
+            sampleRecords.add(sampleRecord);
+        }
+
+        assertThat(
+            DelimitedTextStructureFinder.findLowCardinalityKeywordPattern("col1", sampleRecords, NOOP_TIMEOUT_CHECKER),
+            is("(?:A1|B\\.|C\\?)")
+        );
+    }
+
+    public void testFindLowCardinalityKeywordPatternFails() {
+
+        int failingRecord = randomIntBetween(0, 99);
+        List<Map<String, ?>> sampleRecords = new ArrayList<>();
+        for (int record = 0; record < 100; ++record) {
+            Map<String, String> sampleRecord = new HashMap<>();
+            for (int column = 0; column < 10; ++column) {
+                sampleRecord.put(
+                    "col" + column,
+                    (column == 1 || (record == failingRecord && column == 6)) ? randomFrom("A1", "B.", "C?") : randomAlphaOfLength(3)
+                );
+            }
+            sampleRecords.add(sampleRecord);
+        }
+
+        assertThat(DelimitedTextStructureFinder.findLowCardinalityKeywordPattern("col1", sampleRecords, NOOP_TIMEOUT_CHECKER), nullValue());
+    }
+
+    public void testContainsLastLine() {
+
+        Set<String> values = Set.of("A1", "B2", "C3");
+
+        assertTrue(DelimitedTextStructureFinder.containsLastLine(values, "A1"));
+        assertTrue(DelimitedTextStructureFinder.containsLastLine(values, "B2"));
+        assertFalse(DelimitedTextStructureFinder.containsLastLine(values, "C2"));
+        assertFalse(DelimitedTextStructureFinder.containsLastLine(values, "D4"));
+        assertTrue(DelimitedTextStructureFinder.containsLastLine(values, "A1\nB2"));
+        assertTrue(DelimitedTextStructureFinder.containsLastLine(values, "B1\nA2\nC3"));
+        assertFalse(DelimitedTextStructureFinder.containsLastLine(values, "A1\nB2\nC2"));
+        assertFalse(DelimitedTextStructureFinder.containsLastLine(values, "A1\nB2\nC3\n"));
     }
 
     public void testMakeExcludeLinesPattern() {

--- a/x-pack/plugin/text-structure/src/test/java/org/elasticsearch/xpack/textstructure/structurefinder/GrokPatternCreatorTests.java
+++ b/x-pack/plugin/text-structure/src/test/java/org/elasticsearch/xpack/textstructure/structurefinder/GrokPatternCreatorTests.java
@@ -14,9 +14,11 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.is;
 
 public class GrokPatternCreatorTests extends TextStructureTestCase {
 
@@ -698,5 +700,24 @@ public class GrokPatternCreatorTests extends TextStructureTestCase {
         );
 
         assertEquals("Supplied Grok pattern [" + grokPattern + "] does not match sample messages", e.getMessage());
+    }
+
+    public void testLongestRun() {
+
+        List<Integer> sequence = new ArrayList<>();
+        if (randomBoolean()) {
+            for (int before = randomIntBetween(1, 41); before > 0; --before) {
+                sequence.add(randomIntBetween(1, 2));
+            }
+        }
+        for (int longest = 42; longest > 0; --longest) {
+            sequence.add(42);
+        }
+        if (randomBoolean()) {
+            for (int after = randomIntBetween(1, 41); after > 0; --after) {
+                sequence.add(randomIntBetween(2, 3));
+            }
+        }
+        assertThat(GrokPatternCreator.longestRun(sequence), is(42));
     }
 }


### PR DESCRIPTION
Backports the following commits to 8.1:
 - [ML] Fixes for multi-line start patterns in text structure endpoint (#85066)