### PR TITLE
Do not hold the lock during flush in BulkProcessor

### DIFF
--- a/docs/changelog/86862.yaml
+++ b/docs/changelog/86862.yaml
@@ -1,0 +1,6 @@
+pr: 86862
+summary: Do not hold the lock during flush in `BulkProcessor`
+area: Java High Level REST Client
+type: bug
+issues:
+ - 68468


### PR DESCRIPTION
This commit releases the BulkProcessor lock after a new bulk request
is created during flush instead of waiting until the request is
dispatched. This prevents a deadlock when the GENERIC thread pool
is saturated with tasks adding new items to the BulkProcessor
waiting to obtain the lock, this might prevent the original
BulkRequest of making progress in certain scenarios, as some
retry operations might be dispatched in the GENERIC thread pool.

Closes #68468