### PR TITLE
TSDB: Fix errant test

### DIFF
--- a/modules/reindex/src/yamlRestTest/resources/rest-api-spec/test/reindex/100_tsdb.yml
+++ b/modules/reindex/src/yamlRestTest/resources/rest-api-spec/test/reindex/100_tsdb.yml
@@ -405,6 +405,7 @@ from tsdb to tsdb created by template while modifying dimension:
   - skip:
       version: " - 8.2.99"
       reason: introduced in 8.3.0
+      features: allowed_warnings
 
   - do:
       cluster.put_component_template:
@@ -442,6 +443,8 @@ from tsdb to tsdb created by template while modifying dimension:
                             rx:
                               type: long
   - do:
+      allowed_warnings:
+        - "index template [test-composable-1] has index patterns [tsdb_templated_*] matching patterns from existing older templates [global] with patterns (global => [*]); this template [test-composable-1] will take precedence during new index creation"
       indices.put_index_template:
         name: test-composable-1
         body:


### PR DESCRIPTION
I added a test recently for tsdb and templates with reindex that
sometimes fails with an unexpected warning response. This permits the
warning.

Closes #86804
