### PR TITLE
[8.2] Fix skip caching factor with indices.queries.cache.all_segments (#85510)

### DIFF
--- a/docs/changelog/85510.yaml
+++ b/docs/changelog/85510.yaml
@@ -1,0 +1,5 @@
+pr: 85510
+summary: Fix skip caching factor with `indices.queries.cache.all_segments`
+area: Search
+type: bug
+issues: []

--- a/server/src/main/java/org/elasticsearch/indices/IndicesQueryCache.java
+++ b/server/src/main/java/org/elasticsearch/indices/IndicesQueryCache.java
@@ -77,7 +77,8 @@ public class IndicesQueryCache implements QueryCache, Closeable {
         final int count = INDICES_CACHE_QUERY_COUNT_SETTING.get(settings);
         logger.debug("using [node] query cache with size [{}] max filter count [{}]", size, count);
         if (INDICES_QUERIES_CACHE_ALL_SEGMENTS_SETTING.get(settings)) {
-            cache = new ElasticsearchLRUQueryCache(count, size.getBytes(), context -> true, 1f);
+            // Use the default skip_caching_factor (i.e., 10f) in Lucene
+            cache = new ElasticsearchLRUQueryCache(count, size.getBytes(), context -> true, 10f);
         } else {
             cache = new ElasticsearchLRUQueryCache(count, size.getBytes());
         }


### PR DESCRIPTION
Backports the following commits to 8.2:
 - Fix skip caching factor with indices.queries.cache.all_segments (#85510)