### PR TITLE
GeoBoundingBox query should work on bounding box with equal latitude or longitude

### DIFF
--- a/docs/changelog/85788.yaml
+++ b/docs/changelog/85788.yaml
@@ -1,0 +1,6 @@
+pr: 85788
+summary: GeoBoundingBox query should work on bounding box with equal latitude or longitude
+area: Search
+type: enhancement
+issues:
+  - 77717

--- a/server/src/main/java/org/elasticsearch/index/query/GeoBoundingBoxQueryBuilder.java
+++ b/server/src/main/java/org/elasticsearch/index/query/GeoBoundingBoxQueryBuilder.java
@@ -119,10 +119,6 @@ public class GeoBoundingBoxQueryBuilder extends AbstractQueryBuilder<GeoBounding
             // all corners are valid after above checks - make sure they are in the right relation
             if (top < bottom) {
                 throw new IllegalArgumentException("top is below bottom corner: " + top + " vs. " + bottom);
-            } else if (top == bottom) {
-                throw new IllegalArgumentException("top cannot be the same as bottom: " + top + " == " + bottom);
-            } else if (left == right) {
-                throw new IllegalArgumentException("left cannot be the same as right: " + left + " == " + right);
             }
 
             // we do not check longitudes as the query generation code can deal with flipped left/right values

--- a/server/src/test/java/org/elasticsearch/index/query/GeoBoundingBoxQueryBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/index/query/GeoBoundingBoxQueryBuilderTests.java
@@ -179,6 +179,35 @@ public class GeoBoundingBoxQueryBuilderTests extends AbstractQueryTestCase<GeoBo
         builder.setValidationMethod(GeoValidationMethod.STRICT).setCorners(top, right, bottom, left);
     }
 
