### PR TITLE
Support vector tile buffer in REST API

### DIFF
--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/vector-tile/10_basic.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/vector-tile/10_basic.yml
@@ -53,6 +53,18 @@ setup:
           extent: 256
 
 ---
+"buffer param":
+  - do:
+      search_mvt:
+        index: locations
+        field: location
+        x: 0
+        y: 0
+        zoom: 0
+        body:
+          buffer: 10
+
+---
 "exact bounds":
   - do:
       search_mvt:

--- a/x-pack/plugin/vector-tile/src/main/java/org/elasticsearch/xpack/vectortile/rest/RestVectorTileAction.java
+++ b/x-pack/plugin/vector-tile/src/main/java/org/elasticsearch/xpack/vectortile/rest/RestVectorTileAction.java
@@ -16,7 +16,6 @@ import org.elasticsearch.client.internal.node.NodeClient;
 import org.elasticsearch.common.document.DocumentField;
 import org.elasticsearch.common.geo.GeoBoundingBox;
 import org.elasticsearch.common.geo.GeoPoint;
-import org.elasticsearch.common.geo.SimpleVectorTileFormatter;
 import org.elasticsearch.common.io.Streams;
 import org.elasticsearch.common.io.stream.BytesStream;
 import org.elasticsearch.geometry.Rectangle;
@@ -116,7 +115,7 @@ public class RestVectorTileAction extends BaseRestHandler {
                         request.getX(),
                         request.getY(),
                         request.getExtent(),
-                        SimpleVectorTileFormatter.DEFAULT_BUFFER_PIXELS
+                        request.getBuffer()
                     );
                     final InternalGeoGrid<?> grid = searchResponse.getAggregations() != null
                         ? searchResponse.getAggregations().get(GRID_FIELD)
