### PR TITLE
Propagate SecurityException from painless

### DIFF
--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/PainlessScriptEngine.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/PainlessScriptEngine.java
@@ -402,6 +402,9 @@ public final class PainlessScriptEngine implements ScriptEngine {
                 }
             }, COMPILATION_CONTEXT);
             // Note that it is safe to catch any of the following errors since Painless is stateless.
+        } catch (SecurityException e) {
+            // security exceptions are rethrown so that they can propagate to the ES log, they are not user errors
+            throw e;
         } catch (OutOfMemoryError | StackOverflowError | LinkageError | Exception e) {
             throw convertToScriptException(source, e);
         }

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/phase/PainlessUserTreeToIRTreePhase.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/phase/PainlessUserTreeToIRTreePhase.java
@@ -429,7 +429,8 @@ public class PainlessUserTreeToIRTreePhase extends DefaultUserTreeToIRTreePhase 
                 LinkageError.class,
                 OutOfMemoryError.class,
                 StackOverflowError.class,
-                Exception.class)) {
+                Exception.class
+            )) {
 
                 irThrowNode = createCatchAndThrow(throwable, internalLocation, irTryNode);
 

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/phase/PainlessUserTreeToIRTreePhase.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/phase/PainlessUserTreeToIRTreePhase.java
@@ -340,6 +340,12 @@ public class PainlessUserTreeToIRTreePhase extends DefaultUserTreeToIRTreePhase 
      *
      * and
      *
+     * } catch (SecurityException e) {
+     *     throw e;
+     * }
+     *
+     * and
+     *
      * } catch (PainlessError | LinkageError | OutOfMemoryError | StackOverflowError | Exception e) {
      *     throw this.convertToScriptException(e, e.getHeaders())
      * }

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/phase/PainlessUserTreeToIRTreePhase.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/phase/PainlessUserTreeToIRTreePhase.java
@@ -353,20 +353,7 @@ public class PainlessUserTreeToIRTreePhase extends DefaultUserTreeToIRTreePhase 
             TryNode irTryNode = new TryNode(internalLocation);
             irTryNode.setBlockNode(irBlockNode);
 
-            CatchNode irCatchNode = new CatchNode(internalLocation);
-            irCatchNode.attachDecoration(new IRDExceptionType(PainlessExplainError.class));
-            irCatchNode.attachDecoration(new IRDSymbol("#painlessExplainError"));
-
-            irTryNode.addCatchNode(irCatchNode);
-
-            BlockNode irCatchBlockNode = new BlockNode(internalLocation);
-            irCatchBlockNode.attachCondition(IRCAllEscape.class);
-
-            irCatchNode.setBlockNode(irCatchBlockNode);
-
-            ThrowNode irThrowNode = new ThrowNode(internalLocation);
-
-            irCatchBlockNode.addStatementNode(irThrowNode);
+            ThrowNode irThrowNode = createCatchAndThrow(PainlessExplainError.class, internalLocation, irTryNode);
 
             InvokeCallMemberNode irInvokeCallMemberNode = new InvokeCallMemberNode(internalLocation);
             irInvokeCallMemberNode.attachDecoration(new IRDExpressionType(ScriptException.class));
@@ -425,30 +412,20 @@ public class PainlessUserTreeToIRTreePhase extends DefaultUserTreeToIRTreePhase 
 
             irInvokeCallNode.addArgumentNode(irLoadFieldMemberNode);
 
