### PR TITLE
Support 'GeoJSON' in CartesianPoint for 'point'

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/geo/GenericPointParser.java
+++ b/server/src/main/java/org/elasticsearch/common/geo/GenericPointParser.java
@@ -1,0 +1,271 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.common.geo;
+
+import org.elasticsearch.ElasticsearchParseException;
+import org.elasticsearch.xcontent.XContentParser;
+import org.elasticsearch.xcontent.XContentSubParser;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.function.Function;
+
+import static org.elasticsearch.common.Strings.collectionToDelimitedString;
+
+/**
+ * This class can parse points from XContentParser and supports several formats:
+ * @param <T> type of point to produce (either geographic or cartesian)
+ */
+public abstract class GenericPointParser<T> {
+    private static final String X_FIELD = "x";
+    private static final String Y_FIELD = "y";
+    private static final String Z_FIELD = "z";
+    private static final String GEOHASH = "geohash";
+    private static final String TYPE = "type";
+    private static final String COORDINATES = "coordinates";
+    private final Map<String, FieldParser<?>> fields;
+    private final String mapType;
+    private final String xField;
+    private final String yField;
+
+    private abstract static class FieldParser<T> {
+        final String name;
+
+        abstract T parseField(XContentSubParser subParser) throws IOException;
+
+        private FieldParser(String name) {
+            this.name = name;
+        }
+
+        @Override
+        public String toString() {
+            return this.name;
+        }
+    }
+
+    private static class StringFieldParser extends FieldParser<String> {
+
+        private StringFieldParser(String name) {
+            super(name);
+        }
+
+        @Override
+        String parseField(XContentSubParser subParser) throws IOException {
+            if (subParser.currentToken() == XContentParser.Token.VALUE_STRING) {
+                return subParser.text();
+            } else {
+                throw new ElasticsearchParseException("[{}] must be a string", name);
+            }
+        }
+    }
+
+    private static class DoubleFieldParser extends FieldParser<Double> {
+        final String description;
+
+        private DoubleFieldParser(String name, String description) {
+            super(name);
+            this.description = switch (description) {
+                case "lon" -> "longitude";
+                case "lat" -> "latitude";
+                default -> description;
+            };
+        }
+
+        @Override
+        Double parseField(XContentSubParser subParser) throws IOException {
+            return parseValidDouble(subParser, description);
+        }
+    }
+
+    private static class DoubleArrayFieldParser extends FieldParser<List<Double>> {
+
+        private DoubleArrayFieldParser(String name) {
+            super(name);
+        }
+
+        @Override
+        List<Double> parseField(XContentSubParser subParser) throws IOException {
+            if (subParser.currentToken() == XContentParser.Token.START_ARRAY) {
+                ArrayList<Double> coordinates = new ArrayList<>();
+                while (subParser.nextToken() != XContentParser.Token.END_ARRAY) {
+                    coordinates.add(parseValidDouble(subParser, name));
+                }
+                return coordinates;
+            } else {
+                throw new ElasticsearchParseException("[{}] must be an array", name);
+            }
+        }
+    }
+
+    /**
+     * Construct the parser with some configuration settings
+     * @param mapType whether the parser is for 'geo_point' or 'point'
+     * @param xField the name of the first coordinate when constructing points (either 'x' or 'lat')
+     * @param yField the name of the second coordinate when constructing points (either 'y' or 'lon')
+     * @param supportGeohash whether to support parsing geohash values (only geo_point supports this currently)
+     */
+    public GenericPointParser(String mapType, String xField, String yField, boolean supportGeohash) {
+        this.mapType = mapType;
+        this.xField = xField;
+        this.yField = yField;
+        fields = new LinkedHashMap<>();
+        fields.put(xField, new DoubleFieldParser(X_FIELD, xField));
+        fields.put(yField, new DoubleFieldParser(Y_FIELD, yField));
+        fields.put(Z_FIELD, new DoubleFieldParser(Z_FIELD, Z_FIELD));
+        fields.put(TYPE, new StringFieldParser(TYPE));
+        fields.put(COORDINATES, new DoubleArrayFieldParser(COORDINATES));
+        if (supportGeohash) {
+            fields.put(GEOHASH, new StringFieldParser(GEOHASH));
+        }
+    }
+
+    public abstract void assertZValue(boolean ignoreZValue, double zValue);
+
+    public abstract T createPoint(double xValue, double yValue);
+
+    public abstract String fieldError();
+
+    /**
+     * Parse a Point with an {@link XContentParser}.
+     *
+     * @param parser {@link XContentParser} to parse the value from
+     * @param ignoreZValue {@link XContentParser} to not throw an error if 3 dimensional data is provided
+     * @return new Point parsed from the parser
+     */
+    public T parsePoint(XContentParser parser, boolean ignoreZValue, Function<String, T> fromString, Function<String, T> fromGeohash)
+        throws IOException, ElasticsearchParseException {
+        double x = Double.NaN;
+        double y = Double.NaN;
+        String geohash = null;
+        String geojsonType = null;
+        List<Double> coordinates = null;
+
+        if (parser.currentToken() == XContentParser.Token.START_OBJECT) {
+            try (XContentSubParser subParser = new XContentSubParser(parser)) {
+                while (subParser.nextToken() != XContentParser.Token.END_OBJECT) {
+                    if (subParser.currentToken() == XContentParser.Token.FIELD_NAME) {
+                        String field = subParser.currentName();
+                        subParser.nextToken();
+                        FieldParser<?> fieldParser = fields.get(field);
+                        if (fieldParser != null) {
+                            switch (fieldParser.name) {
+                                case X_FIELD -> x = (Double) fieldParser.parseField(subParser);
+                                case Y_FIELD -> y = (Double) fieldParser.parseField(subParser);
+                                case Z_FIELD -> assertZValue(ignoreZValue, (Double) fieldParser.parseField(subParser));
+                                case GEOHASH -> geohash = (String) fieldParser.parseField(subParser);
+                                case TYPE -> geojsonType = (String) fieldParser.parseField(subParser);
+                                case COORDINATES -> coordinates = ((DoubleArrayFieldParser) fieldParser).parseField(subParser);
+                            }
+                        } else {
+                            String fieldKeys = collectionToDelimitedString(fields.keySet(), ", ");
+                            throw new ElasticsearchParseException("field [{}] not supported - must be one of: {}", field, fieldKeys);
+                        }
+                    } else {
+                        throw new ElasticsearchParseException("token [{}] not allowed", subParser.currentToken());
+                    }
+                }
+            }
+            assertOnlyOneFormat(
+                geohash != null,
+                Double.isNaN(x) == false,
+                Double.isNaN(y) == false,
+                coordinates != null,
+                geojsonType != null
+            );
+            if (geohash != null) {
+                return fromGeohash.apply(geohash);
+            }
+            if (coordinates != null) {
+                if (geojsonType == null || geojsonType.toLowerCase(Locale.ROOT).equals("point") == false) {
+                    throw new ElasticsearchParseException("[type] for {} can only be 'Point'", mapType);
+                }
+                if (coordinates.size() < 2) {
+                    throw new ElasticsearchParseException("[coordinates] must contain at least two values");
+                }
+                if (coordinates.size() == 3) {
+                    assertZValue(ignoreZValue, coordinates.get(2));
+                }
+                if (coordinates.size() > 3) {
+                    throw new ElasticsearchParseException("[{}] field type does not accept > 3 dimensions", mapType);
+                }
+                return createPoint(coordinates.get(0), coordinates.get(1));
+            }
+            return createPoint(x, y);
+
+        } else if (parser.currentToken() == XContentParser.Token.START_ARRAY) {
+            try (XContentSubParser subParser = new XContentSubParser(parser)) {
+                int element = 0;
+                while (subParser.nextToken() != XContentParser.Token.END_ARRAY) {
+                    if (subParser.currentToken() == XContentParser.Token.VALUE_NUMBER) {
+                        element++;
+                        if (element == 1) {
+                            x = subParser.doubleValue();
+                        } else if (element == 2) {
+                            y = subParser.doubleValue();
+                        } else if (element == 3) {
+                            assertZValue(ignoreZValue, subParser.doubleValue());
+                        } else {
+                            throw new ElasticsearchParseException("[{}] field type does not accept > 3 dimensions", mapType);
+                        }
+                    } else {
+                        throw new ElasticsearchParseException("numeric value expected");
+                    }
+                }
+            }
+            return createPoint(x, y);
+        } else if (parser.currentToken() == XContentParser.Token.VALUE_STRING) {
+            return fromString.apply(parser.text());
+        } else {
+            throw new ElasticsearchParseException("{} expected", mapType);
+        }
+    }
+
+    private static double parseValidDouble(XContentSubParser subParser, String field) throws IOException {
+        try {
+            return switch (subParser.currentToken()) {
+                case VALUE_NUMBER, VALUE_STRING -> subParser.doubleValue(true);
+                default -> throw new ElasticsearchParseException("{} must be a number", field);
+            };
+        } catch (NumberFormatException e) {
+            throw new ElasticsearchParseException("[{}] must be a valid double value", e, field);
+        }
+    }
+
+    private void assertOnlyOneFormat(boolean geohash, boolean x, boolean y, boolean coordinates, boolean type) {
+        boolean xy = x && y;
+        boolean geojson = coordinates && type;
+        var found = new ArrayList<String>();
+        if (geohash) found.add("geohash");
+        if (xy) found.add(xField + "/" + yField);
+        if (geojson) found.add("GeoJSON");
+        if (found.size() > 1) {
+            throw new ElasticsearchParseException("fields matching more than one point format found: {}", found);
+        } else if (geohash) {
+            if (x || y || type || coordinates) {
+                throw new ElasticsearchParseException(fieldError());
+            }
+        } else if (found.size() == 0) {
+            if (x) {
+                throw new ElasticsearchParseException("Required [{}]", yField);
+            } else if (y) {
+                throw new ElasticsearchParseException("Required [{}]", xField);
+            } else if (coordinates) {
+                throw new ElasticsearchParseException("Required [{}]", TYPE);
+            } else if (type) {
+                throw new ElasticsearchParseException("Required [{}]", COORDINATES);
+            } else {
+                throw new ElasticsearchParseException(fieldError());
+            }
+        }
+    }
+}

