### PR TITLE
Improve error message for search API url parameters

### DIFF
--- a/docs/changelog/86984.yaml
+++ b/docs/changelog/86984.yaml
@@ -1,0 +1,6 @@
+pr: 86984
+summary: Improve error message for search API url parameters
+area: Search
+type: enhancement
+issues:
+ - 79719

--- a/server/src/test/java/org/elasticsearch/rest/action/RestActionsTests.java
+++ b/server/src/test/java/org/elasticsearch/rest/action/RestActionsTests.java
@@ -16,11 +16,15 @@ import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.index.Index;
 import org.elasticsearch.index.query.MatchQueryBuilder;
+import org.elasticsearch.index.query.Operator;
 import org.elasticsearch.index.query.QueryBuilder;
+import org.elasticsearch.index.query.QueryStringQueryBuilder;
 import org.elasticsearch.index.shard.ShardId;
+import org.elasticsearch.rest.RestRequest;
 import org.elasticsearch.search.SearchModule;
 import org.elasticsearch.search.SearchShardTarget;
 import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.test.rest.FakeRestRequest;
 import org.elasticsearch.xcontent.NamedXContentRegistry;
 import org.elasticsearch.xcontent.ToXContent;
 import org.elasticsearch.xcontent.XContentBuilder;
@@ -32,8 +36,10 @@ import org.junit.BeforeClass;
 
 import java.io.IOException;
 import java.util.Arrays;
+import java.util.Map;
 
 import static java.util.Collections.emptyList;
+import static org.elasticsearch.index.query.QueryStringQueryBuilder.DEFAULT_OPERATOR;
 import static org.hamcrest.CoreMatchers.equalTo;
 
 public class RestActionsTests extends ESTestCase {
@@ -174,6 +180,56 @@ public class RestActionsTests extends ESTestCase {
                 ]
               }
             }"""));
+    }
+
+    public void testUrlParamsToQueryBuilder() {
+        // without any parameters, result should be null
+        assertNull(RestActions.urlParamsToQueryBuilder(new FakeRestRequest()));
+
+        RestRequest request = new FakeRestRequest.Builder(xContentRegistry).withParams(Map.of("q", "foo:bar")).build();
+        QueryStringQueryBuilder queryBuilder = (QueryStringQueryBuilder) RestActions.urlParamsToQueryBuilder(request);
+        assertNotNull(queryBuilder);
+        assertNull(queryBuilder.analyzer());
+        assertNull(queryBuilder.defaultField());
+        assertEquals(DEFAULT_OPERATOR, queryBuilder.defaultOperator());
+        assertNull(queryBuilder.lenient());
+        assertFalse(queryBuilder.analyzeWildcard());
+
+        request = new FakeRestRequest.Builder(xContentRegistry).withParams(
+            Map.of(
+                "q",
+                "foo:bar",
+                "analyzer",
+                "german",
+                "analyze_wildcard",
+                "true",
+                "df",
+                "message",
+                "lenient",
+                "true",
+                "default_operator",
+                "and"
+            )
+        ).build();
+        queryBuilder = (QueryStringQueryBuilder) RestActions.urlParamsToQueryBuilder(request);
+        assertNotNull(queryBuilder);
+        assertEquals("german", queryBuilder.analyzer());
+        assertEquals("message", queryBuilder.defaultField());
+        assertEquals(Operator.AND, queryBuilder.defaultOperator());
+        assertTrue(queryBuilder.lenient());
+        assertTrue(queryBuilder.analyzeWildcard());
+    }
+
+    public void testUrlParamsToQueryBuilderError() {
+        RestRequest request = new FakeRestRequest.Builder(xContentRegistry).withParams(
+            Map.of("analyzer", "german", "analyze_wildcard", "true", "df", "message", "lenient", "true", "default_operator", "and")
+        ).build();
+        IllegalArgumentException iae = expectThrows(IllegalArgumentException.class, () -> RestActions.urlParamsToQueryBuilder(request));
+        assertEquals(
+            "request [/] contains parameters [df, analyzer, analyze_wildcard, lenient, default_operator] "
+                + "but missing query string parameter 'q'.",
+            iae.getMessage()
+        );
     }
 
     private static ShardSearchFailure createShardFailureParsingException(String nodeId, int shardId, String clusterAlias) {

--- a/server/src/test/java/org/elasticsearch/rest/action/search/RestSearchActionTests.java
+++ b/server/src/test/java/org/elasticsearch/rest/action/search/RestSearchActionTests.java
@@ -10,6 +10,8 @@ package org.elasticsearch.rest.action.search;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.core.RestApiVersion;
 import org.elasticsearch.rest.RestRequest;
+import org.elasticsearch.search.suggest.SuggestBuilder;
+import org.elasticsearch.search.suggest.term.TermSuggestionBuilder;
 import org.elasticsearch.test.rest.FakeRestChannel;
 import org.elasticsearch.test.rest.FakeRestRequest;
 import org.elasticsearch.test.rest.RestActionTestCase;
@@ -82,5 +84,34 @@ public class RestSearchActionTests extends RestActionTestCase {
 
         Exception ex = expectThrows(IllegalArgumentException.class, () -> action.prepareRequest(request, verifyingClient));
         assertEquals("No search type for [some_search_type]", ex.getMessage());
+    }
+
+    public void testParseSuggestParameters() {
+        assertNull(RestSearchAction.parseSuggestUrlParameters(new FakeRestRequest()));
+
+        RestRequest request = new FakeRestRequest.Builder(xContentRegistry()).withParams(
+            Map.of("suggest_field", "field", "suggest_text", "text", "suggest_size", "3", "suggest_mode", "missing")
+        ).build();
+        SuggestBuilder suggestBuilder = RestSearchAction.parseSuggestUrlParameters(request);
+        TermSuggestionBuilder builder = (TermSuggestionBuilder) suggestBuilder.getSuggestions().get("field");
+        assertNotNull(builder);
+        assertEquals("text", builder.text());
+        assertEquals("field", builder.field());
+        assertEquals(3, builder.size().intValue());
+        assertEquals(TermSuggestionBuilder.SuggestMode.MISSING, builder.suggestMode());
+    }
+
+    public void testParseSuggestParametersError() {
+        RestRequest request = new FakeRestRequest.Builder(xContentRegistry()).withParams(
+            Map.of("suggest_text", "text", "suggest_size", "3", "suggest_mode", "missing")
+        ).build();
+        IllegalArgumentException iae = expectThrows(
+            IllegalArgumentException.class,
+            () -> RestSearchAction.parseSuggestUrlParameters(request)
+        );
+        assertEquals(
+            "request [/] contains parameters [suggest_text, suggest_size, suggest_mode] but missing 'suggest_field' parameter.",
+            iae.getMessage()
+        );
     }
 }


### PR DESCRIPTION
The search API uses url query parameters that require other parameters to be
present. When one of them is ommited, the other depending parameters might not
be consumed, leading to an error message about unconsumed parameters from the
BaseRestHandler that are not actionable by the user.
This change adds improvements for url query parameters that require the
existance of the 'q' query string parameter and also adds better error message
for suggestion url parameter handling.

Closes #79719
