### PR TITLE
Authentication.token now uses version from the existing authentication (#85978)

### DIFF
--- a/docs/changelog/85978.yaml
+++ b/docs/changelog/85978.yaml
@@ -1,0 +1,5 @@
+pr: 85978
+summary: Authentication.token now uses version from the existing authentication
+area: Security
+type: bug
+issues: []

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authc/Authentication.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authc/Authentication.java
@@ -198,7 +198,7 @@ public class Authentication implements ToXContentObject {
             getUser(),
             getAuthenticatedBy(),
             getLookedUpBy(),
-            Version.CURRENT,
+            getVersion(),
             AuthenticationType.TOKEN,
             getMetadata()
         );


### PR DESCRIPTION
The token method creates a new authentication based on the existing one
It changes only the authentication type. Hence it should use the version
of the existing authentication as well instead of CURRENT.

Resolves: #85902
