### PR TITLE
[ML] Null out deployment stats fields that have not been used

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/allocation/AllocationStats.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/allocation/AllocationStats.java
@@ -102,7 +102,7 @@ public class AllocationStats implements ToXContentObject, Writeable {
             DiscoveryNode node,
             Long inferenceCount,
             Double avgInferenceTime,
-            Instant lastAccess,
+            @Nullable Instant lastAccess,
             Integer pendingCount,
             int errorCount,
             int rejectedExecutionCount,

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/allocation/AllocationStatsTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/allocation/AllocationStatsTests.java
@@ -52,21 +52,33 @@ public class AllocationStatsTests extends AbstractWireSerializingTestCase<Alloca
     }
 
     public static AllocationStats.NodeStats randomNodeStats(DiscoveryNode node) {
+        var lastAccess = Instant.now();
+        var inferenceCount = randomNonNegativeLong();
+        Double avgInferenceTime = randomDoubleBetween(0.0, 100.0, true);
+        Double avgInferenceTimeLastPeriod = randomDoubleBetween(0.0, 100.0, true);
+
+        var noInferenceCallsOnNodeYet = randomBoolean();
+        if (noInferenceCallsOnNodeYet) {
+            lastAccess = null;
+            inferenceCount = 0;
+            avgInferenceTime = null;
+            avgInferenceTimeLastPeriod = null;
+        }
         return AllocationStats.NodeStats.forStartedState(
             node,
-            randomNonNegativeLong(),
-            randomBoolean() ? randomDoubleBetween(0.0, 100.0, true) : null,
+            inferenceCount,
+            avgInferenceTime,
             randomIntBetween(0, 100),
             randomIntBetween(0, 100),
             randomIntBetween(0, 100),
             randomIntBetween(0, 100),
-            Instant.now(),
+            lastAccess,
             Instant.now(),
             randomIntBetween(1, 16),
             randomIntBetween(1, 16),
             randomIntBetween(0, 100),
             randomIntBetween(0, 100),
-            randomBoolean() ? randomDoubleBetween(0.0, 100.0, true) : null
+            avgInferenceTimeLastPeriod
         );
     }
 

--- a/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/PyTorchModelIT.java
+++ b/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/PyTorchModelIT.java
@@ -290,25 +290,50 @@ public class PyTorchModelIT extends ESRestTestCase {
         putVocabulary(List.of("once", "twice"), modelA);
         putModelDefinition(modelA);
         startDeployment(modelA, AllocationStatus.State.FULLY_ALLOCATED.toString());
+        {
+            Response noInferenceCallsStatsResponse = getTrainedModelStats(modelA);
+            List<Map<String, Object>> stats = (List<Map<String, Object>>) entityAsMap(noInferenceCallsStatsResponse).get(
+                "trained_model_stats"
+            );
+            assertThat(stats, hasSize(1));
+
+            List<Map<String, Object>> nodes = (List<Map<String, Object>>) XContentMapValues.extractValue(
+                "deployment_stats.nodes",
+                stats.get(0)
+            );
+            int inferenceCount = sumInferenceCountOnNodes(nodes);
+            assertThat(inferenceCount, equalTo(0));
+
+            for (var node : nodes) {
+                // null before the model is used
+                assertThat(node.get("last_access"), nullValue());
+                assertThat(node.get("average_inference_time_ms"), nullValue());
+                assertThat(node.get("average_inference_time_ms_last_minute"), nullValue());
+            }
+        }
+
         infer("once", modelA);
         infer("twice", modelA);
-        Response response = getTrainedModelStats(modelA);
-        List<Map<String, Object>> stats = (List<Map<String, Object>>) entityAsMap(response).get("trained_model_stats");
-        assertThat(stats, hasSize(1));
-        assertThat(XContentMapValues.extractValue("deployment_stats.model_id", stats.get(0)), equalTo(modelA));
-        assertThat(XContentMapValues.extractValue("model_size_stats.model_size_bytes", stats.get(0)), equalTo((int) RAW_MODEL_SIZE));
-        List<Map<String, Object>> nodes = (List<Map<String, Object>>) XContentMapValues.extractValue(
-            "deployment_stats.nodes",
-            stats.get(0)
-        );
-        // 2 of the 3 nodes in the cluster are ML nodes
-        assertThat(nodes, hasSize(2));
-        int inferenceCount = sumInferenceCountOnNodes(nodes);
-        for (var node : nodes) {
-            assertThat(node.get("number_of_pending_requests"), notNullValue());
-            // last_access and average_inference_time_ms may be null if inference wasn't performed on this node
+        {
+            Response postInferStatsResponse = getTrainedModelStats(modelA);
+            List<Map<String, Object>> stats = (List<Map<String, Object>>) entityAsMap(postInferStatsResponse).get("trained_model_stats");
+            assertThat(stats, hasSize(1));
+            assertThat(XContentMapValues.extractValue("deployment_stats.model_id", stats.get(0)), equalTo(modelA));
+            assertThat(XContentMapValues.extractValue("model_size_stats.model_size_bytes", stats.get(0)), equalTo((int) RAW_MODEL_SIZE));
+            List<Map<String, Object>> nodes = (List<Map<String, Object>>) XContentMapValues.extractValue(
+                "deployment_stats.nodes",
+                stats.get(0)
+            );
+            // 2 of the 3 nodes in the cluster are ML nodes
+            assertThat(nodes, hasSize(2));
+            for (var node : nodes) {
+                assertThat(node.get("number_of_pending_requests"), notNullValue());
+                // last_access and average_inference_time_ms may be null if inference wasn't performed on this node
+            }
+
+            int inferenceCount = sumInferenceCountOnNodes(nodes);
+            assertThat(inferenceCount, equalTo(2));
         }
-        assertThat(inferenceCount, equalTo(2));
     }
 
     @SuppressWarnings("unchecked")

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/pytorch/process/PyTorchResultProcessor.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/pytorch/process/PyTorchResultProcessor.java
@@ -28,7 +28,7 @@ import java.util.function.LongSupplier;
 
 public class PyTorchResultProcessor {
 
-    public record RecentStats(long requestsProcessed, double avgInferenceTime) {}
+    public record RecentStats(long requestsProcessed, Double avgInferenceTime) {}
 
     public record ResultStats(
         LongSummaryStatistics timingStats,
@@ -161,14 +161,14 @@ public class PyTorchResultProcessor {
 
         if (rs == null) {
             // no results processed in the previous period
-            rs = new RecentStats(0L, 0.0);
+            rs = new RecentStats(0L, null);
         }
 
         return new ResultStats(
             new LongSummaryStatistics(timingStats.getCount(), timingStats.getMin(), timingStats.getMax(), timingStats.getSum()),
             errorCount,
             pendingResults.size(),
-            Instant.ofEpochMilli(lastResultTimeMs),
+            lastResultTimeMs > 0 ? Instant.ofEpochMilli(lastResultTimeMs) : null,
             this.peakThroughput,
             rs
         );


### PR DESCRIPTION
When inference has not been used on a node in a trained model deployment certain fields in the deployment stats response should not be set. 

Last access time was incorrectly being reported as Epoch 0 seconds and Average Inference time last period was 0.0 when it should be null if it has not been used. 

Non issue as this fixes a regression that has not been released yet. 