### PR TITLE
Disable template cleanup in MultiVersionRepositoryAccessIT to fix it in older versions

### DIFF
--- a/qa/repository-multi-version/src/test/java/org/elasticsearch/upgrades/MultiVersionRepositoryAccessIT.java
+++ b/qa/repository-multi-version/src/test/java/org/elasticsearch/upgrades/MultiVersionRepositoryAccessIT.java
@@ -88,7 +88,11 @@ public class MultiVersionRepositoryAccessIT extends ESRestTestCase {
         return true;
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/82569")
+    @Override
+    protected boolean preserveTemplatesUponCompletion() {
+        return true;
+    }
+
     public void testCreateAndRestoreSnapshot() throws IOException {
         final String repoName = getTestName();
         try {
@@ -135,7 +139,6 @@ public class MultiVersionRepositoryAccessIT extends ESRestTestCase {
         }
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/82569")
     public void testReadOnlyRepo() throws IOException {
         final String repoName = getTestName();
         final int shards = 3;
@@ -169,7 +172,6 @@ public class MultiVersionRepositoryAccessIT extends ESRestTestCase {
         ElasticsearchStatusException.class
     );
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/82569")
     public void testUpgradeMovesRepoToNewMetaVersion() throws IOException {
         final String repoName = getTestName();
         try {


### PR DESCRIPTION
I could not find a clean way of making the template cleanup work with very old versions.
I found that it's also disabled in other tests dealing with old versions (full cluster restart tests)
so I'm disabling it here as well to finally make these important tests functional again.

closes #82569