### PR TITLE
Simplify and Speedup QueryPhaseResultConsumer#close

### DIFF
--- a/docs/changelog/85389.yaml
+++ b/docs/changelog/85389.yaml
@@ -1,0 +1,5 @@
+pr: 85389
+summary: Simplify and Speedup `QueryPhaseResultConsumer#close`
+area: Aggregations
+type: enhancement
+issues: []

--- a/server/src/main/java/org/elasticsearch/action/search/QueryPhaseResultConsumer.java
+++ b/server/src/main/java/org/elasticsearch/action/search/QueryPhaseResultConsumer.java
@@ -37,7 +37,6 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 
-import static java.util.stream.Collectors.toCollection;
 import static org.elasticsearch.action.search.SearchPhaseController.getTopDocsSize;
 import static org.elasticsearch.action.search.SearchPhaseController.mergeTopDocs;
 import static org.elasticsearch.action.search.SearchPhaseController.setShardIndex;
@@ -256,22 +255,31 @@ public class QueryPhaseResultConsumer extends ArraySearchPhaseResults<SearchPhas
 
         @Override
         public synchronized void close() {
+            assert assertCircuitBreakerConsistent();
+            if (hasAggs) {
+                releaseAggs();
+            }
+            circuitBreaker.addWithoutBreaking(-circuitBreakerBytes);
+            circuitBreakerBytes = 0;
+
+            if (hasPendingMerges()) {
+                // This is a theoretically unreachable exception.
+                throw new IllegalStateException("Attempted to close with partial reduce in-flight");
+            }
+        }
+
+        private boolean assertCircuitBreakerConsistent() {
             if (hasFailure()) {
                 assert circuitBreakerBytes == 0;
             } else {
                 assert circuitBreakerBytes >= 0;
             }
+            return true;
+        }
 
-            List<Releasable> toRelease = buffer.stream().<Releasable>map(b -> b::releaseAggs).collect(toCollection(ArrayList::new));
-            toRelease.add(() -> {
-                circuitBreaker.addWithoutBreaking(-circuitBreakerBytes);
-                circuitBreakerBytes = 0;
-            });
-            Releasables.close(toRelease);
-
-            if (hasPendingMerges()) {
-                // This is a theoretically unreachable exception.
-                throw new IllegalStateException("Attempted to close with partial reduce in-flight");
+        private void releaseAggs() {
+            for (int i = 0; i < buffer.size(); i++) {
+                buffer.get(i).releaseAggs();
             }
         }
 
@@ -343,7 +351,7 @@ public class QueryPhaseResultConsumer extends ArraySearchPhaseResults<SearchPhas
                             addEstimateAndMaybeBreak(aggsSize);
                         } catch (Exception exc) {
                             result.releaseAggs();
-                            buffer.forEach(QuerySearchResult::releaseAggs);
+                            releaseAggs();
                             buffer.clear();
                             onMergeFailure(exc);
                             next.run();
@@ -513,7 +521,7 @@ public class QueryPhaseResultConsumer extends ArraySearchPhaseResults<SearchPhas
     private static class MergeTask {
         private final List<SearchShard> emptyResults;
         private QuerySearchResult[] buffer;
-        private long aggsBufferSize;
+        private final long aggsBufferSize;
         private Runnable next;
 
         private MergeTask(QuerySearchResult[] buffer, long aggsBufferSize, List<SearchShard> emptyResults, Runnable next) {


### PR DESCRIPTION
There's no need to build a list of lambdas before closing in such
a complicated way (especially when this list can be up to 512 elements in size?).
Releasing aggs never throws anyway and we have no guard
against it throwing in 3 other places in this file today so we
don't even need the safe Releasable.close in the first place.
Also extracted assert only logic in `close` into its own method.
