### PR TITLE
[8.1] correct way of getting node heap size (#85045)

### DIFF
--- a/docs/reference/cat/nodes.asciidoc
+++ b/docs/reference/cat/nodes.asciidoc
@@ -48,6 +48,9 @@ Valid columns are:
 `heap.percent`, `hp`, `heapPercent`::
 (Default) Maximum configured heap, such as `7`.
 
+`heap.max`, `hm`, `heapMax`::
+(Default) Total heap, such as `4gb`.
+
 `ram.percent`, `rp`, `ramPercent`::
 (Default) Used total memory percentage, such as `47`.
 

--- a/docs/reference/how-to/size-your-shards.asciidoc
+++ b/docs/reference/how-to/size-your-shards.asciidoc
@@ -187,12 +187,12 @@ Some system indices for {enterprise-search-ref}/index.html[Enterprise Search]
 are nearly empty and rarely used. Due to their low overhead, you shouldn't
 count shards for these indices toward a node's shard limit.
 
-To check the current size of each node's heap, use the <<cat-nodes,cat nodes
+To check the configured size of each node's heap, use the <<cat-nodes,cat nodes
 API>>.
 
 [source,console]
 ----
-GET _cat/nodes?v=true&h=heap.current
+GET _cat/nodes?v=true&h=heap.max
 ----
 // TEST[setup:my_index]
 


### PR DESCRIPTION
Backports the following commits to 8.1:
 - correct way of getting node heap size (#85045)