### PR TITLE
Transport profiles do not inherit default transport settings

### DIFF
--- a/docs/reference/settings/security-settings.asciidoc
+++ b/docs/reference/settings/security-settings.asciidoc
@@ -2345,10 +2345,11 @@ include::ssl-settings.asciidoc[]
 [[ssl-tls-profile-settings]]
 [discrete]
 ===== Transport profile TLS/SSL settings
+NOTE: Transport profiles do not inherit TLS/SSL settings
+from the default transport. 
+
 The same settings that are available for the <<transport-tls-ssl-settings, default transport>>
-are also available for each transport profile. By default, the settings for a
-transport profile will be the same as the default transport unless they
-are specified.
+are also available for each transport profile. 
 
 As an example, lets look at the key setting. For the default transport
 this is `xpack.security.transport.ssl.key`. In order to use this setting in a


### PR DESCRIPTION
Transport profiles do not inherit default transport settings.  This PR clarifies the documentation.  Please back port accordingly.

Related: https://github.com/elastic/elasticsearch/issues/39960