### PR TITLE
Remove last usage of Authentication constructor from production code

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authc/Authentication.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authc/Authentication.java
@@ -15,6 +15,7 @@ import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.common.util.ArrayUtils;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.common.xcontent.XContentHelper;
 import org.elasticsearch.core.Nullable;
@@ -204,6 +205,58 @@ public class Authentication implements ToXContentObject {
         );
         assert Objects.equals(getDomain(), newTokenAuthentication.getDomain());
         return newTokenAuthentication;
+    }
+
+    /**
+      * The final list of roles a user has should include all roles granted to the anonymous user when
+      *  1. Anonymous access is enable
+      *  2. The user itself is not the anonymous user
+      *  3. The authentication is not an API key or service account
+      *
+      *  Depending on whether the above criteria is satisfied, the method may either return a new
+      *  authentication object incorporating anonymous roles or the same authentication object (if anonymous
+      *  roles are not applicable)
+      *
+      *  NOTE this method is an artifact of how anonymous roles are resolved today on each node as opposed to
+      *  just on the coordinating node. Whether this behaviour should be changed is an ongoing discussion.
+      *  Therefore, using this method in more places other than its current usage requires careful consideration.
+      */
+    public Authentication maybeAddAnonymousRoles(@Nullable AnonymousUser anonymousUser) {
+        final boolean shouldAddAnonymousRoleNames = anonymousUser != null
+            && anonymousUser.enabled()
+            && false == anonymousUser.equals(getUser())
+            && false == User.isInternal(getUser())
+            && false == isApiKey()
+            && false == isServiceAccount();
+
+        if (false == shouldAddAnonymousRoleNames) {
+            return this;
+        }
+
+        // TODO: should we validate enable status and length of role names on instantiation time of anonymousUser?
+        if (anonymousUser.roles().length == 0) {
+            throw new IllegalStateException("anonymous is only enabled when the anonymous user has roles");
+        }
+        final String[] allRoleNames = ArrayUtils.concat(getUser().roles(), anonymousUser.roles());
+
+        return new Authentication(
+            new User(
+                new User(
+                    getUser().principal(),
+                    allRoleNames,
+                    getUser().fullName(),
+                    getUser().email(),
+                    getUser().metadata(),
+                    getUser().enabled()
+                ),
+                getUser().authenticatedUser()
+            ),
+            getAuthenticatedBy(),
+            getLookedUpBy(),
+            getVersion(),
+            getAuthenticationType(),
+            getMetadata()
+        );
     }
 
     /**


### PR DESCRIPTION
Authentication object has many internal logic on what values can or
cannot be used together. Hence it is better to instantiate it using
convenient methods that is tailored for specific situations instead of
the free usage of constructors.

This PR adds a new convenient method for incorporating anonymous roles
so that all production usages of constructors are removed (other than by
the class itself). The next step is to remove usages in test code and
ultimately locking down how Authentication can be created.

PS: Strictly speaking, the Authentication(StreamInput) constructor is
still used in production code. But this one is special, less used and
not convenient to use. So we can let it stay for now. In long term, we
can also lock it down.

