### PR TITLE
Speed up building RoutingTable from RoutingNodes

### DIFF
--- a/modules/ingest-geoip/src/test/java/org/elasticsearch/ingest/geoip/DatabaseNodeServiceTests.java
+++ b/modules/ingest-geoip/src/test/java/org/elasticsearch/ingest/geoip/DatabaseNodeServiceTests.java
@@ -393,7 +393,7 @@ public class DatabaseNodeServiceTests extends ESTestCase {
                 RoutingTable.builder()
                     .add(
                         IndexRoutingTable.builder(index)
-                            .addIndexShard(new IndexShardRoutingTable.Builder(new ShardId(index, 0)).addShard(shardRouting))
+                            .addIndexShard(IndexShardRoutingTable.builder(new ShardId(index, 0)).addShard(shardRouting))
                     )
             )
             .build();

--- a/modules/ingest-geoip/src/test/java/org/elasticsearch/ingest/geoip/DatabaseNodeServiceTests.java
+++ b/modules/ingest-geoip/src/test/java/org/elasticsearch/ingest/geoip/DatabaseNodeServiceTests.java
@@ -384,13 +384,18 @@ public class DatabaseNodeServiceTests extends ESTestCase {
         if (noStartedShards == false) {
             shardRouting = shardRouting.moveToStarted();
         }
-        IndexShardRoutingTable table = new IndexShardRoutingTable.Builder(new ShardId(index, 0)).addShard(shardRouting).build();
         return ClusterState.builder(new ClusterName("name"))
             .metadata(Metadata.builder().putCustom(TYPE, tasksCustomMetadata).put(idxMeta))
             .nodes(
                 DiscoveryNodes.builder().add(new DiscoveryNode("_id1", buildNewFakeTransportAddress(), Version.CURRENT)).localNodeId("_id1")
             )
-            .routingTable(RoutingTable.builder().add(IndexRoutingTable.builder(index).addIndexShard(table)))
+            .routingTable(
+                RoutingTable.builder()
+                    .add(
+                        IndexRoutingTable.builder(index)
+                            .addIndexShard(new IndexShardRoutingTable.Builder(new ShardId(index, 0)).addShard(shardRouting))
+                    )
+            )
             .build();
     }
 

--- a/server/src/internalClusterTest/java/org/elasticsearch/cluster/ClusterStateDiffIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/cluster/ClusterStateDiffIT.java
@@ -296,7 +296,7 @@ public class ClusterStateDiffIT extends ESIntegTestCase {
                     )
                 );
             }
-            builder.addIndexShard(indexShard.build());
+            builder.addIndexShard(indexShard);
         }
         return builder.build();
     }

--- a/server/src/internalClusterTest/java/org/elasticsearch/indices/store/IndicesStoreIntegrationIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/indices/store/IndicesStoreIntegrationIT.java
@@ -481,7 +481,7 @@ public class IndicesStoreIntegrationIT extends ESIntegTestCase {
             indexRoutingTableBuilder.addIndexShard(
                 new IndexShardRoutingTable.Builder(shardId).addShard(
                     TestShardRouting.newShardRouting(shardId, masterId, true, ShardRoutingState.STARTED)
-                ).build()
+                )
             );
         }
         ClusterState newState = ClusterState.builder(currentState)

