### PR TITLE
[8.0] Expose proxy settings for GCS repositories (#85785)

### DIFF
--- a/docs/changelog/85785.yaml
+++ b/docs/changelog/85785.yaml
@@ -1,0 +1,6 @@
+pr: 85785
+summary: Expose proxy settings for GCS repositories
+area: Snapshot/Restore
+type: bug
+issues:
+ - 84569

--- a/modules/repository-gcs/src/main/java/org/elasticsearch/repositories/gcs/GoogleCloudStoragePlugin.java
+++ b/modules/repository-gcs/src/main/java/org/elasticsearch/repositories/gcs/GoogleCloudStoragePlugin.java
@@ -71,7 +71,10 @@ public class GoogleCloudStoragePlugin extends Plugin implements RepositoryPlugin
             GoogleCloudStorageClientSettings.CONNECT_TIMEOUT_SETTING,
             GoogleCloudStorageClientSettings.READ_TIMEOUT_SETTING,
             GoogleCloudStorageClientSettings.APPLICATION_NAME_SETTING,
-            GoogleCloudStorageClientSettings.TOKEN_URI_SETTING
+            GoogleCloudStorageClientSettings.TOKEN_URI_SETTING,
+            GoogleCloudStorageClientSettings.PROXY_TYPE_SETTING,
+            GoogleCloudStorageClientSettings.PROXY_HOST_SETTING,
+            GoogleCloudStorageClientSettings.PROXY_PORT_SETTING
         );
     }
 

--- a/modules/repository-gcs/src/test/java/org/elasticsearch/repositories/gcs/GoogleCloudStoragePluginTests.java
+++ b/modules/repository-gcs/src/test/java/org/elasticsearch/repositories/gcs/GoogleCloudStoragePluginTests.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.repositories.gcs;
+
+import org.elasticsearch.common.settings.Setting;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.test.ESTestCase;
+import org.junit.Assert;
+
+import java.util.List;
+
+public class GoogleCloudStoragePluginTests extends ESTestCase {
+
+    public void testExposedSettings() {
+        List<Setting<?>> settings = new GoogleCloudStoragePlugin(Settings.EMPTY).getSettings();
+
+        Assert.assertEquals(
+            List.of(
+                "gcs.client.*.credentials_file",
+                "gcs.client.*.endpoint",
+                "gcs.client.*.project_id",
+                "gcs.client.*.connect_timeout",
+                "gcs.client.*.read_timeout",
+                "gcs.client.*.application_name",
+                "gcs.client.*.token_uri",
+                "gcs.client.*.proxy.type",
+                "gcs.client.*.proxy.host",
+                "gcs.client.*.proxy.port"
+            ),
+            settings.stream().map(Setting::getKey).toList()
+        );
+    }
+}


### PR DESCRIPTION
Backports the following commits to 8.0:
 - Expose proxy settings for GCS repositories (#85785)