### PR TITLE
Remove unnecessary uses of ObjectHashSet

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/admin/indices/mapping/put/PutMappingRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/mapping/put/PutMappingRequest.java
@@ -8,8 +8,6 @@
 
 package org.elasticsearch.action.admin.indices.mapping.put;
 
-import com.carrotsearch.hppc.ObjectHashSet;
-
 import org.elasticsearch.ElasticsearchGenerationException;
 import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionRequestValidationException;
@@ -35,6 +33,7 @@ import java.io.UncheckedIOException;
 import java.util.Arrays;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 
 import static org.elasticsearch.action.ValidateActions.addValidationError;
 
@@ -51,7 +50,7 @@ import static org.elasticsearch.action.ValidateActions.addValidationError;
  */
 public class PutMappingRequest extends AcknowledgedRequest<PutMappingRequest> implements IndicesRequest.Replaceable {
 
-    private static ObjectHashSet<String> RESERVED_FIELDS = ObjectHashSet.from(
+    private static Set<String> RESERVED_FIELDS = Set.of(
         "_uid",
         "_id",
         "_type",

--- a/server/src/main/java/org/elasticsearch/indices/IndicesRequestCache.java
+++ b/server/src/main/java/org/elasticsearch/indices/IndicesRequestCache.java
@@ -8,9 +8,6 @@
 
 package org.elasticsearch.indices;
 
-import com.carrotsearch.hppc.ObjectHashSet;
-import com.carrotsearch.hppc.ObjectSet;
-
 import org.apache.lucene.index.DirectoryReader;
 import org.apache.lucene.util.Accountable;
 import org.apache.lucene.util.RamUsageEstimator;
@@ -34,6 +31,7 @@ import java.io.Closeable;
 import java.io.IOException;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Objects;
 import java.util.Set;
@@ -319,10 +317,8 @@ public final class IndicesRequestCache implements RemovalListener<IndicesRequest
     }
 
     synchronized void cleanCache() {
-        final ObjectSet<CleanupKey> currentKeysToClean = new ObjectHashSet<>();
-        final ObjectSet<Object> currentFullClean = new ObjectHashSet<>();
-        currentKeysToClean.clear();
-        currentFullClean.clear();
+        final Set<CleanupKey> currentKeysToClean = new HashSet<>();
+        final Set<Object> currentFullClean = new HashSet<>();
         for (Iterator<CleanupKey> iterator = keysToClean.iterator(); iterator.hasNext();) {
             CleanupKey cleanupKey = iterator.next();
             iterator.remove();


### PR DESCRIPTION
A couple places in ES code use ObjectHashSet when a Java HashSet is
essentially equivalent. This commit converts these trivial uses to use
HashSet.

relates #84735