### PR TITLE
QL: Stop using Mockito for mocking ZoneId class

### DIFF
--- a/x-pack/plugin/ql/src/test/java/org/elasticsearch/xpack/ql/tree/NodeSubclassTests.java
+++ b/x-pack/plugin/ql/src/test/java/org/elasticsearch/xpack/ql/tree/NodeSubclassTests.java
@@ -46,6 +46,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.SimpleFileVisitor;
 import java.nio.file.attribute.BasicFileAttributes;
+import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.EnumSet;
@@ -513,6 +514,10 @@ public class NodeSubclassTests<T extends B, B extends Node<B>> extends ESTestCas
         if (argClass == Source.class) {
             // Location is final and can't be mocked but we have a handy method to generate ones.
             return SourceTests.randomSource();
+        }
+        if (argClass == ZoneId.class) {
+            // ZoneId is a sealed class (cannot be mocked) starting with Java 19
+            return randomZone();
         }
         try {
             return mock(argClass);


### PR DESCRIPTION
With Java 19, [ZoneId is a sealed class](https://bugs.openjdk.java.net/browse/JDK-8282131?page=com.atlassian.jira.plugin.system.issuetabpanels%3Aall-tabpanel) and cannot be mocked anymore. With this PR, in `NodeSubclassTests` we start using a random ZoneId instead.

Fixes https://github.com/elastic/elasticsearch/issues/86128.