### PR TITLE
Some cleanup around the transport thread hot path

### DIFF
--- a/server/src/main/java/org/elasticsearch/transport/InboundAggregator.java
+++ b/server/src/main/java/org/elasticsearch/transport/InboundAggregator.java
@@ -40,7 +40,7 @@ public class InboundAggregator implements Releasable {
         Function<String, RequestHandlerRegistry<TransportRequest>> registryFunction,
         boolean ignoreDeserializationErrors
     ) {
-        this(circuitBreaker, (Predicate<String>) actionName -> {
+        this(circuitBreaker, actionName -> {
             final RequestHandlerRegistry<TransportRequest> reg = registryFunction.apply(actionName);
             if (reg == null) {
                 assert ignoreDeserializationErrors : actionName;

--- a/server/src/main/java/org/elasticsearch/transport/InboundPipeline.java
+++ b/server/src/main/java/org/elasticsearch/transport/InboundPipeline.java
@@ -90,7 +90,7 @@ public class InboundPipeline implements Releasable {
         }
     }
 
-    public void doHandleBytes(TcpChannel channel, ReleasableBytesReference reference) throws IOException {
+    private void doHandleBytes(TcpChannel channel, ReleasableBytesReference reference) throws IOException {
         channel.getChannelStats().markAccessed(relativeTimeInMillis.getAsLong());
         statsTracker.markBytesRead(reference.length());
         pending.add(reference.retain());

--- a/server/src/test/java/org/elasticsearch/transport/InboundDecoderTests.java
+++ b/server/src/test/java/org/elasticsearch/transport/InboundDecoderTests.java
@@ -357,36 +357,36 @@ public class InboundDecoderTests extends ESTestCase {
         assertFalse(releasable1.hasReferences());
     }
 
-    public void testEnsureVersionCompatibility() throws IOException {
-        IllegalStateException ise = InboundDecoder.ensureVersionCompatibility(
+    public void testEnsureVersionCompatibility() {
+        InboundDecoder.ensureVersionCompatibility(
             VersionUtils.randomVersionBetween(random(), Version.CURRENT.minimumCompatibilityVersion(), Version.CURRENT),
             Version.CURRENT,
             randomBoolean()
         );
-        assertNull(ise);
 
         final Version version = Version.fromString("7.0.0");
-        ise = InboundDecoder.ensureVersionCompatibility(Version.fromString("6.0.0"), version, true);
-        assertNull(ise);
+        InboundDecoder.ensureVersionCompatibility(Version.fromString("6.0.0"), version, true);
 
-        ise = InboundDecoder.ensureVersionCompatibility(Version.fromString("6.0.0"), version, false);
         assertEquals(
             "Received message from unsupported version: [6.0.0] minimal compatible version is: ["
                 + version.minimumCompatibilityVersion()
                 + "]",
-            ise.getMessage()
+            expectThrows(
+                IllegalStateException.class,
+                () -> InboundDecoder.ensureVersionCompatibility(Version.fromString("6.0.0"), version, false)
+            ).getMessage()
         );
 
         // For handshake we are compatible with N-2
-        ise = InboundDecoder.ensureVersionCompatibility(Version.fromString("5.6.0"), version, true);
-        assertNull(ise);
-
-        ise = InboundDecoder.ensureVersionCompatibility(Version.fromString("5.6.0"), version, false);
+        InboundDecoder.ensureVersionCompatibility(Version.fromString("5.6.0"), version, true);
         assertEquals(
             "Received message from unsupported version: [5.6.0] minimal compatible version is: ["
                 + version.minimumCompatibilityVersion()
                 + "]",
-            ise.getMessage()
+            expectThrows(
+                IllegalStateException.class,
+                () -> InboundDecoder.ensureVersionCompatibility(Version.fromString("5.6.0"), version, false)
+            ).getMessage()
         );
     }
 }


### PR DESCRIPTION
Make this code a little easier to read (both for humans and the JIT compiler)
by moving cold paths into their own methods and splitting up some huge methods.
