### PR TITLE
Log at WARN level for Watcher cluster state validation errors

### DIFF
--- a/docs/changelog/85632.yaml
+++ b/docs/changelog/85632.yaml
@@ -1,0 +1,5 @@
+pr: 85632
+summary: Log at WARN level for Watcher cluster state validation errors
+area: Watcher
+type: bug
+issues: []

--- a/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/WatcherService.java
+++ b/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/WatcherService.java
@@ -163,7 +163,7 @@ public class WatcherService {
                 || (watcherIndexMetadata.getState() == IndexMetadata.State.OPEN
                     && state.routingTable().index(watcherIndexMetadata.getIndex()).allPrimaryShardsActive());
         } catch (IllegalStateException e) {
-            logger.debug("error validating to start watcher", e);
+            logger.warn("Validation error: cannot start watcher", e);
             return false;
         }
     }


### PR DESCRIPTION
One of our users found that Watcher was not starting up correctly, but left no information in the log. We had to enable debug logging to see the log message that revealed the problem. This PR bumps that log line to WARN so that we can resolve similar future issues more quickly.

If I understand the code correctly, an error here will always prevent Watcher from starting, so I think it makes sense to log it at WARN level.

Relates https://github.com/elastic/elasticsearch/pull/85507