### PR TITLE
Fix EnrichSecurityIT resource cleanup

### DIFF
--- a/x-pack/plugin/enrich/qa/common/src/main/java/org/elasticsearch/test/enrich/CommonEnrichRestTestCase.java
+++ b/x-pack/plugin/enrich/qa/common/src/main/java/org/elasticsearch/test/enrich/CommonEnrichRestTestCase.java
@@ -60,7 +60,7 @@ public abstract class CommonEnrichRestTestCase extends ESRestTestCase {
         return (Property) map.get(key);
     }
 
-    private void setupGenericLifecycleTest(boolean deletePipeilne, String field, String type, String value) throws Exception {
+    private void setupGenericLifecycleTest(boolean deletePipeline, String field, String type, String value) throws Exception {
         // Create source index:
         createSourceIndex("my-source-index");
 
@@ -133,7 +133,7 @@ public abstract class CommonEnrichRestTestCase extends ESRestTestCase {
         Object originalMatchValue = ((Map<?, ?>) response.get("_source")).get(field);
         assertThat(originalMatchValue, equalTo(value));
 
-        if (deletePipeilne) {
+        if (deletePipeline) {
             // delete the pipeline so the policies can be deleted
             client().performRequest(new Request("DELETE", "/_ingest/pipeline/my_pipeline"));
         }

--- a/x-pack/plugin/enrich/qa/common/src/main/java/org/elasticsearch/test/enrich/CommonEnrichRestTestCase.java
+++ b/x-pack/plugin/enrich/qa/common/src/main/java/org/elasticsearch/test/enrich/CommonEnrichRestTestCase.java
@@ -34,45 +34,43 @@ import static org.hamcrest.Matchers.notNullValue;
 
 public abstract class CommonEnrichRestTestCase extends ESRestTestCase {
 
+    private List<String> cleanupPipelines = new ArrayList<>();
+
+    /**
+     * Registers a pipeline for subsequent post-test clean up (i.e. DELETE),
+     * see {@link CommonEnrichRestTestCase#deletePipelinesAndPolicies()}.
+     *
+     * @param pipeline the name of the pipeline to clean up
+     */
+    public void cleanupPipelineAfterTest(String pipeline) {
+        cleanupPipelines.add(pipeline);
+    }
+
     @After
     public void deletePipelinesAndPolicies() throws Exception {
-        {
-            // delete all pipelines
-            List<String> pipelines = new ArrayList<>();
-            try {
-                Map<String, Object> responseMap = toMap(adminClient().performRequest(new Request("GET", "/_ingest/pipeline")));
-                pipelines.addAll(responseMap.keySet());
-            } catch (ResponseException e) {
-                // if there are no pipelines, then GET /_ingest/pipeline 404s, so this is actually expected
-                if (e.getResponse().getStatusLine().getStatusCode() != 404) {
-                    throw e; // rethrow if it isn't a 404, though
-                }
-            }
-
-            for (String pipeline : pipelines) {
-                String endpoint = "/_ingest/pipeline/" + pipeline;
-                assertOK(client().performRequest(new Request("DELETE", endpoint)));
-            }
+        // delete pipelines
+        for (String pipeline : cleanupPipelines) {
+            String endpoint = "/_ingest/pipeline/" + pipeline;
+            assertOK(client().performRequest(new Request("DELETE", endpoint)));
         }
+        cleanupPipelines.clear();
 
-        {
-            // delete all policies
-            Map<String, Object> responseMap = toMap(adminClient().performRequest(new Request("GET", "/_enrich/policy")));
-            List<Map<?, ?>> policies = unsafeGetProperty(responseMap, "policies");
+        // delete all policies
+        Map<String, Object> responseMap = toMap(adminClient().performRequest(new Request("GET", "/_enrich/policy")));
+        List<Map<?, ?>> policies = unsafeGetProperty(responseMap, "policies");
 
-            for (Map<?, ?> entry : policies) {
-                Map<?, Map<String, ?>> config = unsafeGetProperty(entry, "config");
-                Map<String, ?> policy = config.values().iterator().next();
-                String endpoint = "/_enrich/policy/" + policy.get("name");
-                assertOK(client().performRequest(new Request("DELETE", endpoint)));
+        for (Map<?, ?> entry : policies) {
+            Map<?, Map<String, ?>> config = unsafeGetProperty(entry, "config");
+            Map<String, ?> policy = config.values().iterator().next();
+            String endpoint = "/_enrich/policy/" + policy.get("name");
+            assertOK(client().performRequest(new Request("DELETE", endpoint)));
 
-                List<?> sourceIndices = (List<?>) policy.get("indices");
-                for (Object sourceIndex : sourceIndices) {
-                    try {
-                        client().performRequest(new Request("DELETE", "/" + sourceIndex));
-                    } catch (ResponseException e) {
-                        // and that is ok
-                    }
+            List<?> sourceIndices = (List<?>) policy.get("indices");
+            for (Object sourceIndex : sourceIndices) {
+                try {
+                    client().performRequest(new Request("DELETE", "/" + sourceIndex));
+                } catch (ResponseException e) {
+                    // and that is ok
                 }
             }
         }
@@ -83,7 +81,7 @@ public abstract class CommonEnrichRestTestCase extends ESRestTestCase {
         return (Property) map.get(key);
     }
 
-    private void setupGenericLifecycleTest(boolean deletePipeline, String field, String type, String value) throws Exception {
+    private void setupGenericLifecycleTest(String field, String type, String value) throws Exception {
         // Create source index:
         createSourceIndex("my-source-index");
 
@@ -137,6 +135,7 @@ public abstract class CommonEnrichRestTestCase extends ESRestTestCase {
               "processors": [ { "enrich": { "policy_name": "my_policy", "field": "%s", "target_field": "entry" } } ]
             }""", field));
         assertOK(client().performRequest(putPipelineRequest));
+        cleanupPipelineAfterTest("my_pipeline");
 
         // Index document using pipeline with enrich processor:
         indexRequest = new Request("PUT", "/my-index/_doc/1");
@@ -155,45 +154,40 @@ public abstract class CommonEnrichRestTestCase extends ESRestTestCase {
         assertThat(entry.get("tldRank"), equalTo(7));
         Object originalMatchValue = ((Map<?, ?>) response.get("_source")).get(field);
         assertThat(originalMatchValue, equalTo(value));
-
-        if (deletePipeline) {
-            // delete the pipeline so the policies can be deleted
-            client().performRequest(new Request("DELETE", "/_ingest/pipeline/my_pipeline"));
-        }
     }
 
     public void testBasicFlowKeyword() throws Exception {
-        setupGenericLifecycleTest(true, "host", "match", "elastic.co");
+        setupGenericLifecycleTest("host", "match", "elastic.co");
         assertBusy(CommonEnrichRestTestCase::verifyEnrichMonitoring, 3, TimeUnit.MINUTES);
     }
 
     public void testBasicFlowDate() throws Exception {
-        setupGenericLifecycleTest(true, "date", "range", "2021-09-06");
+        setupGenericLifecycleTest("date", "range", "2021-09-06");
         assertBusy(CommonEnrichRestTestCase::verifyEnrichMonitoring, 3, TimeUnit.MINUTES);
     }
 
     public void testBasicFlowInteger() throws Exception {
-        setupGenericLifecycleTest(true, "integer", "range", "41");
+        setupGenericLifecycleTest("integer", "range", "41");
         assertBusy(CommonEnrichRestTestCase::verifyEnrichMonitoring, 3, TimeUnit.MINUTES);
     }
 
     public void testBasicFlowLong() throws Exception {
-        setupGenericLifecycleTest(true, "long", "range", "8411017");
+        setupGenericLifecycleTest("long", "range", "8411017");
         assertBusy(CommonEnrichRestTestCase::verifyEnrichMonitoring, 3, TimeUnit.MINUTES);
     }
 
     public void testBasicFlowDouble() throws Exception {
-        setupGenericLifecycleTest(true, "double", "range", "15.15");
+        setupGenericLifecycleTest("double", "range", "15.15");
         assertBusy(CommonEnrichRestTestCase::verifyEnrichMonitoring, 3, TimeUnit.MINUTES);
     }
 
     public void testBasicFlowFloat() throws Exception {
-        setupGenericLifecycleTest(true, "float", "range", "10000.66666");
+        setupGenericLifecycleTest("float", "range", "10000.66666");
         assertBusy(CommonEnrichRestTestCase::verifyEnrichMonitoring, 3, TimeUnit.MINUTES);
     }
 
     public void testBasicFlowIp() throws Exception {
-        setupGenericLifecycleTest(true, "ip", "range", "100.120.140.160");
+        setupGenericLifecycleTest("ip", "range", "100.120.140.160");
         assertBusy(CommonEnrichRestTestCase::verifyEnrichMonitoring, 3, TimeUnit.MINUTES);
     }
 
@@ -221,8 +215,7 @@ public abstract class CommonEnrichRestTestCase extends ESRestTestCase {
     }
 
     public void testDeleteExistingPipeline() throws Exception {
-        // lets not delete the pipeline at first, to test the failure
-        setupGenericLifecycleTest(false, "host", "match", "elastic.co");
+        setupGenericLifecycleTest("host", "match", "elastic.co");
 
         Request putPipelineRequest = new Request("PUT", "/_ingest/pipeline/another_pipeline");
         putPipelineRequest.setJsonEntity("""
@@ -230,6 +223,7 @@ public abstract class CommonEnrichRestTestCase extends ESRestTestCase {
               "processors": [ { "enrich": { "policy_name": "my_policy", "field": "host", "target_field": "entry" } } ]
             }""");
         assertOK(client().performRequest(putPipelineRequest));
+        cleanupPipelineAfterTest("another_pipeline");
 
         ResponseException exc = expectThrows(
             ResponseException.class,
@@ -238,10 +232,6 @@ public abstract class CommonEnrichRestTestCase extends ESRestTestCase {
         assertTrue(exc.getMessage().contains("Could not delete policy [my_policy] because a pipeline is referencing it ["));
         assertTrue(exc.getMessage().contains("another_pipeline"));
         assertTrue(exc.getMessage().contains("my_pipeline"));
-
-        // delete the pipelines so the policies can be deleted
-        client().performRequest(new Request("DELETE", "/_ingest/pipeline/my_pipeline"));
-        client().performRequest(new Request("DELETE", "/_ingest/pipeline/another_pipeline"));
 
         // verify the delete did not happen
         Request getRequest = new Request("GET", "/_enrich/policy/my_policy");

--- a/x-pack/plugin/enrich/qa/common/src/main/java/org/elasticsearch/test/enrich/CommonEnrichRestTestCase.java
+++ b/x-pack/plugin/enrich/qa/common/src/main/java/org/elasticsearch/test/enrich/CommonEnrichRestTestCase.java
@@ -133,6 +133,8 @@ public abstract class CommonEnrichRestTestCase extends ESRestTestCase {
         Object originalMatchValue = ((Map<?, ?>) response.get("_source")).get(field);
         assertThat(originalMatchValue, equalTo(value));
 
+        assertNotEquals("host", field);
+
         if (deletePipeline) {
             // delete the pipeline so the policies can be deleted
             client().performRequest(new Request("DELETE", "/_ingest/pipeline/my_pipeline"));

--- a/x-pack/plugin/enrich/qa/common/src/main/java/org/elasticsearch/test/enrich/CommonEnrichRestTestCase.java
+++ b/x-pack/plugin/enrich/qa/common/src/main/java/org/elasticsearch/test/enrich/CommonEnrichRestTestCase.java
@@ -156,8 +156,6 @@ public abstract class CommonEnrichRestTestCase extends ESRestTestCase {
         Object originalMatchValue = ((Map<?, ?>) response.get("_source")).get(field);
         assertThat(originalMatchValue, equalTo(value));
 
-        assertNotEquals("host", field);
-
         if (deletePipeline) {
             // delete the pipeline so the policies can be deleted
             client().performRequest(new Request("DELETE", "/_ingest/pipeline/my_pipeline"));


### PR DESCRIPTION
Closes #84885

So the test failure from https://github.com/elastic/elasticsearch/issues/84885 is really interesting. What happens is that one test randomly fails due to the stacktrace below (which IIUC is an issue that @jbaiera is looking into in the general case), but then that kicks off a comedy of errors where everything fails:

```
org.elasticsearch.xpack.enrich.EnrichSecurityIT > testBasicFlowDate FAILED
    org.elasticsearch.client.WarningFailureException: method [PUT], host [http://127.0.0.1:34431/], URI [/my-index/_doc/1?pipeline=my_pipeline], status line [HTTP/1.1 201 Created]
    Warnings: [index name [.monitoring-es-7-2022.03.10] starts with a dot '.', in the next major version, index names starting with a dot are reserved for hidden indices and system indices]
    {"_index":"my-index","_id":"1","_version":1,"result":"created","_shards":{"total":2,"successful":1,"failed":0},"_seq_no":0,"_primary_term":1}
        at app//org.elasticsearch.client.RestClient.convertResponse(RestClient.java:342)
        at app//org.elasticsearch.client.RestClient.performRequest(RestClient.java:312)
        at app//org.elasticsearch.client.RestClient.performRequest(RestClient.java:287)
```

See, since that warning is attached to our request, that results in an exception being thrown, so the pipeline that that test just created is never deleted. Which means that the policy referencing that pipeline cannot be deleted and then subsequent tests can't put a new policy because there's already a non-deleted policy with the same name in place.

That is, once any test in this class fails (and so fails to clean up after itself) then all tests in that class from there on out will fail.

This PR fixes that.