### PR TITLE
Set working directory in windows env script

### DIFF
--- a/distribution/src/bin/elasticsearch-env.bat
+++ b/distribution/src/bin/elasticsearch-env.bat
@@ -74,3 +74,4 @@ if defined JAVA_OPTS (
   echo pass JVM parameters via ES_JAVA_OPTS
 )
 
+cd %ES_HOME%


### PR DESCRIPTION
The elasticsearch-env script for nix sets the working directory for
all Elasticsearch shell scripts to ES_HOME. However, the windows env
script does not. This commit adds a `cd` at the end of the windows env
to bring it in line with the nix script.

relates #85758