### PR TITLE
Unmute Lintian packaging test

### DIFF
--- a/qa/os/src/test/java/org/elasticsearch/packaging/test/DebMetadataTests.java
+++ b/qa/os/src/test/java/org/elasticsearch/packaging/test/DebMetadataTests.java
@@ -27,7 +27,6 @@ public class DebMetadataTests extends PackagingTestCase {
         assumeTrue("only deb", distribution.packaging == Distribution.Packaging.DEB);
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/85691")
     public void test05CheckLintian() {
         String extraArgs = "";
         final String helpText = sh.run("lintian --help").stdout();


### PR DESCRIPTION
The test was muted due to #85691.

The underlying problem should be fixed by
elastic/ml-cpp#2255.

This PR needs to be merged after the new artifacts
created from merging elastic/ml-cpp#2255 have been
uploaded to S3.