### PR TITLE
Adjust deprecation notice for ingest privileges with mapping

### DIFF
--- a/docs/changelog/85573.yaml
+++ b/docs/changelog/85573.yaml
@@ -1,0 +1,11 @@
+pr: 85573
+summary: Adjust deprecation notice for ingest privileges with mapping
+area: Authorization
+type: deprecation
+issues: []
+deprecation:
+  title: Adjust deprecation notice for ingest privileges with mapping
+  area: Authorization
+  details: Please describe the details of this change for the release notes. You can
+    use asciidoc.
+  impact: Please describe the impact of this change to users

--- a/docs/reference/migration/migrate_7_9.asciidoc
+++ b/docs/reference/migration/migrate_7_9.asciidoc
@@ -111,7 +111,7 @@ context.  For example, for the `processor_conditional` context, use
 [%collapsible]
 ====
 *Details* +
-In {es} 8.0.0, the following privileges will no longer allow users to
+In {es} 9.0.0, the following privileges will no longer allow users to
 explicitly update the mapping of an index:
 
 * `create_doc`
@@ -119,8 +119,8 @@ explicitly update the mapping of an index:
 * `index`
 * `write`
 
-Additionally, in {es} 8.0.0, the following privileges will no longer allow users to
-{ref}/dynamic-mapping.html[dynamically update the mapping] of an index 
+Additionally, in {es} 9.0.0, the following privileges will no longer allow users to
+{ref}/dynamic-mapping.html[dynamically update the mapping] of an index
 during indexing or ingest:
 
 * `create_doc`
@@ -128,7 +128,7 @@ during indexing or ingest:
 * `index`
 
 These privileges will continue to allow mapping actions on indices (but not on data streams) until
-{es} 8.0.0. However, deprecation warnings will be returned.
+{es} 9.0.0. However, deprecation warnings will be returned.
 
 *Impact* +
 To allow users to explicitly update the mapping of an index,

--- a/x-pack/docs/en/security/authorization/privileges.asciidoc
+++ b/x-pack/docs/en/security/authorization/privileges.asciidoc
@@ -197,7 +197,7 @@ not permitting updating one.
 +
 deprecated:[7.9] Also grants the permission to update the index mapping (but not
 the data stream mapping), using the update mapping action, or relying on
-{ref}/dynamic-mapping.html[dynamic mappings]. In the next major release,
+{ref}/dynamic-mapping.html[dynamic mappings]. In a future major release,
 this privilege will not grant any mapping update permission.
 +
 --
@@ -214,7 +214,7 @@ existing ones.
 +
 deprecated:[7.9] Also grants the permission to update the index mapping (but not
 the data stream mapping), using the update mapping action, or relying on
-{ref}/dynamic-mapping.html[dynamic mappings]. In the next major release,
+{ref}/dynamic-mapping.html[dynamic mappings]. In a future major release,
 this privilege will not grant any mapping update permission.
 +
 --
@@ -250,7 +250,7 @@ Privilege to index (overwriting included) and update documents.
 +
 deprecated:[7.9] Also grants the permission to update the index mapping (but not
 the data stream mapping), using the update mapping action, or relying on
-{ref}/dynamic-mapping.html[dynamic mappings]. In the next major release,
+{ref}/dynamic-mapping.html[dynamic mappings]. In a future major release,
 this privilege will not grant any mapping update permission.
 
 `maintenance`::
@@ -301,8 +301,8 @@ permission to index, update, and delete documents as well as performing bulk
 operations, and allows the {ref}/dynamic-mapping.html[dynamic mapping updates]
 as a result of these.
 +
-deprecated:[7.9] Until the next major release, this also grants access to the
-update mapping action, but only on indices, not on data streams.
+deprecated:[7.9] This also grants access to the update mapping action on
+indices only, not on data streams. This access will be removed in a future major release.
 
 ==== Run as privilege
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/permission/IndicesPermission.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/permission/IndicesPermission.java
@@ -385,7 +385,7 @@ public final class IndicesPermission {
                                                 + "] on index ["
                                                 + resource.name
                                                 + "], this "
-                                                + "privilege will not permit mapping updates in the next major release - users who require "
+                                                + "privilege will not permit mapping updates in a future major release - users who require "
                                                 + "access to update mappings must be granted explicit privileges"
                                         );
                                     });

--- a/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/integration/IndexPrivilegeTests.java
+++ b/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/integration/IndexPrivilegeTests.java
@@ -719,7 +719,7 @@ public class IndexPrivilegeTests extends AbstractPrivilegeTestCase {
                             "the index privilege [index] allowed the update mapping action "
                                 + "[indices:admin/mapping/auto_put] on index ["
                                 + index
-                                + "], this privilege will not permit mapping updates in the next major release - "
+                                + "], this privilege will not permit mapping updates in a future major release - "
                                 + "users who require access to update mappings must be granted explicit privileges"
                         )
                     );
