### PR TITLE
[8.2] Upgrade to JDK 18.0.0+36 (#85376)

### DIFF
--- a/build-tools-internal/version.properties
+++ b/build-tools-internal/version.properties
@@ -2,7 +2,7 @@ elasticsearch     = 8.2.0
 lucene            = 9.1.0
 
 bundled_jdk_vendor = adoptium
-bundled_jdk = 17.0.2+8
+bundled_jdk = 18+36
 
 checkstyle = 9.3
 

--- a/docs/changelog/85376.yaml
+++ b/docs/changelog/85376.yaml
@@ -1,0 +1,6 @@
+pr: 85376
+summary: Upgrade to JDK 18.0.0+36
+area: Packaging
+type: upgrade
+issues:
+ - 85357


### PR DESCRIPTION
Backports the following commits to 8.2:
 - Upgrade to JDK 18.0.0+36 (#85376)