### PR TITLE
Handle no breaking changes in release notes

### DIFF
--- a/build-tools-internal/src/main/resources/templates/breaking-changes.asciidoc
+++ b/build-tools-internal/src/main/resources/templates/breaking-changes.asciidoc
@@ -11,11 +11,13 @@ See also <<release-highlights>> and <<es-release-notes>>.
 <% if (isElasticsearchSnapshot) { %>
 coming::[${version}]
 <% } %>
-<% if (breakingByNotabilityByArea.isEmpty() == false) { %>
+
 [discrete]
 [[breaking-changes-${majorDotMinor}]]
 === Breaking changes
-
+<% if (breakingByNotabilityByArea.isEmpty()) { %>
+There are no breaking changes in {es} ${majorDotMinor}.
+<% } else { %>
 The following changes in {es} ${majorDotMinor} might affect your applications
 and prevent them from operating normally.
 Before upgrading to ${majorDotMinor}, review these changes and take the described steps


### PR DESCRIPTION
Closes #85707.

If there are no breaking changes in the input files for the release note
generation process, the output asciidoc will contain a broken link. Fix
this by always generating the breaking changes section, but where there
are no breaking changes we now state this fact.