### PR TITLE
Guard cursor for journalctl command in packaging tests

### DIFF
--- a/qa/os/src/test/java/org/elasticsearch/packaging/util/Packages.java
+++ b/qa/os/src/test/java/org/elasticsearch/packaging/util/Packages.java
@@ -337,7 +337,11 @@ public class Packages {
          * @return Recent journald logs for the Elasticsearch service.
          */
         public Result getLogs() {
-            return sh.run("journalctl -u elasticsearch.service --after-cursor='" + this.cursor + "'");
+            String cmd = "journalctl -u elasticsearch.service";
+            if (cursor.isEmpty() == false) {
+                cmd += " --after-cursor='" + this.cursor + "'";
+            }
+            return sh.run(cmd);
         }
     }
 


### PR DESCRIPTION
It is possible for the cursor from journalctl to be empty, perhaps if
the log is empty. This commit guards the getLogs command line to only
add the --after-cursor if a non empty cursor exists, otherwise
journalctl raises an error.