### PR TITLE
Forward port default hasher for FIPS/TestClusters (#66841) 

### DIFF
--- a/build-tools-internal/src/main/groovy/elasticsearch.fips.gradle
+++ b/build-tools-internal/src/main/groovy/elasticsearch.fips.gradle
@@ -66,6 +66,7 @@ if (BuildParams.inFipsJvm) {
           setting 'xpack.security.enabled', 'false'
           setting 'xpack.security.fips_mode.enabled', 'true'
           setting 'xpack.license.self_generated.type', 'trial'
+          setting 'xpack.security.authc.password_hashing.algorithm', 'pbkdf2_stretch'
           keystorePassword 'keystore-password'
         }
       }


### PR DESCRIPTION
When running tests in FIPS mode, automatically set the password hasher
to pbkdf2_stretch rather than relying on the default (which is
bcrypt).

This is only relevant to the 7.x series, as this setting has a FIPS
specific default when run in FIPS mode on 8.0+

This is a forward port of #66841

Closes #86144