### PR TITLE
Test 1 issuer, 2 realms, different client secrets

### DIFF
--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/jwt/JwtRealmAuthenticateTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/jwt/JwtRealmAuthenticateTests.java
@@ -15,7 +15,9 @@ import com.nimbusds.jwt.SignedJWT;
 
 import org.elasticsearch.action.support.PlainActionFuture;
 import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.settings.MockSecureSettings;
 import org.elasticsearch.common.settings.SecureString;
+import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.settings.SettingsException;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.xpack.core.security.authc.AuthenticationResult;
@@ -24,6 +26,7 @@ import org.elasticsearch.xpack.core.security.authc.RealmSettings;
 import org.elasticsearch.xpack.core.security.authc.jwt.JwtRealmSettings;
 import org.elasticsearch.xpack.core.security.user.User;
 
+import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Date;
@@ -297,5 +300,73 @@ public class JwtRealmAuthenticateTests extends JwtRealmTestCase {
             final SecureString jwtExpPast = JwtValidateUtil.signJwt(algJwkPair.jwk(), new SignedJWT(jwtHeader, claimsSet));
             this.verifyAuthenticateFailureHelper(jwtIssuerAndRealm, jwtExpPast, clientSecret);
         }
+    }
+
+    /**
+     * Configure two realms for same issuer. Use identical realm config, except different client secrets.
+     * Generate a JWT which is valid for both realms, but verify authentication only succeeds for second realm due to the client secret.
+     * @throws Exception Unexpected test failure
+     */
+    public void testSameIssuerTwoRealmsDifferentClientSecrets() throws Exception {
+        final int realmsCount = 2;
+        final List<Realm> allRealms = new ArrayList<>(realmsCount); // two identical realms for same issuer, except different client secret
+        final JwtIssuer jwtIssuer = this.createJwtIssuer(0, 12, 1, 1, 1, false);
+        this.jwtIssuerAndRealms = new ArrayList<>(realmsCount);
+        for (int i = 0; i < realmsCount; i++) {
+            final String realmName = "realm_" + jwtIssuer.issuer + "_" + i;
+            final String clientSecret = "clientSecret_" + jwtIssuer.issuer + "_" + i;
+
+            final Settings.Builder authcSettings = Settings.builder()
+                .put(this.globalSettings)
+                .put(RealmSettings.getFullSettingKey(realmName, JwtRealmSettings.ALLOWED_ISSUER), jwtIssuer.issuer)
+                .put(
+                    RealmSettings.getFullSettingKey(realmName, JwtRealmSettings.ALLOWED_SIGNATURE_ALGORITHMS),
+                    String.join(",", jwtIssuer.algorithmsAll)
+                )
+                .put(RealmSettings.getFullSettingKey(realmName, JwtRealmSettings.ALLOWED_AUDIENCES), jwtIssuer.audiences.get(0))
+                .put(RealmSettings.getFullSettingKey(realmName, JwtRealmSettings.CLAIMS_PRINCIPAL.getClaim()), "sub")
+                .put(
+                    RealmSettings.getFullSettingKey(realmName, JwtRealmSettings.CLIENT_AUTHENTICATION_TYPE),
+                    JwtRealmSettings.ClientAuthenticationType.SHARED_SECRET.value()
+                );
+            if (Strings.hasText(jwtIssuer.encodedJwkSetPkcPublic)) {
+                authcSettings.put(
+                    RealmSettings.getFullSettingKey(realmName, JwtRealmSettings.PKC_JWKSET_PATH),
+                    super.saveToTempFile("jwkset.", ".json", jwtIssuer.encodedJwkSetPkcPublic.getBytes(StandardCharsets.UTF_8))
+                );
+            }
+            // JWT authc realm secure settings
+            final MockSecureSettings secureSettings = new MockSecureSettings();
+            if (Strings.hasText(jwtIssuer.encodedJwkSetHmac)) {
+                secureSettings.setString(
+                    RealmSettings.getFullSettingKey(realmName, JwtRealmSettings.HMAC_JWKSET),
+                    jwtIssuer.encodedJwkSetHmac
+                );
+            }
+            if (Strings.hasText(jwtIssuer.encodedKeyHmacOidc)) {
+                secureSettings.setString(
+                    RealmSettings.getFullSettingKey(realmName, JwtRealmSettings.HMAC_KEY),
+                    jwtIssuer.encodedKeyHmacOidc
+                );
+            }
+            secureSettings.setString(
+                RealmSettings.getFullSettingKey(realmName, JwtRealmSettings.CLIENT_AUTHENTICATION_SHARED_SECRET),
+                clientSecret
+            );
+            authcSettings.setSecureSettings(secureSettings);
+            final JwtRealmNameAndSettingsBuilder realmNameAndSettingsBuilder = new JwtRealmNameAndSettingsBuilder(realmName, authcSettings);
+            final JwtRealm jwtRealm = this.createJwtRealm(allRealms, jwtIssuer, realmNameAndSettingsBuilder);
+            jwtRealm.initialize(allRealms, super.licenseState);
+            final JwtIssuerAndRealm jwtIssuerAndRealm = new JwtIssuerAndRealm(jwtIssuer, jwtRealm, realmNameAndSettingsBuilder);
+            this.jwtIssuerAndRealms.add(jwtIssuerAndRealm); // add them so the test will clean them up
+        }
+
+        // pick 2nd realm and use its secret, verify 2nd realm does authc, which implies 1st realm rejects the secret
+        final JwtIssuerAndRealm jwtIssuerAndRealm = this.jwtIssuerAndRealms.get(1);
+        final User user = this.randomUser(jwtIssuerAndRealm.issuer());
+        final SecureString jwt = this.randomJwt(jwtIssuerAndRealm, user);
+        final SecureString clientSecret = jwtIssuerAndRealm.realm().clientAuthenticationSharedSecret;
+        final MinMax jwtAuthcRange = new MinMax(2, 3);
+        this.multipleRealmsAuthenticateJwtHelper(jwtIssuerAndRealm.realm(), user, jwt, clientSecret, jwtAuthcRange);
     }
 }


### PR DESCRIPTION
Goal of this PR is to add a test.

Consider two realms configured to verify the same JWT from the same JWT issuer, but each realm has different client secrets. If a request contains the secret for the 2nd realm, the first realm should reject the request, and allow continuation to the 2nd realm for successful authentication.