### PR TITLE
[7.17] Don't download geoip databases if geoip system index is blocked

### DIFF
--- a/docs/changelog/86842.yaml
+++ b/docs/changelog/86842.yaml
@@ -1,0 +1,5 @@
+pr: 86842
+summary: Don't download geoip databases if geoip system index is blocked
+area: Ingest
+type: bug
+issues: []

--- a/modules/ingest-geoip/src/main/java/org/elasticsearch/ingest/geoip/DatabaseNodeService.java
+++ b/modules/ingest-geoip/src/main/java/org/elasticsearch/ingest/geoip/DatabaseNodeService.java
@@ -17,6 +17,7 @@ import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.client.OriginSettingClient;
 import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.metadata.IndexAbstraction;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.routing.IndexRoutingTable;
 import org.elasticsearch.common.hash.MessageDigests;
@@ -24,6 +25,7 @@ import org.elasticsearch.core.CheckedConsumer;
 import org.elasticsearch.core.CheckedRunnable;
 import org.elasticsearch.core.internal.io.IOUtils;
 import org.elasticsearch.env.Environment;
+import org.elasticsearch.index.Index;
 import org.elasticsearch.index.query.TermQueryBuilder;
 import org.elasticsearch.ingest.IngestService;
 import org.elasticsearch.persistent.PersistentTasksCustomMetadata;
@@ -191,9 +193,16 @@ public final class DatabaseNodeService implements Closeable {
             return;
         }
 
-        IndexRoutingTable databasesIndexRT = state.getRoutingTable().index(GeoIpDownloader.DATABASES_INDEX);
-        if (databasesIndexRT == null || databasesIndexRT.allPrimaryShardsActive() == false) {
+        IndexAbstraction databasesAbstraction = state.getMetadata().getIndicesLookup().get(GeoIpDownloader.DATABASES_INDEX);
+        if (databasesAbstraction == null) {
             return;
+        } else {
+            // regardless of whether DATABASES_INDEX is an alias, resolve it to a concrete index
+            Index databasesIndex = databasesAbstraction.getWriteIndex();
+            IndexRoutingTable databasesIndexRT = state.getRoutingTable().index(databasesIndex);
+            if (databasesIndexRT == null || databasesIndexRT.allPrimaryShardsActive() == false) {
+                return;
+            }
         }
 
         PersistentTasksCustomMetadata.PersistentTask<?> task = PersistentTasksCustomMetadata.getTaskWithId(


### PR DESCRIPTION
Backporting #86842 to 7.17 branch.

For example in the case that the a cluster is running out of disk
space and indices reject writes.

This can otherwise load to unnecessary error logs being printed and
just add to more instability. Instead, the GeoIpDownloader should
just try to download the files the next it runs.