### PR TITLE
[ML] Allow 100% significance threshold for new categorize_text aggregation

### DIFF
--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/aggs/categorization2/TokenListCategorizer.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/aggs/categorization2/TokenListCategorizer.java
@@ -78,8 +78,8 @@ public class TokenListCategorizer implements Accountable {
         float threshold
     ) {
 
-        if (threshold < 0.01f || threshold > 0.99f) {
-            throw new IllegalArgumentException("threshold must be between 0.01 and 0.99: got " + threshold);
+        if (threshold < 0.01f || threshold > 1.0f) {
+            throw new IllegalArgumentException("threshold must be between 0.01 and 1.0: got " + threshold);
         }
 
         this.bytesRefHash = bytesRefHash;

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/aggs/categorization2/InternalCategorizationAggregationTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/aggs/categorization2/InternalCategorizationAggregationTests.java
@@ -7,7 +7,6 @@
 
 package org.elasticsearch.xpack.ml.aggs.categorization2;
 
-import org.apache.lucene.tests.util.LuceneTestCase;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.common.util.BytesRefHash;
@@ -34,7 +33,6 @@ import java.util.stream.Stream;
 
 import static org.hamcrest.Matchers.equalTo;
 
-@LuceneTestCase.AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/85903")
 public class InternalCategorizationAggregationTests extends InternalMultiBucketAggregationTestCase<InternalCategorizationAggregation> {
 
     private CategorizationBytesRefHash bytesRefHash;


### PR DESCRIPTION
Previously there was validation in one place to enforce a 99%
maximum. However, other validation enforced 100% as a maximum
and the old categorize_text aggregation also permitted 100%, so
for BWC the new one should too.

Fixes #85903