### PR TITLE
Remove unnecessary fork in HandshakingTAConnector

### DIFF
--- a/server/src/main/java/org/elasticsearch/discovery/HandshakingTransportAddressConnector.java
+++ b/server/src/main/java/org/elasticsearch/discovery/HandshakingTransportAddressConnector.java
@@ -150,8 +150,8 @@ public class HandshakingTransportAddressConnector implements TransportAddressCon
                                             logger.warn(
                                                 new ParameterizedMessage(
                                                     "completed handshake with [{}] at [{}] but followup connection to [{}] failed",
-                                                    transportAddress,
                                                     remoteNode.descriptionWithoutAttributes(),
+                                                    transportAddress,
                                                     remoteNode.getAddress()
                                                 ),
                                                 e

--- a/server/src/main/java/org/elasticsearch/discovery/HandshakingTransportAddressConnector.java
+++ b/server/src/main/java/org/elasticsearch/discovery/HandshakingTransportAddressConnector.java
@@ -13,7 +13,6 @@ import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.message.ParameterizedMessage;
 import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionListener;
-import org.elasticsearch.action.ActionRunnable;
 import org.elasticsearch.action.NotifyOnceListener;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.common.Randomness;
@@ -21,7 +20,6 @@ import org.elasticsearch.common.UUIDs;
 import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.transport.TransportAddress;
-import org.elasticsearch.common.util.concurrent.AbstractRunnable;
 import org.elasticsearch.core.Releasable;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.core.internal.io.IOUtils;
@@ -66,15 +64,14 @@ public class HandshakingTransportAddressConnector implements TransportAddressCon
 
     @Override
     public void connectToRemoteMasterNode(TransportAddress transportAddress, ActionListener<ProbeConnectionResult> listener) {
-        transportService.getThreadPool().generic().execute(new ActionRunnable<>(listener) {
-            private final AbstractRunnable thisConnectionAttempt = this;
+        try {
 
-            @Override
-            protected void doRun() {
-                // We could skip this if the transportService were already connected to the given address, but the savings would be minimal
-                // so we open a new connection anyway.
+            // We could skip this if the transportService were already connected to the given address, but the savings would be minimal so
+            // we open a new connection anyway.
 
-                final DiscoveryNode targetNode = new DiscoveryNode(
+            logger.trace("[{}] opening probe connection", transportAddress);
+            transportService.openConnection(
+                new DiscoveryNode(
                     "",
                     transportAddress.toString(),
                     UUIDs.randomBase64UUID(Randomness.get()), // generated deterministically for reproducible tests
@@ -84,114 +81,107 @@ public class HandshakingTransportAddressConnector implements TransportAddressCon
                     emptyMap(),
                     emptySet(),
                     Version.CURRENT.minimumCompatibilityVersion()
-                );
+                ),
+                ConnectionProfile.buildSingleChannelProfile(
+                    Type.REG,
+                    probeConnectTimeout,
+                    probeHandshakeTimeout,
+                    TimeValue.MINUS_ONE,
+                    null,
+                    null
+                ),
+                listener.delegateFailure((l, connection) -> {
+                    logger.trace("[{}] opened probe connection", transportAddress);
 
-                logger.trace("[{}] opening probe connection", thisConnectionAttempt);
-                transportService.openConnection(
-                    targetNode,
-                    ConnectionProfile.buildSingleChannelProfile(
-                        Type.REG,
-                        probeConnectTimeout,
-                        probeHandshakeTimeout,
-                        TimeValue.MINUS_ONE,
-                        null,
-                        null
-                    ),
-                    listener.delegateFailure((l, connection) -> {
-                        logger.trace("[{}] opened probe connection", thisConnectionAttempt);
+                    // use NotifyOnceListener to make sure the following line does not result in onFailure being called when
+                    // the connection is closed in the onResponse handler
+                    transportService.handshake(connection, probeHandshakeTimeout, new NotifyOnceListener<>() {
 
-                        // use NotifyOnceListener to make sure the following line does not result in onFailure being called when
-                        // the connection is closed in the onResponse handler
-                        transportService.handshake(connection, probeHandshakeTimeout, new NotifyOnceListener<>() {
-
-                            @Override
-                            protected void innerOnResponse(DiscoveryNode remoteNode) {
-                                try {
-                                    // success means (amongst other things) that the cluster names match
-                                    logger.trace("[{}] handshake successful: {}", thisConnectionAttempt, remoteNode);
-                                    IOUtils.closeWhileHandlingException(connection);
-
-                                    if (remoteNode.equals(transportService.getLocalNode())) {
-                                        listener.onFailure(
-                                            new ConnectTransportException(
-                                                remoteNode,
-                                                String.format(
-                                                    Locale.ROOT,
-                                                    "successfully discovered local node %s at [%s]",
-                                                    remoteNode.descriptionWithoutAttributes(),
-                                                    transportAddress
-                                                )
-                                            )
-                                        );
-                                    } else if (remoteNode.isMasterNode() == false) {
-                                        listener.onFailure(
-                                            new ConnectTransportException(
-                                                remoteNode,
-                                                String.format(
-                                                    Locale.ROOT,
-                                                    """
-                                                        successfully discovered master-ineligible node %s at [%s]; to suppress this \
-                                                        message, remove address [%s] from your discovery configuration or ensure that \
-                                                        traffic to this address is routed only to master-eligible nodes""",
-                                                    remoteNode.descriptionWithoutAttributes(),
-                                                    transportAddress,
-                                                    transportAddress
-                                                )
-                                            )
-                                        );
-                                    } else {
-                                        transportService.connectToNode(remoteNode, new ActionListener<>() {
-                                            @Override
-                                            public void onResponse(Releasable connectionReleasable) {
-                                                logger.trace("[{}] completed full connection with [{}]", thisConnectionAttempt, remoteNode);
-                                                listener.onResponse(new ProbeConnectionResult(remoteNode, connectionReleasable));
-                                            }
-
-                                            @Override
-                                            public void onFailure(Exception e) {
-                                                // we opened a connection and successfully performed a handshake, so we're definitely
-                                                // talking to a master-eligible node with a matching cluster name and a good version, but
-                                                // the attempt to open a full connection to its publish address failed; a common reason is
-                                                // that the remote node is listening on 0.0.0.0 but has made an inappropriate choice for its
-                                                // publish address.
-                                                logger.warn(
-                                                    new ParameterizedMessage(
-                                                        "[{}] completed handshake with [{}] but followup connection failed",
-                                                        thisConnectionAttempt,
-                                                        remoteNode
-                                                    ),
-                                                    e
-                                                );
-                                                listener.onFailure(e);
-                                            }
-                                        });
-                                    }
-                                } catch (Exception e) {
-                                    listener.onFailure(e);
-                                }
-                            }
-
-                            @Override
-                            protected void innerOnFailure(Exception e) {
-                                // we opened a connection and successfully performed a low-level handshake, so we were definitely
-                                // talking to an Elasticsearch node, but the high-level handshake failed indicating some kind of
-                                // mismatched configurations (e.g. cluster name) that the user should address
-                                logger.warn(new ParameterizedMessage("handshake failed for [{}]", thisConnectionAttempt), e);
+                        @Override
+                        protected void innerOnResponse(DiscoveryNode remoteNode) {
+                            try {
+                                // success means (amongst other things) that the cluster names match
+                                logger.trace("[{}] handshake successful: {}", transportAddress, remoteNode);
                                 IOUtils.closeWhileHandlingException(connection);
+
+                                if (remoteNode.equals(transportService.getLocalNode())) {
+                                    listener.onFailure(
+                                        new ConnectTransportException(
+                                            remoteNode,
+                                            String.format(
+                                                Locale.ROOT,
+                                                "successfully discovered local node %s at [%s]",
+                                                remoteNode.descriptionWithoutAttributes(),
+                                                transportAddress
+                                            )
+                                        )
+                                    );
+                                } else if (remoteNode.isMasterNode() == false) {
+                                    listener.onFailure(
+                                        new ConnectTransportException(
+                                            remoteNode,
+                                            String.format(
+                                                Locale.ROOT,
+                                                """
+                                                    successfully discovered master-ineligible node %s at [%s]; to suppress this message, \
+                                                    remove address [%s] from your discovery configuration or ensure that traffic to this \
+                                                    address is routed only to master-eligible nodes""",
+                                                remoteNode.descriptionWithoutAttributes(),
+                                                transportAddress,
+                                                transportAddress
+                                            )
+                                        )
+                                    );
+                                } else {
+                                    transportService.connectToNode(remoteNode, new ActionListener<>() {
+                                        @Override
+                                        public void onResponse(Releasable connectionReleasable) {
+                                            logger.trace("[{}] completed full connection with [{}]", transportAddress, remoteNode);
+                                            listener.onResponse(new ProbeConnectionResult(remoteNode, connectionReleasable));
+                                        }
+
+                                        @Override
+                                        public void onFailure(Exception e) {
+                                            // we opened a connection and successfully performed a handshake, so we're definitely
+                                            // talking to a master-eligible node with a matching cluster name and a good version, but
+                                            // the attempt to open a full connection to its publish address failed; a common reason is
+                                            // that the remote node is listening on 0.0.0.0 but has made an inappropriate choice for its
+                                            // publish address.
+                                            logger.warn(
+                                                new ParameterizedMessage(
+                                                    "completed handshake with [{}] at [{}] but followup connection to [{}] failed",
+                                                    transportAddress,
+                                                    remoteNode.descriptionWithoutAttributes(),
+                                                    remoteNode.getAddress()
+                                                ),
+                                                e
+                                            );
+                                            listener.onFailure(e);
+                                        }
+                                    });
+                                }
+                            } catch (Exception e) {
                                 listener.onFailure(e);
                             }
+                        }
 
-                        });
+                        @Override
+                        protected void innerOnFailure(Exception e) {
+                            // we opened a connection and successfully performed a low-level handshake, so we were definitely
+                            // talking to an Elasticsearch node, but the high-level handshake failed indicating some kind of
+                            // mismatched configurations (e.g. cluster name) that the user should address
+                            logger.warn(new ParameterizedMessage("handshake to [{}] failed", transportAddress), e);
+                            IOUtils.closeWhileHandlingException(connection);
+                            listener.onFailure(e);
+                        }
 
-                    })
-                );
+                    });
 
-            }
+                })
+            );
 
-            @Override
-            public String toString() {
-                return "connectToRemoteMasterNode[" + transportAddress + "]";
-            }
-        });
+        } catch (Exception e) {
+            listener.onFailure(e);
+        }
     }
 }

--- a/server/src/test/java/org/elasticsearch/discovery/HandshakingTransportAddressConnectorTests.java
+++ b/server/src/test/java/org/elasticsearch/discovery/HandshakingTransportAddressConnectorTests.java
@@ -166,7 +166,7 @@ public class HandshakingTransportAddressConnectorTests extends ESTestCase {
                 "message",
                 HandshakingTransportAddressConnector.class.getCanonicalName(),
                 Level.WARN,
-                "*completed handshake with [*] but followup connection failed*"
+                "*completed handshake with [*] at [*] but followup connection to [*] failed*"
             )
         );
         Logger targetLogger = LogManager.getLogger(HandshakingTransportAddressConnector.class);

