### PR TITLE
Cleanup SnapshotInProgressAllocationDecider a little

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/SnapshotInProgressAllocationDecider.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/SnapshotInProgressAllocationDecider.java
@@ -48,7 +48,7 @@ public class SnapshotInProgressAllocationDecider extends AllocationDecider {
         return canAllocate(shardRouting, node, allocation);
     }
 
-    private static final Decision YES_NO_SNAPSHOTS_RUNNING = Decision.single(Decision.Type.YES, NAME, "no snapshots are currently running");
+    private static final Decision YES_NOT_RUNNING = Decision.single(Decision.Type.YES, NAME, "no snapshots are currently running");
     private static final Decision YES_NOT_SNAPSHOTTED = Decision.single(Decision.Type.YES, NAME, "the shard is not being snapshotted");
 
     private static Decision canMove(ShardRouting shardRouting, RoutingAllocation allocation) {
@@ -60,7 +60,7 @@ public class SnapshotInProgressAllocationDecider extends AllocationDecider {
         SnapshotsInProgress snapshotsInProgress = allocation.custom(SnapshotsInProgress.TYPE);
         if (snapshotsInProgress == null || snapshotsInProgress.isEmpty()) {
             // Snapshots are not running
-            return YES_NO_SNAPSHOTS_RUNNING;
+            return YES_NOT_RUNNING;
         }
 
         final ShardId shardId = shardRouting.shardId();

--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/SnapshotInProgressAllocationDecider.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/SnapshotInProgressAllocationDecider.java
@@ -8,22 +8,19 @@
 
 package org.elasticsearch.cluster.routing.allocation.decider;
 
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.elasticsearch.cluster.SnapshotsInProgress;
 import org.elasticsearch.cluster.routing.RoutingNode;
 import org.elasticsearch.cluster.routing.ShardRouting;
 import org.elasticsearch.cluster.routing.allocation.RoutingAllocation;
+import org.elasticsearch.index.shard.ShardId;
 
-import java.util.Iterator;
+import java.util.function.Predicate;
 
 /**
  * This {@link org.elasticsearch.cluster.routing.allocation.decider.AllocationDecider} prevents shards that
  * are currently been snapshotted to be moved to other nodes.
  */
 public class SnapshotInProgressAllocationDecider extends AllocationDecider {
-
-    private static final Logger logger = LogManager.getLogger(SnapshotInProgressAllocationDecider.class);
 
     public static final String NAME = "snapshot_in_progress";
 
@@ -51,45 +48,41 @@ public class SnapshotInProgressAllocationDecider extends AllocationDecider {
         return canAllocate(shardRouting, node, allocation);
     }
 
+    private static final Decision YES_NO_SNAPSHOTS_RUNNING = Decision.single(Decision.Type.YES, NAME, "no snapshots are currently running");
+    private static final Decision YES_NOT_SNAPSHOTTED = Decision.single(Decision.Type.YES, NAME, "the shard is not being snapshotted");
+
     private static Decision canMove(ShardRouting shardRouting, RoutingAllocation allocation) {
-        if (shardRouting.primary()) {
+        if (shardRouting.primary() == false) {
             // Only primary shards are snapshotted
+            return YES_NOT_SNAPSHOTTED;
+        }
 
-            SnapshotsInProgress snapshotsInProgress = allocation.custom(SnapshotsInProgress.TYPE);
-            if (snapshotsInProgress == null || snapshotsInProgress.isEmpty()) {
-                // Snapshots are not running
-                return allocation.decision(Decision.YES, NAME, "no snapshots are currently running");
-            }
+        SnapshotsInProgress snapshotsInProgress = allocation.custom(SnapshotsInProgress.TYPE);
+        if (snapshotsInProgress == null || snapshotsInProgress.isEmpty()) {
+            // Snapshots are not running
+            return YES_NO_SNAPSHOTS_RUNNING;
+        }
 
-            final Iterator<SnapshotsInProgress.Entry> entryIterator = snapshotsInProgress.asStream().iterator();
-            while (entryIterator.hasNext()) {
-                final SnapshotsInProgress.Entry snapshot = entryIterator.next();
-                if (snapshot.isClone()) {
-                    continue;
-                }
-                SnapshotsInProgress.ShardSnapshotStatus shardSnapshotStatus = snapshot.shards().get(shardRouting.shardId());
-                if (shardSnapshotStatus != null
+        final ShardId shardId = shardRouting.shardId();
+        return snapshotsInProgress.asStream()
+            .filter(Predicate.not(SnapshotsInProgress.Entry::isClone))
+            .map(entry -> entry.shards().get(shardId))
+            .filter(
+                shardSnapshotStatus -> shardSnapshotStatus != null
                     && shardSnapshotStatus.state().completed() == false
                     && shardSnapshotStatus.nodeId() != null
-                    && shardSnapshotStatus.nodeId().equals(shardRouting.currentNodeId())) {
-                    if (logger.isTraceEnabled()) {
-                        logger.trace(
-                            "Preventing snapshotted shard [{}] from being moved away from node [{}]",
-                            shardRouting.shardId(),
-                            shardSnapshotStatus.nodeId()
-                        );
-                    }
-                    return allocation.decision(
-                        Decision.THROTTLE,
-                        NAME,
-                        "waiting for snapshotting of shard [%s] to complete on this node [%s]",
-                        shardRouting.shardId(),
-                        shardSnapshotStatus.nodeId()
-                    );
-                }
-            }
-        }
-        return allocation.decision(Decision.YES, NAME, "the shard is not being snapshotted");
+                    && shardSnapshotStatus.nodeId().equals(shardRouting.currentNodeId())
+            )
+            .findAny()
+            .map(
+                shardSnapshotStatus -> allocation.decision(
+                    Decision.THROTTLE,
+                    NAME,
+                    "waiting for snapshotting of shard [%s] to complete on this node [%s]",
+                    shardId,
+                    shardSnapshotStatus.nodeId()
+                )
+            )
+            .orElse(YES_NOT_SNAPSHOTTED);
     }
-
 }


### PR DESCRIPTION
This should really be made faster via a better `SnapshotsInProgress` that has an index of what's going on per shard, but for now at least make it a little better.

We already have a stream here, lets not make this needlessly slow via the iterator
when we can have the stream iterate much faster when used directly.
Also, looks nicer this way.

relates #77466 