### PR TITLE
[8.2] Fix SQLCompatIT.testCursorFromOldNodeFailsOnNewNode (#85531)

### DIFF
--- a/docs/changelog/85531.yaml
+++ b/docs/changelog/85531.yaml
@@ -1,0 +1,6 @@
+pr: 85531
+summary: Fix SQLCompatIT.testCursorFromOldNodeFailsOnNewNode
+area: SQL
+type: bug
+issues:
+ - 85520


### PR DESCRIPTION
Backports the following commits to 8.2:
 - Fix SQLCompatIT.testCursorFromOldNodeFailsOnNewNode (#85531)