### PR TITLE
[DOCS] Add readiness listener documentation

### DIFF
--- a/docs/reference/setup/advanced-configuration.asciidoc
+++ b/docs/reference/setup/advanced-configuration.asciidoc
@@ -159,10 +159,10 @@ If configured, a node can open a TCP port when the node is in a ready state. A n
 ready when it has successfully joined a cluster. In a single node configuration, the node is
 said to be ready, when it's able to accept requests.
 
-The readiness TCP port can be configured through the `readiness.port` setting and it is
-always bound to the loopback address. By default, the IPv4 loopback address of `127.0.0.1`
-is used. If you wish to bind the readiness port to the IPv6 loopback address of `::1`,
-you should add `-Djava.net.preferIPv6Addresses=true` to the <<set-jvm-options,JVM options>>.
+To enable the readiness TCP port, use the `readiness.port` setting. The port is
+always bound to the loopback address, which defaults to the IPv4 loopback address`127.0.0.1`.
+To bind the readiness port to the IPv6 loopback address `::1`,
+add `-Djava.net.preferIPv6Addresses=true` to the <<set-jvm-options,JVM options>>.
 
 If the node leaves the cluster, or the <<put-shutdown,Shutdown API>> is used to mark the node
 for shutdown, the readiness port is immediately closed.

--- a/docs/reference/setup/advanced-configuration.asciidoc
+++ b/docs/reference/setup/advanced-configuration.asciidoc
@@ -53,7 +53,7 @@ or a range of versions followed by a colon.
 -------------------------------------
 +
 To apply a setting to a specific version and any later versions,
-omit the upper bound of the range. 
+omit the upper bound of the range.
 For example, this setting applies to Java 8 and later:
 +
 [source,text]
@@ -69,7 +69,7 @@ as valid JVM arguments are rejected and {es} will fail to start.
 ===== Use environment variables to set JVM options
 
 In production, use JVM options files to override the
-default settings. In testing and development environments, 
+default settings. In testing and development environments,
 you can also set JVM options through the `ES_JAVA_OPTS` environment variable.
 
 [source,sh]
@@ -149,3 +149,25 @@ options. We do not recommend using `ES_JAVA_OPTS` in production.
 
 NOTE: If you are running {es} as a Windows service, you can change the heap size
 using the service manager. See <<windows-service>>.
+
+[[readiness-tcp-port]]
+===== Enable the Elasticsearch TCP readiness port
+
+NOTE: This feature is currently experimental for internal use by Elastic software only.
+
+If configured, a node can open a TCP port when the node is in a ready state. A node is deemed
+ready when it has successfully joined a cluster. In a single node configuration, the node is
+said to be ready, when it's able to accept requests.
+
+The readiness TCP port can be configured through the `readiness.port` setting and it is
+always bound to the loopback address. By default, the IPv4 loopback address of `127.0.0.1`
+is used. If you wish to bind the readiness port to the IPv6 loopback address of `::1`,
+you should add `-Djava.net.preferIPv6Addresses=true` to the <<set-jvm-options,JVM options>>.
+
+If the node leaves the cluster, or the <<put-shutdown,Shutdown API>> is used to mark the node
+for shutdown, the readiness port is immediately closed.
+
+When clients connect to the readiness TCP port, no data is sent back to the client, the server
+simply terminates the socket connection. A successful connection on the configured TCP port
+signals that the Elasticsearch node is ready, while not being able to connect means that the node
+is not ready.

--- a/docs/reference/setup/advanced-configuration.asciidoc
+++ b/docs/reference/setup/advanced-configuration.asciidoc
@@ -167,7 +167,7 @@ you should add `-Djava.net.preferIPv6Addresses=true` to the <<set-jvm-options,JV
 If the node leaves the cluster, or the <<put-shutdown,Shutdown API>> is used to mark the node
 for shutdown, the readiness port is immediately closed.
 
-When clients connect to the readiness TCP port, no data is sent back to the client, the server
-simply terminates the socket connection. A successful connection on the configured TCP port
-signals that the Elasticsearch node is ready, while not being able to connect means that the node
-is not ready.
+A successful connection to the readiness TCP port signals that the {es} node is ready. When a client connects to the readiness port, the server simply terminates the socket connection. No data is sent back to the client. 
+If a client cannot connect to the readiness port, the node is not ready.
+
+

--- a/docs/reference/setup/advanced-configuration.asciidoc
+++ b/docs/reference/setup/advanced-configuration.asciidoc
@@ -153,21 +153,24 @@ using the service manager. See <<windows-service>>.
 [[readiness-tcp-port]]
 ===== Enable the Elasticsearch TCP readiness port
 
-preview::["This functionality is in technical preview and may be changed or removed in a future release. It is intended for internal, experimental use. Features in technical preview are not subject to the support SLA of official GA features."]
+preview::["This functionality is in technical preview and may be changed or removed in a future release.
+It is intended for internal, experimental use. Features in technical preview are not subject to the support
+SLA of official GA features."]
 
 If configured, a node can open a TCP port when the node is in a ready state. A node is deemed
 ready when it has successfully joined a cluster. In a single node configuration, the node is
 said to be ready, when it's able to accept requests.
 
 To enable the readiness TCP port, use the `readiness.port` setting. The port is
-always bound to the loopback address, which defaults to the IPv4 loopback address`127.0.0.1`.
+always bound to the loopback address, which defaults to the IPv4 loopback address `127.0.0.1`.
 To bind the readiness port to the IPv6 loopback address `::1`,
 add `-Djava.net.preferIPv6Addresses=true` to the <<set-jvm-options,JVM options>>.
 
 If the node leaves the cluster, or the <<put-shutdown,Shutdown API>> is used to mark the node
 for shutdown, the readiness port is immediately closed.
 
-A successful connection to the readiness TCP port signals that the {es} node is ready. When a client connects to the readiness port, the server simply terminates the socket connection. No data is sent back to the client. 
-If a client cannot connect to the readiness port, the node is not ready.
+A successful connection to the readiness TCP port signals that the {es} node is ready. When a client
+connects to the readiness port, the server simply terminates the socket connection. No data is sent back
+to the client. If a client cannot connect to the readiness port, the node is not ready.
 
 

--- a/docs/reference/setup/advanced-configuration.asciidoc
+++ b/docs/reference/setup/advanced-configuration.asciidoc
@@ -153,7 +153,7 @@ using the service manager. See <<windows-service>>.
 [[readiness-tcp-port]]
 ===== Enable the Elasticsearch TCP readiness port
 
-NOTE: This feature is currently experimental for internal use by Elastic software only.
+preview::["This functionality is in technical preview and may be changed or removed in a future release. It is intended for internal, experimental use. Features in technical preview are not subject to the support SLA of official GA features."]
 
 If configured, a node can open a TCP port when the node is in a ready state. A node is deemed
 ready when it has successfully joined a cluster. In a single node configuration, the node is


### PR DESCRIPTION
This PR adds documentation on the experimental TCP readiness port listener.

I added the docs for this feature under the Advanced Configuration section, since the feature is for now intended for internal Elasticsearch use and not on by default.

Relates to https://github.com/elastic/elasticsearch/pull/84375