### PR TITLE
Correct terminal input in setup password test

### DIFF
--- a/x-pack/qa/security-setup-password-tests/src/test/java/org/elasticsearch/xpack/security/authc/esnative/tool/SetupPasswordToolIT.java
+++ b/x-pack/qa/security-setup-password-tests/src/test/java/org/elasticsearch/xpack/security/authc/esnative/tool/SetupPasswordToolIT.java
@@ -27,8 +27,8 @@ public class SetupPasswordToolIT extends AbstractPasswordToolTestCase {
         SetupPasswordTool tool = new SetupPasswordTool();
         final int status;
         if (randomBoolean()) {
-            mockTerminal.addTextInput("y"); // answer yes to continue prompt
             possiblyDecryptKeystore(mockTerminal);
+            mockTerminal.addTextInput("y"); // answer yes to continue prompt
             status = tool.main(new String[] { "auto" }, mockTerminal, getToolProcessInfo());
         } else {
             possiblyDecryptKeystore(mockTerminal);


### PR DESCRIPTION
In FIPS-mode `SetupPasswordToolIT` can take two terminal prompt inputs:
a confirmation and a keystore password. Currently, these are provided
in reverse order (i.e., confirmation prompt response `y` is used for
the password) causing the test to fail. This PR corrects the order.

Closes #86363