### PR TITLE
Rectified the "Add lifecycle policy" hyperlink.

### DIFF
--- a/docs/reference/indices/index-mgmt.asciidoc
+++ b/docs/reference/indices/index-mgmt.asciidoc
@@ -68,7 +68,7 @@ indices on the overview page. The menu includes the following actions:
 * <<indices-refresh,*Refresh index*>>
 * <<indices-flush,*Flush index*>>
 * <<indices-delete-index,*Delete index*>>
-* *Add* <<set-up-lifecycle-policy,*lifecycle policy*>>
+* <<set-up-lifecycle-policy,*Add lifecycle policy*>>
 
 [float]
 [[manage-data-streams]]


### PR DESCRIPTION
"Add" is out of the hyperlink context which I would like to fix in document https://www.elastic.co/guide/en/elasticsearch/reference/8.2/index-mgmt.html#_perform_index_level_operations

Earlier line 71 was like : * *Add*  <<set-up-lifecycle-policy,*lifecycle policy*>>

After rectifying line 71, it is like : * <<set-up-lifecycle-policy,*Add lifecycle policy*>>

<!--
Thank you for your interest in and contributing to Elasticsearch! There
are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your
attention.
-->

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/elasticsearch/blob/master/CONTRIBUTING.md)?
- If submitting code, have you built your formula locally prior to submission with `gradle check`?
- If submitting code, is your pull request against master? Unless there is a good reason otherwise, we prefer pull requests against master and will backport as needed.
- If submitting code, have you checked that your submission is for an [OS and architecture that we support](https://www.elastic.co/support/matrix#show_os)?
- If you are submitting this code for a class then read our [policy](https://github.com/elastic/elasticsearch/blob/master/CONTRIBUTING.md#contributing-as-part-of-a-class) for that.
