### PR TITLE
Make infra-monitoring-ui codeowners of Stack Monitoring templates

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,17 @@
+# GitHub CODEOWNERS definition
+# Identify which groups will be pinged by changes to different parts of the codebase.
+# For more info, see https://help.github.com/articles/about-codeowners/
+
+# Stack Monitoring index templates
+x-pack/plugin/core/src/main/resources/monitoring-alerts-7.json @elastic/infra-monitoring-ui
+x-pack/plugin/core/src/main/resources/monitoring-beats-mb.json @elastic/infra-monitoring-ui
+x-pack/plugin/core/src/main/resources/monitoring-beats.json @elastic/infra-monitoring-ui
+x-pack/plugin/core/src/main/resources/monitoring-ent-search-mb.json @elastic/infra-monitoring-ui
+x-pack/plugin/core/src/main/resources/monitoring-es-mb.json @elastic/infra-monitoring-ui
+x-pack/plugin/core/src/main/resources/monitoring-es.json @elastic/infra-monitoring-ui
+x-pack/plugin/core/src/main/resources/monitoring-kibana-mb.json @elastic/infra-monitoring-ui
+x-pack/plugin/core/src/main/resources/monitoring-kibana.json @elastic/infra-monitoring-ui
+x-pack/plugin/core/src/main/resources/monitoring-logstash-mb.json @elastic/infra-monitoring-ui
+x-pack/plugin/core/src/main/resources/monitoring-logstash.json @elastic/infra-monitoring-ui
+x-pack/plugin/core/src/main/resources/monitoring-mb-ilm-policy.json @elastic/infra-monitoring-ui
+x-pack/plugin/monitoring/src/main/java/org/elasticsearch/xpack/monitoring/MonitoringTemplateRegistry.java @elastic/infra-monitoring-ui


### PR DESCRIPTION
This PR adds a CODEOWNERS file to this repo, which only includes entires for the files relates to the templates used by Stack Monitoring, marking those files as owned by @elastic/infra-monitoring-ui so we get notified about any PRs that change them.