### PR TITLE
Speed up DatastreamTimestampFieldMapper#postParse

### DIFF
--- a/docs/changelog/85270.yaml
+++ b/docs/changelog/85270.yaml
@@ -1,0 +1,5 @@
+pr: 85270
+summary: Speed up `DatastreamTimestampFieldMapper#postParse`
+area: Data streams
+type: enhancement
+issues: []

--- a/server/src/main/java/org/elasticsearch/index/mapper/DataStreamTimestampFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/DataStreamTimestampFieldMapper.java
@@ -22,7 +22,6 @@ import org.elasticsearch.xcontent.XContentType;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.time.Instant;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 
@@ -196,26 +195,35 @@ public class DataStreamTimestampFieldMapper extends MetadataFieldMapper {
             // not configured, so skip the validation
             return;
         }
+        boolean foundFsTimestampField = false;
+        IndexableField first = null;
+        final List<IndexableField> fields = context.rootDoc().getFields();
+        for (int i = 0; i < fields.size(); i++) {
+            IndexableField indexableField = fields.get(i);
+            if (DEFAULT_PATH.equals(indexableField.name()) == false) {
+                continue;
+            }
+            if (first == null) {
+                first = indexableField;
+            }
+            if (indexableField.fieldType().docValuesType() == DocValuesType.SORTED_NUMERIC) {
+                if (foundFsTimestampField) {
+                    throw new IllegalArgumentException("data stream timestamp field [" + DEFAULT_PATH + "] encountered multiple values");
+                }
+                foundFsTimestampField = true;
+            }
+        }
 
-        IndexableField[] fields = context.rootDoc().getFields(DEFAULT_PATH);
-        if (fields.length == 0) {
+        if (first == null) {
             throw new IllegalArgumentException("data stream timestamp field [" + DEFAULT_PATH + "] is missing");
         }
-
-        long numberOfValues = Arrays.stream(fields)
-            .filter(indexableField -> indexableField.fieldType().docValuesType() == DocValuesType.SORTED_NUMERIC)
-            .count();
-        if (numberOfValues > 1) {
-            throw new IllegalArgumentException("data stream timestamp field [" + DEFAULT_PATH + "] encountered multiple values");
-        }
-
         TimestampBounds bounds = context.indexSettings().getTimestampBounds();
         if (bounds != null) {
-            validateTimestamp(bounds.startTime(), bounds.endTime(), fields[0], context);
+            validateTimestamp(bounds, first, context);
         }
     }
 
-    private void validateTimestamp(long startTime, long endTime, IndexableField field, DocumentParserContext context) {
+    private static void validateTimestamp(TimestampBounds bounds, IndexableField field, DocumentParserContext context) {
         long originValue = field.numericValue().longValue();
         long value = originValue;
 
@@ -230,6 +238,7 @@ public class DataStreamTimestampFieldMapper extends MetadataFieldMapper {
             resolution = Resolution.MILLISECONDS;
         }
 
+        final long startTime = bounds.startTime();
         if (value < startTime) {
             throw new IllegalArgumentException(
                 "time series index @timestamp value ["
@@ -239,6 +248,7 @@ public class DataStreamTimestampFieldMapper extends MetadataFieldMapper {
             );
         }
 
+        final long endTime = bounds.endTime();
         if (value >= endTime) {
             throw new IllegalArgumentException(
                 "time series index @timestamp value ["


### PR DESCRIPTION
This method took up 5% of document parsing time in many shards benchmarks.
With this change it's much cheaper though still not free for documents
with a large number of fields.

The stream creation really hurts, as does the intermediary list and array creation.

<img width="1680" alt="image" src="https://user-images.githubusercontent.com/6490959/159695034-d550c343-7e53-4592-b017-f8f7fd2f477a.png">
