### PR TITLE
Fix flaky DesiredNodeTests#testGetRoles

### DIFF
--- a/server/src/test/java/org/elasticsearch/cluster/metadata/DesiredNodeTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/DesiredNodeTests.java
@@ -14,6 +14,7 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.test.ESTestCase;
 
+import static org.elasticsearch.cluster.node.DiscoveryNodeRole.VOTING_ONLY_NODE_ROLE;
 import static org.elasticsearch.node.Node.NODE_EXTERNAL_ID_SETTING;
 import static org.elasticsearch.node.Node.NODE_NAME_SETTING;
 import static org.elasticsearch.node.NodeRoleSettings.NODE_ROLES_SETTING;
@@ -90,11 +91,10 @@ public class DesiredNodeTests extends ESTestCase {
         }
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/85882")
     public void testGetRoles() {
         final var settings = Settings.builder().put(NODE_NAME_SETTING.getKey(), randomAlphaOfLength(10));
 
-        final var role = randomBoolean() ? null : randomFrom(DiscoveryNodeRole.roles());
+        final var role = randomBoolean() ? null : randomValueOtherThan(VOTING_ONLY_NODE_ROLE, () -> randomFrom(DiscoveryNodeRole.roles()));
         if (role != null) {
             settings.put(NODE_ROLES_SETTING.getKey(), role.roleName());
         }


### PR DESCRIPTION
Exclude VOTING_ONLY_NODE_ROLE from the list of randomy picked roles as
it could not be used in isolation without MASTER role

Closes: #85882
