### PR TITLE
[DOCS] Add notable highlight sections for 8.2.0

### DIFF
--- a/docs/reference/release-notes/highlights.asciidoc
+++ b/docs/reference/release-notes/highlights.asciidoc
@@ -17,14 +17,8 @@ Other versions:
 
 // The notable-highlights tag marks entries that
 // should be featured in the Stack Installation and Upgrade Guide:
+
 // tag::notable-highlights[]
-// [discrete]
-// === Heading
-//
-// Description.
-// end::notable-highlights[]
-
-
 [discrete]
 [[integrate_filtering_support_for_approximate_nearest_neighbor_search]]
 === Integrate filtering support for approximate nearest neighbor search
@@ -58,3 +52,4 @@ exponentially accelerate their aggregations for calculations, with a slight
 trade off in accuracy, by randomly sampling documents in a statistically robust 
 manner. The random sampler aggregation can be used to accelerate any application 
 that utilizes aggregations for calculations.
+// end::notable-highlights[]


### PR DESCRIPTION
This PR updates the tagged sections in https://www.elastic.co/guide/en/elasticsearch/reference/8.2/release-highlights.html so that the highlights are re-used within the Installation and Upgrade Guide.