### PR TITLE
Less complexity in after-key parsing for unmapped fields

### DIFF
--- a/docs/changelog/86359.yaml
+++ b/docs/changelog/86359.yaml
@@ -1,0 +1,6 @@
+pr: 86359
+summary: Less jank in after-key parsing for unmapped fields
+area: CompositeAggs
+type: bug
+issues:
+ - 85928

--- a/docs/changelog/86359.yaml
+++ b/docs/changelog/86359.yaml
@@ -1,6 +1,6 @@
 pr: 86359
 summary: Less jank in after-key parsing for unmapped fields
-area: CompositeAggs
+area: Aggregations
 type: bug
 issues:
  - 85928

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/composite/GlobalOrdinalValuesSource.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/composite/GlobalOrdinalValuesSource.java
@@ -105,7 +105,7 @@ class GlobalOrdinalValuesSource extends SingleDimensionValuesSource<BytesRef> {
         if (missingBucket && value == null) {
             afterValue = null;
             afterValueGlobalOrd = MISSING_VALUE_FLAG;
-        } else if (value.getClass() == String.class || (missingBucket && fieldType == null)) {
+        } else if (value.getClass() == String.class || (fieldType == null)) {
             // the value might be not string if this field is missing in this shard but present in other shards
             // and doesn't have a string type
             afterValue = format.parseBytesRef(value);


### PR DESCRIPTION
Resolves #85928

The after-key parsing is pretty weird, and there are probably more bugs there.  I did not take the opportunity to refactor the whole thing, but we should.  This fixes the immediate problem by treating after keys as bytes refs when we don't have a field but think we want a keyword.  We were already doing that if the user asked for a missing bucket, this just extends the behavior in the case that we don't.

Long term, the terms Composite source (and probably other Composite sources) should have specializations for unmapped fields.  That's the direction we want to take aggs in general.