### PR TITLE
installation on windows must be done as admin

### DIFF
--- a/docs/reference/setup/install/zip-windows-start.asciidoc
+++ b/docs/reference/setup/install/zip-windows-start.asciidoc
@@ -1,6 +1,6 @@
 ==== Run {es} from the command line
 
-Run the following command to start {es} from the command line:
+Run as an administrator user the following command to start {es} from the command line:
 
 [source,sh]
 ----


### PR DESCRIPTION
As reported by users, the `.\bin\elasticsearch.bat` command must be executed as an administrator, but this is not 100% clear from the documentation. Thus submitting this pull request adding this detail.

