### PR TITLE
Sorting impact index names by index priority

### DIFF
--- a/docs/changelog/85347.yaml
+++ b/docs/changelog/85347.yaml
@@ -1,0 +1,5 @@
+pr: 85347
+summary: Sorting impact index names by index priority
+area: Health
+type: feature
+issues: []

--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/ShardsAvailabilityHealthIndicatorService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/ShardsAvailabilityHealthIndicatorService.java
@@ -148,7 +148,7 @@ public class ShardsAvailabilityHealthIndicatorService implements HealthIndicator
         private final ShardAllocationCounts replicas = new ShardAllocationCounts();
         private final Metadata clusterMetadata;
 
-        public ShardAllocationStatus(Metadata clusterMetadata) {
+        ShardAllocationStatus(Metadata clusterMetadata) {
             this.clusterMetadata = clusterMetadata;
         }
 

--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/ShardsAvailabilityHealthIndicatorService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/ShardsAvailabilityHealthIndicatorService.java
@@ -9,6 +9,7 @@
 package org.elasticsearch.cluster.routing.allocation;
 
 import org.elasticsearch.cluster.health.ClusterHealthStatus;
+import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.cluster.metadata.NodesShutdownMetadata;
 import org.elasticsearch.cluster.metadata.SingleNodeShutdownMetadata;
 import org.elasticsearch.cluster.routing.IndexRoutingTable;
@@ -23,6 +24,7 @@ import org.elasticsearch.health.HealthStatus;
 import org.elasticsearch.health.SimpleHealthIndicatorDetails;
 
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
@@ -73,7 +75,7 @@ public class ShardsAvailabilityHealthIndicatorService implements HealthIndicator
     public HealthIndicatorResult calculate() {
         var state = clusterService.state();
         var shutdown = state.getMetadata().custom(NodesShutdownMetadata.TYPE, NodesShutdownMetadata.EMPTY);
-        var status = new ShardAllocationStatus();
+        var status = new ShardAllocationStatus(state.getMetadata());
 
         for (IndexRoutingTable indexShardRouting : state.routingTable()) {
             for (int i = 0; i < indexShardRouting.size(); i++) {
@@ -144,6 +146,11 @@ public class ShardsAvailabilityHealthIndicatorService implements HealthIndicator
     private static class ShardAllocationStatus {
         private final ShardAllocationCounts primaries = new ShardAllocationCounts();
         private final ShardAllocationCounts replicas = new ShardAllocationCounts();
+        private final Metadata clusterMetadata;
+
+        public ShardAllocationStatus(Metadata clusterMetadata) {
+            this.clusterMetadata = clusterMetadata;
+        }
 
         public void addPrimary(ShardRouting routing, NodesShutdownMetadata shutdowns) {
             primaries.increment(routing, shutdowns);
@@ -226,7 +233,7 @@ public class ShardsAvailabilityHealthIndicatorService implements HealthIndicator
                     "Cannot add data to %d %s [%s]. Searches might return incomplete results.",
                     primaries.indicesWithUnavailableShards.size(),
                     primaries.indicesWithUnavailableShards.size() == 1 ? "index" : "indices",
-                    getTruncatedIndicesString(primaries.indicesWithUnavailableShards)
+                    getTruncatedIndicesString(primaries.indicesWithUnavailableShards, clusterMetadata)
                 );
                 impacts.add(new HealthIndicatorImpact(1, impactDescription));
             }
@@ -243,7 +250,7 @@ public class ShardsAvailabilityHealthIndicatorService implements HealthIndicator
                     "Searches might return slower than usual. Fewer redundant copies of the data exist on %d %s [%s].",
                     indicesWithUnavailableReplicasOnly.size(),
                     indicesWithUnavailableReplicasOnly.size() == 1 ? "index" : "indices",
-                    getTruncatedIndicesString(indicesWithUnavailableReplicasOnly)
+                    getTruncatedIndicesString(indicesWithUnavailableReplicasOnly, clusterMetadata)
                 );
                 impacts.add(new HealthIndicatorImpact(3, impactDescription));
             }
@@ -252,9 +259,16 @@ public class ShardsAvailabilityHealthIndicatorService implements HealthIndicator
 
     }
 
-    private static String getTruncatedIndicesString(Set<String> indices) {
+    private static String getTruncatedIndicesString(Set<String> indices, Metadata clusterMetadata) {
         final int maxIndices = 10;
-        String truncatedIndicesString = indices.stream().limit(maxIndices).collect(joining(", "));
+        Comparator<String> comparePrioritiesAscendingComparator = Comparator.comparingInt(index -> clusterMetadata.index(index).priority());
+        // Reversing it because the higher the priority number, the higher the priority:
+        Comparator<String> comparePrioritiesDescendingComparator = comparePrioritiesAscendingComparator.reversed();
+        Comparator<String> comparePrioritiesThenNameComparaotr = comparePrioritiesDescendingComparator.thenComparing(index -> index);
+        String truncatedIndicesString = indices.stream()
+            .sorted(comparePrioritiesThenNameComparaotr)
+            .limit(maxIndices)
+            .collect(joining(", "));
         if (maxIndices < indices.size()) {
             truncatedIndicesString = truncatedIndicesString + ", ...";
         }


### PR DESCRIPTION
We truncate the list of indexes that we give in a health indicator impact to a small number of indexes. This change makes it so that the index names are sorted by priority order (and by index name if the priority is identical).
Relates #84899