### PR TITLE
Make verbosity in Terminal immutable

### DIFF
--- a/distribution/tools/plugin-cli/src/test/java/org/elasticsearch/plugins/cli/InstallPluginActionTests.java
+++ b/distribution/tools/plugin-cli/src/test/java/org/elasticsearch/plugins/cli/InstallPluginActionTests.java
@@ -846,13 +846,13 @@ public class InstallPluginActionTests extends ESTestCase {
     }
 
     public void testQuietFlagDisabled() throws Exception {
-        terminal.setVerbosity(randomFrom(Terminal.Verbosity.NORMAL, Terminal.Verbosity.VERBOSE));
+        terminal = MockTerminal.create(randomFrom(Terminal.Verbosity.NORMAL, Terminal.Verbosity.VERBOSE));
         installPlugin(false);
         assertThat(terminal.getOutput(), containsString("100%"));
     }
 
     public void testQuietFlagEnabled() throws Exception {
-        terminal.setVerbosity(Terminal.Verbosity.SILENT);
+        terminal = MockTerminal.create(Terminal.Verbosity.SILENT);
         installPlugin(false);
         assertThat(terminal.getOutput(), not(containsString("100%")));
     }

--- a/libs/cli/src/main/java/org/elasticsearch/cli/Command.java
+++ b/libs/cli/src/main/java/org/elasticsearch/cli/Command.java
@@ -97,15 +97,16 @@ public abstract class Command implements Closeable {
             return;
         }
 
+        final Terminal.Verbosity verbosity;
         if (options.has(silentOption)) {
-            terminal.setVerbosity(Terminal.Verbosity.SILENT);
+            verbosity = Terminal.Verbosity.SILENT;
         } else if (options.has(verboseOption)) {
-            terminal.setVerbosity(Terminal.Verbosity.VERBOSE);
+            verbosity = Terminal.Verbosity.VERBOSE;
         } else {
-            terminal.setVerbosity(Terminal.Verbosity.NORMAL);
+            verbosity = Terminal.Verbosity.NORMAL;
         }
 
-        execute(terminal, options, processInfo);
+        execute(terminal.withVerbosity(verbosity), options, processInfo);
     }
 
     /** Prints a help message for the command to the terminal. */

