### PR TITLE
https://github.com/glennvill/elasticsearch.git

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/query/GeoBoundingBoxQueryBuilder.java
+++ b/server/src/main/java/org/elasticsearch/index/query/GeoBoundingBoxQueryBuilder.java
@@ -119,8 +119,6 @@ public class GeoBoundingBoxQueryBuilder extends AbstractQueryBuilder<GeoBounding
             // all corners are valid after above checks - make sure they are in the right relation
             if (top < bottom) {
                 throw new IllegalArgumentException("top is below bottom corner: " + top + " vs. " + bottom);
-            } else if (top == bottom) {
-                throw new IllegalArgumentException("top cannot be the same as bottom: " + top + " == " + bottom);
             } else if (left == right) {
                 throw new IllegalArgumentException("left cannot be the same as right: " + left + " == " + right);
             }


### PR DESCRIPTION
fixed query builder so that top can be the same as bottom

As the same bounding box on a geo_shape query works. Lucene supports it so this fix is a must