### PR TITLE
fix(xpack): check for equality in memory checks

### DIFF
--- a/x-pack/plugin/autoscaling/src/main/java/org/elasticsearch/xpack/autoscaling/capacity/memory/AutoscalingMemoryInfoService.java
+++ b/x-pack/plugin/autoscaling/src/main/java/org/elasticsearch/xpack/autoscaling/capacity/memory/AutoscalingMemoryInfoService.java
@@ -186,7 +186,7 @@ public class AutoscalingMemoryInfoService {
         return node -> {
             Long result = nodeToMemoryRef.get(node.getEphemeralId());
             // noinspection NumberEquality
-            if (result == FETCHING_SENTINEL) {
+            if (result.equals(FETCHING_SENTINEL)) {
                 return null;
             } else {
                 return result;


### PR DESCRIPTION
In AutoscalingMemoryInfoService.java, the result is checked against FETCHING_SENTINEL (Long.MIN_VALUE). However, the check uses equality, which checks against object identity. Since result will not equal the identity of a new object, and based off of the implementation, it's likely that the equals method was intended here.