### PR TITLE
[7.17] Make InternalTestArtifactBasePlugin rely on JavaBase plugin explicit (#86719)

### DIFF
--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/InternalTestArtifactBasePlugin.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/InternalTestArtifactBasePlugin.java
@@ -15,7 +15,6 @@ import org.gradle.api.provider.ProviderFactory;
 import javax.inject.Inject;
 
 public class InternalTestArtifactBasePlugin implements Plugin<Project> {
-
     private final ProviderFactory providerFactory;
 
     @Inject


### PR DESCRIPTION
Backports the following commits to 7.17:
 - Make InternalTestArtifactBasePlugin rely on JavaBase plugin explicit (#86719)