### PR TITLE
Extract transport cluster settings/ilm execute logic

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/settings/TransportClusterUpdateSettingsAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/settings/TransportClusterUpdateSettingsAction.java
@@ -243,10 +243,6 @@ public class TransportClusterUpdateSettingsAction extends TransportMasterNodeAct
             this.request = request;
         }
 
-        public ClusterUpdateSettingsTask(final ClusterSettings clusterSettings, ClusterUpdateSettingsRequest request) {
-            this(clusterSettings, Priority.IMMEDIATE, request, null);
-        }
-
         @Override
         public ClusterState execute(final ClusterState currentState) {
             final ClusterState clusterState = updater.updateSettings(

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/settings/TransportClusterUpdateSettingsAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/settings/TransportClusterUpdateSettingsAction.java
@@ -13,6 +13,7 @@ import org.apache.logging.log4j.Logger;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.ActionFilters;
+import org.elasticsearch.action.support.master.AcknowledgedResponse;
 import org.elasticsearch.action.support.master.TransportMasterNodeAction;
 import org.elasticsearch.cluster.AckedClusterStateUpdateTask;
 import org.elasticsearch.cluster.ClusterState;
@@ -137,11 +138,7 @@ public class TransportClusterUpdateSettingsAction extends TransportMasterNodeAct
         final ClusterState state,
         final ActionListener<ClusterUpdateSettingsResponse> listener
     ) {
-        final SettingsUpdater updater = new SettingsUpdater(clusterSettings);
-        submitUnbatchedTask(UPDATE_TASK_SOURCE, new AckedClusterStateUpdateTask(Priority.IMMEDIATE, request, listener) {
-
-            private volatile boolean changed = false;
-
+        submitUnbatchedTask(UPDATE_TASK_SOURCE, new ClusterUpdateSettingsTask(clusterSettings, Priority.IMMEDIATE, request, listener) {
             @Override
             protected ClusterUpdateSettingsResponse newResponse(boolean acknowledged) {
                 return new ClusterUpdateSettingsResponse(acknowledged, updater.getTransientUpdates(), updater.getPersistentUpdate());
@@ -225,19 +222,42 @@ public class TransportClusterUpdateSettingsAction extends TransportMasterNodeAct
                 logger.debug(() -> "failed to perform [" + UPDATE_TASK_SOURCE + "]", e);
                 super.onFailure(e);
             }
-
-            @Override
-            public ClusterState execute(final ClusterState currentState) {
-                final ClusterState clusterState = updater.updateSettings(
-                    currentState,
-                    clusterSettings.upgradeSettings(request.transientSettings()),
-                    clusterSettings.upgradeSettings(request.persistentSettings()),
-                    logger
-                );
-                changed = clusterState != currentState;
-                return clusterState;
-            }
         });
+    }
+
+    public static class ClusterUpdateSettingsTask extends AckedClusterStateUpdateTask {
+        protected volatile boolean changed = false;
+        protected final SettingsUpdater updater;
+        protected final ClusterUpdateSettingsRequest request;
+        private final ClusterSettings clusterSettings;
+
+        public ClusterUpdateSettingsTask(
+            final ClusterSettings clusterSettings,
+            Priority priority,
+            ClusterUpdateSettingsRequest request,
+            ActionListener<? extends AcknowledgedResponse> listener
+        ) {
+            super(priority, request, listener);
+            this.clusterSettings = clusterSettings;
+            this.updater = new SettingsUpdater(clusterSettings);
+            this.request = request;
+        }
+
+        public ClusterUpdateSettingsTask(final ClusterSettings clusterSettings, ClusterUpdateSettingsRequest request) {
+            this(clusterSettings, Priority.IMMEDIATE, request, null);
+        }
+
+        @Override
+        public ClusterState execute(final ClusterState currentState) {
+            final ClusterState clusterState = updater.updateSettings(
+                currentState,
+                clusterSettings.upgradeSettings(request.transientSettings()),
+                clusterSettings.upgradeSettings(request.persistentSettings()),
+                logger
+            );
+            changed = clusterState != currentState;
+            return clusterState;
+        }
     }
 
     @SuppressForbidden(reason = "legacy usage of unbatched task") // TODO add support for batching here


### PR DESCRIPTION
Extract the execute logic from the transport actions for cluster update settings and ILM put/delete to support future reuse for operator file based updates.

This PR serves as a base for the follow-up work to actually implement file based settings. There's no particular reason why these two were chosen, other than diversity of operations: settings vs entities and elasticsearch core vs plugin.

Relates to #86224
