### PR TITLE
[7.17] Do not apply StandaloneRestTestPlugin in StandaloneTestPlugin (#86400)

### DIFF
--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/test/StandaloneTestPlugin.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/test/StandaloneTestPlugin.java
@@ -8,9 +8,16 @@
 
 package org.elasticsearch.gradle.internal.test;
 
+import org.elasticsearch.gradle.internal.ElasticsearchJavaBasePlugin;
+import org.elasticsearch.gradle.internal.ElasticsearchTestBasePlugin;
+import org.elasticsearch.gradle.internal.info.GlobalBuildInfoPlugin;
+import org.elasticsearch.gradle.internal.precommit.InternalPrecommitTasks;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.api.plugins.JavaBasePlugin;
+import org.gradle.api.tasks.SourceSet;
+import org.gradle.api.tasks.SourceSetContainer;
+import org.gradle.api.tasks.TaskProvider;
 import org.gradle.api.tasks.testing.Test;
 
 /**
@@ -21,14 +28,28 @@ import org.gradle.api.tasks.testing.Test;
 public class StandaloneTestPlugin implements Plugin<Project> {
     @Override
     public void apply(final Project project) {
-        project.getPluginManager().apply(StandaloneRestTestPlugin.class);
+        project.getRootProject().getPluginManager().apply(GlobalBuildInfoPlugin.class);
+        project.getPluginManager().apply(ElasticsearchJavaBasePlugin.class);
+        project.getPluginManager().apply(ElasticsearchTestBasePlugin.class);
 
-        project.getTasks().register("test", Test.class).configure(test -> {
+        // only setup tests to build
+        SourceSetContainer sourceSets = project.getExtensions().getByType(SourceSetContainer.class);
+        final SourceSet testSourceSet = sourceSets.create("test");
+        project.getDependencies().add(testSourceSet.getImplementationConfigurationName(), project.project(":test:framework"));
+
+        project.getTasks().withType(Test.class).configureEach(test -> {
+            test.setTestClassesDirs(testSourceSet.getOutput().getClassesDirs());
+            test.setClasspath(testSourceSet.getRuntimeClasspath());
+        });
+        TaskProvider<Test> testTask = project.getTasks().register("test", Test.class);
+        testTask.configure(test -> {
             test.setGroup(JavaBasePlugin.VERIFICATION_GROUP);
             test.setDescription("Runs unit tests that are separate");
             test.mustRunAfter(project.getTasks().getByName("precommit"));
         });
 
-        project.getTasks().named("check").configure(task -> task.dependsOn(project.getTasks().named("test")));
+        project.getTasks().named("check").configure(task -> task.dependsOn(testTask));
+
+        InternalPrecommitTasks.create(project, false);
     }
 }

--- a/qa/evil-tests/build.gradle
+++ b/qa/evil-tests/build.gradle
@@ -17,6 +17,7 @@ apply plugin: 'elasticsearch.standalone-test'
 
 dependencies {
   testImplementation "com.google.jimfs:jimfs:1.2"
+  testImplementation project(":test:framework")
   testImplementation project(':distribution:tools:plugin-cli')
 }
 

--- a/qa/translog-policy/build.gradle
+++ b/qa/translog-policy/build.gradle
@@ -12,7 +12,7 @@ import org.elasticsearch.gradle.internal.info.BuildParams
 import org.elasticsearch.gradle.testclusters.StandaloneRestIntegTestTask
 
 apply plugin: 'elasticsearch.testclusters'
-apply plugin: 'elasticsearch.standalone-test'
+apply plugin: 'elasticsearch.standalone-rest-test'
 apply plugin: 'elasticsearch.bwc-test'
 
 for (Version bwcVersion : BuildParams.bwcVersions.indexCompatible) {


### PR DESCRIPTION
Backports the following commits to 7.17:
 - Do not apply StandaloneRestTestPlugin in StandaloneTestPlugin (#86400)