### PR TITLE
Remove remaining references to legacy role settings

### DIFF
--- a/distribution/tools/launchers/src/main/java/org/elasticsearch/tools/launchers/MachineDependentHeap.java
+++ b/distribution/tools/launchers/src/main/java/org/elasticsearch/tools/launchers/MachineDependentHeap.java
@@ -22,7 +22,6 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.function.Function;
 
 import static java.lang.Math.max;
@@ -90,15 +89,6 @@ public final class MachineDependentHeap {
      * Parses role information from elasticsearch.yml and determines machine node role.
      */
     static class NodeRoleParser {
-        private static final Set<String> LEGACY_ROLE_SETTINGS = Set.of(
-            "node.master",
-            "node.ingest",
-            "node.data",
-            "node.voting_only",
-            "node.ml",
-            "node.transform",
-            "node.remote_cluster_client"
-        );
 
         @SuppressWarnings("unchecked")
         public static MachineNodeRole parse(InputStream config) {
@@ -113,30 +103,24 @@ public final class MachineDependentHeap {
 
             if (root != null) {
                 Map<String, Object> map = flatten(root, null);
-
-                if (hasLegacySettings(map.keySet())) {
-                    // We don't attempt to auto-determine heap if legacy role settings are used
+                List<String> roles = null;
+                try {
+                    if (map.containsKey("node.roles")) {
+                        roles = (List<String>) map.get("node.roles");
+                    }
+                } catch (ClassCastException ex) {
                     return MachineNodeRole.UNKNOWN;
-                } else {
-                    List<String> roles = null;
-                    try {
-                        if (map.containsKey("node.roles")) {
-                            roles = (List<String>) map.get("node.roles");
-                        }
-                    } catch (ClassCastException ex) {
-                        return MachineNodeRole.UNKNOWN;
-                    }
+                }
 
-                    if (roles == null || roles.isEmpty()) {
-                        // If roles are missing or empty (coordinating node) assume defaults and consider this a data node
-                        return MachineNodeRole.DATA;
-                    } else if (containsOnly(roles, "master")) {
-                        return MachineNodeRole.MASTER_ONLY;
-                    } else if (roles.contains("ml") && containsOnly(roles, "ml", "remote_cluster_client")) {
-                        return MachineNodeRole.ML_ONLY;
-                    } else {
-                        return MachineNodeRole.DATA;
-                    }
+                if (roles == null || roles.isEmpty()) {
+                    // If roles are missing or empty (coordinating node) assume defaults and consider this a data node
+                    return MachineNodeRole.DATA;
+                } else if (containsOnly(roles, "master")) {
+                    return MachineNodeRole.MASTER_ONLY;
+                } else if (roles.contains("ml") && containsOnly(roles, "ml", "remote_cluster_client")) {
+                    return MachineNodeRole.ML_ONLY;
+                } else {
+                    return MachineNodeRole.DATA;
                 }
             } else { // if the config is completely empty, then assume defaults and consider this a data node
                 return MachineNodeRole.DATA;
@@ -173,10 +157,6 @@ public final class MachineDependentHeap {
         @SuppressWarnings("unchecked")
         private static <T> boolean containsOnly(Collection<T> collection, T... items) {
             return Arrays.asList(items).containsAll(collection);
-        }
-
-        private static boolean hasLegacySettings(Set<String> keys) {
-            return LEGACY_ROLE_SETTINGS.stream().anyMatch(keys::contains);
         }
     }
 

--- a/distribution/tools/launchers/src/test/java/org/elasticsearch/tools/launchers/NodeRoleParserTests.java
+++ b/distribution/tools/launchers/src/test/java/org/elasticsearch/tools/launchers/NodeRoleParserTests.java
@@ -66,20 +66,6 @@ public class NodeRoleParserTests extends LaunchersTestCase {
         assertThat(nodeRole, equalTo(DATA));
     }
 
-    public void testLegacySettings() throws IOException {
-        MachineDependentHeap.MachineNodeRole nodeRole = parseConfig(sb -> sb.append("node.ml: true"));
-        assertThat(nodeRole, equalTo(UNKNOWN));
-
-        nodeRole = parseConfig(sb -> sb.append("node.master: true"));
-        assertThat(nodeRole, equalTo(UNKNOWN));
-
-        nodeRole = parseConfig(sb -> sb.append("node.data: false"));
-        assertThat(nodeRole, equalTo(UNKNOWN));
-
-        nodeRole = parseConfig(sb -> sb.append("node.ingest: false"));
-        assertThat(nodeRole, equalTo(UNKNOWN));
-    }
-
     public void testYamlSyntax() throws IOException {
         MachineDependentHeap.MachineNodeRole nodeRole = parseConfig(sb -> sb.append("""
             node:


### PR DESCRIPTION
The legacy node.ROLENAME settings were removed in 8.0 (#71163), but
machine dependent heap still handles them. This commit cleans up the
heap settings determination to no longer look for these legacy settings.

relates #85758