### PR TITLE
Add NOOP ActionListener Singleton

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/ActionListener.java
+++ b/server/src/main/java/org/elasticsearch/action/ActionListener.java
@@ -34,6 +34,32 @@ public interface ActionListener<Response> {
      */
     void onFailure(Exception e);
 
+    @SuppressWarnings("rawtypes")
+    ActionListener NOOP = new ActionListener() {
+        @Override
+        public void onResponse(Object o) {
+
+        }
+
+        @Override
+        public void onFailure(Exception e) {
+
+        }
+
+        @Override
+        public String toString() {
+            return "NoopActionListener";
+        }
+    };
+
+    /**
+     * @return a listener that does nothing
+     */
+    @SuppressWarnings("unchecked")
+    static <T> ActionListener<T> noop() {
+        return (ActionListener<T>) NOOP;
+    }
+
     /**
      * Creates a listener that wraps this listener, mapping response values via the given mapping function and passing along
      * exceptions to this instance.

--- a/server/src/main/java/org/elasticsearch/action/search/SearchTransportService.java
+++ b/server/src/main/java/org/elasticsearch/action/search/SearchTransportService.java
@@ -108,17 +108,8 @@ public class SearchTransportService {
             FREE_CONTEXT_ACTION_NAME,
             new SearchFreeContextRequest(originalIndices, contextId),
             TransportRequestOptions.EMPTY,
-            new ActionListenerResponseHandler<>(new ActionListener<SearchFreeContextResponse>() {
-                @Override
-                public void onResponse(SearchFreeContextResponse response) {
-                    // no need to respond if it was freed or not
-                }
-
-                @Override
-                public void onFailure(Exception e) {
-
-                }
-            }, SearchFreeContextResponse::new)
+            // no need to respond if it was freed or not
+            new ActionListenerResponseHandler<>(ActionListener.noop(), SearchFreeContextResponse::new)
         );
     }
 
@@ -671,7 +662,7 @@ public class SearchTransportService {
         CancelTasksRequest req = new CancelTasksRequest().setTargetTaskId(new TaskId(client.getLocalNodeId(), task.getId()))
             .setReason("Fatal failure during search: " + reason);
         // force the origin to execute the cancellation as a system user
-        new OriginSettingClient(client, GetTaskAction.TASKS_ORIGIN).admin().cluster().cancelTasks(req, ActionListener.wrap(() -> {}));
+        new OriginSettingClient(client, GetTaskAction.TASKS_ORIGIN).admin().cluster().cancelTasks(req, ActionListener.noop());
     }
 
     public NamedWriteableRegistry getNamedWriteableRegistry() {

--- a/server/src/main/java/org/elasticsearch/cluster/coordination/Coordinator.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/Coordinator.java
@@ -772,7 +772,7 @@ public class Coordinator extends AbstractLifecycleComponent implements ClusterSt
 
             if (applierState.nodes().getMasterNodeId() != null) {
                 applierState = clusterStateWithNoMasterBlock(applierState);
-                clusterApplier.onNewClusterState("becoming candidate: " + method, () -> applierState, ActionListener.wrap(() -> {}));
+                clusterApplier.onNewClusterState("becoming candidate: " + method, () -> applierState, ActionListener.noop());
             }
         }
 

--- a/server/src/main/java/org/elasticsearch/http/AbstractHttpServerTransport.java
+++ b/server/src/main/java/org/elasticsearch/http/AbstractHttpServerTransport.java
@@ -65,7 +65,6 @@ import static org.elasticsearch.http.HttpTransportSettings.SETTING_HTTP_PUBLISH_
 
 public abstract class AbstractHttpServerTransport extends AbstractLifecycleComponent implements HttpServerTransport {
     private static final Logger logger = LogManager.getLogger(AbstractHttpServerTransport.class);
-    private static final ActionListener<Void> NO_OP = ActionListener.wrap(() -> {});
 
     protected final Settings settings;
     public final HttpHandlingSettings handlingSettings;
@@ -490,7 +489,7 @@ public abstract class AbstractHttpServerTransport extends AbstractLifecycleCompo
         if (HttpUtils.shouldCloseConnection(request)) {
             return ActionListener.wrap(() -> CloseableChannel.closeChannel(httpChannel));
         } else {
-            return NO_OP;
+            return ActionListener.noop();
         }
     }
 }

--- a/server/src/main/java/org/elasticsearch/indices/cluster/IndicesClusterStateService.java
+++ b/server/src/main/java/org/elasticsearch/indices/cluster/IndicesClusterStateService.java
@@ -94,8 +94,6 @@ public class IndicesClusterStateService extends AbstractLifecycleComponent imple
     private final PeerRecoveryTargetService recoveryTargetService;
     private final ShardStateAction shardStateAction;
 
-    private static final ActionListener<Void> SHARD_STATE_ACTION_LISTENER = ActionListener.wrap(() -> {});
-
     private final Settings settings;
     // a list of shards that failed during recovery
     // we keep track of these shards in order to prevent repeated recovery of these shards on each cluster state update
@@ -258,7 +256,7 @@ public class IndicesClusterStateService extends AbstractLifecycleComponent imple
                 if (masterNode != null) { // TODO: can we remove this? Is resending shard failures the responsibility of shardStateAction?
                     String message = "master " + masterNode + " has not removed previously failed shard. resending shard failure";
                     logger.trace("[{}] re-sending failed shard [{}], reason [{}]", matchedRouting.shardId(), matchedRouting, message);
-                    shardStateAction.localShardFailed(matchedRouting, message, null, SHARD_STATE_ACTION_LISTENER, state);
+                    shardStateAction.localShardFailed(matchedRouting, message, null, ActionListener.noop(), state);
                 }
             }
         }
@@ -670,7 +668,7 @@ public class IndicesClusterStateService extends AbstractLifecycleComponent imple
                         + state
                         + "], mark shard as started",
                     shard.getTimestampRange(),
-                    SHARD_STATE_ACTION_LISTENER,
+                    ActionListener.noop(),
                     clusterState
                 );
             }
@@ -735,7 +733,7 @@ public class IndicesClusterStateService extends AbstractLifecycleComponent imple
                 primaryTerm,
                 "after " + state.getRecoverySource(),
                 timestampMillisFieldRange,
-                SHARD_STATE_ACTION_LISTENER
+                ActionListener.noop()
             );
         }
 
@@ -791,7 +789,7 @@ public class IndicesClusterStateService extends AbstractLifecycleComponent imple
                 failure
             );
             failedShardsCache.put(shardRouting.shardId(), shardRouting);
-            shardStateAction.localShardFailed(shardRouting, message, failure, SHARD_STATE_ACTION_LISTENER, state);
+            shardStateAction.localShardFailed(shardRouting, message, failure, ActionListener.noop(), state);
         } catch (Exception inner) {
             if (failure != null) inner.addSuppressed(failure);
             logger.warn(

--- a/server/src/main/java/org/elasticsearch/rest/action/RestCancellableNodeClient.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/RestCancellableNodeClient.java
@@ -106,7 +106,7 @@ public class RestCancellableNodeClient extends FilterClient {
     private void cancelTask(TaskId taskId) {
         CancelTasksRequest req = new CancelTasksRequest().setTargetTaskId(taskId).setReason("http channel [" + httpChannel + "] closed");
         // force the origin to execute the cancellation as a system user
-        new OriginSettingClient(client, TASKS_ORIGIN).admin().cluster().cancelTasks(req, ActionListener.wrap(() -> {}));
+        new OriginSettingClient(client, TASKS_ORIGIN).admin().cluster().cancelTasks(req, ActionListener.noop());
     }
 
     private class CloseListener implements ActionListener<Void> {

--- a/server/src/main/java/org/elasticsearch/tasks/TaskManager.java
+++ b/server/src/main/java/org/elasticsearch/tasks/TaskManager.java
@@ -717,7 +717,7 @@ public class TaskManager implements ClusterStateApplier {
                 @Override
                 protected void doRun() {
                     for (CancellableTask task : tasks) {
-                        cancelTaskAndDescendants(task, "channel was closed", false, ActionListener.wrap(() -> {}));
+                        cancelTaskAndDescendants(task, "channel was closed", false, ActionListener.noop());
                     }
                 }
             });

--- a/server/src/main/java/org/elasticsearch/transport/RemoteClusterAwareClient.java
+++ b/server/src/main/java/org/elasticsearch/transport/RemoteClusterAwareClient.java
@@ -57,7 +57,7 @@ final class RemoteClusterAwareClient extends AbstractClient {
             } catch (NoSuchRemoteClusterException e) {
                 if (ensureConnected == false) {
                     // trigger another connection attempt, but don't wait for it to complete
-                    remoteClusterService.ensureConnected(clusterAlias, ActionListener.wrap(() -> {}));
+                    remoteClusterService.ensureConnected(clusterAlias, ActionListener.noop());
                 }
                 throw e;
             }

--- a/server/src/test/java/org/elasticsearch/action/ActionListenerTests.java
+++ b/server/src/test/java/org/elasticsearch/action/ActionListenerTests.java
@@ -146,13 +146,13 @@ public class ActionListenerTests extends ESTestCase {
     public void testRunAfter() {
         {
             AtomicBoolean afterSuccess = new AtomicBoolean();
-            ActionListener<Object> listener = ActionListener.runAfter(ActionListener.wrap(r -> {}, e -> {}), () -> afterSuccess.set(true));
+            ActionListener<Object> listener = ActionListener.runAfter(ActionListener.noop(), () -> afterSuccess.set(true));
             listener.onResponse(null);
             assertThat(afterSuccess.get(), equalTo(true));
         }
         {
             AtomicBoolean afterFailure = new AtomicBoolean();
-            ActionListener<Object> listener = ActionListener.runAfter(ActionListener.wrap(r -> {}, e -> {}), () -> afterFailure.set(true));
+            ActionListener<Object> listener = ActionListener.runAfter(ActionListener.noop(), () -> afterFailure.set(true));
             listener.onFailure(null);
             assertThat(afterFailure.get(), equalTo(true));
         }
@@ -161,13 +161,13 @@ public class ActionListenerTests extends ESTestCase {
     public void testRunBefore() {
         {
             AtomicBoolean afterSuccess = new AtomicBoolean();
-            ActionListener<Object> listener = ActionListener.runBefore(ActionListener.wrap(r -> {}, e -> {}), () -> afterSuccess.set(true));
+            ActionListener<Object> listener = ActionListener.runBefore(ActionListener.noop(), () -> afterSuccess.set(true));
             listener.onResponse(null);
             assertThat(afterSuccess.get(), equalTo(true));
         }
         {
             AtomicBoolean afterFailure = new AtomicBoolean();
-            ActionListener<Object> listener = ActionListener.runBefore(ActionListener.wrap(r -> {}, e -> {}), () -> afterFailure.set(true));
+            ActionListener<Object> listener = ActionListener.runBefore(ActionListener.noop(), () -> afterFailure.set(true));
             listener.onFailure(null);
             assertThat(afterFailure.get(), equalTo(true));
         }

--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/node/tasks/CancellableTasksTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/node/tasks/CancellableTasksTests.java
@@ -434,7 +434,7 @@ public class CancellableTasksTests extends TaskManagerTestCase {
                 testAction,
                 childRequest,
                 testNodes[0].transportService.getLocalNodeConnection(),
-                ActionTestUtils.wrapAsTaskListener(ActionListener.wrap(() -> {}))
+                ActionTestUtils.wrapAsTaskListener(ActionListener.noop())
             )
         );
         assertThat(cancelledException.getMessage(), equalTo("task cancelled before starting [test]"));

--- a/server/src/test/java/org/elasticsearch/action/admin/indices/resolve/TransportResolveIndexActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/indices/resolve/TransportResolveIndexActionTests.java
@@ -75,13 +75,7 @@ public class TransportResolveIndexActionTests extends ESTestCase {
 
             IllegalArgumentException ex = expectThrows(
                 IllegalArgumentException.class,
-                () -> action.doExecute(null, request, new ActionListener<ResolveIndexAction.Response>() {
-                    @Override
-                    public void onResponse(ResolveIndexAction.Response response) {}
-
-                    @Override
-                    public void onFailure(Exception e) {}
-                })
+                () -> action.doExecute(null, request, ActionListener.noop())
             );
 
             assertThat(ex.getMessage(), containsString("not compatible with version"));

--- a/server/src/test/java/org/elasticsearch/action/bulk/BulkRequestModifierTests.java
+++ b/server/src/test/java/org/elasticsearch/action/bulk/BulkRequestModifierTests.java
@@ -127,8 +127,7 @@ public class BulkRequestModifierTests extends ESTestCase {
 
         BulkRequest bulkRequest = modifier.getBulkRequest();
         assertThat(bulkRequest, Matchers.sameInstance(originalBulkRequest));
-        ActionListener<BulkResponse> actionListener = ActionListener.wrap(() -> {});
-        assertThat(modifier.wrapActionListenerIfNeeded(1L, actionListener), instanceOf(ActionListener.MappedActionListener.class));
+        assertThat(modifier.wrapActionListenerIfNeeded(1L, ActionListener.noop()), instanceOf(ActionListener.MappedActionListener.class));
     }
 
     private static class CaptureActionListener implements ActionListener<BulkResponse> {

--- a/server/src/test/java/org/elasticsearch/action/fieldcaps/TransportFieldCapabilitiesActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/fieldcaps/TransportFieldCapabilitiesActionTests.java
@@ -81,13 +81,7 @@ public class TransportFieldCapabilitiesActionTests extends ESTestCase {
 
             IllegalArgumentException ex = expectThrows(
                 IllegalArgumentException.class,
-                () -> action.doExecute(null, fieldCapsRequest, new ActionListener<FieldCapabilitiesResponse>() {
-                    @Override
-                    public void onResponse(FieldCapabilitiesResponse response) {}
-
-                    @Override
-                    public void onFailure(Exception e) {}
-                })
+                () -> action.doExecute(null, fieldCapsRequest, ActionListener.noop())
             );
 
             assertThat(

--- a/server/src/test/java/org/elasticsearch/action/get/TransportMultiGetActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/get/TransportMultiGetActionTests.java
@@ -226,7 +226,7 @@ public class TransportMultiGetActionTests extends ESTestCase {
             }
         };
 
-        ActionTestUtils.execute(transportAction, task, request.request(), new ActionListenerAdapter());
+        ActionTestUtils.execute(transportAction, task, request.request(), ActionListener.noop());
         assertTrue(shardActionInvoked.get());
     }
 
@@ -259,7 +259,7 @@ public class TransportMultiGetActionTests extends ESTestCase {
             }
         };
 
-        ActionTestUtils.execute(transportAction, task, request.request(), new ActionListenerAdapter());
+        ActionTestUtils.execute(transportAction, task, request.request(), ActionListener.noop());
         assertTrue(shardActionInvoked.get());
 
     }
@@ -287,12 +287,4 @@ public class TransportMultiGetActionTests extends ESTestCase {
         }
     }
 
-    static class ActionListenerAdapter implements ActionListener<MultiGetResponse> {
-
-        @Override
-        public void onResponse(MultiGetResponse response) {}
-
-        @Override
-        public void onFailure(Exception e) {}
-    }
 }

--- a/server/src/test/java/org/elasticsearch/action/termvectors/TransportMultiTermVectorsActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/termvectors/TransportMultiTermVectorsActionTests.java
@@ -230,7 +230,7 @@ public class TransportMultiTermVectorsActionTests extends ESTestCase {
             }
         };
 
-        ActionTestUtils.execute(transportAction, task, request.request(), new ActionListenerAdapter());
+        ActionTestUtils.execute(transportAction, task, request.request(), ActionListener.noop());
         assertTrue(shardActionInvoked.get());
     }
 
@@ -263,7 +263,7 @@ public class TransportMultiTermVectorsActionTests extends ESTestCase {
             }
         };
 
-        ActionTestUtils.execute(transportAction, task, request.request(), new ActionListenerAdapter());
+        ActionTestUtils.execute(transportAction, task, request.request(), ActionListener.noop());
         assertTrue(shardActionInvoked.get());
     }
 
@@ -290,12 +290,4 @@ public class TransportMultiTermVectorsActionTests extends ESTestCase {
         }
     }
 
-    static class ActionListenerAdapter implements ActionListener<MultiTermVectorsResponse> {
-
-        @Override
-        public void onResponse(MultiTermVectorsResponse response) {}
-
-        @Override
-        public void onFailure(Exception e) {}
-    }
 }

--- a/server/src/test/java/org/elasticsearch/cluster/action/index/MappingUpdatedActionTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/action/index/MappingUpdatedActionTests.java
@@ -149,7 +149,7 @@ public class MappingUpdatedActionTests extends ESTestCase {
         RootObjectMapper rootObjectMapper = new RootObjectMapper.Builder("name").build(MapperBuilderContext.ROOT);
         Mapping update = new Mapping(rootObjectMapper, new MetadataFieldMapper[0], Map.of());
 
-        mua.sendUpdateMapping(new Index("name", "uuid"), update, ActionListener.wrap(() -> {}));
+        mua.sendUpdateMapping(new Index("name", "uuid"), update, ActionListener.noop());
         verify(indicesAdminClient).execute(eq(AutoPutMappingAction.INSTANCE), any(), any());
     }
 }

--- a/server/src/test/java/org/elasticsearch/cluster/health/ClusterStateHealthTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/health/ClusterStateHealthTests.java
@@ -140,7 +140,7 @@ public class ClusterStateHealthTests extends ESTestCase {
                 () -> ClusterState.builder(currentState)
                     .nodes(DiscoveryNodes.builder(currentState.nodes()).masterNodeId(currentState.nodes().getLocalNodeId()))
                     .build(),
-                ActionListener.wrap(() -> {})
+                ActionListener.noop()
             );
 
         logger.info("--> waiting for listener to be called and cluster state being blocked");

--- a/server/src/test/java/org/elasticsearch/cluster/routing/BatchedRerouteServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/BatchedRerouteServiceTests.java
@@ -223,7 +223,7 @@ public class BatchedRerouteServiceTests extends ESTestCase {
                     return ClusterState.builder(state)
                         .nodes(DiscoveryNodes.builder(state.nodes()).masterNodeId(randomBoolean() ? null : state.nodes().getLocalNodeId()))
                         .build();
-                }, ActionListener.wrap(() -> {}));
+                }, ActionListener.noop());
             }
         }
 

--- a/server/src/test/java/org/elasticsearch/index/seqno/PeerRecoveryRetentionLeaseExpiryTests.java
+++ b/server/src/test/java/org/elasticsearch/index/seqno/PeerRecoveryRetentionLeaseExpiryTests.java
@@ -8,7 +8,6 @@
 package org.elasticsearch.index.seqno;
 
 import org.elasticsearch.action.ActionListener;
-import org.elasticsearch.action.support.replication.ReplicationResponse;
 import org.elasticsearch.cluster.routing.AllocationId;
 import org.elasticsearch.cluster.routing.IndexShardRoutingTable;
 import org.elasticsearch.cluster.routing.RoutingNodesHelper;
@@ -33,8 +32,6 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
 
 public class PeerRecoveryRetentionLeaseExpiryTests extends ReplicationTrackerTestCase {
-
-    private static final ActionListener<ReplicationResponse> EMPTY_LISTENER = ActionListener.wrap(() -> {});
 
     private ReplicationTracker replicationTracker;
     private AtomicLong currentTimeMillis;
@@ -87,7 +84,7 @@ public class PeerRecoveryRetentionLeaseExpiryTests extends ReplicationTrackerTes
         replicationTracker.addPeerRecoveryRetentionLease(
             routingTableWithReplica.getByAllocationId(replicaAllocationId.getId()).currentNodeId(),
             randomCheckpoint(),
-            EMPTY_LISTENER
+            ActionListener.noop()
         );
 
         replicationTracker.initiateTracking(replicaAllocationId.getId());
@@ -135,7 +132,7 @@ public class PeerRecoveryRetentionLeaseExpiryTests extends ReplicationTrackerTes
     public void testPeerRecoveryRetentionLeasesForUnassignedCopiesDoNotExpireImmediatelyIfShardsNotAllStarted() {
         final String unknownNodeId = randomAlphaOfLength(10);
         final long globalCheckpoint = randomNonNegativeLong(); // not NO_OPS_PERFORMED since this always results in file-based recovery
-        replicationTracker.addPeerRecoveryRetentionLease(unknownNodeId, globalCheckpoint, EMPTY_LISTENER);
+        replicationTracker.addPeerRecoveryRetentionLease(unknownNodeId, globalCheckpoint, ActionListener.noop());
 
         currentTimeMillis.set(
             currentTimeMillis.get() + randomLongBetween(
@@ -168,7 +165,7 @@ public class PeerRecoveryRetentionLeaseExpiryTests extends ReplicationTrackerTes
 
         final String unknownNodeId = randomAlphaOfLength(10);
         final long globalCheckpoint = randomCheckpoint();
-        replicationTracker.addPeerRecoveryRetentionLease(unknownNodeId, globalCheckpoint, EMPTY_LISTENER);
+        replicationTracker.addPeerRecoveryRetentionLease(unknownNodeId, globalCheckpoint, ActionListener.noop());
 
         currentTimeMillis.set(
             randomLongBetween(
@@ -195,7 +192,7 @@ public class PeerRecoveryRetentionLeaseExpiryTests extends ReplicationTrackerTes
 
     public void testPeerRecoveryRetentionLeasesForUnassignedCopiesExpireImmediatelyIfShardsAllStarted() {
         final String unknownNodeId = randomAlphaOfLength(10);
-        replicationTracker.addPeerRecoveryRetentionLease(unknownNodeId, randomCheckpoint(), EMPTY_LISTENER);
+        replicationTracker.addPeerRecoveryRetentionLease(unknownNodeId, randomCheckpoint(), ActionListener.noop());
 
         startReplica();
 
@@ -227,7 +224,7 @@ public class PeerRecoveryRetentionLeaseExpiryTests extends ReplicationTrackerTes
 
         final String unknownNodeId = randomAlphaOfLength(10);
         final long globalCheckpoint = randomValueOtherThan(SequenceNumbers.NO_OPS_PERFORMED, this::randomCheckpoint);
-        replicationTracker.addPeerRecoveryRetentionLease(unknownNodeId, globalCheckpoint, EMPTY_LISTENER);
+        replicationTracker.addPeerRecoveryRetentionLease(unknownNodeId, globalCheckpoint, ActionListener.noop());
 
         safeCommitInfo = randomSafeCommitInfoSuitableForFileBasedRecovery(globalCheckpoint);
 

--- a/server/src/test/java/org/elasticsearch/index/seqno/ReplicationTrackerRetentionLeaseTests.java
+++ b/server/src/test/java/org/elasticsearch/index/seqno/ReplicationTrackerRetentionLeaseTests.java
@@ -80,7 +80,7 @@ public class ReplicationTrackerRetentionLeaseTests extends ReplicationTrackerTes
                 Integer.toString(i),
                 minimumRetainingSequenceNumbers[i],
                 "test-" + i,
-                ActionListener.wrap(() -> {})
+                ActionListener.noop()
             );
             assertRetentionLeases(replicationTracker, i + 1, minimumRetainingSequenceNumbers, primaryTerm, 2 + i, true, false);
         }
@@ -119,11 +119,11 @@ public class ReplicationTrackerRetentionLeaseTests extends ReplicationTrackerTes
         final String id = randomAlphaOfLength(8);
         final long retainingSequenceNumber = randomNonNegativeLong();
         final String source = randomAlphaOfLength(8);
-        replicationTracker.addRetentionLease(id, retainingSequenceNumber, source, ActionListener.wrap(() -> {}));
+        replicationTracker.addRetentionLease(id, retainingSequenceNumber, source, ActionListener.noop());
         final long nextRetaininSequenceNumber = randomLongBetween(retainingSequenceNumber, Long.MAX_VALUE);
         final RetentionLeaseAlreadyExistsException e = expectThrows(
             RetentionLeaseAlreadyExistsException.class,
-            () -> replicationTracker.addRetentionLease(id, nextRetaininSequenceNumber, source, ActionListener.wrap(() -> {}))
+            () -> replicationTracker.addRetentionLease(id, nextRetaininSequenceNumber, source, ActionListener.noop())
         );
         assertThat(e, hasToString(containsString("retention lease with ID [" + id + "] already exists")));
     }
@@ -194,7 +194,7 @@ public class ReplicationTrackerRetentionLeaseTests extends ReplicationTrackerTes
             final String id = randomAlphaOfLength(8);
             final long retainingSequenceNumber = randomLongBetween(SequenceNumbers.NO_OPS_PERFORMED, Long.MAX_VALUE);
             retainingSequenceNumbers.put(id, retainingSequenceNumber);
-            replicationTracker.addRetentionLease(id, retainingSequenceNumber, "test", ActionListener.wrap(() -> {}));
+            replicationTracker.addRetentionLease(id, retainingSequenceNumber, "test", ActionListener.noop());
             // assert that the new retention lease callback was invoked
             assertTrue(invoked.get());
 
@@ -237,7 +237,7 @@ public class ReplicationTrackerRetentionLeaseTests extends ReplicationTrackerTes
                 Integer.toString(i),
                 minimumRetainingSequenceNumbers[i],
                 "test-" + i,
-                ActionListener.wrap(() -> {})
+                ActionListener.noop()
             );
         }
 
@@ -250,7 +250,7 @@ public class ReplicationTrackerRetentionLeaseTests extends ReplicationTrackerTes
              * Remove from the end since it will make the following assertion easier; we want to ensure that only the intended lease was
              * removed.
              */
-            replicationTracker.removeRetentionLease(Integer.toString(length - i - 1), ActionListener.wrap(() -> {}));
+            replicationTracker.removeRetentionLease(Integer.toString(length - i - 1), ActionListener.noop());
             assertRetentionLeases(
                 replicationTracker,
                 length - i - 1,
@@ -339,7 +339,7 @@ public class ReplicationTrackerRetentionLeaseTests extends ReplicationTrackerTes
         assertThat(
             expectThrows(
                 RetentionLeaseNotFoundException.class,
-                () -> replicationTracker.cloneRetentionLease("nonexistent-lease-id", "target", ActionListener.wrap(() -> {}))
+                () -> replicationTracker.cloneRetentionLease("nonexistent-lease-id", "target", ActionListener.noop())
             ).getMessage(),
             equalTo("retention lease with ID [nonexistent-lease-id] not found")
         );
@@ -365,13 +365,13 @@ public class ReplicationTrackerRetentionLeaseTests extends ReplicationTrackerTes
         );
         replicationTracker.activatePrimaryMode(SequenceNumbers.NO_OPS_PERFORMED);
 
-        replicationTracker.addRetentionLease("source", randomLongBetween(0L, Long.MAX_VALUE), "test-source", ActionListener.wrap(() -> {}));
-        replicationTracker.addRetentionLease("exists", randomLongBetween(0L, Long.MAX_VALUE), "test-source", ActionListener.wrap(() -> {}));
+        replicationTracker.addRetentionLease("source", randomLongBetween(0L, Long.MAX_VALUE), "test-source", ActionListener.noop());
+        replicationTracker.addRetentionLease("exists", randomLongBetween(0L, Long.MAX_VALUE), "test-source", ActionListener.noop());
 
         assertThat(
             expectThrows(
                 RetentionLeaseAlreadyExistsException.class,
-                () -> replicationTracker.cloneRetentionLease("source", "exists", ActionListener.wrap(() -> {}))
+                () -> replicationTracker.cloneRetentionLease("source", "exists", ActionListener.noop())
             ).getMessage(),
             equalTo("retention lease with ID [exists] already exists")
         );
@@ -400,7 +400,7 @@ public class ReplicationTrackerRetentionLeaseTests extends ReplicationTrackerTes
         final String id = randomAlphaOfLength(8);
         final RetentionLeaseNotFoundException e = expectThrows(
             RetentionLeaseNotFoundException.class,
-            () -> replicationTracker.removeRetentionLease(id, ActionListener.wrap(() -> {}))
+            () -> replicationTracker.removeRetentionLease(id, ActionListener.noop())
         );
         assertThat(e, hasToString(containsString("retention lease with ID [" + id + "] not found")));
     }
