### PR TITLE
[7.17] Fix javadoc plugin func tests on windows (#86674)

### DIFF
--- a/build-tools-internal/src/integTest/groovy/org/elasticsearch/gradle/internal/ElasticsearchJavadocPluginFuncTest.groovy
+++ b/build-tools-internal/src/integTest/groovy/org/elasticsearch/gradle/internal/ElasticsearchJavadocPluginFuncTest.groovy
@@ -53,10 +53,10 @@ class ElasticsearchJavadocPluginFuncTest extends AbstractGradleFuncTest {
         result.task(":some-lib:javadoc").outcome == TaskOutcome.SUCCESS
         result.task(":some-depending-lib:javadoc").outcome == TaskOutcome.SUCCESS
 
-        def options = file('some-depending-lib/build/tmp/javadoc/javadoc.options').text
+        def options = normalized(file('some-depending-lib/build/tmp/javadoc/javadoc.options').text)
         options.contains('-notimestamp')
         options.contains('-quiet')
-        options.contains("-linkoffline '$expectedLink' '${file('some-lib/build/docs/javadoc/').canonicalPath}/'")
+        options.contains("-linkoffline '$expectedLink' './some-lib/build/docs/javadoc/'")
 
         where:
         version        | versionType | expectedLink
@@ -123,14 +123,13 @@ class ElasticsearchJavadocPluginFuncTest extends AbstractGradleFuncTest {
         def result = gradleRunner(':some-depending-lib:javadoc').build()
 
         then:
-
-        def options = file('some-depending-lib/build/tmp/javadoc/javadoc.options').text
+        def options = normalized(file('some-depending-lib/build/tmp/javadoc/javadoc.options').text)
         options.contains('-notimestamp')
         options.contains('-quiet')
 
         // normal dependencies handles as usual
         result.task(":some-lib:javadoc").outcome == TaskOutcome.SUCCESS
-        options.contains("-linkoffline 'https://artifacts.elastic.co/javadoc/org/acme/some-lib/1.0' '${file('some-lib/build/docs/javadoc/').canonicalPath}/'")
+        options.contains("-linkoffline 'https://artifacts.elastic.co/javadoc/org/acme/some-lib/1.0' './some-lib/build/docs/javadoc/'")
         file('some-depending-lib/build/docs/javadoc/org/acme/Something.html').exists() == false
 
         // source of shadowed dependencies are inlined
@@ -175,12 +174,15 @@ class ElasticsearchJavadocPluginFuncTest extends AbstractGradleFuncTest {
         result.task(":some-lib:javadoc").outcome == TaskOutcome.SKIPPED
         result.task(":some-depending-lib:javadoc").outcome == TaskOutcome.SUCCESS
 
-        def options = file('some-depending-lib/build/tmp/javadoc/javadoc.options').text
+        def options = normalized(file('some-depending-lib/build/tmp/javadoc/javadoc.options').text)
         options.contains('-notimestamp')
         options.contains('-quiet')
-        options.contains("-linkoffline 'https://artifacts.elastic.co/javadoc/org/acme/some-lib/1.0' '${file('some-lib/build/docs/javadoc/').canonicalPath}/'") == false
+        options.contains("-linkoffline 'https://artifacts.elastic.co/javadoc/org/acme/some-lib/1.0' './some-lib/build/docs/javadoc'") == false
     }
 
+    String normalized(String input) {
+        return super.normalized(input.replace("\\\\", "/"))
+    }
 
     private File someLibProject() {
         subProject("some-lib") {

--- a/build-tools/src/testFixtures/java/org/elasticsearch/gradle/internal/test/TestUtils.java
+++ b/build-tools/src/testFixtures/java/org/elasticsearch/gradle/internal/test/TestUtils.java
@@ -16,17 +16,12 @@ public class TestUtils {
 
     public static String normalizeString(String input, File projectRootDir) {
         try {
-<<<<<<< HEAD
-            String normalizedPathPrefix = projectRootDir.getCanonicalPath().replaceAll("\\\\", "/");
-            System.out.println("normalizedPathPrefix = " + normalizedPathPrefix);
-=======
             String cannonicalNormalizedPathPrefix = projectRootDir.getCanonicalPath().replace("\\", "/");
             String normalizedPathPrefix = projectRootDir.getAbsolutePath().replace("\\", "/");
->>>>>>> 333fe4d840c (Fix javadoc plugin func tests on windows (#86674))
             return input.lines()
                 .map(it -> it.replace("\\", "/"))
-                .map(it -> it.replaceAll(cannonicalNormalizedPathPrefix, "."))
-                .map(it -> it.replaceAll(normalizedPathPrefix, "."))
+                .map(it -> it.replace(cannonicalNormalizedPathPrefix, "."))
+                .map(it -> it.replace(normalizedPathPrefix, "."))
                 .map(it -> it.replaceAll("Gradle Test Executor \\d", "Gradle Test Executor 1"))
                 .collect(Collectors.joining("\n"));
         } catch (IOException e) {

--- a/build-tools/src/testFixtures/java/org/elasticsearch/gradle/internal/test/TestUtils.java
+++ b/build-tools/src/testFixtures/java/org/elasticsearch/gradle/internal/test/TestUtils.java
@@ -16,10 +16,16 @@ public class TestUtils {
 
     public static String normalizeString(String input, File projectRootDir) {
         try {
+<<<<<<< HEAD
             String normalizedPathPrefix = projectRootDir.getCanonicalPath().replaceAll("\\\\", "/");
             System.out.println("normalizedPathPrefix = " + normalizedPathPrefix);
+=======
+            String cannonicalNormalizedPathPrefix = projectRootDir.getCanonicalPath().replace("\\", "/");
+            String normalizedPathPrefix = projectRootDir.getAbsolutePath().replace("\\", "/");
+>>>>>>> 333fe4d840c (Fix javadoc plugin func tests on windows (#86674))
             return input.lines()
-                .map(it -> it.replaceAll("\\\\", "/"))
+                .map(it -> it.replace("\\", "/"))
+                .map(it -> it.replaceAll(cannonicalNormalizedPathPrefix, "."))
                 .map(it -> it.replaceAll(normalizedPathPrefix, "."))
                 .map(it -> it.replaceAll("Gradle Test Executor \\d", "Gradle Test Executor 1"))
                 .collect(Collectors.joining("\n"));


### PR DESCRIPTION
Backports the following commits to 7.17:
 - Fix javadoc plugin func tests on windows (#86674)