### PR TITLE
Add getResolution method to H3

### DIFF
--- a/libs/h3/src/main/java/org/elasticsearch/h3/H3.java
+++ b/libs/h3/src/main/java/org/elasticsearch/h3/H3.java
@@ -47,6 +47,16 @@ public final class H3 {
         return Long.parseUnsignedLong(h3Address, 16);
     }
 
+    /** returns the resolution of the provided H3 cell */
+    public static int getResolution(long h3) {
+        return H3Index.H3_get_resolution(h3);
+    }
+
+    /** returns the resolution of the provided H3 cell in string format */
+    public static int getResolution(String h3Address) {
+        return getResolution(stringToH3(h3Address));
+    }
+
     /** determines if an H3 cell is a pentagon */
     public static boolean isPentagon(long h3) {
         return H3Index.H3_is_pentagon(h3);

--- a/libs/h3/src/test/java/org/elasticsearch/h3/GeoToH3Tests.java
+++ b/libs/h3/src/test/java/org/elasticsearch/h3/GeoToH3Tests.java
@@ -38,8 +38,9 @@ public class GeoToH3Tests extends ESTestCase {
 
     private void testPoint(double lat, double lon) {
         GeoPoint point = new GeoPoint(PlanetModel.SPHERE, Math.toRadians(lat), Math.toRadians(lon));
-        for (int i = 0; i < Constants.MAX_H3_RES; i++) {
-            String h3Address = H3.geoToH3Address(lat, lon, i);
+        for (int res = 0; res < Constants.MAX_H3_RES; res++) {
+            String h3Address = H3.geoToH3Address(lat, lon, res);
+            assertEquals(res, H3.getResolution(h3Address));
             GeoPolygon polygon = getGeoPolygon(h3Address);
             assertTrue(polygon.isWithin(point));
         }


### PR DESCRIPTION
There can be cases where it is useful to get the resolution of a H3 cell when we only have the h3 or heAddress value.  This PR just exposes the internal implementation.