### PR TITLE
Delay searchable snapshot allocation during shutdown

### DIFF
--- a/docs/changelog/86153.yaml
+++ b/docs/changelog/86153.yaml
@@ -1,6 +1,6 @@
 pr: 86153
 summary: Delay searchable snapshot allocation during shutdown
-area: "Snapshot/Restore, Infra/Node Lifecycle"
+area: "Snapshot/Restore"
 type: bug
 issues:
  - 85052

--- a/docs/changelog/86153.yaml
+++ b/docs/changelog/86153.yaml
@@ -1,0 +1,6 @@
+pr: 86153
+summary: Delay searchable snapshot allocation during shutdown
+area: "Snapshot/Restore, Infra/Node Lifecycle"
+type: bug
+issues:
+ - 85052

--- a/server/src/main/java/org/elasticsearch/gateway/ReplicaShardAllocator.java
+++ b/server/src/main/java/org/elasticsearch/gateway/ReplicaShardAllocator.java
@@ -259,8 +259,12 @@ public abstract class ReplicaShardAllocator extends BaseGatewayShardAllocator {
     /**
      * Return a delayed decision, filling in the right amount of remaining time if decisions are debugged/explained.
      */
-    public static AllocateUnassignedDecision delayedDecision(ShardRouting unassignedShard, RoutingAllocation allocation, Logger logger,
-                                                        List<NodeAllocationResult> nodeDecisions) {
+    public static AllocateUnassignedDecision delayedDecision(
+        ShardRouting unassignedShard,
+        RoutingAllocation allocation,
+        Logger logger,
+        List<NodeAllocationResult> nodeDecisions
+    ) {
         boolean explain = allocation.debugDecision();
         logger.debug("{}: allocation of [{}] is delayed", unassignedShard.shardId(), unassignedShard);
         long remainingDelayMillis = 0L;

--- a/server/src/main/java/org/elasticsearch/gateway/ReplicaShardAllocator.java
+++ b/server/src/main/java/org/elasticsearch/gateway/ReplicaShardAllocator.java
@@ -250,25 +250,34 @@ public abstract class ReplicaShardAllocator extends BaseGatewayShardAllocator {
             // if we didn't manage to find *any* data (regardless of matching sizes), and the replica is
             // unassigned due to a node leaving, so we delay allocation of this replica to see if the
             // node with the shard copy will rejoin so we can re-use the copy it has
-            logger.debug("{}: allocation of [{}] is delayed", unassignedShard.shardId(), unassignedShard);
-            long remainingDelayMillis = 0L;
-            long totalDelayMillis = 0L;
-            if (explain) {
-                UnassignedInfo unassignedInfo = unassignedShard.unassignedInfo();
-                Metadata metadata = allocation.metadata();
-                IndexMetadata indexMetadata = metadata.index(unassignedShard.index());
-                totalDelayMillis = INDEX_DELAYED_NODE_LEFT_TIMEOUT_SETTING.get(indexMetadata.getSettings()).getMillis();
-                long remainingDelayNanos = unassignedInfo.getRemainingDelay(
-                    System.nanoTime(),
-                    indexMetadata.getSettings(),
-                    metadata.nodeShutdowns()
-                );
-                remainingDelayMillis = TimeValue.timeValueNanos(remainingDelayNanos).millis();
-            }
-            return AllocateUnassignedDecision.delayed(remainingDelayMillis, totalDelayMillis, nodeDecisions);
+            return delayedDecision(unassignedShard, allocation, logger, nodeDecisions);
         }
 
         return AllocateUnassignedDecision.NOT_TAKEN;
+    }
+
+    /**
+     * Return a delayed decision, filling in the right amount of remaining time if decisions are debugged/explained.
+     */
+    public static AllocateUnassignedDecision delayedDecision(ShardRouting unassignedShard, RoutingAllocation allocation, Logger logger,
+                                                        List<NodeAllocationResult> nodeDecisions) {
+        boolean explain = allocation.debugDecision();
+        logger.debug("{}: allocation of [{}] is delayed", unassignedShard.shardId(), unassignedShard);
+        long remainingDelayMillis = 0L;
+        long totalDelayMillis = 0L;
+        if (explain) {
+            UnassignedInfo unassignedInfo = unassignedShard.unassignedInfo();
+            Metadata metadata = allocation.metadata();
+            IndexMetadata indexMetadata = metadata.index(unassignedShard.index());
+            totalDelayMillis = INDEX_DELAYED_NODE_LEFT_TIMEOUT_SETTING.get(indexMetadata.getSettings()).getMillis();
+            long remainingDelayNanos = unassignedInfo.getRemainingDelay(
+                System.nanoTime(),
+                indexMetadata.getSettings(),
+                metadata.nodeShutdowns()
+            );
+            remainingDelayMillis = TimeValue.timeValueNanos(remainingDelayNanos).millis();
+        }
+        return AllocateUnassignedDecision.delayed(remainingDelayMillis, totalDelayMillis, nodeDecisions);
     }
 
     /**

--- a/x-pack/plugin/searchable-snapshots/build.gradle
+++ b/x-pack/plugin/searchable-snapshots/build.gradle
@@ -14,6 +14,7 @@ dependencies {
   compileOnly project(path: xpackModule('core'))
   implementation project(path: 'preallocate')
   internalClusterTestImplementation(testArtifact(project(xpackModule('core'))))
+  internalClusterTestImplementation(project(path: xpackModule('shutdown')))
   internalClusterTestImplementation(project(path: ':modules:reindex'))
 }
 

--- a/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/allocation/SearchableSnapshotShutdownIntegTests.java
+++ b/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/allocation/SearchableSnapshotShutdownIntegTests.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.searchablesnapshots.allocation;
+
+import org.elasticsearch.action.admin.cluster.health.ClusterHealthResponse;
+import org.elasticsearch.client.internal.Requests;
+import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.metadata.SingleNodeShutdownMetadata;
+import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.util.CollectionUtils;
+import org.elasticsearch.plugins.Plugin;
+import org.elasticsearch.snapshots.SnapshotId;
+import org.elasticsearch.test.ESIntegTestCase;
+import org.elasticsearch.test.InternalTestCluster;
+import org.elasticsearch.xpack.searchablesnapshots.BaseSearchableSnapshotsIntegTestCase;
+import org.elasticsearch.xpack.searchablesnapshots.cache.full.CacheService;
+import org.elasticsearch.xpack.shutdown.DeleteShutdownNodeAction;
+import org.elasticsearch.xpack.shutdown.PutShutdownNodeAction;
+import org.elasticsearch.xpack.shutdown.ShutdownPlugin;
+import org.hamcrest.Matchers;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ExecutionException;
+import java.util.stream.Collectors;
+
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
+
+@ESIntegTestCase.ClusterScope(scope = ESIntegTestCase.Scope.TEST, minNumDataNodes = 2)
+public class SearchableSnapshotShutdownIntegTests extends BaseSearchableSnapshotsIntegTestCase {
+
+    @Override
+    protected Collection<Class<? extends Plugin>> nodePlugins() {
+        return CollectionUtils.appendToCopy(super.nodePlugins(), ShutdownPlugin.class);
+    }
+
+    public void testAllocationDisabledDuringShutdown() throws Exception {
+        final String restoredIndexName = setupMountedIndex();
+        final Set<String> indexNodes = internalCluster().nodesInclude(restoredIndexName);
+        final ClusterState state = client().admin().cluster().prepareState().clear().setRoutingTable(true).setNodes(true).get().getState();
+        final Map<String, String> nodeNameToId = state.getNodes()
+            .stream()
+            .collect(Collectors.toMap(DiscoveryNode::getName, DiscoveryNode::getId));
+
+        for (String indexNode : indexNodes) {
+            final String indexNodeId = nodeNameToId.get(indexNode);
+            putShutdown(indexNodeId);
+            final int shards = (int) state.routingTable()
+                .allShards(restoredIndexName)
+                .stream()
+                .filter(s -> indexNodeId.equals(s.currentNodeId()))
+                .count();
+            assert shards > 0;
+
+            final CacheService cacheService = internalCluster().getInstance(CacheService.class, indexNode);
+            cacheService.synchronizeCache();
+
+            logger.info("--> Restarting [{}/{}]", indexNodeId, indexNode);
+            internalCluster().restartNode(indexNode, new InternalTestCluster.RestartCallback() {
+                @Override
+                public Settings onNodeStopped(String nodeName) throws Exception {
+                    assertBusy(() -> {
+                        ClusterHealthResponse response = client().admin()
+                            .cluster()
+                            .health(Requests.clusterHealthRequest(restoredIndexName))
+                            .actionGet();
+                        assertThat(response.getUnassignedShards(), Matchers.equalTo(shards));
+                    });
+                    return super.onNodeStopped(nodeName);
+                }
+            });
+            // leave shutdown in place for some nodes to check that shards get assigned anyway.
+            if (randomBoolean()) {
+                removeShutdown(indexNodeId);
+            }
+        }
+
+        ensureGreen(restoredIndexName);
+    }
+
+    private String setupMountedIndex() throws Exception {
+        final String indexName = randomAlphaOfLength(10).toLowerCase(Locale.ROOT);
+        createAndPopulateIndex(indexName, Settings.builder());
+
+        final String repositoryName = randomAlphaOfLength(10).toLowerCase(Locale.ROOT);
+        createRepository(repositoryName, "mock");
+
+        final SnapshotId snapshotId = createSnapshot(repositoryName, "snapshot-1", List.of(indexName)).snapshotId();
+        assertAcked(client().admin().indices().prepareDelete(indexName));
+        return mountSnapshot(repositoryName, snapshotId.getName(), indexName, Settings.EMPTY);
+    }
+
+    private void putShutdown(String nodeToRestartId) throws InterruptedException, ExecutionException {
+        PutShutdownNodeAction.Request putShutdownRequest = new PutShutdownNodeAction.Request(
+            nodeToRestartId,
+            SingleNodeShutdownMetadata.Type.RESTART,
+            this.getTestName(),
+            null,
+            null
+        );
+        assertTrue(client().execute(PutShutdownNodeAction.INSTANCE, putShutdownRequest).get().isAcknowledged());
+    }
+
+    private void removeShutdown(String node) throws ExecutionException, InterruptedException {
+        assertTrue(client().execute(DeleteShutdownNodeAction.INSTANCE, new DeleteShutdownNodeAction.Request(node)).get().isAcknowledged());
+    }
+}

--- a/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/allocation/SearchableSnapshotShutdownIntegTests.java
+++ b/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/allocation/SearchableSnapshotShutdownIntegTests.java
@@ -110,7 +110,7 @@ public class SearchableSnapshotShutdownIntegTests extends BaseSearchableSnapshot
             final String indexName = "index_" + i;
             createAndPopulateIndex(indexName, Settings.builder());
 
-            final SnapshotId snapshotId = createSnapshot(repositoryName, "snapshot-1", List.of(indexName)).snapshotId();
+            final SnapshotId snapshotId = createSnapshot(repositoryName, "snapshot-" + i, List.of(indexName)).snapshotId();
             assertAcked(client().admin().indices().prepareDelete(indexName));
             restoredIndices.add(mountSnapshot(repositoryName, snapshotId.getName(), indexName, Settings.EMPTY));
         }

--- a/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/allocation/SearchableSnapshotShutdownIntegTests.java
+++ b/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/allocation/SearchableSnapshotShutdownIntegTests.java
@@ -46,6 +46,12 @@ public class SearchableSnapshotShutdownIntegTests extends BaseSearchableSnapshot
         return CollectionUtils.appendToCopy(super.nodePlugins(), ShutdownPlugin.class);
     }
 
+    @Override
+    protected int numberOfShards() {
+        // use 1 shard per index and instead use multiple indices to have multiple shards.
+        return 1;
+    }
+
     public void testAllocationDisabledDuringShutdown() throws Exception {
         final List<String> restoredIndexNames = setupMountedIndices();
         final String[] restoredIndexNamesArray = restoredIndexNames.toArray(String[]::new);
@@ -124,11 +130,5 @@ public class SearchableSnapshotShutdownIntegTests extends BaseSearchableSnapshot
 
     private void removeShutdown(String node) throws ExecutionException, InterruptedException {
         assertTrue(client().execute(DeleteShutdownNodeAction.INSTANCE, new DeleteShutdownNodeAction.Request(node)).get().isAcknowledged());
-    }
-
-    @Override
-    protected int numberOfShards() {
-        // use 1 shard per index and instead use multiple indices to have multiple shards.
-        return 1;
     }
 }

--- a/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/allocation/SearchableSnapshotShutdownIntegTests.java
+++ b/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/allocation/SearchableSnapshotShutdownIntegTests.java
@@ -97,12 +97,12 @@ public class SearchableSnapshotShutdownIntegTests extends BaseSearchableSnapshot
     private List<String> setupMountedIndices() throws Exception {
         int count = between(1, 10);
         List<String> restoredIndices = new ArrayList<>();
-        for (int i = 0; i < count; ++i) {
-            final String indexName = randomAlphaOfLength(10).toLowerCase(Locale.ROOT);
-            createAndPopulateIndex(indexName, Settings.builder());
+        final String repositoryName = randomAlphaOfLength(10).toLowerCase(Locale.ROOT);
+        createRepository(repositoryName, "mock");
 
-            final String repositoryName = randomAlphaOfLength(10).toLowerCase(Locale.ROOT);
-            createRepository(repositoryName, "mock");
+        for (int i = 0; i < count; ++i) {
+            final String indexName = "index_" + i;
+            createAndPopulateIndex(indexName, Settings.builder());
 
             final SnapshotId snapshotId = createSnapshot(repositoryName, "snapshot-1", List.of(indexName)).snapshotId();
             assertAcked(client().admin().indices().prepareDelete(indexName));

--- a/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/allocation/SearchableSnapshotShutdownIntegTests.java
+++ b/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/allocation/SearchableSnapshotShutdownIntegTests.java
@@ -38,7 +38,7 @@ import java.util.stream.StreamSupport;
 
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
 
-@ESIntegTestCase.ClusterScope(scope = ESIntegTestCase.Scope.TEST, minNumDataNodes = 2, numDataNodes = 2)
+@ESIntegTestCase.ClusterScope(scope = ESIntegTestCase.Scope.TEST, minNumDataNodes = 2)
 public class SearchableSnapshotShutdownIntegTests extends BaseSearchableSnapshotsIntegTestCase {
 
     @Override

--- a/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/allocation/SearchableSnapshotAllocator.java
+++ b/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/allocation/SearchableSnapshotAllocator.java
@@ -342,7 +342,7 @@ public class SearchableSnapshotAllocator implements ExistingShardsAllocator {
                 );
                 return AllocateUnassignedDecision.yes(nodeWithHighestMatch.node(), null, nodeDecisions, true);
             }
-        } else if (isDelayedDueToShutdown(allocation, shardRouting)) {
+        } else if (isDelayedDueToNodeRestart(allocation, shardRouting)) {
             return ReplicaShardAllocator.delayedDecision(shardRouting, allocation, logger, nodeDecisions);
         }
 
@@ -350,7 +350,7 @@ public class SearchableSnapshotAllocator implements ExistingShardsAllocator {
         return AllocateUnassignedDecision.NOT_TAKEN;
     }
 
-    private boolean isDelayedDueToShutdown(RoutingAllocation allocation, ShardRouting shardRouting) {
+    private boolean isDelayedDueToNodeRestart(RoutingAllocation allocation, ShardRouting shardRouting) {
         if (shardRouting.unassignedInfo().isDelayed()) {
             String lastAllocatedNodeId = shardRouting.unassignedInfo().getLastAllocatedNodeId();
             if (lastAllocatedNodeId != null) {

--- a/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/allocation/SearchableSnapshotAllocator.java
+++ b/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/allocation/SearchableSnapshotAllocator.java
@@ -17,6 +17,7 @@ import org.elasticsearch.cluster.RestoreInProgress;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.metadata.RepositoriesMetadata;
 import org.elasticsearch.cluster.metadata.RepositoryMetadata;
+import org.elasticsearch.cluster.metadata.SingleNodeShutdownMetadata;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
 import org.elasticsearch.cluster.routing.RecoverySource;
@@ -341,9 +342,24 @@ public class SearchableSnapshotAllocator implements ExistingShardsAllocator {
                 );
                 return AllocateUnassignedDecision.yes(nodeWithHighestMatch.node(), null, nodeDecisions, true);
             }
+        } else if (isDelayedDueToShutdown(allocation, shardRouting)) {
+            return ReplicaShardAllocator.delayedDecision(shardRouting, allocation, logger, nodeDecisions);
         }
+
         // TODO: do we need handling of delayed allocation for leaving replicas here?
         return AllocateUnassignedDecision.NOT_TAKEN;
+    }
+
+    private boolean isDelayedDueToShutdown(RoutingAllocation allocation, ShardRouting shardRouting) {
+        if (shardRouting.unassignedInfo().isDelayed()) {
+            String lastAllocatedNodeId = shardRouting.unassignedInfo().getLastAllocatedNodeId();
+            if (lastAllocatedNodeId != null) {
+                SingleNodeShutdownMetadata nodeShutdownMetadata = allocation.nodeShutdowns().get(lastAllocatedNodeId);
+                return nodeShutdownMetadata != null && nodeShutdownMetadata.getType() == SingleNodeShutdownMetadata.Type.RESTART;
+            }
+        }
+
+        return false;
     }
 
     @Override


### PR DESCRIPTION
During a shutdown, searchable snapshots should not be re-allocated to new nodes,
since this leads to data download. Instead, now wait for the shutdown reallocation
delay before reallocating shards.

Fixes #85052
