### PR TITLE
[8.2] Mute SnapshotLifecycleServiceTests#testPolicyCRUD() test. (#85715)

### DIFF
--- a/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/slm/SnapshotLifecycleServiceTests.java
+++ b/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/slm/SnapshotLifecycleServiceTests.java
@@ -188,6 +188,7 @@ public class SnapshotLifecycleServiceTests extends ESTestCase {
      * Test new policies getting scheduled correctly, updated policies also being scheduled,
      * and deleted policies having their schedules cancelled.
      */
+    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/44997")
     public void testPolicyCRUD() throws Exception {
         ClockMock clock = new ClockMock();
         final AtomicInteger triggerCount = new AtomicInteger(0);


### PR DESCRIPTION
Backports the following commits to 8.2:
 - Mute SnapshotLifecycleServiceTests#testPolicyCRUD() test. (#85715)