### PR TITLE
[7.17] Apply precommit checks for non productive projects (#85533)

### DIFF
--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/InternalPluginBuildPlugin.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/InternalPluginBuildPlugin.java
@@ -8,6 +8,7 @@
 
 package org.elasticsearch.gradle.internal;
 
+import org.elasticsearch.gradle.internal.precommit.TestingConventionsPrecommitPlugin;
 import org.elasticsearch.gradle.internal.precommit.TestingConventionsTasks;
 import org.gradle.api.Project;
 
@@ -17,15 +18,19 @@ public class InternalPluginBuildPlugin implements InternalPlugin {
         project.getPluginManager().apply(BuildPlugin.class);
         project.getPluginManager().apply(BaseInternalPluginBuildPlugin.class);
 
-        project.getTasks().withType(TestingConventionsTasks.class).named("testingConventions").configure(t -> {
-            t.getNaming().clear();
-            t.getNaming()
-                .create("Tests", testingConventionRule -> testingConventionRule.baseClass("org.apache.lucene.util.LuceneTestCase"));
-            t.getNaming().create("IT", testingConventionRule -> {
-                testingConventionRule.baseClass("org.elasticsearch.test.ESIntegTestCase");
-                testingConventionRule.baseClass("org.elasticsearch.test.rest.ESRestTestCase");
-                testingConventionRule.baseClass("org.elasticsearch.test.ESSingleNodeTestCase");
-            });
-        });
+        project.getPlugins()
+            .withType(
+                TestingConventionsPrecommitPlugin.class,
+                plugin -> project.getTasks().withType(TestingConventionsTasks.class).named("testingConventions").configure(t -> {
+                    t.getNaming().clear();
+                    t.getNaming()
+                        .create("Tests", testingConventionRule -> testingConventionRule.baseClass("org.apache.lucene.util.LuceneTestCase"));
+                    t.getNaming().create("IT", testingConventionRule -> {
+                        testingConventionRule.baseClass("org.elasticsearch.test.ESIntegTestCase");
+                        testingConventionRule.baseClass("org.elasticsearch.test.rest.ESRestTestCase");
+                        testingConventionRule.baseClass("org.elasticsearch.test.ESSingleNodeTestCase");
+                    });
+                })
+            );
     }
 }

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/precommit/FilePermissionsPrecommitPlugin.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/precommit/FilePermissionsPrecommitPlugin.java
@@ -32,16 +32,19 @@ public class FilePermissionsPrecommitPlugin extends PrecommitPlugin implements I
 
     @Override
     public TaskProvider<? extends Task> createTask(Project project) {
-        return project.getTasks()
-            .register(
-                FILEPERMISSIONS_TASK_NAME,
-                FilePermissionsTask.class,
-                filePermissionsTask -> filePermissionsTask.getSources()
-                    .addAll(
-                        providerFactory.provider(
-                            () -> GradleUtils.getJavaSourceSets(project).stream().map(s -> s.getAllSource()).collect(Collectors.toList())
-                        )
+        return project.getTasks().register(FILEPERMISSIONS_TASK_NAME, FilePermissionsTask.class, t -> {
+            t.getSources()
+                .addAll(
+                    providerFactory.provider(
+                        () -> GradleUtils.getJavaSourceSets(project).stream().map(s -> s.getAllSource()).collect(Collectors.toList())
                     )
+                );
+            t.dependsOn(
+                GradleUtils.getJavaSourceSets(project)
+                    .stream()
+                    .map(sourceSet -> sourceSet.getProcessResourcesTaskName())
+                    .collect(Collectors.toList())
             );
+        });
     }
 }

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/precommit/ForbiddenPatternsPrecommitPlugin.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/precommit/ForbiddenPatternsPrecommitPlugin.java
@@ -39,6 +39,12 @@ public class ForbiddenPatternsPrecommitPlugin extends PrecommitPlugin implements
                         () -> GradleUtils.getJavaSourceSets(project).stream().map(s -> s.getAllSource()).collect(Collectors.toList())
                     )
                 );
