### PR TITLE
Fix Caputuring Lambda use in InternalAggregations Reader

### DIFF
--- a/server/src/main/java/org/elasticsearch/search/aggregations/InternalAggregations.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/InternalAggregations.java
@@ -58,7 +58,7 @@ public final class InternalAggregations extends Aggregations implements Writeabl
     }
 
     public static InternalAggregations readFrom(StreamInput in) throws IOException {
-        return from(in.readList(stream -> in.readNamedWriteable(InternalAggregation.class)));
+        return from(in.readList(stream -> stream.readNamedWriteable(InternalAggregation.class)));
     }
 
     @Override


### PR DESCRIPTION
Randomly spotted this one, should obviously use the stream arg instead of capture it.
