### PR TITLE
Enhance the migrate to tiers action message

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/ShardsAvailabilityHealthIndicatorService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/ShardsAvailabilityHealthIndicatorService.java
@@ -253,8 +253,8 @@ public class ShardsAvailabilityHealthIndicatorService implements HealthIndicator
         "Elasticsearch isn't allowed to allocate some shards from these indices to any of the nodes in their data tiers because the "
             + "indices are configured with allocation filter rules that are incompatible with the nodes in their tier. Remove ["
             + INDEX_ROUTING_REQUIRE_GROUP_PREFIX
-            + ".data] from each index's settings or try migrating to data tiers using the data tier migration action "
-            + "[POST /_ilm/migrate_to_data_tiers].",
+            + ".data] from each index's settings or try migrating to data tiers by first stopping ILM [POST /_ilm/stop] and then using "
+            + "the data tier migration action [POST /_ilm/migrate_to_data_tiers]. Finally, restart ILM [POST /_ilm/start].",
         null
     );
 
@@ -263,8 +263,8 @@ public class ShardsAvailabilityHealthIndicatorService implements HealthIndicator
         "Elasticsearch isn't allowed to allocate some shards from these indices to any of the nodes in their data tiers because the "
             + "indices are configured with allocation filter rules that are incompatible with the nodes in their tier. Remove ["
             + INDEX_ROUTING_INCLUDE_GROUP_PREFIX
-            + ".data] from each index's settings or try migrating to data tiers using the data tier migration action "
-            + "[POST /_ilm/migrate_to_data_tiers].",
+            + ".data] from each index's settings try migrating to data tiers by first stopping ILM [POST /_ilm/stop] and then using "
+            + "the data tier migration action [POST /_ilm/migrate_to_data_tiers]. Finally, restart ILM [POST /_ilm/start].",
         null
     );
 


### PR DESCRIPTION
This instructs the users to first stop ILM before calling the
migrate to tiers API.