### PR TITLE
[7.17] Align spock platform used in build-tool and build-tool-internal (#86276)

### DIFF
--- a/build-tools/build.gradle
+++ b/build-tools/build.gradle
@@ -121,7 +121,7 @@ dependencies {
     testFixturesApi gradleApi()
     testFixturesApi gradleTestKit()
     testFixturesApi 'com.github.tomakehurst:wiremock-jre8-standalone:2.23.2'
-    testFixturesApi platform("org.spockframework:spock-bom:2.0-M5-groovy-3.0")
+    testFixturesApi platform("org.spockframework:spock-bom:2.0-groovy-3.0")
     testFixturesApi("org.spockframework:spock-core") {
         exclude module: "groovy"
     }


### PR DESCRIPTION
Backports the following commits to 7.17:
 - Align spock platform used in build-tool and build-tool-internal (#86276)