### PR TITLE
Disable High Level Rest Client javadoc task

### DIFF
--- a/client/rest-high-level/build.gradle
+++ b/client/rest-high-level/build.gradle
@@ -65,3 +65,6 @@ tasks.named('splitPackagesAudit').configure {
 
 // we don't have tests now, as HLRC is in the process of being removed
 tasks.named("test").configure {enabled = false }
+
+// not published, so no need for javadoc
+tasks.named("javadoc").configure { enabled = false }


### PR DESCRIPTION
This change disables generating the javadoc for the High Level Rest Client.

We no long publish the HLRC, and this Javadoc task requires some work to get working with Java modules, so just disable it if we don't need it.