### PR TITLE
Rename TransportMasterNodeReadAction#checkSizeLimit

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/support/master/TransportMasterNodeReadAction.java
+++ b/server/src/main/java/org/elasticsearch/action/support/master/TransportMasterNodeReadAction.java
@@ -50,7 +50,7 @@ public abstract class TransportMasterNodeReadAction<Request extends MasterNodeRe
 
     protected TransportMasterNodeReadAction(
         String actionName,
-        boolean checkSizeLimit,
+        boolean canTripCircuitBreaker,
         TransportService transportService,
         ClusterService clusterService,
         ThreadPool threadPool,
@@ -62,7 +62,7 @@ public abstract class TransportMasterNodeReadAction<Request extends MasterNodeRe
     ) {
         super(
             actionName,
-            checkSizeLimit,
+            canTripCircuitBreaker,
             transportService,
             clusterService,
             threadPool,


### PR DESCRIPTION
This parameter is called `canTripCircuitBreaker` everywhere else.