### PR TITLE
Fix min node version before state recovery

### DIFF
--- a/docs/changelog/86482.yaml
+++ b/docs/changelog/86482.yaml
@@ -1,0 +1,5 @@
+pr: 86482
+summary: Fix min node version before state recovery
+area: Infra/REST API
+type: bug
+issues: []

--- a/server/src/internalClusterTest/java/org/elasticsearch/cluster/coordination/RestHandlerNodesIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/cluster/coordination/RestHandlerNodesIT.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.cluster.coordination;
+
+import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
+import org.elasticsearch.cluster.node.DiscoveryNodes;
+import org.elasticsearch.common.settings.ClusterSettings;
+import org.elasticsearch.common.settings.IndexScopedSettings;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.settings.SettingsFilter;
+import org.elasticsearch.plugins.ActionPlugin;
+import org.elasticsearch.plugins.Plugin;
+import org.elasticsearch.plugins.PluginsService;
+import org.elasticsearch.rest.RestController;
+import org.elasticsearch.rest.RestHandler;
+import org.elasticsearch.test.ESIntegTestCase;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.function.Supplier;
+
+import static org.elasticsearch.node.Node.INITIAL_STATE_TIMEOUT_SETTING;
+import static org.hamcrest.Matchers.equalTo;
+
+@ESIntegTestCase.ClusterScope(scope = ESIntegTestCase.Scope.TEST, numDataNodes = 0, autoManageMasterNodes = false)
+public class RestHandlerNodesIT extends ESIntegTestCase {
+
+    public static class TestPlugin extends Plugin implements ActionPlugin {
+
+        volatile Supplier<DiscoveryNodes> nodesInCluster;
+
+        @Override
+        public List<RestHandler> getRestHandlers(
+            Settings settings,
+            RestController restController,
+            ClusterSettings clusterSettings,
+            IndexScopedSettings indexScopedSettings,
+            SettingsFilter settingsFilter,
+            IndexNameExpressionResolver indexNameExpressionResolver,
+            Supplier<DiscoveryNodes> nodesInCluster
+        ) {
+            this.nodesInCluster = nodesInCluster;
+            return List.of();
+        }
+    }
+
+    @Override
+    protected Settings nodeSettings(int nodeOrdinal, Settings otherSettings) {
+        return Settings.builder()
+            .put(super.nodeSettings(nodeOrdinal, otherSettings))
+            .put(INITIAL_STATE_TIMEOUT_SETTING.getKey(), "0")
+            .build();
+    }
+
+    @Override
+    protected Collection<Class<? extends Plugin>> nodePlugins() {
+        return List.of(TestPlugin.class);
+    }
+
+    public void testNodesExposedToRestHandler() {
+        internalCluster().setBootstrapMasterNodeIndex(0);
+        internalCluster().startDataOnlyNode();
+
+        final var dataNodeSupplier = internalCluster().getInstance(PluginsService.class)
+            .filterPlugins(TestPlugin.class)
+            .get(0).nodesInCluster;
+
+        assertEquals(DiscoveryNodes.EMPTY_NODES, dataNodeSupplier.get());
+
+        internalCluster().startMasterOnlyNode();
+        internalCluster().validateClusterFormed();
+
+        final var masterNodeSupplier = internalCluster().getCurrentMasterNodeInstance(PluginsService.class)
+            .filterPlugins(TestPlugin.class)
+            .get(0).nodesInCluster;
+
+        assertThat(dataNodeSupplier.get().size(), equalTo(2));
+        assertThat(masterNodeSupplier.get().size(), equalTo(2));
+
+        internalCluster().startNode();
+        internalCluster().validateClusterFormed();
+
+        assertThat(dataNodeSupplier.get().size(), equalTo(3));
+        assertThat(masterNodeSupplier.get().size(), equalTo(3));
+    }
+
+}

--- a/server/src/main/java/org/elasticsearch/cluster/ClusterState.java
+++ b/server/src/main/java/org/elasticsearch/cluster/ClusterState.java
@@ -56,6 +56,8 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.function.Consumer;
 
