### PR TITLE
[Test] Add a dedicate helper class for randomizing Authentication

### DIFF
--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authc/AuthenticationTestHelper.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authc/AuthenticationTestHelper.java
@@ -1,0 +1,491 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.core.security.authc;
+
+import org.elasticsearch.Version;
+import org.elasticsearch.common.bytes.BytesArray;
+import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.test.XContentTestUtils;
+import org.elasticsearch.xcontent.XContentType;
+import org.elasticsearch.xpack.core.security.action.service.TokenInfo;
+import org.elasticsearch.xpack.core.security.authc.Authentication.AuthenticationType;
+import org.elasticsearch.xpack.core.security.authc.esnative.NativeRealmSettings;
+import org.elasticsearch.xpack.core.security.authc.file.FileRealmSettings;
+import org.elasticsearch.xpack.core.security.authc.jwt.JwtRealmSettings;
+import org.elasticsearch.xpack.core.security.authc.kerberos.KerberosRealmSettings;
+import org.elasticsearch.xpack.core.security.authc.ldap.LdapRealmSettings;
+import org.elasticsearch.xpack.core.security.authc.oidc.OpenIdConnectRealmSettings;
+import org.elasticsearch.xpack.core.security.authc.saml.SamlRealmSettings;
+import org.elasticsearch.xpack.core.security.authc.service.ServiceAccountSettings;
+import org.elasticsearch.xpack.core.security.user.AnonymousUser;
+import org.elasticsearch.xpack.core.security.user.AsyncSearchUser;
+import org.elasticsearch.xpack.core.security.user.SystemUser;
+import org.elasticsearch.xpack.core.security.user.User;
+import org.elasticsearch.xpack.core.security.user.XPackSecurityUser;
+import org.elasticsearch.xpack.core.security.user.XPackUser;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.EnumSet;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.function.Supplier;
+
+public class AuthenticationTestHelper {
+
+    private static final Set<String> SYNTHETIC_REALM_TYPES = Set.of(
+        AuthenticationField.API_KEY_REALM_TYPE,
+        AuthenticationField.ANONYMOUS_REALM_TYPE,
+        AuthenticationField.ATTACH_REALM_TYPE,
+        AuthenticationField.FALLBACK_REALM_TYPE,
+        ServiceAccountSettings.REALM_TYPE
+    );
+
+    public static AuthenticationTestBuilder builder() {
+        return new AuthenticationTestBuilder();
+    }
+
+    public static User randomUser() {
+        return new User(
+            ESTestCase.randomAlphaOfLengthBetween(3, 8),
+            ESTestCase.randomArray(1, 3, String[]::new, () -> ESTestCase.randomAlphaOfLengthBetween(3, 8))
+        );
+    }
+
+    public static RealmDomain randomDomain(boolean includeInternal) {
+        final Supplier<String> randomRealmTypeSupplier = randomRealmTypeSupplier(includeInternal);
+        final Set<RealmConfig.RealmIdentifier> domainRealms = new HashSet<>(
+            Arrays.asList(
+                ESTestCase.randomArray(
+                    1,
+                    4,
+                    RealmConfig.RealmIdentifier[]::new,
+                    () -> new RealmConfig.RealmIdentifier(
+                        randomRealmTypeSupplier.get(),
+                        ESTestCase.randomAlphaOfLengthBetween(3, 8).toLowerCase(Locale.ROOT)
+                    )
+                )
+            )
+        );
+        return new RealmDomain(ESTestCase.randomAlphaOfLengthBetween(3, 8), domainRealms);
+    }
+
+    public static Authentication.RealmRef randomRealmRef(boolean underDomain) {
+        return randomRealmRef(underDomain, true);
+    }
+
+    public static Authentication.RealmRef randomRealmRef(boolean underDomain, boolean includeInternal) {
+        if (underDomain) {
+            RealmDomain domain = randomDomain(includeInternal);
+            RealmConfig.RealmIdentifier realmIdentifier = ESTestCase.randomFrom(domain.realms());
+            return new Authentication.RealmRef(
+                realmIdentifier.getName(),
+                realmIdentifier.getType(),
+                ESTestCase.randomAlphaOfLengthBetween(3, 8),
+                domain
+            );
+        } else {
+            return new Authentication.RealmRef(
+                ESTestCase.randomAlphaOfLengthBetween(3, 8),
+                randomRealmTypeSupplier(includeInternal).get(),
+                ESTestCase.randomAlphaOfLengthBetween(3, 8),
+                null
+            );
+        }
+    }
+
+    private static Supplier<String> randomRealmTypeSupplier(boolean includeInternal) {
+        final Supplier<String> randomAllRealmTypeSupplier = () -> ESTestCase.randomFrom(
+            "reserved",
+            FileRealmSettings.TYPE,
+            NativeRealmSettings.TYPE,
+            LdapRealmSettings.AD_TYPE,
+            LdapRealmSettings.LDAP_TYPE,
+            JwtRealmSettings.TYPE,
+            OpenIdConnectRealmSettings.TYPE,
+            SamlRealmSettings.TYPE,
+            KerberosRealmSettings.TYPE,
+            ESTestCase.randomAlphaOfLengthBetween(3, 8)
+        );
+        if (includeInternal) {
+            return randomAllRealmTypeSupplier;
+        } else {
+            return () -> ESTestCase.randomValueOtherThanMany(
+                value -> value.equals(FileRealmSettings.TYPE) || value.equals(NativeRealmSettings.TYPE) || value.equals("reserved"),
+                randomAllRealmTypeSupplier
+            );
+        }
+    }
+
+    public static class AuthenticationTestBuilder {
+        private Version version;
+        private Authentication authenticatingAuthentication;
+        private User user;
+        private Authentication.RealmRef realmRef;
+        private EnumSet<AuthenticationType> candidateAuthenticationTypes = EnumSet.allOf(AuthenticationType.class);
+        private final Map<String, Object> metadata = new HashMap<>();
+        private Boolean isServiceAccount;
+        private Boolean isRealmUnderDomain;
+
+        private AuthenticationTestBuilder() {}
+
+        private AuthenticationTestBuilder(Authentication authentication) {
+            assert false == authentication.getUser().isRunAs() : "authenticating authentication cannot itself be run-as";
+            this.authenticatingAuthentication = authentication;
+            this.version = authentication.getVersion();
+        }
+
+        public AuthenticationTestBuilder realm() {
+            return realm(ESTestCase.randomBoolean());
+        }
+
+        public AuthenticationTestBuilder realm(boolean underDomain) {
+            if (authenticatingAuthentication != null) {
+                throw new IllegalArgumentException("run-as authentication is always looked up from a realm");
+            }
+            resetShortcutRelatedVariables();
+            this.user = null;
+            this.realmRef = null;
+            this.candidateAuthenticationTypes = EnumSet.of(AuthenticationType.REALM);
+            this.isRealmUnderDomain = underDomain;
+            return this;
+        }
+
+        public AuthenticationTestBuilder serviceAccount() {
+            return serviceAccount(
+                new User(ESTestCase.randomAlphaOfLengthBetween(3, 8) + "/" + ESTestCase.randomAlphaOfLengthBetween(3, 8))
+            );
+        }
+
+        public AuthenticationTestBuilder serviceAccount(User user) {
+            assert user.principal().contains("/") : "invalid service account principal";
+            if (authenticatingAuthentication != null) {
+                throw new IllegalArgumentException("run-as authentication cannot be service account");
+            }
+            resetShortcutRelatedVariables();
+            this.isServiceAccount = true;
+            this.user = user;
+            this.realmRef = null;
+            this.candidateAuthenticationTypes = EnumSet.of(AuthenticationType.TOKEN);
+            return this;
+        }
+
+        public AuthenticationTestBuilder apiKey(String apiKeyId) {
+            if (authenticatingAuthentication != null) {
+                throw new IllegalArgumentException("run-as authentication cannot be api key");
+            }
+            resetShortcutRelatedVariables();
+            this.realmRef = null;
+            this.candidateAuthenticationTypes = EnumSet.of(AuthenticationType.API_KEY);
+            metadata.put(AuthenticationField.API_KEY_ID_KEY, Objects.requireNonNull(apiKeyId));
+            return this;
+        }
+
+        public AuthenticationTestBuilder anonymous() {
+            return anonymous(
+                new AnonymousUser(
+                    Settings.builder().put(AnonymousUser.ROLES_SETTING.getKey(), ESTestCase.randomAlphaOfLengthBetween(3, 8)).build()
+                )
+            );
+        }
+
+        public AuthenticationTestBuilder anonymous(User user) {
+            assert user instanceof AnonymousUser : "user must be anonymous for anonymous authentication";
+            if (authenticatingAuthentication != null) {
+                throw new IllegalArgumentException("run-as authentication cannot be anonymous");
+            }
+            resetShortcutRelatedVariables();
+            this.user = null;
+            this.realmRef = null;
+            this.candidateAuthenticationTypes = EnumSet.of(AuthenticationType.ANONYMOUS);
+            return this;
+        }
+
+        public AuthenticationTestBuilder internal() {
+            return internal(
+                ESTestCase.randomFrom(SystemUser.INSTANCE, XPackUser.INSTANCE, XPackSecurityUser.INSTANCE, AsyncSearchUser.INSTANCE)
+            );
+        }
+
+        public AuthenticationTestBuilder internal(User user) {
+            assert User.isInternal(user) : "user must be internal for internal authentication";
+            if (authenticatingAuthentication != null) {
+                throw new IllegalArgumentException("run-as authentication cannot be internal");
+            }
+            resetShortcutRelatedVariables();
+            this.user = user;
+            this.realmRef = null;
+            this.candidateAuthenticationTypes = EnumSet.of(AuthenticationType.INTERNAL);
+            return this;
+        }
+
+        public AuthenticationTestBuilder user(User user) {
+            if (User.isInternal(user)) {
+                return internal(user);
+            } else if (user instanceof AnonymousUser) {
+                return anonymous(user);
+            } else {
+                this.user = user;
+                candidateAuthenticationTypes.removeIf(t -> t == AuthenticationType.INTERNAL || t == AuthenticationType.ANONYMOUS);
+                return this;
+            }
+        }
+
+        public AuthenticationTestBuilder realmRef(Authentication.RealmRef realmRef) {
+            assert false == SYNTHETIC_REALM_TYPES.contains(realmRef.getType()) : "use dedicate methods for synthetic realms";
+            resetShortcutRelatedVariables();
+            this.realmRef = realmRef;
+            isServiceAccount = false;
+            candidateAuthenticationTypes.removeIf(
+                t -> t == AuthenticationType.INTERNAL || t == AuthenticationType.ANONYMOUS || t == AuthenticationType.API_KEY
+            );
+            return this;
+        }
+
+        public AuthenticationTestBuilder version(Version version) {
+            if (authenticatingAuthentication != null) {
+                throw new IllegalArgumentException("cannot set version for run-as authentication");
+            }
+            this.version = Objects.requireNonNull(version);
+            return this;
+        }
+
+        public AuthenticationTestBuilder metadata(Map<String, Object> metadata) {
+            if (authenticatingAuthentication != null) {
+                throw new IllegalArgumentException("cannot add metadata for run-as authentication");
+            }
+            this.metadata.putAll(Objects.requireNonNull(metadata));
+            return this;
+        }
+
+        public AuthenticationTestBuilder runAs() {
+            if (authenticatingAuthentication != null) {
+                throw new IllegalArgumentException("cannot convert to run-as again for run-as authentication");
+            }
+            candidateAuthenticationTypes = EnumSet.of(AuthenticationType.REALM, AuthenticationType.API_KEY);
+            final Authentication authentication = build(false);
+            return new AuthenticationTestBuilder(authentication);
+        }
+
+        public Authentication build() {
+            return build(ESTestCase.randomBoolean());
+        }
+
+        public Authentication build(boolean runAsIfNotAlready) {
+            if (authenticatingAuthentication != null) {
+                if (user == null) {
+                    user = randomUser();
+                }
+                if (realmRef == null) {
+                    realmRef = randomRealmRef(isRealmUnderDomain == null ? ESTestCase.randomBoolean() : isRealmUnderDomain);
+                }
+                return authenticatingAuthentication.runAs(user, realmRef);
+            } else {
+                assert candidateAuthenticationTypes.size() > 0 : "no candidate authentication types";
+                final Authentication authentication;
+                final AuthenticationType authenticationType = ESTestCase.randomFrom(candidateAuthenticationTypes);
+                switch (authenticationType) {
+                    case REALM -> {
+                        if (user == null) {
+                            user = randomUser();
+                        }
+                        if (realmRef == null) {
+                            realmRef = randomRealmRef(isRealmUnderDomain == null ? ESTestCase.randomBoolean() : isRealmUnderDomain);
+                        }
+                        assert false == SYNTHETIC_REALM_TYPES.contains(realmRef.getType()) : "use dedicate methods for synthetic realms";
+                        if (runAsIfNotAlready) {
+                            authentication = builder().runAs().user(user).realmRef(realmRef).build();
+                        } else {
+                            authentication = Authentication.newRealmAuthentication(user, realmRef);
+                        }
+                    }
+                    case API_KEY -> {
+                        assert realmRef == null : "cannot specify realm type for API key authentication";
+                        if (user == null) {
+                            user = randomUser();
+                        }
+                        prepareApiKeyMetadata();
+                        authentication = Authentication.newApiKeyAuthentication(
+                            AuthenticationResult.success(user, metadata),
+                            ESTestCase.randomAlphaOfLengthBetween(3, 8)
+                        );
+                    }
+                    case TOKEN -> {
+                        if (isServiceAccount) {
+                            // service account
+                            assert user != null && user.principal().contains("/") : "invalid service account principal";
+                            assert realmRef == null : "cannot specify realm type for service account authentication";
+                            prepareServiceAccountMetadata();
+                            authentication = Authentication.newServiceAccountAuthentication(
+                                user,
+                                ESTestCase.randomAlphaOfLengthBetween(3, 8),
+                                metadata
+                            );
+                        } else {
+                            final int tokenVariant = ESTestCase.randomIntBetween(0, 9);
+                            if (tokenVariant == 0 && user == null && realmRef == null) {
+                                // service account
+                                authentication = Authentication.newServiceAccountAuthentication(
+                                    new User(
+                                        ESTestCase.randomAlphaOfLengthBetween(3, 8) + "/" + ESTestCase.randomAlphaOfLengthBetween(3, 8)
+                                    ),
+                                    ESTestCase.randomAlphaOfLengthBetween(3, 8),
+                                    metadata
+                                );
+                            } else if (tokenVariant == 1 && realmRef == null) {
+                                // token by api key
+                                if (user == null) {
+                                    user = randomUser();
+                                }
+                                prepareApiKeyMetadata();
+                                authentication = Authentication.newApiKeyAuthentication(
+                                    AuthenticationResult.success(user, metadata),
+                                    ESTestCase.randomAlphaOfLengthBetween(3, 8)
+                                ).token();
+                            } else {
+                                // token by realm user
+                                if (user == null) {
+                                    user = randomUser();
+                                }
+                                if (realmRef == null) {
+                                    realmRef = randomRealmRef(isRealmUnderDomain == null ? ESTestCase.randomBoolean() : isRealmUnderDomain);
+                                }
+                                authentication = Authentication.newRealmAuthentication(user, realmRef).token();
+                            }
+                        }
+                    }
+                    case ANONYMOUS -> {
+                        if (user == null) {
+                            user = new AnonymousUser(
+                                Settings.builder()
+                                    .put(AnonymousUser.ROLES_SETTING.getKey(), ESTestCase.randomAlphaOfLengthBetween(3, 8))
+                                    .build()
+                            );
+                        }
+                        assert user instanceof AnonymousUser : "user must be anonymous for anonymous authentication";
+                        assert realmRef == null : "cannot specify realm type for anonymous authentication";
+                        authentication = Authentication.newAnonymousAuthentication(
+                            (AnonymousUser) user,
+                            ESTestCase.randomAlphaOfLengthBetween(3, 8)
+                        );
+                    }
+                    case INTERNAL -> {
+                        if (user == null) {
+                            user = ESTestCase.randomFrom(
+                                SystemUser.INSTANCE,
+                                XPackUser.INSTANCE,
+                                XPackSecurityUser.INSTANCE,
+                                AsyncSearchUser.INSTANCE
+                            );
+                        }
+                        assert User.isInternal(user) : "user must be internal for internal authentication";
+                        assert realmRef == null : "cannot specify realm type for internal authentication";
+                        String nodeName = ESTestCase.randomAlphaOfLengthBetween(3, 8);
+                        if (user == SystemUser.INSTANCE) {
+                            authentication = ESTestCase.randomFrom(
+                                Authentication.newInternalAuthentication(user, Version.CURRENT, nodeName),
+                                Authentication.newInternalFallbackAuthentication(user, nodeName)
+                            );
+                        } else {
+                            authentication = Authentication.newInternalAuthentication(user, Version.CURRENT, nodeName);
+                        }
+                    }
+                    default -> throw new IllegalArgumentException("unknown authentication type [" + authenticationType + "]");
+                }
+                if (version == null) {
+                    version = Version.CURRENT;
+                }
+                if (version.before(authentication.getVersion())) {
+                    return authentication.maybeRewriteForOlderVersion(version);
+                } else {
+                    return authentication;
+                }
+            }
+        }
+
+        private void prepareApiKeyMetadata() {
+            if (false == metadata.containsKey(AuthenticationField.API_KEY_ID_KEY)) {
+                metadata.put(AuthenticationField.API_KEY_ID_KEY, ESTestCase.randomAlphaOfLength(20));
+            }
+            if (false == metadata.containsKey(AuthenticationField.API_KEY_NAME_KEY)) {
+                metadata.put(
+                    AuthenticationField.API_KEY_NAME_KEY,
+                    ESTestCase.randomBoolean() ? null : ESTestCase.randomAlphaOfLengthBetween(1, 16)
+                );
+            }
+            if (false == metadata.containsKey(AuthenticationField.API_KEY_CREATOR_REALM_NAME)) {
+                assert false == metadata.containsKey(AuthenticationField.API_KEY_CREATOR_REALM_TYPE)
+                    : "creator realm name and type must be both present or absent";
+                final Authentication.RealmRef creatorRealmRef = randomRealmRef(
+                    isRealmUnderDomain == null ? ESTestCase.randomBoolean() : isRealmUnderDomain
+                );
+                metadata.put(AuthenticationField.API_KEY_CREATOR_REALM_NAME, creatorRealmRef.getName());
+                metadata.put(AuthenticationField.API_KEY_CREATOR_REALM_TYPE, creatorRealmRef.getType());
+            }
+            if (false == metadata.containsKey(AuthenticationField.API_KEY_ROLE_DESCRIPTORS_KEY)) {
+                metadata.put(AuthenticationField.API_KEY_ROLE_DESCRIPTORS_KEY, new BytesArray("{}"));
+            }
+            if (false == metadata.containsKey(AuthenticationField.API_KEY_LIMITED_ROLE_DESCRIPTORS_KEY)) {
+                metadata.put(AuthenticationField.API_KEY_LIMITED_ROLE_DESCRIPTORS_KEY, new BytesArray("""
+                    {"x":{"cluster":["all"],"indices":[{"names":["index*"],"privileges":["all"]}]}}"""));
+            }
+            if (false == metadata.containsKey(AuthenticationField.API_KEY_METADATA_KEY)) {
+                if (ESTestCase.randomBoolean()) {
+                    final Map<String, Object> keyMetadata = ESTestCase.randomFrom(
+                        Map.of(
+                            "application",
+                            ESTestCase.randomAlphaOfLength(5),
+                            "number",
+                            1,
+                            "numbers",
+                            List.of(1, 3, 5),
+                            "environment",
+                            Map.of("os", "linux", "level", 42, "category", "trusted")
+                        ),
+                        Map.of(ESTestCase.randomAlphaOfLengthBetween(3, 8), ESTestCase.randomAlphaOfLengthBetween(3, 8)),
+                        Map.of(),
+                        null
+                    );
+                    if (keyMetadata != null) {
+                        final BytesReference metadataBytes;
+                        try {
+                            metadataBytes = XContentTestUtils.convertToXContent(keyMetadata, XContentType.JSON);
+                        } catch (IOException e) {
+                            throw new RuntimeException(e);
+                        }
+                        metadata.put(AuthenticationField.API_KEY_METADATA_KEY, metadataBytes);
+                    }
+                }
+            }
+        }
+
+        private void prepareServiceAccountMetadata() {
+            if (false == metadata.containsKey(ServiceAccountSettings.TOKEN_NAME_FIELD)) {
+                metadata.put(ServiceAccountSettings.TOKEN_NAME_FIELD, ESTestCase.randomAlphaOfLength(8));
+            }
+            if (false == metadata.containsKey(ServiceAccountSettings.TOKEN_SOURCE_FIELD)) {
+                metadata.put(
+                    ServiceAccountSettings.TOKEN_SOURCE_FIELD,
+                    ESTestCase.randomFrom(TokenInfo.TokenSource.values()).name().toLowerCase(Locale.ROOT)
+                );
+            }
+        }
+
+        private void resetShortcutRelatedVariables() {
+            isServiceAccount = null;
+            isRealmUnderDomain = null;
+        }
+    }
+}

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authc/AuthenticationTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authc/AuthenticationTests.java
@@ -8,7 +8,6 @@
 package org.elasticsearch.xpack.core.security.authc;
 
 import org.elasticsearch.Version;
