### PR TITLE
[Transform] Support `range` aggregation in transform

### DIFF
--- a/docs/reference/rest-api/common-parms.asciidoc
+++ b/docs/reference/rest-api/common-parms.asciidoc
@@ -703,6 +703,7 @@ currently supported:
 * <<search-aggregations-metrics-min-aggregation,Min>>
 * <<search-aggregations-bucket-missing-aggregation,Missing>>
 * <<search-aggregations-metrics-percentile-aggregation,Percentiles>>
+* <<search-aggregations-bucket-range-aggregation,Range>>
 * <<search-aggregations-bucket-rare-terms-aggregation, Rare Terms>>
 * <<search-aggregations-metrics-scripted-metric-aggregation,Scripted metric>>
 * <<search-aggregations-metrics-stats-aggregation,Stats>>

--- a/x-pack/plugin/transform/qa/single-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/TransformPivotRestIT.java
+++ b/x-pack/plugin/transform/qa/single-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/TransformPivotRestIT.java
@@ -2026,14 +2026,14 @@ public class TransformPivotRestIT extends TransformRestTestCase {
                       "field": "stars"
                     }
                   },
-                  "simple-ranges": {
+                  "ranges": {
                     "range": {
                       "field": "stars",
                       "keyed": %s,
                       "ranges": [ { "to": 2 }, { "from": 2, "to": 3.99 }, { "from": 4 } ]
                     }
                   },
-                  "simple-ranges-with-avg": {
+                  "ranges-avg": {
                     "range": {
                       "field": "stars",
                       "keyed": %s,
@@ -2053,18 +2053,18 @@ public class TransformPivotRestIT extends TransformRestTestCase {
         // get and check some users
         Map<String, Object> searchResult = getAsMap(transformIndex + "/_search?q=reviewer:user_11");
         assertEquals(1, XContentMapValues.extractValue("hits.total.value", searchResult));
-        Number actual = (Number) ((List<?>) XContentMapValues.extractValue("hits.hits._source.simple-ranges.*-2", searchResult)).get(0);
+        Number actual = (Number) ((List<?>) XContentMapValues.extractValue("hits.hits._source.ranges.*-2", searchResult)).get(0);
         assertEquals(5, actual.longValue());
-        actual = (Number) ((List<?>) XContentMapValues.extractValue("hits.hits._source.simple-ranges.2-3_99", searchResult)).get(0);
+        actual = (Number) ((List<?>) XContentMapValues.extractValue("hits.hits._source.ranges.2-3_99", searchResult)).get(0);
         assertEquals(2, actual.longValue());
-        actual = (Number) ((List<?>) XContentMapValues.extractValue("hits.hits._source.simple-ranges.4-*", searchResult)).get(0);
+        actual = (Number) ((List<?>) XContentMapValues.extractValue("hits.hits._source.ranges.4-*", searchResult)).get(0);
         assertEquals(19, actual.longValue());
 
-        actual = (Number) ((List<?>) XContentMapValues.extractValue("hits.hits._source.simple-ranges-with-avg.*-2.avg_stars", searchResult)).get(0);
+        actual = (Number) ((List<?>) XContentMapValues.extractValue("hits.hits._source.ranges-avg.*-2.avg_stars", searchResult)).get(0);
         assertEquals(1.0, actual.doubleValue(), 1E-6);
-        actual = (Number) ((List<?>) XContentMapValues.extractValue("hits.hits._source.simple-ranges-with-avg.2-3_99.avg_stars", searchResult)).get(0);
+        actual = (Number) ((List<?>) XContentMapValues.extractValue("hits.hits._source.ranges-avg.2-3_99.avg_stars", searchResult)).get(0);
         assertEquals(3.0, actual.doubleValue(), 1E-6);
-        actual = (Number) ((List<?>) XContentMapValues.extractValue("hits.hits._source.simple-ranges-with-avg.4-*.avg_stars", searchResult)).get(0);
+        actual = (Number) ((List<?>) XContentMapValues.extractValue("hits.hits._source.ranges-avg.4-*.avg_stars", searchResult)).get(0);
         assertEquals(4.6842105, actual.doubleValue(), 1E-6);
     }
 

--- a/x-pack/plugin/transform/qa/single-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/TransformPivotRestIT.java
+++ b/x-pack/plugin/transform/qa/single-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/TransformPivotRestIT.java
@@ -2052,27 +2052,20 @@ public class TransformPivotRestIT extends TransformRestTestCase {
         startAndWaitForTransform(transformId, transformIndex);
         assertTrue(indexExists(transformIndex));
         // get and check some users
-        assertOnePivotValue(transformIndex + "/_search?q=reviewer:user_11", 3.846153846);
-        assertOnePivotValue(transformIndex + "/_search?q=reviewer:user_26", 3.918918918);
-
-        Map<String, Object> searchResult = getAsMap(transformIndex + "/_search?q=reviewer:user_4");
-
+        Map<String, Object> searchResult = getAsMap(transformIndex + "/_search?q=reviewer:user_11");
         assertEquals(1, XContentMapValues.extractValue("hits.total.value", searchResult));
         Number actual = (Number) ((List<?>) XContentMapValues.extractValue("hits.hits._source.r.*-2", searchResult)).get(0);
-        assertEquals(6, actual.longValue());
-        actual = (Number) ((List<?>) XContentMapValues.extractValue("hits.hits._source.r.2-3_99", searchResult)).get(0);
-        assertEquals(6, actual.longValue());
-        actual = (Number) ((List<?>) XContentMapValues.extractValue("hits.hits._source.r.4-*", searchResult)).get(0);
-        assertEquals(29, actual.longValue());
-
-        searchResult = getAsMap(transformIndex + "/_search?q=reviewer:user_11");
-        assertEquals(1, XContentMapValues.extractValue("hits.total.value", searchResult));
-        actual = (Number) ((List<?>) XContentMapValues.extractValue("hits.hits._source.r.*-2", searchResult)).get(0);
+        Number actualKeyed = (Number) ((List<?>) XContentMapValues.extractValue("hits.hits._source.r_keyed.*-2", searchResult)).get(0);
         assertEquals(5, actual.longValue());
+        assertEquals(5, actualKeyed.longValue());
         actual = (Number) ((List<?>) XContentMapValues.extractValue("hits.hits._source.r.2-3_99", searchResult)).get(0);
+        actualKeyed = (Number) ((List<?>) XContentMapValues.extractValue("hits.hits._source.r_keyed.2-3_99", searchResult)).get(0);
         assertEquals(2, actual.longValue());
+        assertEquals(2, actualKeyed.longValue());
         actual = (Number) ((List<?>) XContentMapValues.extractValue("hits.hits._source.r.4-*", searchResult)).get(0);
+        actualKeyed = (Number) ((List<?>) XContentMapValues.extractValue("hits.hits._source.r_keyed.4-*", searchResult)).get(0);
         assertEquals(19, actual.longValue());
+        assertEquals(19, actualKeyed.longValue());
     }
 
     public void testPivotWithFilter() throws Exception {

--- a/x-pack/plugin/transform/qa/single-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/TransformPivotRestIT.java
+++ b/x-pack/plugin/transform/qa/single-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/TransformPivotRestIT.java
@@ -9,7 +9,6 @@ package org.elasticsearch.xpack.transform.integration;
 
 import org.apache.http.entity.ContentType;
 import org.apache.http.entity.StringEntity;
-import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.client.Request;
 import org.elasticsearch.client.RequestOptions;
 import org.elasticsearch.client.Response;
@@ -17,7 +16,6 @@ import org.elasticsearch.client.ResponseException;
 import org.elasticsearch.client.WarningsHandler;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.xcontent.support.XContentMapValues;
-import org.elasticsearch.search.aggregations.bucket.range.RangeAggregationBuilder;
 import org.elasticsearch.xcontent.XContentBuilder;
 import org.junit.Before;
 

--- a/x-pack/plugin/transform/qa/single-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/TransformPivotRestIT.java
+++ b/x-pack/plugin/transform/qa/single-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/TransformPivotRestIT.java
@@ -2056,19 +2056,22 @@ public class TransformPivotRestIT extends TransformRestTestCase {
         Map<String, Object> mappingsResult = getAsMap(transformIndex + "/_mapping");
         assertThat(
             XContentMapValues.extractValue("range_pivot_reviews.mappings.properties.ranges.properties", mappingsResult),
-            is(equalTo(Map.of(
-                "4-*", Map.of("type", "long"),
-                "2-3_99", Map.of("type", "long"),
-                "*-2", Map.of("type", "long")
-            )))
+            is(equalTo(Map.of("4-*", Map.of("type", "long"), "2-3_99", Map.of("type", "long"), "*-2", Map.of("type", "long"))))
         );
         assertThat(
             XContentMapValues.extractValue("range_pivot_reviews.mappings.properties.ranges-avg.properties", mappingsResult),
-            is(equalTo(Map.of(
-                "4-*", Map.of("properties", Map.of("avg_stars", Map.of("type", "double"))),
-                "2-3_99", Map.of("properties", Map.of("avg_stars", Map.of("type", "double"))),
-                "*-2", Map.of("properties", Map.of("avg_stars", Map.of("type", "double")))
-            )))
+            is(
+                equalTo(
+                    Map.of(
+                        "4-*",
+                        Map.of("properties", Map.of("avg_stars", Map.of("type", "double"))),
+                        "2-3_99",
+                        Map.of("properties", Map.of("avg_stars", Map.of("type", "double"))),
+                        "*-2",
+                        Map.of("properties", Map.of("avg_stars", Map.of("type", "double")))
+                    )
+                )
+            )
         );
 
         // get and check some users

--- a/x-pack/plugin/transform/qa/single-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/TransformPivotRestIT.java
+++ b/x-pack/plugin/transform/qa/single-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/TransformPivotRestIT.java
@@ -9,6 +9,7 @@ package org.elasticsearch.xpack.transform.integration;
 
 import org.apache.http.entity.ContentType;
 import org.apache.http.entity.StringEntity;
+import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.client.Request;
 import org.elasticsearch.client.RequestOptions;
 import org.elasticsearch.client.Response;
@@ -16,6 +17,7 @@ import org.elasticsearch.client.ResponseException;
 import org.elasticsearch.client.WarningsHandler;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.xcontent.support.XContentMapValues;
+import org.elasticsearch.search.aggregations.bucket.range.RangeAggregationBuilder;
 import org.elasticsearch.xcontent.XContentBuilder;
 import org.junit.Before;
 
@@ -2029,6 +2031,14 @@ public class TransformPivotRestIT extends TransformRestTestCase {
                   "r": {
                     "range": {
                       "field": "stars",
+                      "keyed": false,
+                      "ranges": [ { "to": 2 }, { "from": 2, "to": 3.99 }, { "from": 4 } ]
+                    }
+                  },
+                  "r_keyed": {
+                    "range": {
+                      "field": "stars",
+                      "keyed": true,
                       "ranges": [ { "to": 2 }, { "from": 2, "to": 3.99 }, { "from": 4 } ]
                     }
                   }
@@ -2046,6 +2056,7 @@ public class TransformPivotRestIT extends TransformRestTestCase {
         assertOnePivotValue(transformIndex + "/_search?q=reviewer:user_26", 3.918918918);
 
         Map<String, Object> searchResult = getAsMap(transformIndex + "/_search?q=reviewer:user_4");
+
         assertEquals(1, XContentMapValues.extractValue("hits.total.value", searchResult));
         Number actual = (Number) ((List<?>) XContentMapValues.extractValue("hits.hits._source.r.*-2", searchResult)).get(0);
         assertEquals(6, actual.longValue());

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/pivot/AggregationResultUtils.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/pivot/AggregationResultUtils.java
@@ -355,13 +355,6 @@ public final class AggregationResultUtils {
         }
     }
 
-    static String generateKeyForRange(double from, double to) {
-        return new StringBuilder().append(Double.isInfinite(from) ? "*" : OutputFieldNameConverter.fromDouble(from))
-            .append("-")
-            .append(Double.isInfinite(to) ? "*" : OutputFieldNameConverter.fromDouble(to))
-            .toString();
-    }
-
     static class SingleBucketAggExtractor implements AggValueExtractor {
         @Override
         public Object value(Aggregation agg, Map<String, String> fieldTypeMap, String lookupFieldPrefix) {

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/pivot/TransformAggregations.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/pivot/TransformAggregations.java
@@ -222,7 +222,7 @@ public final class TransformAggregations {
             HashMap<String, String> outputTypes = new HashMap<>();
             HashMap<String, String> inputTypes = new HashMap<>();
             for (Range range : rangeAgg.ranges()) {
-                String fieldName = rangeAgg.getName() + "." + AggregationResultUtils.generateKeyForRange(range.getFrom(), range.getTo());
+                String fieldName = rangeAgg.getName() + "." + generateKeyForRange(range.getFrom(), range.getTo());
                 if (rangeAgg.getSubAggregations().isEmpty()) {
                     outputTypes.put(fieldName, AggregationType.RANGE.getName());
                     continue;
@@ -286,5 +286,13 @@ public final class TransformAggregations {
 
         // catch all in case no special handling required
         return new Tuple<>(Collections.emptyMap(), Collections.singletonMap(agg.getName(), agg.getType()));
+    }
+
+    // Visible for testing
+    static String generateKeyForRange(double from, double to) {
+        return new StringBuilder().append(Double.isInfinite(from) ? "*" : OutputFieldNameConverter.fromDouble(from))
+            .append("-")
+            .append(Double.isInfinite(to) ? "*" : OutputFieldNameConverter.fromDouble(to))
+            .toString();
     }
 }

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/pivot/TransformAggregations.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/pivot/TransformAggregations.java
@@ -10,6 +10,7 @@ package org.elasticsearch.xpack.transform.transforms.pivot;
 import org.elasticsearch.core.Tuple;
 import org.elasticsearch.search.aggregations.AggregationBuilder;
 import org.elasticsearch.search.aggregations.bucket.range.RangeAggregationBuilder;
+import org.elasticsearch.search.aggregations.bucket.range.RangeAggregator.Range;
 import org.elasticsearch.search.aggregations.metrics.PercentilesAggregationBuilder;
 import org.elasticsearch.search.aggregations.support.ValuesSourceAggregationBuilder;
 import org.elasticsearch.xpack.transform.utils.OutputFieldNameConverter;
@@ -112,7 +113,7 @@ public final class TransformAggregations {
         BUCKET_SELECTOR("bucket_selector", DYNAMIC),
         BUCKET_SCRIPT("bucket_script", DYNAMIC),
         PERCENTILES("percentiles", DOUBLE),
-        RANGE("range", SOURCE),
+        RANGE("range", LONG),
         FILTER("filter", LONG),
         TERMS("terms", FLATTENED),
         RARE_TERMS("rare_terms", FLATTENED),
@@ -218,20 +219,26 @@ public final class TransformAggregations {
         }
 
         if (agg instanceof RangeAggregationBuilder rangeAgg) {
-
-            // the merge function (p1, p2) -> p1 ignores duplicates
-            return new Tuple<>(
-                Collections.emptyMap(),
-                rangeAgg.ranges()
-                    .stream()
-                    .collect(
-                        Collectors.toMap(
-                            r -> rangeAgg.getName() + "." + AggregationResultUtils.generateKeyForRange(r.getFrom(), r.getTo()),
-                            r -> "range",
-                            (p1, p2) -> p1
-                        )
-                    )
-            );
+            HashMap<String, String> outputTypes = new HashMap<>();
+            HashMap<String, String> inputTypes = new HashMap<>();
+            for (Range range : rangeAgg.ranges()) {
+                String fieldName = rangeAgg.getName() + "." + AggregationResultUtils.generateKeyForRange(range.getFrom(), range.getTo());
+                if (rangeAgg.getSubAggregations().isEmpty()) {
+                    outputTypes.put(fieldName, AggregationType.RANGE.getName());
+                    continue;
+                }
+                for (AggregationBuilder subAgg : rangeAgg.getSubAggregations()) {
+                    Tuple<Map<String, String>, Map<String, String>> subAggregationTypes = getAggregationInputAndOutputTypes(subAgg);
+                    System.out.println("XXX 1.5 rangeAgg outputTypes: " + subAggregationTypes);
+                    for (Entry<String, String> subAggOutputType : subAggregationTypes.v2().entrySet()) {
+                        outputTypes.put(String.join(".", fieldName, subAggOutputType.getKey()), subAggOutputType.getValue());
+                    }
+                    for (Entry<String, String> subAggInputType : subAggregationTypes.v1().entrySet()) {
+                        inputTypes.put(String.join(".", fieldName, subAggInputType.getKey()), subAggInputType.getValue());
+                    }
+                }
+            }
+            return new Tuple<>(inputTypes, outputTypes);
         }
 
         // does the agg specify output field names

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/pivot/TransformAggregations.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/pivot/TransformAggregations.java
@@ -112,7 +112,7 @@ public final class TransformAggregations {
         BUCKET_SELECTOR("bucket_selector", DYNAMIC),
         BUCKET_SCRIPT("bucket_script", DYNAMIC),
         PERCENTILES("percentiles", DOUBLE),
-        RANGE("range", LONG),
+        RANGE("range", SOURCE),
         FILTER("filter", LONG),
         TERMS("terms", FLATTENED),
         RARE_TERMS("rare_terms", FLATTENED),

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/pivot/TransformAggregations.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/pivot/TransformAggregations.java
@@ -229,7 +229,6 @@ public final class TransformAggregations {
                 }
                 for (AggregationBuilder subAgg : rangeAgg.getSubAggregations()) {
                     Tuple<Map<String, String>, Map<String, String>> subAggregationTypes = getAggregationInputAndOutputTypes(subAgg);
-                    System.out.println("XXX 1.5 rangeAgg outputTypes: " + subAggregationTypes);
                     for (Entry<String, String> subAggOutputType : subAggregationTypes.v2().entrySet()) {
                         outputTypes.put(String.join(".", fieldName, subAggOutputType.getKey()), subAggOutputType.getValue());
                     }

--- a/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/pivot/AggregationResultUtilsTests.java
+++ b/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/pivot/AggregationResultUtilsTests.java
@@ -1010,17 +1010,6 @@ public class AggregationResultUtilsTests extends ESTestCase {
         );
     }
 
-    public void testGenerateKeyForRange() {
-        assertThat(AggregationResultUtils.generateKeyForRange(Double.NEGATIVE_INFINITY, Double.POSITIVE_INFINITY), is(equalTo("*-*")));
-        assertThat(AggregationResultUtils.generateKeyForRange(Double.NEGATIVE_INFINITY, 0.0), is(equalTo("*-0")));
-        assertThat(AggregationResultUtils.generateKeyForRange(0.0, 0.0), is(equalTo("0-0")));
-        assertThat(AggregationResultUtils.generateKeyForRange(10.0, 10.0), is(equalTo("10-10")));
-        assertThat(AggregationResultUtils.generateKeyForRange(10.5, 10.5), is(equalTo("10_5-10_5")));
-        assertThat(AggregationResultUtils.generateKeyForRange(10.5, 19.5), is(equalTo("10_5-19_5")));
-        assertThat(AggregationResultUtils.generateKeyForRange(19.5, 20), is(equalTo("19_5-20")));
-        assertThat(AggregationResultUtils.generateKeyForRange(20, Double.POSITIVE_INFINITY), is(equalTo("20-*")));
-    }
-
     public static SingleBucketAggregation createSingleBucketAgg(String name, long docCount, Aggregation... subAggregations) {
         SingleBucketAggregation agg = mock(SingleBucketAggregation.class);
         when(agg.getDocCount()).thenReturn(docCount);

--- a/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/pivot/AggregationSchemaAndResultTests.java
+++ b/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/pivot/AggregationSchemaAndResultTests.java
@@ -144,7 +144,7 @@ public class AggregationSchemaAndResultTests extends ESTestCase {
         this.<Map<String, String>>assertAsync(
             listener -> SchemaUtil.deduceMappings(client, pivotConfig, new String[] { "source-index" }, emptyMap(), listener),
             mappings -> {
-                assertEquals("Mappings were: " + mappings, numGroupsWithoutScripts + 10, mappings.size());
+                assertEquals("Mappings were: " + mappings, numGroupsWithoutScripts + 15, mappings.size());
                 assertEquals("long", mappings.get("max_rating"));
                 assertEquals("double", mappings.get("avg_rating"));
                 assertEquals("long", mappings.get("count_rating"));
@@ -154,6 +154,11 @@ public class AggregationSchemaAndResultTests extends ESTestCase {
                 assertEquals("double", mappings.get("p_rating.5"));
                 assertEquals("double", mappings.get("p_rating.10"));
                 assertEquals("double", mappings.get("p_rating.99_9"));
+                assertEquals("object", mappings.get("some_range"));
+                assertEquals("long", mappings.get("some_range.*-10_5"));
+                assertEquals("long", mappings.get("some_range.10_5-19_5"));
+                assertEquals("long", mappings.get("some_range.19_5-20"));
+                assertEquals("long", mappings.get("some_range.20-*"));
 
                 Aggregation agg = AggregationResultUtilsTests.createSingleMetricAgg("avg_rating", 33.3, "33.3");
                 assertThat(AggregationResultUtils.getExtractor(agg).value(agg, mappings, ""), equalTo(33.3));

--- a/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/pivot/AggregationSchemaAndResultTests.java
+++ b/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/pivot/AggregationSchemaAndResultTests.java
@@ -144,7 +144,7 @@ public class AggregationSchemaAndResultTests extends ESTestCase {
         this.<Map<String, String>>assertAsync(
             listener -> SchemaUtil.deduceMappings(client, pivotConfig, new String[] { "source-index" }, emptyMap(), listener),
             mappings -> {
-                assertEquals(numGroupsWithoutScripts + 15, mappings.size());
+                assertEquals("Mappings were: " + mappings, numGroupsWithoutScripts + 10, mappings.size());
                 assertEquals("long", mappings.get("max_rating"));
                 assertEquals("double", mappings.get("avg_rating"));
                 assertEquals("long", mappings.get("count_rating"));
@@ -154,11 +154,6 @@ public class AggregationSchemaAndResultTests extends ESTestCase {
                 assertEquals("double", mappings.get("p_rating.5"));
                 assertEquals("double", mappings.get("p_rating.10"));
                 assertEquals("double", mappings.get("p_rating.99_9"));
-                assertEquals("object", mappings.get("some_range"));
-                assertEquals("long", mappings.get("some_range.*-10_5"));
-                assertEquals("long", mappings.get("some_range.10_5-19_5"));
-                assertEquals("long", mappings.get("some_range.19_5-20"));
-                assertEquals("long", mappings.get("some_range.20-*"));
 
                 Aggregation agg = AggregationResultUtilsTests.createSingleMetricAgg("avg_rating", 33.3, "33.3");
                 assertThat(AggregationResultUtils.getExtractor(agg).value(agg, mappings, ""), equalTo(33.3));

--- a/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/pivot/AggregationSchemaAndResultTests.java
+++ b/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/pivot/AggregationSchemaAndResultTests.java
@@ -119,6 +119,16 @@ public class AggregationSchemaAndResultTests extends ESTestCase {
         // percentile produces 1 output per percentile + 1 for the parent object
         aggs.addAggregator(AggregationBuilders.percentiles("p_rating").field("long_stars").percentiles(1, 5, 10, 50, 99.9));
 
+        // range produces 1 output per range + 1 for the parent object
+        aggs.addAggregator(
+            AggregationBuilders.range("some_range")
+                .field("long_stars")
+                .addUnboundedTo(10.5)
+                .addRange(10.5, 19.5)
+                .addRange(19.5, 20)
+                .addUnboundedFrom(20)
+        );
+
         // scripted metric produces no output because its dynamic
         aggs.addAggregator(AggregationBuilders.scriptedMetric("collapsed_ratings"));
 
@@ -134,7 +144,7 @@ public class AggregationSchemaAndResultTests extends ESTestCase {
         this.<Map<String, String>>assertAsync(
             listener -> SchemaUtil.deduceMappings(client, pivotConfig, new String[] { "source-index" }, emptyMap(), listener),
             mappings -> {
-                assertEquals(numGroupsWithoutScripts + 10, mappings.size());
+                assertEquals(numGroupsWithoutScripts + 15, mappings.size());
                 assertEquals("long", mappings.get("max_rating"));
                 assertEquals("double", mappings.get("avg_rating"));
                 assertEquals("long", mappings.get("count_rating"));
@@ -144,6 +154,11 @@ public class AggregationSchemaAndResultTests extends ESTestCase {
                 assertEquals("double", mappings.get("p_rating.5"));
                 assertEquals("double", mappings.get("p_rating.10"));
                 assertEquals("double", mappings.get("p_rating.99_9"));
+                assertEquals("object", mappings.get("some_range"));
+                assertEquals("long", mappings.get("some_range.*-10_5"));
+                assertEquals("long", mappings.get("some_range.10_5-19_5"));
+                assertEquals("long", mappings.get("some_range.19_5-20"));
+                assertEquals("long", mappings.get("some_range.20-*"));
 
                 Aggregation agg = AggregationResultUtilsTests.createSingleMetricAgg("avg_rating", 33.3, "33.3");
                 assertThat(AggregationResultUtils.getExtractor(agg).value(agg, mappings, ""), equalTo(33.3));

--- a/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/pivot/TransformAggregationsTests.java
+++ b/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/pivot/TransformAggregationsTests.java
@@ -360,4 +360,15 @@ public class TransformAggregationsTests extends ESTestCase {
         assertEquals("percentiles", outputTypes.get("filter_1.filter_2.percentiles.88_8"));
         assertEquals("percentiles", outputTypes.get("filter_1.filter_2.percentiles.99_5"));
     }
+
+    public void testGenerateKeyForRange() {
+        assertThat(TransformAggregations.generateKeyForRange(Double.NEGATIVE_INFINITY, Double.POSITIVE_INFINITY), is(equalTo("*-*")));
+        assertThat(TransformAggregations.generateKeyForRange(Double.NEGATIVE_INFINITY, 0.0), is(equalTo("*-0")));
+        assertThat(TransformAggregations.generateKeyForRange(0.0, 0.0), is(equalTo("0-0")));
+        assertThat(TransformAggregations.generateKeyForRange(10.0, 10.0), is(equalTo("10-10")));
+        assertThat(TransformAggregations.generateKeyForRange(10.5, 10.5), is(equalTo("10_5-10_5")));
+        assertThat(TransformAggregations.generateKeyForRange(10.5, 19.5), is(equalTo("10_5-19_5")));
+        assertThat(TransformAggregations.generateKeyForRange(19.5, 20), is(equalTo("19_5-20")));
+        assertThat(TransformAggregations.generateKeyForRange(20, Double.POSITIVE_INFINITY), is(equalTo("20-*")));
+    }
 }

--- a/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/pivot/TransformAggregationsTests.java
+++ b/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/pivot/TransformAggregationsTests.java
@@ -65,10 +65,10 @@ public class TransformAggregationsTests extends ESTestCase {
         assertEquals("double", TransformAggregations.resolveTargetMapping("sum", null));
 
         // range
-        assertEquals("long", TransformAggregations.resolveTargetMapping("range", "int"));
-        assertEquals("long", TransformAggregations.resolveTargetMapping("range", "double"));
-        assertEquals("long", TransformAggregations.resolveTargetMapping("range", "half_float"));
-        assertEquals("long", TransformAggregations.resolveTargetMapping("range", "scaled_float"));
+        assertEquals("int", TransformAggregations.resolveTargetMapping("range", "int"));
+        assertEquals("double", TransformAggregations.resolveTargetMapping("range", "double"));
+        assertEquals("half_float", TransformAggregations.resolveTargetMapping("range", "half_float"));
+        assertEquals("float", TransformAggregations.resolveTargetMapping("range", "scaled_float"));
 
         // geo_centroid
         assertEquals("geo_point", TransformAggregations.resolveTargetMapping("geo_centroid", "geo_point"));

--- a/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/utils/OutputFieldNameConverterTests.java
+++ b/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/utils/OutputFieldNameConverterTests.java
@@ -25,5 +25,6 @@ public class OutputFieldNameConverterTests extends ESTestCase {
         assertEquals("NaN", OutputFieldNameConverter.fromDouble(Double.NaN));
         // infinity
         assertEquals("-Infinity", OutputFieldNameConverter.fromDouble(Double.NEGATIVE_INFINITY));
+        assertEquals("Infinity", OutputFieldNameConverter.fromDouble(Double.POSITIVE_INFINITY));
     }
 }


### PR DESCRIPTION
This PR adds support for `range` aggregation in transform.

Relates https://github.com/elastic/elasticsearch/issues/86367