### PR TITLE
[DOCS] Fix name of OIDC JWT sig algorithm setting

### DIFF
--- a/docs/reference/settings/security-settings.asciidoc
+++ b/docs/reference/settings/security-settings.asciidoc
@@ -1653,7 +1653,7 @@ or `client_secret_jwt`. Defaults to `client_secret_basic`.
 // end::rp-client-auth-method-tag[]
 
 // tag::rp-client-auth-jwt-signature-algorithm[]
-`rp.client_auth_signature_algorithm` {ess-icon}::
+`rp.client_auth_jwt_signature_algorithm` {ess-icon}::
 (<<static-cluster-setting, Static>>)
 The signature algorithm that {es} uses to sign the JWT with which it authenticates
 as a client to the OpenID Connect Provider when `client_secret_jwt` is selected for


### PR DESCRIPTION
The `client_auth_jwt_signature_algorithm` was incorrectly documented.

---

See: https://github.com/elastic/elasticsearch/blob/e467424043b6b97c40c1c010f9dae9f165bbafbe/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authc/oidc/OpenIdConnectRealmSettings.java#L119