### PR TITLE
Remove old optional deps from plugin build

### DIFF
--- a/build-tools/src/main/java/org/elasticsearch/gradle/plugin/PluginBuildPlugin.java
+++ b/build-tools/src/main/java/org/elasticsearch/gradle/plugin/PluginBuildPlugin.java
@@ -99,7 +99,6 @@ public class PluginBuildPlugin implements Plugin<Project> {
         var dependencies = project.getDependencies();
         dependencies.add("compileOnly", "org.elasticsearch:elasticsearch:" + VersionProperties.getElasticsearch());
         dependencies.add("testImplementation", "org.elasticsearch.test:framework:" + VersionProperties.getElasticsearch());
-        dependencies.add("testImplementation", "org.apache.logging.log4j:log4j-core:" + VersionProperties.getVersions().get("log4j"));
     }
 
     /**

--- a/build-tools/src/main/java/org/elasticsearch/gradle/plugin/PluginBuildPlugin.java
+++ b/build-tools/src/main/java/org/elasticsearch/gradle/plugin/PluginBuildPlugin.java
@@ -100,14 +100,6 @@ public class PluginBuildPlugin implements Plugin<Project> {
         dependencies.add("compileOnly", "org.elasticsearch:elasticsearch:" + VersionProperties.getElasticsearch());
         dependencies.add("testImplementation", "org.elasticsearch.test:framework:" + VersionProperties.getElasticsearch());
         dependencies.add("testImplementation", "org.apache.logging.log4j:log4j-core:" + VersionProperties.getVersions().get("log4j"));
-
-        // we "upgrade" these optional deps to provided for plugins, since they will run
-        // with a full elasticsearch server that includes optional deps
-        dependencies.add("compileOnly", "org.locationtech.spatial4j:spatial4j:" + VersionProperties.getVersions().get("spatial4j"));
-        dependencies.add("compileOnly", "org.locationtech.jts:jts-core:" + VersionProperties.getVersions().get("jts"));
-        dependencies.add("compileOnly", "org.apache.logging.log4j:log4j-api:" + VersionProperties.getVersions().get("log4j"));
-        dependencies.add("compileOnly", "org.apache.logging.log4j:log4j-core:" + VersionProperties.getVersions().get("log4j"));
-        dependencies.add("compileOnly", "net.java.dev.jna:jna:" + VersionProperties.getVersions().get("jna"));
     }
 
     /**


### PR DESCRIPTION
The main elasticsearch jar used to have optional deps. This was because
of the high level rest client, where users did not want to pull in these
additional heavyweight deps that are not actually exposed by the Java apis.
These optional deps no longer exist since we no longer ship the HLRC.
When building plugins, these deps were "upgraded" to normal compile
classpath deps, since they were in fact available at runtime for
plugins. Since they are no longer optional, they are included
transitively by the dependency on the elasticsearch jar. This commit
removes the addition of these deps in the plugin build.