### PR TITLE
[Doc]Fix MapperService#getEagerGlobalOrdinalsFields' java doc

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/mapper/MapperService.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/MapperService.java
@@ -451,7 +451,7 @@ public class MapperService extends AbstractIndexComponent implements Closeable {
     }
 
     /**
-     * Returns all mapped field types.
+     * Returns field types that have eager global ordinals.
      */
     public Iterable<MappedFieldType> getEagerGlobalOrdinalsFields() {
         DocumentMapper mapper = this.mapper;


### PR DESCRIPTION
In [#64983](https://github.com/elastic/elasticsearch/pull/64983), @javanna replaced method `fieldTypes()` with method `getEagerGlobalOrdinalsFields()`, but java doc was not updated.
This PR updates java doc for `MapperService#getEagerGlobalOrdinalsFields()`.