### PR TITLE
[8.2] Add Java 17 GraalVM to Java testing matrix (60fd491f)

### DIFF
--- a/.ci/matrix-runtime-javas.yml
+++ b/.ci/matrix-runtime-javas.yml
@@ -6,5 +6,6 @@
 # or 'openjdk' followed by the major release number.
 
 ES_RUNTIME_JAVA:
+  - graalvm-ce17
   - openjdk17
   - openjdk18


### PR DESCRIPTION
Backports the following commits to 8.2:
 - Add Java 17 GraalVM to Java testing matrix (60fd491f)