### PR TITLE
Fix plugin command tests newline assertions

### DIFF
--- a/distribution/tools/plugin-cli/src/test/java/org/elasticsearch/plugins/cli/ListPluginsCommandTests.java
+++ b/distribution/tools/plugin-cli/src/test/java/org/elasticsearch/plugins/cli/ListPluginsCommandTests.java
@@ -27,7 +27,12 @@ import java.nio.file.Files;
 import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
 import java.util.Arrays;
+import java.util.List;
 import java.util.stream.Collectors;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.emptyString;
+import static org.hamcrest.Matchers.equalTo;
 
 @LuceneTestCase.SuppressFileSystems("*")
 public class ListPluginsCommandTests extends CommandTestCase {
@@ -226,18 +231,13 @@ public class ListPluginsCommandTests extends CommandTestCase {
 
         execute();
         String message = "plugin [fake_plugin1] was built for Elasticsearch version 1.0.0 but version " + Version.CURRENT + " is required";
-        assertEquals("""
-            fake_plugin1
-            fake_plugin2
-            """, terminal.getOutput());
-        assertEquals("WARNING: " + message + "\n", terminal.getErrorOutput());
+        assertThat(terminal.getOutput().lines().toList(), equalTo(List.of("fake_plugin1", "fake_plugin2")));
+        assertThat(terminal.getErrorOutput(), containsString("WARNING: " + message));
 
         terminal.reset();
         execute("-s");
-        assertEquals("""
-            fake_plugin1
-            fake_plugin2
-            """, terminal.getOutput());
+        assertThat(terminal.getOutput().lines().toList(), equalTo(List.of("fake_plugin1", "fake_plugin2")));
+        assertThat(terminal.getErrorOutput(), emptyString());
     }
 
     @Override


### PR DESCRIPTION
This commit fixes an edge case that fails on windows where extra
newlines do not match because of the difference in line endings.