### PR TITLE
Reject openConnection attempt while closing

### DIFF
--- a/docs/changelog/86315.yaml
+++ b/docs/changelog/86315.yaml
@@ -1,0 +1,6 @@
+pr: 86315
+summary: Reject `openConnection` attempt while closing
+area: Network
+type: bug
+issues:
+ - 86249


### PR DESCRIPTION
Today while the `ClusterConnectionManager` is closing it will reject
attempts to open _managed_ connections (i.e. using `connectToNode`), but
it still permits ad-hoc connections (i.e. using `openConnection`). This
commit extends the existing refcounting mechanism to cover both cases,
preventing all concurrent connection attempts while shutting down.

Closes #86249
Relates #77539