### PR TITLE
Fix benchmark artifact generation for all scenarios

### DIFF
--- a/.ci/jobs.t/elastic+elasticsearch+pull-request+build-benchmark-part1.yml
+++ b/.ci/jobs.t/elastic+elasticsearch+pull-request+build-benchmark-part1.yml
@@ -46,4 +46,5 @@
          $WORKSPACE/.ci/scripts/run-gradle.sh :build-tools-internal:bootstrapPerformanceTests
          $WORKSPACE/.ci/scripts/install-gradle-profiler.sh
          $WORKSPACE/.ci/scripts/run-gradle-profiler.sh --benchmark --scenario-file build-tools-internal/build/performanceTests/elasticsearch-build-benchmark-part1.scenarios --project-dir . --output-dir profile-out
-         tar -czf build/${BUILD_NUMBER}.tar.bz2 profile-out
+         mkdir $WORKSPACE/build
+         tar -czf $WORKSPACE/build/${BUILD_NUMBER}.tar.bz2 profile-out

--- a/.ci/jobs.t/elastic+elasticsearch+pull-request+build-benchmark-part2.yml
+++ b/.ci/jobs.t/elastic+elasticsearch+pull-request+build-benchmark-part2.yml
@@ -46,4 +46,5 @@
          $WORKSPACE/.ci/scripts/run-gradle.sh :build-tools-internal:bootstrapPerformanceTests
          $WORKSPACE/.ci/scripts/install-gradle-profiler.sh
          $WORKSPACE/.ci/scripts/run-gradle-profiler.sh --benchmark --scenario-file build-tools-internal/build/performanceTests/elasticsearch-build-benchmark-part2.scenarios --project-dir . --output-dir profile-out
-         tar -czf build/${BUILD_NUMBER}.tar.bz2 profile-out
+         mkdir $WORKSPACE/build  
+         tar -czf $WORKSPACE/build/${BUILD_NUMBER}.tar.bz2 profile-out


### PR DESCRIPTION
Depending on the executed scenarios, there might not be a build folder on root level that we used to rely on when generating the build artifacts tar.

We now explicitly call mkdir on build folder before building the tar