### PR TITLE
Isolate console appender startup logic

### DIFF
--- a/qa/evil-tests/src/test/java/org/elasticsearch/common/logging/EvilLoggerConfigurationTests.java
+++ b/qa/evil-tests/src/test/java/org/elasticsearch/common/logging/EvilLoggerConfigurationTests.java
@@ -52,7 +52,7 @@ public class EvilLoggerConfigurationTests extends ESTestCase {
             final Path configDir = getDataPath("config");
             final Settings settings = Settings.builder().put(Environment.PATH_HOME_SETTING.getKey(), createTempDir().toString()).build();
             final Environment environment = new Environment(settings, configDir);
-            LogConfigurator.configure(environment);
+            LogConfigurator.configure(environment, true);
 
             {
                 final LoggerContext ctx = (LoggerContext) LogManager.getContext(false);
@@ -90,7 +90,7 @@ public class EvilLoggerConfigurationTests extends ESTestCase {
             .put("logger.level", level)
             .build();
         final Environment environment = new Environment(settings, configDir);
-        LogConfigurator.configure(environment);
+        LogConfigurator.configure(environment, true);
 
         final String loggerName = "test";
         final Logger logger = LogManager.getLogger(loggerName);
@@ -105,7 +105,7 @@ public class EvilLoggerConfigurationTests extends ESTestCase {
             .put("logger.test_resolve_order", "TRACE")
             .build();
         final Environment environment = new Environment(settings, configDir);
-        LogConfigurator.configure(environment);
+        LogConfigurator.configure(environment, true);
 
         // args should overwrite whatever is in the config
         final String loggerName = "test_resolve_order";
@@ -117,7 +117,7 @@ public class EvilLoggerConfigurationTests extends ESTestCase {
         final Path configDir = getDataPath("hierarchy");
         final Settings settings = Settings.builder().put(Environment.PATH_HOME_SETTING.getKey(), createTempDir().toString()).build();
         final Environment environment = new Environment(settings, configDir);
-        LogConfigurator.configure(environment);
+        LogConfigurator.configure(environment, true);
 
         assertThat(LogManager.getLogger("x").getLevel(), equalTo(Level.TRACE));
         assertThat(LogManager.getLogger("x.y").getLevel(), equalTo(Level.DEBUG));
@@ -133,7 +133,7 @@ public class EvilLoggerConfigurationTests extends ESTestCase {
         final Path configDir = getDataPath("does_not_exist");
         final Settings settings = Settings.builder().put(Environment.PATH_HOME_SETTING.getKey(), createTempDir().toString()).build();
         final Environment environment = new Environment(settings, configDir);
-        UserException e = expectThrows(UserException.class, () -> LogConfigurator.configure(environment));
+        UserException e = expectThrows(UserException.class, () -> LogConfigurator.configure(environment, true));
         assertThat(e, hasToString(containsString("no log4j2.properties found; tried")));
     }
 
@@ -149,7 +149,7 @@ public class EvilLoggerConfigurationTests extends ESTestCase {
             .put("logger.bar", barLevel.name())
             .build();
         final Environment environment = new Environment(settings, configDir);
-        LogConfigurator.configure(environment);
+        LogConfigurator.configure(environment, true);
 
         final LoggerContext ctx = (LoggerContext) LogManager.getContext(false);
         final Configuration config = ctx.getConfiguration();

--- a/qa/evil-tests/src/test/java/org/elasticsearch/common/logging/EvilLoggerTests.java
+++ b/qa/evil-tests/src/test/java/org/elasticsearch/common/logging/EvilLoggerTests.java
@@ -322,7 +322,7 @@ public class EvilLoggerTests extends ESTestCase {
             .build();
         // need to use custom config path so we can use a custom log4j2.properties file for the test
         final Environment environment = new Environment(mergedSettings, configDir);
-        LogConfigurator.configure(environment);
+        LogConfigurator.configure(environment, true);
     }
 
     private void assertLogLine(final String logLine, final Level level, final String location, final String message) {

--- a/qa/logging-config/src/test/java/org/elasticsearch/common/logging/JsonLoggerTests.java
+++ b/qa/logging-config/src/test/java/org/elasticsearch/common/logging/JsonLoggerTests.java
@@ -657,7 +657,7 @@ public class JsonLoggerTests extends ESTestCase {
             .build();
         // need to use custom config path so we can use a custom log4j2.properties file for the test
         final Environment environment = new Environment(mergedSettings, configDir);
-        LogConfigurator.configure(environment);
+        LogConfigurator.configure(environment, true);
     }
 
     private Matcher<JsonLogLine> logLine(String type, Level level, String nodeName, String component, String message) {

--- a/server/src/main/java/org/elasticsearch/bootstrap/Bootstrap.java
+++ b/server/src/main/java/org/elasticsearch/bootstrap/Bootstrap.java
@@ -10,9 +10,7 @@ package org.elasticsearch.bootstrap;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.core.Appender;
 import org.apache.logging.log4j.core.LoggerContext;
-import org.apache.logging.log4j.core.appender.ConsoleAppender;
 import org.apache.logging.log4j.core.config.Configurator;
 import org.apache.lucene.util.Constants;
 import org.apache.lucene.util.StringHelper;
@@ -25,7 +23,6 @@ import org.elasticsearch.common.PidFile;
 import org.elasticsearch.common.filesystem.FileSystemNatives;
 import org.elasticsearch.common.inject.CreationException;
 import org.elasticsearch.common.logging.LogConfigurator;
-import org.elasticsearch.common.logging.Loggers;
 import org.elasticsearch.common.network.IfConfig;
 import org.elasticsearch.common.settings.SecureSettings;
 import org.elasticsearch.common.settings.Settings;
@@ -310,7 +307,7 @@ final class Bootstrap {
 
         LogConfigurator.setNodeName(Node.NODE_NAME_SETTING.get(environment.settings()));
         try {
-            LogConfigurator.configure(environment);
+            LogConfigurator.configure(environment, quiet == false);
         } catch (IOException e) {
             throw new BootstrapException(e);
         }
@@ -323,16 +320,6 @@ final class Bootstrap {
         }
 
         try {
-            final boolean closeStandardStreams = (foreground == false) || quiet;
-            if (closeStandardStreams) {
-                final Logger rootLogger = LogManager.getRootLogger();
-                final Appender maybeConsoleAppender = Loggers.findAppender(rootLogger, ConsoleAppender.class);
-                if (maybeConsoleAppender != null) {
-                    Loggers.removeAppender(rootLogger, maybeConsoleAppender);
-                }
-                sysOutCloser.run();
-            }
-
             // fail if somebody replaced the lucene jars
             checkLucene();
 
@@ -366,41 +353,30 @@ final class Bootstrap {
 
             INSTANCE.start();
 
-            // We don't close stderr if `--quiet` is passed, because that
-            // hides fatal startup errors. For example, if Elasticsearch is
-            // running via systemd, the init script only specifies
-            // `--quiet`, not `-d`, so we want users to be able to see
-            // startup errors via journalctl.
             if (foreground == false) {
+                LogConfigurator.removeConsoleAppender();
+                sysOutCloser.run();
                 sysErrorCloser.run();
             }
 
         } catch (NodeValidationException | RuntimeException e) {
             // disable console logging, so user does not see the exception twice (jvm will show it already)
-            final Logger rootLogger = LogManager.getRootLogger();
-            final Appender maybeConsoleAppender = Loggers.findAppender(rootLogger, ConsoleAppender.class);
-            if (foreground && maybeConsoleAppender != null) {
-                Loggers.removeAppender(rootLogger, maybeConsoleAppender);
-            }
-            Logger logger = LogManager.getLogger(Bootstrap.class);
-            // HACK, it sucks to do this, but we will run users out of disk space otherwise
-            if (e instanceof CreationException) {
-                // guice: log the shortened exc to the log file
-                ByteArrayOutputStream os = new ByteArrayOutputStream();
-                PrintStream ps = new PrintStream(os, false, StandardCharsets.UTF_8);
-                new StartupException(e).printStackTrace(ps);
-                ps.flush();
-                logger.error("Guice Exception: {}", os.toString(StandardCharsets.UTF_8));
-            } else if (e instanceof NodeValidationException) {
-                logger.error("node validation exception\n{}", e.getMessage());
-            } else {
-                // full exception
-                logger.error("Exception", e);
-            }
-            // re-enable it if appropriate, so they can see any logging during the shutdown process
-            if (foreground && maybeConsoleAppender != null) {
-                Loggers.addAppender(rootLogger, maybeConsoleAppender);
-            }
+            LogConfigurator.logWithoutConsole(Bootstrap.class, logger -> {
+                // HACK, it sucks to do this, but we will run users out of disk space otherwise
+                if (e instanceof CreationException) {
+                    // guice: log the shortened exc to the log file
+                    ByteArrayOutputStream os = new ByteArrayOutputStream();
+                    PrintStream ps = new PrintStream(os, false, StandardCharsets.UTF_8);
+                    new StartupException(e).printStackTrace(ps);
+                    ps.flush();
+                    logger.error("Guice Exception: {}", os.toString(StandardCharsets.UTF_8));
+                } else if (e instanceof NodeValidationException) {
+                    logger.error("node validation exception\n{}", e.getMessage());
+                } else {
+                    // full exception
+                    logger.error("Exception", e);
+                }
+            });
 
             throw e;
         }


### PR DESCRIPTION
When bootstrapping Elasticsearch, the console appender is automatically
added by our log4j config. However, there are some cases where we want
to remove that appender. First, if --quiet is passed, we do not want to
log anything to it. Second, if we are daemonizing, then we want to close
the streams, so we need to remove it if it exists. Third, when huge
guice/startup exceptions occur, we log these only to the ES log file, so
we need to remove the appender temporarily.

This commit moves the logic for mucking with the console appender into
LogConfigurator. In the future this can be better isolated within
logging, perhaps even avoiding creating the console appender to begin
with when using --quiet, but for now this at least gets some log specific
logic out of bootstrap.

relates #85758