### PR TITLE
[8.2] Updated format parameter description to reference Java decimal format (#86163)

### DIFF
--- a/docs/reference/aggregations/pipeline/bucket-script-aggregation.asciidoc
+++ b/docs/reference/aggregations/pipeline/bucket-script-aggregation.asciidoc
@@ -39,7 +39,9 @@ for more details) |Required |
 (see <<buckets-path-syntax>> for more details) |Required |
 |`gap_policy` |The policy to apply when gaps are found in the data (see <<gap-policy>> for more
  details)|Optional |`skip`
-|`format` |format to apply to the output value of this aggregation |Optional |`null`
+|`format` |{javadoc}/java.base/java/text/DecimalFormat.html[DecimalFormat pattern] for the
+output value. If specified, the formatted value is returned in the aggregation's
+`value_as_string` property |Optional |`null`
 |===
 
 The following snippet calculates the ratio percentage of t-shirt sales compared to total sales each month:

--- a/docs/reference/aggregations/pipeline/cumulative-cardinality-aggregation.asciidoc
+++ b/docs/reference/aggregations/pipeline/cumulative-cardinality-aggregation.asciidoc
@@ -35,7 +35,9 @@ A `cumulative_cardinality` aggregation looks like this in isolation:
 |Parameter Name |Description |Required |Default Value
 |`buckets_path` |The path to the cardinality aggregation we wish to find the cumulative cardinality for (see <<buckets-path-syntax>> for more
  details) |Required |
-|`format` |format to apply to the output value of this aggregation |Optional |`null` 
+|`format` |{javadoc}/java.base/java/text/DecimalFormat.html[DecimalFormat pattern] for the
+output value. If specified, the formatted value is returned in the aggregation's
+`value_as_string` property |Optional |`null` 
 |===
 
 The following snippet calculates the cumulative cardinality of the total daily `users`:

--- a/docs/reference/aggregations/pipeline/cumulative-sum-aggregation.asciidoc
+++ b/docs/reference/aggregations/pipeline/cumulative-sum-aggregation.asciidoc
@@ -29,7 +29,9 @@ A `cumulative_sum` aggregation looks like this in isolation:
 |Parameter Name |Description |Required |Default Value
 |`buckets_path` |The path to the buckets we wish to find the cumulative sum for (see <<buckets-path-syntax>> for more
  details) |Required |
-|`format` |format to apply to the output value of this aggregation |Optional |`null` 
+|`format` |{javadoc}/java.base/java/text/DecimalFormat.html[DecimalFormat pattern] for the
+output value. If specified, the formatted value is returned in the aggregation's
+`value_as_string` property |Optional |`null` 
 |===
 
 The following snippet calculates the cumulative sum of the total monthly `sales`:

--- a/docs/reference/aggregations/pipeline/derivative-aggregation.asciidoc
+++ b/docs/reference/aggregations/pipeline/derivative-aggregation.asciidoc
@@ -29,7 +29,9 @@ A `derivative` aggregation looks like this in isolation:
  details) |Required |
  |`gap_policy` |The policy to apply when gaps are found in the data (see <<gap-policy>> for more
  details)|Optional |`skip` 
- |`format` |format to apply to the output value of this aggregation |Optional | `null` 
+ |`format` |{javadoc}/java.base/java/text/DecimalFormat.html[DecimalFormat pattern] for the
+output value. If specified, the formatted value is returned in the aggregation's
+`value_as_string` property |Optional | `null` 
 |===
 
 

--- a/docs/reference/aggregations/pipeline/extended-stats-bucket-aggregation.asciidoc
+++ b/docs/reference/aggregations/pipeline/extended-stats-bucket-aggregation.asciidoc
@@ -32,7 +32,9 @@ A `extended_stats_bucket` aggregation looks like this in isolation:
  details) |Required |
 |`gap_policy` |The policy to apply when gaps are found in the data (see <<gap-policy>> for more
  details)|Optional | `skip`
-|`format` |format to apply to the output value of this aggregation |Optional | `null`
+|`format` |{javadoc}/java.base/java/text/DecimalFormat.html[DecimalFormat pattern] for the
+output value. If specified, the formatted value is returned in the aggregation's
+`value_as_string` property |Optional | `null`
 |`sigma` |The number of standard deviations above/below the mean to display |Optional | 2
 |===
 

--- a/docs/reference/aggregations/pipeline/max-bucket-aggregation.asciidoc
+++ b/docs/reference/aggregations/pipeline/max-bucket-aggregation.asciidoc
@@ -31,7 +31,9 @@ A `max_bucket` aggregation looks like this in isolation:
  details) |Required |
 |`gap_policy` |The policy to apply when gaps are found in the data (see <<gap-policy>> for more
  details)|Optional | `skip`
- |`format` |format to apply to the output value of this aggregation |Optional |`null` 
+ |`format` |{javadoc}/java.base/java/text/DecimalFormat.html[DecimalFormat pattern] for the
+output value. If specified, the formatted value is returned in the aggregation's
+`value_as_string` property |Optional |`null` 
 |===
 
 The following snippet calculates the maximum of the total monthly `sales`:

