### PR TITLE
Use urgent priority for node shutdown cluster state update

### DIFF
--- a/x-pack/plugin/shutdown/src/main/java/org/elasticsearch/xpack/shutdown/TransportDeleteShutdownNodeAction.java
+++ b/x-pack/plugin/shutdown/src/main/java/org/elasticsearch/xpack/shutdown/TransportDeleteShutdownNodeAction.java
@@ -93,7 +93,7 @@ public class TransportDeleteShutdownNodeAction extends AcknowledgedTransportMast
             @Override
             public void clusterStateProcessed(ClusterState oldState, ClusterState newState) {
                 clusterService.getRerouteService()
-                    .reroute("node registered for removal from cluster", Priority.NORMAL, new ActionListener<ClusterState>() {
+                    .reroute("node registered for removal from cluster", Priority.URGENT, new ActionListener<ClusterState>() {
                         @Override
                         public void onResponse(ClusterState clusterState) {
                             logger.trace("started reroute after deleting node [{}}] shutdown", request.getNodeId());

--- a/x-pack/plugin/shutdown/src/main/java/org/elasticsearch/xpack/shutdown/TransportPutShutdownNodeAction.java
+++ b/x-pack/plugin/shutdown/src/main/java/org/elasticsearch/xpack/shutdown/TransportPutShutdownNodeAction.java
@@ -105,7 +105,7 @@ public class TransportPutShutdownNodeAction extends AcknowledgedTransportMasterN
                 if (SingleNodeShutdownMetadata.Type.REMOVE.equals(request.getType())
                     || SingleNodeShutdownMetadata.Type.REPLACE.equals(request.getType())) {
                     clusterService.getRerouteService()
-                        .reroute("node registered for removal from cluster", Priority.NORMAL, new ActionListener<ClusterState>() {
+                        .reroute("node registered for removal from cluster", Priority.URGENT, new ActionListener<ClusterState>() {
                             @Override
                             public void onResponse(ClusterState clusterState) {
                                 logger.trace("started reroute after registering node [{}] for removal", request.getNodeId());


### PR DESCRIPTION
Node shutdown requests submit a cluster state update to initiate the
shutdown. Since the cluster may be overloaded, this update could take a
long time to be processed. This commit changes the priority to urgent,
so that shutdown requests can be processed as quickly as possible.

relates #84847