### PR TITLE
Use pipes for spawned controllers

### DIFF
--- a/qa/no-bootstrap-tests/src/test/java/org/elasticsearch/bootstrap/SpawnerNoBootstrapTests.java
+++ b/qa/no-bootstrap-tests/src/test/java/org/elasticsearch/bootstrap/SpawnerNoBootstrapTests.java
@@ -8,18 +8,23 @@
 
 package org.elasticsearch.bootstrap;
 
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.core.LogEvent;
 import org.apache.lucene.tests.util.LuceneTestCase;
 import org.apache.lucene.util.Constants;
 import org.elasticsearch.Version;
+import org.elasticsearch.common.logging.LogConfigurator;
+import org.elasticsearch.common.logging.Loggers;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.env.Environment;
 import org.elasticsearch.env.TestEnvironment;
 import org.elasticsearch.plugins.Platforms;
 import org.elasticsearch.plugins.PluginTestUtil;
+import org.elasticsearch.test.MockLogAppender;
 
-import java.io.BufferedReader;
 import java.io.IOException;
-import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.FileSystemException;
 import java.nio.file.Files;
@@ -30,6 +35,7 @@ import java.nio.file.attribute.PosixFilePermission;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 
@@ -52,9 +58,57 @@ public class SpawnerNoBootstrapTests extends LuceneTestCase {
         #!/bin/bash
 
         echo I am alive
+        echo "I am an error" >&2
 
         read SOMETHING
         """;
+
+    static {
+        // normally done by ESTestCase, but need here because spawner depends on logging
+        LogConfigurator.loadLog4jPlugins();
+    }
+
+    static class ExpectedStreamMessage implements MockLogAppender.LoggingExpectation {
+        final String expectedLogger;
+        final String expectedMessage;
+        final CountDownLatch matchCalledLatch;
+        boolean saw;
+
+        ExpectedStreamMessage(String logger, String message, CountDownLatch matchCalledLatch) {
+            this.expectedLogger = logger;
+            this.expectedMessage = message;
+            this.matchCalledLatch = matchCalledLatch;
+        }
+
+        @Override
+        public void match(LogEvent event) {
+            if (event.getLoggerName().equals(expectedLogger)
+                && event.getLevel().equals(Level.WARN)
+                && event.getMessage().getFormattedMessage().equals(expectedMessage)) {
+                saw = true;
+            }
+            matchCalledLatch.countDown();
+        }
+
+        @Override
+        public void assertMatched() {
+            assertTrue("Expected to see message [" + expectedMessage + "] on logger [" + expectedLogger + "]", saw);
+        }
+    }
+
+    private MockLogAppender addMockLogger(String loggerName) throws Exception {
+        MockLogAppender appender = new MockLogAppender();
+        appender.start();
+        final Logger testLogger = LogManager.getLogger(loggerName);
+        Loggers.addAppender(testLogger, appender);
+        Loggers.setLevel(testLogger, Level.TRACE);
+        return appender;
+    }
+
+    private void removeMockLogger(String loggerName, MockLogAppender appender) {
+        Loggers.removeAppender(LogManager.getLogger(loggerName), appender);
+        appender.stop();
+    }
 
     /**
      * Simplest case: a module with no controller daemon.
@@ -90,7 +144,7 @@ public class SpawnerNoBootstrapTests extends LuceneTestCase {
         );
 
         try (Spawner spawner = new Spawner()) {
-            spawner.spawnNativeControllers(environment, false);
+            spawner.spawnNativeControllers(environment);
             assertThat(spawner.getProcesses(), hasSize(0));
         }
     }
@@ -163,25 +217,39 @@ public class SpawnerNoBootstrapTests extends LuceneTestCase {
             "false"
         );
 
-        Spawner spawner = new Spawner();
-        spawner.spawnNativeControllers(environment, false);
-
-        List<Process> processes = spawner.getProcesses();
-
+        String stdoutLoggerName = "test_plugin-controller-stdout";
+        String stderrLoggerName = "test_plugin-controller-stderr";
+        MockLogAppender stdoutAppender = addMockLogger(stdoutLoggerName);
+        MockLogAppender stderrAppender = addMockLogger(stderrLoggerName);
+        CountDownLatch messagesLoggedLatch = new CountDownLatch(2);
         if (expectSpawn) {
-            // as there should only be a reference in the list for the module that had the controller daemon, we expect one here
-            assertThat(processes, hasSize(1));
-            Process process = processes.get(0);
-            final InputStreamReader in = new InputStreamReader(process.getInputStream(), StandardCharsets.UTF_8);
-            try (BufferedReader stdoutReader = new BufferedReader(in)) {
-                String line = stdoutReader.readLine();
-                assertEquals("I am alive", line);
+            stdoutAppender.addExpectation(new ExpectedStreamMessage(stdoutLoggerName, "I am alive", messagesLoggedLatch));
+            stderrAppender.addExpectation(new ExpectedStreamMessage(stderrLoggerName, "I am an error", messagesLoggedLatch));
+        }
+
+        try {
+            Spawner spawner = new Spawner();
+            spawner.spawnNativeControllers(environment);
+
+            List<Process> processes = spawner.getProcesses();
+
+            if (expectSpawn) {
+                // as there should only be a reference in the list for the module that had the controller daemon, we expect one here
+                assertThat(processes, hasSize(1));
+                Process process = processes.get(0);
+                // fail if we don't get the expected log messages within one second; usually it will be even quicker
+                assertTrue(messagesLoggedLatch.await(1, TimeUnit.SECONDS));
                 spawner.close();
                 // fail if the process does not die within one second; usually it will be even quicker but it depends on OS scheduling
                 assertTrue(process.waitFor(1, TimeUnit.SECONDS));
+            } else {
+                assertThat(processes, hasSize(0));
             }
-        } else {
-            assertThat(processes, hasSize(0));
+            stdoutAppender.assertAllExpectationsMatched();
+            stderrAppender.assertAllExpectationsMatched();
+        } finally {
+            removeMockLogger(stdoutLoggerName, stdoutAppender);
+            removeMockLogger(stderrLoggerName, stderrAppender);
         }
     }
 
@@ -217,7 +285,7 @@ public class SpawnerNoBootstrapTests extends LuceneTestCase {
         createControllerProgram(controllerProgram);
 
         Spawner spawner = new Spawner();
-        IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> spawner.spawnNativeControllers(environment, false));
+        IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> spawner.spawnNativeControllers(environment));
         assertThat(e.getMessage(), equalTo("module [test_plugin] does not have permission to fork native controller"));
     }
 
@@ -236,10 +304,10 @@ public class SpawnerNoBootstrapTests extends LuceneTestCase {
         final Spawner spawner = new Spawner();
         if (Constants.MAC_OS_X) {
             // if the spawner were not skipping the Desktop Services Store files on macOS this would explode
-            spawner.spawnNativeControllers(environment, false);
+            spawner.spawnNativeControllers(environment);
         } else {
             // we do not ignore these files on non-macOS systems
-            final FileSystemException e = expectThrows(FileSystemException.class, () -> spawner.spawnNativeControllers(environment, false));
+            final FileSystemException e = expectThrows(FileSystemException.class, () -> spawner.spawnNativeControllers(environment));
             if (Constants.WINDOWS) {
                 assertThat(e, instanceOf(NoSuchFileException.class));
             } else {

--- a/server/src/main/java/org/elasticsearch/bootstrap/Bootstrap.java
+++ b/server/src/main/java/org/elasticsearch/bootstrap/Bootstrap.java
@@ -167,7 +167,7 @@ final class Bootstrap {
         Settings settings = environment.settings();
 
         try {
-            spawner.spawnNativeControllers(environment, true);
+            spawner.spawnNativeControllers(environment);
         } catch (IOException e) {
             throw new BootstrapException(e);
         }

--- a/server/src/main/java/org/elasticsearch/bootstrap/Spawner.java
+++ b/server/src/main/java/org/elasticsearch/bootstrap/Spawner.java
@@ -50,9 +50,7 @@ final class Spawner implements Closeable {
         closeables.addAll(pumpThreads.stream().map(t -> (Closeable) () -> {
             try {
                 t.join(); // wait for thread to complete now that the spawned process is destroyed
-            } catch (InterruptedException e) {
-                throw new AssertionError(e); // we don't interrupt these threads
-            }
+            } catch (InterruptedException e) { /* best effort, ignore*/ }
         }).toList());
         IOUtils.close(closeables);
     }
@@ -110,7 +108,7 @@ final class Spawner implements Closeable {
                     logger.warn(line);
                 }
             } catch (IOException e) {
-                logger.error("Error while pumping " + streamName + " for " + componentName + " controller", e);
+                logger.error(e);
             }
         }, loggerName + "-pump");
         t.start();
@@ -142,10 +140,6 @@ final class Spawner implements Closeable {
         // the only environment variable passes on the path to the temporary directory
         pb.environment().clear();
         pb.environment().put("TMPDIR", tmpPath.toString());
-
-
-        pb.redirectOutput(ProcessBuilder.Redirect.PIPE);
-        pb.redirectError(ProcessBuilder.Redirect.PIPE);
 
         // the output stream of the process object corresponds to the daemon's stdin
         return pb.start();

--- a/server/src/main/java/org/elasticsearch/bootstrap/Spawner.java
+++ b/server/src/main/java/org/elasticsearch/bootstrap/Spawner.java
@@ -8,6 +8,8 @@
 
 package org.elasticsearch.bootstrap;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.apache.lucene.util.Constants;
 import org.elasticsearch.core.IOUtils;
 import org.elasticsearch.env.Environment;
@@ -15,8 +17,12 @@ import org.elasticsearch.plugins.Platforms;
 import org.elasticsearch.plugins.PluginInfo;
 import org.elasticsearch.plugins.PluginsService;
 
+import java.io.BufferedReader;
 import java.io.Closeable;
 import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
@@ -34,22 +40,30 @@ final class Spawner implements Closeable {
      * References to the processes that have been spawned, so that we can destroy them.
      */
     private final List<Process> processes = new ArrayList<>();
+    private final List<Thread> pumpThreads = new ArrayList<>();
     private AtomicBoolean spawned = new AtomicBoolean();
 
     @Override
     public void close() throws IOException {
-        IOUtils.close(() -> processes.stream().map(s -> (Closeable) s::destroy).iterator());
+        List<Closeable> closeables = new ArrayList<>();
+        closeables.addAll(processes.stream().map(s -> (Closeable) s::destroy).toList());
+        closeables.addAll(pumpThreads.stream().map(t -> (Closeable) () -> {
+            try {
+                t.join(); // wait for thread to complete now that the spawned process is destroyed
+            } catch (InterruptedException e) {
+                throw new AssertionError(e); // we don't interrupt these threads
+            }
+        }).toList());
+        IOUtils.close(closeables);
     }
 
     /**
      * Spawns the native controllers for each module.
      *
      * @param environment The node environment
-     * @param inheritIo   Should the stdout and stderr of the spawned process inherit the
-     *                    stdout and stderr of the JVM spawning it?
      * @throws IOException if an I/O error occurs reading the module or spawning a native process
      */
-    void spawnNativeControllers(final Environment environment, final boolean inheritIo) throws IOException {
+    void spawnNativeControllers(final Environment environment) throws IOException {
         if (spawned.compareAndSet(false, true) == false) {
             throw new IllegalStateException("native controllers already spawned");
         }
@@ -75,16 +89,39 @@ final class Spawner implements Closeable {
                 );
                 throw new IllegalArgumentException(message);
             }
-            final Process process = spawnNativeController(spawnPath, environment.tmpFile(), inheritIo);
+            final Process process = spawnNativeController(spawnPath, environment.tmpFile());
+            // The process _shouldn't_ write any output via its stdout or stderr, but if it does then
+            // it will block if nothing is reading that output. To avoid this we can pipe the
+            // outputs and create pump threads to write any messages there to the ES log.
+            startPumpThread(info.getName(), "stdout", process.getInputStream());
+            startPumpThread(info.getName(), "stderr", process.getErrorStream());
             processes.add(process);
         }
+    }
+
+    private void startPumpThread(String componentName, String streamName, InputStream stream) {
+        String loggerName = componentName + "-controller-" + streamName;
+        final Logger logger = LogManager.getLogger(loggerName);
+        Thread t = new Thread(() -> {
+            try (var br = new BufferedReader(new InputStreamReader(stream, StandardCharsets.UTF_8))) {
+                String line;
+                while ((line = br.readLine()) != null) {
+                    // since we do not expect native controllers to ever write to stdout/stderr, we always log at warn level
+                    logger.warn(line);
+                }
+            } catch (IOException e) {
+                logger.error("Error while pumping " + streamName + " for " + componentName + " controller", e);
+            }
+        }, loggerName + "-pump");
+        t.start();
+        pumpThreads.add(t);
     }
 
     /**
      * Attempt to spawn the controller daemon for a given module. The spawned process will remain connected to this JVM via its stdin,
      * stdout, and stderr streams, but the references to these streams are not available to code outside this package.
      */
-    private static Process spawnNativeController(final Path spawnPath, final Path tmpPath, final boolean inheritIo) throws IOException {
+    private static Process spawnNativeController(final Path spawnPath, final Path tmpPath) throws IOException {
         final String command;
         if (Constants.WINDOWS) {
             /*
@@ -106,13 +143,9 @@ final class Spawner implements Closeable {
         pb.environment().clear();
         pb.environment().put("TMPDIR", tmpPath.toString());
 
-        // The process _shouldn't_ write any output via its stdout or stderr, but if it does then
-        // it will block if nothing is reading that output. To avoid this we can inherit the
-        // JVM's stdout and stderr (which are redirected to files in standard installations).
-        if (inheritIo) {
-            pb.redirectOutput(ProcessBuilder.Redirect.INHERIT);
-            pb.redirectError(ProcessBuilder.Redirect.INHERIT);
-        }
+
+        pb.redirectOutput(ProcessBuilder.Redirect.PIPE);
+        pb.redirectError(ProcessBuilder.Redirect.PIPE);
 
         // the output stream of the process object corresponds to the daemon's stdin
         return pb.start();

--- a/server/src/main/java/org/elasticsearch/bootstrap/Spawner.java
+++ b/server/src/main/java/org/elasticsearch/bootstrap/Spawner.java
@@ -108,7 +108,7 @@ final class Spawner implements Closeable {
                     logger.warn(line);
                 }
             } catch (IOException e) {
-                logger.error(e);
+                logger.error("error while reading " + streamName, e);
             }
         }, loggerName + "-pump");
         t.start();

--- a/server/src/main/java/org/elasticsearch/bootstrap/Spawner.java
+++ b/server/src/main/java/org/elasticsearch/bootstrap/Spawner.java
@@ -50,7 +50,9 @@ final class Spawner implements Closeable {
         closeables.addAll(pumpThreads.stream().map(t -> (Closeable) () -> {
             try {
                 t.join(); // wait for thread to complete now that the spawned process is destroyed
-            } catch (InterruptedException e) { /* best effort, ignore*/ }
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt(); // best effort, ignore
+            }
         }).toList());
         IOUtils.close(closeables);
     }


### PR DESCRIPTION
Controller processes currently inherit stdout/stderr streams from
the main Elasticsearch process. This isn't horrible when we run in the
foreground, but when we daemonize, the open pipe causes the underlying
file descriptor to stay open, even though we have closed the stream
within Elasticsearch.

This commit changes the controller spawner to pipe stdout/stderr, and
creates pump threads.

relates #85758