### PR TITLE
Upgrade bytebuddy to latest version with Java 19 support

### DIFF
--- a/build-tools-internal/build.gradle
+++ b/build-tools-internal/build.gradle
@@ -257,7 +257,7 @@ dependencies {
   integTestImplementation("org.junit.jupiter:junit-jupiter") {
     because 'allows to write and run Jupiter tests'
   }
-  integTestImplementation("net.bytebuddy:byte-buddy:1.11.0") {
+  integTestImplementation("net.bytebuddy:byte-buddy:1.12.9") {
     because 'Generating dynamic mocks of internal libraries like JdkJarHell'
   }
   testRuntimeOnly("org.junit.vintage:junit-vintage-engine") {

--- a/client/test/build.gradle
+++ b/client/test/build.gradle
@@ -26,7 +26,7 @@ dependencies {
 
   // mockito
   api 'org.mockito:mockito-core:4.0.0'
-  api 'net.bytebuddy:byte-buddy:1.11.19'
+  api 'net.bytebuddy:byte-buddy:1.12.9'
   api 'org.objenesis:objenesis:3.2'
 }
 

--- a/client/test/build.gradle
+++ b/client/test/build.gradle
@@ -25,7 +25,7 @@ dependencies {
   api "org.hamcrest:hamcrest:${versions.hamcrest}"
 
   // mockito
-  api 'org.mockito:mockito-core:4.0.0'
+  api 'org.mockito:mockito-core:4.4.0'
   api 'net.bytebuddy:byte-buddy:1.12.9'
   api 'org.objenesis:objenesis:3.2'
 }

--- a/test/framework/build.gradle
+++ b/test/framework/build.gradle
@@ -26,7 +26,7 @@ dependencies {
 
   // mockito
   api 'org.mockito:mockito-core:4.0.0'
-  api 'net.bytebuddy:byte-buddy:1.11.19'
+  api 'net.bytebuddy:byte-buddy:1.12.9'
   api 'org.objenesis:objenesis:3.2'
 
   api "org.elasticsearch:mocksocket:${versions.mocksocket}"

--- a/test/framework/build.gradle
+++ b/test/framework/build.gradle
@@ -25,7 +25,7 @@ dependencies {
   api "commons-codec:commons-codec:${versions.commonscodec}"
 
   // mockito
-  api 'org.mockito:mockito-core:4.0.0'
+  api 'org.mockito:mockito-core:4.4.0'
   api 'net.bytebuddy:byte-buddy:1.12.9'
   api 'org.objenesis:objenesis:3.2'
 


### PR DESCRIPTION
Update bytebuddy to the latest version which has support for Java 19. This addresses some issues we have with Mockito when running tests on Java 19 EA releases.

Closes https://github.com/elastic/elasticsearch/issues/85879