### PR TITLE
Make FetchSource use Singletons where Possible

### DIFF
--- a/benchmarks/src/main/java/org/elasticsearch/benchmark/search/fetch/subphase/FetchSourcePhaseBenchmark.java
+++ b/benchmarks/src/main/java/org/elasticsearch/benchmark/search/fetch/subphase/FetchSourcePhaseBenchmark.java
@@ -59,7 +59,7 @@ public class FetchSourcePhaseBenchmark {
             case "one_4m_field" -> buildBigExample("huge".repeat(1024 * 1024));
             default -> throw new IllegalArgumentException("Unknown source [" + source + "]");
         };
-        fetchContext = new FetchSourceContext(
+        fetchContext = FetchSourceContext.of(
             true,
             Strings.splitStringByCommaToArray(includes),
             Strings.splitStringByCommaToArray(excludes)

--- a/server/src/internalClusterTest/java/org/elasticsearch/mget/SimpleMgetIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/mget/SimpleMgetIT.java
@@ -150,12 +150,12 @@ public class SimpleMgetIT extends ESIntegTestCase {
             if (i % 2 == 0) {
                 request.add(
                     new MultiGetRequest.Item(indexOrAlias(), Integer.toString(i)).fetchSourceContext(
-                        new FetchSourceContext(true, new String[] { "included" }, new String[] { "*.hidden_field" })
+                        FetchSourceContext.of(true, new String[] { "included" }, new String[] { "*.hidden_field" })
                     )
                 );
             } else {
                 request.add(
-                    new MultiGetRequest.Item(indexOrAlias(), Integer.toString(i)).fetchSourceContext(new FetchSourceContext(false))
+                    new MultiGetRequest.Item(indexOrAlias(), Integer.toString(i)).fetchSourceContext(FetchSourceContext.DO_NOT_FETCH_SOURCE)
                 );
             }
         }

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/fetch/subphase/InnerHitsIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/fetch/subphase/InnerHitsIT.java
@@ -509,7 +509,7 @@ public class InnerHitsIT extends ESIntegTestCase {
                         new InnerHitBuilder("remark")
                     ),
                     ScoreMode.Avg
-                ).innerHit(new InnerHitBuilder().setFetchSourceContext(new FetchSourceContext(false)))
+                ).innerHit(new InnerHitBuilder().setFetchSourceContext(FetchSourceContext.DO_NOT_FETCH_SOURCE))
             )
             .get();
         assertNoFailures(response);
