### PR TITLE
Only use InitialMasterNodes during bootstrap

### DIFF
--- a/docs/reference/modules/discovery/bootstrapping.asciidoc
+++ b/docs/reference/modules/discovery/bootstrapping.asciidoc
@@ -31,7 +31,7 @@ node:
 
 When you start a master-eligible node, you can provide this setting on the
 command line or in the `elasticsearch.yml` file. After the cluster has formed,
-this setting is no longer required. It should not be set for master-ineligible
+this setting should no longer be used. It should not be set for master-ineligible
 nodes, master-eligible nodes joining an existing cluster, or cluster restarts.
 
 It is technically sufficient to set `cluster.initial_master_nodes` on a single


### PR DESCRIPTION
👋🏼 [This doc](https://www.elastic.co/guide/en/elasticsearch/reference/8.1/modules-discovery-bootstrap-cluster.html) currently says ... (referring to `cluster.initial_master_nodes`).

>  After the cluster has formed, this setting is no longer required.

This should instead push users that this setting ONLY makes sense during bootstrap and should be removed after.