### PR TITLE
Mute testIndexPointsFromLine and testIndexPointsFromPolygon in legacy geo mappers

### DIFF
--- a/modules/legacy-geo/src/test/java/org/elasticsearch/legacygeo/search/LegacyGeoShapeQueryTests.java
+++ b/modules/legacy-geo/src/test/java/org/elasticsearch/legacygeo/search/LegacyGeoShapeQueryTests.java
@@ -175,4 +175,16 @@ public class LegacyGeoShapeQueryTests extends GeoShapeQueryTestCase {
         SearchResponse response = client().prepareSearch(defaultIndexName).setQuery(geoShapeQuery("alias", multiPoint)).get();
         assertEquals(1, response.getHits().getTotalHits().value);
     }
+
+    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/86118")
+    @Override
+    public void testIndexPointsFromLine() throws Exception {
+        super.testIndexPointsFromLine();
+    }
+
+    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/86118")
+    @Override
+    public void testIndexPointsFromPolygon() throws Exception {
+        super.testIndexPointsFromPolygon();
+    }
 }

--- a/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/index/query/LegacyGeoShapeWithDocValuesQueryTests.java
+++ b/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/index/query/LegacyGeoShapeWithDocValuesQueryTests.java
@@ -228,4 +228,16 @@ public class LegacyGeoShapeWithDocValuesQueryTests extends GeoShapeQueryTestCase
         SearchResponse response = client().prepareSearch(defaultIndexName).setQuery(geoShapeQuery("alias", multiPoint)).get();
         assertEquals(1, response.getHits().getTotalHits().value);
     }
+
+    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/86118")
+    @Override
+    public void testIndexPointsFromLine() throws Exception {
+        super.testIndexPointsFromLine();
+    }
+
+    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/86118")
+    @Override
+    public void testIndexPointsFromPolygon() throws Exception {
+        super.testIndexPointsFromPolygon();
+    }
 }


### PR DESCRIPTION
Tests are failing because legacy geo mappers fail to  match points with longitude equal to 180 degrees.

relates https://github.com/elastic/elasticsearch/issues/86118