### PR TITLE
Fail test if Node#awaitClose times out

### DIFF
--- a/test/framework/src/main/java/org/elasticsearch/test/InternalTestCluster.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/InternalTestCluster.java
@@ -1054,7 +1054,7 @@ public final class InternalTestCluster extends TestCluster {
                 node.close();
                 try {
                     if (node.awaitClose(10, TimeUnit.SECONDS) == false) {
-                        throw new IOException("Node didn't close within 10 seconds.");
+                        throw new AssertionError("Node didn't close within 10 seconds.");
                     }
                 } catch (InterruptedException e) {
                     throw new AssertionError("Interruption while waiting for the node to close", e);


### PR DESCRIPTION
We rely on nodes stopping gracefully in integ tests, rather than timing
out and using `ThreadPool#shutdownNow` to ignore any remaining cleanup
work. Today we throw an `IOException` if the shutdown wasn't graceful.
With this commit we move to an `AssertionError` so we can be sure that
any such problems result in a test failure.

Relates #85131