### PR TITLE
Optimize StreamOutput#writeGenericString to fluss less

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/io/stream/StreamOutput.java
+++ b/server/src/main/java/org/elasticsearch/common/io/stream/StreamOutput.java
@@ -782,8 +782,10 @@ public abstract class StreamOutput extends OutputStream {
     }
 
     public void writeGenericString(String value) throws IOException {
-        writeByte((byte) 0);
-        writeString(value);
+        byte[] buffer = scratch.get();
+        // put the 0 type identifier byte into the buffer instead of writing it outright to do fewer flushes
+        buffer[0] = 0;
+        writeString(value, buffer, 1);
     }
 
     public void writeGenericNull() throws IOException {


### PR DESCRIPTION
Using the same optimization used in #86114 to make this method a little more efficient.
This one gets quite hot for large cluster states that serialize lots of settings and greatly
benefits from fewer flushes to the deflater output stream.
