### PR TITLE
fix running check command.

### DIFF
--- a/docs/reference/setup/install/check-running.asciidoc
+++ b/docs/reference/setup/install/check-running.asciidoc
@@ -5,7 +5,7 @@ You can test that your {es} node is running by sending an HTTPS request to port
 
 ["source","sh",subs="attributes"]
 ----
-curl --cacert {es-conf}{slash}config{slash}certs{slash}http_ca.crt -u elastic https://localhost:9200 <1>
+sudo curl --cacert {es-conf}{slash}certs{slash}http_ca.crt -u elastic https://localhost:9200 <1>
 ----
 // NOTCONSOLE
 <1> Ensure that you use `https` in your call, or the request will fail.


### PR DESCRIPTION
There is no config folder in /etc/elasticsearch so it was showing this error :
  curl: (77) error setting certificate verify locations:
  CAfile: /etc/elasticsearch/config/certs/http_ca.crt
  CApath: /etc/ssl/certs

changes:
correct cert address in command.
add required sudo.

