### PR TITLE
Handle .geoip_databases being an alias or a concrete index

### DIFF
--- a/docs/changelog/85792.yaml
+++ b/docs/changelog/85792.yaml
@@ -1,0 +1,6 @@
+pr: 85792
+summary: Handle `.geoip_databases` being an alias or a concrete index
+area: Ingest
+type: bug
+issues:
+ - 85756

--- a/modules/ingest-geoip/qa/full-cluster-restart/build.gradle
+++ b/modules/ingest-geoip/qa/full-cluster-restart/build.gradle
@@ -1,0 +1,70 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+
+import org.elasticsearch.gradle.Version
+import org.elasticsearch.gradle.internal.info.BuildParams
+import org.elasticsearch.gradle.testclusters.StandaloneRestIntegTestTask
+
+apply plugin: 'elasticsearch.internal-testclusters'
+apply plugin: 'elasticsearch.standalone-rest-test'
+apply plugin: 'elasticsearch.internal-test-artifact'
+apply plugin: 'elasticsearch.bwc-test'
+
+BuildParams.bwcVersions.withWireCompatible(v -> v.before("8.0.0")) { bwcVersion, baseName ->
+  def baseCluster = testClusters.register(baseName) {
+    testDistribution = "DEFAULT"
+    if (bwcVersion.before(BuildParams.bwcVersions.minimumWireCompatibleVersion)) {
+      // When testing older versions we have to first upgrade to 7.last
+      versions = [bwcVersion.toString(), BuildParams.bwcVersions.minimumWireCompatibleVersion.toString(), project.version]
+    } else {
+      versions = [bwcVersion.toString(), project.version]
+    }
+    numberOfNodes = 2
+    // some tests rely on the translog not being flushed
+    setting 'indices.memory.shard_inactive_time', '60m'
+    setting 'path.repo', "${buildDir}/cluster/shared/repo/${baseName}"
+    setting 'xpack.security.enabled', 'false'
+    requiresFeature 'es.index_mode_feature_flag_registered', Version.fromString("8.0.0")
+  }
+
+  tasks.register("${baseName}#oldClusterTest", StandaloneRestIntegTestTask) {
+    useCluster baseCluster
+    mustRunAfter("precommit")
+    doFirst {
+      delete("${buildDir}/cluster/shared/repo/${baseName}")
+    }
+
+    systemProperty 'tests.is_old_cluster', 'true'
+  }
+
+  tasks.register("${baseName}#upgradedClusterTest", StandaloneRestIntegTestTask) {
+    useCluster baseCluster
+    dependsOn "${baseName}#oldClusterTest"
+    doFirst {
+      baseCluster.get().goToNextVersion()
+      if (bwcVersion.before(BuildParams.bwcVersions.minimumWireCompatibleVersion)) {
+        // When doing a full cluster restart of older versions we actually have to upgrade twice. First to 7.last, then to the current version.
+        baseCluster.get().goToNextVersion()
+      }
+    }
+    systemProperty 'tests.is_old_cluster', 'false'
+  }
+
+  String oldVersion = bwcVersion.toString().minus("-SNAPSHOT")
+  tasks.matching { it.name.startsWith(baseName) && it.name.endsWith("ClusterTest") }.configureEach {
+    it.systemProperty 'tests.old_cluster_version', oldVersion
+    it.systemProperty 'tests.path.repo', "${buildDir}/cluster/shared/repo/${baseName}"
+    it.nonInputProperties.systemProperty('tests.rest.cluster', baseCluster.map(c -> c.allHttpSocketURI.join(",")))
+    it.nonInputProperties.systemProperty('tests.clustername', baseName)
+  }
+
+  tasks.register(bwcTaskName(bwcVersion)) {
+    dependsOn tasks.named("${baseName}#upgradedClusterTest")
+  }
+}

--- a/modules/ingest-geoip/qa/full-cluster-restart/build.gradle
+++ b/modules/ingest-geoip/qa/full-cluster-restart/build.gradle
@@ -6,7 +6,6 @@
  * Side Public License, v 1.
  */
 
