### PR TITLE
Remove hppc from multi*shard request and responses

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/get/MultiGetShardRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/get/MultiGetShardRequest.java
@@ -8,8 +8,6 @@
 
 package org.elasticsearch.action.get;
 
-import com.carrotsearch.hppc.IntArrayList;
-
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.support.single.shard.SingleShardRequest;
 import org.elasticsearch.common.io.stream.StreamInput;
@@ -26,13 +24,13 @@ public class MultiGetShardRequest extends SingleShardRequest<MultiGetShardReques
     private boolean realtime;
     private boolean refresh;
 
-    IntArrayList locations;
+    List<Integer> locations;
     List<MultiGetRequest.Item> items;
 
     MultiGetShardRequest(StreamInput in) throws IOException {
         super(in);
         int size = in.readVInt();
-        locations = new IntArrayList(size);
+        locations = new ArrayList<>(size);
         items = new ArrayList<>(size);
 
         for (int i = 0; i < size; i++) {
@@ -48,7 +46,7 @@ public class MultiGetShardRequest extends SingleShardRequest<MultiGetShardReques
     MultiGetShardRequest(MultiGetRequest multiGetRequest, String index, int shardId) {
         super(index);
         this.shardId = shardId;
-        locations = new IntArrayList();
+        locations = new ArrayList<>();
         items = new ArrayList<>();
         preference = multiGetRequest.preference;
         realtime = multiGetRequest.realtime;

--- a/server/src/main/java/org/elasticsearch/action/get/MultiGetShardResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/get/MultiGetShardResponse.java
@@ -8,8 +8,6 @@
 
 package org.elasticsearch.action.get;
 
-import com.carrotsearch.hppc.IntArrayList;
-
 import org.elasticsearch.action.ActionResponse;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -20,12 +18,12 @@ import java.util.List;
 
 public class MultiGetShardResponse extends ActionResponse {
 
-    final IntArrayList locations;
+    final List<Integer> locations;
     final List<GetResponse> responses;
     final List<MultiGetResponse.Failure> failures;
 
     MultiGetShardResponse() {
-        locations = new IntArrayList();
+        locations = new ArrayList<>();
         responses = new ArrayList<>();
         failures = new ArrayList<>();
     }
@@ -33,7 +31,7 @@ public class MultiGetShardResponse extends ActionResponse {
     MultiGetShardResponse(StreamInput in) throws IOException {
         super(in);
         int size = in.readVInt();
-        locations = new IntArrayList(size);
+        locations = new ArrayList<>(size);
         responses = new ArrayList<>(size);
         failures = new ArrayList<>(size);
         for (int i = 0; i < size; i++) {

--- a/server/src/main/java/org/elasticsearch/action/termvectors/MultiTermVectorsShardRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/termvectors/MultiTermVectorsShardRequest.java
@@ -8,8 +8,6 @@
 
 package org.elasticsearch.action.termvectors;
 
-import com.carrotsearch.hppc.IntArrayList;
-
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.support.single.shard.SingleShardRequest;
 import org.elasticsearch.common.io.stream.StreamInput;
@@ -24,13 +22,13 @@ public class MultiTermVectorsShardRequest extends SingleShardRequest<MultiTermVe
     private int shardId;
     private String preference;
 
-    IntArrayList locations;
+    List<Integer> locations;
     List<TermVectorsRequest> requests;
 
     MultiTermVectorsShardRequest(StreamInput in) throws IOException {
         super(in);
         int size = in.readVInt();
-        locations = new IntArrayList(size);
+        locations = new ArrayList<>(size);
         requests = new ArrayList<>(size);
         for (int i = 0; i < size; i++) {
             locations.add(in.readVInt());
@@ -43,7 +41,7 @@ public class MultiTermVectorsShardRequest extends SingleShardRequest<MultiTermVe
     MultiTermVectorsShardRequest(String index, int shardId) {
         super(index);
         this.shardId = shardId;
-        locations = new IntArrayList();
+        locations = new ArrayList<>();
         requests = new ArrayList<>();
     }
 

--- a/server/src/main/java/org/elasticsearch/action/termvectors/MultiTermVectorsShardResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/termvectors/MultiTermVectorsShardResponse.java
@@ -8,8 +8,6 @@
 
 package org.elasticsearch.action.termvectors;
 
-import com.carrotsearch.hppc.IntArrayList;
-
 import org.elasticsearch.action.ActionResponse;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -20,12 +18,12 @@ import java.util.List;
 
 public class MultiTermVectorsShardResponse extends ActionResponse {
 
-    final IntArrayList locations;
+    final List<Integer> locations;
     final List<TermVectorsResponse> responses;
     final List<MultiTermVectorsResponse.Failure> failures;
 
     MultiTermVectorsShardResponse() {
-        locations = new IntArrayList();
+        locations = new ArrayList<>();
         responses = new ArrayList<>();
         failures = new ArrayList<>();
     }
@@ -33,7 +31,7 @@ public class MultiTermVectorsShardResponse extends ActionResponse {
     MultiTermVectorsShardResponse(StreamInput in) throws IOException {
         super(in);
         int size = in.readVInt();
-        locations = new IntArrayList(size);
+        locations = new ArrayList<>(size);
         responses = new ArrayList<>(size);
         failures = new ArrayList<>(size);
         for (int i = 0; i < size; i++) {


### PR DESCRIPTION
The Multi API requests and responses use an hppc int array for
term location data. The use of hppc here dates back to the beginning of
the multi apis, yet all the other members have been converted to Java
collections. This commit converts these uses to ArrayLists.

relates #84735