### PR TITLE
Correct docs on DLS bitset cache default values

### DIFF
--- a/docs/reference/settings/security-settings.asciidoc
+++ b/docs/reference/settings/security-settings.asciidoc
@@ -139,10 +139,10 @@ unused for `2h` (2 hours).
 (<<static-cluster-setting,Static>>)
 The maximum memory usage of cached `BitSet` entries for document level security.
 Document level security queries may depend on Lucene BitSet objects, and these are
-automatically cached to improve performance. Defaults to `10%` (that is, 10% of the
-heap assigned to the node), after which least-recently-used entries will be evicted.
-Can be configured as a raw number of bytes (for example, `200mb` or `1g`) or a 
-percentage of the node's JVM heap memory (for example, `5%`).
+automatically cached to improve performance. Can be configured as a raw number
+of bytes (such as `200mb` or `1g`) or a percentage of the node's JVM heap
+memory (such as `5%`). When the default value is exceeded, the least recently
+used entries are evicted. Defaults to `10%` of the heap assigned to the node).
 
 [discrete]
 [[token-service-settings]]

--- a/docs/reference/settings/security-settings.asciidoc
+++ b/docs/reference/settings/security-settings.asciidoc
@@ -142,7 +142,7 @@ Document level security queries may depend on Lucene BitSet objects, and these a
 automatically cached to improve performance. Can be configured as a raw number
 of bytes (such as `200mb` or `1g`) or a percentage of the node's JVM heap
 memory (such as `5%`). When the default value is exceeded, the least recently
-used entries are evicted. Defaults to `10%` of the heap assigned to the node).
+used entries are evicted. Defaults to `10%` of the heap assigned to the node.
 
 [discrete]
 [[token-service-settings]]

--- a/docs/reference/settings/security-settings.asciidoc
+++ b/docs/reference/settings/security-settings.asciidoc
@@ -133,14 +133,16 @@ from being configured. Defaults to `true`.
 The time-to-live for cached `BitSet` entries for document level security.
 Document level security queries may depend on Lucene BitSet objects, and these are
 automatically cached to improve performance. Defaults to expire entries that are
-unused for `168h` (7 days).
+unused for `2h` (2 hours).
 
 `xpack.security.dls.bitset.cache.size`::
 (<<static-cluster-setting,Static>>)
 The maximum memory usage of cached `BitSet` entries for document level security.
 Document level security queries may depend on Lucene BitSet objects, and these are
-automatically cached to improve performance. Defaults to `50mb`, after which
-least-recently-used entries will be evicted.
+automatically cached to improve performance. Defaults to `10%` (that is, 10% of the
+heap assigned to the node), after which least-recently-used entries will be evicted.
+Can be configured as a raw number of bytes (for example, `200mb` or `1g`) or a 
+percentage of the node's JVM heap memory (for example, `5%`).
 
 [discrete]
 [[token-service-settings]]


### PR DESCRIPTION
In #50535 (ES v7.6) the default values for the
`DocumentSubsetBitsetCache` settings were changed. However, the docs
were not updated at that time, and still reflect the old values for
these settings
