### PR TITLE
Correct the command to location of certs

### DIFF
--- a/docs/reference/setup/install/check-running.asciidoc
+++ b/docs/reference/setup/install/check-running.asciidoc
@@ -5,7 +5,7 @@ You can test that your {es} node is running by sending an HTTPS request to port
 
 ["source","sh",subs="attributes"]
 ----
-curl --cacert {es-conf}{slash}certs{slash}http_ca.crt -u elastic https://localhost:9200 <1>
+curl --cacert {es-conf}{slash}config{slash}certs{slash}http_ca.crt -u elastic https://localhost:9200 <1>
 ----
 // NOTCONSOLE
 <1> Ensure that you use `https` in your call, or the request will fail.


### PR DESCRIPTION
Hi there! Running through these steps, blindly following them leads to some road bumps.

This command:
curl --cacert $ES_PATH_CONF/certs/http_ca.crt -u elastic https://localhost:9200 

Doesn't do yield the reply as expected during my install, we get the following, while in the extracted directory:

curl --cacert ./certs/http_ca.crt -u elastic https://localhost:9200
Enter host password for user 'elastic':
curl: (77) error setting certificate verify locations:
  CAfile: ./certs/http_ca.crt
  CApath: /etc/ssl/certs

However, it seems that adding /config/ prior to the certs directory makes it respond correctly, the command looking as follows:

curl --cacert $ES_PATH_CONF/config/certs/http_ca.crt -u elastic https://localhost:9200 

I've seen this on other pages also, and actually went to the standard linux install instead of using deb packages because I thought it was off.

Do let me know if I've missed something, maybe this could help someone else out!