### PR TITLE
[8.1] [DOCS] Expands transform setup page with info on spaces. (#86479)

### DIFF
--- a/docs/reference/transform/setup.asciidoc
+++ b/docs/reference/transform/setup.asciidoc
@@ -92,10 +92,13 @@ For more information and {kib} security features, see
 [[transform-kib-spaces]]
 == {kib} spaces
 
-{kibana-ref}/xpack-spaces.html[Spaces] enable you to organize your source and 
-destination indices and other saved objects in {kib} and to see only the objects 
-that belong to your space. However, this limited scope does not apply to 
-{transforms}; they are visible in all spaces.
+{kibana-ref}/xpack-spaces.html[Spaces] enable you to organize your source and
+destination indices and other saved objects in {kib} and to see only the objects
+that belong to your space. However, a {transform} is a long running task which 
+is managed on cluster level and therefore not limited in scope to certain 
+spaces. Space awareness can be implemented for a {data-source} under 
+**Stack Management > Kibana** which allows privileges to the {transform} 
+destination index.
 
 To successfully create {transforms} in {kib}, you must be logged into a space
 where the source indices are visible and the `Data View Management` and


### PR DESCRIPTION
Backports the following commits to 8.1:
 - [DOCS] Expands transform setup page with info on spaces. (#86479)