### PR TITLE
AbstractAnalyzerProvider does not need to extend AbstractIndexComponent

### DIFF
--- a/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/ArabicAnalyzerProvider.java
+++ b/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/ArabicAnalyzerProvider.java
@@ -21,7 +21,7 @@ public class ArabicAnalyzerProvider extends AbstractIndexAnalyzerProvider<Arabic
     private final ArabicAnalyzer arabicAnalyzer;
 
     ArabicAnalyzerProvider(IndexSettings indexSettings, Environment env, String name, Settings settings) {
-        super(indexSettings, name, settings);
+        super(name, settings);
         arabicAnalyzer = new ArabicAnalyzer(
             Analysis.parseStopWords(env, settings, ArabicAnalyzer.getDefaultStopSet()),
             Analysis.parseStemExclusion(settings, CharArraySet.EMPTY_SET)

--- a/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/ArmenianAnalyzerProvider.java
+++ b/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/ArmenianAnalyzerProvider.java
@@ -21,7 +21,7 @@ public class ArmenianAnalyzerProvider extends AbstractIndexAnalyzerProvider<Arme
     private final ArmenianAnalyzer analyzer;
 
     ArmenianAnalyzerProvider(IndexSettings indexSettings, Environment env, String name, Settings settings) {
-        super(indexSettings, name, settings);
+        super(name, settings);
         analyzer = new ArmenianAnalyzer(
             Analysis.parseStopWords(env, settings, ArmenianAnalyzer.getDefaultStopSet()),
             Analysis.parseStemExclusion(settings, CharArraySet.EMPTY_SET)

--- a/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/BasqueAnalyzerProvider.java
+++ b/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/BasqueAnalyzerProvider.java
@@ -21,7 +21,7 @@ public class BasqueAnalyzerProvider extends AbstractIndexAnalyzerProvider<Basque
     private final BasqueAnalyzer analyzer;
 
     BasqueAnalyzerProvider(IndexSettings indexSettings, Environment env, String name, Settings settings) {
-        super(indexSettings, name, settings);
+        super(name, settings);
         analyzer = new BasqueAnalyzer(
             Analysis.parseStopWords(env, settings, BasqueAnalyzer.getDefaultStopSet()),
             Analysis.parseStemExclusion(settings, CharArraySet.EMPTY_SET)

--- a/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/BengaliAnalyzerProvider.java
+++ b/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/BengaliAnalyzerProvider.java
@@ -21,7 +21,7 @@ public class BengaliAnalyzerProvider extends AbstractIndexAnalyzerProvider<Benga
     private final BengaliAnalyzer analyzer;
 
     BengaliAnalyzerProvider(IndexSettings indexSettings, Environment env, String name, Settings settings) {
-        super(indexSettings, name, settings);
+        super(name, settings);
         analyzer = new BengaliAnalyzer(
             Analysis.parseStopWords(env, settings, BengaliAnalyzer.getDefaultStopSet()),
             Analysis.parseStemExclusion(settings, CharArraySet.EMPTY_SET)

--- a/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/BrazilianAnalyzerProvider.java
+++ b/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/BrazilianAnalyzerProvider.java
@@ -21,7 +21,7 @@ public class BrazilianAnalyzerProvider extends AbstractIndexAnalyzerProvider<Bra
     private final BrazilianAnalyzer analyzer;
 
     BrazilianAnalyzerProvider(IndexSettings indexSettings, Environment env, String name, Settings settings) {
-        super(indexSettings, name, settings);
+        super(name, settings);
         analyzer = new BrazilianAnalyzer(
             Analysis.parseStopWords(env, settings, BrazilianAnalyzer.getDefaultStopSet()),
             Analysis.parseStemExclusion(settings, CharArraySet.EMPTY_SET)

--- a/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/BulgarianAnalyzerProvider.java
+++ b/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/BulgarianAnalyzerProvider.java
@@ -21,7 +21,7 @@ public class BulgarianAnalyzerProvider extends AbstractIndexAnalyzerProvider<Bul
     private final BulgarianAnalyzer analyzer;
 
     BulgarianAnalyzerProvider(IndexSettings indexSettings, Environment env, String name, Settings settings) {
-        super(indexSettings, name, settings);
+        super(name, settings);
         analyzer = new BulgarianAnalyzer(
             Analysis.parseStopWords(env, settings, BulgarianAnalyzer.getDefaultStopSet()),
             Analysis.parseStemExclusion(settings, CharArraySet.EMPTY_SET)

--- a/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/CatalanAnalyzerProvider.java
+++ b/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/CatalanAnalyzerProvider.java
@@ -21,7 +21,7 @@ public class CatalanAnalyzerProvider extends AbstractIndexAnalyzerProvider<Catal
     private final CatalanAnalyzer analyzer;
 
     CatalanAnalyzerProvider(IndexSettings indexSettings, Environment env, String name, Settings settings) {
-        super(indexSettings, name, settings);
+        super(name, settings);
         analyzer = new CatalanAnalyzer(
             Analysis.parseStopWords(env, settings, CatalanAnalyzer.getDefaultStopSet()),
             Analysis.parseStemExclusion(settings, CharArraySet.EMPTY_SET)

--- a/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/ChineseAnalyzerProvider.java
+++ b/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/ChineseAnalyzerProvider.java
@@ -23,7 +23,7 @@ public class ChineseAnalyzerProvider extends AbstractIndexAnalyzerProvider<Stand
     private final StandardAnalyzer analyzer;
 
     ChineseAnalyzerProvider(IndexSettings indexSettings, Environment environment, String name, Settings settings) {
-        super(indexSettings, name, settings);
+        super(name, settings);
         // old index: best effort
         analyzer = new StandardAnalyzer(EnglishAnalyzer.ENGLISH_STOP_WORDS_SET);
 

--- a/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/CjkAnalyzerProvider.java
+++ b/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/CjkAnalyzerProvider.java
@@ -21,7 +21,7 @@ public class CjkAnalyzerProvider extends AbstractIndexAnalyzerProvider<CJKAnalyz
     private final CJKAnalyzer analyzer;
 
     CjkAnalyzerProvider(IndexSettings indexSettings, Environment env, String name, Settings settings) {
-        super(indexSettings, name, settings);
+        super(name, settings);
         CharArraySet stopWords = Analysis.parseStopWords(env, settings, CJKAnalyzer.getDefaultStopSet());
 
         analyzer = new CJKAnalyzer(stopWords);

--- a/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/CzechAnalyzerProvider.java
+++ b/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/CzechAnalyzerProvider.java
@@ -21,7 +21,7 @@ public class CzechAnalyzerProvider extends AbstractIndexAnalyzerProvider<CzechAn
     private final CzechAnalyzer analyzer;
 
     CzechAnalyzerProvider(IndexSettings indexSettings, Environment env, String name, Settings settings) {
-        super(indexSettings, name, settings);
+        super(name, settings);
         analyzer = new CzechAnalyzer(
             Analysis.parseStopWords(env, settings, CzechAnalyzer.getDefaultStopSet()),
             Analysis.parseStemExclusion(settings, CharArraySet.EMPTY_SET)

--- a/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/DanishAnalyzerProvider.java
+++ b/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/DanishAnalyzerProvider.java
@@ -21,7 +21,7 @@ public class DanishAnalyzerProvider extends AbstractIndexAnalyzerProvider<Danish
     private final DanishAnalyzer analyzer;
 
     DanishAnalyzerProvider(IndexSettings indexSettings, Environment env, String name, Settings settings) {
-        super(indexSettings, name, settings);
+        super(name, settings);
         analyzer = new DanishAnalyzer(
             Analysis.parseStopWords(env, settings, DanishAnalyzer.getDefaultStopSet()),
             Analysis.parseStemExclusion(settings, CharArraySet.EMPTY_SET)

--- a/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/DutchAnalyzerProvider.java
+++ b/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/DutchAnalyzerProvider.java
@@ -21,7 +21,7 @@ public class DutchAnalyzerProvider extends AbstractIndexAnalyzerProvider<DutchAn
     private final DutchAnalyzer analyzer;
 
     DutchAnalyzerProvider(IndexSettings indexSettings, Environment env, String name, Settings settings) {
-        super(indexSettings, name, settings);
+        super(name, settings);
         analyzer = new DutchAnalyzer(
             Analysis.parseStopWords(env, settings, DutchAnalyzer.getDefaultStopSet()),
             Analysis.parseStemExclusion(settings, CharArraySet.EMPTY_SET)

--- a/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/EnglishAnalyzerProvider.java
+++ b/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/EnglishAnalyzerProvider.java
@@ -21,7 +21,7 @@ public class EnglishAnalyzerProvider extends AbstractIndexAnalyzerProvider<Engli
     private final EnglishAnalyzer analyzer;
 
     EnglishAnalyzerProvider(IndexSettings indexSettings, Environment env, String name, Settings settings) {
-        super(indexSettings, name, settings);
+        super(name, settings);
         analyzer = new EnglishAnalyzer(
             Analysis.parseStopWords(env, settings, EnglishAnalyzer.getDefaultStopSet()),
             Analysis.parseStemExclusion(settings, CharArraySet.EMPTY_SET)

--- a/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/EstonianAnalyzerProvider.java
+++ b/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/EstonianAnalyzerProvider.java
@@ -21,7 +21,7 @@ public class EstonianAnalyzerProvider extends AbstractIndexAnalyzerProvider<Esto
     private final EstonianAnalyzer analyzer;
 
     EstonianAnalyzerProvider(IndexSettings indexSettings, Environment env, String name, Settings settings) {
-        super(indexSettings, name, settings);
+        super(name, settings);
         analyzer = new EstonianAnalyzer(
             Analysis.parseStopWords(env, settings, EstonianAnalyzer.getDefaultStopSet()),
             Analysis.parseStemExclusion(settings, CharArraySet.EMPTY_SET)

--- a/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/FingerprintAnalyzerProvider.java
+++ b/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/FingerprintAnalyzerProvider.java
@@ -33,7 +33,7 @@ public class FingerprintAnalyzerProvider extends AbstractIndexAnalyzerProvider<A
     private final FingerprintAnalyzer analyzer;
 
     FingerprintAnalyzerProvider(IndexSettings indexSettings, Environment env, String name, Settings settings) {
-        super(indexSettings, name, settings);
+        super(name, settings);
 
         char separator = parseSeparator(settings);
         int maxOutputSize = settings.getAsInt(MAX_OUTPUT_SIZE.getPreferredName(), DEFAULT_MAX_OUTPUT_SIZE);

--- a/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/FinnishAnalyzerProvider.java
+++ b/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/FinnishAnalyzerProvider.java
@@ -21,7 +21,7 @@ public class FinnishAnalyzerProvider extends AbstractIndexAnalyzerProvider<Finni
     private final FinnishAnalyzer analyzer;
 
     FinnishAnalyzerProvider(IndexSettings indexSettings, Environment env, String name, Settings settings) {
-        super(indexSettings, name, settings);
+        super(name, settings);
         analyzer = new FinnishAnalyzer(
             Analysis.parseStopWords(env, settings, FinnishAnalyzer.getDefaultStopSet()),
             Analysis.parseStemExclusion(settings, CharArraySet.EMPTY_SET)

--- a/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/FrenchAnalyzerProvider.java
+++ b/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/FrenchAnalyzerProvider.java
@@ -21,7 +21,7 @@ public class FrenchAnalyzerProvider extends AbstractIndexAnalyzerProvider<French
     private final FrenchAnalyzer analyzer;
 
     FrenchAnalyzerProvider(IndexSettings indexSettings, Environment env, String name, Settings settings) {
-        super(indexSettings, name, settings);
+        super(name, settings);
         analyzer = new FrenchAnalyzer(
             Analysis.parseStopWords(env, settings, FrenchAnalyzer.getDefaultStopSet()),
             Analysis.parseStemExclusion(settings, CharArraySet.EMPTY_SET)

--- a/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/GalicianAnalyzerProvider.java
+++ b/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/GalicianAnalyzerProvider.java
@@ -21,7 +21,7 @@ public class GalicianAnalyzerProvider extends AbstractIndexAnalyzerProvider<Gali
     private final GalicianAnalyzer analyzer;
 
     GalicianAnalyzerProvider(IndexSettings indexSettings, Environment env, String name, Settings settings) {
-        super(indexSettings, name, settings);
+        super(name, settings);
         analyzer = new GalicianAnalyzer(
             Analysis.parseStopWords(env, settings, GalicianAnalyzer.getDefaultStopSet()),
             Analysis.parseStemExclusion(settings, CharArraySet.EMPTY_SET)

--- a/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/GermanAnalyzerProvider.java
+++ b/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/GermanAnalyzerProvider.java
@@ -21,7 +21,7 @@ public class GermanAnalyzerProvider extends AbstractIndexAnalyzerProvider<German
     private final GermanAnalyzer analyzer;
 
     GermanAnalyzerProvider(IndexSettings indexSettings, Environment env, String name, Settings settings) {
-        super(indexSettings, name, settings);
+        super(name, settings);
         analyzer = new GermanAnalyzer(
             Analysis.parseStopWords(env, settings, GermanAnalyzer.getDefaultStopSet()),
             Analysis.parseStemExclusion(settings, CharArraySet.EMPTY_SET)

--- a/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/GreekAnalyzerProvider.java
+++ b/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/GreekAnalyzerProvider.java
@@ -20,7 +20,7 @@ public class GreekAnalyzerProvider extends AbstractIndexAnalyzerProvider<GreekAn
     private final GreekAnalyzer analyzer;
 
     GreekAnalyzerProvider(IndexSettings indexSettings, Environment env, String name, Settings settings) {
-        super(indexSettings, name, settings);
+        super(name, settings);
         analyzer = new GreekAnalyzer(Analysis.parseStopWords(env, settings, GreekAnalyzer.getDefaultStopSet()));
     }
 

--- a/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/HindiAnalyzerProvider.java
+++ b/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/HindiAnalyzerProvider.java
@@ -21,7 +21,7 @@ public class HindiAnalyzerProvider extends AbstractIndexAnalyzerProvider<HindiAn
     private final HindiAnalyzer analyzer;
 
     HindiAnalyzerProvider(IndexSettings indexSettings, Environment env, String name, Settings settings) {
-        super(indexSettings, name, settings);
+        super(name, settings);
         analyzer = new HindiAnalyzer(
             Analysis.parseStopWords(env, settings, HindiAnalyzer.getDefaultStopSet()),
             Analysis.parseStemExclusion(settings, CharArraySet.EMPTY_SET)

--- a/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/HungarianAnalyzerProvider.java
+++ b/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/HungarianAnalyzerProvider.java
@@ -21,7 +21,7 @@ public class HungarianAnalyzerProvider extends AbstractIndexAnalyzerProvider<Hun
     private final HungarianAnalyzer analyzer;
 
     HungarianAnalyzerProvider(IndexSettings indexSettings, Environment env, String name, Settings settings) {
-        super(indexSettings, name, settings);
+        super(name, settings);
         analyzer = new HungarianAnalyzer(
             Analysis.parseStopWords(env, settings, HungarianAnalyzer.getDefaultStopSet()),
             Analysis.parseStemExclusion(settings, CharArraySet.EMPTY_SET)

--- a/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/IndonesianAnalyzerProvider.java
+++ b/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/IndonesianAnalyzerProvider.java
@@ -21,7 +21,7 @@ public class IndonesianAnalyzerProvider extends AbstractIndexAnalyzerProvider<In
     private final IndonesianAnalyzer analyzer;
 
     IndonesianAnalyzerProvider(IndexSettings indexSettings, Environment env, String name, Settings settings) {
-        super(indexSettings, name, settings);
+        super(name, settings);
         analyzer = new IndonesianAnalyzer(
             Analysis.parseStopWords(env, settings, IndonesianAnalyzer.getDefaultStopSet()),
             Analysis.parseStemExclusion(settings, CharArraySet.EMPTY_SET)

--- a/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/IrishAnalyzerProvider.java
+++ b/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/IrishAnalyzerProvider.java
@@ -24,7 +24,7 @@ public class IrishAnalyzerProvider extends AbstractIndexAnalyzerProvider<IrishAn
     private final IrishAnalyzer analyzer;
 
     IrishAnalyzerProvider(IndexSettings indexSettings, Environment env, String name, Settings settings) {
-        super(indexSettings, name, settings);
+        super(name, settings);
         analyzer = new IrishAnalyzer(
             Analysis.parseStopWords(env, settings, IrishAnalyzer.getDefaultStopSet()),
             Analysis.parseStemExclusion(settings, CharArraySet.EMPTY_SET)

--- a/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/ItalianAnalyzerProvider.java
+++ b/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/ItalianAnalyzerProvider.java
@@ -21,7 +21,7 @@ public class ItalianAnalyzerProvider extends AbstractIndexAnalyzerProvider<Itali
     private final ItalianAnalyzer analyzer;
 
     ItalianAnalyzerProvider(IndexSettings indexSettings, Environment env, String name, Settings settings) {
-        super(indexSettings, name, settings);
+        super(name, settings);
         analyzer = new ItalianAnalyzer(
             Analysis.parseStopWords(env, settings, ItalianAnalyzer.getDefaultStopSet()),
             Analysis.parseStemExclusion(settings, CharArraySet.EMPTY_SET)

--- a/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/LatvianAnalyzerProvider.java
+++ b/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/LatvianAnalyzerProvider.java
@@ -21,7 +21,7 @@ public class LatvianAnalyzerProvider extends AbstractIndexAnalyzerProvider<Latvi
     private final LatvianAnalyzer analyzer;
 
     LatvianAnalyzerProvider(IndexSettings indexSettings, Environment env, String name, Settings settings) {
-        super(indexSettings, name, settings);
+        super(name, settings);
         analyzer = new LatvianAnalyzer(
             Analysis.parseStopWords(env, settings, LatvianAnalyzer.getDefaultStopSet()),
             Analysis.parseStemExclusion(settings, CharArraySet.EMPTY_SET)

--- a/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/LithuanianAnalyzerProvider.java
+++ b/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/LithuanianAnalyzerProvider.java
@@ -24,7 +24,7 @@ public class LithuanianAnalyzerProvider extends AbstractIndexAnalyzerProvider<Li
     private final LithuanianAnalyzer analyzer;
 
     LithuanianAnalyzerProvider(IndexSettings indexSettings, Environment env, String name, Settings settings) {
-        super(indexSettings, name, settings);
+        super(name, settings);
         analyzer = new LithuanianAnalyzer(
             Analysis.parseStopWords(env, settings, LithuanianAnalyzer.getDefaultStopSet()),
             Analysis.parseStemExclusion(settings, CharArraySet.EMPTY_SET)

--- a/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/NorwegianAnalyzerProvider.java
+++ b/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/NorwegianAnalyzerProvider.java
@@ -21,7 +21,7 @@ public class NorwegianAnalyzerProvider extends AbstractIndexAnalyzerProvider<Nor
     private final NorwegianAnalyzer analyzer;
 
     NorwegianAnalyzerProvider(IndexSettings indexSettings, Environment env, String name, Settings settings) {
-        super(indexSettings, name, settings);
+        super(name, settings);
         analyzer = new NorwegianAnalyzer(
             Analysis.parseStopWords(env, settings, NorwegianAnalyzer.getDefaultStopSet()),
             Analysis.parseStemExclusion(settings, CharArraySet.EMPTY_SET)

--- a/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/PatternAnalyzerProvider.java
+++ b/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/PatternAnalyzerProvider.java
@@ -24,7 +24,7 @@ public class PatternAnalyzerProvider extends AbstractIndexAnalyzerProvider<Analy
     private final PatternAnalyzer analyzer;
 
     PatternAnalyzerProvider(IndexSettings indexSettings, Environment env, String name, Settings settings) {
-        super(indexSettings, name, settings);
+        super(name, settings);
 
         final CharArraySet defaultStopwords = CharArraySet.EMPTY_SET;
         boolean lowercase = settings.getAsBoolean("lowercase", true);

--- a/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/PersianAnalyzerProvider.java
+++ b/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/PersianAnalyzerProvider.java
@@ -20,7 +20,7 @@ public class PersianAnalyzerProvider extends AbstractIndexAnalyzerProvider<Persi
     private final PersianAnalyzer analyzer;
 
     PersianAnalyzerProvider(IndexSettings indexSettings, Environment env, String name, Settings settings) {
-        super(indexSettings, name, settings);
+        super(name, settings);
         analyzer = new PersianAnalyzer(Analysis.parseStopWords(env, settings, PersianAnalyzer.getDefaultStopSet()));
     }
 

--- a/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/PortugueseAnalyzerProvider.java
+++ b/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/PortugueseAnalyzerProvider.java
@@ -21,7 +21,7 @@ public class PortugueseAnalyzerProvider extends AbstractIndexAnalyzerProvider<Po
     private final PortugueseAnalyzer analyzer;
 
     PortugueseAnalyzerProvider(IndexSettings indexSettings, Environment env, String name, Settings settings) {
-        super(indexSettings, name, settings);
+        super(name, settings);
         analyzer = new PortugueseAnalyzer(
             Analysis.parseStopWords(env, settings, PortugueseAnalyzer.getDefaultStopSet()),
             Analysis.parseStemExclusion(settings, CharArraySet.EMPTY_SET)

--- a/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/RomanianAnalyzerProvider.java
+++ b/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/RomanianAnalyzerProvider.java
@@ -21,7 +21,7 @@ public class RomanianAnalyzerProvider extends AbstractIndexAnalyzerProvider<Roma
     private final RomanianAnalyzer analyzer;
 
     RomanianAnalyzerProvider(IndexSettings indexSettings, Environment env, String name, Settings settings) {
-        super(indexSettings, name, settings);
+        super(name, settings);
         analyzer = new RomanianAnalyzer(
             Analysis.parseStopWords(env, settings, RomanianAnalyzer.getDefaultStopSet()),
             Analysis.parseStemExclusion(settings, CharArraySet.EMPTY_SET)

--- a/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/RussianAnalyzerProvider.java
+++ b/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/RussianAnalyzerProvider.java
@@ -21,7 +21,7 @@ public class RussianAnalyzerProvider extends AbstractIndexAnalyzerProvider<Russi
     private final RussianAnalyzer analyzer;
 
     RussianAnalyzerProvider(IndexSettings indexSettings, Environment env, String name, Settings settings) {
-        super(indexSettings, name, settings);
+        super(name, settings);
         analyzer = new RussianAnalyzer(
             Analysis.parseStopWords(env, settings, RussianAnalyzer.getDefaultStopSet()),
             Analysis.parseStemExclusion(settings, CharArraySet.EMPTY_SET)

--- a/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/SnowballAnalyzerProvider.java
+++ b/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/SnowballAnalyzerProvider.java
@@ -50,7 +50,7 @@ public class SnowballAnalyzerProvider extends AbstractIndexAnalyzerProvider<Snow
     private final SnowballAnalyzer analyzer;
 
     SnowballAnalyzerProvider(IndexSettings indexSettings, Environment env, String name, Settings settings) {
-        super(indexSettings, name, settings);
+        super(name, settings);
 
         String language = settings.get("language", settings.get("name", "English"));
         CharArraySet defaultStopwords = DEFAULT_LANGUAGE_STOP_WORDS.getOrDefault(language, CharArraySet.EMPTY_SET);

--- a/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/SoraniAnalyzerProvider.java
+++ b/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/SoraniAnalyzerProvider.java
@@ -24,7 +24,7 @@ public class SoraniAnalyzerProvider extends AbstractIndexAnalyzerProvider<Sorani
     private final SoraniAnalyzer analyzer;
 
     SoraniAnalyzerProvider(IndexSettings indexSettings, Environment env, String name, Settings settings) {
-        super(indexSettings, name, settings);
+        super(name, settings);
         analyzer = new SoraniAnalyzer(
             Analysis.parseStopWords(env, settings, SoraniAnalyzer.getDefaultStopSet()),
             Analysis.parseStemExclusion(settings, CharArraySet.EMPTY_SET)

--- a/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/SpanishAnalyzerProvider.java
+++ b/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/SpanishAnalyzerProvider.java
@@ -21,7 +21,7 @@ public class SpanishAnalyzerProvider extends AbstractIndexAnalyzerProvider<Spani
     private final SpanishAnalyzer analyzer;
 
     SpanishAnalyzerProvider(IndexSettings indexSettings, Environment env, String name, Settings settings) {
-        super(indexSettings, name, settings);
+        super(name, settings);
         analyzer = new SpanishAnalyzer(
             Analysis.parseStopWords(env, settings, SpanishAnalyzer.getDefaultStopSet()),
             Analysis.parseStemExclusion(settings, CharArraySet.EMPTY_SET)

--- a/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/SwedishAnalyzerProvider.java
+++ b/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/SwedishAnalyzerProvider.java
@@ -21,7 +21,7 @@ public class SwedishAnalyzerProvider extends AbstractIndexAnalyzerProvider<Swedi
     private final SwedishAnalyzer analyzer;
 
     SwedishAnalyzerProvider(IndexSettings indexSettings, Environment env, String name, Settings settings) {
-        super(indexSettings, name, settings);
+        super(name, settings);
         analyzer = new SwedishAnalyzer(
             Analysis.parseStopWords(env, settings, SwedishAnalyzer.getDefaultStopSet()),
             Analysis.parseStemExclusion(settings, CharArraySet.EMPTY_SET)

--- a/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/ThaiAnalyzerProvider.java
+++ b/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/ThaiAnalyzerProvider.java
@@ -20,7 +20,7 @@ public class ThaiAnalyzerProvider extends AbstractIndexAnalyzerProvider<ThaiAnal
     private final ThaiAnalyzer analyzer;
 
     ThaiAnalyzerProvider(IndexSettings indexSettings, Environment env, String name, Settings settings) {
-        super(indexSettings, name, settings);
+        super(name, settings);
         analyzer = new ThaiAnalyzer(Analysis.parseStopWords(env, settings, ThaiAnalyzer.getDefaultStopSet()));
     }
 

--- a/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/TurkishAnalyzerProvider.java
+++ b/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/TurkishAnalyzerProvider.java
@@ -21,7 +21,7 @@ public class TurkishAnalyzerProvider extends AbstractIndexAnalyzerProvider<Turki
     private final TurkishAnalyzer analyzer;
 
     TurkishAnalyzerProvider(IndexSettings indexSettings, Environment env, String name, Settings settings) {
-        super(indexSettings, name, settings);
+        super(name, settings);
         analyzer = new TurkishAnalyzer(
             Analysis.parseStopWords(env, settings, TurkishAnalyzer.getDefaultStopSet()),
             Analysis.parseStemExclusion(settings, CharArraySet.EMPTY_SET)

--- a/plugins/analysis-icu/src/main/java/org/elasticsearch/plugin/analysis/icu/IcuAnalyzerProvider.java
+++ b/plugins/analysis-icu/src/main/java/org/elasticsearch/plugin/analysis/icu/IcuAnalyzerProvider.java
@@ -27,7 +27,7 @@ public class IcuAnalyzerProvider extends AbstractIndexAnalyzerProvider<Analyzer>
     private final Normalizer2 normalizer;
 
     public IcuAnalyzerProvider(IndexSettings indexSettings, Environment environment, String name, Settings settings) {
-        super(indexSettings, name, settings);
+        super(name, settings);
         String method = settings.get("method", "nfkc_cf");
         String mode = settings.get("mode", "compose");
         if ("compose".equals(mode) == false && "decompose".equals(mode) == false) {

--- a/plugins/analysis-kuromoji/src/main/java/org/elasticsearch/plugin/analysis/kuromoji/KuromojiAnalyzerProvider.java
+++ b/plugins/analysis-kuromoji/src/main/java/org/elasticsearch/plugin/analysis/kuromoji/KuromojiAnalyzerProvider.java
@@ -25,7 +25,7 @@ public class KuromojiAnalyzerProvider extends AbstractIndexAnalyzerProvider<Japa
     private final JapaneseAnalyzer analyzer;
 
     public KuromojiAnalyzerProvider(IndexSettings indexSettings, Environment env, String name, Settings settings) {
-        super(indexSettings, name, settings);
+        super(name, settings);
         final Set<?> stopWords = Analysis.parseStopWords(env, settings, JapaneseAnalyzer.getDefaultStopSet());
         final JapaneseTokenizer.Mode mode = KuromojiTokenizerFactory.getMode(settings);
         final UserDictionary userDictionary = KuromojiTokenizerFactory.getUserDictionary(env, settings);

--- a/plugins/analysis-kuromoji/src/main/java/org/elasticsearch/plugin/analysis/kuromoji/KuromojiCompletionAnalyzerProvider.java
+++ b/plugins/analysis-kuromoji/src/main/java/org/elasticsearch/plugin/analysis/kuromoji/KuromojiCompletionAnalyzerProvider.java
@@ -21,7 +21,7 @@ public class KuromojiCompletionAnalyzerProvider extends AbstractIndexAnalyzerPro
     private final JapaneseCompletionAnalyzer analyzer;
 
     public KuromojiCompletionAnalyzerProvider(IndexSettings indexSettings, Environment env, String name, Settings settings) {
-        super(indexSettings, name, settings);
+        super(name, settings);
         final UserDictionary userDictionary = KuromojiTokenizerFactory.getUserDictionary(env, settings);
         final Mode mode = KuromojiCompletionFilterFactory.getMode(settings);
         analyzer = new JapaneseCompletionAnalyzer(userDictionary, mode);

--- a/plugins/analysis-nori/src/main/java/org/elasticsearch/plugin/analysis/nori/NoriAnalyzerProvider.java
+++ b/plugins/analysis-nori/src/main/java/org/elasticsearch/plugin/analysis/nori/NoriAnalyzerProvider.java
@@ -28,7 +28,7 @@ public class NoriAnalyzerProvider extends AbstractIndexAnalyzerProvider<KoreanAn
     private final KoreanAnalyzer analyzer;
 
     public NoriAnalyzerProvider(IndexSettings indexSettings, Environment env, String name, Settings settings) {
-        super(indexSettings, name, settings);
+        super(name, settings);
         final KoreanTokenizer.DecompoundMode mode = NoriTokenizerFactory.getMode(settings);
         final UserDictionary userDictionary = NoriTokenizerFactory.getUserDictionary(env, settings);
         final List<String> tagList = Analysis.getWordList(env, settings, "stoptags");

--- a/plugins/analysis-smartcn/src/main/java/org/elasticsearch/plugin/analysis/smartcn/SmartChineseAnalyzerProvider.java
+++ b/plugins/analysis-smartcn/src/main/java/org/elasticsearch/plugin/analysis/smartcn/SmartChineseAnalyzerProvider.java
@@ -19,7 +19,7 @@ public class SmartChineseAnalyzerProvider extends AbstractIndexAnalyzerProvider<
     private final SmartChineseAnalyzer analyzer;
 
     public SmartChineseAnalyzerProvider(IndexSettings indexSettings, Environment environment, String name, Settings settings) {
-        super(indexSettings, name, settings);
+        super(name, settings);
 
         analyzer = new SmartChineseAnalyzer(SmartChineseAnalyzer.getDefaultStopSet());
     }

--- a/plugins/analysis-stempel/src/main/java/org/elasticsearch/index/analysis/pl/PolishAnalyzerProvider.java
+++ b/plugins/analysis-stempel/src/main/java/org/elasticsearch/index/analysis/pl/PolishAnalyzerProvider.java
@@ -19,7 +19,7 @@ public class PolishAnalyzerProvider extends AbstractIndexAnalyzerProvider<Polish
     private final PolishAnalyzer analyzer;
 
     public PolishAnalyzerProvider(IndexSettings indexSettings, Environment environment, String name, Settings settings) {
-        super(indexSettings, name, settings);
+        super(name, settings);
 
         analyzer = new PolishAnalyzer(PolishAnalyzer.getDefaultStopSet());
     }

--- a/plugins/analysis-ukrainian/src/main/java/org/elasticsearch/plugin/analysis/ukrainian/UkrainianAnalyzerProvider.java
+++ b/plugins/analysis-ukrainian/src/main/java/org/elasticsearch/plugin/analysis/ukrainian/UkrainianAnalyzerProvider.java
@@ -21,7 +21,7 @@ public class UkrainianAnalyzerProvider extends AbstractIndexAnalyzerProvider<Ukr
     private final UkrainianMorfologikAnalyzer analyzer;
 
     public UkrainianAnalyzerProvider(IndexSettings indexSettings, Environment env, String name, Settings settings) {
-        super(indexSettings, name, settings);
+        super(name, settings);
         analyzer = new UkrainianMorfologikAnalyzer(
             Analysis.parseStopWords(env, settings, UkrainianMorfologikAnalyzer.getDefaultStopwords()),
             Analysis.parseStemExclusion(settings, CharArraySet.EMPTY_SET)

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/fetch/subphase/highlight/HighlighterSearchIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/fetch/subphase/highlight/HighlighterSearchIT.java
@@ -3606,7 +3606,7 @@ public class HighlighterSearchIT extends ESIntegTestCase {
         @Override
         public Map<String, AnalysisModule.AnalysisProvider<AnalyzerProvider<? extends Analyzer>>> getAnalyzers() {
             return singletonMap("mock_whitespace", (indexSettings, environment, name, settings) -> {
-                return new AbstractIndexAnalyzerProvider<Analyzer>(indexSettings, name, settings) {
+                return new AbstractIndexAnalyzerProvider<Analyzer>(name, settings) {
 
                     MockAnalyzer instance = new MockAnalyzer(random(), MockTokenizer.WHITESPACE, false);
 

--- a/server/src/main/java/org/elasticsearch/index/analysis/AbstractIndexAnalyzerProvider.java
+++ b/server/src/main/java/org/elasticsearch/index/analysis/AbstractIndexAnalyzerProvider.java
@@ -10,21 +10,17 @@ package org.elasticsearch.index.analysis;
 
 import org.apache.lucene.analysis.Analyzer;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.index.AbstractIndexComponent;
-import org.elasticsearch.index.IndexSettings;
 
-public abstract class AbstractIndexAnalyzerProvider<T extends Analyzer> extends AbstractIndexComponent implements AnalyzerProvider<T> {
+public abstract class AbstractIndexAnalyzerProvider<T extends Analyzer> implements AnalyzerProvider<T> {
 
     private final String name;
 
     /**
      * Constructs a new analyzer component, with the index name and its settings and the analyzer name.
      *
-     * @param indexSettings the settings and the name of the index
      * @param name          The analyzer name
      */
-    public AbstractIndexAnalyzerProvider(IndexSettings indexSettings, String name, Settings settings) {
-        super(indexSettings);
+    public AbstractIndexAnalyzerProvider(String name, Settings settings) {
         this.name = name;
         Analysis.checkForDeprecatedVersion(name, settings);
     }

--- a/server/src/main/java/org/elasticsearch/index/analysis/AbstractTokenizerFactory.java
+++ b/server/src/main/java/org/elasticsearch/index/analysis/AbstractTokenizerFactory.java
@@ -9,15 +9,13 @@
 package org.elasticsearch.index.analysis;
 
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.index.AbstractIndexComponent;
 import org.elasticsearch.index.IndexSettings;
 
-public abstract class AbstractTokenizerFactory extends AbstractIndexComponent implements TokenizerFactory {
+public abstract class AbstractTokenizerFactory implements TokenizerFactory {
 
     private final String name;
 
     public AbstractTokenizerFactory(IndexSettings indexSettings, Settings settings, String name) {
-        super(indexSettings);
         Analysis.checkForDeprecatedVersion(name, settings);
         this.name = name;
     }

--- a/server/src/main/java/org/elasticsearch/index/analysis/CustomAnalyzerProvider.java
+++ b/server/src/main/java/org/elasticsearch/index/analysis/CustomAnalyzerProvider.java
@@ -28,7 +28,7 @@ public class CustomAnalyzerProvider extends AbstractIndexAnalyzerProvider<Analyz
     private Analyzer customAnalyzer;
 
     public CustomAnalyzerProvider(IndexSettings indexSettings, String name, Settings settings) {
-        super(indexSettings, name, settings);
+        super(name, settings);
         this.analyzerSettings = settings;
     }
 

--- a/server/src/main/java/org/elasticsearch/index/analysis/CustomNormalizerProvider.java
+++ b/server/src/main/java/org/elasticsearch/index/analysis/CustomNormalizerProvider.java
@@ -27,7 +27,7 @@ public final class CustomNormalizerProvider extends AbstractIndexAnalyzerProvide
     private CustomAnalyzer customAnalyzer;
 
     public CustomNormalizerProvider(IndexSettings indexSettings, String name, Settings settings) {
-        super(indexSettings, name, settings);
+        super(name, settings);
         this.analyzerSettings = settings;
     }
 

--- a/server/src/main/java/org/elasticsearch/index/analysis/KeywordAnalyzerProvider.java
+++ b/server/src/main/java/org/elasticsearch/index/analysis/KeywordAnalyzerProvider.java
@@ -18,7 +18,7 @@ public class KeywordAnalyzerProvider extends AbstractIndexAnalyzerProvider<Keywo
     private final KeywordAnalyzer keywordAnalyzer;
 
     public KeywordAnalyzerProvider(IndexSettings indexSettings, Environment environment, String name, Settings settings) {
-        super(indexSettings, name, settings);
+        super(name, settings);
         this.keywordAnalyzer = new KeywordAnalyzer();
     }
 

--- a/server/src/main/java/org/elasticsearch/index/analysis/LowercaseNormalizerProvider.java
+++ b/server/src/main/java/org/elasticsearch/index/analysis/LowercaseNormalizerProvider.java
@@ -20,7 +20,7 @@ public class LowercaseNormalizerProvider extends AbstractIndexAnalyzerProvider<L
     private final LowercaseNormalizer analyzer;
 
     public LowercaseNormalizerProvider(IndexSettings indexSettings, Environment env, String name, Settings settings) {
-        super(indexSettings, name, settings);
+        super(name, settings);
         this.analyzer = new LowercaseNormalizer();
     }
 

--- a/server/src/main/java/org/elasticsearch/index/analysis/SimpleAnalyzerProvider.java
+++ b/server/src/main/java/org/elasticsearch/index/analysis/SimpleAnalyzerProvider.java
@@ -18,7 +18,7 @@ public class SimpleAnalyzerProvider extends AbstractIndexAnalyzerProvider<Simple
     private final SimpleAnalyzer simpleAnalyzer;
 
     public SimpleAnalyzerProvider(IndexSettings indexSettings, Environment environment, String name, Settings settings) {
-        super(indexSettings, name, settings);
+        super(name, settings);
         this.simpleAnalyzer = new SimpleAnalyzer();
     }
 

--- a/server/src/main/java/org/elasticsearch/index/analysis/StandardAnalyzerProvider.java
+++ b/server/src/main/java/org/elasticsearch/index/analysis/StandardAnalyzerProvider.java
@@ -19,7 +19,7 @@ public class StandardAnalyzerProvider extends AbstractIndexAnalyzerProvider<Stan
     private final StandardAnalyzer standardAnalyzer;
 
     public StandardAnalyzerProvider(IndexSettings indexSettings, Environment env, String name, Settings settings) {
-        super(indexSettings, name, settings);
+        super(name, settings);
         final CharArraySet defaultStopwords = CharArraySet.EMPTY_SET;
         CharArraySet stopWords = Analysis.parseStopWords(env, settings, defaultStopwords);
         int maxTokenLength = settings.getAsInt("max_token_length", StandardAnalyzer.DEFAULT_MAX_TOKEN_LENGTH);

--- a/server/src/main/java/org/elasticsearch/index/analysis/StopAnalyzerProvider.java
+++ b/server/src/main/java/org/elasticsearch/index/analysis/StopAnalyzerProvider.java
@@ -20,7 +20,7 @@ public class StopAnalyzerProvider extends AbstractIndexAnalyzerProvider<StopAnal
     private final StopAnalyzer stopAnalyzer;
 
     public StopAnalyzerProvider(IndexSettings indexSettings, Environment env, String name, Settings settings) {
-        super(indexSettings, name, settings);
+        super(name, settings);
         CharArraySet stopWords = Analysis.parseStopWords(env, settings, EnglishAnalyzer.ENGLISH_STOP_WORDS_SET);
         this.stopAnalyzer = new StopAnalyzer(stopWords);
     }

--- a/server/src/main/java/org/elasticsearch/index/analysis/WhitespaceAnalyzerProvider.java
+++ b/server/src/main/java/org/elasticsearch/index/analysis/WhitespaceAnalyzerProvider.java
@@ -18,7 +18,7 @@ public class WhitespaceAnalyzerProvider extends AbstractIndexAnalyzerProvider<Wh
     private final WhitespaceAnalyzer analyzer;
 
     public WhitespaceAnalyzerProvider(IndexSettings indexSettings, Environment environment, String name, Settings settings) {
-        super(indexSettings, name, settings);
+        super(name, settings);
         this.analyzer = new WhitespaceAnalyzer();
     }
 


### PR DESCRIPTION
Remove the inheritance here to make instances smaller and speed up many-shards benchmarks a little (setting up the unused loggers turns out to be costly, we can fix this for other inheritors of `AbstractIndexComponent` as well).
Did not remove the dead arguments from the constructors in this PR as that would have been a
very noisy change.
