### PR TITLE
[DOCS] Fix duplicate anchor

### DIFF
--- a/docs/reference/datatiers.asciidoc
+++ b/docs/reference/datatiers.asciidoc
@@ -114,6 +114,7 @@ and load data from a snapshot repository. This reduces local storage and
 operating costs while still letting you search frozen data. Because {es} must
 sometimes fetch frozen data from the snapshot repository, searches on the frozen
 tier are typically slower than on the cold tier.
+// end::frozen-tier[]
 
 [discrete]
 [[configure-data-tiers-cloud]]

--- a/docs/reference/datatiers.asciidoc
+++ b/docs/reference/datatiers.asciidoc
@@ -165,7 +165,6 @@ node.roles: ["data_hot", "data_content"]
 
 NOTE: We recommend you use <<data-frozen-node,dedicated nodes>> in the frozen
 tier.
-// end::frozen-tier[]
 
 [discrete]
 [[data-tier-allocation]]


### PR DESCRIPTION
Missing end tag for partial include was causing a duplicate anchor build error. 