### PR TITLE
[8.2] fix: make EmptySortValue instances sort after everything else (#85437)

### DIFF
--- a/server/src/test/java/org/elasticsearch/search/sort/SortValueTests.java
+++ b/server/src/test/java/org/elasticsearch/search/sort/SortValueTests.java
@@ -24,6 +24,9 @@ import org.elasticsearch.xcontent.XContentBuilder;
 
 import java.io.IOException;
 import java.time.ZoneId;
+import java.util.Comparator;
+import java.util.List;
+import java.util.stream.Collectors;
 
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
@@ -119,9 +122,9 @@ public class SortValueTests extends AbstractNamedWriteableTestCase<SortValue> {
     public void testCompareToEmpty() {
         assertThat(SortValue.from(1.0), lessThan(SortValue.empty()));
         assertThat(SortValue.from(Double.MAX_VALUE), lessThan(SortValue.empty()));
-        assertThat(SortValue.from(Double.NaN), lessThan(SortValue.empty()));
-        assertThat(SortValue.from(1), greaterThan(SortValue.empty()));
-        assertThat(SortValue.from(Long.MIN_VALUE), greaterThan(SortValue.empty()));
+        assertThat(SortValue.from(Double.NaN), equalTo(SortValue.empty()));
+        assertThat(SortValue.from(1), lessThan(SortValue.empty()));
+        assertThat(SortValue.from(Long.MIN_VALUE), lessThan(SortValue.empty()));
         assertThat(SortValue.from(new BytesRef("cat")), lessThan(SortValue.empty()));
     }
 
@@ -141,6 +144,74 @@ public class SortValueTests extends AbstractNamedWriteableTestCase<SortValue> {
 
     public void testCompareEmpty() {
         assertThat(SortValue.empty(), equalTo(SortValue.empty()));
+    }
+
+    public void testSortValueOrdering() {
+        final SortValue maxLong = SortValue.from(Long.MAX_VALUE);
+        final SortValue minLong = SortValue.from(Long.MIN_VALUE);
+        final SortValue negativeLong = SortValue.from(-12L);
+        final SortValue zeroLong = SortValue.from(0L);
+        final SortValue positiveLong = SortValue.from(110L);
+        final SortValue negativeNan = SortValue.from(-Double.NaN);
+        final SortValue positiveNan = SortValue.from(Double.NaN);
+        final SortValue maxDouble = SortValue.from(Double.MAX_VALUE);
+        final SortValue minDouble = SortValue.from(Double.MIN_VALUE);
+        final SortValue negativeDouble = SortValue.from(-30.5D);
+        final SortValue zeroDouble = SortValue.from(0.0D);
+        final SortValue positiveDouble = SortValue.from(18.97D);
+        final SortValue emptyBytesRef = SortValue.from(new BytesRef(""));
+        final SortValue fooBytesRef = SortValue.from(new BytesRef("Foo"));
+        final SortValue barBytesRef = SortValue.from(new BytesRef("bar"));
+        final SortValue valueless = SortValue.empty();
+        final List<SortValue> values = List.of(
+            maxLong,
+            minLong,
+            negativeLong,
+            zeroLong,
+            positiveLong,
+            negativeNan,
+            positiveNan,
+            maxDouble,
+            minDouble,
+            negativeDouble,
+            zeroDouble,
+            positiveDouble,
+            emptyBytesRef,
+            fooBytesRef,
+            barBytesRef,
+            valueless
+        );
+
+        final List<SortValue> sortedValues = values.stream().sorted(Comparator.naturalOrder()).collect(Collectors.toList());
+
+        /**
+         * `negativeNan` and `positiveNan` are instances of
+         * {@link org.elasticsearch.search.sort.SortValue.ValuelessSortValue}
+         * the same of {@link SortValue#empty()}.
+         */
+        assertThat(
+            sortedValues,
+            equalTo(
+                List.of(
+                    emptyBytesRef,
+                    fooBytesRef,
+                    barBytesRef,
+                    negativeDouble,
+                    zeroDouble,
+                    minDouble,
+                    positiveDouble,
+                    maxDouble,
+                    minLong,
+                    negativeLong,
+                    zeroLong,
+                    positiveLong,
+                    maxLong,
+                    negativeNan,
+                    positiveNan,
+                    valueless
+                )
+            )
+        );
     }
 
     public void testBytes() {


### PR DESCRIPTION
Backports the following commits to 8.2:
 - fix: make EmptySortValue instances sort after everything else (#85437)