### PR TITLE
Strengthen elasticsearch plugin version check

### DIFF
--- a/docs/changelog/85340.yaml
+++ b/docs/changelog/85340.yaml
@@ -1,0 +1,6 @@
+pr: 85340
+summary: Strengthen elasticsearch plugin version check
+area: Infra/Plugins
+type: bug
+issues:
+ - 85336

--- a/server/src/main/java/org/elasticsearch/plugins/PluginInfo.java
+++ b/server/src/main/java/org/elasticsearch/plugins/PluginInfo.java
@@ -173,7 +173,7 @@ public class PluginInfo implements Writeable, ToXContentObject {
         }
 
         final String esVersionString = propsMap.remove("elasticsearch.version");
-        if (esVersionString == null) {
+        if (esVersionString == null || Strings.hasLength(esVersionString) == false) {
             throw new IllegalArgumentException("property [elasticsearch.version] is missing for plugin [" + name + "]");
         }
         final Version esVersion = Version.fromString(esVersionString);

--- a/server/src/main/java/org/elasticsearch/plugins/PluginInfo.java
+++ b/server/src/main/java/org/elasticsearch/plugins/PluginInfo.java
@@ -173,7 +173,7 @@ public class PluginInfo implements Writeable, ToXContentObject {
         }
 
         final String esVersionString = propsMap.remove("elasticsearch.version");
-        if (esVersionString == null || Strings.hasLength(esVersionString) == false) {
+        if (Strings.hasText(esVersionString) == false) {
             throw new IllegalArgumentException("property [elasticsearch.version] is missing for plugin [" + name + "]");
         }
         final Version esVersion = Version.fromString(esVersionString);

--- a/server/src/test/java/org/elasticsearch/plugins/PluginInfoTests.java
+++ b/server/src/test/java/org/elasticsearch/plugins/PluginInfoTests.java
@@ -84,6 +84,23 @@ public class PluginInfoTests extends ESTestCase {
         assertThat(e.getMessage(), containsString("[elasticsearch.version] is missing"));
     }
 
+    public void testReadFromPropertiesElasticsearchVersionEmpty() throws Exception {
+        Path pluginDir = createTempDir().resolve("fake-plugin");
+        PluginTestUtil.writePluginProperties(
+            pluginDir,
+            "description",
+            "fake desc",
+            "name",
+            "my_plugin",
+            "version",
+            "1.0",
+            "elasticsearch.version",
+            ""
+        );
+        IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> PluginInfo.readFromProperties(pluginDir));
+        assertThat(e.getMessage(), containsString("[elasticsearch.version] is missing"));
+    }
+
     public void testReadFromPropertiesJavaVersionMissing() throws Exception {
         Path pluginDir = createTempDir().resolve("fake-plugin");
         PluginTestUtil.writePluginProperties(

--- a/server/src/test/java/org/elasticsearch/plugins/PluginInfoTests.java
+++ b/server/src/test/java/org/elasticsearch/plugins/PluginInfoTests.java
@@ -95,7 +95,7 @@ public class PluginInfoTests extends ESTestCase {
             "version",
             "1.0",
             "elasticsearch.version",
-            ""
+            "  "
         );
         IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> PluginInfo.readFromProperties(pluginDir));
         assertThat(e.getMessage(), containsString("[elasticsearch.version] is missing"));


### PR DESCRIPTION
When a plugin specifies an elasticsearch version with an empty string
in their plugin-descriptor.properties file, we don't enforce the
version check. This PR ensures that we check the version string for
empty as well as null value.

Closes #85336