### PR TITLE
Use HashMap for IndexMetadata.inSyncAllocationIds

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/metadata/IndexMetadata.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/IndexMetadata.java
@@ -1595,7 +1595,7 @@ public class IndexMetadata implements Diffable<IndexMetadata>, ToXContentFragmen
             }
 
             // fill missing slots in inSyncAllocationIds with empty set if needed and make all entries immutable
-            @SuppressWarnings({"unchecked", "rawtype"})
+            @SuppressWarnings({ "unchecked", "rawtypes" })
             Map.Entry<Integer, Set<String>> denseInSyncAllocationIds[] = new Map.Entry[numberOfShards];
             inSyncAllocationIds.entrySet().forEach(e -> denseInSyncAllocationIds[e.getKey()] = e);
             for (int i = 0; i < numberOfShards; i++) {

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/IndexMetadata.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/IndexMetadata.java
@@ -1466,7 +1466,7 @@ public class IndexMetadata implements Diffable<IndexMetadata>, ToXContentFragmen
         }
 
         public Builder putInSyncAllocationIds(int shardId, Set<String> allocationIds) {
-            inSyncAllocationIds.put(shardId, new HashSet<>(allocationIds));
+            inSyncAllocationIds.put(shardId, Set.copyOf(allocationIds));
             return this;
         }
 
@@ -1597,11 +1597,9 @@ public class IndexMetadata implements Diffable<IndexMetadata>, ToXContentFragmen
             // fill missing slots in inSyncAllocationIds with empty set if needed and make all entries immutable
             @SuppressWarnings({ "unchecked", "rawtypes" })
             Map.Entry<Integer, Set<String>> denseInSyncAllocationIds[] = new Map.Entry[numberOfShards];
-            inSyncAllocationIds.entrySet().forEach(e -> denseInSyncAllocationIds[e.getKey()] = e);
             for (int i = 0; i < numberOfShards; i++) {
-                if (denseInSyncAllocationIds[i] == null) {
-                    denseInSyncAllocationIds[i] = Map.entry(i, Set.of());
-                }
+                Set<String> allocIds = inSyncAllocationIds.getOrDefault(i, Set.of());
+                denseInSyncAllocationIds[i] = Map.entry(i, allocIds);
             }
             var requireMap = INDEX_ROUTING_REQUIRE_GROUP_SETTING.getAsMap(settings);
             final DiscoveryNodeFilters requireFilters;


### PR DESCRIPTION
The in sync allocation ids is a mapping from shard to the set of ids
currently being processed. When being built, the metadata uses a sparse
map, only filling a value for a shard as they are put into the builder.
When the final metadata is built, the map is made dense.

This commit converts to using a HashMap instead of ImmutableOpenIntMap.
The boxed keys should not cause allocations, as long as number of shards
is lower than 128. Long term the map itself should become an array, as
we know the number of shards (much like the dense primaryTerms array
here). However, that change will be a little trickier to make, since we
will need to be backward compatible with how diffs are built, currently
using Map differences.

relates #86239