@@ -443,14 +443,14 @@ public class ReplicationTrackerRetentionLeaseTests extends ReplicationTrackerTes
             final String id = randomAlphaOfLength(8);
             final long retainingSequenceNumber = randomLongBetween(SequenceNumbers.NO_OPS_PERFORMED, Long.MAX_VALUE);
             retainingSequenceNumbers.put(id, retainingSequenceNumber);
-            replicationTracker.addRetentionLease(id, retainingSequenceNumber, "test", ActionListener.wrap(() -> {}));
+            replicationTracker.addRetentionLease(id, retainingSequenceNumber, "test", ActionListener.noop());
             // assert that the new retention lease callback was invoked
             assertTrue(invoked.get());
 
             // reset the invocation marker so that we can assert the callback was not invoked when removing the lease
             invoked.set(false);
             retainingSequenceNumbers.remove(id);
-            replicationTracker.removeRetentionLease(id, ActionListener.wrap(() -> {}));
+            replicationTracker.removeRetentionLease(id, ActionListener.noop());
             assertTrue(invoked.get());
         }
     }
@@ -493,7 +493,7 @@ public class ReplicationTrackerRetentionLeaseTests extends ReplicationTrackerTes
         final long[] retainingSequenceNumbers = new long[1];
         retainingSequenceNumbers[0] = randomLongBetween(0, Long.MAX_VALUE);
         if (primaryMode) {
-            replicationTracker.addRetentionLease("0", retainingSequenceNumbers[0], "test-0", ActionListener.wrap(() -> {}));
+            replicationTracker.addRetentionLease("0", retainingSequenceNumbers[0], "test-0", ActionListener.noop());
         } else {
             final RetentionLeases retentionLeases = new RetentionLeases(
                 primaryTerm,
@@ -627,7 +627,7 @@ public class ReplicationTrackerRetentionLeaseTests extends ReplicationTrackerTes
                 replicationTracker.setOperationPrimaryTerm(primaryTerm);
             }
             final long retainingSequenceNumber = randomLongBetween(SequenceNumbers.NO_OPS_PERFORMED, Long.MAX_VALUE);
-            replicationTracker.addRetentionLease(Integer.toString(i), retainingSequenceNumber, "test-" + i, ActionListener.wrap(() -> {}));
+            replicationTracker.addRetentionLease(Integer.toString(i), retainingSequenceNumber, "test-" + i, ActionListener.noop());
         }
 
         final Path path = createTempDir();
