### PR TITLE
[8.2] Ignore app priv failures when resolving superuser (#85519)

### DIFF
--- a/docs/changelog/85519.yaml
+++ b/docs/changelog/85519.yaml
@@ -1,0 +1,5 @@
+pr: 85519
+summary: Ignore app priv failures when resolving superuser
+area: Authorization
+type: bug
+issues: []

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authz/store/CompositeRolesStore.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authz/store/CompositeRolesStore.java
@@ -240,22 +240,7 @@ public class CompositeRolesStore {
         final Role existing = roleCache.get(roleKey);
         if (existing == null) {
             final long invalidationCounter = numInvalidation.get();
-            roleReference.resolve(roleReferenceResolver, ActionListener.wrap(rolesRetrievalResult -> {
-                if (RolesRetrievalResult.EMPTY == rolesRetrievalResult) {
-                    roleActionListener.onResponse(Role.EMPTY);
-                } else if (RolesRetrievalResult.SUPERUSER == rolesRetrievalResult) {
-                    roleActionListener.onResponse(superuserRole);
-                } else {
-                    buildThenMaybeCacheRole(
-                        roleKey,
-                        rolesRetrievalResult.getRoleDescriptors(),
-                        rolesRetrievalResult.getMissingRoles(),
-                        rolesRetrievalResult.isSuccess(),
-                        invalidationCounter,
-                        roleActionListener
-                    );
-                }
-            }, e -> {
+            final Consumer<Exception> failureHandler = e -> {
                 // Because superuser does not have write access to restricted indices, it is valid to mix superuser with other roles to
                 // gain addition access. However, if retrieving those roles fails for some reason, then that could leave admins in a
                 // situation where they are unable to administer their cluster (in order to resolve the problem that is leading to failures
@@ -274,7 +259,23 @@ public class CompositeRolesStore {
                 } else {
                     roleActionListener.onFailure(e);
                 }
-            }));
+            };
+            roleReference.resolve(roleReferenceResolver, ActionListener.wrap(rolesRetrievalResult -> {
+                if (RolesRetrievalResult.EMPTY == rolesRetrievalResult) {
+                    roleActionListener.onResponse(Role.EMPTY);
+                } else if (RolesRetrievalResult.SUPERUSER == rolesRetrievalResult) {
+                    roleActionListener.onResponse(superuserRole);
+                } else {
+                    buildThenMaybeCacheRole(
+                        roleKey,
+                        rolesRetrievalResult.getRoleDescriptors(),
+                        rolesRetrievalResult.getMissingRoles(),
+                        rolesRetrievalResult.isSuccess(),
+                        invalidationCounter,
+                        ActionListener.wrap(roleActionListener::onResponse, failureHandler)
+                    );
+                }
+            }, failureHandler));
         } else {
             roleActionListener.onResponse(existing);
         }


### PR DESCRIPTION
Backports the following commits to 8.2:
 - Ignore app priv failures when resolving superuser (#85519)