### PR TITLE
Replace supplier of ParameterizedMessage with java.util.Supplier<String>

### DIFF
--- a/libs/core/src/main/java/org/elasticsearch/core/Strings.java
+++ b/libs/core/src/main/java/org/elasticsearch/core/Strings.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.core;
+
+import java.util.Locale;
+
+/**
+ * Utilities related to String class
+ */
+public class Strings {
+
+    /**
+     * Returns a formatted string using the specified format string and
+     * arguments.
+     *
+     * This method calls {@link String#format(Locale, String, Object...)}
+     * with Locale.ROOT
+     */
+    public static String format(String format, Object... args) {
+        return String.format(Locale.ROOT, format, args);
+    }
+}

--- a/modules/repository-azure/src/main/java/org/elasticsearch/repositories/azure/AzureBlobStore.java
+++ b/modules/repository-azure/src/main/java/org/elasticsearch/repositories/azure/AzureBlobStore.java
@@ -36,7 +36,6 @@ import com.azure.storage.blob.specialized.BlockBlobAsyncClient;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.message.ParameterizedMessage;
 import org.elasticsearch.cluster.metadata.RepositoryMetadata;
 import org.elasticsearch.common.UUIDs;
 import org.elasticsearch.common.blobstore.BlobContainer;
@@ -80,6 +79,8 @@ import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.BiConsumer;
 import java.util.function.BiPredicate;
 import java.util.stream.StreamSupport;
