### PR TITLE
[8.2] Fix wildcard highlighting on match_only_text (#85500)

### DIFF
--- a/docs/changelog/85500.yaml
+++ b/docs/changelog/85500.yaml
@@ -1,0 +1,6 @@
+pr: 85500
+summary: Fix wildcard highlighting on `match_only_text`
+area: Highlighting
+type: bug
+issues:
+ - 85493

--- a/docs/reference/search/search-your-data/highlighting.asciidoc
+++ b/docs/reference/search/search-your-data/highlighting.asciidoc
@@ -164,12 +164,12 @@ insert the highlighting tags)
 
 fields:: Specifies the fields to retrieve highlights for. You can use wildcards
 to specify fields. For example, you could specify `comment_*` to
-get highlights for all <<text,text>> and <<keyword,keyword>> fields
-that start with `comment_`.
+get highlights for all <<text,text>>, <<match-only-text-field-type,match_only_text>>,
+and <<keyword,keyword>> fields that start with `comment_`.
 +
-NOTE: Only text and keyword fields are highlighted when you use wildcards.
-If you use a custom mapper and want to highlight on a field anyway, you
-must explicitly specify that field name.
+NOTE: Only text, match_only_text, and keyword fields are highlighted when
+you use wildcards. If you use a custom mapper and want to highlight on a
+field anyway, you must explicitly specify that field name.
 
 force_source:: Highlight based on the source even if the field is
 stored separately. Defaults to `false`.

--- a/modules/mapper-extras/src/yamlRestTest/resources/rest-api-spec/test/match_only_text/10_basic.yml
+++ b/modules/mapper-extras/src/yamlRestTest/resources/rest-api-spec/test/match_only_text/10_basic.yml
@@ -252,3 +252,25 @@ setup:
                   term: "lucane"
 
   - match: { "hits.total.value": 3 }
+
+---
+"Wildcard highlighting":
+
+  - skip:
+      version: " - 8.2.99"
+      reason: "Wildcard highlighting on match_only_text was fixed in 8.3"
+
+  - do:
+      search:
+        index: test
+        body:
+          query:
+            match:
+              foo: "many"
+          highlight:
+            fields:
+              "*": {}
+
+  - match: { hits.total.value: 1 }
+  - match: { hits.hits.0._source.foo: "The Apache Software Foundation manages many projects including Lucene" }
+  - match: { hits.hits.0.highlight.foo.0: "The Apache Software Foundation manages <em>many</em> projects including Lucene" }

--- a/modules/mapper-extras/src/yamlRestTest/resources/rest-api-spec/test/match_only_text/10_basic.yml
+++ b/modules/mapper-extras/src/yamlRestTest/resources/rest-api-spec/test/match_only_text/10_basic.yml
@@ -257,8 +257,8 @@ setup:
 "Wildcard highlighting":
 
   - skip:
-      version: " - 8.2.99"
-      reason: "Wildcard highlighting on match_only_text was fixed in 8.3"
+      version: " - 8.1.99"
+      reason: "Wildcard highlighting on match_only_text was fixed in 8.2"
 
   - do:
       search:

--- a/server/src/main/java/org/elasticsearch/search/fetch/subphase/highlight/HighlightPhase.java
+++ b/server/src/main/java/org/elasticsearch/search/fetch/subphase/highlight/HighlightPhase.java
@@ -108,7 +108,8 @@ public class HighlightPhase implements FetchSubPhase {
             for (String fieldName : fieldNamesToHighlight) {
                 MappedFieldType fieldType = context.getSearchExecutionContext().getFieldType(fieldName);
 
-                // We should prevent highlighting if a field is anything but a text or keyword field.
+                // We should prevent highlighting if a field is anything but a text, match_only_text,
+                // or keyword field.
                 // However, someone might implement a custom field type that has text and still want to
                 // highlight on that. We cannot know in advance if the highlighter will be able to
                 // highlight such a field and so we do the following:
@@ -118,7 +119,8 @@ public class HighlightPhase implements FetchSubPhase {
                 // what they were doing and try to highlight anyway.
                 if (fieldNameContainsWildcards) {
                     if (fieldType.typeName().equals(TextFieldMapper.CONTENT_TYPE) == false
-                        && fieldType.typeName().equals(KeywordFieldMapper.CONTENT_TYPE) == false) {
+                        && fieldType.typeName().equals(KeywordFieldMapper.CONTENT_TYPE) == false
+                        && fieldType.typeName().equals("match_only_text") == false) {
                         continue;
                     }
                     if (highlighter.canHighlight(fieldType) == false) {


### PR DESCRIPTION
Backports the following commits to 8.2:
 - Fix wildcard highlighting on match_only_text (#85500)