### PR TITLE
[DOCS] Add 8.2.1 release notes

### DIFF
--- a/docs/reference/migration/migrate_8_2.asciidoc
+++ b/docs/reference/migration/migrate_8_2.asciidoc
@@ -20,4 +20,4 @@ coming::[8.2.1-SNAPSHOT]
 
 There are no breaking changes in {es} 8.2.
 
-//end::notable-breaking-changes[]
+// end::notable-breaking-changes[]

--- a/docs/reference/migration/migrate_8_2.asciidoc
+++ b/docs/reference/migration/migrate_8_2.asciidoc
@@ -9,14 +9,12 @@ your application to {es} 8.2.
 
 See also <<release-highlights>> and <<es-release-notes>>.
 
+coming::[8.2.1-SNAPSHOT]
+
+
 [discrete]
 [[breaking-changes-8.2]]
 === Breaking changes
 
-// NOTE: The notable-breaking-changes tagged regions are re-used in the
-// Installation and Upgrade Guide
-// tag::notable-breaking-changes[]
+There are no breaking changes in {es} 8.2.
 
-There are no breaking changes for 8.2.0.
-
-// end::notable-breaking-changes[]

--- a/docs/reference/migration/migrate_8_2.asciidoc
+++ b/docs/reference/migration/migrate_8_2.asciidoc
@@ -11,10 +11,13 @@ See also <<release-highlights>> and <<es-release-notes>>.
 
 coming::[8.2.1-SNAPSHOT]
 
-
+// NOTE: The notable-breaking-changes tagged regions are re-used in the
+// Installation and Upgrade Guide
+// tag::notable-breaking-changes[]
 [discrete]
 [[breaking-changes-8.2]]
 === Breaking changes
 
 There are no breaking changes in {es} 8.2.
 
+//end::notable-breaking-changes[]

--- a/docs/reference/release-notes.asciidoc
+++ b/docs/reference/release-notes.asciidoc
@@ -6,6 +6,7 @@
 
 This section summarizes the changes in each release.
 
+* <<release-notes-8.2.1>>
 * <<release-notes-8.2.0>>
 * <<release-notes-8.1.3>>
 * <<release-notes-8.1.2>>
@@ -21,6 +22,7 @@ This section summarizes the changes in each release.
 
 --
 
+include::release-notes/8.2.1.asciidoc[]
 include::release-notes/8.2.0.asciidoc[]
 include::release-notes/8.1.3.asciidoc[]
 include::release-notes/8.1.2.asciidoc[]

