### PR TITLE
[7.17] Check if searchable snapshots cache pre-allocation is successful in Windows (#86192)

### DIFF
--- a/docs/changelog/86192.yaml
+++ b/docs/changelog/86192.yaml
@@ -1,0 +1,6 @@
+pr: 86192
+summary: Check if searchable snapshots cache pre-allocation is successful in Windows
+area: Snapshot/Restore
+type: bug
+issues:
+ - 85725

--- a/x-pack/plugin/searchable-snapshots/preallocate/src/main/java/org/elasticsearch/xpack/searchablesnapshots/preallocate/Preallocate.java
+++ b/x-pack/plugin/searchable-snapshots/preallocate/src/main/java/org/elasticsearch/xpack/searchablesnapshots/preallocate/Preallocate.java
@@ -73,9 +73,9 @@ public class Preallocate {
                 if (raf.length() != fileSize) {
                     logger.info("pre-allocating cache file [{}] ({}) using setLength method", cacheFile, new ByteSizeValue(fileSize));
                     raf.setLength(fileSize);
-                    success = true;
                     logger.debug("pre-allocated cache file [{}] using setLength method", cacheFile);
                 }
+                success = raf.length() == fileSize;
             } catch (final Exception e) {
                 logger.warn(new ParameterizedMessage("failed to pre-allocate cache file [{}] using setLength method", cacheFile), e);
                 throw e;


### PR DESCRIPTION
Backports the following commits to 7.17:
 - Check if searchable snapshots cache pre-allocation is successful in Windows (#86192)