### PR TITLE
[DOCS] Add tagged section in breaking changes

### DIFF
--- a/docs/reference/migration/migrate_8_2.asciidoc
+++ b/docs/reference/migration/migrate_8_2.asciidoc
@@ -13,6 +13,10 @@ See also <<release-highlights>> and <<es-release-notes>>.
 [[breaking-changes-8.2]]
 === Breaking changes
 
-coming::[8.2.0-SNAPSHOT]
+// NOTE: The notable-breaking-changes tagged regions are re-used in the
+// Installation and Upgrade Guide
+// tag::notable-breaking-changes[]
 
+coming::[8.2.0]
 
+// end::notable-breaking-changes[]


### PR DESCRIPTION
This PR adds the tagged section necessary for use in https://www.elastic.co/guide/en/elastic-stack/8.2/elasticsearch-breaking-changes.html

Relates to https://github.com/elastic/elasticsearch/pull/85664#issuecomment-1087257141