### PR TITLE
Fix versions in serial diff tests

### DIFF
--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.aggregation/500_serial_diff.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.aggregation/500_serial_diff.yml
@@ -1,4 +1,8 @@
 basic:
+  - skip:
+      version: " - 7.1.99"
+      reason: fixed_interval added in 7.2
+
   - do:
       bulk:
         index: test
@@ -37,6 +41,9 @@ basic:
 
 ---
 lag:
+      - skip:
+          version: " - 7.1.99"
+          reason: fixed_interval added in 7.2
       - do:
           bulk:
             index: test
@@ -80,6 +87,10 @@ lag:
 
 ---
 parent has gap:
+  - skip:
+      version: " - 7.1.99"
+      reason: fixed_interval added in 7.2
+
   - do:
       bulk:
         index: test
@@ -122,8 +133,8 @@ parent has gap:
 ---
 parent has min_doc_count:
   - skip:
-      version: " - 8.2.99"
-      reason: allowed in 8.3.0
+      version: " - 7.17.3"
+      reason: allowed in 7.17.4
 
   - do:
       bulk:


### PR DESCRIPTION
This adds some missing skips to make the tests for the serial_diff
always pass and test the current version. The tests contain a
`fixed_interval` which is only supported in 7.2+. That's fine probably
ok - we don't expect to make backwards breaking changes at all, much
less breaking with 7.1 and *not* 7.2
