### PR TITLE
Remove hppc from nested aggs

### DIFF
--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/nested/NestedAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/nested/NestedAggregator.java
@@ -33,7 +33,6 @@ import org.elasticsearch.search.aggregations.support.AggregationContext;
 import org.elasticsearch.xcontent.ParseField;
 
 import java.io.IOException;
-import java.io.UncheckedIOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -194,14 +193,9 @@ public class NestedAggregator extends BucketsAggregator implements SingleBucketA
 
             for (; childDocId < currentParentDoc; childDocId = childDocs.nextDoc()) {
                 cachedScorer.doc = childDocId;
-                final int docId = childDocId;
-                bucketBuffer.stream().mapToLong(Long::longValue).forEach(bucket -> {
-                    try {
-                        collectBucket(sub, docId, bucket);
-                    } catch (IOException e) {
-                        throw new UncheckedIOException(e);
-                    }
-                });
+                for (var bucket : bucketBuffer) {
+                    collectBucket(sub, childDocId, bucket);
+                }
             }
             bucketBuffer.clear();
         }


### PR DESCRIPTION
The nested and reverse nested aggs use hppc maps and lists for mapping buckets to
ordinals. This commit converts these to use HashMaps and ArrayLists.

relates #84735