### PR TITLE
[7.17] [DOCS] Add transform limitation for underscore field names (#86195)

### DIFF
--- a/docs/reference/transform/limitations.asciidoc
+++ b/docs/reference/transform/limitations.asciidoc
@@ -23,6 +23,14 @@ categories:
 == Configuration limitations
 
 [discrete]
+[[transforms-underscore-limitation]]
+=== Field names prefixed with underscores are omitted from latest {transforms}
+
+If you use the `latest` type of {transform} and the source index has field names
+that start with an underscore (_) character, they are assumed to be internal
+fields. Those fields are omitted from the documents in the destination index.
+
+[discrete]
 [[transforms-ccs-limitation]]
 === {transforms-cap} support {ccs} if the remote cluster is configured properly
 


### PR DESCRIPTION
Backports the following commits to 7.17:
 - [DOCS] Add transform limitation for underscore field names (#86195)