### PR TITLE
[8.2] Remove references to bootstrap.system_call_filter (#85964)

### DIFF
--- a/docs/reference/setup/bootstrap-checks.asciidoc
+++ b/docs/reference/setup/bootstrap-checks.asciidoc
@@ -194,10 +194,9 @@ filters are installed to prevent the ability to execute system calls
 related to forking as a defense mechanism against arbitrary code
 execution attacks on Elasticsearch. The system call filter check ensures
 that if system call filters are enabled, then they were successfully
-installed. To pass the system call filter check you must either fix any
+installed. To pass the system call filter check you must fix any
 configuration errors on your system that prevented system call filters
-from installing (check your logs), or *at your own risk* disable system
-call filters by setting `bootstrap.system_call_filter` to `false`.
+from installing (check your logs).
 
 === OnError and OnOutOfMemoryError checks
 

--- a/server/src/main/java/org/elasticsearch/bootstrap/BootstrapSettings.java
+++ b/server/src/main/java/org/elasticsearch/bootstrap/BootstrapSettings.java
@@ -23,12 +23,7 @@ public final class BootstrapSettings {
     );
 
     public static final Setting<Boolean> MEMORY_LOCK_SETTING = Setting.boolSetting("bootstrap.memory_lock", false, Property.NodeScope);
-    public static final Setting<Boolean> SYSTEM_CALL_FILTER_SETTING = Setting.boolSetting(
-        "bootstrap.system_call_filter",
-        true,
-        Property.DeprecatedWarning,
-        Property.NodeScope
-    );
+
     public static final Setting<Boolean> CTRLHANDLER_SETTING = Setting.boolSetting("bootstrap.ctrlhandler", true, Property.NodeScope);
 
 }

--- a/server/src/test/java/org/elasticsearch/bootstrap/BootstrapChecksTests.java
+++ b/server/src/test/java/org/elasticsearch/bootstrap/BootstrapChecksTests.java
@@ -447,12 +447,7 @@ public class BootstrapChecksTests extends AbstractBootstrapCheckTestCase {
 
     public void testSystemCallFilterCheck() throws NodeValidationException {
         final AtomicBoolean isSystemCallFilterInstalled = new AtomicBoolean();
-        final BootstrapContext context;
-        if (randomBoolean()) {
-            context = createTestContext(Settings.builder().put("bootstrap.system_call_filter", true).build(), null);
-        } else {
-            context = emptyContext;
-        }
+        final BootstrapContext context = emptyContext;
 
         final BootstrapChecks.SystemCallFilterCheck systemCallFilterEnabledCheck = new BootstrapChecks.SystemCallFilterCheck() {
 


### PR DESCRIPTION
Backports the following commits to 8.2:
 - Remove references to bootstrap.system_call_filter (#85964)