### PR TITLE
Rename PluginInfo to PluginDescriptor (#86950)

### DIFF
--- a/distribution/tools/plugin-cli/src/main/java/org/elasticsearch/plugins/cli/InstallPluginAction.java
+++ b/distribution/tools/plugin-cli/src/main/java/org/elasticsearch/plugins/cli/InstallPluginAction.java
@@ -39,7 +39,7 @@ import org.elasticsearch.core.internal.io.IOUtils;
 import org.elasticsearch.env.Environment;
 import org.elasticsearch.jdk.JarHell;
 import org.elasticsearch.plugins.Platforms;
-import org.elasticsearch.plugins.PluginInfo;
+import org.elasticsearch.plugins.PluginDescriptor;
 import org.elasticsearch.plugins.PluginsService;
 
 import java.io.BufferedReader;
@@ -99,7 +99,7 @@ import static org.elasticsearch.cli.Terminal.Verbosity.VERBOSE;
  * </ul>
  * <p>
  * Plugins are packaged as zip files. Each packaged plugin must contain a plugin properties file.
- * See {@link PluginInfo}.
+ * See {@link PluginDescriptor}.
  * <p>
  * The installation process first extracts the plugin files into a temporary
  * directory in order to verify the plugin satisfies the following requirements:
@@ -205,13 +205,13 @@ public class InstallPluginAction implements Closeable {
     }
 
     // pkg private for testing
-    public void execute(List<PluginDescriptor> plugins) throws Exception {
+    public void execute(List<InstallablePlugin> plugins) throws Exception {
         if (plugins.isEmpty()) {
             throw new UserException(ExitCodes.USAGE, "at least one plugin id is required");
         }
 
         final Set<String> uniquePluginIds = new HashSet<>();
-        for (final PluginDescriptor plugin : plugins) {
+        for (final InstallablePlugin plugin : plugins) {
             if (uniquePluginIds.add(plugin.getId()) == false) {
                 throw new UserException(ExitCodes.USAGE, "duplicate plugin id [" + plugin.getId() + "]");
             }
@@ -220,7 +220,7 @@ public class InstallPluginAction implements Closeable {
         final String logPrefix = terminal.isHeadless() ? "" : "-> ";
 
         final Map<String, List<Path>> deleteOnFailures = new LinkedHashMap<>();
-        for (final PluginDescriptor plugin : plugins) {
+        for (final InstallablePlugin plugin : plugins) {
             final String pluginId = plugin.getId();
             terminal.println(logPrefix + "Installing " + pluginId);
             try {
@@ -243,11 +243,11 @@ public class InstallPluginAction implements Closeable {
                 final Path pluginZip = download(plugin, env.tmpFile());
                 final Path extractedZip = unzip(pluginZip, env.pluginsFile());
                 deleteOnFailure.add(extractedZip);
-                final PluginInfo pluginInfo = installPlugin(plugin, extractedZip, deleteOnFailure);
-                terminal.println(logPrefix + "Installed " + pluginInfo.getName());
+                final PluginDescriptor pluginDescriptor = installPlugin(plugin, extractedZip, deleteOnFailure);
+                terminal.println(logPrefix + "Installed " + pluginDescriptor.getName());
                 // swap the entry by plugin id for one with the installed plugin name, it gives a cleaner error message for URL installs
                 deleteOnFailures.remove(pluginId);
-                deleteOnFailures.put(pluginInfo.getName(), deleteOnFailure);
+                deleteOnFailures.put(pluginDescriptor.getName(), deleteOnFailure);
             } catch (final Exception installProblem) {
                 terminal.println(logPrefix + "Failed installing " + pluginId);
                 for (final Map.Entry<String, List<Path>> deleteOnFailureEntry : deleteOnFailures.entrySet()) {
@@ -294,7 +294,7 @@ public class InstallPluginAction implements Closeable {
     /**
      * Downloads the plugin and returns the file it was downloaded to.
      */
-    private Path download(PluginDescriptor plugin, Path tmpDir) throws Exception {
+    private Path download(InstallablePlugin plugin, Path tmpDir) throws Exception {
         final String pluginId = plugin.getId();
 
         final String logPrefix = terminal.isHeadless() ? "" : "-> ";
@@ -861,8 +861,8 @@ public class InstallPluginAction implements Closeable {
     /**
      * Load information about the plugin, and verify it can be installed with no errors.
      */
-    private PluginInfo loadPluginInfo(Path pluginRoot) throws Exception {
-        final PluginInfo info = PluginInfo.readFromProperties(pluginRoot);
+    private PluginDescriptor loadPluginInfo(Path pluginRoot) throws Exception {
+        final PluginDescriptor info = PluginDescriptor.readFromProperties(pluginRoot);
         if (info.hasNativeController()) {
             throw new IllegalStateException("plugins can not have native controllers");
         }
@@ -890,7 +890,7 @@ public class InstallPluginAction implements Closeable {
     /**
      * check a candidate plugin for jar hell before installing it
      */
-    void jarHellCheck(PluginInfo candidateInfo, Path candidateDir, Path pluginsDir, Path modulesDir) throws Exception {
+    void jarHellCheck(PluginDescriptor candidateInfo, Path candidateDir, Path pluginsDir, Path modulesDir) throws Exception {
         // create list of current jars in classpath
         final Set<URL> classpath = JarHell.parseClassPath().stream().filter(url -> {
             try {
@@ -921,8 +921,8 @@ public class InstallPluginAction implements Closeable {
      * Installs the plugin from {@code tmpRoot} into the plugins dir.
      * If the plugin has a bin dir and/or a config dir, those are moved.
      */
-    private PluginInfo installPlugin(PluginDescriptor descriptor, Path tmpRoot, List<Path> deleteOnFailure) throws Exception {
-        final PluginInfo info = loadPluginInfo(tmpRoot);
+    private PluginDescriptor installPlugin(InstallablePlugin descriptor, Path tmpRoot, List<Path> deleteOnFailure) throws Exception {
+        final PluginDescriptor info = loadPluginInfo(tmpRoot);
         checkCanInstallationProceed(terminal, Build.CURRENT.flavor(), info);
         PluginPolicyInfo pluginPolicy = PolicyUtil.getPluginPolicyInfo(tmpRoot, env.tmpFile());
         if (pluginPolicy != null) {
@@ -957,8 +957,13 @@ public class InstallPluginAction implements Closeable {
     /**
      * Moves bin and config directories from the plugin if they exist
      */
-    private void installPluginSupportFiles(PluginInfo info, Path tmpRoot, Path destBinDir, Path destConfigDir, List<Path> deleteOnFailure)
-        throws Exception {
+    private void installPluginSupportFiles(
+        PluginDescriptor info,
+        Path tmpRoot,
+        Path destBinDir,
+        Path destConfigDir,
+        List<Path> deleteOnFailure
+    ) throws Exception {
         Path tmpBinDir = tmpRoot.resolve("bin");
         if (Files.exists(tmpBinDir)) {
             deleteOnFailure.add(destBinDir);
@@ -1003,7 +1008,7 @@ public class InstallPluginAction implements Closeable {
     /**
      * Copies the files from {@code tmpBinDir} into {@code destBinDir}, along with permissions from dest dirs parent.
      */
-    private void installBin(PluginInfo info, Path tmpBinDir, Path destBinDir) throws Exception {
+    private void installBin(PluginDescriptor info, Path tmpBinDir, Path destBinDir) throws Exception {
         if (Files.isDirectory(tmpBinDir) == false) {
             throw new UserException(PLUGIN_MALFORMED, "bin in plugin " + info.getName() + " is not a directory");
         }
@@ -1031,7 +1036,7 @@ public class InstallPluginAction implements Closeable {
      * Copies the files from {@code tmpConfigDir} into {@code destConfigDir}.
      * Any files existing in both the source and destination will be skipped.
      */
-    private void installConfig(PluginInfo info, Path tmpConfigDir, Path destConfigDir) throws Exception {
+    private void installConfig(PluginDescriptor info, Path tmpConfigDir, Path destConfigDir) throws Exception {
         if (Files.isDirectory(tmpConfigDir) == false) {
             throw new UserException(PLUGIN_MALFORMED, "config in plugin " + info.getName() + " is not a directory");
         }
@@ -1093,7 +1098,7 @@ public class InstallPluginAction implements Closeable {
         IOUtils.rm(pathsToDeleteOnShutdown.toArray(new Path[0]));
     }
 
-    public static void checkCanInstallationProceed(Terminal terminal, Build.Flavor flavor, PluginInfo info) throws Exception {
+    public static void checkCanInstallationProceed(Terminal terminal, Build.Flavor flavor, PluginDescriptor info) throws Exception {
         if (info.isLicensed() == false) {
             return;
         }

--- a/distribution/tools/plugin-cli/src/main/java/org/elasticsearch/plugins/cli/InstallPluginCommand.java
+++ b/distribution/tools/plugin-cli/src/main/java/org/elasticsearch/plugins/cli/InstallPluginCommand.java
@@ -14,7 +14,7 @@ import joptsimple.OptionSpec;
 import org.elasticsearch.cli.Terminal;
 import org.elasticsearch.common.cli.EnvironmentAwareCommand;
 import org.elasticsearch.env.Environment;
-import org.elasticsearch.plugins.PluginInfo;
+import org.elasticsearch.plugins.PluginDescriptor;
 
 import java.util.Arrays;
 import java.util.List;
@@ -31,7 +31,7 @@ import java.util.stream.Collectors;
  * </ul>
  * <p>
  * Plugins are packaged as zip files. Each packaged plugin must contain a plugin properties file.
- * See {@link PluginInfo}.
+ * See {@link PluginDescriptor}.
  * <p>
  * The installation process first extracts the plugin files into a temporary
  * directory in order to verify the plugin satisfies the following requirements:
@@ -77,10 +77,10 @@ class InstallPluginCommand extends EnvironmentAwareCommand {
     protected void execute(Terminal terminal, OptionSet options, Environment env) throws Exception {
         SyncPluginsAction.ensureNoConfigFile(env);
 
-        List<PluginDescriptor> plugins = arguments.values(options)
+        List<InstallablePlugin> plugins = arguments.values(options)
             .stream()
             // We only have one piece of data, which could be an ID or could be a location, so we use it for both
-            .map(idOrLocation -> new PluginDescriptor(idOrLocation, idOrLocation))
+            .map(idOrLocation -> new InstallablePlugin(idOrLocation, idOrLocation))
             .collect(Collectors.toList());
         final boolean isBatch = options.has(batchOption);
 

--- a/distribution/tools/plugin-cli/src/main/java/org/elasticsearch/plugins/cli/InstallablePlugin.java
+++ b/distribution/tools/plugin-cli/src/main/java/org/elasticsearch/plugins/cli/InstallablePlugin.java
@@ -15,11 +15,11 @@ import java.util.Objects;
 /**
  * Models a single plugin that can be installed.
  */
-public class PluginDescriptor {
+public class InstallablePlugin {
     private String id;
     private String location;
 
-    public PluginDescriptor() {}
+    public InstallablePlugin() {}
 
     /**
      * Creates a new descriptor instance.
@@ -28,12 +28,12 @@ public class PluginDescriptor {
      * @param location the location from which to fetch the plugin, e.g. a URL or Maven
      *                 coordinates. Can be null for official plugins.
      */
-    public PluginDescriptor(String id, String location) {
+    public InstallablePlugin(String id, String location) {
         this.id = Strings.requireNonBlank(id, "plugin id cannot be null or blank");
         this.location = location;
     }
 
-    public PluginDescriptor(String id) {
+    public InstallablePlugin(String id) {
         this(id, null);
     }
 
@@ -57,7 +57,7 @@ public class PluginDescriptor {
     public boolean equals(Object o) {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
-        PluginDescriptor that = (PluginDescriptor) o;
+        InstallablePlugin that = (InstallablePlugin) o;
         return id.equals(that.id) && Objects.equals(location, that.location);
     }
 

--- a/distribution/tools/plugin-cli/src/main/java/org/elasticsearch/plugins/cli/ListPluginsCommand.java
+++ b/distribution/tools/plugin-cli/src/main/java/org/elasticsearch/plugins/cli/ListPluginsCommand.java
@@ -14,7 +14,7 @@ import org.elasticsearch.Version;
 import org.elasticsearch.cli.Terminal;
 import org.elasticsearch.common.cli.EnvironmentAwareCommand;
 import org.elasticsearch.env.Environment;
-import org.elasticsearch.plugins.PluginInfo;
+import org.elasticsearch.plugins.PluginDescriptor;
 
 import java.io.IOException;
 import java.nio.file.DirectoryStream;
@@ -58,7 +58,7 @@ class ListPluginsCommand extends EnvironmentAwareCommand {
 
     private void printPlugin(Environment env, Terminal terminal, Path plugin, String prefix) throws IOException {
         terminal.println(Terminal.Verbosity.SILENT, prefix + plugin.getFileName().toString());
-        PluginInfo info = PluginInfo.readFromProperties(env.pluginsFile().resolve(plugin));
+        PluginDescriptor info = PluginDescriptor.readFromProperties(env.pluginsFile().resolve(plugin));
         terminal.println(Terminal.Verbosity.VERBOSE, info.toString(prefix));
         if (info.getElasticsearchVersion().equals(Version.CURRENT) == false) {
             terminal.errorPrintln(

--- a/distribution/tools/plugin-cli/src/main/java/org/elasticsearch/plugins/cli/PluginsConfig.java
+++ b/distribution/tools/plugin-cli/src/main/java/org/elasticsearch/plugins/cli/PluginsConfig.java
@@ -33,7 +33,7 @@ import java.util.Set;
  * Elasticsearch plugin.
  */
 public class PluginsConfig {
-    private List<PluginDescriptor> plugins;
+    private List<InstallablePlugin> plugins;
     private String proxy;
 
     public PluginsConfig() {
@@ -41,7 +41,7 @@ public class PluginsConfig {
         proxy = null;
     }
 
-    public void setPlugins(List<PluginDescriptor> plugins) {
+    public void setPlugins(List<InstallablePlugin> plugins) {
         this.plugins = plugins == null ? List.of() : plugins;
     }
 
@@ -52,7 +52,7 @@ public class PluginsConfig {
     /**
      * Validate this instance. For example:
      * <ul>
-     *     <li>All {@link PluginDescriptor}s must have IDs</li>
+     *     <li>All {@link InstallablePlugin}s must have IDs</li>
      *     <li>Any proxy must be well-formed.</li>
      *     <li>Unofficial plugins must have locations</li>
      * </ul>
@@ -68,13 +68,13 @@ public class PluginsConfig {
         }
 
         final Set<String> uniquePluginIds = new HashSet<>();
-        for (final PluginDescriptor plugin : plugins) {
+        for (final InstallablePlugin plugin : plugins) {
             if (uniquePluginIds.add(plugin.getId()) == false) {
                 throw new PluginSyncException("Duplicate plugin ID [" + plugin.getId() + "] found in [elasticsearch-plugins.yml]");
             }
         }
 
-        for (PluginDescriptor plugin : this.plugins) {
+        for (InstallablePlugin plugin : this.plugins) {
             if (officialPlugins.contains(plugin.getId()) == false
                 && migratedPlugins.contains(plugin.getId()) == false
                 && plugin.getLocation() == null) {
@@ -95,7 +95,7 @@ public class PluginsConfig {
             }
         }
 
-        for (PluginDescriptor p : plugins) {
+        for (InstallablePlugin p : plugins) {
             if (p.getLocation() != null) {
                 if (p.getLocation().isBlank()) {
                     throw new PluginSyncException("Empty location for plugin [" + p.getId() + "]");
@@ -111,7 +111,7 @@ public class PluginsConfig {
         }
     }
 
-    public List<PluginDescriptor> getPlugins() {
+    public List<InstallablePlugin> getPlugins() {
         return plugins;
     }
 
@@ -152,9 +152,9 @@ public class PluginsConfig {
         // Normally a parser is declared and built statically in the class, but we'll only
         // use this when starting up Elasticsearch, so there's no point keeping one around.
 
-        final ObjectParser<PluginDescriptor, Void> descriptorParser = new ObjectParser<>("descriptor parser", PluginDescriptor::new);
-        descriptorParser.declareString(PluginDescriptor::setId, new ParseField("id"));
-        descriptorParser.declareStringOrNull(PluginDescriptor::setLocation, new ParseField("location"));
+        final ObjectParser<InstallablePlugin, Void> descriptorParser = new ObjectParser<>("descriptor parser", InstallablePlugin::new);
+        descriptorParser.declareString(InstallablePlugin::setId, new ParseField("id"));
+        descriptorParser.declareStringOrNull(InstallablePlugin::setLocation, new ParseField("location"));
 
         final ObjectParser<PluginsConfig, Void> parser = new ObjectParser<>("plugins parser", PluginsConfig::new);
         parser.declareStringOrNull(PluginsConfig::setProxy, new ParseField("proxy"));
@@ -181,7 +181,7 @@ public class PluginsConfig {
 
         builder.startObject();
         builder.startArray("plugins");
-        for (PluginDescriptor p : config.getPlugins()) {
+        for (InstallablePlugin p : config.getPlugins()) {
             builder.startObject();
             {
                 builder.field("id", p.getId());

--- a/distribution/tools/plugin-cli/src/main/java/org/elasticsearch/plugins/cli/RemovePluginAction.java
+++ b/distribution/tools/plugin-cli/src/main/java/org/elasticsearch/plugins/cli/RemovePluginAction.java
@@ -70,29 +70,29 @@ public class RemovePluginAction {
      * @throws UserException if plugin directory does not exist
      * @throws UserException if the plugin bin directory is not a directory
      */
-    public void execute(List<PluginDescriptor> plugins) throws IOException, UserException {
+    public void execute(List<InstallablePlugin> plugins) throws IOException, UserException {
         if (plugins == null || plugins.isEmpty()) {
             throw new UserException(ExitCodes.USAGE, "At least one plugin ID is required");
         }
 
         ensurePluginsNotUsedByOtherPlugins(plugins);
 
-        for (PluginDescriptor plugin : plugins) {
+        for (InstallablePlugin plugin : plugins) {
             checkCanRemove(plugin);
         }
 
-        for (PluginDescriptor plugin : plugins) {
+        for (InstallablePlugin plugin : plugins) {
             removePlugin(plugin);
         }
     }
 
-    private void ensurePluginsNotUsedByOtherPlugins(List<PluginDescriptor> plugins) throws IOException, UserException {
+    private void ensurePluginsNotUsedByOtherPlugins(List<InstallablePlugin> plugins) throws IOException, UserException {
         // First make sure nothing extends this plugin
         final Map<String, List<String>> usedBy = new HashMap<>();
         Set<PluginsService.Bundle> bundles = PluginsService.getPluginBundles(env.pluginsFile());
         for (PluginsService.Bundle bundle : bundles) {
             for (String extendedPlugin : bundle.plugin.getExtendedPlugins()) {
-                for (PluginDescriptor plugin : plugins) {
+                for (InstallablePlugin plugin : plugins) {
                     String pluginId = plugin.getId();
                     if (extendedPlugin.equals(pluginId)) {
                         usedBy.computeIfAbsent(bundle.plugin.getName(), (_key -> new ArrayList<>())).add(pluginId);
@@ -114,7 +114,7 @@ public class RemovePluginAction {
         throw new UserException(PLUGIN_STILL_USED, message.toString());
     }
 
-    private void checkCanRemove(PluginDescriptor plugin) throws UserException {
+    private void checkCanRemove(InstallablePlugin plugin) throws UserException {
         String pluginId = plugin.getId();
 
         final Path pluginDir = env.pluginsFile().resolve(pluginId);
@@ -151,7 +151,7 @@ public class RemovePluginAction {
         }
     }
 
-    private void removePlugin(PluginDescriptor plugin) throws IOException {
+    private void removePlugin(InstallablePlugin plugin) throws IOException {
         final String pluginId = plugin.getId();
         final Path pluginDir = env.pluginsFile().resolve(pluginId);
         final Path pluginConfigDir = env.configFile().resolve(pluginId);

--- a/distribution/tools/plugin-cli/src/main/java/org/elasticsearch/plugins/cli/RemovePluginCommand.java
+++ b/distribution/tools/plugin-cli/src/main/java/org/elasticsearch/plugins/cli/RemovePluginCommand.java
@@ -36,7 +36,7 @@ class RemovePluginCommand extends EnvironmentAwareCommand {
     protected void execute(final Terminal terminal, final OptionSet options, final Environment env) throws Exception {
         SyncPluginsAction.ensureNoConfigFile(env);
 
-        final List<PluginDescriptor> plugins = arguments.values(options).stream().map(PluginDescriptor::new).collect(Collectors.toList());
+        final List<InstallablePlugin> plugins = arguments.values(options).stream().map(InstallablePlugin::new).collect(Collectors.toList());
 
         final RemovePluginAction action = new RemovePluginAction(terminal, env, options.has(purgeOption));
         action.execute(plugins);

--- a/distribution/tools/plugin-cli/src/main/java/org/elasticsearch/plugins/cli/SyncPluginsAction.java
+++ b/distribution/tools/plugin-cli/src/main/java/org/elasticsearch/plugins/cli/SyncPluginsAction.java
@@ -13,7 +13,7 @@ import org.elasticsearch.cli.ExitCodes;
 import org.elasticsearch.cli.Terminal;
 import org.elasticsearch.cli.UserException;
 import org.elasticsearch.env.Environment;
-import org.elasticsearch.plugins.PluginInfo;
+import org.elasticsearch.plugins.PluginDescriptor;
 import org.elasticsearch.plugins.PluginsSynchronizer;
 import org.elasticsearch.xcontent.cbor.CborXContent;
 import org.elasticsearch.xcontent.yaml.YamlXContent;
@@ -115,28 +115,28 @@ public class SyncPluginsAction implements PluginsSynchronizer {
 
     // @VisibleForTesting
     PluginChanges getPluginChanges(PluginsConfig pluginsConfig, Optional<PluginsConfig> cachedPluginsConfig) throws PluginSyncException {
-        final List<PluginInfo> existingPlugins = getExistingPlugins();
+        final List<PluginDescriptor> existingPlugins = getExistingPlugins();
 
-        final List<PluginDescriptor> pluginsThatShouldExist = getPluginsThatShouldExist(pluginsConfig);
+        final List<InstallablePlugin> pluginsThatShouldExist = getPluginsThatShouldExist(pluginsConfig);
 
-        final List<PluginDescriptor> pluginsThatActuallyExist = existingPlugins.stream()
-            .map(info -> new PluginDescriptor(info.getName()))
+        final List<InstallablePlugin> pluginsThatActuallyExist = existingPlugins.stream()
+            .map(info -> new InstallablePlugin(info.getName()))
             .collect(Collectors.toList());
-        final Set<String> existingPluginIds = pluginsThatActuallyExist.stream().map(PluginDescriptor::getId).collect(Collectors.toSet());
+        final Set<String> existingPluginIds = pluginsThatActuallyExist.stream().map(InstallablePlugin::getId).collect(Collectors.toSet());
 
-        final List<PluginDescriptor> pluginsToInstall = difference(pluginsThatShouldExist, pluginsThatActuallyExist);
-        final List<PluginDescriptor> pluginsToRemove = difference(pluginsThatActuallyExist, pluginsThatShouldExist);
+        final List<InstallablePlugin> pluginsToInstall = difference(pluginsThatShouldExist, pluginsThatActuallyExist);
+        final List<InstallablePlugin> pluginsToRemove = difference(pluginsThatActuallyExist, pluginsThatShouldExist);
 
         // Candidates for upgrade are any plugin that already exist and isn't about to be removed.
-        final List<PluginDescriptor> pluginsToMaybeUpgrade = difference(pluginsThatShouldExist, pluginsToRemove).stream()
+        final List<InstallablePlugin> pluginsToMaybeUpgrade = difference(pluginsThatShouldExist, pluginsToRemove).stream()
             .filter(each -> existingPluginIds.contains(each.getId()))
             .collect(Collectors.toList());
 
-        final List<PluginDescriptor> pluginsToUpgrade = getPluginsToUpgrade(pluginsToMaybeUpgrade, cachedPluginsConfig, existingPlugins);
+        final List<InstallablePlugin> pluginsToUpgrade = getPluginsToUpgrade(pluginsToMaybeUpgrade, cachedPluginsConfig, existingPlugins);
 
-        pluginsToRemove.sort(Comparator.comparing(PluginDescriptor::getId));
-        pluginsToInstall.sort(Comparator.comparing(PluginDescriptor::getId));
-        pluginsToMaybeUpgrade.sort(Comparator.comparing(PluginDescriptor::getId));
+        pluginsToRemove.sort(Comparator.comparing(InstallablePlugin::getId));
+        pluginsToInstall.sort(Comparator.comparing(InstallablePlugin::getId));
+        pluginsToMaybeUpgrade.sort(Comparator.comparing(InstallablePlugin::getId));
 
         return new PluginChanges(pluginsToRemove, pluginsToInstall, pluginsToUpgrade);
     }
@@ -153,12 +153,12 @@ public class SyncPluginsAction implements PluginsSynchronizer {
      * they are currently installed. However, this also means that we need to emit our own warning
      * that installation by plugin is deprecated.
      */
-    private List<PluginDescriptor> getPluginsThatShouldExist(PluginsConfig pluginsConfig) {
-        final List<PluginDescriptor> pluginsThatShouldExist = new ArrayList<>(pluginsConfig.getPlugins());
+    private List<InstallablePlugin> getPluginsThatShouldExist(PluginsConfig pluginsConfig) {
+        final List<InstallablePlugin> pluginsThatShouldExist = new ArrayList<>(pluginsConfig.getPlugins());
 
-        final Iterator<PluginDescriptor> shouldExistIterator = pluginsThatShouldExist.iterator();
+        final Iterator<InstallablePlugin> shouldExistIterator = pluginsThatShouldExist.iterator();
         while (shouldExistIterator.hasNext()) {
-            final PluginDescriptor each = shouldExistIterator.next();
+            final InstallablePlugin each = shouldExistIterator.next();
             if (InstallPluginAction.PLUGINS_CONVERTED_TO_MODULES.contains(each.getId())) {
                 terminal.errorPrintln(
                     "[" + each.getId() + "] is no longer a plugin but instead a module packaged with this distribution of Elasticsearch"
@@ -203,13 +203,13 @@ public class SyncPluginsAction implements PluginsSynchronizer {
         }
     }
 
-    private List<PluginDescriptor> getPluginsToUpgrade(
-        List<PluginDescriptor> pluginsToMaybeUpgrade,
+    private List<InstallablePlugin> getPluginsToUpgrade(
+        List<InstallablePlugin> pluginsToMaybeUpgrade,
         Optional<PluginsConfig> cachedPluginsConfig,
-        List<PluginInfo> existingPlugins
+        List<PluginDescriptor> existingPlugins
     ) {
         final Map<String, String> cachedPluginIdToLocation = cachedPluginsConfig.map(
-            config -> config.getPlugins().stream().collect(Collectors.toMap(PluginDescriptor::getId, PluginDescriptor::getLocation))
+            config -> config.getPlugins().stream().collect(Collectors.toMap(InstallablePlugin::getId, InstallablePlugin::getLocation))
         ).orElse(Map.of());
 
         return pluginsToMaybeUpgrade.stream().filter(eachPlugin -> {
@@ -234,7 +234,7 @@ public class SyncPluginsAction implements PluginsSynchronizer {
             if (InstallPluginAction.OFFICIAL_PLUGINS.contains(eachPluginId)) {
                 // Find the currently installed plugin and check whether the version is lower than
                 // the current node's version.
-                final PluginInfo info = existingPlugins.stream()
+                final PluginDescriptor info = existingPlugins.stream()
                     .filter(each -> each.getName().equals(eachPluginId))
                     .findFirst()
                     .orElseThrow(() -> {
@@ -264,8 +264,8 @@ public class SyncPluginsAction implements PluginsSynchronizer {
         }).collect(Collectors.toList());
     }
 
-    private List<PluginInfo> getExistingPlugins() throws PluginSyncException {
-        final List<PluginInfo> plugins = new ArrayList<>();
+    private List<PluginDescriptor> getExistingPlugins() throws PluginSyncException {
+        final List<PluginDescriptor> plugins = new ArrayList<>();
 
         try {
             try (DirectoryStream<Path> paths = Files.newDirectoryStream(env.pluginsFile())) {
@@ -275,7 +275,7 @@ public class SyncPluginsAction implements PluginsSynchronizer {
                         continue;
                     }
 
-                    PluginInfo info = PluginInfo.readFromProperties(env.pluginsFile().resolve(pluginPath));
+                    PluginDescriptor info = PluginDescriptor.readFromProperties(env.pluginsFile().resolve(pluginPath));
                     plugins.add(info);
 
                     // Check for a version mismatch, unless it's an official plugin since we can upgrade them.
@@ -303,13 +303,13 @@ public class SyncPluginsAction implements PluginsSynchronizer {
     /**
      * Returns a list of all elements in {@code left} that are not present in {@code right}.
      * <p>
-     * Comparisons are based solely using {@link PluginDescriptor#getId()}.
+     * Comparisons are based solely using {@link InstallablePlugin#getId()}.
      *
      * @param left the items that may be retained
      * @param right the items that may be removed
      * @return a list of the remaining elements
      */
-    private static List<PluginDescriptor> difference(List<PluginDescriptor> left, List<PluginDescriptor> right) {
+    private static List<InstallablePlugin> difference(List<InstallablePlugin> left, List<InstallablePlugin> right) {
         return left.stream().filter(eachDescriptor -> {
             final String id = eachDescriptor.getId();
             return right.stream().anyMatch(p -> p.getId().equals(id)) == false;
@@ -317,9 +317,9 @@ public class SyncPluginsAction implements PluginsSynchronizer {
     }
 
     private void logRequiredChanges(PluginChanges changes) {
-        final BiConsumer<String, List<PluginDescriptor>> printSummary = (action, plugins) -> {
+        final BiConsumer<String, List<InstallablePlugin>> printSummary = (action, plugins) -> {
             if (plugins.isEmpty() == false) {
-                List<String> pluginIds = plugins.stream().map(PluginDescriptor::getId).toList();
+                List<String> pluginIds = plugins.stream().map(InstallablePlugin::getId).toList();
                 this.terminal.errorPrintln(String.format(Locale.ROOT, "Plugins to be %s: %s", action, pluginIds));
             }
         };
@@ -331,11 +331,11 @@ public class SyncPluginsAction implements PluginsSynchronizer {
 
     // @VisibleForTesting
     static class PluginChanges {
-        final List<PluginDescriptor> remove;
-        final List<PluginDescriptor> install;
-        final List<PluginDescriptor> upgrade;
+        final List<InstallablePlugin> remove;
+        final List<InstallablePlugin> install;
+        final List<InstallablePlugin> upgrade;
 
-        PluginChanges(List<PluginDescriptor> remove, List<PluginDescriptor> install, List<PluginDescriptor> upgrade) {
+        PluginChanges(List<InstallablePlugin> remove, List<InstallablePlugin> install, List<InstallablePlugin> upgrade) {
             this.remove = Objects.requireNonNull(remove);
             this.install = Objects.requireNonNull(install);
             this.upgrade = Objects.requireNonNull(upgrade);

--- a/distribution/tools/plugin-cli/src/test/java/org/elasticsearch/plugins/cli/InstallLicensedPluginTests.java
+++ b/distribution/tools/plugin-cli/src/test/java/org/elasticsearch/plugins/cli/InstallLicensedPluginTests.java
@@ -13,7 +13,7 @@ import org.elasticsearch.Version;
 import org.elasticsearch.cli.ExitCodes;
 import org.elasticsearch.cli.MockTerminal;
 import org.elasticsearch.cli.UserException;
-import org.elasticsearch.plugins.PluginInfo;
+import org.elasticsearch.plugins.PluginDescriptor;
 import org.elasticsearch.plugins.PluginType;
 import org.elasticsearch.test.ESTestCase;
 
@@ -29,8 +29,8 @@ public class InstallLicensedPluginTests extends ESTestCase {
      */
     public void testUnlicensedPlugin() throws Exception {
         MockTerminal terminal = new MockTerminal();
-        PluginInfo pluginInfo = buildInfo(false);
-        InstallPluginAction.checkCanInstallationProceed(terminal, Build.Flavor.OSS, pluginInfo);
+        PluginDescriptor pluginDescriptor = buildInfo(false);
+        InstallPluginAction.checkCanInstallationProceed(terminal, Build.Flavor.OSS, pluginDescriptor);
     }
 
     /**
@@ -38,10 +38,10 @@ public class InstallLicensedPluginTests extends ESTestCase {
      */
     public void testInstallPluginActionOnOss() throws Exception {
         MockTerminal terminal = new MockTerminal();
-        PluginInfo pluginInfo = buildInfo(true);
+        PluginDescriptor pluginDescriptor = buildInfo(true);
         final UserException userException = expectThrows(
             UserException.class,
-            () -> InstallPluginAction.checkCanInstallationProceed(terminal, Build.Flavor.OSS, pluginInfo)
+            () -> InstallPluginAction.checkCanInstallationProceed(terminal, Build.Flavor.OSS, pluginDescriptor)
         );
 
         assertThat(userException.exitCode, equalTo(ExitCodes.NOPERM));
@@ -53,10 +53,10 @@ public class InstallLicensedPluginTests extends ESTestCase {
      */
     public void testInstallPluginActionOnUnknownDistribution() throws Exception {
         MockTerminal terminal = new MockTerminal();
-        PluginInfo pluginInfo = buildInfo(true);
+        PluginDescriptor pluginDescriptor = buildInfo(true);
         expectThrows(
             UserException.class,
-            () -> InstallPluginAction.checkCanInstallationProceed(terminal, Build.Flavor.UNKNOWN, pluginInfo)
+            () -> InstallPluginAction.checkCanInstallationProceed(terminal, Build.Flavor.UNKNOWN, pluginDescriptor)
         );
         assertThat(terminal.getErrorOutput(), containsString("ERROR: This is a licensed plugin"));
     }
@@ -66,12 +66,12 @@ public class InstallLicensedPluginTests extends ESTestCase {
      */
     public void testInstallPluginActionOnDefault() throws Exception {
         MockTerminal terminal = new MockTerminal();
-        PluginInfo pluginInfo = buildInfo(true);
-        InstallPluginAction.checkCanInstallationProceed(terminal, Build.Flavor.DEFAULT, pluginInfo);
+        PluginDescriptor pluginDescriptor = buildInfo(true);
+        InstallPluginAction.checkCanInstallationProceed(terminal, Build.Flavor.DEFAULT, pluginDescriptor);
     }
 
-    private PluginInfo buildInfo(boolean isLicensed) {
-        return new PluginInfo(
+    private PluginDescriptor buildInfo(boolean isLicensed) {
+        return new PluginDescriptor(
             "name",
             "description",
             "version",

--- a/distribution/tools/plugin-cli/src/test/java/org/elasticsearch/plugins/cli/InstallPluginActionTests.java
+++ b/distribution/tools/plugin-cli/src/test/java/org/elasticsearch/plugins/cli/InstallPluginActionTests.java
@@ -47,7 +47,7 @@ import org.elasticsearch.core.Tuple;
 import org.elasticsearch.env.Environment;
 import org.elasticsearch.env.TestEnvironment;
 import org.elasticsearch.plugins.Platforms;
-import org.elasticsearch.plugins.PluginInfo;
+import org.elasticsearch.plugins.PluginDescriptor;
 import org.elasticsearch.plugins.PluginTestUtil;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.PosixPermissionsResetter;
@@ -146,7 +146,7 @@ public class InstallPluginActionTests extends ESTestCase {
         env = createEnv(temp);
         skipJarHellAction = new InstallPluginAction(terminal, null, false) {
             @Override
-            void jarHellCheck(PluginInfo candidateInfo, Path candidate, Path pluginsDir, Path modulesDir) {
+            void jarHellCheck(PluginDescriptor candidateInfo, Path candidate, Path pluginsDir, Path modulesDir) {
                 // no jarhell check
             }
         };
@@ -236,7 +236,7 @@ public class InstallPluginActionTests extends ESTestCase {
     }
 
     /** creates a plugin .zip and returns the url for testing */
-    static PluginDescriptor createPluginZip(String name, Path structure, String... additionalProps) throws IOException {
+    static InstallablePlugin createPluginZip(String name, Path structure, String... additionalProps) throws IOException {
         return createPlugin(name, structure, additionalProps);
     }
 
@@ -274,29 +274,29 @@ public class InstallPluginActionTests extends ESTestCase {
         Files.write(pluginDir.resolve("plugin-security.policy"), securityPolicyContent.toString().getBytes(StandardCharsets.UTF_8));
     }
 
-    static PluginDescriptor createPlugin(String name, Path structure, String... additionalProps) throws IOException {
+    static InstallablePlugin createPlugin(String name, Path structure, String... additionalProps) throws IOException {
         writePlugin(name, structure, additionalProps);
-        return new PluginDescriptor(name, writeZip(structure, null).toUri().toURL().toString());
+        return new InstallablePlugin(name, writeZip(structure, null).toUri().toURL().toString());
     }
 
     void installPlugin(String id) throws Exception {
-        PluginDescriptor plugin = id == null ? null : new PluginDescriptor(id, id);
+        InstallablePlugin plugin = id == null ? null : new InstallablePlugin(id, id);
         installPlugin(plugin, env.v1(), skipJarHellAction);
     }
 
-    void installPlugin(PluginDescriptor plugin) throws Exception {
+    void installPlugin(InstallablePlugin plugin) throws Exception {
         installPlugin(plugin, env.v1(), skipJarHellAction);
     }
 
-    void installPlugins(final List<PluginDescriptor> plugins, final Path home) throws Exception {
+    void installPlugins(final List<InstallablePlugin> plugins, final Path home) throws Exception {
         installPlugins(plugins, home, skipJarHellAction);
     }
 
-    void installPlugin(PluginDescriptor plugin, Path home, InstallPluginAction action) throws Exception {
+    void installPlugin(InstallablePlugin plugin, Path home, InstallPluginAction action) throws Exception {
         installPlugins(plugin == null ? List.of() : List.of(plugin), home, action);
     }
 
-    void installPlugins(final List<PluginDescriptor> plugins, final Path home, final InstallPluginAction action) throws Exception {
+    void installPlugins(final List<InstallablePlugin> plugins, final Path home, final InstallPluginAction action) throws Exception {
         final Environment environment = TestEnvironment.newEnvironment(Settings.builder().put("path.home", home).build());
         action.setEnvironment(environment);
         action.execute(plugins);
@@ -405,7 +405,7 @@ public class InstallPluginActionTests extends ESTestCase {
     }
 
     public void testSomethingWorks() throws Exception {
-        PluginDescriptor pluginZip = createPluginZip("fake", pluginDir);
+        InstallablePlugin pluginZip = createPluginZip("fake", pluginDir);
         installPlugin(pluginZip);
         assertPlugin("fake", pluginDir, env.v2());
     }
@@ -447,11 +447,11 @@ public class InstallPluginActionTests extends ESTestCase {
             return null;
         }).when(spied).computeSignatureForDownloadedPlugin(any(InputStream.class), any(InputStream.class), any(PGPSignature.class));
 
-        installPlugin(new PluginDescriptor("analysis-icu", null), env.v1(), spied);
+        installPlugin(new InstallablePlugin("analysis-icu", null), env.v1(), spied);
         assertThat(terminal.getOutput(), containsString("The plugin installer is trying to verify the signature "));
 
         // Clean-up the exiting plugin, let's try to reinstall with 'fast' random numbers
-        final List<PluginDescriptor> plugins = List.of(new PluginDescriptor("analysis-icu", null));
+        final List<InstallablePlugin> plugins = List.of(new InstallablePlugin("analysis-icu", null));
         new RemovePluginAction(terminal, env.v2(), true).execute(plugins);
 
         // Make the timer wait practically indefinitely, probably an overkill, but avoid flaky tests.
@@ -464,27 +464,27 @@ public class InstallPluginActionTests extends ESTestCase {
 
         terminal.reset();
 
-        installPlugin(new PluginDescriptor("analysis-icu", null), env.v1(), spied);
+        installPlugin(new InstallablePlugin("analysis-icu", null), env.v1(), spied);
         assertThat(terminal.getOutput(), not(containsString("The plugin installer is trying to verify the signature ")));
     }
 
     public void testMultipleWorks() throws Exception {
-        PluginDescriptor fake1PluginZip = createPluginZip("fake1", pluginDir);
-        PluginDescriptor fake2PluginZip = createPluginZip("fake2", pluginDir);
+        InstallablePlugin fake1PluginZip = createPluginZip("fake1", pluginDir);
+        InstallablePlugin fake2PluginZip = createPluginZip("fake2", pluginDir);
         installPlugins(List.of(fake1PluginZip, fake2PluginZip), env.v1());
         assertPlugin("fake1", pluginDir, env.v2());
         assertPlugin("fake2", pluginDir, env.v2());
     }
 
     public void testDuplicateInstall() throws Exception {
-        PluginDescriptor pluginZip = createPluginZip("fake", pluginDir);
+        InstallablePlugin pluginZip = createPluginZip("fake", pluginDir);
         final UserException e = expectThrows(UserException.class, () -> installPlugins(List.of(pluginZip, pluginZip), env.v1()));
         assertThat(e.getMessage(), equalTo("duplicate plugin id [" + pluginZip.getId() + "]"));
     }
 
     public void testTransaction() throws Exception {
-        PluginDescriptor pluginZip = createPluginZip("fake", pluginDir);
-        PluginDescriptor nonexistentPluginZip = new PluginDescriptor(
+        InstallablePlugin pluginZip = createPluginZip("fake", pluginDir);
+        InstallablePlugin nonexistentPluginZip = new InstallablePlugin(
             pluginZip.getId() + "-does-not-exist",
             pluginZip.getLocation() + "-does-not-exist"
         );
@@ -500,7 +500,7 @@ public class InstallPluginActionTests extends ESTestCase {
     }
 
     public void testInstallFailsIfPreviouslyRemovedPluginFailed() throws Exception {
-        PluginDescriptor pluginZip = createPluginZip("fake", pluginDir);
+        InstallablePlugin pluginZip = createPluginZip("fake", pluginDir);
         final Path removing = env.v2().pluginsFile().resolve(".removing-failed");
         Files.createDirectory(removing);
         final IllegalStateException e = expectThrows(IllegalStateException.class, () -> installPlugin(pluginZip));
@@ -513,19 +513,19 @@ public class InstallPluginActionTests extends ESTestCase {
     }
 
     public void testSpaceInUrl() throws Exception {
-        PluginDescriptor pluginZip = createPluginZip("fake", pluginDir);
+        InstallablePlugin pluginZip = createPluginZip("fake", pluginDir);
         Path pluginZipWithSpaces = createTempFile("foo bar", ".zip");
         try (InputStream in = FileSystemUtils.openFileURLStream(new URL(pluginZip.getLocation()))) {
             Files.copy(in, pluginZipWithSpaces, StandardCopyOption.REPLACE_EXISTING);
         }
-        PluginDescriptor modifiedPlugin = new PluginDescriptor("fake", pluginZipWithSpaces.toUri().toURL().toString());
+        InstallablePlugin modifiedPlugin = new InstallablePlugin("fake", pluginZipWithSpaces.toUri().toURL().toString());
         installPlugin(modifiedPlugin);
         assertPlugin("fake", pluginDir, env.v2());
     }
 
     public void testMalformedUrlNotMaven() {
         // has two colons, so it appears similar to maven coordinates
-        PluginDescriptor plugin = new PluginDescriptor("fake", "://host:1234");
+        InstallablePlugin plugin = new InstallablePlugin("fake", "://host:1234");
         MalformedURLException e = expectThrows(MalformedURLException.class, () -> installPlugin(plugin));
         assertThat(e.getMessage(), containsString("no protocol"));
     }
@@ -550,7 +550,7 @@ public class InstallPluginActionTests extends ESTestCase {
         assumeTrue("posix and filesystem", isPosix && isReal);
         try (PosixPermissionsResetter pluginsAttrs = new PosixPermissionsResetter(env.v2().pluginsFile())) {
             pluginsAttrs.setPermissions(new HashSet<>());
-            PluginDescriptor pluginZip = createPluginZip("fake", pluginDir);
+            InstallablePlugin pluginZip = createPluginZip("fake", pluginDir);
             IOException e = expectThrows(IOException.class, () -> installPlugin(pluginZip));
             assertThat(e.getMessage(), containsString(env.v2().pluginsFile().toString()));
         }
@@ -558,14 +558,14 @@ public class InstallPluginActionTests extends ESTestCase {
     }
 
     public void testBuiltinModule() throws Exception {
-        PluginDescriptor pluginZip = createPluginZip("lang-painless", pluginDir);
+        InstallablePlugin pluginZip = createPluginZip("lang-painless", pluginDir);
         UserException e = expectThrows(UserException.class, () -> installPlugin(pluginZip));
         assertThat(e.getMessage(), containsString("is a system module"));
         assertInstallCleaned(env.v2());
     }
 
     public void testBuiltinXpackModule() throws Exception {
-        PluginDescriptor pluginZip = createPluginZip("x-pack", pluginDir);
+        InstallablePlugin pluginZip = createPluginZip("x-pack", pluginDir);
         // There is separate handling for installing "x-pack", versus installing a plugin
         // whose descriptor contains the name "x-pack".
         pluginZip.setId("not-x-pack");
@@ -579,7 +579,7 @@ public class InstallPluginActionTests extends ESTestCase {
         assumeTrue("real filesystem", isReal);
         Path pluginDirectory = createPluginDir(temp);
         writeJar(pluginDirectory.resolve("other.jar"), "FakePlugin");
-        PluginDescriptor pluginZip = createPluginZip("fake", pluginDirectory); // adds plugin.jar with FakePlugin
+        InstallablePlugin pluginZip = createPluginZip("fake", pluginDirectory); // adds plugin.jar with FakePlugin
         IllegalStateException e = expectThrows(IllegalStateException.class, () -> installPlugin(pluginZip, env.v1(), defaultAction));
         assertThat(e.getMessage(), containsString("jar hell"));
         assertInstallCleaned(env.v2());
@@ -588,17 +588,17 @@ public class InstallPluginActionTests extends ESTestCase {
     public void testIsolatedPlugins() throws Exception {
         // these both share the same FakePlugin class
         Path pluginDir1 = createPluginDir(temp);
-        PluginDescriptor pluginZip1 = createPluginZip("fake1", pluginDir1);
+        InstallablePlugin pluginZip1 = createPluginZip("fake1", pluginDir1);
         installPlugin(pluginZip1);
         Path pluginDir2 = createPluginDir(temp);
-        PluginDescriptor pluginZip2 = createPluginZip("fake2", pluginDir2);
+        InstallablePlugin pluginZip2 = createPluginZip("fake2", pluginDir2);
         installPlugin(pluginZip2);
         assertPlugin("fake1", pluginDir1, env.v2());
         assertPlugin("fake2", pluginDir2, env.v2());
     }
 
     public void testExistingPlugin() throws Exception {
-        PluginDescriptor pluginZip = createPluginZip("fake", pluginDir);
+        InstallablePlugin pluginZip = createPluginZip("fake", pluginDir);
         installPlugin(pluginZip);
         UserException e = expectThrows(UserException.class, () -> installPlugin(pluginZip));
         assertThat(e.getMessage(), containsString("already exists"));
@@ -609,7 +609,7 @@ public class InstallPluginActionTests extends ESTestCase {
         Path binDir = pluginDir.resolve("bin");
         Files.createDirectory(binDir);
         Files.createFile(binDir.resolve("somescript"));
-        PluginDescriptor pluginZip = createPluginZip("fake", pluginDir);
+        InstallablePlugin pluginZip = createPluginZip("fake", pluginDir);
         installPlugin(pluginZip);
         assertPlugin("fake", pluginDir, env.v2());
     }
@@ -617,7 +617,7 @@ public class InstallPluginActionTests extends ESTestCase {
     public void testBinNotDir() throws Exception {
         Path binDir = pluginDir.resolve("bin");
         Files.createFile(binDir);
-        PluginDescriptor pluginZip = createPluginZip("fake", pluginDir);
+        InstallablePlugin pluginZip = createPluginZip("fake", pluginDir);
         UserException e = expectThrows(UserException.class, () -> installPlugin(pluginZip));
         assertThat(e.getMessage(), containsString("not a directory"));
         assertInstallCleaned(env.v2());
@@ -627,7 +627,7 @@ public class InstallPluginActionTests extends ESTestCase {
         Path dirInBinDir = pluginDir.resolve("bin").resolve("foo");
         Files.createDirectories(dirInBinDir);
         Files.createFile(dirInBinDir.resolve("somescript"));
-        PluginDescriptor pluginZip = createPluginZip("fake", pluginDir);
+        InstallablePlugin pluginZip = createPluginZip("fake", pluginDir);
         UserException e = expectThrows(UserException.class, () -> installPlugin(pluginZip));
         assertThat(e.getMessage(), containsString("Directories not allowed in bin dir for plugin"));
         assertInstallCleaned(env.v2());
@@ -637,7 +637,7 @@ public class InstallPluginActionTests extends ESTestCase {
         Path binDir = pluginDir.resolve("bin");
         Files.createDirectory(binDir);
         Files.createFile(binDir.resolve("somescript"));
-        PluginDescriptor pluginZip = createPluginZip("elasticsearch", pluginDir);
+        InstallablePlugin pluginZip = createPluginZip("elasticsearch", pluginDir);
         FileAlreadyExistsException e = expectThrows(FileAlreadyExistsException.class, () -> installPlugin(pluginZip));
         assertThat(e.getMessage(), containsString(env.v2().binFile().resolve("elasticsearch").toString()));
         assertInstallCleaned(env.v2());
@@ -648,7 +648,7 @@ public class InstallPluginActionTests extends ESTestCase {
         Path binDir = pluginDir.resolve("bin");
         Files.createDirectory(binDir);
         Files.createFile(binDir.resolve("somescript"));
-        PluginDescriptor pluginZip = createPluginZip("fake", pluginDir);
+        InstallablePlugin pluginZip = createPluginZip("fake", pluginDir);
         try (PosixPermissionsResetter binAttrs = new PosixPermissionsResetter(env.v2().binFile())) {
             Set<PosixFilePermission> perms = binAttrs.getCopyPermissions();
             // make sure at least one execute perm is missing, so we know we forced it during installation
@@ -674,7 +674,7 @@ public class InstallPluginActionTests extends ESTestCase {
         Files.createDirectory(resourcesDir);
         Files.createFile(resourcesDir.resolve("resource"));
 
-        final PluginDescriptor pluginZip = createPluginZip("fake", tempPluginDir);
+        final InstallablePlugin pluginZip = createPluginZip("fake", tempPluginDir);
 
         installPlugin(pluginZip);
         assertPlugin("fake", tempPluginDir, env.v2());
@@ -723,7 +723,7 @@ public class InstallPluginActionTests extends ESTestCase {
         Path configDir = pluginDir.resolve("config");
         Files.createDirectory(configDir);
         Files.createFile(configDir.resolve("custom.yml"));
-        PluginDescriptor pluginZip = createPluginZip("fake", pluginDir);
+        InstallablePlugin pluginZip = createPluginZip("fake", pluginDir);
         installPlugin(pluginZip);
         assertPlugin("fake", pluginDir, env.v2());
     }
@@ -736,7 +736,7 @@ public class InstallPluginActionTests extends ESTestCase {
         Files.createDirectory(configDir);
         Files.write(configDir.resolve("custom.yml"), "new config".getBytes(StandardCharsets.UTF_8));
         Files.createFile(configDir.resolve("other.yml"));
-        PluginDescriptor pluginZip = createPluginZip("fake", pluginDir);
+        InstallablePlugin pluginZip = createPluginZip("fake", pluginDir);
         installPlugin(pluginZip);
         assertPlugin("fake", pluginDir, env.v2());
         List<String> configLines = Files.readAllLines(envConfigDir.resolve("custom.yml"), StandardCharsets.UTF_8);
@@ -749,7 +749,7 @@ public class InstallPluginActionTests extends ESTestCase {
         Files.createDirectories(pluginDir);
         Path configDir = pluginDir.resolve("config");
         Files.createFile(configDir);
-        PluginDescriptor pluginZip = createPluginZip("fake", pluginDir);
+        InstallablePlugin pluginZip = createPluginZip("fake", pluginDir);
         UserException e = expectThrows(UserException.class, () -> installPlugin(pluginZip));
         assertThat(e.getMessage(), containsString("not a directory"));
         assertInstallCleaned(env.v2());
@@ -759,7 +759,7 @@ public class InstallPluginActionTests extends ESTestCase {
         Path dirInConfigDir = pluginDir.resolve("config").resolve("foo");
         Files.createDirectories(dirInConfigDir);
         Files.createFile(dirInConfigDir.resolve("myconfig.yml"));
-        PluginDescriptor pluginZip = createPluginZip("fake", pluginDir);
+        InstallablePlugin pluginZip = createPluginZip("fake", pluginDir);
         UserException e = expectThrows(UserException.class, () -> installPlugin(pluginZip));
         assertThat(e.getMessage(), containsString("Directories not allowed in config dir for plugin"));
         assertInstallCleaned(env.v2());
@@ -774,7 +774,7 @@ public class InstallPluginActionTests extends ESTestCase {
     }
 
     public void testContainsIntermediateDirectory() throws Exception {
-        Files.createFile(pluginDir.resolve(PluginInfo.ES_PLUGIN_PROPERTIES));
+        Files.createFile(pluginDir.resolve(PluginDescriptor.ES_PLUGIN_PROPERTIES));
         String pluginZip = writeZip(pluginDir, "elasticsearch").toUri().toURL().toString();
         UserException e = expectThrows(UserException.class, () -> installPlugin(pluginZip));
         assertThat(e.getMessage(), containsString("This plugin was built with an older plugin structure"));
@@ -837,7 +837,7 @@ public class InstallPluginActionTests extends ESTestCase {
                 return flavor;
             }
         };
-        final T exception = expectThrows(clazz, () -> flavorAction.execute(List.of(new PluginDescriptor("x-pack"))));
+        final T exception = expectThrows(clazz, () -> flavorAction.execute(List.of(new InstallablePlugin("x-pack"))));
         assertThat(exception.getMessage(), containsString(expectedMessage));
     }
 
@@ -873,7 +873,7 @@ public class InstallPluginActionTests extends ESTestCase {
     }
 
     public void testPluginAlreadyInstalled() throws Exception {
-        PluginDescriptor pluginZip = createPluginZip("fake", pluginDir);
+        InstallablePlugin pluginZip = createPluginZip("fake", pluginDir);
         installPlugin(pluginZip);
         final UserException e = expectThrows(
             UserException.class,
@@ -895,8 +895,8 @@ public class InstallPluginActionTests extends ESTestCase {
      * the ID actually is from the plugin's properties, then the installation fails.
      */
     public void testPluginHasDifferentNameThatDescriptor() throws Exception {
-        PluginDescriptor descriptor = createPluginZip("fake", pluginDir);
-        PluginDescriptor modifiedDescriptor = new PluginDescriptor("other-fake", descriptor.getLocation());
+        InstallablePlugin descriptor = createPluginZip("fake", pluginDir);
+        InstallablePlugin modifiedDescriptor = new InstallablePlugin("other-fake", descriptor.getLocation());
 
         final UserException e = expectThrows(UserException.class, () -> installPlugin(modifiedDescriptor));
         assertThat(e.getMessage(), equalTo("Expected downloaded plugin to have ID [other-fake] but found [fake]"));
@@ -907,7 +907,7 @@ public class InstallPluginActionTests extends ESTestCase {
         if (isBatch) {
             writePluginSecurityPolicy(pluginDir, "setFactory");
         }
-        PluginDescriptor pluginZip = createPlugin("fake", pluginDir, additionalProperties);
+        InstallablePlugin pluginZip = createPlugin("fake", pluginDir, additionalProperties);
         skipJarHellAction.setEnvironment(env.v2());
         skipJarHellAction.setBatch(isBatch);
         skipJarHellAction.execute(List.of(pluginZip));
@@ -960,7 +960,7 @@ public class InstallPluginActionTests extends ESTestCase {
             secretKey,
             signature
         );
-        installPlugin(new PluginDescriptor(pluginId, pluginUrl), env.v1(), action);
+        installPlugin(new InstallablePlugin(pluginId, pluginUrl), env.v1(), action);
         assertPlugin(pluginId, pluginDir, env.v2());
     }
 
@@ -975,7 +975,7 @@ public class InstallPluginActionTests extends ESTestCase {
         final PGPSecretKey secretKey,
         final BiFunction<byte[], PGPSecretKey, String> signature
     ) throws Exception {
-        PluginDescriptor pluginZip = createPlugin(pluginId, pluginDir);
+        InstallablePlugin pluginZip = createPlugin(pluginId, pluginDir);
         Path pluginZipPath = Path.of(URI.create(pluginZip.getLocation()));
         InstallPluginAction action = new InstallPluginAction(terminal, env.v2(), false) {
             @Override
@@ -1053,7 +1053,7 @@ public class InstallPluginActionTests extends ESTestCase {
             }
 
             @Override
-            void jarHellCheck(PluginInfo candidateInfo, Path candidate, Path pluginsDir, Path modulesDir) {
+            void jarHellCheck(PluginDescriptor candidateInfo, Path candidate, Path pluginsDir, Path modulesDir) {
                 // no jarhell check
             }
         };
@@ -1448,7 +1448,7 @@ public class InstallPluginActionTests extends ESTestCase {
 
     // checks the plugin requires a policy confirmation, and does not install when that is rejected by the user
     // the plugin is installed after this method completes
-    private void assertPolicyConfirmation(Tuple<Path, Environment> pathEnvironmentTuple, PluginDescriptor pluginZip, String... warnings)
+    private void assertPolicyConfirmation(Tuple<Path, Environment> pathEnvironmentTuple, InstallablePlugin pluginZip, String... warnings)
         throws Exception {
         for (int i = 0; i < warnings.length; ++i) {
             String warning = warnings[i];
@@ -1492,14 +1492,14 @@ public class InstallPluginActionTests extends ESTestCase {
 
     public void testPolicyConfirmation() throws Exception {
         writePluginSecurityPolicy(pluginDir, "getClassLoader", "setFactory");
-        PluginDescriptor pluginZip = createPluginZip("fake", pluginDir);
+        InstallablePlugin pluginZip = createPluginZip("fake", pluginDir);
 
         assertPolicyConfirmation(env, pluginZip, "plugin requires additional permissions");
         assertPlugin("fake", pluginDir, env.v2());
     }
 
     public void testPluginWithNativeController() throws Exception {
-        PluginDescriptor pluginZip = createPluginZip("fake", pluginDir, "has.native.controller", "true");
+        InstallablePlugin pluginZip = createPluginZip("fake", pluginDir, "has.native.controller", "true");
 
         final IllegalStateException e = expectThrows(IllegalStateException.class, () -> installPlugin(pluginZip));
         assertThat(e.getMessage(), containsString("plugins can not have native controllers"));
@@ -1508,7 +1508,7 @@ public class InstallPluginActionTests extends ESTestCase {
     public void testMultipleJars() throws Exception {
         writeJar(pluginDir.resolve("dep1.jar"), "Dep1");
         writeJar(pluginDir.resolve("dep2.jar"), "Dep2");
-        PluginDescriptor pluginZip = createPluginZip("fake-with-deps", pluginDir);
+        InstallablePlugin pluginZip = createPluginZip("fake-with-deps", pluginDir);
         installPlugin(pluginZip);
         assertPlugin("fake-with-deps", pluginDir, env.v2());
     }

--- a/distribution/tools/plugin-cli/src/test/java/org/elasticsearch/plugins/cli/ListPluginsCommandTests.java
+++ b/distribution/tools/plugin-cli/src/test/java/org/elasticsearch/plugins/cli/ListPluginsCommandTests.java
@@ -16,7 +16,7 @@ import org.elasticsearch.cli.UserException;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.env.Environment;
 import org.elasticsearch.env.TestEnvironment;
-import org.elasticsearch.plugins.PluginInfo;
+import org.elasticsearch.plugins.PluginDescriptor;
 import org.elasticsearch.plugins.PluginTestUtil;
 import org.elasticsearch.test.ESTestCase;
 import org.junit.Before;
@@ -227,14 +227,14 @@ public class ListPluginsCommandTests extends ESTestCase {
         final Path pluginDir = env.pluginsFile().resolve("fake1");
         Files.createDirectories(pluginDir);
         NoSuchFileException e = expectThrows(NoSuchFileException.class, () -> listPlugins(home));
-        assertEquals(pluginDir.resolve(PluginInfo.ES_PLUGIN_PROPERTIES).toString(), e.getFile());
+        assertEquals(pluginDir.resolve(PluginDescriptor.ES_PLUGIN_PROPERTIES).toString(), e.getFile());
     }
 
     public void testPluginWithWrongDescriptorFile() throws Exception {
         final Path pluginDir = env.pluginsFile().resolve("fake1");
         PluginTestUtil.writePluginProperties(pluginDir, "description", "fake desc");
         IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> listPlugins(home));
-        final Path descriptorPath = pluginDir.resolve(PluginInfo.ES_PLUGIN_PROPERTIES);
+        final Path descriptorPath = pluginDir.resolve(PluginDescriptor.ES_PLUGIN_PROPERTIES);
         assertEquals("property [name] is missing in [" + descriptorPath.toString() + "]", e.getMessage());
     }
 

--- a/distribution/tools/plugin-cli/src/test/java/org/elasticsearch/plugins/cli/PluginsConfigTests.java
+++ b/distribution/tools/plugin-cli/src/test/java/org/elasticsearch/plugins/cli/PluginsConfigTests.java
@@ -32,7 +32,7 @@ public class PluginsConfigTests extends ESTestCase {
      */
     public void test_validate_rejectsNullDescriptor() {
         PluginsConfig config = new PluginsConfig();
-        List<PluginDescriptor> descriptors = new ArrayList<>();
+        List<InstallablePlugin> descriptors = new ArrayList<>();
         descriptors.add(null);
         config.setPlugins(descriptors);
         final Exception e = expectThrows(RuntimeException.class, () -> config.validate(Set.of(), Set.of()));
@@ -44,7 +44,7 @@ public class PluginsConfigTests extends ESTestCase {
      */
     public void test_validate_rejectsDescriptorWithNullId() {
         PluginsConfig config = new PluginsConfig();
-        config.setPlugins(List.of(new PluginDescriptor()));
+        config.setPlugins(List.of(new InstallablePlugin()));
         final Exception e = expectThrows(RuntimeException.class, () -> config.validate(Set.of(), Set.of()));
         assertThat(e.getMessage(), equalTo("Cannot have null or empty IDs in [elasticsearch-plugins.yml]"));
     }
@@ -54,7 +54,7 @@ public class PluginsConfigTests extends ESTestCase {
      */
     public void test_validate_rejectsDuplicatePluginId() {
         PluginsConfig config = new PluginsConfig();
-        config.setPlugins(List.of(new PluginDescriptor("foo"), new PluginDescriptor("foo")));
+        config.setPlugins(List.of(new InstallablePlugin("foo"), new InstallablePlugin("foo")));
         final Exception e = expectThrows(PluginSyncException.class, () -> config.validate(Set.of(), Set.of()));
         assertThat(e.getMessage(), equalTo("Duplicate plugin ID [foo] found in [elasticsearch-plugins.yml]"));
     }
@@ -64,7 +64,7 @@ public class PluginsConfigTests extends ESTestCase {
      */
     public void test_validate_rejectsUnofficialPluginWithoutLocation() {
         PluginsConfig config = new PluginsConfig();
-        config.setPlugins(List.of(new PluginDescriptor("foo")));
+        config.setPlugins(List.of(new InstallablePlugin("foo")));
         final Exception e = expectThrows(PluginSyncException.class, () -> config.validate(Set.of(), Set.of()));
         assertThat(e.getMessage(), equalTo("Must specify location for non-official plugin [foo] in [elasticsearch-plugins.yml]"));
     }
@@ -74,7 +74,7 @@ public class PluginsConfigTests extends ESTestCase {
      */
     public void test_validate_rejectsUnofficialPluginWithBlankLocation() {
         PluginsConfig config = new PluginsConfig();
-        config.setPlugins(List.of(new PluginDescriptor("foo", "   ")));
+        config.setPlugins(List.of(new InstallablePlugin("foo", "   ")));
         final Exception e = expectThrows(PluginSyncException.class, () -> config.validate(Set.of(), Set.of()));
         assertThat(e.getMessage(), equalTo("Empty location for plugin [foo]"));
     }
@@ -98,7 +98,7 @@ public class PluginsConfigTests extends ESTestCase {
      */
     public void test_validate_allowsOfficialPlugin() throws PluginSyncException {
         PluginsConfig config = new PluginsConfig();
-        config.setPlugins(List.of(new PluginDescriptor("analysis-icu")));
+        config.setPlugins(List.of(new InstallablePlugin("analysis-icu")));
         config.validate(Set.of("analysis-icu"), Set.of());
     }
 
@@ -107,8 +107,8 @@ public class PluginsConfigTests extends ESTestCase {
      * no longer being plugins.
      */
     public void test_validate_allowsMigratedPlugin() throws PluginSyncException {
-        final List<PluginDescriptor> descriptors = Stream.of("azure", "gcs", "s3")
-            .map(each -> new PluginDescriptor("repository-" + each))
+        final List<InstallablePlugin> descriptors = Stream.of("azure", "gcs", "s3")
+            .map(each -> new InstallablePlugin("repository-" + each))
             .toList();
         PluginsConfig config = new PluginsConfig();
         config.setPlugins(descriptors);

--- a/distribution/tools/plugin-cli/src/test/java/org/elasticsearch/plugins/cli/RemovePluginActionTests.java
+++ b/distribution/tools/plugin-cli/src/test/java/org/elasticsearch/plugins/cli/RemovePluginActionTests.java
@@ -88,9 +88,9 @@ public class RemovePluginActionTests extends ESTestCase {
     static MockTerminal removePlugin(List<String> pluginIds, Path home, boolean purge) throws Exception {
         Environment env = TestEnvironment.newEnvironment(Settings.builder().put("path.home", home).build());
         MockTerminal terminal = new MockTerminal();
-        final List<PluginDescriptor> plugins = pluginIds == null
+        final List<InstallablePlugin> plugins = pluginIds == null
             ? null
-            : pluginIds.stream().map(PluginDescriptor::new).collect(Collectors.toList());
+            : pluginIds.stream().map(InstallablePlugin::new).collect(Collectors.toList());
         new RemovePluginAction(terminal, env, purge).execute(plugins);
         return terminal;
     }

--- a/distribution/tools/plugin-cli/src/test/java/org/elasticsearch/plugins/cli/SyncPluginsActionTests.java
+++ b/distribution/tools/plugin-cli/src/test/java/org/elasticsearch/plugins/cli/SyncPluginsActionTests.java
@@ -112,7 +112,7 @@ public class SyncPluginsActionTests extends ESTestCase {
      * calculate that the plugin needs to be installed.
      */
     public void test_getPluginChanges_withPluginToInstall_returnsPluginToInstall() throws Exception {
-        config.setPlugins(List.of(new PluginDescriptor("my-plugin")));
+        config.setPlugins(List.of(new InstallablePlugin("my-plugin")));
 
         final PluginChanges pluginChanges = action.getPluginChanges(config, Optional.empty());
 
@@ -130,7 +130,7 @@ public class SyncPluginsActionTests extends ESTestCase {
      */
     public void test_getPluginChanges_withPluginToUpgrade_returnsNoChanges() throws Exception {
         createPlugin("my-plugin", Version.CURRENT.previousMajor());
-        config.setPlugins(List.of(new PluginDescriptor("my-plugin")));
+        config.setPlugins(List.of(new InstallablePlugin("my-plugin")));
 
         final PluginChanges pluginChanges = action.getPluginChanges(config, Optional.empty());
 
@@ -143,7 +143,7 @@ public class SyncPluginsActionTests extends ESTestCase {
      */
     public void test_getPluginChanges_withOfficialPluginToUpgrade_returnsPluginToUpgrade() throws Exception {
         createPlugin("analysis-icu", Version.CURRENT.previousMajor());
-        config.setPlugins(List.of(new PluginDescriptor("analysis-icu")));
+        config.setPlugins(List.of(new InstallablePlugin("analysis-icu")));
 
         final PluginChanges pluginChanges = action.getPluginChanges(config, Optional.empty());
 
@@ -160,10 +160,10 @@ public class SyncPluginsActionTests extends ESTestCase {
      */
     public void test_getPluginChanges_withCachedConfigAndNoChanges_returnsNoChanges() throws Exception {
         createPlugin("my-plugin");
-        config.setPlugins(List.of(new PluginDescriptor("my-plugin", "file://plugin.zip")));
+        config.setPlugins(List.of(new InstallablePlugin("my-plugin", "file://plugin.zip")));
 
         final PluginsConfig cachedConfig = new PluginsConfig();
-        cachedConfig.setPlugins(List.of(new PluginDescriptor("my-plugin", "file://plugin.zip")));
+        cachedConfig.setPlugins(List.of(new InstallablePlugin("my-plugin", "file://plugin.zip")));
 
         final PluginChanges pluginChanges = action.getPluginChanges(config, Optional.of(cachedConfig));
 
@@ -176,10 +176,10 @@ public class SyncPluginsActionTests extends ESTestCase {
      */
     public void test_getPluginChanges_withCachedConfigAndChangedLocation_returnsPluginToUpgrade() throws Exception {
         createPlugin("my-plugin");
-        config.setPlugins(List.of(new PluginDescriptor("my-plugin", "file:///after.zip")));
+        config.setPlugins(List.of(new InstallablePlugin("my-plugin", "file:///after.zip")));
 
         final PluginsConfig cachedConfig = new PluginsConfig();
-        cachedConfig.setPlugins(List.of(new PluginDescriptor("my-plugin", "file://before.zip")));
+        cachedConfig.setPlugins(List.of(new InstallablePlugin("my-plugin", "file://before.zip")));
 
         final PluginChanges pluginChanges = action.getPluginChanges(config, Optional.of(cachedConfig));
 
@@ -196,7 +196,11 @@ public class SyncPluginsActionTests extends ESTestCase {
      */
     public void test_getPluginChanges_withModularisedPluginsToInstall_ignoresPlugins() throws Exception {
         config.setPlugins(
-            List.of(new PluginDescriptor("repository-azure"), new PluginDescriptor("repository-gcs"), new PluginDescriptor("repository-s3"))
+            List.of(
+                new InstallablePlugin("repository-azure"),
+                new InstallablePlugin("repository-gcs"),
+                new InstallablePlugin("repository-s3")
+            )
         );
 
         final PluginChanges pluginChanges = action.getPluginChanges(config, Optional.empty());
@@ -221,7 +225,11 @@ public class SyncPluginsActionTests extends ESTestCase {
         createPlugin("repository-gcs");
         createPlugin("repository-s3");
         config.setPlugins(
-            List.of(new PluginDescriptor("repository-azure"), new PluginDescriptor("repository-gcs"), new PluginDescriptor("repository-s3"))
+            List.of(
+                new InstallablePlugin("repository-azure"),
+                new InstallablePlugin("repository-gcs"),
+                new InstallablePlugin("repository-s3")
+            )
         );
 
         final PluginChanges pluginChanges = action.getPluginChanges(config, Optional.empty());
@@ -256,13 +264,13 @@ public class SyncPluginsActionTests extends ESTestCase {
     public void test_performSync_withPluginsToRemove_callsRemoveAction() throws Exception {
         final InstallPluginAction installAction = mock(InstallPluginAction.class);
         final RemovePluginAction removeAction = mock(RemovePluginAction.class);
-        final List<PluginDescriptor> pluginDescriptors = List.of(new PluginDescriptor("plugin1"), new PluginDescriptor("plugin2"));
+        final List<InstallablePlugin> installablePlugins = List.of(new InstallablePlugin("plugin1"), new InstallablePlugin("plugin2"));
 
-        action.performSync(installAction, removeAction, new PluginChanges(pluginDescriptors, List.of(), List.of()));
+        action.performSync(installAction, removeAction, new PluginChanges(installablePlugins, List.of(), List.of()));
 
         verify(installAction, never()).execute(anyList());
         verify(removeAction).setPurge(true);
-        verify(removeAction).execute(pluginDescriptors);
+        verify(removeAction).execute(installablePlugins);
     }
 
     /**
@@ -271,11 +279,11 @@ public class SyncPluginsActionTests extends ESTestCase {
     public void test_performSync_withPluginsToInstall_callsInstallAction() throws Exception {
         final InstallPluginAction installAction = mock(InstallPluginAction.class);
         final RemovePluginAction removeAction = mock(RemovePluginAction.class);
-        final List<PluginDescriptor> pluginDescriptors = List.of(new PluginDescriptor("plugin1"), new PluginDescriptor("plugin2"));
+        final List<InstallablePlugin> installablePlugins = List.of(new InstallablePlugin("plugin1"), new InstallablePlugin("plugin2"));
 
-        action.performSync(installAction, removeAction, new PluginChanges(List.of(), pluginDescriptors, List.of()));
+        action.performSync(installAction, removeAction, new PluginChanges(List.of(), installablePlugins, List.of()));
 
-        verify(installAction).execute(pluginDescriptors);
+        verify(installAction).execute(installablePlugins);
         verify(removeAction, never()).execute(anyList());
     }
 
@@ -287,13 +295,13 @@ public class SyncPluginsActionTests extends ESTestCase {
         final RemovePluginAction removeAction = mock(RemovePluginAction.class);
         final InOrder inOrder = Mockito.inOrder(removeAction, installAction);
 
-        final List<PluginDescriptor> pluginDescriptors = List.of(new PluginDescriptor("plugin1"), new PluginDescriptor("plugin2"));
+        final List<InstallablePlugin> installablePlugins = List.of(new InstallablePlugin("plugin1"), new InstallablePlugin("plugin2"));
 
-        action.performSync(installAction, removeAction, new PluginChanges(List.of(), List.of(), pluginDescriptors));
+        action.performSync(installAction, removeAction, new PluginChanges(List.of(), List.of(), installablePlugins));
 
         inOrder.verify(removeAction).setPurge(false);
-        inOrder.verify(removeAction).execute(pluginDescriptors);
-        inOrder.verify(installAction).execute(pluginDescriptors);
+        inOrder.verify(removeAction).execute(installablePlugins);
+        inOrder.verify(installAction).execute(installablePlugins);
     }
 
     /**
@@ -304,9 +312,9 @@ public class SyncPluginsActionTests extends ESTestCase {
         final RemovePluginAction removeAction = mock(RemovePluginAction.class);
         final InOrder inOrder = Mockito.inOrder(removeAction, installAction);
 
-        final List<PluginDescriptor> pluginsToRemove = List.of(new PluginDescriptor("plugin1"));
-        final List<PluginDescriptor> pluginsToInstall = List.of(new PluginDescriptor("plugin2"));
-        final List<PluginDescriptor> pluginsToUpgrade = List.of(new PluginDescriptor("plugin3"));
+        final List<InstallablePlugin> pluginsToRemove = List.of(new InstallablePlugin("plugin1"));
+        final List<InstallablePlugin> pluginsToInstall = List.of(new InstallablePlugin("plugin2"));
+        final List<InstallablePlugin> pluginsToUpgrade = List.of(new InstallablePlugin("plugin3"));
 
         action.performSync(installAction, removeAction, new PluginChanges(pluginsToRemove, pluginsToInstall, pluginsToUpgrade));
 

--- a/qa/evil-tests/src/test/java/org/elasticsearch/bootstrap/PolicyUtilTests.java
+++ b/qa/evil-tests/src/test/java/org/elasticsearch/bootstrap/PolicyUtilTests.java
@@ -9,7 +9,7 @@
 package org.elasticsearch.bootstrap;
 
 import org.elasticsearch.core.SuppressForbidden;
-import org.elasticsearch.plugins.PluginInfo;
+import org.elasticsearch.plugins.PluginDescriptor;
 import org.elasticsearch.test.ESTestCase;
 import org.junit.Before;
 
@@ -52,7 +52,7 @@ public class PolicyUtilTests extends ESTestCase {
 
     Path makeDummyPlugin(String policy, String... files) throws IOException {
         Path plugin = createTempDir();
-        Files.copy(this.getDataPath(policy), plugin.resolve(PluginInfo.ES_PLUGIN_POLICY));
+        Files.copy(this.getDataPath(policy), plugin.resolve(PluginDescriptor.ES_PLUGIN_POLICY));
         for (String file : files) {
             Files.createFile(plugin.resolve(file));
         }
@@ -102,7 +102,7 @@ public class PolicyUtilTests extends ESTestCase {
 
     public void testPolicyMissingCodebaseProperty() throws Exception {
         Path plugin = makeDummyPlugin("missing-codebase.policy", "foo.jar");
-        URL policyFile = plugin.resolve(PluginInfo.ES_PLUGIN_POLICY).toUri().toURL();
+        URL policyFile = plugin.resolve(PluginDescriptor.ES_PLUGIN_POLICY).toUri().toURL();
         IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> PolicyUtil.readPolicy(policyFile, Map.of()));
         assertThat(e.getMessage(), containsString("Unknown codebases [codebase.doesnotexist] in policy file"));
     }
@@ -113,7 +113,7 @@ public class PolicyUtilTests extends ESTestCase {
         try {
             URL jarUrl = plugin.resolve("foo.jar").toUri().toURL();
             setProperty("jarUrl", jarUrl.toString());
-            URL policyFile = plugin.resolve(PluginInfo.ES_PLUGIN_POLICY).toUri().toURL();
+            URL policyFile = plugin.resolve(PluginDescriptor.ES_PLUGIN_POLICY).toUri().toURL();
             Policy policy = Policy.getInstance("JavaPolicy", new URIParameter(policyFile.toURI()));
 
             Set<Permission> globalPermissions = PolicyUtil.getPolicyPermissions(null, policy, tmpDir);
@@ -144,7 +144,7 @@ public class PolicyUtilTests extends ESTestCase {
         policyString.append(";\n};");
 
         logger.info(policyString.toString());
-        Files.writeString(plugin.resolve(PluginInfo.ES_PLUGIN_POLICY), policyString.toString());
+        Files.writeString(plugin.resolve(PluginDescriptor.ES_PLUGIN_POLICY), policyString.toString());
 
         return plugin;
     }

--- a/qa/evil-tests/src/test/java/org/elasticsearch/plugins/cli/PluginSecurityTests.java
+++ b/qa/evil-tests/src/test/java/org/elasticsearch/plugins/cli/PluginSecurityTests.java
@@ -10,7 +10,7 @@ package org.elasticsearch.plugins.cli;
 
 import org.elasticsearch.bootstrap.PluginPolicyInfo;
 import org.elasticsearch.bootstrap.PolicyUtil;
-import org.elasticsearch.plugins.PluginInfo;
+import org.elasticsearch.plugins.PluginDescriptor;
 import org.elasticsearch.test.ESTestCase;
 
 import java.io.IOException;
@@ -27,7 +27,7 @@ public class PluginSecurityTests extends ESTestCase {
 
     PluginPolicyInfo makeDummyPlugin(String policy, String... files) throws IOException {
         Path plugin = createTempDir();
-        Files.copy(this.getDataPath(policy), plugin.resolve(PluginInfo.ES_PLUGIN_POLICY));
+        Files.copy(this.getDataPath(policy), plugin.resolve(PluginDescriptor.ES_PLUGIN_POLICY));
         for (String file : files) {
             Files.createFile(plugin.resolve(file));
         }

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/node/info/PluginsAndModules.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/node/info/PluginsAndModules.java
@@ -11,7 +11,7 @@ package org.elasticsearch.action.admin.cluster.node.info;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.node.ReportingService;
-import org.elasticsearch.plugins.PluginInfo;
+import org.elasticsearch.plugins.PluginDescriptor;
 import org.elasticsearch.xcontent.XContentBuilder;
 
 import java.io.IOException;
@@ -24,17 +24,17 @@ import java.util.List;
  * Information about plugins and modules
  */
 public class PluginsAndModules implements ReportingService.Info {
-    private final List<PluginInfo> plugins;
-    private final List<PluginInfo> modules;
+    private final List<PluginDescriptor> plugins;
+    private final List<PluginDescriptor> modules;
 
-    public PluginsAndModules(List<PluginInfo> plugins, List<PluginInfo> modules) {
+    public PluginsAndModules(List<PluginDescriptor> plugins, List<PluginDescriptor> modules) {
         this.plugins = Collections.unmodifiableList(plugins);
         this.modules = Collections.unmodifiableList(modules);
     }
 
     public PluginsAndModules(StreamInput in) throws IOException {
-        this.plugins = Collections.unmodifiableList(in.readList(PluginInfo::new));
-        this.modules = Collections.unmodifiableList(in.readList(PluginInfo::new));
+        this.plugins = Collections.unmodifiableList(in.readList(PluginDescriptor::new));
+        this.modules = Collections.unmodifiableList(in.readList(PluginDescriptor::new));
     }
 
     @Override
@@ -46,39 +46,39 @@ public class PluginsAndModules implements ReportingService.Info {
     /**
      * Returns an ordered list based on plugins name
      */
-    public List<PluginInfo> getPluginInfos() {
-        List<PluginInfo> plugins = new ArrayList<>(this.plugins);
-        Collections.sort(plugins, Comparator.comparing(PluginInfo::getName));
+    public List<PluginDescriptor> getPluginInfos() {
+        List<PluginDescriptor> plugins = new ArrayList<>(this.plugins);
+        Collections.sort(plugins, Comparator.comparing(PluginDescriptor::getName));
         return plugins;
     }
 
     /**
      * Returns an ordered list based on modules name
      */
-    public List<PluginInfo> getModuleInfos() {
-        List<PluginInfo> modules = new ArrayList<>(this.modules);
-        Collections.sort(modules, Comparator.comparing(PluginInfo::getName));
+    public List<PluginDescriptor> getModuleInfos() {
+        List<PluginDescriptor> modules = new ArrayList<>(this.modules);
+        Collections.sort(modules, Comparator.comparing(PluginDescriptor::getName));
         return modules;
     }
 
-    public void addPlugin(PluginInfo info) {
+    public void addPlugin(PluginDescriptor info) {
         plugins.add(info);
     }
 
-    public void addModule(PluginInfo info) {
+    public void addModule(PluginDescriptor info) {
         modules.add(info);
     }
 
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
         builder.startArray("plugins");
-        for (PluginInfo pluginInfo : getPluginInfos()) {
-            pluginInfo.toXContent(builder, params);
+        for (PluginDescriptor pluginDescriptor : getPluginInfos()) {
+            pluginDescriptor.toXContent(builder, params);
         }
         builder.endArray();
         // TODO: not ideal, make a better api for this (e.g. with jar metadata, and so on)
         builder.startArray("modules");
-        for (PluginInfo moduleInfo : getModuleInfos()) {
+        for (PluginDescriptor moduleInfo : getModuleInfos()) {
             moduleInfo.toXContent(builder, params);
         }
         builder.endArray();

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/stats/ClusterStatsNodes.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/stats/ClusterStatsNodes.java
@@ -29,7 +29,7 @@ import org.elasticsearch.index.stats.IndexingPressureStats;
 import org.elasticsearch.monitor.fs.FsInfo;
 import org.elasticsearch.monitor.jvm.JvmInfo;
 import org.elasticsearch.monitor.os.OsInfo;
-import org.elasticsearch.plugins.PluginInfo;
+import org.elasticsearch.plugins.PluginDescriptor;
 import org.elasticsearch.transport.TransportInfo;
 import org.elasticsearch.xcontent.ToXContentFragment;
 import org.elasticsearch.xcontent.XContentBuilder;
@@ -56,7 +56,7 @@ public class ClusterStatsNodes implements ToXContentFragment {
     private final ProcessStats process;
     private final JvmStats jvm;
     private final FsInfo.Path fs;
-    private final Set<PluginInfo> plugins;
+    private final Set<PluginDescriptor> plugins;
     private final NetworkTypes networkTypes;
     private final DiscoveryTypes discoveryTypes;
     private final PackagingTypes packagingTypes;
@@ -122,7 +122,7 @@ public class ClusterStatsNodes implements ToXContentFragment {
         return fs;
     }
 
-    public Set<PluginInfo> getPlugins() {
+    public Set<PluginDescriptor> getPlugins() {
         return plugins;
     }
 
@@ -165,8 +165,8 @@ public class ClusterStatsNodes implements ToXContentFragment {
         fs.toXContent(builder, params);
 
         builder.startArray(Fields.PLUGINS);
-        for (PluginInfo pluginInfo : plugins) {
-            pluginInfo.toXContent(builder, params);
+        for (PluginDescriptor pluginDescriptor : plugins) {
+            pluginDescriptor.toXContent(builder, params);
         }
         builder.endArray();
 

--- a/server/src/main/java/org/elasticsearch/bootstrap/PolicyUtil.java
+++ b/server/src/main/java/org/elasticsearch/bootstrap/PolicyUtil.java
@@ -11,7 +11,7 @@ package org.elasticsearch.bootstrap;
 import org.elasticsearch.core.PathUtils;
 import org.elasticsearch.core.SuppressForbidden;
 import org.elasticsearch.core.internal.io.IOUtils;
-import org.elasticsearch.plugins.PluginInfo;
+import org.elasticsearch.plugins.PluginDescriptor;
 import org.elasticsearch.script.ClassPermission;
 
 import java.io.FilePermission;
@@ -299,7 +299,7 @@ public class PolicyUtil {
 
     // pakcage private for tests
     static PluginPolicyInfo readPolicyInfo(Path pluginRoot) throws IOException {
-        Path policyFile = pluginRoot.resolve(PluginInfo.ES_PLUGIN_POLICY);
+        Path policyFile = pluginRoot.resolve(PluginDescriptor.ES_PLUGIN_POLICY);
         if (Files.exists(policyFile) == false) {
             return null;
         }

--- a/server/src/main/java/org/elasticsearch/bootstrap/Spawner.java
+++ b/server/src/main/java/org/elasticsearch/bootstrap/Spawner.java
@@ -12,7 +12,7 @@ import org.apache.lucene.util.Constants;
 import org.elasticsearch.core.internal.io.IOUtils;
 import org.elasticsearch.env.Environment;
 import org.elasticsearch.plugins.Platforms;
-import org.elasticsearch.plugins.PluginInfo;
+import org.elasticsearch.plugins.PluginDescriptor;
 import org.elasticsearch.plugins.PluginsService;
 
 import java.io.Closeable;
@@ -62,7 +62,7 @@ final class Spawner implements Closeable {
          */
         List<Path> paths = PluginsService.findPluginDirs(environment.modulesFile());
         for (final Path modules : paths) {
-            final PluginInfo info = PluginInfo.readFromProperties(modules);
+            final PluginDescriptor info = PluginDescriptor.readFromProperties(modules);
             final Path spawnPath = Platforms.nativeControllerPath(modules);
             if (Files.isRegularFile(spawnPath) == false) {
                 continue;

--- a/server/src/main/java/org/elasticsearch/plugins/PluginDescriptor.java
+++ b/server/src/main/java/org/elasticsearch/plugins/PluginDescriptor.java
@@ -35,7 +35,7 @@ import java.util.stream.Collectors;
 /**
  * An in-memory representation of the plugin descriptor.
  */
-public class PluginInfo implements Writeable, ToXContentObject {
+public class PluginDescriptor implements Writeable, ToXContentObject {
 
     public static final String ES_PLUGIN_PROPERTIES = "plugin-descriptor.properties";
     public static final String ES_PLUGIN_POLICY = "plugin-security.policy";
@@ -69,7 +69,7 @@ public class PluginInfo implements Writeable, ToXContentObject {
      * @param javaOpts              any additional JVM CLI parameters added by this plugin
      * @param isLicensed            whether is this a licensed plugin
      */
-    public PluginInfo(
+    public PluginDescriptor(
         String name,
         String description,
         String version,
@@ -101,7 +101,7 @@ public class PluginInfo implements Writeable, ToXContentObject {
      * @param in the stream
      * @throws IOException if an I/O exception occurred reading the plugin info from the stream
      */
-    public PluginInfo(final StreamInput in) throws IOException {
+    public PluginDescriptor(final StreamInput in) throws IOException {
         this.name = in.readString();
         this.description = in.readString();
         this.version = in.readString();
@@ -147,7 +147,7 @@ public class PluginInfo implements Writeable, ToXContentObject {
      * @return the plugin info
      * @throws IOException if an I/O exception occurred reading the plugin descriptor
      */
-    public static PluginInfo readFromProperties(final Path path) throws IOException {
+    public static PluginDescriptor readFromProperties(final Path path) throws IOException {
         final Path descriptor = path.resolve(ES_PLUGIN_PROPERTIES);
 
         final Map<String, String> propsMap;
@@ -211,7 +211,7 @@ public class PluginInfo implements Writeable, ToXContentObject {
             throw new IllegalArgumentException("Unknown properties for plugin [" + name + "] in plugin descriptor: " + propsMap.keySet());
         }
 
-        return new PluginInfo(
+        return new PluginDescriptor(
             name,
             description,
             version,
@@ -399,7 +399,7 @@ public class PluginInfo implements Writeable, ToXContentObject {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
 
-        PluginInfo that = (PluginInfo) o;
+        PluginDescriptor that = (PluginDescriptor) o;
 
         if (name.equals(that.name) == false) return false;
         // TODO: since the plugins are unique by their directory name, this should only be a name check, version should not matter?

--- a/server/src/main/java/org/elasticsearch/rest/action/cat/RestPluginsAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/cat/RestPluginsAction.java
@@ -18,7 +18,7 @@ import org.elasticsearch.client.internal.node.NodeClient;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
 import org.elasticsearch.common.Table;
-import org.elasticsearch.plugins.PluginInfo;
+import org.elasticsearch.plugins.PluginDescriptor;
 import org.elasticsearch.plugins.PluginType;
 import org.elasticsearch.rest.RestRequest;
 import org.elasticsearch.rest.RestResponse;
@@ -100,17 +100,17 @@ public class RestPluginsAction extends AbstractCatAction {
             if (plugins == null) {
                 continue;
             }
-            for (PluginInfo pluginInfo : plugins.getPluginInfos()) {
-                if (pluginInfo.getType() == PluginType.BOOTSTRAP && includeBootstrapPlugins == false) {
+            for (PluginDescriptor pluginDescriptor : plugins.getPluginInfos()) {
+                if (pluginDescriptor.getType() == PluginType.BOOTSTRAP && includeBootstrapPlugins == false) {
                     continue;
                 }
                 table.startRow();
                 table.addCell(node.getId());
                 table.addCell(node.getName());
-                table.addCell(pluginInfo.getName());
-                table.addCell(pluginInfo.getVersion());
-                table.addCell(pluginInfo.getDescription());
-                table.addCell(pluginInfo.getType().toString().toLowerCase(Locale.ROOT));
+                table.addCell(pluginDescriptor.getName());
+                table.addCell(pluginDescriptor.getVersion());
+                table.addCell(pluginDescriptor.getDescription());
+                table.addCell(pluginDescriptor.getType().toString().toLowerCase(Locale.ROOT));
                 table.endRow();
             }
         }

--- a/server/src/test/java/org/elasticsearch/nodesinfo/NodeInfoStreamingTests.java
+++ b/server/src/test/java/org/elasticsearch/nodesinfo/NodeInfoStreamingTests.java
@@ -25,7 +25,7 @@ import org.elasticsearch.ingest.ProcessorInfo;
 import org.elasticsearch.monitor.jvm.JvmInfo;
 import org.elasticsearch.monitor.os.OsInfo;
 import org.elasticsearch.monitor.process.ProcessInfo;
-import org.elasticsearch.plugins.PluginInfo;
+import org.elasticsearch.plugins.PluginDescriptor;
 import org.elasticsearch.plugins.PluginType;
 import org.elasticsearch.search.aggregations.support.AggregationInfo;
 import org.elasticsearch.search.aggregations.support.AggregationUsageService;
@@ -143,10 +143,10 @@ public class NodeInfoStreamingTests extends ESTestCase {
         PluginsAndModules pluginsAndModules = null;
         if (randomBoolean()) {
             int numPlugins = randomIntBetween(0, 5);
-            List<PluginInfo> plugins = new ArrayList<>();
+            List<PluginDescriptor> plugins = new ArrayList<>();
             for (int i = 0; i < numPlugins; i++) {
                 plugins.add(
-                    new PluginInfo(
+                    new PluginDescriptor(
                         randomAlphaOfLengthBetween(3, 10),
                         randomAlphaOfLengthBetween(3, 10),
                         randomAlphaOfLengthBetween(3, 10),
@@ -162,10 +162,10 @@ public class NodeInfoStreamingTests extends ESTestCase {
                 );
             }
             int numModules = randomIntBetween(0, 5);
-            List<PluginInfo> modules = new ArrayList<>();
+            List<PluginDescriptor> modules = new ArrayList<>();
             for (int i = 0; i < numModules; i++) {
                 modules.add(
-                    new PluginInfo(
+                    new PluginDescriptor(
                         randomAlphaOfLengthBetween(3, 10),
                         randomAlphaOfLengthBetween(3, 10),
                         randomAlphaOfLengthBetween(3, 10),

--- a/server/src/test/java/org/elasticsearch/plugins/PluginDescriptorTests.java
+++ b/server/src/test/java/org/elasticsearch/plugins/PluginDescriptorTests.java
@@ -25,7 +25,7 @@ import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
 
-public class PluginInfoTests extends ESTestCase {
+public class PluginDescriptorTests extends ESTestCase {
 
     public void testReadFromProperties() throws Exception {
         Path pluginDir = createTempDir().resolve("fake-plugin");
@@ -44,7 +44,7 @@ public class PluginInfoTests extends ESTestCase {
             "classname",
             "FakePlugin"
         );
-        PluginInfo info = PluginInfo.readFromProperties(pluginDir);
+        PluginDescriptor info = PluginDescriptor.readFromProperties(pluginDir);
         assertEquals("my_plugin", info.getName());
         assertEquals("fake desc", info.getDescription());
         assertEquals("1.0", info.getVersion());
@@ -55,32 +55,32 @@ public class PluginInfoTests extends ESTestCase {
     public void testReadFromPropertiesNameMissing() throws Exception {
         Path pluginDir = createTempDir().resolve("fake-plugin");
         PluginTestUtil.writePluginProperties(pluginDir);
-        IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> PluginInfo.readFromProperties(pluginDir));
+        IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> PluginDescriptor.readFromProperties(pluginDir));
         assertThat(e.getMessage(), containsString("property [name] is missing in"));
 
         PluginTestUtil.writePluginProperties(pluginDir, "name", "");
-        e = expectThrows(IllegalArgumentException.class, () -> PluginInfo.readFromProperties(pluginDir));
+        e = expectThrows(IllegalArgumentException.class, () -> PluginDescriptor.readFromProperties(pluginDir));
         assertThat(e.getMessage(), containsString("property [name] is missing in"));
     }
 
     public void testReadFromPropertiesDescriptionMissing() throws Exception {
         Path pluginDir = createTempDir().resolve("fake-plugin");
         PluginTestUtil.writePluginProperties(pluginDir, "name", "fake-plugin");
-        IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> PluginInfo.readFromProperties(pluginDir));
+        IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> PluginDescriptor.readFromProperties(pluginDir));
         assertThat(e.getMessage(), containsString("[description] is missing"));
     }
 
     public void testReadFromPropertiesVersionMissing() throws Exception {
         Path pluginDir = createTempDir().resolve("fake-plugin");
         PluginTestUtil.writePluginProperties(pluginDir, "description", "fake desc", "name", "fake-plugin");
-        IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> PluginInfo.readFromProperties(pluginDir));
+        IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> PluginDescriptor.readFromProperties(pluginDir));
         assertThat(e.getMessage(), containsString("[version] is missing"));
     }
 
     public void testReadFromPropertiesElasticsearchVersionMissing() throws Exception {
         Path pluginDir = createTempDir().resolve("fake-plugin");
         PluginTestUtil.writePluginProperties(pluginDir, "description", "fake desc", "name", "my_plugin", "version", "1.0");
-        IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> PluginInfo.readFromProperties(pluginDir));
+        IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> PluginDescriptor.readFromProperties(pluginDir));
         assertThat(e.getMessage(), containsString("[elasticsearch.version] is missing"));
     }
 
@@ -97,7 +97,7 @@ public class PluginInfoTests extends ESTestCase {
             "elasticsearch.version",
             "  "
         );
-        IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> PluginInfo.readFromProperties(pluginDir));
+        IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> PluginDescriptor.readFromProperties(pluginDir));
         assertThat(e.getMessage(), containsString("[elasticsearch.version] is missing"));
     }
 
@@ -114,7 +114,7 @@ public class PluginInfoTests extends ESTestCase {
             "version",
             "1.0"
         );
-        IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> PluginInfo.readFromProperties(pluginDir));
+        IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> PluginDescriptor.readFromProperties(pluginDir));
         assertThat(e.getMessage(), containsString("[java.version] is missing"));
     }
 
@@ -136,7 +136,7 @@ public class PluginInfoTests extends ESTestCase {
             "version",
             "1.0"
         );
-        IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> PluginInfo.readFromProperties(pluginDir));
+        IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> PluginDescriptor.readFromProperties(pluginDir));
         assertThat(e.getMessage(), equalTo("Invalid version string: '1.7.0_80'"));
     }
 
@@ -153,7 +153,7 @@ public class PluginInfoTests extends ESTestCase {
             "elasticsearch.version",
             "bogus"
         );
-        IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> PluginInfo.readFromProperties(pluginDir));
+        IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> PluginDescriptor.readFromProperties(pluginDir));
         assertThat(e.getMessage(), containsString("version needs to contain major, minor, and revision"));
     }
 
@@ -172,7 +172,7 @@ public class PluginInfoTests extends ESTestCase {
             "java.version",
             System.getProperty("java.specification.version")
         );
-        IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> PluginInfo.readFromProperties(pluginDir));
+        IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> PluginDescriptor.readFromProperties(pluginDir));
         assertThat(e.getMessage(), containsString("property [classname] is missing"));
     }
 
@@ -195,7 +195,7 @@ public class PluginInfoTests extends ESTestCase {
             "extended.plugins",
             "foo"
         );
-        PluginInfo info = PluginInfo.readFromProperties(pluginDir);
+        PluginDescriptor info = PluginDescriptor.readFromProperties(pluginDir);
         assertThat(info.getExtendedPlugins(), contains("foo"));
     }
 
@@ -218,7 +218,7 @@ public class PluginInfoTests extends ESTestCase {
             "extended.plugins",
             "foo,bar,baz"
         );
-        PluginInfo info = PluginInfo.readFromProperties(pluginDir);
+        PluginDescriptor info = PluginDescriptor.readFromProperties(pluginDir);
         assertThat(info.getExtendedPlugins(), contains("foo", "bar", "baz"));
     }
 
@@ -241,12 +241,12 @@ public class PluginInfoTests extends ESTestCase {
             "extended.plugins",
             ""
         );
-        PluginInfo info = PluginInfo.readFromProperties(pluginDir);
+        PluginDescriptor info = PluginDescriptor.readFromProperties(pluginDir);
         assertThat(info.getExtendedPlugins(), empty());
     }
 
     public void testSerialize() throws Exception {
-        PluginInfo info = new PluginInfo(
+        PluginDescriptor info = new PluginDescriptor(
             "c",
             "foo",
             "dummy",
@@ -263,15 +263,15 @@ public class PluginInfoTests extends ESTestCase {
         info.writeTo(output);
         ByteBuffer buffer = ByteBuffer.wrap(output.bytes().toBytesRef().bytes);
         ByteBufferStreamInput input = new ByteBufferStreamInput(buffer);
-        PluginInfo info2 = new PluginInfo(input);
+        PluginDescriptor info2 = new PluginDescriptor(input);
         assertThat(info2.toString(), equalTo(info.toString()));
 
     }
 
     public void testPluginListSorted() {
-        List<PluginInfo> plugins = new ArrayList<>();
+        List<PluginDescriptor> plugins = new ArrayList<>();
         plugins.add(
-            new PluginInfo(
+            new PluginDescriptor(
                 "c",
                 "foo",
                 "dummy",
@@ -286,7 +286,7 @@ public class PluginInfoTests extends ESTestCase {
             )
         );
         plugins.add(
-            new PluginInfo(
+            new PluginDescriptor(
                 "b",
                 "foo",
                 "dummy",
@@ -301,7 +301,7 @@ public class PluginInfoTests extends ESTestCase {
             )
         );
         plugins.add(
-            new PluginInfo(
+            new PluginDescriptor(
                 "e",
                 "foo",
                 "dummy",
@@ -316,7 +316,7 @@ public class PluginInfoTests extends ESTestCase {
             )
         );
         plugins.add(
-            new PluginInfo(
+            new PluginDescriptor(
                 "a",
                 "foo",
                 "dummy",
@@ -331,7 +331,7 @@ public class PluginInfoTests extends ESTestCase {
             )
         );
         plugins.add(
-            new PluginInfo(
+            new PluginDescriptor(
                 "d",
                 "foo",
                 "dummy",
@@ -347,8 +347,8 @@ public class PluginInfoTests extends ESTestCase {
         );
         PluginsAndModules pluginsInfo = new PluginsAndModules(plugins, Collections.emptyList());
 
-        final List<PluginInfo> infos = pluginsInfo.getPluginInfos();
-        List<String> names = infos.stream().map(PluginInfo::getName).toList();
+        final List<PluginDescriptor> infos = pluginsInfo.getPluginInfos();
+        List<String> names = infos.stream().map(PluginDescriptor::getName).toList();
         assertThat(names, contains("a", "b", "c", "d", "e"));
     }
 
@@ -373,7 +373,7 @@ public class PluginInfoTests extends ESTestCase {
             "java.version",
             System.getProperty("java.specification.version")
         );
-        IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> PluginInfo.readFromProperties(pluginDir));
+        IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> PluginDescriptor.readFromProperties(pluginDir));
         assertThat(e.getMessage(), containsString("Unknown properties for plugin [my_plugin] in plugin descriptor"));
     }
 
@@ -395,8 +395,8 @@ public class PluginInfoTests extends ESTestCase {
             System.getProperty("java.specification.version")
         );
 
-        final PluginInfo pluginInfo = PluginInfo.readFromProperties(pluginDir);
-        assertThat(pluginInfo.getType(), equalTo(PluginType.ISOLATED));
+        final PluginDescriptor pluginDescriptor = PluginDescriptor.readFromProperties(pluginDir);
+        assertThat(pluginDescriptor.getType(), equalTo(PluginType.ISOLATED));
     }
 
     public void testInvalidType() throws Exception {
@@ -419,7 +419,7 @@ public class PluginInfoTests extends ESTestCase {
             "invalid"
         );
 
-        IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> PluginInfo.readFromProperties(pluginDir));
+        IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> PluginDescriptor.readFromProperties(pluginDir));
         assertThat(e.getMessage(), containsString("[type] must be unspecified or one of [isolated, bootstrap] but found [invalid]"));
     }
 
@@ -443,9 +443,9 @@ public class PluginInfoTests extends ESTestCase {
             "-Dfoo=bar"
         );
 
-        final PluginInfo pluginInfo = PluginInfo.readFromProperties(pluginDir);
-        assertThat(pluginInfo.getType(), equalTo(PluginType.BOOTSTRAP));
-        assertThat(pluginInfo.getJavaOpts(), equalTo("-Dfoo=bar"));
+        final PluginDescriptor pluginDescriptor = PluginDescriptor.readFromProperties(pluginDir);
+        assertThat(pluginDescriptor.getType(), equalTo(PluginType.BOOTSTRAP));
+        assertThat(pluginDescriptor.getJavaOpts(), equalTo("-Dfoo=bar"));
     }
 
     public void testJavaOptsAreRejectedWithNonBootstrapPlugin() throws Exception {
@@ -470,7 +470,7 @@ public class PluginInfoTests extends ESTestCase {
             "-Dfoo=bar"
         );
 
-        IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> PluginInfo.readFromProperties(pluginDir));
+        IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> PluginDescriptor.readFromProperties(pluginDir));
         assertThat(e.getMessage(), containsString("[java.opts] can only have a value when [type] is set to [bootstrap]"));
     }
 
@@ -494,7 +494,7 @@ public class PluginInfoTests extends ESTestCase {
             "bootstrap"
         );
 
-        IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> PluginInfo.readFromProperties(pluginDir));
+        IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> PluginDescriptor.readFromProperties(pluginDir));
         assertThat(e.getMessage(), containsString("[classname] can only have a value when [type] is set to [bootstrap]"));
     }
 }

--- a/server/src/test/java/org/elasticsearch/plugins/PluginsServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/plugins/PluginsServiceTests.java
@@ -314,7 +314,7 @@ public class PluginsServiceTests extends ESTestCase {
 
     public void testSortBundlesCycleSelfReference() throws Exception {
         Path pluginDir = createTempDir();
-        PluginInfo info = new PluginInfo(
+        PluginDescriptor info = new PluginDescriptor(
             "foo",
             "desc",
             "1.0",
@@ -338,7 +338,7 @@ public class PluginsServiceTests extends ESTestCase {
     public void testSortBundlesCycle() throws Exception {
         Path pluginDir = createTempDir();
         Set<PluginsService.Bundle> bundles = new LinkedHashSet<>(); // control iteration order, so we get know the beginning of the cycle
-        PluginInfo info = new PluginInfo(
+        PluginDescriptor info = new PluginDescriptor(
             "foo",
             "desc",
             "1.0",
@@ -352,7 +352,7 @@ public class PluginsServiceTests extends ESTestCase {
             false
         );
         bundles.add(new PluginsService.Bundle(info, pluginDir));
-        PluginInfo info2 = new PluginInfo(
+        PluginDescriptor info2 = new PluginDescriptor(
             "bar",
             "desc",
             "1.0",
@@ -366,7 +366,7 @@ public class PluginsServiceTests extends ESTestCase {
             false
         );
         bundles.add(new PluginsService.Bundle(info2, pluginDir));
-        PluginInfo info3 = new PluginInfo(
+        PluginDescriptor info3 = new PluginDescriptor(
             "baz",
             "desc",
             "1.0",
@@ -380,7 +380,7 @@ public class PluginsServiceTests extends ESTestCase {
             false
         );
         bundles.add(new PluginsService.Bundle(info3, pluginDir));
-        PluginInfo info4 = new PluginInfo(
+        PluginDescriptor info4 = new PluginDescriptor(
             "other",
             "desc",
             "1.0",
@@ -401,7 +401,7 @@ public class PluginsServiceTests extends ESTestCase {
 
     public void testSortBundlesSingle() throws Exception {
         Path pluginDir = createTempDir();
-        PluginInfo info = new PluginInfo(
+        PluginDescriptor info = new PluginDescriptor(
             "foo",
             "desc",
             "1.0",
@@ -422,7 +422,7 @@ public class PluginsServiceTests extends ESTestCase {
     public void testSortBundlesNoDeps() throws Exception {
         Path pluginDir = createTempDir();
         Set<PluginsService.Bundle> bundles = new LinkedHashSet<>(); // control iteration order
-        PluginInfo info1 = new PluginInfo(
+        PluginDescriptor info1 = new PluginDescriptor(
             "foo",
             "desc",
             "1.0",
@@ -437,7 +437,7 @@ public class PluginsServiceTests extends ESTestCase {
         );
         PluginsService.Bundle bundle1 = new PluginsService.Bundle(info1, pluginDir);
         bundles.add(bundle1);
-        PluginInfo info2 = new PluginInfo(
+        PluginDescriptor info2 = new PluginDescriptor(
             "bar",
             "desc",
             "1.0",
@@ -452,7 +452,7 @@ public class PluginsServiceTests extends ESTestCase {
         );
         PluginsService.Bundle bundle2 = new PluginsService.Bundle(info2, pluginDir);
         bundles.add(bundle2);
-        PluginInfo info3 = new PluginInfo(
+        PluginDescriptor info3 = new PluginDescriptor(
             "baz",
             "desc",
             "1.0",
@@ -473,7 +473,7 @@ public class PluginsServiceTests extends ESTestCase {
 
     public void testSortBundlesMissingDep() throws Exception {
         Path pluginDir = createTempDir();
-        PluginInfo info = new PluginInfo(
+        PluginDescriptor info = new PluginDescriptor(
             "foo",
             "desc",
             "1.0",
@@ -497,7 +497,7 @@ public class PluginsServiceTests extends ESTestCase {
     public void testSortBundlesCommonDep() throws Exception {
         Path pluginDir = createTempDir();
         Set<PluginsService.Bundle> bundles = new LinkedHashSet<>(); // control iteration order
-        PluginInfo info1 = new PluginInfo(
+        PluginDescriptor info1 = new PluginDescriptor(
             "grandparent",
             "desc",
             "1.0",
@@ -512,7 +512,7 @@ public class PluginsServiceTests extends ESTestCase {
         );
         PluginsService.Bundle bundle1 = new PluginsService.Bundle(info1, pluginDir);
         bundles.add(bundle1);
-        PluginInfo info2 = new PluginInfo(
+        PluginDescriptor info2 = new PluginDescriptor(
             "foo",
             "desc",
             "1.0",
@@ -527,7 +527,7 @@ public class PluginsServiceTests extends ESTestCase {
         );
         PluginsService.Bundle bundle2 = new PluginsService.Bundle(info2, pluginDir);
         bundles.add(bundle2);
-        PluginInfo info3 = new PluginInfo(
+        PluginDescriptor info3 = new PluginDescriptor(
             "bar",
             "desc",
             "1.0",
@@ -542,7 +542,7 @@ public class PluginsServiceTests extends ESTestCase {
         );
         PluginsService.Bundle bundle3 = new PluginsService.Bundle(info3, pluginDir);
         bundles.add(bundle3);
-        PluginInfo info4 = new PluginInfo(
+        PluginDescriptor info4 = new PluginDescriptor(
             "common",
             "desc",
             "1.0",
@@ -564,7 +564,7 @@ public class PluginsServiceTests extends ESTestCase {
     public void testSortBundlesAlreadyOrdered() throws Exception {
         Path pluginDir = createTempDir();
         Set<PluginsService.Bundle> bundles = new LinkedHashSet<>(); // control iteration order
-        PluginInfo info1 = new PluginInfo(
+        PluginDescriptor info1 = new PluginDescriptor(
             "dep",
             "desc",
             "1.0",
@@ -579,7 +579,7 @@ public class PluginsServiceTests extends ESTestCase {
         );
         PluginsService.Bundle bundle1 = new PluginsService.Bundle(info1, pluginDir);
         bundles.add(bundle1);
-        PluginInfo info2 = new PluginInfo(
+        PluginDescriptor info2 = new PluginDescriptor(
             "myplugin",
             "desc",
             "1.0",
@@ -649,7 +649,7 @@ public class PluginsServiceTests extends ESTestCase {
         makeJar(dupJar);
         Map<String, Set<URL>> transitiveDeps = new HashMap<>();
         transitiveDeps.put("dep", Collections.singleton(dupJar.toUri().toURL()));
-        PluginInfo info1 = new PluginInfo(
+        PluginDescriptor info1 = new PluginDescriptor(
             "myplugin",
             "desc",
             "1.0",
@@ -681,7 +681,7 @@ public class PluginsServiceTests extends ESTestCase {
         Map<String, Set<URL>> transitiveDeps = new HashMap<>();
         transitiveDeps.put("dep1", Collections.singleton(dupJar.toUri().toURL()));
         transitiveDeps.put("dep2", Collections.singleton(dupJar.toUri().toURL()));
-        PluginInfo info1 = new PluginInfo(
+        PluginDescriptor info1 = new PluginDescriptor(
             "myplugin",
             "desc",
             "1.0",
@@ -711,7 +711,7 @@ public class PluginsServiceTests extends ESTestCase {
         Path pluginDir = createTempDir();
         Path pluginJar = pluginDir.resolve("plugin.jar");
         makeJar(pluginJar, Level.class);
-        PluginInfo info1 = new PluginInfo(
+        PluginDescriptor info1 = new PluginDescriptor(
             "myplugin",
             "desc",
             "1.0",
@@ -741,7 +741,7 @@ public class PluginsServiceTests extends ESTestCase {
         Path otherDir = createTempDir();
         Path extendedPlugin = otherDir.resolve("extendedDep-not-present.jar");
 
-        PluginInfo info = new PluginInfo(
+        PluginDescriptor info = new PluginDescriptor(
             "dummy",
             "desc",
             "1.0",
@@ -776,7 +776,7 @@ public class PluginsServiceTests extends ESTestCase {
         makeJar(depJar, DummyClass1.class);
         Map<String, Set<URL>> transitiveDeps = new HashMap<>();
         transitiveDeps.put("dep", Collections.singleton(depJar.toUri().toURL()));
-        PluginInfo info1 = new PluginInfo(
+        PluginDescriptor info1 = new PluginDescriptor(
             "myplugin",
             "desc",
             "1.0",
@@ -812,7 +812,7 @@ public class PluginsServiceTests extends ESTestCase {
         Map<String, Set<URL>> transitiveDeps = new HashMap<>();
         transitiveDeps.put("dep1", Collections.singleton(dep1Jar.toUri().toURL()));
         transitiveDeps.put("dep2", Collections.singleton(dep2Jar.toUri().toURL()));
-        PluginInfo info1 = new PluginInfo(
+        PluginDescriptor info1 = new PluginDescriptor(
             "myplugin",
             "desc",
             "1.0",
@@ -848,7 +848,7 @@ public class PluginsServiceTests extends ESTestCase {
         Map<String, Set<URL>> transitiveDeps = new HashMap<>();
         transitiveDeps.put("dep1", Collections.singleton(dep1Jar.toUri().toURL()));
         transitiveDeps.put("dep2", Collections.singleton(dep2Jar.toUri().toURL()));
-        PluginInfo info1 = new PluginInfo(
+        PluginDescriptor info1 = new PluginDescriptor(
             "myplugin",
             "desc",
             "1.0",
@@ -881,7 +881,7 @@ public class PluginsServiceTests extends ESTestCase {
         makeJar(depJar, DummyClass1.class);
         Map<String, Set<URL>> transitiveDeps = new HashMap<>();
         transitiveDeps.put("dep", Collections.singleton(depJar.toUri().toURL()));
-        PluginInfo info1 = new PluginInfo(
+        PluginDescriptor info1 = new PluginDescriptor(
             "myplugin",
             "desc",
             "1.0",
@@ -913,7 +913,7 @@ public class PluginsServiceTests extends ESTestCase {
         makeJar(depJar, DummyClass1.class);
         Map<String, Set<URL>> transitiveDeps = new HashMap<>();
         transitiveDeps.put("dep", Collections.singleton(depJar.toUri().toURL()));
-        PluginInfo info1 = new PluginInfo(
+        PluginDescriptor info1 = new PluginDescriptor(
             "myplugin",
             "desc",
             "1.0",
@@ -991,7 +991,7 @@ public class PluginsServiceTests extends ESTestCase {
     }
 
     public void testIncompatibleElasticsearchVersion() throws Exception {
-        PluginInfo info = new PluginInfo(
+        PluginDescriptor info = new PluginDescriptor(
             "my_plugin",
             "desc",
             "1.0",
@@ -1009,7 +1009,7 @@ public class PluginsServiceTests extends ESTestCase {
     }
 
     public void testIncompatibleJavaVersion() throws Exception {
-        PluginInfo info = new PluginInfo(
+        PluginDescriptor info = new PluginDescriptor(
             "my_plugin",
             "desc",
             "1.0",
@@ -1145,7 +1145,7 @@ public class PluginsServiceTests extends ESTestCase {
         PluginsService.loadExtensions(
             List.of(
                 Tuple.tuple(
-                    new PluginInfo("extensible", null, null, null, null, null, List.of(), false, PluginType.ISOLATED, "", false),
+                    new PluginDescriptor("extensible", null, null, null, null, null, List.of(), false, PluginType.ISOLATED, "", false),
                     extensiblePlugin
                 )
             )
@@ -1159,11 +1159,23 @@ public class PluginsServiceTests extends ESTestCase {
         PluginsService.loadExtensions(
             List.of(
                 Tuple.tuple(
-                    new PluginInfo("extensible", null, null, null, null, null, List.of(), false, PluginType.ISOLATED, "", false),
+                    new PluginDescriptor("extensible", null, null, null, null, null, List.of(), false, PluginType.ISOLATED, "", false),
                     extensiblePlugin
                 ),
                 Tuple.tuple(
-                    new PluginInfo("test", null, null, null, null, null, List.of("extensible"), false, PluginType.ISOLATED, "", false),
+                    new PluginDescriptor(
+                        "test",
+                        null,
+                        null,
+                        null,
+                        null,
+                        null,
+                        List.of("extensible"),
+                        false,
+                        PluginType.ISOLATED,
+                        "",
+                        false
+                    ),
                     testPlugin
                 )
             )

--- a/server/src/test/java/org/elasticsearch/rest/action/cat/RestPluginsActionTests.java
+++ b/server/src/test/java/org/elasticsearch/rest/action/cat/RestPluginsActionTests.java
@@ -18,7 +18,7 @@ import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
 import org.elasticsearch.common.Table;
-import org.elasticsearch.plugins.PluginInfo;
+import org.elasticsearch.plugins.PluginDescriptor;
 import org.elasticsearch.plugins.PluginType;
 import org.elasticsearch.rest.RestRequest;
 import org.elasticsearch.test.ESTestCase;
@@ -113,7 +113,7 @@ public class RestPluginsActionTests extends ESTestCase {
         assertThat(rows, containsInAnyOrder(matchers));
     }
 
-    private Table buildTable(List<PluginInfo> pluginInfo, boolean includeBootstrap) {
+    private Table buildTable(List<PluginDescriptor> pluginDescriptor, boolean includeBootstrap) {
         final RestRequest request = new FakeRestRequest();
 
         final DiscoveryNodes.Builder builder = DiscoveryNodes.builder();
@@ -140,7 +140,7 @@ public class RestPluginsActionTests extends ESTestCase {
                     null,
                     null,
                     null,
-                    new PluginsAndModules(pluginInfo, List.of()),
+                    new PluginsAndModules(pluginDescriptor, List.of()),
                     null,
                     null,
                     null
@@ -157,7 +157,7 @@ public class RestPluginsActionTests extends ESTestCase {
         return new DiscoveryNode("node-" + id, Integer.toString(id), buildNewFakeTransportAddress(), Map.of(), Set.of(), Version.CURRENT);
     }
 
-    private PluginInfo plugin(String name, PluginType type) {
-        return new PluginInfo(name, name + " description", "1.0", null, null, null, List.of(), false, type, null, false);
+    private PluginDescriptor plugin(String name, PluginType type) {
+        return new PluginDescriptor(name, name + " description", "1.0", null, null, null, List.of(), false, type, null, false);
     }
 }

--- a/test/framework/src/main/java/org/elasticsearch/bootstrap/BootstrapForTesting.java
+++ b/test/framework/src/main/java/org/elasticsearch/bootstrap/BootstrapForTesting.java
@@ -22,7 +22,7 @@ import org.elasticsearch.core.Booleans;
 import org.elasticsearch.core.PathUtils;
 import org.elasticsearch.core.SuppressForbidden;
 import org.elasticsearch.jdk.JarHell;
-import org.elasticsearch.plugins.PluginInfo;
+import org.elasticsearch.plugins.PluginDescriptor;
 import org.elasticsearch.secure_sm.SecureSM;
 import org.elasticsearch.test.mockito.SecureMockMaker;
 import org.junit.Assert;
@@ -177,7 +177,9 @@ public class BootstrapForTesting {
 
                 // guarantee plugin classes are initialized first, in case they have one-time hacks.
                 // this just makes unit testing more realistic
-                for (URL url : Collections.list(BootstrapForTesting.class.getClassLoader().getResources(PluginInfo.ES_PLUGIN_PROPERTIES))) {
+                for (URL url : Collections.list(
+                    BootstrapForTesting.class.getClassLoader().getResources(PluginDescriptor.ES_PLUGIN_PROPERTIES)
+                )) {
                     Properties properties = new Properties();
                     try (InputStream stream = FileSystemUtils.openFileURLStream(url)) {
                         properties.load(stream);
@@ -230,7 +232,9 @@ public class BootstrapForTesting {
      */
     @SuppressForbidden(reason = "accesses fully qualified URLs to configure security")
     static Map<String, Policy> getPluginPermissions() throws Exception {
-        List<URL> pluginPolicies = Collections.list(BootstrapForTesting.class.getClassLoader().getResources(PluginInfo.ES_PLUGIN_POLICY));
+        List<URL> pluginPolicies = Collections.list(
+            BootstrapForTesting.class.getClassLoader().getResources(PluginDescriptor.ES_PLUGIN_POLICY)
+        );
         if (pluginPolicies.isEmpty()) {
             return Collections.emptyMap();
         }

--- a/test/framework/src/main/java/org/elasticsearch/plugins/PluginTestUtil.java
+++ b/test/framework/src/main/java/org/elasticsearch/plugins/PluginTestUtil.java
@@ -18,7 +18,7 @@ import java.util.Properties;
 public class PluginTestUtil {
 
     public static void writePluginProperties(Path pluginDir, String... stringProps) throws IOException {
-        writeProperties(pluginDir.resolve(PluginInfo.ES_PLUGIN_PROPERTIES), stringProps);
+        writeProperties(pluginDir.resolve(PluginDescriptor.ES_PLUGIN_PROPERTIES), stringProps);
     }
 
     /** convenience method to write a plugin properties file */

--- a/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/collector/cluster/ClusterStatsMonitoringDocTests.java
+++ b/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/collector/cluster/ClusterStatsMonitoringDocTests.java
@@ -47,7 +47,7 @@ import org.elasticsearch.monitor.jvm.JvmStats;
 import org.elasticsearch.monitor.os.OsInfo;
 import org.elasticsearch.monitor.os.OsStats;
 import org.elasticsearch.monitor.process.ProcessStats;
-import org.elasticsearch.plugins.PluginInfo;
+import org.elasticsearch.plugins.PluginDescriptor;
 import org.elasticsearch.plugins.PluginType;
 import org.elasticsearch.test.VersionUtils;
 import org.elasticsearch.transport.TransportInfo;
@@ -324,7 +324,7 @@ public class ClusterStatsMonitoringDocTests extends BaseMonitoringDocTestCase<Cl
 
         final PluginsAndModules mockPluginsAndModules = mock(PluginsAndModules.class);
         when(mockNodeInfo.getInfo(PluginsAndModules.class)).thenReturn(mockPluginsAndModules);
-        final PluginInfo pluginInfo = new PluginInfo(
+        final PluginDescriptor pluginDescriptor = new PluginDescriptor(
             "_plugin",
             "_plugin_desc",
             "_plugin_version",
@@ -337,7 +337,7 @@ public class ClusterStatsMonitoringDocTests extends BaseMonitoringDocTestCase<Cl
             "",
             false
         );
-        when(mockPluginsAndModules.getPluginInfos()).thenReturn(singletonList(pluginInfo));
+        when(mockPluginsAndModules.getPluginInfos()).thenReturn(singletonList(pluginDescriptor));
 
         final OsInfo mockOsInfo = mock(OsInfo.class);
         when(mockNodeInfo.getInfo(OsInfo.class)).thenReturn(mockOsInfo);

--- a/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/test/SecuritySingleNodeTestCase.java
+++ b/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/test/SecuritySingleNodeTestCase.java
@@ -25,7 +25,7 @@ import org.elasticsearch.core.internal.io.IOUtils;
 import org.elasticsearch.http.HttpInfo;
 import org.elasticsearch.license.LicenseService;
 import org.elasticsearch.plugins.Plugin;
-import org.elasticsearch.plugins.PluginInfo;
+import org.elasticsearch.plugins.PluginDescriptor;
 import org.elasticsearch.xpack.core.security.authc.support.Hasher;
 import org.elasticsearch.xpack.security.LocalStateSecurity;
 import org.junit.AfterClass;
@@ -152,7 +152,7 @@ public abstract class SecuritySingleNodeTestCase extends ESSingleNodeTestCase {
             Collection<String> pluginNames = nodeInfo.getInfo(PluginsAndModules.class)
                 .getPluginInfos()
                 .stream()
-                .map(PluginInfo::getClassname)
+                .map(PluginDescriptor::getClassname)
                 .collect(Collectors.toList());
             assertThat(
                 "plugin [" + LocalStateSecurity.class.getName() + "] not found in [" + pluginNames + "]",


### PR DESCRIPTION
The class PluginInfo represents the plugin-descriptor.properties file
that each plugin must have. This commit renames the class to more
closely match what it represents: the plugin descriptor.