### PR TITLE
Cleanup XContentParserUtils throw on method signatures

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/bulk/BulkItemResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/bulk/BulkItemResponse.java
@@ -117,7 +117,7 @@ public class BulkItemResponse implements Writeable, StatusToXContentObject {
             builder = deleteResponseBuilder;
             itemParser = (deleteParser) -> DeleteResponse.parseXContentFields(deleteParser, deleteResponseBuilder);
         } else {
-            throwUnknownField(currentFieldName, parser.getTokenLocation());
+            throwUnknownField(currentFieldName, parser);
         }
 
         RestStatus status = null;

--- a/server/src/main/java/org/elasticsearch/action/bulk/BulkResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/bulk/BulkResponse.java
@@ -174,7 +174,7 @@ public class BulkResponse extends ActionResponse implements Iterable<BulkItemRes
                 } else if (INGEST_TOOK.equals(currentFieldName)) {
                     ingestTook = parser.longValue();
                 } else if (ERRORS.equals(currentFieldName) == false) {
-                    throwUnknownField(currentFieldName, parser.getTokenLocation());
+                    throwUnknownField(currentFieldName, parser);
                 }
             } else if (token == XContentParser.Token.START_ARRAY) {
                 if (ITEMS.equals(currentFieldName)) {
@@ -182,10 +182,10 @@ public class BulkResponse extends ActionResponse implements Iterable<BulkItemRes
                         items.add(BulkItemResponse.fromXContent(parser, items.size()));
                     }
                 } else {
-                    throwUnknownField(currentFieldName, parser.getTokenLocation());
+                    throwUnknownField(currentFieldName, parser);
                 }
             } else {
-                throwUnknownToken(token, parser.getTokenLocation());
+                throwUnknownToken(token, parser);
             }
         }
         return new BulkResponse(items.toArray(new BulkItemResponse[items.size()]), took, ingestTook);

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/IndexMetadata.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/IndexMetadata.java
@@ -2074,7 +2074,7 @@ public class IndexMetadata implements Diffable<IndexMetadata>, ToXContentFragmen
                         // unknown, ignore
                     }
                 } else {
-                    XContentParserUtils.throwUnknownToken(token, parser.getTokenLocation());
+                    XContentParserUtils.throwUnknownToken(token, parser);
                 }
             }
             XContentParserUtils.ensureExpectedToken(XContentParser.Token.END_OBJECT, parser.nextToken(), parser);

--- a/server/src/main/java/org/elasticsearch/common/settings/Settings.java
+++ b/server/src/main/java/org/elasticsearch/common/settings/Settings.java
@@ -753,7 +753,7 @@ public final class Settings implements ToXContentFragment {
                     validateValue(key, parser.text(), parser, allowNullValues);
                     builder.put(key, parser.booleanValue());
                 } else {
-                    XContentParserUtils.throwUnknownToken(parser.currentToken(), parser.getTokenLocation());
+                    XContentParserUtils.throwUnknownToken(parser.currentToken(), parser);
                 }
         }
     }

--- a/server/src/main/java/org/elasticsearch/common/xcontent/XContentParserUtils.java
+++ b/server/src/main/java/org/elasticsearch/common/xcontent/XContentParserUtils.java
@@ -13,7 +13,6 @@ import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.core.CheckedFunction;
 import org.elasticsearch.xcontent.NamedXContentRegistry;
-import org.elasticsearch.xcontent.XContentLocation;
 import org.elasticsearch.xcontent.XContentParser;
 import org.elasticsearch.xcontent.XContentParser.Token;
 
