### PR TITLE
[7.17] [ML] Make autoscaling and task assignment use same memory staleness definition

### DIFF
--- a/docs/changelog/86632.yaml
+++ b/docs/changelog/86632.yaml
@@ -1,0 +1,6 @@
+pr: 86632
+summary: Make autoscaling and task assignment use same memory staleness definition
+area: Machine Learning
+type: bug
+issues:
+ - 86616

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/autoscaling/MlAutoscalingDeciderService.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/autoscaling/MlAutoscalingDeciderService.java
@@ -335,13 +335,10 @@ public class MlAutoscalingDeciderService implements AutoscalingDeciderService, L
         if (isMaster == false) {
             throw new IllegalArgumentException("request for scaling information is only allowed on the master node");
         }
-        final Duration memoryTrackingStale;
-        long previousTimeStamp = this.lastTimeToScale;
-        this.lastTimeToScale = this.timeSupplier.getAsLong();
-        if (previousTimeStamp == 0L) {
-            memoryTrackingStale = DEFAULT_MEMORY_REFRESH_RATE;
-        } else {
-            memoryTrackingStale = Duration.ofMillis(TimeValue.timeValueMinutes(1).millis() + this.lastTimeToScale - previousTimeStamp);
+        long previousTimeStamp = lastTimeToScale;
+        lastTimeToScale = timeSupplier.getAsLong();
+        if (previousTimeStamp > 0L && lastTimeToScale > previousTimeStamp) {
+            mlMemoryTracker.setAutoscalingCheckInterval(Duration.ofMillis(lastTimeToScale - previousTimeStamp));
         }
 
         final ClusterState clusterState = context.state();
@@ -412,12 +409,10 @@ public class MlAutoscalingDeciderService implements AutoscalingDeciderService, L
             );
         }
 
-        if (mlMemoryTracker.isRecentlyRefreshed(memoryTrackingStale) == false) {
+        if (mlMemoryTracker.isRecentlyRefreshed() == false) {
             logger.debug(
-                () -> new ParameterizedMessage(
-                    "view of job memory is stale given duration [{}]. Not attempting to make scaling decision",
-                    memoryTrackingStale
-                )
+                "view of job memory is stale given duration [{}]. Not attempting to make scaling decision",
+                mlMemoryTracker.getStalenessDuration()
             );
             return buildDecisionAndRequestRefresh(reasonBuilder);
         }
@@ -459,12 +454,7 @@ public class MlAutoscalingDeciderService implements AutoscalingDeciderService, L
             );
         }
 
