### PR TITLE
[ML] fix distribution change check for change_point aggregation

### DIFF
--- a/docs/changelog/86423.yaml
+++ b/docs/changelog/86423.yaml
@@ -1,0 +1,5 @@
+pr: 86423
+summary: Fix distribution change check for `change_point` aggregation
+area: Machine Learning
+type: bug
+issues: []

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/aggs/changepoint/ChangePointAggregator.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/aggs/changepoint/ChangePointAggregator.java
@@ -256,10 +256,12 @@ public class ChangePointAggregator extends SiblingPipelineAggregator {
             discoveredChangePoints.add(changePoint);
             double pValue = 1;
             for (int i : discoveredChangePoints) {
-                double ksTestPValue = KOLMOGOROV_SMIRNOV_TEST.kolmogorovSmirnovTest(
-                    Arrays.copyOfRange(timeWindow, 0, i),
-                    Arrays.copyOfRange(timeWindow, i, timeWindow.length)
-                );
+                double[] x = Arrays.copyOfRange(timeWindow, 0, i);
+                double[] y = Arrays.copyOfRange(timeWindow, i, timeWindow.length);
+                double statistic = KOLMOGOROV_SMIRNOV_TEST.kolmogorovSmirnovStatistic(x, y);
+                double ksTestPValue = x.length > 10_000 ?
+                    KOLMOGOROV_SMIRNOV_TEST.approximateP(statistic, x.length, y.length) :
+                    KOLMOGOROV_SMIRNOV_TEST.exactP(statistic, x.length, y.length, false);
                 if (ksTestPValue < pValue) {
                     changePoint = i;
                     pValue = ksTestPValue;

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/aggs/changepoint/ChangePointAggregator.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/aggs/changepoint/ChangePointAggregator.java
@@ -259,9 +259,9 @@ public class ChangePointAggregator extends SiblingPipelineAggregator {
                 double[] x = Arrays.copyOfRange(timeWindow, 0, i);
                 double[] y = Arrays.copyOfRange(timeWindow, i, timeWindow.length);
                 double statistic = KOLMOGOROV_SMIRNOV_TEST.kolmogorovSmirnovStatistic(x, y);
-                double ksTestPValue = x.length > 10_000 ?
-                    KOLMOGOROV_SMIRNOV_TEST.approximateP(statistic, x.length, y.length) :
-                    KOLMOGOROV_SMIRNOV_TEST.exactP(statistic, x.length, y.length, false);
+                double ksTestPValue = x.length > 10_000
+                    ? KOLMOGOROV_SMIRNOV_TEST.approximateP(statistic, x.length, y.length)
+                    : KOLMOGOROV_SMIRNOV_TEST.exactP(statistic, x.length, y.length, false);
                 if (ksTestPValue < pValue) {
                     changePoint = i;
                     pValue = ksTestPValue;

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/aggs/changepoint/ChangePointAggregatorTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/aggs/changepoint/ChangePointAggregatorTests.java
@@ -170,38 +170,34 @@ public class ChangePointAggregatorTests extends AggregatorTestCase {
     }
 
     public void testStepChangeEdgeCaseScenarios() throws IOException {
-            double[] bucketValues = new double[]{
-                214505.0,
-                193747.0,
-                204368.0,
-                193905.0,
-                152777.0,
-                203945.0,
-                163390.0,
-                163597.0,
-                214807.0,
-                224819.0,
-                214245.0,
-                21482.0,
-                22264.0,
-                21972.0,
-                22309.0,
-                21506.0,
-                21365.0,
-                21928.0,
-                21973.0,
-                23105.0,
-                22118.0,
-                22165.0,
-                21388.0
-            };
-            testChangeType(
-                bucketValues,
-                changeType -> {
-                    assertThat(changeType,instanceOf(ChangeType.StepChange.class));
-                    assertThat(Arrays.toString(bucketValues), changeType.changePoint(), equalTo(11));
-                }
-            );
+        double[] bucketValues = new double[] {
+            214505.0,
+            193747.0,
+            204368.0,
+            193905.0,
+            152777.0,
+            203945.0,
+            163390.0,
+            163597.0,
+            214807.0,
+            224819.0,
+            214245.0,
+            21482.0,
+            22264.0,
+            21972.0,
+            22309.0,
+            21506.0,
+            21365.0,
+            21928.0,
+            21973.0,
+            23105.0,
+            22118.0,
+            22165.0,
+            21388.0 };
+        testChangeType(bucketValues, changeType -> {
+            assertThat(changeType, instanceOf(ChangeType.StepChange.class));
+            assertThat(Arrays.toString(bucketValues), changeType.changePoint(), equalTo(11));
+        });
     }
 
     void testChangeType(double[] bucketValues, Consumer<ChangeType> changeTypeAssertions) throws IOException {

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/aggs/changepoint/ChangePointAggregatorTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/aggs/changepoint/ChangePointAggregatorTests.java
@@ -169,6 +169,41 @@ public class ChangePointAggregatorTests extends AggregatorTestCase {
         );
     }
 
+    public void testStepChangeEdgeCaseScenarios() throws IOException {
+            double[] bucketValues = new double[]{
+                214505.0,
+                193747.0,
+                204368.0,
+                193905.0,
+                152777.0,
+                203945.0,
+                163390.0,
+                163597.0,
+                214807.0,
+                224819.0,
+                214245.0,
+                21482.0,
+                22264.0,
+                21972.0,
+                22309.0,
+                21506.0,
+                21365.0,
+                21928.0,
+                21973.0,
+                23105.0,
+                22118.0,
+                22165.0,
+                21388.0
+            };
+            testChangeType(
+                bucketValues,
+                changeType -> {
+                    assertThat(changeType,instanceOf(ChangeType.StepChange.class));
+                    assertThat(Arrays.toString(bucketValues), changeType.changePoint(), equalTo(11));
+                }
+            );
+    }
+
     void testChangeType(double[] bucketValues, Consumer<ChangeType> changeTypeAssertions) throws IOException {
         FilterAggregationBuilder dummy = AggregationBuilders.filter("dummy", new MatchAllQueryBuilder())
             .subAggregation(


### PR DESCRIPTION
There are certain scenarios where using apache math's built in ksTest check fails.

When `strict` is `true`, it requires the probability to be expressed as an inequality and typically causes `0` to be the pvalue calculated. This is most likely due to numerical resolution problems.

switching to `strict: false` fixes this. We only want to return that a change point is a distribution change if no only change type could be found or other change type pValues were large.