### PR TITLE
Deduplicate + intern field names in mappers and field caps responses

### DIFF
--- a/docs/changelog/86226.yaml
+++ b/docs/changelog/86226.yaml
@@ -1,0 +1,5 @@
+pr: 86226
+summary: Deduplicate + intern field names in mappers and field caps responses
+area: Search
+type: bug
+issues: []

--- a/server/src/main/java/org/elasticsearch/action/fieldcaps/IndexFieldCapabilities.java
+++ b/server/src/main/java/org/elasticsearch/action/fieldcaps/IndexFieldCapabilities.java
@@ -13,6 +13,7 @@ import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.util.StringLiteralDeduplicator;
+import org.elasticsearch.index.mapper.Mapper;
 import org.elasticsearch.index.mapper.TimeSeriesParams;
 
 import java.io.IOException;
@@ -65,7 +66,6 @@ public class IndexFieldCapabilities implements Writeable {
         TimeSeriesParams.MetricType metricType,
         Map<String, String> meta
     ) {
-
         this.name = name;
         this.type = type;
         this.isMetadatafield = isMetadatafield;
@@ -77,7 +77,7 @@ public class IndexFieldCapabilities implements Writeable {
     }
 
     IndexFieldCapabilities(StreamInput in) throws IOException {
-        this.name = in.readString();
+        this.name = Mapper.internFieldName(in.readString());
         this.type = typeStringDeduplicator.deduplicate(in.readString());
         this.isMetadatafield = in.readBoolean();
         this.isSearchable = in.readBoolean();

--- a/server/src/main/java/org/elasticsearch/index/mapper/FieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/FieldMapper.java
@@ -1446,5 +1446,4 @@ public abstract class FieldMapper extends Mapper implements Cloneable {
             return indexCreatedVersion.onOrAfter(minimumCompatibilityVersion);
         }
     }
-
 }

--- a/server/src/main/java/org/elasticsearch/index/mapper/MappedFieldType.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/MappedFieldType.java
@@ -74,7 +74,7 @@ public abstract class MappedFieldType {
         TextSearchInfo textSearchInfo,
         Map<String, String> meta
     ) {
-        this.name = Objects.requireNonNull(name);
+        this.name = Mapper.internFieldName(name);
         this.isIndexed = isIndexed;
         this.isStored = isStored;
         this.docValues = hasDocValues;

--- a/server/src/main/java/org/elasticsearch/index/mapper/Mapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/Mapper.java
@@ -10,6 +10,7 @@ package org.elasticsearch.index.mapper;
 
 import org.elasticsearch.Version;
 import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.util.StringLiteralDeduplicator;
 import org.elasticsearch.xcontent.ToXContentFragment;
 
 import java.util.Map;
@@ -22,7 +23,7 @@ public abstract class Mapper implements ToXContentFragment, Iterable<Mapper> {
         protected final String name;
 
         protected Builder(String name) {
-            this.name = name;
+            this.name = internFieldName(name);
         }
 
         public String name() {
@@ -48,7 +49,7 @@ public abstract class Mapper implements ToXContentFragment, Iterable<Mapper> {
 
     public Mapper(String simpleName) {
         Objects.requireNonNull(simpleName);
-        this.simpleName = simpleName;
+        this.simpleName = internFieldName(simpleName);
     }
 
     /** Returns the simple name, which identifies this mapper against other mappers at the same level in the mappers hierarchy
@@ -78,5 +79,16 @@ public abstract class Mapper implements ToXContentFragment, Iterable<Mapper> {
     @Override
     public String toString() {
         return Strings.toString(this);
+    }
+
+    private static final StringLiteralDeduplicator fieldNameStringDeduplicator = new StringLiteralDeduplicator();
+
+    /**
+     * Interns the given field name string through a {@link StringLiteralDeduplicator}.
+     * @param fieldName field name to intern
+     * @return interned field name string
+     */
+    public static String internFieldName(String fieldName) {
+        return fieldNameStringDeduplicator.deduplicate(fieldName);
     }
 }

--- a/server/src/main/java/org/elasticsearch/index/mapper/ObjectMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/ObjectMapper.java
@@ -28,7 +28,6 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
-import java.util.Optional;
 
 public class ObjectMapper extends Mapper implements Cloneable {
     private static final DeprecationLogger deprecationLogger = DeprecationLogger.getLogger(ObjectMapper.class);
@@ -142,10 +141,6 @@ public class ObjectMapper extends Mapper implements Cloneable {
                 return child.newBuilder(context.indexSettings().getIndexVersionCreated());
             }
             throw new IllegalArgumentException("Missing intermediate object " + fullChildName);
-        }
-
-        public Optional<Mapper.Builder> getBuilder(String name) {
-            return mappersBuilders.stream().filter(b -> b.name().equals(name)).findFirst();
         }
 
         protected final Map<String, Mapper> buildMappers(boolean root, MapperBuilderContext context) {
@@ -309,7 +304,7 @@ public class ObjectMapper extends Mapper implements Cloneable {
         if (name.isEmpty()) {
             throw new IllegalArgumentException("name cannot be empty string");
         }
-        this.fullPath = fullPath;
+        this.fullPath = internFieldName(fullPath);
         this.enabled = enabled;
         this.dynamic = dynamic;
         if (mappers == null) {


### PR DESCRIPTION
We already intern the type in field caps responses and interning the name
can save some more memory. Also, we can do the same for names in mappers
if which can save a little heap for mapper instances on data nodes
in case of nested field names (top level field names are already interned
by Jackson as far as I can tell).

I think this one will be quite diminished in importance by the other field caps fixes that landed lately but
seems like a safe enough change to maybe backport to 8.1 and 7.17 to address 
known issues in those versions to which we can't backport the larger behavior changes of field caps (see linked issue).
(the interning for mapper instance name fields could be left out of that backport, I just added it here since it seemed like
a freebie in this context)