### PR TITLE
[8.2] Mute XPackRestIT deprecation/10_basic/Test Deprecations (#85807)

### DIFF
--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/deprecation/10_basic.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/deprecation/10_basic.yml
@@ -6,6 +6,9 @@ setup:
 
 ---
 "Test Deprecations":
+  - skip:
+      version: "all"
+      reason: "AwaitsFix https://github.com/elastic/elasticsearch/issues/85806"
   - do:
       migration.deprecations:
         index: "*"


### PR DESCRIPTION
Backports the following commits to 8.2:
 - Mute XPackRestIT deprecation/10_basic/Test Deprecations (#85807)