### PR TITLE
[8.1] [Docs] Fix url for feature migration APIs (#86330)

### DIFF
--- a/docs/reference/migration/apis/feature-migration.asciidoc
+++ b/docs/reference/migration/apis/feature-migration.asciidoc
@@ -18,9 +18,9 @@ process.
 [[feature-migration-api-request]]
 ==== {api-request-title}
 
-`GET /migration/system_features`
+`GET /_migration/system_features`
 
-`POST /migration/system_features`
+`POST /_migration/system_features`
 
 [[feature-migration-api-prereqs]]
 ==== {api-prereq-title}


### PR DESCRIPTION
Backports the following commits to 8.1:
 - [Docs] Fix url for feature migration APIs (#86330)