### PR TITLE
Removes the hppc ObjectArrayList from CollectionUtils.sortAndDedup

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/util/CollectionUtils.java
+++ b/server/src/main/java/org/elasticsearch/common/util/CollectionUtils.java
@@ -8,7 +8,6 @@
 
 package org.elasticsearch.common.util;
 
-import com.carrotsearch.hppc.ObjectArrayList;
 
 import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.BytesRefArray;
@@ -67,7 +66,8 @@ public class CollectionUtils {
         return new RotatedList<>(list, d);
     }
 
-    public static void sortAndDedup(final ObjectArrayList<byte[]> array) {
+    // this method is meant to be sort and deduplicate "in situ" (no additional memory)
+    public static void sortAndDedup(final ArrayList<byte[]> array) {
         int len = array.size();
         if (len > 1) {
             sort(array);
@@ -77,11 +77,11 @@ public class CollectionUtils {
                     array.set(uniqueCount++, array.get(i));
                 }
             }
-            array.elementsCount = uniqueCount;
+            array.subList(uniqueCount, array.size()).clear();
         }
     }
 
-    public static void sort(final ObjectArrayList<byte[]> array) {
+    public static void sort(final List<byte[]> array) {
         new IntroSorter() {
 
             byte[] pivot;

--- a/server/src/main/java/org/elasticsearch/common/util/CollectionUtils.java
+++ b/server/src/main/java/org/elasticsearch/common/util/CollectionUtils.java
@@ -81,7 +81,7 @@ public class CollectionUtils {
         }
     }
 
-    public static void sort(final List<byte[]> array) {
+    public static void sort(final ArrayList<byte[]> array) {
         new IntroSorter() {
 
             byte[] pivot;

--- a/server/src/main/java/org/elasticsearch/common/util/CollectionUtils.java
+++ b/server/src/main/java/org/elasticsearch/common/util/CollectionUtils.java
@@ -8,7 +8,6 @@
 
 package org.elasticsearch.common.util;
 
-
 import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.BytesRefArray;
 import org.apache.lucene.util.BytesRefBuilder;

--- a/server/src/main/java/org/elasticsearch/index/mapper/BinaryFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/BinaryFieldMapper.java
@@ -8,7 +8,6 @@
 
 package org.elasticsearch.index.mapper;
 
-import com.carrotsearch.hppc.ObjectArrayList;
 
 import org.apache.lucene.document.StoredField;
 import org.apache.lucene.search.Query;
@@ -28,6 +27,7 @@ import org.elasticsearch.xcontent.XContentParser;
 
 import java.io.IOException;
 import java.time.ZoneId;
+import java.util.ArrayList;
 import java.util.Base64;
 import java.util.Collections;
 import java.util.List;
@@ -194,13 +194,13 @@ public class BinaryFieldMapper extends FieldMapper {
 
     public static class CustomBinaryDocValuesField extends CustomDocValuesField {
 
-        private final ObjectArrayList<byte[]> bytesList;
+        private final ArrayList<byte[]> bytesList;
 
         private int totalSize = 0;
 
         public CustomBinaryDocValuesField(String name, byte[] bytes) {
             super(name);
-            bytesList = new ObjectArrayList<>();
+            bytesList = new ArrayList<>();
             add(bytes);
         }
 

--- a/server/src/main/java/org/elasticsearch/index/mapper/BinaryFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/BinaryFieldMapper.java
@@ -8,7 +8,6 @@
 
 package org.elasticsearch.index.mapper;
 
-
 import org.apache.lucene.document.StoredField;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.util.BytesRef;


### PR DESCRIPTION
The objectArrayList can be replaced with java.util.ArrayList to achieve
in situ sorting and deduplication.

relates  #84735

<!--
Thank you for your interest in and contributing to Elasticsearch! There
are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your
attention.
-->

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/elasticsearch/blob/master/CONTRIBUTING.md)?
- If submitting code, have you built your formula locally prior to submission with `gradle check`?
- If submitting code, is your pull request against master? Unless there is a good reason otherwise, we prefer pull requests against master and will backport as needed.
- If submitting code, have you checked that your submission is for an [OS and architecture that we support](https://www.elastic.co/support/matrix#show_os)?
- If you are submitting this code for a class then read our [policy](https://github.com/elastic/elasticsearch/blob/master/CONTRIBUTING.md#contributing-as-part-of-a-class) for that.
