### PR TITLE
[7.17] [ML] Fix ML task auditor exception early in cluster lifecycle (#87023)

### DIFF
--- a/docs/changelog/87023.yaml
+++ b/docs/changelog/87023.yaml
@@ -1,0 +1,6 @@
+pr: 87023
+summary: Fix ML task auditor exception early in cluster lifecycle
+area: Machine Learning
+type: bug
+issues:
+ - 87002

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MlAssignmentNotifier.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MlAssignmentNotifier.java
@@ -100,6 +100,9 @@ public class MlAssignmentNotifier implements ClusterStateListener {
         PersistentTasksCustomMetadata currentTasks,
         boolean alwaysAuditUnassigned
     ) {
+        if (currentTasks == null) {
+            return;
+        }
 
         for (PersistentTask<?> currentTask : currentTasks.tasks()) {
             Assignment currentAssignment = currentTask.getAssignment();


### PR DESCRIPTION
Backports the following commits to 7.17:
 - [ML] Fix ML task auditor exception early in cluster lifecycle (#87023)