### PR TITLE
[7.17] Adjust osprobe assertion for burst cpu (#86990)

### DIFF
--- a/docs/changelog/86990.yaml
+++ b/docs/changelog/86990.yaml
@@ -1,0 +1,5 @@
+pr: 86990
+summary: Adjust osprobe assertion for burst cpu
+area: Infra/Core
+type: bug
+issues: []

--- a/server/src/main/java/org/elasticsearch/monitor/os/OsProbe.java
+++ b/server/src/main/java/org/elasticsearch/monitor/os/OsProbe.java
@@ -436,6 +436,13 @@ public class OsProbe {
      * nr_throttled} is the number of times tasks in the given control group have been throttled, and {@code throttled_time} is the total
      * time in nanoseconds for which tasks in the given control group have been throttled.
      *
+     * If the burst feature of the scheduler is enabled, the statistics contain an additional two fields of the form
+     * <blockquote><pre>
+     * nr_bursts \d+
+     * burst_time
+     * </pre></blockquote>
+     * These additional fields are currently ignored.
+     *
      * @param controlGroup the control group to which the Elasticsearch process belongs for the {@code cpu} subsystem
      * @return the lines from {@code cpu.stat}
      * @throws IOException if an I/O exception occurs reading {@code cpu.stat} for the control group
@@ -443,7 +450,7 @@ public class OsProbe {
     @SuppressForbidden(reason = "access /sys/fs/cgroup/cpu")
     List<String> readSysFsCgroupCpuAcctCpuStat(final String controlGroup) throws IOException {
         final List<String> lines = Files.readAllLines(PathUtils.get("/sys/fs/cgroup/cpu", controlGroup, "cpu.stat"));
-        assert lines != null && lines.size() == 3;
+        assert lines != null && (lines.size() == 3 || lines.size() == 5);
         return lines;
     }
 


### PR DESCRIPTION
Backports the following commits to 7.17:
 - Adjust osprobe assertion for burst cpu (#86990)