### PR TITLE
[DOCS] Adds settings of question_answering to inference_config of PUT and infer trained model APIs

### DIFF
--- a/docs/reference/ml/ml-shared.asciidoc
+++ b/docs/reference/ml/ml-shared.asciidoc
@@ -1050,6 +1050,12 @@ post-processing is done to the inference output and the raw pooling layer
 results are returned to the caller.
 end::inference-config-pass-through[]
 
+tag::inference-config-nlp-question-answering[]
+Configures a question answering natural language processing (NLP) task. Question 
+answering is useful for extracting answers for certain questions from a large 
+corpus of text.
+end::inference-config-nlp-question-answering[]
+
 tag::inference-config-text-classification[]
 A text classification task. Text classification classifies a provided text
 sequence into previously known target classes. A specific example of this is

--- a/docs/reference/ml/trained-models/apis/infer-trained-model.asciidoc
+++ b/docs/reference/ml/trained-models/apis/infer-trained-model.asciidoc
@@ -223,7 +223,8 @@ classes:
 ----
 // NOTCONSOLE
 
-Question answering require extra configuration defining the question to answer.
+Question answering models require extra configuration defining the question to 
+answer.
 
 [source,console]
 --------------------------------------------------

--- a/docs/reference/ml/trained-models/apis/infer-trained-model.asciidoc
+++ b/docs/reference/ml/trained-models/apis/infer-trained-model.asciidoc
@@ -237,7 +237,7 @@ POST _ml/trained_models/model2/_infer
   "inference_config": {
     "question_answering": {
       "question": "<question to be answered>"
-      }
+    }
   }
 }
 --------------------------------------------------

--- a/docs/reference/ml/trained-models/apis/infer-trained-model.asciidoc
+++ b/docs/reference/ml/trained-models/apis/infer-trained-model.asciidoc
@@ -248,7 +248,7 @@ The API returns a response similar to the following:
 [source,console-result]
 ----
 {
-    "predicted_value": <string subsection of the text that is the answer>
+    "predicted_value": <string subsection of the text that is the answer>,
     "start_offset": <character offset in document to start>,
     "end_offset": <character offset end of the answer,
     "prediction_probability": <prediction score>

--- a/docs/reference/ml/trained-models/apis/infer-trained-model.asciidoc
+++ b/docs/reference/ml/trained-models/apis/infer-trained-model.asciidoc
@@ -46,9 +46,10 @@ Controls the amount of time to wait for {infer} results. Defaults to 10 seconds.
 `docs`::
 (Required, array)
 An array of objects to pass to the model for inference. The objects should
-contain the fields matching your configured trained model input. Typically for NLP models, the field
-name is `text_field`. Currently for NLP models, only a single value is allowed. For {dfanalytics} or
-imported classification or regression models, more than one value is allowed.
+contain the fields matching your configured trained model input. Typically for 
+NLP models, the field name is `text_field`. Currently for NLP models, only a 
+single value is allowed. For {dfanalytics} or imported classification or 
+regression models, more than one value is allowed.
 
 ////
 [[infer-trained-model-results]]
@@ -159,8 +160,8 @@ The API returns in this case:
 ----
 // NOTCONSOLE
 
-Zero-shot classification models require extra configuration defining the class labels.
-These labels are passed in the zero-shot inference config.
+Zero-shot classification models require extra configuration defining the class 
+labels. These labels are passed in the zero-shot inference config.
 
 [source,console]
 --------------------------------------------------
@@ -221,6 +222,38 @@ The API returns the predicted label and the confidence, as well as the top class
 ----
 // NOTCONSOLE
 
+Question answering require extra configuration defining the question to answer.
+
+[source,console]
+--------------------------------------------------
+POST _ml/trained_models/model2/_infer
+{
+  "docs": [
+    {
+      "text_field": "<long text to extract answer>"
+    }
+  ],
+  "inference_config": {
+    "question_answering": {
+      "question": "<question to be answered>"
+      }
+  }
+}
+--------------------------------------------------
+// TEST[skip:TBD]
+
+The API returns a respons like the following:
+
+[source,console-result]
+----
+{
+    "predicted_value": <string subsection of the document that is the answer>
+    "start_offset": <Char offset in document to start>,
+    "end_offset": <char offset end of the answer,
+    "prediction_probability": <prediction score>
+}
+----
+// NOTCONSOLE
 
 The tokenization truncate option can be overridden when calling the API:
 

--- a/docs/reference/ml/trained-models/apis/infer-trained-model.asciidoc
+++ b/docs/reference/ml/trained-models/apis/infer-trained-model.asciidoc
@@ -187,7 +187,8 @@ POST _ml/trained_models/model2/_infer
 --------------------------------------------------
 // TEST[skip:TBD]
 
-The API returns the predicted label and the confidence, as well as the top classes:
+The API returns the predicted label and the confidence, as well as the top 
+classes:
 
 [source,console-result]
 ----
@@ -247,9 +248,9 @@ The API returns a respons like the following:
 [source,console-result]
 ----
 {
-    "predicted_value": <string subsection of the document that is the answer>
-    "start_offset": <Char offset in document to start>,
-    "end_offset": <char offset end of the answer,
+    "predicted_value": <string subsection of the text that is the answer>
+    "start_offset": <character offset in document to start>,
+    "end_offset": <character offset end of the answer,
     "prediction_probability": <prediction score>
 }
 ----

--- a/docs/reference/ml/trained-models/apis/infer-trained-model.asciidoc
+++ b/docs/reference/ml/trained-models/apis/infer-trained-model.asciidoc
@@ -243,7 +243,7 @@ POST _ml/trained_models/model2/_infer
 --------------------------------------------------
 // TEST[skip:TBD]
 
-The API returns a respons like the following:
+The API returns a response similar to the following:
 
 [source,console-result]
 ----

--- a/docs/reference/ml/trained-models/apis/put-trained-models.asciidoc
+++ b/docs/reference/ml/trained-models/apis/put-trained-models.asciidoc
@@ -698,11 +698,6 @@ include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=inference-config-nlp-question-a
 (Optional, integer)
 The maximum amount of words that the answer consists. Defaults to `15`.
 
-`question`::::
-(Required, string)
-The question that you want to be answered based on the context of the provided 
-text.
-
 `tokenization`::::
 (Optional, object)
 include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=inference-config-nlp-tokenization]

