### PR TITLE
refactor array part into a BytesRefArray which can be serialized and …

### DIFF
--- a/docs/changelog/85826.yaml
+++ b/docs/changelog/85826.yaml
@@ -1,0 +1,5 @@
+pr: 85826
+summary: Refactor array part into a `BytesRefArray` which can be serialized and …
+area: "Infra/Core, Machine Learning"
+type: enhancement
+issues: []

--- a/docs/changelog/85826.yaml
+++ b/docs/changelog/85826.yaml
@@ -1,5 +1,5 @@
 pr: 85826
 summary: Refactor array part into a `BytesRefArray` which can be serialized and …
-area: "Infra/Core, Machine Learning"
+area: "Infra/Core"
 type: enhancement
 issues: []

--- a/server/src/main/java/org/elasticsearch/common/util/BytesRefArray.java
+++ b/server/src/main/java/org/elasticsearch/common/util/BytesRefArray.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.common.util;
+
+import org.apache.lucene.util.Accountable;
+import org.apache.lucene.util.BytesRef;
+import org.apache.lucene.util.RamUsageEstimator;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.core.Releasable;
+import org.elasticsearch.core.Releasables;
+
+import java.io.IOException;
+
+/**
+ * Compact serializable container for ByteRefs
+ */
+public class BytesRefArray implements Accountable, Releasable, Writeable {
+
+    // base size of the bytes ref array
+    private static final long BASE_RAM_BYTES_USED = RamUsageEstimator.shallowSizeOfInstance(BytesRefArray.class);
+
+    private final BigArrays bigArrays;
+    private LongArray startOffsets;
+    private ByteArray bytes;
+    private long size;
+
+    public BytesRefArray(long capacity, BigArrays bigArrays) {
+        this.bigArrays = bigArrays;
+        boolean success = false;
+        try {
+            startOffsets = bigArrays.newLongArray(capacity + 1, false);
+            startOffsets.set(0, 0);
+            bytes = bigArrays.newByteArray(capacity * 3, false);
+            success = true;
+        } finally {
+            if (false == success) {
+                close();
+            }
+        }
+        size = 0;
+    }
+
+    public BytesRefArray(StreamInput in, BigArrays bigArrays) throws IOException {
+        this.bigArrays = bigArrays;
+        // we allocate big arrays so we have to `close` if we fail here or we'll leak them.
+        boolean success = false;
+        try {
+            // startOffsets
+            size = in.readVLong();
+            long sizeOfStartOffsets = size + 1;
+            startOffsets = bigArrays.newLongArray(sizeOfStartOffsets, true);
+            for (long i = 0; i < sizeOfStartOffsets; ++i) {
+                startOffsets.set(i, in.readVLong());
+            }
+
+            // bytes
+            long sizeOfBytes = in.readVLong();
+            bytes = bigArrays.newByteArray(sizeOfBytes, true);
+
+            for (long i = 0; i < sizeOfBytes; ++i) {
+                bytes.set(i, in.readByte());
+            }
+
+            success = true;
+        } finally {
+            if (success == false) {
+                close();
+            }
+        }
+    }
+
+    public void append(BytesRef key) {
+        final long startOffset = startOffsets.get(size);
+        bytes = bigArrays.grow(bytes, startOffset + key.length);
+        bytes.set(startOffset, key.bytes, key.offset, key.length);
+        startOffsets = bigArrays.grow(startOffsets, size + 2);
+        startOffsets.set(size + 1, startOffset + key.length);
+        ++size;
+    }
+
+    /**
+     * Return the key at <code>0 &lt;= index &lt;= capacity()</code>. The result is undefined if the slot is unused.
+     * <p>Beware that the content of the {@link BytesRef} may become invalid as soon as {@link #close()} is called</p>
+     */
+    public BytesRef get(long id, BytesRef dest) {
+        final long startOffset = startOffsets.get(id);
+        final int length = (int) (startOffsets.get(id + 1) - startOffset);
+        bytes.get(startOffset, length, dest);
+        return dest;
+    }
+
+    public long size() {
+        return size;
+    }
+
+    @Override
+    public void close() {
+        Releasables.close(bytes, startOffsets);
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        out.writeVLong(size);
+        long sizeOfStartOffsets = size + 1;
+
+        // start offsets have 1 extra bucket
+        for (long i = 0; i < sizeOfStartOffsets; ++i) {
+            out.writeVLong(startOffsets.get(i));
+        }
+
+        // bytes might be overallocated, the last bucket of startOffsets contains the real size
+        long sizeOfBytes = startOffsets.get(size);
+        out.writeVLong(sizeOfBytes);
+        for (long i = 0; i < sizeOfBytes; ++i) {
+            out.writeByte(bytes.get(i));
+        }
+    }
+
+    @Override
+    public long ramBytesUsed() {
+        return BASE_RAM_BYTES_USED + startOffsets.ramBytesUsed() + bytes.ramBytesUsed();
+    }
+
+}

