### PR TITLE
Add test utility methods for creating simple jar files

### DIFF
--- a/test/framework/src/main/java/org/elasticsearch/test/jar/JarUtils.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/jar/JarUtils.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.test.jar;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.util.Map;
+import java.util.jar.JarEntry;
+import java.util.jar.JarOutputStream;
+import java.util.jar.Manifest;
+
+public final class JarUtils {
+
+    private JarUtils() {}
+
+    /**
+     * Creates a jar file with the given manifest and list of (empty) jar file entry names. The
+     * jar file entries will be added to the jar, but will all be empty (no contents).
+     *
+     * @param dir the directory in which the jar will be created
+     * @param name the name of the jar file
+     * @param manifest the manifest, may be null
+     * @param files the list of jar entry names, to be added to the jar
+     * @return the path of the jar file
+     * @throws IOException if an I/O error occurs
+     */
+    public static Path createJar(Path dir, String name, Manifest manifest, String... files) throws IOException {
+        Path jarpath = dir.resolve(name);
+        UncheckedIOFunction<OutputStream, JarOutputStream> jarOutFunc;
+        if (manifest == null) {
+            jarOutFunc = os -> new JarOutputStream(os);
+        } else {
+            jarOutFunc = os -> new JarOutputStream(os, manifest);
+        }
+        try (var os = Files.newOutputStream(jarpath, StandardOpenOption.CREATE); var out = jarOutFunc.apply(os)) {
+            for (String file : files) {
+                out.putNextEntry(new JarEntry(file));
+            }
+        }
+        return jarpath;
+    }
+
+    /**
+     * Creates a jar file with the given entries.
+     *
+     * @param jarfile the jar file path
+     * @param entries map of entries to add; jar entry name to byte contents
+     * @throws IOException if an I/O error occurs
+     */
+    public static void createJar(Path jarfile, Map<String, byte[]> entries) throws IOException {
+        try (OutputStream out = Files.newOutputStream(jarfile); JarOutputStream jos = new JarOutputStream(out)) {
+            for (var entry : entries.entrySet()) {
+                String name = entry.getKey();
+                jos.putNextEntry(new JarEntry(name));
+                var bais = new ByteArrayInputStream(entry.getValue());
+                bais.transferTo(jos);
+                jos.closeEntry();
+            }
+        }
+    }
+
+    @FunctionalInterface
+    interface UncheckedIOFunction<T, R> {
+        R apply(T t) throws IOException;
+    }
+}

