### PR TITLE
Fix the test framework codebase name

### DIFF
--- a/server/src/main/resources/org/elasticsearch/bootstrap/test-framework.policy
+++ b/server/src/main/resources/org/elasticsearch/bootstrap/test-framework.policy
@@ -83,7 +83,8 @@ grant codeBase "${codebase.mocksocket}" {
 grant codeBase "${codebase.elasticsearch}" {
   permission java.lang.RuntimePermission "setSecurityManager";
 };
-grant codeBase "${codebase.elasticsearch-test-framework}" {
+// this is the test-framework, but the jar is horribly named
+grant codeBase "${codebase.framework}" {
   permission java.lang.RuntimePermission "setSecurityManager";
 };
 

--- a/test/framework/build.gradle
+++ b/test/framework/build.gradle
@@ -10,8 +10,6 @@ import org.elasticsearch.gradle.internal.info.BuildParams;
 apply plugin: 'elasticsearch.build'
 apply plugin: 'elasticsearch.publish'
 
-archivesBaseName = "elasticsearch-test-framework"
-
 dependencies {
   api project(":client:rest")
   api project(':modules:transport-netty4')

--- a/test/framework/src/main/java/org/elasticsearch/bootstrap/BootstrapForTesting.java
+++ b/test/framework/src/main/java/org/elasticsearch/bootstrap/BootstrapForTesting.java
@@ -216,7 +216,7 @@ public class BootstrapForTesting {
         addClassCodebase(codebases, "elasticsearch-rest-client", "org.elasticsearch.client.RestClient");
         addClassCodebase(codebases, "elasticsearch-core", "org.elasticsearch.core.Booleans");
         addClassCodebase(codebases, "elasticsearch-cli", "org.elasticsearch.cli.Command");
-        addClassCodebase(codebases, "elasticsearch-test-framework", "org.elasticsearch.test.ESTestCase");
+        addClassCodebase(codebases, "framework", "org.elasticsearch.test.ESTestCase");
         return codebases;
     }
 


### PR DESCRIPTION
A side effect of https://github.com/elastic/elasticsearch/pull/86706 was
unintentionally renaming the test framework jar. This commit reverts the
jar name to the horrible named "framework", and adjusts the test
security manager bootstrap to account for the name.