### PR TITLE
Introduce vector radius query

### DIFF
--- a/docs/changelog/86951.yaml
+++ b/docs/changelog/86951.yaml
@@ -1,0 +1,5 @@
+pr: 86951
+summary: Introduce vector radius query
+area: Search
+type: feature
+issues: []

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/vectors/70_radius_search.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/vectors/70_radius_search.yml
@@ -1,0 +1,94 @@
+setup:
+  - skip:
+      features: headers
+
+  - do:
+      indices.create:
+        index: test-index
+        body:
+          settings:
+            number_of_replicas: 0
+          mappings:
+            properties:
+              vector:
+                type: dense_vector
+                dims: 5
+                index: true
+                similarity: cosine
+              other_vector:
+                type: dense_vector
+                dims: 5
+                index: true
+                similarity: l2_norm
+  - do:
+      index:
+        index: test-index
+        id: "1"
+        body:
+          vector: [230.0, 300.33, -34.8988, 15.555, -200.0]
+          other_vector: [1, 0, 0, 0, 2]
+
+  - do:
+      index:
+        index: test-index
+        id: "2"
+        body:
+          vector: [-0.5, 100.0, -13, 14.8, -156.0]
+          other_vector: [0, 0, 0, 0, 0]
+
+  - do:
+      index:
+        index: test-index
+        id: "3"
+        body:
+          vector: [0.5, 111.3, -13.0, 14.8, -156.0]
+          other_vector: [2, 1, 2, 3, 1]
+
+  - do:
+      indices.refresh: {}
+
+---
+"Radius search with cosine similarity":
+  - do:
+      headers:
+        Content-Type: application/json
+      search:
+        rest_total_hits_as_int: true
+        body:
+          query:
+            vector_radius:
+              field: vector
+              origin: [0.5, 111.3, -13.0, 14.8, -156.0]
+              radius: 0.8
+              num_candidates: 3
+
+  - match: {hits.total: 2}
+
+  - match: {hits.hits.0._id: "2"}
+  - match: {hits.hits.1._score: 1.0}
+
+  - match: {hits.hits.1._id: "3"}
+  - match: {hits.hits.1._score: 1.0}
+
+---
+"Radius search with l2 distance":
+  - do:
+      headers:
+        Content-Type: application/json
+      search:
+        rest_total_hits_as_int: true
+        body:
+          query:
+            vector_radius:
+              field: other_vector
+              origin: [1, 0, 0, 0, 0]
+              radius: 3
+              num_candidates: 3
+
+  - match: {hits.total: 2}
+
+  - match: {hits.hits.0._id: "1"}
+  - match: {hits.hits.1._score: 1.0}
+
+  - match: {hits.hits.1._id: "2"}
+  - match: {hits.hits.1._score: 1.0}

--- a/x-pack/plugin/vectors/src/main/java/org/elasticsearch/xpack/vectors/DenseVectorPlugin.java
+++ b/x-pack/plugin/vectors/src/main/java/org/elasticsearch/xpack/vectors/DenseVectorPlugin.java
@@ -24,6 +24,7 @@ import org.elasticsearch.xpack.vectors.action.RestKnnSearchAction;
 import org.elasticsearch.xpack.vectors.mapper.DenseVectorFieldMapper;
 import org.elasticsearch.xpack.vectors.mapper.SparseVectorFieldMapper;
 import org.elasticsearch.xpack.vectors.query.KnnVectorQueryBuilder;
+import org.elasticsearch.xpack.vectors.query.VectorRadiusQueryBuilder;
 
 import java.util.Collections;
 import java.util.LinkedHashMap;
@@ -66,7 +67,8 @@ public class DenseVectorPlugin extends Plugin implements ActionPlugin, MapperPlu
                 parser -> {
                     throw new IllegalArgumentException("[knn] queries cannot be provided directly, use the [_knn_search] endpoint instead");
                 }
