### PR TITLE
Report size of bytesrefhash correctly after deserialization

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/util/BytesRefHash.java
+++ b/server/src/main/java/org/elasticsearch/common/util/BytesRefHash.java
@@ -84,6 +84,8 @@ public final class BytesRefHash extends AbstractHash implements Accountable {
             bytesRefs.get(i, spare);
             reset(rehash(spare.hashCode()), i);
         }
+
+        size = bytesRefs.size();
     }
 
     private BytesRefHash(BytesRefArray byteRefs, long capacity, float maxLoadFactor, BigArrays bigArrays) {

--- a/server/src/test/java/org/elasticsearch/common/util/BytesRefHashTests.java
+++ b/server/src/test/java/org/elasticsearch/common/util/BytesRefHashTests.java
@@ -325,7 +325,7 @@ public class BytesRefHashTests extends ESTestCase {
     private void assertAllIn(Set<String> strings, BytesRefHash hash) {
         BytesRefBuilder ref = new BytesRefBuilder();
         BytesRef scratch = new BytesRef();
-        long count = hash.size();
+        long count = strings.size();
         for (String string : strings) {
             ref.copyChars(string);
             long key = hash.add(ref.get()); // add again to check duplicates
@@ -345,6 +345,8 @@ public class BytesRefHashTests extends ESTestCase {
         BytesRef scratch = new BytesRef();
         int numberOfOriginalKeys = 0;
         int numberOfCopyKeys = 0;
+
+        assertEquals(original.size(), copy.size);
 
         // check that all keys of original can be found in the copy
         for (int i = 0; i < original.capacity(); ++i) {


### PR DESCRIPTION
After deserialization a bytesrefhash reported a size of `0` as the size wasn't set correctly.

relates #85826

Note:

 - the issue was missed in #85826, because of a test bug, see the fix for `assertAllIn`, it asserted equality of the _same_ value
 - technically this is a bug, but the PR is flagged as non-issue, because the code hasn't been part of a release