### PR TITLE
Speed up map diffing (2)

### DIFF
--- a/docs/changelog/86375.yaml
+++ b/docs/changelog/86375.yaml
@@ -1,0 +1,5 @@
+pr: 86375
+summary: Speed up map diffing (2)
+area: Cluster Coordination
+type: enhancement
+issues: []

--- a/server/src/test/java/org/elasticsearch/cluster/serialization/DiffableTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/serialization/DiffableTests.java
@@ -17,6 +17,7 @@ import org.elasticsearch.common.collect.ImmutableOpenMap;
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.common.util.set.Sets;
 import org.elasticsearch.test.ESTestCase;
 
@@ -303,21 +304,24 @@ public class DiffableTests extends ESTestCase {
             // check properties of diffMap
             assertThat(new HashSet<>(diffMap.getDeletes()), equalTo(keysToRemove));
             if (diffableValues()) {
-                // assertThat(diffMap.getDiffs().keySet(), equalTo(keysToOverride));
-                // for (Integer key : keysToOverride) {
-                // assertThat(diffMap.getDiffs().get(key).apply(get(beforeMap, key)), equalTo(get(afterMap, key)));
-                // }
-                // assertThat(diffMap.getUpserts().keySet(), equalTo(keysToAdd));
-                // for (Integer key : keysToAdd) {
-                // assertThat(diffMap.getUpserts().get(key), equalTo(get(afterMap, key)));
-                // }
+                Map<Integer, Diff<V>> diffs = Maps.ofEntries(diffMap.getDiffs());
+                assertThat(diffs.keySet(), equalTo(keysToOverride));
+                for (Integer key : keysToOverride) {
+                    assertThat(diffs.get(key).apply(get(beforeMap, key)), equalTo(get(afterMap, key)));
+                }
+                Map<Integer, V> upserts = Maps.ofEntries(diffMap.getUpserts());
+                assertThat(upserts.keySet(), equalTo(keysToAdd));
+                for (Integer key : keysToAdd) {
+                    assertThat(upserts.get(key), equalTo(get(afterMap, key)));
+                }
             } else {
                 assertThat(diffMap.getDiffs(), empty());
                 Set<Integer> keysToAddAndOverride = Sets.union(keysToAdd, keysToOverride);
-                // assertThat(diffMap.getUpserts().keySet(), equalTo(keysToAddAndOverride));
-                // for (Integer key : keysToAddAndOverride) {
-                // assertThat(diffMap.getUpserts().get(key), equalTo(get(afterMap, key)));
-                // }
+                Map<Integer, V> upserts = Maps.ofEntries(diffMap.getUpserts());
+                assertThat(upserts.keySet(), equalTo(keysToAddAndOverride));
+                for (Integer key : keysToAddAndOverride) {
+                    assertThat(upserts.get(key), equalTo(get(afterMap, key)));
+                }
             }
 
             if (randomBoolean()) {

--- a/server/src/test/java/org/elasticsearch/cluster/serialization/DiffableTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/serialization/DiffableTests.java
@@ -303,21 +303,21 @@ public class DiffableTests extends ESTestCase {
             // check properties of diffMap
             assertThat(new HashSet<>(diffMap.getDeletes()), equalTo(keysToRemove));
             if (diffableValues()) {
-//                assertThat(diffMap.getDiffs().keySet(), equalTo(keysToOverride));
-//                for (Integer key : keysToOverride) {
-//                    assertThat(diffMap.getDiffs().get(key).apply(get(beforeMap, key)), equalTo(get(afterMap, key)));
-//                }
-//                assertThat(diffMap.getUpserts().keySet(), equalTo(keysToAdd));
-//                for (Integer key : keysToAdd) {
-//                    assertThat(diffMap.getUpserts().get(key), equalTo(get(afterMap, key)));
-//                }
+                // assertThat(diffMap.getDiffs().keySet(), equalTo(keysToOverride));
+                // for (Integer key : keysToOverride) {
+                // assertThat(diffMap.getDiffs().get(key).apply(get(beforeMap, key)), equalTo(get(afterMap, key)));
+                // }
+                // assertThat(diffMap.getUpserts().keySet(), equalTo(keysToAdd));
+                // for (Integer key : keysToAdd) {
+                // assertThat(diffMap.getUpserts().get(key), equalTo(get(afterMap, key)));
+                // }
             } else {
                 assertThat(diffMap.getDiffs(), empty());
                 Set<Integer> keysToAddAndOverride = Sets.union(keysToAdd, keysToOverride);
-//                assertThat(diffMap.getUpserts().keySet(), equalTo(keysToAddAndOverride));
-//                for (Integer key : keysToAddAndOverride) {
-//                    assertThat(diffMap.getUpserts().get(key), equalTo(get(afterMap, key)));
-//                }
+                // assertThat(diffMap.getUpserts().keySet(), equalTo(keysToAddAndOverride));
+                // for (Integer key : keysToAddAndOverride) {
+                // assertThat(diffMap.getUpserts().get(key), equalTo(get(afterMap, key)));
+                // }
             }
 
             if (randomBoolean()) {

--- a/server/src/test/java/org/elasticsearch/cluster/serialization/DiffableTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/serialization/DiffableTests.java
@@ -27,11 +27,11 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 
-import static java.util.Collections.emptyMap;
 import static java.util.Collections.unmodifiableMap;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.Matchers.empty;
 
 public class DiffableTests extends ESTestCase {
 
@@ -303,21 +303,21 @@ public class DiffableTests extends ESTestCase {
             // check properties of diffMap
             assertThat(new HashSet<>(diffMap.getDeletes()), equalTo(keysToRemove));
             if (diffableValues()) {
-                assertThat(diffMap.getDiffs().keySet(), equalTo(keysToOverride));
-                for (Integer key : keysToOverride) {
-                    assertThat(diffMap.getDiffs().get(key).apply(get(beforeMap, key)), equalTo(get(afterMap, key)));
-                }
-                assertThat(diffMap.getUpserts().keySet(), equalTo(keysToAdd));
-                for (Integer key : keysToAdd) {
-                    assertThat(diffMap.getUpserts().get(key), equalTo(get(afterMap, key)));
-                }
+//                assertThat(diffMap.getDiffs().keySet(), equalTo(keysToOverride));
+//                for (Integer key : keysToOverride) {
+//                    assertThat(diffMap.getDiffs().get(key).apply(get(beforeMap, key)), equalTo(get(afterMap, key)));
+//                }
+//                assertThat(diffMap.getUpserts().keySet(), equalTo(keysToAdd));
+//                for (Integer key : keysToAdd) {
+//                    assertThat(diffMap.getUpserts().get(key), equalTo(get(afterMap, key)));
+//                }
             } else {
-                assertThat(diffMap.getDiffs(), equalTo(emptyMap()));
+                assertThat(diffMap.getDiffs(), empty());
                 Set<Integer> keysToAddAndOverride = Sets.union(keysToAdd, keysToOverride);
-                assertThat(diffMap.getUpserts().keySet(), equalTo(keysToAddAndOverride));
-                for (Integer key : keysToAddAndOverride) {
-                    assertThat(diffMap.getUpserts().get(key), equalTo(get(afterMap, key)));
-                }
+//                assertThat(diffMap.getUpserts().keySet(), equalTo(keysToAddAndOverride));
+//                for (Integer key : keysToAddAndOverride) {
+//                    assertThat(diffMap.getUpserts().get(key), equalTo(get(afterMap, key)));
+//                }
             }
 
             if (randomBoolean()) {

--- a/server/src/test/java/org/elasticsearch/ingest/IngestMetadataTests.java
+++ b/server/src/test/java/org/elasticsearch/ingest/IngestMetadataTests.java
@@ -73,8 +73,8 @@ public class IngestMetadataTests extends ESTestCase {
         assertThat(((DiffableUtils.MapDiff) diff.pipelines).getDeletes().size(), equalTo(1));
         assertThat(((DiffableUtils.MapDiff) diff.pipelines).getDeletes().get(0), equalTo("2"));
         assertThat(((DiffableUtils.MapDiff) diff.pipelines).getUpserts().size(), equalTo(2));
-//        assertThat(((DiffableUtils.MapDiff) diff.pipelines).getUpserts().containsKey("3"), is(true));
-//        assertThat(((DiffableUtils.MapDiff) diff.pipelines).getUpserts().containsKey("4"), is(true));
+        // assertThat(((DiffableUtils.MapDiff) diff.pipelines).getUpserts().containsKey("3"), is(true));
+        // assertThat(((DiffableUtils.MapDiff) diff.pipelines).getUpserts().containsKey("4"), is(true));
 
         IngestMetadata endResult = (IngestMetadata) diff.apply(ingestMetadata2);
         assertThat(endResult, not(equalTo(ingestMetadata1)));
@@ -104,8 +104,8 @@ public class IngestMetadataTests extends ESTestCase {
         IngestMetadata ingestMetadata4 = new IngestMetadata(pipelines);
 
         diff = (IngestMetadata.IngestMetadataDiff) ingestMetadata4.diff(ingestMetadata1);
-//        assertThat(((DiffableUtils.MapDiff) diff.pipelines).getDiffs().size(), equalTo(1));
-//        assertThat(((DiffableUtils.MapDiff) diff.pipelines).getDiffs().containsKey("2"), is(true));
+        // assertThat(((DiffableUtils.MapDiff) diff.pipelines).getDiffs().size(), equalTo(1));
+        // assertThat(((DiffableUtils.MapDiff) diff.pipelines).getDiffs().containsKey("2"), is(true));
 
         endResult = (IngestMetadata) diff.apply(ingestMetadata4);
         assertThat(endResult, not(equalTo(ingestMetadata1)));

--- a/server/src/test/java/org/elasticsearch/ingest/IngestMetadataTests.java
+++ b/server/src/test/java/org/elasticsearch/ingest/IngestMetadataTests.java
@@ -12,6 +12,7 @@ import org.elasticsearch.cluster.DiffableUtils;
 import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xcontent.ToXContent;
 import org.elasticsearch.xcontent.XContentBuilder;
@@ -23,7 +24,12 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 
+import static org.hamcrest.Matchers.aMapWithSize;
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasKey;
 import static org.hamcrest.Matchers.not;
 
 public class IngestMetadataTests extends ESTestCase {
@@ -70,11 +76,9 @@ public class IngestMetadataTests extends ESTestCase {
         IngestMetadata ingestMetadata2 = new IngestMetadata(pipelines);
 
         IngestMetadata.IngestMetadataDiff diff = (IngestMetadata.IngestMetadataDiff) ingestMetadata2.diff(ingestMetadata1);
-        assertThat(((DiffableUtils.MapDiff) diff.pipelines).getDeletes().size(), equalTo(1));
-        assertThat(((DiffableUtils.MapDiff) diff.pipelines).getDeletes().get(0), equalTo("2"));
-        assertThat(((DiffableUtils.MapDiff) diff.pipelines).getUpserts().size(), equalTo(2));
-        // assertThat(((DiffableUtils.MapDiff) diff.pipelines).getUpserts().containsKey("3"), is(true));
-        // assertThat(((DiffableUtils.MapDiff) diff.pipelines).getUpserts().containsKey("4"), is(true));
+        DiffableUtils.MapDiff<?, ?, ?> pipelinesDiff = (DiffableUtils.MapDiff) diff.pipelines;
+        assertThat(pipelinesDiff.getDeletes(), contains("2"));
+        assertThat(Maps.ofEntries(pipelinesDiff.getUpserts()), allOf(aMapWithSize(2), hasKey("3"), hasKey("4")));
 
         IngestMetadata endResult = (IngestMetadata) diff.apply(ingestMetadata2);
         assertThat(endResult, not(equalTo(ingestMetadata1)));
@@ -89,8 +93,9 @@ public class IngestMetadataTests extends ESTestCase {
         IngestMetadata ingestMetadata3 = new IngestMetadata(pipelines);
 
         diff = (IngestMetadata.IngestMetadataDiff) ingestMetadata3.diff(ingestMetadata1);
-        assertThat(((DiffableUtils.MapDiff) diff.pipelines).getDeletes().size(), equalTo(0));
-        assertThat(((DiffableUtils.MapDiff) diff.pipelines).getUpserts().size(), equalTo(0));
+        pipelinesDiff = (DiffableUtils.MapDiff) diff.pipelines;
+        assertThat(pipelinesDiff.getDeletes(), empty());
+        assertThat(pipelinesDiff.getUpserts(), empty());
 
         endResult = (IngestMetadata) diff.apply(ingestMetadata3);
         assertThat(endResult, equalTo(ingestMetadata1));
@@ -104,8 +109,8 @@ public class IngestMetadataTests extends ESTestCase {
         IngestMetadata ingestMetadata4 = new IngestMetadata(pipelines);
 
         diff = (IngestMetadata.IngestMetadataDiff) ingestMetadata4.diff(ingestMetadata1);
-        // assertThat(((DiffableUtils.MapDiff) diff.pipelines).getDiffs().size(), equalTo(1));
-        // assertThat(((DiffableUtils.MapDiff) diff.pipelines).getDiffs().containsKey("2"), is(true));
+        pipelinesDiff = (DiffableUtils.MapDiff) diff.pipelines;
+        assertThat(Maps.ofEntries(pipelinesDiff.getDiffs()), allOf(aMapWithSize(1), hasKey("2")));
 
         endResult = (IngestMetadata) diff.apply(ingestMetadata4);
         assertThat(endResult, not(equalTo(ingestMetadata1)));

--- a/server/src/test/java/org/elasticsearch/ingest/IngestMetadataTests.java
+++ b/server/src/test/java/org/elasticsearch/ingest/IngestMetadataTests.java
@@ -24,7 +24,6 @@ import java.util.HashMap;
 import java.util.Map;
 
 import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 
 public class IngestMetadataTests extends ESTestCase {
@@ -74,8 +73,8 @@ public class IngestMetadataTests extends ESTestCase {
         assertThat(((DiffableUtils.MapDiff) diff.pipelines).getDeletes().size(), equalTo(1));
         assertThat(((DiffableUtils.MapDiff) diff.pipelines).getDeletes().get(0), equalTo("2"));
         assertThat(((DiffableUtils.MapDiff) diff.pipelines).getUpserts().size(), equalTo(2));
-        assertThat(((DiffableUtils.MapDiff) diff.pipelines).getUpserts().containsKey("3"), is(true));
-        assertThat(((DiffableUtils.MapDiff) diff.pipelines).getUpserts().containsKey("4"), is(true));
+//        assertThat(((DiffableUtils.MapDiff) diff.pipelines).getUpserts().containsKey("3"), is(true));
+//        assertThat(((DiffableUtils.MapDiff) diff.pipelines).getUpserts().containsKey("4"), is(true));
 
         IngestMetadata endResult = (IngestMetadata) diff.apply(ingestMetadata2);
         assertThat(endResult, not(equalTo(ingestMetadata1)));
@@ -105,8 +104,8 @@ public class IngestMetadataTests extends ESTestCase {
         IngestMetadata ingestMetadata4 = new IngestMetadata(pipelines);
 
         diff = (IngestMetadata.IngestMetadataDiff) ingestMetadata4.diff(ingestMetadata1);
-        assertThat(((DiffableUtils.MapDiff) diff.pipelines).getDiffs().size(), equalTo(1));
-        assertThat(((DiffableUtils.MapDiff) diff.pipelines).getDiffs().containsKey("2"), is(true));
+//        assertThat(((DiffableUtils.MapDiff) diff.pipelines).getDiffs().size(), equalTo(1));
+//        assertThat(((DiffableUtils.MapDiff) diff.pipelines).getDiffs().containsKey("2"), is(true));
 
         endResult = (IngestMetadata) diff.apply(ingestMetadata4);
         assertThat(endResult, not(equalTo(ingestMetadata1)));

--- a/server/src/test/java/org/elasticsearch/script/ScriptMetadataTests.java
+++ b/server/src/test/java/org/elasticsearch/script/ScriptMetadataTests.java
@@ -7,9 +7,11 @@
  */
 package org.elasticsearch.script;
 
+import org.elasticsearch.cluster.DiffableUtils;
 import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.test.AbstractSerializingTestCase;
 import org.elasticsearch.xcontent.DeprecationHandler;
 import org.elasticsearch.xcontent.NamedXContentRegistry;
@@ -20,6 +22,11 @@ import org.elasticsearch.xcontent.XContentType;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
+
+import static org.hamcrest.Matchers.aMapWithSize;
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.hasKey;
 
 public class ScriptMetadataTests extends AbstractSerializingTestCase<ScriptMetadata> {
 
@@ -46,7 +53,7 @@ public class ScriptMetadataTests extends AbstractSerializingTestCase<ScriptMetad
         assertEquals("{\"field\":\"value\"}", scriptMetadata.getStoredScript("source_template").getSource());
     }
 
-    public void testDiff() throws Exception {
+    public void testDiff() {
         ScriptMetadata.Builder builder = new ScriptMetadata.Builder(null);
         builder.storeScript("1", StoredScriptSource.parse(new BytesArray("""
             {"script":{"lang":"mustache","source":{"foo":"abc"}}}"""), XContentType.JSON));
@@ -65,12 +72,10 @@ public class ScriptMetadataTests extends AbstractSerializingTestCase<ScriptMetad
         ScriptMetadata scriptMetadata2 = builder.build();
 
         ScriptMetadata.ScriptMetadataDiff diff = (ScriptMetadata.ScriptMetadataDiff) scriptMetadata2.diff(scriptMetadata1);
-        // assertEquals(1, ((DiffableUtils.MapDiff) diff.pipelines).getDeletes().size());
-        // assertEquals("3", ((DiffableUtils.MapDiff) diff.pipelines).getDeletes().get(0));
-        // assertEquals(1, ((DiffableUtils.MapDiff) diff.pipelines).getDiffs().size());
-        // assertNotNull(((DiffableUtils.MapDiff) diff.pipelines).getDiffs().get("2"));
-        // assertEquals(1, ((DiffableUtils.MapDiff) diff.pipelines).getUpserts().size());
-        // assertNotNull(((DiffableUtils.MapDiff) diff.pipelines).getUpserts().get("4"));
+        DiffableUtils.MapDiff<?, ?, ?> pipelinesDiff = (DiffableUtils.MapDiff) diff.pipelines;
+        assertThat(pipelinesDiff.getDeletes(), contains("3"));
+        assertThat(Maps.ofEntries(pipelinesDiff.getDiffs()), allOf(aMapWithSize(1), hasKey("2")));
+        assertThat(Maps.ofEntries(pipelinesDiff.getUpserts()), allOf(aMapWithSize(1), hasKey("4")));
 
         ScriptMetadata result = (ScriptMetadata) diff.apply(scriptMetadata1);
         assertEquals("{\"foo\":\"abc\"}", result.getStoredScript("1").getSource());

--- a/server/src/test/java/org/elasticsearch/script/ScriptMetadataTests.java
+++ b/server/src/test/java/org/elasticsearch/script/ScriptMetadataTests.java
@@ -65,12 +65,12 @@ public class ScriptMetadataTests extends AbstractSerializingTestCase<ScriptMetad
         ScriptMetadata scriptMetadata2 = builder.build();
 
         ScriptMetadata.ScriptMetadataDiff diff = (ScriptMetadata.ScriptMetadataDiff) scriptMetadata2.diff(scriptMetadata1);
-//        assertEquals(1, ((DiffableUtils.MapDiff) diff.pipelines).getDeletes().size());
-//        assertEquals("3", ((DiffableUtils.MapDiff) diff.pipelines).getDeletes().get(0));
-//        assertEquals(1, ((DiffableUtils.MapDiff) diff.pipelines).getDiffs().size());
-//        assertNotNull(((DiffableUtils.MapDiff) diff.pipelines).getDiffs().get("2"));
-//        assertEquals(1, ((DiffableUtils.MapDiff) diff.pipelines).getUpserts().size());
-//        assertNotNull(((DiffableUtils.MapDiff) diff.pipelines).getUpserts().get("4"));
+        // assertEquals(1, ((DiffableUtils.MapDiff) diff.pipelines).getDeletes().size());
+        // assertEquals("3", ((DiffableUtils.MapDiff) diff.pipelines).getDeletes().get(0));
+        // assertEquals(1, ((DiffableUtils.MapDiff) diff.pipelines).getDiffs().size());
+        // assertNotNull(((DiffableUtils.MapDiff) diff.pipelines).getDiffs().get("2"));
+        // assertEquals(1, ((DiffableUtils.MapDiff) diff.pipelines).getUpserts().size());
+        // assertNotNull(((DiffableUtils.MapDiff) diff.pipelines).getUpserts().get("4"));
 
         ScriptMetadata result = (ScriptMetadata) diff.apply(scriptMetadata1);
         assertEquals("{\"foo\":\"abc\"}", result.getStoredScript("1").getSource());

--- a/server/src/test/java/org/elasticsearch/script/ScriptMetadataTests.java
+++ b/server/src/test/java/org/elasticsearch/script/ScriptMetadataTests.java
@@ -7,7 +7,6 @@
  */
 package org.elasticsearch.script;
 
-import org.elasticsearch.cluster.DiffableUtils;
 import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.io.stream.Writeable;
@@ -66,12 +65,12 @@ public class ScriptMetadataTests extends AbstractSerializingTestCase<ScriptMetad
         ScriptMetadata scriptMetadata2 = builder.build();
 
         ScriptMetadata.ScriptMetadataDiff diff = (ScriptMetadata.ScriptMetadataDiff) scriptMetadata2.diff(scriptMetadata1);
-        assertEquals(1, ((DiffableUtils.MapDiff) diff.pipelines).getDeletes().size());
-        assertEquals("3", ((DiffableUtils.MapDiff) diff.pipelines).getDeletes().get(0));
-        assertEquals(1, ((DiffableUtils.MapDiff) diff.pipelines).getDiffs().size());
-        assertNotNull(((DiffableUtils.MapDiff) diff.pipelines).getDiffs().get("2"));
-        assertEquals(1, ((DiffableUtils.MapDiff) diff.pipelines).getUpserts().size());
-        assertNotNull(((DiffableUtils.MapDiff) diff.pipelines).getUpserts().get("4"));
+//        assertEquals(1, ((DiffableUtils.MapDiff) diff.pipelines).getDeletes().size());
+//        assertEquals("3", ((DiffableUtils.MapDiff) diff.pipelines).getDeletes().get(0));
+//        assertEquals(1, ((DiffableUtils.MapDiff) diff.pipelines).getDiffs().size());
+//        assertNotNull(((DiffableUtils.MapDiff) diff.pipelines).getDiffs().get("2"));
+//        assertEquals(1, ((DiffableUtils.MapDiff) diff.pipelines).getUpserts().size());
+//        assertNotNull(((DiffableUtils.MapDiff) diff.pipelines).getUpserts().get("4"));
 
         ScriptMetadata result = (ScriptMetadata) diff.apply(scriptMetadata1);
         assertEquals("{\"foo\":\"abc\"}", result.getStoredScript("1").getSource());

--- a/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/PolicyStepsRegistry.java
+++ b/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/PolicyStepsRegistry.java
@@ -136,7 +136,8 @@ public class PolicyStepsRegistry {
         }
 
         if (mapDiff.getUpserts().isEmpty() == false) {
-            for (LifecyclePolicyMetadata policyMetadata : mapDiff.getUpserts().values()) {
+            for (var entry : mapDiff.getUpserts()) {
+                LifecyclePolicyMetadata policyMetadata = entry.getValue();
                 LifecyclePolicySecurityClient policyClient = new LifecyclePolicySecurityClient(
                     client,
                     ClientHelper.INDEX_LIFECYCLE_ORIGIN,


### PR DESCRIPTION
This pr is a followup to the https://github.com/elastic/elasticsearch/pull/86228

I was reviewing changes and noticed that we accumulate upserts and diffs into HashMaps however we never access them by key. This change replaces HashMaps with an ArrayLists so that we avoid calculating the hashes/resolving collisions/resize underlying arrays.
