### PR TITLE
[ML] Fixes to making old ML indices hidden

### DIFF
--- a/docs/changelog/85383.yaml
+++ b/docs/changelog/85383.yaml
@@ -1,0 +1,5 @@
+pr: 85383
+summary: Fixes to making old ML indices hidden
+area: Machine Learning
+type: bug
+issues: []


### PR DESCRIPTION
Some ML indices are supposed to be hidden indices. When
old clusters that predate hidden indices are upgraded we
need to make those old indices hidden.

This change improves the way we do that in two ways:

1. Any problems are now logged at level WARN instead of
   ERROR. This avoids necessary alarm at the severity of
   not being able to make an index hidden at the first
   attempt. We can always try again.
2. We wait until state has been recovered before making
   any attempt to make indices hidden, as no updates to
   cluster state will be possible before state has been
   recovered.