### PR TITLE
fix: do not skip version 7.17.0

### DIFF
--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.aggregation/360_date_histogram.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.aggregation/360_date_histogram.yml
@@ -389,8 +389,8 @@ setup:
 ---
 "Daylight with offset date_histogram test":
   - skip:
-      version: "- 7.17.0"
-      reason: Bug fixed before 7.17.0
+      version: "- 7.16.99"
+      reason: Bug fixed before 7.16.99
 
   - do:
       search:


### PR DESCRIPTION
The bug does not affect version 7.17.0 so here we just limit test execution
to versions strictly older than 7.17.0.