### PR TITLE
Add code disclaimers about DES algorithms

### DIFF
--- a/libs/ssl-config/src/main/java/org/elasticsearch/common/ssl/PemUtils.java
+++ b/libs/ssl-config/src/main/java/org/elasticsearch/common/ssl/PemUtils.java
@@ -73,6 +73,24 @@ public final class PemUtils {
     private static final String PBES2_OID = "1.2.840.113549.1.5.13";
     private static final String AES_OID = "2.16.840.1.101.3.4.1";
 
+    /**
+     * <a href="https://docs.oracle.com/en/java/javase/17/docs/specs/security/standard-names.html">Standard Name</a> for the
+     * DES (<a href="https://en.wikipedia.org/wiki/Data_Encryption_Standard">Data Encryption Standard</a>)
+     * encryption algorithm.
+     * This algorithm is obsolete and should not be used, <em>however</em> many historical versions of OpenSSL would default to using
+     * DES (or {@link #DEPRECATED_DES_EDE_ALGORITHM DESede}) encryption, so we continue to support reading PEM files that are encrypted
+     * using this algorithm
+     */
+    private static final String DEPRECATED_DES_ALGORITHM = "DES";
+    /**
+     * <a href="https://docs.oracle.com/en/java/javase/17/docs/specs/security/standard-names.html">Standard Name</a> for the DES encryption
+     * algorithm in Encrypt-Decrypt-Encrypt mode (that is, <a href="https://en.wikipedia.org/wiki/Triple_DES">Triple DES</a>).
+     * This algorithm is obsolete and should not be used, <em>however</em> many historical versions of OpenSSL would default to using
+     * DESede (specified in PEM as {@code DES-EDE3-CBC}), so we continue to support reading PEM files that are encrypted using this
+     * algorithm.
+     */
+    private static final String DEPRECATED_DES_EDE_ALGORITHM = "DESede";
+
     private PemUtils() {
         throw new IllegalStateException("Utility class should not be instantiated");
     }
@@ -497,10 +515,10 @@ public final class PemUtils {
         }
         if ("DES-CBC".equals(algorithm)) {
             byte[] key = generateOpenSslKey(password, iv, 8);
-            encryptionKey = new SecretKeySpec(key, "DES");
+            encryptionKey = new SecretKeySpec(key, DEPRECATED_DES_ALGORITHM);
         } else if ("DES-EDE3-CBC".equals(algorithm)) {
             byte[] key = generateOpenSslKey(password, iv, 24);
-            encryptionKey = new SecretKeySpec(key, "DESede");
+            encryptionKey = new SecretKeySpec(key, DEPRECATED_DES_EDE_ALGORITHM);
         } else if ("AES-128-CBC".equals(algorithm)) {
             byte[] key = generateOpenSslKey(password, iv, 16);
             encryptionKey = new SecretKeySpec(key, "AES");


### PR DESCRIPTION
For compatibility reasons we support reading PEM files that are
encrypted using DES or TripleDES (DESede). This is necessary because
many historical versions of OpenSSL would default to using these
algorithms and there are a lot of PEM files that require DES parsing
support.

However, there is a risk that this DES code could be copied to other
places, or used as an example of how to perform encryption.
This commit extracts the DES identifiers into appropriately named and
documents constants to explain that their use is for compatibility
only and that DES (and DESede) should not be considered safe for
general encryption needs.

Note: This DES support is for decrypting the contents of a
password-protected PEM file (that is, for a private key). The
encryption format of the file contents does not affect how the
key-pair is used for on-the-wire encryption.
