### PR TITLE
[TEST] Accept warning about multiple matching templates

### DIFF
--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/index/91_metrics_no_subobjects.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/index/91_metrics_no_subobjects.yml
@@ -1,6 +1,7 @@
 ---
 "Metrics indexing":
   - skip:
+      features: allowed_warnings_regex
       version: " - 8.2.99"
       reason: added in 8.3.0
 
@@ -18,6 +19,8 @@
                     subobjects: false
 
   - do:
+      allowed_warnings_regex:
+        - "index \\[test-1\\] matches multiple legacy templates \\[global, test\\], composable templates will only match a single template"
       index:
         index: test-1
         id: 1


### PR DESCRIPTION
This PR fixes a recent test failure caused by multiple matching legacy templates: https://gradle-enterprise.elastic.co/s/usz3awka53gii/console-log?task=:rest-api-spec:yamlRestTest .