+    public void testTopAndBottomCanBeEqual() {
+        GeoBoundingBoxQueryBuilder builder = createTestQueryBuilder();
+        double topBottom = builder.topLeft().getLat();
+        double left = builder.topLeft().getLon();
+        double right = builder.bottomRight().getLon();
+
+        builder.setValidationMethod(GeoValidationMethod.STRICT).setCorners(topBottom, left, topBottom, right);
+        builder.setValidationMethod(GeoValidationMethod.IGNORE_MALFORMED).setCorners(topBottom, left, topBottom, right);
+    }
+
+    public void testLeftAndRightCanBeEqual() {
+        GeoBoundingBoxQueryBuilder builder = createTestQueryBuilder();
+        double top = builder.topLeft().getLat();
+        double leftRight = builder.topLeft().getLon();
+        double bottom = builder.bottomRight().getLat();
+
+        builder.setValidationMethod(GeoValidationMethod.STRICT).setCorners(top, leftRight, bottom, leftRight);
+        builder.setValidationMethod(GeoValidationMethod.IGNORE_MALFORMED).setCorners(top, leftRight, bottom, leftRight);
+    }
+
+    public void testTopBottomAndLeftRightCanBeEqual() {
+        GeoBoundingBoxQueryBuilder builder = createTestQueryBuilder();
+        double topBottom = builder.topLeft().getLat();
+        double leftRight = builder.topLeft().getLon();
+
+        builder.setValidationMethod(GeoValidationMethod.STRICT).setCorners(topBottom, leftRight, topBottom, leftRight);
+        builder.setValidationMethod(GeoValidationMethod.IGNORE_MALFORMED).setCorners(topBottom, leftRight, topBottom, leftRight);
+    }
+
     public void testStrictnessDefault() {
         assertFalse(
             "Someone changed the default for coordinate validation - were the docs changed as well?",

--- a/test/framework/src/main/java/org/elasticsearch/search/geo/GeoBoundingBoxQueryIntegTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/search/geo/GeoBoundingBoxQueryIntegTestCase.java
@@ -230,7 +230,14 @@ public abstract class GeoBoundingBoxQueryIntegTestCase extends ESIntegTestCase {
         searchResponse = client().prepareSearch()
             .setQuery(
                 boolQuery().must(termQuery("userid", 534))
-                    .filter(geoBoundingBoxQuery("location").setCorners(45.509526999999999, -73.570986000000005, 45.509526999999999, -73.570986000000005))
+                    .filter(
+                        geoBoundingBoxQuery("location").setCorners(
+                            45.509526999999999,
+                            -73.570986000000005,
+                            45.509526999999999,
+                            -73.570986000000005
+                        )
+                    )
             )
             .get();
         assertThat(searchResponse.getHits().getTotalHits().value, equalTo(1L));
@@ -255,14 +262,28 @@ public abstract class GeoBoundingBoxQueryIntegTestCase extends ESIntegTestCase {
         searchResponse = client().prepareSearch()
             .setQuery(
                 boolQuery().must(termQuery("userid", 880))
-                    .filter(geoBoundingBoxQuery("location").setCorners(74.579421999999994, 59.328355000000002, -66.668903999999998, 59.328355000000002))
+                    .filter(
+                        geoBoundingBoxQuery("location").setCorners(
+                            74.579421999999994,
+                            59.328355000000002,
+                            -66.668903999999998,
+                            59.328355000000002
+                        )
+                    )
             )
             .get();
         assertThat(searchResponse.getHits().getTotalHits().value, equalTo(1L));
         searchResponse = client().prepareSearch()
             .setQuery(
                 boolQuery().must(termQuery("userid", 534))
-                    .filter(geoBoundingBoxQuery("location").setCorners(74.579421999999994, -73.570986000000005, -66.668903999999998, -73.570986000000005))
+                    .filter(
+                        geoBoundingBoxQuery("location").setCorners(
+                            74.579421999999994,
+                            -73.570986000000005,
+                            -66.668903999999998,
+                            -73.570986000000005
+                        )
+                    )
             )
             .get();
         assertThat(searchResponse.getHits().getTotalHits().value, equalTo(1L));
@@ -351,14 +372,19 @@ public abstract class GeoBoundingBoxQueryIntegTestCase extends ESIntegTestCase {
 
         // top == bottom
         searchResponse = client().prepareSearch()
-            .setQuery(geoBoundingBoxQuery("location").setValidationMethod(GeoValidationMethod.COERCE).setCorners(59.328355000000002, 0, 59.328355000000002, 360))
+            .setQuery(
+                geoBoundingBoxQuery("location").setValidationMethod(GeoValidationMethod.COERCE)
+                    .setCorners(59.328355000000002, 0, 59.328355000000002, 360)
+            )
             .get();
         assertThat(searchResponse.getHits().getTotalHits().value, equalTo(1L));
         searchResponse = client().prepareSearch()
-            .setQuery(geoBoundingBoxQuery("location").setValidationMethod(GeoValidationMethod.COERCE).setCorners(59.328355000000002, -180, 59.328355000000002, 180))
+            .setQuery(
+                geoBoundingBoxQuery("location").setValidationMethod(GeoValidationMethod.COERCE)
+                    .setCorners(59.328355000000002, -180, 59.328355000000002, 180)
+            )
             .get();
         assertThat(searchResponse.getHits().getTotalHits().value, equalTo(1L));
-
 
         // Distance query
         searchResponse = client().prepareSearch()

--- a/test/framework/src/main/java/org/elasticsearch/search/geo/GeoBoundingBoxQueryIntegTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/search/geo/GeoBoundingBoxQueryIntegTestCase.java
@@ -120,6 +120,34 @@ public abstract class GeoBoundingBoxQueryIntegTestCase extends ESIntegTestCase {
         for (SearchHit hit : searchResponse.getHits()) {
             assertThat(hit.getId(), anyOf(equalTo("1"), equalTo("3"), equalTo("5")));
         }
+
+        searchResponse = client().prepareSearch() // top == bottom && left == right
+            .setQuery(geoBoundingBoxQuery("location").setCorners(40.7143528, -74.0059731, 40.7143528, -74.0059731))
+            .get();
+        assertThat(searchResponse.getHits().getTotalHits().value, equalTo(1L));
+        assertThat(searchResponse.getHits().getHits().length, equalTo(1));
+        for (SearchHit hit : searchResponse.getHits()) {
+            assertThat(hit.getId(), equalTo("1"));
+        }
+
+        searchResponse = client().prepareSearch() // top == bottom
+            .setQuery(geoBoundingBoxQuery("location").setCorners(40.759011, -74.00009, 40.759011, -73.0059731))
+            .get();
+        assertThat(searchResponse.getHits().getTotalHits().value, equalTo(1L));
+        assertThat(searchResponse.getHits().getHits().length, equalTo(1));
+        for (SearchHit hit : searchResponse.getHits()) {
+            assertThat(hit.getId(), equalTo("2"));
+        }
+
+        searchResponse = client().prepareSearch() // left == right
+            .setQuery(geoBoundingBoxQuery("location").setCorners(41.8, -73.9844722, 40.7, -73.9844722))
+            .get();
+        assertThat(searchResponse.getHits().getTotalHits().value, equalTo(1L));
+        assertThat(searchResponse.getHits().getHits().length, equalTo(1));
+        for (SearchHit hit : searchResponse.getHits()) {
+            assertThat(hit.getId(), equalTo("2"));
+        }
+
         // Distance query
         searchResponse = client().prepareSearch() // from NY
             .setQuery(geoDistanceQuery("location").point(40.5, -73.9).distance(25, DistanceUnit.KILOMETERS))
@@ -187,6 +215,54 @@ public abstract class GeoBoundingBoxQueryIntegTestCase extends ESIntegTestCase {
             .setQuery(
                 boolQuery().must(termQuery("userid", 534))
                     .filter(geoBoundingBoxQuery("location").setCorners(74.579421999999994, 143.5, -66.668903999999998, 113.96875))
+            )
+            .get();
+        assertThat(searchResponse.getHits().getTotalHits().value, equalTo(1L));
+
+        // top == bottom && left == right
+        searchResponse = client().prepareSearch()
+            .setQuery(
+                boolQuery().must(termQuery("userid", 880))
+                    .filter(geoBoundingBoxQuery("location").setCorners(18.036842, 59.328355000000002, 18.036842, 59.328355000000002))
+            )
+            .get();
+        assertThat(searchResponse.getHits().getTotalHits().value, equalTo(1L));
+        searchResponse = client().prepareSearch()
+            .setQuery(
+                boolQuery().must(termQuery("userid", 534))
+                    .filter(geoBoundingBoxQuery("location").setCorners(45.509526999999999, -73.570986000000005, 45.509526999999999, -73.570986000000005))
+            )
+            .get();
+        assertThat(searchResponse.getHits().getTotalHits().value, equalTo(1L));
+
+        // top == bottom
+        searchResponse = client().prepareSearch()
+            .setQuery(
+                boolQuery().must(termQuery("userid", 880))
+                    .filter(geoBoundingBoxQuery("location").setCorners(18.036842, 143.5, 18.036842, 113.96875))
+            )
+            .get();
+        assertThat(searchResponse.getHits().getTotalHits().value, equalTo(1L));
+        searchResponse = client().prepareSearch()
+            .setQuery(
+                boolQuery().must(termQuery("userid", 534))
+                    .filter(geoBoundingBoxQuery("location").setCorners(45.509526999999999, 143.5, 45.509526999999999, 113.96875))
+            )
+            .get();
+        assertThat(searchResponse.getHits().getTotalHits().value, equalTo(1L));
+
+        // left == right
+        searchResponse = client().prepareSearch()
+            .setQuery(
+                boolQuery().must(termQuery("userid", 880))
+                    .filter(geoBoundingBoxQuery("location").setCorners(74.579421999999994, 59.328355000000002, -66.668903999999998, 59.328355000000002))
+            )
+            .get();
+        assertThat(searchResponse.getHits().getTotalHits().value, equalTo(1L));
+        searchResponse = client().prepareSearch()
+            .setQuery(
+                boolQuery().must(termQuery("userid", 534))
+                    .filter(geoBoundingBoxQuery("location").setCorners(74.579421999999994, -73.570986000000005, -66.668903999999998, -73.570986000000005))
             )
             .get();
         assertThat(searchResponse.getHits().getTotalHits().value, equalTo(1L));
@@ -272,6 +348,17 @@ public abstract class GeoBoundingBoxQueryIntegTestCase extends ESIntegTestCase {
             .setQuery(geoBoundingBoxQuery("location").setValidationMethod(GeoValidationMethod.COERCE).setCorners(90, 0, -90, 360))
             .get();
         assertThat(searchResponse.getHits().getTotalHits().value, equalTo(2L));
+
+        // top == bottom
+        searchResponse = client().prepareSearch()
+            .setQuery(geoBoundingBoxQuery("location").setValidationMethod(GeoValidationMethod.COERCE).setCorners(59.328355000000002, 0, 59.328355000000002, 360))
+            .get();
+        assertThat(searchResponse.getHits().getTotalHits().value, equalTo(1L));
+        searchResponse = client().prepareSearch()
+            .setQuery(geoBoundingBoxQuery("location").setValidationMethod(GeoValidationMethod.COERCE).setCorners(59.328355000000002, -180, 59.328355000000002, 180))
+            .get();
+        assertThat(searchResponse.getHits().getTotalHits().value, equalTo(1L));
+
 
         // Distance query
         searchResponse = client().prepareSearch()


### PR DESCRIPTION
This PR removes the validation checkers for latitude/ longitude equality and adds test cases that covers the changes.

fixes #77717 


