### PR TITLE
Wildcard support in Logstash pipelines search API.

### DIFF
--- a/x-pack/plugin/logstash/src/main/java/org/elasticsearch/xpack/logstash/action/TransportGetPipelineAction.java
+++ b/x-pack/plugin/logstash/src/main/java/org/elasticsearch/xpack/logstash/action/TransportGetPipelineAction.java
@@ -35,7 +35,10 @@ import org.elasticsearch.xpack.logstash.Logstash;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.function.Consumer;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 import static org.elasticsearch.xpack.core.ClientHelper.LOGSTASH_MANAGEMENT_ORIGIN;
@@ -43,6 +46,13 @@ import static org.elasticsearch.xpack.core.ClientHelper.LOGSTASH_MANAGEMENT_ORIG
 public class TransportGetPipelineAction extends HandledTransportAction<GetPipelineRequest, GetPipelineResponse> {
 
     private static final Logger logger = LogManager.getLogger(TransportGetPipelineAction.class);
+
+    private static final Integer SIZE = 10000;
+
+    private static final String WILDCARD = "*";
+
+    private static final Pattern WILDCARD_PATTERN = Pattern.compile("[^*]+|(\\*)");
+
     private final Client client;
 
     @Inject
@@ -53,7 +63,74 @@ public class TransportGetPipelineAction extends HandledTransportAction<GetPipeli
 
     @Override
     protected void doExecute(Task task, GetPipelineRequest request, ActionListener<GetPipelineResponse> listener) {
-        if (request.ids().isEmpty()) {
+        final Set<String> explicitPipelineIds = request.ids()
+            .stream()
+            .filter(pipeline -> pipeline.contains(WILDCARD) == false)
+            .collect(Collectors.toSet());
+
+        final Set<String> wildcardPipelineIdPatterns = request.ids()
+            .stream()
+            .filter(pipeline -> pipeline.contains(WILDCARD))
+            .map(this::toWildcardPipelineIdPattern)
+            .collect(Collectors.toSet());
+
+        if (explicitPipelineIds.size() > 0 && wildcardPipelineIdPatterns.size() == 0) {
+            getPipelinesByIds(explicitPipelineIds, listener);
+            return;
+        }
+
+        client.prepareSearch(Logstash.LOGSTASH_CONCRETE_INDEX_NAME)
+            .setSource(
+                SearchSourceBuilder.searchSource().fetchSource(true).query(QueryBuilders.matchAllQuery()).size(SIZE).trackTotalHits(true)
+            )
+            .setScroll(TimeValue.timeValueMinutes(1L))
+            .execute(ActionListener.wrap(searchResponse -> {
+                final int numHits = Math.toIntExact(searchResponse.getHits().getTotalHits().value);
+                final Map<String, BytesReference> pipelineSources = Maps.newMapWithExpectedSize(numHits);
+                final Consumer<SearchResponse> clearScroll = (response) -> {
+                    if (response != null && response.getScrollId() != null) {
+                        ClearScrollRequest clearScrollRequest = new ClearScrollRequest();
+                        clearScrollRequest.addScrollId(response.getScrollId());
+                        client.clearScroll(
+                            clearScrollRequest,
+                            ActionListener.wrap(
+                                (r) -> {},
+                                e -> logger.warn(
+                                    new ParameterizedMessage("clear scroll failed for scroll id [{}]", response.getScrollId()),
+                                    e
+                                )
+                            )
+                        );
+                    }
+                };
+                final int maxNumHitsToFetch = 0;
+                handleFilteringSearchResponse(
+                    searchResponse,
+                    pipelineSources,
+                    explicitPipelineIds,
+                    wildcardPipelineIdPatterns,
+                    maxNumHitsToFetch,
+                    clearScroll,
+                    listener
+                );
+            }, e -> handleFailure(e, listener)));
+    }
+
+    private void getPipelinesByIds(Set<String> ids, ActionListener<GetPipelineResponse> listener) {
+        client.prepareMultiGet()
+            .addIds(Logstash.LOGSTASH_CONCRETE_INDEX_NAME, ids)
+            .execute(ActionListener.wrap(mGetResponse -> {
+                logFailures(mGetResponse);
+                listener.onResponse(
+                    new GetPipelineResponse(
+                        Arrays.stream(mGetResponse.getResponses())
+                            .filter(itemResponse -> itemResponse.isFailed() == false)
+                            .filter(itemResponse -> itemResponse.getResponse().isExists())
+                            .map(MultiGetItemResponse::getResponse)
+                            .collect(Collectors.toMap(GetResponse::getId, GetResponse::getSourceAsBytesRef))
+                    ));
+            }, e -> handleFailure(e, listener)));
+        /*if (request.ids().isEmpty()) {
             client.prepareSearch(Logstash.LOGSTASH_CONCRETE_INDEX_NAME)
                 .setSource(
                     SearchSourceBuilder.searchSource()
@@ -106,7 +183,7 @@ public class TransportGetPipelineAction extends HandledTransportAction<GetPipeli
                         )
                     );
                 }, e -> handleFailure(e, listener)));
-        }
+        }*/
     }
 
     private void handleFailure(Exception e, ActionListener<GetPipelineResponse> listener) {
@@ -118,37 +195,66 @@ public class TransportGetPipelineAction extends HandledTransportAction<GetPipeli
         }
     }
 
-    private void handleSearchResponse(
+    private void handleFilteringSearchResponse(
         SearchResponse searchResponse,
         Map<String, BytesReference> pipelineSources,
+        Set<String> explicitPipelineIds,
+        Set<String> wildcardPipelineIdPatterns,
+        int maxNumHitsToFetch,
         Consumer<SearchResponse> clearScroll,
         ActionListener<GetPipelineResponse> listener
     ) {
+        maxNumHitsToFetch += searchResponse.getHits().getHits().length;
         for (SearchHit hit : searchResponse.getHits().getHits()) {
-            pipelineSources.put(hit.getId(), hit.getSourceRef());
+            if (explicitPipelineIds.isEmpty() && wildcardPipelineIdPatterns.isEmpty()) {
+                pipelineSources.put(hit.getId(), hit.getSourceRef());
+                continue;
+            }
+
+            // take if ID is in request IDs set
+            if (explicitPipelineIds.contains(hit.getId())) {
+                pipelineSources.put(hit.getId(), hit.getSourceRef());
+                continue;
+            }
+            // take if id matches request wildcard pattern
+            for (String wildcardPipelineIdPattern : wildcardPipelineIdPatterns) {
+                if (Pattern.matches(wildcardPipelineIdPattern, hit.getId())) {
+                    pipelineSources.put(hit.getId(), hit.getSourceRef());
+                    break;
+                }
+            }
         }
 
-        if (pipelineSources.size() > searchResponse.getHits().getTotalHits().value) {
+        if (maxNumHitsToFetch > searchResponse.getHits().getTotalHits().value) {
             clearScroll.accept(searchResponse);
             listener.onFailure(
                 new IllegalStateException(
                     "scrolling returned more hits ["
-                        + pipelineSources.size()
+                        + maxNumHitsToFetch
                         + "] than expected ["
                         + searchResponse.getHits().getTotalHits().value
                         + "] so bailing out to prevent unbounded "
                         + "memory consumption."
                 )
             );
-        } else if (pipelineSources.size() == searchResponse.getHits().getTotalHits().value) {
+        } else if (maxNumHitsToFetch == searchResponse.getHits().getTotalHits().value) {
             clearScroll.accept(searchResponse);
             listener.onResponse(new GetPipelineResponse(pipelineSources));
         } else {
+            int finalNumHitsToFetch = maxNumHitsToFetch;
             client.prepareSearchScroll(searchResponse.getScrollId())
                 .setScroll(TimeValue.timeValueMinutes(1L))
                 .execute(
                     ActionListener.wrap(
-                        searchResponse1 -> handleSearchResponse(searchResponse1, pipelineSources, clearScroll, listener),
+                        searchResponse1 -> handleFilteringSearchResponse(
+                            searchResponse1,
+                            pipelineSources,
+                            explicitPipelineIds,
+                            wildcardPipelineIdPatterns,
+                            finalNumHitsToFetch,
+                            clearScroll,
+                            listener
+                        ),
                         listener::onFailure
                     )
                 );
@@ -164,5 +270,19 @@ public class TransportGetPipelineAction extends HandledTransportAction<GetPipeli
         if (ids.isEmpty() == false) {
             logger.info("Could not retrieve logstash pipelines with ids: {}", ids);
         }
+    }
+
+    private String toWildcardPipelineIdPattern(String wildcardPipelineId) {
+        Matcher matcher = WILDCARD_PATTERN.matcher(wildcardPipelineId);
+        StringBuilder stringBuilder = new StringBuilder();
+        while (matcher.find()) {
+            if (matcher.group(1) != null) {
+                matcher.appendReplacement(stringBuilder, ".*");
+            } else {
+                matcher.appendReplacement(stringBuilder, "\\\\Q" + matcher.group(0) + "\\\\E");
+            }
+        }
+        matcher.appendTail(stringBuilder);
+        return stringBuilder.toString();
     }
 }

--- a/x-pack/plugin/logstash/src/main/java/org/elasticsearch/xpack/logstash/action/TransportGetPipelineAction.java
+++ b/x-pack/plugin/logstash/src/main/java/org/elasticsearch/xpack/logstash/action/TransportGetPipelineAction.java
@@ -114,19 +114,18 @@ public class TransportGetPipelineAction extends HandledTransportAction<GetPipeli
     }
 
     private void getPipelinesByIds(Set<String> ids, ActionListener<GetPipelineResponse> listener) {
-        client.prepareMultiGet()
-            .addIds(Logstash.LOGSTASH_CONCRETE_INDEX_NAME, ids)
-            .execute(ActionListener.wrap(mGetResponse -> {
-                logFailures(mGetResponse);
-                listener.onResponse(
-                    new GetPipelineResponse(
-                        Arrays.stream(mGetResponse.getResponses())
-                            .filter(itemResponse -> itemResponse.isFailed() == false)
-                            .filter(itemResponse -> itemResponse.getResponse().isExists())
-                            .map(MultiGetItemResponse::getResponse)
-                            .collect(Collectors.toMap(GetResponse::getId, GetResponse::getSourceAsBytesRef))
-                    ));
-            }, e -> handleFailure(e, listener)));
+        client.prepareMultiGet().addIds(Logstash.LOGSTASH_CONCRETE_INDEX_NAME, ids).execute(ActionListener.wrap(mGetResponse -> {
+            logFailures(mGetResponse);
+            listener.onResponse(
+                new GetPipelineResponse(
+                    Arrays.stream(mGetResponse.getResponses())
+                        .filter(itemResponse -> itemResponse.isFailed() == false)
+                        .filter(itemResponse -> itemResponse.getResponse().isExists())
+                        .map(MultiGetItemResponse::getResponse)
+                        .collect(Collectors.toMap(GetResponse::getId, GetResponse::getSourceAsBytesRef))
+                )
+            );
+        }, e -> handleFailure(e, listener)));
     }
 
     private void handleFailure(Exception e, ActionListener<GetPipelineResponse> listener) {

--- a/x-pack/plugin/logstash/src/main/java/org/elasticsearch/xpack/logstash/action/TransportGetPipelineAction.java
+++ b/x-pack/plugin/logstash/src/main/java/org/elasticsearch/xpack/logstash/action/TransportGetPipelineAction.java
@@ -96,10 +96,7 @@ public class TransportGetPipelineAction extends HandledTransportAction<GetPipeli
                             clearScrollRequest,
                             ActionListener.wrap(
                                 (r) -> {},
-                                e -> logger.warn(
-                                    new ParameterizedMessage("clear scroll failed for scroll id [{}]", response.getScrollId()),
-                                    e
-                                )
+                                e -> logger.warn(() -> "clear scroll failed for scroll id [" + response.getScrollId() + "]", e)
                             )
                         );
                     }
@@ -130,60 +127,6 @@ public class TransportGetPipelineAction extends HandledTransportAction<GetPipeli
                             .collect(Collectors.toMap(GetResponse::getId, GetResponse::getSourceAsBytesRef))
                     ));
             }, e -> handleFailure(e, listener)));
