### PR TITLE
Add immutable list reader to StreamInput

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/io/stream/StreamInput.java
+++ b/server/src/main/java/org/elasticsearch/common/io/stream/StreamInput.java
@@ -1150,6 +1150,27 @@ public abstract class StreamInput extends InputStream {
     }
 
     /**
+     * Reads an list of objects. The list is expected to have been written using {@link StreamOutput#writeList(List)}.
+     * The returned list is immutable.
+     *
+     * @return the list of objects
+     * @throws IOException if an I/O exception occurs reading the list
+     */
+    public <T> List<T> readImmutableList(final Writeable.Reader<T> reader) throws IOException {
+        int count = readArraySize();
+        if (count == 0) {
+            return List.of();
+        }
+        Object[] entries = new Object[count];
+        for (int i = 0; i < count; i++) {
+            entries[i] = reader.read(this);
+        }
+        @SuppressWarnings("unchecked")
+        T[] typedEntries = (T[]) entries;
+        return List.of(typedEntries);
+    }
+
+    /**
      * Reads a list of strings. The list is expected to have been written using {@link StreamOutput#writeStringCollection(Collection)}.
      * If the returned list contains any entries it will be mutable. If it is empty it might be immutable.
      *

--- a/server/src/main/java/org/elasticsearch/common/io/stream/StreamInput.java
+++ b/server/src/main/java/org/elasticsearch/common/io/stream/StreamInput.java
@@ -1158,8 +1158,13 @@ public abstract class StreamInput extends InputStream {
      */
     public <T> List<T> readImmutableList(final Writeable.Reader<T> reader) throws IOException {
         int count = readArraySize();
+        // special cases small arrays, just like in java.util.List.of(...)
         if (count == 0) {
             return List.of();
+        } else if (count == 1) {
+            return List.of(reader.read(this));
+        } else if (count == 2) {
+            return List.of(reader.read(this), reader.read(this));
         }
         Object[] entries = new Object[count];
         for (int i = 0; i < count; i++) {

--- a/server/src/test/java/org/elasticsearch/common/io/stream/AbstractStreamTests.java
+++ b/server/src/test/java/org/elasticsearch/common/io/stream/AbstractStreamTests.java
@@ -475,7 +475,8 @@ public abstract class AbstractStreamTests extends ESTestCase {
         assertImmutableMapSerialization(Map.of("a", 1, "b", 2));
     }
 
-    public <T> void assertImmutableListSerialization(List<T> expected, Writeable.Reader<T> reader, Writeable.Writer<T> writer) throws IOException {
+    public <T> void assertImmutableListSerialization(List<T> expected, Writeable.Reader<T> reader, Writeable.Writer<T> writer)
+        throws IOException {
         final BytesStreamOutput output = new BytesStreamOutput();
         output.writeCollection(expected, writer);
         final BytesReference bytesReference = output.bytes();
@@ -492,6 +493,7 @@ public abstract class AbstractStreamTests extends ESTestCase {
         assertImmutableListSerialization(List.of("a"), StreamInput::readString, StreamOutput::writeString);
         assertImmutableListSerialization(List.of("a", "b"), StreamInput::readString, StreamOutput::writeString);
         assertImmutableListSerialization(List.of(1), StreamInput::readVInt, StreamOutput::writeVInt);
+        assertImmutableListSerialization(List.of(1, 2, 3), StreamInput::readVInt, StreamOutput::writeVInt);
     }
 
     private void assertSerialization(

--- a/server/src/test/java/org/elasticsearch/common/io/stream/AbstractStreamTests.java
+++ b/server/src/test/java/org/elasticsearch/common/io/stream/AbstractStreamTests.java
@@ -475,6 +475,25 @@ public abstract class AbstractStreamTests extends ESTestCase {
         assertImmutableMapSerialization(Map.of("a", 1, "b", 2));
     }
 
+    public <T> void assertImmutableListSerialization(List<T> expected, Writeable.Reader<T> reader, Writeable.Writer<T> writer) throws IOException {
+        final BytesStreamOutput output = new BytesStreamOutput();
+        output.writeCollection(expected, writer);
+        final BytesReference bytesReference = output.bytes();
+
+        final StreamInput input = getStreamInput(bytesReference);
+        List<T> got = input.readImmutableList(reader);
+        assertThat(got, equalTo(expected));
+
+        expectThrows(UnsupportedOperationException.class, got::clear);
+    }
+
+    public void testImmutableListSerialization() throws IOException {
+        assertImmutableListSerialization(List.of(), StreamInput::readString, StreamOutput::writeString);
+        assertImmutableListSerialization(List.of("a"), StreamInput::readString, StreamOutput::writeString);
+        assertImmutableListSerialization(List.of("a", "b"), StreamInput::readString, StreamOutput::writeString);
+        assertImmutableListSerialization(List.of(1), StreamInput::readVInt, StreamOutput::writeVInt);
+    }
+
     private void assertSerialization(
         CheckedConsumer<StreamOutput, IOException> outputAssertions,
         CheckedConsumer<StreamInput, IOException> inputAssertions


### PR DESCRIPTION
This commit adds a utility method for reading an immutable list to
StreamInput.

relates #86427