### PR TITLE
Synethetic Source: Fix scaled float

### DIFF
--- a/modules/mapper-extras/src/main/java/org/elasticsearch/index/mapper/extras/ScaledFloatFieldMapper.java
+++ b/modules/mapper-extras/src/main/java/org/elasticsearch/index/mapper/extras/ScaledFloatFieldMapper.java
@@ -464,7 +464,7 @@ public class ScaledFloatFieldMapper extends FieldMapper {
                 throw new IllegalArgumentException("[scaled_float] only supports finite values, but got [" + doubleValue + "]");
             }
         }
-        long scaledValue = Math.round(doubleValue * scalingFactor);
+        long scaledValue = encode(doubleValue, scalingFactor);
 
         List<Field> fields = NumberFieldMapper.NumberType.LONG.createFields(fieldType().name(), scaledValue, indexed, hasDocValues, stored);
         context.doc().addAll(fields);
@@ -472,6 +472,10 @@ public class ScaledFloatFieldMapper extends FieldMapper {
         if (hasDocValues == false && (indexed || stored)) {
             context.addToFieldNames(fieldType().name());
         }
+    }
+
+    static long encode(double value, double scalingFactor) {
+        return Math.round(value * scalingFactor);
     }
 
     static Double parse(Object value) {
@@ -677,55 +681,55 @@ public class ScaledFloatFieldMapper extends FieldMapper {
         return new NumberFieldMapper.NumericSyntheticFieldLoader(name(), simpleName()) {
             @Override
             protected void loadNextValue(XContentBuilder b, long value) throws IOException {
-                b.value(convert(value));
-            }
-
-            /**
-             * Convert the scaled value back into it's {@code double} representation,
-             * attempting to undo {@code Math.round(value * scalingFactor)}. It's
-             * important that "round tripping" a value into the index, back out, and
-             * then back in yields the same index. That's important because we use
-             * the synthetic source produced by these this for reindex.
-             * <p>
-             * The tricky thing about undoing {@link Math#round} is that it
-             * "saturates" to {@link Long#MAX_VALUE} when the {@code double} that
-             * it's given is too large to fit into a {@code long}. And
-             * {@link Long#MIN_VALUE} for {@code double}s that are too small. But
-             * {@code Long.MAX_VALUE / scalingFactor} doesn't always yield a value
-             * that would saturate. In other words, sometimes:
-             * <pre>{@code
-             *   long scaled1 = Math.round(BIG * scalingFactor);
-             *   assert scaled1 == Long.MAX_VALUE;
-             *   double decoded = scaled1 / scalingFactor;
-             *   long scaled2 = Math.round(decoded * scalingFactor);
-             *   assert scaled2 != Long.MAX_VALUE;
-             * }</pre>
-             * <p>
-             * We work around this by detecting such cases and artificially bumping them
-             * up by a single digit in the last place, forcing them to always saturate
-             * the {@link Math#round} call.
-             */
-            private double convert(long scaledValue) {
-                if (scaledValue == Long.MAX_VALUE) {
-                    double max = Long.MAX_VALUE / scalingFactor;
-                    if (Math.round(max * scalingFactor) != Long.MAX_VALUE) {
-                        double v = max + Math.ulp(max);
-                        assert Math.round(v * scalingFactor) == Long.MAX_VALUE;
-                        return v;
-                    }
-                    return max;
-                }
-                if (scaledValue == Long.MIN_VALUE) {
-                    double min = Long.MIN_VALUE / scalingFactor;
-                    if (Math.round(min * scalingFactor) != Long.MIN_VALUE) {
-                        double v = min - Math.ulp(min);
-                        assert Math.round(v * scalingFactor) == Long.MIN_VALUE;
-                        return v;
-                    }
-                    return min;
-                }
-                return scaledValue / scalingFactor;
+                b.value(decodeForSyntheticSource(value, scalingFactor));
             }
         };
+    }
+
+    /**
+     * Convert the scaled value back into it's {@code double} representation,
+     * attempting to undo {@code Math.round(value * scalingFactor)}. It's
+     * important that "round tripping" a value into the index, back out, and
+     * then back in yields the same index. That's important because we use
+     * the synthetic source produced by these this for reindex.
+     * <p>
+     * The tricky thing about undoing {@link Math#round} is that it
+     * "saturates" to {@link Long#MAX_VALUE} when the {@code double} that
+     * it's given is too large to fit into a {@code long}. And
+     * {@link Long#MIN_VALUE} for {@code double}s that are too small. But
+     * {@code Long.MAX_VALUE / scalingFactor} doesn't always yield a value
+     * that would saturate. In other words, sometimes:
+     * <pre>{@code
+     *   long scaled1 = Math.round(BIG * scalingFactor);
+     *   assert scaled1 == Long.MAX_VALUE;
+     *   double decoded = scaled1 / scalingFactor;
+     *   long scaled2 = Math.round(decoded * scalingFactor);
+     *   assert scaled2 != Long.MAX_VALUE;
+     * }</pre>
+     * <p>
+     * We work around this by detecting such cases and artificially bumping them
+     * up by a single digit in the last place, forcing them to always saturate
+     * the {@link Math#round} call.
+     */
+    static double decodeForSyntheticSource(long scaledValue, double scalingFactor) {
+        if (scaledValue == Long.MAX_VALUE) {
+            double max = Long.MAX_VALUE / scalingFactor;
+            if (Math.round(max * scalingFactor) != Long.MAX_VALUE) {
+                double v = max + Math.ulp(max);
+                assert Math.round(v * scalingFactor) == Long.MAX_VALUE;
+                return v;
+            }
+            return max;
+        }
+        if (scaledValue == Long.MIN_VALUE) {
+            double min = Long.MIN_VALUE / scalingFactor;
+            if (Math.round(min * scalingFactor) != Long.MIN_VALUE) {
+                double v = min - Math.ulp(min);
+                assert Math.round(v * scalingFactor) == Long.MIN_VALUE;
+                return v;
+            }
+            return min;
+        }
+        return scaledValue / scalingFactor;
     }
 }

