### PR TITLE
Ignore missing JDK 18 java.desktop finalize methods

### DIFF
--- a/build-tools-internal/src/main/resources/forbidden/jdk-deprecated.txt
+++ b/build-tools-internal/src/main/resources/forbidden/jdk-deprecated.txt
@@ -9,7 +9,6 @@
 # This file contains all public, deprecated API signatures in Java version 17 (extracted from build 17).
 
 @ignoreMissingClasses
-@ignoreUnresolvable
 @defaultMessage Deprecated in Java 17
 
 java.applet.Applet
@@ -142,7 +141,6 @@ java.awt.Window#hide()
 java.awt.Window#postEvent(java.awt.Event)
 java.awt.Window#reshape(int,int,int,int)
 java.awt.Window#show()
-java.awt.color.ICC_Profile#finalize() # removed in Java 18
 java.awt.datatransfer.DataFlavor#equals(java.lang.String)
 java.awt.datatransfer.DataFlavor#normalizeMimeType(java.lang.String)
 java.awt.datatransfer.DataFlavor#normalizeMimeTypeParameter(java.lang.String,java.lang.String)
@@ -159,8 +157,6 @@ java.awt.event.InputEvent#getModifiers()
 java.awt.event.KeyEvent#<init>(java.awt.Component,int,long,int,int)
 java.awt.event.KeyEvent#getKeyModifiersText(int)
 java.awt.event.KeyEvent#setModifiers(int)
-java.awt.image.ColorModel#finalize() # removed in Java 18
-java.awt.image.IndexColorModel#finalize() # removed in Java 18
 java.awt.image.renderable.RenderContext#concetenateTransform(java.awt.geom.AffineTransform)
 java.awt.image.renderable.RenderContext#preConcetenateTransform(java.awt.geom.AffineTransform)
 java.beans.AppletInitializer

--- a/build-tools-internal/src/main/resources/forbidden/jdk-deprecated.txt
+++ b/build-tools-internal/src/main/resources/forbidden/jdk-deprecated.txt
@@ -9,6 +9,7 @@
 # This file contains all public, deprecated API signatures in Java version 17 (extracted from build 17).
 
 @ignoreMissingClasses
+@ignoreUnresolvable
 @defaultMessage Deprecated in Java 17
 
 java.applet.Applet
@@ -141,7 +142,7 @@ java.awt.Window#hide()
 java.awt.Window#postEvent(java.awt.Event)
 java.awt.Window#reshape(int,int,int,int)
 java.awt.Window#show()
-java.awt.color.ICC_Profile#finalize()
+java.awt.color.ICC_Profile#finalize() # removed in Java 18
 java.awt.datatransfer.DataFlavor#equals(java.lang.String)
 java.awt.datatransfer.DataFlavor#normalizeMimeType(java.lang.String)
 java.awt.datatransfer.DataFlavor#normalizeMimeTypeParameter(java.lang.String,java.lang.String)
@@ -158,8 +159,8 @@ java.awt.event.InputEvent#getModifiers()
 java.awt.event.KeyEvent#<init>(java.awt.Component,int,long,int,int)
 java.awt.event.KeyEvent#getKeyModifiersText(int)
 java.awt.event.KeyEvent#setModifiers(int)
-java.awt.image.ColorModel#finalize()
-java.awt.image.IndexColorModel#finalize()
+java.awt.image.ColorModel#finalize() # removed in Java 18
+java.awt.image.IndexColorModel#finalize() # removed in Java 18
 java.awt.image.renderable.RenderContext#concetenateTransform(java.awt.geom.AffineTransform)
 java.awt.image.renderable.RenderContext#preConcetenateTransform(java.awt.geom.AffineTransform)
 java.beans.AppletInitializer


### PR DESCRIPTION
This change allows to build ES with JDK 18. Prior to this change the build fails because of missing java.desktop finalize methods, during the processing of the forbidden deprecated APIs list.

JDK 18 removed a number of deprecated-for-removal empty finalize() in java.desktop module, see https://bugs.openjdk.java.net/browse/JDK-8273103 

closes #85992