### PR TITLE
[DOCS] Fix config directory for installation

### DIFF
--- a/docs/reference/setup/install/targz.asciidoc
+++ b/docs/reference/setup/install/targz.asciidoc
@@ -80,7 +80,7 @@ endif::include-xpack[]
 [[targz-running]]
 include::targz-start.asciidoc[]
 
-:es-conf:       $ES_PATH_CONF
+:es-conf:      $ES_HOME/config
 :slash:        /
 
 include::check-running.asciidoc[]

--- a/docs/reference/setup/install/zip-windows.asciidoc
+++ b/docs/reference/setup/install/zip-windows.asciidoc
@@ -81,7 +81,7 @@ TIP: Typically, any cluster-wide settings (like `cluster.name`) should be
 added to the `elasticsearch.yml` config file, while any node-specific settings
 such as `node.name` could be specified on the command line.
 
-:es-config:       %ES_PATH_CONF%
+:es-conf:    %ES_HOME%\config
 :slash:        \
 
 include::check-running.asciidoc[]


### PR DESCRIPTION
Updates the `{es-conf}` variable for `tar.gz` and `zip` installations to include the `config` directory so that it doesn't display for RPM or DEB packages.

Closes #85728
Closes #85824

Preview links:

* [MacOS](https://elasticsearch_86390.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/targz.html#_check_that_elasticsearch_is_running)
* [Windows](https://elasticsearch_86390.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/zip-windows.html#_check_that_elasticsearch_is_running_2)