### PR TITLE
Fix max_primary_shard_size resize factor math

### DIFF
--- a/docs/changelog/86897.yaml
+++ b/docs/changelog/86897.yaml
@@ -1,0 +1,5 @@
+pr: 86897
+summary: Fix `max_primary_shard_size` resize factor math
+area: ILM+SLM
+type: bug
+issues: []

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/shrink/ResizeNumberOfShardsCalculator.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/shrink/ResizeNumberOfShardsCalculator.java
@@ -134,7 +134,7 @@ public interface ResizeNumberOfShardsCalculator {
                     }
                 }
             } else {
-                for (int i = 1; i < num; i++) {
+                for (int i = 1; i <= num; i++) {
                     if (sourceIndexShardsNum % i == 0 && minShardsNum <= i) {
                         return i;
                     }

--- a/server/src/test/java/org/elasticsearch/action/admin/indices/shrink/ResizeNumberOfShardsCalculatorTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/indices/shrink/ResizeNumberOfShardsCalculatorTests.java
@@ -91,15 +91,15 @@ public class ResizeNumberOfShardsCalculatorTests extends ESTestCase {
     }
 
     public void testCalculateTargetShardsNumberInShrink() {
-        assertEquals(calculateAcceptableNumberOfShards(0, 0), 1);
-        assertEquals(calculateAcceptableNumberOfShards(10, 0), 1);
-        assertEquals(calculateAcceptableNumberOfShards(10, 1), 1);
-        assertEquals(calculateAcceptableNumberOfShards(10, 2), 2);
-        assertEquals(calculateAcceptableNumberOfShards(10, 3), 5);
-        assertEquals(calculateAcceptableNumberOfShards(10, 6), 10);
-        assertEquals(calculateAcceptableNumberOfShards(10, 11), 10);
-        assertEquals(calculateAcceptableNumberOfShards(59, 21), 59);
-        assertEquals(calculateAcceptableNumberOfShards(60, 21), 30);
-        assertEquals(calculateAcceptableNumberOfShards(60, 31), 60);
+        assertEquals(1, calculateAcceptableNumberOfShards(0, 0));
+        assertEquals(1, calculateAcceptableNumberOfShards(10, 0));
+        assertEquals(1, calculateAcceptableNumberOfShards(10, 1));
+        assertEquals(2, calculateAcceptableNumberOfShards(10, 2));
+        assertEquals(5, calculateAcceptableNumberOfShards(10, 3));
+        assertEquals(10, calculateAcceptableNumberOfShards(10, 6));
+        assertEquals(10, calculateAcceptableNumberOfShards(10, 11));
+        assertEquals(59, calculateAcceptableNumberOfShards(59, 21));
+        assertEquals(30, calculateAcceptableNumberOfShards(60, 21));
+        assertEquals(60, calculateAcceptableNumberOfShards(60, 31));
     }
 }

--- a/server/src/test/java/org/elasticsearch/action/admin/indices/shrink/ResizeNumberOfShardsCalculatorTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/indices/shrink/ResizeNumberOfShardsCalculatorTests.java
@@ -92,6 +92,7 @@ public class ResizeNumberOfShardsCalculatorTests extends ESTestCase {
 
     public void testCalculateTargetShardsNumberInShrink() {
         assertEquals(1, calculateAcceptableNumberOfShards(0, 0));
+        assertEquals(3, calculateAcceptableNumberOfShards(9, 2));
         assertEquals(1, calculateAcceptableNumberOfShards(10, 0));
         assertEquals(1, calculateAcceptableNumberOfShards(10, 1));
         assertEquals(2, calculateAcceptableNumberOfShards(10, 2));


### PR DESCRIPTION
There's an off-by-one bug in #67705, such that the logic doesn't handle all factors correctly in some circumstances.

For example, `calculateAcceptableNumberOfShards(9, 2)` would return 9 rather than 3, because it would evaluate all potential factors up to but not including 3 (`<`), and not finding such a factor, it would return 9. The correct logic should evaluate all potential factors up to and including 3 (`<=`), and return 3.