### PR TITLE
Use Windows newlines when listing plugin information on Windows

### DIFF
--- a/distribution/tools/plugin-cli/src/test/java/org/elasticsearch/plugins/cli/ListPluginsCommandTests.java
+++ b/distribution/tools/plugin-cli/src/test/java/org/elasticsearch/plugins/cli/ListPluginsCommandTests.java
@@ -102,7 +102,6 @@ public class ListPluginsCommandTests extends CommandTestCase {
         assertEquals(buildMultiline("fake1", "fake2"), terminal.getOutput());
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/86352")
     public void testPluginWithVerbose() throws Exception {
         buildFakePlugin(env, "fake desc", "fake_plugin", "org.fake");
         execute("-v");
@@ -126,7 +125,6 @@ public class ListPluginsCommandTests extends CommandTestCase {
         );
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/86352")
     public void testPluginWithNativeController() throws Exception {
         buildFakePlugin(env, "fake desc 1", "fake_plugin1", "org.fake", true);
         execute("-v");
@@ -150,7 +148,6 @@ public class ListPluginsCommandTests extends CommandTestCase {
         );
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/86352")
     public void testPluginWithVerboseMultiplePlugins() throws Exception {
         buildFakePlugin(env, "fake desc 1", "fake_plugin1", "org.fake");
         buildFakePlugin(env, "fake desc 2", "fake_plugin2", "org.fake2");
@@ -209,7 +206,6 @@ public class ListPluginsCommandTests extends CommandTestCase {
         assertEquals("property [name] is missing in [" + descriptorPath.toString() + "]", e.getMessage());
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/86352")
     public void testExistingIncompatiblePlugin() throws Exception {
         PluginTestUtil.writePluginProperties(
             env.pluginsFile().resolve("fake_plugin1"),

--- a/docs/changelog/86408.yaml
+++ b/docs/changelog/86408.yaml
@@ -1,0 +1,6 @@
+pr: 86408
+summary: Use Windows newlines when listing plugin information on Windows
+area: Infra/Plugins
+type: bug
+issues:
+ - 86352

--- a/server/src/main/java/org/elasticsearch/plugins/PluginInfo.java
+++ b/server/src/main/java/org/elasticsearch/plugins/PluginInfo.java
@@ -445,52 +445,34 @@ public class PluginInfo implements Writeable, ToXContentObject {
     }
 
     public String toString(String prefix) {
-        final StringBuilder information = new StringBuilder().append(prefix)
-            .append("- Plugin information:\n")
-            .append(prefix)
-            .append("Name: ")
-            .append(name)
-            .append("\n")
-            .append(prefix)
-            .append("Description: ")
-            .append(description)
-            .append("\n")
-            .append(prefix)
-            .append("Version: ")
-            .append(version)
-            .append("\n")
-            .append(prefix)
-            .append("Elasticsearch Version: ")
-            .append(elasticsearchVersion)
-            .append("\n")
-            .append(prefix)
-            .append("Java Version: ")
-            .append(javaVersion)
-            .append("\n")
-            .append(prefix)
-            .append("Native Controller: ")
-            .append(hasNativeController)
-            .append("\n")
-            .append(prefix)
-            .append("Licensed: ")
-            .append(isLicensed)
-            .append("\n")
-            .append(prefix)
-            .append("Type: ")
-            .append(type)
-            .append("\n");
+        final StringBuilder information = new StringBuilder();
+
+        addln(information, prefix, "- Plugin information:", "");
+        addln(information, prefix, "Name: ", name);
+        addln(information, prefix, "Description: ", description);
+        addln(information, prefix, "Version: ", version);
+        addln(information, prefix, "Elasticsearch Version: ", elasticsearchVersion);
+        addln(information, prefix, "Java Version: ", javaVersion);
+        addln(information, prefix, "Native Controller: ", hasNativeController);
+        addln(information, prefix, "Licensed: ", isLicensed);
+        addln(information, prefix, "Type: ", type);
 
         if (type == PluginType.BOOTSTRAP) {
-            information.append(prefix).append("Java Opts: ").append(javaOpts).append("\n");
+            addln(information, prefix, "Java Opts: ", javaOpts);
         }
 
-        information.append(prefix)
-            .append("Extended Plugins: ")
-            .append(extendedPlugins)
-            .append("\n")
-            .append(prefix)
-            .append(" * Classname: ")
-            .append(classname);
+        addln(information, prefix, "Extended Plugins: ", extendedPlugins);
+        add(information, prefix, " * Classname: ", classname);
+
         return information.toString();
+    }
+
+    private static void add(StringBuilder builder, String prefix, String field, Object value) {
+        builder.append(prefix).append(field).append(value);
+    }
+
+    private static void addln(StringBuilder builder, String prefix, String field, Object value) {
+        add(builder, prefix, field, value);
+        builder.append(System.lineSeparator());
     }
 }

--- a/server/src/main/java/org/elasticsearch/plugins/PluginInfo.java
+++ b/server/src/main/java/org/elasticsearch/plugins/PluginInfo.java
@@ -22,6 +22,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -445,34 +446,29 @@ public class PluginInfo implements Writeable, ToXContentObject {
     }
 
     public String toString(String prefix) {
-        final StringBuilder information = new StringBuilder();
+        final List<String> lines = new ArrayList<>();
 
-        addln(information, prefix, "- Plugin information:", "");
-        addln(information, prefix, "Name: ", name);
-        addln(information, prefix, "Description: ", description);
-        addln(information, prefix, "Version: ", version);
-        addln(information, prefix, "Elasticsearch Version: ", elasticsearchVersion);
-        addln(information, prefix, "Java Version: ", javaVersion);
-        addln(information, prefix, "Native Controller: ", hasNativeController);
-        addln(information, prefix, "Licensed: ", isLicensed);
-        addln(information, prefix, "Type: ", type);
+        appendLine(lines, prefix, "- Plugin information:", "");
+        appendLine(lines, prefix, "Name: ", name);
+        appendLine(lines, prefix, "Description: ", description);
+        appendLine(lines, prefix, "Version: ", version);
+        appendLine(lines, prefix, "Elasticsearch Version: ", elasticsearchVersion);
+        appendLine(lines, prefix, "Java Version: ", javaVersion);
+        appendLine(lines, prefix, "Native Controller: ", hasNativeController);
+        appendLine(lines, prefix, "Licensed: ", isLicensed);
+        appendLine(lines, prefix, "Type: ", type);
 
         if (type == PluginType.BOOTSTRAP) {
-            addln(information, prefix, "Java Opts: ", javaOpts);
+            appendLine(lines, prefix, "Java Opts: ", javaOpts);
         }
 
-        addln(information, prefix, "Extended Plugins: ", extendedPlugins);
-        add(information, prefix, " * Classname: ", classname);
+        appendLine(lines, prefix, "Extended Plugins: ", extendedPlugins.toString());
+        appendLine(lines, prefix, " * Classname: ", classname);
 
-        return information.toString();
+        return String.join(System.lineSeparator(), lines);
     }
 
-    private static void add(StringBuilder builder, String prefix, String field, Object value) {
-        builder.append(prefix).append(field).append(value);
-    }
-
-    private static void addln(StringBuilder builder, String prefix, String field, Object value) {
-        add(builder, prefix, field, value);
-        builder.append(System.lineSeparator());
+    private static void appendLine(List<String> builder, String prefix, String field, Object value) {
+        builder.add(prefix + field + value);
     }
 }


### PR DESCRIPTION
We hard-coded *nix line endings in the PluginInfo toString method, which means that the output would look garbled on Windows. We caught this when fixing up some Windows unit tests.

This PR makes things work for Windows. I also refactored for what I think is readability.

Fixes #86352 
Related #86312