### PR TITLE
[Refactor] Flexible general actions over plugins in PluginsService

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/IndexModule.java
+++ b/server/src/main/java/org/elasticsearch/index/IndexModule.java
@@ -155,7 +155,7 @@ public final class IndexModule {
 
     /**
      * Construct the index module for the index with the specified index settings. The index module contains extension points for plugins
-     * via {@link org.elasticsearch.plugins.PluginsService#onIndexModule(IndexModule)}.
+     * via {@link org.elasticsearch.plugins.Plugin#onIndexModule(IndexModule)}.
      *
      * @param indexSettings       the index settings
      * @param analysisRegistry    the analysis registry

--- a/server/src/main/java/org/elasticsearch/indices/IndicesService.java
+++ b/server/src/main/java/org/elasticsearch/indices/IndicesService.java
@@ -706,7 +706,7 @@ public class IndicesService extends AbstractLifecycleComponent
         for (IndexingOperationListener operationListener : indexingOperationListeners) {
             indexModule.addIndexOperationListener(operationListener);
         }
-        pluginsService.onIndexModule(indexModule);
+        pluginsService.forEach(p -> p.onIndexModule(indexModule));
         for (IndexEventListener listener : builtInListeners) {
             indexModule.addIndexEventListener(listener);
         }
@@ -779,7 +779,7 @@ public class IndicesService extends AbstractLifecycleComponent
             indexNameExpressionResolver,
             recoveryStateFactories
         );
-        pluginsService.onIndexModule(indexModule);
+        pluginsService.forEach(p -> p.onIndexModule(indexModule));
         return indexModule.newIndexMapperService(parserConfig, mapperRegistry, scriptService);
     }
 

--- a/server/src/main/java/org/elasticsearch/plugins/PluginsService.java
+++ b/server/src/main/java/org/elasticsearch/plugins/PluginsService.java
@@ -207,7 +207,7 @@ public class PluginsService implements ReportingService<PluginsAndModules> {
     }
 
     /**
-     * FlatMap a function over all plugins
+     * Map a function over all plugins
      * @param function a function that takes a plugin and returns a result
      * @return A stream of results
      * @param <T> The generic type of the result

--- a/server/src/main/java/org/elasticsearch/plugins/PluginsService.java
+++ b/server/src/main/java/org/elasticsearch/plugins/PluginsService.java
@@ -206,6 +206,12 @@ public class PluginsService implements ReportingService<PluginsAndModules> {
         }
     }
 
+    /**
+     * FlatMap a function over all plugins
+     * @param function a function that takes a plugin and returns a result
+     * @return A stream of results
+     * @param <T> The generic type of the result
+     */
     public <T> Stream<T> map(Function<Plugin, T> function) {
         return plugins.stream().map(LoadedPlugin::instance).map(function);
     }
@@ -213,7 +219,7 @@ public class PluginsService implements ReportingService<PluginsAndModules> {
     /**
      * FlatMap a function over all plugins
      * @param function a function that takes a plugin and returns a collection
-     * @return A list of results
+     * @return A stream of results
      * @param <T> The generic type of the collection
      */
     public <T> Stream<T> flatMap(Function<Plugin, Collection<T>> function) {

--- a/server/src/main/java/org/elasticsearch/plugins/PluginsService.java
+++ b/server/src/main/java/org/elasticsearch/plugins/PluginsService.java
@@ -23,11 +23,9 @@ import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Setting.Property;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.core.Tuple;
-import org.elasticsearch.index.IndexModule;
 import org.elasticsearch.jdk.JarHell;
 import org.elasticsearch.node.ReportingService;
 import org.elasticsearch.plugins.spi.SPIClassIterator;
-import org.elasticsearch.threadpool.ExecutorBuilder;
 
 import java.io.IOException;
 import java.lang.reflect.Constructor;
@@ -50,8 +48,10 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import static org.elasticsearch.common.io.FileSystemUtils.isAccessibleDirectory;
 
@@ -82,14 +82,6 @@ public class PluginsService implements ReportingService<PluginsAndModules> {
         Function.identity(),
         Property.NodeScope
     );
-
-    public List<Setting<?>> getPluginSettings() {
-        return plugins.stream().flatMap(p -> p.instance().getSettings().stream()).toList();
-    }
-
-    public List<String> getPluginSettingsFilter() {
-        return plugins.stream().flatMap(p -> p.instance().getSettingsFilter().stream()).toList();
-    }
 
     /**
      * Constructs a new PluginService
@@ -214,6 +206,28 @@ public class PluginsService implements ReportingService<PluginsAndModules> {
         }
     }
 
+    public <T> Stream<T> map(Function<Plugin, T> function) {
+        return plugins.stream().map(LoadedPlugin::instance).map(function);
+    }
+
+    /**
+     * FlatMap a function over all plugins
+     * @param function a function that takes a plugin and returns a collection
+     * @return A list of results
+     * @param <T> The generic type of the collection
+     */
+    public <T> Stream<T> flatMap(Function<Plugin, Collection<T>> function) {
+        return plugins.stream().map(LoadedPlugin::instance).flatMap(p -> function.apply(p).stream());
+    }
+
+    /**
+     * Apply a consumer action to each plugin
+     * @param consumer An action that consumes a plugin
+     */
+    public void forEach(Consumer<Plugin> consumer) {
+        plugins.stream().map(LoadedPlugin::instance).forEach(consumer);
+    }
+
     public Settings updatedSettings() {
         Map<String, String> foundSettings = new HashMap<>();
         final Settings.Builder builder = Settings.builder();
@@ -237,20 +251,6 @@ public class PluginsService implements ReportingService<PluginsAndModules> {
             builder.put(settings);
         }
         return builder.put(this.settings).build();
-    }
-
-    public List<ExecutorBuilder<?>> getExecutorBuilders(Settings settings) {
-        final ArrayList<ExecutorBuilder<?>> builders = new ArrayList<>();
-        for (final LoadedPlugin plugin : plugins) {
-            builders.addAll(plugin.instance().getExecutorBuilders(settings));
-        }
-        return builders;
-    }
-
-    public void onIndexModule(IndexModule indexModule) {
-        for (LoadedPlugin plugin : plugins) {
-            plugin.instance().onIndexModule(indexModule);
-        }
     }
 
     /**

--- a/test/framework/src/main/java/org/elasticsearch/test/AbstractBuilderTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/AbstractBuilderTestCase.java
@@ -28,7 +28,6 @@ import org.elasticsearch.common.compress.CompressedXContent;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.regex.Regex;
 import org.elasticsearch.common.settings.IndexScopedSettings;
-import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.settings.SettingsModule;
 import org.elasticsearch.common.xcontent.LoggingDeprecationHandler;
@@ -370,11 +369,10 @@ public abstract class AbstractBuilderTestCase extends ESTestCase {
                 clientInvocationHandler
             );
             ScriptModule scriptModule = createScriptModule(pluginsService.filterPlugins(ScriptPlugin.class));
-            List<Setting<?>> additionalSettings = pluginsService.getPluginSettings();
             SettingsModule settingsModule = new SettingsModule(
                 nodeSettings,
-                additionalSettings,
-                pluginsService.getPluginSettingsFilter(),
+                pluginsService.flatMap(Plugin::getSettings).toList(),
+                pluginsService.flatMap(Plugin::getSettingsFilter).toList(),
                 Collections.emptySet()
             );
             searchModule = new SearchModule(nodeSettings, pluginsService.filterPlugins(SearchPlugin.class));


### PR DESCRIPTION
PluginsService had a handful of methods that simply called a method from the Plugin superclass for every plugin in the plugin service. Here, we refactor this logic out to the call sites by adding flexible, generic methods for applying actions to all plugins.

We also find places in the Node class that used filterPlugin(Plugin.class) to accomplish the same thing, and replace those usages with these new methods.