### PR TITLE
[8.1] Fix a linebreak (#86739)

### DIFF
--- a/docs/reference/mapping/runtime.asciidoc
+++ b/docs/reference/mapping/runtime.asciidoc
@@ -1067,8 +1067,7 @@ POST my-index-000001/_search
       }
     }
   },
-  "fields": [
-    "voltage_corrected", "node"]
+  "fields": ["voltage_corrected", "node"]
 }
 ----
 // TEST[continued]


### PR DESCRIPTION
# Backport

This will backport the following commits from `8.2` to `8.1`:
 - [Fix a linebreak (#86739)](https://github.com/elastic/elasticsearch/pull/86739)

<!--- Backport version: 8.4.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)