### PR TITLE
Propagate MapperBuilderContext across merge calls

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/mapper/DocumentParserContext.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/DocumentParserContext.java
@@ -364,6 +364,14 @@ public abstract class DocumentParserContext {
 
     public abstract ContentPath path();
 
+    public final MapperBuilderContext createMapperBuilderContext() {
+        String p = path().pathAsText("");
+        if (p.endsWith(".")) {
+            p = p.substring(0, p.length() - 1);
+        }
+        return new MapperBuilderContext(p);
+    }
+
     public abstract XContentParser parser();
 
     public abstract LuceneDocument rootDoc();

--- a/server/src/main/java/org/elasticsearch/index/mapper/DynamicFieldsBuilder.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/DynamicFieldsBuilder.java
@@ -159,7 +159,9 @@ final class DynamicFieldsBuilder {
      */
     static Mapper createDynamicObjectMapper(DocumentParserContext context, String name) {
         Mapper mapper = createObjectMapperFromTemplate(context, name);
-        return mapper != null ? mapper : new ObjectMapper.Builder(name).enabled(true).build(MapperBuilderContext.forPath(context.path()));
+        return mapper != null
+            ? mapper
+            : new ObjectMapper.Builder(name).enabled(ObjectMapper.Defaults.ENABLED).build(context.createMapperBuilderContext());
     }
 
     /**
@@ -167,7 +169,7 @@ final class DynamicFieldsBuilder {
      */
     static Mapper createObjectMapperFromTemplate(DocumentParserContext context, String name) {
         Mapper.Builder templateBuilder = findTemplateBuilderForObject(context, name);
-        return templateBuilder == null ? null : templateBuilder.build(MapperBuilderContext.forPath(context.path()));
+        return templateBuilder == null ? null : templateBuilder.build(context.createMapperBuilderContext());
     }
 
     /**
@@ -302,7 +304,7 @@ final class DynamicFieldsBuilder {
         }
 
         void createDynamicField(Mapper.Builder builder, DocumentParserContext context) throws IOException {
-            Mapper mapper = builder.build(MapperBuilderContext.forPath(context.path()));
+            Mapper mapper = builder.build(context.createMapperBuilderContext());
             context.addDynamicMapper(mapper);
             parseField.accept(context, mapper);
         }

--- a/server/src/main/java/org/elasticsearch/index/mapper/FieldAliasMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/FieldAliasMapper.java
@@ -55,7 +55,7 @@ public final class FieldAliasMapper extends Mapper {
     }
 
     @Override
-    public Mapper merge(Mapper mergeWith) {
+    public Mapper merge(Mapper mergeWith, MapperBuilderContext mapperBuilderContext) {
         if ((mergeWith instanceof FieldAliasMapper) == false) {
             throw new IllegalArgumentException(
                 "Cannot merge a field alias mapping [" + name() + "] with a mapping that is not for a field alias."

--- a/server/src/main/java/org/elasticsearch/index/mapper/FieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/FieldMapper.java
@@ -1142,8 +1142,9 @@ public abstract class FieldMapper extends Mapper implements Cloneable {
             for (Parameter<?> param : getParameters()) {
                 param.merge(in, conflicts);
             }
+            MapperBuilderContext childContext = mapperBuilderContext.createChildContext(in.simpleName());
             for (FieldMapper newSubField : in.multiFields.mappers) {
-                multiFieldsBuilder.update(newSubField, mapperBuilderContext);
+                multiFieldsBuilder.update(newSubField, childContext);
             }
             this.copyTo.reset(in.copyTo);
             validate();

--- a/server/src/main/java/org/elasticsearch/index/mapper/FieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/FieldMapper.java
@@ -321,7 +321,7 @@ public abstract class FieldMapper extends Mapper implements Cloneable {
     public abstract Builder getMergeBuilder();
 
     @Override
-    public final FieldMapper merge(Mapper mergeWith) {
+    public final FieldMapper merge(Mapper mergeWith, MapperBuilderContext mapperBuilderContext) {
         if (mergeWith == this) {
             return this;
         }
@@ -343,9 +343,9 @@ public abstract class FieldMapper extends Mapper implements Cloneable {
             return (FieldMapper) mergeWith;
         }
         Conflicts conflicts = new Conflicts(name());
-        builder.merge((FieldMapper) mergeWith, conflicts);
+        builder.merge((FieldMapper) mergeWith, conflicts, mapperBuilderContext);
         conflicts.check();
-        return builder.build(MapperBuilderContext.forPath(Builder.parentPath(name())));
+        return builder.build(mapperBuilderContext);
     }
 
     protected void checkIncomingMergeType(FieldMapper mergeWith) {
@@ -408,7 +408,7 @@ public abstract class FieldMapper extends Mapper implements Cloneable {
                     add(toMerge);
                 } else {
                     FieldMapper existing = mapperBuilders.get(toMerge.simpleName()).apply(context);
-                    add(existing.merge(toMerge));
+                    add(existing.merge(toMerge, context));
                 }
                 return this;
             }
@@ -1138,12 +1138,12 @@ public abstract class FieldMapper extends Mapper implements Cloneable {
             return this;
         }
 
-        protected void merge(FieldMapper in, Conflicts conflicts) {
+        protected void merge(FieldMapper in, Conflicts conflicts, MapperBuilderContext mapperBuilderContext) {
             for (Parameter<?> param : getParameters()) {
                 param.merge(in, conflicts);
             }
             for (FieldMapper newSubField : in.multiFields.mappers) {
-                multiFieldsBuilder.update(newSubField, MapperBuilderContext.forPath(parentPath(newSubField.name())));
+                multiFieldsBuilder.update(newSubField, mapperBuilderContext);
             }
             this.copyTo.reset(in.copyTo);
             validate();

--- a/server/src/main/java/org/elasticsearch/index/mapper/Mapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/Mapper.java
@@ -25,6 +25,7 @@ public abstract class Mapper implements ToXContentFragment, Iterable<Mapper> {
             this.name = internFieldName(name);
         }
 
+        // TODO rename this to leafName?
         public String name() {
             return this.name;
         }
@@ -53,11 +54,13 @@ public abstract class Mapper implements ToXContentFragment, Iterable<Mapper> {
 
     /** Returns the simple name, which identifies this mapper against other mappers at the same level in the mappers hierarchy
      * TODO: make this protected once Mapper and FieldMapper are merged together */
+    // TODO rename this to leafName?
     public final String simpleName() {
         return simpleName;
     }
 
     /** Returns the canonical name which uniquely identifies the mapper against other mappers in a type. */
+    // TODO rename this to fullPath???
     public abstract String name();
 
     /**
@@ -67,7 +70,7 @@ public abstract class Mapper implements ToXContentFragment, Iterable<Mapper> {
 
     /** Return the merge of {@code mergeWith} into this.
      *  Both {@code this} and {@code mergeWith} will be left unmodified. */
-    public abstract Mapper merge(Mapper mergeWith);
+    public abstract Mapper merge(Mapper mergeWith, MapperBuilderContext mapperBuilderContext);
 
     /**
      * Validate any cross-field references made by this mapper

--- a/server/src/main/java/org/elasticsearch/index/mapper/MapperBuilderContext.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/MapperBuilderContext.java
@@ -10,29 +10,26 @@ package org.elasticsearch.index.mapper;
 
 import org.elasticsearch.common.Strings;
 
+import java.util.Objects;
+
 /**
  * Holds context for building Mapper objects from their Builders
  */
-public class MapperBuilderContext {
+public final class MapperBuilderContext {
 
     /**
      * The root context, to be used when building a tree of mappers
      */
-    public static final MapperBuilderContext ROOT = new MapperBuilderContext(null);
-
-    // TODO remove this
-    public static MapperBuilderContext forPath(ContentPath path) {
-        String p = path.pathAsText("");
-        if (p.endsWith(".")) {
-            p = p.substring(0, p.length() - 1);
-        }
-        return new MapperBuilderContext(p);
-    }
+    public static final MapperBuilderContext ROOT = new MapperBuilderContext();
 
     private final String path;
 
-    private MapperBuilderContext(String path) {
-        this.path = path;
+    private MapperBuilderContext() {
+        this.path = null;
+    }
+
+    MapperBuilderContext(String path) {
+        this.path = Objects.requireNonNull(path);
     }
 
     /**
@@ -47,7 +44,7 @@ public class MapperBuilderContext {
     /**
      * Builds the full name of the field, taking into account parent objects
      */
-    public final String buildFullName(String name) {
+    public String buildFullName(String name) {
         if (Strings.isEmpty(path)) {
             return name;
         }

--- a/server/src/main/java/org/elasticsearch/index/mapper/Mapping.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/Mapping.java
@@ -127,7 +127,7 @@ public final class Mapping implements ToXContentFragment {
      * @return the resulting merged mapping.
      */
     Mapping merge(Mapping mergeWith, MergeReason reason) {
-        RootObjectMapper mergedRoot = root.merge(mergeWith.root, reason);
+        RootObjectMapper mergedRoot = root.merge(mergeWith.root, reason, MapperBuilderContext.ROOT);
 
         // When merging metadata fields as part of applying an index template, new field definitions
         // completely overwrite existing ones instead of being merged. This behavior matches how we
@@ -139,7 +139,7 @@ public final class Mapping implements ToXContentFragment {
             if (mergeInto == null || reason == MergeReason.INDEX_TEMPLATE) {
                 merged = metaMergeWith;
             } else {
-                merged = (MetadataFieldMapper) mergeInto.merge(metaMergeWith);
+                merged = (MetadataFieldMapper) mergeInto.merge(metaMergeWith, MapperBuilderContext.ROOT);
             }
             mergedMetadataMappers.put(merged.getClass(), merged);
         }

--- a/server/src/main/java/org/elasticsearch/index/mapper/NestedObjectMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/NestedObjectMapper.java
@@ -170,7 +170,7 @@ public class NestedObjectMapper extends ObjectMapper {
     }
 
     @Override
-    public ObjectMapper merge(Mapper mergeWith, MapperService.MergeReason reason) {
+    public ObjectMapper merge(Mapper mergeWith, MapperService.MergeReason reason, MapperBuilderContext mapperBuilderContext) {
         if ((mergeWith instanceof NestedObjectMapper) == false) {
             throw new IllegalArgumentException("can't merge a non nested mapping [" + mergeWith.name() + "] with a nested mapping");
         }
@@ -191,7 +191,7 @@ public class NestedObjectMapper extends ObjectMapper {
                 throw new MapperException("the [include_in_root] parameter can't be updated on a nested object mapping");
             }
         }
-        toMerge.doMerge(mergeWithObject, reason);
+        toMerge.doMerge(mergeWithObject, reason, mapperBuilderContext);
         return toMerge;
     }
 

--- a/server/src/main/java/org/elasticsearch/index/mapper/ObjectMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/ObjectMapper.java
@@ -163,7 +163,7 @@ public class ObjectMapper extends Mapper implements Cloneable {
                 }
                 Mapper existing = mappers.get(mapper.simpleName());
                 if (existing != null) {
-                    mapper = existing.merge(mapper);
+                    mapper = existing.merge(mapper, mapperBuilderContext);
                 }
                 mappers.put(mapper.simpleName(), mapper);
             }
@@ -414,8 +414,8 @@ public class ObjectMapper extends Mapper implements Cloneable {
     }
 
     @Override
-    public ObjectMapper merge(Mapper mergeWith) {
-        return merge(mergeWith, MergeReason.MAPPING_UPDATE);
+    public ObjectMapper merge(Mapper mergeWith, MapperBuilderContext mapperBuilderContext) {
+        return merge(mergeWith, MergeReason.MAPPING_UPDATE, mapperBuilderContext);
     }
 
     @Override
@@ -425,7 +425,7 @@ public class ObjectMapper extends Mapper implements Cloneable {
         }
     }
 
-    public ObjectMapper merge(Mapper mergeWith, MergeReason reason) {
+    public ObjectMapper merge(Mapper mergeWith, MergeReason reason, MapperBuilderContext mapperBuilderContext) {
         if ((mergeWith instanceof ObjectMapper) == false) {
             throw new IllegalArgumentException("can't merge a non object mapping [" + mergeWith.name() + "] with an object mapping");
         }
@@ -435,11 +435,11 @@ public class ObjectMapper extends Mapper implements Cloneable {
         }
         ObjectMapper mergeWithObject = (ObjectMapper) mergeWith;
         ObjectMapper merged = clone();
-        merged.doMerge(mergeWithObject, reason);
+        merged.doMerge(mergeWithObject, reason, mapperBuilderContext);
         return merged;
     }
 
-    protected void doMerge(final ObjectMapper mergeWith, MergeReason reason) {
+    protected void doMerge(final ObjectMapper mergeWith, MergeReason reason, MapperBuilderContext mapperBuilderContext) {
 
         if (mergeWith.dynamic != null) {
             this.dynamic = mergeWith.dynamic;
@@ -469,7 +469,8 @@ public class ObjectMapper extends Mapper implements Cloneable {
             if (mergeIntoMapper == null) {
                 merged = mergeWithMapper;
             } else if (mergeIntoMapper instanceof ObjectMapper objectMapper) {
-                merged = objectMapper.merge(mergeWithMapper, reason);
+                MapperBuilderContext childContext = mapperBuilderContext.createChildContext(objectMapper.simpleName());
+                merged = objectMapper.merge(mergeWithMapper, reason, childContext);
             } else {
                 assert mergeIntoMapper instanceof FieldMapper || mergeIntoMapper instanceof FieldAliasMapper;
                 if (mergeWithMapper instanceof ObjectMapper) {
@@ -483,7 +484,7 @@ public class ObjectMapper extends Mapper implements Cloneable {
                 if (reason == MergeReason.INDEX_TEMPLATE) {
                     merged = mergeWithMapper;
                 } else {
-                    merged = mergeIntoMapper.merge(mergeWithMapper);
+                    merged = mergeIntoMapper.merge(mergeWithMapper, mapperBuilderContext);
                 }
             }
             if (mergedMappers == null) {

--- a/server/src/main/java/org/elasticsearch/index/mapper/PlaceHolderFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/PlaceHolderFieldMapper.java
@@ -65,10 +65,10 @@ public class PlaceHolderFieldMapper extends FieldMapper {
         }
 
         @Override
-        protected void merge(FieldMapper in, Conflicts conflicts) {
+        protected void merge(FieldMapper in, Conflicts conflicts, MapperBuilderContext mapperBuilderContext) {
             assert in instanceof PlaceHolderFieldMapper;
             unknownParams.putAll(((PlaceHolderFieldMapper) in).unknownParams);
-            super.merge(in, conflicts);
+            super.merge(in, conflicts, mapperBuilderContext);
         }
 
         @Override

--- a/server/src/main/java/org/elasticsearch/index/mapper/RootObjectMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/RootObjectMapper.java
@@ -322,13 +322,13 @@ public class RootObjectMapper extends ObjectMapper {
     }
 
     @Override
-    public RootObjectMapper merge(Mapper mergeWith, MergeReason reason) {
-        return (RootObjectMapper) super.merge(mergeWith, reason);
+    public RootObjectMapper merge(Mapper mergeWith, MergeReason reason, MapperBuilderContext mapperBuilderContext) {
+        return (RootObjectMapper) super.merge(mergeWith, reason, mapperBuilderContext);
     }
 
     @Override
-    protected void doMerge(ObjectMapper mergeWith, MergeReason reason) {
-        super.doMerge(mergeWith, reason);
+    protected void doMerge(ObjectMapper mergeWith, MergeReason reason, MapperBuilderContext mapperBuilderContext) {
+        super.doMerge(mergeWith, reason, mapperBuilderContext);
         RootObjectMapper mergeWithObject = (RootObjectMapper) mergeWith;
         if (mergeWithObject.numericDetection.explicit()) {
             this.numericDetection = mergeWithObject.numericDetection;

--- a/server/src/test/java/org/elasticsearch/index/mapper/FieldAliasMapperValidationTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/FieldAliasMapperValidationTests.java
@@ -158,9 +158,7 @@ public class FieldAliasMapperValidationTests extends ESTestCase {
     }
 
     private static FieldMapper createFieldMapper(String parent, String name) {
-        return new BooleanFieldMapper.Builder(name, ScriptCompiler.NONE, Version.CURRENT).build(
-            MapperBuilderContext.forPath(new ContentPath(parent))
-        );
+        return new BooleanFieldMapper.Builder(name, ScriptCompiler.NONE, Version.CURRENT).build(new MapperBuilderContext(parent));
     }
 
     private static ObjectMapper createObjectMapper(String name) {

--- a/server/src/test/java/org/elasticsearch/index/mapper/ObjectMapperMergeTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/ObjectMapperMergeTests.java
@@ -135,7 +135,7 @@ public class ObjectMapperMergeTests extends ESTestCase {
         assertTrue(result.isIncludeInRoot());
     }
 
-    public void testMergeFieldWithDotsSubobjectsFalseAtRoot() {
+    public void testMergedFieldNamesFieldWithDotsSubobjectsFalseAtRoot() {
         RootObjectMapper mergeInto = createRootSubobjectFalseLeafWithDots();
         RootObjectMapper mergeWith = createRootSubobjectFalseLeafWithDots();
 
@@ -146,7 +146,7 @@ public class ObjectMapperMergeTests extends ESTestCase {
         assertEquals("host.name", keywordFieldMapper.simpleName());
     }
 
-    public void testMergeFieldWithDotsSubobjectsFalse() {
+    public void testMergedFieldNamesFieldWithDotsSubobjectsFalse() {
         RootObjectMapper mergeInto = createRootObjectMapper(
             "_doc",
             true,
@@ -167,7 +167,7 @@ public class ObjectMapperMergeTests extends ESTestCase {
         assertEquals("host.name", keywordFieldMapper.simpleName());
     }
 
-    public void testMergeMultiFields() {
+    public void testMergedFieldNamesMultiFields() {
         RootObjectMapper mergeInto = createRootObjectMapper(
             "_doc",
             true,
@@ -189,7 +189,7 @@ public class ObjectMapperMergeTests extends ESTestCase {
         assertEquals("keyword", keyword.simpleName());
     }
 
-    public void testMergeMultiFieldsWithinSubobjectsFalse() {
+    public void testMergedFieldNamesMultiFieldsWithinSubobjectsFalse() {
         RootObjectMapper mergeInto = createRootObjectMapper(
             "_doc",
             true,

--- a/server/src/test/java/org/elasticsearch/index/mapper/ObjectMapperMergeTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/ObjectMapperMergeTests.java
@@ -49,7 +49,7 @@ public class ObjectMapperMergeTests extends ESTestCase {
         ObjectMapper mergeWith = createMapping(false, true, true, true);
 
         // WHEN merging mappings
-        final ObjectMapper merged = rootObjectMapper.merge(mergeWith);
+        final ObjectMapper merged = rootObjectMapper.merge(mergeWith, MapperBuilderContext.ROOT);
 
         // THEN "baz" new field is added to merged mapping
         final ObjectMapper mergedFoo = (ObjectMapper) merged.getMapper("foo");
@@ -63,7 +63,7 @@ public class ObjectMapperMergeTests extends ESTestCase {
 
         // WHEN merging mappings
         // THEN a MapperException is thrown with an excepted message
-        MapperException e = expectThrows(MapperException.class, () -> rootObjectMapper.merge(mergeWith));
+        MapperException e = expectThrows(MapperException.class, () -> rootObjectMapper.merge(mergeWith, MapperBuilderContext.ROOT));
         assertEquals("the [enabled] parameter can't be updated for the object mapping [foo]", e.getMessage());
     }
 
@@ -74,17 +74,17 @@ public class ObjectMapperMergeTests extends ESTestCase {
         mappers.put("disabled", new ObjectMapper.Builder("disabled").build(MapperBuilderContext.ROOT));
         RootObjectMapper mergeWith = createRootObjectMapper("type1", true, Collections.unmodifiableMap(mappers));
 
-        RootObjectMapper merged = (RootObjectMapper) rootObjectMapper.merge(mergeWith);
+        RootObjectMapper merged = (RootObjectMapper) rootObjectMapper.merge(mergeWith, MapperBuilderContext.ROOT);
         assertFalse(((ObjectMapper) merged.getMapper("disabled")).isEnabled());
     }
 
     public void testMergeEnabled() {
         ObjectMapper mergeWith = createMapping(true, true, true, false);
 
-        MapperException e = expectThrows(MapperException.class, () -> rootObjectMapper.merge(mergeWith));
+        MapperException e = expectThrows(MapperException.class, () -> rootObjectMapper.merge(mergeWith, MapperBuilderContext.ROOT));
         assertEquals("the [enabled] parameter can't be updated for the object mapping [disabled]", e.getMessage());
 
-        ObjectMapper result = rootObjectMapper.merge(mergeWith, MapperService.MergeReason.INDEX_TEMPLATE);
+        ObjectMapper result = rootObjectMapper.merge(mergeWith, MapperService.MergeReason.INDEX_TEMPLATE, MapperBuilderContext.ROOT);
         assertTrue(result.isEnabled());
     }
 
@@ -93,10 +93,10 @@ public class ObjectMapperMergeTests extends ESTestCase {
         ObjectMapper firstMapper = createRootObjectMapper(type, true, Collections.emptyMap());
         ObjectMapper secondMapper = createRootObjectMapper(type, false, Collections.emptyMap());
 
-        MapperException e = expectThrows(MapperException.class, () -> firstMapper.merge(secondMapper));
+        MapperException e = expectThrows(MapperException.class, () -> firstMapper.merge(secondMapper, MapperBuilderContext.ROOT));
         assertEquals("the [enabled] parameter can't be updated for the object mapping [" + type + "]", e.getMessage());
 
-        ObjectMapper result = firstMapper.merge(secondMapper, MapperService.MergeReason.INDEX_TEMPLATE);
+        ObjectMapper result = firstMapper.merge(secondMapper, MapperService.MergeReason.INDEX_TEMPLATE, MapperBuilderContext.ROOT);
         assertFalse(result.isEnabled());
     }
 
@@ -109,14 +109,13 @@ public class ObjectMapperMergeTests extends ESTestCase {
             Collections.singletonMap("test", new TestRuntimeField("test", "long"))
         ).build(MapperBuilderContext.ROOT);
 
-        RootObjectMapper merged = (RootObjectMapper) rootObjectMapper.merge(mergeWith);
+        RootObjectMapper merged = (RootObjectMapper) rootObjectMapper.merge(mergeWith, MapperBuilderContext.ROOT);
         assertFalse(merged.isEnabled());
         assertEquals(1, merged.runtimeFields().size());
         assertEquals("test", merged.runtimeFields().iterator().next().name());
     }
 
     public void testMergeNested() {
-
         NestedObjectMapper firstMapper = new NestedObjectMapper.Builder("nested1", Version.CURRENT).includeInParent(true)
             .includeInRoot(true)
             .build(MapperBuilderContext.ROOT);
@@ -124,12 +123,57 @@ public class ObjectMapperMergeTests extends ESTestCase {
             .includeInRoot(true)
             .build(MapperBuilderContext.ROOT);
 
-        MapperException e = expectThrows(MapperException.class, () -> firstMapper.merge(secondMapper));
+        MapperException e = expectThrows(MapperException.class, () -> firstMapper.merge(secondMapper, MapperBuilderContext.ROOT));
         assertThat(e.getMessage(), containsString("[include_in_parent] parameter can't be updated on a nested object mapping"));
 
-        NestedObjectMapper result = (NestedObjectMapper) firstMapper.merge(secondMapper, MapperService.MergeReason.INDEX_TEMPLATE);
+        NestedObjectMapper result = (NestedObjectMapper) firstMapper.merge(
+            secondMapper,
+            MapperService.MergeReason.INDEX_TEMPLATE,
+            MapperBuilderContext.ROOT
+        );
         assertFalse(result.isIncludeInParent());
         assertTrue(result.isIncludeInRoot());
+    }
+
+    public void testMergeFieldWithDotsSubobjectsFalseAtRoot() {
+        RootObjectMapper mergeInto = createRootSubobjectFalseLeafWithDots();
+        RootObjectMapper mergeWith = createRootSubobjectFalseLeafWithDots();
+
+        final ObjectMapper merged = mergeInto.merge(mergeWith, MapperBuilderContext.ROOT);
+
+        final KeywordFieldMapper keywordFieldMapper = (KeywordFieldMapper) merged.getMapper("host.name");
+        assertEquals("host.name", keywordFieldMapper.name());
+        assertEquals("host.name", keywordFieldMapper.simpleName());
+    }
+
+    public void testMergeFieldWithDotsSubobjectsFalse() {
+        RootObjectMapper mergeInto = createRootObjectMapper(
+            "_doc",
+            true,
+            Collections.singletonMap("foo", createObjectSubobjectsFalseLeafWithDots())
+        );
+        RootObjectMapper mergeWith = createRootObjectMapper(
+            "_doc",
+            true,
+            Collections.singletonMap("foo", createObjectSubobjectsFalseLeafWithDots())
+        );
+
+        final ObjectMapper merged = mergeInto.merge(mergeWith, MapperBuilderContext.ROOT);
+
+        ObjectMapper foo = (ObjectMapper) merged.getMapper("foo");
+        ObjectMapper metrics = (ObjectMapper) foo.getMapper("metrics");
+        final KeywordFieldMapper keywordFieldMapper = (KeywordFieldMapper) metrics.getMapper("host.name");
+        assertEquals("foo.metrics.host.name", keywordFieldMapper.name());
+        assertEquals("host.name", keywordFieldMapper.simpleName());
+    }
+
+    private static RootObjectMapper createRootSubobjectFalseLeafWithDots() {
+        FieldMapper fieldMapper = new KeywordFieldMapper.Builder("host.name", Version.CURRENT).build(MapperBuilderContext.ROOT);
+        assertEquals("host.name", fieldMapper.simpleName());
+        assertEquals("host.name", fieldMapper.name());
+        return (RootObjectMapper) new RootObjectMapper.Builder("_doc").subobjects(false)
+            .addMappers(Collections.singletonMap("host.name", fieldMapper))
+            .build(MapperBuilderContext.ROOT);
     }
 
     private static RootObjectMapper createRootObjectMapper(String name, boolean enabled, Map<String, Mapper> mappers) {
@@ -138,6 +182,18 @@ public class ObjectMapperMergeTests extends ESTestCase {
 
     private static ObjectMapper createObjectMapper(String name, boolean enabled, Map<String, Mapper> mappers) {
         return new ObjectMapper.Builder(name).enabled(enabled).addMappers(mappers).build(MapperBuilderContext.ROOT);
+    }
+
+    private static ObjectMapper createObjectSubobjectsFalseLeafWithDots() {
+        KeywordFieldMapper fieldMapper = new KeywordFieldMapper.Builder("host.name", Version.CURRENT).build(
+            new MapperBuilderContext("foo.metrics")
+        );
+        assertEquals("host.name", fieldMapper.simpleName());
+        assertEquals("foo.metrics.host.name", fieldMapper.name());
+        ObjectMapper metrics = new ObjectMapper.Builder("metrics").subobjects(false)
+            .addMappers(Collections.singletonMap("host.name", fieldMapper))
+            .build(new MapperBuilderContext("foo"));
+        return new ObjectMapper.Builder("foo").addMappers(Collections.singletonMap("metrics", metrics)).build(MapperBuilderContext.ROOT);
     }
 
     private TextFieldMapper createTextFieldMapper(String name) {


### PR DESCRIPTION
With #86166 we have added support for leaf fields that have dots in their names, without needing to expand their path to intermediate objects. That means that for instance a host.name keyword field mapper can be held directly by the root object mapper if the root has subobjects set to false.

This opens up for situations where a field name containing dots can't necessarily be split into a leaf name and a parent path made of intermediate object mappers. In the field mapper merge code, we build the full path of the merged field making that now incorrect assumption, which causes the result of merged leaf fields to have incorrect full path. This is a bug although it got unnoticed so far as the full path of a field mapper is not so widely used compared to its leaf name (returned by the simpleName method). One place where the full path is used is when sorting the child mappers in ObjectMapper#serializeMappers which was causing MapperService#assertRefreshIsNotNeeded to trip as the result of the merge has fields in a different order compared to the incoming mappings, due to the different name between the original mapper and the merged mapper.

With this fix, we add a MapperBuilderContext argument to the different merge methods, propagate the MapperBuilderContext in all the merge calls and create a child context when needed, meaning whenever merging object mappers, so that their children mappers are created with the proper full path.