### PR TITLE
[DOCS] Add detached mode for enrolling Kibana

### DIFF
--- a/x-pack/docs/en/security/configuring-stack-security.asciidoc
+++ b/x-pack/docs/en/security/configuring-stack-security.asciidoc
@@ -62,22 +62,44 @@ curl --cacert config/certs/http_ca.crt -u elastic https://localhost:9200
 ----
 // NOTCONSOLE
 
-. From the directory where you installed {kib}, start {kib}.
+. From the directory where you installed {kib}, start {kib} in either
+interactive or detached mode.
 +
+--
+*Interactive mode*
+
+Use this mode if you want to enroll {kib} using your browser.
+
 [source,shell]
 ----
 bin/kibana
 ----
-+
+
 This command generates a unique link to enroll your {kib} instance with {es}.
 
-  .. In your terminal, click the generated link to open {kib} in your browser.
+. In your terminal, click the generated link to open {kib} in your browser.
 
-  .. In your browser, paste the enrollment token that you copied and click the
+. In your browser, paste the enrollment token that you copied and click the
 button to connect your {kib} instance with {es}.
 
-  .. Log in to {kib} as the `elastic` user with the password that was generated
+. Log in to {kib} as the `elastic` user with the password that was generated
 when you started {es}.
+
+'''
+
+*Detached mode*
+
+Use this mode if you want to enroll {kib} without a browser, or want to enroll
+{kib} on a machine where you don't have access to a browser.
+
+Start {kib} and pass the generated enrollment token with the `--token`
+parameter.
+
+[source,shell]
+----
+bin/kibana_setup --token <enrollment-token>
+----
+--
 
 [discrete]
 [[stack-enroll-nodes]]

--- a/x-pack/docs/en/security/configuring-stack-security.asciidoc
+++ b/x-pack/docs/en/security/configuring-stack-security.asciidoc
@@ -62,44 +62,30 @@ curl --cacert config/certs/http_ca.crt -u elastic https://localhost:9200
 ----
 // NOTCONSOLE
 
-. From the directory where you installed {kib}, start {kib} in either
-interactive or detached mode.
+. From the directory where you installed {kib}, start {kib}.
 +
---
-*Interactive mode*
-
-Use this mode if you want to enroll {kib} using your browser.
-
 [source,shell]
 ----
 bin/kibana
 ----
 
-This command generates a unique link to enroll your {kib} instance with {es}.
+. Enroll {kib} using either interactive or detached mode.
 
-. In your terminal, click the generated link to open {kib} in your browser.
+  * *Interactive mode* (browser)
+  
+  .. In your terminal, click the generated link to open {kib} in your browser.
+  .. In your browser, paste the enrollment token that you copied and click the
+  button to connect your {kib} instance with {es}.
 
-. In your browser, paste the enrollment token that you copied and click the
-button to connect your {kib} instance with {es}.
-
-. Log in to {kib} as the `elastic` user with the password that was generated
-when you started {es}.
-
-'''
-
-*Detached mode*
-
-Use this mode if you want to enroll {kib} without a browser, or want to enroll
-{kib} on a machine where you don't have access to a browser.
-
-Start {kib} and pass the generated enrollment token with the `--token`
-parameter.
-
-[source,shell]
+  * *Detached mode* (non-browser)
++
+Run the `kibana-setup` tool and pass the generated enrollment token with the 
+`--enrollment-token` parameter.
++  
+["source","sh",subs="attributes"]
 ----
-bin/kibana_setup --token <enrollment-token>
+bin/kibana-setup --enrollment-token <enrollment-token>
 ----
---
 
 [discrete]
 [[stack-enroll-nodes]]


### PR DESCRIPTION
A user on the [Elastic forums](https://discuss.elastic.co/t/using-token-to-enrol-kibana-without-a-local-browser/302426/2) indicated that we do not document how to enroll Kibana with Elasticsearch in detached mode. This PR adds support for enrolling Kibana without a browser.

Preview link: https://elasticsearch_85933.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/configuring-stack-security.html