### PR TITLE
Add option to define a geo_bounding_box query using a geohash or a geotile

### DIFF
--- a/docs/changelog/86292.yaml
+++ b/docs/changelog/86292.yaml
@@ -1,0 +1,5 @@
+pr: 86292
+summary: Add option to define a `geo_bounding_box` query using a geohash or a geotile
+area: Geo
+type: enhancement
+issues: []

--- a/docs/changelog/86292.yaml
+++ b/docs/changelog/86292.yaml
@@ -1,5 +1,0 @@
-pr: 86292
-summary: Add option to define a `geo_bounding_box` query using a geohash or a geotile
-area: Geo
-type: enhancement
-issues: []

--- a/docs/reference/query-dsl/geo-bounding-box-query.asciidoc
+++ b/docs/reference/query-dsl/geo-bounding-box-query.asciidoc
@@ -265,6 +265,38 @@ GET my_locations/_search
 --------------------------------------------------
 
 [discrete]
+===== Lat Lon As a Geohash
+
+When geohashes are used to specify the bounding the edges of the
+bounding box, the geohashes are treated as rectangles. The bounding
+box is defined in such a way that its top left corresponds to the top
+left corner of the geohash specified in the `top_left` parameter and
+its bottom right is defined as the bottom right of the geohash
+specified in the `bottom_right` parameter.
+
+[source,console]
+--------------------------------------------------
+GET my_locations/_search
+{
+  "query": {
+    "bool": {
+      "must": {
+        "match_all": {}
+      },
+      "filter": {
+        "geo_bounding_box": {
+          "pin.location": {
+            "top_left": "dr5r9ydj2y73",
+            "bottom_right": "drj7teegpus6"
+          }
+        }
+      }
+    }
+  }
+}
+--------------------------------------------------
+
+[discrete]
 ===== Bounding Box as Well-Known Text (WKT)
 
 [source,console]
@@ -291,6 +323,27 @@ GET my_locations/_search
 [discrete]
 ===== Geohash
 
+It specifies a bounding box that would match entire area of a geohash.
+
+[source,console]
+--------------------------------------------------
+GET my_locations/_search
+{
+  "query": {
+    "geo_bounding_box": {
+      "pin.location": {
+        "geohash": "dr"
+      }
+    }
+  }
+}
+--------------------------------------------------
+
+[discrete]
+===== Geotile
+
+It specifies a bounding box that would match entire area of a geotile.
+
 [source,console]
 --------------------------------------------------
 GET my_locations/_search
@@ -303,8 +356,7 @@ GET my_locations/_search
       "filter": {
         "geo_bounding_box": {
           "pin.location": {
-            "top_left": "dr5r9ydj2y73",
-            "bottom_right": "drj7teegpus6"
+            "geotile": "1/0/0"
           }
         }
       }
@@ -312,37 +364,6 @@ GET my_locations/_search
   }
 }
 --------------------------------------------------
