### PR TITLE
[Refactor] Make PluginBundle package-private

### DIFF
--- a/distribution/tools/plugin-cli/src/main/java/org/elasticsearch/plugins/cli/InstallPluginAction.java
+++ b/distribution/tools/plugin-cli/src/main/java/org/elasticsearch/plugins/cli/InstallPluginAction.java
@@ -81,7 +81,6 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.Timer;
 import java.util.TimerTask;
-import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
@@ -876,7 +875,8 @@ public class InstallPluginAction implements Closeable {
      * check a candidate plugin for jar hell before installing it
      */
     void jarHellCheck(PluginInfo candidateInfo, Path candidateDir, Path pluginsDir, Path modulesDir) throws Exception {
-        final Set<URL> classpath = JarHell.parseClassPath().stream().filter((Predicate<? super URL>) url -> {
+        // create list of current jars in classpath
+        final Set<URL> classpath = JarHell.parseClassPath().stream().filter(url -> {
             try {
                 return url.toURI().getPath().matches(LIB_TOOLS_PLUGIN_CLI_CLASSPATH_JAR) == false;
             } catch (final URISyntaxException e) {

--- a/distribution/tools/plugin-cli/src/main/java/org/elasticsearch/plugins/cli/RemovePluginAction.java
+++ b/distribution/tools/plugin-cli/src/main/java/org/elasticsearch/plugins/cli/RemovePluginAction.java
@@ -89,6 +89,9 @@ public class RemovePluginAction {
         // First make sure nothing extends this plugin
         final Map<String, List<String>> usedBy = new HashMap<>();
 
+        // We build a new map where the keys are plugins that extend plugins
+        // we want to remove and the values are the plugins we can't remove
+        // because of this dependency
         Map<String, List<String>> pluginDependencyMap = PluginsUtils.getDependencyMapView(env.pluginsFile());
         for (Map.Entry<String, List<String>> entry : pluginDependencyMap.entrySet()) {
             for (String extendedPlugin : entry.getValue()) {

--- a/server/src/main/java/org/elasticsearch/plugins/PluginBundle.java
+++ b/server/src/main/java/org/elasticsearch/plugins/PluginBundle.java
@@ -20,13 +20,13 @@ import java.util.Set;
 /**
  * A "bundle" is a group of jars that will be loaded in their own classloader
  */
-public class PluginBundle {
+class PluginBundle {
     public final PluginInfo plugin;
     public final Set<URL> urls;
     public final Set<URL> spiUrls;
     public final Set<URL> allUrls;
 
-    public PluginBundle(PluginInfo plugin, Path dir) throws IOException {
+    PluginBundle(PluginInfo plugin, Path dir) throws IOException {
         this.plugin = Objects.requireNonNull(plugin);
 
         Path spiDir = dir.resolve("spi");

--- a/server/src/main/java/org/elasticsearch/plugins/PluginsUtils.java
+++ b/server/src/main/java/org/elasticsearch/plugins/PluginsUtils.java
@@ -16,7 +16,6 @@ import org.elasticsearch.common.io.FileSystemUtils;
 import org.elasticsearch.jdk.JarHell;
 
 import java.io.IOException;
-import java.net.URISyntaxException;
 import java.net.URL;
 import java.nio.file.DirectoryStream;
 import java.nio.file.Files;
@@ -31,7 +30,6 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Function;
-import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
 /**

--- a/server/src/main/java/org/elasticsearch/plugins/PluginsUtils.java
+++ b/server/src/main/java/org/elasticsearch/plugins/PluginsUtils.java
@@ -31,6 +31,7 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Function;
+import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
 /**
@@ -169,21 +170,26 @@ public class PluginsUtils {
         return new PluginBundle(info, plugin);
     }
 
+    /**
+     * Given a plugin that we would like to install, perform a series of "jar hell
+     * checks to make sure that we don't have any classname conflicts. Some of these
+     * checks are unique to the "pre-installation" scenario, but we also call the
+     * {@link #checkBundleJarHell(Set, PluginBundle, Map)}.
+     * @param candidateInfo Candidate for installation
+     * @param candidateDir Directory containing the candidate plugin files
+     * @param pluginsDir Directory containing already-installed plugins
+     * @param modulesDir Directory containing Elasticsearch modules
+     * @param classpath Set of URLs to use for a classpath
+     * @throws IOException on failed plugin reads
+     */
     public static void preInstallJarHellCheck(
         PluginInfo candidateInfo,
         Path candidateDir,
         Path pluginsDir,
         Path modulesDir,
-        String jarFilter
-    ) throws Exception {
+        Set<URL> classpath
+    ) throws IOException {
         // create list of current jars in classpath
-        final Set<URL> classpath = JarHell.parseClassPath().stream().filter(url -> {
-            try {
-                return url.toURI().getPath().matches(jarFilter) == false;
-            } catch (final URISyntaxException e) {
-                throw new AssertionError(e);
-            }
-        }).collect(Collectors.toSet());
 
         // read existing bundles. this does some checks on the installation too.
         Set<PluginBundle> bundles = new HashSet<>(getPluginBundles(pluginsDir));


### PR DESCRIPTION
Our plugin loading code uses the `PluginBundle` class to describe a plugin on disk. This should be an implementation detail of the plugin loading code, and not part of the API shared with the plugin CLI. This refactoring moves static methods from the plugin CLI to the `PluginsUtils` class, makes `PluginBundle` package-private, and reduces the visibility of `PluginsUtils` static methods where possible. 