### PR TITLE
[ML] Express lane inference 

### DIFF
--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportInferTrainedModelDeploymentAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportInferTrainedModelDeploymentAction.java
@@ -137,6 +137,7 @@ public class TransportInferTrainedModelDeploymentAction extends TransportTasksAc
         task.infer(
             request.getDocs().get(0),
             request.getUpdate(),
+            request.isSkipQueue(),
             request.getInferenceTimeout(),
             ActionListener.wrap(
                 pyTorchResult -> listener.onResponse(new InferTrainedModelDeploymentAction.Response(pyTorchResult)),

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/assignment/TrainedModelAssignmentNodeService.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/assignment/TrainedModelAssignmentNodeService.java
@@ -271,10 +271,11 @@ public class TrainedModelAssignmentNodeService implements ClusterStateListener {
         TrainedModelDeploymentTask task,
         InferenceConfig config,
         Map<String, Object> doc,
+        boolean skipQueue,
         TimeValue timeout,
         ActionListener<InferenceResults> listener
     ) {
-        deploymentManager.infer(task, config, doc, timeout, listener);
+        deploymentManager.infer(task, config, doc, skipQueue, timeout, listener);
     }
 
     public Optional<ModelStats> modelStats(TrainedModelDeploymentTask task) {

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/deployment/AbstractPyTorchAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/deployment/AbstractPyTorchAction.java
@@ -107,5 +107,9 @@ abstract class AbstractPyTorchAction<T> extends AbstractRunnable {
         return processContext;
     }
 
+    TimeValue getTimeout() {
+        return timeout;
+    }
+
     protected abstract Logger getLogger();
 }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/deployment/DeploymentManager.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/deployment/DeploymentManager.java
@@ -40,12 +40,12 @@ import org.elasticsearch.xpack.core.ml.utils.ExceptionsHelper;
 import org.elasticsearch.xpack.ml.MachineLearning;
 import org.elasticsearch.xpack.ml.inference.nlp.NlpTask;
 import org.elasticsearch.xpack.ml.inference.nlp.Vocabulary;
+import org.elasticsearch.xpack.ml.inference.pytorch.PriorityProcessWorkerExecutorService;
 import org.elasticsearch.xpack.ml.inference.pytorch.process.PyTorchProcess;
 import org.elasticsearch.xpack.ml.inference.pytorch.process.PyTorchProcessFactory;
 import org.elasticsearch.xpack.ml.inference.pytorch.process.PyTorchResultProcessor;
 import org.elasticsearch.xpack.ml.inference.pytorch.process.PyTorchStateStreamer;
 import org.elasticsearch.xpack.ml.inference.pytorch.results.ThreadSettings;
-import org.elasticsearch.xpack.ml.job.process.ProcessWorkerExecutorService;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -288,11 +288,10 @@ public class DeploymentManager {
 
     public void executePyTorchAction(ProcessContext processContext, boolean skipQueue, AbstractPyTorchAction<?> action) {
         try {
-            if (skipQueue == false) {
-                processContext.getExecutorService().execute(action);
-            } else {
-                processContext.getExecutorService().executeFirst(action, action.getTimeout());
-            }
+            PriorityProcessWorkerExecutorService.RequestPriority priority = skipQueue
+                ? PriorityProcessWorkerExecutorService.RequestPriority.HIGH
+                : PriorityProcessWorkerExecutorService.RequestPriority.NORMAL;
+            processContext.getExecutorService().executeWithPriority(action, priority, action.getRequestId());
         } catch (EsRejectedExecutionException e) {
             processContext.getRejectedExecutionCount().incrementAndGet();
             action.onFailure(e);
@@ -330,7 +329,7 @@ public class DeploymentManager {
         private final SetOnce<TrainedModelInput> modelInput = new SetOnce<>();
         private final PyTorchResultProcessor resultProcessor;
         private final PyTorchStateStreamer stateStreamer;
-        private final ProcessWorkerExecutorService executorService;
+        private final PriorityProcessWorkerExecutorService executorService;
         private volatile Instant startTime;
         private volatile Integer numThreadsPerAllocation;
         private volatile Integer numAllocations;
@@ -344,7 +343,7 @@ public class DeploymentManager {
                 this.numAllocations = threadSettings.numAllocations();
             });
             this.stateStreamer = new PyTorchStateStreamer(client, executorService, xContentRegistry);
-            this.executorService = new ProcessWorkerExecutorService(
+            this.executorService = new PriorityProcessWorkerExecutorService(
                 threadPool.getThreadContext(),
                 "inference process",
                 task.getParams().getQueueCapacity()
@@ -407,7 +406,7 @@ public class DeploymentManager {
         }
 
         // accessor used for mocking in tests
-        ProcessWorkerExecutorService getExecutorService() {
+        PriorityProcessWorkerExecutorService getExecutorService() {
             return executorService;
         }
 

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/deployment/DeploymentManager.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/deployment/DeploymentManager.java
@@ -257,7 +257,11 @@ public class DeploymentManager {
             listener
         );
 
-        executePyTorchAction(processContext, skipQueue, inferenceAction);
+        PriorityProcessWorkerExecutorService.RequestPriority priority = skipQueue
+            ? PriorityProcessWorkerExecutorService.RequestPriority.HIGH
+            : PriorityProcessWorkerExecutorService.RequestPriority.NORMAL;
+
+        executePyTorchAction(processContext, priority, inferenceAction);
     }
 
     public void updateNumAllocations(
@@ -283,14 +287,15 @@ public class DeploymentManager {
             listener
         );
 
-        executePyTorchAction(processContext, false, controlMessageAction);
+        executePyTorchAction(processContext, PriorityProcessWorkerExecutorService.RequestPriority.HIGHEST, controlMessageAction);
     }
 
-    public void executePyTorchAction(ProcessContext processContext, boolean skipQueue, AbstractPyTorchAction<?> action) {
+    public void executePyTorchAction(
+        ProcessContext processContext,
+        PriorityProcessWorkerExecutorService.RequestPriority priority,
+        AbstractPyTorchAction<?> action
+    ) {
         try {
-            PriorityProcessWorkerExecutorService.RequestPriority priority = skipQueue
-                ? PriorityProcessWorkerExecutorService.RequestPriority.HIGH
-                : PriorityProcessWorkerExecutorService.RequestPriority.NORMAL;
             processContext.getExecutorService().executeWithPriority(action, priority, action.getRequestId());
         } catch (EsRejectedExecutionException e) {
             processContext.getRejectedExecutionCount().incrementAndGet();

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/deployment/TrainedModelDeploymentTask.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/deployment/TrainedModelDeploymentTask.java
@@ -114,7 +114,13 @@ public class TrainedModelDeploymentTask extends CancellableTask implements Start
         );
     }
 
-    public void infer(Map<String, Object> doc, InferenceConfigUpdate update, TimeValue timeout, ActionListener<InferenceResults> listener) {
+    public void infer(
+        Map<String, Object> doc,
+        InferenceConfigUpdate update,
+        boolean skipQueue,
+        TimeValue timeout,
+        ActionListener<InferenceResults> listener
+    ) {
         if (inferenceConfigHolder.get() == null) {
             listener.onFailure(ExceptionsHelper.conflictStatusException("Trained model [{}] is not initialized", params.getModelId()));
             return;
@@ -131,7 +137,7 @@ public class TrainedModelDeploymentTask extends CancellableTask implements Start
             );
             return;
         }
-        trainedModelAssignmentNodeService.infer(this, update.apply(inferenceConfigHolder.get()), doc, timeout, listener);
+        trainedModelAssignmentNodeService.infer(this, update.apply(inferenceConfigHolder.get()), doc, skipQueue, timeout, listener);
     }
 
     public Optional<ModelStats> modelStats() {

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/pytorch/PriorityProcessWorkerExecutorService.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/pytorch/PriorityProcessWorkerExecutorService.java
@@ -83,10 +83,14 @@ public class PriorityProcessWorkerExecutorService extends AbstractProcessWorkerE
             return;
         }
 
-        if (queue.size() == queueCapacity
-            || queue.add(new OrderedRunnable(priority, tieBreaker, contextHolder.preserveContext(command))) == false) {
+        // highest priority requests are always accepted even if the queue is full
+        if (queue.size() >= queueCapacity && priority != RequestPriority.HIGHEST) {
             command.onRejection(new EsRejectedExecutionException(processName + " queue is full. Unable to execute command", false));
+            return;
         }
+
+        // PriorityBlockingQueue::offer always returns true
+        queue.offer(new OrderedRunnable(priority, tieBreaker, contextHolder.preserveContext(command)));
     }
 
     @Override

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/pytorch/PriorityProcessWorkerExecutorService.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/pytorch/PriorityProcessWorkerExecutorService.java
@@ -17,9 +17,8 @@ import java.util.concurrent.PriorityBlockingQueue;
 
 /**
  * An {@link AbstractProcessWorkerExecutorService} where the runnables
- * are have a priority and are executed in priority order with a tie breaker
- * value for requests of equal priority. The tie breaker can be used to
- * preserve insertion order.
+ * are executed in priority order with a tie breaker value for requests
+ * of equal priority. The tie breaker can be used to preserve insertion order.
  *
  * Order is maintained by a PriorityQueue
  */

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/pytorch/PriorityProcessWorkerExecutorService.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/pytorch/PriorityProcessWorkerExecutorService.java
@@ -76,13 +76,14 @@ public class PriorityProcessWorkerExecutorService extends AbstractProcessWorkerE
      * @param priority Request priority
      * @param tieBreaker For sorting requests of equal priority
      */
-    public void executeWithPriority(AbstractRunnable command, RequestPriority priority, long tieBreaker) {
+    public synchronized void executeWithPriority(AbstractRunnable command, RequestPriority priority, long tieBreaker) {
         if (isShutdown()) {
             EsRejectedExecutionException rejected = new EsRejectedExecutionException(processName + " worker service has shutdown", true);
             command.onRejection(rejected);
             return;
         }
 
+        // PriorityBlockingQueue is an unbounded queue so check it has not reached capacity.
         // highest priority requests are always accepted even if the queue is full
         if (queue.size() >= queueCapacity && priority != RequestPriority.HIGHEST) {
             command.onRejection(new EsRejectedExecutionException(processName + " queue is full. Unable to execute command", false));

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/pytorch/PriorityProcessWorkerExecutorService.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/pytorch/PriorityProcessWorkerExecutorService.java
@@ -7,34 +7,41 @@
 
 package org.elasticsearch.xpack.ml.inference.pytorch;
 
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.message.ParameterizedMessage;
 import org.elasticsearch.common.util.concurrent.AbstractRunnable;
-import org.elasticsearch.common.util.concurrent.EsExecutors;
 import org.elasticsearch.common.util.concurrent.EsRejectedExecutionException;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.core.SuppressForbidden;
+import org.elasticsearch.xpack.ml.job.process.AbstractProcessWorkerExecutorService;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Objects;
-import java.util.concurrent.AbstractExecutorService;
-import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.PriorityBlockingQueue;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicReference;
 
-public class PriorityProcessWorkerExecutorService extends AbstractExecutorService {
+/**
+ * An {@link AbstractProcessWorkerExecutorService} where the runnables
+ * are have a priority and are executed in priority order with a tie breaker
+ * value for requests of equal priority. The tie breaker can be used to
+ * preserve insertion order.
+ *
+ * Order is maintained by a PriorityQueue
+ */
+public class PriorityProcessWorkerExecutorService extends AbstractProcessWorkerExecutorService<
+    PriorityProcessWorkerExecutorService.OrderedRunnable> {
 
     public enum RequestPriority {
+        HIGHEST,
         HIGH,
         NORMAL
     };
 
-    private static record OrderRunnable(RequestPriority priority, long tieBreaker, Runnable runnable) implements Comparable<OrderRunnable> {
+    /**
+     * A Runnable sorted first by RequestPriority then a tie breaker which in
+     * most cases will be the insertion order
+     */
+    public static record OrderedRunnable(RequestPriority priority, long tieBreaker, Runnable runnable)
+        implements
+            Comparable<OrderedRunnable>,
+            Runnable {
         @Override
-        public int compareTo(OrderRunnable o) {
+        public int compareTo(OrderedRunnable o) {
             int p = this.priority.compareTo(o.priority);
             if (p == 0) {
                 return (int) (this.tieBreaker - o.tieBreaker);
@@ -42,67 +49,34 @@ public class PriorityProcessWorkerExecutorService extends AbstractExecutorServic
 
             return p;
         }
+
+        @Override
+        public void run() {
+            runnable.run();
+        }
     };
 
-    private static final Logger logger = LogManager.getLogger(PriorityProcessWorkerExecutorService.class);
-
-    private final ThreadContext contextHolder;
-    private final String processName;
-    private final CountDownLatch awaitTermination = new CountDownLatch(1);
-    private final PriorityBlockingQueue<OrderRunnable> priorityQueue;
-    private final AtomicReference<Exception> error = new AtomicReference<>();
     private final int queueCapacity;
 
-    private volatile boolean running = true;
-
     /**
-         * @param contextHolder the thread context holder
-         * @param processName the name of the process to be used in logging
-         * @param queueCapacity the capacity of the queue holding operations. If an operation is added
-         *                  for execution when the queue is full a 429 error is thrown.
-         */
+     * @param contextHolder the thread context holder
+     * @param processName the name of the process to be used in logging
+     * @param queueCapacity the capacity of the queue holding operations. If an operation is added
+     *                  for execution when the queue is full a 429 error is thrown.
+     */
     @SuppressForbidden(reason = "properly rethrowing errors, see EsExecutors.rethrowErrors")
     public PriorityProcessWorkerExecutorService(ThreadContext contextHolder, String processName, int queueCapacity) {
-        this.contextHolder = Objects.requireNonNull(contextHolder);
-        this.processName = Objects.requireNonNull(processName);
-        this.priorityQueue = new PriorityBlockingQueue<>(queueCapacity);
+        super(contextHolder, processName, queueCapacity, PriorityBlockingQueue::new);
         this.queueCapacity = queueCapacity;
     }
 
-    public int queueSize() {
-        return priorityQueue.size();
-    }
-
-    public void shutdownWithError(Exception e) {
-        error.set(e);
-        shutdown();
-    }
-
-    @Override
-    public void shutdown() {
-        running = false;
-    }
-
-    @Override
-    public List<Runnable> shutdownNow() {
-        throw new UnsupportedOperationException("not supported");
-    }
-
-    @Override
-    public boolean isShutdown() {
-        return running == false;
-    }
-
-    @Override
-    public boolean isTerminated() {
-        return awaitTermination.getCount() == 0;
-    }
-
-    @Override
-    public boolean awaitTermination(long timeout, TimeUnit unit) throws InterruptedException {
-        return awaitTermination.await(timeout, unit);
-    }
-
+    /**
+     * Insert a runnable into the executor queue.
+     *
+     * @param command The runnable
+     * @param priority Request priority
+     * @param tieBreaker For sorting requests of equal priority
+     */
     public void executeWithPriority(AbstractRunnable command, RequestPriority priority, long tieBreaker) {
         if (isShutdown()) {
             EsRejectedExecutionException rejected = new EsRejectedExecutionException(processName + " worker service has shutdown", true);
@@ -110,54 +84,14 @@ public class PriorityProcessWorkerExecutorService extends AbstractExecutorServic
             return;
         }
 
-        if (priorityQueue.size() == queueCapacity
-            || priorityQueue.add(new OrderRunnable(priority, tieBreaker, contextHolder.preserveContext(command))) == false) {
-            throw new EsRejectedExecutionException(processName + " queue is full. Unable to execute command", false);
+        if (queue.size() == queueCapacity
+            || queue.add(new OrderedRunnable(priority, tieBreaker, contextHolder.preserveContext(command))) == false) {
+            command.onRejection(new EsRejectedExecutionException(processName + " queue is full. Unable to execute command", false));
         }
     }
 
     @Override
     public synchronized void execute(Runnable command) {
         throw new UnsupportedOperationException("use executeWithPriority");
-    }
-
-    public void start() {
-        try {
-            while (running) {
-                var runnable = priorityQueue.poll(500, java.util.concurrent.TimeUnit.MILLISECONDS);
-                if (runnable != null) {
-                    try {
-                        runnable.runnable().run();
-                    } catch (Exception e) {
-                        logger.error(() -> new ParameterizedMessage("error handling process [{}] operation", processName), e);
-                    }
-                    EsExecutors.rethrowErrors(ThreadContext.unwrap(runnable.runnable()));
-                }
-            }
-
-            synchronized (this) {
-                // if shutdown with tasks pending notify the handlers
-                if (priorityQueue.isEmpty() == false) {
-                    List<OrderRunnable> notExecuted = new ArrayList<>();
-                    priorityQueue.drainTo(notExecuted);
-
-                    String msg = "unable to process as " + processName + " worker service has shutdown";
-                    Exception ex = error.get();
-                    for (var runnable : notExecuted) {
-                        if (runnable.runnable()instanceof AbstractRunnable ar) {
-                            if (ex != null) {
-                                ar.onFailure(ex);
-                            } else {
-                                ar.onRejection(new EsRejectedExecutionException(msg, true));
-                            }
-                        }
-                    }
-                }
-            }
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-        } finally {
-            awaitTermination.countDown();
-        }
     }
 }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/process/AbstractProcessWorkerExecutorService.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/process/AbstractProcessWorkerExecutorService.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.ml.job.process;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.message.ParameterizedMessage;
+import org.elasticsearch.common.util.concurrent.AbstractRunnable;
+import org.elasticsearch.common.util.concurrent.EsExecutors;
+import org.elasticsearch.common.util.concurrent.EsRejectedExecutionException;
+import org.elasticsearch.common.util.concurrent.ThreadContext;
+import org.elasticsearch.core.SuppressForbidden;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.AbstractExecutorService;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Function;
+
+public abstract class AbstractProcessWorkerExecutorService<T extends Runnable> extends AbstractExecutorService {
+
+    private static final Logger logger = LogManager.getLogger(ProcessWorkerExecutorService.class);
+
+    protected final ThreadContext contextHolder;
+    protected final String processName;
+    private final CountDownLatch awaitTermination = new CountDownLatch(1);
+    protected final BlockingQueue<T> queue;
+    private final AtomicReference<Exception> error = new AtomicReference<>();
+
+    private volatile boolean running = true;
+
+    /**
+     * @param contextHolder the thread context holder
+     * @param processName the name of the process to be used in logging
+     * @param queueCapacity the capacity of the queue holding operations. If an operation is added
+     *                  for execution when the queue is full a 429 error is thrown.
+     * @param queueSupplier BlockingQueue constructor
+     */
+    @SuppressForbidden(reason = "properly rethrowing errors, see EsExecutors.rethrowErrors")
+    public AbstractProcessWorkerExecutorService(
+        ThreadContext contextHolder,
+        String processName,
+        int queueCapacity,
+        Function<Integer, BlockingQueue<T>> queueSupplier
+    ) {
+        this.contextHolder = Objects.requireNonNull(contextHolder);
+        this.processName = Objects.requireNonNull(processName);
+        this.queue = queueSupplier.apply(queueCapacity);
+    }
+
+    public int queueSize() {
+        return queue.size();
+    }
+
+    public void shutdownWithError(Exception e) {
+        error.set(e);
+        shutdown();
+    }
+
+    @Override
+    public void shutdown() {
+        running = false;
+    }
+
+    @Override
+    public List<Runnable> shutdownNow() {
+        throw new UnsupportedOperationException("not supported");
+    }
+
+    @Override
+    public boolean isShutdown() {
+        return running == false;
+    }
+
+    @Override
+    public boolean isTerminated() {
+        return awaitTermination.getCount() == 0;
+    }
+
+    @Override
+    public boolean awaitTermination(long timeout, TimeUnit unit) throws InterruptedException {
+        return awaitTermination.await(timeout, unit);
+    }
+
+    public void start() {
+        try {
+            while (running) {
+                Runnable runnable = queue.poll(500, TimeUnit.MILLISECONDS);
+                if (runnable != null) {
+                    try {
+                        runnable.run();
+                    } catch (Exception e) {
+                        logger.error(() -> "error handling process [" + processName + "] operation", e);
+                    }
+                    EsExecutors.rethrowErrors(ThreadContext.unwrap(runnable));
+                }
+            }
+
+            synchronized (this) {
+                // if shutdown with tasks pending notify the handlers
+                if (queue.isEmpty() == false) {
+                    List<Runnable> notExecuted = new ArrayList<>();
+                    queue.drainTo(notExecuted);
+
+                    String msg = "unable to process as " + processName + " worker service has shutdown";
+                    Exception ex = error.get();
+                    for (Runnable runnable : notExecuted) {
+                        if (runnable instanceof AbstractRunnable ar) {
+                            if (ex != null) {
+                                ar.onFailure(ex);
+                            } else {
+                                ar.onRejection(new EsRejectedExecutionException(msg, true));
+                            }
+                        }
+                    }
+                }
+            }
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        } finally {
+            awaitTermination.countDown();
+        }
+    }
+}

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/process/AbstractProcessWorkerExecutorService.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/process/AbstractProcessWorkerExecutorService.java
@@ -26,9 +26,14 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
 
+/**
+ * A worker service that executes runnables sequentially in
+ * a single worker thread.
+ * @param <T> implements Runnable
+ */
 public abstract class AbstractProcessWorkerExecutorService<T extends Runnable> extends AbstractExecutorService {
 
-    private static final Logger logger = LogManager.getLogger(ProcessWorkerExecutorService.class);
+    private static final Logger logger = LogManager.getLogger(AbstractProcessWorkerExecutorService.class);
 
     protected final ThreadContext contextHolder;
     protected final String processName;

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/process/AbstractProcessWorkerExecutorService.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/process/AbstractProcessWorkerExecutorService.java
@@ -9,7 +9,6 @@ package org.elasticsearch.xpack.ml.job.process;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.message.ParameterizedMessage;
 import org.elasticsearch.common.util.concurrent.AbstractRunnable;
 import org.elasticsearch.common.util.concurrent.EsExecutors;
 import org.elasticsearch.common.util.concurrent.EsRejectedExecutionException;

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/process/ProcessWorkerExecutorService.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/process/ProcessWorkerExecutorService.java
@@ -6,40 +6,19 @@
  */
 package org.elasticsearch.xpack.ml.job.process;
 
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.elasticsearch.common.util.concurrent.AbstractRunnable;
-import org.elasticsearch.common.util.concurrent.EsExecutors;
 import org.elasticsearch.common.util.concurrent.EsRejectedExecutionException;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.core.SuppressForbidden;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Objects;
-import java.util.concurrent.AbstractExecutorService;
-import java.util.concurrent.BlockingQueue;
-import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.LinkedBlockingQueue;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicReference;
 
 /*
  * Native ML processes can only handle a single operation at a time. In order to guarantee that, all
  * operations are initially added to a queue and a worker thread from an ML threadpool will process each
  * operation at a time.
  */
-public class ProcessWorkerExecutorService extends AbstractExecutorService {
-
-    private static final Logger logger = LogManager.getLogger(ProcessWorkerExecutorService.class);
-
-    private final ThreadContext contextHolder;
-    private final String processName;
-    private final CountDownLatch awaitTermination = new CountDownLatch(1);
-    private final BlockingQueue<Runnable> queue;
-    private final AtomicReference<Exception> error = new AtomicReference<>();
-
-    private volatile boolean running = true;
+public class ProcessWorkerExecutorService extends AbstractProcessWorkerExecutorService<Runnable> {
 
     /**
      * @param contextHolder the thread context holder
@@ -49,43 +28,7 @@ public class ProcessWorkerExecutorService extends AbstractExecutorService {
      */
     @SuppressForbidden(reason = "properly rethrowing errors, see EsExecutors.rethrowErrors")
     public ProcessWorkerExecutorService(ThreadContext contextHolder, String processName, int queueCapacity) {
-        this.contextHolder = Objects.requireNonNull(contextHolder);
-        this.processName = Objects.requireNonNull(processName);
-        this.queue = new LinkedBlockingQueue<>(queueCapacity);
-    }
-
-    public int queueSize() {
-        return queue.size();
-    }
-
-    public void shutdownWithError(Exception e) {
-        error.set(e);
-        shutdown();
-    }
-
-    @Override
-    public void shutdown() {
-        running = false;
-    }
-
-    @Override
-    public List<Runnable> shutdownNow() {
-        throw new UnsupportedOperationException("not supported");
-    }
-
-    @Override
-    public boolean isShutdown() {
-        return running == false;
-    }
-
-    @Override
-    public boolean isTerminated() {
-        return awaitTermination.getCount() == 0;
-    }
-
-    @Override
-    public boolean awaitTermination(long timeout, TimeUnit unit) throws InterruptedException {
-        return awaitTermination.await(timeout, unit);
+        super(contextHolder, processName, queueCapacity, LinkedBlockingQueue::new);
     }
 
     @Override
@@ -103,46 +46,6 @@ public class ProcessWorkerExecutorService extends AbstractExecutorService {
         boolean added = queue.offer(contextHolder.preserveContext(command));
         if (added == false) {
             throw new EsRejectedExecutionException(processName + " queue is full. Unable to execute command", false);
-        }
-    }
-
-    public void start() {
-        try {
-            while (running) {
-                Runnable runnable = queue.poll(500, TimeUnit.MILLISECONDS);
-                if (runnable != null) {
-                    try {
-                        runnable.run();
-                    } catch (Exception e) {
-                        logger.error(() -> "error handling process [" + processName + "] operation", e);
-                    }
-                    EsExecutors.rethrowErrors(ThreadContext.unwrap(runnable));
-                }
-            }
-
-            synchronized (this) {
-                // if shutdown with tasks pending notify the handlers
-                if (queue.isEmpty() == false) {
-                    List<Runnable> notExecuted = new ArrayList<>();
-                    queue.drainTo(notExecuted);
-
-                    String msg = "unable to process as " + processName + " worker service has shutdown";
-                    Exception ex = error.get();
-                    for (Runnable runnable : notExecuted) {
-                        if (runnable instanceof AbstractRunnable ar) {
-                            if (ex != null) {
-                                ar.onFailure(ex);
-                            } else {
-                                ar.onRejection(new EsRejectedExecutionException(msg, true));
-                            }
-                        }
-                    }
-                }
-            }
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-        } finally {
-            awaitTermination.countDown();
         }
     }
 }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/process/ProcessWorkerExecutorService.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/process/ProcessWorkerExecutorService.java
@@ -13,14 +13,15 @@ import org.elasticsearch.common.util.concurrent.EsExecutors;
 import org.elasticsearch.common.util.concurrent.EsRejectedExecutionException;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.core.SuppressForbidden;
+import org.elasticsearch.core.TimeValue;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.AbstractExecutorService;
-import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.BlockingDeque;
 import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.LinkedBlockingDeque;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -36,7 +37,7 @@ public class ProcessWorkerExecutorService extends AbstractExecutorService {
     private final ThreadContext contextHolder;
     private final String processName;
     private final CountDownLatch awaitTermination = new CountDownLatch(1);
-    private final BlockingQueue<Runnable> queue;
+    private final BlockingDeque<Runnable> queue;
     private final AtomicReference<Exception> error = new AtomicReference<>();
 
     private volatile boolean running = true;
@@ -51,7 +52,7 @@ public class ProcessWorkerExecutorService extends AbstractExecutorService {
     public ProcessWorkerExecutorService(ThreadContext contextHolder, String processName, int queueCapacity) {
         this.contextHolder = Objects.requireNonNull(contextHolder);
         this.processName = Objects.requireNonNull(processName);
-        this.queue = new LinkedBlockingQueue<>(queueCapacity);
+        this.queue = new LinkedBlockingDeque<>(queueCapacity);
     }
 
     public int queueSize() {
@@ -86,6 +87,20 @@ public class ProcessWorkerExecutorService extends AbstractExecutorService {
     @Override
     public boolean awaitTermination(long timeout, TimeUnit unit) throws InterruptedException {
         return awaitTermination.await(timeout, unit);
+    }
+
+    /**
+     * Skip to the front of the queue and execute first.
+     * @param command The command to run
+     * @param timeout Time to wait to put the command at the head of
+     *                the queue.
+     * @throws InterruptedException If interrupted
+     */
+    public void executeFirst(Runnable command, TimeValue timeout) throws InterruptedException {
+        boolean added = queue.offerFirst(contextHolder.preserveContext(command), timeout.millis(), TimeUnit.MILLISECONDS);
+        if (added == false) {
+            throw new EsRejectedExecutionException(processName + " queue is full. Unable to execute command", false);
+        }
     }
 
     @Override

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/deployment/DeploymentManagerTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/deployment/DeploymentManagerTests.java
@@ -9,6 +9,7 @@ package org.elasticsearch.xpack.ml.inference.deployment;
 
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.client.internal.Client;
+import org.elasticsearch.common.util.concurrent.AbstractRunnable;
 import org.elasticsearch.common.util.concurrent.EsRejectedExecutionException;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.test.ESTestCase;
@@ -17,9 +18,9 @@ import org.elasticsearch.threadpool.TestThreadPool;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.xcontent.NamedXContentRegistry;
 import org.elasticsearch.xpack.core.ml.inference.trainedmodel.InferenceConfig;
+import org.elasticsearch.xpack.ml.inference.pytorch.PriorityProcessWorkerExecutorService;
 import org.elasticsearch.xpack.ml.inference.pytorch.process.PyTorchProcessFactory;
 import org.elasticsearch.xpack.ml.inference.pytorch.process.PyTorchResultProcessor;
-import org.elasticsearch.xpack.ml.job.process.ProcessWorkerExecutorService;
 import org.junit.After;
 import org.junit.Before;
 
@@ -31,6 +32,7 @@ import static org.elasticsearch.xpack.ml.MachineLearning.UTILITY_THREAD_POOL_NAM
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -80,8 +82,9 @@ public class DeploymentManagerTests extends ESTestCase {
             mock(PyTorchProcessFactory.class)
         );
 
-        ProcessWorkerExecutorService executorService = mock(ProcessWorkerExecutorService.class);
-        doThrow(new EsRejectedExecutionException("mock executor rejection")).when(executorService).execute(any(Runnable.class));
+        PriorityProcessWorkerExecutorService executorService = mock(PriorityProcessWorkerExecutorService.class);
+        doThrow(new EsRejectedExecutionException("mock executor rejection")).when(executorService)
+            .executeWithPriority(any(AbstractRunnable.class), any(), anyLong());
 
         AtomicInteger rejectedCount = new AtomicInteger();
 

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/deployment/DeploymentManagerTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/deployment/DeploymentManagerTests.java
@@ -19,11 +19,11 @@ import org.elasticsearch.xcontent.NamedXContentRegistry;
 import org.elasticsearch.xpack.core.ml.inference.trainedmodel.InferenceConfig;
 import org.elasticsearch.xpack.ml.inference.pytorch.process.PyTorchProcessFactory;
 import org.elasticsearch.xpack.ml.inference.pytorch.process.PyTorchResultProcessor;
+import org.elasticsearch.xpack.ml.job.process.ProcessWorkerExecutorService;
 import org.junit.After;
 import org.junit.Before;
 
 import java.util.Map;
-import java.util.concurrent.ExecutorService;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.elasticsearch.xpack.ml.MachineLearning.JOB_COMMS_THREAD_POOL_NAME;
@@ -80,7 +80,7 @@ public class DeploymentManagerTests extends ESTestCase {
             mock(PyTorchProcessFactory.class)
         );
 
-        ExecutorService executorService = mock(ExecutorService.class);
+        ProcessWorkerExecutorService executorService = mock(ProcessWorkerExecutorService.class);
         doThrow(new EsRejectedExecutionException("mock executor rejection")).when(executorService).execute(any(Runnable.class));
 
         AtomicInteger rejectedCount = new AtomicInteger();
@@ -96,6 +96,7 @@ public class DeploymentManagerTests extends ESTestCase {
             task,
             mock(InferenceConfig.class),
             Map.of(),
+            false,
             TimeValue.timeValueMinutes(1),
             ActionListener.wrap(result -> fail("unexpected success"), e -> assertThat(e, instanceOf(EsRejectedExecutionException.class)))
         );

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/pytorch/PriorityProcessWorkerExecutorServiceTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/pytorch/PriorityProcessWorkerExecutorServiceTests.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.ml.inference.pytorch;
+
+import org.elasticsearch.common.util.concurrent.AbstractRunnable;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.threadpool.TestThreadPool;
+import org.elasticsearch.threadpool.ThreadPool;
+import org.junit.After;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.elasticsearch.xpack.ml.inference.pytorch.PriorityProcessWorkerExecutorService.RequestPriority;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.lessThan;
+
+public class PriorityProcessWorkerExecutorServiceTests extends ESTestCase {
+
+    private final ThreadPool threadPool = new TestThreadPool("PriorityProcessWorkerExecutorServiceTests");
+
+    @After
+    public void stopThreadPool() {
+        terminate(threadPool);
+    }
+
+    public void testOrderedRunnables_NormalPriority() throws InterruptedException {
+        var executor = createProcessWorkerExecutorService();
+
+        var counter = new AtomicInteger();
+
+        var r1 = new RunOrderValidator(1, counter);
+        executor.executeWithPriority(r1, RequestPriority.NORMAL, 100L);
+        var r2 = new RunOrderValidator(2, counter);
+        executor.executeWithPriority(r2, RequestPriority.NORMAL, 101L);
+        var r3 = new RunOrderValidator(3, counter);
+        executor.executeWithPriority(r3, RequestPriority.NORMAL, 102L);
+
+        // final action stops the executor
+        executor.executeWithPriority(new AbstractRunnable() {
+            @Override
+            public void onFailure(Exception e) {
+                executor.shutdown();
+                fail(e.getMessage());
+            }
+
+            @Override
+            protected void doRun() {
+                executor.shutdown();
+            }
+        }, RequestPriority.NORMAL, 10000L);
+
+        executor.start();
+
+        assertTrue(r1.hasBeenRun);
+        assertTrue(r2.hasBeenRun);
+        assertTrue(r3.hasBeenRun);
+    }
+
+    public void testOrderedRunnables_MixedPriorities() throws InterruptedException {
+        var executor = createProcessWorkerExecutorService();
+
+        assertThat(RequestPriority.HIGH.compareTo(RequestPriority.NORMAL), lessThan(0));
+
+        var counter = new AtomicInteger();
+        long requestId = 1;
+        var r1 = new RunOrderValidator(2, counter);
+        executor.executeWithPriority(r1, RequestPriority.NORMAL, requestId++);
+        executor.executeWithPriority(new RunOrderValidator(3, counter), RequestPriority.NORMAL, requestId++);
+        executor.executeWithPriority(new RunOrderValidator(4, counter), RequestPriority.NORMAL, requestId++);
+        executor.executeWithPriority(new RunOrderValidator(1, counter), RequestPriority.HIGH, requestId++);
+        executor.executeWithPriority(new RunOrderValidator(5, counter), RequestPriority.NORMAL, requestId++);
+        executor.executeWithPriority(new RunOrderValidator(6, counter), RequestPriority.NORMAL, requestId++);
+
+        // final action stops the executor
+        executor.executeWithPriority(new AbstractRunnable() {
+            @Override
+            public void onFailure(Exception e) {
+                executor.shutdown();
+                fail(e.getMessage());
+            }
+
+            @Override
+            protected void doRun() {
+                executor.shutdown();
+            }
+        }, RequestPriority.NORMAL, 10000L);
+
+        executor.start();
+
+        assertTrue(r1.hasBeenRun);
+    }
+
+    private PriorityProcessWorkerExecutorService createProcessWorkerExecutorService() {
+        return new PriorityProcessWorkerExecutorService(threadPool.getThreadContext(), "PriorityProcessWorkerExecutorServiceTests", 100);
+    }
+
+    private static class RunOrderValidator extends AbstractRunnable {
+
+        private boolean hasBeenRun = false;
+        private final int expectedOrder;
+        private final AtomicInteger counter;
+
+        RunOrderValidator(int expectedOrder, AtomicInteger counter) {
+            this.expectedOrder = expectedOrder;
+            this.counter = counter;
+        }
+
+        @Override
+        public void onFailure(Exception e) {
+            fail(e.getMessage());
+        }
+
+        @Override
+        protected void doRun() {
+            hasBeenRun = true;
+            assertThat(expectedOrder, equalTo(counter.incrementAndGet()));
+        }
+    }
+}

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/process/ProcessWorkerExecutorServiceTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/process/ProcessWorkerExecutorServiceTests.java
@@ -9,7 +9,6 @@ package org.elasticsearch.xpack.ml.job.process;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.common.util.concurrent.AbstractRunnable;
 import org.elasticsearch.common.util.concurrent.EsRejectedExecutionException;
-import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.threadpool.TestThreadPool;
 import org.elasticsearch.threadpool.ThreadPool;
@@ -20,10 +19,8 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.concurrent.atomic.AtomicIntegerArray;
 
 import static org.hamcrest.Matchers.containsString;
-import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.isA;
 
@@ -131,45 +128,6 @@ public class ProcessWorkerExecutorServiceTests extends ESTestCase {
         }
         Error e = expectThrows(Error.class, executor::start);
         assertThat(e.getMessage(), containsString("future error"));
-    }
-
-    public void testExecuteFirst() throws InterruptedException {
-        ProcessWorkerExecutorService executor = createExecutorService();
-
-        CountDownLatch start = new CountDownLatch(1);
-        CountDownLatch finished = new CountDownLatch(1);
-        threadPool.generic().submit(executor::start);
-
-        var order = new AtomicInteger();
-        var orderCalled = new AtomicIntegerArray(4);
-
-        // run a task that will block while the others are queued up
-        executor.execute(() -> {
-            try {
-                start.await();
-                orderCalled.set(0, order.incrementAndGet());
-            } catch (InterruptedException e) {
-                fail(e.getMessage());
-            }
-        });
-
-        executor.executeFirst(() -> { orderCalled.set(1, order.incrementAndGet()); }, TimeValue.timeValueMillis(1000));
-
-        executor.executeFirst(() -> { orderCalled.set(2, order.incrementAndGet()); }, TimeValue.timeValueMillis(1000));
-
-        executor.execute(() -> { orderCalled.set(3, order.incrementAndGet()); });
-
-        executor.execute(finished::countDown);
-
-        start.countDown();
-        finished.await();
-
-        assertThat(orderCalled.get(0), equalTo(1));
-        assertThat(orderCalled.get(1), equalTo(3)); // executeFirst
-        assertThat(orderCalled.get(2), equalTo(2)); // executeFirst
-        assertThat(orderCalled.get(3), equalTo(4));
-
-        executor.shutdown();
     }
 
     private ProcessWorkerExecutorService createExecutorService() {


### PR DESCRIPTION
Not all inference requests are equal, requests for searches should have a higher priority than those generated by ingest. 

3 types of request are expected each with a different priority:
- Normal inference requests executed at normal priority
- Higher priority inference requests (e.g. for search) that skip ahead of the queue of normal requests
- Control messages that change the number of allocations/threads. These are highest priority and are always executed even if the number of items in the queue has reached the capacity value.

An unbounded priority queue is used to queue the requests which are sorted first by priority then my the requests id (long) to preserve order. 

A `skipQueue` option is added to the internal inference request, this is not exposed to the REST API or indeed used anywhere as it will be used by the model allocation service. 