-
-
-When geohashes are used to specify the bounding the edges of the
-bounding box, the geohashes are treated as rectangles. The bounding
-box is defined in such a way that its top left corresponds to the top
-left corner of the geohash specified in the `top_left` parameter and
-its bottom right is defined as the bottom right of the geohash
-specified in the `bottom_right` parameter.
-
-In order to specify a bounding box that would match entire area of a
-geohash the geohash can be specified in both `top_left` and
-`bottom_right` parameters:
-
-[source,console]
---------------------------------------------------
-GET my_locations/_search
-{
-  "query": {
-    "geo_bounding_box": {
-      "pin.location": {
-        "top_left": "dr",
-        "bottom_right": "dr"
-      }
-    }
-  }
-}
---------------------------------------------------
-
-In this example, the geohash `dr` will produce the bounding box
-query with the top left corner at `45.0,-78.75` and the bottom right
-corner at `39.375,-67.5`.
 
 [discrete]
 ==== Vertices

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search/400_geo_bounding_box_query.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search/400_geo_bounding_box_query.yml
@@ -1,0 +1,114 @@
+---
+setup:
+  - do:
+      indices.create:
+        index: test_index
+        body:
+          mappings:
+            properties:
+              location:
+                type: geo_point
+
+  - do:
+      bulk:
+        refresh: true
+        body:
+          - '{"index": {"_index": "test_index", "_id": "u1"}}'
+          - '{"location": "34.5, 60.5"}'
+          - '{"index": {"_index": "test_index", "_id": "u2"}}'
+          - '{"location": {"lat" : -34.5 , "lon" : 60.5}}'
+          - '{"index": {"_index": "test_index", "_id": "u3"}}'
+          - '{"location": [-60.5, 34.5]}'
+          - '{"index": {"_index": "test_index", "_id": "u4"}}'
+          - '{"location": "POINT(-60.5, -34.5)"}'
+          - '{"index": {"_index": "test_index", "_id": "u5"}}'
+          - '{"location": {"type" : "Point", "coordinates" : [0, 0]}}'
+---
+"bounding box explicit":
+  - do:
+      search:
+        rest_total_hits_as_int: true
+        index: test_index
+        body:
+          query:
+            geo_bounding_box:
+              location:
+                top_left: [-180, 90]
+                bottom_right: [0, 0]
+
+  - match: {hits.total: 2}
+
+---
+"bounding box explicit with lat lot":
+  - do:
+      search:
+        rest_total_hits_as_int: true
+        index: test_index
+        body:
+          query:
+            geo_bounding_box:
+              location:
+                top_left:
+                  lat: 90
+                  lon: -180
+                bottom_right:
+                   lat: 0
+                   lon: 0
+
+  - match: {hits.total: 2}
+
+---
+"bounding box wkt":
+  - do:
+      search:
+        rest_total_hits_as_int: true
+        index: test_index
+        body:
+          query:
+            geo_bounding_box:
+              location:
+                wkt: "BBOX (0, -180, 90, 0)"
+
+  - match: {hits.total: 2}
+
+---
+"bounding box geohash":
+  - do:
+      search:
+        rest_total_hits_as_int: true
+        index: test_index
+        body:
+          query:
+            geo_bounding_box:
+              location:
+                geohash: "s"
+
+  - match: {hits.total: 1}
+---
+"bounding box lat lon geohash":
+  - do:
+      search:
+        rest_total_hits_as_int: true
+        index: test_index
+        body:
+          query:
+            geo_bounding_box:
+              location:
+                top_left: "s"
+                bottom_right: "s"
+
+  - match: {hits.total: 1}
+
+---
+"bounding box geotile":
+  - do:
+      search:
+        rest_total_hits_as_int: true
+        index: test_index
+        body:
+          query:
+            geo_bounding_box:
+              location:
+                geotile: "1/0/0"
+
+  - match: {hits.total: 2}

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search/400_geo_bounding_box_query.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search/400_geo_bounding_box_query.yml
@@ -14,15 +14,13 @@ setup:
         refresh: true
         body:
           - '{"index": {"_index": "test_index", "_id": "u1"}}'
-          - '{"location": "34.5, 60.5"}'
+          - '{"location": "45.0, 45.0"}'
           - '{"index": {"_index": "test_index", "_id": "u2"}}'
-          - '{"location": {"lat" : -34.5 , "lon" : 60.5}}'
+          - '{"location": {"lat" : -45.0 , "lon" : 45.0}}'
           - '{"index": {"_index": "test_index", "_id": "u3"}}'
-          - '{"location": [-60.5, 34.5]}'
+          - '{"location": [-45.0, 45.0]}'
           - '{"index": {"_index": "test_index", "_id": "u4"}}'
-          - '{"location": "POINT(-60.5, -34.5)"}'
-          - '{"index": {"_index": "test_index", "_id": "u5"}}'
-          - '{"location": {"type" : "Point", "coordinates" : [45, 45]}}'
+          - '{"location": "POINT(-45.0 -45.0)"}'
 ---
 "bounding box explicit":
   - do:

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search/400_geo_bounding_box_query.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search/400_geo_bounding_box_query.yml
@@ -22,7 +22,7 @@ setup:
           - '{"index": {"_index": "test_index", "_id": "u4"}}'
           - '{"location": "POINT(-60.5, -34.5)"}'
           - '{"index": {"_index": "test_index", "_id": "u5"}}'
-          - '{"location": {"type" : "Point", "coordinates" : [0, 0]}}'
+          - '{"location": {"type" : "Point", "coordinates" : [45, 45]}}'
 ---
 "bounding box explicit":
   - do:
