### PR TITLE
Remove isMeta check during rewrite field-caps responses

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/fieldcaps/IndexFieldCapabilities.java
+++ b/server/src/main/java/org/elasticsearch/action/fieldcaps/IndexFieldCapabilities.java
@@ -35,19 +35,6 @@ public class IndexFieldCapabilities implements Writeable {
     private final TimeSeriesParams.MetricType metricType;
     private final Map<String, String> meta;
 
-    static IndexFieldCapabilities withMetadata(IndexFieldCapabilities input, boolean isMetadata) {
-        return new IndexFieldCapabilities(
-            input.getName(),
-            input.getType(),
-            isMetadata,
-            input.isSearchable,
-            input.isAggregatable,
-            input.isDimension,
-            input.metricType,
-            input.meta
-        );
-    }
-
     /**
      * @param name The name of the field.
      * @param type The type associated with the field.

--- a/server/src/main/java/org/elasticsearch/action/fieldcaps/ResponseRewriter.java
+++ b/server/src/main/java/org/elasticsearch/action/fieldcaps/ResponseRewriter.java
@@ -27,19 +27,12 @@ final class ResponseRewriter {
         Version version,
         Map<String, IndexFieldCapabilities> input,
         String[] filters,
-        String[] allowedTypes,
-        Predicate<String> isMetadata
+        String[] allowedTypes
     ) {
         if (version.onOrAfter(Version.V_8_2_0)) {
             return input;   // nothing needs to be done
         }
-        Function<IndexFieldCapabilities, IndexFieldCapabilities> transformer = buildTransformer(
-            version,
-            input,
-            filters,
-            allowedTypes,
-            isMetadata
-        );
+        Function<IndexFieldCapabilities, IndexFieldCapabilities> transformer = buildTransformer(input, filters, allowedTypes);
         Map<String, IndexFieldCapabilities> rewritten = new HashMap<>();
         for (var entry : input.entrySet()) {
             IndexFieldCapabilities fc = transformer.apply(entry.getValue());
@@ -51,13 +44,10 @@ final class ResponseRewriter {
     }
 
     private static Function<IndexFieldCapabilities, IndexFieldCapabilities> buildTransformer(
-        Version version,
         Map<String, IndexFieldCapabilities> input,
         String[] filters,
-        String[] allowedTypes,
-        Predicate<String> isMetadata
+        String[] allowedTypes
     ) {
-        boolean checkMetadata = version.before(Version.V_7_13_0);
         Predicate<IndexFieldCapabilities> test = ifc -> true;
         Set<String> objects = null;
         Set<String> nestedObjects = null;
@@ -93,14 +83,10 @@ final class ResponseRewriter {
         }
         Predicate<IndexFieldCapabilities> finalTest = test;
         return fc -> {
-            IndexFieldCapabilities rewritten = fc;
-            if (checkMetadata) {
-                rewritten = IndexFieldCapabilities.withMetadata(fc, isMetadata.test(fc.getName()));
-            }
-            if (finalTest.test(rewritten) == false) {
+            if (finalTest.test(fc) == false) {
                 return null;
             }
-            return rewritten;
+            return fc;
         };
     }
 

--- a/server/src/main/java/org/elasticsearch/action/fieldcaps/TransportFieldCapabilitiesAction.java
+++ b/server/src/main/java/org/elasticsearch/action/fieldcaps/TransportFieldCapabilitiesAction.java
@@ -43,7 +43,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Consumer;
-import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
 import static org.elasticsearch.action.search.TransportSearchHelper.checkCCSVersionCompatibility;
@@ -56,7 +55,6 @@ public class TransportFieldCapabilitiesAction extends HandledTransportAction<Fie
     private final ClusterService clusterService;
     private final IndexNameExpressionResolver indexNameExpressionResolver;
 
-    private final Predicate<String> metadataFieldPred;
     private final IndicesService indicesService;
     private final boolean ccsCheckCompatibility;
 
@@ -75,8 +73,6 @@ public class TransportFieldCapabilitiesAction extends HandledTransportAction<Fie
         this.clusterService = clusterService;
         this.indexNameExpressionResolver = indexNameExpressionResolver;
         this.indicesService = indicesService;
-        final Set<String> metadataFields = indicesService.getAllMetadataFields();
-        this.metadataFieldPred = metadataFields::contains;
         transportService.registerRequestHandler(
             ACTION_NODE_NAME,
             ThreadPool.Names.SEARCH_COORDINATION,
@@ -281,8 +277,7 @@ public class TransportFieldCapabilitiesAction extends HandledTransportAction<Fie
             response.getOriginVersion(),
             response.get(),
             request.filters(),
-            request.types(),
-            metadataFieldPred
+            request.types()
         );
         for (Map.Entry<String, IndexFieldCapabilities> entry : fields.entrySet()) {
             final String field = entry.getKey();

--- a/server/src/main/java/org/elasticsearch/index/mapper/MapperRegistry.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/MapperRegistry.java
@@ -85,13 +85,6 @@ public final class MapperRegistry {
     }
 
     /**
-     * Return a map of all meta mappers that have been registered in all compatible versions.
-     */
-    public Map<String, MetadataFieldMapper.TypeParser> getAllMetadataMapperParsers() {
-        return metadataMapperParsers;
-    }
-
-    /**
      * Returns a function that given an index name, returns a predicate that fields must match in order to be returned by get mappings,
      * get index, get field mappings and field capabilities API. Useful to filter the fields that such API return.
      * The predicate receives the field name as input arguments. In case multiple plugins register a field filter through

--- a/server/src/main/java/org/elasticsearch/indices/IndicesService.java
+++ b/server/src/main/java/org/elasticsearch/indices/IndicesService.java
@@ -1724,13 +1724,6 @@ public class IndicesService extends AbstractLifecycleComponent
         return mapperRegistry.getMetadataMapperParsers(version).keySet();
     }
 
-    /**
-     * Returns the registered metadata field names for all compatible versions.
-     */
-    public Set<String> getAllMetadataFields() {
-        return mapperRegistry.getAllMetadataMapperParsers().keySet();
-    }
-
     private void setIdFieldDataEnabled(boolean value) {
         this.idFieldDataEnabled = value;
     }

--- a/server/src/test/java/org/elasticsearch/action/fieldcaps/ResponseRewriterTests.java
+++ b/server/src/test/java/org/elasticsearch/action/fieldcaps/ResponseRewriterTests.java
@@ -29,8 +29,7 @@ public class ResponseRewriterTests extends ESTestCase {
             Version.V_8_0_0,
             oldResponse,
             new String[] { "-metadata" },
-            Strings.EMPTY_ARRAY,
-            f -> f.startsWith("_")
+            Strings.EMPTY_ARRAY
         );
 
         assertTrue(rewritten.containsKey("field"));
@@ -49,8 +48,7 @@ public class ResponseRewriterTests extends ESTestCase {
             Version.V_8_0_0,
             oldResponse,
             new String[] { "+metadata" },
-            Strings.EMPTY_ARRAY,
-            f -> f.startsWith("_")
+            Strings.EMPTY_ARRAY
         );
 
         assertFalse(rewritten.containsKey("field"));
@@ -71,8 +69,7 @@ public class ResponseRewriterTests extends ESTestCase {
             Version.V_8_0_0,
             oldResponse,
             new String[] { "-nested" },
-            Strings.EMPTY_ARRAY,
-            f -> f.startsWith("_")
+            Strings.EMPTY_ARRAY
         );
 
         assertTrue(rewritten.containsKey("field"));
@@ -96,8 +93,7 @@ public class ResponseRewriterTests extends ESTestCase {
             Version.V_8_0_0,
             oldResponse,
             new String[] { "-multifield" },
-            Strings.EMPTY_ARRAY,
-            f -> f.startsWith("_")
+            Strings.EMPTY_ARRAY
         );
 
         assertTrue(rewritten.containsKey("field"));
@@ -119,8 +115,7 @@ public class ResponseRewriterTests extends ESTestCase {
             Version.V_8_0_0,
             oldResponse,
             new String[] { "-parent" },
-            Strings.EMPTY_ARRAY,
-            f -> f.startsWith("_")
+            Strings.EMPTY_ARRAY
         );
 
         assertTrue(rewritten.containsKey("field"));
@@ -142,8 +137,7 @@ public class ResponseRewriterTests extends ESTestCase {
             Version.V_8_0_0,
             oldResponse,
             Strings.EMPTY_ARRAY,
-            new String[] { "text", "keyword" },
-            f -> f.startsWith("_")
+            new String[] { "text", "keyword" }
         );
 
         assertTrue(rewritten.containsKey("text"));

--- a/server/src/test/java/org/elasticsearch/action/fieldcaps/TransportFieldCapabilitiesActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/fieldcaps/TransportFieldCapabilitiesActionTests.java
@@ -26,7 +26,6 @@ import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
 
 import java.io.IOException;
-import java.util.Collections;
 import java.util.concurrent.TimeUnit;
 
 import static org.hamcrest.Matchers.containsString;
@@ -64,7 +63,6 @@ public class TransportFieldCapabilitiesActionTests extends ESTestCase {
             });
 
             IndicesService indicesService = mock(IndicesService.class);
-            when(indicesService.getAllMetadataFields()).thenReturn(Collections.singleton("_index"));
             ClusterService clusterService = new ClusterService(
                 settings,
                 new ClusterSettings(settings, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS),


### PR DESCRIPTION
This check is no longer needed because 8.3+ won't handle index field-caps responses from 7.13 or before.