### PR TITLE
[8.2] [DOCS] Remove unnecessary link. (#86205)

### DIFF
--- a/docs/reference/ilm/actions/ilm-readonly.asciidoc
+++ b/docs/reference/ilm/actions/ilm-readonly.asciidoc
@@ -4,7 +4,8 @@
 
 Phases allowed: hot, warm, cold.
 
-Makes the index <<index-blocks-read-only,read-only>>.
+Makes the index read-only;
+writes and metadata changes are no longer allowed.
 
 To use the `readonly` action in the `hot` phase, the `rollover` action *must* be present.
 If no rollover action is configured, {ilm-init} will reject the policy.


### PR DESCRIPTION
Backports the following commits to 8.2:
 - [DOCS] Remove unnecessary link. (#86205)