### PR TITLE
[ML] Fix serialisation of text embedding updates

### DIFF
--- a/docs/changelog/85863.yaml
+++ b/docs/changelog/85863.yaml
@@ -1,0 +1,5 @@
+pr: 85863
+summary: Fix serialisation of text embedding updates
+area: Machine Learning
+type: bug
+issues: []

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/MlInferenceNamedXContentProvider.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/MlInferenceNamedXContentProvider.java
@@ -603,7 +603,7 @@ public class MlInferenceNamedXContentProvider implements NamedXContentProvider {
             new NamedWriteableRegistry.Entry(
                 InferenceConfigUpdate.class,
                 TextEmbeddingConfigUpdate.NAME,
-                TextClassificationConfigUpdate::new
+                TextEmbeddingConfigUpdate::new
             )
         );
         namedWriteables.add(

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/MlInferenceNamedXContentProvider.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/MlInferenceNamedXContentProvider.java
@@ -600,11 +600,7 @@ public class MlInferenceNamedXContentProvider implements NamedXContentProvider {
             )
         );
         namedWriteables.add(
-            new NamedWriteableRegistry.Entry(
-                InferenceConfigUpdate.class,
-                TextEmbeddingConfigUpdate.NAME,
-                TextEmbeddingConfigUpdate::new
-            )
+            new NamedWriteableRegistry.Entry(InferenceConfigUpdate.class, TextEmbeddingConfigUpdate.NAME, TextEmbeddingConfigUpdate::new)
         );
         namedWriteables.add(
             new NamedWriteableRegistry.Entry(


### PR DESCRIPTION
Fixes an issue where text_embeddding updates could not be serialised between nodes. 