### PR TITLE
Added buffer to vector tile REST API docs

### DIFF
--- a/docs/reference/search/search-vector-tile-api.asciidoc
+++ b/docs/reference/search/search-vector-tile-api.asciidoc
@@ -202,6 +202,13 @@ larger than the vector tile.
 square with equal sides. Defaults to `4096`.
 // end::extent-param[]
 
+// tag::buffer-param[]
+`buffer`::
+(Optional, integer) Size, in pixels, of a clipping buffer outside the tile.
+This allows renderers to avoid outline artifacts from geometries that extend past the extent of the tile.
+Defaults to `5`.
+// end::buffer-param[]
+
 // tag::grid-agg[]
 `grid_agg`::
 (Optional, string) Aggregation used to create a grid for the `<field>`.
@@ -374,6 +381,8 @@ for internal aggregations.
 include::search-vector-tile-api.asciidoc[tag=exact-bounds]
 
 include::search-vector-tile-api.asciidoc[tag=extent-param]
+
+include::search-vector-tile-api.asciidoc[tag=buffer-param]
 
 `fields`::
 (Optional, array of strings and objects) Fields to return in the `hits` layer.


### PR DESCRIPTION
This adds some basic API docs for the enhancement added in https://github.com/elastic/elasticsearch/pull/85450

https://elasticsearch_85460.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/search-vector-tile-api.html