### PR TITLE
Remove hppc from o.e.index tests

### DIFF
--- a/server/src/test/java/org/elasticsearch/index/engine/CombinedDeletionPolicyTests.java
+++ b/server/src/test/java/org/elasticsearch/index/engine/CombinedDeletionPolicyTests.java
@@ -8,8 +8,6 @@
 
 package org.elasticsearch.index.engine;
 
-import com.carrotsearch.hppc.LongArrayList;
-
 import org.apache.lucene.index.IndexCommit;
 import org.apache.lucene.store.Directory;
 import org.elasticsearch.index.seqno.RetentionLeases;
@@ -50,7 +48,7 @@ public class CombinedDeletionPolicyTests extends ESTestCase {
         TranslogDeletionPolicy translogPolicy = new TranslogDeletionPolicy();
         CombinedDeletionPolicy indexPolicy = newCombinedDeletionPolicy(translogPolicy, softDeletesPolicy, globalCheckpoint);
 
-        final LongArrayList maxSeqNoList = new LongArrayList();
+        final List<Long> maxSeqNoList = new ArrayList<>();
         final List<IndexCommit> commitList = new ArrayList<>();
         int totalCommits = between(2, 20);
         long lastMaxSeqNo = 0;

--- a/server/src/test/java/org/elasticsearch/index/translog/MultiSnapshotTests.java
+++ b/server/src/test/java/org/elasticsearch/index/translog/MultiSnapshotTests.java
@@ -8,14 +8,13 @@
 
 package org.elasticsearch.index.translog;
 
-import com.carrotsearch.hppc.LongHashSet;
-import com.carrotsearch.hppc.LongSet;
-
 import org.elasticsearch.common.Randomness;
 import org.elasticsearch.test.ESTestCase;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.LongStream;
@@ -38,7 +37,7 @@ public class MultiSnapshotTests extends ESTestCase {
 
     public void testTrackSeqNoDenseRanges() throws Exception {
         final MultiSnapshot.SeqNoSet bitSet = new MultiSnapshot.SeqNoSet();
-        final LongSet normalSet = new LongHashSet();
+        final Set<Long> normalSet = new HashSet<>();
         IntStream.range(0, scaledRandomIntBetween(5_000, 10_000)).forEach(i -> {
             long seq = between(0, 5000);
             boolean existed = normalSet.add(seq) == false;
@@ -48,7 +47,7 @@ public class MultiSnapshotTests extends ESTestCase {
 
     public void testTrackSeqNoSparseRanges() throws Exception {
         final MultiSnapshot.SeqNoSet bitSet = new MultiSnapshot.SeqNoSet();
-        final LongSet normalSet = new LongHashSet();
+        final Set<Long> normalSet = new HashSet<>();
         IntStream.range(0, scaledRandomIntBetween(5_000, 10_000)).forEach(i -> {
             long seq = between(i * 10_000, i * 30_000);
             boolean existed = normalSet.add(seq) == false;
@@ -58,7 +57,7 @@ public class MultiSnapshotTests extends ESTestCase {
 
     public void testTrackSeqNoMimicTranslogRanges() throws Exception {
         final MultiSnapshot.SeqNoSet bitSet = new MultiSnapshot.SeqNoSet();
-        final LongSet normalSet = new LongHashSet();
+        final Set<Long> normalSet = new HashSet<>();
         long currentSeq = between(10_000_000, 1_000_000_000);
         final int iterations = scaledRandomIntBetween(100, 2000);
         for (long i = 0; i < iterations; i++) {

--- a/server/src/test/java/org/elasticsearch/index/translog/SnapshotMatchers.java
+++ b/server/src/test/java/org/elasticsearch/index/translog/SnapshotMatchers.java
@@ -8,9 +8,6 @@
 
 package org.elasticsearch.index.translog;
 
-import com.carrotsearch.hppc.LongHashSet;
-import com.carrotsearch.hppc.LongSet;
-
 import org.elasticsearch.ElasticsearchException;
 import org.hamcrest.Description;
 import org.hamcrest.Matcher;
@@ -19,7 +16,9 @@ import org.hamcrest.TypeSafeMatcher;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 public final class SnapshotMatchers {
     private SnapshotMatchers() {
@@ -193,7 +192,7 @@ public final class SnapshotMatchers {
         @Override
         protected boolean matchesSafely(Translog.Snapshot snapshot) {
             try {
-                final LongSet seqNoList = new LongHashSet();
+                final Set<Long> seqNoList = new HashSet<>();
                 Translog.Operation op;
                 while ((op = snapshot.next()) != null) {
                     seqNoList.add(op.seqNo());


### PR DESCRIPTION
This commit removes hppc uses from a few tests.

relates #84735