### PR TITLE
[DOCS] Removes coming tag from release notes

### DIFF
--- a/docs/reference/migration/index.asciidoc
+++ b/docs/reference/migration/index.asciidoc
@@ -34,6 +34,6 @@ For information about how to upgrade your cluster, see <<setup-upgrade>>.
 * <<migrating-8.1,Migrating to 8.1>>
 * <<migrating-8.0,Migrating to 8.0>>
 
-include:migrate_8_2.asciidoc[]
+include::migrate_8_2.asciidoc[]
 include::migrate_8_1.asciidoc[]
 include::migrate_8_0.asciidoc[]

--- a/docs/reference/migration/index.asciidoc
+++ b/docs/reference/migration/index.asciidoc
@@ -30,8 +30,10 @@ For more information about {minor-version},
 see the <<release-highlights>> and <<es-release-notes>>.
 For information about how to upgrade your cluster, see <<setup-upgrade>>.
 
+* <<migrating-8.2,Migrating to 8.2>>
 * <<migrating-8.1,Migrating to 8.1>>
 * <<migrating-8.0,Migrating to 8.0>>
 
+include:migrate_8_2.asciidoc[]
 include::migrate_8_1.asciidoc[]
 include::migrate_8_0.asciidoc[]

--- a/docs/reference/release-notes/8.2.0.asciidoc
+++ b/docs/reference/release-notes/8.2.0.asciidoc
@@ -1,8 +1,6 @@
 [[release-notes-8.2.0]]
 == {es} version 8.2.0
 
-coming[8.2.0]
-
 // Also see <<breaking-changes-8.2,Breaking changes in 8.2>>.
 
 [[bug-8.2.0]]


### PR DESCRIPTION
Removes the "coming" admonition from https://www.elastic.co/guide/en/elasticsearch/reference/8.2/release-notes-8.2.0.html