### PR TITLE
Add UNKNOWN health api status

### DIFF
--- a/server/src/main/java/org/elasticsearch/health/HealthStatus.java
+++ b/server/src/main/java/org/elasticsearch/health/HealthStatus.java
@@ -18,8 +18,10 @@ import java.util.stream.Stream;
 
 public enum HealthStatus implements Writeable {
     GREEN((byte) 0),
-    YELLOW((byte) 1),
-    RED((byte) 2);
+
+    UNKNOWN((byte) 1),
+    YELLOW((byte) 2),
+    RED((byte) 3);
 
     private final byte value;
 

--- a/server/src/main/java/org/elasticsearch/health/HealthStatus.java
+++ b/server/src/main/java/org/elasticsearch/health/HealthStatus.java
@@ -38,7 +38,8 @@ public enum HealthStatus implements Writeable {
     }
 
     public static HealthStatus merge(Stream<HealthStatus> statuses) {
-        return statuses.max(Comparator.comparing(HealthStatus::value)).orElse(GREEN);
+        return statuses.max(Comparator.comparing(HealthStatus::value))
+            .orElseThrow(() -> new IllegalArgumentException("Cannot merge empty health status stream."));
     }
 
     public String xContentValue() {

--- a/server/src/main/java/org/elasticsearch/health/HealthStatus.java
+++ b/server/src/main/java/org/elasticsearch/health/HealthStatus.java
@@ -18,7 +18,6 @@ import java.util.stream.Stream;
 
 public enum HealthStatus implements Writeable {
     GREEN((byte) 0),
-
     UNKNOWN((byte) 1),
     YELLOW((byte) 2),
     RED((byte) 3);

--- a/server/src/test/java/org/elasticsearch/health/HealthStatusTests.java
+++ b/server/src/test/java/org/elasticsearch/health/HealthStatusTests.java
@@ -37,7 +37,7 @@ public class HealthStatusTests extends ESTestCase {
     }
 
     public void testEmpty() {
-        assertEquals(GREEN, HealthStatus.merge(Stream.empty()));
+        expectThrows(IllegalArgumentException.class, () -> HealthStatus.merge(Stream.empty()));
     }
 
     private static Stream<HealthStatus> randomStatusesContaining(HealthStatus... statuses) {

--- a/server/src/test/java/org/elasticsearch/health/HealthStatusTests.java
+++ b/server/src/test/java/org/elasticsearch/health/HealthStatusTests.java
@@ -15,6 +15,7 @@ import java.util.stream.Stream;
 
 import static org.elasticsearch.health.HealthStatus.GREEN;
 import static org.elasticsearch.health.HealthStatus.RED;
+import static org.elasticsearch.health.HealthStatus.UNKNOWN;
 import static org.elasticsearch.health.HealthStatus.YELLOW;
 
 public class HealthStatusTests extends ESTestCase {
@@ -23,12 +24,16 @@ public class HealthStatusTests extends ESTestCase {
         assertEquals(GREEN, HealthStatus.merge(randomStatusesContaining(GREEN)));
     }
 
+    public void testUnknownStatus() {
+        assertEquals(UNKNOWN, HealthStatus.merge(randomStatusesContaining(GREEN, UNKNOWN)));
+    }
+
     public void testYellowStatus() {
-        assertEquals(YELLOW, HealthStatus.merge(randomStatusesContaining(GREEN, YELLOW)));
+        assertEquals(YELLOW, HealthStatus.merge(randomStatusesContaining(GREEN, UNKNOWN, YELLOW)));
     }
 
     public void testRedStatus() {
-        assertEquals(RED, HealthStatus.merge(randomStatusesContaining(GREEN, YELLOW, RED)));
+        assertEquals(RED, HealthStatus.merge(randomStatusesContaining(GREEN, UNKNOWN, YELLOW, RED)));
     }
 
     public void testEmpty() {


### PR DESCRIPTION
Adds an `UNKNOWN` health api status that will be used when the health of an indicator cannot be reliably determined.

UNKNOWN status has a priority that is higher than GREEN but lower than both YELLOW and RED.