### PR TITLE
Support geo label position through REST vector tiles API

### DIFF
--- a/docs/changelog/86458.yaml
+++ b/docs/changelog/86458.yaml
@@ -1,0 +1,6 @@
+pr: 86458
+summary: Support geo label position through REST vector tiles API
+area: Geo
+type: enhancement
+issues:
+ - 86044

--- a/docs/reference/search/search-vector-tile-api.asciidoc
+++ b/docs/reference/search/search-vector-tile-api.asciidoc
@@ -371,7 +371,9 @@ polygon selected from the <<geoshape-indexing-approach,sorted triangle-tree>>.
 from the <<geoshape-indexing-approach,triangle-tree>>.
 * The aggregation results will provide one central point for each aggregation bucket.
 
-All label features added to the results will be distinguishable using the tag `_mvt_label_position`.
++
+All attributes from the original features will also be copied to the new label features.
+In addition, the new features will be distinguishable using the tag `_mvt_label_position`.
 // end::with_labels[]
 
 [role="child_attributes"]

--- a/docs/reference/search/search-vector-tile-api.asciidoc
+++ b/docs/reference/search/search-vector-tile-api.asciidoc
@@ -101,6 +101,11 @@ aggregation uses the `<zoom>/<x>/<y>` tile as a bounding box.
 on the `<field>`. The search only includes this aggregation if the
 `exact_bounds` parameter is `true`.
 
+* If the optional parameter `with_labels` is true, the internal search will include
+a dynamic runtime field that calls the `getLabelPosition` function of the geometry doc value.
+This enables the generation of new point features containing suggested geometry labels,
+so that, for example, multi-polygons will have only one label.
+
 For example, {es} may translate a vector tile search API request with a
 `grid_agg` argument of `geotile` and an `exact_bounds` argument of `true`
 into the following search:
@@ -353,6 +358,22 @@ If `true`, the exact number of hits is returned at the cost of some performance.
 If `false`, the response does not include the total number of hits matching the query.
 // end::track_total_hits[]
 
+// tag::with_labels[]
+`with_labels`::
+(Optional, Boolean)
+If true, the hits and aggs layers will contain additional point features representing
+suggested label positions for the original features.
+* `Point` and `MultiPoint` features will have one of the points selected.
+* `Polygon` and `MultiPolygon` features will have a single point generated,
+either the centroid, if it is within the polygon, or another point within the
+polygon selected from the <<geoshape-indexing-approach,sorted triangle-tree>>.
+* `LineString` features will likewise provide a roughly central point selected
+from the <<geoshape-indexing-approach,triangle-tree>>.
+* The aggregation results will provide one central point for each aggregation bucket.
+
+All label features added to the results will be distinguishable using the tag `_mvt_label_position`.
+// end::with_labels[]
+
 [role="child_attributes"]
 [[search-vector-tile-api-request-body]]
 ==== {api-request-body-title}
@@ -421,6 +442,8 @@ By default, the API calculates a bounding box for each feature. It sorts
 features based on this box's diagonal length, from longest to shortest.
 
 include::search-vector-tile-api.asciidoc[tag=track_total_hits]
