### PR TITLE
Explicit set gradle user home for bwc builds

### DIFF
--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/BwcSetupExtension.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/BwcSetupExtension.java
@@ -82,6 +82,8 @@ public class BwcSetupExtension {
             } else {
                 loggedExec.executable(new File(checkoutDir.get(), "gradlew").toString());
             }
+
+            loggedExec.args("-g", project.getGradle().getGradleUserHomeDir());
             if (project.getGradle().getStartParameter().isOffline()) {
                 loggedExec.args("--offline");
             }


### PR DESCRIPTION
This should fix flaky tests of bwc build logic (see #83269)