### PR TITLE
[Refactor] Convert ExecutorNames POJO to Record object

### DIFF
--- a/server/src/main/java/org/elasticsearch/indices/ExecutorNames.java
+++ b/server/src/main/java/org/elasticsearch/indices/ExecutorNames.java
@@ -14,10 +14,7 @@ import org.elasticsearch.threadpool.ThreadPool;
  * A class that gathers the names of thread pool executors that should be used for a particular system index or system data stream. This
  * object is used both by the {@link SystemIndexDescriptor} and the {@link SystemDataStreamDescriptor} classes.
  */
-public class ExecutorNames {
-    private final String getPoolName;
-    private final String searchPoolName;
-    private final String writePoolName;
+public record ExecutorNames(String threadPoolForGet, String threadPoolForSearch, String threadPoolForWrite) {
 
     /**
      * The thread pools for a typical system index.
@@ -49,44 +46,21 @@ public class ExecutorNames {
     /**
      * Create a new collection of thread pool names for a system descriptor to use.
      *
-     * @param getPoolName    Name of the thread pool that get operations should use.
-     * @param searchPoolName Name of the thread pool that search operations should use. (In same cases, this is the same as the name of the
-     *                       pool for get operations.)
-     * @param writePoolName  Name of the thread pool that write operations should use.
+     * @param threadPoolForGet    Name of the thread pool that get operations should use.
+     * @param threadPoolForSearch Name of the thread pool that search operations should use.
+     *                            (In same cases, this is the same as the name of the
+     *                            pool for get operations.)
+     * @param threadPoolForWrite  Name of the thread pool that write operations should use.
      */
-    public ExecutorNames(String getPoolName, String searchPoolName, String writePoolName) {
-        if (ThreadPool.THREAD_POOL_TYPES.containsKey(getPoolName) == false) {
-            throw new IllegalArgumentException(getPoolName + " is not a valid thread pool");
+    public ExecutorNames {
+        if (ThreadPool.THREAD_POOL_TYPES.containsKey(threadPoolForGet) == false) {
+            throw new IllegalArgumentException(threadPoolForGet + " is not a valid thread pool");
         }
-        if (ThreadPool.THREAD_POOL_TYPES.containsKey(searchPoolName) == false) {
-            throw new IllegalArgumentException(searchPoolName + " is not a valid thread pool");
+        if (ThreadPool.THREAD_POOL_TYPES.containsKey(threadPoolForSearch) == false) {
+            throw new IllegalArgumentException(threadPoolForSearch + " is not a valid thread pool");
         }
-        if (ThreadPool.THREAD_POOL_TYPES.containsKey(writePoolName) == false) {
-            throw new IllegalArgumentException(writePoolName + " is not a valid thread pool");
+        if (ThreadPool.THREAD_POOL_TYPES.containsKey(threadPoolForWrite) == false) {
+            throw new IllegalArgumentException(threadPoolForWrite + " is not a valid thread pool");
         }
-        this.getPoolName = getPoolName;
-        this.searchPoolName = searchPoolName;
-        this.writePoolName = writePoolName;
-    }
-
-    /**
-     * @return Name of the thread pool that get operations should use
-     */
-    public String threadPoolForGet() {
-        return getPoolName;
-    }
-
-    /**
-     * @return Name of the thread pool that search operations should use
-     */
-    public String threadPoolForSearch() {
-        return searchPoolName;
-    }
-
-    /**
-     * @return Name of the thread pool that write operations should use
-     */
-    public String threadPoolForWrite() {
-        return writePoolName;
     }
 }


### PR DESCRIPTION
ExecutorNames was a very simple data-holding class that easily works as a Java record.