### PR TITLE
[ML] fix bug where certain trained model deployments failed with "Object cannot be set twice!"

### DIFF
--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/deployment/TrainedModelDeploymentTask.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/deployment/TrainedModelDeploymentTask.java
@@ -66,8 +66,9 @@ public class TrainedModelDeploymentTask extends CancellableTask implements Start
     }
 
     void init(InferenceConfig inferenceConfig) {
-        this.inferenceConfigHolder.set(inferenceConfig);
-        licensedFeature.startTracking(licenseState, "model-" + params.getModelId());
+        if (this.inferenceConfigHolder.trySet(inferenceConfig)) {
+            licensedFeature.startTracking(licenseState, "model-" + params.getModelId());
+        }
     }
 
     public String getModelId() {


### PR DESCRIPTION
When an allocation fails for a given model, we retry that allocation. We only do this in certain failure paths.

But, if an allocation makes it as far as setting the model config, we will attempt to set the model config again on the same task instance. This will throw a Lucene `Object cannot be set twice!` exception.

This commit addresses this bug by using a `trySet`, which is atomic and safe. And then starts tracking the model usage once the config is set. 