### PR TITLE
User profiles: fix search action to support query source param

### DIFF
--- a/docs/changelog/85139.yaml
+++ b/docs/changelog/85139.yaml
@@ -1,6 +1,0 @@
-pr: 85139
-summary: "User profiles: fix search action to support query source param"
-area: Security
-type: bug
-issues:
- - 85090

--- a/docs/changelog/85139.yaml
+++ b/docs/changelog/85139.yaml
@@ -1,0 +1,6 @@
+pr: 85139
+summary: "User profiles: fix search action to support query source param"
+area: Security
+type: bug
+issues:
+ - 85090

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/rest/action/profile/RestSearchProfilesAction.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/rest/action/profile/RestSearchProfilesAction.java
@@ -56,7 +56,9 @@ public class RestSearchProfilesAction extends SecurityBaseRestHandler {
     @Override
     protected RestChannelConsumer innerPrepareRequest(RestRequest request, NodeClient client) throws IOException {
         final Set<String> dataKeys = Strings.tokenizeByCommaToSet(request.param("data", null));
-        final Payload payload = request.hasContent() ? PARSER.parse(request.contentParser(), null) : new Payload(null, null);
+        final Payload payload = request.hasContentOrSourceParam()
+            ? PARSER.parse(request.contentOrSourceParamParser(), null)
+            : new Payload(null, null);
 
         final SearchProfilesRequest searchProfilesRequest = new SearchProfilesRequest(dataKeys, payload.name(), payload.size());
         return channel -> client.execute(SearchProfilesAction.INSTANCE, searchProfilesRequest, new RestToXContentListener<>(channel));

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/rest/action/profile/RestSearchProfilesActionTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/rest/action/profile/RestSearchProfilesActionTests.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.security.rest.action.profile;
+
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.license.XPackLicenseState;
+import org.elasticsearch.rest.RestRequest;
+import org.elasticsearch.test.rest.FakeRestRequest;
+import org.elasticsearch.test.rest.RestActionTestCase;
+import org.elasticsearch.xcontent.NamedXContentRegistry;
+import org.elasticsearch.xpack.core.XPackSettings;
+import org.elasticsearch.xpack.core.security.action.profile.SearchProfilesRequest;
+import org.elasticsearch.xpack.core.security.action.profile.SearchProfilesResponse;
+import org.junit.Before;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.mockito.Mockito.mock;
+
+public class RestSearchProfilesActionTests extends RestActionTestCase {
+    private Settings settings;
+    private XPackLicenseState licenseState;
+    private AtomicReference<SearchProfilesRequest> requestHolder;
+
+    @Before
+    public void init() {
+        settings = Settings.builder().put(XPackSettings.SECURITY_ENABLED.getKey(), true).build();
+        licenseState = mock(XPackLicenseState.class);
+        requestHolder = new AtomicReference<>();
+        controller().registerHandler(new RestSearchProfilesAction(settings, licenseState));
+        verifyingClient.setExecuteVerifier(((actionType, actionRequest) -> {
+            assertThat(actionRequest, instanceOf(SearchProfilesRequest.class));
+            requestHolder.set((SearchProfilesRequest) actionRequest);
+            return mock(SearchProfilesResponse.class);
+        }));
+    }
+
+    public void testInnerPrepareRequestWithEmptyTokenName() {
+        String expectedName = "bob";
+        final Map<String, String> params = new HashMap<>(
+            Map.of("source", "{\"name\":\"" + expectedName + "\"}", "source_content_type", "application/json")
+        );
+        final FakeRestRequest restRequest = new FakeRestRequest.Builder(NamedXContentRegistry.EMPTY).withMethod(RestRequest.Method.GET)
+            .withPath("/_security/profile/_search")
+            .withParams(params)
+            .build();
+
+        dispatchRequest(restRequest);
+
+        final SearchProfilesRequest searchProfilesRequest = requestHolder.get();
+        assertThat(searchProfilesRequest.getName(), equalTo(expectedName));
+    }
+}

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/rest/action/profile/RestSearchProfilesActionTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/rest/action/profile/RestSearchProfilesActionTests.java
@@ -44,15 +44,14 @@ public class RestSearchProfilesActionTests extends RestActionTestCase {
         }));
     }
 
-    public void testInnerPrepareRequestWithEmptyTokenName() {
+    public void testInnerPrepareRequestWithSourceParameter() {
         String expectedName = "bob";
         final Map<String, String> params = new HashMap<>(
             Map.of("source", "{\"name\":\"" + expectedName + "\"}", "source_content_type", "application/json")
         );
-        final FakeRestRequest restRequest = new FakeRestRequest.Builder(NamedXContentRegistry.EMPTY).withMethod(RestRequest.Method.GET)
-            .withPath("/_security/profile/_search")
-            .withParams(params)
-            .build();
+        final FakeRestRequest restRequest = new FakeRestRequest.Builder(NamedXContentRegistry.EMPTY).withMethod(
+            randomFrom(RestRequest.Method.GET, RestRequest.Method.POST)
+        ).withPath("/_security/profile/_search").withParams(params).build();
 
         dispatchRequest(restRequest);
 


### PR DESCRIPTION
Tweaks the search profiles action to accept request payload
encoded as source query param.

Closes #85090