### PR TITLE
Intern field names in Mappers

### DIFF
--- a/docs/changelog/86301.yaml
+++ b/docs/changelog/86301.yaml
@@ -1,0 +1,5 @@
+pr: 86301
+summary: Intern field names in Mappers
+area: Mapping
+type: enhancement
+issues: []

--- a/server/src/main/java/org/elasticsearch/index/mapper/MappedFieldType.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/MappedFieldType.java
@@ -74,7 +74,7 @@ public abstract class MappedFieldType {
         TextSearchInfo textSearchInfo,
         Map<String, String> meta
     ) {
-        this.name = Objects.requireNonNull(name);
+        this.name = Mapper.internFieldName(name);
         this.isIndexed = isIndexed;
         this.isStored = isStored;
         this.docValues = hasDocValues;

--- a/server/src/main/java/org/elasticsearch/index/mapper/Mapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/Mapper.java
@@ -10,6 +10,7 @@ package org.elasticsearch.index.mapper;
 
 import org.elasticsearch.Version;
 import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.util.StringLiteralDeduplicator;
 import org.elasticsearch.xcontent.ToXContentFragment;
 
 import java.util.Map;
@@ -22,7 +23,7 @@ public abstract class Mapper implements ToXContentFragment, Iterable<Mapper> {
         protected final String name;
 
         protected Builder(String name) {
-            this.name = name;
+            this.name = internFieldName(name);
         }
 
         public String name() {
@@ -48,7 +49,7 @@ public abstract class Mapper implements ToXContentFragment, Iterable<Mapper> {
 
     public Mapper(String simpleName) {
         Objects.requireNonNull(simpleName);
-        this.simpleName = simpleName;
+        this.simpleName = internFieldName(simpleName);
     }
 
     /** Returns the simple name, which identifies this mapper against other mappers at the same level in the mappers hierarchy
@@ -78,5 +79,16 @@ public abstract class Mapper implements ToXContentFragment, Iterable<Mapper> {
     @Override
     public String toString() {
         return Strings.toString(this);
+    }
+
+    private static final StringLiteralDeduplicator fieldNameStringDeduplicator = new StringLiteralDeduplicator();
+
+    /**
+     * Interns the given field name string through a {@link StringLiteralDeduplicator}.
+     * @param fieldName field name to intern
+     * @return interned field name string
+     */
+    public static String internFieldName(String fieldName) {
+        return fieldNameStringDeduplicator.deduplicate(fieldName);
     }
 }

--- a/server/src/main/java/org/elasticsearch/index/mapper/ObjectMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/ObjectMapper.java
@@ -28,7 +28,6 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
-import java.util.Optional;
 
 public class ObjectMapper extends Mapper implements Cloneable {
     private static final DeprecationLogger deprecationLogger = DeprecationLogger.getLogger(ObjectMapper.class);
@@ -142,10 +141,6 @@ public class ObjectMapper extends Mapper implements Cloneable {
                 return child.newBuilder(context.indexSettings().getIndexVersionCreated());
             }
             throw new IllegalArgumentException("Missing intermediate object " + fullChildName);
-        }
-
-        public Optional<Mapper.Builder> getBuilder(String name) {
-            return mappersBuilders.stream().filter(b -> b.name().equals(name)).findFirst();
         }
 
         protected final Map<String, Mapper> buildMappers(boolean root, MapperBuilderContext context) {
@@ -309,7 +304,7 @@ public class ObjectMapper extends Mapper implements Cloneable {
         if (name.isEmpty()) {
             throw new IllegalArgumentException("name cannot be empty string");
         }
-        this.fullPath = fullPath;
+        this.fullPath = internFieldName(fullPath);
         this.enabled = enabled;
         this.dynamic = dynamic;
         if (mappers == null) {


### PR DESCRIPTION
Intern field names in mapper instances to save memory on nodes holding large
numbers of shards with similar mappings. In the example case of Beats mappings
this saves about 1G per 10k indices on a node which is a non-trivial win on
large frozen or warm nodes in particular.