--- a/server/src/main/java/org/elasticsearch/cluster/routing/IndexRoutingTable.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/IndexRoutingTable.java
@@ -418,7 +418,7 @@ public class IndexRoutingTable implements SimpleDiffable<IndexRoutingTable> {
             shards = new IndexShardRoutingTable.Builder[indexMetadata.getNumberOfShards()];
             for (int shardNumber = 0; shardNumber < indexMetadata.getNumberOfShards(); shardNumber++) {
                 ShardId shardId = new ShardId(index, shardNumber);
-                IndexShardRoutingTable.Builder indexShardRoutingBuilder = new IndexShardRoutingTable.Builder(shardId);
+                IndexShardRoutingTable.Builder indexShardRoutingBuilder = IndexShardRoutingTable.builder(shardId);
                 for (int i = 0; i <= indexMetadata.getNumberOfReplicas(); i++) {
                     boolean primary = i == 0;
                     if (asNew && ignoreShards.contains(shardNumber)) {
@@ -469,7 +469,7 @@ public class IndexRoutingTable implements SimpleDiffable<IndexRoutingTable> {
                     // a freshly created index with no restriction
                     primaryRecoverySource = EmptyStoreRecoverySource.INSTANCE;
                 }
-                IndexShardRoutingTable.Builder indexShardRoutingBuilder = new IndexShardRoutingTable.Builder(shardId);
+                IndexShardRoutingTable.Builder indexShardRoutingBuilder = IndexShardRoutingTable.builder(shardId);
                 for (int i = 0; i <= indexMetadata.getNumberOfReplicas(); i++) {
                     boolean primary = i == 0;
                     indexShardRoutingBuilder.addShard(
@@ -487,13 +487,9 @@ public class IndexRoutingTable implements SimpleDiffable<IndexRoutingTable> {
         }
 
         public Builder addReplica() {
-            if (shards == null) {
-                return this;
-            }
+            assert shards != null;
             for (IndexShardRoutingTable.Builder existing : shards) {
-                if (existing == null) {
-                    continue;
-                }
+                assert existing != null;
                 // version 0, will get updated when reroute will happen
                 existing.addShard(
                     ShardRouting.newUnassigned(
@@ -508,21 +504,17 @@ public class IndexRoutingTable implements SimpleDiffable<IndexRoutingTable> {
         }
 
         public Builder removeReplica() {
-            if (shards == null) {
-                return this;
-            }
+            assert shards != null;
             for (int shardId = 0; shardId < shards.length; shardId++) {
                 IndexShardRoutingTable.Builder found = shards[shardId];
-                if (found == null) {
-                    continue;
-                }
+                assert found != null;
                 final IndexShardRoutingTable indexShard = found.build();
                 if (indexShard.replicaShards().isEmpty()) {
                     // nothing to do here!
                     return this;
                 }
                 // re-add all the current ones
-                IndexShardRoutingTable.Builder builder = new IndexShardRoutingTable.Builder(indexShard.shardId());
+                IndexShardRoutingTable.Builder builder = IndexShardRoutingTable.builder(indexShard.shardId());
                 for (int copy = 0; copy < indexShard.size(); copy++) {
                     ShardRouting shardRouting = indexShard.shard(copy);
                     builder.addShard(shardRouting);
@@ -565,14 +557,14 @@ public class IndexRoutingTable implements SimpleDiffable<IndexRoutingTable> {
             ensureShardArray(shardId);
             IndexShardRoutingTable.Builder indexShard = shards[shardId];
             if (indexShard == null) {
-                shards[shardId] = new IndexShardRoutingTable.Builder(shard.shardId()).addShard(shard);
+                shards[shardId] = IndexShardRoutingTable.builder(shard.shardId()).addShard(shard);
             } else {
                 indexShard.addShard(shard);
             }
             return this;
         }
 
-        private void ensureShardArray(int shardId) {
+        void ensureShardArray(int shardId) {
             if (shards == null) {
                 shards = new IndexShardRoutingTable.Builder[shardId + 1];
             } else if (shards.length < shardId + 1) {

--- a/server/src/main/java/org/elasticsearch/cluster/routing/IndexRoutingTable.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/IndexRoutingTable.java
@@ -298,7 +298,7 @@ public class IndexRoutingTable implements SimpleDiffable<IndexRoutingTable> {
         Builder builder = new Builder(index);
 
         int size = in.readVInt();
-        builder.ensureShardArray(size - 1);
+        builder.ensureShardArray(size);
         for (int i = 0; i < size; i++) {
             builder.addIndexShard(IndexShardRoutingTable.Builder.readFromThin(in, index));
         }
@@ -542,7 +542,7 @@ public class IndexRoutingTable implements SimpleDiffable<IndexRoutingTable> {
             assert indexShard.shardId().getIndex().equals(index)
                 : "cannot add shard routing table for " + indexShard.shardId() + " to index routing table for " + index;
             final int sid = indexShard.shardId().id();
-            ensureShardArray(sid);
+            ensureShardArray(sid + 1);
             shards[sid] = indexShard;
             return this;
         }
@@ -554,7 +554,7 @@ public class IndexRoutingTable implements SimpleDiffable<IndexRoutingTable> {
         public Builder addShard(ShardRouting shard) {
             assert shard.index().equals(index) : "cannot add [" + shard + "] to routing table for " + index;
             int shardId = shard.id();
-            ensureShardArray(shardId);
+            ensureShardArray(shardId + 1);
             IndexShardRoutingTable.Builder indexShard = shards[shardId];
             if (indexShard == null) {
                 shards[shardId] = IndexShardRoutingTable.builder(shard.shardId()).addShard(shard);
@@ -564,11 +564,11 @@ public class IndexRoutingTable implements SimpleDiffable<IndexRoutingTable> {
             return this;
         }
 
-        void ensureShardArray(int shardId) {
+        void ensureShardArray(int shardCount) {
             if (shards == null) {
-                shards = new IndexShardRoutingTable.Builder[shardId + 1];
-            } else if (shards.length < shardId + 1) {
-                IndexShardRoutingTable.Builder[] updated = new IndexShardRoutingTable.Builder[shardId + 1];
+                shards = new IndexShardRoutingTable.Builder[shardCount];
+            } else if (shards.length < shardCount) {
+                IndexShardRoutingTable.Builder[] updated = new IndexShardRoutingTable.Builder[shardCount];
                 System.arraycopy(shards, 0, updated, 0, shards.length);
                 shards = updated;
             }

--- a/server/src/main/java/org/elasticsearch/cluster/routing/IndexRoutingTable.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/IndexRoutingTable.java
@@ -490,24 +490,21 @@ public class IndexRoutingTable implements SimpleDiffable<IndexRoutingTable> {
             if (shards == null) {
                 return this;
             }
-            for (int shardNumber = 0; shardNumber < shards.length; shardNumber++) {
-                IndexShardRoutingTable.Builder existing = shards[shardNumber];
+            for (IndexShardRoutingTable.Builder existing : shards) {
                 if (existing == null) {
                     continue;
                 }
                 // version 0, will get updated when reroute will happen
-                existing.addShard(newUnassignedReplica(existing.shardId()));
+                existing.addShard(
+                    ShardRouting.newUnassigned(
+                        existing.shardId(),
+                        false,
+                        PeerRecoverySource.INSTANCE,
+                        new UnassignedInfo(UnassignedInfo.Reason.REPLICA_ADDED, null)
+                    )
+                );
             }
             return this;
-        }
-
-        private ShardRouting newUnassignedReplica(ShardId shardId) {
-            return ShardRouting.newUnassigned(
-                shardId,
-                false,
-                PeerRecoverySource.INSTANCE,
-                new UnassignedInfo(UnassignedInfo.Reason.REPLICA_ADDED, null)
-            );
         }
 
         public Builder removeReplica() {

--- a/server/src/main/java/org/elasticsearch/cluster/routing/IndexShardRoutingTable.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/IndexShardRoutingTable.java
@@ -520,6 +520,10 @@ public class IndexShardRoutingTable {
         return shards;
     }
 
+    public static Builder builder(ShardId shardId) {
+        return new Builder(shardId);
+    }
+
     public static class Builder {
 
         private final ShardId shardId;

--- a/server/src/main/java/org/elasticsearch/cluster/routing/IndexShardRoutingTable.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/IndexShardRoutingTable.java
@@ -9,6 +9,7 @@
 package org.elasticsearch.cluster.routing;
 
 import org.elasticsearch.cluster.node.DiscoveryNodes;
+import org.elasticsearch.cluster.service.MasterService;
 import org.elasticsearch.common.ExponentiallyWeightedMovingAverage;
 import org.elasticsearch.common.Randomness;
 import org.elasticsearch.common.io.stream.StreamInput;
@@ -471,6 +472,7 @@ public class IndexShardRoutingTable {
     }
 
     public Set<String> getAllAllocationIds() {
+        assert MasterService.assertNotMasterUpdateThread("not using this on the master thread so we don't have to pre-compute this");
         Set<String> allAllocationIds = new HashSet<>();
         for (ShardRouting shard : shards) {
             if (shard.relocating()) {

--- a/server/src/main/java/org/elasticsearch/cluster/routing/IndexShardRoutingTable.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/IndexShardRoutingTable.java
@@ -588,12 +588,12 @@ public class IndexShardRoutingTable {
             return true;
         }
 
-        public static IndexShardRoutingTable readFrom(StreamInput in) throws IOException {
+        public static IndexShardRoutingTable.Builder readFrom(StreamInput in) throws IOException {
             Index index = new Index(in);
             return readFromThin(in, index);
         }
 
-        public static IndexShardRoutingTable readFromThin(StreamInput in, Index index) throws IOException {
+        public static IndexShardRoutingTable.Builder readFromThin(StreamInput in, Index index) throws IOException {
             int iShardId = in.readVInt();
             ShardId shardId = new ShardId(index, iShardId);
             Builder builder = new Builder(shardId);
@@ -604,7 +604,7 @@ public class IndexShardRoutingTable {
                 builder.addShard(shard);
             }
 
-            return builder.build();
+            return builder;
         }
 
         public static void writeTo(IndexShardRoutingTable indexShard, StreamOutput out) throws IOException {

--- a/server/src/main/java/org/elasticsearch/cluster/routing/RoutingTable.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/RoutingTable.java
@@ -17,7 +17,6 @@ import org.elasticsearch.cluster.routing.RecoverySource.SnapshotRecoverySource;
 import org.elasticsearch.common.collect.ImmutableOpenMap;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
-import org.elasticsearch.common.util.iterable.Iterables;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.index.Index;
 import org.elasticsearch.index.IndexNotFoundException;
@@ -385,6 +384,31 @@ public class RoutingTable implements Iterable<IndexRoutingTable>, Diffable<Routi
         }
     }
 
+    public static RoutingTable of(long version, RoutingNodes routingNodes) {
+        Map<String, IndexRoutingTable.Builder> indexRoutingTableBuilders = new HashMap<>();
+        for (RoutingNode routingNode : routingNodes) {
+            for (ShardRouting shardRoutingEntry : routingNode) {
+                // every relocating shard has a double entry, ignore the target one.
+                if (shardRoutingEntry.initializing() && shardRoutingEntry.relocatingNodeId() != null) continue;
+                Builder.addShard(indexRoutingTableBuilders, shardRoutingEntry);
+            }
+        }
+
+        for (ShardRouting shardRoutingEntry : routingNodes.unassigned()) {
+            Builder.addShard(indexRoutingTableBuilders, shardRoutingEntry);
+        }
+        for (ShardRouting shardRoutingEntry : routingNodes.unassigned().ignored()) {
+            Builder.addShard(indexRoutingTableBuilders, shardRoutingEntry);
+        }
+
+        ImmutableOpenMap.Builder<String, IndexRoutingTable> indicesRouting = ImmutableOpenMap.builder(indexRoutingTableBuilders.size());
+        for (IndexRoutingTable.Builder indexBuilder : indexRoutingTableBuilders.values()) {
+            IndexRoutingTable indexRoutingTable = indexBuilder.build();
+            indicesRouting.put(indexRoutingTable.getIndex().getName(), indexRoutingTable);
+        }
+        return new RoutingTable(version, indicesRouting.build());
+    }
+
     public static Builder builder() {
         return new Builder();
     }
@@ -410,43 +434,13 @@ public class RoutingTable implements Iterable<IndexRoutingTable>, Diffable<Routi
             indicesRouting = ImmutableOpenMap.builder(routingTable.indicesRouting);
         }
 
-        public Builder updateNodes(long version, RoutingNodes routingNodes) {
-            // this is being called without pre initializing the routing table, so we must copy over the version as well
-            this.version = version;
-
-            Map<String, IndexRoutingTable.Builder> indexRoutingTableBuilders = new HashMap<>();
-            for (RoutingNode routingNode : routingNodes) {
-                for (ShardRouting shardRoutingEntry : routingNode) {
-                    // every relocating shard has a double entry, ignore the target one.
-                    if (shardRoutingEntry.initializing() && shardRoutingEntry.relocatingNodeId() != null) continue;
-
-                    addShard(indexRoutingTableBuilders, shardRoutingEntry);
-                }
-            }
-
-            Iterable<ShardRouting> shardRoutingEntries = Iterables.concat(routingNodes.unassigned(), routingNodes.unassigned().ignored());
-
-            for (ShardRouting shardRoutingEntry : shardRoutingEntries) {
-                addShard(indexRoutingTableBuilders, shardRoutingEntry);
-            }
-
-            for (IndexRoutingTable.Builder indexBuilder : indexRoutingTableBuilders.values()) {
-                add(indexBuilder);
-            }
-            return this;
-        }
-
         private static void addShard(
             final Map<String, IndexRoutingTable.Builder> indexRoutingTableBuilders,
             final ShardRouting shardRoutingEntry
         ) {
             Index index = shardRoutingEntry.index();
-            IndexRoutingTable.Builder indexBuilder = indexRoutingTableBuilders.get(index.getName());
-            if (indexBuilder == null) {
-                indexBuilder = new IndexRoutingTable.Builder(index);
-                indexRoutingTableBuilders.put(index.getName(), indexBuilder);
-            }
-            indexBuilder.addShard(shardRoutingEntry);
+            indexRoutingTableBuilders.computeIfAbsent(index.getName(), idxName -> new IndexRoutingTable.Builder(index))
+                .addShard(shardRoutingEntry);
         }
 
         /**

--- a/server/src/main/java/org/elasticsearch/cluster/routing/RoutingTable.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/RoutingTable.java
@@ -463,7 +463,7 @@ public class RoutingTable implements Iterable<IndexRoutingTable>, Diffable<Routi
                 int currentNumberOfReplicas = indexRoutingTable.shard(0).size() - 1; // remove the required primary
                 IndexRoutingTable.Builder builder = new IndexRoutingTable.Builder(indexRoutingTable.getIndex());
                 // re-add all the shards
-                builder.ensureShardArray(indexRoutingTable.size() - 1);
+                builder.ensureShardArray(indexRoutingTable.size());
                 for (int i = 0; i < indexRoutingTable.size(); i++) {
                     builder.addIndexShard(new IndexShardRoutingTable.Builder(indexRoutingTable.shard(i)));
                 }

--- a/server/src/main/java/org/elasticsearch/cluster/routing/RoutingTable.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/RoutingTable.java
@@ -464,7 +464,7 @@ public class RoutingTable implements Iterable<IndexRoutingTable>, Diffable<Routi
                 IndexRoutingTable.Builder builder = new IndexRoutingTable.Builder(indexRoutingTable.getIndex());
                 // re-add all the shards
                 for (int i = 0; i < indexRoutingTable.size(); i++) {
-                    builder.addIndexShard(indexRoutingTable.shard(i));
+                    builder.addIndexShard(new IndexShardRoutingTable.Builder(indexRoutingTable.shard(i)));
                 }
                 if (currentNumberOfReplicas < numberOfReplicas) {
                     // now, add "empty" ones

--- a/server/src/main/java/org/elasticsearch/cluster/routing/RoutingTable.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/RoutingTable.java
@@ -463,6 +463,7 @@ public class RoutingTable implements Iterable<IndexRoutingTable>, Diffable<Routi
                 int currentNumberOfReplicas = indexRoutingTable.shard(0).size() - 1; // remove the required primary
                 IndexRoutingTable.Builder builder = new IndexRoutingTable.Builder(indexRoutingTable.getIndex());
                 // re-add all the shards
+                builder.ensureShardArray(indexRoutingTable.size() - 1);
                 for (int i = 0; i < indexRoutingTable.size(); i++) {
                     builder.addIndexShard(new IndexShardRoutingTable.Builder(indexRoutingTable.shard(i)));
                 }

--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/AllocationService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/AllocationService.java
@@ -152,7 +152,7 @@ public class AllocationService {
     private static ClusterState buildResultAndLogHealthChange(ClusterState oldState, RoutingAllocation allocation, String reason) {
         final RoutingTable oldRoutingTable = oldState.routingTable();
         final RoutingNodes newRoutingNodes = allocation.routingNodes();
-        final RoutingTable newRoutingTable = new RoutingTable.Builder().updateNodes(oldRoutingTable.version(), newRoutingNodes).build();
+        final RoutingTable newRoutingTable = RoutingTable.of(oldRoutingTable.version(), newRoutingNodes);
         final Metadata newMetadata = allocation.updateMetadataWithRoutingChanges(newRoutingTable);
         assert newRoutingTable.validate(newMetadata); // validates the routing table is coherent with the cluster state metadata
 

--- a/server/src/main/java/org/elasticsearch/index/seqno/ReplicationTracker.java
+++ b/server/src/main/java/org/elasticsearch/index/seqno/ReplicationTracker.java
@@ -1570,7 +1570,7 @@ public class ReplicationTracker extends AbstractIndexShardComponent implements L
         public PrimaryContext(StreamInput in) throws IOException {
             clusterStateVersion = in.readVLong();
             checkpoints = in.readMap(StreamInput::readString, CheckpointState::new);
-            routingTable = IndexShardRoutingTable.Builder.readFrom(in);
+            routingTable = IndexShardRoutingTable.Builder.readFrom(in).build();
         }
 
         public long clusterStateVersion() {

--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/allocation/ClusterAllocationExplainActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/allocation/ClusterAllocationExplainActionTests.java
@@ -164,7 +164,7 @@ public class ClusterAllocationExplainActionTests extends ESTestCase {
                         shardBuilder.addShard(shardRouting);
                     }
                 }
-                indexBuilder.addIndexShard(shardBuilder.build());
+                indexBuilder.addIndexShard(shardBuilder);
             }
             routingTableBuilder.add(indexBuilder);
         }

--- a/server/src/test/java/org/elasticsearch/action/support/broadcast/node/TransportBroadcastByNodeActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/support/broadcast/node/TransportBroadcastByNodeActionTests.java
@@ -264,7 +264,7 @@ public class TransportBroadcastByNodeActionTests extends ESTestCase {
                 );
                 IndexShardRoutingTable.Builder indexShard = new IndexShardRoutingTable.Builder(shardId);
                 indexShard.addShard(shard);
-                indexRoutingTable.addIndexShard(indexShard.build());
+                indexRoutingTable.addIndexShard(indexShard);
             }
         }
         discoBuilder.localNodeId(newNode(0).getId());

--- a/server/src/test/java/org/elasticsearch/action/support/replication/TransportReplicationAllPermitsAcquisitionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/support/replication/TransportReplicationAllPermitsAcquisitionTests.java
@@ -155,7 +155,7 @@ public class TransportReplicationAllPermitsAcquisitionTests extends IndexShardTe
         recoverReplica(replica, primary, true);
 
         IndexRoutingTable.Builder routing = IndexRoutingTable.builder(indexMetadata.getIndex());
-        routing.addIndexShard(new IndexShardRoutingTable.Builder(shardId).addShard(primary.routingEntry()).build());
+        routing.addIndexShard(new IndexShardRoutingTable.Builder(shardId).addShard(primary.routingEntry()));
         state.routingTable(RoutingTable.builder().add(routing.build()).build());
 
         setState(clusterService, state.build());

--- a/server/src/test/java/org/elasticsearch/cluster/ClusterStateTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/ClusterStateTests.java
@@ -948,7 +948,7 @@ public class ClusterStateTests extends ESTestCase {
                                         true,
                                         ShardRoutingState.STARTED
                                     )
-                                ).build()
+                                )
                             )
                             .build()
                     )

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/MetadataIndexStateServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/MetadataIndexStateServiceTests.java
@@ -413,7 +413,7 @@ public class MetadataIndexStateServiceTests extends ESTestCase {
             for (int k = 0; k < indexMetadata.getNumberOfReplicas(); k++) {
                 indexShardRoutingBuilder.addShard(newShardRouting(shardId, randomAlphaOfLength(10), false, ShardRoutingState.STARTED));
             }
-            indexRoutingTable.addIndexShard(indexShardRoutingBuilder.build());
+            indexRoutingTable.addIndexShard(indexShardRoutingBuilder);
         }
         clusterStateBuilder.routingTable(RoutingTable.builder(currentState.routingTable()).add(indexRoutingTable).build());
 

--- a/server/src/test/java/org/elasticsearch/cluster/routing/RoutingTableGenerator.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/RoutingTableGenerator.java
@@ -62,7 +62,7 @@ public class RoutingTableGenerator {
 
     }
 
-    public IndexShardRoutingTable genShardRoutingTable(IndexMetadata indexMetadata, int shardId, ShardCounter counter) {
+    public IndexShardRoutingTable.Builder genShardRoutingTable(IndexMetadata indexMetadata, int shardId, ShardCounter counter) {
         final String index = indexMetadata.getIndex().getName();
         IndexShardRoutingTable.Builder builder = new IndexShardRoutingTable.Builder(new ShardId(index, "_na_", shardId));
         ShardRouting shardRouting = genShardRouting(index, shardId, true);
@@ -74,7 +74,7 @@ public class RoutingTableGenerator {
             builder.addShard(shardRouting);
         }
 
-        return builder.build();
+        return builder;
     }
 
     public IndexRoutingTable genIndexRoutingTable(IndexMetadata indexMetadata, ShardCounter counter) {

--- a/server/src/test/java/org/elasticsearch/cluster/routing/RoutingTableTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/RoutingTableTests.java
@@ -10,6 +10,7 @@ package org.elasticsearch.cluster.routing;
 
 import org.elasticsearch.Version;
 import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.Diff;
 import org.elasticsearch.cluster.ESAllocationTestCase;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.metadata.Metadata;
@@ -479,6 +480,15 @@ public class RoutingTableTests extends ESAllocationTestCase {
                 }
             }
         }
+    }
+
+    public void testRoutingNodesRoundtrip() {
+        final RoutingTable originalTable = clusterState.getRoutingTable();
+        final RoutingNodes routingNodes = clusterState.getRoutingNodes();
+        final RoutingTable fromNodes = RoutingTable.of(originalTable.version(), routingNodes);
+        // we don't have an equals implementation for the routing table so we assert equality by checking for a noop diff
+        final Diff<RoutingTable> routingTableDiff = fromNodes.diff(originalTable);
+        assertSame(originalTable, routingTableDiff.apply(originalTable));
     }
 
     /** reverse engineer the in sync aid based on the given indexRoutingTable **/

--- a/server/src/test/java/org/elasticsearch/cluster/routing/UnassignedInfoTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/UnassignedInfoTests.java
@@ -285,7 +285,7 @@ public class UnassignedInfoTests extends ESAllocationTestCase {
         IndexRoutingTable.Builder builder = IndexRoutingTable.builder(index);
         final IndexRoutingTable indexRoutingTable = clusterState.routingTable().index(index);
         for (int i = 0; i < indexRoutingTable.size(); i++) {
-            builder.addIndexShard(indexRoutingTable.shard(i));
+            builder.addIndexShard(new IndexShardRoutingTable.Builder(indexRoutingTable.shard(i)));
         }
         builder.addReplica();
         clusterState = ClusterState.builder(clusterState)

--- a/server/src/test/java/org/elasticsearch/cluster/routing/allocation/CatAllocationTestCase.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/allocation/CatAllocationTestCase.java
@@ -116,7 +116,7 @@ public abstract class CatAllocationTestCase extends ESAllocationTestCase {
                 shardIdToRouting.put(r.getId(), refData);
             }
             for (IndexShardRoutingTable t : shardIdToRouting.values()) {
-                tableBuilder.addIndexShard(t);
+                tableBuilder.addIndexShard(new IndexShardRoutingTable.Builder(t));
             }
             IndexRoutingTable table = tableBuilder.build();
             routingTableBuilder.add(table);

--- a/server/src/test/java/org/elasticsearch/cluster/routing/allocation/NodeVersionAllocationDeciderTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/allocation/NodeVersionAllocationDeciderTests.java
@@ -373,7 +373,6 @@ public class NodeVersionAllocationDeciderTests extends ESAllocationTestCase {
                                     allocationId1R
                                 )
                             )
-                            .build()
                     )
             )
             .add(
@@ -401,7 +400,6 @@ public class NodeVersionAllocationDeciderTests extends ESAllocationTestCase {
                                     allocationId2R
                                 )
                             )
-                            .build()
                     )
             )
             .build();

--- a/server/src/test/java/org/elasticsearch/cluster/routing/allocation/StartedShardsRoutingTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/allocation/StartedShardsRoutingTests.java
@@ -69,8 +69,8 @@ public class StartedShardsRoutingTests extends ESAllocationTestCase {
             RoutingTable.builder()
                 .add(
                     IndexRoutingTable.builder(index)
-                        .addIndexShard(new IndexShardRoutingTable.Builder(initShard.shardId()).addShard(initShard))
-                        .addIndexShard(new IndexShardRoutingTable.Builder(relocatingShard.shardId()).addShard(relocatingShard))
+                        .addIndexShard(IndexShardRoutingTable.builder(initShard.shardId()).addShard(initShard))
+                        .addIndexShard(IndexShardRoutingTable.builder(relocatingShard.shardId()).addShard(relocatingShard))
                 )
                 .build()
         );

--- a/server/src/test/java/org/elasticsearch/cluster/routing/allocation/StartedShardsRoutingTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/allocation/StartedShardsRoutingTests.java
@@ -69,8 +69,8 @@ public class StartedShardsRoutingTests extends ESAllocationTestCase {
             RoutingTable.builder()
                 .add(
                     IndexRoutingTable.builder(index)
-                        .addIndexShard(new IndexShardRoutingTable.Builder(initShard.shardId()).addShard(initShard).build())
-                        .addIndexShard(new IndexShardRoutingTable.Builder(relocatingShard.shardId()).addShard(relocatingShard).build())
+                        .addIndexShard(new IndexShardRoutingTable.Builder(initShard.shardId()).addShard(initShard))
+                        .addIndexShard(new IndexShardRoutingTable.Builder(relocatingShard.shardId()).addShard(relocatingShard))
                 )
                 .build()
         );
@@ -147,9 +147,7 @@ public class StartedShardsRoutingTests extends ESAllocationTestCase {
                 .add(
                     IndexRoutingTable.builder(index)
                         .addIndexShard(
-                            new IndexShardRoutingTable.Builder(relocatingPrimary.shardId()).addShard(relocatingPrimary)
-                                .addShard(replica)
-                                .build()
+                            new IndexShardRoutingTable.Builder(relocatingPrimary.shardId()).addShard(relocatingPrimary).addShard(replica)
                         )
                 )
                 .build()

--- a/server/src/test/java/org/elasticsearch/cluster/routing/allocation/decider/DiskThresholdDeciderTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/allocation/decider/DiskThresholdDeciderTests.java
@@ -923,8 +923,8 @@ public class DiskThresholdDeciderTests extends ESAllocationTestCase {
         RoutingTable.Builder builder = RoutingTable.builder()
             .add(
                 IndexRoutingTable.builder(firstRouting.index())
-                    .addIndexShard(new IndexShardRoutingTable.Builder(firstRouting.shardId()).addShard(firstRouting).build())
-                    .addIndexShard(new IndexShardRoutingTable.Builder(secondRouting.shardId()).addShard(secondRouting).build())
+                    .addIndexShard(new IndexShardRoutingTable.Builder(firstRouting.shardId()).addShard(firstRouting))
+                    .addIndexShard(new IndexShardRoutingTable.Builder(secondRouting.shardId()).addShard(secondRouting))
             );
         ClusterState clusterState = ClusterState.builder(baseClusterState).routingTable(builder.build()).build();
         RoutingAllocation routingAllocation = new RoutingAllocation(
@@ -955,8 +955,8 @@ public class DiskThresholdDeciderTests extends ESAllocationTestCase {
         builder = RoutingTable.builder()
             .add(
                 IndexRoutingTable.builder(firstRouting.index())
-                    .addIndexShard(new IndexShardRoutingTable.Builder(firstRouting.shardId()).addShard(firstRouting).build())
-                    .addIndexShard(new IndexShardRoutingTable.Builder(secondRouting.shardId()).addShard(secondRouting).build())
+                    .addIndexShard(new IndexShardRoutingTable.Builder(firstRouting.shardId()).addShard(firstRouting))
+                    .addIndexShard(new IndexShardRoutingTable.Builder(secondRouting.shardId()).addShard(secondRouting))
             );
         clusterState = ClusterState.builder(baseClusterState).routingTable(builder.build()).build();
         routingAllocation = new RoutingAllocation(
@@ -1115,7 +1115,7 @@ public class DiskThresholdDeciderTests extends ESAllocationTestCase {
         RoutingTable forceAssignedRoutingTable = RoutingTable.builder()
             .add(
                 IndexRoutingTable.builder(shardId.getIndex())
-                    .addIndexShard(new IndexShardRoutingTable.Builder(shardId).addShard(startedShard).build())
+                    .addIndexShard(new IndexShardRoutingTable.Builder(shardId).addShard(startedShard))
             )
             .build();
         clusterState = ClusterState.builder(clusterState).routingTable(forceAssignedRoutingTable).build();

--- a/server/src/test/java/org/elasticsearch/cluster/routing/allocation/decider/DiskThresholdDeciderTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/allocation/decider/DiskThresholdDeciderTests.java
@@ -923,8 +923,8 @@ public class DiskThresholdDeciderTests extends ESAllocationTestCase {
         RoutingTable.Builder builder = RoutingTable.builder()
             .add(
                 IndexRoutingTable.builder(firstRouting.index())
-                    .addIndexShard(new IndexShardRoutingTable.Builder(firstRouting.shardId()).addShard(firstRouting))
-                    .addIndexShard(new IndexShardRoutingTable.Builder(secondRouting.shardId()).addShard(secondRouting))
+                    .addIndexShard(IndexShardRoutingTable.builder(firstRouting.shardId()).addShard(firstRouting))
+                    .addIndexShard(IndexShardRoutingTable.builder(secondRouting.shardId()).addShard(secondRouting))
             );
         ClusterState clusterState = ClusterState.builder(baseClusterState).routingTable(builder.build()).build();
         RoutingAllocation routingAllocation = new RoutingAllocation(

--- a/server/src/test/java/org/elasticsearch/gateway/PrimaryShardAllocatorTests.java
+++ b/server/src/test/java/org/elasticsearch/gateway/PrimaryShardAllocatorTests.java
@@ -533,7 +533,7 @@ public class PrimaryShardAllocatorTests extends ESAllocationTestCase {
     private void assertClusterHealthStatus(RoutingAllocation allocation, ClusterHealthStatus expectedStatus) {
         RoutingTable oldRoutingTable = allocation.routingTable();
         RoutingNodes newRoutingNodes = allocation.routingNodes();
-        final RoutingTable newRoutingTable = new RoutingTable.Builder().updateNodes(oldRoutingTable.version(), newRoutingNodes).build();
+        final RoutingTable newRoutingTable = RoutingTable.of(oldRoutingTable.version(), newRoutingNodes);
         ClusterState clusterState = ClusterState.builder(new ClusterName("test-cluster")).routingTable(newRoutingTable).build();
         ClusterStateHealth clusterStateHealth = new ClusterStateHealth(clusterState);
         assertThat(clusterStateHealth.getStatus().ordinal(), lessThanOrEqualTo(expectedStatus.ordinal()));

--- a/server/src/test/java/org/elasticsearch/gateway/ReplicaShardAllocatorTests.java
+++ b/server/src/test/java/org/elasticsearch/gateway/ReplicaShardAllocatorTests.java
@@ -566,7 +566,6 @@ public class ReplicaShardAllocatorTests extends ESAllocationTestCase {
                                     )
                                 )
                             )
-                            .build()
                     )
             )
             .build();
@@ -611,7 +610,6 @@ public class ReplicaShardAllocatorTests extends ESAllocationTestCase {
                                     unassignedInfo
                                 )
                             )
-                            .build()
                     )
             )
             .build();

--- a/server/src/test/java/org/elasticsearch/indices/SystemIndexManagerTests.java
+++ b/server/src/test/java/org/elasticsearch/indices/SystemIndexManagerTests.java
@@ -324,7 +324,7 @@ public class SystemIndexManagerTests extends ESTestCase {
                             )
                                 .initialize(UUIDs.randomBase64UUID(random()), null, 0L)
                                 .moveToUnassigned(new UnassignedInfo(UnassignedInfo.Reason.ALLOCATION_FAILED, ""))
-                        ).build()
+                        )
                     )
             )
             .build();
@@ -382,10 +382,17 @@ public class SystemIndexManagerTests extends ESTestCase {
             new UnassignedInfo(UnassignedInfo.Reason.INDEX_CREATED, "")
         );
         String nodeId = ESTestCase.randomAlphaOfLength(8);
-        IndexShardRoutingTable table = new IndexShardRoutingTable.Builder(new ShardId(index, 0)).addShard(
-            shardRouting.initialize(nodeId, null, shardRouting.getExpectedShardSize()).moveToStarted()
-        ).build();
-        return RoutingTable.builder().add(IndexRoutingTable.builder(index).addIndexShard(table).build()).build();
+        return RoutingTable.builder()
+            .add(
+                IndexRoutingTable.builder(index)
+                    .addIndexShard(
+                        new IndexShardRoutingTable.Builder(new ShardId(index, 0)).addShard(
+                            shardRouting.initialize(nodeId, null, shardRouting.getExpectedShardSize()).moveToStarted()
+                        )
+                    )
+                    .build()
+            )
+            .build();
     }
 
     private ClusterChangedEvent event(ClusterState clusterState) {

--- a/server/src/test/java/org/elasticsearch/indices/SystemIndexManagerTests.java
+++ b/server/src/test/java/org/elasticsearch/indices/SystemIndexManagerTests.java
@@ -315,16 +315,17 @@ public class SystemIndexManagerTests extends ESTestCase {
             .add(
                 IndexRoutingTable.builder(prevIndex)
                     .addIndexShard(
-                        new IndexShardRoutingTable.Builder(new ShardId(prevIndex, 0)).addShard(
-                            ShardRouting.newUnassigned(
-                                new ShardId(prevIndex, 0),
-                                true,
-                                RecoverySource.ExistingStoreRecoverySource.INSTANCE,
-                                new UnassignedInfo(UnassignedInfo.Reason.INDEX_CREATED, "")
+                        IndexShardRoutingTable.builder(new ShardId(prevIndex, 0))
+                            .addShard(
+                                ShardRouting.newUnassigned(
+                                    new ShardId(prevIndex, 0),
+                                    true,
+                                    RecoverySource.ExistingStoreRecoverySource.INSTANCE,
+                                    new UnassignedInfo(UnassignedInfo.Reason.INDEX_CREATED, "")
+                                )
+                                    .initialize(UUIDs.randomBase64UUID(random()), null, 0L)
+                                    .moveToUnassigned(new UnassignedInfo(UnassignedInfo.Reason.ALLOCATION_FAILED, ""))
                             )
-                                .initialize(UUIDs.randomBase64UUID(random()), null, 0L)
-                                .moveToUnassigned(new UnassignedInfo(UnassignedInfo.Reason.ALLOCATION_FAILED, ""))
-                        )
                     )
             )
             .build();
@@ -386,9 +387,8 @@ public class SystemIndexManagerTests extends ESTestCase {
             .add(
                 IndexRoutingTable.builder(index)
                     .addIndexShard(
-                        new IndexShardRoutingTable.Builder(new ShardId(index, 0)).addShard(
-                            shardRouting.initialize(nodeId, null, shardRouting.getExpectedShardSize()).moveToStarted()
-                        )
+                        IndexShardRoutingTable.builder(new ShardId(index, 0))
+                            .addShard(shardRouting.initialize(nodeId, null, shardRouting.getExpectedShardSize()).moveToStarted())
                     )
                     .build()
             )

--- a/server/src/test/java/org/elasticsearch/snapshots/SnapshotsServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/snapshots/SnapshotsServiceTests.java
@@ -228,9 +228,10 @@ public class SnapshotsServiceTests extends ESTestCase {
                     .add(
                         IndexRoutingTable.builder(routingShardId1.getIndex())
                             .addIndexShard(
-                                new IndexShardRoutingTable.Builder(routingShardId1).addShard(
-                                    TestShardRouting.newShardRouting(routingShardId1, dataNodeId, true, ShardRoutingState.STARTED)
-                                )
+                                IndexShardRoutingTable.builder(routingShardId1)
+                                    .addShard(
+                                        TestShardRouting.newShardRouting(routingShardId1, dataNodeId, true, ShardRoutingState.STARTED)
+                                    )
                             )
                     )
                     .build()
@@ -256,9 +257,10 @@ public class SnapshotsServiceTests extends ESTestCase {
                     .add(
                         IndexRoutingTable.builder(routingShardId1.getIndex())
                             .addIndexShard(
-                                new IndexShardRoutingTable.Builder(routingShardId1).addShard(
-                                    TestShardRouting.newShardRouting(routingShardId1, dataNodeId, true, ShardRoutingState.INITIALIZING)
-                                )
+                                IndexShardRoutingTable.builder(routingShardId1)
+                                    .addShard(
+                                        TestShardRouting.newShardRouting(routingShardId1, dataNodeId, true, ShardRoutingState.INITIALIZING)
+                                    )
                             )
                     )
                     .build()
@@ -481,7 +483,7 @@ public class SnapshotsServiceTests extends ESTestCase {
         final RoutingTable.Builder routingTable = RoutingTable.builder();
         for (String index : indexNames) {
             final Index idx = metaBuilder.get(index).getIndex();
-            routingTable.add(IndexRoutingTable.builder(idx).addIndexShard(new IndexShardRoutingTable.Builder(new ShardId(idx, 0))));
+            routingTable.add(IndexRoutingTable.builder(idx).addIndexShard(IndexShardRoutingTable.builder(new ShardId(idx, 0))));
         }
         return ClusterState.builder(ClusterState.EMPTY_STATE).metadata(metaBuilder).routingTable(routingTable.build()).build();
     }

--- a/server/src/test/java/org/elasticsearch/snapshots/SnapshotsServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/snapshots/SnapshotsServiceTests.java
@@ -230,7 +230,7 @@ public class SnapshotsServiceTests extends ESTestCase {
                             .addIndexShard(
                                 new IndexShardRoutingTable.Builder(routingShardId1).addShard(
                                     TestShardRouting.newShardRouting(routingShardId1, dataNodeId, true, ShardRoutingState.STARTED)
-                                ).build()
+                                )
                             )
                     )
                     .build()
@@ -258,7 +258,7 @@ public class SnapshotsServiceTests extends ESTestCase {
                             .addIndexShard(
                                 new IndexShardRoutingTable.Builder(routingShardId1).addShard(
                                     TestShardRouting.newShardRouting(routingShardId1, dataNodeId, true, ShardRoutingState.INITIALIZING)
-                                ).build()
+                                )
                             )
                     )
                     .build()
@@ -481,7 +481,7 @@ public class SnapshotsServiceTests extends ESTestCase {
         final RoutingTable.Builder routingTable = RoutingTable.builder();
         for (String index : indexNames) {
             final Index idx = metaBuilder.get(index).getIndex();
-            routingTable.add(IndexRoutingTable.builder(idx).addIndexShard(new IndexShardRoutingTable.Builder(new ShardId(idx, 0)).build()));
+            routingTable.add(IndexRoutingTable.builder(idx).addIndexShard(new IndexShardRoutingTable.Builder(new ShardId(idx, 0))));
         }
         return ClusterState.builder(ClusterState.EMPTY_STATE).metadata(metaBuilder).routingTable(routingTable.build()).build();
     }

--- a/test/framework/src/main/java/org/elasticsearch/action/support/replication/ClusterStateCreationUtils.java
+++ b/test/framework/src/main/java/org/elasticsearch/action/support/replication/ClusterStateCreationUtils.java
@@ -162,7 +162,7 @@ public class ClusterStateCreationUtils {
         state.nodes(discoBuilder);
         state.metadata(Metadata.builder().put(indexMetadataBuilder.build(), false).generateClusterUuidIfNeeded());
         state.routingTable(
-            RoutingTable.builder().add(IndexRoutingTable.builder(indexMetadata.getIndex()).addIndexShard(indexShardRoutingTable)).build()
+            RoutingTable.builder().add(IndexRoutingTable.builder(indexMetadata.getIndex()).addIndexShard(indexShardRoutingBuilder)).build()
         );
         return state.build();
     }
@@ -198,7 +198,7 @@ public class ClusterStateCreationUtils {
             indexShardRoutingBuilder.addShard(
                 TestShardRouting.newShardRouting(shardId, randomFrom(nodes), true, ShardRoutingState.STARTED)
             );
-            indexRoutingTable.addIndexShard(indexShardRoutingBuilder.build());
+            indexRoutingTable.addIndexShard(indexShardRoutingBuilder);
         }
 
         ClusterState.Builder state = ClusterState.builder(new ClusterName("test"));
@@ -248,7 +248,7 @@ public class ClusterStateCreationUtils {
                 if (currentNodeToAssign == nodesList.size()) {
                     currentNodeToAssign = 0;
                 }
-                indexRoutingTable.addIndexShard(indexShardRoutingBuilder.build());
+                indexRoutingTable.addIndexShard(indexShardRoutingBuilder);
             }
 
             metadata.put(indexMetadata, false);
@@ -296,7 +296,7 @@ public class ClusterStateCreationUtils {
             indexShardRoutingBuilder.addShard(
                 TestShardRouting.newShardRouting(index, i, newNode(1).getId(), null, false, ShardRoutingState.STARTED)
             );
-            indexRoutingTableBuilder.addIndexShard(indexShardRoutingBuilder.build());
+            indexRoutingTableBuilder.addIndexShard(indexShardRoutingBuilder);
         }
         state.routingTable(RoutingTable.builder().add(indexRoutingTableBuilder.build()).build());
         return state.build();
@@ -348,7 +348,7 @@ public class ClusterStateCreationUtils {
                         TestShardRouting.newShardRouting(index, i, newNode(replica + 1).getId(), null, false, ShardRoutingState.STARTED)
                     );
                 }
-                indexRoutingTableBuilder.addIndexShard(indexShardRoutingBuilder.build());
+                indexRoutingTableBuilder.addIndexShard(indexShardRoutingBuilder);
             }
             routingTableBuilder.add(indexRoutingTableBuilder.build());
         }

--- a/test/framework/src/main/java/org/elasticsearch/action/support/replication/ClusterStateCreationUtils.java
+++ b/test/framework/src/main/java/org/elasticsearch/action/support/replication/ClusterStateCreationUtils.java
@@ -194,7 +194,7 @@ public class ClusterStateCreationUtils {
         IndexRoutingTable.Builder indexRoutingTable = IndexRoutingTable.builder(indexMetadata.getIndex());
         for (int i = 0; i < numberOfPrimaries; i++) {
             ShardId shardId = new ShardId(indexMetadata.getIndex(), i);
-            IndexShardRoutingTable.Builder indexShardRoutingBuilder = new IndexShardRoutingTable.Builder(shardId);
+            IndexShardRoutingTable.Builder indexShardRoutingBuilder = IndexShardRoutingTable.builder(shardId);
             indexShardRoutingBuilder.addShard(
                 TestShardRouting.newShardRouting(shardId, randomFrom(nodes), true, ShardRoutingState.STARTED)
             );
@@ -241,7 +241,7 @@ public class ClusterStateCreationUtils {
             IndexRoutingTable.Builder indexRoutingTable = IndexRoutingTable.builder(indexMetadata.getIndex());
             for (int i = 0; i < numberOfPrimaries; i++) {
                 ShardId shardId = new ShardId(indexMetadata.getIndex(), i);
-                IndexShardRoutingTable.Builder indexShardRoutingBuilder = new IndexShardRoutingTable.Builder(shardId);
+                IndexShardRoutingTable.Builder indexShardRoutingBuilder = IndexShardRoutingTable.builder(shardId);
                 indexShardRoutingBuilder.addShard(
                     TestShardRouting.newShardRouting(shardId, nodesList.get(currentNodeToAssign++), true, ShardRoutingState.STARTED)
                 );
@@ -289,7 +289,7 @@ public class ClusterStateCreationUtils {
         IndexRoutingTable.Builder indexRoutingTableBuilder = IndexRoutingTable.builder(indexMetadata.getIndex());
         for (int i = 0; i < numberOfShards; i++) {
             final ShardId shardId = new ShardId(index, "_na_", i);
-            IndexShardRoutingTable.Builder indexShardRoutingBuilder = new IndexShardRoutingTable.Builder(shardId);
+            IndexShardRoutingTable.Builder indexShardRoutingBuilder = IndexShardRoutingTable.builder(shardId);
             indexShardRoutingBuilder.addShard(
                 TestShardRouting.newShardRouting(index, i, newNode(0).getId(), null, true, ShardRoutingState.STARTED)
             );
@@ -339,7 +339,7 @@ public class ClusterStateCreationUtils {
             IndexRoutingTable.Builder indexRoutingTableBuilder = IndexRoutingTable.builder(indexMetadata.getIndex());
             for (int i = 0; i < numberOfShards; i++) {
                 final ShardId shardId = new ShardId(index, "_na_", i);
-                IndexShardRoutingTable.Builder indexShardRoutingBuilder = new IndexShardRoutingTable.Builder(shardId);
+                IndexShardRoutingTable.Builder indexShardRoutingBuilder = IndexShardRoutingTable.builder(shardId);
                 indexShardRoutingBuilder.addShard(
                     TestShardRouting.newShardRouting(index, i, newNode(0).getId(), null, true, ShardRoutingState.STARTED)
                 );

--- a/x-pack/plugin/autoscaling/src/test/java/org/elasticsearch/xpack/autoscaling/storage/ReactiveStorageDeciderServiceTests.java
+++ b/x-pack/plugin/autoscaling/src/test/java/org/elasticsearch/xpack/autoscaling/storage/ReactiveStorageDeciderServiceTests.java
@@ -655,7 +655,7 @@ public class ReactiveStorageDeciderServiceTests extends AutoscalingTestCase {
         }
         final RoutingTable oldRoutingTable = oldState.routingTable();
         final RoutingNodes newRoutingNodes = allocation.routingNodes();
-        final RoutingTable newRoutingTable = new RoutingTable.Builder().updateNodes(oldRoutingTable.version(), newRoutingNodes).build();
+        final RoutingTable newRoutingTable = RoutingTable.of(oldRoutingTable.version(), newRoutingNodes);
         final Metadata newMetadata = allocation.updateMetadataWithRoutingChanges(newRoutingTable);
         assert newRoutingTable.validate(newMetadata); // validates the routing table is coherent with the cluster state metadata
 

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/DataTiersUsageTransportActionTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/DataTiersUsageTransportActionTests.java
@@ -749,7 +749,7 @@ public class DataTiersUsageTransportActionTests extends ESTestCase {
             );
             primary = false;
         }
-        indexRoutingTableBuilder.addIndexShard(indexShardRoutingBuilder.build());
+        indexRoutingTableBuilder.addIndexShard(indexShardRoutingBuilder);
     }
 
     private List<NodeStats> buildNodeStats(ClusterState clusterState, long bytesPerShard, long docsPerShard) {

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/MlConfigMigrationEligibilityCheckTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/MlConfigMigrationEligibilityCheckTests.java
@@ -135,7 +135,7 @@ public class MlConfigMigrationEligibilityCheckTests extends ESTestCase {
         shardRouting = shardRouting.initialize("node_id", null, 0L);
         shardRouting = shardRouting.moveToStarted();
         routingTable.add(
-            IndexRoutingTable.builder(index).addIndexShard(new IndexShardRoutingTable.Builder(shardId).addShard(shardRouting).build())
+            IndexRoutingTable.builder(index).addIndexShard(new IndexShardRoutingTable.Builder(shardId).addShard(shardRouting))
         );
     }
 

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/MlConfigMigrationEligibilityCheckTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/MlConfigMigrationEligibilityCheckTests.java
@@ -134,9 +134,7 @@ public class MlConfigMigrationEligibilityCheckTests extends ESTestCase {
         );
         shardRouting = shardRouting.initialize("node_id", null, 0L);
         shardRouting = shardRouting.moveToStarted();
-        routingTable.add(
-            IndexRoutingTable.builder(index).addIndexShard(new IndexShardRoutingTable.Builder(shardId).addShard(shardRouting))
-        );
+        routingTable.add(IndexRoutingTable.builder(index).addIndexShard(IndexShardRoutingTable.builder(shardId).addShard(shardRouting)));
     }
 
     private void givenClusterSettings(Settings settings) {

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/datafeed/DatafeedConfigAutoUpdaterTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/datafeed/DatafeedConfigAutoUpdaterTests.java
@@ -181,9 +181,7 @@ public class DatafeedConfigAutoUpdaterTests extends ESTestCase {
         );
         shardRouting = shardRouting.initialize("node_id", null, 0L);
         shardRouting = shardRouting.moveToStarted();
-        routingTable.add(
-            IndexRoutingTable.builder(index).addIndexShard(new IndexShardRoutingTable.Builder(shardId).addShard(shardRouting))
-        );
+        routingTable.add(IndexRoutingTable.builder(index).addIndexShard(IndexShardRoutingTable.builder(shardId).addShard(shardRouting)));
 
         ClusterState.Builder csBuilder = ClusterState.builder(new ClusterName("_name"));
         csBuilder.routingTable(routingTable.build());
@@ -208,7 +206,7 @@ public class DatafeedConfigAutoUpdaterTests extends ESTestCase {
             );
             shardRouting = shardRouting.initialize("node_id", null, 0L);
             routingTable.add(
-                IndexRoutingTable.builder(index).addIndexShard(new IndexShardRoutingTable.Builder(shardId).addShard(shardRouting))
+                IndexRoutingTable.builder(index).addIndexShard(IndexShardRoutingTable.builder(shardId).addShard(shardRouting))
             );
         }
 

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/datafeed/DatafeedConfigAutoUpdaterTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/datafeed/DatafeedConfigAutoUpdaterTests.java
@@ -182,7 +182,7 @@ public class DatafeedConfigAutoUpdaterTests extends ESTestCase {
         shardRouting = shardRouting.initialize("node_id", null, 0L);
         shardRouting = shardRouting.moveToStarted();
         routingTable.add(
-            IndexRoutingTable.builder(index).addIndexShard(new IndexShardRoutingTable.Builder(shardId).addShard(shardRouting).build())
+            IndexRoutingTable.builder(index).addIndexShard(new IndexShardRoutingTable.Builder(shardId).addShard(shardRouting))
         );
 
         ClusterState.Builder csBuilder = ClusterState.builder(new ClusterName("_name"));
@@ -208,7 +208,7 @@ public class DatafeedConfigAutoUpdaterTests extends ESTestCase {
             );
             shardRouting = shardRouting.initialize("node_id", null, 0L);
             routingTable.add(
-                IndexRoutingTable.builder(index).addIndexShard(new IndexShardRoutingTable.Builder(shardId).addShard(shardRouting).build())
+                IndexRoutingTable.builder(index).addIndexShard(new IndexShardRoutingTable.Builder(shardId).addShard(shardRouting))
             );
         }
 

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/datafeed/DatafeedNodeSelectorTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/datafeed/DatafeedNodeSelectorTests.java
@@ -727,7 +727,7 @@ public class DatafeedNodeSelectorTests extends ESTestCase {
             }
 
             shardRTBuilder.addShard(shardRouting);
-            rtBuilder.addIndexShard(shardRTBuilder.build());
+            rtBuilder.addIndexShard(shardRTBuilder);
             counter += 1;
         }
 

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/TrainedModelStatsServiceTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/TrainedModelStatsServiceTests.java
@@ -127,7 +127,7 @@ public class TrainedModelStatsServiceTests extends ESTestCase {
                 );
                 shardRouting = shardRouting.initialize("node_id", null, 0L);
                 routingTable.add(
-                    IndexRoutingTable.builder(index).addIndexShard(new IndexShardRoutingTable.Builder(shardId).addShard(shardRouting))
+                    IndexRoutingTable.builder(index).addIndexShard(IndexShardRoutingTable.builder(shardId).addShard(shardRouting))
                 );
             }
 
@@ -348,8 +348,6 @@ public class TrainedModelStatsServiceTests extends ESTestCase {
         );
         shardRouting = shardRouting.initialize("node_id", null, 0L);
         shardRouting = shardRouting.moveToStarted();
-        routingTable.add(
-            IndexRoutingTable.builder(index).addIndexShard(new IndexShardRoutingTable.Builder(shardId).addShard(shardRouting))
-        );
+        routingTable.add(IndexRoutingTable.builder(index).addIndexShard(IndexShardRoutingTable.builder(shardId).addShard(shardRouting)));
     }
 }

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/TrainedModelStatsServiceTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/TrainedModelStatsServiceTests.java
@@ -127,8 +127,7 @@ public class TrainedModelStatsServiceTests extends ESTestCase {
                 );
                 shardRouting = shardRouting.initialize("node_id", null, 0L);
                 routingTable.add(
-                    IndexRoutingTable.builder(index)
-                        .addIndexShard(new IndexShardRoutingTable.Builder(shardId).addShard(shardRouting).build())
+                    IndexRoutingTable.builder(index).addIndexShard(new IndexShardRoutingTable.Builder(shardId).addShard(shardRouting))
                 );
             }
 
@@ -350,7 +349,7 @@ public class TrainedModelStatsServiceTests extends ESTestCase {
         shardRouting = shardRouting.initialize("node_id", null, 0L);
         shardRouting = shardRouting.moveToStarted();
         routingTable.add(
-            IndexRoutingTable.builder(index).addIndexShard(new IndexShardRoutingTable.Builder(shardId).addShard(shardRouting).build())
+            IndexRoutingTable.builder(index).addIndexShard(new IndexShardRoutingTable.Builder(shardId).addShard(shardRouting))
         );
     }
 }

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/task/OpenJobPersistentTasksExecutorTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/task/OpenJobPersistentTasksExecutorTests.java
@@ -264,7 +264,7 @@ public class OpenJobPersistentTasksExecutorTests extends ESTestCase {
             shardRouting = shardRouting.initialize("node_id", null, 0L);
             shardRouting = shardRouting.moveToStarted();
             routingTable.add(
-                IndexRoutingTable.builder(index).addIndexShard(new IndexShardRoutingTable.Builder(shardId).addShard(shardRouting).build())
+                IndexRoutingTable.builder(index).addIndexShard(new IndexShardRoutingTable.Builder(shardId).addShard(shardRouting))
             );
         }
     }

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/task/OpenJobPersistentTasksExecutorTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/task/OpenJobPersistentTasksExecutorTests.java
@@ -264,7 +264,7 @@ public class OpenJobPersistentTasksExecutorTests extends ESTestCase {
             shardRouting = shardRouting.initialize("node_id", null, 0L);
             shardRouting = shardRouting.moveToStarted();
             routingTable.add(
-                IndexRoutingTable.builder(index).addIndexShard(new IndexShardRoutingTable.Builder(shardId).addShard(shardRouting))
+                IndexRoutingTable.builder(index).addIndexShard(IndexShardRoutingTable.builder(shardId).addShard(shardRouting))
             );
         }
     }

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/task/AbstractJobPersistentTasksExecutorTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/task/AbstractJobPersistentTasksExecutorTests.java
@@ -88,7 +88,7 @@ public class AbstractJobPersistentTasksExecutorTests extends ESTestCase {
             );
             shardRouting = shardRouting.initialize("node_id", null, 0L);
             routingTable.add(
-                IndexRoutingTable.builder(index).addIndexShard(new IndexShardRoutingTable.Builder(shardId).addShard(shardRouting).build())
+                IndexRoutingTable.builder(index).addIndexShard(new IndexShardRoutingTable.Builder(shardId).addShard(shardRouting))
             );
         }
 
@@ -138,7 +138,7 @@ public class AbstractJobPersistentTasksExecutorTests extends ESTestCase {
             shardRouting = shardRouting.initialize("node_id", null, 0L);
             shardRouting = shardRouting.moveToStarted();
             routingTable.add(
-                IndexRoutingTable.builder(index).addIndexShard(new IndexShardRoutingTable.Builder(shardId).addShard(shardRouting).build())
+                IndexRoutingTable.builder(index).addIndexShard(new IndexShardRoutingTable.Builder(shardId).addShard(shardRouting))
             );
         }
     }

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/task/AbstractJobPersistentTasksExecutorTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/task/AbstractJobPersistentTasksExecutorTests.java
@@ -88,7 +88,7 @@ public class AbstractJobPersistentTasksExecutorTests extends ESTestCase {
             );
             shardRouting = shardRouting.initialize("node_id", null, 0L);
             routingTable.add(
-                IndexRoutingTable.builder(index).addIndexShard(new IndexShardRoutingTable.Builder(shardId).addShard(shardRouting))
+                IndexRoutingTable.builder(index).addIndexShard(IndexShardRoutingTable.builder(shardId).addShard(shardRouting))
             );
         }
 

--- a/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/collector/indices/IndexStatsMonitoringDocTests.java
+++ b/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/collector/indices/IndexStatsMonitoringDocTests.java
@@ -527,7 +527,7 @@ public class IndexStatsMonitoringDocTests extends BaseFilteredMonitoringDocTestC
                 }
             }
 
-            builder.addIndexShard(shard.build());
+            builder.addIndexShard(shard);
         }
 
         // sanity checks

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authz/store/NativeRolesStoreTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authz/store/NativeRolesStoreTests.java
@@ -304,9 +304,10 @@ public class NativeRolesStoreTests extends ESTestCase {
             .add(
                 IndexRoutingTable.builder(index)
                     .addIndexShard(
-                        new IndexShardRoutingTable.Builder(new ShardId(index, 0)).addShard(
-                            shardRouting.initialize(randomAlphaOfLength(8), null, shardRouting.getExpectedShardSize()).moveToStarted()
-                        )
+                        IndexShardRoutingTable.builder(new ShardId(index, 0))
+                            .addShard(
+                                shardRouting.initialize(randomAlphaOfLength(8), null, shardRouting.getExpectedShardSize()).moveToStarted()
+                            )
                     )
                     .build()
             )

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authz/store/NativeRolesStoreTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authz/store/NativeRolesStoreTests.java
@@ -300,10 +300,17 @@ public class NativeRolesStoreTests extends ESTestCase {
             RecoverySource.ExistingStoreRecoverySource.INSTANCE,
             new UnassignedInfo(Reason.INDEX_CREATED, "")
         );
-        IndexShardRoutingTable table = new IndexShardRoutingTable.Builder(new ShardId(index, 0)).addShard(
-            shardRouting.initialize(randomAlphaOfLength(8), null, shardRouting.getExpectedShardSize()).moveToStarted()
-        ).build();
-        RoutingTable routingTable = RoutingTable.builder().add(IndexRoutingTable.builder(index).addIndexShard(table).build()).build();
+        RoutingTable routingTable = RoutingTable.builder()
+            .add(
+                IndexRoutingTable.builder(index)
+                    .addIndexShard(
+                        new IndexShardRoutingTable.Builder(new ShardId(index, 0)).addShard(
+                            shardRouting.initialize(randomAlphaOfLength(8), null, shardRouting.getExpectedShardSize()).moveToStarted()
+                        )
+                    )
+                    .build()
+            )
+            .build();
 
         ClusterState clusterState = ClusterState.builder(new ClusterName(NativeRolesStoreTests.class.getName()))
             .metadata(metadata)

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/support/SecurityIndexManagerTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/support/SecurityIndexManagerTests.java
@@ -147,10 +147,11 @@ public class SecurityIndexManagerTests extends ESTestCase {
                 .add(
                     IndexRoutingTable.builder(index)
                         .addIndexShard(
-                            new IndexShardRoutingTable.Builder(new ShardId(index, 0)).addShard(
-                                shardRouting.initialize(nodeId, null, shardRouting.getExpectedShardSize())
-                                    .moveToUnassigned(new UnassignedInfo(UnassignedInfo.Reason.ALLOCATION_FAILED, ""))
-                            )
+                            IndexShardRoutingTable.builder(new ShardId(index, 0))
+                                .addShard(
+                                    shardRouting.initialize(nodeId, null, shardRouting.getExpectedShardSize())
+                                        .moveToUnassigned(new UnassignedInfo(UnassignedInfo.Reason.ALLOCATION_FAILED, ""))
+                                )
                         )
                         .build()
                 )

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/support/SecurityIndexManagerTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/support/SecurityIndexManagerTests.java
@@ -142,11 +142,20 @@ public class SecurityIndexManagerTests extends ESTestCase {
             new UnassignedInfo(UnassignedInfo.Reason.INDEX_CREATED, "")
         );
         String nodeId = ESTestCase.randomAlphaOfLength(8);
-        IndexShardRoutingTable table = new IndexShardRoutingTable.Builder(new ShardId(index, 0)).addShard(
-            shardRouting.initialize(nodeId, null, shardRouting.getExpectedShardSize())
-                .moveToUnassigned(new UnassignedInfo(UnassignedInfo.Reason.ALLOCATION_FAILED, ""))
-        ).build();
-        clusterStateBuilder.routingTable(RoutingTable.builder().add(IndexRoutingTable.builder(index).addIndexShard(table).build()).build());
+        clusterStateBuilder.routingTable(
+            RoutingTable.builder()
+                .add(
+                    IndexRoutingTable.builder(index)
+                        .addIndexShard(
+                            new IndexShardRoutingTable.Builder(new ShardId(index, 0)).addShard(
+                                shardRouting.initialize(nodeId, null, shardRouting.getExpectedShardSize())
+                                    .moveToUnassigned(new UnassignedInfo(UnassignedInfo.Reason.ALLOCATION_FAILED, ""))
+                            )
+                        )
+                        .build()
+                )
+                .build()
+        );
         manager.clusterChanged(event(clusterStateBuilder.build()));
 
         assertIndexUpToDateButNotAvailable();
@@ -210,7 +219,7 @@ public class SecurityIndexManagerTests extends ESTestCase {
                                     )
                                         .initialize(UUIDs.randomBase64UUID(random()), null, 0L)
                                         .moveToUnassigned(new UnassignedInfo(UnassignedInfo.Reason.ALLOCATION_FAILED, ""))
-                                ).build()
+                                )
                             )
                     )
                     .build()

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/test/SecurityTestUtils.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/test/SecurityTestUtils.java
@@ -78,9 +78,8 @@ public class SecurityTestUtils {
             .add(
                 IndexRoutingTable.builder(index)
                     .addIndexShard(
-                        new IndexShardRoutingTable.Builder(new ShardId(index, 0)).addShard(
-                            shardRouting.initialize(nodeId, null, shardRouting.getExpectedShardSize()).moveToStarted()
-                        )
+                        IndexShardRoutingTable.builder(new ShardId(index, 0))
+                            .addShard(shardRouting.initialize(nodeId, null, shardRouting.getExpectedShardSize()).moveToStarted())
                     )
                     .build()
             )

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/test/SecurityTestUtils.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/test/SecurityTestUtils.java
@@ -74,10 +74,17 @@ public class SecurityTestUtils {
             new UnassignedInfo(UnassignedInfo.Reason.INDEX_CREATED, "")
         );
         String nodeId = ESTestCase.randomAlphaOfLength(8);
-        IndexShardRoutingTable table = new IndexShardRoutingTable.Builder(new ShardId(index, 0)).addShard(
-            shardRouting.initialize(nodeId, null, shardRouting.getExpectedShardSize()).moveToStarted()
-        ).build();
-        return RoutingTable.builder().add(IndexRoutingTable.builder(index).addIndexShard(table).build()).build();
+        return RoutingTable.builder()
+            .add(
+                IndexRoutingTable.builder(index)
+                    .addIndexShard(
+                        new IndexShardRoutingTable.Builder(new ShardId(index, 0)).addShard(
+                            shardRouting.initialize(nodeId, null, shardRouting.getExpectedShardSize()).moveToStarted()
+                        )
+                    )
+                    .build()
+            )
+            .build();
     }
 
     /**

--- a/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/TransformPersistentTasksExecutorTests.java
+++ b/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/TransformPersistentTasksExecutorTests.java
@@ -204,7 +204,7 @@ public class TransformPersistentTasksExecutorTests extends ESTestCase {
             );
             shardRouting = shardRouting.initialize("node_id", null, 0L);
             routingTable.add(
-                IndexRoutingTable.builder(index).addIndexShard(new IndexShardRoutingTable.Builder(shardId).addShard(shardRouting).build())
+                IndexRoutingTable.builder(index).addIndexShard(new IndexShardRoutingTable.Builder(shardId).addShard(shardRouting))
             );
         }
 
@@ -243,7 +243,7 @@ public class TransformPersistentTasksExecutorTests extends ESTestCase {
             shardRouting = shardRouting.initialize("node_id", null, 0L);
             shardRouting = shardRouting.moveToStarted();
             routingTable.add(
-                IndexRoutingTable.builder(index).addIndexShard(new IndexShardRoutingTable.Builder(shardId).addShard(shardRouting).build())
+                IndexRoutingTable.builder(index).addIndexShard(new IndexShardRoutingTable.Builder(shardId).addShard(shardRouting))
             );
         }
     }

--- a/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/TransformPersistentTasksExecutorTests.java
+++ b/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/TransformPersistentTasksExecutorTests.java
@@ -204,7 +204,7 @@ public class TransformPersistentTasksExecutorTests extends ESTestCase {
             );
             shardRouting = shardRouting.initialize("node_id", null, 0L);
             routingTable.add(
-                IndexRoutingTable.builder(index).addIndexShard(new IndexShardRoutingTable.Builder(shardId).addShard(shardRouting))
+                IndexRoutingTable.builder(index).addIndexShard(IndexShardRoutingTable.builder(shardId).addShard(shardRouting))
             );
         }
 

--- a/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/WatcherServiceTests.java
+++ b/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/WatcherServiceTests.java
@@ -149,11 +149,13 @@ public class WatcherServiceTests extends ESTestCase {
         Index watchIndex = new Index(Watch.INDEX, "uuid");
         ShardId shardId = new ShardId(watchIndex, 0);
 
-        IndexShardRoutingTable indexShardRoutingTable = new IndexShardRoutingTable.Builder(shardId).addShard(
-            TestShardRouting.newShardRouting(shardId, "node", true, ShardRoutingState.STARTED)
-        ).build();
-
-        IndexRoutingTable indexRoutingTable = IndexRoutingTable.builder(watchIndex).addIndexShard(indexShardRoutingTable).build();
+        IndexRoutingTable indexRoutingTable = IndexRoutingTable.builder(watchIndex)
+            .addIndexShard(
+                new IndexShardRoutingTable.Builder(shardId).addShard(
+                    TestShardRouting.newShardRouting(shardId, "node", true, ShardRoutingState.STARTED)
+                )
+            )
+            .build();
         RoutingTable routingTable = RoutingTable.builder().add(indexRoutingTable).build();
         csBuilder.routingTable(routingTable);
 

--- a/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/WatcherServiceTests.java
+++ b/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/WatcherServiceTests.java
@@ -151,9 +151,8 @@ public class WatcherServiceTests extends ESTestCase {
 
         IndexRoutingTable indexRoutingTable = IndexRoutingTable.builder(watchIndex)
             .addIndexShard(
-                new IndexShardRoutingTable.Builder(shardId).addShard(
-                    TestShardRouting.newShardRouting(shardId, "node", true, ShardRoutingState.STARTED)
-                )
+                IndexShardRoutingTable.builder(shardId)
+                    .addShard(TestShardRouting.newShardRouting(shardId, "node", true, ShardRoutingState.STARTED))
             )
             .build();
         RoutingTable routingTable = RoutingTable.builder().add(indexRoutingTable).build();

--- a/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/execution/TriggeredWatchStoreTests.java
+++ b/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/execution/TriggeredWatchStoreTests.java
@@ -181,7 +181,7 @@ public class TriggeredWatchStoreTests extends ESTestCase {
                         state,
                         new UnassignedInfo(UnassignedInfo.Reason.INDEX_CREATED, "")
                     )
-                ).build()
+                )
             );
             indexRoutingTableBuilder.addReplica();
         }
@@ -206,7 +206,7 @@ public class TriggeredWatchStoreTests extends ESTestCase {
         indexRoutingTableBuilder.addIndexShard(
             new IndexShardRoutingTable.Builder(shardId).addShard(
                 TestShardRouting.newShardRouting(shardId, "_node_id", null, true, ShardRoutingState.STARTED)
-            ).build()
+            )
         );
         indexRoutingTableBuilder.addReplica();
         routingTableBuilder.add(indexRoutingTableBuilder.build());
@@ -338,7 +338,7 @@ public class TriggeredWatchStoreTests extends ESTestCase {
         indexRoutingTableBuilder.addIndexShard(
             new IndexShardRoutingTable.Builder(shardId).addShard(
                 TestShardRouting.newShardRouting(shardId, "_node_id", null, true, ShardRoutingState.STARTED)
-            ).build()
+            )
         );
         indexRoutingTableBuilder.addReplica();
         routingTableBuilder.add(indexRoutingTableBuilder.build());
@@ -372,7 +372,7 @@ public class TriggeredWatchStoreTests extends ESTestCase {
         indexRoutingTableBuilder.addIndexShard(
             new IndexShardRoutingTable.Builder(new ShardId(index, 0)).addShard(
                 TestShardRouting.newShardRouting("triggered-watches-alias", 0, "_node_id", null, true, ShardRoutingState.STARTED)
-            ).build()
+            )
         );
         indexRoutingTableBuilder.addReplica();
         final Index otherIndex = metadataBuilder.get("whatever").getIndex();
@@ -380,7 +380,7 @@ public class TriggeredWatchStoreTests extends ESTestCase {
         otherIndexRoutingTableBuilder.addIndexShard(
             new IndexShardRoutingTable.Builder(new ShardId(otherIndex, 0)).addShard(
                 TestShardRouting.newShardRouting("whatever", 0, "_node_id", null, true, ShardRoutingState.STARTED)
-            ).build()
+            )
         );
 
         csBuilder.metadata(metadataBuilder);


### PR DESCRIPTION
We do the routing nodes -> routing table step during reroute and it's a significant contributor
to the runtime of reroute.
The PR speeds it up by more than double in the common one shard + one primary case by saving the expensive
and slow-to-iterate hashmap keyed by shard id, the needless pre-computation of the allocation ids set (it's only used in an assertion and in the replica tracker but it was the most expensive part in that constructor) and a redundant round of building `IndexShardRoutingTable` in `addShard`.

This gives us another 2-3% speedup on the initial indices bootstrap in the many-shards benchmark.
Relates #77466 