### PR TITLE
Return empty version instead of blowing up if we cannot find it

### DIFF
--- a/docs/changelog/85244.yaml
+++ b/docs/changelog/85244.yaml
@@ -1,0 +1,5 @@
+pr: 85244
+summary: Return empty version instead of blowing up if we cannot find it
+area: Infra/Core
+type: bug
+issues: []

--- a/server/src/main/java/org/elasticsearch/indices/SystemIndexManager.java
+++ b/server/src/main/java/org/elasticsearch/indices/SystemIndexManager.java
@@ -310,12 +310,9 @@ public class SystemIndexManager implements ClusterStateListener {
                 return Version.V_EMPTY;
             }
             return Version.fromString(versionString);
-        } catch (ElasticsearchParseException e) {
+        } catch (ElasticsearchParseException | IllegalArgumentException e) {
             logger.error(new ParameterizedMessage("Cannot parse the mapping for index [{}]", indexName), e);
-            throw new ElasticsearchException("Cannot parse the mapping for index [{}]", e, indexName);
-        } catch (IllegalArgumentException e) {
-            logger.error(new ParameterizedMessage("Cannot parse the mapping for index [{}]", indexName), e);
-            throw e;
+            return Version.V_EMPTY;
         }
     }
 


### PR DESCRIPTION
In SystemIndexManager.readMappingVersion(), we currently throw an exception in a few cases if we cannot find a valid version. For example in some really old versions of certain system indices we see version numbers like `7090399`. This causes a stack trace like:
```
[2022-03-21T00:15:08,643][ERROR][o.e.i.SystemIndexManager ] [mxfuobey] Cannot parse the mapping for index [.ml-meta]
java.lang.IllegalArgumentException: the version needs to contain major, minor, and revision, and optionally the build: 7090399
        at org.elasticsearch.Version.fromStringSlow(Version.java:293) ~[elasticsearch-7.17.1.jar:7.17.1]
        at org.elasticsearch.Version.fromString(Version.java:283) ~[elasticsearch-7.17.1.jar:7.17.1]
        at org.elasticsearch.indices.SystemIndexManager.readMappingVersion(SystemIndexManager.java:331) [elasticsearch-7.17.1.jar:7.17.1]
        at org.elasticsearch.indices.SystemIndexManager.checkIndexMappingUpToDate(SystemIndexManager.java:284) [elasticsearch-7.17.1.jar:7.17.1]
        at org.elasticsearch.indices.SystemIndexManager.calculateIndexState(SystemIndexManager.java:253) [elasticsearch-7.17.1.jar:7.17.1]
        at org.elasticsearch.indices.SystemIndexManager.getUpgradeStatus(SystemIndexManager.java:163) [elasticsearch-7.17.1.jar:7.17.1]
        at org.elasticsearch.indices.SystemIndexManager.clusterChanged(SystemIndexManager.java:105) [elasticsearch-7.17.1.jar:7.17.1]
        at org.elasticsearch.cluster.service.ClusterApplierService.callClusterStateListener(ClusterApplierService.java:573) [elasticsearch-7.17.1.jar:7.17.1]
        at org.elasticsearch.cluster.service.ClusterApplierService.callClusterStateListeners(ClusterApplierService.java:559) [elasticsearch-7.17.1.jar:7.17.1]
        at org.elasticsearch.cluster.service.ClusterApplierService.applyChanges(ClusterApplierService.java:519) [elasticsearch-7.17.1.jar:7.17.1]
        at org.elasticsearch.cluster.service.ClusterApplierService.runTask(ClusterApplierService.java:428) [elasticsearch-7.17.1.jar:7.17.1]
        at org.elasticsearch.cluster.service.ClusterApplierService.access$000(ClusterApplierService.java:56) [elasticsearch-7.17.1.jar:7.17.1]
        at org.elasticsearch.cluster.service.ClusterApplierService$UpdateTask.run(ClusterApplierService.java:154) [elasticsearch-7.17.1.jar:7.17.1]
        at org.elasticsearch.common.util.concurrent.ThreadContext$ContextPreservingRunnable.run(ThreadContext.java:718) [elasticsearch-7.17.1.jar:7.17.1]
        at org.elasticsearch.common.util.concurrent.PrioritizedEsThreadPoolExecutor$TieBreakingPrioritizedRunnable.runAndClean(PrioritizedEsThreadPoolExecutor.java:262) [elasticsearch-7.17.1.jar:7.17.1]
        at org.elasticsearch.common.util.concurrent.PrioritizedEsThreadPoolExecutor$TieBreakingPrioritizedRunnable.run(PrioritizedEsThreadPoolExecutor.java:225) [elasticsearch-7.17.1.jar:7.17.1]
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136) [?:?]
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635) [?:?]
```
This exception causes downstream failures. This PR changes it to just return an empty version (which is what we already do in several other places). 