### PR TITLE
Log node identity at startup

### DIFF
--- a/docs/changelog/85773.yaml
+++ b/docs/changelog/85773.yaml
@@ -1,0 +1,5 @@
+pr: 85773
+summary: Log node identity at startup
+area: Network
+type: enhancement
+issues: []

--- a/server/src/main/java/org/elasticsearch/node/Node.java
+++ b/server/src/main/java/org/elasticsearch/node/Node.java
@@ -1267,7 +1267,7 @@ public class Node implements Closeable {
             }
         }
 
-        logger.info("started");
+        logger.info("started {}", transportService.getLocalNode());
 
         pluginsService.filterPlugins(ClusterPlugin.class).forEach(ClusterPlugin::onNodeStarted);
 


### PR DESCRIPTION
At startup we construct a `DiscoveryNode` which identifies the local
node, and we report various components of this identity in the startup
logs. You can often deduce other parts (e.g. the ephemeral and
persistent node IDs) from other logs, but this is hard to do reliably.
With this commit we report the node identity in full at startup to avoid
any ambiguity.

Relates #83034, #85721, and other test failures explainable by mistaken
identities.