### PR TITLE
Use larger string literal deduplicator for field names

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/util/StringLiteralDeduplicator.java
+++ b/server/src/main/java/org/elasticsearch/common/util/StringLiteralDeduplicator.java
@@ -18,11 +18,19 @@ import java.util.Map;
  */
 public final class StringLiteralDeduplicator {
 
-    private static final int MAX_SIZE = 1000;
+    private static final int DEFAULT_MAX_SIZE = 1000;
 
     private final Map<String, String> map = ConcurrentCollections.newConcurrentMapWithAggressiveConcurrency();
 
-    public StringLiteralDeduplicator() {}
+    private final int maxSize;
+
+    public StringLiteralDeduplicator() {
+        this(DEFAULT_MAX_SIZE);
+    }
+
+    public StringLiteralDeduplicator(int maxSize) {
+        this.maxSize = maxSize;
+    }
 
     public String deduplicate(String string) {
         final String res = map.get(string);
@@ -30,7 +38,7 @@ public final class StringLiteralDeduplicator {
             return res;
         }
         final String interned = string.intern();
-        if (map.size() > MAX_SIZE) {
+        if (map.size() > maxSize) {
             map.clear();
         }
         map.put(interned, interned);

--- a/server/src/main/java/org/elasticsearch/index/mapper/Mapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/Mapper.java
@@ -92,7 +92,9 @@ public abstract class Mapper implements ToXContentFragment, Iterable<Mapper> {
         return Strings.toString(this);
     }
 
-    private static final StringLiteralDeduplicator fieldNameStringDeduplicator = new StringLiteralDeduplicator();
+    // Some mappings like those created by Beats contain thousands of fields so we size this deduplicator larger than the default to
+    // speed up mapping parsing
+    private static final StringLiteralDeduplicator fieldNameStringDeduplicator = new StringLiteralDeduplicator(5000);
 
     /**
      * Interns the given field name string through a {@link StringLiteralDeduplicator}.


### PR DESCRIPTION
Beats mappings are almost 5k fields, lets size this larger to make mapper parsing
faster. The extra memory cost of 5k vs 1k really doesn't matter much here
in practice anyway but is a nice couple of percent speedup for bootstrapping the many shards benchmarks cluster.