-
 import org.elasticsearch.gradle.Version
 import org.elasticsearch.gradle.internal.info.BuildParams
 import org.elasticsearch.gradle.testclusters.StandaloneRestIntegTestTask
@@ -15,6 +14,29 @@ apply plugin: 'elasticsearch.internal-testclusters'
 apply plugin: 'elasticsearch.standalone-rest-test'
 apply plugin: 'elasticsearch.internal-test-artifact'
 apply plugin: 'elasticsearch.bwc-test'
+
+def useFixture = providers.environmentVariable("geoip_use_service")
+  .map { s -> Boolean.parseBoolean(s) == false }
+  .getOrElse(true)
+
+def fixtureAddress = {
+  assert useFixture: 'closure should not be used without a fixture'
+  int ephemeralPort = tasks.getByPath(":test:fixtures:geoip-fixture:postProcessFixture").ext."test.fixtures.geoip-fixture-restart.tcp.80"
+  assert ephemeralPort > 0
+  return "http://127.0.0.1:${ephemeralPort}/"
+}
+
+if (useFixture) {
+  apply plugin: 'elasticsearch.test.fixtures'
+  testFixtures.useFixture(':test:fixtures:geoip-fixture', 'geoip-fixture-restart')
+}
+
+tasks.withType(Test).configureEach {
+  if (useFixture) {
+    nonInputProperties.systemProperty "geoip_endpoint", "${-> fixtureAddress()}"
+  }
+}
+
 
 BuildParams.bwcVersions.withWireCompatible(v -> v.before("8.0.0")) { bwcVersion, baseName ->
   def baseCluster = testClusters.register(baseName) {
@@ -30,6 +52,9 @@ BuildParams.bwcVersions.withWireCompatible(v -> v.before("8.0.0")) { bwcVersion,
     setting 'indices.memory.shard_inactive_time', '60m'
     setting 'path.repo', "${buildDir}/cluster/shared/repo/${baseName}"
     setting 'xpack.security.enabled', 'false'
+    if (useFixture) {
+      setting 'ingest.geoip.downloader.endpoint', { "${-> fixtureAddress()}" }
+    }
     requiresFeature 'es.index_mode_feature_flag_registered', Version.fromString("8.0.0")
   }
 

--- a/modules/ingest-geoip/qa/full-cluster-restart/src/test/java/org/elasticsearch/ingest/geoip/FullClusterRestartIT.java
+++ b/modules/ingest-geoip/qa/full-cluster-restart/src/test/java/org/elasticsearch/ingest/geoip/FullClusterRestartIT.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+package org.elasticsearch.ingest.geoip;
+
+import org.apache.http.util.EntityUtils;
+import org.elasticsearch.client.Request;
+import org.elasticsearch.test.rest.ObjectPath;
+import org.elasticsearch.upgrades.AbstractFullClusterRestartTestCase;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+import static org.hamcrest.Matchers.contains;
+
+public class FullClusterRestartIT extends AbstractFullClusterRestartTestCase {
+
+    public void testGeoIpSystemFeaturesMigration() throws Exception {
+        if (isRunningAgainstOldCluster()) {
+            Request enableDownloader = new Request("PUT", "/_cluster/settings");
+            enableDownloader.setJsonEntity("""
+                {"persistent": {"ingest.geoip.downloader.enabled": true}}
+                """);
+            assertOK(client().performRequest(enableDownloader));
+
+            Request putPipeline = new Request("PUT", "/_ingest/pipeline/geoip");
+            putPipeline.setJsonEntity("""
+                {
+                    "description": "Add geoip info",
+                    "processors": [{
+                        "geoip": {
+                            "field": "ip",
+                            "target_field": "geo",
+                            "database_file": "GeoLite2-Country.mmdb"
+                        }
+                    }]
+                }
+                """);
+            assertOK(client().performRequest(putPipeline));
+
+            // wait for the geo databases to all be loaded
+            assertBusy(() -> testDatabasesLoaded(), 30, TimeUnit.SECONDS);
+
+            // the geoip index should be created
+            assertBusy(() -> testCatIndices(".geoip_databases"));
+            assertBusy(() -> testIndexGeoDoc());
+        } else {
+            Request migrateSystemFeatures = new Request("POST", "/_migration/system_features");
+            assertOK(client().performRequest(migrateSystemFeatures));
+
+            assertBusy(() -> testCatIndices(".geoip_databases-reindexed-for-8", "my-index-00001"));
+            assertBusy(() -> testIndexGeoDoc());
+
+            Request disableDownloader = new Request("PUT", "/_cluster/settings");
+            disableDownloader.setJsonEntity("""
+                {"persistent": {"ingest.geoip.downloader.enabled": false}}
+                """);
+            assertOK(client().performRequest(disableDownloader));
+
+            // the geoip index should be deleted
+            assertBusy(() -> testCatIndices("my-index-00001"));
+
+            Request enableDownloader = new Request("PUT", "/_cluster/settings");
+            enableDownloader.setJsonEntity("""
+                {"persistent": {"ingest.geoip.downloader.enabled": true}}
+                """);
+            assertOK(client().performRequest(enableDownloader));
+
+            // wait for the geo databases to all be loaded
+            assertBusy(() -> testDatabasesLoaded(), 30, TimeUnit.SECONDS);
+
+            // the geoip index should be recreated
+            assertBusy(() -> testCatIndices(".geoip_databases", "my-index-00001"));
+            assertBusy(() -> testIndexGeoDoc());
+        }
+    }
+
+    private void testDatabasesLoaded() throws IOException {
+        Request getTaskState = new Request("GET", "/_cluster/state");
+        ObjectPath state = ObjectPath.createFromResponse(client().performRequest(getTaskState));
+
+        Map<String, Object> databases = null;
+        try {
+            databases = state.evaluate("metadata.persistent_tasks.tasks.0.task.geoip-downloader.state.databases");
+        } catch (Exception e) {
+            // ObjectPath doesn't like the 0 above if the list of tasks is empty, and it throws rather than returning null,
+            // catch that and throw an AssertionError instead (which assertBusy will handle)
+            fail();
+        }
+        assertNotNull(databases);
+
+        for (String name : List.of("GeoLite2-ASN.mmdb", "GeoLite2-City.mmdb", "GeoLite2-Country.mmdb")) {
+            Object database = databases.get(name);
+            assertNotNull(database);
+            assertNotNull(ObjectPath.evaluate(database, "md5"));
+        }
+    }
+
+    private void testCatIndices(String... indexNames) throws IOException {
+        Request catIndices = new Request("GET", "_cat/indices/*?s=index&h=index&expand_wildcards=all");
+        String response = EntityUtils.toString(client().performRequest(catIndices).getEntity());
+        List<String> indices = List.of(response.trim().split("\\s+"));
+        assertThat(indices, contains(indexNames));
+    }
+
+    private void testIndexGeoDoc() throws IOException {
+        Request putDoc = new Request("PUT", "/my-index-00001/_doc/my_id?pipeline=geoip");
+        putDoc.setJsonEntity("""
+            {"ip": "8.8.8.8"}
+            """);
+        assertOK(client().performRequest(putDoc));
+
+        Request getDoc = new Request("GET", "/my-index-00001/_doc/my_id");
+        ObjectPath doc = ObjectPath.createFromResponse(client().performRequest(getDoc));
+        assertNull(doc.evaluate("_source.tags"));
+        assertEquals("United States", doc.evaluate("_source.geo.country_name"));
+    }
+}

--- a/modules/ingest-geoip/qa/full-cluster-restart/src/test/java/org/elasticsearch/ingest/geoip/FullClusterRestartIT.java
+++ b/modules/ingest-geoip/qa/full-cluster-restart/src/test/java/org/elasticsearch/ingest/geoip/FullClusterRestartIT.java
@@ -112,13 +112,13 @@ public class FullClusterRestartIT extends AbstractFullClusterRestartTestCase {
     private void testIndexGeoDoc() throws IOException {
         Request putDoc = new Request("PUT", "/my-index-00001/_doc/my_id?pipeline=geoip");
         putDoc.setJsonEntity("""
-            {"ip": "8.8.8.8"}
+            {"ip": "89.160.20.128"}
             """);
         assertOK(client().performRequest(putDoc));
 
         Request getDoc = new Request("GET", "/my-index-00001/_doc/my_id");
         ObjectPath doc = ObjectPath.createFromResponse(client().performRequest(getDoc));
         assertNull(doc.evaluate("_source.tags"));
-        assertEquals("United States", doc.evaluate("_source.geo.country_name"));
+        assertEquals("Sweden", doc.evaluate("_source.geo.country_name"));
     }
 }

--- a/modules/ingest-geoip/src/test/java/org/elasticsearch/ingest/geoip/DatabaseNodeServiceTests.java
+++ b/modules/ingest-geoip/src/test/java/org/elasticsearch/ingest/geoip/DatabaseNodeServiceTests.java
@@ -20,6 +20,7 @@ import org.elasticsearch.action.search.SearchResponseSections;
 import org.elasticsearch.client.internal.Client;
 import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.DiscoveryNodeRole;
@@ -137,14 +138,7 @@ public class DatabaseNodeServiceTests extends ESTestCase {
         task = new PersistentTask<>(task, new GeoIpTaskState(Map.of("GeoIP2-City.mmdb", new GeoIpTaskState.Metadata(10, 5, 14, md5, 10))));
         PersistentTasksCustomMetadata tasksCustomMetadata = new PersistentTasksCustomMetadata(1L, Map.of(taskId, task));
 
-        ClusterState state = ClusterState.builder(new ClusterName("name"))
-            .metadata(Metadata.builder().putCustom(TYPE, tasksCustomMetadata).build())
-            .nodes(
-                new DiscoveryNodes.Builder().add(new DiscoveryNode("_id1", buildNewFakeTransportAddress(), Version.CURRENT))
-                    .localNodeId("_id1")
-            )
-            .routingTable(createIndexRoutingTable())
-            .build();
+        ClusterState state = createClusterState(tasksCustomMetadata);
 
         int numPipelinesToBeReloaded = randomInt(4);
         List<String> pipelineIds = IntStream.range(0, numPipelinesToBeReloaded).mapToObj(String::valueOf).collect(Collectors.toList());
@@ -167,14 +161,8 @@ public class DatabaseNodeServiceTests extends ESTestCase {
         );
         tasksCustomMetadata = new PersistentTasksCustomMetadata(1L, Map.of(taskId, task));
 
-        state = ClusterState.builder(new ClusterName("name"))
-            .metadata(Metadata.builder().putCustom(TYPE, tasksCustomMetadata).build())
-            .nodes(
-                new DiscoveryNodes.Builder().add(new DiscoveryNode("_id1", buildNewFakeTransportAddress(), Version.CURRENT))
-                    .localNodeId("_id1")
-            )
-            .routingTable(createIndexRoutingTable())
-            .build();
+        state = createClusterState(tasksCustomMetadata);
+
         // Database should be downloaded
         databaseNodeService.checkDatabases(state);
         database = databaseNodeService.getDatabase("GeoIP2-City.mmdb");
@@ -196,8 +184,7 @@ public class DatabaseNodeServiceTests extends ESTestCase {
         task = new PersistentTask<>(task, new GeoIpTaskState(Map.of("GeoIP2-City.mmdb", new GeoIpTaskState.Metadata(0L, 0, 9, md5, 10))));
         PersistentTasksCustomMetadata tasksCustomMetadata = new PersistentTasksCustomMetadata(1L, Map.of(taskId, task));
 
-        ClusterState state = ClusterState.builder(new ClusterName("name"))
-            .metadata(Metadata.builder().putCustom(TYPE, tasksCustomMetadata).build())
+        ClusterState state = ClusterState.builder(createClusterState(tasksCustomMetadata))
             .nodes(
                 new DiscoveryNodes.Builder().add(
                     new DiscoveryNode(
@@ -210,7 +197,6 @@ public class DatabaseNodeServiceTests extends ESTestCase {
                     )
                 ).localNodeId("_id1")
             )
-            .routingTable(createIndexRoutingTable())
             .build();
 
         databaseNodeService.checkDatabases(state);
@@ -247,14 +233,7 @@ public class DatabaseNodeServiceTests extends ESTestCase {
     public void testCheckDatabases_dontCheckDatabaseWhenGeoIpDownloadTask() throws Exception {
         PersistentTasksCustomMetadata tasksCustomMetadata = new PersistentTasksCustomMetadata(0L, Map.of());
 
-        ClusterState state = ClusterState.builder(new ClusterName("name"))
-            .metadata(Metadata.builder().putCustom(TYPE, tasksCustomMetadata).build())
-            .nodes(
-                new DiscoveryNodes.Builder().add(new DiscoveryNode("_id1", buildNewFakeTransportAddress(), Version.CURRENT))
-                    .localNodeId("_id1")
-            )
-            .routingTable(createIndexRoutingTable())
-            .build();
+        ClusterState state = createClusterState(tasksCustomMetadata);
 
         mockSearches("GeoIP2-City.mmdb", 0, 9);
 
@@ -372,8 +351,16 @@ public class DatabaseNodeServiceTests extends ESTestCase {
         return MessageDigests.toHexString(md.digest());
     }
 
-    private static RoutingTable createIndexRoutingTable() {
+    private static ClusterState createClusterState(PersistentTasksCustomMetadata tasksCustomMetadata) {
         Index index = new Index(GeoIpDownloader.DATABASES_INDEX, UUID.randomUUID().toString());
+        IndexMetadata.Builder idxMeta = IndexMetadata.builder(index.getName())
+            .settings(
+                Settings.builder()
+                    .put("index.version.created", Version.CURRENT)
+                    .put("index.uuid", index.getUUID())
+                    .put("index.number_of_shards", 1)
+                    .put("index.number_of_replicas", 0)
+            );
         ShardRouting shardRouting = ShardRouting.newUnassigned(
             new ShardId(index, 0),
             true,
@@ -384,7 +371,13 @@ public class DatabaseNodeServiceTests extends ESTestCase {
         IndexShardRoutingTable table = new IndexShardRoutingTable.Builder(new ShardId(index, 0)).addShard(
             shardRouting.initialize(nodeId, null, shardRouting.getExpectedShardSize()).moveToStarted()
         ).build();
-        return RoutingTable.builder().add(IndexRoutingTable.builder(index).addIndexShard(table).build()).build();
+        return ClusterState.builder(new ClusterName("name"))
+            .metadata(Metadata.builder().putCustom(TYPE, tasksCustomMetadata).put(idxMeta))
+            .nodes(
+                DiscoveryNodes.builder().add(new DiscoveryNode("_id1", buildNewFakeTransportAddress(), Version.CURRENT)).localNodeId("_id1")
+            )
+            .routingTable(RoutingTable.builder().add(IndexRoutingTable.builder(index).addIndexShard(table)))
+            .build();
     }
 
     private static List<byte[]> gzip(String name, String content, int chunks) throws IOException {

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/IndexAbstraction.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/IndexAbstraction.java
@@ -145,7 +145,7 @@ public interface IndexAbstraction {
      */
     class ConcreteIndex implements IndexAbstraction {
 
-        private final Index concreteIndexName;
+        private final Index concreteIndex;
         private final boolean isHidden;
         private final boolean isSystem;
         private final List<String> aliases;
@@ -153,7 +153,7 @@ public interface IndexAbstraction {
 
         public ConcreteIndex(IndexMetadata indexMetadata, DataStream dataStream) {
             // note: don't capture a reference to the indexMetadata here
-            this.concreteIndexName = indexMetadata.getIndex();
+            this.concreteIndex = indexMetadata.getIndex();
             this.isHidden = indexMetadata.isHidden();
             this.isSystem = indexMetadata.isSystem();
             this.aliases = indexMetadata.getAliases() != null ? List.copyOf(indexMetadata.getAliases().keySet()) : null;
@@ -166,7 +166,7 @@ public interface IndexAbstraction {
 
         @Override
         public String getName() {
-            return concreteIndexName.getName();
+            return concreteIndex.getName();
         }
 
         @Override
@@ -176,12 +176,12 @@ public interface IndexAbstraction {
 
         @Override
         public List<Index> getIndices() {
-            return List.of(concreteIndexName);
+            return List.of(concreteIndex);
         }
 
         @Override
         public Index getWriteIndex() {
-            return concreteIndexName;
+            return concreteIndex;
         }
 
         @Override
@@ -211,14 +211,14 @@ public interface IndexAbstraction {
             ConcreteIndex that = (ConcreteIndex) o;
             return isHidden == that.isHidden
                 && isSystem == that.isSystem
-                && concreteIndexName.equals(that.concreteIndexName)
+                && concreteIndex.equals(that.concreteIndex)
                 && Objects.equals(aliases, that.aliases)
                 && Objects.equals(dataStream, that.dataStream);
         }
 
         @Override
         public int hashCode() {
-            return Objects.hash(concreteIndexName, isHidden, isSystem, aliases, dataStream);
+            return Objects.hash(concreteIndex, isHidden, isSystem, aliases, dataStream);
         }
     }
 

--- a/test/fixtures/geoip-fixture/docker-compose.yml
+++ b/test/fixtures/geoip-fixture/docker-compose.yml
@@ -11,3 +11,14 @@ services:
       - ./testfixtures_shared/shared:/fixture/shared
     ports:
       - "80"
+  geoip-fixture-restart:
+    build:
+      context: .
+      args:
+        fixtureClass: fixture.geoip.GeoIpHttpFixture
+        port: 80
+      dockerfile: Dockerfile
+    volumes:
+      - ./testfixtures_shared/shared:/fixture/shared
+    ports:
+      - "80"


### PR DESCRIPTION
Closes #85756

There's two places we need to handle the maybe-it's-an-alias-or-maybe-it's-not logic. First, `DatabaseNodeService` wants to make sure all the primary shards are active before the service fully initializes. Second, `GeoIpDownloaderTaskExecutor` needs to delete the real index (not the alias!) when the downloader is disabled, so we need to potentially dereference the alias there, too.

Manually testing with a persistent data directory is pretty straightforward. I used a collection of requests like this:

```
PUT _cluster/settings
{
  "persistent": {
    "ingest.geoip.downloader.enabled": true
  }
}

PUT _cluster/settings
{
  "persistent": {
    "ingest.geoip.downloader.enabled": false
  }
}

POST _migration/system_features

PUT _ingest/pipeline/geoip
{
  "description": "Add geoip info",
  "processors": [
    {
      "geoip": {
        "field": "ip",
        "target_field": "geo",
        "database_file": "GeoLite2-Country.mmdb"
      }
    }
  ]
}

PUT my-index-00001/_doc/my_id?pipeline=geoip
{
  "ip": "8.8.8.8"
}

GET my-index-00001/_doc/my_id

GET _cat/indices?expand_wildcards=all
```

And then tested like this:

1. Start up a 7.17 node, enable the downloader, put the geoip pipeline.
2. Test some docs (they should have the ip turned into geo data).
3. Stop the node, upgrade to 8.3.0-SNAPSHOT, run the system features migration, restart the node.
4. Verify that the index exists, and it is actually behind an alias now because of the migration.
5. Test some docs (they should have the ip turned into geo data).
6. Disable the downloader and verify that the index was deleted.