--- a/docs/reference/release-notes/8.2.1.asciidoc
+++ b/docs/reference/release-notes/8.2.1.asciidoc
@@ -1,0 +1,70 @@
+[[release-notes-8.2.1]]
+== {es} version 8.2.1
+
+coming[8.2.1]
+
+Also see <<breaking-changes-8.2,Breaking changes in 8.2>>.
+
+[[bug-8.2.1]]
+[float]
+=== Bug fixes
+
+Aggregations::
+* Fix `AdaptingAggregator` `toString` method {es-pull}86042[#86042]
+* Less jank in after-key parsing for unmapped fields {es-pull}86359[#86359] (issue: {es-issue}85928[#85928])
+
+Authentication::
+* Ensure authentication is wire compatible when setting user {es-pull}86741[#86741] (issue: {es-issue}86716[#86716])
+
+Cluster Coordination::
+* Avoid breaking add/clear voting exclusions {es-pull}86657[#86657]
+
+Geo::
+* Fix bounded hexagonal grids when they contain the bin on one of the poles {es-pull}86460[#86460]
+* Fix mvt polygon orientation {es-pull}86555[#86555] (issue: {es-issue}86560[#86560])
+
+ILM+SLM::
+* Fix `max_primary_shard_size` resize factor math {es-pull}86897[#86897]
+* Reroute after migrating to data tiers routing {es-pull}86574[#86574] (issue: {es-issue}86572[#86572])
+
+Infra/Core::
+* Fix `assertDefaultThreadContext` enumerating allowed headers {es-pull}86262[#86262]
+* Forward port MDP deprecation info api {es-pull}86103[#86103]
+* Make data directories work with symlinks again {es-pull}85878[#85878] (issue: {es-issue}85701[#85701])
+* Set autoexpand replicas on fleet actions data stream {es-pull}85511[#85511]
+* [DRAFT] Do not autocreate alias for non-primary system indices {es-pull}85977[#85977] (issue: {es-issue}85072[#85072])
+
+Ingest::
+* Don't download geoip databases if geoip system index is blocked {es-pull}86842[#86842]
+* Fix NPE when using object field as match field for enrich policy {es-pull}86089[#86089] (issue: {es-issue}86058[#86058])
+* Handle `.geoip_databases` being an alias or a concrete index {es-pull}85792[#85792] (issue: {es-issue}85756[#85756])
+
+Machine Learning::
+* Adjust memory overhead for `PyTorch` models {es-pull}86416[#86416]
+* Fix `max_model_memory_limit` reported by `_ml/info` when autoscaling is enabled {es-pull}86660[#86660]
+* Improve reliability of job stats in larger clusters {es-pull}86305[#86305]
+* Make autoscaling and task assignment use same memory staleness definition {es-pull}86632[#86632] (issue: {es-issue}86616[#86616])
+
+Packaging::
+* Fix edge case where user-defined heap settings are ignored {es-pull}86438[#86438] (issue: {es-issue}86431[#86431])
+
+Security::
+* Authentication.token now uses version from the existing authentication {es-pull}85978[#85978]
+
+Snapshot/Restore::
+* Better failure for source-only snapshots of partially/fully mounted indices {es-pull}86207[#86207]
+* Check if searchable snapshots cache pre-allocation is successful in Windows {es-pull}86192[#86192] (issue: {es-issue}85725[#85725])
+* Delay searchable snapshot allocation during shutdown {es-pull}86153[#86153] (issue: {es-issue}85052[#85052])
+* [s3-repository] Support generating AWS role session name in case it's not provided {es-pull}86255[#86255]
+
+Stats::
+* Correctly calculate disk usage for frozen data tier telemetry {es-pull}86580[#86580] (issue: {es-issue}86055[#86055])
+
+[[upgrade-8.2.1]]
+[float]
+=== Upgrades
+
+Packaging::
+* Switch to OpenJDK and upgrade to 18.0.1 {es-pull}86554[#86554]
+
+

--- a/docs/reference/release-notes/8.2.1.asciidoc
+++ b/docs/reference/release-notes/8.2.1.asciidoc
@@ -11,7 +11,7 @@ Also see <<breaking-changes-8.2,Breaking changes in 8.2>>.
 
 Aggregations::
 * Fix `AdaptingAggregator` `toString` method {es-pull}86042[#86042]
-* Less jank in after-key parsing for unmapped fields {es-pull}86359[#86359] (issue: {es-issue}85928[#85928])
+* Less complexity in after-key parsing for unmapped fields {es-pull}86359[#86359] (issue: {es-issue}85928[#85928])
 
 Authentication::
 * Ensure authentication is wire compatible when setting user {es-pull}86741[#86741] (issue: {es-issue}86716[#86716])
@@ -29,10 +29,10 @@ ILM+SLM::
 
 Infra/Core::
 * Fix `assertDefaultThreadContext` enumerating allowed headers {es-pull}86262[#86262]
-* Forward port MDP deprecation info api {es-pull}86103[#86103]
+* Forward port MDP deprecation info API {es-pull}86103[#86103]
 * Make data directories work with symlinks again {es-pull}85878[#85878] (issue: {es-issue}85701[#85701])
-* Set autoexpand replicas on fleet actions data stream {es-pull}85511[#85511]
-* [DRAFT] Do not autocreate alias for non-primary system indices {es-pull}85977[#85977] (issue: {es-issue}85072[#85072])
+* Set autoexpand replicas on Fleet actions data stream {es-pull}85511[#85511]
+* Do not autocreate alias for non-primary system indices {es-pull}85977[#85977] (issue: {es-issue}85072[#85072])
 
 Ingest::
 * Don't download geoip databases if geoip system index is blocked {es-pull}86842[#86842]
@@ -55,7 +55,7 @@ Snapshot/Restore::
 * Better failure for source-only snapshots of partially/fully mounted indices {es-pull}86207[#86207]
 * Check if searchable snapshots cache pre-allocation is successful in Windows {es-pull}86192[#86192] (issue: {es-issue}85725[#85725])
 * Delay searchable snapshot allocation during shutdown {es-pull}86153[#86153] (issue: {es-issue}85052[#85052])
-* [s3-repository] Support generating AWS role session name in case it's not provided {es-pull}86255[#86255]
+* Support generating AWS role session name in case it's not provided {es-pull}86255[#86255]
 
 Stats::
 * Correctly calculate disk usage for frozen data tier telemetry {es-pull}86580[#86580] (issue: {es-issue}86055[#86055])

--- a/docs/reference/release-notes/highlights.asciidoc
+++ b/docs/reference/release-notes/highlights.asciidoc
@@ -23,33 +23,33 @@ Other versions:
 [[integrate_filtering_support_for_approximate_nearest_neighbor_search]]
 === Integrate filtering support for approximate nearest neighbor search
 
-The {ref}/knn-search-api.html[_knn_search endpoint] now has a "filter" option 
-that allows to return only the nearest documents that satisfy the provided 
+The {ref}/knn-search-api.html[_knn_search endpoint] now has a "filter" option
+that allows to return only the nearest documents that satisfy the provided
 filter.
 
 [discrete]
 [[nlp-latency-throughput-stats]]
 === NLP latency and throughput stats
 
-New statistics are available for the NLP inference to show how quickly it is 
+New statistics are available for the NLP inference to show how quickly it is
 working. The three new statistics are:
 
 * peak_throughput_per_minute
 * throughput_last_minute
 * average_inference_time_ms_last_minute
 
-The aim is to provide an indication of whether inference is currently keeping up 
-with requirements or the cluster needs to be scaled up to meet demand. The 
-statistics for the last minute give quick feedback to show the effect of scaling 
+The aim is to provide an indication of whether inference is currently keeping up
+with requirements or the cluster needs to be scaled up to meet demand. The
+statistics for the last minute give quick feedback to show the effect of scaling
 the {ml} nodes.
 
 [discrete]
 [[random-sampler-aggregation]]
 === Random sampler aggregation
 
-With the new random sampler aggregation, in technical preview, developers can 
-exponentially accelerate their aggregations for calculations, with a slight 
-trade off in accuracy, by randomly sampling documents in a statistically robust 
-manner. The random sampler aggregation can be used to accelerate any application 
+With the new random sampler aggregation, in technical preview, developers can
+exponentially accelerate their aggregations for calculations, with a slight
+trade off in accuracy, by randomly sampling documents in a statistically robust
+manner. The random sampler aggregation can be used to accelerate any application
 that utilizes aggregations for calculations.
 // end::notable-highlights[]


### PR DESCRIPTION
I had to keep the highlights because they were manually modified in https://github.com/elastic/elasticsearch/pull/86137 and the `./gradlew generateReleaseNotes` command overwrote it.