### PR TITLE
Fix BWC checkouts when running packaging tests

### DIFF
--- a/.ci/scripts/packaging-test.sh
+++ b/.ci/scripts/packaging-test.sh
@@ -53,6 +53,10 @@ sudo chmod 0440 /etc/sudoers.d/elasticsearch_vars
 sudo rm -Rf /elasticsearch
 sudo mkdir -p /elasticsearch/qa/ && sudo chown jenkins /elasticsearch/qa/ && ln -s $PWD/qa/vagrant /elasticsearch/qa/
 
+# Ensure since we're running as root that we can do git operations in this directory
+# See: https://git-scm.com/docs/git-config/2.35.2#Documentation/git-config.txt-safedirectory
+git config --global --add safe.directory $WORKSPACE
+
 # sudo sets it's own PATH thus we use env to override that and call sudo annother time so we keep the secure root PATH
 # run with --continue to run both bats and java tests even if one fails
 # be explicit about Gradle home dir so we use the same even with sudo


### PR DESCRIPTION
This should resolve errors like [this one](https://gradle-enterprise.elastic.co/s/bykzad56fmozg) where `git` fails to perform a checkout of BWC branches due to security restrictions.