### PR TITLE
Fix handling security manager in tests with java 17

### DIFF
--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/ElasticsearchTestBasePlugin.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/ElasticsearchTestBasePlugin.java
@@ -99,7 +99,7 @@ public class ElasticsearchTestBasePlugin implements Plugin<Project> {
                             "--add-opens=java.management/java.lang.management=ALL-UNNAMED"
                         );
                     }
-                    if (BuildParams.getRuntimeJavaVersion().isCompatibleWith(JavaVersion.VERSION_18)) {
+                    if (BuildParams.getRuntimeJavaVersion().isCompatibleWith(JavaVersion.VERSION_17)) {
                         test.jvmArgs("-Djava.security.manager=allow");
                     }
                 }


### PR DESCRIPTION
This fixes test failures caused by setting a security manager in our tests when using java 17