### PR TITLE
Remove unused method from SystemIndices.Feature

### DIFF
--- a/server/src/main/java/org/elasticsearch/indices/SystemIndices.java
+++ b/server/src/main/java/org/elasticsearch/indices/SystemIndices.java
@@ -852,18 +852,5 @@ public class SystemIndices {
                 ActionListener<Boolean> listener
             );
         }
-
-        public static Feature pluginToFeature(SystemIndexPlugin plugin, Settings settings) {
-            return new Feature(
-                plugin.getFeatureName(),
-                plugin.getFeatureDescription(),
-                plugin.getSystemIndexDescriptors(settings),
-                plugin.getSystemDataStreamDescriptors(),
-                plugin.getAssociatedIndexDescriptors(),
-                plugin::cleanUpFeature,
-                plugin::prepareForIndicesMigration,
-                plugin::indicesMigrationComplete
-            );
-        }
     }
 }


### PR DESCRIPTION
This unused method looks like an accidental duplication of
SystemIndices.Feature#fromSystemIndexPlugin.