### PR TITLE
Make InternalTestArtifactBasePlugin rely on JavaBase plugin explicit

### DIFF
--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/InternalTestArtifactBasePlugin.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/InternalTestArtifactBasePlugin.java
@@ -16,6 +16,7 @@ import javax.inject.Inject;
 
 public class InternalTestArtifactBasePlugin implements Plugin<Project> {
     private final ProviderFactory providerFactory;
+
     @Inject
     public InternalTestArtifactBasePlugin(ProviderFactory providerFactory) {
         this.providerFactory = providerFactory;

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/InternalTestArtifactBasePlugin.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/InternalTestArtifactBasePlugin.java
@@ -15,9 +15,7 @@ import org.gradle.api.provider.ProviderFactory;
 import javax.inject.Inject;
 
 public class InternalTestArtifactBasePlugin implements Plugin<Project> {
-
     private final ProviderFactory providerFactory;
-
     @Inject
     public InternalTestArtifactBasePlugin(ProviderFactory providerFactory) {
         this.providerFactory = providerFactory;
@@ -25,6 +23,7 @@ public class InternalTestArtifactBasePlugin implements Plugin<Project> {
 
     @Override
     public void apply(Project project) {
+        project.getPlugins().apply(ElasticsearchJavaBasePlugin.class)
         project.getExtensions().create("testArtifacts", InternalTestArtifactExtension.class, project, providerFactory);
     }
 }

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/InternalTestArtifactBasePlugin.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/InternalTestArtifactBasePlugin.java
@@ -23,7 +23,7 @@ public class InternalTestArtifactBasePlugin implements Plugin<Project> {
 
     @Override
     public void apply(Project project) {
-        project.getPlugins().apply(ElasticsearchJavaBasePlugin.class)
+        project.getPlugins().apply(ElasticsearchJavaBasePlugin.class);
         project.getExtensions().create("testArtifacts", InternalTestArtifactExtension.class, project, providerFactory);
     }
 }


### PR DESCRIPTION
The InternalTestArtifactBasePlugin relies on the javabase plugin as it requires
SourceSets and JavaBaseExtensions when in use. This change makes this explicit
allowing using the plugin without any other plugin applied