--- a/modules/mapper-extras/src/main/java/org/elasticsearch/index/mapper/extras/ScaledFloatFieldMapper.java
+++ b/modules/mapper-extras/src/main/java/org/elasticsearch/index/mapper/extras/ScaledFloatFieldMapper.java
@@ -677,7 +677,29 @@ public class ScaledFloatFieldMapper extends FieldMapper {
         return new NumberFieldMapper.NumericSyntheticFieldLoader(name(), simpleName()) {
             @Override
             protected void loadNextValue(XContentBuilder b, long value) throws IOException {
-                b.value(value / scalingFactor);
+                b.value(convert(value));
+            }
+
+            private double convert(long scaledValue) {
+                if (scaledValue == Long.MAX_VALUE) {
+                    double max = Long.MAX_VALUE / scalingFactor;
+                    if (Math.round(max * scalingFactor) != Long.MAX_VALUE) {
+                        double v = max + Math.ulp(max);
+                        assert Math.round(v * scalingFactor) == Long.MAX_VALUE;
+                        return v;
+                    }
+                    return max;
+                }
+                if (scaledValue == Long.MIN_VALUE) {
+                    double min = Long.MIN_VALUE / scalingFactor;
+                    if (Math.round(min * scalingFactor) != Long.MIN_VALUE) {
+                        double v = min - Math.ulp(min);
+                        assert Math.round(v * scalingFactor) == Long.MIN_VALUE;
+                        return v;
+                    }
+                    return min;
+                }
+                return scaledValue / scalingFactor;
             }
         };
     }

--- a/modules/mapper-extras/src/main/java/org/elasticsearch/index/mapper/extras/ScaledFloatFieldMapper.java
+++ b/modules/mapper-extras/src/main/java/org/elasticsearch/index/mapper/extras/ScaledFloatFieldMapper.java
@@ -686,7 +686,8 @@ public class ScaledFloatFieldMapper extends FieldMapper {
              * important that "round tripping" a value into the index, back out, and
              * then back in yields the same index. That's important because we use
              * the synthetic source produced by these this for reindex.
-             * <p>The tricky thing about undoing {@link Math#round} is that it
+             * <p>
+             * The tricky thing about undoing {@link Math#round} is that it
              * "saturates" to {@link Long#MAX_VALUE} when the {@code double} that
              * it's given is too large to fit into a {@code long}. And
              * {@link Long#MIN_VALUE} for {@code double}s that are too small. But
@@ -695,10 +696,11 @@ public class ScaledFloatFieldMapper extends FieldMapper {
              * <pre>{@code
              *   long scaled1 = Math.round(BIG * scalingFactor);
              *   assert scaled1 == Long.MAX_VALUE;
-             *   double decoded = scaled / scalingFactory;
+             *   double decoded = scaled1 / scalingFactor;
              *   long scaled2 = Math.round(decoded * scalingFactor);
              *   assert scaled2 != Long.MAX_VALUE;
              * }</pre>
+             * <p>
              * We work around this by detecting such cases and artificially bumping them
              * up by a single digit in the last place, forcing them to always saturate
              * the {@link Math#round} call.


### PR DESCRIPTION
This causes scaled float values that entirely saturate their numeric
range to continue saturating their range on round trip.
