### PR TITLE
Release notes for 7.17.3

### DIFF
--- a/docs/changelog/85534.yaml
+++ b/docs/changelog/85534.yaml
@@ -1,5 +1,0 @@
-pr: 85534
-summary: "Fix: remove tests from 7.17"
-area: Aggregations
-type: bug
-issues: []

--- a/docs/changelog/85581.yaml
+++ b/docs/changelog/85581.yaml
@@ -1,5 +1,5 @@
 pr: 85581
 summary: Bump commons-compress to 1.21
 area: Ingest
-type: bug
+type: upgrade
 issues: []

--- a/docs/changelog/85672.yaml
+++ b/docs/changelog/85672.yaml
@@ -1,5 +1,5 @@
 pr: 85672
-summary: Allow retrieving `boolean` fields from `_source` in DFA jobs
+summary: Allow retrieving `boolean` fields from `_source` in data frame analytics jobs
 area: Machine Learning
 type: bug
 issues: []

--- a/docs/reference/release-notes.asciidoc
+++ b/docs/reference/release-notes.asciidoc
@@ -6,6 +6,7 @@
 
 This section summarizes the changes in each release.
 
+* <<release-notes-7.17.3>>
 * <<release-notes-7.17.2>>
 * <<release-notes-7.17.1>>
 * <<release-notes-7.17.0>>
@@ -63,6 +64,7 @@ This section summarizes the changes in each release.
 
 --
 
+include::release-notes/7.17.3.asciidoc[]
 include::release-notes/7.17.2.asciidoc[]
 include::release-notes/7.17.1.asciidoc[]
 include::release-notes/7.17.0.asciidoc[]

--- a/docs/reference/release-notes/7.17.3.asciidoc
+++ b/docs/reference/release-notes/7.17.3.asciidoc
@@ -14,7 +14,7 @@ Highlighting::
 * Fix wildcard highlighting on `match_only_text` {es-pull}85500[#85500] (issue: {es-issue}85493[#85493])
 
 Machine Learning::
-* Allow retrieving `boolean` fields from `_source` in DFA jobs {es-pull}85672[#85672]
+* Allow retrieving `boolean` fields from `_source` in data frame analytics jobs {es-pull}85672[#85672]
 * Avoid multiple queued quantiles documents in renormalizer {es-pull}85555[#85555] (issue: {es-issue}85539[#85539])
 
 Search::

--- a/docs/reference/release-notes/7.17.3.asciidoc
+++ b/docs/reference/release-notes/7.17.3.asciidoc
@@ -1,0 +1,30 @@
+[[release-notes-7.17.3]]
+== {es} version 7.17.3
+
+Also see <<breaking-changes-7.17,Breaking changes in 7.17>>.
+
+[[bug-7.17.3]]
+[float]
+=== Bug fixes
+
+Geo::
+* Fix fields wildcard support to vector tile search API {es-pull}85595[#85595] (issue: {es-issue}85592[#85592])
+
+Highlighting::
+* Fix wildcard highlighting on `match_only_text` {es-pull}85500[#85500] (issue: {es-issue}85493[#85493])
+
+Machine Learning::
+* Allow retrieving `boolean` fields from `_source` in DFA jobs {es-pull}85672[#85672]
+* Avoid multiple queued quantiles documents in renormalizer {es-pull}85555[#85555] (issue: {es-issue}85539[#85539])
+
+Search::
+* Fix skip caching factor with `indices.queries.cache.all_segments` {es-pull}85510[#85510]
+
+[[upgrade-7.17.3]]
+[float]
+=== Upgrades
+
+Ingest::
+* Bump commons-compress to 1.21 {es-pull}85581[#85581]
+
+


### PR DESCRIPTION
Release notes for 7.17.3.

* One changelog file was for a test fix and wasn't required. I've removed it from upstream.
* One changelog had the wrong change type. I've corrected it upstream.