### PR TITLE
[Test] Fix FollowIndexSecurityIT by granting needed previleges (#84467)

### DIFF
--- a/x-pack/plugin/ccr/qa/security/leader-roles.yml
+++ b/x-pack/plugin/ccr/qa/security/leader-roles.yml
@@ -4,7 +4,5 @@ ccruser:
   indices:
     - names: [ 'allowed-index', 'clean-leader', 'forget-leader', 'logs-eu*' ]
       privileges:
-        - monitor
+        - manage
         - read
-        - manage_leader_index
-        - view_index_metadata


### PR DESCRIPTION
CCR user on the leader cluster needs more privileges than what are
documented (#61308). Specifically it needs to renew the retention lease
at a fixed time interval. This PR fixes it by granting the "manage"
index privilege to the CCR user on the leader cluster.

Note we still want to revisit privileges required CCR or at least fix
our documentation. This will be tracked with #61308.

Resolves: #84156

Backport: #84467