-        /*if (request.ids().isEmpty()) {
-            client.prepareSearch(Logstash.LOGSTASH_CONCRETE_INDEX_NAME)
-                .setSource(
-                    SearchSourceBuilder.searchSource()
-                        .fetchSource(true)
-                        .query(QueryBuilders.matchAllQuery())
-                        .size(1000)
-                        .trackTotalHits(true)
-                )
-                .setScroll(TimeValue.timeValueMinutes(1L))
-                .execute(ActionListener.wrap(searchResponse -> {
-                    final int numHits = Math.toIntExact(searchResponse.getHits().getTotalHits().value);
-                    final Map<String, BytesReference> pipelineSources = Maps.newMapWithExpectedSize(numHits);
-                    final Consumer<SearchResponse> clearScroll = (response) -> {
-                        if (response != null && response.getScrollId() != null) {
-                            ClearScrollRequest clearScrollRequest = new ClearScrollRequest();
-                            clearScrollRequest.addScrollId(response.getScrollId());
-                            client.clearScroll(
-                                clearScrollRequest,
-                                ActionListener.wrap(
-                                    (r) -> {},
-                                    e -> logger.warn(() -> "clear scroll failed for scroll id [" + response.getScrollId() + "]", e)
-                                )
-                            );
-                        }
-                    };
-                    handleSearchResponse(searchResponse, pipelineSources, clearScroll, listener);
-                }, e -> handleFailure(e, listener)));
-        } else if (request.ids().size() == 1) {
-            client.prepareGet(Logstash.LOGSTASH_CONCRETE_INDEX_NAME, request.ids().get(0))
-                .setFetchSource(true)
-                .execute(ActionListener.wrap(response -> {
-                    if (response.isExists()) {
-                        listener.onResponse(new GetPipelineResponse(Map.of(response.getId(), response.getSourceAsBytesRef())));
-                    } else {
-                        listener.onResponse(new GetPipelineResponse(Map.of()));
-                    }
-                }, e -> handleFailure(e, listener)));
-        } else {
-            client.prepareMultiGet()
-                .addIds(Logstash.LOGSTASH_CONCRETE_INDEX_NAME, request.ids())
-                .execute(ActionListener.wrap(mGetResponse -> {
-                    logFailures(mGetResponse);
-                    listener.onResponse(
-                        new GetPipelineResponse(
-                            Arrays.stream(mGetResponse.getResponses())
-                                .filter(itemResponse -> itemResponse.isFailed() == false)
-                                .filter(itemResponse -> itemResponse.getResponse().isExists())
-                                .map(MultiGetItemResponse::getResponse)
-                                .collect(Collectors.toMap(GetResponse::getId, GetResponse::getSourceAsBytesRef))
-                        )
-                    );
-                }, e -> handleFailure(e, listener)));
-        }*/
     }
 
     private void handleFailure(Exception e, ActionListener<GetPipelineResponse> listener) {

--- a/x-pack/plugin/logstash/src/test/java/org/elasticsearch/xpack/logstash/action/TransportGetPipelineActionTests.java
+++ b/x-pack/plugin/logstash/src/test/java/org/elasticsearch/xpack/logstash/action/TransportGetPipelineActionTests.java
@@ -7,8 +7,6 @@
 
 package org.elasticsearch.xpack.logstash.action;
 
-import com.carrotsearch.randomizedtesting.annotations.ThreadLeakScope;
-
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -49,7 +47,6 @@ import static org.hamcrest.Matchers.notNullValue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-@ThreadLeakScope(ThreadLeakScope.Scope.NONE)
 public class TransportGetPipelineActionTests extends ESTestCase {
 
     /**

--- a/x-pack/plugin/logstash/src/test/java/org/elasticsearch/xpack/logstash/action/TransportGetPipelineActionTests.java
+++ b/x-pack/plugin/logstash/src/test/java/org/elasticsearch/xpack/logstash/action/TransportGetPipelineActionTests.java
@@ -155,11 +155,13 @@ public class TransportGetPipelineActionTests extends ESTestCase {
             }
         };
 
-        new TransportGetPipelineAction(mock(TransportService.class), mock(ActionFilters.class), getMockClient(searchResponse)).doExecute(
-            null,
-            request,
-            testActionListener
-        );
+        try (Client client = getMockClient(searchResponse)) {
+            new TransportGetPipelineAction(mock(TransportService.class), mock(ActionFilters.class), client)
+                .doExecute(
+                    null,
+                    request,
+                    testActionListener);
+        }
 
         assertNull(failure.get());
     }

--- a/x-pack/plugin/logstash/src/test/java/org/elasticsearch/xpack/logstash/action/TransportGetPipelineActionTests.java
+++ b/x-pack/plugin/logstash/src/test/java/org/elasticsearch/xpack/logstash/action/TransportGetPipelineActionTests.java
@@ -7,9 +7,12 @@
 
 package org.elasticsearch.xpack.logstash.action;
 
+import com.carrotsearch.randomizedtesting.annotations.ThreadLeakScope;
+
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.apache.lucene.search.TotalHits;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionResponse;
@@ -17,12 +20,19 @@ import org.elasticsearch.action.ActionType;
 import org.elasticsearch.action.get.GetResponse;
 import org.elasticsearch.action.get.MultiGetItemResponse;
 import org.elasticsearch.action.get.MultiGetResponse;
+import org.elasticsearch.action.search.SearchResponse;
+import org.elasticsearch.action.search.ShardSearchFailure;
 import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.PlainActionFuture;
 import org.elasticsearch.client.internal.Client;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.logging.Loggers;
 import org.elasticsearch.index.IndexNotFoundException;
+import org.elasticsearch.index.shard.ShardId;
+import org.elasticsearch.search.SearchHit;
+import org.elasticsearch.search.SearchHits;
+import org.elasticsearch.search.SearchShardTarget;
+import org.elasticsearch.search.internal.InternalSearchResponse;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.MockLogAppender;
 import org.elasticsearch.test.client.NoOpClient;
@@ -30,6 +40,7 @@ import org.elasticsearch.transport.RemoteTransportException;
 import org.elasticsearch.transport.TransportService;
 
 import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
 
 import static org.hamcrest.Matchers.anEmptyMap;
 import static org.hamcrest.Matchers.equalTo;
@@ -38,6 +49,7 @@ import static org.hamcrest.Matchers.notNullValue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+@ThreadLeakScope(ThreadLeakScope.Scope.NONE)
 public class TransportGetPipelineActionTests extends ESTestCase {
 
     /**
@@ -103,6 +115,55 @@ public class TransportGetPipelineActionTests extends ESTestCase {
         }
     }
 
+    /**
+     * Test that the explicit and wildcard IDs are requested.
+     */
+    public void testGetPipelinesByExplicitAndWildcardIds() {
+        InternalSearchResponse internalSearchResponse = new InternalSearchResponse(prepareSearchHits(), null, null, null, false, null, 1);
+        SearchResponse searchResponse = new SearchResponse(
+            internalSearchResponse,
+            null,
+            1,
+            1,
+            0,
+            100,
+            ShardSearchFailure.EMPTY_ARRAY,
+            SearchResponse.Clusters.EMPTY,
+            null
+        );
+
+        SearchResponse mockResponse = mock(SearchResponse.class);
+        when(mockResponse.getHits()).thenReturn(prepareSearchHits());
+
+        GetPipelineRequest request = new GetPipelineRequest(List.of("1", "2", "3*"));
+        AtomicReference<Exception> failure = new AtomicReference<>();
+
+        // Set up an ActionListener for the actual test conditions
+        ActionListener<GetPipelineResponse> testActionListener = new ActionListener<>() {
+            @Override
+            public void onResponse(GetPipelineResponse getPipelineResponse) {
+                assertThat(getPipelineResponse, is(notNullValue()));
+                assertThat(getPipelineResponse.pipelines().size(), equalTo(3));
+                assertTrue(getPipelineResponse.pipelines().containsKey("1"));
+                assertTrue(getPipelineResponse.pipelines().containsKey("2"));
+                assertTrue(getPipelineResponse.pipelines().containsKey("3*"));
+            }
+
+            @Override
+            public void onFailure(Exception e) {
+                failure.set(e);
+            }
+        };
+
+        new TransportGetPipelineAction(mock(TransportService.class), mock(ActionFilters.class), getMockClient(searchResponse)).doExecute(
+            null,
+            request,
+            testActionListener
+        );
+
+        assertNull(failure.get());
+    }
+
     public void testMissingIndexHandling() throws Exception {
         try (Client failureClient = getFailureClient(new IndexNotFoundException("foo"))) {
             final TransportGetPipelineAction action = new TransportGetPipelineAction(
@@ -147,5 +208,21 @@ public class TransportGetPipelineActionTests extends ESTestCase {
                 }
             }
         };
+    }
+
+    private SearchHits prepareSearchHits() {
+        SearchHit hit1 = new SearchHit(0, "1", null, null);
+        hit1.score(1f);
+        hit1.shard(new SearchShardTarget("a", new ShardId("a", "indexUUID", 0), null));
+
+        SearchHit hit2 = new SearchHit(0, "2", null, null);
+        hit2.score(1f);
+        hit2.shard(new SearchShardTarget("a", new ShardId("a", "indexUUID", 0), null));
+
+        SearchHit hit3 = new SearchHit(0, "3*", null, null);
+        hit3.score(1f);
+        hit3.shard(new SearchShardTarget("a", new ShardId("a", "indexUUID", 0), null));
+
+        return new SearchHits(new SearchHit[] { hit1, hit2, hit3 }, new TotalHits(3L, TotalHits.Relation.EQUAL_TO), 1f);
     }
 }

--- a/x-pack/plugin/logstash/src/test/java/org/elasticsearch/xpack/logstash/action/TransportGetPipelineActionTests.java
+++ b/x-pack/plugin/logstash/src/test/java/org/elasticsearch/xpack/logstash/action/TransportGetPipelineActionTests.java
@@ -153,11 +153,11 @@ public class TransportGetPipelineActionTests extends ESTestCase {
         };
 
         try (Client client = getMockClient(searchResponse)) {
-            new TransportGetPipelineAction(mock(TransportService.class), mock(ActionFilters.class), client)
-                .doExecute(
-                    null,
-                    request,
-                    testActionListener);
+            new TransportGetPipelineAction(mock(TransportService.class), mock(ActionFilters.class), client).doExecute(
+                null,
+                request,
+                testActionListener
+            );
         }
 
         assertNull(failure.get());


### PR DESCRIPTION
## What is happening?
`_logstash/pipeline?id={}` API does not support searching pipelines by `wildcard IDs`.

**Why it is important?**
Currently, every Logstash instance fetches all pipelines (from `.logstash` index) every 5s (configurable) and filters locally based on Logstash instance pipeline settings. Pipeline config may include wildcard IDs. After this change, every Logstash instance should consider ROI pipelines config. That's said, LS instance sends its pipeline IDs to Elasticsearch and gets the pipeline configs only belong to itself. This dramatically decreases network load as well as gives an opportunity to control pipelines in dynamic way with wildcards.

### Issue
Closes #84772

## Does Kibana get affected by this change?
- **NO**: we are not changing API interface, extending its behavior.

## Documentation
- No change required in [Elasticsearch (Kibana CPM) ](https://www.elastic.co/guide/en/kibana/8.2/logstash-configuration-management-api.html)side since no feature affected in Kibana.
- Logstash team documents when client side behavior/code changes (after merging this PR).

## Acceptance Criteria
API should support wildcard IDs and return pipeline configs based on requested IDs (explicit and wildcard).

## Solution
We had two solution approaches:
- fetching all docs from `.logstash` index and filter based on requested ID.
- support wildcard ES query
Why we choose #option 1? - Based on team's decision ([RFC](https://docs.google.com/document/d/1NtTB0L9oBno4yEjpr8PkliFSMV8JXa5silyBizFZxJw)), customers are less affected.

### Tests
#### Prerequisites
- Make sure you cloned the Elasticsearch repo
- Make sure you installed Kibana on your local machine
- Make sure you cloned the Logstash repo (required LS to ES communication)
- Make sure python is installed on your local machine
- Run Elasticsearch with `./gradlew :run`
- Go to Postman and send a request to generate Kibana token, add user name & password to Basic auth header.
`POST: localhost:9200/_security/service/elastic/kibana/credential/token/kibanaToken`
- Set received Kibana token to kibana.yml under the Kibana config folder
- Run the Kibana and go to the Stack Management -> Users page. Note that default authentication will be uid: elastic, pwd: password when accessing the Kibana.
- Create a user named logstash with logstash-admin & logstash-system roles. They will be required to directly access the .logstash index.
- Run the [python script](https://gist.github.com/mashhurs/79441a7380ae18c32931dc544ec549ab) to generate bunch of pipelines

#### Test
- Now you can go to Postman and do wildcard pipelines search, eg.:
`GET http://localhost:9200/_logstash/pipeline?id=ry*,rob*,ki*chy*`