### PR TITLE
Fix calculation of max parallel forks for test execution

### DIFF
--- a/build-conventions/src/main/java/org/elasticsearch/gradle/internal/conventions/info/ParallelDetector.java
+++ b/build-conventions/src/main/java/org/elasticsearch/gradle/internal/conventions/info/ParallelDetector.java
@@ -62,9 +62,15 @@ public class ParallelDetector {
             } else if (isMac(project.getProviders())) {
                 // Ask macOS to count physical CPUs for us
                 ByteArrayOutputStream stdout = new ByteArrayOutputStream();
+
+                // On Apple silicon, we only want to use the performance cores
+                String query = project.getProviders().systemProperty("os.arch").getOrElse("").equals("aarch64")
+                    ? "hw.perflevel0.physicalcpu"
+                    : "hw.physicalcpu";
+
                 project.exec(spec -> {
                     spec.setExecutable("sysctl");
-                    spec.args("-n", "hw.physicalcpu");
+                    spec.args("-n", query);
                     spec.setStandardOutput(stdout);
                 });
 

--- a/build-conventions/src/main/java/org/elasticsearch/gradle/internal/conventions/info/ParallelDetector.java
+++ b/build-conventions/src/main/java/org/elasticsearch/gradle/internal/conventions/info/ParallelDetector.java
@@ -69,12 +69,12 @@ public class ParallelDetector {
                 });
 
                 _defaultParallel = Integer.parseInt(stdout.toString().trim());
+            } else {
+                _defaultParallel = Runtime.getRuntime().availableProcessors() / 2;
             }
-
-            _defaultParallel = Runtime.getRuntime().availableProcessors() / 2;
         }
 
-        return _defaultParallel;
+        return Math.min(_defaultParallel, project.getGradle().getStartParameter().getMaxWorkerCount());
     }
 
     private static boolean isMac(ProviderFactory providers) {

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/info/GlobalBuildInfoPlugin.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/info/GlobalBuildInfoPlugin.java
@@ -8,7 +8,6 @@
 package org.elasticsearch.gradle.internal.info;
 
 import org.apache.commons.io.IOUtils;
-import org.elasticsearch.gradle.OS;
 import org.elasticsearch.gradle.internal.BwcVersions;
 import org.elasticsearch.gradle.internal.conventions.info.GitInfo;
 import org.elasticsearch.gradle.internal.conventions.info.ParallelDetector;
@@ -30,10 +29,8 @@ import org.gradle.jvm.toolchain.internal.JavaInstallationRegistry;
 import org.gradle.util.GradleVersion;
 
 import java.io.BufferedReader;
-import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.FileInputStream;
-import java.io.FileReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.UncheckedIOException;
@@ -41,10 +38,8 @@ import java.nio.file.Files;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.util.Arrays;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
-import java.util.Map;
 import java.util.Random;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
@@ -55,7 +50,6 @@ import javax.inject.Inject;
 public class GlobalBuildInfoPlugin implements Plugin<Project> {
     private static final Logger LOGGER = Logging.getLogger(GlobalBuildInfoPlugin.class);
     private static final String DEFAULT_VERSION_JAVA_FILE_PATH = "server/src/main/java/org/elasticsearch/Version.java";
-    private static Integer _defaultParallel = null;
 
     private final JavaInstallationRegistry javaInstallationRegistry;
     private final JvmMetadataDetector metadataDetector;


### PR DESCRIPTION
We were inadvertently always using the "fallback" calculation of half
the reported number of processors instead of the more sophisticated
platform-specific implementations. On an M1 Pro this resulted in only
5 parallel test workers instead of the more appropriate 10. Also, even
though Gradle will do this for us, let explicitly make sure we don't
set it higher than the current max worker count.

This commit also removes a duplicate and unused copy of this same logic
from the GlobalBuildInfoPlugin.