### PR TITLE
Fixing ShardLimitValidatorTests

### DIFF
--- a/server/src/test/java/org/elasticsearch/indices/ShardLimitValidatorTests.java
+++ b/server/src/test/java/org/elasticsearch/indices/ShardLimitValidatorTests.java
@@ -77,7 +77,12 @@ public class ShardLimitValidatorTests extends ESTestCase {
             errorMessage.get()
         );
         assertFalse(
-            ShardLimitValidator.canAddShardsToCluster(counts.getFailingIndexShards(), counts.getFailingIndexReplicas(), state, true)
+            ShardLimitValidator.canAddShardsToCluster(
+                counts.getFailingIndexShards(),
+                counts.getFailingIndexReplicas(),
+                state,
+                ShardLimitValidator.FROZEN_GROUP.equals(group)
+            )
         );
     }
 
@@ -106,7 +111,7 @@ public class ShardLimitValidatorTests extends ESTestCase {
         );
 
         assertFalse(errorMessage.isPresent());
-        assertTrue(ShardLimitValidator.canAddShardsToCluster(shardsToAdd, 0, state, true));
+        assertTrue(ShardLimitValidator.canAddShardsToCluster(shardsToAdd, 0, state, ShardLimitValidator.FROZEN_GROUP.equals(group)));
     }
 
     public void testValidateShardLimitOpenIndices() {


### PR DESCRIPTION
ShardLimitValidatorTests was accidentally broken as part of #85967 because the new assertions in that class were not taking the type of nodes into account ("normal" or "frozen"). This is a simple change to take that into account.