### PR TITLE
Fix using FilterOutputStream without overriding bulk write

### DIFF
--- a/docs/changelog/86304.yaml
+++ b/docs/changelog/86304.yaml
@@ -1,0 +1,5 @@
+pr: 86304
+summary: Fix using `FilterOutputStream` without overriding bulk write
+area: Infra/Core
+type: bug
+issues: []

--- a/libs/core/src/main/java/org/elasticsearch/core/Streams.java
+++ b/libs/core/src/main/java/org/elasticsearch/core/Streams.java
@@ -8,6 +8,7 @@
 
 package org.elasticsearch.core;
 
+import java.io.FilterOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -75,5 +76,26 @@ public class Streams {
      */
     public static long copy(final InputStream in, final OutputStream out) throws IOException {
         return copy(in, out, LOCAL_BUFFER.get(), true);
+    }
+
+    /**
+     * Wraps an {@link OutputStream} such that it's {@code close} method becomes a noop
+     *
+     * @param stream {@code OutputStream} to wrap
+     * @return wrapped {@code OutputStream}
+     */
+    public static OutputStream noCloseStream(OutputStream stream) {
+        return new FilterOutputStream(stream) {
+
+            @Override
+            public void write(byte[] b, int off, int len) throws IOException {
+                out.write(b, off, len);
+            }
+
+            @Override
+            public void close() {
+                // noop
+            }
+        };
     }
 }

--- a/server/src/main/java/org/elasticsearch/common/blobstore/fs/FsBlobContainer.java
+++ b/server/src/main/java/org/elasticsearch/common/blobstore/fs/FsBlobContainer.java
@@ -22,7 +22,6 @@ import org.elasticsearch.core.CheckedConsumer;
 import org.elasticsearch.core.IOUtils;
 
 import java.io.FileNotFoundException;
