### PR TITLE
Unmute XPackRestIT deprecation/10_basic/Test Deprecations

### DIFF
--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/deprecation/10_basic.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/deprecation/10_basic.yml
@@ -6,9 +6,6 @@ setup:
 
 ---
 "Test Deprecations":
-  - skip:
-      version: "all"
-      reason: "AwaitsFix https://github.com/elastic/elasticsearch/issues/85806"
   - do:
       migration.deprecations:
         index: "*"


### PR DESCRIPTION
Closes #85806.

This reverts commit 024dbc3d1fd5de866fe73e9b94659a1a0cf7a9a7, which is #85807.

See `@mark-vieira`'s https://github.com/elastic/elasticsearch/issues/84583#issuecomment-1101705228 -- these tests primarily failed when they were running on Mac workers, and those don't exist anymore.