### PR TITLE
Adjust random values for padPixels

### DIFF
--- a/x-pack/plugin/vector-tile/src/test/java/org/elasticsearch/xpack/vectortile/feature/FeatureFactoryTests.java
+++ b/x-pack/plugin/vector-tile/src/test/java/org/elasticsearch/xpack/vectortile/feature/FeatureFactoryTests.java
@@ -106,7 +106,7 @@ public class FeatureFactoryTests extends ESTestCase {
         final int x = randomIntBetween(2, (1 << z) - 1);
         final int y = randomIntBetween(2, (1 << z) - 1);
         final int extent = randomIntBetween(1 << 8, 1 << 14);
-        final int padPixels = randomIntBetween(0, extent);
+        final int padPixels = randomIntBetween(0, extent - 1);
         final FeatureFactory builder = new FeatureFactory(z, x, y, extent, padPixels);
         {
             final Rectangle r = GeoTileUtils.toBoundingBox(x, y, z);


### PR DESCRIPTION
In #84710 we introduced the possibility to change the buffer size of vector tiles. We currently use random values between 0 and the current extent of the tile. The problem is that when the random value is picked to be the extent, then the test might fail because we are using a tile at distance two to create another geometry that should be discarded. In the case the padding is equal to the extent this fails.

This PR adjusts random values to be between `0` and `extent -1`.


fixes #85390