### PR TITLE
[8.2] Better failure for source-only snapshots of partially/fully mounted indices (#86207)

### DIFF
--- a/docs/changelog/86207.yaml
+++ b/docs/changelog/86207.yaml
@@ -1,0 +1,5 @@
+pr: 86207
+summary: Better failure for source-only snapshots of partially/fully mounted indices
+area: Snapshot/Restore
+type: bug
+issues: []

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/snapshots/sourceonly/SourceOnlySnapshotRepository.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/snapshots/sourceonly/SourceOnlySnapshotRepository.java
@@ -148,7 +148,15 @@ public final class SourceOnlySnapshotRepository extends FilterRepository {
         final Store store = context.store();
         Directory unwrap = FilterDirectory.unwrap(store.directory());
         if (unwrap instanceof FSDirectory == false) {
-            throw new AssertionError("expected FSDirectory but got " + unwrap.toString());
+            context.onFailure(
+                new IllegalStateException(
+                    context.indexCommit()
+                        + " is not a regular index, but ["
+                        + unwrap.toString()
+                        + "]  and cannot be snapshotted into a source-only repository"
+                )
+            );
+            return;
         }
         Path dataPath = ((FSDirectory) unwrap).getDirectory().getParent();
         // TODO should we have a snapshot tmp directory per shard that is maintained by the system?


### PR DESCRIPTION
Backports the following commits to 8.2:
 - Better failure for source-only snapshots of partially/fully mounted indices (#86207)