### PR TITLE
Dedicated API for unbatched master tasks

### DIFF
--- a/build-tools-internal/src/main/resources/forbidden/es-server-signatures.txt
+++ b/build-tools-internal/src/main/resources/forbidden/es-server-signatures.txt
@@ -139,4 +139,5 @@ org.apache.logging.log4j.LogManager#getLogger()
 java.lang.String#formatted(java.lang.Object[]) @ Uses default locale - use String#format(Locale, String, Object...) instead
 
 @defaultMessage Unbatched cluster state tasks are a source of performance and stability bugs. Implement the update logic in a executor which is reused across tasks instead.
-org.elasticsearch.cluster.ClusterStateTaskExecutor#unbatched()
+org.elasticsearch.cluster.service.MasterService#submitUnbatchedStateUpdateTask(java.lang.String, org.elasticsearch.cluster.ClusterStateUpdateTask)
+org.elasticsearch.cluster.service.ClusterService#submitUnbatchedStateUpdateTask(java.lang.String, org.elasticsearch.cluster.ClusterStateUpdateTask)

--- a/modules/data-streams/src/main/java/org/elasticsearch/datastreams/UpdateTimeSeriesRangeService.java
+++ b/modules/data-streams/src/main/java/org/elasticsearch/datastreams/UpdateTimeSeriesRangeService.java
@@ -11,7 +11,6 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.message.ParameterizedMessage;
 import org.elasticsearch.cluster.ClusterState;
-import org.elasticsearch.cluster.ClusterStateTaskExecutor;
 import org.elasticsearch.cluster.ClusterStateUpdateTask;
 import org.elasticsearch.cluster.LocalNodeMasterListener;
 import org.elasticsearch.cluster.metadata.DataStream;
@@ -60,7 +59,7 @@ public class UpdateTimeSeriesRangeService extends AbstractLifecycleComponent imp
     void perform(Runnable onComplete) {
         if (running.compareAndSet(false, true)) {
             LOGGER.debug("starting tsdb update task");
-            clusterService.submitStateUpdateTask("update_tsdb_data_stream_end_times", new ClusterStateUpdateTask(Priority.URGENT) {
+            submitUnbatchedTask("update_tsdb_data_stream_end_times", new ClusterStateUpdateTask(Priority.URGENT) {
                 @Override
                 public ClusterState execute(ClusterState currentState) throws Exception {
                     return updateTimeSeriesTemporalRange(currentState, Instant.now());
@@ -79,15 +78,15 @@ public class UpdateTimeSeriesRangeService extends AbstractLifecycleComponent imp
                     onComplete.run();
                 }
 
-            }, newExecutor());
+            });
         } else {
             LOGGER.debug("not starting tsdb update task, because another execution is still running");
         }
     }
 
     @SuppressForbidden(reason = "legacy usage of unbatched task") // TODO add support for batching here
