### PR TITLE
[8.2] Correctly calculate disk usage for frozen data tier telemetry (#86580)

### DIFF
--- a/docs/changelog/86580.yaml
+++ b/docs/changelog/86580.yaml
@@ -1,0 +1,6 @@
+pr: 86580
+summary: Correctly calculate disk usage for frozen data tier telemetry
+area: Stats
+type: bug
+issues:
+ - 86055

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/DataTiersUsageTransportAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/DataTiersUsageTransportAction.java
@@ -203,7 +203,7 @@ public class DataTiersUsageTransportAction extends XPackUsageFeatureTransportAct
         final List<IndexShardStats> allShardStats = nodeStats.getIndices().getShardStats(index);
         if (allShardStats != null) {
             for (IndexShardStats shardStat : allShardStats) {
-                accumulator.totalByteCount += shardStat.getTotal().getStore().getSizeInBytes();
+                accumulator.totalByteCount += shardStat.getTotal().getStore().totalDataSetSizeInBytes();
                 accumulator.docCount += shardStat.getTotal().getDocs().getCount();
 
                 // Accumulate stats about started shards
@@ -215,7 +215,7 @@ public class DataTiersUsageTransportAction extends XPackUsageFeatureTransportAct
                     if (primaryStoreStats != null) {
                         // if primaryStoreStats is null, it means there is no primary on the node in question
                         accumulator.primaryShardCount++;
-                        long primarySize = primaryStoreStats.getSizeInBytes();
+                        long primarySize = primaryStoreStats.totalDataSetSizeInBytes();
                         accumulator.primaryByteCount += primarySize;
                         accumulator.valueSketch.add(primarySize);
                     }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/DataTiersUsageTransportActionTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/DataTiersUsageTransportActionTests.java
@@ -775,7 +775,7 @@ public class DataTiersUsageTransportActionTests extends ESTestCase {
     }
 
     private static ShardStats shardStat(long byteCount, long docCount, ShardRouting routing) {
-        StoreStats storeStats = new StoreStats(byteCount, 0L, 0L);
+        StoreStats storeStats = new StoreStats(randomNonNegativeLong(), byteCount, 0L);
         DocsStats docsStats = new DocsStats(docCount, 0L, byteCount);
 
         CommonStats commonStats = new CommonStats(CommonStatsFlags.ALL);


### PR DESCRIPTION
Backports the following commits to 8.2:
 - Correctly calculate disk usage for frozen data tier telemetry (#86580)