### PR TITLE
[8.0] [DOCS] Fix config directory for installation (#86390)

### DIFF
--- a/docs/reference/setup/install/targz.asciidoc
+++ b/docs/reference/setup/install/targz.asciidoc
@@ -80,7 +80,7 @@ endif::include-xpack[]
 [[targz-running]]
 include::targz-start.asciidoc[]
 
-:es-conf:       $ES_PATH_CONF
+:es-conf:      $ES_HOME/config
 :slash:        /
 
 include::check-running.asciidoc[]

--- a/docs/reference/setup/install/zip-windows.asciidoc
+++ b/docs/reference/setup/install/zip-windows.asciidoc
@@ -81,7 +81,7 @@ TIP: Typically, any cluster-wide settings (like `cluster.name`) should be
 added to the `elasticsearch.yml` config file, while any node-specific settings
 such as `node.name` could be specified on the command line.
 
-:es-config:       %ES_PATH_CONF%
+:es-conf:    %ES_HOME%\config
 :slash:        \
 
 include::check-running.asciidoc[]


### PR DESCRIPTION
Backports the following commits to 8.0:
 - [DOCS] Fix config directory for installation (#86390)