### PR TITLE
Fix test: set refresh param on indexing test data

### DIFF
--- a/x-pack/plugin/sql/qa/server/single-node/src/test/java/org/elasticsearch/xpack/sql/qa/single_node/JdbcShardFailureIT.java
+++ b/x-pack/plugin/sql/qa/server/single-node/src/test/java/org/elasticsearch/xpack/sql/qa/single_node/JdbcShardFailureIT.java
@@ -104,6 +104,7 @@ public class JdbcShardFailureIT extends JdbcIntegrationTestCase {
             assertOK(provisioningClient().performRequest(request));
 
             request = new Request("POST", indexName + "/_doc");
+            request.addParameter("refresh", "true");
             request.setJsonEntity("{\"bool\": " + (indexWithDocVals || randomBoolean()) + "}");
             assertOK(provisioningClient().performRequest(request));
         }


### PR DESCRIPTION
Set refresh=true when indexing test data, before searching it.

Fixes #86092