### PR TITLE
[Refactor] Extract method for mandatory plugins check

### DIFF
--- a/server/src/main/java/org/elasticsearch/plugins/PluginsService.java
+++ b/server/src/main/java/org/elasticsearch/plugins/PluginsService.java
@@ -163,8 +163,16 @@ public class PluginsService implements ReportingService<PluginsAndModules> {
         this.info = new PluginsAndModules(pluginsList, modulesList);
         this.plugins = Collections.unmodifiableList(pluginsLoaded);
 
-        // Checking expected plugins
-        List<String> mandatoryPlugins = MANDATORY_SETTING.get(settings);
+        checkMandatoryPlugins(pluginsNames, MANDATORY_SETTING.get(settings));
+
+        // we don't log jars in lib/ we really shouldn't log modules,
+        // but for now: just be transparent so we can debug any potential issues
+        logPluginInfo(info.getModuleInfos(), "module", logger);
+        logPluginInfo(info.getPluginInfos(), "plugin", logger);
+    }
+
+    // package-private for testing
+    static void checkMandatoryPlugins(List<String> pluginsNames, List<String> mandatoryPlugins) {
         if (mandatoryPlugins.isEmpty() == false) {
             Set<String> missingPlugins = new HashSet<>();
             for (String mandatoryPlugin : mandatoryPlugins) {
@@ -182,11 +190,6 @@ public class PluginsService implements ReportingService<PluginsAndModules> {
                 throw new IllegalStateException(message);
             }
         }
-
-        // we don't log jars in lib/ we really shouldn't log modules,
-        // but for now: just be transparent so we can debug any potential issues
-        logPluginInfo(info.getModuleInfos(), "module", logger);
-        logPluginInfo(info.getPluginInfos(), "plugin", logger);
     }
 
     private static void logPluginInfo(final List<PluginInfo> pluginInfos, final String type, final Logger logger) {

--- a/server/src/test/java/org/elasticsearch/plugins/PluginsServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/plugins/PluginsServiceTests.java
@@ -350,6 +350,35 @@ public class PluginsServiceTests extends ESTestCase {
             .put("plugin.mandatory", "org.elasticsearch.plugins.PluginsServiceTests$FakePlugin")
             .build();
         newPluginsService(settings, FakePlugin.class);
+        PluginsService.checkMandatoryPlugins(
+            List.of("org.elasticsearch.plugins.PluginsServiceTests$FakePlugin"),
+            List.of("org.elasticsearch.plugins.PluginsServiceTests$FakePlugin")
+        );
+    }
+
+    public void testMissingMandatoryClasspathPlugin() {
+        final Settings settings = Settings.builder()
+            .put("path.home", createTempDir())
+            .put("plugin.mandatory", "org.elasticsearch.plugins.PluginsServiceTests$FakePlugin")
+            .build();
+        {
+            IllegalStateException e = expectThrows(IllegalStateException.class, () -> newPluginsService(settings));
+            assertEquals(
+                "missing mandatory plugins [org.elasticsearch.plugins.PluginsServiceTests$FakePlugin], found plugins []",
+                e.getMessage()
+            );
+        }
+
+        {
+            IllegalStateException e = expectThrows(
+                IllegalStateException.class,
+                () -> PluginsService.checkMandatoryPlugins(List.of(), List.of("org.elasticsearch.plugins.PluginsServiceTests$FakePlugin"))
+            );
+            assertEquals(
+                "missing mandatory plugins [org.elasticsearch.plugins.PluginsServiceTests$FakePlugin], found plugins []",
+                e.getMessage()
+            );
+        }
     }
 
     public static class FakePlugin extends Plugin {

--- a/server/src/test/java/org/elasticsearch/plugins/PluginsServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/plugins/PluginsServiceTests.java
@@ -344,41 +344,30 @@ public class PluginsServiceTests extends ESTestCase {
         assertEquals("Plugin [myplugin] cannot extend non-extensible plugin [nonextensible]", e.getMessage());
     }
 
-    public void testExistingMandatoryClasspathPlugin() {
+    public void testPassingMandatoryPluginCheck() {
         final Settings settings = Settings.builder()
             .put("path.home", createTempDir())
             .put("plugin.mandatory", "org.elasticsearch.plugins.PluginsServiceTests$FakePlugin")
             .build();
-        newPluginsService(settings, FakePlugin.class);
         PluginsService.checkMandatoryPlugins(
             List.of("org.elasticsearch.plugins.PluginsServiceTests$FakePlugin"),
             List.of("org.elasticsearch.plugins.PluginsServiceTests$FakePlugin")
         );
     }
 
-    public void testMissingMandatoryClasspathPlugin() {
+    public void testFailingMandatoryPluginCheck() {
         final Settings settings = Settings.builder()
             .put("path.home", createTempDir())
             .put("plugin.mandatory", "org.elasticsearch.plugins.PluginsServiceTests$FakePlugin")
             .build();
-        {
-            IllegalStateException e = expectThrows(IllegalStateException.class, () -> newPluginsService(settings));
-            assertEquals(
-                "missing mandatory plugins [org.elasticsearch.plugins.PluginsServiceTests$FakePlugin], found plugins []",
-                e.getMessage()
-            );
-        }
-
-        {
-            IllegalStateException e = expectThrows(
-                IllegalStateException.class,
-                () -> PluginsService.checkMandatoryPlugins(List.of(), List.of("org.elasticsearch.plugins.PluginsServiceTests$FakePlugin"))
-            );
-            assertEquals(
-                "missing mandatory plugins [org.elasticsearch.plugins.PluginsServiceTests$FakePlugin], found plugins []",
-                e.getMessage()
-            );
-        }
+        IllegalStateException e = expectThrows(
+            IllegalStateException.class,
+            () -> PluginsService.checkMandatoryPlugins(List.of(), List.of("org.elasticsearch.plugins.PluginsServiceTests$FakePlugin"))
+        );
+        assertEquals(
+            "missing mandatory plugins [org.elasticsearch.plugins.PluginsServiceTests$FakePlugin], found plugins []",
+            e.getMessage()
+        );
     }
 
     public static class FakePlugin extends Plugin {


### PR DESCRIPTION
We had some unit tests that checked whether classpath plugins matched a list of mandatory plugins. Since we shouldn't be using classpath plugins in production, I don't know how useful this is as a check, but this PR factors out a `checkMandatoryPlugins` method so we can keep test coverage without using the classpath plugin code path, which will soon be moved to `MockNode`.

I also couldn't resist using set logic instead of for-loop list building for the check itself.