### PR TITLE
[8.1] mute PackageUpgradeTests.test21CheckUpgradedVersion (#85616)

### DIFF
--- a/qa/os/src/test/java/org/elasticsearch/packaging/test/PackageUpgradeTests.java
+++ b/qa/os/src/test/java/org/elasticsearch/packaging/test/PackageUpgradeTests.java
@@ -108,6 +108,7 @@ public class PackageUpgradeTests extends PackagingTestCase {
         verifySecurityNotAutoConfigured(installation);
     }
 
+    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/85386")
     public void test21CheckUpgradedVersion() throws Exception {
         assertWhileRunning(() -> { assertDocsExist(); });
     }


### PR DESCRIPTION
Backports the following commits to 8.1:
 - mute PackageUpgradeTests.test21CheckUpgradedVersion (#85616)