### PR TITLE
Support `fields` option on source-less indices

### DIFF
--- a/docs/changelog/85185.yaml
+++ b/docs/changelog/85185.yaml
@@ -1,0 +1,5 @@
+pr: 85185
+summary: Support `fields` option on source-less indices
+area: Search
+type: enhancement
+issues: []

--- a/rest-api-spec/build.gradle
+++ b/rest-api-spec/build.gradle
@@ -1,5 +1,4 @@
 import org.elasticsearch.gradle.Version
-import org.elasticsearch.gradle.internal.info.BuildParams
 
 apply plugin: 'elasticsearch.build'
 apply plugin: 'elasticsearch.publish'
@@ -74,6 +73,7 @@ tasks.named("yamlRestTestV7CompatTransform").configure { task ->
   task.skipTest("indices.create/10_basic/Create index without soft deletes", "Make soft-deletes mandatory in 8.0 #51122 - settings changes are note supported in Rest Api compatibility")
   task.skipTest("field_caps/30_filter/Field caps with index filter", "behaviour change after #63692 4digits dates are parsed as epoch and in quotes as year")
   task.skipTest("indices.forcemerge/10_basic/Check deprecation warning when incompatible only_expunge_deletes and max_num_segments values are both set", "#44761 bug fix")
+  task.skipTest("search/330_fetch_fields/Test disable source", "7.x expects this to fail against keyword fields but it doesn't any more")
   task.skipTest("search/340_type_query/type query", "#47207 type query throws exception in compatible mode")
   task.skipTest("search.aggregation/210_top_hits_nested_metric/top_hits aggregation with sequence numbers", "#42809 the use nested path and filter sort throws an exception")
   task.skipTest("search/310_match_bool_prefix/multi_match multiple fields with cutoff_frequency throws exception", "#42654 cutoff_frequency, common terms are not supported. Throwing an exception")

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search/330_fetch_fields.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search/330_fetch_fields.yml
@@ -94,7 +94,7 @@ setup:
               format: "yyyy/MM/dd"
 
 ---
-"Test disable source":
+"Test disable source from text":
   - do:
       indices.create:
         index:  test
@@ -105,15 +105,15 @@ setup:
             _source:
               enabled: false
             properties:
-              keyword:
-                type: keyword
+              text:
+                type: text
 
   - do:
       index:
         index:  test
         id:     "1"
         body:
-          keyword: [ "a" ]
+          text: [ "the quick brown fox jumped over the lazy dog" ]
 
   - do:
       indices.refresh:
@@ -124,10 +124,9 @@ setup:
       search:
         index: test
         body:
-          fields: [keyword]
+          fields: [text]
   - match: { error.root_cause.0.type: "illegal_argument_exception" }
-  - match: { error.root_cause.0.reason: "Unable to retrieve the requested [fields] since _source is disabled
-        in the mappings for index [test]" }
+  - match: { error.root_cause.0.reason: "error fetching [text]: Unable to retrieve values because _source is disabled in the mappings for index [test]" }
 
 ---
 "Test ignore malformed":

--- a/server/src/main/java/org/elasticsearch/index/mapper/BooleanFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/BooleanFieldMapper.java
@@ -193,17 +193,23 @@ public class BooleanFieldMapper extends FieldMapper {
             if (this.scriptValues != null) {
                 return FieldValues.valueFetcher(this.scriptValues, context);
             }
-            return new SourceValueFetcher(name(), context, nullValue) {
-                @Override
-                protected Boolean parseSourceValue(Object value) {
-                    if (value instanceof Boolean) {
-                        return (Boolean) value;
-                    } else {
-                        String textValue = value.toString();
-                        return Booleans.parseBoolean(textValue.toCharArray(), 0, textValue.length(), false);
+            if (context.isSourceEnabled()) {
+                return new SourceValueFetcher(name(), context, nullValue) {
+                    @Override
+                    protected Boolean parseSourceValue(Object value) {
+                        if (value instanceof Boolean) {
+                            return (Boolean) value;
+                        } else {
+                            String textValue = value.toString();
+                            return Booleans.parseBoolean(textValue.toCharArray(), 0, textValue.length(), false);
+                        }
                     }
-                }
-            };
+                };
+            }
+            if (hasDocValues()) {
+                return docValueFetcher(context, format);
+            }
+            throw errorForValueFetcherWithoutSourceOrDocValues(context);
         }
 
         @Override

--- a/server/src/main/java/org/elasticsearch/index/mapper/KeywordFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/KeywordFieldMapper.java
@@ -650,17 +650,23 @@ public final class KeywordFieldMapper extends FieldMapper {
             if (this.scriptValues != null) {
                 return FieldValues.valueFetcher(this.scriptValues, context);
             }
-            return new SourceValueFetcher(name(), context, nullValue) {
-                @Override
-                protected String parseSourceValue(Object value) {
-                    String keywordValue = value.toString();
-                    if (keywordValue.length() > ignoreAbove) {
-                        return null;
-                    }
+            if (context.isSourceEnabled()) {
+                return new SourceValueFetcher(name(), context, nullValue) {
+                    @Override
+                    protected String parseSourceValue(Object value) {
+                        String keywordValue = value.toString();
+                        if (keywordValue.length() > ignoreAbove) {
+                            return null;
+                        }
 
-                    return normalizeValue(normalizer(), name(), keywordValue);
-                }
-            };
+                        return normalizeValue(normalizer(), name(), keywordValue);
+                    }
+                };
+            }
+            if (hasDocValues()) {
+                return docValueFetcher(context, format);
+            }
+            throw errorForValueFetcherWithoutSourceOrDocValues(context);
         }
 
         @Override

--- a/server/src/main/java/org/elasticsearch/index/mapper/MappedFieldType.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/MappedFieldType.java
@@ -104,6 +104,25 @@ public abstract class MappedFieldType {
      */
     public abstract ValueFetcher valueFetcher(SearchExecutionContext context, @Nullable String format);
 
+    /**
+     * The error to use when attempting to a field that supports fetching from {@code _source} or doc
+     * values but neither an enabled.
+     */
+    protected final IllegalArgumentException errorForValueFetcherWithoutSourceOrDocValues(SearchExecutionContext context) {
+        return new IllegalArgumentException(
+            "Unable to retrieve values because _source is disabled in the mappings for index ["
+                + context.index().getName()
+                + "] and the field doesn't have doc values"
+        );
+    }
+
+    /**
+     * Create a helper class to fetch field values from doc values.
+     */
+    public final ValueFetcher docValueFetcher(SearchExecutionContext context, @Nullable String format) {
+        return new DocValueFetcher(docValueFormat(format, null), context.getForField(this));
+    }
+
     /** Returns the name of this type, as would be specified in mapping properties */
     public abstract String typeName();
 

--- a/server/src/main/java/org/elasticsearch/index/mapper/NumberFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/NumberFieldMapper.java
@@ -1344,15 +1344,21 @@ public class NumberFieldMapper extends FieldMapper {
             if (this.scriptValues != null) {
                 return FieldValues.valueFetcher(this.scriptValues, context);
             }
-            return new SourceValueFetcher(name(), context, nullValue) {
-                @Override
-                protected Object parseSourceValue(Object value) {
-                    if (value.equals("")) {
-                        return nullValue;
+            if (context.isSourceEnabled()) {
+                return new SourceValueFetcher(name(), context, nullValue) {
+                    @Override
+                    protected Object parseSourceValue(Object value) {
+                        if (value.equals("")) {
+                            return nullValue;
+                        }
+                        return type.parse(value, coerce);
                     }
-                    return type.parse(value, coerce);
-                }
-            };
+                };
+            }
+            if (hasDocValues()) {
+                return docValueFetcher(context, format);
+            }
+            throw errorForValueFetcherWithoutSourceOrDocValues(context);
         }
 
         @Override

--- a/server/src/main/java/org/elasticsearch/index/mapper/SourceValueFetcher.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/SourceValueFetcher.java
@@ -39,6 +39,11 @@ public abstract class SourceValueFetcher implements ValueFetcher {
      */
     public SourceValueFetcher(String fieldName, SearchExecutionContext context, Object nullValue) {
         this(context.sourcePath(fieldName), nullValue);
+        if (context.isSourceEnabled() == false) {
+            throw new IllegalArgumentException(
+                "Unable to retrieve values because _source is disabled in the mappings for index [" + context.index().getName() + "]"
+            );
+        }
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/search/fetch/subphase/FetchDocValuesPhase.java
+++ b/server/src/main/java/org/elasticsearch/search/fetch/subphase/FetchDocValuesPhase.java
@@ -9,7 +9,6 @@ package org.elasticsearch.search.fetch.subphase;
 
 import org.apache.lucene.index.LeafReaderContext;
 import org.elasticsearch.common.document.DocumentField;
-import org.elasticsearch.index.mapper.DocValueFetcher;
 import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.mapper.ValueFetcher;
 import org.elasticsearch.search.fetch.FetchContext;
@@ -44,10 +43,7 @@ public final class FetchDocValuesPhase implements FetchSubPhase {
             if (ft == null) {
                 continue;
             }
-            ValueFetcher fetcher = new DocValueFetcher(
-                ft.docValueFormat(fieldAndFormat.format, null),
-                context.searchLookup().getForField(ft)
-            );
+            ValueFetcher fetcher = ft.docValueFetcher(context.getSearchExecutionContext(), fieldAndFormat.format);
             fields.add(new DocValueField(fieldAndFormat.field, fetcher));
         }
 

--- a/server/src/main/java/org/elasticsearch/search/fetch/subphase/FetchFieldsPhase.java
+++ b/server/src/main/java/org/elasticsearch/search/fetch/subphase/FetchFieldsPhase.java
@@ -31,15 +31,6 @@ public final class FetchFieldsPhase implements FetchSubPhase {
             return null;
         }
 
-        if (fetchContext.getSearchExecutionContext().isSourceEnabled() == false) {
-            throw new IllegalArgumentException(
-                "Unable to retrieve the requested [fields] since _source is disabled "
-                    + "in the mappings for index ["
-                    + fetchContext.getIndexName()
-                    + "]"
-            );
-        }
-
         FieldFetcher fieldFetcher = FieldFetcher.create(fetchContext.getSearchExecutionContext(), fetchFieldsContext.fields());
 
         return new FetchSubPhaseProcessor() {

--- a/server/src/test/java/org/elasticsearch/index/mapper/BinaryFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/BinaryFieldMapperTests.java
@@ -136,4 +136,9 @@ public class BinaryFieldMapperTests extends MapperTestCase {
     protected boolean dedupAfterFetch() {
         return true;
     }
+
+    @Override
+    protected boolean supportsFetchWithSourceDisabled() {
+        return false;
+    }
 }

--- a/server/src/test/java/org/elasticsearch/index/mapper/NumberFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/NumberFieldMapperTests.java
@@ -330,5 +330,4 @@ public abstract class NumberFieldMapperTests extends MapperTestCase {
     }
 
     protected abstract Number randomNumber();
-
 }

--- a/server/src/test/java/org/elasticsearch/index/mapper/NumberFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/NumberFieldMapperTests.java
@@ -330,4 +330,5 @@ public abstract class NumberFieldMapperTests extends MapperTestCase {
     }
 
     protected abstract Number randomNumber();
+
 }

--- a/server/src/test/java/org/elasticsearch/index/mapper/TextFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/TextFieldMapperTests.java
@@ -1087,4 +1087,9 @@ public class TextFieldMapperTests extends MapperTestCase {
     protected void randomFetchTestFieldConfig(XContentBuilder b) throws IOException {
         assumeFalse("We don't have a way to assert things here", true);
     }
+
+    @Override
+    protected boolean supportsFetchWithSourceDisabled() {
+        return false;
+    }
 }

--- a/server/src/test/java/org/elasticsearch/index/mapper/flattened/KeyedFlattenedFieldTypeTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/flattened/KeyedFlattenedFieldTypeTests.java
@@ -177,7 +177,7 @@ public class KeyedFlattenedFieldTypeTests extends FieldTypeTestCase {
 
         SearchExecutionContext searchExecutionContext = mock(SearchExecutionContext.class);
         when(searchExecutionContext.sourcePath("field.key")).thenReturn(Set.of("field.key"));
-
+        when(searchExecutionContext.isSourceEnabled()).thenReturn(true);
         ValueFetcher fetcher = ft.valueFetcher(searchExecutionContext, null);
         SourceLookup lookup = new SourceLookup();
         lookup.setSource(Collections.singletonMap("field", sourceValue));

--- a/test/framework/src/main/java/org/elasticsearch/index/mapper/FieldTypeTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/index/mapper/FieldTypeTestCase.java
@@ -61,6 +61,6 @@ public abstract class FieldTypeTestCase extends ESTestCase {
     }
 
     public static List<?> fetchSourceValues(MappedFieldType fieldType, Object... values) throws IOException {
-        return fetchSourceValue(fieldType, Collections.singletonMap(fieldType.name(), List.of(values)));
+        return fetchSourceValue(fieldType, List.of(values));
     }
 }

--- a/test/framework/src/main/java/org/elasticsearch/index/mapper/FieldTypeTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/index/mapper/FieldTypeTestCase.java
@@ -52,6 +52,7 @@ public abstract class FieldTypeTestCase extends ESTestCase {
         String field = fieldType.name();
         SearchExecutionContext searchExecutionContext = mock(SearchExecutionContext.class);
         when(searchExecutionContext.sourcePath(field)).thenReturn(Set.of(field));
+        when(searchExecutionContext.isSourceEnabled()).thenReturn(true);
 
         ValueFetcher fetcher = fieldType.valueFetcher(searchExecutionContext, format);
         SourceLookup lookup = new SourceLookup();
@@ -60,13 +61,6 @@ public abstract class FieldTypeTestCase extends ESTestCase {
     }
 
     public static List<?> fetchSourceValues(MappedFieldType fieldType, Object... values) throws IOException {
-        String field = fieldType.name();
-        SearchExecutionContext searchExecutionContext = mock(SearchExecutionContext.class);
-        when(searchExecutionContext.sourcePath(field)).thenReturn(Set.of(field));
-
-        ValueFetcher fetcher = fieldType.valueFetcher(searchExecutionContext, null);
-        SourceLookup lookup = new SourceLookup();
-        lookup.setSource(Collections.singletonMap(field, List.of(values)));
-        return fetcher.fetchValues(lookup, new ArrayList<>());
+        return fetchSourceValue(fieldType, Collections.singletonMap(fieldType.name(), List.of(values)));
     }
 }

--- a/test/framework/src/main/java/org/elasticsearch/index/mapper/MapperTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/index/mapper/MapperTestCase.java
@@ -45,7 +45,6 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -56,8 +55,6 @@ import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.instanceOf;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 /**
  * Base class for testing {@link Mapper}s.
@@ -519,9 +516,16 @@ public abstract class MapperTestCase extends MapperServiceTestCase {
     }
 
     protected final MapperService randomFetchTestMapper() throws IOException {
-        return createMapperService(mapping(b -> {
-            b.startObject("field");
-            randomFetchTestFieldConfig(b);
+        return createMapperService(topMapping(b -> {
+            if (supportsFetchWithSourceDisabled() && randomBoolean()) {
+                b.startObject("_source").field("enabled", false).endObject();
+            }
+            b.startObject("properties");
+            {
+                b.startObject("field");
+                randomFetchTestFieldConfig(b);
+                b.endObject();
+            }
             b.endObject();
         }));
     }
@@ -533,6 +537,15 @@ public abstract class MapperTestCase extends MapperServiceTestCase {
      */
     protected void randomFetchTestFieldConfig(XContentBuilder b) throws IOException {
         minimalMapping(b);
+    }
+
+    /**
+     * Field configuration for {@link #testFetch} and {@link #testFetchMany}.
+     * Default implementation delegates to {@link #minimalMapping} but can
+     * be overridden to randomize the field type and options.
+     */
+    protected boolean supportsFetchWithSourceDisabled() {
+        return true;
     }
 
     /**
@@ -579,15 +592,8 @@ public abstract class MapperTestCase extends MapperServiceTestCase {
     protected void assertFetch(MapperService mapperService, String field, Object value, String format) throws IOException {
         MappedFieldType ft = mapperService.fieldType(field);
         SourceToParse source = source(b -> b.field(ft.name(), value));
-        ValueFetcher docValueFetcher = new DocValueFetcher(
-            ft.docValueFormat(format, null),
-            ft.fielddataBuilder("test", () -> null).build(new IndexFieldDataCache.None(), new NoneCircuitBreakerService())
-        );
-        SearchExecutionContext searchExecutionContext = mock(SearchExecutionContext.class);
-        when(searchExecutionContext.sourcePath(field)).thenReturn(Set.of(field));
-        when(searchExecutionContext.getForField(ft)).thenAnswer(
-            inv -> { return fieldDataLookup().apply(ft, () -> { throw new UnsupportedOperationException(); }); }
-        );
+        SearchExecutionContext searchExecutionContext = createSearchExecutionContext(mapperService);
+        ValueFetcher docValueFetcher = ft.docValueFetcher(searchExecutionContext, format);
         ValueFetcher nativeFetcher = ft.valueFetcher(searchExecutionContext, format);
         ParsedDocument doc = mapperService.documentMapper().parse(source);
         withLuceneIndex(mapperService, iw -> iw.addDocuments(doc.docs()), ir -> {

--- a/x-pack/plugin/mapper-version/src/main/java/org/elasticsearch/xpack/versionfield/VersionStringFieldMapper.java
+++ b/x-pack/plugin/mapper-version/src/main/java/org/elasticsearch/xpack/versionfield/VersionStringFieldMapper.java
@@ -133,7 +133,11 @@ public class VersionStringFieldMapper extends FieldMapper {
 
         @Override
         public ValueFetcher valueFetcher(SearchExecutionContext context, String format) {
-            return SourceValueFetcher.toString(name(), context, format);
+            if (context.isSourceEnabled()) {
+                return SourceValueFetcher.toString(name(), context, format);
+            }
+            assert hasDocValues();
+            return docValueFetcher(context, format);
         }
 
         @Override

--- a/x-pack/plugin/wildcard/src/main/java/org/elasticsearch/xpack/wildcard/mapper/WildcardFieldMapper.java
+++ b/x-pack/plugin/wildcard/src/main/java/org/elasticsearch/xpack/wildcard/mapper/WildcardFieldMapper.java
@@ -847,17 +847,20 @@ public class WildcardFieldMapper extends FieldMapper {
             if (format != null) {
                 throw new IllegalArgumentException("Field [" + name() + "] of type [" + typeName() + "] doesn't support formats.");
             }
-
-            return new SourceValueFetcher(name(), context, nullValue) {
-                @Override
-                protected String parseSourceValue(Object value) {
-                    String keywordValue = value.toString();
-                    if (keywordValue.length() > ignoreAbove) {
-                        return null;
+            if (context.isSourceEnabled()) {
+                return new SourceValueFetcher(name(), context, nullValue) {
+                    @Override
+                    protected String parseSourceValue(Object value) {
+                        String keywordValue = value.toString();
+                        if (keywordValue.length() > ignoreAbove) {
+                            return null;
+                        }
+                        return keywordValue;
                     }
-                    return keywordValue;
-                }
-            };
+                };
+            }
+            assert hasDocValues();
+            return docValueFetcher(context, format);
         }
 
     }


### PR DESCRIPTION
This adds support for fetching `fields` from doc values for a few field
types:
* long
* int
* short
* byte
* double
* short
* date
* boolean
* ip
* keyword
* unsigned long
* version string
* wildcard
* scaled float

We've had support for fetching from doc values forever using the
`docvalue_fields` option and this just plugs into that when the source
is disabled. It's possible that it's faster to plug into it in other
cases but we don't know those cases yet.
