### PR TITLE
Revert "Mute failing MixedClusterClientYamlTestSuiteIT test {p0=indic…

### DIFF
--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/indices.split/20_source_mapping.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/indices.split/20_source_mapping.yml
@@ -1,8 +1,5 @@
 ---
 "Split index ignores target template mapping":
-  - skip:
-      version: all
-      reason: https://github.com/elastic/elasticsearch/issues/74197
 
   # create index
   - do:


### PR DESCRIPTION
Related to #74197 and #73073, reverts #74198

Since I missed unmuting a test on https://github.com/elastic/elasticsearch/pull/85694, I decided to do a quick audit and look for other tests that could also be unmuted -- I found this one (it ain't much, but it's something).
