### PR TITLE
[DOCS] Searchable snapshot data persistence (#85218)

### DIFF
--- a/docs/reference/searchable-snapshots/index.asciidoc
+++ b/docs/reference/searchable-snapshots/index.asciidoc
@@ -131,7 +131,8 @@ snapshot repository. While recovery is ongoing, search performance may be
 slower than with a regular index because a search may need some data that has
 not yet been retrieved into the local copy. If that happens, {es} will eagerly
 retrieve the data needed to complete the search in parallel with the ongoing
-recovery.
+recovery. On-disk data is preserved across restarts, such that the node does
+not need to re-download data that is already stored on the node after a restart.
 
 [[partially-mounted]]
 Partially mounted index::
@@ -143,7 +144,7 @@ If a search requires data that is not in the cache, {es} fetches the missing
 data from the snapshot repository. Searches that require these fetches are
 slower, but the fetched data is stored in the cache so that similar searches
 can be served more quickly in future. {es} will evict infrequently used data
-from the cache to free up space.
+from the cache to free up space. The cache is cleared when a node is restarted.
 +
 Although slower than a fully mounted index or a regular index, a
 partially mounted index still returns search results quickly, even for


### PR DESCRIPTION
Backport of #85218 

Clarified that fully mounted indices persists on-disk data across
restarts whereas partially mounted indices are cleared upon restarts.
