### PR TITLE
Fix flaky CoordinatorTests#testReportsConnectBackProblemsDuringJoining

### DIFF
--- a/server/src/test/java/org/elasticsearch/cluster/coordination/CoordinatorTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/coordination/CoordinatorTests.java
@@ -1713,9 +1713,8 @@ public class CoordinatorTests extends AbstractCoordinatorTestCase {
             Loggers.addAppender(joinHelperLogger, mockAppender);
             try {
                 cluster.runFor(
-                    // This expects 8 tasks to be executed:
+                    // This expects 8 tasks to be executed after PeerFinder handling wakeup:
                     //
-                    // * PeerFinder handling wakeup
                     // * connectToRemoteMasterNode[0.0.0.0:11]
                     // * [internal:transport/handshake] from {node1} to {node2}
                     // * response to [internal:transport/handshake] from {node1} to {node2}

--- a/server/src/test/java/org/elasticsearch/cluster/coordination/CoordinatorTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/coordination/CoordinatorTests.java
@@ -1713,7 +1713,18 @@ public class CoordinatorTests extends AbstractCoordinatorTestCase {
             Loggers.addAppender(joinHelperLogger, mockAppender);
             try {
                 cluster.runFor(
-                    defaultMillis(DISCOVERY_FIND_PEERS_INTERVAL_SETTING) + 2 * DEFAULT_DELAY_VARIABILITY,
+                    // This expects 8 tasks to be executed:
+                    //
+                    // * PeerFinder handling wakeup
+                    // * connectToRemoteMasterNode[0.0.0.0:11]
+                    // * [internal:transport/handshake] from {node1} to {node2}
+                    // * response to [internal:transport/handshake] from {node1} to {node2}
+                    // * [internal:discovery/request_peers] from {node1} to
+                    // * response to [internal:discovery/request_peers] from {node1} to {node2}
+                    // * [internal:cluster/coordination/join] from {node1} to {node2}
+                    // * error response to [internal:cluster/coordination/join] from {node1} to {node2}
+                    //
+                    defaultMillis(DISCOVERY_FIND_PEERS_INTERVAL_SETTING) + 8 * DEFAULT_DELAY_VARIABILITY,
                     "allowing time for join attempt"
                 );
                 mockAppender.assertAllExpectationsMatched();

--- a/server/src/test/java/org/elasticsearch/cluster/coordination/CoordinatorTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/coordination/CoordinatorTests.java
@@ -1722,6 +1722,7 @@ public class CoordinatorTests extends AbstractCoordinatorTestCase {
                     // * [internal:discovery/request_peers] from {node1} to
                     // * response to [internal:discovery/request_peers] from {node1} to {node2}
                     // * [internal:cluster/coordination/join] from {node1} to {node2}
+                    // * [internal:transport/handshake] from {node2} to {node1} (rejected due to action block)
                     // * error response to [internal:cluster/coordination/join] from {node1} to {node2}
                     //
                     defaultMillis(DISCOVERY_FIND_PEERS_INTERVAL_SETTING) + 8 * DEFAULT_DELAY_VARIABILITY,


### PR DESCRIPTION
This test was failing previously as it was allocating too few time for
all expected tasks to execute.

Closes: #85087 