### PR TITLE
[7.17][DOCS] Removes coming tag from release notes

### DIFF
--- a/docs/reference/release-notes/7.17.2.asciidoc
+++ b/docs/reference/release-notes/7.17.2.asciidoc
@@ -1,8 +1,6 @@
 [[release-notes-7.17.2]]
 == {es} version 7.17.2
 
-coming[7.17.2]
-
 Also see <<breaking-changes-7.17,Breaking changes in 7.17>>.
 
 [[bug-7.17.2]]


### PR DESCRIPTION
## Overview

This PR removes the `coming` tag from the 7.17.2 release notes page.