### PR TITLE
[8.2] Primary system indices should be write indices for system aliases (#85977)

### DIFF
--- a/docs/changelog/85977.yaml
+++ b/docs/changelog/85977.yaml
@@ -1,0 +1,6 @@
+pr: 85977
+summary: "[DRAFT] Do not autocreate alias for non-primary system indices"
+area: Infra/Core
+type: bug
+issues:
+ - 85072

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/create/AutoCreateAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/create/AutoCreateAction.java
@@ -337,7 +337,11 @@ public final class AutoCreateAction extends ActionType<CreateIndexResponse> {
                     updateRequest.settings(settings);
                 }
                 if (aliasName != null) {
-                    updateRequest.aliases(Set.of(new Alias(aliasName).isHidden(true)));
+                    Alias systemAlias = new Alias(aliasName).isHidden(true);
+                    if (concreteIndexName.equals(descriptor.getPrimaryIndex())) {
+                        systemAlias.writeIndex(true);
+                    }
+                    updateRequest.aliases(Set.of(systemAlias));
                 }
 
                 if (logger.isDebugEnabled()) {

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/create/TransportCreateIndexAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/create/TransportCreateIndexAction.java
@@ -182,7 +182,7 @@ public class TransportCreateIndexAction extends TransportMasterNodeAction<Create
         if (descriptor.getAliasName() == null) {
             aliases = Set.of();
         } else {
-            aliases = Set.of(new Alias(descriptor.getAliasName()).isHidden(true));
+            aliases = Set.of(new Alias(descriptor.getAliasName()).isHidden(true).writeIndex(true));
         }
 
         // Here, we override the user's requested index with the descriptor's primary index


### PR DESCRIPTION
Backports the following commits to 8.2:
 - Primary system indices should be write indices for system aliases (#85977)