### PR TITLE
[8.2] Add indices permissions to Enterprise Search service account (#85726)

### DIFF
--- a/docs/changelog/85726.yaml
+++ b/docs/changelog/85726.yaml
@@ -1,0 +1,5 @@
+pr: 85726
+summary: Add indices permissions to Enterprise Search service account
+area: Authorization
+type: enhancement
+issues: []

--- a/x-pack/plugin/security/qa/service-account/src/javaRestTest/java/org/elasticsearch/xpack/security/authc/service/ServiceAccountIT.java
+++ b/x-pack/plugin/security/qa/service-account/src/javaRestTest/java/org/elasticsearch/xpack/security/authc/service/ServiceAccountIT.java
@@ -171,6 +171,16 @@ public class ServiceAccountIT extends ESRestTestCase {
                         "write"
                     ],
                     "allow_restricted_indices": false
+                },
+                {
+                    "names": [
+                        "search-*"
+                    ],
+                    "privileges": [
+                        "read",
+                        "view_index_metadata"
+                    ],
+                    "allow_restricted_indices": false
                 }
             ],
             "applications": [],

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/service/ElasticServiceAccounts.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/service/ElasticServiceAccounts.java
@@ -43,7 +43,8 @@ final class ElasticServiceAccounts {
                         "logs-workplace_search.content_events-default"
                     )
                     .privileges("manage", "read", "write")
-                    .build() },
+                    .build(),
+                RoleDescriptor.IndicesPrivileges.builder().indices("search-*").privileges("read", "view_index_metadata").build() },
             null,
             null,
             null,

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/service/ElasticServiceAccountsTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/service/ElasticServiceAccountsTests.java
@@ -20,6 +20,7 @@ import org.elasticsearch.action.admin.indices.template.delete.DeleteIndexTemplat
 import org.elasticsearch.action.admin.indices.template.get.GetIndexTemplatesAction;
 import org.elasticsearch.action.admin.indices.template.put.PutIndexTemplateAction;
 import org.elasticsearch.action.bulk.BulkAction;
+import org.elasticsearch.action.datastreams.GetDataStreamAction;
 import org.elasticsearch.action.delete.DeleteAction;
 import org.elasticsearch.action.get.GetAction;
 import org.elasticsearch.action.get.MultiGetAction;
@@ -31,6 +32,7 @@ import org.elasticsearch.cluster.metadata.IndexAbstraction;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.transport.TransportRequest;
+import org.elasticsearch.xpack.core.ilm.action.ExplainLifecycleAction;
 import org.elasticsearch.xpack.core.ilm.action.GetLifecycleAction;
 import org.elasticsearch.xpack.core.ilm.action.PutLifecycleAction;
 import org.elasticsearch.xpack.core.ml.action.CloseJobAction;
@@ -367,6 +369,19 @@ public class ElasticServiceAccountsTests extends ESTestCase {
             assertThat(role.indices().allowedIndicesMatcher(RefreshAction.NAME).test(enterpriseSearchIndex), is(true));
             assertThat(role.indices().allowedIndicesMatcher("indices:foo").test(enterpriseSearchIndex), is(false));
         });
+
+        final IndexAbstraction elasticsearchIndex = mockIndexAbstraction("search-" + randomAlphaOfLengthBetween(1, 20));
+        // read
+        assertThat(role.indices().allowedIndicesMatcher(GetAction.NAME).test(elasticsearchIndex), is(true));
+        assertThat(role.indices().allowedIndicesMatcher(MultiGetAction.NAME).test(elasticsearchIndex), is(true));
+        assertThat(role.indices().allowedIndicesMatcher(SearchAction.NAME).test(elasticsearchIndex), is(true));
+        assertThat(role.indices().allowedIndicesMatcher(MultiSearchAction.NAME).test(elasticsearchIndex), is(true));
+        // view_index_metadata
+        assertThat(role.indices().allowedIndicesMatcher(GetDataStreamAction.NAME).test(elasticsearchIndex), is(true));
+        assertThat(role.indices().allowedIndicesMatcher(ExplainLifecycleAction.NAME).test(elasticsearchIndex), is(true));
+        // ingestion and delete are forbidden
+        assertThat(role.indices().allowedIndicesMatcher(IndexAction.NAME).test(elasticsearchIndex), is(false));
+        assertThat(role.indices().allowedIndicesMatcher(DeleteAction.NAME).test(elasticsearchIndex), is(false));
     }
 
     private IndexAbstraction mockIndexAbstraction(String name) {


### PR DESCRIPTION
Backports the following commits to 8.2:
 - Add indices permissions to Enterprise Search service account (#85726)