### PR TITLE
Initialize active realms without logging a message (#81380).

### DIFF
--- a/docs/changelog/86134.yaml
+++ b/docs/changelog/86134.yaml
@@ -1,0 +1,6 @@
+pr: 86134
+summary: Initialize active realms without logging a message
+area: License
+type: enhancement
+issues:
+ - 81380

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/Realms.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/Realms.java
@@ -95,7 +95,7 @@ public class Realms implements Iterable<Realm> {
         this.allConfiguredRealms.forEach(r -> r.initialize(this.allConfiguredRealms, licenseState));
         assert this.allConfiguredRealms.get(0) == reservedRealm : "the first realm must be reserved realm";
 
-        recomputeActiveRealms();
+        this.activeRealms = calculateLicensedRealms(licenseState.copyCurrentLicenseState());
         licenseState.addListener(this::recomputeActiveRealms);
     }
 

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/RealmsTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/RealmsTests.java
@@ -207,7 +207,7 @@ public class RealmsTests extends ESTestCase {
         Realms realms = new Realms(settings, env, factories, licenseState, threadContext, reservedRealm);
         verify(licenseState, times(1)).addListener(Mockito.any(LicenseStateListener.class));
         verify(licenseState, times(1)).copyCurrentLicenseState();
-        verify(licenseState, times(1)).getOperationMode();
+        verify(licenseState, times(0)).getOperationMode();
 
         // Verify that we recorded licensed-feature use for each realm (this is trigger on license load during node startup)
         verify(licenseState, Mockito.atLeast(randomRealmTypesCount)).isAllowed(Security.CUSTOM_REALMS_FEATURE);
@@ -757,7 +757,8 @@ public class RealmsTests extends ESTestCase {
         verify(licenseState, times(1)).addListener(Mockito.any(LicenseStateListener.class));
         // each time the license state changes
         verify(licenseState, times(1)).copyCurrentLicenseState();
-        verify(licenseState, times(1)).getOperationMode();
+        // During init we do not log license state, hence operation mode should not be called.
+        verify(licenseState, times(0)).getOperationMode();
 
         // Verify that we recorded licensed-feature use for each licensed realm (this is trigger on license load/change)
         verify(licenseState, times(1)).isAllowed(Security.LDAP_REALM_FEATURE);
@@ -767,7 +768,7 @@ public class RealmsTests extends ESTestCase {
         allowOnlyNativeRealms();
         // because the license state changed ...
         verify(licenseState, times(2)).copyCurrentLicenseState();
-        verify(licenseState, times(2)).getOperationMode();
+        verify(licenseState, times(1)).getOperationMode();
 
         iter = realms.iterator();
         assertThat(iter.hasNext(), is(true));


### PR DESCRIPTION
This commit tries to remove confusing initial log message about the license and active realms.
When `Realms` is created, `activeRealms` property is initialized with default (`TRIAL`) license state and message is logged.
Few seconds later an event is triggered which updates license to the actual user's license.
This causes a second message to be logged. This introduces a confusion when the actual license (e.g. `BASIC`) is different than the initial license (`TRIAL`).

Closes #81380
