### PR TITLE
Add support for impact_areas to health impacts 

### DIFF
--- a/docs/changelog/85830.yaml
+++ b/docs/changelog/85830.yaml
@@ -1,0 +1,6 @@
+pr: 85830
+summary: Add support for `impact_areas` to health impacts
+area: Health
+type: feature
+issues:
+ - 85829

--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/ShardsAvailabilityHealthIndicatorService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/ShardsAvailabilityHealthIndicatorService.java
@@ -259,7 +259,7 @@ public class ShardsAvailabilityHealthIndicatorService implements HealthIndicator
                     indicesWithUnavailableReplicasOnly.size() == 1 ? "index" : "indices",
                     getTruncatedIndicesString(indicesWithUnavailableReplicasOnly, clusterMetadata)
                 );
-                impacts.add(new HealthIndicatorImpact(3, impactDescription, List.of(ImpactArea.SEARCH)));
+                impacts.add(new HealthIndicatorImpact(2, impactDescription, List.of(ImpactArea.SEARCH)));
             }
             return impacts;
         }

--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/ShardsAvailabilityHealthIndicatorService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/ShardsAvailabilityHealthIndicatorService.java
@@ -23,6 +23,7 @@ import org.elasticsearch.health.HealthIndicatorImpact;
 import org.elasticsearch.health.HealthIndicatorResult;
 import org.elasticsearch.health.HealthIndicatorService;
 import org.elasticsearch.health.HealthStatus;
+import org.elasticsearch.health.ImpactArea;
 import org.elasticsearch.health.SimpleHealthIndicatorDetails;
 
 import java.util.ArrayList;
@@ -241,7 +242,7 @@ public class ShardsAvailabilityHealthIndicatorService implements HealthIndicator
                     primaries.indicesWithUnavailableShards.size() == 1 ? "index" : "indices",
                     getTruncatedIndicesString(primaries.indicesWithUnavailableShards, clusterMetadata)
                 );
