### PR TITLE
[8.2] [ML] Adjust memory overhead for PyTorch models (#86416)

### DIFF
--- a/docs/changelog/86416.yaml
+++ b/docs/changelog/86416.yaml
@@ -1,0 +1,5 @@
+pr: 86416
+summary: Adjust memory overhead for `PyTorch` models
+area: Machine Learning
+type: bug
+issues: []

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/StartTrainedModelDeploymentAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/StartTrainedModelDeploymentAction.java
@@ -47,10 +47,14 @@ public class StartTrainedModelDeploymentAction extends ActionType<CreateTrainedM
 
     /**
      * This has been found to be approximately 300MB on linux by manual testing.
-     * We also subtract 30MB that we always add as overhead (see MachineLearning.NATIVE_EXECUTABLE_CODE_OVERHEAD).
+     * 30MB of this is accounted for via the space set aside to load the code into memory
+     * that we always add as overhead (see MachineLearning.NATIVE_EXECUTABLE_CODE_OVERHEAD).
+     * That would result in 270MB here, although the problem with this is that it would
+     * mean few models would fit on a 2GB ML node in Cloud with logging and metrics enabled.
+     * Therefore we push the boundary a bit and require a 240MB per-model overhead.
      * TODO Check if it is substantially different in other platforms.
      */
-    private static final ByteSizeValue MEMORY_OVERHEAD = ByteSizeValue.ofMb(270);
+    private static final ByteSizeValue MEMORY_OVERHEAD = ByteSizeValue.ofMb(240);
 
     public StartTrainedModelDeploymentAction() {
         super(NAME, CreateTrainedModelAllocationAction.Response::new);

--- a/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/PyTorchModelIT.java
+++ b/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/PyTorchModelIT.java
@@ -251,7 +251,7 @@ public class PyTorchModelIT extends ESRestTestCase {
                 stats.get(0)
             );
             assertThat(responseMap.toString(), requiredNativeMemory, is(not(nullValue())));
-            assertThat(requiredNativeMemory, equalTo((int) (ByteSizeValue.ofMb(270).getBytes() + 2 * RAW_MODEL_SIZE)));
+            assertThat(requiredNativeMemory, equalTo((int) (ByteSizeValue.ofMb(240).getBytes() + 2 * RAW_MODEL_SIZE)));
 
             Response humanResponse = client().performRequest(new Request("GET", "/_ml/trained_models/" + modelId + "/_stats?human"));
             var humanResponseMap = entityAsMap(humanResponse);
@@ -273,7 +273,7 @@ public class PyTorchModelIT extends ESRestTestCase {
                 stringRequiredNativeMemory,
                 is(not(nullValue()))
             );
-            assertThat(stringRequiredNativeMemory, equalTo("270mb"));
+            assertThat(stringRequiredNativeMemory, equalTo("240mb"));
             stopDeployment(modelId);
         };
 

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/allocation/TrainedModelAllocationClusterService.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/allocation/TrainedModelAllocationClusterService.java
@@ -535,7 +535,12 @@ public class TrainedModelAllocationClusterService implements ClusterStateListene
                 )
             );
         }
-        if (load.getFreeMemory() < params.estimateMemoryUsageBytes()) {
+        // If any ML processes are running on a node we require some space to load the shared libraries.
+        // So if none are currently running then this per-node overhead must be added to the requirement.
+        long requiredMemory = params.estimateMemoryUsageBytes() + ((load.getNumAssignedJobs() == 0)
+            ? MachineLearning.NATIVE_EXECUTABLE_CODE_OVERHEAD.getBytes()
+            : 0);
+        if (load.getFreeMemory() < requiredMemory) {
             return Optional.of(
                 ParameterizedMessage.format(
                     "This node has insufficient available memory. Available memory for ML [{} ({})], "
@@ -546,8 +551,8 @@ public class TrainedModelAllocationClusterService implements ClusterStateListene
                         ByteSizeValue.ofBytes(load.getMaxMlMemory()).toString(),
                         load.getAssignedJobMemory(),
                         ByteSizeValue.ofBytes(load.getAssignedJobMemory()).toString(),
-                        params.estimateMemoryUsageBytes(),
-                        ByteSizeValue.ofBytes(params.estimateMemoryUsageBytes()).toString() }
+                        requiredMemory,
+                        ByteSizeValue.ofBytes(requiredMemory).toString() }
                 )
             );
         }

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/NodeLoadDetectorTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/NodeLoadDetectorTests.java
@@ -158,7 +158,7 @@ public class NodeLoadDetectorTests extends ESTestCase {
         assertThat(load.getMaxMlMemory(), equalTo(0L));
 
         load = nodeLoadDetector.detectNodeLoad(cs, nodes.get("_node_id4"), 5, 30, false);
-        assertThat(load.getAssignedJobMemory(), equalTo(429916160L));
+        assertThat(load.getAssignedJobMemory(), equalTo(398458880L));
         assertThat(load.getNumAllocatingJobs(), equalTo(0L));
         assertThat(load.getNumAssignedJobs(), equalTo(2L));
         assertThat(load.getMaxJobs(), equalTo(5));


### PR DESCRIPTION
Backports the following commits to 8.2:
 - [ML] Adjust memory overhead for PyTorch models (#86416)