### PR TITLE
Fix version filter when generating release notes

### DIFF
--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/release/GenerateReleaseNotesTask.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/release/GenerateReleaseNotesTask.java
@@ -179,7 +179,10 @@ public class GenerateReleaseNotesTask extends DefaultTask {
 
         final List<QualifiedVersion> earlierVersions = gitWrapper.listVersions(tagWildcard)
             // Only keep earlier versions, and if `currentVersion` is a prerelease, then only prereleases too.
-            .filter(each -> each.isBefore(currentVersion) && (currentVersion.hasQualifier() == each.hasQualifier()))
+            .filter(
+                each -> each.isBefore(currentVersion)
+                    && (currentVersion.isSnapshot() || (currentVersion.hasQualifier() == each.hasQualifier()))
+            )
             .sorted(naturalOrder())
             .toList();
 


### PR DESCRIPTION
Closes #85227. The git label version filter didn't take into account
snapshot versions. Now it does.
