### PR TITLE
[ML] Update the number of allocations per nlp process

### DIFF
--- a/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/MlMemoryIT.java
+++ b/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/MlMemoryIT.java
@@ -57,7 +57,6 @@ public class MlMemoryIT extends MlNativeDataFrameAnalyticsIntegTestCase {
         cleanUp();
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/ml-cpp/pull/2258")
     public void testMemoryStats() throws Exception {
 
         deployTrainedModel();

--- a/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/PyTorchModelIT.java
+++ b/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/PyTorchModelIT.java
@@ -251,7 +251,7 @@ public class PyTorchModelIT extends ESRestTestCase {
                 stats.get(0)
             );
             assertThat(responseMap.toString(), requiredNativeMemory, is(not(nullValue())));
-            assertThat(requiredNativeMemory, equalTo((int) (ByteSizeValue.ofMb(270).getBytes() + 2 * RAW_MODEL_SIZE)));
+            assertThat(requiredNativeMemory, equalTo((int) (ByteSizeValue.ofMb(240).getBytes() + 2 * RAW_MODEL_SIZE)));
 
             Response humanResponse = client().performRequest(new Request("GET", "/_ml/trained_models/" + modelId + "/_stats?human"));
             var humanResponseMap = entityAsMap(humanResponse);
@@ -273,7 +273,7 @@ public class PyTorchModelIT extends ESRestTestCase {
                 stringRequiredNativeMemory,
                 is(not(nullValue()))
             );
-            assertThat(stringRequiredNativeMemory, equalTo("270mb"));
+            assertThat(stringRequiredNativeMemory, equalTo("240mb"));
             stopDeployment(modelId);
         };
 

--- a/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/PyTorchModelIT.java
+++ b/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/PyTorchModelIT.java
@@ -8,7 +8,6 @@
 package org.elasticsearch.xpack.ml.integration;
 
 import org.apache.http.util.EntityUtils;
-import org.apache.lucene.tests.util.LuceneTestCase;
 import org.elasticsearch.client.Request;
 import org.elasticsearch.client.Response;
 import org.elasticsearch.client.ResponseException;
@@ -75,8 +74,6 @@ import static org.hamcrest.Matchers.nullValue;
  * torch.jit.save(traced_model, "simplemodel.pt")
  * ## End Python
  */
-
-@LuceneTestCase.AwaitsFix(bugUrl = "https://github.com/elastic/ml-cpp/pull/2258")
 public class PyTorchModelIT extends ESRestTestCase {
 
     private static final String BASIC_AUTH_VALUE_SUPER_USER = UsernamePasswordToken.basicAuthHeaderValue(

--- a/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/TestFeatureResetIT.java
+++ b/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/TestFeatureResetIT.java
@@ -165,7 +165,6 @@ public class TestFeatureResetIT extends MlNativeAutodetectIntegTestCase {
         assertThat(isResetMode(), is(false));
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/ml-cpp/pull/2258")
     public void testMLFeatureResetWithModelDeployment() throws Exception {
         createModelDeployment();
         client().execute(ResetFeatureStateAction.INSTANCE, new ResetFeatureStateRequest()).actionGet();

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/deployment/AbstractPyTorchAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/deployment/AbstractPyTorchAction.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.ml.inference.deployment;
+
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.message.ParameterizedMessage;
+import org.elasticsearch.ElasticsearchStatusException;
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.common.util.concurrent.AbstractRunnable;
+import org.elasticsearch.core.TimeValue;
+import org.elasticsearch.rest.RestStatus;
+import org.elasticsearch.threadpool.Scheduler;
+import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.xpack.core.ml.utils.ExceptionsHelper;
+import org.elasticsearch.xpack.ml.MachineLearning;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+abstract class AbstractPyTorchAction<T> extends AbstractRunnable {
+
+    private final String modelId;
+    private final long requestId;
+    private final TimeValue timeout;
+    private final Scheduler.Cancellable timeoutHandler;
+    private final DeploymentManager.ProcessContext processContext;
+    private final AtomicBoolean notified = new AtomicBoolean();
+
+    private final ActionListener<T> listener;
+
+    protected AbstractPyTorchAction(
+        String modelId,
+        long requestId,
+        TimeValue timeout,
+        DeploymentManager.ProcessContext processContext,
+        ThreadPool threadPool,
+        ActionListener<T> listener
+    ) {
+        this.modelId = modelId;
+        this.requestId = requestId;
+        this.timeout = timeout;
+        this.timeoutHandler = threadPool.schedule(
+            this::onTimeout,
+            ExceptionsHelper.requireNonNull(timeout, "timeout"),
+            MachineLearning.UTILITY_THREAD_POOL_NAME
+        );
+        this.processContext = processContext;
+        this.listener = listener;
+    }
+
+    void onTimeout() {
+        if (notified.compareAndSet(false, true)) {
+            processContext.getTimeoutCount().incrementAndGet();
+            processContext.getResultProcessor().ignoreResponseWithoutNotifying(String.valueOf(requestId));
+            listener.onFailure(
+                new ElasticsearchStatusException("timeout [{}] waiting for inference result", RestStatus.REQUEST_TIMEOUT, timeout)
+            );
+            return;
+        }
+        getLogger().debug("[{}] request [{}] received timeout after [{}] but listener already alerted", modelId, requestId, timeout);
+    }
+
+    void onSuccess(T result) {
+        timeoutHandler.cancel();
+        if (notified.compareAndSet(false, true)) {
+            listener.onResponse(result);
+            return;
+        }
+        getLogger().debug("[{}] request [{}] received inference response but listener already notified", modelId, requestId);
+    }
+
+    @Override
+    public void onFailure(Exception e) {
+        timeoutHandler.cancel();
+        if (notified.compareAndSet(false, true)) {
+            processContext.getResultProcessor().ignoreResponseWithoutNotifying(String.valueOf(requestId));
+            listener.onFailure(e);
+            return;
+        }
+        getLogger().debug(
+            () -> new ParameterizedMessage("[{}] request [{}] received failure but listener already notified", modelId, requestId),
+            e
+        );
+    }
+
+    protected void onFailure(String errorMessage) {
+        onFailure(new ElasticsearchStatusException("Error in inference process: [" + errorMessage + "]", RestStatus.INTERNAL_SERVER_ERROR));
+    }
+
+    boolean isNotified() {
+        return notified.get();
+    }
+
+    long getRequestId() {
+        return requestId;
+    }
+
+    String getModelId() {
+        return modelId;
+    }
+
+    DeploymentManager.ProcessContext getProcessContext() {
+        return processContext;
+    }
+
+    protected abstract Logger getLogger();
+}

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/deployment/ControlMessagePyTorchAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/deployment/ControlMessagePyTorchAction.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.ml.inference.deployment;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.message.ParameterizedMessage;
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.core.TimeValue;
+import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.xcontent.XContentBuilder;
+import org.elasticsearch.xcontent.XContentFactory;
+import org.elasticsearch.xpack.core.ml.utils.ExceptionsHelper;
+import org.elasticsearch.xpack.ml.inference.pytorch.results.PyTorchResult;
+import org.elasticsearch.xpack.ml.inference.pytorch.results.ThreadSettings;
+
+import java.io.IOException;
+
+class ControlMessagePyTorchAction extends AbstractPyTorchAction<ThreadSettings> {
+
+    private static final Logger logger = LogManager.getLogger(InferencePyTorchAction.class);
+
+    private final int numAllocationThreads;
+
+    private enum ControlMessageTypes {
+        AllocationThreads
+    };
+
+    ControlMessagePyTorchAction(
+        String modelId,
+        long requestId,
+        int numAllocationThreads,
+        TimeValue timeout,
+        DeploymentManager.ProcessContext processContext,
+        ThreadPool threadPool,
+        ActionListener<ThreadSettings> listener
+    ) {
+        super(modelId, requestId, timeout, processContext, threadPool, listener);
+        this.numAllocationThreads = numAllocationThreads;
+    }
+
+    @Override
+    protected void doRun() throws Exception {
+        if (isNotified()) {
+            // Should not execute request as it has already timed out while waiting in the queue
+            logger.debug(
+                () -> new ParameterizedMessage(
+                    "[{}] skipping control message on request [{}] as it has timed out",
+                    getModelId(),
+                    getRequestId()
+                )
+            );
+            return;
+        }
+
+        final String requestIdStr = String.valueOf(getRequestId());
+        try {
+            var message = buildControlMessage(requestIdStr, numAllocationThreads);
+
+            getProcessContext().getResultProcessor()
+                .registerRequest(requestIdStr, ActionListener.wrap(this::processResponse, this::onFailure));
+
+            getProcessContext().getProcess().get().writeInferenceRequest(message);
+        } catch (IOException e) {
+            logger.error(new ParameterizedMessage("[{}] error writing control message to the inference process", getModelId()), e);
+            onFailure(ExceptionsHelper.serverError("Error writing control message to the inference process", e));
+        } catch (Exception e) {
+            onFailure(e);
+        }
+    }
+
+    public static BytesReference buildControlMessage(String requestId, int numAllocationThreads) throws IOException {
+        XContentBuilder builder = XContentFactory.jsonBuilder();
+        builder.startObject();
+        builder.field("request_id", requestId);
+        builder.field("control", ControlMessageTypes.AllocationThreads.ordinal());
+        builder.field("num_allocations", numAllocationThreads);
+        builder.endObject();
+
+        // BytesReference.bytes closes the builder
+        return BytesReference.bytes(builder);
+    }
+
+    public void processResponse(PyTorchResult result) {
+        if (result.isError()) {
+            onFailure(result.errorResult().error());
+            return;
+        }
+        onSuccess(result.threadSettings());
+    }
+
+    @Override
+    protected Logger getLogger() {
+        return logger;
+    }
+
+}

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/deployment/DeploymentManager.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/deployment/DeploymentManager.java
@@ -11,20 +11,16 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.message.ParameterizedMessage;
 import org.apache.lucene.util.SetOnce;
-import org.elasticsearch.ElasticsearchStatusException;
 import org.elasticsearch.ResourceNotFoundException;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.search.SearchAction;
 import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.client.internal.Client;
-import org.elasticsearch.common.util.concurrent.AbstractRunnable;
 import org.elasticsearch.common.util.concurrent.EsRejectedExecutionException;
 import org.elasticsearch.common.xcontent.LoggingDeprecationHandler;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.index.query.IdsQueryBuilder;
-import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.search.SearchHit;
-import org.elasticsearch.threadpool.Scheduler;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.xcontent.NamedXContentRegistry;
 import org.elasticsearch.xcontent.XContentFactory;
@@ -45,26 +41,22 @@ import org.elasticsearch.xpack.core.ml.utils.ExceptionsHelper;
 import org.elasticsearch.xpack.ml.MachineLearning;
 import org.elasticsearch.xpack.ml.inference.nlp.NlpTask;
 import org.elasticsearch.xpack.ml.inference.nlp.Vocabulary;
-import org.elasticsearch.xpack.ml.inference.nlp.tokenizers.TokenizationResult;
 import org.elasticsearch.xpack.ml.inference.pytorch.process.PyTorchProcess;
 import org.elasticsearch.xpack.ml.inference.pytorch.process.PyTorchProcessFactory;
 import org.elasticsearch.xpack.ml.inference.pytorch.process.PyTorchResultProcessor;
 import org.elasticsearch.xpack.ml.inference.pytorch.process.PyTorchStateStreamer;
-import org.elasticsearch.xpack.ml.inference.pytorch.results.PyTorchInferenceResult;
+import org.elasticsearch.xpack.ml.inference.pytorch.results.ThreadSettings;
 import org.elasticsearch.xpack.ml.job.process.ProcessWorkerExecutorService;
 
 import java.io.IOException;
 import java.io.InputStream;
 import java.time.Instant;
-import java.util.Collections;
-import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Consumer;
@@ -114,8 +106,8 @@ public class DeploymentManager {
                 stats.errorCount(),
                 processContext.rejectedExecutionCount.intValue(),
                 processContext.timeoutCount.intValue(),
-                processContext.inferenceThreads,
-                processContext.modelThreads,
+                processContext.numThreadsPerAllocation,
+                processContext.numAllocations,
                 stats.peakThroughput(),
                 stats.recentStats().requestsProcessed(),
                 stats.recentStats().avgInferenceTime()
@@ -247,25 +239,14 @@ public class DeploymentManager {
         TimeValue timeout,
         ActionListener<InferenceResults> listener
     ) {
-        if (task.isStopped()) {
-            listener.onFailure(
-                ExceptionsHelper.conflictStatusException(
-                    "[{}] is stopping or stopped due to [{}]",
-                    task.getModelId(),
-                    task.stoppedReason().orElse("")
-                )
-            );
-            return;
-        }
-
-        ProcessContext processContext = processContextByAllocation.get(task.getId());
+        var processContext = getProcessContext(task, listener::onFailure);
         if (processContext == null) {
-            listener.onFailure(ExceptionsHelper.conflictStatusException("[{}] process context missing", task.getModelId()));
+            // error reporting handled in the call to getProcessContext
             return;
         }
 
         final long requestId = requestIdCounter.getAndIncrement();
-        InferenceAction inferenceAction = new InferenceAction(
+        InferencePyTorchAction inferenceAction = new InferencePyTorchAction(
             task.getModelId(),
             requestId,
             timeout,
@@ -285,163 +266,57 @@ public class DeploymentManager {
         }
     }
 
-    static class InferenceAction extends AbstractRunnable implements ActionListener<InferenceResults> {
-        private final String modelId;
-        private final long requestId;
-        private final TimeValue timeout;
-        private final Scheduler.Cancellable timeoutHandler;
-        private final ProcessContext processContext;
-        private final InferenceConfig config;
-        private final Map<String, Object> doc;
-        private final ActionListener<InferenceResults> listener;
-        private final AtomicBoolean notified = new AtomicBoolean();
+    public void updateNumAllocations(
+        TrainedModelDeploymentTask task,
+        int numAllocationThreads,
+        TimeValue timeout,
+        ActionListener<ThreadSettings> listener
+    ) {
+        var processContext = getProcessContext(task, listener::onFailure);
+        if (processContext == null) {
+            // error reporting handled in the call to getProcessContext
+            return;
+        }
 
-        InferenceAction(
-            String modelId,
-            long requestId,
-            TimeValue timeout,
-            ProcessContext processContext,
-            InferenceConfig config,
-            Map<String, Object> doc,
-            ThreadPool threadPool,
-            ActionListener<InferenceResults> listener
-        ) {
-            this.modelId = modelId;
-            this.requestId = requestId;
-            this.timeout = timeout;
-            this.processContext = processContext;
-            this.config = config;
-            this.doc = doc;
-            this.listener = listener;
-            this.timeoutHandler = threadPool.schedule(
-                this::onTimeout,
-                ExceptionsHelper.requireNonNull(timeout, "timeout"),
-                MachineLearning.UTILITY_THREAD_POOL_NAME
+        final long requestId = requestIdCounter.getAndIncrement();
+        ControlMessagePyTorchAction controlMessageAction = new ControlMessagePyTorchAction(
+            task.getModelId(),
+            requestId,
+            numAllocationThreads,
+            timeout,
+            processContext,
+            threadPool,
+            listener
+        );
+        try {
+            processContext.getExecutorService().execute(controlMessageAction);
+        } catch (EsRejectedExecutionException e) {
+            processContext.getRejectedExecutionCount().incrementAndGet();
+            controlMessageAction.onFailure(e);
+        } catch (Exception e) {
+            controlMessageAction.onFailure(e);
+        }
+    }
+
+    private ProcessContext getProcessContext(TrainedModelDeploymentTask task, Consumer<Exception> errorConsumer) {
+        if (task.isStopped()) {
+            errorConsumer.accept(
+                ExceptionsHelper.conflictStatusException(
+                    "[{}] is stopping or stopped due to [{}]",
+                    task.getModelId(),
+                    task.stoppedReason().orElse("")
+                )
             );
+            return null;
         }
 
-        void onTimeout() {
-            if (notified.compareAndSet(false, true)) {
-                processContext.getTimeoutCount().incrementAndGet();
-                processContext.getResultProcessor().ignoreResponseWithoutNotifying(String.valueOf(requestId));
-                listener.onFailure(
-                    new ElasticsearchStatusException("timeout [{}] waiting for inference result", RestStatus.REQUEST_TIMEOUT, timeout)
-                );
-                return;
-            }
-            logger.debug("[{}] request [{}] received timeout after [{}] but listener already alerted", modelId, requestId, timeout);
+        ProcessContext processContext = processContextByAllocation.get(task.getId());
+        if (processContext == null) {
+            errorConsumer.accept(ExceptionsHelper.conflictStatusException("[{}] process context missing", task.getModelId()));
+            return null;
         }
 
-        @Override
-        public void onResponse(InferenceResults inferenceResults) {
-            onSuccess(inferenceResults);
-        }
-
-        void onSuccess(InferenceResults inferenceResults) {
-            timeoutHandler.cancel();
-            if (notified.compareAndSet(false, true)) {
-                listener.onResponse(inferenceResults);
-                return;
-            }
-            logger.debug("[{}] request [{}] received inference response but listener already notified", modelId, requestId);
-        }
-
-        @Override
-        public void onFailure(Exception e) {
-            timeoutHandler.cancel();
-            if (notified.compareAndSet(false, true)) {
-                processContext.getResultProcessor().ignoreResponseWithoutNotifying(String.valueOf(requestId));
-                listener.onFailure(e);
-                return;
-            }
-            logger.debug(
-                () -> new ParameterizedMessage("[{}] request [{}] received failure but listener already notified", modelId, requestId),
-                e
-            );
-        }
-
-        @Override
-        protected void doRun() throws Exception {
-            if (notified.get()) {
-                // Should not execute request as it has already timed out while waiting in the queue
-                logger.debug(
-                    () -> new ParameterizedMessage("[{}] skipping inference on request [{}] as it has timed out", modelId, requestId)
-                );
-                return;
-            }
-
-            final String requestIdStr = String.valueOf(requestId);
-            try {
-                // The request builder expect a list of inputs which are then batched.
-                // TODO batching was implemented for expected use-cases such as zero-shot
-                // classification but is not used here.
-                List<String> text = Collections.singletonList(NlpTask.extractInput(processContext.modelInput.get(), doc));
-                NlpTask.Processor processor = processContext.nlpTaskProcessor.get();
-                processor.validateInputs(text);
-                assert config instanceof NlpConfig;
-                NlpConfig nlpConfig = (NlpConfig) config;
-                NlpTask.Request request = processor.getRequestBuilder(nlpConfig)
-                    .buildRequest(text, requestIdStr, nlpConfig.getTokenization().getTruncate(), nlpConfig.getTokenization().getSpan());
-                logger.debug(() -> "Inference Request " + request.processInput().utf8ToString());
-                if (request.tokenization().anyTruncated()) {
-                    logger.debug("[{}] [{}] input truncated", modelId, requestId);
-                }
-                processContext.getResultProcessor()
-                    .registerRequest(
-                        requestIdStr,
-                        ActionListener.wrap(
-                            inferenceResult -> processResult(
-                                inferenceResult,
-                                processContext,
-                                request.tokenization(),
-                                processor.getResultProcessor((NlpConfig) config),
-                                this
-                            ),
-                            this::onFailure
-                        )
-                    );
-                processContext.process.get().writeInferenceRequest(request.processInput());
-            } catch (IOException e) {
-                logger.error(new ParameterizedMessage("[{}] error writing to inference process", processContext.task.getModelId()), e);
-                onFailure(ExceptionsHelper.serverError("Error writing to inference process", e));
-            } catch (Exception e) {
-                onFailure(e);
-            }
-        }
-
-        private void processResult(
-            PyTorchInferenceResult inferenceResult,
-            ProcessContext context,
-            TokenizationResult tokenization,
-            NlpTask.ResultProcessor inferenceResultsProcessor,
-            ActionListener<InferenceResults> resultsListener
-        ) {
-            if (inferenceResult.isError()) {
-                resultsListener.onFailure(
-                    new ElasticsearchStatusException(
-                        "Error in inference process: [" + inferenceResult.getError() + "]",
-                        RestStatus.INTERNAL_SERVER_ERROR
-                    )
-                );
-                return;
-            }
-
-            logger.debug(() -> new ParameterizedMessage("[{}] retrieved result for request [{}]", context.task.getModelId(), requestId));
-            if (notified.get()) {
-                // The request has timed out. No need to spend cycles processing the result.
-                logger.debug(
-                    () -> new ParameterizedMessage(
-                        "[{}] skipping result processing for request [{}] as the request has timed out",
-                        context.task.getModelId(),
-                        requestId
-                    )
-                );
-                return;
-            }
-            InferenceResults results = inferenceResultsProcessor.processResult(tokenization, inferenceResult);
-            logger.debug(() -> new ParameterizedMessage("[{}] processed result for request [{}]", context.task.getModelId(), requestId));
-            resultsListener.onResponse(results);
-        }
+        return processContext;
     }
 
     class ProcessContext {
@@ -454,16 +329,16 @@ public class DeploymentManager {
         private final PyTorchStateStreamer stateStreamer;
         private final ProcessWorkerExecutorService executorService;
         private volatile Instant startTime;
-        private volatile Integer inferenceThreads;
-        private volatile Integer modelThreads;
+        private volatile Integer numThreadsPerAllocation;
+        private volatile Integer numAllocations;
         private final AtomicInteger rejectedExecutionCount = new AtomicInteger();
         private final AtomicInteger timeoutCount = new AtomicInteger();
 
         ProcessContext(TrainedModelDeploymentTask task, ExecutorService executorService) {
             this.task = Objects.requireNonNull(task);
             resultProcessor = new PyTorchResultProcessor(task.getModelId(), threadSettings -> {
-                this.inferenceThreads = threadSettings.inferenceThreads();
-                this.modelThreads = threadSettings.modelThreads();
+                this.numThreadsPerAllocation = threadSettings.numThreadsPerAllocation();
+                this.numAllocations = threadSettings.numAllocations();
             });
             this.stateStreamer = new PyTorchStateStreamer(client, executorService, xContentRegistry);
             this.executorService = new ProcessWorkerExecutorService(
@@ -536,6 +411,18 @@ public class DeploymentManager {
         // accessor used for mocking in tests
         AtomicInteger getRejectedExecutionCount() {
             return rejectedExecutionCount;
+        }
+
+        SetOnce<TrainedModelInput> getModelInput() {
+            return modelInput;
+        }
+
+        SetOnce<PyTorchProcess> getProcess() {
+            return process;
+        }
+
+        SetOnce<NlpTask.Processor> getNlpTaskProcessor() {
+            return nlpTaskProcessor;
         }
     }
 }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/deployment/DeploymentManager.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/deployment/DeploymentManager.java
@@ -256,14 +256,8 @@ public class DeploymentManager {
             threadPool,
             listener
         );
-        try {
-            processContext.getExecutorService().execute(inferenceAction);
-        } catch (EsRejectedExecutionException e) {
-            processContext.getRejectedExecutionCount().incrementAndGet();
-            inferenceAction.onFailure(e);
-        } catch (Exception e) {
-            inferenceAction.onFailure(e);
-        }
+
+        executePyTorchAction(processContext, inferenceAction);
     }
 
     public void updateNumAllocations(
@@ -288,13 +282,18 @@ public class DeploymentManager {
             threadPool,
             listener
         );
+
+        executePyTorchAction(processContext, controlMessageAction);
+    }
+
+    public void executePyTorchAction(ProcessContext processContext, AbstractPyTorchAction<?> action) {
         try {
-            processContext.getExecutorService().execute(controlMessageAction);
+            processContext.getExecutorService().execute(action);
         } catch (EsRejectedExecutionException e) {
             processContext.getRejectedExecutionCount().incrementAndGet();
-            controlMessageAction.onFailure(e);
+            action.onFailure(e);
         } catch (Exception e) {
-            controlMessageAction.onFailure(e);
+            action.onFailure(e);
         }
     }
 

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/deployment/InferencePyTorchAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/deployment/InferencePyTorchAction.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.ml.inference.deployment;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.message.ParameterizedMessage;
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.core.TimeValue;
+import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.xpack.core.ml.inference.results.InferenceResults;
+import org.elasticsearch.xpack.core.ml.inference.trainedmodel.InferenceConfig;
+import org.elasticsearch.xpack.core.ml.inference.trainedmodel.NlpConfig;
+import org.elasticsearch.xpack.core.ml.utils.ExceptionsHelper;
+import org.elasticsearch.xpack.ml.inference.nlp.NlpTask;
+import org.elasticsearch.xpack.ml.inference.nlp.tokenizers.TokenizationResult;
+import org.elasticsearch.xpack.ml.inference.pytorch.results.PyTorchResult;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+class InferencePyTorchAction extends AbstractPyTorchAction<InferenceResults> {
+
+    private static final Logger logger = LogManager.getLogger(InferencePyTorchAction.class);
+
+    private final InferenceConfig config;
+    private final Map<String, Object> doc;
+
+    InferencePyTorchAction(
+        String modelId,
+        long requestId,
+        TimeValue timeout,
+        DeploymentManager.ProcessContext processContext,
+        InferenceConfig config,
+        Map<String, Object> doc,
+        ThreadPool threadPool,
+        ActionListener<InferenceResults> listener
+    ) {
+        super(modelId, requestId, timeout, processContext, threadPool, listener);
+        this.config = config;
+        this.doc = doc;
+    }
+
+    @Override
+    protected void doRun() throws Exception {
+        if (isNotified()) {
+            // Should not execute request as it has already timed out while waiting in the queue
+            logger.debug(
+                () -> new ParameterizedMessage("[{}] skipping inference on request [{}] as it has timed out", getModelId(), getRequestId())
+            );
+            return;
+        }
+
+        final String requestIdStr = String.valueOf(getRequestId());
+        try {
+            // The request builder expect a list of inputs which are then batched.
+            // TODO batching was implemented for expected use-cases such as zero-shot
+            // classification but is not used here.
+            List<String> text = Collections.singletonList(NlpTask.extractInput(getProcessContext().getModelInput().get(), doc));
+            NlpTask.Processor processor = getProcessContext().getNlpTaskProcessor().get();
+            processor.validateInputs(text);
+            assert config instanceof NlpConfig;
+            NlpConfig nlpConfig = (NlpConfig) config;
+            NlpTask.Request request = processor.getRequestBuilder(nlpConfig)
+                .buildRequest(text, requestIdStr, nlpConfig.getTokenization().getTruncate(), nlpConfig.getTokenization().getSpan());
+            logger.debug(() -> "Inference Request " + request.processInput().utf8ToString());
+            if (request.tokenization().anyTruncated()) {
+                logger.debug("[{}] [{}] input truncated", getModelId(), getRequestId());
+            }
+
+            getProcessContext().getResultProcessor()
+                .registerRequest(
+                    requestIdStr,
+                    ActionListener.wrap(
+                        result -> processResult(result, request.tokenization(), processor.getResultProcessor(nlpConfig)),
+                        this::onFailure
+                    )
+                );
+            getProcessContext().getProcess().get().writeInferenceRequest(request.processInput());
+        } catch (IOException e) {
+            logger.error(new ParameterizedMessage("[{}] error writing to inference process", getModelId()), e);
+            onFailure(ExceptionsHelper.serverError("Error writing to inference process", e));
+        } catch (Exception e) {
+            onFailure(e);
+        }
+    }
+
+    private void processResult(
+        PyTorchResult pyTorchResult,
+        TokenizationResult tokenization,
+        NlpTask.ResultProcessor inferenceResultsProcessor
+    ) {
+        if (pyTorchResult.isError()) {
+            onFailure(pyTorchResult.errorResult().error());
+            return;
+        }
+
+        logger.debug(() -> new ParameterizedMessage("[{}] retrieved result for request [{}]", getModelId(), getRequestId()));
+        if (isNotified()) {
+            // The request has timed out. No need to spend cycles processing the result.
+            logger.debug(
+                () -> new ParameterizedMessage(
+                    "[{}] skipping result processing for request [{}] as the request has timed out",
+                    getModelId(),
+                    getRequestId()
+                )
+            );
+            return;
+        }
+        InferenceResults results = inferenceResultsProcessor.processResult(tokenization, pyTorchResult.inferenceResult());
+        logger.debug(() -> new ParameterizedMessage("[{}] processed result for request [{}]", getModelId(), getRequestId()));
+        onSuccess(results);
+    }
+
+    @Override
+    protected Logger getLogger() {
+        return logger;
+    }
+}

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/pytorch/process/PyTorchBuilder.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/pytorch/process/PyTorchBuilder.java
@@ -21,8 +21,8 @@ public class PyTorchBuilder {
     private static final String PROCESS_PATH = "./" + PROCESS_NAME;
 
     private static final String LICENSE_KEY_VALIDATED_ARG = "--validElasticLicenseKeyConfirmed=";
-    private static final String INFERENCE_THREADS_ARG = "--inferenceThreads=";
-    private static final String MODEL_THREADS_ARG = "--modelThreads=";
+    private static final String NUM_THREADS_PER_ALLOCATION_ARG = "--numThreadsPerAllocation=";
+    private static final String NUM_ALLOCATIONS_ARG = "--numAllocations=";
 
     private final NativeController nativeController;
     private final ProcessPipes processPipes;
@@ -49,8 +49,8 @@ public class PyTorchBuilder {
         // License was validated when the trained model was started
         command.add(LICENSE_KEY_VALIDATED_ARG + true);
 
-        command.add(INFERENCE_THREADS_ARG + inferenceThreads);
-        command.add(MODEL_THREADS_ARG + modelThreads);
+        command.add(NUM_THREADS_PER_ALLOCATION_ARG + inferenceThreads);
+        command.add(NUM_ALLOCATIONS_ARG + modelThreads);
 
         return command;
     }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/pytorch/process/PyTorchResultProcessor.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/pytorch/process/PyTorchResultProcessor.java
@@ -13,6 +13,7 @@ import org.apache.logging.log4j.message.ParameterizedMessage;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.xpack.core.ml.utils.Intervals;
+import org.elasticsearch.xpack.ml.inference.pytorch.results.ErrorResult;
 import org.elasticsearch.xpack.ml.inference.pytorch.results.PyTorchInferenceResult;
 import org.elasticsearch.xpack.ml.inference.pytorch.results.PyTorchResult;
 import org.elasticsearch.xpack.ml.inference.pytorch.results.ThreadSettings;
@@ -70,10 +71,9 @@ public class PyTorchResultProcessor {
         this.currentTimeMsSupplier = currentTimeSupplier;
         this.startTime = currentTimeSupplier.getAsLong();
         this.currentPeriodEndTimeMs = startTime + REPORTING_PERIOD_MS;
-
     }
 
-    public void registerRequest(String requestId, ActionListener<PyTorchInferenceResult> listener) {
+    public void registerRequest(String requestId, ActionListener<PyTorchResult> listener) {
         pendingResults.computeIfAbsent(requestId, k -> new PendingResult(listener));
     }
 
@@ -92,14 +92,19 @@ public class PyTorchResultProcessor {
             Iterator<PyTorchResult> iterator = process.readResults();
             while (iterator.hasNext()) {
                 PyTorchResult result = iterator.next();
-                PyTorchInferenceResult inferenceResult = result.inferenceResult();
-                if (inferenceResult != null) {
-                    processInferenceResult(inferenceResult);
+
+                if (result.inferenceResult() != null) {
+                    processInferenceResult(result);
                 }
                 ThreadSettings threadSettings = result.threadSettings();
                 if (threadSettings != null) {
                     threadSettingsConsumer.accept(threadSettings);
+                    processThreadSettings(result);
                 }
+                if (result.errorResult() != null) {
+                    processErrorResult(result);
+                }
+
             }
         } catch (Exception e) {
             // No need to report error as we're stopping
@@ -108,13 +113,15 @@ public class PyTorchResultProcessor {
             }
             pendingResults.forEach(
                 (id, pendingResult) -> pendingResult.listener.onResponse(
-                    new PyTorchInferenceResult(
-                        id,
+                    new PyTorchResult(
                         null,
                         null,
-                        isStopping
-                            ? "inference canceled as process is stopping"
-                            : "inference native process died unexpectedly with failure [" + e.getMessage() + "]"
+                        new ErrorResult(
+                            id,
+                            isStopping
+                                ? "inference canceled as process is stopping"
+                                : "inference native process died unexpectedly with failure [" + e.getMessage() + "]"
+                        )
                     )
                 )
             );
@@ -122,7 +129,7 @@ public class PyTorchResultProcessor {
         } finally {
             pendingResults.forEach(
                 (id, pendingResult) -> pendingResult.listener.onResponse(
-                    new PyTorchInferenceResult(id, null, null, "inference canceled as process is stopping")
+                    new PyTorchResult(null, null, new ErrorResult(id, "inference canceled as process is stopping"))
                 )
             );
             pendingResults.clear();
@@ -130,14 +137,45 @@ public class PyTorchResultProcessor {
         logger.debug(() -> new ParameterizedMessage("[{}] Results processing finished", deploymentId));
     }
 
-    void processInferenceResult(PyTorchInferenceResult inferenceResult) {
+    void processInferenceResult(PyTorchResult result) {
+        PyTorchInferenceResult inferenceResult = result.inferenceResult();
+        assert inferenceResult != null;
+
         logger.trace(() -> new ParameterizedMessage("[{}] Parsed result with id [{}]", deploymentId, inferenceResult.getRequestId()));
         processResult(inferenceResult);
         PendingResult pendingResult = pendingResults.remove(inferenceResult.getRequestId());
         if (pendingResult == null) {
             logger.debug(() -> new ParameterizedMessage("[{}] no pending result for [{}]", deploymentId, inferenceResult.getRequestId()));
         } else {
-            pendingResult.listener.onResponse(inferenceResult);
+            pendingResult.listener.onResponse(result);
+        }
+    }
+
+    void processThreadSettings(PyTorchResult result) {
+        ThreadSettings threadSettings = result.threadSettings();
+        assert threadSettings != null;
+
+        logger.trace(() -> new ParameterizedMessage("[{}] Parsed result with id [{}]", deploymentId, threadSettings.requestId()));
+        PendingResult pendingResult = pendingResults.remove(threadSettings.requestId());
+        if (pendingResult == null) {
+            logger.debug(() -> new ParameterizedMessage("[{}] no pending result for [{}]", deploymentId, threadSettings.requestId()));
+        } else {
+            pendingResult.listener.onResponse(result);
+        }
+    }
+
+    void processErrorResult(PyTorchResult result) {
+        ErrorResult errorResult = result.errorResult();
+        assert errorResult != null;
+
+        errorCount++;
+
+        logger.trace(() -> new ParameterizedMessage("[{}] Parsed error with id [{}]", deploymentId, errorResult.requestId()));
+        PendingResult pendingResult = pendingResults.remove(errorResult.requestId());
+        if (pendingResult == null) {
+            logger.debug(() -> new ParameterizedMessage("[{}] no pending result for [{}]", deploymentId, errorResult.requestId()));
+        } else {
+            pendingResult.listener.onResponse(result);
         }
     }
 
@@ -176,11 +214,6 @@ public class PyTorchResultProcessor {
     }
 
     private synchronized void processResult(PyTorchInferenceResult result) {
-        if (result.isError()) {
-            errorCount++;
-            return;
-        }
-
         timingStats.accept(result.getTimeMs());
 
         lastResultTimeMs = currentTimeMsSupplier.getAsLong();
@@ -211,9 +244,9 @@ public class PyTorchResultProcessor {
     }
 
     public static class PendingResult {
-        public final ActionListener<PyTorchInferenceResult> listener;
+        public final ActionListener<PyTorchResult> listener;
 
-        public PendingResult(ActionListener<PyTorchInferenceResult> listener) {
+        public PendingResult(ActionListener<PyTorchResult> listener) {
             this.listener = Objects.requireNonNull(listener);
         }
     }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/pytorch/results/ErrorResult.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/pytorch/results/ErrorResult.java
@@ -14,30 +14,27 @@ import org.elasticsearch.xcontent.XContentBuilder;
 
 import java.io.IOException;
 
-public record ThreadSettings(int numThreadsPerAllocation, int numAllocations, String requestId) implements ToXContentObject {
+public record ErrorResult(String requestId, String error) implements ToXContentObject {
 
-    private static final ParseField NUM_ALLOCATIONS = new ParseField("num_threads_per_allocation");
-    private static final ParseField NUM_THREADS_PER_ALLOCATION = new ParseField("num_allocations");
+    public static final ParseField ERROR = new ParseField("error");
 
-    public static ConstructingObjectParser<ThreadSettings, Void> PARSER = new ConstructingObjectParser<>(
-        "thread_settings",
-        a -> new ThreadSettings((int) a[0], (int) a[1], (String) a[2])
+    public static ConstructingObjectParser<ErrorResult, Void> PARSER = new ConstructingObjectParser<>(
+        "error",
+        a -> new ErrorResult((String) a[0], (String) a[1])
     );
 
     static {
-        PARSER.declareInt(ConstructingObjectParser.constructorArg(), NUM_THREADS_PER_ALLOCATION);
-        PARSER.declareInt(ConstructingObjectParser.constructorArg(), NUM_ALLOCATIONS);
         PARSER.declareString(ConstructingObjectParser.optionalConstructorArg(), PyTorchResult.REQUEST_ID);
+        PARSER.declareString(ConstructingObjectParser.constructorArg(), ERROR);
     }
 
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
         builder.startObject();
-        builder.field(NUM_THREADS_PER_ALLOCATION.getPreferredName(), numThreadsPerAllocation);
-        builder.field(NUM_ALLOCATIONS.getPreferredName(), numAllocations);
         if (requestId != null) {
             builder.field(PyTorchResult.REQUEST_ID.getPreferredName(), requestId);
         }
+        builder.field(ERROR.getPreferredName(), error);
         builder.endObject();
         return builder;
     }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/pytorch/results/PyTorchInferenceResult.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/pytorch/results/PyTorchInferenceResult.java
@@ -27,18 +27,16 @@ import java.util.Objects;
  */
 public class PyTorchInferenceResult implements ToXContentObject {
 
-    private static final ParseField REQUEST_ID = new ParseField("request_id");
     private static final ParseField INFERENCE = new ParseField("inference");
-    private static final ParseField ERROR = new ParseField("error");
     private static final ParseField TIME_MS = new ParseField("time_ms");
 
     public static final ConstructingObjectParser<PyTorchInferenceResult, Void> PARSER = new ConstructingObjectParser<>(
         "pytorch_inference_result",
-        a -> new PyTorchInferenceResult((String) a[0], (double[][][]) a[1], (Long) a[2], (String) a[3])
+        a -> new PyTorchInferenceResult((String) a[0], (double[][][]) a[1], (Long) a[2])
     );
 
     static {
-        PARSER.declareString(ConstructingObjectParser.constructorArg(), REQUEST_ID);
+        PARSER.declareString(ConstructingObjectParser.constructorArg(), PyTorchResult.REQUEST_ID);
         PARSER.declareField(
             ConstructingObjectParser.optionalConstructorArg(),
             (p, c) -> MlParserUtils.parse3DArrayOfDoubles(INFERENCE.getPreferredName(), p),
@@ -46,7 +44,6 @@ public class PyTorchInferenceResult implements ToXContentObject {
             ObjectParser.ValueType.VALUE_ARRAY
         );
         PARSER.declareLong(ConstructingObjectParser.optionalConstructorArg(), TIME_MS);
-        PARSER.declareString(ConstructingObjectParser.optionalConstructorArg(), ERROR);
     }
 
     public static PyTorchInferenceResult fromXContent(XContentParser parser) throws IOException {
@@ -56,25 +53,15 @@ public class PyTorchInferenceResult implements ToXContentObject {
     private final String requestId;
     private final double[][][] inference;
     private final Long timeMs;
-    private final String error;
 
-    public PyTorchInferenceResult(String requestId, @Nullable double[][][] inference, @Nullable Long timeMs, @Nullable String error) {
+    public PyTorchInferenceResult(String requestId, @Nullable double[][][] inference, @Nullable Long timeMs) {
         this.requestId = Objects.requireNonNull(requestId);
         this.inference = inference;
         this.timeMs = timeMs;
-        this.error = error;
     }
 
     public String getRequestId() {
         return requestId;
-    }
-
-    public boolean isError() {
-        return error != null;
-    }
-
-    public String getError() {
-        return error;
     }
 
     public double[][][] getInferenceResult() {
@@ -88,7 +75,7 @@ public class PyTorchInferenceResult implements ToXContentObject {
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
         builder.startObject();
-        builder.field(REQUEST_ID.getPreferredName(), requestId);
+        builder.field(PyTorchResult.REQUEST_ID.getPreferredName(), requestId);
         if (inference != null) {
             builder.startArray(INFERENCE.getPreferredName());
             for (double[][] doubles : inference) {
@@ -103,16 +90,13 @@ public class PyTorchInferenceResult implements ToXContentObject {
         if (timeMs != null) {
             builder.field(TIME_MS.getPreferredName(), timeMs);
         }
-        if (error != null) {
-            builder.field(ERROR.getPreferredName(), error);
-        }
         builder.endObject();
         return builder;
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(requestId, Arrays.deepHashCode(inference), error);
+        return Objects.hash(requestId, timeMs, Arrays.deepHashCode(inference));
     }
 
     @Override
@@ -123,6 +107,6 @@ public class PyTorchInferenceResult implements ToXContentObject {
         PyTorchInferenceResult that = (PyTorchInferenceResult) other;
         return Objects.equals(requestId, that.requestId)
             && Arrays.deepEquals(inference, that.inference)
-            && Objects.equals(error, that.error);
+            && Objects.equals(timeMs, that.timeMs);
     }
 }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/pytorch/results/PyTorchResult.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/pytorch/results/PyTorchResult.java
@@ -16,23 +16,32 @@ import org.elasticsearch.xcontent.XContentBuilder;
 import java.io.IOException;
 
 /**
- * The top level object capturing output from the pytorch process
+ * The top level object capturing output from the pytorch process.
  */
-public record PyTorchResult(@Nullable PyTorchInferenceResult inferenceResult, @Nullable ThreadSettings threadSettings)
-    implements
-        ToXContentObject {
+public record PyTorchResult(
+    @Nullable PyTorchInferenceResult inferenceResult,
+    @Nullable ThreadSettings threadSettings,
+    @Nullable ErrorResult errorResult
+) implements ToXContentObject {
+
+    static final ParseField REQUEST_ID = new ParseField("request_id");
 
     private static final ParseField RESULT = new ParseField("result");
     private static final ParseField THREAD_SETTINGS = new ParseField("thread_settings");
 
     public static ConstructingObjectParser<PyTorchResult, Void> PARSER = new ConstructingObjectParser<>(
         "pytorch_result",
-        a -> new PyTorchResult((PyTorchInferenceResult) a[0], (ThreadSettings) a[1])
+        a -> new PyTorchResult((PyTorchInferenceResult) a[0], (ThreadSettings) a[1], (ErrorResult) a[2])
     );
 
     static {
         PARSER.declareObject(ConstructingObjectParser.optionalConstructorArg(), PyTorchInferenceResult.PARSER, RESULT);
         PARSER.declareObject(ConstructingObjectParser.optionalConstructorArg(), ThreadSettings.PARSER, THREAD_SETTINGS);
+        PARSER.declareObject(ConstructingObjectParser.optionalConstructorArg(), ErrorResult.PARSER, ErrorResult.ERROR);
+    }
+
+    public boolean isError() {
+        return errorResult != null;
     }
 
     @Override
@@ -44,6 +53,10 @@ public record PyTorchResult(@Nullable PyTorchInferenceResult inferenceResult, @N
         if (threadSettings != null) {
             builder.field(THREAD_SETTINGS.getPreferredName(), threadSettings);
         }
+        if (errorResult != null) {
+            builder.field(ErrorResult.ERROR.getPreferredName(), errorResult);
+        }
+
         builder.endObject();
         return builder;
     }

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/deployment/ControlMessagePyTorchActionTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/deployment/ControlMessagePyTorchActionTests.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.ml.inference.deployment;
+
+import org.apache.lucene.util.SetOnce;
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.core.TimeValue;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.threadpool.Scheduler;
+import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.xpack.ml.inference.pytorch.process.PyTorchProcess;
+import org.elasticsearch.xpack.ml.inference.pytorch.process.PyTorchResultProcessor;
+import org.elasticsearch.xpack.ml.inference.pytorch.results.ThreadSettings;
+import org.mockito.ArgumentCaptor;
+
+import java.io.IOException;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class ControlMessagePyTorchActionTests extends ESTestCase {
+
+    private ThreadPool tp;
+
+    public void testBuildControlMessage() throws IOException {
+        var message = ControlMessagePyTorchAction.buildControlMessage("foo", 4);
+
+        assertEquals("{\"request_id\":\"foo\",\"control\":0,\"num_allocations\":4}", message.utf8ToString());
+    }
+
+    @SuppressWarnings("unchecked")
+    public void testRunNotCalledAfterNotified() {
+        DeploymentManager.ProcessContext processContext = mock(DeploymentManager.ProcessContext.class);
+        PyTorchResultProcessor resultProcessor = mock(PyTorchResultProcessor.class);
+        when(processContext.getResultProcessor()).thenReturn(resultProcessor);
+        AtomicInteger timeoutCount = new AtomicInteger();
+        when(processContext.getTimeoutCount()).thenReturn(timeoutCount);
+
+        Scheduler.ScheduledCancellable cancellable = mock(Scheduler.ScheduledCancellable.class);
+        ThreadPool tp = mock(ThreadPool.class);
+        when(tp.schedule(any(), any(), any())).thenReturn(cancellable);
+
+        {
+            ActionListener<ThreadSettings> listener = mock(ActionListener.class);
+            ControlMessagePyTorchAction action = new ControlMessagePyTorchAction(
+                "test-model",
+                1,
+                1,
+                TimeValue.MAX_VALUE,
+                processContext,
+                tp,
+                listener
+            );
+
+            action.onTimeout();
+            action.run();
+            verify(resultProcessor, times(1)).ignoreResponseWithoutNotifying("1");
+            verify(resultProcessor, never()).registerRequest(anyString(), any());
+            verify(listener, times(1)).onFailure(any());
+            verify(listener, never()).onResponse(any());
+        }
+        {
+            ActionListener<ThreadSettings> listener = mock(ActionListener.class);
+            ControlMessagePyTorchAction action = new ControlMessagePyTorchAction(
+                "test-model",
+                1,
+                1,
+                TimeValue.MAX_VALUE,
+                processContext,
+                tp,
+                listener
+            );
+
+            action.onFailure(new IllegalStateException());
+            action.run();
+            verify(resultProcessor, never()).registerRequest(anyString(), any());
+            verify(listener, times(1)).onFailure(any());
+            verify(listener, never()).onResponse(any());
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    public void testDoRun() throws IOException {
+        DeploymentManager.ProcessContext processContext = mock(DeploymentManager.ProcessContext.class);
+        PyTorchResultProcessor resultProcessor = mock(PyTorchResultProcessor.class);
+        when(processContext.getResultProcessor()).thenReturn(resultProcessor);
+        AtomicInteger timeoutCount = new AtomicInteger();
+        when(processContext.getTimeoutCount()).thenReturn(timeoutCount);
+        SetOnce<PyTorchProcess> process = new SetOnce<>();
+        PyTorchProcess pp = mock(PyTorchProcess.class);
+        process.set(pp);
+        when(processContext.getProcess()).thenReturn(process);
+
+        Scheduler.ScheduledCancellable cancellable = mock(Scheduler.ScheduledCancellable.class);
+        ThreadPool tp = mock(ThreadPool.class);
+        when(tp.schedule(any(), any(), any())).thenReturn(cancellable);
+
+        ActionListener<ThreadSettings> listener = mock(ActionListener.class);
+        ArgumentCaptor<BytesReference> messageCapture = ArgumentCaptor.forClass(BytesReference.class);
+        doNothing().when(pp).writeInferenceRequest(messageCapture.capture());
+
+        ControlMessagePyTorchAction action = new ControlMessagePyTorchAction(
+            "test-model",
+            1,
+            1,
+            TimeValue.MAX_VALUE,
+            processContext,
+            tp,
+            listener
+        );
+
+        action.run();
+
+        verify(resultProcessor).registerRequest(eq("1"), any());
+        verify(listener, never()).onFailure(any());
+        assertEquals("{\"request_id\":\"1\",\"control\":0,\"num_allocations\":1}", messageCapture.getValue().utf8ToString());
+    }
+}

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/deployment/DeploymentManagerTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/deployment/DeploymentManagerTests.java
@@ -16,10 +16,7 @@ import org.elasticsearch.threadpool.ScalingExecutorBuilder;
 import org.elasticsearch.threadpool.TestThreadPool;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.xcontent.NamedXContentRegistry;
-import org.elasticsearch.xpack.core.ml.inference.results.InferenceResults;
-import org.elasticsearch.xpack.core.ml.inference.results.WarningInferenceResults;
 import org.elasticsearch.xpack.core.ml.inference.trainedmodel.InferenceConfig;
-import org.elasticsearch.xpack.core.ml.inference.trainedmodel.PassThroughConfig;
 import org.elasticsearch.xpack.ml.inference.pytorch.process.PyTorchProcessFactory;
 import org.elasticsearch.xpack.ml.inference.pytorch.process.PyTorchResultProcessor;
 import org.junit.After;
@@ -70,76 +67,6 @@ public class DeploymentManagerTests extends ESTestCase {
         tp.shutdown();
     }
 
-    public void testInferListenerOnlyCalledOnce() {
-        DeploymentManager.ProcessContext processContext = mock(DeploymentManager.ProcessContext.class);
-        PyTorchResultProcessor resultProcessor = new PyTorchResultProcessor("1", threadSettings -> {});
-        when(processContext.getResultProcessor()).thenReturn(resultProcessor);
-        AtomicInteger timeoutCount = new AtomicInteger();
-        when(processContext.getTimeoutCount()).thenReturn(timeoutCount);
-
-        ListenerCounter listener = new ListenerCounter();
-        DeploymentManager.InferenceAction action = new DeploymentManager.InferenceAction(
-            "test-model",
-            1,
-            TimeValue.MAX_VALUE,
-            processContext,
-            new PassThroughConfig(null, null, null),
-            Map.of(),
-            tp,
-            listener
-        );
-
-        action.onSuccess(new WarningInferenceResults("foo"));
-        for (int i = 0; i < 10; i++) {
-            action.onSuccess(new WarningInferenceResults("foo"));
-            action.onFailure(new Exception("foo"));
-            action.onTimeout();
-        }
-        assertThat(listener.failureCounts, equalTo(0));
-        assertThat(listener.responseCounts, equalTo(1));
-
-        action = new DeploymentManager.InferenceAction(
-            "test-model",
-            1,
-            TimeValue.MAX_VALUE,
-            processContext,
-            new PassThroughConfig(null, null, null),
-            Map.of(),
-            tp,
-            listener
-        );
-
-        action.onTimeout();
-        for (int i = 0; i < 10; i++) {
-            action.onSuccess(new WarningInferenceResults("foo"));
-            action.onFailure(new Exception("foo"));
-            action.onTimeout();
-        }
-        assertThat(listener.failureCounts, equalTo(1));
-        assertThat(listener.responseCounts, equalTo(1));
-        assertThat(timeoutCount.intValue(), equalTo(1));
-
-        action = new DeploymentManager.InferenceAction(
-            "test-model",
-            1,
-            TimeValue.MAX_VALUE,
-            processContext,
-            new PassThroughConfig(null, null, null),
-            Map.of(),
-            tp,
-            listener
-        );
-
-        action.onFailure(new Exception("bar"));
-        for (int i = 0; i < 10; i++) {
-            action.onSuccess(new WarningInferenceResults("foo"));
-            action.onFailure(new Exception("foo"));
-            action.onTimeout();
-        }
-        assertThat(listener.failureCounts, equalTo(2));
-        assertThat(listener.responseCounts, equalTo(1));
-    }
-
     public void testRejectedExecution() {
         TrainedModelDeploymentTask task = mock(TrainedModelDeploymentTask.class);
         Long taskId = 1L;
@@ -175,20 +102,4 @@ public class DeploymentManagerTests extends ESTestCase {
 
         assertThat(rejectedCount.intValue(), equalTo(1));
     }
-
-    private static class ListenerCounter implements ActionListener<InferenceResults> {
-        private int responseCounts;
-        private int failureCounts;
-
-        @Override
-        public void onResponse(InferenceResults inferenceResults) {
-            responseCounts++;
-        }
-
-        @Override
-        public void onFailure(Exception e) {
-            failureCounts++;
-        }
-    }
-
 }

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/deployment/InferencePyTorchActionTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/deployment/InferencePyTorchActionTests.java
@@ -1,0 +1,187 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.ml.inference.deployment;
+
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.core.TimeValue;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.threadpool.ScalingExecutorBuilder;
+import org.elasticsearch.threadpool.TestThreadPool;
+import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.xpack.core.ml.inference.results.InferenceResults;
+import org.elasticsearch.xpack.core.ml.inference.results.WarningInferenceResults;
+import org.elasticsearch.xpack.core.ml.inference.trainedmodel.PassThroughConfig;
+import org.elasticsearch.xpack.ml.inference.pytorch.process.PyTorchResultProcessor;
+import org.junit.After;
+import org.junit.Before;
+
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.elasticsearch.xpack.ml.MachineLearning.UTILITY_THREAD_POOL_NAME;
+import static org.hamcrest.Matchers.equalTo;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class InferencePyTorchActionTests extends ESTestCase {
+
+    private ThreadPool tp;
+
+    @Before
+    public void managerSetup() {
+        tp = new TestThreadPool(
+            "DeploymentManagerTests",
+            new ScalingExecutorBuilder(
+                UTILITY_THREAD_POOL_NAME,
+                1,
+                4,
+                TimeValue.timeValueMinutes(10),
+                false,
+                "xpack.ml.utility_thread_pool"
+            )
+        );
+    }
+
+    @After
+    public void shutdownThreadpool() {
+        tp.shutdown();
+    }
+
+    public void testInferListenerOnlyCalledOnce() {
+        DeploymentManager.ProcessContext processContext = mock(DeploymentManager.ProcessContext.class);
+        PyTorchResultProcessor resultProcessor = new PyTorchResultProcessor("1", threadSettings -> {});
+        when(processContext.getResultProcessor()).thenReturn(resultProcessor);
+        AtomicInteger timeoutCount = new AtomicInteger();
+        when(processContext.getTimeoutCount()).thenReturn(timeoutCount);
+
+        ListenerCounter listener = new ListenerCounter();
+        InferencePyTorchAction action = new InferencePyTorchAction(
+            "test-model",
+            1,
+            TimeValue.MAX_VALUE,
+            processContext,
+            new PassThroughConfig(null, null, null),
+            Map.of(),
+            tp,
+            listener
+        );
+
+        action.onSuccess(new WarningInferenceResults("foo"));
+        for (int i = 0; i < 10; i++) {
+            action.onSuccess(new WarningInferenceResults("foo"));
+            action.onFailure(new Exception("foo"));
+            action.onTimeout();
+        }
+        assertThat(listener.failureCounts, equalTo(0));
+        assertThat(listener.responseCounts, equalTo(1));
+
+        action = new InferencePyTorchAction(
+            "test-model",
+            1,
+            TimeValue.MAX_VALUE,
+            processContext,
+            new PassThroughConfig(null, null, null),
+            Map.of(),
+            tp,
+            listener
+        );
+
+        action.onTimeout();
+        for (int i = 0; i < 10; i++) {
+            action.onSuccess(new WarningInferenceResults("foo"));
+            action.onFailure(new Exception("foo"));
+            action.onTimeout();
+        }
+        assertThat(listener.failureCounts, equalTo(1));
+        assertThat(listener.responseCounts, equalTo(1));
+        assertThat(timeoutCount.intValue(), equalTo(1));
+
+        action = new InferencePyTorchAction(
+            "test-model",
+            1,
+            TimeValue.MAX_VALUE,
+            processContext,
+            new PassThroughConfig(null, null, null),
+            Map.of(),
+            tp,
+            listener
+        );
+
+        action.onFailure(new Exception("bar"));
+        for (int i = 0; i < 10; i++) {
+            action.onSuccess(new WarningInferenceResults("foo"));
+            action.onFailure(new Exception("foo"));
+            action.onTimeout();
+        }
+        assertThat(listener.failureCounts, equalTo(2));
+        assertThat(listener.responseCounts, equalTo(1));
+    }
+
+    public void testRunNotCalledAfterNotified() {
+        DeploymentManager.ProcessContext processContext = mock(DeploymentManager.ProcessContext.class);
+        PyTorchResultProcessor resultProcessor = mock(PyTorchResultProcessor.class);
+        when(processContext.getResultProcessor()).thenReturn(resultProcessor);
+        AtomicInteger timeoutCount = new AtomicInteger();
+        when(processContext.getTimeoutCount()).thenReturn(timeoutCount);
+
+        ListenerCounter listener = new ListenerCounter();
+        {
+            InferencePyTorchAction action = new InferencePyTorchAction(
+                "test-model",
+                1,
+                TimeValue.MAX_VALUE,
+                processContext,
+                new PassThroughConfig(null, null, null),
+                Map.of(),
+                tp,
+                listener
+            );
+
+            action.onTimeout();
+            action.run();
+            verify(resultProcessor, times(1)).ignoreResponseWithoutNotifying("1");
+            verify(resultProcessor, never()).registerRequest(anyString(), any());
+        }
+        {
+            InferencePyTorchAction action = new InferencePyTorchAction(
+                "test-model",
+                1,
+                TimeValue.MAX_VALUE,
+                processContext,
+                new PassThroughConfig(null, null, null),
+                Map.of(),
+                tp,
+                listener
+            );
+
+            action.onFailure(new IllegalStateException());
+            action.run();
+            verify(resultProcessor, never()).registerRequest(anyString(), any());
+        }
+    }
+
+    static class ListenerCounter implements ActionListener<InferenceResults> {
+        private int responseCounts;
+        private int failureCounts;
+
+        @Override
+        public void onResponse(InferenceResults inferenceResults) {
+            responseCounts++;
+        }
+
+        @Override
+        public void onFailure(Exception e) {
+            failureCounts++;
+        }
+    }
+}

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/nlp/FillMaskProcessorTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/nlp/FillMaskProcessorTests.java
@@ -66,7 +66,7 @@ public class FillMaskProcessorTests extends ESTestCase {
         String resultsField = randomAlphaOfLength(10);
         FillMaskResults result = (FillMaskResults) FillMaskProcessor.processResult(
             tokenization,
-            new PyTorchInferenceResult("1", scores, 0L, null),
+            new PyTorchInferenceResult("1", scores, 0L),
             tokenizer,
             4,
             resultsField
@@ -93,7 +93,7 @@ public class FillMaskProcessorTests extends ESTestCase {
             0
         );
 
-        PyTorchInferenceResult pyTorchResult = new PyTorchInferenceResult("1", new double[][][] { { {} } }, 0L, null);
+        PyTorchInferenceResult pyTorchResult = new PyTorchInferenceResult("1", new double[][][] { { {} } }, 0L);
         expectThrows(
             ElasticsearchStatusException.class,
             () -> FillMaskProcessor.processResult(tokenization, pyTorchResult, tokenizer, 5, randomAlphaOfLength(10))

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/nlp/NerProcessorTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/nlp/NerProcessorTests.java
@@ -95,7 +95,7 @@ public class NerProcessorTests extends ESTestCase {
 
         var e = expectThrows(
             ElasticsearchStatusException.class,
-            () -> processor.processResult(tokenization, new PyTorchInferenceResult("test", null, 0L, null))
+            () -> processor.processResult(tokenization, new PyTorchInferenceResult("test", null, 0L))
         );
         assertThat(e, instanceOf(ElasticsearchStatusException.class));
     }
@@ -134,7 +134,7 @@ public class NerProcessorTests extends ESTestCase {
                 { 0, 0, 0, 0, 0, 0, 0, 6, 0 }, // london
                 { 7, 0, 0, 0, 0, 0, 0, 0, 0 } // sep
             } };
-        NerResults result = (NerResults) processor.processResult(tokenization, new PyTorchInferenceResult("1", scores, 1L, null));
+        NerResults result = (NerResults) processor.processResult(tokenization, new PyTorchInferenceResult("1", scores, 1L));
 
         assertThat(result.getAnnotatedResult(), equalTo("Many use [Elasticsearch](ORG&Elasticsearch) in [London](LOC&London)"));
         assertThat(result.getEntityGroups().size(), equalTo(2));
@@ -161,7 +161,7 @@ public class NerProcessorTests extends ESTestCase {
                 { 0, 0, 0, 0, 0, 0, 0, 0, 0 }, // in
                 { 0, 0, 0, 0, 0, 0, 0, 6, 0 } // london
             } };
-        NerResults result = (NerResults) processor.processResult(tokenization, new PyTorchInferenceResult("1", scores, 1L, null));
+        NerResults result = (NerResults) processor.processResult(tokenization, new PyTorchInferenceResult("1", scores, 1L));
 
         assertThat(result.getAnnotatedResult(), equalTo("Many use [Elasticsearch](ORG&Elasticsearch) in [London](LOC&London)"));
         assertThat(result.getEntityGroups().size(), equalTo(2));
@@ -198,7 +198,7 @@ public class NerProcessorTests extends ESTestCase {
                 { 0, 0, 0, 0, 0, 0, 0, 0, 5 }, // in
                 { 6, 0, 0, 0, 0, 0, 0, 0, 0 } // london
             } };
-        NerResults result = (NerResults) processor.processResult(tokenization, new PyTorchInferenceResult("1", scores, 1L, null));
+        NerResults result = (NerResults) processor.processResult(tokenization, new PyTorchInferenceResult("1", scores, 1L));
 
         assertThat(result.getAnnotatedResult(), equalTo("[Elasticsearch](ORG&Elasticsearch) in [London](LOC&London)"));
         assertThat(result.getEntityGroups().size(), equalTo(2));

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/nlp/QuestionAnsweringProcessorTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/nlp/QuestionAnsweringProcessorTests.java
@@ -87,7 +87,7 @@ public class QuestionAnsweringProcessorTests extends ESTestCase {
         assertThat(tokenizationResult.getTokenization(0).seqPairOffset(), equalTo(7));
         double[][][] scores = { { START_TOKEN_SCORES }, { END_TOKEN_SCORES } };
         NlpTask.ResultProcessor resultProcessor = processor.getResultProcessor(config);
-        PyTorchInferenceResult pyTorchResult = new PyTorchInferenceResult("1", scores, 1L, null);
+        PyTorchInferenceResult pyTorchResult = new PyTorchInferenceResult("1", scores, 1L);
         QuestionAnsweringInferenceResults result = (QuestionAnsweringInferenceResults) resultProcessor.processResult(
             tokenizationResult,
             pyTorchResult

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/nlp/TextClassificationProcessorTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/nlp/TextClassificationProcessorTests.java
@@ -32,7 +32,7 @@ public class TextClassificationProcessorTests extends ESTestCase {
 
     public void testInvalidResult() {
         {
-            PyTorchInferenceResult torchResult = new PyTorchInferenceResult("foo", new double[][][] {}, 0L, null);
+            PyTorchInferenceResult torchResult = new PyTorchInferenceResult("foo", new double[][][] {}, 0L);
             var e = expectThrows(
                 ElasticsearchStatusException.class,
                 () -> TextClassificationProcessor.processResult(null, torchResult, randomInt(), List.of("a", "b"), randomAlphaOfLength(10))
@@ -41,7 +41,7 @@ public class TextClassificationProcessorTests extends ESTestCase {
             assertThat(e.getMessage(), containsString("Text classification result has no data"));
         }
         {
-            PyTorchInferenceResult torchResult = new PyTorchInferenceResult("foo", new double[][][] { { { 1.0 } } }, 0L, null);
+            PyTorchInferenceResult torchResult = new PyTorchInferenceResult("foo", new double[][][] { { { 1.0 } } }, 0L);
             var e = expectThrows(
                 ElasticsearchStatusException.class,
                 () -> TextClassificationProcessor.processResult(null, torchResult, randomInt(), List.of("a", "b"), randomAlphaOfLength(10))

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/pytorch/process/PyTorchBuilderTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/pytorch/process/PyTorchBuilderTests.java
@@ -53,8 +53,8 @@ public class PyTorchBuilderTests extends ESTestCase {
             contains(
                 "./pytorch_inference",
                 "--validElasticLicenseKeyConfirmed=true",
-                "--inferenceThreads=2",
-                "--modelThreads=4",
+                "--numThreadsPerAllocation=2",
+                "--numAllocations=4",
                 PROCESS_PIPES_ARG
             )
         );

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/pytorch/process/PyTorchResultProcessorTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/pytorch/process/PyTorchResultProcessorTests.java
@@ -9,6 +9,7 @@ package org.elasticsearch.xpack.ml.inference.pytorch.process;
 
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xpack.ml.inference.pytorch.results.ErrorResult;
 import org.elasticsearch.xpack.ml.inference.pytorch.results.PyTorchInferenceResult;
 import org.elasticsearch.xpack.ml.inference.pytorch.results.PyTorchResult;
 import org.elasticsearch.xpack.ml.inference.pytorch.results.ThreadSettings;
@@ -34,29 +35,61 @@ public class PyTorchResultProcessorTests extends ESTestCase {
 
     public void testsThreadSettings() {
         var settingsHolder = new AtomicReference<ThreadSettings>();
-        var processor = new PyTorchResultProcessor("foo", settingsHolder::set);
+        var processor = new PyTorchResultProcessor("deployment-foo", settingsHolder::set);
 
-        var settings = new ThreadSettings(1, 1);
-        processor.process(mockNativeProcess(List.of(new PyTorchResult(null, settings)).iterator()));
+        var settings = new ThreadSettings(1, 1, "thread-setting");
+        processor.registerRequest("thread-setting", new AssertingResultListener(r -> assertEquals(settings, r.threadSettings())));
+
+        processor.process(mockNativeProcess(List.of(new PyTorchResult(null, settings, null)).iterator()));
 
         assertEquals(settings, settingsHolder.get());
+    }
+
+    public void testResultsProcessing() {
+        var inferenceResult = new PyTorchInferenceResult("a", null, 1000L);
+        var threadSettings = new ThreadSettings(1, 1, "b");
+        var errorResult = new ErrorResult("c", "a bad thing has happened");
+
+        var inferenceListener = new AssertingResultListener(
+            r -> assertEquals(inferenceResult, r.inferenceResult())
+        );
+        var threadSettingsListener = new AssertingResultListener(
+            r -> assertEquals(threadSettings, r.threadSettings())
+        );
+        var errorListener = new AssertingResultListener(
+            r -> assertEquals(errorResult, r.errorResult())
+        );
+
+        var processor = new PyTorchResultProcessor("foo", s -> {});
+        processor.registerRequest("a", inferenceListener);
+        processor.registerRequest("b", threadSettingsListener);
+        processor.registerRequest("c", errorListener);
+
+        processor.process(mockNativeProcess(List.of(new PyTorchResult(inferenceResult, null, null),
+            new PyTorchResult(null, threadSettings, null),
+            new PyTorchResult(null, null, errorResult)
+        ).iterator()));
+
+        assertTrue(inferenceListener.hasResponse);
+        assertTrue(threadSettingsListener.hasResponse);
+        assertTrue(errorListener.hasResponse);
     }
 
     public void testPendingRequest() {
         var processor = new PyTorchResultProcessor("foo", s -> {});
 
         var resultHolder = new AtomicReference<PyTorchInferenceResult>();
-        processor.registerRequest("a", new AssertingResultListener(resultHolder::set));
+        processor.registerRequest("a", new AssertingResultListener(r -> resultHolder.set(r.inferenceResult())));
 
         // this listener should only be called when the processor shuts down
         var calledOnShutdown = new AssertingResultListener(
-            r -> assertThat(r.getError(), containsString("inference canceled as process is stopping"))
+            r -> assertThat(r.errorResult().error(), containsString("inference canceled as process is stopping"))
         );
         processor.registerRequest("b", calledOnShutdown);
 
-        var inferenceResult = new PyTorchInferenceResult("a", null, 1000L, null);
+        var inferenceResult = new PyTorchInferenceResult("a", null, 1000L);
 
-        processor.process(mockNativeProcess(List.of(new PyTorchResult(inferenceResult, null)).iterator()));
+        processor.process(mockNativeProcess(List.of(new PyTorchResult(inferenceResult, null, null)).iterator()));
         assertSame(inferenceResult, resultHolder.get());
         assertTrue(calledOnShutdown.hasResponse);
     }
@@ -68,18 +101,18 @@ public class PyTorchResultProcessorTests extends ESTestCase {
 
         processor.ignoreResponseWithoutNotifying("a");
 
-        var inferenceResult = new PyTorchInferenceResult("a", null, 1000L, null);
-        processor.process(mockNativeProcess(List.of(new PyTorchResult(inferenceResult, null)).iterator()));
+        var inferenceResult = new PyTorchInferenceResult("a", null, 1000L);
+        processor.process(mockNativeProcess(List.of(new PyTorchResult(inferenceResult, null, null)).iterator()));
     }
 
     public void testPendingRequestAreCalledAtShutdown() {
         var processor = new PyTorchResultProcessor("foo", s -> {});
 
         var listeners = List.of(
-            new AssertingResultListener(r -> assertEquals(r.getError(), "inference canceled as process is stopping")),
-            new AssertingResultListener(r -> assertEquals(r.getError(), "inference canceled as process is stopping")),
-            new AssertingResultListener(r -> assertEquals(r.getError(), "inference canceled as process is stopping")),
-            new AssertingResultListener(r -> assertEquals(r.getError(), "inference canceled as process is stopping"))
+            new AssertingResultListener(r -> assertEquals(r.errorResult().error(), "inference canceled as process is stopping")),
+            new AssertingResultListener(r -> assertEquals(r.errorResult().error(), "inference canceled as process is stopping")),
+            new AssertingResultListener(r -> assertEquals(r.errorResult().error(), "inference canceled as process is stopping")),
+            new AssertingResultListener(r -> assertEquals(r.errorResult().error(), "inference canceled as process is stopping"))
         );
 
         int i = 0;
@@ -94,24 +127,28 @@ public class PyTorchResultProcessorTests extends ESTestCase {
         }
     }
 
-    private static class AssertingResultListener implements ActionListener<PyTorchInferenceResult> {
+    private static class AssertingResultListener implements ActionListener<PyTorchResult> {
         boolean hasResponse;
-        final Consumer<PyTorchInferenceResult> responseAsserter;
+        final Consumer<PyTorchResult> responseAsserter;
 
-        AssertingResultListener(Consumer<PyTorchInferenceResult> responseAsserter) {
+        AssertingResultListener(Consumer<PyTorchResult> responseAsserter) {
             this.responseAsserter = responseAsserter;
         }
 
         @Override
-        public void onResponse(PyTorchInferenceResult pyTorchInferenceResult) {
+        public void onResponse(PyTorchResult pyTorchResult) {
             hasResponse = true;
-            responseAsserter.accept(pyTorchInferenceResult);
+            responseAsserter.accept(pyTorchResult);
         }
 
         @Override
         public void onFailure(Exception e) {
             fail(e.getMessage());
         }
+    }
+
+    private PyTorchResult wrapInferenceResult(PyTorchInferenceResult result) {
+        return new PyTorchResult(result, null, null);
     }
 
     public void testsStats() {
@@ -125,9 +162,9 @@ public class PyTorchResultProcessorTests extends ESTestCase {
         processor.registerRequest("b", pendingB);
         processor.registerRequest("c", pendingC);
 
-        var a = new PyTorchInferenceResult("a", null, 1000L, null);
-        var b = new PyTorchInferenceResult("b", null, 900L, null);
-        var c = new PyTorchInferenceResult("c", null, 200L, null);
+        var a = wrapInferenceResult(new PyTorchInferenceResult("a", null, 1000L));
+        var b = wrapInferenceResult(new PyTorchInferenceResult("b", null, 900L));
+        var c = wrapInferenceResult(new PyTorchInferenceResult("c", null, 200L));
 
         processor.processInferenceResult(a);
         var stats = processor.getResultStats();
@@ -184,31 +221,13 @@ public class PyTorchResultProcessorTests extends ESTestCase {
             start + (7L * REPORTING_PERIOD_MS) + 55,
             start + (8L * REPORTING_PERIOD_MS) + 90 };
 
-        var inferenceResults = List.of(
-            // 1st period
-            new PyTorchInferenceResult("foo", null, 200L, null),
-            new PyTorchInferenceResult("foo", null, 200L, null),
-            new PyTorchInferenceResult("foo", null, 200L, null),
-            // 2nd
-            new PyTorchInferenceResult("foo", null, 100L, null),
-            // 4th
-            new PyTorchInferenceResult("foo", null, 300L, null),
-            // 7th
-            new PyTorchInferenceResult("foo", null, 400L, null),
-            new PyTorchInferenceResult("foo", null, 400L, null),
-            // 8th
-            new PyTorchInferenceResult("foo", null, 500L, null),
-            new PyTorchInferenceResult("foo", null, 500L, null),
-            new PyTorchInferenceResult("foo", null, 500L, null)
-        );
-
         var timeSupplier = new TimeSupplier(resultTimestamps);
         var processor = new PyTorchResultProcessor("foo", s -> {}, timeSupplier);
 
         // 1st period
-        processor.processInferenceResult(new PyTorchInferenceResult("foo", null, 200L, null));
-        processor.processInferenceResult(new PyTorchInferenceResult("foo", null, 200L, null));
-        processor.processInferenceResult(new PyTorchInferenceResult("foo", null, 200L, null));
+        processor.processInferenceResult(wrapInferenceResult(new PyTorchInferenceResult("foo", null, 200L)));
+        processor.processInferenceResult(wrapInferenceResult(new PyTorchInferenceResult("foo", null, 200L)));
+        processor.processInferenceResult(wrapInferenceResult(new PyTorchInferenceResult("foo", null, 200L)));
         // first call has no results as is in the same period
         var stats = processor.getResultStats();
         assertThat(stats.recentStats().requestsProcessed(), equalTo(0L));
@@ -222,7 +241,7 @@ public class PyTorchResultProcessorTests extends ESTestCase {
         assertThat(stats.peakThroughput(), equalTo(3L));
 
         // 2nd period
-        processor.processInferenceResult(new PyTorchInferenceResult("foo", null, 100L, null));
+        processor.processInferenceResult(wrapInferenceResult(new PyTorchInferenceResult("foo", null, 100L)));
         stats = processor.getResultStats();
         assertNotNull(stats.recentStats());
         assertThat(stats.recentStats().requestsProcessed(), equalTo(1L));
@@ -234,7 +253,7 @@ public class PyTorchResultProcessorTests extends ESTestCase {
         assertThat(stats.recentStats().requestsProcessed(), equalTo(0L));
 
         // 4th period
-        processor.processInferenceResult(new PyTorchInferenceResult("foo", null, 300L, null));
+        processor.processInferenceResult(wrapInferenceResult(new PyTorchInferenceResult("foo", null, 300L)));
         stats = processor.getResultStats();
         assertNotNull(stats.recentStats());
         assertThat(stats.recentStats().requestsProcessed(), equalTo(1L));
@@ -242,8 +261,8 @@ public class PyTorchResultProcessorTests extends ESTestCase {
         assertThat(stats.lastUsed(), equalTo(Instant.ofEpochMilli(resultTimestamps[9])));
 
         // 7th period
-        processor.processInferenceResult(new PyTorchInferenceResult("foo", null, 410L, null));
-        processor.processInferenceResult(new PyTorchInferenceResult("foo", null, 390L, null));
+        processor.processInferenceResult(wrapInferenceResult(new PyTorchInferenceResult("foo", null, 410L)));
+        processor.processInferenceResult(wrapInferenceResult(new PyTorchInferenceResult("foo", null, 390L)));
         stats = processor.getResultStats();
         assertThat(stats.recentStats().requestsProcessed(), equalTo(0L));
         assertThat(stats.recentStats().avgInferenceTime(), nullValue());
@@ -254,9 +273,9 @@ public class PyTorchResultProcessorTests extends ESTestCase {
         assertThat(stats.lastUsed(), equalTo(Instant.ofEpochMilli(resultTimestamps[12])));
 
         // 8th period
-        processor.processInferenceResult(new PyTorchInferenceResult("foo", null, 510L, null));
-        processor.processInferenceResult(new PyTorchInferenceResult("foo", null, 500L, null));
-        processor.processInferenceResult(new PyTorchInferenceResult("foo", null, 490L, null));
+        processor.processInferenceResult(wrapInferenceResult(new PyTorchInferenceResult("foo", null, 510L)));
+        processor.processInferenceResult(wrapInferenceResult(new PyTorchInferenceResult("foo", null, 500L)));
+        processor.processInferenceResult(wrapInferenceResult(new PyTorchInferenceResult("foo", null, 490L)));
         stats = processor.getResultStats();
         assertNotNull(stats.recentStats());
         assertThat(stats.recentStats().requestsProcessed(), equalTo(3L));

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/pytorch/process/PyTorchResultProcessorTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/pytorch/process/PyTorchResultProcessorTests.java
@@ -50,25 +50,24 @@ public class PyTorchResultProcessorTests extends ESTestCase {
         var threadSettings = new ThreadSettings(1, 1, "b");
         var errorResult = new ErrorResult("c", "a bad thing has happened");
 
-        var inferenceListener = new AssertingResultListener(
-            r -> assertEquals(inferenceResult, r.inferenceResult())
-        );
-        var threadSettingsListener = new AssertingResultListener(
-            r -> assertEquals(threadSettings, r.threadSettings())
-        );
-        var errorListener = new AssertingResultListener(
-            r -> assertEquals(errorResult, r.errorResult())
-        );
+        var inferenceListener = new AssertingResultListener(r -> assertEquals(inferenceResult, r.inferenceResult()));
+        var threadSettingsListener = new AssertingResultListener(r -> assertEquals(threadSettings, r.threadSettings()));
+        var errorListener = new AssertingResultListener(r -> assertEquals(errorResult, r.errorResult()));
 
         var processor = new PyTorchResultProcessor("foo", s -> {});
         processor.registerRequest("a", inferenceListener);
         processor.registerRequest("b", threadSettingsListener);
         processor.registerRequest("c", errorListener);
 
-        processor.process(mockNativeProcess(List.of(new PyTorchResult(inferenceResult, null, null),
-            new PyTorchResult(null, threadSettings, null),
-            new PyTorchResult(null, null, errorResult)
-        ).iterator()));
+        processor.process(
+            mockNativeProcess(
+                List.of(
+                    new PyTorchResult(inferenceResult, null, null),
+                    new PyTorchResult(null, threadSettings, null),
+                    new PyTorchResult(null, null, errorResult)
+                ).iterator()
+            )
+        );
 
         assertTrue(inferenceListener.hasResponse);
         assertTrue(threadSettingsListener.hasResponse);

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/pytorch/results/ErrorResultTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/pytorch/results/ErrorResultTests.java
@@ -12,24 +12,20 @@ import org.elasticsearch.xcontent.XContentParser;
 
 import java.io.IOException;
 
-public class ThreadSettingsTests extends AbstractXContentTestCase<ThreadSettings> {
+public class ErrorResultTests extends AbstractXContentTestCase<ErrorResult> {
 
-    public static ThreadSettings createRandom() {
-        return new ThreadSettings(
-            randomIntBetween(1, Integer.MAX_VALUE),
-            randomIntBetween(1, Integer.MAX_VALUE),
-            randomBoolean() ? null : randomAlphaOfLength(5)
-        );
+    public static ErrorResult createRandom() {
+        return new ErrorResult(randomBoolean() ? null : randomAlphaOfLength(5), randomAlphaOfLength(5));
     }
 
     @Override
-    protected ThreadSettings createTestInstance() {
+    protected ErrorResult createTestInstance() {
         return createRandom();
     }
 
     @Override
-    protected ThreadSettings doParseInstance(XContentParser parser) throws IOException {
-        return ThreadSettings.PARSER.parse(parser, null);
+    protected ErrorResult doParseInstance(XContentParser parser) throws IOException {
+        return ErrorResult.PARSER.parse(parser, null);
     }
 
     @Override

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/pytorch/results/PyTorchInferenceResultTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/pytorch/results/PyTorchInferenceResultTests.java
@@ -30,23 +30,19 @@ public class PyTorchInferenceResultTests extends AbstractXContentTestCase<PyTorc
     }
 
     public static PyTorchInferenceResult createRandom() {
-        boolean createError = randomBoolean();
         String id = randomAlphaOfLength(6);
-        if (createError) {
-            return new PyTorchInferenceResult(id, null, null, "This is an error message");
-        } else {
-            int rows = randomIntBetween(1, 10);
-            int columns = randomIntBetween(1, 10);
-            int depth = randomIntBetween(1, 10);
-            double[][][] arr = new double[rows][columns][depth];
-            for (int i = 0; i < rows; i++) {
-                for (int j = 0; j < columns; j++) {
-                    for (int k = 0; k < depth; k++) {
-                        arr[i][j][k] = randomDouble();
-                    }
+
+        int rows = randomIntBetween(1, 10);
+        int columns = randomIntBetween(1, 10);
+        int depth = randomIntBetween(1, 10);
+        double[][][] arr = new double[rows][columns][depth];
+        for (int i = 0; i < rows; i++) {
+            for (int j = 0; j < columns; j++) {
+                for (int k = 0; k < depth; k++) {
+                    arr[i][j][k] = randomDouble();
                 }
             }
-            return new PyTorchInferenceResult(id, arr, randomLong(), null);
         }
+        return new PyTorchInferenceResult(id, arr, randomLong());
     }
 }

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/pytorch/results/PyTorchResultTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/pytorch/results/PyTorchResultTests.java
@@ -16,10 +16,12 @@ public class PyTorchResultTests extends AbstractXContentTestCase<PyTorchResult> 
 
     @Override
     protected PyTorchResult createTestInstance() {
-        return new PyTorchResult(
-            randomBoolean() ? null : PyTorchInferenceResultTests.createRandom(),
-            randomBoolean() ? null : ThreadSettingsTests.createRandom()
-        );
+        int type = randomIntBetween(0, 2);
+        return switch (type) {
+            case 0 -> new PyTorchResult(PyTorchInferenceResultTests.createRandom(), null, null);
+            case 1 -> new PyTorchResult(null, ThreadSettingsTests.createRandom(), null);
+            default -> new PyTorchResult(null, null, ErrorResultTests.createRandom());
+        };
     }
 
     @Override

--- a/x-pack/qa/full-cluster-restart/src/test/java/org/elasticsearch/xpack/restart/MLModelDeploymentFullClusterRestartIT.java
+++ b/x-pack/qa/full-cluster-restart/src/test/java/org/elasticsearch/xpack/restart/MLModelDeploymentFullClusterRestartIT.java
@@ -30,7 +30,6 @@ import java.util.stream.Collectors;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
 
-@AbstractFullClusterRestartTestCase.AwaitsFix(bugUrl = "https://github.com/elastic/ml-cpp/pull/2258")
 public class MLModelDeploymentFullClusterRestartIT extends AbstractFullClusterRestartTestCase {
 
     // See PyTorchModelIT for how this model was created

--- a/x-pack/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/MLModelDeploymentsUpgradeIT.java
+++ b/x-pack/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/MLModelDeploymentsUpgradeIT.java
@@ -25,7 +25,6 @@ import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
 
-@AbstractUpgradeTestCase.AwaitsFix(bugUrl = "https://github.com/elastic/ml-cpp/pull/2258")
 public class MLModelDeploymentsUpgradeIT extends AbstractUpgradeTestCase {
 
     // See PyTorchModelIT for how this model was created


### PR DESCRIPTION
This is the Java side of elastic/ml-cpp#2258 which causes internal breakages while the PRs are out of sync due to naming changes.

Adds a method to `DeploymentManager` to update the number of allocations per process as implemented in elastic/ml-cpp#2258. 

Also `PyTorchResults` now has an error type rather than the error being a special case of the inference result and reverts the test mutes in #86263

