### PR TITLE
Guard for adding null value tags to vector tiles

### DIFF
--- a/docs/changelog/87051.yaml
+++ b/docs/changelog/87051.yaml
@@ -1,0 +1,5 @@
+pr: 87051
+summary: Guard for adding null value tags to vector tiles
+area: Geo
+type: bug
+issues: []

--- a/x-pack/plugin/vector-tile/src/javaRestTest/java/org/elasticsearch/xpack/vectortile/VectorTileRestIT.java
+++ b/x-pack/plugin/vector-tile/src/javaRestTest/java/org/elasticsearch/xpack/vectortile/VectorTileRestIT.java
@@ -123,6 +123,10 @@ public class VectorTileRestIT extends ESRestTestCase {
                 },
                 "name": {
                   "type": "keyword"
+                },
+                "ignore_value": {
+                  "type": "double",
+                  "ignore_malformed" : true
                 }
               }
             }""");
@@ -132,7 +136,7 @@ public class VectorTileRestIT extends ESRestTestCase {
         final Request putRequest = new Request(HttpPost.METHOD_NAME, indexName + "/_doc/" + id);
         putRequest.setJsonEntity("""
             {
-              "location": "%s", "name": "geometry", "value1": %s, "value2": %s, "nullField" : null
+              "location": "%s", "name": "geometry", "value1": %s, "value2": %s, "nullField" : null, "ignore_value" : ""
             }""".formatted(WellKnownText.toWKT(geometry), 1, 2));
         response = client().performRequest(putRequest);
         assertThat(response.getStatusLine().getStatusCode(), Matchers.equalTo(HttpStatus.SC_CREATED));
@@ -780,6 +784,16 @@ public class VectorTileRestIT extends ESRestTestCase {
     public void testWithNullFields() throws Exception {
         final Request mvtRequest = new Request(getHttpMethod(), INDEX_POLYGON + "/_mvt/location/" + z + "/" + x + "/" + y);
         mvtRequest.setJsonEntity("{\"fields\": [\"nullField\"] }");
+        final VectorTile.Tile tile = execute(mvtRequest);
+        assertThat(tile.getLayersCount(), Matchers.equalTo(3));
+        assertLayer(tile, HITS_LAYER, 4096, 1, 2);
+        assertLayer(tile, AGGS_LAYER, 4096, 256 * 256, 2);
+        assertLayer(tile, META_LAYER, 4096, 1, 13);
+    }
+
+    public void testWithIgnoreMalformedValueFields() throws Exception {
+        final Request mvtRequest = new Request(getHttpMethod(), INDEX_POLYGON + "/_mvt/location/" + z + "/" + x + "/" + y);
+        mvtRequest.setJsonEntity("{\"fields\": [ \"ignore_value\"] }");
         final VectorTile.Tile tile = execute(mvtRequest);
         assertThat(tile.getLayersCount(), Matchers.equalTo(3));
         assertLayer(tile, HITS_LAYER, 4096, 1, 2);

--- a/x-pack/plugin/vector-tile/src/main/java/org/elasticsearch/xpack/vectortile/rest/VectorTileUtils.java
+++ b/x-pack/plugin/vector-tile/src/main/java/org/elasticsearch/xpack/vectortile/rest/VectorTileUtils.java
@@ -60,6 +60,10 @@ class VectorTileUtils {
      * Adds the provided key / value pair into the feature as tags.
      */
     public static void addPropertyToFeature(VectorTile.Tile.Feature.Builder feature, MvtLayerProps layerProps, String key, Object value) {
+        if (value == null) {
+            // guard for null values
+            return;
+        }
         feature.addTags(layerProps.addKey(key));
         feature.addTags(layerProps.addValue(value));
     }


### PR DESCRIPTION
It is possible for the fields API to return null objects when a field is set to ignore_malformed values and the values are actually malformed. This causes a NPE on vector tiles if trying to add the value as the value of a tag. This PR adds a guard so tags with null values are ignored.