### PR TITLE
Fleet: Add start_time and minimum_execution_duration attributes to actions

### DIFF
--- a/docs/changelog/86167.yaml
+++ b/docs/changelog/86167.yaml
@@ -1,0 +1,5 @@
+pr: 86167
+summary: "Fleet: Add `start_time` and `minimum_execution_duration` attributes to actions"
+area: Infra/Core
+type: enhancement
+issues: []

--- a/x-pack/plugin/core/src/main/resources/fleet-actions.json
+++ b/x-pack/plugin/core/src/main/resources/fleet-actions.json
@@ -22,6 +22,13 @@
         "expiration": {
           "type": "date"
         },
+        "start_time": {
+          "type": "date"
+        },
+        "minimum_execution_duration": {
+          "type": "keyword",
+          "enabled": false
+        },
         "input_type": {
           "type": "keyword"
         },

--- a/x-pack/plugin/core/src/main/resources/fleet-actions.json
+++ b/x-pack/plugin/core/src/main/resources/fleet-actions.json
@@ -26,8 +26,7 @@
           "type": "date"
         },
         "minimum_execution_duration": {
-          "type": "keyword",
-          "enabled": false
+          "type": "keyword"
         },
         "input_type": {
           "type": "keyword"

--- a/x-pack/plugin/core/src/main/resources/fleet-actions.json
+++ b/x-pack/plugin/core/src/main/resources/fleet-actions.json
@@ -26,7 +26,7 @@
           "type": "date"
         },
         "minimum_execution_duration": {
-          "type": "keyword"
+          "type": "integer"
         },
         "input_type": {
           "type": "keyword"


### PR DESCRIPTION
### What does this PR Do?

Add new start_time and minimum_execution_duration attributes to
.fleet-actions index mapping.

### Related Issues

- https://github.com/elastic/fleet-server/issues/1380
