### PR TITLE
Fixes testAggregationSampling flakey test 86050

### DIFF
--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/sampler/random/RandomSamplerAggregatorTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/sampler/random/RandomSamplerAggregatorTests.java
@@ -13,12 +13,16 @@ import org.apache.lucene.document.SortedSetDocValuesField;
 import org.apache.lucene.search.MatchAllDocsQuery;
 import org.apache.lucene.tests.index.RandomIndexWriter;
 import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.common.Strings;
 import org.elasticsearch.index.mapper.KeywordFieldMapper;
 import org.elasticsearch.index.query.QueryBuilders;
 import org.elasticsearch.search.aggregations.AggregationBuilders;
 import org.elasticsearch.search.aggregations.AggregatorTestCase;
 import org.elasticsearch.search.aggregations.bucket.filter.Filter;
 import org.elasticsearch.search.aggregations.metrics.Avg;
+import org.hamcrest.Description;
+import org.hamcrest.Matcher;
+import org.hamcrest.TypeSafeMatcher;
 
 import java.io.IOException;
 import java.util.List;
@@ -32,6 +36,8 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.lessThanOrEqualTo;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.notANumber;
 
 public class RandomSamplerAggregatorTests extends AggregatorTestCase {
 
@@ -51,9 +57,11 @@ public class RandomSamplerAggregatorTests extends AggregatorTestCase {
                 RandomSamplerAggregatorTests::writeTestDocs,
                 (InternalRandomSampler result) -> {
                     counts[integer.get()] = result.getDocCount();
-                    Avg agg = result.getAggregations().get("avg");
-                    assertTrue(Double.isNaN(agg.getValue()) == false && Double.isFinite(agg.getValue()));
-                    avgs[integer.get()] = agg.getValue();
+                    if (result.getDocCount() > 0) {
+                        Avg agg = result.getAggregations().get("avg");
+                        assertThat(Strings.toString(result), agg.getValue(), allOf(not(notANumber()), IsFinite.isFinite()));
+                        avgs[integer.get()] = agg.getValue();
+                    }
                 },
                 longField(NUMERIC_FIELD_NAME)
             );
@@ -116,6 +124,22 @@ public class RandomSamplerAggregatorTests extends AggregatorTestCase {
                     )
                 )
             );
+        }
+    }
+
+    private static class IsFinite extends TypeSafeMatcher<Double> {
+        public static Matcher<Double> isFinite() {
+            return new IsFinite();
+        }
+
+        @Override
+        protected boolean matchesSafely(Double item) {
+            return Double.isFinite(item);
+        }
+
+        @Override
+        public void describeTo(Description description) {
+            description.appendText("a finite double value");
         }
     }
 


### PR DESCRIPTION
It is possible the test segments are exceptionally small.

Consequently, even when sampling at 0.25 probability we hit no docs.

closes #86050