### PR TITLE
Disable shards rebalancing in IndexDiskUsageAnalyzerIT

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/action/admin/indices/diskusage/IndexDiskUsageAnalyzerIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/action/admin/indices/diskusage/IndexDiskUsageAnalyzerIT.java
@@ -304,6 +304,7 @@ public class IndexDiskUsageAnalyzerIT extends ESIntegTestCase {
             .setSettings(
                 Settings.builder()
                     .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, numberOfShards)
+                    .put("index.routing.rebalance.enable", "none")
                     .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 0)
             )
             .get();


### PR DESCRIPTION
To avoid failing and counting shards that are being relocated

Closes #85158