### PR TITLE
Handle windows scripts invoked without .bat

### DIFF
--- a/distribution/tools/cli-launcher/src/main/java/org/elasticsearch/launcher/CliToolLauncher.java
+++ b/distribution/tools/cli-launcher/src/main/java/org/elasticsearch/launcher/CliToolLauncher.java
@@ -78,7 +78,9 @@ class CliToolLauncher {
 
             if (sysprops.get("os.name").startsWith("Windows")) {
                 int dotIndex = toolname.indexOf(".bat"); // strip off .bat
-                toolname = toolname.substring(0, dotIndex);
+                if (dotIndex != -1) {
+                    toolname = toolname.substring(0, dotIndex);
+                }
             }
         }
         return toolname;

--- a/distribution/tools/cli-launcher/src/test/java/org/elasticsearch/launcher/CliToolLauncherTests.java
+++ b/distribution/tools/cli-launcher/src/test/java/org/elasticsearch/launcher/CliToolLauncherTests.java
@@ -37,6 +37,8 @@ public class CliToolLauncherTests extends ESTestCase {
     public void testScriptNameSyspropWindows() {
         var sysprops = Map.of("cli.name", "", "cli.script", "C:\\foo\\bar\\elasticsearch-mycli.bat", "os.name", "Windows XP");
         assertThat(getToolName(sysprops), equalTo("mycli"));
+        sysprops = Map.of("cli.name", "", "cli.script", "C:\\foo\\bar\\elasticsearch-mycli", "os.name", "Windows XP");
+        assertThat(getToolName(sysprops), equalTo("mycli"));
     }
 
     public void testShutdownHook() {


### PR DESCRIPTION
On Windows cmd, one can invoke `myscript.bat` by just typing `myscript`.
This commit adjusts the CliToolLauncher to account for this case, making
the .bat stripping to find the toolname conditional.

closes #86940