### PR TITLE
User Profile - Remove profile.user.active field

### DIFF
--- a/x-pack/docs/en/rest-api/security/activate-user-profile.asciidoc
+++ b/x-pack/docs/en/rest-api/security/activate-user-profile.asciidoc
@@ -113,8 +113,7 @@ The API returns the following response:
     ],
     "realm_name": "native",
     "full_name": "Jack Nicholson",
-    "email": "jacknich@example.com",
-    "active": true
+    "email": "jacknich@example.com"
   },
   "access": {},
   "data": {},

--- a/x-pack/docs/en/rest-api/security/get-user-profile.asciidoc
+++ b/x-pack/docs/en/rest-api/security/get-user-profile.asciidoc
@@ -76,8 +76,7 @@ The API returns the following response for a `uid` matching `u_kd2JMqwUQwSCCOxMv
       ],
       "realm_name": "native1",
       "full_name": "Jack Nicholson",
-      "email": "jacknich@example.com",
-      "active": true
+      "email": "jacknich@example.com"
     },
     "access": {},
     "data": {}, <1>
@@ -117,8 +116,7 @@ GET /_security/profile/u_kd2JMqwUQwSCCOxMv7M1vw?data=app1.key1
       ],
       "realm_name": "native1",
       "full_name": "Jack Nicholson",
-      "email": "jacknich@example.com",
-      "active": true
+      "email": "jacknich@example.com"
     },
     "access": {},
     "data": {

--- a/x-pack/docs/en/rest-api/security/suggest-user-profile.asciidoc
+++ b/x-pack/docs/en/rest-api/security/suggest-user-profile.asciidoc
@@ -90,8 +90,7 @@ The API returns:
         "full_name": "Jack Nicholson",
         "email": "jacknich@example.org",
         "roles": [ "admin", "other_role1" ],
-        "realm_name": "native1",
-        "active": true
+        "realm_name": "native1"
       }
     }
   ]

--- a/x-pack/docs/en/rest-api/security/update-user-profile-data.asciidoc
+++ b/x-pack/docs/en/rest-api/security/update-user-profile-data.asciidoc
@@ -147,8 +147,7 @@ If you run the request again, the consolidated profile data is returned:
       ],
       "realm_name": "native1",
       "full_name": "Jack Nicholson",
-      "email": "jacknich@example.com",
-      "active": true
+      "email": "jacknich@example.com"
     },
     "access": {
       "app1": {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/profile/Profile.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/profile/Profile.java
@@ -37,8 +37,7 @@ public record Profile(
         String realmName,
         @Nullable String domainName,
         String email,
-        String fullName,
-        boolean active
+        String fullName
     ) implements Writeable, ToXContent {
 
         public ProfileUser(StreamInput in) throws IOException {
@@ -48,8 +47,7 @@ public record Profile(
                 in.readString(),
                 in.readOptionalString(),
                 in.readOptionalString(),
-                in.readOptionalString(),
-                in.readBoolean()
+                in.readOptionalString()
             );
         }
 
@@ -72,7 +70,6 @@ public record Profile(
             if (fullName != null) {
                 builder.field("full_name", fullName);
             }
-            builder.field("active", active);
             builder.endObject();
             return builder;
         }
@@ -85,7 +82,6 @@ public record Profile(
             out.writeOptionalString(domainName);
             out.writeOptionalString(email);
             out.writeOptionalString(fullName);
-            out.writeBoolean(active);
         }
     }
 

--- a/x-pack/plugin/security/qa/profile/src/javaRestTest/java/org/elasticsearch/xpack/security/profile/ProfileIT.java
+++ b/x-pack/plugin/security/qa/profile/src/javaRestTest/java/org/elasticsearch/xpack/security/profile/ProfileIT.java
@@ -56,8 +56,7 @@ public class ProfileIT extends ESRestTestCase {
                 "node_name": "node1"
               },
               "email": "foo@example.com",
-              "full_name": "User Foo",
-              "active": true
+              "full_name": "User Foo"
             },
             "last_synchronized": %s,
             "access": {

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/profile/ProfileDocument.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/profile/ProfileDocument.java
@@ -44,14 +44,9 @@ public record ProfileDocument(
     BytesReference applicationData
 ) implements ToXContentObject {
 
-    public record ProfileDocumentUser(
-        String username,
-        List<String> roles,
-        Authentication.RealmRef realm,
-        String email,
-        String fullName,
-        boolean active
-    ) implements ToXContent {
+    public record ProfileDocumentUser(String username, List<String> roles, Authentication.RealmRef realm, String email, String fullName)
+        implements
+            ToXContent {
 
         @Override
         public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
@@ -61,14 +56,13 @@ public record ProfileDocument(
             builder.field("realm", realm);
             builder.field("email", email);
             builder.field("full_name", fullName);
-            builder.field("active", active);
             builder.endObject();
             return builder;
         }
 
         public Profile.ProfileUser toProfileUser() {
             final String domainName = realm.getDomain() != null ? realm.getDomain().name() : null;
-            return new Profile.ProfileUser(username, roles, realm.getName(), domainName, email, fullName, active);
+            return new Profile.ProfileUser(username, roles, realm.getName(), domainName, email, fullName);
         }
     }
 
@@ -96,7 +90,7 @@ public record ProfileDocument(
 
     public Subject subject() {
         return new Subject(
-            new User(user.username, user.roles.toArray(String[]::new), user.fullName, user.email, Map.of(), user.active),
+            new User(user.username, user.roles.toArray(String[]::new), user.fullName, user.email, Map.of(), true),
             user.realm
         );
     }
@@ -118,8 +112,7 @@ public record ProfileDocument(
                 Arrays.asList(subjectUser.roles()),
                 subject.getRealm(),
                 subjectUser.email(),
-                subjectUser.fullName(),
-                subjectUser.enabled()
+                subjectUser.fullName()
             ),
             Map.of(),
             null
@@ -162,8 +155,7 @@ public record ProfileDocument(
             (List<String>) args[1],
             (Authentication.RealmRef) args[2],
             (String) args[3],
-            (String) args[4],
-            (Boolean) args[5]
+            (String) args[4]
         )
     );
 
@@ -193,7 +185,6 @@ public record ProfileDocument(
         PROFILE_DOC_USER_PARSER.declareObject(constructorArg(), (p, c) -> REALM_REF_PARSER.parse(p, c), new ParseField("realm"));
         PROFILE_DOC_USER_PARSER.declareStringOrNull(optionalConstructorArg(), new ParseField("email"));
         PROFILE_DOC_USER_PARSER.declareStringOrNull(optionalConstructorArg(), new ParseField("full_name"));
-        PROFILE_DOC_USER_PARSER.declareBoolean(constructorArg(), new ParseField("active"));
 
         PROFILE_DOC_PARSER.declareString(constructorArg(), new ParseField("uid"));
         PROFILE_DOC_PARSER.declareBoolean(constructorArg(), new ParseField("enabled"));

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/profile/ProfileService.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/profile/ProfileService.java
@@ -617,8 +617,7 @@ public class ProfileService {
                 subject.getRealm(),
                 // Replace with incoming information even when they are null
                 subjectUser.email(),
-                subjectUser.fullName(),
-                subjectUser.enabled()
+                subjectUser.fullName()
             ),
             doc.access(),
             doc.applicationData()

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/support/SecuritySystemIndices.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/support/SecuritySystemIndices.java
@@ -833,10 +833,6 @@ public class SecuritySystemIndices {
                                     builder.startObject("full_name");
                                     builder.field("type", "search_as_you_type");
                                     builder.endObject();
-
-                                    builder.startObject("active");
-                                    builder.field("type", "boolean");
-                                    builder.endObject();
                                 }
                                 builder.endObject();
                             }

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/profile/ProfileServiceTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/profile/ProfileServiceTests.java
@@ -80,8 +80,7 @@ public class ProfileServiceTests extends ESTestCase {
                 "node_name": "node1"
               },
               "email": "foo@example.com",
-              "full_name": "User Foo",
-              "active": true
+              "full_name": "User Foo"
             },
             "last_synchronized": %s,
             "access": {
@@ -161,15 +160,7 @@ public class ProfileServiceTests extends ESTestCase {
                     uid,
                     true,
                     lastSynchronized,
-                    new Profile.ProfileUser(
-                        "Foo",
-                        List.of("role1", "role2"),
-                        "realm_name_1",
-                        "domainA",
-                        "foo@example.com",
-                        "User Foo",
-                        true
-                    ),
+                    new Profile.ProfileUser("Foo", List.of("role1", "role2"), "realm_name_1", "domainA", "foo@example.com", "User Foo"),
                     Map.of(),
                     applicationData,
                     new Profile.VersionControl(1, 0)
@@ -253,8 +244,7 @@ public class ProfileServiceTests extends ESTestCase {
                 List.of(),
                 AuthenticationTests.randomRealmRef(randomBoolean()),
                 "foo@example.com",
-                null,
-                true
+                null
             ),
             Map.of(),
             null


### PR DESCRIPTION
The profile document has two boolean fields, profile.enabled and
profile.user.active. The intention was that profile.enabled=false means
the profile is not searchable (somewhat equivalent to being deleted) and
profile.user.active=false means the profile is searchable but may not be
assignable (in Kibana). However we don't currently have a concrete
requirement for the later. Also we don't provide an API so far to set
profile.user.active to false. Hence we agree to leave this field out
till we have a better requirement for it.
