### PR TITLE
[7.17] Fix atomic writes in HDFS (#85210)

### DIFF
--- a/docs/changelog/85210.yaml
+++ b/docs/changelog/85210.yaml
@@ -1,0 +1,5 @@
+pr: 85210
+summary: Fix atomic writes in HDFS
+area: Snapshot/Restore
+type: bug
+issues: []


### PR DESCRIPTION
Backports the following commits to 7.17:
 - Fix atomic writes in HDFS (#85210)