### PR TITLE
[DOCS] Add default value for destructive_requires_name

### DIFF
--- a/docs/reference/modules/indices/index_management.asciidoc
+++ b/docs/reference/modules/indices/index_management.asciidoc
@@ -15,7 +15,7 @@ features.
 // tag::action-destructive-requires-name-tag[]
 `action.destructive_requires_name` {ess-icon}::
 (<<dynamic-cluster-setting,Dynamic>>)
-When set to `true`, you must specify the index name to <<indices-delete-index,delete an index>>. It is not possible to delete all indices with `_all` or use wildcards.
+When set to `true`, you must specify the index name to <<indices-delete-index,delete an index>>. It is not possible to delete all indices with `_all` or use wildcards. Defaults to `true`.
 // end::action-destructive-requires-name-tag[]
 
 [[cluster-indices-close-enable]]


### PR DESCRIPTION
As per https://github.com/elastic/elasticsearch/pull/66908, the setting now defaults to `True`, but it's not shown in the doc.  Can we please have the doc updated?