### PR TITLE
Port build dependencies to gradle version catalogue

### DIFF
--- a/build-conventions/build.gradle
+++ b/build-conventions/build.gradle
@@ -62,11 +62,19 @@ repositories {
 }
 
 dependencies {
+<<<<<<< HEAD
     api 'org.apache.maven:maven-model:3.6.2'
     api 'gradle.plugin.com.github.johnrengelman:shadow:7.1.2'
     api 'org.apache.rat:apache-rat:0.11'
     compileOnly "com.puppycrawl.tools:checkstyle:9.3"
     api('com.diffplug.spotless:spotless-plugin-gradle:6.5.2') {
+=======
+    api buildLibs.maven.model
+    api buildLibs.shadow.plugin
+    api buildLibs.apache.rat
+    compileOnly buildLibs.checkstyle
+    api(buildLibs.spotless.plugin) {
+>>>>>>> 822b1d11ee8 (Port build dependencies to gradle version catalogue)
       exclude module: "groovy-xml"
     }
 }

--- a/build-conventions/build.gradle
+++ b/build-conventions/build.gradle
@@ -62,19 +62,11 @@ repositories {
 }
 
 dependencies {
-<<<<<<< HEAD
-    api 'org.apache.maven:maven-model:3.6.2'
-    api 'gradle.plugin.com.github.johnrengelman:shadow:7.1.2'
-    api 'org.apache.rat:apache-rat:0.11'
-    compileOnly "com.puppycrawl.tools:checkstyle:9.3"
-    api('com.diffplug.spotless:spotless-plugin-gradle:6.5.2') {
-=======
     api buildLibs.maven.model
     api buildLibs.shadow.plugin
     api buildLibs.apache.rat
     compileOnly buildLibs.checkstyle
     api(buildLibs.spotless.plugin) {
->>>>>>> 822b1d11ee8 (Port build dependencies to gradle version catalogue)
       exclude module: "groovy-xml"
     }
 }

--- a/build-conventions/settings.gradle
+++ b/build-conventions/settings.gradle
@@ -6,3 +6,11 @@
  * Side Public License, v 1.
  */
 rootProject.name = 'build-conventions'
+
+dependencyResolutionManagement {
+    versionCatalogs {
+        create("buildLibs") {
+            from(files("../gradle/build.versions.toml"))
+        }
+    }
+}

--- a/build-conventions/settings.gradle
+++ b/build-conventions/settings.gradle
@@ -9,7 +9,7 @@ rootProject.name = 'build-conventions'
 
 dependencyResolutionManagement {
     versionCatalogs {
-        create("buildLibs") {
+        buildLibs {
             from(files("../gradle/build.versions.toml"))
         }
     }

--- a/build-tools-internal/build.gradle
+++ b/build-tools-internal/build.gradle
@@ -240,22 +240,21 @@ dependencies {
   api buildLibs.idea.ext
   // When upgrading forbidden apis, ensure dependency version is bumped in ThirdPartyPrecommitPlugin as well
   api buildLibs.forbiddenApis
-  api 'com.avast.gradle:gradle-docker-compose-plugin:0.14.13'
-  api 'org.apache.maven:maven-model:3.6.2'
+  api buildLibs.docker.compose
+  api buildLibs.maven.model
   // needs to match the jackson minor version in use
-  api 'com.networknt:json-schema-validator:1.0.49'
-  api "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:${versions.getProperty('jackson')}"
-  api 'org.ow2.asm:asm:9.2'
-  api 'org.ow2.asm:asm-tree:9.2'
-  api "org.apache.httpcomponents:httpclient:${versions.getProperty('httpclient')}"
-  api "org.apache.httpcomponents:httpcore:${versions.getProperty('httpcore')}"
+  api buildLibs.json.schema.validator
+  api buildLibs.jackson.dataformat.yaml
+  api buildLibs.asm
+  api buildLibs.asm.tree
+  api buildLibs.httpclient
+  api buildLibs.httpcore
   compileOnly buildLibs.checkstyle
   runtimeOnly "org.elasticsearch.gradle:reaper:$version"
   testImplementation buildLibs.checkstyle
   testImplementation buildLibs.wiremock
-  testImplementation 'org.mockito:mockito-core:1.9.5'
-  testImplementation "org.hamcrest:hamcrest:${versions.getProperty('hamcrest')}"
-
+  testImplementation buildLibs.mockito.core
+  testImplementation buildLibs.hamcrest
   testImplementation testFixtures("org.elasticsearch.gradle:build-tools:$version")
 
   testImplementation(platform(buildLibs.junit5.platform))
@@ -266,7 +265,7 @@ dependencies {
   integTestImplementation("org.junit.jupiter:junit-jupiter") {
     because 'allows to write and run Jupiter tests'
   }
-  integTestImplementation("net.bytebuddy:byte-buddy:1.12.9") {
+  integTestImplementation(buildLibs.bytebuddy) {
     because 'Generating dynamic mocks of internal libraries like JdkJarHell'
   }
   testRuntimeOnly("org.junit.vintage:junit-vintage-engine") {
@@ -276,20 +275,20 @@ dependencies {
     because 'allows tests to run from IDEs that bundle older version of launcher'
   }
 
-  testImplementation platform("org.spockframework:spock-bom:2.1-groovy-3.0")
-  testImplementation("org.spockframework:spock-core") {
+  testImplementation platform(buildLibs.spock.platform)
+  testImplementation(buildLibs.spock.core) {
     exclude module: "groovy"
   }
-  integTestImplementation platform("org.spockframework:spock-bom:2.1-groovy-3.0")
-  integTestImplementation("org.spockframework:spock-core") {
+  integTestImplementation platform(buildLibs.spock.platform)
+  integTestImplementation(buildLibs.spock.core) {
     exclude module: "groovy"
   }
   // required as we rely on junit4 rules
-  integTestImplementation("org.spockframework:spock-junit4") {
+  integTestImplementation(buildLibs.spock.junit4) {
     exclude module: "groovy"
   }
-  testImplementation "org.spockframework:spock-junit4"
-  integTestImplementation "org.xmlunit:xmlunit-core:2.8.2"
+  testImplementation buildLibs.spock.junit4
+  integTestImplementation buildLibs.xmlunit.core
 }
 
 tasks.named('test').configure {

--- a/build-tools-internal/build.gradle
+++ b/build-tools-internal/build.gradle
@@ -258,20 +258,20 @@ dependencies {
   testImplementation testFixtures("org.elasticsearch.gradle:build-tools:$version")
 
   testImplementation(platform(buildLibs.junit5.platform))
-  testImplementation("org.junit.jupiter:junit-jupiter") {
+  testImplementation(buildLibs.junit5.jupiter) {
     because 'allows to write and run Jupiter tests'
   }
   integTestImplementation(platform(buildLibs.junit5.platform))
-  integTestImplementation("org.junit.jupiter:junit-jupiter") {
+  integTestImplementation(buildLibs.junit5.jupiter) {
     because 'allows to write and run Jupiter tests'
   }
   integTestImplementation(buildLibs.bytebuddy) {
     because 'Generating dynamic mocks of internal libraries like JdkJarHell'
   }
-  testRuntimeOnly("org.junit.vintage:junit-vintage-engine") {
+  testRuntimeOnly(buildLibs.junit5.vintage) {
     because 'allows JUnit 3 and JUnit 4 tests to run'
   }
-  testRuntimeOnly("org.junit.platform:junit-platform-launcher") {
+  testRuntimeOnly(buildLibs.junit5.platform.launcher) {
     because 'allows tests to run from IDEs that bundle older version of launcher'
   }
 

--- a/build-tools-internal/build.gradle
+++ b/build-tools-internal/build.gradle
@@ -217,11 +217,11 @@ dependencies {
   components.all(JacksonAlignmentRule)
   constraints {
     // ensuring brought asm version brought in by spock is up-to-date
-    testImplementation 'org.ow2.asm:asm:9.3'
-    integTestImplementation 'org.ow2.asm:asm:9.3'
+    testImplementation buildLibs.asm
+    integTestImplementation buildLibs.asm
   }
   // Forcefully downgrade the jackson platform as used in production
-  api enforcedPlatform("com.fasterxml.jackson:jackson-bom:${versions.getProperty('jackson')}")
+  api enforcedPlatform(buildLibs.jackson.platform)
   api localGroovy()
   api gradleApi()
 
@@ -229,17 +229,17 @@ dependencies {
   api "org.elasticsearch.gradle:build-tools:$version"
 
   // same version as http client transitive dep
-  api 'commons-codec:commons-codec:1.11'
-  api 'org.apache.commons:commons-compress:1.21'
-  api 'org.apache.ant:ant:1.10.8'
-  api 'com.netflix.nebula:gradle-info-plugin:11.3.3'
-  api 'org.apache.rat:apache-rat:0.11'
-  api "net.java.dev.jna:jna:${versions.getProperty('jna')}"
-  api 'gradle.plugin.com.github.johnrengelman:shadow:7.1.2'
+  api buildLibs.commons.codec
+  api buildLibs.apache.compress
+  api buildLibs.ant
+  api buildLibs.nebula.info
+  api buildLibs.apache.rat
+  api buildLibs.jna
+  api buildLibs.shadow.plugin
   // for our ide tweaking
-  api 'gradle.plugin.org.jetbrains.gradle.plugin.idea-ext:gradle-idea-ext:1.1.1'
+  api buildLibs.idea.ext
   // When upgrading forbidden apis, ensure dependency version is bumped in ThirdPartyPrecommitPlugin as well
-  api 'de.thetaphi:forbiddenapis:3.2'
+  api buildLibs.forbiddenApis
   api 'com.avast.gradle:gradle-docker-compose-plugin:0.14.13'
   api 'org.apache.maven:maven-model:3.6.2'
   // needs to match the jackson minor version in use
@@ -249,20 +249,20 @@ dependencies {
   api 'org.ow2.asm:asm-tree:9.2'
   api "org.apache.httpcomponents:httpclient:${versions.getProperty('httpclient')}"
   api "org.apache.httpcomponents:httpcore:${versions.getProperty('httpcore')}"
-  compileOnly "com.puppycrawl.tools:checkstyle:${versions.getProperty('checkstyle')}"
+  compileOnly buildLibs.checkstyle
   runtimeOnly "org.elasticsearch.gradle:reaper:$version"
-  testImplementation "com.puppycrawl.tools:checkstyle:${versions.getProperty('checkstyle')}"
-  testImplementation 'com.github.tomakehurst:wiremock-jre8-standalone:2.23.2'
+  testImplementation buildLibs.checkstyle
+  testImplementation buildLibs.wiremock
   testImplementation 'org.mockito:mockito-core:1.9.5'
   testImplementation "org.hamcrest:hamcrest:${versions.getProperty('hamcrest')}"
 
   testImplementation testFixtures("org.elasticsearch.gradle:build-tools:$version")
 
-  testImplementation(platform("org.junit:junit-bom:${versions.getProperty('junit5')}"))
+  testImplementation(platform(buildLibs.junit5.platform))
   testImplementation("org.junit.jupiter:junit-jupiter") {
     because 'allows to write and run Jupiter tests'
   }
-  integTestImplementation(platform("org.junit:junit-bom:${versions.getProperty('junit5')}"))
+  integTestImplementation(platform(buildLibs.junit5.platform))
   integTestImplementation("org.junit.jupiter:junit-jupiter") {
     because 'allows to write and run Jupiter tests'
   }

--- a/build-tools-internal/build.gradle
+++ b/build-tools-internal/build.gradle
@@ -231,7 +231,6 @@ dependencies {
   // same version as http client transitive dep
   api buildLibs.commons.codec
   api buildLibs.apache.compress
-  api buildLibs.ant
   api buildLibs.nebula.info
   api buildLibs.apache.rat
   api buildLibs.jna

--- a/build-tools-internal/settings.gradle
+++ b/build-tools-internal/settings.gradle
@@ -1,6 +1,6 @@
 dependencyResolutionManagement {
     versionCatalogs {
-        create("buildLibs") {
+        buildLibs {
             from(files("../gradle/build.versions.toml"))
         }
     }

--- a/build-tools-internal/settings.gradle
+++ b/build-tools-internal/settings.gradle
@@ -1,0 +1,7 @@
+dependencyResolutionManagement {
+    versionCatalogs {
+        create("buildLibs") {
+            from(files("../gradle/build.versions.toml"))
+        }
+    }
+}

--- a/build-tools/build.gradle
+++ b/build-tools/build.gradle
@@ -122,7 +122,6 @@ dependencies {
     testFixturesApi gradleApi()
     testFixturesApi gradleTestKit()
     testFixturesApi buildLibs.junit
-    testFixturesApi buildLibs.junit
     testFixturesApi buildLibs.randomized.runner
     testFixturesApi buildLibs.wiremock
     testFixturesApi platform(buildLibs.spock.platform)

--- a/build-tools/build.gradle
+++ b/build-tools/build.gradle
@@ -135,14 +135,14 @@ dependencies {
     }
 
     integTestImplementation(platform(buildLibs.junit5.platform))
-    integTestImplementation("org.junit.jupiter:junit-jupiter") {
+    integTestImplementation(buildLibs.junit5.jupiter) {
         because 'allows to write and run Jupiter tests'
     }
-    integTestRuntimeOnly("org.junit.vintage:junit-vintage-engine") {
+    integTestRuntimeOnly(buildLibs.junit5.vintage) {
         because 'allows JUnit 3 and JUnit 4 tests to run'
     }
 
-    integTestRuntimeOnly("org.junit.platform:junit-platform-launcher") {
+    integTestRuntimeOnly(buildLibs.junit5.platform.launcher) {
         because 'allows tests to run from IDEs that bundle older version of launcher'
     }
 }

--- a/build-tools/build.gradle
+++ b/build-tools/build.gradle
@@ -130,7 +130,7 @@ dependencies {
         exclude module: "groovy"
     }
 
-    integTestImplementation(buildLibs.spock.junit) {
+    integTestImplementation(buildLibs.spock.junit4) {
         because 'required as we rely on junit4 rules'
     }
 

--- a/build-tools/build.gradle
+++ b/build-tools/build.gradle
@@ -106,34 +106,35 @@ repositories {
 dependencies {
     constraints {
         // ensuring brought asm version brought in by spock is up-to-date
-        testFixturesApi 'org.ow2.asm:asm:9.3'
-        integTestImplementation 'org.ow2.asm:asm:9.3'
+        testFixturesApi buildLibs.asm
+        integTestImplementation buildLibs.asm
     }
     reaper project('reaper')
 
     api localGroovy()
     api gradleApi()
-    api 'org.apache.commons:commons-compress:1.21'
-    api 'org.apache.ant:ant:1.10.8'
-    api 'commons-io:commons-io:2.2'
-    implementation 'org.ow2.asm:asm-tree:9.3'
-    implementation 'org.ow2.asm:asm:9.3'
+    api buildLibs.apache.compress
+    api buildLibs.ant
+    api buildLibs.commmons.io
+    implementation buildLibs.asm.tree
+    implementation buildLibs.asm
 
-    testFixturesApi "junit:junit:${versions.getProperty('junit')}"
-    testFixturesApi "com.carrotsearch.randomizedtesting:randomizedtesting-runner:${versions.getProperty('randomizedrunner')}"
     testFixturesApi gradleApi()
     testFixturesApi gradleTestKit()
-    testFixturesApi 'com.github.tomakehurst:wiremock-jre8-standalone:2.23.2'
-    testFixturesApi platform("org.spockframework:spock-bom:2.1-groovy-3.0")
-    testFixturesApi("org.spockframework:spock-core") {
+    testFixturesApi buildLibs.junit
+    testFixturesApi buildLibs.junit
+    testFixturesApi buildLibs.randomized.runner
+    testFixturesApi buildLibs.wiremock
+    testFixturesApi platform(buildLibs.spock.platform)
+    testFixturesApi(buildLibs.spock.core) {
         exclude module: "groovy"
     }
 
-    integTestImplementation("org.spockframework:spock-junit4") {
+    integTestImplementation(buildLibs.spock.junit) {
         because 'required as we rely on junit4 rules'
     }
 
-    integTestImplementation(platform("org.junit:junit-bom:${versions.getProperty('junit5')}"))
+    integTestImplementation(platform(buildLibs.junit5.platform))
     integTestImplementation("org.junit.jupiter:junit-jupiter") {
         because 'allows to write and run Jupiter tests'
     }

--- a/build-tools/settings.gradle
+++ b/build-tools/settings.gradle
@@ -9,7 +9,7 @@ include 'reaper'
 
 dependencyResolutionManagement {
     versionCatalogs {
-        create("buildLibs") {
+        buildLibs {
             from(files("../gradle/build.versions.toml"))
         }
     }

--- a/build-tools/settings.gradle
+++ b/build-tools/settings.gradle
@@ -6,3 +6,11 @@
  * Side Public License, v 1.
  */
 include 'reaper'
+
+dependencyResolutionManagement {
+    versionCatalogs {
+        create("buildLibs") {
+            from(files("../gradle/build.versions.toml"))
+        }
+    }
+}

--- a/gradle/build.versions.toml
+++ b/gradle/build.versions.toml
@@ -1,0 +1,28 @@
+[versions]
+asm = "9.3"
+spock = "2.1-groovy-3.0"
+junit5 = "5.7.1"
+[libraries]
+shadow-plugin = "gradle.plugin.com.github.johnrengelman:shadow:7.1.2"
+checkstyle = "com.puppycrawl.tools:checkstyle:9.3"
+spotless-plugin = "com.diffplug.spotless:spotless-plugin-gradle:6.5.2"
+maven-model = "org.apache.maven:maven-model:3.6.2"
+apache-rat = "org.apache.rat:apache-rat:0.11"
+asm = { group = "org.ow2.asm", name="asm", version.ref="asm" }
+asm-tree = { group = "org.ow2.asm", name="asm-tree", version.ref="asm" }
+apache-compress = "org.apache.commons:commons-compress:1.21"
+ant = "org.apache.ant:ant:1.10.8"
+commmons-io = "commons-io:commons-io:2.2"
+junit = "junit:junit:4.12"
+randomized-runner = "com.carrotsearch.randomizedtesting:randomizedtesting-runner:2.7.7"
+wiremock = "com.github.tomakehurst:wiremock-jre8-standalone:2.23.2"
+spock-platform = { group = "org.spockframework", name="spock-bom", version.ref="spock" }
+spock-core = { group = "org.spockframework", name="spock-core", version.ref="spock" }
+spock-junit = { group = "org.spockframework", name="spock-junit4", version.ref="spock" }
+junit5-platform = { group = "org.junit", name="junit-bom", version.ref="junit5" }
+jackson-platform = "com.fasterxml.jackson:jackson-bom:2.13.2"
+commons-codec = "commons-codec:commons-codec:1.11"
+nebula-info = "com.netflix.nebula:gradle-info-plugin:11.3.3"
+jna = "net.java.dev.jna:jna:5.10.0"
+idea-ext = "gradle.plugin.org.jetbrains.gradle.plugin.idea-ext:gradle-idea-ext:1.1.1"
+forbiddenApis = "de.thetaphi:forbiddenapis:3.2"

--- a/gradle/build.versions.toml
+++ b/gradle/build.versions.toml
@@ -26,6 +26,10 @@ jackson-platform = { group = "com.fasterxml.jackson", name="jackson-bom", versio
 jna = "net.java.dev.jna:jna:5.10.0"
 junit = "junit:junit:4.12"
 junit5-platform = { group = "org.junit", name="junit-bom", version.ref="junit5" }
+junit5-jupiter = "org.junit.jupiter:junit-jupiter:5.8.1"
+junit5-platform-launcher = "org.junit.platform:junit-platform-launcher:1.8.0"
+junit5-vintage = "org.junit.vintage:junit-vintage-engine:5.8.1"
+
 maven-model = "org.apache.maven:maven-model:3.6.2"
 mockito-core = "org.mockito:mockito-core:1.9.5"
 nebula-info = "com.netflix.nebula:gradle-info-plugin:11.3.3"

--- a/gradle/build.versions.toml
+++ b/gradle/build.versions.toml
@@ -1,38 +1,39 @@
 [versions]
 asm = "9.3"
-spock = "2.1-groovy-3.0"
-junit5 = "5.7.1"
 jackson = "2.13.2"
+junit5 = "5.7.1"
+spock = "2.1-groovy-3.0"
+
 [libraries]
-shadow-plugin = "gradle.plugin.com.github.johnrengelman:shadow:7.1.2"
-checkstyle = "com.puppycrawl.tools:checkstyle:9.3"
-spotless-plugin = "com.diffplug.spotless:spotless-plugin-gradle:6.5.2"
-maven-model = "org.apache.maven:maven-model:3.6.2"
+ant = "org.apache.ant:ant:1.10.8"
+apache-compress = "org.apache.commons:commons-compress:1.21"
 apache-rat = "org.apache.rat:apache-rat:0.11"
 asm = { group = "org.ow2.asm", name="asm", version.ref="asm" }
 asm-tree = { group = "org.ow2.asm", name="asm-tree", version.ref="asm" }
-apache-compress = "org.apache.commons:commons-compress:1.21"
-ant = "org.apache.ant:ant:1.10.8"
-commmons-io = "commons-io:commons-io:2.2"
-junit = "junit:junit:4.12"
-randomized-runner = "com.carrotsearch.randomizedtesting:randomizedtesting-runner:2.7.7"
-wiremock = "com.github.tomakehurst:wiremock-jre8-standalone:2.23.2"
-spock-platform = { group = "org.spockframework", name="spock-bom", version.ref="spock" }
-spock-core = { group = "org.spockframework", name="spock-core", version.ref="spock" }
-spock-junit4 = { group = "org.spockframework", name="spock-junit4", version.ref="spock" }
-junit5-platform = { group = "org.junit", name="junit-bom", version.ref="junit5" }
-jackson-platform = { group = "com.fasterxml.jackson", name="jackson-bom", version.ref="jackson" }
+bytebuddy = "net.bytebuddy:byte-buddy:1.12.9"
+checkstyle = "com.puppycrawl.tools:checkstyle:9.3"
 commons-codec = "commons-codec:commons-codec:1.11"
-nebula-info = "com.netflix.nebula:gradle-info-plugin:11.3.3"
-jna = "net.java.dev.jna:jna:5.10.0"
-idea-ext = "gradle.plugin.org.jetbrains.gradle.plugin.idea-ext:gradle-idea-ext:1.1.1"
-forbiddenApis = "de.thetaphi:forbiddenapis:3.2"
+commmons-io = "commons-io:commons-io:2.2"
 docker-compose = "com.avast.gradle:gradle-docker-compose-plugin:0.14.13"
+forbiddenApis = "de.thetaphi:forbiddenapis:3.2"
+hamcrest = "org.hamcrest:hamcrest:2.1"
+httpcore = "org.apache.httpcomponents:httpcore:4.4.12"
+httpclient = "org.apache.httpcomponents:httpclient:4.5.10"
+idea-ext = "gradle.plugin.org.jetbrains.gradle.plugin.idea-ext:gradle-idea-ext:1.1.1"
 json-schema-validator = "com.networknt:json-schema-validator:1.0.49"
 jackson-dataformat-yaml = { group = "com.fasterxml.jackson.dataformat", name="jackson-dataformat-yaml", version.ref="jackson" }
-httpclient = "org.apache.httpcomponents:httpclient:4.5.10"
-httpcore = "org.apache.httpcomponents:httpcore:4.4.12"
+jackson-platform = { group = "com.fasterxml.jackson", name="jackson-bom", version.ref="jackson" }
+jna = "net.java.dev.jna:jna:5.10.0"
+junit = "junit:junit:4.12"
+junit5-platform = { group = "org.junit", name="junit-bom", version.ref="junit5" }
+maven-model = "org.apache.maven:maven-model:3.6.2"
 mockito-core = "org.mockito:mockito-core:1.9.5"
-hamcrest = "org.hamcrest:hamcrest:2.1"
-bytebuddy = "net.bytebuddy:byte-buddy:1.12.9"
+nebula-info = "com.netflix.nebula:gradle-info-plugin:11.3.3"
+randomized-runner = "com.carrotsearch.randomizedtesting:randomizedtesting-runner:2.7.7"
+shadow-plugin = "gradle.plugin.com.github.johnrengelman:shadow:7.1.2"
+spock-core = { group = "org.spockframework", name="spock-core", version.ref="spock" }
+spock-junit4 = { group = "org.spockframework", name="spock-junit4", version.ref="spock" }
+spock-platform = { group = "org.spockframework", name="spock-bom", version.ref="spock" }
+spotless-plugin = "com.diffplug.spotless:spotless-plugin-gradle:6.5.2"
+wiremock = "com.github.tomakehurst:wiremock-jre8-standalone:2.23.2"
 xmlunit-core = "org.xmlunit:xmlunit-core:2.8.2"

--- a/gradle/build.versions.toml
+++ b/gradle/build.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 asm = "9.3"
 jackson = "2.13.2"
-junit5 = "5.7.1"
+junit5 = "5.8.1"
 spock = "2.1-groovy-3.0"
 
 [libraries]
@@ -26,9 +26,9 @@ jackson-platform = { group = "com.fasterxml.jackson", name="jackson-bom", versio
 jna = "net.java.dev.jna:jna:5.10.0"
 junit = "junit:junit:4.12"
 junit5-platform = { group = "org.junit", name="junit-bom", version.ref="junit5" }
-junit5-jupiter = "org.junit.jupiter:junit-jupiter:5.8.1"
+junit5-jupiter = { group = "org.junit.jupiter", name="junit-jupiter", version.ref="junit5" }
 junit5-platform-launcher = "org.junit.platform:junit-platform-launcher:1.8.0"
-junit5-vintage = "org.junit.vintage:junit-vintage-engine:5.8.1"
+junit5-vintage = { group = "org.junit.vintage", name="junit-vintage-engine", version.ref="junit5" }
 maven-model = "org.apache.maven:maven-model:3.6.2"
 mockito-core = "org.mockito:mockito-core:1.9.5"
 nebula-info = "com.netflix.nebula:gradle-info-plugin:11.3.3"

--- a/gradle/build.versions.toml
+++ b/gradle/build.versions.toml
@@ -29,7 +29,6 @@ junit5-platform = { group = "org.junit", name="junit-bom", version.ref="junit5" 
 junit5-jupiter = "org.junit.jupiter:junit-jupiter:5.8.1"
 junit5-platform-launcher = "org.junit.platform:junit-platform-launcher:1.8.0"
 junit5-vintage = "org.junit.vintage:junit-vintage-engine:5.8.1"
-
 maven-model = "org.apache.maven:maven-model:3.6.2"
 mockito-core = "org.mockito:mockito-core:1.9.5"
 nebula-info = "com.netflix.nebula:gradle-info-plugin:11.3.3"

--- a/gradle/build.versions.toml
+++ b/gradle/build.versions.toml
@@ -2,6 +2,7 @@
 asm = "9.3"
 spock = "2.1-groovy-3.0"
 junit5 = "5.7.1"
+jackson = "2.13.2"
 [libraries]
 shadow-plugin = "gradle.plugin.com.github.johnrengelman:shadow:7.1.2"
 checkstyle = "com.puppycrawl.tools:checkstyle:9.3"
@@ -18,11 +19,20 @@ randomized-runner = "com.carrotsearch.randomizedtesting:randomizedtesting-runner
 wiremock = "com.github.tomakehurst:wiremock-jre8-standalone:2.23.2"
 spock-platform = { group = "org.spockframework", name="spock-bom", version.ref="spock" }
 spock-core = { group = "org.spockframework", name="spock-core", version.ref="spock" }
-spock-junit = { group = "org.spockframework", name="spock-junit4", version.ref="spock" }
+spock-junit4 = { group = "org.spockframework", name="spock-junit4", version.ref="spock" }
 junit5-platform = { group = "org.junit", name="junit-bom", version.ref="junit5" }
-jackson-platform = "com.fasterxml.jackson:jackson-bom:2.13.2"
+jackson-platform = { group = "com.fasterxml.jackson", name="jackson-bom", version.ref="jackson" }
 commons-codec = "commons-codec:commons-codec:1.11"
 nebula-info = "com.netflix.nebula:gradle-info-plugin:11.3.3"
 jna = "net.java.dev.jna:jna:5.10.0"
 idea-ext = "gradle.plugin.org.jetbrains.gradle.plugin.idea-ext:gradle-idea-ext:1.1.1"
 forbiddenApis = "de.thetaphi:forbiddenapis:3.2"
+docker-compose = "com.avast.gradle:gradle-docker-compose-plugin:0.14.13"
+json-schema-validator = "com.networknt:json-schema-validator:1.0.49"
+jackson-dataformat-yaml = { group = "com.fasterxml.jackson.dataformat", name="jackson-dataformat-yaml", version.ref="jackson" }
+httpclient = "org.apache.httpcomponents:httpclient:4.5.10"
+httpcore = "org.apache.httpcomponents:httpcore:4.4.12"
+mockito-core = "org.mockito:mockito-core:1.9.5"
+hamcrest = "org.hamcrest:hamcrest:2.1"
+bytebuddy = "net.bytebuddy:byte-buddy:1.12.9"
+xmlunit-core = "org.xmlunit:xmlunit-core:2.8.2"


### PR DESCRIPTION
We introduce the use of a Gradle version catalogue for handling build related dependencies. 

This provides type safe accessors for dependencies and allow centralised version definitions. 
Later we want to move all our dependency handling to version catalogues. 
Since this is a Gradle feature we remove  long term maintenance cost for custom version handling in 
our build and make centralised version handling more straight forward and support better tooling 
based on version catalogues 

Fixes asm version alignment on the way using 9.3 everywhere in our build logic.