--- a/server/src/test/java/org/elasticsearch/discovery/HandshakingTransportAddressConnectorTests.java
+++ b/server/src/test/java/org/elasticsearch/discovery/HandshakingTransportAddressConnectorTests.java
@@ -167,13 +167,13 @@ public class HandshakingTransportAddressConnectorTests extends ESTestCase {
                 "message",
                 HandshakingTransportAddressConnector.class.getCanonicalName(),
                 Level.WARN,
-                "*completed handshake with ["
+                "completed handshake with ["
                     + remoteNode.descriptionWithoutAttributes()
                     + "] at ["
                     + discoveryAddress
                     + "] but followup connection to ["
                     + remoteNodeAddress
-                    + "] failed*"
+                    + "] failed"
             )
         );
         Logger targetLogger = LogManager.getLogger(HandshakingTransportAddressConnector.class);

--- a/server/src/test/java/org/elasticsearch/discovery/HandshakingTransportAddressConnectorTests.java
+++ b/server/src/test/java/org/elasticsearch/discovery/HandshakingTransportAddressConnectorTests.java
@@ -151,7 +151,8 @@ public class HandshakingTransportAddressConnectorTests extends ESTestCase {
     @TestLogging(reason = "ensure logging happens", value = "org.elasticsearch.discovery.HandshakingTransportAddressConnector:INFO")
     public void testLogsFullConnectionFailureAfterSuccessfulHandshake() throws Exception {
 
-        remoteNode = new DiscoveryNode("remote-node", buildNewFakeTransportAddress(), Version.CURRENT);
+        final var remoteNodeAddress = buildNewFakeTransportAddress();
+        remoteNode = new DiscoveryNode("remote-node", remoteNodeAddress, Version.CURRENT);
         remoteClusterName = "local-cluster";
         discoveryAddress = buildNewFakeTransportAddress();
 
@@ -166,7 +167,13 @@ public class HandshakingTransportAddressConnectorTests extends ESTestCase {
                 "message",
                 HandshakingTransportAddressConnector.class.getCanonicalName(),
                 Level.WARN,
-                "*completed handshake with [*] at [*] but followup connection to [*] failed*"
+                "*completed handshake with ["
+                    + remoteNode.descriptionWithoutAttributes()
+                    + "] at ["
+                    + discoveryAddress
+                    + "] but followup connection to ["
+                    + remoteNodeAddress
+                    + "] failed*"
             )
         );
         Logger targetLogger = LogManager.getLogger(HandshakingTransportAddressConnector.class);


### PR DESCRIPTION
Connecting to a node was originally a blocking operation so
`HandshakingTransportAddressConnector` had to fork the connection
attempt to a new thread. Opening a connection is now fully async so the
fork is now unnecessary. With this commit we remove it.