### PR TITLE
Remove hppc from tcp transport

### DIFF
--- a/server/src/main/java/org/elasticsearch/transport/TcpTransport.java
+++ b/server/src/main/java/org/elasticsearch/transport/TcpTransport.java
@@ -7,9 +7,6 @@
  */
 package org.elasticsearch.transport;
 
-import com.carrotsearch.hppc.IntHashSet;
-import com.carrotsearch.hppc.IntSet;
-
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -545,12 +542,12 @@ public abstract class TcpTransport extends AbstractLifecycleComponent implements
 
         // if no matching boundAddress found, check if there is a unique port for all bound addresses
         if (publishPort < 0) {
-            final IntSet ports = new IntHashSet();
+            final Set<Integer> ports = new HashSet<>();
             for (InetSocketAddress boundAddress : boundAddresses) {
                 ports.add(boundAddress.getPort());
             }
             if (ports.size() == 1) {
-                publishPort = ports.iterator().next().value;
+                publishPort = ports.iterator().next();
             }
         }
 


### PR DESCRIPTION
The TcpTransport uses an hppc int set when falling back to
determine if there is a unique port bound. Since the expectation is this
is a single value, the map should be very small. This commit switches to
using a HashSet.

relates #84735