### PR TITLE
[8.1] Forward port default hasher test cluster config (#86171)

### DIFF
--- a/build-tools-internal/src/main/groovy/elasticsearch.fips.gradle
+++ b/build-tools-internal/src/main/groovy/elasticsearch.fips.gradle
@@ -66,6 +66,7 @@ if (BuildParams.inFipsJvm) {
           setting 'xpack.security.enabled', 'false'
           setting 'xpack.security.fips_mode.enabled', 'true'
           setting 'xpack.license.self_generated.type', 'trial'
+          setting 'xpack.security.authc.password_hashing.algorithm', 'pbkdf2_stretch'
           keystorePassword 'keystore-password'
         }
       }


### PR DESCRIPTION
Backports the following commits to 8.1:
 - Forward port default hasher test cluster config (#86171)