### PR TITLE
Fix spotless exclude for build benchmarking

### DIFF
--- a/build-conventions/src/main/java/org/elasticsearch/gradle/internal/conventions/precommit/FormattingPrecommitPlugin.java
+++ b/build-conventions/src/main/java/org/elasticsearch/gradle/internal/conventions/precommit/FormattingPrecommitPlugin.java
@@ -76,7 +76,7 @@ public class FormattingPrecommitPlugin implements Plugin<Project> {
                 // The gradle-profiler unfortunately does not generate compliant formatted
                 // sources so we ignore that altered file when running build benchmarks
                 if(Boolean.getBoolean("BUILD_PERFORMANCE_TEST") && project.getPath().equals(":server")) {
-                    java.ignoreErrorForPath("src/main/java/org/elasticsearch/bootstrap/BootstrapInfo.java");
+                    java.targetExclude("src/main/java/org/elasticsearch/bootstrap/BootstrapInfo.java");
                 }
             });
 


### PR DESCRIPTION
Use targetExclude for excluding file from spotless checks as formatter warnings are not
reported as Error in spotless and still can cause the build to fail