### PR TITLE
[7.17] test: timezone with data_histogram and composite date_histogram (#85176)

### DIFF
--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.aggregation/230_composite.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.aggregation/230_composite.yml
@@ -61,6 +61,18 @@ setup:
                   type: integer
 
   - do:
+      indices.create:
+        index: date_histogram_timezone_test
+        body:
+          settings:
+            number_of_replicas: 0
+          mappings:
+            properties:
+              date:
+                type: date
+                format: "yyyy-MM-dd HH:mm:ss"
+
+  - do:
       index:
         index: nonesting
         id:    "1"
@@ -199,8 +211,34 @@ setup:
         body:  { "date": "2017-10-20T03:08:45" }
 
   - do:
+      bulk:
+        index: date_histogram_timezone_test
+        refresh: true
+        body:
+          - { "index": { } }
+          - { "date": "2021-05-01 20:00:00" }
+          - { "index": { } }
+          - { "date": "2021-05-01 21:30:00" }
+          - { "index": { } }
+          - { "date": "2021-05-01 23:54:00" }
+          - { "index": { } }
+          - { "date": "2021-05-01 23:40:00" }
+          - { "index": { } }
+          - { "date": "2021-05-01 22:20:00" }
+          - { "index": { } }
+          - { "date": "2021-05-01 21:20:00" }
+          - { "index": { } }
+          - { "date": "2021-05-01 23:50:00" }
+          - { "index": { } }
+          - { "date": "2021-05-01 22:15:00" }
+          - { "index": { } }
+          - { "date": "2021-05-01 22:40:00" }
+          - { "index": { } }
+          - { "date": "2021-05-01 22:20:00" }
+
+  - do:
       indices.refresh:
-        index: [test, other, verynested, nonesting]
+        index: [test, other, verynested, nonesting, date_histogram_timezone_test]
 
 ---
 "Simple Composite aggregation":
@@ -1534,3 +1572,61 @@ setup:
   - match: { aggregations.test.buckets.2.key.long: null}
   - match: { aggregations.test.buckets.2.key.kw: null }
   - match: { aggregations.test.buckets.2.doc_count: 2 }
+
+---
+"date_histogram and date_histogram_composite timezone":
+  - skip:
+      version: " - 7.16.99"
+      reason: bug fixed somewhere between 7.2 and 7.17
+  - do:
+      search:
+        index: date_histogram_timezone_test
+        body:
+          size: 0
+          aggs:
+            date_histogram_yes_tz:
+              composite:
+                size: 20
+                sources:
+                  - datefield:
+                      date_histogram:
+                        field: date
+                        format: "yyyy-MM-dd HH:mm:ss"
+                        calendar_interval: hour
+                        time_zone: Asia/Jakarta
+            date_histogram_no__tz:
+              composite:
+                size: 20
+                sources:
+                  - datefield:
+                      date_histogram:
+                        field: date
+                        format: "yyyy-MM-dd HH:mm:ss"
+                        calendar_interval: hour
+
+  - match: { hits.total.value: 10 }
+  - match:  { hits.total.relation: "eq" }
+
+  - match:  { aggregations.date_histogram_yes_tz.buckets.0.key.datefield: "2021-05-02 03:00:00" }
+  - match:  { aggregations.date_histogram_no__tz.buckets.0.key.datefield: "2021-05-01 20:00:00" }
+
+  - match:  { aggregations.date_histogram_yes_tz.buckets.1.key.datefield: "2021-05-02 04:00:00" }
+  - match:  { aggregations.date_histogram_no__tz.buckets.1.key.datefield: "2021-05-01 21:00:00" }
+
+  - match:  { aggregations.date_histogram_yes_tz.buckets.2.key.datefield: "2021-05-02 05:00:00" }
+  - match:  { aggregations.date_histogram_no__tz.buckets.2.key.datefield: "2021-05-01 22:00:00" }
+
+  - match:  { aggregations.date_histogram_yes_tz.buckets.3.key.datefield: "2021-05-02 06:00:00" }
+  - match:  { aggregations.date_histogram_no__tz.buckets.3.key.datefield: "2021-05-01 23:00:00" }
+
+  - length: { aggregations.date_histogram_yes_tz.buckets: 4 }
+  - match:  { aggregations.date_histogram_yes_tz.buckets.0.doc_count: 1 }
+  - match:  { aggregations.date_histogram_yes_tz.buckets.1.doc_count: 2 }
+  - match:  { aggregations.date_histogram_yes_tz.buckets.2.doc_count: 4 }
+  - match:  { aggregations.date_histogram_yes_tz.buckets.3.doc_count: 3 }
+
+  - length: { aggregations.date_histogram_no__tz.buckets: 4 }
+  - match:  { aggregations.date_histogram_no__tz.buckets.0.doc_count: 1 }
+  - match:  { aggregations.date_histogram_no__tz.buckets.1.doc_count: 2 }
+  - match:  { aggregations.date_histogram_no__tz.buckets.2.doc_count: 4 }
+  - match:  { aggregations.date_histogram_no__tz.buckets.3.doc_count: 3 }

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.aggregation/230_composite.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.aggregation/230_composite.yml
@@ -70,7 +70,7 @@ setup:
             properties:
               date:
                 type: date
-                format: "yyyy-MM-dd HH:mm:ss"
+                format: "YYYY-MM-dd HH:mm:ss"
 
   - do:
       index:
@@ -1591,7 +1591,7 @@ setup:
                   - datefield:
                       date_histogram:
                         field: date
-                        format: "yyyy-MM-dd HH:mm:ss"
+                        format: "YYYY-MM-dd HH:mm:ss"
                         calendar_interval: hour
                         time_zone: Asia/Jakarta
             date_histogram_no__tz:
@@ -1601,7 +1601,7 @@ setup:
                   - datefield:
                       date_histogram:
                         field: date
-                        format: "yyyy-MM-dd HH:mm:ss"
+                        format: "YYYY-MM-dd HH:mm:ss"
                         calendar_interval: hour
 
   - match: { hits.total.value: 10 }

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.aggregation/230_composite.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.aggregation/230_composite.yml
@@ -70,7 +70,7 @@ setup:
             properties:
               date:
                 type: date
-                format: "YYYY-MM-dd HH:mm:ss"
+                format: "8yyyy-MM-dd HH:mm:ss"
 
   - do:
       index:
@@ -1591,7 +1591,7 @@ setup:
                   - datefield:
                       date_histogram:
                         field: date
-                        format: "YYYY-MM-dd HH:mm:ss"
+                        format: "8yyyy-MM-dd HH:mm:ss"
                         calendar_interval: hour
                         time_zone: Asia/Jakarta
             date_histogram_no__tz:
@@ -1601,7 +1601,7 @@ setup:
                   - datefield:
                       date_histogram:
                         field: date
-                        format: "YYYY-MM-dd HH:mm:ss"
+                        format: "8yyyy-MM-dd HH:mm:ss"
                         calendar_interval: hour
 
   - match: { hits.total.value: 10 }

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.aggregation/360_date_histogram.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.aggregation/360_date_histogram.yml
@@ -17,6 +17,18 @@ setup:
                 type: date_range
 
   - do:
+      indices.create:
+        index: date_histogram_timezone_test
+        body:
+          settings:
+            number_of_replicas: 0
+          mappings:
+            properties:
+              date:
+                type: date
+                format: "yyyy-MM-dd HH:mm:ss"
+
+  - do:
       bulk:
         index: test_date_hist
         refresh: true
@@ -34,6 +46,32 @@ setup:
           - '{"index": {}}'
           - '{"range": {"lt": "2016-02-01"}}'
 
+  - do:
+      bulk:
+        index: date_histogram_timezone_test
+        refresh: true
+        body:
+          - { "index": { } }
+          - { "date": "2021-05-01 20:00:00" }
+          - { "index": { } }
+          - { "date": "2021-05-01 21:30:00" }
+          - { "index": { } }
+          - { "date": "2021-05-01 23:54:00" }
+          - { "index": { } }
+          - { "date": "2021-05-01 23:40:00" }
+          - { "index": { } }
+          - { "date": "2021-05-01 22:20:00" }
+          - { "index": { } }
+          - { "date": "2021-05-01 21:20:00" }
+          - { "index": { } }
+          - { "date": "2021-05-01 23:50:00" }
+          - { "index": { } }
+          - { "date": "2021-05-01 22:15:00" }
+          - { "index": { } }
+          - { "date": "2021-05-01 22:40:00" }
+          - { "index": { } }
+          - { "date": "2021-05-01 22:20:00" }
+
 ---
 "date_histogram on range with hard bounds":
   - skip:
@@ -42,6 +80,7 @@ setup:
 
   - do:
       search:
+        index: test_date_hist
         body:
           size: 0
           aggs:
@@ -61,3 +100,107 @@ setup:
   - match: { aggregations.histo.buckets.8.doc_count: 1 }
   - match: { aggregations.histo.buckets.12.key_as_string: "2016-06-01T00:00:00.000Z" }
   - match: { aggregations.histo.buckets.12.doc_count: 1 }
+
+---
+"date_histogram and date_histogram_composite timezone":
+  - skip:
+      version: " - 7.16.99"
+      reason: bug fixed somewhere between 7.2 and 7.17
+  - do:
+      search:
+        index: date_histogram_timezone_test
+        body:
+          size: 0
+          aggs:
+            date_histogram_yes_tz:
+              date_histogram:
+                field: date
+                format: "yyyy-MM-dd HH:mm:ss"
+                calendar_interval: hour
+                time_zone: Asia/Jakarta
+            date_histogram_no__tz:
+              date_histogram:
+                field: date
+                format: "yyyy-MM-dd HH:mm:ss"
+                calendar_interval: hour
+
+
+  - match: { hits.total.value: 10 }
+  - match:  { hits.total.relation: "eq" }
+
+  - match:  { aggregations.date_histogram_yes_tz.buckets.0.key_as_string: "2021-05-02 03:00:00" }
+  - match:  { aggregations.date_histogram_no__tz.buckets.0.key_as_string: "2021-05-01 20:00:00" }
+
+  - match:  { aggregations.date_histogram_yes_tz.buckets.1.key_as_string: "2021-05-02 04:00:00" }
+  - match:  { aggregations.date_histogram_no__tz.buckets.1.key_as_string: "2021-05-01 21:00:00" }
+
+  - match:  { aggregations.date_histogram_yes_tz.buckets.2.key_as_string: "2021-05-02 05:00:00" }
+  - match:  { aggregations.date_histogram_no__tz.buckets.2.key_as_string: "2021-05-01 22:00:00" }
+
+  - match:  { aggregations.date_histogram_yes_tz.buckets.3.key_as_string: "2021-05-02 06:00:00" }
+  - match:  { aggregations.date_histogram_no__tz.buckets.3.key_as_string: "2021-05-01 23:00:00" }
+
+  - length: { aggregations.date_histogram_yes_tz.buckets: 4 }
+  - match:  { aggregations.date_histogram_yes_tz.buckets.0.doc_count: 1 }
+  - match:  { aggregations.date_histogram_yes_tz.buckets.1.doc_count: 2 }
+  - match:  { aggregations.date_histogram_yes_tz.buckets.2.doc_count: 4 }
+  - match:  { aggregations.date_histogram_yes_tz.buckets.3.doc_count: 3 }
+
+  - length: { aggregations.date_histogram_no__tz.buckets: 4 }
+  - match:  { aggregations.date_histogram_no__tz.buckets.0.doc_count: 1 }
+  - match:  { aggregations.date_histogram_no__tz.buckets.1.doc_count: 2 }
+  - match:  { aggregations.date_histogram_no__tz.buckets.2.doc_count: 4 }
+  - match:  { aggregations.date_histogram_no__tz.buckets.3.doc_count: 3 }
+
+  - match: { aggregations.date_histogram_yes_tz.buckets.0.key: 1619899200000 }
+  - match: { aggregations.date_histogram_yes_tz.buckets.1.key: 1619902800000 }
+  - match: { aggregations.date_histogram_yes_tz.buckets.2.key: 1619906400000 }
+  - match: { aggregations.date_histogram_yes_tz.buckets.3.key: 1619910000000 }
+
+  - match: { aggregations.date_histogram_no__tz.buckets.0.key: 1619899200000 }
+  - match: { aggregations.date_histogram_no__tz.buckets.1.key: 1619902800000 }
+  - match: { aggregations.date_histogram_no__tz.buckets.2.key: 1619906400000 }
+  - match: { aggregations.date_histogram_no__tz.buckets.3.key: 1619910000000 }
+
+---
+"Multi-value date histogram":
+  - skip:
+      version: " - 8.1.99"
+      reason:  Bug fixed in 8.2.0
+
+  - do:
+      search:
+        body:
+          query:
+            match:
+              date: "2021-04-01"
+          aggs:
+            datehisto:
+              date_histogram:
+                field: "date"
+                calendar_interval: "1M"
+
+  - match: { hits.total.value: 1 }
+  - length: { aggregations.datehisto.buckets: 2 }
+
+---
+"Multi-value date histogram docvalues only":
+  - skip:
+      version: " - 8.1.99"
+      reason:  Bug fixed in 8.2.0
+
+  - do:
+      search:
+        body:
+          profile: true
+          query:
+            match:
+              date_not_indexed: "2021-04-01"
+          aggs:
+            datehisto:
+              date_histogram:
+                field: "date_not_indexed"
+                calendar_interval: "1M"
+
+  - match: { hits.total.value: 1 }
+  - length: { aggregations.datehisto.buckets: 3 }


### PR DESCRIPTION
# Backport

This is an automatic backport to `7.17` of:
 - #85176

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)