### PR TITLE
[8.1] Improve DeprecationHttpIT robustness (#85235)

### DIFF
--- a/x-pack/plugin/deprecation/qa/rest/src/javaRestTest/java/org/elasticsearch/xpack/deprecation/DeprecationHttpIT.java
+++ b/x-pack/plugin/deprecation/qa/rest/src/javaRestTest/java/org/elasticsearch/xpack/deprecation/DeprecationHttpIT.java
@@ -259,7 +259,7 @@ public class DeprecationHttpIT extends ESRestTestCase {
      * <p>
      * Re-running this back-to-back helps to ensure that warnings are not being maintained across requests.
      */
-    private void doTestDeprecationWarningsAppearInHeaders() throws IOException {
+    private void doTestDeprecationWarningsAppearInHeaders() throws Exception {
         final boolean useDeprecatedField = randomBoolean();
         final boolean useNonDeprecatedSetting = randomBoolean();
 
@@ -280,10 +280,8 @@ public class DeprecationHttpIT extends ESRestTestCase {
         // trigger all deprecations
         Request request = new Request("GET", "/_test_cluster/deprecated_settings");
         request.setEntity(buildSettingsRequest(settings, useDeprecatedField ? "deprecated_settings" : "settings"));
-        final RequestOptions options = request.getOptions()
-            .toBuilder()
-            .addHeader("X-Opaque-Id", "XOpaqueId-doTestDeprecationWarningsAppearInHeaders")
-            .build();
+        String xOpaqueId = "XOpaqueId-doTestDeprecationWarningsAppearInHeaders" + randomInt();
+        final RequestOptions options = request.getOptions().toBuilder().addHeader("X-Opaque-Id", xOpaqueId).build();
         request.setOptions(options);
         Response response = client().performRequest(request);
         assertOK(response);
@@ -306,6 +304,13 @@ public class DeprecationHttpIT extends ESRestTestCase {
         for (Matcher<String> headerMatcher : headerMatchers) {
             assertThat(actualWarningValues, hasItem(headerMatcher));
         }
+        // expect to index same number of new deprecations as the number of header warnings in the response
+        assertBusy(() -> {
+            List<Map<String, Object>> documents = DeprecationTestUtils.getIndexedDeprecations(client());
+            long indexedDeprecations = documents.stream().filter(m -> xOpaqueId.equals(m.get(X_OPAQUE_ID_FIELD_NAME))).count();
+            assertThat(documents.toString(), indexedDeprecations, equalTo((long) headerMatchers.size()));
+        });
+
     }
 
     public void testDeprecationRouteThrottling() throws Exception {


### PR DESCRIPTION
Backports the following commits to 8.1:
 - Improve DeprecationHttpIT robustness (#85235)