### PR TITLE
[DOCS] Adds more details to the frequent items agg documentation

### DIFF
--- a/docs/reference/aggregations/bucket/frequent-items-aggregation.asciidoc
+++ b/docs/reference/aggregations/bucket/frequent-items-aggregation.asciidoc
@@ -91,6 +91,10 @@ aggregation.
 
 In the following examples, we use the e-commerce {kib} sample data set.
 
+
+[discrete]
+==== Aggregation with two analized fields
+
 In the first example, the goal is to find out based on transaction data (1.) 
 from what product categories the customers purchase products frequently together 
 and (2.) from which cities they make those purchases. We are interested in sets 
@@ -181,6 +185,10 @@ products from these categories together. The item set with the second highest
 support is `Women's Clothing` and `Women's Accessories` with customers mostly 
 from New York. Finally, the item set with the third highest support is 
 `Men's Clothing` and `Men's Shoes` with customers mostly from Cairo.
+
+
+[discrete]
+==== Aggregation analizing numeric values via a runtime field
 
 The frequent items aggregation enables you to bucket numeric values by using 
 <<runtime,runtime fields>>. The next example demonstrates how to use a script to 

--- a/docs/reference/aggregations/bucket/frequent-items-aggregation.asciidoc
+++ b/docs/reference/aggregations/bucket/frequent-items-aggregation.asciidoc
@@ -55,7 +55,7 @@ A `frequent_items` aggregation looks like this in isolation:
 ==== Fields
 
 Supported field types for the analyzed fields are keyword, numeric, ip, date, 
-and array. You can also add runtime fields to your analyzed fields.
+and arrays of these types. You can also add runtime fields to your analyzed fields.
 
 If the combined cardinality of the analyzed fields are high, then the 
 aggregation might require a significant amount of system resources.

--- a/docs/reference/aggregations/bucket/frequent-items-aggregation.asciidoc
+++ b/docs/reference/aggregations/bucket/frequent-items-aggregation.asciidoc
@@ -65,8 +65,8 @@ aggregation might require a significant amount of system resources.
 ==== Minimum set size
 
 The minimum set size is the minimum number of items the set needs to contain. A 
-value of 1 returns the frequency of single items. The higher the minimum set 
-size the less items are returned. For example, the item 
+value of 1 returns the frequency of single items. Only item sets that contain at 
+least the number of `minimum_set_size` items are returned. For example, the item 
 set `orange, banana, apple` is only returned if the minimum set size is 3 or 
 lower.
 

--- a/docs/reference/aggregations/bucket/frequent-items-aggregation.asciidoc
+++ b/docs/reference/aggregations/bucket/frequent-items-aggregation.asciidoc
@@ -49,6 +49,17 @@ A `frequent_items` aggregation looks like this in isolation:
 |`size` | (integer) The number of top item sets to return. | Optional | `10`
 |===
 
+
+[discrete]
+[[frequent-items-fields]]
+==== Fields
+
+Supported field types for the analyzed fields are keyword, numeric, ip, date, 
+and array. You can also add runtime fields to your analyzed fields.
+
+If the combined cardinality of the analyzed fields are high, then the 
+aggregation might be resource intensive.
+
 [discrete]
 [[frequent-items-minimum-set-size]]
 ==== Minimum set size
@@ -188,7 +199,7 @@ from New York. Finally, the item set with the third highest support is
 
 
 [discrete]
-==== Aggregation analizing numeric values via a runtime field
+==== Analizing numeric values by using a runtime field
 
 The frequent items aggregation enables you to bucket numeric values by using 
 <<runtime,runtime fields>>. The next example demonstrates how to use a script to 

--- a/docs/reference/aggregations/bucket/frequent-items-aggregation.asciidoc
+++ b/docs/reference/aggregations/bucket/frequent-items-aggregation.asciidoc
@@ -66,8 +66,9 @@ aggregation might require a significant amount of system resources.
 
 The minimum set size is the minimum number of items the set needs to contain. A 
 value of 1 returns the frequency of single items. The higher the minimum set 
-size the less items are returned. For example, the item set `orange, banana, 
-apple` is only returned if the minimum set size is 3 or lower.
+size the less items are returned. For example, the item 
+set `orange, banana, apple` is only returned if the minimum set size is 3 or 
+lower.
 
 [discrete]
 [[frequent-items-minimum-support]]

--- a/docs/reference/aggregations/bucket/frequent-items-aggregation.asciidoc
+++ b/docs/reference/aggregations/bucket/frequent-items-aggregation.asciidoc
@@ -58,7 +58,7 @@ Supported field types for the analyzed fields are keyword, numeric, ip, date,
 and array. You can also add runtime fields to your analyzed fields.
 
 If the combined cardinality of the analyzed fields are high, then the 
-aggregation might be resource intensive.
+aggregation might require a significant amount of system resources.
 
 [discrete]
 [[frequent-items-minimum-set-size]]


### PR DESCRIPTION
## Overview

This PR:
* divides the two examples into separate sections for better readability,
* opens a `Fields` section below the parameters table that contains information about the supported field types and high cardinality fields.

Related to https://github.com/elastic/elasticsearch/pull/86037.

### Preview

[Frequent items agg](https://elasticsearch_86661.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/search-aggregations-bucket-frequent-items-aggregation.html)