### PR TITLE
Faster ipv4 parser

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/network/InetAddresses.java
+++ b/server/src/main/java/org/elasticsearch/common/network/InetAddresses.java
@@ -109,7 +109,7 @@ public class InetAddresses {
                 if (next > 255 /* octet is outside a byte range */ || (digits > 1 && bytes[octet] == 0) /* octet contains leading 0 */) {
                     return null;
                 }
-                bytes[octet] = (byte)next;
+                bytes[octet] = (byte) next;
             } else {
                 return null;
             }

--- a/server/src/main/java/org/elasticsearch/common/network/InetAddresses.java
+++ b/server/src/main/java/org/elasticsearch/common/network/InetAddresses.java
@@ -92,32 +92,29 @@ public class InetAddresses {
     }
 
     private static byte[] textToNumericFormatV4(String ipString) {
-        String[] address = ipString.split("\\.", IPV4_PART_COUNT + 1);
-        if (address.length != IPV4_PART_COUNT) {
-            return null;
-        }
-
         byte[] bytes = new byte[IPV4_PART_COUNT];
-        try {
-            for (int i = 0; i < bytes.length; i++) {
-                bytes[i] = parseOctet(address[i]);
+        byte octet = 0;
+        byte digits = 0;
+        for (int i = 0; i < ipString.length(); i++) {
+            char c = ipString.charAt(i);
+            if (c == '.') {
+                octet++;
+                if (octet > 3 /* too many octets */ || digits == 0 /* empty octet */) {
+                    return null;
+                }
+                digits = 0;
+            } else if (c >= '0' && c <= '9') {
+                digits++;
+                var next = bytes[octet] * 10 + (c - '0');
+                if (next > 255 /* octet is outside a byte range */ || (digits > 1 && bytes[octet] == 0) /* octet contains leading 0 */) {
+                    return null;
+                }
+                bytes[octet] = (byte)next;
+            } else {
+                return null;
             }
-        } catch (NumberFormatException ex) {
-            return null;
         }
-
-        return bytes;
-    }
-
-    private static byte parseOctet(String ipPart) {
-        // Note: we already verified that this string contains only hex digits.
-        int octet = Integer.parseInt(ipPart);
-        // Disallow leading zeroes, because no clear standard exists on
-        // whether these should be interpreted as decimal or octal.
-        if (octet > 255 || (ipPart.startsWith("0") && ipPart.length() > 1)) {
-            throw new NumberFormatException();
-        }
-        return (byte) octet;
+        return octet != 3 ? null : bytes;
     }
 
     private static byte[] textToNumericFormatV6(String ipString) {


### PR DESCRIPTION
According to the `BeatsMapperBenchmark`: single ip field parsing is visible (highlighted) in the async flame graph.

![image](https://user-images.githubusercontent.com/1331856/161941050-89887cec-44c9-4bf1-b10a-454c5d77b643.png)

Updating implementation with one that would not need intermediate list and string allocations:
```
Benchmark                         (ip)         Mode  Cnt    Score   Error  Units
InetAddressesBenchmark. current   192.168.0.1  avgt    5  146.564 ± 6.164  ns/op
InetAddressesBenchmark. new       192.168.0.1  avgt    5   29.605 ± 1.845  ns/op
```