### PR TITLE
Optimize FieldPath::<init> by avoiding split via regex

### DIFF
--- a/server/src/main/java/org/elasticsearch/ingest/IngestDocument.java
+++ b/server/src/main/java/org/elasticsearch/ingest/IngestDocument.java
@@ -898,6 +898,8 @@ public final class IngestDocument {
 
     private class FieldPath {
 
+        private static final String[] EMPTY_STRING_ARRAY = new String[0];
+
         private final String[] pathElements;
         private final Object initialContext;
 
@@ -917,12 +919,22 @@ public final class IngestDocument {
                     newPath = path;
                 }
             }
-            this.pathElements = newPath.split("\\.");
+            this.pathElements = split(newPath, '.');
             if (pathElements.length == 1 && pathElements[0].isEmpty()) {
                 throw new IllegalArgumentException("path [" + path + "] is not valid");
             }
         }
 
+        private static String[] split(String input, char separator) {
+            List<String> l = new ArrayList<>();
+            int offset = 0;
+            for (int index = input.indexOf(separator); index != -1; index = input.indexOf(separator, offset)) {
+                l.add(input.substring(offset, index));
+                offset = index + 1;
+            }
+            l.add(input.substring(offset));
+            return l.toArray(EMPTY_STRING_ARRAY);
+        }
     }
 
     private static class ResolveResult {


### PR DESCRIPTION
A lot of methods in `IngestDocument` (such as `IngestDocument::hasField` or `IngestDocument::setFieldValue`) take a `String path` argument that represents a dot-separated path within the document.

Currently, the string is split not very efficiently - via a non-compiled regex (`path.split("\\.")`). Looking at the profiles I attached to https://github.com/elastic/elasticsearch/pull/76483, it becomes apparent that the overhead of splitting the string in this way is non-negligible.

Due to the pervasive use of `FieldPath` in almost every processor I think this can have a significant overall impact. It would be interesting to see the difference in observability rally tracks.