### PR TITLE
Convert no arg parameterized message to direct strings

### DIFF
--- a/modules/repository-azure/src/main/java/org/elasticsearch/repositories/azure/CancellableRateLimitedFluxIterator.java
+++ b/modules/repository-azure/src/main/java/org/elasticsearch/repositories/azure/CancellableRateLimitedFluxIterator.java
@@ -215,7 +215,7 @@ class CancellableRateLimitedFluxIterator<T> implements Subscriber<T>, Iterator<T
         try {
             cleaner.accept(element);
         } catch (Exception e) {
-            logger.warn(new ParameterizedMessage("Unable to clean unused element"), e);
+            logger.warn("Unable to clean unused element", e);
         }
     }
 

--- a/modules/repository-azure/src/main/java/org/elasticsearch/repositories/azure/CancellableRateLimitedFluxIterator.java
+++ b/modules/repository-azure/src/main/java/org/elasticsearch/repositories/azure/CancellableRateLimitedFluxIterator.java
@@ -10,7 +10,6 @@ package org.elasticsearch.repositories.azure;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.message.ParameterizedMessage;
 import org.reactivestreams.Subscriber;
 import org.reactivestreams.Subscription;
 

--- a/server/src/main/java/org/elasticsearch/action/search/SearchProgressListener.java
+++ b/server/src/main/java/org/elasticsearch/action/search/SearchProgressListener.java
@@ -101,7 +101,7 @@ public abstract class SearchProgressListener {
         try {
             onListShards(shards, skippedShards, clusters, fetchPhase);
         } catch (Exception e) {
-            logger.warn(() -> new ParameterizedMessage("Failed to execute progress listener on list shards"), e);
+            logger.warn("Failed to execute progress listener on list shards", e);
         }
     }
 
@@ -131,7 +131,7 @@ public abstract class SearchProgressListener {
         try {
             onPartialReduce(shards, totalHits, aggs, reducePhase);
         } catch (Exception e) {
-            logger.warn(() -> new ParameterizedMessage("Failed to execute progress listener on partial reduce"), e);
+            logger.warn("Failed to execute progress listener on partial reduce", e);
         }
     }
 
@@ -139,7 +139,7 @@ public abstract class SearchProgressListener {
         try {
             onFinalReduce(shards, totalHits, aggs, reducePhase);
         } catch (Exception e) {
-            logger.warn(() -> new ParameterizedMessage("Failed to execute progress listener on reduce"), e);
+            logger.warn("Failed to execute progress listener on reduce", e);
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/index/engine/Engine.java
+++ b/server/src/main/java/org/elasticsearch/index/engine/Engine.java
@@ -661,7 +661,7 @@ public abstract class Engine implements Closeable {
         } catch (Exception ex) {
             maybeFailEngine("acquire_reader", ex);
             ensureOpen(ex); // throw EngineCloseException here if we are already closed
-            logger.error(() -> new ParameterizedMessage("failed to acquire reader"), ex);
+            logger.error("failed to acquire reader", ex);
             throw new EngineException(shardId, "failed to acquire reader", ex);
         } finally {
             Releasables.close(releasable);

--- a/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/repository/CcrRepository.java
+++ b/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/repository/CcrRepository.java
@@ -698,10 +698,7 @@ public class CcrRepository extends AbstractLifecycleComponent implements Reposit
                                         listener.onFailure(e);
                                     } catch (Exception ex) {
                                         e.addSuppressed(ex);
-                                        logger.warn(
-                                            "failed to execute failure callback for chunk request",
-                                            e
-                                        );
+                                        logger.warn("failed to execute failure callback for chunk request", e);
                                     }
                                 });
                             }

--- a/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/repository/CcrRepository.java
+++ b/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/repository/CcrRepository.java
@@ -699,7 +699,7 @@ public class CcrRepository extends AbstractLifecycleComponent implements Reposit
                                     } catch (Exception ex) {
                                         e.addSuppressed(ex);
                                         logger.warn(
-                                            () -> new ParameterizedMessage("failed to execute failure callback for chunk request"),
+                                            "failed to execute failure callback for chunk request",
                                             e
                                         );
                                     }

--- a/x-pack/plugin/monitoring/src/main/java/org/elasticsearch/xpack/monitoring/MonitoringService.java
+++ b/x-pack/plugin/monitoring/src/main/java/org/elasticsearch/xpack/monitoring/MonitoringService.java
@@ -174,7 +174,7 @@ public class MonitoringService extends AbstractLifecycleComponent {
                 scheduleExecution();
                 logger.debug("monitoring service started");
             } catch (Exception e) {
-                logger.error((Supplier<?>) () -> new ParameterizedMessage("failed to start monitoring service"), e);
+                logger.error("failed to start monitoring service", e);
                 started.set(false);
                 throw e;
             }

--- a/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/common/http/HttpClientTests.java
+++ b/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/common/http/HttpClientTests.java
@@ -10,8 +10,6 @@ import org.apache.http.HttpHeaders;
 import org.apache.http.HttpHost;
 import org.apache.http.client.ClientProtocolException;
 import org.apache.http.client.config.RequestConfig;
-import org.apache.logging.log4j.message.ParameterizedMessage;
-import org.apache.logging.log4j.util.Supplier;
 import org.apache.lucene.util.automaton.CharacterRunAutomaton;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.cluster.service.ClusterService;
@@ -54,7 +52,6 @@ import java.util.Locale;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicReference;
-
 import javax.net.ssl.SSLContext;
 
 import static org.hamcrest.Matchers.containsInAnyOrder;
@@ -541,7 +538,7 @@ public class HttpClientTests extends ESTestCase {
                     socket.getOutputStream().flush();
                 } catch (Exception e) {
                     hasExceptionHappened.set(e);
-                    logger.error((Supplier<?>) () -> new ParameterizedMessage("Error in writing non HTTP response"), e);
+                    logger.error("Error in writing non HTTP response", e);
                 }
             });
             HttpRequest request = HttpRequest.builder("localhost", serverSocket.getLocalPort()).path("/").build();

--- a/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/common/http/HttpClientTests.java
+++ b/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/common/http/HttpClientTests.java
@@ -52,6 +52,7 @@ import java.util.Locale;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicReference;
+
 import javax.net.ssl.SSLContext;
 
 import static org.hamcrest.Matchers.containsInAnyOrder;


### PR DESCRIPTION
This commit converts all ParameterizedMessages which take no arguments
to direct logging messages. There is no need for lazy evaluation since
these strings are static.

relates #86549