### PR TITLE
Relax data path deprecations from critical to warn (#85952)

### DIFF
--- a/docs/changelog/85952.yaml
+++ b/docs/changelog/85952.yaml
@@ -1,0 +1,5 @@
+pr: 85952
+summary: Relax data path deprecations from critical to warn
+area: Infra/Core
+type: bug
+issues: []

--- a/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/NodeDeprecationChecks.java
+++ b/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/NodeDeprecationChecks.java
@@ -691,7 +691,7 @@ class NodeDeprecationChecks {
                 "Remove the [%s] setting. This setting has had no effect since 6.0.",
                 Environment.PATH_SHARED_DATA_SETTING.getKey()
             );
-            return new DeprecationIssue(DeprecationIssue.Level.CRITICAL, message, url, details, false, null);
+            return new DeprecationIssue(DeprecationIssue.Level.WARNING, message, url, details, false, null);
         }
         return null;
     }

--- a/x-pack/plugin/deprecation/src/test/java/org/elasticsearch/xpack/deprecation/IndexDeprecationChecksTests.java
+++ b/x-pack/plugin/deprecation/src/test/java/org/elasticsearch/xpack/deprecation/IndexDeprecationChecksTests.java
@@ -727,7 +727,7 @@ public class IndexDeprecationChecksTests extends ESTestCase {
             contains(
                 new DeprecationIssue(
                     DeprecationIssue.Level.WARNING,
-                    "Setting [index.data_path] is deprecated",
+                    "setting [index.data_path] is deprecated and will be removed in a future version",
                     expectedUrl,
                     "Remove the [index.data_path] setting. This setting has had no effect since 6.0.",
                     false,

--- a/x-pack/plugin/deprecation/src/test/java/org/elasticsearch/xpack/deprecation/IndexDeprecationChecksTests.java
+++ b/x-pack/plugin/deprecation/src/test/java/org/elasticsearch/xpack/deprecation/IndexDeprecationChecksTests.java
@@ -727,7 +727,7 @@ public class IndexDeprecationChecksTests extends ESTestCase {
             contains(
                 new DeprecationIssue(
                     DeprecationIssue.Level.WARNING,
-                    "setting [index.data_path] is deprecated and will be removed in a future version",
+                    "setting [index.data_path] is deprecated",
                     expectedUrl,
                     "Remove the [index.data_path] setting. This setting has had no effect since 6.0.",
                     false,

--- a/x-pack/plugin/deprecation/src/test/java/org/elasticsearch/xpack/deprecation/IndexDeprecationChecksTests.java
+++ b/x-pack/plugin/deprecation/src/test/java/org/elasticsearch/xpack/deprecation/IndexDeprecationChecksTests.java
@@ -727,7 +727,7 @@ public class IndexDeprecationChecksTests extends ESTestCase {
             contains(
                 new DeprecationIssue(
                     DeprecationIssue.Level.WARNING,
-                    "setting [index.data_path] is deprecated",
+                    "Setting [index.data_path] is deprecated",
                     expectedUrl,
                     "Remove the [index.data_path] setting. This setting has had no effect since 6.0.",
                     false,

--- a/x-pack/plugin/deprecation/src/test/java/org/elasticsearch/xpack/deprecation/NodeDeprecationChecksTests.java
+++ b/x-pack/plugin/deprecation/src/test/java/org/elasticsearch/xpack/deprecation/NodeDeprecationChecksTests.java
@@ -784,7 +784,7 @@ public class NodeDeprecationChecksTests extends ESTestCase {
             issue,
             equalTo(
                 new DeprecationIssue(
-                    DeprecationIssue.Level.CRITICAL,
+                    DeprecationIssue.Level.WARNING,
                     "Setting [path.shared_data] is deprecated",
                     expectedUrl,
                     "Remove the [path.shared_data] setting. This setting has had no effect since 6.0.",


### PR DESCRIPTION
The deprecations for index and shared data paths were defined at
critical level, but these are not removed in 8.0. This commit relaxes
these deprecation messages so they are just warnings.

relates #85695