### PR TITLE
various updates related to minimum Java version 17

### DIFF
--- a/distribution/src/config/jvm.options
+++ b/distribution/src/config/jvm.options
@@ -49,17 +49,7 @@
 ##
 ################################################################
 
-## GC configuration
-8-13:-XX:+UseConcMarkSweepGC
-8-13:-XX:CMSInitiatingOccupancyFraction=75
-8-13:-XX:+UseCMSInitiatingOccupancyOnly
-
-## G1GC Configuration
-# to use G1GC, uncomment the next two lines and update the version on the
-# following three lines to your version of the JDK
-# 8-13:-XX:-UseConcMarkSweepGC
-# 8-13:-XX:-UseCMSInitiatingOccupancyOnly
-14-:-XX:+UseG1GC
+-XX:+UseG1GC
 
 ## JVM temporary directory
 -Djava.io.tmpdir=${ES_TMPDIR}
@@ -71,9 +61,8 @@
 # specified
 -XX:+HeapDumpOnOutOfMemoryError
 
-# exit right after heap dump on out of memory error. Recommended to also use
-# on java 8 for supported versions (8u92+).
-9-:-XX:+ExitOnOutOfMemoryError
+# exit right after heap dump on out of memory error
+-XX:+ExitOnOutOfMemoryError
 
 # specify an alternative path for heap dumps; ensure the directory exists and
 # has sufficient space

--- a/distribution/tools/launchers/src/main/java/org/elasticsearch/tools/launchers/JvmOptionsParser.java
+++ b/distribution/tools/launchers/src/main/java/org/elasticsearch/tools/launchers/JvmOptionsParser.java
@@ -239,31 +239,31 @@ final class JvmOptionsParser {
      *     </li>
      * </ul>
      *
-     * For example, if the specified Java major version is 8, the following JVM options will be accepted:
+     * For example, if the specified Java major version is 17, the following JVM options will be accepted:
      * <ul>
      *     <li>
      *         {@code -XX:+PrintGCDateStamps}
      *     </li>
      *     <li>
-     *         {@code 8:-XX:+PrintGCDateStamps}
+     *         {@code 17:-XX:+PrintGCDateStamps}
      *     </li>
      *     <li>
-     *         {@code 8-:-XX:+PrintGCDateStamps}
+     *         {@code 17-:-XX:+PrintGCDateStamps}
      *     </li>
      *     <li>
-     *         {@code 7-8:-XX:+PrintGCDateStamps}
+     *         {@code 17-18:-XX:+PrintGCDateStamps}
      *     </li>
      * </ul>
      * and the following JVM options will not be accepted:
      * <ul>
      *     <li>
-     *         {@code 9:-Xlog:age*=trace,gc*,safepoint:file=logs/gc.log:utctime,pid,tags:filecount=32,filesize=64m}
+     *         {@code 18:-Xlog:age*=trace,gc*,safepoint:file=logs/gc.log:utctime,pid,tags:filecount=32,filesize=64m}
      *     </li>
      *     <li>
-     *         {@code 9-:-Xlog:age*=trace,gc*,safepoint:file=logs/gc.log:utctime,pid,tags:filecount=32,filesize=64m}
+     *         {@code 18-:-Xlog:age*=trace,gc*,safepoint:file=logs/gc.log:utctime,pid,tags:filecount=32,filesize=64m}
      *     </li>
      *     <li>
-     *         {@code 9-10:-Xlog:age*=trace,gc*,safepoint:file=logs/gc.log:utctime,pid,tags:filecount=32,filesize=64m}
+     *         {@code 18-19:-Xlog:age*=trace,gc*,safepoint:file=logs/gc.log:utctime,pid,tags:filecount=32,filesize=64m}
      *     </li>
      * </ul>
      *

--- a/docs/reference/setup/advanced-configuration.asciidoc
+++ b/docs/reference/setup/advanced-configuration.asciidoc
@@ -42,23 +42,23 @@ or a range of versions followed by a colon.
 +
 [source,text]
 -------------------------------------
-8:-Xmx2g
+17:-Xmx2g
 -------------------------------------
 
 * Apply a setting to a range of versions:
 +
 [source,text]
 -------------------------------------
-8-9:-Xmx2g
+17-18:-Xmx2g
 -------------------------------------
 +
 To apply a setting to a specific version and any later versions,
-omit the upper bound of the range. 
+omit the upper bound of the range.
 For example, this setting applies to Java 8 and later:
 +
 [source,text]
 -------------------------------------
-8-:-Xmx2g
+17-:-Xmx2g
 -------------------------------------
 
 Blank lines are ignored. Lines beginning with `#` are treated as comments
@@ -69,7 +69,7 @@ as valid JVM arguments are rejected and {es} will fail to start.
 ===== Use environment variables to set JVM options
 
 In production, use JVM options files to override the
-default settings. In testing and development environments, 
+default settings. In testing and development environments,
 you can also set JVM options through the `ES_JAVA_OPTS` environment variable.
 
 [source,sh]
@@ -90,8 +90,6 @@ By default, {es} automatically sets the JVM heap size based on a node's
 <<node-roles,roles>> and total memory.
 Using the default sizing is recommended for most production environments.
 
-NOTE: Automatic heap sizing requires the <<jvm-version,bundled JDK>> or, if using
-a custom JRE location, a Java 14 or later JRE.
 
 To override the default heap size, set the minimum and maximum heap size
 settings, `Xms` and `Xmx`. The minimum and maximum values must be the same.

--- a/docs/reference/setup/important-settings/heap-size.asciidoc
+++ b/docs/reference/setup/important-settings/heap-size.asciidoc
@@ -6,8 +6,5 @@ By default, {es} automatically sets the JVM heap size based on a node's
 <<node-roles,roles>> and total memory.
 We recommend the default sizing for most production environments.
 
-NOTE: Automatic heap sizing requires the <<jvm-version,bundled JDK>> or, if using
-a custom JRE location, a Java 14 or later JRE.
-
 If needed, you can override the default sizing by manually
 <<set-jvm-heap-size,setting the JVM heap size>>.


### PR DESCRIPTION
Since 8.0.0, we only support Java 17 and up. This change cleans up unsupported Java versions from jvm.options and updates documentation to reference supported Java versions, in case it is confusing to users.