### PR TITLE
[7.17] Port build dependencies to gradle version catalogue (#86548)

### DIFF
--- a/build-conventions/build.gradle
+++ b/build-conventions/build.gradle
@@ -61,11 +61,11 @@ repositories {
 }
 
 dependencies {
-    api 'org.apache.maven:maven-model:3.6.2'
-    api 'gradle.plugin.com.github.johnrengelman:shadow:7.1.2'
-    api 'org.apache.rat:apache-rat:0.11'
-    compileOnly "com.puppycrawl.tools:checkstyle:9.3"
-    api('com.diffplug.spotless:spotless-plugin-gradle:6.5.2') {
+    api buildLibs.maven.model
+    api buildLibs.shadow.plugin
+    api buildLibs.apache.rat
+    compileOnly buildLibs.checkstyle
+    api(buildLibs.spotless.plugin) {
       exclude module: "groovy-xml"
     }
 }

--- a/build-conventions/settings.gradle
+++ b/build-conventions/settings.gradle
@@ -6,3 +6,11 @@
  * Side Public License, v 1.
  */
 rootProject.name = 'build-conventions'
+
+dependencyResolutionManagement {
+    versionCatalogs {
+        buildLibs {
+            from(files("../gradle/build.versions.toml"))
+        }
+    }
+}

--- a/build-tools-internal/build.gradle
+++ b/build-tools-internal/build.gradle
@@ -220,8 +220,8 @@ dependencies {
       because 'We want to use the exact same jackson version we use in production'
     }
     // ensuring brought asm version brought in by spock is up-to-date
-    testImplementation 'org.ow2.asm:asm:9.3'
-    integTestImplementation 'org.ow2.asm:asm:9.3'
+    testImplementation buildLibs.asm
+    integTestImplementation buildLibs.asm
   }
   api localGroovy()
   api gradleApi()
@@ -229,66 +229,65 @@ dependencies {
   api "org.elasticsearch.gradle:build-tools:$version"
   api "org.openrewrite:rewrite-java:7.10.0"
   api 'org.openrewrite:plugin:5.6.0'
-  api 'commons-codec:commons-codec:1.11'
-  api 'org.apache.commons:commons-compress:1.21'
-  api 'org.apache.ant:ant:1.10.8'
+  api buildLibs.commons.codec
+  api buildLibs.apache.compress
+  api buildLibs.ant
   api 'com.netflix.nebula:gradle-extra-configurations-plugin:7.0.0'
-  api 'com.netflix.nebula:gradle-info-plugin:11.1.0'
-  api 'org.apache.rat:apache-rat:0.11'
-  api "net.java.dev.jna:jna:${versions.getProperty('jna')}"
-  api 'gradle.plugin.com.github.johnrengelman:shadow:7.1.2'
+  api buildLibs.nebula.info
+  api buildLibs.apache.rat
+  api buildLibs.jna
+  api buildLibs.shadow.plugin
   // for our ide tweaking
-  api 'gradle.plugin.org.jetbrains.gradle.plugin.idea-ext:gradle-idea-ext:1.1.1'
+  api buildLibs.idea.ext
   // When upgrading forbidden apis, ensure dependency version is bumped in ThirdPartyPrecommitPlugin as well
-  api 'de.thetaphi:forbiddenapis:3.2'
-  api 'com.avast.gradle:gradle-docker-compose-plugin:0.14.13'
-  api 'org.apache.maven:maven-model:3.6.2'
-  api 'com.networknt:json-schema-validator:1.0.65'
-  api "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:${versions.getProperty('jackson')}"
-  api 'org.ow2.asm:asm:9.2'
-  api 'org.ow2.asm:asm-tree:9.2'
+  api buildLibs.forbiddenApis
+  api buildLibs.docker.compose
+  api buildLibs.maven.model
+  api buildLibs.json.schema.validator
+  api buildLibs.jackson.dataformat.yaml
+  api buildLibs.asm
+  api buildLibs.asm.tree
 
-  compileOnly "com.puppycrawl.tools:checkstyle:${versions.getProperty('checkstyle')}"
+  compileOnly buildLibs.checkstyle
   runtimeOnly "org.elasticsearch.gradle:reaper:$version"
-  testImplementation "com.puppycrawl.tools:checkstyle:${versions.getProperty('checkstyle')}"
-  testImplementation 'com.github.tomakehurst:wiremock-jre8-standalone:2.23.2'
-  testImplementation 'org.mockito:mockito-core:1.9.5'
-  testImplementation "org.hamcrest:hamcrest:${versions.getProperty('hamcrest')}"
-
+  testImplementation buildLibs.checkstyle
+  testImplementation buildLibs.wiremock
+  testImplementation buildLibs.mockito.core
+  testImplementation buildLibs.hamcrest
   testImplementation testFixtures("org.elasticsearch.gradle:build-tools:$version")
 
-  testImplementation(platform("org.junit:junit-bom:${versions.getProperty('junit5')}"))
-  testImplementation("org.junit.jupiter:junit-jupiter") {
+  testImplementation(platform(buildLibs.junit5.platform))
+  testImplementation(buildLibs.junit5.jupiter) {
     because 'allows to write and run Jupiter tests'
   }
-  integTestImplementation(platform("org.junit:junit-bom:${versions.getProperty('junit5')}"))
-  integTestImplementation("org.junit.jupiter:junit-jupiter") {
+  integTestImplementation(platform(buildLibs.junit5.platform))
+  integTestImplementation(buildLibs.junit5.jupiter) {
     because 'allows to write and run Jupiter tests'
   }
-  integTestImplementation("net.bytebuddy:byte-buddy:1.12.9") {
+  integTestImplementation(buildLibs.bytebuddy) {
     because 'Generating dynamic mocks of internal libraries like JdkJarHell'
   }
-  testRuntimeOnly("org.junit.vintage:junit-vintage-engine") {
+  testRuntimeOnly(buildLibs.junit5.vintage) {
     because 'allows JUnit 3 and JUnit 4 tests to run'
   }
-  testRuntimeOnly("org.junit.platform:junit-platform-launcher") {
+  testRuntimeOnly(buildLibs.junit5.platform.launcher) {
     because 'allows tests to run from IDEs that bundle older version of launcher'
   }
 
-  testImplementation platform("org.spockframework:spock-bom:2.1-groovy-3.0")
-  testImplementation("org.spockframework:spock-core") {
+  testImplementation platform(buildLibs.spock.platform)
+  testImplementation(buildLibs.spock.core) {
     exclude module: "groovy"
   }
-  integTestImplementation platform("org.spockframework:spock-bom:2.1-groovy-3.0")
-  integTestImplementation("org.spockframework:spock-core") {
+  integTestImplementation platform(buildLibs.spock.platform)
+  integTestImplementation(buildLibs.spock.core) {
     exclude module: "groovy"
   }
   // required as we rely on junit4 rules
-  integTestImplementation("org.spockframework:spock-junit4") {
+  integTestImplementation(buildLibs.spock.junit4) {
     exclude module: "groovy"
   }
-  testImplementation "org.spockframework:spock-junit4"
-  integTestImplementation "org.xmlunit:xmlunit-core:2.8.2"
+  testImplementation buildLibs.spock.junit4
+  integTestImplementation buildLibs.xmlunit.core
 }
 
 tasks.named('test').configure {

--- a/build-tools-internal/settings.gradle
+++ b/build-tools-internal/settings.gradle
@@ -1,0 +1,7 @@
+dependencyResolutionManagement {
+    versionCatalogs {
+        buildLibs {
+            from(files("../gradle/build.versions.toml"))
+        }
+    }
+}

--- a/build-tools/build.gradle
+++ b/build-tools/build.gradle
@@ -110,40 +110,42 @@ repositories {
 dependencies {
     constraints {
         // ensuring brought asm version brought in by spock is up-to-date
-        testFixturesApi 'org.ow2.asm:asm:9.3'
-        integTestImplementation 'org.ow2.asm:asm:9.3'
+        testFixturesApi buildLibs.asm
+        integTestImplementation buildLibs.asm
     }
     reaper project('reaper')
 
     api localGroovy()
     api gradleApi()
-    api 'org.apache.commons:commons-compress:1.21'
-    api 'org.apache.ant:ant:1.10.8'
-    api 'commons-io:commons-io:2.2'
+    api buildLibs.apache.compress
+    api buildLibs.ant
+    api buildLibs.commmons.io
 
     testFixturesApi "junit:junit:${versions.getProperty('junit')}"
     testFixturesApi "com.carrotsearch.randomizedtesting:randomizedtesting-runner:${versions.getProperty('randomizedrunner')}"
     testFixturesApi gradleApi()
     testFixturesApi gradleTestKit()
-    testFixturesApi 'com.github.tomakehurst:wiremock-jre8-standalone:2.23.2'
-    testFixturesApi platform("org.spockframework:spock-bom:2.1-groovy-3.0")
-    testFixturesApi("org.spockframework:spock-core") {
+    testFixturesApi buildLibs.junit
+    testFixturesApi buildLibs.randomized.runner
+    testFixturesApi buildLibs.wiremock
+    testFixturesApi platform(buildLibs.spock.platform)
+    testFixturesApi(buildLibs.spock.core) {
         exclude module: "groovy"
     }
 
-    integTestImplementation("org.spockframework:spock-junit4") {
+    integTestImplementation(buildLibs.spock.junit4) {
         because 'required as we rely on junit4 rules'
     }
 
-    integTestImplementation(platform("org.junit:junit-bom:${versions.getProperty('junit5')}"))
-    integTestImplementation("org.junit.jupiter:junit-jupiter") {
+    integTestImplementation(platform(buildLibs.junit5.platform))
+    integTestImplementation(buildLibs.junit5.jupiter) {
         because 'allows to write and run Jupiter tests'
     }
-    integTestRuntimeOnly("org.junit.vintage:junit-vintage-engine") {
+    integTestRuntimeOnly(buildLibs.junit5.vintage) {
         because 'allows JUnit 3 and JUnit 4 tests to run'
     }
 
-    integTestRuntimeOnly("org.junit.platform:junit-platform-launcher") {
+    integTestRuntimeOnly(buildLibs.junit5.platform.launcher) {
         because 'allows tests to run from IDEs that bundle older version of launcher'
     }
 }

--- a/build-tools/settings.gradle
+++ b/build-tools/settings.gradle
@@ -6,3 +6,11 @@
  * Side Public License, v 1.
  */
 include 'reaper'
+
+dependencyResolutionManagement {
+    versionCatalogs {
+        buildLibs {
+            from(files("../gradle/build.versions.toml"))
+        }
+    }
+}

--- a/gradle/build.versions.toml
+++ b/gradle/build.versions.toml
@@ -1,0 +1,42 @@
+[versions]
+asm = "9.3"
+jackson = "2.10.4"
+junit5 = "5.8.1"
+spock = "2.1-groovy-3.0"
+
+[libraries]
+ant = "org.apache.ant:ant:1.10.8"
+apache-compress = "org.apache.commons:commons-compress:1.21"
+apache-rat = "org.apache.rat:apache-rat:0.11"
+asm = { group = "org.ow2.asm", name="asm", version.ref="asm" }
+asm-tree = { group = "org.ow2.asm", name="asm-tree", version.ref="asm" }
+bytebuddy = "net.bytebuddy:byte-buddy:1.12.9"
+checkstyle = "com.puppycrawl.tools:checkstyle:9.3"
+commons-codec = "commons-codec:commons-codec:1.11"
+commmons-io = "commons-io:commons-io:2.2"
+docker-compose = "com.avast.gradle:gradle-docker-compose-plugin:0.14.13"
+forbiddenApis = "de.thetaphi:forbiddenapis:3.2"
+hamcrest = "org.hamcrest:hamcrest:2.1"
+httpcore = "org.apache.httpcomponents:httpcore:4.4.12"
+httpclient = "org.apache.httpcomponents:httpclient:4.5.10"
+idea-ext = "gradle.plugin.org.jetbrains.gradle.plugin.idea-ext:gradle-idea-ext:1.1.1"
+json-schema-validator = "com.networknt:json-schema-validator:1.0.49"
+jackson-dataformat-yaml = { group = "com.fasterxml.jackson.dataformat", name="jackson-dataformat-yaml", version.ref="jackson" }
+jackson-platform = { group = "com.fasterxml.jackson", name="jackson-bom", version.ref="jackson" }
+jna = "net.java.dev.jna:jna:5.10.0"
+junit = "junit:junit:4.12"
+junit5-platform = { group = "org.junit", name="junit-bom", version.ref="junit5" }
+junit5-jupiter = { group = "org.junit.jupiter", name="junit-jupiter", version.ref="junit5" }
+junit5-platform-launcher = "org.junit.platform:junit-platform-launcher:1.8.0"
+junit5-vintage = { group = "org.junit.vintage", name="junit-vintage-engine", version.ref="junit5" }
+maven-model = "org.apache.maven:maven-model:3.6.2"
+mockito-core = "org.mockito:mockito-core:1.9.5"
+nebula-info = "com.netflix.nebula:gradle-info-plugin:11.3.3"
+randomized-runner = "com.carrotsearch.randomizedtesting:randomizedtesting-runner:2.7.7"
+shadow-plugin = "gradle.plugin.com.github.johnrengelman:shadow:7.1.2"
+spock-core = { group = "org.spockframework", name="spock-core", version.ref="spock" }
+spock-junit4 = { group = "org.spockframework", name="spock-junit4", version.ref="spock" }
+spock-platform = { group = "org.spockframework", name="spock-bom", version.ref="spock" }
+spotless-plugin = "com.diffplug.spotless:spotless-plugin-gradle:6.5.2"
+wiremock = "com.github.tomakehurst:wiremock-jre8-standalone:2.23.2"
+xmlunit-core = "org.xmlunit:xmlunit-core:2.8.2"


### PR DESCRIPTION
Backports the following commits to 7.17:
 - Port build dependencies to gradle version catalogue (#86548)