### PR TITLE
Add a test-only in-memory java source code compiler

### DIFF
--- a/test/framework/src/main/java/org/elasticsearch/bootstrap/BootstrapForTesting.java
+++ b/test/framework/src/main/java/org/elasticsearch/bootstrap/BootstrapForTesting.java
@@ -24,10 +24,12 @@ import org.elasticsearch.core.SuppressForbidden;
 import org.elasticsearch.jdk.JarHell;
 import org.elasticsearch.plugins.PluginInfo;
 import org.elasticsearch.secure_sm.SecureSM;
+import org.elasticsearch.test.compiler.InMemoryJavaCompiler;
 import org.elasticsearch.test.mockito.SecureMockMaker;
 import org.junit.Assert;
 
 import java.io.InputStream;
+import java.lang.invoke.MethodHandles;
 import java.net.SocketPermission;
 import java.net.URL;
 import java.nio.file.Files;
@@ -101,6 +103,13 @@ public class BootstrapForTesting {
 
         // init mockito
         SecureMockMaker.init();
+
+        // init the test in-memory java source code compiler
+        try {
+            MethodHandles.publicLookup().ensureInitialized(InMemoryJavaCompiler.class);
+        } catch (IllegalAccessException unexpected) {
+            throw new AssertionError(unexpected);
+        }
 
         // Log ifconfig output before SecurityManager is installed
         IfConfig.logIfNecessary();

--- a/test/framework/src/main/java/org/elasticsearch/test/compiler/InMemoryJavaCompiler.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/compiler/InMemoryJavaCompiler.java
@@ -1,0 +1,201 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.test.compiler;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.URI;
+import java.security.AccessControlContext;
+import java.security.AccessController;
+import java.security.DomainCombiner;
+import java.security.PrivilegedAction;
+import java.security.ProtectionDomain;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+
+import javax.tools.FileObject;
+import javax.tools.ForwardingJavaFileManager;
+import javax.tools.JavaCompiler;
+import javax.tools.JavaCompiler.CompilationTask;
+import javax.tools.JavaFileManager;
+import javax.tools.JavaFileObject;
+import javax.tools.JavaFileObject.Kind;
+import javax.tools.SimpleJavaFileObject;
+import javax.tools.ToolProvider;
+
+/**
+ * An in-memory java source code compiler. InMemoryJavaCompiler can be used for compiling source
+ * code, represented as a CharSequence, to byte code, represented as a byte[].
+ *
+ * <p> The compiler will not use the file system at all, instead using a ByteArrayOutputStream for
+ * storing the byte code.
+ *
+ * <p> Example:
+ * <pre>{@code
+ *     Map<String, CharSequence> sources = Map.of(
+ *       "module-info",
+ *       """
+ *       module foo {
+ *         exports p;
+ *       }
+ *       """,
+ *       "p.Foo",
+ *       """
+ *       package p;
+ *       public class Foo implements java.util.function.Supplier<String> {
+ *        @Override public String get() {
+ *          return "Hello World!";
+ *         }
+ *       }
+ *       """
+ *     );
+ *     Map<String, byte[]> result = compile(sources);
+ * }</pre>
+ */
+public class InMemoryJavaCompiler {
+    private static class InMemoryJavaFileObject extends SimpleJavaFileObject {
+        private final String className;
+        private final CharSequence sourceCode;
+        private final ByteArrayOutputStream byteCode;
+
+        InMemoryJavaFileObject(String className, CharSequence sourceCode) {
+            super(URI.create("string:///" + className.replace('.', '/') + Kind.SOURCE.extension), Kind.SOURCE);
+            this.className = className;
+            this.sourceCode = sourceCode;
+            this.byteCode = new ByteArrayOutputStream();
+        }
+
+        @Override
+        public CharSequence getCharContent(boolean ignoreEncodingErrors) {
+            return sourceCode;
+        }
+
+        @Override
+        public OutputStream openOutputStream() {
+            return byteCode;
+        }
+
+        public byte[] getByteCode() {
+            return byteCode.toByteArray();
+        }
+
+        public String getClassName() {
+            return className;
+        }
+    }
+
+    private static class FileManagerWrapper extends ForwardingJavaFileManager<JavaFileManager> {
+
+        private final List<InMemoryJavaFileObject> files;
+
+        FileManagerWrapper(List<InMemoryJavaFileObject> files) {
+            super(getCompiler().getStandardFileManager(null, null, null));
+            this.files = List.copyOf(files);
+        }
+
+        FileManagerWrapper(InMemoryJavaFileObject file) {
+            super(getCompiler().getStandardFileManager(null, null, null));
+            this.files = List.of(file);
+        }
+
+        @Override
+        public JavaFileObject getJavaFileForOutput(Location location, String className, Kind kind, FileObject sibling) throws IOException {
+            return files.stream()
+                .filter(f -> f.getClassName().endsWith(className))
+                .findFirst()
+                .orElseThrow(newIOException(className, files));
+        }
+
+        static Supplier<IOException> newIOException(String className, List<InMemoryJavaFileObject> files) {
+            return () -> new IOException(
+                "Expected class with name " + className + ", in " + files.stream().map(InMemoryJavaFileObject::getClassName).toList()
+            );
+        }
+    }
+
+    /**
+     * Compiles the classes with the given names and source code.
+     *
+     * @param sources A map of class names to source code
+     * @param options Additional command line options (optional)
+     * @throws RuntimeException If the compilation did not succeed
+     * @return A Map containing the resulting byte code from the compilation, one entry per class name
+     */
+    public static Map<String, byte[]> compile(Map<String, CharSequence> sources, String... options) {
+        var files = sources.entrySet().stream().map(e -> new InMemoryJavaFileObject(e.getKey(), e.getValue())).toList();
+        CompilationTask task = getCompilationTask(files, options);
+
+        boolean result = privilegedCall(task::call);
+        if (result == false) {
+            throw new RuntimeException("Could not compile " + sources.entrySet().stream().toList());
+        }
+
+        return files.stream().collect(Collectors.toMap(InMemoryJavaFileObject::getClassName, InMemoryJavaFileObject::getByteCode));
+    }
+
+    /**
+     * Compiles the class with the given name and source code.
+     *
+     * @param className The name of the class
+     * @param sourceCode The source code for the class with name {@code className}
+     * @param options Additional command line options (optional)
+     * @throws RuntimeException If the compilation did not succeed
+     * @return The resulting byte code from the compilation
+     */
+    public static byte[] compile(String className, CharSequence sourceCode, String... options) {
+        InMemoryJavaFileObject file = new InMemoryJavaFileObject(className, sourceCode);
+        CompilationTask task = getCompilationTask(file, options);
+
+        boolean result = privilegedCall(task::call);
+        if (result == false) {
+            throw new RuntimeException("Could not compile " + className + " with source code " + sourceCode);
+        }
+
+        return file.getByteCode();
+    }
+
+    private static JavaCompiler getCompiler() {
+        return ToolProvider.getSystemJavaCompiler();
+    }
+
+    private static CompilationTask getCompilationTask(List<InMemoryJavaFileObject> files, String... options) {
+        List<String> opts = Arrays.stream(options).toList();
+        return getCompiler().getTask(null, new FileManagerWrapper(files), null, opts, null, files);
+    }
+
+    private static CompilationTask getCompilationTask(InMemoryJavaFileObject file, String... options) {
+        List<String> opts = Arrays.stream(options).toList();
+        return getCompiler().getTask(null, new FileManagerWrapper(file), null, opts, null, List.of(file));
+    }
+
+    // -- security manager related stuff, to facilitate asserting permissions during compilation
+    // (since the JDK compiler checks a number of permissions)
+
+    @SuppressWarnings("removal")
+    private static AccessControlContext getContext() {
+        ProtectionDomain[] pda = new ProtectionDomain[] { privilegedCall(org.elasticsearch.secure_sm.SecureSM.class::getProtectionDomain) };
+        DomainCombiner combiner = (ignoreCurrent, ignoreAssigned) -> pda;
+        AccessControlContext acc = new AccessControlContext(AccessController.getContext(), combiner);
+        // getContext must be called with the new acc so that a combined context will be created
+        return AccessController.doPrivileged((PrivilegedAction<AccessControlContext>) AccessController::getContext, acc);
+    }
+
+    // Use the all-powerful protection domain of secure_sm for wrapping calls
+    @SuppressWarnings("removal")
+    private static final AccessControlContext context = getContext();
+
+    @SuppressWarnings("removal")
+    static <T> T privilegedCall(Supplier<T> supplier) {
+        return AccessController.doPrivileged((PrivilegedAction<T>) supplier::get, context);
+    }
+}

--- a/test/framework/src/main/java/org/elasticsearch/test/compiler/InMemoryJavaCompiler.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/compiler/InMemoryJavaCompiler.java
@@ -17,7 +17,6 @@ import java.security.AccessController;
 import java.security.DomainCombiner;
 import java.security.PrivilegedAction;
 import java.security.ProtectionDomain;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Supplier;
@@ -169,13 +168,11 @@ public class InMemoryJavaCompiler {
     }
 
     private static CompilationTask getCompilationTask(List<InMemoryJavaFileObject> files, String... options) {
-        List<String> opts = Arrays.stream(options).toList();
-        return getCompiler().getTask(null, new FileManagerWrapper(files), null, opts, null, files);
+        return getCompiler().getTask(null, new FileManagerWrapper(files), null, List.of(options), null, files);
     }
 
     private static CompilationTask getCompilationTask(InMemoryJavaFileObject file, String... options) {
-        List<String> opts = Arrays.stream(options).toList();
-        return getCompiler().getTask(null, new FileManagerWrapper(file), null, opts, null, List.of(file));
+        return getCompiler().getTask(null, new FileManagerWrapper(file), null, List.of(options), null, List.of(file));
     }
 
     // -- security manager related stuff, to facilitate asserting permissions during compilation

--- a/test/framework/src/test/java/org/elasticsearch/test/compiler/InMemoryJavaCompilerTests.java
+++ b/test/framework/src/test/java/org/elasticsearch/test/compiler/InMemoryJavaCompilerTests.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.test.compiler;
+
+import org.elasticsearch.common.io.stream.ByteArrayStreamInput;
+import org.elasticsearch.test.ESTestCase;
+
+import java.lang.module.ModuleDescriptor;
+import java.util.Map;
+
+import static org.elasticsearch.test.compiler.InMemoryJavaCompiler.compile;
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasEntry;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+
+public class InMemoryJavaCompilerTests extends ESTestCase {
+
+    // mostly good enough if compile succeeds 1) without throwing, and 2) returns non-null
+
+    public void testCompileBasic() {
+        assertThat(compile("Foo", "public class Foo { }"), notNullValue());
+    }
+
+    public void testCompilePackage() {
+        assertThat(compile("p.Foo", "package p; public class Foo { }"), notNullValue());
+    }
+
+    public void testCompileSerializableRecord() {
+        assertThat(compile("Foo", "public record Foo () implements java.io.Serializable { }"), notNullValue());
+    }
+
+    public void testCompileModule() throws Exception {
+        byte[] ba = compile("module-info", "module foo { requires java.base; }");
+        assertThat(ba, notNullValue());
+        var md = ModuleDescriptor.read(new ByteArrayStreamInput(ba));
+        assertThat(md.name(), equalTo("foo"));
+    }
+
+    public void testCompileModuleWithExports() {
+        Map<String, CharSequence> sources = Map.of("module-info", """
+            module foo {
+              exports p;
+            }
+            """, "p.Foo", """
+            package p;
+            public class Foo implements java.util.function.Supplier<String> {
+              @Override public String get() {
+                return "Hello World!";
+              }
+            }
+            """);
+        var result = compile(sources);
+        assertThat(result, notNullValue());
+        assertThat(result, allOf(hasEntry(is("module-info"), notNullValue()), hasEntry(is("p.Foo"), notNullValue())));
+    }
+
+    public void testCompileModuleProvider() {
+        Map<String, CharSequence> sources = Map.of("module-info", """
+            module x.foo.impl {
+              exports p;
+              opens q;
+              provides java.util.function.IntSupplier with p.FooIntSupplier;
+            }
+            """, "p.FooIntSupplier", """
+            package p;
+            public class FooIntSupplier implements java.util.function.IntSupplier, q.MsgSupplier {
+              @Override public int getAsInt() {
+                return 12;
+              }
+              @Override public String msg() {
+                return "Hello from FooIntSupplier";
+              }
+            }
+            """, "q.MsgSupplier", """
+            package q;
+            public interface MsgSupplier {
+              String msg();
+            }
+            """);
+        var classToBytes = InMemoryJavaCompiler.compile(sources);
+        var result = compile(sources);
+        assertThat(result, notNullValue());
+        assertThat(
+            result,
+            allOf(
+                hasEntry(is("module-info"), notNullValue()),
+                hasEntry(is("p.FooIntSupplier"), notNullValue()),
+                hasEntry(is("q.MsgSupplier"), notNullValue())
+            )
+        );
+    }
+
+    static final Class<RuntimeException> RE = RuntimeException.class;
+
+    public void testCompileFailure() {
+        // Expect:
+        // /p/Foo.java:1: error: cannot find symbol
+        // package p; public class Foo extends Bar { }
+        // ^
+        // symbol: class Bar
+        // 1 error
+        var e = expectThrows(RE, () -> compile("p.Foo", "package p; public class Foo extends Bar { }"));
+        assertThat(e.getMessage(), containsString("Could not compile p.Foo with source code"));
+    }
+}


### PR DESCRIPTION
This PR adds a minimal test-only in-memory Java source code compiler.

With this we can more easily write tests, containing small code
snippets, for the embedded class loader, and assert the loader's
capabilities.

This PR simply adds the test compiler and a unit test. Subsequent PR's
will make use of it in test specific scenarios.