### PR TITLE
Update docs for v8.2.0 release

### DIFF
--- a/docs/reference/migration/migrate_8_2.asciidoc
+++ b/docs/reference/migration/migrate_8_2.asciidoc
@@ -1,0 +1,14 @@
+[[migrating-8.2]]
+== Migrating to 8.2
+++++
+<titleabbrev>8.2</titleabbrev>
+++++
+
+This section discusses the changes that you need to be aware of when migrating
+your application to {es} 8.2.
+
+See also <<release-highlights>> and <<es-release-notes>>.
+
+coming::[8.2.0-SNAPSHOT]
+
+

--- a/docs/reference/migration/migrate_8_2.asciidoc
+++ b/docs/reference/migration/migrate_8_2.asciidoc
@@ -9,6 +9,10 @@ your application to {es} 8.2.
 
 See also <<release-highlights>> and <<es-release-notes>>.
 
+[discrete]
+[[breaking-changes-8.2]]
+=== Breaking changes
+
 coming::[8.2.0-SNAPSHOT]
 
 

--- a/docs/reference/release-notes.asciidoc
+++ b/docs/reference/release-notes.asciidoc
@@ -6,6 +6,7 @@
 
 This section summarizes the changes in each release.
 
+* <<release-notes-8.2.0>>
 * <<release-notes-8.1.2>>
 * <<release-notes-8.1.1>>
 * <<release-notes-8.1.0>>
@@ -19,6 +20,7 @@ This section summarizes the changes in each release.
 
 --
 
+include::release-notes/8.2.0.asciidoc[]
 include::release-notes/8.1.2.asciidoc[]
 include::release-notes/8.1.1.asciidoc[]
 include::release-notes/8.1.0.asciidoc[]

--- a/docs/reference/release-notes/8.2.0.asciidoc
+++ b/docs/reference/release-notes/8.2.0.asciidoc
@@ -5,6 +5,10 @@ coming[8.2.0]
 
 Also see <<breaking-changes-8.2,Breaking changes in 8.2>>.
 
+[[breaking-8.2.0]]
+[float]
+=== Breaking changes
+
 [[bug-8.2.0]]
 [float]
 === Bug fixes

--- a/docs/reference/release-notes/8.2.0.asciidoc
+++ b/docs/reference/release-notes/8.2.0.asciidoc
@@ -3,7 +3,7 @@
 
 coming[8.2.0]
 
-Also see <<breaking-changes-8.2,Breaking changes in 8.2>>.
+// Also see <<breaking-changes-8.2,Breaking changes in 8.2>>.
 
 [[bug-8.2.0]]
 [float]

--- a/docs/reference/release-notes/8.2.0.asciidoc
+++ b/docs/reference/release-notes/8.2.0.asciidoc
@@ -5,10 +5,6 @@ coming[8.2.0]
 
 Also see <<breaking-changes-8.2,Breaking changes in 8.2>>.
 
-[[breaking-8.2.0]]
-[float]
-=== Breaking changes
-
 [[bug-8.2.0]]
 [float]
 === Bug fixes

