### PR TITLE
Redirect testclusters ES process stdout/stderr to log file

### DIFF
--- a/build-tools/src/main/java/org/elasticsearch/gradle/testclusters/ElasticsearchNode.java
+++ b/build-tools/src/main/java/org/elasticsearch/gradle/testclusters/ElasticsearchNode.java
@@ -914,9 +914,10 @@ public class ElasticsearchNode implements TestClusterConfiguration {
         environment.clear();
         environment.putAll(getESEnvironment());
 
-        // Just toss the output since we rely on the normal log file written by Elasticsearch
-        processBuilder.redirectOutput(ProcessBuilder.Redirect.DISCARD);
-        processBuilder.redirectError(ProcessBuilder.Redirect.DISCARD);
+        // Direct the stdout and stderr to the ES log file. This should not contend with the actual ES
+        // process once it is started since there we close replace stdout/stderr handles once logging is setup.
+        processBuilder.redirectOutput(ProcessBuilder.Redirect.appendTo(esLogFile.toFile()));
+        processBuilder.redirectErrorStream(true);
 
         if (keystorePassword != null && keystorePassword.length() > 0) {
             try {


### PR DESCRIPTION
Although most of the time the stdout and stderr of the Java process is
not needed since ES has its own log file, there are some cases where it
is very important to have the output before ES has initialized its
logging system. This commit changes the stdout/stderr of the ES process
created by testclusters to use the same log file that ES will write to.
There should not be contention with ProcessBuilder and ES trying to
write at the same time because ES swaps out the stream handles to write
to its logging system, so after that point ProcessBuilder will never see
anymore output.

relates #68333