### PR TITLE
[7.17] Relax docs about using new repos across major versions (#85740)

### DIFF
--- a/docs/reference/snapshot-restore/register-repository.asciidoc
+++ b/docs/reference/snapshot-restore/register-repository.asciidoc
@@ -54,8 +54,11 @@ become visible straight away.
 // end::multi-cluster-repo[]
 --
 
-* Use a different snapshot repository for each major version of {es}. Mixing
-snapshots from different major versions can corrupt a repository’s contents.
+* When upgrading {es} to a newer version you can continue to use the same
+repository you were using before the upgrade. If the repository is accessed by
+multiple clusters, they should all have the same version. Once a repository has
+been modified by a particular version of {es}, it may not work correctly when
+accessed by older versions.
 
 [discrete]
 [[manage-snapshot-repos]]


### PR DESCRIPTION
Backports the following commits to 7.17:
 - Relax docs about using new repos across major versions (#85740)