### PR TITLE
Remove Terminal.readSecret with max length

### DIFF
--- a/distribution/tools/keystore-cli/src/test/java/org/elasticsearch/cli/keystore/BootstrapTests.java
+++ b/distribution/tools/keystore-cli/src/test/java/org/elasticsearch/cli/keystore/BootstrapTests.java
@@ -34,8 +34,6 @@ public class BootstrapTests extends ESTestCase {
     Environment env;
     List<FileSystem> fileSystems = new ArrayList<>();
 
-    private static final int MAX_PASSPHRASE_LENGTH = 10;
-
     @After
     public void closeMockFileSystems() throws IOException {
         IOUtils.close(fileSystems);
@@ -80,31 +78,20 @@ public class BootstrapTests extends ESTestCase {
         assertPassphraseRead("hello\r\nhi\r\n", "hello");
     }
 
-    public void testPassphraseTooLong() throws Exception {
-        byte[] source = "hellohello!\n".getBytes(StandardCharsets.UTF_8);
-        try (InputStream stream = new ByteArrayInputStream(source)) {
-            expectThrows(
-                RuntimeException.class,
-                "Password exceeded maximum length of 10",
-                () -> BootstrapUtil.readPassphrase(stream, MAX_PASSPHRASE_LENGTH)
-            );
-        }
-    }
-
     public void testNoPassPhraseProvided() throws Exception {
         byte[] source = "\r\n".getBytes(StandardCharsets.UTF_8);
         try (InputStream stream = new ByteArrayInputStream(source)) {
             expectThrows(
                 RuntimeException.class,
                 "Keystore passphrase required but none provided.",
-                () -> BootstrapUtil.readPassphrase(stream, MAX_PASSPHRASE_LENGTH)
+                () -> BootstrapUtil.readPassphrase(stream)
             );
         }
     }
 
     private void assertPassphraseRead(String source, String expected) {
         try (InputStream stream = new ByteArrayInputStream(source.getBytes(StandardCharsets.UTF_8))) {
-            SecureString result = BootstrapUtil.readPassphrase(stream, MAX_PASSPHRASE_LENGTH);
+            SecureString result = BootstrapUtil.readPassphrase(stream);
             assertThat(result, equalTo(expected));
         } catch (IOException e) {
             throw new RuntimeException(e);

--- a/server/src/main/java/org/elasticsearch/bootstrap/BootstrapUtil.java
+++ b/server/src/main/java/org/elasticsearch/bootstrap/BootstrapUtil.java
@@ -31,16 +31,11 @@ public class BootstrapUtil {
      * Read from an InputStream up to the first carriage return or newline,
      * returning no more than maxLength characters.
      */
-    public static SecureString readPassphrase(InputStream stream, int maxLength) throws IOException {
+    public static SecureString readPassphrase(InputStream stream) throws IOException {
         SecureString passphrase;
 
         try (InputStreamReader reader = new InputStreamReader(stream, StandardCharsets.UTF_8)) {
-            passphrase = new SecureString(Terminal.readLineToCharArray(reader, maxLength));
-        } catch (RuntimeException e) {
-            if (e.getMessage().startsWith("Input exceeded maximum length")) {
-                throw new IllegalStateException("Password exceeded maximum length of " + maxLength, e);
-            }
-            throw e;
+            passphrase = new SecureString(Terminal.readLineToCharArray(reader));
         }
 
         if (passphrase.length() == 0) {
@@ -57,7 +52,7 @@ public class BootstrapUtil {
 
     public static SecureSettings loadSecureSettings(Environment initialEnv, InputStream stdin) throws BootstrapException {
         try {
-            return KeyStoreWrapper.bootstrap(initialEnv.configFile(), () -> readPassphrase(stdin, KeyStoreWrapper.MAX_PASSPHRASE_LENGTH));
+            return KeyStoreWrapper.bootstrap(initialEnv.configFile(), () -> readPassphrase(stdin));
         } catch (Exception e) {
             throw new BootstrapException(e);
         }

--- a/server/src/main/java/org/elasticsearch/bootstrap/plugins/LoggerTerminal.java
+++ b/server/src/main/java/org/elasticsearch/bootstrap/plugins/LoggerTerminal.java
@@ -48,11 +48,6 @@ public final class LoggerTerminal extends Terminal {
     }
 
     @Override
-    public char[] readSecret(String prompt, int maxLength) {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
     public PrintWriter getWriter() {
         throw new UnsupportedOperationException();
     }

--- a/server/src/main/java/org/elasticsearch/common/cli/KeyStoreAwareCommand.java
+++ b/server/src/main/java/org/elasticsearch/common/cli/KeyStoreAwareCommand.java
@@ -42,9 +42,7 @@ public abstract class KeyStoreAwareCommand extends EnvironmentAwareCommand {
     protected static SecureString readPassword(Terminal terminal, boolean withVerification) throws UserException {
         final char[] passwordArray;
         if (withVerification) {
-            passwordArray = terminal.readSecret(
-                "Enter new password for the elasticsearch keystore (empty for no password): "
-            );
+            passwordArray = terminal.readSecret("Enter new password for the elasticsearch keystore (empty for no password): ");
             char[] passwordVerification = terminal.readSecret("Enter same password again: ");
             if (Arrays.equals(passwordArray, passwordVerification) == false) {
                 throw new UserException(ExitCodes.DATA_ERROR, "Passwords are not equal, exiting.");

--- a/server/src/main/java/org/elasticsearch/common/cli/KeyStoreAwareCommand.java
+++ b/server/src/main/java/org/elasticsearch/common/cli/KeyStoreAwareCommand.java
@@ -43,10 +43,9 @@ public abstract class KeyStoreAwareCommand extends EnvironmentAwareCommand {
         final char[] passwordArray;
         if (withVerification) {
             passwordArray = terminal.readSecret(
-                "Enter new password for the elasticsearch keystore (empty for no password): ",
-                KeyStoreWrapper.MAX_PASSPHRASE_LENGTH
+                "Enter new password for the elasticsearch keystore (empty for no password): "
             );
-            char[] passwordVerification = terminal.readSecret("Enter same password again: ", KeyStoreWrapper.MAX_PASSPHRASE_LENGTH);
+            char[] passwordVerification = terminal.readSecret("Enter same password again: ");
             if (Arrays.equals(passwordArray, passwordVerification) == false) {
                 throw new UserException(ExitCodes.DATA_ERROR, "Passwords are not equal, exiting.");
             }

--- a/server/src/main/java/org/elasticsearch/common/settings/KeyStoreWrapper.java
+++ b/server/src/main/java/org/elasticsearch/common/settings/KeyStoreWrapper.java
@@ -54,7 +54,6 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.regex.Pattern;
-
 import javax.crypto.AEADBadTagException;
 import javax.crypto.Cipher;
 import javax.crypto.CipherInputStream;
@@ -74,9 +73,6 @@ import javax.crypto.spec.SecretKeySpec;
  * in a single thread. Once decrypted, settings may be read in multiple threads.
  */
 public class KeyStoreWrapper implements SecureSettings {
-
-    /** Arbitrarily chosen maximum passphrase length */
-    public static final int MAX_PASSPHRASE_LENGTH = 128;
 
     /** An identifier for the type of data that may be stored in a keystore entry. */
     private enum EntryType {

--- a/server/src/main/java/org/elasticsearch/common/settings/KeyStoreWrapper.java
+++ b/server/src/main/java/org/elasticsearch/common/settings/KeyStoreWrapper.java
@@ -54,6 +54,7 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.regex.Pattern;
+
 import javax.crypto.AEADBadTagException;
 import javax.crypto.Cipher;
 import javax.crypto.CipherInputStream;

--- a/x-pack/plugin/security/cli/src/main/java/org/elasticsearch/xpack/security/cli/AutoConfigureNode.java
+++ b/x-pack/plugin/security/cli/src/main/java/org/elasticsearch/xpack/security/cli/AutoConfigureNode.java
@@ -92,6 +92,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+
 import javax.security.auth.x500.X500Principal;
 
 import static org.elasticsearch.common.ssl.PemUtils.parsePKCS8PemString;
@@ -1251,9 +1252,7 @@ public class AutoConfigureNode extends EnvironmentAwareCommand {
             try (
                 KeyStoreWrapper existingKeystore = KeyStoreWrapper.load(env.configFile());
                 SecureString keystorePassword = existingKeystore.hasPassword()
-                    ? new SecureString(
-                        terminal.readSecret("Enter password for the elasticsearch keystore: ")
-                    )
+                    ? new SecureString(terminal.readSecret("Enter password for the elasticsearch keystore: "))
                     : new SecureString(new char[0]);
             ) {
                 existingKeystore.decrypt(keystorePassword.getChars());

--- a/x-pack/plugin/security/cli/src/main/java/org/elasticsearch/xpack/security/cli/AutoConfigureNode.java
+++ b/x-pack/plugin/security/cli/src/main/java/org/elasticsearch/xpack/security/cli/AutoConfigureNode.java
@@ -92,7 +92,6 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-
 import javax.security.auth.x500.X500Principal;
 
 import static org.elasticsearch.common.ssl.PemUtils.parsePKCS8PemString;
@@ -509,7 +508,7 @@ public class AutoConfigureNode extends EnvironmentAwareCommand {
 
         final SetOnce<SecureString> nodeKeystorePassword = new SetOnce<>();
         try (KeyStoreWrapper nodeKeystore = KeyStoreWrapper.bootstrap(env.configFile(), () -> {
-            nodeKeystorePassword.set(new SecureString(terminal.readSecret("", KeyStoreWrapper.MAX_PASSPHRASE_LENGTH)));
+            nodeKeystorePassword.set(new SecureString(terminal.readSecret("")));
             return nodeKeystorePassword.get().clone();
         })) {
             // do not overwrite keystore entries
@@ -1253,7 +1252,7 @@ public class AutoConfigureNode extends EnvironmentAwareCommand {
                 KeyStoreWrapper existingKeystore = KeyStoreWrapper.load(env.configFile());
                 SecureString keystorePassword = existingKeystore.hasPassword()
                     ? new SecureString(
-                        terminal.readSecret("Enter password for the elasticsearch keystore: ", KeyStoreWrapper.MAX_PASSPHRASE_LENGTH)
+                        terminal.readSecret("Enter password for the elasticsearch keystore: ")
                     )
                     : new SecureString(new char[0]);
             ) {


### PR DESCRIPTION
The Terminal class currently has two variants of readSecret, one that is
similar to Console.readPassword, and another that takes a maximum length
to read. This second variant was originally added as a protection when
reading the keystore password. However, there are no other uses of it,
and the passphrase has already been fully read in bin/elasticsearch by
the time it is read from Terminal, so it shouldn't be possible to
actually hit this edge case. This commit removes the maxLength variant.

relates #85758