### PR TITLE
Use Faster API for Parsing Maps from XContent

### DIFF
--- a/libs/x-content/impl/src/main/java/org/elasticsearch/xcontent/provider/json/JsonXContentParser.java
+++ b/libs/x-content/impl/src/main/java/org/elasticsearch/xcontent/provider/json/JsonXContentParser.java
@@ -64,6 +64,15 @@ public class JsonXContentParser extends AbstractXContentParser {
     }
 
     @Override
+    public String nextFieldName() throws IOException {
+        try {
+            return parser.nextFieldName();
+        } catch (JsonParseException e) {
+            throw newXContentParseException(e);
+        }
+    }
+
+    @Override
     public void skipChildren() throws IOException {
         parser.skipChildren();
     }

--- a/libs/x-content/src/main/java/org/elasticsearch/xcontent/XContentParser.java
+++ b/libs/x-content/src/main/java/org/elasticsearch/xcontent/XContentParser.java
@@ -9,6 +9,7 @@
 package org.elasticsearch.xcontent;
 
 import org.elasticsearch.core.CheckedFunction;
+import org.elasticsearch.core.Nullable;
 import org.elasticsearch.core.RestApiVersion;
 
 import java.io.Closeable;
@@ -69,6 +70,11 @@ public interface XContentParser extends Closeable {
     void allowDuplicateKeys(boolean allowDuplicateKeys);
 
     Token nextToken() throws IOException;
+
+    @Nullable
+    default String nextFieldName() throws IOException {
+        return nextToken() == Token.FIELD_NAME ? currentName() : null;
+    }
 
     void skipChildren() throws IOException;
 

--- a/server/src/main/java/org/elasticsearch/repositories/RepositoryData.java
+++ b/server/src/main/java/org/elasticsearch/repositories/RepositoryData.java
@@ -787,8 +787,8 @@ public final class RepositoryData {
         Map<String, String> indexMetaIdentifiers = null;
         String uuid = MISSING_UUID;
         String clusterUUID = MISSING_UUID;
-        while (parser.nextToken() == XContentParser.Token.FIELD_NAME) {
-            final String field = parser.currentName();
+        String field;
+        while ((field = parser.nextFieldName()) != null) {
             switch (field) {
                 case SNAPSHOTS -> parseSnapshots(parser, snapshots, snapshotsDetails, indexMetaLookup);
                 case INDICES -> parseIndices(parser, fixBrokenShardGens, snapshots, indexSnapshots, indexLookup, shardGenerations);


### PR DESCRIPTION
We can be a little more efficient when parsing maps and exploit
the fact that we know the next token is a name in a couple of cases.
I fixed the most performance relevant one but there's a couple more
that could make use of this API in a follow up.

The `nextFieldName` call itself doesn't seem to do too much for us in benchmarking, but saving the `nextToken()` call is quite helpful in making things inline better because it saves the huge switch we have when converting from Jackson to our own tokens.