### PR TITLE
fix: make EmptySortValue instances sort after everything else

### DIFF
--- a/server/src/main/java/org/elasticsearch/search/sort/SortValue.java
+++ b/server/src/main/java/org/elasticsearch/search/sort/SortValue.java
@@ -125,7 +125,7 @@ public abstract class SortValue implements NamedWriteable, Comparable<SortValue>
     @Override
     public abstract String toString();
 
-    // Force implementations to override sortOrder and sort each subclass by type first
+    // Force implementations to override compareToDifferentType and sort each subclass by type first
     protected abstract int compareToDifferentType();
 
     /**

--- a/server/src/main/java/org/elasticsearch/search/sort/SortValue.java
+++ b/server/src/main/java/org/elasticsearch/search/sort/SortValue.java
@@ -123,7 +123,7 @@ public abstract class SortValue implements NamedWriteable, Comparable<SortValue>
     @Override
     public abstract String toString();
 
-    // Force implementations to override compareToDifferentType and sort each subclass by type first
+    // Force implementations to override typeComparisonKey and associate each subclass with an integer key
     protected abstract int typeComparisonKey();
 
     /**

--- a/server/src/main/java/org/elasticsearch/search/sort/SortValue.java
+++ b/server/src/main/java/org/elasticsearch/search/sort/SortValue.java
@@ -19,15 +19,12 @@ import org.elasticsearch.xcontent.XContentBuilder;
 
 import java.io.IOException;
 import java.util.Arrays;
-import java.util.Comparator;
 import java.util.List;
 
 /**
  * A {@link Comparable}, {@link DocValueFormat} aware wrapper around a sort value.
  */
 public abstract class SortValue implements NamedWriteable, Comparable<SortValue> {
-    private static final Comparator<SortValue> TYPE_COMPARATOR = Comparator.comparing(SortValue::compareToDifferentType);
-    private static final Comparator<SortValue> VALUE_COMPARATOR = TYPE_COMPARATOR.thenComparing(SortValue::compareToSameType);
     private static final SortValue EMPTY_SORT_VALUE = new EmptySortValue();
 
     /**
@@ -80,7 +77,8 @@ public abstract class SortValue implements NamedWriteable, Comparable<SortValue>
 
     @Override
     public final int compareTo(SortValue other) {
-        return VALUE_COMPARATOR.compare(this, other);
+        int typeComparison = typeComparisonKey() - other.typeComparisonKey();
+        return typeComparison == 0 ? compareToSameType(other) : typeComparison;
     }
 
     /**
@@ -126,7 +124,7 @@ public abstract class SortValue implements NamedWriteable, Comparable<SortValue>
     public abstract String toString();
 
     // Force implementations to override compareToDifferentType and sort each subclass by type first
-    protected abstract int compareToDifferentType();
+    protected abstract int typeComparisonKey();
 
     /**
      * Return this {@linkplain SortValue} as a boxed {@linkplain Number}
@@ -200,7 +198,7 @@ public abstract class SortValue implements NamedWriteable, Comparable<SortValue>
         }
 
         @Override
-        public int compareToDifferentType() {
+        public int typeComparisonKey() {
             return SORT_VALUE;
         }
 
@@ -275,7 +273,7 @@ public abstract class SortValue implements NamedWriteable, Comparable<SortValue>
         }
 
         @Override
-        public int compareToDifferentType() {
+        public int typeComparisonKey() {
             return SORT_VALUE;
         }
 
@@ -357,7 +355,7 @@ public abstract class SortValue implements NamedWriteable, Comparable<SortValue>
         }
 
         @Override
-        public int compareToDifferentType() {
+        public int typeComparisonKey() {
             return SORT_VALUE;
         }
 
@@ -421,7 +419,7 @@ public abstract class SortValue implements NamedWriteable, Comparable<SortValue>
         }
 
         @Override
-        public int compareToDifferentType() {
+        public int typeComparisonKey() {
             return sortValue;
         }
 

--- a/server/src/test/java/org/elasticsearch/search/sort/SortValueTests.java
+++ b/server/src/test/java/org/elasticsearch/search/sort/SortValueTests.java
@@ -55,7 +55,7 @@ public class SortValueTests extends AbstractNamedWriteableTestCase<SortValue> {
             case 0 -> SortValue.from(randomDouble());
             case 1 -> SortValue.from(randomLong());
             case 2 -> SortValue.from(new BytesRef(randomAlphaOfLength(5)));
-            case 3 -> SortValue.valueless();
+            case 3 -> SortValue.empty();
             default -> throw new AssertionError();
         };
     }
@@ -77,7 +77,7 @@ public class SortValueTests extends AbstractNamedWriteableTestCase<SortValue> {
     }
 
     public void testFormatEmpty() {
-        assertThat(SortValue.valueless().format(DocValueFormat.RAW), equalTo(""));
+        assertThat(SortValue.empty().format(DocValueFormat.RAW), equalTo(""));
     }
 
     public void testToXContentDouble() {
@@ -100,7 +100,7 @@ public class SortValueTests extends AbstractNamedWriteableTestCase<SortValue> {
     }
 
     public void testToXContentEmpty() {
-        assertThat(toXContent(SortValue.valueless(), DocValueFormat.RAW), equalTo("{\"test\"}"));
+        assertThat(toXContent(SortValue.empty(), DocValueFormat.RAW), equalTo("{\"test\"}"));
     }
 
     public void testCompareDifferentTypes() {
@@ -120,12 +120,12 @@ public class SortValueTests extends AbstractNamedWriteableTestCase<SortValue> {
      * See {@link org.elasticsearch.search.sort.SortValue#compareTo}.
      */
     public void testCompareToEmpty() {
-        assertThat(SortValue.from(1.0), lessThan(SortValue.valueless()));
-        assertThat(SortValue.from(Double.MAX_VALUE), lessThan(SortValue.valueless()));
-        assertThat(SortValue.from(Double.NaN), equalTo(SortValue.valueless()));
-        assertThat(SortValue.from(1), lessThan(SortValue.valueless()));
-        assertThat(SortValue.from(Long.MIN_VALUE), lessThan(SortValue.valueless()));
-        assertThat(SortValue.from(new BytesRef("cat")), lessThan(SortValue.valueless()));
+        assertThat(SortValue.from(1.0), lessThan(SortValue.empty()));
+        assertThat(SortValue.from(Double.MAX_VALUE), lessThan(SortValue.empty()));
+        assertThat(SortValue.from(Double.NaN), equalTo(SortValue.empty()));
+        assertThat(SortValue.from(1), lessThan(SortValue.empty()));
+        assertThat(SortValue.from(Long.MIN_VALUE), lessThan(SortValue.empty()));
+        assertThat(SortValue.from(new BytesRef("cat")), lessThan(SortValue.empty()));
     }
 
     public void testCompareDoubles() {
@@ -143,7 +143,7 @@ public class SortValueTests extends AbstractNamedWriteableTestCase<SortValue> {
     }
 
     public void testCompareEmpty() {
-        assertThat(SortValue.valueless(), equalTo(SortValue.valueless()));
+        assertThat(SortValue.empty(), equalTo(SortValue.empty()));
     }
 
     public void testSortValueOrdering() {
@@ -162,7 +162,7 @@ public class SortValueTests extends AbstractNamedWriteableTestCase<SortValue> {
         final SortValue emptyBytesRef = SortValue.from(new BytesRef(""));
         final SortValue fooBytesRef = SortValue.from(new BytesRef("Foo"));
         final SortValue barBytesRef = SortValue.from(new BytesRef("bar"));
-        final SortValue valueless = SortValue.valueless();
+        final SortValue valueless = SortValue.empty();
         final List<SortValue> values = List.of(
             maxLong,
             minLong,
@@ -187,7 +187,7 @@ public class SortValueTests extends AbstractNamedWriteableTestCase<SortValue> {
         /**
          * `negativeNan` and `positiveNan` are instances of
          * {@link org.elasticsearch.search.sort.SortValue.ValuelessSortValue}
-         * the same of {@link SortValue#valueless()}.
+         * the same of {@link SortValue#empty()}.
          */
         assertThat(
             sortedValues,

--- a/server/src/test/java/org/elasticsearch/search/sort/SortValueTests.java
+++ b/server/src/test/java/org/elasticsearch/search/sort/SortValueTests.java
@@ -24,6 +24,9 @@ import org.elasticsearch.xcontent.XContentBuilder;
 
 import java.io.IOException;
 import java.time.ZoneId;
+import java.util.Comparator;
+import java.util.List;
+import java.util.stream.Collectors;
 
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
@@ -52,7 +55,7 @@ public class SortValueTests extends AbstractNamedWriteableTestCase<SortValue> {
             case 0 -> SortValue.from(randomDouble());
             case 1 -> SortValue.from(randomLong());
             case 2 -> SortValue.from(new BytesRef(randomAlphaOfLength(5)));
-            case 3 -> SortValue.empty();
+            case 3 -> SortValue.valueless();
             default -> throw new AssertionError();
         };
     }
@@ -74,7 +77,7 @@ public class SortValueTests extends AbstractNamedWriteableTestCase<SortValue> {
     }
 
     public void testFormatEmpty() {
-        assertThat(SortValue.empty().format(DocValueFormat.RAW), equalTo(""));
+        assertThat(SortValue.valueless().format(DocValueFormat.RAW), equalTo(""));
     }
 
     public void testToXContentDouble() {
@@ -97,7 +100,7 @@ public class SortValueTests extends AbstractNamedWriteableTestCase<SortValue> {
     }
 
     public void testToXContentEmpty() {
-        assertThat(toXContent(SortValue.empty(), DocValueFormat.RAW), equalTo("{\"test\"}"));
+        assertThat(toXContent(SortValue.valueless(), DocValueFormat.RAW), equalTo("{\"test\"}"));
     }
 
     public void testCompareDifferentTypes() {
@@ -117,12 +120,12 @@ public class SortValueTests extends AbstractNamedWriteableTestCase<SortValue> {
      * See {@link org.elasticsearch.search.sort.SortValue#compareTo}.
      */
     public void testCompareToEmpty() {
-        assertThat(SortValue.from(1.0), lessThan(SortValue.empty()));
-        assertThat(SortValue.from(Double.MAX_VALUE), lessThan(SortValue.empty()));
-        assertThat(SortValue.from(Double.NaN), lessThan(SortValue.empty()));
-        assertThat(SortValue.from(1), greaterThan(SortValue.empty()));
-        assertThat(SortValue.from(Long.MIN_VALUE), greaterThan(SortValue.empty()));
-        assertThat(SortValue.from(new BytesRef("cat")), lessThan(SortValue.empty()));
+        assertThat(SortValue.from(1.0), lessThan(SortValue.valueless()));
+        assertThat(SortValue.from(Double.MAX_VALUE), lessThan(SortValue.valueless()));
+        assertThat(SortValue.from(Double.NaN), equalTo(SortValue.valueless()));
+        assertThat(SortValue.from(1), lessThan(SortValue.valueless()));
+        assertThat(SortValue.from(Long.MIN_VALUE), lessThan(SortValue.valueless()));
+        assertThat(SortValue.from(new BytesRef("cat")), lessThan(SortValue.valueless()));
     }
 
     public void testCompareDoubles() {
@@ -140,7 +143,50 @@ public class SortValueTests extends AbstractNamedWriteableTestCase<SortValue> {
     }
 
     public void testCompareEmpty() {
-        assertThat(SortValue.empty(), equalTo(SortValue.empty()));
+        assertThat(SortValue.valueless(), equalTo(SortValue.valueless()));
+    }
+
+    public void testSortValueOrdering() {
+        final SortValue maxLong = SortValue.from(Long.MAX_VALUE);
+        final SortValue minLong = SortValue.from(Long.MIN_VALUE);
+        final SortValue negativeLong = SortValue.from(-12L);
+        final SortValue zeroLong = SortValue.from(0L);
+        final SortValue positiveLong = SortValue.from(110L);
+        final SortValue negativeNan = SortValue.from(-Double.NaN);
+        final SortValue positiveNan = SortValue.from(Double.NaN);
+        final SortValue maxDouble = SortValue.from(Double.MAX_VALUE);
+        final SortValue minDouble = SortValue.from(Double.MIN_VALUE);
+        final SortValue negativeDouble = SortValue.from(-30.5D);
+        final SortValue zeroDouble = SortValue.from(0.0D);
+        final SortValue positiveDouble = SortValue.from(18.97D);
+        final SortValue emptyBytesRef = SortValue.from(new BytesRef(""));
+        final SortValue fooBytesRef = SortValue.from(new BytesRef("Foo"));
+        final SortValue barBytesRef = SortValue.from(new BytesRef("bar"));
+        final SortValue valueless = SortValue.valueless();
+        final List<SortValue> values = List.of(
+            maxLong, minLong, negativeLong, zeroLong, positiveLong, //Long
+            negativeNan, positiveNan, maxDouble, minDouble, negativeDouble, zeroDouble, positiveDouble, //Double
+            emptyBytesRef, fooBytesRef, barBytesRef, //BytesRef
+            valueless //Valueless
+        );
+
+        final List<SortValue> sortedValues = values.stream()
+            .sorted(Comparator.naturalOrder())
+            .collect(Collectors.toList());
+
+        /**
+         * `negativeNan` and `positiveNan` are instances of
+         * {@link org.elasticsearch.search.sort.SortValue.ValuelessSortValue}
+         * the same of {@link SortValue#valueless()}.
+         */
+        assertThat(sortedValues, equalTo(
+            List.of(
+                emptyBytesRef, fooBytesRef, barBytesRef, //BytesRef
+                negativeDouble, zeroDouble, minDouble, positiveDouble, maxDouble, minLong, //Double
+                negativeLong, zeroLong, positiveLong, maxLong, //Long
+                negativeNan, positiveNan, valueless //Valueless
+            )
+        ));
     }
 
     public void testBytes() {

--- a/server/src/test/java/org/elasticsearch/search/sort/SortValueTests.java
+++ b/server/src/test/java/org/elasticsearch/search/sort/SortValueTests.java
@@ -164,29 +164,54 @@ public class SortValueTests extends AbstractNamedWriteableTestCase<SortValue> {
         final SortValue barBytesRef = SortValue.from(new BytesRef("bar"));
         final SortValue valueless = SortValue.valueless();
         final List<SortValue> values = List.of(
-            maxLong, minLong, negativeLong, zeroLong, positiveLong, //Long
-            negativeNan, positiveNan, maxDouble, minDouble, negativeDouble, zeroDouble, positiveDouble, //Double
-            emptyBytesRef, fooBytesRef, barBytesRef, //BytesRef
-            valueless //Valueless
+            maxLong,
+            minLong,
+            negativeLong,
+            zeroLong,
+            positiveLong,
+            negativeNan,
+            positiveNan,
+            maxDouble,
+            minDouble,
+            negativeDouble,
+            zeroDouble,
+            positiveDouble,
+            emptyBytesRef,
+            fooBytesRef,
+            barBytesRef,
+            valueless
         );
 
-        final List<SortValue> sortedValues = values.stream()
-            .sorted(Comparator.naturalOrder())
-            .collect(Collectors.toList());
+        final List<SortValue> sortedValues = values.stream().sorted(Comparator.naturalOrder()).collect(Collectors.toList());
 
         /**
          * `negativeNan` and `positiveNan` are instances of
          * {@link org.elasticsearch.search.sort.SortValue.ValuelessSortValue}
          * the same of {@link SortValue#valueless()}.
          */
-        assertThat(sortedValues, equalTo(
-            List.of(
-                emptyBytesRef, fooBytesRef, barBytesRef, //BytesRef
-                negativeDouble, zeroDouble, minDouble, positiveDouble, maxDouble, minLong, //Double
-                negativeLong, zeroLong, positiveLong, maxLong, //Long
-                negativeNan, positiveNan, valueless //Valueless
+        assertThat(
+            sortedValues,
+            equalTo(
+                List.of(
+                    emptyBytesRef,
+                    fooBytesRef,
+                    barBytesRef,
+                    negativeDouble,
+                    zeroDouble,
+                    minDouble,
+                    positiveDouble,
+                    maxDouble,
+                    minLong,
+                    negativeLong,
+                    zeroLong,
+                    positiveLong,
+                    maxLong,
+                    negativeNan,
+                    positiveNan,
+                    valueless
+                )
             )
-        ));
+        );
     }
 
     public void testBytes() {

--- a/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/topmetrics/InternalTopMetrics.java
+++ b/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/topmetrics/InternalTopMetrics.java
@@ -177,12 +177,12 @@ public class InternalTopMetrics extends InternalMultiValueAggregation {
             throw new IllegalArgumentException("unknown metric [" + key + "]");
         }
         if (topMetrics.isEmpty()) {
-            return SortValue.empty();
+            return SortValue.valueless();
         }
 
         MetricValue value = topMetrics.get(0).metricValues.get(index);
         if (value == null) {
-            return SortValue.empty();
+            return SortValue.valueless();
         }
 
         return value.getValue();

--- a/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/topmetrics/InternalTopMetrics.java
+++ b/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/topmetrics/InternalTopMetrics.java
@@ -177,12 +177,12 @@ public class InternalTopMetrics extends InternalMultiValueAggregation {
             throw new IllegalArgumentException("unknown metric [" + key + "]");
         }
         if (topMetrics.isEmpty()) {
-            return SortValue.valueless();
+            return SortValue.empty();
         }
 
         MetricValue value = topMetrics.get(0).metricValues.get(index);
         if (value == null) {
-            return SortValue.valueless();
+            return SortValue.empty();
         }
 
         return value.getValue();


### PR DESCRIPTION
When comparing instances of SortValue we make sure that instances
of subclass EmptySortValue sort after everything else. This is
also to be consistent with the way Double.NaN values are sorted
with respect to Double values.

Additionally we make sure to create an instance of EmptySortValue
when creating an instance from a Double.NaN value.

This PR is intented to fix a potential issue introduced by #85058.