-            for (Class<?> throwable : new Class<?>[] {
+            irThrowNode = createCatchAndThrow(SecurityException.class, internalLocation, irTryNode);
+            irLoadVariableNode = new LoadVariableNode(internalLocation);
+            irLoadVariableNode.attachDecoration(new IRDExpressionType(SecurityException.class));
+            irLoadVariableNode.attachDecoration(new IRDName(getExceptionVariableName(SecurityException.class)));
+            irThrowNode.setExpressionNode(irLoadVariableNode);
+
+            for (Class<? extends Throwable> throwable : List.of(
                 PainlessError.class,
                 LinkageError.class,
                 OutOfMemoryError.class,
                 StackOverflowError.class,
-                Exception.class }) {
+                Exception.class)) {
 
-                String name = throwable.getSimpleName();
-                name = "#" + Character.toLowerCase(name.charAt(0)) + name.substring(1);
-
-                irCatchNode = new CatchNode(internalLocation);
-                irCatchNode.attachDecoration(new IRDExceptionType(throwable));
-                irCatchNode.attachDecoration(new IRDSymbol(name));
-
-                irTryNode.addCatchNode(irCatchNode);
-
-                irCatchBlockNode = new BlockNode(internalLocation);
-                irCatchBlockNode.attachCondition(IRCAllEscape.class);
-
-                irCatchNode.setBlockNode(irCatchBlockNode);
-
-                irThrowNode = new ThrowNode(internalLocation);
-
-                irCatchBlockNode.addStatementNode(irThrowNode);
+                irThrowNode = createCatchAndThrow(throwable, internalLocation, irTryNode);
 
                 irInvokeCallMemberNode = new InvokeCallMemberNode(internalLocation);
                 irInvokeCallMemberNode.attachDecoration(new IRDExpressionType(ScriptException.class));
@@ -468,7 +445,7 @@ public class PainlessUserTreeToIRTreePhase extends DefaultUserTreeToIRTreePhase 
 
                 irLoadVariableNode = new LoadVariableNode(internalLocation);
                 irLoadVariableNode.attachDecoration(new IRDExpressionType(ScriptException.class));
-                irLoadVariableNode.attachDecoration(new IRDName(name));
+                irLoadVariableNode.attachDecoration(new IRDName(getExceptionVariableName(throwable)));
 
                 irInvokeCallMemberNode.addArgumentNode(irLoadVariableNode);
 
@@ -508,6 +485,32 @@ public class PainlessUserTreeToIRTreePhase extends DefaultUserTreeToIRTreePhase 
         } catch (Exception exception) {
             throw new RuntimeException(exception);
         }
+    }
+
+    // Turn an exception class name into a local variable name to hold an object of that type
+    private static String getExceptionVariableName(Class<? extends Throwable> throwable) {
+        String name = throwable.getSimpleName();
+        return "#" + Character.toLowerCase(name.charAt(0)) + name.substring(1);
+    }
+
+    // Helper for catching a known exception type. Returns the ThrowNode to be filled in.
+    private static ThrowNode createCatchAndThrow(Class<? extends Throwable> throwable, Location internalLocation, TryNode irTryNode) {
+        String name = getExceptionVariableName(throwable);
+
+        CatchNode irCatchNode = new CatchNode(internalLocation);
+        irCatchNode.attachDecoration(new IRDExceptionType(throwable));
+        irCatchNode.attachDecoration(new IRDSymbol(name));
+
+        irTryNode.addCatchNode(irCatchNode);
+
+        BlockNode irCatchBlockNode = new BlockNode(internalLocation);
+        irCatchBlockNode.attachCondition(IRCAllEscape.class);
+
+        irCatchNode.setBlockNode(irCatchBlockNode);
+        ThrowNode irThrowNode = new ThrowNode(internalLocation);
+        irCatchBlockNode.addStatementNode(irThrowNode);
+
+        return irThrowNode;
     }
 
     @Override

--- a/modules/lang-painless/src/main/resources/org/elasticsearch/painless/java.lang.txt
+++ b/modules/lang-painless/src/main/resources/org/elasticsearch/painless/java.lang.txt
@@ -1076,11 +1076,6 @@ class java.lang.RuntimeException {
   (String)
 }
 
-class java.lang.SecurityException {
-  ()
-  (String)
-}
-
 class java.lang.StringIndexOutOfBoundsException {
   ()
   (String)

--- a/modules/lang-painless/src/test/java/org/elasticsearch/painless/WhenThingsGoWrongTests.java
+++ b/modules/lang-painless/src/test/java/org/elasticsearch/painless/WhenThingsGoWrongTests.java
@@ -212,11 +212,10 @@ public class WhenThingsGoWrongTests extends ScriptTestCase {
     }
 
     public void testSecurityException() {
-        expectThrows(SecurityException.class, () -> {
-            exec("params.v.get();", Map.of("v", (Supplier<String>) () -> {
-                throw new SecurityException();
-            }), true);
-        });
+        expectThrows(
+            SecurityException.class,
+            () -> { exec("params.v.get();", Map.of("v", (Supplier<String>) () -> { throw new SecurityException(); }), true); }
+        );
     }
 
     public void testOutOfMemoryError() {

--- a/modules/lang-painless/src/test/java/org/elasticsearch/painless/WhenThingsGoWrongTests.java
+++ b/modules/lang-painless/src/test/java/org/elasticsearch/painless/WhenThingsGoWrongTests.java
@@ -15,6 +15,8 @@ import org.elasticsearch.script.ScriptException;
 
 import java.lang.invoke.WrongMethodTypeException;
 import java.util.Collections;
+import java.util.Map;
+import java.util.function.Supplier;
 
 import static java.util.Collections.emptyMap;
 import static java.util.Collections.singletonMap;
@@ -207,6 +209,14 @@ public class WhenThingsGoWrongTests extends ScriptTestCase {
 
     public void testBadBoxingCast() {
         expectScriptThrows(ClassCastException.class, () -> { exec("BitSet bs = new BitSet(); bs.and(2);"); });
+    }
+
+    public void testSecurityException() {
+        expectThrows(SecurityException.class, () -> {
+            exec("params.v.get();", Map.of("v", (Supplier<String>) () -> {
+                throw new SecurityException();
+            }), true);
+        });
     }
 
     public void testOutOfMemoryError() {


### PR DESCRIPTION
Painless calls out to various Elasticsearch classes, for example when
accessing doc values. If there is an exception thrown from those
Elasticsearch classes, it is caught by painless and wrapped in a
ScriptException. However, this is not always correct, as that error
might be something that is not the users fault.

If a SecurityException is thrown while load data, for example because
an appropriate doPrivileged block was not present, we want the exception
to propagate all the way back out of the code calling painless, so that
it can be logged as a system error. This commit changes painless'
exception handling to account for SecurityException and rethrow.

relates #85217