### PR TITLE
Faster RoutingTable Builder

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/routing/RoutingTable.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/RoutingTable.java
@@ -399,17 +399,15 @@ public class RoutingTable implements Iterable<IndexRoutingTable>, Diffable<Routi
     public static class Builder {
 
         private long version;
-        private ImmutableOpenMap.Builder<String, IndexRoutingTable> indicesRouting = ImmutableOpenMap.builder();
+        private ImmutableOpenMap.Builder<String, IndexRoutingTable> indicesRouting;
 
         public Builder() {
-
+            indicesRouting = ImmutableOpenMap.builder();
         }
 
         public Builder(RoutingTable routingTable) {
             version = routingTable.version;
-            for (IndexRoutingTable indexRoutingTable : routingTable) {
-                indicesRouting.put(indexRoutingTable.getIndex().getName(), indexRoutingTable);
-            }
+            indicesRouting = ImmutableOpenMap.builder(routingTable.indicesRouting);
         }
 
         public Builder updateNodes(long version, RoutingNodes routingNodes) {


### PR DESCRIPTION
Copying the map one by one gets very expensive for large tables
=> leveraging the faster copy constructor that clones the map
internally gives a non-trivial speedup to many shards benchmark
bootstrapping.

relates #77466 