### PR TITLE
Update build convention dependencies

### DIFF
--- a/build-conventions/build.gradle
+++ b/build-conventions/build.gradle
@@ -63,10 +63,10 @@ repositories {
 
 dependencies {
     api 'org.apache.maven:maven-model:3.6.2'
-    api 'gradle.plugin.com.github.jengelman.gradle.plugins:shadow:7.0.0'
+    api 'gradle.plugin.com.github.johnrengelman:shadow:7.1.2'
     api 'org.apache.rat:apache-rat:0.11'
     compileOnly "com.puppycrawl.tools:checkstyle:9.3"
-    api('com.diffplug.spotless:spotless-plugin-gradle:6.0.0') {
+    api('com.diffplug.spotless:spotless-plugin-gradle:6.4.0') {
       exclude module: "groovy-xml"
     }
 }


### PR DESCRIPTION
- Update spotless to potentially fix invalid git worktree handling
- Update shadow plugin to be in sync with version used in build-tools