@@ -47,17 +46,17 @@ public final class XContentParserUtils {
     /**
      * @throws ParsingException with a "unknown field found" reason
      */
-    public static void throwUnknownField(String field, XContentLocation location) {
+    public static void throwUnknownField(String field, XContentParser parser) {
         String message = "Failed to parse object: unknown field [%s] found";
-        throw new ParsingException(location, String.format(Locale.ROOT, message, field));
+        throw new ParsingException(parser.getTokenLocation(), String.format(Locale.ROOT, message, field));
     }
 
     /**
      * @throws ParsingException with a "unknown token found" reason
      */
-    public static void throwUnknownToken(Token token, XContentLocation location) {
+    public static void throwUnknownToken(Token token, XContentParser parser) {
         String message = "Failed to parse object: unexpected token [%s] found";
-        throw new ParsingException(location, String.format(Locale.ROOT, message, token));
+        throw new ParsingException(parser.getTokenLocation(), String.format(Locale.ROOT, message, token));
     }
 
     /**
@@ -113,7 +112,7 @@ public final class XContentParserUtils {
         } else if (token == Token.START_ARRAY) {
             value = parser.listOrderedMap();
         } else {
-            throwUnknownToken(token, parser.getTokenLocation());
+            throwUnknownToken(token, parser);
         }
         return value;
     }
@@ -141,7 +140,7 @@ public final class XContentParserUtils {
     public static <T> void parseTypedKeysObject(XContentParser parser, String delimiter, Class<T> objectClass, Consumer<T> consumer)
         throws IOException {
         if (parser.currentToken() != Token.START_OBJECT && parser.currentToken() != Token.START_ARRAY) {
-            throwUnknownToken(parser.currentToken(), parser.getTokenLocation());
+            throwUnknownToken(parser.currentToken(), parser);
         }
         String currentFieldName = parser.currentName();
         if (Strings.hasLength(currentFieldName)) {

--- a/server/src/main/java/org/elasticsearch/index/snapshots/blobstore/BlobStoreIndexShardSnapshot.java
+++ b/server/src/main/java/org/elasticsearch/index/snapshots/blobstore/BlobStoreIndexShardSnapshot.java
@@ -323,13 +323,13 @@ public class BlobStoreIndexShardSnapshot implements ToXContentFragment {
                             writerUuid = new BytesRef(parser.binaryValue());
                             assert writerUuid.length > 0;
                         } else {
-                            XContentParserUtils.throwUnknownField(currentFieldName, parser.getTokenLocation());
+                            XContentParserUtils.throwUnknownField(currentFieldName, parser);
                         }
                     } else {
-                        XContentParserUtils.throwUnknownToken(token, parser.getTokenLocation());
+                        XContentParserUtils.throwUnknownToken(token, parser);
                     }
                 } else {
-                    XContentParserUtils.throwUnknownToken(token, parser.getTokenLocation());
+                    XContentParserUtils.throwUnknownToken(token, parser);
                 }
             }
 
@@ -567,16 +567,16 @@ public class BlobStoreIndexShardSnapshot implements ToXContentFragment {
                 } else if (PARSE_INCREMENTAL_SIZE.match(currentFieldName, parser.getDeprecationHandler())) {
                     incrementalSize = parser.longValue();
                 } else {
-                    XContentParserUtils.throwUnknownField(currentFieldName, parser.getTokenLocation());
+                    XContentParserUtils.throwUnknownField(currentFieldName, parser);
                 }
             } else if (token == XContentParser.Token.START_ARRAY) {
                 if (PARSE_FILES.match(currentFieldName, parser.getDeprecationHandler())) {
                     indexFiles = XContentParserUtils.parseList(parser, FileInfo::fromXContent);
                 } else {
-                    XContentParserUtils.throwUnknownField(currentFieldName, parser.getTokenLocation());
+                    XContentParserUtils.throwUnknownField(currentFieldName, parser);
                 }
             } else {
-                XContentParserUtils.throwUnknownToken(token, parser.getTokenLocation());
+                XContentParserUtils.throwUnknownToken(token, parser);
             }
         }
 

--- a/server/src/main/java/org/elasticsearch/index/snapshots/blobstore/BlobStoreIndexShardSnapshots.java
+++ b/server/src/main/java/org/elasticsearch/index/snapshots/blobstore/BlobStoreIndexShardSnapshots.java
@@ -244,7 +244,7 @@ public class BlobStoreIndexShardSnapshots implements Iterable<SnapshotFiles>, To
             token = parser.nextToken();
             if (token == XContentParser.Token.START_ARRAY) {
                 if (ParseFields.FILES.match(currentFieldName, parser.getDeprecationHandler()) == false) {
-                    XContentParserUtils.throwUnknownField(currentFieldName, parser.getTokenLocation());
+                    XContentParserUtils.throwUnknownField(currentFieldName, parser);
                 }
                 while (parser.nextToken() != XContentParser.Token.END_ARRAY) {
                     FileInfo fileInfo = FileInfo.fromXContent(parser);
@@ -252,7 +252,7 @@ public class BlobStoreIndexShardSnapshots implements Iterable<SnapshotFiles>, To
                 }
             } else if (token == XContentParser.Token.START_OBJECT) {
                 if (ParseFields.SNAPSHOTS.match(currentFieldName, parser.getDeprecationHandler()) == false) {
-                    XContentParserUtils.throwUnknownField(currentFieldName, parser.getTokenLocation());
+                    XContentParserUtils.throwUnknownField(currentFieldName, parser);
                 }
                 while ((token = parser.nextToken()) != XContentParser.Token.END_OBJECT) {
                     XContentParserUtils.ensureExpectedToken(XContentParser.Token.FIELD_NAME, token, parser);
@@ -272,7 +272,7 @@ public class BlobStoreIndexShardSnapshots implements Iterable<SnapshotFiles>, To
                     }
                 }
             } else {
-                XContentParserUtils.throwUnknownToken(token, parser.getTokenLocation());
+                XContentParserUtils.throwUnknownToken(token, parser);
             }
         }
 

--- a/server/src/main/java/org/elasticsearch/repositories/RepositoryData.java
+++ b/server/src/main/java/org/elasticsearch/repositories/RepositoryData.java
@@ -816,7 +816,7 @@ public final class RepositoryData {
                     clusterUUID = parser.text();
                     assert clusterUUID.equals(MISSING_UUID) == false;
                 }
-                default -> XContentParserUtils.throwUnknownField(field, parser.getTokenLocation());
+                default -> XContentParserUtils.throwUnknownField(field, parser);
             }
         }
 

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/range/GeoDistanceAggregationBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/range/GeoDistanceAggregationBuilder.java
@@ -193,7 +193,7 @@ public class GeoDistanceAggregationBuilder extends ValuesSourceAggregationBuilde
                 } else if (TO_FIELD.match(currentFieldName, parser.getDeprecationHandler())) {
                     to = parser.doubleValue();
                 } else {
-                    XContentParserUtils.throwUnknownField(currentFieldName, parser.getTokenLocation());
+                    XContentParserUtils.throwUnknownField(currentFieldName, parser);
                 }
             } else if (token == XContentParser.Token.VALUE_STRING) {
                 if (KEY_FIELD.match(currentFieldName, parser.getDeprecationHandler())) {
@@ -203,7 +203,7 @@ public class GeoDistanceAggregationBuilder extends ValuesSourceAggregationBuilde
                 } else if (TO_FIELD.match(currentFieldName, parser.getDeprecationHandler())) {
                     toAsStr = parser.text();
                 } else {
-                    XContentParserUtils.throwUnknownField(currentFieldName, parser.getTokenLocation());
+                    XContentParserUtils.throwUnknownField(currentFieldName, parser);
                 }
             } else if (token == XContentParser.Token.VALUE_NULL) {
                 if (FROM_FIELD.match(currentFieldName, parser.getDeprecationHandler())
@@ -211,10 +211,10 @@ public class GeoDistanceAggregationBuilder extends ValuesSourceAggregationBuilde
                     || KEY_FIELD.match(currentFieldName, parser.getDeprecationHandler())) {
                     // ignore null value
                 } else {
-                    XContentParserUtils.throwUnknownField(currentFieldName, parser.getTokenLocation());
+                    XContentParserUtils.throwUnknownField(currentFieldName, parser);
                 }
             } else {
-                XContentParserUtils.throwUnknownToken(token, parser.getTokenLocation());
+                XContentParserUtils.throwUnknownToken(token, parser);
             }
         }
         if (fromAsStr != null || toAsStr != null) {


### PR DESCRIPTION
No need to make all callers pass in the the location object here
as all call sites take the current location of the parser anyway.
