### PR TITLE
Remove Restricted String Mapping Param

### DIFF
--- a/modules/mapper-extras/src/main/java/org/elasticsearch/index/mapper/extras/SearchAsYouTypeFieldMapper.java
+++ b/modules/mapper-extras/src/main/java/org/elasticsearch/index/mapper/extras/SearchAsYouTypeFieldMapper.java
@@ -135,7 +135,7 @@ public class SearchAsYouTypeFieldMapper extends FieldMapper {
         final TextParams.Analyzers analyzers;
         final Parameter<SimilarityProvider> similarity = TextParams.similarity(m -> builder(m).similarity.get());
 
-        final Parameter<String> indexOptions = TextParams.indexOptionsWithPositionsAndOffsets(m -> builder(m).indexOptions.get());
+        final Parameter<String> indexOptions = TextParams.textIndexOptions(m -> builder(m).indexOptions.get());
         final Parameter<Boolean> norms = TextParams.norms(true, m -> builder(m).norms.get());
         final Parameter<String> termVectors = TextParams.termVectors(m -> builder(m).termVectors.get());
 

--- a/modules/mapper-extras/src/main/java/org/elasticsearch/index/mapper/extras/SearchAsYouTypeFieldMapper.java
+++ b/modules/mapper-extras/src/main/java/org/elasticsearch/index/mapper/extras/SearchAsYouTypeFieldMapper.java
@@ -135,7 +135,7 @@ public class SearchAsYouTypeFieldMapper extends FieldMapper {
         final TextParams.Analyzers analyzers;
         final Parameter<SimilarityProvider> similarity = TextParams.similarity(m -> builder(m).similarity.get());
 
-        final Parameter<String> indexOptions = TextParams.indexOptions(m -> builder(m).indexOptions.get());
+        final Parameter<String> indexOptions = TextParams.indexOptionsWithPositionsAndOffsets(m -> builder(m).indexOptions.get());
         final Parameter<Boolean> norms = TextParams.norms(true, m -> builder(m).norms.get());
         final Parameter<String> termVectors = TextParams.termVectors(m -> builder(m).termVectors.get());
 

--- a/plugins/analysis-icu/src/main/java/org/elasticsearch/plugin/analysis/icu/ICUCollationKeywordFieldMapper.java
+++ b/plugins/analysis-icu/src/main/java/org/elasticsearch/plugin/analysis/icu/ICUCollationKeywordFieldMapper.java
@@ -224,13 +224,7 @@ public class ICUCollationKeywordFieldMapper extends FieldMapper {
         final Parameter<Boolean> hasDocValues = Parameter.docValuesParam(m -> toType(m).hasDocValues, true);
         final Parameter<Boolean> stored = Parameter.storeParam(m -> toType(m).fieldType.stored(), false);
 
-        final Parameter<String> indexOptions = Parameter.restrictedStringParam(
-            "index_options",
-            false,
-            m -> toType(m).indexOptions,
-            "docs",
-            "freqs"
-        );
+        final Parameter<String> indexOptions = TextParams.indexOptions(m -> toType(m).indexOptions);
         final Parameter<Boolean> hasNorms = TextParams.norms(false, m -> toType(m).fieldType.omitNorms() == false);
 
         final Parameter<Map<String, String>> meta = Parameter.metaParam();

--- a/plugins/analysis-icu/src/main/java/org/elasticsearch/plugin/analysis/icu/ICUCollationKeywordFieldMapper.java
+++ b/plugins/analysis-icu/src/main/java/org/elasticsearch/plugin/analysis/icu/ICUCollationKeywordFieldMapper.java
@@ -224,7 +224,7 @@ public class ICUCollationKeywordFieldMapper extends FieldMapper {
         final Parameter<Boolean> hasDocValues = Parameter.docValuesParam(m -> toType(m).hasDocValues, true);
         final Parameter<Boolean> stored = Parameter.storeParam(m -> toType(m).fieldType.stored(), false);
 
-        final Parameter<String> indexOptions = TextParams.indexOptions(m -> toType(m).indexOptions);
+        final Parameter<String> indexOptions = TextParams.keywordIndexOptions(m -> toType(m).indexOptions);
         final Parameter<Boolean> hasNorms = TextParams.norms(false, m -> toType(m).fieldType.omitNorms() == false);
 
         final Parameter<Map<String, String>> meta = Parameter.metaParam();

--- a/plugins/mapper-annotated-text/src/main/java/org/elasticsearch/index/mapper/annotatedtext/AnnotatedTextFieldMapper.java
+++ b/plugins/mapper-annotated-text/src/main/java/org/elasticsearch/index/mapper/annotatedtext/AnnotatedTextFieldMapper.java
@@ -80,7 +80,7 @@ public class AnnotatedTextFieldMapper extends FieldMapper {
         final TextParams.Analyzers analyzers;
         final Parameter<SimilarityProvider> similarity = TextParams.similarity(m -> builder(m).similarity.getValue());
 
-        final Parameter<String> indexOptions = TextParams.indexOptions(m -> builder(m).indexOptions.getValue());
+        final Parameter<String> indexOptions = TextParams.indexOptionsWithPositionsAndOffsets(m -> builder(m).indexOptions.getValue());
         final Parameter<Boolean> norms = TextParams.norms(true, m -> builder(m).norms.getValue());
         final Parameter<String> termVectors = TextParams.termVectors(m -> builder(m).termVectors.getValue());
 

--- a/plugins/mapper-annotated-text/src/main/java/org/elasticsearch/index/mapper/annotatedtext/AnnotatedTextFieldMapper.java
+++ b/plugins/mapper-annotated-text/src/main/java/org/elasticsearch/index/mapper/annotatedtext/AnnotatedTextFieldMapper.java
@@ -80,7 +80,7 @@ public class AnnotatedTextFieldMapper extends FieldMapper {
         final TextParams.Analyzers analyzers;
         final Parameter<SimilarityProvider> similarity = TextParams.similarity(m -> builder(m).similarity.getValue());
 
-        final Parameter<String> indexOptions = TextParams.indexOptionsWithPositionsAndOffsets(m -> builder(m).indexOptions.getValue());
+        final Parameter<String> indexOptions = TextParams.textIndexOptions(m -> builder(m).indexOptions.getValue());
         final Parameter<Boolean> norms = TextParams.norms(true, m -> builder(m).norms.getValue());
         final Parameter<String> termVectors = TextParams.termVectors(m -> builder(m).termVectors.getValue());
 

--- a/server/src/main/java/org/elasticsearch/index/mapper/FieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/FieldMapper.java
@@ -35,7 +35,6 @@ import java.util.Comparator;
 import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.Iterator;
-import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -864,7 +863,7 @@ public abstract class FieldMapper extends Mapper implements Cloneable {
             return new Parameter<>(
                 name,
                 updateable,
-                () -> defaultValue,
+                defaultValue ? () -> true : () -> false,
                 (n, c, o) -> XContentMapValues.nodeBooleanValue(o),
                 initializer,
                 XContentBuilder::field,
@@ -947,7 +946,7 @@ public abstract class FieldMapper extends Mapper implements Cloneable {
             return new Parameter<>(
                 name,
                 updateable,
-                () -> defaultValue,
+                defaultValue == null ? () -> null : () -> defaultValue,
                 (n, c, o) -> XContentMapValues.nodeStringValue(o),
                 initializer,
                 serializer,
@@ -959,10 +958,9 @@ public abstract class FieldMapper extends Mapper implements Cloneable {
         public static Parameter<List<String>> stringArrayParam(
             String name,
             boolean updateable,
-            Function<FieldMapper, List<String>> initializer,
-            List<String> defaultValue
+            Function<FieldMapper, List<String>> initializer
         ) {
-            return new Parameter<>(name, updateable, () -> defaultValue, (n, c, o) -> {
+            return new Parameter<>(name, updateable, List::of, (n, c, o) -> {
                 List<Object> values = (List<Object>) o;
                 List<String> strValues = new ArrayList<>();
                 for (Object item : values) {
@@ -970,32 +968,6 @@ public abstract class FieldMapper extends Mapper implements Cloneable {
                 }
                 return strValues;
             }, initializer, XContentBuilder::stringListField, Objects::toString);
-        }
-
-        /**
-         * Defines a parameter that takes one of a restricted set of string values
-         * @param name          the parameter name
-         * @param updateable    whether the parameter can be changed by a mapping update
-         * @param initializer   a function that reads the parameter value from an existing mapper
-         * @param values        the set of values that the parameter can take.  The first value in the list
-         *                      is the default value, to be used if the parameter is undefined in a mapping
-         */
-        public static Parameter<String> restrictedStringParam(
-            String name,
-            boolean updateable,
-            Function<FieldMapper, String> initializer,
-            String... values
-        ) {
-            assert values.length > 0;
-            Set<String> acceptedValues = new LinkedHashSet<>(Arrays.asList(values));
-            return stringParam(name, updateable, initializer, values[0]).addValidator(v -> {
-                if (acceptedValues.contains(v)) {
-                    return;
-                }
-                throw new MapperParsingException(
-                    "Unknown value [" + v + "] for field [" + name + "] - accepted values are " + acceptedValues.toString()
-                );
-            });
         }
 
         /**
@@ -1133,8 +1105,25 @@ public abstract class FieldMapper extends Mapper implements Cloneable {
             Function<FieldMapper, String> initializer,
             Parameter<Script> dependentScriptParam
         ) {
-            return Parameter.restrictedStringParam("on_script_error", true, initializer, "fail", "continue")
-                .requiresParameters(dependentScriptParam);
+            return new Parameter<>(
+                "on_script_error",
+                true,
+                () -> "fail",
+                (n, c, o) -> XContentMapValues.nodeStringValue(o),
+                initializer,
+                XContentBuilder::field,
+                Function.identity()
+            ).addValidator(v -> {
+                switch (v) {
+                    case "fail":
+                    case "continue":
+                        return;
+                    default:
+                        throw new MapperParsingException(
+                            "Unknown value [" + v + "] for field [on_script_error] - accepted values are [fail,continue]"
+                        );
+                }
+            }).requiresParameters(dependentScriptParam);
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/index/mapper/FieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/FieldMapper.java
@@ -1120,7 +1120,7 @@ public abstract class FieldMapper extends Mapper implements Cloneable {
                         return;
                     default:
                         throw new MapperParsingException(
-                            "Unknown value [" + v + "] for field [on_script_error] - accepted values are [fail,continue]"
+                            "Unknown value [" + v + "] for field [on_script_error] - accepted values are [fail, continue]"
                         );
                 }
             }).requiresParameters(dependentScriptParam);

--- a/server/src/main/java/org/elasticsearch/index/mapper/KeywordFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/KeywordFieldMapper.java
@@ -127,7 +127,7 @@ public final class KeywordFieldMapper extends FieldMapper {
             Defaults.IGNORE_ABOVE
         );
 
-        private final Parameter<String> indexOptions = TextParams.indexOptions(m -> toType(m).indexOptions);
+        private final Parameter<String> indexOptions = TextParams.keywordIndexOptions(m -> toType(m).indexOptions);
         private final Parameter<Boolean> hasNorms = TextParams.norms(false, m -> toType(m).fieldType.omitNorms() == false);
         private final Parameter<SimilarityProvider> similarity = TextParams.similarity(m -> toType(m).similarity);
 

--- a/server/src/main/java/org/elasticsearch/index/mapper/KeywordFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/KeywordFieldMapper.java
@@ -127,13 +127,7 @@ public final class KeywordFieldMapper extends FieldMapper {
             Defaults.IGNORE_ABOVE
         );
 
-        private final Parameter<String> indexOptions = Parameter.restrictedStringParam(
-            "index_options",
-            false,
-            m -> toType(m).indexOptions,
-            "docs",
-            "freqs"
-        );
+        private final Parameter<String> indexOptions = TextParams.indexOptions(m -> toType(m).indexOptions);
         private final Parameter<Boolean> hasNorms = TextParams.norms(false, m -> toType(m).fieldType.omitNorms() == false);
         private final Parameter<SimilarityProvider> similarity = TextParams.similarity(m -> toType(m).similarity);
 

--- a/server/src/main/java/org/elasticsearch/index/mapper/SourceFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/SourceFieldMapper.java
@@ -63,14 +63,12 @@ public class SourceFieldMapper extends MetadataFieldMapper {
         private final Parameter<List<String>> includes = Parameter.stringArrayParam(
             "includes",
             false,
-            m -> Arrays.asList(toType(m).includes),
-            Collections.emptyList()
+            m -> Arrays.asList(toType(m).includes)
         );
         private final Parameter<List<String>> excludes = Parameter.stringArrayParam(
             "excludes",
             false,
-            m -> Arrays.asList(toType(m).excludes),
-            Collections.emptyList()
+            m -> Arrays.asList(toType(m).excludes)
         );
 
         public Builder() {

--- a/server/src/main/java/org/elasticsearch/index/mapper/TextFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/TextFieldMapper.java
@@ -232,7 +232,7 @@ public class TextFieldMapper extends FieldMapper {
 
         final Parameter<SimilarityProvider> similarity = TextParams.similarity(m -> ((TextFieldMapper) m).similarity);
 
-        final Parameter<String> indexOptions = TextParams.indexOptionsWithPositionsAndOffsets(m -> ((TextFieldMapper) m).indexOptions);
+        final Parameter<String> indexOptions = TextParams.textIndexOptions(m -> ((TextFieldMapper) m).indexOptions);
         final Parameter<Boolean> norms = TextParams.norms(true, m -> ((TextFieldMapper) m).norms);
         final Parameter<String> termVectors = TextParams.termVectors(m -> ((TextFieldMapper) m).termVectors);
 

--- a/server/src/main/java/org/elasticsearch/index/mapper/TextFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/TextFieldMapper.java
@@ -232,7 +232,7 @@ public class TextFieldMapper extends FieldMapper {
 
         final Parameter<SimilarityProvider> similarity = TextParams.similarity(m -> ((TextFieldMapper) m).similarity);
 
-        final Parameter<String> indexOptions = TextParams.indexOptions(m -> ((TextFieldMapper) m).indexOptions);
+        final Parameter<String> indexOptions = TextParams.indexOptionsWithPositionsAndOffsets(m -> ((TextFieldMapper) m).indexOptions);
         final Parameter<Boolean> norms = TextParams.norms(true, m -> ((TextFieldMapper) m).norms);
         final Parameter<String> termVectors = TextParams.termVectors(m -> ((TextFieldMapper) m).termVectors);
 

--- a/server/src/main/java/org/elasticsearch/index/mapper/TextParams.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/TextParams.java
@@ -128,7 +128,7 @@ public final class TextParams {
         ).acceptsNull();
     }
 
-    public static Parameter<String> indexOptions(Function<FieldMapper, String> initializer) {
+    public static Parameter<String> keywordIndexOptions(Function<FieldMapper, String> initializer) {
         return Parameter.stringParam("index_options", false, initializer, "docs").addValidator(v -> {
             switch (v) {
                 case "docs":
@@ -142,7 +142,7 @@ public final class TextParams {
         });
     }
 
-    public static Parameter<String> indexOptionsWithPositionsAndOffsets(Function<FieldMapper, String> initializer) {
+    public static Parameter<String> textIndexOptions(Function<FieldMapper, String> initializer) {
         return Parameter.stringParam("index_options", false, initializer, "positions").addValidator(v -> {
             switch (v) {
                 case "positions":

--- a/server/src/main/java/org/elasticsearch/index/mapper/TextParams.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/TextParams.java
@@ -129,7 +129,33 @@ public final class TextParams {
     }
 
     public static Parameter<String> indexOptions(Function<FieldMapper, String> initializer) {
-        return Parameter.restrictedStringParam("index_options", false, initializer, "positions", "docs", "freqs", "offsets");
+        return Parameter.stringParam("index_options", false, initializer, "docs").addValidator(v -> {
+            switch (v) {
+                case "docs":
+                case "freqs":
+                    return;
+                default:
+                    throw new MapperParsingException(
+                        "Unknown value [" + v + "] for field [index_options] - accepted values are [docs, freqs]"
+                    );
+            }
+        });
+    }
+
+    public static Parameter<String> indexOptionsWithPositionsAndOffsets(Function<FieldMapper, String> initializer) {
+        return Parameter.stringParam("index_options", false, initializer, "positions").addValidator(v -> {
+            switch (v) {
+                case "positions":
+                case "docs":
+                case "freqs":
+                case "offsets":
+                    return;
+                default:
+                    throw new MapperParsingException(
+                        "Unknown value [" + v + "] for field [index_options] - accepted values are [positions, docs, freqs, offsets]"
+                    );
+            }
+        });
     }
 
     public static FieldType buildFieldType(
@@ -166,18 +192,25 @@ public final class TextParams {
     }
 
     public static Parameter<String> termVectors(Function<FieldMapper, String> initializer) {
-        return Parameter.restrictedStringParam(
-            "term_vector",
-            false,
-            initializer,
-            "no",
-            "yes",
-            "with_positions",
-            "with_offsets",
-            "with_positions_offsets",
-            "with_positions_payloads",
-            "with_positions_offsets_payloads"
-        );
+        return Parameter.stringParam("term_vector", false, initializer, "no").addValidator(v -> {
+            switch (v) {
+                case "no":
+                case "yes":
+                case "with_positions":
+                case "with_offsets":
+                case "with_positions_offsets":
+                case "with_positions_payloads":
+                case "with_positions_offsets_payloads":
+                    return;
+                default:
+                    throw new MapperParsingException(
+                        "Unknown value ["
+                            + v
+                            + "] for field [term_vector] - accepted values are [no, yes, with_positions, with_offsets, "
+                            + "with_positions_offsets, with_positions_payloads, with_positions_offsets_payloads]"
+                    );
+            }
+        });
     }
 
     public static void setTermVectorParams(String configuration, FieldType fieldType) {

--- a/server/src/main/java/org/elasticsearch/index/mapper/flattened/FlattenedFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/flattened/FlattenedFieldMapper.java
@@ -144,13 +144,7 @@ public final class FlattenedFieldMapper extends FieldMapper {
             Integer.MAX_VALUE
         );
 
-        private final Parameter<String> indexOptions = Parameter.restrictedStringParam(
-            "index_options",
-            false,
-            m -> builder(m).indexOptions.get(),
-            "docs",
-            "freqs"
-        );
+        private final Parameter<String> indexOptions = TextParams.indexOptions(m -> builder(m).indexOptions.get());
         private final Parameter<SimilarityProvider> similarity = TextParams.similarity(m -> builder(m).similarity.get());
 
         private final Parameter<Boolean> splitQueriesOnWhitespace = Parameter.boolParam(

--- a/server/src/main/java/org/elasticsearch/index/mapper/flattened/FlattenedFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/flattened/FlattenedFieldMapper.java
@@ -144,7 +144,7 @@ public final class FlattenedFieldMapper extends FieldMapper {
             Integer.MAX_VALUE
         );
 
-        private final Parameter<String> indexOptions = TextParams.indexOptions(m -> builder(m).indexOptions.get());
+        private final Parameter<String> indexOptions = TextParams.keywordIndexOptions(m -> builder(m).indexOptions.get());
         private final Parameter<SimilarityProvider> similarity = TextParams.similarity(m -> builder(m).similarity.get());
 
         private final Parameter<Boolean> splitQueriesOnWhitespace = Parameter.boolParam(

--- a/server/src/test/java/org/elasticsearch/index/mapper/ParametrizedMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/ParametrizedMapperTests.java
@@ -123,8 +123,6 @@ public class ParametrizedMapperTests extends MapperServiceTestCase {
                 throw new IllegalArgumentException("field [required] must be specified");
             }
         });
-        final Parameter<String> restricted = Parameter.restrictedStringParam("restricted", true, m -> toType(m).restricted, "foo", "bar");
-
         final Parameter<DummyEnumType> enumField = Parameter.enumParam(
             "enum_field",
             true,
@@ -162,7 +160,6 @@ public class ParametrizedMapperTests extends MapperServiceTestCase {
                 analyzer,
                 searchAnalyzer,
                 required,
-                restricted,
                 enumField,
                 restrictedEnumField
             );
@@ -196,7 +193,6 @@ public class ParametrizedMapperTests extends MapperServiceTestCase {
         private final NamedAnalyzer searchAnalyzer;
         private final boolean index;
         private final String required;
-        private final String restricted;
         private final DummyEnumType enumField;
         private final DummyEnumType restrictedEnumField;
 
@@ -217,7 +213,6 @@ public class ParametrizedMapperTests extends MapperServiceTestCase {
             this.searchAnalyzer = builder.searchAnalyzer.getValue();
             this.index = builder.index.getValue();
             this.required = builder.required.getValue();
-            this.restricted = builder.restricted.getValue();
             this.enumField = builder.enumField.getValue();
             this.restrictedEnumField = builder.restrictedEnumField.getValue();
         }
@@ -322,7 +317,6 @@ public class ParametrizedMapperTests extends MapperServiceTestCase {
                 "int_value": 5,
                 "analyzer": "_keyword",
                 "required": "value",
-                "restricted": "foo",
                 "enum_field": "name1",
                 "restricted_enum_field": "name1"
               }
@@ -615,7 +609,6 @@ public class ParametrizedMapperTests extends MapperServiceTestCase {
                 "int_value": 5,
                 "analyzer": "default",
                 "required": "value",
-                "restricted": "foo",
                 "enum_field": "name1",
                 "restricted_enum_field": "name1"
               }
@@ -633,27 +626,6 @@ public class ParametrizedMapperTests extends MapperServiceTestCase {
                 {"type":"test_mapper","required":null}""";
             MapperParsingException exc = expectThrows(MapperParsingException.class, () -> fromMapping(mapping));
             assertEquals("[required] on mapper [field] of type [test_mapper] must not have a [null] value", exc.getMessage());
-        }
-    }
-
-    public void testRestrictedField() {
-        {
-            String mapping = """
-                {"type":"test_mapper","required":"a","restricted":"baz"}""";
-            MapperParsingException e = expectThrows(MapperParsingException.class, () -> fromMapping(mapping));
-            assertEquals("Unknown value [baz] for field [restricted] - accepted values are [foo, bar]", e.getMessage());
-        }
-        {
-            String mapping = """
-                {"type":"test_mapper","required":"a","restricted":"bar"}""";
-            TestMapper mapper = fromMapping(mapping);
-            assertEquals("bar", mapper.restricted);
-        }
-        {
-            String mapping = """
-                {"type":"test_mapper","required":"a"}""";
-            TestMapper mapper = fromMapping(mapping);
-            assertEquals("foo", mapper.restricted);
         }
     }
 


### PR DESCRIPTION
This param was incredibly expensive to set up when parsing mappings and
is one of the big contributors to mapping parsing slowness on master.
Since all uses of this parameter type are statically known it seems the most
straight forward to simply statically hard code the validators so that we save
some allocations.

relates https://github.com/elastic/elasticsearch/issues/77466
