### PR TITLE
Speed up MetadataStateFormat Writes

### DIFF
--- a/docs/changelog/85138.yaml
+++ b/docs/changelog/85138.yaml
@@ -1,0 +1,5 @@
+pr: 85138
+summary: Speed up `MetadataStateFormat` Writes
+area: Cluster Coordination
+type: enhancement
+issues: []

--- a/server/src/main/java/org/elasticsearch/env/NodeEnvironment.java
+++ b/server/src/main/java/org/elasticsearch/env/NodeEnvironment.java
@@ -56,7 +56,6 @@ import org.elasticsearch.xcontent.NamedXContentRegistry;
 import java.io.Closeable;
 import java.io.IOException;
 import java.io.UncheckedIOException;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.AtomicMoveNotSupportedException;
 import java.nio.file.DirectoryStream;
 import java.nio.file.FileStore;
@@ -298,7 +297,7 @@ public final class NodeEnvironment implements Closeable {
                     final String content = "written by Elasticsearch v"
                         + Version.CURRENT
                         + " to prevent a downgrade to a version prior to v8.0.0 which would result in data loss";
-                    Files.write(legacyNodesPath, content.getBytes(StandardCharsets.UTF_8));
+                    Files.writeString(legacyNodesPath, content);
                     IOUtils.fsync(legacyNodesPath, false);
                     IOUtils.fsync(dataPath, true);
                 }
