### PR TITLE
Compute master task batch summary lazily

### DIFF
--- a/docs/changelog/86210.yaml
+++ b/docs/changelog/86210.yaml
@@ -1,0 +1,5 @@
+pr: 86210
+summary: Compute master task batch summary lazily
+area: Cluster Coordination
+type: enhancement
+issues: []

--- a/server/src/main/java/org/elasticsearch/cluster/ClusterStatePublicationEvent.java
+++ b/server/src/main/java/org/elasticsearch/cluster/ClusterStatePublicationEvent.java
@@ -8,6 +8,8 @@
 
 package org.elasticsearch.cluster;
 
+import org.elasticsearch.cluster.service.BatchSummary;
+
 /**
  * Represents a cluster state update computed by the {@link org.elasticsearch.cluster.service.MasterService} for publication to the cluster.
  * If publication is successful then this creates a {@link ClusterChangedEvent} which is applied on every node.
@@ -19,7 +21,7 @@ public class ClusterStatePublicationEvent {
      */
     private static final long NOT_SET = -1L;
 
-    private final String summary;
+    private final BatchSummary summary;
     private final ClusterState oldState;
     private final ClusterState newState;
     private final long computationTimeMillis;
@@ -30,7 +32,7 @@ public class ClusterStatePublicationEvent {
     private volatile long masterApplyElapsedMillis = NOT_SET;
 
     public ClusterStatePublicationEvent(
-        String summary,
+        BatchSummary summary,
         ClusterState oldState,
         ClusterState newState,
         long computationTimeMillis,
@@ -43,7 +45,7 @@ public class ClusterStatePublicationEvent {
         this.publicationStartTimeMillis = publicationStartTimeMillis;
     }
 
-    public String getSummary() {
+    public BatchSummary getSummary() {
         return summary;
     }
 

--- a/server/src/main/java/org/elasticsearch/cluster/service/BatchSummary.java
+++ b/server/src/main/java/org/elasticsearch/cluster/service/BatchSummary.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.cluster.service;
+
+import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.util.LazyInitializable;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class BatchSummary {
+
+    static final int MAX_TASK_DESCRIPTION_CHARS = 8 * 1024;
+
+    private final LazyInitializable<String, RuntimeException> lazyDescription;
+
+    public BatchSummary(TaskBatcher.BatchedTask firstTask, List<TaskBatcher.BatchedTask> allTasks) {
+        lazyDescription = new LazyInitializable<>(() -> {
+            final Map<String, List<TaskBatcher.BatchedTask>> processTasksBySource = new HashMap<>();
+            for (final var task : allTasks) {
+                processTasksBySource.computeIfAbsent(task.source, s -> new ArrayList<>()).add(task);
+            }
+            final StringBuilder output = new StringBuilder();
+            Strings.collectionToDelimitedStringWithLimit((Iterable<String>) () -> processTasksBySource.entrySet().stream().map(entry -> {
+                String tasks = firstTask.describeTasks(entry.getValue());
+                return tasks.isEmpty() ? entry.getKey() : entry.getKey() + "[" + tasks + "]";
+            }).filter(s -> s.isEmpty() == false).iterator(), ", ", "", "", MAX_TASK_DESCRIPTION_CHARS, output);
+            if (output.length() > MAX_TASK_DESCRIPTION_CHARS) {
+                output.append(" (").append(allTasks.size()).append(" tasks in total)");
+            }
+            return output.toString();
+        });
+    }
+
+    // for tests
+    public BatchSummary(String string) {
+        lazyDescription = new LazyInitializable<>(() -> string);
+    }
+
+    @Override
+    public String toString() {
+        return lazyDescription.getOrCompute();
+    }
+}

--- a/server/src/main/java/org/elasticsearch/cluster/service/MasterService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/service/MasterService.java
@@ -150,7 +150,7 @@ public class MasterService extends AbstractLifecycleComponent {
         }
 
         @Override
-        protected void run(Object batchingKey, List<? extends BatchedTask> tasks, String tasksSummary) {
+        protected void run(Object batchingKey, List<? extends BatchedTask> tasks, BatchSummary tasksSummary) {
             runTasks((ClusterStateTaskExecutor<ClusterStateTaskListener>) batchingKey, (List<UpdateTask>) tasks, tasksSummary);
         }
 
@@ -231,7 +231,7 @@ public class MasterService extends AbstractLifecycleComponent {
     private void runTasks(
         ClusterStateTaskExecutor<ClusterStateTaskListener> executor,
         List<Batcher.UpdateTask> updateTasks,
-        String summary
+        BatchSummary summary
     ) {
         if (lifecycle.started() == false) {
             logger.debug("processing [{}]: ignoring, master service not started", summary);
@@ -422,7 +422,7 @@ public class MasterService extends AbstractLifecycleComponent {
         );
     }
 
-    private void handleException(String summary, long startTimeMillis, ClusterState newClusterState, Exception e) {
+    private void handleException(BatchSummary summary, long startTimeMillis, ClusterState newClusterState, Exception e) {
         final TimeValue executionTime = getTimeSince(startTimeMillis);
         final long version = newClusterState.version();
         final String stateUUID = newClusterState.stateUUID();
@@ -587,7 +587,7 @@ public class MasterService extends AbstractLifecycleComponent {
         return threadPoolExecutor.getMaxTaskWaitTime();
     }
 
-    private void logExecutionTime(TimeValue executionTime, String activity, String summary) {
+    private void logExecutionTime(TimeValue executionTime, String activity, BatchSummary summary) {
         if (executionTime.getMillis() > slowTaskLoggingThreshold.getMillis()) {
             logger.warn(
                 "took [{}/{}ms] to {} for [{}], which exceeds the warn threshold of [{}]",
@@ -898,7 +898,7 @@ public class MasterService extends AbstractLifecycleComponent {
         ClusterState previousClusterState,
         List<ExecutionResult<ClusterStateTaskListener>> executionResults,
         ClusterStateTaskExecutor<ClusterStateTaskListener> executor,
-        String summary
+        BatchSummary summary
     ) {
         final var resultingState = innerExecuteTasks(previousClusterState, executionResults, executor, summary);
         if (previousClusterState != resultingState
@@ -926,7 +926,7 @@ public class MasterService extends AbstractLifecycleComponent {
         ClusterState previousClusterState,
         List<ExecutionResult<ClusterStateTaskListener>> executionResults,
         ClusterStateTaskExecutor<ClusterStateTaskListener> executor,
-        String summary
+        BatchSummary summary
     ) {
         final var taskContexts = castTaskContexts(executionResults);
         try {

--- a/server/src/test/java/org/elasticsearch/cluster/coordination/PublicationTransportHandlerTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/coordination/PublicationTransportHandlerTests.java
@@ -19,6 +19,7 @@ import org.elasticsearch.cluster.coordination.CoordinationMetadata.VotingConfigu
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.DiscoveryNodeRole;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
+import org.elasticsearch.cluster.service.BatchSummary;
 import org.elasticsearch.common.UUIDs;
 import org.elasticsearch.common.compress.Compressor;
 import org.elasticsearch.common.compress.CompressorFactory;
@@ -99,7 +100,9 @@ public class PublicationTransportHandlerTests extends ESTestCase {
 
         final ElasticsearchException e = expectThrows(
             ElasticsearchException.class,
-            () -> handler.newPublicationContext(new ClusterStatePublicationEvent("test", clusterState, unserializableClusterState, 0L, 0L))
+            () -> handler.newPublicationContext(
+                new ClusterStatePublicationEvent(new BatchSummary("test"), clusterState, unserializableClusterState, 0L, 0L)
+            )
         );
         assertNotNull(e.getCause());
         assertThat(e.getCause(), instanceOf(IOException.class));
@@ -273,7 +276,7 @@ public class PublicationTransportHandlerTests extends ESTestCase {
             final PublicationTransportHandler.PublicationContext context;
             try {
                 context = handler.newPublicationContext(
-                    new ClusterStatePublicationEvent("test", prevClusterState, nextClusterState, 0L, 0L)
+                    new ClusterStatePublicationEvent(new BatchSummary("test"), prevClusterState, nextClusterState, 0L, 0L)
                 );
             } catch (ElasticsearchException e) {
                 assertTrue(simulateFailures);

--- a/server/src/test/java/org/elasticsearch/cluster/service/TaskBatcherTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/service/TaskBatcherTests.java
@@ -47,7 +47,7 @@ public class TaskBatcherTests extends TaskExecutorTests {
 
         @SuppressWarnings("unchecked")
         @Override
-        protected void run(Object batchingKey, List<? extends BatchedTask> tasks, String tasksSummary) {
+        protected void run(Object batchingKey, List<? extends BatchedTask> tasks, BatchSummary tasksSummary) {
             List<UpdateTask> updateTasks = (List<UpdateTask>) tasks;
             ((TestExecutor<Object>) batchingKey).execute(updateTasks.stream().map(t -> t.task).toList());
             updateTasks.forEach(updateTask -> updateTask.listener.processed());


### PR DESCRIPTION
Today we construct a string description of every batch of master tasks
in case we need to log it, grouping the tasks by `source` and calling
`toString()` on each one. Yet, we almost never emit the description in
the logs so this effort is usually wasted. This commit makes the summary
computation lazy, deferring the effort until we discover it's actually
needed and avoiding it entirely in most cases.