### PR TITLE
[8.2] Fix AdaptingAggregator toString method (#86042)

### DIFF
--- a/docs/changelog/86042.yaml
+++ b/docs/changelog/86042.yaml
@@ -1,0 +1,5 @@
+pr: 86042
+summary: Fix `AdaptingAggregator` `toString` method
+area: Aggregations
+type: bug
+issues: []

--- a/server/src/main/java/org/elasticsearch/search/aggregations/AdaptingAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/AdaptingAggregator.java
@@ -128,4 +128,9 @@ public abstract class AdaptingAggregator extends Aggregator {
     public Aggregator delegate() {
         return delegate;
     }
+
+    @Override
+    public String toString() {
+        return name();
+    }
 }


### PR DESCRIPTION
Backports the following commits to 8.2:
 - Fix AdaptingAggregator toString method (#86042)