### PR TITLE
[8.1] No longer require master node to install Watcher templates (#85287)

### DIFF
--- a/docs/changelog/85287.yaml
+++ b/docs/changelog/85287.yaml
@@ -1,0 +1,6 @@
+pr: 85287
+summary: No longer require master node to install Watcher templates
+area: Watcher
+type: bug
+issues:
+ - 85043

--- a/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/support/WatcherIndexTemplateRegistry.java
+++ b/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/support/WatcherIndexTemplateRegistry.java
@@ -94,12 +94,4 @@ public class WatcherIndexTemplateRegistry extends IndexTemplateRegistry {
             .map(s -> Integer.valueOf(s.substring(s.lastIndexOf('-') + 1)))
             .anyMatch(version -> version >= 12);
     }
-
-    @Override
-    protected boolean requiresMasterNode() {
-        // These installs a composable index template which is only supported in early versions of 7.x
-        // In mixed cluster without this set to true can result in errors in the logs during rolling upgrades.
-        // If these template(s) are only installed via elected master node then composable templates are available.
-        return true;
-    }
 }


### PR DESCRIPTION
Backports the following commits to 8.1:
 - No longer require master node to install Watcher templates (#85287)