### PR TITLE
[DOCS] Adds size param to evaluate DFA API docs

### DIFF
--- a/docs/reference/ml/df-analytics/apis/evaluate-dfanalytics.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/evaluate-dfanalytics.asciidoc
@@ -214,7 +214,7 @@ belongs.
     (Optional, object) Multiclass confusion matrix.
 
     `size`::::
-      (Optional, double) Specifies the size of the multi class confusion matrix. 
+      (Optional, double) Specifies the size of the multiclass confusion matrix. 
       Defaults to `10` which results in a matrix of size 10x10.
 
   `precision`:::

--- a/docs/reference/ml/df-analytics/apis/evaluate-dfanalytics.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/evaluate-dfanalytics.asciidoc
@@ -213,6 +213,10 @@ belongs.
   `multiclass_confusion_matrix`:::
     (Optional, object) Multiclass confusion matrix.
 
+    `size`::::
+      (Optional, double) Specifies the size of the multi class confusion matrix. 
+      Defaults to `10` which results in a matrix of size 10x10.
+
   `precision`:::
     (Optional, object) Precision of predictions (per-class and average).
 


### PR DESCRIPTION
## Overview

This PR adds the `size` parameter to the `multiclass_confusion_matrix` parameter in the Evaluate DFA API docs.


### Preview

[Evaluate data frame analytics API](https://elasticsearch_85735.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/evaluate-dfanalytics.html#classification-evaluation-resources)