### PR TITLE
[8.1] Do not fail on duplicated content field filters (#85382)

### DIFF
--- a/docs/changelog/85382.yaml
+++ b/docs/changelog/85382.yaml
@@ -1,0 +1,5 @@
+pr: 85382
+summary: Do not fail on duplicated content field filters
+area: Mapping
+type: bug
+issues: []

--- a/libs/x-content/src/test/java/org/elasticsearch/xcontent/support/filtering/AbstractXContentFilteringTestCase.java
+++ b/libs/x-content/src/test/java/org/elasticsearch/xcontent/support/filtering/AbstractXContentFilteringTestCase.java
@@ -20,6 +20,7 @@ import org.elasticsearch.xcontent.XContentType;
 
 import java.io.IOException;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Set;
 import java.util.stream.IntStream;
 
@@ -324,8 +325,9 @@ public abstract class AbstractXContentFilteringTestCase extends AbstractFilterin
     }
 
     @Override
-    protected final void testFilter(Builder expected, Builder sample, Set<String> includes, Set<String> excludes) throws IOException {
-        testFilter(expected, sample, includes, excludes, false);
+    protected final void testFilter(Builder expected, Builder sample, Collection<String> includes, Collection<String> excludes)
+        throws IOException {
+        testFilter(expected, sample, Set.copyOf(includes), Set.copyOf(excludes), false);
     }
 
     private void testFilter(Builder expected, Builder sample, Set<String> includes, Set<String> excludes, boolean matchFieldNamesWithDots)

--- a/server/src/main/java/org/elasticsearch/common/xcontent/XContentFieldFilter.java
+++ b/server/src/main/java/org/elasticsearch/common/xcontent/XContentFieldFilter.java
@@ -73,8 +73,8 @@ public interface XContentFieldFilter {
             };
         } else {
             final XContentParserConfiguration parserConfig = XContentParserConfiguration.EMPTY.withFiltering(
-                Set.of(includes),
-                Set.of(excludes),
+                Set.copyOf(Arrays.asList(includes)),
+                Set.copyOf(Arrays.asList(excludes)),
                 true
             );
             return (originalSource, contentType) -> {

--- a/server/src/test/java/org/elasticsearch/common/xcontent/support/XContentMapValuesTests.java
+++ b/server/src/test/java/org/elasticsearch/common/xcontent/support/XContentMapValuesTests.java
@@ -22,11 +22,11 @@ import org.hamcrest.Matchers;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 
 import static org.elasticsearch.common.xcontent.XContentHelper.convertToMap;
 import static org.elasticsearch.common.xcontent.XContentHelper.toXContent;
@@ -44,7 +44,8 @@ import static org.hamcrest.core.IsEqual.equalTo;
 public class XContentMapValuesTests extends AbstractFilteringTestCase {
 
     @Override
-    protected void testFilter(Builder expected, Builder actual, Set<String> includes, Set<String> excludes) throws IOException {
+    protected void testFilter(Builder expected, Builder actual, Collection<String> includes, Collection<String> excludes)
+        throws IOException {
         final XContentType xContentType = randomFrom(XContentType.values());
         final boolean humanReadable = randomBoolean();
 

--- a/test/framework/src/main/java/org/elasticsearch/common/xcontent/support/AbstractFilteringTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/common/xcontent/support/AbstractFilteringTestCase.java
@@ -26,6 +26,7 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.net.URISyntaxException;
 import java.nio.charset.StandardCharsets;
+import java.util.Collection;
 import java.util.Set;
 
 import static java.util.Collections.emptySet;
@@ -41,7 +42,8 @@ public abstract class AbstractFilteringTestCase extends ESTestCase {
     @FunctionalInterface
     protected interface Builder extends CheckedFunction<XContentBuilder, XContentBuilder, IOException> {}
 
-    protected abstract void testFilter(Builder expected, Builder actual, Set<String> includes, Set<String> excludes) throws IOException;
+    protected abstract void testFilter(Builder expected, Builder actual, Collection<String> includes, Collection<String> excludes)
+        throws IOException;
 
     /** Sample test case */
     protected static final Builder SAMPLE = builderFor("sample.json");


### PR DESCRIPTION
Backports the following commits to 8.1:
 - Do not fail on duplicated content field filters (#85382)