### PR TITLE
[8.0] [DOC] Air gapped environments and GEOIP (#85637)

### DIFF
--- a/docs/reference/ingest/processors/geoip.asciidoc
+++ b/docs/reference/ingest/processors/geoip.asciidoc
@@ -327,6 +327,12 @@ a secure proxy. You can then specify the proxy endpoint URL in the
 <<ingest-geoip-downloader-endpoint,`ingest.geoip.downloader.endpoint`>> setting
 of each node’s `elasticsearch.yml` file.
 
+[IMPORTANT]
+====
+In air gapped environments, the {es} nodes require access to `https://geoip.elastic.co`
+and `https://storage.googleapis.com/`.
+====
+
 [[use-custom-geoip-endpoint]]
 **Use a custom endpoint**
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `8.0`:
 - [[DOC] Air gapped environments and GEOIP (#85637)](https://github.com/elastic/elasticsearch/pull/85637)

<!--- Backport version: 8.4.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)