### PR TITLE
[Refactor] Use Lists instead of Maps for SystemIndices features

### DIFF
--- a/modules/data-streams/src/test/java/org/elasticsearch/datastreams/action/GetDataStreamsTransportActionTests.java
+++ b/modules/data-streams/src/test/java/org/elasticsearch/datastreams/action/GetDataStreamsTransportActionTests.java
@@ -34,7 +34,7 @@ import static org.hamcrest.Matchers.hasSize;
 public class GetDataStreamsTransportActionTests extends ESTestCase {
 
     private final IndexNameExpressionResolver resolver = TestIndexNameExpressionResolver.newInstance();
-    private final SystemIndices systemIndices = new SystemIndices(Map.of());
+    private final SystemIndices systemIndices = new SystemIndices(List.of());
 
     public void testGetDataStream() {
         final String dataStreamName = "my-data-stream";

--- a/modules/data-streams/src/test/java/org/elasticsearch/datastreams/action/GetDataStreamsTransportActionTests.java
+++ b/modules/data-streams/src/test/java/org/elasticsearch/datastreams/action/GetDataStreamsTransportActionTests.java
@@ -23,7 +23,6 @@ import org.elasticsearch.test.ESTestCase;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.List;
-import java.util.Map;
 
 import static org.elasticsearch.cluster.metadata.DataStreamTestHelper.getClusterStateWithDataStreams;
 import static org.hamcrest.Matchers.contains;

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/migration/TransportGetFeatureUpgradeStatusAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/migration/TransportGetFeatureUpgradeStatusAction.java
@@ -89,7 +89,6 @@ public class TransportGetFeatureUpgradeStatusAction extends TransportMasterNodeA
     ) throws Exception {
 
         List<GetFeatureUpgradeStatusResponse.FeatureUpgradeStatus> features = systemIndices.getFeatures()
-            .values()
             .stream()
             .sorted(Comparator.comparing(SystemIndices.Feature::getName))
             .map(feature -> getFeatureUpgradeStatus(state, feature))

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/migration/TransportPostFeatureUpgradeAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/migration/TransportPostFeatureUpgradeAction.java
@@ -81,7 +81,6 @@ public class TransportPostFeatureUpgradeAction extends TransportMasterNodeAction
             GetFeatureUpgradeStatusResponse.UpgradeStatus.ERROR
         );
         List<PostFeatureUpgradeResponse.Feature> featuresToMigrate = systemIndices.getFeatures()
-            .values()
             .stream()
             .map(feature -> getFeatureUpgradeStatus(state, feature))
             .filter(status -> upgradableStatuses.contains(status.getUpgradeStatus()))

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/features/TransportResetFeatureStateAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/features/TransportResetFeatureStateAction.java
@@ -80,7 +80,7 @@ public class TransportResetFeatureStateAction extends TransportMasterNodeAction<
             systemIndices.getFeatures().size()
         );
 
-        for (SystemIndices.Feature feature : systemIndices.getFeatures().values()) {
+        for (SystemIndices.Feature feature : systemIndices.getFeatures()) {
             feature.getCleanUpFunction().apply(clusterService, client, groupedActionListener);
         }
     }

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/features/TransportSnapshottableFeaturesAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/features/TransportSnapshottableFeaturesAction.java
@@ -61,14 +61,8 @@ public class TransportSnapshottableFeaturesAction extends TransportMasterNodeAct
         listener.onResponse(
             new GetSnapshottableFeaturesResponse(
                 systemIndices.getFeatures()
-                    .entrySet()
                     .stream()
-                    .map(
-                        featureEntry -> new GetSnapshottableFeaturesResponse.SnapshottableFeature(
-                            featureEntry.getKey(),
-                            featureEntry.getValue().getDescription()
-                        )
-                    )
+                    .map(feature -> new GetSnapshottableFeaturesResponse.SnapshottableFeature(feature.getName(), feature.getDescription()))
                     .toList()
             )
         );

