### PR TITLE
Remove hppc from FieldMemoryStats

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/FieldMemoryStats.java
+++ b/server/src/main/java/org/elasticsearch/common/FieldMemoryStats.java
@@ -8,9 +8,6 @@
 
 package org.elasticsearch.common;
 
-import com.carrotsearch.hppc.ObjectLongHashMap;
-import com.carrotsearch.hppc.cursors.ObjectLongCursor;
-
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;

--- a/server/src/main/java/org/elasticsearch/common/FieldMemoryStats.java
+++ b/server/src/main/java/org/elasticsearch/common/FieldMemoryStats.java
@@ -18,20 +18,22 @@ import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.xcontent.XContentBuilder;
 
 import java.io.IOException;
+import java.util.HashMap;
 import java.util.Iterator;
+import java.util.Map;
 import java.util.Objects;
 
 /**
  * A reusable class to encode {@code field -&gt; memory size} mappings
  */
-public final class FieldMemoryStats implements Writeable, Iterable<ObjectLongCursor<String>> {
+public final class FieldMemoryStats implements Writeable, Iterable<Map.Entry<String, Long>> {
 
-    private final ObjectLongHashMap<String> stats;
+    private final Map<String, Long> stats;
 
     /**
      * Creates a new FieldMemoryStats instance
      */
-    public FieldMemoryStats(ObjectLongHashMap<String> stats) {
+    public FieldMemoryStats(Map<String, Long> stats) {
         this.stats = Objects.requireNonNull(stats, "status must be non-null");
         assert stats.containsKey(null) == false;
     }
@@ -40,29 +42,21 @@ public final class FieldMemoryStats implements Writeable, Iterable<ObjectLongCur
      * Creates a new FieldMemoryStats instance from a stream
      */
     public FieldMemoryStats(StreamInput input) throws IOException {
-        int size = input.readVInt();
-        stats = new ObjectLongHashMap<>(size);
-        for (int i = 0; i < size; i++) {
-            stats.put(input.readString(), input.readVLong());
-        }
+        stats = input.readMap(StreamInput::readString, StreamInput::readVLong);
     }
 
     /**
      * Adds / merges the given field memory stats into this stats instance
      */
     public void add(FieldMemoryStats fieldMemoryStats) {
-        for (ObjectLongCursor<String> entry : fieldMemoryStats.stats) {
-            stats.addTo(entry.key, entry.value);
+        for (var entry : fieldMemoryStats.stats.entrySet()) {
+            stats.merge(entry.getKey(), entry.getValue(), Long::sum);
         }
     }
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
-        out.writeVInt(stats.size());
-        for (ObjectLongCursor<String> entry : stats) {
-            out.writeString(entry.key);
-            out.writeVLong(entry.value);
-        }
+        out.writeMap(stats, StreamOutput::writeString, StreamOutput::writeVLong);
     }
 
     /**
@@ -74,9 +68,9 @@ public final class FieldMemoryStats implements Writeable, Iterable<ObjectLongCur
      */
     public void toXContent(XContentBuilder builder, String key, String rawKey, String readableKey) throws IOException {
         builder.startObject(key);
-        for (ObjectLongCursor<String> entry : stats) {
-            builder.startObject(entry.key);
-            builder.humanReadableField(rawKey, readableKey, new ByteSizeValue(entry.value));
+        for (var entry : stats.entrySet()) {
+            builder.startObject(entry.getKey());
+            builder.humanReadableField(rawKey, readableKey, new ByteSizeValue(entry.getValue()));
             builder.endObject();
         }
         builder.endObject();
@@ -86,7 +80,8 @@ public final class FieldMemoryStats implements Writeable, Iterable<ObjectLongCur
      * Creates a deep copy of this stats instance
      */
     public FieldMemoryStats copy() {
-        return new FieldMemoryStats(stats.clone());
+        // String keys and boxed Longs are both immutable, so only the map needs to be recreated in order to clone
+        return new FieldMemoryStats(new HashMap<>(stats));
     }
 
     @Override
@@ -103,15 +98,15 @@ public final class FieldMemoryStats implements Writeable, Iterable<ObjectLongCur
     }
 
     @Override
-    public Iterator<ObjectLongCursor<String>> iterator() {
-        return stats.iterator();
+    public Iterator<Map.Entry<String, Long>> iterator() {
+        return stats.entrySet().iterator();
     }
 
     /**
      * Returns the fields value in bytes or <code>0</code> if it's not present in the stats
      */
     public long get(String field) {
-        return stats.get(field);
+        return stats.getOrDefault(field, 0L);
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/index/engine/CompletionStatsCache.java
+++ b/server/src/main/java/org/elasticsearch/index/engine/CompletionStatsCache.java
@@ -7,9 +7,6 @@
  */
 package org.elasticsearch.index.engine;
 
-import com.carrotsearch.hppc.ObjectLongHashMap;
-import com.carrotsearch.hppc.cursors.ObjectLongCursor;
-
 import org.apache.lucene.index.FieldInfo;
 import org.apache.lucene.index.LeafReader;
 import org.apache.lucene.index.LeafReaderContext;

--- a/server/src/main/java/org/elasticsearch/index/engine/CompletionStatsCache.java
+++ b/server/src/main/java/org/elasticsearch/index/engine/CompletionStatsCache.java
@@ -23,6 +23,8 @@ import org.elasticsearch.common.regex.Regex;
 import org.elasticsearch.common.util.CollectionUtils;
 import org.elasticsearch.search.suggest.completion.CompletionStats;
 
+import java.util.HashMap;
+import java.util.Map;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Supplier;
 
@@ -54,7 +56,7 @@ class CompletionStatsCache implements ReferenceManager.RefreshListener {
         // we won the race, nobody else is already computing stats, so it's up to us
         ActionListener.completeWith(newFuture, () -> {
             long sizeInBytes = 0;
-            final ObjectLongHashMap<String> completionFields = new ObjectLongHashMap<>();
+            final Map<String, Long> completionFields = new HashMap<>();
 
             try (Engine.Searcher currentSearcher = searcherSupplier.get()) {
                 for (LeafReaderContext atomicReaderContext : currentSearcher.getIndexReader().leaves()) {
@@ -64,7 +66,7 @@ class CompletionStatsCache implements ReferenceManager.RefreshListener {
                         if (terms instanceof CompletionTerms) {
                             // TODO: currently we load up the suggester for reporting its size
                             final long fstSize = ((CompletionTerms) terms).suggester().ramBytesUsed();
-                            completionFields.addTo(info.name, fstSize);
+                            completionFields.merge(info.name, fstSize, Long::sum);
                             sizeInBytes += fstSize;
                         }
                     }
@@ -92,10 +94,10 @@ class CompletionStatsCache implements ReferenceManager.RefreshListener {
     private static CompletionStats filterCompletionStatsByFieldName(String[] fieldNamePatterns, CompletionStats fullCompletionStats) {
         final FieldMemoryStats fieldMemoryStats;
         if (CollectionUtils.isEmpty(fieldNamePatterns) == false) {
-            final ObjectLongHashMap<String> completionFields = new ObjectLongHashMap<>(fieldNamePatterns.length);
-            for (ObjectLongCursor<String> fieldCursor : fullCompletionStats.getFields()) {
-                if (Regex.simpleMatch(fieldNamePatterns, fieldCursor.key)) {
-                    completionFields.addTo(fieldCursor.key, fieldCursor.value);
+            final Map<String, Long> completionFields = new HashMap<>(fieldNamePatterns.length);
+            for (var field : fullCompletionStats.getFields()) {
+                if (Regex.simpleMatch(fieldNamePatterns, field.getKey())) {
+                    completionFields.merge(field.getKey(), field.getValue(), Long::sum);
                 }
             }
             fieldMemoryStats = new FieldMemoryStats(completionFields);

--- a/server/src/main/java/org/elasticsearch/index/fielddata/ShardFieldData.java
+++ b/server/src/main/java/org/elasticsearch/index/fielddata/ShardFieldData.java
@@ -18,6 +18,7 @@ import org.elasticsearch.common.util.CollectionUtils;
 import org.elasticsearch.common.util.concurrent.ConcurrentCollections;
 import org.elasticsearch.index.shard.ShardId;
 
+import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.ConcurrentMap;
 
@@ -28,9 +29,9 @@ public class ShardFieldData implements IndexFieldDataCache.Listener {
     private final ConcurrentMap<String, CounterMetric> perFieldTotals = ConcurrentCollections.newConcurrentMap();
 
     public FieldDataStats stats(String... fields) {
-        ObjectLongHashMap<String> fieldTotals = null;
+        Map<String, Long> fieldTotals = null;
         if (CollectionUtils.isEmpty(fields) == false) {
-            fieldTotals = new ObjectLongHashMap<>();
+            fieldTotals = new HashMap<>();
             for (Map.Entry<String, CounterMetric> entry : perFieldTotals.entrySet()) {
                 if (Regex.simpleMatch(fields, entry.getKey())) {
                     fieldTotals.put(entry.getKey(), entry.getValue().count());

--- a/server/src/main/java/org/elasticsearch/index/fielddata/ShardFieldData.java
+++ b/server/src/main/java/org/elasticsearch/index/fielddata/ShardFieldData.java
@@ -8,8 +8,6 @@
 
 package org.elasticsearch.index.fielddata;
 
-import com.carrotsearch.hppc.ObjectLongHashMap;
-
 import org.apache.lucene.util.Accountable;
 import org.elasticsearch.common.FieldMemoryStats;
 import org.elasticsearch.common.metrics.CounterMetric;

--- a/server/src/main/java/org/elasticsearch/rest/action/cat/RestFielddataAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/cat/RestFielddataAction.java
@@ -8,8 +8,6 @@
 
 package org.elasticsearch.rest.action.cat;
 
-import com.carrotsearch.hppc.cursors.ObjectLongCursor;
-
 import org.elasticsearch.action.admin.cluster.node.stats.NodeStats;
 import org.elasticsearch.action.admin.cluster.node.stats.NodesStatsRequest;
 import org.elasticsearch.action.admin.cluster.node.stats.NodesStatsResponse;

--- a/server/src/main/java/org/elasticsearch/rest/action/cat/RestFielddataAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/cat/RestFielddataAction.java
@@ -80,14 +80,14 @@ public class RestFielddataAction extends AbstractCatAction {
 
         for (NodeStats nodeStats : nodeStatses.getNodes()) {
             if (nodeStats.getIndices().getFieldData().getFields() != null) {
-                for (ObjectLongCursor<String> cursor : nodeStats.getIndices().getFieldData().getFields()) {
+                for (var field : nodeStats.getIndices().getFieldData().getFields()) {
                     table.startRow();
                     table.addCell(nodeStats.getNode().getId());
                     table.addCell(nodeStats.getNode().getHostName());
                     table.addCell(nodeStats.getNode().getHostAddress());
                     table.addCell(nodeStats.getNode().getName());
-                    table.addCell(cursor.key);
-                    table.addCell(new ByteSizeValue(cursor.value));
+                    table.addCell(field.getKey());
+                    table.addCell(new ByteSizeValue(field.getValue()));
                     table.endRow();
                 }
             }

--- a/server/src/test/java/org/elasticsearch/common/FieldMemoryStatsTests.java
+++ b/server/src/test/java/org/elasticsearch/common/FieldMemoryStatsTests.java
@@ -7,13 +7,13 @@
  */
 package org.elasticsearch.common;
 
-import com.carrotsearch.hppc.ObjectLongHashMap;
-
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.test.ESTestCase;
 
 import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
 
 public class FieldMemoryStatsTests extends ESTestCase {
 
@@ -31,21 +31,21 @@ public class FieldMemoryStatsTests extends ESTestCase {
         FieldMemoryStats stats = randomFieldMemoryStats();
         assertEquals(stats, stats);
         assertEquals(stats.hashCode(), stats.hashCode());
-        ObjectLongHashMap<String> map1 = new ObjectLongHashMap<>();
-        map1.put("bar", 1);
+        Map<String, Long> map1 = new HashMap<>();
+        map1.put("bar", 1L);
         FieldMemoryStats stats1 = new FieldMemoryStats(map1);
-        ObjectLongHashMap<String> map2 = new ObjectLongHashMap<>();
-        map2.put("foo", 2);
+        Map<String, Long> map2 = new HashMap<>();
+        map2.put("foo", 2L);
         FieldMemoryStats stats2 = new FieldMemoryStats(map2);
 
-        ObjectLongHashMap<String> map3 = new ObjectLongHashMap<>();
-        map3.put("foo", 2);
-        map3.put("bar", 1);
+        Map<String, Long> map3 = new HashMap<>();
+        map3.put("foo", 2L);
+        map3.put("bar", 1L);
         FieldMemoryStats stats3 = new FieldMemoryStats(map3);
 
-        ObjectLongHashMap<String> map4 = new ObjectLongHashMap<>();
-        map4.put("foo", 2);
-        map4.put("bar", 1);
+        Map<String, Long> map4 = new HashMap<>();
+        map4.put("foo", 2L);
+        map4.put("bar", 1L);
         FieldMemoryStats stats4 = new FieldMemoryStats(map4);
 
         assertNotEquals(stats1, stats2);
@@ -60,21 +60,21 @@ public class FieldMemoryStatsTests extends ESTestCase {
     }
 
     public void testAdd() {
-        ObjectLongHashMap<String> map1 = new ObjectLongHashMap<>();
-        map1.put("bar", 1);
+        Map<String, Long> map1 = new HashMap<>();
+        map1.put("bar", 1L);
         FieldMemoryStats stats1 = new FieldMemoryStats(map1);
-        ObjectLongHashMap<String> map2 = new ObjectLongHashMap<>();
-        map2.put("foo", 2);
+        Map<String, Long> map2 = new HashMap<>();
+        map2.put("foo", 2L);
         FieldMemoryStats stats2 = new FieldMemoryStats(map2);
 
-        ObjectLongHashMap<String> map3 = new ObjectLongHashMap<>();
-        map3.put("bar", 1);
+        Map<String, Long> map3 = new HashMap<>();
+        map3.put("bar", 1L);
         FieldMemoryStats stats3 = new FieldMemoryStats(map3);
         stats3.add(stats1);
 
-        ObjectLongHashMap<String> map4 = new ObjectLongHashMap<>();
-        map4.put("foo", 2);
-        map4.put("bar", 2);
+        Map<String, Long> map4 = new HashMap<>();
+        map4.put("foo", 2L);
+        map4.put("bar", 2L);
         FieldMemoryStats stats4 = new FieldMemoryStats(map4);
         assertNotEquals(stats3, stats4);
         stats3.add(stats2);
@@ -82,7 +82,7 @@ public class FieldMemoryStatsTests extends ESTestCase {
     }
 
     public static FieldMemoryStats randomFieldMemoryStats() {
-        ObjectLongHashMap<String> map = new ObjectLongHashMap<>();
+        Map<String, Long> map = new HashMap<>();
         int keys = randomIntBetween(1, 1000);
         for (int i = 0; i < keys; i++) {
             map.put(randomRealisticUnicodeOfCodepointLengthBetween(1, 10), randomNonNegativeLong());


### PR DESCRIPTION
FieldMemoryStats is a simple wrapper around the association of a field
to how much memory it is taking up. The size of this is not that large
(not millions of keys), and there is lots of other overhead, so hppc
classes are not really needed. This commit converts FieldMemoryStats to
use a HashMap internally.

relates #84735