### PR TITLE
Add UNKNOWN status to health api if cluster state is unknown

### DIFF
--- a/docs/changelog/86240.yaml
+++ b/docs/changelog/86240.yaml
@@ -1,0 +1,6 @@
+pr: 86240
+summary: Add UNKNOWN status to health api if cluster state is unknown
+area: Health
+type: enhancement
+issues:
+ - 84792

--- a/server/src/main/java/org/elasticsearch/cluster/coordination/InstanceHasMasterHealthIndicatorService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/InstanceHasMasterHealthIndicatorService.java
@@ -14,24 +14,22 @@ import org.elasticsearch.cluster.node.DiscoveryNodes;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.health.HealthIndicatorDetails;
 import org.elasticsearch.health.HealthIndicatorResult;
-import org.elasticsearch.health.HealthIndicatorService;
+import org.elasticsearch.health.HealthIndicatorServiceBase;
 import org.elasticsearch.health.HealthStatus;
 
 import java.util.Collections;
 
 import static org.elasticsearch.health.ServerHealthComponents.CLUSTER_COORDINATION;
 
-public class InstanceHasMasterHealthIndicatorService implements HealthIndicatorService {
+public class InstanceHasMasterHealthIndicatorService extends HealthIndicatorServiceBase {
 
     public static final String NAME = "instance_has_master";
 
     private static final String INSTANCE_HAS_MASTER_GREEN_SUMMARY = "Health coordinating instance has a master node.";
     private static final String INSTANCE_HAS_MASTER_RED_SUMMARY = "Health coordinating instance does not have a master node.";
 
-    private final ClusterService clusterService;
-
     public InstanceHasMasterHealthIndicatorService(ClusterService clusterService) {
-        this.clusterService = clusterService;
+        super(clusterService);
     }
 
     @Override
@@ -45,10 +43,18 @@ public class InstanceHasMasterHealthIndicatorService implements HealthIndicatorS
     }
 
     @Override
-    public HealthIndicatorResult calculate(boolean includeDetails) {
+    protected HealthIndicatorResult doCalculate(ClusterState clusterState, boolean calculateDetails) {
+        return calculateResult(clusterState, calculateDetails);
+    }
 
-        DiscoveryNode coordinatingNode = clusterService.localNode();
-        ClusterState clusterState = clusterService.state();
+    @Override
+    protected HealthIndicatorResult doCalculateUnknown(ClusterState clusterState, boolean calculateDetails) {
+        return calculateResult(clusterState, calculateDetails);
+    }
+
+    HealthIndicatorResult calculateResult(ClusterState clusterState, boolean includeDetails) {
+
+        DiscoveryNode coordinatingNode = clusterState.nodes().getLocalNode();
         DiscoveryNodes nodes = clusterState.nodes();
         DiscoveryNode masterNode = nodes.getMasterNode();
 

--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/ShardsAvailabilityHealthIndicatorService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/ShardsAvailabilityHealthIndicatorService.java
@@ -8,6 +8,7 @@
 
 package org.elasticsearch.cluster.routing.allocation;
 
+import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.health.ClusterHealthStatus;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.metadata.Metadata;
@@ -21,7 +22,7 @@ import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.health.HealthIndicatorDetails;
 import org.elasticsearch.health.HealthIndicatorImpact;
 import org.elasticsearch.health.HealthIndicatorResult;
-import org.elasticsearch.health.HealthIndicatorService;
+import org.elasticsearch.health.HealthIndicatorServiceBase;
 import org.elasticsearch.health.HealthStatus;
 import org.elasticsearch.health.ImpactArea;
 import org.elasticsearch.health.SimpleHealthIndicatorDetails;
@@ -54,14 +55,12 @@ import static org.elasticsearch.health.ServerHealthComponents.DATA;
  * Each shard needs to be available and replicated in order to guarantee high availability and prevent data loses.
  * Shards allocated on nodes scheduled for restart (using nodes shutdown API) will not degrade this indicator health.
  */
-public class ShardsAvailabilityHealthIndicatorService implements HealthIndicatorService {
+public class ShardsAvailabilityHealthIndicatorService extends HealthIndicatorServiceBase {
 
     public static final String NAME = "shards_availability";
 
-    private final ClusterService clusterService;
-
     public ShardsAvailabilityHealthIndicatorService(ClusterService clusterService) {
-        this.clusterService = clusterService;
+        super(clusterService);
     }
 
     @Override
@@ -75,8 +74,7 @@ public class ShardsAvailabilityHealthIndicatorService implements HealthIndicator
     }
 
     @Override
-    public HealthIndicatorResult calculate(boolean includeDetails) {
-        var state = clusterService.state();
+    public HealthIndicatorResult doCalculate(ClusterState state, boolean includeDetails) {
         var shutdown = state.getMetadata().custom(NodesShutdownMetadata.TYPE, NodesShutdownMetadata.EMPTY);
         var status = new ShardAllocationStatus(state.getMetadata());
 

--- a/server/src/main/java/org/elasticsearch/health/HealthIndicatorServiceBase.java
+++ b/server/src/main/java/org/elasticsearch/health/HealthIndicatorServiceBase.java
@@ -19,7 +19,7 @@ import java.util.Collections;
 
 public abstract class HealthIndicatorServiceBase implements HealthIndicatorService {
 
-    static final String COULD_NOT_DETERMINE_HEALTH = "Health could not be determined";
+    static final String COULD_NOT_DETERMINE_HEALTH = "Health could not be determined. Try executing health api again.";
 
     private final ClusterService clusterService;
 

--- a/server/src/main/java/org/elasticsearch/health/HealthIndicatorServiceBase.java
+++ b/server/src/main/java/org/elasticsearch/health/HealthIndicatorServiceBase.java
@@ -61,7 +61,7 @@ public abstract class HealthIndicatorServiceBase implements HealthIndicatorServi
         };
     }
 
-    private static boolean stateIsKnown(ClusterState clusterState) {
+    static boolean stateIsKnown(ClusterState clusterState) {
         return clusterState.getBlocks().hasGlobalBlock(GatewayService.STATE_NOT_RECOVERED_BLOCK) == false
             && clusterState.getBlocks().hasGlobalBlockWithId(NoMasterBlockService.NO_MASTER_BLOCK_ID) == false;
     }

--- a/server/src/main/java/org/elasticsearch/health/HealthIndicatorServiceBase.java
+++ b/server/src/main/java/org/elasticsearch/health/HealthIndicatorServiceBase.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.health;
+
+import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.coordination.NoMasterBlockService;
+import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.gateway.GatewayService;
+import org.elasticsearch.xcontent.ToXContent;
+import org.elasticsearch.xcontent.XContentBuilder;
+
+import java.util.Collections;
+
+public abstract class HealthIndicatorServiceBase implements HealthIndicatorService {
+
+    static final String COULD_NOT_DETERMINE_HEALTH = "Health could not be determined";
+
+    private final ClusterService clusterService;
+
+    public HealthIndicatorServiceBase(ClusterService clusterService) {
+        this.clusterService = clusterService;
+    }
+
+    @Override
+    public HealthIndicatorResult calculate(boolean calculateDetails) {
+        ClusterState clusterState = clusterService.state();
+        if (stateIsKnown(clusterState)) {
+            return doCalculate(clusterState, calculateDetails);
+        } else {
+            return doCalculateUnknown(clusterState, calculateDetails);
+        }
+    }
+
+    protected abstract HealthIndicatorResult doCalculate(ClusterState clusterState, boolean calculateDetails);
+    protected HealthIndicatorResult doCalculateUnknown(ClusterState clusterState, boolean calculateDetails) {
+        return createIndicator(
+            HealthStatus.UNKNOWN,
+            COULD_NOT_DETERMINE_HEALTH,
+            calculateDetails ? unknownHealthDetails(clusterState) : HealthIndicatorDetails.EMPTY,
+            Collections.emptyList()
+        );
+    }
+
+    private HealthIndicatorDetails unknownHealthDetails(ClusterState clusterState) {
+        boolean hasMaster = clusterState.getBlocks().hasGlobalBlockWithId(NoMasterBlockService.NO_MASTER_BLOCK_ID) == false;
+        boolean clusterStateRecovered = clusterState.getBlocks().hasGlobalBlock(GatewayService.STATE_NOT_RECOVERED_BLOCK) == false;
+        return (XContentBuilder builder, ToXContent.Params params) -> {
+            builder.startObject();
+            builder.object("reason", xContentBuilder -> {
+                builder.field("has_master", hasMaster);
+                builder.field("cluster_state_recovered", clusterStateRecovered);
+            });
+            return builder.endObject();
+        };
+    }
+
+    private static boolean stateIsKnown(ClusterState clusterState) {
+        return clusterState.getBlocks().hasGlobalBlock(GatewayService.STATE_NOT_RECOVERED_BLOCK) == false &&
+            clusterState.getBlocks().hasGlobalBlockWithId(NoMasterBlockService.NO_MASTER_BLOCK_ID) == false;
+    }
+}

--- a/server/src/main/java/org/elasticsearch/health/HealthIndicatorServiceBase.java
+++ b/server/src/main/java/org/elasticsearch/health/HealthIndicatorServiceBase.java
@@ -38,6 +38,7 @@ public abstract class HealthIndicatorServiceBase implements HealthIndicatorServi
     }
 
     protected abstract HealthIndicatorResult doCalculate(ClusterState clusterState, boolean calculateDetails);
+
     protected HealthIndicatorResult doCalculateUnknown(ClusterState clusterState, boolean calculateDetails) {
         return createIndicator(
             HealthStatus.UNKNOWN,
@@ -61,7 +62,7 @@ public abstract class HealthIndicatorServiceBase implements HealthIndicatorServi
     }
 
     private static boolean stateIsKnown(ClusterState clusterState) {
-        return clusterState.getBlocks().hasGlobalBlock(GatewayService.STATE_NOT_RECOVERED_BLOCK) == false &&
-            clusterState.getBlocks().hasGlobalBlockWithId(NoMasterBlockService.NO_MASTER_BLOCK_ID) == false;
+        return clusterState.getBlocks().hasGlobalBlock(GatewayService.STATE_NOT_RECOVERED_BLOCK) == false
+            && clusterState.getBlocks().hasGlobalBlockWithId(NoMasterBlockService.NO_MASTER_BLOCK_ID) == false;
     }
 }

--- a/server/src/main/java/org/elasticsearch/health/HealthStatus.java
+++ b/server/src/main/java/org/elasticsearch/health/HealthStatus.java
@@ -17,8 +17,8 @@ import java.util.Locale;
 import java.util.stream.Stream;
 
 public enum HealthStatus implements Writeable {
-    UNKNOWN((byte) 0),
-    GREEN((byte) 1),
+    GREEN((byte) 0),
+    UNKNOWN((byte) 1),
     YELLOW((byte) 2),
     RED((byte) 3);
 
@@ -38,7 +38,7 @@ public enum HealthStatus implements Writeable {
     }
 
     public static HealthStatus merge(Stream<HealthStatus> statuses) {
-        return statuses.max(Comparator.comparing(HealthStatus::value)).orElse(UNKNOWN);
+        return statuses.max(Comparator.comparing(HealthStatus::value)).orElse(GREEN);
     }
 
     public String xContentValue() {

--- a/server/src/main/java/org/elasticsearch/health/HealthStatus.java
+++ b/server/src/main/java/org/elasticsearch/health/HealthStatus.java
@@ -17,9 +17,10 @@ import java.util.Locale;
 import java.util.stream.Stream;
 
 public enum HealthStatus implements Writeable {
-    GREEN((byte) 0),
-    YELLOW((byte) 1),
-    RED((byte) 2);
+    UNKNOWN((byte) 0),
+    GREEN((byte) 1),
+    YELLOW((byte) 2),
+    RED((byte) 3);
 
     private final byte value;
 
@@ -37,7 +38,7 @@ public enum HealthStatus implements Writeable {
     }
 
     public static HealthStatus merge(Stream<HealthStatus> statuses) {
-        return statuses.max(Comparator.comparing(HealthStatus::value)).orElse(GREEN);
+        return statuses.max(Comparator.comparing(HealthStatus::value)).orElse(UNKNOWN);
     }
 
     public String xContentValue() {

--- a/server/src/main/java/org/elasticsearch/node/Node.java
+++ b/server/src/main/java/org/elasticsearch/node/Node.java
@@ -98,6 +98,7 @@ import org.elasticsearch.gateway.GatewayModule;
 import org.elasticsearch.gateway.GatewayService;
 import org.elasticsearch.gateway.MetaStateService;
 import org.elasticsearch.gateway.PersistedClusterStateService;
+import org.elasticsearch.health.HealthIndicatorService;
 import org.elasticsearch.health.HealthService;
 import org.elasticsearch.http.HttpServerTransport;
 import org.elasticsearch.index.IndexSettingProviders;
@@ -1039,7 +1040,7 @@ public class Node implements Closeable {
     }
 
     private HealthService createHealthService(ClusterService clusterService) {
-        var serverHealthIndicatorServices = List.of(
+        List<HealthIndicatorService> serverHealthIndicatorServices = List.of(
             new InstanceHasMasterHealthIndicatorService(clusterService),
             new RepositoryIntegrityHealthIndicatorService(clusterService),
             new ShardsAvailabilityHealthIndicatorService(clusterService)

--- a/server/src/main/java/org/elasticsearch/snapshots/RepositoryIntegrityHealthIndicatorService.java
+++ b/server/src/main/java/org/elasticsearch/snapshots/RepositoryIntegrityHealthIndicatorService.java
@@ -8,12 +8,13 @@
 
 package org.elasticsearch.snapshots;
 
+import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.metadata.RepositoriesMetadata;
 import org.elasticsearch.cluster.metadata.RepositoryMetadata;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.health.HealthIndicatorDetails;
 import org.elasticsearch.health.HealthIndicatorResult;
-import org.elasticsearch.health.HealthIndicatorService;
+import org.elasticsearch.health.HealthIndicatorServiceBase;
 import org.elasticsearch.health.SimpleHealthIndicatorDetails;
 import org.elasticsearch.repositories.RepositoryData;
 
@@ -35,14 +36,12 @@ import static org.elasticsearch.health.ServerHealthComponents.SNAPSHOT;
  *
  * Corrupted repository most likely need to be manually cleaned and a new snapshot needs to be created from scratch.
  */
-public class RepositoryIntegrityHealthIndicatorService implements HealthIndicatorService {
+public class RepositoryIntegrityHealthIndicatorService extends HealthIndicatorServiceBase {
 
     public static final String NAME = "repository_integrity";
 
-    private final ClusterService clusterService;
-
     public RepositoryIntegrityHealthIndicatorService(ClusterService clusterService) {
-        this.clusterService = clusterService;
+        super(clusterService);
     }
 
     @Override
@@ -56,8 +55,8 @@ public class RepositoryIntegrityHealthIndicatorService implements HealthIndicato
     }
 
     @Override
-    public HealthIndicatorResult calculate(boolean includeDetails) {
-        var snapshotMetadata = clusterService.state().metadata().custom(RepositoriesMetadata.TYPE, RepositoriesMetadata.EMPTY);
+    public HealthIndicatorResult doCalculate(ClusterState clusterState, boolean includeDetails) {
+        var snapshotMetadata = clusterState.metadata().custom(RepositoriesMetadata.TYPE, RepositoriesMetadata.EMPTY);
 
         if (snapshotMetadata.repositories().isEmpty()) {
             return createIndicator(GREEN, "No repositories configured.", HealthIndicatorDetails.EMPTY, Collections.emptyList());

--- a/server/src/test/java/org/elasticsearch/health/HealthIndicatorServiceBaseTest.java
+++ b/server/src/test/java/org/elasticsearch/health/HealthIndicatorServiceBaseTest.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.health;
+
+import org.elasticsearch.cluster.ClusterName;
+import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.block.ClusterBlock;
+import org.elasticsearch.cluster.block.ClusterBlocks;
+import org.elasticsearch.cluster.coordination.NoMasterBlockService;
+import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.common.xcontent.XContentHelper;
+import org.elasticsearch.gateway.GatewayService;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xcontent.ToXContent;
+import org.elasticsearch.xcontent.XContentBuilder;
+import org.elasticsearch.xcontent.XContentFactory;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.sameInstance;
+import static org.hamcrest.Matchers.anEmptyMap;
+import static org.hamcrest.Matchers.hasKey;
+import static org.hamcrest.Matchers.not;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class HealthIndicatorServiceBaseTest extends ESTestCase {
+
+    private static final String TEST_INDICATOR_NAME = "test";
+    private static final String TEST_INDICATOR_COMPONENT = "testing";
+
+    /**
+     * Dummy implementation that returns a predefined result when state is known.
+     */
+    private static class TestBaseIndicatorService extends HealthIndicatorServiceBase {
+        private final HealthIndicatorResult result;
+
+        TestBaseIndicatorService(ClusterService clusterService, HealthIndicatorResult result) {
+            super(clusterService);
+            this.result = result;
+        }
+
+        @Override
+        public String name() {
+            return TEST_INDICATOR_NAME;
+        }
+
+        @Override
+        public String component() {
+            return TEST_INDICATOR_COMPONENT;
+        }
+
+        @Override
+        protected HealthIndicatorResult doCalculate(ClusterState clusterState, boolean calculateDetails) {
+            return result;
+        }
+    }
+
+    private static final HealthIndicatorResult SIMPLE_RESULT = new HealthIndicatorResult(
+        TEST_INDICATOR_NAME,
+        TEST_INDICATOR_COMPONENT,
+        HealthStatus.GREEN,
+        "",
+        HealthIndicatorDetails.EMPTY,
+        Collections.emptyList()
+    );
+
+    public void testDoCalculate() {
+        ClusterState clusterState = ClusterState.builder(new ClusterName("test-cluster")).build();
+        TestBaseIndicatorService indicator = createIndicator(clusterState, SIMPLE_RESULT);
+        HealthIndicatorResult actualResult = indicator.calculate(randomBoolean());
+        assertThat(actualResult, is(sameInstance(SIMPLE_RESULT)));
+    }
+
+    public void testDoCalculateUnknownNotRecovered() throws IOException {
+        runCalculateUnknownTest(GatewayService.STATE_NOT_RECOVERED_BLOCK, true, false);
+    }
+
+    public void testDoCalculateUnknownNoMaster() throws IOException {
+        runCalculateUnknownTest(
+            randomFrom(
+                NoMasterBlockService.NO_MASTER_BLOCK_ALL,
+                NoMasterBlockService.NO_MASTER_BLOCK_WRITES,
+                NoMasterBlockService.NO_MASTER_BLOCK_METADATA_WRITES
+            ),
+            false,
+            true
+        );
+    }
+
+    public void runCalculateUnknownTest(ClusterBlock block, boolean hasMaster, boolean clusterStateRecovered) throws IOException {
+        ClusterState clusterState = ClusterState.builder(new ClusterName("test-cluster"))
+            .blocks(ClusterBlocks.builder().addGlobalBlock(block))
+            .build();
+        boolean detailed = randomBoolean();
+
+        TestBaseIndicatorService indicator = createIndicator(clusterState, SIMPLE_RESULT);
+        HealthIndicatorResult actualResult = indicator.calculate(detailed);
+
+        assertThat(actualResult, is(not(sameInstance(SIMPLE_RESULT))));
+        assertThat(actualResult.name(), is(equalTo(TEST_INDICATOR_NAME)));
+        assertThat(actualResult.component(), is(equalTo(TEST_INDICATOR_COMPONENT)));
+        assertThat(actualResult.status(), is(equalTo(HealthStatus.UNKNOWN)));
+        assertThat(actualResult.summary(), is(equalTo(HealthIndicatorServiceBase.COULD_NOT_DETERMINE_HEALTH)));
+
+        if (detailed) {
+            HealthIndicatorDetails details = actualResult.details();
+            assertThat(details, not(sameInstance(HealthIndicatorDetails.EMPTY)));
+
+            XContentBuilder builder = XContentFactory.jsonBuilder().prettyPrint();
+            details.toXContent(builder, ToXContent.EMPTY_PARAMS);
+            Map<String, Object> detailMap = XContentHelper.convertToMap(BytesReference.bytes(builder), false, builder.contentType()).v2();
+            assertThat(detailMap, is(not(anEmptyMap())));
+            assertThat(detailMap, hasKey("reason"));
+
+            Map<String, Object> expectedReasons = new HashMap<>();
+            expectedReasons.put("has_master", hasMaster);
+            expectedReasons.put("cluster_state_recovered", clusterStateRecovered);
+            assertThat(detailMap.get("reason"), is(equalTo(expectedReasons)));
+        } else {
+            assertThat(actualResult.details(), sameInstance(HealthIndicatorDetails.EMPTY));
+        }
+    }
+
+    private static TestBaseIndicatorService createIndicator(ClusterState clusterState, HealthIndicatorResult result) {
+        var clusterService = mock(ClusterService.class);
+        when(clusterService.state()).thenReturn(clusterState);
+        return new TestBaseIndicatorService(clusterService, result);
+    }
+}

--- a/server/src/test/java/org/elasticsearch/health/HealthIndicatorServiceBaseTests.java
+++ b/server/src/test/java/org/elasticsearch/health/HealthIndicatorServiceBaseTests.java
@@ -36,7 +36,7 @@ import static org.hamcrest.Matchers.not;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-public class HealthIndicatorServiceBaseTest extends ESTestCase {
+public class HealthIndicatorServiceBaseTests extends ESTestCase {
 
     private static final String TEST_INDICATOR_NAME = "test";
     private static final String TEST_INDICATOR_COMPONENT = "testing";

--- a/server/src/test/java/org/elasticsearch/health/HealthStatusTests.java
+++ b/server/src/test/java/org/elasticsearch/health/HealthStatusTests.java
@@ -15,24 +15,29 @@ import java.util.stream.Stream;
 
 import static org.elasticsearch.health.HealthStatus.GREEN;
 import static org.elasticsearch.health.HealthStatus.RED;
+import static org.elasticsearch.health.HealthStatus.UNKNOWN;
 import static org.elasticsearch.health.HealthStatus.YELLOW;
 
 public class HealthStatusTests extends ESTestCase {
 
-    public void testAllGreenStatuses() {
-        assertEquals(GREEN, HealthStatus.merge(randomStatusesContaining(GREEN)));
+    public void testAllUnknownStatuses() {
+        assertEquals(UNKNOWN, HealthStatus.merge(randomStatusesContaining(UNKNOWN)));
+    }
+
+    public void testGreenStatus() {
+        assertEquals(GREEN, HealthStatus.merge(randomStatusesContaining(UNKNOWN, GREEN)));
     }
 
     public void testYellowStatus() {
-        assertEquals(YELLOW, HealthStatus.merge(randomStatusesContaining(GREEN, YELLOW)));
+        assertEquals(YELLOW, HealthStatus.merge(randomStatusesContaining(UNKNOWN, GREEN, YELLOW)));
     }
 
     public void testRedStatus() {
-        assertEquals(RED, HealthStatus.merge(randomStatusesContaining(GREEN, YELLOW, RED)));
+        assertEquals(RED, HealthStatus.merge(randomStatusesContaining(UNKNOWN, GREEN, YELLOW, RED)));
     }
 
     public void testEmpty() {
-        assertEquals(GREEN, HealthStatus.merge(Stream.empty()));
+        assertEquals(UNKNOWN, HealthStatus.merge(Stream.empty()));
     }
 
     private static Stream<HealthStatus> randomStatusesContaining(HealthStatus... statuses) {

--- a/server/src/test/java/org/elasticsearch/health/HealthStatusTests.java
+++ b/server/src/test/java/org/elasticsearch/health/HealthStatusTests.java
@@ -20,24 +20,24 @@ import static org.elasticsearch.health.HealthStatus.YELLOW;
 
 public class HealthStatusTests extends ESTestCase {
 
-    public void testAllUnknownStatuses() {
-        assertEquals(UNKNOWN, HealthStatus.merge(randomStatusesContaining(UNKNOWN)));
+    public void testAllGreenStatuses() {
+        assertEquals(GREEN, HealthStatus.merge(randomStatusesContaining(GREEN)));
     }
 
-    public void testGreenStatus() {
-        assertEquals(GREEN, HealthStatus.merge(randomStatusesContaining(UNKNOWN, GREEN)));
+    public void testUnknownStatus() {
+        assertEquals(UNKNOWN, HealthStatus.merge(randomStatusesContaining(GREEN, UNKNOWN)));
     }
 
     public void testYellowStatus() {
-        assertEquals(YELLOW, HealthStatus.merge(randomStatusesContaining(UNKNOWN, GREEN, YELLOW)));
+        assertEquals(YELLOW, HealthStatus.merge(randomStatusesContaining(GREEN, UNKNOWN, YELLOW)));
     }
 
     public void testRedStatus() {
-        assertEquals(RED, HealthStatus.merge(randomStatusesContaining(UNKNOWN, GREEN, YELLOW, RED)));
+        assertEquals(RED, HealthStatus.merge(randomStatusesContaining(GREEN, UNKNOWN, YELLOW, RED)));
     }
 
     public void testEmpty() {
-        assertEquals(UNKNOWN, HealthStatus.merge(Stream.empty()));
+        assertEquals(GREEN, HealthStatus.merge(Stream.empty()));
     }
 
     private static Stream<HealthStatus> randomStatusesContaining(HealthStatus... statuses) {

--- a/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/IlmHealthIndicatorService.java
+++ b/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/IlmHealthIndicatorService.java
@@ -7,10 +7,11 @@
 
 package org.elasticsearch.xpack.ilm;
 
+import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.health.HealthIndicatorDetails;
 import org.elasticsearch.health.HealthIndicatorResult;
-import org.elasticsearch.health.HealthIndicatorService;
+import org.elasticsearch.health.HealthIndicatorServiceBase;
 import org.elasticsearch.health.SimpleHealthIndicatorDetails;
 import org.elasticsearch.xpack.core.ilm.IndexLifecycleMetadata;
 import org.elasticsearch.xpack.core.ilm.OperationMode;
@@ -30,14 +31,12 @@ import static org.elasticsearch.health.ServerHealthComponents.DATA;
  *
  * ILM must be running to fix warning reported by this indicator.
  */
-public class IlmHealthIndicatorService implements HealthIndicatorService {
+public class IlmHealthIndicatorService extends HealthIndicatorServiceBase {
 
     public static final String NAME = "ilm";
 
-    private final ClusterService clusterService;
-
     public IlmHealthIndicatorService(ClusterService clusterService) {
-        this.clusterService = clusterService;
+        super(clusterService);
     }
 
     @Override
@@ -51,8 +50,8 @@ public class IlmHealthIndicatorService implements HealthIndicatorService {
     }
 
     @Override
-    public HealthIndicatorResult calculate(boolean includeDetails) {
-        var ilmMetadata = clusterService.state().metadata().custom(IndexLifecycleMetadata.TYPE, IndexLifecycleMetadata.EMPTY);
+    public HealthIndicatorResult doCalculate(ClusterState clusterState, boolean includeDetails) {
+        var ilmMetadata = clusterState.metadata().custom(IndexLifecycleMetadata.TYPE, IndexLifecycleMetadata.EMPTY);
         if (ilmMetadata.getPolicyMetadatas().isEmpty()) {
             return createIndicator(GREEN, "No policies configured", createDetails(includeDetails, ilmMetadata), Collections.emptyList());
         } else if (ilmMetadata.getOperationMode() != OperationMode.RUNNING) {

--- a/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/slm/SlmHealthIndicatorService.java
+++ b/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/slm/SlmHealthIndicatorService.java
@@ -7,10 +7,11 @@
 
 package org.elasticsearch.xpack.slm;
 
+import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.health.HealthIndicatorDetails;
 import org.elasticsearch.health.HealthIndicatorResult;
-import org.elasticsearch.health.HealthIndicatorService;
+import org.elasticsearch.health.HealthIndicatorServiceBase;
 import org.elasticsearch.health.SimpleHealthIndicatorDetails;
 import org.elasticsearch.xpack.core.ilm.OperationMode;
 import org.elasticsearch.xpack.core.slm.SnapshotLifecycleMetadata;
@@ -30,14 +31,12 @@ import static org.elasticsearch.health.ServerHealthComponents.SNAPSHOT;
  *
  * SLM must be running to fix warning reported by this indicator.
  */
-public class SlmHealthIndicatorService implements HealthIndicatorService {
+public class SlmHealthIndicatorService extends HealthIndicatorServiceBase {
 
     public static final String NAME = "slm";
 
-    private final ClusterService clusterService;
-
     public SlmHealthIndicatorService(ClusterService clusterService) {
-        this.clusterService = clusterService;
+        super(clusterService);
     }
 
     @Override
@@ -51,8 +50,8 @@ public class SlmHealthIndicatorService implements HealthIndicatorService {
     }
 
     @Override
-    public HealthIndicatorResult calculate(boolean includeDetails) {
-        var slmMetadata = clusterService.state().metadata().custom(SnapshotLifecycleMetadata.TYPE, SnapshotLifecycleMetadata.EMPTY);
+    public HealthIndicatorResult doCalculate(ClusterState clusterState, boolean includeDetails) {
+        var slmMetadata = clusterState.metadata().custom(SnapshotLifecycleMetadata.TYPE, SnapshotLifecycleMetadata.EMPTY);
         if (slmMetadata.getSnapshotConfigurations().isEmpty()) {
             return createIndicator(GREEN, "No policies configured", createDetails(includeDetails, slmMetadata), Collections.emptyList());
         } else if (slmMetadata.getOperationMode() != OperationMode.RUNNING) {


### PR DESCRIPTION
This PR adds an unknown status to indicators when the cluster state is not yet recovered or if there is no master node.

The "has master node" indicator logic is left unchanged to signal poor health if a node is not part of a cluster, but all other indicators that rely on cluster state will report a generic UNKNOWN health response.

The UNKNOWN health status is the second lowest priority when merging health statuses. If any other indicators have YELLOW, or RED results, those will be chosen for the overall health in the result. If all other indicators are GREEN, the resulting status will be UNKNOWN.

The generic UNKNOWN health status respects the calculateDetails flag, and will add metadata to the result indicating the reason it could not determine the state of the indicator. Right now, these reasons are simply "has_master" and "cluster_state_recovered".

An example result from a data node that has no elected master:
```json
{
    "status": "red",
    "cluster_name": "runTask",
    "components": {
        "cluster_coordination": {
            "status": "red",
            "indicators": {
                "instance_has_master": {
                    "status": "red",
                    "summary": "Health coordinating instance does not have a master node."
                }
            }
        },
        "data": {
            "status": "unknown",
            "indicators": {
                "shards_availability": {
                    "status": "unknown",
                    "summary": "Health could not be determined. Try executing health api again."
                },
                "ilm": {
                    "status": "unknown",
                    "summary": "Health could not be determined. Try executing health api again."
                }
            }
        },
        "snapshot": {
            "status": "unknown",
            "indicators": {
                "repository_integrity": {
                    "status": "unknown",
                    "summary": "Health could not be determined. Try executing health api again."
                },
                "slm": {
                    "status": "unknown",
                    "summary": "Health could not be determined. Try executing health api again."
                }
            }
        }
    }
}
```

And the drilldown into data/shards_availability:
```json
{
    "cluster_name": "runTask",
    "components": {
        "data": {
            "indicators": {
                "shards_availability": {
                    "status": "unknown",
                    "summary": "Health could not be determined. Try executing health api again.",
                    "details": {
                        "reason": {
                            "has_master": false,
                            "cluster_state_recovered": false
                        }
                    }
                }
            }
        }
    }
}
```

Resolves #84792