### PR TITLE
[8.2] Add missing settings hmac_jwkset and hmac_key for JWT realm to security-settings.asciidoc (#86085)

### DIFF
--- a/docs/reference/settings/security-settings.asciidoc
+++ b/docs/reference/settings/security-settings.asciidoc
@@ -2018,7 +2018,7 @@ See <<authorization_realms>>.
 `claims.dn` {ess-icon}::
 (<<static-cluster-setting,Static>>)
 The name of the JWT claim that contains the user's Distinguished Name (DN),
-which uniquely identifies a user or group. 
+which uniquely identifies a user or group.
 // end::jwt-claims-dn-tag[]
 
 // tag::jwt-claims-pattern-dn-tag[]
@@ -2095,7 +2095,7 @@ the principal. Another example is `sub` which may not need a pattern setting.
 `client_authentication.type` {ess-icon}::
 (<<static-cluster-setting,Static>>)
 Specifies whether to use `shared_secret` or `none` to authenticate
-incoming client requests. If this value is `shared_secret`, the client is 
+incoming client requests. If this value is `shared_secret`, the client is
 authenticated using an HTTP request header that must match a pre-configured
 secret value. The client must provide this shared secret with every request in
 the `ES-Client-Authentication` header. If this value is `none`, then the
@@ -2104,7 +2104,7 @@ request header `ES-Client-Authentication` is ignored. Defaults to
 +
 Enabling client authentication is recommended. If JWT bearer
 tokens are shared with other clients or services, client authentication
-restricts which ones are allowed to submit those JWTs to {es}. 
+restricts which ones are allowed to submit those JWTs to {es}.
 // end::jwt-client-authentication-type-tag[]
 
 // tag::jwt-client-authentication-shared-secret-tag[]
@@ -2160,11 +2160,11 @@ JWTs can only be cached if client authentication is successful (or disabled).
 Uses the standard {es} <<time-units,time units>>. If clients use a different JWT
 for every request, set to `0` to disable the JWT cache. Defaults to `20m`.
 
-// tag::jwt-jwkset-path-tag[]
+// tag::jwt-pkc-jwkset-path-tag[]
 `pkc_jwkset_path` {ess-icon}::
 (<<static-cluster-setting,Static>>)
-The file path or URL to a JSON Web Key Set with the key material that the JWT
-Issuer uses for signing tokens and claims responses. If a path is provided,
+The file path or URL to a JSON Web Key Set with the public key material that
+the JWT Realm uses for verifying token signatures. If a path is provided,
 then it is resolved relative to the {es} configuration directory.
 If a URL is provided, then it must be either a `file` URL or an `https` URL.
 {es} automatically caches the retrieved JWK set to avoid unnecessary HTTP
@@ -2174,7 +2174,30 @@ rotated the signing keys.
 +
 File-based resources are polled at a frequency determined by the global {es}
 `resource.reload.interval.high` setting, which defaults to `5s`.
-// end::jwt-jwkset-path-tag[]
+// end::jwt-pkc-jwkset-path-tag[]
+
+// tag::jwt-hmac-jwkset-tag[]
+`hmac_jwkset` {ess-icon}::
+(<<secure-settings,Secure>>)
+Contents of a JSON Web Key Set (JWKS), including the secret key that the JWT
+realm uses to verify token signatures. This format supports multiple keys and
+optional attributes, and is preferred over the `hmac_key` setting. Cannot be
+used in conjunction with the `hmac_key` setting. Refer to
+<<jwt-realm-configuration,Configure {es} to use a JWT realm>>.
+// end::jwt-hmac-jwkset-tag[]
+
+// tag::jwt-hmac-key-tag[]
+`hmac_key` {ess-icon}::
+(<<secure-settings,Secure>>)
+Contents of a single JSON Web Key (JWK), including the secret key that the JWT
+realm uses to verify token signatures. This format only supports a single key
+without attributes, and cannot be used with the `hmac_jwkset` setting. This 
+format is compatible with OIDC. The HMAC key must be a UNICODE string, where 
+the key bytes are the UTF-8 encoding of the UNICODE string.
+The `hmac_jwkset` setting is preferred. Refer to
+<<jwt-realm-configuration,Configure {es} to use a JWT realm>>.
+
+// end::jwt-hmac-key-tag[]
 
 // tag::jwt-populate-user-metadata-tag[]
 `populate_user_metadata` {ess-icon}::

--- a/x-pack/docs/en/security/authentication/jwt-realm.asciidoc
+++ b/x-pack/docs/en/security/authentication/jwt-realm.asciidoc
@@ -95,7 +95,7 @@ Indicates that {es} should use the `RS256` or `HS256` signature algorithms to
 verify the signature of the JWT from the JWT issuer.
 
 `pkc_jwkset_path`::
-The file path to a JSON Web Key (JWK) set containing the public key material
+The file path to a JSON Web Key Set (JWKS) containing the public key material
 that the JWT realm uses to verify JWT signatures. If a path is provided,
 then it is resolved relative to the {es} configuration directory.
 
@@ -118,7 +118,7 @@ SHA-256 algorithm `HS256` in the example:
 ----
 bin/elasticsearch-keystore add-file xpack.security.authc.realms.jwt.jwt1.hmac_jwkset <path> <1>
 ----
-<1> Path to a JWK Set, which is a resource for a set of JSON-encoded secret keys.
+<1> Path to a JWKS, which is a resource for a set of JSON-encoded secret keys.
 The file can be removed after the contents are loaded into the {es} keystore setting.
 +
 [NOTE]


### PR DESCRIPTION
Backports the following commits to 8.2:
 - Add missing settings hmac_jwkset and hmac_key for JWT realm to security-settings.asciidoc (#86085)