### PR TITLE
Fix DesiredBalanceReconcilerTests#testFailsNewPrimariesIfNoDataNodes

### DIFF
--- a/server/src/test/java/org/elasticsearch/cluster/routing/allocation/allocator/DesiredBalanceReconcilerTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/allocation/allocator/DesiredBalanceReconcilerTests.java
@@ -167,25 +167,15 @@ public class DesiredBalanceReconcilerTests extends ESTestCase {
             );
         }
 
-        reconcile(routingAllocation, new DesiredBalance(Map.of(), Map.of()));
-        assertFalse(routingAllocation.routingNodesChanged());
-
-        for (ShardRouting shardRouting : routingAllocation.routingNodes().unassigned()) {
-            assertTrue(shardRouting.toString(), shardRouting.unassigned());
-            assertThat(
-                shardRouting.unassignedInfo().getLastAllocationStatus(),
-                equalTo(
-                    shardRouting.primary() && shardRouting.shardId().id() == 1
-                        ? UnassignedInfo.AllocationStatus.DECIDERS_THROTTLED
-                        : UnassignedInfo.AllocationStatus.NO_ATTEMPT
-                )
-            );
-        }
-
         reconcile(
             routingAllocation,
             new DesiredBalance(
-                Map.of(new ShardId(clusterState.metadata().index(DesiredBalanceServiceTests.TEST_INDEX).getIndex(), 0), Set.of("node-0")),
+                randomBoolean()
+                    ? Map.of()
+                    : Map.of(
+                        new ShardId(clusterState.metadata().index(DesiredBalanceServiceTests.TEST_INDEX).getIndex(), 0),
+                        Set.of("node-0")
+                    ),
                 Map.of()
             )
         );


### PR DESCRIPTION
This test was checking that the reconciler does nothing if the desired
balance is empty, but that wasn't the case: if there are no data nodes
then we fail the allocation of new primaries. This commit removes these
unnecessary assertions.