--- a/docs/reference/release-notes/8.2.0.asciidoc
+++ b/docs/reference/release-notes/8.2.0.asciidoc
@@ -1,0 +1,330 @@
+[[release-notes-8.2.0]]
+== {es} version 8.2.0
+
+coming[8.2.0]
+
+Also see <<breaking-changes-8.2,Breaking changes in 8.2>>.
+
+[[bug-8.2.0]]
+[float]
+=== Bug fixes
+
+Aggregations::
+* Don't apply the rewrite-as-range optimization if field is multivalued {es-pull}84535[#84535] (issue: {es-issue}82903[#82903])
+* Fix: nested top metrics sort on keyword field {es-pull}85058[#85058]
+* Fix: use the correct field name when reading data from multi fields {es-pull}84752[#84752]
+
+Analysis::
+* Add tests for `min_hash` configuration and fix settings names {es-pull}84753[#84753] (issue: {es-issue}84578[#84578])
+
+Authorization::
+* Add delete privilege to `kibana_system` for APM {es-pull}85085[#85085]
+* Ensure API key can only see itself with `QueryApiKey` API {es-pull}84859[#84859]
+* Fix ownership of refresh tokens {es-pull}85010[#85010]
+* Handle role descriptor retrieval for internal users {es-pull}85049[#85049]
+* Ignore app priv failures when resolving superuser {es-pull}85519[#85519]
+
+EQL::
+* Clean any used memory by the sequence matcher and circuit breaker used bytes in case of exception {es-pull}84451[#84451]
+
+Engine::
+* Increase store ref before snapshotting index commit {es-pull}84776[#84776]
+
+Geo::
+* Fix fields wildcard support to vector tile search API {es-pull}85595[#85595] (issue: {es-issue}85592[#85592])
+
+Highlighting::
+* Fix wildcard highlighting on `match_only_text` {es-pull}85500[#85500] (issue: {es-issue}85493[#85493])
+
+ILM+SLM::
+* Fix Stacktraces Taking Memory in ILM Error Step Serialization {es-pull}84266[#84266]
+* Invoke initial `AsyncActionStep` for newly created indices {es-pull}84541[#84541] (issue: {es-issue}77269[#77269])
+* Retry clean and create snapshot if it already exists #83694 {es-pull}84829[#84829] (issue: {es-issue}83694[#83694])
+* Skip the shrink step if the number of shards of the shrunk index is the same with the original {es-pull}84434[#84434] (issue: {es-issue}80180[#80180])
+
+Indices APIs::
+* Remove existing indices/datastreams/aliases before simulating index template {es-pull}84675[#84675] (issue: {es-issue}84256[#84256])
+
+Infra/Core::
+* Fix `NullPointerException` in `SystemIndexMetadataUpgradeService` hidden alias handling {es-pull}84780[#84780] (issue: {es-issue}81411[#81411])
+* Require and preserve content type for filtered rest requests {es-pull}84914[#84914] (issue: {es-issue}84784[#84784])
+* Return empty version instead of blowing up if we cannot find it {es-pull}85244[#85244]
+* Validate index format agreement for system index descriptors {es-pull}85173[#85173]
+* Wrap thread creation in `doPrivileged` call {es-pull}85180[#85180]
+
+Infra/Plugins::
+* Strengthen elasticsearch plugin version check {es-pull}85340[#85340] (issue: {es-issue}85336[#85336])
+
+Infra/REST API::
+* Correctly return `_type` field for documents in V7 compatiblity mode {es-pull}84873[#84873] (issue: {es-issue}84173[#84173])
+
+Ingest::
+* Mark `GeoIpDownloaderTask` as completed after cancellation {es-pull}84028[#84028]
+* `CompoundProcessor` should also catch exceptions when executing a processor {es-pull}84838[#84838] (issue: {es-issue}84781[#84781])
+
+License::
+* Fix license downgrade warnings for API Keys and Tokens {es-pull}85276[#85276] (issue: {es-issue}75271[#75271])
+
+Machine Learning::
+* Avoid multiple queued quantiles documents in renormalizer {es-pull}85555[#85555] (issue: {es-issue}85539[#85539])
+* Disallow new trained model deployments when nodes are different versions {es-pull}85465[#85465]
+* Do not fetch source when finding index of last state docs {es-pull}85334[#85334]
+* Fix Kibana date format and similar overrides in text structure endpoint {es-pull}84967[#84967]
+* Fix race condition when stopping a recently relocated datafeed {es-pull}84636[#84636]
+* Fixes for multi-line start patterns in text structure endpoint {es-pull}85066[#85066]
+* Fixes to making old ML indices hidden {es-pull}85383[#85383]
+* Reallocate model deployments on node shutdown events {es-pull}85310[#85310]
+* Retry datafeed searches on skipped CCS clusters {es-pull}84052[#84052] (issue: {es-issue}83838[#83838])
+* Return all Datafeeds with GET Anomaly Detector {es-pull}84759[#84759]
+
+Mapping::
+* Do not fail on duplicated content field filters {es-pull}85382[#85382]
+* Runtime fields core-with-mapped tests support tsdb {es-pull}83577[#83577]
+
+Packaging::
+* Remove use of Cloudflare zlib {es-pull}84680[#84680]
+
+Rollup::
+* Add support for comma delimited index patterns to rollup job configuration {es-pull}47041[#47041] (issue: {es-issue}45591[#45591])
+
+SQL::
+* Add range checks to interval multiplication operation {es-pull}83478[#83478] (issue: {es-issue}83336[#83336])
+* Avoid empty last pages for GROUP BY queries when possible {es-pull}84356[#84356] (issue: {es-issue}75528[#75528])
+* Fix SQLCompatIT.testCursorFromOldNodeFailsOnNewNode {es-pull}85531[#85531] (issue: {es-issue}85520[#85520])
+* Fix issues with format=txt when paging through result sets and in mixed node environments {es-pull}83833[#83833] (issues: {es-issue}83581[#83581], {es-issue}83788[#83788])
+* Improve ROUND and TRUNCATE to better manage Long values and big Doubles {es-pull}85106[#85106] (issues: {es-issue}85105[#85105], {es-issue}49391[#49391])
+* Use exact attributes for script templates from scalar functions {es-pull}84813[#84813] (issue: {es-issue}80551[#80551])
+* `RANDOM(<expr>)` always evaluates to `NULL` if `<expr>` is `NULL` {es-pull}84632[#84632] (issue: {es-issue}84627[#84627])
+
+Search::
+* Fix point visitor in `DiskUsage` API {es-pull}84909[#84909]
+* Fix skip caching factor with `indices.queries.cache.all_segments` {es-pull}85510[#85510]
+* Increase store ref before analyzing disk usage {es-pull}84774[#84774]
+* Limit concurrent shard requests in disk usage API {es-pull}84900[#84900] (issue: {es-issue}84779[#84779])
+* `DotExpandingXContentParser` to expose the original token location {es-pull}84970[#84970]
+* `TransportBroadcastAction` should always set response for each shard {es-pull}84926[#84926]
+
+Security::
+* Ensure tokens represent effective user's identity in all cases {es-pull}84263[#84263]
+
+Snapshot/Restore::
+* Don't fail if there no symlink for AWS Web Identity Token {es-pull}84697[#84697]
+* Fix atomic writes in HDFS {es-pull}85210[#85210]
+* Fix leaking listeners bug on frozen tier {es-pull}85239[#85239]
+* Fix snapshot status messages on node-left {es-pull}85021[#85021]
+* [s3-repository] Lookup AWS Region for STS Client from STS endpoint {es-pull}84585[#84585] (issue: {es-issue}83826[#83826])
+
+Stats::
+* Discard intermediate results upon cancellation for stats endpoints {es-pull}82685[#82685] (issue: {es-issue}82337[#82337])
+
+Transform::
+* Correctly validate permissions when retention policy is configured {es-pull}85413[#85413] (issue: {es-issue}85409[#85409])
+
+Watcher::
+* Avoiding watcher validation errors when a data stream points to more than one index {es-pull}85507[#85507] (issue: {es-issue}85508[#85508])
+* Log at WARN level for Watcher cluster state validation errors {es-pull}85632[#85632]
+* No longer require master node to install Watcher templates {es-pull}85287[#85287] (issue: {es-issue}85043[#85043])
+
+[[enhancement-8.2.0]]
+[float]
+=== Enhancements
+
+Aggregations::
+* Aggs: no filter-by-filter if `_doc_count` field {es-pull}84427[#84427] (issue: {es-issue}84048[#84048])
+* Extract agg bounds from queries in FILTER {es-pull}83902[#83902]
+* Give Lucene more opportunities to enable the filter-by-filter optimization {es-pull}85322[#85322]
+* Improve performance of `date_histogram` when date histogram is in a BoostingQuery {es-pull}83751[#83751] (issues: {es-issue}82384[#82384], {es-issue}75542[#75542])
+
+Allocation::
+* Make allocation explanations more actionable {es-pull}83983[#83983]
+* Use static empty store files metadata {es-pull}84034[#84034]
+
+Audit::
+* User Profile - Audit security config change for profile APIs {es-pull}84785[#84785]
+
+Authentication::
+* Authentication under domains {es-pull}82639[#82639]
+* Improve BWC for persisted authentication headers {es-pull}83913[#83913] (issue: {es-issue}83567[#83567])
+* Warn on SAML attributes with special attribute names {es-pull}85248[#85248] (issue: {es-issue}48613[#48613])
+
+Authorization::
+* Add elastic/enterprise-search-server service account {es-pull}83325[#83325]
+* Add index privileges for logs-enterprise_search.api-default to the enterprise-search-server service account {es-pull}84965[#84965]
+* Note restricted indices in access denied message {es-pull}85013[#85013]
+* Security global privilege for updating profile data of applications {es-pull}83728[#83728]
+* [Osquery] Extend `kibana_system` role with an access to `osquery_manager` indices {es-pull}84279[#84279]
+
+CRUD::
+* Speed up Reading `RetentionLeases` from the Wire {es-pull}85159[#85159]
+
+Cluster Coordination::
+* Avoid deserializing cluster states on master {es-pull}58416[#58416]
+* Improve logging for connect-back failures {es-pull}84915[#84915]
+* Remove intermediate map from master task execution {es-pull}84406[#84406]
+* Reuse `JoinTaskExecutor` {es-pull}85325[#85325]
+* Speed up `MetadataStateFormat` Writes {es-pull}85138[#85138]
+
+Data streams::
+* Speed up `DatastreamTimestampFieldMapper#postParse` {es-pull}85270[#85270]
+
+Discovery-Plugins::
+* Support IMDSv2 for EC2 Discovery {es-pull}84410[#84410] (issue: {es-issue}80398[#80398])
+
+Distributed::
+* Add elasticsearch health API {es-pull}83119[#83119]
+
+Geo::
+* Add `geohex_grid` aggregation to vector tiles API {es-pull}84553[#84553]
+* Added buffer pixels to vector tile spec parsing {es-pull}84710[#84710] (issue: {es-issue}84492[#84492])
+* Normalise polygons only when necessary {es-pull}84229[#84229] (issue: {es-issue}35349[#35349])
+* Support GeoJSON for `geo_point` {es-pull}85120[#85120]
+
+Health::
+* Fix naming in health indicators {es-pull}83587[#83587]
+* ILM/SLM health indicator services {es-pull}83440[#83440]
+* Introduce dedicated interface for health indicator details {es-pull}83417[#83417]
+* Repository integrity health indicator services {es-pull}83445[#83445]
+* Shards allocation health indicator services {es-pull}83513[#83513]
+
+ILM+SLM::
+* Cache ILM policy name on `IndexMetadata` {es-pull}83603[#83603] (issue: {es-issue}83582[#83582])
+* GET _index_template and GET _component_template request support query parameter flat_settings {es-pull}83297[#83297]
+* Make rollover cancellable #81763 {es-pull}84584[#84584] (issue: {es-issue}81763[#81763])
+* Rollover add max_primary_shard_docs condition {es-pull}80981[#80981]
+* Speed up ILM cluster task execution {es-pull}85405[#85405] (issue: {es-issue}82708[#82708])
+
+Indices APIs::
+* Batch add index block cluster state updates {es-pull}84374[#84374]
+* Batch close-indices cluster state updates {es-pull}84259[#84259]
+* Batch open-indices cluster state updates {es-pull}83760[#83760]
+* Remove LegacyCTRAL from `TransportRolloverAction` {es-pull}84166[#84166]
+
+Infra/Core::
+* Add support for negtive epoch timestamps {es-pull}80208[#80208] (issues: {es-issue}79135[#79135], {es-issue}72123[#72123], {es-issue}40983[#40983])
+* Allow yaml values for dynamic node settings {es-pull}85186[#85186] (issue: {es-issue}65577[#65577])
+* Improve XContent Array Parser {es-pull}84477[#84477]
+* Optimize `ImmutableOpenMap.Builder` {es-pull}85184[#85184]
+* Provide 'system' attribute when resolving system indices {es-pull}85042[#85042] (issue: {es-issue}82671[#82671])
+* Remove Lucene split packages {es-pull}82132[#82132] (issue: {es-issue}81981[#81981])
+* Simplify reading a list and converting it to a map from stream {es-pull}84183[#84183]
+* Speed up CompressedXContent Serialization {es-pull}84802[#84802]
+* Update `readMap` to avoid resizing map during reading {es-pull}84045[#84045]
+
+Infra/Plugins::
+* Warn on slow signature verification {es-pull}84766[#84766] (issue: {es-issue}80480[#80480])
+
+Infra/Scripting::
+* Script: Fields API for Dense Vector {es-pull}83550[#83550]
+
+Ingest::
+* Do not throw exceptions when resolving paths in ingest documents {es-pull}84659[#84659]
+* RemoveProcessor updated to support fieldsToKeep {es-pull}83665[#83665]
+
+Machine Learning::
+* Add ML memory stats API {es-pull}83802[#83802]
+* Add support for RoBERTa and BART NLP models {es-pull}84777[#84777]
+* Add throughput stats for Trained Model Deployments {es-pull}84628[#84628]
+* Improve `zero_shot_classification` tokenization performance {es-pull}84988[#84988] (issue: {es-issue}84820[#84820])
+
+Mapping::
+* Check the utf8 length of keyword field is not bigger than 32766 in ES, rather than in Lucene. {es-pull}83738[#83738] (issue: {es-issue}80865[#80865])
+* Make `FieldMapper.Param` Cheaper to Construct {es-pull}85191[#85191]
+* Terms enum support for doc value only keyword fields {es-pull}83482[#83482] (issue: {es-issue}83451[#83451])
+
+Network::
+* Use Throttling Netty Write Handler on HTTP Path {es-pull}84751[#84751]
+
+Query Languages::
+* Add `unsigned_long` type support {es-pull}65145[#65145] (issue: {es-issue}63312[#63312])
+
+Recovery::
+* Improve failure logging in recovery-from-snapshot {es-pull}84910[#84910]
+
+Reindex::
+* Use `SecureString` for reindex from remote password {es-pull}85091[#85091]
+
+SQL::
+* Add leniency option to SQL CLI {es-pull}83795[#83795] (issue: {es-issue}67436[#67436])
+* Forward warning headers to JDBC driver {es-pull}84499[#84499]
+* List data streams as VIEWs {es-pull}85168[#85168] (issue: {es-issue}83449[#83449])
+* PIT for `GROUP BY` and `PIVOT` queries {es-pull}84605[#84605] (issue: {es-issue}84349[#84349])
+* Replace scroll cursors with point-in-time and `search_after` {es-pull}83381[#83381] (issues: {es-issue}61873[#61873], {es-issue}80523[#80523])
+
+Search::
+* Add filtering to fieldcaps endpoint {es-pull}83636[#83636] (issue: {es-issue}82966[#82966])
+* Group field caps response by index mapping hash {es-pull}83494[#83494] (issues: {es-issue}78665[#78665], {es-issue}82879[#82879])
+* Integrate filtering support for ANN {es-pull}84734[#84734] (issue: {es-issue}81788[#81788])
+* Speed up merging field-caps response {es-pull}83704[#83704]
+
+Security::
+* Bind host all instead of just _site_ when needed {es-pull}83145[#83145]
+* Fleet: Add a new mapping for .fleet-actions-results `action_input_type` field {es-pull}84316[#84316]
+* Update X509Certificate principal methods {es-pull}85163[#85163] (issue: {es-issue}81008[#81008])
+* User Profile - Add APIs for enable/disable profile {es-pull}84548[#84548]
+* User Profile - Add rest spec files and tests {es-pull}83307[#83307]
+* User Profile - More REST spec, tests, API docs {es-pull}84597[#84597]
+* User Profile - Update APIs to work with domain {es-pull}83570[#83570]
+* User Profile - Update xpack usage output for domains {es-pull}84747[#84747]
+* User Profile - capture domain when creating API keys and tokens {es-pull}84547[#84547]
+* User Profile: Add feature flag {es-pull}83347[#83347]
+* User Profile: Add initial search profile API {es-pull}83191[#83191]
+* User Profile: handle racing on creating new profile {es-pull}84208[#84208]
+
+TSDB::
+* TSDB: Expand `_id` on version conflict {es-pull}84957[#84957]
+* TSDB: Reject the nested object fields that are configured time_series_dimension {es-pull}83920[#83920]
+* TSDB: routingPath object type check improvement {es-pull}83310[#83310]
+* TSDB: shrink `_id` inverted index {es-pull}85008[#85008]
+
+Watcher::
+* Add list of allowed domains for Watcher email action {es-pull}84894[#84894] (issue: {es-issue}84739[#84739])
+
+[[feature-8.2.0]]
+[float]
+=== New features
+
+Aggregations::
+* New `random_sampler` aggregation for sampling documents in aggregations {es-pull}84363[#84363]
+
+Authentication::
+* Add JWT realm support for JWT validation {es-pull}83155[#83155]
+* Add smoke test for JWT realm wiring {es-pull}84249[#84249]
+* Support mail, name, and dn claims in JWT realms {es-pull}84907[#84907]
+
+Authorization::
+* API Key APIs with Security Domain {es-pull}84704[#84704]
+
+Health::
+* Add Health Indicator Plugin {es-pull}83205[#83205]
+* Adding impacts block to the health info API response {es-pull}84899[#84899] (issue: {es-issue}84773[#84773])
+
+Indices APIs::
+* Adding cat api for component template {es-pull}71274[#71274] (issue: {es-issue}68941[#68941])
+
+Infra/Core::
+* Introduce an unauthenticated endpoint for readiness checks {es-pull}84375[#84375] (issue: {es-issue}81168[#81168])
+
+Machine Learning::
+* Adds new `change_point` pipeline aggregation {es-pull}83428[#83428]
+
+Search::
+* Introduce lookup runtime fields {es-pull}82385[#82385]
+* Resolve wildcards in disk usage API {es-pull}84832[#84832]
+
+TSDB::
+* TSDB: Support GET and DELETE and doc versioning {es-pull}82633[#82633]
+
+[[upgrade-8.2.0]]
+[float]
+=== Upgrades
+
+Infra/Core::
+* Upgrade jackson for x-content to 2.13.2 {es-pull}84905[#84905]
+
+Network::
+* Upgrade Netty to 4.1.74 {es-pull}84562[#84562]
+
+Search::
+* Upgrade to lucene 9.1.0-snapshot-5b522487ba8 {es-pull}85025[#85025]
+
+

--- a/docs/reference/release-notes/highlights.asciidoc
+++ b/docs/reference/release-notes/highlights.asciidoc
@@ -28,5 +28,5 @@ Other versions:
 [discrete]
 [[integrate_filtering_support_for_approximate_nearest_neighbor_search]]
 === Integrate filtering support for approximate nearest neighbor search
-_knn_search endpoint now has a "filter" option that allows to return only the nearest documents that satisfy the provided filter
+The {ref}/knn-search-api.html[_knn_search endpoint] now has a "filter" option that allows to return only the nearest documents that satisfy the provided filter
 

--- a/docs/reference/release-notes/highlights.asciidoc
+++ b/docs/reference/release-notes/highlights.asciidoc
@@ -1,17 +1,21 @@
 [[release-highlights]]
 == What's new in {minor-version}
 
-Here are the highlights of what's new and improved in {es} {minor-version}!
+coming::[{minor-version}]
 
+Here are the highlights of what's new and improved in {es} {minor-version}!
+ifeval::[\{release-state}\"!=\"unreleased\"]
 For detailed information about this release, see the <<es-release-notes>> and
 <<breaking-changes>>.
+endif::[]
 
 // Add previous release to the list
-// Other versions:
-// {ref-bare}/7.last/release-highlights.html[7.last]
-// | {ref-bare}/8.0/release-highlights.html[8.0]
+Other versions:
 
-// Use the notable-highlights tag to mark entries that
+{ref-bare}/8.1/release-highlights.html[8.1]
+| {ref-bare}/8.0/release-highlights.html[8.0]
+
+// The notable-highlights tag marks entries that
 // should be featured in the Stack Installation and Upgrade Guide:
 // tag::notable-highlights[]
 // [discrete]
@@ -20,10 +24,9 @@ For detailed information about this release, see the <<es-release-notes>> and
 // Description.
 // end::notable-highlights[]
 
-// Omit the notable highlights tag for entries that only need to appear in the ES ref:
-// [discrete]
-// === Heading
-//
-// Description.
 
+[discrete]
+[[integrate_filtering_support_for_approximate_nearest_neighbor_search]]
+=== Integrate filtering support for approximate nearest neighbor search
+_knn_search endpoint now has a "filter" option that allows to return only the nearest documents that satisfy the provided filter
 


### PR DESCRIPTION
Once CI is complete the documentation will be available at:
https://elasticsearch_85664.docs-preview.app.elstc.co/diff