### PR TITLE
[8.2] Fix NPE when using object field as match field for enrich policy (#86089)

### DIFF
--- a/docs/changelog/86089.yaml
+++ b/docs/changelog/86089.yaml
@@ -1,0 +1,6 @@
+pr: 86089
+summary: Fix NPE when using object field as match field for enrich policy
+area: Ingest
+type: bug
+issues:
+ - 86058

--- a/x-pack/plugin/enrich/src/main/java/org/elasticsearch/xpack/enrich/EnrichPolicyRunner.java
+++ b/x-pack/plugin/enrich/src/main/java/org/elasticsearch/xpack/enrich/EnrichPolicyRunner.java
@@ -268,6 +268,15 @@ public class EnrichPolicyRunner implements Runnable {
         Set<String> types = matchFieldMappings.stream().map(map -> map.get("type")).collect(Collectors.toSet());
         if (types.size() == 1) {
             String type = types.iterator().next();
+            if (type == null) {
+                // when no type is defined in a field mapping then it is of type object:
+                throw new ElasticsearchException(
+                    "Field '{}' has type [object] which doesn't appear to be a range type",
+                    enrichPolicy.getMatchField(),
+                    type
+                );
+            }
+
             switch (type) {
                 case "integer_range":
                 case "float_range":

--- a/x-pack/plugin/enrich/src/test/java/org/elasticsearch/xpack/enrich/EnrichPolicyRunnerTests.java
+++ b/x-pack/plugin/enrich/src/test/java/org/elasticsearch/xpack/enrich/EnrichPolicyRunnerTests.java
@@ -56,6 +56,7 @@ import org.elasticsearch.test.TestGeoShapeFieldMapperPlugin;
 import org.elasticsearch.threadpool.TestThreadPool;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.xcontent.XContentBuilder;
+import org.elasticsearch.xcontent.XContentFactory;
 import org.elasticsearch.xcontent.XContentType;
 import org.elasticsearch.xcontent.json.JsonXContent;
 import org.elasticsearch.xcontent.smile.SmileXContent;
@@ -1949,6 +1950,47 @@ public class EnrichPolicyRunnerTests extends ESSingleNodeTestCase {
         latch.await();
         assertThat(exception.get(), notNullValue());
         assertThat(exception.get().getMessage(), containsString("cancelled policy execution [test1], status ["));
+    }
+
+    public void testRunRangePolicyWithObjectFieldAsMatchField() throws Exception {
+        final String sourceIndex = "source-index";
+        XContentBuilder mapping = XContentFactory.jsonBuilder()
+            .startObject()
+            .startObject("_doc")
+            .startObject("properties")
+            .startObject("field1");
+        if (randomBoolean()) {
+            mapping.field("type", "object");
+        }
+        mapping.startObject("properties")
+            .startObject("sub")
+            .field("type", "keyword")
+            .endObject()
+            .endObject()
+            .endObject()
+            .startObject("field3")
+            .field("type", "keyword")
+            .endObject()
+            .endObject()
+            .endObject()
+            .endObject();
+        createIndex(sourceIndex, Settings.EMPTY, mapping);
+
+        EnrichPolicy policy = new EnrichPolicy(EnrichPolicy.RANGE_TYPE, null, List.of(sourceIndex), "field1", List.of("field2"));
+        String policyName = "test1";
+
+        final long createTime = randomNonNegativeLong();
+        final AtomicReference<Exception> exception = new AtomicReference<>();
+        final CountDownLatch latch = new CountDownLatch(1);
+        ActionListener<ExecuteEnrichPolicyStatus> listener = createTestListener(latch, exception::set);
+        EnrichPolicyRunner enrichPolicyRunner = createPolicyRunner(policyName, policy, listener, createTime);
+
+        logger.info("Starting policy run");
+        enrichPolicyRunner.run();
+        latch.await();
+        Exception e = exception.get();
+        assertThat(e, notNullValue());
+        assertThat(e.getMessage(), equalTo("Field 'field1' has type [object] which doesn't appear to be a range type"));
     }
 
     private EnrichPolicyRunner createPolicyRunner(


### PR DESCRIPTION
Backports the following commits to 8.2:
 - Fix NPE when using object field as match field for enrich policy (#86089)