@@ -36,7 +36,7 @@ setup:
                 top_left: [-180, 90]
                 bottom_right: [0, 0]
 
-  - match: {hits.total: 2}
+  - match: {hits.total: 1}
 
 ---
 "bounding box explicit with lat lot":
@@ -55,7 +55,7 @@ setup:
                    lat: 0
                    lon: 0
 
-  - match: {hits.total: 2}
+  - match: {hits.total: 1}
 
 ---
 "bounding box wkt":
@@ -67,12 +67,15 @@ setup:
           query:
             geo_bounding_box:
               location:
-                wkt: "BBOX (0, -180, 90, 0)"
+                wkt: "BBOX (-180, 0, 90, 0)"
 
-  - match: {hits.total: 2}
+  - match: {hits.total: 1}
 
 ---
 "bounding box geohash":
+  - skip:
+      version: ' - 8.2.99'
+      reason: fetch profiling implemented in 8.3.0
   - do:
       search:
         rest_total_hits_as_int: true
@@ -84,6 +87,7 @@ setup:
                 geohash: "s"
 
   - match: {hits.total: 1}
+
 ---
 "bounding box lat lon geohash":
   - do:
@@ -101,6 +105,9 @@ setup:
 
 ---
 "bounding box geotile":
+  - skip:
+      version: ' - 8.2.99'
+      reason: fetch profiling implemented in 8.3.0
   - do:
       search:
         rest_total_hits_as_int: true
@@ -111,4 +118,4 @@ setup:
               location:
                 geotile: "1/0/0"
 
-  - match: {hits.total: 2}
+  - match: {hits.total: 1}

--- a/server/src/main/java/org/elasticsearch/index/query/GeoBoundingBoxQueryBuilder.java
+++ b/server/src/main/java/org/elasticsearch/index/query/GeoBoundingBoxQueryBuilder.java
@@ -25,6 +25,7 @@ import org.elasticsearch.geometry.Rectangle;
 import org.elasticsearch.geometry.utils.Geohash;
 import org.elasticsearch.index.mapper.GeoShapeQueryable;
 import org.elasticsearch.index.mapper.MappedFieldType;
+import org.elasticsearch.search.aggregations.bucket.geogrid.GeoTileUtils;
 import org.elasticsearch.xcontent.ParseField;
 import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xcontent.XContentParser;
@@ -139,13 +140,33 @@ public class GeoBoundingBoxQueryBuilder extends AbstractQueryBuilder<GeoBounding
     }
 
     /**
-     * Adds points from a single geohash.
+     * Adds bounding box represented by the provided geohash.
+     * @param geohash The geohash for computing the bounding box.
+     * @deprecated use {@link #setCornersFromGeohash(String)} instead
+     */
+    @Deprecated
+    public GeoBoundingBoxQueryBuilder setCorners(final String geohash) {
+        return setCornersFromGeohash(geohash);
+    }
+
+    /**
+     * Adds bounding box represented by the provided geohash.
      * @param geohash The geohash for computing the bounding box.
      */
-    public GeoBoundingBoxQueryBuilder setCorners(final String geohash) {
+    public GeoBoundingBoxQueryBuilder setCornersFromGeohash(final String geohash) {
         // get the bounding box of the geohash and set topLeft and bottomRight
         Rectangle ghBBox = Geohash.toBoundingBox(geohash);
         return setCorners(new GeoPoint(ghBBox.getMaxY(), ghBBox.getMinX()), new GeoPoint(ghBBox.getMinY(), ghBBox.getMaxX()));
+    }
+
+    /**
+     * Adds bounding box represented by the provided geotile.
+     * @param geotile The geotile for computing the bounding box.
+     */
+    public GeoBoundingBoxQueryBuilder setCornersFromGeoTile(final String geotile) {
+        // get the bounding box of the geotile and set topLeft and bottomRight
+        Rectangle tile = GeoTileUtils.toBoundingBox(geotile);
+        return setCorners(new GeoPoint(tile.getMaxY(), tile.getMinX()), new GeoPoint(tile.getMinY(), tile.getMaxX()));
     }
 
     /**


### PR DESCRIPTION
This PR extends the geo_bounding_box API so users can define a bounding box by defining a single geohash using the `geohash` parameter or a geotile using the `geotile` parameter.

relates https://github.com/elastic/elasticsearch/issues/85727 