### PR TITLE
[ML] Reallocate model deployments on node shutdown events. (#85310)

### DIFF
--- a/docs/changelog/85310.yaml
+++ b/docs/changelog/85310.yaml
@@ -1,0 +1,5 @@
+pr: 85310
+summary: Reallocate model deployments on node shutdown events
+area: Machine Learning
+type: bug
+issues: []

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/allocation/TrainedModelAllocationClusterService.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/allocation/TrainedModelAllocationClusterService.java
@@ -28,6 +28,7 @@ import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.ByteSizeValue;
+import org.elasticsearch.common.util.set.Sets;
 import org.elasticsearch.gateway.GatewayService;
 import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.xpack.core.ml.MlMetadata;
@@ -423,21 +424,63 @@ public class TrainedModelAllocationClusterService implements ClusterStateListene
         if (newMetadata == null) {
             return false;
         }
-        if (event.nodesChanged()) {
+
+        // Reallocate in reaction to either node change events or
+        // changes triggered by the node shutdown API.
+        // When the shutdown API is used the metadata is modified
+        // before the node is removed and then once again after
+        // the node has returned. In this situation the node change
+        // events become a no-op due to the checks against shutting
+        // down nodes and because reallocation has already been
+        // triggered by the node shutdown metadata changes.
+        //
+        // If the shutdown API is not used the node change events
+        // are sufficient to cause a reallocation.
+        //
+        // Shutdowns should be respected so that the service does not
+        // allocate models to a node that is about to leave the cluster
+        boolean nodesShutdownChanged = event.changedCustomMetadataSet().contains(NodesShutdownMetadata.TYPE);
+        if (event.nodesChanged() || nodesShutdownChanged) {
             Set<String> shuttingDownNodes = nodesShuttingDown(event.state());
             DiscoveryNodes.Delta nodesDelta = event.nodesDelta();
+
+            Set<String> removedNodes = nodesDelta.removedNodes().stream().map(DiscoveryNode::getId).collect(Collectors.toSet());
+            Set<String> addedNodes = nodesDelta.addedNodes().stream().map(DiscoveryNode::getId).collect(Collectors.toSet());
+
+            Set<String> exitingShutDownNodes;
+            if (nodesShutdownChanged) {
+                Set<String> previousShuttingDownNodes = nodesShuttingDown(event.previousState());
+
+                // Add nodes that where marked for shutdown in the previous state
+                // but are no longer marked as shutdown in the current state.
+                Set<String> returningShutDownNodes = Sets.difference(previousShuttingDownNodes, shuttingDownNodes);
+                addedNodes.addAll(returningShutDownNodes);
+
+                // and nodes that are marked for shutdown in this event only
+                exitingShutDownNodes = Sets.difference(shuttingDownNodes, previousShuttingDownNodes);
+                removedNodes.addAll(exitingShutDownNodes);
+            } else {
+                exitingShutDownNodes = Collections.emptySet();
+            }
+
             for (TrainedModelAllocation trainedModelAllocation : newMetadata.modelAllocations().values()) {
                 if (trainedModelAllocation.getAllocationState().equals(AllocationState.STOPPING)) {
                     continue;
                 }
-                for (DiscoveryNode removed : nodesDelta.removedNodes()) {
-                    if (trainedModelAllocation.isRoutedToNode(removed.getId())) {
+                for (var nodeId : exitingShutDownNodes) {
+                    if (trainedModelAllocation.isRoutedToNode(nodeId)) {
                         return true;
                     }
                 }
-                for (DiscoveryNode added : nodesDelta.addedNodes()) {
-                    if (StartTrainedModelDeploymentAction.TaskParams.mayAllocateToNode(added)
-                        && shuttingDownNodes.contains(added.getId()) == false) {
+
+                for (var nodeId : removedNodes) {
+                    if (trainedModelAllocation.isRoutedToNode(nodeId) && shuttingDownNodes.contains(nodeId) == false) {
+                        return true;
+                    }
+                }
+                for (var nodeId : addedNodes) {
+                    if (StartTrainedModelDeploymentAction.TaskParams.mayAllocateToNode(event.state().nodes().get(nodeId))
+                        && shuttingDownNodes.contains(nodeId) == false) {
                         return true;
                     }
                 }


### PR DESCRIPTION
Trigger reallocation on Node Shutdown changes first then node change events
if the Node Shutdown API has not been used.

Backport of #85310