### PR TITLE
Make embedded class loader MRJAR aware

### DIFF
--- a/docs/changelog/86316.yaml
+++ b/docs/changelog/86316.yaml
@@ -1,5 +1,5 @@
 pr: 86316
 summary: Make embedded class loader MRJAR aware
 area: Infra/Core
-type: enhancement
+type: bug
 issues: []

--- a/docs/changelog/86316.yaml
+++ b/docs/changelog/86316.yaml
@@ -1,5 +1,0 @@
-pr: 86316
-summary: Make embedded class loader MRJAR aware
-area: Infra/Core
-type: bug
-issues: []

--- a/docs/changelog/86316.yaml
+++ b/docs/changelog/86316.yaml
@@ -1,0 +1,5 @@
+pr: 86316
+summary: Make embedded class loader MRJAR aware
+area: Infra/Core
+type: enhancement
+issues: []

--- a/libs/core/src/main/java/org/elasticsearch/core/internal/provider/EmbeddedImplClassLoader.java
+++ b/libs/core/src/main/java/org/elasticsearch/core/internal/provider/EmbeddedImplClassLoader.java
@@ -14,8 +14,6 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.UncheckedIOException;
 import java.net.MalformedURLException;
-import java.net.URI;
-import java.net.URISyntaxException;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.security.AccessController;

--- a/libs/core/src/main/java/org/elasticsearch/core/internal/provider/EmbeddedImplClassLoader.java
+++ b/libs/core/src/main/java/org/elasticsearch/core/internal/provider/EmbeddedImplClassLoader.java
@@ -13,6 +13,9 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.UncheckedIOException;
+import java.net.MalformedURLException;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.security.AccessController;
@@ -27,22 +30,30 @@ import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Objects;
+import java.util.jar.Manifest;
+
+import static java.util.jar.Attributes.Name.MULTI_RELEASE;
+import static java.util.stream.Collectors.toUnmodifiableMap;
 
 /**
- * A class loader that is responsible for loading implementation classes and resources embedded within an archive.
+ * A class loader that is responsible for loading implementation classes and resources embedded
+ * within an archive.
  *
- * <p> This loader facilitates a scenario whereby an API can embed its implementation and dependencies all within the same archive as the
- * API itself. The archive can be put directly on the class path, where it's API classes are loadable by the application class loader, but
- * the embedded implementation and dependencies are not. When locating a concrete provider, the API can create an instance of an
- * EmbeddedImplClassLoader to locate and load the implementation.
+ * <p> This loader facilitates a scenario whereby an API can embed its implementation and
+ * dependencies all within the same archive as the API itself. The archive can be put directly on
+ * the class path, where it's API classes are loadable by the application class loader, but the
+ * embedded implementation and dependencies are not. When locating a concrete provider, the API can
+ * create an instance of an EmbeddedImplClassLoader to locate and load the implementation.
  *
  * <p> The archive typically consists of two disjoint logically groups:
  *  1. the top-level classes and resources,
  *  2. the embedded classes and resources
  *
- * <p> The top-level classes and resources are typically loaded and located, respectively, by the parent of an EmbeddedImplClassLoader
- * loader. The embedded classes and resources, are located by the parent loader as pure resources with a provider specific name prefix, and
- * classes are defined by the EmbeddedImplClassLoader. The list of prefixes is determined by reading the entries in the MANIFEST.TXT.
+ * <p> The top-level classes and resources are typically loaded and located, respectively, by the
+ * parent of an EmbeddedImplClassLoader loader. The embedded classes and resources, are located by
+ * the parent loader as pure resources with a provider specific name prefix, and classes are defined
+ * by the EmbeddedImplClassLoader. The list of prefixes is determined by reading the entries in the
+ * LISTING.TXT.
  *
  * <p> For example, the structure of the archive named x-content:
  * <pre>
@@ -56,66 +67,63 @@ import java.util.Objects;
 public final class EmbeddedImplClassLoader extends SecureClassLoader {
 
     private static final String IMPL_PREFIX = "IMPL-JARS/";
-    private static final String MANIFEST_FILE = "/LISTING.TXT";
+    private static final String JAR_LISTING_FILE = "/LISTING.TXT";
 
-    private final List<String> prefixes;
-    private final ClassLoader parent;
+    record JarMeta(String prefix, boolean isMultiRelease) {}
+
+    /** Ordered list of jar metadata (prefixes and code sources) to use when loading classes and resources. */
+    private final List<JarMeta> jarMetas;
+
+    /** A map of prefix to codebase, used to determine the code source when defining classes. */
     private final Map<String, CodeSource> prefixToCodeBase;
 
-    private static Map<String, CodeSource> getProviderPrefixes(ClassLoader parent, String providerName) {
-        String providerPrefix = IMPL_PREFIX + providerName;
-        URL manifest = parent.getResource(providerPrefix + MANIFEST_FILE);
-        if (manifest == null) {
-            throw new IllegalStateException("missing x-content provider jars list");
-        }
-        try (
-            InputStream in = manifest.openStream();
-            InputStreamReader isr = new InputStreamReader(in, StandardCharsets.UTF_8);
-            BufferedReader reader = new BufferedReader(isr)
-        ) {
-            List<String> jars = reader.lines().toList();
-            Map<String, CodeSource> map = new HashMap<>();
-            for (String jar : jars) {
-                map.put(providerPrefix + "/" + jar, new CodeSource(new URL(manifest, jar), (CodeSigner[]) null /*signers*/));
-            }
-            return Collections.unmodifiableMap(map);
-        } catch (IOException e) {
-            throw new UncheckedIOException(e);
-        }
-    }
+    /** The loader used to find the class and resource bytes. */
+    private final ClassLoader parent;
 
     static EmbeddedImplClassLoader getInstance(ClassLoader parent, String providerName) {
-        return new EmbeddedImplClassLoader(parent, getProviderPrefixes(parent, providerName));
+        PrivilegedAction<EmbeddedImplClassLoader> pa = () -> new EmbeddedImplClassLoader(parent, getProviderPrefixes(parent, providerName));
+        return AccessController.doPrivileged(pa);
     }
 
