### PR TITLE
[8.1] Allowing _cat/allocation to return more than 0 shards in test (#84539)

### DIFF
--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/cat.allocation/10_basic.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/cat.allocation/10_basic.yml
@@ -82,7 +82,7 @@
   - match:
       $body: |
             /^
-              ( 0                      \s+
+              ( \d                     \s+   #usually 0, unless some system index has been recreated before this runs
                 \d+(\.\d+)?[kmgt]?b    \s+
                 \d+(\.\d+)?[kmgt]?b    \s+
                 (\d+(\.\d+)?[kmgt]b   \s+)?  #no value from client nodes
@@ -216,7 +216,7 @@
   - match:
       $body: |
             /^
-              ( 0                   \s+
+              ( \d                  \s+    #usually 0, unless some system index has been recreated before this runs
                 0                   \s+
                 \d+                 \s+
                 (\d+                 \s+)  #always should return value since we filter out non data nodes by default

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/cat.indices/10_basic.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/cat.indices/10_basic.yml
@@ -18,7 +18,8 @@
             number_of_shards: "1"
             number_of_replicas: "0"
   - do:
-      cat.indices: {}
+      cat.indices:
+        index: index1
 
   - match:
       $body: |
@@ -37,6 +38,7 @@
 
   - do:
       cat.indices:
+        index: index1
         v: false
         h: i,cd,cds,creation.date,creation.date.string
   - match:
@@ -262,6 +264,7 @@
 
   - do:
       cat.indices:
+        index: b*,foo
         h: [status, index]
         s: [status, index]
 
@@ -274,6 +277,7 @@
 
   - do:
       cat.indices:
+        index: b*,foo
         h: [status, index]
         s: [status, "index:desc"]
 

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/cat.indices/20_hidden.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/cat.indices/20_hidden.yml
@@ -13,13 +13,15 @@
             index:
               hidden: true
   - do:
-      cat.indices: {}
+      cat.indices:
+        index: i*
   - match:
       $body: |
         /^$/
 
   - do:
       cat.indices:
+        index: i*
         expand_wildcards: ["all"]
   - match:
       $body: |
@@ -58,7 +60,7 @@
 
   - do:
       cat.indices:
-        index: ".*"
+        index: ".i*"
   - match:
       $body: |
         /^(green  \s+
@@ -103,6 +105,7 @@
 
   - do:
       cat.indices:
+        index: "i*"
         expand_wildcards: ["open", "hidden"]
   - match:
       $body: |
@@ -155,7 +158,8 @@
             alias1:
               is_hidden: true
   - do:
-      cat.indices: {}
+      cat.indices:
+        index: i*
 
   - match:
       $body: |
@@ -163,6 +167,7 @@
 
   - do:
       cat.indices:
+        index: i*
         expand_wildcards: ["all"]
   - match:
       $body: |
@@ -224,7 +229,8 @@
         index: ".*"
   - match:
       $body: |
-        /^(green  \s+
+        /^(.*           # Accounts for system indices that get automatically generated
+           green  \s+
            open   \s+
            index1 \s+
            ([a-zA-Z0-9=/_+]|[\\\-]){22} \s+
@@ -234,5 +240,6 @@
            0      \s+
            (\d+|\d+[.]\d+)(kb|b) \s+
            (\d+|\d+[.]\d+)(kb|b) \s*
+           .*           # Accounts for system indices that get automatically generated
          )
          $/

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/cat.shards/10_basic.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/cat.shards/10_basic.yml
@@ -90,7 +90,8 @@
 "Test cat shards output":
 
   - do:
-      cat.shards: {}
+      cat.shards:
+        index: i*
 
   - match:
       $body: |
@@ -103,7 +104,8 @@
             number_of_shards: "5"
             number_of_replicas: "1"
   - do:
-      cat.shards: {}
+      cat.shards:
+        index: i*
 
   - match:
       $body: |
@@ -118,7 +120,8 @@
             number_of_replicas: "0"
 
   - do:
-      cat.shards: {}
+      cat.shards:
+        index: i*
   - match:
       $body: |
                /^(index(1|2) \s+ \d \s+ (p|r) \s+ ((STARTED|INITIALIZING|RELOCATING) \s+ (\d \s+ (\d+|\d+[.]\d+)(kb|b) \s+)? \d{1,3}.\d{1,3}.\d{1,3}.\d{1,3} \s+ .+|UNASSIGNED \s+) \n?){15}$/


### PR DESCRIPTION
Backports the following commits to 8.1:
 - Allowing _cat/allocation to return more than 0 shards in test (#84539)