### PR TITLE
[7.17] [ML] Fix max_model_memory_limit reported by _ml/info with autoscaling

### DIFF
--- a/docs/changelog/86660.yaml
+++ b/docs/changelog/86660.yaml
@@ -1,0 +1,5 @@
+pr: 86660
+summary: Fix `max_model_memory_limit` reported by `_ml/info` when autoscaling is enabled
+area: Machine Learning
+type: bug
+issues: []

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/action/TransportMlInfoActionTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/action/TransportMlInfoActionTests.java
@@ -171,14 +171,22 @@ public class TransportMlInfoActionTests extends ESTestCase {
 
         ByteSizeValue effectiveMaxModelMemoryLimit = TransportMlInfoAction.calculateEffectiveMaxModelMemoryLimit(clusterSettings, nodes);
 
-        // Expect configured percentage of current node size (allowing for small rounding errors) - max is bigger but can't be added
+        // Expect configured percentage of max node size - our lazy nodes are exhausted, but are smaller so should scale up to the max
         assertThat(effectiveMaxModelMemoryLimit, notNullValue());
+        // Memory limit is rounded down to the next whole megabyte, so allow a 1MB range here
         assertThat(
             effectiveMaxModelMemoryLimit.getBytes() + Math.max(
                 Job.PROCESS_MEMORY_OVERHEAD.getBytes(),
                 DataFrameAnalyticsConfig.PROCESS_MEMORY_OVERHEAD.getBytes()
             ) + MachineLearning.NATIVE_EXECUTABLE_CODE_OVERHEAD.getBytes(),
-            lessThanOrEqualTo(mlMachineMemory * mlMemoryPercent / 100)
+            lessThanOrEqualTo(mlMaxNodeSize * mlMemoryPercent / 100)
+        );
+        assertThat(
+            effectiveMaxModelMemoryLimit.getBytes() + Math.max(
+                Job.PROCESS_MEMORY_OVERHEAD.getBytes(),
+                DataFrameAnalyticsConfig.PROCESS_MEMORY_OVERHEAD.getBytes()
+            ) + MachineLearning.NATIVE_EXECUTABLE_CODE_OVERHEAD.getBytes(),
+            greaterThan(mlMaxNodeSize * mlMemoryPercent / 100 - ByteSizeValue.ofMb(1).getBytes())
         );
 
         ByteSizeValue totalMlMemory = TransportMlInfoAction.calculateTotalMlMemory(clusterSettings, nodes);


### PR DESCRIPTION
Previously the _ml/info endpoint took account of lazy nodes that
were not added to the cluster, but didn't take account of the
possibility of lazy nodes already in the cluster being able to
scale up to a larger size. This meant that the UI could incorrectly
cap the model_memory_limit that could be configured for new jobs
in autoscaling Cloud clusters where the tier limit meant only one
node per availability zone was possible. This PR fixes that case.

Backport of #86660