### PR TITLE
[8.1] Remove version skips for product header issue (#86196)

### DIFF
--- a/test/framework/src/main/java/org/elasticsearch/test/rest/yaml/section/DoSection.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/rest/yaml/section/DoSection.java
@@ -367,11 +367,8 @@ public class DoSection implements ExecutableSection {
             final String testPath = executionContext.getClientYamlTestCandidate() != null
                 ? executionContext.getClientYamlTestCandidate().getTestPath()
                 : null;
-            if (executionContext.esVersion().after(Version.V_8_1_0)
-                || (executionContext.esVersion().major == Version.V_7_17_0.major && executionContext.esVersion().after(Version.V_7_17_1))) {
-                // #84038 and #84089 mean that this assertion fails when running against a small number of released versions, but at time of
-                // writing it's unclear exactly which released versions will contain the fix.
-                // TODO once a fixed version has been released, adjust the condition above to match.
+            if (executionContext.esVersion().major == Version.V_7_17_0.major && executionContext.esVersion().after(Version.V_7_17_1)) {
+                // #84038 and #84089 mean that this assertion fails when running against a small number of 7.17.x released versions
                 checkElasticProductHeader(response.getHeaders("X-elastic-product"));
             }
             checkWarningHeaders(response.getWarningHeaders(), testPath);


### PR DESCRIPTION
Backports the following commits to 8.1:
 - Remove version skips for product header issue (#86196)