### PR TITLE
Replace failing PolicyStepsRegistry sanity check assert with a test

### DIFF
--- a/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/PolicyStepsRegistry.java
+++ b/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/PolicyStepsRegistry.java
@@ -370,7 +370,8 @@ public class PolicyStepsRegistry {
             cachedSteps.put(indexMetadata.getIndex(), Tuple.tuple(indexMetadata, s));
             // assert that the cache works as expected -- that is, if we put something into the cache,
             // we should get back the same thing if we were to invoke getStep again with the same arguments
-            assert s == getCachedStep(indexMetadata, stepKey) : "policy step registry cache failed sanity check";
+            Step found = getCachedStep(indexMetadata, stepKey);
+            assert s == found : "policy step registry cache failed sanity check (expected [" + s + "], found [" + found + "])";
         }
         return s;
     }

--- a/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/PolicyStepsRegistry.java
+++ b/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/PolicyStepsRegistry.java
@@ -368,10 +368,6 @@ public class PolicyStepsRegistry {
         final Step s = phaseSteps.stream().filter(step -> step.getKey().equals(stepKey)).findFirst().orElse(null);
         if (s != null) {
             cachedSteps.put(indexMetadata.getIndex(), Tuple.tuple(indexMetadata, s));
-            // assert that the cache works as expected -- that is, if we put something into the cache,
-            // we should get back the same thing if we were to invoke getStep again with the same arguments
-            Step found = getCachedStep(indexMetadata, stepKey);
-            assert s == found : "policy step registry cache failed sanity check (expected [" + s + "], found [" + found + "])";
         }
         return s;
     }

--- a/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/ilm/PolicyStepsRegistryTests.java
+++ b/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/ilm/PolicyStepsRegistryTests.java
@@ -502,6 +502,9 @@ public class PolicyStepsRegistryTests extends ESTestCase {
         for (int i = 0; i < scaledRandomIntBetween(100, 1000); i++) {
             LifecycleAction action = randomValueOtherThan(MigrateAction.DISABLED, () -> randomFrom(phase.getActions().values()));
             Step step = randomFrom(action.toSteps(client, phaseName, MOCK_STEP_KEY, null));
+            // if the step's key is different from the previous iteration of the loop, then the cache will be updated, and we'll
+            // get a non-cached response. if the step's key happens to be the same as the previous iteration of the loop, then
+            // we'll get a cached response. so this loop randomly tests both cached and non-cached responses.
             Step actualStep = registry.getStep(indexMetadata, step.getKey());
             assertThat(actualStep.getKey(), equalTo(step.getKey()));
         }

--- a/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/ilm/PolicyStepsRegistryTests.java
+++ b/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/ilm/PolicyStepsRegistryTests.java
@@ -511,12 +511,13 @@ public class PolicyStepsRegistryTests extends ESTestCase {
 
         // now, in another thread, update the registry repeatedly as fast as possible.
         // updating the registry has the side effect of clearing the cache.
-        new Thread(() -> {
+        Thread t = new Thread(() -> {
             latch.countDown(); // signal that we're starting
             while (done.get() == false) {
                 registry.update(meta);
             }
-        }).start();
+        });
+        t.start();
 
         try {
             latch.await(); // wait until the other thread started
@@ -530,8 +531,9 @@ public class PolicyStepsRegistryTests extends ESTestCase {
                 assertThat(actualStep.getKey(), equalTo(step.getKey()));
             }
         } finally {
-            // tell the other thread we're finished
+            // tell the other thread we're finished and wait for it to die
             done.set(true);
+            t.join(1000);
         }
     }
 }


### PR DESCRIPTION
Follow up to #84588, which was itself a follow up to #82316

I wanted this assert in there out of an abundance of caution, but indeed the other change in #84588 to `PolicyStepsRegistryTests` was a fair test of the intended behavior change on that PR.

This PR moves the stress test to actual test code. I've run it with `-Dtests.iters=10000` and it's fine (with the assert remaining it fails the sanity check (returning `null` rather than the expected step) in the neighborhood of 20% of the time as measured with `-Dtests.iters=100`). The test takes about a tenth of a second to run on a warmed up jvm on my box.

Closes #84979 
Closes #85036 
Closes #85075 
Closes #85175