### PR TITLE
Use ImmutableOpenMap for DatastreamMetadata to speed up DS operations

### DIFF
--- a/server/src/test/java/org/elasticsearch/cluster/metadata/DataStreamMetadataTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/DataStreamMetadataTests.java
@@ -8,14 +8,13 @@
 
 package org.elasticsearch.cluster.metadata;
 
+import org.elasticsearch.common.collect.ImmutableOpenMap;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.test.AbstractNamedWriteableTestCase;
 import org.elasticsearch.xcontent.ToXContent;
 
 import java.io.IOException;
 import java.util.Collections;
-import java.util.HashMap;
-import java.util.Map;
 
 import static org.elasticsearch.test.AbstractXContentTestCase.xContentTester;
 
@@ -30,21 +29,21 @@ public class DataStreamMetadataTests extends AbstractNamedWriteableTestCase<Data
     @Override
     protected DataStreamMetadata createTestInstance() {
         if (randomBoolean()) {
-            return new DataStreamMetadata(Map.of(), Map.of());
+            return new DataStreamMetadata(ImmutableOpenMap.of(), ImmutableOpenMap.of());
         }
-        Map<String, DataStream> dataStreams = new HashMap<>();
+        ImmutableOpenMap.Builder<String, DataStream> dataStreams = ImmutableOpenMap.builder();
         for (int i = 0; i < randomIntBetween(1, 5); i++) {
             dataStreams.put(randomAlphaOfLength(5), DataStreamTestHelper.randomInstance());
         }
 
-        Map<String, DataStreamAlias> dataStreamsAliases = new HashMap<>();
+        ImmutableOpenMap.Builder<String, DataStreamAlias> dataStreamsAliases = ImmutableOpenMap.builder();
         if (randomBoolean()) {
             for (int i = 0; i < randomIntBetween(1, 5); i++) {
                 DataStreamAlias alias = DataStreamTestHelper.randomAliasInstance();
                 dataStreamsAliases.put(alias.getName(), alias);
             }
         }
-        return new DataStreamMetadata(dataStreams, dataStreamsAliases);
+        return new DataStreamMetadata(dataStreams.build(), dataStreamsAliases.build());
     }
 
     @Override

--- a/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/watch/WatchStoreUtilsTests.java
+++ b/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/watch/WatchStoreUtilsTests.java
@@ -21,7 +21,6 @@ import org.elasticsearch.index.Index;
 import org.elasticsearch.test.ESTestCase;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -49,8 +48,11 @@ public class WatchStoreUtilsTests extends ESTestCase {
                 indexNames.stream().map(indexName -> new Index(indexName, IndexMetadata.INDEX_UUID_NA_VALUE)).collect(Collectors.toList())
             )
         );
-        Map<String, DataStreamAlias> dataStreamAliases = Collections.emptyMap();
-        DataStreamMetadata dataStreamMetadata = new DataStreamMetadata(dataStreams, dataStreamAliases);
+        ImmutableOpenMap<String, DataStreamAlias> dataStreamAliases = ImmutableOpenMap.of();
+        DataStreamMetadata dataStreamMetadata = new DataStreamMetadata(
+            ImmutableOpenMap.<String, DataStream>builder().putAllFromMap(dataStreams).build(),
+            dataStreamAliases
+        );
         customsBuilder.put(DataStreamMetadata.TYPE, dataStreamMetadata);
         metadataBuilder.customs(customsBuilder.build());
         IndexMetadata concreteIndex = WatchStoreUtils.getConcreteIndex(dataStreamName, metadataBuilder.build());


### PR DESCRIPTION
This is mainly motivated by the many-shards benchmark performance.
Working with `ImmutableOpenMap` is orders of magnitude faster than the immutable JDK immutable-map copy-on-write manipulations. This translates into about a 20% speedup for bootstrapping the 50k data streams cluster in the many shards benchmark.
The trade-off vs the JDK's immmutable maps is a trivial amount of memory overhead because the immutable open maps aren't filled to 100% capacity and a (barely measurable) reduction in iteration performance.

Before:
<img width="1559" alt="image" src="https://user-images.githubusercontent.com/6490959/167836649-6fafc10c-d492-4c13-bd6e-0ad05d135d45.png">

After:

(hint: the adding of a DS to the metadata is simply gone in this one and accounts for less than 0.1% of the overall profile vs 25% before)

<img width="1383" alt="image" src="https://user-images.githubusercontent.com/6490959/167836731-539cc30a-e80e-4b7d-8a3b-228a41805260.png">


relates #77466 