### PR TITLE
Speed up ILM Logging

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/Step.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/Step.java
@@ -166,7 +166,7 @@ public abstract class Step {
 
         @Override
         public String toString() {
-            return Strings.toString(this);
+            return "{\"phase\":\"" + phase + "\",\"action\":\"" + action + "\",\"name\":\"" + name + "\"}";
         }
 
         @Override

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/StepKeyTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/StepKeyTests.java
@@ -6,10 +6,14 @@
  */
 package org.elasticsearch.xpack.core.ilm;
 
+import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.test.AbstractSerializingTestCase;
 import org.elasticsearch.xcontent.XContentParser;
+import org.elasticsearch.xcontent.json.JsonXContent;
 import org.elasticsearch.xpack.core.ilm.Step.StepKey;
+
+import java.io.IOException;
 
 public class StepKeyTests extends AbstractSerializingTestCase<StepKey> {
 
@@ -46,5 +50,15 @@ public class StepKeyTests extends AbstractSerializingTestCase<StepKey> {
         }
 
         return new StepKey(phase, action, step);
+    }
+
+    public void testToString() throws IOException {
+        // toString yields parseable json
+        StepKey s = randomStepKey();
+        XContentParser parser = createParser(JsonXContent.jsonXContent, s.toString());
+        assertEquals(s, StepKey.parse(parser));
+
+        // although we're not actually using Strings.toString for performance reasons, we expect the same result as if we had
+        assertEquals(Strings.toString(s), s.toString());
     }
 }


### PR DESCRIPTION
We serialize the step key a lot in logging and use the very expensive `Strings.toString` for it.
With changes to ILM incoming that massively improve ILM performance across the board this is one of the
few remaining slow spots in profiling.
Just using string concatenation instead while leaving the format unchange almost fully removes
the `toString` method and thus the logging from profiling.

Essentially this makes the left-hand side of this profile of ILM CS application as well go away for a 50% speedup (as well as a bunch of other things where ILM is hot):

<img width="1887" alt="image" src="https://user-images.githubusercontent.com/6490959/159740095-0f48cb41-83a9-4329-b5e5-93eb70d88ea8.png">

