### PR TITLE
[DOCS] Removes infer trained model deployment API

### DIFF
--- a/docs/reference/ml/trained-models/apis/index.asciidoc
+++ b/docs/reference/ml/trained-models/apis/index.asciidoc
@@ -11,8 +11,7 @@ include::delete-trained-models.asciidoc[leveloffset=+2]
 include::get-trained-models.asciidoc[leveloffset=+2]
 include::get-trained-models-stats.asciidoc[leveloffset=+2]
 //INFER
-include::infer-trained-model.asciidoc[leveloffset=+2]
-include::infer-trained-model-deployment.asciidoc[leveloffset=+2]
+include::infer-trained-model.asciidoc[leveloffset=+2][leveloffset=+2]
 //START/STOP
 include::start-trained-model-deployment.asciidoc[leveloffset=+2]
 include::stop-trained-model-deployment.asciidoc[leveloffset=+2]

--- a/docs/reference/ml/trained-models/apis/ml-trained-models-apis.asciidoc
+++ b/docs/reference/ml/trained-models/apis/ml-trained-models-apis.asciidoc
@@ -13,7 +13,6 @@ You can use the following APIs to perform model management operations:
 * <<get-trained-models>>
 * <<get-trained-models-stats>>
 * <<infer-trained-model>>
-* <<infer-trained-model-deployment>> deprecated:[8.3.0]
 * <<start-trained-model-deployment>>
 * <<stop-trained-model-deployment>>
 

--- a/docs/reference/redirects.asciidoc
+++ b/docs/reference/redirects.asciidoc
@@ -72,7 +72,7 @@ See <<back-up-config-files>> and <<cluster-state-snapshots>>.
 // [END] Snapshot and restore
 
 [role="exclude",id="configuring-tls-docker"]
-== Encrypting communications in an {es} Docker Container
+=== Encrypting communications in an {es} Docker Container
 
 Refer to <<docker-compose-file,Starting a multi-node cluster with Docker Compose>>.
 
@@ -84,7 +84,7 @@ Refer to <<docker-compose-file,Starting a multi-node cluster with Docker Compose
 // [START] Remote clusters
 
 [role="exclude",id="ccs-clients-integrations"]
-== {ccs-cap}, clients, and integrations
+=== {ccs-cap}, clients, and integrations
 
 Refer to <<security-clients-integrations,Securing clients and integrations>>.
 

--- a/docs/reference/redirects.asciidoc
+++ b/docs/reference/redirects.asciidoc
@@ -1857,3 +1857,8 @@ include::redirects.asciidoc[tag=upgrade-reindex]
 
 For more information about reindexing from a remote cluster, refer to
 <<reindex-from-remote>>.
+
+[role="exclude",id="infer-trained-model-deployment"]
+=== Infer trained model deployment API
+
+See <<infer-trained-model>>.


### PR DESCRIPTION
Relates to https://github.com/elastic/elasticsearch/pull/86361

This PR removes the "infer trained model deployment" API reference. It temporarily adds redirects for https://www.elastic.co/guide/en/elasticsearch/reference/master/infer-trained-model-deployment.html, until the following dependencies are removed:

> 16:42:16 INFO:build_docs:Bad cross-document links:
16:42:16 INFO:build_docs:  /tmp/docsbuild/target_repo/html/en/elasticsearch/client/javascript-api/8.0/api-reference.html contains broken links to:
16:42:16 INFO:build_docs:   - en/elasticsearch/reference/master/infer-trained-model-deployment.html
16:42:16 INFO:build_docs:  /tmp/docsbuild/target_repo/html/en/elasticsearch/client/javascript-api/8.1/api-reference.html contains broken links to:
16:42:16 INFO:build_docs:   - en/elasticsearch/reference/master/infer-trained-model-deployment.html
16:42:16 INFO:build_docs:  /tmp/docsbuild/target_repo/html/en/elasticsearch/client/javascript-api/8.2/api-reference.html contains broken links to:
16:42:16 INFO:build_docs:   - en/elasticsearch/reference/master/infer-trained-model-deployment.html
16:42:16 INFO:build_docs:  /tmp/docsbuild/target_repo/html/en/elasticsearch/client/javascript-api/current/api-reference.html contains broken links to:
16:42:16 INFO:build_docs:   - en/elasticsearch/reference/master/infer-trained-model-deployment.html
16:42:16 INFO:build_docs:  /tmp/docsbuild/target_repo/html/en/elasticsearch/client/javascript-api/master/api-reference.html contains broken links to:
16:42:16 INFO:build_docs:   - en/elasticsearch/reference/master/infer-trained-model-deployment.html
16:42:16 INFO:build_docs:  /tmp/docsbuild/target_repo/html/en/machine-learning/master/ml-nlp-apis.html contains broken links to:
16:42:16 INFO:build_docs:   - en/elasticsearch/reference/master/infer-trained-model-deployment.html
16:42:16 INFO:build_docs:  /tmp/docsbuild/target_repo/html/en/machine-learning/master/ml-nlp-deploy-models.html contains broken links to:
16:42:16 INFO:build_docs:   - en/elasticsearch/reference/master/infer-trained-model-deployment.html

### Preview

https://elasticsearch_86497.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/infer-trained-model-deployment.html