### PR TITLE
Avoid wrapping searchers multiple times in multi gets

### DIFF
--- a/docs/changelog/85345.yaml
+++ b/docs/changelog/85345.yaml
@@ -2,4 +2,5 @@ pr: 85345
 summary: Avoid wrapping searchers multiple times in multi gets
 area: Search
 type: enhancement
-issues: []
+issues:
+ - 85069

--- a/docs/changelog/85345.yaml
+++ b/docs/changelog/85345.yaml
@@ -1,0 +1,5 @@
+pr: 85345
+summary: Avoid wrapping searchers multiple times in multi gets
+area: Search
+type: enhancement
+issues: []

--- a/server/src/main/java/org/elasticsearch/action/explain/TransportExplainAction.java
+++ b/server/src/main/java/org/elasticsearch/action/explain/TransportExplainAction.java
@@ -107,7 +107,7 @@ public class TransportExplainAction extends TransportSingleShardAction<ExplainRe
         Engine.GetResult result = null;
         try {
             // No need to check the type, IndexShard#get does it for us
-            result = context.indexShard().get(new Engine.Get(false, false, request.id()));
+            result = context.indexShard().getFromEngine(false).apply(new Engine.Get(false, false, request.id()));
             if (result.exists() == false) {
                 return new ExplainResponse(shardId.getIndexName(), request.id(), false);
             }

--- a/server/src/main/java/org/elasticsearch/index/get/GetAndFetchContext.java
+++ b/server/src/main/java/org/elasticsearch/index/get/GetAndFetchContext.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.index.get;
+
+import org.elasticsearch.index.engine.Engine;
+import org.elasticsearch.search.fetch.subphase.FetchSourceContext;
+
+public record GetAndFetchContext(Engine.Get engineGet, String[] gFields, FetchSourceContext fetchSourceContext) {
+    public String id() {
+        return engineGet().id();
+    }
+}

--- a/server/src/main/java/org/elasticsearch/index/get/GetResultOrFailure.java
+++ b/server/src/main/java/org/elasticsearch/index/get/GetResultOrFailure.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.index.get;
+
+import org.elasticsearch.ExceptionsHelper;
+
+public final class GetResultOrFailure {
+    private final GetResult result;
+    private final Exception failure;
+
+    public GetResultOrFailure(GetResult result) {
+        this.result = result;
+        this.failure = null;
+    }
+
+    public GetResultOrFailure(Exception failure) {
+        this.result = null;
+        this.failure = failure;
+    }
+
+    public GetResult getResult() {
+        return result;
+    }
+
+    public Exception getFailure() {
+        return failure;
+    }
+
+    public GetResult getResultOrThrow() {
+        if (failure != null) {
+            throw ExceptionsHelper.convertToRuntime(failure);
+        }
+        return result;
+    }
+}

--- a/server/src/main/java/org/elasticsearch/index/shard/CacheableSearcherWrapper.java
+++ b/server/src/main/java/org/elasticsearch/index/shard/CacheableSearcherWrapper.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.index.shard;
+
+import org.apache.lucene.index.IndexReader;
+import org.elasticsearch.core.AbstractRefCounted;
+import org.elasticsearch.core.Releasable;
+import org.elasticsearch.core.Releasables;
+import org.elasticsearch.index.engine.Engine;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Function;
+
+/**
+ * A searcher wrapper that avoids wrapping the same searcher multiple times.
+ * This wrapper must be created and used by a single thread.
+ */
+final class CacheableSearcherWrapper implements Function<Engine.Searcher, Engine.Searcher> {
+    private final Map<IndexReader.CacheKey, SearcherHolder> caches = new HashMap<>();
+    private final Function<Engine.Searcher, Engine.Searcher> delegate;
+    private final Thread creationThread;
+
+    CacheableSearcherWrapper(Function<Engine.Searcher, Engine.Searcher> delegate) {
+        this.creationThread = Thread.currentThread();
+        this.delegate = delegate;
+    }
+
+    private boolean assertAccessingThread() {
+        assert creationThread == Thread.currentThread()
+            : "created by [" + creationThread + "] != current thread [" + Thread.currentThread() + "]";
+        return true;
+    }
+
+    @Override
+    public Engine.Searcher apply(Engine.Searcher in) {
+        assert assertAccessingThread();
+        final IndexReader.CacheHelper cacheHelper = in.getIndexReader().getReaderCacheHelper();
+        final IndexReader.CacheKey cacheKey = cacheHelper != null ? cacheHelper.getKey() : null;
+        if (cacheKey == null) {
+            return delegate.apply(in);
+        }
+        final SearcherHolder searcherHolder = caches.compute(cacheKey, (key, curr) -> {
+            if (curr != null) {
+                curr.incRef();
+            } else {
+                final Engine.Searcher wrapped = delegate.apply(in);
+                curr = new SearcherHolder(wrapped, () -> caches.remove(key));
+            }
+            return curr;
+        });
+        return searcherHolder.searcher;
+    }
+
+    private static class SearcherHolder extends AbstractRefCounted {
+        private final Engine.Searcher searcher;
+        private final Releasable onClose;
+
+        SearcherHolder(Engine.Searcher searcher, Releasable onClose) {
+            this.onClose = Releasables.wrap(onClose, searcher);
+            this.searcher = new Engine.Searcher(
+                searcher.source(),
+                searcher.getIndexReader(),
+                searcher.getSimilarity(),
+                searcher.getQueryCache(),
+                searcher.getQueryCachingPolicy(),
+                this::decRef
+            );
+        }
+
+        @Override
+        protected void closeInternal() {
+            onClose.close();
+        }
+    }
+
+    // for testing
+    int cacheSize() {
+        return caches.size();
+    }
+}

--- a/server/src/main/java/org/elasticsearch/index/termvectors/TermVectorsService.java
+++ b/server/src/main/java/org/elasticsearch/index/termvectors/TermVectorsService.java
@@ -78,9 +78,10 @@ public class TermVectorsService {
         }
 
         try (
-            Engine.GetResult get = indexShard.get(
-                new Engine.Get(request.realtime(), false, request.id()).version(request.version()).versionType(request.versionType())
-            );
+            Engine.GetResult get = indexShard.getFromEngine(false)
+                .apply(
+                    new Engine.Get(request.realtime(), false, request.id()).version(request.version()).versionType(request.versionType())
+                );
             Engine.Searcher searcher = indexShard.acquireSearcher("term_vector")
         ) {
             Fields topLevelFields = fields(get.searcher() != null ? get.searcher().getIndexReader() : searcher.getIndexReader());

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/snapshots/sourceonly/SourceOnlySnapshotShardTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/snapshots/sourceonly/SourceOnlySnapshotShardTests.java
@@ -375,7 +375,7 @@ public class SourceOnlySnapshotShardTests extends IndexShardTestCase {
         assertEquals(restoredShard.docStats().getCount(), shard.docStats().getCount());
         EngineException engineException = expectThrows(
             EngineException.class,
-            () -> restoredShard.get(new Engine.Get(false, false, Integer.toString(0)))
+            () -> restoredShard.getFromEngine(randomBoolean()).apply(new Engine.Get(false, false, Integer.toString(0)))
         );
         assertEquals(engineException.getCause().getMessage(), "_source only indices can't be searched or filtered");
         SeqNoStats seqNoStats = restoredShard.seqNoStats();
@@ -409,8 +409,8 @@ public class SourceOnlySnapshotShardTests extends IndexShardTestCase {
 
         for (int i = 0; i < numInitialDocs; i++) {
             Engine.Get get = new Engine.Get(false, false, Integer.toString(i));
-            Engine.GetResult original = shard.get(get);
-            Engine.GetResult restored = targetShard.get(get);
+            Engine.GetResult original = shard.getFromEngine(randomBoolean()).apply(get);
+            Engine.GetResult restored = targetShard.getFromEngine(randomBoolean()).apply(get);
             assertEquals(original.exists(), restored.exists());
 
             if (original.exists()) {


### PR DESCRIPTION
This commit avoids wrapping searchers multiple times for a single multi-get request. The proposal here is also for #85232 (i.e., utilize the sequential stored-fields reader when possible).

Closes #85069 