### PR TITLE
Script: Fix setter shortcut for unbridged setters

### DIFF
--- a/docs/changelog/86868.yaml
+++ b/docs/changelog/86868.yaml
@@ -1,0 +1,5 @@
+pr: 86868
+summary: "Script: Fix setter shortcut for unbridged setters"
+area: Infra/Scripting
+type: bug
+issues: []

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/phase/DefaultSemanticAnalysisPhase.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/phase/DefaultSemanticAnalysisPhase.java
@@ -2880,7 +2880,7 @@ public class DefaultSemanticAnalysisPhase extends UserTreeBaseVisitor<SemanticSc
                                 prefixType,
                                 isStatic,
                                 "set" + Character.toUpperCase(index.charAt(0)) + index.substring(1),
-                                0
+                                1
                             );
 
                         if (getter != null || setter != null) {

--- a/modules/lang-painless/src/test/java/org/elasticsearch/painless/BasicAPITests.java
+++ b/modules/lang-painless/src/test/java/org/elasticsearch/painless/BasicAPITests.java
@@ -167,6 +167,16 @@ public class BasicAPITests extends ScriptTestCase {
         );
     }
 
+    public void testSetterShortcut() {
+        assertEquals(
+            25,
+            exec(
+                "org.elasticsearch.painless.FeatureTestObject ft = new org.elasticsearch.painless.FeatureTestObject();"
+                    + "ft.y = 25; return ft.y;"
+            )
+        );
+    }
+
     public void testNoSemicolon() {
         assertEquals(true, exec("def x = true; if (x) return x"));
     }


### PR DESCRIPTION
The setter shortcut resolution worked for bridged setter methods, in `PainlessLookupBuilder.cacheRuntimeHandles`, but did not work for other setters.