### PR TITLE
Clarify environments with strict firewalls and GEOIP (RE: #85637)

### DIFF
--- a/docs/reference/ingest/processors/geoip.asciidoc
+++ b/docs/reference/ingest/processors/geoip.asciidoc
@@ -327,6 +327,12 @@ a secure proxy. You can then specify the proxy endpoint URL in the
 <<ingest-geoip-downloader-endpoint,`ingest.geoip.downloader.endpoint`>> setting
 of each node’s `elasticsearch.yml` file.
 
+In a strict setup the following domains may need to be added to the allowed
+domains list:
+
+* `geoip.elastic.co`
+* `storage.googleapis.com`
+
 [[use-custom-geoip-endpoint]]
 **Use a custom endpoint**
 

--- a/docs/reference/ingest/processors/geoip.asciidoc
+++ b/docs/reference/ingest/processors/geoip.asciidoc
@@ -327,12 +327,6 @@ a secure proxy. You can then specify the proxy endpoint URL in the
 <<ingest-geoip-downloader-endpoint,`ingest.geoip.downloader.endpoint`>> setting
 of each node’s `elasticsearch.yml` file.
 
-[IMPORTANT]
-====
-In air gapped environments, the {es} nodes require access to `https://geoip.elastic.co`
-and `https://storage.googleapis.com/`.
-====
-
 [[use-custom-geoip-endpoint]]
 **Use a custom endpoint**
 


### PR DESCRIPTION
This reverts commit 1c52081b1f1adfb3292232bd1a744352e5f10c66.

There has been a misunderstanding somewhere. You cannot access the internet across an air gap. **That's the whole point of the air gap.**

If you connect your network to the internet you no longer have an air gap.

Please see the most well-established definition of an air gap in [RFC 4949](https://datatracker.ietf.org/doc/html/rfc4949#section-4).
```
   $ air gap
      (I) An interface between two systems at which (a) they are not
      connected physically and (b) any logical connection is not
      automated (i.e., data is transferred through the interface only
      manually, under human control). (See: sneaker net. Compare:
      gateway.)

      Example: Computer A and computer B are on opposite sides of a
      room. To move data from A to B, a person carries a disk across the
      room. If A and B operate in different security domains, then
      moving data across the air gap may involve an upgrade or downgrade
      operation.
```

Also, see [Wikipedia](https://en.wikipedia.org/wiki/Air_gap_(networking)).

> An air gap, air wall, air gapping or disconnected network is a network security measure employed on one or more computers to ensure that a secure computer network is physically isolated from unsecured networks, such as the public Internet or an unsecured local area network.
