### PR TITLE
Add reminder to add BWC codecs on major version upgrade

### DIFF
--- a/x-pack/plugin/old-lucene-versions/src/test/java/org/elasticsearch/xpack/lucene/bwc/codecs/OldCodecsAvailableTests.java
+++ b/x-pack/plugin/old-lucene-versions/src/test/java/org/elasticsearch/xpack/lucene/bwc/codecs/OldCodecsAvailableTests.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.lucene.bwc.codecs;
+
+import org.elasticsearch.Version;
+import org.elasticsearch.test.ESTestCase;
+
+public class OldCodecsAvailableTests extends ESTestCase {
+
+    /**
+     * Reminder to add Lucene BWC codecs under {@link org.elasticsearch.xpack.lucene.bwc.codecs} whenever Elasticsearch is upgraded
+     * to the next major Lucene version.
+     */
+    public void testLuceneBWCCodecsAvailable() {
+        assertEquals("Add Lucene BWC codecs for Elasticsearch version 7", 8, Version.CURRENT.major);
+    }
+
+}

--- a/x-pack/qa/repository-old-versions/build.gradle
+++ b/x-pack/qa/repository-old-versions/build.gradle
@@ -62,6 +62,8 @@ if (Os.isFamily(Os.FAMILY_WINDOWS)) {
     transformSpec.getTo().attribute(ArtifactTypeDefinition.ARTIFACT_TYPE_ATTRIBUTE, ArtifactTypeDefinition.DIRECTORY_TYPE);
   });
 
+  int currentMajorVersion = org.elasticsearch.gradle.VersionProperties.elasticsearchVersion.major
+  assert (currentMajorVersion - 2) == 6 : "add archive BWC tests for major version " + (currentMajorVersion - 2)
   for (String versionString : ['5.0.0', '5.6.16', '6.0.0', '6.8.20']) {
     Version version = Version.fromString(versionString)
     String packageName = 'org.elasticsearch.distribution.zip'


### PR DESCRIPTION
Codifies the requirement to add Lucene BWC codecs and corresponding tests when upgrading Elasticsearch to the next major version.

Relates https://github.com/elastic/elasticsearch/issues/81210