### PR TITLE
[8.2] Wait longer for CCR auto-follow stats to appear in monitoring index (#86140)

### DIFF
--- a/x-pack/plugin/ccr/qa/security/src/test/java/org/elasticsearch/xpack/ccr/FollowIndexSecurityIT.java
+++ b/x-pack/plugin/ccr/qa/security/src/test/java/org/elasticsearch/xpack/ccr/FollowIndexSecurityIT.java
@@ -69,7 +69,7 @@ public class FollowIndexSecurityIT extends ESCCRRestTestCase {
             followIndex("leader_cluster", allowedIndex, allowedIndex);
             assertBusy(() -> verifyDocuments(allowedIndex, numDocs, "*:*"));
             assertThat(getCcrNodeTasks(), contains(new CcrNodeTask("leader_cluster", allowedIndex, allowedIndex, 0)));
-            assertBusy(() -> verifyCcrMonitoring(allowedIndex, allowedIndex), 30, TimeUnit.SECONDS);
+            assertBusy(() -> verifyCcrMonitoring(allowedIndex, allowedIndex), 120L, TimeUnit.SECONDS);
             pauseFollow(allowedIndex);
             // Make sure that there are no other ccr relates operations running:
             assertBusy(() -> {
@@ -176,8 +176,8 @@ public class FollowIndexSecurityIT extends ESCCRRestTestCase {
             assertBusy(() -> ensureYellow(allowedIndex), 30, TimeUnit.SECONDS);
             assertBusy(() -> verifyDocuments(allowedIndex, 5, "*:*"), 30, TimeUnit.SECONDS);
             assertThat(indexExists(disallowedIndex), is(false));
-            assertBusy(() -> verifyCcrMonitoring(allowedIndex, allowedIndex), 30, TimeUnit.SECONDS);
-            assertBusy(ESCCRRestTestCase::verifyAutoFollowMonitoring, 30, TimeUnit.SECONDS);
+            assertBusy(() -> verifyCcrMonitoring(allowedIndex, allowedIndex), 120L, TimeUnit.SECONDS);
+            assertBusy(ESCCRRestTestCase::verifyAutoFollowMonitoring, 120L, TimeUnit.SECONDS);
         } finally {
             // Cleanup by deleting auto follow pattern and pause following:
             try {


### PR DESCRIPTION
Now #84467 has been backported to 7.17 (#85514) the recent failures
are always due to monitoring docs not being indexed in monitoring
indices within 30s.

Similarly to what has been done for `AutoFollowIT.testAutoFollowPatterns()`
in #85278 which reduced the number of failures, we can wait longer in
`FollowIndexSecurityIT.testAutoFollowPatterns()` for monitoring docs
to be indexed.

Closes #84888
Backport of #86140