### PR TITLE
Fix double-close at reboot in CoordinatorTests (#86008)

### DIFF
--- a/test/framework/src/main/java/org/elasticsearch/cluster/coordination/AbstractCoordinatorTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/cluster/coordination/AbstractCoordinatorTestCase.java
@@ -1867,8 +1867,9 @@ public class AbstractCoordinatorTestCase extends ESTestCase {
 
             @Override
             public void close() {
-                delegate.close();
-                trackedArrays.remove(this);
+                if (trackedArrays.remove(this)) {
+                    delegate.close();
+                }
             }
 
             @Override


### PR DESCRIPTION
Simulated reboots release any outstanding recyclable pages, but it's
possible that we've enqueued an action which releases one of these pages
too. This commit ensures that each page is released at most once.

Closes #86005