### PR TITLE
Avoid circuit breaker trips in shutdown node actions (#86047)

### DIFF
--- a/x-pack/plugin/shutdown/src/main/java/org/elasticsearch/xpack/shutdown/RestDeleteShutdownNodeAction.java
+++ b/x-pack/plugin/shutdown/src/main/java/org/elasticsearch/xpack/shutdown/RestDeleteShutdownNodeAction.java
@@ -28,6 +28,11 @@ public class RestDeleteShutdownNodeAction extends BaseRestHandler {
     }
 
     @Override
+    public boolean canTripCircuitBreaker() {
+        return false;
+    }
+
+    @Override
     protected RestChannelConsumer prepareRequest(RestRequest request, NodeClient client) {
         String nodeId = request.param("nodeId");
         return channel -> client.execute(

--- a/x-pack/plugin/shutdown/src/main/java/org/elasticsearch/xpack/shutdown/RestPutShutdownNodeAction.java
+++ b/x-pack/plugin/shutdown/src/main/java/org/elasticsearch/xpack/shutdown/RestPutShutdownNodeAction.java
@@ -30,6 +30,11 @@ public class RestPutShutdownNodeAction extends BaseRestHandler {
     }
 
     @Override
+    public boolean canTripCircuitBreaker() {
+        return false;
+    }
+
+    @Override
     protected RestChannelConsumer prepareRequest(RestRequest request, NodeClient client) throws IOException {
         String nodeId = request.param("nodeId");
         try (XContentParser parser = request.contentParser()) {

--- a/x-pack/plugin/shutdown/src/main/java/org/elasticsearch/xpack/shutdown/TransportDeleteShutdownNodeAction.java
+++ b/x-pack/plugin/shutdown/src/main/java/org/elasticsearch/xpack/shutdown/TransportDeleteShutdownNodeAction.java
@@ -41,6 +41,7 @@ public class TransportDeleteShutdownNodeAction extends AcknowledgedTransportMast
     ) {
         super(
             DeleteShutdownNodeAction.NAME,
+            false,
             transportService,
             clusterService,
             threadPool,

--- a/x-pack/plugin/shutdown/src/main/java/org/elasticsearch/xpack/shutdown/TransportPutShutdownNodeAction.java
+++ b/x-pack/plugin/shutdown/src/main/java/org/elasticsearch/xpack/shutdown/TransportPutShutdownNodeAction.java
@@ -43,6 +43,7 @@ public class TransportPutShutdownNodeAction extends AcknowledgedTransportMasterN
     ) {
         super(
             PutShutdownNodeAction.NAME,
+            false,
             transportService,
             clusterService,
             threadPool,


### PR DESCRIPTION
When adding or deleting node shutdown metadata, it is important that as
few things go wrong as possible. Since these actions do not do anything
with memory, there is no reason they should trip the circuit breaker,
but they might accidentally if there is pressure on the system. This
commit declares the rest and transport actions as not capable of
tripping the circuit breaker.

closes #84847
