### PR TITLE
[8.0] Add delete privilege to kibana_system for APM (#85085)

### DIFF
--- a/docs/changelog/85085.yaml
+++ b/docs/changelog/85085.yaml
@@ -1,0 +1,5 @@
+pr: 85085
+summary: Add delete privilege to `kibana_system` for APM
+area: Authorization
+type: bug
+issues: []

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStore.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStore.java
@@ -756,7 +756,15 @@ public class ReservedRolesStore implements BiConsumer<Set<String>, ActionListene
                     .build(),
                 // For ILM policy for APM & Endpoint packages that have delete action
                 RoleDescriptor.IndicesPrivileges.builder()
-                    .indices(".logs-endpoint.diagnostic.collection-*", "traces-apm.sampled-*")
+                    .indices(
+                        ".logs-endpoint.diagnostic.collection-*",
+                        "logs-apm-*",
+                        "logs-apm.*-*",
+                        "metrics-apm-*",
+                        "metrics-apm.*-*",
+                        "traces-apm-*",
+                        "traces-apm.*-*"
+                    )
                     .privileges(DeleteIndexAction.NAME)
                     .build(),
                 // For src/dest indices of the Endpoint package that ships a transform

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStoreTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStoreTests.java
@@ -775,9 +775,14 @@ public class ReservedRolesStoreTests extends ESTestCase {
             assertThat(kibanaRole.indices().allowedIndicesMatcher(SearchAction.NAME).test(indexAbstraction), is(isAlsoReadIndex));
             assertThat(kibanaRole.indices().allowedIndicesMatcher(MultiSearchAction.NAME).test(indexAbstraction), is(isAlsoReadIndex));
 
-            // Endpoint diagnostic and sampled traces data streams also have an ILM policy with a delete action, all others should not.
+            // Endpoint diagnostic and APM data streams also have an ILM policy with a delete action, all others should not.
             final boolean isAlsoIlmDeleteIndex = indexName.startsWith(".logs-endpoint.diagnostic.collection-")
-                || indexName.startsWith("traces-apm.sampled-");
+                || indexName.startsWith("logs-apm-")
+                || indexName.startsWith("logs-apm.")
+                || indexName.startsWith("metrics-apm-")
+                || indexName.startsWith("metrics-apm.")
+                || indexName.startsWith("traces-apm-")
+                || indexName.startsWith("traces-apm.");
             assertThat(kibanaRole.indices().allowedIndicesMatcher(DeleteIndexAction.NAME).test(indexAbstraction), is(isAlsoIlmDeleteIndex));
         });
 
@@ -847,27 +852,20 @@ public class ReservedRolesStoreTests extends ESTestCase {
 
         // Ensure privileges necessary for ILM policies in APM & Endpoint packages
         Arrays.asList(
-            "metrics-apm.app-" + randomAlphaOfLengthBetween(3, 8),
-            "metrics-apm.internal-" + randomAlphaOfLengthBetween(3, 8),
-            "metrics-apm.profiling-" + randomAlphaOfLengthBetween(3, 8),
-            "logs-apm.error_logs-" + randomAlphaOfLengthBetween(3, 8),
-            "traces-apm-" + randomAlphaOfLengthBetween(3, 8)
-        ).forEach(indexName -> {
-            logger.info("index name [{}]", indexName);
-            final IndexAbstraction indexAbstraction = mockIndexAbstraction(indexName);
-
-            assertThat(kibanaRole.indices().allowedIndicesMatcher(UpdateSettingsAction.NAME).test(indexAbstraction), is(true));
-            assertThat(kibanaRole.indices().allowedIndicesMatcher(RolloverAction.NAME).test(indexAbstraction), is(true));
-        });
-        Arrays.asList(
             ".logs-endpoint.diagnostic.collection-" + randomAlphaOfLengthBetween(3, 8),
-            "traces-apm.sampled-" + randomAlphaOfLengthBetween(3, 8)
+            "logs-apm-" + randomAlphaOfLengthBetween(3, 8),
+            "logs-apm." + randomAlphaOfLengthBetween(3, 8) + "-" + randomAlphaOfLengthBetween(3, 8),
+            "metrics-apm-" + randomAlphaOfLengthBetween(3, 8),
+            "metrics-apm." + randomAlphaOfLengthBetween(3, 8) + "-" + randomAlphaOfLengthBetween(3, 8),
+            "traces-apm-" + randomAlphaOfLengthBetween(3, 8),
+            "traces-apm." + randomAlphaOfLengthBetween(3, 8) + "-" + randomAlphaOfLengthBetween(3, 8)
         ).forEach(indexName -> {
             logger.info("index name [{}]", indexName);
             final IndexAbstraction indexAbstraction = mockIndexAbstraction(indexName);
 
             assertThat(kibanaRole.indices().allowedIndicesMatcher(DeleteIndexAction.NAME).test(indexAbstraction), is(true));
             assertThat(kibanaRole.indices().allowedIndicesMatcher(RolloverAction.NAME).test(indexAbstraction), is(true));
+            assertThat(kibanaRole.indices().allowedIndicesMatcher(UpdateSettingsAction.NAME).test(indexAbstraction), is(true));
         });
     }
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `8.0`:
 - [Add delete privilege to kibana_system for APM (#85085)](https://github.com/elastic/elasticsearch/pull/85085)

<!--- Backport version: 8.1.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)