### PR TITLE
[DOCS] Fix CA cert directory for client connections

### DIFF
--- a/docs/reference/setup/install/connect-clients.asciidoc
+++ b/docs/reference/setup/install/connect-clients.asciidoc
@@ -1,8 +1,16 @@
 ==== Connect clients to {es}
+// This file is reused in each of the installation pages. Ensure that any changes
+// you make to this file are applicable across all installation environments.
 
 When you start {es} for the first time, TLS is configured automatically for the
-HTTP layer. A CA certificate is generated and stored on disk at
-`$ES_HOME/config/certs/http_ca.crt`. The hex-encoded SHA-256 fingerprint of this
+HTTP layer. A CA certificate is generated and stored on disk at:
+
+[source,sh,subs="attributes"]
+----
+{es-conf}{slash}certs{slash}http_ca.crt
+----
+
+The hex-encoded SHA-256 fingerprint of this
 certificate is also output to the terminal. Any clients that connect to {es},
 such as the 
 https://www.elastic.co/guide/en/elasticsearch/client/index.html[{es} Clients],
@@ -45,7 +53,13 @@ SHA256 Fingerprint=<fingerprint>
 ===== Use the CA certificate
 
 If your library doesn't support a method of validating the fingerprint, the 
-auto-generated CA certificate is created in the
-`$ES_HOME/config/certs/` directory on each {es} node. Copy the
-`http_ca.crt` file to your machine and configure your client to use this
+auto-generated CA certificate is created in the following directory on each {es}
+node:
+
+[source,sh,subs="attributes"]
+----
+{es-conf}{slash}certs{slash}http_ca.crt
+----
+
+Copy the `http_ca.crt` file to your machine and configure your client to use this
 certificate to establish trust when it connects to {es}.


### PR DESCRIPTION
A community user indicated in #85128 that the CA certificate directory in the [Connect clients to Elasticsearch](https://www.elastic.co/guide/en/elasticsearch/reference/current/rpm.html#_connect_clients_to_elasticsearch_4) page was incorrect for Debian (which is also true for RPM). This PR adds a code block with attributes that can be substituted for each installation environment where the `connect-clients.asciidoc` file is reused so that the directory renders correctly for each environment.

Preview links:
* The [`tar.gz` page](https://elasticsearch_86613.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/targz.html#_connect_clients_to_elasticsearch) shows `$ES_HOME/config/certs/http_ca.crt`
* The [Debian page](https://elasticsearch_86613.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/deb.html#_connect_clients_to_elasticsearch_3) (and RPM) shows `/etc/elasticsearch/certs/http_ca.crt`
* The [.zip page](https://elasticsearch_86613.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/zip-windows.html#_connect_clients_to_elasticsearch_2) shows `%ES_HOME%\config\certs\http_ca.crt`