### PR TITLE
[TEST] Wait to lose master in Readiness tests

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/readiness/ReadinessClusterIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/readiness/ReadinessClusterIT.java
@@ -8,6 +8,7 @@
 package org.elasticsearch.readiness;
 
 import org.elasticsearch.client.internal.Client;
+import org.elasticsearch.cluster.coordination.MasterHistoryService;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.discovery.MasterNotDiscoveredException;
 import org.elasticsearch.test.ESIntegTestCase;
@@ -132,6 +133,8 @@ public class ReadinessClusterIT extends ESIntegTestCase implements ReadinessClie
                 expectMasterNotFound();
 
                 for (String dataNode : dataNodes) {
+                    MasterHistoryService mh = internalCluster().getInstance(MasterHistoryService.class, dataNode);
+                    waitUntil(() -> mh.getLocalMasterHistory().getMostRecentMaster() == null);
                     ReadinessService s = internalCluster().getInstance(ReadinessService.class, dataNode);
                     tcpReadinessProbeFalse(s);
                 }

--- a/server/src/internalClusterTest/java/org/elasticsearch/readiness/ReadinessClusterIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/readiness/ReadinessClusterIT.java
@@ -8,7 +8,6 @@
 package org.elasticsearch.readiness;
 
 import org.elasticsearch.client.internal.Client;
-import org.elasticsearch.cluster.coordination.MasterHistoryService;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.discovery.MasterNotDiscoveredException;
 import org.elasticsearch.test.ESIntegTestCase;
@@ -17,6 +16,7 @@ import org.elasticsearch.test.InternalTestCluster;
 import org.elasticsearch.test.readiness.ReadinessClientProbe;
 
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 
 import static org.elasticsearch.test.NodeRoles.dataOnlyNode;
 import static org.elasticsearch.test.NodeRoles.masterNode;
@@ -133,9 +133,8 @@ public class ReadinessClusterIT extends ESIntegTestCase implements ReadinessClie
                 expectMasterNotFound();
 
                 for (String dataNode : dataNodes) {
-                    MasterHistoryService mh = internalCluster().getInstance(MasterHistoryService.class, dataNode);
-                    waitUntil(() -> mh.getLocalMasterHistory().getMostRecentMaster() == null);
                     ReadinessService s = internalCluster().getInstance(ReadinessService.class, dataNode);
+                    s.listenerThreadLatch.await(10, TimeUnit.SECONDS);
                     tcpReadinessProbeFalse(s);
                 }
 

--- a/server/src/main/java/org/elasticsearch/readiness/ReadinessService.java
+++ b/server/src/main/java/org/elasticsearch/readiness/ReadinessService.java
@@ -43,7 +43,8 @@ public class ReadinessService extends AbstractLifecycleComponent implements Clus
 
     private volatile boolean active; // false;
     private volatile ServerSocketChannel serverChannel;
-    private CountDownLatch listenerThreadLatch;
+    // package private for testing
+    volatile CountDownLatch listenerThreadLatch = new CountDownLatch(0);
     final AtomicReference<InetSocketAddress> boundSocket = new AtomicReference<>();
     private final Collection<BoundAddressListener> boundAddressListeners = new CopyOnWriteArrayList<>();
 
@@ -152,7 +153,7 @@ public class ReadinessService extends AbstractLifecycleComponent implements Clus
         this.listenerThreadLatch = new CountDownLatch(1);
 
         new Thread(() -> {
-            assert serverChannel != null && listenerThreadLatch != null;
+            assert serverChannel != null;
             try {
                 while (serverChannel.isOpen()) {
                     AccessController.doPrivileged((PrivilegedAction<Void>) () -> {


### PR DESCRIPTION
Readiness IT tests check that the data nodes individually report not ready when the master is down, however there's a timing hole at the moment, where the node may not update the cluster state master node to null on time for the test.

This fix waits for the cluster state master node to be seen as null by the data node, before checking for the node to be not ready.

Closes https://github.com/elastic/elasticsearch/issues/86664