### PR TITLE
Rewrite match and match_phrase queries to term queries on keyword fields

### DIFF
--- a/docs/changelog/85165.yaml
+++ b/docs/changelog/85165.yaml
@@ -1,0 +1,6 @@
+pr: 85165
+summary: Rewrite match and `match_phrase` queries to term queries on keyword fields
+area: Search
+type: bug
+issues:
+ - 82515

--- a/qa/full-cluster-restart/src/test/java/org/elasticsearch/upgrades/QueryBuilderBWCIT.java
+++ b/qa/full-cluster-restart/src/test/java/org/elasticsearch/upgrades/QueryBuilderBWCIT.java
@@ -63,27 +63,27 @@ public class QueryBuilderBWCIT extends AbstractFullClusterRestartTestCase {
     private static final List<Object[]> CANDIDATES = new ArrayList<>();
 
     static {
-        addCandidate("\"match\": { \"keyword_field\": \"value\"}", new MatchQueryBuilder("keyword_field", "value"));
+        addCandidate("\"match\": { \"text_field\": \"value\"}", new MatchQueryBuilder("text_field", "value"));
         addCandidate(
-            "\"match\": { \"keyword_field\": {\"query\": \"value\", \"operator\": \"and\"} }",
-            new MatchQueryBuilder("keyword_field", "value").operator(Operator.AND)
+            "\"match\": { \"text_field\": {\"query\": \"value\", \"operator\": \"and\"} }",
+            new MatchQueryBuilder("text_field", "value").operator(Operator.AND)
         );
         addCandidate(
-            "\"match\": { \"keyword_field\": {\"query\": \"value\", \"analyzer\": \"english\"} }",
-            new MatchQueryBuilder("keyword_field", "value").analyzer("english")
+            "\"match\": { \"text_field\": {\"query\": \"value\", \"analyzer\": \"english\"} }",
+            new MatchQueryBuilder("text_field", "value").analyzer("english")
         );
         addCandidate(
-            "\"match\": { \"keyword_field\": {\"query\": \"value\", \"minimum_should_match\": 3} }",
-            new MatchQueryBuilder("keyword_field", "value").minimumShouldMatch("3")
+            "\"match\": { \"text_field\": {\"query\": \"value\", \"minimum_should_match\": 3} }",
+            new MatchQueryBuilder("text_field", "value").minimumShouldMatch("3")
         );
         addCandidate(
-            "\"match\": { \"keyword_field\": {\"query\": \"value\", \"fuzziness\": \"auto\"} }",
-            new MatchQueryBuilder("keyword_field", "value").fuzziness(Fuzziness.AUTO)
+            "\"match\": { \"text_field\": {\"query\": \"value\", \"fuzziness\": \"auto\"} }",
+            new MatchQueryBuilder("text_field", "value").fuzziness(Fuzziness.AUTO)
         );
-        addCandidate("\"match_phrase\": { \"keyword_field\": \"value\"}", new MatchPhraseQueryBuilder("keyword_field", "value"));
+        addCandidate("\"match_phrase\": { \"text_field\": \"value\"}", new MatchPhraseQueryBuilder("text_field", "value"));
         addCandidate(
-            "\"match_phrase\": { \"keyword_field\": {\"query\": \"value\", \"slop\": 3}}",
-            new MatchPhraseQueryBuilder("keyword_field", "value").slop(3)
+            "\"match_phrase\": { \"text_field\": {\"query\": \"value\", \"slop\": 3}}",
+            new MatchPhraseQueryBuilder("text_field", "value").slop(3)
         );
         addCandidate("\"range\": { \"long_field\": {\"gte\": 1, \"lte\": 9}}", new RangeQueryBuilder("long_field").from(1).to(9));
         addCandidate(
@@ -170,6 +170,11 @@ public class QueryBuilderBWCIT extends AbstractFullClusterRestartTestCase {
                 {
                     mappingsAndSettings.startObject("keyword_field");
                     mappingsAndSettings.field("type", "keyword");
+                    mappingsAndSettings.endObject();
+                }
+                {
+                    mappingsAndSettings.startObject("text_field");
+                    mappingsAndSettings.field("type", "text");
                     mappingsAndSettings.endObject();
                 }
                 {

--- a/server/src/main/java/org/elasticsearch/index/query/MatchPhraseQueryBuilder.java
+++ b/server/src/main/java/org/elasticsearch/index/query/MatchPhraseQueryBuilder.java
@@ -8,12 +8,15 @@
 
 package org.elasticsearch.index.query;
 
+import org.apache.lucene.analysis.core.KeywordAnalyzer;
 import org.apache.lucene.search.Query;
 import org.elasticsearch.Version;
 import org.elasticsearch.common.ParsingException;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.index.analysis.NamedAnalyzer;
+import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.search.MatchQueryParser;
 import org.elasticsearch.xcontent.ParseField;
 import org.elasticsearch.xcontent.XContentBuilder;
@@ -151,6 +154,35 @@ public class MatchPhraseQueryBuilder extends AbstractQueryBuilder<MatchPhraseQue
         printBoostAndQueryName(builder);
         builder.endObject();
         builder.endObject();
+    }
+
+    @Override
+    protected QueryBuilder doRewrite(QueryRewriteContext queryRewriteContext) throws IOException {
+        SearchExecutionContext sec = queryRewriteContext.convertToSearchExecutionContext();
+        if (sec == null) {
+            return this;
+        }
+        // If we're using the default keyword analyzer then we can rewrite this to a TermQueryBuilder
+        // and possibly shortcut
+        // If we're using a keyword analyzer then we can rewrite this to a TermQueryBuilder
+        // and possibly shortcut
+        NamedAnalyzer configuredAnalyzer = configuredAnalyzer(sec);
+        if (configuredAnalyzer != null && configuredAnalyzer.analyzer() instanceof KeywordAnalyzer) {
+            TermQueryBuilder termQueryBuilder = new TermQueryBuilder(fieldName, value);
+            return termQueryBuilder.rewrite(sec);
+        }
+        return this;
+    }
+
+    private NamedAnalyzer configuredAnalyzer(SearchExecutionContext context) {
+        if (analyzer != null) {
+            return context.getIndexAnalyzers().get(analyzer);
+        }
+        MappedFieldType mft = context.getFieldType(fieldName);
+        if (mft != null) {
+            return mft.getTextSearchInfo().getSearchAnalyzer();
+        }
+        return null;
     }
 
     @Override


### PR DESCRIPTION
Term queries can in certain circumstances (eg when run against constant keyword
fields) rewrite themselves to match_no_docs queries, which is very useful for filtering
out shards from searches and field_caps requests. But match and match_phrase
queries can reduce down to simple term queries when there is no fuzziness defined
on them, and when they are run using a keyword analyzer.

This commit makes simple match and match_phrase rewrite themselves to term
queries when run against keyword fields.

Fixes #82515