### PR TITLE
Remove hppc from top hits agg

### DIFF
--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/TopHitsAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/TopHitsAggregator.java
@@ -104,6 +104,7 @@ class TopHitsAggregator extends MetricsAggregator {
         // then causes assertions to trip or incorrect top docs to be computed.
         if (leafCollectors != null) {
             leafCollectors.close();
+            leafCollectors = null; // set to null, just in case the new allocation below fails
         }
         leafCollectors = new LongObjectPagedHashMap<>(1, bigArrays);
         return new LeafBucketCollectorBase(sub, null) {


### PR DESCRIPTION
The top hits aggregator uses hppc for keeping track of leaf bucket
collectors. This commit converts it to use HashMap.

relates #84735