### PR TITLE
Remove version skips for product header issue

### DIFF
--- a/test/yaml-rest-runner/src/main/java/org/elasticsearch/test/rest/yaml/section/DoSection.java
+++ b/test/yaml-rest-runner/src/main/java/org/elasticsearch/test/rest/yaml/section/DoSection.java
@@ -362,11 +362,8 @@ public class DoSection implements ExecutableSection {
             final String testPath = executionContext.getClientYamlTestCandidate() != null
                 ? executionContext.getClientYamlTestCandidate().getTestPath()
                 : null;
-            if (executionContext.esVersion().after(Version.V_8_1_0)
-                || (executionContext.esVersion().major == Version.V_7_17_0.major && executionContext.esVersion().after(Version.V_7_17_1))) {
-                // #84038 and #84089 mean that this assertion fails when running against a small number of released versions, but at time of
-                // writing it's unclear exactly which released versions will contain the fix.
-                // TODO once a fixed version has been released, adjust the condition above to match.
+            if (executionContext.esVersion().major == Version.V_7_17_0.major && executionContext.esVersion().after(Version.V_7_17_1)) {
+                // #84038 and #84089 mean that this assertion fails when running against a small number of 7.17.x released versions
                 checkElasticProductHeader(response.getHeaders("X-elastic-product"));
             }
             checkWarningHeaders(response.getWarningHeaders(), testPath);


### PR DESCRIPTION
We added some logic to skep checking the product header on versions with known bugs in the product header response functionality. Fortunately, we managed to get all of our fixes out in the same 8.x versions where we added the assertion, so we should be able to remove the 8.x skips altogether.

Closes #84243