### PR TITLE
Speed up Strings.validFileName

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/Strings.java
+++ b/server/src/main/java/org/elasticsearch/common/Strings.java
@@ -32,6 +32,8 @@ import java.util.Set;
 import java.util.StringTokenizer;
 import java.util.TreeSet;
 import java.util.function.Supplier;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 public class Strings {
 
@@ -351,7 +353,9 @@ public class Strings {
         return sb.toString();
     }
 
-    public static final Set<Character> INVALID_FILENAME_CHARS = Set.of('\\', '/', '*', '?', '"', '<', '>', '|', ' ', ',');
+    public static final String INVALID_FILENAME_CHARS = "["
+        + Stream.of('\\', '/', '*', '?', '"', '<', '>', '|', ' ', ',').map(c -> "'" + c + "'").collect(Collectors.joining(","))
+        + "]";
 
     public static boolean validFileName(String fileName) {
         for (int i = 0; i < fileName.length(); i++) {
@@ -373,12 +377,10 @@ public class Strings {
     }
 
     private static boolean isInvalidFileNameCharacter(char c) {
-        switch (c) {
-            case '\\', '/', '*', '?', '"', '<', '>', '|', ' ', ',' -> {
-                return true;
-            }
-        }
-        return false;
+        return switch (c) {
+            case '\\', '/', '*', '?', '"', '<', '>', '|', ' ', ',' -> true;
+            default -> false;
+        };
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/common/Strings.java
+++ b/server/src/main/java/org/elasticsearch/common/Strings.java
@@ -355,8 +355,7 @@ public class Strings {
 
     public static boolean validFileName(String fileName) {
         for (int i = 0; i < fileName.length(); i++) {
-            char c = fileName.charAt(i);
-            if (INVALID_FILENAME_CHARS.contains(c)) {
+            if (isInvalidFileNameCharacter(fileName.charAt(i))) {
                 return false;
             }
         }
@@ -366,11 +365,20 @@ public class Strings {
     public static boolean validFileNameExcludingAstrix(String fileName) {
         for (int i = 0; i < fileName.length(); i++) {
             char c = fileName.charAt(i);
-            if (c != '*' && INVALID_FILENAME_CHARS.contains(c)) {
+            if (c != '*' && isInvalidFileNameCharacter(c)) {
                 return false;
             }
         }
         return true;
+    }
+
+    private static boolean isInvalidFileNameCharacter(char c) {
+        switch (c) {
+            case '\\', '/', '*', '?', '"', '<', '>', '|', ' ', ',' -> {
+                return true;
+            }
+        }
+        return false;
     }
 
     /**

--- a/server/src/test/java/org/elasticsearch/repositories/RepositoriesServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/repositories/RepositoriesServiceTests.java
@@ -23,7 +23,6 @@ import org.elasticsearch.cluster.metadata.RepositoryMetadata;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.service.ClusterApplierService;
 import org.elasticsearch.cluster.service.ClusterService;
-import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.UUIDs;
 import org.elasticsearch.common.blobstore.BlobPath;
 import org.elasticsearch.common.blobstore.BlobStore;
@@ -45,6 +44,7 @@ import org.elasticsearch.transport.Transport;
 import org.elasticsearch.transport.TransportService;
 import org.elasticsearch.xcontent.NamedXContentRegistry;
 
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
@@ -139,7 +139,7 @@ public class RepositoriesServiceTests extends ESTestCase {
     public void testRegisterRejectsInvalidRepositoryNames() {
         assertThrowsOnRegister("");
         assertThrowsOnRegister("contains#InvalidCharacter");
-        for (char c : Strings.INVALID_FILENAME_CHARS) {
+        for (char c : Arrays.asList('\\', '/', '*', '?', '"', '<', '>', '|', ' ', ',')) {
             assertThrowsOnRegister("contains" + c + "InvalidCharacters");
         }
     }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/privilege/ApplicationPrivilege.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/privilege/ApplicationPrivilege.java
@@ -140,7 +140,7 @@ public final class ApplicationPrivilege extends Privilege {
             if (Strings.validFileName(suffix) == false) {
                 throw new IllegalArgumentException(
                     "An application name suffix may not contain any of the characters '"
-                        + Strings.collectionToDelimitedString(Strings.INVALID_FILENAME_CHARS, "")
+                        + Strings.INVALID_FILENAME_CHARS
                         + "' (found '"
                         + suffix
                         + "')"


### PR DESCRIPTION
This method takes up ~10-15% of the CPU of updating an instance of `BlobStoreIndexShardSnapshots`
at the moment. This does matter for large repositories where there's a lot of shards to update, particularly
during deletes which all run on the same node.
Boxing and comparing chars via the set does not appear to get optimized by the compiler in any way
while the new method inlines fully and is essentially free compared to the rest of the logic in the caller methods.
