### PR TITLE
[8.2] Avoid starting test fixtures when resolving all external dependencies (#86357)

### DIFF
--- a/plugins/repository-hdfs/build.gradle
+++ b/plugins/repository-hdfs/build.gradle
@@ -389,3 +389,8 @@ tasks.named("thirdPartyAudit").configure {
             'org.apache.hadoop.thirdparty.protobuf.UnsafeUtil$MemoryAccessor'
     )
 }
+
+tasks.named('resolveAllDependencies') {
+  // This avoids spinning up the test fixture when downloading all dependencies
+  configs = project.configurations - [project.configurations.krb5Config]
+}


### PR DESCRIPTION
Backports the following commits to 8.2:
 - Avoid starting test fixtures when resolving all external dependencies (#86357)