### PR TITLE
Batch reroute in TransportClusterUpdateSettingsAction

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/settings/TransportClusterUpdateSettingsAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/settings/TransportClusterUpdateSettingsAction.java
@@ -18,12 +18,12 @@ import org.elasticsearch.action.support.master.TransportMasterNodeAction;
 import org.elasticsearch.cluster.AckedClusterStateUpdateTask;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.ClusterStateUpdateTask;
+import org.elasticsearch.cluster.NotMasterException;
 import org.elasticsearch.cluster.block.ClusterBlockException;
 import org.elasticsearch.cluster.block.ClusterBlockLevel;
+import org.elasticsearch.cluster.coordination.FailedToCommitClusterStateException;
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.metadata.Metadata;
-import org.elasticsearch.cluster.node.DiscoveryNode;
-import org.elasticsearch.cluster.routing.allocation.AllocationService;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.Priority;
 import org.elasticsearch.common.inject.Inject;
@@ -45,8 +45,6 @@ public class TransportClusterUpdateSettingsAction extends TransportMasterNodeAct
 
     private static final Logger logger = LogManager.getLogger(TransportClusterUpdateSettingsAction.class);
 
-    private final AllocationService allocationService;
-
     private final ClusterSettings clusterSettings;
 
     @Inject
@@ -54,7 +52,6 @@ public class TransportClusterUpdateSettingsAction extends TransportMasterNodeAct
         TransportService transportService,
         ClusterService clusterService,
         ThreadPool threadPool,
-        AllocationService allocationService,
         ActionFilters actionFilters,
         IndexNameExpressionResolver indexNameExpressionResolver,
         ClusterSettings clusterSettings
@@ -71,7 +68,6 @@ public class TransportClusterUpdateSettingsAction extends TransportMasterNodeAct
             ClusterUpdateSettingsResponse::new,
             ThreadPool.Names.SAME
         );
-        this.allocationService = allocationService;
         this.clusterSettings = clusterSettings;
     }
 
@@ -192,32 +188,13 @@ public class TransportClusterUpdateSettingsAction extends TransportMasterNodeAct
                     return;
                 }
 
-                // The reason the reroute needs to be send as separate update task, is that all the *cluster* settings are encapsulate
-                // in the components (e.g. FilterAllocationDecider), so the changes made by the first call aren't visible
-                // to the components until the ClusterStateListener instances have been invoked, but are visible after
-                // the first update task has been completed.
-                submitUnbatchedTask(REROUTE_TASK_SOURCE, new AckedClusterStateUpdateTask(Priority.URGENT, request, listener) {
-
+                // The reason the reroute needs to be send as separate update task, is that all the *cluster* settings are encapsulated in
+                // the components (e.g. FilterAllocationDecider), so the changes made by the first call aren't visible to the components
+                // until the ClusterStateListener instances have been invoked, but are visible after the first update task has been
+                // completed.
+                clusterService.getRerouteService().reroute(REROUTE_TASK_SOURCE, Priority.URGENT, new ActionListener<>() {
                     @Override
-                    public boolean mustAck(DiscoveryNode discoveryNode) {
-                        // we wait for the reroute ack only if the update settings was acknowledged
-                        return updateSettingsAcked;
-                    }
-
-                    @Override
-                    // we return when the cluster reroute is acked or it times out but the acknowledged flag depends on whether the
-                    // update settings was acknowledged
-                    protected ClusterUpdateSettingsResponse newResponse(boolean acknowledged) {
-                        return new ClusterUpdateSettingsResponse(
-                            updateSettingsAcked && acknowledged,
-                            updater.getTransientUpdates(),
-                            updater.getPersistentUpdate()
-                        );
-                    }
-
-                    @Override
-                    public void onNoLongerMaster() {
-                        logger.debug("failed to preform reroute after cluster settings were updated - current node is no longer a master");
+                    public void onResponse(ClusterState clusterState) {
                         listener.onResponse(
                             new ClusterUpdateSettingsResponse(
                                 updateSettingsAcked,
@@ -229,15 +206,18 @@ public class TransportClusterUpdateSettingsAction extends TransportMasterNodeAct
 
                     @Override
                     public void onFailure(Exception e) {
-                        // if the reroute fails we only log
-                        logger.debug(() -> new ParameterizedMessage("failed to perform [{}]", REROUTE_TASK_SOURCE), e);
-                        listener.onFailure(new ElasticsearchException("reroute after update settings failed", e));
-                    }
-
-                    @Override
-                    public ClusterState execute(final ClusterState currentState) {
-                        // now, reroute in case things that require it changed (e.g. number of replicas)
-                        return allocationService.reroute(currentState, "reroute after cluster update settings");
+                        logger.debug(new ParameterizedMessage("failed to perform [{}]", REROUTE_TASK_SOURCE), e);
+                        if (e instanceof NotMasterException || e instanceof FailedToCommitClusterStateException) {
+                            listener.onResponse(
+                                new ClusterUpdateSettingsResponse(
+                                    updateSettingsAcked,
+                                    updater.getTransientUpdates(),
+                                    updater.getPersistentUpdate()
+                                )
+                            );
+                        } else {
+                            listener.onFailure(new ElasticsearchException("reroute after update settings failed", e));
+                        }
                     }
                 });
             }


### PR DESCRIPTION
There's no need for the followup reroute task to wait for acks from all
nodes (indeed it sometimes reports `acknowledged: true` even if the
update fails). Dropping the acking reduces this task to a simple
reroute, which can then be batched. This commit does that.