### PR TITLE
Speed up JsonXContentParser token conversion and text()

### DIFF
--- a/libs/x-content/impl/src/main/java/org/elasticsearch/xcontent/provider/json/JsonXContentParser.java
+++ b/libs/x-content/impl/src/main/java/org/elasticsearch/xcontent/provider/json/JsonXContentParser.java
@@ -94,9 +94,13 @@ public class JsonXContentParser extends AbstractXContentParser {
 
     @Override
     public String text() throws IOException {
-        if (currentToken().isValue()) {
-            return parser.getText();
+        if (currentToken().isValue() == false) {
+            throwOnNoText();
         }
+        return parser.getText();
+    }
+
+    private void throwOnNoText() {
         throw new IllegalStateException("Can't get text on a " + currentToken() + " at " + getTokenLocation());
     }
 
@@ -269,31 +273,23 @@ public class JsonXContentParser extends AbstractXContentParser {
         if (token == null) {
             return null;
         }
-        switch (token) {
-            case FIELD_NAME:
-                return Token.FIELD_NAME;
-            case VALUE_FALSE:
-            case VALUE_TRUE:
-                return Token.VALUE_BOOLEAN;
-            case VALUE_STRING:
-                return Token.VALUE_STRING;
-            case VALUE_NUMBER_INT:
-            case VALUE_NUMBER_FLOAT:
-                return Token.VALUE_NUMBER;
-            case VALUE_NULL:
-                return Token.VALUE_NULL;
-            case START_OBJECT:
-                return Token.START_OBJECT;
-            case END_OBJECT:
-                return Token.END_OBJECT;
-            case START_ARRAY:
-                return Token.START_ARRAY;
-            case END_ARRAY:
-                return Token.END_ARRAY;
-            case VALUE_EMBEDDED_OBJECT:
-                return Token.VALUE_EMBEDDED_OBJECT;
-        }
-        throw new IllegalStateException("No matching token for json_token [" + token + "]");
+        return switch (token) {
+            case START_OBJECT -> Token.START_OBJECT;
+            case END_OBJECT -> Token.END_OBJECT;
+            case START_ARRAY -> Token.START_ARRAY;
+            case END_ARRAY -> Token.END_ARRAY;
+            case FIELD_NAME -> Token.FIELD_NAME;
+            case VALUE_EMBEDDED_OBJECT -> Token.VALUE_EMBEDDED_OBJECT;
+            case VALUE_STRING -> Token.VALUE_STRING;
+            case VALUE_NUMBER_INT, VALUE_NUMBER_FLOAT -> Token.VALUE_NUMBER;
+            case VALUE_FALSE, VALUE_TRUE -> Token.VALUE_BOOLEAN;
+            case VALUE_NULL -> Token.VALUE_NULL;
+            default -> throw unknownTokenException(token);
+        };
+    }
+
+    private static IllegalStateException unknownTokenException(JsonToken token) {
+        return new IllegalStateException("No matching token for json_token [" + token + "]");
     }
 
     @Override

--- a/libs/x-content/src/main/java/org/elasticsearch/xcontent/XContentParser.java
+++ b/libs/x-content/src/main/java/org/elasticsearch/xcontent/XContentParser.java
@@ -32,78 +32,27 @@ import java.util.function.Supplier;
 public interface XContentParser extends Closeable {
 
     enum Token {
-        START_OBJECT {
-            @Override
-            public boolean isValue() {
-                return false;
-            }
-        },
-
-        END_OBJECT {
-            @Override
-            public boolean isValue() {
-                return false;
-            }
-        },
-
-        START_ARRAY {
-            @Override
-            public boolean isValue() {
-                return false;
-            }
-        },
-
-        END_ARRAY {
-            @Override
-            public boolean isValue() {
-                return false;
-            }
-        },
-
-        FIELD_NAME {
-            @Override
-            public boolean isValue() {
-                return false;
-            }
-        },
-
-        VALUE_STRING {
-            @Override
-            public boolean isValue() {
-                return true;
-            }
-        },
-
-        VALUE_NUMBER {
-            @Override
-            public boolean isValue() {
-                return true;
-            }
-        },
-
-        VALUE_BOOLEAN {
-            @Override
-            public boolean isValue() {
-                return true;
-            }
-        },
-
+        START_OBJECT(false),
+        END_OBJECT(false),
+        START_ARRAY(false),
+        END_ARRAY(false),
+        FIELD_NAME(false),
+        VALUE_STRING(true),
+        VALUE_NUMBER(true),
+        VALUE_BOOLEAN(true),
         // usually a binary value
-        VALUE_EMBEDDED_OBJECT {
-            @Override
-            public boolean isValue() {
-                return true;
-            }
-        },
+        VALUE_EMBEDDED_OBJECT(true),
+        VALUE_NULL(false);
 
-        VALUE_NULL {
-            @Override
-            public boolean isValue() {
-                return false;
-            }
-        };
+        private final boolean isValue;
 
-        public abstract boolean isValue();
+        Token(boolean isValue) {
+            this.isValue = isValue;
+        }
+
+        public boolean isValue() {
+            return isValue;
+        }
     }
 
     enum NumberType {


### PR DESCRIPTION
This reduces the compile size of convert token by about 20 bytes making it inline in a couple
of places that wouldn't inline before once `unknownTokenException` is deoptimized as dead code.
Same for the change to `text()` that saves some method size there so it inlines into the much used
textOrNull here and there.

With this change all calls in to `convertToken` in the common hot paths inline as do all the `isValue` checks from removing the strange overrides on the enum.