### PR TITLE
[7.17] Throw NoSeedNodeLeftException on proxy failure (#80961)

### DIFF
--- a/server/src/main/java/org/elasticsearch/transport/NoSeedNodeLeftException.java
+++ b/server/src/main/java/org/elasticsearch/transport/NoSeedNodeLeftException.java
@@ -14,12 +14,20 @@ import org.elasticsearch.common.io.stream.StreamInput;
 import java.io.IOException;
 
 /**
- * Thrown after failed to connect to all seed nodes of the remote cluster.
+ * Thrown after completely failing to connect to any node of the remote cluster.
  */
 public class NoSeedNodeLeftException extends ElasticsearchException {
 
-    public NoSeedNodeLeftException(String clusterName) {
-        super("no seed node left for cluster: [" + clusterName + "]");
+    public NoSeedNodeLeftException(String message) {
+        super(message);
+    }
+
+    NoSeedNodeLeftException(RemoteConnectionStrategy.ConnectionStrategy connectionStrategy, String clusterName) {
+        super(
+            connectionStrategy == RemoteConnectionStrategy.ConnectionStrategy.SNIFF
+                ? "no seed node left for cluster: [" + clusterName + "]"
+                : "Unable to open any proxy connections to cluster [" + clusterName + "]"
+        );
     }
 
     public NoSeedNodeLeftException(StreamInput in) throws IOException {

--- a/server/src/main/java/org/elasticsearch/transport/ProxyConnectionStrategy.java
+++ b/server/src/main/java/org/elasticsearch/transport/ProxyConnectionStrategy.java
@@ -287,9 +287,7 @@ public class ProxyConnectionStrategy extends RemoteConnectionStrategy {
         } else {
             int openConnections = connectionManager.size();
             if (openConnections == 0) {
-                finished.onFailure(
-                    new IllegalStateException("Unable to open any proxy connections to remote cluster [" + clusterAlias + "]")
-                );
+                finished.onFailure(new NoSeedNodeLeftException(strategyType(), clusterAlias));
             } else {
                 logger.debug(
                     "unable to open maximum number of connections [remote cluster: {}, opened: {}, maximum: {}]",

--- a/server/src/main/java/org/elasticsearch/transport/SniffConnectionStrategy.java
+++ b/server/src/main/java/org/elasticsearch/transport/SniffConnectionStrategy.java
@@ -410,7 +410,7 @@ public class SniffConnectionStrategy extends RemoteConnectionStrategy {
                 onFailure.accept(e);
             });
         } else {
-            listener.onFailure(new NoSeedNodeLeftException(clusterAlias));
+            listener.onFailure(new NoSeedNodeLeftException(strategyType(), clusterAlias));
         }
     }
 

--- a/server/src/test/java/org/elasticsearch/transport/ProxyConnectionStrategyTests.java
+++ b/server/src/test/java/org/elasticsearch/transport/ProxyConnectionStrategyTests.java
@@ -34,6 +34,9 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.containsString;
+
 public class ProxyConnectionStrategyTests extends ESTestCase {
 
     private final String clusterAlias = "cluster-alias";
@@ -214,7 +217,10 @@ public class ProxyConnectionStrategyTests extends ESTestCase {
 
                     PlainActionFuture<Void> connectFuture = PlainActionFuture.newFuture();
                     strategy.connect(connectFuture);
-                    expectThrows(Exception.class, connectFuture::actionGet);
+                    assertThat(
+                        expectThrows(NoSeedNodeLeftException.class, connectFuture::actionGet).getMessage(),
+                        allOf(containsString("Unable to open any proxy connections"), containsString('[' + clusterAlias + ']'))
+                    );
 
                     assertFalse(connectionManager.getAllConnectedNodes().stream().anyMatch(n -> n.getAddress().equals(address1)));
                     assertEquals(0, connectionManager.size());

--- a/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/action/ShardFollowNodeTask.java
+++ b/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/action/ShardFollowNodeTask.java
@@ -632,13 +632,10 @@ public abstract class ShardFollowNodeTask extends AllocatedPersistentTask {
             || actual instanceof NoShardAvailableActionException
             || actual instanceof UnavailableShardsException
             || actual instanceof AlreadyClosedException
-            || actual instanceof ElasticsearchSecurityException
-            || // If user does not have sufficient privileges
-            actual instanceof ClusterBlockException
-            || // If leader index is closed or no elected master
-            actual instanceof IndexClosedException
-            || // If follow index is closed
-            actual instanceof ConnectTransportException
+            || actual instanceof ElasticsearchSecurityException // If user does not have sufficient privileges
+            || actual instanceof ClusterBlockException // If leader index is closed or no elected master
+            || actual instanceof IndexClosedException // If follow index is closed
+            || actual instanceof ConnectTransportException
             || actual instanceof NodeClosedException
             || actual instanceof NoSuchRemoteClusterException
             || actual instanceof NoSeedNodeLeftException


### PR DESCRIPTION
Backports the following commits to 7.17:

* https://github.com/elastic/elasticsearch/pull/80961