### PR TITLE
Unmute SimpleSecurityNetty4ServerTransportTests#testThreadContext

### DIFF
--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/transport/netty4/SimpleSecurityNetty4ServerTransportTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/transport/netty4/SimpleSecurityNetty4ServerTransportTests.java
@@ -24,14 +24,6 @@ import org.elasticsearch.xpack.security.transport.AbstractSimpleSecurityTranspor
 import java.util.Collections;
 
 public class SimpleSecurityNetty4ServerTransportTests extends AbstractSimpleSecurityTransportTestCase {
-
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/67427")
-    @Override
-    public void testThreadContext() {
-        // This empty method is here just for the purpose of muting the
-        // test defined in the base class
-    }
-
     @Override
     protected Transport build(Settings settings, final Version version, ClusterSettings clusterSettings, boolean doHandshake) {
         NamedWriteableRegistry namedWriteableRegistry = new NamedWriteableRegistry(Collections.emptyList());


### PR DESCRIPTION
This test was muted due to the test failure reported in #67427. The
failure was addressed in #68799 but the test remained muted. This commit
reinstates the test.