### PR TITLE
[Refactor] Use records instead of tuples in PluginService

### DIFF
--- a/server/src/main/java/org/elasticsearch/plugins/PluginsService.java
+++ b/server/src/main/java/org/elasticsearch/plugins/PluginsService.java
@@ -22,7 +22,6 @@ import org.elasticsearch.common.io.FileSystemUtils;
 import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Setting.Property;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.core.Nullable;
 import org.elasticsearch.core.Tuple;
 import org.elasticsearch.index.IndexModule;
 import org.elasticsearch.jdk.JarHell;
@@ -64,7 +63,7 @@ public class PluginsService implements ReportingService<PluginsAndModules> {
      * @param instance The constructed instance of the plugin's main class
      * @param loader   The classloader for the plugin
      */
-    record LoadedPlugin(PluginInfo info, Plugin instance, @Nullable ClassLoader loader) {}
+    record LoadedPlugin(PluginInfo info, Plugin instance, ClassLoader loader) {}
 
     private static final Logger logger = LogManager.getLogger(PluginsService.class);
 

--- a/server/src/main/java/org/elasticsearch/plugins/PluginsService.java
+++ b/server/src/main/java/org/elasticsearch/plugins/PluginsService.java
@@ -22,6 +22,7 @@ import org.elasticsearch.common.io.FileSystemUtils;
 import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Setting.Property;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.core.Nullable;
 import org.elasticsearch.core.Tuple;
 import org.elasticsearch.index.IndexModule;
 import org.elasticsearch.jdk.JarHell;
@@ -63,7 +64,7 @@ public class PluginsService implements ReportingService<PluginsAndModules> {
      * @param instance The constructed instance of the plugin's main class
      * @param loader   The classloader for the plugin
      */
-    record LoadedPlugin(PluginInfo info, Plugin instance, ClassLoader loader) {}
+    record LoadedPlugin(PluginInfo info, Plugin instance, @Nullable ClassLoader loader) {}
 
     private static final Logger logger = LogManager.getLogger(PluginsService.class);
 
@@ -133,7 +134,7 @@ public class PluginsService implements ReportingService<PluginsAndModules> {
             if (logger.isTraceEnabled()) {
                 logger.trace("plugin loaded from classpath [{}]", pluginInfo);
             }
-            pluginsLoaded.add(new LoadedPlugin(pluginInfo, plugin, PluginsService.class.getClassLoader()));
+            pluginsLoaded.add(new LoadedPlugin(pluginInfo, plugin, null));
             pluginsList.add(pluginInfo);
             pluginsNames.add(pluginInfo.getName());
         }
@@ -668,6 +669,7 @@ public class PluginsService implements ReportingService<PluginsAndModules> {
             if (ExtensiblePlugin.class.isInstance(extendedPlugin.instance()) == false) {
                 throw new IllegalStateException("Plugin [" + name + "] cannot extend non-extensible plugin [" + extendedPluginName + "]");
             }
+            assert extendedPlugin.loader() != null : "All non-classpath plugins should be loaded with a classloader";
             extendedLoaders.add(extendedPlugin.loader());
         }
 

--- a/server/src/test/java/org/elasticsearch/plugins/PluginsServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/plugins/PluginsServiceTests.java
@@ -1172,7 +1172,8 @@ public class PluginsServiceTests extends ESTestCase {
             List.of(
                 new PluginsService.LoadedPlugin(
                     new PluginInfo("extensible", null, null, null, null, null, null, List.of(), false, PluginType.ISOLATED, "", false),
-                    extensiblePlugin
+                    extensiblePlugin,
+                    PluginsServiceTests.class.getClassLoader()
                 )
             )
         );
@@ -1186,7 +1187,8 @@ public class PluginsServiceTests extends ESTestCase {
             List.of(
                 new PluginsService.LoadedPlugin(
                     new PluginInfo("extensible", null, null, null, null, null, null, List.of(), false, PluginType.ISOLATED, "", false),
-                    extensiblePlugin
+                    extensiblePlugin,
+                    PluginsServiceTests.class.getClassLoader()
                 ),
                 new PluginsService.LoadedPlugin(
                     new PluginInfo(
@@ -1203,7 +1205,8 @@ public class PluginsServiceTests extends ESTestCase {
                         "",
                         false
                     ),
-                    testPlugin
+                    testPlugin,
+                    PluginsServiceTests.class.getClassLoader()
                 )
             )
         );

--- a/server/src/test/java/org/elasticsearch/plugins/PluginsServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/plugins/PluginsServiceTests.java
@@ -14,7 +14,6 @@ import org.apache.lucene.util.Constants;
 import org.elasticsearch.Version;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.core.PathUtils;
-import org.elasticsearch.core.Tuple;
 import org.elasticsearch.env.Environment;
 import org.elasticsearch.env.TestEnvironment;
 import org.elasticsearch.index.IndexModule;
@@ -1171,7 +1170,7 @@ public class PluginsServiceTests extends ESTestCase {
         TestExtensiblePlugin extensiblePlugin = new TestExtensiblePlugin();
         PluginsService.loadExtensions(
             List.of(
-                Tuple.tuple(
+                new PluginsService.LoadedPlugin(
                     new PluginInfo("extensible", null, null, null, null, null, null, List.of(), false, PluginType.ISOLATED, "", false),
                     extensiblePlugin
                 )
@@ -1185,11 +1184,11 @@ public class PluginsServiceTests extends ESTestCase {
         TestPlugin testPlugin = new TestPlugin();
         PluginsService.loadExtensions(
             List.of(
-                Tuple.tuple(
+                new PluginsService.LoadedPlugin(
                     new PluginInfo("extensible", null, null, null, null, null, null, List.of(), false, PluginType.ISOLATED, "", false),
                     extensiblePlugin
                 ),
-                Tuple.tuple(
+                new PluginsService.LoadedPlugin(
                     new PluginInfo(
                         "test",
                         null,

--- a/server/src/test/java/org/elasticsearch/plugins/PluginsServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/plugins/PluginsServiceTests.java
@@ -1173,7 +1173,7 @@ public class PluginsServiceTests extends ESTestCase {
                 new PluginsService.LoadedPlugin(
                     new PluginInfo("extensible", null, null, null, null, null, null, List.of(), false, PluginType.ISOLATED, "", false),
                     extensiblePlugin,
-                    PluginsServiceTests.class.getClassLoader()
+                    null
                 )
             )
         );
@@ -1188,7 +1188,7 @@ public class PluginsServiceTests extends ESTestCase {
                 new PluginsService.LoadedPlugin(
                     new PluginInfo("extensible", null, null, null, null, null, null, List.of(), false, PluginType.ISOLATED, "", false),
                     extensiblePlugin,
-                    PluginsServiceTests.class.getClassLoader()
+                    null
                 ),
                 new PluginsService.LoadedPlugin(
                     new PluginInfo(
@@ -1206,7 +1206,7 @@ public class PluginsServiceTests extends ESTestCase {
                         false
                     ),
                     testPlugin,
-                    PluginsServiceTests.class.getClassLoader()
+                    null
                 )
             )
         );


### PR DESCRIPTION
PluginsService used tuples to pair plugin instances with other objects. I've tried replacing the ones that are used in lists and passed between methods with records, for clarity. I left the transient usages within stream operations alone.

This is my first PR with Java Records, so please let me know if I've messed up any standard conventions.