### PR TITLE
[ML] Adjust memory overhead for PyTorch models

### DIFF
--- a/docs/changelog/86416.yaml
+++ b/docs/changelog/86416.yaml
@@ -1,0 +1,5 @@
+pr: 86416
+summary: Adjust memory overhead for `PyTorch` models
+area: Machine Learning
+type: bug
+issues: []

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/StartTrainedModelDeploymentAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/StartTrainedModelDeploymentAction.java
@@ -47,10 +47,14 @@ public class StartTrainedModelDeploymentAction extends ActionType<CreateTrainedM
 
     /**
      * This has been found to be approximately 300MB on linux by manual testing.
-     * We also subtract 30MB that we always add as overhead (see MachineLearning.NATIVE_EXECUTABLE_CODE_OVERHEAD).
+     * 30MB of this is accounted for via the space set aside to load the code into memory
+     * that we always add as overhead (see MachineLearning.NATIVE_EXECUTABLE_CODE_OVERHEAD).
+     * That would result in 270MB here, although the problem with this is that it would
+     * mean few models would fit on a 2GB ML node in Cloud with logging and metrics enabled.
+     * Therefore we push the boundary a bit and require a 240MB per-model overhead.
      * TODO Check if it is substantially different in other platforms.
      */
-    private static final ByteSizeValue MEMORY_OVERHEAD = ByteSizeValue.ofMb(270);
+    private static final ByteSizeValue MEMORY_OVERHEAD = ByteSizeValue.ofMb(240);
 
     public StartTrainedModelDeploymentAction() {
         super(NAME, CreateTrainedModelAssignmentAction.Response::new);

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/assignment/TrainedModelAssignmentClusterService.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/assignment/TrainedModelAssignmentClusterService.java
@@ -537,7 +537,12 @@ public class TrainedModelAssignmentClusterService implements ClusterStateListene
                 )
             );
         }
-        if (load.getFreeMemory() < params.estimateMemoryUsageBytes()) {
+        // If any ML processes are running on a node we require some space to load the shared libraries.
+        // So if none are currently running then this per-node overhead must be added to the requirement.
+        long requiredMemory = params.estimateMemoryUsageBytes() + ((load.getNumAssignedJobs() == 0)
+            ? MachineLearning.NATIVE_EXECUTABLE_CODE_OVERHEAD.getBytes()
+            : 0);
+        if (load.getFreeMemory() < requiredMemory) {
             return Optional.of(
                 ParameterizedMessage.format(
                     "This node has insufficient available memory. Available memory for ML [{} ({})], "
@@ -548,8 +553,8 @@ public class TrainedModelAssignmentClusterService implements ClusterStateListene
                         ByteSizeValue.ofBytes(load.getMaxMlMemory()).toString(),
                         load.getAssignedJobMemory(),
                         ByteSizeValue.ofBytes(load.getAssignedJobMemory()).toString(),
-                        params.estimateMemoryUsageBytes(),
-                        ByteSizeValue.ofBytes(params.estimateMemoryUsageBytes()).toString() }
+                        requiredMemory,
+                        ByteSizeValue.ofBytes(requiredMemory).toString() }
                 )
             );
         }

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/NodeLoadDetectorTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/NodeLoadDetectorTests.java
@@ -158,7 +158,7 @@ public class NodeLoadDetectorTests extends ESTestCase {
         assertThat(load.getMaxMlMemory(), equalTo(0L));
 
         load = nodeLoadDetector.detectNodeLoad(cs, nodes.get("_node_id4"), 5, 30, false);
-        assertThat(load.getAssignedJobMemory(), equalTo(429916160L));
+        assertThat(load.getAssignedJobMemory(), equalTo(398458880L));
         assertThat(load.getNumAllocatingJobs(), equalTo(0L));
         assertThat(load.getNumAssignedJobs(), equalTo(2L));
         assertThat(load.getMaxJobs(), equalTo(5));


### PR DESCRIPTION
This PR fixes a bug where the native code overhead that we
assume for the memory needed to load shared libraries was
not considered if a PyTorch model was the first ML process
to load on a node.

Because that overhead _was_ considered after the model had
been assigned to the node this could have caused inconsistencies
such as total assigned memory being greater than permitted,
or repeated autoscaling loops.

There is a complication though, as we want it to be possible to
load a good selection of PyTorch models on 2GB ML nodes in
Cloud. Many models are very close to the limit of what's
possible, and wouldn't fit if the extra 30MB was added in
without changing anything else. (This is particularly the case
when logging and metrics collection is enabled, because then
memory gets set aside for Filebeat and Metricbeat.)

To avoid drastically reducing the selection of models that will
fit on a 2GB node the per-process overhead is reduced from 270MB
to 240MB. Therefore, when there is just one model running per
node this PR has no effect on which models will fit. When multiple
models run on the same node the memory requirement is slightly
reduced compared to before. However, the 270MB was a pretty rough
estimate in the first place, so this is unlikely to be a major
problem.