### PR TITLE
[7.17] Use TaskCancelledException in TMNA (#86659)

### DIFF
--- a/docs/changelog/86659.yaml
+++ b/docs/changelog/86659.yaml
@@ -1,0 +1,5 @@
+pr: 86659
+summary: Use `TaskCancelledException` in TMNA
+area: Task Management
+type: bug
+issues: []

--- a/server/src/main/java/org/elasticsearch/action/support/master/TransportMasterNodeAction.java
+++ b/server/src/main/java/org/elasticsearch/action/support/master/TransportMasterNodeAction.java
@@ -37,13 +37,13 @@ import org.elasticsearch.index.IndexNotFoundException;
 import org.elasticsearch.node.NodeClosedException;
 import org.elasticsearch.tasks.CancellableTask;
 import org.elasticsearch.tasks.Task;
+import org.elasticsearch.tasks.TaskCancelledException;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.ConnectTransportException;
 import org.elasticsearch.transport.RemoteTransportException;
 import org.elasticsearch.transport.TransportException;
 import org.elasticsearch.transport.TransportService;
 
-import java.util.concurrent.CancellationException;
 import java.util.function.Predicate;
 
 /**
@@ -121,7 +121,7 @@ public abstract class TransportMasterNodeAction<Request extends MasterNodeReques
     private void executeMasterOperation(Task task, Request request, ClusterState state, ActionListener<Response> listener)
         throws Exception {
         if (task instanceof CancellableTask && ((CancellableTask) task).isCancelled()) {
-            throw new CancellationException("Task was cancelled");
+            throw new TaskCancelledException("Task was cancelled");
         }
 
         masterOperation(task, request, state, listener);
@@ -175,7 +175,7 @@ public abstract class TransportMasterNodeAction<Request extends MasterNodeReques
 
         protected void doStart(ClusterState clusterState) {
             if (isTaskCancelled()) {
-                listener.onFailure(new CancellationException("Task was cancelled"));
+                listener.onFailure(new TaskCancelledException("Task was cancelled"));
                 return;
             }
             try {

--- a/server/src/test/java/org/elasticsearch/action/support/master/TransportMasterNodeActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/support/master/TransportMasterNodeActionTests.java
@@ -46,6 +46,7 @@ import org.elasticsearch.node.NodeClosedException;
 import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.tasks.CancellableTask;
 import org.elasticsearch.tasks.Task;
+import org.elasticsearch.tasks.TaskCancelledException;
 import org.elasticsearch.tasks.TaskId;
 import org.elasticsearch.tasks.TaskManager;
 import org.elasticsearch.test.ESTestCase;
@@ -65,7 +66,6 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
-import java.util.concurrent.CancellationException;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.CyclicBarrier;
 import java.util.concurrent.ExecutionException;
@@ -593,7 +593,7 @@ public class TransportMasterNodeActionTests extends ESTestCase {
             }
             setState(clusterService, newStateBuilder.build());
         }
-        expectThrows(CancellationException.class, listener::actionGet);
+        expectThrows(TaskCancelledException.class, listener::actionGet);
     }
 
     public void testTaskCancellationOnceActionItIsDispatchedToMaster() throws Exception {
@@ -620,7 +620,7 @@ public class TransportMasterNodeActionTests extends ESTestCase {
 
         releaseBlockedThreads.run();
 
-        expectThrows(CancellationException.class, listener::actionGet);
+        expectThrows(TaskCancelledException.class, listener::actionGet);
     }
 
     public void testGlobalBlocksAreCheckedAfterIndexNotFoundException() throws Exception {


### PR DESCRIPTION
Backports the following commits to 7.17:
 - Use TaskCancelledException in TMNA (#86659)