### PR TITLE
[8.2] Backport avoid JDK bug: JDK-8285835 (#86614) 

### DIFF
--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/DateHistogramAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/DateHistogramAggregator.java
@@ -428,7 +428,10 @@ class DateHistogramAggregator extends BucketsAggregator implements SizedBucketAg
         protected InternalAggregation adapt(InternalAggregation delegateResult) {
             InternalDateRange range = (InternalDateRange) delegateResult;
             List<InternalDateHistogram.Bucket> buckets = new ArrayList<>(range.getBuckets().size());
-            for (InternalDateRange.Bucket rangeBucket : range.getBuckets()) {
+            // This code below was converted from a regular for loop to a stream forEach to avoid
+            // JDK-8285835. It needs to stay in this form until we upgrade our JDK distribution to
+            // pick up a fix for the compiler crash.
+            range.getBuckets().stream().forEach(rangeBucket -> {
                 if (rangeBucket.getDocCount() > 0) {
                     buckets.add(
                         new InternalDateHistogram.Bucket(
@@ -440,7 +443,8 @@ class DateHistogramAggregator extends BucketsAggregator implements SizedBucketAg
                         )
                     );
                 }
-            }
+            });
+
             CollectionUtil.introSort(buckets, BucketOrder.key(true).comparator());
 
             InternalDateHistogram.EmptyBucketInfo emptyBucketInfo = minDocCount == 0


### PR DESCRIPTION
8.2 Backport of https://github.com/elastic/elasticsearch/pull/86614