### PR TITLE
Fix double-close at reboot in CoordinatorTests

### DIFF
--- a/test/framework/src/main/java/org/elasticsearch/cluster/coordination/AbstractCoordinatorTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/cluster/coordination/AbstractCoordinatorTestCase.java
@@ -1860,8 +1860,9 @@ public class AbstractCoordinatorTestCase extends ESTestCase {
 
                 @Override
                 public void close() {
-                    innerRef.close();
-                    trackedRefs.remove(this);
+                    if (trackedRefs.remove(this)) {
+                        innerRef.close();
+                    }
                 }
             };
             trackedRefs.add(trackedRef);


### PR DESCRIPTION
Simulated reboots release any outstanding recyclable pages, but it's
possible that we've enqueued an action which releases one of these pages
too. This commit ensures that each page is released at most once.

Closes #86005