@@ -662,7 +662,7 @@ public class ReplicationTrackerRetentionLeaseTests extends ReplicationTrackerTes
                 replicationTracker.setOperationPrimaryTerm(primaryTerm);
             }
             final long retainingSequenceNumber = randomLongBetween(SequenceNumbers.NO_OPS_PERFORMED, Long.MAX_VALUE);
-            replicationTracker.addRetentionLease(Integer.toString(i), retainingSequenceNumber, "test-" + i, ActionListener.wrap(() -> {}));
+            replicationTracker.addRetentionLease(Integer.toString(i), retainingSequenceNumber, "test-" + i, ActionListener.noop());
         }
 
         final Path path = createTempDir();
@@ -715,7 +715,7 @@ public class ReplicationTrackerRetentionLeaseTests extends ReplicationTrackerTes
                 replicationTracker.setOperationPrimaryTerm(primaryTerm);
             }
             final long retainingSequenceNumber = randomLongBetween(SequenceNumbers.NO_OPS_PERFORMED, Long.MAX_VALUE);
-            replicationTracker.addRetentionLease(Integer.toString(i), retainingSequenceNumber, "test-" + i, ActionListener.wrap(() -> {}));
+            replicationTracker.addRetentionLease(Integer.toString(i), retainingSequenceNumber, "test-" + i, ActionListener.noop());
         }
 
         final Path path = createTempDir();
