### PR TITLE
Remove hppc from search and aggs tests

### DIFF
--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/range/BinaryRangeAggregatorTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/range/BinaryRangeAggregatorTests.java
@@ -7,8 +7,6 @@
  */
 package org.elasticsearch.search.aggregations.bucket.range;
 
-import com.carrotsearch.hppc.LongHashSet;
-
 import org.apache.lucene.tests.util.TestUtil;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.index.fielddata.AbstractSortedSetDocValues;
@@ -93,12 +91,12 @@ public class BinaryRangeAggregatorTests extends ESTestCase {
         final int[] expectedCounts = new int[ranges.length];
         final int maxDoc = randomIntBetween(5, 10);
         for (int doc = 0; doc < maxDoc; ++doc) {
-            LongHashSet ordinalSet = new LongHashSet();
+            Set<Long> ordinalSet = new HashSet<>();
             final int numValues = randomInt(maxNumValuesPerDoc);
             while (ordinalSet.size() < numValues) {
-                ordinalSet.add(random().nextInt(terms.length));
+                ordinalSet.add(random().nextLong(terms.length));
             }
-            final long[] ords = ordinalSet.toArray();
+            final long[] ords = ordinalSet.stream().mapToLong(Long::longValue).toArray();
             Arrays.sort(ords);
             values.ords = ords;
 
@@ -194,12 +192,12 @@ public class BinaryRangeAggregatorTests extends ESTestCase {
         final int[] expectedCounts = new int[ranges.length];
         final int maxDoc = randomIntBetween(5, 10);
         for (int doc = 0; doc < maxDoc; ++doc) {
-            LongHashSet ordinalSet = new LongHashSet();
+            Set<Long> ordinalSet = new HashSet<>();
             final int numValues = randomInt(maxNumValuesPerDoc);
             while (ordinalSet.size() < numValues) {
-                ordinalSet.add(random().nextInt(terms.length));
+                ordinalSet.add(random().nextLong(terms.length));
             }
-            final long[] ords = ordinalSet.toArray();
+            final long[] ords = ordinalSet.stream().mapToLong(Long::longValue).toArray();
             Arrays.sort(ords);
             values.ords = ords;
 

--- a/server/src/test/java/org/elasticsearch/search/aggregations/metrics/AbstractGeoTestCase.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/metrics/AbstractGeoTestCase.java
@@ -8,11 +8,6 @@
 
 package org.elasticsearch.search.aggregations.metrics;
 
-import com.carrotsearch.hppc.ObjectIntHashMap;
-import com.carrotsearch.hppc.ObjectIntMap;
-import com.carrotsearch.hppc.ObjectObjectHashMap;
-import com.carrotsearch.hppc.ObjectObjectMap;
-
 import org.elasticsearch.action.index.IndexRequestBuilder;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.common.Strings;
@@ -30,7 +25,9 @@ import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xcontent.XContentFactory;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertSearchResponse;
@@ -55,8 +52,8 @@ public abstract class AbstractGeoTestCase extends ESIntegTestCase {
     protected static GeoPoint[] singleValues, multiValues;
     protected static GeoPoint singleTopLeft, singleBottomRight, multiTopLeft, multiBottomRight, singleCentroid, multiCentroid,
         unmappedCentroid;
-    protected static ObjectIntMap<String> expectedDocCountsForGeoHash = null;
-    protected static ObjectObjectMap<String, GeoPoint> expectedCentroidsForGeoHash = null;
+    protected static Map<String, Integer> expectedDocCountsForGeoHash = null;
+    protected static Map<String, GeoPoint> expectedCentroidsForGeoHash = null;
     protected static final double GEOHASH_TOLERANCE = 1E-5D;
 
     @Override
@@ -85,8 +82,8 @@ public abstract class AbstractGeoTestCase extends ESIntegTestCase {
 
         numDocs = randomIntBetween(6, 20);
         numUniqueGeoPoints = randomIntBetween(1, numDocs);
-        expectedDocCountsForGeoHash = new ObjectIntHashMap<>(numDocs * 2);
-        expectedCentroidsForGeoHash = new ObjectObjectHashMap<>(numDocs * 2);
+        expectedDocCountsForGeoHash = new HashMap<>(numDocs * 2);
+        expectedCentroidsForGeoHash = new HashMap<>(numDocs * 2);
 
         singleValues = new GeoPoint[numUniqueGeoPoints];
         for (int i = 0; i < singleValues.length; i++) {

--- a/server/src/test/java/org/elasticsearch/search/aggregations/metrics/HyperLogLogPlusPlusTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/metrics/HyperLogLogPlusPlusTests.java
@@ -9,7 +9,6 @@
 package org.elasticsearch.search.aggregations.metrics;
 
 import com.carrotsearch.hppc.BitMixer;
-import com.carrotsearch.hppc.IntHashSet;
 
 import org.elasticsearch.common.breaker.CircuitBreaker;
 import org.elasticsearch.common.breaker.CircuitBreakingException;
@@ -21,6 +20,8 @@ import org.elasticsearch.common.util.PageCacheRecycler;
 import org.elasticsearch.indices.breaker.CircuitBreakerService;
 import org.elasticsearch.test.ESTestCase;
 
+import java.util.HashSet;
+import java.util.Set;
 import java.util.concurrent.atomic.AtomicLong;
 
 import static org.elasticsearch.search.aggregations.metrics.AbstractCardinalityAlgorithm.MAX_PRECISION;
@@ -60,7 +61,7 @@ public class HyperLogLogPlusPlusTests extends ESTestCase {
         final int numValues = randomIntBetween(1, 100000);
         final int maxValue = randomIntBetween(1, randomBoolean() ? 1000 : 100000);
         final int p = randomIntBetween(14, MAX_PRECISION);
-        IntHashSet set = new IntHashSet();
+        Set<Integer> set = new HashSet<>();
         HyperLogLogPlusPlus e = new HyperLogLogPlusPlus(p, BigArrays.NON_RECYCLING_INSTANCE, 1);
         for (int i = 0; i < numValues; ++i) {
             final int n = randomInt(maxValue);


### PR DESCRIPTION
This commit removes uses of hppc collections in search and aggs tests that are
purely for local record keeping.

relates #84735