### PR TITLE
[DOCS] Edits transform secondary auth header details

### DIFF
--- a/docs/reference/transform/apis/preview-transform.asciidoc
+++ b/docs/reference/transform/apis/preview-transform.asciidoc
@@ -30,12 +30,7 @@ Requires the following privileges:
 * cluster: `manage_transform` (the `transform_admin` built-in role grants this
   privilege)
 * source indices: `read`, `view_index_metadata`.
-+
---
-NOTE:  If you provide
-<<http-clients-secondary-authorization,secondary authorization headers>>, those
-credentials are used.
---
+
 [[preview-transform-desc]]
 == {api-description-title}
 
@@ -56,6 +51,15 @@ or an index template with your preferred mappings before you start the
 
 You must choose either the `latest` or `pivot` method for your {transform}; you
 cannot use both in a single {transform}.
+
+IMPORTANT: When you preview a {transform}, it uses the credentials of the user
+calling the API. When you start a {transform}, it uses the roles of the last
+user to create or update it. If the two sets of roles differ, the preview may
+not accurately reflect the behavior of the {transform}. To avoid such problems,
+the same user that creates or updates the {transform} should preview it to
+ensure it is returning the expected data. Alternatively, use
+<<http-clients-secondary-authorization,secondary authorization headers>> to
+supply the credentials
 
 [role="child_attributes"]
 

--- a/docs/reference/transform/apis/put-transform.asciidoc
+++ b/docs/reference/transform/apis/put-transform.asciidoc
@@ -24,12 +24,6 @@ Requires the following privileges:
 * source indices: `read`, `view_index_metadata`
 * destination index: `read`, `create_index`, `index`. If a `retention_policy` is configured, the `delete` privilege is
   also required.
-+
---
-NOTE:  If you provide
-<<http-clients-secondary-authorization,secondary authorization headers>>, those
-credentials are used.
---
 
 [[put-transform-desc]]
 == {api-description-title}
@@ -52,17 +46,24 @@ and a check that the destination index is not part of the source index pattern.
 You can use the `defer_validation` parameter to skip these checks.
 
 Deferred validations are always run when the {transform} is started, with the
-exception of privilege checks. When {es} {security-features} are enabled, the
-{transform} remembers which roles the user that created it had at the time of
-creation and uses those same roles. If those roles do not have the required
-privileges on the source and destination indices, the {transform} fails when it
-attempts unauthorized operations.
+exception of privilege checks.
 
-IMPORTANT: You must use {kib} or this API to create a {transform}. Do not add a
+[IMPORTANT]
+====
+
+* The {transform} remembers which roles the user that created it had at the time
+of creation and uses those same roles. If those roles do not have the required
+privileges on the source and destination indices, the {transform} fails when it
+attempts unauthorized operations. If you provide
+<<http-clients-secondary-authorization,secondary authorization headers>>, those
+credentials are used instead.
+* You must use {kib} or this API to create a {transform}. Do not add a
 {transform} directly into any `.transform-internal*` indices using the {es}
 index API. If {es} {security-features} are enabled, do not give users any
 privileges on `.transform-internal*` indices. If you used {transforms} prior to
 7.5, also do not give users any privileges on `.data-frame-internal*` indices.
+
+====
 
 You must choose either the latest or pivot method for your {transform}; you
 cannot use both in a single {transform}.

--- a/docs/reference/transform/apis/update-transform.asciidoc
+++ b/docs/reference/transform/apis/update-transform.asciidoc
@@ -42,9 +42,8 @@ each checkpoint.
 [IMPORTANT]
 ====
 
-* When {es} {security-features} are enabled, your {transform} remembers which
-roles the user who updated it had at the time of update and runs with those
-privileges. If you provide
+* Your {transform} remembers which roles the user who updated it had at the time
+of update and runs with those privileges. If you provide
 <<http-clients-secondary-authorization,secondary authorization headers>>, those
 credentials are used instead.
 * You must use {kib} or this API to update a {transform}. Do not update a


### PR DESCRIPTION
Relates to https://github.com/elastic/elasticsearch/pull/86757

This PR edits the transform API docs so that their information about secondary auth headers aligns with the docs for the datafeed APIs.

### Preview

* https://elasticsearch_86815.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/update-transform.html
* https://elasticsearch_86815.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/preview-transform.html
* https://elasticsearch_86815.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/put-transform.html