### PR TITLE
[8.2] [Docs] Document apiKey usage in remote reindex (#85209)

### DIFF
--- a/docs/reference/docs/reindex.asciidoc
+++ b/docs/reference/docs/reindex.asciidoc
@@ -534,7 +534,8 @@ Required when indexing from remote.
 (Optional, <<time-units, time units>>) The remote socket read timeout. Defaults to 30 seconds.
 `connect_timeout`::::
 (Optional, <<time-units, time units>>) The remote connection timeout. Defaults to 30 seconds.
-
+`headers`::::
+(Optional, object) An object containing the headers of ther request.
 `size`:::
 {Optional, integer) The number of documents to index per batch.
 Use when indexing from remote to ensure that the batches fit within the on-heap buffer,
@@ -994,7 +995,38 @@ using basic auth or the password will be sent in plain text.
 There are a range of <<reindex-ssl,settings>> available to configure the behaviour of the
  `https` connection.
 
-Remote hosts have to be explicitly allowed in elasticsearch.yml using the
+When using {ecloud}, it is also possible to authenticate against the remote cluster
+through the use of a valid API key:
+
+[source,console]
+----
+POST _reindex
+{
+  "source": {
+    "remote": {
+      "host": "http://otherhost:9200",
+      "headers": {
+        "Authorization": "ApiKey API_KEY_VALUE"
+      }
+    },
+    "index": "my-index-000001",
+    "query": {
+      "match": {
+        "test": "data"
+      }
+    }
+  },
+  "dest": {
+    "index": "my-new-index-000001"
+  }
+}
+----
+// TEST[setup:host]
+// TEST[s/^/PUT my-index-000001\n/]
+// TEST[s/otherhost:9200",/\${host}",/]
+// TEST[s/API_KEY_VALUE" /\93116930-2ecb-4161-aa5e-4f3586c87ac6"/]
+
+Remote hosts have to be explicitly allowed in `elasticsearch.yml` using the
 `reindex.remote.whitelist` property. It can be set to a comma delimited list
 of allowed remote `host` and `port` combinations. Scheme is
 ignored, only the host and port are used. For example:


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `8.2`:
 - [[Docs] Document apiKey usage in remote reindex (#85209)](https://github.com/elastic/elasticsearch/pull/85209)

<!--- Backport version: 8.4.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)