### PR TITLE
Do not reuse ES log file in testclusters (#85576)

### DIFF
--- a/build-tools/src/integTest/groovy/org/elasticsearch/gradle/TestClustersPluginFuncTest.groovy
+++ b/build-tools/src/integTest/groovy/org/elasticsearch/gradle/TestClustersPluginFuncTest.groovy
@@ -35,25 +35,25 @@ class TestClustersPluginFuncTest extends AbstractGradleFuncTest {
             class SomeClusterAwareTask extends DefaultTask implements TestClustersAware {
 
                 private Collection<ElasticsearchCluster> clusters = new HashSet<>();
-            
+
                 @Override
                 @Nested
                 public Collection<ElasticsearchCluster> getClusters() {
                     return clusters;
                 }
-                
+
                 @OutputFile
                 Provider<RegularFile> outputFile
-             
+
                 @Inject
                 SomeClusterAwareTask(ProjectLayout projectLayout) {
                     outputFile = projectLayout.getBuildDirectory().file("someclusteraware.txt")
                 }
-   
+
                 @TaskAction void doSomething() {
                     outputFile.get().getAsFile().text = "done"
                     println 'SomeClusterAwareTask executed'
-                    
+
                 }
             }
         """
@@ -80,8 +80,8 @@ class TestClustersPluginFuncTest extends AbstractGradleFuncTest {
 
         then:
         result.output.contains("elasticsearch-keystore script executed!")
-        assertEsLogContains("myCluster", "Starting Elasticsearch process")
-        assertEsLogContains("myCluster", "Stopping node")
+        assertEsOutputContains("myCluster", "Starting Elasticsearch process")
+        assertEsOutputContains("myCluster", "Stopping node")
         assertNoCustomDistro('myCluster')
     }
 
@@ -111,8 +111,8 @@ class TestClustersPluginFuncTest extends AbstractGradleFuncTest {
         then:
         result.output.contains("Task ':myTask' is not up-to-date because:\n  Input property 'clusters.myCluster\$0.nodes.\$0.$inputProperty'")
         result.output.contains("elasticsearch-keystore script executed!")
-        assertEsLogContains("myCluster", "Starting Elasticsearch process")
-        assertEsLogContains("myCluster", "Stopping node")
+        assertEsOutputContains("myCluster", "Starting Elasticsearch process")
+        assertEsOutputContains("myCluster", "Stopping node")
         assertNoCustomDistro('myCluster')
 
         where:
@@ -129,13 +129,13 @@ class TestClustersPluginFuncTest extends AbstractGradleFuncTest {
             // do not hassle with resolving predefined dependencies
             configurations.compileOnly.dependencies.clear()
             configurations.testImplementation.dependencies.clear()
-            
+
             esplugin {
                 name = 'test-module'
                 classname 'org.acme.TestModule'
                 description = "test module description"
             }
-            
+
             version = "1.0"
             group = 'org.acme'
         """
@@ -166,8 +166,8 @@ class TestClustersPluginFuncTest extends AbstractGradleFuncTest {
         result.output.contains("Task ':myTask' is not up-to-date because:\n" +
                 "  Input property 'clusters.myCluster\$0.nodes.\$0.$propertyName'")
         result.output.contains("elasticsearch-keystore script executed!")
-        assertEsLogContains("myCluster", "Starting Elasticsearch process")
-        assertEsLogContains("myCluster", "Stopping node")
+        assertEsOutputContains("myCluster", "Starting Elasticsearch process")
+        assertEsOutputContains("myCluster", "Stopping node")
 
         where:
         propertyName         | fileChange
@@ -195,8 +195,8 @@ class TestClustersPluginFuncTest extends AbstractGradleFuncTest {
 
         then:
         result.output.contains("elasticsearch-keystore script executed!")
-        assertEsLogContains("myCluster", "Starting Elasticsearch process")
-        assertEsLogContains("myCluster", "Stopping node")
+        assertEsOutputContains("myCluster", "Starting Elasticsearch process")
+        assertEsOutputContains("myCluster", "Stopping node")
         assertNoCustomDistro('myCluster')
     }
 
@@ -222,14 +222,14 @@ class TestClustersPluginFuncTest extends AbstractGradleFuncTest {
 
         then:
         result.output.contains("elasticsearch-keystore script executed!")
-        assertEsLogContains("myCluster", "Starting Elasticsearch process")
-        assertEsLogContains("myCluster", "Stopping node")
+        assertEsOutputContains("myCluster", "Starting Elasticsearch process")
+        assertEsOutputContains("myCluster", "Stopping node")
         assertCustomDistro('myCluster')
     }
 
-    boolean assertEsLogContains(String testCluster, String expectedOutput) {
+    boolean assertEsOutputContains(String testCluster, String expectedOutput) {
         assert new File(testProjectDir.root,
-                "build/testclusters/${testCluster}-0/logs/${testCluster}.log").text.contains(expectedOutput)
+                "build/testclusters/${testCluster}-0/logs/es.out").text.contains(expectedOutput)
         true
     }
 

--- a/build-tools/src/main/java/org/elasticsearch/gradle/testclusters/ElasticsearchNode.java
+++ b/build-tools/src/main/java/org/elasticsearch/gradle/testclusters/ElasticsearchNode.java
@@ -153,8 +153,8 @@ public class ElasticsearchNode implements TestClusterConfiguration {
     private final Path confPathLogs;
     private final Path transportPortFile;
     private final Path httpPortsFile;
-    private final Path esLogFile;
-    private final Path esStdinFile;
+    private final Path esOutputFile;
+    private final Path esInputFile;
     private final Path tmpDir;
     private final Provider<File> runtimeJava;
 
@@ -202,8 +202,8 @@ public class ElasticsearchNode implements TestClusterConfiguration {
         confPathLogs = workingDir.resolve("logs");
         transportPortFile = confPathLogs.resolve("transport.ports");
         httpPortsFile = confPathLogs.resolve("http.ports");
-        esLogFile = confPathLogs.resolve(clusterName + ".log");
-        esStdinFile = workingDir.resolve("es.stdin");
+        esOutputFile = confPathLogs.resolve("es.out");
+        esInputFile = workingDir.resolve("es.in");
         tmpDir = workingDir.resolve("tmp");
         waitConditions.put("ports files", this::checkPortsFilesExistWithDelay);
         defaultConfig.put("cluster.name", clusterName);
@@ -603,11 +603,11 @@ public class ElasticsearchNode implements TestClusterConfiguration {
 
     private void logToProcessStdout(String message) {
         try {
-            if (Files.exists(esLogFile.getParent()) == false) {
-                Files.createDirectories(esLogFile.getParent());
+            if (Files.exists(esOutputFile.getParent()) == false) {
+                Files.createDirectories(esOutputFile.getParent());
             }
             Files.write(
-                esLogFile,
+                esOutputFile,
                 ("[" + Instant.now().toString() + "] [BUILD] " + message + "\n").getBytes(StandardCharsets.UTF_8),
                 StandardOpenOption.CREATE,
                 StandardOpenOption.APPEND
@@ -906,15 +906,15 @@ public class ElasticsearchNode implements TestClusterConfiguration {
         environment.clear();
         environment.putAll(getESEnvironment());
 
-        // Direct the stdout and stderr to the ES log file. This should not contend with the actual ES
-        // process once it is started since there we close replace stdout/stderr handles once logging is setup.
-        processBuilder.redirectOutput(ProcessBuilder.Redirect.appendTo(esLogFile.toFile()));
+        // Direct the stderr to the ES log file. This should capture any jvm problems to start.
+        // Stdout is discarded because ES duplicates the log file to stdout when run in the foreground.
+        processBuilder.redirectOutput(ProcessBuilder.Redirect.appendTo(esOutputFile.toFile()));
         processBuilder.redirectErrorStream(true);
 
         if (keystorePassword != null && keystorePassword.length() > 0) {
             try {
-                Files.write(esStdinFile, (keystorePassword + "\n").getBytes(StandardCharsets.UTF_8), StandardOpenOption.CREATE);
-                processBuilder.redirectInput(esStdinFile.toFile());
+                Files.write(esInputFile, (keystorePassword + "\n").getBytes(StandardCharsets.UTF_8), StandardOpenOption.CREATE);
+                processBuilder.redirectInput(esInputFile.toFile());
             } catch (IOException e) {
                 throw new TestClustersException("Failed to set the keystore password for " + this, e);
             }
@@ -1006,7 +1006,7 @@ public class ElasticsearchNode implements TestClusterConfiguration {
         } catch (IOException e) {
             throw new UncheckedIOException(e);
         }
-        logFileContents("Log output of node", esLogFile, tailLogs);
+        logFileContents("Log output of node", esOutputFile, tailLogs);
     }
 
     @Override
@@ -1578,8 +1578,8 @@ public class ElasticsearchNode implements TestClusterConfiguration {
     }
 
     @Internal
-    Path getEsLogFile() {
-        return esLogFile;
+    Path getEsOutputFile() {
+        return esOutputFile;
     }
 
     private static class FileEntry implements Named {

--- a/build-tools/src/main/java/org/elasticsearch/gradle/testclusters/ElasticsearchNode.java
+++ b/build-tools/src/main/java/org/elasticsearch/gradle/testclusters/ElasticsearchNode.java
@@ -474,15 +474,6 @@ public class ElasticsearchNode implements TestClusterConfiguration {
         configurationFrozen.set(true);
     }
 
-    /**
-     * Returns a stream of lines in the generated logs similar to Files.lines
-     *
-     * @return stream of log lines
-     */
-    public Stream<String> logLines() throws IOException {
-        return Files.lines(esLogFile, StandardCharsets.UTF_8);
-    }
-
     @Override
     public synchronized void start() {
         LOGGER.info("Starting `{}`", this);

--- a/build-tools/src/main/java/org/elasticsearch/gradle/testclusters/RunTask.java
+++ b/build-tools/src/main/java/org/elasticsearch/gradle/testclusters/RunTask.java
@@ -142,7 +142,7 @@ public class RunTask extends DefaultTestClustersTask {
         try {
             for (ElasticsearchCluster cluster : getClusters()) {
                 for (ElasticsearchNode node : cluster.getNodes()) {
-                    BufferedReader reader = Files.newBufferedReader(node.getEsLogFile());
+                    BufferedReader reader = Files.newBufferedReader(node.getEsOutputFile());
                     toRead.add(reader);
                     aliveChecks.add(node::isProcessAlive);
                 }


### PR DESCRIPTION
In #85349 we restored capturing the stdout and stderr of Elasticsearch
processes started by testclusters. However, since testclusters launches
Elasticsearch in the forground for each process, the log output is
duplicated to stdout. This commit changes the redirects to use a
unique file, separate from ES's log file.

closes #85553