### PR TITLE
Improve DeprecationHttpIT robustness

### DIFF
--- a/x-pack/plugin/deprecation/qa/rest/src/javaRestTest/java/org/elasticsearch/xpack/deprecation/DeprecationHttpIT.java
+++ b/x-pack/plugin/deprecation/qa/rest/src/javaRestTest/java/org/elasticsearch/xpack/deprecation/DeprecationHttpIT.java
@@ -280,10 +280,8 @@ public class DeprecationHttpIT extends ESRestTestCase {
         // trigger all deprecations
         Request request = new Request("GET", "/_test_cluster/deprecated_settings");
         request.setEntity(buildSettingsRequest(settings, useDeprecatedField ? "deprecated_settings" : "settings"));
-        final RequestOptions options = request.getOptions()
-            .toBuilder()
-            .addHeader("X-Opaque-Id", "XOpaqueId-doTestDeprecationWarningsAppearInHeaders")
-            .build();
+        String xOpaqueId = "XOpaqueId-doTestDeprecationWarningsAppearInHeaders" + randomInt();
+        final RequestOptions options = request.getOptions().toBuilder().addHeader("X-Opaque-Id", xOpaqueId).build();
         request.setOptions(options);
         Response response = client().performRequest(request);
         assertOK(response);
@@ -306,11 +304,13 @@ public class DeprecationHttpIT extends ESRestTestCase {
         for (Matcher<String> headerMatcher : headerMatchers) {
             assertThat(actualWarningValues, hasItem(headerMatcher));
         }
-
+        // expect to index same number of new deprecations as the number of header warnings in the response
         assertBusy(() -> {
             List<Map<String, Object>> documents = DeprecationTestUtils.getIndexedDeprecations(client());
-            assertThat(documents.toString(), documents, hasSize(headerMatchers.size()));
+            long indexedDeprecations = documents.stream().filter(m -> xOpaqueId.equals(m.get(X_OPAQUE_ID_FIELD_NAME))).count();
+            assertThat(documents.toString(), indexedDeprecations, equalTo((long) headerMatchers.size()));
         });
+
     }
 
     public void testDeprecationRouteThrottling() throws Exception {

--- a/x-pack/plugin/deprecation/qa/rest/src/javaRestTest/java/org/elasticsearch/xpack/deprecation/DeprecationHttpIT.java
+++ b/x-pack/plugin/deprecation/qa/rest/src/javaRestTest/java/org/elasticsearch/xpack/deprecation/DeprecationHttpIT.java
@@ -259,7 +259,7 @@ public class DeprecationHttpIT extends ESRestTestCase {
      * <p>
      * Re-running this back-to-back helps to ensure that warnings are not being maintained across requests.
      */
-    private void doTestDeprecationWarningsAppearInHeaders() throws IOException {
+    private void doTestDeprecationWarningsAppearInHeaders() throws Exception {
         final boolean useDeprecatedField = randomBoolean();
         final boolean useNonDeprecatedSetting = randomBoolean();
 
@@ -306,6 +306,11 @@ public class DeprecationHttpIT extends ESRestTestCase {
         for (Matcher<String> headerMatcher : headerMatchers) {
             assertThat(actualWarningValues, hasItem(headerMatcher));
         }
+
+        assertBusy(() -> {
+            List<Map<String, Object>> documents = DeprecationTestUtils.getIndexedDeprecations(client());
+            assertThat(documents.toString(), documents, hasSize(headerMatchers.size()));
+        });
     }
 
     public void testDeprecationRouteThrottling() throws Exception {


### PR DESCRIPTION
`doTestDeprecationWarningsAppearInHeaders` was not asserting about its deprecation
logs indexed. Therefore it was not waiting for these to appear in data stream.
This was affecting other tests expecting empty data stream.

Closes #83091.