### PR TITLE
[8.1] [DOCS] Fix name of OIDC JWT sig algorithm setting (#86561)

### DIFF
--- a/docs/reference/settings/security-settings.asciidoc
+++ b/docs/reference/settings/security-settings.asciidoc
@@ -1629,7 +1629,7 @@ or `client_secret_jwt`. Defaults to `client_secret_basic`.
 // end::rp-client-auth-method-tag[]
 
 // tag::rp-client-auth-jwt-signature-algorithm[]
-`rp.client_auth_signature_algorithm` {ess-icon}::
+`rp.client_auth_jwt_signature_algorithm` {ess-icon}::
 (<<static-cluster-setting, Static>>)
 The signature algorithm that {es} uses to sign the JWT with which it authenticates
 as a client to the OpenID Connect Provider when `client_secret_jwt` is selected for


### PR DESCRIPTION
Backports the following commits to 8.1:
 - [DOCS] Fix name of OIDC JWT sig algorithm setting (#86561)