### PR TITLE
[DOCS] Add preview admonition to infer API

### DIFF
--- a/docs/reference/ml/trained-models/apis/infer-trained-model-deployment.asciidoc
+++ b/docs/reference/ml/trained-models/apis/infer-trained-model-deployment.asciidoc
@@ -8,6 +8,8 @@
 
 Evaluates a trained model.
 
+preview::[]
+
 [[infer-trained-model-deployment-request]]
 == {api-request-title}
 
@@ -38,7 +40,7 @@ include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=model-id]
 (Optional, time)
 Controls the amount of time to wait for {infer} results. Defaults to 10 seconds.
 
-[[infer-trained-model-request-body]]
+[[infer-trained-model-deployment-request-body]]
 == {api-request-body-title}
 
 `docs`::

--- a/docs/reference/ml/trained-models/apis/infer-trained-model-deployment.asciidoc
+++ b/docs/reference/ml/trained-models/apis/infer-trained-model-deployment.asciidoc
@@ -10,7 +10,6 @@ Evaluates a trained model.
 
 deprecated::[8.3.0,Replaced by <<infer-trained-model>>.]
 
-
 [[infer-trained-model-deployment-request]]
 == {api-request-title}
 

--- a/docs/reference/ml/trained-models/apis/infer-trained-model.asciidoc
+++ b/docs/reference/ml/trained-models/apis/infer-trained-model.asciidoc
@@ -8,6 +8,8 @@
 
 Evaluates a trained model. The model may be any supervised model either trained by {dfanalytics} or imported.
 
+preview::[]
+
 [[infer-trained-model-request]]
 == {api-request-title}
 

--- a/docs/reference/ml/trained-models/apis/put-trained-model-definition-part.asciidoc
+++ b/docs/reference/ml/trained-models/apis/put-trained-model-definition-part.asciidoc
@@ -6,9 +6,9 @@
 <titleabbrev>Create part of a trained model</titleabbrev>
 ++++
 
-experimental::[]
-
 Creates part of a trained model definition.
+
+preview::[]
 
 [[ml-put-trained-model-definition-part-request]]
 == {api-request-title}

--- a/docs/reference/ml/trained-models/apis/put-trained-model-vocabulary.asciidoc
+++ b/docs/reference/ml/trained-models/apis/put-trained-model-vocabulary.asciidoc
@@ -9,7 +9,7 @@
 Creates a trained model vocabulary.
 This is supported only for natural language processing (NLP) models.
 
-experimental::[]
+preview::[]
 
 [[ml-put-trained-model-vocabulary-request]]
 == {api-request-title}

--- a/docs/reference/ml/trained-models/apis/start-trained-model-deployment.asciidoc
+++ b/docs/reference/ml/trained-models/apis/start-trained-model-deployment.asciidoc
@@ -6,9 +6,9 @@
 <titleabbrev>Start trained model deployment</titleabbrev>
 ++++
 
-experimental::[]
-
 Starts a new trained model deployment.
+
+preview::[]
 
 [[start-trained-model-deployment-request]]
 == {api-request-title}

--- a/docs/reference/ml/trained-models/apis/stop-trained-model-deployment.asciidoc
+++ b/docs/reference/ml/trained-models/apis/stop-trained-model-deployment.asciidoc
@@ -6,9 +6,9 @@
 <titleabbrev>Stop trained model deployment</titleabbrev>
 ++++
 
-experimental::[]
-
 Stops a trained model deployment.
+
+preview::[]
 
 [[stop-trained-model-deployment-request]]
 == {api-request-title}


### PR DESCRIPTION
This PR updates the [infer trained model API](https://www.elastic.co/guide/en/elasticsearch/reference/master/infer-trained-model.html) to match the API [specification](https://github.com/elastic/elasticsearch/blob/master/rest-api-spec/src/main/resources/rest-api-spec/api/ml.infer_trained_model_deployment.json), in particular with respect to its "stability" value.

It also updates the other trained model APIs to use the new "preview" admonition instead of the "experimental" admonition.

### Preview

https://elasticsearch_86486.docs-preview.app.elstc.co/diff