+import static org.elasticsearch.gateway.GatewayService.STATE_NOT_RECOVERED_BLOCK;
+
 /**
  * Represents the state of the cluster, held in memory on all nodes in the cluster with updates coordinated by the elected master.
  * <p>
@@ -238,6 +240,17 @@ public class ClusterState implements ToXContentFragment, Diffable<ClusterState> 
 
     public DiscoveryNodes getNodes() {
         return nodes();
+    }
+
+    /**
+     * Returns the set of nodes that should be exposed to things like REST handlers that behave differently depending on the nodes in the
+     * cluster and their versions. Specifically, if the cluster has properly formed then this is the nodes in the last-applied cluster
+     * state, but if the cluster has not properly formed then no nodes are returned.
+     *
+     * @return the nodes in the cluster if the cluster has properly formed, otherwise an empty set of nodes.
+     */
+    public DiscoveryNodes nodesIfRecovered() {
+        return blocks.hasGlobalBlock(STATE_NOT_RECOVERED_BLOCK) ? DiscoveryNodes.EMPTY_NODES : nodes;
     }
 
     public Metadata metadata() {

--- a/server/src/main/java/org/elasticsearch/cluster/node/DiscoveryNodes.java
+++ b/server/src/main/java/org/elasticsearch/cluster/node/DiscoveryNodes.java
@@ -748,7 +748,7 @@ public class DiscoveryNodes extends AbstractCollection<DiscoveryNode> implements
                 localNodeId,
                 minNonClientNodeVersion == null ? Version.CURRENT : minNonClientNodeVersion,
                 maxNodeVersion == null ? Version.CURRENT : maxNodeVersion,
-                minNodeVersion == null ? Version.CURRENT : minNodeVersion
+                minNodeVersion == null ? Version.CURRENT.minimumCompatibilityVersion() : minNodeVersion
             );
         }
 

--- a/server/src/main/java/org/elasticsearch/node/Node.java
+++ b/server/src/main/java/org/elasticsearch/node/Node.java
@@ -1025,7 +1025,7 @@ public class Node implements Closeable {
             this.namedXContentRegistry = xContentRegistry;
 
             logger.debug("initializing HTTP handlers ...");
-            actionModule.initRestHandlers(() -> clusterService.state().nodes());
+            actionModule.initRestHandlers(() -> clusterService.state().nodesIfRecovered());
             logger.info("initialized");
 
             success = true;

--- a/server/src/test/java/org/elasticsearch/cluster/ClusterStateTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/ClusterStateTests.java
@@ -31,6 +31,7 @@ import org.elasticsearch.common.collect.ImmutableOpenMap;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.transport.TransportAddress;
 import org.elasticsearch.common.xcontent.XContentHelper;
+import org.elasticsearch.gateway.GatewayService;
 import org.elasticsearch.index.Index;
 import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.rest.RestStatus;
@@ -954,5 +955,18 @@ public class ClusterStateTests extends ESTestCase {
                     .build()
             )
             .build();
+    }
+
+    public void testNodesIfRecovered() throws IOException {
+        final var initialState = buildClusterState();
+
+        final var recoveredState = ClusterState.builder(initialState).blocks(ClusterBlocks.EMPTY_CLUSTER_BLOCK).build();
+        assertEquals(1, recoveredState.nodes().size());
+        assertEquals(recoveredState.nodes(), recoveredState.nodesIfRecovered());
+
+        final var notRecoveredState = ClusterState.builder(initialState)
+            .blocks(ClusterBlocks.builder().addGlobalBlock(GatewayService.STATE_NOT_RECOVERED_BLOCK))
+            .build();
+        assertEquals(DiscoveryNodes.EMPTY_NODES, notRecoveredState.nodesIfRecovered());
     }
 }

--- a/server/src/test/java/org/elasticsearch/cluster/node/DiscoveryNodesTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/node/DiscoveryNodesTests.java
@@ -389,6 +389,9 @@ public class DiscoveryNodesTests extends ESTestCase {
     }
 
     public void testMaxMinNodeVersion() {
+        assertEquals(Version.CURRENT, DiscoveryNodes.EMPTY_NODES.getMaxNodeVersion());
+        assertEquals(Version.CURRENT.minimumCompatibilityVersion(), DiscoveryNodes.EMPTY_NODES.getMinNodeVersion());
+
         DiscoveryNodes.Builder discoBuilder = DiscoveryNodes.builder();
         discoBuilder.add(
             new DiscoveryNode(


### PR DESCRIPTION
We use the minimum node version in the cluster state to make decisions
about backwards compatibility (e.g. to choose newer actions in the REST
layer only if all nodes will support it). Once the cluster is fully
formed we reject attempts by older nodes to join the cluster so that the
minimum node version only ever increases, which makes
backwards-compatibility decisions safe.

However, it's possible that the REST layer will make decisions about
backwards compatibility before the cluster is fully formed. In this
state, older nodes may still join the cluster and may therefore see
actions that they do not understand.

With this commit we report no nodes to the REST layer until the cluster
is fully-formed, and change the minimum node version in an empty cluster
to be the minimum compatible version. This means the REST layer will
operate in a maximally-compatible mode until the cluster is formed.

Relates #86405