@@ -728,7 +728,7 @@ public class ReplicationTrackerRetentionLeaseTests extends ReplicationTrackerTes
                 try {
                     barrier.await();
                     final long retainingSequenceNumber = randomLongBetween(SequenceNumbers.NO_OPS_PERFORMED, Long.MAX_VALUE);
-                    replicationTracker.addRetentionLease(id, retainingSequenceNumber, "test-" + id, ActionListener.wrap(() -> {}));
+                    replicationTracker.addRetentionLease(id, retainingSequenceNumber, "test-" + id, ActionListener.noop());
                     replicationTracker.persistRetentionLeases(path);
                     barrier.await();
                 } catch (final BrokenBarrierException | InterruptedException | WriteStateException e) {
@@ -775,7 +775,7 @@ public class ReplicationTrackerRetentionLeaseTests extends ReplicationTrackerTes
         final String id = randomAlphaOfLength(8);
         final long retainingSequenceNumber = randomNonNegativeLong();
         final String source = randomAlphaOfLength(8);
-        replicationTracker.addRetentionLease(id, retainingSequenceNumber, source, ActionListener.wrap(() -> {}));
+        replicationTracker.addRetentionLease(id, retainingSequenceNumber, source, ActionListener.noop());
         final long lowerRetainingSequenceNumber = randomLongBetween(SequenceNumbers.NO_OPS_PERFORMED, retainingSequenceNumber - 1);
         final RetentionLeaseInvalidRetainingSeqNoException e = expectThrows(
             RetentionLeaseInvalidRetainingSeqNoException.class,

--- a/server/src/test/java/org/elasticsearch/index/seqno/ReplicationTrackerTests.java
+++ b/server/src/test/java/org/elasticsearch/index/seqno/ReplicationTrackerTests.java
@@ -1033,7 +1033,7 @@ public class ReplicationTrackerTests extends ReplicationTrackerTestCase {
     private static void addPeerRecoveryRetentionLease(final ReplicationTracker tracker, final AllocationId allocationId) {
         final String nodeId = nodeIdFromAllocationId(allocationId);
         if (tracker.getRetentionLeases().contains(ReplicationTracker.getPeerRecoveryRetentionLeaseId(nodeId)) == false) {
-            tracker.addPeerRecoveryRetentionLease(nodeId, NO_OPS_PERFORMED, ActionListener.wrap(() -> {}));
+            tracker.addPeerRecoveryRetentionLease(nodeId, NO_OPS_PERFORMED, ActionListener.noop());
         }
     }
 
@@ -1167,7 +1167,7 @@ public class ReplicationTrackerTests extends ReplicationTrackerTestCase {
                 equalTo(expectedLeaseIds)
             );
             // ... and any extra peer recovery retention leases are expired immediately since the shard is fully active
-            tracker.addPeerRecoveryRetentionLease(randomAlphaOfLength(10), randomNonNegativeLong(), ActionListener.wrap(() -> {}));
+            tracker.addPeerRecoveryRetentionLease(randomAlphaOfLength(10), randomNonNegativeLong(), ActionListener.noop());
         });
 
         tracker.renewPeerRecoveryRetentionLeases();

--- a/server/src/test/java/org/elasticsearch/index/shard/IndexShardRetentionLeaseTests.java
+++ b/server/src/test/java/org/elasticsearch/index/shard/IndexShardRetentionLeaseTests.java
@@ -60,12 +60,7 @@ public class IndexShardRetentionLeaseTests extends IndexShardTestCase {
             final long[] minimumRetainingSequenceNumbers = new long[length];
             for (int i = 0; i < length; i++) {
                 minimumRetainingSequenceNumbers[i] = randomLongBetween(SequenceNumbers.NO_OPS_PERFORMED, Long.MAX_VALUE);
-                indexShard.addRetentionLease(
-                    Integer.toString(i),
-                    minimumRetainingSequenceNumbers[i],
-                    "test-" + i,
-                    ActionListener.wrap(() -> {})
-                );
+                indexShard.addRetentionLease(Integer.toString(i), minimumRetainingSequenceNumbers[i], "test-" + i, ActionListener.noop());
                 assertRetentionLeases(indexShard, i + 1, minimumRetainingSequenceNumbers, primaryTerm, 2 + i, true, false);
             }
 
@@ -90,17 +85,12 @@ public class IndexShardRetentionLeaseTests extends IndexShardTestCase {
             final long[] minimumRetainingSequenceNumbers = new long[length];
             for (int i = 0; i < length; i++) {
                 minimumRetainingSequenceNumbers[i] = randomLongBetween(SequenceNumbers.NO_OPS_PERFORMED, Long.MAX_VALUE);
-                indexShard.addRetentionLease(
-                    Integer.toString(i),
-                    minimumRetainingSequenceNumbers[i],
-                    "test-" + i,
-                    ActionListener.wrap(() -> {})
-                );
+                indexShard.addRetentionLease(Integer.toString(i), minimumRetainingSequenceNumbers[i], "test-" + i, ActionListener.noop());
                 assertRetentionLeases(indexShard, i + 1, minimumRetainingSequenceNumbers, primaryTerm, 2 + i, true, false);
             }
 
             for (int i = 0; i < length; i++) {
-                indexShard.removeRetentionLease(Integer.toString(length - i - 1), ActionListener.wrap(() -> {}));
+                indexShard.removeRetentionLease(Integer.toString(length - i - 1), ActionListener.noop());
                 assertRetentionLeases(
                     indexShard,
                     length - i - 1,
@@ -148,7 +138,7 @@ public class IndexShardRetentionLeaseTests extends IndexShardTestCase {
             final long initialVersion;
             if (primary) {
                 initialVersion = 2;
-                indexShard.addRetentionLease("0", retainingSequenceNumbers[0], "test-0", ActionListener.wrap(() -> {}));
+                indexShard.addRetentionLease("0", retainingSequenceNumbers[0], "test-0", ActionListener.noop());
             } else {
                 initialVersion = 3;
                 final RetentionLeases retentionLeases = new RetentionLeases(
@@ -224,12 +214,7 @@ public class IndexShardRetentionLeaseTests extends IndexShardTestCase {
             for (int i = 0; i < length; i++) {
                 minimumRetainingSequenceNumbers[i] = randomLongBetween(SequenceNumbers.NO_OPS_PERFORMED, Long.MAX_VALUE);
                 currentTimeMillis.set(TimeUnit.NANOSECONDS.toMillis(randomNonNegativeLong()));
-                indexShard.addRetentionLease(
-                    Integer.toString(i),
-                    minimumRetainingSequenceNumbers[i],
-                    "test-" + i,
-                    ActionListener.wrap(() -> {})
-                );
+                indexShard.addRetentionLease(Integer.toString(i), minimumRetainingSequenceNumbers[i], "test-" + i, ActionListener.noop());
             }
 
             currentTimeMillis.set(TimeUnit.NANOSECONDS.toMillis(Long.MAX_VALUE));
@@ -292,12 +277,7 @@ public class IndexShardRetentionLeaseTests extends IndexShardTestCase {
             final long[] minimumRetainingSequenceNumbers = new long[length];
             for (int i = 0; i < length; i++) {
                 minimumRetainingSequenceNumbers[i] = randomLongBetween(SequenceNumbers.NO_OPS_PERFORMED, Long.MAX_VALUE);
-                indexShard.addRetentionLease(
-                    Integer.toString(i),
-                    minimumRetainingSequenceNumbers[i],
-                    "test-" + i,
-                    ActionListener.wrap(() -> {})
-                );
+                indexShard.addRetentionLease(Integer.toString(i), minimumRetainingSequenceNumbers[i], "test-" + i, ActionListener.noop());
             }
             final RetentionLeaseStats stats = indexShard.getRetentionLeaseStats();
             assertRetentionLeases(

--- a/server/src/test/java/org/elasticsearch/index/shard/IndexShardTests.java
+++ b/server/src/test/java/org/elasticsearch/index/shard/IndexShardTests.java
@@ -1882,7 +1882,7 @@ public class IndexShardTests extends IndexShardTestCase {
                 shard.relocated(routing.getTargetRelocatingShard().allocationId().getId(), (primaryContext, listener) -> {
                     relocationStarted.countDown();
                     listener.onResponse(null);
-                }, ActionListener.wrap(() -> {}));
+                }, ActionListener.noop());
             } catch (InterruptedException e) {
                 throw new RuntimeException(e);
             }

--- a/server/src/test/java/org/elasticsearch/snapshots/SnapshotResiliencyTests.java
+++ b/server/src/test/java/org/elasticsearch/snapshots/SnapshotResiliencyTests.java
@@ -851,7 +851,7 @@ public class SnapshotResiliencyTests extends ESTestCase {
                 public void onResponse(AcknowledgedResponse acknowledgedResponse) {
                     if (partialSnapshot) {
                         // Recreate index by the same name to test that we don't snapshot conflicting metadata in this scenario
-                        client().admin().indices().create(new CreateIndexRequest(index), noopListener());
+                        client().admin().indices().create(new CreateIndexRequest(index), ActionListener.noop());
                     }
                 }
 
@@ -1013,7 +1013,7 @@ public class SnapshotResiliencyTests extends ESTestCase {
                                     createdSnapshot.set(true);
                                     testClusterNodes.randomDataNodeSafe().client.admin()
                                         .cluster()
-                                        .deleteSnapshot(new DeleteSnapshotRequest(repoName, snapshotName), noopListener());
+                                        .deleteSnapshot(new DeleteSnapshotRequest(repoName, snapshotName), ActionListener.noop());
                                 }));
                             scheduleNow(
                                 () -> testClusterNodes.randomMasterNodeSafe().client.admin()
@@ -1027,7 +1027,7 @@ public class SnapshotResiliencyTests extends ESTestCase {
                                                 true
                                             )
                                         ),
-                                        noopListener()
+                                        ActionListener.noop()
                                     )
                             );
                         } else {
@@ -1371,10 +1371,6 @@ public class SnapshotResiliencyTests extends ESTestCase {
 
     private static <T> void continueOrDie(StepListener<T> listener, CheckedConsumer<T, Exception> onResponse) {
         listener.whenComplete(onResponse, e -> { throw new AssertionError(e); });
-    }
-
-    private static <T> ActionListener<T> noopListener() {
-        return ActionListener.wrap(() -> {});
     }
 
     public NodeClient client() {

--- a/server/src/test/java/org/elasticsearch/transport/RemoteClusterServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/transport/RemoteClusterServiceTests.java
@@ -1001,7 +1001,7 @@ public class RemoteClusterServiceTests extends ESTestCase {
             service.acceptIncomingRequests();
             final IllegalArgumentException e = expectThrows(
                 IllegalArgumentException.class,
-                () -> service.getRemoteClusterService().collectNodes(Set.of(), ActionListener.wrap(r -> {}, r -> {}))
+                () -> service.getRemoteClusterService().collectNodes(Set.of(), ActionListener.noop())
             );
             assertThat(e.getMessage(), equalTo("this node does not have the remote_cluster_client role"));
         }

--- a/test/framework/src/main/java/org/elasticsearch/cluster/coordination/AbstractCoordinatorTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/cluster/coordination/AbstractCoordinatorTestCase.java
@@ -1679,9 +1679,7 @@ public class AbstractCoordinatorTestCase extends ESTestCase {
             if (clusterStateApplyResponse == ClusterStateApplyResponse.HANG) {
                 if (randomBoolean()) {
                     // apply cluster state, but don't notify listener
-                    super.onNewClusterState(source, clusterStateSupplier, ActionListener.wrap(() -> {
-                        // ignore result
-                    }));
+                    super.onNewClusterState(source, clusterStateSupplier, ActionListener.noop());
                 }
             } else {
                 super.onNewClusterState(source, clusterStateSupplier, listener);

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/license/RemoteClusterLicenseCheckerTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/license/RemoteClusterLicenseCheckerTests.java
@@ -292,10 +292,7 @@ public final class RemoteClusterLicenseCheckerTests extends ESTestCase {
             final RemoteClusterLicenseChecker licenseChecker = new RemoteClusterLicenseChecker(client, feature);
 
             final List<String> remoteClusterAliases = Collections.singletonList("valid");
-            licenseChecker.checkRemoteClusterLicenses(
-                remoteClusterAliases,
-                doubleInvocationProtectingListener(ActionListener.wrap(() -> {}))
-            );
+            licenseChecker.checkRemoteClusterLicenses(remoteClusterAliases, doubleInvocationProtectingListener(ActionListener.noop()));
 
             verify(client, times(1)).execute(same(XPackInfoAction.INSTANCE), any(), any());
         } finally {

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/CleanupShrinkIndexStepTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/CleanupShrinkIndexStepTests.java
@@ -102,13 +102,7 @@ public class CleanupShrinkIndexStepTests extends AbstractStepTestCase<CleanupShr
 
         try (NoOpClient client = getDeleteIndexRequestAssertingClient(shrinkIndexName)) {
             CleanupShrinkIndexStep step = new CleanupShrinkIndexStep(randomStepKey(), randomStepKey(), client);
-            step.performAction(indexMetadata, clusterState, null, new ActionListener<>() {
-                @Override
-                public void onResponse(Void complete) {}
-
-                @Override
-                public void onFailure(Exception e) {}
-            });
+            step.performAction(indexMetadata, clusterState, null, ActionListener.noop());
         }
     }
 
@@ -134,15 +128,7 @@ public class CleanupShrinkIndexStepTests extends AbstractStepTestCase<CleanupShr
 
         try (NoOpClient client = getFailingIfCalledClient()) {
             CleanupShrinkIndexStep step = new CleanupShrinkIndexStep(randomStepKey(), randomStepKey(), client);
-            step.performAction(shrunkIndexMetadata, clusterState, null, new ActionListener<>() {
-                @Override
-                public void onResponse(Void complete) {}
-
-                @Override
-                public void onFailure(Exception e) {
-
-                }
-            });
+            step.performAction(shrunkIndexMetadata, clusterState, null, ActionListener.noop());
         }
     }
 

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/CleanupSnapshotStepTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/CleanupSnapshotStepTests.java
@@ -110,13 +110,7 @@ public class CleanupSnapshotStepTests extends AbstractStepTestCase<CleanupSnapsh
 
         try (NoOpClient client = getDeleteSnapshotRequestAssertingClient(snapshotName)) {
             CleanupSnapshotStep step = new CleanupSnapshotStep(randomStepKey(), randomStepKey(), client);
-            step.performAction(indexMetadata, clusterState, null, new ActionListener<>() {
-                @Override
-                public void onResponse(Void complete) {}
-
-                @Override
-                public void onFailure(Exception e) {}
-            });
+            step.performAction(indexMetadata, clusterState, null, ActionListener.noop());
         }
     }
 

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/CreateSnapshotStepTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/CreateSnapshotStepTests.java
@@ -134,13 +134,7 @@ public class CreateSnapshotStepTests extends AbstractStepTestCase<CreateSnapshot
 
         try (NoOpClient client = getCreateSnapshotRequestAssertingClient(repository, snapshotName, indexName)) {
             CreateSnapshotStep step = new CreateSnapshotStep(randomStepKey(), randomStepKey(), randomStepKey(), client);
-            step.performAction(indexMetadata, clusterState, null, new ActionListener<>() {
-                @Override
-                public void onResponse(Void complete) {}
-
-                @Override
-                public void onFailure(Exception e) {}
-            });
+            step.performAction(indexMetadata, clusterState, null, ActionListener.noop());
         }
     }
 
@@ -173,17 +167,7 @@ public class CreateSnapshotStepTests extends AbstractStepTestCase<CreateSnapshot
                         listener.onResponse(true);
                     }
                 };
-                completeStep.performAction(indexMetadata, clusterState, null, new ActionListener<>() {
-                    @Override
-                    public void onResponse(Void unused) {
-
-                    }
-
-                    @Override
-                    public void onFailure(Exception e) {
-
-                    }
-                });
+                completeStep.performAction(indexMetadata, clusterState, null, ActionListener.noop());
                 assertThat(completeStep.getNextStepKey(), is(nextKeyOnComplete));
             }
         }
@@ -203,17 +187,7 @@ public class CreateSnapshotStepTests extends AbstractStepTestCase<CreateSnapshot
                         listener.onResponse(false);
                     }
                 };
-                incompleteStep.performAction(indexMetadata, clusterState, null, new ActionListener<>() {
-                    @Override
-                    public void onResponse(Void unused) {
-
-                    }
-
-                    @Override
-                    public void onFailure(Exception e) {
-
-                    }
-                });
+                incompleteStep.performAction(indexMetadata, clusterState, null, ActionListener.noop());
                 assertThat(incompleteStep.getNextStepKey(), is(nextKeyOnIncomplete));
             }
         }
