### PR TITLE
Fix deprecation in jdk provisioning for resolving configurations out of context

### DIFF
--- a/build-tools-internal/src/main/groovy/elasticsearch.runtime-jdk-provision.gradle
+++ b/build-tools-internal/src/main/groovy/elasticsearch.runtime-jdk-provision.gradle
@@ -13,23 +13,24 @@ import org.elasticsearch.gradle.internal.info.BuildParams
 
 // gradle has an open issue of failing applying plugins in
 // precompiled script plugins (see https://github.com/gradle/gradle/issues/17004)
-// apply plugin: 'elasticsearch.jdk-download'
 
-jdks {
-    provisioned_runtime {
-        vendor = VersionProperties.bundledJdkVendor
-        version = VersionProperties.bundledJdkVersion
-        platform = OS.current().name().toLowerCase()
-        architecture = Architecture.current().name().toLowerCase()
-    }
-}
 
 configure(allprojects) {
+    apply plugin: 'elasticsearch.jdk-download'
+
+    jdks {
+        provisioned_runtime {
+            vendor = VersionProperties.bundledJdkVendor
+            version = VersionProperties.bundledJdkVersion
+            platform = OS.current().name().toLowerCase()
+            architecture = Architecture.current().name().toLowerCase()
+        }
+    }
     project.tasks.withType(Test).configureEach { Test test ->
         if (BuildParams.getIsRuntimeJavaHomeSet()) {
             test.executable = "${BuildParams.runtimeJavaHome}/bin/java"
         } else {
-            test.dependsOn(rootProject.jdks.provisioned_runtime)
+            test.dependsOn(project.jdks.provisioned_runtime)
             test.executable = rootProject.jdks.provisioned_runtime.getBinJavaPath()
         }
     }
@@ -37,7 +38,7 @@ configure(allprojects) {
         project.plugins.withId("elasticsearch.internal-testclusters") { internalPlugin ->
             if (BuildParams.getIsRuntimeJavaHomeSet() == false) {
                 // If no runtime java home is set, use the bundled JDK for test clusters
-                testClustersPlugin.setRuntimeJava(providers.provider(() -> file("${rootProject.jdks.provisioned_runtime.javaHomePath}")))
+                testClustersPlugin.setRuntimeJava(providers.provider(() -> file("${project.jdks.provisioned_runtime.javaHomePath}")))
             }
         }
     }


### PR DESCRIPTION
Fixes a deprecation warning when resolving a configuration of root project in the context of another subproject