### PR TITLE
[ML] Fix ML task auditor exception early in cluster lifecycle

### DIFF
--- a/docs/changelog/87023.yaml
+++ b/docs/changelog/87023.yaml
@@ -1,0 +1,6 @@
+pr: 87023
+summary: Fix ML task auditor exception early in cluster lifecycle
+area: Machine Learning
+type: bug
+issues:
+ - 87002

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MlAssignmentNotifier.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MlAssignmentNotifier.java
@@ -92,6 +92,9 @@ public class MlAssignmentNotifier implements ClusterStateListener {
         PersistentTasksCustomMetadata currentTasks,
         boolean alwaysAuditUnassigned
     ) {
+        if (currentTasks == null) {
+            return;
+        }
 
         for (PersistentTask<?> currentTask : currentTasks.tasks()) {
             Assignment currentAssignment = currentTask.getAssignment();


### PR DESCRIPTION
In a very young cluster where there's never been a persistent
task it was possible that the ML task assignment auditor could
throw null pointer exceptions. Nothing particularly bad resulted
from this apart from filling up the log file with stack traces.

This PR avoids the problem.

Fixes #87002