### PR TITLE
Forward port MDP deprecation info api

### DIFF
--- a/docs/changelog/86103.yaml
+++ b/docs/changelog/86103.yaml
@@ -3,9 +3,3 @@ summary: Forward port MDP deprecation info api
 area: Infra/Core
 type: bug
 issues: []
-deprecation:
-  title: Forward port MDP deprecation info api
-  area: Infra/Core
-  details: Please describe the details of this change for the release notes. You can
-    use asciidoc.
-  impact: Please describe the impact of this change to users

--- a/docs/changelog/86103.yaml
+++ b/docs/changelog/86103.yaml
@@ -1,7 +1,7 @@
 pr: 86103
 summary: Forward port MDP deprecation info api
 area: Infra/Core
-type: deprecation
+type: bug
 issues: []
 deprecation:
   title: Forward port MDP deprecation info api

--- a/docs/changelog/86103.yaml
+++ b/docs/changelog/86103.yaml
@@ -1,0 +1,11 @@
+pr: 86103
+summary: Forward port MDP deprecation info api
+area: Infra/Core
+type: deprecation
+issues: []
+deprecation:
+  title: Forward port MDP deprecation info api
+  area: Infra/Core
+  details: Please describe the details of this change for the release notes. You can
+    use asciidoc.
+  impact: Please describe the impact of this change to users

