### PR TITLE
[8.1] [ML] Fix serialisation of text embedding updates (#85863)

### DIFF
--- a/docs/changelog/85863.yaml
+++ b/docs/changelog/85863.yaml
@@ -1,0 +1,5 @@
+pr: 85863
+summary: Fix serialisation of text embedding updates
+area: Machine Learning
+type: bug
+issues: []

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/MlInferenceNamedXContentProvider.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/MlInferenceNamedXContentProvider.java
@@ -584,11 +584,7 @@ public class MlInferenceNamedXContentProvider implements NamedXContentProvider {
             )
         );
         namedWriteables.add(
-            new NamedWriteableRegistry.Entry(
-                InferenceConfigUpdate.class,
-                TextEmbeddingConfigUpdate.NAME,
-                TextClassificationConfigUpdate::new
-            )
+            new NamedWriteableRegistry.Entry(InferenceConfigUpdate.class, TextEmbeddingConfigUpdate.NAME, TextEmbeddingConfigUpdate::new)
         );
         namedWriteables.add(
             new NamedWriteableRegistry.Entry(


### PR DESCRIPTION
Backports the following commits to 8.1:
 - [ML] Fix serialisation of text embedding updates (#85863)