+
+include::search-vector-tile-api.asciidoc[tag=with_labels]
 
 [role="child_attributes"]
 [[search-vector-tile-api-response]]

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/search_mvt.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/search_mvt.json
@@ -81,6 +81,11 @@
       "track_total_hits":{
         "type":"boolean|long",
         "description":"Indicate if the number of documents that match the query should be tracked. A number can also be specified, to accurately track the total hit count up to the number."
+      },
+      "with_labels":{
+        "type":"boolean",
+        "description":"If true, the hits and aggs layers will contain additional point features with suggested label positions for the original features.",
+        "default":false
       }
     },
     "body":{

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/vector-tile/10_basic.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/vector-tile/10_basic.yml
@@ -77,6 +77,18 @@ setup:
           exact_bounds: true
 
 ---
+"with labels":
+  - do:
+      search_mvt:
+        index: locations
+        field: location
+        x: 0
+        y: 0
+        zoom: 0
+        body:
+          with_labels: true
+
+---
 "grid precision":
   - do:
       search_mvt:
@@ -149,6 +161,32 @@ setup:
           grid_type: centroid
 
 ---
+"grid agg geotile with labels":
+  - do:
+      search_mvt:
+        index: locations
+        field: location
+        x: 0
+        y: 0
+        zoom: 0
+        body:
+          grid_agg: geotile
+          with_labels: true
+
+---
+"grid agg geohex with labels":
+  - do:
+      search_mvt:
+        index: locations
+        field: location
+        x: 0
+        y: 0
+        zoom: 0
+        body:
+          grid_agg: geohex
+          with_labels: true
+
+---
 "field field":
   - do:
       search_mvt:
@@ -175,6 +213,24 @@ setup:
               script: emit(doc['location'].lon)
               type: double
           fields: [lon]
+
+---
+"runtime_fields label position":
+  - do:
+      search_mvt:
+        index: locations
+        field: location
+        x: 0
+        y: 0
+        zoom: 0
+        body:
+          runtime_mappings:
+            label_position:
+              script:
+                GeoPoint point = doc['location'].getLabelPosition();
+                emit(point.getLat(), point.getLon());
+              type: geo_point
+          fields: [label_position]
 
 ---
 "query field":

--- a/x-pack/plugin/vector-tile/src/javaRestTest/java/org/elasticsearch/xpack/vectortile/VectorTileRestIT.java
+++ b/x-pack/plugin/vector-tile/src/javaRestTest/java/org/elasticsearch/xpack/vectortile/VectorTileRestIT.java
@@ -31,11 +31,14 @@ import org.junit.Before;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
 import java.util.List;
 
 /**
- * Rest test for _mvt end point. The test only check that the structure of the vector tiles is sound in
- * respect to the number of layers returned and the number of features abd tags in each layer.
+ * Rest test for _mvt end point. The tests only check that the structure of the vector tiles is sound in
+ * respect to the number of layers returned and the number of features and tags in each layer.
  */
 public class VectorTileRestIT extends ESRestTestCase {
 
@@ -315,6 +318,62 @@ public class VectorTileRestIT extends ESRestTestCase {
             final ResponseException ex = expectThrows(ResponseException.class, () -> execute(mvtRequest));
             assertThat(ex.getResponse().getStatusLine().getStatusCode(), Matchers.equalTo(HttpStatus.SC_BAD_REQUEST));
         }
+    }
+
+    public void testWithLabels() throws Exception {
+        {
+            final Request mvtRequest = new Request(getHttpMethod(), INDEX_POINTS + "/_mvt/location/" + z + "/" + x + "/" + y);
+            mvtRequest.setJsonEntity("{\"size\" : 100, \"with_labels\": true }");
+            final VectorTile.Tile tile = execute(mvtRequest);
+            assertThat(tile.getLayersCount(), Matchers.equalTo(3));
+            // CHeck that double the points are returned (one extra label position for each point)
+            assertLayer(tile, HITS_LAYER, 4096, 66, 4, "_id", "_index", "__EsIsLabelFeature", "_mvt_label_positions");
+            assertLayer(tile, AGGS_LAYER, 4096, 1, 2);
+            assertLayer(tile, META_LAYER, 4096, 1, 13);
+            // Check that features exist for label positions
+            assertFeatureTags(tile, HITS_LAYER, 0, "_id", "_index");
+            assertFeatureTags(tile, HITS_LAYER, 1, "_id", "__EsIsLabelFeature");
+            assertFeatureTags(tile, HITS_LAYER, 64, "_id", "_index");
+            assertFeatureTags(tile, HITS_LAYER, 65, "_id", "__EsIsLabelFeature");
+        }
+    }
+
+    public void testBasicShapeWithLabels() throws Exception {
+        final Request mvtRequest = new Request(getHttpMethod(), INDEX_POLYGON + "/_mvt/location/" + z + "/" + x + "/" + y);
+        mvtRequest.setJsonEntity("{\"with_labels\": true }");
+        final VectorTile.Tile tile = execute(mvtRequest);
+        assertThat(tile.getLayersCount(), Matchers.equalTo(3));
+        // Check that there is an extra feature returned, a point label position
+        assertLayer(tile, HITS_LAYER, 4096, 2, 4, "_id", "_index", "__EsIsLabelFeature", "_mvt_label_positions");
+        assertLayer(tile, AGGS_LAYER, 4096, 256 * 256, 2);
+        assertLayer(tile, META_LAYER, 4096, 1, 13);
+        assertStringTag(getLayer(tile, HITS_LAYER), getLayer(tile, HITS_LAYER).getFeatures(0), "_index", INDEX_POLYGON);
+        assertStringTag(getLayer(tile, HITS_LAYER), getLayer(tile, HITS_LAYER).getFeatures(0), "_id", "polygon");
+        // Check that the polygon and label features have the right tags
+        assertFeatureTags(tile, HITS_LAYER, 0, "_id", "_index");
+        assertFeatureTags(tile, HITS_LAYER, 1, "_id", "__EsIsLabelFeature");
+    }
+
+    public void testMultipolygonWithLabels() throws Exception {
+        final String index = "multipolygon";
+        final Rectangle r1 = new Rectangle(-10, -5, 10, -10);
+        final Rectangle r2 = new Rectangle(5, 10, 10, -10);
+        // Centroid should be outside both polygons, and around 0,0
+        createIndexAndPutGeometry(index, new MultiPolygon(List.of(toPolygon(r1), toPolygon(r2))), "multi_polygon");
+        final Request mvtRequest = new Request(getHttpMethod(), index + "/_mvt/location/0/0/0?grid_precision=1");
+        mvtRequest.setJsonEntity("{\"with_labels\": true }");
+        final VectorTile.Tile tile = execute(mvtRequest);
+        assertThat(tile.getLayersCount(), Matchers.equalTo(3));
+        assertLayer(tile, HITS_LAYER, 4096, 2, 4);
+        assertLayer(tile, AGGS_LAYER, 4096, 2 * 2, 2);
+        assertLayer(tile, META_LAYER, 4096, 1, 13);
+        assertStringTag(getLayer(tile, HITS_LAYER), getLayer(tile, HITS_LAYER).getFeatures(0), "_index", index);
+        assertStringTag(getLayer(tile, HITS_LAYER), getLayer(tile, HITS_LAYER).getFeatures(0), "_id", "multi_polygon");
+        // Check that the polygon and label features have the right tags
+        assertFeatureTags(tile, HITS_LAYER, 0, "_id", "_index");
+        assertFeatureTags(tile, HITS_LAYER, 1, "_id", "__EsIsLabelFeature");
+        final Response response = client().performRequest(new Request(HttpDelete.METHOD_NAME, index));
+        assertThat(response.getStatusLine().getStatusCode(), Matchers.equalTo(HttpStatus.SC_OK));
     }
 
     public void testGeoTileGrid() throws Exception {
@@ -715,8 +774,8 @@ public class VectorTileRestIT extends ESRestTestCase {
     }
 
     public void testOverlappingMultipolygon() throws Exception {
-        // Overlapping multipolygon are accepted by Elasticsearch but is invalid for JTS. This
-        // causes and error in the mvt library that gets logged using slf4j
+        // Overlapping multipolygon are accepted by Elasticsearch but is invalid for JTS.
+        // This causes an error in the mvt library that gets logged using slf4j
         final String index = "overlapping_multipolygon";
         final Rectangle r1 = new Rectangle(-160, 160, 80, -80);
         final Rectangle r2 = new Rectangle(-159, 161, 79, -81);
@@ -742,11 +801,41 @@ public class VectorTileRestIT extends ESRestTestCase {
         }
     }
 
-    private void assertLayer(VectorTile.Tile tile, String name, int extent, int numFeatures, int numTags) {
+    private void assertFeatureTags(VectorTile.Tile tile, String name, int featureIndex, String... tags) {
         final VectorTile.Tile.Layer layer = getLayer(tile, name);
-        assertThat(layer.getExtent(), Matchers.equalTo(extent));
-        assertThat(layer.getFeaturesCount(), Matchers.equalTo(numFeatures));
-        assertThat(layer.getKeysCount(), Matchers.equalTo(numTags));
+        VectorTile.Tile.Feature feature = layer.getFeatures(featureIndex);
+        for (String tag : tags) {
+            boolean found = false;
+            ArrayList<String> featureTags = new ArrayList<>();
+            for (int i = 0; i < feature.getTagsCount(); i += 2) {
+                String key = layer.getKeys(feature.getTags(i));
+                VectorTile.Tile.Value value = layer.getValues(feature.getTags(i + 1));
+                featureTags.add(key + "=" + value.toString().trim());
+                if (tag.equals(key)) {
+                    found = true;
+                }
+            }
+            assertTrue(
+                "Feature " + featureIndex + " did not contain expected tag " + tag + " but contained instead: " + featureTags,
+                found
+            );
+        }
+        assertThat("Feature " + featureIndex + " tag count does not match", feature.getTagsCount(), Matchers.equalTo(2 * tags.length));
+    }
+
+    private void assertLayer(VectorTile.Tile tile, String name, int extent, int numFeatures, int numTags, String... tags) {
+        final VectorTile.Tile.Layer layer = getLayer(tile, name);
+        assertThat("Layer " + name + " extent does not match", layer.getExtent(), Matchers.equalTo(extent));
+        assertThat("Layer " + name + " feature count does not match", layer.getFeaturesCount(), Matchers.equalTo(numFeatures));
+        assertThat("Layer " + name + " tag count does not match", layer.getKeysCount(), Matchers.equalTo(numTags));
+        if (tags.length > 0) {
+            HashSet<String> expected = new HashSet<>();
+            Arrays.stream(tags).forEach(t -> expected.add(t));
+            for (int i = 0; i < layer.getKeysCount(); i++) {
+                String key = layer.getKeys(i);
+                assertTrue("Expected layer to contain tag " + key, expected.contains(key));
+            }
+        }
     }
 
     private void assertSintTag(VectorTile.Tile.Layer layer, VectorTile.Tile.Feature feature, String tag, long value) {

--- a/x-pack/plugin/vector-tile/src/main/java/org/elasticsearch/xpack/vectortile/rest/RestVectorTileAction.java
+++ b/x-pack/plugin/vector-tile/src/main/java/org/elasticsearch/xpack/vectortile/rest/RestVectorTileAction.java
@@ -351,7 +351,7 @@ public class RestVectorTileAction extends BaseRestHandler {
                 featureBuilder.clear();
                 GeoPoint labelPos = (GeoPoint) bucket.getKey();
                 byte[] labelPosFeature = featureFactory.point(labelPos.lon(), labelPos.lat());
-                if (labelPosFeature != null && labelPosFeature.length == 0) {
+                if (labelPosFeature != null && labelPosFeature.length != 0) {
                     featureBuilder.mergeFrom(labelPosFeature);
                     VectorTileUtils.addPropertyToFeature(featureBuilder, layerProps, KEY_TAG, bucketKey);
                     VectorTileUtils.addPropertyToFeature(featureBuilder, layerProps, LABEL_POSITION_TAG, true);

--- a/x-pack/plugin/vector-tile/src/main/java/org/elasticsearch/xpack/vectortile/rest/VectorTileRequest.java
+++ b/x-pack/plugin/vector-tile/src/main/java/org/elasticsearch/xpack/vectortile/rest/VectorTileRequest.java
@@ -58,6 +58,7 @@ class VectorTileRequest {
     protected static final ParseField EXTENT_FIELD = new ParseField("extent");
     protected static final ParseField BUFFER_FIELD = new ParseField("buffer");
     protected static final ParseField EXACT_BOUNDS_FIELD = new ParseField("exact_bounds");
+    protected static final ParseField WITH_LABELS_FIELD = new ParseField("with_labels");
 
     protected static class Defaults {
         public static final int SIZE = 10000;
@@ -71,6 +72,7 @@ class VectorTileRequest {
         public static final int EXTENT = SimpleVectorTileFormatter.DEFAULT_EXTENT;
         public static final int BUFFER = SimpleVectorTileFormatter.DEFAULT_BUFFER_PIXELS;
         public static final boolean EXACT_BOUNDS = false;
+        public static final boolean WITH_LABELS = false;
         public static final int TRACK_TOTAL_HITS_UP_TO = DEFAULT_TRACK_TOTAL_HITS_UP_TO;
     }
 
@@ -117,6 +119,7 @@ class VectorTileRequest {
         PARSER.declareInt(VectorTileRequest::setExtent, EXTENT_FIELD);
         PARSER.declareInt(VectorTileRequest::setBuffer, BUFFER_FIELD);
         PARSER.declareBoolean(VectorTileRequest::setExactBounds, EXACT_BOUNDS_FIELD);
+        PARSER.declareBoolean(VectorTileRequest::setWithLabels, WITH_LABELS_FIELD);
         PARSER.declareField(VectorTileRequest::setTrackTotalHitsUpTo, (p) -> {
             XContentParser.Token token = p.currentToken();
             if (token == XContentParser.Token.VALUE_BOOLEAN
@@ -164,6 +167,9 @@ class VectorTileRequest {
         if (restRequest.hasParam(EXACT_BOUNDS_FIELD.getPreferredName())) {
             request.setExactBounds(restRequest.paramAsBoolean(EXACT_BOUNDS_FIELD.getPreferredName(), Defaults.EXACT_BOUNDS));
         }
+        if (restRequest.hasParam(WITH_LABELS_FIELD.getPreferredName())) {
+            request.setWithLabels(restRequest.paramAsBoolean(WITH_LABELS_FIELD.getPreferredName(), Defaults.WITH_LABELS));
+        }
         if (restRequest.hasParam(SearchSourceBuilder.TRACK_TOTAL_HITS_FIELD.getPreferredName())) {
             if (Booleans.isBoolean(restRequest.param(SearchSourceBuilder.TRACK_TOTAL_HITS_FIELD.getPreferredName()))) {
                 if (restRequest.paramAsBoolean(SearchSourceBuilder.TRACK_TOTAL_HITS_FIELD.getPreferredName(), true)) {
@@ -206,6 +212,7 @@ class VectorTileRequest {
     private List<FieldAndFormat> fields = Defaults.FETCH;
     private List<SortBuilder<?>> sortBuilders;
     private boolean exact_bounds = Defaults.EXACT_BOUNDS;
+    private boolean with_labels = Defaults.WITH_LABELS;
     private int trackTotalHitsUpTo = Defaults.TRACK_TOTAL_HITS_UP_TO;
 
     private VectorTileRequest(String[] indexes, String field, int z, int x, int y) {
@@ -270,6 +277,14 @@ class VectorTileRequest {
 
     private void setExactBounds(boolean exact_bounds) {
         this.exact_bounds = exact_bounds;
+    }
+
+    public boolean getWithLabels() {
+        return with_labels;
+    }
+
+    private void setWithLabels(boolean with_labels) {
+        this.with_labels = with_labels;
     }
 
     public List<FieldAndFormat> getFieldAndFormats() {

--- a/x-pack/plugin/vector-tile/src/test/java/org/elasticsearch/xpack/vectortile/rest/VectorTileRequestTests.java
+++ b/x-pack/plugin/vector-tile/src/test/java/org/elasticsearch/xpack/vectortile/rest/VectorTileRequestTests.java
@@ -57,6 +57,7 @@ public class VectorTileRequestTests extends ESTestCase {
             assertThat(vectorTileRequest.getGridType(), Matchers.equalTo(VectorTileRequest.Defaults.GRID_TYPE));
             assertThat(vectorTileRequest.getGridPrecision(), Matchers.equalTo(VectorTileRequest.Defaults.GRID_PRECISION));
             assertThat(vectorTileRequest.getExactBounds(), Matchers.equalTo(VectorTileRequest.Defaults.EXACT_BOUNDS));
+            assertThat(vectorTileRequest.getWithLabels(), Matchers.equalTo(VectorTileRequest.Defaults.WITH_LABELS));
             assertThat(vectorTileRequest.getRuntimeMappings(), Matchers.equalTo(VectorTileRequest.Defaults.RUNTIME_MAPPINGS));
             assertThat(vectorTileRequest.getQueryBuilder(), Matchers.equalTo(VectorTileRequest.Defaults.QUERY));
             assertThat(vectorTileRequest.getTrackTotalHitsUpTo(), Matchers.equalTo(VectorTileRequest.Defaults.TRACK_TOTAL_HITS_UP_TO));
@@ -150,6 +151,14 @@ public class VectorTileRequestTests extends ESTestCase {
         assertRestRequest(
             (builder) -> builder.field(VectorTileRequest.EXACT_BOUNDS_FIELD.getPreferredName(), exactBounds),
             (vectorTileRequest) -> assertThat(vectorTileRequest.getExactBounds(), Matchers.equalTo(exactBounds))
+        );
+    }
+
+    public void testWithLabels() throws IOException {
+        final boolean withLabels = randomBoolean();
+        assertRestRequest(
+            (builder) -> builder.field(VectorTileRequest.WITH_LABELS_FIELD.getPreferredName(), withLabels),
+            (vectorTileRequest) -> assertThat(vectorTileRequest.getWithLabels(), Matchers.equalTo(withLabels))
         );
     }
 


### PR DESCRIPTION
There is a need to provide sensibly calculated label positions for polygons and lines in Kibana maps (as requested in https://github.com/elastic/elasticsearch/issues/86044). A very convenient way to satisfy this need is through a runtime field that the rest API can make use of when labels are requested. This has the advantage of providing painless access to the label position as well.

Building onto https://github.com/elastic/elasticsearch/pull/86154, this PR adds support for the REST API to provide label positions to MVT queries, both for the HITS layer and the AGGS layer. To enable this feature, set `with_labels` to `true` as a query parameter to the vector tile search query.

Closes #86044