### PR TITLE
Expose proxy settings for GCS repositories

### DIFF
--- a/docs/changelog/85785.yaml
+++ b/docs/changelog/85785.yaml
@@ -1,0 +1,6 @@
+pr: 85785
+summary: Expose proxy settings for GCS repositories
+area: Snapshot/Restore
+type: bug
+issues:
+ - 84569

--- a/modules/repository-gcs/src/main/java/org/elasticsearch/repositories/gcs/GoogleCloudStoragePlugin.java
+++ b/modules/repository-gcs/src/main/java/org/elasticsearch/repositories/gcs/GoogleCloudStoragePlugin.java
@@ -71,7 +71,10 @@ public class GoogleCloudStoragePlugin extends Plugin implements RepositoryPlugin
             GoogleCloudStorageClientSettings.CONNECT_TIMEOUT_SETTING,
             GoogleCloudStorageClientSettings.READ_TIMEOUT_SETTING,
             GoogleCloudStorageClientSettings.APPLICATION_NAME_SETTING,
-            GoogleCloudStorageClientSettings.TOKEN_URI_SETTING
+            GoogleCloudStorageClientSettings.TOKEN_URI_SETTING,
+            GoogleCloudStorageClientSettings.PROXY_TYPE_SETTING,
+            GoogleCloudStorageClientSettings.PROXY_HOST_SETTING,
+            GoogleCloudStorageClientSettings.PROXY_PORT_SETTING
         );
     }
 

--- a/modules/repository-gcs/src/test/java/org/elasticsearch/repositories/gcs/GoogleCloudStoragePluginTest.java
+++ b/modules/repository-gcs/src/test/java/org/elasticsearch/repositories/gcs/GoogleCloudStoragePluginTest.java
@@ -1,0 +1,32 @@
+package org.elasticsearch.repositories.gcs;
+
+import org.elasticsearch.common.settings.Setting;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.test.ESTestCase;
+import org.junit.Assert;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class GoogleCloudStoragePluginTest extends ESTestCase {
+
+    public void testGetSettings() {
+        List<Setting<?>> settings = new GoogleCloudStoragePlugin(Settings.EMPTY).getSettings();
+
+        Assert.assertEquals(
+            List.of(
+                "gcs.client.*.credentials_file",
+                "gcs.client.*.endpoint",
+                "gcs.client.*.project_id",
+                "gcs.client.*.connect_timeout",
+                "gcs.client.*.read_timeout",
+                "gcs.client.*.application_name",
+                "gcs.client.*.token_uri",
+                "gcs.client.*.proxy.type",
+                "gcs.client.*.proxy.host",
+                "gcs.client.*.proxy.port"
+            ),
+            settings.stream().map(Setting::getKey).collect(Collectors.toList())
+        );
+    }
+}

--- a/modules/repository-gcs/src/test/java/org/elasticsearch/repositories/gcs/GoogleCloudStoragePluginTest.java
+++ b/modules/repository-gcs/src/test/java/org/elasticsearch/repositories/gcs/GoogleCloudStoragePluginTest.java
@@ -6,7 +6,6 @@ import org.elasticsearch.test.ESTestCase;
 import org.junit.Assert;
 
 import java.util.List;
-import java.util.stream.Collectors;
 
 public class GoogleCloudStoragePluginTest extends ESTestCase {
 
@@ -26,7 +25,7 @@ public class GoogleCloudStoragePluginTest extends ESTestCase {
                 "gcs.client.*.proxy.host",
                 "gcs.client.*.proxy.port"
             ),
-            settings.stream().map(Setting::getKey).collect(Collectors.toList())
+            settings.stream().map(Setting::getKey).toList()
         );
     }
 }

--- a/modules/repository-gcs/src/test/java/org/elasticsearch/repositories/gcs/GoogleCloudStoragePluginTest.java
+++ b/modules/repository-gcs/src/test/java/org/elasticsearch/repositories/gcs/GoogleCloudStoragePluginTest.java
@@ -1,3 +1,11 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
 package org.elasticsearch.repositories.gcs;
 
 import org.elasticsearch.common.settings.Setting;

--- a/modules/repository-gcs/src/test/java/org/elasticsearch/repositories/gcs/GoogleCloudStoragePluginTest.java
+++ b/modules/repository-gcs/src/test/java/org/elasticsearch/repositories/gcs/GoogleCloudStoragePluginTest.java
@@ -9,7 +9,7 @@ import java.util.List;
 
 public class GoogleCloudStoragePluginTest extends ESTestCase {
 
-    public void testGetSettings() {
+    public void testExposedSettings() {
         List<Setting<?>> settings = new GoogleCloudStoragePlugin(Settings.EMPTY).getSettings();
 
         Assert.assertEquals(

--- a/modules/repository-gcs/src/test/java/org/elasticsearch/repositories/gcs/GoogleCloudStoragePluginTests.java
+++ b/modules/repository-gcs/src/test/java/org/elasticsearch/repositories/gcs/GoogleCloudStoragePluginTests.java
@@ -15,7 +15,7 @@ import org.junit.Assert;
 
 import java.util.List;
 
-public class GoogleCloudStoragePluginTest extends ESTestCase {
+public class GoogleCloudStoragePluginTests extends ESTestCase {
 
     public void testExposedSettings() {
         List<Setting<?>> settings = new GoogleCloudStoragePlugin(Settings.EMPTY).getSettings();


### PR DESCRIPTION
They were added in #82737, but not exposed via the `GCSPlugin` to end users.

Resolves #84569