### PR TITLE
Mute FlattenedFieldSearchTests.testCardinalityAggregation

### DIFF
--- a/server/src/test/java/org/elasticsearch/index/mapper/flattened/FlattenedFieldSearchTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/flattened/FlattenedFieldSearchTests.java
@@ -209,6 +209,7 @@ public class FlattenedFieldSearchTests extends ESSingleNodeTestCase {
         assertHitCount(searchResponse, 0L);
     }
 
+    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/86115")
     public void testCardinalityAggregation() throws IOException {
         int numDocs = randomIntBetween(2, 100);
         int precisionThreshold = randomIntBetween(0, 1 << randomInt(20));


### PR DESCRIPTION
Muting for https://github.com/elastic/elasticsearch/issues/86115