@@ -177,12 +176,8 @@ public class RestVectorTileAction extends BaseRestHandler {
         searchRequestBuilder.setSize(request.getSize());
         searchRequestBuilder.setFetchSource(false);
         searchRequestBuilder.setTrackTotalHitsUpTo(request.getTrackTotalHitsUpTo());
-        searchRequestBuilder.addFetchField(
-            new FieldAndFormat(
-                request.getField(),
-                "mvt(" + request.getZ() + "/" + request.getX() + "/" + request.getY() + "@" + request.getExtent() + ")"
-            )
-        );
+        String args = request.getZ() + "/" + request.getX() + "/" + request.getY() + "@" + request.getExtent() + ":" + request.getBuffer();
+        searchRequestBuilder.addFetchField(new FieldAndFormat(request.getField(), "mvt(" + args + ")"));
         for (FieldAndFormat field : request.getFieldAndFormats()) {
             searchRequestBuilder.addFetchField(field);
         }

--- a/x-pack/plugin/vector-tile/src/test/java/org/elasticsearch/xpack/vectortile/rest/VectorTileRequestTests.java
+++ b/x-pack/plugin/vector-tile/src/test/java/org/elasticsearch/xpack/vectortile/rest/VectorTileRequestTests.java
@@ -50,6 +50,7 @@ public class VectorTileRequestTests extends ESTestCase {
         assertRestRequest((builder) -> {}, (vectorTileRequest) -> {
             assertThat(vectorTileRequest.getSize(), Matchers.equalTo(VectorTileRequest.Defaults.SIZE));
             assertThat(vectorTileRequest.getExtent(), Matchers.equalTo(VectorTileRequest.Defaults.EXTENT));
+            assertThat(vectorTileRequest.getBuffer(), Matchers.equalTo(VectorTileRequest.Defaults.BUFFER));
             assertThat(vectorTileRequest.getAggBuilder(), Matchers.equalTo(VectorTileRequest.Defaults.AGGS));
             assertThat(vectorTileRequest.getFieldAndFormats(), Matchers.equalTo(VectorTileRequest.Defaults.FETCH));
             assertThat(vectorTileRequest.getGridAgg(), Matchers.equalTo(VectorTileRequest.Defaults.GRID_AGG));
@@ -65,20 +66,20 @@ public class VectorTileRequestTests extends ESTestCase {
     public void testFieldSize() throws IOException {
         final int size = randomIntBetween(0, 10000);
         assertRestRequest(
-            (builder) -> { builder.field(SearchSourceBuilder.SIZE_FIELD.getPreferredName(), size); },
-            (vectorTileRequest) -> { assertThat(vectorTileRequest.getSize(), Matchers.equalTo(size)); }
+            (builder) -> builder.field(SearchSourceBuilder.SIZE_FIELD.getPreferredName(), size),
+            (vectorTileRequest) -> assertThat(vectorTileRequest.getSize(), Matchers.equalTo(size))
         );
     }
 
     public void testFieldTrackTotalHitsAsBoolean() throws IOException {
         assertRestRequest(
-            (builder) -> { builder.field(SearchSourceBuilder.TRACK_TOTAL_HITS_FIELD.getPreferredName(), true); },
+            (builder) -> builder.field(SearchSourceBuilder.TRACK_TOTAL_HITS_FIELD.getPreferredName(), true),
             (vectorTileRequest) -> {
                 assertThat(vectorTileRequest.getTrackTotalHitsUpTo(), Matchers.equalTo(SearchContext.TRACK_TOTAL_HITS_ACCURATE));
             }
         );
         assertRestRequest(
-            (builder) -> { builder.field(SearchSourceBuilder.TRACK_TOTAL_HITS_FIELD.getPreferredName(), false); },
+            (builder) -> builder.field(SearchSourceBuilder.TRACK_TOTAL_HITS_FIELD.getPreferredName(), false),
             (vectorTileRequest) -> {
                 assertThat(vectorTileRequest.getTrackTotalHitsUpTo(), Matchers.equalTo(SearchContext.TRACK_TOTAL_HITS_DISABLED));
             }
@@ -88,23 +89,31 @@ public class VectorTileRequestTests extends ESTestCase {
     public void testFieldTrackTotalHitsAsInt() throws IOException {
         final int trackTotalHits = randomIntBetween(1, 10000);
         assertRestRequest(
-            (builder) -> { builder.field(SearchSourceBuilder.TRACK_TOTAL_HITS_FIELD.getPreferredName(), trackTotalHits); },
-            (vectorTileRequest) -> { assertThat(vectorTileRequest.getTrackTotalHitsUpTo(), Matchers.equalTo(trackTotalHits)); }
+            (builder) -> builder.field(SearchSourceBuilder.TRACK_TOTAL_HITS_FIELD.getPreferredName(), trackTotalHits),
+            (vectorTileRequest) -> assertThat(vectorTileRequest.getTrackTotalHitsUpTo(), Matchers.equalTo(trackTotalHits))
         );
     }
 
     public void testFieldExtent() throws IOException {
         final int extent = randomIntBetween(256, 8192);
         assertRestRequest(
-            (builder) -> { builder.field(VectorTileRequest.EXTENT_FIELD.getPreferredName(), extent); },
-            (vectorTileRequest) -> { assertThat(vectorTileRequest.getExtent(), Matchers.equalTo(extent)); }
+            (builder) -> builder.field(VectorTileRequest.EXTENT_FIELD.getPreferredName(), extent),
+            (vectorTileRequest) -> assertThat(vectorTileRequest.getExtent(), Matchers.equalTo(extent))
+        );
+    }
+
+    public void testFieldBuffer() throws IOException {
+        final int buffer = randomIntBetween(0, VectorTileRequest.Defaults.EXTENT - 1);
+        assertRestRequest(
+            (builder) -> builder.field(VectorTileRequest.BUFFER_FIELD.getPreferredName(), buffer),
+            (vectorTileRequest) -> assertThat(vectorTileRequest.getBuffer(), Matchers.equalTo(buffer))
         );
     }
 
     public void testFieldFetch() throws IOException {
         final String fetchField = randomAlphaOfLength(10);
         assertRestRequest(
-            (builder) -> { builder.field(SearchSourceBuilder.FETCH_FIELDS_FIELD.getPreferredName(), new String[] { fetchField }); },
+            (builder) -> builder.field(SearchSourceBuilder.FETCH_FIELDS_FIELD.getPreferredName(), new String[] { fetchField }),
             (vectorTileRequest) -> {
                 assertThat(vectorTileRequest.getFieldAndFormats(), Matchers.iterableWithSize(1));
                 assertThat(vectorTileRequest.getFieldAndFormats().get(0).field, Matchers.equalTo(fetchField));
@@ -115,32 +124,32 @@ public class VectorTileRequestTests extends ESTestCase {
     public void testFieldGridAgg() throws IOException {
         final GridAggregation grid_agg = RandomPicks.randomFrom(random(), GridAggregation.values());
         assertRestRequest(
-            (builder) -> { builder.field(VectorTileRequest.GRID_AGG_FIELD.getPreferredName(), grid_agg.name()); },
-            (vectorTileRequest) -> { assertThat(vectorTileRequest.getGridAgg(), Matchers.equalTo(grid_agg)); }
+            (builder) -> builder.field(VectorTileRequest.GRID_AGG_FIELD.getPreferredName(), grid_agg.name()),
+            (vectorTileRequest) -> assertThat(vectorTileRequest.getGridAgg(), Matchers.equalTo(grid_agg))
         );
     }
 
     public void testFieldGridType() throws IOException {
         final GridType grid_type = RandomPicks.randomFrom(random(), GridType.values());
         assertRestRequest(
-            (builder) -> { builder.field(VectorTileRequest.GRID_TYPE_FIELD.getPreferredName(), grid_type.name()); },
-            (vectorTileRequest) -> { assertThat(vectorTileRequest.getGridType(), Matchers.equalTo(grid_type)); }
+            (builder) -> builder.field(VectorTileRequest.GRID_TYPE_FIELD.getPreferredName(), grid_type.name()),
+            (vectorTileRequest) -> assertThat(vectorTileRequest.getGridType(), Matchers.equalTo(grid_type))
         );
     }
 
     public void testFieldGridPrecision() throws IOException {
         final int grid_precision = randomIntBetween(1, 8);
         assertRestRequest(
-            (builder) -> { builder.field(VectorTileRequest.GRID_PRECISION_FIELD.getPreferredName(), grid_precision); },
-            (vectorTileRequest) -> { assertThat(vectorTileRequest.getGridPrecision(), Matchers.equalTo(grid_precision)); }
+            (builder) -> builder.field(VectorTileRequest.GRID_PRECISION_FIELD.getPreferredName(), grid_precision),
+            (vectorTileRequest) -> assertThat(vectorTileRequest.getGridPrecision(), Matchers.equalTo(grid_precision))
         );
     }
 
     public void testFieldExactBounds() throws IOException {
         final boolean exactBounds = randomBoolean();
         assertRestRequest(
-            (builder) -> { builder.field(VectorTileRequest.EXACT_BOUNDS_FIELD.getPreferredName(), exactBounds); },
-            (vectorTileRequest) -> { assertThat(vectorTileRequest.getExactBounds(), Matchers.equalTo(exactBounds)); }
+            (builder) -> builder.field(VectorTileRequest.EXACT_BOUNDS_FIELD.getPreferredName(), exactBounds),
+            (vectorTileRequest) -> assertThat(vectorTileRequest.getExactBounds(), Matchers.equalTo(exactBounds))
         );
     }
 
@@ -149,7 +158,7 @@ public class VectorTileRequestTests extends ESTestCase {
         assertRestRequest((builder) -> {
             builder.field(SearchSourceBuilder.QUERY_FIELD.getPreferredName());
             queryBuilder.toXContent(builder, ToXContent.EMPTY_PARAMS);
-        }, (vectorTileRequest) -> { assertThat(vectorTileRequest.getQueryBuilder(), Matchers.equalTo(queryBuilder)); });
+        }, (vectorTileRequest) -> assertThat(vectorTileRequest.getQueryBuilder(), Matchers.equalTo(queryBuilder)));
     }
 
     public void testFieldAgg() throws IOException {


### PR DESCRIPTION
In a previous PR https://github.com/elastic/elasticsearch/pull/84710
we supported the configurable buffer for field formatting in the mvt() function, but not in the REST API.
This commit adds the missing piece.

Closes https://github.com/elastic/elasticsearch/issues/84492