### PR TITLE
[7.17] Mute MigrationIT.testGetDeprecationInfo (#85813)

### DIFF
--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/MigrationIT.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/MigrationIT.java
@@ -33,6 +33,7 @@ import static org.hamcrest.Matchers.is;
 
 public class MigrationIT extends ESRestHighLevelClientTestCase {
 
+    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/85743")
     public void testGetDeprecationInfo() throws IOException {
         createIndex("test", Settings.EMPTY);
         DeprecationInfoRequest request = new DeprecationInfoRequest(Collections.singletonList("test"));


### PR DESCRIPTION
Backports the following commits to 7.17:
 - Mute MigrationIT.testGetDeprecationInfo (#85813)