### PR TITLE
[7.17] Cleanup SystemIndexMigration tests (#84281)

### DIFF
--- a/modules/reindex/src/internalClusterTest/java/org/elasticsearch/migration/AbstractFeatureMigrationIntegTest.java
+++ b/modules/reindex/src/internalClusterTest/java/org/elasticsearch/migration/AbstractFeatureMigrationIntegTest.java
@@ -53,6 +53,7 @@ import static org.hamcrest.Matchers.endsWith;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 
+@ESIntegTestCase.ClusterScope(scope = ESIntegTestCase.Scope.TEST, numDataNodes = 0, numClientNodes = 0, autoManageMasterNodes = false)
 public abstract class AbstractFeatureMigrationIntegTest extends ESIntegTestCase {
 
     static final String VERSION_META_KEY = "version";
@@ -118,8 +119,15 @@ public abstract class AbstractFeatureMigrationIntegTest extends ESIntegTestCase 
     static final int EXTERNAL_UNMANAGED_FLAG_VALUE = 4;
     static final String ASSOCIATED_INDEX_NAME = ".my-associated-idx";
 
+    protected String masterAndDataNode;
+    protected String masterName;
+
     @Before
-    public void setupTestPlugin() {
+    public void setup() {
+        internalCluster().setBootstrapMasterNodeIndex(0);
+        masterName = internalCluster().startMasterOnlyNode();
+        masterAndDataNode = internalCluster().startNode();
+
         TestPlugin testPlugin = getPlugin(TestPlugin.class);
         testPlugin.preMigrationHook.set((state) -> Collections.emptyMap());
         testPlugin.postMigrationHook.set((state, metadata) -> {});

--- a/modules/reindex/src/internalClusterTest/java/org/elasticsearch/migration/FeatureMigrationIT.java
+++ b/modules/reindex/src/internalClusterTest/java/org/elasticsearch/migration/FeatureMigrationIT.java
@@ -79,9 +79,6 @@ public class FeatureMigrationIT extends AbstractFeatureMigrationIntegTest {
         createSystemIndexForDescriptor(EXTERNAL_MANAGED);
         createSystemIndexForDescriptor(EXTERNAL_UNMANAGED);
 
-        TestPlugin.preMigrationHook.set((state) -> Collections.emptyMap());
-        TestPlugin.postMigrationHook.set((state, metadata) -> {});
-
         ensureGreen();
 
         PostFeatureUpgradeRequest migrationRequest = new PostFeatureUpgradeRequest();
@@ -132,7 +129,7 @@ public class FeatureMigrationIT extends AbstractFeatureMigrationIntegTest {
 
         SetOnce<Boolean> preUpgradeHookCalled = new SetOnce<>();
         SetOnce<Boolean> postUpgradeHookCalled = new SetOnce<>();
-        TestPlugin.preMigrationHook.set(clusterState -> {
+        getPlugin(TestPlugin.class).preMigrationHook.set(clusterState -> {
             // Check that the ordering of these calls is correct.
             assertThat(postUpgradeHookCalled.get(), nullValue());
             Map<String, Object> metadata = new HashMap<>();
@@ -149,7 +146,7 @@ public class FeatureMigrationIT extends AbstractFeatureMigrationIntegTest {
             return metadata;
         });
 
-        TestPlugin.postMigrationHook.set((clusterState, metadata) -> {
+        getPlugin(TestPlugin.class).postMigrationHook.set((clusterState, metadata) -> {
             assertThat(preUpgradeHookCalled.get(), is(true));
 
             assertThat(metadata, hasEntry("stringKey", "stringValue"));
@@ -242,9 +239,6 @@ public class FeatureMigrationIT extends AbstractFeatureMigrationIntegTest {
             .orElse(INTERNAL_UNMANAGED.getIndexPattern().replace("*", "old"));
         client().admin().indices().prepareUpdateSettings(indexName).setSettings(Settings.builder().put("index.blocks.write", true)).get();
 
-        TestPlugin.preMigrationHook.set((state) -> Collections.emptyMap());
-        TestPlugin.postMigrationHook.set((state, metadata) -> {});
-
         ensureGreen();
 
         client().execute(PostFeatureUpgradeAction.INSTANCE, new PostFeatureUpgradeRequest()).get();
@@ -261,9 +255,6 @@ public class FeatureMigrationIT extends AbstractFeatureMigrationIntegTest {
 
     public void testMigrationWillRunAfterError() throws Exception {
         createSystemIndexForDescriptor(INTERNAL_MANAGED);
-
-        TestPlugin.preMigrationHook.set((state) -> Collections.emptyMap());
-        TestPlugin.postMigrationHook.set((state, metadata) -> {});
 
         ensureGreen();
 

--- a/modules/reindex/src/internalClusterTest/java/org/elasticsearch/migration/MultiFeatureMigrationIT.java
+++ b/modules/reindex/src/internalClusterTest/java/org/elasticsearch/migration/MultiFeatureMigrationIT.java
@@ -100,7 +100,7 @@ public class MultiFeatureMigrationIT extends AbstractFeatureMigrationIntegTest {
         SetOnce<Boolean> secondPluginPreMigrationHookCalled = new SetOnce<>();
         SetOnce<Boolean> secondPluginPostMigrationHookCalled = new SetOnce<>();
 
-        TestPlugin.preMigrationHook.set(clusterState -> {
+        getPlugin(TestPlugin.class).preMigrationHook.set(clusterState -> {
             // None of the other hooks should have been called yet.
             assertThat(postMigrationHookCalled.get(), nullValue());
             assertThat(secondPluginPreMigrationHookCalled.get(), nullValue());
@@ -117,7 +117,7 @@ public class MultiFeatureMigrationIT extends AbstractFeatureMigrationIntegTest {
             return metadata;
         });
 
-        TestPlugin.postMigrationHook.set((clusterState, metadata) -> {
+        getPlugin(TestPlugin.class).postMigrationHook.set((clusterState, metadata) -> {
             // Check that the hooks have been called or not as expected.
             assertThat(preMigrationHookCalled.get(), is(true));
             assertThat(secondPluginPreMigrationHookCalled.get(), nullValue());
@@ -133,7 +133,7 @@ public class MultiFeatureMigrationIT extends AbstractFeatureMigrationIntegTest {
             hooksCalled.countDown();
         });
 
-        SecondPlugin.preMigrationHook.set(clusterState -> {
+        getPlugin(SecondPlugin.class).preMigrationHook.set(clusterState -> {
             // Check that the hooks have been called or not as expected.
             assertThat(preMigrationHookCalled.get(), is(true));
             assertThat(postMigrationHookCalled.get(), is(true));
@@ -155,7 +155,7 @@ public class MultiFeatureMigrationIT extends AbstractFeatureMigrationIntegTest {
             return metadata;
         });
 
-        SecondPlugin.postMigrationHook.set((clusterState, metadata) -> {
+        getPlugin(SecondPlugin.class).postMigrationHook.set((clusterState, metadata) -> {
             // Check that the hooks have been called or not as expected.
             assertThat(preMigrationHookCalled.get(), is(true));
             assertThat(postMigrationHookCalled.get(), is(true));
@@ -263,8 +263,8 @@ public class MultiFeatureMigrationIT extends AbstractFeatureMigrationIntegTest {
         .setAliasName(".second-internal-managed-alias")
         .setPrimaryIndex(".second-int-man-old")
         .setType(SystemIndexDescriptor.Type.INTERNAL_MANAGED)
-        .setSettings(createSimpleSettings(Version.V_6_0_0, 0))
-        .setMappings(createSimpleMapping(true, true, true))
+        .setSettings(createSettings(Version.V_6_0_0, 0))
+        .setMappings(createMapping(true, true, true))
         .setOrigin(ORIGIN)
         .setVersionMetaKey(VERSION_META_KEY)
         .setAllowedElasticProductOrigins(Collections.emptyList())
@@ -274,12 +274,10 @@ public class MultiFeatureMigrationIT extends AbstractFeatureMigrationIntegTest {
 
     public static class SecondPlugin extends Plugin implements SystemIndexPlugin {
 
-        private static final AtomicReference<Function<ClusterState, Map<String, Object>>> preMigrationHook = new AtomicReference<>();
-        private static final AtomicReference<BiConsumer<ClusterState, Map<String, Object>>> postMigrationHook = new AtomicReference<>();
+        private final AtomicReference<Function<ClusterState, Map<String, Object>>> preMigrationHook = new AtomicReference<>();
+        private final AtomicReference<BiConsumer<ClusterState, Map<String, Object>>> postMigrationHook = new AtomicReference<>();
 
-        public SecondPlugin() {
-
-        }
+        public SecondPlugin() {}
 
         @Override
         public String getFeatureName() {

--- a/modules/reindex/src/internalClusterTest/java/org/elasticsearch/migration/SystemIndexMigrationIT.java
+++ b/modules/reindex/src/internalClusterTest/java/org/elasticsearch/migration/SystemIndexMigrationIT.java
@@ -24,6 +24,7 @@ import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.reindex.ReindexPlugin;
 import org.elasticsearch.test.ESIntegTestCase;
 import org.elasticsearch.test.InternalTestCluster;
+import org.junit.Before;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -63,15 +64,20 @@ public class SystemIndexMigrationIT extends AbstractFeatureMigrationIntegTest {
         return plugins;
     }
 
-    public void testSystemIndexMigrationCanBeInterruptedWithShutdown() throws Exception {
+    @Before
+    public void init() {
+        // master node is created in AbstractFeatureMigrationIntegTest#setupTestPlugin when trying to access plugins
+        internalCluster().setBootstrapMasterNodeIndex(0);
+    }
 
+    public void testSystemIndexMigrationCanBeInterruptedWithShutdown() throws Exception {
         CyclicBarrier taskCreated = new CyclicBarrier(2);
         CyclicBarrier shutdownCompleted = new CyclicBarrier(2);
         AtomicBoolean hasBlocked = new AtomicBoolean();
 
-        internalCluster().setBootstrapMasterNodeIndex(0);
-        final String masterName = internalCluster().startMasterOnlyNode();
+        final String masterName = internalCluster().getMasterName();
         final String masterAndDataNode = internalCluster().startNode();
+
         createSystemIndexForDescriptor(INTERNAL_MANAGED);
 
         final ClusterStateListener clusterStateListener = event -> {

--- a/modules/reindex/src/internalClusterTest/java/org/elasticsearch/migration/SystemIndexMigrationIT.java
+++ b/modules/reindex/src/internalClusterTest/java/org/elasticsearch/migration/SystemIndexMigrationIT.java
@@ -22,9 +22,7 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.persistent.PersistentTasksCustomMetadata;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.reindex.ReindexPlugin;
-import org.elasticsearch.test.ESIntegTestCase;
 import org.elasticsearch.test.InternalTestCluster;
-import org.junit.Before;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -41,7 +39,6 @@ import static org.hamcrest.Matchers.equalTo;
 /**
  * This class is for testing that when restarting a node, SystemIndexMigrationTaskState can be read.
  */
-@ESIntegTestCase.ClusterScope(scope = ESIntegTestCase.Scope.TEST, numDataNodes = 0, numClientNodes = 0, autoManageMasterNodes = false)
 public class SystemIndexMigrationIT extends AbstractFeatureMigrationIntegTest {
     private static Logger logger = LogManager.getLogger(SystemIndexMigrationIT.class);
 
@@ -64,25 +61,21 @@ public class SystemIndexMigrationIT extends AbstractFeatureMigrationIntegTest {
         return plugins;
     }
 
-    @Before
-    public void init() {
-        // master node is created in AbstractFeatureMigrationIntegTest#setupTestPlugin when trying to access plugins
-        internalCluster().setBootstrapMasterNodeIndex(0);
-    }
-
     public void testSystemIndexMigrationCanBeInterruptedWithShutdown() throws Exception {
         CyclicBarrier taskCreated = new CyclicBarrier(2);
         CyclicBarrier shutdownCompleted = new CyclicBarrier(2);
         AtomicBoolean hasBlocked = new AtomicBoolean();
 
-        final String masterName = internalCluster().getMasterName();
-        final String masterAndDataNode = internalCluster().startNode();
-
         createSystemIndexForDescriptor(INTERNAL_MANAGED);
 
         final ClusterStateListener clusterStateListener = event -> {
+            PersistentTasksCustomMetadata.PersistentTask<?> task = PersistentTasksCustomMetadata.getTaskWithId(
+                event.state(),
+                SYSTEM_INDEX_UPGRADE_TASK_NAME
+            );
 
-            if (PersistentTasksCustomMetadata.getTaskWithId(event.state(), SYSTEM_INDEX_UPGRADE_TASK_NAME) != null
+            if (task != null
+                && task.getState() != null // Make sure the task is really started
                 && hasBlocked.compareAndSet(false, true)) {
                 try {
                     logger.info("Task created");

--- a/server/src/main/java/org/elasticsearch/upgrades/SystemIndexMigrationTaskState.java
+++ b/server/src/main/java/org/elasticsearch/upgrades/SystemIndexMigrationTaskState.java
@@ -33,7 +33,8 @@ import static org.elasticsearch.xcontent.ConstructingObjectParser.constructorArg
 public class SystemIndexMigrationTaskState implements PersistentTaskState {
     private static final ParseField CURRENT_INDEX_FIELD = new ParseField("current_index");
     private static final ParseField CURRENT_FEATURE_FIELD = new ParseField("current_feature");
-    private static final ParseField FEATURE_METADATA_MAP_FIELD = new ParseField("feature_metadata");
+    // scope for testing
+    static final ParseField FEATURE_METADATA_MAP_FIELD = new ParseField("feature_metadata");
 
     @SuppressWarnings(value = "unchecked")
     static final ConstructingObjectParser<SystemIndexMigrationTaskState, Void> PARSER = new ConstructingObjectParser<>(

--- a/server/src/test/java/org/elasticsearch/upgrades/SystemIndexMigrationTaskParamsXContentTests.java
+++ b/server/src/test/java/org/elasticsearch/upgrades/SystemIndexMigrationTaskParamsXContentTests.java
@@ -28,7 +28,7 @@ public class SystemIndexMigrationTaskParamsXContentTests extends AbstractXConten
 
     @Override
     protected boolean supportsUnknownFields() {
-        return false;
+        return true;
     }
 
     @Override

--- a/server/src/test/java/org/elasticsearch/upgrades/SystemIndexMigrationTaskStateXContentTests.java
+++ b/server/src/test/java/org/elasticsearch/upgrades/SystemIndexMigrationTaskStateXContentTests.java
@@ -13,6 +13,7 @@ import org.elasticsearch.xcontent.NamedXContentRegistry;
 import org.elasticsearch.xcontent.XContentParser;
 
 import java.io.IOException;
+import java.util.function.Predicate;
 
 public class SystemIndexMigrationTaskStateXContentTests extends AbstractXContentTestCase<SystemIndexMigrationTaskState> {
 
@@ -28,7 +29,13 @@ public class SystemIndexMigrationTaskStateXContentTests extends AbstractXContent
 
     @Override
     protected boolean supportsUnknownFields() {
-        return false;
+        return true;
+    }
+
+    @Override
+    protected Predicate<String> getRandomFieldsExcludeFilter() {
+        // featureCallbackMetadata is a Map<String,Object> so adding random fields there make no sense
+        return p -> p.startsWith(SystemIndexMigrationTaskState.FEATURE_METADATA_MAP_FIELD.getPreferredName());
     }
 
     @Override


### PR DESCRIPTION
Backports the following commits to 8.0:

Cleanup SystemIndexMigration tests (https://github.com/elastic/elasticsearch/pull/84281)
and
Fix randomness in SystemIndexMigrationIT #85224