### PR TITLE
[DOCS] Removed extraneous end tag

### DIFF
--- a/docs/reference/datatiers.asciidoc
+++ b/docs/reference/datatiers.asciidoc
@@ -122,7 +122,6 @@ and load data from a snapshot repository. This reduces local storage and
 operating costs while still letting you search frozen data. Because {es} must
 sometimes fetch frozen data from the snapshot repository, searches on the frozen
 tier are typically slower than on the cold tier.
-// end::frozen-tier[]
 
 NOTE: We recommend you use <<data-frozen-node,dedicated nodes>> in the frozen
 tier.


### PR DESCRIPTION
Doc build was failing due to too many end tags for an included section.