### PR TITLE
Remove legacy error for illegal node config file name

### DIFF
--- a/server/src/main/java/org/elasticsearch/node/InternalSettingsPreparer.java
+++ b/server/src/main/java/org/elasticsearch/node/InternalSettingsPreparer.java
@@ -44,18 +44,10 @@ public class InternalSettingsPreparer {
         Path configPath,
         Supplier<String> defaultNodeName
     ) {
-        Path configFile = findConfigDir(configPath, input, properties);
-
-        if (Files.exists(configFile.resolve("elasticsearch.yaml"))) {
-            throw new SettingsException("elasticsearch.yaml was deprecated in 5.5.0 and must be renamed to elasticsearch.yml");
-        }
-
-        if (Files.exists(configFile.resolve("elasticsearch.json"))) {
-            throw new SettingsException("elasticsearch.json was deprecated in 5.5.0 and must be converted to elasticsearch.yml");
-        }
+        Path configDir = findConfigDir(configPath, input, properties);
 
         Settings.Builder output = Settings.builder(); // start with a fresh output
-        Path path = configFile.resolve("elasticsearch.yml");
+        Path path = configDir.resolve("elasticsearch.yml");
 
         if (Files.exists(path)) {
             try {
@@ -71,7 +63,7 @@ public class InternalSettingsPreparer {
         initializeSettings(output, input);
         finalizeSettings(output, defaultNodeName);
 
-        return new Environment(output.build(), configFile);
+        return new Environment(output.build(), configDir);
     }
 
     static Path findConfigDir(Path configPath, Settings input, Map<String, String> properties) {

--- a/server/src/test/java/org/elasticsearch/node/InternalSettingsPreparerTests.java
+++ b/server/src/test/java/org/elasticsearch/node/InternalSettingsPreparerTests.java
@@ -85,40 +85,6 @@ public class InternalSettingsPreparerTests extends ESTestCase {
         }
     }
 
-    public void testYamlNotAllowed() throws IOException {
-        InputStream yaml = getClass().getResourceAsStream("/config/elasticsearch.yml");
-        Path config = homeDir.resolve("config");
-        Files.createDirectory(config);
-        Files.copy(yaml, config.resolve("elasticsearch.yaml"));
-        SettingsException e = expectThrows(
-            SettingsException.class,
-            () -> InternalSettingsPreparer.prepareEnvironment(
-                Settings.builder().put(baseEnvSettings).build(),
-                emptyMap(),
-                null,
-                DEFAULT_NODE_NAME_SHOULDNT_BE_CALLED
-            )
-        );
-        assertEquals("elasticsearch.yaml was deprecated in 5.5.0 and must be renamed to elasticsearch.yml", e.getMessage());
-    }
-
-    public void testJsonNotAllowed() throws IOException {
-        InputStream yaml = getClass().getResourceAsStream("/config/elasticsearch.json");
-        Path config = homeDir.resolve("config");
-        Files.createDirectory(config);
-        Files.copy(yaml, config.resolve("elasticsearch.json"));
-        SettingsException e = expectThrows(
-            SettingsException.class,
-            () -> InternalSettingsPreparer.prepareEnvironment(
-                Settings.builder().put(baseEnvSettings).build(),
-                emptyMap(),
-                null,
-                DEFAULT_NODE_NAME_SHOULDNT_BE_CALLED
-            )
-        );
-        assertEquals("elasticsearch.json was deprecated in 5.5.0 and must be converted to elasticsearch.yml", e.getMessage());
-    }
-
     public void testSecureSettings() {
         MockSecureSettings secureSettings = new MockSecureSettings();
         secureSettings.setString("foo", "secret");


### PR DESCRIPTION
Before Elasticsearch 6.0, alternative file names and formats were
allowed for the main config file. These were elasticsearch.json, and
elasticsearch.yaml. Support was deprecated in 5.5.0, and removed in 6.0,
with a direct error message indicating the file must be reformatted or
renamed. This commit removes these legacy error messages as there is no
direct upgrading from 5.x to 8.x.