### PR TITLE
User Profile - Allow kibana_system to access kibana*

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStore.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStore.java
@@ -797,7 +797,7 @@ public class ReservedRolesStore implements BiConsumer<Set<String>, ActionListene
             null,
             new ConfigurableClusterPrivilege[] {
                 new ManageApplicationPrivileges(Set.of("kibana-*")),
-                new WriteProfileDataPrivileges(Set.of("kibana-*")) },
+                new WriteProfileDataPrivileges(Set.of("kibana*")) },
             null,
             MetadataUtils.DEFAULT_RESERVED_METADATA,
             null

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStoreTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStoreTests.java
@@ -460,7 +460,7 @@ public class ReservedRolesStoreTests extends ESTestCase {
         UpdateProfileDataRequest updateProfileDataRequest = randomBoolean()
             ? new UpdateProfileDataRequest(
                 randomAlphaOfLength(10),
-                Map.of("kibana-" + randomAlphaOfLengthBetween(0, 4), mock(Object.class)),
+                Map.of("kibana" + randomAlphaOfLengthBetween(0, 4), mock(Object.class)),
                 Map.of(),
                 randomFrom(-1L, randomLong()),
                 randomFrom(-1L, randomLong()),
@@ -469,7 +469,7 @@ public class ReservedRolesStoreTests extends ESTestCase {
             : new UpdateProfileDataRequest(
                 randomAlphaOfLength(10),
                 Map.of(),
-                Map.of("kibana-" + randomAlphaOfLengthBetween(0, 4), mock(Object.class)),
+                Map.of("kibana" + randomAlphaOfLengthBetween(0, 4), mock(Object.class)),
                 randomFrom(-1L, randomLong()),
                 randomFrom(-1L, randomLong()),
                 randomFrom(WriteRequest.RefreshPolicy.values())
@@ -477,8 +477,8 @@ public class ReservedRolesStoreTests extends ESTestCase {
         assertThat(kibanaRole.cluster().check(UpdateProfileDataAction.NAME, updateProfileDataRequest, authentication), is(true));
         updateProfileDataRequest = new UpdateProfileDataRequest(
             randomAlphaOfLength(10),
-            Map.of("kibana-" + randomAlphaOfLengthBetween(0, 4), mock(Object.class)),
-            Map.of("kibana-" + randomAlphaOfLengthBetween(0, 4), mock(Object.class)),
+            Map.of("kibana" + randomAlphaOfLengthBetween(0, 4), mock(Object.class)),
+            Map.of("kibana" + randomAlphaOfLengthBetween(0, 4), mock(Object.class)),
             randomFrom(-1L, randomLong()),
             randomFrom(-1L, randomLong()),
             randomFrom(WriteRequest.RefreshPolicy.values())
@@ -487,7 +487,7 @@ public class ReservedRolesStoreTests extends ESTestCase {
         updateProfileDataRequest = randomBoolean()
             ? new UpdateProfileDataRequest(
                 randomAlphaOfLength(10),
-                Map.of(randomAlphaOfLengthBetween(0, 6), mock(Object.class)),
+                Map.of(randomValueOtherThan("kibana", () -> randomAlphaOfLengthBetween(0, 6)), mock(Object.class)),
                 Map.of(),
                 randomFrom(-1L, randomLong()),
                 randomFrom(-1L, randomLong()),
@@ -506,23 +506,23 @@ public class ReservedRolesStoreTests extends ESTestCase {
             ? new UpdateProfileDataRequest(
                 randomAlphaOfLength(10),
                 Map.of(
-                    "kibana-" + randomAlphaOfLengthBetween(0, 4),
+                    "kibana" + randomAlphaOfLengthBetween(0, 4),
                     mock(Object.class),
-                    randomAlphaOfLengthBetween(0, 6),
+                    randomValueOtherThan("kibana", () -> randomAlphaOfLengthBetween(0, 6)),
                     mock(Object.class)
                 ),
-                Map.of("kibana-" + randomAlphaOfLengthBetween(0, 4), mock(Object.class)),
+                Map.of("kibana" + randomAlphaOfLengthBetween(0, 4), mock(Object.class)),
                 randomFrom(-1L, randomLong()),
                 randomFrom(-1L, randomLong()),
                 randomFrom(WriteRequest.RefreshPolicy.values())
             )
             : new UpdateProfileDataRequest(
                 randomAlphaOfLength(10),
-                Map.of("kibana-" + randomAlphaOfLengthBetween(0, 4), mock(Object.class)),
+                Map.of("kibana" + randomAlphaOfLengthBetween(0, 4), mock(Object.class)),
                 Map.of(
-                    "kibana-" + randomAlphaOfLengthBetween(0, 4),
+                    "kibana" + randomAlphaOfLengthBetween(0, 4),
                     mock(Object.class),
-                    randomAlphaOfLengthBetween(0, 6),
+                    randomValueOtherThan("kibana", () -> randomAlphaOfLengthBetween(0, 6)),
                     mock(Object.class)
                 ),
                 randomFrom(-1L, randomLong()),


### PR DESCRIPTION
This PR expands the namespace accessible to kibana_system user from
"kibana-*" to simply "kibana*".

The format "kibana-*" was used for manageApplicationPrivileges because
kibana use to support running multiple instances _with different `kibana.index` settings_ against a single ES
deployment. This setup is no longer supported. Hence there is no need
for UpdateProfileData privilege to use the same namespace pattern.