@@ -610,7 +610,7 @@ public class InnerHitsIT extends ESIntegTestCase {
         SearchResponse resp1 = client().prepareSearch("articles")
             .setQuery(
                 nestedQuery("comments.messages", matchQuery("comments.messages.message", "fox"), ScoreMode.Avg).innerHit(
-                    new InnerHitBuilder().setFetchSourceContext(new FetchSourceContext(true))
+                    new InnerHitBuilder().setFetchSourceContext(FetchSourceContext.FETCH_SOURCE)
                 )
             )
             .get();
@@ -626,7 +626,7 @@ public class InnerHitsIT extends ESIntegTestCase {
         SearchResponse response = client().prepareSearch("articles")
             .setQuery(
                 nestedQuery("comments.messages", matchQuery("comments.messages.message", "fox"), ScoreMode.Avg).innerHit(
-                    new InnerHitBuilder().setFetchSourceContext(new FetchSourceContext(false))
+                    new InnerHitBuilder().setFetchSourceContext(FetchSourceContext.DO_NOT_FETCH_SOURCE)
                 )
             )
             .get();
@@ -648,7 +648,7 @@ public class InnerHitsIT extends ESIntegTestCase {
         response = client().prepareSearch("articles")
             .setQuery(
                 nestedQuery("comments.messages", matchQuery("comments.messages.message", "bear"), ScoreMode.Avg).innerHit(
-                    new InnerHitBuilder().setFetchSourceContext(new FetchSourceContext(false))
+                    new InnerHitBuilder().setFetchSourceContext(FetchSourceContext.DO_NOT_FETCH_SOURCE)
                 )
             )
             .get();
@@ -683,7 +683,7 @@ public class InnerHitsIT extends ESIntegTestCase {
         response = client().prepareSearch("articles")
             .setQuery(
                 nestedQuery("comments.messages", matchQuery("comments.messages.message", "fox"), ScoreMode.Avg).innerHit(
-                    new InnerHitBuilder().setFetchSourceContext(new FetchSourceContext(false))
+                    new InnerHitBuilder().setFetchSourceContext(FetchSourceContext.DO_NOT_FETCH_SOURCE)
                 )
             )
             .get();
@@ -851,7 +851,7 @@ public class InnerHitsIT extends ESIntegTestCase {
         SearchResponse response = client().prepareSearch()
             .setQuery(
                 nestedQuery("comments", matchQuery("comments.message", "fox"), ScoreMode.None).innerHit(
-                    new InnerHitBuilder().setFetchSourceContext(new FetchSourceContext(true, new String[] { "comments.message" }, null))
+                    new InnerHitBuilder().setFetchSourceContext(FetchSourceContext.of(true, new String[] { "comments.message" }, null))
                 )
             )
             .get();
@@ -894,7 +894,7 @@ public class InnerHitsIT extends ESIntegTestCase {
             .setQuery(
                 nestedQuery("comments", matchQuery("comments.message", "away"), ScoreMode.None).innerHit(
                     new InnerHitBuilder().setFetchSourceContext(
-                        new FetchSourceContext(true, new String[] { "comments.missing_field" }, null)
+                        FetchSourceContext.of(true, new String[] { "comments.missing_field" }, null)
                     )
                 )
             )

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/source/MetadataFetchingIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/source/MetadataFetchingIT.java
@@ -56,7 +56,7 @@ public class MetadataFetchingIT extends ESIntegTestCase {
             .setQuery(
                 new NestedQueryBuilder("nested", new TermQueryBuilder("nested.title", "foo"), ScoreMode.Total).innerHit(
                     new InnerHitBuilder().setStoredFieldNames(Collections.singletonList("_none_"))
-                        .setFetchSourceContext(new FetchSourceContext(false))
+                        .setFetchSourceContext(FetchSourceContext.DO_NOT_FETCH_SOURCE)
                 )
             )
             .get();

--- a/server/src/main/java/org/elasticsearch/action/explain/ExplainRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/explain/ExplainRequest.java
@@ -64,7 +64,7 @@ public class ExplainRequest extends SingleShardRequest<ExplainRequest> implement
         query = in.readNamedWriteable(QueryBuilder.class);
         filteringAlias = new AliasFilter(in);
         storedFields = in.readOptionalStringArray();
-        fetchSourceContext = in.readOptionalWriteable(FetchSourceContext::new);
+        fetchSourceContext = in.readOptionalWriteable(FetchSourceContext::readFrom);
         nowInMillis = in.readVLong();
     }
 

--- a/server/src/main/java/org/elasticsearch/action/explain/ExplainRequestBuilder.java
+++ b/server/src/main/java/org/elasticsearch/action/explain/ExplainRequestBuilder.java
@@ -83,7 +83,7 @@ public class ExplainRequestBuilder extends SingleShardOperationRequestBuilder<Ex
         FetchSourceContext fetchSourceContext = request.fetchSourceContext() != null
             ? request.fetchSourceContext()
             : FetchSourceContext.FETCH_SOURCE;
-        request.fetchSourceContext(new FetchSourceContext(fetch, fetchSourceContext.includes(), fetchSourceContext.excludes()));
+        request.fetchSourceContext(FetchSourceContext.of(fetch, fetchSourceContext.includes(), fetchSourceContext.excludes()));
         return this;
     }
 
@@ -112,7 +112,7 @@ public class ExplainRequestBuilder extends SingleShardOperationRequestBuilder<Ex
         FetchSourceContext fetchSourceContext = request.fetchSourceContext() != null
             ? request.fetchSourceContext()
             : FetchSourceContext.FETCH_SOURCE;
-        request.fetchSourceContext(new FetchSourceContext(fetchSourceContext.fetchSource(), includes, excludes));
+        request.fetchSourceContext(FetchSourceContext.of(fetchSourceContext.fetchSource(), includes, excludes));
         return this;
     }
 }

--- a/server/src/main/java/org/elasticsearch/action/get/GetRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/get/GetRequest.java
@@ -69,7 +69,7 @@ public class GetRequest extends SingleShardRequest<GetRequest> implements Realti
 
         this.versionType = VersionType.fromValue(in.readByte());
         this.version = in.readLong();
-        fetchSourceContext = in.readOptionalWriteable(FetchSourceContext::new);
+        fetchSourceContext = in.readOptionalWriteable(FetchSourceContext::readFrom);
     }
 
     public GetRequest() {}

--- a/server/src/main/java/org/elasticsearch/action/get/GetRequestBuilder.java
+++ b/server/src/main/java/org/elasticsearch/action/get/GetRequestBuilder.java
@@ -71,7 +71,7 @@ public class GetRequestBuilder extends SingleShardOperationRequestBuilder<GetReq
      */
     public GetRequestBuilder setFetchSource(boolean fetch) {
         FetchSourceContext context = request.fetchSourceContext() == null ? FetchSourceContext.FETCH_SOURCE : request.fetchSourceContext();
-        request.fetchSourceContext(new FetchSourceContext(fetch, context.includes(), context.excludes()));
+        request.fetchSourceContext(FetchSourceContext.of(fetch, context.includes(), context.excludes()));
         return this;
     }
 
@@ -98,7 +98,7 @@ public class GetRequestBuilder extends SingleShardOperationRequestBuilder<GetReq
      */
     public GetRequestBuilder setFetchSource(@Nullable String[] includes, @Nullable String[] excludes) {
         FetchSourceContext context = request.fetchSourceContext() == null ? FetchSourceContext.FETCH_SOURCE : request.fetchSourceContext();
-        request.fetchSourceContext(new FetchSourceContext(context.fetchSource(), includes, excludes));
+        request.fetchSourceContext(FetchSourceContext.of(context.fetchSource(), includes, excludes));
         return this;
     }
 

--- a/server/src/main/java/org/elasticsearch/action/update/UpdateRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/update/UpdateRequest.java
@@ -150,7 +150,7 @@ public class UpdateRequest extends InstanceShardOperationRequest<UpdateRequest>
         if (in.readBoolean()) {
             doc = new IndexRequest(shardId, in);
         }
-        fetchSourceContext = in.readOptionalWriteable(FetchSourceContext::new);
+        fetchSourceContext = in.readOptionalWriteable(FetchSourceContext::readFrom);
         if (in.readBoolean()) {
             upsertRequest = new IndexRequest(shardId, in);
         }
@@ -442,7 +442,7 @@ public class UpdateRequest extends InstanceShardOperationRequest<UpdateRequest>
         FetchSourceContext context = this.fetchSourceContext == null ? FetchSourceContext.FETCH_SOURCE : this.fetchSourceContext;
         String[] includes = include == null ? Strings.EMPTY_ARRAY : new String[] { include };
         String[] excludes = exclude == null ? Strings.EMPTY_ARRAY : new String[] { exclude };
-        this.fetchSourceContext = new FetchSourceContext(context.fetchSource(), includes, excludes);
+        this.fetchSourceContext = FetchSourceContext.of(context.fetchSource(), includes, excludes);
         return this;
     }
 
@@ -460,7 +460,7 @@ public class UpdateRequest extends InstanceShardOperationRequest<UpdateRequest>
      */
     public UpdateRequest fetchSource(@Nullable String[] includes, @Nullable String[] excludes) {
         FetchSourceContext context = this.fetchSourceContext == null ? FetchSourceContext.FETCH_SOURCE : this.fetchSourceContext;
-        this.fetchSourceContext = new FetchSourceContext(context.fetchSource(), includes, excludes);
+        this.fetchSourceContext = FetchSourceContext.of(context.fetchSource(), includes, excludes);
         return this;
     }
 
@@ -469,7 +469,7 @@ public class UpdateRequest extends InstanceShardOperationRequest<UpdateRequest>
      */
     public UpdateRequest fetchSource(boolean fetchSource) {
         FetchSourceContext context = this.fetchSourceContext == null ? FetchSourceContext.FETCH_SOURCE : this.fetchSourceContext;
-        this.fetchSourceContext = new FetchSourceContext(fetchSource, context.includes(), context.excludes());
+        this.fetchSourceContext = FetchSourceContext.of(fetchSource, context.includes(), context.excludes());
         return this;
     }
 

--- a/server/src/main/java/org/elasticsearch/index/query/InnerHitBuilder.java
+++ b/server/src/main/java/org/elasticsearch/index/query/InnerHitBuilder.java
@@ -177,7 +177,7 @@ public final class InnerHitBuilder implements Writeable, ToXContentObject {
                 scriptFields.add(new ScriptField(in));
             }
         }
-        fetchSourceContext = in.readOptionalWriteable(FetchSourceContext::new);
+        fetchSourceContext = in.readOptionalWriteable(FetchSourceContext::readFrom);
         if (in.readBoolean()) {
             int size = in.readVInt();
             sorts = new ArrayList<>(size);

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/TopHitsAggregationBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/TopHitsAggregationBuilder.java
@@ -85,13 +85,7 @@ public class TopHitsAggregationBuilder extends AbstractAggregationBuilder<TopHit
         this.docValueFields = clone.docValueFields == null ? null : new ArrayList<>(clone.docValueFields);
         this.fetchFields = clone.fetchFields == null ? null : new ArrayList<>(clone.fetchFields);
         this.scriptFields = clone.scriptFields == null ? null : new HashSet<>(clone.scriptFields);
-        this.fetchSourceContext = clone.fetchSourceContext == null
-            ? null
-            : new FetchSourceContext(
-                clone.fetchSourceContext.fetchSource(),
-                clone.fetchSourceContext.includes(),
-                clone.fetchSourceContext.excludes()
-            );
+        this.fetchSourceContext = clone.fetchSourceContext;
     }
 
     @Override
