### PR TITLE
Remove uses of Charset name parsing

### DIFF
--- a/build-tools/src/main/java/org/elasticsearch/gradle/LoggedExec.java
+++ b/build-tools/src/main/java/org/elasticsearch/gradle/LoggedExec.java
@@ -31,6 +31,7 @@ import java.nio.file.Files;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.regex.Pattern;
+
 import javax.inject.Inject;
 
 /**
@@ -93,9 +94,7 @@ public class LoggedExec extends Exec implements FileSystemOperationsAware {
             };
         } else {
             out = new ByteArrayOutputStream();
-            outputLogger = logger -> {
-                logger.error(((ByteArrayOutputStream) out).toString(StandardCharsets.UTF_8));
-            };
+            outputLogger = logger -> { logger.error(((ByteArrayOutputStream) out).toString(StandardCharsets.UTF_8)); };
         }
         setStandardOutput(out);
         setErrorOutput(out);

--- a/build-tools/src/main/java/org/elasticsearch/gradle/LoggedExec.java
+++ b/build-tools/src/main/java/org/elasticsearch/gradle/LoggedExec.java
@@ -26,13 +26,11 @@ import java.io.File;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.io.UncheckedIOException;
-import java.io.UnsupportedEncodingException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.regex.Pattern;
-
 import javax.inject.Inject;
 
 /**
@@ -96,11 +94,7 @@ public class LoggedExec extends Exec implements FileSystemOperationsAware {
         } else {
             out = new ByteArrayOutputStream();
             outputLogger = logger -> {
-                try {
-                    logger.error(((ByteArrayOutputStream) out).toString("UTF-8"));
-                } catch (UnsupportedEncodingException e) {
-                    throw new RuntimeException(e);
-                }
+                logger.error(((ByteArrayOutputStream) out).toString(StandardCharsets.UTF_8));
             };
         }
         setStandardOutput(out);
@@ -134,13 +128,9 @@ public class LoggedExec extends Exec implements FileSystemOperationsAware {
                 }
             });
         } catch (Exception e) {
-            try {
-                if (output.size() != 0) {
-                    LOGGER.error("Exec output and error:");
-                    NEWLINE.splitAsStream(output.toString("UTF-8")).forEach(s -> LOGGER.error("| " + s));
-                }
-            } catch (UnsupportedEncodingException ue) {
-                throw new GradleException("Failed to read exec output", ue);
+            if (output.size() != 0) {
+                LOGGER.error("Exec output and error:");
+                NEWLINE.splitAsStream(output.toString(StandardCharsets.UTF_8)).forEach(s -> LOGGER.error("| " + s));
             }
             throw e;
         }

--- a/modules/ingest-common/src/main/java/org/elasticsearch/ingest/common/URLDecodeProcessor.java
+++ b/modules/ingest-common/src/main/java/org/elasticsearch/ingest/common/URLDecodeProcessor.java
@@ -8,8 +8,8 @@
 
 package org.elasticsearch.ingest.common;
 
-import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
 import java.util.Map;
 
 /**
@@ -24,11 +24,7 @@ public final class URLDecodeProcessor extends AbstractStringProcessor<String> {
     }
 
     public static String apply(String value) {
-        try {
-            return URLDecoder.decode(value, "UTF-8");
-        } catch (UnsupportedEncodingException e) {
-            throw new IllegalArgumentException("Could not URL-decode value.", e);
-        }
+        return URLDecoder.decode(value, StandardCharsets.UTF_8);
     }
 
     @Override

--- a/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/URLDecodeProcessorTests.java
+++ b/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/URLDecodeProcessorTests.java
@@ -8,8 +8,8 @@
 
 package org.elasticsearch.ingest.common;
 
-import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 
 public class URLDecodeProcessorTests extends AbstractStringProcessorTestCase<String> {
@@ -25,11 +25,7 @@ public class URLDecodeProcessorTests extends AbstractStringProcessorTestCase<Str
 
     @Override
     protected String expectedResult(String input) {
-        try {
-            return "Hello Günter" + URLDecoder.decode(input, "UTF-8");
-        } catch (UnsupportedEncodingException e) {
-            throw new IllegalArgumentException("invalid");
-        }
+        return "Hello Günter" + URLDecoder.decode(input, StandardCharsets.UTF_8);
     }
 
     @Override

--- a/modules/reindex/src/main/java/org/elasticsearch/reindex/remote/RemoteRequestBuilders.java
+++ b/modules/reindex/src/main/java/org/elasticsearch/reindex/remote/RemoteRequestBuilders.java
@@ -27,8 +27,8 @@ import org.elasticsearch.xcontent.XContentParser;
 import org.elasticsearch.xcontent.json.JsonXContent;
 
 import java.io.IOException;
-import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.stream.Collectors;
 
@@ -165,11 +165,7 @@ final class RemoteRequestBuilders {
     }
 
     private static String encodeIndex(String s) {
-        try {
-            return URLEncoder.encode(s, "utf-8");
-        } catch (UnsupportedEncodingException e) {
-            throw new RuntimeException(e);
-        }
+        return URLEncoder.encode(s, StandardCharsets.UTF_8);
     }
 
     private static String sortToUri(SortBuilder<?> sort) {

--- a/plugins/mapper-annotated-text/src/main/java/org/elasticsearch/index/mapper/annotatedtext/AnnotatedPassageFormatter.java
+++ b/plugins/mapper-annotated-text/src/main/java/org/elasticsearch/index/mapper/annotatedtext/AnnotatedPassageFormatter.java
@@ -125,11 +125,7 @@ public class AnnotatedPassageFormatter extends PassageFormatter {
             int start = passage.getMatchStarts()[i];
             int end = passage.getMatchEnds()[i];
             String searchTerm = passage.getMatchTerms()[i].utf8ToString();
-            Markup markup = new Markup(
-                start,
-                end,
-                SEARCH_HIT_TYPE + "=" + URLEncoder.encode(searchTerm, StandardCharsets.UTF_8)
-            );
+            Markup markup = new Markup(start, end, SEARCH_HIT_TYPE + "=" + URLEncoder.encode(searchTerm, StandardCharsets.UTF_8));
             markupPassage.addUnlessOverlapping(markup);
         }
 

--- a/plugins/mapper-annotated-text/src/main/java/org/elasticsearch/index/mapper/annotatedtext/AnnotatedPassageFormatter.java
+++ b/plugins/mapper-annotated-text/src/main/java/org/elasticsearch/index/mapper/annotatedtext/AnnotatedPassageFormatter.java
@@ -16,7 +16,6 @@ import org.elasticsearch.index.mapper.annotatedtext.AnnotatedTextFieldMapper.Ann
 import org.elasticsearch.lucene.search.uhighlight.Snippet;
 import org.elasticsearch.search.fetch.subphase.highlight.HighlightUtils;
 
-import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
@@ -119,38 +118,32 @@ public class AnnotatedPassageFormatter extends PassageFormatter {
 
     // Merge original annotations and search hits into a single set of markups for each passage
     static MarkupPassage mergeAnnotations(AnnotationToken[] annotations, Passage passage) {
-        try {
-            MarkupPassage markupPassage = new MarkupPassage();
+        MarkupPassage markupPassage = new MarkupPassage();
 
-            // Add search hits first - they take precedence over any other markup
-            for (int i = 0; i < passage.getNumMatches(); i++) {
-                int start = passage.getMatchStarts()[i];
-                int end = passage.getMatchEnds()[i];
-                String searchTerm = passage.getMatchTerms()[i].utf8ToString();
-                Markup markup = new Markup(
-                    start,
-                    end,
-                    SEARCH_HIT_TYPE + "=" + URLEncoder.encode(searchTerm, StandardCharsets.UTF_8.name())
-                );
+        // Add search hits first - they take precedence over any other markup
+        for (int i = 0; i < passage.getNumMatches(); i++) {
+            int start = passage.getMatchStarts()[i];
+            int end = passage.getMatchEnds()[i];
+            String searchTerm = passage.getMatchTerms()[i].utf8ToString();
+            Markup markup = new Markup(
+                start,
+                end,
+                SEARCH_HIT_TYPE + "=" + URLEncoder.encode(searchTerm, StandardCharsets.UTF_8)
+            );
+            markupPassage.addUnlessOverlapping(markup);
+        }
+
+        // Now add original text's annotations - ignoring any that might conflict with the search hits markup.
+        for (AnnotationToken token : annotations) {
+            int start = token.offset();
+            int end = token.endOffset();
+            if (start >= passage.getStartOffset() && end <= passage.getEndOffset()) {
+                String escapedValue = URLEncoder.encode(token.value(), StandardCharsets.UTF_8);
+                Markup markup = new Markup(start, end, escapedValue);
                 markupPassage.addUnlessOverlapping(markup);
             }
-
-            // Now add original text's annotations - ignoring any that might conflict with the search hits markup.
-            for (AnnotationToken token : annotations) {
-                int start = token.offset();
-                int end = token.endOffset();
-                if (start >= passage.getStartOffset() && end <= passage.getEndOffset()) {
-                    String escapedValue = URLEncoder.encode(token.value(), StandardCharsets.UTF_8.name());
-                    Markup markup = new Markup(start, end, escapedValue);
-                    markupPassage.addUnlessOverlapping(markup);
-                }
-            }
-            return markupPassage;
-
-        } catch (UnsupportedEncodingException e) {
-            // We should always have UTF-8 support
-            throw new IllegalStateException(e);
         }
+        return markupPassage;
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/action/DocWriteResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/DocWriteResponse.java
@@ -29,8 +29,8 @@ import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xcontent.XContentParser;
 
 import java.io.IOException;
-import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.util.Locale;
 import java.util.Objects;
 
@@ -229,19 +229,11 @@ public abstract class DocWriteResponse extends ReplicationResponse implements Wr
      * @return the relative URI for the location of the document
      */
     public String getLocation(@Nullable String routing) {
-        final String encodedIndex;
-        final String encodedType;
-        final String encodedId;
-        final String encodedRouting;
-        try {
-            // encode the path components separately otherwise the path separators will be encoded
-            encodedIndex = URLEncoder.encode(getIndex(), "UTF-8");
-            encodedType = URLEncoder.encode(MapperService.SINGLE_MAPPING_NAME, "UTF-8");
-            encodedId = URLEncoder.encode(getId(), "UTF-8");
-            encodedRouting = routing == null ? null : URLEncoder.encode(routing, "UTF-8");
-        } catch (final UnsupportedEncodingException e) {
-            throw new AssertionError(e);
-        }
+        // encode the path components separately otherwise the path separators will be encoded
+        final String encodedIndex = URLEncoder.encode(getIndex(), StandardCharsets.UTF_8);
+        final String encodedType = URLEncoder.encode(MapperService.SINGLE_MAPPING_NAME, StandardCharsets.UTF_8);
+        final String encodedId = URLEncoder.encode(getId(), StandardCharsets.UTF_8);
+        final String encodedRouting = routing == null ? null : URLEncoder.encode(routing, StandardCharsets.UTF_8);
         final String routingStart = "?routing=";
         final int bufferSizeExcludingRouting = 3 + encodedIndex.length() + encodedType.length() + encodedId.length();
         final int bufferSize;

--- a/server/src/main/java/org/elasticsearch/bootstrap/Bootstrap.java
+++ b/server/src/main/java/org/elasticsearch/bootstrap/Bootstrap.java
@@ -45,8 +45,8 @@ import org.elasticsearch.node.NodeValidationException;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.PrintStream;
-import java.io.UnsupportedEncodingException;
 import java.net.URISyntaxException;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.security.NoSuchAlgorithmException;
 import java.util.Collections;
@@ -387,21 +387,10 @@ final class Bootstrap {
             if (e instanceof CreationException) {
                 // guice: log the shortened exc to the log file
                 ByteArrayOutputStream os = new ByteArrayOutputStream();
-                PrintStream ps = null;
-                try {
-                    ps = new PrintStream(os, false, "UTF-8");
-                } catch (UnsupportedEncodingException uee) {
-                    assert false;
-                    e.addSuppressed(uee);
-                }
+                PrintStream ps = new PrintStream(os, false, StandardCharsets.UTF_8);
                 new StartupException(e).printStackTrace(ps);
                 ps.flush();
-                try {
-                    logger.error("Guice Exception: {}", os.toString("UTF-8"));
-                } catch (UnsupportedEncodingException uee) {
-                    assert false;
-                    e.addSuppressed(uee);
-                }
+                logger.error("Guice Exception: {}", os.toString(StandardCharsets.UTF_8));
             } else if (e instanceof NodeValidationException) {
                 logger.error("node validation exception\n{}", e.getMessage());
             } else {

--- a/server/src/test/java/org/elasticsearch/action/index/IndexRequestTests.java
+++ b/server/src/test/java/org/elasticsearch/action/index/IndexRequestTests.java
@@ -30,7 +30,7 @@ import org.elasticsearch.test.VersionUtils;
 import org.elasticsearch.xcontent.XContentType;
 
 import java.io.IOException;
-import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
@@ -249,7 +249,7 @@ public class IndexRequestTests extends ESTestCase {
         }
     }
 
-    public void testToStringSizeLimit() throws UnsupportedEncodingException {
+    public void testToStringSizeLimit() {
         IndexRequest request = new IndexRequest("index");
 
         String source = "{\"name\":\"value\"}";
@@ -260,7 +260,7 @@ public class IndexRequestTests extends ESTestCase {
             {"name":"%s"}
             """.formatted(randomUnicodeOfLength(IndexRequest.MAX_SOURCE_LENGTH_IN_TOSTRING));
         request.source(source, XContentType.JSON);
-        int actualBytes = source.getBytes("UTF-8").length;
+        int actualBytes = source.getBytes(StandardCharsets.UTF_8).length;
         assertEquals(
             "index {[index][null], source[n/a, actual length: ["
                 + new ByteSizeValue(actualBytes).toString()

--- a/server/src/test/java/org/elasticsearch/common/hashing/MurmurHash3Tests.java
+++ b/server/src/test/java/org/elasticsearch/common/hashing/MurmurHash3Tests.java
@@ -11,11 +11,10 @@ package org.elasticsearch.common.hashing;
 import org.elasticsearch.common.hash.MurmurHash3;
 import org.elasticsearch.test.ESTestCase;
 
-import java.io.UnsupportedEncodingException;
 import java.nio.charset.StandardCharsets;
 
 public class MurmurHash3Tests extends ESTestCase {
-    public void testKnownValues() throws UnsupportedEncodingException {
+    public void testKnownValues() {
         assertHash(0x629942693e10f867L, 0x92db0b82baeb5347L, "hell", 0);
         assertHash(0xa78ddff5adae8d10L, 0x128900ef20900135L, "hello", 1);
         assertHash(0x8a486b23f422e826L, 0xf962a2c58947765fL, "hello ", 2);

--- a/server/src/test/java/org/elasticsearch/index/query/WrapperQueryBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/index/query/WrapperQueryBuilderTests.java
@@ -22,7 +22,7 @@ import org.elasticsearch.xcontent.XContentType;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
-import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
 
 public class WrapperQueryBuilderTests extends AbstractQueryTestCase<WrapperQueryBuilder> {
 
@@ -97,12 +97,7 @@ public class WrapperQueryBuilderTests extends AbstractQueryTestCase<WrapperQuery
 
         WrapperQueryBuilder parsed = (WrapperQueryBuilder) parseQuery(json);
         checkGeneratedJson(json, parsed);
-
-        try {
-            assertEquals(json, "{}", new String(parsed.source(), "UTF-8"));
-        } catch (UnsupportedEncodingException e) {
-            throw new RuntimeException(e);
-        }
+        assertEquals(json, "{}", new String(parsed.source(), StandardCharsets.UTF_8));
     }
 
     @Override

--- a/test/framework/src/main/java/org/elasticsearch/cli/MockTerminal.java
+++ b/test/framework/src/main/java/org/elasticsearch/cli/MockTerminal.java
@@ -12,7 +12,6 @@ import java.io.ByteArrayOutputStream;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
-import java.io.UnsupportedEncodingException;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
@@ -92,8 +91,8 @@ public class MockTerminal extends Terminal {
     }
 
     /** Returns all output written to this terminal. */
-    public String getOutput() throws UnsupportedEncodingException {
-        return stdoutBuffer.toString("UTF-8");
+    public String getOutput() {
+        return stdoutBuffer.toString(StandardCharsets.UTF_8);
     }
 
     /** Returns all bytes  written to this terminal. */
@@ -102,8 +101,8 @@ public class MockTerminal extends Terminal {
     }
 
     /** Returns all output written to this terminal. */
-    public String getErrorOutput() throws UnsupportedEncodingException {
-        return stderrBuffer.toString("UTF-8");
+    public String getErrorOutput() {
+        return stderrBuffer.toString(StandardCharsets.UTF_8);
     }
 
     /** Wipes the input and output. */

--- a/test/framework/src/main/java/org/elasticsearch/snapshots/mockstore/MockRepository.java
+++ b/test/framework/src/main/java/org/elasticsearch/snapshots/mockstore/MockRepository.java
@@ -43,7 +43,7 @@ import org.elasticsearch.xcontent.NamedXContentRegistry;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
-import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
@@ -402,10 +402,10 @@ public class MockRepository extends FsRepository {
             private int hashCode(String path) {
                 try {
                     MessageDigest digest = MessageDigest.getInstance("MD5");
-                    byte[] bytes = digest.digest(path.getBytes("UTF-8"));
+                    byte[] bytes = digest.digest(path.getBytes(StandardCharsets.UTF_8));
                     int i = 0;
                     return ((bytes[i++] & 0xFF) << 24) | ((bytes[i++] & 0xFF) << 16) | ((bytes[i++] & 0xFF) << 8) | (bytes[i++] & 0xFF);
-                } catch (NoSuchAlgorithmException | UnsupportedEncodingException ex) {
+                } catch (NoSuchAlgorithmException ex) {
                     throw new ElasticsearchException("cannot calculate hashcode", ex);
                 }
             }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/HttpResponse.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/HttpResponse.java
@@ -10,7 +10,6 @@ import org.elasticsearch.ElasticsearchParseException;
 import org.elasticsearch.common.xcontent.XContentHelper;
 import org.elasticsearch.xcontent.XContentType;
 
-import java.io.UnsupportedEncodingException;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -47,8 +46,7 @@ public final class HttpResponse {
             return this;
         }
 
-        public HttpResponseBuilder withResponseBody(final String responseJson) throws ElasticsearchParseException,
-            UnsupportedEncodingException {
+        public HttpResponseBuilder withResponseBody(final String responseJson) throws ElasticsearchParseException {
             if (responseJson == null || responseJson.trim().isEmpty()) {
                 throw new ElasticsearchParseException(
                     "Invalid string provided as http response body, Failed to parse content to form response body."

--- a/x-pack/plugin/identity-provider/src/internalClusterTest/java/org/elasticsearch/xpack/idp/action/SamlIdentityProviderTests.java
+++ b/x-pack/plugin/identity-provider/src/internalClusterTest/java/org/elasticsearch/xpack/idp/action/SamlIdentityProviderTests.java
@@ -44,7 +44,6 @@ import org.opensaml.xmlsec.signature.support.SignatureConstants;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.UncheckedIOException;
-import java.io.UnsupportedEncodingException;
 import java.net.URL;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
@@ -463,8 +462,8 @@ public class SamlIdentityProviderTests extends IdentityProviderIntegTestCase {
         return Base64.getEncoder().encodeToString(bytes);
     }
 
-    private static String urlEncode(String param) throws UnsupportedEncodingException {
-        return URLEncoder.encode(param, StandardCharsets.UTF_8.name());
+    private static String urlEncode(String param) {
+        return URLEncoder.encode(param, StandardCharsets.UTF_8);
     }
 
     private String deflateAndBase64Encode(SAMLObject message) throws Exception {

--- a/x-pack/plugin/identity-provider/src/main/java/org/elasticsearch/xpack/idp/saml/authn/SamlAuthnRequestValidator.java
+++ b/x-pack/plugin/identity-provider/src/main/java/org/elasticsearch/xpack/idp/saml/authn/SamlAuthnRequestValidator.java
@@ -47,6 +47,7 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.zip.Inflater;
 import java.util.zip.InflaterInputStream;
+
 import javax.xml.parsers.DocumentBuilder;
 
 import static org.opensaml.saml.common.xml.SAMLConstants.SAML2_REDIRECT_BINDING_URI;

--- a/x-pack/plugin/identity-provider/src/main/java/org/elasticsearch/xpack/idp/saml/authn/SamlAuthnRequestValidator.java
+++ b/x-pack/plugin/identity-provider/src/main/java/org/elasticsearch/xpack/idp/saml/authn/SamlAuthnRequestValidator.java
@@ -33,7 +33,6 @@ import org.xml.sax.SAXException;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
-import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.security.InvalidKeyException;
@@ -48,7 +47,6 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.zip.Inflater;
 import java.util.zip.InflaterInputStream;
-
 import javax.xml.parsers.DocumentBuilder;
 
 import static org.opensaml.saml.common.xml.SAMLConstants.SAML2_REDIRECT_BINDING_URI;
@@ -369,8 +367,8 @@ public class SamlAuthnRequestValidator {
         }
     }
 
-    private String urlEncode(String param) throws UnsupportedEncodingException {
-        return URLEncoder.encode(param, StandardCharsets.UTF_8.name());
+    private String urlEncode(String param) {
+        return URLEncoder.encode(param, StandardCharsets.UTF_8);
     }
 
     private void logAndRespond(String message, ActionListener<SamlValidateAuthnRequestResponse> listener) {
@@ -406,13 +404,9 @@ public class SamlAuthnRequestValidator {
         }
 
         public String reconstructQueryParameters() throws ElasticsearchSecurityException {
-            try {
-                return relayState == null
-                    ? "SAMLRequest=" + urlEncode(samlRequest) + "&SigAlg=" + urlEncode(sigAlg)
-                    : "SAMLRequest=" + urlEncode(samlRequest) + "&RelayState=" + urlEncode(relayState) + "&SigAlg=" + urlEncode(sigAlg);
-            } catch (UnsupportedEncodingException e) {
-                throw new ElasticsearchSecurityException("Cannot reconstruct query for signature verification", e);
-            }
+            return relayState == null
+                ? "SAMLRequest=" + urlEncode(samlRequest) + "&SigAlg=" + urlEncode(sigAlg)
+                : "SAMLRequest=" + urlEncode(samlRequest) + "&RelayState=" + urlEncode(relayState) + "&SigAlg=" + urlEncode(sigAlg);
         }
     }
 }

--- a/x-pack/plugin/identity-provider/src/test/java/org/elasticsearch/xpack/idp/saml/authn/SamlAuthnRequestValidatorTests.java
+++ b/x-pack/plugin/identity-provider/src/test/java/org/elasticsearch/xpack/idp/saml/authn/SamlAuthnRequestValidatorTests.java
@@ -29,7 +29,6 @@ import org.opensaml.xmlsec.crypto.XMLSigningUtil;
 import org.opensaml.xmlsec.signature.support.SignatureConstants;
 
 import java.io.ByteArrayOutputStream;
-import java.io.UnsupportedEncodingException;
 import java.net.URL;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
@@ -328,8 +327,8 @@ public class SamlAuthnRequestValidatorTests extends IdpSamlTestCase {
         return Base64.getEncoder().encodeToString(bytes);
     }
 
-    private String urlEncode(String param) throws UnsupportedEncodingException {
-        return URLEncoder.encode(param, StandardCharsets.UTF_8.name());
+    private String urlEncode(String param) {
+        return URLEncoder.encode(param, StandardCharsets.UTF_8);
     }
 
     private String deflateAndBase64Encode(SAMLObject message) throws Exception {

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/oidc/OpenIdConnectAuthenticator.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/oidc/OpenIdConnectAuthenticator.java
@@ -93,7 +93,6 @@ import org.elasticsearch.xpack.core.security.authc.oidc.OpenIdConnectRealmSettin
 import org.elasticsearch.xpack.core.ssl.SSLService;
 
 import java.io.IOException;
-import java.io.UnsupportedEncodingException;
 import java.net.URI;
 import java.net.URL;
 import java.net.URLEncoder;
@@ -568,7 +567,7 @@ public class OpenIdConnectAuthenticator {
                     )
                 );
             }
-            httpPost.setEntity(new UrlEncodedFormEntity(params));
+            httpPost.setEntity(new UrlEncodedFormEntity(params, (Charset) null));
             SpecialPermission.check();
             AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
 
@@ -593,7 +592,7 @@ public class OpenIdConnectAuthenticator {
                 });
                 return null;
             });
-        } catch (AuthenticationException | UnsupportedEncodingException | JOSEException e) {
+        } catch (AuthenticationException | JOSEException e) {
             tokensListener.onFailure(
                 new ElasticsearchSecurityException("Failed to exchange code for Id Token using the Token Endpoint.", e)
             );

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/saml/SamlRedirect.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/saml/SamlRedirect.java
@@ -14,7 +14,6 @@ import org.opensaml.saml.saml2.core.StatusResponseType;
 import org.opensaml.xmlsec.signature.support.SignatureConstants;
 
 import java.io.ByteArrayOutputStream;
-import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
@@ -79,8 +78,8 @@ public class SamlRedirect {
         return Base64.getEncoder().encodeToString(bytes);
     }
 
-    private String urlEncode(String param) throws UnsupportedEncodingException {
-        return URLEncoder.encode(param, StandardCharsets.US_ASCII.name());
+    private String urlEncode(String param) {
+        return URLEncoder.encode(param, StandardCharsets.US_ASCII);
     }
 
     protected String deflateAndBase64Encode(SAMLObject message) throws Exception {

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/saml/SamlLogoutRequestHandlerTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/saml/SamlLogoutRequestHandlerTests.java
@@ -19,7 +19,6 @@ import org.opensaml.saml.saml2.core.NameID;
 import org.opensaml.security.x509.X509Credential;
 import org.opensaml.xmlsec.signature.support.SignatureConstants;
 
-import java.io.UnsupportedEncodingException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URLEncoder;
@@ -173,8 +172,8 @@ public class SamlLogoutRequestHandlerTests extends SamlTestCase {
         assertThat(result.getRelayState(), equalTo("Hail Hydra"));
     }
 
-    private String urlEncode(String str) throws UnsupportedEncodingException {
-        return URLEncoder.encode(str, StandardCharsets.US_ASCII.name());
+    private String urlEncode(String str) {
+        return URLEncoder.encode(str, StandardCharsets.US_ASCII);
     }
 
     private String buildSignedQueryString(LogoutRequest logoutRequest) throws URISyntaxException {

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/saml/SamlRedirectTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/saml/SamlRedirectTests.java
@@ -13,7 +13,6 @@ import org.opensaml.saml.saml2.core.NameID;
 import org.opensaml.saml.saml2.metadata.EntityDescriptor;
 import org.opensaml.security.x509.X509Credential;
 
-import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;
 import java.security.InvalidKeyException;
@@ -157,12 +156,12 @@ public class SamlRedirectTests extends SamlTestCase {
         assertThat(validateSignature(queryParam.substring(0, queryParam.length() - 5), signature, credential), equalTo(false));
     }
 
-    private String parseAndUrlDecodeParameter(String parameter) throws UnsupportedEncodingException {
+    private String parseAndUrlDecodeParameter(String parameter) {
         final String value = parameter.split("=", 2)[1];
-        return URLDecoder.decode(value, "UTF-8");
+        return URLDecoder.decode(value, StandardCharsets.UTF_8);
     }
 
-    private String validateUrlAndGetSignature(String url) throws UnsupportedEncodingException {
+    private String validateUrlAndGetSignature(String url) {
         final String params[] = url.split("\\?")[1].split("&");
         assert (params.length == 3);
         String sigAlg = parseAndUrlDecodeParameter(params[1]);

--- a/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/common/http/HttpClient.java
+++ b/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/common/http/HttpClient.java
@@ -75,6 +75,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
+
 import javax.net.ssl.HostnameVerifier;
 
 public class HttpClient implements Closeable {

--- a/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/common/http/HttpClient.java
+++ b/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/common/http/HttpClient.java
@@ -65,7 +65,6 @@ import java.io.ByteArrayOutputStream;
 import java.io.Closeable;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.UnsupportedEncodingException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URLDecoder;
@@ -76,7 +75,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
-
 import javax.net.ssl.HostnameVerifier;
 
 public class HttpClient implements Closeable {
@@ -366,7 +364,7 @@ public class HttpClient implements Closeable {
                     String part = pathParts[i];
                     boolean isLast = i == pathParts.length - 1;
                     if (Strings.isEmpty(part) == false) {
-                        unescapedPathParts.add(URLDecoder.decode(part, StandardCharsets.UTF_8.name()));
+                        unescapedPathParts.add(URLDecoder.decode(part, StandardCharsets.UTF_8));
                         // if the passed URL ends with a slash, adding an empty string to the
                         // unescaped paths will ensure the slash will be added back
                         boolean appendSlash = isPathEndsWithSlash && isLast;
@@ -385,7 +383,7 @@ public class HttpClient implements Closeable {
                 .build();
             final HttpHost httpHost = URIUtils.extractHost(uri);
             return new Tuple<>(httpHost, uri);
-        } catch (URISyntaxException | UnsupportedEncodingException e) {
+        } catch (URISyntaxException e) {
             throw new IllegalArgumentException(e);
         }
     }

--- a/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/common/http/HttpRequest.java
+++ b/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/common/http/HttpRequest.java
@@ -26,11 +26,11 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.UnsupportedEncodingException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URLDecoder;
 import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -142,19 +142,11 @@ public class HttpRequest implements ToXContentObject {
     }
 
     public static String encodeUrl(String text) {
-        try {
-            return URLEncoder.encode(text, "UTF-8");
-        } catch (UnsupportedEncodingException e) {
-            throw new IllegalArgumentException("failed to URL encode text [" + text + "]", e);
-        }
+        return URLEncoder.encode(text, StandardCharsets.UTF_8);
     }
 
     public static String decodeUrl(String text) {
-        try {
-            return URLDecoder.decode(text, "UTF-8");
-        } catch (UnsupportedEncodingException e) {
-            throw new IllegalArgumentException("failed to URL decode text [" + text + "]", e);
-        }
+        return URLDecoder.decode(text, StandardCharsets.UTF_8);
     }
 
     @Override


### PR DESCRIPTION
There are many places in Elasticsearch which must decode some stream of
bytes into characters. Most of the time this is expected to be UTF-8
encoded data, and we hardcode that charset name. However, methods in the
JDK that take a String charset name require catching
UnsupportedEncodingException. Yet most of these APIs also has a variant
of the same methods which take a known Charset instance, for which we
can use StandardCharsets.UTF_8. This commit converts most instances of
passing string charset names to use a Charset instance.