### PR TITLE
Ensure authentication is randomized as expected

### DIFF
--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/ApiKeyServiceTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/ApiKeyServiceTests.java
@@ -1683,7 +1683,6 @@ public class ApiKeyServiceTests extends ESTestCase {
         assertEquals(new BytesArray("{}"), apiKeyDoc.roleDescriptorsBytes);
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/86179")
     public void testGetApiKeyMetadata() throws IOException {
         final Map<String, Object> metadata;
         final Map<String, Object> apiKeyMetadata = ApiKeyTests.randomMetadata();
@@ -1708,7 +1707,8 @@ public class ApiKeyServiceTests extends ESTestCase {
 
         final Authentication authentication = AuthenticationTests.randomAuthentication(
             AuthenticationTests.randomUser(),
-            AuthenticationTests.randomRealmRef(randomBoolean())
+            AuthenticationTests.randomRealmRef(randomBoolean()),
+            false
         );
         final IllegalArgumentException e = expectThrows(
             IllegalArgumentException.class,


### PR DESCRIPTION
In #85255, some mocking of Authentication class got replaced by randomly
creating actual Authentication objects. This is a general direction we
want to head towards because Authentication object has plenty internal
logics which makes it hard to mock correctly (and also undesirable). The
recent change in #85590 adds a test helper which makes randomising
Authentication object easier for tests.

For ApiKeyServiceTests.testGetApiKeyMetadata, the randomisation is
however too broad (broader then what the mocking provided) and can
sometimes creates authentication object that does not pass the
assertion.

The assertion expects no API key authentication. But the randomisation
can generate such one because it randomises whether the authentication
has run-as even when the effective user is from a realm. Since API keys
can run-as, the resulted Authentication object can be an overall API key
authentication object.

This PR reduces the randomness by not allow run-as so that the resulted
Authentication cannot be API keys.

Relates: #85255
Resolves: #86179
