### PR TITLE
[7.17] [DOCS] Reuse data tier content in node role docs (#84346)

### DIFF
--- a/docs/reference/datatiers.asciidoc
+++ b/docs/reference/datatiers.asciidoc
@@ -41,6 +41,7 @@ node.roles: ["data_hot", "data_content"]
 [[content-tier]]
 === Content tier
 
+// tag::content-tier[]
 Data stored in the content tier is generally a collection of items such as a product catalog or article archive.
 Unlike time series data, the value of the content remains relatively constant over time,
 so it doesn't make sense to move it to a tier with different performance characteristics as it ages.
@@ -55,11 +56,13 @@ tier should be configured to use one or more replicas.
 
 The content tier is required. System indices and other indices that aren't part
 of a data stream are automatically allocated to the content tier.
+// end::content-tier[]
 
 [discrete]
 [[hot-tier]]
 === Hot tier
 
+// tag::hot-tier[]
 The hot tier is the {es} entry point for time series data and holds your most-recent,
 most-frequently-searched time series data.
 Nodes in the hot tier need to be fast for both reads and writes,
@@ -68,22 +71,26 @@ For resiliency, indices in the hot tier should be configured to use one or more 
 
 The hot tier is required. New indices that are part of a <<data-streams,
 data stream>> are automatically allocated to the hot tier.
+// end::hot-tier[]
 
 [discrete]
 [[warm-tier]]
 === Warm tier
 
+// tag::warm-tier[]
 Time series data can move to the warm tier once it is being queried less frequently
 than the recently-indexed data in the hot tier.
 The warm tier typically holds data from recent weeks.
 Updates are still allowed, but likely infrequent.
 Nodes in the warm tier generally don't need to be as fast as those in the hot tier.
 For resiliency, indices in the warm tier should be configured to use one or more replicas.
+// end::warm-tier[]
 
 [discrete]
 [[cold-tier]]
 === Cold tier
 
+// tag::cold-tier[]
 When you no longer need to search time series data regularly, it can move from
 the warm tier to the cold tier. While still searchable, this tier is typically
 optimized for lower storage costs rather than search speed.
@@ -99,11 +106,13 @@ Fully mounted indices are read-only.
 Alternatively, you can use the cold tier to store regular indices with replicas instead
 of using {search-snaps}. This lets you store older data on less expensive hardware
 but doesn't reduce required disk space compared to the warm tier.
+// end::cold-tier[]
 
 [discrete]
 [[frozen-tier]]
 === Frozen tier
 
+// tag::frozen-tier[]
 Once data is no longer being queried, or being queried rarely, it may move from
 the cold tier to the frozen tier where it stays for the rest of its life.
 
@@ -116,6 +125,7 @@ tier are typically slower than on the cold tier.
 
 NOTE: We recommend you use <<data-frozen-node,dedicated nodes>> in the frozen
 tier.
+// end::frozen-tier[]
 
 [discrete]
 [[data-tier-allocation]]

--- a/docs/reference/modules/node.asciidoc
+++ b/docs/reference/modules/node.asciidoc
@@ -238,8 +238,8 @@ that has one of the specialized data roles cannot have the generic `data` role.
 [[data-content-node]]
 ==== Content data node
 
-Content data nodes accommodate user-created content. They enable operations like CRUD,
-search and aggregations.
+Content data nodes are part of the content tier.
+include::{es-repo-dir}/datatiers.asciidoc[tag=content-tier]
 
 To create a dedicated content node, set:
 [source,yaml]
@@ -251,8 +251,8 @@ node.roles: [ data_content ]
 [[data-hot-node]]
 ==== Hot data node
 
-Hot data nodes store time series data as it enters {es}. The hot tier must be fast for
-both reads and writes, and requires more hardware resources (such as SSD drives).
+Hot data nodes are part of the hot tier.
+include::{es-repo-dir}/datatiers.asciidoc[tag=hot-tier]
 
 To create a dedicated hot node, set:
 [source,yaml]
@@ -264,9 +264,8 @@ node.roles: [ data_hot ]
 [[data-warm-node]]
 ==== Warm data node
 
-Warm data nodes store indices that are no longer being regularly updated, but are still being
-queried. Query volume is usually at a lower frequency than it was while the index was in the hot tier.
-Less performant hardware can usually be used for nodes in this tier.
+Warm data nodes are part of the warm tier.
+include::{es-repo-dir}/datatiers.asciidoc[tag=warm-tier]
 
 To create a dedicated warm node, set:
 [source,yaml]
@@ -278,7 +277,8 @@ node.roles: [ data_warm ]
 [[data-cold-node]]
 ==== Cold data node
 
-Cold data nodes store read-only indices that are accessed less frequently. This tier uses less performant hardware and may leverage searchable snapshot indices to minimize the resources required.
+Cold data nodes are part of the cold tier.
+include::{es-repo-dir}/datatiers.asciidoc[tag=cold-tier]
 
 To create a dedicated cold node, set:
 [source,yaml]
@@ -290,11 +290,10 @@ node.roles: [ data_cold ]
 [[data-frozen-node]]
 ==== Frozen data node
 
-The frozen tier stores <<partially-mounted,partially mounted indices>>
-exclusively. We recommend you use dedicated nodes in the frozen tier.
+Frozen data nodes are part of the frozen tier.
+include::{es-repo-dir}/datatiers.asciidoc[tag=frozen-tier]
 
 To create a dedicated frozen node, set:
-
 [source,yaml]
 ----
 node.roles: [ data_frozen ]


### PR DESCRIPTION
Backports the following commits to 7.17:
 - [DOCS] Reuse data tier content in node role docs (#84346)