### PR TITLE
Remove hppc from translog classes

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/translog/MultiSnapshot.java
+++ b/server/src/main/java/org/elasticsearch/index/translog/MultiSnapshot.java
@@ -8,14 +8,14 @@
 
 package org.elasticsearch.index.translog;
 
-import com.carrotsearch.hppc.LongObjectHashMap;
-
 import org.elasticsearch.index.seqno.CountedBitSet;
 import org.elasticsearch.index.seqno.SequenceNumbers;
 
 import java.io.Closeable;
 import java.io.IOException;
 import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
 
 /**
  * A snapshot composed out of multiple snapshots
@@ -75,7 +75,7 @@ final class MultiSnapshot implements Translog.Snapshot {
 
     static final class SeqNoSet {
         static final short BIT_SET_SIZE = 1024;
-        private final LongObjectHashMap<CountedBitSet> bitSets = new LongObjectHashMap<>();
+        private final Map<Long, CountedBitSet> bitSets = new HashMap<>();
 
         /**
          * Marks this sequence number and returns {@code true} if it is seen before.
@@ -83,11 +83,7 @@ final class MultiSnapshot implements Translog.Snapshot {
         boolean getAndSet(long value) {
             assert value >= 0;
             final long key = value / BIT_SET_SIZE;
-            CountedBitSet bitset = bitSets.get(key);
-            if (bitset == null) {
-                bitset = new CountedBitSet(BIT_SET_SIZE);
-                bitSets.put(key, bitset);
-            }
+            CountedBitSet bitset = bitSets.computeIfAbsent(key, k -> new CountedBitSet(BIT_SET_SIZE));
             final int index = Math.toIntExact(value % BIT_SET_SIZE);
             final boolean wasOn = bitset.get(index);
             bitset.set(index);


### PR DESCRIPTION
The translog writer uses hppc maps for mapping sequence numbers to
bitsets, and keeping track of which sequence numbers have been flushed
or not. This commit converts these uses to Java collections.

relates #84735