### PR TITLE
[Test] Increase length of test password for FIPS

### DIFF
--- a/distribution/tools/server-cli/src/test/java/org/elasticsearch/server/cli/ServerCliTests.java
+++ b/distribution/tools/server-cli/src/test/java/org/elasticsearch/server/cli/ServerCliTests.java
@@ -251,7 +251,7 @@ public class ServerCliTests extends CommandTestCase {
     public void testKeystorePassword() throws Exception {
         assertKeystorePassword(null); // no keystore exists
         assertKeystorePassword("");
-        assertKeystorePassword("dummypassword");
+        assertKeystorePassword("a-dummy-password");
     }
 
     public void testCloseStopsServer() throws Exception {


### PR DESCRIPTION
Password must be at least 114 bits in FIPS mode. This PR fixes the password length
in the new ServerCliTests so it passes in FIPS mode.

Relates: #85758 

PS: The test [failed](https://gradle-enterprise.elastic.co/s/mrlw6o27onxee/tests/:distribution:tools:server-cli:test/org.elasticsearch.server.cli.ServerCliTests/testKeystorePassword) on my PR CI. 