--- a/server/src/main/java/org/elasticsearch/common/util/BytesRefHash.java
+++ b/server/src/main/java/org/elasticsearch/common/util/BytesRefHash.java
@@ -78,15 +78,7 @@ public final class BytesRefHash extends AbstractHash implements Accountable {
         // recreate hashes
         for (int i = 0; i < byteRefs.size(); ++i) {
             byteRefs.get(i, spare);
-            int code = rehash(spare.hashCode());
-            final long slot = slot(code, mask);
-            for (long index = slot;; index = nextSlot(index, mask)) {
-                final long curId = id(index);
-                if (curId == -1) { // means unset
-                    id(index, i);
-                    break;
-                }
-            }
+            reset(rehash(spare.hashCode()), i);
         }
     }
 

--- a/server/src/test/java/org/elasticsearch/common/util/BytesRefArrayTests.java
+++ b/server/src/test/java/org/elasticsearch/common/util/BytesRefArrayTests.java
@@ -19,6 +19,23 @@ import java.io.IOException;
 
 public class BytesRefArrayTests extends ESTestCase {
 
+    public static BytesRefArray randomArray() {
+        return randomArray(randomIntBetween(0, 100), randomIntBetween(10, 50), mockBigArrays());
+    }
+
+    public static BytesRefArray randomArray(long capacity, int entries, BigArrays bigArrays) {
+        BytesRefArray bytesRefs = new BytesRefArray(capacity, bigArrays);
+        BytesRefBuilder ref = new BytesRefBuilder();
+
+        for (int i = 0; i < entries; i++) {
+            String str = randomUnicodeOfLengthBetween(4, 20);
+            ref.copyChars(str);
+            bytesRefs.append(ref.get());
+        }
+
+        return bytesRefs;
+    }
+
     public void testRandomWithSerialization() throws IOException {
         int runs = randomIntBetween(2, 20);
         BytesRefArray array = randomArray();
@@ -40,22 +57,8 @@ public class BytesRefArrayTests extends ESTestCase {
         array.close();
     }
 
-    private BigArrays mockBigArrays() {
+    private static BigArrays mockBigArrays() {
         return new MockBigArrays(new MockPageCacheRecycler(Settings.EMPTY), new NoneCircuitBreakerService());
-    }
-
-    private BytesRefArray randomArray() {
-        BytesRefArray bytesRefs = new BytesRefArray(randomIntBetween(0, 100), mockBigArrays());
-        BytesRefBuilder ref = new BytesRefBuilder();
-        int entries = randomIntBetween(10, 50);
-
-        for (int i = 0; i < entries; i++) {
-            String str = randomUnicodeOfLengthBetween(4, 20);
-            ref.copyChars(str);
-            bytesRefs.append(ref.get());
-        }
-
-        return bytesRefs;
     }
 
     private void assertEquality(BytesRefArray original, BytesRefArray copy) {

--- a/server/src/test/java/org/elasticsearch/common/util/BytesRefArrayTests.java
+++ b/server/src/test/java/org/elasticsearch/common/util/BytesRefArrayTests.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.common.util;
+
+import org.apache.lucene.util.BytesRef;
+import org.apache.lucene.util.BytesRefBuilder;
+import org.elasticsearch.Version;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.indices.breaker.NoneCircuitBreakerService;
+import org.elasticsearch.test.ESTestCase;
+
+import java.io.IOException;
+
+public class BytesRefArrayTests extends ESTestCase {
+
+    public void testRandomWithSerialization() throws IOException {
+        int runs = randomIntBetween(2, 20);
+        BytesRefArray array = randomArray();
+
+        for (int j = 0; j < runs; j++) {
+            BytesRefArray copy = copyInstance(
+                array,
+                writableRegistry(),
+                (out, value) -> value.writeTo(out),
+                in -> new BytesRefArray(in, mockBigArrays()),
+                Version.CURRENT
+            );
+
+            assertEquality(array, copy);
+            copy.close();
+            array.close();
+            array = randomArray();
+        }
+        array.close();
+    }
+
+    private BigArrays mockBigArrays() {
+        return new MockBigArrays(new MockPageCacheRecycler(Settings.EMPTY), new NoneCircuitBreakerService());
+    }
+
+    private BytesRefArray randomArray() {
+        BytesRefArray bytesRefs = new BytesRefArray(randomIntBetween(0, 100), mockBigArrays());
+        BytesRefBuilder ref = new BytesRefBuilder();
+        int entries = randomIntBetween(10, 50);
+
+        for (int i = 0; i < entries; i++) {
+            String str = randomUnicodeOfLengthBetween(4, 20);
+            ref.copyChars(str);
+            bytesRefs.append(ref.get());
+        }
+
+        return bytesRefs;
+    }
+
+    private void assertEquality(BytesRefArray original, BytesRefArray copy) {
+        BytesRef scratch = new BytesRef();
+        BytesRef scratch2 = new BytesRef();
+
+        assertEquals(original.size(), copy.size());
+
+        // check that all keys of original can be found in the copy
+        for (int i = 0; i < original.size(); ++i) {
+            original.get(i, scratch);
+            copy.get(i, scratch2);
+            assertEquals(scratch, scratch2);
+        }
+    }
+}

--- a/server/src/test/java/org/elasticsearch/common/util/BytesRefHashTests.java
+++ b/server/src/test/java/org/elasticsearch/common/util/BytesRefHashTests.java
@@ -406,14 +406,14 @@ public class BytesRefHashTests extends ESTestCase {
         hash.close();
     }
 
-    // demonstrates how a given BytesRefArray must be secured against leakage
+    // demonstrates how a given BytesRefArray must be protected against leakage
     public void testDontLeakBytesRefArray() {
         BytesRefArray array = null;
         boolean success = false;
         boolean thrown = false;
         BytesRefHash hash = null;
         try {
-            // create a big array, so it is allocated using ordinary java arrays
+            // create a big array, so it is not allocated using ordinary java arrays
             array = BytesRefArrayTests.randomArray(
                 PageCacheRecycler.LONG_PAGE_SIZE + 100,
                 PageCacheRecycler.LONG_PAGE_SIZE + 100,
@@ -438,14 +438,14 @@ public class BytesRefHashTests extends ESTestCase {
         assertNull(hash);
     }
 
-    // demonstrates how a given BytesRefArray must be secured against leakage, special case
+    // demonstrates how a given BytesRefArray must be protected against leakage, special case
     public void testDontLeakBytesRefArray2() {
         BytesRefArray array = null;
         boolean success = false;
         boolean thrown = false;
         BytesRefHash hash = null;
         try {
-            // create a big array, so it is allocated using ordinary java arrays
+            // create a big array, so it is not allocated using ordinary java arrays
             array = BytesRefArrayTests.randomArray(
                 PageCacheRecycler.LONG_PAGE_SIZE + 100,
                 PageCacheRecycler.LONG_PAGE_SIZE + 100,
@@ -470,14 +470,14 @@ public class BytesRefHashTests extends ESTestCase {
         assertNull(hash);
     }
 
-    // demonstrates how a given BytesRefArray must be secured against leakage, special case when the array creation already throws
+    // demonstrates how a given BytesRefArray must be protected against leakage, special case when the array creation already throws
     public void testDontLeakBytesRefArray3() {
         BytesRefArray array = null;
         boolean success = false;
         boolean thrown = false;
         BytesRefHash hash = null;
         try {
-            // create a big array, so it is allocated using ordinary java arrays
+            // create a big array, so it is not allocated using ordinary java arrays
             array = BytesRefArrayTests.randomArray(
                 PageCacheRecycler.LONG_PAGE_SIZE + 100,
                 PageCacheRecycler.LONG_PAGE_SIZE + 100,


### PR DESCRIPTION
refactor BytesRefHash and extract BytesRefArray. The BytesRefArray can be serialized for communication.

**Background**

This PR is a spin off from a bigger task to implement a frequent_items aggregation. For this aggregation I need a data structure that collects data in form of largish frequency tables. These tables need to be centrally merged before the core algorithm mines for frequent items (I happily provide more details, just ping me). The closest re-usable structure I could find was BytesRefHash used in several places, however it wasn't able serialize and deserialize. 

This PR extracts part that stores the keys out of BytesRefHash. 

Serialization/Deserialization: For communication, get the BytesRefsArray. On the receiver side, serialize the BytesRefsArray and re-create the BytesRefHash. The added constructor uses the given BytesRefsArray and re-creates the hashtable part.

Relates https://github.com/elastic/elasticsearch/pull/83055