--- a/docs/reference/ml/trained-models/apis/put-trained-models.asciidoc
+++ b/docs/reference/ml/trained-models/apis/put-trained-models.asciidoc
@@ -706,7 +706,6 @@ text.
 `tokenization`::::
 (Optional, object)
 include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=inference-config-nlp-tokenization]
-
 Recommended to set `max_sentence_length` to `386` with `128` of `span` and set 
 `truncate` to `none`.
 +

--- a/docs/reference/ml/trained-models/apis/put-trained-models.asciidoc
+++ b/docs/reference/ml/trained-models/apis/put-trained-models.asciidoc
@@ -384,10 +384,12 @@ the model definition is not supplied.
 `inference_config`::
 (Required, object)
 The default configuration for inference. This can be: `regression`,
-`classification`, `fill_mask`, `ner`, `text_classification`, `text_embedding` or `zero_shot_classification`.
+`classification`, `fill_mask`, `ner`, `question_answering`, 
+`text_classification`, `text_embedding` or `zero_shot_classification`.
 If `regression` or `classification`, it must match the `target_type` of the
-underlying `definition.trained_model`. If `fill_mask`, `ner`,
-`text_classification`, or `text_embedding`; the `model_type` must be `pytorch`.
+underlying `definition.trained_model`. If `fill_mask`, `ner`, 
+`question_answering`, `text_classification`, or `text_embedding`; the 
+`model_type` must be `pytorch`.
 +
 .Properties of `inference_config`
 [%collapsible%open]
@@ -515,9 +517,10 @@ include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=inference-config-ner]
 =====
 `classification_labels`::::
 (Optional, string)
-An array of classification labels. NER only supports Inside-Outside-Beginning labels (IOB)
-and only persons, organizations, locations, and miscellaneous.
-Example: ["O", "B-PER", "I-PER", "B-ORG", "I-ORG", "B-LOC", "I-LOC", "B-MISC", "I-MISC"]
+An array of classification labels. NER only supports Inside-Outside-Beginning 
+labels (IOB) and only persons, organizations, locations, and miscellaneous.
+Example: ["O", "B-PER", "I-PER", "B-ORG", "I-ORG", "B-LOC", "I-LOC", "B-MISC", 
+"I-MISC"]
 
 `tokenization`::::
 (Optional, object)