-import java.io.FilterOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -270,7 +269,7 @@ public class FsBlobContainer extends AbstractBlobContainer {
         throws IOException {
         final Path file = path.resolve(blobName);
         try {
-            try (OutputStream out = new BlobOutputStream(file)) {
+            try (OutputStream out = blobOutputStream(file)) {
                 writer.accept(out);
             }
         } catch (FileAlreadyExistsException faee) {
@@ -278,7 +277,7 @@ public class FsBlobContainer extends AbstractBlobContainer {
                 throw faee;
             }
             deleteBlobsIgnoringIfNotExists(Iterators.single(blobName));
-            try (OutputStream out = new BlobOutputStream(file)) {
+            try (OutputStream out = blobOutputStream(file)) {
                 writer.accept(out);
             }
         }
@@ -352,15 +351,7 @@ public class FsBlobContainer extends AbstractBlobContainer {
         return blobName.startsWith(TEMP_FILE_PREFIX);
     }
 
-    private static class BlobOutputStream extends FilterOutputStream {
-
-        BlobOutputStream(Path file) throws IOException {
-            super(Files.newOutputStream(file, StandardOpenOption.CREATE_NEW));
-        }
-
-        @Override
-        public void write(byte[] b, int off, int len) throws IOException {
-            out.write(b, off, len);
-        }
+    private static OutputStream blobOutputStream(Path file) throws IOException {
+        return Files.newOutputStream(file, StandardOpenOption.CREATE_NEW);
     }
 }

--- a/server/src/main/java/org/elasticsearch/common/io/Streams.java
+++ b/server/src/main/java/org/elasticsearch/common/io/Streams.java
@@ -15,7 +15,6 @@ import org.elasticsearch.common.io.stream.StreamOutput;
 
 import java.io.BufferedReader;
 import java.io.FilterInputStream;
-import java.io.FilterOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
@@ -199,27 +198,6 @@ public abstract class Streams {
      */
     public static InputStream noCloseStream(InputStream stream) {
         return new FilterInputStream(stream) {
-            @Override
-            public void close() {
-                // noop
-            }
-        };
-    }
-
-    /**
-     * Wraps an {@link OutputStream} such that it's {@code close} method becomes a noop
-     *
-     * @param stream {@code OutputStream} to wrap
-     * @return wrapped {@code OutputStream}
-     */
-    public static OutputStream noCloseStream(OutputStream stream) {
-        return new FilterOutputStream(stream) {
-
-            @Override
-            public void write(byte[] b, int off, int len) throws IOException {
-                out.write(b, off, len);
-            }
-
             @Override
             public void close() {
                 // noop

--- a/server/src/main/java/org/elasticsearch/repositories/blobstore/BlobStoreRepository.java
+++ b/server/src/main/java/org/elasticsearch/repositories/blobstore/BlobStoreRepository.java
@@ -2304,7 +2304,7 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
             final String indexBlob = INDEX_FILE_PREFIX + Long.toString(newGen);
             logger.debug("Repository [{}] writing new index generational blob [{}]", metadata.name(), indexBlob);
             writeAtomic(blobContainer(), indexBlob, out -> {
-                try (XContentBuilder xContentBuilder = XContentFactory.jsonBuilder(Streams.noCloseStream(out))) {
+                try (XContentBuilder xContentBuilder = XContentFactory.jsonBuilder(org.elasticsearch.core.Streams.noCloseStream(out))) {
                     newRepositoryData.snapshotsToXContent(xContentBuilder, version);
                 }
             }, true);

--- a/server/src/main/java/org/elasticsearch/repositories/blobstore/ChecksumBlobStoreFormat.java
+++ b/server/src/main/java/org/elasticsearch/repositories/blobstore/ChecksumBlobStoreFormat.java
@@ -349,7 +349,7 @@ public final class ChecksumBlobStoreFormat<T extends ToXContent> {
             OutputStreamIndexOutput indexOutput = new OutputStreamIndexOutput(
                 "ChecksumBlobStoreFormat.serialize(blob=\"" + blobName + "\")",
                 blobName,
-                org.elasticsearch.common.io.Streams.noCloseStream(outputStream),
+                org.elasticsearch.core.Streams.noCloseStream(outputStream),
                 BUFFER_SIZE
             )
         ) {

--- a/server/src/main/java/org/elasticsearch/transport/OutboundMessage.java
+++ b/server/src/main/java/org/elasticsearch/transport/OutboundMessage.java
@@ -13,12 +13,12 @@ import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.bytes.CompositeBytesReference;
 import org.elasticsearch.common.compress.CompressorFactory;
-import org.elasticsearch.common.io.Streams;
 import org.elasticsearch.common.io.stream.OutputStreamStreamOutput;
 import org.elasticsearch.common.io.stream.RecyclerBytesStreamOutput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
+import org.elasticsearch.core.Streams;
 
 import java.io.IOException;
 
@@ -94,7 +94,9 @@ abstract class OutboundMessage extends NetworkMessage {
     // resources and write EOS marker bytes but must not yet release the bytes themselves
     private StreamOutput wrapCompressed(RecyclerBytesStreamOutput bytesStream) throws IOException {
         if (compressionScheme == Compression.Scheme.DEFLATE) {
-            return new OutputStreamStreamOutput(CompressorFactory.COMPRESSOR.threadLocalOutputStream(Streams.noCloseStream(bytesStream)));
+            return new OutputStreamStreamOutput(
+                CompressorFactory.COMPRESSOR.threadLocalOutputStream(org.elasticsearch.core.Streams.noCloseStream(bytesStream))
+            );
         } else if (compressionScheme == Compression.Scheme.LZ4) {
             return new OutputStreamStreamOutput(Compression.Scheme.lz4OutputStream(Streams.noCloseStream(bytesStream)));
         } else {

--- a/server/src/test/java/org/elasticsearch/transport/Lz4TransportDecompressorTests.java
+++ b/server/src/test/java/org/elasticsearch/transport/Lz4TransportDecompressorTests.java
@@ -36,7 +36,7 @@ public class Lz4TransportDecompressorTests extends ESTestCase {
     public void testSimpleCompression() throws IOException {
         try (BytesStreamOutput output = new BytesStreamOutput()) {
             byte randomByte = randomByte();
-            try (OutputStream lz4BlockStream = Compression.Scheme.lz4OutputStream(Streams.noCloseStream(output))) {
+            try (OutputStream lz4BlockStream = Compression.Scheme.lz4OutputStream(org.elasticsearch.core.Streams.noCloseStream(output))) {
                 lz4BlockStream.write(randomByte);
             }
 


### PR DESCRIPTION
Fix using the filter output stream without overriding the bulk write.
The usage in `directFieldAsBase64` seems like a serious performance bug 
(marking this as >bug because it can cause serious slowness in async search I believe)
since the stream is used to write a potentially larger response here.
Had to move the no-close method to the core streams class to be able to use the 
existing solution in the x-content lib.

I also removed the `BlobOutputStream` that used to contain the same
fix now added to the no-close stream after realizing the class is pointless
to begin with to cut down on our usage of `FilterOutputStream` where the bulk
write fix is needed.


