### PR TITLE
Use TaskCancelledException in TMNA

### DIFF
--- a/docs/changelog/86659.yaml
+++ b/docs/changelog/86659.yaml
@@ -1,0 +1,5 @@
+pr: 86659
+summary: Use `TaskCancelledException` in TMNA
+area: Task Management
+type: bug
+issues: []

--- a/server/src/main/java/org/elasticsearch/action/support/master/TransportMasterNodeAction.java
+++ b/server/src/main/java/org/elasticsearch/action/support/master/TransportMasterNodeAction.java
@@ -36,13 +36,13 @@ import org.elasticsearch.index.IndexNotFoundException;
 import org.elasticsearch.node.NodeClosedException;
 import org.elasticsearch.tasks.CancellableTask;
 import org.elasticsearch.tasks.Task;
+import org.elasticsearch.tasks.TaskCancelledException;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.ConnectTransportException;
 import org.elasticsearch.transport.RemoteTransportException;
 import org.elasticsearch.transport.TransportException;
 import org.elasticsearch.transport.TransportService;
 
-import java.util.concurrent.CancellationException;
 import java.util.function.Predicate;
 
 /**
@@ -114,7 +114,7 @@ public abstract class TransportMasterNodeAction<Request extends MasterNodeReques
     private void executeMasterOperation(Task task, Request request, ClusterState state, ActionListener<Response> listener)
         throws Exception {
         if (task instanceof CancellableTask && ((CancellableTask) task).isCancelled()) {
-            throw new CancellationException("Task was cancelled");
+            throw new TaskCancelledException("Task was cancelled");
         }
 
         masterOperation(task, request, state, listener);
@@ -168,7 +168,7 @@ public abstract class TransportMasterNodeAction<Request extends MasterNodeReques
 
         protected void doStart(ClusterState clusterState) {
             if (isTaskCancelled()) {
-                listener.onFailure(new CancellationException("Task was cancelled"));
+                listener.onFailure(new TaskCancelledException("Task was cancelled"));
                 return;
             }
             try {

--- a/server/src/test/java/org/elasticsearch/action/support/master/TransportMasterNodeActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/support/master/TransportMasterNodeActionTests.java
@@ -46,6 +46,7 @@ import org.elasticsearch.node.NodeClosedException;
 import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.tasks.CancellableTask;
 import org.elasticsearch.tasks.Task;
+import org.elasticsearch.tasks.TaskCancelledException;
 import org.elasticsearch.tasks.TaskId;
 import org.elasticsearch.tasks.TaskManager;
 import org.elasticsearch.test.ESTestCase;
@@ -65,7 +66,6 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
-import java.util.concurrent.CancellationException;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.CyclicBarrier;
 import java.util.concurrent.ExecutionException;
@@ -594,7 +594,7 @@ public class TransportMasterNodeActionTests extends ESTestCase {
             }
             setState(clusterService, newStateBuilder.build());
         }
-        expectThrows(CancellationException.class, listener::actionGet);
+        expectThrows(TaskCancelledException.class, listener::actionGet);
     }
 
     public void testTaskCancellationOnceActionItIsDispatchedToMaster() throws Exception {
@@ -621,7 +621,7 @@ public class TransportMasterNodeActionTests extends ESTestCase {
 
         releaseBlockedThreads.run();
 
-        expectThrows(CancellationException.class, listener::actionGet);
+        expectThrows(TaskCancelledException.class, listener::actionGet);
     }
 
     public void testGlobalBlocksAreCheckedAfterIndexNotFoundException() throws Exception {


### PR DESCRIPTION
In #72157 we made it so that cancelling the task that a
`TransportMasterNodeAction` was executing causes the action to fail with
a `java.util.concurrent.CancellationException`. This exception is
treated as a `500 Internal Server Error` which results in `WARN`-level
logs, but cancelling a task is normal and expected behaviour and should
not be logged (see #73524).

This commit fixes this by using a `TaskCancelledException` instead,
since this exception maps to a `400 Bad Request` and generates no logs.