### PR TITLE
Drop faulty assertion in TransportService

### DIFF
--- a/server/src/main/java/org/elasticsearch/transport/TransportService.java
+++ b/server/src/main/java/org/elasticsearch/transport/TransportService.java
@@ -300,10 +300,6 @@ public class TransportService extends AbstractLifecycleComponent
                     final TransportResponseHandler<?> handler = holderToNotify.handler();
                     final var targetNode = holderToNotify.connection().getNode();
 
-                    // Assertion only holds for TcpTransport only because other transports (used in tests) may not implement the proper
-                    // close-connection behaviour. TODO fix this.
-                    assert transport instanceof TcpTransport == false || targetNode.equals(localNode) : targetNode + " vs " + localNode;
-
                     final var exception = new SendRequestTransportException(
                         targetNode,
                         holderToNotify.action(),


### PR DESCRIPTION
We introduced an assertion in #85131 to check the assumption that there
are no pending non-local response handlers when the `TransportService`
shuts down. We later discovered that this assertion rarely tripped,
which we fixed in #86315, but that fix did not go into 8.2 so there are
still rare failures on this branch. This commit drops the faulty
assertion in 8.2.

Relates #86293