### PR TITLE
[8.2] Fix bounded hexagonal grids when they contain the bin on one of the poles (#86460)

### DIFF
--- a/docs/changelog/86460.yaml
+++ b/docs/changelog/86460.yaml
@@ -1,0 +1,5 @@
+pr: 86460
+summary: Fix bounded hexagonal grids when they contain the bin on one of the poles
+area: Geo
+type: bug
+issues: []

--- a/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/search/aggregations/bucket/geogrid/GeoHexCellIdSource.java
+++ b/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/search/aggregations/bucket/geogrid/GeoHexCellIdSource.java
@@ -76,10 +76,14 @@ public class GeoHexCellIdSource extends ValuesSource.Numeric {
         private final boolean crossesDateline;
         private final GeoBoundingBox bbox;
 
+        private final long northPoleHex, southPoleHex;
+
         protected BoundedCellValues(MultiGeoPointValues geoValues, int precision, GeoBoundingBox bbox) {
             super(geoValues, precision);
             this.crossesDateline = bbox.right() < bbox.left();
             this.bbox = bbox;
+            northPoleHex = H3.geoToH3(90, 0, precision);
+            southPoleHex = H3.geoToH3(-90, 0, precision);
         }
 
         @Override
@@ -120,7 +124,11 @@ public class GeoHexCellIdSource extends ValuesSource.Numeric {
                 minLat = Math.min(minLat, boundaryLat);
                 maxLat = Math.max(maxLat, boundaryLat);
             }
-            if (maxLon - minLon > 180) {
+            if (northPoleHex == hex) {
+                return minLat < bbox.top();
+            } else if (southPoleHex == hex) {
+                return maxLat > bbox.bottom();
+            } else if (maxLon - minLon > 180) {
                 return intersects(-180, minLon, minLat, maxLat) || intersects(maxLon, 180, minLat, maxLat);
             } else {
                 return intersects(minLon, maxLon, minLat, maxLat);

--- a/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/search/aggregations/bucket/geogrid/GeoHexAggregatorTests.java
+++ b/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/search/aggregations/bucket/geogrid/GeoHexAggregatorTests.java
@@ -133,4 +133,26 @@ public class GeoHexAggregatorTests extends GeoGridAggregatorTestCase<InternalGeo
             iw -> iw.addDocument(Collections.singletonList(field))
         );
     }
+
+    public void testHexContainsNorthPole() throws IOException {
+        GeoBoundingBox bbox = new GeoBoundingBox(new GeoPoint(90, 0), new GeoPoint(89, 10));
+        LatLonDocValuesField fieldNorth = new LatLonDocValuesField("bar", 90, -5);
+        LatLonDocValuesField fieldSouth = new LatLonDocValuesField("bar", -90, -5);
+        testCase(new MatchAllDocsQuery(), "bar", 0, bbox, geoGrid -> {
+            assertTrue(AggregationInspectionHelper.hasValue(geoGrid));
+            assertEquals(1, geoGrid.getBuckets().size());
+            assertEquals(1, geoGrid.getBuckets().get(0).getDocCount());
+        }, iw -> iw.addDocument(List.of(fieldNorth, fieldSouth)));
+    }
+
+    public void testHexContainsSouthPole() throws IOException {
+        GeoBoundingBox bbox = new GeoBoundingBox(new GeoPoint(-89, 0), new GeoPoint(-90, 10));
+        LatLonDocValuesField fieldNorth = new LatLonDocValuesField("bar", 90, -5);
+        LatLonDocValuesField fieldSouth = new LatLonDocValuesField("bar", -90, -5);
+        testCase(new MatchAllDocsQuery(), "bar", 0, bbox, geoGrid -> {
+            assertTrue(AggregationInspectionHelper.hasValue(geoGrid));
+            assertEquals(1, geoGrid.getBuckets().size());
+            assertEquals(1, geoGrid.getBuckets().get(0).getDocCount());
+        }, iw -> iw.addDocument(List.of(fieldNorth, fieldSouth)));
+    }
 }


### PR DESCRIPTION
Backports the following commits to 8.2:
 - Fix bounded hexagonal grids when they contain the bin on one of the poles (#86460)