@@ -851,8 +850,9 @@ public final class NodeEnvironment implements Closeable {
         final InternalShardLock shardLock;
         final boolean acquired;
         synchronized (shardLocks) {
-            if (shardLocks.containsKey(shardId)) {
-                shardLock = shardLocks.get(shardId);
+            final InternalShardLock found = shardLocks.get(shardId);
+            if (found != null) {
+                shardLock = found;
                 shardLock.incWaitCount();
                 acquired = false;
             } else {

--- a/server/src/main/java/org/elasticsearch/env/ShardLockObtainFailedException.java
+++ b/server/src/main/java/org/elasticsearch/env/ShardLockObtainFailedException.java
@@ -34,10 +34,6 @@ public class ShardLockObtainFailedException extends ElasticsearchException {
     }
 
     private static String buildMessage(ShardId shardId, String message) {
-        StringBuilder sb = new StringBuilder();
-        sb.append(shardId.toString());
-        sb.append(": ");
-        sb.append(message);
-        return sb.toString();
+        return shardId.toString() + ": " + message;
     }
 }

--- a/server/src/test/java/org/elasticsearch/gateway/MetadataStateFormatTests.java
+++ b/server/src/test/java/org/elasticsearch/gateway/MetadataStateFormatTests.java
@@ -280,7 +280,6 @@ public class MetadataStateFormatTests extends ESTestCase {
 
         for (int i = 0; i < randomIntBetween(1, 5); i++) {
             format.failOnMethods(
-                Format.FAIL_DELETE_TMP_FILE,
                 Format.FAIL_CREATE_OUTPUT_FILE,
                 Format.FAIL_WRITE_TO_OUTPUT_FILE,
                 Format.FAIL_FSYNC_TMP_FILE,

--- a/server/src/test/java/org/elasticsearch/gateway/MetadataStateFormatTests.java
+++ b/server/src/test/java/org/elasticsearch/gateway/MetadataStateFormatTests.java
@@ -279,7 +279,7 @@ public class MetadataStateFormatTests extends ESTestCase {
         DummyState initialState = writeAndReadStateSuccessfully(format, path);
 
         for (int i = 0; i < randomIntBetween(1, 5); i++) {
-            format.failOnMethods(
+            format.failOnRandomMethod(
                 Format.FAIL_CREATE_OUTPUT_FILE,
                 Format.FAIL_WRITE_TO_OUTPUT_FILE,
                 Format.FAIL_FSYNC_TMP_FILE,
@@ -302,6 +302,30 @@ public class MetadataStateFormatTests extends ESTestCase {
         writeAndReadStateSuccessfully(format, path);
     }
 
+    public void testHandleExistingTmpFile() throws IOException {
+        Path path = createTempDir();
+        Format format = new Format("foo-");
+
+        DummyState initialState = writeAndReadStateSuccessfully(format, path);
+
+        format.failOnMethods(Format.FAIL_FSYNC_TMP_FILE, Format.FAIL_DELETE_TMP_FILE);
+        DummyState newState = new DummyState(
+            randomRealisticUnicodeOfCodepointLengthBetween(1, 100),
+            randomInt(),
+            randomLong(),
+            randomDouble(),
+            randomBoolean()
+        );
+        WriteStateException ex = expectThrows(WriteStateException.class, () -> format.writeAndCleanup(newState, path));
+        assertFalse(ex.isDirty());
+
+        format.noFailures();
+        assertEquals(initialState, format.loadLatestState(logger, NamedXContentRegistry.EMPTY, path));
+        format.writeAndCleanup(newState, path);
+        assertEquals(newState, format.loadLatestState(logger, NamedXContentRegistry.EMPTY, path));
+        writeAndReadStateSuccessfully(format, path);
+    }
+
     public void testFailWriteAndReadAnyState() throws IOException {
         Path path = createTempDir();
         Format format = new Format("foo-");
@@ -311,7 +335,7 @@ public class MetadataStateFormatTests extends ESTestCase {
         possibleStates.add(initialState);
 
         for (int i = 0; i < randomIntBetween(1, 5); i++) {
-            format.failOnMethods(Format.FAIL_FSYNC_STATE_DIRECTORY);
+            format.failOnRandomMethod(Format.FAIL_FSYNC_STATE_DIRECTORY);
             DummyState newState = new DummyState(
                 randomRealisticUnicodeOfCodepointLengthBetween(1, 100),
                 randomInt(),
@@ -340,7 +364,7 @@ public class MetadataStateFormatTests extends ESTestCase {
         DummyState initialState = writeAndReadStateSuccessfully(format, paths);
 
         for (int i = 0; i < randomIntBetween(1, 5); i++) {
-            format.failOnMethods(Format.FAIL_OPEN_STATE_FILE_WHEN_COPYING);
+            format.failOnRandomMethod(Format.FAIL_OPEN_STATE_FILE_WHEN_COPYING);
             DummyState newState = new DummyState(
                 randomRealisticUnicodeOfCodepointLengthBetween(1, 100),
                 randomInt(),
@@ -432,7 +456,7 @@ public class MetadataStateFormatTests extends ESTestCase {
         Path badPath = paths[paths.length - 1];
 
         format.failOnPaths(badPath.resolve(MetadataStateFormat.STATE_DIR_NAME));
-        format.failOnMethods(Format.FAIL_RENAME_TMP_FILE);
+        format.failOnRandomMethod(Format.FAIL_RENAME_TMP_FILE);
 
         DummyState newState = new DummyState(
             randomRealisticUnicodeOfCodepointLengthBetween(1, 100),
@@ -523,7 +547,7 @@ public class MetadataStateFormatTests extends ESTestCase {
         final int badDirIndex = 1;
 
         format.failOnPaths(paths[badDirIndex].resolve(MetadataStateFormat.STATE_DIR_NAME));
-        format.failOnMethods(Format.FAIL_DELETE_TMP_FILE);
+        format.failOnRandomMethod(Format.FAIL_DELETE_TMP_FILE);
 
         // Ensure clean-up old files doesn't fail with one bad dir. We pretend we want to
         // keep a newer generation that doesn't exist (genId + 1).
@@ -545,6 +569,7 @@ public class MetadataStateFormatTests extends ESTestCase {
         private enum FailureMode {
             NO_FAILURES,
             FAIL_ON_METHOD,
+            FAIL_MULTIPLE_METHODS,
             FAIL_RANDOMLY
         }
 
@@ -564,8 +589,8 @@ public class MetadataStateFormatTests extends ESTestCase {
         /**
          * Constructs a MetadataStateFormat object for storing/retrieving DummyState.
          * By default no I/O failures are injected.
-         * I/O failure behaviour can be controlled by {@link #noFailures()}, {@link #failOnMethods(String...)} and
-         * {@link #failRandomly()} method calls.
+         * I/O failure behaviour can be controlled by {@link #noFailures()}, {@link #failOnRandomMethod(String...)},
+         * {@link #failOnMethods(String...)} and {@link #failRandomly()} method calls.
          */
         Format(String prefix) {
             super(prefix);
@@ -586,8 +611,13 @@ public class MetadataStateFormatTests extends ESTestCase {
             this.failureMode = FailureMode.NO_FAILURES;
         }
 
-        public void failOnMethods(String... failureMethods) {
+        public void failOnRandomMethod(String... failureMethods) {
             this.failureMode = FailureMode.FAIL_ON_METHOD;
+            this.failureMethods = failureMethods;
+        }
+
+        public void failOnMethods(String... failureMethods) {
+            this.failureMode = FailureMode.FAIL_MULTIPLE_METHODS;
             this.failureMethods = failureMethods;
         }
 
@@ -614,7 +644,20 @@ public class MetadataStateFormatTests extends ESTestCase {
         @Override
         protected Directory newDirectory(Path dir) {
             MockDirectoryWrapper mock = newMockFSDirectory(dir);
-            if (failureMode == FailureMode.FAIL_ON_METHOD) {
+            if (failureMode == FailureMode.FAIL_MULTIPLE_METHODS) {
+                final Set<String> failMethods = Set.of(failureMethods);
+                MockDirectoryWrapper.Failure fail = new MockDirectoryWrapper.Failure() {
+                    @Override
+                    public void eval(MockDirectoryWrapper directory) throws IOException {
+                        for (StackTraceElement e : Thread.currentThread().getStackTrace()) {
+                            if (failMethods.contains(e.getMethodName())) {
+                                throwDirectoryExceptionCheckPaths(dir);
+                            }
+                        }
+                    }
+                };
+                mock.failOn(fail);
+            } else if (failureMode == FailureMode.FAIL_ON_METHOD) {
                 final String failMethod = randomFrom(failureMethods);
                 MockDirectoryWrapper.Failure fail = new MockDirectoryWrapper.Failure() {
                     @Override


### PR DESCRIPTION
There's some needless deleting and exists checking here that gets quite expensive
in tests and in some benchmarks. We can save quite a few system calls
and IO by doing what `FsBlobContainer` does and optimistically attempt
writes that will essentially always work out.
The deletes of the temp paths are also noops unless there's an exception so we can
skip those as well.
Lastly, `Path.resolve` isn't free or even cheap in some cases, so I added some guards
around trace logging for it.

This speeds up tests by a couple of seconds on each `:server:check` run and saves IOPS
in production as well.