@@ -233,17 +207,7 @@ public class CreateSnapshotStepTests extends AbstractStepTestCase<CreateSnapshot
                         listener.onFailure(new SnapshotNameAlreadyInUseException(repository, snapshotName, "simulated"));
                     }
                 };
-                doubleInvocationStep.performAction(indexMetadata, clusterState, null, new ActionListener<>() {
-                    @Override
-                    public void onResponse(Void unused) {
-
-                    }
-
-                    @Override
-                    public void onFailure(Exception e) {
-
-                    }
-                });
+                doubleInvocationStep.performAction(indexMetadata, clusterState, null, ActionListener.noop());
                 assertThat(doubleInvocationStep.getNextStepKey(), is(nextKeyOnIncomplete));
             }
         }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/SwapAliasesAndDeleteSourceIndexStepTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/SwapAliasesAndDeleteSourceIndexStepTests.java
@@ -112,13 +112,7 @@ public class SwapAliasesAndDeleteSourceIndexStepTests extends AbstractStepTestCa
                 .metadata(Metadata.builder().put(sourceIndexMetadata, true).put(targetIndexMetadataBuilder).build())
                 .build();
 
-            step.performAction(sourceIndexMetadata, clusterState, null, new ActionListener<>() {
-                @Override
-                public void onResponse(Void complete) {}
-
-                @Override
-                public void onFailure(Exception e) {}
-            });
+            step.performAction(sourceIndexMetadata, clusterState, null, ActionListener.noop());
         }
     }
 