--- a/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/DeprecationChecks.java
+++ b/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/DeprecationChecks.java
@@ -41,6 +41,8 @@ public class DeprecationChecks {
     static final List<
         NodeDeprecationCheck<Settings, PluginsAndModules, ClusterState, XPackLicenseState, DeprecationIssue>> NODE_SETTINGS_CHECKS = List
             .of(
+                NodeDeprecationChecks::checkMultipleDataPaths,
+                NodeDeprecationChecks::checkDataPathsList,
                 NodeDeprecationChecks::checkSharedDataPathSetting,
                 NodeDeprecationChecks::checkReservedPrefixedRealmNames,
                 NodeDeprecationChecks::checkSingleDataNodeWatermarkSetting,

--- a/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/NodeDeprecationChecks.java
+++ b/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/NodeDeprecationChecks.java
@@ -114,6 +114,47 @@ public class NodeDeprecationChecks {
         return new DeprecationIssue(deprecationLevel, message, url, details, false, meta);
     }
 
+    static DeprecationIssue checkMultipleDataPaths(
+        Settings nodeSettings,
+        PluginsAndModules plugins,
+        final ClusterState clusterState,
+        final XPackLicenseState licenseState
+    ) {
+        List<String> dataPaths = Environment.PATH_DATA_SETTING.get(nodeSettings);
+        if (dataPaths.size() > 1) {
+            return new DeprecationIssue(
+                DeprecationIssue.Level.WARNING,
+                "Specifying multiple data paths is deprecated",
+                "https://ela.st/es-deprecation-7-multiple-paths",
+                "The [path.data] setting contains a list of paths. Specify a single path as a string. Use RAID or other system level "
+                    + "features to utilize multiple disks. If multiple data paths are configured, the node will fail to start in 8.0. ",
+                false,
+                null
+            );
+        }
+        return null;
+    }
+
+    static DeprecationIssue checkDataPathsList(
+        Settings nodeSettings,
+        PluginsAndModules plugins,
+        final ClusterState clusterState,
+        final XPackLicenseState licenseState
+    ) {
+        if (Environment.dataPathUsesList(nodeSettings)) {
+            return new DeprecationIssue(
+                DeprecationIssue.Level.WARNING,
+                "Multiple data paths are not supported",
+                "https://ela.st/es-deprecation-7-multiple-paths",
+                "The [path.data] setting contains a list of paths. Specify a single path as a string. Use RAID or other system level "
+                    + "features to utilize multiple disks. If multiple data paths are configured, the node will fail to start in 8.0. ",
+                false,
+                null
+            );
+        }
+        return null;
+    }
+
     static DeprecationIssue checkSharedDataPathSetting(
         final Settings settings,
         final PluginsAndModules pluginsAndModules,

--- a/x-pack/plugin/deprecation/src/test/java/org/elasticsearch/xpack/deprecation/NodeDeprecationChecksTests.java
+++ b/x-pack/plugin/deprecation/src/test/java/org/elasticsearch/xpack/deprecation/NodeDeprecationChecksTests.java
@@ -27,6 +27,7 @@ import org.elasticsearch.xpack.core.deprecation.DeprecationIssue;
 import org.elasticsearch.xpack.core.ilm.LifecycleSettings;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -73,6 +74,56 @@ public class NodeDeprecationChecksTests extends ESTestCase {
         assertThat(issue.getMessage(), equalTo("Setting [node.removed_setting] is deprecated"));
         assertThat(issue.getDetails(), equalTo("Remove the [node.removed_setting] setting. Some detail."));
         assertThat(issue.getUrl(), equalTo("https://removed-setting.example.com"));
+    }
+
+    public void testMultipleDataPaths() {
+        final Settings settings = Settings.builder().putList("path.data", Arrays.asList("d1", "d2")).build();
+        final XPackLicenseState licenseState = new XPackLicenseState(() -> 0);
+        final DeprecationIssue issue = NodeDeprecationChecks.checkMultipleDataPaths(settings, null, null, licenseState);
+        assertThat(issue, not(nullValue()));
+        assertThat(issue.getLevel(), equalTo(DeprecationIssue.Level.WARNING));
+        assertThat(issue.getMessage(), equalTo("Specifying multiple data paths is deprecated"));
+        assertThat(
+            issue.getDetails(),
+            equalTo(
+                "The [path.data] setting contains a list of paths. Specify a single path as a string. Use RAID or other system level "
+                    + "features to utilize multiple disks. If multiple data paths are configured, the node will fail to start in 8.0. "
+            )
+        );
+        String url = "https://ela.st/es-deprecation-7-multiple-paths";
+        assertThat(issue.getUrl(), equalTo(url));
+    }
+
+    public void testNoMultipleDataPaths() {
+        Settings settings = Settings.builder().put("path.data", "data").build();
+        final XPackLicenseState licenseState = new XPackLicenseState(() -> 0);
+        final DeprecationIssue issue = NodeDeprecationChecks.checkMultipleDataPaths(settings, null, null, licenseState);
+        assertThat(issue, nullValue());
+    }
+
+    public void testDataPathsList() {
+        final Settings settings = Settings.builder().putList("path.data", "d1").build();
+        final XPackLicenseState licenseState = new XPackLicenseState(() -> 0);
+        final DeprecationIssue issue = NodeDeprecationChecks.checkDataPathsList(settings, null, null, licenseState);
+        assertThat(issue, not(nullValue()));
+        assertThat(issue.getLevel(), equalTo(DeprecationIssue.Level.WARNING));
+        assertThat(issue.getMessage(), equalTo("Multiple data paths are not supported"));
+        assertThat(
+            issue.getDetails(),
+            equalTo(
+                "The [path.data] setting contains a list of paths. Specify a single path as a string. Use RAID or other system level "
+                    + "features to utilize multiple disks. If multiple data paths are configured, the node will fail to start in 8.0. "
+            )
+        );
+        String url = "https://ela.st/es-deprecation-7-multiple-paths";
+        assertThat(issue.getUrl(), equalTo(url));
+    }
+
+    public void testNoDataPathsListDefault() {
+        final Settings settings = Settings.builder().build();
+        final XPackLicenseState licenseState = new XPackLicenseState(() -> 0);
+        final DeprecationIssue issue = NodeDeprecationChecks.checkDataPathsList(settings, null, null, licenseState);
+        assertThat(issue, nullValue());
     }
 
     public void testSharedDataPathSetting() {


### PR DESCRIPTION
Multiple data paths was deprecated in 7.13. At the time, the deprecation
was only added to the deprecation logs. Later, it was also added to the
deprecation info api, but by that time, MDP had already been removed
from master. When MDP was added back to master, the deprecation log
messages were added back, but the info api messages were not since they
never existed in master.

This commit forward ports the deprecation info messages for MDP to 8.x.

relates #85695