--- a/server/src/main/java/org/elasticsearch/common/geo/GeoBoundingBox.java
+++ b/server/src/main/java/org/elasticsearch/common/geo/GeoBoundingBox.java
@@ -174,13 +174,12 @@ public class GeoBoundingBox implements ToXContentFragment, Writeable {
         double right = Double.NaN;
 
         String currentFieldName;
-        GeoPoint sparse = new GeoPoint();
         Rectangle envelope = null;
 
         while ((token = parser.nextToken()) != XContentParser.Token.END_OBJECT) {
             if (token == XContentParser.Token.FIELD_NAME) {
                 currentFieldName = parser.currentName();
-                token = parser.nextToken();
+                parser.nextToken();
                 if (WKT_FIELD.match(currentFieldName, parser.getDeprecationHandler())) {
                     try {
                         Geometry geometry = WellKnownText.fromWKT(StandardValidator.instance(true), true, parser.text());
@@ -203,19 +202,19 @@ public class GeoBoundingBox implements ToXContentFragment, Writeable {
                     right = parser.doubleValue();
                 } else {
                     if (TOP_LEFT_FIELD.match(currentFieldName, parser.getDeprecationHandler())) {
-                        GeoUtils.parseGeoPoint(parser, sparse, false, GeoUtils.EffectivePoint.TOP_LEFT);
+                        GeoPoint sparse = GeoUtils.parseGeoPoint(parser, false, GeoUtils.EffectivePoint.TOP_LEFT);
                         top = sparse.getLat();
                         left = sparse.getLon();
                     } else if (BOTTOM_RIGHT_FIELD.match(currentFieldName, parser.getDeprecationHandler())) {
-                        GeoUtils.parseGeoPoint(parser, sparse, false, GeoUtils.EffectivePoint.BOTTOM_RIGHT);
+                        GeoPoint sparse = GeoUtils.parseGeoPoint(parser, false, GeoUtils.EffectivePoint.BOTTOM_RIGHT);
                         bottom = sparse.getLat();
                         right = sparse.getLon();
                     } else if (TOP_RIGHT_FIELD.match(currentFieldName, parser.getDeprecationHandler())) {
-                        GeoUtils.parseGeoPoint(parser, sparse, false, GeoUtils.EffectivePoint.TOP_RIGHT);
+                        GeoPoint sparse = GeoUtils.parseGeoPoint(parser, false, GeoUtils.EffectivePoint.TOP_RIGHT);
                         top = sparse.getLat();
                         right = sparse.getLon();
                     } else if (BOTTOM_LEFT_FIELD.match(currentFieldName, parser.getDeprecationHandler())) {
-                        GeoUtils.parseGeoPoint(parser, sparse, false, GeoUtils.EffectivePoint.BOTTOM_LEFT);
+                        GeoPoint sparse = GeoUtils.parseGeoPoint(parser, false, GeoUtils.EffectivePoint.BOTTOM_LEFT);
                         bottom = sparse.getLat();
                         left = sparse.getLon();
                     } else {

--- a/server/src/main/java/org/elasticsearch/common/geo/GeometryParser.java
+++ b/server/src/main/java/org/elasticsearch/common/geo/GeometryParser.java
@@ -84,7 +84,7 @@ public final class GeometryParser {
             parser.nextToken(); // field name
             parser.nextToken(); // field value
             if (isPoint(value)) {
-                GeoPoint point = GeoUtils.parseGeoPoint(parser, new GeoPoint(), ignoreZValue);
+                GeoPoint point = GeoUtils.parseGeoPoint(parser, ignoreZValue);
                 return new Point(point.lon(), point.lat());
             } else {
                 return parse(parser);

--- a/server/src/main/java/org/elasticsearch/index/mapper/AbstractPointGeometryFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/AbstractPointGeometryFieldMapper.java
@@ -8,10 +8,10 @@
 package org.elasticsearch.index.mapper;
 
 import org.elasticsearch.ElasticsearchParseException;
-import org.elasticsearch.common.CheckedBiFunction;
 import org.elasticsearch.common.Explicit;
 import org.elasticsearch.common.TriFunction;
 import org.elasticsearch.core.CheckedConsumer;
+import org.elasticsearch.core.CheckedFunction;
 import org.elasticsearch.xcontent.XContentParser;
 
 import java.io.IOException;
@@ -20,7 +20,7 @@ import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
-/** Base class for for spatial fields that only support indexing points */
+/** Base class for spatial fields that only support indexing points */
 public abstract class AbstractPointGeometryFieldMapper<T> extends AbstractGeometryFieldMapper<T> {
 
     public static <T> Parameter<T> nullValueParam(
@@ -67,22 +67,19 @@ public abstract class AbstractPointGeometryFieldMapper<T> extends AbstractGeomet
     /** A base parser implementation for point formats */
     protected abstract static class PointParser<T> extends Parser<T> {
         protected final String field;
-        private final Supplier<T> pointSupplier;
-        private final CheckedBiFunction<XContentParser, T, T, IOException> objectParser;
+        private final CheckedFunction<XContentParser, T, IOException> objectParser;
         private final T nullValue;
         private final boolean ignoreZValue;
         protected final boolean ignoreMalformed;
 
         protected PointParser(
             String field,
-            Supplier<T> pointSupplier,
-            CheckedBiFunction<XContentParser, T, T, IOException> objectParser,
+            CheckedFunction<XContentParser, T, IOException> objectParser,
             T nullValue,
             boolean ignoreZValue,
             boolean ignoreMalformed
         ) {
             this.field = field;
-            this.pointSupplier = pointSupplier;
             this.objectParser = objectParser;
             this.nullValue = nullValue == null ? null : validate(nullValue);
             this.ignoreZValue = ignoreZValue;
@@ -91,14 +88,13 @@ public abstract class AbstractPointGeometryFieldMapper<T> extends AbstractGeomet
 
         protected abstract T validate(T in);
 
-        protected abstract void reset(T in, double x, double y);
+        protected abstract T createPoint(double x, double y);
 
         @Override
         public void parse(XContentParser parser, CheckedConsumer<T, IOException> consumer, Consumer<Exception> onMalformed)
             throws IOException {
             if (parser.currentToken() == XContentParser.Token.START_ARRAY) {
                 XContentParser.Token token = parser.nextToken();
-                T point = pointSupplier.get();
                 if (token == XContentParser.Token.VALUE_NUMBER) {
                     double x = parser.doubleValue();
                     parser.nextToken();
@@ -116,7 +112,7 @@ public abstract class AbstractPointGeometryFieldMapper<T> extends AbstractGeomet
                         throw new ElasticsearchParseException("field type does not accept > 3 dimensions");
                     }
 
-                    reset(point, x, y);
+                    T point = createPoint(x, y);
                     consumer.accept(validate(point));
                 } else {
                     while (token != XContentParser.Token.END_ARRAY) {
@@ -125,8 +121,7 @@ public abstract class AbstractPointGeometryFieldMapper<T> extends AbstractGeomet
                                 consumer.accept(nullValue);
                             }
                         } else {
-                            parseAndConsumeFromObject(parser, point, consumer, onMalformed);
-                            point = pointSupplier.get();
+                            parseAndConsumeFromObject(parser, consumer, onMalformed);
                         }
                         token = parser.nextToken();
                     }
@@ -136,18 +131,17 @@ public abstract class AbstractPointGeometryFieldMapper<T> extends AbstractGeomet
                     consumer.accept(nullValue);
                 }
             } else {
-                parseAndConsumeFromObject(parser, pointSupplier.get(), consumer, onMalformed);
+                parseAndConsumeFromObject(parser, consumer, onMalformed);
             }
         }
 
         private void parseAndConsumeFromObject(
             XContentParser parser,
-            T point,
             CheckedConsumer<T, IOException> consumer,
             Consumer<Exception> onMalformed
         ) {
             try {
-                point = objectParser.apply(parser, point);
+                T point = objectParser.apply(parser);
                 consumer.accept(validate(point));
             } catch (Exception e) {
                 onMalformed.accept(e);

--- a/server/src/main/java/org/elasticsearch/index/mapper/GeoPointFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/GeoPointFieldMapper.java
@@ -17,7 +17,6 @@ import org.apache.lucene.search.IndexOrDocValuesQuery;
 import org.apache.lucene.search.Query;
 import org.elasticsearch.ElasticsearchParseException;
 import org.elasticsearch.Version;
-import org.elasticsearch.common.CheckedBiFunction;
 import org.elasticsearch.common.Explicit;
 import org.elasticsearch.common.geo.GeoFormatterFactory;
 import org.elasticsearch.common.geo.GeoPoint;
@@ -26,6 +25,7 @@ import org.elasticsearch.common.geo.GeometryFormatterFactory;
 import org.elasticsearch.common.geo.ShapeRelation;
 import org.elasticsearch.common.geo.SimpleVectorTileFormatter;
 import org.elasticsearch.common.unit.DistanceUnit;
+import org.elasticsearch.core.CheckedFunction;
 import org.elasticsearch.geometry.Point;
 import org.elasticsearch.index.fielddata.IndexFieldData;
 import org.elasticsearch.index.fielddata.plain.AbstractLatLonPointIndexFieldData;
@@ -110,8 +110,7 @@ public class GeoPointFieldMapper extends AbstractPointGeometryFieldMapper<GeoPoi
             if (nullValue == null) {
                 return null;
             }
-            GeoPoint point = new GeoPoint();
-            GeoUtils.parseGeoPoint(nullValue, point, ignoreZValue);
+            GeoPoint point = GeoUtils.parseGeoPoint(nullValue, ignoreZValue);
             if (ignoreMalformed == false) {
                 if (point.lat() > 90.0 || point.lat() < -90.0) {
                     throw new IllegalArgumentException("illegal latitude value [" + point.lat() + "]");
@@ -139,10 +138,13 @@ public class GeoPointFieldMapper extends AbstractPointGeometryFieldMapper<GeoPoi
 
         @Override
         public FieldMapper build(MapperBuilderContext context) {
-            Parser<GeoPoint> geoParser = new GeoPointParser(name, GeoPoint::new, (parser, point) -> {
-                GeoUtils.parseGeoPoint(parser, point, ignoreZValue.get().value());
-                return point;
-            }, nullValue.get(), ignoreZValue.get().value(), ignoreMalformed.get().value());
+            Parser<GeoPoint> geoParser = new GeoPointParser(
+                name,
+                (parser) -> GeoUtils.parseGeoPoint(parser, ignoreZValue.get().value()),
+                nullValue.get(),
+                ignoreZValue.get().value(),
+                ignoreMalformed.get().value()
+            );
             GeoPointFieldType ft = new GeoPointFieldType(
                 context.buildFullName(name),
                 indexed.get() && indexCreatedVersion.isLegacyIndexVersion() == false,
@@ -396,13 +398,12 @@ public class GeoPointFieldMapper extends AbstractPointGeometryFieldMapper<GeoPoi
 
         GeoPointParser(
             String field,
-            Supplier<GeoPoint> pointSupplier,
-            CheckedBiFunction<XContentParser, GeoPoint, GeoPoint, IOException> objectParser,
+            CheckedFunction<XContentParser, GeoPoint, IOException> objectParser,
             GeoPoint nullValue,
             boolean ignoreZValue,
             boolean ignoreMalformed
         ) {
-            super(field, pointSupplier, objectParser, nullValue, ignoreZValue, ignoreMalformed);
+            super(field, objectParser, nullValue, ignoreZValue, ignoreMalformed);
         }
 
         protected GeoPoint validate(GeoPoint in) {
@@ -428,8 +429,8 @@ public class GeoPointFieldMapper extends AbstractPointGeometryFieldMapper<GeoPoi
         }
 
         @Override
-        protected void reset(GeoPoint in, double x, double y) {
-            in.reset(y, x);
+        protected GeoPoint createPoint(double x, double y) {
+            return new GeoPoint(y, x);
         }
 
         @Override

--- a/server/src/main/java/org/elasticsearch/index/query/GeoDistanceQueryBuilder.java
+++ b/server/src/main/java/org/elasticsearch/index/query/GeoDistanceQueryBuilder.java
@@ -278,7 +278,7 @@ public class GeoDistanceQueryBuilder extends AbstractQueryBuilder<GeoDistanceQue
                 currentFieldName = parser.currentName();
             } else if (token == XContentParser.Token.START_ARRAY) {
                 fieldName = currentFieldName;
-                GeoUtils.parseGeoPoint(parser, point);
+                point = GeoUtils.parseGeoPoint(parser);
             } else if (token == XContentParser.Token.START_OBJECT) {
                 throwParsingExceptionOnMultipleFields(NAME, parser.getTokenLocation(), fieldName, currentFieldName);
                 // the json in the format of -> field : { lat : 30, lon : 12 }

--- a/server/src/main/java/org/elasticsearch/script/GeoPointFieldScript.java
+++ b/server/src/main/java/org/elasticsearch/script/GeoPointFieldScript.java
@@ -80,8 +80,6 @@ public abstract class GeoPointFieldScript extends AbstractLongFieldScript {
         GeoPointFieldScript newInstance(LeafReaderContext ctx);
     }
 
-    private final GeoPoint scratch = new GeoPoint();
-
     public GeoPointFieldScript(String fieldName, Map<String, Object> params, SearchLookup searchLookup, LeafReaderContext ctx) {
         super(fieldName, params, searchLookup, ctx);
     }
@@ -135,18 +133,18 @@ public abstract class GeoPointFieldScript extends AbstractLongFieldScript {
     private void emitPoint(Object point) {
         if (point != null) {
             try {
-                GeoUtils.parseGeoPoint(point, scratch, true);
+                GeoPoint geoPoint = GeoUtils.parseGeoPoint(point, true);
+                emit(geoPoint.lat(), geoPoint.lon());
             } catch (Exception e) {
-                // ignore
+                emit(0, 0);
             }
-            emit(scratch.lat(), scratch.lon());
         }
     }
 
     protected final void emit(double lat, double lon) {
         int latitudeEncoded = encodeLatitude(lat);
         int longitudeEncoded = encodeLongitude(lon);
-        emit(Long.valueOf((((long) latitudeEncoded) << 32) | (longitudeEncoded & 0xFFFFFFFFL)));
+        emit((((long) latitudeEncoded) << 32) | (longitudeEncoded & 0xFFFFFFFFL));
     }
 
     public static class Emit {

--- a/server/src/main/java/org/elasticsearch/search/sort/GeoDistanceSortBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/sort/GeoDistanceSortBuilder.java
@@ -448,9 +448,7 @@ public class GeoDistanceSortBuilder extends SortBuilder<GeoDistanceSortBuilder> 
                         );
                     }
                     fieldName = currentName;
-                    GeoPoint point = new GeoPoint();
-                    GeoUtils.parseGeoPoint(parser, point);
-                    geoPoints.add(point);
+                    geoPoints.add(GeoUtils.parseGeoPoint(parser));
                 }
             } else if (token.isValue()) {
                 if (parser.getRestApiVersion() == RestApiVersion.V_7
@@ -728,13 +726,9 @@ public class GeoDistanceSortBuilder extends SortBuilder<GeoDistanceSortBuilder> 
                     );
                 }
                 double lat = parser.doubleValue();
-                GeoPoint point = new GeoPoint();
-                point.reset(lat, lon);
-                geoPoints.add(point);
+                geoPoints.add(new GeoPoint(lat, lon));
             } else {
-                GeoPoint point = new GeoPoint();
-                GeoUtils.parseGeoPoint(parser, point);
-                geoPoints.add(point);
+                geoPoints.add(GeoUtils.parseGeoPoint(parser));
             }
 
         }

--- a/server/src/test/java/org/elasticsearch/index/search/geo/GeoPointParsingTests.java
+++ b/server/src/test/java/org/elasticsearch/index/search/geo/GeoPointParsingTests.java
@@ -90,19 +90,19 @@ public class GeoPointParsingTests extends ESTestCase {
         point = GeoUtils.parseGeoPoint(toObject(objectLatLon(randomPt.lat(), randomPt.lon())), randomBoolean());
         assertPointsEqual(point, randomPt);
 
-        GeoUtils.parseGeoPoint(arrayLatLon(randomPt.lat(), randomPt.lon()), point);
+        point = GeoUtils.parseGeoPoint(arrayLatLon(randomPt.lat(), randomPt.lon()));
         assertPointsEqual(point, randomPt);
 
         point = GeoUtils.parseGeoPoint(toObject(arrayLatLon(randomPt.lat(), randomPt.lon())), randomBoolean());
         assertPointsEqual(point, randomPt);
 
-        GeoUtils.parseGeoPoint(geohash(randomPt.lat(), randomPt.lon()), point);
+        point = GeoUtils.parseGeoPoint(geohash(randomPt.lat(), randomPt.lon()));
         assertCloseTo(point, randomPt.lat(), randomPt.lon());
 
         point = GeoUtils.parseGeoPoint(toObject(geohash(randomPt.lat(), randomPt.lon())), randomBoolean());
         assertCloseTo(point, randomPt.lat(), randomPt.lon());
 
-        GeoUtils.parseGeoPoint(stringLatLon(randomPt.lat(), randomPt.lon()), point);
+        point = GeoUtils.parseGeoPoint(stringLatLon(randomPt.lat(), randomPt.lon()));
         assertCloseTo(point, randomPt.lat(), randomPt.lon());
 
         point = GeoUtils.parseGeoPoint(toObject(stringLatLon(randomPt.lat(), randomPt.lon())), randomBoolean());
@@ -124,12 +124,12 @@ public class GeoPointParsingTests extends ESTestCase {
         try (XContentParser parser = createParser(JsonXContent.jsonXContent, BytesReference.bytes(content))) {
             parser.nextToken();
             Exception e = expectThrows(ElasticsearchParseException.class, () -> GeoUtils.parseGeoPoint(parser));
-            assertThat(e.getMessage(), is("field must be either [lat], [lon], [geohash], [coordinates] or [type]"));
+            assertThat(e.getMessage(), is("field [location] not supported - must be one of: lon, lat, z, type, coordinates, geohash"));
         }
         try (XContentParser parser2 = createParser(JsonXContent.jsonXContent, BytesReference.bytes(content))) {
             parser2.nextToken();
             Exception e = expectThrows(ElasticsearchParseException.class, () -> GeoUtils.parseGeoPoint(toObject(parser2), randomBoolean()));
-            assertThat(e.getMessage(), is("field must be either [lat], [lon], [geohash], [coordinates] or [type]"));
+            assertThat(e.getMessage(), is("field [location] not supported - must be one of: lon, lat, z, type, coordinates, geohash"));
         }
     }
 
@@ -170,13 +170,13 @@ public class GeoPointParsingTests extends ESTestCase {
         try (XContentParser parser = createParser(JsonXContent.jsonXContent, BytesReference.bytes(content))) {
             parser.nextToken();
             Exception e = expectThrows(ElasticsearchParseException.class, () -> GeoUtils.parseGeoPoint(parser));
-            assertThat(e.getMessage(), is("field must be either [lat], [lon], [geohash], [coordinates] or [type]"));
+            assertThat(e.getMessage(), is("field [test] not supported - must be one of: lon, lat, z, type, coordinates, geohash"));
         }
 
         try (XContentParser parser2 = createParser(JsonXContent.jsonXContent, BytesReference.bytes(content))) {
             parser2.nextToken();
             Exception e = expectThrows(ElasticsearchParseException.class, () -> GeoUtils.parseGeoPoint(toObject(parser2), randomBoolean()));
-            assertThat(e.getMessage(), is("field must be either [lat], [lon], [geohash], [coordinates] or [type]"));
+            assertThat(e.getMessage(), is("field [test] not supported - must be one of: lon, lat, z, type, coordinates, geohash"));
         }
     }
 

--- a/server/src/test/java/org/elasticsearch/index/search/geo/GeoUtilsTests.java
+++ b/server/src/test/java/org/elasticsearch/index/search/geo/GeoUtilsTests.java
@@ -484,7 +484,7 @@ public class GeoUtilsTests extends ESTestCase {
             while (parser.currentToken() != Token.VALUE_STRING) {
                 parser.nextToken();
             }
-            Exception e = expectThrows(ElasticsearchParseException.class, () -> GeoUtils.parseGeoPoint(parser, new GeoPoint(), false));
+            Exception e = expectThrows(ElasticsearchParseException.class, () -> GeoUtils.parseGeoPoint(parser, false));
             assertThat(e.getMessage(), containsString("but [ignore_z_value] parameter is [false]"));
         }
     }
@@ -496,7 +496,7 @@ public class GeoUtilsTests extends ESTestCase {
         XContentBuilder json = jsonBuilder().startArray().value(lat).value(lon).value(alt).endArray();
         try (XContentParser parser = createParser(json)) {
             parser.nextToken();
-            Exception e = expectThrows(ElasticsearchParseException.class, () -> GeoUtils.parseGeoPoint(parser, new GeoPoint(), false));
+            Exception e = expectThrows(ElasticsearchParseException.class, () -> GeoUtils.parseGeoPoint(parser, false));
             assertThat(e.getMessage(), containsString("but [ignore_z_value] parameter is [false]"));
             assertThat(parser.currentToken(), is(Token.END_ARRAY));
             assertNull(parser.nextToken());
@@ -536,7 +536,7 @@ public class GeoUtilsTests extends ESTestCase {
         try (XContentParser parser = createParser(json)) {
             parser.nextToken();
             Exception e = expectThrows(ElasticsearchParseException.class, () -> GeoUtils.parseGeoPoint(parser));
-            assertThat(e.getMessage(), containsString("geohash must be a string"));
+            assertThat(e.getMessage(), containsString("[geohash] must be a string"));
             assertThat(parser.currentToken(), is(Token.END_OBJECT));
             assertNull(parser.nextToken());
         }
@@ -548,7 +548,7 @@ public class GeoUtilsTests extends ESTestCase {
         try (XContentParser parser = createParser(json)) {
             parser.nextToken();
             Exception e = expectThrows(ElasticsearchParseException.class, () -> GeoUtils.parseGeoPoint(parser));
-            assertThat(e.getMessage(), is("field [lon] missing"));
+            assertThat(e.getMessage(), is("Required [lon]"));
             assertThat(parser.currentToken(), is(Token.END_OBJECT));
             assertNull(parser.nextToken());
         }
@@ -560,7 +560,7 @@ public class GeoUtilsTests extends ESTestCase {
         try (XContentParser parser = createParser(json)) {
             parser.nextToken();
             Exception e = expectThrows(ElasticsearchParseException.class, () -> GeoUtils.parseGeoPoint(parser));
-            assertThat(e.getMessage(), is("field [lat] missing"));
+            assertThat(e.getMessage(), is("Required [lat]"));
             assertThat(parser.currentToken(), is(Token.END_OBJECT));
             assertNull(parser.nextToken());
         }
@@ -596,7 +596,7 @@ public class GeoUtilsTests extends ESTestCase {
         try (XContentParser parser = createParser(json)) {
             parser.nextToken();
             Exception e = expectThrows(ElasticsearchParseException.class, () -> GeoUtils.parseGeoPoint(parser));
-            assertThat(e.getMessage(), is("field [type] missing"));
+            assertThat(e.getMessage(), is("Required [type]"));
             assertThat(parser.currentToken(), is(Token.END_OBJECT));
             assertNull(parser.nextToken());
         }
@@ -607,7 +607,7 @@ public class GeoUtilsTests extends ESTestCase {
         try (XContentParser parser = createParser(json)) {
             parser.nextToken();
             Exception e = expectThrows(ElasticsearchParseException.class, () -> GeoUtils.parseGeoPoint(parser));
-            assertThat(e.getMessage(), is("field [coordinates] missing"));
+            assertThat(e.getMessage(), is("Required [coordinates]"));
             assertThat(parser.currentToken(), is(Token.END_OBJECT));
             assertNull(parser.nextToken());
         }
@@ -619,7 +619,7 @@ public class GeoUtilsTests extends ESTestCase {
         try (XContentParser parser = createParser(json)) {
             parser.nextToken();
             Exception e = expectThrows(ElasticsearchParseException.class, () -> GeoUtils.parseGeoPoint(parser));
-            assertThat(e.getMessage(), is("GeoJSON 'type' for geo_point can only be 'Point'"));
+            assertThat(e.getMessage(), is("[type] for geo_point can only be 'Point'"));
             assertThat(parser.currentToken(), is(Token.END_OBJECT));
             assertNull(parser.nextToken());
         }
@@ -631,7 +631,7 @@ public class GeoUtilsTests extends ESTestCase {
         try (XContentParser parser = createParser(json)) {
             parser.nextToken();
             Exception e = expectThrows(ElasticsearchParseException.class, () -> GeoUtils.parseGeoPoint(parser));
-            assertThat(e.getMessage(), is("GeoJSON 'type' must be a string"));
+            assertThat(e.getMessage(), is("[type] must be a string"));
             assertThat(parser.currentToken(), is(Token.END_OBJECT));
             assertNull(parser.nextToken());
         }
@@ -642,7 +642,7 @@ public class GeoUtilsTests extends ESTestCase {
         try (XContentParser parser = createParser(json)) {
             parser.nextToken();
             Exception e = expectThrows(ElasticsearchParseException.class, () -> GeoUtils.parseGeoPoint(parser));
-            assertThat(e.getMessage(), is("GeoJSON 'coordinates' must be an array"));
+            assertThat(e.getMessage(), is("[coordinates] must be an array"));
             assertThat(parser.currentToken(), is(Token.END_OBJECT));
             assertNull(parser.nextToken());
         }
@@ -654,7 +654,7 @@ public class GeoUtilsTests extends ESTestCase {
         try (XContentParser parser = createParser(json)) {
             parser.nextToken();
             Exception e = expectThrows(ElasticsearchParseException.class, () -> GeoUtils.parseGeoPoint(parser));
-            assertThat(e.getMessage(), is("GeoJSON 'coordinates' must contain at least two values"));
+            assertThat(e.getMessage(), is("[coordinates] must contain at least two values"));
             assertThat(parser.currentToken(), is(Token.END_OBJECT));
             assertNull(parser.nextToken());
         }
@@ -691,7 +691,7 @@ public class GeoUtilsTests extends ESTestCase {
         try (XContentParser parser = createParser(json)) {
             parser.nextToken();
             Exception e = expectThrows(ElasticsearchParseException.class, () -> GeoUtils.parseGeoPoint(parser));
-            assertThat(e.getMessage(), is("field must be either [lat], [lon], [geohash], [coordinates] or [type]"));
+            assertThat(e.getMessage(), is("field [foo] not supported - must be one of: lon, lat, z, type, coordinates, geohash"));
         }
     }
 
@@ -730,7 +730,7 @@ public class GeoUtilsTests extends ESTestCase {
             while (parser.currentToken() != Token.START_ARRAY) {
                 parser.nextToken();
             }
-            GeoPoint point = GeoUtils.parseGeoPoint(parser, new GeoPoint(), true);
+            GeoPoint point = GeoUtils.parseGeoPoint(parser, true);
             assertThat(point.lat(), equalTo(lat));
             assertThat(point.lon(), equalTo(lon));
         }
@@ -774,7 +774,7 @@ public class GeoUtilsTests extends ESTestCase {
     private GeoPoint parseGeohash(String geohash, GeoUtils.EffectivePoint effectivePoint) throws IOException {
         try (XContentParser parser = createParser(jsonBuilder().startObject().field("geohash", geohash).endObject())) {
             parser.nextToken();
-            return GeoUtils.parseGeoPoint(parser, new GeoPoint(), randomBoolean(), effectivePoint);
+            return GeoUtils.parseGeoPoint(parser, randomBoolean(), effectivePoint);
         }
     }
 

--- a/server/src/test/java/org/elasticsearch/search/runtime/GeoPointScriptFieldDistanceFeatureQueryTests.java
+++ b/server/src/test/java/org/elasticsearch/search/runtime/GeoPointScriptFieldDistanceFeatureQueryTests.java
@@ -88,11 +88,9 @@ public class GeoPointScriptFieldDistanceFeatureQueryTests extends AbstractScript
                     searchLookup,
                     ctx
                 ) {
-                    final GeoPoint point = new GeoPoint();
-
                     @Override
                     public void execute() {
-                        GeoUtils.parseGeoPoint(searchLookup.source().get("location"), point, true);
+                        GeoPoint point = GeoUtils.parseGeoPoint(searchLookup.source().get("location"), true);
                         emit(point.lat(), point.lon());
                     }
                 };

--- a/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/common/CartesianPoint.java
+++ b/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/common/CartesianPoint.java
@@ -8,17 +8,16 @@
 package org.elasticsearch.xpack.spatial.common;
 
 import org.elasticsearch.ElasticsearchParseException;
+import org.elasticsearch.common.geo.GenericPointParser;
 import org.elasticsearch.common.xcontent.LoggingDeprecationHandler;
 import org.elasticsearch.geometry.Geometry;
 import org.elasticsearch.geometry.ShapeType;
 import org.elasticsearch.geometry.utils.StandardValidator;
 import org.elasticsearch.geometry.utils.WellKnownText;
 import org.elasticsearch.xcontent.NamedXContentRegistry;
-import org.elasticsearch.xcontent.ParseField;
 import org.elasticsearch.xcontent.ToXContentFragment;
 import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xcontent.XContentParser;
-import org.elasticsearch.xcontent.XContentSubParser;
 import org.elasticsearch.xcontent.support.MapXContentParser;
 import org.elasticsearch.xpack.spatial.index.mapper.PointFieldMapper;
 
@@ -32,9 +31,9 @@ import java.util.Objects;
  */
 public class CartesianPoint implements ToXContentFragment {
 
-    private static final ParseField X_FIELD = new ParseField("x");
-    private static final ParseField Y_FIELD = new ParseField("y");
-    private static final ParseField Z_FIELD = new ParseField("z");
+    private static final String X_FIELD = "x";
+    private static final String Y_FIELD = "y";
+    private static final String Z_FIELD = "z";
 
     protected double x;
     protected double y;
@@ -77,30 +76,30 @@ public class CartesianPoint implements ToXContentFragment {
             if (Double.isFinite(x) == false) {
                 throw new ElasticsearchParseException(
                     "invalid [{}] value [{}]; " + "must be between -3.4028234663852886E38 and 3.4028234663852886E38",
-                    X_FIELD.getPreferredName(),
+                    X_FIELD,
                     x
                 );
             }
         } catch (NumberFormatException ex) {
-            throw new ElasticsearchParseException("[{}]] must be a number", X_FIELD.getPreferredName());
+            throw new ElasticsearchParseException("[{}] must be a number", X_FIELD);
         }
         try {
             y = Double.parseDouble(vals[1].trim());
             if (Double.isFinite(y) == false) {
                 throw new ElasticsearchParseException(
                     "invalid [{}] value [{}]; " + "must be between -3.4028234663852886E38 and 3.4028234663852886E38",
-                    Y_FIELD.getPreferredName(),
+                    Y_FIELD,
                     y
                 );
             }
         } catch (NumberFormatException ex) {
-            throw new ElasticsearchParseException("[{}]] must be a number", Y_FIELD.getPreferredName());
+            throw new ElasticsearchParseException("[{}] must be a number", Y_FIELD);
         }
         if (vals.length > 2) {
             try {
                 CartesianPoint.assertZValue(ignoreZValue, Double.parseDouble(vals[2].trim()));
             } catch (NumberFormatException ex) {
-                throw new ElasticsearchParseException("[{}]] must be a number", Y_FIELD.getPreferredName());
+                throw new ElasticsearchParseException("[{}] must be a number", Y_FIELD);
             }
         }
         return reset(x, y);
@@ -157,124 +156,33 @@ public class CartesianPoint implements ToXContentFragment {
 
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
-        return builder.startObject().field(X_FIELD.getPreferredName(), x).field(Y_FIELD.getPreferredName(), y).endObject();
+        return builder.startObject().field(X_FIELD, x).field(Y_FIELD, y).endObject();
     }
 
-    public static CartesianPoint parsePoint(XContentParser parser, CartesianPoint point, boolean ignoreZvalue) throws IOException,
+    /**
+     * Parse a {@link CartesianPoint} with a {@link XContentParser}. A point has one of the following forms:
+     *
+     * <ul>
+     *     <li>Object: <pre>{&quot;x&quot;: <i>&lt;x-value&gt;</i>, &quot;y&quot;: <i>&lt;y-value&gt;</i>}</pre></li>
+     *     <li>Object: <pre>{&quot;type&quot;: <i>Point</i>, &quot;coordinates&quot;: <i>&lt;array of doubles&gt;</i>}</pre></li>
+     *     <li>String: <pre>&quot;<i>&lt;latitude&gt;</i>,<i>&lt;longitude&gt;</i>&quot;</pre></li>
+     *     <li>Array: <pre>[<i>&lt;x&gt;</i>,<i>&lt;y&gt;</i>]</pre></li>
+     * </ul>
+     *
+     * @param parser {@link XContentParser} to parse the value from
+     * @param ignoreZValue {@link XContentParser} to not throw an error if 3 dimensional data is provided
+     * @return new {@link CartesianPoint} parsed from the parser
+     */
+    public static CartesianPoint parsePoint(XContentParser parser, final boolean ignoreZValue) throws IOException,
         ElasticsearchParseException {
-        double x = Double.NaN;
-        double y = Double.NaN;
-        NumberFormatException numberFormatException = null;
-
-        if (parser.currentToken() == XContentParser.Token.START_OBJECT) {
-            try (XContentSubParser subParser = new XContentSubParser(parser)) {
-                while (subParser.nextToken() != XContentParser.Token.END_OBJECT) {
-                    if (subParser.currentToken() == XContentParser.Token.FIELD_NAME) {
-                        String field = subParser.currentName();
-                        if (field.equals(X_FIELD.getPreferredName())) {
-                            subParser.nextToken();
-                            switch (subParser.currentToken()) {
-                                case VALUE_NUMBER:
-                                case VALUE_STRING:
-                                    try {
-                                        x = subParser.doubleValue(true);
-                                    } catch (NumberFormatException e) {
-                                        numberFormatException = e;
-                                    }
-                                    break;
-                                default:
-                                    throw new ElasticsearchParseException("[{}] must be a number", X_FIELD.getPreferredName());
-                            }
-                        } else if (field.equals(Y_FIELD.getPreferredName())) {
-                            subParser.nextToken();
-                            switch (subParser.currentToken()) {
-                                case VALUE_NUMBER:
-                                case VALUE_STRING:
-                                    try {
-                                        y = subParser.doubleValue(true);
-                                    } catch (NumberFormatException e) {
-                                        numberFormatException = e;
-                                    }
-                                    break;
-                                default:
-                                    throw new ElasticsearchParseException("[{}] must be a number", Y_FIELD.getPreferredName());
-                            }
-                        } else if (field.equals(Z_FIELD.getPreferredName())) {
-                            subParser.nextToken();
-                            switch (subParser.currentToken()) {
-                                case VALUE_NUMBER:
-                                case VALUE_STRING:
-                                    try {
-                                        CartesianPoint.assertZValue(ignoreZvalue, subParser.doubleValue(true));
-                                    } catch (NumberFormatException e) {
-                                        numberFormatException = e;
-                                    }
-                                    break;
-                                default:
-                                    throw new ElasticsearchParseException("[{}] must be a number", Z_FIELD.getPreferredName());
-                            }
-                        } else {
-                            throw new ElasticsearchParseException(
-                                "field must be either [{}] or [{}]",
-                                X_FIELD.getPreferredName(),
-                                Y_FIELD.getPreferredName()
-                            );
-                        }
-                    } else {
-                        throw new ElasticsearchParseException("token [{}] not allowed", subParser.currentToken());
-                    }
-                }
-            }
-            if (numberFormatException != null) {
-                throw new ElasticsearchParseException(
-                    "[{}] and [{}] must be valid double values",
-                    numberFormatException,
-                    X_FIELD.getPreferredName(),
-                    Y_FIELD.getPreferredName()
-                );
-            } else if (Double.isNaN(x)) {
-                throw new ElasticsearchParseException("field [{}] missing", X_FIELD.getPreferredName());
-            } else if (Double.isNaN(y)) {
-                throw new ElasticsearchParseException("field [{}] missing", Y_FIELD.getPreferredName());
-            } else {
-                return point.reset(x, y);
-            }
-
-        } else if (parser.currentToken() == XContentParser.Token.START_ARRAY) {
-            try (XContentSubParser subParser = new XContentSubParser(parser)) {
-                int element = 0;
-                while (subParser.nextToken() != XContentParser.Token.END_ARRAY) {
-                    if (subParser.currentToken() == XContentParser.Token.VALUE_NUMBER) {
-                        element++;
-                        if (element == 1) {
-                            x = subParser.doubleValue();
-                        } else if (element == 2) {
-                            y = subParser.doubleValue();
-                        } else {
-                            throw new ElasticsearchParseException(
-                                "[{}}] field type does not accept > 2 dimensions",
-                                PointFieldMapper.CONTENT_TYPE
-                            );
-                        }
-                    } else {
-                        throw new ElasticsearchParseException("numeric value expected");
-                    }
-                }
-            }
-            return point.reset(x, y);
-        } else if (parser.currentToken() == XContentParser.Token.VALUE_STRING) {
-            String val = parser.text();
-            return point.resetFromString(val, ignoreZvalue);
-        } else {
-            throw new ElasticsearchParseException("point expected");
-        }
+        return cartesianPointParser.parsePoint(parser, ignoreZValue, value -> {
+            CartesianPoint point = new CartesianPoint();
+            point.resetFromString(value, ignoreZValue);
+            return point;
+        }, value -> null);
     }
 
     public static CartesianPoint parsePoint(Object value, boolean ignoreZValue) throws ElasticsearchParseException {
-        return parsePoint(value, new CartesianPoint(), ignoreZValue);
-    }
-
-    public static CartesianPoint parsePoint(Object value, CartesianPoint point, boolean ignoreZValue) throws ElasticsearchParseException {
         try (
             XContentParser parser = new MapXContentParser(
                 NamedXContentRegistry.EMPTY,
@@ -286,13 +194,13 @@ public class CartesianPoint implements ToXContentFragment {
             parser.nextToken(); // start object
             parser.nextToken(); // field name
             parser.nextToken(); // field value
-            return parsePoint(parser, point, ignoreZValue);
+            return parsePoint(parser, ignoreZValue);
         } catch (IOException ex) {
             throw new ElasticsearchParseException("error parsing point", ex);
         }
     }
 
-    public static double assertZValue(final boolean ignoreZValue, double zValue) {
+    public static void assertZValue(final boolean ignoreZValue, double zValue) {
         if (ignoreZValue == false) {
             throw new ElasticsearchParseException(
                 "Exception parsing coordinates: found Z value [{}] but [ignore_z_value] " + "parameter is [{}]",
@@ -303,10 +211,28 @@ public class CartesianPoint implements ToXContentFragment {
         if (Double.isFinite(zValue) == false) {
             throw new ElasticsearchParseException(
                 "invalid [{}] value [{}]; " + "must be between -3.4028234663852886E38 and 3.4028234663852886E38",
-                Z_FIELD.getPreferredName(),
+                Z_FIELD,
                 zValue
             );
         }
-        return zValue;
     }
+
+    private static GenericPointParser<CartesianPoint> cartesianPointParser = new GenericPointParser<>("point", "x", "y", false) {
+
+        @Override
+        public void assertZValue(boolean ignoreZValue, double zValue) {
+            CartesianPoint.assertZValue(ignoreZValue, zValue);
+        }
+
+        @Override
+        public CartesianPoint createPoint(double x, double y) {
+            return new CartesianPoint(x, y);
+        }
+
+        @Override
+        public String fieldError() {
+            return "field must be either lat/lon or type/coordinates";
+        }
+    };
+
 }

--- a/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/index/mapper/PointFieldMapper.java
+++ b/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/index/mapper/PointFieldMapper.java
@@ -10,12 +10,12 @@ import org.apache.lucene.document.StoredField;
 import org.apache.lucene.document.XYDocValuesField;
 import org.apache.lucene.document.XYPointField;
 import org.apache.lucene.search.Query;
-import org.elasticsearch.common.CheckedBiFunction;
 import org.elasticsearch.common.Explicit;
 import org.elasticsearch.common.geo.GeometryFormatterFactory;
 import org.elasticsearch.common.geo.ShapeRelation;
 import org.elasticsearch.common.logging.DeprecationCategory;
 import org.elasticsearch.common.logging.DeprecationLogger;
+import org.elasticsearch.core.CheckedFunction;
 import org.elasticsearch.geometry.Geometry;
 import org.elasticsearch.geometry.Point;
 import org.elasticsearch.index.mapper.AbstractPointGeometryFieldMapper;
@@ -35,7 +35,6 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
-import java.util.function.Supplier;
 
 /**
  * Field Mapper for point type.
@@ -79,8 +78,7 @@ public class PointFieldMapper extends AbstractPointGeometryFieldMapper<Cartesian
         }
 
         private static CartesianPoint parseNullValue(Object nullValue, boolean ignoreZValue, boolean ignoreMalformed) {
-            CartesianPoint point = new CartesianPoint();
-            CartesianPoint.parsePoint(nullValue, point, ignoreZValue);
+            CartesianPoint point = CartesianPoint.parsePoint(nullValue, ignoreZValue);
             if (ignoreMalformed == false) {
                 if (Double.isFinite(point.getX()) == false) {
                     throw new IllegalArgumentException("illegal x value [" + point.getX() + "]");
@@ -101,10 +99,13 @@ public class PointFieldMapper extends AbstractPointGeometryFieldMapper<Cartesian
                     "Adding multifields to [point] mappers has no effect and will be forbidden in future"
                 );
             }
-            CartesianPointParser parser = new CartesianPointParser(name, CartesianPoint::new, (p, point) -> {
-                CartesianPoint.parsePoint(p, point, ignoreZValue.get().value());
-                return point;
-            }, nullValue.get(), ignoreZValue.get().value(), ignoreMalformed.get().value());
+            CartesianPointParser parser = new CartesianPointParser(
+                name,
+                p -> CartesianPoint.parsePoint(p, ignoreZValue.get().value()),
+                nullValue.get(),
+                ignoreZValue.get().value(),
+                ignoreMalformed.get().value()
+            );
             PointFieldType ft = new PointFieldType(
                 context.buildFullName(name),
                 indexed.get(),
@@ -210,13 +211,12 @@ public class PointFieldMapper extends AbstractPointGeometryFieldMapper<Cartesian
 
         CartesianPointParser(
             String field,
-            Supplier<CartesianPoint> pointSupplier,
-            CheckedBiFunction<XContentParser, CartesianPoint, CartesianPoint, IOException> objectParser,
+            CheckedFunction<XContentParser, CartesianPoint, IOException> objectParser,
             CartesianPoint nullValue,
             boolean ignoreZValue,
             boolean ignoreMalformed
         ) {
-            super(field, pointSupplier, objectParser, nullValue, ignoreZValue, ignoreMalformed);
+            super(field, objectParser, nullValue, ignoreZValue, ignoreMalformed);
         }
 
         @Override
@@ -233,8 +233,8 @@ public class PointFieldMapper extends AbstractPointGeometryFieldMapper<Cartesian
         }
 
         @Override
-        protected void reset(CartesianPoint in, double x, double y) {
-            in.reset(x, y);
+        protected CartesianPoint createPoint(double x, double y) {
+            return new CartesianPoint(x, y);
         }
 
         @Override

--- a/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/index/mapper/CartesianFieldMapperTests.java
+++ b/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/index/mapper/CartesianFieldMapperTests.java
@@ -21,6 +21,7 @@ import java.io.IOException;
 import java.util.Collection;
 import java.util.Collections;
 
+import static org.elasticsearch.geometry.utils.Geohash.stringEncode;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
@@ -99,6 +100,13 @@ public abstract class CartesianFieldMapperTests extends MapperTestCase {
 
         assertThat(
             mapper.parse(source(b -> b.startObject(FIELD_NAME).field("x", 1.3).field("y", "-").endObject())).rootDoc().getField(FIELD_NAME),
+            nullValue()
+        );
+
+        assertThat(
+            mapper.parse(source(b -> b.startObject(FIELD_NAME).field("geohash", stringEncode(0, 0)).endObject()))
+                .rootDoc()
+                .getField(FIELD_NAME),
             nullValue()
         );
 

--- a/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/index/mapper/ShapeFieldMapperTests.java
+++ b/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/index/mapper/ShapeFieldMapperTests.java
@@ -6,12 +6,14 @@
  */
 package org.elasticsearch.xpack.spatial.index.mapper;
 
+import org.apache.lucene.document.ShapeField;
 import org.apache.lucene.index.IndexableField;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.geo.Orientation;
 import org.elasticsearch.index.mapper.DocumentMapper;
 import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.mapper.Mapper;
+import org.elasticsearch.index.mapper.MapperParsingException;
 import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.index.mapper.ParsedDocument;
 import org.elasticsearch.index.mapper.SourceToParse;
@@ -20,9 +22,11 @@ import org.elasticsearch.xcontent.ToXContent;
 import java.io.IOException;
 import java.util.Collections;
 
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.isA;
 
 /** testing for {@link org.elasticsearch.xpack.spatial.index.mapper.ShapeFieldMapper} */
 public class ShapeFieldMapperTests extends CartesianFieldMapperTests {
@@ -30,6 +34,20 @@ public class ShapeFieldMapperTests extends CartesianFieldMapperTests {
     @Override
     protected String getFieldName() {
         return "shape";
+    }
+
+    @Override
+    protected void assertXYPointField(IndexableField field, float x, float y) {
+        // TODO: ShapeField contains binary, perhaps we can decode the x/y from that
+        assertThat(field, isA(ShapeField.Triangle.class));
+    }
+
+    /** The GeoJSON parser used by 'geo_shape' has a more complex exception handling approach than for 'geo_point' or 'point' */
+    @Override
+    protected void assertGeoJSONParseException(MapperParsingException e, String missingField) {
+        assertThat(e.getMessage(), containsString("failed to parse"));
+        assertThat(e.getCause().getMessage(), containsString("Failed to build"));
+        assertThat(e.getCause().getCause().getMessage(), containsString(missingField + " not included"));
     }
 
     @Override


### PR DESCRIPTION
This is done by using a common parser with GeoPoint (and 'geo_point').

In addition, we refactored away the pattern of creating the point high
in the stack and modifying it deep in the stack. Instead, we create the
points low in the stack. This leads to much simpler code. There are a
few cases of increased object creation, but they seem very slight:

- The GeoBoundingBox class uses it to extract the bounds
- The GeoPointFieldScript used a shared point for repeated use

This PR enhanced the work done in https://github.com/elastic/elasticsearch/pull/85120