-            )
+            ),
+            new QuerySpec<>(VectorRadiusQueryBuilder.NAME, VectorRadiusQueryBuilder::new, VectorRadiusQueryBuilder::fromXContent)
         );
     }
 }

--- a/x-pack/plugin/vectors/src/main/java/org/elasticsearch/xpack/vectors/mapper/DenseVectorFieldMapper.java
+++ b/x-pack/plugin/vectors/src/main/java/org/elasticsearch/xpack/vectors/mapper/DenseVectorFieldMapper.java
@@ -41,6 +41,7 @@ import org.elasticsearch.xcontent.ToXContent;
 import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xcontent.XContentParser.Token;
 import org.elasticsearch.xpack.vectors.query.VectorIndexFieldData;
+import org.elasticsearch.xpack.vectors.query.VectorRadiusQuery;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
@@ -302,6 +303,16 @@ public class DenseVectorFieldMapper extends FieldMapper implements PerFieldKnnVe
         }
 
         public KnnVectorQuery createKnnQuery(float[] queryVector, int numCands, Query filter) {
+            validateQueryVector(queryVector);
+            return new KnnVectorQuery(name(), queryVector, numCands, filter);
+        }
+
+        public VectorRadiusQuery createRadiusQuery(float[] queryVector, int numCands, float radius) {
+            validateQueryVector(queryVector);
+            return new VectorRadiusQuery(name(), queryVector, radius, numCands);
+        }
+
+        private void validateQueryVector(float[] queryVector) {
             if (isIndexed() == false) {
                 throw new IllegalArgumentException(
                     "to perform knn search on field [" + name() + "], its mapping must have [index] set to [true]"
@@ -321,7 +332,6 @@ public class DenseVectorFieldMapper extends FieldMapper implements PerFieldKnnVe
                 }
                 checkVectorMagnitude(queryVector, squaredMagnitude);
             }
-            return new KnnVectorQuery(name(), queryVector, numCands, filter);
         }
 
         private void checkVectorMagnitude(float[] vector, float squaredMagnitude) {

--- a/x-pack/plugin/vectors/src/main/java/org/elasticsearch/xpack/vectors/query/VectorRadiusQuery.java
+++ b/x-pack/plugin/vectors/src/main/java/org/elasticsearch/xpack/vectors/query/VectorRadiusQuery.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.vectors.query;
+
+import org.apache.lucene.codecs.KnnVectorsReader;
+import org.apache.lucene.document.KnnVectorField;
+import org.apache.lucene.index.FieldInfo;
+import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.index.VectorSimilarityFunction;
+import org.apache.lucene.search.ConstantScoreScorer;
+import org.apache.lucene.search.ConstantScoreWeight;
+import org.apache.lucene.search.DocIdSetIterator;
+import org.apache.lucene.search.IndexSearcher;
+import org.apache.lucene.search.Query;
+import org.apache.lucene.search.QueryVisitor;
+import org.apache.lucene.search.ScoreDoc;
+import org.apache.lucene.search.ScoreMode;
+import org.apache.lucene.search.Scorer;
+import org.apache.lucene.search.TopDocs;
+import org.apache.lucene.search.Weight;
+import org.apache.lucene.util.Bits;
+import org.apache.lucene.util.DocIdSetBuilder;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Objects;
+
+/**
+ * Uses {@link KnnVectorsReader#search} to find the nearest neighbors within a given search radius.
+ */
+public class VectorRadiusQuery extends Query {
+    private final String field;
+    private final float[] origin;
+    private final float radius;
+    private final int numCands;
+
+    /**
+     * Find the documents with the nearest vectors to the origin vector within a search radius.
+     * The radius is expressed in terms of the vector similarity (see {@link VectorSimilarityFunction}).
+     *
+     * @param field a field that has been indexed as a {@link KnnVectorField}.
+     * @param origin the origin vector for the search
+     * @param radius the search radius that the candidate vectors must fall in to be returned
+     * @param numCands the number of nearest neighbor candidates to consider per segment
+     */
+    public VectorRadiusQuery(String field, float[] origin, float radius, int numCands) {
+        this.field = field;
+        this.origin = origin;
+        this.radius = radius;
+        this.numCands = numCands;
+    }
+
+    @Override
+    public String toString(String field) {
+        return getClass().getSimpleName() + ":" + this.field + "[" + origin[0] + ",...][" + radius + "][" + numCands + "]";
+    }
+
+    @Override
+    public void visit(QueryVisitor visitor) {
+        if (visitor.acceptField(field)) {
+            visitor.visitLeaf(this);
+        }
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        VectorRadiusQuery that = (VectorRadiusQuery) o;
+        return Float.compare(that.radius, radius) == 0
+            && numCands == that.numCands
+            && Objects.equals(field, that.field)
+            && Arrays.equals(origin, that.origin);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = Objects.hash(field, radius, numCands);
+        result = 31 * result + Arrays.hashCode(origin);
+        return result;
+    }
+
+    @Override
+    public Weight createWeight(IndexSearcher searcher, ScoreMode scoreMode, float boost) {
+        return new ConstantScoreWeight(this, boost) {
+
+            @Override
+            public Scorer scorer(LeafReaderContext context) throws IOException {
+                Bits acceptDocs = context.reader().getLiveDocs();
+                TopDocs topDocs = context.reader().searchNearestVectors(field, origin, numCands, acceptDocs, Integer.MAX_VALUE);
+                if (topDocs == null) {
+                    return null;
+                }
+
+                // Only keep the vector candidates that satisfy the search radius
+                FieldInfo fi = context.reader().getFieldInfos().fieldInfo(field);
+                assert fi != null && fi.hasVectorValues();
+
+                DocIdSetBuilder builder = new DocIdSetBuilder(context.reader().maxDoc());
+                DocIdSetBuilder.BulkAdder adder = builder.grow(topDocs.scoreDocs.length);
+
+                VectorSimilarityFunction similarityFunction = fi.getVectorSimilarityFunction();
+                float minScore = similarityFunction.convertToScore(radius);
+                for (ScoreDoc scoreDoc : topDocs.scoreDocs) {
+                    if (scoreDoc.score >= minScore) {
+                        adder.add(scoreDoc.doc);
+                    }
+                }
+
+                DocIdSetIterator iterator = builder.build().iterator();
+                return new ConstantScoreScorer(this, boost, scoreMode, iterator);
+            }
+
+            @Override
+            public boolean isCacheable(LeafReaderContext ctx) {
+                return true;
+            }
+        };
+    }
+}

--- a/x-pack/plugin/vectors/src/main/java/org/elasticsearch/xpack/vectors/query/VectorRadiusQueryBuilder.java
+++ b/x-pack/plugin/vectors/src/main/java/org/elasticsearch/xpack/vectors/query/VectorRadiusQueryBuilder.java
@@ -1,0 +1,150 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.vectors.query;
+
+import org.apache.lucene.search.KnnVectorQuery;
+import org.apache.lucene.search.Query;
+import org.elasticsearch.Version;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.index.mapper.MappedFieldType;
+import org.elasticsearch.index.query.AbstractQueryBuilder;
+import org.elasticsearch.index.query.SearchExecutionContext;
+import org.elasticsearch.xcontent.ConstructingObjectParser;
+import org.elasticsearch.xcontent.ParseField;
+import org.elasticsearch.xcontent.XContentBuilder;
+import org.elasticsearch.xcontent.XContentParser;
+import org.elasticsearch.xpack.vectors.mapper.DenseVectorFieldMapper;
+import org.elasticsearch.xpack.vectors.mapper.DenseVectorFieldMapper.DenseVectorFieldType;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+
+import static org.elasticsearch.xcontent.ConstructingObjectParser.constructorArg;
+
+/**
+ * A query that performs kNN search using Lucene's {@link KnnVectorQuery}.
+ *
+ * NOTE: this is an internal class and should not be used outside of core Elasticsearch code.
+ */
+public class VectorRadiusQueryBuilder extends AbstractQueryBuilder<VectorRadiusQueryBuilder> {
+    public static final String NAME = "vector_radius";
+
+    private final String fieldName;
+    private final float[] origin;
+    private final float radius;
+    private final int numCands;
+
+    public VectorRadiusQueryBuilder(String fieldName, float[] origin, float radius, int numCands) {
+        this.fieldName = fieldName;
+        this.origin = origin;
+        this.radius = radius;
+        this.numCands = numCands;
+    }
+
+    public VectorRadiusQueryBuilder(StreamInput in) throws IOException {
+        super(in);
+        this.fieldName = in.readString();
+        this.numCands = in.readVInt();
+        this.origin = in.readFloatArray();
+        this.radius = in.readFloat();
+    }
+
+    @Override
+    protected void doWriteTo(StreamOutput out) throws IOException {
+        out.writeString(fieldName);
+        out.writeFloatArray(origin);
+        out.writeFloat(radius);
+        out.writeVInt(numCands);
+    }
+
+    private static final ParseField FIELD_FIELD = new ParseField("field");
+    private static final ParseField ORIGIN_FIELD = new ParseField("origin");
+    private static final ParseField RADIUS_FIELD = new ParseField("radius");
+    private static final ParseField NUM_CANDS_FIELD = new ParseField("num_candidates");
+
+    private static final ConstructingObjectParser<VectorRadiusQueryBuilder, Void> PARSER = new ConstructingObjectParser<>(
+        "vector_radius",
+        args -> {
+            @SuppressWarnings("unchecked")
+            List<Float> vector = (List<Float>) args[1];
+            float[] vectorArray = new float[vector.size()];
+            for (int i = 0; i < vector.size(); i++) {
+                vectorArray[i] = vector.get(i);
+            }
+            return new VectorRadiusQueryBuilder((String) args[0], vectorArray, (float) args[2], (int) args[3]);
+        }
+    );
+
+    static {
+        PARSER.declareString(constructorArg(), FIELD_FIELD);
+        PARSER.declareFloatArray(constructorArg(), ORIGIN_FIELD);
+        PARSER.declareFloat(constructorArg(), RADIUS_FIELD);
+        PARSER.declareInt(constructorArg(), NUM_CANDS_FIELD);
+        PARSER.declareFloat(VectorRadiusQueryBuilder::boost, BOOST_FIELD);
+        PARSER.declareString(VectorRadiusQueryBuilder::queryName, NAME_FIELD);
+    }
+
+    public static VectorRadiusQueryBuilder fromXContent(XContentParser parser) throws IOException {
+        return PARSER.parse(parser, null);
+    }
+
+    @Override
+    protected void doXContent(XContentBuilder builder, Params params) throws IOException {
+        builder.startObject(NAME)
+            .field("field", fieldName)
+            .field("origin", origin)
+            .field("radius", radius)
+            .field("num_candidates", numCands);
+        boostAndQueryNameToXContent(builder);
+        builder.endObject();
+    }
+
+    @Override
+    public String getWriteableName() {
+        return NAME;
+    }
+
+    @Override
+    protected Query doToQuery(SearchExecutionContext context) {
+        MappedFieldType fieldType = context.getFieldType(fieldName);
+        if (fieldType == null) {
+            throw new IllegalArgumentException("field [" + fieldName + "] does not exist in the mapping");
+        }
+
+        if (fieldType instanceof DenseVectorFieldType == false) {
+            throw new IllegalArgumentException(
+                "[" + NAME + "] queries are only supported on [" + DenseVectorFieldMapper.CONTENT_TYPE + "] fields"
+            );
+        }
+
+        DenseVectorFieldType vectorFieldType = (DenseVectorFieldType) fieldType;
+        return vectorFieldType.createRadiusQuery(origin, numCands, radius);
+    }
+
+    @Override
+    protected int doHashCode() {
+        return Objects.hash(fieldName, Arrays.hashCode(origin), numCands, radius);
+    }
+
+    @Override
+    protected boolean doEquals(VectorRadiusQueryBuilder other) {
+        return Objects.equals(fieldName, other.fieldName)
+            && Arrays.equals(origin, other.origin)
+            && numCands == other.numCands
+            && radius == other.radius;
+    }
+
+    @Override
+    public Version getMinimalSupportedVersion() {
+        return Version.V_8_3_0;
+    }
+
+}

--- a/x-pack/plugin/vectors/src/test/java/org/elasticsearch/xpack/vectors/query/VectorRadiusQueryTests.java
+++ b/x-pack/plugin/vectors/src/test/java/org/elasticsearch/xpack/vectors/query/VectorRadiusQueryTests.java
@@ -1,0 +1,313 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.vectors.query;
+
+import org.apache.lucene.document.Document;
+import org.apache.lucene.document.Field;
+import org.apache.lucene.document.KnnVectorField;
+import org.apache.lucene.document.StringField;
+import org.apache.lucene.index.DirectoryReader;
+import org.apache.lucene.index.IndexReader;
+import org.apache.lucene.index.IndexWriter;
+import org.apache.lucene.index.IndexWriterConfig;
+import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.index.Term;
+import org.apache.lucene.index.VectorValues;
+import org.apache.lucene.search.IndexSearcher;
+import org.apache.lucene.search.MatchAllDocsQuery;
+import org.apache.lucene.search.Query;
+import org.apache.lucene.search.ScoreDoc;
+import org.apache.lucene.search.TermQuery;
+import org.apache.lucene.search.TopDocs;
+import org.apache.lucene.store.Directory;
+import org.apache.lucene.tests.index.RandomIndexWriter;
+import org.apache.lucene.tests.util.LuceneTestCase;
+
+import java.io.IOException;
+import java.util.HashSet;
+import java.util.Set;
+
+import static com.carrotsearch.randomizedtesting.RandomizedTest.frequently;
+import static org.apache.lucene.index.VectorSimilarityFunction.COSINE;
+import static org.apache.lucene.search.DocIdSetIterator.NO_MORE_DOCS;
+
+public class VectorRadiusQueryTests extends LuceneTestCase {
+
+    public void testEquals() {
+        VectorRadiusQuery q1 = new VectorRadiusQuery("f1", new float[] { 0, 1 }, 0.25f, 10);
+
+        assertEquals(q1, new VectorRadiusQuery("f1", new float[] { 0, 1 }, 0.25f, 10));
+        assertNotEquals(null, q1);
+        assertNotEquals(q1, new TermQuery(new Term("f1", "x")));
+
+        assertNotEquals(q1, new VectorRadiusQuery("f2", new float[] { 0, 1 }, 0.25f, 10));
+        assertNotEquals(q1, new VectorRadiusQuery("f1", new float[] { 1, 1 }, 0.25f, 10));
+        assertNotEquals(q1, new VectorRadiusQuery("f1", new float[] { 0, 1 }, 0.5f, 2));
+        assertNotEquals(q1, new VectorRadiusQuery("f1", new float[] { 0, 1 }, 0.25f, 2));
+        assertNotEquals(q1, new VectorRadiusQuery("f1", new float[] { 0 }, 0.25f, 10));
+    }
+
+    public void testToString() {
+        VectorRadiusQuery q1 = new VectorRadiusQuery("f1", new float[] { 0, 1 }, 0.25f, 10);
+        assertEquals("VectorRadiusQuery:f1[0.0,...][0.25][10]", q1.toString("ignored"));
+    }
+
+    public void testDimensionMismatch() throws IOException {
+        try (
+            Directory indexStore = getIndexStore("field", new float[] { 0, 1 }, new float[] { 1, 2 }, new float[] { 0, 0 });
+            IndexReader reader = DirectoryReader.open(indexStore)
+        ) {
+            IndexSearcher searcher = newSearcher(reader);
+            VectorRadiusQuery kvq = new VectorRadiusQuery("field", new float[] { 0 }, 0.5f, 10);
+            IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> searcher.search(kvq, 10));
+            assertEquals("vector dimensions differ: 1!=2", e.getMessage());
+        }
+    }
+
+    public void testNonVectorField() throws IOException {
+        try (
+            Directory indexStore = getIndexStore("field", new float[] { 0, 1 }, new float[] { 1, 2 }, new float[] { 0, 0 });
+            IndexReader reader = DirectoryReader.open(indexStore)
+        ) {
+            IndexSearcher searcher = newSearcher(reader);
+            assertMatches(searcher, new VectorRadiusQuery("xyzzy", new float[] { 0 }, 0.3f, 10), 0);
+            assertMatches(searcher, new VectorRadiusQuery("id", new float[] { 0 }, 0.3f, 10), 0);
+        }
+    }
+
+    public void testEmptyIndex() throws IOException {
+        try (Directory indexStore = getIndexStore("field"); IndexReader reader = DirectoryReader.open(indexStore)) {
+            IndexSearcher searcher = newSearcher(reader);
+            VectorRadiusQuery query = new VectorRadiusQuery("field", new float[] { 1, 2 }, -1.0f, 10);
+            assertMatches(searcher, query, 0);
+        }
+    }
+
+    public void testFindAll() throws IOException {
+        try (
+            Directory indexStore = getIndexStore(
+                "field",
+                new float[] { 0.0f, 1.0f },
+                new float[] { 1.0f, 2.0f },
+                new float[] { 0.1f, 0.1f }
+            );
+            IndexReader reader = DirectoryReader.open(indexStore)
+        ) {
+            IndexSearcher searcher = newSearcher(reader);
+
+            VectorRadiusQuery query = new VectorRadiusQuery("field", new float[] { 0.1f, 1.0f }, 0.0f, 10);
+            ScoreDoc[] scoreDocs = searcher.search(query, 3).scoreDocs;
+            assertIdsMatch(reader, scoreDocs, "id0", "id1", "id2");
+        }
+    }
+
+    public void testFindNone() throws IOException {
+        try (
+            Directory indexStore = getIndexStore(
+                "field",
+                new float[] { 0.0f, 1.0f },
+                new float[] { 1.0f, 2.0f },
+                new float[] { 0.1f, 0.1f }
+            );
+            IndexReader reader = DirectoryReader.open(indexStore)
+        ) {
+            IndexSearcher searcher = newSearcher(reader);
+            VectorRadiusQuery query = new VectorRadiusQuery("field", new float[] { 0.1f, 1.0f }, 1.0f, 10);
+            assertMatches(searcher, query, 0);
+        }
+    }
+
+    public void testBasicQuery() throws IOException {
+        try (Directory d = newDirectory()) {
+            try (IndexWriter w = new IndexWriter(d, new IndexWriterConfig())) {
+                int id = 0;
+                for (int i = 1; i < 6; i++) {
+                    for (int j = 0; j < 5; j++) {
+                        Document doc = new Document();
+                        doc.add(new KnnVectorField("field", new float[] { i, j }, COSINE));
+                        doc.add(new StringField("id", "id" + id++, Field.Store.YES));
+                        w.addDocument(doc);
+                    }
+                    w.flush();
+                }
+            }
+            try (IndexReader reader = DirectoryReader.open(d)) {
+                IndexSearcher searcher = newSearcher(reader);
+                TopDocs results = searcher.search(new VectorRadiusQuery("field", new float[] { 2.0f, 0.0f }, 0.99f, 10), 50);
+                assertIdsMatch(reader, results.scoreDocs, "id0", "id5", "id10", "id15", "id20");
+            }
+        }
+    }
+
+    /**
+     * Tests with random vectors, number of documents, etc. Uses RandomIndexWriter.
+     */
+    public void testRandom() throws IOException {
+        int numDocs = atLeast(500);
+        int dimension = atLeast(5);
+        int numIters = atLeast(10);
+        boolean everyDocHasAVector = random().nextBoolean();
+        try (Directory d = newDirectory()) {
+            RandomIndexWriter w = new RandomIndexWriter(random(), d);
+            for (int i = 0; i < numDocs; i++) {
+                Document doc = new Document();
+                if (everyDocHasAVector || random().nextInt(10) != 2) {
+                    doc.add(new KnnVectorField("field", randomVector(dimension), COSINE));
+                }
+                w.addDocument(doc);
+            }
+            w.forceMerge(1);
+            w.close();
+
+            try (IndexReader reader = DirectoryReader.open(d)) {
+                IndexSearcher searcher = newSearcher(reader);
+                for (int i = 0; i < numIters; i++) {
+                    float[] queryVector = randomVector(dimension);
+                    int numCands = random().nextInt(50) + 1;
+                    // Choose a generous radius so we're very likely to match some documents
+                    VectorRadiusQuery query = new VectorRadiusQuery("field", queryVector, 0.5f, numCands);
+
+                    int n = random().nextInt(100) + 1;
+                    TopDocs results = searcher.search(query, n);
+                    assertTrue(results.totalHits.value >= results.scoreDocs.length);
+
+                    // verify the results are in descending doc ID order and the vectors are within the radius
+                    assert reader.leaves().size() == 1;
+                    LeafReaderContext context = reader.leaves().get(0);
+                    VectorValues vectorValues = context.reader().getVectorValues("field");
+
+                    int last = -1;
+                    for (ScoreDoc scoreDoc : results.scoreDocs) {
+                        int nextDoc = vectorValues.advance(scoreDoc.doc);
+                        assertNotEquals(NO_MORE_DOCS, nextDoc);
+
+                        float similarity = COSINE.compare(queryVector, vectorValues.vectorValue());
+                        assertTrue(similarity >= 0.5f);
+
+                        assertTrue(scoreDoc.doc > last);
+                        last = scoreDoc.doc;
+                    }
+                }
+            }
+        }
+    }
+
+    public void testDeletes() throws IOException {
+        try (Directory dir = newDirectory(); IndexWriter w = new IndexWriter(dir, newIndexWriterConfig())) {
+            final int numDocs = atLeast(100);
+            final int dim = 30;
+            for (int i = 0; i < numDocs; ++i) {
+                Document d = new Document();
+                d.add(new StringField("index", String.valueOf(i), Field.Store.YES));
+                if (frequently()) {
+                    d.add(new KnnVectorField("vector", randomVector(dim), COSINE));
+                }
+                w.addDocument(d);
+            }
+            w.commit();
+
+            // Delete some documents at random, both those with and without vectors
+            Set<Term> toDelete = new HashSet<>();
+            for (int i = 0; i < 25; i++) {
+                int index = random().nextInt(numDocs);
+                toDelete.add(new Term("index", String.valueOf(index)));
+            }
+            w.deleteDocuments(toDelete.toArray(new Term[0]));
+            w.commit();
+
+            int hits = 50;
+            try (IndexReader reader = DirectoryReader.open(dir)) {
+                Set<String> allIds = new HashSet<>();
+                IndexSearcher searcher = new IndexSearcher(reader);
+                VectorRadiusQuery query = new VectorRadiusQuery("vector", randomVector(dim), 0.0f, 100);
+                TopDocs topDocs = searcher.search(query, hits);
+                for (ScoreDoc scoreDoc : topDocs.scoreDocs) {
+                    Document doc = reader.document(scoreDoc.doc, Set.of("index"));
+                    String index = doc.get("index");
+                    assertFalse("search returned a deleted document: " + index, toDelete.contains(new Term("index", index)));
+                    allIds.add(index);
+                }
+                assertEquals("search missed some documents", hits, allIds.size());
+            }
+        }
+    }
+
+    public void testAllDeletes() throws IOException {
+        try (Directory dir = newDirectory(); IndexWriter w = new IndexWriter(dir, newIndexWriterConfig())) {
+            final int numDocs = atLeast(100);
+            final int dim = 30;
+            for (int i = 0; i < numDocs; ++i) {
+                Document d = new Document();
+                d.add(new KnnVectorField("vector", randomVector(dim)));
+                w.addDocument(d);
+            }
+            w.commit();
+
+            w.deleteDocuments(new MatchAllDocsQuery());
+            w.commit();
+
+            try (IndexReader reader = DirectoryReader.open(dir)) {
+                IndexSearcher searcher = new IndexSearcher(reader);
+                VectorRadiusQuery query = new VectorRadiusQuery("vector", randomVector(dim), 0.0f, numDocs);
+                TopDocs topDocs = searcher.search(query, numDocs);
+                assertEquals(0, topDocs.scoreDocs.length);
+            }
+        }
+    }
+
+    /**
+     * Creates a new directory and adds documents with the given vectors as kNN vector fields
+     */
+    private Directory getIndexStore(String field, float[]... contents) throws IOException {
+        Directory indexStore = newDirectory();
+        RandomIndexWriter writer = new RandomIndexWriter(random(), indexStore);
+        for (int i = 0; i < contents.length; ++i) {
+            Document doc = new Document();
+            doc.add(new KnnVectorField(field, contents[i], COSINE));
+            doc.add(new StringField("id", "id" + i, Field.Store.YES));
+            writer.addDocument(doc);
+        }
+        // Add some documents without a vector
+        for (int i = 0; i < 5; i++) {
+            Document doc = new Document();
+            doc.add(new StringField("other", "value", Field.Store.NO));
+            writer.addDocument(doc);
+        }
+
+        writer.close();
+        return indexStore;
+    }
+
+    private static float[] randomVector(int dimension) {
+        float[] result = new float[dimension];
+        result[0] = random().nextFloat() + 0.01f;
+        for (int i = 1; i < dimension; i++) {
+            result[i] = random().nextFloat();
+        }
+        return result;
+    }
+
+    private void assertMatches(IndexSearcher searcher, Query q, int expectedMatches) throws IOException {
+        ScoreDoc[] result = searcher.search(q, 1000).scoreDocs;
+        assertEquals(expectedMatches, result.length);
+    }
+
+    private void assertIdsMatch(IndexReader reader, ScoreDoc[] scoreDocs, String... expectedIds) throws IOException {
+        Set<String> actualIds = new HashSet<>();
+        for (ScoreDoc scoreDoc : scoreDocs) {
+            String actualId = reader.document(scoreDoc.doc).get("id");
+            boolean exists = actualIds.add(actualId);
+            assertTrue("the results contained a duplicate ID, which should never happen", exists);
+        }
+
+        assertEquals("wrong number of results", expectedIds.length, actualIds.size());
+        for (String expectedId : expectedIds) {
+            assertTrue("ID " + expectedId + " is missing in results", actualIds.contains(expectedId));
+        }
+    }
+}


### PR DESCRIPTION
DRAFT: not ready for review

This PR adds support for a radius query on dense vector fields. Instead of always returning k results like kNN search, radius queries return vectors within a specific similarity to the query vector.

```
POST index/_search
{
 "query": {
   "bool": {
     "should": [
       "match": {
         "description": "flower dress"
       },
       "vector_radius": {
         "field": "image-vector",
         "query_vector": [0.1, ....],
         "radius": 0.24,
         "num_candidates": 100
       }
     ]
   }
 }
} 
```

The new query uses Lucene’s ANN search methods to retrieve `num_candidates` nearest neighbors per segment. Then it filters out those candidates that are not within the search radius. This means it's important to pick a sufficiently large `num_candidates` to make sure the results are not too incomplete. The implementation is essentially the same as kNN search, except we apply a radius cutoff instead of taking the top k.