### PR TITLE
Remove hppc from LocalCheckpointTracker

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/seqno/LocalCheckpointTracker.java
+++ b/server/src/main/java/org/elasticsearch/index/seqno/LocalCheckpointTracker.java
@@ -8,8 +8,8 @@
 
 package org.elasticsearch.index.seqno;
 
-import com.carrotsearch.hppc.LongObjectHashMap;
-
+import java.util.HashMap;
+import java.util.Map;
 import java.util.concurrent.atomic.AtomicLong;
 
 /**
@@ -28,13 +28,13 @@ public class LocalCheckpointTracker {
      * A collection of bit sets representing processed sequence numbers. Each sequence number is mapped to a bit set by dividing by the
      * bit set size.
      */
-    final LongObjectHashMap<CountedBitSet> processedSeqNo = new LongObjectHashMap<>();
+    final Map<Long, CountedBitSet> processedSeqNo = new HashMap<>();
 
     /**
      * A collection of bit sets representing durably persisted sequence numbers. Each sequence number is mapped to a bit set by dividing by
      * the bit set size.
      */
-    final LongObjectHashMap<CountedBitSet> persistedSeqNo = new LongObjectHashMap<>();
+    final Map<Long, CountedBitSet> persistedSeqNo = new HashMap<>();
 
     /**
      * The current local checkpoint, i.e., all sequence numbers no more than this number have been processed.
@@ -109,7 +109,7 @@ public class LocalCheckpointTracker {
         markSeqNo(seqNo, persistedCheckpoint, persistedSeqNo);
     }
 
-    private void markSeqNo(final long seqNo, final AtomicLong checkPoint, final LongObjectHashMap<CountedBitSet> bitSetMap) {
+    private void markSeqNo(final long seqNo, final AtomicLong checkPoint, final Map<Long, CountedBitSet> bitSetMap) {
         assert Thread.holdsLock(this);
         // make sure we track highest seen sequence number
         advanceMaxSeqNo(seqNo);
@@ -188,7 +188,7 @@ public class LocalCheckpointTracker {
      * Moves the checkpoint to the last consecutively processed sequence number. This method assumes that the sequence number
      * following the current checkpoint is processed.
      */
-    private void updateCheckpoint(AtomicLong checkPoint, LongObjectHashMap<CountedBitSet> bitSetMap) {
+    private void updateCheckpoint(AtomicLong checkPoint, Map<Long, CountedBitSet> bitSetMap) {
         assert Thread.holdsLock(this);
         assert getBitSetForSeqNo(bitSetMap, checkPoint.get() + 1).get(seqNoToBitSetOffset(checkPoint.get() + 1))
             : "updateCheckpoint is called but the bit following the checkpoint is not set";
@@ -229,23 +229,15 @@ public class LocalCheckpointTracker {
         return seqNo / BIT_SET_SIZE;
     }
 
-    private CountedBitSet getBitSetForSeqNo(final LongObjectHashMap<CountedBitSet> bitSetMap, final long seqNo) {
+    private CountedBitSet getBitSetForSeqNo(final Map<Long, CountedBitSet> bitSetMap, final long seqNo) {
         assert Thread.holdsLock(this);
         final long bitSetKey = getBitSetKey(seqNo);
-        final int index = bitSetMap.indexOf(bitSetKey);
-        final CountedBitSet bitSet;
-        if (bitSetMap.indexExists(index)) {
-            bitSet = bitSetMap.indexGet(index);
-        } else {
-            bitSet = new CountedBitSet(BIT_SET_SIZE);
-            bitSetMap.indexInsert(index, bitSetKey, bitSet);
-        }
-        return bitSet;
+        return bitSetMap.computeIfAbsent(seqNo, k -> new CountedBitSet(BIT_SET_SIZE));
     }
 
     /**
      * Obtain the position in the bit set corresponding to the provided sequence number. The bit set corresponding to the sequence number
-     * can be obtained via {@link #getBitSetForSeqNo(LongObjectHashMap, long)}.
+     * can be obtained via {@link #getBitSetForSeqNo(Map, long)}.
      *
      * @param seqNo the sequence number to obtain the position for
      * @return the position in the bit set corresponding to the provided sequence number

--- a/server/src/main/java/org/elasticsearch/index/seqno/LocalCheckpointTracker.java
+++ b/server/src/main/java/org/elasticsearch/index/seqno/LocalCheckpointTracker.java
@@ -232,7 +232,7 @@ public class LocalCheckpointTracker {
     private CountedBitSet getBitSetForSeqNo(final Map<Long, CountedBitSet> bitSetMap, final long seqNo) {
         assert Thread.holdsLock(this);
         final long bitSetKey = getBitSetKey(seqNo);
-        return bitSetMap.computeIfAbsent(seqNo, k -> new CountedBitSet(BIT_SET_SIZE));
+        return bitSetMap.computeIfAbsent(bitSetKey, k -> new CountedBitSet(BIT_SET_SIZE));
     }
 
     /**

--- a/server/src/test/java/org/elasticsearch/index/seqno/LocalCheckpointTrackerTests.java
+++ b/server/src/test/java/org/elasticsearch/index/seqno/LocalCheckpointTrackerTests.java
@@ -145,7 +145,7 @@ public class LocalCheckpointTrackerTests extends ESTestCase {
         assertThat(tracker.processedCheckpoint.get(), equalTo(maxOps - 1L));
         assertThat(tracker.processedSeqNo.size(), equalTo(aligned ? 0 : 1));
         if (aligned == false) {
-            assertThat(tracker.processedSeqNo.keys().iterator().next().value, equalTo(tracker.processedCheckpoint.get() / BIT_SET_SIZE));
+            assertThat(tracker.processedSeqNo.keySet().iterator().next(), equalTo(tracker.processedCheckpoint.get() / BIT_SET_SIZE));
         }
         assertThat(tracker.hasProcessed(randomFrom(seqNoList)), equalTo(true));
         final long notCompletedSeqNo = randomValueOtherThanMany(seqNoList::contains, ESTestCase::randomNonNegativeLong);
@@ -191,7 +191,7 @@ public class LocalCheckpointTrackerTests extends ESTestCase {
         assertThat(tracker.getProcessedCheckpoint(), equalTo(maxOps - 1L));
         assertThat(tracker.processedSeqNo.size(), is(oneOf(0, 1)));
         if (tracker.processedSeqNo.size() == 1) {
-            assertThat(tracker.processedSeqNo.keys().iterator().next().value, equalTo(tracker.processedCheckpoint.get() / BIT_SET_SIZE));
+            assertThat(tracker.processedSeqNo.keySet().iterator().next(), equalTo(tracker.processedCheckpoint.get() / BIT_SET_SIZE));
         }
     }
 
@@ -245,7 +245,7 @@ public class LocalCheckpointTrackerTests extends ESTestCase {
         assertThat(tracker.hasProcessed(randomLongBetween(maxOps, Long.MAX_VALUE)), equalTo(false));
         assertThat(tracker.processedSeqNo.size(), is(oneOf(0, 1)));
         if (tracker.processedSeqNo.size() == 1) {
-            assertThat(tracker.processedSeqNo.keys().iterator().next().value, equalTo(tracker.processedCheckpoint.get() / BIT_SET_SIZE));
+            assertThat(tracker.processedSeqNo.keySet().iterator().next(), equalTo(tracker.processedCheckpoint.get() / BIT_SET_SIZE));
         }
     }
 


### PR DESCRIPTION
The LocalCheckpointTracker keeps mappings between sequence number and a
bitsets, using hppc primitive maps. This commit converts these to use
standard HashMaps.

relates #84735