### PR TITLE
Fix ElasticsearchJavaModulePathPluginFuncTest on Windows

### DIFF
--- a/build-tools-internal/src/integTest/groovy/org/elasticsearch/gradle/internal/ElasticsearchJavaModulePathPluginFuncTest.groovy
+++ b/build-tools-internal/src/integTest/groovy/org/elasticsearch/gradle/internal/ElasticsearchJavaModulePathPluginFuncTest.groovy
@@ -8,18 +8,14 @@
 
 package org.elasticsearch.gradle.internal
 
-import spock.lang.IgnoreIf
-
 import org.elasticsearch.gradle.VersionProperties
 import org.elasticsearch.gradle.fixtures.AbstractJavaGradleFuncTest
-import org.gradle.internal.os.OperatingSystem
 import org.gradle.testkit.runner.TaskOutcome
 import org.objectweb.asm.ClassReader
 import org.objectweb.asm.tree.ClassNode
 
 import java.nio.file.Files
 
-@IgnoreIf({ os.isWindows() })
 class ElasticsearchJavaModulePathPluginFuncTest extends AbstractJavaGradleFuncTest {
 
     public static final GString JAVA_BASE_MODULE = "java.base:${System.getProperty("java.version")}"
@@ -60,7 +56,8 @@ class ElasticsearchJavaModulePathPluginFuncTest extends AbstractJavaGradleFuncTe
 
             tasks.named('compileJava').configure {
                 doLast {
-                    println "COMPILE_JAVA_COMPILER_ARGS " + options.allCompilerArgs.join(';')
+                    def sep = org.gradle.internal.os.OperatingSystem.current().isWindows() ? ':' : ';'
+                    println "COMPILE_JAVA_COMPILER_ARGS " + options.allCompilerArgs.join(sep)
                     println "COMPILE_JAVA_CLASSPATH "  + classpath.asPath
                 }
             }
@@ -166,9 +163,8 @@ class ElasticsearchJavaModulePathPluginFuncTest extends AbstractJavaGradleFuncTe
         if(allArgs.isEmpty()) {
             assert expectedEntries.size() == 0
         } else {
-            def modulePathEntries = OperatingSystem.current().isWindows() ?
-                allArgs.find(/(?<=.*--module-path=).*/).minus(";--module-version=${ES_VERSION}") :
-                allArgs.find(/(?<=.*--module-path=)[^;]*(?=;)?/)
+            def sep = org.gradle.internal.os.OperatingSystem.current().isWindows() ? ':' : ';'
+            def modulePathEntries = allArgs.find(/(?<=.*--module-path=)[^${sep}]*(?=${sep})?/)
             doClasspathAssertion(modulePathEntries, expectedEntries)
         }
         true

--- a/build-tools-internal/src/integTest/groovy/org/elasticsearch/gradle/internal/ElasticsearchJavaModulePathPluginFuncTest.groovy
+++ b/build-tools-internal/src/integTest/groovy/org/elasticsearch/gradle/internal/ElasticsearchJavaModulePathPluginFuncTest.groovy
@@ -10,6 +10,7 @@ package org.elasticsearch.gradle.internal
 
 import org.elasticsearch.gradle.VersionProperties
 import org.elasticsearch.gradle.fixtures.AbstractJavaGradleFuncTest
+import org.gradle.internal.os.OperatingSystem
 import org.gradle.testkit.runner.TaskOutcome
 import org.objectweb.asm.ClassReader
 import org.objectweb.asm.tree.ClassNode
@@ -163,7 +164,7 @@ class ElasticsearchJavaModulePathPluginFuncTest extends AbstractJavaGradleFuncTe
         if(allArgs.isEmpty()) {
             assert expectedEntries.size() == 0
         } else {
-            def sep = org.gradle.internal.os.OperatingSystem.current().isWindows() ? ':' : ';'
+            def sep = OperatingSystem.current().isWindows() ? ':' : ';'
             def modulePathEntries = allArgs.find(/(?<=.*--module-path=)[^${sep}]*(?=${sep})?/)
             doClasspathAssertion(modulePathEntries, expectedEntries)
         }


### PR DESCRIPTION
Re-enable temporarily disabled ElasticsearchJavaModulePathPluginFuncTest on Windows.

We can simplify the regex by just flipping between logical separators on Windows versus non-Windows platforms - since Windows uses `;` for the path-separator character.