### PR TITLE
Adding support for filtering pit requests by index and shard

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/action/search/PointInTimeIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/action/search/PointInTimeIT.java
@@ -419,7 +419,7 @@ public class PointInTimeIT extends ESIntegTestCase {
     }
 
     @SuppressWarnings({ "rawtypes", "unchecked" })
-        private void assertPagination(PointInTimeBuilder pit, int expectedNumDocs, int size, SortBuilder<?>... sorts) throws Exception {
+    private void assertPagination(PointInTimeBuilder pit, int expectedNumDocs, int size, SortBuilder<?>... sorts) throws Exception {
         Set<String> seen = new HashSet<>();
         SearchRequestBuilder builder = client().prepareSearch().setPreference(null).setSize(size).setPointInTime(pit);
         for (SortBuilder<?> sort : sorts) {

--- a/server/src/internalClusterTest/java/org/elasticsearch/action/search/PointInTimeIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/action/search/PointInTimeIT.java
@@ -419,9 +419,9 @@ public class PointInTimeIT extends ESIntegTestCase {
     }
 
     @SuppressWarnings({ "rawtypes", "unchecked" })
-    private void assertPagination(PointInTimeBuilder pit, int expectedNumDocs, int size, SortBuilder<?>... sorts) throws Exception {
+        private void assertPagination(PointInTimeBuilder pit, int expectedNumDocs, int size, SortBuilder<?>... sorts) throws Exception {
         Set<String> seen = new HashSet<>();
-        SearchRequestBuilder builder = client().prepareSearch().setSize(size).setPointInTime(pit);
+        SearchRequestBuilder builder = client().prepareSearch().setPreference(null).setSize(size).setPointInTime(pit);
         for (SortBuilder<?> sort : sorts) {
             builder.addSort(sort);
         }

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/slice/SearchSliceIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/slice/SearchSliceIT.java
@@ -226,7 +226,7 @@ public class SearchSliceIT extends ESIntegTestCase {
         for (int id = 0; id < numSlice; id++) {
             int numSliceResults = 0;
 
-            SearchRequestBuilder request = client().prepareSearch("test")
+            SearchRequestBuilder request = client().prepareSearch("test").setPreference(null)
                 .slice(new SliceBuilder(sliceField, id, numSlice))
                 .setPointInTime(new PointInTimeBuilder(pointInTimeId))
                 .addSort(SortBuilders.fieldSort(sortField))

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/slice/SearchSliceIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/slice/SearchSliceIT.java
@@ -226,7 +226,8 @@ public class SearchSliceIT extends ESIntegTestCase {
         for (int id = 0; id < numSlice; id++) {
             int numSliceResults = 0;
 
-            SearchRequestBuilder request = client().prepareSearch("test").setPreference(null)
+            SearchRequestBuilder request = client().prepareSearch("test")
+                .setPreference(null)
                 .slice(new SliceBuilder(sliceField, id, numSlice))
                 .setPointInTime(new PointInTimeBuilder(pointInTimeId))
                 .addSort(SortBuilders.fieldSort(sortField))

--- a/x-pack/plugin/async-search/qa/security/src/javaRestTest/java/org/elasticsearch/xpack/search/AsyncSearchSecurityIT.java
+++ b/x-pack/plugin/async-search/qa/security/src/javaRestTest/java/org/elasticsearch/xpack/search/AsyncSearchSecurityIT.java
@@ -222,10 +222,7 @@ public class AsyncSearchSecurityIT extends ESRestTestCase {
             request.setJsonEntity(Strings.toString(requestBody));
             final ResponseException exc = expectThrows(ResponseException.class, () -> client().performRequest(request));
             assertThat(exc.getResponse().getStatusLine().getStatusCode(), equalTo(400));
-            assertThat(
-                exc.getMessage(),
-                containsString("Provided indices [" + badIndexName + "] are not supported by the given pit")
-            );
+            assertThat(exc.getMessage(), containsString("Provided indices [" + badIndexName + "] are not supported by the given pit"));
         } finally {
             closePointInTime(pitId, authorizedUser);
         }

--- a/x-pack/plugin/async-search/qa/security/src/javaRestTest/java/org/elasticsearch/xpack/search/AsyncSearchSecurityIT.java
+++ b/x-pack/plugin/async-search/qa/security/src/javaRestTest/java/org/elasticsearch/xpack/search/AsyncSearchSecurityIT.java
@@ -204,13 +204,14 @@ public class AsyncSearchSecurityIT extends ESRestTestCase {
         try {
             final Request request = new Request("POST", "/_async_search");
             setRunAsHeader(request, authorizedUser);
-            request.addParameter("wait_for_completion_timeout", "true");
             request.addParameter("keep_on_completion", "true");
+            String badIndexName;
             if (randomBoolean()) {
-                request.addParameter("index", "index-" + authorizedUser);
+                badIndexName = "index-" + authorizedUser + "-2";
             } else {
-                request.addParameter("index", "*");
+                badIndexName = "*";
             }
+            request.addParameter("index", badIndexName);
             final XContentBuilder requestBody = JsonXContent.contentBuilder()
                 .startObject()
                 .startObject("pit")
@@ -223,7 +224,7 @@ public class AsyncSearchSecurityIT extends ESRestTestCase {
             assertThat(exc.getResponse().getStatusLine().getStatusCode(), equalTo(400));
             assertThat(
                 exc.getMessage(),
-                containsString("[indices] cannot be used with point in time. Do not specify any index with point in time.")
+                containsString("Provided indices [" + badIndexName + "] are not supported by the given pit")
             );
         } finally {
             closePointInTime(pitId, authorizedUser);


### PR DESCRIPTION
This makes it so that you can have a PIT query only search given indices and shards, bringing it to parity with what scrolls support.
I'm marking this as draft because I'm not familiar with this code, and not sure if the search team even wants this feature.
Closes #85703
Relates https://github.com/elastic/elasticsearch-hadoop/issues/1925
