### PR TITLE
Disable get API on legacy indices

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/shard/IndexShard.java
+++ b/server/src/main/java/org/elasticsearch/index/shard/IndexShard.java
@@ -1185,6 +1185,9 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
         if (mappingLookup.hasMappings() == false) {
             return GetResult.NOT_EXISTS;
         }
+        if (indexSettings.getIndexVersionCreated().isLegacyIndexVersion()) {
+            throw new IllegalStateException("get operations not allowed on a legacy index");
+        }
         return getEngine().get(get, mappingLookup, mapperService.documentParser(), this::wrapSearcher);
     }
 

--- a/x-pack/qa/repository-old-versions/src/test/java/org/elasticsearch/oldrepos/OldRepositoryAccessIT.java
+++ b/x-pack/qa/repository-old-versions/src/test/java/org/elasticsearch/oldrepos/OldRepositoryAccessIT.java
@@ -16,6 +16,7 @@ import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.client.Request;
 import org.elasticsearch.client.RequestOptions;
 import org.elasticsearch.client.Response;
+import org.elasticsearch.client.ResponseException;
 import org.elasticsearch.client.RestClient;
 import org.elasticsearch.client.RestHighLevelClient;
 import org.elasticsearch.client.core.ShardsAcknowledgedResponse;
@@ -49,6 +50,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
@@ -455,6 +457,12 @@ public class OldRepositoryAccessIT extends ESRestTestCase {
                     assertEquals(randomType, typeField.getValue());
                 }
             }
+
+            assertThat(
+                expectThrows(ResponseException.class, () -> client().performRequest(new Request("GET", "/" + index + "/_doc/" + id)))
+                    .getMessage(),
+                containsString("get operations not allowed on a legacy index")
+            );
         }
     }
 


### PR DESCRIPTION
The get API relies under the hood on accessing postings to lookup the _id and retrieve the corresponding document. Guaranteeing this access via postings is not something we would like to guarantee on archive indices. While we are adding "[text field support](https://github.com/elastic/elasticsearch/pull/86591)" for archive indices, we reserve the flexibility to eventually swap that out with a "runtime-text field" variant, and hence only provide those capabilities that can be emulated via a runtime field. Doing the same for "get" would mean doing a full scan of the index (using stored fields), which is counterintuitive to what the get API is meant to be used for (quick lookup of document). We would therefore rather not have the API accessible on archive indices.

Relates #81210