### PR TITLE
[ML] Adding a node availability zone calculator

### DIFF
--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/autoscaling/NodeAvailabilityZoneMapper.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/autoscaling/NodeAvailabilityZoneMapper.java
@@ -1,0 +1,162 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.ml.autoscaling;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.elasticsearch.cluster.ClusterChangedEvent;
+import org.elasticsearch.cluster.ClusterStateListener;
+import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.cluster.node.DiscoveryNodeRole;
+import org.elasticsearch.cluster.node.DiscoveryNodes;
+import org.elasticsearch.cluster.routing.allocation.decider.AwarenessAllocationDecider;
+import org.elasticsearch.common.settings.ClusterSettings;
+import org.elasticsearch.common.settings.Settings;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.OptionalInt;
+
+/**
+ * Maintains a list of the nodes in each availability zone, where an availability zone
+ * means a unique combination of values of the attributes listed in the cluster setting
+ * cluster.routing.allocation.awareness.attributes.
+ */
+public class NodeAvailabilityZoneMapper implements ClusterStateListener {
+
+    private static final Logger logger = LogManager.getLogger(NodeAvailabilityZoneMapper.class);
+
+    private volatile List<String> awarenessAttributes;
+    private volatile DiscoveryNodes lastDiscoveryNodes;
+    private volatile Map<List<String>, Collection<DiscoveryNode>> allNodesByAvailabilityZone;
+    private volatile Map<List<String>, Collection<DiscoveryNode>> mlNodesByAvailabilityZone;
+
+    public NodeAvailabilityZoneMapper(Settings settings, ClusterSettings clusterSettings) {
+        this(settings, clusterSettings, null);
+    }
+
+    public NodeAvailabilityZoneMapper(Settings settings, ClusterSettings clusterSettings, DiscoveryNodes discoveryNodes) {
+        awarenessAttributes = AwarenessAllocationDecider.CLUSTER_ROUTING_ALLOCATION_AWARENESS_ATTRIBUTE_SETTING.get(settings);
+        lastDiscoveryNodes = discoveryNodes;
+        buildNodesByAvailabilityZone();
+        clusterSettings.addSettingsUpdateConsumer(
+            AwarenessAllocationDecider.CLUSTER_ROUTING_ALLOCATION_AWARENESS_ATTRIBUTE_SETTING,
+            this::setAwarenessAttributes
+        );
+    }
+
+    private synchronized void setAwarenessAttributes(List<String> awarenessAttributes) {
+        this.awarenessAttributes = List.copyOf(awarenessAttributes);
+        buildNodesByAvailabilityZone();
+    }
+
+    public List<String> getAwarenessAttributes() {
+        return awarenessAttributes;
+    }
+
+    /**
+     * @return A map whose keys are lists of awareness attribute values in the same order as the configured awareness attribute
+     *         names, and whose values are collections of nodes that have that combination of attributes. If availability zones
+     *         are not configured then the map will contain one entry mapping an empty list to a collection of all nodes. If
+     *         it is too early in the lifecycle of the node to know the answer then an empty map will be returned.
+     */
+    public Map<List<String>, Collection<DiscoveryNode>> getAllNodesByAvailabilityZone() {
+        return allNodesByAvailabilityZone;
+    }
+
+    /**
+     * @return The number of availability zones in the cluster. If availability zones are not configured this will be 1.
+     *         If it is too early in the lifecycle of the node to know the answer then {@link OptionalInt#empty()} will be returned.
+     */
+    public OptionalInt getNumAvailabilityZones() {
+        return (lastDiscoveryNodes == null) ? OptionalInt.empty() : OptionalInt.of(allNodesByAvailabilityZone.size());
+    }
+
+    /**
+     * @return A map whose keys are lists of awareness attribute values in the same order as the configured awareness attribute
+     *         names, and whose values are collections of nodes that have that combination of attributes. If availability zones
+     *         are not configured then the map will contain one entry mapping an empty list to a collection of all nodes. If
+     *         it is too early in the lifecycle of the node to know the answer then an empty map will be returned. An empty
+     *         map will also be returned if there are no ML nodes in the cluster. (These two empty map return scenarios can be
+     *         distinguished by calling one of the other methods.)
+     */
+    public Map<List<String>, Collection<DiscoveryNode>> getMlNodesByAvailabilityZone() {
+        return mlNodesByAvailabilityZone;
+    }
+
+    /**
+     * @return The number of availability zones in the cluster. If availability zones are not configured this will be 1.
+     *         If it is too early in the lifecycle of the node to know the answer then {@link OptionalInt#empty()} will be returned.
+     *         Unlike {@link #getNumAvailabilityZones()}, it is possible this method will return 0, as it is possible
+     *         for a cluster to have no ML nodes.
+     */
+    public OptionalInt getNumMlAvailabilityZones() {
+        return (lastDiscoveryNodes == null) ? OptionalInt.empty() : OptionalInt.of(mlNodesByAvailabilityZone.size());
+    }
+
+    @Override
+    public synchronized void clusterChanged(ClusterChangedEvent event) {
+        if (lastDiscoveryNodes == null || event.nodesChanged()) {
+            lastDiscoveryNodes = event.state().nodes();
+            buildNodesByAvailabilityZone();
+        }
+    }
+
+    private synchronized void buildNodesByAvailabilityZone() {
+        if (lastDiscoveryNodes == null) {
+            allNodesByAvailabilityZone = Map.of();
+            mlNodesByAvailabilityZone = allNodesByAvailabilityZone;
+            return;
+        }
+
+        Collection<DiscoveryNode> nodes = lastDiscoveryNodes.getNodes().values();
+
+        if (awarenessAttributes.isEmpty()) {
+            allNodesByAvailabilityZone = Map.of(List.of(), nodes);
+            mlNodesByAvailabilityZone = Map.of(
+                List.of(),
+                nodes.stream().filter(n -> n.getRoles().contains(DiscoveryNodeRole.ML_ROLE)).toList()
+            );
+            return;
+        }
+
+        Map<List<String>, Collection<DiscoveryNode>> updatedNodesByAvailabilityZone = new HashMap<>();
+        Map<List<String>, Collection<DiscoveryNode>> updatedMlNodesByAvailabilityZone = new HashMap<>();
+        for (DiscoveryNode node : nodes) {
+            List<String> orderedNodeAttributeValues = awarenessAttributes.stream()
+                .map(a -> node.getAttributes().get(a))
+                .filter(Objects::nonNull)
+                .toList();
+            if (orderedNodeAttributeValues.size() != awarenessAttributes.size()) {
+                // This indicates bad configuration - there shouldn't be nodes that don't have all the awareness attributes
+                logger.trace(
+                    "Node [{}] does not have all configured awareness attributes {} - will be ignored in availability zone mapper",
+                    node,
+                    awarenessAttributes
+                );
+                continue;
+            }
+            updatedNodesByAvailabilityZone.computeIfAbsent(orderedNodeAttributeValues, k -> new ArrayList<>()).add(node);
+            if (node.getRoles().contains(DiscoveryNodeRole.ML_ROLE)) {
+                updatedMlNodesByAvailabilityZone.compute(orderedNodeAttributeValues, (k, v) -> {
+                    if (v == null) {
+                        v = new ArrayList<>();
+                    }
+                    v.add(node);
+                    return v;
+                });
+            }
+        }
+        allNodesByAvailabilityZone = Map.copyOf(updatedNodesByAvailabilityZone);
+        mlNodesByAvailabilityZone = Map.copyOf(updatedMlNodesByAvailabilityZone);
+    }
+}

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/autoscaling/NodeAvailabilityZoneMapperTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/autoscaling/NodeAvailabilityZoneMapperTests.java
@@ -1,0 +1,290 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.ml.autoscaling;
+
+import org.elasticsearch.Version;
+import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.cluster.node.DiscoveryNodeRole;
+import org.elasticsearch.cluster.node.DiscoveryNodes;
+import org.elasticsearch.cluster.routing.allocation.decider.AwarenessAllocationDecider;
+import org.elasticsearch.common.settings.ClusterSettings;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.transport.TransportAddress;
+import org.elasticsearch.test.ESTestCase;
+
+import java.net.InetAddress;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.OptionalInt;
+import java.util.Set;
+
+import static org.elasticsearch.cluster.node.DiscoveryNodeRole.DATA_ROLE;
+import static org.elasticsearch.cluster.node.DiscoveryNodeRole.MASTER_ROLE;
+import static org.elasticsearch.cluster.node.DiscoveryNodeRole.ML_ROLE;
+import static org.hamcrest.Matchers.aMapWithSize;
+import static org.hamcrest.Matchers.anEmptyMap;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+
+public class NodeAvailabilityZoneMapperTests extends ESTestCase {
+
+    public void testBeforeClusterReady() {
+        Settings settings = Settings.builder()
+            .putList(
+                AwarenessAllocationDecider.CLUSTER_ROUTING_ALLOCATION_AWARENESS_ATTRIBUTE_SETTING.getKey(),
+                List.of("region", "logical_availability_zone")
+            )
+            .build();
+        ClusterSettings clusterSettings = new ClusterSettings(
+            settings,
+            Set.of(AwarenessAllocationDecider.CLUSTER_ROUTING_ALLOCATION_AWARENESS_ATTRIBUTE_SETTING)
+        );
+
+        NodeAvailabilityZoneMapper nodeAvailabilityZoneMapper = new NodeAvailabilityZoneMapper(settings, clusterSettings);
+
+        assertThat(nodeAvailabilityZoneMapper.getAwarenessAttributes(), equalTo(List.of("region", "logical_availability_zone")));
+        assertThat(nodeAvailabilityZoneMapper.getAllNodesByAvailabilityZone(), anEmptyMap());
+        assertThat(nodeAvailabilityZoneMapper.getNumAvailabilityZones(), is(OptionalInt.empty()));
+    }
+
+    public void testAvailabilityZonesNotConfiguredMultiRoleNodes() {
+        Settings settings = Settings.EMPTY;
+        ClusterSettings clusterSettings = new ClusterSettings(
+            settings,
+            Set.of(AwarenessAllocationDecider.CLUSTER_ROUTING_ALLOCATION_AWARENESS_ATTRIBUTE_SETTING)
+        );
+
+        DiscoveryNodes discoveryNodes = DiscoveryNodes.builder()
+            .add(
+                new DiscoveryNode(
+                    "node-1",
+                    new TransportAddress(InetAddress.getLoopbackAddress(), 9300),
+                    Map.of(),
+                    Set.of(MASTER_ROLE, DATA_ROLE, ML_ROLE),
+                    Version.CURRENT
+                )
+            )
+            .add(
+                new DiscoveryNode(
+                    "node-2",
+                    new TransportAddress(InetAddress.getLoopbackAddress(), 9301),
+                    Map.of(),
+                    Set.of(MASTER_ROLE, DATA_ROLE, ML_ROLE),
+                    Version.CURRENT
+                )
+            )
+            .build();
+        NodeAvailabilityZoneMapper nodeAvailabilityZoneMapper = new NodeAvailabilityZoneMapper(settings, clusterSettings, discoveryNodes);
+
+        assertThat(nodeAvailabilityZoneMapper.getAwarenessAttributes(), empty());
+        assertThat(nodeAvailabilityZoneMapper.getAllNodesByAvailabilityZone(), aMapWithSize(1));
+        assertThat(nodeAvailabilityZoneMapper.getAllNodesByAvailabilityZone().keySet().iterator().next(), empty());
+        assertThat(
+            nodeAvailabilityZoneMapper.getAllNodesByAvailabilityZone().get(List.of()),
+            containsInAnyOrder(discoveryNodes.getNodes().values().toArray())
+        );
+        assertThat(nodeAvailabilityZoneMapper.getNumAvailabilityZones().getAsInt(), is(1));
+        assertThat(nodeAvailabilityZoneMapper.getMlNodesByAvailabilityZone(), aMapWithSize(1));
+        assertThat(nodeAvailabilityZoneMapper.getMlNodesByAvailabilityZone().keySet().iterator().next(), empty());
+        assertThat(
+            nodeAvailabilityZoneMapper.getMlNodesByAvailabilityZone().get(List.of()),
+            containsInAnyOrder(discoveryNodes.getNodes().values().toArray())
+        );
+        assertThat(nodeAvailabilityZoneMapper.getNumMlAvailabilityZones().getAsInt(), is(1));
+    }
+
+    public void testAvailabilityZonesNotConfiguredDedicatedNodes() {
+        Settings settings = Settings.EMPTY;
+        ClusterSettings clusterSettings = new ClusterSettings(
+            settings,
+            Set.of(AwarenessAllocationDecider.CLUSTER_ROUTING_ALLOCATION_AWARENESS_ATTRIBUTE_SETTING)
+        );
+
+        DiscoveryNode mlNode = new DiscoveryNode(
+            "node-1",
+            new TransportAddress(InetAddress.getLoopbackAddress(), 9300),
+            Map.of(),
+            Set.of(ML_ROLE),
+            Version.CURRENT
+        );
+        DiscoveryNodes discoveryNodes = DiscoveryNodes.builder()
+            .add(mlNode)
+            .add(
+                new DiscoveryNode(
+                    "node-2",
+                    new TransportAddress(InetAddress.getLoopbackAddress(), 9301),
+                    Map.of(),
+                    Set.of(MASTER_ROLE),
+                    Version.CURRENT
+                )
+            )
+            .add(
+                new DiscoveryNode(
+                    "node-3",
+                    new TransportAddress(InetAddress.getLoopbackAddress(), 9202),
+                    Map.of(),
+                    Set.of(DATA_ROLE),
+                    Version.CURRENT
+                )
+            )
+            .build();
+        NodeAvailabilityZoneMapper nodeAvailabilityZoneMapper = new NodeAvailabilityZoneMapper(settings, clusterSettings, discoveryNodes);
+
+        assertThat(nodeAvailabilityZoneMapper.getAwarenessAttributes(), empty());
+        assertThat(nodeAvailabilityZoneMapper.getAllNodesByAvailabilityZone(), aMapWithSize(1));
+        assertThat(nodeAvailabilityZoneMapper.getAllNodesByAvailabilityZone().keySet().iterator().next(), empty());
+        assertThat(
+            nodeAvailabilityZoneMapper.getAllNodesByAvailabilityZone().get(List.of()),
+            containsInAnyOrder(discoveryNodes.getNodes().values().toArray())
+        );
+        assertThat(nodeAvailabilityZoneMapper.getNumAvailabilityZones().getAsInt(), is(1));
+        assertThat(nodeAvailabilityZoneMapper.getMlNodesByAvailabilityZone(), aMapWithSize(1));
+        assertThat(nodeAvailabilityZoneMapper.getMlNodesByAvailabilityZone().keySet().iterator().next(), empty());
+        assertThat(nodeAvailabilityZoneMapper.getMlNodesByAvailabilityZone().get(List.of()), contains(mlNode));
+        assertThat(nodeAvailabilityZoneMapper.getNumMlAvailabilityZones().getAsInt(), is(1));
+    }
+
+    public void testAvailabilityZonesConfiguredMultiRoleNodes() {
+        Settings settings = Settings.builder()
+            .putList(
+                AwarenessAllocationDecider.CLUSTER_ROUTING_ALLOCATION_AWARENESS_ATTRIBUTE_SETTING.getKey(),
+                List.of("region", "logical_availability_zone")
+            )
+            .build();
+        ClusterSettings clusterSettings = new ClusterSettings(
+            settings,
+            Set.of(AwarenessAllocationDecider.CLUSTER_ROUTING_ALLOCATION_AWARENESS_ATTRIBUTE_SETTING)
+        );
+
+        DiscoveryNodes.Builder discoveryNodesBuilder = DiscoveryNodes.builder();
+        int numNodes = randomIntBetween(2, 50);
+        int numZones = randomIntBetween(1, Math.min(numNodes, 3));
+        for (int nodeNum = 1; nodeNum <= numNodes; ++nodeNum) {
+            discoveryNodesBuilder.add(
+                new DiscoveryNode(
+                    "node-" + nodeNum,
+                    new TransportAddress(InetAddress.getLoopbackAddress(), 9299 + nodeNum),
+                    Map.of("region", "unknown-region", "logical_availability_zone", "zone-" + (nodeNum % numZones)),
+                    Set.of(MASTER_ROLE, DATA_ROLE, ML_ROLE),
+                    Version.CURRENT
+                )
+            );
+        }
+
+        DiscoveryNodes discoveryNodes = discoveryNodesBuilder.build();
+        NodeAvailabilityZoneMapper nodeAvailabilityZoneMapper = new NodeAvailabilityZoneMapper(settings, clusterSettings, discoveryNodes);
+
+        assertThat(nodeAvailabilityZoneMapper.getAwarenessAttributes(), equalTo(List.of("region", "logical_availability_zone")));
+        assertThat(nodeAvailabilityZoneMapper.getAllNodesByAvailabilityZone(), aMapWithSize(numZones));
+        int totalNodesMapped = 0;
+        for (Map.Entry<List<String>, Collection<DiscoveryNode>> entry : nodeAvailabilityZoneMapper.getAllNodesByAvailabilityZone()
+            .entrySet()) {
+            List<String> key = entry.getKey();
+            assertThat(key, hasSize(2));
+            assertThat(key.get(0), equalTo("unknown-region"));
+            String zoneAttributeValue = key.get(1);
+            for (DiscoveryNode node : entry.getValue()) {
+                assertThat(node.getAttributes().get("logical_availability_zone"), equalTo(zoneAttributeValue));
+                ++totalNodesMapped;
+            }
+        }
+        assertThat(totalNodesMapped, is(numNodes));
+        assertThat(nodeAvailabilityZoneMapper.getNumAvailabilityZones().getAsInt(), is(numZones));
+        totalNodesMapped = 0;
+        for (Map.Entry<List<String>, Collection<DiscoveryNode>> entry : nodeAvailabilityZoneMapper.getMlNodesByAvailabilityZone()
+            .entrySet()) {
+            List<String> key = entry.getKey();
+            assertThat(key, hasSize(2));
+            assertThat(key.get(0), equalTo("unknown-region"));
+            String zoneAttributeValue = key.get(1);
+            for (DiscoveryNode node : entry.getValue()) {
+                assertThat(node.getAttributes().get("logical_availability_zone"), equalTo(zoneAttributeValue));
+                ++totalNodesMapped;
+            }
+        }
+        assertThat(totalNodesMapped, is(numNodes));
+        assertThat(nodeAvailabilityZoneMapper.getNumMlAvailabilityZones().getAsInt(), is(numZones));
+    }
+
+    public void testAvailabilityZonesConfiguredDedicatedNodes() {
+        Settings settings = Settings.builder()
+            .putList(
+                AwarenessAllocationDecider.CLUSTER_ROUTING_ALLOCATION_AWARENESS_ATTRIBUTE_SETTING.getKey(),
+                List.of("region", "logical_availability_zone")
+            )
+            .build();
+        ClusterSettings clusterSettings = new ClusterSettings(
+            settings,
+            Set.of(AwarenessAllocationDecider.CLUSTER_ROUTING_ALLOCATION_AWARENESS_ATTRIBUTE_SETTING)
+        );
+
+        List<DiscoveryNode> mlNodes = new ArrayList<>();
+        Set<Integer> mlZones = new HashSet<>();
+        DiscoveryNodes.Builder discoveryNodesBuilder = DiscoveryNodes.builder();
+        int numNodes = randomIntBetween(10, 50);
+        int numZones = randomIntBetween(2, 3);
+        int numMlZones = randomIntBetween(1, numZones);
+        for (int nodeNum = 1; nodeNum <= numNodes; ++nodeNum) {
+            int zone = nodeNum % numZones;
+            DiscoveryNodeRole role = (zone < numMlZones) ? randomFrom(MASTER_ROLE, DATA_ROLE, ML_ROLE) : randomFrom(MASTER_ROLE, DATA_ROLE);
+            DiscoveryNode node = new DiscoveryNode(
+                "node-" + nodeNum,
+                new TransportAddress(InetAddress.getLoopbackAddress(), 9199 + nodeNum),
+                Map.of("region", "unknown-region", "logical_availability_zone", "zone-" + zone),
+                Set.of(role),
+                Version.CURRENT
+            );
+            if (role == ML_ROLE) {
+                mlNodes.add(node);
+                mlZones.add(zone);
+            }
+            discoveryNodesBuilder.add(node);
+        }
+
+        DiscoveryNodes discoveryNodes = discoveryNodesBuilder.build();
+        NodeAvailabilityZoneMapper nodeAvailabilityZoneMapper = new NodeAvailabilityZoneMapper(settings, clusterSettings, discoveryNodes);
+
+        assertThat(nodeAvailabilityZoneMapper.getAwarenessAttributes(), equalTo(List.of("region", "logical_availability_zone")));
+        assertThat(nodeAvailabilityZoneMapper.getAllNodesByAvailabilityZone(), aMapWithSize(numZones));
+        int totalNodesMapped = 0;
+        for (Map.Entry<List<String>, Collection<DiscoveryNode>> entry : nodeAvailabilityZoneMapper.getAllNodesByAvailabilityZone()
+            .entrySet()) {
+            List<String> key = entry.getKey();
+            assertThat(key, hasSize(2));
+            assertThat(key.get(0), equalTo("unknown-region"));
+            String zoneAttributeValue = key.get(1);
+            for (DiscoveryNode node : entry.getValue()) {
+                assertThat(node.getAttributes().get("logical_availability_zone"), equalTo(zoneAttributeValue));
+                ++totalNodesMapped;
+            }
+        }
+        assertThat(totalNodesMapped, is(numNodes));
+        assertThat(nodeAvailabilityZoneMapper.getNumAvailabilityZones().getAsInt(), is(numZones));
+        int totalMlNodesMapped = 0;
+        for (Map.Entry<List<String>, Collection<DiscoveryNode>> entry : nodeAvailabilityZoneMapper.getMlNodesByAvailabilityZone()
+            .entrySet()) {
+            List<String> key = entry.getKey();
+            assertThat(key, hasSize(2));
+            assertThat(key.get(0), equalTo("unknown-region"));
+            String zoneAttributeValue = key.get(1);
+            for (DiscoveryNode node : entry.getValue()) {
+                assertThat(node.getAttributes().get("logical_availability_zone"), equalTo(zoneAttributeValue));
+                ++totalMlNodesMapped;
+            }
+        }
+        assertThat(totalMlNodesMapped, is(mlNodes.size()));
+        assertThat(nodeAvailabilityZoneMapper.getNumMlAvailabilityZones().getAsInt(), is(mlZones.size()));
+    }
+}


### PR DESCRIPTION
This is a utility class to help with node assignment and autoscaling
decisions in environments that have a concept of availability zones,
i.e. zones within the cluster where it's more likely to simultaneously
lose all nodes together due to hardware failure.

It maintains a list of the nodes in each availability zone, where an
availability zone means a unique combination of values of the attributes
listed in the cluster setting cluster.routing.allocation.awareness.attributes.

It's also possible to quickly find out how many availability zones there
are in total, and how many of them have ML nodes.