### PR TITLE
[ML] disallow new trained model deployments when nodes are different versions

### DIFF
--- a/docs/changelog/85465.yaml
+++ b/docs/changelog/85465.yaml
@@ -1,0 +1,5 @@
+pr: 85465
+summary: Disallow new trained model deployments when nodes are different versions
+area: Machine Learning
+type: bug
+issues: []

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportStartTrainedModelDeploymentAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportStartTrainedModelDeploymentAction.java
@@ -154,7 +154,7 @@ public class TransportStartTrainedModelDeploymentAction extends TransportMasterN
         if (state.nodes().getMaxNodeVersion().after(state.nodes().getMinNodeVersion())) {
             listener.onFailure(
                 new ElasticsearchStatusException(
-                    "Cannot not start a new model deployment as not all nodes are on version {}. All nodes must be the same version",
+                    "Cannot start a new model deployment as not all nodes are on version {}. All nodes must be the same version",
                     RestStatus.FORBIDDEN,
                     state.getNodes().getMaxNodeVersion()
                 )

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportStartTrainedModelDeploymentAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportStartTrainedModelDeploymentAction.java
@@ -151,6 +151,17 @@ public class TransportStartTrainedModelDeploymentAction extends TransportMasterN
             return;
         }
 
+        if (state.nodes().getMaxNodeVersion().after(state.nodes().getMinNodeVersion())) {
+            listener.onFailure(
+                new ElasticsearchStatusException(
+                    "Cannot not start a new model deployment as not all nodes are on version {}. All nodes must be the same version",
+                    RestStatus.FORBIDDEN,
+                    state.getNodes().getMaxNodeVersion()
+                )
+            );
+            return;
+        }
+
         if (TrainedModelAllocationMetadata.fromState(state).modelAllocations().size() >= MachineLearning.MAX_TRAINED_MODEL_DEPLOYMENTS) {
             listener.onFailure(
                 new ElasticsearchStatusException(


### PR DESCRIPTION
Since trained model deployments are experimental. Backwards compatibility is not always guaranteed between versions. 

To protect users, this commit disallows new deployments to be created in a mixed versioned cluster environment.