### PR TITLE
[8.2] Ignore frozen shared cache file during data folder upgrades (#85638)

### DIFF
--- a/docs/changelog/85638.yaml
+++ b/docs/changelog/85638.yaml
@@ -1,0 +1,6 @@
+pr: 85638
+summary: Ignore frozen shared cache file during data folder upgrades
+area: Snapshot/Restore
+type: bug
+issues:
+ - 85603

--- a/server/src/internalClusterTest/java/org/elasticsearch/env/NodeEnvironmentIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/env/NodeEnvironmentIT.java
@@ -32,6 +32,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 
+import static org.elasticsearch.env.NodeEnvironment.SEARCHABLE_SHARED_CACHE_FILE;
 import static org.elasticsearch.index.query.QueryBuilders.matchAllQuery;
 import static org.elasticsearch.test.NodeRoles.nonDataNode;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertHitCount;
@@ -214,6 +215,13 @@ public class NodeEnvironmentIT extends ESIntegTestCase {
                 assertThat(ise.getMessage(), containsString("target folder already exists during data folder upgrade"));
                 Files.delete(conflictingFolder);
             }
+        }
+
+        // simulate a frozen node with a shared cache file
+        if (rarely()) {
+            final Path randomDataPath = randomFrom(dataPaths);
+            final Path sharedCache = randomDataPath.resolve("nodes").resolve("0").resolve(SEARCHABLE_SHARED_CACHE_FILE);
+            Files.createFile(sharedCache);
         }
 
         // check that upgrade works

--- a/server/src/main/java/org/elasticsearch/env/NodeEnvironment.java
+++ b/server/src/main/java/org/elasticsearch/env/NodeEnvironment.java
@@ -182,6 +182,11 @@ public final class NodeEnvironment implements Closeable {
      */
     private static final String SNAPSHOT_CACHE_FOLDER = "snapshot_cache";
 
+    /**
+     * Searchable snapshot's shared cache file
+     */
+    static final String SEARCHABLE_SHARED_CACHE_FILE = "shared_snapshot_cache";
+
     public static class NodeLock implements Releasable {
 
         private final Lock[] locks;
@@ -417,7 +422,13 @@ public final class NodeEnvironment implements Closeable {
                 );
 
                 final Set<String> ignoredFileNames = new HashSet<>(
-                    Arrays.asList(NODE_LOCK_FILENAME, TEMP_FILE_NAME, TEMP_FILE_NAME + ".tmp", TEMP_FILE_NAME + ".final")
+                    Arrays.asList(
+                        NODE_LOCK_FILENAME,
+                        TEMP_FILE_NAME,
+                        TEMP_FILE_NAME + ".tmp",
+                        TEMP_FILE_NAME + ".final",
+                        SEARCHABLE_SHARED_CACHE_FILE
+                    )
                 );
 
                 try (DirectoryStream<Path> stream = Files.newDirectoryStream(legacyNodePath.path)) {

--- a/x-pack/plugin/build.gradle
+++ b/x-pack/plugin/build.gradle
@@ -167,7 +167,8 @@ testClusters.configureEach {
   setting 'indices.lifecycle.history_index_enabled', 'false'
   keystore 'bootstrap.password', 'x-pack-test-password'
   keystore 'xpack.security.transport.ssl.secure_key_passphrase', 'testnode'
-  setting 'xpack.searchable.snapshot.shared_cache.size', '10mb'
+  setting 'xpack.searchable.snapshot.shared_cache.size', '16MB'
+  setting 'xpack.searchable.snapshot.shared_cache.region_size', '256KB'
 
   user username: "x_pack_rest_user", password: "x-pack-test-password"
   extraConfigFile nodeKey.name, nodeKey

--- a/x-pack/plugin/ilm/qa/multi-node/build.gradle
+++ b/x-pack/plugin/ilm/qa/multi-node/build.gradle
@@ -25,7 +25,8 @@ testClusters.configureEach {
   numberOfNodes = 4
 
   setting 'path.repo', repoDir.absolutePath
-  setting 'xpack.searchable.snapshot.shared_cache.size', '10mb'
+  setting 'xpack.searchable.snapshot.shared_cache.size', '16MB'
+  setting 'xpack.searchable.snapshot.shared_cache.region_size', '256KB'
   setting 'xpack.security.enabled', 'false'
   setting 'xpack.watcher.enabled', 'false'
   setting 'xpack.ml.enabled', 'false'

--- a/x-pack/plugin/shutdown/qa/rolling-upgrade/build.gradle
+++ b/x-pack/plugin/shutdown/qa/rolling-upgrade/build.gradle
@@ -99,7 +99,8 @@ BuildParams.bwcVersions.withWireCompatible { bwcVersion, baseName ->
     setting 'logger.org.elasticsearch.xpack.watcher', 'DEBUG'
 
     if (bwcVersion.onOrAfter('7.12.0')) {
-      setting 'xpack.searchable.snapshot.shared_cache.size', '10mb'
+      setting 'xpack.searchable.snapshot.shared_cache.size', '16MB'
+      setting 'xpack.searchable.snapshot.shared_cache.region_size', '256KB'
     }
   }
 

--- a/x-pack/qa/rolling-upgrade/build.gradle
+++ b/x-pack/qa/rolling-upgrade/build.gradle
@@ -99,7 +99,8 @@ BuildParams.bwcVersions.withWireCompatible { bwcVersion, baseName ->
     setting 'logger.org.elasticsearch.xpack.watcher', 'DEBUG'
 
     if (bwcVersion.onOrAfter('7.12.0')) {
-      setting 'xpack.searchable.snapshot.shared_cache.size', '10mb'
+      setting 'xpack.searchable.snapshot.shared_cache.size', '16MB'
+      setting 'xpack.searchable.snapshot.shared_cache.region_size', '256KB'
     }
   }
 

--- a/x-pack/qa/xpack-prefix-rest-compat/build.gradle
+++ b/x-pack/qa/xpack-prefix-rest-compat/build.gradle
@@ -89,7 +89,8 @@ testClusters.configureEach {
   setting 'indices.lifecycle.history_index_enabled', 'false'
   keystore 'bootstrap.password', 'x-pack-test-password'
   keystore 'xpack.security.transport.ssl.secure_key_passphrase', 'testnode'
-  setting 'xpack.searchable.snapshot.shared_cache.size', '10mb'
+  setting 'xpack.searchable.snapshot.shared_cache.size', '16MB'
+  setting 'xpack.searchable.snapshot.shared_cache.region_size', '256KB'
 
   user username: "x_pack_rest_user", password: "x-pack-test-password"
   extraConfigFile nodeKey.name, nodeKey


### PR DESCRIPTION
Backports the following commits to 8.2:
 - Ignore frozen shared cache file during data folder upgrades (#85638)