### PR TITLE
Add error type and message to the log

### DIFF
--- a/server/src/main/java/org/elasticsearch/ExceptionsHelper.java
+++ b/server/src/main/java/org/elasticsearch/ExceptionsHelper.java
@@ -255,7 +255,7 @@ public final class ExceptionsHelper {
             try {
                 // try to log the current stack trace
                 final String formatted = ExceptionsHelper.formatStackTrace(Thread.currentThread().getStackTrace());
-                logger.error("fatal error {}({})\n{}", error.getClass().getCanonicalName(), error.getMessage(), formatted);
+                logger.error("fatal error {}: {}\n{}", error.getClass().getCanonicalName(), error.getMessage(), formatted);
             } finally {
                 new Thread(() -> { throw error; }).start();
             }

--- a/server/src/main/java/org/elasticsearch/ExceptionsHelper.java
+++ b/server/src/main/java/org/elasticsearch/ExceptionsHelper.java
@@ -255,7 +255,7 @@ public final class ExceptionsHelper {
             try {
                 // try to log the current stack trace
                 final String formatted = ExceptionsHelper.formatStackTrace(Thread.currentThread().getStackTrace());
-                logger.error("fatal error\n{}", formatted);
+                logger.error("fatal error {}({})\n{}", error.getClass().getCanonicalName(), error.getMessage(), formatted);
             } finally {
                 new Thread(() -> { throw error; }).start();
             }


### PR DESCRIPTION
Currently, only stack trace is logged and actual error and message could
be lost in some cases.