@@ -737,7 +737,7 @@ public class IndexPrivilegeTests extends AbstractPrivilegeTestCase {
                             "the index privilege [index] allowed the update mapping action "
                                 + "[indices:admin/mapping/auto_put] on index ["
                                 + index
-                                + "], this privilege will not permit mapping updates in the next major release - "
+                                + "], this privilege will not permit mapping updates in a future major release - "
                                 + "users who require access to update mappings must be granted explicit privileges"
                         )
                     );

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authz/accesscontrol/IndicesPermissionTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authz/accesscontrol/IndicesPermissionTests.java
@@ -509,17 +509,17 @@ public class IndicesPermissionTests extends ESTestCase {
             "the index privilege [index] allowed the update mapping action ["
                 + PutMappingAction.NAME
                 + "] on "
-                + "index [test1], this privilege will not permit mapping updates in the next major release - "
+                + "index [test1], this privilege will not permit mapping updates in a future major release - "
                 + "users who require access to update mappings must be granted explicit privileges",
             "the index privilege [index] allowed the update mapping action ["
                 + PutMappingAction.NAME
                 + "] on "
-                + "index [test_write1], this privilege will not permit mapping updates in the next major release - "
+                + "index [test_write1], this privilege will not permit mapping updates in a future major release - "
                 + "users who require access to update mappings must be granted explicit privileges",
             "the index privilege [write] allowed the update mapping action ["
                 + PutMappingAction.NAME
                 + "] on "
-                + "index [test_write1], this privilege will not permit mapping updates in the next major release - "
+                + "index [test_write1], this privilege will not permit mapping updates in a future major release - "
                 + "users who require access to update mappings must be granted explicit privileges"
         );
         iac = core.authorize(AutoPutMappingAction.NAME, Sets.newHashSet("test1", "test_write1"), lookup, fieldPermissionsCache);
@@ -530,7 +530,7 @@ public class IndicesPermissionTests extends ESTestCase {
             "the index privilege [index] allowed the update mapping action ["
                 + AutoPutMappingAction.NAME
                 + "] on "
-                + "index [test1], this privilege will not permit mapping updates in the next major release - "
+                + "index [test1], this privilege will not permit mapping updates in a future major release - "
                 + "users who require access to update mappings must be granted explicit privileges"
         );
 

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/security/authz/15_auto_create.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/security/authz/15_auto_create.yml
@@ -45,7 +45,7 @@ teardown:
   # Only auto creation of logs-foobar index works.
   - do:
       allowed_warnings:
-        - "the index privilege [create_doc] allowed the update mapping action [indices:admin/mapping/auto_put] on index [logs-foobar], this privilege will not permit mapping updates in the next major release - users who require access to update mappings must be granted explicit privileges"
+        - "the index privilege [create_doc] allowed the update mapping action [indices:admin/mapping/auto_put] on index [logs-foobar], this privilege will not permit mapping updates in a future major release - users who require access to update mappings must be granted explicit privileges"
       headers: { Authorization: "Basic dGVzdF91c2VyOngtcGFjay10ZXN0LXBhc3N3b3Jk" } # test_user
       bulk:
         body:
@@ -76,7 +76,7 @@ teardown:
   # Ensure that just appending data via both indices work now that the indices have been auto created
   - do:
       allowed_warnings:
-        - "the index privilege [create_doc] allowed the update mapping action [indices:admin/mapping/auto_put] on index [logs-barbaz], this privilege will not permit mapping updates in the next major release - users who require access to update mappings must be granted explicit privileges"
+        - "the index privilege [create_doc] allowed the update mapping action [indices:admin/mapping/auto_put] on index [logs-barbaz], this privilege will not permit mapping updates in a future major release - users who require access to update mappings must be granted explicit privileges"
       headers: { Authorization: "Basic dGVzdF91c2VyOngtcGFjay10ZXN0LXBhc3N3b3Jk" } # test_user
       bulk:
         body:

--- a/x-pack/qa/smoke-test-security-with-mustache/src/test/resources/rest-api-spec/test/20_small_users_one_index.yml
+++ b/x-pack/qa/smoke-test-security-with-mustache/src/test/resources/rest-api-spec/test/20_small_users_one_index.yml
@@ -85,7 +85,7 @@ teardown:
 
   - do:
       allowed_warnings:
-        - "the index privilege [create] allowed the update mapping action [indices:admin/mapping/auto_put] on index [shared_logs], this privilege will not permit mapping updates in the next major release - users who require access to update mappings must be granted explicit privileges"
+        - "the index privilege [create] allowed the update mapping action [indices:admin/mapping/auto_put] on index [shared_logs], this privilege will not permit mapping updates in a future major release - users who require access to update mappings must be granted explicit privileges"
       headers:
         Authorization: "Basic am9lOngtcGFjay10ZXN0LXBhc3N3b3Jk"
       index:
@@ -156,7 +156,7 @@ teardown:
 
   - do:
       allowed_warnings:
-        - "the index privilege [create] allowed the update mapping action [indices:admin/mapping/auto_put] on index [shared_logs], this privilege will not permit mapping updates in the next major release - users who require access to update mappings must be granted explicit privileges"
+        - "the index privilege [create] allowed the update mapping action [indices:admin/mapping/auto_put] on index [shared_logs], this privilege will not permit mapping updates in a future major release - users who require access to update mappings must be granted explicit privileges"
       headers:
         Authorization: "Basic am9lOngtcGFjay10ZXN0LXBhc3N3b3Jk"
       index:


### PR DESCRIPTION
We've failed to introduce the promised breaking behavior in v8 about the
access to mapping updates for ingest privileges.
This PR adjusts the deprecations to reflect the new plan of breaking the
behavior in v9.

Related:
https://github.com/elastic/elasticsearch/pull/85570
https://github.com/elastic/elasticsearch/pull/58784
https://github.com/elastic/elasticsearch/pull/60024

