### PR TITLE
[DOCS] Update quickstart curl commands

### DIFF
--- a/docs/reference/tab-widgets/api-call.asciidoc
+++ b/docs/reference/tab-widgets/api-call.asciidoc
@@ -48,9 +48,21 @@ include::api-call.asciidoc[tag=kibana-api-ex]
 To submit an example API request, run the following curl command in a new
 terminal session.
 
+. Copy the `http_ca.crt` security certificate from your Docker container to
+your local machine.
++
 [source,sh]
 ----
-curl -X GET http://localhost:9200/
+docker cp es01:/usr/share/elasticsearch/config/certs/http_ca.crt .
+----
+
+. Open a new terminal and verify that you can connect to your {es} cluster by
+making an authenticated call, using the `http_ca.crt` file that you copied from
+your Docker container. Enter the password for the `elastic` user when prompted.
++
+[source,sh]
+----
+curl --cacert http_ca.crt -u elastic https://localhost:9200
 ----
 // NOTCONSOLE
 

--- a/docs/reference/tab-widgets/quick-start-cleanup.asciidoc
+++ b/docs/reference/tab-widgets/quick-start-cleanup.asciidoc
@@ -9,7 +9,7 @@ To stop your {es} and {kib} Docker containers, run:
 
 [source,sh]
 ----
-docker stop es-node01
+docker stop es01
 docker stop kib-01
 ----
 
@@ -18,7 +18,7 @@ To remove the containers and their network, run:
 [source,sh]
 ----
 docker network rm elastic
-docker rm es-node01
+docker rm es01
 docker rm kib-01
 ----
 // end::self-managed[]

--- a/docs/reference/tab-widgets/quick-start-cleanup.asciidoc
+++ b/docs/reference/tab-widgets/quick-start-cleanup.asciidoc
@@ -10,7 +10,7 @@ To stop your {es} and {kib} Docker containers, run:
 [source,sh]
 ----
 docker stop es01
-docker stop kib-01
+docker stop kibana
 ----
 
 To remove the containers and their network, run:
@@ -19,6 +19,6 @@ To remove the containers and their network, run:
 ----
 docker network rm elastic
 docker rm es01
-docker rm kib-01
+docker rm kibana
 ----
 // end::self-managed[]

--- a/docs/reference/tab-widgets/quick-start-install.asciidoc
+++ b/docs/reference/tab-widgets/quick-start-install.asciidoc
@@ -25,7 +25,7 @@ Desktop].
 ----
 docker network create elastic
 docker pull {docker-repo}:{version}
-docker run --name es-node01 --net elastic -p 9200:9200 -p 9300:9300 -it {docker-image}
+docker run --name es01 --net elastic -p 9200:9200 -p 9300:9300 -it {docker-image}
 ----
 +
 When you start {es} for the first time, the following security configuration 

--- a/docs/reference/tab-widgets/quick-start-install.asciidoc
+++ b/docs/reference/tab-widgets/quick-start-install.asciidoc
@@ -73,7 +73,7 @@ ifeval::["{release-state}"!="unreleased"]
 ["source","txt",subs="attributes"]
 ----
 docker pull docker.elastic.co/kibana/kibana:{version}
-docker run --name kib-01 --net elastic -p 5601:5601 docker.elastic.co/kibana/kibana:{version}
+docker run --name kibana --net elastic -p 5601:5601 docker.elastic.co/kibana/kibana:{version}
 ----
 +
 When you start {kib}, a unique link is output to your terminal.


### PR DESCRIPTION
Updates the `curl` commands in the quick start guide to use the generated security certificate. Because the quickstart uses Docker, these commands reference the security certificate in the Docker container.

Closes #85130