@@ -105,7 +99,7 @@ public class TopHitsAggregationBuilder extends AbstractAggregationBuilder<TopHit
     public TopHitsAggregationBuilder(StreamInput in) throws IOException {
         super(in);
         explain = in.readBoolean();
-        fetchSourceContext = in.readOptionalWriteable(FetchSourceContext::new);
+        fetchSourceContext = in.readOptionalWriteable(FetchSourceContext::readFrom);
         if (in.readBoolean()) {
             int size = in.readVInt();
             docValueFields = new ArrayList<>(size);
@@ -313,7 +307,7 @@ public class TopHitsAggregationBuilder extends AbstractAggregationBuilder<TopHit
      */
     public TopHitsAggregationBuilder fetchSource(boolean fetch) {
         FetchSourceContext fetchSourceContext = this.fetchSourceContext != null ? this.fetchSourceContext : FetchSourceContext.FETCH_SOURCE;
-        this.fetchSourceContext = new FetchSourceContext(fetch, fetchSourceContext.includes(), fetchSourceContext.excludes());
+        this.fetchSourceContext = FetchSourceContext.of(fetch, fetchSourceContext.includes(), fetchSourceContext.excludes());
         return this;
     }
 
@@ -351,7 +345,7 @@ public class TopHitsAggregationBuilder extends AbstractAggregationBuilder<TopHit
      */
     public TopHitsAggregationBuilder fetchSource(@Nullable String[] includes, @Nullable String[] excludes) {
         FetchSourceContext fetchSourceContext = this.fetchSourceContext != null ? this.fetchSourceContext : FetchSourceContext.FETCH_SOURCE;
-        this.fetchSourceContext = new FetchSourceContext(fetchSourceContext.fetchSource(), includes, excludes);
+        this.fetchSourceContext = FetchSourceContext.of(fetchSourceContext.fetchSource(), includes, excludes);
         return this;
     }
 

--- a/server/src/main/java/org/elasticsearch/search/builder/SearchSourceBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/builder/SearchSourceBuilder.java
@@ -200,7 +200,7 @@ public final class SearchSourceBuilder implements Writeable, ToXContentObject, R
     public SearchSourceBuilder(StreamInput in) throws IOException {
         aggregations = in.readOptionalWriteable(AggregatorFactories.Builder::new);
         explain = in.readOptionalBoolean();
-        fetchSourceContext = in.readOptionalWriteable(FetchSourceContext::new);
+        fetchSourceContext = in.readOptionalWriteable(FetchSourceContext::readFrom);
         if (in.readBoolean()) {
             docValueFields = in.readList(FieldAndFormat::new);
         } else {
@@ -736,7 +736,7 @@ public final class SearchSourceBuilder implements Writeable, ToXContentObject, R
      */
     public SearchSourceBuilder fetchSource(boolean fetch) {
         FetchSourceContext fetchSourceContext = this.fetchSourceContext != null ? this.fetchSourceContext : FetchSourceContext.FETCH_SOURCE;
-        this.fetchSourceContext = new FetchSourceContext(fetch, fetchSourceContext.includes(), fetchSourceContext.excludes());
+        this.fetchSourceContext = FetchSourceContext.of(fetch, fetchSourceContext.includes(), fetchSourceContext.excludes());
         return this;
     }
 
@@ -773,7 +773,7 @@ public final class SearchSourceBuilder implements Writeable, ToXContentObject, R
      */
     public SearchSourceBuilder fetchSource(@Nullable String[] includes, @Nullable String[] excludes) {
         FetchSourceContext fetchSourceContext = this.fetchSourceContext != null ? this.fetchSourceContext : FetchSourceContext.FETCH_SOURCE;
-        this.fetchSourceContext = new FetchSourceContext(fetchSourceContext.fetchSource(), includes, excludes);
+        this.fetchSourceContext = FetchSourceContext.of(fetchSourceContext.fetchSource(), includes, excludes);
         return this;
     }
 

--- a/server/src/main/java/org/elasticsearch/search/fetch/FetchPhase.java
+++ b/server/src/main/java/org/elasticsearch/search/fetch/FetchPhase.java
@@ -216,7 +216,7 @@ public class FetchPhase {
         if (storedFieldsContext == null) {
             // no fields specified, default to return source if no explicit indication
             if (context.hasScriptFields() == false && context.hasFetchSourceContext() == false) {
-                context.fetchSourceContext(new FetchSourceContext(true));
+                context.fetchSourceContext(FetchSourceContext.FETCH_SOURCE);
             }
             boolean loadSource = sourceRequired(context);
             return new FieldsVisitor(loadSource);
@@ -229,7 +229,7 @@ public class FetchPhase {
                     FetchSourceContext fetchSourceContext = context.hasFetchSourceContext()
                         ? context.fetchSourceContext()
                         : FetchSourceContext.FETCH_SOURCE;
-                    context.fetchSourceContext(new FetchSourceContext(true, fetchSourceContext.includes(), fetchSourceContext.excludes()));
+                    context.fetchSourceContext(FetchSourceContext.of(true, fetchSourceContext.includes(), fetchSourceContext.excludes()));
                     continue;
                 }
                 SearchExecutionContext searchExecutionContext = context.getSearchExecutionContext();

--- a/server/src/main/java/org/elasticsearch/search/fetch/subphase/FetchSourceContext.java
+++ b/server/src/main/java/org/elasticsearch/search/fetch/subphase/FetchSourceContext.java
@@ -15,6 +15,7 @@ import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.xcontent.support.XContentMapValues;
 import org.elasticsearch.core.Booleans;
+import org.elasticsearch.core.Nullable;
 import org.elasticsearch.rest.RestRequest;
 import org.elasticsearch.xcontent.ParseField;
 import org.elasticsearch.xcontent.ToXContentObject;
@@ -36,27 +37,35 @@ public class FetchSourceContext implements Writeable, ToXContentObject {
     public static final ParseField INCLUDES_FIELD = new ParseField("includes", "include");
     public static final ParseField EXCLUDES_FIELD = new ParseField("excludes", "exclude");
 
-    public static final FetchSourceContext FETCH_SOURCE = new FetchSourceContext(true);
-    public static final FetchSourceContext DO_NOT_FETCH_SOURCE = new FetchSourceContext(false);
+    public static final FetchSourceContext FETCH_SOURCE = new FetchSourceContext(true, Strings.EMPTY_ARRAY, Strings.EMPTY_ARRAY);
+    public static final FetchSourceContext DO_NOT_FETCH_SOURCE = new FetchSourceContext(false, Strings.EMPTY_ARRAY, Strings.EMPTY_ARRAY);
     private final boolean fetchSource;
     private final String[] includes;
     private final String[] excludes;
     private Function<Map<String, ?>, Map<String, Object>> filter;
 
-    public FetchSourceContext(boolean fetchSource, String[] includes, String[] excludes) {
+    public static FetchSourceContext of(boolean fetchSource) {
+        return fetchSource ? FETCH_SOURCE : DO_NOT_FETCH_SOURCE;
+    }
+
+    public static FetchSourceContext of(boolean fetchSource, @Nullable String[] includes, @Nullable String[] excludes) {
+        if ((includes == null || includes.length == 0) && (excludes == null || excludes.length == 0)) {
+            return of(fetchSource);
+        }
+        return new FetchSourceContext(fetchSource, includes, excludes);
+    }
+
+    public static FetchSourceContext readFrom(StreamInput in) throws IOException {
+        final boolean fetchSource = in.readBoolean();
+        final String[] includes = in.readStringArray();
+        final String[] excludes = in.readStringArray();
+        return of(fetchSource, includes, excludes);
+    }
+
+    private FetchSourceContext(boolean fetchSource, @Nullable String[] includes, @Nullable String[] excludes) {
         this.fetchSource = fetchSource;
         this.includes = includes == null ? Strings.EMPTY_ARRAY : includes;
         this.excludes = excludes == null ? Strings.EMPTY_ARRAY : excludes;
-    }
-
-    public FetchSourceContext(boolean fetchSource) {
-        this(fetchSource, Strings.EMPTY_ARRAY, Strings.EMPTY_ARRAY);
-    }
-
-    public FetchSourceContext(StreamInput in) throws IOException {
-        fetchSource = in.readBoolean();
-        includes = in.readStringArray();
-        excludes = in.readStringArray();
     }
 
     @Override
@@ -105,7 +114,7 @@ public class FetchSourceContext implements Writeable, ToXContentObject {
         }
 
         if (fetchSource != null || sourceIncludes != null || sourceExcludes != null) {
-            return new FetchSourceContext(fetchSource == null ? true : fetchSource, sourceIncludes, sourceExcludes);
+            return FetchSourceContext.of(fetchSource == null || fetchSource, sourceIncludes, sourceExcludes);
         }
         return null;
     }
@@ -128,7 +137,7 @@ public class FetchSourceContext implements Writeable, ToXContentObject {
             while ((parser.nextToken()) != XContentParser.Token.END_ARRAY) {
                 list.add(parser.text());
             }
-            includes = list.toArray(new String[list.size()]);
+            includes = list.toArray(Strings.EMPTY_ARRAY);
         } else if (token == XContentParser.Token.START_OBJECT) {
             String currentFieldName = null;
             while ((token = parser.nextToken()) != XContentParser.Token.END_OBJECT) {
@@ -148,7 +157,7 @@ public class FetchSourceContext implements Writeable, ToXContentObject {
                                 );
                             }
                         }
-                        includes = includesList.toArray(new String[includesList.size()]);
+                        includes = includesList.toArray(Strings.EMPTY_ARRAY);
                     } else if (EXCLUDES_FIELD.match(currentFieldName, parser.getDeprecationHandler())) {
                         List<String> excludesList = new ArrayList<>();
                         while ((token = parser.nextToken()) != XContentParser.Token.END_ARRAY) {
@@ -162,7 +171,7 @@ public class FetchSourceContext implements Writeable, ToXContentObject {
                                 );
                             }
                         }
-                        excludes = excludesList.toArray(new String[excludesList.size()]);
+                        excludes = excludesList.toArray(Strings.EMPTY_ARRAY);
                     } else {
                         throw new ParsingException(
                             parser.getTokenLocation(),
@@ -207,7 +216,7 @@ public class FetchSourceContext implements Writeable, ToXContentObject {
                 parser.getTokenLocation()
             );
         }
-        return new FetchSourceContext(fetchSource, includes, excludes);
+        return FetchSourceContext.of(fetchSource, includes, excludes);
     }
 
     @Override
@@ -240,8 +249,8 @@ public class FetchSourceContext implements Writeable, ToXContentObject {
     @Override
     public int hashCode() {
         int result = (fetchSource ? 1 : 0);
-        result = 31 * result + (includes != null ? Arrays.hashCode(includes) : 0);
-        result = 31 * result + (excludes != null ? Arrays.hashCode(excludes) : 0);
+        result = 31 * result + Arrays.hashCode(includes);
+        result = 31 * result + Arrays.hashCode(excludes);
         return result;
     }
 

--- a/server/src/test/java/org/elasticsearch/action/explain/ExplainRequestTests.java
+++ b/server/src/test/java/org/elasticsearch/action/explain/ExplainRequestTests.java
@@ -44,7 +44,7 @@ public class ExplainRequestTests extends ESTestCase {
     public void testSerialize() throws IOException {
         try (BytesStreamOutput output = new BytesStreamOutput()) {
             ExplainRequest request = new ExplainRequest("index", "id");
-            request.fetchSourceContext(new FetchSourceContext(true, new String[] { "field1.*" }, new String[] { "field2.*" }));
+            request.fetchSourceContext(FetchSourceContext.of(true, new String[] { "field1.*" }, new String[] { "field2.*" }));
             request.filteringAlias(new AliasFilter(QueryBuilders.termQuery("filter_field", "value"), "alias0", "alias1"));
             request.preference("the_preference");
             request.query(QueryBuilders.termQuery("field", "value"));

--- a/server/src/test/java/org/elasticsearch/action/get/MultiGetRequestTests.java
+++ b/server/src/test/java/org/elasticsearch/action/get/MultiGetRequestTests.java
@@ -131,13 +131,13 @@ public class MultiGetRequestTests extends ESTestCase {
             if (randomBoolean()) {
                 FetchSourceContext fetchSourceContext;
                 if (randomBoolean()) {
-                    fetchSourceContext = new FetchSourceContext(
+                    fetchSourceContext = FetchSourceContext.of(
                         true,
                         generateRandomStringArray(16, 8, false),
                         generateRandomStringArray(5, 4, false)
                     );
                 } else {
-                    fetchSourceContext = new FetchSourceContext(false);
+                    fetchSourceContext = FetchSourceContext.DO_NOT_FETCH_SOURCE;
                 }
                 item.fetchSourceContext(fetchSourceContext);
             }

--- a/server/src/test/java/org/elasticsearch/action/get/MultiGetShardRequestTests.java
+++ b/server/src/test/java/org/elasticsearch/action/get/MultiGetShardRequestTests.java
@@ -48,7 +48,7 @@ public class MultiGetShardRequestTests extends ESTestCase {
                 item.versionType(randomFrom(VersionType.values()));
             }
             if (randomBoolean()) {
-                item.fetchSourceContext(new FetchSourceContext(randomBoolean()));
+                item.fetchSourceContext(FetchSourceContext.of(randomBoolean()));
             }
             multiGetShardRequest.add(0, item);
         }

--- a/server/src/test/java/org/elasticsearch/index/query/InnerHitBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/index/query/InnerHitBuilderTests.java
@@ -159,15 +159,15 @@ public class InnerHitBuilderTests extends ESTestCase {
         FetchSourceContext randomFetchSourceContext;
         int randomInt = randomIntBetween(0, 2);
         if (randomInt == 0) {
-            randomFetchSourceContext = new FetchSourceContext(true, Strings.EMPTY_ARRAY, Strings.EMPTY_ARRAY);
+            randomFetchSourceContext = FetchSourceContext.FETCH_SOURCE;
         } else if (randomInt == 1) {
-            randomFetchSourceContext = new FetchSourceContext(
+            randomFetchSourceContext = FetchSourceContext.of(
                 true,
                 generateRandomStringArray(12, 16, false),
                 generateRandomStringArray(12, 16, false)
             );
         } else {
-            randomFetchSourceContext = new FetchSourceContext(randomBoolean());
+            randomFetchSourceContext = FetchSourceContext.of(randomBoolean());
         }
         innerHits.setFetchSourceContext(randomFetchSourceContext);
         if (randomBoolean()) {
@@ -229,9 +229,9 @@ public class InnerHitBuilderTests extends ESTestCase {
         modifiers.add(() -> copy.setFetchSourceContext(randomValueOtherThan(copy.getFetchSourceContext(), () -> {
             FetchSourceContext randomFetchSourceContext;
             if (randomBoolean()) {
-                randomFetchSourceContext = new FetchSourceContext(randomBoolean());
+                randomFetchSourceContext = FetchSourceContext.of(randomBoolean());
             } else {
-                randomFetchSourceContext = new FetchSourceContext(
+                randomFetchSourceContext = FetchSourceContext.of(
                     true,
                     generateRandomStringArray(12, 16, false),
                     generateRandomStringArray(12, 16, false)

--- a/server/src/test/java/org/elasticsearch/search/aggregations/metrics/TopHitsTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/metrics/TopHitsTests.java
@@ -107,16 +107,16 @@ public class TopHitsTests extends BaseAggregationTestCase<TopHitsAggregationBuil
                 excludes[i] = randomAlphaOfLengthBetween(5, 20);
             }
             fetchSourceContext = switch (branch) {
-                case 0 -> new FetchSourceContext(randomBoolean());
-                case 1 -> new FetchSourceContext(true, includes, excludes);
-                case 2 -> new FetchSourceContext(
+                case 0 -> FetchSourceContext.of(randomBoolean());
+                case 1 -> FetchSourceContext.of(true, includes, excludes);
+                case 2 -> FetchSourceContext.of(
                     true,
                     new String[] { randomAlphaOfLengthBetween(5, 20) },
                     new String[] { randomAlphaOfLengthBetween(5, 20) }
                 );
-                case 3 -> new FetchSourceContext(true, includes, excludes);
-                case 4 -> new FetchSourceContext(true, includes, null);
-                case 5 -> new FetchSourceContext(true, new String[] { randomAlphaOfLengthBetween(5, 20) }, null);
+                case 3 -> FetchSourceContext.of(true, includes, excludes);
+                case 4 -> FetchSourceContext.of(true, includes, null);
+                case 5 -> FetchSourceContext.of(true, new String[] { randomAlphaOfLengthBetween(5, 20) }, null);
                 default -> throw new IllegalStateException();
             };
             factory.fetchSource(fetchSourceContext);

--- a/server/src/test/java/org/elasticsearch/search/fetch/subphase/FetchSourceContextTests.java
+++ b/server/src/test/java/org/elasticsearch/search/fetch/subphase/FetchSourceContextTests.java
@@ -27,12 +27,12 @@ public class FetchSourceContextTests extends AbstractSerializingTestCase<FetchSo
 
     @Override
     protected Writeable.Reader<FetchSourceContext> instanceReader() {
-        return FetchSourceContext::new;
+        return FetchSourceContext::readFrom;
     }
 
     @Override
     protected FetchSourceContext createTestInstance() {
-        return new FetchSourceContext(
+        return FetchSourceContext.of(
             true,
             randomArray(0, 5, String[]::new, () -> randomAlphaOfLength(5)),
             randomArray(0, 5, String[]::new, () -> randomAlphaOfLength(5))
@@ -50,5 +50,14 @@ public class FetchSourceContextTests extends AbstractSerializingTestCase<FetchSo
             containsString("Expected one of [VALUE_BOOLEAN, VALUE_STRING, START_ARRAY, START_OBJECT] but found [VALUE_NUMBER]")
         );
 
+    }
+
+    @Override
+    protected void assertEqualInstances(FetchSourceContext expectedInstance, FetchSourceContext newInstance) {
+        if (expectedInstance == FetchSourceContext.FETCH_SOURCE || expectedInstance == FetchSourceContext.DO_NOT_FETCH_SOURCE) {
+            assertSame(expectedInstance, newInstance);
+        } else {
+            super.assertEqualInstances(expectedInstance, newInstance);
+        }
     }
 }

--- a/server/src/test/java/org/elasticsearch/search/fetch/subphase/FetchSourcePhaseTests.java
+++ b/server/src/test/java/org/elasticsearch/search/fetch/subphase/FetchSourcePhaseTests.java
@@ -161,7 +161,7 @@ public class FetchSourcePhaseTests extends ESTestCase {
         String[] excludes,
         SearchHit.NestedIdentity nestedIdentity
     ) throws IOException {
-        FetchSourceContext fetchSourceContext = new FetchSourceContext(fetchSource, includes, excludes);
+        FetchSourceContext fetchSourceContext = FetchSourceContext.of(fetchSource, includes, excludes);
         FetchContext fetchContext = mock(FetchContext.class);
         when(fetchContext.fetchSourceContext()).thenReturn(fetchSourceContext);
         when(fetchContext.getIndexName()).thenReturn("index");

--- a/test/framework/src/main/java/org/elasticsearch/search/RandomSearchRequestGenerator.java
+++ b/test/framework/src/main/java/org/elasticsearch/search/RandomSearchRequestGenerator.java
@@ -208,16 +208,16 @@ public class RandomSearchRequestGenerator {
                 excludes[i] = randomAlphaOfLengthBetween(5, 20);
             }
             fetchSourceContext = switch (branch) {
-                case 0 -> new FetchSourceContext(randomBoolean());
-                case 1 -> new FetchSourceContext(true, includes, excludes);
-                case 2 -> new FetchSourceContext(
+                case 0 -> FetchSourceContext.of(randomBoolean());
+                case 1 -> FetchSourceContext.of(true, includes, excludes);
+                case 2 -> FetchSourceContext.of(
                     true,
                     new String[] { randomAlphaOfLengthBetween(5, 20) },
                     new String[] { randomAlphaOfLengthBetween(5, 20) }
                 );
-                case 3 -> new FetchSourceContext(true, includes, excludes);
-                case 4 -> new FetchSourceContext(true, includes, null);
-                case 5 -> new FetchSourceContext(true, new String[] { randomAlphaOfLengthBetween(5, 20) }, null);
+                case 3 -> FetchSourceContext.of(true, includes, excludes);
+                case 4 -> FetchSourceContext.of(true, includes, null);
+                case 5 -> FetchSourceContext.of(true, new String[] { randomAlphaOfLengthBetween(5, 20) }, null);
                 default -> throw new IllegalStateException();
             };
             builder.fetchSource(fetchSourceContext);

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/DataFrameAnalyticsConfig.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/DataFrameAnalyticsConfig.java
@@ -177,7 +177,7 @@ public class DataFrameAnalyticsConfig implements ToXContentObject, Writeable {
         this.source = new DataFrameAnalyticsSource(in);
         this.dest = new DataFrameAnalyticsDest(in);
         this.analysis = in.readNamedWriteable(DataFrameAnalysis.class);
-        this.analyzedFields = in.readOptionalWriteable(FetchSourceContext::new);
+        this.analyzedFields = in.readOptionalWriteable(FetchSourceContext::readFrom);
         this.modelMemoryLimit = in.readOptionalWriteable(ByteSizeValue::new);
         this.headers = Collections.unmodifiableMap(in.readMap(StreamInput::readString, StreamInput::readString));
         this.createTime = in.readOptionalInstant();
@@ -384,7 +384,7 @@ public class DataFrameAnalyticsConfig implements ToXContentObject, Writeable {
             this.modelMemoryLimit = config.modelMemoryLimit;
             this.maxModelMemoryLimit = maxModelMemoryLimit;
             if (config.analyzedFields != null) {
-                this.analyzedFields = new FetchSourceContext(true, config.analyzedFields.includes(), config.analyzedFields.excludes());
+                this.analyzedFields = FetchSourceContext.of(true, config.analyzedFields.includes(), config.analyzedFields.excludes());
             }
             this.createTime = config.createTime;
             this.version = config.version;

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/DataFrameAnalyticsSource.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/DataFrameAnalyticsSource.java
@@ -105,20 +105,14 @@ public class DataFrameAnalyticsSource implements Writeable, ToXContentObject {
     public DataFrameAnalyticsSource(StreamInput in) throws IOException {
         index = in.readStringArray();
         queryProvider = QueryProvider.fromStream(in);
-        sourceFiltering = in.readOptionalWriteable(FetchSourceContext::new);
+        sourceFiltering = in.readOptionalWriteable(FetchSourceContext::readFrom);
         runtimeMappings = in.readMap();
     }
 
     public DataFrameAnalyticsSource(DataFrameAnalyticsSource other) {
         this.index = Arrays.copyOf(other.index, other.index.length);
         this.queryProvider = new QueryProvider(other.queryProvider);
-        this.sourceFiltering = other.sourceFiltering == null
-            ? null
-            : new FetchSourceContext(
-                other.sourceFiltering.fetchSource(),
-                other.sourceFiltering.includes(),
-                other.sourceFiltering.excludes()
-            );
+        this.sourceFiltering = other.sourceFiltering;
         this.runtimeMappings = Collections.unmodifiableMap(new HashMap<>(other.runtimeMappings));
     }
 

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/action/PutDataFrameAnalyticsActionRequestTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/action/PutDataFrameAnalyticsActionRequestTests.java
@@ -83,10 +83,10 @@ public class PutDataFrameAnalyticsActionRequestTests extends AbstractSerializing
         DataFrameAnalyticsSource source = new DataFrameAnalyticsSource(
             new String[] { "index" },
             null,
-            new FetchSourceContext(true, null, new String[] { "excluded" }),
+            FetchSourceContext.of(true, null, new String[] { "excluded" }),
             null
         );
-        FetchSourceContext analyzedFields = new FetchSourceContext(true, new String[] { "excluded" }, null);
+        FetchSourceContext analyzedFields = FetchSourceContext.of(true, new String[] { "excluded" }, null);
         DataFrameAnalyticsConfig config = new DataFrameAnalyticsConfig.Builder().setId("foo")
             .setSource(source)
             .setAnalysis(OutlierDetectionTests.createRandom())
@@ -104,10 +104,10 @@ public class PutDataFrameAnalyticsActionRequestTests extends AbstractSerializing
         DataFrameAnalyticsSource source = new DataFrameAnalyticsSource(
             new String[] { "index" },
             null,
-            new FetchSourceContext(true, new String[] { "included" }, null),
+            FetchSourceContext.of(true, new String[] { "included" }, null),
             null
         );
-        FetchSourceContext analyzedFields = new FetchSourceContext(true, new String[] { "included" }, null);
+        FetchSourceContext analyzedFields = FetchSourceContext.of(true, new String[] { "included" }, null);
         DataFrameAnalyticsConfig config = new DataFrameAnalyticsConfig.Builder().setId("foo")
             .setSource(source)
             .setAnalysis(OutlierDetectionTests.createRandom())

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/dataframe/DataFrameAnalyticsConfigTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/dataframe/DataFrameAnalyticsConfigTests.java
@@ -146,7 +146,7 @@ public class DataFrameAnalyticsConfigTests extends AbstractBWCSerializationTestC
             .setDest(dest);
         if (randomBoolean()) {
             builder.setAnalyzedFields(
-                new FetchSourceContext(
+                FetchSourceContext.of(
                     true,
                     generateRandomStringArray(10, 10, false, false),
                     generateRandomStringArray(10, 10, false, false)

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/dataframe/DataFrameAnalyticsSourceTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/dataframe/DataFrameAnalyticsSourceTests.java
@@ -67,7 +67,7 @@ public class DataFrameAnalyticsSourceTests extends AbstractBWCSerializationTestC
             }
         }
         if (randomBoolean()) {
-            sourceFiltering = new FetchSourceContext(
+            sourceFiltering = FetchSourceContext.of(
                 true,
                 generateRandomStringArray(10, 10, false, false),
                 generateRandomStringArray(10, 10, false, false)
@@ -97,7 +97,7 @@ public class DataFrameAnalyticsSourceTests extends AbstractBWCSerializationTestC
     public void testConstructor_GivenDisabledSource() {
         IllegalArgumentException e = expectThrows(
             IllegalArgumentException.class,
-            () -> new DataFrameAnalyticsSource(new String[] { "index" }, null, new FetchSourceContext(false, null, null), null)
+            () -> new DataFrameAnalyticsSource(new String[] { "index" }, null, FetchSourceContext.DO_NOT_FETCH_SOURCE, null)
         );
         assertThat(e.getMessage(), equalTo("source._source cannot be disabled"));
     }
@@ -124,7 +124,7 @@ public class DataFrameAnalyticsSourceTests extends AbstractBWCSerializationTestC
         DataFrameAnalyticsSource source = new DataFrameAnalyticsSource(
             new String[] { "index" },
             null,
-            new FetchSourceContext(true, null, null),
+            FetchSourceContext.FETCH_SOURCE,
             null
         );
         assertThat(source.isFieldExcluded(randomAlphaOfLength(10)), is(false));
@@ -169,7 +169,7 @@ public class DataFrameAnalyticsSourceTests extends AbstractBWCSerializationTestC
     }
 
     private static DataFrameAnalyticsSource newSourceWithIncludesExcludes(List<String> includes, List<String> excludes) {
-        FetchSourceContext sourceFiltering = new FetchSourceContext(true, includes.toArray(new String[0]), excludes.toArray(new String[0]));
+        FetchSourceContext sourceFiltering = FetchSourceContext.of(true, includes.toArray(new String[0]), excludes.toArray(new String[0]));
         return new DataFrameAnalyticsSource(new String[] { "index" }, null, sourceFiltering, null);
     }
 

--- a/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/ClassificationIT.java
+++ b/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/ClassificationIT.java
@@ -933,7 +933,7 @@ public class ClassificationIT extends MlNativeDataFrameAnalyticsIntegTestCase {
         DataFrameAnalyticsConfig config = new DataFrameAnalyticsConfig.Builder().setId(jobId)
             .setSource(new DataFrameAnalyticsSource(new String[] { sourceIndex }, null, null, runtimeFields))
             .setDest(new DataFrameAnalyticsDest(destIndex, null))
-            .setAnalyzedFields(new FetchSourceContext(true, new String[] { numericRuntimeField, dependentVariableRuntimeField }, null))
+            .setAnalyzedFields(FetchSourceContext.of(true, new String[] { numericRuntimeField, dependentVariableRuntimeField }, null))
             .setAnalysis(
                 new Classification(
                     dependentVariableRuntimeField,

--- a/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/DataFrameAnalysisCustomFeatureIT.java
+++ b/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/DataFrameAnalysisCustomFeatureIT.java
@@ -154,7 +154,7 @@ public class DataFrameAnalysisCustomFeatureIT extends MlNativeDataFrameAnalytics
                     null
                 )
             )
-            .setAnalyzedFields(new FetchSourceContext(true, new String[] { TEXT_FIELD, NUMERICAL_FIELD }, new String[] {}))
+            .setAnalyzedFields(FetchSourceContext.of(true, new String[] { TEXT_FIELD, NUMERICAL_FIELD }, new String[] {}))
             .build();
         putAnalytics(config);
 

--- a/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/RegressionIT.java
+++ b/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/RegressionIT.java
@@ -606,7 +606,7 @@ public class RegressionIT extends MlNativeDataFrameAnalyticsIntegTestCase {
             .setSource(new DataFrameAnalyticsSource(new String[] { sourceIndex }, null, null, Collections.emptyMap()))
             .setDest(new DataFrameAnalyticsDest(destIndex, null))
             .setAnalysis(regression)
-            .setAnalyzedFields(new FetchSourceContext(true, null, new String[] { "field_1" }))
+            .setAnalyzedFields(FetchSourceContext.of(true, null, new String[] { "field_1" }))
             .build();
         putAnalytics(config);
 
@@ -763,7 +763,7 @@ public class RegressionIT extends MlNativeDataFrameAnalyticsIntegTestCase {
         DataFrameAnalyticsConfig config = new DataFrameAnalyticsConfig.Builder().setId(jobId)
             .setSource(new DataFrameAnalyticsSource(new String[] { sourceIndex }, null, null, runtimeFields))
             .setDest(new DataFrameAnalyticsDest(destIndex, null))
-            .setAnalyzedFields(new FetchSourceContext(true, new String[] { numericRuntimeField, dependentVariableRuntimeField }, null))
+            .setAnalyzedFields(FetchSourceContext.of(true, new String[] { numericRuntimeField, dependentVariableRuntimeField }, null))
             .setAnalysis(
                 new Regression(
                     dependentVariableRuntimeField,

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/persistence/JobResultsProvider.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/persistence/JobResultsProvider.java
@@ -159,7 +159,7 @@ public class JobResultsProvider {
     private static final double ESTABLISHED_MEMORY_CV_THRESHOLD = 0.1;
 
     // filter for quantiles in modelSnapshots to avoid memory overhead
-    private static final FetchSourceContext REMOVE_QUANTILES_FROM_SOURCE = new FetchSourceContext(
+    private static final FetchSourceContext REMOVE_QUANTILES_FROM_SOURCE = FetchSourceContext.of(
         true,
         null,
         new String[] { ModelSnapshot.QUANTILES.getPreferredName() }

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/dataframe/MappingsMergerTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/dataframe/MappingsMergerTests.java
@@ -255,6 +255,6 @@ public class MappingsMergerTests extends ESTestCase {
     }
 
     private static DataFrameAnalyticsSource newSourceWithExcludes(String... excludes) {
-        return new DataFrameAnalyticsSource(new String[] { "index" }, null, new FetchSourceContext(true, null, excludes), null);
+        return new DataFrameAnalyticsSource(new String[] { "index" }, null, FetchSourceContext.of(true, null, excludes), null);
     }
 }

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/dataframe/extractor/ExtractedFieldsDetectorTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/dataframe/extractor/ExtractedFieldsDetectorTests.java
@@ -269,7 +269,7 @@ public class ExtractedFieldsDetectorTests extends ESTestCase {
             .addAggregatableField("some_keyword", "keyword")
             .addAggregatableField("foo", "float")
             .build();
-        analyzedFields = new FetchSourceContext(true, new String[0], new String[] { "foo" });
+        analyzedFields = FetchSourceContext.of(true, new String[0], new String[] { "foo" });
 
         ExtractedFieldsDetector extractedFieldsDetector = new ExtractedFieldsDetector(
             buildRegressionConfig("foo"),
@@ -288,7 +288,7 @@ public class ExtractedFieldsDetectorTests extends ESTestCase {
             .addAggregatableField("some_keyword", "keyword")
             .addAggregatableField("foo", "float")
             .build();
-        analyzedFields = new FetchSourceContext(true, new String[] { "some_float", "some_keyword" }, new String[0]);
+        analyzedFields = FetchSourceContext.of(true, new String[] { "some_float", "some_keyword" }, new String[0]);
 
         ExtractedFieldsDetector extractedFieldsDetector = new ExtractedFieldsDetector(
             buildRegressionConfig("foo"),
@@ -305,7 +305,7 @@ public class ExtractedFieldsDetectorTests extends ESTestCase {
         FieldCapabilitiesResponse fieldCapabilities = new MockFieldCapsResponseBuilder().addAggregatableField("foo", "float")
             .addAggregatableField("bar", "float")
             .build();
-        analyzedFields = new FetchSourceContext(true, new String[] { "foo", "bar" }, new String[] { "foo" });
+        analyzedFields = FetchSourceContext.of(true, new String[] { "foo", "bar" }, new String[] { "foo" });
 
         ExtractedFieldsDetector extractedFieldsDetector = new ExtractedFieldsDetector(
             buildOutlierDetectionConfig(),
@@ -330,7 +330,7 @@ public class ExtractedFieldsDetectorTests extends ESTestCase {
         FieldCapabilitiesResponse fieldCapabilities = new MockFieldCapsResponseBuilder().addAggregatableField("foo", "float")
             .addAggregatableField("bar", "float")
             .build();
-        analyzedFields = new FetchSourceContext(true, new String[] { "foo" }, new String[] { "bar" });
+        analyzedFields = FetchSourceContext.of(true, new String[] { "foo" }, new String[] { "bar" });
 
         ExtractedFieldsDetector extractedFieldsDetector = new ExtractedFieldsDetector(
             buildOutlierDetectionConfig(),
@@ -433,7 +433,7 @@ public class ExtractedFieldsDetectorTests extends ESTestCase {
 
     public void testDetect_GivenIncludedIgnoredField() {
         FieldCapabilitiesResponse fieldCapabilities = new MockFieldCapsResponseBuilder().addField("_id", true, false, "float").build();
-        analyzedFields = new FetchSourceContext(true, new String[] { "_id" }, new String[0]);
+        analyzedFields = FetchSourceContext.of(true, new String[] { "_id" }, new String[0]);
 
         ExtractedFieldsDetector extractedFieldsDetector = new ExtractedFieldsDetector(
             buildOutlierDetectionConfig(),
@@ -448,7 +448,7 @@ public class ExtractedFieldsDetectorTests extends ESTestCase {
 
     public void testDetect_GivenExcludedFieldIsMissing() {
         FieldCapabilitiesResponse fieldCapabilities = new MockFieldCapsResponseBuilder().addAggregatableField("foo", "float").build();
-        analyzedFields = new FetchSourceContext(true, new String[] { "*" }, new String[] { "bar" });
+        analyzedFields = FetchSourceContext.of(true, new String[] { "*" }, new String[] { "bar" });
 
         ExtractedFieldsDetector extractedFieldsDetector = new ExtractedFieldsDetector(
             buildOutlierDetectionConfig(),
@@ -465,7 +465,7 @@ public class ExtractedFieldsDetectorTests extends ESTestCase {
         FieldCapabilitiesResponse fieldCapabilities = new MockFieldCapsResponseBuilder().addAggregatableField("numeric", "float")
             .addAggregatableField("categorical", "keyword")
             .build();
-        analyzedFields = new FetchSourceContext(true, null, new String[] { "categorical" });
+        analyzedFields = FetchSourceContext.of(true, null, new String[] { "categorical" });
 
         ExtractedFieldsDetector extractedFieldsDetector = new ExtractedFieldsDetector(
             buildOutlierDetectionConfig(),
@@ -528,7 +528,7 @@ public class ExtractedFieldsDetectorTests extends ESTestCase {
             .addAggregatableField("my_field2", "float")
             .build();
 
-        analyzedFields = new FetchSourceContext(true, new String[] { "your_field1", "my*" }, new String[0]);
+        analyzedFields = FetchSourceContext.of(true, new String[] { "your_field1", "my*" }, new String[0]);
 
         ExtractedFieldsDetector extractedFieldsDetector = new ExtractedFieldsDetector(
             buildOutlierDetectionConfig(),
@@ -546,7 +546,7 @@ public class ExtractedFieldsDetectorTests extends ESTestCase {
             .addAggregatableField("my_field2", "float")
             .build();
 
-        analyzedFields = new FetchSourceContext(true, new String[0], new String[] { "my_*" });
+        analyzedFields = FetchSourceContext.of(true, new String[0], new String[] { "my_*" });
 
         ExtractedFieldsDetector extractedFieldsDetector = new ExtractedFieldsDetector(
             buildOutlierDetectionConfig(),
@@ -567,7 +567,7 @@ public class ExtractedFieldsDetectorTests extends ESTestCase {
             .addAggregatableField("your_field2", "float")
             .build();
 
-        analyzedFields = new FetchSourceContext(true, new String[] { "your*", "my_*" }, new String[] { "*nope" });
+        analyzedFields = FetchSourceContext.of(true, new String[] { "your*", "my_*" }, new String[] { "*nope" });
 
         ExtractedFieldsDetector extractedFieldsDetector = new ExtractedFieldsDetector(
             buildOutlierDetectionConfig(),
@@ -599,7 +599,7 @@ public class ExtractedFieldsDetectorTests extends ESTestCase {
             .addAggregatableField("your_keyword", "keyword")
             .build();
 
-        analyzedFields = new FetchSourceContext(true, new String[] { "your*", "my_*" }, new String[] { "*nope" });
+        analyzedFields = FetchSourceContext.of(true, new String[] { "your*", "my_*" }, new String[] { "*nope" });
 
         ExtractedFieldsDetector extractedFieldsDetector = new ExtractedFieldsDetector(
             buildOutlierDetectionConfig(),
@@ -622,7 +622,7 @@ public class ExtractedFieldsDetectorTests extends ESTestCase {
         FieldCapabilitiesResponse fieldCapabilities = new MockFieldCapsResponseBuilder().addAggregatableField("numeric", "float")
             .addAggregatableField("categorical", "keyword")
             .build();
-        analyzedFields = new FetchSourceContext(true, new String[] { "numeric" }, null);
+        analyzedFields = FetchSourceContext.of(true, new String[] { "numeric" }, null);
 
         ExtractedFieldsDetector extractedFieldsDetector = new ExtractedFieldsDetector(
             buildOutlierDetectionConfig(),
@@ -696,7 +696,7 @@ public class ExtractedFieldsDetectorTests extends ESTestCase {
             .addAggregatableField("your_field2", "float")
             .addAggregatableField("your_keyword", "keyword")
             .build();
-        analyzedFields = new FetchSourceContext(true, new String[] { RESULTS_FIELD }, new String[0]);
+        analyzedFields = FetchSourceContext.of(true, new String[] { RESULTS_FIELD }, new String[0]);
 
         ExtractedFieldsDetector extractedFieldsDetector = new ExtractedFieldsDetector(
             buildOutlierDetectionConfig(),
@@ -1090,7 +1090,7 @@ public class ExtractedFieldsDetectorTests extends ESTestCase {
             .addAggregatableField("field_1.keyword", "keyword")
             .addAggregatableField("field_2", "float")
             .build();
-        analyzedFields = new FetchSourceContext(true, new String[] { "field_1", "field_2" }, new String[0]);
+        analyzedFields = FetchSourceContext.of(true, new String[] { "field_1", "field_2" }, new String[0]);
 
         ExtractedFieldsDetector extractedFieldsDetector = new ExtractedFieldsDetector(
             buildRegressionConfig("field_2"),
@@ -1123,7 +1123,7 @@ public class ExtractedFieldsDetectorTests extends ESTestCase {
             .addAggregatableField("field_22", "float")
             .build();
 
-        sourceFiltering = new FetchSourceContext(true, new String[] { "field_1*" }, null);
+        sourceFiltering = FetchSourceContext.of(true, new String[] { "field_1*" }, null);
 
         ExtractedFieldsDetector extractedFieldsDetector = new ExtractedFieldsDetector(
             buildOutlierDetectionConfig(),
@@ -1152,7 +1152,7 @@ public class ExtractedFieldsDetectorTests extends ESTestCase {
             .addAggregatableField("field_22", "float")
             .build();
 
-        sourceFiltering = new FetchSourceContext(true, null, new String[] { "field_1*" });
+        sourceFiltering = FetchSourceContext.of(true, null, new String[] { "field_1*" });
 
         ExtractedFieldsDetector extractedFieldsDetector = new ExtractedFieldsDetector(
             buildOutlierDetectionConfig(),
@@ -1254,7 +1254,7 @@ public class ExtractedFieldsDetectorTests extends ESTestCase {
             .addNonAggregatableField("object_field", "object")
             .build();
 
-        analyzedFields = new FetchSourceContext(true, new String[] { "float_field", "object_field" }, null);
+        analyzedFields = FetchSourceContext.of(true, new String[] { "float_field", "object_field" }, null);
 
         ExtractedFieldsDetector extractedFieldsDetector = new ExtractedFieldsDetector(
             buildOutlierDetectionConfig(),
@@ -1272,7 +1272,7 @@ public class ExtractedFieldsDetectorTests extends ESTestCase {
             .addNonAggregatableField("nested_field", "nested")
             .build();
 
-        analyzedFields = new FetchSourceContext(true, new String[] { "float_field", "nested_field" }, null);
+        analyzedFields = FetchSourceContext.of(true, new String[] { "float_field", "nested_field" }, null);
 
         ExtractedFieldsDetector extractedFieldsDetector = new ExtractedFieldsDetector(
             buildOutlierDetectionConfig(),
@@ -1301,7 +1301,7 @@ public class ExtractedFieldsDetectorTests extends ESTestCase {
             .addNonAggregatableField("object_field", "object")
             .build();
 
-        analyzedFields = new FetchSourceContext(true, null, new String[] { "object_field" });
+        analyzedFields = FetchSourceContext.of(true, null, new String[] { "object_field" });
 
         ExtractedFieldsDetector extractedFieldsDetector = new ExtractedFieldsDetector(
             buildOutlierDetectionConfig(),
@@ -1319,7 +1319,7 @@ public class ExtractedFieldsDetectorTests extends ESTestCase {
             .addNonAggregatableField("nested_field", "nested")
             .build();
 
-        analyzedFields = new FetchSourceContext(true, null, new String[] { "nested_field" });
+        analyzedFields = FetchSourceContext.of(true, null, new String[] { "nested_field" });
 
         ExtractedFieldsDetector extractedFieldsDetector = new ExtractedFieldsDetector(
             buildOutlierDetectionConfig(),
@@ -1423,7 +1423,7 @@ public class ExtractedFieldsDetectorTests extends ESTestCase {
 
     public void testDetect_givenFeatureProcessorsFailures_BadSourceFiltering() {
         FieldCapabilitiesResponse fieldCapabilities = simpleFieldResponse();
-        sourceFiltering = new FetchSourceContext(true, null, new String[] { "field_1*" });
+        sourceFiltering = FetchSourceContext.of(true, null, new String[] { "field_1*" });
         ExtractedFieldsDetector extractedFieldsDetector = new ExtractedFieldsDetector(
             buildRegressionConfig("field_31", Arrays.asList(buildPreProcessor("field_11", "foo"))),
             100,
@@ -1437,7 +1437,7 @@ public class ExtractedFieldsDetectorTests extends ESTestCase {
 
     public void testDetect_givenFeatureProcessorsFailures_MissingAnalyzedField() {
         FieldCapabilitiesResponse fieldCapabilities = simpleFieldResponse();
-        analyzedFields = new FetchSourceContext(true, null, new String[] { "field_1*" });
+        analyzedFields = FetchSourceContext.of(true, null, new String[] { "field_1*" });
         ExtractedFieldsDetector extractedFieldsDetector = new ExtractedFieldsDetector(
             buildRegressionConfig("field_31", Arrays.asList(buildPreProcessor("field_11", "foo"))),
             100,


### PR DESCRIPTION
Saw tons of duplicate instances of this one in a recent heap dump analysis. Obviously a small improvement but still -> use singletons for this whenever possible to a save a few objects here and there.
