### PR TITLE
Reduce cli tests calling main directly

### DIFF
--- a/distribution/tools/geoip-cli/src/test/java/org/elasticsearch/geoip/GeoIpCliTests.java
+++ b/distribution/tools/geoip-cli/src/test/java/org/elasticsearch/geoip/GeoIpCliTests.java
@@ -8,10 +8,14 @@
 
 package org.elasticsearch.geoip;
 
+import joptsimple.OptionException;
+
 import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
 import org.apache.commons.compress.archivers.tar.TarArchiveInputStream;
 import org.apache.lucene.tests.util.LuceneTestCase;
-import org.elasticsearch.cli.MockTerminal;
+import org.elasticsearch.cli.Command;
+import org.elasticsearch.cli.CommandTestCase;
+import org.elasticsearch.cli.UserException;
 import org.elasticsearch.xcontent.XContentParser;
 import org.elasticsearch.xcontent.XContentParserConfiguration;
 import org.elasticsearch.xcontent.XContentType;
@@ -34,7 +38,7 @@ import static org.hamcrest.Matchers.hasEntry;
 import static org.hamcrest.Matchers.hasKey;
 
 @LuceneTestCase.SuppressFileSystems(value = "ExtrasFS") // Don't randomly add 'extra' files to directory.
-public class GeoIpCliTests extends LuceneTestCase {
+public class GeoIpCliTests extends CommandTestCase {
 
     private Path source;
     private Path target;
@@ -46,16 +50,14 @@ public class GeoIpCliTests extends LuceneTestCase {
     }
 
     public void testNoSource() throws Exception {
-        MockTerminal terminal = new MockTerminal();
-        new GeoIpCli().main(new String[] {}, terminal);
-        assertThat(terminal.getErrorOutput(), containsString("Missing required option(s) [s/source]"));
+        var e = expectThrows(OptionException.class, () -> execute());
+        assertThat(e.getMessage(), containsString("Missing required option(s) [s/source]"));
     }
 
     public void testDifferentDirectories() throws Exception {
         Map<String, byte[]> data = createTestFiles(source);
 
-        GeoIpCli cli = new GeoIpCli();
-        cli.main(new String[] { "-t", target.toAbsolutePath().toString(), "-s", source.toAbsolutePath().toString() }, new MockTerminal());
+        execute("-t", target.toAbsolutePath().toString(), "-s", source.toAbsolutePath().toString());
 
         try (Stream<Path> list = Files.list(source)) {
             List<String> files = list.map(p -> p.getFileName().toString()).collect(Collectors.toList());
@@ -73,9 +75,7 @@ public class GeoIpCliTests extends LuceneTestCase {
 
     public void testSameDirectory() throws Exception {
         Map<String, byte[]> data = createTestFiles(target);
-
-        GeoIpCli cli = new GeoIpCli();
-        cli.main(new String[] { "-s", target.toAbsolutePath().toString() }, new MockTerminal());
+        execute("-s", target.toAbsolutePath().toString());
 
         try (Stream<Path> list = Files.list(target)) {
             List<String> files = list.map(p -> p.getFileName().toString()).collect(Collectors.toList());
@@ -142,5 +142,10 @@ public class GeoIpCliTests extends LuceneTestCase {
         Files.createFile(dir.resolve("c.tgz"));
 
         return data;
+    }
+
+    @Override
+    protected Command newCommand() {
+        return new GeoIpCli();
     }
 }

--- a/distribution/tools/geoip-cli/src/test/java/org/elasticsearch/geoip/GeoIpCliTests.java
+++ b/distribution/tools/geoip-cli/src/test/java/org/elasticsearch/geoip/GeoIpCliTests.java
@@ -15,7 +15,6 @@ import org.apache.commons.compress.archivers.tar.TarArchiveInputStream;
 import org.apache.lucene.tests.util.LuceneTestCase;
 import org.elasticsearch.cli.Command;
 import org.elasticsearch.cli.CommandTestCase;
-import org.elasticsearch.cli.UserException;
 import org.elasticsearch.xcontent.XContentParser;
 import org.elasticsearch.xcontent.XContentParserConfiguration;
 import org.elasticsearch.xcontent.XContentType;

--- a/distribution/tools/plugin-cli/src/test/java/org/elasticsearch/plugins/cli/ListPluginsCommandTests.java
+++ b/distribution/tools/plugin-cli/src/test/java/org/elasticsearch/plugins/cli/ListPluginsCommandTests.java
@@ -10,15 +10,13 @@ package org.elasticsearch.plugins.cli;
 
 import org.apache.lucene.tests.util.LuceneTestCase;
 import org.elasticsearch.Version;
-import org.elasticsearch.cli.ExitCodes;
-import org.elasticsearch.cli.MockTerminal;
-import org.elasticsearch.cli.UserException;
+import org.elasticsearch.cli.Command;
+import org.elasticsearch.cli.CommandTestCase;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.env.Environment;
 import org.elasticsearch.env.TestEnvironment;
 import org.elasticsearch.plugins.PluginInfo;
 import org.elasticsearch.plugins.PluginTestUtil;
-import org.elasticsearch.test.ESTestCase;
 import org.junit.Before;
 
 import java.io.IOException;
@@ -30,45 +28,17 @@ import java.util.Map;
 import java.util.stream.Collectors;
 
 @LuceneTestCase.SuppressFileSystems("*")
-public class ListPluginsCommandTests extends ESTestCase {
+public class ListPluginsCommandTests extends CommandTestCase {
 
     private Path home;
     private Environment env;
 
     @Before
-    public void setUp() throws Exception {
-        super.setUp();
+    public void initEnv() throws Exception {
         home = createTempDir();
         Files.createDirectories(home.resolve("plugins"));
         Settings settings = Settings.builder().put("path.home", home).build();
         env = TestEnvironment.newEnvironment(settings);
-    }
-
-    static MockTerminal listPlugins(Path home) throws Exception {
-        return listPlugins(home, new String[0]);
-    }
-
-    static MockTerminal listPlugins(Path home, String[] args) throws Exception {
-        String[] argsAndHome = new String[args.length + 1];
-        System.arraycopy(args, 0, argsAndHome, 0, args.length);
-        argsAndHome[args.length] = "-Epath.home=" + home;
-        MockTerminal terminal = new MockTerminal();
-        int status = new ListPluginsCommand() {
-            @Override
-            protected Environment createEnv(Map<String, String> settings) throws UserException {
-                Settings.Builder builder = Settings.builder().put("path.home", home);
-                settings.forEach((k, v) -> builder.put(k, v));
-                final Settings realSettings = builder.build();
-                return new Environment(realSettings, home.resolve("config"));
-            }
-
-            @Override
-            protected boolean addShutdownHook() {
-                return false;
-            }
-        }.main(argsAndHome, terminal);
-        assertEquals(ExitCodes.OK, status);
-        return terminal;
     }
 
     private static String buildMultiline(String... args) {
@@ -108,32 +78,31 @@ public class ListPluginsCommandTests extends ESTestCase {
 
     public void testPluginsDirMissing() throws Exception {
         Files.delete(env.pluginsFile());
-        IOException e = expectThrows(IOException.class, () -> listPlugins(home));
+        IOException e = expectThrows(IOException.class, () -> execute());
         assertEquals("Plugins directory missing: " + env.pluginsFile(), e.getMessage());
     }
 
     public void testNoPlugins() throws Exception {
-        MockTerminal terminal = listPlugins(home);
+        execute();
         assertTrue(terminal.getOutput(), terminal.getOutput().isEmpty());
     }
 
     public void testOnePlugin() throws Exception {
         buildFakePlugin(env, "fake desc", "fake", "org.fake");
-        MockTerminal terminal = listPlugins(home);
+        execute();
         assertEquals(buildMultiline("fake"), terminal.getOutput());
     }
 
     public void testTwoPlugins() throws Exception {
         buildFakePlugin(env, "fake desc", "fake1", "org.fake");
         buildFakePlugin(env, "fake desc 2", "fake2", "org.fake");
-        MockTerminal terminal = listPlugins(home);
+        execute();
         assertEquals(buildMultiline("fake1", "fake2"), terminal.getOutput());
     }
 
     public void testPluginWithVerbose() throws Exception {
         buildFakePlugin(env, "fake desc", "fake_plugin", "org.fake");
-        String[] params = { "-v" };
-        MockTerminal terminal = listPlugins(home, params);
+        execute("-v");
         assertEquals(
             buildMultiline(
                 "Plugins directory: " + env.pluginsFile(),
@@ -156,8 +125,7 @@ public class ListPluginsCommandTests extends ESTestCase {
 
     public void testPluginWithNativeController() throws Exception {
         buildFakePlugin(env, "fake desc 1", "fake_plugin1", "org.fake", true);
-        String[] params = { "-v" };
-        MockTerminal terminal = listPlugins(home, params);
+        execute("-v");
         assertEquals(
             buildMultiline(
                 "Plugins directory: " + env.pluginsFile(),
@@ -181,8 +149,7 @@ public class ListPluginsCommandTests extends ESTestCase {
     public void testPluginWithVerboseMultiplePlugins() throws Exception {
         buildFakePlugin(env, "fake desc 1", "fake_plugin1", "org.fake");
         buildFakePlugin(env, "fake desc 2", "fake_plugin2", "org.fake2");
-        String[] params = { "-v" };
-        MockTerminal terminal = listPlugins(home, params);
+        execute("-v");
         assertEquals(
             buildMultiline(
                 "Plugins directory: " + env.pluginsFile(),
@@ -218,22 +185,21 @@ public class ListPluginsCommandTests extends ESTestCase {
     public void testPluginWithoutVerboseMultiplePlugins() throws Exception {
         buildFakePlugin(env, "fake desc 1", "fake_plugin1", "org.fake");
         buildFakePlugin(env, "fake desc 2", "fake_plugin2", "org.fake2");
-        MockTerminal terminal = listPlugins(home, new String[0]);
-        String output = terminal.getOutput();
-        assertEquals(buildMultiline("fake_plugin1", "fake_plugin2"), output);
+        execute();
+        assertEquals(buildMultiline("fake_plugin1", "fake_plugin2"), terminal.getOutput());
     }
 
     public void testPluginWithoutDescriptorFile() throws Exception {
         final Path pluginDir = env.pluginsFile().resolve("fake1");
         Files.createDirectories(pluginDir);
-        NoSuchFileException e = expectThrows(NoSuchFileException.class, () -> listPlugins(home));
+        NoSuchFileException e = expectThrows(NoSuchFileException.class, () -> execute());
         assertEquals(pluginDir.resolve(PluginInfo.ES_PLUGIN_PROPERTIES).toString(), e.getFile());
     }
 
     public void testPluginWithWrongDescriptorFile() throws Exception {
         final Path pluginDir = env.pluginsFile().resolve("fake1");
         PluginTestUtil.writePluginProperties(pluginDir, "description", "fake desc");
-        IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> listPlugins(home));
+        IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> execute());
         final Path descriptorPath = pluginDir.resolve(PluginInfo.ES_PLUGIN_PROPERTIES);
         assertEquals("property [name] is missing in [" + descriptorPath.toString() + "]", e.getMessage());
     }
@@ -256,7 +222,7 @@ public class ListPluginsCommandTests extends ESTestCase {
         );
         buildFakePlugin(env, "fake desc 2", "fake_plugin2", "org.fake2");
 
-        MockTerminal terminal = listPlugins(home);
+        execute();
         String message = "plugin [fake_plugin1] was built for Elasticsearch version 1.0.0 but version " + Version.CURRENT + " is required";
         assertEquals("""
             fake_plugin1
@@ -264,11 +230,25 @@ public class ListPluginsCommandTests extends ESTestCase {
             """, terminal.getOutput());
         assertEquals("WARNING: " + message + "\n", terminal.getErrorOutput());
 
-        String[] params = { "-s" };
-        terminal = listPlugins(home, params);
+        terminal.reset();
+        execute("-s");
         assertEquals("""
             fake_plugin1
             fake_plugin2
             """, terminal.getOutput());
+    }
+
+    @Override
+    protected Command newCommand() {
+        return new ListPluginsCommand() {
+            @Override
+            protected Environment createEnv(Map<String, String> settings) {
+                return env;
+            }
+            @Override
+            protected boolean addShutdownHook() {
+                return false;
+            }
+        };
     }
 }

--- a/distribution/tools/plugin-cli/src/test/java/org/elasticsearch/plugins/cli/ListPluginsCommandTests.java
+++ b/distribution/tools/plugin-cli/src/test/java/org/elasticsearch/plugins/cli/ListPluginsCommandTests.java
@@ -245,6 +245,7 @@ public class ListPluginsCommandTests extends CommandTestCase {
             protected Environment createEnv(Map<String, String> settings) {
                 return env;
             }
+
             @Override
             protected boolean addShutdownHook() {
                 return false;

--- a/server/src/test/java/org/elasticsearch/cli/CommandTests.java
+++ b/server/src/test/java/org/elasticsearch/cli/CommandTests.java
@@ -8,59 +8,40 @@
 
 package org.elasticsearch.cli;
 
-import joptsimple.OptionException;
 import joptsimple.OptionSet;
 
-import org.elasticsearch.test.ESTestCase;
+import org.junit.Before;
 
-public class CommandTests extends ESTestCase {
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
 
-    static class UserErrorCommand extends Command {
+public class CommandTests extends CommandTestCase {
 
-        UserErrorCommand() {
-            super("Throws a user error", () -> {});
-        }
+    DummyCommand command;
 
-        @Override
-        protected void execute(Terminal terminal, OptionSet options) throws Exception {
-            throw new UserException(ExitCodes.DATA_ERROR, "Bad input");
-        }
-
-        @Override
-        protected boolean addShutdownHook() {
-            return false;
-        }
-
+    @Before
+    public void setupCommand() {
+        command = new DummyCommand();
     }
 
-    static class UsageErrorCommand extends Command {
-
-        UsageErrorCommand() {
-            super("Throws a usage error", () -> {});
-        }
-
-        @Override
-        protected void execute(Terminal terminal, OptionSet options) throws Exception {
-            throw new UserException(ExitCodes.USAGE, "something was no good");
-        }
-
-        @Override
-        protected boolean addShutdownHook() {
-            return false;
-        }
-
+    @Override
+    protected Command newCommand() {
+        return command;
     }
 
-    static class NoopCommand extends Command {
-
+    static class DummyCommand extends Command {
         boolean executed = false;
+        Exception exception = null;
 
-        NoopCommand() {
+        DummyCommand() {
             super("Does nothing", () -> {});
         }
 
         @Override
         protected void execute(Terminal terminal, OptionSet options) throws Exception {
+            if (exception != null) {
+                throw exception;
+            }
             terminal.println("Normal output");
             terminal.println(Terminal.Verbosity.SILENT, "Silent output");
             terminal.println(Terminal.Verbosity.VERBOSE, "Verbose output");
@@ -80,20 +61,17 @@ public class CommandTests extends ESTestCase {
     }
 
     public void testHelp() throws Exception {
-        NoopCommand command = new NoopCommand();
-        MockTerminal terminal = new MockTerminal();
-        String[] args = { "-h" };
-        int status = command.main(args, terminal);
+        int status = executeMain("-h");
         String output = terminal.getOutput();
         assertEquals(output, ExitCodes.OK, status);
         assertTrue(output, output.contains("Does nothing"));
         assertTrue(output, output.contains("Some extra help"));
         assertFalse(command.executed);
+    }
 
-        command = new NoopCommand();
-        String[] args2 = { "--help" };
-        status = command.main(args2, terminal);
-        output = terminal.getOutput();
+    public void testLongHelp() throws Exception {
+        int status = executeMain("--help");
+        String output = terminal.getOutput();
         assertEquals(output, ExitCodes.OK, status);
         assertTrue(output, output.contains("Does nothing"));
         assertTrue(output, output.contains("Some extra help"));
@@ -101,10 +79,7 @@ public class CommandTests extends ESTestCase {
     }
 
     public void testUnknownOptions() throws Exception {
-        NoopCommand command = new NoopCommand();
-        MockTerminal terminal = new MockTerminal();
-        String[] args = { "-Z" };
-        int status = command.main(args, terminal);
+        int status = executeMain("-Z");
         String output = terminal.getOutput();
         String error = terminal.getErrorOutput();
         assertEquals(output, ExitCodes.USAGE, status);
@@ -112,79 +87,56 @@ public class CommandTests extends ESTestCase {
         assertFalse(output, output.contains("Some extra help")); // extra help not printed for usage errors
         assertTrue(error, error.contains("ERROR: Z is not a recognized option"));
         assertFalse(command.executed);
+    }
 
-        command = new NoopCommand();
-        String[] args2 = { "--foobar" };
-        status = command.main(args2, terminal);
-        output = terminal.getOutput();
-        error = terminal.getErrorOutput();
+    public void testLongUnknownOption() throws Exception {
+        int status = executeMain("--foobar");
+        String output = terminal.getOutput();
+        String error = terminal.getErrorOutput();
         assertEquals(output, ExitCodes.USAGE, status);
         assertTrue(error, error.contains("Does nothing"));
         assertFalse(output, output.contains("Some extra help")); // extra help not printed for usage errors
-        assertTrue(error, error.contains("ERROR: Z is not a recognized option"));
+        assertThat(error, containsString("ERROR: foobar is not a recognized option"));
         assertFalse(command.executed);
     }
 
     public void testVerbositySilentAndVerbose() throws Exception {
-        MockTerminal terminal = new MockTerminal();
-        NoopCommand command = new NoopCommand();
-        String[] args = { "-v", "-s" };
-        OptionException e = expectThrows(OptionException.class, () -> { command.mainWithoutErrorHandling(args, terminal); });
-        assertTrue(
-            e.getMessage(),
-            e.getMessage().contains("Option(s) [v/verbose] are unavailable given other options on the command line")
-        );
+        int status = executeMain("-v", "-s");
+        assertThat(status, equalTo(ExitCodes.USAGE));
+        assertThat(terminal.getErrorOutput(), containsString("Option(s) [v/verbose] are unavailable"));
     }
 
     public void testSilentVerbosity() throws Exception {
-        MockTerminal terminal = new MockTerminal();
-        NoopCommand command = new NoopCommand();
-        String[] args = { "-s" };
-        command.main(args, terminal);
-        String output = terminal.getOutput();
-        assertTrue(output, output.contains("Silent output"));
+        executeMain("-s");
+        assertThat(terminal.getOutput(), containsString("Silent output"));
     }
 
     public void testNormalVerbosity() throws Exception {
-        MockTerminal terminal = new MockTerminal();
-        terminal.setVerbosity(Terminal.Verbosity.SILENT);
-        NoopCommand command = new NoopCommand();
-        String[] args = {};
-        command.main(args, terminal);
-        String output = terminal.getOutput();
-        assertTrue(output, output.contains("Normal output"));
+        executeMain();
+        assertThat(terminal.getOutput(), containsString("Normal output"));
     }
 
     public void testVerboseVerbosity() throws Exception {
-        MockTerminal terminal = new MockTerminal();
-        NoopCommand command = new NoopCommand();
-        String[] args = { "-v" };
-        command.main(args, terminal);
-        String output = terminal.getOutput();
-        assertTrue(output, output.contains("Verbose output"));
+        executeMain("-v");
+        assertThat(terminal.getOutput(), containsString("Verbose output"));
     }
 
     public void testUserError() throws Exception {
-        MockTerminal terminal = new MockTerminal();
-        UserErrorCommand command = new UserErrorCommand();
-        String[] args = {};
-        int status = command.main(args, terminal);
+        command.exception = new UserException(ExitCodes.DATA_ERROR, "Bad input");
+        int status = executeMain();
         String output = terminal.getOutput();
-        String error = terminal.getErrorOutput();
-        assertEquals(output, ExitCodes.DATA_ERROR, status);
-        assertTrue(error, error.contains("ERROR: Bad input"));
+        assertThat(output, status, equalTo(ExitCodes.DATA_ERROR));
+        assertThat(terminal.getErrorOutput(), containsString("ERROR: Bad input"));
     }
 
     public void testUsageError() throws Exception {
-        MockTerminal terminal = new MockTerminal();
-        UsageErrorCommand command = new UsageErrorCommand();
-        String[] args = {};
-        int status = command.main(args, terminal);
+        command.exception = new UserException(ExitCodes.USAGE, "something was no good");
+        int status = executeMain();
         String output = terminal.getOutput();
         String error = terminal.getErrorOutput();
         assertEquals(output, ExitCodes.USAGE, status);
-        assertTrue(error, error.contains("Throws a usage error"));
-        assertTrue(error, error.contains("ERROR: something was no good"));
+        assertThat(error, containsString("Does nothing"));
+        assertThat(error, containsString("ERROR: something was no good"));
     }
 
 }

--- a/server/src/test/java/org/elasticsearch/cli/MultiCommandTests.java
+++ b/server/src/test/java/org/elasticsearch/cli/MultiCommandTests.java
@@ -40,6 +40,11 @@ public class MultiCommandTests extends CommandTestCase {
                 throw new IllegalStateException("DummyMultiCommand already closed");
             }
         }
+
+        @Override
+        protected boolean addShutdownHook() {
+            return false;
+        }
     }
 
     static class DummySubCommand extends Command {
@@ -196,17 +201,6 @@ public class MultiCommandTests extends CommandTestCase {
 
     // Tests for multicommand error logging
 
-    static class ErrorHandlingMultiCommand extends MultiCommand {
-        ErrorHandlingMultiCommand() {
-            super("error catching", () -> {});
-        }
-
-        @Override
-        protected boolean addShutdownHook() {
-            return false;
-        }
-    }
-
     static class ErrorThrowingSubCommand extends Command {
         ErrorThrowingSubCommand() {
             super("error throwing", () -> {});
@@ -224,24 +218,20 @@ public class MultiCommandTests extends CommandTestCase {
     }
 
     public void testErrorDisplayedWithDefault() throws Exception {
-        MockTerminal terminal = new MockTerminal();
-        MultiCommand mc = new ErrorHandlingMultiCommand();
-        mc.subcommands.put("throw", new ErrorThrowingSubCommand());
-        mc.main(new String[] { "throw", "--silent" }, terminal);
+        multiCommand.subcommands.put("throw", new ErrorThrowingSubCommand());
+        executeMain("throw", "--silent");
         assertThat(terminal.getOutput(), is(emptyString()));
         assertThat(terminal.getErrorOutput(), equalTo("ERROR: Dummy error\n"));
     }
 
     public void testNullErrorMessageSuppressesErrorOutput() throws Exception {
-        MockTerminal terminal = new MockTerminal();
-        MultiCommand mc = new ErrorHandlingMultiCommand();
-        mc.subcommands.put("throw", new ErrorThrowingSubCommand() {
+        multiCommand.subcommands.put("throw", new ErrorThrowingSubCommand() {
             @Override
             protected void execute(Terminal terminal, OptionSet options) throws Exception {
                 throw new UserException(1, null);
             }
         });
-        mc.main(new String[] { "throw", "--silent" }, terminal);
+        executeMain("throw", "--silent");
         assertThat(terminal.getOutput(), is(emptyString()));
         assertThat(terminal.getErrorOutput(), is(emptyString()));
     }

--- a/test/framework/src/main/java/org/elasticsearch/cli/CommandTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/cli/CommandTestCase.java
@@ -29,7 +29,16 @@ public abstract class CommandTestCase extends ESTestCase {
     protected abstract Command newCommand();
 
     /**
-     * Runs a command with the given args.
+     * Run the main method of a new command with the given args.
+     *
+     * Output can be found in {@link #terminal}.
+     */
+    public int executeMain(String... args) throws Exception {
+        return newCommand().main(args, terminal);
+    }
+
+    /**
+     * Runs a new command with the given args.
      *
      * Output can be found in {@link #terminal}.
      */
@@ -38,7 +47,7 @@ public abstract class CommandTestCase extends ESTestCase {
     }
 
     /**
-     * Runs the specified command with the given args.
+     * Runs the specified command with the given args, throwing exceptions on errors.
      * <p>
      * Output can be found in {@link #terminal}.
      */


### PR DESCRIPTION
The main method of Command is not normally called by cli tests. Instead
they call the execute helper which calls mainWithoutErrorHandling.
Sometimes, though, it is desirable to test the top level behavior. This
commit cleans up the base class tests to not call main directly. This
will help with future refactorings to change the signature of main, so
that less uses need to be changed.