### PR TITLE
Update secure-settings.asciidoc

### DIFF
--- a/docs/reference/setup/secure-settings.asciidoc
+++ b/docs/reference/setup/secure-settings.asciidoc
@@ -12,7 +12,8 @@ settings to the keystore causes {es} to fail to start. To see whether a setting
 is supported in the keystore, look for a "Secure" qualifier the setting
 reference.
 
-All the modifications to the keystore take effect only after restarting {es}.
+All the modifications to secure settings take effect only after restarting {es}, except
+for the keystore reloadable-secure-settings.
 
 These settings, just like the regular ones in the `elasticsearch.yml` config file,
 need to be specified on each node in the cluster. Currently, all secure settings
@@ -24,8 +25,7 @@ are node-specific settings that must have the same value on every node.
 
 Just like the settings values in `elasticsearch.yml`, changes to the keystore
 contents are not automatically applied to the running {es} node. Re-reading
-settings requires a node restart. However, certain secure settings are marked as
-*reloadable*. Such settings can be <<cluster-nodes-reload-secure-settings, re-read and applied on a running node>>.
+*reloadable* settings requires a reload. Such settings can be <<cluster-nodes-reload-secure-settings, re-read and applied on a running node>>.
 
 The values of all secure settings, *reloadable* or not, must be identical
 across all cluster nodes. After making the desired secure settings changes,


### PR DESCRIPTION
Reloadable secure settings are not reloaded after node restart. After using the `bin/elasticsearch-keystore add` command, call:

[source,console]
----
POST _nodes/reload_secure_settings
{
  "secure_settings_password": "keystore-password" <1>
}

to reload secure settings from keystore.

<!--
Thank you for your interest in and contributing to Elasticsearch! There
are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your
attention.
-->

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/elasticsearch/blob/master/CONTRIBUTING.md)?
- If submitting code, have you built your formula locally prior to submission with `gradle check`?
- If submitting code, is your pull request against master? Unless there is a good reason otherwise, we prefer pull requests against master and will backport as needed.
- If submitting code, have you checked that your submission is for an [OS and architecture that we support](https://www.elastic.co/support/matrix#show_os)?
- If you are submitting this code for a class then read our [policy](https://github.com/elastic/elasticsearch/blob/master/CONTRIBUTING.md#contributing-as-part-of-a-class) for that.
