### PR TITLE
Adjust MDP deprecation to warning instead of critical

### DIFF
--- a/docs/changelog/86102.yaml
+++ b/docs/changelog/86102.yaml
@@ -1,0 +1,6 @@
+pr: 86102
+summary: Adjust MDP deprecation to warning instead of critical
+area: Infra/Settings
+type: bug
+issues:
+ - 85695

--- a/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/NodeDeprecationChecks.java
+++ b/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/NodeDeprecationChecks.java
@@ -645,7 +645,7 @@ class NodeDeprecationChecks {
         List<String> dataPaths = Environment.PATH_DATA_SETTING.get(nodeSettings);
         if (dataPaths.size() > 1) {
             return new DeprecationIssue(
-                DeprecationIssue.Level.CRITICAL,
+                DeprecationIssue.Level.WARNING,
                 "Specifying multiple data paths is deprecated",
                 "https://ela.st/es-deprecation-7-multiple-paths",
                 "The [path.data] setting contains a list of paths. Specify a single path as a string. Use RAID or other system level "
@@ -665,7 +665,7 @@ class NodeDeprecationChecks {
     ) {
         if (Environment.dataPathUsesList(nodeSettings)) {
             return new DeprecationIssue(
-                DeprecationIssue.Level.CRITICAL,
+                DeprecationIssue.Level.WARNING,
                 "Multiple data paths are not supported",
                 "https://ela.st/es-deprecation-7-multiple-paths",
                 "The [path.data] setting contains a list of paths. Specify a single path as a string. Use RAID or other system level "

--- a/x-pack/plugin/deprecation/src/test/java/org/elasticsearch/xpack/deprecation/NodeDeprecationChecksTests.java
+++ b/x-pack/plugin/deprecation/src/test/java/org/elasticsearch/xpack/deprecation/NodeDeprecationChecksTests.java
@@ -727,7 +727,7 @@ public class NodeDeprecationChecksTests extends ESTestCase {
         final XPackLicenseState licenseState = new XPackLicenseState(Settings.EMPTY, () -> 0);
         final DeprecationIssue issue = NodeDeprecationChecks.checkMultipleDataPaths(settings, null, null, licenseState);
         assertThat(issue, not(nullValue()));
-        assertThat(issue.getLevel(), equalTo(DeprecationIssue.Level.CRITICAL));
+        assertThat(issue.getLevel(), equalTo(DeprecationIssue.Level.WARNING));
         assertThat(issue.getMessage(), equalTo("Specifying multiple data paths is deprecated"));
         assertThat(
             issue.getDetails(),
@@ -752,7 +752,7 @@ public class NodeDeprecationChecksTests extends ESTestCase {
         final XPackLicenseState licenseState = new XPackLicenseState(Settings.EMPTY, () -> 0);
         final DeprecationIssue issue = NodeDeprecationChecks.checkDataPathsList(settings, null, null, licenseState);
         assertThat(issue, not(nullValue()));
-        assertThat(issue.getLevel(), equalTo(DeprecationIssue.Level.CRITICAL));
+        assertThat(issue.getLevel(), equalTo(DeprecationIssue.Level.WARNING));
         assertThat(issue.getMessage(), equalTo("Multiple data paths are not supported"));
         assertThat(
             issue.getDetails(),


### PR DESCRIPTION
Multiple data paths was deprecated in 7.13, but the deprecation notice
in the deprecation api was set to critical, even though it is not
removed in 8.0. This commit adjusts the deprecation level to warning.

closes #85695