### PR TITLE
Enable HLRC compatibility mode by default

### DIFF
--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/RestHighLevelClient.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/RestHighLevelClient.java
@@ -347,7 +347,12 @@ public class RestHighLevelClient implements Closeable {
                 .flatMap(Function.identity())
                 .collect(toList())
         );
-        if (useAPICompatibility == null && "true".equals(System.getenv(API_VERSIONING_ENV_VARIABLE))) {
+
+        // Compatibility mode is on by default, then env variable has precedence over builder setting
+        String apiVersioningEnv = System.getenv(API_VERSIONING_ENV_VARIABLE);
+        if (useAPICompatibility == null && apiVersioningEnv == null) {
+            this.useAPICompatibility = true;
+        } else if (useAPICompatibility == null && "true".equals(System.getenv(API_VERSIONING_ENV_VARIABLE))) {
             this.useAPICompatibility = true;
         } else {
             this.useAPICompatibility = Boolean.TRUE.equals(useAPICompatibility);

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/CustomRestHighLevelClientTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/CustomRestHighLevelClientTests.java
@@ -147,7 +147,8 @@ public class CustomRestHighLevelClientTests extends ESTestCase {
      * Mocks the synchronous request execution like if it was executed by Elasticsearch.
      */
     private Response mockPerformRequest(Request request) throws IOException {
-        assertThat(request.getOptions().getHeaders(), hasSize(1));
+        // Headers contain 'node_name' set by optionsForNodeName and 'Accept' from HLRC compatibility mode
+        assertThat(request.getOptions().getHeaders(), hasSize(2));
         Header httpHeader = request.getOptions().getHeaders().get(0);
         final Response mockResponse = mock(Response.class);
         when(mockResponse.getHost()).thenReturn(new HttpHost("localhost", 9200));

--- a/docs/changelog/86517.yaml
+++ b/docs/changelog/86517.yaml
@@ -1,11 +1,11 @@
 pr: 86517
 summary: Enable HLRC compatibility mode by default
 area: Java High Level REST Client
-type: "enhancement, breaking"
+type: "breaking"
 issues: []
 breaking:
   title: Enable HLRC compatibility mode by default
-  area: Java High Level REST Client
+  area: REST API
   details: |-
     Compatibility mode allows HLRC to communicate with {es} 8.x by sending version information in the `Content-Type` and `Accept`
     request headers, which causes {es} 8 to behave like {es} 7. As this feature isn't very well known, a number of users had

--- a/docs/changelog/86517.yaml
+++ b/docs/changelog/86517.yaml
@@ -1,5 +1,12 @@
 pr: 86517
 summary: Enable HLRC compatibility mode by default
 area: Java High Level REST Client
-type: enhancement
+type: "enhancement, breaking"
 issues: []
+breaking:
+  title: Enable HLRC compatibility mode by default
+  area: Java High Level REST Client
+  details: Please describe the details of this change for the release notes. You can
+    use asciidoc.
+  impact: Please describe the impact of this change to users
+  notable: false

--- a/docs/changelog/86517.yaml
+++ b/docs/changelog/86517.yaml
@@ -6,7 +6,13 @@ issues: []
 breaking:
   title: Enable HLRC compatibility mode by default
   area: Java High Level REST Client
-  details: Please describe the details of this change for the release notes. You can
-    use asciidoc.
-  impact: Please describe the impact of this change to users
-  notable: false
+  details: |-
+    Compatibility mode allows HLRC to communicate with {es} 8.x by sending version information in the `Content-Type` and `Accept`
+    request headers, which causes {es} 8 to behave like {es} 7. As this feature isn't very well known, a number of users had
+    the wrong impression that HLRC 7.17 was not working with {es} 8.
+
+    Compatibility mode is now enabled by default, allowing it to work out of the box with {es} 8.
+  impact: |-
+    Compatibilty mode was introduced in {es} 7.11. Using HLRC 7.17.4 with {es} 7.10 and before therefore requires to disable
+    compatibility mode when creating an HLRC instance.
+  notable: true

--- a/docs/changelog/86517.yaml
+++ b/docs/changelog/86517.yaml
@@ -1,0 +1,5 @@
+pr: 86517
+summary: Enable HLRC compatibility mode by default
+area: Java High Level REST Client
+type: enhancement
+issues: []

--- a/docs/java-rest/high-level/getting-started.asciidoc
+++ b/docs/java-rest/high-level/getting-started.asciidoc
@@ -18,11 +18,11 @@ doesn't need to be in the same minor version as the Elasticsearch nodes it
 communicates with, as it is forward compatible meaning that it supports
 communicating with later versions of Elasticsearch than the one it was developed for.
 
-The 6.0 client is able to communicate with any 6.x Elasticsearch node, while the 6.1
-client is for sure able to communicate with 6.1, 6.2 and any later 6.x version, but
+The 7.0 client is able to communicate with any 7.x Elasticsearch node, while the 7.1
+client is for sure able to communicate with 7.1, 7.2 and any later 7.x version, but
 there may be incompatibility issues when communicating with a previous Elasticsearch
-node version, for instance between 6.1 and 6.0, in case the 6.1 client supports new
-request body fields for some APIs that are not known by the 6.0 node(s).
+node version, for instance between 7.1 and 7.0, in case the 7.1 client supports new
+request body fields for some APIs that are not known by the 7.0 node(s).
 
 It is recommended to upgrade the High Level Client when upgrading the Elasticsearch
 cluster to a new major version, as REST API breaking changes may cause unexpected
@@ -30,6 +30,24 @@ results depending on the node that is hit by the request, and newly added APIs w
 only be supported by the newer version of the client. The client should always be
 updated last, once all of the nodes in the cluster have been upgraded to the new
 major version.
+
+*Compatibility with Elasticsearch 8.x*
+
+The High Level Client version 7.16 and higher can communicate with Elasticsearch version 8.x after enabling API compatibility mode. When this mode enabled, the client will send HTTP headers that instruct Elasticsearch 8.x to honor 7.x request/responses.
+
+Compatibility mode is enabled as follows:
+
+["source","java",subs="attributes"]
+--------------------------------------------------
+RestHighLevelClient esClient = new RestHighLevelClientBuilder(restClient)
+    .setApiCompatibilityMode(true)
+    .build()
+--------------------------------------------------
+
+NOTE: Starting with version 7.17.4, compatibility mode is enabled by default.
+
+When compatibility mode is enabled, the client can also communicate with Elasticsearch version 7.16 and higher.
+
 
 [[java-rest-high-javadoc]]
 === Javadoc
@@ -141,7 +159,7 @@ transitive dependencies:
 [[java-rest-high-getting-started-initialization]]
 === Initialization
 
-A `RestHighLevelClient` instance needs a 
+A `RestHighLevelClient` instance needs a
 {java-api-client}/java-rest-low-usage-initialization.html[REST low-level client builder]
 to be built as follows:
 
@@ -172,27 +190,27 @@ All APIs in the `RestHighLevelClient` accept a `RequestOptions` which you can
 use to customize the request in ways that won't change how Elasticsearch
 executes the request. For example, this is the place where you'd specify a
 `NodeSelector` to control which node receives the request. See the
-{java-api-client}/java-rest-low-usage-requests.html#java-rest-low-usage-request-options[low level client documentation] 
+{java-api-client}/java-rest-low-usage-requests.html#java-rest-low-usage-request-options[low level client documentation]
 for more examples of customizing the options.
 
 [[java-rest-high-getting-started-asynchronous-usage]]
 === Asynchronous usage
 
-All of the methods across the different clients exist in a traditional synchronous and 
-asynchronous variant. The difference is that the asynchronous ones use asynchronous requests 
+All of the methods across the different clients exist in a traditional synchronous and
+asynchronous variant. The difference is that the asynchronous ones use asynchronous requests
 in the REST Low Level Client. This is useful if you are doing multiple requests or are using e.g.
 rx java, Kotlin co-routines, or similar frameworks.
 
-The asynchronous methods are recognizable by the fact that they have the word "Async" in their name 
-and return a `Cancellable` instance. The asynchronous methods accept the same request object 
-as the synchronous variant and accept a generic `ActionListener<T>` where `T` is the return 
-type of the synchronous method. 
+The asynchronous methods are recognizable by the fact that they have the word "Async" in their name
+and return a `Cancellable` instance. The asynchronous methods accept the same request object
+as the synchronous variant and accept a generic `ActionListener<T>` where `T` is the return
+type of the synchronous method.
 
-All asynchronous methods return a `Cancellable` object with a `cancel` method that you may call 
+All asynchronous methods return a `Cancellable` object with a `cancel` method that you may call
 in case you want to abort the request. Cancelling
-no longer needed requests is a good way to avoid putting unnecessary 
+no longer needed requests is a good way to avoid putting unnecessary
 load on Elasticsearch.
 
-Using the `Cancellable` instance is optional and you can safely ignore this if you have 
-no need for this. A use case for this would be using this with e.g. Kotlin's `suspendCancellableCoRoutine`. 
+Using the `Cancellable` instance is optional and you can safely ignore this if you have
+no need for this. A use case for this would be using this with e.g. Kotlin's `suspendCancellableCoRoutine`.
 

--- a/docs/java-rest/high-level/getting-started.asciidoc
+++ b/docs/java-rest/high-level/getting-started.asciidoc
@@ -44,10 +44,9 @@ RestHighLevelClient esClient = new RestHighLevelClientBuilder(restClient)
     .build()
 --------------------------------------------------
 
+When compatibility mode is enabled, the client can also communicate with Elasticsearch version 7.11 and higher.
+
 NOTE: Starting with version 7.17.4, compatibility mode is enabled by default.
-
-When compatibility mode is enabled, the client can also communicate with Elasticsearch version 7.16 and higher.
-
 
 [[java-rest-high-javadoc]]
 === Javadoc

--- a/docs/java-rest/high-level/index.asciidoc
+++ b/docs/java-rest/high-level/index.asciidoc
@@ -8,6 +8,8 @@
 
 deprecated[7.15.0, The High Level REST Client is deprecated in favour of the {java-api-client}/index.html[Java API Client].]
 
+NOTE: The High Level Rest Client version 7.17 can work with {es} `8.x` with <<java-rest-high-compatibility,compatibility mode enabled>>.
+
 The Java High Level REST Client works on top of the Java Low Level REST client.
 Its main goal is to expose API specific methods, that accept request objects as
 an argument and return response objects, so that request marshalling and

--- a/qa/ccs-old-version-remote-cluster/src/test/java/org/elasticsearch/upgrades/CCSFieldsOptionEmulationIT.java
+++ b/qa/ccs-old-version-remote-cluster/src/test/java/org/elasticsearch/upgrades/CCSFieldsOptionEmulationIT.java
@@ -40,6 +40,7 @@ import org.elasticsearch.client.Response;
 import org.elasticsearch.client.ResponseException;
 import org.elasticsearch.client.RestClient;
 import org.elasticsearch.client.RestHighLevelClient;
+import org.elasticsearch.client.RestHighLevelClientBuilder;
 import org.elasticsearch.client.indices.CreateIndexRequest;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.common.document.DocumentField;
@@ -89,11 +90,13 @@ public class CCSFieldsOptionEmulationIT extends AbstractCCSRestTestCase {
         final List<HttpHost> hosts = parseHosts("tests.rest.cluster");
         final int index = random().nextInt(hosts.size());
         logger.info("Using client node {}", index);
-        return new RestHighLevelClient(RestClient.builder(hosts.get(index)));
+        return new RestHighLevelClientBuilder(RestClient.builder(hosts.get(index)).build()).setApiCompatibilityMode(false).build();
     }
 
     static RestHighLevelClient newRemoteClient() {
-        return new RestHighLevelClient(RestClient.builder(randomFrom(parseHosts("tests.rest.remote_cluster"))));
+        return new RestHighLevelClientBuilder(RestClient.builder(randomFrom(parseHosts("tests.rest.remote_cluster"))).build())
+            .setApiCompatibilityMode(false)
+            .build();
     }
 
     public void testFieldsOptionEmulation() throws Exception {

--- a/qa/ccs-rolling-upgrade-remote-cluster/src/test/java/org/elasticsearch/upgrades/SearchStatesIT.java
+++ b/qa/ccs-rolling-upgrade-remote-cluster/src/test/java/org/elasticsearch/upgrades/SearchStatesIT.java
@@ -39,6 +39,7 @@ import org.elasticsearch.client.RequestOptions;
 import org.elasticsearch.client.Response;
 import org.elasticsearch.client.RestClient;
 import org.elasticsearch.client.RestHighLevelClient;
+import org.elasticsearch.client.RestHighLevelClientBuilder;
 import org.elasticsearch.client.indices.CreateIndexRequest;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.common.settings.Settings;
@@ -72,7 +73,7 @@ public class SearchStatesIT extends AbstractCCSRestTestCase {
         final List<HttpHost> hosts = parseHosts("tests.rest.cluster");
         final int index = random().nextInt(hosts.size());
         logger.info("Using client node {}", index);
-        return new RestHighLevelClient(RestClient.builder(hosts.get(index)));
+        return new RestHighLevelClientBuilder(RestClient.builder(hosts.get(index)).build()).setApiCompatibilityMode(false).build();
     }
 
     protected static RestHighLevelClient newRemoteClient() {

--- a/qa/ccs-rolling-upgrade-remote-cluster/src/test/java/org/elasticsearch/upgrades/SearchStatesIT.java
+++ b/qa/ccs-rolling-upgrade-remote-cluster/src/test/java/org/elasticsearch/upgrades/SearchStatesIT.java
@@ -77,7 +77,9 @@ public class SearchStatesIT extends AbstractCCSRestTestCase {
     }
 
     protected static RestHighLevelClient newRemoteClient() {
-        return new RestHighLevelClient(RestClient.builder(randomFrom(parseHosts("tests.rest.remote_cluster"))));
+        return new RestHighLevelClientBuilder(RestClient.builder(randomFrom(parseHosts("tests.rest.remote_cluster"))).build())
+            .setApiCompatibilityMode(false)
+            .build();
     }
 
     static int indexDocs(RestHighLevelClient client, String index, int numDocs) throws IOException {

--- a/x-pack/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/MlJobSnapshotUpgradeIT.java
+++ b/x-pack/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/MlJobSnapshotUpgradeIT.java
@@ -15,6 +15,7 @@ import org.elasticsearch.client.Response;
 import org.elasticsearch.client.ResponseException;
 import org.elasticsearch.client.RestClient;
 import org.elasticsearch.client.RestHighLevelClient;
+import org.elasticsearch.client.RestHighLevelClientBuilder;
 import org.elasticsearch.client.ml.CloseJobRequest;
 import org.elasticsearch.client.ml.CloseJobResponse;
 import org.elasticsearch.client.ml.FlushJobRequest;
@@ -69,10 +70,8 @@ public class MlJobSnapshotUpgradeIT extends AbstractUpgradeTestCase {
     // min version in upgraded 7.series is 7.11.0
     private static final Version CPP_COMPATIBILTIY_VERSION = Version.V_7_11_0;
 
-    private static class HLRC extends RestHighLevelClient {
-        HLRC(RestClient restClient) {
-            super(restClient, RestClient::close, new ArrayList<>());
-        }
+    private static RestHighLevelClient HLRC(RestClient restClient) {
+        return new RestHighLevelClientBuilder(restClient).setApiCompatibilityMode(false).build();
     }
 
     private MachineLearningClient hlrc;
@@ -98,7 +97,7 @@ public class MlJobSnapshotUpgradeIT extends AbstractUpgradeTestCase {
      * index mappings when it is assigned to an upgraded node even if no other ML endpoint is called after the upgrade
      */
     public void testSnapshotUpgrader() throws Exception {
-        hlrc = new HLRC(client()).machineLearning();
+        hlrc = HLRC(client()).machineLearning();
         Request adjustLoggingLevels = new Request("PUT", "/_cluster/settings");
         adjustLoggingLevels.setJsonEntity("{\"persistent\": {" + "\"logger.org.elasticsearch.xpack.ml\": \"trace\"" + "}}");
         client().performRequest(adjustLoggingLevels);


### PR DESCRIPTION
HLRC compatibility mode allows it to communicate with Elasticsearch 8.x. Users are generally unaware of this feature, and this leads to a lot of questions and issues about the migration from 7.x to 8.x and the transition from HLRC to the new Java API client (we recently [added docs there](https://www.elastic.co/guide/en/elasticsearch/client/java-api-client/current/migrate-hlrc.html) as well).

This PR enables compatibility mode by default so that HLRC will work out of the box with versions 7.x and 8.x without any additional configuration.

It also adds docs about it, with a prominent note on the index page linking to compatibility mode explanations.

Reviewers:
* @dakrone who initially added compatibility mode
* @szabosteve for the doc part