### PR TITLE
Add annotation for disabling security manager in tests

### DIFF
--- a/build-tools-internal/src/main/groovy/elasticsearch.ide.gradle
+++ b/build-tools-internal/src/main/groovy/elasticsearch.ide.gradle
@@ -122,6 +122,7 @@ if (providers.systemProperty('idea.active').getOrNull() == 'true') {
           defaults(JUnit) {
             vmParameters = [
               '-ea',
+              '-Djava.security.manager=allow',
               '-Djava.locale.providers=SPI,COMPAT',
               // TODO: only open these for mockito when it is modularized
               '--add-opens=java.base/java.security.cert=ALL-UNNAMED',

--- a/qa/evil-tests/src/test/java/org/elasticsearch/bootstrap/EvilBootstrapChecksTests.java
+++ b/qa/evil-tests/src/test/java/org/elasticsearch/bootstrap/EvilBootstrapChecksTests.java
@@ -12,7 +12,6 @@ import org.apache.logging.log4j.Logger;
 import org.elasticsearch.core.SuppressForbidden;
 import org.elasticsearch.node.NodeValidationException;
 import org.elasticsearch.test.AbstractBootstrapCheckTestCase;
-import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.ESTestCase.WithoutSecurityManager;
 import org.hamcrest.Matcher;
 import org.junit.After;

--- a/qa/evil-tests/src/test/java/org/elasticsearch/bootstrap/EvilBootstrapChecksTests.java
+++ b/qa/evil-tests/src/test/java/org/elasticsearch/bootstrap/EvilBootstrapChecksTests.java
@@ -29,7 +29,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 
-@ESTestCase.NoSecurityManager
+@ESTestCase.WithoutSecurityManager
 public class EvilBootstrapChecksTests extends AbstractBootstrapCheckTestCase {
 
     private String esEnforceBootstrapChecks = System.getProperty(ES_ENFORCE_BOOTSTRAP_CHECKS);

--- a/qa/evil-tests/src/test/java/org/elasticsearch/bootstrap/EvilBootstrapChecksTests.java
+++ b/qa/evil-tests/src/test/java/org/elasticsearch/bootstrap/EvilBootstrapChecksTests.java
@@ -12,6 +12,7 @@ import org.apache.logging.log4j.Logger;
 import org.elasticsearch.core.SuppressForbidden;
 import org.elasticsearch.node.NodeValidationException;
 import org.elasticsearch.test.AbstractBootstrapCheckTestCase;
+import org.elasticsearch.test.ESTestCase;
 import org.hamcrest.Matcher;
 import org.junit.After;
 import org.junit.Before;
@@ -28,6 +29,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 
+@ESTestCase.NoSecurityManager
 public class EvilBootstrapChecksTests extends AbstractBootstrapCheckTestCase {
 
     private String esEnforceBootstrapChecks = System.getProperty(ES_ENFORCE_BOOTSTRAP_CHECKS);

--- a/qa/evil-tests/src/test/java/org/elasticsearch/bootstrap/EvilBootstrapChecksTests.java
+++ b/qa/evil-tests/src/test/java/org/elasticsearch/bootstrap/EvilBootstrapChecksTests.java
@@ -13,6 +13,7 @@ import org.elasticsearch.core.SuppressForbidden;
 import org.elasticsearch.node.NodeValidationException;
 import org.elasticsearch.test.AbstractBootstrapCheckTestCase;
 import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.test.ESTestCase.WithoutSecurityManager;
 import org.hamcrest.Matcher;
 import org.junit.After;
 import org.junit.Before;
@@ -29,7 +30,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 
-@ESTestCase.WithoutSecurityManager
+@WithoutSecurityManager
 public class EvilBootstrapChecksTests extends AbstractBootstrapCheckTestCase {
 
     private String esEnforceBootstrapChecks = System.getProperty(ES_ENFORCE_BOOTSTRAP_CHECKS);

--- a/server/src/main/resources/org/elasticsearch/bootstrap/test-framework.policy
+++ b/server/src/main/resources/org/elasticsearch/bootstrap/test-framework.policy
@@ -78,6 +78,8 @@ grant codeBase "${codebase.mocksocket}" {
   permission java.net.SocketPermission "*", "accept,connect";
 };
 
+// the test framework can dynamically remove the security manager
+// for tests that need to run without it
 grant codeBase "${codebase.elasticsearch}" {
   permission java.lang.RuntimePermission "setSecurityManager";
 };

--- a/server/src/main/resources/org/elasticsearch/bootstrap/test-framework.policy
+++ b/server/src/main/resources/org/elasticsearch/bootstrap/test-framework.policy
@@ -78,6 +78,13 @@ grant codeBase "${codebase.mocksocket}" {
   permission java.net.SocketPermission "*", "accept,connect";
 };
 
+grant codeBase "${codebase.elasticsearch}" {
+  permission java.lang.RuntimePermission "setSecurityManager";
+};
+grant codeBase "${codebase.elasticsearch-test-framework}" {
+  permission java.lang.RuntimePermission "setSecurityManager";
+};
+
 grant codeBase "${codebase.elasticsearch-rest-client}" {
   // rest makes socket connections for rest tests
   permission java.net.SocketPermission "*", "connect";

--- a/test/framework/build.gradle
+++ b/test/framework/build.gradle
@@ -10,6 +10,8 @@ import org.elasticsearch.gradle.internal.info.BuildParams;
 apply plugin: 'elasticsearch.build'
 apply plugin: 'elasticsearch.publish'
 
+archivesBaseName = "elasticsearch-test-framework"
+
 dependencies {
   api project(":client:rest")
   api project(':modules:transport-netty4')

--- a/test/framework/src/main/java/org/elasticsearch/bootstrap/BootstrapForTesting.java
+++ b/test/framework/src/main/java/org/elasticsearch/bootstrap/BootstrapForTesting.java
@@ -362,8 +362,8 @@ public class BootstrapForTesting {
             return null;
         });
         return () -> AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
-                Security.setSecurityManager(sm);
-                return null;
-            });
+            Security.setSecurityManager(sm);
+            return null;
+        });
     }
 }

--- a/test/framework/src/main/java/org/elasticsearch/bootstrap/BootstrapForTesting.java
+++ b/test/framework/src/main/java/org/elasticsearch/bootstrap/BootstrapForTesting.java
@@ -24,19 +24,23 @@ import org.elasticsearch.core.SuppressForbidden;
 import org.elasticsearch.jdk.JarHell;
 import org.elasticsearch.plugins.PluginInfo;
 import org.elasticsearch.secure_sm.SecureSM;
+import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.PrivilegedOperations;
 import org.elasticsearch.test.mockito.SecureMockMaker;
 import org.junit.Assert;
 
+import java.io.Closeable;
 import java.io.InputStream;
 import java.lang.invoke.MethodHandles;
 import java.net.SocketPermission;
 import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.security.AccessController;
 import java.security.Permission;
 import java.security.Permissions;
 import java.security.Policy;
+import java.security.PrivilegedAction;
 import java.security.ProtectionDomain;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -212,6 +216,7 @@ public class BootstrapForTesting {
         addClassCodebase(codebases, "elasticsearch-rest-client", "org.elasticsearch.client.RestClient");
         addClassCodebase(codebases, "elasticsearch-core", "org.elasticsearch.core.Booleans");
         addClassCodebase(codebases, "elasticsearch-cli", "org.elasticsearch.cli.Command");
+        addClassCodebase(codebases, "elasticsearch-test-framework", "org.elasticsearch.test.ESTestCase");
         return codebases;
     }
 
@@ -337,4 +342,28 @@ public class BootstrapForTesting {
 
     // does nothing, just easy way to make sure the class is loaded.
     public static void ensureInitialized() {}
+
+    /**
+     * Temporarily dsiables security manager for a test.
+     *
+     * <p> This method is only callable by {@link org.elasticsearch.test.ESTestCase}.
+     *
+     * @return A closeable object which restores the test security manager
+     */
+    @SuppressWarnings("removal")
+    public static Closeable disableTestSecurityManager() {
+        var caller = Thread.currentThread().getStackTrace()[2];
+        if (ESTestCase.class.getName().equals(caller.getClassName()) == false) {
+            throw new SecurityException("Cannot disable test SecurityManager directly. Use @NoSecurityManager to disable on a test suite");
+        }
+        final var sm = System.getSecurityManager();
+        AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
+            Security.setSecurityManager(null);
+            return null;
+        });
+        return () -> AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
+                Security.setSecurityManager(sm);
+                return null;
+            });
+    }
 }

