### PR TITLE
[master] Rectified the "Add lifecycle policy" hyperlink. (#86717)

### DIFF
--- a/docs/reference/indices/index-mgmt.asciidoc
+++ b/docs/reference/indices/index-mgmt.asciidoc
@@ -68,7 +68,7 @@ indices on the overview page. The menu includes the following actions:
 * <<indices-refresh,*Refresh index*>>
 * <<indices-flush,*Flush index*>>
 * <<indices-delete-index,*Delete index*>>
-* *Add* <<set-up-lifecycle-policy,*lifecycle policy*>>
+* <<set-up-lifecycle-policy,*Add lifecycle policy*>>
 
 [float]
 [[manage-data-streams]]


### PR DESCRIPTION
# Backport

This will backport the following commits from `8.2` to `master`:
 - [Rectified the "Add lifecycle policy" hyperlink. (#86717)](https://github.com/elastic/elasticsearch/pull/86717)

<!--- Backport version: 8.4.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)