### PR TITLE
Fix assertDefaultThreadContext enumerating allowed headers (#86262)

### DIFF
--- a/docs/changelog/86262.yaml
+++ b/docs/changelog/86262.yaml
@@ -1,0 +1,5 @@
+pr: 86262
+summary: Fix `assertDefaultThreadContext` enumerating allowed headers
+area: Infra/Core
+type: bug
+issues: []

--- a/server/src/main/java/org/elasticsearch/transport/Transports.java
+++ b/server/src/main/java/org/elasticsearch/transport/Transports.java
@@ -9,14 +9,19 @@
 package org.elasticsearch.transport;
 
 import org.elasticsearch.common.util.concurrent.ThreadContext;
-import org.elasticsearch.core.Set;
 import org.elasticsearch.http.HttpServerTransport;
 import org.elasticsearch.tasks.Task;
 
 import java.util.Arrays;
+import java.util.Set;
 
 public enum Transports {
     ;
+    private static final Set<String> REQUEST_HEADERS_ALLOWED_ON_DEFAULT_THREAD_CONTEXT = org.elasticsearch.core.Set.of(
+        Task.TRACE_ID,
+        Task.X_OPAQUE_ID_HTTP_HEADER,
+        Task.X_ELASTIC_PRODUCT_ORIGIN_HTTP_HEADER
+    );
 
     /** threads whose name is prefixed by this string will be considered network threads, even though they aren't */
     public static final String TEST_MOCK_TRANSPORT_THREAD_PREFIX = "__mock_network_thread";
@@ -54,9 +59,7 @@ public enum Transports {
 
     public static boolean assertDefaultThreadContext(ThreadContext threadContext) {
         assert threadContext.getRequestHeadersOnly().isEmpty()
-            || threadContext.getRequestHeadersOnly().keySet().equals(Set.of(Task.X_OPAQUE_ID_HTTP_HEADER))
-            || threadContext.getRequestHeadersOnly().keySet().equals(Set.of(Task.TRACE_ID))
-            || threadContext.getRequestHeadersOnly().keySet().equals(Set.of(Task.X_OPAQUE_ID_HTTP_HEADER, Task.TRACE_ID))
+            || REQUEST_HEADERS_ALLOWED_ON_DEFAULT_THREAD_CONTEXT.containsAll(threadContext.getRequestHeadersOnly().keySet())
             : "expected empty context but was " + threadContext.getRequestHeadersOnly() + " on " + Thread.currentThread().getName();
         return true;
     }


### PR DESCRIPTION
Default thread context should has headers from a finite set or be empty.
The allowed headers are the ones that we want to "follow the request" so
that we can log them.
Previously the assertDefaultThreadContext was trying to enumerate combinations
of allowed headers.
Any combination with these headers is allowed, so we should simplify this method.

<!--
Thank you for your interest in and contributing to Elasticsearch! There
are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your
attention.
-->

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/elasticsearch/blob/master/CONTRIBUTING.md)?
- If submitting code, have you built your formula locally prior to submission with `gradle check`?
- If submitting code, is your pull request against master? Unless there is a good reason otherwise, we prefer pull requests against master and will backport as needed.
- If submitting code, have you checked that your submission is for an [OS and architecture that we support](https://www.elastic.co/support/matrix#show_os)?
- If you are submitting this code for a class then read our [policy](https://github.com/elastic/elasticsearch/blob/master/CONTRIBUTING.md#contributing-as-part-of-a-class) for that.
