### PR TITLE
[ML] Extra logging for ML deployment upgrade test

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/utils/ExceptionsHelper.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/utils/ExceptionsHelper.java
@@ -49,6 +49,10 @@ public class ExceptionsHelper {
         return new ResourceNotFoundException("No known trained model with model_id [{}]", modelId);
     }
 
+    public static ResourceNotFoundException missingTrainedModel(String modelId, Exception cause) {
+        return new ResourceNotFoundException("No known trained model with model_id [{}]", cause, modelId);
+    }
+
     public static ResourceNotFoundException missingDeployment(String deploymentId) {
         return new ResourceNotFoundException("No known trained model with deployment with id [{}]", deploymentId);
     }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/allocation/TrainedModelAllocationNodeService.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/allocation/TrainedModelAllocationNodeService.java
@@ -192,8 +192,9 @@ public class TrainedModelAllocationNodeService implements ClusterStateListener {
                 // kicks off asynchronous cluster state update
                 handleLoadSuccess(deployedTask);
             } catch (Exception ex) {
+                logger.warn(new ParameterizedMessage("[{}] Start deployment failed", modelId), ex);
                 if (ExceptionsHelper.unwrapCause(ex) instanceof ResourceNotFoundException) {
-                    handleLoadFailure(loadingTask, ExceptionsHelper.missingTrainedModel(loadingTask.getModelId()));
+                    handleLoadFailure(loadingTask, ExceptionsHelper.missingTrainedModel(loadingTask.getModelId(), ex));
                 } else if (ExceptionsHelper.unwrapCause(ex) instanceof SearchPhaseExecutionException) {
                     // A search phase execution failure should be retried, push task back to the queue
                     loadingToRetry.add(loadingTask);

--- a/x-pack/qa/full-cluster-restart/src/test/java/org/elasticsearch/xpack/restart/MLModelDeploymentFullClusterRestartIT.java
+++ b/x-pack/qa/full-cluster-restart/src/test/java/org/elasticsearch/xpack/restart/MLModelDeploymentFullClusterRestartIT.java
@@ -79,7 +79,6 @@ public class MLModelDeploymentFullClusterRestartIT extends AbstractFullClusterRe
         return Settings.builder().put(ThreadContext.PREFIX + ".Authorization", token).build();
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/85438")
     public void testDeploymentSurvivesRestart() throws Exception {
         assumeTrue("NLP model deployments added in 8.0", getOldClusterVersion().onOrAfter(Version.V_8_0_0));
 


### PR DESCRIPTION
The cause of the error was lost when the exception was rewritten as a model not found error.

For the test failure in #85438