### PR TITLE
Unmute some monitoring tests

### DIFF
--- a/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/action/TransportMonitoringMigrateAlertsActionTests.java
+++ b/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/action/TransportMonitoringMigrateAlertsActionTests.java
@@ -214,7 +214,6 @@ public class TransportMonitoringMigrateAlertsActionTests extends MonitoringInteg
         }
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/66586")
     public void testDisabledLocalExporterAlertsRemoval() throws Exception {
         try {
             // start monitoring service
@@ -259,7 +258,6 @@ public class TransportMonitoringMigrateAlertsActionTests extends MonitoringInteg
         }
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/66586")
     public void testLocalExporterWithAlertingDisabled() throws Exception {
         try {
             // start monitoring service

--- a/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/exporter/local/LocalExporterResourceIntegTests.java
+++ b/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/exporter/local/LocalExporterResourceIntegTests.java
@@ -6,7 +6,6 @@
  */
 package org.elasticsearch.xpack.monitoring.exporter.local;
 
-import org.apache.lucene.util.Constants;
 import org.elasticsearch.Version;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.cluster.ClusterState;
@@ -66,7 +65,6 @@ public class LocalExporterResourceIntegTests extends LocalExporterIntegTestCase 
     );
 
     public void testCreateWhenResourcesNeedToBeAddedOrUpdated() throws Exception {
-        assumeFalse("https://github.com/elastic/elasticsearch/issues/68608", Constants.MAC_OS_X);
         // sometimes they need to be added; sometimes they need to be replaced
         if (randomBoolean()) {
             putResources(oldVersion());


### PR DESCRIPTION
#68608 is closeable -- we don't have darwin builds in CI anymore, so no need to solve test failures that only come up during darwin builds.

#66586 has been closed, so I think it's fair to unmute the tests that say they're waiting on that ticket.

Of course, if it turns out that these do need to be re-muted because they still fail, well, that's easy to do and we'll benefit from having more recent failure data to investigate.