### PR TITLE
Fewer ThreadLocals in version/seqno resolver

### DIFF
--- a/docs/changelog/85896.yaml
+++ b/docs/changelog/85896.yaml
@@ -1,0 +1,6 @@
+pr: 85896
+summary: Fewer `ThreadLocals` in version/seqno resolver
+area: CRUD
+type: bug
+issues:
+ - 56766


### PR DESCRIPTION
Today we create a new `ThreadLocal` for every `IndexReader` encountered
during non-append-only indexing (effectively every refresh on every
shard). Each thread keeps a table of all its live thread-locals, where
"live" effectively means "has not been garbage-collected". Some of these
`IndexReader` instances have lifespans long enough for the corresponding
thread-local to escape the young generation which means that it may not
be garbage-collected for a very long time, preventing their slots in the
table from being re-used. This causes the thread-local table for `write`
threads to grow rather large, which egregiously slows down other
operations on unrelated thread-locals on these threads.

This commit changes the map-of-thread-locals to a thread-local-of-maps,
reducing the churn of thread-locals and releasing the resolver in each
thread's thread-local map as soon as the corresponding `IndexReader` is
closed.

Closes #56766