+
+import static org.elasticsearch.core.Strings.format;
 
 public class AzureBlobStore implements BlobStore {
     private static final Logger logger = LogManager.getLogger(AzureBlobStore.class);
@@ -286,7 +287,7 @@ public class AzureBlobStore implements BlobStore {
     }
 
     public InputStream getInputStream(String blob, long position, final @Nullable Long length) throws IOException {
-        logger.trace(() -> new ParameterizedMessage("reading container [{}], blob [{}]", container, blob));
+        logger.trace(() -> format("reading container [%s], blob [%s]", container, blob));
         final AzureBlobServiceClient azureBlobServiceClient = getAzureBlobServiceClientClient();
         final BlobServiceClient syncClient = azureBlobServiceClient.getSyncClient();
         final BlobServiceAsyncClient asyncClient = azureBlobServiceClient.getAsyncClient();
@@ -315,7 +316,7 @@ public class AzureBlobStore implements BlobStore {
 
     public Map<String, BlobMetadata> listBlobsByPrefix(String keyPath, String prefix) throws IOException {
         final var blobsBuilder = new HashMap<String, BlobMetadata>();
-        logger.trace(() -> new ParameterizedMessage("listing container [{}], keyPath [{}], prefix [{}]", container, keyPath, prefix));
+        logger.trace(() -> format("listing container [%s], keyPath [%s], prefix [%s]", container, keyPath, prefix));
         try {
             final BlobServiceClient client = client();
             SocketAccess.doPrivilegedVoidException(() -> {
@@ -426,7 +427,7 @@ public class AzureBlobStore implements BlobStore {
     public void writeBlob(String blobName, InputStream inputStream, long blobSize, boolean failIfAlreadyExists) throws IOException {
         assert inputStream.markSupported()
             : "Should not be used with non-mark supporting streams as their retry handling in the SDK is broken";
-        logger.trace(() -> new ParameterizedMessage("writeBlob({}, stream, {})", blobName, blobSize));
+        logger.trace(() -> format("writeBlob(%s, stream, %s)", blobName, blobSize));
         try {
             if (blobSize <= getLargeBlobThresholdInBytes()) {
                 final Flux<ByteBuffer> byteBufferFlux = convertStreamToByteBuffer(inputStream, blobSize, DEFAULT_UPLOAD_BUFFERS_SIZE);
@@ -445,7 +446,7 @@ public class AzureBlobStore implements BlobStore {
             throw new IOException("Unable to write blob " + blobName, e);
         }
 
-        logger.trace(() -> new ParameterizedMessage("writeBlob({}, stream, {}) - done", blobName, blobSize));
+        logger.trace(() -> format("writeBlob(%s, stream, %s) - done", blobName, blobSize));
     }
 
     private void executeSingleUpload(String blobName, Flux<ByteBuffer> byteBufferFlux, long blobSize, boolean failIfAlreadyExists) {

--- a/modules/repository-azure/src/main/java/org/elasticsearch/repositories/azure/AzureRepository.java
+++ b/modules/repository-azure/src/main/java/org/elasticsearch/repositories/azure/AzureRepository.java
@@ -10,7 +10,6 @@ package org.elasticsearch.repositories.azure;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.message.ParameterizedMessage;
 import org.elasticsearch.cluster.metadata.RepositoryMetadata;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.Strings;
@@ -29,6 +28,7 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.function.Function;
 
+import static org.elasticsearch.core.Strings.format;
 import static org.elasticsearch.repositories.azure.AzureStorageService.MAX_CHUNK_SIZE;
 import static org.elasticsearch.repositories.azure.AzureStorageService.MIN_CHUNK_SIZE;
 
@@ -155,8 +155,8 @@ public class AzureRepository extends MeteredBlobStoreRepository {
         final AzureBlobStore blobStore = new AzureBlobStore(metadata, storageService, bigArrays);
 
         logger.debug(
-            () -> new ParameterizedMessage(
-                "using container [{}], chunk_size [{}], compress [{}], base_path [{}]",
+            () -> format(
+                "using container [%s], chunk_size [%s], compress [%s], base_path [%s]",
                 blobStore,
                 chunkSize,
                 isCompress(),

--- a/modules/repository-gcs/src/main/java/org/elasticsearch/repositories/gcs/GoogleCloudStorageService.java
+++ b/modules/repository-gcs/src/main/java/org/elasticsearch/repositories/gcs/GoogleCloudStorageService.java
@@ -22,7 +22,6 @@ import com.google.cloud.storage.StorageOptions;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.message.ParameterizedMessage;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.collect.MapBuilder;
 import org.elasticsearch.common.util.Maps;
@@ -42,6 +41,7 @@ import java.util.Map;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Collections.emptyMap;
+import static org.elasticsearch.core.Strings.format;
 
 public class GoogleCloudStorageService {
 
@@ -107,9 +107,7 @@ public class GoogleCloudStorageService {
                 );
             }
 
-            logger.debug(
-                () -> new ParameterizedMessage("creating GCS client with client_name [{}], endpoint [{}]", clientName, settings.getHost())
-            );
+            logger.debug(() -> format("creating GCS client with client_name [%s], endpoint [%s]", clientName, settings.getHost()));
             final Storage storage = createClient(settings, stats);
             clientCache = Maps.copyMapWithAddedEntry(clientCache, repositoryName, storage);
             return storage;

--- a/server/src/main/java/org/elasticsearch/cluster/action/shard/ShardStateAction.java
+++ b/server/src/main/java/org/elasticsearch/cluster/action/shard/ShardStateAction.java
@@ -70,6 +70,8 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.function.Predicate;
 
+import static org.elasticsearch.core.Strings.format;
+
 public class ShardStateAction {
 
     private static final Logger logger = LogManager.getLogger(ShardStateAction.class);
@@ -882,7 +884,7 @@ public class ShardStateAction {
         @Override
         public void onFailure(Exception e) {
             if (e instanceof NotMasterException) {
-                logger.debug(() -> new ParameterizedMessage("{} no longer master while starting shard [{}]", entry.shardId, entry));
+                logger.debug(() -> format("%s no longer master while starting shard [%s]", entry.shardId, entry));
             } else if (e instanceof FailedToCommitClusterStateException) {
                 logger.debug(() -> new ParameterizedMessage("{} unexpected failure while starting shard [{}]", entry.shardId, entry), e);
             } else {

--- a/server/src/main/java/org/elasticsearch/cluster/coordination/Coordinator.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/Coordinator.java
@@ -93,6 +93,7 @@ import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
 import static org.elasticsearch.cluster.coordination.NoMasterBlockService.NO_MASTER_BLOCK_ID;
+import static org.elasticsearch.core.Strings.format;
 import static org.elasticsearch.gateway.ClusterStateUpdaters.hideStateIfNotRecovered;
 import static org.elasticsearch.gateway.GatewayService.STATE_NOT_RECOVERED_BLOCK;
 import static org.elasticsearch.monitor.StatusInfo.Status.UNHEALTHY;
@@ -1332,8 +1333,8 @@ public class Coordinator extends AbstractLifecycleComponent implements ClusterSt
             synchronized (mutex) {
                 if (mode != Mode.LEADER || getCurrentTerm() != clusterStatePublicationEvent.getNewState().term()) {
                     logger.debug(
-                        () -> new ParameterizedMessage(
-                            "[{}] failed publication as node is no longer master for term {}",
+                        () -> format(
+                            "[%s] failed publication as node is no longer master for term %s",
                             clusterStatePublicationEvent.getSummary(),
                             clusterStatePublicationEvent.getNewState().term()
                         )
@@ -1351,8 +1352,8 @@ public class Coordinator extends AbstractLifecycleComponent implements ClusterSt
                 if (currentPublication.isPresent()) {
                     assert false : "[" + currentPublication.get() + "] in progress, cannot start new publication";
                     logger.warn(
-                        () -> new ParameterizedMessage(
-                            "[{}] failed publication as already publication in progress",
+                        () -> format(
+                            "[%s] failed publication as already publication in progress",
                             clusterStatePublicationEvent.getSummary()
                         )
                     );

--- a/server/src/main/java/org/elasticsearch/cluster/coordination/PublicationTransportHandler.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/PublicationTransportHandler.java
@@ -51,6 +51,8 @@ import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
 
+import static org.elasticsearch.core.Strings.format;
+
 /**
  * Implements the low-level mechanics of sending a cluster state to other nodes in the cluster during a publication.
  * <p>
@@ -395,8 +397,8 @@ public class PublicationTransportHandler {
                 if (e instanceof final TransportException transportException) {
                     if (transportException.unwrapCause() instanceof IncompatibleClusterStateVersionException) {
                         logger.debug(
-                            () -> new ParameterizedMessage(
-                                "resending full cluster state to node {} reason {}",
+                            () -> format(
+                                "resending full cluster state to node %s reason %s",
                                 destination,
                                 transportException.getDetailedMessage()
                             )

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataIndexStateService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataIndexStateService.java
@@ -10,7 +10,6 @@ package org.elasticsearch.cluster.metadata;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.message.ParameterizedMessage;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionListener;
@@ -84,6 +83,9 @@ import java.util.Set;
 import java.util.SortedMap;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
+
+import static java.util.stream.Collectors.joining;
+import static org.elasticsearch.core.Strings.format;
 
 /**
  * Service responsible for submitting open/close index requests as well as for adding index blocks
@@ -363,12 +365,7 @@ public class MetadataIndexStateService {
             blockedIndices.put(index, indexBlock);
         }
 
-        logger.info(
-            () -> new ParameterizedMessage(
-                "closing indices {}",
-                blockedIndices.keySet().stream().map(Object::toString).collect(Collectors.joining(","))
-            )
-        );
+        logger.info(() -> format("closing indices %s", blockedIndices.keySet().stream().map(Object::toString).collect(joining(","))));
         return ClusterState.builder(currentState).blocks(blocks).build();
     }
 

--- a/server/src/main/java/org/elasticsearch/common/breaker/ChildMemoryCircuitBreaker.java
+++ b/server/src/main/java/org/elasticsearch/common/breaker/ChildMemoryCircuitBreaker.java
@@ -9,12 +9,13 @@
 package org.elasticsearch.common.breaker;
 
 import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.message.ParameterizedMessage;
 import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.indices.breaker.BreakerSettings;
 import org.elasticsearch.indices.breaker.HierarchyCircuitBreakerService;
 
 import java.util.concurrent.atomic.AtomicLong;
+
+import static org.elasticsearch.core.Strings.format;
 
 /**
  * Breaker that will check a parent's when incrementing
@@ -45,7 +46,7 @@ public class ChildMemoryCircuitBreaker implements CircuitBreaker {
         this.used = new AtomicLong(0);
         this.trippedCount = new AtomicLong(0);
         this.logger = logger;
-        logger.trace(() -> new ParameterizedMessage("creating ChildCircuitBreaker with settings {}", settings));
+        logger.trace(() -> format("creating ChildCircuitBreaker with settings %s", settings));
         this.parent = parent;
     }
 
@@ -72,7 +73,7 @@ public class ChildMemoryCircuitBreaker implements CircuitBreaker {
             + "/"
             + new ByteSizeValue(memoryBytesLimit)
             + "]";
-        logger.debug(() -> new ParameterizedMessage("{}", message));
+        logger.debug(() -> format("%s", message));
         throw new CircuitBreakingException(message, bytesNeeded, memoryBytesLimit, durability);
     }
 
@@ -120,8 +121,8 @@ public class ChildMemoryCircuitBreaker implements CircuitBreaker {
         long newUsed;
         newUsed = this.used.addAndGet(bytes);
         logger.trace(
-            () -> new ParameterizedMessage(
-                "[{}] Adding [{}][{}] to used bytes [new used: [{}], limit: [-1b]]",
+            () -> format(
+                "[%s] Adding [%s][%s] to used bytes [new used: [%s], limit: [-1b]]",
                 this.name,
                 new ByteSizeValue(bytes),
                 label,
@@ -183,7 +184,7 @@ public class ChildMemoryCircuitBreaker implements CircuitBreaker {
     @Override
     public void addWithoutBreaking(long bytes) {
         long u = used.addAndGet(bytes);
-        logger.trace(() -> new ParameterizedMessage("[{}] Adjusted breaker by [{}] bytes, now [{}]", this.name, bytes, u));
+        logger.trace(() -> format("[%s] Adjusted breaker by [%s] bytes, now [%s]", this.name, bytes, u));
         assert u >= 0 : "Used bytes: [" + u + "] must be >= 0";
     }
 

--- a/server/src/main/java/org/elasticsearch/gateway/GatewayAllocator.java
+++ b/server/src/main/java/org/elasticsearch/gateway/GatewayAllocator.java
@@ -27,7 +27,6 @@ import org.elasticsearch.cluster.routing.allocation.RoutingAllocation;
 import org.elasticsearch.common.Priority;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.util.concurrent.ConcurrentCollections;
-import org.elasticsearch.common.util.set.Sets;
 import org.elasticsearch.core.Releasables;
 import org.elasticsearch.gateway.AsyncShardFetch.Lister;
 import org.elasticsearch.gateway.TransportNodesListGatewayStartedShards.NodeGatewayStartedShards;
@@ -41,6 +40,9 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentMap;
 import java.util.stream.Collectors;
+
+import static org.elasticsearch.common.util.set.Sets.difference;
+import static org.elasticsearch.core.Strings.format;
 
 public class GatewayAllocator implements ExistingShardsAllocator {
 
@@ -181,9 +183,9 @@ public class GatewayAllocator implements ExistingShardsAllocator {
             // ways we could decide to cancel a recovery based on stale data (e.g. changing allocation filters or a primary failure) but
             // making the wrong decision here is not catastrophic so we only need to cover the common case.
             logger.trace(
-                () -> new ParameterizedMessage(
-                    "new nodes {} found, clearing primary async-fetch-store cache",
-                    Sets.difference(newEphemeralIds, lastSeenEphemeralIds)
+                () -> format(
+                    "new nodes %s found, clearing primary async-fetch-store cache",
+                    difference(newEphemeralIds, lastSeenEphemeralIds)
                 )
             );
             asyncFetchStore.values().forEach(fetch -> clearCacheForPrimary(fetch, allocation));

--- a/server/src/main/java/org/elasticsearch/http/AbstractHttpServerTransport.java
+++ b/server/src/main/java/org/elasticsearch/http/AbstractHttpServerTransport.java
@@ -56,6 +56,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 
+import static org.elasticsearch.core.Strings.format;
 import static org.elasticsearch.http.HttpTransportSettings.SETTING_HTTP_BIND_HOST;
 import static org.elasticsearch.http.HttpTransportSettings.SETTING_HTTP_MAX_CONTENT_LENGTH;
 import static org.elasticsearch.http.HttpTransportSettings.SETTING_HTTP_PORT;
@@ -341,7 +342,7 @@ public abstract class AbstractHttpServerTransport extends AbstractLifecycleCompo
         }));
         totalChannelsAccepted.incrementAndGet();
         httpClientStatsTracker.addClientStats(httpChannel);
-        logger.trace(() -> new ParameterizedMessage("Http channel accepted: {}", httpChannel));
+        logger.trace(() -> format("Http channel accepted: %s", httpChannel));
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/index/engine/InternalEngine.java
+++ b/server/src/main/java/org/elasticsearch/index/engine/InternalEngine.java
@@ -9,7 +9,6 @@
 package org.elasticsearch.index.engine;
 
 import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.message.ParameterizedMessage;
 import org.apache.lucene.document.LongPoint;
 import org.apache.lucene.document.NumericDocValuesField;
 import org.apache.lucene.index.DirectoryReader;
@@ -108,6 +107,8 @@ import java.util.function.LongConsumer;
 import java.util.function.LongSupplier;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+
+import static org.elasticsearch.core.Strings.format;
 
 public class InternalEngine extends Engine {
 
@@ -501,8 +502,8 @@ public class InternalEngine extends Engine {
         assert pendingTranslogRecovery.get() : "translogRecovery is not pending but should be";
         pendingTranslogRecovery.set(false); // we are good - now we can commit
         logger.trace(
-            () -> new ParameterizedMessage(
-                "flushing post recovery from translog: ops recovered [{}], current translog generation [{}]",
+            () -> format(
+                "flushing post recovery from translog: ops recovered [%s], current translog generation [%s]",
                 opsRecovered,
                 translog.currentFileGeneration()
             )

--- a/server/src/main/java/org/elasticsearch/indices/breaker/HierarchyCircuitBreakerService.java
+++ b/server/src/main/java/org/elasticsearch/indices/breaker/HierarchyCircuitBreakerService.java
@@ -10,7 +10,6 @@ package org.elasticsearch.indices.breaker;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.message.ParameterizedMessage;
 import org.elasticsearch.common.breaker.ChildMemoryCircuitBreaker;
 import org.elasticsearch.common.breaker.CircuitBreaker;
 import org.elasticsearch.common.breaker.CircuitBreakingException;
@@ -40,6 +39,7 @@ import java.util.function.Function;
 import java.util.function.LongSupplier;
 import java.util.stream.Collectors;
 
+import static org.elasticsearch.core.Strings.format;
 import static org.elasticsearch.indices.breaker.BreakerSettings.CIRCUIT_BREAKER_LIMIT_SETTING;
 import static org.elasticsearch.indices.breaker.BreakerSettings.CIRCUIT_BREAKER_OVERHEAD_SETTING;
 
@@ -211,7 +211,7 @@ public class HierarchyCircuitBreakerService extends CircuitBreakerService {
             CircuitBreaker.Type.PARENT,
             null
         );
-        logger.trace(() -> new ParameterizedMessage("parent circuit breaker with settings {}", this.parentSettings));
+        logger.trace(() -> format("parent circuit breaker with settings %s", this.parentSettings));
 
         this.trackRealMemoryUsage = USE_REAL_MEMORY_USAGE_SETTING.get(settings);
 
@@ -436,7 +436,7 @@ public class HierarchyCircuitBreakerService extends CircuitBreakerService {
             CircuitBreaker.Durability durability = memoryUsed.transientChildUsage >= memoryUsed.permanentChildUsage
                 ? CircuitBreaker.Durability.TRANSIENT
                 : CircuitBreaker.Durability.PERMANENT;
-            logger.debug(() -> new ParameterizedMessage("{}", message.toString()));
+            logger.debug(() -> format("%s", message.toString()));
             throw new CircuitBreakingException(message.toString(), memoryUsed.totalUsage, parentLimit, durability);
         }
     }

--- a/server/src/main/java/org/elasticsearch/indices/recovery/RecoverySettings.java
+++ b/server/src/main/java/org/elasticsearch/indices/recovery/RecoverySettings.java
@@ -10,7 +10,6 @@ package org.elasticsearch.indices.recovery;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.message.ParameterizedMessage;
 import org.apache.lucene.store.RateLimiter;
 import org.apache.lucene.store.RateLimiter.SimpleRateLimiter;
 import org.elasticsearch.Version;
@@ -38,6 +37,8 @@ import java.util.Locale;
 import java.util.Map;
 
 import static org.elasticsearch.common.settings.Setting.parseInt;
+import static org.elasticsearch.common.unit.ByteSizeValue.ofBytes;
+import static org.elasticsearch.core.Strings.format;
 import static org.elasticsearch.node.NodeRoleSettings.NODE_ROLES_SETTING;
 
 public class RecoverySettings {
@@ -520,13 +521,13 @@ public class RecoverySettings {
             finalMaxBytesPerSec = ByteSizeValue.ofBytes(maxBytesPerSec);
         }
         logger.info(
-            () -> new ParameterizedMessage(
-                "using rate limit [{}] with [default={}, read={}, write={}, max={}]",
+            () -> format(
+                "using rate limit [%s] with [default=%s, read=%s, write=%s, max=%s]",
                 finalMaxBytesPerSec,
-                ByteSizeValue.ofBytes(defaultBytesPerSec),
-                ByteSizeValue.ofBytes(readBytesPerSec),
-                ByteSizeValue.ofBytes(writeBytesPerSec),
-                ByteSizeValue.ofBytes(maxAllowedBytesPerSec)
+                ofBytes(defaultBytesPerSec),
+                ofBytes(readBytesPerSec),
+                ofBytes(writeBytesPerSec),
+                ofBytes(maxAllowedBytesPerSec)
             )
         );
         setMaxBytesPerSec(finalMaxBytesPerSec);

--- a/server/src/main/java/org/elasticsearch/repositories/RepositoriesService.java
+++ b/server/src/main/java/org/elasticsearch/repositories/RepositoriesService.java
@@ -63,6 +63,7 @@ import java.util.function.Function;
 import java.util.stream.Stream;
 
 import static java.util.Collections.unmodifiableMap;
+import static org.elasticsearch.core.Strings.format;
 import static org.elasticsearch.snapshots.SearchableSnapshotsSettings.SEARCHABLE_SNAPSHOTS_REPOSITORY_NAME_SETTING_KEY;
 import static org.elasticsearch.snapshots.SearchableSnapshotsSettings.SEARCHABLE_SNAPSHOTS_REPOSITORY_UUID_SETTING_KEY;
 
@@ -636,7 +637,7 @@ public class RepositoriesService extends AbstractLifecycleComponent implements C
         Repository repository = internalRepositories.remove(name);
         if (repository != null) {
             RepositoryMetadata metadata = repository.getMetadata();
-            logger.debug(() -> new ParameterizedMessage("delete internal repository [{}][{}].", metadata.type(), name));
+            logger.debug(() -> format("delete internal repository [%s][%s].", metadata.type(), name));
             closeRepository(repository);
         }
     }

--- a/server/src/main/java/org/elasticsearch/repositories/blobstore/BlobStoreRepository.java
+++ b/server/src/main/java/org/elasticsearch/repositories/blobstore/BlobStoreRepository.java
@@ -149,6 +149,7 @@ import java.util.stream.Collectors;
 import java.util.stream.LongStream;
 import java.util.stream.Stream;
 
+import static org.elasticsearch.core.Strings.format;
 import static org.elasticsearch.index.snapshots.blobstore.BlobStoreIndexShardSnapshot.FileInfo.canonicalName;
 
 /**
@@ -2616,7 +2617,7 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
         CheckedConsumer<OutputStream, IOException> writer,
         boolean failIfAlreadyExists
     ) throws IOException {
-        logger.trace(() -> new ParameterizedMessage("[{}] Writing [{}] to {} atomically", metadata.name(), blobName, container.path()));
+        logger.trace(() -> format("[%s] Writing [%s] to %s atomically", metadata.name(), blobName, container.path()));
         container.writeBlob(blobName, failIfAlreadyExists, true, writer);
     }
 
@@ -3061,7 +3062,7 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
 
                 private void restoreFile(BlobStoreIndexShardSnapshot.FileInfo fileInfo, Store store) throws IOException {
                     ensureNotClosing(store);
-                    logger.trace(() -> new ParameterizedMessage("[{}] restoring [{}] to [{}]", metadata.name(), fileInfo, store));
+                    logger.trace(() -> format("[%s] restoring [%s] to [%s]", metadata.name(), fileInfo, store));
                     boolean success = false;
                     try (
                         IndexOutput indexOutput = store.createVerifyingOutput(
@@ -3321,9 +3322,7 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
         Map<String, String> serializationParams
     ) throws IOException {
         assert indexGeneration >= 0 : "Shard generation must not be negative but saw [" + indexGeneration + "]";
-        logger.trace(
-            () -> new ParameterizedMessage("[{}] Writing shard index [{}] to [{}]", metadata.name(), indexGeneration, shardContainer.path())
-        );
+        logger.trace(() -> format("[%s] Writing shard index [%s] to [%s]", metadata.name(), indexGeneration, shardContainer.path()));
         final String blobName = INDEX_SHARD_SNAPSHOTS_FORMAT.blobName(String.valueOf(indexGeneration));
         writeAtomic(
             shardContainer,

--- a/server/src/main/java/org/elasticsearch/snapshots/RestoreService.java
+++ b/server/src/main/java/org/elasticsearch/snapshots/RestoreService.java
@@ -104,6 +104,7 @@ import static org.elasticsearch.cluster.metadata.IndexMetadata.SETTING_INDEX_UUI
 import static org.elasticsearch.cluster.metadata.IndexMetadata.SETTING_NUMBER_OF_REPLICAS;
 import static org.elasticsearch.cluster.metadata.IndexMetadata.SETTING_NUMBER_OF_SHARDS;
 import static org.elasticsearch.cluster.metadata.IndexMetadata.SETTING_VERSION_CREATED;
+import static org.elasticsearch.core.Strings.format;
 import static org.elasticsearch.index.IndexModule.INDEX_STORE_TYPE_SETTING;
 import static org.elasticsearch.snapshots.SearchableSnapshotsSettings.SEARCHABLE_SNAPSHOTS_DELETE_SNAPSHOT_ON_INDEX_DELETION;
 import static org.elasticsearch.snapshots.SearchableSnapshotsSettings.SEARCHABLE_SNAPSHOTS_REPOSITORY_NAME_SETTING_KEY;
@@ -342,8 +343,8 @@ public class RestoreService implements ClusterStateApplier {
                 return true;
             }
             logger.warn(
-                () -> new ParameterizedMessage(
-                    "Restoring snapshot[{}] skipping feature [{}] because it is not available in this cluster",
+                () -> format(
+                    "Restoring snapshot[%s] skipping feature [%s] because it is not available in this cluster",
                     snapshotInfo.snapshotId(),
                     featureName
                 )

--- a/server/src/main/java/org/elasticsearch/snapshots/SnapshotsService.java
+++ b/server/src/main/java/org/elasticsearch/snapshots/SnapshotsService.java
@@ -116,6 +116,8 @@ import java.util.stream.Stream;
 
 import static java.util.Collections.unmodifiableList;
 import static org.elasticsearch.cluster.SnapshotsInProgress.completed;
+import static org.elasticsearch.common.Strings.arrayToCommaDelimitedString;
+import static org.elasticsearch.core.Strings.format;
 
 /**
  * Service responsible for creating snapshots. This service runs all the steps executed on the master node during snapshot creation and
@@ -2055,11 +2057,7 @@ public class SnapshotsService extends AbstractLifecycleComponent implements Clus
         final String repositoryName = request.repository();
         final String[] snapshotNames = request.snapshots();
         logger.info(
-            () -> new ParameterizedMessage(
-                "deleting snapshots [{}] from repository [{}]",
-                Strings.arrayToCommaDelimitedString(snapshotNames),
-                repositoryName
-            )
+            () -> format("deleting snapshots [%s] from repository [%s]", arrayToCommaDelimitedString(snapshotNames), repositoryName)
         );
 
         final Repository repository = repositoriesService.repository(repositoryName);

--- a/server/src/main/java/org/elasticsearch/transport/TcpTransport.java
+++ b/server/src/main/java/org/elasticsearch/transport/TcpTransport.java
@@ -80,6 +80,7 @@ import java.util.regex.Pattern;
 import static java.util.Collections.unmodifiableMap;
 import static org.elasticsearch.common.transport.NetworkExceptionHelper.isConnectException;
 import static org.elasticsearch.common.util.concurrent.ConcurrentCollections.newConcurrentMap;
+import static org.elasticsearch.core.Strings.format;
 
 public abstract class TcpTransport extends AbstractLifecycleComponent implements Transport {
     private static final Logger logger = LogManager.getLogger(TcpTransport.class);
@@ -729,9 +730,9 @@ public abstract class TcpTransport extends AbstractLifecycleComponent implements
                     closeChannel = false;
                 }
             } else if (e instanceof StreamCorruptedException) {
-                logger.warn(() -> new ParameterizedMessage("{}, [{}], closing connection", e.getMessage(), channel));
+                logger.warn(() -> format("%s, [%s], closing connection", e.getMessage(), channel));
             } else if (e instanceof TransportNotReadyException) {
-                logger.debug(() -> new ParameterizedMessage("{} on [{}], closing connection", e.getMessage(), channel));
+                logger.debug(() -> format("%s on [%s], closing connection", e.getMessage(), channel));
             } else {
                 logger.warn(() -> "exception caught on transport layer [" + channel + "], closing connection", e);
             }
@@ -756,7 +757,7 @@ public abstract class TcpTransport extends AbstractLifecycleComponent implements
         // Mark the channel init time
         channel.getChannelStats().markAccessed(threadPool.relativeTimeInMillis());
         channel.addCloseListener(ActionListener.wrap(() -> acceptedChannels.remove(channel)));
-        logger.trace(() -> new ParameterizedMessage("Tcp transport channel accepted: {}", channel));
+        logger.trace(() -> format("Tcp transport channel accepted: %s", channel));
     }
 
     /**

--- a/server/src/test/java/org/elasticsearch/common/logging/LoggersTests.java
+++ b/server/src/test/java/org/elasticsearch/common/logging/LoggersTests.java
@@ -37,34 +37,33 @@ public class LoggersTests extends ESTestCase {
         testLogger.error(() -> new ParameterizedMessage("an error message"), ex);
         assertThat(appender.lastEvent.getLevel(), equalTo(Level.ERROR));
         assertThat(appender.lastEvent.getThrown(), equalTo(ex));
-        assertThat(appender.lastParameterizedMessage().getFormattedMessage(), equalTo("an error message"));
+        assertThat(appender.lastMessage().getFormattedMessage(), equalTo("an error message"));
 
         ex = randomException();
         testLogger.warn(() -> new ParameterizedMessage("a warn message: [{}]", "long gc"), ex);
         assertThat(appender.lastEvent.getLevel(), equalTo(Level.WARN));
         assertThat(appender.lastEvent.getThrown(), equalTo(ex));
-        assertThat(appender.lastParameterizedMessage().getFormattedMessage(), equalTo("a warn message: [long gc]"));
-        assertThat(appender.lastParameterizedMessage().getParameters(), arrayContaining("long gc"));
+        assertThat(appender.lastMessage().getFormattedMessage(), equalTo("a warn message: [long gc]"));
+        assertThat(appender.lastMessage().getParameters(), arrayContaining("long gc"));
 
         testLogger.info(() -> format("an info message a=[%s], b=[%s], c=[%s]", 1, 2, 3));
         assertThat(appender.lastEvent.getLevel(), equalTo(Level.INFO));
         assertThat(appender.lastEvent.getThrown(), nullValue());
-        assertThat(appender.lastParameterizedMessage().getFormattedMessage(), equalTo("an info message a=[1], b=[2], c=[3]"));
-        assertThat(appender.lastParameterizedMessage().getParameters(), arrayContaining(1, 2, 3));
+        assertThat(appender.lastMessage().getFormattedMessage(), equalTo("an info message a=[1], b=[2], c=[3]"));
 
         ex = randomException();
         testLogger.debug(() -> new ParameterizedMessage("a debug message options = {}", Arrays.asList("yes", "no")), ex);
         assertThat(appender.lastEvent.getLevel(), equalTo(Level.DEBUG));
         assertThat(appender.lastEvent.getThrown(), equalTo(ex));
-        assertThat(appender.lastParameterizedMessage().getFormattedMessage(), equalTo("a debug message options = [yes, no]"));
-        assertThat(appender.lastParameterizedMessage().getParameters(), arrayContaining(Arrays.asList("yes", "no")));
+        assertThat(appender.lastMessage().getFormattedMessage(), equalTo("a debug message options = [yes, no]"));
+        assertThat(appender.lastMessage().getParameters(), arrayContaining(Arrays.asList("yes", "no")));
 
         ex = randomException();
         testLogger.trace(() -> new ParameterizedMessage("a trace message; element = [{}]", new Object[] { null }), ex);
         assertThat(appender.lastEvent.getLevel(), equalTo(Level.TRACE));
         assertThat(appender.lastEvent.getThrown(), equalTo(ex));
-        assertThat(appender.lastParameterizedMessage().getFormattedMessage(), equalTo("a trace message; element = [null]"));
-        assertThat(appender.lastParameterizedMessage().getParameters(), arrayContaining(new Object[] { null }));
+        assertThat(appender.lastMessage().getFormattedMessage(), equalTo("a trace message; element = [null]"));
+        assertThat(appender.lastMessage().getParameters(), arrayContaining(new Object[] { null }));
     }
 
     private Throwable randomException() {

--- a/server/src/test/java/org/elasticsearch/common/logging/LoggersTests.java
+++ b/server/src/test/java/org/elasticsearch/common/logging/LoggersTests.java
@@ -18,6 +18,7 @@ import java.io.IOException;
 import java.net.UnknownHostException;
 import java.util.Arrays;
 
+import static org.elasticsearch.core.Strings.format;
 import static org.hamcrest.Matchers.arrayContaining;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.nullValue;
@@ -45,7 +46,7 @@ public class LoggersTests extends ESTestCase {
         assertThat(appender.lastParameterizedMessage().getFormattedMessage(), equalTo("a warn message: [long gc]"));
         assertThat(appender.lastParameterizedMessage().getParameters(), arrayContaining("long gc"));
 
-        testLogger.info(() -> new ParameterizedMessage("an info message a=[{}], b=[{}], c=[{}]", 1, 2, 3));
+        testLogger.info(() -> format("an info message a=[%s], b=[%s], c=[%s]", 1, 2, 3));
         assertThat(appender.lastEvent.getLevel(), equalTo(Level.INFO));
         assertThat(appender.lastEvent.getThrown(), nullValue());
         assertThat(appender.lastParameterizedMessage().getFormattedMessage(), equalTo("an info message a=[1], b=[2], c=[3]"));

--- a/server/src/test/java/org/elasticsearch/common/logging/MockAppender.java
+++ b/server/src/test/java/org/elasticsearch/common/logging/MockAppender.java
@@ -11,7 +11,7 @@ package org.elasticsearch.common.logging;
 import org.apache.logging.log4j.core.LogEvent;
 import org.apache.logging.log4j.core.appender.AbstractAppender;
 import org.apache.logging.log4j.core.filter.RegexFilter;
-import org.apache.logging.log4j.message.ParameterizedMessage;
+import org.apache.logging.log4j.message.Message;
 
 public class MockAppender extends AbstractAppender {
     public LogEvent lastEvent;
@@ -25,8 +25,8 @@ public class MockAppender extends AbstractAppender {
         lastEvent = event.toImmutable();
     }
 
-    ParameterizedMessage lastParameterizedMessage() {
-        return (ParameterizedMessage) lastEvent.getMessage();
+    Message lastMessage() {
+        return lastEvent.getMessage();
     }
 
     public LogEvent getLastEventAndReset() {

--- a/test/fixtures/gcs-fixture/src/main/java/fixture/gcs/GoogleCloudStorageHttpHandler.java
+++ b/test/fixtures/gcs-fixture/src/main/java/fixture/gcs/GoogleCloudStorageHttpHandler.java
@@ -12,7 +12,6 @@ import com.sun.net.httpserver.HttpHandler;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.message.ParameterizedMessage;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.UUIDs;
 import org.elasticsearch.common.bytes.BytesArray;
@@ -44,10 +43,11 @@ import java.util.concurrent.ConcurrentMap;
 import java.util.function.BiFunction;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-import java.util.stream.Collectors;
 import java.util.zip.GZIPInputStream;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.util.stream.Collectors.joining;
+import static org.elasticsearch.core.Strings.format;
 
 /**
  * Minimal HTTP handler that acts as a Google Cloud Storage compliant server
@@ -333,9 +333,9 @@ public class GoogleCloudStorageHttpHandler implements HttpHandler {
         if (content == null) {
             final InputStream stream = fullRequestBody.streamInput();
             logger.warn(
-                () -> new ParameterizedMessage(
-                    "Failed to find multi-part upload in [{}]",
-                    new BufferedReader(new InputStreamReader(stream)).lines().collect(Collectors.joining("\n"))
+                () -> format(
+                    "Failed to find multi-part upload in [%s]",
+                    new BufferedReader(new InputStreamReader(stream)).lines().collect(joining("\n"))
                 )
             );
         }

--- a/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/repository/CcrRepository.java
+++ b/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/repository/CcrRepository.java
@@ -108,6 +108,7 @@ import java.util.function.LongConsumer;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
+import static org.elasticsearch.core.Strings.format;
 import static org.elasticsearch.index.seqno.RetentionLeaseActions.RETAIN_ALL;
 import static org.elasticsearch.repositories.RepositoryData.MISSING_UUID;
 import static org.elasticsearch.xpack.ccr.CcrRetentionLeases.retentionLeaseId;
@@ -447,7 +448,7 @@ public class CcrRepository extends AbstractLifecycleComponent implements Reposit
         final ShardId leaderShardId,
         final Client remoteClient
     ) {
-        logger.trace(() -> new ParameterizedMessage("{} requesting leader to add retention lease [{}]", shardId, retentionLeaseId));
+        logger.trace(() -> format("%s requesting leader to add retention lease [%s]", shardId, retentionLeaseId));
         final TimeValue timeout = ccrSettings.getRecoveryActionTimeout();
         final Optional<RetentionLeaseAlreadyExistsException> maybeAddAlready = syncAddRetentionLease(
             leaderShardId,

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/action/AbstractTransportSetResetModeAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/action/AbstractTransportSetResetModeAction.java
@@ -9,7 +9,6 @@ package org.elasticsearch.xpack.core.action;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.message.ParameterizedMessage;
 import org.elasticsearch.ElasticsearchTimeoutException;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.ActionFilters;
@@ -27,6 +26,8 @@ import org.elasticsearch.core.SuppressForbidden;
 import org.elasticsearch.tasks.Task;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
+
+import static org.elasticsearch.core.Strings.format;
 
 public abstract class AbstractTransportSetResetModeAction extends AcknowledgedTransportMasterNodeAction<SetResetModeActionRequest> {
 
@@ -78,12 +79,7 @@ public abstract class AbstractTransportSetResetModeAction extends AcknowledgedTr
         }
 
         logger.debug(
-            () -> new ParameterizedMessage(
-                "Starting to set [reset_mode] for [{}] to [{}] from [{}]",
-                featureName(),
-                request.isEnabled(),
-                isResetModeEnabled
-            )
+            () -> format("Starting to set [reset_mode] for [%s] to [%s] from [%s]", featureName(), request.isEnabled(), isResetModeEnabled)
         );
 
         ActionListener<AcknowledgedResponse> wrappedListener = ActionListener.wrap(r -> {
@@ -106,7 +102,7 @@ public abstract class AbstractTransportSetResetModeAction extends AcknowledgedTr
 
             @Override
             protected AcknowledgedResponse newResponse(boolean acknowledged) {
-                logger.trace(() -> new ParameterizedMessage("Cluster update response built for [{}]: {}", featureName(), acknowledged));
+                logger.trace(() -> format("Cluster update response built for [%s]: %s", featureName(), acknowledged));
                 return AcknowledgedResponse.of(acknowledged);
             }
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/annotations/AnnotationIndex.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/annotations/AnnotationIndex.java
@@ -8,7 +8,6 @@ package org.elasticsearch.xpack.core.ml.annotations;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.message.ParameterizedMessage;
 import org.elasticsearch.ResourceAlreadyExistsException;
 import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionListener;
@@ -35,6 +34,9 @@ import org.elasticsearch.xpack.core.template.TemplateUtils;
 import java.util.List;
 import java.util.SortedMap;
 
+import static java.lang.Thread.currentThread;
+import static org.elasticsearch.ExceptionsHelper.formatStackTrace;
+import static org.elasticsearch.core.Strings.format;
 import static org.elasticsearch.xpack.core.ClientHelper.ML_ORIGIN;
 import static org.elasticsearch.xpack.core.ClientHelper.executeAsyncWithOrigin;
 
@@ -149,11 +151,11 @@ public class AnnotationIndex {
             IndexAbstraction currentIndexAbstraction = mlLookup.get(LATEST_INDEX_NAME);
             if (currentIndexAbstraction == null) {
                 logger.debug(
-                    () -> new ParameterizedMessage(
-                        "Creating [{}] because [{}] exists; trace {}",
+                    () -> format(
+                        "Creating [%s] because [%s] exists; trace %s",
                         LATEST_INDEX_NAME,
                         mlLookup.firstKey(),
-                        org.elasticsearch.ExceptionsHelper.formatStackTrace(Thread.currentThread().getStackTrace())
+                        formatStackTrace(currentThread().getStackTrace())
                     )
                 );
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/inference/EnsembleInferenceModel.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/inference/EnsembleInferenceModel.java
@@ -9,7 +9,6 @@ package org.elasticsearch.xpack.core.ml.inference.trainedmodel.inference;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.message.ParameterizedMessage;
 import org.apache.lucene.util.RamUsageEstimator;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.core.Nullable;
@@ -40,6 +39,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
+import static org.elasticsearch.core.Strings.format;
 import static org.elasticsearch.xcontent.ConstructingObjectParser.constructorArg;
 import static org.elasticsearch.xcontent.ConstructingObjectParser.optionalConstructorArg;
 import static org.elasticsearch.xpack.core.ml.inference.trainedmodel.InferenceHelpers.classificationLabel;
@@ -254,7 +254,7 @@ public class EnsembleInferenceModel implements InferenceModel {
 
     @Override
     public void rewriteFeatureIndices(final Map<String, Integer> newFeatureIndexMapping) {
-        LOGGER.debug(() -> new ParameterizedMessage("rewriting features {}", newFeatureIndexMapping));
+        LOGGER.debug(() -> format("rewriting features %s", newFeatureIndexMapping));
         if (preparedForInference) {
             return;
         }
@@ -262,7 +262,7 @@ public class EnsembleInferenceModel implements InferenceModel {
         Map<String, Integer> featureIndexMapping = new HashMap<>();
         if (newFeatureIndexMapping == null || newFeatureIndexMapping.isEmpty()) {
             Set<String> referencedFeatures = subModelFeatures();
-            LOGGER.debug(() -> new ParameterizedMessage("detected submodel feature names {}", referencedFeatures));
+            LOGGER.debug(() -> format("detected submodel feature names %s", referencedFeatures));
             int newFeatureIndex = 0;
             featureIndexMapping = new HashMap<>();
             this.featureNames = new String[referencedFeatures.size()];

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/inference/TreeInferenceModel.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/inference/TreeInferenceModel.java
@@ -9,7 +9,6 @@ package org.elasticsearch.xpack.core.ml.inference.trainedmodel.inference;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.message.ParameterizedMessage;
 import org.apache.lucene.util.Accountable;
 import org.elasticsearch.common.Numbers;
 import org.elasticsearch.core.Nullable;
@@ -42,6 +41,7 @@ import java.util.stream.IntStream;
 import static org.apache.lucene.util.RamUsageEstimator.shallowSizeOfInstance;
 import static org.apache.lucene.util.RamUsageEstimator.sizeOf;
 import static org.apache.lucene.util.RamUsageEstimator.sizeOfCollection;
+import static org.elasticsearch.core.Strings.format;
 import static org.elasticsearch.xcontent.ConstructingObjectParser.constructorArg;
 import static org.elasticsearch.xcontent.ConstructingObjectParser.optionalConstructorArg;
 import static org.elasticsearch.xpack.core.ml.inference.trainedmodel.InferenceHelpers.classificationLabel;
@@ -333,7 +333,7 @@ public class TreeInferenceModel implements InferenceModel {
 
     @Override
     public void rewriteFeatureIndices(Map<String, Integer> newFeatureIndexMapping) {
-        LOGGER.debug(() -> new ParameterizedMessage("rewriting features {}", newFeatureIndexMapping));
+        LOGGER.debug(() -> format("rewriting features %s", newFeatureIndexMapping));
         if (preparedForInference) {
             return;
         }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authc/support/mapper/expressiondsl/ExpressionModel.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authc/support/mapper/expressiondsl/ExpressionModel.java
@@ -8,9 +8,7 @@ package org.elasticsearch.xpack.core.security.authc.support.mapper.expressiondsl
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.message.ParameterizedMessage;
 import org.elasticsearch.common.Numbers;
-import org.elasticsearch.common.Strings;
 
 import java.util.Collection;
 import java.util.Collections;
@@ -18,6 +16,9 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Predicate;
+
+import static org.elasticsearch.common.Strings.collectionToCommaDelimitedString;
+import static org.elasticsearch.core.Strings.format;
 
 /**
  * Represents the "model" object to be evaluated within a {@link RoleMapperExpression}.
@@ -64,14 +65,14 @@ public class ExpressionModel {
         boolean isMatch = values.stream().anyMatch(predicate);
         if (isMatch == false && predicate == NULL_PREDICATE && fieldPredicates.containsKey(field) == false) {
             logger.debug(
-                () -> new ParameterizedMessage(
-                    "Attempt to test field [{}] against value(s) [{}],"
-                        + " but the field [{}] does not have a value on this object;"
-                        + " known fields are [{}]",
+                () -> format(
+                    "Attempt to test field [%s] against value(s) [%s],"
+                        + " but the field [%s] does not have a value on this object;"
+                        + " known fields are [%s]",
                     field,
-                    Strings.collectionToCommaDelimitedString(values),
+                    collectionToCommaDelimitedString(values),
                     field,
-                    Strings.collectionToCommaDelimitedString(fieldPredicates.keySet())
+                    collectionToCommaDelimitedString(fieldPredicates.keySet())
                 )
             );
         }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/slm/SnapshotRetentionConfiguration.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/slm/SnapshotRetentionConfiguration.java
@@ -9,7 +9,6 @@ package org.elasticsearch.xpack.core.slm;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.message.ParameterizedMessage;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -33,6 +32,8 @@ import java.util.Set;
 import java.util.function.LongSupplier;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
+
+import static org.elasticsearch.core.Strings.format;
 
 public class SnapshotRetentionConfiguration implements ToXContentObject, Writeable {
 
@@ -253,8 +254,8 @@ public class SnapshotRetentionConfiguration implements ToXContentObject, Writeab
                 final long snapshotAge = nowSupplier.getAsLong() - si.startTime();
                 if (snapshotAge > this.expireAfter.getMillis()) {
                     logger.trace(
-                        () -> new ParameterizedMessage(
-                            "[{}]: ELIGIBLE as snapshot age of {} is older than {}",
+                        () -> format(
+                            "[%s]: ELIGIBLE as snapshot age of %s is older than %s",
                             snapName,
                             new TimeValue(snapshotAge).toHumanReadableString(3),
                             this.expireAfter.toHumanReadableString(3)
@@ -263,8 +264,8 @@ public class SnapshotRetentionConfiguration implements ToXContentObject, Writeab
                     return true;
                 } else {
                     logger.trace(
-                        () -> new ParameterizedMessage(
-                            "[{}]: INELIGIBLE as snapshot age of [{}ms] is newer than {}",
+                        () -> format(
+                            "[%s]: INELIGIBLE as snapshot age of [%sms] is newer than %s",
                             snapName,
                             new TimeValue(snapshotAge).toHumanReadableString(3),
                             this.expireAfter.toHumanReadableString(3)

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ssl/RestrictedTrustManager.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ssl/RestrictedTrustManager.java
@@ -8,7 +8,6 @@ package org.elasticsearch.xpack.core.ssl;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.message.ParameterizedMessage;
 import org.elasticsearch.common.ssl.DerParser;
 
 import java.io.IOException;
@@ -27,6 +26,8 @@ import java.util.stream.Collectors;
 
 import javax.net.ssl.SSLEngine;
 import javax.net.ssl.X509ExtendedTrustManager;
+
+import static org.elasticsearch.core.Strings.format;
 
 /**
  * An X509 trust manager that only trusts connections from a restricted set of predefined network entities (nodes, clients, etc).
@@ -98,8 +99,8 @@ public final class RestrictedTrustManager extends X509ExtendedTrustManager {
         Set<String> names = readCommonNames(certificate);
         if (verifyCertificateNames(names)) {
             logger.debug(
-                () -> new ParameterizedMessage(
-                    "Trusting certificate [{}] [{}] with common-names [{}]",
+                () -> format(
+                    "Trusting certificate [%s] [%s] with common-names [%s]",
                     certificate.getSubjectX500Principal(),
                     certificate.getSerialNumber().toString(16),
                     names

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportCloseJobAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportCloseJobAction.java
@@ -59,6 +59,8 @@ import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 
+import static org.elasticsearch.core.Strings.format;
+
 public class TransportCloseJobAction extends TransportTasksAction<
     JobTask,
     CloseJobAction.Request,
@@ -196,10 +198,7 @@ public class TransportCloseJobAction extends TransportTasksAction<
                                                 jobTask.getId(),
                                                 ActionListener.wrap(
                                                     r -> logger.trace(
-                                                        () -> new ParameterizedMessage(
-                                                            "[{}] removed task to close unassigned job",
-                                                            resolvedJobId
-                                                        )
+                                                        () -> format("[%s] removed task to close unassigned job", resolvedJobId)
                                                     ),
                                                     e -> logger.error(
                                                         () -> new ParameterizedMessage(

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportDeleteJobAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportDeleteJobAction.java
@@ -8,7 +8,6 @@ package org.elasticsearch.xpack.ml.action;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.message.ParameterizedMessage;
 import org.elasticsearch.ElasticsearchStatusException;
 import org.elasticsearch.ResourceNotFoundException;
 import org.elasticsearch.action.ActionListener;
@@ -57,6 +56,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import static org.elasticsearch.core.Strings.format;
 import static org.elasticsearch.xpack.core.ClientHelper.ML_ORIGIN;
 import static org.elasticsearch.xpack.core.ClientHelper.executeAsyncWithOrigin;
 
@@ -140,8 +140,8 @@ public class TransportDeleteJobAction extends AcknowledgedTransportMasterNodeAct
         synchronized (listenersByJobId) {
             if (listenersByJobId.containsKey(request.getJobId())) {
                 logger.debug(
-                    () -> new ParameterizedMessage(
-                        "[{}] Deletion task [{}] will wait for existing deletion task to complete",
+                    () -> format(
+                        "[%s] Deletion task [%s] will wait for existing deletion task to complete",
                         request.getJobId(),
                         task.getId()
                     )

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportDeleteModelSnapshotAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportDeleteModelSnapshotAction.java
@@ -8,7 +8,6 @@ package org.elasticsearch.xpack.ml.action;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.message.ParameterizedMessage;
 import org.elasticsearch.ResourceNotFoundException;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.ActionFilters;
@@ -28,6 +27,8 @@ import org.elasticsearch.xpack.ml.notifications.AnomalyDetectionAuditor;
 
 import java.util.Collections;
 import java.util.List;
+
+import static org.elasticsearch.core.Strings.format;
 
 public class TransportDeleteModelSnapshotAction extends HandledTransportAction<DeleteModelSnapshotAction.Request, AcknowledgedResponse> {
 
@@ -101,7 +102,7 @@ public class TransportDeleteModelSnapshotAction extends HandledTransportAction<D
                     );
 
                     auditor.info(request.getJobId(), msg);
-                    logger.debug(() -> new ParameterizedMessage("[{}] {}", request.getJobId(), msg));
+                    logger.debug(() -> format("[%s] %s", request.getJobId(), msg));
                     // We don't care about the bulk response, just that it succeeded
                     l.onResponse(AcknowledgedResponse.TRUE);
                 }));

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportDeleteTrainedModelAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportDeleteTrainedModelAction.java
@@ -8,7 +8,6 @@ package org.elasticsearch.xpack.ml.action;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.message.ParameterizedMessage;
 import org.elasticsearch.ElasticsearchStatusException;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.ActionFilters;
@@ -50,6 +49,8 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
+
+import static org.elasticsearch.core.Strings.format;
 
 /**
  * The action is a master node action to ensure it reads an up-to-date cluster
@@ -99,9 +100,7 @@ public class TransportDeleteTrainedModelAction extends AcknowledgedTransportMast
         ClusterState state,
         ActionListener<AcknowledgedResponse> listener
     ) {
-        logger.debug(
-            () -> new ParameterizedMessage("[{}] Request to delete trained model{}", request.getId(), request.isForce() ? " (force)" : "")
-        );
+        logger.debug(() -> format("[%s] Request to delete trained model%s", request.getId(), request.isForce() ? " (force)" : ""));
 
         String id = request.getId();
         IngestMetadata currentIngestMetadata = state.metadata().custom(IngestMetadata.TYPE);

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportGetDatafeedRunningStateAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportGetDatafeedRunningStateAction.java
@@ -8,7 +8,6 @@ package org.elasticsearch.xpack.ml.action;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.message.ParameterizedMessage;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.FailedNodeException;
 import org.elasticsearch.action.TaskOperationFailure;
@@ -32,6 +31,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.stream.Collectors;
+
+import static org.elasticsearch.core.Strings.format;
 
 public class TransportGetDatafeedRunningStateAction extends TransportTasksAction<
     TransportStartDatafeedAction.DatafeedTask,
@@ -135,9 +136,7 @@ public class TransportGetDatafeedRunningStateAction extends TransportTasksAction
             .toArray(String[]::new);
 
         if (nodesOfConcern.length == 0) {
-            logger.debug(
-                () -> new ParameterizedMessage("Unable to find executor nodes for datafeed tasks {}", request.getDatafeedTaskIds())
-            );
+            logger.debug(() -> format("Unable to find executor nodes for datafeed tasks %s", request.getDatafeedTaskIds()));
 
             taskResponseListener.onResponse(new Response(Collections.emptyMap()));
             return;

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportGetJobModelSnapshotsUpgradeStatsAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportGetJobModelSnapshotsUpgradeStatsAction.java
@@ -9,7 +9,6 @@ package org.elasticsearch.xpack.ml.action;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.message.ParameterizedMessage;
 import org.elasticsearch.ResourceNotFoundException;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.ActionFilters;
@@ -39,6 +38,8 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
+
+import static org.elasticsearch.core.Strings.format;
 
 public class TransportGetJobModelSnapshotsUpgradeStatsAction extends TransportMasterNodeReadAction<Request, Response> {
 
@@ -71,9 +72,7 @@ public class TransportGetJobModelSnapshotsUpgradeStatsAction extends TransportMa
 
     @Override
     protected void masterOperation(Task task, Request request, ClusterState state, ActionListener<Response> listener) {
-        logger.debug(
-            () -> new ParameterizedMessage("[{}] get stats for model snapshot [{}] upgrades", request.getJobId(), request.getSnapshotId())
-        );
+        logger.debug(() -> format("[%s] get stats for model snapshot [%s] upgrades", request.getJobId(), request.getSnapshotId()));
         final PersistentTasksCustomMetadata tasksInProgress = state.getMetadata().custom(PersistentTasksCustomMetadata.TYPE);
         final Collection<PersistentTasksCustomMetadata.PersistentTask<?>> snapshotUpgrades = MlTasks.snapshotUpgradeTasks(tasksInProgress);
 

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportGetModelSnapshotsAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportGetModelSnapshotsAction.java
@@ -8,7 +8,6 @@ package org.elasticsearch.xpack.ml.action;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.message.ParameterizedMessage;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.HandledTransportAction;
@@ -19,6 +18,8 @@ import org.elasticsearch.transport.TransportService;
 import org.elasticsearch.xpack.core.ml.action.GetModelSnapshotsAction;
 import org.elasticsearch.xpack.ml.job.JobManager;
 import org.elasticsearch.xpack.ml.job.persistence.JobResultsProvider;
+
+import static org.elasticsearch.core.Strings.format;
 
 public class TransportGetModelSnapshotsAction extends HandledTransportAction<
     GetModelSnapshotsAction.Request,
@@ -48,8 +49,8 @@ public class TransportGetModelSnapshotsAction extends HandledTransportAction<
         ActionListener<GetModelSnapshotsAction.Response> listener
     ) {
         logger.debug(
-            () -> new ParameterizedMessage(
-                "Get model snapshots for job {} snapshot ID {}. from = {}, size = {} start = '{}', end='{}', sort={} descending={}",
+            () -> format(
+                "Get model snapshots for job %s snapshot ID %s. from = %s, size = %s start = '%s', end='%s', sort=%s descending=%s",
                 request.getJobId(),
                 request.getSnapshotId(),
                 request.getPageParams().getFrom(),

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportResetJobAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportResetJobAction.java
@@ -9,7 +9,6 @@ package org.elasticsearch.xpack.ml.action;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.message.ParameterizedMessage;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.admin.cluster.node.tasks.get.GetTaskAction;
 import org.elasticsearch.action.admin.cluster.node.tasks.get.GetTaskRequest;
@@ -48,6 +47,7 @@ import org.elasticsearch.xpack.ml.notifications.AnomalyDetectionAuditor;
 
 import java.util.Objects;
 
+import static org.elasticsearch.core.Strings.format;
 import static org.elasticsearch.xpack.core.ClientHelper.ML_ORIGIN;
 import static org.elasticsearch.xpack.core.ClientHelper.executeAsyncWithOrigin;
 
@@ -143,7 +143,7 @@ public class TransportResetJobAction extends AcknowledgedTransportMasterNodeActi
         ResetJobAction.Request request,
         ActionListener<AcknowledgedResponse> listener
     ) {
-        logger.debug(() -> new ParameterizedMessage("[{}] Waiting on existing reset task: {}", request.getJobId(), existingTaskId));
+        logger.debug(() -> format("[%s] Waiting on existing reset task: %s", request.getJobId(), existingTaskId));
         GetTaskRequest getTaskRequest = new GetTaskRequest();
         getTaskRequest.setTaskId(existingTaskId);
         getTaskRequest.setWaitForCompletion(true);

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportStartTrainedModelDeploymentAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportStartTrainedModelDeploymentAction.java
@@ -77,6 +77,7 @@ import java.util.Set;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
+import static org.elasticsearch.core.Strings.format;
 import static org.elasticsearch.xpack.core.ClientHelper.ML_ORIGIN;
 import static org.elasticsearch.xpack.core.ml.action.PutTrainedModelDefinitionPartAction.MAX_NUM_NATIVE_DEFINITION_PARTS;
 
@@ -509,8 +510,8 @@ public class TransportStartTrainedModelDeploymentAction extends TransportMasterN
                 return true;
             }
             logger.trace(
-                () -> new ParameterizedMessage(
-                    "[{}] tested with state [{}] and nodes {} still initializing",
+                () -> format(
+                    "[%s] tested with state [%s] and nodes %s still initializing",
                     modelId,
                     trainedModelAssignment.getAssignmentState(),
                     nodesStillInitializing

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportStopTrainedModelDeploymentAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportStopTrainedModelDeploymentAction.java
@@ -46,6 +46,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 
+import static org.elasticsearch.core.Strings.format;
 import static org.elasticsearch.xpack.core.ClientHelper.ML_ORIGIN;
 import static org.elasticsearch.xpack.ml.action.TransportDeleteTrainedModelAction.getReferencedModelKeys;
 
@@ -105,9 +106,7 @@ public class TransportStopTrainedModelDeploymentAction extends TransportTasksAct
             return;
         }
 
-        logger.debug(
-            () -> new ParameterizedMessage("[{}] Received request to undeploy{}", request.getId(), request.isForce() ? " (force)" : "")
-        );
+        logger.debug(() -> format("[%s] Received request to undeploy%s", request.getId(), request.isForce() ? " (force)" : ""));
 
         ActionListener<GetTrainedModelsAction.Response> getModelListener = ActionListener.wrap(getModelsResponse -> {
             List<TrainedModelConfig> models = getModelsResponse.getResources().results();

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/autoscaling/MlAutoscalingDeciderService.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/autoscaling/MlAutoscalingDeciderService.java
@@ -8,7 +8,6 @@ package org.elasticsearch.xpack.ml.autoscaling;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.message.ParameterizedMessage;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.LocalNodeMasterListener;
 import org.elasticsearch.cluster.node.DiscoveryNode;
@@ -66,6 +65,9 @@ import java.util.function.LongSupplier;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import static java.time.Instant.ofEpochMilli;
+import static org.elasticsearch.common.xcontent.XContentElasticsearchExtension.DEFAULT_FORMATTER;
+import static org.elasticsearch.core.Strings.format;
 import static org.elasticsearch.xpack.core.ml.MlTasks.getDataFrameAnalyticsState;
 import static org.elasticsearch.xpack.core.ml.MlTasks.getJobStateModifiedForReassignments;
 import static org.elasticsearch.xpack.core.ml.MlTasks.getSnapshotUpgradeState;
@@ -623,8 +625,8 @@ public class MlAutoscalingDeciderService implements AutoscalingDeciderService, L
             // This next message could obviously be pretty big, but should only get logged very rarely as it
             // requires both debug enabled and some other bug to exist to cause us to be in this branch
             logger.debug(
-                () -> new ParameterizedMessage(
-                    "persistent tasks that caused unexpected scaling situation: [{}]",
+                () -> format(
+                    "persistent tasks that caused unexpected scaling situation: [%s]",
                     (tasks == null) ? "null" : Strings.toString(tasks)
                 )
             );
@@ -672,11 +674,7 @@ public class MlAutoscalingDeciderService implements AutoscalingDeciderService, L
                         MAX_OPEN_JOBS_PER_NODE.getKey()
                     );
                     logger.info(
-                        () -> new ParameterizedMessage(
-                            "{} Calculated potential scaled down capacity [{}]",
-                            msg,
-                            scaleDownDecisionResult.requiredCapacity()
-                        )
+                        () -> format("%s Calculated potential scaled down capacity [%s]", msg, scaleDownDecisionResult.requiredCapacity())
                     );
                     return new AutoscalingDeciderResult(context.currentCapacity(), reasonBuilder.setSimpleReason(msg).build());
                 }
@@ -688,11 +686,11 @@ public class MlAutoscalingDeciderService implements AutoscalingDeciderService, L
             }
             TimeValue downScaleDelay = DOWN_SCALE_DELAY.get(configuration);
             logger.debug(
-                () -> new ParameterizedMessage(
-                    "not scaling down as the current scale down delay [{}] is not satisfied."
-                        + " The last time scale down was detected [{}]. Calculated scaled down capacity [{}] ",
+                () -> format(
+                    "not scaling down as the current scale down delay [%s] is not satisfied."
+                        + " The last time scale down was detected [%s]. Calculated scaled down capacity [%s] ",
                     downScaleDelay.getStringRep(),
-                    XContentElasticsearchExtension.DEFAULT_FORMATTER.format(Instant.ofEpochMilli(scaleDownDetected)),
+                    DEFAULT_FORMATTER.format(ofEpochMilli(scaleDownDetected)),
                     scaleDownDecisionResult.requiredCapacity()
                 )
             );
@@ -833,15 +831,15 @@ public class MlAutoscalingDeciderService implements AutoscalingDeciderService, L
         MlScalingReason.Builder reasonBuilder
     ) {
         logger.debug(
-            () -> new ParameterizedMessage(
+            () -> format(
                 "Checking for scale up -"
-                    + " waiting data frame analytics jobs [{}]"
-                    + " data frame analytics jobs allowed to queue [{}]"
-                    + " waiting anomaly detection jobs (including model snapshot upgrades) [{}]"
-                    + " anomaly detection jobs allowed to queue [{}]"
-                    + " waiting models [{}]"
-                    + " future freed capacity [{}]"
-                    + " current scale [{}]",
+                    + " waiting data frame analytics jobs [%s]"
+                    + " data frame analytics jobs allowed to queue [%s]"
+                    + " waiting anomaly detection jobs (including model snapshot upgrades) [%s]"
+                    + " anomaly detection jobs allowed to queue [%s]"
+                    + " waiting models [%s]"
+                    + " future freed capacity [%s]"
+                    + " current scale [%s]",
                 waitingAnalyticsJobs.size(),
                 numAnalyticsJobsInQueue,
                 waitingAnomalyJobs.size() + waitingSnapshotUpgrades.size(),

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/DatafeedConfigAutoUpdater.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/DatafeedConfigAutoUpdater.java
@@ -9,7 +9,6 @@ package org.elasticsearch.xpack.ml.datafeed;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.message.ParameterizedMessage;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.Version;
 import org.elasticsearch.action.support.IndicesOptions;
@@ -27,6 +26,9 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
+
+import static java.util.stream.Collectors.toList;
+import static org.elasticsearch.core.Strings.format;
 
 public class DatafeedConfigAutoUpdater implements MlAutoUpdateService.UpdateAction {
 
@@ -87,10 +89,7 @@ public class DatafeedConfigAutoUpdater implements MlAutoUpdateService.UpdateActi
         }
 
         logger.debug(
-            () -> new ParameterizedMessage(
-                "{} datafeeds are currently being updated",
-                updates.stream().map(DatafeedUpdate::getId).collect(Collectors.toList())
-            )
+            () -> format("%s datafeeds are currently being updated", updates.stream().map(DatafeedUpdate::getId).collect(toList()))
         );
 
         List<Exception> failures = new ArrayList<>();
@@ -113,10 +112,7 @@ public class DatafeedConfigAutoUpdater implements MlAutoUpdateService.UpdateActi
         }
         if (failures.isEmpty()) {
             logger.debug(
-                () -> new ParameterizedMessage(
-                    "{} datafeeds are finished being updated",
-                    updates.stream().map(DatafeedUpdate::getId).collect(Collectors.toList())
-                )
+                () -> format("%s datafeeds are finished being updated", updates.stream().map(DatafeedUpdate::getId).collect(toList()))
             );
             return;
         }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/DatafeedJob.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/DatafeedJob.java
@@ -8,7 +8,6 @@ package org.elasticsearch.xpack.ml.datafeed;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.message.ParameterizedMessage;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.ElasticsearchStatusException;
 import org.elasticsearch.ElasticsearchWrapperException;
@@ -49,6 +48,7 @@ import java.util.Optional;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Supplier;
 
+import static org.elasticsearch.core.Strings.format;
 import static org.elasticsearch.xpack.core.ClientHelper.ML_ORIGIN;
 
 class DatafeedJob {
@@ -398,8 +398,8 @@ class DatafeedJob {
                 try (InputStream in = extractedData.get()) {
                     counts = postData(in, XContentType.JSON);
                     LOGGER.trace(
-                        () -> new ParameterizedMessage(
-                            "[{}] Processed another {} records with latest timestamp [{}]",
+                        () -> format(
+                            "[%s] Processed another %s records with latest timestamp [%s]",
                             jobId,
                             counts.getProcessedRecordCount(),
                             counts.getLatestRecordTimeStamp()

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/extractor/aggregation/AggregationToJsonProcessor.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/extractor/aggregation/AggregationToJsonProcessor.java
@@ -8,7 +8,6 @@ package org.elasticsearch.xpack.ml.datafeed.extractor.aggregation;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.message.ParameterizedMessage;
 import org.elasticsearch.common.util.set.Sets;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.search.aggregations.Aggregation;
@@ -43,6 +42,8 @@ import java.util.SortedMap;
 import java.util.TreeMap;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
+
+import static org.elasticsearch.core.Strings.format;
 
 /**
  * Processes {@link Aggregation} objects and writes flat JSON documents for each leaf aggregation.
@@ -260,7 +261,7 @@ class AggregationToJsonProcessor {
 
                 long bucketTime = toHistogramKeyToEpoch(bucket.getKey().get(compositeAggDateValueSourceName));
                 if (bucketTime < startTime) {
-                    LOGGER.debug(() -> new ParameterizedMessage("Skipping bucket at [{}], startTime is [{}]", bucketTime, startTime));
+                    LOGGER.debug(() -> format("Skipping bucket at [%s], startTime is [%s]", bucketTime, startTime));
                     continue;
                 } else {
                     checkBucketTime = false;

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/extractor/aggregation/CompositeAggregationDataExtractor.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/extractor/aggregation/CompositeAggregationDataExtractor.java
@@ -8,7 +8,6 @@ package org.elasticsearch.xpack.ml.datafeed.extractor.aggregation;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.message.ParameterizedMessage;
 import org.elasticsearch.action.ActionRequestBuilder;
 import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.action.search.SearchResponse;
@@ -32,6 +31,8 @@ import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Objects;
 import java.util.Optional;
+
+import static org.elasticsearch.core.Strings.format;
 
 /**
  * An implementation that extracts data from elasticsearch using search with composite aggregations on a client.
@@ -118,12 +119,7 @@ class CompositeAggregationDataExtractor implements DataExtractor {
         // Also, it doesn't make sense to have a derivative when grouping by time AND by some other criteria.
 
         LOGGER.trace(
-            () -> new ParameterizedMessage(
-                "[{}] Executing composite aggregated search from [{}] to [{}]",
-                context.jobId,
-                context.start,
-                context.end
-            )
+            () -> format("[%s] Executing composite aggregated search from [%s] to [%s]", context.jobId, context.start, context.end)
         );
         SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder().size(0)
             .query(ExtractorUtils.wrapInTimeRangeQuery(context.query, context.timeField, context.start, context.end));
@@ -170,8 +166,8 @@ class CompositeAggregationDataExtractor implements DataExtractor {
             context.compositeAggDateHistogramGroupSourceName
         );
         LOGGER.trace(
-            () -> new ParameterizedMessage(
-                "[{}] got [{}] composite buckets",
+            () -> format(
+                "[%s] got [%s] composite buckets",
                 context.jobId,
                 ((CompositeAggregation) aggs.get(compositeAggregationBuilder.getName())).getBuckets().size()
             )
@@ -196,8 +192,8 @@ class CompositeAggregationDataExtractor implements DataExtractor {
                     // If we are not matching the current bucket floor, then this simply aligns to the next bucket
                     nextBucketOnCancel = Intervals.alignToFloor(timestamp + interval, interval);
                     LOGGER.debug(
-                        () -> new ParameterizedMessage(
-                            "[{}] set future timestamp cancel to [{}] via timestamp [{}]",
+                        () -> format(
+                            "[%s] set future timestamp cancel to [%s] via timestamp [%s]",
                             context.jobId,
                             nextBucketOnCancel,
                             timestamp
@@ -211,8 +207,8 @@ class CompositeAggregationDataExtractor implements DataExtractor {
         // If the process is canceled and cancelable, then we can indicate that there are no more buckets to process.
         if (isCancelled && cancellable) {
             LOGGER.debug(
-                () -> new ParameterizedMessage(
-                    "[{}] cancelled before bucket [{}] on date_histogram page [{}]",
+                () -> format(
+                    "[%s] cancelled before bucket [%s] on date_histogram page [%s]",
                     context.jobId,
                     nextBucketOnCancel,
                     afterKeyTimeBucket != null ? afterKeyTimeBucket : "__null__"

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/DataFrameAnalyticsManager.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/DataFrameAnalyticsManager.java
@@ -8,7 +8,6 @@ package org.elasticsearch.xpack.ml.dataframe;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.message.ParameterizedMessage;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.admin.indices.delete.DeleteIndexAction;
 import org.elasticsearch.action.admin.indices.delete.DeleteIndexRequest;
@@ -49,6 +48,7 @@ import org.elasticsearch.xpack.ml.utils.persistence.ResultsPersisterService;
 import java.util.Objects;
 import java.util.concurrent.atomic.AtomicBoolean;
 
+import static org.elasticsearch.core.Strings.format;
 import static org.elasticsearch.xpack.core.ClientHelper.ML_ORIGIN;
 
 public class DataFrameAnalyticsManager {
@@ -182,7 +182,7 @@ public class DataFrameAnalyticsManager {
     private void determineProgressAndResume(DataFrameAnalyticsTask task, DataFrameAnalyticsConfig config) {
         DataFrameAnalyticsTask.StartingState startingState = task.determineStartingState();
 
-        LOGGER.debug(() -> new ParameterizedMessage("[{}] Starting job from state [{}]", config.getId(), startingState));
+        LOGGER.debug(() -> format("[%s] Starting job from state [%s]", config.getId(), startingState));
         switch (startingState) {
             case FIRST_TIME -> executeStep(task, config, new ReindexingStep(clusterService, client, task, auditor, config));
             case RESUMING_REINDEXING -> executeJobInMiddleOfReindexing(task, config);

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/DataFrameAnalyticsTask.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/DataFrameAnalyticsTask.java
@@ -50,6 +50,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
+import static org.elasticsearch.core.Strings.format;
 import static org.elasticsearch.xpack.core.ClientHelper.ML_ORIGIN;
 import static org.elasticsearch.xpack.core.ClientHelper.executeAsyncWithOrigin;
 
@@ -153,7 +154,7 @@ public class DataFrameAnalyticsTask extends LicensedAllocatedPersistentTask impl
     public void stop(String reason, TimeValue timeout) {
         isStopping = true;
 
-        LOGGER.debug(() -> new ParameterizedMessage("[{}] Stopping task due to reason [{}]", getParams().getId(), reason));
+        LOGGER.debug(() -> format("[%s] Stopping task due to reason [%s]", getParams().getId(), reason));
 
         DataFrameAnalyticsStep cachedCurrentStep = currentStep;
         ActionListener<Void> stepProgressListener = ActionListener.wrap(aVoid -> cachedCurrentStep.cancel(reason, timeout), e -> {
@@ -245,8 +246,8 @@ public class DataFrameAnalyticsTask extends LicensedAllocatedPersistentTask impl
             storedProgress.set(new StoredProgress(progress));
             if (storedProgress.get().equals(previous)) {
                 LOGGER.debug(
-                    () -> new ParameterizedMessage(
-                        "[{}] new progress is the same as previously persisted progress. Skipping storage of progress: {}",
+                    () -> format(
+                        "[%s] new progress is the same as previously persisted progress. Skipping storage of progress: %s",
                         jobId,
                         progress
                     )
@@ -259,7 +260,7 @@ public class DataFrameAnalyticsTask extends LicensedAllocatedPersistentTask impl
                 .setRequireAlias(AnomalyDetectorsIndex.jobStateIndexWriteAlias().equals(indexOrAlias))
                 .setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE);
             try (XContentBuilder jsonBuilder = JsonXContent.contentBuilder()) {
-                LOGGER.debug(() -> new ParameterizedMessage("[{}] Persisting progress is: {}", jobId, progress));
+                LOGGER.debug(() -> format("[%s] Persisting progress is: %s", jobId, progress));
                 storedProgress.get().toXContent(jsonBuilder, Payload.XContent.EMPTY_PARAMS);
                 indexRequest.source(jsonBuilder);
             }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/extractor/DataFrameDataExtractor.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/extractor/DataFrameDataExtractor.java
@@ -8,7 +8,6 @@ package org.elasticsearch.xpack.ml.dataframe.extractor;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.message.ParameterizedMessage;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.search.SearchAction;
 import org.elasticsearch.action.search.SearchRequestBuilder;
@@ -45,6 +44,9 @@ import java.util.Set;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+
+import static org.elasticsearch.core.Strings.format;
+import static org.elasticsearch.xpack.ml.dataframe.DestinationIndex.INCREMENTAL_ID;
 
 /**
  * An implementation that extracts data from elasticsearch using ranged searches
@@ -199,15 +201,7 @@ public class DataFrameDataExtractor {
         long from = lastSortKey + 1;
         long to = from + context.scrollSize;
 
-        LOGGER.trace(
-            () -> new ParameterizedMessage(
-                "[{}] Searching docs with [{}] in [{}, {})",
-                context.jobId,
-                DestinationIndex.INCREMENTAL_ID,
-                from,
-                to
-            )
-        );
+        LOGGER.trace(() -> format("[%s] Searching docs with [%s] in [%s, %s)", context.jobId, INCREMENTAL_ID, from, to));
 
         SearchRequestBuilder searchRequestBuilder = new SearchRequestBuilder(client, SearchAction.INSTANCE)
             // This ensures the search throws if there are failures and the scroll context gets cleared automatically
@@ -326,8 +320,8 @@ public class DataFrameDataExtractor {
         boolean isTraining = trainTestSplitter.get().isTraining(extractedValues);
         Row row = new Row(extractedValues, hit, isTraining);
         LOGGER.trace(
-            () -> new ParameterizedMessage(
-                "[{}] Extracted row: sort key = [{}], is_training = [{}], values = {}",
+            () -> format(
+                "[%s] Extracted row: sort key = [%s], is_training = [%s], values = %s",
                 context.jobId,
                 row.getSortKey(),
                 isTraining,
@@ -377,7 +371,7 @@ public class DataFrameDataExtractor {
         SearchRequestBuilder searchRequestBuilder = buildDataSummarySearchRequestBuilder();
         SearchResponse searchResponse = executeSearchRequest(searchRequestBuilder);
         long rows = searchResponse.getHits().getTotalHits().value;
-        LOGGER.debug(() -> new ParameterizedMessage("[{}] Data summary rows [{}]", context.jobId, rows));
+        LOGGER.debug(() -> format("[%s] Data summary rows [%s]", context.jobId, rows));
         return new DataSummary(rows, organicFeatures.length + processedFeatures.length);
     }
 

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/extractor/ExtractedFieldsDetectorFactory.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/extractor/ExtractedFieldsDetectorFactory.java
@@ -8,7 +8,6 @@ package org.elasticsearch.xpack.ml.dataframe.extractor;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.message.ParameterizedMessage;
 import org.elasticsearch.ResourceNotFoundException;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.admin.indices.settings.get.GetSettingsAction;
@@ -45,6 +44,7 @@ import java.util.Objects;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
+import static org.elasticsearch.core.Strings.format;
 import static org.elasticsearch.xpack.core.ClientHelper.ML_ORIGIN;
 import static org.elasticsearch.xpack.core.ClientHelper.executeAsyncWithOrigin;
 
@@ -86,7 +86,7 @@ public class ExtractedFieldsDetectorFactory {
 
         // Step 3. Get cardinalities for fields with constraints
         ActionListener<FieldCapabilitiesResponse> fieldCapabilitiesHandler = ActionListener.wrap(fieldCapabilitiesResponse -> {
-            LOGGER.debug(() -> new ParameterizedMessage("[{}] Field capabilities response: {}", config.getId(), fieldCapabilitiesResponse));
+            LOGGER.debug(() -> format("[%s] Field capabilities response: %s", config.getId(), fieldCapabilitiesResponse));
             fieldCapsResponseHolder.set(fieldCapabilitiesResponse);
             getCardinalitiesForFieldsWithConstraints(index, config, fieldCapabilitiesResponse, fieldCardinalitiesHandler);
         }, listener::onFailure);
@@ -174,7 +174,7 @@ public class ExtractedFieldsDetectorFactory {
         fieldCapabilitiesRequest.indicesOptions(IndicesOptions.lenientExpandOpen());
         fieldCapabilitiesRequest.fields("*");
         fieldCapabilitiesRequest.runtimeFields(config.getSource().getRuntimeMappings());
-        LOGGER.debug(() -> new ParameterizedMessage("[{}] Requesting field caps for index {}", config.getId(), Arrays.toString(index)));
+        LOGGER.debug(() -> format("[%s] Requesting field caps for index %s", config.getId(), Arrays.toString(index)));
         ClientHelper.executeWithHeaders(config.getHeaders(), ML_ORIGIN, client, () -> {
             client.execute(FieldCapabilitiesAction.INSTANCE, fieldCapabilitiesRequest, listener);
             // This response gets discarded - the listener handles the real response

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/inference/InferenceRunner.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/inference/InferenceRunner.java
@@ -48,6 +48,8 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Objects;
 
+import static org.elasticsearch.core.Strings.format;
+
 public class InferenceRunner {
 
     private static final Logger LOGGER = LogManager.getLogger(InferenceRunner.class);
@@ -160,8 +162,8 @@ public class InferenceRunner {
         Long lastIncrementalId = processedTestDocCount == 0 ? null : (long) maxIncrementalIdAgg.value();
         if (lastIncrementalId != null) {
             LOGGER.debug(
-                () -> new ParameterizedMessage(
-                    "[{}] Resuming inference; last incremental id [{}]; processed test doc count [{}]",
+                () -> format(
+                    "[%s] Resuming inference; last incremental id [%s]; processed test doc count [%s]",
                     config.getId(),
                     lastIncrementalId,
                     processedTestDocCount

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/process/AnalyticsProcessManager.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/process/AnalyticsProcessManager.java
@@ -46,6 +46,7 @@ import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.ExecutorService;
 import java.util.function.Consumer;
 
+import static org.elasticsearch.core.Strings.format;
 import static org.elasticsearch.xpack.core.ClientHelper.ML_ORIGIN;
 
 public class AnalyticsProcessManager {
@@ -281,7 +282,7 @@ public class AnalyticsProcessManager {
         DataFrameAnalyticsTask task
     ) throws IOException {
         List<String> fieldNames = dataExtractor.getFieldNames();
-        LOGGER.debug(() -> new ParameterizedMessage("[{}] header row fields {}", task.getParams().getId(), fieldNames));
+        LOGGER.debug(() -> format("[%s] header row fields %s", task.getParams().getId(), fieldNames));
 
         // We add 2 extra fields, both named dot:
         // - the document hash

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/process/ChunkedTrainedModelPersister.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/process/ChunkedTrainedModelPersister.java
@@ -53,6 +53,7 @@ import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
 import static java.util.stream.Collectors.toList;
+import static org.elasticsearch.core.Strings.format;
 
 public class ChunkedTrainedModelPersister {
 
@@ -166,8 +167,8 @@ public class ChunkedTrainedModelPersister {
         // First, store the model and refresh is necessary
         ActionListener<Void> storeListener = ActionListener.wrap(r -> {
             LOGGER.debug(
-                () -> new ParameterizedMessage(
-                    "[{}] stored trained model definition chunk [{}] [{}]",
+                () -> format(
+                    "[%s] stored trained model definition chunk [%s] [%s]",
                     analytics.getId(),
                     trainedModelDefinitionDoc.getModelId(),
                     trainedModelDefinitionDoc.getDocNum()

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/process/NativeAnalyticsProcess.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/process/NativeAnalyticsProcess.java
@@ -8,7 +8,6 @@ package org.elasticsearch.xpack.ml.dataframe.process;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.message.ParameterizedMessage;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.client.internal.Client;
 import org.elasticsearch.index.query.QueryBuilders;
@@ -26,6 +25,8 @@ import java.nio.file.Path;
 import java.util.List;
 import java.util.Objects;
 import java.util.function.Consumer;
+
+import static org.elasticsearch.core.Strings.format;
 
 public class NativeAnalyticsProcess extends AbstractNativeAnalyticsProcess<AnalyticsResult> {
 
@@ -101,7 +102,7 @@ public class NativeAnalyticsProcess extends AbstractNativeAnalyticsProcess<Analy
                     break;
                 }
                 SearchHit stateDoc = stateResponse.getHits().getAt(0);
-                logger.debug(() -> new ParameterizedMessage("[{}] Restoring state document [{}]", config.jobId(), stateDoc.getId()));
+                logger.debug(() -> format("[%s] Restoring state document [%s]", config.jobId(), stateDoc.getId()));
                 StateToProcessWriterHelper.writeStateToStream(stateDoc.getSourceRef(), restoreStream);
             }
         }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/steps/AbstractDataFrameAnalyticsStep.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/steps/AbstractDataFrameAnalyticsStep.java
@@ -9,7 +9,6 @@ package org.elasticsearch.xpack.ml.dataframe.steps;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.message.ParameterizedMessage;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.admin.indices.refresh.RefreshAction;
 import org.elasticsearch.action.admin.indices.refresh.RefreshRequest;
@@ -23,6 +22,7 @@ import org.elasticsearch.xpack.ml.notifications.DataFrameAnalyticsAuditor;
 
 import java.util.Objects;
 
+import static org.elasticsearch.core.Strings.format;
 import static org.elasticsearch.xpack.core.ClientHelper.ML_ORIGIN;
 import static org.elasticsearch.xpack.core.ClientHelper.executeWithHeadersAsync;
 
@@ -61,9 +61,9 @@ abstract class AbstractDataFrameAnalyticsStep implements DataFrameAnalyticsStep 
 
     @Override
     public final void execute(ActionListener<StepResponse> listener) {
-        logger.debug(() -> new ParameterizedMessage("[{}] Executing step [{}]", config.getId(), name()));
+        logger.debug(() -> format("[%s] Executing step [%s]", config.getId(), name()));
         if (task.isStopping() && shouldSkipIfTaskIsStopping()) {
-            logger.debug(() -> new ParameterizedMessage("[{}] task is stopping before starting [{}] step", config.getId(), name()));
+            logger.debug(() -> format("[%s] task is stopping before starting [%s] step", config.getId(), name()));
             listener.onResponse(new StepResponse(true));
             return;
         }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/steps/FinalStep.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/steps/FinalStep.java
@@ -9,7 +9,6 @@ package org.elasticsearch.xpack.ml.dataframe.steps;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.message.ParameterizedMessage;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.admin.indices.refresh.RefreshAction;
 import org.elasticsearch.action.admin.indices.refresh.RefreshRequest;
@@ -36,6 +35,7 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collections;
 
+import static org.elasticsearch.core.Strings.format;
 import static org.elasticsearch.xpack.core.ClientHelper.ML_ORIGIN;
 import static org.elasticsearch.xpack.core.ClientHelper.executeAsyncWithOrigin;
 
@@ -97,9 +97,7 @@ public class FinalStep extends AbstractDataFrameAnalyticsStep {
         );
         refreshRequest.indicesOptions(IndicesOptions.lenientExpandOpen());
 
-        LOGGER.debug(
-            () -> new ParameterizedMessage("[{}] Refreshing indices {}", config.getId(), Arrays.toString(refreshRequest.indices()))
-        );
+        LOGGER.debug(() -> format("[%s] Refreshing indices %s", config.getId(), Arrays.toString(refreshRequest.indices())));
 
         executeAsyncWithOrigin(parentTaskClient(), ML_ORIGIN, RefreshAction.INSTANCE, refreshRequest, listener);
     }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/steps/InferenceStep.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/steps/InferenceStep.java
@@ -9,7 +9,6 @@ package org.elasticsearch.xpack.ml.dataframe.steps;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.message.ParameterizedMessage;
 import org.elasticsearch.ResourceNotFoundException;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.admin.indices.refresh.RefreshResponse;
@@ -34,6 +33,7 @@ import org.elasticsearch.xpack.ml.utils.MlIndicesUtils;
 
 import java.util.Objects;
 
+import static org.elasticsearch.core.Strings.format;
 import static org.elasticsearch.xpack.core.ClientHelper.ML_ORIGIN;
 import static org.elasticsearch.xpack.core.ClientHelper.executeAsyncWithOrigin;
 
@@ -65,12 +65,7 @@ public class InferenceStep extends AbstractDataFrameAnalyticsStep {
     @Override
     protected void doExecute(ActionListener<StepResponse> listener) {
         if (config.getAnalysis().supportsInference() == false) {
-            LOGGER.debug(
-                () -> new ParameterizedMessage(
-                    "[{}] Inference step completed immediately as analysis does not support inference",
-                    config.getId()
-                )
-            );
+            LOGGER.debug(() -> format("[%s] Inference step completed immediately as analysis does not support inference", config.getId()));
             listener.onResponse(new StepResponse(false));
             return;
         }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/assignment/TrainedModelAssignmentClusterService.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/assignment/TrainedModelAssignmentClusterService.java
@@ -51,6 +51,9 @@ import java.util.TreeMap;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
+import static org.elasticsearch.core.Strings.format;
+import static org.elasticsearch.xpack.ml.inference.assignment.TrainedModelAssignmentMetadata.fromState;
+
 public class TrainedModelAssignmentClusterService implements ClusterStateListener {
 
     private static final Logger logger = LogManager.getLogger(TrainedModelAssignmentClusterService.class);
@@ -129,9 +132,9 @@ public class TrainedModelAssignmentClusterService implements ClusterStateListene
                 @Override
                 public void clusterStateProcessed(ClusterState oldState, ClusterState newState) {
                     logger.trace(
-                        () -> new ParameterizedMessage(
-                            "updated model assignments based on node changes in the cluster; new metadata [{}]",
-                            Strings.toString(TrainedModelAssignmentMetadata.fromState(newState), false, true)
+                        () -> format(
+                            "updated model assignments based on node changes in the cluster; new metadata [%s]",
+                            Strings.toString(fromState(newState), false, true)
                         )
                     );
                 }
@@ -312,9 +315,7 @@ public class TrainedModelAssignmentClusterService implements ClusterStateListene
         final String modelId = request.getModelId();
         final String nodeId = request.getNodeId();
         TrainedModelAssignmentMetadata metadata = TrainedModelAssignmentMetadata.fromState(currentState);
-        logger.trace(
-            () -> new ParameterizedMessage("[{}] [{}] current metadata before update {}", modelId, nodeId, Strings.toString(metadata))
-        );
+        logger.trace(() -> format("[%s] [%s] current metadata before update %s", modelId, nodeId, Strings.toString(metadata)));
         final TrainedModelAssignment existingAssignment = metadata.getModelAssignment(modelId);
         final TrainedModelAssignmentMetadata.Builder builder = TrainedModelAssignmentMetadata.builder(currentState);
         // If state is stopped, this indicates the node process is closed, remove the node from the assignment
@@ -332,8 +333,8 @@ public class TrainedModelAssignmentClusterService implements ClusterStateListene
         // If we are stopping, don't update anything
         if (existingAssignment.getAssignmentState().equals(AssignmentState.STOPPING)) {
             logger.debug(
-                () -> new ParameterizedMessage(
-                    "[{}] requested update from node [{}] to update route state to [{}]",
+                () -> format(
+                    "[%s] requested update from node [%s] to update route state to [%s]",
                     modelId,
                     nodeId,
                     request.getRoutingState()

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/assignment/TrainedModelAssignmentNodeService.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/assignment/TrainedModelAssignmentNodeService.java
@@ -55,6 +55,7 @@ import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentLinkedDeque;
 
+import static org.elasticsearch.core.Strings.format;
 import static org.elasticsearch.xpack.core.ml.MlTasks.TRAINED_MODEL_ASSIGNMENT_TASK_ACTION;
 import static org.elasticsearch.xpack.core.ml.MlTasks.TRAINED_MODEL_ASSIGNMENT_TASK_TYPE;
 import static org.elasticsearch.xpack.ml.MachineLearning.ML_PYTORCH_MODEL_INFERENCE_FEATURE;
@@ -372,9 +373,7 @@ public class TrainedModelAssignmentNodeService implements ClusterStateListener {
     }
 
     void prepareModelToLoad(StartTrainedModelDeploymentAction.TaskParams taskParams) {
-        logger.debug(
-            () -> new ParameterizedMessage("[{}] preparing to load model with task params: {}", taskParams.getModelId(), taskParams)
-        );
+        logger.debug(() -> format("[%s] preparing to load model with task params: %s", taskParams.getModelId(), taskParams));
         TrainedModelDeploymentTask task = (TrainedModelDeploymentTask) taskManager.register(
             TRAINED_MODEL_ASSIGNMENT_TASK_TYPE,
             TRAINED_MODEL_ASSIGNMENT_TASK_ACTION,
@@ -394,8 +393,8 @@ public class TrainedModelAssignmentNodeService implements ClusterStateListener {
         logger.debug(() -> "[" + modelId + "] model successfully loaded and ready for inference. Notifying master node");
         if (task.isStopped()) {
             logger.debug(
-                () -> new ParameterizedMessage(
-                    "[{}] model loaded successfully, but stopped before routing table was updated; reason [{}]",
+                () -> format(
+                    "[%s] model loaded successfully, but stopped before routing table was updated; reason [%s]",
                     modelId,
                     task.stoppedReason().orElse("_unknown_")
                 )
@@ -433,9 +432,7 @@ public class TrainedModelAssignmentNodeService implements ClusterStateListener {
         trainedModelAssignmentService.updateModelAssignmentState(
             new UpdateTrainedModelAssignmentStateAction.Request(nodeId, modelId, routingStateAndReason),
             ActionListener.wrap(success -> {
-                logger.debug(
-                    () -> new ParameterizedMessage("[{}] model is [{}] and master notified", modelId, routingStateAndReason.getState())
-                );
+                logger.debug(() -> format("[%s] model is [%s] and master notified", modelId, routingStateAndReason.getState()));
                 listener.onResponse(AcknowledgedResponse.TRUE);
             }, error -> {
                 logger.warn(
@@ -455,8 +452,8 @@ public class TrainedModelAssignmentNodeService implements ClusterStateListener {
         logger.error(() -> "[" + task.getModelId() + "] model failed to load", ex);
         if (task.isStopped()) {
             logger.debug(
-                () -> new ParameterizedMessage(
-                    "[{}] model failed to load, but is now stopped; reason [{}]",
+                () -> format(
+                    "[%s] model failed to load, but is now stopped; reason [%s]",
                     task.getModelId(),
                     task.stoppedReason().orElse("_unknown_")
                 )

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/deployment/ControlMessagePyTorchAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/deployment/ControlMessagePyTorchAction.java
@@ -9,7 +9,6 @@ package org.elasticsearch.xpack.ml.inference.deployment;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.message.ParameterizedMessage;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.core.TimeValue;
@@ -21,6 +20,8 @@ import org.elasticsearch.xpack.ml.inference.pytorch.results.PyTorchResult;
 import org.elasticsearch.xpack.ml.inference.pytorch.results.ThreadSettings;
 
 import java.io.IOException;
+
+import static org.elasticsearch.core.Strings.format;
 
 class ControlMessagePyTorchAction extends AbstractPyTorchAction<ThreadSettings> {
 
@@ -49,13 +50,7 @@ class ControlMessagePyTorchAction extends AbstractPyTorchAction<ThreadSettings> 
     protected void doRun() throws Exception {
         if (isNotified()) {
             // Should not execute request as it has already timed out while waiting in the queue
-            logger.debug(
-                () -> new ParameterizedMessage(
-                    "[{}] skipping control message on request [{}] as it has timed out",
-                    getModelId(),
-                    getRequestId()
-                )
-            );
+            logger.debug(() -> format("[%s] skipping control message on request [%s] as it has timed out", getModelId(), getRequestId()));
             return;
         }
 

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/deployment/InferencePyTorchAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/deployment/InferencePyTorchAction.java
@@ -9,7 +9,6 @@ package org.elasticsearch.xpack.ml.inference.deployment;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.message.ParameterizedMessage;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.threadpool.ThreadPool;
@@ -25,6 +24,8 @@ import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+
+import static org.elasticsearch.core.Strings.format;
 
 class InferencePyTorchAction extends AbstractPyTorchAction<InferenceResults> {
 
@@ -52,9 +53,7 @@ class InferencePyTorchAction extends AbstractPyTorchAction<InferenceResults> {
     protected void doRun() throws Exception {
         if (isNotified()) {
             // Should not execute request as it has already timed out while waiting in the queue
-            logger.debug(
-                () -> new ParameterizedMessage("[{}] skipping inference on request [{}] as it has timed out", getModelId(), getRequestId())
-            );
+            logger.debug(() -> format("[%s] skipping inference on request [%s] as it has timed out", getModelId(), getRequestId()));
             return;
         }
 
@@ -102,20 +101,16 @@ class InferencePyTorchAction extends AbstractPyTorchAction<InferenceResults> {
             return;
         }
 
-        logger.debug(() -> new ParameterizedMessage("[{}] retrieved result for request [{}]", getModelId(), getRequestId()));
+        logger.debug(() -> format("[%s] retrieved result for request [%s]", getModelId(), getRequestId()));
         if (isNotified()) {
             // The request has timed out. No need to spend cycles processing the result.
             logger.debug(
-                () -> new ParameterizedMessage(
-                    "[{}] skipping result processing for request [{}] as the request has timed out",
-                    getModelId(),
-                    getRequestId()
-                )
+                () -> format("[%s] skipping result processing for request [%s] as the request has timed out", getModelId(), getRequestId())
             );
             return;
         }
         InferenceResults results = inferenceResultsProcessor.processResult(tokenization, pyTorchResult.inferenceResult());
-        logger.debug(() -> new ParameterizedMessage("[{}] processed result for request [{}]", getModelId(), getRequestId()));
+        logger.debug(() -> format("[%s] processed result for request [%s]", getModelId(), getRequestId()));
         onSuccess(results);
     }
 

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/loadingservice/ModelLoadingService.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/loadingservice/ModelLoadingService.java
@@ -61,6 +61,7 @@ import java.util.Set;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 
+import static org.elasticsearch.core.Strings.format;
 import static org.elasticsearch.xpack.core.ml.utils.ExceptionsHelper.unwrapCause;
 import static org.elasticsearch.xpack.ml.MachineLearning.ML_MODEL_INFERENCE_FEATURE;
 
@@ -264,17 +265,13 @@ public class ModelLoadingService implements ClusterStateListener {
                 return;
             }
             modelActionListener.onResponse(cachedModel.model);
-            logger.trace(() -> new ParameterizedMessage("[{}] (model_alias [{}]) loaded from cache", modelId, modelIdOrAlias));
+            logger.trace(() -> format("[%s] (model_alias [%s]) loaded from cache", modelId, modelIdOrAlias));
             return;
         }
 
         if (loadModelIfNecessary(modelIdOrAlias, consumer, modelActionListener)) {
             logger.trace(
-                () -> new ParameterizedMessage(
-                    "[{}] (model_alias [{}]) is loading or loaded, added new listener to queue",
-                    modelId,
-                    modelIdOrAlias
-                )
+                () -> format("[%s] (model_alias [%s]) is loading or loaded, added new listener to queue", modelId, modelIdOrAlias)
             );
         }
     }
@@ -321,17 +318,11 @@ public class ModelLoadingService implements ClusterStateListener {
                 // The model is requested by a pipeline but not referenced by any ingest pipelines.
                 // This means it is a simulate call and the model should not be cached
                 logger.trace(
-                    () -> new ParameterizedMessage(
-                        "[{}] (model_alias [{}]) not actively loading, eager loading without cache",
-                        modelId,
-                        modelIdOrAlias
-                    )
+                    () -> format("[%s] (model_alias [%s]) not actively loading, eager loading without cache", modelId, modelIdOrAlias)
                 );
                 loadWithoutCaching(modelId, consumer, modelActionListener);
             } else {
-                logger.trace(
-                    () -> new ParameterizedMessage("[{}] (model_alias [{}]) attempting to load and cache", modelId, modelIdOrAlias)
-                );
+                logger.trace(() -> format("[%s] (model_alias [%s]) attempting to load and cache", modelId, modelIdOrAlias));
                 loadingListeners.put(modelId, addFluently(new ArrayDeque<>(), modelActionListener));
                 loadModel(modelId, consumer);
             }
@@ -564,9 +555,7 @@ public class ModelLoadingService implements ClusterStateListener {
     private void populateNewModelAlias(String modelId) {
         Set<String> newModelAliases = modelIdToUpdatedModelAliases.remove(modelId);
         if (newModelAliases != null && newModelAliases.isEmpty() == false) {
-            logger.trace(
-                () -> new ParameterizedMessage("[{}] model is now loaded, setting new model_aliases {}", modelId, newModelAliases)
-            );
+            logger.trace(() -> format("[%s] model is now loaded, setting new model_aliases %s", modelId, newModelAliases));
             for (String modelAlias : newModelAliases) {
                 modelAliasToId.put(modelAlias, modelId);
             }
@@ -590,8 +579,8 @@ public class ModelLoadingService implements ClusterStateListener {
             }
             String modelId = modelAliasToId.getOrDefault(notification.getKey(), notification.getKey());
             logger.trace(
-                () -> new ParameterizedMessage(
-                    "Persisting stats for evicted model [{}] (model_aliases {})",
+                () -> format(
+                    "Persisting stats for evicted model [%s] (model_aliases %s)",
                     modelId,
                     modelIdToModelAliases.getOrDefault(modelId, new HashSet<>())
                 )
@@ -794,7 +783,7 @@ public class ModelLoadingService implements ClusterStateListener {
 
     private void auditIfNecessary(String modelId, MessageSupplier msg) {
         if (shouldNotAudit.contains(modelId)) {
-            logger.trace(() -> new ParameterizedMessage("[{}] {}", modelId, msg.get().getFormattedMessage()));
+            logger.trace(() -> format("[%s] %s", modelId, msg.get().getFormattedMessage()));
             return;
         }
         auditor.info(modelId, msg.get().getFormattedMessage());

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/pytorch/process/PyTorchResultProcessor.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/pytorch/process/PyTorchResultProcessor.java
@@ -9,7 +9,6 @@ package org.elasticsearch.xpack.ml.inference.pytorch.process;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.message.ParameterizedMessage;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.xpack.core.ml.utils.Intervals;
@@ -26,6 +25,8 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.function.Consumer;
 import java.util.function.LongSupplier;
+
+import static org.elasticsearch.core.Strings.format;
 
 public class PyTorchResultProcessor {
 
@@ -141,11 +142,11 @@ public class PyTorchResultProcessor {
         PyTorchInferenceResult inferenceResult = result.inferenceResult();
         assert inferenceResult != null;
 
-        logger.trace(() -> new ParameterizedMessage("[{}] Parsed result with id [{}]", deploymentId, inferenceResult.getRequestId()));
+        logger.trace(() -> format("[%s] Parsed result with id [%s]", deploymentId, inferenceResult.getRequestId()));
         processResult(inferenceResult);
         PendingResult pendingResult = pendingResults.remove(inferenceResult.getRequestId());
         if (pendingResult == null) {
-            logger.debug(() -> new ParameterizedMessage("[{}] no pending result for [{}]", deploymentId, inferenceResult.getRequestId()));
+            logger.debug(() -> format("[%s] no pending result for [%s]", deploymentId, inferenceResult.getRequestId()));
         } else {
             pendingResult.listener.onResponse(result);
         }
@@ -155,10 +156,10 @@ public class PyTorchResultProcessor {
         ThreadSettings threadSettings = result.threadSettings();
         assert threadSettings != null;
 
-        logger.trace(() -> new ParameterizedMessage("[{}] Parsed result with id [{}]", deploymentId, threadSettings.requestId()));
+        logger.trace(() -> format("[%s] Parsed result with id [%s]", deploymentId, threadSettings.requestId()));
         PendingResult pendingResult = pendingResults.remove(threadSettings.requestId());
         if (pendingResult == null) {
-            logger.debug(() -> new ParameterizedMessage("[{}] no pending result for [{}]", deploymentId, threadSettings.requestId()));
+            logger.debug(() -> format("[%s] no pending result for [%s]", deploymentId, threadSettings.requestId()));
         } else {
             pendingResult.listener.onResponse(result);
         }
@@ -170,10 +171,10 @@ public class PyTorchResultProcessor {
 
         errorCount++;
 
-        logger.trace(() -> new ParameterizedMessage("[{}] Parsed error with id [{}]", deploymentId, errorResult.requestId()));
+        logger.trace(() -> format("[%s] Parsed error with id [%s]", deploymentId, errorResult.requestId()));
         PendingResult pendingResult = pendingResults.remove(errorResult.requestId());
         if (pendingResult == null) {
-            logger.debug(() -> new ParameterizedMessage("[{}] no pending result for [{}]", deploymentId, errorResult.requestId()));
+            logger.debug(() -> format("[%s] no pending result for [%s]", deploymentId, errorResult.requestId()));
         } else {
             pendingResult.listener.onResponse(result);
         }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/categorization/GrokPatternCreator.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/categorization/GrokPatternCreator.java
@@ -8,7 +8,6 @@ package org.elasticsearch.xpack.ml.job.categorization;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.message.ParameterizedMessage;
 import org.elasticsearch.grok.Grok;
 
 import java.util.ArrayList;
@@ -19,6 +18,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+
+import static org.elasticsearch.core.Strings.format;
 
 /**
  * Creates Grok patterns that will match all the examples in a given category_definition.
@@ -124,13 +125,7 @@ public final class GrokPatternCreator {
                 // case we will have appended an ellipsis to indicate truncation.
                 assert example.endsWith("...") : exampleProcessor.pattern() + " did not match non-truncated example " + example;
                 if (example.endsWith("...")) {
-                    logger.trace(
-                        () -> new ParameterizedMessage(
-                            "[{}] Pattern [{}] did not match truncated example",
-                            jobId,
-                            exampleProcessor.pattern()
-                        )
-                    );
+                    logger.trace(() -> format("[%s] Pattern [%s] did not match truncated example", jobId, exampleProcessor.pattern()));
                 } else {
                     logger.warn("[{}] Pattern [{}] did not match non-truncated example [{}]", jobId, exampleProcessor.pattern(), example);
                 }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/process/autodetect/AutodetectProcessManager.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/process/autodetect/AutodetectProcessManager.java
@@ -97,6 +97,7 @@ import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import java.util.function.Function;
 
+import static org.elasticsearch.core.Strings.format;
 import static org.elasticsearch.xpack.core.ClientHelper.ML_ORIGIN;
 import static org.elasticsearch.xpack.core.ClientHelper.executeAsyncWithOrigin;
 
@@ -187,12 +188,7 @@ public class AutodetectProcessManager implements ClusterStateListener {
 
     public void killProcess(JobTask jobTask, boolean awaitCompletion, String reason) {
         logger.trace(
-            () -> new ParameterizedMessage(
-                "[{}] Killing process: awaitCompletion = [{}]; reason = [{}]",
-                jobTask.getJobId(),
-                awaitCompletion,
-                reason
-            )
+            () -> format("[%s] Killing process: awaitCompletion = [%s]; reason = [%s]", jobTask.getJobId(), awaitCompletion, reason)
         );
         ProcessContext processContext = processByAllocation.remove(jobTask.getAllocationId());
         if (processContext != null) {
@@ -480,11 +476,7 @@ public class AutodetectProcessManager implements ClusterStateListener {
                 }
                 if (resetInProgress) {
                     logger.trace(
-                        () -> new ParameterizedMessage(
-                            "Aborted upgrading snapshot [{}] for job [{}] as ML feature is being reset",
-                            snapshotId,
-                            jobId
-                        )
+                        () -> format("Aborted upgrading snapshot [%s] for job [%s] as ML feature is being reset", snapshotId, jobId)
                     );
                     closeHandler.accept(null);
                     return;
@@ -499,23 +491,13 @@ public class AutodetectProcessManager implements ClusterStateListener {
                     @Override
                     protected void doRun() {
                         if (nodeDying) {
-                            logger.info(
-                                () -> new ParameterizedMessage(
-                                    "Aborted upgrading snapshot [{}] for job [{}] as node is dying",
-                                    snapshotId,
-                                    jobId
-                                )
-                            );
+                            logger.info(() -> format("Aborted upgrading snapshot [%s] for job [%s] as node is dying", snapshotId, jobId));
                             closeHandler.accept(null);
                             return;
                         }
                         if (resetInProgress) {
                             logger.trace(
-                                () -> new ParameterizedMessage(
-                                    "Aborted upgrading snapshot [{}] for job [{}] as ML feature is being reset",
-                                    snapshotId,
-                                    jobId
-                                )
+                                () -> format("Aborted upgrading snapshot [%s] for job [%s] as ML feature is being reset", snapshotId, jobId)
                             );
                             closeHandler.accept(null);
                             return;

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/process/autodetect/JobModelSnapshotUpgrader.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/process/autodetect/JobModelSnapshotUpgrader.java
@@ -53,6 +53,7 @@ import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 
+import static org.elasticsearch.core.Strings.format;
 import static org.elasticsearch.xpack.ml.MachineLearning.UTILITY_THREAD_POOL_NAME;
 
 public final class JobModelSnapshotUpgrader {
@@ -238,7 +239,7 @@ public final class JobModelSnapshotUpgrader {
         }
 
         FlushAcknowledgement waitFlushToCompletion(String flushId) throws Exception {
-            logger.debug(() -> new ParameterizedMessage("[{}] [{}] waiting for flush [{}]", jobId, snapshotId, flushId));
+            logger.debug(() -> format("[%s] [%s] waiting for flush [%s]", jobId, snapshotId, flushId));
 
             FlushAcknowledgement flushAcknowledgement;
             try {
@@ -251,7 +252,7 @@ public final class JobModelSnapshotUpgrader {
             } finally {
                 processor.clearAwaitingFlush(flushId);
             }
-            logger.debug(() -> new ParameterizedMessage("[{}] [{}] flush completed [{}]", jobId, snapshotId, flushId));
+            logger.debug(() -> format("[%s] [%s] flush completed [%s]", jobId, snapshotId, flushId));
             return flushAcknowledgement;
         }
 
@@ -280,8 +281,8 @@ public final class JobModelSnapshotUpgrader {
                     );
                 } else {
                     logger.debug(
-                        () -> new ParameterizedMessage(
-                            "[{}] [{}] flush [{}] acknowledged requesting state write",
+                        () -> format(
+                            "[%s] [%s] flush [%s] acknowledged requesting state write",
                             jobId,
                             snapshotId,
                             flushAcknowledgement.getId()

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/process/autodetect/output/JobSnapshotUpgraderResultProcessor.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/process/autodetect/output/JobSnapshotUpgraderResultProcessor.java
@@ -38,6 +38,8 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
+import static org.elasticsearch.core.Strings.format;
+
 /**
  * A runnable class that reads the autodetect process output in the
  * {@link #process()} method and persists parsed
@@ -207,8 +209,8 @@ public class JobSnapshotUpgraderResultProcessor {
         FlushAcknowledgement flushAcknowledgement = result.getFlushAcknowledgement();
         if (flushAcknowledgement != null) {
             LOGGER.debug(
-                () -> new ParameterizedMessage(
-                    "[{}] [{}] Flush acknowledgement parsed from output for ID {}",
+                () -> format(
+                    "[%s] [%s] Flush acknowledgement parsed from output for ID %s",
                     jobId,
                     snapshotId,
                     flushAcknowledgement.getId()

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/retention/ExpiredModelSnapshotsRemover.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/retention/ExpiredModelSnapshotsRemover.java
@@ -8,7 +8,6 @@ package org.elasticsearch.xpack.ml.job.retention;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.message.ParameterizedMessage;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.search.SearchRequest;
@@ -41,7 +40,9 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.TimeUnit;
-import java.util.stream.Collectors;
+
+import static java.util.stream.Collectors.toList;
+import static org.elasticsearch.core.Strings.format;
 
 /**
  * Deletes all model snapshots that have expired the configured retention time
@@ -169,8 +170,8 @@ public class ExpiredModelSnapshotsRemover extends AbstractExpiredJobDataRemover 
             return;
         }
         LOGGER.debug(
-            () -> new ParameterizedMessage(
-                "Considering model snapshots of job [{}] that have a timestamp before [{}] for removal",
+            () -> format(
+                "Considering model snapshots of job [%s] that have a timestamp before [%s] for removal",
                 job.getId(),
                 cutoffEpochMs
             )
@@ -245,11 +246,11 @@ public class ExpiredModelSnapshotsRemover extends AbstractExpiredJobDataRemover 
         deleter.deleteModelSnapshots(modelSnapshots, ActionListener.wrap(bulkResponse -> {
             auditor.info(jobId, Messages.getMessage(Messages.JOB_AUDIT_SNAPSHOTS_DELETED, modelSnapshots.size()));
             LOGGER.debug(
-                () -> new ParameterizedMessage(
-                    "[{}] deleted model snapshots {} with descriptions {}",
+                () -> format(
+                    "[%s] deleted model snapshots %s with descriptions %s",
                     jobId,
-                    modelSnapshots.stream().map(ModelSnapshot::getSnapshotId).collect(Collectors.toList()),
-                    modelSnapshots.stream().map(ModelSnapshot::getDescription).collect(Collectors.toList())
+                    modelSnapshots.stream().map(ModelSnapshot::getSnapshotId).collect(toList()),
+                    modelSnapshots.stream().map(ModelSnapshot::getDescription).collect(toList())
                 )
             );
             listener.onResponse(true);

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/task/JobTask.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/task/JobTask.java
@@ -9,7 +9,6 @@ package org.elasticsearch.xpack.ml.job.task;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.message.ParameterizedMessage;
 import org.elasticsearch.license.LicensedAllocatedPersistentTask;
 import org.elasticsearch.license.XPackLicenseState;
 import org.elasticsearch.tasks.TaskId;
@@ -19,6 +18,8 @@ import org.elasticsearch.xpack.ml.job.process.autodetect.AutodetectProcessManage
 
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicReference;
+
+import static org.elasticsearch.core.Strings.format;
 
 public class JobTask extends LicensedAllocatedPersistentTask implements OpenJobAction.JobTaskMatcher {
 
@@ -57,7 +58,7 @@ public class JobTask extends LicensedAllocatedPersistentTask implements OpenJobA
     @Override
     protected void onCancelled() {
         String reason = getReasonCancelled();
-        logger.trace(() -> new ParameterizedMessage("[{}] Cancelling job task because: {}", jobId, reason));
+        logger.trace(() -> format("[%s] Cancelling job task because: %s", jobId, reason));
         closingOrVacating.set(ClosingOrVacating.CLOSING);
         autodetectProcessManager.killProcess(this, false, reason);
     }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/utils/persistence/ResultsPersisterService.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/utils/persistence/ResultsPersisterService.java
@@ -52,6 +52,7 @@ import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 import static org.elasticsearch.ExceptionsHelper.status;
+import static org.elasticsearch.core.Strings.format;
 import static org.elasticsearch.xpack.ml.MachineLearning.UTILITY_THREAD_POOL_NAME;
 
 public class ResultsPersisterService {
@@ -475,7 +476,7 @@ public class ResultsPersisterService {
             currentMax = Math.min(uncappedBackoff, MAX_RETRY_SLEEP_MILLIS);
             String msg = new ParameterizedMessage("failed to {} after [{}] attempts. Will attempt again.", getName(), currentAttempt)
                 .getFormattedMessage();
-            LOGGER.warn(() -> new ParameterizedMessage("[{}] {}", jobId, msg));
+            LOGGER.warn(() -> format("[%s] %s", jobId, msg));
             msgHandler.accept(msg);
             // RetryableAction randomizes in the interval [currentMax/2 ; currentMax].
             // Its good to have a random window along the exponentially increasing curve

--- a/x-pack/plugin/repository-encrypted/src/main/java/org/elasticsearch/repositories/encrypted/SingleUseKey.java
+++ b/x-pack/plugin/repository-encrypted/src/main/java/org/elasticsearch/repositories/encrypted/SingleUseKey.java
@@ -9,7 +9,6 @@ package org.elasticsearch.repositories.encrypted;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.message.ParameterizedMessage;
 import org.elasticsearch.common.CheckedSupplier;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.core.Tuple;
@@ -17,6 +16,8 @@ import org.elasticsearch.core.Tuple;
 import java.util.concurrent.atomic.AtomicReference;
 
 import javax.crypto.SecretKey;
+
+import static org.elasticsearch.core.Strings.format;
 
 /**
  * Container class for a {@code SecretKey} with a unique identifier, and a 4-byte wide {@code Integer} nonce, that can be used for a
@@ -81,9 +82,7 @@ final class SingleUseKey {
                 );
                 if (nonceAndKey.nonce < MAX_NONCE) {
                     // this is the commonly used code path, where just the nonce is incremented
-                    logger.trace(
-                        () -> new ParameterizedMessage("Key with id [{}] reused with nonce [{}]", nonceAndKey.keyId, nonceAndKey.nonce)
-                    );
+                    logger.trace(() -> format("Key with id [%s] reused with nonce [%s]", nonceAndKey.keyId, nonceAndKey.nonce));
                     return nonceAndKey;
                 } else {
                     // this is the infrequent code path, where a new key is generated and the nonce is reset back

--- a/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/cache/blob/BlobStoreCacheMaintenanceService.java
+++ b/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/cache/blob/BlobStoreCacheMaintenanceService.java
@@ -80,6 +80,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
+import static org.elasticsearch.core.Strings.format;
 import static org.elasticsearch.gateway.GatewayService.STATE_NOT_RECOVERED_BLOCK;
 import static org.elasticsearch.xpack.core.ClientHelper.SEARCHABLE_SNAPSHOTS_ORIGIN;
 import static org.elasticsearch.xpack.searchablesnapshots.SearchableSnapshots.SNAPSHOT_BLOB_CACHE_INDEX;
@@ -630,8 +631,8 @@ public class BlobStoreCacheMaintenanceService implements ClusterStateListener {
                     );
                 } else {
                     logger.info(
-                        () -> new ParameterizedMessage(
-                            "periodic maintenance task completed ({} deleted documents out of a total of {})",
+                        () -> format(
+                            "periodic maintenance task completed (%s deleted documents out of a total of %s)",
                             deletes.get(),
                             total.get()
                         )

--- a/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/store/SearchableSnapshotDirectory.java
+++ b/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/store/SearchableSnapshotDirectory.java
@@ -35,7 +35,6 @@ import org.elasticsearch.common.util.concurrent.ConcurrentCollections;
 import org.elasticsearch.core.CheckedRunnable;
 import org.elasticsearch.core.IOUtils;
 import org.elasticsearch.core.Nullable;
-import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.core.Tuple;
 import org.elasticsearch.index.IndexSettings;
 import org.elasticsearch.index.shard.ShardId;
@@ -86,6 +85,8 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.LongSupplier;
 import java.util.function.Supplier;
 
+import static org.elasticsearch.core.Strings.format;
+import static org.elasticsearch.core.TimeValue.timeValueNanos;
 import static org.elasticsearch.index.IndexModule.INDEX_STORE_TYPE_SETTING;
 import static org.elasticsearch.snapshots.SearchableSnapshotsSettings.SEARCHABLE_SNAPSHOT_STORE_TYPE;
 import static org.elasticsearch.snapshots.SearchableSnapshotsSettings.SNAPSHOT_PARTIAL_SETTING;
@@ -543,13 +544,13 @@ public class SearchableSnapshotDirectory extends BaseDirectory {
                         }
 
                         logger.trace(
-                            () -> new ParameterizedMessage(
-                                "{} part [{}/{}] of [{}] warmed in [{}] ms",
+                            () -> format(
+                                "%s part [%s/%s] of [%s] warmed in [%s] ms",
                                 shardId,
                                 part + 1,
                                 numberOfParts,
                                 file.physicalName(),
-                                TimeValue.timeValueNanos(statsCurrentTimeNanosSupplier.getAsLong() - startTimeInNanos).millis()
+                                timeValueNanos(statsCurrentTimeNanosSupplier.getAsLong() - startTimeInNanos).millis()
                             )
                         );
                     }));

--- a/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/store/input/FrozenIndexInput.java
+++ b/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/store/input/FrozenIndexInput.java
@@ -9,7 +9,6 @@ package org.elasticsearch.xpack.searchablesnapshots.store.input;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.message.ParameterizedMessage;
 import org.apache.lucene.codecs.CodecUtil;
 import org.apache.lucene.index.IndexFileNames;
 import org.apache.lucene.store.IOContext;
@@ -32,6 +31,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.function.Consumer;
 
+import static org.elasticsearch.core.Strings.format;
 import static org.elasticsearch.xpack.searchablesnapshots.SearchableSnapshotsUtils.toIntBytes;
 
 public class FrozenIndexInput extends MetadataCachingIndexInput {
@@ -314,7 +314,7 @@ public class FrozenIndexInput extends MetadataCachingIndexInput {
         );
         final long end = relativePos + length;
         final byte[] copyBuffer = new byte[toIntBytes(Math.min(COPY_BUFFER_SIZE, length))];
-        logger.trace(() -> new ParameterizedMessage("writing range [{}-{}] to cache file [{}]", relativePos, end, frozenCacheFile));
+        logger.trace(() -> format("writing range [%s-%s] to cache file [%s]", relativePos, end, frozenCacheFile));
 
         long bytesCopied = 0L;
         long remaining = length;

--- a/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/store/input/MetadataCachingIndexInput.java
+++ b/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/store/input/MetadataCachingIndexInput.java
@@ -38,6 +38,7 @@ import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 
+import static org.elasticsearch.core.Strings.format;
 import static org.elasticsearch.xpack.searchablesnapshots.SearchableSnapshotsUtils.toIntBytes;
 
 /**
@@ -257,7 +258,7 @@ public abstract class MetadataCachingIndexInput extends BaseSearchableSnapshotIn
         assert assertCurrentThreadMayWriteCacheFile();
         final long length = end - start;
         final byte[] copyBuffer = new byte[toIntBytes(Math.min(COPY_BUFFER_SIZE, length))];
-        logger.trace(() -> new ParameterizedMessage("writing range [{}-{}] to cache file [{}]", start, end, cacheFileReference));
+        logger.trace(() -> format("writing range [%s-%s] to cache file [%s]", start, end, cacheFileReference));
 
         long bytesCopied = 0L;
         long remaining = end - start;
@@ -370,12 +371,7 @@ public abstract class MetadataCachingIndexInput extends BaseSearchableSnapshotIn
                 final long length = b.remaining();
                 final byte[] copyBuffer = new byte[toIntBytes(Math.min(COPY_BUFFER_SIZE, length))];
                 logger.trace(
-                    () -> new ParameterizedMessage(
-                        "direct reading of range [{}-{}] for cache file [{}]",
-                        position,
-                        position + length,
-                        cacheFileReference
-                    )
+                    () -> format("direct reading of range [%s-%s] for cache file [%s]", position, position + length, cacheFileReference)
                 );
 
                 int bytesCopied = 0;

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/TokenService.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/TokenService.java
@@ -150,6 +150,7 @@ import javax.crypto.spec.PBEKeySpec;
 import javax.crypto.spec.SecretKeySpec;
 
 import static org.elasticsearch.action.support.TransportActions.isShardNotAvailableException;
+import static org.elasticsearch.core.Strings.format;
 import static org.elasticsearch.gateway.GatewayService.STATE_NOT_RECOVERED_BLOCK;
 import static org.elasticsearch.search.SearchService.DEFAULT_KEEPALIVE_SETTING;
 import static org.elasticsearch.threadpool.ThreadPool.Names.GENERIC;
@@ -610,7 +611,7 @@ public final class TokenService {
                         }
                     }, listener::onFailure));
                 } else {
-                    logger.debug(() -> new ParameterizedMessage("invalid key {} key: {}", passphraseHash, keyCache.cache.keySet()));
+                    logger.debug(() -> format("invalid key %s key: %s", passphraseHash, keyCache.cache.keySet()));
                     listener.onResponse(null);
                 }
             }
@@ -889,11 +890,7 @@ public final class TokenService {
                                 UpdateResponse updateResponse = bulkItemResponse.getResponse();
                                 if (updateResponse.getResult() == DocWriteResponse.Result.UPDATED) {
                                     logger.debug(
-                                        () -> new ParameterizedMessage(
-                                            "Invalidated [{}] for doc [{}]",
-                                            srcPrefix,
-                                            updateResponse.getGetResult().getId()
-                                        )
+                                        () -> format("Invalidated [%s] for doc [%s]", srcPrefix, updateResponse.getGetResult().getId())
                                     );
                                     invalidated.add(updateResponse.getGetResult().getId());
                                 } else if (updateResponse.getResult() == DocWriteResponse.Result.NOOP) {
@@ -1212,10 +1209,7 @@ public final class TokenService {
                     ActionListener.<UpdateResponse>wrap(updateResponse -> {
                         if (updateResponse.getResult() == DocWriteResponse.Result.UPDATED) {
                             logger.debug(
-                                () -> new ParameterizedMessage(
-                                    "updated the original token document to {}",
-                                    updateResponse.getGetResult().sourceAsMap()
-                                )
+                                () -> format("updated the original token document to %s", updateResponse.getGetResult().sourceAsMap())
                             );
                             final Tuple<UserToken, String> parsedTokens = parseTokensFromDocument(source, null);
                             final UserToken toRefreshUserToken = parsedTokens.v1();
@@ -2428,7 +2422,7 @@ public final class TokenService {
         }
         createdTimeStamps.set(maxTimestamp);
         keyCache = new TokenKeys(Collections.unmodifiableMap(map), currentUsedKeyHash);
-        logger.debug(() -> new ParameterizedMessage("refreshed keys current: {}, keys: {}", currentUsedKeyHash, keyCache.cache.keySet()));
+        logger.debug(() -> format("refreshed keys current: %s, keys: %s", currentUsedKeyHash, keyCache.cache.keySet()));
     }
 
     private SecureString generateTokenKey() {

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/jwt/JwtRealm.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/jwt/JwtRealm.java
@@ -14,7 +14,6 @@ import com.nimbusds.jwt.SignedJWT;
 import org.apache.http.impl.nio.client.CloseableHttpAsyncClient;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.message.ParameterizedMessage;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.cache.Cache;
@@ -50,6 +49,9 @@ import java.util.Collections;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
+
+import static java.lang.String.join;
+import static org.elasticsearch.core.Strings.format;
 
 /**
  * JWT realms supports JWTs as bearer tokens for authenticating to Elasticsearch.
@@ -470,12 +472,7 @@ public class JwtRealm extends Realm implements CachingRealm, Releasable {
                 if (result.isAuthenticated()) {
                     final User user = result.getValue();
                     LOGGER.debug(
-                        () -> new ParameterizedMessage(
-                            "Realm [{}] roles [{}] for principal=[{}].",
-                            super.name(),
-                            String.join(",", user.roles()),
-                            principal
-                        )
+                        () -> format("Realm [%s] roles [%s] for principal=[%s].", super.name(), join(",", user.roles()), principal)
                     );
                     if ((this.jwtCache != null) && (this.jwtCacheHelper != null)) {
                         try (ReleasableLock ignored = this.jwtCacheHelper.acquireUpdateLock()) {

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/saml/SamlObjectHandler.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/saml/SamlObjectHandler.java
@@ -8,7 +8,6 @@ package org.elasticsearch.xpack.security.authc.saml;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.message.ParameterizedMessage;
 import org.elasticsearch.ElasticsearchSecurityException;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.core.CheckedFunction;
@@ -72,6 +71,7 @@ import java.util.zip.InflaterInputStream;
 
 import javax.xml.parsers.DocumentBuilder;
 
+import static org.elasticsearch.core.Strings.format;
 import static org.elasticsearch.xpack.security.authc.saml.SamlUtils.samlException;
 import static org.opensaml.core.xml.config.XMLObjectProviderRegistrySupport.getUnmarshallerFactory;
 
@@ -174,8 +174,8 @@ public class SamlObjectHandler {
                     try (RestorableContextClassLoader ignore = new RestorableContextClassLoader(SignatureValidator.class)) {
                         SignatureValidator.validate(signature, credential);
                         logger.debug(
-                            () -> new ParameterizedMessage(
-                                "SAML Signature [{}] matches credentials [{}] [{}]",
+                            () -> format(
+                                "SAML Signature [%s] matches credentials [%s] [%s]",
                                 signatureText,
                                 credential.getEntityId(),
                                 credential.getPublicKey()
@@ -203,8 +203,8 @@ public class SamlObjectHandler {
                 return check.apply(credential);
             } catch (SignatureException | SecurityException e) {
                 logger.debug(
-                    () -> new ParameterizedMessage(
-                        "SAML Signature [{}] does not match credentials [{}] [{}] -- {}",
+                    () -> format(
+                        "SAML Signature [%s] does not match credentials [%s] [%s] -- %s",
                         signatureText,
                         credential.getEntityId(),
                         credential.getPublicKey(),
@@ -387,8 +387,8 @@ public class SamlObjectHandler {
         checkIdpSignature(credential -> {
             if (XMLSigningUtil.verifyWithURI(credential, signatureAlgorithm, sigBytes, inputBytes)) {
                 logger.debug(
-                    () -> new ParameterizedMessage(
-                        "SAML Signature [{}] matches credentials [{}] [{}]",
+                    () -> format(
+                        "SAML Signature [%s] matches credentials [%s] [%s]",
                         signatureText,
                         credential.getEntityId(),
                         credential.getPublicKey()
@@ -397,8 +397,8 @@ public class SamlObjectHandler {
                 return true;
             } else {
                 logger.debug(
-                    () -> new ParameterizedMessage(
-                        "SAML Signature [{}] failed against credentials [{}] [{}]",
+                    () -> format(
+                        "SAML Signature [%s] failed against credentials [%s] [%s]",
                         signatureText,
                         credential.getEntityId(),
                         credential.getPublicKey()

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/saml/SamlRealm.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/saml/SamlRealm.java
@@ -16,7 +16,6 @@ import org.apache.http.conn.ssl.SSLConnectionSocketFactory;
 import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.message.ParameterizedMessage;
 import org.elasticsearch.ElasticsearchSecurityException;
 import org.elasticsearch.ExceptionsHelper;
 import org.elasticsearch.SpecialPermission;
@@ -104,6 +103,8 @@ import java.util.stream.Stream;
 import javax.net.ssl.HostnameVerifier;
 import javax.net.ssl.X509KeyManager;
 
+import static org.elasticsearch.common.Strings.collectionToCommaDelimitedString;
+import static org.elasticsearch.core.Strings.format;
 import static org.elasticsearch.xpack.core.security.authc.saml.SamlRealmSettings.CLOCK_SKEW;
 import static org.elasticsearch.xpack.core.security.authc.saml.SamlRealmSettings.DN_ATTRIBUTE;
 import static org.elasticsearch.xpack.core.security.authc.saml.SamlRealmSettings.ENCRYPTION_KEY_ALIAS;
@@ -855,13 +856,7 @@ public final class SamlRealm extends Realm implements Releasable {
 
         List<String> getAttribute(SamlAttributes attributes) {
             final List<String> attrValue = parser.apply(attributes);
-            logger.trace(
-                () -> new ParameterizedMessage(
-                    "Parser [{}] generated values [{}]",
-                    name,
-                    Strings.collectionToCommaDelimitedString(attrValue)
-                )
-            );
+            logger.trace(() -> format("Parser [%s] generated values [%s]", name, collectionToCommaDelimitedString(attrValue)));
             return attrValue;
         }
 

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/service/ServiceAccountToken.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/service/ServiceAccountToken.java
@@ -9,7 +9,6 @@ package org.elasticsearch.xpack.security.authc.service;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.message.ParameterizedMessage;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.UUIDs;
 import org.elasticsearch.common.hash.MessageDigests;
@@ -29,6 +28,8 @@ import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Base64;
 import java.util.Objects;
+
+import static org.elasticsearch.core.Strings.format;
 
 /**
  * A decoded credential that may be used to authenticate a {@link ServiceAccount}.
@@ -95,8 +96,8 @@ public class ServiceAccountToken implements AuthenticationToken, Closeable {
             final byte[] prefixBytes = in.readNBytes(4);
             if (prefixBytes.length != 4 || false == Arrays.equals(prefixBytes, PREFIX)) {
                 logger.trace(
-                    () -> new ParameterizedMessage(
-                        "service account token expects the 4 leading bytes to be {}, got {}.",
+                    () -> format(
+                        "service account token expects the 4 leading bytes to be %s, got %s.",
                         Arrays.toString(PREFIX),
                         Arrays.toString(prefixBytes)
                     )

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authz/RBACEngine.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authz/RBACEngine.java
@@ -9,7 +9,6 @@ package org.elasticsearch.xpack.security.authz;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.message.ParameterizedMessage;
 import org.apache.lucene.util.automaton.Automaton;
 import org.apache.lucene.util.automaton.Operations;
 import org.elasticsearch.action.ActionListener;
@@ -96,6 +95,7 @@ import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 import static org.elasticsearch.common.Strings.arrayToCommaDelimitedString;
+import static org.elasticsearch.core.Strings.format;
 import static org.elasticsearch.xpack.security.audit.logfile.LoggingAuditTrail.PRINCIPAL_ROLES_FIELD_NAME;
 
 public class RBACEngine implements AuthorizationEngine {
@@ -526,9 +526,9 @@ public class RBACEngine implements AuthorizationEngine {
         }
         final Role userRole = ((RBACAuthorizationInfo) authorizationInfo).getRole();
         logger.trace(
-            () -> new ParameterizedMessage(
-                "Check whether role [{}] has privileges cluster=[{}] index=[{}] application=[{}]",
-                Strings.arrayToCommaDelimitedString(userRole.names()),
+            () -> format(
+                "Check whether role [%s] has privileges cluster=[%s] index=[%s] application=[%s]",
+                arrayToCommaDelimitedString(userRole.names()),
                 Arrays.toString(privilegesToCheck.cluster()),
                 Arrays.toString(privilegesToCheck.index()),
                 Arrays.toString(privilegesToCheck.application())
@@ -539,9 +539,9 @@ public class RBACEngine implements AuthorizationEngine {
             final PrivilegesCheckResult result = simpleRole.checkPrivilegesWithCache(privilegesToCheck);
             if (result != null) {
                 logger.debug(
-                    () -> new ParameterizedMessage(
-                        "role [{}] has privileges check result in cache for check: [{}]",
-                        Strings.arrayToCommaDelimitedString(userRole.names()),
+                    () -> format(
+                        "role [%s] has privileges check result in cache for check: [%s]",
+                        arrayToCommaDelimitedString(userRole.names()),
                         privilegesToCheck
                     )
                 );

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authz/interceptor/DlsFlsLicenseRequestInterceptor.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authz/interceptor/DlsFlsLicenseRequestInterceptor.java
@@ -9,7 +9,6 @@ package org.elasticsearch.xpack.security.authz.interceptor;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.message.ParameterizedMessage;
 import org.elasticsearch.ElasticsearchSecurityException;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.IndicesRequest;
@@ -23,6 +22,7 @@ import org.elasticsearch.xpack.core.security.authz.accesscontrol.IndicesAccessCo
 import org.elasticsearch.xpack.core.security.authz.permission.Role;
 import org.elasticsearch.xpack.security.authz.RBACEngine;
 
+import static org.elasticsearch.core.Strings.format;
 import static org.elasticsearch.xpack.core.security.SecurityField.DOCUMENT_LEVEL_SECURITY_FEATURE;
 import static org.elasticsearch.xpack.core.security.SecurityField.FIELD_LEVEL_SECURITY_FEATURE;
 import static org.elasticsearch.xpack.core.security.authz.AuthorizationServiceField.AUTHORIZATION_INFO_KEY;
@@ -60,8 +60,8 @@ public class DlsFlsLicenseRequestInterceptor implements RequestInterceptor {
                     boolean incompatibleLicense = false;
                     if (dlsFlsUsage.hasFieldLevelSecurity()) {
                         logger.debug(
-                            () -> new ParameterizedMessage(
-                                "User [{}] has field level security on [{}]",
+                            () -> format(
+                                "User [%s] has field level security on [%s]",
                                 requestInfo.getAuthentication(),
                                 indicesAccessControl.getIndicesWithFieldLevelSecurity()
                             )
@@ -72,8 +72,8 @@ public class DlsFlsLicenseRequestInterceptor implements RequestInterceptor {
                     }
                     if (dlsFlsUsage.hasDocumentLevelSecurity()) {
                         logger.debug(
-                            () -> new ParameterizedMessage(
-                                "User [{}] has document level security on [{}]",
+                            () -> format(
+                                "User [%s] has document level security on [%s]",
                                 requestInfo.getAuthentication(),
                                 indicesAccessControl.getIndicesWithDocumentLevelSecurity()
                             )

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authz/store/NativePrivilegeStore.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authz/store/NativePrivilegeStore.java
@@ -8,7 +8,6 @@ package org.elasticsearch.xpack.security.authz.store;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.message.ParameterizedMessage;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.DocWriteResponse;
@@ -63,6 +62,7 @@ import java.util.function.Supplier;
 import java.util.stream.Collector;
 import java.util.stream.Collectors;
 
+import static org.elasticsearch.core.Strings.format;
 import static org.elasticsearch.search.SearchService.DEFAULT_KEEPALIVE_SETTING;
 import static org.elasticsearch.xcontent.XContentFactory.jsonBuilder;
 import static org.elasticsearch.xpack.core.ClientHelper.SECURITY_ORIGIN;
@@ -197,13 +197,7 @@ public class NativePrivilegeStore {
                         .setSize(1000)
                         .setFetchSource(true)
                         .request();
-                    logger.trace(
-                        () -> new ParameterizedMessage(
-                            "Searching for [{}] privileges with query [{}]",
-                            applications,
-                            Strings.toString(query)
-                        )
-                    );
+                    logger.trace(() -> format("Searching for [%s] privileges with query [%s]", applications, Strings.toString(query)));
                     request.indicesOptions().ignoreUnavailable();
                     ScrollHelper.fetchAllByEntity(
                         client,

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authz/store/RoleDescriptorStore.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authz/store/RoleDescriptorStore.java
@@ -41,6 +41,8 @@ import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
+import static java.util.stream.Collectors.joining;
+import static org.elasticsearch.core.Strings.format;
 import static org.elasticsearch.xpack.core.security.SecurityField.DOCUMENT_LEVEL_SECURITY_FEATURE;
 
 public class RoleDescriptorStore implements RoleReferenceResolver {
@@ -136,18 +138,12 @@ public class RoleDescriptorStore implements RoleReferenceResolver {
             logDeprecatedRoles(rolesRetrievalResult.getRoleDescriptors());
             final boolean missingRoles = rolesRetrievalResult.getMissingRoles().isEmpty() == false;
             if (missingRoles) {
-                logger.debug(() -> new ParameterizedMessage("Could not find roles with names {}", rolesRetrievalResult.getMissingRoles()));
+                logger.debug(() -> format("Could not find roles with names %s", rolesRetrievalResult.getMissingRoles()));
             }
             final Set<RoleDescriptor> effectiveDescriptors = maybeSkipRolesUsingDocumentOrFieldLevelSecurity(
                 rolesRetrievalResult.getRoleDescriptors()
             );
-            logger.trace(
-                () -> new ParameterizedMessage(
-                    "Exposing effective role descriptors [{}] for role names [{}]",
-                    effectiveDescriptors,
-                    roleNames
-                )
-            );
+            logger.trace(() -> format("Exposing effective role descriptors [%s] for role names [%s]", effectiveDescriptors, roleNames));
             effectiveRoleDescriptorsConsumer.accept(Collections.unmodifiableCollection(effectiveDescriptors));
             // TODO: why not populate negativeLookupCache here with missing roles?
 
@@ -231,9 +227,9 @@ public class RoleDescriptorStore implements RoleReferenceResolver {
             rolesProvider.accept(roleNames, ActionListener.wrap(result -> {
                 if (result.isSuccess()) {
                     logger.debug(
-                        () -> new ParameterizedMessage(
-                            "Roles [{}] were resolved by [{}]",
-                            result.getDescriptors().stream().map(RoleDescriptor::getName).collect(Collectors.joining(",")),
+                        () -> format(
+                            "Roles [%s] were resolved by [%s]",
+                            result.getDescriptors().stream().map(RoleDescriptor::getName).collect(joining(",")),
                             rolesProvider
                         )
                     );

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/profile/ProfileService.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/profile/ProfileService.java
@@ -82,6 +82,8 @@ import java.util.TreeSet;
 import java.util.stream.Collectors;
 
 import static org.elasticsearch.action.bulk.TransportSingleItemBulkWriteAction.toSingleItemBulkRequest;
+import static org.elasticsearch.common.Strings.collectionToCommaDelimitedString;
+import static org.elasticsearch.core.Strings.format;
 import static org.elasticsearch.xpack.core.ClientHelper.SECURITY_ORIGIN;
 import static org.elasticsearch.xpack.core.ClientHelper.SECURITY_PROFILE_ORIGIN;
 import static org.elasticsearch.xpack.core.ClientHelper.executeAsyncWithOrigin;
@@ -393,10 +395,10 @@ public class ProfileService {
                 }
             } else {
                 logger.debug(
-                    () -> new ParameterizedMessage(
-                        "searching existing profile document for user [{}] from any of the realms [{}] under domain [{}]",
+                    () -> format(
+                        "searching existing profile document for user [%s] from any of the realms [%s] under domain [%s]",
                         subject.getUser().principal(),
-                        Strings.collectionToCommaDelimitedString(subject.getRealm().getDomain().realms()),
+                        collectionToCommaDelimitedString(subject.getRealm().getDomain().realms()),
                         subject.getRealm().getDomain().name()
                     )
                 );

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/ClientTransformIndexer.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/ClientTransformIndexer.java
@@ -66,6 +66,8 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 
+import static org.elasticsearch.core.Strings.format;
+
 class ClientTransformIndexer extends TransformIndexer {
 
     private static final TimeValue PIT_KEEP_ALIVE = TimeValue.timeValueSeconds(30);
@@ -336,14 +338,7 @@ class ClientTransformIndexer extends TransformIndexer {
     }
 
     void updateSeqNoPrimaryTermAndIndex(SeqNoPrimaryTermAndIndex expectedValue, SeqNoPrimaryTermAndIndex newValue) {
-        logger.debug(
-            () -> new ParameterizedMessage(
-                "[{}] Updated state document from [{}] to [{}]",
-                transformConfig.getId(),
-                expectedValue,
-                newValue
-            )
-        );
+        logger.debug(() -> format("[%s] Updated state document from [%s] to [%s]", transformConfig.getId(), expectedValue, newValue));
         boolean updated = seqNoPrimaryTermAndIndexHolder.compareAndSet(expectedValue, newValue);
         // This should never happen. We ONLY ever update this value if at initialization or we just finished updating the document
         // famous last words...

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/TransformIndexer.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/TransformIndexer.java
@@ -61,6 +61,8 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Stream;
 
+import static org.elasticsearch.core.Strings.format;
+
 public abstract class TransformIndexer extends AsyncTwoPhaseIndexer<TransformIndexerPosition, TransformIndexerStats> {
 
     private static final int PERSIST_STOP_AT_CHECKPOINT_TIMEOUT_SEC = 5;
@@ -452,8 +454,8 @@ public abstract class TransformIndexer extends AsyncTwoPhaseIndexer<TransformInd
         }
 
         logger.debug(
-            () -> new ParameterizedMessage(
-                "[{}] Run delete based on retention policy using dbq [{}] with query: [{}]",
+            () -> format(
+                "[%s] Run delete based on retention policy using dbq [%s] with query: [%s]",
                 getJobId(),
                 deleteByQuery,
                 deleteByQuery.getSearchRequest()
@@ -462,7 +464,7 @@ public abstract class TransformIndexer extends AsyncTwoPhaseIndexer<TransformInd
         getStats().markStartDelete();
 
         doDeleteByQuery(deleteByQuery, ActionListener.wrap(bulkByScrollResponse -> {
-            logger.trace(() -> new ParameterizedMessage("[{}] dbq response: [{}]", getJobId(), bulkByScrollResponse));
+            logger.trace(() -> format("[%s] dbq response: [%s]", getJobId(), bulkByScrollResponse));
 
             getStats().markEndDelete();
             getStats().incrementNumDeletedDocuments(bulkByScrollResponse.getDeleted());

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/common/DocumentConversionUtils.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/common/DocumentConversionUtils.java
@@ -9,7 +9,6 @@ package org.elasticsearch.xpack.transform.transforms.common;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.message.ParameterizedMessage;
 import org.elasticsearch.action.fieldcaps.FieldCapabilitiesResponse;
 import org.elasticsearch.action.index.IndexRequest;
 
@@ -17,6 +16,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import static java.util.function.Predicate.not;
+import static org.elasticsearch.core.Strings.format;
 
 /**
  * Helper functions for converting raw maps into documents and determining index mappings
@@ -74,7 +74,7 @@ public class DocumentConversionUtils {
         response.get().forEach((fieldName, capabilitiesMap) -> {
             // TODO: overwrites types, requires resolve if types are mixed
             capabilitiesMap.forEach((name, capability) -> {
-                logger.trace(() -> new ParameterizedMessage("Extracted type for [{}] : [{}]", fieldName, capability.getType()));
+                logger.trace(() -> format("Extracted type for [%s] : [%s]", fieldName, capability.getType()));
                 extractedTypes.put(fieldName, capability.getType());
             });
         });

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/pivot/SchemaUtil.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/pivot/SchemaUtil.java
@@ -9,7 +9,6 @@ package org.elasticsearch.xpack.transform.transforms.pivot;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.message.ParameterizedMessage;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.fieldcaps.FieldCapabilitiesAction;
 import org.elasticsearch.action.fieldcaps.FieldCapabilitiesRequest;
@@ -31,6 +30,7 @@ import java.util.Objects;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import static org.elasticsearch.core.Strings.format;
 import static org.elasticsearch.xpack.transform.transforms.common.DocumentConversionUtils.extractFieldMappings;
 
 public final class SchemaUtil {
@@ -200,21 +200,12 @@ public final class SchemaUtil {
             String destinationMapping = TransformAggregations.resolveTargetMapping(aggregationName, sourceMapping);
 
             logger.debug(
-                () -> new ParameterizedMessage(
-                    "Deduced mapping for: [{}], agg type [{}] to [{}]",
-                    targetFieldName,
-                    aggregationName,
-                    destinationMapping
-                )
+                () -> format("Deduced mapping for: [%s], agg type [%s] to [%s]", targetFieldName, aggregationName, destinationMapping)
             );
 
             if (TransformAggregations.isDynamicMapping(destinationMapping)) {
                 logger.debug(
-                    () -> new ParameterizedMessage(
-                        "Dynamic target mapping set for field [{}] and aggregation [{}]",
-                        targetFieldName,
-                        aggregationName
-                    )
+                    () -> format("Dynamic target mapping set for field [%s] and aggregation [%s]", targetFieldName, aggregationName)
                 );
             } else if (destinationMapping != null) {
                 targetMapping.put(targetFieldName, destinationMapping);
@@ -229,7 +220,7 @@ public final class SchemaUtil {
 
         fieldNamesForGrouping.forEach((targetFieldName, sourceFieldName) -> {
             String destinationMapping = fieldTypesForGrouping.computeIfAbsent(targetFieldName, (s) -> sourceMappings.get(sourceFieldName));
-            logger.debug(() -> new ParameterizedMessage("Deduced mapping for: [{}] to [{}]", targetFieldName, destinationMapping));
+            logger.debug(() -> format("Deduced mapping for: [%s] to [%s]", targetFieldName, destinationMapping));
             if (destinationMapping != null) {
                 targetMapping.put(targetFieldName, destinationMapping);
             } else {


### PR DESCRIPTION
This is a result of structural search/replace in intellij. This only affects log methods with a signature
logger.info(Supplier<?>) where level could be info/debug etc and supplier argument is in a form of
()-> new ParameterizedMessage

This commit also introduced a Strings utility class to avoid passing Locale.ROOT to every 
String.format(Locale.ROOT, pattern, args)
relates #86549

<!--
Thank you for your interest in and contributing to Elasticsearch! There
are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your
attention.
-->

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/elasticsearch/blob/master/CONTRIBUTING.md)?
- If submitting code, have you built your formula locally prior to submission with `gradle check`?
- If submitting code, is your pull request against master? Unless there is a good reason otherwise, we prefer pull requests against master and will backport as needed.
- If submitting code, have you checked that your submission is for an [OS and architecture that we support](https://www.elastic.co/support/matrix#show_os)?
- If you are submitting this code for a class then read our [policy](https://github.com/elastic/elasticsearch/blob/master/CONTRIBUTING.md#contributing-as-part-of-a-class) for that.
