### PR TITLE
Mute AzureStorageRepositoryClientYamlTestSuiteIT via `tests.rest.blacklist`

### DIFF
--- a/plugins/repository-azure/qa/microsoft-azure-storage/build.gradle
+++ b/plugins/repository-azure/qa/microsoft-azure-storage/build.gradle
@@ -83,3 +83,7 @@ integTestCluster {
 task azureThirdPartyTest {
   dependsOn integTest
 }
+
+integTestRunner {
+    systemProperty 'tests.rest.blacklist', 'repository_azure/10_repository/*'
+}

--- a/plugins/repository-azure/qa/microsoft-azure-storage/src/test/java/org/elasticsearch/repositories/azure/AzureStorageRepositoryClientYamlTestSuiteIT.java
+++ b/plugins/repository-azure/qa/microsoft-azure-storage/src/test/java/org/elasticsearch/repositories/azure/AzureStorageRepositoryClientYamlTestSuiteIT.java
@@ -21,13 +21,11 @@ package org.elasticsearch.repositories.azure;
 
 import com.carrotsearch.randomizedtesting.annotations.Name;
 import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
-import org.apache.lucene.util.LuceneTestCase.AwaitsFix;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.test.rest.ESRestTestCase;
 import org.elasticsearch.test.rest.yaml.ClientYamlTestCandidate;
 import org.elasticsearch.test.rest.yaml.ESClientYamlSuiteTestCase;
 
-@AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/85311")
 public class AzureStorageRepositoryClientYamlTestSuiteIT extends ESClientYamlSuiteTestCase {
 
     public AzureStorageRepositoryClientYamlTestSuiteIT(@Name("yaml") ClientYamlTestCandidate testCandidate) {


### PR DESCRIPTION
Muting via `@AwaitsFix` fails with "There were no executed tests"

See #85313