-import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.elasticsearch.common.io.stream.StreamInput;
@@ -19,33 +18,18 @@ import org.elasticsearch.test.VersionUtils;
 import org.elasticsearch.xcontent.ToXContent;
 import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xcontent.XContentType;
-import org.elasticsearch.xpack.core.security.action.service.TokenInfo;
-import org.elasticsearch.xpack.core.security.authc.Authentication.AuthenticationType;
 import org.elasticsearch.xpack.core.security.authc.Authentication.RealmRef;
 import org.elasticsearch.xpack.core.security.authc.esnative.NativeRealmSettings;
 import org.elasticsearch.xpack.core.security.authc.file.FileRealmSettings;
-import org.elasticsearch.xpack.core.security.authc.jwt.JwtRealmSettings;
-import org.elasticsearch.xpack.core.security.authc.kerberos.KerberosRealmSettings;
-import org.elasticsearch.xpack.core.security.authc.ldap.LdapRealmSettings;
-import org.elasticsearch.xpack.core.security.authc.oidc.OpenIdConnectRealmSettings;
-import org.elasticsearch.xpack.core.security.authc.saml.SamlRealmSettings;
 import org.elasticsearch.xpack.core.security.authc.service.ServiceAccountSettings;
 import org.elasticsearch.xpack.core.security.user.AnonymousUser;
