### PR TITLE
[8.2] Fix edge case where user-defined heap settings are ignored (#86438)

### DIFF
--- a/distribution/tools/launchers/src/main/java/org/elasticsearch/tools/launchers/JvmOption.java
+++ b/distribution/tools/launchers/src/main/java/org/elasticsearch/tools/launchers/JvmOption.java
@@ -41,7 +41,7 @@ class JvmOption {
     }
 
     public boolean isCommandLineOrigin() {
-        return "command line".equals(this.origin);
+        return this.origin.contains("command line");
     }
 
     private static final Pattern OPTION = Pattern.compile(

--- a/distribution/tools/launchers/src/test/java/org/elasticsearch/tools/launchers/MachineDependentHeapTests.java
+++ b/distribution/tools/launchers/src/test/java/org/elasticsearch/tools/launchers/MachineDependentHeapTests.java
@@ -41,6 +41,17 @@ public class MachineDependentHeapTests extends LaunchersTestCase {
         assertThat(options, empty());
     }
 
+    // Explicitly test odd heap sizes
+    // See: https://github.com/elastic/elasticsearch/issues/86431
+    public void testOddUserPassedHeapArgs() throws Exception {
+        MachineDependentHeap heap = new MachineDependentHeap(systemMemoryInGigabytes(8));
+        List<String> options = heap.determineHeapSettings(configPath(), List.of("-Xmx409m"));
+        assertThat(options, empty());
+
+        options = heap.determineHeapSettings(configPath(), List.of("-Xms409m"));
+        assertThat(options, empty());
+    }
+
     public void testMasterOnlyOptions() {
         List<String> options = calculateHeap(16, "master");
         assertThat(options, containsInAnyOrder("-Xmx9830m", "-Xms9830m"));

--- a/docs/changelog/86438.yaml
+++ b/docs/changelog/86438.yaml
@@ -1,0 +1,6 @@
+pr: 86438
+summary: Fix edge case where user-defined heap settings are ignored
+area: Packaging
+type: bug
+issues:
+ - 86431


### PR DESCRIPTION
Backports the following commits to 8.2:
 - Fix edge case where user-defined heap settings are ignored (#86438)