### PR TITLE
[8.1] Log at WARN level for Watcher cluster state validation errors (#85632)

### DIFF
--- a/docs/changelog/85632.yaml
+++ b/docs/changelog/85632.yaml
@@ -1,0 +1,5 @@
+pr: 85632
+summary: Log at WARN level for Watcher cluster state validation errors
+area: Watcher
+type: bug
+issues: []

--- a/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/WatcherService.java
+++ b/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/WatcherService.java
@@ -164,7 +164,7 @@ public class WatcherService {
                 || (watcherIndexMetadata.getState() == IndexMetadata.State.OPEN
                     && state.routingTable().index(watcherIndexMetadata.getIndex()).allPrimaryShardsActive());
         } catch (IllegalStateException e) {
-            logger.debug("error validating to start watcher", e);
+            logger.warn("Validation error: cannot start watcher", e);
             return false;
         }
     }


### PR DESCRIPTION
Backports the following commits to 8.1:
 - Log at WARN level for Watcher cluster state validation errors (#85632)