### PR TITLE
[7.17] Update asm version in build tools for java19 support (#86288)

### DIFF
--- a/build-tools-internal/build.gradle
+++ b/build-tools-internal/build.gradle
@@ -215,6 +215,9 @@ dependencies {
       }
       because 'We want to use the exact same jackson version we use in production'
     }
+    // ensuring brought asm version brought in by spock is up-to-date
+    testImplementation 'org.ow2.asm:asm:9.3'
+    integTestImplementation 'org.ow2.asm:asm:9.3'
   }
   api localGroovy()
   api gradleApi()
@@ -268,11 +271,11 @@ dependencies {
     because 'allows tests to run from IDEs that bundle older version of launcher'
   }
 
-  testImplementation platform("org.spockframework:spock-bom:2.0-groovy-3.0")
+  testImplementation platform("org.spockframework:spock-bom:2.1-groovy-3.0")
   testImplementation("org.spockframework:spock-core") {
     exclude module: "groovy"
   }
-  integTestImplementation platform("org.spockframework:spock-bom:2.0-groovy-3.0")
+  integTestImplementation platform("org.spockframework:spock-bom:2.1-groovy-3.0")
   integTestImplementation("org.spockframework:spock-core") {
     exclude module: "groovy"
   }

--- a/build-tools/build.gradle
+++ b/build-tools/build.gradle
@@ -108,6 +108,11 @@ repositories {
 }
 
 dependencies {
+    constraints {
+        // ensuring brought asm version brought in by spock is up-to-date
+        testFixturesApi 'org.ow2.asm:asm:9.3'
+        integTestImplementation 'org.ow2.asm:asm:9.3'
+    }
     reaper project('reaper')
 
     api localGroovy()
@@ -121,7 +126,7 @@ dependencies {
     testFixturesApi gradleApi()
     testFixturesApi gradleTestKit()
     testFixturesApi 'com.github.tomakehurst:wiremock-jre8-standalone:2.23.2'
-    testFixturesApi platform("org.spockframework:spock-bom:2.0-groovy-3.0")
+    testFixturesApi platform("org.spockframework:spock-bom:2.1-groovy-3.0")
     testFixturesApi("org.spockframework:spock-core") {
         exclude module: "groovy"
     }


### PR DESCRIPTION
Backports the following commits to 7.17:
 - Update asm version in build tools for java19 support (#86288)