### PR TITLE
User Profile - Use security origin for BWC cases

### DIFF
--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/Security.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/Security.java
@@ -769,6 +769,7 @@ public class Security extends Plugin
             getClock(),
             client,
             systemIndices.getProfileIndexManager(),
+            clusterService,
             threadPool
         );
         components.add(profileService);

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/support/SecuritySystemIndices.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/support/SecuritySystemIndices.java
@@ -46,6 +46,7 @@ public class SecuritySystemIndices {
 
     public static final String INTERNAL_SECURITY_PROFILE_INDEX_8 = ".security-profile-8";
     public static final String SECURITY_PROFILE_ALIAS = ".security-profile";
+    public static final Version VERSION_SECURITY_PROFILE_ORIGIN = Version.V_8_3_0;
 
     private final Logger logger = LogManager.getLogger(SecuritySystemIndices.class);
 
@@ -737,8 +738,25 @@ public class SecuritySystemIndices {
             .setAliasName(SECURITY_PROFILE_ALIAS)
             .setIndexFormat(INTERNAL_PROFILE_INDEX_FORMAT)
             .setVersionMetaKey(SECURITY_VERSION_STRING)
-            .setOrigin(SECURITY_PROFILE_ORIGIN)
+            .setOrigin(SECURITY_PROFILE_ORIGIN) // new origin since 8.3
             .setThreadPools(ExecutorNames.CRITICAL_SYSTEM_INDEX_THREAD_POOLS)
+            .setMinimumNodeVersion(VERSION_SECURITY_PROFILE_ORIGIN)
+            .setPriorSystemIndexDescriptors(
+                List.of(
+                    SystemIndexDescriptor.builder()
+                        .setIndexPattern(".security-profile-[0-9]+*")
+                        .setPrimaryIndex(INTERNAL_SECURITY_PROFILE_INDEX_8)
+                        .setDescription("Contains user profile documents")
+                        .setMappings(getProfileIndexMappings())
+                        .setSettings(getProfileIndexSettings())
+                        .setAliasName(SECURITY_PROFILE_ALIAS)
+                        .setIndexFormat(INTERNAL_PROFILE_INDEX_FORMAT)
+                        .setVersionMetaKey(SECURITY_VERSION_STRING)
+                        .setOrigin(SECURITY_ORIGIN)
+                        .setThreadPools(ExecutorNames.CRITICAL_SYSTEM_INDEX_THREAD_POOLS)
+                        .build()
+                )
+            )
             .build();
     }
 

--- a/x-pack/qa/rolling-upgrade/build.gradle
+++ b/x-pack/qa/rolling-upgrade/build.gradle
@@ -1,3 +1,4 @@
+import org.elasticsearch.gradle.Version
 import org.elasticsearch.gradle.VersionProperties
 import org.elasticsearch.gradle.internal.info.BuildParams
 import org.elasticsearch.gradle.testclusters.StandaloneRestIntegTestTask
@@ -86,6 +87,8 @@ BuildParams.bwcVersions.withWireCompatible { bwcVersion, baseName ->
 
     keystore 'xpack.watcher.encryption_key', file("${project.projectDir}/src/test/resources/system_key")
     setting 'xpack.watcher.encrypt_sensitive_data', 'true'
+
+    requiresFeature 'es.user_profile_feature_flag_enabled', Version.fromString("8.1.0")
 
     // Old versions of the code contain an invalid assertion that trips
     // during tests.  Versions 5.6.9 and 6.2.4 have been fixed by removing

--- a/x-pack/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/mixed_cluster/140_user_profile.yml
+++ b/x-pack/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/mixed_cluster/140_user_profile.yml
@@ -1,0 +1,29 @@
+---
+"Test User Profile feature will work in a mixed cluster":
+
+  - skip:
+      features: [headers, node_selector]
+
+  - do:
+      node_selector:
+        version: " 8.3.0 - "
+      security.activate_user_profile:
+        body: >
+          {
+            "grant_type": "password",
+            "username": "test_user",
+            "password" : "x-pack-test-password"
+          }
+  - is_true: uid
+  - match: { "user.username" : "test_user" }
+  - set: { uid: profile_uid }
+
+  - do:
+      security.get_user_profile:
+        uid: "$profile_uid"
+
+  - length: { $body: 1 }
+  - is_true: "$profile_uid"
+  - set: { $profile_uid: profile }
+  - match: { $profile.uid : "$profile_uid" }
+  - match: { $profile.user.username : "test_user" }

--- a/x-pack/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/mixed_cluster/140_user_profile.yml
+++ b/x-pack/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/mixed_cluster/140_user_profile.yml
@@ -2,7 +2,9 @@
 "Test User Profile feature will work in a mixed cluster":
 
   - skip:
-      features: [headers, node_selector]
+      features: node_selector
+      version: " - 7.99.99"
+      reason: "https://github.com/elastic/elasticsearch/issues/86373"
 
   - do:
       node_selector:

--- a/x-pack/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/mixed_cluster/140_user_profile.yml
+++ b/x-pack/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/mixed_cluster/140_user_profile.yml
@@ -19,6 +19,8 @@
   - set: { uid: profile_uid }
 
   - do:
+      node_selector:
+        version: " 8.3.0 - "
       security.get_user_profile:
         uid: "$profile_uid"
 


### PR DESCRIPTION
The security profile action origin and internal user is not available
before version 8.3.0. This PR makes all profile actions to use the
existing security origin if the cluster has any node that is older than
8.3.0.

The change makes it possible to use User Profile features in a mixed
cluster (7.17 and 8.3+) as long as the request always hits a node of
newer version first.

