### PR TITLE
[DOCS] No breaking changes in release 8.2.0

### DIFF
--- a/docs/reference/migration/migrate_8_2.asciidoc
+++ b/docs/reference/migration/migrate_8_2.asciidoc
@@ -13,7 +13,7 @@ See also <<release-highlights>> and <<es-release-notes>>.
 [[breaking-changes-8.2]]
 === Breaking changes
 
-There are no breaking changes for 6.8.0
+There are no breaking changes for 8.2.0
 
 See also <<release-highlights>> and <<es-release-notes>>.
 

--- a/docs/reference/migration/migrate_8_2.asciidoc
+++ b/docs/reference/migration/migrate_8_2.asciidoc
@@ -15,8 +15,6 @@ See also <<release-highlights>> and <<es-release-notes>>.
 
 There are no breaking changes for 8.2.0
 
-See also <<release-highlights>> and <<es-release-notes>>.
-
 // NOTE: The notable-breaking-changes tagged regions are re-used in the
 // Installation and Upgrade Guide
 // tag::notable-breaking-changes[]

--- a/docs/reference/migration/migrate_8_2.asciidoc
+++ b/docs/reference/migration/migrate_8_2.asciidoc
@@ -13,12 +13,10 @@ See also <<release-highlights>> and <<es-release-notes>>.
 [[breaking-changes-8.2]]
 === Breaking changes
 
-There are no breaking changes for 8.2.0
-
 // NOTE: The notable-breaking-changes tagged regions are re-used in the
 // Installation and Upgrade Guide
 // tag::notable-breaking-changes[]
 
-coming::[8.2.0]
+There are no breaking changes for 8.2.0.
 
 // end::notable-breaking-changes[]

--- a/docs/reference/migration/migrate_8_2.asciidoc
+++ b/docs/reference/migration/migrate_8_2.asciidoc
@@ -13,6 +13,10 @@ See also <<release-highlights>> and <<es-release-notes>>.
 [[breaking-changes-8.2]]
 === Breaking changes
 
+There are no breaking changes for 6.8.0
+
+See also <<release-highlights>> and <<es-release-notes>>.
+
 // NOTE: The notable-breaking-changes tagged regions are re-used in the
 // Installation and Upgrade Guide
 // tag::notable-breaking-changes[]


### PR DESCRIPTION
Explicitly mention that there are no breaking changes in release 8.2.0.

Documentation: https://elasticsearch_86356.docs-preview.app.elstc.co/diff