### PR TITLE
TSDB: Make reindex tests pass

### DIFF
--- a/modules/reindex/src/yamlRestTest/resources/rest-api-spec/test/reindex/100_tsdb.yml
+++ b/modules/reindex/src/yamlRestTest/resources/rest-api-spec/test/reindex/100_tsdb.yml
@@ -167,8 +167,9 @@ from tsdb to tsdb:
   - match: {hits.hits.1._source.@timestamp: 2021-04-28T18:50:23.142Z}
   - match: {hits.hits.2._source.@timestamp: 2021-04-28T18:50:53.142Z}
   - match: {hits.hits.3._source.@timestamp: 2021-04-28T18:51:03.142Z}
+
 ---
-from standard to tsdb:
+from standard with tsdb id to tsdb:
   - skip:
       version: " - 8.1.99"
       reason: introduced in 8.2.0
@@ -198,9 +199,80 @@ from standard to tsdb:
         refresh: true
         body:
           source:
-            index: tsdb
+            index: standard
           dest:
             index: tsdb_new
+  - match: {created: 4}
+  - match: {updated: 0}
+  - match: {version_conflicts: 0}
+  - match: {batches: 1}
+  - match: {failures: []}
+  - match: {throttled_millis: 0}
+  - gte: { took: 0 }
+  - is_false: task
+  - is_false: deleted
+
+  - do:
+      indices.refresh: {}
+
+  - do:
+      search:
+        index: tsdb_new
+        body:
+          sort: '@timestamp'
+          aggs:
+            tsids:
+              terms:
+                field: _tsid
+                order:
+                  _key: asc
+
+  - match: {hits.total.value: 4}
+  - match: {aggregations.tsids.buckets.0.key: {k8s.pod.uid: 1c4fc7b8-93b7-4ba8-b609-2a48af2f8e39, metricset: pod}}
+  - match: {aggregations.tsids.buckets.0.doc_count: 4}
+  - match: {hits.hits.0._source.@timestamp: 2021-04-28T18:50:03.142Z}
+  - match: {hits.hits.1._source.@timestamp: 2021-04-28T18:50:23.142Z}
+  - match: {hits.hits.2._source.@timestamp: 2021-04-28T18:50:53.142Z}
+  - match: {hits.hits.3._source.@timestamp: 2021-04-28T18:51:03.142Z}
+
+---
+from standard with random _id to tsdb:
+  - skip:
+      version: " - 8.1.99"
+      reason: introduced in 8.2.0
+
+  # Populate the standard index
+  - do:
+      reindex:
+        refresh: true
+        body:
+          source:
+            index: tsdb
+          dest:
+            index: standard
+          script:
+            source: ctx._id = null
+  - match: {created: 4}
+  - match: {updated: 0}
+  - match: {version_conflicts: 0}
+  - match: {batches: 1}
+  - match: {failures: []}
+  - match: {throttled_millis: 0}
+  - gte: { took: 0 }
+  - is_false: task
+  - is_false: deleted
+
+  # Now test reindexing from it to tsdb
+  - do:
+      reindex:
+        refresh: true
+        body:
+          source:
+            index: standard
+          dest:
+            index: tsdb_new
+          script:
+            source: ctx._id = null
   - match: {created: 4}
   - match: {updated: 0}
   - match: {version_conflicts: 0}
@@ -241,7 +313,6 @@ from tsdb to tsdb modifying timestamp:
       reason: introduced in 8.2.0
 
   - do:
-      catch: bad_request # TODO make this work
       reindex:
         refresh: true
         body:
@@ -250,7 +321,39 @@ from tsdb to tsdb modifying timestamp:
           dest:
             index: tsdb_new
           script:
-            source: ctx._source["@timestamp"] = ctx._source["@timestamp"].replace("-04-", "-05-")
+            source: ctx._id = null; ctx._source["@timestamp"] = ctx._source["@timestamp"].replace("-04-", "-05-")
+  - match: {created: 4}
+  - match: {updated: 0}
+  - match: {version_conflicts: 0}
+  - match: {batches: 1}
+  - match: {failures: []}
+  - match: {throttled_millis: 0}
+  - gte: { took: 0 }
+  - is_false: task
+  - is_false: deleted
+
+  - do:
+      indices.refresh: {}
+
+  - do:
+      search:
+        index: tsdb_new
+        body:
+          sort: '@timestamp'
+          aggs:
+            tsids:
+              terms:
+                field: _tsid
+                order:
+                  _key: asc
+
+  - match: {hits.total.value: 4}
+  - match: {aggregations.tsids.buckets.0.key: {k8s.pod.uid: 1c4fc7b8-93b7-4ba8-b609-2a48af2f8e39, metricset: pod}}
+  - match: {aggregations.tsids.buckets.0.doc_count: 4}
+  - match: {hits.hits.0._source.@timestamp: 2021-05-28T18:50:03.142Z}
+  - match: {hits.hits.1._source.@timestamp: 2021-05-28T18:50:23.142Z}
+  - match: {hits.hits.2._source.@timestamp: 2021-05-28T18:50:53.142Z}
+  - match: {hits.hits.3._source.@timestamp: 2021-05-28T18:51:03.142Z}
 
 ---
 from tsdb to tsdb modifying dimension:
@@ -259,7 +362,6 @@ from tsdb to tsdb modifying dimension:
       reason: introduced in 8.2.0
 
   - do:
-      catch: bad_request # TODO make this work
       reindex:
         refresh: true
         body:
@@ -268,4 +370,36 @@ from tsdb to tsdb modifying dimension:
           dest:
             index: tsdb_new
           script:
-            source: ctx._source["metricset"] = "bubbles"
+            source: ctx._id = null; ctx._source["metricset"] = "bubbles"
+  - match: {created: 4}
+  - match: {updated: 0}
+  - match: {version_conflicts: 0}
+  - match: {batches: 1}
+  - match: {failures: []}
+  - match: {throttled_millis: 0}
+  - gte: { took: 0 }
+  - is_false: task
+  - is_false: deleted
+
+  - do:
+      indices.refresh: {}
+
+  - do:
+      search:
+        index: tsdb_new
+        body:
+          sort: '@timestamp'
+          aggs:
+            tsids:
+              terms:
+                field: _tsid
+                order:
+                  _key: asc
+
+  - match: {hits.total.value: 4}
+  - match: {aggregations.tsids.buckets.0.key: {k8s.pod.uid: 1c4fc7b8-93b7-4ba8-b609-2a48af2f8e39, metricset: bubbles}}
+  - match: {aggregations.tsids.buckets.0.doc_count: 4}
+  - match: {hits.hits.0._source.@timestamp: 2021-04-28T18:50:03.142Z}
+  - match: {hits.hits.1._source.@timestamp: 2021-04-28T18:50:23.142Z}
+  - match: {hits.hits.2._source.@timestamp: 2021-04-28T18:50:53.142Z}
+  - match: {hits.hits.3._source.@timestamp: 2021-04-28T18:51:03.142Z}


### PR DESCRIPTION
It turns out that there is a fairly simple recipe for reindexing to a
`time_series` index:
1. If you are reindexing from a time series index to a time series index
   and *not* changing the `@timestamp` or dimensions it "just
   works"(TM).
2. If you are reindexing from a standard index with a standard random
   `_id` you should clear it on reindex.
3. If you are reindexing from tsdb index to a tsdb index and modifying a
   dimension or `@timestamp` then you should clear the `_id`.

This is not pleasant to have to remember. But it doesn't crash!
