### PR TITLE
Remove args capture in sql cli

### DIFF
--- a/x-pack/plugin/sql/src/main/bin/elasticsearch-sql-cli
+++ b/x-pack/plugin/sql/src/main/bin/elasticsearch-sql-cli
@@ -5,8 +5,6 @@
 # 2.0; you may not use this file except in compliance with the Elastic License
 # 2.0.
 
-CLI_PARAMETERS="$@"
-
 source "`dirname "$0"`"/elasticsearch-env
 
 CLI_JAR=$(ls "$ES_HOME"/bin/elasticsearch-sql-cli-*.jar)
@@ -14,4 +12,4 @@ CLI_JAR=$(ls "$ES_HOME"/bin/elasticsearch-sql-cli-*.jar)
 exec \
   "$JAVA" \
   -jar "$CLI_JAR" \
-  $CLI_PARAMETERS
+  "$@"


### PR DESCRIPTION
The sql cli in Docker has a hack (#67737) to first capture the script arguments
before sourcing elasticsearch-env. This is because in Docker the env
script modified the arguments, adding in -E params based on the users
env settings. However, that Docker specific env logic was moved into
Java startup, so it is no longer necessary to capture the script args.

relates #85758