### PR TITLE
[8.1] Make sure the random generated shape can be indexed in GeoTilerTests (#84986)

### DIFF
--- a/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/search/aggregations/bucket/geogrid/GeoGridTilerTestCase.java
+++ b/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/search/aggregations/bucket/geogrid/GeoGridTilerTestCase.java
@@ -106,7 +106,8 @@ public abstract class GeoGridTilerTestCase extends ESTestCase {
             int precision = randomIntBetween(0, 3);
             Geometry geometry = GeometryNormalizer.apply(Orientation.CCW, randomValueOtherThanMany(g -> {
                 try {
-                    GeometryNormalizer.apply(Orientation.CCW, g);
+                    // make sure is a valid shape
+                    new GeoShapeIndexer(Orientation.CCW, "test").indexShape(g);
                     return false;
                 } catch (Exception e) {
                     return true;


### PR DESCRIPTION
Backports the following commits to 8.1:
 - Make sure the random generated shape can be indexed in GeoTilerTests (#84986)