### PR TITLE
[7.17] Avoid starting test fixtures when resolving all external dependencies (#86357)

### DIFF
--- a/plugins/repository-hdfs/build.gradle
+++ b/plugins/repository-hdfs/build.gradle
@@ -391,3 +391,8 @@ tasks.named("thirdPartyAudit").configure {
             'org.apache.hadoop.thirdparty.protobuf.UnsafeUtil$MemoryAccessor'
     )
 }
+
+tasks.named('resolveAllDependencies') {
+  // This avoids spinning up the test fixture when downloading all dependencies
+  configs = project.configurations - [project.configurations.krb5Config]
+}


### PR DESCRIPTION
Backports the following commits to 7.17:
 - Avoid starting test fixtures when resolving all external dependencies (#86357)