### PR TITLE
[8.1] Wrap thread creation in doPrivileged call (#85180)

### DIFF
--- a/docs/changelog/85180.yaml
+++ b/docs/changelog/85180.yaml
@@ -1,0 +1,5 @@
+pr: 85180
+summary: Wrap thread creation in `doPrivileged` call
+area: Infra/Core
+type: bug
+issues: []

--- a/server/src/main/java/org/elasticsearch/common/util/concurrent/EsExecutors.java
+++ b/server/src/main/java/org/elasticsearch/common/util/concurrent/EsExecutors.java
@@ -15,6 +15,8 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.core.SuppressForbidden;
 import org.elasticsearch.node.Node;
 
+import java.security.AccessController;
+import java.security.PrivilegedAction;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.AbstractExecutorService;
@@ -270,9 +272,11 @@ public class EsExecutors {
 
         @Override
         public Thread newThread(Runnable r) {
-            Thread t = new Thread(group, r, namePrefix + "[T#" + threadNumber.getAndIncrement() + "]", 0);
-            t.setDaemon(true);
-            return t;
+            return AccessController.doPrivileged((PrivilegedAction<Thread>) () -> {
+                Thread t = new Thread(group, r, namePrefix + "[T#" + threadNumber.getAndIncrement() + "]", 0);
+                t.setDaemon(true);
+                return t;
+            });
         }
 
     }


### PR DESCRIPTION
Backports the following commits to 8.1:
 - Wrap thread creation in doPrivileged call (#85180)