### PR TITLE
Fix null message in output

### DIFF
--- a/distribution/tools/server-cli/src/main/java/org/elasticsearch/server/cli/ServerCli.java
+++ b/distribution/tools/server-cli/src/main/java/org/elasticsearch/server/cli/ServerCli.java
@@ -153,7 +153,9 @@ class ServerCli extends EnvironmentAwareCommand {
             };
             if (options.has(enrollmentTokenOption) == false && okCode) {
                 // we still want to print the error, just don't fail startup
-                terminal.errorPrintln(e.getMessage());
+                if (e.getMessage() != null) {
+                    terminal.errorPrintln(e.getMessage());
+                }
                 changed = false;
             } else {
                 throw e;

--- a/distribution/tools/server-cli/src/test/java/org/elasticsearch/server/cli/ServerCliTests.java
+++ b/distribution/tools/server-cli/src/test/java/org/elasticsearch/server/cli/ServerCliTests.java
@@ -261,6 +261,16 @@ public class ServerCliTests extends CommandTestCase {
         assertThat(mockServer.stopCalled, is(true));
     }
 
+    public void testIgnoreNullExceptionOutput() throws Exception {
+        Command command = newCommand();
+
+        autoConfigCallback = (t, options, env, processInfo) -> { throw new UserException(ExitCodes.NOOP, null); };
+        terminal.reset();
+        command.main(new String[0], terminal, new ProcessInfo(sysprops, envVars, esHomeDir));
+        command.close();
+        assertThat(terminal.getErrorOutput(), not(containsString("null")));
+    }
+
     interface AutoConfigMethod {
         void autoconfig(Terminal terminal, OptionSet options, Environment env, ProcessInfo processInfo) throws UserException;
     }

--- a/docs/changelog/86981.yaml
+++ b/docs/changelog/86981.yaml
@@ -1,0 +1,5 @@
+pr: 86981
+summary: Fix null message in output
+area: Infra/Core
+type: bug
+issues: []


### PR DESCRIPTION
When launching Elasticsearch, the node auto configuration code might throw an exception because security is disabled or already setup. If this node is not in enrolment mode, the exception is thrown with null message, which we should ignore and not print.