### PR TITLE
Add run-as support for OAuth2 tokens

### DIFF
--- a/docs/changelog/86680.yaml
+++ b/docs/changelog/86680.yaml
@@ -1,0 +1,5 @@
+pr: 86680
+summary: Add run-as support for OAuth2 tokens
+area: Security
+type: enhancement
+issues: []

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authc/Authentication.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authc/Authentication.java
@@ -391,7 +391,7 @@ public class Authentication implements ToXContentObject {
     /**
      * Whether the authentication can run-as another user
      */
-    public boolean supportsRunAs(AnonymousUser anonymousUser) {
+    public boolean supportsRunAs(@Nullable AnonymousUser anonymousUser) {
         // Chained run-as not allowed
         if (isRunAs()) {
             return false;

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authc/Authentication.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authc/Authentication.java
@@ -242,12 +242,12 @@ public class Authentication implements ToXContentObject {
      * The security {@code RealmRef#Domain} of the resulting {@code Authentication} is that of the run-as user's realm.
      */
     public Authentication runAs(User runAs, @Nullable RealmRef lookupRealmRef) {
-        Objects.requireNonNull(runAs);
+        assert supportsRunAs(null);
         assert false == runAs instanceof RunAsUser;
         assert false == runAs instanceof AnonymousUser;
-        assert false == getUser() instanceof RunAsUser;
         assert false == hasSyntheticRealmNameOrType(lookupRealmRef) : "should not use synthetic realm name/type for lookup realms";
-        assert AuthenticationType.REALM == getAuthenticationType() || AuthenticationType.API_KEY == getAuthenticationType();
+
+        Objects.requireNonNull(runAs);
         return new Authentication(
             new RunAsUser(runAs, getUser()),
             getAuthenticatedBy(),
@@ -386,6 +386,55 @@ public class Authentication implements ToXContentObject {
      */
     public boolean isApiKey() {
         return effectiveSubject.getType() == Subject.Type.API_KEY;
+    }
+
+    /**
+     * Whether the authentication can run-as another user
+     */
+    public boolean supportsRunAs(AnonymousUser anonymousUser) {
+        // Chained run-as not allowed
+        if (isRunAs()) {
+            return false;
+        }
+        assert false == getUser() instanceof RunAsUser;
+
+        // We may allow service account to run-as in the future, but for now no service account requires it
+        if (isServiceAccount()) {
+            return false;
+        }
+
+        // There is no reason for internal users to run-as. This check prevents either internal user itself
+        // or a token created for it (though no such thing in current code) to run-as.
+        if (User.isInternal(getUser())) {
+            return false;
+        }
+
+        // Anonymous user or its token cannot run-as
+        // There is no perfect way to determine an anonymous user if we take custom realms into consideration
+        // 1. A custom realm can return a user object that can pass `equals(anonymousUser)` check
+        // (this is the existing check used elsewhere)
+        // 2. A custom realm can declare its type and name to be __anonymous
+        //
+        // This problem is at least partly due to we don't have special serialisation for the AnonymousUser class.
+        // As a result, it is serialised just as a normal user. At deserializing time, it is impossible to reliably
+        // tell the difference. This is what happens when AnonymousUser creates a token.
+        // Also, if anonymous access is disabled or anonymous username, roles are changed after the token is created.
+        // Should we still consider the token being created by an anonymous user which is now different from the new
+        // anonymous user?
+        if (getUser().equals(anonymousUser)) {
+            assert ANONYMOUS_REALM_TYPE.equals(getAuthenticatingSubject().getRealm().getType())
+                && ANONYMOUS_REALM_NAME.equals(getAuthenticatingSubject().getRealm().getName());
+            return false;
+        }
+
+        // Run-as is supported for authentication with realm, api_key or token.
+        if (AuthenticationType.REALM == getAuthenticationType()
+            || AuthenticationType.API_KEY == getAuthenticationType()
+            || AuthenticationType.TOKEN == getAuthenticationType()) {
+            return true;
+        }
+
+        return false;
     }
 
     /**

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/AuthenticatorChain.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/AuthenticatorChain.java
@@ -29,7 +29,6 @@ import org.elasticsearch.xpack.core.security.user.User;
 import org.elasticsearch.xpack.security.operator.OperatorPrivileges.OperatorPrivilegesService;
 
 import java.util.List;
-import java.util.Locale;
 import java.util.Map;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
@@ -206,12 +205,8 @@ class AuthenticatorChain {
         // Run-as is supported for authentication with realm or api_key. Run-as for other authentication types is ignored.
         // Both realm user and api_key can create tokens. They can also run-as another user and create tokens.
         // In both cases, the created token will have a TOKEN authentication type and hence does not support run-as.
-        if (Authentication.AuthenticationType.REALM != authentication.getAuthenticationType()
-            && Authentication.AuthenticationType.API_KEY != authentication.getAuthenticationType()) {
-            logger.info(
-                "ignore run-as header since it is currently not supported for authentication type [{}]",
-                authentication.getAuthenticationType().name().toLowerCase(Locale.ROOT)
-            );
+        if (false == authentication.supportsRunAs(anonymousUser)) {
+            logger.info("ignore run-as header since the authentication does not support it [{}]", authentication);
             finishAuthentication(context, authentication, listener);
             return;
         }

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/AuthenticatorChain.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/AuthenticatorChain.java
@@ -202,9 +202,6 @@ class AuthenticatorChain {
             return;
         }
 
-        // Run-as is supported for authentication with realm or api_key. Run-as for other authentication types is ignored.
-        // Both realm user and api_key can create tokens. They can also run-as another user and create tokens.
-        // In both cases, the created token will have a TOKEN authentication type and hence does not support run-as.
         if (false == authentication.supportsRunAs(anonymousUser)) {
             logger.info("ignore run-as header since it is currently not supported for authentication [{}]", authentication);
             finishAuthentication(context, authentication, listener);

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/AuthenticatorChain.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/AuthenticatorChain.java
@@ -206,7 +206,7 @@ class AuthenticatorChain {
         // Both realm user and api_key can create tokens. They can also run-as another user and create tokens.
         // In both cases, the created token will have a TOKEN authentication type and hence does not support run-as.
         if (false == authentication.supportsRunAs(anonymousUser)) {
-            logger.info("ignore run-as header since the authentication does not support it [{}]", authentication);
+            logger.info("ignore run-as header since it is currently not supported for authentication [{}]", authentication);
             finishAuthentication(context, authentication, listener);
             return;
         }

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/AuthenticatorChainTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/AuthenticatorChainTests.java
@@ -286,7 +286,7 @@ public class AuthenticatorChainTests extends ESTestCase {
         final ElasticsearchSecurityException e = expectThrows(ElasticsearchSecurityException.class, future::actionGet);
         assertThat(
             e.getMessage(),
-            containsString("" + "unable to authenticate with provided credentials and anonymous access is not allowed for this request")
+            containsString("unable to authenticate with provided credentials and anonymous access is not allowed for this request")
         );
         assertThat(
             e.getMetadata("es.additional_unsuccessful_credentials"),
@@ -358,7 +358,7 @@ public class AuthenticatorChainTests extends ESTestCase {
                     "run-as",
                     AuthenticatorChain.class.getName(),
                     Level.INFO,
-                    "ignore run-as header since the authentication does not support it [" + authentication + "]"
+                    "ignore run-as header since it is currently not supported for authentication [" + authentication + "]"
                 )
             );
             final PlainActionFuture<Authentication> future = new PlainActionFuture<>();

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/AuthenticatorChainTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/AuthenticatorChainTests.java
@@ -25,7 +25,6 @@ import org.elasticsearch.xpack.core.security.authc.Authentication;
 import org.elasticsearch.xpack.core.security.authc.AuthenticationResult;
 import org.elasticsearch.xpack.core.security.authc.AuthenticationServiceField;
 import org.elasticsearch.xpack.core.security.authc.AuthenticationTestHelper;
-import org.elasticsearch.xpack.core.security.authc.AuthenticationTests;
 import org.elasticsearch.xpack.core.security.authc.AuthenticationToken;
 import org.elasticsearch.xpack.core.security.authc.Realm;
 import org.elasticsearch.xpack.core.security.authc.support.AuthenticationContextSerializer;
@@ -39,7 +38,6 @@ import org.junit.Before;
 
 import java.io.IOException;
 import java.util.List;
-import java.util.Locale;
 
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
@@ -83,6 +81,7 @@ public class AuthenticatorChainTests extends ESTestCase {
         realms = mock(Realms.class);
         operatorPrivilegesService = mock(OperatorPrivilegesService.class);
         anonymousUser = mock(AnonymousUser.class);
+        when(anonymousUser.enabled()).thenReturn(true);
 
         authenticationContextSerializer = mock(AuthenticationContextSerializer.class);
         serviceAccountAuthenticator = mock(ServiceAccountAuthenticator.class);
@@ -297,8 +296,10 @@ public class AuthenticatorChainTests extends ESTestCase {
 
     public void testMaybeLookupRunAsUser() {
         final Authentication authentication = randomFrom(
-            AuthenticationTests.randomApiKeyAuthentication(AuthenticationTests.randomUser(), randomAlphaOfLength(20)),
-            AuthenticationTests.randomRealmAuthentication(false)
+            AuthenticationTestHelper.builder().realm().build(false),
+            AuthenticationTestHelper.builder().realm().build(false).token(),
+            AuthenticationTestHelper.builder().apiKey().build(false),
+            AuthenticationTestHelper.builder().apiKey().build(false).token()
         );
         final String runAsUsername = "your-run-as-username";
         threadContext.putHeader(AuthenticationServiceField.RUN_AS_USER_HEADER, runAsUsername);
@@ -321,11 +322,15 @@ public class AuthenticatorChainTests extends ESTestCase {
 
     public void testRunAsIsIgnoredForUnsupportedAuthenticationTypes() throws IllegalAccessException {
         final Authentication authentication = randomFrom(
-            AuthenticationTests.randomApiKeyAuthentication(AuthenticationTests.randomUser(), randomAlphaOfLength(20)).token(),
-            AuthenticationTests.randomRealmAuthentication(false).token(),
-            AuthenticationTests.randomServiceAccountAuthentication(),
-            AuthenticationTests.randomAnonymousAuthentication(),
-            AuthenticationTests.randomInternalAuthentication()
+            AuthenticationTestHelper.builder().serviceAccount().build(),
+            AuthenticationTestHelper.builder().anonymous(anonymousUser).build(),
+            AuthenticationTestHelper.builder().anonymous(anonymousUser).build().token(),
+            AuthenticationTestHelper.builder().internal().build(),
+            AuthenticationTestHelper.builder().internal().build().token(),
+            AuthenticationTestHelper.builder().realm().build(true),
+            AuthenticationTestHelper.builder().realm().build(true).token(),
+            AuthenticationTestHelper.builder().apiKey().runAs().build(),
+            AuthenticationTestHelper.builder().apiKey().runAs().build().token()
         );
         threadContext.putHeader(AuthenticationServiceField.RUN_AS_USER_HEADER, "you-shall-not-pass");
         assertThat(
@@ -353,9 +358,7 @@ public class AuthenticatorChainTests extends ESTestCase {
                     "run-as",
                     AuthenticatorChain.class.getName(),
                     Level.INFO,
-                    "ignore run-as header since it is currently not supported for authentication type ["
-                        + authentication.getAuthenticationType().name().toLowerCase(Locale.ROOT)
-                        + "]"
+                    "ignore run-as header since the authentication does not support it [" + authentication + "]"
                 )
             );
             final PlainActionFuture<Authentication> future = new PlainActionFuture<>();


### PR DESCRIPTION
Authentication with an OAuth2 token can now perform run-as with changes
in this PR. This is in addition to the existing run-as support for realm
and API key authentication.

NB there are additional constraints on whether an OAuth2 token is
indeed qualified for run-as:
1. The token cannot itself already be a run-as (this can happen when the token is created using run-as and `client_credentials` grant)
2. The token cannot be created by anonymous or internal users

Service accounts cannot create tokens which meant run-as is not
supported for service accounts (none of existing service accounts
requires it anyway).

Relates: #84336