--- a/server/src/main/java/org/elasticsearch/bootstrap/plugins/LoggerTerminal.java
+++ b/server/src/main/java/org/elasticsearch/bootstrap/plugins/LoggerTerminal.java
@@ -23,7 +23,7 @@ public final class LoggerTerminal extends Terminal {
     private static final String FQCN = LoggerTerminal.class.getName();
 
     private LoggerTerminal(final Logger logger) {
-        super(null, null, null);
+        super(null, null, null, null);
         this.logger = new ExtendedLoggerWrapper((AbstractLogger) logger, logger.getName(), logger.getMessageFactory());
     }
 
@@ -34,6 +34,11 @@ public final class LoggerTerminal extends Terminal {
     @Override
     public boolean isHeadless() {
         return true;
+    }
+
+    @Override
+    public Terminal withVerbosity(Verbosity verbosity) {
+        return this; // verbosity is ignored by this terminal
     }
 
     @Override

--- a/server/src/test/java/org/elasticsearch/cli/TerminalTests.java
+++ b/server/src/test/java/org/elasticsearch/cli/TerminalTests.java
@@ -18,8 +18,7 @@ import static org.hamcrest.Matchers.equalTo;
 public class TerminalTests extends ESTestCase {
 
     public void testVerbosity() throws Exception {
-        MockTerminal terminal = MockTerminal.create();
-        terminal.setVerbosity(Terminal.Verbosity.SILENT);
+        MockTerminal terminal = MockTerminal.create(Terminal.Verbosity.SILENT);
         assertPrinted(terminal, Terminal.Verbosity.SILENT, "text");
         assertNotPrinted(terminal, Terminal.Verbosity.NORMAL, "text");
         assertNotPrinted(terminal, Terminal.Verbosity.VERBOSE, "text");
@@ -29,16 +28,14 @@ public class TerminalTests extends ESTestCase {
         assertPrinted(terminal, Terminal.Verbosity.NORMAL, "text");
         assertNotPrinted(terminal, Terminal.Verbosity.VERBOSE, "text");
 
-        terminal = MockTerminal.create();
-        terminal.setVerbosity(Terminal.Verbosity.VERBOSE);
+        terminal = MockTerminal.create(Terminal.Verbosity.VERBOSE);
         assertPrinted(terminal, Terminal.Verbosity.SILENT, "text");
         assertPrinted(terminal, Terminal.Verbosity.NORMAL, "text");
         assertPrinted(terminal, Terminal.Verbosity.VERBOSE, "text");
     }
 
     public void testErrorVerbosity() throws Exception {
-        MockTerminal terminal = MockTerminal.create();
-        terminal.setVerbosity(Terminal.Verbosity.SILENT);
+        MockTerminal terminal = MockTerminal.create(Terminal.Verbosity.SILENT);
         assertErrorPrinted(terminal, Terminal.Verbosity.SILENT, "text");
         assertErrorNotPrinted(terminal, Terminal.Verbosity.NORMAL, "text");
         assertErrorNotPrinted(terminal, Terminal.Verbosity.VERBOSE, "text");
@@ -48,8 +45,7 @@ public class TerminalTests extends ESTestCase {
         assertErrorPrinted(terminal, Terminal.Verbosity.NORMAL, "text");
         assertErrorNotPrinted(terminal, Terminal.Verbosity.VERBOSE, "text");
 
-        terminal = MockTerminal.create();
-        terminal.setVerbosity(Terminal.Verbosity.VERBOSE);
+        terminal = MockTerminal.create(Terminal.Verbosity.VERBOSE);
         assertErrorPrinted(terminal, Terminal.Verbosity.SILENT, "text");
         assertErrorPrinted(terminal, Terminal.Verbosity.NORMAL, "text");
         assertErrorPrinted(terminal, Terminal.Verbosity.VERBOSE, "text");

--- a/server/src/test/java/org/elasticsearch/env/NodeRepurposeCommandTests.java
+++ b/server/src/test/java/org/elasticsearch/env/NodeRepurposeCommandTests.java
@@ -200,10 +200,8 @@ public class NodeRepurposeCommandTests extends ESTestCase {
 
     private static void withTerminal(boolean verbose, Matcher<String> outputMatcher, CheckedConsumer<MockTerminal, Exception> consumer)
         throws Exception {
-        MockTerminal terminal = MockTerminal.create();
-        if (verbose) {
-            terminal.setVerbosity(Terminal.Verbosity.VERBOSE);
-        }
+        Terminal.Verbosity verbosity = verbose ? Terminal.Verbosity.VERBOSE : Terminal.Verbosity.NORMAL;
+        MockTerminal terminal = MockTerminal.create(verbosity);
 
         consumer.accept(terminal);
 

--- a/server/src/test/java/org/elasticsearch/index/shard/RemoveCorruptedShardDataCommandTests.java
+++ b/server/src/test/java/org/elasticsearch/index/shard/RemoveCorruptedShardDataCommandTests.java
@@ -234,13 +234,12 @@ public class RemoveCorruptedShardDataCommandTests extends IndexShardTestCase {
         }
 
         final RemoveCorruptedShardDataCommand command = new RemoveCorruptedShardDataCommand();
-        final MockTerminal t = MockTerminal.create();
+        final MockTerminal t = MockTerminal.create(Terminal.Verbosity.VERBOSE);
         final OptionParser parser = command.getParser();
 
         // run command with dry-run
         t.addTextInput("n"); // mean dry run
         final OptionSet options = parser.parse("-d", indexPath.toString());
-        t.setVerbosity(Terminal.Verbosity.VERBOSE);
         try {
             command.execute(t, options, environment, processInfo);
             fail();
@@ -299,13 +298,12 @@ public class RemoveCorruptedShardDataCommandTests extends IndexShardTestCase {
         closeShard(corruptedShard, false); // translog is corrupted already - do not check consistency
 
         final RemoveCorruptedShardDataCommand command = new RemoveCorruptedShardDataCommand();
-        final MockTerminal t = MockTerminal.create();
+        final MockTerminal t = MockTerminal.create(Terminal.Verbosity.VERBOSE);
         final OptionParser parser = command.getParser();
 
         final OptionSet options = parser.parse("-d", translogPath.toString());
         // run command with dry-run
         t.addTextInput("n"); // mean dry run
-        t.setVerbosity(Terminal.Verbosity.VERBOSE);
         try {
             command.execute(t, options, environment, processInfo);
             fail();
@@ -354,14 +352,13 @@ public class RemoveCorruptedShardDataCommandTests extends IndexShardTestCase {
         TestTranslog.corruptRandomTranslogFile(logger, random(), translogPath);
 
         final RemoveCorruptedShardDataCommand command = new RemoveCorruptedShardDataCommand();
-        final MockTerminal t = MockTerminal.create();
+        final MockTerminal t = MockTerminal.create(Terminal.Verbosity.VERBOSE);
         final OptionParser parser = command.getParser();
 
         final OptionSet options = parser.parse("-d", translogPath.toString());
         // run command with dry-run
         t.addTextInput("n"); // mean dry run
         t.addTextInput("n"); // mean dry run
-        t.setVerbosity(Terminal.Verbosity.VERBOSE);
         try {
             command.execute(t, options, environment, processInfo);
             fail();
@@ -432,11 +429,10 @@ public class RemoveCorruptedShardDataCommandTests extends IndexShardTestCase {
         closeShards(indexShard);
 
         final RemoveCorruptedShardDataCommand command = new RemoveCorruptedShardDataCommand();
-        final MockTerminal t = MockTerminal.create();
+        final MockTerminal t = MockTerminal.create(Terminal.Verbosity.VERBOSE);
         final OptionParser parser = command.getParser();
 
         final OptionSet options = parser.parse("-d", translogPath.toString());
-        t.setVerbosity(Terminal.Verbosity.VERBOSE);
         assertThat(
             expectThrows(ElasticsearchException.class, () -> command.execute(t, options, environment, processInfo)).getMessage(),
             allOf(containsString("Shard does not seem to be corrupted"), containsString("--" + TRUNCATE_CLEAN_TRANSLOG_FLAG))
@@ -450,12 +446,11 @@ public class RemoveCorruptedShardDataCommandTests extends IndexShardTestCase {
         closeShards(indexShard);
 
         final RemoveCorruptedShardDataCommand command = new RemoveCorruptedShardDataCommand();
-        final MockTerminal t = MockTerminal.create();
+        final MockTerminal t = MockTerminal.create(Terminal.Verbosity.VERBOSE);
         final OptionParser parser = command.getParser();
 
         final OptionSet options = parser.parse("-d", translogPath.toString(), "--" + TRUNCATE_CLEAN_TRANSLOG_FLAG);
         t.addTextInput("y");
-        t.setVerbosity(Terminal.Verbosity.VERBOSE);
         command.execute(t, options, environment, processInfo);
         assertThat(t.getOutput(), containsString("Lucene index is clean"));
         assertThat(t.getOutput(), containsString("Translog was not analysed and will be truncated"));
@@ -476,14 +471,13 @@ public class RemoveCorruptedShardDataCommandTests extends IndexShardTestCase {
         closeShards(corruptedShard);
 
         final RemoveCorruptedShardDataCommand command = new RemoveCorruptedShardDataCommand();
-        final MockTerminal t = MockTerminal.create();
+        final MockTerminal t = MockTerminal.create(Terminal.Verbosity.VERBOSE);
         final OptionParser parser = command.getParser();
 
         final OptionSet options = parser.parse("-d", translogPath.toString());
         // run command with dry-run
         t.addTextInput("n"); // mean dry run
         t.addTextInput("n"); // mean dry run
-        t.setVerbosity(Terminal.Verbosity.VERBOSE);
         try {
             command.execute(t, options, environment, processInfo);
             fail();

--- a/test/framework/src/main/java/org/elasticsearch/cli/CommandTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/cli/CommandTestCase.java
@@ -36,7 +36,6 @@ public abstract class CommandTestCase extends ESTestCase {
     public void resetTerminal() {
         terminal.reset();
         terminal.setSupportsBinary(false);
-        terminal.setVerbosity(Terminal.Verbosity.NORMAL);
         esHomeDir = createTempDir();
         sysprops.clear();
         sysprops.put("es.path.home", esHomeDir.toString());

--- a/test/framework/src/main/java/org/elasticsearch/cli/MockTerminal.java
+++ b/test/framework/src/main/java/org/elasticsearch/cli/MockTerminal.java
@@ -123,7 +123,7 @@ public class MockTerminal extends Terminal {
         var reader = new ResettableInputStreamReader(new LazyByteArrayInputStream());
         var stdout = new ByteArrayOutputStream();
         var stderr = new ByteArrayOutputStream();
-        return new MockTerminal(Verbosity.DEFAULT, reader, stdout, stderr, newPrintWriter(stdout), newPrintWriter(stderr));
+        return new MockTerminal(verbosity, reader, stdout, stderr, newPrintWriter(stdout), newPrintWriter(stderr));
     }
 
     /** Adds a character input that will be returned from reading this Terminal. Values are read in FIFO order. */

--- a/test/framework/src/main/java/org/elasticsearch/cli/MockTerminal.java
+++ b/test/framework/src/main/java/org/elasticsearch/cli/MockTerminal.java
@@ -81,12 +81,24 @@ public class MockTerminal extends Terminal {
     private final ByteArrayOutputStream stderrBuffer;
     private boolean supportsBinary = false;
 
-    private MockTerminal(ResettableInputStreamReader stdinReader, ByteArrayOutputStream stdout, ByteArrayOutputStream stderr) {
-        super(stdinReader, newPrintWriter(stdout), newPrintWriter(stderr));
+    private MockTerminal(
+        Verbosity verbosity,
+        ResettableInputStreamReader stdinReader,
+        ByteArrayOutputStream stdout,
+        ByteArrayOutputStream stderr,
+        PrintWriter outWriter,
+        PrintWriter errWriter
+    ) {
+        super(verbosity, stdinReader, outWriter, errWriter);
         this.stdinReader = stdinReader;
         this.stdinBuffer = stdinReader.stream;
         this.stdoutBuffer = stdout;
         this.stderrBuffer = stderr;
+    }
+
+    @Override
+    public Terminal withVerbosity(Verbosity verbosity) {
+        return new MockTerminal(verbosity, stdinReader, stdoutBuffer, stderrBuffer, getWriter(), getErrorWriter());
     }
 
     @Override
@@ -104,8 +116,14 @@ public class MockTerminal extends Terminal {
     }
 
     public static MockTerminal create() {
+        return create(Verbosity.DEFAULT);
+    }
+
+    public static MockTerminal create(Verbosity verbosity) {
         var reader = new ResettableInputStreamReader(new LazyByteArrayInputStream());
-        return new MockTerminal(reader, new ByteArrayOutputStream(), new ByteArrayOutputStream());
+        var stdout = new ByteArrayOutputStream();
+        var stderr = new ByteArrayOutputStream();
+        return new MockTerminal(Verbosity.DEFAULT, reader, stdout, stderr, newPrintWriter(stdout), newPrintWriter(stderr));
     }
 
     /** Adds a character input that will be returned from reading this Terminal. Values are read in FIFO order. */


### PR DESCRIPTION
The Terminal class is almost immutable, except for the verbosity. In
production this is never modified after startup, but tests tweak the
verbosity, and startup does need to get at a terminal with a different
verbosity depending on cli args.

This commit adds a withVerbosity method to Terminal, which returns a new
Terminal, of the same underlying implementation, but with a modified
verbsity level.