### PR TITLE
[8.1] [ML] Avoid multiple queued quantiles documents in renormalizer (#85555)

### DIFF
--- a/docs/changelog/85555.yaml
+++ b/docs/changelog/85555.yaml
@@ -1,0 +1,6 @@
+pr: 85555
+summary: Avoid multiple queued quantiles documents in renormalizer
+area: Machine Learning
+type: bug
+issues:
+ - 85539

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/process/autodetect/output/AutodetectResultProcessor.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/process/autodetect/output/AutodetectResultProcessor.java
@@ -234,7 +234,12 @@ public class AutodetectResultProcessor {
 
     public void setProcessKilled() {
         processKilled = true;
-        renormalizer.shutdown();
+        try {
+            renormalizer.shutdown();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new RuntimeException(e);
+        }
     }
 
     void handleOpenForecasts() {
@@ -538,7 +543,7 @@ public class AutodetectResultProcessor {
         flushListener.clear(flushId);
     }
 
-    public void waitUntilRenormalizerIsIdle() {
+    public void waitUntilRenormalizerIsIdle() throws InterruptedException {
         renormalizer.waitUntilIdle();
     }
 

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/process/normalizer/Renormalizer.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/process/normalizer/Renormalizer.java
@@ -25,10 +25,10 @@ public interface Renormalizer {
     /**
      * Blocks until the renormalizer is idle and no further quantiles updates are pending.
      */
-    void waitUntilIdle();
+    void waitUntilIdle() throws InterruptedException;
 
     /**
      * Shut down the renormalization ASAP.  Do not wait for it to fully complete.
      */
-    void shutdown();
+    void shutdown() throws InterruptedException;
 }

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/process/autodetect/output/AutodetectResultProcessorTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/process/autodetect/output/AutodetectResultProcessorTests.java
@@ -61,7 +61,6 @@ import java.util.Date;
 import java.util.Iterator;
 import java.util.List;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
-import java.util.concurrent.TimeoutException;
 
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
@@ -139,7 +138,7 @@ public class AutodetectResultProcessorTests extends ESTestCase {
         executor.shutdown();
     }
 
-    public void testProcess() throws TimeoutException {
+    public void testProcess() throws Exception {
         AutodetectResult autodetectResult = mock(AutodetectResult.class);
         when(process.readAutodetectResults()).thenReturn(Collections.singletonList(autodetectResult).iterator());
 
@@ -439,7 +438,7 @@ public class AutodetectResultProcessorTests extends ESTestCase {
         verify(renormalizer).isEnabled();
     }
 
-    public void testAwaitCompletion() throws TimeoutException {
+    public void testAwaitCompletion() throws Exception {
         AutodetectResult autodetectResult = mock(AutodetectResult.class);
         when(process.readAutodetectResults()).thenReturn(Collections.singletonList(autodetectResult).iterator());
 
@@ -492,7 +491,7 @@ public class AutodetectResultProcessorTests extends ESTestCase {
         verify(persister).bulkPersisterBuilder(eq(JOB_ID));
     }
 
-    public void testKill() throws TimeoutException {
+    public void testKill() throws Exception {
         AutodetectResult autodetectResult = mock(AutodetectResult.class);
         when(process.readAutodetectResults()).thenReturn(Collections.singletonList(autodetectResult).iterator());
 


### PR DESCRIPTION
Backports the following commits to 8.1:
 - [ML] Avoid multiple queued quantiles documents in renormalizer (#85555)