### PR TITLE
Locking down Authentication constructors

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authc/Authentication.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authc/Authentication.java
@@ -76,13 +76,7 @@ public class Authentication implements ToXContentObject {
     private final Subject authenticatingSubject;
     private final Subject effectiveSubject;
 
-    // TODO: remove this constructor. all usages have been removed
-    public Authentication(User user, RealmRef authenticatedBy, RealmRef lookedUpBy) {
-        this(user, authenticatedBy, lookedUpBy, Version.CURRENT, AuthenticationType.REALM, Collections.emptyMap());
-    }
-
-    // TODO: make this constructor private to favour dedicate methods for instantiation Authentication
-    public Authentication(
+    private Authentication(
         User user,
         RealmRef authenticatedBy,
         RealmRef lookedUpBy,


### PR DESCRIPTION
This PR removes one constructor from Authentication and change
the visibility of the other one to private. This means Authentication
object must now be created using dedicated convenient methods, e.g.
newRealmAuthentication. This approach helps maintain the internal logic
of Authentication object more easily and correctly. It also allows
further refactoring for Authentication internals easier.

Technically, the constructor with StreamInput argument is still public.
But this one is special enough that we can leave it for now and come
back to it later if necessary.

Relates: #85905
Relates: #86020
Relates: #86054