@@ -672,6 +675,116 @@ include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=inference-config-nlp-tokenizati
 `max_sequence_length`::::
 (Optional, integer)
 include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=inference-config-nlp-tokenization-max-sequence-length]
+
+`truncate`::::
+(Optional, string)
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=inference-config-nlp-tokenization-truncate]
+
+`with_special_tokens`::::
+(Optional, boolean)
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=inference-config-nlp-tokenization-mpnet-with-special-tokens]
+=======
+======
+=====
+
+`question_answering`:::
+(Optional, object)
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=inference-config-nlp-question-answering]
++
+.Properties of question_answering inference
+[%collapsible%open]
+=====
+`max_answer_length`::::
+(Optional, integer)
+The maximum amount of words that the answer consists. Defaults to `15`.
+
+`question`::::
+(Required, string)
+The question that you want to be answered based on the context of the provided 
+text.
+
+`tokenization`::::
+(Optional, object)
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=inference-config-nlp-tokenization]
+
+Recommended to set `max_sentence_length` to `386` with `128` of `span` and set 
+`truncate` to `none`.
++
+.Properties of tokenization
+[%collapsible%open]
+======
+`bert`::::
+(Optional, object)
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=inference-config-nlp-tokenization-bert]
++
+.Properties of bert
+[%collapsible%open]
+=======
+`do_lower_case`::::
+(Optional, boolean)
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=inference-config-nlp-tokenization-do-lower-case]
+
+`max_sequence_length`::::
+(Optional, integer)
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=inference-config-nlp-tokenization-max-sequence-length]
+
+`span`::::
+(Optional, integer)
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=inference-config-nlp-tokenization-span]
+
+`truncate`::::
+(Optional, string)
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=inference-config-nlp-tokenization-truncate]
+
+`with_special_tokens`::::
+(Optional, boolean)
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=inference-config-nlp-tokenization-bert-with-special-tokens]
+=======
+`roberta`::::
+(Optional, object)
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=inference-config-nlp-tokenization-roberta]
++
+.Properties of roberta
+[%collapsible%open]
+=======
+`add_prefix_space`::::
+(Optional, boolean)
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=inference-config-nlp-tokenization-roberta-add-prefix-space]
+
+`max_sequence_length`::::
+(Optional, integer)
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=inference-config-nlp-tokenization-max-sequence-length]
+
+`span`::::
+(Optional, integer)
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=inference-config-nlp-tokenization-span]
+
+`truncate`::::
+(Optional, string)
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=inference-config-nlp-tokenization-truncate]
+
+`with_special_tokens`::::
+(Optional, boolean)
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=inference-config-nlp-tokenization-roberta-with-special-tokens]
+=======
+`mpnet`::::
+(Optional, object)
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=inference-config-nlp-tokenization-mpnet]
++
+.Properties of mpnet
+[%collapsible%open]
+=======
+`do_lower_case`::::
+(Optional, boolean)
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=inference-config-nlp-tokenization-do-lower-case]
+
+`max_sequence_length`::::
+(Optional, integer)
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=inference-config-nlp-tokenization-max-sequence-length]
+
+`span`::::
+(Optional, integer)
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=inference-config-nlp-tokenization-span]
 
 `truncate`::::
 (Optional, string)

--- a/docs/reference/ml/trained-models/apis/put-trained-models.asciidoc
+++ b/docs/reference/ml/trained-models/apis/put-trained-models.asciidoc
@@ -696,11 +696,12 @@ include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=inference-config-nlp-question-a
 =====
 `max_answer_length`::::
 (Optional, integer)
-The maximum amount of words that the answer consists. Defaults to `15`.
+The maximum amount of words in the answer. Defaults to `15`.
 
 `tokenization`::::
 (Optional, object)
 include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=inference-config-nlp-tokenization]
++
 Recommended to set `max_sentence_length` to `386` with `128` of `span` and set 
 `truncate` to `none`.
 +


### PR DESCRIPTION
## Overview

This PR adds the settings of the `question_answering` NLP task to the `inference_config` in the PUT trained models API docs.

Relates to https://github.com/elastic/elasticsearch/pull/85958, https://github.com/elastic/ml-team/issues/794, and https://github.com/elastic/stack-docs/pull/2138.

### Preview

[PUT trained models](https://elasticsearch_86895.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/put-trained-models.html)
[Infer trained model API](https://elasticsearch_86895.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/infer-trained-model.html)