### PR TITLE
[8.2] Avoid breaking add/clear voting exclusions (#86657)

### DIFF
--- a/docs/changelog/86657.yaml
+++ b/docs/changelog/86657.yaml
@@ -1,0 +1,5 @@
+pr: 86657
+summary: Avoid breaking add/clear voting exclusions
+area: Cluster Coordination
+type: bug
+issues: []

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/configuration/TransportAddVotingConfigExclusionsAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/configuration/TransportAddVotingConfigExclusionsAction.java
@@ -71,6 +71,7 @@ public class TransportAddVotingConfigExclusionsAction extends TransportMasterNod
     ) {
         super(
             AddVotingConfigExclusionsAction.NAME,
+            false,
             transportService,
             clusterService,
             threadPool,

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/configuration/TransportClearVotingConfigExclusionsAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/configuration/TransportClearVotingConfigExclusionsAction.java
@@ -53,6 +53,7 @@ public class TransportClearVotingConfigExclusionsAction extends TransportMasterN
     ) {
         super(
             ClearVotingConfigExclusionsAction.NAME,
+            false,
             transportService,
             clusterService,
             threadPool,

--- a/server/src/main/java/org/elasticsearch/rest/action/admin/cluster/RestAddVotingConfigExclusionAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/admin/cluster/RestAddVotingConfigExclusionAction.java
@@ -46,6 +46,11 @@ public class RestAddVotingConfigExclusionAction extends BaseRestHandler {
     }
 
     @Override
+    public boolean canTripCircuitBreaker() {
+        return false;
+    }
+
+    @Override
     protected RestChannelConsumer prepareRequest(final RestRequest request, final NodeClient client) throws IOException {
         AddVotingConfigExclusionsRequest votingConfigExclusionsRequest = resolveVotingConfigExclusionsRequest(request);
         return channel -> client.execute(

--- a/server/src/main/java/org/elasticsearch/rest/action/admin/cluster/RestClearVotingConfigExclusionsAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/admin/cluster/RestClearVotingConfigExclusionsAction.java
@@ -28,6 +28,11 @@ public class RestClearVotingConfigExclusionsAction extends BaseRestHandler {
     }
 
     @Override
+    public boolean canTripCircuitBreaker() {
+        return false;
+    }
+
+    @Override
     public String getName() {
         return "clear_voting_config_exclusions_action";
     }


### PR DESCRIPTION
Backports the following commits to 8.2:
 - Avoid breaking add/clear voting exclusions (#86657)