### PR TITLE
Strengthen testIncorrectHeaderHandling

### DIFF
--- a/server/src/main/java/org/elasticsearch/http/AbstractHttpServerTransport.java
+++ b/server/src/main/java/org/elasticsearch/http/AbstractHttpServerTransport.java
@@ -469,18 +469,18 @@ public abstract class AbstractHttpServerTransport extends AbstractLifecycleCompo
         Set<String> failedHeaderNames
     ) {
         assert failedHeaderNames.size() > 0;
-        HttpRequest httpRequestWithoutContentType = httpRequest;
+        HttpRequest httpRequestWithoutHeader = httpRequest;
         for (String failedHeaderName : failedHeaderNames) {
-            httpRequestWithoutContentType = httpRequestWithoutContentType.removeHeader(failedHeaderName);
+            httpRequestWithoutHeader = httpRequestWithoutHeader.removeHeader(failedHeaderName);
         }
         try {
-            return RestRequest.request(parserConfig, httpRequestWithoutContentType, httpChannel);
+            return RestRequest.request(parserConfig, httpRequestWithoutHeader, httpChannel);
         } catch (final RestRequest.MediaTypeHeaderException e) {
             badRequestCause = ExceptionsHelper.useOrSuppress(badRequestCause, e);
-            return requestWithoutFailedHeader(httpRequest, httpChannel, badRequestCause, e.getFailedHeaderNames());
+            return requestWithoutFailedHeader(httpRequestWithoutHeader, httpChannel, badRequestCause, e.getFailedHeaderNames());
         } catch (final RestRequest.BadParameterException e) {
             badRequestCause.addSuppressed(e);
-            return RestRequest.requestWithoutParameters(parserConfig, httpRequestWithoutContentType, httpChannel);
+            return RestRequest.requestWithoutParameters(parserConfig, httpRequestWithoutHeader, httpChannel);
         }
     }
 

--- a/server/src/test/java/org/elasticsearch/http/AbstractHttpServerTransportTests.java
+++ b/server/src/test/java/org/elasticsearch/http/AbstractHttpServerTransportTests.java
@@ -225,7 +225,10 @@ public class AbstractHttpServerTransportTests extends ESTestCase {
         try (AbstractHttpServerTransport transport = failureAssertingtHttpServerTransport(clusterSettings, Set.of("Accept"))) {
 
             Map<String, List<String>> headers = new HashMap<>();
-            headers.put("Accept", Collections.singletonList("incorrectheader"));
+            headers.put("Accept", List.of("incorrectHeader"));
+            if (randomBoolean()) {
+                headers.put("Content-Type", List.of("alsoIncorrectHeader"));
+            }
 
             FakeRestRequest.FakeHttpRequest fakeHttpRequest = new FakeRestRequest.FakeHttpRequest(
                 RestRequest.Method.GET,
@@ -238,8 +241,10 @@ public class AbstractHttpServerTransportTests extends ESTestCase {
         }
         try (AbstractHttpServerTransport transport = failureAssertingtHttpServerTransport(clusterSettings, Set.of("Content-Type"))) {
             Map<String, List<String>> headers = new HashMap<>();
-            headers.put("Accept", Collections.singletonList("application/json"));
-            headers.put("Content-Type", Collections.singletonList("incorrectheader"));
+            if (randomBoolean()) {
+                headers.put("Accept", List.of("application/json"));
+            }
+            headers.put("Content-Type", List.of("incorrectHeader"));
 
             FakeRestRequest.FakeHttpRequest fakeHttpRequest = new FakeRestRequest.FakeHttpRequest(
                 RestRequest.Method.GET,

--- a/test/framework/src/main/java/org/elasticsearch/test/rest/FakeRestRequest.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/rest/FakeRestRequest.java
@@ -106,8 +106,9 @@ public class FakeRestRequest extends RestRequest {
 
         @Override
         public HttpRequest removeHeader(String header) {
-            headers.remove(header);
-            return this;
+            final var filteredHeaders = new HashMap<>(headers);
+            filteredHeaders.remove(header);
+            return new FakeHttpRequest(method, uri, content, filteredHeaders, inboundException);
         }
 
         @Override


### PR DESCRIPTION
Enhances this test to cover more combinations of present/absent headers,
and makes the fake REST request immutable to align it with the
production implementation.