### PR TITLE
Support ?master_timeout in node shutdown APIs

### DIFF
--- a/x-pack/plugin/shutdown/src/main/java/org/elasticsearch/xpack/shutdown/RestDeleteShutdownNodeAction.java
+++ b/x-pack/plugin/shutdown/src/main/java/org/elasticsearch/xpack/shutdown/RestDeleteShutdownNodeAction.java
@@ -34,10 +34,8 @@ public class RestDeleteShutdownNodeAction extends BaseRestHandler {
     @Override
     protected RestChannelConsumer prepareRequest(RestRequest request, NodeClient client) {
         String nodeId = request.param("nodeId");
-        return channel -> client.execute(
-            DeleteShutdownNodeAction.INSTANCE,
-            new DeleteShutdownNodeAction.Request(nodeId),
-            new RestToXContentListener<>(channel)
-        );
+        final var parsedRequest = new DeleteShutdownNodeAction.Request(nodeId);
+        parsedRequest.masterNodeTimeout(request.paramAsTime("master_timeout", parsedRequest.masterNodeTimeout()));
+        return channel -> client.execute(DeleteShutdownNodeAction.INSTANCE, parsedRequest, new RestToXContentListener<>(channel));
     }
 }

--- a/x-pack/plugin/shutdown/src/main/java/org/elasticsearch/xpack/shutdown/RestPutShutdownNodeAction.java
+++ b/x-pack/plugin/shutdown/src/main/java/org/elasticsearch/xpack/shutdown/RestPutShutdownNodeAction.java
@@ -38,7 +38,7 @@ public class RestPutShutdownNodeAction extends BaseRestHandler {
         String nodeId = request.param("nodeId");
         try (XContentParser parser = request.contentParser()) {
             PutShutdownNodeAction.Request parsedRequest = PutShutdownNodeAction.Request.parseRequest(nodeId, parser);
-
+            parsedRequest.masterNodeTimeout(request.paramAsTime("master_timeout", parsedRequest.masterNodeTimeout()));
             return channel -> client.execute(PutShutdownNodeAction.INSTANCE, parsedRequest, new RestToXContentListener<>(channel));
         }
     }


### PR DESCRIPTION
The put-shutdown and delete-shutdown actions use the default 30s timeout
for master node actions. This commit adds support for the
`?master_timeout` parameter so that clients can adjust the task timeout.

Relates #84847