-                impacts.add(new HealthIndicatorImpact(1, impactDescription));
+                impacts.add(new HealthIndicatorImpact(1, impactDescription, List.of(ImpactArea.INGEST, ImpactArea.SEARCH)));
             }
             /*
              * It is possible that we're working with an intermediate cluster state, and that for an index we have no primary but a replica
@@ -258,7 +259,7 @@ public class ShardsAvailabilityHealthIndicatorService implements HealthIndicator
                     indicesWithUnavailableReplicasOnly.size() == 1 ? "index" : "indices",
                     getTruncatedIndicesString(indicesWithUnavailableReplicasOnly, clusterMetadata)
                 );
-                impacts.add(new HealthIndicatorImpact(3, impactDescription));
+                impacts.add(new HealthIndicatorImpact(3, impactDescription, List.of(ImpactArea.SEARCH)));
             }
             return impacts;
         }

--- a/server/src/main/java/org/elasticsearch/health/HealthIndicatorImpact.java
+++ b/server/src/main/java/org/elasticsearch/health/HealthIndicatorImpact.java
@@ -8,19 +8,25 @@
 
 package org.elasticsearch.health;
 
+import org.elasticsearch.common.Strings;
 import org.elasticsearch.xcontent.ToXContentObject;
 import org.elasticsearch.xcontent.XContentBuilder;
 
 import java.io.IOException;
-import java.util.Objects;
+import java.util.List;
 
-public record HealthIndicatorImpact(int severity, String impactDescription) implements ToXContentObject {
+public record HealthIndicatorImpact(int severity, String impactDescription, List<ImpactArea> impactAreas) implements ToXContentObject {
 
     public HealthIndicatorImpact {
         if (severity < 0) {
             throw new IllegalArgumentException("Severity cannot be less than 0");
         }
-        Objects.requireNonNull(impactDescription);
+        if (Strings.isEmpty(impactDescription)) {
+            throw new IllegalArgumentException("Impact description must be provided");
+        }
+        if (impactAreas == null || impactAreas.isEmpty()) {
+            throw new IllegalArgumentException("At least one impact area must be provided");
+        }
     }
 
     @Override
@@ -28,6 +34,11 @@ public record HealthIndicatorImpact(int severity, String impactDescription) impl
         builder.startObject();
         builder.field("severity", severity);
         builder.field("description", impactDescription);
+        builder.startArray("impact_areas");
+        for (ImpactArea impactArea : impactAreas) {
+            builder.value(impactArea.displayValue());
+        }
+        builder.endArray();
         builder.endObject();
         return builder;
     }

--- a/server/src/main/java/org/elasticsearch/health/ImpactArea.java
+++ b/server/src/main/java/org/elasticsearch/health/ImpactArea.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.health;
+
+public enum ImpactArea {
+    SEARCH("search"),
+    INGEST("ingest");
+
+    private final String displayValue;
+
+    ImpactArea(String displayValue) {
+        this.displayValue = displayValue;
+    }
+
+    public String displayValue() {
+        return displayValue;
+    }
+}

--- a/server/src/test/java/org/elasticsearch/cluster/routing/allocation/ShardsAvailabilityHealthIndicatorServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/allocation/ShardsAvailabilityHealthIndicatorServiceTests.java
@@ -116,7 +116,7 @@ public class ShardsAvailabilityHealthIndicatorServiceTests extends ESTestCase {
                     ),
                     List.of(
                         new HealthIndicatorImpact(
-                            3,
+                            2,
                             "Searches might return slower than usual. Fewer redundant copies of the data exist on 1 index [yellow-index].",
                             List.of(ImpactArea.SEARCH)
                         )
@@ -216,7 +216,7 @@ public class ShardsAvailabilityHealthIndicatorServiceTests extends ESTestCase {
             result.impacts().get(1),
             equalTo(
                 new HealthIndicatorImpact(
-                    3,
+                    2,
                     "Searches might return slower than usual. Fewer redundant copies of the data exist on 2 indices [yellow-index-2, "
                         + "yellow-index-1].", List.of(ImpactArea.SEARCH)
                 )
@@ -247,7 +247,7 @@ public class ShardsAvailabilityHealthIndicatorServiceTests extends ESTestCase {
             result.impacts().get(0),
             equalTo(
                 new HealthIndicatorImpact(
-                    3,
+                    2,
                     "Searches might return slower than usual. Fewer redundant copies of the data exist on 3 indices [index-2, "
                         + "index-1, index-3].",
                     List.of(ImpactArea.SEARCH)
@@ -324,7 +324,7 @@ public class ShardsAvailabilityHealthIndicatorServiceTests extends ESTestCase {
                     Map.of("started_primaries", 1, "unassigned_replicas", 1),
                     List.of(
                         new HealthIndicatorImpact(
-                            3,
+                            2,
                             "Searches might return slower than usual. Fewer redundant copies of the data exist on 1 index "
                                 + "[restarting-index].",
                             List.of(ImpactArea.SEARCH)

--- a/server/src/test/java/org/elasticsearch/cluster/routing/allocation/ShardsAvailabilityHealthIndicatorServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/allocation/ShardsAvailabilityHealthIndicatorServiceTests.java
@@ -26,6 +26,7 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.health.HealthIndicatorImpact;
 import org.elasticsearch.health.HealthIndicatorResult;
 import org.elasticsearch.health.HealthStatus;
+import org.elasticsearch.health.ImpactArea;
 import org.elasticsearch.health.SimpleHealthIndicatorDetails;
 import org.elasticsearch.index.Index;
 import org.elasticsearch.index.shard.ShardId;
@@ -116,7 +117,8 @@ public class ShardsAvailabilityHealthIndicatorServiceTests extends ESTestCase {
                     List.of(
                         new HealthIndicatorImpact(
                             3,
-                            "Searches might return slower than usual. Fewer redundant copies of the data exist on 1 index [yellow-index]."
+                            "Searches might return slower than usual. Fewer redundant copies of the data exist on 1 index [yellow-index].",
+                            List.of(ImpactArea.SEARCH)
                         )
                     )
                 )
@@ -139,7 +141,8 @@ public class ShardsAvailabilityHealthIndicatorServiceTests extends ESTestCase {
                     "This cluster has 1 unavailable primary.",
                     Map.of("unassigned_primaries", 1, "started_replicas", 1),
                     List.of(
-                        new HealthIndicatorImpact(1, "Cannot add data to 1 index [red-index]. Searches might return incomplete results.")
+                        new HealthIndicatorImpact(1, "Cannot add data to 1 index [red-index]. Searches might return incomplete results.",
+                            List.of(ImpactArea.INGEST, ImpactArea.SEARCH))
                     )
                 )
             )
@@ -158,7 +161,8 @@ public class ShardsAvailabilityHealthIndicatorServiceTests extends ESTestCase {
                     "This cluster has 1 unavailable primary.",
                     Map.of("unassigned_primaries", 1),
                     List.of(
-                        new HealthIndicatorImpact(1, "Cannot add data to 1 index [red-index]. Searches might return incomplete results.")
+                        new HealthIndicatorImpact(1, "Cannot add data to 1 index [red-index]. Searches might return incomplete results.",
+                            List.of(ImpactArea.INGEST, ImpactArea.SEARCH))
                     )
                 )
             )
@@ -178,7 +182,8 @@ public class ShardsAvailabilityHealthIndicatorServiceTests extends ESTestCase {
         assertEquals(1, result.impacts().size());
         assertEquals(
             result.impacts().get(0),
-            new HealthIndicatorImpact(1, "Cannot add data to 1 index [red-index]. Searches might return incomplete results.")
+            new HealthIndicatorImpact(1, "Cannot add data to 1 index [red-index]. Searches might return incomplete results.",
+                List.of(ImpactArea.INGEST, ImpactArea.SEARCH))
         );
     }
 
@@ -203,7 +208,8 @@ public class ShardsAvailabilityHealthIndicatorServiceTests extends ESTestCase {
         assertEquals(2, result.impacts().size());
         assertEquals(
             result.impacts().get(0),
-            new HealthIndicatorImpact(1, "Cannot add data to 1 index [red-index]. Searches might return incomplete results.")
+            new HealthIndicatorImpact(1, "Cannot add data to 1 index [red-index]. Searches might return incomplete results.",
+                List.of(ImpactArea.INGEST, ImpactArea.SEARCH))
         );
         // yellow-index-2 has the higher priority so it ought to be listed first:
         assertThat(
@@ -212,7 +218,7 @@ public class ShardsAvailabilityHealthIndicatorServiceTests extends ESTestCase {
                 new HealthIndicatorImpact(
                     3,
                     "Searches might return slower than usual. Fewer redundant copies of the data exist on 2 indices [yellow-index-2, "
-                        + "yellow-index-1]."
+                        + "yellow-index-1].", List.of(ImpactArea.SEARCH)
                 )
             )
         );
@@ -243,7 +249,8 @@ public class ShardsAvailabilityHealthIndicatorServiceTests extends ESTestCase {
                 new HealthIndicatorImpact(
                     3,
                     "Searches might return slower than usual. Fewer redundant copies of the data exist on 3 indices [index-2, "
-                        + "index-1, index-3]."
+                        + "index-1, index-3].",
+                    List.of(ImpactArea.SEARCH)
                 )
             )
         );
@@ -319,7 +326,8 @@ public class ShardsAvailabilityHealthIndicatorServiceTests extends ESTestCase {
                         new HealthIndicatorImpact(
                             3,
                             "Searches might return slower than usual. Fewer redundant copies of the data exist on 1 index "
-                                + "[restarting-index]."
+                                + "[restarting-index].",
+                            List.of(ImpactArea.SEARCH)
                         )
                     )
                 )
@@ -389,7 +397,8 @@ public class ShardsAvailabilityHealthIndicatorServiceTests extends ESTestCase {
                     List.of(
                         new HealthIndicatorImpact(
                             1,
-                            "Cannot add data to 1 index [restarting-index]. Searches might return incomplete results."
+                            "Cannot add data to 1 index [restarting-index]. Searches might return incomplete results.",
+                            List.of(ImpactArea.INGEST, ImpactArea.SEARCH)
                         )
                     )
                 )

--- a/server/src/test/java/org/elasticsearch/cluster/routing/allocation/ShardsAvailabilityHealthIndicatorServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/allocation/ShardsAvailabilityHealthIndicatorServiceTests.java
@@ -141,8 +141,11 @@ public class ShardsAvailabilityHealthIndicatorServiceTests extends ESTestCase {
                     "This cluster has 1 unavailable primary.",
                     Map.of("unassigned_primaries", 1, "started_replicas", 1),
                     List.of(
-                        new HealthIndicatorImpact(1, "Cannot add data to 1 index [red-index]. Searches might return incomplete results.",
-                            List.of(ImpactArea.INGEST, ImpactArea.SEARCH))
+                        new HealthIndicatorImpact(
+                            1,
+                            "Cannot add data to 1 index [red-index]. Searches might return incomplete results.",
+                            List.of(ImpactArea.INGEST, ImpactArea.SEARCH)
+                        )
                     )
                 )
             )
@@ -161,8 +164,11 @@ public class ShardsAvailabilityHealthIndicatorServiceTests extends ESTestCase {
                     "This cluster has 1 unavailable primary.",
                     Map.of("unassigned_primaries", 1),
                     List.of(
-                        new HealthIndicatorImpact(1, "Cannot add data to 1 index [red-index]. Searches might return incomplete results.",
-                            List.of(ImpactArea.INGEST, ImpactArea.SEARCH))
+                        new HealthIndicatorImpact(
+                            1,
+                            "Cannot add data to 1 index [red-index]. Searches might return incomplete results.",
+                            List.of(ImpactArea.INGEST, ImpactArea.SEARCH)
+                        )
                     )
                 )
             )
@@ -182,8 +188,11 @@ public class ShardsAvailabilityHealthIndicatorServiceTests extends ESTestCase {
         assertEquals(1, result.impacts().size());
         assertEquals(
             result.impacts().get(0),
-            new HealthIndicatorImpact(1, "Cannot add data to 1 index [red-index]. Searches might return incomplete results.",
-                List.of(ImpactArea.INGEST, ImpactArea.SEARCH))
+            new HealthIndicatorImpact(
+                1,
+                "Cannot add data to 1 index [red-index]. Searches might return incomplete results.",
+                List.of(ImpactArea.INGEST, ImpactArea.SEARCH)
+            )
         );
     }
 
@@ -208,8 +217,11 @@ public class ShardsAvailabilityHealthIndicatorServiceTests extends ESTestCase {
         assertEquals(2, result.impacts().size());
         assertEquals(
             result.impacts().get(0),
-            new HealthIndicatorImpact(1, "Cannot add data to 1 index [red-index]. Searches might return incomplete results.",
-                List.of(ImpactArea.INGEST, ImpactArea.SEARCH))
+            new HealthIndicatorImpact(
+                1,
+                "Cannot add data to 1 index [red-index]. Searches might return incomplete results.",
+                List.of(ImpactArea.INGEST, ImpactArea.SEARCH)
+            )
         );
         // yellow-index-2 has the higher priority so it ought to be listed first:
         assertThat(
@@ -218,7 +230,8 @@ public class ShardsAvailabilityHealthIndicatorServiceTests extends ESTestCase {
                 new HealthIndicatorImpact(
                     2,
                     "Searches might return slower than usual. Fewer redundant copies of the data exist on 2 indices [yellow-index-2, "
-                        + "yellow-index-1].", List.of(ImpactArea.SEARCH)
+                        + "yellow-index-1].",
+                    List.of(ImpactArea.SEARCH)
                 )
             )
         );

--- a/server/src/test/java/org/elasticsearch/health/HealthIndicatorResultTests.java
+++ b/server/src/test/java/org/elasticsearch/health/HealthIndicatorResultTests.java
@@ -32,10 +32,12 @@ public class HealthIndicatorResultTests extends ESTestCase {
         List<HealthIndicatorImpact> impacts = new ArrayList<>();
         int impact1Severity = randomIntBetween(1, 5);
         String impact1Description = randomAlphaOfLength(30);
-        impacts.add(new HealthIndicatorImpact(impact1Severity, impact1Description));
+        ImpactArea firstImpactArea = randomFrom(ImpactArea.values());
+        impacts.add(new HealthIndicatorImpact(impact1Severity, impact1Description, List.of(firstImpactArea)));
         int impact2Severity = randomIntBetween(1, 5);
         String impact2Description = randomAlphaOfLength(30);
-        impacts.add(new HealthIndicatorImpact(impact2Severity, impact2Description));
+        ImpactArea secondImpactArea = randomFrom(ImpactArea.values());
+        impacts.add(new HealthIndicatorImpact(impact2Severity, impact2Description, List.of(secondImpactArea)));
         HealthIndicatorResult result = new HealthIndicatorResult(name, component, status, summary, details, impacts);
         XContentBuilder builder = XContentFactory.jsonBuilder().prettyPrint();
         result.toXContent(builder, ToXContent.EMPTY_PARAMS);
@@ -47,9 +49,11 @@ public class HealthIndicatorResultTests extends ESTestCase {
         Map<String, Object> expectedImpact1 = new HashMap<>();
         expectedImpact1.put("severity", impact1Severity);
         expectedImpact1.put("description", impact1Description);
+        expectedImpact1.put("impact_areas", List.of(firstImpactArea.displayValue()));
         Map<String, Object> expectedImpact2 = new HashMap<>();
         expectedImpact2.put("severity", impact2Severity);
         expectedImpact2.put("description", impact2Description);
+        expectedImpact2.put("impact_areas", List.of(secondImpactArea.displayValue()));
         expectedImpacts.add(expectedImpact1);
         expectedImpacts.add(expectedImpact2);
         assertEquals(expectedImpacts, xContentMap.get("impacts"));

--- a/server/src/test/java/org/elasticsearch/health/HealthIndicatorServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/health/HealthIndicatorServiceTests.java
@@ -22,16 +22,18 @@ public class HealthIndicatorServiceTests extends ESTestCase {
         HealthStatus status = randomFrom(HealthStatus.RED, HealthStatus.YELLOW, HealthStatus.GREEN);
         Set<HealthIndicatorImpact> impacts = new HashSet<>();
         for (int i = 0; i < 10; i++) {
-            impacts.add(new HealthIndicatorImpact(randomIntBetween(5, 20), randomAlphaOfLength(20)));
+            impacts.add(new HealthIndicatorImpact(randomIntBetween(5, 20), randomAlphaOfLength(20),
+                List.of(randomFrom(ImpactArea.values()))));
         }
-        HealthIndicatorImpact impact1 = new HealthIndicatorImpact(1, randomAlphaOfLength(20));
-        HealthIndicatorImpact impact2 = new HealthIndicatorImpact(2, randomAlphaOfLength(20));
-        HealthIndicatorImpact impact3 = new HealthIndicatorImpact(3, randomAlphaOfLength(20));
+        HealthIndicatorImpact impact1 = new HealthIndicatorImpact(1, randomAlphaOfLength(20), List.of(randomFrom(ImpactArea.values())));
+        HealthIndicatorImpact impact2 = new HealthIndicatorImpact(2, randomAlphaOfLength(20), List.of(randomFrom(ImpactArea.values())));
+        HealthIndicatorImpact impact3 = new HealthIndicatorImpact(3, randomAlphaOfLength(20), List.of(randomFrom(ImpactArea.values())));
         impacts.add(impact2);
         impacts.add(impact1);
         impacts.add(impact3);
         for (int i = 0; i < 10; i++) {
-            impacts.add(new HealthIndicatorImpact(randomIntBetween(5, 20), randomAlphaOfLength(20)));
+            impacts.add(new HealthIndicatorImpact(randomIntBetween(5, 20), randomAlphaOfLength(20),
+                List.of(randomFrom(ImpactArea.values()))));
         }
         HealthIndicatorResult result = service.createIndicator(status, randomAlphaOfLength(20), HealthIndicatorDetails.EMPTY, impacts);
         List<HealthIndicatorImpact> outputImpacts = result.impacts();

--- a/server/src/test/java/org/elasticsearch/health/HealthIndicatorServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/health/HealthIndicatorServiceTests.java
@@ -22,8 +22,9 @@ public class HealthIndicatorServiceTests extends ESTestCase {
         HealthStatus status = randomFrom(HealthStatus.RED, HealthStatus.YELLOW, HealthStatus.GREEN);
         Set<HealthIndicatorImpact> impacts = new HashSet<>();
         for (int i = 0; i < 10; i++) {
-            impacts.add(new HealthIndicatorImpact(randomIntBetween(5, 20), randomAlphaOfLength(20),
-                List.of(randomFrom(ImpactArea.values()))));
+            impacts.add(
+                new HealthIndicatorImpact(randomIntBetween(5, 20), randomAlphaOfLength(20), List.of(randomFrom(ImpactArea.values())))
+            );
         }
         HealthIndicatorImpact impact1 = new HealthIndicatorImpact(1, randomAlphaOfLength(20), List.of(randomFrom(ImpactArea.values())));
         HealthIndicatorImpact impact2 = new HealthIndicatorImpact(2, randomAlphaOfLength(20), List.of(randomFrom(ImpactArea.values())));
@@ -32,8 +33,9 @@ public class HealthIndicatorServiceTests extends ESTestCase {
         impacts.add(impact1);
         impacts.add(impact3);
         for (int i = 0; i < 10; i++) {
-            impacts.add(new HealthIndicatorImpact(randomIntBetween(5, 20), randomAlphaOfLength(20),
-                List.of(randomFrom(ImpactArea.values()))));
+            impacts.add(
+                new HealthIndicatorImpact(randomIntBetween(5, 20), randomAlphaOfLength(20), List.of(randomFrom(ImpactArea.values())))
+            );
         }
         HealthIndicatorResult result = service.createIndicator(status, randomAlphaOfLength(20), HealthIndicatorDetails.EMPTY, impacts);
         List<HealthIndicatorImpact> outputImpacts = result.impacts();


### PR DESCRIPTION
This adds an `impact_areas` section to the impacts returned by the
health API.

eg. the `shards_availability` indicator might be returning:
```
"impacts": [
  {
    "severity": 1,
    "description":"Cannot add data to 1 index [red-index]. Searches might return incomplete results.",
    "impact_areas": [
      "ingest","search"
    ]
  },
  {
    "severity": 2,
    "description": "Searches might return slower than usual. Fewer redundant copies of the data exist on 2 indices [.ds-logslogslogs-2022.04.12-000001, my-index-000001].",
    "impact_areas": [
      "search"
    ]
  }
]
```

Resolves #85829 