### PR TITLE
[8.2] Minor documentation fix in enroll node API section (#85267)

### DIFF
--- a/x-pack/docs/en/rest-api/security/enroll-node.asciidoc
+++ b/x-pack/docs/en/rest-api/security/enroll-node.asciidoc
@@ -27,7 +27,7 @@ caller to generate valid signed certificates for the HTTP layer of all nodes in 
 
 [source,console]
 --------------------------------------------------
-GET /security/enroll/node
+GET /_security/enroll/node
 --------------------------------------------------
 // TEST[skip:Determine behavior for keystore with multiple keys]
 The API returns a response such as


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.2`:
 - [Minor documentation fix in enroll node API section (#85267)](https://github.com/elastic/elasticsearch/pull/85267)

<!--- Backport version: 8.4.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)