### PR TITLE
[8.2] [ML] Fix max_model_memory_limit reported by _ml/info with autoscaling (#86660)

### DIFF
--- a/docs/changelog/86660.yaml
+++ b/docs/changelog/86660.yaml
@@ -1,0 +1,5 @@
+pr: 86660
+summary: Fix `max_model_memory_limit` reported by `_ml/info` when autoscaling is enabled
+area: Machine Learning
+type: bug
+issues: []

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/utils/NativeMemoryCalculator.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/utils/NativeMemoryCalculator.java
@@ -216,7 +216,6 @@ public final class NativeMemoryCalculator {
     public static ByteSizeValue calculateMaxModelMemoryLimitToFit(ClusterSettings clusterSettings, DiscoveryNodes nodes) {
 
         long maxMlMemory = 0;
-        int numMlNodes = 0;
 
         for (DiscoveryNode node : nodes) {
             OptionalLong limit = allowedBytesForMl(node, clusterSettings);
@@ -224,14 +223,18 @@ public final class NativeMemoryCalculator {
                 continue;
             }
             maxMlMemory = Math.max(maxMlMemory, limit.getAsLong());
-            ++numMlNodes;
         }
 
         // It is possible that there is scope for more ML nodes to be added
         // to the cluster, in which case take those into account too
         long maxMlNodeSize = clusterSettings.get(MAX_ML_NODE_SIZE).getBytes();
         int maxLazyNodes = clusterSettings.get(MAX_LAZY_ML_NODES);
-        if (maxMlNodeSize > 0 && numMlNodes < maxLazyNodes) {
+        // Even if all the lazy nodes have been added to the cluster, we make
+        // the assumption that if any were configured they'll be able to grow
+        // to the maximum ML node size. (We are assuming that lazy nodes always
+        // behave like they do with Elastic Cloud autoscaling, where vertical
+        // scaling is possible.)
+        if (maxMlNodeSize > 0 && maxLazyNodes > 0) {
             maxMlMemory = Math.max(
                 maxMlMemory,
                 allowedBytesForMl(

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/utils/NativeMemoryCalculatorTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/utils/NativeMemoryCalculatorTests.java
@@ -368,14 +368,22 @@ public class NativeMemoryCalculatorTests extends ESTestCase {
 
         ByteSizeValue maxModelMemoryLimitToFit = NativeMemoryCalculator.calculateMaxModelMemoryLimitToFit(clusterSettings, nodes);
 
-        // Expect configured percentage of current node size (allowing for small rounding errors) - max is bigger but can't be added
+        // Expect configured percentage of max node size - our lazy nodes are exhausted, but are smaller so should scale up to the max
         assertThat(maxModelMemoryLimitToFit, notNullValue());
+        // Memory limit is rounded down to the next whole megabyte, so allow a 1MB range here
         assertThat(
             maxModelMemoryLimitToFit.getBytes() + Math.max(
                 Job.PROCESS_MEMORY_OVERHEAD.getBytes(),
                 DataFrameAnalyticsConfig.PROCESS_MEMORY_OVERHEAD.getBytes()
             ) + MachineLearning.NATIVE_EXECUTABLE_CODE_OVERHEAD.getBytes(),
-            lessThanOrEqualTo(mlMachineMemory * mlMemoryPercent / 100)
+            lessThanOrEqualTo(mlMaxNodeSize * mlMemoryPercent / 100)
+        );
+        assertThat(
+            maxModelMemoryLimitToFit.getBytes() + Math.max(
+                Job.PROCESS_MEMORY_OVERHEAD.getBytes(),
+                DataFrameAnalyticsConfig.PROCESS_MEMORY_OVERHEAD.getBytes()
+            ) + MachineLearning.NATIVE_EXECUTABLE_CODE_OVERHEAD.getBytes(),
+            greaterThan(mlMaxNodeSize * mlMemoryPercent / 100 - ByteSizeValue.ofMb(1).getBytes())
         );
 
         ByteSizeValue totalMlMemory = NativeMemoryCalculator.calculateTotalMlMemory(clusterSettings, nodes);


### PR DESCRIPTION
Backports the following commits to 8.2:
 - [ML] Fix max_model_memory_limit reported by _ml/info with autoscaling (#86660)