### PR TITLE
[ML] [Transforms] fix transform _start permissions to use stored headers in the config

### DIFF
--- a/docs/changelog/86802.yaml
+++ b/docs/changelog/86802.yaml
@@ -1,5 +1,5 @@
 pr: 86802
-summary: "[Transforms] fix transform `_start` permissions to use stored headers in\
+summary: "Fix transform `_start` permissions to use stored headers in\
   \ the config"
 area: Transform
 type: bug

--- a/docs/changelog/86802.yaml
+++ b/docs/changelog/86802.yaml
@@ -1,0 +1,6 @@
+pr: 86802
+summary: "[Transforms] fix transform `_start` permissions to use stored headers in\
+  \ the config"
+area: Transform
+type: bug
+issues: []

--- a/docs/reference/transform/apis/start-transform.asciidoc
+++ b/docs/reference/transform/apis/start-transform.asciidoc
@@ -21,9 +21,6 @@ Requires the following privileges:
 
 * cluster: `manage_transform` (the `transform_admin` built-in role grants this
   privilege)
-* source indices: `read`, `view_index_metadata`.
-* destination index: `read`, `create_index`, `index`. If a `retention_policy` is configured, the `delete` privilege is
-  also required.
 
 [[start-transform-desc]]
 == {api-description-title}

--- a/x-pack/plugin/transform/qa/single-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/TransformUpdateIT.java
+++ b/x-pack/plugin/transform/qa/single-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/TransformUpdateIT.java
@@ -229,8 +229,12 @@ public class TransformUpdateIT extends TransformRestTestCase {
         assertEquals(1, XContentMapValues.extractValue("count", transforms));
 
         // start using admin 1, but as the header is still admin 2
-        // BUG: this should fail, because the transform can not access the source index any longer
-        startAndWaitForTransform(transformId, transformDest, BASIC_AUTH_VALUE_TRANSFORM_ADMIN_1);
+        try {
+            startAndWaitForTransform(transformId, transformDest, BASIC_AUTH_VALUE_TRANSFORM_ADMIN_1);
+            fail("request should have failed");
+        } catch (ResponseException e) {
+            assertThat(e.getResponse().getStatusLine().getStatusCode(), equalTo(500));
+        }
 
         assertBusy(() -> {
             Map<?, ?> transformStatsAsMap = getTransformStateAndStats(transformId);

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/persistence/TransformIndex.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/persistence/TransformIndex.java
@@ -21,6 +21,7 @@ import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.metadata.MappingMetadata;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.index.IndexNotFoundException;
+import org.elasticsearch.xpack.core.ClientHelper;
 import org.elasticsearch.xpack.core.transform.TransformField;
 import org.elasticsearch.xpack.core.transform.TransformMessages;
 import org.elasticsearch.xpack.core.transform.transforms.TransformConfig;
@@ -103,7 +104,10 @@ public final class TransformIndex {
             request.alias(alias);
         }
 
-        client.execute(
+        ClientHelper.executeWithHeadersAsync(
+            transformConfig.getHeaders(),
+            TRANSFORM_ORIGIN,
+            client,
             CreateIndexAction.INSTANCE,
             request,
             ActionListener.wrap(createIndexResponse -> { listener.onResponse(true); }, e -> {

--- a/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/persistence/TransformIndexTests.java
+++ b/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/persistence/TransformIndexTests.java
@@ -50,6 +50,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
+import static org.mockito.internal.verification.VerificationModeFactory.atLeastOnce;
 
 public class TransformIndexTests extends ESTestCase {
 
@@ -59,7 +60,7 @@ public class TransformIndexTests extends ESTestCase {
     private static final String CREATED_BY = "transform";
 
     private Client client;
-    private Clock clock = Clock.fixed(Instant.ofEpochMilli(CURRENT_TIME_MILLIS), ZoneId.systemDefault());
+    private final Clock clock = Clock.fixed(Instant.ofEpochMilli(CURRENT_TIME_MILLIS), ZoneId.systemDefault());
 
     @Before
     public void setUpMocks() {
@@ -141,11 +142,12 @@ public class TransformIndexTests extends ESTestCase {
             client,
             TransformConfigTests.randomTransformConfig(TRANSFORM_ID),
             TransformIndex.createTransformDestIndexSettings(new HashMap<>(), TRANSFORM_ID, clock),
-            ActionListener.wrap(value -> assertTrue(value), e -> fail(e.getMessage()))
+            ActionListener.wrap(Assert::assertTrue, e -> fail(e.getMessage()))
         );
 
         ArgumentCaptor<CreateIndexRequest> createIndexRequestCaptor = ArgumentCaptor.forClass(CreateIndexRequest.class);
         verify(client).execute(eq(CreateIndexAction.INSTANCE), createIndexRequestCaptor.capture(), any());
+        verify(client, atLeastOnce()).threadPool();
         verifyNoMoreInteractions(client);
 
         CreateIndexRequest createIndexRequest = createIndexRequestCaptor.getValue();


### PR DESCRIPTION
It was previously required that the `_start` API caller required the same roles as the `create` API caller. 

This does not make sense as when the transform is actually running (after `_start`) we rely solely on the roles of the caller who created the transform. 

Consequently, this commit does the permission validations and various checks with the roles of user who created the transform, not the one calling `_start`