### PR TITLE
Blacklist wildcard highlighting v7 compat test on 8.1

### DIFF
--- a/modules/mapper-extras/build.gradle
+++ b/modules/mapper-extras/build.gradle
@@ -28,3 +28,9 @@ if (BuildParams.isSnapshotBuild() == false) {
     systemProperty 'es.index_mode_feature_flag_registered', 'true'
   }
 }
+
+tasks.named("yamlRestTestV7CompatTest").configure {
+  systemProperty 'tests.rest.blacklist', [
+    'match_only_text/10_basic/Wildcard highlighting',
+  ].join(',')
+}

--- a/modules/mapper-extras/build.gradle
+++ b/modules/mapper-extras/build.gradle
@@ -30,7 +30,5 @@ if (BuildParams.isSnapshotBuild() == false) {
 }
 
 tasks.named("yamlRestTestV7CompatTest").configure {
-  systemProperty 'tests.rest.blacklist', [
-    'match_only_text/10_basic/Wildcard highlighting',
-  ].join(',')
+  systemProperty 'tests.rest.blacklist', 'match_only_text/10_basic/Wildcard highlighting'
 }


### PR DESCRIPTION
The bug was fixed on 7.latest and 8.2+ so 8.1 can't run that newly added test from 7.latest.

Closes #85604