### PR TITLE
Rename PluginInfo to PluginDescriptor (#86950)

### DIFF
--- a/distribution/tools/plugin-cli/src/main/java/org/elasticsearch/plugins/cli/InstallPluginCommand.java
+++ b/distribution/tools/plugin-cli/src/main/java/org/elasticsearch/plugins/cli/InstallPluginCommand.java
@@ -14,7 +14,7 @@ import joptsimple.OptionSpec;
 import org.elasticsearch.cli.EnvironmentAwareCommand;
 import org.elasticsearch.cli.Terminal;
 import org.elasticsearch.env.Environment;
-import org.elasticsearch.plugins.PluginInfo;
+import org.elasticsearch.plugins.PluginDescriptor;
 
 import java.util.Arrays;
 import java.util.List;
@@ -31,7 +31,7 @@ import java.util.stream.Collectors;
  * </ul>
  * <p>
  * Plugins are packaged as zip files. Each packaged plugin must contain a plugin properties file.
- * See {@link PluginInfo}.
+ * See {@link PluginDescriptor}.
  * <p>
  * The installation process first extracts the plugin files into a temporary
  * directory in order to verify the plugin satisfies the following requirements:
@@ -77,10 +77,10 @@ class InstallPluginCommand extends EnvironmentAwareCommand {
     protected void execute(Terminal terminal, OptionSet options, Environment env) throws Exception {
         SyncPluginsAction.ensureNoConfigFile(env);
 
-        List<PluginDescriptor> plugins = arguments.values(options)
+        List<InstallablePlugin> plugins = arguments.values(options)
             .stream()
             // We only have one piece of data, which could be an ID or could be a location, so we use it for both
-            .map(idOrLocation -> new PluginDescriptor(idOrLocation, idOrLocation))
+            .map(idOrLocation -> new InstallablePlugin(idOrLocation, idOrLocation))
             .collect(Collectors.toList());
         final boolean isBatch = options.has(batchOption);
 

--- a/distribution/tools/plugin-cli/src/main/java/org/elasticsearch/plugins/cli/InstallablePlugin.java
+++ b/distribution/tools/plugin-cli/src/main/java/org/elasticsearch/plugins/cli/InstallablePlugin.java
@@ -13,11 +13,11 @@ import java.util.Objects;
 /**
  * Models a single plugin that can be installed.
  */
-public class PluginDescriptor {
+public class InstallablePlugin {
     private String id;
     private String location;
 
-    public PluginDescriptor() {}
+    public InstallablePlugin() {}
 
     /**
      * Creates a new descriptor instance.
@@ -26,12 +26,12 @@ public class PluginDescriptor {
      * @param location the location from which to fetch the plugin, e.g. a URL or Maven
      *                 coordinates. Can be null for official plugins.
      */
-    public PluginDescriptor(String id, String location) {
+    public InstallablePlugin(String id, String location) {
         this.id = Objects.requireNonNull(id, "id cannot be null");
         this.location = location;
     }
 
-    public PluginDescriptor(String id) {
+    public InstallablePlugin(String id) {
         this(id, null);
     }
 
@@ -55,7 +55,7 @@ public class PluginDescriptor {
     public boolean equals(Object o) {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
-        PluginDescriptor that = (PluginDescriptor) o;
+        InstallablePlugin that = (InstallablePlugin) o;
         return id.equals(that.id) && Objects.equals(location, that.location);
     }
 

--- a/distribution/tools/plugin-cli/src/main/java/org/elasticsearch/plugins/cli/ListPluginsCommand.java
+++ b/distribution/tools/plugin-cli/src/main/java/org/elasticsearch/plugins/cli/ListPluginsCommand.java
@@ -14,7 +14,7 @@ import org.elasticsearch.Version;
 import org.elasticsearch.cli.EnvironmentAwareCommand;
 import org.elasticsearch.cli.Terminal;
 import org.elasticsearch.env.Environment;
-import org.elasticsearch.plugins.PluginInfo;
+import org.elasticsearch.plugins.PluginDescriptor;
 
 import java.io.IOException;
 import java.nio.file.DirectoryStream;
@@ -58,7 +58,7 @@ class ListPluginsCommand extends EnvironmentAwareCommand {
 
     private void printPlugin(Environment env, Terminal terminal, Path plugin, String prefix) throws IOException {
         terminal.println(Terminal.Verbosity.SILENT, prefix + plugin.getFileName().toString());
-        PluginInfo info = PluginInfo.readFromProperties(env.pluginsFile().resolve(plugin));
+        PluginDescriptor info = PluginDescriptor.readFromProperties(env.pluginsFile().resolve(plugin));
         terminal.println(Terminal.Verbosity.VERBOSE, info.toString(prefix));
         if (info.getElasticsearchVersion().equals(Version.CURRENT) == false) {
             terminal.errorPrintln(

--- a/distribution/tools/plugin-cli/src/main/java/org/elasticsearch/plugins/cli/PluginsConfig.java
+++ b/distribution/tools/plugin-cli/src/main/java/org/elasticsearch/plugins/cli/PluginsConfig.java
@@ -36,7 +36,7 @@ import static java.util.Collections.emptyList;
  * Elasticsearch plugin.
  */
 public class PluginsConfig {
-    private List<PluginDescriptor> plugins;
+    private List<InstallablePlugin> plugins;
     private String proxy;
 
     public PluginsConfig() {
@@ -44,7 +44,7 @@ public class PluginsConfig {
         proxy = null;
     }
 
-    public void setPlugins(List<PluginDescriptor> plugins) {
+    public void setPlugins(List<InstallablePlugin> plugins) {
         this.plugins = plugins == null ? emptyList() : plugins;
     }
 
@@ -55,7 +55,7 @@ public class PluginsConfig {
     /**
      * Validate this instance. For example:
      * <ul>
-     *     <li>All {@link PluginDescriptor}s must have IDs</li>
+     *     <li>All {@link InstallablePlugin}s must have IDs</li>
      *     <li>Any proxy must be well-formed.</li>
      *     <li>Unofficial plugins must have locations</li>
      * </ul>
@@ -69,13 +69,13 @@ public class PluginsConfig {
         }
 
         final Set<String> uniquePluginIds = new HashSet<>();
-        for (final PluginDescriptor plugin : plugins) {
+        for (final InstallablePlugin plugin : plugins) {
             if (uniquePluginIds.add(plugin.getId()) == false) {
                 throw new PluginSyncException("Duplicate plugin ID [" + plugin.getId() + "] found in [elasticsearch-plugins.yml]");
             }
         }
 
-        for (PluginDescriptor plugin : this.plugins) {
+        for (InstallablePlugin plugin : this.plugins) {
             if (officialPlugins.contains(plugin.getId()) == false && plugin.getLocation() == null) {
                 throw new PluginSyncException(
                     "Must specify location for non-official plugin [" + plugin.getId() + "] in [elasticsearch-plugins.yml]"
@@ -94,7 +94,7 @@ public class PluginsConfig {
             }
         }
 
-        for (PluginDescriptor p : plugins) {
+        for (InstallablePlugin p : plugins) {
             if (p.getLocation() != null) {
                 if (Strings.hasText(p.getLocation()) == false) {
                     throw new PluginSyncException("Empty location for plugin [" + p.getId() + "]");
@@ -110,7 +110,7 @@ public class PluginsConfig {
         }
     }
 
-    public List<PluginDescriptor> getPlugins() {
+    public List<InstallablePlugin> getPlugins() {
         return plugins;
     }
 
@@ -151,9 +151,9 @@ public class PluginsConfig {
         // Normally a parser is declared and built statically in the class, but we'll only
         // use this when starting up Elasticsearch, so there's no point keeping one around.
 
-        final ObjectParser<PluginDescriptor, Void> descriptorParser = new ObjectParser<>("descriptor parser", PluginDescriptor::new);
-        descriptorParser.declareString(PluginDescriptor::setId, new ParseField("id"));
-        descriptorParser.declareStringOrNull(PluginDescriptor::setLocation, new ParseField("location"));
+        final ObjectParser<InstallablePlugin, Void> descriptorParser = new ObjectParser<>("descriptor parser", InstallablePlugin::new);
+        descriptorParser.declareString(InstallablePlugin::setId, new ParseField("id"));
+        descriptorParser.declareStringOrNull(InstallablePlugin::setLocation, new ParseField("location"));
 
         final ObjectParser<PluginsConfig, Void> parser = new ObjectParser<>("plugins parser", PluginsConfig::new);
         parser.declareStringOrNull(PluginsConfig::setProxy, new ParseField("proxy"));
@@ -181,7 +181,7 @@ public class PluginsConfig {
 
         builder.startObject();
         builder.startArray("plugins");
-        for (PluginDescriptor p : config.getPlugins()) {
+        for (InstallablePlugin p : config.getPlugins()) {
             builder.startObject();
             {
                 builder.field("id", p.getId());

--- a/distribution/tools/plugin-cli/src/main/java/org/elasticsearch/plugins/cli/RemovePluginAction.java
+++ b/distribution/tools/plugin-cli/src/main/java/org/elasticsearch/plugins/cli/RemovePluginAction.java
@@ -70,29 +70,29 @@ public class RemovePluginAction {
      * @throws UserException if plugin directory does not exist
      * @throws UserException if the plugin bin directory is not a directory
      */
-    public void execute(List<PluginDescriptor> plugins) throws IOException, UserException {
+    public void execute(List<InstallablePlugin> plugins) throws IOException, UserException {
         if (plugins == null || plugins.isEmpty()) {
             throw new UserException(ExitCodes.USAGE, "At least one plugin ID is required");
         }
 
         ensurePluginsNotUsedByOtherPlugins(plugins);
 
-        for (PluginDescriptor plugin : plugins) {
+        for (InstallablePlugin plugin : plugins) {
             checkCanRemove(plugin);
         }
 
-        for (PluginDescriptor plugin : plugins) {
+        for (InstallablePlugin plugin : plugins) {
             removePlugin(plugin);
         }
     }
 
-    private void ensurePluginsNotUsedByOtherPlugins(List<PluginDescriptor> plugins) throws IOException, UserException {
+    private void ensurePluginsNotUsedByOtherPlugins(List<InstallablePlugin> plugins) throws IOException, UserException {
         // First make sure nothing extends this plugin
         final Map<String, List<String>> usedBy = new HashMap<>();
         Set<PluginsService.Bundle> bundles = PluginsService.getPluginBundles(env.pluginsFile());
         for (PluginsService.Bundle bundle : bundles) {
             for (String extendedPlugin : bundle.plugin.getExtendedPlugins()) {
-                for (PluginDescriptor plugin : plugins) {
+                for (InstallablePlugin plugin : plugins) {
                     String pluginId = plugin.getId();
                     if (extendedPlugin.equals(pluginId)) {
                         usedBy.computeIfAbsent(bundle.plugin.getName(), (_key -> new ArrayList<>())).add(pluginId);
@@ -114,7 +114,7 @@ public class RemovePluginAction {
         throw new UserException(PLUGIN_STILL_USED, message.toString());
     }
 
-    private void checkCanRemove(PluginDescriptor plugin) throws UserException {
+    private void checkCanRemove(InstallablePlugin plugin) throws UserException {
         String pluginId = plugin.getId();
         final Path pluginDir = env.pluginsFile().resolve(pluginId);
         final Path pluginConfigDir = env.configFile().resolve(pluginId);
@@ -143,7 +143,7 @@ public class RemovePluginAction {
         }
     }
 
-    private void removePlugin(PluginDescriptor plugin) throws IOException {
+    private void removePlugin(InstallablePlugin plugin) throws IOException {
         final String pluginId = plugin.getId();
         final Path pluginDir = env.pluginsFile().resolve(pluginId);
         final Path pluginConfigDir = env.configFile().resolve(pluginId);

--- a/distribution/tools/plugin-cli/src/main/java/org/elasticsearch/plugins/cli/RemovePluginCommand.java
+++ b/distribution/tools/plugin-cli/src/main/java/org/elasticsearch/plugins/cli/RemovePluginCommand.java
@@ -36,7 +36,7 @@ class RemovePluginCommand extends EnvironmentAwareCommand {
     protected void execute(final Terminal terminal, final OptionSet options, final Environment env) throws Exception {
         SyncPluginsAction.ensureNoConfigFile(env);
 
-        final List<PluginDescriptor> plugins = arguments.values(options).stream().map(PluginDescriptor::new).collect(Collectors.toList());
+        final List<InstallablePlugin> plugins = arguments.values(options).stream().map(InstallablePlugin::new).collect(Collectors.toList());
 
         final RemovePluginAction action = new RemovePluginAction(terminal, env, options.has(purgeOption));
         action.execute(plugins);

--- a/distribution/tools/plugin-cli/src/test/java/org/elasticsearch/plugins/cli/InstallLicensedPluginTests.java
+++ b/distribution/tools/plugin-cli/src/test/java/org/elasticsearch/plugins/cli/InstallLicensedPluginTests.java
@@ -13,7 +13,7 @@ import org.elasticsearch.Version;
 import org.elasticsearch.cli.ExitCodes;
 import org.elasticsearch.cli.MockTerminal;
 import org.elasticsearch.cli.UserException;
-import org.elasticsearch.plugins.PluginInfo;
+import org.elasticsearch.plugins.PluginDescriptor;
 import org.elasticsearch.plugins.PluginType;
 import org.elasticsearch.test.ESTestCase;
 
@@ -29,8 +29,8 @@ public class InstallLicensedPluginTests extends ESTestCase {
      */
     public void testUnlicensedPlugin() throws Exception {
         MockTerminal terminal = new MockTerminal();
-        PluginInfo pluginInfo = buildInfo(false);
-        InstallPluginAction.checkCanInstallationProceed(terminal, Build.Flavor.OSS, pluginInfo);
+        PluginDescriptor pluginDescriptor = buildInfo(false);
+        InstallPluginAction.checkCanInstallationProceed(terminal, Build.Flavor.OSS, pluginDescriptor);
     }
 
     /**
@@ -38,10 +38,10 @@ public class InstallLicensedPluginTests extends ESTestCase {
      */
     public void testInstallPluginActionOnOss() throws Exception {
         MockTerminal terminal = new MockTerminal();
-        PluginInfo pluginInfo = buildInfo(true);
+        PluginDescriptor pluginDescriptor = buildInfo(true);
         final UserException userException = expectThrows(
             UserException.class,
-            () -> InstallPluginAction.checkCanInstallationProceed(terminal, Build.Flavor.OSS, pluginInfo)
+            () -> InstallPluginAction.checkCanInstallationProceed(terminal, Build.Flavor.OSS, pluginDescriptor)
         );
 
         assertThat(userException.exitCode, equalTo(ExitCodes.NOPERM));
@@ -53,10 +53,10 @@ public class InstallLicensedPluginTests extends ESTestCase {
      */
     public void testInstallPluginActionOnUnknownDistribution() throws Exception {
         MockTerminal terminal = new MockTerminal();
-        PluginInfo pluginInfo = buildInfo(true);
+        PluginDescriptor pluginDescriptor = buildInfo(true);
         expectThrows(
             UserException.class,
-            () -> InstallPluginAction.checkCanInstallationProceed(terminal, Build.Flavor.UNKNOWN, pluginInfo)
+            () -> InstallPluginAction.checkCanInstallationProceed(terminal, Build.Flavor.UNKNOWN, pluginDescriptor)
         );
         assertThat(terminal.getErrorOutput(), containsString("ERROR: This is a licensed plugin"));
     }
@@ -66,12 +66,12 @@ public class InstallLicensedPluginTests extends ESTestCase {
      */
     public void testInstallPluginActionOnDefault() throws Exception {
         MockTerminal terminal = new MockTerminal();
-        PluginInfo pluginInfo = buildInfo(true);
-        InstallPluginAction.checkCanInstallationProceed(terminal, Build.Flavor.DEFAULT, pluginInfo);
+        PluginDescriptor pluginDescriptor = buildInfo(true);
+        InstallPluginAction.checkCanInstallationProceed(terminal, Build.Flavor.DEFAULT, pluginDescriptor);
     }
 
-    private PluginInfo buildInfo(boolean isLicensed) {
-        return new PluginInfo(
+    private PluginDescriptor buildInfo(boolean isLicensed) {
+        return new PluginDescriptor(
             "name",
             "description",
             "version",

--- a/distribution/tools/plugin-cli/src/test/java/org/elasticsearch/plugins/cli/InstallPluginActionTests.java
+++ b/distribution/tools/plugin-cli/src/test/java/org/elasticsearch/plugins/cli/InstallPluginActionTests.java
@@ -47,7 +47,7 @@ import org.elasticsearch.core.Tuple;
 import org.elasticsearch.env.Environment;
 import org.elasticsearch.env.TestEnvironment;
 import org.elasticsearch.plugins.Platforms;
-import org.elasticsearch.plugins.PluginInfo;
+import org.elasticsearch.plugins.PluginDescriptor;
 import org.elasticsearch.plugins.PluginTestUtil;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.PosixPermissionsResetter;
@@ -142,7 +142,7 @@ public class InstallPluginActionTests extends ESTestCase {
         env = createEnv(temp);
         skipJarHellAction = new InstallPluginAction(terminal, null, false) {
             @Override
-            void jarHellCheck(PluginInfo candidateInfo, Path candidate, Path pluginsDir, Path modulesDir) {
+            void jarHellCheck(PluginDescriptor candidateInfo, Path candidate, Path pluginsDir, Path modulesDir) {
                 // no jarhell check
             }
         };
@@ -232,7 +232,7 @@ public class InstallPluginActionTests extends ESTestCase {
     }
 
     /** creates a plugin .zip and returns the url for testing */
-    static PluginDescriptor createPluginZip(String name, Path structure, String... additionalProps) throws IOException {
+    static InstallablePlugin createPluginZip(String name, Path structure, String... additionalProps) throws IOException {
         return createPlugin(name, structure, additionalProps);
     }
 
@@ -270,29 +270,29 @@ public class InstallPluginActionTests extends ESTestCase {
         Files.write(pluginDir.resolve("plugin-security.policy"), securityPolicyContent.toString().getBytes(StandardCharsets.UTF_8));
     }
 
-    static PluginDescriptor createPlugin(String name, Path structure, String... additionalProps) throws IOException {
+    static InstallablePlugin createPlugin(String name, Path structure, String... additionalProps) throws IOException {
         writePlugin(name, structure, additionalProps);
-        return new PluginDescriptor(name, writeZip(structure, null).toUri().toURL().toString());
+        return new InstallablePlugin(name, writeZip(structure, null).toUri().toURL().toString());
     }
 
     void installPlugin(String id) throws Exception {
-        PluginDescriptor plugin = id == null ? null : new PluginDescriptor(id, id);
+        InstallablePlugin plugin = id == null ? null : new InstallablePlugin(id, id);
         installPlugin(plugin, env.v1(), skipJarHellAction);
     }
 
-    void installPlugin(PluginDescriptor plugin) throws Exception {
+    void installPlugin(InstallablePlugin plugin) throws Exception {
         installPlugin(plugin, env.v1(), skipJarHellAction);
     }
 
-    void installPlugins(final List<PluginDescriptor> plugins, final Path home) throws Exception {
+    void installPlugins(final List<InstallablePlugin> plugins, final Path home) throws Exception {
         installPlugins(plugins, home, skipJarHellAction);
     }
 
-    void installPlugin(PluginDescriptor plugin, Path home, InstallPluginAction action) throws Exception {
+    void installPlugin(InstallablePlugin plugin, Path home, InstallPluginAction action) throws Exception {
         installPlugins(plugin == null ? Collections.emptyList() : Collections.singletonList(plugin), home, action);
     }
 
-    void installPlugins(final List<PluginDescriptor> plugins, final Path home, final InstallPluginAction action) throws Exception {
+    void installPlugins(final List<InstallablePlugin> plugins, final Path home, final InstallPluginAction action) throws Exception {
         final Environment environment = TestEnvironment.newEnvironment(Settings.builder().put("path.home", home).build());
         action.setEnvironment(environment);
         action.execute(plugins);
@@ -401,28 +401,28 @@ public class InstallPluginActionTests extends ESTestCase {
     }
 
     public void testSomethingWorks() throws Exception {
-        PluginDescriptor pluginZip = createPluginZip("fake", pluginDir);
+        InstallablePlugin pluginZip = createPluginZip("fake", pluginDir);
         installPlugin(pluginZip);
         assertPlugin("fake", pluginDir, env.v2());
     }
 
     public void testMultipleWorks() throws Exception {
-        PluginDescriptor fake1PluginZip = createPluginZip("fake1", pluginDir);
-        PluginDescriptor fake2PluginZip = createPluginZip("fake2", pluginDir);
+        InstallablePlugin fake1PluginZip = createPluginZip("fake1", pluginDir);
+        InstallablePlugin fake2PluginZip = createPluginZip("fake2", pluginDir);
         installPlugins(Arrays.asList(fake1PluginZip, fake2PluginZip), env.v1());
         assertPlugin("fake1", pluginDir, env.v2());
         assertPlugin("fake2", pluginDir, env.v2());
     }
 
     public void testDuplicateInstall() throws Exception {
-        PluginDescriptor pluginZip = createPluginZip("fake", pluginDir);
+        InstallablePlugin pluginZip = createPluginZip("fake", pluginDir);
         final UserException e = expectThrows(UserException.class, () -> installPlugins(Arrays.asList(pluginZip, pluginZip), env.v1()));
         assertThat(e.getMessage(), equalTo("duplicate plugin id [" + pluginZip.getId() + "]"));
     }
 
     public void testTransaction() throws Exception {
-        PluginDescriptor pluginZip = createPluginZip("fake", pluginDir);
-        PluginDescriptor nonexistentPluginZip = new PluginDescriptor(
+        InstallablePlugin pluginZip = createPluginZip("fake", pluginDir);
+        InstallablePlugin nonexistentPluginZip = new InstallablePlugin(
             pluginZip.getId() + "-does-not-exist",
             pluginZip.getLocation() + "-does-not-exist"
         );
@@ -438,7 +438,7 @@ public class InstallPluginActionTests extends ESTestCase {
     }
 
     public void testInstallFailsIfPreviouslyRemovedPluginFailed() throws Exception {
-        PluginDescriptor pluginZip = createPluginZip("fake", pluginDir);
+        InstallablePlugin pluginZip = createPluginZip("fake", pluginDir);
         final Path removing = env.v2().pluginsFile().resolve(".removing-failed");
         Files.createDirectory(removing);
         final IllegalStateException e = expectThrows(IllegalStateException.class, () -> installPlugin(pluginZip));
@@ -451,19 +451,19 @@ public class InstallPluginActionTests extends ESTestCase {
     }
 
     public void testSpaceInUrl() throws Exception {
-        PluginDescriptor pluginZip = createPluginZip("fake", pluginDir);
+        InstallablePlugin pluginZip = createPluginZip("fake", pluginDir);
         Path pluginZipWithSpaces = createTempFile("foo bar", ".zip");
         try (InputStream in = FileSystemUtils.openFileURLStream(new URL(pluginZip.getLocation()))) {
             Files.copy(in, pluginZipWithSpaces, StandardCopyOption.REPLACE_EXISTING);
         }
-        PluginDescriptor modifiedPlugin = new PluginDescriptor("fake", pluginZipWithSpaces.toUri().toURL().toString());
+        InstallablePlugin modifiedPlugin = new InstallablePlugin("fake", pluginZipWithSpaces.toUri().toURL().toString());
         installPlugin(modifiedPlugin);
         assertPlugin("fake", pluginDir, env.v2());
     }
 
     public void testMalformedUrlNotMaven() {
         // has two colons, so it appears similar to maven coordinates
-        PluginDescriptor plugin = new PluginDescriptor("fake", "://host:1234");
+        InstallablePlugin plugin = new InstallablePlugin("fake", "://host:1234");
         MalformedURLException e = expectThrows(MalformedURLException.class, () -> installPlugin(plugin));
         assertThat(e.getMessage(), containsString("no protocol"));
     }
@@ -488,7 +488,7 @@ public class InstallPluginActionTests extends ESTestCase {
         assumeTrue("posix and filesystem", isPosix && isReal);
         try (PosixPermissionsResetter pluginsAttrs = new PosixPermissionsResetter(env.v2().pluginsFile())) {
             pluginsAttrs.setPermissions(new HashSet<>());
-            PluginDescriptor pluginZip = createPluginZip("fake", pluginDir);
+            InstallablePlugin pluginZip = createPluginZip("fake", pluginDir);
             IOException e = expectThrows(IOException.class, () -> installPlugin(pluginZip));
             assertThat(e.getMessage(), containsString(env.v2().pluginsFile().toString()));
         }
@@ -496,14 +496,14 @@ public class InstallPluginActionTests extends ESTestCase {
     }
 
     public void testBuiltinModule() throws Exception {
-        PluginDescriptor pluginZip = createPluginZip("lang-painless", pluginDir);
+        InstallablePlugin pluginZip = createPluginZip("lang-painless", pluginDir);
         UserException e = expectThrows(UserException.class, () -> installPlugin(pluginZip));
         assertThat(e.getMessage(), containsString("is a system module"));
         assertInstallCleaned(env.v2());
     }
 
     public void testBuiltinXpackModule() throws Exception {
-        PluginDescriptor pluginZip = createPluginZip("x-pack", pluginDir);
+        InstallablePlugin pluginZip = createPluginZip("x-pack", pluginDir);
         // There is separate handling for installing "x-pack", versus installing a plugin
         // whose descriptor contains the name "x-pack".
         pluginZip.setId("not-x-pack");
@@ -517,7 +517,7 @@ public class InstallPluginActionTests extends ESTestCase {
         assumeTrue("real filesystem", isReal);
         Path pluginDirectory = createPluginDir(temp);
         writeJar(pluginDirectory.resolve("other.jar"), "FakePlugin");
-        PluginDescriptor pluginZip = createPluginZip("fake", pluginDirectory); // adds plugin.jar with FakePlugin
+        InstallablePlugin pluginZip = createPluginZip("fake", pluginDirectory); // adds plugin.jar with FakePlugin
         IllegalStateException e = expectThrows(IllegalStateException.class, () -> installPlugin(pluginZip, env.v1(), defaultAction));
         assertThat(e.getMessage(), containsString("jar hell"));
         assertInstallCleaned(env.v2());
@@ -526,17 +526,17 @@ public class InstallPluginActionTests extends ESTestCase {
     public void testIsolatedPlugins() throws Exception {
         // these both share the same FakePlugin class
         Path pluginDir1 = createPluginDir(temp);
-        PluginDescriptor pluginZip1 = createPluginZip("fake1", pluginDir1);
+        InstallablePlugin pluginZip1 = createPluginZip("fake1", pluginDir1);
         installPlugin(pluginZip1);
         Path pluginDir2 = createPluginDir(temp);
-        PluginDescriptor pluginZip2 = createPluginZip("fake2", pluginDir2);
+        InstallablePlugin pluginZip2 = createPluginZip("fake2", pluginDir2);
         installPlugin(pluginZip2);
         assertPlugin("fake1", pluginDir1, env.v2());
         assertPlugin("fake2", pluginDir2, env.v2());
     }
 
     public void testExistingPlugin() throws Exception {
-        PluginDescriptor pluginZip = createPluginZip("fake", pluginDir);
+        InstallablePlugin pluginZip = createPluginZip("fake", pluginDir);
         installPlugin(pluginZip);
         UserException e = expectThrows(UserException.class, () -> installPlugin(pluginZip));
         assertThat(e.getMessage(), containsString("already exists"));
@@ -547,7 +547,7 @@ public class InstallPluginActionTests extends ESTestCase {
         Path binDir = pluginDir.resolve("bin");
         Files.createDirectory(binDir);
         Files.createFile(binDir.resolve("somescript"));
-        PluginDescriptor pluginZip = createPluginZip("fake", pluginDir);
+        InstallablePlugin pluginZip = createPluginZip("fake", pluginDir);
         installPlugin(pluginZip);
         assertPlugin("fake", pluginDir, env.v2());
     }
@@ -555,7 +555,7 @@ public class InstallPluginActionTests extends ESTestCase {
     public void testBinNotDir() throws Exception {
         Path binDir = pluginDir.resolve("bin");
         Files.createFile(binDir);
-        PluginDescriptor pluginZip = createPluginZip("fake", pluginDir);
+        InstallablePlugin pluginZip = createPluginZip("fake", pluginDir);
         UserException e = expectThrows(UserException.class, () -> installPlugin(pluginZip));
         assertThat(e.getMessage(), containsString("not a directory"));
         assertInstallCleaned(env.v2());
@@ -565,7 +565,7 @@ public class InstallPluginActionTests extends ESTestCase {
         Path dirInBinDir = pluginDir.resolve("bin").resolve("foo");
         Files.createDirectories(dirInBinDir);
         Files.createFile(dirInBinDir.resolve("somescript"));
-        PluginDescriptor pluginZip = createPluginZip("fake", pluginDir);
+        InstallablePlugin pluginZip = createPluginZip("fake", pluginDir);
         UserException e = expectThrows(UserException.class, () -> installPlugin(pluginZip));
         assertThat(e.getMessage(), containsString("Directories not allowed in bin dir for plugin"));
         assertInstallCleaned(env.v2());
@@ -575,7 +575,7 @@ public class InstallPluginActionTests extends ESTestCase {
         Path binDir = pluginDir.resolve("bin");
         Files.createDirectory(binDir);
         Files.createFile(binDir.resolve("somescript"));
-        PluginDescriptor pluginZip = createPluginZip("elasticsearch", pluginDir);
+        InstallablePlugin pluginZip = createPluginZip("elasticsearch", pluginDir);
         FileAlreadyExistsException e = expectThrows(FileAlreadyExistsException.class, () -> installPlugin(pluginZip));
         assertThat(e.getMessage(), containsString(env.v2().binFile().resolve("elasticsearch").toString()));
         assertInstallCleaned(env.v2());
@@ -586,7 +586,7 @@ public class InstallPluginActionTests extends ESTestCase {
         Path binDir = pluginDir.resolve("bin");
         Files.createDirectory(binDir);
         Files.createFile(binDir.resolve("somescript"));
-        PluginDescriptor pluginZip = createPluginZip("fake", pluginDir);
+        InstallablePlugin pluginZip = createPluginZip("fake", pluginDir);
         try (PosixPermissionsResetter binAttrs = new PosixPermissionsResetter(env.v2().binFile())) {
             Set<PosixFilePermission> perms = binAttrs.getCopyPermissions();
             // make sure at least one execute perm is missing, so we know we forced it during installation
@@ -612,7 +612,7 @@ public class InstallPluginActionTests extends ESTestCase {
         Files.createDirectory(resourcesDir);
         Files.createFile(resourcesDir.resolve("resource"));
 
-        final PluginDescriptor pluginZip = createPluginZip("fake", tempPluginDir);
+        final InstallablePlugin pluginZip = createPluginZip("fake", tempPluginDir);
 
         installPlugin(pluginZip);
         assertPlugin("fake", tempPluginDir, env.v2());
@@ -661,7 +661,7 @@ public class InstallPluginActionTests extends ESTestCase {
         Path configDir = pluginDir.resolve("config");
         Files.createDirectory(configDir);
         Files.createFile(configDir.resolve("custom.yml"));
-        PluginDescriptor pluginZip = createPluginZip("fake", pluginDir);
+        InstallablePlugin pluginZip = createPluginZip("fake", pluginDir);
         installPlugin(pluginZip);
         assertPlugin("fake", pluginDir, env.v2());
     }
@@ -674,7 +674,7 @@ public class InstallPluginActionTests extends ESTestCase {
         Files.createDirectory(configDir);
         Files.write(configDir.resolve("custom.yml"), "new config".getBytes(StandardCharsets.UTF_8));
         Files.createFile(configDir.resolve("other.yml"));
-        PluginDescriptor pluginZip = createPluginZip("fake", pluginDir);
+        InstallablePlugin pluginZip = createPluginZip("fake", pluginDir);
         installPlugin(pluginZip);
         assertPlugin("fake", pluginDir, env.v2());
         List<String> configLines = Files.readAllLines(envConfigDir.resolve("custom.yml"), StandardCharsets.UTF_8);
@@ -687,7 +687,7 @@ public class InstallPluginActionTests extends ESTestCase {
         Files.createDirectories(pluginDir);
         Path configDir = pluginDir.resolve("config");
         Files.createFile(configDir);
-        PluginDescriptor pluginZip = createPluginZip("fake", pluginDir);
+        InstallablePlugin pluginZip = createPluginZip("fake", pluginDir);
         UserException e = expectThrows(UserException.class, () -> installPlugin(pluginZip));
         assertThat(e.getMessage(), containsString("not a directory"));
         assertInstallCleaned(env.v2());
@@ -697,7 +697,7 @@ public class InstallPluginActionTests extends ESTestCase {
         Path dirInConfigDir = pluginDir.resolve("config").resolve("foo");
         Files.createDirectories(dirInConfigDir);
         Files.createFile(dirInConfigDir.resolve("myconfig.yml"));
-        PluginDescriptor pluginZip = createPluginZip("fake", pluginDir);
+        InstallablePlugin pluginZip = createPluginZip("fake", pluginDir);
         UserException e = expectThrows(UserException.class, () -> installPlugin(pluginZip));
         assertThat(e.getMessage(), containsString("Directories not allowed in config dir for plugin"));
         assertInstallCleaned(env.v2());
@@ -712,7 +712,7 @@ public class InstallPluginActionTests extends ESTestCase {
     }
 
     public void testContainsIntermediateDirectory() throws Exception {
-        Files.createFile(pluginDir.resolve(PluginInfo.ES_PLUGIN_PROPERTIES));
+        Files.createFile(pluginDir.resolve(PluginDescriptor.ES_PLUGIN_PROPERTIES));
         String pluginZip = writeZip(pluginDir, "elasticsearch").toUri().toURL().toString();
         UserException e = expectThrows(UserException.class, () -> installPlugin(pluginZip));
         assertThat(e.getMessage(), containsString("This plugin was built with an older plugin structure"));
@@ -775,7 +775,7 @@ public class InstallPluginActionTests extends ESTestCase {
                 return flavor;
             }
         };
-        final T exception = expectThrows(clazz, () -> flavorAction.execute(Collections.singletonList(new PluginDescriptor("x-pack"))));
+        final T exception = expectThrows(clazz, () -> flavorAction.execute(Collections.singletonList(new InstallablePlugin("x-pack"))));
         assertThat(exception.getMessage(), containsString(expectedMessage));
     }
 
@@ -811,7 +811,7 @@ public class InstallPluginActionTests extends ESTestCase {
     }
 
     public void testPluginAlreadyInstalled() throws Exception {
-        PluginDescriptor pluginZip = createPluginZip("fake", pluginDir);
+        InstallablePlugin pluginZip = createPluginZip("fake", pluginDir);
         installPlugin(pluginZip);
         final UserException e = expectThrows(
             UserException.class,
@@ -833,8 +833,8 @@ public class InstallPluginActionTests extends ESTestCase {
      * the ID actually is from the plugin's properties, then the installation fails.
      */
     public void testPluginHasDifferentNameThatDescriptor() throws Exception {
-        PluginDescriptor descriptor = createPluginZip("fake", pluginDir);
-        PluginDescriptor modifiedDescriptor = new PluginDescriptor("other-fake", descriptor.getLocation());
+        InstallablePlugin descriptor = createPluginZip("fake", pluginDir);
+        InstallablePlugin modifiedDescriptor = new InstallablePlugin("other-fake", descriptor.getLocation());
 
         final UserException e = expectThrows(UserException.class, () -> installPlugin(modifiedDescriptor));
         assertThat(e.getMessage(), equalTo("Expected downloaded plugin to have ID [other-fake] but found [fake]"));
@@ -845,7 +845,7 @@ public class InstallPluginActionTests extends ESTestCase {
         if (isBatch) {
             writePluginSecurityPolicy(pluginDir, "setFactory");
         }
-        PluginDescriptor pluginZip = createPlugin("fake", pluginDir, additionalProperties);
+        InstallablePlugin pluginZip = createPlugin("fake", pluginDir, additionalProperties);
         skipJarHellAction.setEnvironment(env.v2());
         skipJarHellAction.setBatch(isBatch);
         skipJarHellAction.execute(Collections.singletonList(pluginZip));
@@ -889,7 +889,7 @@ public class InstallPluginActionTests extends ESTestCase {
         final PGPSecretKey secretKey,
         final BiFunction<byte[], PGPSecretKey, String> signature
     ) throws Exception {
-        PluginDescriptor pluginZip = createPlugin(pluginId, pluginDir);
+        InstallablePlugin pluginZip = createPlugin(pluginId, pluginDir);
         Path pluginZipPath = Paths.get(URI.create(pluginZip.getLocation()));
         InstallPluginAction action = new InstallPluginAction(terminal, env.v2(), false) {
             @Override
@@ -967,11 +967,11 @@ public class InstallPluginActionTests extends ESTestCase {
             }
 
             @Override
-            void jarHellCheck(PluginInfo candidateInfo, Path candidate, Path pluginsDir, Path modulesDir) {
+            void jarHellCheck(PluginDescriptor candidateInfo, Path candidate, Path pluginsDir, Path modulesDir) {
                 // no jarhell check
             }
         };
-        installPlugin(new PluginDescriptor(pluginId, pluginUrl), env.v1(), action);
+        installPlugin(new InstallablePlugin(pluginId, pluginUrl), env.v1(), action);
         assertPlugin(pluginId, pluginDir, env.v2());
     }
 
@@ -1362,7 +1362,7 @@ public class InstallPluginActionTests extends ESTestCase {
 
     // checks the plugin requires a policy confirmation, and does not install when that is rejected by the user
     // the plugin is installed after this method completes
-    private void assertPolicyConfirmation(Tuple<Path, Environment> pathEnvironmentTuple, PluginDescriptor pluginZip, String... warnings)
+    private void assertPolicyConfirmation(Tuple<Path, Environment> pathEnvironmentTuple, InstallablePlugin pluginZip, String... warnings)
         throws Exception {
         for (int i = 0; i < warnings.length; ++i) {
             String warning = warnings[i];
@@ -1406,14 +1406,14 @@ public class InstallPluginActionTests extends ESTestCase {
 
     public void testPolicyConfirmation() throws Exception {
         writePluginSecurityPolicy(pluginDir, "createClassLoader", "setFactory");
-        PluginDescriptor pluginZip = createPluginZip("fake", pluginDir);
+        InstallablePlugin pluginZip = createPluginZip("fake", pluginDir);
 
         assertPolicyConfirmation(env, pluginZip, "plugin requires additional permissions");
         assertPlugin("fake", pluginDir, env.v2());
     }
 
     public void testPluginWithNativeController() throws Exception {
-        PluginDescriptor pluginZip = createPluginZip("fake", pluginDir, "has.native.controller", "true");
+        InstallablePlugin pluginZip = createPluginZip("fake", pluginDir, "has.native.controller", "true");
 
         final IllegalStateException e = expectThrows(IllegalStateException.class, () -> installPlugin(pluginZip));
         assertThat(e.getMessage(), containsString("plugins can not have native controllers"));
@@ -1422,7 +1422,7 @@ public class InstallPluginActionTests extends ESTestCase {
     public void testMultipleJars() throws Exception {
         writeJar(pluginDir.resolve("dep1.jar"), "Dep1");
         writeJar(pluginDir.resolve("dep2.jar"), "Dep2");
-        PluginDescriptor pluginZip = createPluginZip("fake-with-deps", pluginDir);
+        InstallablePlugin pluginZip = createPluginZip("fake-with-deps", pluginDir);
         installPlugin(pluginZip);
         assertPlugin("fake-with-deps", pluginDir, env.v2());
     }

--- a/distribution/tools/plugin-cli/src/test/java/org/elasticsearch/plugins/cli/ListPluginsCommandTests.java
+++ b/distribution/tools/plugin-cli/src/test/java/org/elasticsearch/plugins/cli/ListPluginsCommandTests.java
@@ -16,7 +16,7 @@ import org.elasticsearch.cli.UserException;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.env.Environment;
 import org.elasticsearch.env.TestEnvironment;
-import org.elasticsearch.plugins.PluginInfo;
+import org.elasticsearch.plugins.PluginDescriptor;
 import org.elasticsearch.plugins.PluginTestUtil;
 import org.elasticsearch.test.ESTestCase;
 import org.junit.Before;
@@ -227,14 +227,14 @@ public class ListPluginsCommandTests extends ESTestCase {
         final Path pluginDir = env.pluginsFile().resolve("fake1");
         Files.createDirectories(pluginDir);
         NoSuchFileException e = expectThrows(NoSuchFileException.class, () -> listPlugins(home));
-        assertEquals(pluginDir.resolve(PluginInfo.ES_PLUGIN_PROPERTIES).toString(), e.getFile());
+        assertEquals(pluginDir.resolve(PluginDescriptor.ES_PLUGIN_PROPERTIES).toString(), e.getFile());
     }
 
     public void testPluginWithWrongDescriptorFile() throws Exception {
         final Path pluginDir = env.pluginsFile().resolve("fake1");
         PluginTestUtil.writePluginProperties(pluginDir, "description", "fake desc");
         IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> listPlugins(home));
-        final Path descriptorPath = pluginDir.resolve(PluginInfo.ES_PLUGIN_PROPERTIES);
+        final Path descriptorPath = pluginDir.resolve(PluginDescriptor.ES_PLUGIN_PROPERTIES);
         assertEquals("property [name] is missing in [" + descriptorPath.toString() + "]", e.getMessage());
     }
 

--- a/distribution/tools/plugin-cli/src/test/java/org/elasticsearch/plugins/cli/RemovePluginActionTests.java
+++ b/distribution/tools/plugin-cli/src/test/java/org/elasticsearch/plugins/cli/RemovePluginActionTests.java
@@ -88,9 +88,9 @@ public class RemovePluginActionTests extends ESTestCase {
     static MockTerminal removePlugin(List<String> pluginIds, Path home, boolean purge) throws Exception {
         Environment env = TestEnvironment.newEnvironment(Settings.builder().put("path.home", home).build());
         MockTerminal terminal = new MockTerminal();
-        final List<PluginDescriptor> plugins = pluginIds == null
+        final List<InstallablePlugin> plugins = pluginIds == null
             ? null
-            : pluginIds.stream().map(PluginDescriptor::new).collect(Collectors.toList());
+            : pluginIds.stream().map(InstallablePlugin::new).collect(Collectors.toList());
         new RemovePluginAction(terminal, env, purge).execute(plugins);
         return terminal;
     }

--- a/qa/evil-tests/src/test/java/org/elasticsearch/bootstrap/PolicyUtilTests.java
+++ b/qa/evil-tests/src/test/java/org/elasticsearch/bootstrap/PolicyUtilTests.java
@@ -9,7 +9,7 @@
 package org.elasticsearch.bootstrap;
 
 import org.elasticsearch.core.SuppressForbidden;
-import org.elasticsearch.plugins.PluginInfo;
+import org.elasticsearch.plugins.PluginDescriptor;
 import org.elasticsearch.test.ESTestCase;
 import org.junit.Before;
 
@@ -55,7 +55,7 @@ public class PolicyUtilTests extends ESTestCase {
 
     Path makeDummyPlugin(String policy, String... files) throws IOException {
         Path plugin = createTempDir();
-        Files.copy(this.getDataPath(policy), plugin.resolve(PluginInfo.ES_PLUGIN_POLICY));
+        Files.copy(this.getDataPath(policy), plugin.resolve(PluginDescriptor.ES_PLUGIN_POLICY));
         for (String file : files) {
             Files.createFile(plugin.resolve(file));
         }
@@ -107,7 +107,7 @@ public class PolicyUtilTests extends ESTestCase {
 
     public void testPolicyMissingCodebaseProperty() throws Exception {
         Path plugin = makeDummyPlugin("missing-codebase.policy", "foo.jar");
-        URL policyFile = plugin.resolve(PluginInfo.ES_PLUGIN_POLICY).toUri().toURL();
+        URL policyFile = plugin.resolve(PluginDescriptor.ES_PLUGIN_POLICY).toUri().toURL();
         IllegalArgumentException e = expectThrows(
             IllegalArgumentException.class,
             () -> PolicyUtil.readPolicy(policyFile, Collections.emptyMap())
@@ -121,7 +121,7 @@ public class PolicyUtilTests extends ESTestCase {
         try {
             URL jarUrl = plugin.resolve("foo.jar").toUri().toURL();
             setProperty("jarUrl", jarUrl.toString());
-            URL policyFile = plugin.resolve(PluginInfo.ES_PLUGIN_POLICY).toUri().toURL();
+            URL policyFile = plugin.resolve(PluginDescriptor.ES_PLUGIN_POLICY).toUri().toURL();
             Policy policy = Policy.getInstance("JavaPolicy", new URIParameter(policyFile.toURI()));
 
             Set<Permission> globalPermissions = PolicyUtil.getPolicyPermissions(null, policy, tmpDir);
@@ -152,7 +152,7 @@ public class PolicyUtilTests extends ESTestCase {
         policyString.append(";\n};");
 
         logger.info(policyString.toString());
-        Files.write(plugin.resolve(PluginInfo.ES_PLUGIN_POLICY), policyString.toString().getBytes(StandardCharsets.UTF_8));
+        Files.write(plugin.resolve(PluginDescriptor.ES_PLUGIN_POLICY), policyString.toString().getBytes(StandardCharsets.UTF_8));
 
         return plugin;
     }

--- a/qa/evil-tests/src/test/java/org/elasticsearch/plugins/cli/PluginSecurityTests.java
+++ b/qa/evil-tests/src/test/java/org/elasticsearch/plugins/cli/PluginSecurityTests.java
@@ -10,7 +10,7 @@ package org.elasticsearch.plugins.cli;
 
 import org.elasticsearch.bootstrap.PluginPolicyInfo;
 import org.elasticsearch.bootstrap.PolicyUtil;
-import org.elasticsearch.plugins.PluginInfo;
+import org.elasticsearch.plugins.PluginDescriptor;
 import org.elasticsearch.test.ESTestCase;
 
 import java.io.IOException;
@@ -27,7 +27,7 @@ public class PluginSecurityTests extends ESTestCase {
 
     PluginPolicyInfo makeDummyPlugin(String policy, String... files) throws IOException {
         Path plugin = createTempDir();
-        Files.copy(this.getDataPath(policy), plugin.resolve(PluginInfo.ES_PLUGIN_POLICY));
+        Files.copy(this.getDataPath(policy), plugin.resolve(PluginDescriptor.ES_PLUGIN_POLICY));
         for (String file : files) {
             Files.createFile(plugin.resolve(file));
         }

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/node/info/PluginsAndModules.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/node/info/PluginsAndModules.java
@@ -11,7 +11,7 @@ package org.elasticsearch.action.admin.cluster.node.info;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.node.ReportingService;
-import org.elasticsearch.plugins.PluginInfo;
+import org.elasticsearch.plugins.PluginDescriptor;
 import org.elasticsearch.xcontent.XContentBuilder;
 
 import java.io.IOException;
@@ -24,17 +24,17 @@ import java.util.List;
  * Information about plugins and modules
  */
 public class PluginsAndModules implements ReportingService.Info {
-    private final List<PluginInfo> plugins;
-    private final List<PluginInfo> modules;
+    private final List<PluginDescriptor> plugins;
+    private final List<PluginDescriptor> modules;
 
-    public PluginsAndModules(List<PluginInfo> plugins, List<PluginInfo> modules) {
+    public PluginsAndModules(List<PluginDescriptor> plugins, List<PluginDescriptor> modules) {
         this.plugins = Collections.unmodifiableList(plugins);
         this.modules = Collections.unmodifiableList(modules);
     }
 
     public PluginsAndModules(StreamInput in) throws IOException {
-        this.plugins = Collections.unmodifiableList(in.readList(PluginInfo::new));
-        this.modules = Collections.unmodifiableList(in.readList(PluginInfo::new));
+        this.plugins = Collections.unmodifiableList(in.readList(PluginDescriptor::new));
+        this.modules = Collections.unmodifiableList(in.readList(PluginDescriptor::new));
     }
 
     @Override
@@ -46,39 +46,39 @@ public class PluginsAndModules implements ReportingService.Info {
     /**
      * Returns an ordered list based on plugins name
      */
-    public List<PluginInfo> getPluginInfos() {
-        List<PluginInfo> plugins = new ArrayList<>(this.plugins);
-        Collections.sort(plugins, Comparator.comparing(PluginInfo::getName));
+    public List<PluginDescriptor> getPluginInfos() {
+        List<PluginDescriptor> plugins = new ArrayList<>(this.plugins);
+        Collections.sort(plugins, Comparator.comparing(PluginDescriptor::getName));
         return plugins;
     }
 
     /**
      * Returns an ordered list based on modules name
      */
-    public List<PluginInfo> getModuleInfos() {
-        List<PluginInfo> modules = new ArrayList<>(this.modules);
-        Collections.sort(modules, Comparator.comparing(PluginInfo::getName));
+    public List<PluginDescriptor> getModuleInfos() {
+        List<PluginDescriptor> modules = new ArrayList<>(this.modules);
+        Collections.sort(modules, Comparator.comparing(PluginDescriptor::getName));
         return modules;
     }
 
-    public void addPlugin(PluginInfo info) {
+    public void addPlugin(PluginDescriptor info) {
         plugins.add(info);
     }
 
-    public void addModule(PluginInfo info) {
+    public void addModule(PluginDescriptor info) {
         modules.add(info);
     }
 
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
         builder.startArray("plugins");
-        for (PluginInfo pluginInfo : getPluginInfos()) {
-            pluginInfo.toXContent(builder, params);
+        for (PluginDescriptor pluginDescriptor : getPluginInfos()) {
+            pluginDescriptor.toXContent(builder, params);
         }
         builder.endArray();
         // TODO: not ideal, make a better api for this (e.g. with jar metadata, and so on)
         builder.startArray("modules");
-        for (PluginInfo moduleInfo : getModuleInfos()) {
+        for (PluginDescriptor moduleInfo : getModuleInfos()) {
             moduleInfo.toXContent(builder, params);
         }
         builder.endArray();

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/stats/ClusterStatsNodes.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/stats/ClusterStatsNodes.java
@@ -28,7 +28,7 @@ import org.elasticsearch.discovery.DiscoveryModule;
 import org.elasticsearch.monitor.fs.FsInfo;
 import org.elasticsearch.monitor.jvm.JvmInfo;
 import org.elasticsearch.monitor.os.OsInfo;
-import org.elasticsearch.plugins.PluginInfo;
+import org.elasticsearch.plugins.PluginDescriptor;
 import org.elasticsearch.transport.TransportInfo;
 import org.elasticsearch.xcontent.ToXContentFragment;
 import org.elasticsearch.xcontent.XContentBuilder;
@@ -55,7 +55,7 @@ public class ClusterStatsNodes implements ToXContentFragment {
     private final ProcessStats process;
     private final JvmStats jvm;
     private final FsInfo.Path fs;
-    private final Set<PluginInfo> plugins;
+    private final Set<PluginDescriptor> plugins;
     private final NetworkTypes networkTypes;
     private final DiscoveryTypes discoveryTypes;
     private final PackagingTypes packagingTypes;
@@ -119,7 +119,7 @@ public class ClusterStatsNodes implements ToXContentFragment {
         return fs;
     }
 
-    public Set<PluginInfo> getPlugins() {
+    public Set<PluginDescriptor> getPlugins() {
         return plugins;
     }
 
@@ -162,8 +162,8 @@ public class ClusterStatsNodes implements ToXContentFragment {
         fs.toXContent(builder, params);
 
         builder.startArray(Fields.PLUGINS);
-        for (PluginInfo pluginInfo : plugins) {
-            pluginInfo.toXContent(builder, params);
+        for (PluginDescriptor pluginDescriptor : plugins) {
+            pluginDescriptor.toXContent(builder, params);
         }
         builder.endArray();
 

--- a/server/src/main/java/org/elasticsearch/bootstrap/PolicyUtil.java
+++ b/server/src/main/java/org/elasticsearch/bootstrap/PolicyUtil.java
@@ -11,7 +11,7 @@ package org.elasticsearch.bootstrap;
 import org.elasticsearch.core.PathUtils;
 import org.elasticsearch.core.SuppressForbidden;
 import org.elasticsearch.core.internal.io.IOUtils;
-import org.elasticsearch.plugins.PluginInfo;
+import org.elasticsearch.plugins.PluginDescriptor;
 import org.elasticsearch.script.ClassPermission;
 
 import java.io.FilePermission;
@@ -299,7 +299,7 @@ public class PolicyUtil {
 
     // pakcage private for tests
     static PluginPolicyInfo readPolicyInfo(Path pluginRoot) throws IOException {
-        Path policyFile = pluginRoot.resolve(PluginInfo.ES_PLUGIN_POLICY);
+        Path policyFile = pluginRoot.resolve(PluginDescriptor.ES_PLUGIN_POLICY);
         if (Files.exists(policyFile) == false) {
             return null;
         }

--- a/server/src/main/java/org/elasticsearch/bootstrap/Spawner.java
+++ b/server/src/main/java/org/elasticsearch/bootstrap/Spawner.java
@@ -12,7 +12,7 @@ import org.apache.lucene.util.Constants;
 import org.elasticsearch.core.internal.io.IOUtils;
 import org.elasticsearch.env.Environment;
 import org.elasticsearch.plugins.Platforms;
-import org.elasticsearch.plugins.PluginInfo;
+import org.elasticsearch.plugins.PluginDescriptor;
 import org.elasticsearch.plugins.PluginsService;
 
 import java.io.Closeable;
@@ -62,7 +62,7 @@ final class Spawner implements Closeable {
          */
         List<Path> paths = PluginsService.findPluginDirs(environment.modulesFile());
         for (final Path modules : paths) {
-            final PluginInfo info = PluginInfo.readFromProperties(modules);
+            final PluginDescriptor info = PluginDescriptor.readFromProperties(modules);
             final Path spawnPath = Platforms.nativeControllerPath(modules);
             if (Files.isRegularFile(spawnPath) == false) {
                 continue;

--- a/server/src/main/java/org/elasticsearch/plugins/PluginDescriptor.java
+++ b/server/src/main/java/org/elasticsearch/plugins/PluginDescriptor.java
@@ -35,7 +35,7 @@ import java.util.stream.Collectors;
 /**
  * An in-memory representation of the plugin descriptor.
  */
-public class PluginInfo implements Writeable, ToXContentObject {
+public class PluginDescriptor implements Writeable, ToXContentObject {
 
     public static final String ES_PLUGIN_PROPERTIES = "plugin-descriptor.properties";
     public static final String ES_PLUGIN_POLICY = "plugin-security.policy";
@@ -69,7 +69,7 @@ public class PluginInfo implements Writeable, ToXContentObject {
      * @param javaOpts              any additional JVM CLI parameters added by this plugin
      * @param isLicensed            whether is this a licensed plugin
      */
-    public PluginInfo(
+    public PluginDescriptor(
         String name,
         String description,
         String version,
@@ -101,7 +101,7 @@ public class PluginInfo implements Writeable, ToXContentObject {
      * @param in the stream
      * @throws IOException if an I/O exception occurred reading the plugin info from the stream
      */
-    public PluginInfo(final StreamInput in) throws IOException {
+    public PluginDescriptor(final StreamInput in) throws IOException {
         this.name = in.readString();
         this.description = in.readString();
         this.version = in.readString();
@@ -174,7 +174,7 @@ public class PluginInfo implements Writeable, ToXContentObject {
      * @return the plugin info
      * @throws IOException if an I/O exception occurred reading the plugin descriptor
      */
-    public static PluginInfo readFromProperties(final Path path) throws IOException {
+    public static PluginDescriptor readFromProperties(final Path path) throws IOException {
         final Path descriptor = path.resolve(ES_PLUGIN_PROPERTIES);
 
         final Map<String, String> propsMap;
@@ -245,7 +245,7 @@ public class PluginInfo implements Writeable, ToXContentObject {
             throw new IllegalArgumentException("Unknown properties for plugin [" + name + "] in plugin descriptor: " + propsMap.keySet());
         }
 
-        return new PluginInfo(
+        return new PluginDescriptor(
             name,
             description,
             version,
@@ -433,7 +433,7 @@ public class PluginInfo implements Writeable, ToXContentObject {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
 
-        PluginInfo that = (PluginInfo) o;
+        PluginDescriptor that = (PluginDescriptor) o;
 
         if (name.equals(that.name) == false) return false;
         // TODO: since the plugins are unique by their directory name, this should only be a name check, version should not matter?

--- a/server/src/main/java/org/elasticsearch/plugins/PluginsService.java
+++ b/server/src/main/java/org/elasticsearch/plugins/PluginsService.java
@@ -70,7 +70,7 @@ public class PluginsService implements ReportingService<PluginsAndModules> {
     /**
      * We keep around a list of plugins and modules
      */
-    private final List<Tuple<PluginInfo, Plugin>> plugins;
+    private final List<Tuple<PluginDescriptor, Plugin>> plugins;
     private final PluginsAndModules info;
 
     public static final Setting<List<String>> MANDATORY_SETTING = Setting.listSetting(
@@ -105,15 +105,15 @@ public class PluginsService implements ReportingService<PluginsAndModules> {
         this.settings = settings;
         this.configPath = configPath;
 
-        List<Tuple<PluginInfo, Plugin>> pluginsLoaded = new ArrayList<>();
-        List<PluginInfo> pluginsList = new ArrayList<>();
+        List<Tuple<PluginDescriptor, Plugin>> pluginsLoaded = new ArrayList<>();
+        List<PluginDescriptor> pluginsList = new ArrayList<>();
         // we need to build a List of plugins for checking mandatory plugins
         final List<String> pluginsNames = new ArrayList<>();
 
         // first we load plugins that are on the classpath. this is for tests and transport clients
         for (Class<? extends Plugin> pluginClass : classpathPlugins) {
             Plugin plugin = loadPlugin(pluginClass, settings, configPath);
-            PluginInfo pluginInfo = new PluginInfo(
+            PluginDescriptor pluginDescriptor = new PluginDescriptor(
                 pluginClass.getName(),
                 "classpath plugin",
                 "NA",
@@ -127,15 +127,15 @@ public class PluginsService implements ReportingService<PluginsAndModules> {
                 false
             );
             if (logger.isTraceEnabled()) {
-                logger.trace("plugin loaded from classpath [{}]", pluginInfo);
+                logger.trace("plugin loaded from classpath [{}]", pluginDescriptor);
             }
-            pluginsLoaded.add(new Tuple<>(pluginInfo, plugin));
-            pluginsList.add(pluginInfo);
-            pluginsNames.add(pluginInfo.getName());
+            pluginsLoaded.add(new Tuple<>(pluginDescriptor, plugin));
+            pluginsList.add(pluginDescriptor);
+            pluginsNames.add(pluginDescriptor.getName());
         }
 
         Set<Bundle> seenBundles = new LinkedHashSet<>();
-        List<PluginInfo> modulesList = new ArrayList<>();
+        List<PluginDescriptor> modulesList = new ArrayList<>();
         // load modules
         if (modulesDirectory != null) {
             try {
@@ -167,7 +167,7 @@ public class PluginsService implements ReportingService<PluginsAndModules> {
             }
         }
 
-        List<Tuple<PluginInfo, Plugin>> loaded = loadBundles(seenBundles);
+        List<Tuple<PluginDescriptor, Plugin>> loaded = loadBundles(seenBundles);
         pluginsLoaded.addAll(loaded);
 
         this.info = new PluginsAndModules(pluginsList, modulesList);
@@ -199,12 +199,12 @@ public class PluginsService implements ReportingService<PluginsAndModules> {
         logPluginInfo(info.getPluginInfos(), "plugin", logger);
     }
 
-    private static void logPluginInfo(final List<PluginInfo> pluginInfos, final String type, final Logger logger) {
-        assert pluginInfos != null;
-        if (pluginInfos.isEmpty()) {
+    private static void logPluginInfo(final List<PluginDescriptor> pluginDescriptors, final String type, final Logger logger) {
+        assert pluginDescriptors != null;
+        if (pluginDescriptors.isEmpty()) {
             logger.info("no " + type + "s loaded");
         } else {
-            for (final String name : pluginInfos.stream().map(PluginInfo::getName).sorted().collect(Collectors.toList())) {
+            for (final String name : pluginDescriptors.stream().map(PluginDescriptor::getName).sorted().collect(Collectors.toList())) {
                 logger.info("loaded " + type + " [" + name + "]");
             }
         }
@@ -214,7 +214,7 @@ public class PluginsService implements ReportingService<PluginsAndModules> {
         Map<String, String> foundSettings = new HashMap<>();
         final Map<String, String> features = new TreeMap<>();
         final Settings.Builder builder = Settings.builder();
-        for (Tuple<PluginInfo, Plugin> plugin : plugins) {
+        for (Tuple<PluginDescriptor, Plugin> plugin : plugins) {
             Settings settings = plugin.v2().additionalSettings();
             for (String setting : settings.keySet()) {
                 String oldPlugin = foundSettings.put(setting, plugin.v1().getName());
@@ -256,7 +256,7 @@ public class PluginsService implements ReportingService<PluginsAndModules> {
 
     public Collection<Module> createGuiceModules() {
         List<Module> modules = new ArrayList<>();
-        for (Tuple<PluginInfo, Plugin> plugin : plugins) {
+        for (Tuple<PluginDescriptor, Plugin> plugin : plugins) {
             modules.addAll(plugin.v2().createGuiceModules());
         }
         return modules;
@@ -264,7 +264,7 @@ public class PluginsService implements ReportingService<PluginsAndModules> {
 
     public List<ExecutorBuilder<?>> getExecutorBuilders(Settings settings) {
         final ArrayList<ExecutorBuilder<?>> builders = new ArrayList<>();
-        for (final Tuple<PluginInfo, Plugin> plugin : plugins) {
+        for (final Tuple<PluginDescriptor, Plugin> plugin : plugins) {
             builders.addAll(plugin.v2().getExecutorBuilders(settings));
         }
         return builders;
@@ -273,14 +273,14 @@ public class PluginsService implements ReportingService<PluginsAndModules> {
     /** Returns all classes injected into guice by plugins which extend {@link LifecycleComponent}. */
     public Collection<Class<? extends LifecycleComponent>> getGuiceServiceClasses() {
         List<Class<? extends LifecycleComponent>> services = new ArrayList<>();
-        for (Tuple<PluginInfo, Plugin> plugin : plugins) {
+        for (Tuple<PluginDescriptor, Plugin> plugin : plugins) {
             services.addAll(plugin.v2().getGuiceServiceClasses());
         }
         return services;
     }
 
     public void onIndexModule(IndexModule indexModule) {
-        for (Tuple<PluginInfo, Plugin> plugin : plugins) {
+        for (Tuple<PluginDescriptor, Plugin> plugin : plugins) {
             plugin.v2().onIndexModule(indexModule);
         }
     }
@@ -295,12 +295,12 @@ public class PluginsService implements ReportingService<PluginsAndModules> {
 
     // a "bundle" is a group of jars in a single classloader
     public static class Bundle {
-        public final PluginInfo plugin;
+        public final PluginDescriptor plugin;
         public final Set<URL> urls;
         public final Set<URL> spiUrls;
         public final Set<URL> allUrls;
 
-        public Bundle(PluginInfo plugin, Path dir) throws IOException {
+        public Bundle(PluginDescriptor plugin, Path dir) throws IOException {
             this.plugin = Objects.requireNonNull(plugin);
 
             Path spiDir = dir.resolve("spi");
@@ -382,7 +382,7 @@ public class PluginsService implements ReportingService<PluginsAndModules> {
     /**
      * Verify the given plugin is compatible with the current Elasticsearch installation.
      */
-    public static void verifyCompatibility(PluginInfo info) {
+    public static void verifyCompatibility(PluginDescriptor info) {
         if (info.getElasticsearchVersion().equals(Version.CURRENT) == false) {
             throw new IllegalArgumentException(
                 "Plugin ["
@@ -454,9 +454,9 @@ public class PluginsService implements ReportingService<PluginsAndModules> {
 
     // get a bundle for a single plugin dir
     private static Bundle readPluginBundle(final Path plugin, String type) throws IOException {
-        final PluginInfo info;
+        final PluginDescriptor info;
         try {
-            info = PluginInfo.readFromProperties(plugin);
+            info = PluginDescriptor.readFromProperties(plugin);
         } catch (final IOException e) {
             throw new IllegalStateException(
                 "Could not load plugin descriptor for " + type + " directory [" + plugin.getFileName() + "]",
@@ -521,8 +521,8 @@ public class PluginsService implements ReportingService<PluginsAndModules> {
         sortedBundles.add(bundle);
     }
 
-    private List<Tuple<PluginInfo, Plugin>> loadBundles(Set<Bundle> bundles) {
-        List<Tuple<PluginInfo, Plugin>> plugins = new ArrayList<>();
+    private List<Tuple<PluginDescriptor, Plugin>> loadBundles(Set<Bundle> bundles) {
+        List<Tuple<PluginDescriptor, Plugin>> plugins = new ArrayList<>();
         Map<String, Tuple<Plugin, ClassLoader>> loaded = new HashMap<>();
         Map<String, Set<URL>> transitiveUrls = new HashMap<>();
         List<Bundle> sortedBundles = sortBundles(bundles);
@@ -540,11 +540,11 @@ public class PluginsService implements ReportingService<PluginsAndModules> {
     }
 
     // package-private for test visibility
-    static void loadExtensions(List<Tuple<PluginInfo, Plugin>> plugins) {
+    static void loadExtensions(List<Tuple<PluginDescriptor, Plugin>> plugins) {
         Map<String, List<Plugin>> extendingPluginsByName = plugins.stream()
             .flatMap(t -> t.v1().getExtendedPlugins().stream().map(extendedPlugin -> Tuple.tuple(extendedPlugin, t.v2())))
             .collect(Collectors.groupingBy(Tuple::v1, Collectors.mapping(Tuple::v2, Collectors.toList())));
-        for (Tuple<PluginInfo, Plugin> pluginTuple : plugins) {
+        for (Tuple<PluginDescriptor, Plugin> pluginTuple : plugins) {
             if (pluginTuple.v2() instanceof ExtensiblePlugin) {
                 loadExtensionsForPlugin(
                     (ExtensiblePlugin) pluginTuple.v2(),

--- a/server/src/main/java/org/elasticsearch/rest/action/cat/RestPluginsAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/cat/RestPluginsAction.java
@@ -18,7 +18,7 @@ import org.elasticsearch.client.node.NodeClient;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
 import org.elasticsearch.common.Table;
-import org.elasticsearch.plugins.PluginInfo;
+import org.elasticsearch.plugins.PluginDescriptor;
 import org.elasticsearch.plugins.PluginType;
 import org.elasticsearch.rest.RestRequest;
 import org.elasticsearch.rest.RestResponse;
@@ -101,17 +101,17 @@ public class RestPluginsAction extends AbstractCatAction {
             if (plugins == null) {
                 continue;
             }
-            for (PluginInfo pluginInfo : plugins.getPluginInfos()) {
-                if (pluginInfo.getType() == PluginType.BOOTSTRAP && includeBootstrapPlugins == false) {
+            for (PluginDescriptor pluginDescriptor : plugins.getPluginInfos()) {
+                if (pluginDescriptor.getType() == PluginType.BOOTSTRAP && includeBootstrapPlugins == false) {
                     continue;
                 }
                 table.startRow();
                 table.addCell(node.getId());
                 table.addCell(node.getName());
-                table.addCell(pluginInfo.getName());
-                table.addCell(pluginInfo.getVersion());
-                table.addCell(pluginInfo.getDescription());
-                table.addCell(pluginInfo.getType().toString().toLowerCase(Locale.ROOT));
+                table.addCell(pluginDescriptor.getName());
+                table.addCell(pluginDescriptor.getVersion());
+                table.addCell(pluginDescriptor.getDescription());
+                table.addCell(pluginDescriptor.getType().toString().toLowerCase(Locale.ROOT));
                 table.endRow();
             }
         }

--- a/server/src/test/java/org/elasticsearch/nodesinfo/NodeInfoStreamingTests.java
+++ b/server/src/test/java/org/elasticsearch/nodesinfo/NodeInfoStreamingTests.java
@@ -25,7 +25,7 @@ import org.elasticsearch.ingest.ProcessorInfo;
 import org.elasticsearch.monitor.jvm.JvmInfo;
 import org.elasticsearch.monitor.os.OsInfo;
 import org.elasticsearch.monitor.process.ProcessInfo;
-import org.elasticsearch.plugins.PluginInfo;
+import org.elasticsearch.plugins.PluginDescriptor;
 import org.elasticsearch.plugins.PluginType;
 import org.elasticsearch.search.aggregations.support.AggregationInfo;
 import org.elasticsearch.search.aggregations.support.AggregationUsageService;
@@ -143,10 +143,10 @@ public class NodeInfoStreamingTests extends ESTestCase {
         PluginsAndModules pluginsAndModules = null;
         if (randomBoolean()) {
             int numPlugins = randomIntBetween(0, 5);
-            List<PluginInfo> plugins = new ArrayList<>();
+            List<PluginDescriptor> plugins = new ArrayList<>();
             for (int i = 0; i < numPlugins; i++) {
                 plugins.add(
-                    new PluginInfo(
+                    new PluginDescriptor(
                         randomAlphaOfLengthBetween(3, 10),
                         randomAlphaOfLengthBetween(3, 10),
                         randomAlphaOfLengthBetween(3, 10),
@@ -162,10 +162,10 @@ public class NodeInfoStreamingTests extends ESTestCase {
                 );
             }
             int numModules = randomIntBetween(0, 5);
-            List<PluginInfo> modules = new ArrayList<>();
+            List<PluginDescriptor> modules = new ArrayList<>();
             for (int i = 0; i < numModules; i++) {
                 modules.add(
-                    new PluginInfo(
+                    new PluginDescriptor(
                         randomAlphaOfLengthBetween(3, 10),
                         randomAlphaOfLengthBetween(3, 10),
                         randomAlphaOfLengthBetween(3, 10),

--- a/server/src/test/java/org/elasticsearch/plugins/PluginDescriptorTests.java
+++ b/server/src/test/java/org/elasticsearch/plugins/PluginDescriptorTests.java
@@ -26,7 +26,7 @@ import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
 
-public class PluginInfoTests extends ESTestCase {
+public class PluginDescriptorTests extends ESTestCase {
 
     public void testReadFromProperties() throws Exception {
         Path pluginDir = createTempDir().resolve("fake-plugin");
@@ -45,7 +45,7 @@ public class PluginInfoTests extends ESTestCase {
             "classname",
             "FakePlugin"
         );
-        PluginInfo info = PluginInfo.readFromProperties(pluginDir);
+        PluginDescriptor info = PluginDescriptor.readFromProperties(pluginDir);
         assertEquals("my_plugin", info.getName());
         assertEquals("fake desc", info.getDescription());
         assertEquals("1.0", info.getVersion());
@@ -56,32 +56,32 @@ public class PluginInfoTests extends ESTestCase {
     public void testReadFromPropertiesNameMissing() throws Exception {
         Path pluginDir = createTempDir().resolve("fake-plugin");
         PluginTestUtil.writePluginProperties(pluginDir);
-        IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> PluginInfo.readFromProperties(pluginDir));
+        IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> PluginDescriptor.readFromProperties(pluginDir));
         assertThat(e.getMessage(), containsString("property [name] is missing in"));
 
         PluginTestUtil.writePluginProperties(pluginDir, "name", "");
-        e = expectThrows(IllegalArgumentException.class, () -> PluginInfo.readFromProperties(pluginDir));
+        e = expectThrows(IllegalArgumentException.class, () -> PluginDescriptor.readFromProperties(pluginDir));
         assertThat(e.getMessage(), containsString("property [name] is missing in"));
     }
 
     public void testReadFromPropertiesDescriptionMissing() throws Exception {
         Path pluginDir = createTempDir().resolve("fake-plugin");
         PluginTestUtil.writePluginProperties(pluginDir, "name", "fake-plugin");
-        IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> PluginInfo.readFromProperties(pluginDir));
+        IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> PluginDescriptor.readFromProperties(pluginDir));
         assertThat(e.getMessage(), containsString("[description] is missing"));
     }
 
     public void testReadFromPropertiesVersionMissing() throws Exception {
         Path pluginDir = createTempDir().resolve("fake-plugin");
         PluginTestUtil.writePluginProperties(pluginDir, "description", "fake desc", "name", "fake-plugin");
-        IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> PluginInfo.readFromProperties(pluginDir));
+        IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> PluginDescriptor.readFromProperties(pluginDir));
         assertThat(e.getMessage(), containsString("[version] is missing"));
     }
 
     public void testReadFromPropertiesElasticsearchVersionMissing() throws Exception {
         Path pluginDir = createTempDir().resolve("fake-plugin");
         PluginTestUtil.writePluginProperties(pluginDir, "description", "fake desc", "name", "my_plugin", "version", "1.0");
-        IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> PluginInfo.readFromProperties(pluginDir));
+        IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> PluginDescriptor.readFromProperties(pluginDir));
         assertThat(e.getMessage(), containsString("[elasticsearch.version] is missing"));
     }
 
@@ -98,7 +98,7 @@ public class PluginInfoTests extends ESTestCase {
             "version",
             "1.0"
         );
-        IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> PluginInfo.readFromProperties(pluginDir));
+        IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> PluginDescriptor.readFromProperties(pluginDir));
         assertThat(e.getMessage(), containsString("[java.version] is missing"));
     }
 
@@ -120,7 +120,7 @@ public class PluginInfoTests extends ESTestCase {
             "version",
             "1.0"
         );
-        IllegalStateException e = expectThrows(IllegalStateException.class, () -> PluginInfo.readFromProperties(pluginDir));
+        IllegalStateException e = expectThrows(IllegalStateException.class, () -> PluginDescriptor.readFromProperties(pluginDir));
         assertThat(
             e.getMessage(),
             equalTo(
@@ -143,7 +143,7 @@ public class PluginInfoTests extends ESTestCase {
             "elasticsearch.version",
             "bogus"
         );
-        IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> PluginInfo.readFromProperties(pluginDir));
+        IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> PluginDescriptor.readFromProperties(pluginDir));
         assertThat(e.getMessage(), containsString("version needs to contain major, minor, and revision"));
     }
 
@@ -162,7 +162,7 @@ public class PluginInfoTests extends ESTestCase {
             "java.version",
             System.getProperty("java.specification.version")
         );
-        IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> PluginInfo.readFromProperties(pluginDir));
+        IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> PluginDescriptor.readFromProperties(pluginDir));
         assertThat(e.getMessage(), containsString("property [classname] is missing"));
     }
 
@@ -185,7 +185,7 @@ public class PluginInfoTests extends ESTestCase {
             "extended.plugins",
             "foo"
         );
-        PluginInfo info = PluginInfo.readFromProperties(pluginDir);
+        PluginDescriptor info = PluginDescriptor.readFromProperties(pluginDir);
         assertThat(info.getExtendedPlugins(), contains("foo"));
     }
 
@@ -208,7 +208,7 @@ public class PluginInfoTests extends ESTestCase {
             "extended.plugins",
             "foo,bar,baz"
         );
-        PluginInfo info = PluginInfo.readFromProperties(pluginDir);
+        PluginDescriptor info = PluginDescriptor.readFromProperties(pluginDir);
         assertThat(info.getExtendedPlugins(), contains("foo", "bar", "baz"));
     }
 
@@ -231,12 +231,12 @@ public class PluginInfoTests extends ESTestCase {
             "extended.plugins",
             ""
         );
-        PluginInfo info = PluginInfo.readFromProperties(pluginDir);
+        PluginDescriptor info = PluginDescriptor.readFromProperties(pluginDir);
         assertThat(info.getExtendedPlugins(), empty());
     }
 
     public void testSerialize() throws Exception {
-        PluginInfo info = new PluginInfo(
+        PluginDescriptor info = new PluginDescriptor(
             "c",
             "foo",
             "dummy",
@@ -253,15 +253,15 @@ public class PluginInfoTests extends ESTestCase {
         info.writeTo(output);
         ByteBuffer buffer = ByteBuffer.wrap(output.bytes().toBytesRef().bytes);
         ByteBufferStreamInput input = new ByteBufferStreamInput(buffer);
-        PluginInfo info2 = new PluginInfo(input);
+        PluginDescriptor info2 = new PluginDescriptor(input);
         assertThat(info2.toString(), equalTo(info.toString()));
 
     }
 
     public void testPluginListSorted() {
-        List<PluginInfo> plugins = new ArrayList<>();
+        List<PluginDescriptor> plugins = new ArrayList<>();
         plugins.add(
-            new PluginInfo(
+            new PluginDescriptor(
                 "c",
                 "foo",
                 "dummy",
@@ -276,7 +276,7 @@ public class PluginInfoTests extends ESTestCase {
             )
         );
         plugins.add(
-            new PluginInfo(
+            new PluginDescriptor(
                 "b",
                 "foo",
                 "dummy",
@@ -291,7 +291,7 @@ public class PluginInfoTests extends ESTestCase {
             )
         );
         plugins.add(
-            new PluginInfo(
+            new PluginDescriptor(
                 "e",
                 "foo",
                 "dummy",
@@ -306,7 +306,7 @@ public class PluginInfoTests extends ESTestCase {
             )
         );
         plugins.add(
-            new PluginInfo(
+            new PluginDescriptor(
                 "a",
                 "foo",
                 "dummy",
@@ -321,7 +321,7 @@ public class PluginInfoTests extends ESTestCase {
             )
         );
         plugins.add(
-            new PluginInfo(
+            new PluginDescriptor(
                 "d",
                 "foo",
                 "dummy",
@@ -337,8 +337,8 @@ public class PluginInfoTests extends ESTestCase {
         );
         PluginsAndModules pluginsInfo = new PluginsAndModules(plugins, Collections.emptyList());
 
-        final List<PluginInfo> infos = pluginsInfo.getPluginInfos();
-        List<String> names = infos.stream().map(PluginInfo::getName).collect(Collectors.toList());
+        final List<PluginDescriptor> infos = pluginsInfo.getPluginInfos();
+        List<String> names = infos.stream().map(PluginDescriptor::getName).collect(Collectors.toList());
         assertThat(names, contains("a", "b", "c", "d", "e"));
     }
 
@@ -363,7 +363,7 @@ public class PluginInfoTests extends ESTestCase {
             "java.version",
             System.getProperty("java.specification.version")
         );
-        IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> PluginInfo.readFromProperties(pluginDir));
+        IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> PluginDescriptor.readFromProperties(pluginDir));
         assertThat(e.getMessage(), containsString("Unknown properties for plugin [my_plugin] in plugin descriptor"));
     }
 
@@ -385,8 +385,8 @@ public class PluginInfoTests extends ESTestCase {
             System.getProperty("java.specification.version")
         );
 
-        final PluginInfo pluginInfo = PluginInfo.readFromProperties(pluginDir);
-        assertThat(pluginInfo.getType(), equalTo(PluginType.ISOLATED));
+        final PluginDescriptor pluginDescriptor = PluginDescriptor.readFromProperties(pluginDir);
+        assertThat(pluginDescriptor.getType(), equalTo(PluginType.ISOLATED));
     }
 
     public void testInvalidType() throws Exception {
@@ -409,7 +409,7 @@ public class PluginInfoTests extends ESTestCase {
             "invalid"
         );
 
-        IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> PluginInfo.readFromProperties(pluginDir));
+        IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> PluginDescriptor.readFromProperties(pluginDir));
         assertThat(e.getMessage(), containsString("[type] must be unspecified or one of [isolated, bootstrap] but found [invalid]"));
     }
 
@@ -433,9 +433,9 @@ public class PluginInfoTests extends ESTestCase {
             "-Dfoo=bar"
         );
 
-        final PluginInfo pluginInfo = PluginInfo.readFromProperties(pluginDir);
-        assertThat(pluginInfo.getType(), equalTo(PluginType.BOOTSTRAP));
-        assertThat(pluginInfo.getJavaOpts(), equalTo("-Dfoo=bar"));
+        final PluginDescriptor pluginDescriptor = PluginDescriptor.readFromProperties(pluginDir);
+        assertThat(pluginDescriptor.getType(), equalTo(PluginType.BOOTSTRAP));
+        assertThat(pluginDescriptor.getJavaOpts(), equalTo("-Dfoo=bar"));
     }
 
     public void testJavaOptsAreRejectedWithNonBootstrapPlugin() throws Exception {
@@ -460,7 +460,7 @@ public class PluginInfoTests extends ESTestCase {
             "-Dfoo=bar"
         );
 
-        IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> PluginInfo.readFromProperties(pluginDir));
+        IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> PluginDescriptor.readFromProperties(pluginDir));
         assertThat(e.getMessage(), containsString("[java.opts] can only have a value when [type] is set to [bootstrap]"));
     }
 
@@ -484,7 +484,7 @@ public class PluginInfoTests extends ESTestCase {
             "bootstrap"
         );
 
-        IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> PluginInfo.readFromProperties(pluginDir));
+        IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> PluginDescriptor.readFromProperties(pluginDir));
         assertThat(e.getMessage(), containsString("[classname] can only have a value when [type] is set to [bootstrap]"));
     }
 }

--- a/server/src/test/java/org/elasticsearch/plugins/PluginsServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/plugins/PluginsServiceTests.java
@@ -320,7 +320,7 @@ public class PluginsServiceTests extends ESTestCase {
 
     public void testSortBundlesCycleSelfReference() throws Exception {
         Path pluginDir = createTempDir();
-        PluginInfo info = new PluginInfo(
+        PluginDescriptor info = new PluginDescriptor(
             "foo",
             "desc",
             "1.0",
@@ -344,7 +344,7 @@ public class PluginsServiceTests extends ESTestCase {
     public void testSortBundlesCycle() throws Exception {
         Path pluginDir = createTempDir();
         Set<PluginsService.Bundle> bundles = new LinkedHashSet<>(); // control iteration order, so we get know the beginning of the cycle
-        PluginInfo info = new PluginInfo(
+        PluginDescriptor info = new PluginDescriptor(
             "foo",
             "desc",
             "1.0",
@@ -358,7 +358,7 @@ public class PluginsServiceTests extends ESTestCase {
             false
         );
         bundles.add(new PluginsService.Bundle(info, pluginDir));
-        PluginInfo info2 = new PluginInfo(
+        PluginDescriptor info2 = new PluginDescriptor(
             "bar",
             "desc",
             "1.0",
@@ -372,7 +372,7 @@ public class PluginsServiceTests extends ESTestCase {
             false
         );
         bundles.add(new PluginsService.Bundle(info2, pluginDir));
-        PluginInfo info3 = new PluginInfo(
+        PluginDescriptor info3 = new PluginDescriptor(
             "baz",
             "desc",
             "1.0",
@@ -386,7 +386,7 @@ public class PluginsServiceTests extends ESTestCase {
             false
         );
         bundles.add(new PluginsService.Bundle(info3, pluginDir));
-        PluginInfo info4 = new PluginInfo(
+        PluginDescriptor info4 = new PluginDescriptor(
             "other",
             "desc",
             "1.0",
@@ -407,7 +407,7 @@ public class PluginsServiceTests extends ESTestCase {
 
     public void testSortBundlesSingle() throws Exception {
         Path pluginDir = createTempDir();
-        PluginInfo info = new PluginInfo(
+        PluginDescriptor info = new PluginDescriptor(
             "foo",
             "desc",
             "1.0",
@@ -428,7 +428,7 @@ public class PluginsServiceTests extends ESTestCase {
     public void testSortBundlesNoDeps() throws Exception {
         Path pluginDir = createTempDir();
         Set<PluginsService.Bundle> bundles = new LinkedHashSet<>(); // control iteration order
-        PluginInfo info1 = new PluginInfo(
+        PluginDescriptor info1 = new PluginDescriptor(
             "foo",
             "desc",
             "1.0",
@@ -443,7 +443,7 @@ public class PluginsServiceTests extends ESTestCase {
         );
         PluginsService.Bundle bundle1 = new PluginsService.Bundle(info1, pluginDir);
         bundles.add(bundle1);
-        PluginInfo info2 = new PluginInfo(
+        PluginDescriptor info2 = new PluginDescriptor(
             "bar",
             "desc",
             "1.0",
@@ -458,7 +458,7 @@ public class PluginsServiceTests extends ESTestCase {
         );
         PluginsService.Bundle bundle2 = new PluginsService.Bundle(info2, pluginDir);
         bundles.add(bundle2);
-        PluginInfo info3 = new PluginInfo(
+        PluginDescriptor info3 = new PluginDescriptor(
             "baz",
             "desc",
             "1.0",
@@ -479,7 +479,7 @@ public class PluginsServiceTests extends ESTestCase {
 
     public void testSortBundlesMissingDep() throws Exception {
         Path pluginDir = createTempDir();
-        PluginInfo info = new PluginInfo(
+        PluginDescriptor info = new PluginDescriptor(
             "foo",
             "desc",
             "1.0",
@@ -503,7 +503,7 @@ public class PluginsServiceTests extends ESTestCase {
     public void testSortBundlesCommonDep() throws Exception {
         Path pluginDir = createTempDir();
         Set<PluginsService.Bundle> bundles = new LinkedHashSet<>(); // control iteration order
-        PluginInfo info1 = new PluginInfo(
+        PluginDescriptor info1 = new PluginDescriptor(
             "grandparent",
             "desc",
             "1.0",
@@ -518,7 +518,7 @@ public class PluginsServiceTests extends ESTestCase {
         );
         PluginsService.Bundle bundle1 = new PluginsService.Bundle(info1, pluginDir);
         bundles.add(bundle1);
-        PluginInfo info2 = new PluginInfo(
+        PluginDescriptor info2 = new PluginDescriptor(
             "foo",
             "desc",
             "1.0",
@@ -533,7 +533,7 @@ public class PluginsServiceTests extends ESTestCase {
         );
         PluginsService.Bundle bundle2 = new PluginsService.Bundle(info2, pluginDir);
         bundles.add(bundle2);
-        PluginInfo info3 = new PluginInfo(
+        PluginDescriptor info3 = new PluginDescriptor(
             "bar",
             "desc",
             "1.0",
@@ -548,7 +548,7 @@ public class PluginsServiceTests extends ESTestCase {
         );
         PluginsService.Bundle bundle3 = new PluginsService.Bundle(info3, pluginDir);
         bundles.add(bundle3);
-        PluginInfo info4 = new PluginInfo(
+        PluginDescriptor info4 = new PluginDescriptor(
             "common",
             "desc",
             "1.0",
@@ -570,7 +570,7 @@ public class PluginsServiceTests extends ESTestCase {
     public void testSortBundlesAlreadyOrdered() throws Exception {
         Path pluginDir = createTempDir();
         Set<PluginsService.Bundle> bundles = new LinkedHashSet<>(); // control iteration order
-        PluginInfo info1 = new PluginInfo(
+        PluginDescriptor info1 = new PluginDescriptor(
             "dep",
             "desc",
             "1.0",
@@ -585,7 +585,7 @@ public class PluginsServiceTests extends ESTestCase {
         );
         PluginsService.Bundle bundle1 = new PluginsService.Bundle(info1, pluginDir);
         bundles.add(bundle1);
-        PluginInfo info2 = new PluginInfo(
+        PluginDescriptor info2 = new PluginDescriptor(
             "myplugin",
             "desc",
             "1.0",
@@ -655,7 +655,7 @@ public class PluginsServiceTests extends ESTestCase {
         makeJar(dupJar);
         Map<String, Set<URL>> transitiveDeps = new HashMap<>();
         transitiveDeps.put("dep", Collections.singleton(dupJar.toUri().toURL()));
-        PluginInfo info1 = new PluginInfo(
+        PluginDescriptor info1 = new PluginDescriptor(
             "myplugin",
             "desc",
             "1.0",
@@ -687,7 +687,7 @@ public class PluginsServiceTests extends ESTestCase {
         Map<String, Set<URL>> transitiveDeps = new HashMap<>();
         transitiveDeps.put("dep1", Collections.singleton(dupJar.toUri().toURL()));
         transitiveDeps.put("dep2", Collections.singleton(dupJar.toUri().toURL()));
-        PluginInfo info1 = new PluginInfo(
+        PluginDescriptor info1 = new PluginDescriptor(
             "myplugin",
             "desc",
             "1.0",
@@ -717,7 +717,7 @@ public class PluginsServiceTests extends ESTestCase {
         Path pluginDir = createTempDir();
         Path pluginJar = pluginDir.resolve("plugin.jar");
         makeJar(pluginJar, Level.class);
-        PluginInfo info1 = new PluginInfo(
+        PluginDescriptor info1 = new PluginDescriptor(
             "myplugin",
             "desc",
             "1.0",
@@ -747,7 +747,7 @@ public class PluginsServiceTests extends ESTestCase {
         Path otherDir = createTempDir();
         Path extendedPlugin = otherDir.resolve("extendedDep-not-present.jar");
 
-        PluginInfo info = new PluginInfo(
+        PluginDescriptor info = new PluginDescriptor(
             "dummy",
             "desc",
             "1.0",
@@ -782,7 +782,7 @@ public class PluginsServiceTests extends ESTestCase {
         makeJar(depJar, DummyClass1.class);
         Map<String, Set<URL>> transitiveDeps = new HashMap<>();
         transitiveDeps.put("dep", Collections.singleton(depJar.toUri().toURL()));
-        PluginInfo info1 = new PluginInfo(
+        PluginDescriptor info1 = new PluginDescriptor(
             "myplugin",
             "desc",
             "1.0",
@@ -818,7 +818,7 @@ public class PluginsServiceTests extends ESTestCase {
         Map<String, Set<URL>> transitiveDeps = new HashMap<>();
         transitiveDeps.put("dep1", Collections.singleton(dep1Jar.toUri().toURL()));
         transitiveDeps.put("dep2", Collections.singleton(dep2Jar.toUri().toURL()));
-        PluginInfo info1 = new PluginInfo(
+        PluginDescriptor info1 = new PluginDescriptor(
             "myplugin",
             "desc",
             "1.0",
@@ -854,7 +854,7 @@ public class PluginsServiceTests extends ESTestCase {
         Map<String, Set<URL>> transitiveDeps = new HashMap<>();
         transitiveDeps.put("dep1", Collections.singleton(dep1Jar.toUri().toURL()));
         transitiveDeps.put("dep2", Collections.singleton(dep2Jar.toUri().toURL()));
-        PluginInfo info1 = new PluginInfo(
+        PluginDescriptor info1 = new PluginDescriptor(
             "myplugin",
             "desc",
             "1.0",
@@ -887,7 +887,7 @@ public class PluginsServiceTests extends ESTestCase {
         makeJar(depJar, DummyClass1.class);
         Map<String, Set<URL>> transitiveDeps = new HashMap<>();
         transitiveDeps.put("dep", Collections.singleton(depJar.toUri().toURL()));
-        PluginInfo info1 = new PluginInfo(
+        PluginDescriptor info1 = new PluginDescriptor(
             "myplugin",
             "desc",
             "1.0",
@@ -919,7 +919,7 @@ public class PluginsServiceTests extends ESTestCase {
         makeJar(depJar, DummyClass1.class);
         Map<String, Set<URL>> transitiveDeps = new HashMap<>();
         transitiveDeps.put("dep", Collections.singleton(depJar.toUri().toURL()));
-        PluginInfo info1 = new PluginInfo(
+        PluginDescriptor info1 = new PluginDescriptor(
             "myplugin",
             "desc",
             "1.0",
@@ -997,7 +997,7 @@ public class PluginsServiceTests extends ESTestCase {
     }
 
     public void testIncompatibleElasticsearchVersion() throws Exception {
-        PluginInfo info = new PluginInfo(
+        PluginDescriptor info = new PluginDescriptor(
             "my_plugin",
             "desc",
             "1.0",
@@ -1015,7 +1015,7 @@ public class PluginsServiceTests extends ESTestCase {
     }
 
     public void testIncompatibleJavaVersion() throws Exception {
-        PluginInfo info = new PluginInfo(
+        PluginDescriptor info = new PluginDescriptor(
             "my_plugin",
             "desc",
             "1.0",
@@ -1151,7 +1151,7 @@ public class PluginsServiceTests extends ESTestCase {
         PluginsService.loadExtensions(
             singletonList(
                 Tuple.tuple(
-                    new PluginInfo(
+                    new PluginDescriptor(
                         "extensible",
                         null,
                         null,
@@ -1177,7 +1177,7 @@ public class PluginsServiceTests extends ESTestCase {
         PluginsService.loadExtensions(
             Arrays.asList(
                 Tuple.tuple(
-                    new PluginInfo(
+                    new PluginDescriptor(
                         "extensible",
                         null,
                         null,
@@ -1193,7 +1193,7 @@ public class PluginsServiceTests extends ESTestCase {
                     extensiblePlugin
                 ),
                 Tuple.tuple(
-                    new PluginInfo(
+                    new PluginDescriptor(
                         "test",
                         null,
                         null,

--- a/server/src/test/java/org/elasticsearch/rest/action/cat/RestPluginsActionTests.java
+++ b/server/src/test/java/org/elasticsearch/rest/action/cat/RestPluginsActionTests.java
@@ -18,7 +18,7 @@ import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
 import org.elasticsearch.common.Table;
-import org.elasticsearch.plugins.PluginInfo;
+import org.elasticsearch.plugins.PluginDescriptor;
 import org.elasticsearch.plugins.PluginType;
 import org.elasticsearch.rest.RestRequest;
 import org.elasticsearch.test.ESTestCase;
@@ -116,7 +116,7 @@ public class RestPluginsActionTests extends ESTestCase {
         assertThat(rows, containsInAnyOrder(matchers));
     }
 
-    private Table buildTable(List<PluginInfo> pluginInfo, boolean includeBootstrap) {
+    private Table buildTable(List<PluginDescriptor> pluginDescriptor, boolean includeBootstrap) {
         final RestRequest request = new FakeRestRequest();
 
         final DiscoveryNodes.Builder builder = DiscoveryNodes.builder();
@@ -143,7 +143,7 @@ public class RestPluginsActionTests extends ESTestCase {
                     null,
                     null,
                     null,
-                    new PluginsAndModules(pluginInfo, emptyList()),
+                    new PluginsAndModules(pluginDescriptor, emptyList()),
                     null,
                     null,
                     null
@@ -167,7 +167,7 @@ public class RestPluginsActionTests extends ESTestCase {
         );
     }
 
-    private PluginInfo plugin(String name, PluginType type) {
-        return new PluginInfo(name, name + " description", "1.0", null, null, null, emptyList(), false, type, null, false);
+    private PluginDescriptor plugin(String name, PluginType type) {
+        return new PluginDescriptor(name, name + " description", "1.0", null, null, null, emptyList(), false, type, null, false);
     }
 }

--- a/test/framework/src/main/java/org/elasticsearch/bootstrap/BootstrapForTesting.java
+++ b/test/framework/src/main/java/org/elasticsearch/bootstrap/BootstrapForTesting.java
@@ -21,7 +21,7 @@ import org.elasticsearch.core.Booleans;
 import org.elasticsearch.core.PathUtils;
 import org.elasticsearch.core.SuppressForbidden;
 import org.elasticsearch.jdk.JarHell;
-import org.elasticsearch.plugins.PluginInfo;
+import org.elasticsearch.plugins.PluginDescriptor;
 import org.elasticsearch.secure_sm.SecureSM;
 import org.elasticsearch.test.mockito.SecureMockMaker;
 import org.junit.Assert;
@@ -165,7 +165,9 @@ public class BootstrapForTesting {
 
                 // guarantee plugin classes are initialized first, in case they have one-time hacks.
                 // this just makes unit testing more realistic
-                for (URL url : Collections.list(BootstrapForTesting.class.getClassLoader().getResources(PluginInfo.ES_PLUGIN_PROPERTIES))) {
+                for (URL url : Collections.list(
+                    BootstrapForTesting.class.getClassLoader().getResources(PluginDescriptor.ES_PLUGIN_PROPERTIES)
+                )) {
                     Properties properties = new Properties();
                     try (InputStream stream = FileSystemUtils.openFileURLStream(url)) {
                         properties.load(stream);
@@ -217,7 +219,9 @@ public class BootstrapForTesting {
      */
     @SuppressForbidden(reason = "accesses fully qualified URLs to configure security")
     static Map<String, Policy> getPluginPermissions() throws Exception {
-        List<URL> pluginPolicies = Collections.list(BootstrapForTesting.class.getClassLoader().getResources(PluginInfo.ES_PLUGIN_POLICY));
+        List<URL> pluginPolicies = Collections.list(
+            BootstrapForTesting.class.getClassLoader().getResources(PluginDescriptor.ES_PLUGIN_POLICY)
+        );
         if (pluginPolicies.isEmpty()) {
             return Collections.emptyMap();
         }

--- a/test/framework/src/main/java/org/elasticsearch/plugins/PluginTestUtil.java
+++ b/test/framework/src/main/java/org/elasticsearch/plugins/PluginTestUtil.java
@@ -18,7 +18,7 @@ import java.util.Properties;
 public class PluginTestUtil {
 
     public static void writePluginProperties(Path pluginDir, String... stringProps) throws IOException {
-        writeProperties(pluginDir.resolve(PluginInfo.ES_PLUGIN_PROPERTIES), stringProps);
+        writeProperties(pluginDir.resolve(PluginDescriptor.ES_PLUGIN_PROPERTIES), stringProps);
     }
 
     /** convenience method to write a plugin properties file */

--- a/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/collector/cluster/ClusterStatsMonitoringDocTests.java
+++ b/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/collector/cluster/ClusterStatsMonitoringDocTests.java
@@ -47,7 +47,7 @@ import org.elasticsearch.monitor.jvm.JvmStats;
 import org.elasticsearch.monitor.os.OsInfo;
 import org.elasticsearch.monitor.os.OsStats;
 import org.elasticsearch.monitor.process.ProcessStats;
-import org.elasticsearch.plugins.PluginInfo;
+import org.elasticsearch.plugins.PluginDescriptor;
 import org.elasticsearch.plugins.PluginType;
 import org.elasticsearch.test.VersionUtils;
 import org.elasticsearch.transport.TransportInfo;
@@ -317,7 +317,7 @@ public class ClusterStatsMonitoringDocTests extends BaseMonitoringDocTestCase<Cl
 
         final PluginsAndModules mockPluginsAndModules = mock(PluginsAndModules.class);
         when(mockNodeInfo.getInfo(PluginsAndModules.class)).thenReturn(mockPluginsAndModules);
-        final PluginInfo pluginInfo = new PluginInfo(
+        final PluginDescriptor pluginDescriptor = new PluginDescriptor(
             "_plugin",
             "_plugin_desc",
             "_plugin_version",
@@ -330,7 +330,7 @@ public class ClusterStatsMonitoringDocTests extends BaseMonitoringDocTestCase<Cl
             "",
             false
         );
-        when(mockPluginsAndModules.getPluginInfos()).thenReturn(singletonList(pluginInfo));
+        when(mockPluginsAndModules.getPluginInfos()).thenReturn(singletonList(pluginDescriptor));
 
         final OsInfo mockOsInfo = mock(OsInfo.class);
         when(mockNodeInfo.getInfo(OsInfo.class)).thenReturn(mockOsInfo);

--- a/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/test/SecuritySingleNodeTestCase.java
+++ b/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/test/SecuritySingleNodeTestCase.java
@@ -25,7 +25,7 @@ import org.elasticsearch.core.internal.io.IOUtils;
 import org.elasticsearch.http.HttpInfo;
 import org.elasticsearch.license.LicenseService;
 import org.elasticsearch.plugins.Plugin;
-import org.elasticsearch.plugins.PluginInfo;
+import org.elasticsearch.plugins.PluginDescriptor;
 import org.elasticsearch.xpack.core.XPackSettings;
 import org.elasticsearch.xpack.core.security.authc.support.Hasher;
 import org.elasticsearch.xpack.security.LocalStateSecurity;
@@ -164,7 +164,7 @@ public abstract class SecuritySingleNodeTestCase extends ESSingleNodeTestCase {
             Collection<String> pluginNames = nodeInfo.getInfo(PluginsAndModules.class)
                 .getPluginInfos()
                 .stream()
-                .map(PluginInfo::getClassname)
+                .map(PluginDescriptor::getClassname)
                 .collect(Collectors.toList());
             assertThat(
                 "plugin [" + LocalStateSecurity.class.getName() + "] not found in [" + pluginNames + "]",


### PR DESCRIPTION
The class PluginInfo represents the plugin-descriptor.properties file
that each plugin must have. This commit renames the class to more
closely match what it represents: the plugin descriptor.