### PR TITLE
Make FieldMapper.Param Cheaper to Construct

### DIFF
--- a/docs/changelog/85191.yaml
+++ b/docs/changelog/85191.yaml
@@ -1,0 +1,5 @@
+pr: 85191
+summary: Make `FieldMapper.Param` Cheaper to Construct
+area: Mapping
+type: enhancement
+issues: []

--- a/server/src/main/java/org/elasticsearch/common/util/CollectionUtils.java
+++ b/server/src/main/java/org/elasticsearch/common/util/CollectionUtils.java
@@ -304,6 +304,41 @@ public class CollectionUtils {
         return Collections.unmodifiableList(Arrays.asList(array));
     }
 
+    /**
+     * Same as {@link #appendToCopy(Collection, Object)} but faster by assuming that all elements in the collection and the given element
+     * are non-null.
+     * @param collection collection to copy
+     * @param element    element to append
+     * @return           list with appended element
+     */
+    @SuppressWarnings("unchecked")
+    public static <E> List<E> appendToCopyNoNullElements(Collection<E> collection, E element) {
+        final int existingSize = collection.size();
+        if (existingSize == 0) {
+            return List.of(element);
+        }
+        final int size = existingSize + 1;
+        final E[] array = collection.toArray((E[]) new Object[size]);
+        array[size - 1] = element;
+        return List.of(array);
+    }
+
+    /**
+     * Same as {@link #appendToCopyNoNullElements(Collection, Object)} but for multiple elements to append.
+     */
+    @SuppressWarnings("unchecked")
+    public static <E> List<E> appendToCopyNoNullElements(Collection<E> collection, E... elements) {
+        final int existingSize = collection.size();
+        if (existingSize == 0) {
+            return List.of(elements);
+        }
+        final int addedSize = elements.length;
+        final int size = existingSize + addedSize;
+        final E[] array = collection.toArray((E[]) new Object[size]);
+        System.arraycopy(elements, 0, array, size - 1, addedSize);
+        return List.of(array);
+    }
+
     public static <E> ArrayList<E> newSingletonArrayList(E element) {
         return new ArrayList<>(Collections.singletonList(element));
     }

--- a/x-pack/plugin/vectors/src/main/java/org/elasticsearch/xpack/vectors/mapper/DenseVectorFieldMapper.java
+++ b/x-pack/plugin/vectors/src/main/java/org/elasticsearch/xpack/vectors/mapper/DenseVectorFieldMapper.java
@@ -116,10 +116,10 @@ public class DenseVectorFieldMapper extends FieldMapper implements PerFieldKnnVe
             super(name);
             this.indexVersionCreated = indexVersionCreated;
 
-            this.indexed.requiresParameters(similarity);
+            this.indexed.requiresParameter(similarity);
             this.similarity.setSerializerCheck((id, ic, v) -> v != null);
-            this.similarity.requiresParameters(indexed);
-            this.indexOptions.requiresParameters(indexed);
+            this.similarity.requiresParameter(indexed);
+            this.indexOptions.requiresParameter(indexed);
             this.indexOptions.setSerializerCheck((id, ic, v) -> v != null);
         }
 


### PR DESCRIPTION
These are constructed at an extreme rate when serializing large states.
This makes them a lot cheaper both in CPU and heap to set up.
Adds some new primitives for faster list copy + append operations that will come in handy elsewhere as well.
Mainly creates a significant speedup in setting up these parameter instances (which is part of mapper serialization + parsing) by avoiding the creation of mostly empty or very short array lists which are both expensive to create but also expensive to iterate later in `org.elasticsearch.index.mapper.FieldMapper.Parameter#validate`.


Before:
<img width="1680" alt="image" src="https://user-images.githubusercontent.com/6490959/159374588-7cb97249-a789-464d-8901-437a24452458.png">


After:
<img width="1677" alt="image" src="https://user-images.githubusercontent.com/6490959/159374543-bbf5d6e9-8010-4987-b2f3-600028e53d16.png">


relates #77466