-        Optional<NativeMemoryCapacity> futureFreedCapacity = calculateFutureAvailableCapacity(
-            tasks,
-            memoryTrackingStale,
-            nodes,
-            clusterState
-        );
+        Optional<NativeMemoryCapacity> futureFreedCapacity = calculateFutureAvailableCapacity(tasks, nodes, clusterState);
 
         final Optional<AutoscalingDeciderResult> scaleUpDecision = checkForScaleUp(
             numAnomalyJobsInQueue,
@@ -489,7 +479,7 @@ public class MlAutoscalingDeciderService implements AutoscalingDeciderService, L
             resetScaleDownCoolDown();
             return noScaleResultOrRefresh(
                 reasonBuilder,
-                mlMemoryTracker.isRecentlyRefreshed(memoryTrackingStale) == false,
+                mlMemoryTracker.isRecentlyRefreshed() == false,
                 new AutoscalingDeciderResult(
                     context.currentCapacity(),
                     reasonBuilder.setSimpleReason(
@@ -626,7 +616,7 @@ public class MlAutoscalingDeciderService implements AutoscalingDeciderService, L
 
         return noScaleResultOrRefresh(
             reasonBuilder,
-            mlMemoryTracker.isRecentlyRefreshed(memoryTrackingStale) == false,
+            mlMemoryTracker.isRecentlyRefreshed() == false,
             new AutoscalingDeciderResult(
                 context.currentCapacity(),
                 reasonBuilder.setSimpleReason("Passing currently perceived capacity as no scaling changes were detected to be possible")
@@ -881,11 +871,10 @@ public class MlAutoscalingDeciderService implements AutoscalingDeciderService, L
     // - If > 1 "batch" ml tasks are running on the same node, we sum their resources.
     Optional<NativeMemoryCapacity> calculateFutureAvailableCapacity(
         PersistentTasksCustomMetadata tasks,
-        Duration jobMemoryExpiry,
-        List<DiscoveryNode> mlNodes,
+        Collection<DiscoveryNode> mlNodes,
         ClusterState clusterState
     ) {
-        if (mlMemoryTracker.isRecentlyRefreshed(jobMemoryExpiry) == false) {
+        if (mlMemoryTracker.isRecentlyRefreshed() == false) {
             return Optional.empty();
         }
         final List<PersistentTask<DatafeedParams>> jobsWithLookbackDatafeeds = datafeedTasks(tasks).stream()

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/autoscaling/MlAutoscalingDeciderServiceTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/autoscaling/MlAutoscalingDeciderServiceTests.java
@@ -46,7 +46,6 @@ import org.elasticsearch.xpack.ml.process.MlMemoryTracker;
 import org.elasticsearch.xpack.ml.utils.NativeMemoryCalculator;
 import org.junit.Before;
 
-import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -116,7 +115,7 @@ public class MlAutoscalingDeciderServiceTests extends ESTestCase {
     @Before
     public void setup() {
         mlMemoryTracker = mock(MlMemoryTracker.class);
-        when(mlMemoryTracker.isRecentlyRefreshed(any())).thenReturn(true);
+        when(mlMemoryTracker.isRecentlyRefreshed()).thenReturn(true);
         when(mlMemoryTracker.asyncRefresh()).thenReturn(true);
         when(mlMemoryTracker.getAnomalyDetectorJobMemoryRequirement(any())).thenReturn(DEFAULT_JOB_SIZE);
         when(mlMemoryTracker.getDataFrameAnalyticsJobMemoryRequirement(any())).thenReturn(DEFAULT_JOB_SIZE);
@@ -874,7 +873,6 @@ public class MlAutoscalingDeciderServiceTests extends ESTestCase {
 
         Optional<NativeMemoryCapacity> nativeMemoryCapacity = service.calculateFutureAvailableCapacity(
             clusterState.metadata().custom(PersistentTasksCustomMetadata.TYPE),
-            Duration.ofMillis(10),
             clusterState.getNodes().mastersFirstStream().collect(Collectors.toList()),
             clusterState
         );

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/process/MlMemoryTrackerTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/process/MlMemoryTrackerTests.java
@@ -30,6 +30,7 @@ import org.elasticsearch.xpack.ml.job.JobManager;
 import org.elasticsearch.xpack.ml.job.persistence.JobResultsProvider;
 import org.junit.Before;
 
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -42,6 +43,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 
+import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
@@ -377,6 +379,12 @@ public class MlMemoryTrackerTests extends ESTestCase {
         assertNotNull(exception.get());
         assertThat(exception.get(), instanceOf(EsRejectedExecutionException.class));
         assertEquals("Couldn't run ML memory update - node is shutting down", exception.get().getMessage());
+    }
+
+    public void testMaxDuration() {
+        assertThat(MlMemoryTracker.max(Duration.ofMinutes(1), Duration.ofMinutes(2)), equalTo(Duration.ofMinutes(2)));
+        assertThat(MlMemoryTracker.max(Duration.ofMinutes(4), Duration.ofMinutes(3)), equalTo(Duration.ofMinutes(4)));
+        assertThat(MlMemoryTracker.max(Duration.ofMinutes(5), Duration.ofMinutes(5)), equalTo(Duration.ofMinutes(5)));
     }
 
     private PersistentTasksCustomMetadata.PersistentTask<OpenJobAction.JobParams> makeTestAnomalyDetectorTask(String jobId) {


### PR DESCRIPTION
Previously autoscaling used a staleness definition of ~7 minutes
and task assignment used a staleness definition of ~90seconds.

This could lead to the assignment explanation of tasks not being
"awaiting lazy assignment" at the moment when autoscaling ran,
thus preventing an autoscaling decision being made.

The solution is to always use the same definition of staleness in
the memory tracker. This is set to the maximum of what the two
interested parties suggest.

Backport of #86632