### PR TITLE
Wrap thread creation in doPrivileged call

### DIFF
--- a/docs/changelog/85180.yaml
+++ b/docs/changelog/85180.yaml
@@ -1,0 +1,5 @@
+pr: 85180
+summary: Wrap thread creation in `doPrivileged` call
+area: Infra/Core
+type: bug
+issues: []

--- a/server/src/main/java/org/elasticsearch/common/util/concurrent/EsExecutors.java
+++ b/server/src/main/java/org/elasticsearch/common/util/concurrent/EsExecutors.java
@@ -15,6 +15,8 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.core.SuppressForbidden;
 import org.elasticsearch.node.Node;
 
+import java.security.AccessController;
+import java.security.PrivilegedAction;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.AbstractExecutorService;
@@ -270,9 +272,11 @@ public class EsExecutors {
 
         @Override
         public Thread newThread(Runnable r) {
-            Thread t = new Thread(group, r, namePrefix + "[T#" + threadNumber.getAndIncrement() + "]", 0);
-            t.setDaemon(true);
-            return t;
+            return AccessController.doPrivileged((PrivilegedAction<Thread>) () -> {
+                Thread t = new Thread(group, r, namePrefix + "[T#" + threadNumber.getAndIncrement() + "]", 0);
+                t.setDaemon(true);
+                return t;
+            });
         }
 
     }


### PR DESCRIPTION
EsExecutors has a thread factory for thread construction, and both
creates a thread in a given thread group and sets it as a daemon thread.
Currently that thread creation happens in the access control context of
the calling code, but this could happen from anywhere inside
Elasticsearch. Since the point of EsExecutors is be the one place
handling thread creation (for the most part), this should happen in the
context of server, without caring about the whatever code triggered the
thread pool to expand.