### PR TITLE
[ML] Lower memory threshold for running LP in assignment planner

### DIFF
--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/assignment/planning/LinearProgrammingPlanSolver.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/assignment/planning/LinearProgrammingPlanSolver.java
@@ -45,10 +45,11 @@ class LinearProgrammingPlanSolver {
 
     /**
      * Ojalgo creates a 2D double array with size of complexity {@link #memoryComplexity()}.
-     * We set a limit of storing 10M doubles (~80MB) to avoid OOM. We fall back to the
+     * We set a limit of storing 4M doubles. This should result to a max of about ~100MB (determined through tests)
+     * for the solver to run in the heap. This should be enough to avoid OOM exceptions. We fall back to the
      * bin packing solution if we're over that limit.
      */
-    private static final int MEMORY_COMPLEXITY_LIMIT = 10_000_000;
+    private static final int MEMORY_COMPLEXITY_LIMIT = 4_000_000;
 
     private final Random random = new Random(RANDOMIZATION_SEED);
 

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/assignment/planning/AssignmentPlannerTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/assignment/planning/AssignmentPlannerTests.java
@@ -247,27 +247,27 @@ public class AssignmentPlannerTests extends ESTestCase {
     }
 
     public void testTooManyNodesAndModels_DoesNotThrowOOM_GivenNodesJustUnderLimit() {
-        runTooManyNodesAndModels(3150, 1);
+        runTooManyNodesAndModels(1999, 1);
     }
 
     public void testTooManyNodesAndModels_DoesNotThrowOOM_GivenNodesJustOverLimit() {
-        runTooManyNodesAndModels(3151, 1);
+        runTooManyNodesAndModels(2000, 1);
     }
 
     public void testTooManyNodesAndModels_DoesNotThrowOOM_GivenModelsJustUnderLimit() {
-        runTooManyNodesAndModels(1, 3150);
+        runTooManyNodesAndModels(1, 1999);
     }
 
     public void testTooManyNodesAndModels_DoesNotThrowOOM_GivenModelsJustOverLimit() {
-        runTooManyNodesAndModels(1, 3151);
+        runTooManyNodesAndModels(1, 2000);
     }
 
     public void testTooManyNodesAndModels_DoesNotThrowOOM_GivenComboJustUnderLimit() {
-        runTooManyNodesAndModels(171, 171);
+        runTooManyNodesAndModels(125, 126);
     }
 
     public void testTooManyNodesAndModels_DoesNotThrowOOM_GivenComboJustOverLimit() {
-        runTooManyNodesAndModels(172, 171);
+        runTooManyNodesAndModels(126, 126);
     }
 
     public void testTooManyNodesAndModels_DoesNotThrowOOM_GivenComboWayOverLimit() {


### PR DESCRIPTION
After test failures in CI I retested how much memory is used in the heap
when the assignment planner runs on the limits of the memory threshold.
In this PR we lower the memory threshold before switching to bin-packing
so that the solver should never user more than ~100MB. Previously it could
use up to ~200MB.

Closes #86496
