### PR TITLE
Move DotExpandingXContentParser to server

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/mapper/DocumentParser.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/DocumentParser.java
@@ -23,7 +23,6 @@ import org.elasticsearch.index.fielddata.IndexFieldDataCache;
 import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.indices.breaker.NoneCircuitBreakerService;
 import org.elasticsearch.search.lookup.SearchLookup;
-import org.elasticsearch.xcontent.DotExpandingXContentParser;
 import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xcontent.XContentParser;
 import org.elasticsearch.xcontent.XContentParserConfiguration;

--- a/server/src/main/java/org/elasticsearch/index/mapper/DocumentParserContext.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/DocumentParserContext.java
@@ -12,7 +12,6 @@ import org.apache.lucene.document.Field;
 import org.elasticsearch.common.time.DateFormatter;
 import org.elasticsearch.index.IndexSettings;
 import org.elasticsearch.index.analysis.IndexAnalyzers;
-import org.elasticsearch.xcontent.DotExpandingXContentParser;
 import org.elasticsearch.xcontent.FilterXContentParserWrapper;
 import org.elasticsearch.xcontent.XContentParser;
 

--- a/server/src/main/java/org/elasticsearch/index/mapper/DotExpandingXContentParser.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/DotExpandingXContentParser.java
@@ -6,9 +6,14 @@
  * Side Public License, v 1.
  */
 
-package org.elasticsearch.xcontent;
+package org.elasticsearch.index.mapper;
 
 import org.elasticsearch.core.CheckedFunction;
+import org.elasticsearch.xcontent.FilterXContentParser;
+import org.elasticsearch.xcontent.FilterXContentParserWrapper;
+import org.elasticsearch.xcontent.XContentLocation;
+import org.elasticsearch.xcontent.XContentParser;
+import org.elasticsearch.xcontent.XContentSubParser;
 
 import java.io.IOException;
 import java.util.ArrayDeque;
@@ -26,7 +31,7 @@ import java.util.function.Supplier;
  * lookups will return the same mapper/field type, and we never load incoming documents in a map where duplicate
  * keys would end up overriding each other.
  */
-public class DotExpandingXContentParser extends FilterXContentParserWrapper {
+class DotExpandingXContentParser extends FilterXContentParserWrapper {
 
     private static final class WrappingParser extends FilterXContentParser {
 
@@ -146,7 +151,7 @@ public class DotExpandingXContentParser extends FilterXContentParserWrapper {
      * @param in    the parser to wrap
      * @return  the wrapped XContentParser
      */
-    public static XContentParser expandDots(XContentParser in) throws IOException {
+    static XContentParser expandDots(XContentParser in) throws IOException {
         return new WrappingParser(in);
     }
 

--- a/server/src/test/java/org/elasticsearch/index/mapper/DotExpandingXContentParserTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/DotExpandingXContentParserTests.java
@@ -6,10 +6,13 @@
  * Side Public License, v 1.
  */
 
-package org.elasticsearch.xcontent;
+package org.elasticsearch.index.mapper;
 
 import org.elasticsearch.common.Strings;
+import org.elasticsearch.index.mapper.DotExpandingXContentParser;
 import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xcontent.XContentBuilder;
+import org.elasticsearch.xcontent.XContentParser;
 import org.elasticsearch.xcontent.json.JsonXContent;
 
 import java.io.IOException;

--- a/server/src/test/java/org/elasticsearch/index/mapper/DotExpandingXContentParserTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/DotExpandingXContentParserTests.java
@@ -9,7 +9,6 @@
 package org.elasticsearch.index.mapper;
 
 import org.elasticsearch.common.Strings;
-import org.elasticsearch.index.mapper.DotExpandingXContentParser;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xcontent.XContentParser;


### PR DESCRIPTION
DotExpandingXContentParser is a parser that's very specific to document parsing, based on the assumption
that what gets parsed is never loaded into a map as it can expose duplicate keys. That means that we want
to make sure it does not get misused in other scenarios, hence this commit moves it out of the xcontent
library into server as a package private class.