### PR TITLE
[8.1] [ML] Do not fetch source when finding index of last state docs (#85334)

### DIFF
--- a/docs/changelog/85334.yaml
+++ b/docs/changelog/85334.yaml
@@ -1,0 +1,5 @@
+pr: 85334
+summary: Do not fetch source when finding index of last state docs
+area: Machine Learning
+type: bug
+issues: []

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/persistence/JobResultsPersister.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/persistence/JobResultsPersister.java
@@ -341,6 +341,7 @@ public class JobResultsPersister {
         return new SearchRequest(AnomalyDetectorsIndex.jobStateIndexPattern()).allowPartialSearchResults(false)
             .source(
                 new SearchSourceBuilder().size(1)
+                    .fetchSource(false)
                     .trackTotalHits(false)
                     .query(new BoolQueryBuilder().filter(new IdsQueryBuilder().addIds(quantilesDocId)))
             );

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/process/IndexingStateProcessor.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/process/IndexingStateProcessor.java
@@ -224,6 +224,7 @@ public class IndexingStateProcessor implements StateProcessor {
         SearchRequest searchRequest = new SearchRequest(AnomalyDetectorsIndex.jobStateIndexPattern()).allowPartialSearchResults(false)
             .source(
                 new SearchSourceBuilder().size(1)
+                    .fetchSource(false)
                     .trackTotalHits(false)
                     .query(new BoolQueryBuilder().filter(new IdsQueryBuilder().addIds(documentId)))
             );


### PR DESCRIPTION
Backports the following commits to 8.1:
 - [ML] Do not fetch source when finding index of last state docs (#85334)