--- a/test/framework/src/main/java/org/elasticsearch/test/jar/JarUtils.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/jar/JarUtils.java
@@ -57,7 +57,7 @@ public final class JarUtils {
      * @param entries map of entries to add; jar entry name to byte contents
      * @throws IOException if an I/O error occurs
      */
-    public static void createJar(Path jarfile, Map<String, byte[]> entries) throws IOException {
+    public static void createJarWithEntries(Path jarfile, Map<String, byte[]> entries) throws IOException {
         try (OutputStream out = Files.newOutputStream(jarfile); JarOutputStream jos = new JarOutputStream(out)) {
             for (var entry : entries.entrySet()) {
                 String name = entry.getKey();

--- a/test/framework/src/test/java/org/elasticsearch/test/jar/JarUtilsTests.java
+++ b/test/framework/src/test/java/org/elasticsearch/test/jar/JarUtilsTests.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.test.jar;
+
+import org.elasticsearch.core.SuppressForbidden;
+import org.elasticsearch.test.ESTestCase;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.Map;
+import java.util.Set;
+import java.util.jar.JarEntry;
+import java.util.jar.JarFile;
+import java.util.jar.Manifest;
+import java.util.stream.Collectors;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.elasticsearch.test.jar.JarUtils.createJar;
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasEntry;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+
+@SuppressForbidden(reason = "requires access to JarFile to assert jar contents")
+public class JarUtilsTests extends ESTestCase {
+
+    public void testCreateJarWithContents() throws IOException {
+        Path dir = createTempDir();
+
+        Map<String, byte[]> jarEntries = Map.of(
+            "a/b/c/hello.txt",
+            "hello ".getBytes(UTF_8),
+            "a/b/c/d/world.txt",
+            "world!".getBytes(UTF_8),
+            "META-INF/MANIFEST.MF",
+            "Multi-Release: true\n".getBytes(UTF_8)
+        );
+        Path jar = dir.resolve("foo.jar");
+        createJar(jar, jarEntries);
+
+        try (JarFile jarFile = new JarFile(jar.toFile())) {
+            Map<String, byte[]> entries = jarFile.stream().collect(Collectors.toMap(JarEntry::getName, e -> entryContents(e, jarFile)));
+            assertThat(
+                entries,
+                allOf(
+                    hasEntry(is("a/b/c/hello.txt"), is("hello ".getBytes(UTF_8))),
+                    hasEntry(is("a/b/c/d/world.txt"), is("world!".getBytes(UTF_8)))
+                )
+            );
+            assertThat(jarFile.getManifest().getMainAttributes().getValue("Multi-Release"), equalTo("true"));
+        }
+    }
+
+    public void testCreateJarWithoutContents() throws IOException {
+        Path dir = createTempDir();
+        Manifest manifest = new Manifest(new ByteArrayInputStream("""
+            Manifest-Version: 1.0
+            Automatic-Module-Name: foo.bar
+            """.getBytes(UTF_8)));
+        Path jarPath = JarUtils.createJar(
+            dir,
+            "impl.jar",
+            manifest,
+            "module-info.class",
+            "p/Foo.class",
+            "q/Bar.class",
+            "META-INF/services/a.b.c.Foo"
+        );
+        try (JarFile jarFile = new JarFile(jarPath.toFile())) {
+            Set<String> entries = jarFile.stream().map(JarEntry::getName).collect(Collectors.toSet());
+            assertThat(
+                entries,
+                containsInAnyOrder(
+                    is("module-info.class"),
+                    is("p/Foo.class"),
+                    is("q/Bar.class"),
+                    is("META-INF/services/a.b.c.Foo"),
+                    is("META-INF/MANIFEST.MF")
+                )
+            );
+            assertThat(jarFile.getManifest().getMainAttributes().getValue("Manifest-Version"), equalTo("1.0"));
+            assertThat(jarFile.getManifest().getMainAttributes().getValue("Automatic-Module-Name"), equalTo("foo.bar"));
+        }
+    }
+
+    public void testCreateJarNoManifest() throws IOException {
+        Path dir = createTempDir();
+        Path jarPath = JarUtils.createJar(dir, "bar.jar", null, "q/Bar.class");
+        try (JarFile jarFile = new JarFile(jarPath.toFile())) {
+            Set<String> entries = jarFile.stream().map(JarEntry::getName).collect(Collectors.toSet());
+            assertThat(entries, containsInAnyOrder(is("q/Bar.class")));
+            assertThat(jarFile.getManifest(), nullValue());
+        }
+    }
+
+    private static byte[] entryContents(JarEntry je, JarFile jf) {
+        try {
+            return jf.getInputStream(je).readAllBytes();
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/test/framework/src/test/java/org/elasticsearch/test/jar/JarUtilsTests.java
+++ b/test/framework/src/test/java/org/elasticsearch/test/jar/JarUtilsTests.java
@@ -22,6 +22,7 @@ import java.util.jar.Manifest;
 import java.util.stream.Collectors;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.elasticsearch.test.jar.JarUtils.createJar;
 import static org.elasticsearch.test.jar.JarUtils.createJarWithEntries;
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.containsInAnyOrder;
@@ -45,7 +46,7 @@ public class JarUtilsTests extends ESTestCase {
             "Multi-Release: true\n".getBytes(UTF_8)
         );
         Path jar = dir.resolve("foo.jar");
-        JarUtils.createJarWithEntries(jar, jarEntries);
+        createJarWithEntries(jar, jarEntries);
 
         try (JarFile jarFile = new JarFile(jar.toFile())) {
             Map<String, byte[]> entries = jarFile.stream().collect(Collectors.toMap(JarEntry::getName, e -> entryContents(e, jarFile)));
@@ -66,7 +67,7 @@ public class JarUtilsTests extends ESTestCase {
             Manifest-Version: 1.0
             Automatic-Module-Name: foo.bar
             """.getBytes(UTF_8)));
-        Path jarPath = JarUtils.createJar(
+        Path jarPath = createJar(
             dir,
             "impl.jar",
             manifest,
@@ -94,7 +95,7 @@ public class JarUtilsTests extends ESTestCase {
 
     public void testCreateJarNoManifest() throws IOException {
         Path dir = createTempDir();
-        Path jarPath = JarUtils.createJar(dir, "bar.jar", null, "q/Bar.class");
+        Path jarPath = createJar(dir, "bar.jar", null, "q/Bar.class");
         try (JarFile jarFile = new JarFile(jarPath.toFile())) {
             Set<String> entries = jarFile.stream().map(JarEntry::getName).collect(Collectors.toSet());
             assertThat(entries, containsInAnyOrder(is("q/Bar.class")));

--- a/test/framework/src/test/java/org/elasticsearch/test/jar/JarUtilsTests.java
+++ b/test/framework/src/test/java/org/elasticsearch/test/jar/JarUtilsTests.java
@@ -22,7 +22,7 @@ import java.util.jar.Manifest;
 import java.util.stream.Collectors;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
-import static org.elasticsearch.test.jar.JarUtils.createJar;
+import static org.elasticsearch.test.jar.JarUtils.createJarWithEntries;
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.equalTo;
@@ -45,7 +45,7 @@ public class JarUtilsTests extends ESTestCase {
             "Multi-Release: true\n".getBytes(UTF_8)
         );
         Path jar = dir.resolve("foo.jar");
-        createJar(jar, jarEntries);
+        JarUtils.createJarWithEntries(jar, jarEntries);
 
         try (JarFile jarFile = new JarFile(jar.toFile())) {
             Map<String, byte[]> entries = jarFile.stream().collect(Collectors.toMap(JarEntry::getName, e -> entryContents(e, jarFile)));


### PR DESCRIPTION
This PR adds test utility methods for creating simple jar files.

With this we can more easily write tests requiring jar archives for
the embedded class loader, and assert the loader's capabilities.

This PR simply adds the test utility methods for creating simple jar
files. Subsequent PR's will make use of these in test specific
scenarios.