### PR TITLE
Avoid starting test fixtures when resolving all external dependencies

### DIFF
--- a/plugins/repository-hdfs/build.gradle
+++ b/plugins/repository-hdfs/build.gradle
@@ -389,3 +389,8 @@ tasks.named("thirdPartyAudit").configure {
             'org.apache.hadoop.thirdparty.protobuf.UnsafeUtil$MemoryAccessor'
     )
 }
+
+tasks.named('resolveAllDependencies') {
+  // This avoids spinning up the test fixture when downloading all dependencies
+  configs = project.configurations - [project.configurations.krb5Config]
+}


### PR DESCRIPTION
I noticed a few of our CI image builds failing due to `compseUp` tasks timing out. We really shouldn't be starting test fixtures when resolving dependencies. This just happened to be a case where a dependency is actually generated by the test fixture. Given these aren't "external" dependencies, it makes no sense to seed them into our CI images so I've ignored it here. There are likely loads of other instances of this, perhaps we should use some kind of convention when declaring these types of configurations so they are ignored.