### PR TITLE
Disable dynamic mapping in Stack Monitoring index templates

### DIFF
--- a/x-pack/plugin/core/src/main/resources/monitoring-beats-mb.json
+++ b/x-pack/plugin/core/src/main/resources/monitoring-beats-mb.json
@@ -3,6 +3,7 @@
   "version": ${xpack.stack.monitoring.template.release.version},
   "template": {
     "mappings": {
+      "dynamic": false,
       "properties": {
         "beat": {
           "properties": {
@@ -2237,6 +2238,7 @@
       }
     },
     "settings": {
+      "index.mapping.total_fields.limit": 2000,
       "index.lifecycle.name": "${xpack.stack.monitoring.policy.name}"
     }
   },

--- a/x-pack/plugin/core/src/main/resources/monitoring-ent-search-mb.json
+++ b/x-pack/plugin/core/src/main/resources/monitoring-ent-search-mb.json
@@ -7,6 +7,7 @@
   },
   "template": {
     "mappings": {
+      "dynamic": false,
       "properties": {
         "enterprisesearch": {
           "properties": {
@@ -714,7 +715,8 @@
       }
     },
     "settings": {
-      "index.mapping.total_fields.limit": 2000
+      "index.mapping.total_fields.limit": 2000,
+      "index.lifecycle.name": "${xpack.stack.monitoring.policy.name}"
     }
   },
   "data_stream": {}

--- a/x-pack/plugin/core/src/main/resources/monitoring-es-mb.json
+++ b/x-pack/plugin/core/src/main/resources/monitoring-es-mb.json
@@ -3,6 +3,7 @@
   "version": ${xpack.stack.monitoring.template.release.version},
   "template": {
     "mappings": {
+      "dynamic": false,
       "properties": {
         "@timestamp": {
           "type": "date"

--- a/x-pack/plugin/core/src/main/resources/monitoring-kibana-mb.json
+++ b/x-pack/plugin/core/src/main/resources/monitoring-kibana-mb.json
@@ -3,6 +3,7 @@
   "version": ${xpack.stack.monitoring.template.release.version},
   "template": {
     "mappings": {
+      "dynamic": false,
       "properties": {
         "process": {
           "properties": {

--- a/x-pack/plugin/core/src/main/resources/monitoring-logstash-mb.json
+++ b/x-pack/plugin/core/src/main/resources/monitoring-logstash-mb.json
@@ -3,6 +3,7 @@
   "version": ${xpack.stack.monitoring.template.release.version},
   "template": {
     "mappings": {
+      "dynamic": false,
       "properties": {
         "logstash": {
           "properties": {

--- a/x-pack/plugin/monitoring/src/main/java/org/elasticsearch/xpack/monitoring/MonitoringTemplateRegistry.java
+++ b/x-pack/plugin/monitoring/src/main/java/org/elasticsearch/xpack/monitoring/MonitoringTemplateRegistry.java
@@ -78,7 +78,7 @@ public class MonitoringTemplateRegistry extends IndexTemplateRegistry {
      * writes monitoring data in ECS format as of 8.0. These templates define the ECS schema as well as alias fields for the old monitoring
      * mappings that point to the corresponding ECS fields.
      */
-    public static final int STACK_MONITORING_REGISTRY_VERSION = Version.V_8_0_0.id + 1;
+    public static final int STACK_MONITORING_REGISTRY_VERSION = Version.V_8_0_0.id + 2;
     private static final String STACK_MONITORING_REGISTRY_VERSION_VARIABLE = "xpack.stack.monitoring.template.release.version";
     private static final String STACK_TEMPLATE_VERSION = "8";
     private static final String STACK_TEMPLATE_VERSION_VARIABLE = "xpack.stack.monitoring.template.version";


### PR DESCRIPTION
This aligns the new Metricbeat templates with the settings found in the older
internal collection templates. By disabling dynamic mapping we avoid the
possible field explosion that can happen for example when there are lots of
nodes in the Elasticsearch cluster stats response which could easily blow past
the 2 000 field limit.

This commit also adds the missing ILM policy to the Enterprise search mappings.