### PR TITLE
[7.17] Wrap thread creation in doPrivileged call (#85180)

### DIFF
--- a/docs/changelog/85180.yaml
+++ b/docs/changelog/85180.yaml
@@ -1,0 +1,5 @@
+pr: 85180
+summary: Wrap thread creation in `doPrivileged` call
+area: Infra/Core
+type: bug
+issues: []

--- a/server/src/main/java/org/elasticsearch/common/util/concurrent/EsExecutors.java
+++ b/server/src/main/java/org/elasticsearch/common/util/concurrent/EsExecutors.java
@@ -18,6 +18,8 @@ import org.elasticsearch.core.SuppressForbidden;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.node.Node;
 
+import java.security.AccessController;
+import java.security.PrivilegedAction;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.AbstractExecutorService;
@@ -335,9 +337,11 @@ public class EsExecutors {
 
         @Override
         public Thread newThread(Runnable r) {
-            Thread t = new Thread(group, r, namePrefix + "[T#" + threadNumber.getAndIncrement() + "]", 0);
-            t.setDaemon(true);
-            return t;
+            return AccessController.doPrivileged((PrivilegedAction<Thread>) () -> {
+                Thread t = new Thread(group, r, namePrefix + "[T#" + threadNumber.getAndIncrement() + "]", 0);
+                t.setDaemon(true);
+                return t;
+            });
         }
 
     }


### PR DESCRIPTION
Backports the following commits to 7.17:
 - Wrap thread creation in doPrivileged call (#85180)