### PR TITLE
[DOCS] Add transform limitation for underscore field names

### DIFF
--- a/docs/reference/transform/limitations.asciidoc
+++ b/docs/reference/transform/limitations.asciidoc
@@ -24,11 +24,11 @@ categories:
 
 [discrete]
 [[transforms-underscore-limitation]]
-=== Field names prefixed with underscores omitted from latest {transforms}
+=== Field names prefixed with underscores are omitted from latest {transforms}
 
-If you have field names that start with an underscore character (_), they are
-omitted from the resulting documents in the destination index for `latest` type
-of {transform}, since they are assumed to be internal fields.
+If you use the `latest` type of {transform} and the source index has field names
+that start with an underscore (_) character, they are assumed to be internal
+fields. Those fields are omitted from the documents in the destination index.
 
 [discrete]
 [[transforms-ccs-limitation]]

--- a/docs/reference/transform/limitations.asciidoc
+++ b/docs/reference/transform/limitations.asciidoc
@@ -23,6 +23,14 @@ categories:
 == Configuration limitations
 
 [discrete]
+[[transforms-underscore-limitation]]
+=== Field names prefixed with underscores omitted from latest {transforms}
+
+If you have field names that start with an underscore character (_), they are
+omitted from the resulting documents in the destination index for `latest` type
+of {transform}, since they are assumed to be internal fields.
+
+[discrete]
 [[transforms-ccs-limitation]]
 === {transforms-cap} support {ccs} if the remote cluster is configured properly
 


### PR DESCRIPTION
This PR adds a section in the transform limitations documentation.

Relates to https://github.com/elastic/elasticsearch/issues/86181

## Preview

https://elasticsearch_86195.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/transform-limitations.html#transform-config-limitations