--- a/test/framework/src/main/java/org/elasticsearch/test/ESTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/ESTestCase.java
@@ -361,7 +361,7 @@ public abstract class ESTestCase extends LuceneTestCase {
     @Retention(RetentionPolicy.RUNTIME)
     @Target({ ElementType.TYPE })
     @Inherited
-    public @interface NoSecurityManager {
+    public @interface WithoutSecurityManager {
     }
 
     private static Closeable securityManagerRestorer;
@@ -370,7 +370,7 @@ public abstract class ESTestCase extends LuceneTestCase {
 
     @BeforeClass
     public static void maybeStashClassSecurityManager() {
-        if (getTestClass().isAnnotationPresent(NoSecurityManager.class)) {
+        if (getTestClass().isAnnotationPresent(WithoutSecurityManager.class)) {
             securityManagerRestorer = BootstrapForTesting.disableTestSecurityManager();
         }
     }

--- a/test/framework/src/main/java/org/elasticsearch/test/ESTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/ESTestCase.java
@@ -127,8 +127,6 @@ import java.math.BigInteger;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.nio.file.Path;
-import java.security.AccessController;
-import java.security.PrivilegedAction;
 import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -361,9 +359,10 @@ public abstract class ESTestCase extends LuceneTestCase {
      * Marks a test suite or a test method that should run without security manager enabled.
      */
     @Retention(RetentionPolicy.RUNTIME)
-    @Target({ElementType.TYPE})
+    @Target({ ElementType.TYPE })
     @Inherited
-    public @interface NoSecurityManager {}
+    public @interface NoSecurityManager {
+    }
 
     private static Closeable securityManagerRestorer;
 

--- a/test/framework/src/main/java/org/elasticsearch/test/ESTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/ESTestCase.java
@@ -378,8 +378,9 @@ public abstract class ESTestCase extends LuceneTestCase {
 
     @AfterClass
     public static void maybeRestoreClassSecurityManager() throws IOException {
-        if (getTestClass().isAnnotationPresent(NoSecurityManager.class)) {
+        if (securityManagerRestorer != null) {
             securityManagerRestorer.close();
+            securityManagerRestorer = null;
         }
     }
 

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/scheduler/SchedulerEngineTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/scheduler/SchedulerEngineTests.java
@@ -39,6 +39,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 
+@ESTestCase.NoSecurityManager
 public class SchedulerEngineTests extends ESTestCase {
 
     public void testListenersThrowingExceptionsDoNotCauseOtherListenersToBeSkipped() throws InterruptedException {

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/scheduler/SchedulerEngineTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/scheduler/SchedulerEngineTests.java
@@ -39,7 +39,6 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 
-@ESTestCase.NoSecurityManager
 public class SchedulerEngineTests extends ESTestCase {
 
     public void testListenersThrowingExceptionsDoNotCauseOtherListenersToBeSkipped() throws InterruptedException {


### PR DESCRIPTION
The Elasticsearch test framework initializes a test security manager, so
that tests run in a similar environment to that which we run in
production. However, some tests need to run without security manager
because they do "evil" things, like setting adding and removing jvm wide
shutdown hooks. Currently these tests must exist in separate projects,
mostly under qa/evil-tests, so that the security manager can be disabled
for the entire jvm with the tests.security.manager system property. The
separation between these tests and the other tests for the server makes
development of these tests more difficult, especially the inability to run
these within IntelliJ without manually adding additional sysprops.

This commit adds a new mechanism to disable security manager for these
tests. A new `@NoSecurityManager` annotation can be added to a test
suite. ESTestCase detects this annotation and removes the security
manager for the duration of that test suite. We could potentially allow
this per test as well, but I started with the simple suite wide
strategy. One example test is converted. The rest will be converted in
followups.