### PR TITLE
Temporarily skip JarHellTests::testNonJDKModuleURLs on JDK 19

### DIFF
--- a/libs/core/src/test/java/org/elasticsearch/jdk/JarHellTests.java
+++ b/libs/core/src/test/java/org/elasticsearch/jdk/JarHellTests.java
@@ -119,6 +119,8 @@ public class JarHellTests extends ESTestCase {
     }
 
     public void testNonJDKModuleURLs() throws Throwable {
+        // Temporarily skip on JDK 19, until this issue is resolved https://bugs.openjdk.java.net/browse/JDK-8287097
+        assumeTrue("Skip on 19", Runtime.version().feature() < 19);
         var bootLayer = ModuleLayer.boot();
 
         Path fooDir = createTempDir(getTestName());


### PR DESCRIPTION
Temporarily skip JarHellTests::testNonJDKModuleURLs on JDK 19, until this issue is resolved https://bugs.openjdk.java.net/browse/JDK-8287097

closes #86833