### PR TITLE
Added missing changelog entry for GeoJSON PR

### DIFF
--- a/docs/changelog/85442.yaml
+++ b/docs/changelog/85442.yaml
@@ -1,0 +1,5 @@
+pr: 85442
+summary: Support 'GeoJSON' in CartesianPoint for 'point'
+area: Geo
+type: enhancement
+issues: []


### PR DESCRIPTION
The original enhancement PR at https://github.com/elastic/elasticsearch/pull/85442 was missing the changelog entry, so this PR adds that back.