### PR TITLE
Issue #50932 PKCS#12 format

### DIFF
--- a/docs/changelog/85119.yaml
+++ b/docs/changelog/85119.yaml
@@ -1,0 +1,5 @@
+pr: 85119
+summary: Change the format of Kibana certificate to PKCS#12
+area: Security
+type: enhancement, TLS
+issues: []

--- a/x-pack/plugin/security/cli/src/main/java/org/elasticsearch/xpack/security/cli/HttpCertificateCommand.java
+++ b/x-pack/plugin/security/cli/src/main/java/org/elasticsearch/xpack/security/cli/HttpCertificateCommand.java
@@ -427,8 +427,6 @@ class HttpCertificateCommand extends EnvironmentAwareCommand {
         try {
             writeTextFile(zip, dirName + "/README.txt", KIBANA_README, substitutions);
             if (ca != null) {
-                //writePemEntry(zip, dirName + "/" + caCert, new JcaMiscPEMGenerator(ca.certAndKey.cert));
-
                 final KeyStore pkcs12 = KeyStore.getInstance("PKCS12");
                 pkcs12.load(null);
                 pkcs12.setKeyEntry("elasticsearch-ca", ca.certAndKey.key, ca.password, new Certificate[] { ca.certAndKey.cert });

--- a/x-pack/plugin/security/cli/src/main/java/org/elasticsearch/xpack/security/cli/HttpCertificateCommand.java
+++ b/x-pack/plugin/security/cli/src/main/java/org/elasticsearch/xpack/security/cli/HttpCertificateCommand.java
@@ -413,7 +413,7 @@ class HttpCertificateCommand extends EnvironmentAwareCommand {
     }
 
     private void writeKibanaInfo(ZipOutputStream zip, String dirName, CertificateTool.CAInfo ca, Environment env) {
-        final String caCertName = "elasticsearch-ca.pem";
+        final String caCertName = "elasticsearch-ca.p12";
         final String caCert = ca == null ? "" : caCertName;
         final String ymlFile = "sample-kibana.yml";
 
@@ -427,10 +427,18 @@ class HttpCertificateCommand extends EnvironmentAwareCommand {
         try {
             writeTextFile(zip, dirName + "/README.txt", KIBANA_README, substitutions);
             if (ca != null) {
-                writePemEntry(zip, dirName + "/" + caCert, new JcaMiscPEMGenerator(ca.certAndKey.cert));
+                //writePemEntry(zip, dirName + "/" + caCert, new JcaMiscPEMGenerator(ca.certAndKey.cert));
+
+                final KeyStore pkcs12 = KeyStore.getInstance("PKCS12");
+                pkcs12.load(null);
+                pkcs12.setKeyEntry("elasticsearch-ca", ca.certAndKey.key, ca.password, new Certificate[] { ca.certAndKey.cert });
+                try (ZipEntryStream entry = new ZipEntryStream(zip, dirName + "/elasticsearch-ca.p12")) {
+                    pkcs12.store(entry, ca.password);
+                }
+
             }
             writeTextFile(zip, dirName + "/" + ymlFile, KIBANA_YML, substitutions);
-        } catch (IOException e) {
+        } catch (KeyStoreException | IOException | CertificateException | NoSuchAlgorithmException e) {
             throw new ElasticsearchException("Failed to write Kibana details ZIP file", e);
         }
     }


### PR DESCRIPTION
# This document gives the technical details of our contribution to the issue  \#50932

## Summary of issue \#50932

The purpose of this [issue \#50932](https://github.com/elastic/elasticsearch/issues/50932)
is to change the format of the Kibana certificate from PEM to PKCS12.

1- [HttpCommand_certificate](https://github.com/elastic/elasticsearch/blob/814f7f9f52cb8c05db6465b9bfc818ea5d76c575/x-pack/plugin/security/cli/src/main/java/org/elasticsearch/xpack/security/cli/HttpCertificateCommand.java#L415)

# Details
## Code
In order to change the format of the certificate we changed this [file]
(https://github.com/elastic/elasticsearch/blob/814f7f9f52cb8c05db6465b9bfc818ea5d76c575/x-pack/plugin/security/cli/src/main/java/org/elasticsearch/xpack/security/cli/HttpCertificateCommand.java#L415)

We modified the function writeKibanaInfo() by adding this part : 

```java 
try {
            writeTextFile(zip, dirName + "/README.txt", KIBANA_README, substitutions);
            if (ca != null) {
                final KeyStore pkcs12 = KeyStore.getInstance("PKCS12");
                pkcs12.load(null);
                pkcs12.setKeyEntry("elasticsearch-ca", ca.certAndKey.key, ca.password, new Certificate[] { ca.certAndKey.cert });
                try (ZipEntryStream entry = new ZipEntryStream(zip, dirName + "/elasticsearch-ca.p12")) {
                    pkcs12.store(entry, ca.password);
                }

            }
            writeTextFile(zip, dirName + "/" + ymlFile, KIBANA_YML, substitutions);
        } catch (KeyStoreException | IOException | CertificateException | NoSuchAlgorithmException e) {
            throw new ElasticsearchException("Failed to write Kibana details ZIP file", e);
        }
```

Now when the certificate of Kibana is generated it's automatically stored 
in PKCS#12 format instead of PEM


## Choices made in order to improve the security of the project
PKCS 12 is a format which allows to store the Key and the certificate in 
the same file in order to make it more pratical to manipulate.
