### PR TITLE
[7.17] Make sure the random generated shape can be indexed in GeoTilerTests (#84986)

### DIFF
--- a/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/search/aggregations/bucket/geogrid/GeoGridTilerTestCase.java
+++ b/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/search/aggregations/bucket/geogrid/GeoGridTilerTestCase.java
@@ -105,7 +105,7 @@ public abstract class GeoGridTilerTestCase extends ESTestCase {
             GeoShapeIndexer indexer = new GeoShapeIndexer(true, "test");
             Geometry geometry = indexer.prepareForIndexing(randomValueOtherThanMany(g -> {
                 try {
-                    indexer.prepareForIndexing(g);
+                    indexer.indexShape(indexer.prepareForIndexing(g));
                     return false;
                 } catch (Exception e) {
                     return true;


### PR DESCRIPTION
Backports the following commits to 7.17:
 - Make sure the random generated shape can be indexed in GeoTilerTests (#84986)