### PR TITLE
Remove failing test which mocked now sealed InetAddress class

### DIFF
--- a/x-pack/plugin/security/cli/src/test/java/org/elasticsearch/xpack/security/cli/CertGenUtilsTests.java
+++ b/x-pack/plugin/security/cli/src/test/java/org/elasticsearch/xpack/security/cli/CertGenUtilsTests.java
@@ -34,10 +34,6 @@ import javax.security.auth.x500.X500Principal;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoMoreInteractions;
-import static org.mockito.Mockito.when;
 
 /**
  * Unit tests for cert utils
@@ -95,19 +91,6 @@ public class CertGenUtilsTests extends ESTestCase {
     private boolean isResolvable(InetAddress inetAddress) {
         String hostname = inetAddress.getHostName();
         return hostname.equals(inetAddress.getHostAddress()) == false;
-    }
-
-    public void testIsAnyLocalAddress() throws Exception {
-        InetAddress address = mock(InetAddress.class);
-        when(address.isAnyLocalAddress()).thenReturn(true);
-
-        GeneralNames generalNames = CertGenUtils.getSubjectAlternativeNames(randomBoolean(), Collections.singleton(address));
-        assertThat(generalNames, notNullValue());
-        GeneralName[] generalNameArray = generalNames.getNames();
-        assertThat(generalNameArray, notNullValue());
-
-        verify(address).isAnyLocalAddress();
-        verifyNoMoreInteractions(address);
     }
 
     public void testIssuerCertSubjectDN() throws Exception {


### PR DESCRIPTION
Removing `testIsAnyLocalAddress` because `InetAddress` class cannot be mocked anymore (well not without enabling experimental mockito plugin). The class is marked as sealed in Java 19.
`testIsAnyLocalAddress` was simply testing if `InetAddress#isAnyLocalAddress` method  was the only one called. Since this test is not adding particular value, I think removal is justified.

Closes #86418

