### PR TITLE
Remove oldState from ILM's onClusterStateProcessed

### DIFF
--- a/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/ExecuteStepsUpdateTask.java
+++ b/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/ExecuteStepsUpdateTask.java
@@ -220,7 +220,7 @@ public class ExecuteStepsUpdateTask extends IndexLifecycleClusterStateUpdateTask
     }
 
     @Override
-    public void onClusterStateProcessed(ClusterState oldState, ClusterState newState) {
+    public void onClusterStateProcessed(ClusterState newState) {
         final Metadata metadata = newState.metadata();
         final IndexMetadata indexMetadata = metadata.index(index);
         if (indexMetadata != null) {

--- a/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/IndexLifecycleClusterStateUpdateTask.java
+++ b/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/IndexLifecycleClusterStateUpdateTask.java
@@ -56,7 +56,7 @@ public abstract class IndexLifecycleClusterStateUpdateTask implements ClusterSta
     public final void clusterStateProcessed(ClusterState oldState, ClusterState newState) {
         listener.onResponse(null);
         if (executed) {
-            onClusterStateProcessed(oldState, newState);
+            onClusterStateProcessed(newState);
         }
     }
 
@@ -68,7 +68,7 @@ public abstract class IndexLifecycleClusterStateUpdateTask implements ClusterSta
 
     /**
      * Add a listener that is resolved once this update has been processed or failed and before either the
-     * {@link #onClusterStateProcessed(ClusterState, ClusterState)} or the {@link #handleFailure(Exception)} hooks are
+     * {@link #onClusterStateProcessed(ClusterState)} or the {@link #handleFailure(Exception)} hooks are
      * executed.
      */
     public final void addListener(ActionListener<Void> actionListener) {
@@ -79,10 +79,9 @@ public abstract class IndexLifecycleClusterStateUpdateTask implements ClusterSta
      * This method is functionally the same as {@link ClusterStateTaskListener#clusterStateProcessed(ClusterState, ClusterState)}
      * and implementations can override it as they would override {@code ClusterStateUpdateTask#clusterStateProcessed}.
      * The only difference to  {@code ClusterStateUpdateTask#clusterStateProcessed} is that if the {@link #execute(ClusterState)}
-     * implementation was a noop and returned the input cluster state, then this method will not be invoked. It is therefore guaranteed
-     * that {@code oldState} is always different from {@code newState}.
+     * implementation was a noop and returned the input cluster state, then this method will not be invoked.
      */
-    protected void onClusterStateProcessed(ClusterState oldState, ClusterState newState) {}
+    protected void onClusterStateProcessed(ClusterState newState) {}
 
     @Override
     public abstract boolean equals(Object other);

--- a/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/MoveToErrorStepUpdateTask.java
+++ b/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/MoveToErrorStepUpdateTask.java
@@ -74,7 +74,7 @@ public class MoveToErrorStepUpdateTask extends IndexLifecycleClusterStateUpdateT
     }
 
     @Override
-    public void onClusterStateProcessed(ClusterState oldState, ClusterState newState) {
+    public void onClusterStateProcessed(ClusterState newState) {
         stateChangeConsumer.accept(newState);
     }
 

--- a/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/MoveToNextStepUpdateTask.java
+++ b/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/MoveToNextStepUpdateTask.java
@@ -66,7 +66,7 @@ public class MoveToNextStepUpdateTask extends IndexLifecycleClusterStateUpdateTa
     }
 
     @Override
-    public void onClusterStateProcessed(ClusterState oldState, ClusterState newState) {
+    public void onClusterStateProcessed(ClusterState newState) {
         stateChangeConsumer.accept(newState);
     }
 


### PR DESCRIPTION
Relying on the original cluster state during publication completion
handling is incompatible with proper batching. ILM's
`IndexLifecycleClusterStateUpdateTask` passes the original state into
its custom `onClusterStateProcessed` method, but none of the
implementations use it. This commit removes this unused parameter.