+            forbiddenPatternsTask.dependsOn(
+                GradleUtils.getJavaSourceSets(project)
+                    .stream()
+                    .map(sourceSet -> sourceSet.getProcessResourcesTaskName())
+                    .collect(Collectors.toList())
+            );
             forbiddenPatternsTask.getRootDir().set(project.getRootDir());
         });
     }

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/precommit/ForbiddenPatternsTask.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/precommit/ForbiddenPatternsTask.java
@@ -66,6 +66,7 @@ public abstract class ForbiddenPatternsTask extends DefaultTask {
         .exclude("**/*.zip")
         .exclude("**/*.jks")
         .exclude("**/*.crt")
+        .exclude("**/*.p12")
         .exclude("**/*.keystore")
         .exclude("**/*.png")
         // vim swap file - included here to stop the build falling over if you happen to have a file open :-|

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/precommit/InternalPrecommitTasks.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/precommit/InternalPrecommitTasks.java
@@ -25,13 +25,22 @@ public class InternalPrecommitTasks {
         project.getPluginManager().apply(ForbiddenPatternsPrecommitPlugin.class);
         project.getPluginManager().apply(LicenseHeadersPrecommitPlugin.class);
         project.getPluginManager().apply(FilePermissionsPrecommitPlugin.class);
-        project.getPluginManager().apply(TestingConventionsPrecommitPlugin.class);
         project.getPluginManager().apply(LoggerUsagePrecommitPlugin.class);
-        project.getPluginManager().apply(JarHellPrecommitPlugin.class);
+
+        // TestingConventionsPlugin is incompatible with projects without
+        // test source sets. We wanna remove this plugin once we moved away from
+        // StandaloneRestTest plugin and RestTestPlugin. For apply this plugin only
+        // when tests are available.
+        // Long Term we want remove the need for most of this plugins functionality
+        // and not rely on multiple test tasks against a sourceSet.
+        if (project.file("src/test").exists()) {
+            project.getPluginManager().apply(TestingConventionsPrecommitPlugin.class);
+        }
 
         // tasks with just tests don't need certain tasks to run, so this flag makes adding
         // the task optional
         if (withProductiveCode) {
+            project.getPluginManager().apply(JarHellPrecommitPlugin.class);
             project.getPluginManager().apply(ThirdPartyAuditPrecommitPlugin.class);
             project.getPluginManager().apply(DependencyLicensesPrecommitPlugin.class);
             project.getPluginManager().apply(SplitPackagesAuditPrecommitPlugin.class);

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/test/RestTestBasePlugin.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/test/RestTestBasePlugin.java
@@ -12,6 +12,7 @@ import org.elasticsearch.gradle.internal.ElasticsearchJavaBasePlugin;
 import org.elasticsearch.gradle.internal.ElasticsearchTestBasePlugin;
 import org.elasticsearch.gradle.internal.FixtureStop;
 import org.elasticsearch.gradle.internal.InternalTestClustersPlugin;
+import org.elasticsearch.gradle.internal.precommit.InternalPrecommitTasks;
 import org.elasticsearch.gradle.test.SystemPropertyCommandLineArgumentProvider;
 import org.elasticsearch.gradle.testclusters.ElasticsearchCluster;
 import org.elasticsearch.gradle.testclusters.StandaloneRestIntegTestTask;
@@ -44,6 +45,7 @@ public class RestTestBasePlugin implements Plugin<Project> {
         project.getPluginManager().apply(ElasticsearchJavaBasePlugin.class);
         project.getPluginManager().apply(ElasticsearchTestBasePlugin.class);
         project.getPluginManager().apply(InternalTestClustersPlugin.class);
+        InternalPrecommitTasks.create(project, false);
         project.getTasks().withType(RestIntegTestTask.class).configureEach(restIntegTestTask -> {
             @SuppressWarnings("unchecked")
             NamedDomainObjectContainer<ElasticsearchCluster> testClusters = (NamedDomainObjectContainer<ElasticsearchCluster>) project

--- a/modules/runtime-fields-common/build.gradle
+++ b/modules/runtime-fields-common/build.gradle
@@ -20,6 +20,3 @@ dependencies {
   api project(':libs:elasticsearch-grok')
   api project(':libs:elasticsearch-dissect')
 }
-
-//this plugin is here only for the painless extension, there are no unit tests
-tasks.named("testingConventions").configure { enabled = false }

--- a/test/x-content/build.gradle
+++ b/test/x-content/build.gradle
@@ -1,0 +1,67 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+apply plugin: 'elasticsearch.build'
+apply plugin: 'elasticsearch.publish'
+
+dependencies {
+  api project(":test:framework")
+  api project(":libs:elasticsearch-x-content")
+
+  // json schema validation dependencies
+  implementation "com.fasterxml.jackson.core:jackson-core:${versions.jackson}"
+  implementation "com.networknt:json-schema-validator:${versions.networknt_json_schema_validator}"
+  implementation "com.fasterxml.jackson.core:jackson-databind:${versions.jackson}"
+  implementation "com.fasterxml.jackson.core:jackson-annotations:${versions.jackson}"
+  implementation "org.apache.commons:commons-compress:1.21"
+  implementation "org.apache.commons:commons-lang3:${versions.commons_lang3}"
+}
+
+// the main files are actually test files, so use the appropriate forbidden api sigs
+tasks.named('forbiddenApisMain').configure {
+  replaceSignatureFiles 'jdk-signatures', 'es-all-signatures', 'es-test-signatures'
+}
+
+// TODO: should we have licenses for our test deps?
+tasks.named("dependencyLicenses").configure { enabled = false }
+tasks.named("dependenciesInfo").configure { enabled = false }
+tasks.named("dependenciesGraph").configure { enabled = false }
+
+tasks.named("thirdPartyAudit").configure {
+  ignoreMissingClasses(
+          // classes are missing
+          'com.github.luben.zstd.BufferPool',
+          'com.github.luben.zstd.ZstdInputStream',
+          'com.github.luben.zstd.ZstdOutputStream',
+          'org.brotli.dec.BrotliInputStream',
+          'org.jcodings.specific.UTF8Encoding',
+          'org.joni.Matcher',
+          'org.joni.Regex',
+          'org.joni.Syntax',
+          'org.objectweb.asm.AnnotationVisitor',
+          'org.objectweb.asm.Attribute',
+          'org.objectweb.asm.ClassReader',
+          'org.objectweb.asm.ClassVisitor',
+          'org.objectweb.asm.FieldVisitor',
+          'org.objectweb.asm.Label',
+          'org.objectweb.asm.MethodVisitor',
+          'org.objectweb.asm.Type',
+          'org.slf4j.Logger',
+          'org.slf4j.LoggerFactory',
+          'org.tukaani.xz.DeltaOptions',
+          'org.tukaani.xz.FilterOptions',
+          'org.tukaani.xz.LZMA2InputStream',
+          'org.tukaani.xz.LZMA2Options',
+          'org.tukaani.xz.LZMAInputStream',
+          'org.tukaani.xz.LZMAOutputStream',
+          'org.tukaani.xz.MemoryLimitException',
+          'org.tukaani.xz.UnsupportedOptionsException',
+          'org.tukaani.xz.XZ',
+          'org.tukaani.xz.XZOutputStream',
+  )
+}

--- a/x-pack/plugin/data-streams/qa/rest/src/yamlRestTest/java/org/elasticsearch/xpack/datastreams/AutoCreateDataStreamIT.java
+++ b/x-pack/plugin/data-streams/qa/rest/src/yamlRestTest/java/org/elasticsearch/xpack/datastreams/AutoCreateDataStreamIT.java
@@ -1,9 +1,8 @@
 /*
  * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
  * or more contributor license agreements. Licensed under the Elastic License
- * 2.0 and the Server Side Public License, v 1; you may not use this file except
- * in compliance with, at your election, the Elastic License 2.0 or the Server
- * Side Public License, v 1.
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
  */
 
 package org.elasticsearch.xpack.datastreams;

--- a/x-pack/plugin/eql/qa/security/src/javaRestTest/java/org/elasticsearch/xpack/eql/EqlRestValidationIT.java
+++ b/x-pack/plugin/eql/qa/security/src/javaRestTest/java/org/elasticsearch/xpack/eql/EqlRestValidationIT.java
@@ -1,3 +1,10 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
 package org.elasticsearch.xpack.eql;
 
 import org.elasticsearch.common.settings.Settings;

--- a/x-pack/plugin/ilm/qa/multi-node/src/javaRestTest/java/org/elasticsearch/xpack/ilm/actions/SearchableSnapshotActionIT.java
+++ b/x-pack/plugin/ilm/qa/multi-node/src/javaRestTest/java/org/elasticsearch/xpack/ilm/actions/SearchableSnapshotActionIT.java
@@ -95,7 +95,7 @@ public class SearchableSnapshotActionIT extends ESRestTestCase {
 
         createComposableTemplate(
             client(),
-            randomAlphaOfLengthBetween(5, 10).toLowerCase(),
+            randomAlphaOfLengthBetween(5, 10).toLowerCase(Locale.ROOT),
             dataStream,
             new Template(Settings.builder().put(LifecycleSettings.LIFECYCLE_NAME, policy).build(), null, null)
         );
@@ -126,7 +126,12 @@ public class SearchableSnapshotActionIT extends ESRestTestCase {
         createSnapshotRepo(client(), snapshotRepo, randomBoolean());
         createNewSingletonPolicy(client(), policy, "cold", new SearchableSnapshotAction(snapshotRepo, true));
 
-        createComposableTemplate(client(), randomAlphaOfLengthBetween(5, 10).toLowerCase(), dataStream, new Template(null, null, null));
+        createComposableTemplate(
+            client(),
+            randomAlphaOfLengthBetween(5, 10).toLowerCase(Locale.ROOT),
+            dataStream,
+            new Template(null, null, null)
+        );
 
         for (int i = 0; i < randomIntBetween(5, 10); i++) {
             indexDocument(client(), dataStream, true);
@@ -196,7 +201,7 @@ public class SearchableSnapshotActionIT extends ESRestTestCase {
 
         createComposableTemplate(
             client(),
-            randomAlphaOfLengthBetween(5, 10).toLowerCase(),
+            randomAlphaOfLengthBetween(5, 10).toLowerCase(Locale.ROOT),
             dataStream,
             new Template(Settings.builder().put(LifecycleSettings.LIFECYCLE_NAME, policy).build(), null, null)
         );
@@ -290,7 +295,7 @@ public class SearchableSnapshotActionIT extends ESRestTestCase {
 
         createComposableTemplate(
             client(),
-            randomAlphaOfLengthBetween(5, 10).toLowerCase(),
+            randomAlphaOfLengthBetween(5, 10).toLowerCase(Locale.ROOT),
             dataStream,
             new Template(
                 Settings.builder().put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 5).put(LifecycleSettings.LIFECYCLE_NAME, policy).build(),
@@ -382,7 +387,7 @@ public class SearchableSnapshotActionIT extends ESRestTestCase {
 
         createComposableTemplate(
             client(),
-            randomAlphaOfLengthBetween(5, 10).toLowerCase(),
+            randomAlphaOfLengthBetween(5, 10).toLowerCase(Locale.ROOT),
             dataStream,
             new Template(
                 Settings.builder().put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 5).put(LifecycleSettings.LIFECYCLE_NAME, policy).build(),
@@ -648,7 +653,7 @@ public class SearchableSnapshotActionIT extends ESRestTestCase {
 
         createComposableTemplate(
             client(),
-            randomAlphaOfLengthBetween(5, 10).toLowerCase(),
+            randomAlphaOfLengthBetween(5, 10).toLowerCase(Locale.ROOT),
             dataStream,
             new Template(
                 Settings.builder().put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1).put(LifecycleSettings.LIFECYCLE_NAME, policy).build(),
@@ -695,7 +700,7 @@ public class SearchableSnapshotActionIT extends ESRestTestCase {
 
         createComposableTemplate(
             client(),
-            randomAlphaOfLengthBetween(5, 10).toLowerCase(),
+            randomAlphaOfLengthBetween(5, 10).toLowerCase(Locale.ROOT),
             dataStream,
             new Template(Settings.builder().put(LifecycleSettings.LIFECYCLE_NAME, policy).build(), null, null)
         );

--- a/x-pack/plugin/searchable-snapshots/preallocate/build.gradle
+++ b/x-pack/plugin/searchable-snapshots/preallocate/build.gradle
@@ -12,5 +12,3 @@ archivesBaseName = 'preallocate'
 dependencies {
   compileOnly project(":server")
 }
-
-tasks.named("testingConventions").configure { enabled = false }

--- a/x-pack/plugin/sql/qa/jdbc/security/build.gradle
+++ b/x-pack/plugin/sql/qa/jdbc/security/build.gradle
@@ -47,6 +47,4 @@ subprojects {
     nonInputProperties.systemProperty 'tests.audit.yesterday.logfile',
       "${-> testClusters.integTest.singleNode().getAuditLog().getParentFile()}/integTest_audit-${new Date().format('yyyy-MM-dd')}.json"
   }
-
-  tasks.named("testingConventions").configure { enabled = false }
 }

--- a/x-pack/plugin/sql/qa/server/security/build.gradle
+++ b/x-pack/plugin/sql/qa/server/security/build.gradle
@@ -48,5 +48,4 @@ subprojects {
       "${-> testClusters.integTest.singleNode().getAuditLog().getParentFile()}/integTest_audit-${new Date().format('yyyy-MM-dd')}.json"
   }
 
-  tasks.named("testingConventions").configure { enabled = false }
 }

--- a/x-pack/plugin/src/test/java/org/elasticsearch/xpack/test/rest/AbstractXPackRestTest.java
+++ b/x-pack/plugin/src/test/java/org/elasticsearch/xpack/test/rest/AbstractXPackRestTest.java
@@ -42,7 +42,7 @@ import static java.util.Collections.singletonMap;
 /** Runs rest tests against external cluster */
 // TODO: Remove this timeout increase once this test suite is broken up
 @TimeoutSuite(millis = 60 * TimeUnits.MINUTE)
-public class AbstractXPackRestTest extends ESClientYamlSuiteTestCase {
+public abstract class AbstractXPackRestTest extends ESClientYamlSuiteTestCase {
     private static final String BASIC_AUTH_VALUE = basicAuthHeaderValue(
         "x_pack_rest_user",
         SecuritySettingsSourceField.TEST_PASSWORD_SECURE_STRING

--- a/x-pack/plugin/transform/qa/multi-node-tests/build.gradle
+++ b/x-pack/plugin/transform/qa/multi-node-tests/build.gradle
@@ -11,7 +11,7 @@ File keystoreDir = new File(project.buildDir, 'keystore')
 File nodeKey = file("$keystoreDir/testnode.pem")
 File nodeCert = file("$keystoreDir/testnode.crt")
 // Add key and certs to test classpath: it expects it there
-tasks.register("copyKeyCerts", Copy) {
+def copyKeyCerts = tasks.register("copyKeyCerts", Copy) {
   from(project(':x-pack:plugin:core').file('src/test/resources/org/elasticsearch/xpack/security/transport/ssl/certs/simple/')) {
     include 'testnode.crt', 'testnode.pem'
   }

--- a/x-pack/plugin/transform/qa/multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/LatestIT.java
+++ b/x-pack/plugin/transform/qa/multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/LatestIT.java
@@ -46,12 +46,12 @@ public class LatestIT extends TransformIntegTestCase {
 
     private static final String TRANSFORM_NAME = "transform-crud-latest";
 
-    private static final Integer getUserIdForRow(int row) {
+    private static Integer getUserIdForRow(int row) {
         int userId = row % (NUM_USERS + 1);
         return userId < NUM_USERS ? userId : null;
     }
 
-    private static final String getDateStringForRow(int row) {
+    private static String getDateStringForRow(int row) {
         int month = 1 + (row / 28);
         int day = 1 + (row % 28);
         return "2017-" + (month < 10 ? "0" + month : month) + "-" + (day < 10 ? "0" + day : day) + "T12:30:00Z";
@@ -64,7 +64,7 @@ public class LatestIT extends TransformIntegTestCase {
     private static final String STARS = "stars";
     private static final String COMMENT = "comment";
 
-    private static final Map<String, Object> row(String userId, String businessId, int count, int stars, String timestamp, String comment) {
+    private static Map<String, Object> row(String userId, String businessId, int count, int stars, String timestamp, String comment) {
         return new HashMap<String, Object>() {
             {
                 if (userId != null) {

--- a/x-pack/plugin/transform/qa/multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/TransformUsingSearchRuntimeFieldsIT.java
+++ b/x-pack/plugin/transform/qa/multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/TransformUsingSearchRuntimeFieldsIT.java
@@ -56,11 +56,11 @@ public class TransformUsingSearchRuntimeFieldsIT extends TransformIntegTestCase 
     private static final String REVIEWS_INDEX_NAME = "basic-crud-reviews";
     private static final int NUM_USERS = 28;
 
-    private static final Integer getUserIdForRow(int row) {
+    private static Integer getUserIdForRow(int row) {
         return row % NUM_USERS;
     }
 
-    private static final String getDateStringForRow(int row) {
+    private static String getDateStringForRow(int row) {
         int day = (11 + (row / 100)) % 28;
         int hour = 10 + (row % 13);
         int min = 10 + (row % 49);

--- a/x-pack/plugin/transform/qa/multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/continuous/DateHistogramGroupByOtherTimeFieldIT.java
+++ b/x-pack/plugin/transform/qa/multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/continuous/DateHistogramGroupByOtherTimeFieldIT.java
@@ -1,3 +1,10 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
 package org.elasticsearch.xpack.transform.integration.continuous;
 
 import org.elasticsearch.action.search.SearchRequest;

--- a/x-pack/plugin/transform/qa/multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/continuous/HistogramGroupByIT.java
+++ b/x-pack/plugin/transform/qa/multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/continuous/HistogramGroupByIT.java
@@ -1,3 +1,10 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
 package org.elasticsearch.xpack.transform.integration.continuous;
 
 import org.elasticsearch.action.search.SearchRequest;

--- a/x-pack/plugin/transform/qa/multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/continuous/LatestContinuousIT.java
+++ b/x-pack/plugin/transform/qa/multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/continuous/LatestContinuousIT.java
@@ -28,6 +28,7 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 
@@ -126,7 +127,7 @@ public class LatestContinuousIT extends ContinuousTestCase {
             String transformBucketKey = eventFieldValue != null
                 // The bucket key in source can be either an ordinary field or a runtime field. When it is runtime field, simulate its
                 // script ("toUpperCase()") here.
-                ? "event".equals(eventField) ? eventFieldValue : eventFieldValue.toUpperCase()
+                ? "event".equals(eventField) ? eventFieldValue : eventFieldValue.toUpperCase(Locale.ROOT)
                 : MISSING_BUCKET_KEY;
 
             // Verify that the results from the aggregation and the results from the transform are the same.

--- a/x-pack/plugin/transform/qa/multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/continuous/TransformContinuousIT.java
+++ b/x-pack/plugin/transform/qa/multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/continuous/TransformContinuousIT.java
@@ -389,7 +389,8 @@ public class TransformContinuousIT extends ESRestTestCase {
                     .startObject("script")
                     .field(
                         "source",
-                        "if (doc['metric-timestamp'].size()!=0) {emit(doc['metric-timestamp'].value.minus(5, ChronoUnit.MINUTES).toInstant().toEpochMilli())}"
+                        "if (doc['metric-timestamp'].size()!=0) {emit(doc['metric-timestamp'].value"
+                            + ".minus(5, ChronoUnit.MINUTES).toInstant().toEpochMilli())}"
                     )
                     .endObject()
                     .endObject()
@@ -398,7 +399,8 @@ public class TransformContinuousIT extends ESRestTestCase {
                     .startObject("script")
                     .field(
                         "source",
-                        "if (doc['some-timestamp'].size()!=0) {emit(doc['some-timestamp'].value.minus(10, ChronoUnit.MINUTES).toInstant().toEpochMilli())}"
+                        "if (doc['some-timestamp'].size()!=0) {emit(doc['some-timestamp'].value"
+                            + ".minus(10, ChronoUnit.MINUTES).toInstant().toEpochMilli())}"
                     )
                     .endObject()
                     .endObject();


### PR DESCRIPTION
Backports the following commits to 7.17:
 - Apply precommit checks for non productive projects (#85533)