### PR TITLE
[8.2][Transform] workaound exception on CCS

### DIFF
--- a/docs/changelog/86729.yaml
+++ b/docs/changelog/86729.yaml
@@ -1,0 +1,5 @@
+pr: 86729
+summary: "[8.2][Transform] workaound exception on CCS"
+area: Transform
+type: bug
+issues: []

--- a/x-pack/plugin/transform/qa/multi-cluster-tests-with-security/build.gradle
+++ b/x-pack/plugin/transform/qa/multi-cluster-tests-with-security/build.gradle
@@ -29,6 +29,9 @@ def remoteCluster = testClusters.register('remote-cluster') {
     setting 'xpack.watcher.enabled', 'false'
     setting 'xpack.license.self_generated.type', 'trial'
 
+    // see gh#86716, disable assert to test fix
+    jvmArgs '-da'
+
     user username: "test_user", password: "x-pack-test-password"
 }
 

--- a/x-pack/plugin/transform/qa/multi-cluster-tests-with-security/build.gradle
+++ b/x-pack/plugin/transform/qa/multi-cluster-tests-with-security/build.gradle
@@ -1,4 +1,6 @@
 import org.elasticsearch.gradle.internal.test.RestIntegTestTask
+import org.elasticsearch.gradle.Version
+import org.elasticsearch.gradle.VersionProperties
 
 apply plugin: 'elasticsearch.internal-testclusters'
 apply plugin: 'elasticsearch.standalone-rest-test'
@@ -9,6 +11,8 @@ dependencies {
   testImplementation project(':client:rest-high-level')
 }
 
+Version ccsCompatVersion = new Version(VersionProperties.getElasticsearchVersion().getMajor(), VersionProperties.getElasticsearchVersion().getMinor() - 1, 0)
+
 restResources {
   restApi {
     include '_common', 'bulk', 'indices', 'cluster', 'search', 'security', 'transform'
@@ -18,6 +22,7 @@ restResources {
 
 def remoteCluster = testClusters.register('remote-cluster') {
     testDistribution = 'DEFAULT'
+    versions = [ccsCompatVersion.toString(), project.version]
     numberOfNodes = 2
     setting 'node.roles', '[data,ingest,master]'
     setting 'xpack.security.enabled', 'true'


### PR DESCRIPTION
implement a workaound for security exception caught when CCS 8.2 talks to a 8.1 node.