--- a/x-pack/plugin/enrich/src/test/java/org/elasticsearch/xpack/enrich/EnrichPolicyExecutorTests.java
+++ b/x-pack/plugin/enrich/src/test/java/org/elasticsearch/xpack/enrich/EnrichPolicyExecutorTests.java
@@ -43,13 +43,6 @@ import static org.mockito.Mockito.when;
 public class EnrichPolicyExecutorTests extends ESTestCase {
 
     private static ThreadPool testThreadPool;
-    private static final ActionListener<ExecuteEnrichPolicyAction.Response> noOpListener = new ActionListener<>() {
-        @Override
-        public void onResponse(ExecuteEnrichPolicyAction.Response ignored) {}
-
-        @Override
-        public void onFailure(Exception e) {}
-    };
 
     @BeforeClass
     public static void beforeCLass() {
@@ -79,7 +72,7 @@ public class EnrichPolicyExecutorTests extends ESTestCase {
         final CountDownLatch firstTaskComplete = new CountDownLatch(1);
         testExecutor.coordinatePolicyExecution(
             new ExecuteEnrichPolicyAction.Request(testPolicyName),
-            new LatchedActionListener<>(noOpListener, firstTaskComplete)
+            new LatchedActionListener<>(ActionListener.noop(), firstTaskComplete)
         );
 
         // Launch a second fake run that should fail immediately because the lock is obtained.
@@ -87,7 +80,7 @@ public class EnrichPolicyExecutorTests extends ESTestCase {
             EsRejectedExecutionException.class,
             "Expected exception but nothing was thrown",
             () -> {
-                testExecutor.coordinatePolicyExecution(new ExecuteEnrichPolicyAction.Request(testPolicyName), noOpListener);
+                testExecutor.coordinatePolicyExecution(new ExecuteEnrichPolicyAction.Request(testPolicyName), ActionListener.noop());
                 // Should throw exception on the previous statement, but if it doesn't, be a
                 // good citizen and conclude the fake runs to keep the logs clean from interrupted exceptions
                 latch.countDown();
@@ -109,7 +102,7 @@ public class EnrichPolicyExecutorTests extends ESTestCase {
         CountDownLatch secondTaskComplete = new CountDownLatch(1);
         testExecutor.coordinatePolicyExecution(
             new ExecuteEnrichPolicyAction.Request(testPolicyName),
-            new LatchedActionListener<>(noOpListener, secondTaskComplete)
+            new LatchedActionListener<>(ActionListener.noop(), secondTaskComplete)
         );
         secondTaskComplete.await();
     }
@@ -133,13 +126,13 @@ public class EnrichPolicyExecutorTests extends ESTestCase {
         final CountDownLatch firstTaskComplete = new CountDownLatch(1);
         testExecutor.coordinatePolicyExecution(
             new ExecuteEnrichPolicyAction.Request(testPolicyBaseName + "1"),
-            new LatchedActionListener<>(noOpListener, firstTaskComplete)
+            new LatchedActionListener<>(ActionListener.noop(), firstTaskComplete)
         );
 
         final CountDownLatch secondTaskComplete = new CountDownLatch(1);
         testExecutor.coordinatePolicyExecution(
             new ExecuteEnrichPolicyAction.Request(testPolicyBaseName + "2"),
-            new LatchedActionListener<>(noOpListener, secondTaskComplete)
+            new LatchedActionListener<>(ActionListener.noop(), secondTaskComplete)
         );
 
         // Launch a third fake run that should fail immediately because the lock is obtained.
@@ -147,7 +140,10 @@ public class EnrichPolicyExecutorTests extends ESTestCase {
             EsRejectedExecutionException.class,
             "Expected exception but nothing was thrown",
             () -> {
-                testExecutor.coordinatePolicyExecution(new ExecuteEnrichPolicyAction.Request(testPolicyBaseName + "3"), noOpListener);
+                testExecutor.coordinatePolicyExecution(
+                    new ExecuteEnrichPolicyAction.Request(testPolicyBaseName + "3"),
+                    ActionListener.noop()
+                );
                 // Should throw exception on the previous statement, but if it doesn't, be a
                 // good citizen and conclude the fake runs to keep the logs clean from interrupted exceptions
                 latch.countDown();
@@ -173,7 +169,7 @@ public class EnrichPolicyExecutorTests extends ESTestCase {
         CountDownLatch finalTaskComplete = new CountDownLatch(1);
         testExecutor.coordinatePolicyExecution(
             new ExecuteEnrichPolicyAction.Request(testPolicyBaseName + "1"),
-            new LatchedActionListener<>(noOpListener, finalTaskComplete)
+            new LatchedActionListener<>(ActionListener.noop(), finalTaskComplete)
         );
         finalTaskComplete.await();
     }

--- a/x-pack/plugin/enrich/src/test/java/org/elasticsearch/xpack/enrich/action/CoordinatorTests.java
+++ b/x-pack/plugin/enrich/src/test/java/org/elasticsearch/xpack/enrich/action/CoordinatorTests.java
@@ -204,7 +204,7 @@ public class CoordinatorTests extends ESTestCase {
         Coordinator coordinator = new Coordinator(lookupFunction, 1, 1, 1);
 
         // Pre-load the queue to be at capacity and spoof the coordinator state to seem like max requests in flight.
-        coordinator.queue.add(new Coordinator.Slot(new SearchRequest(), ActionListener.wrap(() -> {})));
+        coordinator.queue.add(new Coordinator.Slot(new SearchRequest(), ActionListener.noop()));
         assertTrue(coordinator.remoteRequestPermits.tryAcquire());
 
         // Try to schedule an item into the coordinator, should emit an exception

--- a/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/ilm/action/TransportStopILMActionTests.java
+++ b/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/ilm/action/TransportStopILMActionTests.java
@@ -9,7 +9,6 @@ package org.elasticsearch.xpack.ilm.action;
 
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.ActionFilters;
-import org.elasticsearch.action.support.master.AcknowledgedResponse;
 import org.elasticsearch.cluster.AckedClusterStateUpdateTask;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
@@ -33,18 +32,6 @@ import static org.mockito.Mockito.verify;
 
 public class TransportStopILMActionTests extends ESTestCase {
 
-    private static final ActionListener<AcknowledgedResponse> EMPTY_LISTENER = new ActionListener<>() {
-        @Override
-        public void onResponse(AcknowledgedResponse response) {
-
-        }
-
-        @Override
-        public void onFailure(Exception e) {
-
-        }
-    };
-
     public void testStopILMClusterStatePriorityIsImmediate() {
         ClusterService clusterService = mock(ClusterService.class);
 
@@ -64,7 +51,7 @@ public class TransportStopILMActionTests extends ESTestCase {
             emptyMap()
         );
         StopILMRequest request = new StopILMRequest();
-        transportStopILMAction.masterOperation(task, request, ClusterState.EMPTY_STATE, EMPTY_LISTENER);
+        transportStopILMAction.masterOperation(task, request, ClusterState.EMPTY_STATE, ActionListener.noop());
 
         verify(clusterService).submitStateUpdateTask(
             eq("ilm_operation_mode_update[stopping]"),

--- a/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/slm/action/TransportStopSLMActionTests.java
+++ b/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/slm/action/TransportStopSLMActionTests.java
@@ -9,7 +9,6 @@ package org.elasticsearch.xpack.slm.action;
 
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.ActionFilters;
-import org.elasticsearch.action.support.master.AcknowledgedResponse;
 import org.elasticsearch.cluster.AckedClusterStateUpdateTask;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
@@ -33,18 +32,6 @@ import static org.mockito.Mockito.verify;
 
 public class TransportStopSLMActionTests extends ESTestCase {
 
-    private static final ActionListener<AcknowledgedResponse> EMPTY_LISTENER = new ActionListener<>() {
-        @Override
-        public void onResponse(AcknowledgedResponse response) {
-
-        }
-
-        @Override
-        public void onFailure(Exception e) {
-
-        }
-    };
-
     public void testStopILMClusterStatePriorityIsImmediate() {
         ClusterService clusterService = mock(ClusterService.class);
 
@@ -64,7 +51,7 @@ public class TransportStopSLMActionTests extends ESTestCase {
             emptyMap()
         );
         StopSLMAction.Request request = new StopSLMAction.Request();
-        transportStopSLMAction.masterOperation(task, request, ClusterState.EMPTY_STATE, EMPTY_LISTENER);
+        transportStopSLMAction.masterOperation(task, request, ClusterState.EMPTY_STATE, ActionListener.noop());
 
         verify(clusterService).submitStateUpdateTask(
             eq("slm_operation_mode_update[stopping]"),

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportStopDataFrameAnalyticsAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportStopDataFrameAnalyticsAction.java
@@ -324,7 +324,7 @@ public class TransportStopDataFrameAnalyticsAction extends TransportTasksAction<
                 // This means the task has not been assigned to a node yet so
                 // we can stop it by removing its persistent task.
                 // The listener is a no-op as we're already going to wait for the task to be removed.
-                persistentTasksService.sendRemoveRequest(task.getId(), ActionListener.wrap(r -> {}, e -> {}));
+                persistentTasksService.sendRemoveRequest(task.getId(), ActionListener.noop());
             }
         }
         return nodes.toArray(new String[0]);

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/allocation/TrainedModelAllocationNodeService.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/allocation/TrainedModelAllocationNodeService.java
@@ -441,7 +441,7 @@ public class TrainedModelAllocationNodeService implements ClusterStateListener {
         Runnable stopTask = () -> stopDeploymentAsync(
             task,
             "model failed to load; reason [" + ex.getMessage() + "]",
-            ActionListener.wrap(r -> {}, e -> {})
+            ActionListener.noop()
         );
         updateStoredState(
             task.getModelId(),

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/allocation/TrainedModelAllocationNodeServiceTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/allocation/TrainedModelAllocationNodeServiceTests.java
@@ -196,7 +196,7 @@ public class TrainedModelAllocationNodeServiceTests extends ESTestCase {
         // Only one model should be loaded, the other should be stopped
         trainedModelAllocationNodeService.prepareModelToLoad(newParams(modelToLoad));
         trainedModelAllocationNodeService.prepareModelToLoad(newParams(stoppedModelToLoad));
-        trainedModelAllocationNodeService.getTask(stoppedModelToLoad).stop("testing", ActionListener.wrap(r -> {}, e -> {}));
+        trainedModelAllocationNodeService.getTask(stoppedModelToLoad).stop("testing", ActionListener.noop());
         trainedModelAllocationNodeService.loadQueuedModels();
 
         assertBusy(() -> {

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/deployment/TrainedModelDeploymentTaskTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/deployment/TrainedModelDeploymentTaskTests.java
@@ -71,7 +71,7 @@ public class TrainedModelDeploymentTaskTests extends ESTestCase {
     }
 
     public void testOnStop() {
-        assertTrackingComplete(t -> t.stop("foo", ActionListener.wrap(r -> {}, e -> {})), randomAlphaOfLength(10));
+        assertTrackingComplete(t -> t.stop("foo", ActionListener.noop()), randomAlphaOfLength(10));
     }
 
     public void testCancelled() {

--- a/x-pack/plugin/rollup/src/test/java/org/elasticsearch/xpack/rollup/v2/RollupActionSingleNodeTests.java
+++ b/x-pack/plugin/rollup/src/test/java/org/elasticsearch/xpack/rollup/v2/RollupActionSingleNodeTests.java
@@ -196,7 +196,7 @@ public class RollupActionSingleNodeTests extends ESSingleNodeTestCase {
             Collections.singletonList(new MetricConfig("numeric_1", Collections.singletonList("max")))
         );
         bulkIndex(sourceSupplier);
-        client().execute(RollupAction.INSTANCE, new RollupAction.Request(index, rollupIndex, config), ActionListener.wrap(() -> {}));
+        client().execute(RollupAction.INSTANCE, new RollupAction.Request(index, rollupIndex, config), ActionListener.noop());
         ResourceAlreadyExistsException exception = expectThrows(
             ResourceAlreadyExistsException.class,
             () -> rollup(index, rollupIndex, config)

--- a/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/SearchableSnapshots.java
+++ b/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/SearchableSnapshots.java
@@ -750,7 +750,7 @@ public class SearchableSnapshots extends Plugin implements IndexStorePlugin, Eng
                 .filter(s -> s.equals(RepositoryData.MISSING_UUID) == false)
                 .collect(Collectors.toSet());
             if (knownUuids.addAll(newUuids)) {
-                rerouteService.reroute("repository UUIDs changed", Priority.NORMAL, ActionListener.wrap((() -> {})));
+                rerouteService.reroute("repository UUIDs changed", Priority.NORMAL, ActionListener.noop());
             }
             knownUuids.retainAll(newUuids);
             assert knownUuids.equals(newUuids) : knownUuids + " vs " + newUuids;

--- a/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/cache/shared/FrozenCacheInfoService.java
+++ b/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/cache/shared/FrozenCacheInfoService.java
@@ -109,7 +109,7 @@ public class FrozenCacheInfoService {
                     @Override
                     public void onResponse(FrozenCacheInfoResponse response) {
                         updateEntry(response.hasFrozenCache() ? NodeState.HAS_CACHE : NodeState.NO_CACHE);
-                        rerouteService.reroute("frozen cache state retrieved", Priority.LOW, ActionListener.wrap(() -> {}));
+                        rerouteService.reroute("frozen cache state retrieved", Priority.LOW, ActionListener.noop());
                     }
 
                     @Override

--- a/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/xpack/searchablesnapshots/store/input/FrozenIndexInputTests.java
+++ b/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/xpack/searchablesnapshots/store/input/FrozenIndexInputTests.java
@@ -110,7 +110,7 @@ public class FrozenIndexInputTests extends AbstractSearchableSnapshotsTestCase {
             )
         ) {
             cacheService.start();
-            directory.loadSnapshot(createRecoveryState(true), ActionListener.wrap(() -> {}));
+            directory.loadSnapshot(createRecoveryState(true), ActionListener.noop());
 
             // TODO does not test using the recovery range size
             final IndexInput indexInput = directory.openInput(fileName, randomIOContext());

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/support/mapper/NativeRoleMappingStore.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/support/mapper/NativeRoleMappingStore.java
@@ -85,18 +85,6 @@ public class NativeRoleMappingStore implements UserRoleMapper {
 
     private static final String ID_PREFIX = DOC_TYPE_ROLE_MAPPING + "_";
 
-    private static final ActionListener<Object> NO_OP_ACTION_LISTENER = new ActionListener<Object>() {
-        @Override
-        public void onResponse(Object o) {
-            // nothing
-        }
-
-        @Override
-        public void onFailure(Exception e) {
-            // nothing
-        }
-    };
-
     private final Settings settings;
     private final Client client;
     private final SecurityIndexManager securityIndex;
@@ -356,7 +344,7 @@ public class NativeRoleMappingStore implements UserRoleMapper {
             || isIndexDeleted(previousState, currentState)
             || Objects.equals(previousState.indexUUID, currentState.indexUUID) == false
             || previousState.isIndexUpToDate != currentState.isIndexUpToDate) {
-            refreshRealms(NO_OP_ACTION_LISTENER, null);
+            refreshRealms(ActionListener.noop(), null);
         }
     }
 

--- a/x-pack/plugin/snapshot-repo-test-kit/src/main/java/org/elasticsearch/repositories/blobstore/testkit/BlobAnalyzeAction.java
+++ b/x-pack/plugin/snapshot-repo-test-kit/src/main/java/org/elasticsearch/repositories/blobstore/testkit/BlobAnalyzeAction.java
@@ -438,7 +438,7 @@ public class BlobAnalyzeAction extends ActionType<BlobAnalyzeAction.Response> {
         }
 
         private void cancelReadsCleanUpAndReturnFailure(Exception exception) {
-            transportService.getTaskManager().cancelTaskAndDescendants(task, "task failed", false, ActionListener.wrap(() -> {}));
+            transportService.getTaskManager().cancelTaskAndDescendants(task, "task failed", false, ActionListener.noop());
             cleanUpAndReturnFailure(exception);
         }
 

--- a/x-pack/plugin/snapshot-repo-test-kit/src/main/java/org/elasticsearch/repositories/blobstore/testkit/RepositoryAnalyzeAction.java
+++ b/x-pack/plugin/snapshot-repo-test-kit/src/main/java/org/elasticsearch/repositories/blobstore/testkit/RepositoryAnalyzeAction.java
@@ -394,7 +394,7 @@ public class RepositoryAnalyzeAction extends ActionType<RepositoryAnalyzeAction.
 
         private void fail(Exception e) {
             if (failure.compareAndSet(null, e)) {
-                transportService.getTaskManager().cancelTaskAndDescendants(task, "task failed", false, ActionListener.wrap(() -> {}));
+                transportService.getTaskManager().cancelTaskAndDescendants(task, "task failed", false, ActionListener.noop());
             } else {
                 if (innerFailures.tryAcquire()) {
                     final Throwable cause = ExceptionsHelper.unwrapCause(e);
@@ -428,7 +428,7 @@ public class RepositoryAnalyzeAction extends ActionType<RepositoryAnalyzeAction.
                     null,
                     new RepositoryVerificationException(request.repositoryName, "analysis timed out after [" + request.getTimeout() + "]")
                 )) {
-                    transportService.getTaskManager().cancelTaskAndDescendants(task, "timed out", false, ActionListener.wrap(() -> {}));
+                    transportService.getTaskManager().cancelTaskAndDescendants(task, "timed out", false, ActionListener.noop());
                 }
                 // if this CAS failed then we're already failing for some other reason, nbd
                 return false;

--- a/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/action/TransformUpdaterTests.java
+++ b/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/action/TransformUpdaterTests.java
@@ -107,7 +107,7 @@ public class TransformUpdaterTests extends ESTestCase {
             randomAlphaOfLengthBetween(1, 10),
             Version.CURRENT
         );
-        transformConfigManager.putTransformConfiguration(maxCompatibleConfig, ActionListener.wrap(r -> {}, e -> {}));
+        transformConfigManager.putTransformConfiguration(maxCompatibleConfig, ActionListener.noop());
         assertConfiguration(
             listener -> transformConfigManager.getTransformConfiguration(maxCompatibleConfig.getId(), listener),
             config -> {}
@@ -145,7 +145,7 @@ public class TransformUpdaterTests extends ESTestCase {
             randomAlphaOfLengthBetween(1, 10),
             TransformConfig.CONFIG_VERSION_LAST_DEFAULTS_CHANGED
         );
-        transformConfigManager.putTransformConfiguration(minCompatibleConfig, ActionListener.wrap(r -> {}, e -> {}));
+        transformConfigManager.putTransformConfiguration(minCompatibleConfig, ActionListener.noop());
 
         assertUpdate(
             listener -> TransformUpdater.updateTransform(
@@ -187,7 +187,7 @@ public class TransformUpdaterTests extends ESTestCase {
             )
         );
 
-        transformConfigManager.putOldTransformConfiguration(oldConfig, ActionListener.wrap(r -> {}, e -> {}));
+        transformConfigManager.putOldTransformConfiguration(oldConfig, ActionListener.noop());
         TransformCheckpoint checkpoint = new TransformCheckpoint(
             oldConfig.getId(),
             0L, // timestamp
@@ -195,7 +195,7 @@ public class TransformUpdaterTests extends ESTestCase {
             Collections.singletonMap("index_1", new long[] { 1, 2, 3, 4 }), // index checkpoints
             0L
         );
-        transformConfigManager.putOldTransformCheckpoint(checkpoint, ActionListener.wrap(r -> {}, e -> {}));
+        transformConfigManager.putOldTransformCheckpoint(checkpoint, ActionListener.noop());
 
         TransformStoredDoc stateDoc = new TransformStoredDoc(
             oldConfig.getId(),
@@ -211,7 +211,7 @@ public class TransformUpdaterTests extends ESTestCase {
             ),
             TransformIndexerStatsTests.randomStats()
         );
-        transformConfigManager.putOrUpdateOldTransformStoredDoc(stateDoc, null, ActionListener.wrap(r -> {}, e -> {}));
+        transformConfigManager.putOrUpdateOldTransformStoredDoc(stateDoc, null, ActionListener.noop());
 
         assertConfiguration(listener -> transformConfigManager.getTransformConfiguration(oldConfig.getId(), listener), config -> {});
 
@@ -274,7 +274,7 @@ public class TransformUpdaterTests extends ESTestCase {
             )
         );
 
-        transformConfigManager.putOldTransformConfiguration(oldConfigForDryRunUpdate, ActionListener.wrap(r -> {}, e -> {}));
+        transformConfigManager.putOldTransformConfiguration(oldConfigForDryRunUpdate, ActionListener.noop());
         assertConfiguration(
             listener -> transformConfigManager.getTransformConfiguration(oldConfigForDryRunUpdate.getId(), listener),
             config -> {}

--- a/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/TransformIndexerStateTests.java
+++ b/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/TransformIndexerStateTests.java
@@ -620,7 +620,7 @@ public class TransformIndexerStateTests extends ESTestCase {
         TransformContext context
     ) {
         CheckpointProvider checkpointProvider = new MockTimebasedCheckpointProvider(config);
-        transformConfigManager.putTransformConfiguration(config, ActionListener.wrap(r -> {}, e -> {}));
+        transformConfigManager.putTransformConfiguration(config, ActionListener.noop());
         TransformServices transformServices = new TransformServices(
             transformConfigManager,
             mock(TransformCheckpointService.class),

--- a/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/TransformIndexerTests.java
+++ b/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/TransformIndexerTests.java
@@ -441,7 +441,7 @@ public class TransformIndexerTests extends ESTestCase {
         TransformContext context
     ) {
         CheckpointProvider checkpointProvider = new MockTimebasedCheckpointProvider(config);
-        transformConfigManager.putTransformConfiguration(config, ActionListener.wrap(r -> {}, e -> {}));
+        transformConfigManager.putTransformConfiguration(config, ActionListener.noop());
         TransformServices transformServices = new TransformServices(
             transformConfigManager,
             mock(TransformCheckpointService.class),


### PR DESCRIPTION
I know there was some reservation against adding this in the past because
noop listeners are hard to debug since they don't even have any logging in them.
Then again, given that it was possible to identify `103` uses of a noop listener
within minutes using Idea I think it's better to face reality here and at least save
some objects and make the code easier to read.
Also having a clean `toString` on this method will render nicer in logs IMO when combined with other listeners.
Last but not least it simply saves some memory and compiler work to have a
singleton for this.
