### PR TITLE
[8.2] Add missing defaults for three OIDC settings (#86746)

### DIFF
--- a/docs/reference/settings/security-settings.asciidoc
+++ b/docs/reference/settings/security-settings.asciidoc
@@ -1770,6 +1770,7 @@ As per `claim_patterns.principal`, but for the _dn_ property.
 (<<static-cluster-setting,Static>>)
 The maximum allowed clock skew to be taken into consideration when validating
 id tokens with regards to their creation and expiration times.
+Defaults to `60s`.
 // end::oidc-allowed-clock-skew-tag[]
 
 // tag::oidc-populate-user-metadata-tag[]
@@ -1832,6 +1833,7 @@ a maximum period inactivity between two consecutive data packets). Defaults to
 Controls the behavior of the http client used for back-channel communication to
 the OpenID Connect Provider endpoints. Specifies the maximum number of
 connections allowed across all endpoints.
+Defaults to `200`.
 // end::oidc-http-max-connections-tag[]
 
 // tag::oidc-http-max-endpoint-connections-tag[]
@@ -1840,6 +1842,7 @@ connections allowed across all endpoints.
 Controls the behavior of the http client used for back-channel communication to
 the OpenID Connect Provider endpoints. Specifies the maximum number of
 connections allowed per endpoint.
+Defaults to `200`.
 // end::oidc-http-max-endpoint-connections-tag[]
 
 [discrete]
@@ -2193,8 +2196,8 @@ used in conjunction with the `hmac_key` setting. Refer to
 (<<secure-settings,Secure>>)
 Contents of a single JSON Web Key (JWK), including the secret key that the JWT
 realm uses to verify token signatures. This format only supports a single key
-without attributes, and cannot be used with the `hmac_jwkset` setting. This 
-format is compatible with OIDC. The HMAC key must be a UNICODE string, where 
+without attributes, and cannot be used with the `hmac_jwkset` setting. This
+format is compatible with OIDC. The HMAC key must be a UNICODE string, where
 the key bytes are the UTF-8 encoding of the UNICODE string.
 The `hmac_jwkset` setting is preferred. Refer to
 <<jwt-realm-configuration,Configure {es} to use a JWT realm>>.


### PR DESCRIPTION
Backports the following commits to 8.2:
 - Add missing defaults for three OIDC settings (#86746)