### PR TITLE
Correctly keep master in master history if it was active at the beginning of the master history period

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/coordination/MasterHistory.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/MasterHistory.java
@@ -76,13 +76,14 @@ public class MasterHistory implements ClusterStateListener {
             int startIndex = Math.max(0, sizeAfterAddingNewMaster - MAX_HISTORY_SIZE);
             for (int i = startIndex; i < masterHistory.size(); i++) {
                 TimeAndMaster timeAndMaster = masterHistory.get(i);
-                final long endTime;
+                final long currentMasterEndTime;
                 if (i < masterHistory.size() - 1) {
-                    endTime = masterHistory.get(i + 1).startTimeMillis;
+                    // We treat the start time of the next master as the end time of this current master
+                    currentMasterEndTime = masterHistory.get(i + 1).startTimeMillis;
                 } else {
-                    endTime = Long.MAX_VALUE;
+                    currentMasterEndTime = Long.MAX_VALUE; // This current master has no end time
                 }
-                if (endTime >= oldestRelevantHistoryTime) {
+                if (currentMasterEndTime >= oldestRelevantHistoryTime) {
                     newMasterHistory.add(timeAndMaster);
                 }
             }
@@ -180,8 +181,8 @@ public class MasterHistory implements ClusterStateListener {
     }
 
     /**
-     * Returns true if a non-null master was seen at any point in the last nSeconds seconds, including if the master was non-null
-     * nSeconds ago but has transitioned to null since then.
+     * Returns true if a non-null master existed at any point in the last nSeconds seconds. Note that this could be a master whose start
+     * time was more than nSeconds ago, as long as either it is still master or the next master took over less than nSeconds ago.
      * @param nSeconds The number of seconds to look back
      * @return true if the current master is non-null or if a non-null master was seen in the last nSeconds seconds
      */

--- a/server/src/main/java/org/elasticsearch/cluster/coordination/MasterHistory.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/MasterHistory.java
@@ -23,7 +23,6 @@ import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 import java.util.function.LongSupplier;
-import java.util.stream.Collectors;
 
 /**
  * This class represents a node's view of the history of which nodes have been elected master over the last 30 minutes. It is kept in

--- a/server/src/test/java/org/elasticsearch/cluster/coordination/MasterHistoryTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/coordination/MasterHistoryTests.java
@@ -18,12 +18,14 @@ import org.elasticsearch.cluster.node.DiscoveryNodes;
 import org.elasticsearch.cluster.routing.RoutingTable;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.junit.Before;
 
 import java.net.UnknownHostException;
 import java.util.UUID;
+import java.util.concurrent.TimeUnit;
 
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.lessThanOrEqualTo;
@@ -129,7 +131,7 @@ public class MasterHistoryTests extends ESTestCase {
          * null -> node1 -> node2 -> node3
          * Except for when only null had been master, there has been a non-null master node in the last 5 seconds all along
          */
-        long sixtyMinutesAgo = System.currentTimeMillis() - (60 * 60 * 1000);
+        long sixtyMinutesAgo = System.currentTimeMillis() - new TimeValue(60, TimeUnit.MINUTES).getMillis();
         when(threadPool.relativeTimeInMillis()).thenReturn(sixtyMinutesAgo);
         masterHistory.clusterChanged(new ClusterChangedEvent(TEST_SOURCE, nullMasterClusterState, nullMasterClusterState));
         assertFalse(masterHistory.hasSeenMasterInLastNSeconds(5));
@@ -143,7 +145,7 @@ public class MasterHistoryTests extends ESTestCase {
          * null -> node1 -> null -> null -> node1
          * There has been a non-null master for the last 5 seconds every step at this time
          */
-        long fourtyMinutesAgo = System.currentTimeMillis() - (40 * 60 * 1000);
+        long fourtyMinutesAgo = System.currentTimeMillis() - new TimeValue(40, TimeUnit.MINUTES).getMillis();
         when(threadPool.relativeTimeInMillis()).thenReturn(fourtyMinutesAgo);
         assertTrue(masterHistory.hasSeenMasterInLastNSeconds(5));
         masterHistory.clusterChanged(new ClusterChangedEvent(TEST_SOURCE, nullMasterClusterState, node3MasterClusterState));
@@ -163,7 +165,7 @@ public class MasterHistoryTests extends ESTestCase {
          * than 5 seconds ago (and more than the age of history we keep, 30 minutes), the transition from it to null was just now, so we
          * still say that there has been a master recently.
          */
-        long sixSecondsAgo = System.currentTimeMillis() - (6 * 1000);
+        long sixSecondsAgo = System.currentTimeMillis() - new TimeValue(6, TimeUnit.SECONDS).getMillis();
         when(threadPool.relativeTimeInMillis()).thenReturn(sixSecondsAgo);
         masterHistory.clusterChanged(new ClusterChangedEvent(TEST_SOURCE, nullMasterClusterState, node1MasterClusterState));
         assertTrue(masterHistory.hasSeenMasterInLastNSeconds(5));

--- a/server/src/test/java/org/elasticsearch/cluster/coordination/MasterHistoryTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/coordination/MasterHistoryTests.java
@@ -113,6 +113,76 @@ public class MasterHistoryTests extends ESTestCase {
         assertThat(masterHistory.getMostRecentMaster(), equalTo(node3MasterClusterState.nodes().getMasterNode()));
         when(threadPool.relativeTimeInMillis()).thenReturn(System.currentTimeMillis());
         assertThat(masterHistory.getMostRecentMaster(), equalTo(node3MasterClusterState.nodes().getMasterNode()));
+        masterHistory.clusterChanged(new ClusterChangedEvent(TEST_SOURCE, nullMasterClusterState, node3MasterClusterState));
+        assertTrue(masterHistory.hasSeenMasterInLastNSeconds(5));
+        masterHistory.clusterChanged(new ClusterChangedEvent(TEST_SOURCE, node1MasterClusterState, nullMasterClusterState));
+    }
+
+    public void testHasSeenMasterInLastNSeconds() {
+        var clusterService = mock(ClusterService.class);
+        when(clusterService.getSettings()).thenReturn(Settings.EMPTY);
+        ThreadPool threadPool = mock(ThreadPool.class);
+        MasterHistory masterHistory = new MasterHistory(threadPool, clusterService);
+
+        /*
+         * 60 minutes ago we get these master changes:
+         * null -> node1 -> node2 -> node3
+         * Except for when only null had been master, there has been a non-null master node in the last 5 seconds all along
+         */
+        long sixtyMinutesAgo = System.currentTimeMillis() - (60 * 60 * 1000);
+        when(threadPool.relativeTimeInMillis()).thenReturn(sixtyMinutesAgo);
+        masterHistory.clusterChanged(new ClusterChangedEvent(TEST_SOURCE, nullMasterClusterState, nullMasterClusterState));
+        assertFalse(masterHistory.hasSeenMasterInLastNSeconds(5));
+        masterHistory.clusterChanged(new ClusterChangedEvent(TEST_SOURCE, node1MasterClusterState, nullMasterClusterState));
+        masterHistory.clusterChanged(new ClusterChangedEvent(TEST_SOURCE, node2MasterClusterState, node1MasterClusterState));
+        masterHistory.clusterChanged(new ClusterChangedEvent(TEST_SOURCE, node3MasterClusterState, node2MasterClusterState));
+        assertTrue(masterHistory.hasSeenMasterInLastNSeconds(5));
+
+        /*
+         * 40 minutes ago we get these master changes (the master was node3 when this section began):
+         * null -> node1 -> null -> null -> node1
+         * There has been a non-null master for the last 5 seconds every step at this time
+         */
+        long fourtyMinutesAgo = System.currentTimeMillis() - (40 * 60 * 1000);
+        when(threadPool.relativeTimeInMillis()).thenReturn(fourtyMinutesAgo);
+        assertTrue(masterHistory.hasSeenMasterInLastNSeconds(5));
+        masterHistory.clusterChanged(new ClusterChangedEvent(TEST_SOURCE, nullMasterClusterState, node3MasterClusterState));
+        assertTrue(masterHistory.hasSeenMasterInLastNSeconds(5));
+        masterHistory.clusterChanged(new ClusterChangedEvent(TEST_SOURCE, node1MasterClusterState, nullMasterClusterState));
+        assertTrue(masterHistory.hasSeenMasterInLastNSeconds(5));
+        masterHistory.clusterChanged(new ClusterChangedEvent(TEST_SOURCE, nullMasterClusterState, node1MasterClusterState));
+        masterHistory.clusterChanged(new ClusterChangedEvent(TEST_SOURCE, nullMasterClusterState, nullMasterClusterState));
+        assertTrue(masterHistory.hasSeenMasterInLastNSeconds(5));
+        masterHistory.clusterChanged(new ClusterChangedEvent(TEST_SOURCE, node1MasterClusterState, nullMasterClusterState));
+        assertTrue(masterHistory.hasSeenMasterInLastNSeconds(5));
+
+        /*
+         * 6 seconds ago we get these master changes (it had been set to node1 previously):
+         * null -> null
+         * Even though the last non-null master was more
+         * than 5 seconds ago (and more than the age of history we keep, 30 minutes), the transition from it to null was just now, so we
+         * still say that there has been a master recently.
+         */
+        long sixSecondsAgo = System.currentTimeMillis() - (6 * 1000);
+        when(threadPool.relativeTimeInMillis()).thenReturn(sixSecondsAgo);
+        masterHistory.clusterChanged(new ClusterChangedEvent(TEST_SOURCE, nullMasterClusterState, node1MasterClusterState));
+        assertTrue(masterHistory.hasSeenMasterInLastNSeconds(5));
+        masterHistory.clusterChanged(new ClusterChangedEvent(TEST_SOURCE, nullMasterClusterState, nullMasterClusterState));
+        assertTrue(masterHistory.hasSeenMasterInLastNSeconds(5));
+
+        /*
+         * Right now we get these master changes (the master was null when this section began):
+         * null -> node1
+         * Even before the first transition to null, we have no longer seen a non-null master within the last 5 seconds (because we last
+         * transitioned from a non-null master 6 seconds ago). After the transition to node1, we again have seen a non-null master in the
+         *  last 5 seconds.
+         */
+        long now = System.currentTimeMillis();
+        when(threadPool.relativeTimeInMillis()).thenReturn(now);
+        assertFalse(masterHistory.hasSeenMasterInLastNSeconds(5));
+        masterHistory.clusterChanged(new ClusterChangedEvent(TEST_SOURCE, nullMasterClusterState, nullMasterClusterState));
+        assertFalse(masterHistory.hasSeenMasterInLastNSeconds(5));
+        masterHistory.clusterChanged(new ClusterChangedEvent(TEST_SOURCE, node1MasterClusterState, nullMasterClusterState));
         assertTrue(masterHistory.hasSeenMasterInLastNSeconds(5));
     }
 


### PR DESCRIPTION
This commit fixes a problem with the MasterHistory class. If we have had a single master for a week and then that master went to null 5 seconds ago, we want to say that we have had a non-null master within the last 30 seconds. However before this change, MasterHistory.hasSeenMasterInLastNSeconds(30) would return false in that case because the non-null master had a start time much more than 30 seconds ago. This fix recognizes that a node is master up until the start time of the master that replaces it. This required changing the methods that pruned the master history based on time so that we do not prune masters that are in any way active during the time period.

Here's an example scenario (which is now accounted for in a unit test):
```
node1 (7 days ago)
null (20 seconds ago)
null (10 seconds ago)*
```
The master is clearly null right now, but MasterHistory.hasSeenMasterInLastNSeconds(30) ought to return true because the master was node1 up until 20 seconds ago.

\* I don't think that we would ever set the master to null twice in a row, but the code now accounts for this just in case it happens.