### PR TITLE
[8.2] [DOCS] Fix CA cert directory for client connections (#86613)

### DIFF
--- a/docs/reference/setup/install/connect-clients.asciidoc
+++ b/docs/reference/setup/install/connect-clients.asciidoc
@@ -1,8 +1,16 @@
 ==== Connect clients to {es}
+// This file is reused in each of the installation pages. Ensure that any changes
+// you make to this file are applicable across all installation environments.
 
 When you start {es} for the first time, TLS is configured automatically for the
-HTTP layer. A CA certificate is generated and stored on disk at
-`$ES_HOME/config/certs/http_ca.crt`. The hex-encoded SHA-256 fingerprint of this
+HTTP layer. A CA certificate is generated and stored on disk at:
+
+[source,sh,subs="attributes"]
+----
+{es-conf}{slash}certs{slash}http_ca.crt
+----
+
+The hex-encoded SHA-256 fingerprint of this
 certificate is also output to the terminal. Any clients that connect to {es},
 such as the 
 https://www.elastic.co/guide/en/elasticsearch/client/index.html[{es} Clients],
@@ -45,7 +53,13 @@ SHA256 Fingerprint=<fingerprint>
 ===== Use the CA certificate
 
 If your library doesn't support a method of validating the fingerprint, the 
-auto-generated CA certificate is created in the
-`$ES_HOME/config/certs/` directory on each {es} node. Copy the
-`http_ca.crt` file to your machine and configure your client to use this
+auto-generated CA certificate is created in the following directory on each {es}
+node:
+
+[source,sh,subs="attributes"]
+----
+{es-conf}{slash}certs{slash}http_ca.crt
+----
+
+Copy the `http_ca.crt` file to your machine and configure your client to use this
 certificate to establish trust when it connects to {es}.


### PR DESCRIPTION
Backports the following commits to 8.2:
 - [DOCS] Fix CA cert directory for client connections (#86613)