### PR TITLE
Remove hppc from o.e.c.util tests

### DIFF
--- a/server/src/test/java/org/elasticsearch/common/util/BytesRefHashTests.java
+++ b/server/src/test/java/org/elasticsearch/common/util/BytesRefHashTests.java
@@ -8,10 +8,6 @@
 
 package org.elasticsearch.common.util;
 
-import com.carrotsearch.hppc.ObjectLongHashMap;
-import com.carrotsearch.hppc.ObjectLongMap;
-import com.carrotsearch.hppc.cursors.ObjectLongCursor;
-
 import org.apache.lucene.tests.util.TestUtil;
 import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.BytesRefBuilder;
@@ -44,7 +40,7 @@ public class BytesRefHashTests extends ESTestCase {
             for (int i = 0; i < values.length; ++i) {
                 values[i] = new BytesRef(randomAlphaOfLength(5));
             }
-            final ObjectLongMap<BytesRef> valueToId = new ObjectLongHashMap<>();
+            final Map<BytesRef, Integer> valueToId = new HashMap<>();
             final BytesRef[] idToValue = new BytesRef[values.length];
             final int iters = randomInt(1000000);
             for (int i = 0; i < iters; ++i) {
@@ -59,8 +55,8 @@ public class BytesRefHashTests extends ESTestCase {
             }
 
             assertEquals(valueToId.size(), hash.size());
-            for (final ObjectLongCursor<BytesRef> next : valueToId) {
-                assertEquals(next.value, hash.find(next.key, next.key.hashCode()));
+            for (var entry : valueToId.entrySet()) {
+                assertEquals(entry.getValue().longValue(), hash.find(entry.getKey(), entry.getKey().hashCode()));
             }
 
             for (long i = 0; i < hash.capacity(); ++i) {

--- a/server/src/test/java/org/elasticsearch/common/util/LongHashTests.java
+++ b/server/src/test/java/org/elasticsearch/common/util/LongHashTests.java
@@ -8,10 +8,6 @@
 
 package org.elasticsearch.common.util;
 
-import com.carrotsearch.hppc.LongLongHashMap;
-import com.carrotsearch.hppc.LongLongMap;
-import com.carrotsearch.hppc.cursors.LongLongCursor;
-
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.indices.breaker.NoneCircuitBreakerService;
@@ -19,7 +15,6 @@ import org.elasticsearch.test.ESTestCase;
 
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.Iterator;
 import java.util.Map;
 import java.util.Set;
 
@@ -34,13 +29,13 @@ public class LongHashTests extends ESTestCase {
         return new LongHash(randomIntBetween(0, 100), maxLoadFactor, mockBigArrays());
     }
 
-    public void testDuell() {
+    public void testDuel() {
         try (LongHash hash = randomHash()) {
             final Long[] values = new Long[randomIntBetween(1, 100000)];
             for (int i = 0; i < values.length; ++i) {
                 values[i] = randomLong();
             }
-            final LongLongMap valueToId = new LongLongHashMap();
+            final Map<Long, Integer> valueToId = new HashMap<>();
             final long[] idToValue = new long[values.length];
             final int iters = randomInt(1000000);
             for (int i = 0; i < iters; ++i) {
@@ -55,9 +50,8 @@ public class LongHashTests extends ESTestCase {
             }
 
             assertEquals(valueToId.size(), hash.size());
-            for (Iterator<LongLongCursor> iterator = valueToId.iterator(); iterator.hasNext();) {
-                final LongLongCursor next = iterator.next();
-                assertEquals(next.value, hash.find(next.key));
+            for (var entry : valueToId.entrySet()) {
+                assertEquals(entry.getValue().longValue(), hash.find(entry.getKey()));
             }
 
             for (long i = 0; i < hash.capacity(); ++i) {

--- a/server/src/test/java/org/elasticsearch/common/util/LongObjectPagedHashMapTests.java
+++ b/server/src/test/java/org/elasticsearch/common/util/LongObjectPagedHashMapTests.java
@@ -8,12 +8,13 @@
 
 package org.elasticsearch.common.util;
 
-import com.carrotsearch.hppc.LongObjectHashMap;
-
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.indices.breaker.NoneCircuitBreakerService;
 import org.elasticsearch.test.ESTestCase;
+
+import java.util.HashMap;
+import java.util.Map;
 
 public class LongObjectPagedHashMapTests extends ESTestCase {
 
@@ -22,7 +23,7 @@ public class LongObjectPagedHashMapTests extends ESTestCase {
     }
 
     public void testDuel() {
-        final LongObjectHashMap<Object> map1 = new LongObjectHashMap<>();
+        final Map<Long, Object> map1 = new HashMap<>();
         final LongObjectPagedHashMap<Object> map2 = new LongObjectPagedHashMap<>(
             randomInt(42),
             0.6f + randomFloat() * 0.39f,
@@ -44,10 +45,10 @@ public class LongObjectPagedHashMapTests extends ESTestCase {
                 assertEquals(map1.size(), map2.size());
             }
         }
-        for (int i = 0; i <= maxKey; ++i) {
+        for (long i = 0; i <= maxKey; ++i) {
             assertSame(map1.get(i), map2.get(i));
         }
-        final LongObjectHashMap<Object> copy = new LongObjectHashMap<>();
+        final Map<Long, Object> copy = new HashMap<>();
         for (LongObjectPagedHashMap.Cursor<Object> cursor : map2) {
             copy.put(cursor.key, cursor.value);
         }


### PR DESCRIPTION
These tests have no need to use hppc since they do not interact with any
hppc types from server.

relates #84735