-    private static <T extends ClusterStateUpdateTask> ClusterStateTaskExecutor<T> newExecutor() {
-        return ClusterStateTaskExecutor.unbatched();
+    private void submitUnbatchedTask(@SuppressWarnings("SameParameterValue") String source, ClusterStateUpdateTask task) {
+        clusterService.submitUnbatchedStateUpdateTask(source, task);
     }
 
     void setPollInterval(TimeValue newValue) {

--- a/modules/reindex/src/internalClusterTest/java/org/elasticsearch/migration/FeatureMigrationIT.java
+++ b/modules/reindex/src/internalClusterTest/java/org/elasticsearch/migration/FeatureMigrationIT.java
@@ -19,7 +19,6 @@ import org.elasticsearch.action.admin.indices.create.CreateIndexRequestBuilder;
 import org.elasticsearch.action.admin.indices.create.CreateIndexResponse;
 import org.elasticsearch.action.support.ActiveShardCount;
 import org.elasticsearch.cluster.ClusterState;
-import org.elasticsearch.cluster.ClusterStateTaskExecutor;
 import org.elasticsearch.cluster.ClusterStateUpdateTask;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.metadata.Metadata;
@@ -262,7 +261,7 @@ public class FeatureMigrationIT extends AbstractFeatureMigrationIntegTest {
         SetOnce<Exception> failure = new SetOnce<>();
         CountDownLatch clusterStateUpdated = new CountDownLatch(1);
         internalCluster().getCurrentMasterNodeInstance(ClusterService.class)
-            .submitStateUpdateTask(this.getTestName(), new ClusterStateUpdateTask() {
+            .submitUnbatchedStateUpdateTask(this.getTestName(), new ClusterStateUpdateTask() {
                 @Override
                 public ClusterState execute(ClusterState currentState) throws Exception {
                     FeatureMigrationResults newResults = new FeatureMigrationResults(
@@ -287,7 +286,7 @@ public class FeatureMigrationIT extends AbstractFeatureMigrationIntegTest {
                     failure.set(e);
                     clusterStateUpdated.countDown();
                 }
-            }, ClusterStateTaskExecutor.unbatched());
+            });
 
         clusterStateUpdated.await(10, TimeUnit.SECONDS); // Should be basically instantaneous
         if (failure.get() != null) {

--- a/qa/smoke-test-http/src/test/java/org/elasticsearch/http/ClusterStateRestCancellationIT.java
+++ b/qa/smoke-test-http/src/test/java/org/elasticsearch/http/ClusterStateRestCancellationIT.java
@@ -16,7 +16,6 @@ import org.elasticsearch.client.Cancellable;
 import org.elasticsearch.client.Request;
 import org.elasticsearch.client.Response;
 import org.elasticsearch.cluster.ClusterState;
-import org.elasticsearch.cluster.ClusterStateTaskExecutor;
 import org.elasticsearch.cluster.ClusterStateUpdateTask;
 import org.elasticsearch.cluster.SimpleDiffable;
 import org.elasticsearch.cluster.service.ClusterService;
@@ -45,7 +44,7 @@ public class ClusterStateRestCancellationIT extends HttpSmokeTestCase {
 
     private void updateClusterState(ClusterService clusterService, UnaryOperator<ClusterState> updateOperator) {
         final PlainActionFuture<Void> future = new PlainActionFuture<>();
-        clusterService.submitStateUpdateTask("update state", new ClusterStateUpdateTask() {
+        clusterService.submitUnbatchedStateUpdateTask("update state", new ClusterStateUpdateTask() {
             @Override
             public ClusterState execute(ClusterState currentState) {
                 return updateOperator.apply(currentState);
@@ -60,7 +59,7 @@ public class ClusterStateRestCancellationIT extends HttpSmokeTestCase {
             public void clusterStateProcessed(ClusterState oldState, ClusterState newState) {
                 future.onResponse(null);
             }
-        }, ClusterStateTaskExecutor.unbatched());
+        });
         future.actionGet();
     }
 

--- a/qa/smoke-test-http/src/test/java/org/elasticsearch/http/RestGetMappingsCancellationIT.java
+++ b/qa/smoke-test-http/src/test/java/org/elasticsearch/http/RestGetMappingsCancellationIT.java
@@ -17,7 +17,6 @@ import org.elasticsearch.client.Request;
 import org.elasticsearch.client.Response;
 import org.elasticsearch.cluster.AckedClusterStateUpdateTask;
 import org.elasticsearch.cluster.ClusterState;
-import org.elasticsearch.cluster.ClusterStateTaskExecutor;
 import org.elasticsearch.cluster.ack.AckedRequest;
 import org.elasticsearch.cluster.block.ClusterBlock;
 import org.elasticsearch.cluster.block.ClusterBlockLevel;
@@ -98,12 +97,12 @@ public class RestGetMappingsCancellationIT extends HttpSmokeTestCase {
 
         PlainActionFuture<AcknowledgedResponse> future = PlainActionFuture.newFuture();
         internalCluster().getAnyMasterNodeInstance(ClusterService.class)
-            .submitStateUpdateTask("get_mappings_cancellation_test", new AckedClusterStateUpdateTask(ackedRequest, future) {
+            .submitUnbatchedStateUpdateTask("get_mappings_cancellation_test", new AckedClusterStateUpdateTask(ackedRequest, future) {
                 @Override
                 public ClusterState execute(ClusterState currentState) throws Exception {
                     return transformationFn.apply(currentState);
                 }
-            }, ClusterStateTaskExecutor.unbatched());
+            });
 
         future.actionGet();
     }

--- a/server/src/internalClusterTest/java/org/elasticsearch/action/admin/cluster/desirednodes/TransportDesiredNodesActionsIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/action/admin/cluster/desirednodes/TransportDesiredNodesActionsIT.java
@@ -13,7 +13,6 @@ import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionFuture;
 import org.elasticsearch.action.ActionResponse;
 import org.elasticsearch.cluster.ClusterState;
-import org.elasticsearch.cluster.ClusterStateTaskExecutor;
 import org.elasticsearch.cluster.ClusterStateUpdateTask;
 import org.elasticsearch.cluster.desirednodes.VersionConflictException;
 import org.elasticsearch.cluster.metadata.DesiredNode;
@@ -364,7 +363,7 @@ public class TransportDesiredNodesActionsIT extends ESIntegTestCase {
         final CountDownLatch unblockClusterStateUpdateTask = new CountDownLatch(1);
         final CountDownLatch blockingClusterStateUpdateTaskExecuting = new CountDownLatch(1);
         final ClusterService clusterService = internalCluster().getCurrentMasterNodeInstance(ClusterService.class);
-        clusterService.submitStateUpdateTask("blocking-task", new ClusterStateUpdateTask(Priority.IMMEDIATE) {
+        clusterService.submitUnbatchedStateUpdateTask("blocking-task", new ClusterStateUpdateTask(Priority.IMMEDIATE) {
             @Override
             public ClusterState execute(ClusterState currentState) throws Exception {
                 blockingClusterStateUpdateTaskExecuting.countDown();
@@ -377,7 +376,7 @@ public class TransportDesiredNodesActionsIT extends ESIntegTestCase {
                 blockingClusterStateUpdateTaskExecuting.countDown();
                 assert false : e.getMessage();
             }
-        }, ClusterStateTaskExecutor.unbatched());
+        });
 
         assertTrue(blockingClusterStateUpdateTaskExecuting.await(10, TimeUnit.SECONDS));
         return unblockClusterStateUpdateTask::countDown;

--- a/server/src/internalClusterTest/java/org/elasticsearch/cluster/ClusterHealthIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/cluster/ClusterHealthIT.java
@@ -286,7 +286,7 @@ public class ClusterHealthIT extends ESIntegTestCase {
         final AtomicBoolean keepSubmittingTasks = new AtomicBoolean(true);
         final ClusterService clusterService = internalCluster().getInstance(ClusterService.class, internalCluster().getMasterName());
         final PlainActionFuture<Void> completionFuture = new PlainActionFuture<>();
-        clusterService.submitStateUpdateTask("looping task", new ClusterStateUpdateTask(Priority.LOW) {
+        clusterService.submitUnbatchedStateUpdateTask("looping task", new ClusterStateUpdateTask(Priority.LOW) {
             @Override
             public ClusterState execute(ClusterState currentState) {
                 return currentState;
@@ -301,12 +301,12 @@ public class ClusterHealthIT extends ESIntegTestCase {
             @Override
             public void clusterStateProcessed(ClusterState oldState, ClusterState newState) {
                 if (keepSubmittingTasks.get()) {
-                    clusterService.submitStateUpdateTask("looping task", this, ClusterStateTaskExecutor.unbatched());
+                    clusterService.submitUnbatchedStateUpdateTask("looping task", this);
                 } else {
                     completionFuture.onResponse(null);
                 }
             }
-        }, ClusterStateTaskExecutor.unbatched());
+        });
 
         try {
             createIndex("index");
@@ -377,7 +377,7 @@ public class ClusterHealthIT extends ESIntegTestCase {
         final AtomicBoolean keepSubmittingTasks = new AtomicBoolean(true);
         final ClusterService clusterService = internalCluster().getInstance(ClusterService.class, internalCluster().getMasterName());
         final PlainActionFuture<Void> completionFuture = new PlainActionFuture<>();
-        clusterService.submitStateUpdateTask("looping task", new ClusterStateUpdateTask(Priority.LOW) {
+        clusterService.submitUnbatchedStateUpdateTask("looping task", new ClusterStateUpdateTask(Priority.LOW) {
             @Override
             public ClusterState execute(ClusterState currentState) {
                 return currentState;
@@ -392,12 +392,12 @@ public class ClusterHealthIT extends ESIntegTestCase {
             @Override
             public void clusterStateProcessed(ClusterState oldState, ClusterState newState) {
                 if (keepSubmittingTasks.get()) {
-                    clusterService.submitStateUpdateTask("looping task", this, ClusterStateTaskExecutor.unbatched());
+                    clusterService.submitUnbatchedStateUpdateTask("looping task", this);
                 } else {
                     completionFuture.onResponse(null);
                 }
             }
-        }, ClusterStateTaskExecutor.unbatched());
+        });
 
         try {
             final ClusterHealthResponse clusterHealthResponse = client().admin()

--- a/server/src/internalClusterTest/java/org/elasticsearch/cluster/MinimumMasterNodesIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/cluster/MinimumMasterNodesIT.java
@@ -333,7 +333,7 @@ public class MinimumMasterNodesIT extends ESIntegTestCase {
         final AtomicReference<Exception> failure = new AtomicReference<>();
         logger.debug("--> submitting for cluster state to be rejected");
         final ClusterService masterClusterService = internalCluster().clusterService(master);
-        masterClusterService.submitStateUpdateTask("test", new ClusterStateUpdateTask() {
+        masterClusterService.submitUnbatchedStateUpdateTask("test", new ClusterStateUpdateTask() {
             @Override
             public void clusterStateProcessed(ClusterState oldState, ClusterState newState) {
                 latch.countDown();
@@ -355,7 +355,7 @@ public class MinimumMasterNodesIT extends ESIntegTestCase {
                 failure.set(e);
                 latch.countDown();
             }
-        }, ClusterStateTaskExecutor.unbatched());
+        });
 
         logger.debug("--> waiting for cluster state to be processed/rejected");
         latch.await();

--- a/server/src/internalClusterTest/java/org/elasticsearch/cluster/SimpleClusterStateIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/cluster/SimpleClusterStateIT.java
@@ -450,25 +450,28 @@ public class SimpleClusterStateIT extends ESIntegTestCase {
                 if (state.nodes().isLocalNodeElectedMaster()) {
                     if (state.custom("test") == null) {
                         if (installed.compareAndSet(false, true)) {
-                            clusterService.submitStateUpdateTask("install-metadata-custom", new ClusterStateUpdateTask(Priority.URGENT) {
+                            clusterService.submitUnbatchedStateUpdateTask(
+                                "install-metadata-custom",
+                                new ClusterStateUpdateTask(Priority.URGENT) {
 
-                                @Override
-                                public ClusterState execute(ClusterState currentState) {
-                                    if (currentState.custom("test") == null) {
-                                        final ClusterState.Builder builder = ClusterState.builder(currentState);
-                                        builder.putCustom("test", new TestCustom(42));
-                                        return builder.build();
-                                    } else {
-                                        return currentState;
+                                    @Override
+                                    public ClusterState execute(ClusterState currentState) {
+                                        if (currentState.custom("test") == null) {
+                                            final ClusterState.Builder builder = ClusterState.builder(currentState);
+                                            builder.putCustom("test", new TestCustom(42));
+                                            return builder.build();
+                                        } else {
+                                            return currentState;
+                                        }
                                     }
-                                }
 
-                                @Override
-                                public void onFailure(Exception e) {
-                                    throw new AssertionError(e);
-                                }
+                                    @Override
+                                    public void onFailure(Exception e) {
+                                        throw new AssertionError(e);
+                                    }
 
-                            }, ClusterStateTaskExecutor.unbatched());
+                                }
+                            );
                         }
                     }
                 }

--- a/server/src/internalClusterTest/java/org/elasticsearch/cluster/coordination/RareClusterStateIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/cluster/coordination/RareClusterStateIT.java
@@ -17,7 +17,6 @@ import org.elasticsearch.action.ActionResponse;
 import org.elasticsearch.action.index.IndexResponse;
 import org.elasticsearch.action.support.master.AcknowledgedResponse;
 import org.elasticsearch.cluster.ClusterState;
-import org.elasticsearch.cluster.ClusterStateTaskExecutor;
 import org.elasticsearch.cluster.ClusterStateUpdateTask;
 import org.elasticsearch.cluster.block.ClusterBlocks;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
@@ -81,7 +80,7 @@ public class RareClusterStateIT extends ESIntegTestCase {
         final String masterName = internalCluster().getMasterName();
         final ClusterService clusterService = internalCluster().clusterService(masterName);
         final AllocationService allocationService = internalCluster().getInstance(AllocationService.class, masterName);
-        clusterService.submitStateUpdateTask("test-inject-node-and-reroute", new ClusterStateUpdateTask() {
+        clusterService.submitUnbatchedStateUpdateTask("test-inject-node-and-reroute", new ClusterStateUpdateTask() {
             @Override
             public ClusterState execute(ClusterState currentState) {
                 // inject a node
@@ -109,10 +108,10 @@ public class RareClusterStateIT extends ESIntegTestCase {
 
             @Override
             public void onFailure(Exception e) {}
-        }, ClusterStateTaskExecutor.unbatched());
+        });
         ensureGreen(index);
         // remove the extra node
-        clusterService.submitStateUpdateTask("test-remove-injected-node", new ClusterStateUpdateTask() {
+        clusterService.submitUnbatchedStateUpdateTask("test-remove-injected-node", new ClusterStateUpdateTask() {
             @Override
             public ClusterState execute(ClusterState currentState) throws Exception {
                 ClusterState.Builder builder = ClusterState.builder(currentState);
@@ -124,7 +123,7 @@ public class RareClusterStateIT extends ESIntegTestCase {
 
             @Override
             public void onFailure(Exception e) {}
-        }, ClusterStateTaskExecutor.unbatched());
+        });
     }
 
     private <Req extends ActionRequest, Res extends ActionResponse> ActionFuture<Res> executeAndCancelCommittedPublication(

--- a/server/src/internalClusterTest/java/org/elasticsearch/cluster/service/ClusterServiceIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/cluster/service/ClusterServiceIT.java
@@ -10,7 +10,6 @@ package org.elasticsearch.cluster.service;
 import org.elasticsearch.action.admin.cluster.tasks.PendingClusterTasksResponse;
 import org.elasticsearch.cluster.AckedClusterStateUpdateTask;
 import org.elasticsearch.cluster.ClusterState;
-import org.elasticsearch.cluster.ClusterStateTaskExecutor;
 import org.elasticsearch.cluster.ClusterStateUpdateTask;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.common.settings.Settings;
@@ -47,7 +46,7 @@ public class ClusterServiceIT extends ESIntegTestCase {
         final AtomicBoolean executed = new AtomicBoolean(false);
         final CountDownLatch latch = new CountDownLatch(1);
         final CountDownLatch processedLatch = new CountDownLatch(1);
-        clusterService.submitStateUpdateTask(
+        clusterService.submitUnbatchedStateUpdateTask(
             "test",
             new AckedClusterStateUpdateTask(MasterServiceTests.ackedRequest(TEN_SECONDS, TEN_SECONDS), null) {
                 @Override
@@ -90,8 +89,7 @@ public class ClusterServiceIT extends ESIntegTestCase {
                     onFailure.set(true);
                     latch.countDown();
                 }
-            },
-            ClusterStateTaskExecutor.unbatched()
+            }
         );
 
         ensureGreen();
@@ -117,7 +115,7 @@ public class ClusterServiceIT extends ESIntegTestCase {
         final AtomicBoolean executed = new AtomicBoolean(false);
         final CountDownLatch latch = new CountDownLatch(1);
         final CountDownLatch processedLatch = new CountDownLatch(1);
-        clusterService.submitStateUpdateTask(
+        clusterService.submitUnbatchedStateUpdateTask(
             "test",
             new AckedClusterStateUpdateTask(MasterServiceTests.ackedRequest(TEN_SECONDS, TEN_SECONDS), null) {
                 @Override
@@ -155,8 +153,7 @@ public class ClusterServiceIT extends ESIntegTestCase {
                     onFailure.set(true);
                     latch.countDown();
                 }
-            },
-            ClusterStateTaskExecutor.unbatched()
+            }
         );
 
         ensureGreen();
@@ -182,7 +179,7 @@ public class ClusterServiceIT extends ESIntegTestCase {
         final AtomicBoolean executed = new AtomicBoolean(false);
         final CountDownLatch latch = new CountDownLatch(1);
 
-        clusterService.submitStateUpdateTask(
+        clusterService.submitUnbatchedStateUpdateTask(
             "test",
             new AckedClusterStateUpdateTask(MasterServiceTests.ackedRequest(TEN_SECONDS, TEN_SECONDS), null) {
                 @Override
@@ -223,8 +220,7 @@ public class ClusterServiceIT extends ESIntegTestCase {
                     onFailure.set(true);
                     latch.countDown();
                 }
-            },
-            ClusterStateTaskExecutor.unbatched()
+            }
         );
 
         ensureGreen();
@@ -248,7 +244,7 @@ public class ClusterServiceIT extends ESIntegTestCase {
         final AtomicBoolean executed = new AtomicBoolean(false);
         final CountDownLatch latch = new CountDownLatch(1);
         final CountDownLatch processedLatch = new CountDownLatch(1);
-        clusterService.submitStateUpdateTask(
+        clusterService.submitUnbatchedStateUpdateTask(
             "test",
             new AckedClusterStateUpdateTask(MasterServiceTests.ackedRequest(TimeValue.ZERO, TEN_SECONDS), null) {
                 @Override
@@ -291,8 +287,7 @@ public class ClusterServiceIT extends ESIntegTestCase {
                     onFailure.set(true);
                     latch.countDown();
                 }
-            },
-            ClusterStateTaskExecutor.unbatched()
+            }
         );
 
         ensureGreen();
@@ -314,7 +309,7 @@ public class ClusterServiceIT extends ESIntegTestCase {
         final ClusterService clusterService = internalCluster().getInstance(ClusterService.class, node_0);
         final CountDownLatch block1 = new CountDownLatch(1);
         final CountDownLatch invoked1 = new CountDownLatch(1);
-        clusterService.submitStateUpdateTask("1", new ClusterStateUpdateTask() {
+        clusterService.submitUnbatchedStateUpdateTask("1", new ClusterStateUpdateTask() {
             @Override
             public ClusterState execute(ClusterState currentState) {
                 invoked1.countDown();
@@ -331,11 +326,11 @@ public class ClusterServiceIT extends ESIntegTestCase {
                 invoked1.countDown();
                 fail();
             }
-        }, ClusterStateTaskExecutor.unbatched());
+        });
         invoked1.await();
         final CountDownLatch invoked2 = new CountDownLatch(9);
         for (int i = 2; i <= 10; i++) {
-            clusterService.submitStateUpdateTask(Integer.toString(i), new ClusterStateUpdateTask() {
+            clusterService.submitUnbatchedStateUpdateTask(Integer.toString(i), new ClusterStateUpdateTask() {
                 @Override
                 public ClusterState execute(ClusterState currentState) {
                     return currentState;
@@ -350,7 +345,7 @@ public class ClusterServiceIT extends ESIntegTestCase {
                 public void clusterStateProcessed(ClusterState oldState, ClusterState newState) {
                     invoked2.countDown();
                 }
-            }, ClusterStateTaskExecutor.unbatched());
+            });
         }
 
         // there might be other tasks in this node, make sure to only take the ones we add into account in this test
@@ -384,7 +379,7 @@ public class ClusterServiceIT extends ESIntegTestCase {
 
         final CountDownLatch block2 = new CountDownLatch(1);
         final CountDownLatch invoked3 = new CountDownLatch(1);
-        clusterService.submitStateUpdateTask("1", new ClusterStateUpdateTask() {
+        clusterService.submitUnbatchedStateUpdateTask("1", new ClusterStateUpdateTask() {
             @Override
             public ClusterState execute(ClusterState currentState) {
                 invoked3.countDown();
@@ -401,11 +396,11 @@ public class ClusterServiceIT extends ESIntegTestCase {
                 invoked3.countDown();
                 fail();
             }
-        }, ClusterStateTaskExecutor.unbatched());
+        });
         invoked3.await();
 
         for (int i = 2; i <= 5; i++) {
-            clusterService.submitStateUpdateTask(Integer.toString(i), new ClusterStateUpdateTask() {
+            clusterService.submitUnbatchedStateUpdateTask(Integer.toString(i), new ClusterStateUpdateTask() {
                 @Override
                 public ClusterState execute(ClusterState currentState) {
                     return currentState;
@@ -415,7 +410,7 @@ public class ClusterServiceIT extends ESIntegTestCase {
                 public void onFailure(Exception e) {
                     fail();
                 }
-            }, ClusterStateTaskExecutor.unbatched());
+            });
         }
         Thread.sleep(100);
 

--- a/server/src/internalClusterTest/java/org/elasticsearch/discovery/StableMasterDisruptionIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/discovery/StableMasterDisruptionIT.java
@@ -10,7 +10,6 @@ package org.elasticsearch.discovery;
 
 import org.elasticsearch.action.admin.cluster.state.ClusterStateRequest;
 import org.elasticsearch.cluster.ClusterState;
-import org.elasticsearch.cluster.ClusterStateTaskExecutor;
 import org.elasticsearch.cluster.ClusterStateUpdateTask;
 import org.elasticsearch.cluster.coordination.Coordinator;
 import org.elasticsearch.cluster.coordination.FollowersChecker;
@@ -232,7 +231,7 @@ public class StableMasterDisruptionIT extends ESIntegTestCase {
         // once the old master node un-freezes it gets executed. The old master node will send this update + the cluster state where it is
         // flagged as master to the other nodes that follow the new master. These nodes should ignore this update.
         internalCluster().getInstance(ClusterService.class, oldMasterNode)
-            .submitStateUpdateTask("sneaky-update", new ClusterStateUpdateTask(Priority.IMMEDIATE) {
+            .submitUnbatchedStateUpdateTask("sneaky-update", new ClusterStateUpdateTask(Priority.IMMEDIATE) {
                 @Override
                 public ClusterState execute(ClusterState currentState) {
                     return ClusterState.builder(currentState).build();
@@ -242,7 +241,7 @@ public class StableMasterDisruptionIT extends ESIntegTestCase {
                 public void onFailure(Exception e) {
                     logger.warn("failure [sneaky-update]", e);
                 }
-            }, ClusterStateTaskExecutor.unbatched());
+            });
 
         // Save the new elected master node
         final String newMasterNode = internalCluster().getMasterName(majoritySide.get(0));

--- a/server/src/internalClusterTest/java/org/elasticsearch/index/mapper/DynamicMappingIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/index/mapper/DynamicMappingIT.java
@@ -16,7 +16,6 @@ import org.elasticsearch.action.index.IndexRequestBuilder;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.action.support.WriteRequest;
 import org.elasticsearch.cluster.ClusterState;
-import org.elasticsearch.cluster.ClusterStateTaskExecutor;
 import org.elasticsearch.cluster.ClusterStateUpdateTask;
 import org.elasticsearch.cluster.metadata.MappingMetadata;
 import org.elasticsearch.cluster.service.ClusterService;
@@ -147,7 +146,7 @@ public class DynamicMappingIT extends ESIntegTestCase {
         final CountDownLatch indexingCompletedLatch = new CountDownLatch(1);
 
         internalCluster().getInstance(ClusterService.class, internalCluster().getMasterName())
-            .submitStateUpdateTask("block-state-updates", new ClusterStateUpdateTask() {
+            .submitUnbatchedStateUpdateTask("block-state-updates", new ClusterStateUpdateTask() {
                 @Override
                 public ClusterState execute(ClusterState currentState) throws Exception {
                     masterBlockedLatch.countDown();
@@ -159,7 +158,7 @@ public class DynamicMappingIT extends ESIntegTestCase {
                 public void onFailure(Exception e) {
                     throw new AssertionError("unexpected", e);
                 }
-            }, ClusterStateTaskExecutor.unbatched());
+            });
 
         masterBlockedLatch.await();
         final IndexRequestBuilder indexRequestBuilder = client().prepareIndex("index")
@@ -184,7 +183,7 @@ public class DynamicMappingIT extends ESIntegTestCase {
         final CountDownLatch indexingCompletedLatch = new CountDownLatch(1);
 
         internalCluster().getInstance(ClusterService.class, internalCluster().getMasterName())
-            .submitStateUpdateTask("block-state-updates", new ClusterStateUpdateTask() {
+            .submitUnbatchedStateUpdateTask("block-state-updates", new ClusterStateUpdateTask() {
                 @Override
                 public ClusterState execute(ClusterState currentState) throws Exception {
                     masterBlockedLatch.countDown();
@@ -196,7 +195,7 @@ public class DynamicMappingIT extends ESIntegTestCase {
                 public void onFailure(Exception e) {
                     throw new AssertionError("unexpected", e);
                 }
-            }, ClusterStateTaskExecutor.unbatched());
+            });
 
         masterBlockedLatch.await();
         final IndexRequestBuilder indexRequestBuilder = client().prepareIndex("index").setId("2").setSource("field2", "value2");

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/configuration/TransportAddVotingConfigExclusionsAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/configuration/TransportAddVotingConfigExclusionsAction.java
@@ -18,7 +18,6 @@ import org.elasticsearch.action.support.master.TransportMasterNodeAction;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.ClusterStateObserver;
 import org.elasticsearch.cluster.ClusterStateObserver.Listener;
-import org.elasticsearch.cluster.ClusterStateTaskExecutor;
 import org.elasticsearch.cluster.ClusterStateUpdateTask;
 import org.elasticsearch.cluster.block.ClusterBlockException;
 import org.elasticsearch.cluster.block.ClusterBlockLevel;
@@ -100,7 +99,7 @@ public class TransportAddVotingConfigExclusionsAction extends TransportMasterNod
         resolveVotingConfigExclusionsAndCheckMaximum(request, state, maxVotingConfigExclusions);
         // throws IAE if no nodes matched or maximum exceeded
 
-        clusterService.submitStateUpdateTask("add-voting-config-exclusions", new ClusterStateUpdateTask(Priority.URGENT) {
+        submitUnbatchedTask("add-voting-config-exclusions", new ClusterStateUpdateTask(Priority.URGENT) {
 
             private Set<VotingConfigExclusion> resolvedExclusions;
 
@@ -175,12 +174,12 @@ public class TransportAddVotingConfigExclusionsAction extends TransportMasterNod
                     observer.waitForNextChange(clusterStateListener, allNodesRemoved);
                 }
             }
-        }, newExecutor());
+        });
     }
 
     @SuppressForbidden(reason = "legacy usage of unbatched task") // TODO add support for batching here
-    private static <T extends ClusterStateUpdateTask> ClusterStateTaskExecutor<T> newExecutor() {
-        return ClusterStateTaskExecutor.unbatched();
+    private void submitUnbatchedTask(@SuppressWarnings("SameParameterValue") String source, ClusterStateUpdateTask task) {
+        clusterService.submitUnbatchedStateUpdateTask(source, task);
     }
 
     private static Set<VotingConfigExclusion> resolveVotingConfigExclusionsAndCheckMaximum(

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/configuration/TransportClearVotingConfigExclusionsAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/configuration/TransportClearVotingConfigExclusionsAction.java
@@ -18,7 +18,6 @@ import org.elasticsearch.action.support.master.TransportMasterNodeAction;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.ClusterStateObserver;
 import org.elasticsearch.cluster.ClusterStateObserver.Listener;
-import org.elasticsearch.cluster.ClusterStateTaskExecutor;
 import org.elasticsearch.cluster.ClusterStateUpdateTask;
 import org.elasticsearch.cluster.block.ClusterBlockException;
 import org.elasticsearch.cluster.block.ClusterBlockLevel;
@@ -128,7 +127,7 @@ public class TransportClearVotingConfigExclusionsAction extends TransportMasterN
         long startTimeMillis,
         ActionListener<ActionResponse.Empty> listener
     ) {
-        clusterService.submitStateUpdateTask(
+        submitUnbatchedTask(
             "clear-voting-config-exclusions",
             new ClusterStateUpdateTask(
                 Priority.URGENT,
@@ -154,14 +153,13 @@ public class TransportClearVotingConfigExclusionsAction extends TransportMasterN
                 public void clusterStateProcessed(ClusterState oldState, ClusterState newState) {
                     listener.onResponse(ActionResponse.Empty.INSTANCE);
                 }
-            },
-            newExecutor()
+            }
         );
     }
 
     @SuppressForbidden(reason = "legacy usage of unbatched task") // TODO add support for batching here
-    private static <T extends ClusterStateUpdateTask> ClusterStateTaskExecutor<T> newExecutor() {
-        return ClusterStateTaskExecutor.unbatched();
+    private void submitUnbatchedTask(@SuppressWarnings("SameParameterValue") String source, ClusterStateUpdateTask task) {
+        clusterService.submitUnbatchedStateUpdateTask(source, task);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/settings/TransportClusterUpdateSettingsAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/settings/TransportClusterUpdateSettingsAction.java
@@ -17,7 +17,6 @@ import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.master.TransportMasterNodeAction;
 import org.elasticsearch.cluster.AckedClusterStateUpdateTask;
 import org.elasticsearch.cluster.ClusterState;
-import org.elasticsearch.cluster.ClusterStateTaskExecutor;
 import org.elasticsearch.cluster.ClusterStateUpdateTask;
 import org.elasticsearch.cluster.block.ClusterBlockException;
 import org.elasticsearch.cluster.block.ClusterBlockLevel;
@@ -145,7 +144,7 @@ public class TransportClusterUpdateSettingsAction extends TransportMasterNodeAct
         final ActionListener<ClusterUpdateSettingsResponse> listener
     ) {
         final SettingsUpdater updater = new SettingsUpdater(clusterSettings);
-        clusterService.submitStateUpdateTask(UPDATE_TASK_SOURCE, new AckedClusterStateUpdateTask(Priority.IMMEDIATE, request, listener) {
+        submitUnbatchedTask(UPDATE_TASK_SOURCE, new AckedClusterStateUpdateTask(Priority.IMMEDIATE, request, listener) {
 
             private volatile boolean changed = false;
 
@@ -197,56 +196,50 @@ public class TransportClusterUpdateSettingsAction extends TransportMasterNodeAct
                 // in the components (e.g. FilterAllocationDecider), so the changes made by the first call aren't visible
                 // to the components until the ClusterStateListener instances have been invoked, but are visible after
                 // the first update task has been completed.
-                clusterService.submitStateUpdateTask(
-                    REROUTE_TASK_SOURCE,
-                    new AckedClusterStateUpdateTask(Priority.URGENT, request, listener) {
+                submitUnbatchedTask(REROUTE_TASK_SOURCE, new AckedClusterStateUpdateTask(Priority.URGENT, request, listener) {
 
-                        @Override
-                        public boolean mustAck(DiscoveryNode discoveryNode) {
-                            // we wait for the reroute ack only if the update settings was acknowledged
-                            return updateSettingsAcked;
-                        }
+                    @Override
+                    public boolean mustAck(DiscoveryNode discoveryNode) {
+                        // we wait for the reroute ack only if the update settings was acknowledged
+                        return updateSettingsAcked;
+                    }
 
-                        @Override
-                        // we return when the cluster reroute is acked or it times out but the acknowledged flag depends on whether the
-                        // update settings was acknowledged
-                        protected ClusterUpdateSettingsResponse newResponse(boolean acknowledged) {
-                            return new ClusterUpdateSettingsResponse(
-                                updateSettingsAcked && acknowledged,
+                    @Override
+                    // we return when the cluster reroute is acked or it times out but the acknowledged flag depends on whether the
+                    // update settings was acknowledged
+                    protected ClusterUpdateSettingsResponse newResponse(boolean acknowledged) {
+                        return new ClusterUpdateSettingsResponse(
+                            updateSettingsAcked && acknowledged,
+                            updater.getTransientUpdates(),
+                            updater.getPersistentUpdate()
+                        );
+                    }
+
+                    @Override
+                    public void onNoLongerMaster() {
+                        logger.debug("failed to preform reroute after cluster settings were updated - current node is no longer a master");
+                        listener.onResponse(
+                            new ClusterUpdateSettingsResponse(
+                                updateSettingsAcked,
                                 updater.getTransientUpdates(),
                                 updater.getPersistentUpdate()
-                            );
-                        }
+                            )
+                        );
+                    }
 
-                        @Override
-                        public void onNoLongerMaster() {
-                            logger.debug(
-                                "failed to preform reroute after cluster settings were updated - current node is no longer a master"
-                            );
-                            listener.onResponse(
-                                new ClusterUpdateSettingsResponse(
-                                    updateSettingsAcked,
-                                    updater.getTransientUpdates(),
-                                    updater.getPersistentUpdate()
-                                )
-                            );
-                        }
+                    @Override
+                    public void onFailure(Exception e) {
+                        // if the reroute fails we only log
+                        logger.debug(() -> new ParameterizedMessage("failed to perform [{}]", REROUTE_TASK_SOURCE), e);
+                        listener.onFailure(new ElasticsearchException("reroute after update settings failed", e));
+                    }
 
-                        @Override
-                        public void onFailure(Exception e) {
-                            // if the reroute fails we only log
-                            logger.debug(() -> new ParameterizedMessage("failed to perform [{}]", REROUTE_TASK_SOURCE), e);
-                            listener.onFailure(new ElasticsearchException("reroute after update settings failed", e));
-                        }
-
-                        @Override
-                        public ClusterState execute(final ClusterState currentState) {
-                            // now, reroute in case things that require it changed (e.g. number of replicas)
-                            return allocationService.reroute(currentState, "reroute after cluster update settings");
-                        }
-                    },
-                    newExecutor()
-                );
+                    @Override
+                    public ClusterState execute(final ClusterState currentState) {
+                        // now, reroute in case things that require it changed (e.g. number of replicas)
+                        return allocationService.reroute(currentState, "reroute after cluster update settings");
+                    }
+                });
             }
 
             @Override
@@ -266,11 +259,11 @@ public class TransportClusterUpdateSettingsAction extends TransportMasterNodeAct
                 changed = clusterState != currentState;
                 return clusterState;
             }
-        }, newExecutor());
+        });
     }
 
     @SuppressForbidden(reason = "legacy usage of unbatched task") // TODO add support for batching here
-    private static <T extends ClusterStateUpdateTask> ClusterStateTaskExecutor<T> newExecutor() {
-        return ClusterStateTaskExecutor.unbatched();
+    private void submitUnbatchedTask(@SuppressWarnings("SameParameterValue") String source, ClusterStateUpdateTask task) {
+        clusterService.submitUnbatchedStateUpdateTask(source, task);
     }
 }

--- a/server/src/main/java/org/elasticsearch/cluster/coordination/Coordinator.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/Coordinator.java
@@ -22,7 +22,6 @@ import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.ClusterStatePublicationEvent;
 import org.elasticsearch.cluster.ClusterStateTaskConfig;
-import org.elasticsearch.cluster.ClusterStateTaskExecutor;
 import org.elasticsearch.cluster.ClusterStateUpdateTask;
 import org.elasticsearch.cluster.LocalMasterServiceTask;
 import org.elasticsearch.cluster.block.ClusterBlocks;
@@ -1217,7 +1216,7 @@ public class Coordinator extends AbstractLifecycleComponent implements ClusterSt
         final ClusterState state = getLastAcceptedState();
         if (improveConfiguration(state) != state && reconfigurationTaskScheduled.compareAndSet(false, true)) {
             logger.trace("scheduling reconfiguration");
-            masterService.submitStateUpdateTask("reconfigure", new ClusterStateUpdateTask(Priority.URGENT) {
+            submitUnbatchedTask("reconfigure", new ClusterStateUpdateTask(Priority.URGENT) {
                 @Override
                 public ClusterState execute(ClusterState currentState) {
                     reconfigurationTaskScheduled.set(false);
@@ -1231,13 +1230,13 @@ public class Coordinator extends AbstractLifecycleComponent implements ClusterSt
                     reconfigurationTaskScheduled.set(false);
                     logger.debug("reconfiguration failed", e);
                 }
-            }, newExecutor());
+            });
         }
     }
 
     @SuppressForbidden(reason = "legacy usage of unbatched task") // TODO add support for batching here
-    private static <T extends ClusterStateUpdateTask> ClusterStateTaskExecutor<T> newExecutor() {
-        return ClusterStateTaskExecutor.unbatched();
+    private void submitUnbatchedTask(String source, ClusterStateUpdateTask task) {
+        masterService.submitUnbatchedStateUpdateTask(source, task);
     }
 
     // exposed for tests

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataCreateDataStreamService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataCreateDataStreamService.java
@@ -19,7 +19,6 @@ import org.elasticsearch.action.support.ActiveShardsObserver;
 import org.elasticsearch.action.support.master.AcknowledgedResponse;
 import org.elasticsearch.cluster.AckedClusterStateUpdateTask;
 import org.elasticsearch.cluster.ClusterState;
-import org.elasticsearch.cluster.ClusterStateTaskExecutor;
 import org.elasticsearch.cluster.ClusterStateUpdateTask;
 import org.elasticsearch.cluster.ack.ClusterStateUpdateRequest;
 import org.elasticsearch.cluster.service.ClusterService;
@@ -81,23 +80,19 @@ public class MetadataCreateDataStreamService {
                 finalListener.onResponse(AcknowledgedResponse.FALSE);
             }
         }, finalListener::onFailure);
-        clusterService.submitStateUpdateTask(
-            "create-data-stream [" + request.name + "]",
-            new AckedClusterStateUpdateTask(Priority.HIGH, request, listener) {
-                @Override
-                public ClusterState execute(ClusterState currentState) throws Exception {
-                    ClusterState clusterState = createDataStream(metadataCreateIndexService, currentState, request);
-                    firstBackingIndexRef.set(clusterState.metadata().dataStreams().get(request.name).getIndices().get(0).getName());
-                    return clusterState;
-                }
-            },
-            newExecutor()
-        );
+        submitUnbatchedTask("create-data-stream [" + request.name + "]", new AckedClusterStateUpdateTask(Priority.HIGH, request, listener) {
+            @Override
+            public ClusterState execute(ClusterState currentState) throws Exception {
+                ClusterState clusterState = createDataStream(metadataCreateIndexService, currentState, request);
+                firstBackingIndexRef.set(clusterState.metadata().dataStreams().get(request.name).getIndices().get(0).getName());
+                return clusterState;
+            }
+        });
     }
 
     @SuppressForbidden(reason = "legacy usage of unbatched task") // TODO add support for batching here
-    private static <T extends ClusterStateUpdateTask> ClusterStateTaskExecutor<T> newExecutor() {
-        return ClusterStateTaskExecutor.unbatched();
+    private void submitUnbatchedTask(@SuppressWarnings("SameParameterValue") String source, ClusterStateUpdateTask task) {
+        clusterService.submitUnbatchedStateUpdateTask(source, task);
     }
 
     public ClusterState createDataStream(CreateDataStreamClusterStateUpdateRequest request, ClusterState current) throws Exception {

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataUpdateSettingsService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataUpdateSettingsService.java
@@ -263,7 +263,12 @@ public class MetadataUpdateSettingsService {
             }
         };
 
-        clusterService.submitStateUpdateTask("update-settings " + Arrays.toString(request.indices()), clusterTask, this.executor);
+        clusterService.submitStateUpdateTask(
+            "update-settings " + Arrays.toString(request.indices()),
+            clusterTask,
+            clusterTask,
+            this.executor
+        );
     }
 
     public static void updateIndexSettings(

--- a/server/src/main/java/org/elasticsearch/cluster/routing/DelayedAllocationService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/DelayedAllocationService.java
@@ -13,7 +13,6 @@ import org.apache.logging.log4j.Logger;
 import org.elasticsearch.cluster.ClusterChangedEvent;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.ClusterStateListener;
-import org.elasticsearch.cluster.ClusterStateTaskExecutor;
 import org.elasticsearch.cluster.ClusterStateUpdateTask;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.routing.allocation.AllocationService;
@@ -87,7 +86,7 @@ public class DelayedAllocationService extends AbstractLifecycleComponent impleme
                     if (cancelScheduling.get()) {
                         return;
                     }
-                    clusterService.submitStateUpdateTask(CLUSTER_UPDATE_TASK_SOURCE, DelayedRerouteTask.this, newExecutor());
+                    submitUnbatchedTask(CLUSTER_UPDATE_TASK_SOURCE, DelayedRerouteTask.this);
                 }
 
                 @Override
@@ -122,8 +121,8 @@ public class DelayedAllocationService extends AbstractLifecycleComponent impleme
     }
 
     @SuppressForbidden(reason = "legacy usage of unbatched task") // TODO add support for batching here
-    private static <T extends ClusterStateUpdateTask> ClusterStateTaskExecutor<T> newExecutor() {
-        return ClusterStateTaskExecutor.unbatched();
+    private void submitUnbatchedTask(@SuppressWarnings("SameParameterValue") String source, ClusterStateUpdateTask task) {
+        clusterService.submitUnbatchedStateUpdateTask(source, task);
     }
 
     @Inject

--- a/server/src/main/java/org/elasticsearch/cluster/service/ClusterService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/service/ClusterService.java
@@ -15,6 +15,7 @@ import org.elasticsearch.cluster.ClusterStateListener;
 import org.elasticsearch.cluster.ClusterStateTaskConfig;
 import org.elasticsearch.cluster.ClusterStateTaskExecutor;
 import org.elasticsearch.cluster.ClusterStateTaskListener;
+import org.elasticsearch.cluster.ClusterStateUpdateTask;
 import org.elasticsearch.cluster.LocalNodeMasterListener;
 import org.elasticsearch.cluster.NodeConnectionsService;
 import org.elasticsearch.cluster.node.DiscoveryNode;
@@ -25,6 +26,7 @@ import org.elasticsearch.common.settings.ClusterSettings;
 import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Setting.Property;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.core.SuppressForbidden;
 import org.elasticsearch.node.Node;
 import org.elasticsearch.threadpool.ThreadPool;
 
@@ -221,17 +223,18 @@ public class ClusterService extends AbstractLifecycleComponent {
     }
 
     /**
-     * Submits a cluster state update task
+     * Submits an unbatched cluster state update task. This method exists for legacy reasons but is deprecated and forbidden in new
+     * production code because unbatched tasks are a source of performance and stability bugs. You should instead implement your update
+     * logic in a dedicated {@link ClusterStateTaskExecutor} which is reused across multiple task instances. The task itself is typically
+     * just a collection of parameters consumed by the executor, together with any listeners to be notified when execution completes.
+     *
      * @param source     the source of the cluster state update task
      * @param updateTask the full context for the cluster state update
-     * @param executor   the executor to use for the submitted task.
      */
-    public <T extends ClusterStateTaskConfig & ClusterStateTaskListener> void submitStateUpdateTask(
-        String source,
-        T updateTask,
-        ClusterStateTaskExecutor<T> executor
-    ) {
-        submitStateUpdateTask(source, updateTask, updateTask, executor);
+    @Deprecated
+    @SuppressForbidden(reason = "this method is itself forbidden")
+    public void submitUnbatchedStateUpdateTask(String source, ClusterStateUpdateTask updateTask) {
+        masterService.submitUnbatchedStateUpdateTask(source, updateTask);
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/gateway/GatewayService.java
+++ b/server/src/main/java/org/elasticsearch/gateway/GatewayService.java
@@ -15,7 +15,6 @@ import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.cluster.ClusterChangedEvent;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.ClusterStateListener;
-import org.elasticsearch.cluster.ClusterStateTaskExecutor;
 import org.elasticsearch.cluster.ClusterStateUpdateTask;
 import org.elasticsearch.cluster.block.ClusterBlock;
 import org.elasticsearch.cluster.block.ClusterBlockLevel;
@@ -244,11 +243,11 @@ public class GatewayService extends AbstractLifecycleComponent implements Cluste
     }
 
     private void runRecovery() {
-        clusterService.submitStateUpdateTask(TASK_SOURCE, new RecoverStateUpdateTask(), newExecutor());
+        submitUnbatchedTask(TASK_SOURCE, new RecoverStateUpdateTask());
     }
 
     @SuppressForbidden(reason = "legacy usage of unbatched task") // TODO add support for batching here
-    private static <T extends ClusterStateUpdateTask> ClusterStateTaskExecutor<T> newExecutor() {
-        return ClusterStateTaskExecutor.unbatched();
+    private void submitUnbatchedTask(@SuppressWarnings("SameParameterValue") String source, ClusterStateUpdateTask task) {
+        clusterService.submitUnbatchedStateUpdateTask(source, task);
     }
 }

--- a/server/src/main/java/org/elasticsearch/persistent/PersistentTasksClusterService.java
+++ b/server/src/main/java/org/elasticsearch/persistent/PersistentTasksClusterService.java
@@ -16,7 +16,6 @@ import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.cluster.ClusterChangedEvent;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.ClusterStateListener;
-import org.elasticsearch.cluster.ClusterStateTaskExecutor;
 import org.elasticsearch.cluster.ClusterStateUpdateTask;
 import org.elasticsearch.cluster.NotMasterException;
 import org.elasticsearch.cluster.metadata.Metadata;
@@ -112,7 +111,7 @@ public class PersistentTasksClusterService implements ClusterStateListener, Clos
         Params taskParams,
         ActionListener<PersistentTask<?>> listener
     ) {
-        clusterService.submitStateUpdateTask("create persistent task", new ClusterStateUpdateTask() {
+        submitUnbatchedTask("create persistent task", new ClusterStateUpdateTask() {
             @Override
             public ClusterState execute(ClusterState currentState) {
                 PersistentTasksCustomMetadata.Builder builder = builder(currentState);
@@ -145,12 +144,12 @@ public class PersistentTasksClusterService implements ClusterStateListener, Clos
                     listener.onResponse(null);
                 }
             }
-        }, newExecutor());
+        });
     }
 
     @SuppressForbidden(reason = "legacy usage of unbatched task") // TODO add support for batching here
-    private static <T extends ClusterStateUpdateTask> ClusterStateTaskExecutor<T> newExecutor() {
-        return ClusterStateTaskExecutor.unbatched();
+    private void submitUnbatchedTask(@SuppressWarnings("SameParameterValue") String source, ClusterStateUpdateTask task) {
+        clusterService.submitUnbatchedStateUpdateTask(source, task);
     }
 
     /**
@@ -169,7 +168,7 @@ public class PersistentTasksClusterService implements ClusterStateListener, Clos
         } else {
             source = "finish persistent task (success)";
         }
-        clusterService.submitStateUpdateTask(source, new ClusterStateUpdateTask() {
+        submitUnbatchedTask(source, new ClusterStateUpdateTask() {
             @Override
             public ClusterState execute(ClusterState currentState) {
                 PersistentTasksCustomMetadata.Builder tasksInProgress = builder(currentState);
@@ -201,7 +200,7 @@ public class PersistentTasksClusterService implements ClusterStateListener, Clos
                 // Using old state since in the new state the task is already gone
                 listener.onResponse(PersistentTasksCustomMetadata.getTaskWithId(oldState, id));
             }
-        }, newExecutor());
+        });
     }
 
     /**
@@ -211,7 +210,7 @@ public class PersistentTasksClusterService implements ClusterStateListener, Clos
      * @param listener the listener that will be called when task is removed
      */
     public void removePersistentTask(String id, ActionListener<PersistentTask<?>> listener) {
-        clusterService.submitStateUpdateTask("remove persistent task", new ClusterStateUpdateTask() {
+        submitUnbatchedTask("remove persistent task", new ClusterStateUpdateTask() {
             @Override
             public ClusterState execute(ClusterState currentState) {
                 PersistentTasksCustomMetadata.Builder tasksInProgress = builder(currentState);
@@ -232,7 +231,7 @@ public class PersistentTasksClusterService implements ClusterStateListener, Clos
                 // Using old state since in the new state the task is already gone
                 listener.onResponse(PersistentTasksCustomMetadata.getTaskWithId(oldState, id));
             }
-        }, newExecutor());
+        });
     }
 
     /**
@@ -249,7 +248,7 @@ public class PersistentTasksClusterService implements ClusterStateListener, Clos
         final PersistentTaskState taskState,
         final ActionListener<PersistentTask<?>> listener
     ) {
-        clusterService.submitStateUpdateTask("update task state [" + taskId + "]", new ClusterStateUpdateTask() {
+        submitUnbatchedTask("update task state [" + taskId + "]", new ClusterStateUpdateTask() {
             @Override
             public ClusterState execute(ClusterState currentState) {
                 PersistentTasksCustomMetadata.Builder tasksInProgress = builder(currentState);
@@ -274,7 +273,7 @@ public class PersistentTasksClusterService implements ClusterStateListener, Clos
             public void clusterStateProcessed(ClusterState oldState, ClusterState newState) {
                 listener.onResponse(PersistentTasksCustomMetadata.getTaskWithId(newState, taskId));
             }
-        }, newExecutor());
+        });
     }
 
     /**
@@ -294,7 +293,7 @@ public class PersistentTasksClusterService implements ClusterStateListener, Clos
         final String reason,
         final ActionListener<PersistentTask<?>> listener
     ) {
-        clusterService.submitStateUpdateTask("unassign persistent task from any node", new ClusterStateUpdateTask() {
+        submitUnbatchedTask("unassign persistent task from any node", new ClusterStateUpdateTask() {
             @Override
             public ClusterState execute(ClusterState currentState) throws Exception {
                 PersistentTasksCustomMetadata.Builder tasksInProgress = builder(currentState);
@@ -315,7 +314,7 @@ public class PersistentTasksClusterService implements ClusterStateListener, Clos
             public void clusterStateProcessed(ClusterState oldState, ClusterState newState) {
                 listener.onResponse(PersistentTasksCustomMetadata.getTaskWithId(newState, taskId));
             }
-        }, newExecutor());
+        });
     }
 
     /**
@@ -393,7 +392,7 @@ public class PersistentTasksClusterService implements ClusterStateListener, Clos
         if (this.reassigningTasks.compareAndSet(false, true) == false) {
             return;
         }
-        clusterService.submitStateUpdateTask("reassign persistent tasks", new ClusterStateUpdateTask() {
+        submitUnbatchedTask("reassign persistent tasks", new ClusterStateUpdateTask() {
             @Override
             public ClusterState execute(ClusterState currentState) {
                 return reassignTasks(currentState);
@@ -418,7 +417,7 @@ public class PersistentTasksClusterService implements ClusterStateListener, Clos
                     periodicRechecker.rescheduleIfNecessary();
                 }
             }
-        }, newExecutor());
+        });
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/repositories/blobstore/BlobStoreRepository.java
+++ b/server/src/main/java/org/elasticsearch/repositories/blobstore/BlobStoreRepository.java
@@ -33,7 +33,6 @@ import org.elasticsearch.action.support.ListenableActionFuture;
 import org.elasticsearch.action.support.PlainActionFuture;
 import org.elasticsearch.action.support.ThreadedActionListener;
 import org.elasticsearch.cluster.ClusterState;
-import org.elasticsearch.cluster.ClusterStateTaskExecutor;
 import org.elasticsearch.cluster.ClusterStateUpdateTask;
 import org.elasticsearch.cluster.RepositoryCleanupInProgress;
 import org.elasticsearch.cluster.SnapshotDeletionsInProgress;
@@ -469,7 +468,7 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
         final RepositoryMetadata repositoryMetadataStart = metadata;
         getRepositoryData(ActionListener.wrap(repositoryData -> {
             final ClusterStateUpdateTask updateTask = createUpdateTask.apply(repositoryData);
-            clusterService.submitStateUpdateTask(source, new ClusterStateUpdateTask(updateTask.priority(), updateTask.timeout()) {
+            submitUnbatchedTask(source, new ClusterStateUpdateTask(updateTask.priority(), updateTask.timeout()) {
 
                 private boolean executedTask = false;
 
@@ -505,13 +504,13 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
                         executeConsistentStateUpdate(createUpdateTask, source, onFailure);
                     }
                 }
-            }, newExecutor());
+            });
         }, onFailure));
     }
 
     @SuppressForbidden(reason = "legacy usage of unbatched task") // TODO add support for batching here
-    private static <T extends ClusterStateUpdateTask> ClusterStateTaskExecutor<T> newExecutor() {
-        return ClusterStateTaskExecutor.unbatched();
+    private void submitUnbatchedTask(@SuppressWarnings("SameParameterValue") String source, ClusterStateUpdateTask task) {
+        clusterService.submitUnbatchedStateUpdateTask(source, task);
     }
 
     @Override
@@ -1787,7 +1786,7 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
                     .execute(
                         ActionRunnable.wrap(
                             ActionListener.wrap(
-                                repoData -> clusterService.submitStateUpdateTask(
+                                repoData -> submitUnbatchedTask(
                                     "set initial safe repository generation [" + metadata.name() + "][" + repoData.getGenId() + "]",
                                     new ClusterStateUpdateTask() {
                                         @Override
@@ -1848,8 +1847,7 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
                                                 );
                                             });
                                         }
-                                    },
-                                    newExecutor()
+                                    }
                                 ),
                                 onFailure
                             ),
@@ -2040,7 +2038,7 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
     private void markRepoCorrupted(long corruptedGeneration, Exception originalException, ActionListener<Void> listener) {
         assert corruptedGeneration != RepositoryData.UNKNOWN_REPO_GEN;
         assert bestEffortConsistency == false;
-        clusterService.submitStateUpdateTask(
+        submitUnbatchedTask(
             "mark repository corrupted [" + metadata.name() + "][" + corruptedGeneration + "]",
             new ClusterStateUpdateTask() {
                 @Override
@@ -2087,8 +2085,7 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
                 public void clusterStateProcessed(ClusterState oldState, ClusterState newState) {
                     listener.onResponse(null);
                 }
-            },
-            newExecutor()
+            }
         );
     }
 
@@ -2172,7 +2169,7 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
         // Step 1: Set repository generation state to the next possible pending generation
         final StepListener<Long> setPendingStep = new StepListener<>();
         final String setPendingGenerationSource = "set pending repository generation [" + metadata.name() + "][" + expectedGen + "]";
-        clusterService.submitStateUpdateTask(setPendingGenerationSource, new ClusterStateUpdateTask() {
+        submitUnbatchedTask(setPendingGenerationSource, new ClusterStateUpdateTask() {
 
             private long newGen;
 
@@ -2240,7 +2237,7 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
                 logger.trace("[{}] successfully set pending repository generation to [{}]", metadata.name(), newGen);
                 setPendingStep.onResponse(newGen);
             }
-        }, newExecutor());
+        });
 
         final StepListener<RepositoryData> filterRepositoryDataStep = new StepListener<>();
 
@@ -2315,7 +2312,7 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
 
             // Step 3: Update CS to reflect new repository generation.
             final String setSafeGenerationSource = "set safe repository generation [" + metadata.name() + "][" + newGen + "]";
-            clusterService.submitStateUpdateTask(setSafeGenerationSource, new ClusterStateUpdateTask() {
+            submitUnbatchedTask(setSafeGenerationSource, new ClusterStateUpdateTask() {
                 @Override
                 public ClusterState execute(ClusterState currentState) {
                     final RepositoryMetadata meta = getRepoMetadata(currentState);
@@ -2379,7 +2376,7 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
                         return newRepositoryData;
                     }));
                 }
-            }, newExecutor());
+            });
         }, listener::onFailure);
     }
 

--- a/server/src/main/java/org/elasticsearch/upgrades/SystemIndexMigrator.java
+++ b/server/src/main/java/org/elasticsearch/upgrades/SystemIndexMigrator.java
@@ -24,7 +24,6 @@ import org.elasticsearch.action.support.master.ShardsAcknowledgedResponse;
 import org.elasticsearch.client.internal.Client;
 import org.elasticsearch.client.internal.ParentTaskAssigningClient;
 import org.elasticsearch.cluster.ClusterState;
-import org.elasticsearch.cluster.ClusterStateTaskExecutor;
 import org.elasticsearch.cluster.ClusterStateUpdateTask;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.metadata.Metadata;
@@ -587,7 +586,7 @@ public class SystemIndexMigrator extends AllocatedPersistentTask {
      * @param listener A listener that will be called upon successfully updating the cluster state.
      */
     private static void clearResults(ClusterService clusterService, ActionListener<ClusterState> listener) {
-        clusterService.submitStateUpdateTask("clear migration results", new ClusterStateUpdateTask() {
+        submitUnbatchedTask(clusterService, "clear migration results", new ClusterStateUpdateTask() {
             @Override
             public ClusterState execute(ClusterState currentState) throws Exception {
                 if (currentState.metadata().custom(FeatureMigrationResults.TYPE) != null) {
@@ -608,13 +607,17 @@ public class SystemIndexMigrator extends AllocatedPersistentTask {
                 logger.error("failed to clear migration results when starting new migration", e);
                 listener.onFailure(e);
             }
-        }, newExecutor());
+        });
         logger.debug("submitted update task to clear migration results");
     }
 
     @SuppressForbidden(reason = "legacy usage of unbatched task") // TODO add support for batching here
-    private static <T extends ClusterStateUpdateTask> ClusterStateTaskExecutor<T> newExecutor() {
-        return ClusterStateTaskExecutor.unbatched();
+    private static void submitUnbatchedTask(
+        ClusterService clusterService,
+        @SuppressWarnings("SameParameterValue") String source,
+        ClusterStateUpdateTask task
+    ) {
+        clusterService.submitUnbatchedStateUpdateTask(source, task);
     }
 
     private SystemIndexMigrationInfo currentMigrationInfo() {

--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/configuration/TransportAddVotingConfigExclusionsActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/configuration/TransportAddVotingConfigExclusionsActionTests.java
@@ -16,7 +16,6 @@ import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.ClusterStateObserver;
 import org.elasticsearch.cluster.ClusterStateObserver.Listener;
-import org.elasticsearch.cluster.ClusterStateTaskExecutor;
 import org.elasticsearch.cluster.ClusterStateUpdateTask;
 import org.elasticsearch.cluster.coordination.CoordinationMetadata;
 import org.elasticsearch.cluster.coordination.CoordinationMetadata.VotingConfigExclusion;
@@ -525,7 +524,7 @@ public class TransportAddVotingConfigExclusionsActionTests extends ESTestCase {
 
         @Override
         public void onNewClusterState(ClusterState state) {
-            clusterService.getMasterService().submitStateUpdateTask("reconfiguration", new ClusterStateUpdateTask() {
+            clusterService.getMasterService().submitUnbatchedStateUpdateTask("reconfiguration", new ClusterStateUpdateTask() {
                 @Override
                 public ClusterState execute(ClusterState currentState) {
                     assertThat(currentState, sameInstance(state));
@@ -553,7 +552,7 @@ public class TransportAddVotingConfigExclusionsActionTests extends ESTestCase {
                 public void clusterStateProcessed(ClusterState oldState, ClusterState newState) {
                     doneLatch.countDown();
                 }
-            }, ClusterStateTaskExecutor.unbatched());
+            });
         }
 
         @Override

--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/desirednodes/TransportUpdateDesiredNodesActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/desirednodes/TransportUpdateDesiredNodesActionTests.java
@@ -117,7 +117,7 @@ public class TransportUpdateDesiredNodesActionTests extends DesiredNodesTestCase
         IllegalArgumentException exception = expectThrows(IllegalArgumentException.class, future::actionGet);
         assertThat(exception.getMessage(), containsString("Invalid settings"));
 
-        verify(clusterService, never()).submitStateUpdateTask(any(), any(), any());
+        verify(clusterService, never()).submitUnbatchedStateUpdateTask(any(), any());
     }
 
     public void testUpdateDesiredNodes() {

--- a/server/src/test/java/org/elasticsearch/cluster/routing/DelayedAllocationServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/DelayedAllocationServiceTests.java
@@ -174,7 +174,7 @@ public class DelayedAllocationServiceTests extends ESAllocationTestCase {
             clusterStateUpdateTask.set((ClusterStateUpdateTask) invocationOnMock.getArguments()[1]);
             latch.countDown();
             return null;
-        }).when(clusterService).submitStateUpdateTask(eq(CLUSTER_UPDATE_TASK_SOURCE), any(ClusterStateUpdateTask.class), any());
+        }).when(clusterService).submitUnbatchedStateUpdateTask(eq(CLUSTER_UPDATE_TASK_SOURCE), any(ClusterStateUpdateTask.class));
         assertNull(delayedAllocationService.delayedRerouteTask.get());
         long delayUntilClusterChangeEvent = TimeValue.timeValueNanos(randomInt((int) delaySetting.nanos() - 1)).nanos();
         long clusterChangeEventTimestampNanos = baseTimestampNanos + delayUntilClusterChangeEvent;
@@ -193,7 +193,7 @@ public class DelayedAllocationServiceTests extends ESAllocationTestCase {
 
         // check that submitStateUpdateTask() was invoked on the cluster service mock
         assertTrue(latch.await(30, TimeUnit.SECONDS));
-        verify(clusterService).submitStateUpdateTask(eq(CLUSTER_UPDATE_TASK_SOURCE), eq(clusterStateUpdateTask.get()), any());
+        verify(clusterService).submitUnbatchedStateUpdateTask(eq(CLUSTER_UPDATE_TASK_SOURCE), eq(clusterStateUpdateTask.get()));
 
         // advance the time on the allocation service to a timestamp that happened after the delayed scheduling
         long nanoTimeForReroute = clusterChangeEventTimestampNanos + delaySetting.nanos() + timeValueMillis(randomInt(200)).nanos();
@@ -313,7 +313,7 @@ public class DelayedAllocationServiceTests extends ESAllocationTestCase {
             clusterStateUpdateTask1.set((ClusterStateUpdateTask) invocationOnMock.getArguments()[1]);
             latch1.countDown();
             return null;
-        }).when(clusterService).submitStateUpdateTask(eq(CLUSTER_UPDATE_TASK_SOURCE), any(ClusterStateUpdateTask.class), any());
+        }).when(clusterService).submitUnbatchedStateUpdateTask(eq(CLUSTER_UPDATE_TASK_SOURCE), any(ClusterStateUpdateTask.class));
         assertNull(delayedAllocationService.delayedRerouteTask.get());
         long delayUntilClusterChangeEvent = TimeValue.timeValueNanos(randomInt((int) shortDelaySetting.nanos() - 1)).nanos();
         long clusterChangeEventTimestampNanos = baseTimestampNanos + delayUntilClusterChangeEvent;
@@ -338,7 +338,7 @@ public class DelayedAllocationServiceTests extends ESAllocationTestCase {
 
         // check that submitStateUpdateTask() was invoked on the cluster service mock
         assertTrue(latch1.await(30, TimeUnit.SECONDS));
-        verify(clusterService).submitStateUpdateTask(eq(CLUSTER_UPDATE_TASK_SOURCE), eq(clusterStateUpdateTask1.get()), any());
+        verify(clusterService).submitUnbatchedStateUpdateTask(eq(CLUSTER_UPDATE_TASK_SOURCE), eq(clusterStateUpdateTask1.get()));
 
         // advance the time on the allocation service to a timestamp that happened after the delayed scheduling
         long nanoTimeForReroute = clusterChangeEventTimestampNanos + shortDelaySetting.nanos() + timeValueMillis(randomInt(50)).nanos();
@@ -357,7 +357,7 @@ public class DelayedAllocationServiceTests extends ESAllocationTestCase {
             clusterStateUpdateTask2.set((ClusterStateUpdateTask) invocationOnMock.getArguments()[1]);
             latch2.countDown();
             return null;
-        }).when(clusterService).submitStateUpdateTask(eq(CLUSTER_UPDATE_TASK_SOURCE), any(ClusterStateUpdateTask.class), any());
+        }).when(clusterService).submitUnbatchedStateUpdateTask(eq(CLUSTER_UPDATE_TASK_SOURCE), any(ClusterStateUpdateTask.class));
         // simulate calling listener (cluster change event)
         delayUntilClusterChangeEvent = timeValueMillis(randomInt(50)).nanos();
         clusterChangeEventTimestampNanos = nanoTimeForReroute + delayUntilClusterChangeEvent;
@@ -382,7 +382,7 @@ public class DelayedAllocationServiceTests extends ESAllocationTestCase {
 
         // check that submitStateUpdateTask() was invoked on the cluster service mock
         assertTrue(latch2.await(30, TimeUnit.SECONDS));
-        verify(clusterService).submitStateUpdateTask(eq(CLUSTER_UPDATE_TASK_SOURCE), eq(clusterStateUpdateTask2.get()), any());
+        verify(clusterService).submitUnbatchedStateUpdateTask(eq(CLUSTER_UPDATE_TASK_SOURCE), eq(clusterStateUpdateTask2.get()));
 
         // advance the time on the allocation service to a timestamp that happened after the delayed scheduling
         nanoTimeForReroute = clusterChangeEventTimestampNanos + longDelaySetting.nanos() + timeValueMillis(randomInt(50)).nanos();

--- a/server/src/test/java/org/elasticsearch/cluster/service/MasterServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/service/MasterServiceTests.java
@@ -138,7 +138,7 @@ public class MasterServiceTests extends ESTestCase {
 
         final boolean[] taskFailed = { false };
         final CountDownLatch latch1 = new CountDownLatch(1);
-        nonMaster.submitStateUpdateTask("test", new ClusterStateUpdateTask() {
+        nonMaster.submitUnbatchedStateUpdateTask("test", new ClusterStateUpdateTask() {
             @Override
             public ClusterState execute(ClusterState currentState) {
                 latch1.countDown();
@@ -150,7 +150,7 @@ public class MasterServiceTests extends ESTestCase {
                 taskFailed[0] = true;
                 latch1.countDown();
             }
-        }, ClusterStateTaskExecutor.unbatched());
+        });
 
         latch1.await();
         assertTrue("cluster state update task was executed on a non-master", taskFailed[0]);
@@ -190,7 +190,7 @@ public class MasterServiceTests extends ESTestCase {
             final TimeValue ackTimeout = randomBoolean() ? TimeValue.ZERO : TimeValue.timeValueMillis(randomInt(10000));
             final TimeValue masterTimeout = randomBoolean() ? TimeValue.ZERO : TimeValue.timeValueMillis(randomInt(10000));
 
-            master.submitStateUpdateTask("test", new AckedClusterStateUpdateTask(ackedRequest(ackTimeout, masterTimeout), null) {
+            master.submitUnbatchedStateUpdateTask("test", new AckedClusterStateUpdateTask(ackedRequest(ackTimeout, masterTimeout), null) {
                 @Override
                 public ClusterState execute(ClusterState currentState) {
                     assertTrue(threadPool.getThreadContext().isSystemContext());
@@ -247,7 +247,7 @@ public class MasterServiceTests extends ESTestCase {
                     latch.countDown();
                 }
 
-            }, ClusterStateTaskExecutor.unbatched());
+            });
 
             assertFalse(threadPool.getThreadContext().isSystemContext());
             assertEquals(expectedHeaders, threadPool.getThreadContext().getHeaders());
@@ -395,7 +395,7 @@ public class MasterServiceTests extends ESTestCase {
         Logger clusterLogger = LogManager.getLogger(MasterService.class);
         Loggers.addAppender(clusterLogger, mockAppender);
         try (MasterService masterService = createMasterService(true)) {
-            masterService.submitStateUpdateTask("test1", new ClusterStateUpdateTask() {
+            masterService.submitUnbatchedStateUpdateTask("test1", new ClusterStateUpdateTask() {
                 @Override
                 public ClusterState execute(ClusterState currentState) {
                     relativeTimeInMillis += TimeValue.timeValueSeconds(1).millis();
@@ -409,8 +409,8 @@ public class MasterServiceTests extends ESTestCase {
                 public void onFailure(Exception e) {
                     fail();
                 }
-            }, ClusterStateTaskExecutor.unbatched());
-            masterService.submitStateUpdateTask("test2", new ClusterStateUpdateTask() {
+            });
+            masterService.submitUnbatchedStateUpdateTask("test2", new ClusterStateUpdateTask() {
                 @Override
                 public ClusterState execute(ClusterState currentState) {
                     relativeTimeInMillis += TimeValue.timeValueSeconds(2).millis();
@@ -424,8 +424,8 @@ public class MasterServiceTests extends ESTestCase {
 
                 @Override
                 public void onFailure(Exception e) {}
-            }, ClusterStateTaskExecutor.unbatched());
-            masterService.submitStateUpdateTask("test3", new ClusterStateUpdateTask() {
+            });
+            masterService.submitUnbatchedStateUpdateTask("test3", new ClusterStateUpdateTask() {
                 @Override
                 public ClusterState execute(ClusterState currentState) {
                     relativeTimeInMillis += TimeValue.timeValueSeconds(3).millis();
@@ -441,8 +441,8 @@ public class MasterServiceTests extends ESTestCase {
                 public void onFailure(Exception e) {
                     fail();
                 }
-            }, ClusterStateTaskExecutor.unbatched());
-            masterService.submitStateUpdateTask("test4", new ClusterStateUpdateTask() {
+            });
+            masterService.submitUnbatchedStateUpdateTask("test4", new ClusterStateUpdateTask() {
                 @Override
                 public ClusterState execute(ClusterState currentState) {
                     return currentState;
@@ -455,7 +455,7 @@ public class MasterServiceTests extends ESTestCase {
                 public void onFailure(Exception e) {
                     fail();
                 }
-            }, ClusterStateTaskExecutor.unbatched());
+            });
             assertBusy(mockAppender::assertAllExpectationsMatched);
         } finally {
             Loggers.removeAppender(clusterLogger, mockAppender);
@@ -818,7 +818,7 @@ public class MasterServiceTests extends ESTestCase {
 
         try (var masterService = createMasterService(true)) {
 
-            masterService.submitStateUpdateTask("block", blockMasterTask, ClusterStateTaskExecutor.unbatched());
+            masterService.submitUnbatchedStateUpdateTask("block", blockMasterTask);
             executionBarrier.await(10, TimeUnit.SECONDS); // wait for the master service to be blocked
 
             masterService.setClusterStatePublisher(
@@ -892,7 +892,7 @@ public class MasterServiceTests extends ESTestCase {
 
             // success case: submit some tasks, possibly in different contexts, and verify that the expected listener is completed
 
-            masterService.submitStateUpdateTask("block", blockMasterTask, ClusterStateTaskExecutor.unbatched());
+            masterService.submitUnbatchedStateUpdateTask("block", blockMasterTask);
             executionBarrier.await(10, TimeUnit.SECONDS); // wait for the master service to be blocked
 
             final AtomicReference<ClusterState> publishedState = new AtomicReference<>();
@@ -933,7 +933,7 @@ public class MasterServiceTests extends ESTestCase {
 
             // failure case: submit some tasks, possibly in different contexts, and verify that the expected listener is completed
 
-            masterService.submitStateUpdateTask("block", blockMasterTask, ClusterStateTaskExecutor.unbatched());
+            masterService.submitUnbatchedStateUpdateTask("block", blockMasterTask);
             executionBarrier.await(10, TimeUnit.SECONDS); // wait for the master service to be blocked
 
             final String exceptionMessage = "simulated";
@@ -1110,7 +1110,7 @@ public class MasterServiceTests extends ESTestCase {
 
             final CountDownLatch latch = new CountDownLatch(6);
             final CountDownLatch processedFirstTask = new CountDownLatch(1);
-            masterService.submitStateUpdateTask("test1", new ClusterStateUpdateTask() {
+            masterService.submitUnbatchedStateUpdateTask("test1", new ClusterStateUpdateTask() {
                 @Override
                 public ClusterState execute(ClusterState currentState) {
                     relativeTimeInMillis += randomLongBetween(
@@ -1130,10 +1130,10 @@ public class MasterServiceTests extends ESTestCase {
                 public void onFailure(Exception e) {
                     fail();
                 }
-            }, ClusterStateTaskExecutor.unbatched());
+            });
 
             processedFirstTask.await();
-            masterService.submitStateUpdateTask("test2", new ClusterStateUpdateTask() {
+            masterService.submitUnbatchedStateUpdateTask("test2", new ClusterStateUpdateTask() {
                 @Override
                 public ClusterState execute(ClusterState currentState) {
                     relativeTimeInMillis += MasterService.MASTER_SERVICE_SLOW_TASK_LOGGING_THRESHOLD_SETTING.get(Settings.EMPTY).millis()
@@ -1150,8 +1150,8 @@ public class MasterServiceTests extends ESTestCase {
                 public void onFailure(Exception e) {
                     latch.countDown();
                 }
-            }, ClusterStateTaskExecutor.unbatched());
-            masterService.submitStateUpdateTask("test3", new ClusterStateUpdateTask() {
+            });
+            masterService.submitUnbatchedStateUpdateTask("test3", new ClusterStateUpdateTask() {
                 @Override
                 public ClusterState execute(ClusterState currentState) {
                     relativeTimeInMillis += MasterService.MASTER_SERVICE_SLOW_TASK_LOGGING_THRESHOLD_SETTING.get(Settings.EMPTY).millis()
@@ -1168,8 +1168,8 @@ public class MasterServiceTests extends ESTestCase {
                 public void onFailure(Exception e) {
                     fail();
                 }
-            }, ClusterStateTaskExecutor.unbatched());
-            masterService.submitStateUpdateTask("test4", new ClusterStateUpdateTask() {
+            });
+            masterService.submitUnbatchedStateUpdateTask("test4", new ClusterStateUpdateTask() {
                 @Override
                 public ClusterState execute(ClusterState currentState) {
                     relativeTimeInMillis += MasterService.MASTER_SERVICE_SLOW_TASK_LOGGING_THRESHOLD_SETTING.get(Settings.EMPTY).millis()
@@ -1186,8 +1186,8 @@ public class MasterServiceTests extends ESTestCase {
                 public void onFailure(Exception e) {
                     fail();
                 }
-            }, ClusterStateTaskExecutor.unbatched());
-            masterService.submitStateUpdateTask("test5", new ClusterStateUpdateTask() {
+            });
+            masterService.submitUnbatchedStateUpdateTask("test5", new ClusterStateUpdateTask() {
                 @Override
                 public ClusterState execute(ClusterState currentState) {
                     return ClusterState.builder(currentState).incrementVersion().build();
@@ -1202,8 +1202,8 @@ public class MasterServiceTests extends ESTestCase {
                 public void onFailure(Exception e) {
                     fail();
                 }
-            }, ClusterStateTaskExecutor.unbatched());
-            masterService.submitStateUpdateTask("test6", new ClusterStateUpdateTask() {
+            });
+            masterService.submitUnbatchedStateUpdateTask("test6", new ClusterStateUpdateTask() {
                 @Override
                 public ClusterState execute(ClusterState currentState) {
                     return ClusterState.builder(currentState).incrementVersion().build();
@@ -1218,10 +1218,10 @@ public class MasterServiceTests extends ESTestCase {
                 public void onFailure(Exception e) {
                     fail(); // maybe we should notify here?
                 }
-            }, ClusterStateTaskExecutor.unbatched());
+            });
             // Additional update task to make sure all previous logging made it to the loggerName
             // We don't check logging for this on since there is no guarantee that it will occur before our check
-            masterService.submitStateUpdateTask("test7", new ClusterStateUpdateTask() {
+            masterService.submitUnbatchedStateUpdateTask("test7", new ClusterStateUpdateTask() {
                 @Override
                 public ClusterState execute(ClusterState currentState) {
                     return currentState;
@@ -1236,7 +1236,7 @@ public class MasterServiceTests extends ESTestCase {
                 public void onFailure(Exception e) {
                     fail();
                 }
-            }, ClusterStateTaskExecutor.unbatched());
+            });
             latch.await();
         } finally {
             Loggers.removeAppender(clusterLogger, mockAppender);
@@ -1458,33 +1458,36 @@ public class MasterServiceTests extends ESTestCase {
                     )
                 );
 
-                masterService.submitStateUpdateTask("test2", new AckedClusterStateUpdateTask(ackedRequest(TimeValue.ZERO, null), null) {
-                    @Override
-                    public ClusterState execute(ClusterState currentState) {
-                        return ClusterState.builder(currentState).build();
-                    }
+                masterService.submitUnbatchedStateUpdateTask(
+                    "test2",
+                    new AckedClusterStateUpdateTask(ackedRequest(TimeValue.ZERO, null), null) {
+                        @Override
+                        public ClusterState execute(ClusterState currentState) {
+                            return ClusterState.builder(currentState).build();
+                        }
 
-                    @Override
-                    public void clusterStateProcessed(ClusterState oldState, ClusterState newState) {
-                        fail();
-                    }
+                        @Override
+                        public void clusterStateProcessed(ClusterState oldState, ClusterState newState) {
+                            fail();
+                        }
 
-                    @Override
-                    protected AcknowledgedResponse newResponse(boolean acknowledged) {
-                        fail();
-                        return null;
-                    }
+                        @Override
+                        protected AcknowledgedResponse newResponse(boolean acknowledged) {
+                            fail();
+                            return null;
+                        }
 
-                    @Override
-                    public void onFailure(Exception e) {
-                        latch.countDown();
-                    }
+                        @Override
+                        public void onFailure(Exception e) {
+                            latch.countDown();
+                        }
 
-                    @Override
-                    public void onAckTimeout() {
-                        fail();
+                        @Override
+                        public void onAckTimeout() {
+                            fail();
+                        }
                     }
-                }, ClusterStateTaskExecutor.unbatched());
+                );
 
                 latch.await();
             }
@@ -1503,33 +1506,36 @@ public class MasterServiceTests extends ESTestCase {
                     ackListener.onNodeAck(node3, null);
                 });
 
-                masterService.submitStateUpdateTask("test2", new AckedClusterStateUpdateTask(ackedRequest(ackTimeout, null), null) {
-                    @Override
-                    public ClusterState execute(ClusterState currentState) {
-                        return ClusterState.builder(currentState).build();
-                    }
+                masterService.submitUnbatchedStateUpdateTask(
+                    "test2",
+                    new AckedClusterStateUpdateTask(ackedRequest(ackTimeout, null), null) {
+                        @Override
+                        public ClusterState execute(ClusterState currentState) {
+                            return ClusterState.builder(currentState).build();
+                        }
 
-                    @Override
-                    public void clusterStateProcessed(ClusterState oldState, ClusterState newState) {
-                        latch.countDown();
-                    }
+                        @Override
+                        public void clusterStateProcessed(ClusterState oldState, ClusterState newState) {
+                            latch.countDown();
+                        }
 
-                    @Override
-                    protected AcknowledgedResponse newResponse(boolean acknowledged) {
-                        fail();
-                        return null;
-                    }
+                        @Override
+                        protected AcknowledgedResponse newResponse(boolean acknowledged) {
+                            fail();
+                            return null;
+                        }
 
-                    @Override
-                    public void onFailure(Exception e) {
-                        fail();
-                    }
+                        @Override
+                        public void onFailure(Exception e) {
+                            fail();
+                        }
 
-                    @Override
-                    public void onAckTimeout() {
-                        latch.countDown();
+                        @Override
+                        public void onAckTimeout() {
+                            latch.countDown();
+                        }
                     }
-                }, ClusterStateTaskExecutor.unbatched());
+                );
 
                 latch.await();
             }
@@ -1574,7 +1580,7 @@ public class MasterServiceTests extends ESTestCase {
                     await.run();
                     relativeTimeInMillis += taskDurationMillis;
                     if (keepRunning.get()) {
-                        masterService.submitStateUpdateTask("starvation-causing task", this, ClusterStateTaskExecutor.unbatched());
+                        masterService.submitUnbatchedStateUpdateTask("starvation-causing task", this);
                     }
                     await.run();
                     return currentState;
@@ -1585,10 +1591,10 @@ public class MasterServiceTests extends ESTestCase {
                     fail();
                 }
             };
-            masterService.submitStateUpdateTask("starvation-causing task", starvationCausingTask, ClusterStateTaskExecutor.unbatched());
+            masterService.submitUnbatchedStateUpdateTask("starvation-causing task", starvationCausingTask);
 
             final CountDownLatch starvedTaskExecuted = new CountDownLatch(1);
-            masterService.submitStateUpdateTask("starved task", new ClusterStateUpdateTask(Priority.NORMAL) {
+            masterService.submitUnbatchedStateUpdateTask("starved task", new ClusterStateUpdateTask(Priority.NORMAL) {
                 @Override
                 public ClusterState execute(ClusterState currentState) {
                     assertFalse(keepRunning.get());
@@ -1600,7 +1606,7 @@ public class MasterServiceTests extends ESTestCase {
                 public void onFailure(Exception e) {
                     fail();
                 }
-            }, ClusterStateTaskExecutor.unbatched());
+            });
 
             // check that a warning is logged after 5m
             final MockLogAppender.EventuallySeenEventExpectation expectation1 = new MockLogAppender.EventuallySeenEventExpectation(

--- a/server/src/test/java/org/elasticsearch/common/settings/ConsistentSettingsServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/common/settings/ConsistentSettingsServiceTests.java
@@ -37,7 +37,7 @@ public class ConsistentSettingsServiceTests extends ESTestCase {
             final ClusterStateUpdateTask arg0 = (ClusterStateUpdateTask) invocation.getArguments()[1];
             this.clusterState.set(arg0.execute(this.clusterState.get()));
             return null;
-        }).when(clusterService).submitStateUpdateTask(Mockito.isA(String.class), Mockito.isA(ClusterStateUpdateTask.class), Mockito.any());
+        }).when(clusterService).submitUnbatchedStateUpdateTask(Mockito.isA(String.class), Mockito.isA(ClusterStateUpdateTask.class));
     }
 
     public void testSingleStringSetting() throws Exception {

--- a/server/src/test/java/org/elasticsearch/indices/settings/InternalOrPrivateSettingsPlugin.java
+++ b/server/src/test/java/org/elasticsearch/indices/settings/InternalOrPrivateSettingsPlugin.java
@@ -17,7 +17,6 @@ import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.master.MasterNodeRequest;
 import org.elasticsearch.action.support.master.TransportMasterNodeAction;
 import org.elasticsearch.cluster.ClusterState;
-import org.elasticsearch.cluster.ClusterStateTaskExecutor;
 import org.elasticsearch.cluster.ClusterStateUpdateTask;
 import org.elasticsearch.cluster.block.ClusterBlockException;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
@@ -149,7 +148,7 @@ public class InternalOrPrivateSettingsPlugin extends Plugin implements ActionPlu
             final ClusterState state,
             final ActionListener<UpdateInternalOrPrivateAction.Response> listener
         ) throws Exception {
-            clusterService.submitStateUpdateTask("update-index-internal-or-private", new ClusterStateUpdateTask() {
+            clusterService.submitUnbatchedStateUpdateTask("update-index-internal-or-private", new ClusterStateUpdateTask() {
                 @Override
                 public ClusterState execute(final ClusterState currentState) throws Exception {
                     final Metadata.Builder builder = Metadata.builder(currentState.metadata());
@@ -173,7 +172,7 @@ public class InternalOrPrivateSettingsPlugin extends Plugin implements ActionPlu
                     listener.onFailure(e);
                 }
 
-            }, ClusterStateTaskExecutor.unbatched());
+            });
         }
 
         @Override

--- a/server/src/test/java/org/elasticsearch/persistent/PersistentTasksClusterServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/persistent/PersistentTasksClusterServiceTests.java
@@ -698,7 +698,10 @@ public class PersistentTasksClusterServiceTests extends ESTestCase {
             t1.start();
             // Make sure we have at least one reassign check before we count down the latch
             assertBusy(
-                () -> verify(recheckTestClusterService, atLeastOnce()).submitStateUpdateTask(eq("reassign persistent tasks"), any(), any())
+                () -> verify(recheckTestClusterService, atLeastOnce()).submitUnbatchedStateUpdateTask(
+                    eq("reassign persistent tasks"),
+                    any()
+                )
             );
             t2.start();
         } finally {
@@ -709,7 +712,9 @@ public class PersistentTasksClusterServiceTests extends ESTestCase {
         }
         // verify that our reassignment is possible again, here we have once from the previous reassignment in the `try` block
         // And one from the line above once the other threads have joined
-        assertBusy(() -> verify(recheckTestClusterService, times(2)).submitStateUpdateTask(eq("reassign persistent tasks"), any(), any()));
+        assertBusy(
+            () -> verify(recheckTestClusterService, times(2)).submitUnbatchedStateUpdateTask(eq("reassign persistent tasks"), any())
+        );
         verifyNoMoreInteractions(recheckTestClusterService);
     }
 
@@ -739,7 +744,7 @@ public class PersistentTasksClusterServiceTests extends ESTestCase {
                 task.clusterStateProcessed(before, after);
             }
             return null;
-        }).when(recheckTestClusterService).submitStateUpdateTask(anyString(), any(ClusterStateUpdateTask.class), any());
+        }).when(recheckTestClusterService).submitUnbatchedStateUpdateTask(anyString(), any(ClusterStateUpdateTask.class));
 
         return recheckTestClusterService;
     }

--- a/test/framework/src/main/java/org/elasticsearch/cluster/coordination/AbstractCoordinatorTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/cluster/coordination/AbstractCoordinatorTestCase.java
@@ -22,7 +22,6 @@ import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.client.internal.node.NodeClient;
 import org.elasticsearch.cluster.ClusterModule;
 import org.elasticsearch.cluster.ClusterState;
-import org.elasticsearch.cluster.ClusterStateTaskExecutor;
 import org.elasticsearch.cluster.ClusterStateTaskListener;
 import org.elasticsearch.cluster.ClusterStateUpdateTask;
 import org.elasticsearch.cluster.ESAllocationTestCase;
@@ -1427,7 +1426,7 @@ public class AbstractCoordinatorTestCase extends ESTestCase {
                 onNode(() -> {
                     logger.trace("[{}] submitUpdateTask: enqueueing [{}]", localNode.getId(), source);
                     final long submittedTerm = coordinator.getCurrentTerm();
-                    masterService.submitStateUpdateTask(source, new ClusterStateUpdateTask() {
+                    masterService.submitUnbatchedStateUpdateTask(source, new ClusterStateUpdateTask() {
                         @Override
                         public ClusterState execute(ClusterState currentState) {
                             assertThat(currentState.term(), greaterThanOrEqualTo(submittedTerm));
@@ -1456,7 +1455,7 @@ public class AbstractCoordinatorTestCase extends ESTestCase {
                             logger.trace("successfully published: [{}]", newState);
                             taskListener.clusterStateProcessed(oldState, newState);
                         }
-                    }, ClusterStateTaskExecutor.unbatched());
+                    });
                 }).run();
                 return ackCollector;
             }

--- a/test/framework/src/main/java/org/elasticsearch/repositories/blobstore/BlobStoreTestUtil.java
+++ b/test/framework/src/main/java/org/elasticsearch/repositories/blobstore/BlobStoreTestUtil.java
@@ -450,7 +450,7 @@ public final class BlobStoreTestUtil {
             );
             task.clusterStateProcessed(current, next);
             return null;
-        }).when(clusterService).submitStateUpdateTask(anyString(), any(ClusterStateUpdateTask.class), any());
+        }).when(clusterService).submitUnbatchedStateUpdateTask(anyString(), any(ClusterStateUpdateTask.class));
         doAnswer(invocation -> {
             appliers.add((ClusterStateApplier) invocation.getArguments()[0]);
             return null;

--- a/test/framework/src/main/java/org/elasticsearch/snapshots/AbstractSnapshotIntegTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/snapshots/AbstractSnapshotIntegTestCase.java
@@ -21,7 +21,6 @@ import org.elasticsearch.action.support.GroupedActionListener;
 import org.elasticsearch.action.support.PlainActionFuture;
 import org.elasticsearch.action.support.master.AcknowledgedResponse;
 import org.elasticsearch.cluster.ClusterState;
-import org.elasticsearch.cluster.ClusterStateTaskExecutor;
 import org.elasticsearch.cluster.ClusterStateUpdateTask;
 import org.elasticsearch.cluster.SnapshotDeletionsInProgress;
 import org.elasticsearch.cluster.SnapshotsInProgress;
@@ -649,7 +648,7 @@ public abstract class AbstractSnapshotIntegTestCase extends ESIntegTestCase {
     protected static void updateClusterState(final Function<ClusterState, ClusterState> updater) throws Exception {
         final PlainActionFuture<Void> future = PlainActionFuture.newFuture();
         final ClusterService clusterService = internalCluster().getCurrentMasterNodeInstance(ClusterService.class);
-        clusterService.submitStateUpdateTask("test", new ClusterStateUpdateTask() {
+        clusterService.submitUnbatchedStateUpdateTask("test", new ClusterStateUpdateTask() {
             @Override
             public ClusterState execute(ClusterState currentState) {
                 return updater.apply(currentState);
@@ -664,7 +663,7 @@ public abstract class AbstractSnapshotIntegTestCase extends ESIntegTestCase {
             public void clusterStateProcessed(ClusterState oldState, ClusterState newState) {
                 future.onResponse(null);
             }
-        }, ClusterStateTaskExecutor.unbatched());
+        });
         future.get();
     }
 

--- a/test/framework/src/main/java/org/elasticsearch/test/ClusterServiceUtils.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/ClusterServiceUtils.java
@@ -17,7 +17,6 @@ import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.ClusterStateObserver;
 import org.elasticsearch.cluster.ClusterStatePublicationEvent;
-import org.elasticsearch.cluster.ClusterStateTaskExecutor;
 import org.elasticsearch.cluster.ClusterStateUpdateTask;
 import org.elasticsearch.cluster.NodeConnectionsService;
 import org.elasticsearch.cluster.block.ClusterBlocks;
@@ -76,7 +75,7 @@ public class ClusterServiceUtils {
 
     public static void setState(MasterService executor, ClusterState clusterState) {
         CountDownLatch latch = new CountDownLatch(1);
-        executor.submitStateUpdateTask("test setting state", new ClusterStateUpdateTask() {
+        executor.submitUnbatchedStateUpdateTask("test setting state", new ClusterStateUpdateTask() {
             @Override
             public ClusterState execute(ClusterState currentState) throws Exception {
                 // make sure we increment versions as listener may depend on it for change
@@ -92,7 +91,7 @@ public class ClusterServiceUtils {
             public void onFailure(Exception e) {
                 fail("unexpected exception" + e);
             }
-        }, ClusterStateTaskExecutor.unbatched());
+        });
         try {
             latch.await();
         } catch (InterruptedException e) {

--- a/test/framework/src/main/java/org/elasticsearch/test/disruption/BusyMasterServiceDisruption.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/disruption/BusyMasterServiceDisruption.java
@@ -8,7 +8,6 @@
 package org.elasticsearch.test.disruption;
 
 import org.elasticsearch.cluster.ClusterState;
-import org.elasticsearch.cluster.ClusterStateTaskExecutor;
 import org.elasticsearch.cluster.ClusterStateUpdateTask;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.Priority;
@@ -44,7 +43,7 @@ public class BusyMasterServiceDisruption extends SingleNodeDisruption {
     }
 
     private void submitTask(ClusterService clusterService) {
-        clusterService.getMasterService().submitStateUpdateTask("service_disruption_block", new ClusterStateUpdateTask(priority) {
+        clusterService.getMasterService().submitUnbatchedStateUpdateTask("service_disruption_block", new ClusterStateUpdateTask(priority) {
             @Override
             public ClusterState execute(ClusterState currentState) {
                 if (active.get()) {
@@ -57,7 +56,7 @@ public class BusyMasterServiceDisruption extends SingleNodeDisruption {
             public void onFailure(Exception e) {
                 logger.error("unexpected error during disruption", e);
             }
-        }, ClusterStateTaskExecutor.unbatched());
+        });
     }
 
     @Override

--- a/test/framework/src/test/java/org/elasticsearch/cluster/service/FakeThreadPoolMasterServiceTests.java
+++ b/test/framework/src/test/java/org/elasticsearch/cluster/service/FakeThreadPoolMasterServiceTests.java
@@ -11,7 +11,6 @@ import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.replication.ClusterStateCreationUtils;
 import org.elasticsearch.cluster.ClusterState;
-import org.elasticsearch.cluster.ClusterStateTaskExecutor;
 import org.elasticsearch.cluster.ClusterStateUpdateTask;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.metadata.Metadata;
@@ -77,7 +76,7 @@ public class FakeThreadPoolMasterServiceTests extends ESTestCase {
         masterService.start();
 
         AtomicBoolean firstTaskCompleted = new AtomicBoolean();
-        masterService.submitStateUpdateTask("test1", new ClusterStateUpdateTask() {
+        masterService.submitUnbatchedStateUpdateTask("test1", new ClusterStateUpdateTask() {
             @Override
             public ClusterState execute(ClusterState currentState) {
                 return ClusterState.builder(currentState)
@@ -95,7 +94,7 @@ public class FakeThreadPoolMasterServiceTests extends ESTestCase {
             public void onFailure(Exception e) {
                 throw new AssertionError();
             }
-        }, ClusterStateTaskExecutor.unbatched());
+        });
         assertThat(runnableTasks.size(), equalTo(1));
         assertThat(lastClusterStateRef.get().metadata().indices().size(), equalTo(0));
         assertThat(lastClusterStateRef.get().version(), equalTo(firstClusterStateVersion));
@@ -117,7 +116,7 @@ public class FakeThreadPoolMasterServiceTests extends ESTestCase {
         assertThat(runnableTasks.size(), equalTo(0));
 
         AtomicBoolean secondTaskCompleted = new AtomicBoolean();
-        masterService.submitStateUpdateTask("test2", new ClusterStateUpdateTask() {
+        masterService.submitUnbatchedStateUpdateTask("test2", new ClusterStateUpdateTask() {
             @Override
             public ClusterState execute(ClusterState currentState) {
                 return ClusterState.builder(currentState)
@@ -135,7 +134,7 @@ public class FakeThreadPoolMasterServiceTests extends ESTestCase {
             public void onFailure(Exception e) {
                 throw new AssertionError();
             }
-        }, ClusterStateTaskExecutor.unbatched());
+        });
         assertThat(runnableTasks.size(), equalTo(0));
 
         publishingCallback.getAndSet(null).onResponse(null);

--- a/x-pack/plugin/autoscaling/src/main/java/org/elasticsearch/xpack/autoscaling/action/TransportDeleteAutoscalingPolicyAction.java
+++ b/x-pack/plugin/autoscaling/src/main/java/org/elasticsearch/xpack/autoscaling/action/TransportDeleteAutoscalingPolicyAction.java
@@ -16,7 +16,6 @@ import org.elasticsearch.action.support.master.AcknowledgedResponse;
 import org.elasticsearch.action.support.master.AcknowledgedTransportMasterNodeAction;
 import org.elasticsearch.cluster.AckedClusterStateUpdateTask;
 import org.elasticsearch.cluster.ClusterState;
-import org.elasticsearch.cluster.ClusterStateTaskExecutor;
 import org.elasticsearch.cluster.ClusterStateUpdateTask;
 import org.elasticsearch.cluster.block.ClusterBlockException;
 import org.elasticsearch.cluster.block.ClusterBlockLevel;
@@ -68,17 +67,17 @@ public class TransportDeleteAutoscalingPolicyAction extends AcknowledgedTranspor
     ) {
         // no license check, we will allow deleting policies even if the license is out of compliance, for cleanup purposes
 
-        clusterService.submitStateUpdateTask("delete-autoscaling-policy", new AckedClusterStateUpdateTask(request, listener) {
+        submitUnbatchedTask("delete-autoscaling-policy", new AckedClusterStateUpdateTask(request, listener) {
             @Override
             public ClusterState execute(final ClusterState currentState) {
                 return deleteAutoscalingPolicy(currentState, request.name(), LOGGER);
             }
-        }, newExecutor());
+        });
     }
 
     @SuppressForbidden(reason = "legacy usage of unbatched task") // TODO add support for batching here
-    private static <T extends ClusterStateUpdateTask> ClusterStateTaskExecutor<T> newExecutor() {
-        return ClusterStateTaskExecutor.unbatched();
+    private void submitUnbatchedTask(@SuppressWarnings("SameParameterValue") String source, ClusterStateUpdateTask task) {
+        clusterService.submitUnbatchedStateUpdateTask(source, task);
     }
 
     @Override

--- a/x-pack/plugin/autoscaling/src/main/java/org/elasticsearch/xpack/autoscaling/action/TransportPutAutoscalingPolicyAction.java
+++ b/x-pack/plugin/autoscaling/src/main/java/org/elasticsearch/xpack/autoscaling/action/TransportPutAutoscalingPolicyAction.java
@@ -15,7 +15,6 @@ import org.elasticsearch.action.support.master.AcknowledgedResponse;
 import org.elasticsearch.action.support.master.AcknowledgedTransportMasterNodeAction;
 import org.elasticsearch.cluster.AckedClusterStateUpdateTask;
 import org.elasticsearch.cluster.ClusterState;
-import org.elasticsearch.cluster.ClusterStateTaskExecutor;
 import org.elasticsearch.cluster.ClusterStateUpdateTask;
 import org.elasticsearch.cluster.block.ClusterBlockException;
 import org.elasticsearch.cluster.block.ClusterBlockLevel;
@@ -104,17 +103,17 @@ public class TransportPutAutoscalingPolicyAction extends AcknowledgedTransportMa
             return;
         }
 
-        clusterService.submitStateUpdateTask("put-autoscaling-policy", new AckedClusterStateUpdateTask(request, listener) {
+        submitUnbatchedTask("put-autoscaling-policy", new AckedClusterStateUpdateTask(request, listener) {
             @Override
             public ClusterState execute(final ClusterState currentState) {
                 return putAutoscalingPolicy(currentState, request, policyValidator, LOGGER);
             }
-        }, newExecutor());
+        });
     }
 
     @SuppressForbidden(reason = "legacy usage of unbatched task") // TODO add support for batching here
-    private static <T extends ClusterStateUpdateTask> ClusterStateTaskExecutor<T> newExecutor() {
-        return ClusterStateTaskExecutor.unbatched();
+    private void submitUnbatchedTask(@SuppressWarnings("SameParameterValue") String source, ClusterStateUpdateTask task) {
+        clusterService.submitUnbatchedStateUpdateTask(source, task);
     }
 
     @Override

--- a/x-pack/plugin/ccr/src/internalClusterTest/java/org/elasticsearch/xpack/ccr/CcrLicenseIT.java
+++ b/x-pack/plugin/ccr/src/internalClusterTest/java/org/elasticsearch/xpack/ccr/CcrLicenseIT.java
@@ -14,7 +14,6 @@ import org.elasticsearch.ElasticsearchSecurityException;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.master.AcknowledgedResponse;
 import org.elasticsearch.cluster.ClusterState;
-import org.elasticsearch.cluster.ClusterStateTaskExecutor;
 import org.elasticsearch.cluster.ClusterStateUpdateTask;
 import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.cluster.service.ClusterService;
@@ -156,7 +155,7 @@ public class CcrLicenseIT extends CcrSingleNodeTestCase {
             // in case of incompatible license:
             CountDownLatch latch = new CountDownLatch(1);
             ClusterService clusterService = getInstanceFromNode(ClusterService.class);
-            clusterService.submitStateUpdateTask("test-add-auto-follow-pattern", new ClusterStateUpdateTask() {
+            clusterService.submitUnbatchedStateUpdateTask("test-add-auto-follow-pattern", new ClusterStateUpdateTask() {
 
                 @Override
                 public ClusterState execute(ClusterState currentState) throws Exception {
@@ -201,7 +200,7 @@ public class CcrLicenseIT extends CcrSingleNodeTestCase {
                     latch.countDown();
                     fail("unexpected error [" + e.getMessage() + "]");
                 }
-            }, ClusterStateTaskExecutor.unbatched());
+            });
             latch.await();
             appender.assertAllExpectationsMatched();
         } finally {

--- a/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/action/TransportActivateAutoFollowPatternAction.java
+++ b/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/action/TransportActivateAutoFollowPatternAction.java
@@ -13,7 +13,6 @@ import org.elasticsearch.action.support.master.AcknowledgedResponse;
 import org.elasticsearch.action.support.master.AcknowledgedTransportMasterNodeAction;
 import org.elasticsearch.cluster.AckedClusterStateUpdateTask;
 import org.elasticsearch.cluster.ClusterState;
-import org.elasticsearch.cluster.ClusterStateTaskExecutor;
 import org.elasticsearch.cluster.ClusterStateUpdateTask;
 import org.elasticsearch.cluster.block.ClusterBlockException;
 import org.elasticsearch.cluster.block.ClusterBlockLevel;
@@ -65,21 +64,17 @@ public class TransportActivateAutoFollowPatternAction extends AcknowledgedTransp
         final ClusterState state,
         final ActionListener<AcknowledgedResponse> listener
     ) {
-        clusterService.submitStateUpdateTask(
-            "activate-auto-follow-pattern-" + request.getName(),
-            new AckedClusterStateUpdateTask(request, listener) {
-                @Override
-                public ClusterState execute(final ClusterState currentState) {
-                    return innerActivate(request, currentState);
-                }
-            },
-            newExecutor()
-        );
+        submitUnbatchedTask("activate-auto-follow-pattern-" + request.getName(), new AckedClusterStateUpdateTask(request, listener) {
+            @Override
+            public ClusterState execute(final ClusterState currentState) {
+                return innerActivate(request, currentState);
+            }
+        });
     }
 
     @SuppressForbidden(reason = "legacy usage of unbatched task") // TODO add support for batching here
-    private static <T extends ClusterStateUpdateTask> ClusterStateTaskExecutor<T> newExecutor() {
-        return ClusterStateTaskExecutor.unbatched();
+    private void submitUnbatchedTask(@SuppressWarnings("SameParameterValue") String source, ClusterStateUpdateTask task) {
+        clusterService.submitUnbatchedStateUpdateTask(source, task);
     }
 
     static ClusterState innerActivate(final Request request, ClusterState currentState) {

--- a/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/action/TransportPutAutoFollowPatternAction.java
+++ b/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/action/TransportPutAutoFollowPatternAction.java
@@ -15,7 +15,6 @@ import org.elasticsearch.action.support.master.AcknowledgedTransportMasterNodeAc
 import org.elasticsearch.client.internal.Client;
 import org.elasticsearch.cluster.AckedClusterStateUpdateTask;
 import org.elasticsearch.cluster.ClusterState;
-import org.elasticsearch.cluster.ClusterStateTaskExecutor;
 import org.elasticsearch.cluster.ClusterStateUpdateTask;
 import org.elasticsearch.cluster.block.ClusterBlockException;
 import org.elasticsearch.cluster.block.ClusterBlockLevel;
@@ -106,15 +105,14 @@ public class TransportPutAutoFollowPatternAction extends AcknowledgedTransportMa
             String[] indices = request.getLeaderIndexPatterns().toArray(new String[0]);
             ccrLicenseChecker.hasPrivilegesToFollowIndices(remoteClient, indices, e -> {
                 if (e == null) {
-                    clusterService.submitStateUpdateTask(
+                    submitUnbatchedTask(
                         "put-auto-follow-pattern-" + request.getRemoteCluster(),
                         new AckedClusterStateUpdateTask(request, listener) {
                             @Override
                             public ClusterState execute(ClusterState currentState) {
                                 return innerPut(request, filteredHeaders, currentState, remoteClusterState.getState());
                             }
-                        },
-                        newExecutor()
+                        }
                     );
                 } else {
                     listener.onFailure(e);
@@ -137,8 +135,8 @@ public class TransportPutAutoFollowPatternAction extends AcknowledgedTransportMa
     }
 
     @SuppressForbidden(reason = "legacy usage of unbatched task") // TODO add support for batching here
-    private static <T extends ClusterStateUpdateTask> ClusterStateTaskExecutor<T> newExecutor() {
-        return ClusterStateTaskExecutor.unbatched();
+    private void submitUnbatchedTask(@SuppressWarnings("SameParameterValue") String source, ClusterStateUpdateTask task) {
+        clusterService.submitUnbatchedStateUpdateTask(source, task);
     }
 
     static ClusterState innerPut(

--- a/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/action/TransportUnfollowAction.java
+++ b/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/action/TransportUnfollowAction.java
@@ -22,7 +22,6 @@ import org.elasticsearch.action.support.master.AcknowledgedResponse;
 import org.elasticsearch.action.support.master.AcknowledgedTransportMasterNodeAction;
 import org.elasticsearch.client.internal.Client;
 import org.elasticsearch.cluster.ClusterState;
-import org.elasticsearch.cluster.ClusterStateTaskExecutor;
 import org.elasticsearch.cluster.ClusterStateUpdateTask;
 import org.elasticsearch.cluster.block.ClusterBlockException;
 import org.elasticsearch.cluster.block.ClusterBlockLevel;
@@ -86,7 +85,7 @@ public class TransportUnfollowAction extends AcknowledgedTransportMasterNodeActi
         final ClusterState state,
         final ActionListener<AcknowledgedResponse> listener
     ) {
-        clusterService.submitStateUpdateTask("unfollow_action", new ClusterStateUpdateTask() {
+        submitUnbatchedTask("unfollow_action", new ClusterStateUpdateTask() {
 
             @Override
             public ClusterState execute(final ClusterState current) {
@@ -228,12 +227,12 @@ public class TransportUnfollowAction extends AcknowledgedTransportMasterNodeActi
                 }
             }
 
-        }, newExecutor());
+        });
     }
 
     @SuppressForbidden(reason = "legacy usage of unbatched task") // TODO add support for batching here
-    private static <T extends ClusterStateUpdateTask> ClusterStateTaskExecutor<T> newExecutor() {
-        return ClusterStateTaskExecutor.unbatched();
+    private void submitUnbatchedTask(@SuppressWarnings("SameParameterValue") String source, ClusterStateUpdateTask task) {
+        clusterService.submitUnbatchedStateUpdateTask(source, task);
     }
 
     @Override

--- a/x-pack/plugin/ccr/src/test/java/org/elasticsearch/xpack/CcrIntegTestCase.java
+++ b/x-pack/plugin/ccr/src/test/java/org/elasticsearch/xpack/CcrIntegTestCase.java
@@ -29,7 +29,6 @@ import org.elasticsearch.client.internal.Requests;
 import org.elasticsearch.cluster.ClusterChangedEvent;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.ClusterStateListener;
-import org.elasticsearch.cluster.ClusterStateTaskExecutor;
 import org.elasticsearch.cluster.ClusterStateUpdateTask;
 import org.elasticsearch.cluster.RestoreInProgress;
 import org.elasticsearch.cluster.health.ClusterHealthStatus;
@@ -888,7 +887,7 @@ public abstract class CcrIntegTestCase extends ESTestCase {
 
     static void removeCCRRelatedMetadataFromClusterState(ClusterService clusterService) throws Exception {
         CountDownLatch latch = new CountDownLatch(1);
-        clusterService.submitStateUpdateTask("remove-ccr-related-metadata", new ClusterStateUpdateTask() {
+        clusterService.submitUnbatchedStateUpdateTask("remove-ccr-related-metadata", new ClusterStateUpdateTask() {
             @Override
             public ClusterState execute(ClusterState currentState) throws Exception {
                 AutoFollowMetadata empty = new AutoFollowMetadata(Collections.emptyMap(), Collections.emptyMap(), Collections.emptyMap());
@@ -911,7 +910,7 @@ public abstract class CcrIntegTestCase extends ESTestCase {
             public void clusterStateProcessed(ClusterState oldState, ClusterState newState) {
                 latch.countDown();
             }
-        }, ClusterStateTaskExecutor.unbatched());
+        });
         latch.await();
     }
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/license/LicenseService.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/license/LicenseService.java
@@ -15,7 +15,6 @@ import org.elasticsearch.cluster.AckedClusterStateUpdateTask;
 import org.elasticsearch.cluster.ClusterChangedEvent;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.ClusterStateListener;
-import org.elasticsearch.cluster.ClusterStateTaskExecutor;
 import org.elasticsearch.cluster.ClusterStateUpdateTask;
 import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.cluster.service.ClusterService;
@@ -303,42 +302,38 @@ public class LicenseService extends AbstractLifecycleComponent implements Cluste
                 }
             }
 
-            clusterService.submitStateUpdateTask(
-                "register license [" + newLicense.uid() + "]",
-                new AckedClusterStateUpdateTask(request, listener) {
-                    @Override
-                    protected PutLicenseResponse newResponse(boolean acknowledged) {
-                        return new PutLicenseResponse(acknowledged, LicensesStatus.VALID);
-                    }
+            submitUnbatchedTask("register license [" + newLicense.uid() + "]", new AckedClusterStateUpdateTask(request, listener) {
+                @Override
+                protected PutLicenseResponse newResponse(boolean acknowledged) {
+                    return new PutLicenseResponse(acknowledged, LicensesStatus.VALID);
+                }
 
-                    @Override
-                    public ClusterState execute(ClusterState currentState) throws Exception {
-                        XPackPlugin.checkReadyForXPackCustomMetadata(currentState);
-                        final Version oldestNodeVersion = currentState.nodes().getSmallestNonClientNodeVersion();
-                        if (licenseIsCompatible(newLicense, oldestNodeVersion) == false) {
-                            throw new IllegalStateException(
-                                "The provided license is not compatible with node version [" + oldestNodeVersion + "]"
-                            );
-                        }
-                        Metadata currentMetadata = currentState.metadata();
-                        LicensesMetadata licensesMetadata = currentMetadata.custom(LicensesMetadata.TYPE);
-                        Version trialVersion = null;
-                        if (licensesMetadata != null) {
-                            trialVersion = licensesMetadata.getMostRecentTrialVersion();
-                        }
-                        Metadata.Builder mdBuilder = Metadata.builder(currentMetadata);
-                        mdBuilder.putCustom(LicensesMetadata.TYPE, new LicensesMetadata(newLicense, trialVersion));
-                        return ClusterState.builder(currentState).metadata(mdBuilder).build();
+                @Override
+                public ClusterState execute(ClusterState currentState) throws Exception {
+                    XPackPlugin.checkReadyForXPackCustomMetadata(currentState);
+                    final Version oldestNodeVersion = currentState.nodes().getSmallestNonClientNodeVersion();
+                    if (licenseIsCompatible(newLicense, oldestNodeVersion) == false) {
+                        throw new IllegalStateException(
+                            "The provided license is not compatible with node version [" + oldestNodeVersion + "]"
+                        );
                     }
-                },
-                newExecutor()
-            );
+                    Metadata currentMetadata = currentState.metadata();
+                    LicensesMetadata licensesMetadata = currentMetadata.custom(LicensesMetadata.TYPE);
+                    Version trialVersion = null;
+                    if (licensesMetadata != null) {
+                        trialVersion = licensesMetadata.getMostRecentTrialVersion();
+                    }
+                    Metadata.Builder mdBuilder = Metadata.builder(currentMetadata);
+                    mdBuilder.putCustom(LicensesMetadata.TYPE, new LicensesMetadata(newLicense, trialVersion));
+                    return ClusterState.builder(currentState).metadata(mdBuilder).build();
+                }
+            });
         }
     }
 
     @SuppressForbidden(reason = "legacy usage of unbatched task") // TODO add support for batching here
-    private static <T extends ClusterStateUpdateTask> ClusterStateTaskExecutor<T> newExecutor() {
-        return ClusterStateTaskExecutor.unbatched();
+    private void submitUnbatchedTask(@SuppressWarnings("SameParameterValue") String source, ClusterStateUpdateTask task) {
+        clusterService.submitUnbatchedStateUpdateTask(source, task);
     }
 
     private static boolean licenseIsCompatible(License license, Version version) {
@@ -403,7 +398,7 @@ public class LicenseService extends AbstractLifecycleComponent implements Cluste
             "delete license",
             listener
         );
-        clusterService.submitStateUpdateTask(task.getDescription(), task, newExecutor());
+        submitUnbatchedTask(task.getDescription(), task);
     }
 
     public License getLicense() {
@@ -427,7 +422,7 @@ public class LicenseService extends AbstractLifecycleComponent implements Cluste
             );
         }
         StartTrialClusterTask task = new StartTrialClusterTask(logger, clusterService.getClusterName().value(), clock, request, listener);
-        clusterService.submitStateUpdateTask(StartTrialClusterTask.TASK_SOURCE, task, newExecutor());
+        submitUnbatchedTask(StartTrialClusterTask.TASK_SOURCE, task);
     }
 
     void startBasicLicense(PostStartBasicRequest request, final ActionListener<PostStartBasicResponse> listener) {
@@ -439,7 +434,7 @@ public class LicenseService extends AbstractLifecycleComponent implements Cluste
             "start basic license",
             listener
         );
-        clusterService.submitStateUpdateTask(task.getDescription(), task, newExecutor());
+        submitUnbatchedTask(task.getDescription(), task);
     }
 
     /**
@@ -449,10 +444,9 @@ public class LicenseService extends AbstractLifecycleComponent implements Cluste
      * a new basic license with no expiration date is generated.
      */
     private void registerOrUpdateSelfGeneratedLicense() {
-        clusterService.submitStateUpdateTask(
+        submitUnbatchedTask(
             StartupSelfGeneratedLicenseTask.TASK_SOURCE,
-            new StartupSelfGeneratedLicenseTask(settings, clock, clusterService),
-            newExecutor()
+            new StartupSelfGeneratedLicenseTask(settings, clock, clusterService)
         );
     }
 

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/license/AbstractLicensesIntegrationTestCase.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/license/AbstractLicensesIntegrationTestCase.java
@@ -8,7 +8,6 @@ package org.elasticsearch.license;
 
 import org.elasticsearch.analysis.common.CommonAnalysisPlugin;
 import org.elasticsearch.cluster.ClusterState;
-import org.elasticsearch.cluster.ClusterStateTaskExecutor;
 import org.elasticsearch.cluster.ClusterStateUpdateTask;
 import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.cluster.service.ClusterService;
@@ -41,7 +40,7 @@ public abstract class AbstractLicensesIntegrationTestCase extends ESIntegTestCas
     protected void putLicense(final License license) throws InterruptedException {
         final CountDownLatch latch = new CountDownLatch(1);
         ClusterService clusterService = internalCluster().getInstance(ClusterService.class, internalCluster().getMasterName());
-        clusterService.submitStateUpdateTask("putting license", new ClusterStateUpdateTask() {
+        clusterService.submitUnbatchedStateUpdateTask("putting license", new ClusterStateUpdateTask() {
             @Override
             public void clusterStateProcessed(ClusterState oldState, ClusterState newState) {
                 latch.countDown();
@@ -58,7 +57,7 @@ public abstract class AbstractLicensesIntegrationTestCase extends ESIntegTestCas
             public void onFailure(@Nullable Exception e) {
                 logger.error("error on metadata cleanup after test", e);
             }
-        }, ClusterStateTaskExecutor.unbatched());
+        });
         latch.await();
     }
 
@@ -69,7 +68,7 @@ public abstract class AbstractLicensesIntegrationTestCase extends ESIntegTestCas
     protected void wipeAllLicenses() throws InterruptedException {
         final CountDownLatch latch = new CountDownLatch(1);
         ClusterService clusterService = internalCluster().getInstance(ClusterService.class, internalCluster().getMasterName());
-        clusterService.submitStateUpdateTask("delete licensing metadata", new ClusterStateUpdateTask() {
+        clusterService.submitUnbatchedStateUpdateTask("delete licensing metadata", new ClusterStateUpdateTask() {
             @Override
             public void clusterStateProcessed(ClusterState oldState, ClusterState newState) {
                 latch.countDown();
@@ -86,7 +85,7 @@ public abstract class AbstractLicensesIntegrationTestCase extends ESIntegTestCas
             public void onFailure(@Nullable Exception e) {
                 logger.error("error on metadata cleanup after test", e);
             }
-        }, ClusterStateTaskExecutor.unbatched());
+        });
         latch.await();
     }
 

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/license/LicenseClusterChangeTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/license/LicenseClusterChangeTests.java
@@ -73,7 +73,7 @@ public class LicenseClusterChangeTests extends AbstractLicenseServiceTestCase {
 
         licenseService.clusterChanged(new ClusterChangedEvent("simulated", newState, oldState));
         ArgumentCaptor<ClusterStateUpdateTask> stateUpdater = ArgumentCaptor.forClass(ClusterStateUpdateTask.class);
-        verify(clusterService, times(1)).submitStateUpdateTask(any(), stateUpdater.capture(), any());
+        verify(clusterService, times(1)).submitUnbatchedStateUpdateTask(any(), stateUpdater.capture());
         ClusterState stateWithLicense = stateUpdater.getValue().execute(newState);
         LicensesMetadata licenseMetadata = stateWithLicense.metadata().custom(LicensesMetadata.TYPE);
         assertNotNull(licenseMetadata);

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/license/LicenseFIPSTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/license/LicenseFIPSTests.java
@@ -40,7 +40,7 @@ public class LicenseFIPSTests extends AbstractLicenseServiceTestCase {
             // In which case, this `actionGet` should throw a more useful exception than the verify below.
             responseFuture.actionGet();
         }
-        verify(clusterService).submitStateUpdateTask(any(String.class), any(ClusterStateUpdateTask.class), any());
+        verify(clusterService).submitUnbatchedStateUpdateTask(any(String.class), any(ClusterStateUpdateTask.class));
     }
 
     public void testFIPSCheckWithoutAllowedLicense() throws Exception {
@@ -80,6 +80,6 @@ public class LicenseFIPSTests extends AbstractLicenseServiceTestCase {
             // In which case, this `actionGet` should throw a more useful exception than the verify below.
             responseFuture.actionGet();
         }
-        verify(clusterService).submitStateUpdateTask(any(String.class), any(ClusterStateUpdateTask.class), any());
+        verify(clusterService).submitUnbatchedStateUpdateTask(any(String.class), any(ClusterStateUpdateTask.class));
     }
 }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/license/LicenseRegistrationTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/license/LicenseRegistrationTests.java
@@ -31,7 +31,7 @@ public class LicenseRegistrationTests extends AbstractLicenseServiceTestCase {
 
         ClusterState state = ClusterState.builder(new ClusterName("a")).build();
         ArgumentCaptor<ClusterStateUpdateTask> stateUpdater = ArgumentCaptor.forClass(ClusterStateUpdateTask.class);
-        verify(clusterService, Mockito.times(1)).submitStateUpdateTask(any(), stateUpdater.capture(), any());
+        verify(clusterService, Mockito.times(1)).submitUnbatchedStateUpdateTask(any(), stateUpdater.capture());
         ClusterState stateWithLicense = stateUpdater.getValue().execute(state);
         LicensesMetadata licenseMetadata = stateWithLicense.metadata().custom(LicensesMetadata.TYPE);
         assertNotNull(licenseMetadata);
@@ -52,7 +52,7 @@ public class LicenseRegistrationTests extends AbstractLicenseServiceTestCase {
 
         ClusterState state = ClusterState.builder(new ClusterName("a")).build();
         ArgumentCaptor<ClusterStateUpdateTask> stateUpdater = ArgumentCaptor.forClass(ClusterStateUpdateTask.class);
-        verify(clusterService, Mockito.times(1)).submitStateUpdateTask(any(), stateUpdater.capture(), any());
+        verify(clusterService, Mockito.times(1)).submitUnbatchedStateUpdateTask(any(), stateUpdater.capture());
         ClusterState stateWithLicense = stateUpdater.getValue().execute(state);
         LicensesMetadata licenseMetadata = stateWithLicense.metadata().custom(LicensesMetadata.TYPE);
         assertNotNull(licenseMetadata);
@@ -86,7 +86,7 @@ public class LicenseRegistrationTests extends AbstractLicenseServiceTestCase {
         mdBuilder.putCustom(LicensesMetadata.TYPE, new LicensesMetadata(license, null));
         ClusterState state = ClusterState.builder(new ClusterName("a")).metadata(mdBuilder.build()).build();
         ArgumentCaptor<ClusterStateUpdateTask> stateUpdater = ArgumentCaptor.forClass(ClusterStateUpdateTask.class);
-        verify(clusterService, Mockito.times(1)).submitStateUpdateTask(any(), stateUpdater.capture(), any());
+        verify(clusterService, Mockito.times(1)).submitUnbatchedStateUpdateTask(any(), stateUpdater.capture());
         ClusterState stateWithLicense = stateUpdater.getValue().execute(state);
         LicensesMetadata licenseMetadata = stateWithLicense.metadata().custom(LicensesMetadata.TYPE);
         assertNotNull(licenseMetadata);
@@ -118,7 +118,7 @@ public class LicenseRegistrationTests extends AbstractLicenseServiceTestCase {
         mdBuilder.putCustom(LicensesMetadata.TYPE, new LicensesMetadata(license, null));
         ClusterState state = ClusterState.builder(new ClusterName("a")).metadata(mdBuilder.build()).build();
         ArgumentCaptor<ClusterStateUpdateTask> stateUpdater = ArgumentCaptor.forClass(ClusterStateUpdateTask.class);
-        verify(clusterService, Mockito.times(1)).submitStateUpdateTask(any(), stateUpdater.capture(), any());
+        verify(clusterService, Mockito.times(1)).submitUnbatchedStateUpdateTask(any(), stateUpdater.capture());
         ClusterState stateWithLicense = stateUpdater.getValue().execute(state);
         LicensesMetadata licenseMetadata = stateWithLicense.metadata().custom(LicensesMetadata.TYPE);
         assertNotNull(licenseMetadata);

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/license/LicenseServiceTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/license/LicenseServiceTests.java
@@ -204,7 +204,7 @@ public class LicenseServiceTests extends ESTestCase {
             assertion.accept(future);
         } else {
             ArgumentCaptor<ClusterStateUpdateTask> taskCaptor = ArgumentCaptor.forClass(ClusterStateUpdateTask.class);
-            verify(clusterService, times(1)).submitStateUpdateTask(any(), taskCaptor.capture(), any());
+            verify(clusterService, times(1)).submitUnbatchedStateUpdateTask(any(), taskCaptor.capture());
 
             final ClusterStateUpdateTask task = taskCaptor.getValue();
             assertThat(task, instanceOf(AckedClusterStateUpdateTask.class));

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/license/LicenseTLSTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/license/LicenseTLSTests.java
@@ -42,7 +42,7 @@ public class LicenseTLSTests extends AbstractLicenseServiceTestCase {
         licenseService.start();
         PlainActionFuture<PutLicenseResponse> responseFuture = new PlainActionFuture<>();
         licenseService.registerLicense(request, responseFuture);
-        verify(clusterService).submitStateUpdateTask(any(String.class), any(ClusterStateUpdateTask.class), any());
+        verify(clusterService).submitUnbatchedStateUpdateTask(any(String.class), any(ClusterStateUpdateTask.class));
 
         inetAddress = TransportAddress.META_ADDRESS;
         settings = Settings.builder()
@@ -54,7 +54,7 @@ public class LicenseTLSTests extends AbstractLicenseServiceTestCase {
         setInitialState(null, licenseState, settings);
         licenseService.start();
         licenseService.registerLicense(request, responseFuture);
-        verify(clusterService, times(2)).submitStateUpdateTask(any(String.class), any(ClusterStateUpdateTask.class), any());
+        verify(clusterService, times(2)).submitUnbatchedStateUpdateTask(any(String.class), any(ClusterStateUpdateTask.class));
     }
 
     @Override

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/license/LicensesAcknowledgementTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/license/LicensesAcknowledgementTests.java
@@ -33,13 +33,13 @@ public class LicensesAcknowledgementTests extends AbstractLicenseServiceTestCase
         // ensure acknowledgement message was part of the response
         licenseService.registerLicense(putLicenseRequest, new AssertingLicensesUpdateResponse(false, LicensesStatus.VALID, true));
         assertThat(licenseService.getLicense(), not(signedLicense));
-        verify(clusterService, times(0)).submitStateUpdateTask(any(String.class), any(ClusterStateUpdateTask.class), any());
+        verify(clusterService, times(0)).submitUnbatchedStateUpdateTask(any(String.class), any(ClusterStateUpdateTask.class));
 
         // try installing a signed license with acknowledgement
         putLicenseRequest = new PutLicenseRequest().license(signedLicense).acknowledge(true);
         // ensure license was installed and no acknowledgment message was returned
         licenseService.registerLicense(putLicenseRequest, new AssertingLicensesUpdateResponse(true, LicensesStatus.VALID, false));
-        verify(clusterService, times(1)).submitStateUpdateTask(any(String.class), any(ClusterStateUpdateTask.class), any());
+        verify(clusterService, times(1)).submitUnbatchedStateUpdateTask(any(String.class), any(ClusterStateUpdateTask.class));
     }
 
     private static class AssertingLicensesUpdateResponse implements ActionListener<PutLicenseResponse> {

--- a/x-pack/plugin/enrich/src/main/java/org/elasticsearch/xpack/enrich/EnrichStore.java
+++ b/x-pack/plugin/enrich/src/main/java/org/elasticsearch/xpack/enrich/EnrichStore.java
@@ -11,7 +11,6 @@ import org.elasticsearch.ResourceNotFoundException;
 import org.elasticsearch.Version;
 import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.cluster.ClusterState;
-import org.elasticsearch.cluster.ClusterStateTaskExecutor;
 import org.elasticsearch.cluster.ClusterStateUpdateTask;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
@@ -185,7 +184,7 @@ public final class EnrichStore {
         Consumer<Exception> handler,
         Function<ClusterState, Map<String, EnrichPolicy>> function
     ) {
-        clusterService.submitStateUpdateTask("update-enrich-metadata", new ClusterStateUpdateTask() {
+        submitUnbatchedTask(clusterService, "update-enrich-metadata", new ClusterStateUpdateTask() {
 
             @Override
             public ClusterState execute(ClusterState currentState) throws Exception {
@@ -205,11 +204,15 @@ public final class EnrichStore {
             public void onFailure(Exception e) {
                 handler.accept(e);
             }
-        }, newExecutor());
+        });
     }
 
     @SuppressForbidden(reason = "legacy usage of unbatched task") // TODO add support for batching here
-    private static <T extends ClusterStateUpdateTask> ClusterStateTaskExecutor<T> newExecutor() {
-        return ClusterStateTaskExecutor.unbatched();
+    private static void submitUnbatchedTask(
+        ClusterService clusterService,
+        @SuppressWarnings("SameParameterValue") String source,
+        ClusterStateUpdateTask task
+    ) {
+        clusterService.submitUnbatchedStateUpdateTask(source, task);
     }
 }

--- a/x-pack/plugin/frozen-indices/src/main/java/org/elasticsearch/xpack/frozen/action/TransportFreezeIndexAction.java
+++ b/x-pack/plugin/frozen-indices/src/main/java/org/elasticsearch/xpack/frozen/action/TransportFreezeIndexAction.java
@@ -19,7 +19,6 @@ import org.elasticsearch.action.support.DestructiveOperations;
 import org.elasticsearch.action.support.master.TransportMasterNodeAction;
 import org.elasticsearch.cluster.AckedClusterStateUpdateTask;
 import org.elasticsearch.cluster.ClusterState;
-import org.elasticsearch.cluster.ClusterStateTaskExecutor;
 import org.elasticsearch.cluster.ClusterStateUpdateTask;
 import org.elasticsearch.cluster.block.ClusterBlockException;
 import org.elasticsearch.cluster.block.ClusterBlockLevel;
@@ -142,7 +141,7 @@ public final class TransportFreezeIndexAction extends TransportMasterNodeAction<
         final FreezeRequest request,
         final ActionListener<FreezeResponse> listener
     ) {
-        clusterService.submitStateUpdateTask(
+        submitUnbatchedTask(
             "toggle-frozen-settings",
             new AckedClusterStateUpdateTask(Priority.URGENT, request, listener.delegateFailure((delegate, acknowledgedResponse) -> {
                 OpenIndexClusterStateUpdateRequest updateRequest = new OpenIndexClusterStateUpdateRequest().ackTimeout(request.timeout())
@@ -210,8 +209,7 @@ public final class TransportFreezeIndexAction extends TransportMasterNodeAction<
                     }
                     return ClusterState.builder(currentState).blocks(blocks).metadata(builder).build();
                 }
-            },
-            newExecutor()
+            }
         );
     }
 
@@ -222,7 +220,7 @@ public final class TransportFreezeIndexAction extends TransportMasterNodeAction<
     }
 
     @SuppressForbidden(reason = "legacy usage of unbatched task") // TODO add support for batching here
-    private static <T extends ClusterStateUpdateTask> ClusterStateTaskExecutor<T> newExecutor() {
-        return ClusterStateTaskExecutor.unbatched();
+    private void submitUnbatchedTask(@SuppressWarnings("SameParameterValue") String source, ClusterStateUpdateTask task) {
+        clusterService.submitUnbatchedStateUpdateTask(source, task);
     }
 }

--- a/x-pack/plugin/ilm/src/internalClusterTest/java/org/elasticsearch/xpack/ilm/ClusterStateWaitThresholdBreachTests.java
+++ b/x-pack/plugin/ilm/src/internalClusterTest/java/org/elasticsearch/xpack/ilm/ClusterStateWaitThresholdBreachTests.java
@@ -9,7 +9,6 @@ package org.elasticsearch.xpack.ilm;
 
 import org.elasticsearch.action.admin.indices.create.CreateIndexResponse;
 import org.elasticsearch.cluster.ClusterState;
-import org.elasticsearch.cluster.ClusterStateTaskExecutor;
 import org.elasticsearch.cluster.ClusterStateUpdateTask;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.service.ClusterService;
@@ -145,7 +144,7 @@ public class ClusterStateWaitThresholdBreachTests extends ESIntegTestCase {
         // an old timestamp so the `1h` wait threshold we configured using LIFECYCLE_STEP_WAIT_TIME_THRESHOLD is breached and a new
         // shrink cycle is started
         LongSupplier nowWayBackInThePastSupplier = () -> 1234L;
-        clusterService.submitStateUpdateTask("testing-move-to-step-to-manipulate-step-time", new ClusterStateUpdateTask() {
+        clusterService.submitUnbatchedStateUpdateTask("testing-move-to-step-to-manipulate-step-time", new ClusterStateUpdateTask() {
             @Override
             public ClusterState execute(ClusterState currentState) throws Exception {
                 return new MoveToNextStepUpdateTask(
@@ -163,7 +162,7 @@ public class ClusterStateWaitThresholdBreachTests extends ESIntegTestCase {
             public void onFailure(Exception e) {
                 throw new AssertionError(e);
             }
-        }, ClusterStateTaskExecutor.unbatched());
+        });
 
         String[] secondCycleShrinkIndexName = new String[1];
         assertBusy(() -> {

--- a/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/IndexLifecycleService.java
+++ b/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/IndexLifecycleService.java
@@ -15,7 +15,6 @@ import org.elasticsearch.cluster.ClusterChangedEvent;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.ClusterStateApplier;
 import org.elasticsearch.cluster.ClusterStateListener;
-import org.elasticsearch.cluster.ClusterStateTaskExecutor;
 import org.elasticsearch.cluster.ClusterStateUpdateTask;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.metadata.LifecycleExecutionState;
@@ -239,11 +238,7 @@ public class IndexLifecycleService
             }
 
             if (safeToStop && OperationMode.STOPPING == currentMode) {
-                clusterService.submitStateUpdateTask(
-                    "ilm_operation_mode_update[stopped]",
-                    OperationModeUpdateTask.ilmMode(OperationMode.STOPPED),
-                    newExecutor()
-                );
+                submitUnbatchedTask("ilm_operation_mode_update[stopped]", OperationModeUpdateTask.ilmMode(OperationMode.STOPPED));
             }
         }
     }
@@ -453,11 +448,7 @@ public class IndexLifecycleService
         }
 
         if (safeToStop && OperationMode.STOPPING == currentMode) {
-            clusterService.submitStateUpdateTask(
-                "ilm_operation_mode_update[stopped]",
-                OperationModeUpdateTask.ilmMode(OperationMode.STOPPED),
-                newExecutor()
-            );
+            submitUnbatchedTask("ilm_operation_mode_update[stopped]", OperationModeUpdateTask.ilmMode(OperationMode.STOPPED));
         }
     }
 
@@ -551,7 +542,7 @@ public class IndexLifecycleService
     }
 
     @SuppressForbidden(reason = "legacy usage of unbatched task") // TODO add support for batching here
-    private static <T extends ClusterStateUpdateTask> ClusterStateTaskExecutor<T> newExecutor() {
-        return ClusterStateTaskExecutor.unbatched();
+    private void submitUnbatchedTask(@SuppressWarnings("SameParameterValue") String source, ClusterStateUpdateTask task) {
+        clusterService.submitUnbatchedStateUpdateTask(source, task);
     }
 }

--- a/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/action/TransportStartILMAction.java
+++ b/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/action/TransportStartILMAction.java
@@ -12,7 +12,6 @@ import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.master.AcknowledgedResponse;
 import org.elasticsearch.action.support.master.AcknowledgedTransportMasterNodeAction;
 import org.elasticsearch.cluster.ClusterState;
-import org.elasticsearch.cluster.ClusterStateTaskExecutor;
 import org.elasticsearch.cluster.ClusterStateUpdateTask;
 import org.elasticsearch.cluster.block.ClusterBlockException;
 import org.elasticsearch.cluster.block.ClusterBlockLevel;
@@ -52,16 +51,15 @@ public class TransportStartILMAction extends AcknowledgedTransportMasterNodeActi
 
     @Override
     protected void masterOperation(Task task, StartILMRequest request, ClusterState state, ActionListener<AcknowledgedResponse> listener) {
-        clusterService.submitStateUpdateTask(
+        submitUnbatchedTask(
             "ilm_operation_mode_update[running]",
-            OperationModeUpdateTask.wrap(OperationModeUpdateTask.ilmMode(OperationMode.RUNNING), request, listener),
-            newExecutor()
+            OperationModeUpdateTask.wrap(OperationModeUpdateTask.ilmMode(OperationMode.RUNNING), request, listener)
         );
     }
 
     @SuppressForbidden(reason = "legacy usage of unbatched task") // TODO add support for batching here
-    private static <T extends ClusterStateUpdateTask> ClusterStateTaskExecutor<T> newExecutor() {
-        return ClusterStateTaskExecutor.unbatched();
+    private void submitUnbatchedTask(@SuppressWarnings("SameParameterValue") String source, ClusterStateUpdateTask task) {
+        clusterService.submitUnbatchedStateUpdateTask(source, task);
     }
 
     @Override

--- a/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/action/TransportStopILMAction.java
+++ b/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/action/TransportStopILMAction.java
@@ -12,7 +12,6 @@ import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.master.AcknowledgedResponse;
 import org.elasticsearch.action.support.master.AcknowledgedTransportMasterNodeAction;
 import org.elasticsearch.cluster.ClusterState;
-import org.elasticsearch.cluster.ClusterStateTaskExecutor;
 import org.elasticsearch.cluster.ClusterStateUpdateTask;
 import org.elasticsearch.cluster.block.ClusterBlockException;
 import org.elasticsearch.cluster.block.ClusterBlockLevel;
@@ -52,16 +51,15 @@ public class TransportStopILMAction extends AcknowledgedTransportMasterNodeActio
 
     @Override
     protected void masterOperation(Task task, StopILMRequest request, ClusterState state, ActionListener<AcknowledgedResponse> listener) {
-        clusterService.submitStateUpdateTask(
+        submitUnbatchedTask(
             "ilm_operation_mode_update[stopping]",
-            OperationModeUpdateTask.wrap(OperationModeUpdateTask.ilmMode(OperationMode.STOPPING), request, listener),
-            newExecutor()
+            OperationModeUpdateTask.wrap(OperationModeUpdateTask.ilmMode(OperationMode.STOPPING), request, listener)
         );
     }
 
     @SuppressForbidden(reason = "legacy usage of unbatched task") // TODO add support for batching here
-    private static <T extends ClusterStateUpdateTask> ClusterStateTaskExecutor<T> newExecutor() {
-        return ClusterStateTaskExecutor.unbatched();
+    private void submitUnbatchedTask(@SuppressWarnings("SameParameterValue") String source, ClusterStateUpdateTask task) {
+        clusterService.submitUnbatchedStateUpdateTask(source, task);
     }
 
     @Override

--- a/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/slm/SnapshotLifecycleService.java
+++ b/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/slm/SnapshotLifecycleService.java
@@ -12,7 +12,6 @@ import org.apache.logging.log4j.Logger;
 import org.elasticsearch.cluster.ClusterChangedEvent;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.ClusterStateListener;
-import org.elasticsearch.cluster.ClusterStateTaskExecutor;
 import org.elasticsearch.cluster.ClusterStateUpdateTask;
 import org.elasticsearch.cluster.metadata.RepositoriesMetadata;
 import org.elasticsearch.cluster.service.ClusterService;
@@ -98,11 +97,7 @@ public class SnapshotLifecycleService implements Closeable, ClusterStateListener
                     cancelSnapshotJobs();
                 }
                 if (slmStopping(state)) {
-                    clusterService.submitStateUpdateTask(
-                        "slm_operation_mode_update[stopped]",
-                        OperationModeUpdateTask.slmMode(OperationMode.STOPPED),
-                        newExecutor()
-                    );
+                    submitUnbatchedTask("slm_operation_mode_update[stopped]", OperationModeUpdateTask.slmMode(OperationMode.STOPPED));
                 }
                 return;
             }
@@ -113,8 +108,8 @@ public class SnapshotLifecycleService implements Closeable, ClusterStateListener
     }
 
     @SuppressForbidden(reason = "legacy usage of unbatched task") // TODO add support for batching here
-    private static <T extends ClusterStateUpdateTask> ClusterStateTaskExecutor<T> newExecutor() {
-        return ClusterStateTaskExecutor.unbatched();
+    private void submitUnbatchedTask(@SuppressWarnings("SameParameterValue") String source, ClusterStateUpdateTask task) {
+        clusterService.submitUnbatchedStateUpdateTask(source, task);
     }
 
     // Only used for testing

--- a/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/slm/SnapshotRetentionTask.java
+++ b/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/slm/SnapshotRetentionTask.java
@@ -16,7 +16,6 @@ import org.elasticsearch.action.support.master.AcknowledgedResponse;
 import org.elasticsearch.client.internal.Client;
 import org.elasticsearch.client.internal.OriginSettingClient;
 import org.elasticsearch.cluster.ClusterState;
-import org.elasticsearch.cluster.ClusterStateTaskExecutor;
 import org.elasticsearch.cluster.ClusterStateUpdateTask;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.Strings;
@@ -450,15 +449,11 @@ public class SnapshotRetentionTask implements SchedulerEngine.Listener {
     }
 
     void updateStateWithStats(SnapshotLifecycleStats newStats) {
-        clusterService.submitStateUpdateTask(
-            UpdateSnapshotLifecycleStatsTask.TASK_SOURCE,
-            new UpdateSnapshotLifecycleStatsTask(newStats),
-            newExecutor()
-        );
+        submitUnbatchedTask(UpdateSnapshotLifecycleStatsTask.TASK_SOURCE, new UpdateSnapshotLifecycleStatsTask(newStats));
     }
 
     @SuppressForbidden(reason = "legacy usage of unbatched task") // TODO add support for batching here
-    private static <T extends ClusterStateUpdateTask> ClusterStateTaskExecutor<T> newExecutor() {
-        return ClusterStateTaskExecutor.unbatched();
+    private void submitUnbatchedTask(@SuppressWarnings("SameParameterValue") String source, ClusterStateUpdateTask task) {
+        clusterService.submitUnbatchedStateUpdateTask(source, task);
     }
 }

--- a/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/slm/action/TransportStartSLMAction.java
+++ b/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/slm/action/TransportStartSLMAction.java
@@ -12,7 +12,6 @@ import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.master.AcknowledgedResponse;
 import org.elasticsearch.action.support.master.AcknowledgedTransportMasterNodeAction;
 import org.elasticsearch.cluster.ClusterState;
-import org.elasticsearch.cluster.ClusterStateTaskExecutor;
 import org.elasticsearch.cluster.ClusterStateUpdateTask;
 import org.elasticsearch.cluster.block.ClusterBlockException;
 import org.elasticsearch.cluster.block.ClusterBlockLevel;
@@ -56,16 +55,15 @@ public class TransportStartSLMAction extends AcknowledgedTransportMasterNodeActi
         ClusterState state,
         ActionListener<AcknowledgedResponse> listener
     ) {
-        clusterService.submitStateUpdateTask(
+        submitUnbatchedTask(
             "slm_operation_mode_update[running]",
-            OperationModeUpdateTask.wrap(OperationModeUpdateTask.slmMode(OperationMode.RUNNING), request, listener),
-            newExecutor()
+            OperationModeUpdateTask.wrap(OperationModeUpdateTask.slmMode(OperationMode.RUNNING), request, listener)
         );
     }
 
     @SuppressForbidden(reason = "legacy usage of unbatched task") // TODO add support for batching here
-    private static <T extends ClusterStateUpdateTask> ClusterStateTaskExecutor<T> newExecutor() {
-        return ClusterStateTaskExecutor.unbatched();
+    private void submitUnbatchedTask(@SuppressWarnings("SameParameterValue") String source, ClusterStateUpdateTask task) {
+        clusterService.submitUnbatchedStateUpdateTask(source, task);
     }
 
     @Override

--- a/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/slm/action/TransportStopSLMAction.java
+++ b/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/slm/action/TransportStopSLMAction.java
@@ -12,7 +12,6 @@ import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.master.AcknowledgedResponse;
 import org.elasticsearch.action.support.master.AcknowledgedTransportMasterNodeAction;
 import org.elasticsearch.cluster.ClusterState;
-import org.elasticsearch.cluster.ClusterStateTaskExecutor;
 import org.elasticsearch.cluster.ClusterStateUpdateTask;
 import org.elasticsearch.cluster.block.ClusterBlockException;
 import org.elasticsearch.cluster.block.ClusterBlockLevel;
@@ -56,16 +55,15 @@ public class TransportStopSLMAction extends AcknowledgedTransportMasterNodeActio
         ClusterState state,
         ActionListener<AcknowledgedResponse> listener
     ) {
-        clusterService.submitStateUpdateTask(
+        submitUnbatchedTask(
             "slm_operation_mode_update[stopping]",
-            OperationModeUpdateTask.wrap(OperationModeUpdateTask.slmMode(OperationMode.STOPPING), request, listener),
-            newExecutor()
+            OperationModeUpdateTask.wrap(OperationModeUpdateTask.slmMode(OperationMode.STOPPING), request, listener)
         );
     }
 
     @SuppressForbidden(reason = "legacy usage of unbatched task") // TODO add support for batching here
-    private static <T extends ClusterStateUpdateTask> ClusterStateTaskExecutor<T> newExecutor() {
-        return ClusterStateTaskExecutor.unbatched();
+    private void submitUnbatchedTask(@SuppressWarnings("SameParameterValue") String source, ClusterStateUpdateTask task) {
+        clusterService.submitUnbatchedStateUpdateTask(source, task);
     }
 
     @Override

--- a/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/ilm/IndexLifecycleRunnerTests.java
+++ b/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/ilm/IndexLifecycleRunnerTests.java
@@ -250,7 +250,7 @@ public class IndexLifecycleRunnerTests extends ESTestCase {
 
         runner.runPeriodicStep(policyName, Metadata.builder().put(indexMetadata, true).build(), indexMetadata);
 
-        Mockito.verify(clusterService, times(1)).submitStateUpdateTask(any(), any(), any());
+        Mockito.verify(clusterService, times(1)).submitUnbatchedStateUpdateTask(any(), any());
     }
 
     public void testRunStateChangePolicyWithNoNextStep() throws Exception {

--- a/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/ilm/IndexLifecycleServiceTests.java
+++ b/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/ilm/IndexLifecycleServiceTests.java
@@ -222,7 +222,7 @@ public class IndexLifecycleServiceTests extends ESTestCase {
         doAnswer(invocationOnMock -> {
             changedOperationMode.set(true);
             return null;
-        }).when(clusterService).submitStateUpdateTask(eq("ilm_operation_mode_update"), any(OperationModeUpdateTask.class), any());
+        }).when(clusterService).submitUnbatchedStateUpdateTask(eq("ilm_operation_mode_update"), any(OperationModeUpdateTask.class));
         indexLifecycleService.applyClusterState(event);
         indexLifecycleService.triggerPolicies(currentState, true);
         assertNull(changedOperationMode.get());
@@ -283,10 +283,9 @@ public class IndexLifecycleServiceTests extends ESTestCase {
             changedOperationMode.set(true);
             return null;
         }).when(clusterService)
-            .submitStateUpdateTask(
+            .submitUnbatchedStateUpdateTask(
                 eq("ilm_operation_mode_update[stopped]"),
-                eq(OperationModeUpdateTask.ilmMode(OperationMode.STOPPED)),
-                any()
+                eq(OperationModeUpdateTask.ilmMode(OperationMode.STOPPED))
             );
         indexLifecycleService.applyClusterState(event);
         indexLifecycleService.triggerPolicies(currentState, true);
@@ -345,7 +344,8 @@ public class IndexLifecycleServiceTests extends ESTestCase {
             assertThat(task.getILMOperationMode(), equalTo(OperationMode.STOPPED));
             moveToMaintenance.set(true);
             return null;
-        }).when(clusterService).submitStateUpdateTask(eq("ilm_operation_mode_update[stopped]"), any(OperationModeUpdateTask.class), any());
+        }).when(clusterService)
+            .submitUnbatchedStateUpdateTask(eq("ilm_operation_mode_update[stopped]"), any(OperationModeUpdateTask.class));
 
         indexLifecycleService.applyClusterState(event);
         indexLifecycleService.triggerPolicies(currentState, randomBoolean());

--- a/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/ilm/action/TransportStopILMActionTests.java
+++ b/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/ilm/action/TransportStopILMActionTests.java
@@ -24,7 +24,6 @@ import org.elasticsearch.xpack.core.ilm.action.StopILMAction;
 import org.mockito.ArgumentMatcher;
 
 import static java.util.Collections.emptyMap;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
@@ -53,7 +52,7 @@ public class TransportStopILMActionTests extends ESTestCase {
         StopILMRequest request = new StopILMRequest();
         transportStopILMAction.masterOperation(task, request, ClusterState.EMPTY_STATE, ActionListener.noop());
 
-        verify(clusterService).submitStateUpdateTask(
+        verify(clusterService).submitUnbatchedStateUpdateTask(
             eq("ilm_operation_mode_update[stopping]"),
             argThat(new ArgumentMatcher<AckedClusterStateUpdateTask>() {
 
@@ -64,8 +63,7 @@ public class TransportStopILMActionTests extends ESTestCase {
                     actualPriority = other.priority();
                     return actualPriority == Priority.IMMEDIATE;
                 }
-            }),
-            any()
+            })
         );
     }
 

--- a/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/slm/SnapshotLifecycleServiceTests.java
+++ b/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/slm/SnapshotLifecycleServiceTests.java
@@ -12,9 +12,6 @@ import org.elasticsearch.Version;
 import org.elasticsearch.cluster.ClusterChangedEvent;
 import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.cluster.ClusterState;
-import org.elasticsearch.cluster.ClusterStateTaskConfig;
-import org.elasticsearch.cluster.ClusterStateTaskExecutor;
-import org.elasticsearch.cluster.ClusterStateTaskListener;
 import org.elasticsearch.cluster.ClusterStateUpdateTask;
 import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.cluster.metadata.RepositoriesMetadata;
@@ -461,11 +458,7 @@ public class SnapshotLifecycleServiceTests extends ESTestCase {
         final SetOnce<ClusterStateUpdateTask> task = new SetOnce<>();
         ClusterService fakeService = new ClusterService(Settings.EMPTY, clusterSettings, threadPool) {
             @Override
-            public <T extends ClusterStateTaskConfig & ClusterStateTaskListener> void submitStateUpdateTask(
-                String source,
-                T updateTask,
-                ClusterStateTaskExecutor<T> executor
-            ) {
+            public void submitUnbatchedStateUpdateTask(String source, ClusterStateUpdateTask updateTask) {
                 logger.info("--> got task: [source: {}]: {}", source, updateTask);
                 if (updateTask instanceof OperationModeUpdateTask) {
                     task.set((OperationModeUpdateTask) updateTask);

--- a/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/slm/action/TransportStopSLMActionTests.java
+++ b/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/slm/action/TransportStopSLMActionTests.java
@@ -24,7 +24,6 @@ import org.elasticsearch.xpack.core.slm.action.StopSLMAction;
 import org.mockito.ArgumentMatcher;
 
 import static java.util.Collections.emptyMap;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
@@ -53,7 +52,7 @@ public class TransportStopSLMActionTests extends ESTestCase {
         StopSLMAction.Request request = new StopSLMAction.Request();
         transportStopSLMAction.masterOperation(task, request, ClusterState.EMPTY_STATE, ActionListener.noop());
 
-        verify(clusterService).submitStateUpdateTask(
+        verify(clusterService).submitUnbatchedStateUpdateTask(
             eq("slm_operation_mode_update[stopping]"),
             argThat(new ArgumentMatcher<AckedClusterStateUpdateTask>() {
 
@@ -64,8 +63,7 @@ public class TransportStopSLMActionTests extends ESTestCase {
                     actualPriority = other.priority();
                     return actualPriority == Priority.IMMEDIATE;
                 }
-            }),
-            any()
+            })
         );
     }
 

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportDeleteTrainedModelAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportDeleteTrainedModelAction.java
@@ -17,7 +17,6 @@ import org.elasticsearch.action.support.master.AcknowledgedTransportMasterNodeAc
 import org.elasticsearch.client.internal.Client;
 import org.elasticsearch.cluster.AckedClusterStateUpdateTask;
 import org.elasticsearch.cluster.ClusterState;
-import org.elasticsearch.cluster.ClusterStateTaskExecutor;
 import org.elasticsearch.cluster.ClusterStateUpdateTask;
 import org.elasticsearch.cluster.block.ClusterBlockException;
 import org.elasticsearch.cluster.block.ClusterBlockLevel;
@@ -227,7 +226,7 @@ public class TransportDeleteTrainedModelAction extends AcknowledgedTransportMast
             return;
         }
 
-        clusterService.submitStateUpdateTask("delete-trained-model-alias", new AckedClusterStateUpdateTask(request, nameDeletionListener) {
+        submitUnbatchedTask("delete-trained-model-alias", new AckedClusterStateUpdateTask(request, nameDeletionListener) {
             @Override
             public ClusterState execute(final ClusterState currentState) {
                 final ClusterState.Builder builder = ClusterState.builder(currentState);
@@ -244,12 +243,12 @@ public class TransportDeleteTrainedModelAction extends AcknowledgedTransportMast
                 );
                 return builder.build();
             }
-        }, newExecutor());
+        });
     }
 
     @SuppressForbidden(reason = "legacy usage of unbatched task") // TODO add support for batching here
-    private static <T extends ClusterStateUpdateTask> ClusterStateTaskExecutor<T> newExecutor() {
-        return ClusterStateTaskExecutor.unbatched();
+    private void submitUnbatchedTask(@SuppressWarnings("SameParameterValue") String source, ClusterStateUpdateTask task) {
+        clusterService.submitUnbatchedStateUpdateTask(source, task);
     }
 
     @Override

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportDeleteTrainedModelAliasAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportDeleteTrainedModelAliasAction.java
@@ -16,7 +16,6 @@ import org.elasticsearch.action.support.master.AcknowledgedResponse;
 import org.elasticsearch.action.support.master.AcknowledgedTransportMasterNodeAction;
 import org.elasticsearch.cluster.AckedClusterStateUpdateTask;
 import org.elasticsearch.cluster.ClusterState;
-import org.elasticsearch.cluster.ClusterStateTaskExecutor;
 import org.elasticsearch.cluster.ClusterStateUpdateTask;
 import org.elasticsearch.cluster.block.ClusterBlockException;
 import org.elasticsearch.cluster.block.ClusterBlockLevel;
@@ -80,17 +79,17 @@ public class TransportDeleteTrainedModelAliasAction extends AcknowledgedTranspor
         ClusterState state,
         ActionListener<AcknowledgedResponse> listener
     ) throws Exception {
-        clusterService.submitStateUpdateTask("delete-model-alias", new AckedClusterStateUpdateTask(request, listener) {
+        submitUnbatchedTask("delete-model-alias", new AckedClusterStateUpdateTask(request, listener) {
             @Override
             public ClusterState execute(final ClusterState currentState) {
                 return deleteModelAlias(currentState, ingestService, auditor, request);
             }
-        }, newExecutor());
+        });
     }
 
     @SuppressForbidden(reason = "legacy usage of unbatched task") // TODO add support for batching here
-    private static <T extends ClusterStateUpdateTask> ClusterStateTaskExecutor<T> newExecutor() {
-        return ClusterStateTaskExecutor.unbatched();
+    private void submitUnbatchedTask(@SuppressWarnings("SameParameterValue") String source, ClusterStateUpdateTask task) {
+        clusterService.submitUnbatchedStateUpdateTask(source, task);
     }
 
     static ClusterState deleteModelAlias(

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/assignment/TrainedModelAssignmentClusterService.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/assignment/TrainedModelAssignmentClusterService.java
@@ -18,7 +18,6 @@ import org.elasticsearch.action.support.master.AcknowledgedResponse;
 import org.elasticsearch.cluster.ClusterChangedEvent;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.ClusterStateListener;
-import org.elasticsearch.cluster.ClusterStateTaskExecutor;
 import org.elasticsearch.cluster.ClusterStateUpdateTask;
 import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.cluster.metadata.NodesShutdownMetadata;
@@ -92,8 +91,8 @@ public class TrainedModelAssignmentClusterService implements ClusterStateListene
     }
 
     @SuppressForbidden(reason = "legacy usage of unbatched task") // TODO add support for batching here
-    private static <T extends ClusterStateUpdateTask> ClusterStateTaskExecutor<T> newExecutor() {
-        return ClusterStateTaskExecutor.unbatched();
+    private void submitUnbatchedTask(@SuppressWarnings("SameParameterValue") String source, ClusterStateUpdateTask task) {
+        clusterService.submitUnbatchedStateUpdateTask(source, task);
     }
 
     @Override
@@ -102,7 +101,7 @@ public class TrainedModelAssignmentClusterService implements ClusterStateListene
             return;
         }
         if (event.localNodeMaster() && shouldAllocateModels(event)) {
-            clusterService.submitStateUpdateTask("allocating models to nodes", new ClusterStateUpdateTask() {
+            submitUnbatchedTask("allocating models to nodes", new ClusterStateUpdateTask() {
                 @Override
                 public ClusterState execute(ClusterState currentState) {
                     // TODO this has a weird side-effect for allocating to nodes
@@ -136,7 +135,7 @@ public class TrainedModelAssignmentClusterService implements ClusterStateListene
                         )
                     );
                 }
-            }, newExecutor());
+            });
         }
     }
 
@@ -144,7 +143,7 @@ public class TrainedModelAssignmentClusterService implements ClusterStateListene
         UpdateTrainedModelAssignmentStateAction.Request request,
         ActionListener<AcknowledgedResponse> listener
     ) {
-        clusterService.submitStateUpdateTask("updating model routing for node assignment", new ClusterStateUpdateTask() {
+        submitUnbatchedTask("updating model routing for node assignment", new ClusterStateUpdateTask() {
             @Override
             public ClusterState execute(ClusterState currentState) {
                 return updateModelRoutingTable(currentState, request);
@@ -159,14 +158,14 @@ public class TrainedModelAssignmentClusterService implements ClusterStateListene
             public void clusterStateProcessed(ClusterState oldState, ClusterState newState) {
                 listener.onResponse(AcknowledgedResponse.TRUE);
             }
-        }, newExecutor());
+        });
     }
 
     public void createNewModelAssignment(
         StartTrainedModelDeploymentAction.TaskParams params,
         ActionListener<TrainedModelAssignment> listener
     ) {
-        clusterService.submitStateUpdateTask("create model assignment", new ClusterStateUpdateTask() {
+        submitUnbatchedTask("create model assignment", new ClusterStateUpdateTask() {
             @Override
             public ClusterState execute(ClusterState currentState) {
                 return createModelAssignment(currentState, params);
@@ -181,11 +180,11 @@ public class TrainedModelAssignmentClusterService implements ClusterStateListene
             public void clusterStateProcessed(ClusterState oldState, ClusterState newState) {
                 listener.onResponse(TrainedModelAssignmentMetadata.fromState(newState).getModelAssignment(params.getModelId()));
             }
-        }, newExecutor());
+        });
     }
 
     public void setModelAssignmentToStopping(String modelId, ActionListener<AcknowledgedResponse> listener) {
-        clusterService.submitStateUpdateTask("set model assignment stopping", new ClusterStateUpdateTask() {
+        submitUnbatchedTask("set model assignment stopping", new ClusterStateUpdateTask() {
             @Override
             public ClusterState execute(ClusterState currentState) {
                 return setToStopping(currentState, modelId, "client API call");
@@ -200,11 +199,11 @@ public class TrainedModelAssignmentClusterService implements ClusterStateListene
             public void clusterStateProcessed(ClusterState oldState, ClusterState newState) {
                 listener.onResponse(AcknowledgedResponse.TRUE);
             }
-        }, newExecutor());
+        });
     }
 
     public void removeModelAssignment(String modelId, ActionListener<AcknowledgedResponse> listener) {
-        clusterService.submitStateUpdateTask("delete model assignment", new ClusterStateUpdateTask() {
+        submitUnbatchedTask("delete model assignment", new ClusterStateUpdateTask() {
             @Override
             public ClusterState execute(ClusterState currentState) {
                 return removeAssignment(currentState, modelId);
@@ -219,12 +218,12 @@ public class TrainedModelAssignmentClusterService implements ClusterStateListene
             public void clusterStateProcessed(ClusterState oldState, ClusterState newState) {
                 listener.onResponse(AcknowledgedResponse.TRUE);
             }
-        }, newExecutor());
+        });
     }
 
     // Used by the reset action directly
     public void removeAllModelAssignments(ActionListener<AcknowledgedResponse> listener) {
-        clusterService.submitStateUpdateTask("delete all model assignments", new ClusterStateUpdateTask() {
+        submitUnbatchedTask("delete all model assignments", new ClusterStateUpdateTask() {
             @Override
             public ClusterState execute(ClusterState currentState) {
                 return removeAllAssignments(currentState);
@@ -239,7 +238,7 @@ public class TrainedModelAssignmentClusterService implements ClusterStateListene
             public void clusterStateProcessed(ClusterState oldState, ClusterState newState) {
                 listener.onResponse(AcknowledgedResponse.TRUE);
             }
-        }, newExecutor());
+        });
     }
 
     private static ClusterState update(ClusterState currentState, TrainedModelAssignmentMetadata.Builder modelAssignments) {

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/action/TransportFinalizeJobExecutionActionTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/action/TransportFinalizeJobExecutionActionTests.java
@@ -76,7 +76,7 @@ public class TransportFinalizeJobExecutionActionTests extends ESTestCase {
 
         assertTrue(ack.get().isAcknowledged());
         verify(client, times(2)).execute(eq(UpdateAction.INSTANCE), any(), any());
-        verify(clusterService, never()).submitStateUpdateTask(any(), any(), any());
+        verify(clusterService, never()).submitUnbatchedStateUpdateTask(any(), any());
     }
 
     private TransportFinalizeJobExecutionAction createAction(ClusterService clusterService) {

--- a/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/upgrade/SearchableSnapshotIndexMetadataUpgrader.java
+++ b/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/upgrade/SearchableSnapshotIndexMetadataUpgrader.java
@@ -13,7 +13,6 @@ import org.elasticsearch.Version;
 import org.elasticsearch.cluster.ClusterChangedEvent;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.ClusterStateListener;
-import org.elasticsearch.cluster.ClusterStateTaskExecutor;
 import org.elasticsearch.cluster.ClusterStateUpdateTask;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.metadata.Metadata;
@@ -64,7 +63,7 @@ public class SearchableSnapshotIndexMetadataUpgrader {
         // 99% of the time, this will be a noop, so precheck that before adding a cluster state update.
         if (needsUpgrade(state)) {
             logger.info("Upgrading partial searchable snapshots to use frozen shard limit group");
-            clusterService.submitStateUpdateTask("searchable-snapshot-index-upgrader", new ClusterStateUpdateTask() {
+            submitUnbatchedTask("searchable-snapshot-index-upgrader", new ClusterStateUpdateTask() {
                 @Override
                 public ClusterState execute(ClusterState currentState) throws Exception {
                     return upgradeIndices(currentState);
@@ -84,15 +83,15 @@ public class SearchableSnapshotIndexMetadataUpgrader {
                     // let us try again later.
                     upgraded.set(false);
                 }
-            }, newExecutor());
+            });
         } else {
             clusterService.removeListener(listener);
         }
     }
 
     @SuppressForbidden(reason = "legacy usage of unbatched task") // TODO add support for batching here
-    private static <T extends ClusterStateUpdateTask> ClusterStateTaskExecutor<T> newExecutor() {
-        return ClusterStateTaskExecutor.unbatched();
+    private void submitUnbatchedTask(@SuppressWarnings("SameParameterValue") String source, ClusterStateUpdateTask task) {
+        clusterService.submitUnbatchedStateUpdateTask(source, task);
     }
 
     static boolean needsUpgrade(ClusterState state) {

--- a/x-pack/plugin/shutdown/src/main/java/org/elasticsearch/xpack/shutdown/NodeSeenService.java
+++ b/x-pack/plugin/shutdown/src/main/java/org/elasticsearch/xpack/shutdown/NodeSeenService.java
@@ -13,7 +13,6 @@ import org.apache.logging.log4j.message.ParameterizedMessage;
 import org.elasticsearch.cluster.ClusterChangedEvent;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.ClusterStateListener;
-import org.elasticsearch.cluster.ClusterStateTaskExecutor;
 import org.elasticsearch.cluster.ClusterStateUpdateTask;
 import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.cluster.metadata.NodesShutdownMetadata;
@@ -71,7 +70,7 @@ public class NodeSeenService implements ClusterStateListener {
             .collect(Collectors.toUnmodifiableSet());
 
         if (nodesNotPreviouslySeen.isEmpty() == false) {
-            clusterService.submitStateUpdateTask("shutdown-seen-nodes-updater", new ClusterStateUpdateTask() {
+            submitUnbatchedTask("shutdown-seen-nodes-updater", new ClusterStateUpdateTask() {
                 @Override
                 public ClusterState execute(ClusterState currentState) throws Exception {
                     NodesShutdownMetadata currentShutdownMetadata = currentState.metadata().custom(NodesShutdownMetadata.TYPE);
@@ -103,12 +102,12 @@ public class NodeSeenService implements ClusterStateListener {
                 public void onFailure(Exception e) {
                     logger.warn(new ParameterizedMessage("failed to mark shutting down nodes as seen: {}", nodesNotPreviouslySeen), e);
                 }
-            }, newExecutor());
+            });
         }
     }
 
     @SuppressForbidden(reason = "legacy usage of unbatched task") // TODO add support for batching here
-    private static <T extends ClusterStateUpdateTask> ClusterStateTaskExecutor<T> newExecutor() {
-        return ClusterStateTaskExecutor.unbatched();
+    private void submitUnbatchedTask(@SuppressWarnings("SameParameterValue") String source, ClusterStateUpdateTask task) {
+        clusterService.submitUnbatchedStateUpdateTask(source, task);
     }
 }

--- a/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/WatcherLifeCycleServiceTests.java
+++ b/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/WatcherLifeCycleServiceTests.java
@@ -75,7 +75,7 @@ public class WatcherLifeCycleServiceTests extends ESTestCase {
             updateTask.onAllNodesAcked();
             return null;
         };
-        doAnswer(answer).when(clusterService).submitStateUpdateTask(anyString(), any(ClusterStateUpdateTask.class), any());
+        doAnswer(answer).when(clusterService).submitUnbatchedStateUpdateTask(anyString(), any(ClusterStateUpdateTask.class));
         watcherService = mock(WatcherService.class);
         lifeCycleService = new WatcherLifeCycleService(clusterService, watcherService);
     }


### PR DESCRIPTION
Today when submitting a cluster state update task the caller can
indicate that it is not to be included in a batch by using an executor
obtained from `ClusterStateTaskExecutor#unbatched()`. This is kind of
weird: the caller must not re-use the executor, and also the master
service has no practical way to handle this special case any
differently.

This commit introduces a dedicated API for unbatched tasks, opening the
door to some future simplifications.