### PR TITLE
Do not reuse ES log file in testclusters (#85576)

### DIFF
--- a/build-tools/src/integTest/groovy/org/elasticsearch/gradle/TestClustersPluginFuncTest.groovy
+++ b/build-tools/src/integTest/groovy/org/elasticsearch/gradle/TestClustersPluginFuncTest.groovy
@@ -35,25 +35,25 @@ class TestClustersPluginFuncTest extends AbstractGradleFuncTest {
             class SomeClusterAwareTask extends DefaultTask implements TestClustersAware {
 
                 private Collection<ElasticsearchCluster> clusters = new HashSet<>();
-            
+
                 @Override
                 @Nested
                 public Collection<ElasticsearchCluster> getClusters() {
                     return clusters;
                 }
-                
+
                 @OutputFile
                 Provider<RegularFile> outputFile
-             
+
                 @Inject
                 SomeClusterAwareTask(ProjectLayout projectLayout) {
                     outputFile = projectLayout.getBuildDirectory().file("someclusteraware.txt")
                 }
-   
+
                 @TaskAction void doSomething() {
                     outputFile.get().getAsFile().text = "done"
                     println 'SomeClusterAwareTask executed'
-                    
+
                 }
             }
         """
@@ -80,8 +80,8 @@ class TestClustersPluginFuncTest extends AbstractGradleFuncTest {
 
         then:
         result.output.contains("elasticsearch-keystore script executed!")
-        assertEsLogContains("myCluster", "Starting Elasticsearch process")
-        assertEsLogContains("myCluster", "Stopping node")
+        assertEsOutputContains("myCluster", "Starting Elasticsearch process")
+        assertEsOutputContains("myCluster", "Stopping node")
         assertNoCustomDistro('myCluster')
     }
 
@@ -111,8 +111,8 @@ class TestClustersPluginFuncTest extends AbstractGradleFuncTest {
         then:
         result.output.contains("Task ':myTask' is not up-to-date because:\n  Input property 'clusters.myCluster\$0.nodes.\$0.$inputProperty'")
         result.output.contains("elasticsearch-keystore script executed!")
-        assertEsLogContains("myCluster", "Starting Elasticsearch process")
-        assertEsLogContains("myCluster", "Stopping node")
+        assertEsOutputContains("myCluster", "Starting Elasticsearch process")
+        assertEsOutputContains("myCluster", "Stopping node")
         assertNoCustomDistro('myCluster')
 
         where:
@@ -129,13 +129,13 @@ class TestClustersPluginFuncTest extends AbstractGradleFuncTest {
             // do not hassle with resolving predefined dependencies
             configurations.compileOnly.dependencies.clear()
             configurations.testImplementation.dependencies.clear()
-            
+
             esplugin {
                 name = 'test-$pluginType'
                 classname 'org.acme.TestModule'
                 description = "test $pluginType description"
             }
-            
+
             version = "1.0"
             group = 'org.acme'
         """
@@ -166,8 +166,8 @@ class TestClustersPluginFuncTest extends AbstractGradleFuncTest {
         result.output.contains("Task ':myTask' is not up-to-date because:\n" +
                 "  Input property 'clusters.myCluster\$0.nodes.\$0.$propertyName'")
         result.output.contains("elasticsearch-keystore script executed!")
-        assertEsLogContains("myCluster", "Starting Elasticsearch process")
-        assertEsLogContains("myCluster", "Stopping node")
+        assertEsOutputContains("myCluster", "Starting Elasticsearch process")
+        assertEsOutputContains("myCluster", "Stopping node")
 
         where:
         pluginType | propertyName         | fileChange
@@ -197,8 +197,8 @@ class TestClustersPluginFuncTest extends AbstractGradleFuncTest {
 
         then:
         result.output.contains("elasticsearch-keystore script executed!")
-        assertEsLogContains("myCluster", "Starting Elasticsearch process")
-        assertEsLogContains("myCluster", "Stopping node")
+        assertEsOutputContains("myCluster", "Starting Elasticsearch process")
+        assertEsOutputContains("myCluster", "Stopping node")
         assertNoCustomDistro('myCluster')
     }
 
@@ -224,14 +224,14 @@ class TestClustersPluginFuncTest extends AbstractGradleFuncTest {
 
         then:
         result.output.contains("elasticsearch-keystore script executed!")
-        assertEsLogContains("myCluster", "Starting Elasticsearch process")
-        assertEsLogContains("myCluster", "Stopping node")
+        assertEsOutputContains("myCluster", "Starting Elasticsearch process")
+        assertEsOutputContains("myCluster", "Stopping node")
         assertCustomDistro('myCluster')
     }
 
-    boolean assertEsLogContains(String testCluster, String expectedOutput) {
+    boolean assertEsOutputContains(String testCluster, String expectedOutput) {
         assert new File(testProjectDir.root,
-                "build/testclusters/${testCluster}-0/logs/${testCluster}.log").text.contains(expectedOutput)
+                "build/testclusters/${testCluster}-0/logs/es.out").text.contains(expectedOutput)
         true
     }
 

--- a/build-tools/src/main/java/org/elasticsearch/gradle/testclusters/RunTask.java
+++ b/build-tools/src/main/java/org/elasticsearch/gradle/testclusters/RunTask.java
@@ -142,7 +142,7 @@ public class RunTask extends DefaultTestClustersTask {
         try {
             for (ElasticsearchCluster cluster : getClusters()) {
                 for (ElasticsearchNode node : cluster.getNodes()) {
-                    BufferedReader reader = Files.newBufferedReader(node.getEsLogFile());
+                    BufferedReader reader = Files.newBufferedReader(node.getEsOutputFile());
                     toRead.add(reader);
                     aliveChecks.add(node::isProcessAlive);
                 }


### PR DESCRIPTION
In #85349 we restored capturing the stdout and stderr of Elasticsearch
processes started by testclusters. However, since testclusters launches
Elasticsearch in the forground for each process, the log output is
duplicated to stdout. This commit changes the redirects to use a 
unique file, separate from ES's log file.

closes #85553