### PR TITLE
[8.2] [ML] ensure roberta tokenization options are updateable (#85578)

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/NlpConfigUpdate.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/NlpConfigUpdate.java
@@ -36,7 +36,9 @@ public abstract class NlpConfigUpdate implements InferenceConfigUpdate, NamedXCo
             BertTokenization.NAME.getPreferredName(),
             BertTokenizationUpdate::new,
             MPNetTokenization.NAME.getPreferredName(),
-            MPNetTokenizationUpdate::new
+            MPNetTokenizationUpdate::new,
+            RobertaTokenizationUpdate.NAME.getPreferredName(),
+            RobertaTokenizationUpdate::new
         );
 
         Map<String, Object> tokenizationConfig = null;

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/RobertaTokenizationUpdate.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/RobertaTokenizationUpdate.java
@@ -111,7 +111,7 @@ public class RobertaTokenizationUpdate implements TokenizationUpdate {
     public boolean equals(Object o) {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
-        RobertaTokenization that = (RobertaTokenization) o;
+        RobertaTokenizationUpdate that = (RobertaTokenizationUpdate) o;
         return Objects.equals(truncate, that.truncate) && Objects.equals(span, that.span);
     }
 

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/AbstractNlpConfigUpdateTestCase.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/AbstractNlpConfigUpdateTestCase.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.core.ml.inference.trainedmodel;
+
+import org.elasticsearch.ElasticsearchException;
+import org.elasticsearch.core.Tuple;
+import org.elasticsearch.xpack.core.ml.AbstractBWCSerializationTestCase;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.hamcrest.Matchers.equalTo;
+
+abstract class AbstractNlpConfigUpdateTestCase<T extends NlpConfigUpdate> extends AbstractBWCSerializationTestCase<T> {
+
+    /**
+     * @param expectedTokenization The tokenization update that will be provided
+     * @return A map and expected resulting object. Note: `tokenization` will be overwritten if provided in the returned map
+     */
+    abstract Tuple<Map<String, Object>, T> fromMapTestInstances(TokenizationUpdate expectedTokenization);
+
+    /**
+     * @param map The map of options
+     * @return A NlpConfigUpdate object
+     */
+    abstract T fromMap(Map<String, Object> map);
+
+    public void testFromMapWithUnknownField() {
+        ElasticsearchException ex = expectThrows(ElasticsearchException.class, () -> fromMap(Collections.singletonMap("some_key", 1)));
+        assertThat(ex.getMessage(), equalTo("Unrecognized fields [some_key]."));
+    }
+
+    public void testFromMap() {
+        for (int i = 0; i < NUMBER_OF_TEST_RUNS; i++) {
+            final String tokenizationKind;
+            final TokenizationUpdate update;
+            final Tokenization.Truncate truncate = randomFrom(Tokenization.Truncate.values());
+            int testCase = randomInt(2);
+            switch (testCase) {
+                case 0 -> {
+                    tokenizationKind = "bert";
+                    update = new BertTokenizationUpdate(truncate, null);
+                }
+                case 1 -> {
+                    tokenizationKind = "mpnet";
+                    update = new MPNetTokenizationUpdate(truncate, null);
+                }
+                case 2 -> {
+                    tokenizationKind = "roberta";
+                    update = new RobertaTokenizationUpdate(truncate, null);
+                }
+                default -> throw new UnsupportedOperationException("unexpected test case");
+
+            }
+            var expected = fromMapTestInstances(update);
+            Map<String, Object> config = new HashMap<>(expected.v1());
+            Map<String, Object> tokenizationConfig = new HashMap<>() {
+                {
+                    put(tokenizationKind, new HashMap<>() {
+                        {
+                            put("truncate", truncate.toString());
+                        }
+                    });
+                }
+            };
+            config.put("tokenization", tokenizationConfig);
+            assertFromMapEquality(expected.v2(), fromMap(config));
+        }
+    }
+
+    void assertFromMapEquality(T expected, T parsedFromMap) {
+        assertThat(parsedFromMap, equalTo(expected));
+    }
+}

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/FillMaskConfigUpdateTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/FillMaskConfigUpdateTests.java
@@ -7,17 +7,15 @@
 
 package org.elasticsearch.xpack.core.ml.inference.trainedmodel;
 
-import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.Version;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.core.Tuple;
 import org.elasticsearch.xcontent.NamedXContentRegistry;
 import org.elasticsearch.xcontent.XContentParser;
-import org.elasticsearch.xpack.core.ml.AbstractBWCSerializationTestCase;
 import org.elasticsearch.xpack.core.ml.inference.MlInferenceNamedXContentProvider;
 
 import java.io.IOException;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -25,35 +23,24 @@ import static org.elasticsearch.xpack.core.ml.inference.trainedmodel.InferenceCo
 import static org.elasticsearch.xpack.core.ml.inference.trainedmodel.InferenceConfigTestScaffolding.createTokenizationUpdate;
 import static org.hamcrest.Matchers.equalTo;
 
-public class FillMaskConfigUpdateTests extends AbstractBWCSerializationTestCase<FillMaskConfigUpdate> {
+public class FillMaskConfigUpdateTests extends AbstractNlpConfigUpdateTestCase<FillMaskConfigUpdate> {
 
-    public void testFromMap() {
-        FillMaskConfigUpdate expected = new FillMaskConfigUpdate(
-            3,
-            "ml-results",
-            new BertTokenizationUpdate(Tokenization.Truncate.FIRST, null)
-        );
+    @Override
+    Tuple<Map<String, Object>, FillMaskConfigUpdate> fromMapTestInstances(TokenizationUpdate expectedTokenization) {
+        int topClasses = randomIntBetween(1, 10);
+        FillMaskConfigUpdate expected = new FillMaskConfigUpdate(topClasses, "ml-results", expectedTokenization);
         Map<String, Object> config = new HashMap<>() {
             {
                 put(NlpConfig.RESULTS_FIELD.getPreferredName(), "ml-results");
-                put(NlpConfig.NUM_TOP_CLASSES.getPreferredName(), 3);
-                Map<String, Object> truncate = new HashMap<>();
-                truncate.put("truncate", "first");
-                Map<String, Object> bert = new HashMap<>();
-                bert.put("bert", truncate);
-                put("tokenization", bert);
+                put(NlpConfig.NUM_TOP_CLASSES.getPreferredName(), topClasses);
             }
         };
-        var pp = FillMaskConfigUpdate.fromMap(config);
-        assertThat(pp, equalTo(expected));
+        return Tuple.tuple(config, expected);
     }
 
-    public void testFromMapWithUnknownField() {
-        ElasticsearchException ex = expectThrows(
-            ElasticsearchException.class,
-            () -> FillMaskConfigUpdate.fromMap(Collections.singletonMap("some_key", 1))
-        );
-        assertThat(ex.getMessage(), equalTo("Unrecognized fields [some_key]."));
+    @Override
+    FillMaskConfigUpdate fromMap(Map<String, Object> map) {
+        return FillMaskConfigUpdate.fromMap(map);
     }
 
     public void testIsNoop() {

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/NerConfigUpdateTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/NerConfigUpdateTests.java
@@ -7,17 +7,15 @@
 
 package org.elasticsearch.xpack.core.ml.inference.trainedmodel;
 
-import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.Version;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.core.Tuple;
 import org.elasticsearch.xcontent.NamedXContentRegistry;
 import org.elasticsearch.xcontent.XContentParser;
-import org.elasticsearch.xpack.core.ml.AbstractBWCSerializationTestCase;
 import org.elasticsearch.xpack.core.ml.inference.MlInferenceNamedXContentProvider;
 
 import java.io.IOException;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -26,29 +24,22 @@ import static org.elasticsearch.xpack.core.ml.inference.trainedmodel.InferenceCo
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.sameInstance;
 
-public class NerConfigUpdateTests extends AbstractBWCSerializationTestCase<NerConfigUpdate> {
+public class NerConfigUpdateTests extends AbstractNlpConfigUpdateTestCase<NerConfigUpdate> {
 
-    public void testFromMap() {
-        NerConfigUpdate expected = new NerConfigUpdate("ml-results", new BertTokenizationUpdate(Tokenization.Truncate.FIRST, null));
+    @Override
+    Tuple<Map<String, Object>, NerConfigUpdate> fromMapTestInstances(TokenizationUpdate expectedTokenization) {
+        NerConfigUpdate expected = new NerConfigUpdate("ml-results", expectedTokenization);
         Map<String, Object> config = new HashMap<>() {
             {
                 put(NlpConfig.RESULTS_FIELD.getPreferredName(), "ml-results");
-                Map<String, Object> truncate = new HashMap<>();
-                truncate.put("truncate", "first");
-                Map<String, Object> bert = new HashMap<>();
-                bert.put("bert", truncate);
-                put("tokenization", bert);
             }
         };
-        assertThat(NerConfigUpdate.fromMap(config), equalTo(expected));
+        return Tuple.tuple(config, expected);
     }
 
-    public void testFromMapWithUnknownField() {
-        ElasticsearchException ex = expectThrows(
-            ElasticsearchException.class,
-            () -> NerConfigUpdate.fromMap(Collections.singletonMap("some_key", 1))
-        );
-        assertThat(ex.getMessage(), equalTo("Unrecognized fields [some_key]."));
+    @Override
+    NerConfigUpdate fromMap(Map<String, Object> map) {
+        return NerConfigUpdate.fromMap(map);
     }
 
     public void testApply() {

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/NlpConfigUpdateTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/NlpConfigUpdateTests.java
@@ -71,7 +71,7 @@ public class NlpConfigUpdateTests extends ESTestCase {
             ElasticsearchStatusException.class,
             () -> NlpConfigUpdate.tokenizationFromMap(finalConfig)
         );
-        assertThat(e.getMessage(), containsString("unknown tokenization type expecting one of [bert, mpnet] got [not_bert]"));
+        assertThat(e.getMessage(), containsString("unknown tokenization type expecting one of [bert, mpnet, roberta] got [not_bert]"));
     }
 
     public void testTokenizationFromMap_MpNet() {
@@ -97,5 +97,30 @@ public class NlpConfigUpdateTests extends ESTestCase {
             }
         };
         assertThat(NlpConfigUpdate.tokenizationFromMap(config), equalTo(new MPNetTokenizationUpdate(Tokenization.Truncate.FIRST, 0)));
+    }
+
+    public void testTokenizationFromMap_Roberta() {
+        Map<String, Object> config = new HashMap<>() {
+            {
+                Map<String, Object> truncate = new HashMap<>();
+                truncate.put("truncate", "first");
+                Map<String, Object> tokenizer = new HashMap<>();
+                tokenizer.put("roberta", truncate);
+                put("tokenization", tokenizer);
+            }
+        };
+        assertThat(NlpConfigUpdate.tokenizationFromMap(config), equalTo(new RobertaTokenizationUpdate(Tokenization.Truncate.FIRST, null)));
+
+        config = new HashMap<>() {
+            {
+                Map<String, Object> truncate = new HashMap<>();
+                truncate.put("truncate", "first");
+                truncate.put("span", 0);
+                Map<String, Object> tokenizer = new HashMap<>();
+                tokenizer.put("roberta", truncate);
+                put("tokenization", tokenizer);
+            }
+        };
+        assertThat(NlpConfigUpdate.tokenizationFromMap(config), equalTo(new RobertaTokenizationUpdate(Tokenization.Truncate.FIRST, 0)));
     }
 }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/PassThroughConfigUpdateTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/PassThroughConfigUpdateTests.java
@@ -7,17 +7,15 @@
 
 package org.elasticsearch.xpack.core.ml.inference.trainedmodel;
 
-import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.Version;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.core.Tuple;
 import org.elasticsearch.xcontent.NamedXContentRegistry;
 import org.elasticsearch.xcontent.XContentParser;
-import org.elasticsearch.xpack.core.ml.AbstractBWCSerializationTestCase;
 import org.elasticsearch.xpack.core.ml.inference.MlInferenceNamedXContentProvider;
 
 import java.io.IOException;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -26,32 +24,22 @@ import static org.elasticsearch.xpack.core.ml.inference.trainedmodel.InferenceCo
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.sameInstance;
 
-public class PassThroughConfigUpdateTests extends AbstractBWCSerializationTestCase<PassThroughConfigUpdate> {
+public class PassThroughConfigUpdateTests extends AbstractNlpConfigUpdateTestCase<PassThroughConfigUpdate> {
 
-    public void testFromMap() {
-        PassThroughConfigUpdate expected = new PassThroughConfigUpdate(
-            "ml-results",
-            new BertTokenizationUpdate(Tokenization.Truncate.FIRST, null)
-        );
+    @Override
+    Tuple<Map<String, Object>, PassThroughConfigUpdate> fromMapTestInstances(TokenizationUpdate expectedTokenization) {
+        PassThroughConfigUpdate expected = new PassThroughConfigUpdate("ml-results", expectedTokenization);
         Map<String, Object> config = new HashMap<>() {
             {
                 put(NlpConfig.RESULTS_FIELD.getPreferredName(), "ml-results");
-                Map<String, Object> truncate = new HashMap<>();
-                truncate.put("truncate", "first");
-                Map<String, Object> bert = new HashMap<>();
-                bert.put("bert", truncate);
-                put("tokenization", bert);
             }
         };
-        assertThat(PassThroughConfigUpdate.fromMap(config), equalTo(expected));
+        return Tuple.tuple(config, expected);
     }
 
-    public void testFromMapWithUnknownField() {
-        ElasticsearchException ex = expectThrows(
-            ElasticsearchException.class,
-            () -> PassThroughConfigUpdate.fromMap(Collections.singletonMap("some_key", 1))
-        );
-        assertThat(ex.getMessage(), equalTo("Unrecognized fields [some_key]."));
+    @Override
+    PassThroughConfigUpdate fromMap(Map<String, Object> map) {
+        return PassThroughConfigUpdate.fromMap(map);
     }
 
     public void testApply() {

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/TextClassificationConfigUpdateTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/TextClassificationConfigUpdateTests.java
@@ -7,18 +7,16 @@
 
 package org.elasticsearch.xpack.core.ml.inference.trainedmodel;
 
-import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.ElasticsearchStatusException;
 import org.elasticsearch.Version;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.core.Tuple;
 import org.elasticsearch.xcontent.NamedXContentRegistry;
 import org.elasticsearch.xcontent.XContentParser;
-import org.elasticsearch.xpack.core.ml.AbstractBWCSerializationTestCase;
 import org.elasticsearch.xpack.core.ml.inference.MlInferenceNamedXContentProvider;
 
 import java.io.IOException;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -28,36 +26,30 @@ import static org.elasticsearch.xpack.core.ml.inference.trainedmodel.InferenceCo
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 
-public class TextClassificationConfigUpdateTests extends AbstractBWCSerializationTestCase<TextClassificationConfigUpdate> {
+public class TextClassificationConfigUpdateTests extends AbstractNlpConfigUpdateTestCase<TextClassificationConfigUpdate> {
 
-    public void testFromMap() {
+    @Override
+    Tuple<Map<String, Object>, TextClassificationConfigUpdate> fromMapTestInstances(TokenizationUpdate expectedTokenization) {
+        int numClasses = randomIntBetween(1, 10);
         TextClassificationConfigUpdate expected = new TextClassificationConfigUpdate(
             List.of("foo", "bar"),
-            3,
+            numClasses,
             "ml-results",
-            new BertTokenizationUpdate(Tokenization.Truncate.FIRST, null)
+            expectedTokenization
         );
         Map<String, Object> config = new HashMap<>() {
             {
                 put(NlpConfig.RESULTS_FIELD.getPreferredName(), "ml-results");
                 put(NlpConfig.CLASSIFICATION_LABELS.getPreferredName(), List.of("foo", "bar"));
-                put(NlpConfig.NUM_TOP_CLASSES.getPreferredName(), 3);
-                Map<String, Object> truncate = new HashMap<>();
-                truncate.put("truncate", "first");
-                Map<String, Object> bert = new HashMap<>();
-                bert.put("bert", truncate);
-                put("tokenization", bert);
+                put(NlpConfig.NUM_TOP_CLASSES.getPreferredName(), numClasses);
             }
         };
-        assertThat(TextClassificationConfigUpdate.fromMap(config), equalTo(expected));
+        return Tuple.tuple(config, expected);
     }
 
-    public void testFromMapWithUnknownField() {
-        ElasticsearchException ex = expectThrows(
-            ElasticsearchException.class,
-            () -> TextClassificationConfigUpdate.fromMap(Collections.singletonMap("some_key", 1))
-        );
-        assertThat(ex.getMessage(), equalTo("Unrecognized fields [some_key]."));
+    @Override
+    TextClassificationConfigUpdate fromMap(Map<String, Object> map) {
+        return TextClassificationConfigUpdate.fromMap(map);
     }
 
     public void testIsNoop() {

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/TextEmbeddingConfigUpdateTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/TextEmbeddingConfigUpdateTests.java
@@ -7,17 +7,15 @@
 
 package org.elasticsearch.xpack.core.ml.inference.trainedmodel;
 
-import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.Version;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.core.Tuple;
 import org.elasticsearch.xcontent.NamedXContentRegistry;
 import org.elasticsearch.xcontent.XContentParser;
-import org.elasticsearch.xpack.core.ml.AbstractBWCSerializationTestCase;
 import org.elasticsearch.xpack.core.ml.inference.MlInferenceNamedXContentProvider;
 
 import java.io.IOException;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -26,32 +24,22 @@ import static org.elasticsearch.xpack.core.ml.inference.trainedmodel.InferenceCo
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.sameInstance;
 
-public class TextEmbeddingConfigUpdateTests extends AbstractBWCSerializationTestCase<TextEmbeddingConfigUpdate> {
+public class TextEmbeddingConfigUpdateTests extends AbstractNlpConfigUpdateTestCase<TextEmbeddingConfigUpdate> {
 
-    public void testFromMap() {
-        TextEmbeddingConfigUpdate expected = new TextEmbeddingConfigUpdate(
-            "ml-results",
-            new BertTokenizationUpdate(Tokenization.Truncate.FIRST, null)
-        );
+    @Override
+    Tuple<Map<String, Object>, TextEmbeddingConfigUpdate> fromMapTestInstances(TokenizationUpdate expectedTokenization) {
+        TextEmbeddingConfigUpdate expected = new TextEmbeddingConfigUpdate("ml-results", expectedTokenization);
         Map<String, Object> config = new HashMap<>() {
             {
                 put(NlpConfig.RESULTS_FIELD.getPreferredName(), "ml-results");
-                Map<String, Object> truncate = new HashMap<>();
-                truncate.put("truncate", "first");
-                Map<String, Object> bert = new HashMap<>();
-                bert.put("bert", truncate);
-                put("tokenization", bert);
             }
         };
-        assertThat(TextEmbeddingConfigUpdate.fromMap(config), equalTo(expected));
+        return Tuple.tuple(config, expected);
     }
 
-    public void testFromMapWithUnknownField() {
-        ElasticsearchException ex = expectThrows(
-            ElasticsearchException.class,
-            () -> TextEmbeddingConfigUpdate.fromMap(Collections.singletonMap("some_key", 1))
-        );
-        assertThat(ex.getMessage(), equalTo("Unrecognized fields [some_key]."));
+    @Override
+    TextEmbeddingConfigUpdate fromMap(Map<String, Object> map) {
+        return TextEmbeddingConfigUpdate.fromMap(map);
     }
 
     public void testApply() {

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/ZeroShotClassificationConfigUpdateTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/ZeroShotClassificationConfigUpdateTests.java
@@ -7,17 +7,15 @@
 
 package org.elasticsearch.xpack.core.ml.inference.trainedmodel;
 
-import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.Version;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.core.Tuple;
 import org.elasticsearch.xcontent.NamedXContentRegistry;
 import org.elasticsearch.xcontent.XContentParser;
-import org.elasticsearch.xpack.core.ml.inference.InferenceConfigItemTestCase;
 import org.elasticsearch.xpack.core.ml.inference.MlInferenceNamedXContentProvider;
 
 import java.io.IOException;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -27,7 +25,7 @@ import static org.elasticsearch.xpack.core.ml.inference.trainedmodel.InferenceCo
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 
-public class ZeroShotClassificationConfigUpdateTests extends InferenceConfigItemTestCase<ZeroShotClassificationConfigUpdate> {
+public class ZeroShotClassificationConfigUpdateTests extends AbstractNlpConfigUpdateTestCase<ZeroShotClassificationConfigUpdate> {
 
     @Override
     protected boolean supportsUnknownFields() {
@@ -57,35 +55,29 @@ public class ZeroShotClassificationConfigUpdateTests extends InferenceConfigItem
         return instance;
     }
 
-    public void testFromMap() {
+    @Override
+    Tuple<Map<String, Object>, ZeroShotClassificationConfigUpdate> fromMapTestInstances(TokenizationUpdate expectedTokenization) {
+        boolean multiLabel = randomBoolean();
         ZeroShotClassificationConfigUpdate expected = new ZeroShotClassificationConfigUpdate(
             List.of("foo", "bar"),
-            false,
+            multiLabel,
             "ml-results",
-            new BertTokenizationUpdate(Tokenization.Truncate.FIRST, null)
+            expectedTokenization
         );
 
         Map<String, Object> config = new HashMap<>() {
             {
                 put(ZeroShotClassificationConfig.LABELS.getPreferredName(), List.of("foo", "bar"));
-                put(ZeroShotClassificationConfig.MULTI_LABEL.getPreferredName(), false);
+                put(ZeroShotClassificationConfig.MULTI_LABEL.getPreferredName(), multiLabel);
                 put(ZeroShotClassificationConfig.RESULTS_FIELD.getPreferredName(), "ml-results");
-                Map<String, Object> truncate = new HashMap<>();
-                truncate.put("truncate", "first");
-                Map<String, Object> bert = new HashMap<>();
-                bert.put("bert", truncate);
-                put("tokenization", bert);
             }
         };
-        assertThat(ZeroShotClassificationConfigUpdate.fromMap(config), equalTo(expected));
+        return Tuple.tuple(config, expected);
     }
 
-    public void testFromMapWithUnknownField() {
-        ElasticsearchException ex = expectThrows(
-            ElasticsearchException.class,
-            () -> ZeroShotClassificationConfigUpdate.fromMap(Collections.singletonMap("some_key", 1))
-        );
-        assertThat(ex.getMessage(), equalTo("Unrecognized fields [some_key]."));
+    @Override
+    ZeroShotClassificationConfigUpdate fromMap(Map<String, Object> map) {
+        return ZeroShotClassificationConfigUpdate.fromMap(map);
     }
 
     public void testApply() {


### PR DESCRIPTION
Backports the following commits to 8.2:
 - [ML] ensure roberta tokenization options are updateable (#85578)