### PR TITLE
Wait longer for CCR auto-follow stats to appear in monitoring index

### DIFF
--- a/x-pack/plugin/ccr/qa/multi-cluster/src/test/java/org/elasticsearch/xpack/ccr/AutoFollowIT.java
+++ b/x-pack/plugin/ccr/qa/multi-cluster/src/test/java/org/elasticsearch/xpack/ccr/AutoFollowIT.java
@@ -105,7 +105,6 @@ public class AutoFollowIT extends ESCCRRestTestCase {
         }
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/84403")
     public void testAutoFollowPatterns() throws Exception {
         if ("follow".equals(targetCluster) == false) {
             logger.info("skipping test, waiting for target cluster [follow]");
@@ -176,14 +175,12 @@ public class AutoFollowIT extends ESCCRRestTestCase {
                 assertThat(indexExists(excludedIndex), is(false));
             });
 
-            assertBusy(() -> {
-                verifyCcrMonitoring("metrics-20210101", "metrics-20210101");
-                verifyAutoFollowMonitoring();
-            }, 30, TimeUnit.SECONDS);
+            assertLongBusy(() -> verifyCcrMonitoring("metrics-20210101", "metrics-20210101"));
+            assertLongBusy(ESCCRRestTestCase::verifyAutoFollowMonitoring);
 
         } finally {
-            cleanUpLeader(List.of("metrics-20210101", excludedIndex), List.of(), List.of());
             cleanUpFollower(List.of("metrics-20210101"), List.of(), List.of(autoFollowPatternName));
+            cleanUpLeader(List.of("metrics-20210101", excludedIndex), List.of(), List.of());
         }
     }
 


### PR DESCRIPTION
The test `AutoFollowIT.testAutoFollowPatterns()` failed multiple times when waiting for CCR's auto-follow stats to be collected and indexed in the `.monitoring-es-*` index. This is possibly because monitoring data are collected every 10 seconds and some of them can take more time to be collected, exceeding the 30s timeout in the test.

This pull request re-uses the `assertLongBusy()` so that the test will wait more time for the data to show up and in case the data are not here it will prints out the current CCR's auto-follow stats for debugging purpose. 

Closes #84403