### PR TITLE
Add missing defaults for three OIDC settings

### DIFF
--- a/docs/reference/settings/security-settings.asciidoc
+++ b/docs/reference/settings/security-settings.asciidoc
@@ -1770,6 +1770,7 @@ As per `claim_patterns.principal`, but for the _dn_ property.
 (<<static-cluster-setting,Static>>)
 The maximum allowed clock skew to be taken into consideration when validating
 id tokens with regards to their creation and expiration times.
+Defaults to `60m`.
 // end::oidc-allowed-clock-skew-tag[]
 
 // tag::oidc-populate-user-metadata-tag[]
@@ -1832,6 +1833,7 @@ a maximum period inactivity between two consecutive data packets). Defaults to
 Controls the behavior of the http client used for back-channel communication to
 the OpenID Connect Provider endpoints. Specifies the maximum number of
 connections allowed across all endpoints.
+Defaults to 200.
 // end::oidc-http-max-connections-tag[]
 
 // tag::oidc-http-max-endpoint-connections-tag[]
@@ -1840,6 +1842,7 @@ connections allowed across all endpoints.
 Controls the behavior of the http client used for back-channel communication to
 the OpenID Connect Provider endpoints. Specifies the maximum number of
 connections allowed per endpoint.
+Defaults to 200.
 // end::oidc-http-max-endpoint-connections-tag[]
 
 [discrete]
@@ -2193,8 +2196,8 @@ used in conjunction with the `hmac_key` setting. Refer to
 (<<secure-settings,Secure>>)
 Contents of a single JSON Web Key (JWK), including the secret key that the JWT
 realm uses to verify token signatures. This format only supports a single key
-without attributes, and cannot be used with the `hmac_jwkset` setting. This 
-format is compatible with OIDC. The HMAC key must be a UNICODE string, where 
+without attributes, and cannot be used with the `hmac_jwkset` setting. This
+format is compatible with OIDC. The HMAC key must be a UNICODE string, where
 the key bytes are the UTF-8 encoding of the UNICODE string.
 The `hmac_jwkset` setting is preferred. Refer to
 <<jwt-realm-configuration,Configure {es} to use a JWT realm>>.

--- a/docs/reference/settings/security-settings.asciidoc
+++ b/docs/reference/settings/security-settings.asciidoc
@@ -1842,7 +1842,7 @@ Defaults to `200`.
 Controls the behavior of the http client used for back-channel communication to
 the OpenID Connect Provider endpoints. Specifies the maximum number of
 connections allowed per endpoint.
-Defaults to 200.
+Defaults to `200`.
 // end::oidc-http-max-endpoint-connections-tag[]
 
 [discrete]

--- a/docs/reference/settings/security-settings.asciidoc
+++ b/docs/reference/settings/security-settings.asciidoc
@@ -1770,7 +1770,7 @@ As per `claim_patterns.principal`, but for the _dn_ property.
 (<<static-cluster-setting,Static>>)
 The maximum allowed clock skew to be taken into consideration when validating
 id tokens with regards to their creation and expiration times.
-Defaults to `60m`.
+Defaults to `60s`.
 // end::oidc-allowed-clock-skew-tag[]
 
 // tag::oidc-populate-user-metadata-tag[]

--- a/docs/reference/settings/security-settings.asciidoc
+++ b/docs/reference/settings/security-settings.asciidoc
@@ -1833,7 +1833,7 @@ a maximum period inactivity between two consecutive data packets). Defaults to
 Controls the behavior of the http client used for back-channel communication to
 the OpenID Connect Provider endpoints. Specifies the maximum number of
 connections allowed across all endpoints.
-Defaults to 200.
+Defaults to `200`.
 // end::oidc-http-max-connections-tag[]
 
 // tag::oidc-http-max-endpoint-connections-tag[]


### PR DESCRIPTION
For review of #86561 to fix a misspelled OIDC setting in the docs, I double checked all other settings in OpenIdConnectRealmSettings.java were present and spelled correctly in security-settings.java.

At the same time, I noticed these three OIDC settings have defaults in code which are not mentioned in the docs. This PR adds those missing defaults to the docs.

Doc PR previews are available for a short while after a build:
- https://elasticsearch_86746.docs-preview.app.elstc.co/diff