### PR TITLE
[DOCS] Remove licensing note from Watcher docs

### DIFF
--- a/x-pack/docs/en/watcher/getting-started.asciidoc
+++ b/x-pack/docs/en/watcher/getting-started.asciidoc
@@ -2,11 +2,6 @@
 [[watcher-getting-started]]
 == Getting started with {watcher}
 
-TIP: To complete these steps, you must obtain a license that includes the
-{alert-features}. For more information about Elastic license levels, see 
-https://www.elastic.co/subscriptions and
-{kibana-ref}/managing-licenses.html[License management].
-
 [[watch-log-data]]
 To set up a watch to start sending alerts:
 


### PR DESCRIPTION
Removes a licensing note from the Watcher docs.

The ES docs generally don't reference licensing information for individual features. Instead, users should go to https://www.elastic.co/subscriptions as the single source of truth.

Relates to https://github.com/elastic/elasticsearch/pull/84642