### PR TITLE
Revert "Mute ClientYamlTestSuiteIT "Get all aliases via /_alias" and …

### DIFF
--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/indices.get_alias/10_basic.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/indices.get_alias/10_basic.yml
@@ -18,9 +18,6 @@ setup:
 
 ---
 "Get all aliases via /_alias":
-  - skip:
-      version: "all"
-      reason: "AwaitsFix https://github.com/elastic/elasticsearch/issues/83256"
 
   - do:
       indices.create:
@@ -82,10 +79,6 @@ setup:
 
 ---
 "Get aliases via /_all/_alias/":
-  - skip:
-      version: "all"
-      reason: "AwaitsFix https://github.com/elastic/elasticsearch/issues/83256"
-
   - do:
       indices.create:
         index: myindex


### PR DESCRIPTION
Related to #83256 and #83510 I should have reverted this in #85683, but I missed it.