### PR TITLE
Use faster and cleaner map parsing loop in ObjectParser.parse

### DIFF
--- a/libs/x-content/src/main/java/org/elasticsearch/xcontent/ObjectParser.java
+++ b/libs/x-content/src/main/java/org/elasticsearch/xcontent/ObjectParser.java
@@ -275,9 +275,6 @@ public final class ObjectParser<Value, Context> extends AbstractObjectParser<Val
             }
         }
 
-        FieldParser fieldParser = null;
-        String currentFieldName = null;
-        XContentLocation currentPosition = null;
         final List<String[]> requiredFields = this.requiredFieldSets.isEmpty() ? null : new ArrayList<>(this.requiredFieldSets);
         final List<List<String>> exclusiveFields;
         if (exclusiveFieldSets.isEmpty()) {
@@ -289,36 +286,32 @@ public final class ObjectParser<Value, Context> extends AbstractObjectParser<Val
             }
         }
 
+        FieldParser fieldParser;
+        String currentFieldName;
+        XContentLocation currentPosition;
         final Map<String, FieldParser> parsers = fieldParserMap.getOrDefault(parser.getRestApiVersion(), Collections.emptyMap());
-        while ((token = parser.nextToken()) != XContentParser.Token.END_OBJECT) {
-            if (token == XContentParser.Token.FIELD_NAME) {
-                currentFieldName = parser.currentName();
-                currentPosition = parser.getTokenLocation();
-                fieldParser = parsers.get(currentFieldName);
+        while ((currentFieldName = parser.nextFieldName()) != null) {
+            currentPosition = parser.getTokenLocation();
+            fieldParser = parsers.get(currentFieldName);
+            token = parser.nextToken();
+            if (fieldParser == null) {
+                unknownFieldParser.acceptUnknownField(this, currentFieldName, currentPosition, parser, value, context);
             } else {
-                if (currentFieldName == null) {
-                    throwNoFieldFound(parser);
+                fieldParser.assertSupports(name, parser, token, currentFieldName);
+
+                if (requiredFields != null) {
+                    // Check to see if this field is a required field, if it is we can
+                    // remove the entry as the requirement is satisfied
+                    maybeMarkRequiredField(currentFieldName, requiredFields);
                 }
-                if (fieldParser == null) {
-                    unknownFieldParser.acceptUnknownField(this, currentFieldName, currentPosition, parser, value, context);
-                } else {
-                    fieldParser.assertSupports(name, parser, currentFieldName);
 
-                    if (requiredFields != null) {
-                        // Check to see if this field is a required field, if it is we can
-                        // remove the entry as the requirement is satisfied
-                        maybeMarkRequiredField(currentFieldName, requiredFields);
-                    }
-
-                    if (exclusiveFields != null) {
-                        // Check if this field is in an exclusive set, if it is then mark
-                        // it as seen.
-                        maybeMarkExclusiveField(currentFieldName, exclusiveFields);
-                    }
-
-                    parseSub(parser, fieldParser, currentFieldName, value, context);
+                if (exclusiveFields != null) {
+                    // Check if this field is in an exclusive set, if it is then mark
+                    // it as seen.
+                    maybeMarkExclusiveField(currentFieldName, exclusiveFields);
                 }
-                fieldParser = null;
+
+                parseSub(parser, fieldParser, token, currentFieldName, value, context);
             }
         }
 
@@ -334,10 +327,6 @@ public final class ObjectParser<Value, Context> extends AbstractObjectParser<Val
 
     private void throwExpectedStartObject(XContentParser parser, XContentParser.Token token) {
         throw new XContentParseException(parser.getTokenLocation(), "[" + name + "] Expected START_OBJECT but was: " + token);
-    }
-
-    private void throwNoFieldFound(XContentParser parser) {
-        throw new XContentParseException(parser.getTokenLocation(), "[" + name + "] no field found");
     }
 
     private static void throwMissingRequiredFields(List<String[]> requiredFields) {
@@ -626,8 +615,14 @@ public final class ObjectParser<Value, Context> extends AbstractObjectParser<Val
         throw new XContentParseException(parser.getTokenLocation(), "[" + name + "] failed to parse field [" + currentFieldName + "]", ex);
     }
 
-    private void parseSub(XContentParser parser, FieldParser fieldParser, String currentFieldName, Value value, Context context) {
-        final XContentParser.Token token = parser.currentToken();
+    private void parseSub(
+        XContentParser parser,
+        FieldParser fieldParser,
+        XContentParser.Token token,
+        String currentFieldName,
+        Value value,
+        Context context
+    ) {
         switch (token) {
             case START_OBJECT -> {
                 parseValue(parser, fieldParser, currentFieldName, value, context);
@@ -689,7 +684,7 @@ public final class ObjectParser<Value, Context> extends AbstractObjectParser<Val
             this.type = type;
         }
 
-        void assertSupports(String parserName, XContentParser xContentParser, String currentFieldName) {
+        void assertSupports(String parserName, XContentParser xContentParser, XContentParser.Token currentToken, String currentFieldName) {
             boolean match = parseField.match(
                 parserName,
                 xContentParser::getTokenLocation,
@@ -705,7 +700,7 @@ public final class ObjectParser<Value, Context> extends AbstractObjectParser<Val
             if (supportedTokens.contains(xContentParser.currentToken()) == false) {
                 throw new XContentParseException(
                     xContentParser.getTokenLocation(),
-                    "[" + parserName + "] " + currentFieldName + " doesn't support values of type: " + xContentParser.currentToken()
+                    "[" + parserName + "] " + currentFieldName + " doesn't support values of type: " + currentToken
                 );
             }
         }

--- a/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/notification/email/attachment/ReportingAttachmentParserTests.java
+++ b/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/notification/email/attachment/ReportingAttachmentParserTests.java
@@ -15,7 +15,6 @@ import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xcontent.XContentBuilder;
-import org.elasticsearch.xcontent.XContentEOFException;
 import org.elasticsearch.xcontent.XContentParseException;
 import org.elasticsearch.xcontent.XContentParser;
 import org.elasticsearch.xpack.core.watcher.execution.WatchExecutionContext;
@@ -234,8 +233,8 @@ public class ReportingAttachmentParserTests extends ESTestCase {
             // closing json bracket is missing
             .thenReturn(new HttpResponse(200, "{\"path\":\"anything\""));
         ReportingAttachment attachment = new ReportingAttachment("foo", dashboardUrl, randomBoolean(), null, null, null, null);
-        XContentEOFException e = expectThrows(
-            XContentEOFException.class,
+        XContentParseException e = expectThrows(
+            XContentParseException.class,
             () -> reportingAttachmentParser.toAttachment(createWatchExecutionContext(), Payload.EMPTY, attachment)
         );
         assertThat(e.getMessage(), containsString("Unexpected end-of-input"));


### PR DESCRIPTION
Much easier to use the new API and not have to worry about all the manual
checks on the field name that were dead code anyway because they'd only be
hit on malformed input bytes which Jackson would throw on before entering
our code.
Also, removes some `currentToken()` calls by reusing the token as those aren't free and
speeding this up in any way possible is nice for the stability of snapshot inspection APIs
in large clusters.