-    private EmbeddedImplClassLoader(ClassLoader parent, Map<String, CodeSource> prefixToCodeBase) {
+    private EmbeddedImplClassLoader(ClassLoader parent, Map<JarMeta, CodeSource> prefixToCodeBase) {
         super(null);
-        this.prefixes = prefixToCodeBase.keySet().stream().toList();
-        this.prefixToCodeBase = prefixToCodeBase;
+        this.jarMetas = prefixToCodeBase.keySet().stream().toList();
         this.parent = parent;
+        this.prefixToCodeBase = prefixToCodeBase.entrySet()
+            .stream()
+            .collect(toUnmodifiableMap(k -> k.getKey().prefix(), Map.Entry::getValue));
     }
 
     record Resource(InputStream inputStream, CodeSource codeSource) {}
 
     /** Searches for the named resource. Iterates over all prefixes. */
     private Resource privilegedGetResourceOrNull(String name) {
-        return AccessController.doPrivileged(new PrivilegedAction<Resource>() {
-            @Override
-            public Resource run() {
-                for (String prefix : prefixes) {
-                    URL url = parent.getResource(prefix + "/" + name);
-                    if (url != null) {
-                        try {
-                            InputStream is = url.openStream();
-                            return new Resource(is, prefixToCodeBase.get(prefix));
-                        } catch (IOException e) {
-                            // silently ignore, same as ClassLoader
-                        }
+        return AccessController.doPrivileged((PrivilegedAction<Resource>) () -> {
+            for (JarMeta jarMeta : jarMetas) {
+                URL url = findResourceForPrefixOrNull(name, jarMeta);
+                if (url != null) {
+                    try {
+                        InputStream is = url.openStream();
+                        return new Resource(is, prefixToCodeBase.get(jarMeta.prefix()));
+                    } catch (IOException e) {
+                        // silently ignore, same as ClassLoader
                     }
                 }
-                return null;
             }
+            return null;
         });
+    }
+
+    @Override
+    public Class<?> findClass(String moduleName, String name) {
+        try {
+            Class<?> c = findClass(name);
+            if (moduleName != null && moduleName.equals(c.getModule().getName()) == false) {
+                throw new AssertionError("expected module:" + moduleName + ", got: " + c.getModule().getName());
+            }
+            return c;
+        } catch (ClassNotFoundException ignore) {}
+        return null;
     }
 
     @Override
@@ -136,23 +144,146 @@ public final class EmbeddedImplClassLoader extends SecureClassLoader {
     @Override
     protected URL findResource(String name) {
         Objects.requireNonNull(name);
-        URL url = prefixes.stream().map(p -> p + "/" + name).map(parent::getResource).filter(Objects::nonNull).findFirst().orElse(null);
-        if (url != null) {
-            return url;
+        for (JarMeta jarMeta : jarMetas) {
+            URL url = findResourceForPrefixOrNull(name, jarMeta);
+            if (url != null) {
+                return url;
+            }
         }
         return parent.getResource(name);
     }
 
+    /**
+     * Searches for the named resource, returning its url or null if not found.
+     * Iterates over all multi-release versions, then the root, for the given jar prefix.
+     */
+    URL findResourceForPrefixOrNull(String name, JarMeta jarMeta) {
+        URL url;
+        if (jarMeta.isMultiRelease) {
+            url = findVersionedResourceForPrefixOrNull(name, jarMeta.prefix());
+            if (url != null) {
+                return url;
+            }
+        }
+        return parent.getResource(jarMeta.prefix() + "/" + name);
+    }
+
+    URL findVersionedResourceForPrefixOrNull(String name, String prefix) {
+        for (int v = RUNTIME_VERSION_FEATURE; v >= BASE_VERSION_FEATURE; v--) {
+            URL url = parent.getResource(prefix + "/" + MRJAR_VERSION_PREFIX + v + "/" + name);
+            if (url != null) {
+                return url;
+            }
+        }
+        return null;
+    }
+
     @Override
     protected Enumeration<URL> findResources(String name) throws IOException {
-        final int size = prefixes.size();
+        Enumeration<URL> enum1 = new Enumeration<>() {
+            private int jarMetaIndex = 0;
+
+            private URL url = null;
+
+            private boolean next() {
+                if (url != null) {
+                    return true;
+                } else {
+                    while (jarMetaIndex < jarMetas.size()) {
+                        URL u = findResourceForPrefixOrNull(name, jarMetas.get(jarMetaIndex));
+                        jarMetaIndex++;
+                        if (u != null) {
+                            url = u;
+                            return true;
+                        }
+                    }
+                    return false;
+                }
+            }
+
+            @Override
+            public boolean hasMoreElements() {
+                return next();
+            }
+
+            @Override
+            public URL nextElement() {
+                if (next() == false) {
+                    throw new NoSuchElementException();
+                }
+                URL u = url;
+                url = null;
+                return u;
+            }
+        };
+
         @SuppressWarnings("unchecked")
-        Enumeration<URL>[] tmp = (Enumeration<URL>[]) new Enumeration<?>[size + 1];
-        for (int i = 0; i < size; i++) {
-            tmp[i] = parent.getResources(prefixes.get(i) + "/" + name);
-        }
-        tmp[size] = parent.getResources(name);
+        Enumeration<URL>[] tmp = (Enumeration<URL>[]) new Enumeration<?>[2];
+        tmp[0] = enum1;
+        tmp[1] = parent.getResources(name);
         return new CompoundEnumeration<>(tmp);
+    }
+
+    // -- infra
+
+    private static Map<JarMeta, CodeSource> getProviderPrefixes(ClassLoader parent, String providerName) {
+        String providerPrefix = IMPL_PREFIX + providerName;
+        URL listingURL = parent.getResource(providerPrefix + JAR_LISTING_FILE);
+        if (listingURL == null) {
+            throw new IllegalStateException("missing %s provider jars list".formatted(providerName));
+        }
+        try (
+            InputStream in = listingURL.openStream();
+            InputStreamReader isr = new InputStreamReader(in, StandardCharsets.UTF_8);
+            BufferedReader reader = new BufferedReader(isr)
+        ) {
+            List<String> jars = reader.lines().toList();
+            Map<JarMeta, CodeSource> map = new HashMap<>();
+            for (String jar : jars) {
+                final String jarPrefix = providerPrefix + "/" + jar;
+                JarMeta jam;
+                if (isMultiRelease(parent, jarPrefix)) {
+                    jam = new JarMeta(jarPrefix, true);
+                } else {
+                    jam = new JarMeta(jarPrefix, false);
+                }
+                map.put(jam, codeSource(listingURL, jar));
+            }
+            return Collections.unmodifiableMap(map);
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    private static CodeSource codeSource(URL baseURL, String jarName) throws MalformedURLException {
+        return new CodeSource(new URL(baseURL, jarName), (CodeSigner[]) null /*signers*/);
+    }
+
+    private static boolean isMultiRelease(ClassLoader parent, String jarPrefix) throws IOException {
+        try (InputStream is = parent.getResourceAsStream(jarPrefix + "/META-INF/MANIFEST.MF")) {
+            if (is != null) {
+                Manifest manifest = new Manifest(is);
+                return Boolean.parseBoolean(manifest.getMainAttributes().getValue(MULTI_RELEASE));
+            }
+        }
+        return false;
+    }
+
+    private static final int BASE_VERSION_FEATURE = 8; // lowest supported release version
+    private static final int RUNTIME_VERSION_FEATURE = Runtime.version().feature();
+
+    static {
+        assert RUNTIME_VERSION_FEATURE >= BASE_VERSION_FEATURE;
+    }
+
+    private static final String MRJAR_VERSION_PREFIX = "META-INF/versions/";
+
+    private static String getParent(String uriString) {
+        int index = uriString.lastIndexOf('/');
+        if (index > 0) {
+            return uriString.substring(0, index);
+        }
+        return "/";
     }
 
     static final class CompoundEnumeration<E> implements Enumeration<E> {

--- a/libs/core/src/main/java/org/elasticsearch/core/internal/provider/EmbeddedImplClassLoader.java
+++ b/libs/core/src/main/java/org/elasticsearch/core/internal/provider/EmbeddedImplClassLoader.java
@@ -21,7 +21,6 @@ import java.security.CodeSigner;
 import java.security.CodeSource;
 import java.security.PrivilegedAction;
 import java.security.SecureClassLoader;
-import java.util.Collections;
 import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.List;
@@ -158,7 +157,7 @@ public final class EmbeddedImplClassLoader extends SecureClassLoader {
     URL findResourceForPrefixOrNull(String name, JarMeta jarMeta) {
         URL url;
         if (jarMeta.isMultiRelease) {
-            url = findVersionedResourceForPrefixOrNull(name, jarMeta.prefix());
+            url = findVersionedResourceForPrefixOrNull(jarMeta.prefix(), name);
             if (url != null) {
                 return url;
             }
@@ -166,7 +165,7 @@ public final class EmbeddedImplClassLoader extends SecureClassLoader {
         return parent.getResource(jarMeta.prefix() + "/" + name);
     }
 
-    URL findVersionedResourceForPrefixOrNull(String name, String prefix) {
+    URL findVersionedResourceForPrefixOrNull(String prefix, String name) {
         for (int v = RUNTIME_VERSION_FEATURE; v >= BASE_VERSION_FEATURE; v--) {
             URL url = parent.getResource(prefix + "/" + MRJAR_VERSION_PREFIX + v + "/" + name);
             if (url != null) {
@@ -247,7 +246,7 @@ public final class EmbeddedImplClassLoader extends SecureClassLoader {
                 }
                 map.put(jam, codeSource(listingURL, jar));
             }
-            return Collections.unmodifiableMap(map);
+            return Map.copyOf(map);
         } catch (IOException e) {
             throw new UncheckedIOException(e);
         }

--- a/libs/core/src/test/java/org/elasticsearch/core/internal/provider/EmbeddedImplClassLoaderTests.java
+++ b/libs/core/src/test/java/org/elasticsearch/core/internal/provider/EmbeddedImplClassLoaderTests.java
@@ -1,0 +1,459 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.core.internal.provider;
+
+import org.elasticsearch.core.SuppressForbidden;
+import org.elasticsearch.core.internal.provider.EmbeddedImplClassLoader.CompoundEnumeration;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.test.compiler.InMemoryJavaCompiler;
+import org.elasticsearch.test.jar.JarUtils;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Enumeration;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.NoSuchElementException;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.util.Arrays.stream;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.emptyCollectionOf;
+import static org.hamcrest.Matchers.endsWith;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.hasToString;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.nullValue;
+import static org.hamcrest.Matchers.startsWith;
+
+public class EmbeddedImplClassLoaderTests extends ESTestCase {
+
+    /*
+     * Tests that the root version of a class is loaded, when the multi-release attribute is absent.
+     */
+    public void testLoadWithoutMultiReleaseDisabled() throws Exception {
+        Object foobar = newFooBar(false, 0);
+        assertThat(foobar.toString(), equalTo("FooBar " + 0));
+
+        foobar = newFooBar(false, 9);
+        assertThat(foobar.toString(), equalTo("FooBar " + 0));
+
+        foobar = newFooBar(false, 11);
+        assertThat(foobar.toString(), equalTo("FooBar " + 0));
+
+        foobar = newFooBar(false, 17);
+        assertThat(foobar.toString(), equalTo("FooBar " + 0));
+    }
+
+    /*
+     * Tests that the root version of a class is loaded, when the multi-release attribute is present,
+     * but the versioned entry is greater than the runtime version.
+     */
+    public void testLoadMegaVersionWithMultiReleaseEnabled() throws Exception {
+        assumeTrue("JDK version not less than 10_000", Runtime.version().feature() < 10_000);
+        Object foobar = newFooBar(true, 10_000);
+        assertThat(foobar.toString(), equalTo("FooBar " + 0));
+
+        foobar = newFooBar(true, 10_001);
+        assertThat(foobar.toString(), equalTo("FooBar " + 0));
+
+        foobar = newFooBar(true, 100_000);
+        assertThat(foobar.toString(), equalTo("FooBar " + 0));
+    }
+
+    /*
+     * Tests that the specific, 9, version of a class is loaded, when the multi-release attribute
+     * is present and the versioned entry is less than or equal to the runtime version.
+     */
+    public void testLoadWithMultiReleaseEnabled9() throws Exception {
+        assumeTrue("JDK version not greater than or equal to 9", Runtime.version().feature() >= 9);
+        Object foobar = newFooBar(true, 9);
+        // expect 9 version of FooBar to be loaded
+        assertThat(foobar.toString(), equalTo("FooBar " + 9));
+
+        foobar = newFooBar(true, 9, 8);
+        assertThat(foobar.toString(), equalTo("FooBar " + 9));
+    }
+
+    /*
+     * Tests that the specific, 11, version of a class is loaded, when the multi-release attribute
+     * is present and the versioned entry is less than or equal to the runtime version.
+     */
+    public void testLoadWithMultiReleaseEnabled11() throws Exception {
+        assumeTrue("JDK version not greater than or equal to 11", Runtime.version().feature() >= 11);
+        Object foobar = newFooBar(true, 11);
+        // expect 11 version of FooBar to be loaded
+        assertThat(foobar.toString(), equalTo("FooBar " + 11));
+
+        foobar = newFooBar(true, 11, 10, 9, 8);
+        assertThat(foobar.toString(), equalTo("FooBar " + 11));
+    }
+
+    /*
+     * Tests that the specific, 17, version of a class is loaded, when the multi-release attribute
+     * is present and the versioned entry is less than or equal to the runtime version.
+     */
+    public void testLoadWithMultiReleaseEnabled17() throws Exception {
+        assumeTrue("JDK version not greater than or equal to 17", Runtime.version().feature() >= 17);
+        Object foobar = newFooBar(true, 17);
+        // expect 17 version of FooBar to be loaded
+        assertThat(foobar.toString(), equalTo("FooBar " + 17));
+
+        foobar = newFooBar(true, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8);
+        assertThat(foobar.toString(), equalTo("FooBar " + 17));
+    }
+
+    /*
+     * Tests that the greatest specific version of a class is loaded, when the multi-release attribute
+     * is present and the versioned entry is less than or equal to the runtime version.
+     */
+    public void testLoadWithMultiReleaseEnabledALL() throws Exception {
+        assumeTrue("JDK version not greater than or equal to 17", Runtime.version().feature() >= 17);
+
+        Object foobar = newFooBar(true, 16, 13, 11, 9);
+        // expect 16 version of FooBar to be loaded
+        assertThat(foobar.toString(), equalTo("FooBar " + 16));
+
+        foobar = newFooBar(true, 13, 12, 11, 10, 9, 8);
+        // expect 13 version of FooBar to be loaded
+        assertThat(foobar.toString(), equalTo("FooBar " + 13));
+
+        foobar = newFooBar(true, 10, 9, 8);
+        // expect 10 version of FooBar to be loaded
+        assertThat(foobar.toString(), equalTo("FooBar " + 10));
+    }
+
+    /* Creates a FooBar class that reports the given version in its toString. */
+    static byte[] classBytesForVersion(int version) {
+        return InMemoryJavaCompiler.compile("p.FooBar", String.format(Locale.ENGLISH, """
+            package p;
+            public class FooBar {
+                @Override public String toString() {
+                    return "FooBar %d";
+                }
+            }
+            """, version));
+    }
+
+    /*
+     * Instantiates an instance of FooBar. First generates and compiles the code, then packages it,
+     * and lastly loads the FooBar class with an embedded loader.
+     *
+     * @param enableMulti whether to set the multi-release attribute
+     * @param versions the runtime version number of the entries to create in the jar
+     */
+    private static Object newFooBar(boolean enableMulti, int... versions) throws Exception {
+        String prefix = "IMPL-JARS/x-foo/x-foo-impl.jar/";
+        Map<String, byte[]> jarEntries = new HashMap<>();
+        jarEntries.put("IMPL-JARS/x-foo/LISTING.TXT", bytes("x-foo-impl.jar"));
+        jarEntries.put(prefix + "p/FooBar.class", classBytesForVersion(0)); // root version is always 0
+        if (enableMulti) {
+            jarEntries.put(prefix + "META-INF/MANIFEST.MF", bytes("Multi-Release: true\n"));
+        }
+        stream(versions).forEach(v -> jarEntries.put(prefix + "META-INF/versions/" + v + "/p/FooBar.class", classBytesForVersion(v)));
+
+        Path topLevelDir = createTempDir();
+        Path outerJar = topLevelDir.resolve("impl.jar");
+        JarUtils.createJarWithEntries(outerJar, jarEntries);
+        URLClassLoader parent = URLClassLoader.newInstance(
+            new URL[] { outerJar.toUri().toURL() },
+            EmbeddedImplClassLoaderTests.class.getClassLoader()
+        );
+
+        EmbeddedImplClassLoader loader = EmbeddedImplClassLoader.getInstance(parent, "x-foo");
+        Class<?> c = loader.loadClass("p.FooBar");
+        return c.getConstructor().newInstance();
+    }
+
+    public void testCompoundEnumeration() {
+        @SuppressWarnings("unchecked")
+        var enumerations = (Enumeration<String>[]) new Enumeration<?>[] {
+            Collections.enumeration(List.of("hello")),
+            Collections.enumeration(List.of("world")) };
+        var compoundEnumeration = new CompoundEnumeration<>(enumerations);
+
+        List<String> l = new ArrayList<>();
+        while (compoundEnumeration.hasMoreElements()) {
+            l.add(compoundEnumeration.nextElement());
+        }
+        assertThat(l, contains(is("hello"), is("world")));
+        expectThrows(NoSuchElementException.class, () -> compoundEnumeration.nextElement());
+    }
+
+    /* Basic test for resource loading. */
+    public void testResourcesBasic() throws Exception {
+        Path topLevelDir = createTempDir();
+
+        Map<String, byte[]> jarEntries = new HashMap<>();
+        jarEntries.put("IMPL-JARS/res/LISTING.TXT", "res-impl.jar".getBytes(UTF_8));
+        jarEntries.put("IMPL-JARS/res/res-impl.jar/p/res.txt", "Hello World".getBytes(UTF_8));
+
+        Path outerJar = topLevelDir.resolve("impl.jar");
+        JarUtils.createJarWithEntries(outerJar, jarEntries);
+        URLClassLoader parent = URLClassLoader.newInstance(
+            new URL[] { outerJar.toUri().toURL() },
+            EmbeddedImplClassLoaderTests.class.getClassLoader()
+        );
+
+        EmbeddedImplClassLoader loader = EmbeddedImplClassLoader.getInstance(parent, "res");
+        URL url = loader.findResource("p/res.txt");
+        assertThat(url.toString(), endsWith("impl.jar!/IMPL-JARS/res/res-impl.jar/p/res.txt"));
+
+        var resources = loader.findResources("p/res.txt");
+        assertThat(Collections.list(resources), contains(hasToString(endsWith("impl.jar!/IMPL-JARS/res/res-impl.jar/p/res.txt"))));
+    }
+
+    /*
+     * Tests that the root version of a resource is located, when the multi-release attribute is absent.
+     */
+    public void testResourcesWithoutMultiRelease() throws Exception {
+        assumeTrue("JDK version not greater than or equal to 17", Runtime.version().feature() >= 17);
+        testResourcesVersioned(false, 0, 9);
+        testResourcesVersioned(false, 0, 15);
+        testResourcesVersioned(false, 0, 17);
+        testResourcesVersioned(false, 0, 11, 10, 9, 8);
+    }
+
+    /*
+     * Tests that the specific, 9, version of a resource is located, when the multi-release attribute
+     * is present and the versioned entry is less than or equal to the runtime version.
+     */
+    public void testResourcesVersioned9() throws Exception {
+        assumeTrue("JDK version not greater than or equal to 9", Runtime.version().feature() >= 9);
+        testResourcesVersioned(true, 9, 9);
+        testResourcesVersioned(true, 9, 9, 8);
+    }
+
+    /*
+     * Tests that the specific, 11, version of a resource is located, when the multi-release attribute
+     * is present and the versioned entry is less than or equal to the runtime version.
+     */
+    public void testResourcesVersioned11() throws Exception {
+        assumeTrue("JDK version not greater than or equal to 11", Runtime.version().feature() >= 11);
+        testResourcesVersioned(true, 11, 11);
+        testResourcesVersioned(true, 11, 11, 10, 9, 8);
+    }
+
+    /*
+     * Tests that the specific, 17, version of a resource is located, when the multi-release attribute
+     * is present and the versioned entry is less than or equal to the runtime version.
+     */
+    public void testResourcesVersioned17() throws Exception {
+        assumeTrue("JDK version not greater than or equal to 17", Runtime.version().feature() >= 17);
+        testResourcesVersioned(true, 17, 17);
+        testResourcesVersioned(true, 17, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8);
+    }
+
+    static byte[] bytes(String str) {
+        return str.getBytes(UTF_8);
+    }
+
+    /*
+     * Tests that the expected version of a resource is located.
+     *
+     * A jar archive is created with a resource, and optionally additional version specific entries
+     * of said resource. Both a URLClassLoader and an embedded loader are created to locate the
+     * resource. The resource located by embedded loader is compared to that of the equivalent
+     * resource located by the URLClassLoader.
+     *
+     * @param enableMulti whether to set the multi-release attribute
+     * @param expectedVersion the expected resource version to locate
+     * @param versions the runtime version number of the entries to create in the jar
+     */
+    private void testResourcesVersioned(boolean enableMulti, int expectedVersion, int... versions) throws Exception {
+        Path topLevelDir = createTempDir();
+
+        ClassLoader embedLoader, urlcLoader;
+        {   // load content with URLClassLoader
+            Map<String, byte[]> jarEntries = new HashMap<>();
+            jarEntries.put("p/res.txt", bytes("Hello World0"));
+            if (enableMulti) {
+                jarEntries.put("META-INF/MANIFEST.MF", bytes("Multi-Release: true\n"));
+            }
+            stream(versions).forEach(v -> jarEntries.put("META-INF/versions/" + v + "/p/res.txt", bytes("Hello World" + v)));
+            Path fooJar = topLevelDir.resolve("foo.jar");
+            JarUtils.createJarWithEntries(fooJar, jarEntries);
+            urlcLoader = URLClassLoader.newInstance(
+                new URL[] { fooJar.toUri().toURL() },
+                EmbeddedImplClassLoaderTests.class.getClassLoader()
+            );
+        }
+        {   // load EQUIVALENT content with EmbeddedImplClassLoader
+            String prefix = "IMPL-JARS/res/res-impl.jar/";
+            Map<String, byte[]> jarEntries = new HashMap<>();
+            jarEntries.put("IMPL-JARS/res/LISTING.TXT", bytes("res-impl.jar"));
+            jarEntries.put(prefix + "p/res.txt", bytes("Hello World0"));
+            if (enableMulti) {
+                jarEntries.put(prefix + "META-INF/MANIFEST.MF", bytes("Multi-Release: true\n"));
+            }
+            stream(versions).forEach(v -> jarEntries.put(prefix + "META-INF/versions/" + v + "/p/res.txt", bytes(("Hello World" + v))));
+            Path outerJar = topLevelDir.resolve("impl.jar");
+            JarUtils.createJarWithEntries(outerJar, jarEntries);
+            URLClassLoader parent = URLClassLoader.newInstance(
+                new URL[] { outerJar.toUri().toURL() },
+                EmbeddedImplClassLoaderTests.class.getClassLoader()
+            );
+            embedLoader = EmbeddedImplClassLoader.getInstance(parent, "res");
+        }
+
+        // finding resources with the different loaders should give EQUIVALENT results
+
+        String expectedURLSuffix = "p/res.txt";
+        if (enableMulti) {
+            expectedURLSuffix = "META-INF/versions/" + expectedVersion + "/p/res.txt";
+        }
+
+        // getResource
+        URL url1 = urlcLoader.getResource("p/res.txt");
+        assertThat(url1.toString(), endsWith("!/" + expectedURLSuffix));
+        URL url2 = embedLoader.getResource("p/res.txt");
+        assertThat(url2.toString(), endsWith("impl.jar!/IMPL-JARS/res/res-impl.jar/" + expectedURLSuffix));
+        assertThat(suffix(url2), endsWith(suffix(url1)));
+
+        // getResources
+        var urls1 = Collections.list(urlcLoader.getResources("p/res.txt")).stream().map(URL::toString).toList();
+        var urls2 = Collections.list(embedLoader.getResources("p/res.txt")).stream().map(URL::toString).toList();
+        assertThat("urls1=%s, urls2=%s".formatted(urls1, urls2), urls2, hasSize(1));
+        assertThat(urls1.get(0), endsWith("!/" + expectedURLSuffix));
+        assertThat(urls2.get(0), endsWith("impl.jar!/IMPL-JARS/res/res-impl.jar/" + expectedURLSuffix));
+
+        // getResourceAsStream
+        assertThat(new String(embedLoader.getResourceAsStream("p/res.txt").readAllBytes(), UTF_8), is("Hello World" + expectedVersion));
+    }
+
+    private static String suffix(URL url) {
+        String urlStr = url.toString();
+        int idx = urlStr.indexOf("!/");
+        assert idx > 0;
+        return urlStr.substring(idx + 2);
+    }
+
+    static final Class<NullPointerException> NPE = NullPointerException.class;
+    static final Class<ClassNotFoundException> CNFE = ClassNotFoundException.class;
+
+    /*
+     * Tests locating classes and resource not in the embedded loader.
+     * As well as additional null checks.
+     */
+    public void testIDontHaveIt() throws Exception {
+        Path topLevelDir = createTempDir();
+
+        ClassLoader embedLoader;
+        Map<String, byte[]> jarEntries = new HashMap<>();
+        jarEntries.put("IMPL-JARS/res/LISTING.TXT", "res-impl.jar".getBytes(UTF_8));
+        jarEntries.put("IMPL-JARS/res/res-impl.jar/p/res.txt", "Hello World0".getBytes(UTF_8));
+        Path outerJar = topLevelDir.resolve("impl.jar");
+        JarUtils.createJarWithEntries(outerJar, jarEntries);
+        URLClassLoader parent = URLClassLoader.newInstance(
+            new URL[] { outerJar.toUri().toURL() },
+            EmbeddedImplClassLoaderTests.class.getClassLoader()
+        );
+        embedLoader = EmbeddedImplClassLoader.getInstance(parent, "res");
+
+        Class<?> c = embedLoader.loadClass("java.lang.Object");
+        assertThat(c, is(java.lang.Object.class));
+        assertThat(c.getClassLoader(), not(equalTo(embedLoader)));
+
+        // not found
+        expectThrows(CNFE, () -> embedLoader.loadClass("a.b.c.Unknown"));
+        assertThat(embedLoader.getResource("a/b/c/Unknown.class"), nullValue());
+        assertThat(embedLoader.getResources("a/b/c/Unknown.class").hasMoreElements(), is(false));
+        assertThat(embedLoader.getResourceAsStream("a/b/c/Unknown.class"), nullValue());
+        assertThat(embedLoader.resources("a/b/c/Unknown.class").toList(), emptyCollectionOf(URL.class));
+
+        // nulls
+        expectThrows(NPE, () -> embedLoader.getResource(null));
+        expectThrows(NPE, () -> embedLoader.getResources(null));
+        expectThrows(NPE, () -> embedLoader.getResourceAsStream(null));
+        expectThrows(NPE, () -> embedLoader.resources(null));
+        expectThrows(NPE, () -> embedLoader.loadClass(null));
+    }
+
+    /*
+     * Tests class loading with dependencies across multiple embedded jars.
+     */
+    public void testLoadWithJarDependencies() throws Exception {
+        Map<String, CharSequence> sources = new HashMap<>();
+        sources.put("p.Foo", "package p; public class Foo extends q.Bar { }");
+        sources.put("q.Bar", "package q; public class Bar extends r.Baz { }");
+        sources.put("r.Baz", "package r; public class Baz { }");
+        var classToBytes = InMemoryJavaCompiler.compile(sources);
+
+        Map<String, byte[]> jarEntries = new HashMap<>();
+        jarEntries.put("IMPL-JARS/blah/LISTING.TXT", "foo.jar\nbar.jar\nbaz.jar".getBytes(UTF_8));
+        jarEntries.put("IMPL-JARS/blah/foo.jar/p/Foo.class", classToBytes.get("p.Foo"));
+        jarEntries.put("IMPL-JARS/blah/bar.jar/META-INF/MANIFEST.MF", "Multi-Release: True\n".getBytes(UTF_8));
+        jarEntries.put("IMPL-JARS/blah/bar.jar/META-INF/versions/9/q/Bar.class", classToBytes.get("q.Bar"));
+        jarEntries.put("IMPL-JARS/blah/baz.jar/META-INF/MANIFEST.MF", "Multi-Release: true\n".getBytes(UTF_8));
+        jarEntries.put("IMPL-JARS/blah/baz.jar/META-INF/versions/11/r/Baz.class", classToBytes.get("r.Baz"));
+
+        Path topLevelDir = createTempDir();
+        Path outerJar = topLevelDir.resolve("impl.jar");
+        JarUtils.createJarWithEntries(outerJar, jarEntries);
+        URLClassLoader parent = URLClassLoader.newInstance(
+            new URL[] { outerJar.toUri().toURL() },
+            EmbeddedImplClassLoaderTests.class.getClassLoader()
+        );
+
+        EmbeddedImplClassLoader loader = EmbeddedImplClassLoader.getInstance(parent, "blah");
+        Class<?> c = loader.loadClass("p.Foo");
+        Object obj = c.getConstructor().newInstance();
+        assertThat(obj.toString(), startsWith("p.Foo"));
+        assertThat(c.getSuperclass().getName(), is("q.Bar"));
+        assertThat(c.getSuperclass().getSuperclass().getName(), is("r.Baz"));
+    }
+
+    /*
+     * Tests resource lookup across multiple embedded jars.
+     */
+    public void testResourcesWithMultipleJars() throws Exception {
+        Path topLevelDir = createTempDir();
+
+        Map<String, String> jarEntries = new HashMap<>();
+        jarEntries.put("IMPL-JARS/blah/LISTING.TXT", "foo.jar\nbar.jar\nbaz.jar");
+        jarEntries.put("IMPL-JARS/blah/foo.jar/res.txt", "fooRes");
+        jarEntries.put("IMPL-JARS/blah/bar.jar/META-INF/MANIFEST.MF", "Multi-Release: TRUE\n");
+        jarEntries.put("IMPL-JARS/blah/bar.jar/META-INF/versions/9/res.txt", "barRes");
+        jarEntries.put("IMPL-JARS/blah/baz.jar/META-INF/MANIFEST.MF", "Multi-Release: trUE\n");
+        jarEntries.put("IMPL-JARS/blah/baz.jar/META-INF/versions/11/res.txt", "bazRes");
+
+        Path outerJar = topLevelDir.resolve("impl.jar");
+        JarUtils.createJarWithEntries(outerJar, jarEntries, UTF_8);
+        URLClassLoader parent = URLClassLoader.newInstance(
+            new URL[] { outerJar.toUri().toURL() },
+            EmbeddedImplClassLoaderTests.class.getClassLoader()
+        );
+
+        EmbeddedImplClassLoader loader = EmbeddedImplClassLoader.getInstance(parent, "blah");
+        var res = Collections.list(loader.getResources("res.txt"));
+
+        assertThat(res, hasSize(3));
+        List<String> l = res.stream().map(EmbeddedImplClassLoaderTests::urlToString).toList();
+        assertThat(l, containsInAnyOrder("fooRes", "barRes", "bazRes"));
+    }
+
+    @SuppressForbidden(reason = "file urls")
+    static String urlToString(URL url) {
+        try {
+            return new String(url.openStream().readAllBytes(), UTF_8);
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+}

--- a/libs/core/src/test/java/org/elasticsearch/core/internal/provider/EmbeddedImplClassLoaderTests.java
+++ b/libs/core/src/test/java/org/elasticsearch/core/internal/provider/EmbeddedImplClassLoaderTests.java
@@ -200,12 +200,12 @@ public class EmbeddedImplClassLoaderTests extends ESTestCase {
     public void testResourcesBasic() throws Exception {
         Path topLevelDir = createTempDir();
 
-        Map<String, byte[]> jarEntries = new HashMap<>();
-        jarEntries.put("IMPL-JARS/res/LISTING.TXT", "res-impl.jar".getBytes(UTF_8));
-        jarEntries.put("IMPL-JARS/res/res-impl.jar/p/res.txt", "Hello World".getBytes(UTF_8));
+        Map<String, String> jarEntries = new HashMap<>();
+        jarEntries.put("IMPL-JARS/res/LISTING.TXT", "res-impl.jar");
+        jarEntries.put("IMPL-JARS/res/res-impl.jar/p/res.txt", "Hello World");
 
         Path outerJar = topLevelDir.resolve("impl.jar");
-        JarUtils.createJarWithEntries(outerJar, jarEntries);
+        JarUtils.createJarWithEntriesUTF(outerJar, jarEntries);
         URLClassLoader parent = URLClassLoader.newInstance(
             new URL[] { outerJar.toUri().toURL() },
             EmbeddedImplClassLoaderTests.class.getClassLoader()
@@ -281,14 +281,14 @@ public class EmbeddedImplClassLoaderTests extends ESTestCase {
 
         ClassLoader embedLoader, urlcLoader;
         {   // load content with URLClassLoader
-            Map<String, byte[]> jarEntries = new HashMap<>();
-            jarEntries.put("p/res.txt", bytes("Hello World0"));
+            Map<String, String> jarEntries = new HashMap<>();
+            jarEntries.put("p/res.txt", "Hello World0");
             if (enableMulti) {
-                jarEntries.put("META-INF/MANIFEST.MF", bytes("Multi-Release: true\n"));
+                jarEntries.put("META-INF/MANIFEST.MF", "Multi-Release: true\n");
             }
-            stream(versions).forEach(v -> jarEntries.put("META-INF/versions/" + v + "/p/res.txt", bytes("Hello World" + v)));
+            stream(versions).forEach(v -> jarEntries.put("META-INF/versions/" + v + "/p/res.txt", "Hello World" + v));
             Path fooJar = topLevelDir.resolve("foo.jar");
-            JarUtils.createJarWithEntries(fooJar, jarEntries);
+            JarUtils.createJarWithEntriesUTF(fooJar, jarEntries);
             urlcLoader = URLClassLoader.newInstance(
                 new URL[] { fooJar.toUri().toURL() },
                 EmbeddedImplClassLoaderTests.class.getClassLoader()
@@ -296,15 +296,15 @@ public class EmbeddedImplClassLoaderTests extends ESTestCase {
         }
         {   // load EQUIVALENT content with EmbeddedImplClassLoader
             String prefix = "IMPL-JARS/res/res-impl.jar/";
-            Map<String, byte[]> jarEntries = new HashMap<>();
-            jarEntries.put("IMPL-JARS/res/LISTING.TXT", bytes("res-impl.jar"));
-            jarEntries.put(prefix + "p/res.txt", bytes("Hello World0"));
+            Map<String, String> jarEntries = new HashMap<>();
+            jarEntries.put("IMPL-JARS/res/LISTING.TXT", "res-impl.jar");
+            jarEntries.put(prefix + "p/res.txt", "Hello World0");
             if (enableMulti) {
-                jarEntries.put(prefix + "META-INF/MANIFEST.MF", bytes("Multi-Release: true\n"));
+                jarEntries.put(prefix + "META-INF/MANIFEST.MF", "Multi-Release: true\n");
             }
-            stream(versions).forEach(v -> jarEntries.put(prefix + "META-INF/versions/" + v + "/p/res.txt", bytes(("Hello World" + v))));
+            stream(versions).forEach(v -> jarEntries.put(prefix + "META-INF/versions/" + v + "/p/res.txt", ("Hello World" + v)));
             Path outerJar = topLevelDir.resolve("impl.jar");
-            JarUtils.createJarWithEntries(outerJar, jarEntries);
+            JarUtils.createJarWithEntriesUTF(outerJar, jarEntries);
             URLClassLoader parent = URLClassLoader.newInstance(
                 new URL[] { outerJar.toUri().toURL() },
                 EmbeddedImplClassLoaderTests.class.getClassLoader()
@@ -355,11 +355,11 @@ public class EmbeddedImplClassLoaderTests extends ESTestCase {
         Path topLevelDir = createTempDir();
 
         ClassLoader embedLoader;
-        Map<String, byte[]> jarEntries = new HashMap<>();
-        jarEntries.put("IMPL-JARS/res/LISTING.TXT", "res-impl.jar".getBytes(UTF_8));
-        jarEntries.put("IMPL-JARS/res/res-impl.jar/p/res.txt", "Hello World0".getBytes(UTF_8));
+        Map<String, String> jarEntries = new HashMap<>();
+        jarEntries.put("IMPL-JARS/res/LISTING.TXT", "res-impl.jar");
+        jarEntries.put("IMPL-JARS/res/res-impl.jar/p/res.txt", "Hello World0");
         Path outerJar = topLevelDir.resolve("impl.jar");
-        JarUtils.createJarWithEntries(outerJar, jarEntries);
+        JarUtils.createJarWithEntriesUTF(outerJar, jarEntries);
         URLClassLoader parent = URLClassLoader.newInstance(
             new URL[] { outerJar.toUri().toURL() },
             EmbeddedImplClassLoaderTests.class.getClassLoader()
@@ -434,7 +434,7 @@ public class EmbeddedImplClassLoaderTests extends ESTestCase {
         jarEntries.put("IMPL-JARS/blah/baz.jar/META-INF/versions/11/res.txt", "bazRes");
 
         Path outerJar = topLevelDir.resolve("impl.jar");
-        JarUtils.createJarWithEntries(outerJar, jarEntries, UTF_8);
+        JarUtils.createJarWithEntriesUTF(outerJar, jarEntries);
         URLClassLoader parent = URLClassLoader.newInstance(
             new URL[] { outerJar.toUri().toURL() },
             EmbeddedImplClassLoaderTests.class.getClassLoader()

--- a/test/framework/src/main/java/org/elasticsearch/test/jar/JarUtils.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/jar/JarUtils.java
@@ -11,6 +11,7 @@ package org.elasticsearch.test.jar;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.nio.charset.Charset;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
@@ -18,6 +19,8 @@ import java.util.Map;
 import java.util.jar.JarEntry;
 import java.util.jar.JarOutputStream;
 import java.util.jar.Manifest;
+
+import static java.util.stream.Collectors.toUnmodifiableMap;
 
 public final class JarUtils {
 
@@ -67,6 +70,19 @@ public final class JarUtils {
                 jos.closeEntry();
             }
         }
+    }
+
+    /**
+     * Creates a jar file with the given entries.
+     *
+     * @param jarfile the jar file path
+     * @param entries map of entries to add; jar entry name to String contents
+     * @param charset the charset used to convert the entry values to bytes
+     * @throws IOException if an I/O error occurs
+     */
+    public static void createJarWithEntries(Path jarfile, Map<String, String> entries, Charset charset) throws IOException {
+        var map = entries.entrySet().stream().collect(toUnmodifiableMap(Map.Entry::getKey, v -> v.getValue().getBytes(charset)));
+        createJarWithEntries(jarfile, map);
     }
 
     @FunctionalInterface

--- a/test/framework/src/main/java/org/elasticsearch/test/jar/JarUtils.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/jar/JarUtils.java
@@ -11,7 +11,6 @@ package org.elasticsearch.test.jar;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.OutputStream;
-import java.nio.charset.Charset;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
@@ -20,6 +19,7 @@ import java.util.jar.JarEntry;
 import java.util.jar.JarOutputStream;
 import java.util.jar.Manifest;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.stream.Collectors.toUnmodifiableMap;
 
 public final class JarUtils {
@@ -73,15 +73,14 @@ public final class JarUtils {
     }
 
     /**
-     * Creates a jar file with the given entries.
+     * Creates a jar file with the given entries. Entry values are converted to bytes using UTF-8.
      *
      * @param jarfile the jar file path
      * @param entries map of entries to add; jar entry name to String contents
-     * @param charset the charset used to convert the entry values to bytes
      * @throws IOException if an I/O error occurs
      */
-    public static void createJarWithEntries(Path jarfile, Map<String, String> entries, Charset charset) throws IOException {
-        var map = entries.entrySet().stream().collect(toUnmodifiableMap(Map.Entry::getKey, v -> v.getValue().getBytes(charset)));
+    public static void createJarWithEntriesUTF(Path jarfile, Map<String, String> entries) throws IOException {
+        var map = entries.entrySet().stream().collect(toUnmodifiableMap(Map.Entry::getKey, v -> v.getValue().getBytes(UTF_8)));
         createJarWithEntries(jarfile, map);
     }
 


### PR DESCRIPTION
This PR updates the embedded class loader to be MRJAR aware.

A number of the implementation dependencies that are loaded by the 
embedded class loader are MRJARs. The loader should search for classes
and resources in the versioned section before the root.