### PR TITLE
Fix BWC versions to 8.3.0

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/node/stats/NodeStats.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/node/stats/NodeStats.java
@@ -112,7 +112,7 @@ public class NodeStats extends BaseNodeResponse implements ToXContentFragment {
         ingestStats = in.readOptionalWriteable(IngestStats::new);
         adaptiveSelectionStats = in.readOptionalWriteable(AdaptiveSelectionStats::new);
         indexingPressureStats = in.readOptionalWriteable(IndexingPressureStats::new);
-        if (in.getVersion().onOrAfter(Version.V_8_2_0)) {
+        if (in.getVersion().onOrAfter(Version.V_8_3_0)) {
             statsRequestStats = in.readOptionalWriteable(StatsRequestStats::new);
         }
     }
@@ -287,7 +287,7 @@ public class NodeStats extends BaseNodeResponse implements ToXContentFragment {
         out.writeOptionalWriteable(ingestStats);
         out.writeOptionalWriteable(adaptiveSelectionStats);
         out.writeOptionalWriteable(indexingPressureStats);
-        if (out.getVersion().onOrAfter(Version.V_8_2_0)) {
+        if (out.getVersion().onOrAfter(Version.V_8_3_0)) {
             out.writeOptionalWriteable(statsRequestStats);
         }
     }


### PR DESCRIPTION
Follow up to #85504 (that PR touched 8.2, only, but it has BWC implications w.r.t. master, too, which I had failed to consider).

Updates the BWC versions on master for #83832, since that was actually removed from the 8.2 branch on #85504.

I reproduced the failing build locally and confirmed that this commit fixes that.