### PR TITLE
Better message in guessRootCauses

### DIFF
--- a/server/src/main/java/org/elasticsearch/ElasticsearchException.java
+++ b/server/src/main/java/org/elasticsearch/ElasticsearchException.java
@@ -635,7 +635,7 @@ public class ElasticsearchException extends RuntimeException implements ToXConte
                 }
             }
         }
-        return new ElasticsearchException[] { new ElasticsearchException(ex.getMessage(), ex) {
+        return new ElasticsearchException[] { new ElasticsearchException(String.join("->", ex.getStackTrace().map(i -> i.getMethodName())), ex) {
             @Override
             protected String getExceptionName() {
                 return getExceptionName(getCause());


### PR DESCRIPTION
Just hoping to inspire better solutions, with respect to https://github.com/elastic/elasticsearch/issues/85127 and follow up discussion https://github.com/elastic/elasticsearch/pull/85774 where it seems a better error message for the users is needed, I suggest returning the method names that appear in the stack trace joined by “->”. 