### PR TITLE
Fix log message in JwtRealmGenerateTests for printing test ES-Client-Authentication header values

### DIFF
--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/jwt/JwtRealmGenerateTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/jwt/JwtRealmGenerateTests.java
@@ -415,7 +415,14 @@ public class JwtRealmGenerateTests extends JwtRealmTestCase {
             JwtRealmGenerateTests.printIssuerSettings(jwtIssuer)
                 + JwtRealmGenerateTests.printRealmSettings(config)
                 + "\n===\nRequest Headers\n===\n"
-                + (Strings.hasText(clientSecret) ? JwtRealm.HEADER_CLIENT_AUTHENTICATION + ": " + clientSecret + "\n" : "")
+                + (Strings.hasText(clientSecret)
+                    ? JwtRealm.HEADER_CLIENT_AUTHENTICATION
+                        + ": "
+                        + JwtRealm.HEADER_SHARED_SECRET_AUTHENTICATION_SCHEME
+                        + " "
+                        + clientSecret
+                        + "\n"
+                    : "")
                 + JwtRealm.HEADER_END_USER_AUTHENTICATION
                 + ": "
                 + jwt


### PR DESCRIPTION
This PR adds the missing value in a log message. It is not a functional change.

The tests in JwtRealmGenerateTests generate an example JWT issuer and use it to issue a JWT. The teams also create a JWT realm, and use the JWT to run an authentication test against the realm. At the end of the test, the issuer settings, realm settings, JWT contents, and request headers are printed.

The value for the request header ES-Client-Authentication should look like this.
```
ES-Client-Authentication: SharedSecret client-shared-secret-string
```

The test was printing this, with a missing value. Manually copying the generated examples to Elasticsearch and running it fails.
```
ES-Client-Authentication: client-shared-secret-string
```