### PR TITLE
Clarify where force merge will occur in ILM

### DIFF
--- a/docs/reference/ilm/actions/ilm-forcemerge.asciidoc
+++ b/docs/reference/ilm/actions/ilm-forcemerge.asciidoc
@@ -33,6 +33,11 @@ To do this, configure the `thread_pool.force_merge.size` <<cluster-get-settings,
 
 IMPORTANT: This can have cascading performance impacts. 
 Monitor cluster performance and increment the size of the thread pool slowly to reduce the backlog.
+
+Force merging will be performed by the nodes within the current phase of the index. A forcemerge in
+the `hot` phase will use hot nodes with potentially faster nodes, while impacting ingestion more. A
+forcemerge in the `warm` phase will use warm nodes and potentially take longer to perform, but
+without impacting ingestion in the `hot` tier.
 ****
 
 

--- a/docs/reference/ilm/actions/ilm-searchable-snapshot.asciidoc
+++ b/docs/reference/ilm/actions/ilm-searchable-snapshot.asciidoc
@@ -63,6 +63,12 @@ the shards are relocating, in which case they will not be merged.
 The `searchable_snapshot` action will continue executing even if not all shards
 are force merged.
 
+This force merging occurs in the phase that the index is in *prior* to the `searchable_snapshot`
+action. For example, if using a `searchable_snapshot` action in the `hot` phase, the force merge
+will be performed on the hot nodes. If using a `searchable_snapshot` action in the `cold` phase, the
+force merge will be performed on whatever tier the index is *prior* to the `cold` phase (either
+`hot` or `warm`).
+
 [[ilm-searchable-snapshot-ex]]
 ==== Examples
 ////


### PR DESCRIPTION
This commit clarifies the force merge behavior for the `forcemerge` action either as a standalone
ILM action, or as part of the searchable snapshot action. When using a searchable snapshot it can be
confusing especially because the force merge can occur in a phase prior to the phase configured in
the ILM policy (since ILM doesn't migrate the index prior to the searchable snapshot mounting).
