### PR TITLE
Optional sub claim in JwtAuthenticationToken

### DIFF
--- a/docs/changelog/86156.yaml
+++ b/docs/changelog/86156.yaml
@@ -1,0 +1,5 @@
+pr: 86156
+summary: Optional sub claim in `JwtAuthenticationToken`
+area: Authentication
+type: enhancement
+issues: []

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/jwt/JwtAuthenticationToken.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/jwt/JwtAuthenticationToken.java
@@ -76,7 +76,7 @@ public class JwtAuthenticationToken implements AuthenticationToken {
             if (remainingClaims.isEmpty()) {
                 throw new IllegalArgumentException("No claims left after filtering [" + String.join(",", CLAIMS_TO_FILTER) + "].");
             }
-            computedSubject = new TreeMap<>(jwtClaimsSet.getClaims()).toString(); // principal = "iss/aud/orderedClaimsSubset"
+            computedSubject = new TreeMap<>(remainingClaims).toString(); // principal = "iss/aud/orderedClaimsSubset"
         }
         this.principal = jwtClaimsSet.getIssuer() + "/" + orderedAudiences + "/" + computedSubject;
     }

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/jwt/JwtRealmTestCase.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/jwt/JwtRealmTestCase.java
@@ -596,6 +596,7 @@ public abstract class JwtRealmTestCase extends JwtTestCase {
         final JwtIssuer.AlgJwkPair algJwkPair = randomFrom(jwtIssuerAndRealm.issuer.algAndJwksAll);
         LOGGER.info("JWK=[" + algJwkPair.jwk().getKeyType() + "/" + algJwkPair.jwk().size() + "], alg=[" + algJwkPair.alg() + "].");
 
+        final boolean setSubClaim = jwtIssuerAndRealm.realm.claimParserPrincipal.getClaimName().equals("sub") || randomBoolean();
         final Instant now = Instant.now().truncatedTo(ChronoUnit.SECONDS);
         final SignedJWT unsignedJwt = JwtTestCase.buildUnsignedJwt(
             randomBoolean() ? null : JOSEObjectType.JWT.toString(),
@@ -603,7 +604,7 @@ public abstract class JwtRealmTestCase extends JwtTestCase {
             randomAlphaOfLengthBetween(10, 20), // jwtID
             jwtIssuerAndRealm.realm.allowedIssuer, // iss
             jwtIssuerAndRealm.realm.allowedAudiences, // aud
-            randomBoolean() ? user.principal() : user.principal() + "_" + randomAlphaOfLength(8), // sub
+            setSubClaim ? randomBoolean() ? user.principal() : user.principal() + "_" + randomAlphaOfLength(8) : null, // sub
             jwtIssuerAndRealm.realm.claimParserPrincipal.getClaimName(), // principal claim name
             user.principal(), // principal claim value
             jwtIssuerAndRealm.realm.claimParserGroups.getClaimName(), // group claim name


### PR DESCRIPTION
JWT `sub` claim is required in JwtAuthenticationToken, but optional in JwtRealm via the `claims.principal` setting.

The goal of this PR is to make the `sub` claim optional in JwtAuthenticationToken. If `sub` is absent, use the other claims to compute a substitute for the `sub` claim. The computed substitute is all of the claims, ordered to make the cache key deterministic, and filtered to exclude 7 claims (i.e. `iss`, `aud`, `jti`, `iat`, `exp`, `nbf`, `auth_time`). The exclude list is hard-coded, because JwtAuthenticationToken handling is common to all JWT realms, not per-realm.

Note, the `aud` claim is ordered to make that part of the cache key deterministic too.

JwtRealmTestCase `createJwtRealmSettings` already randomizes the `claims.principal` setting to `sub` or `<realmname>_sub`. JwtRealmTestCase `randomJwt` has been updated to check if the `claims.principal` setting is `sub` or not. If not `sub`, a value for `sub` is randomized to be included or omitted.

Example values of the token principal can be seen in trace/debug logs of `JwtRealm`, like so:
1. If `claims.principal` setting is `sub`:
```
token=[iss1_4324/iss1_4324_aud1/principal0]
```
2. If `claims.principal` setting is `realm_iss1_4324_sub`:
```
token=[iss1_4324/iss1_4324_aud1/{gr0up=superuser, realm_iss1_4324_sub=principal0}]
```