### PR TITLE
[8.1] Upgrade bytebuddy to latest version with Java 19 support (#85881)

### DIFF
--- a/build-tools-internal/build.gradle
+++ b/build-tools-internal/build.gradle
@@ -257,7 +257,7 @@ dependencies {
   integTestImplementation("org.junit.jupiter:junit-jupiter") {
     because 'allows to write and run Jupiter tests'
   }
-  integTestImplementation("net.bytebuddy:byte-buddy:1.11.0") {
+  integTestImplementation("net.bytebuddy:byte-buddy:1.12.9") {
     because 'Generating dynamic mocks of internal libraries like JdkJarHell'
   }
   testRuntimeOnly("org.junit.vintage:junit-vintage-engine") {

--- a/client/test/build.gradle
+++ b/client/test/build.gradle
@@ -25,8 +25,8 @@ dependencies {
   api "org.hamcrest:hamcrest:${versions.hamcrest}"
 
   // mockito
-  api 'org.mockito:mockito-core:4.0.0'
-  api 'net.bytebuddy:byte-buddy:1.11.19'
+  api 'org.mockito:mockito-core:4.4.0'
+  api 'net.bytebuddy:byte-buddy:1.12.9'
   api 'org.objenesis:objenesis:3.2'
 }
 

--- a/test/framework/build.gradle
+++ b/test/framework/build.gradle
@@ -26,8 +26,8 @@ dependencies {
   api "commons-codec:commons-codec:${versions.commonscodec}"
 
   // mockito
-  api 'org.mockito:mockito-core:4.0.0'
-  api 'net.bytebuddy:byte-buddy:1.11.19'
+  api 'org.mockito:mockito-core:4.4.0'
+  api 'net.bytebuddy:byte-buddy:1.12.9'
   api 'org.objenesis:objenesis:3.2'
 
   api "org.elasticsearch:mocksocket:${versions.mocksocket}"


### PR DESCRIPTION
Backports the following commits to 8.1:
 - Upgrade bytebuddy to latest version with Java 19 support (#85881)