### PR TITLE
[7.17] Fix audit logging to consistently include port number in origin.address (#86732)

### DIFF
--- a/docs/changelog/86732.yaml
+++ b/docs/changelog/86732.yaml
@@ -1,0 +1,5 @@
+pr: 86732
+summary: Fix audit logging to consistently include port number in `origin.address`
+area: Audit
+type: bug
+issues: []

--- a/x-pack/docs/en/security/auditing/event-types.asciidoc
+++ b/x-pack/docs/en/security/auditing/event-types.asciidoc
@@ -188,7 +188,7 @@ Logged when an incoming TCP connection does not pass the
 [source,js]
 {"type":"audit", "timestamp":"2020-12-30T21:47:31,526+0200", "node.id":
 "0RMNyghkQYCc_gVd1G6tZQ", "event.type":"ip_filter", "event.action":
-"connection_denied", "origin.type":"rest", "origin.address":"10.10.0.20",
+"connection_denied", "origin.type":"rest", "origin.address":"10.10.0.20:52314",
 "transport.profile":".http", "rule":"deny 10.10.0.0/16"}
 ====
 
@@ -203,7 +203,7 @@ for a specific profile.
 [source,js]
 {"type":"audit", "timestamp":"2020-12-30T21:47:31,526+0200", "node.id":
 "0RMNyghkQYCc_gVd1G6tZQ", "event.type":"ip_filter", "event.action":
-"connection_granted", "origin.type":"rest", "origin.address":"::1",
+"connection_granted", "origin.type":"rest", "origin.address":"[::1]:52314",
 "transport.profile":".http", "rule":"allow ::1,127.0.0.1"}
 ====
 

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/audit/AuditTrail.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/audit/AuditTrail.java
@@ -15,7 +15,7 @@ import org.elasticsearch.xpack.core.security.authc.AuthenticationToken;
 import org.elasticsearch.xpack.core.security.authz.AuthorizationEngine.AuthorizationInfo;
 import org.elasticsearch.xpack.security.transport.filter.SecurityIpFilterRule;
 
-import java.net.InetAddress;
+import java.net.InetSocketAddress;
 
 public interface AuditTrail {
 
@@ -66,14 +66,14 @@ public interface AuditTrail {
     void tamperedRequest(String requestId, Authentication authentication, String action, TransportRequest transportRequest);
 
     /**
-     * The {@link #connectionGranted(InetAddress, String, SecurityIpFilterRule)} and
-     * {@link #connectionDenied(InetAddress, String, SecurityIpFilterRule)} methods do not have a requestId because they related to a
+     * The {@link #connectionGranted(InetSocketAddress, String, SecurityIpFilterRule)} and
+     * {@link #connectionDenied(InetSocketAddress, String, SecurityIpFilterRule)} methods do not have a requestId because they related to a
      * potentially long-lived TCP connection, not a single request. For both Transport and Rest connections, a single connection
      * granted/denied event is generated even if that connection is used for multiple Elasticsearch actions (potentially as different users)
      */
-    void connectionGranted(InetAddress inetAddress, String profile, SecurityIpFilterRule rule);
+    void connectionGranted(InetSocketAddress inetAddress, String profile, SecurityIpFilterRule rule);
 
-    void connectionDenied(InetAddress inetAddress, String profile, SecurityIpFilterRule rule);
+    void connectionDenied(InetSocketAddress inetAddress, String profile, SecurityIpFilterRule rule);
 
     void runAsGranted(
         String requestId,

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/audit/AuditTrailService.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/audit/AuditTrailService.java
@@ -19,7 +19,7 @@ import org.elasticsearch.xpack.core.security.authz.AuthorizationEngine.Authoriza
 import org.elasticsearch.xpack.security.Security;
 import org.elasticsearch.xpack.security.transport.filter.SecurityIpFilterRule;
 
-import java.net.InetAddress;
+import java.net.InetSocketAddress;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.Collections;
@@ -150,10 +150,10 @@ public class AuditTrailService {
         public void tamperedRequest(String requestId, Authentication authentication, String action, TransportRequest transportRequest) {}
 
         @Override
-        public void connectionGranted(InetAddress inetAddress, String profile, SecurityIpFilterRule rule) {}
+        public void connectionGranted(InetSocketAddress inetAddress, String profile, SecurityIpFilterRule rule) {}
 
         @Override
-        public void connectionDenied(InetAddress inetAddress, String profile, SecurityIpFilterRule rule) {}
+        public void connectionDenied(InetSocketAddress inetAddress, String profile, SecurityIpFilterRule rule) {}
 
         @Override
         public void runAsGranted(
@@ -362,14 +362,14 @@ public class AuditTrailService {
         }
 
         @Override
-        public void connectionGranted(InetAddress inetAddress, String profile, SecurityIpFilterRule rule) {
+        public void connectionGranted(InetSocketAddress inetAddress, String profile, SecurityIpFilterRule rule) {
             for (AuditTrail auditTrail : auditTrails) {
                 auditTrail.connectionGranted(inetAddress, profile, rule);
             }
         }
 
         @Override
-        public void connectionDenied(InetAddress inetAddress, String profile, SecurityIpFilterRule rule) {
+        public void connectionDenied(InetSocketAddress inetAddress, String profile, SecurityIpFilterRule rule) {
             for (AuditTrail auditTrail : auditTrails) {
                 auditTrail.connectionDenied(inetAddress, profile, rule);
             }

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/audit/logfile/LoggingAuditTrail.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/audit/logfile/LoggingAuditTrail.java
@@ -90,7 +90,6 @@ import org.elasticsearch.xpack.security.transport.filter.IPFilter;
 import org.elasticsearch.xpack.security.transport.filter.SecurityIpFilterRule;
 
 import java.io.IOException;
-import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.util.Arrays;
 import java.util.Collections;
@@ -879,7 +878,7 @@ public class LoggingAuditTrail implements AuditTrail, ClusterStateListener {
     }
 
     @Override
-    public void connectionGranted(InetAddress inetAddress, String profile, SecurityIpFilterRule rule) {
+    public void connectionGranted(InetSocketAddress inetAddress, String profile, SecurityIpFilterRule rule) {
         if (events.contains(CONNECTION_GRANTED) && eventFilterPolicyRegistry.ignorePredicate().test(AuditEventMetaInfo.EMPTY) == false) {
             new LogEntryBuilder().with(EVENT_TYPE_FIELD_NAME, IP_FILTER_ORIGIN_FIELD_VALUE)
                 .with(EVENT_ACTION_FIELD_NAME, "connection_granted")
@@ -896,7 +895,7 @@ public class LoggingAuditTrail implements AuditTrail, ClusterStateListener {
     }
 
     @Override
-    public void connectionDenied(InetAddress inetAddress, String profile, SecurityIpFilterRule rule) {
+    public void connectionDenied(InetSocketAddress inetAddress, String profile, SecurityIpFilterRule rule) {
         if (events.contains(CONNECTION_DENIED) && eventFilterPolicyRegistry.ignorePredicate().test(AuditEventMetaInfo.EMPTY) == false) {
             new LogEntryBuilder().with(EVENT_TYPE_FIELD_NAME, IP_FILTER_ORIGIN_FIELD_VALUE)
                 .with(EVENT_ACTION_FIELD_NAME, "connection_denied")

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/transport/filter/IPFilter.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/transport/filter/IPFilter.java
@@ -288,15 +288,15 @@ public class IPFilter {
             if (rule.matches(peerAddress)) {
                 boolean isAllowed = rule.ruleType() == IpFilterRuleType.ACCEPT;
                 if (isAllowed) {
-                    auditTrail.connectionGranted(peerAddress.getAddress(), profile, rule);
+                    auditTrail.connectionGranted(peerAddress, profile, rule);
                 } else {
-                    auditTrail.connectionDenied(peerAddress.getAddress(), profile, rule);
+                    auditTrail.connectionDenied(peerAddress, profile, rule);
                 }
                 return isAllowed;
             }
         }
 
-        auditTrail.connectionGranted(peerAddress.getAddress(), profile, DEFAULT_PROFILE_ACCEPT_ALL);
+        auditTrail.connectionGranted(peerAddress, profile, DEFAULT_PROFILE_ACCEPT_ALL);
         return true;
     }
 

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/audit/AuditTrailServiceTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/audit/AuditTrailServiceTests.java
@@ -27,6 +27,7 @@ import org.elasticsearch.xpack.security.transport.filter.SecurityIpFilterRule;
 import org.junit.Before;
 
 import java.net.InetAddress;
+import java.net.InetSocketAddress;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.ArrayList;
@@ -260,7 +261,7 @@ public class AuditTrailServiceTests extends ESTestCase {
     }
 
     public void testConnectionGranted() throws Exception {
-        InetAddress inetAddress = InetAddress.getLoopbackAddress();
+        InetSocketAddress inetAddress = new InetSocketAddress(InetAddress.getLoopbackAddress(), randomIntBetween(0, 65535));
         SecurityIpFilterRule rule = randomBoolean() ? SecurityIpFilterRule.ACCEPT_ALL : IPFilter.DEFAULT_PROFILE_ACCEPT_ALL;
         service.get().connectionGranted(inetAddress, "client", rule);
         verify(licenseState).isAllowed(Security.AUDITING_FEATURE);
@@ -274,7 +275,7 @@ public class AuditTrailServiceTests extends ESTestCase {
     }
 
     public void testConnectionDenied() throws Exception {
-        InetAddress inetAddress = InetAddress.getLoopbackAddress();
+        InetSocketAddress inetAddress = new InetSocketAddress(InetAddress.getLoopbackAddress(), randomIntBetween(0, 65535));
         SecurityIpFilterRule rule = new SecurityIpFilterRule(false, "_all");
         service.get().connectionDenied(inetAddress, "client", rule);
         verify(licenseState).isAllowed(Security.AUDITING_FEATURE);

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/audit/logfile/LoggingAuditTrailFilterTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/audit/logfile/LoggingAuditTrailFilterTests.java
@@ -1101,7 +1101,7 @@ public class LoggingAuditTrailFilterTests extends ESTestCase {
         threadContext.stashContext();
 
         // connection denied
-        auditTrail.connectionDenied(InetAddress.getLoopbackAddress(), "default", new SecurityIpFilterRule(false, "_all"));
+        auditTrail.connectionDenied(randomLoopbackInetSocketAddress(), "default", new SecurityIpFilterRule(false, "_all"));
         if (filterMissingUser) {
             assertThat("Connection denied: is not filtered out by the missing user filter", logOutput.size(), is(0));
         } else {
@@ -1111,7 +1111,7 @@ public class LoggingAuditTrailFilterTests extends ESTestCase {
         threadContext.stashContext();
 
         // connection granted
-        auditTrail.connectionGranted(InetAddress.getLoopbackAddress(), "default", new SecurityIpFilterRule(false, "_all"));
+        auditTrail.connectionGranted(randomLoopbackInetSocketAddress(), "default", new SecurityIpFilterRule(false, "_all"));
         if (filterMissingUser) {
             assertThat("Connection granted: is not filtered out by the missing user filter", logOutput.size(), is(0));
         } else {
@@ -1550,7 +1550,7 @@ public class LoggingAuditTrailFilterTests extends ESTestCase {
         threadContext.stashContext();
 
         // connection denied
-        auditTrail.connectionDenied(InetAddress.getLoopbackAddress(), "default", new SecurityIpFilterRule(false, "_all"));
+        auditTrail.connectionDenied(randomLoopbackInetSocketAddress(), "default", new SecurityIpFilterRule(false, "_all"));
         if (filterMissingRealm) {
             assertThat("Connection denied: is not filtered out by the missing realm filter", logOutput.size(), is(0));
         } else {
@@ -1560,7 +1560,7 @@ public class LoggingAuditTrailFilterTests extends ESTestCase {
         threadContext.stashContext();
 
         // connection granted
-        auditTrail.connectionGranted(InetAddress.getLoopbackAddress(), "default", new SecurityIpFilterRule(false, "_all"));
+        auditTrail.connectionGranted(randomLoopbackInetSocketAddress(), "default", new SecurityIpFilterRule(false, "_all"));
         if (filterMissingRealm) {
             assertThat("Connection granted: is not filtered out by the missing realm filter", logOutput.size(), is(0));
         } else {
@@ -1885,7 +1885,7 @@ public class LoggingAuditTrailFilterTests extends ESTestCase {
         threadContext.stashContext();
 
         // connection denied
-        auditTrail.connectionDenied(InetAddress.getLoopbackAddress(), "default", new SecurityIpFilterRule(false, "_all"));
+        auditTrail.connectionDenied(randomLoopbackInetSocketAddress(), "default", new SecurityIpFilterRule(false, "_all"));
         if (filterMissingRoles) {
             assertThat("Connection denied: is not filtered out by the missing roles filter", logOutput.size(), is(0));
         } else {
@@ -1895,7 +1895,7 @@ public class LoggingAuditTrailFilterTests extends ESTestCase {
         threadContext.stashContext();
 
         // connection granted
-        auditTrail.connectionGranted(InetAddress.getLoopbackAddress(), "default", new SecurityIpFilterRule(false, "_all"));
+        auditTrail.connectionGranted(randomLoopbackInetSocketAddress(), "default", new SecurityIpFilterRule(false, "_all"));
         if (filterMissingRoles) {
             assertThat("Connection granted: is not filtered out by the missing roles filter", logOutput.size(), is(0));
         } else {
@@ -2341,7 +2341,7 @@ public class LoggingAuditTrailFilterTests extends ESTestCase {
         threadContext.stashContext();
 
         // connection denied
-        auditTrail.connectionDenied(InetAddress.getLoopbackAddress(), "default", new SecurityIpFilterRule(false, "_all"));
+        auditTrail.connectionDenied(randomLoopbackInetSocketAddress(), "default", new SecurityIpFilterRule(false, "_all"));
         if (filterMissingIndices) {
             assertThat("Connection denied: not filtered out by missing indices filter", logOutput.size(), is(0));
         } else {
@@ -2351,7 +2351,7 @@ public class LoggingAuditTrailFilterTests extends ESTestCase {
         threadContext.stashContext();
 
         // connection granted
-        auditTrail.connectionGranted(InetAddress.getLoopbackAddress(), "default", new SecurityIpFilterRule(false, "_all"));
+        auditTrail.connectionGranted(randomLoopbackInetSocketAddress(), "default", new SecurityIpFilterRule(false, "_all"));
         if (filterMissingIndices) {
             assertThat("Connection granted: not filtered out by missing indices filter", logOutput.size(), is(0));
         } else {
@@ -2623,7 +2623,7 @@ public class LoggingAuditTrailFilterTests extends ESTestCase {
         threadContext.stashContext();
 
         // connection denied
-        auditTrail.connectionDenied(InetAddress.getLoopbackAddress(), "default", new SecurityIpFilterRule(false, "_all"));
+        auditTrail.connectionDenied(randomLoopbackInetSocketAddress(), "default", new SecurityIpFilterRule(false, "_all"));
         if (filterMissingAction) {
             assertThat("Connection denied: not filtered out by the missing action filter", logOutput.size(), is(0));
         } else {
@@ -2633,7 +2633,7 @@ public class LoggingAuditTrailFilterTests extends ESTestCase {
         threadContext.stashContext();
 
         // connection granted
-        auditTrail.connectionGranted(InetAddress.getLoopbackAddress(), "default", new SecurityIpFilterRule(false, "_all"));
+        auditTrail.connectionGranted(randomLoopbackInetSocketAddress(), "default", new SecurityIpFilterRule(false, "_all"));
         if (filterMissingAction) {
             assertThat("Connection granted: not filtered out by the missing action filter", logOutput.size(), is(0));
         } else {
@@ -2721,6 +2721,10 @@ public class LoggingAuditTrailFilterTests extends ESTestCase {
         assertThat("AuthenticationSuccess message: unfiltered action is filtered out", logOutput.size(), is(1));
         logOutput.clear();
         threadContext.stashContext();
+    }
+
+    private InetSocketAddress randomLoopbackInetSocketAddress() {
+        return new InetSocketAddress(InetAddress.getLoopbackAddress(), randomIntBetween(0, 65535));
     }
 
     private <T> List<T> randomListFromLengthBetween(List<T> l, int min, int max) {

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/audit/logfile/LoggingAuditTrailTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/audit/logfile/LoggingAuditTrailTests.java
@@ -2049,7 +2049,7 @@ public class LoggingAuditTrailTests extends ESTestCase {
     }
 
     public void testConnectionDenied() throws Exception {
-        final InetAddress inetAddress = InetAddress.getLoopbackAddress();
+        final InetSocketAddress inetAddress = new InetSocketAddress(InetAddress.getLoopbackAddress(), randomIntBetween(0, 65535));
         final SecurityIpFilterRule rule = new SecurityIpFilterRule(false, "_all");
         final String profile = randomBoolean() ? IPFilter.HTTP_PROFILE_NAME : randomAlphaOfLengthBetween(1, 6);
 
@@ -2081,7 +2081,7 @@ public class LoggingAuditTrailTests extends ESTestCase {
     }
 
     public void testConnectionGranted() throws Exception {
-        final InetAddress inetAddress = InetAddress.getLoopbackAddress();
+        final InetSocketAddress inetAddress = new InetSocketAddress(InetAddress.getLoopbackAddress(), randomIntBetween(0, 65535));
         final SecurityIpFilterRule rule = IPFilter.DEFAULT_PROFILE_ACCEPT_ALL;
         final String profile = randomBoolean() ? IPFilter.HTTP_PROFILE_NAME : randomAlphaOfLengthBetween(1, 6);
 

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/transport/filter/IPFilterTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/transport/filter/IPFilterTests.java
@@ -296,8 +296,8 @@ public class IPFilterTests extends ESTestCase {
     private void assertAddressIsAllowedForProfile(String profile, String... inetAddresses) {
         for (String inetAddress : inetAddresses) {
             String message = String.format(Locale.ROOT, "Expected address %s to be allowed", inetAddress);
-            InetAddress address = InetAddresses.forString(inetAddress);
-            assertTrue(message, ipFilter.accept(profile, new InetSocketAddress(address, 0)));
+            InetSocketAddress address = new InetSocketAddress(InetAddresses.forString(inetAddress), 0);
+            assertTrue(message, ipFilter.accept(profile, address));
             ArgumentCaptor<SecurityIpFilterRule> ruleCaptor = ArgumentCaptor.forClass(SecurityIpFilterRule.class);
             verify(auditTrail).connectionGranted(eq(address), eq(profile), ruleCaptor.capture());
             assertNotNull(ruleCaptor.getValue());
@@ -311,8 +311,8 @@ public class IPFilterTests extends ESTestCase {
     private void assertAddressIsDeniedForProfile(String profile, String... inetAddresses) {
         for (String inetAddress : inetAddresses) {
             String message = String.format(Locale.ROOT, "Expected address %s to be denied", inetAddress);
-            InetAddress address = InetAddresses.forString(inetAddress);
-            assertFalse(message, ipFilter.accept(profile, new InetSocketAddress(address, 0)));
+            InetSocketAddress address = new InetSocketAddress(InetAddresses.forString(inetAddress), 0);
+            assertFalse(message, ipFilter.accept(profile, address));
             ArgumentCaptor<SecurityIpFilterRule> ruleCaptor = ArgumentCaptor.forClass(SecurityIpFilterRule.class);
             verify(auditTrail).connectionDenied(eq(address), eq(profile), ruleCaptor.capture());
             assertNotNull(ruleCaptor.getValue());


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `7.17`:
 - [Fix audit logging to consistently include port number in origin.address (#86732)](https://github.com/elastic/elasticsearch/pull/86732)

<!--- Backport version: 8.4.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)