### PR TITLE
[8.2] Less jank in after-key parsing for unmapped fields (#86359)

### DIFF
--- a/docs/changelog/86359.yaml
+++ b/docs/changelog/86359.yaml
@@ -1,0 +1,6 @@
+pr: 86359
+summary: Less jank in after-key parsing for unmapped fields
+area: Aggregations
+type: bug
+issues:
+ - 85928

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/composite/GlobalOrdinalValuesSource.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/composite/GlobalOrdinalValuesSource.java
@@ -105,7 +105,7 @@ class GlobalOrdinalValuesSource extends SingleDimensionValuesSource<BytesRef> {
         if (missingBucket && value == null) {
             afterValue = null;
             afterValueGlobalOrd = MISSING_VALUE_FLAG;
-        } else if (value.getClass() == String.class || (missingBucket && fieldType == null)) {
+        } else if (value.getClass() == String.class || (fieldType == null)) {
             // the value might be not string if this field is missing in this shard but present in other shards
             // and doesn't have a string type
             afterValue = format.parseBytesRef(value);


### PR DESCRIPTION
Backports the following commits to 8.2:
 - Less jank in after-key parsing for unmapped fields (#86359)