### PR TITLE
Remove hppc from percentiles agg

### DIFF
--- a/server/src/main/java/org/elasticsearch/search/aggregations/pipeline/PercentilesBucketPipelineAggregationBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/pipeline/PercentilesBucketPipelineAggregationBuilder.java
@@ -156,7 +156,7 @@ public class PercentilesBucketPipelineAggregationBuilder extends BucketMetricsPi
                 while (parser.nextToken() != XContentParser.Token.END_ARRAY) {
                     percents.add(parser.doubleValue());
                 }
-                params.put(PERCENTS_FIELD.getPreferredName(), percents.toArray());
+                params.put(PERCENTS_FIELD.getPreferredName(), percents.stream().mapToDouble(Double::doubleValue).toArray());
                 return true;
             } else if (KEYED_FIELD.match(field, parser.getDeprecationHandler()) && token == XContentParser.Token.VALUE_BOOLEAN) {
                 params.put(KEYED_FIELD.getPreferredName(), parser.booleanValue());

--- a/server/src/main/java/org/elasticsearch/search/aggregations/pipeline/PercentilesBucketPipelineAggregationBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/pipeline/PercentilesBucketPipelineAggregationBuilder.java
@@ -8,8 +8,6 @@
 
 package org.elasticsearch.search.aggregations.pipeline;
 
-import com.carrotsearch.hppc.DoubleArrayList;
-
 import org.elasticsearch.Version;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -18,7 +16,9 @@ import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xcontent.XContentParser;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
@@ -152,7 +152,7 @@ public class PercentilesBucketPipelineAggregationBuilder extends BucketMetricsPi
         protected boolean token(XContentParser parser, String field, XContentParser.Token token, Map<String, Object> params)
             throws IOException {
             if (PERCENTS_FIELD.match(field, parser.getDeprecationHandler()) && token == XContentParser.Token.START_ARRAY) {
-                DoubleArrayList percents = new DoubleArrayList(10);
+                List<Double> percents = new ArrayList<>(10);
                 while (parser.nextToken() != XContentParser.Token.END_ARRAY) {
                     percents.add(parser.doubleValue());
                 }


### PR DESCRIPTION
The percentiles bucket agg uses an hppc arraylist of doubles to store
the parsed percent values. This is a very small list and does not need
to be a native array. This commit changes to using a standard ArrayList.

relates #84735