### PR TITLE
REST tests for avg/max/min/sum_bucket aggs

### DIFF
--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.aggregation/500_avg_bucket.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.aggregation/500_avg_bucket.yml
@@ -1,0 +1,149 @@
+setup:
+  - do:
+      bulk:
+        index: no_gaps
+        refresh: true
+        body:
+          - { "index": { } }
+          - { "@timestamp": "2022-01-01T00:00:00", "v": 1 }
+          - { "index": { } }
+          - { "@timestamp": "2022-01-01T01:00:00", "v": 2 }
+          - { "index": { } }
+          - { "@timestamp": "2022-01-01T02:00:00", "v": 1 }
+
+  - do:
+      bulk:
+        index: gaps
+        refresh: true
+        body:
+          - { "index": { } }
+          - { "@timestamp": "2022-01-01T00:00:00", "v": 1 }
+          - { "index": { } }
+          - { "@timestamp": "2022-01-01T02:00:00", "v": 2 }
+          - { "index": { } }
+          - { "@timestamp": "2022-01-01T03:00:00", "v": 1 }
+
+---
+basic:
+  - skip:
+      features: close_to
+
+  - do:
+      search:
+        index: no_gaps
+        body:
+          size: 0
+          aggs:
+            "@timestamp":
+              date_histogram:
+                field: "@timestamp"
+                fixed_interval: 1h
+              aggs:
+                v: {avg: {field: v}}
+            d:
+              avg_bucket:
+                buckets_path: "@timestamp>v"
+  - match: { hits.total.value: 3 }
+  - length: { aggregations.@timestamp.buckets: 3 }
+  - close_to: { aggregations.d.value: { value: 1.333, error: 0.0005 }}
+
+---
+format:
+  - skip:
+      features: close_to
+
+  - do:
+      search:
+        index: no_gaps
+        body:
+          size: 0
+          aggs:
+            "@timestamp":
+              date_histogram:
+                field: "@timestamp"
+                fixed_interval: 1h
+              aggs:
+                v: {avg: {field: v}}
+            d:
+              avg_bucket:
+                buckets_path: "@timestamp>v"
+                format: "0.00"
+  - match: { hits.total.value: 3 }
+  - length: { aggregations.@timestamp.buckets: 3 }
+  - close_to: { aggregations.d.value: { value: 1.333, error: 0.0005 }}
+  - match: { aggregations.d.value_as_string: "1.33" }
+
+---
+gap_policy=skip:
+  - skip:
+      features: close_to
+
+  - do:
+      search:
+        index: gaps
+        body:
+          size: 0
+          aggs:
+            "@timestamp":
+              date_histogram:
+                field: "@timestamp"
+                fixed_interval: 1h
+              aggs:
+                v: {avg: {field: v}}
+            d:
+              avg_bucket:
+                buckets_path: "@timestamp>v"
+                gap_policy: skip
+  - match: { hits.total.value: 3 }
+  - length: { aggregations.@timestamp.buckets: 4 }
+  - close_to: { aggregations.d.value: { value: 1.333, error: 0.0005 }}
+
+---
+gap_policy=insert_zeros:
+  - skip:
+      features: close_to
+
+  - do:
+      search:
+        index: gaps
+        body:
+          size: 0
+          aggs:
+            "@timestamp":
+              date_histogram:
+                field: "@timestamp"
+                fixed_interval: 1h
+              aggs:
+                v: {avg: {field: v}}
+            d:
+              avg_bucket:
+                buckets_path: "@timestamp>v"
+                gap_policy: insert_zeros
+  - match: { hits.total.value: 3 }
+  - length: { aggregations.@timestamp.buckets: 4 }
+  - match: { aggregations.d.value: 1.0 }
+
+---
+gap_policy=keep_value:
+  - skip:
+      features: close_to
+
+  - do:
+      search:
+        index: gaps
+        body:
+          size: 0
+          aggs:
+            "@timestamp":
+              date_histogram:
+                field: "@timestamp"
+                fixed_interval: 1h
+              aggs:
+                v: {avg: {field: v}}
+            d:
+              avg_bucket:
+                buckets_path: "@timestamp>v"
+                gap_policy: keep_values
+  - match: { hits.total.value: 3 }
+  - length: { aggregations.@timestamp.buckets: 4 }
+  - close_to: { aggregations.d.value: { value: 1.333, error: 0.0005 }}

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.aggregation/500_max_bucket.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.aggregation/500_max_bucket.yml
@@ -1,0 +1,134 @@
+setup:
+  - do:
+      bulk:
+        index: no_gaps
+        refresh: true
+        body:
+          - { "index": { } }
+          - { "@timestamp": "2022-01-01T00:00:00", "v": 1 }
+          - { "index": { } }
+          - { "@timestamp": "2022-01-01T01:00:00", "v": 2 }
+          - { "index": { } }
+          - { "@timestamp": "2022-01-01T02:00:00", "v": 1 }
+
+  - do:
+      bulk:
+        index: gaps
+        refresh: true
+        body:
+          - { "index": { } }
+          - { "@timestamp": "2022-01-01T00:00:00", "v": -1 }
+          - { "index": { } }
+          - { "@timestamp": "2022-01-01T02:00:00", "v": -2 }
+          - { "index": { } }
+          - { "@timestamp": "2022-01-01T03:00:00", "v": -1 }
+
+---
+basic:
+  - do:
+      search:
+        index: no_gaps
+        body:
+          size: 0
+          aggs:
+            "@timestamp":
+              date_histogram:
+                field: "@timestamp"
+                fixed_interval: 1h
+              aggs:
+                v: {avg: {field: v}}
+            d:
+              max_bucket:
+                buckets_path: "@timestamp>v"
+  - match: { hits.total.value: 3 }
+  - length: { aggregations.@timestamp.buckets: 3 }
+  - match: { aggregations.d.value: 2.0 }
+
+---
+format:
+  - do:
+      search:
+        index: no_gaps
+        body:
+          size: 0
+          aggs:
+            "@timestamp":
+              date_histogram:
+                field: "@timestamp"
+                fixed_interval: 1h
+              aggs:
+                v: {avg: {field: v}}
+            d:
+              max_bucket:
+                buckets_path: "@timestamp>v"
+                format: "0.00"
+  - match: { hits.total.value: 3 }
+  - length: { aggregations.@timestamp.buckets: 3 }
+  - match: { aggregations.d.value: 2.0 }
+  - match: { aggregations.d.value_as_string: "2.00" }
+
+---
+gap_policy=skip:
+  - do:
+      search:
+        index: gaps
+        body:
+          size: 0
+          aggs:
+            "@timestamp":
+              date_histogram:
+                field: "@timestamp"
+                fixed_interval: 1h
+              aggs:
+                v: {avg: {field: v}}
+            d:
+              max_bucket:
+                buckets_path: "@timestamp>v"
+                gap_policy: skip
+  - match: { hits.total.value: 3 }
+  - length: { aggregations.@timestamp.buckets: 4 }
+  - match: { aggregations.d.value: -1.0 }
+
+---
+gap_policy=insert_zeros:
+  - do:
+      search:
+        index: gaps
+        body:
+          size: 0
+          aggs:
+            "@timestamp":
+              date_histogram:
+                field: "@timestamp"
+                fixed_interval: 1h
+              aggs:
+                v: {avg: {field: v}}
+            d:
+              max_bucket:
+                buckets_path: "@timestamp>v"
+                gap_policy: insert_zeros
+  - match: { hits.total.value: 3 }
+  - length: { aggregations.@timestamp.buckets: 4 }
+  - match: { aggregations.d.value: 0.0 }
+
+---
+gap_policy=keep_value:
+  - do:
+      search:
+        index: gaps
+        body:
+          size: 0
+          aggs:
+            "@timestamp":
+              date_histogram:
+                field: "@timestamp"
+                fixed_interval: 1h
+              aggs:
+                v: {avg: {field: v}}
+            d:
+              max_bucket:
+                buckets_path: "@timestamp>v"
+                gap_policy: keep_values
+  - match: { hits.total.value: 3 }
+  - length: { aggregations.@timestamp.buckets: 4 }
+  - match: { aggregations.d.value: -1.0 }

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.aggregation/500_min_bucket.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.aggregation/500_min_bucket.yml
@@ -1,0 +1,134 @@
+setup:
+  - do:
+      bulk:
+        index: no_gaps
+        refresh: true
+        body:
+          - { "index": { } }
+          - { "@timestamp": "2022-01-01T00:00:00", "v": 1 }
+          - { "index": { } }
+          - { "@timestamp": "2022-01-01T01:00:00", "v": 2 }
+          - { "index": { } }
+          - { "@timestamp": "2022-01-01T02:00:00", "v": 1 }
+
+  - do:
+      bulk:
+        index: gaps
+        refresh: true
+        body:
+          - { "index": { } }
+          - { "@timestamp": "2022-01-01T00:00:00", "v": 1 }
+          - { "index": { } }
+          - { "@timestamp": "2022-01-01T02:00:00", "v": 2 }
+          - { "index": { } }
+          - { "@timestamp": "2022-01-01T03:00:00", "v": 1 }
+
+---
+basic:
+  - do:
+      search:
+        index: no_gaps
+        body:
+          size: 0
+          aggs:
+            "@timestamp":
+              date_histogram:
+                field: "@timestamp"
+                fixed_interval: 1h
+              aggs:
+                v: {avg: {field: v}}
+            d:
+              min_bucket:
+                buckets_path: "@timestamp>v"
+  - match: { hits.total.value: 3 }
+  - length: { aggregations.@timestamp.buckets: 3 }
+  - match: { aggregations.d.value: 1.0 }
+
+---
+format:
+  - do:
+      search:
+        index: no_gaps
+        body:
+          size: 0
+          aggs:
+            "@timestamp":
+              date_histogram:
+                field: "@timestamp"
+                fixed_interval: 1h
+              aggs:
+                v: {avg: {field: v}}
+            d:
+              min_bucket:
+                buckets_path: "@timestamp>v"
+                format: "0.00"
+  - match: { hits.total.value: 3 }
+  - length: { aggregations.@timestamp.buckets: 3 }
+  - match: { aggregations.d.value: 1.0 }
+  - match: { aggregations.d.value_as_string: "1.00" }
+
+---
+gap_policy=skip:
+  - do:
+      search:
+        index: gaps
+        body:
+          size: 0
+          aggs:
+            "@timestamp":
+              date_histogram:
+                field: "@timestamp"
+                fixed_interval: 1h
+              aggs:
+                v: {avg: {field: v}}
+            d:
+              min_bucket:
+                buckets_path: "@timestamp>v"
+                gap_policy: skip
+  - match: { hits.total.value: 3 }
+  - length: { aggregations.@timestamp.buckets: 4 }
+  - match: { aggregations.d.value: 1.0 }
+
+---
+gap_policy=insert_zeros:
+  - do:
+      search:
+        index: gaps
+        body:
+          size: 0
+          aggs:
+            "@timestamp":
+              date_histogram:
+                field: "@timestamp"
+                fixed_interval: 1h
+              aggs:
+                v: {avg: {field: v}}
+            d:
+              min_bucket:
+                buckets_path: "@timestamp>v"
+                gap_policy: insert_zeros
+  - match: { hits.total.value: 3 }
+  - length: { aggregations.@timestamp.buckets: 4 }
+  - match: { aggregations.d.value: 0.0 }
+
+---
+gap_policy=keep_value:
+  - do:
+      search:
+        index: gaps
+        body:
+          size: 0
+          aggs:
+            "@timestamp":
+              date_histogram:
+                field: "@timestamp"
+                fixed_interval: 1h
+              aggs:
+                v: {avg: {field: v}}
+            d:
+              min_bucket:
+                buckets_path: "@timestamp>v"
+                gap_policy: keep_values
+  - match: { hits.total.value: 3 }
+  - length: { aggregations.@timestamp.buckets: 4 }
+  - match: { aggregations.d.value: 1.0 }

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.aggregation/500_sum_bucket.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.aggregation/500_sum_bucket.yml
@@ -1,0 +1,134 @@
+setup:
+  - do:
+      bulk:
+        index: no_gaps
+        refresh: true
+        body:
+          - { "index": { } }
+          - { "@timestamp": "2022-01-01T00:00:00", "v": 1 }
+          - { "index": { } }
+          - { "@timestamp": "2022-01-01T01:00:00", "v": 2 }
+          - { "index": { } }
+          - { "@timestamp": "2022-01-01T02:00:00", "v": 1 }
+
+  - do:
+      bulk:
+        index: gaps
+        refresh: true
+        body:
+          - { "index": { } }
+          - { "@timestamp": "2022-01-01T00:00:00", "v": 1 }
+          - { "index": { } }
+          - { "@timestamp": "2022-01-01T02:00:00", "v": 2 }
+          - { "index": { } }
+          - { "@timestamp": "2022-01-01T03:00:00", "v": 1 }
+
+---
+basic:
+  - do:
+      search:
+        index: no_gaps
+        body:
+          size: 0
+          aggs:
+            "@timestamp":
+              date_histogram:
+                field: "@timestamp"
+                fixed_interval: 1h
+              aggs:
+                v: {avg: {field: v}}
+            d:
+              sum_bucket:
+                buckets_path: "@timestamp>v"
+  - match: { hits.total.value: 3 }
+  - length: { aggregations.@timestamp.buckets: 3 }
+  - match: { aggregations.d.value: 4.0 }
+
+---
+format:
+  - do:
+      search:
+        index: no_gaps
+        body:
+          size: 0
+          aggs:
+            "@timestamp":
+              date_histogram:
+                field: "@timestamp"
+                fixed_interval: 1h
+              aggs:
+                v: {avg: {field: v}}
+            d:
+              sum_bucket:
+                buckets_path: "@timestamp>v"
+                format: "0.00"
+  - match: { hits.total.value: 3 }
+  - length: { aggregations.@timestamp.buckets: 3 }
+  - match: { aggregations.d.value: 4.0 }
+  - match: { aggregations.d.value_as_string: "4.00" }
+
+---
+gap_policy=skip:
+  - do:
+      search:
+        index: gaps
+        body:
+          size: 0
+          aggs:
+            "@timestamp":
+              date_histogram:
+                field: "@timestamp"
+                fixed_interval: 1h
+              aggs:
+                v: {avg: {field: v}}
+            d:
+              sum_bucket:
+                buckets_path: "@timestamp>v"
+                gap_policy: skip
+  - match: { hits.total.value: 3 }
+  - length: { aggregations.@timestamp.buckets: 4 }
+  - match: { aggregations.d.value: 4.0 }
+
+---
+gap_policy=insert_zeros:
+  - do:
+      search:
+        index: gaps
+        body:
+          size: 0
+          aggs:
+            "@timestamp":
+              date_histogram:
+                field: "@timestamp"
+                fixed_interval: 1h
+              aggs:
+                v: {avg: {field: v}}
+            d:
+              sum_bucket:
+                buckets_path: "@timestamp>v"
+                gap_policy: insert_zeros
+  - match: { hits.total.value: 3 }
+  - length: { aggregations.@timestamp.buckets: 4 }
+  - match: { aggregations.d.value: 4.0 }
+
+---
+gap_policy=keep_value:
+  - do:
+      search:
+        index: gaps
+        body:
+          size: 0
+          aggs:
+            "@timestamp":
+              date_histogram:
+                field: "@timestamp"
+                fixed_interval: 1h
+              aggs:
+                v: {avg: {field: v}}
+            d:
+              sum_bucket:
+                buckets_path: "@timestamp>v"
+                gap_policy: keep_values
+  - match: { hits.total.value: 3 }
+  - length: { aggregations.@timestamp.buckets: 4 }
+  - match: { aggregations.d.value: 4.0 }


### PR DESCRIPTION
Adds REST layer tests for the `avg_bucket`, `max_bucket`, `min_bucket`,
and `sum_bucket` pipeline aggregations. This gives us forwards and
backwards compatibility tests for these aggs as well as mixed version
cluster tests for these aggs.

Relates to #26220
