### PR TITLE
[8.2] Fix assertDefaultThreadContext enumerating allowed headers (#86262)

### DIFF
--- a/docs/changelog/86262.yaml
+++ b/docs/changelog/86262.yaml
@@ -1,0 +1,5 @@
+pr: 86262
+summary: Fix `assertDefaultThreadContext` enumerating allowed headers
+area: Infra/Core
+type: bug
+issues: []

--- a/server/src/main/java/org/elasticsearch/transport/Transports.java
+++ b/server/src/main/java/org/elasticsearch/transport/Transports.java
@@ -17,6 +17,11 @@ import java.util.Set;
 
 public enum Transports {
     ;
+    private static final Set<String> REQUEST_HEADERS_ALLOWED_ON_DEFAULT_THREAD_CONTEXT = Set.of(
+        Task.TRACE_ID,
+        Task.X_OPAQUE_ID_HTTP_HEADER,
+        Task.X_ELASTIC_PRODUCT_ORIGIN_HTTP_HEADER
+    );
 
     /** threads whose name is prefixed by this string will be considered network threads, even though they aren't */
     public static final String TEST_MOCK_TRANSPORT_THREAD_PREFIX = "__mock_network_thread";
@@ -54,10 +59,7 @@ public enum Transports {
 
     public static boolean assertDefaultThreadContext(ThreadContext threadContext) {
         assert threadContext.getRequestHeadersOnly().isEmpty()
-            || threadContext.getRequestHeadersOnly().keySet().equals(Set.of(Task.X_OPAQUE_ID_HTTP_HEADER))
-            || threadContext.getRequestHeadersOnly().keySet().equals(Set.of(Task.TRACE_ID))
-            || threadContext.getRequestHeadersOnly().keySet().equals(Set.of(Task.X_OPAQUE_ID_HTTP_HEADER, Task.TRACE_ID))
-            || threadContext.getRequestHeadersOnly().keySet().equals(Set.of(Task.X_ELASTIC_PRODUCT_ORIGIN_HTTP_HEADER))
+            || REQUEST_HEADERS_ALLOWED_ON_DEFAULT_THREAD_CONTEXT.containsAll(threadContext.getRequestHeadersOnly().keySet())
             : "expected empty context but was " + threadContext.getRequestHeadersOnly() + " on " + Thread.currentThread().getName();
         return true;
     }


### PR DESCRIPTION
Backports the following commits to 8.2:
 - Fix assertDefaultThreadContext enumerating allowed headers (#86262)