### PR TITLE
[7.17] Set autoexpand replicas on fleet actions data stream (#85511)

### DIFF
--- a/docs/changelog/85511.yaml
+++ b/docs/changelog/85511.yaml
@@ -1,0 +1,5 @@
+pr: 85511
+summary: Set autoexpand replicas on fleet actions data stream
+area: Infra/Core
+type: bug
+issues: []

--- a/x-pack/plugin/core/src/main/resources/fleet-actions-results.json
+++ b/x-pack/plugin/core/src/main/resources/fleet-actions-results.json
@@ -5,7 +5,8 @@
   "data_stream": {},
   "template": {
     "settings": {
-      "index.lifecycle.name": ".fleet-actions-results-ilm-policy"
+      "index.lifecycle.name": ".fleet-actions-results-ilm-policy",
+      "index.auto_expand_replicas": "0-1"
     },
     "mappings": {
       "_meta": {


### PR DESCRIPTION
Backports the following commits to 7.17:
 - Set autoexpand replicas on fleet actions data stream (#85511)