### PR TITLE
87034 fixed link of lucene stop filter

### DIFF
--- a/docs/reference/analysis/tokenfilters/stop-tokenfilter.asciidoc
+++ b/docs/reference/analysis/tokenfilters/stop-tokenfilter.asciidoc
@@ -19,7 +19,7 @@ In addition to English, the `stop` filter supports predefined
 languages>>. You can also specify your own stop words as an array or file.
 
 The `stop` filter uses Lucene's
-{lucene-analysis-docs}/StopFilter.html[StopFilter].
+{lucene-analysis-docs}/core/StopFilter.html[StopFilter].
 
 [[analysis-stop-tokenfilter-analyze-ex]]
 ==== Example


### PR DESCRIPTION
Updates the docs with the new Javadoc location for Lucene's stop filter.

Closes #87034.