### PR TITLE
Mute MetadataIndexTemplateServiceTests.testValidateTsdbDataStreamsReferringTsdbTemplate

### DIFF
--- a/modules/data-streams/src/test/java/org/elasticsearch/datastreams/MetadataIndexTemplateServiceTests.java
+++ b/modules/data-streams/src/test/java/org/elasticsearch/datastreams/MetadataIndexTemplateServiceTests.java
@@ -46,6 +46,7 @@ import static org.mockito.Mockito.when;
  */
 public class MetadataIndexTemplateServiceTests extends ESSingleNodeTestCase {
 
+    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/86333")
     public void testValidateTsdbDataStreamsReferringTsdbTemplate() throws Exception {
         var state = ClusterState.EMPTY_STATE;
         final var service = getMetadataIndexTemplateService();


### PR DESCRIPTION
Muting the test failure described in #86333 