### PR TITLE
[doc] Update to include API for checking JVM pointers

### DIFF
--- a/docs/reference/setup/advanced-configuration.asciidoc
+++ b/docs/reference/setup/advanced-configuration.asciidoc
@@ -117,6 +117,13 @@ threshold, check the {es} log for an entry like this:
 ----
 heap size [1.9gb], compressed ordinary object pointers [true]
 ----
++
+Or check the <<cluster-nodes-info,nodes info API's>> `nodes.{name}.jvm.using_compressed_ordinary_object_pointers` value:
++
+[source,console]
+----
+GET _nodes/_all/jvm
+----
 
 The more heap available to {es}, the more memory it can use for its internal
 caches. This leaves less memory for the operating system to use

--- a/docs/reference/setup/advanced-configuration.asciidoc
+++ b/docs/reference/setup/advanced-configuration.asciidoc
@@ -118,7 +118,7 @@ threshold, check the {es} log for an entry like this:
 heap size [1.9gb], compressed ordinary object pointers [true]
 ----
 +
-Or check the <<cluster-nodes-info,nodes info API's>> `nodes.{name}.jvm.using_compressed_ordinary_object_pointers` value:
+Or check the `jvm.using_compressed_ordinary_object_pointers` value for the nodes using the <<cluster-nodes-info,nodes info API>>:
 +
 [source,console]
 ----


### PR DESCRIPTION
Add information for how to find if compressed ordinary object pointers is in use using the REST APIs.

Currently the documentation only includes how to check it via the log file.
https://www.elastic.co/guide/en/elasticsearch/reference/8.1/advanced-configuration.html#set-jvm-heap-size
https://www.elastic.co/guide/en/elasticsearch/reference/7.17/advanced-configuration.html#set-jvm-heap-size

This documentation update should be back ported to at least the 7.17 version as I tested the command against v7.17.
