### PR TITLE
Reindex support for TSDB creating indices

### DIFF
--- a/modules/reindex/src/test/java/org/elasticsearch/reindex/ReindexMetadataTests.java
+++ b/modules/reindex/src/test/java/org/elasticsearch/reindex/ReindexMetadataTests.java
@@ -63,7 +63,9 @@ public class ReindexMetadataTests extends AbstractAsyncBulkByScrollActionMetadat
 
     @Override
     protected ReindexRequest request() {
-        return new ReindexRequest();
+        ReindexRequest request = new ReindexRequest();
+        request.getDestination().index("test");
+        return request;
     }
 
     private class TestAction extends Reindexer.AsyncIndexBySearchAction {

--- a/modules/reindex/src/test/java/org/elasticsearch/reindex/ReindexScriptTests.java
+++ b/modules/reindex/src/test/java/org/elasticsearch/reindex/ReindexScriptTests.java
@@ -77,7 +77,9 @@ public class ReindexScriptTests extends AbstractAsyncBulkByScrollActionScriptTes
 
     @Override
     protected ReindexRequest request() {
-        return new ReindexRequest();
+        ReindexRequest request = new ReindexRequest();
+        request.getDestination().index("test");
+        return request;
     }
 
     @Override

--- a/modules/reindex/src/yamlRestTest/resources/rest-api-spec/test/reindex/100_tsdb.yml
+++ b/modules/reindex/src/yamlRestTest/resources/rest-api-spec/test/reindex/100_tsdb.yml
@@ -399,3 +399,96 @@ from tsdb to tsdb modifying dimension:
   - match: {hits.hits.1._source.@timestamp: 2021-04-28T18:50:23.142Z}
   - match: {hits.hits.2._source.@timestamp: 2021-04-28T18:50:53.142Z}
   - match: {hits.hits.3._source.@timestamp: 2021-04-28T18:51:03.142Z}
+
+---
+from tsdb to tsdb created by template while modifying dimension:
+  - skip:
+      version: " - 8.2.99"
+      reason: introduced in 8.3.0
+
+  - do:
+      cluster.put_component_template:
+        name: test-component-template
+        body:
+          template:
+            settings:
+              index:
+                mode: time_series
+                routing_path: [metricset, k8s.pod.uid]
+                number_of_replicas: 0
+                number_of_shards: 2
+            mappings:
+              properties:
+                "@timestamp":
+                  type: date
+                metricset:
+                  type: keyword
+                  time_series_dimension: true
+                k8s:
+                  properties:
+                    pod:
+                      properties:
+                        uid:
+                          type: keyword
+                          time_series_dimension: true
+                        name:
+                          type: keyword
+                        ip:
+                          type: ip
+                        network:
+                          properties:
+                            tx:
+                              type: long
+                            rx:
+                              type: long
+  - do:
+      indices.put_index_template:
+        name: test-composable-1
+        body:
+          index_patterns:
+            - tsdb_templated_*
+          composed_of:
+            - test-component-template
+
+  - do:
+      reindex:
+        refresh: true
+        body:
+          source:
+            index: tsdb
+          dest:
+            index: tsdb_templated_new
+          script:
+            source: ctx._source["metricset"] = "bubbles"
+  - match: {created: 4}
+  - match: {updated: 0}
+  - match: {version_conflicts: 0}
+  - match: {batches: 1}
+  - match: {failures: []}
+  - match: {throttled_millis: 0}
+  - gte: { took: 0 }
+  - is_false: task
+  - is_false: deleted
+
+  - do:
+      indices.refresh: {}
+
+  - do:
+      search:
+        index: tsdb_templated_new
+        body:
+          sort: '@timestamp'
+          aggs:
+            tsids:
+              terms:
+                field: _tsid
+                order:
+                  _key: asc
+
+  - match: {hits.total.value: 4}
+  - match: {aggregations.tsids.buckets.0.key: {k8s.pod.uid: 1c4fc7b8-93b7-4ba8-b609-2a48af2f8e39, metricset: bubbles}}
+  - match: {aggregations.tsids.buckets.0.doc_count: 4}
+  - match: {hits.hits.0._source.@timestamp: 2021-04-28T18:50:03.142Z}
+  - match: {hits.hits.1._source.@timestamp: 2021-04-28T18:50:23.142Z}
+  - match: {hits.hits.2._source.@timestamp: 2021-04-28T18:50:53.142Z}
+  - match: {hits.hits.3._source.@timestamp: 2021-04-28T18:51:03.142Z}


### PR DESCRIPTION
This teaches reindex to infer if the destination index is a tsdb index
if it doesn't yet exist. It looks at the templates that apply to the
index and checks what settings they use. So you should be able to
reindex into a non-existant index and automatically get the tsdb
support.