--- a/server/src/main/java/org/elasticsearch/indices/SystemIndices.java
+++ b/server/src/main/java/org/elasticsearch/indices/SystemIndices.java
@@ -84,11 +84,10 @@ public class SystemIndices {
 
     /**
      * Initialize the SystemIndices object
-     * @param pluginAndModulesDescriptors A map of this node's feature names to
-     *                                    feature objects.
+     * @param features A list of features from which we will load system indices
      */
-    public SystemIndices(Map<String, Feature> pluginAndModulesDescriptors) {
-        featureDescriptors = buildSystemIndexDescriptorMap(pluginAndModulesDescriptors);
+    public SystemIndices(List<Feature> features) {
+        featureDescriptors = buildSystemIndexDescriptorMap(features);
         indexDescriptors = featureDescriptors.values()
             .stream()
             .flatMap(f -> f.getIndexDescriptors().stream())
@@ -577,9 +576,9 @@ public class SystemIndices {
         return Operations.isEmpty(Operations.intersection(a1Automaton, a2Automaton)) == false;
     }
 
-    private static Map<String, Feature> buildSystemIndexDescriptorMap(Map<String, Feature> featuresMap) {
-        final Map<String, Feature> map = Maps.newMapWithExpectedSize(featuresMap.size() + SERVER_SYSTEM_INDEX_DESCRIPTORS.size());
-        map.putAll(featuresMap);
+    private static Map<String, Feature> buildSystemIndexDescriptorMap(List<Feature> features) {
+        final Map<String, Feature> map = Maps.newMapWithExpectedSize(features.size() + SERVER_SYSTEM_INDEX_DESCRIPTORS.size());
+        features.forEach(f -> map.put(f.getName(), f));
         // put the server items last since we expect less of them
         SERVER_SYSTEM_INDEX_DESCRIPTORS.forEach((source, feature) -> {
             if (map.putIfAbsent(source, feature) != null) {

--- a/server/src/main/java/org/elasticsearch/indices/SystemIndices.java
+++ b/server/src/main/java/org/elasticsearch/indices/SystemIndices.java
@@ -92,7 +92,7 @@ public class SystemIndices {
             .flatMap(f -> f.getDataStreamDescriptors().stream())
             .collect(Collectors.toUnmodifiableMap(SystemDataStreamDescriptor::getDataStreamName, Function.identity()));
         checkForOverlappingPatterns(featureDescriptors);
-        ensurePatternsAllowSuffix(toMap(featureDescriptors));
+        ensurePatternsAllowSuffix(featureDescriptors);
         checkForDuplicateAliases(this.getSystemIndexDescriptors());
         Automaton systemIndexAutomata = buildIndexAutomaton(toMap(featureDescriptors));
         this.systemIndexRunAutomaton = new CharacterRunAutomaton(systemIndexAutomata);
@@ -116,13 +116,11 @@ public class SystemIndices {
         return features.stream().collect(Collectors.toMap(Feature::getName, Function.identity()));
     }
 
-    static void ensurePatternsAllowSuffix(Map<String, Feature> features) {
+    static void ensurePatternsAllowSuffix(List<Feature> features) {
         String suffixPattern = "*" + UPGRADED_INDEX_SUFFIX;
-        final List<String> descriptorsWithNoRoomForSuffix = features.entrySet()
-            .stream()
+        final List<String> descriptorsWithNoRoomForSuffix = features.stream()
             .flatMap(
-                feature -> feature.getValue()
-                    .getIndexDescriptors()
+                feature -> feature.getIndexDescriptors()
                     .stream()
                     // The below filter & map are inside the enclosing flapMap so we have access to both the feature and the descriptor
                     .filter(descriptor -> overlaps(descriptor.getIndexPattern(), suffixPattern) == false)
@@ -130,7 +128,7 @@ public class SystemIndices {
                         descriptor -> new ParameterizedMessage(
                             "pattern [{}] from feature [{}]",
                             descriptor.getIndexPattern(),
-                            feature.getKey()
+                            feature.getName()
                         ).getFormattedMessage()
                     )
             )

--- a/server/src/main/java/org/elasticsearch/indices/SystemIndices.java
+++ b/server/src/main/java/org/elasticsearch/indices/SystemIndices.java
@@ -45,6 +45,7 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Optional;
+import java.util.Set;
 import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
@@ -328,6 +329,10 @@ public class SystemIndices {
             return name -> false;
         }
         return automaton::run;
+    }
+
+    public Set<String> getFeatureNames() {
+        return features.keySet();
     }
 
     public Feature getFeature(String name) {

--- a/server/src/main/java/org/elasticsearch/indices/SystemIndices.java
+++ b/server/src/main/java/org/elasticsearch/indices/SystemIndices.java
@@ -334,14 +334,28 @@ public class SystemIndices {
         return automaton::run;
     }
 
+    /**
+     * Get a set of feature names. This is useful for checking whether particular
+     * features are present on the node.
+     * @return A set of all feature names
+     */
     public Set<String> getFeatureNames() {
         return featureDescriptors.keySet();
     }
 
+    /**
+     * Get a feature by name.
+     * @param name Name of a feature.
+     * @return The corresponding feature if it exists on this node, null otherwise.
+     */
     public Feature getFeature(String name) {
         return featureDescriptors.get(name);
     }
 
+    /**
+     * Get a collection of the Features this SystemIndices object is managing.
+     * @return A collection of Features.
+     */
     public Collection<Feature> getFeatures() {
         return featureDescriptors.values();
     }
@@ -515,7 +529,7 @@ public class SystemIndices {
      * Given a collection of {@link SystemIndexDescriptor}s and their sources, checks to see if the index patterns of the listed
      * descriptors overlap with any of the other patterns. If any do, throws an exception.
      *
-     * @param featureDescriptors A list of Features that will provide SystemIndexDescriptors
+     * @param featureDescriptors A map of feature names to the Features that will provide SystemIndexDescriptors
      * @throws IllegalStateException Thrown if any of the index patterns overlaps with another.
      */
     static void checkForOverlappingPatterns(Map<String, Feature> featureDescriptors) {

--- a/server/src/main/java/org/elasticsearch/indices/SystemIndices.java
+++ b/server/src/main/java/org/elasticsearch/indices/SystemIndices.java
@@ -100,18 +100,13 @@ public class SystemIndices {
         this.systemDataStreamIndicesRunAutomaton = new CharacterRunAutomaton(systemDataStreamIndicesAutomata);
         this.systemDataStreamPredicate = buildDataStreamNamePredicate(featureDescriptors);
         this.netNewSystemIndexAutomaton = buildNetNewIndexCharacterRunAutomaton(featureDescriptors);
-        this.productToSystemIndicesMatcher = getProductToSystemIndicesMap(toMap(featureDescriptors));
+        this.productToSystemIndicesMatcher = getProductToSystemIndicesMap(featureDescriptors);
         this.executorSelector = new ExecutorSelector(this);
         this.systemNameAutomaton = MinimizationOperations.minimize(
             Operations.union(List.of(systemIndexAutomata, systemDataStreamIndicesAutomata, buildDataStreamAutomaton(featureDescriptors))),
             Integer.MAX_VALUE
         );
         this.systemNameRunAutomaton = new CharacterRunAutomaton(systemNameAutomaton);
-    }
-
-    @Deprecated
-    private static Map<String, Feature> toMap(List<Feature> features) {
-        return features.stream().collect(Collectors.toMap(Feature::getName, Function.identity()));
     }
 
     static void ensurePatternsAllowSuffix(List<Feature> features) {
@@ -164,9 +159,9 @@ public class SystemIndices {
         }
     }
 
-    private static Map<String, CharacterRunAutomaton> getProductToSystemIndicesMap(Map<String, Feature> descriptors) {
+    private static Map<String, CharacterRunAutomaton> getProductToSystemIndicesMap(List<Feature> features) {
         Map<String, Automaton> productToSystemIndicesMap = new HashMap<>();
-        for (Feature feature : descriptors.values()) {
+        for (Feature feature : features) {
             feature.getIndexDescriptors().forEach(systemIndexDescriptor -> {
                 if (systemIndexDescriptor.isExternal()) {
                     systemIndexDescriptor.getAllowedElasticProductOrigins()
@@ -332,7 +327,7 @@ public class SystemIndices {
     }
 
     public Map<String, Feature> getFeatures() {
-        return toMap(featureDescriptors);
+        return featureDescriptors.stream().collect(Collectors.toMap(Feature::getName, Function.identity()));
     }
 
     private static Automaton buildIndexAutomaton(List<Feature> features) {

--- a/server/src/main/java/org/elasticsearch/node/Node.java
+++ b/server/src/main/java/org/elasticsearch/node/Node.java
@@ -496,13 +496,10 @@ public class Node implements Closeable {
                     SystemIndexMigrationExecutor.getNamedXContentParsers().stream()
                 ).flatMap(Function.identity()).collect(toList())
             );
-            final List<SystemIndices.Feature> features = pluginsService.filterPlugins(SystemIndexPlugin.class)
-                .stream()
-                .map(plugin -> {
-                    SystemIndices.validateFeatureName(plugin.getFeatureName(), plugin.getClass().getCanonicalName());
-                    return SystemIndices.Feature.fromSystemIndexPlugin(plugin, settings);
-                })
-                .toList();
+            final List<SystemIndices.Feature> features = pluginsService.filterPlugins(SystemIndexPlugin.class).stream().map(plugin -> {
+                SystemIndices.validateFeatureName(plugin.getFeatureName(), plugin.getClass().getCanonicalName());
+                return SystemIndices.Feature.fromSystemIndexPlugin(plugin, settings);
+            }).toList();
             final SystemIndices systemIndices = new SystemIndices(features);
             final ExecutorSelector executorSelector = systemIndices.getExecutorSelector();
 

--- a/server/src/main/java/org/elasticsearch/node/Node.java
+++ b/server/src/main/java/org/elasticsearch/node/Node.java
@@ -496,16 +496,14 @@ public class Node implements Closeable {
                     SystemIndexMigrationExecutor.getNamedXContentParsers().stream()
                 ).flatMap(Function.identity()).collect(toList())
             );
-            final Map<String, SystemIndices.Feature> featuresMap = pluginsService.filterPlugins(SystemIndexPlugin.class)
+            final List<SystemIndices.Feature> features = pluginsService.filterPlugins(SystemIndexPlugin.class)
                 .stream()
-                .peek(plugin -> SystemIndices.validateFeatureName(plugin.getFeatureName(), plugin.getClass().getCanonicalName()))
-                .collect(
-                    Collectors.toUnmodifiableMap(
-                        SystemIndexPlugin::getFeatureName,
-                        plugin -> SystemIndices.Feature.fromSystemIndexPlugin(plugin, settings)
-                    )
-                );
-            final SystemIndices systemIndices = new SystemIndices(featuresMap);
+                .map(plugin -> {
+                    SystemIndices.validateFeatureName(plugin.getFeatureName(), plugin.getClass().getCanonicalName());
+                    return SystemIndices.Feature.fromSystemIndexPlugin(plugin, settings);
+                })
+                .toList();
+            final SystemIndices systemIndices = new SystemIndices(features);
             final ExecutorSelector executorSelector = systemIndices.getExecutorSelector();
 
             ModulesBuilder modules = new ModulesBuilder();

--- a/server/src/main/java/org/elasticsearch/snapshots/RestoreService.java
+++ b/server/src/main/java/org/elasticsearch/snapshots/RestoreService.java
@@ -653,7 +653,7 @@ public class RestoreService implements ClusterStateApplier {
 
         final List<String> featuresNotOnThisNode = featureStatesToRestore.keySet()
             .stream()
-            .filter(s -> Objects.nonNull(systemIndices.getFeature(s)))
+            .filter(s -> Objects.nonNull(systemIndices.getFeature(s)) == false)
             .toList();
         if (featuresNotOnThisNode.isEmpty() == false) {
             throw new SnapshotRestoreException(

--- a/server/src/main/java/org/elasticsearch/snapshots/RestoreService.java
+++ b/server/src/main/java/org/elasticsearch/snapshots/RestoreService.java
@@ -337,7 +337,7 @@ public class RestoreService implements ClusterStateApplier {
             .collect(Collectors.toSet());
 
         final Set<String> featureStateDataStreams = featureStatesToRestore.keySet().stream().filter(featureName -> {
-            if (Objects.nonNull(systemIndices.getFeature(featureName))) {
+            if (systemIndices.getFeatureNames().contains(featureName)) {
                 return true;
             }
             logger.warn(
@@ -653,7 +653,7 @@ public class RestoreService implements ClusterStateApplier {
 
         final List<String> featuresNotOnThisNode = featureStatesToRestore.keySet()
             .stream()
-            .filter(s -> Objects.nonNull(systemIndices.getFeature(s)) == false)
+            .filter(s -> systemIndices.getFeatureNames().contains(s) == false)
             .toList();
         if (featuresNotOnThisNode.isEmpty() == false) {
             throw new SnapshotRestoreException(

--- a/server/src/main/java/org/elasticsearch/snapshots/SnapshotsService.java
+++ b/server/src/main/java/org/elasticsearch/snapshots/SnapshotsService.java
@@ -265,7 +265,7 @@ public class SnapshotsService extends AbstractLifecycleComponent implements Clus
         if (request.includeGlobalState() || requestedStates.isEmpty() == false) {
             if (request.includeGlobalState() && requestedStates.isEmpty()) {
                 // If we're including global state and feature states aren't specified, include all of them
-                featureStatesSet = systemIndices.getFeatures().stream().map(SystemIndices.Feature::getName).collect(Collectors.toSet());
+                featureStatesSet = systemIndices.getFeatureNames();
             } else if (requestedStates.size() == 1 && NO_FEATURE_STATES_VALUE.equalsIgnoreCase(requestedStates.get(0))) {
                 // If there's exactly one value and it's "none", include no states
                 featureStatesSet = Collections.emptySet();
@@ -284,7 +284,7 @@ public class SnapshotsService extends AbstractLifecycleComponent implements Clus
                     return;
                 }
                 featureStatesSet = new HashSet<>(requestedStates);
-                featureStatesSet.retainAll(systemIndices.getFeatures().stream().map(SystemIndices.Feature::getName).toList());
+                featureStatesSet.retainAll(systemIndices.getFeatureNames());
             }
         } else {
             featureStatesSet = Collections.emptySet();

--- a/server/src/main/java/org/elasticsearch/snapshots/SnapshotsService.java
+++ b/server/src/main/java/org/elasticsearch/snapshots/SnapshotsService.java
@@ -265,7 +265,7 @@ public class SnapshotsService extends AbstractLifecycleComponent implements Clus
         if (request.includeGlobalState() || requestedStates.isEmpty() == false) {
             if (request.includeGlobalState() && requestedStates.isEmpty()) {
                 // If we're including global state and feature states aren't specified, include all of them
-                featureStatesSet = systemIndices.getFeatures().keySet();
+                featureStatesSet = systemIndices.getFeatures().stream().map(SystemIndices.Feature::getName).collect(Collectors.toSet());
             } else if (requestedStates.size() == 1 && NO_FEATURE_STATES_VALUE.equalsIgnoreCase(requestedStates.get(0))) {
                 // If there's exactly one value and it's "none", include no states
                 featureStatesSet = Collections.emptySet();
@@ -284,7 +284,7 @@ public class SnapshotsService extends AbstractLifecycleComponent implements Clus
                     return;
                 }
                 featureStatesSet = new HashSet<>(requestedStates);
-                featureStatesSet.retainAll(systemIndices.getFeatures().keySet());
+                featureStatesSet.retainAll(systemIndices.getFeatures().stream().map(SystemIndices.Feature::getName).toList());
             }
         } else {
             featureStatesSet = Collections.emptySet();
@@ -336,7 +336,7 @@ public class SnapshotsService extends AbstractLifecycleComponent implements Clus
                 // been requested by the request directly
                 final Set<String> indexNames = new HashSet<>(indices);
                 for (String featureName : featureStatesSet) {
-                    SystemIndices.Feature feature = systemIndices.getFeatures().get(featureName);
+                    SystemIndices.Feature feature = systemIndices.getFeature(featureName);
 
                     Set<String> featureSystemIndices = feature.getIndexDescriptors()
                         .stream()

--- a/server/src/main/java/org/elasticsearch/upgrades/SystemIndexMigrationInfo.java
+++ b/server/src/main/java/org/elasticsearch/upgrades/SystemIndexMigrationInfo.java
@@ -239,7 +239,7 @@ class SystemIndexMigrationInfo implements Comparable<SystemIndexMigrationInfo> {
         IndexScopedSettings indexScopedSettings
     ) {
         SystemIndexDescriptor descriptor = systemIndices.findMatchingDescriptor(taskState.getCurrentIndex());
-        SystemIndices.Feature feature = systemIndices.getFeatures().get(taskState.getCurrentFeature());
+        SystemIndices.Feature feature = systemIndices.getFeature(taskState.getCurrentFeature());
         IndexMetadata imd = metadata.index(taskState.getCurrentIndex());
 
         // It's possible for one or both of these to happen if the executing node fails during execution and:

--- a/server/src/main/java/org/elasticsearch/upgrades/SystemIndexMigrator.java
+++ b/server/src/main/java/org/elasticsearch/upgrades/SystemIndexMigrator.java
@@ -117,7 +117,7 @@ public class SystemIndexMigrator extends AllocatedPersistentTask {
             stateIndexName = taskState.getCurrentIndex();
             stateFeatureName = taskState.getCurrentFeature();
 
-            SystemIndices.Feature feature = systemIndices.getFeatures().get(stateFeatureName);
+            SystemIndices.Feature feature = systemIndices.getFeature(stateFeatureName);
             if (feature == null) {
                 markAsFailed(
                     new IllegalStateException(
@@ -144,7 +144,6 @@ public class SystemIndexMigrator extends AllocatedPersistentTask {
             }
 
             systemIndices.getFeatures()
-                .values()
                 .stream()
                 .flatMap(feature -> SystemIndexMigrationInfo.fromFeature(feature, clusterState.metadata(), indexScopedSettings))
                 .filter(migrationInfo -> needsToBeMigrated(clusterState.metadata().index(migrationInfo.getCurrentIndexName())))

--- a/server/src/test/java/org/elasticsearch/action/admin/indices/alias/get/TransportGetAliasesActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/indices/alias/get/TransportGetAliasesActionTests.java
@@ -293,8 +293,7 @@ public class TransportGetAliasesActionTests extends ESTestCase {
             .setNetNew()
             .build();
         SystemIndices systemIndices = new SystemIndices(
-            Collections.singletonMap(
-                this.getTestName(),
+            Collections.singletonList(
                 new SystemIndices.Feature(this.getTestName(), "test feature", Collections.singletonList(netNewDescriptor))
             )
         );

--- a/server/src/test/java/org/elasticsearch/action/admin/indices/create/TransportCreateIndexActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/indices/create/TransportCreateIndexActionTests.java
@@ -29,7 +29,6 @@ import org.junit.Before;
 import org.mockito.ArgumentCaptor;
 
 import java.util.List;
-import java.util.Map;
 
 import static org.elasticsearch.cluster.metadata.IndexMetadata.SETTING_INDEX_HIDDEN;
 import static org.hamcrest.Matchers.equalTo;

--- a/server/src/test/java/org/elasticsearch/action/admin/indices/create/TransportCreateIndexActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/indices/create/TransportCreateIndexActionTests.java
@@ -47,8 +47,7 @@ public class TransportCreateIndexActionTests extends ESTestCase {
     private static final String SYSTEM_INDEX_NAME = ".my-system";
     private static final String SYSTEM_ALIAS_NAME = ".my-alias";
     private static final SystemIndices SYSTEM_INDICES = new SystemIndices(
-        Map.of(
-            "test-feature",
+        List.of(
             new SystemIndices.Feature(
                 "test-feature",
                 "a test feature",

--- a/server/src/test/java/org/elasticsearch/action/admin/indices/settings/put/TransportUpdateSettingsActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/indices/settings/put/TransportUpdateSettingsActionTests.java
@@ -30,7 +30,6 @@ import org.junit.Before;
 import org.mockito.ArgumentCaptor;
 
 import java.util.List;
-import java.util.Map;
 
 import static org.hamcrest.Matchers.equalTo;
 import static org.mockito.ArgumentMatchers.any;

--- a/server/src/test/java/org/elasticsearch/action/admin/indices/settings/put/TransportUpdateSettingsActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/indices/settings/put/TransportUpdateSettingsActionTests.java
@@ -62,8 +62,7 @@ public class TransportUpdateSettingsActionTests extends ESTestCase {
 
     private static final String SYSTEM_INDEX_NAME = ".my-system";
     private static final SystemIndices SYSTEM_INDICES = new SystemIndices(
-        Map.of(
-            "test-feature",
+        List.of(
             new SystemIndices.Feature("test-feature", "a test feature", List.of(new SystemIndexDescriptor(SYSTEM_INDEX_NAME + "*", "test")))
         )
     );

--- a/server/src/test/java/org/elasticsearch/action/bulk/TransportBulkActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/bulk/TransportBulkActionTests.java
@@ -291,7 +291,7 @@ public class TransportBulkActionTests extends ESTestCase {
             new ConcreteIndex(IndexMetadata.builder(".bar").settings(settings).system(true).numberOfShards(1).numberOfReplicas(0).build())
         );
         SystemIndices systemIndices = new SystemIndices(
-            Map.of("plugin", new SystemIndices.Feature("plugin", "test feature", List.of(new SystemIndexDescriptor(".test*", ""))))
+            List.of(new SystemIndices.Feature("plugin", "test feature", List.of(new SystemIndexDescriptor(".test*", ""))))
         );
         List<String> onlySystem = List.of(".foo", ".bar");
         assertTrue(TransportBulkAction.isOnlySystem(buildBulkRequest(onlySystem), indicesLookup, systemIndices));

--- a/server/src/test/java/org/elasticsearch/action/bulk/TransportBulkActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/bulk/TransportBulkActionTests.java
@@ -49,7 +49,6 @@ import org.junit.Before;
 
 import java.util.Collections;
 import java.util.List;
-import java.util.Map;
 import java.util.SortedMap;
 import java.util.TreeMap;
 import java.util.concurrent.TimeUnit;

--- a/server/src/test/java/org/elasticsearch/action/support/AutoCreateIndexTests.java
+++ b/server/src/test/java/org/elasticsearch/action/support/AutoCreateIndexTests.java
@@ -325,8 +325,7 @@ public class AutoCreateIndexTests extends ESTestCase {
 
     private AutoCreateIndex newAutoCreateIndex(Settings settings) {
         SystemIndices systemIndices = new SystemIndices(
-            Map.of(
-                "plugin",
+            List.of(
                 new SystemIndices.Feature("plugin", "test feature", List.of(new SystemIndexDescriptor(TEST_SYSTEM_INDEX_NAME + "*", "")))
             )
         );

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/IndexNameExpressionResolverTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/IndexNameExpressionResolverTests.java
@@ -48,7 +48,6 @@ import java.util.Comparator;
 import java.util.EnumSet;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 import java.util.function.Function;
 

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/IndexNameExpressionResolverTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/IndexNameExpressionResolverTests.java
@@ -2323,16 +2323,13 @@ public class IndexNameExpressionResolverTests extends ESTestCase {
             )
             .build();
         SystemIndices systemIndices = new SystemIndices(
-            Map.of(
-                "ml",
+            List.of(
                 new Feature(
                     "ml",
                     "ml indices",
                     List.of(new SystemIndexDescriptor(".ml-meta*", "ml meta"), new SystemIndexDescriptor(".ml-stuff*", "other ml"))
                 ),
-                "watcher",
                 new Feature("watcher", "watcher indices", List.of(new SystemIndexDescriptor(".watches*", "watches index"))),
-                "stack-component",
                 new Feature(
                     "stack-component",
                     "stack component",

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/IndexNameExpressionResolverTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/IndexNameExpressionResolverTests.java
@@ -2983,14 +2983,12 @@ public class IndexNameExpressionResolverTests extends ESTestCase {
             .put(indexBuilder(".ml-stuff", SystemIndexDescriptor.DEFAULT_SETTINGS).state(State.OPEN).system(true))
             .put(indexBuilder("some-other-index").state(State.OPEN));
         SystemIndices systemIndices = new SystemIndices(
-            Map.of(
-                "ml",
+            List.of(
                 new Feature(
                     "ml",
                     "ml indices",
                     List.of(new SystemIndexDescriptor(".ml-meta*", "ml meta"), new SystemIndexDescriptor(".ml-stuff*", "other ml"))
                 ),
-                "watcher",
                 new Feature("watcher", "watcher indices", List.of(new SystemIndexDescriptor(".watches*", "watches index")))
             )
         );

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/MetadataCreateDataStreamServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/MetadataCreateDataStreamServiceTests.java
@@ -344,12 +344,11 @@ public class MetadataCreateDataStreamServiceTests extends ESTestCase {
     }
 
     private static SystemIndices getSystemIndices() {
-        Map<String, Feature> map = Map.of(
-            "system",
+        List<Feature> features = List.of(
             new Feature("systemFeature", "system feature description", List.of(), List.of(systemDataStreamDescriptor()))
         );
 
-        return new SystemIndices(map);
+        return new SystemIndices(features);
     }
 
     private static SystemDataStreamDescriptor systemDataStreamDescriptor() {

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/MetadataCreateIndexServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/MetadataCreateIndexServiceTests.java
@@ -649,9 +649,7 @@ public class MetadataCreateIndexServiceTests extends ESTestCase {
                 null,
                 threadPool,
                 null,
-                new SystemIndices(
-                    Collections.singletonList(new SystemIndices.Feature("foo", "test feature", systemIndexDescriptors))
-                ),
+                new SystemIndices(Collections.singletonList(new SystemIndices.Feature("foo", "test feature", systemIndexDescriptors))),
                 false,
                 new IndexSettingProviders(Set.of())
             );

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/MetadataCreateIndexServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/MetadataCreateIndexServiceTests.java
@@ -650,7 +650,7 @@ public class MetadataCreateIndexServiceTests extends ESTestCase {
                 threadPool,
                 null,
                 new SystemIndices(
-                    Collections.singletonMap("foo", new SystemIndices.Feature("foo", "test feature", systemIndexDescriptors))
+                    Collections.singletonList(new SystemIndices.Feature("foo", "test feature", systemIndexDescriptors))
                 ),
                 false,
                 new IndexSettingProviders(Set.of())

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/SystemIndexMetadataUpgradeServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/SystemIndexMetadataUpgradeServiceTests.java
@@ -46,7 +46,7 @@ public class SystemIndexMetadataUpgradeServiceTests extends ESTestCase {
     public void setUpTest() {
         // set up a system index upgrade service
         this.service = new SystemIndexMetadataUpgradeService(
-            new SystemIndices(Map.of("MyIndex", new SystemIndices.Feature("foo", "a test feature", List.of(DESCRIPTOR)))),
+            new SystemIndices(List.of(new SystemIndices.Feature("foo", "a test feature", List.of(DESCRIPTOR)))),
             mock(ClusterService.class)
         );
     }

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/SystemIndexMetadataUpgradeServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/SystemIndexMetadataUpgradeServiceTests.java
@@ -20,7 +20,6 @@ import org.elasticsearch.test.ESTestCase;
 import org.junit.Before;
 
 import java.util.List;
-import java.util.Map;
 
 import static org.hamcrest.Matchers.equalTo;
 import static org.mockito.Mockito.mock;

--- a/server/src/test/java/org/elasticsearch/indices/ExecutorSelectorTests.java
+++ b/server/src/test/java/org/elasticsearch/indices/ExecutorSelectorTests.java
@@ -24,8 +24,7 @@ public class ExecutorSelectorTests extends ESTestCase {
     public void testNonCriticalSystemIndexThreadPools() {
         ExecutorSelector service = new ExecutorSelector(
             new SystemIndices(
-                Map.of(
-                    "normal system index",
+                List.of(
                     new SystemIndices.Feature(
                         "normal",
                         "normal system index",
@@ -43,8 +42,7 @@ public class ExecutorSelectorTests extends ESTestCase {
     public void testCriticalSystemIndexThreadPools() {
         ExecutorSelector service = new ExecutorSelector(
             new SystemIndices(
-                Map.of(
-                    "critical system index",
+                List.of(
                     new SystemIndices.Feature(
                         "critical",
                         "critical system index",
@@ -69,8 +67,7 @@ public class ExecutorSelectorTests extends ESTestCase {
     public void testDefaultSystemDataStreamThreadPools() {
         ExecutorSelector service = new ExecutorSelector(
             new SystemIndices(
-                Map.of(
-                    "normal system index",
+                List.of(
                     new SystemIndices.Feature(
                         "data stream",
                         "data stream feature with default thread pools",
@@ -107,8 +104,7 @@ public class ExecutorSelectorTests extends ESTestCase {
     public void testCustomSystemDataStreamThreadPools() {
         ExecutorSelector service = new ExecutorSelector(
             new SystemIndices(
-                Map.of(
-                    "normal system index",
+                List.of(
                     new SystemIndices.Feature(
                         "data stream",
                         "data stream feature with custom thread pools",

--- a/server/src/test/java/org/elasticsearch/indices/SystemIndexManagerTests.java
+++ b/server/src/test/java/org/elasticsearch/indices/SystemIndexManagerTests.java
@@ -46,7 +46,6 @@ import java.io.UncheckedIOException;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Map;
 
 import static org.elasticsearch.xcontent.XContentFactory.jsonBuilder;
 import static org.hamcrest.Matchers.contains;

--- a/server/src/test/java/org/elasticsearch/indices/SystemIndexManagerTests.java
+++ b/server/src/test/java/org/elasticsearch/indices/SystemIndexManagerTests.java
@@ -106,10 +106,8 @@ public class SystemIndexManagerTests extends ESTestCase {
             .build();
 
         SystemIndices systemIndices = new SystemIndices(
-            Map.of(
-                "index 1",
+            List.of(
                 new SystemIndices.Feature("index 1", "index 1 feature", List.of(d1)),
-                "index 2",
                 new SystemIndices.Feature("index 2", "index 2 feature", List.of(d2))
             )
         );
@@ -151,10 +149,8 @@ public class SystemIndexManagerTests extends ESTestCase {
             .build();
 
         SystemIndices systemIndices = new SystemIndices(
-            Map.of(
-                "index 1",
+            List.of(
                 new SystemIndices.Feature("index 1", "index 1 feature", List.of(d1)),
-                "index 2",
                 new SystemIndices.Feature("index 2", "index 2 feature", List.of(d2))
             )
         );
@@ -251,7 +247,7 @@ public class SystemIndexManagerTests extends ESTestCase {
      * Check that the manager submits the expected request for an index whose mappings are out-of-date.
      */
     public void testManagerSubmitsPutRequest() {
-        SystemIndices systemIndices = new SystemIndices(Map.of("MyIndex", FEATURE));
+        SystemIndices systemIndices = new SystemIndices(List.of(FEATURE));
         SystemIndexManager manager = new SystemIndexManager(systemIndices, client);
 
         manager.clusterChanged(event(markShardsAvailable(createClusterState(Strings.toString(getMappings("1.0.0"))))));

--- a/server/src/test/java/org/elasticsearch/indices/SystemIndicesTests.java
+++ b/server/src/test/java/org/elasticsearch/indices/SystemIndicesTests.java
@@ -10,6 +10,7 @@ package org.elasticsearch.indices;
 
 import org.elasticsearch.test.ESTestCase;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -36,10 +37,9 @@ public class SystemIndicesTests extends ESTestCase {
         // across tests
         String broadPatternSource = "AAA" + randomAlphaOfLength(5);
         String otherSource = "ZZZ" + randomAlphaOfLength(6);
-        Map<String, SystemIndices.Feature> descriptors = new HashMap<>();
-        descriptors.put(broadPatternSource, new SystemIndices.Feature(broadPatternSource, "test feature", List.of(broadPattern)));
-        descriptors.put(
-            otherSource,
+        List<SystemIndices.Feature> descriptors = new ArrayList<>();
+        descriptors.add(new SystemIndices.Feature(broadPatternSource, "test feature", List.of(broadPattern)));
+        descriptors.add(
             new SystemIndices.Feature(otherSource, "test 2", List.of(notOverlapping, overlapping1, overlapping2, overlapping3))
         );
 
@@ -76,9 +76,9 @@ public class SystemIndicesTests extends ESTestCase {
         // across tests
         String source1 = "AAA" + randomAlphaOfLength(5);
         String source2 = "ZZZ" + randomAlphaOfLength(6);
-        Map<String, SystemIndices.Feature> descriptors = new HashMap<>();
-        descriptors.put(source1, new SystemIndices.Feature(source1, "test", List.of(pattern1)));
-        descriptors.put(source2, new SystemIndices.Feature(source2, "test", List.of(pattern2)));
+        List<SystemIndices.Feature> descriptors = new ArrayList<>();
+        descriptors.add(new SystemIndices.Feature(source1, "test", List.of(pattern1)));
+        descriptors.add(new SystemIndices.Feature(source2, "test", List.of(pattern2)));
 
         IllegalStateException exception = expectThrows(
             IllegalStateException.class,
@@ -97,15 +97,14 @@ public class SystemIndicesTests extends ESTestCase {
     }
 
     public void testBuiltInSystemIndices() {
-        SystemIndices systemIndices = new SystemIndices(Map.of());
+        SystemIndices systemIndices = new SystemIndices(List.of());
         assertTrue(systemIndices.isSystemIndex(".tasks"));
         assertTrue(systemIndices.isSystemIndex(".tasks1"));
         assertTrue(systemIndices.isSystemIndex(".tasks-old"));
     }
 
     public void testPluginCannotOverrideBuiltInSystemIndex() {
-        Map<String, SystemIndices.Feature> pluginMap = Map.of(
-            TASKS_FEATURE_NAME,
+        List<SystemIndices.Feature> pluginMap = List.of(
             new SystemIndices.Feature(
                 TASKS_FEATURE_NAME,
                 "test",
@@ -119,8 +118,7 @@ public class SystemIndicesTests extends ESTestCase {
     public void testPatternWithSimpleRange() {
 
         final SystemIndices systemIndices = new SystemIndices(
-            Map.of(
-                "test",
+            List.of(
                 new SystemIndices.Feature(
                     "test",
                     "test feature",
@@ -141,8 +139,7 @@ public class SystemIndicesTests extends ESTestCase {
 
     public void testPatternWithSimpleRangeAndRepeatOperator() {
         final SystemIndices systemIndices = new SystemIndices(
-            Map.of(
-                "test",
+            List.of(
                 new SystemIndices.Feature(
                     "test",
                     "test feature",
@@ -160,8 +157,7 @@ public class SystemIndicesTests extends ESTestCase {
 
     public void testPatternWithComplexRange() {
         final SystemIndices systemIndices = new SystemIndices(
-            Map.of(
-                "test",
+            List.of(
                 new SystemIndices.Feature(
                     "test",
                     "test feature",
@@ -187,9 +183,9 @@ public class SystemIndicesTests extends ESTestCase {
         SystemIndexDescriptor pattern1 = new SystemIndexDescriptor(".test-[ab]*", "");
         SystemIndexDescriptor pattern2 = new SystemIndexDescriptor(".test-a*", "");
 
-        Map<String, SystemIndices.Feature> descriptors = new HashMap<>();
-        descriptors.put(source1, new SystemIndices.Feature(source1, "source 1", List.of(pattern1)));
-        descriptors.put(source2, new SystemIndices.Feature(source2, "source 2", List.of(pattern2)));
+        List<SystemIndices.Feature> descriptors = new ArrayList();
+        descriptors.add(new SystemIndices.Feature(source1, "source 1", List.of(pattern1)));
+        descriptors.add(new SystemIndices.Feature(source2, "source 2", List.of(pattern2)));
 
         IllegalStateException exception = expectThrows(
             IllegalStateException.class,

--- a/server/src/test/java/org/elasticsearch/indices/SystemIndicesTests.java
+++ b/server/src/test/java/org/elasticsearch/indices/SystemIndicesTests.java
@@ -12,9 +12,7 @@ import org.elasticsearch.test.ESTestCase;
 
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
 import static org.elasticsearch.tasks.TaskResultsService.TASKS_FEATURE_NAME;
 import static org.elasticsearch.tasks.TaskResultsService.TASK_INDEX;
@@ -208,10 +206,9 @@ public class SystemIndicesTests extends ESTestCase {
         final SystemIndexDescriptor okayDescriptor = new SystemIndexDescriptor(".okay*", "concrete index");
         final SystemIndexDescriptor endsWithNumbersThenWildcard = new SystemIndexDescriptor(".desc[0-9]+*", "concrete index");
 
-        final Map<String, SystemIndices.Feature> features = new HashMap<>();
+        final List<SystemIndices.Feature> features = new ArrayList<>();
         final String firstFeature = "first";
-        features.put(
-            firstFeature,
+        features.add(
             new SystemIndices.Feature(
                 firstFeature,
                 this.getTestName() + " - " + firstFeature,
@@ -219,13 +216,11 @@ public class SystemIndicesTests extends ESTestCase {
             )
         );
         final String secondFeature = "second";
-        features.put(
-            secondFeature,
+        features.add(
             new SystemIndices.Feature(secondFeature, this.getTestName() + " - " + secondFeature, List.of(concreteIndex, okayDescriptor))
         );
         final String thirdFeature = "third";
-        features.put(
-            thirdFeature,
+        features.add(
             new SystemIndices.Feature(thirdFeature, this.getTestName() + " - " + thirdFeature, List.of(endsWithNumbersThenWildcard))
         );
 

--- a/server/src/test/java/org/elasticsearch/indices/SystemIndicesTests.java
+++ b/server/src/test/java/org/elasticsearch/indices/SystemIndicesTests.java
@@ -10,9 +10,10 @@ package org.elasticsearch.indices;
 
 import org.elasticsearch.test.ESTestCase;
 
-import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import static org.elasticsearch.tasks.TaskResultsService.TASKS_FEATURE_NAME;
 import static org.elasticsearch.tasks.TaskResultsService.TASK_INDEX;
@@ -35,9 +36,10 @@ public class SystemIndicesTests extends ESTestCase {
         // across tests
         String broadPatternSource = "AAA" + randomAlphaOfLength(5);
         String otherSource = "ZZZ" + randomAlphaOfLength(6);
-        List<SystemIndices.Feature> descriptors = new ArrayList<>();
-        descriptors.add(new SystemIndices.Feature(broadPatternSource, "test feature", List.of(broadPattern)));
-        descriptors.add(
+        Map<String, SystemIndices.Feature> descriptors = new HashMap<>();
+        descriptors.put(broadPatternSource, new SystemIndices.Feature(broadPatternSource, "test feature", List.of(broadPattern)));
+        descriptors.put(
+            otherSource,
             new SystemIndices.Feature(otherSource, "test 2", List.of(notOverlapping, overlapping1, overlapping2, overlapping3))
         );
 
@@ -61,7 +63,10 @@ public class SystemIndicesTests extends ESTestCase {
         assertThat(exception.getMessage(), containsString(overlapping3.toString() + fromPluginString));
         assertThat(exception.getMessage(), not(containsString(notOverlapping.toString())));
 
-        IllegalStateException constructorException = expectThrows(IllegalStateException.class, () -> new SystemIndices(descriptors));
+        IllegalStateException constructorException = expectThrows(
+            IllegalStateException.class,
+            () -> new SystemIndices(List.copyOf(descriptors.values()))
+        );
         assertThat(constructorException.getMessage(), equalTo(exception.getMessage()));
     }
 
@@ -74,9 +79,9 @@ public class SystemIndicesTests extends ESTestCase {
         // across tests
         String source1 = "AAA" + randomAlphaOfLength(5);
         String source2 = "ZZZ" + randomAlphaOfLength(6);
-        List<SystemIndices.Feature> descriptors = new ArrayList<>();
-        descriptors.add(new SystemIndices.Feature(source1, "test", List.of(pattern1)));
-        descriptors.add(new SystemIndices.Feature(source2, "test", List.of(pattern2)));
+        Map<String, SystemIndices.Feature> descriptors = new HashMap<>();
+        descriptors.put(source1, new SystemIndices.Feature(source1, "test", List.of(pattern1)));
+        descriptors.put(source2, new SystemIndices.Feature(source2, "test", List.of(pattern2)));
 
         IllegalStateException exception = expectThrows(
             IllegalStateException.class,
@@ -90,7 +95,10 @@ public class SystemIndicesTests extends ESTestCase {
         );
         assertThat(exception.getMessage(), containsString(pattern2.toString() + " from [" + source2 + "]"));
 
-        IllegalStateException constructorException = expectThrows(IllegalStateException.class, () -> new SystemIndices(descriptors));
+        IllegalStateException constructorException = expectThrows(
+            IllegalStateException.class,
+            () -> new SystemIndices(List.copyOf(descriptors.values()))
+        );
         assertThat(constructorException.getMessage(), equalTo(exception.getMessage()));
     }
 
@@ -181,9 +189,9 @@ public class SystemIndicesTests extends ESTestCase {
         SystemIndexDescriptor pattern1 = new SystemIndexDescriptor(".test-[ab]*", "");
         SystemIndexDescriptor pattern2 = new SystemIndexDescriptor(".test-a*", "");
 
-        List<SystemIndices.Feature> descriptors = new ArrayList<>();
-        descriptors.add(new SystemIndices.Feature(source1, "source 1", List.of(pattern1)));
-        descriptors.add(new SystemIndices.Feature(source2, "source 2", List.of(pattern2)));
+        Map<String, SystemIndices.Feature> descriptors = new HashMap<>();
+        descriptors.put(source1, new SystemIndices.Feature(source1, "source 1", List.of(pattern1)));
+        descriptors.put(source2, new SystemIndices.Feature(source2, "source 2", List.of(pattern2)));
 
         IllegalStateException exception = expectThrows(
             IllegalStateException.class,
@@ -206,9 +214,10 @@ public class SystemIndicesTests extends ESTestCase {
         final SystemIndexDescriptor okayDescriptor = new SystemIndexDescriptor(".okay*", "concrete index");
         final SystemIndexDescriptor endsWithNumbersThenWildcard = new SystemIndexDescriptor(".desc[0-9]+*", "concrete index");
 
-        final List<SystemIndices.Feature> features = new ArrayList<>();
+        final Map<String, SystemIndices.Feature> features = new HashMap<>();
         final String firstFeature = "first";
-        features.add(
+        features.put(
+            firstFeature,
             new SystemIndices.Feature(
                 firstFeature,
                 this.getTestName() + " - " + firstFeature,
@@ -216,11 +225,13 @@ public class SystemIndicesTests extends ESTestCase {
             )
         );
         final String secondFeature = "second";
-        features.add(
+        features.put(
+            secondFeature,
             new SystemIndices.Feature(secondFeature, this.getTestName() + " - " + secondFeature, List.of(concreteIndex, okayDescriptor))
         );
         final String thirdFeature = "third";
-        features.add(
+        features.put(
+            thirdFeature,
             new SystemIndices.Feature(thirdFeature, this.getTestName() + " - " + thirdFeature, List.of(endsWithNumbersThenWildcard))
         );
 

--- a/server/src/test/java/org/elasticsearch/indices/SystemIndicesTests.java
+++ b/server/src/test/java/org/elasticsearch/indices/SystemIndicesTests.java
@@ -183,7 +183,7 @@ public class SystemIndicesTests extends ESTestCase {
         SystemIndexDescriptor pattern1 = new SystemIndexDescriptor(".test-[ab]*", "");
         SystemIndexDescriptor pattern2 = new SystemIndexDescriptor(".test-a*", "");
 
-        List<SystemIndices.Feature> descriptors = new ArrayList();
+        List<SystemIndices.Feature> descriptors = new ArrayList<>();
         descriptors.add(new SystemIndices.Feature(source1, "source 1", List.of(pattern1)));
         descriptors.add(new SystemIndices.Feature(source2, "source 2", List.of(pattern2)));
 

--- a/test/framework/src/main/java/org/elasticsearch/indices/EmptySystemIndices.java
+++ b/test/framework/src/main/java/org/elasticsearch/indices/EmptySystemIndices.java
@@ -8,7 +8,7 @@
 
 package org.elasticsearch.indices;
 
-import java.util.Map;
+import java.util.List;
 
 /**
  * A test class which contains a singleton instance of the {@link SystemIndices} class that has been created with no
@@ -19,6 +19,6 @@ public class EmptySystemIndices extends SystemIndices {
     public static final SystemIndices INSTANCE = new EmptySystemIndices();
 
     private EmptySystemIndices() {
-        super(Map.of());
+        super(List.of());
     }
 }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/test/TestRestrictedIndices.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/test/TestRestrictedIndices.java
@@ -65,9 +65,7 @@ public class TestRestrictedIndices {
                 List.of(getMainSecurityDescriptor(), getSecurityTokensDescriptor())
             )
         );
-        features.add(
-            new Feature("async search mock", "fake async search for restricted indices", List.of(getAsyncSearchDescriptor()))
-        );
+        features.add(new Feature("async search mock", "fake async search for restricted indices", List.of(getAsyncSearchDescriptor())));
         features.add(
             new Feature(
                 "kibana-mock",

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/test/TestRestrictedIndices.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/test/TestRestrictedIndices.java
@@ -24,10 +24,9 @@ import org.elasticsearch.xpack.core.security.authz.RestrictedIndices;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
+import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 
 import static org.elasticsearch.index.mapper.MapperService.SINGLE_MAPPING_NAME;
@@ -58,21 +57,18 @@ public class TestRestrictedIndices {
     );
 
     static {
-        Map<String, Feature> featureMap = new HashMap<>();
-        featureMap.put(
-            "security-mock",
+        List<Feature> features = new ArrayList<>();
+        features.add(
             new Feature(
                 "security-mock",
                 "fake security for test restricted indices",
                 List.of(getMainSecurityDescriptor(), getSecurityTokensDescriptor())
             )
         );
-        featureMap.put(
-            "async-search-mock",
+        features.add(
             new Feature("async search mock", "fake async search for restricted indices", List.of(getAsyncSearchDescriptor()))
         );
-        featureMap.put(
-            "kibana-mock",
+        features.add(
             new Feature(
                 "kibana-mock",
                 "fake kibana for testing restricted indices",
@@ -87,16 +83,14 @@ public class TestRestrictedIndices {
 
         // From here, we have very minimal mock features that only supply system index patterns,
         // not settings or mock mappings.
-        featureMap.put(
-            "enrich-mock",
+        features.add(
             new Feature(
                 "enrich-mock",
                 "fake enrich for restricted indices tests",
                 List.of(new SystemIndexDescriptor(".enrich-*", "enrich pattern"))
             )
         );
-        featureMap.put(
-            "fleet-mock",
+        features.add(
             new Feature(
                 "fleet-mock",
                 "fake fleet for restricted indices tests",
@@ -111,24 +105,21 @@ public class TestRestrictedIndices {
                 )
             )
         );
-        featureMap.put(
-            "ingest-geoip-mock",
+        features.add(
             new Feature(
                 "ingest-geoip-mock",
                 "fake geoip for restricted indices tests",
                 List.of(new SystemIndexDescriptor(".geoip_databases*", "geoip databases"))
             )
         );
-        featureMap.put(
-            "logstash-mock",
+        features.add(
             new Feature(
                 "logstash-mock",
                 "fake logstash for restricted indices tests",
                 List.of(new SystemIndexDescriptor(".logstash*", "logstash"))
             )
         );
-        featureMap.put(
-            "machine-learning-mock",
+        features.add(
             new Feature(
                 "machine-learning-mock",
                 "fake machine learning for restricted indices tests",
@@ -139,24 +130,21 @@ public class TestRestrictedIndices {
                 )
             )
         );
-        featureMap.put(
-            "searchable-snapshots-mock",
+        features.add(
             new Feature(
                 "searchable-snapshots-mock",
                 "fake searchable snapshots for restricted indices tests",
                 List.of(new SystemIndexDescriptor(".snapshot-blob-cache*", "snapshot blob cache"))
             )
         );
-        featureMap.put(
-            "transform-mock",
+        features.add(
             new Feature(
                 "transform-mock",
                 "fake transform for restricted indices tests",
                 List.of(new SystemIndexDescriptor(".transform-internal-*", "transform internal"))
             )
         );
-        featureMap.put(
-            "watcher-mock",
+        features.add(
             new Feature(
                 "watcher-mock",
                 "fake watcher for restricted indices tests",
@@ -167,7 +155,7 @@ public class TestRestrictedIndices {
             )
         );
 
-        SystemIndices systemIndices = new SystemIndices(featureMap);
+        SystemIndices systemIndices = new SystemIndices(features);
         RESTRICTED_INDICES = new RestrictedIndices(systemIndices.getSystemNameAutomaton());
         RESOLVER = TestIndexNameExpressionResolver.newInstance(systemIndices);
     }

--- a/x-pack/plugin/fleet/src/test/java/org/elasticsearch/xpack/fleet/FleetTests.java
+++ b/x-pack/plugin/fleet/src/test/java/org/elasticsearch/xpack/fleet/FleetTests.java
@@ -14,7 +14,7 @@ import org.elasticsearch.indices.SystemIndices.Feature;
 import org.elasticsearch.test.ESTestCase;
 
 import java.util.Collection;
-import java.util.Map;
+import java.util.List;
 import java.util.stream.Collectors;
 
 import static org.hamcrest.Matchers.containsInAnyOrder;
@@ -53,7 +53,7 @@ public class FleetTests extends ESTestCase {
     public void testFleetFeature() {
         Fleet module = new Fleet();
         Feature fleet = Feature.fromSystemIndexPlugin(module, Settings.EMPTY);
-        SystemIndices systemIndices = new SystemIndices(Map.of(module.getFeatureName(), fleet));
+        SystemIndices systemIndices = new SystemIndices(List.of(fleet));
         assertNotNull(systemIndices);
     }
 }


### PR DESCRIPTION
This PR gets rid of a lot of crufty code in `SystemIndices` and related classes. Basically, we held Feature objects in maps of feature name to feature, implicitly expecting that the map key would match the value of Feature#getName. This was easy to mess up in tests.

The history here is that `Feature#getName` was added to the Feature class after all those maps had been written, but I never cleaned up the old code.

One place we did take advantage of the map structure was in the snapshot/restore code, so I've added a `SystemIndices#getFeature` method to replace it.

I also renamed some variables as I was going to better reflect what was actually being passed around.

If approved, I'm planning to backport this so that we can more easily apply bugfixes in the system indices code.