### PR TITLE
[8.1] Make data directories work with symlinks again (#85878)

### DIFF
--- a/docs/changelog/85878.yaml
+++ b/docs/changelog/85878.yaml
@@ -1,0 +1,6 @@
+pr: 85878
+summary: Make data directories work with symlinks again
+area: Infra/Core
+type: bug
+issues:
+ - 85701

--- a/qa/os/src/test/java/org/elasticsearch/packaging/test/PackagingTestCase.java
+++ b/qa/os/src/test/java/org/elasticsearch/packaging/test/PackagingTestCase.java
@@ -700,5 +700,4 @@ public abstract class PackagingTestCase extends Assert {
             assertThat(caCert.toString(), Matchers.not(Matchers.containsString("certs")));
         }
     }
-
 }

--- a/server/src/main/java/org/elasticsearch/env/NodeEnvironment.java
+++ b/server/src/main/java/org/elasticsearch/env/NodeEnvironment.java
@@ -258,6 +258,12 @@ public final class NodeEnvironment implements Closeable {
             sharedDataPath = environment.sharedDataFile();
 
             for (Path path : environment.dataFiles()) {
+                if (Files.exists(path)) {
+                    // Call to toRealPath required to resolve symlinks.
+                    // We let it fall through to create directories to ensure the symlink
+                    // isn't a file instead of a directory.
+                    path = path.toRealPath();
+                }
                 Files.createDirectories(path);
             }
 

--- a/server/src/main/resources/org/elasticsearch/bootstrap/test-framework.policy
+++ b/server/src/main/resources/org/elasticsearch/bootstrap/test-framework.policy
@@ -111,3 +111,7 @@ grant codeBase "${codebase.netty-transport}" {
    permission java.util.PropertyPermission "sun.nio.ch.bugLevel", "write";
    permission java.net.SocketPermission "*", "accept,connect";
 };
+
+grant {
+  permission java.nio.file.LinkPermission "symbolic";
+};

--- a/server/src/test/java/org/elasticsearch/env/NodeEnvironmentTests.java
+++ b/server/src/test/java/org/elasticsearch/env/NodeEnvironmentTests.java
@@ -597,6 +597,18 @@ public class NodeEnvironmentTests extends ESTestCase {
         }
     }
 
+    public void testSymlinkDataDirectory() throws Exception {
+        Path tempDir = createTempDir().toAbsolutePath();
+        Path dataPath = tempDir.resolve("data");
+        Files.createDirectories(dataPath);
+        Path symLinkPath = tempDir.resolve("data_symlink");
+        Files.createSymbolicLink(symLinkPath, dataPath);
+        NodeEnvironment env = newNodeEnvironment(new String[] { symLinkPath.toString() }, "/tmp", Settings.EMPTY);
+
+        assertTrue(Files.exists(symLinkPath));
+        env.close();
+    }
+
     private void verifyFailsOnShardData(Settings settings, Path indexPath, String shardDataDirName) {
         IllegalStateException ex = expectThrows(
             IllegalStateException.class,


### PR DESCRIPTION
Backports the following commits to 8.1:

Make data directories work with symlinks again (https://github.com/elastic/elasticsearch/pull/85878)