### PR TITLE
Do not rely on git for resolving benchmark build gradle version

### DIFF
--- a/build-tools-internal/build.gradle
+++ b/build-tools-internal/build.gradle
@@ -302,19 +302,12 @@ tasks.register("bootstrapPerformanceTests", Copy) {
   def root = file('..')
   filter(ReplaceTokens, tokens: [
           testGitCommit:GitInfo.gitInfo(root).revision,
-          masterWrapper:"${ -> resolveWrapperVersion(root)}".toString(),
+          masterWrapper:"${ -> resolveMasterWrapperVersion()}".toString(),
           branchWrapper:"${-> new File(root, "build-tools-internal/src/main/resources/minimumGradleVersion").text}".toString()])
 }
 
-def resolveWrapperVersion(File root) {
-  new ByteArrayOutputStream().with { outputStream ->
-    project.exec { ExecSpec it ->
-      it.setStandardOutput(outputStream)
-      it.setWorkingDir(root)
-      it.setCommandLine("git", "show", "master:build-tools-internal/src/main/resources/minimumGradleVersion")
-    }
-    return outputStream.toString()
-  }
+def resolveMasterWrapperVersion() {
+  new URL("https://raw.githubusercontent.com/elastic/elasticsearch/master/build-tools-internal/src/main/resources/minimumGradleVersion").text.trim()
 }
 
 abstract class JacksonAlignmentRule implements ComponentMetadataRule {


### PR DESCRIPTION
On sparse checkouts this can cause trouble, so we just resolve directly from github via URL#text

Follow up on #85263