--- a/docs/reference/aggregations/pipeline/min-bucket-aggregation.asciidoc
+++ b/docs/reference/aggregations/pipeline/min-bucket-aggregation.asciidoc
@@ -31,7 +31,9 @@ A `min_bucket` aggregation looks like this in isolation:
  details) |Required |
  |`gap_policy` |The policy to apply when gaps are found in the data (see <<gap-policy>> for more
  details)|Optional | `skip`
- |`format` |format to apply to the output value of this aggregation |Optional |`null`
+ |`format` |{javadoc}/java.base/java/text/DecimalFormat.html[DecimalFormat pattern] for the
+output value. If specified, the formatted value is returned in the aggregation's
+`value_as_string` property |Optional |`null`
 |===
 
 The following snippet calculates the minimum of the total monthly `sales`:

--- a/docs/reference/aggregations/pipeline/normalize-aggregation.asciidoc
+++ b/docs/reference/aggregations/pipeline/normalize-aggregation.asciidoc
@@ -30,7 +30,9 @@ A `normalize` aggregation looks like this in isolation:
 |Parameter Name |Description |Required |Default Value
 |`buckets_path` |The path to the buckets we wish to normalize (see <<buckets-path-syntax, `buckets_path` syntax>> for more details) |Required |
 |`method` | The specific <<normalize_pipeline-method, method>> to apply | Required |
-|`format` |format to apply to the output value of this aggregation |Optional |`null`
+|`format` |{javadoc}/java.base/java/text/DecimalFormat.html[DecimalFormat pattern] for the
+output value. If specified, the formatted value is returned in the aggregation's
+`value_as_string` property |Optional |`null`
 |===
 
 ==== Methods

--- a/docs/reference/aggregations/pipeline/percentiles-bucket-aggregation.asciidoc
+++ b/docs/reference/aggregations/pipeline/percentiles-bucket-aggregation.asciidoc
@@ -30,7 +30,9 @@ A `percentiles_bucket` aggregation looks like this in isolation:
  details) |Required |
 |`gap_policy` |The policy to apply when gaps are found in the data (see <<gap-policy>> for more
  details)|Optional | `skip`
-|`format` |format to apply to the output value of this aggregation |Optional | `null`
+|`format` |{javadoc}/java.base/java/text/DecimalFormat.html[DecimalFormat pattern] for the
+output value. If specified, the formatted value is returned in the aggregation's
+`value_as_string` property |Optional | `null`
 |`percents` |The list of percentiles to calculate |Optional | `[ 1, 5, 25, 50, 75, 95, 99 ]`
 |`keyed` |Flag which returns the range as an hash instead of an array of key-value pairs |Optional | `true`
 |===

--- a/docs/reference/aggregations/pipeline/serial-diff-aggregation.asciidoc
+++ b/docs/reference/aggregations/pipeline/serial-diff-aggregation.asciidoc
@@ -58,7 +58,9 @@ A `serial_diff` aggregation looks like this in isolation:
 |`lag` |The historical bucket to subtract from the current value. E.g. a lag of 7 will subtract the current value from
  the value 7 buckets ago. Must be a positive, non-zero integer |Optional |`1`
 |`gap_policy` |Determines what should happen when a gap in the data is encountered. |Optional |`insert_zeros`
-|`format` |Format to apply to the output value of this aggregation |Optional | `null`
+|`format` |{javadoc}/java.base/java/text/DecimalFormat.html[DecimalFormat pattern] for the
+output value. If specified, the formatted value is returned in the aggregation's
+`value_as_string` property |Optional | `null`
 |===
 
 `serial_diff` aggregations must be embedded inside of a `histogram` or `date_histogram` aggregation:

--- a/docs/reference/aggregations/pipeline/stats-bucket-aggregation.asciidoc
+++ b/docs/reference/aggregations/pipeline/stats-bucket-aggregation.asciidoc
@@ -30,7 +30,9 @@ A `stats_bucket` aggregation looks like this in isolation:
  details) |Required |
 |`gap_policy` |The policy to apply when gaps are found in the data (see <<gap-policy>> for more
  details)|Optional | `skip`
-|`format` |format to apply to the output value of this aggregation |Optional | `null`
+|`format` |{javadoc}/java.base/java/text/DecimalFormat.html[DecimalFormat pattern] for the
+output value. If specified, the formatted value is returned in the aggregation's
+`value_as_string` property|Optional | `null`
 |===
 
 The following snippet calculates the stats for monthly `sales`:

--- a/docs/reference/aggregations/pipeline/sum-bucket-aggregation.asciidoc
+++ b/docs/reference/aggregations/pipeline/sum-bucket-aggregation.asciidoc
@@ -31,7 +31,9 @@ A `sum_bucket` aggregation looks like this in isolation:
  details) |Required |
  |`gap_policy` |The policy to apply when gaps are found in the data (see <<gap-policy>> for more
  details)|Optional | `skip`
- |`format` |format to apply to the output value of this aggregation |Optional |`null` 
+ |`format` |{javadoc}/java.base/java/text/DecimalFormat.html[DecimalFormat pattern] for the
+output value. If specified, the formatted value is returned in the aggregation's
+`value_as_string` property. |Optional |`null` 
 |===
 
 The following snippet calculates the sum of all the total monthly `sales` buckets:


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `8.2`:
 - [Updated format parameter description to reference Java decimal format (#86163)](https://github.com/elastic/elasticsearch/pull/86163)

<!--- Backport version: 8.4.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)