-import org.elasticsearch.xpack.core.security.user.AsyncSearchUser;
-import org.elasticsearch.xpack.core.security.user.SystemUser;
 import org.elasticsearch.xpack.core.security.user.User;
-import org.elasticsearch.xpack.core.security.user.XPackSecurityUser;
-import org.elasticsearch.xpack.core.security.user.XPackUser;
 
 import java.io.IOException;
 import java.util.Arrays;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Consumer;
-import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 import static org.hamcrest.Matchers.hasEntry;
@@ -487,70 +471,6 @@ public class AuthenticationTests extends ESTestCase {
         assertFalse(authentication1.canAccessResourcesOf(authentication0));
     }
 
-    public static User randomUser() {
-        return new User(randomAlphaOfLengthBetween(3, 8), randomArray(1, 3, String[]::new, () -> randomAlphaOfLengthBetween(3, 8)));
-    }
-
-    public static RealmRef randomRealmRef(boolean underDomain) {
-        return randomRealmRef(underDomain, true);
-    }
-
-    private static Supplier<String> randomRealmTypeSupplier(boolean includeInternal) {
-        final Supplier<String> randomAllRealmTypeSupplier = () -> randomFrom(
-            "reserved",
-            FileRealmSettings.TYPE,
-            NativeRealmSettings.TYPE,
-            LdapRealmSettings.AD_TYPE,
-            LdapRealmSettings.LDAP_TYPE,
-            JwtRealmSettings.TYPE,
-            OpenIdConnectRealmSettings.TYPE,
-            SamlRealmSettings.TYPE,
-            KerberosRealmSettings.TYPE,
-            randomAlphaOfLengthBetween(3, 8)
-        );
-        if (includeInternal) {
-            return randomAllRealmTypeSupplier;
-        } else {
-            return () -> randomValueOtherThanMany(
-                value -> value.equals(FileRealmSettings.TYPE) || value.equals(NativeRealmSettings.TYPE) || value.equals("reserved"),
-                randomAllRealmTypeSupplier
-            );
-        }
-    }
-
-    public static RealmDomain randomDomain(boolean includeInternal) {
-        final Supplier<String> randomRealmTypeSupplier = randomRealmTypeSupplier(includeInternal);
-        final Set<RealmConfig.RealmIdentifier> domainRealms = new HashSet<>(
-            Arrays.asList(
-                randomArray(
-                    1,
-                    4,
-                    RealmConfig.RealmIdentifier[]::new,
-                    () -> new RealmConfig.RealmIdentifier(
-                        randomRealmTypeSupplier.get(),
-                        randomAlphaOfLengthBetween(3, 8).toLowerCase(Locale.ROOT)
-                    )
-                )
-            )
-        );
-        return new RealmDomain(randomAlphaOfLengthBetween(3, 8), domainRealms);
-    }
-
-    public static RealmRef randomRealmRef(boolean underDomain, boolean includeInternal) {
-        if (underDomain) {
-            RealmDomain domain = randomDomain(includeInternal);
-            RealmConfig.RealmIdentifier realmIdentifier = randomFrom(domain.realms());
-            return new RealmRef(realmIdentifier.getName(), realmIdentifier.getType(), randomAlphaOfLengthBetween(3, 8), domain);
-        } else {
-            return new RealmRef(
-                randomAlphaOfLengthBetween(3, 8),
-                randomRealmTypeSupplier(includeInternal).get(),
-                randomAlphaOfLengthBetween(3, 8),
-                null
-            );
-        }
-    }
-
     private RealmRef mutateRealm(RealmRef original, String name, String type) {
         return new RealmRef(
             name == null ? original.getName() : name,
@@ -559,6 +479,26 @@ public class AuthenticationTests extends ESTestCase {
         );
     }
 
+    public static User randomUser() {
+        return AuthenticationTestHelper.randomUser();
+    }
+
+    public static RealmRef randomRealmRef(boolean underDomain) {
+        return AuthenticationTestHelper.randomRealmRef(underDomain);
+    }
+
+    public static RealmDomain randomDomain(boolean includeInternal) {
+        return AuthenticationTestHelper.randomDomain(includeInternal);
+    }
+
+    public static RealmRef randomRealmRef(boolean underDomain, boolean includeInternal) {
+        return AuthenticationTestHelper.randomRealmRef(underDomain, includeInternal);
+    }
+
+    /**
+     * Randomly create an authentication that has either realm or token authentication type.
+     * The authentication can have any version from 7.0.0 to current and random metadata.
+     */
     public static Authentication randomAuthentication(User user, RealmRef realmRef) {
         if (user == null) {
             user = randomUser();
@@ -567,17 +507,6 @@ public class AuthenticationTests extends ESTestCase {
             realmRef = randomRealmRef(false);
         }
         final Version version = VersionUtils.randomVersionBetween(random(), Version.V_7_0_0, Version.CURRENT);
-        final AuthenticationType authenticationType;
-        if (realmRef.getDomain() != null) {
-            authenticationType = randomValueOtherThanMany(
-                authType -> authType == AuthenticationType.API_KEY
-                    || authType == AuthenticationType.INTERNAL
-                    || authType == AuthenticationType.ANONYMOUS,
-                () -> randomFrom(AuthenticationType.values())
-            );
-        } else {
-            authenticationType = randomValueOtherThan(AuthenticationType.API_KEY, () -> randomFrom(AuthenticationType.values()));
-        }
         final Map<String, Object> metadata;
         if (randomBoolean()) {
             metadata = Map.of(randomAlphaOfLengthBetween(3, 8), randomAlphaOfLengthBetween(3, 8));
@@ -586,18 +515,7 @@ public class AuthenticationTests extends ESTestCase {
                 .distinct()
                 .collect(Collectors.toMap(s -> s, s -> randomAlphaOfLengthBetween(3, 8)));
         }
-        if (randomBoolean()) { // run-as
-            return new Authentication(
-                new User(user.principal(), user.roles(), randomUser()),
-                randomRealmRef(randomBoolean()),
-                realmRef,
-                version,
-                authenticationType,
-                metadata
-            );
-        } else {
-            return new Authentication(user, realmRef, null, version, authenticationType, metadata);
-        }
+        return AuthenticationTestHelper.builder().user(user).realmRef(realmRef).version(version).metadata(metadata).build();
     }
 
     public static Authentication randomApiKeyAuthentication(User user, String apiKeyId) {
@@ -621,51 +539,35 @@ public class AuthenticationTests extends ESTestCase {
         String creatorRealmType,
         Version version
     ) {
-        final HashMap<String, Object> metadata = new HashMap<>();
-        metadata.put(AuthenticationField.API_KEY_ID_KEY, apiKeyId);
-        metadata.put(AuthenticationField.API_KEY_NAME_KEY, randomBoolean() ? null : randomAlphaOfLengthBetween(1, 16));
-        metadata.put(AuthenticationField.API_KEY_CREATOR_REALM_NAME, creatorRealmName);
-        metadata.put(AuthenticationField.API_KEY_CREATOR_REALM_TYPE, creatorRealmType);
-        metadata.put(AuthenticationField.API_KEY_ROLE_DESCRIPTORS_KEY, new BytesArray("{}"));
-        metadata.put(AuthenticationField.API_KEY_LIMITED_ROLE_DESCRIPTORS_KEY, new BytesArray("""
-            {"x":{"cluster":["all"],"indices":[{"names":["index*"],"privileges":["all"]}]}}"""));
-        return Authentication.newApiKeyAuthentication(AuthenticationResult.success(user, metadata), randomAlphaOfLengthBetween(3, 8))
-            .maybeRewriteForOlderVersion(version);
+        return AuthenticationTestHelper.builder()
+            .apiKey(apiKeyId)
+            .user(user)
+            .version(version)
+            .metadata(
+                Map.of(
+                    AuthenticationField.API_KEY_CREATOR_REALM_NAME,
+                    creatorRealmName,
+                    AuthenticationField.API_KEY_CREATOR_REALM_TYPE,
+                    creatorRealmType
+                )
+            )
+            .build();
     }
 
     public static Authentication randomServiceAccountAuthentication() {
-        return Authentication.newServiceAccountAuthentication(
-            new User(randomAlphaOfLengthBetween(3, 8) + "/" + randomAlphaOfLengthBetween(3, 8)),
-            randomAlphaOfLengthBetween(3, 8),
-            Map.of(
-                "_token_name",
-                randomAlphaOfLength(8),
-                "_token_source",
-                randomFrom(TokenInfo.TokenSource.values()).name().toLowerCase(Locale.ROOT)
-            )
-        );
+        return AuthenticationTestHelper.builder().serviceAccount().build();
     }
 
     public static Authentication randomRealmAuthentication(boolean underDomain) {
-        return Authentication.newRealmAuthentication(randomUser(), randomRealmRef(underDomain));
+        return AuthenticationTestHelper.builder().realm(underDomain).build(false);
     }
 
     public static Authentication randomInternalAuthentication() {
-        String nodeName = randomAlphaOfLengthBetween(3, 8);
-        return randomFrom(
-            Authentication.newInternalAuthentication(
-                randomFrom(SystemUser.INSTANCE, XPackUser.INSTANCE, XPackSecurityUser.INSTANCE, AsyncSearchUser.INSTANCE),
-                Version.CURRENT,
-                nodeName
-            ),
-            Authentication.newInternalFallbackAuthentication(SystemUser.INSTANCE, nodeName)
-        );
+        return AuthenticationTestHelper.builder().internal().build();
     }
 
     public static Authentication randomAnonymousAuthentication() {
-        Settings settings = Settings.builder().put(AnonymousUser.ROLES_SETTING.getKey(), "anon_role").build();
-        String nodeName = randomAlphaOfLengthBetween(3, 8);
-        return Authentication.newAnonymousAuthentication(new AnonymousUser(settings), nodeName);
+        return AuthenticationTestHelper.builder().anonymous().build();
     }
 
     private boolean realmIsSingleton(RealmRef realmRef) {


### PR DESCRIPTION
The Authentication class has many internal logics about what values can
or cannot be combined together. It is not straightforward to always get
the logic right when trying to create such an object for tests. This
could lead to spurious failures or incomplete test coverage.

This PR adds a helper class for creating such an object with necessary
configurabililty. The relevant methods in AuthenticationTests now
delegate to the new class to avoid having to touch too many files in one
PR. The ultimate goal is to have it used in every place where an
Authentication object is needed for test to replace any calls to
constructors or mocking.

