### PR TITLE
Fix restart with auto-expand replicas

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/NodeShutdownAllocationDecider.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/NodeShutdownAllocationDecider.java
@@ -83,7 +83,7 @@ public class NodeShutdownAllocationDecider extends AllocationDecider {
             case RESTART -> allocation.decision(
                 Decision.YES,
                 NAME,
-                "node [%s] is restarting",
+                "node [%s] is not preparing for removal from the cluster (is " + "restarting)",
                 node.getId()
             );
             case REPLACE, REMOVE -> allocation.decision(

--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/NodeShutdownAllocationDecider.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/NodeShutdownAllocationDecider.java
@@ -76,14 +76,14 @@ public class NodeShutdownAllocationDecider extends AllocationDecider {
         SingleNodeShutdownMetadata thisNodeShutdownMetadata = getNodeShutdownMetadata(allocation.metadata(), node.getId());
 
         if (thisNodeShutdownMetadata == null) {
-            return allocation.decision(Decision.YES, NAME, "node [%s] is not preparing for removal from the cluster");
+            return allocation.decision(Decision.YES, NAME, "node [%s] is not preparing for removal from the cluster", node.getId());
         }
 
         return switch (thisNodeShutdownMetadata.getType()) {
             case RESTART -> allocation.decision(
-                Decision.NO,
+                Decision.YES,
                 NAME,
-                "node [%s] is preparing to restart, auto-expansion waiting until it is complete",
+                "node [%s] is restarting",
                 node.getId()
             );
             case REPLACE, REMOVE -> allocation.decision(

--- a/server/src/test/java/org/elasticsearch/cluster/routing/allocation/decider/NodeShutdownAllocationDeciderTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/allocation/decider/NodeShutdownAllocationDeciderTests.java
@@ -138,7 +138,7 @@ public class NodeShutdownAllocationDeciderTests extends ESAllocationTestCase {
         assertThat(decision.getExplanation(), equalTo("node [" + DATA_NODE.getId() + "] is preparing to be removed from the cluster"));
     }
 
-    public void testCannotAutoExpandToRestartingNode() {
+    public void testCanAutoExpandToRestartingNode() {
         ClusterState state = prepareState(
             service.reroute(ClusterState.EMPTY_STATE, "initial state"),
             SingleNodeShutdownMetadata.Type.RESTART
@@ -147,10 +147,24 @@ public class NodeShutdownAllocationDeciderTests extends ESAllocationTestCase {
         allocation.debugDecision(true);
 
         Decision decision = decider.shouldAutoExpandToNode(indexMetadata, DATA_NODE, allocation);
-        assertThat(decision.type(), equalTo(Decision.Type.NO));
+        assertThat(decision.type(), equalTo(Decision.Type.YES));
         assertThat(
             decision.getExplanation(),
-            equalTo("node [" + DATA_NODE.getId() + "] is preparing to restart, auto-expansion waiting until it is complete")
+            equalTo("node [" + DATA_NODE.getId() + "] is restarting")
+        );
+    }
+
+    public void testCanAutoExpandToNodeThatIsNotShuttingDown() {
+        ClusterState state = service.reroute(ClusterState.EMPTY_STATE, "initial state");
+
+        RoutingAllocation allocation = new RoutingAllocation(allocationDeciders, state, null, null, 0);
+        allocation.debugDecision(true);
+
+        Decision decision = decider.shouldAutoExpandToNode(indexMetadata, DATA_NODE, allocation);
+        assertThat(decision.type(), equalTo(Decision.Type.YES));
+        assertThat(
+            decision.getExplanation(),
+            equalTo("node [" + DATA_NODE.getId() + "] is not preparing for removal from the cluster")
         );
     }
 

--- a/server/src/test/java/org/elasticsearch/cluster/routing/allocation/decider/NodeShutdownAllocationDeciderTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/allocation/decider/NodeShutdownAllocationDeciderTests.java
@@ -150,7 +150,7 @@ public class NodeShutdownAllocationDeciderTests extends ESAllocationTestCase {
         assertThat(decision.type(), equalTo(Decision.Type.YES));
         assertThat(
             decision.getExplanation(),
-            equalTo("node [" + DATA_NODE.getId() + "] is restarting")
+            equalTo("node [" + DATA_NODE.getId() + "] is not preparing for removal from the cluster (is restarting)")
         );
     }
 
@@ -162,10 +162,7 @@ public class NodeShutdownAllocationDeciderTests extends ESAllocationTestCase {
 
         Decision decision = decider.shouldAutoExpandToNode(indexMetadata, DATA_NODE, allocation);
         assertThat(decision.type(), equalTo(Decision.Type.YES));
-        assertThat(
-            decision.getExplanation(),
-            equalTo("node [" + DATA_NODE.getId() + "] is not preparing for removal from the cluster")
-        );
+        assertThat(decision.getExplanation(), equalTo("node [" + DATA_NODE.getId() + "] is not preparing for removal from the cluster"));
     }
 
     public void testCannotAutoExpandToRemovingNode() {

--- a/x-pack/plugin/shutdown/src/internalClusterTest/java/org/elasticsearch/xpack/shutdown/NodeShutdownShardsIT.java
+++ b/x-pack/plugin/shutdown/src/internalClusterTest/java/org/elasticsearch/xpack/shutdown/NodeShutdownShardsIT.java
@@ -493,34 +493,47 @@ public class NodeShutdownShardsIT extends ESIntegTestCase {
     public void testAutoExpandDuringRestart() throws Exception {
         final String primaryNode = internalCluster().startNode();
         final String primaryNodeId = getNodeId(primaryNode);
-        createIndex("myindex",
-            Settings.builder().put("index.number_of_shards", 1).put("index.auto_expand_replicas", randomFrom("0-all", "0-1")).build());
+        createIndex(
+            "myindex",
+            Settings.builder().put("index.number_of_shards", 1).put("index.auto_expand_replicas", randomFrom("0-all", "0-1")).build()
+        );
 
         final String nodeB = internalCluster().startNode();
         assertBusy(() -> {
-            assertThat(client().admin().indices().prepareGetSettings("myindex").setNames("index.number_of_replicas").get().getSetting(
-                "myindex",
-                "index.number_of_replicas"), equalTo("1"));
+            assertThat(
+                client().admin()
+                    .indices()
+                    .prepareGetSettings("myindex")
+                    .setNames("index.number_of_replicas")
+                    .get()
+                    .getSetting("myindex", "index.number_of_replicas"),
+                equalTo("1")
+            );
         });
         ensureGreen("myindex");
 
         // Mark the node for shutdown
-        assertAcked(client().execute(PutShutdownNodeAction.INSTANCE, new PutShutdownNodeAction.Request(
-            primaryNodeId,
-            SingleNodeShutdownMetadata.Type.RESTART,
-            this.getTestName(),
-            null,
-            null
-        )).get());
+        assertAcked(
+            client().execute(
+                PutShutdownNodeAction.INSTANCE,
+                new PutShutdownNodeAction.Request(primaryNodeId, SingleNodeShutdownMetadata.Type.RESTART, this.getTestName(), null, null)
+            ).get()
+        );
 
         // RESTART did not reroute, neither should it when we no longer contract replicas, but we provoke it here in the test to ensure
         // that auto-expansion has run.
         updateIndexSettings("myindex", Settings.builder().put("index.routing.allocation.exclude.name", "non-existent"));
 
         assertBusy(() -> {
-            assertThat(client().admin().indices().prepareGetSettings("myindex").setNames("index.number_of_replicas").get().getSetting(
-                "myindex",
-                "index.number_of_replicas"), equalTo("1"));
+            assertThat(
+                client().admin()
+                    .indices()
+                    .prepareGetSettings("myindex")
+                    .setNames("index.number_of_replicas")
+                    .get()
+                    .getSetting("myindex", "index.number_of_replicas"),
+                equalTo("1")
+            );
         });
 
         client().prepareIndex("myindex").setSource("field", "value");

--- a/x-pack/plugin/shutdown/src/internalClusterTest/java/org/elasticsearch/xpack/shutdown/NodeShutdownShardsIT.java
+++ b/x-pack/plugin/shutdown/src/internalClusterTest/java/org/elasticsearch/xpack/shutdown/NodeShutdownShardsIT.java
@@ -18,6 +18,7 @@ import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.metadata.SingleNodeShutdownMetadata;
 import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.cluster.routing.IndexRoutingTable;
 import org.elasticsearch.cluster.routing.RoutingNodesHelper;
 import org.elasticsearch.cluster.routing.ShardRouting;
 import org.elasticsearch.cluster.routing.ShardRoutingState;
@@ -35,6 +36,7 @@ import java.util.stream.Collectors;
 
 import static org.elasticsearch.cluster.metadata.SingleNodeShutdownMetadata.Status.COMPLETE;
 import static org.elasticsearch.cluster.metadata.SingleNodeShutdownMetadata.Status.STALLED;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
 import static org.hamcrest.Matchers.equalTo;
 
 @ESIntegTestCase.ClusterScope(scope = ESIntegTestCase.Scope.TEST, numDataNodes = 0, numClientNodes = 0)
@@ -479,6 +481,59 @@ public class NodeShutdownShardsIT extends ESIntegTestCase {
         internalCluster().restartNode(nodeC);
 
         // All shards for the index should be allocated
+        ensureGreen("myindex");
+    }
+
+    /**
+     * Test that a node that is restarting does not affect auto-expand and that 0-1/0-all auto-expand indices stay available during
+     * shutdown for restart and restart.
+     * We used to have a bug where we would not auto-expand to a restarting node. That in essence meant that the index would contract. If
+     * the primary were on the restarting node, we would end up with one shard on that sole node. The subsequent restart would make that
+     * index unavailable.
+     */
+    public void testAutoExpandDuringRestart() throws Exception {
+        final String primaryNode = internalCluster().startNode();
+        final String primaryNodeId = getNodeId(primaryNode);
+        createIndex("myindex",
+            Settings.builder().put("index.number_of_shards", 1).put("index.auto_expand_replicas", randomFrom("0-all", "0-1")).build());
+
+        final String nodeB = internalCluster().startNode();
+        assertBusy(() -> {
+            assertThat(client().admin().indices().prepareGetSettings("myindex").setNames("index.number_of_replicas").get().getSetting(
+                "myindex",
+                "index.number_of_replicas"), equalTo("1"));
+        });
+        ensureGreen("myindex");
+
+        // Mark the node for shutdown
+        assertAcked(client().execute(PutShutdownNodeAction.INSTANCE, new PutShutdownNodeAction.Request(
+            primaryNodeId,
+            SingleNodeShutdownMetadata.Type.RESTART,
+            this.getTestName(),
+            null,
+            null
+        )).get());
+
+        // RESTART did not reroute, neither should it when we no longer contract replicas, but we provoke it here in the test to ensure
+        // that auto-expansion has run.
+        updateIndexSettings("myindex", Settings.builder().put("index.routing.allocation.exclude.name", "non-existent"));
+
+        assertBusy(() -> {
+            assertThat(client().admin().indices().prepareGetSettings("myindex").setNames("index.number_of_replicas").get().getSetting(
+                "myindex",
+                "index.number_of_replicas"), equalTo("1"));
+        });
+
+        client().prepareIndex("myindex").setSource("field", "value");
+
+        internalCluster().restartNode(primaryNode, new InternalTestCluster.RestartCallback() {
+            @Override
+            public Settings onNodeStopped(String nodeName) throws Exception {
+                ensureYellow("myindex");
+                return super.onNodeStopped(nodeName);
+            }
+        });
+
         ensureGreen("myindex");
     }
 

--- a/x-pack/plugin/shutdown/src/internalClusterTest/java/org/elasticsearch/xpack/shutdown/NodeShutdownShardsIT.java
+++ b/x-pack/plugin/shutdown/src/internalClusterTest/java/org/elasticsearch/xpack/shutdown/NodeShutdownShardsIT.java
@@ -18,7 +18,6 @@ import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.metadata.SingleNodeShutdownMetadata;
 import org.elasticsearch.cluster.node.DiscoveryNode;
-import org.elasticsearch.cluster.routing.IndexRoutingTable;
 import org.elasticsearch.cluster.routing.RoutingNodesHelper;
 import org.elasticsearch.cluster.routing.ShardRouting;
 import org.elasticsearch.cluster.routing.ShardRoutingState;


### PR DESCRIPTION
No longer contract `number_of_replicas` when a node is marked
restarting, since this poses a risk of the shard/index becoming
unavailable.
