### PR TITLE
[8.1] Fall back to naive parallel forks calculation in non-standard cases (#85410)

### DIFF
--- a/build-conventions/src/main/java/org/elasticsearch/gradle/internal/conventions/info/ParallelDetector.java
+++ b/build-conventions/src/main/java/org/elasticsearch/gradle/internal/conventions/info/ParallelDetector.java
@@ -75,9 +75,12 @@ public class ParallelDetector {
                 });
 
                 _defaultParallel = Integer.parseInt(stdout.toString().trim());
-            } else {
+            }
+
+            if (_defaultParallel == null || _defaultParallel < 1) {
                 _defaultParallel = Runtime.getRuntime().availableProcessors() / 2;
             }
+
         }
 
         return Math.min(_defaultParallel, project.getGradle().getStartParameter().getMaxWorkerCount());


### PR DESCRIPTION
Backports the following commits to 8.1:
 - Fall back to naive parallel forks calculation in non-standard cases (#85410)