### PR TITLE
Set gradle version explicitly in benchmark scenarios

### DIFF
--- a/build-tools-internal/build.gradle
+++ b/build-tools-internal/build.gradle
@@ -300,7 +300,21 @@ tasks.register("bootstrapPerformanceTests", Copy) {
   from('performance')
   into('build/performanceTests')
   def root = file('..')
-  filter(ReplaceTokens, tokens: [testGitCommit:GitInfo.gitInfo(root).revision])
+  filter(ReplaceTokens, tokens: [
+          testGitCommit:GitInfo.gitInfo(root).revision,
+          masterWrapper:"${ -> resolveWrapperVersion(root)}".toString(),
+          branchWrapper:"${-> new File(root, "build-tools-internal/src/main/resources/minimumGradleVersion").text}".toString()])
+}
+
+def resolveWrapperVersion(File root) {
+  new ByteArrayOutputStream().with { outputStream ->
+    project.exec { ExecSpec it ->
+      it.setStandardOutput(outputStream)
+      it.setWorkingDir(root)
+      it.setCommandLine("git", "show", "master:build-tools-internal/src/main/resources/minimumGradleVersion")
+    }
+    return outputStream.toString()
+  }
 }
 
 abstract class JacksonAlignmentRule implements ComponentMetadataRule {

--- a/build-tools-internal/performance/elasticsearch-build-benchmark-part1.scenarios
+++ b/build-tools-internal/performance/elasticsearch-build-benchmark-part1.scenarios
@@ -3,6 +3,7 @@ default-scenarios = ["buildConfiguration_master", "buildConfiguration_branch", "
 
 buildConfiguration_master {
     title = "configuration phase (master)"
+    versions = ["@masterWrapper@"]
     tasks = ["help"]
     gradle-args = ["--no-scan", "--no-build-cache"]
     run-using = cli // value can be "cli" or "tooling-api"
@@ -19,6 +20,7 @@ buildConfiguration_master {
 
 buildConfiguration_branch {
     title = "configuration phase (@testGitCommit@)"
+    versions = ["@branchWrapper@"]
     tasks = ["help"]
     gradle-args = ["--no-scan", "--no-build-cache"]
     run-using = cli // value can be "cli" or "tooling-api"
@@ -35,6 +37,7 @@ buildConfiguration_branch {
 
 single_project_master {
     title = "single project (master)"
+    versions = ["@masterWrapper@"]
     tasks = [":server:precommit"]
     gradle-args = ["--no-scan"]
     apply-abi-change-to = "server/src/main/java/org/elasticsearch/bootstrap/BootstrapInfo.java"
@@ -52,6 +55,7 @@ single_project_master {
 
 single_project_branch {
     title = "single project (@testGitCommit@)"
+    versions = ["@branchWrapper@"]
     tasks = [":server:precommit"]
     gradle-args = ["--no-scan"]
     apply-abi-change-to = "server/src/main/java/org/elasticsearch/bootstrap/BootstrapInfo.java"

--- a/build-tools-internal/performance/elasticsearch-build-benchmark-part2.scenarios
+++ b/build-tools-internal/performance/elasticsearch-build-benchmark-part2.scenarios
@@ -2,6 +2,7 @@ default-scenarios = ["precommit_master", "precommit_branch"]
 
 precommit_master {
     title = "precommit (master)"
+    versions = ["@masterWrapper@"]
     cleanup-tasks = ["clean"]
     tasks = ["precommit"]
     gradle-args = ["--no-scan", "--no-build-cache"]
@@ -19,6 +20,7 @@ precommit_master {
 
 precommit_branch {
     title = "precommit (@testGitCommit@)"
+    versions = ["@branchWrapper@"]
     cleanup-tasks = ["clean"]
     tasks = ["precommit"]
     gradle-args = ["--no-scan", "--no-build-cache"]


### PR DESCRIPTION
Gradle versions in scenarios are not automatically resolved from the gradle wrapper version, which makes it impossible to compare branches with different wrappers declared (e.g. gradle update scenarios)