### PR TITLE
[8.1] Return empty version instead of blowing up if we cannot find it (#85244)

### DIFF
--- a/docs/changelog/85244.yaml
+++ b/docs/changelog/85244.yaml
@@ -1,0 +1,5 @@
+pr: 85244
+summary: Return empty version instead of blowing up if we cannot find it
+area: Infra/Core
+type: bug
+issues: []

--- a/server/src/main/java/org/elasticsearch/indices/SystemIndexManager.java
+++ b/server/src/main/java/org/elasticsearch/indices/SystemIndexManager.java
@@ -311,12 +311,9 @@ public class SystemIndexManager implements ClusterStateListener {
                 return Version.V_EMPTY;
             }
             return Version.fromString(versionString);
-        } catch (ElasticsearchParseException e) {
+        } catch (ElasticsearchParseException | IllegalArgumentException e) {
             logger.error(new ParameterizedMessage("Cannot parse the mapping for index [{}]", indexName), e);
-            throw new ElasticsearchException("Cannot parse the mapping for index [{}]", e, indexName);
-        } catch (IllegalArgumentException e) {
-            logger.error(new ParameterizedMessage("Cannot parse the mapping for index [{}]", indexName), e);
-            throw e;
+            return Version.V_EMPTY;
         }
     }
 


### PR DESCRIPTION
Backports the following commits to 8.1:
 - Return empty version instead of blowing up if we cannot find it (#85244)