### PR TITLE
[7.17] Avoid breaking add/clear voting exclusions (#86657)

### DIFF
--- a/docs/changelog/86657.yaml
+++ b/docs/changelog/86657.yaml
@@ -1,0 +1,5 @@
+pr: 86657
+summary: Avoid breaking add/clear voting exclusions
+area: Cluster Coordination
+type: bug
+issues: []

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/configuration/TransportAddVotingConfigExclusionsAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/configuration/TransportAddVotingConfigExclusionsAction.java
@@ -68,6 +68,7 @@ public class TransportAddVotingConfigExclusionsAction extends TransportMasterNod
     ) {
         super(
             AddVotingConfigExclusionsAction.NAME,
+            false,
             transportService,
             clusterService,
             threadPool,

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/configuration/TransportClearVotingConfigExclusionsAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/configuration/TransportClearVotingConfigExclusionsAction.java
@@ -50,6 +50,7 @@ public class TransportClearVotingConfigExclusionsAction extends TransportMasterN
     ) {
         super(
             ClearVotingConfigExclusionsAction.NAME,
+            false,
             transportService,
             clusterService,
             threadPool,

--- a/server/src/main/java/org/elasticsearch/rest/action/admin/cluster/RestAddVotingConfigExclusionAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/admin/cluster/RestAddVotingConfigExclusionAction.java
@@ -51,6 +51,11 @@ public class RestAddVotingConfigExclusionAction extends BaseRestHandler {
     }
 
     @Override
+    public boolean canTripCircuitBreaker() {
+        return false;
+    }
+
+    @Override
     protected RestChannelConsumer prepareRequest(final RestRequest request, final NodeClient client) throws IOException {
         AddVotingConfigExclusionsRequest votingConfigExclusionsRequest = resolveVotingConfigExclusionsRequest(request);
         return channel -> client.execute(

--- a/server/src/main/java/org/elasticsearch/rest/action/admin/cluster/RestClearVotingConfigExclusionsAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/admin/cluster/RestClearVotingConfigExclusionsAction.java
@@ -29,6 +29,11 @@ public class RestClearVotingConfigExclusionsAction extends BaseRestHandler {
     }
 
     @Override
+    public boolean canTripCircuitBreaker() {
+        return false;
+    }
+
+    @Override
     public String getName() {
         return "clear_voting_config_exclusions_action";
     }


### PR DESCRIPTION
Backports the following commits to 7.17:
 - Avoid breaking add/clear voting exclusions (#86657)