### PR TITLE
Modularize the analysis-common component

### DIFF
--- a/modules/analysis-common/build.gradle
+++ b/modules/analysis-common/build.gradle
@@ -22,7 +22,7 @@ restResources {
 }
 
 dependencies {
-  compileOnly project(':modules:lang-painless')
+  compileOnly project(':modules:lang-painless:spi')
 }
 
 tasks.named("yamlRestTestV7CompatTransform").configure { task ->

--- a/modules/analysis-common/src/main/java/module-info.java
+++ b/modules/analysis-common/src/main/java/module-info.java
@@ -17,5 +17,8 @@ module org.elasticsearch.analysis.common {
     requires org.apache.lucene.core;
     requires org.apache.lucene.analysis.common;
 
+    exports org.elasticsearch.analysis.common;  // for painless
+    opens org.elasticsearch.analysis.common to org.elasticsearch.painless.spi; // whitelist resource access
+
     provides org.elasticsearch.painless.spi.PainlessExtension with org.elasticsearch.analysis.common.AnalysisPainlessExtension;
 }

--- a/modules/analysis-common/src/main/java/module-info.java
+++ b/modules/analysis-common/src/main/java/module-info.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+module org.elasticsearch.analysis.common {
+    requires java.xml;
+
+    requires org.elasticsearch.painless.spi;
+    requires org.elasticsearch.server;
+    requires org.elasticsearch.xcontent;
+
+    requires org.apache.logging.log4j;
+    requires org.apache.lucene.core;
+    requires org.apache.lucene.analysis.common;
+
+    provides org.elasticsearch.painless.spi.PainlessExtension with org.elasticsearch.analysis.common.AnalysisPainlessExtension;
+}

--- a/modules/analysis-common/src/main/java/module-info.java
+++ b/modules/analysis-common/src/main/java/module-info.java
@@ -18,6 +18,7 @@ module org.elasticsearch.analysis.common {
     requires org.apache.lucene.analysis.common;
 
     exports org.elasticsearch.analysis.common;  // for painless
+
     opens org.elasticsearch.analysis.common to org.elasticsearch.painless.spi; // whitelist resource access
 
     provides org.elasticsearch.painless.spi.PainlessExtension with org.elasticsearch.analysis.common.AnalysisPainlessExtension;


### PR DESCRIPTION
This change modularizes analysis-common, by adding a module-info.java

The project only requires painless SPI to compile, so that was fixed along the way ( so that the compile module path can be inferred directly from the dependencies ).

relates #78744