### PR TITLE
Assert that some getters are not accessed for unmanaged indices

### DIFF
--- a/modules/reindex/src/internalClusterTest/java/org/elasticsearch/migration/AbstractFeatureMigrationIntegTest.java
+++ b/modules/reindex/src/internalClusterTest/java/org/elasticsearch/migration/AbstractFeatureMigrationIntegTest.java
@@ -71,7 +71,6 @@ public abstract class AbstractFeatureMigrationIntegTest extends ESIntegTestCase 
         .setIndexPattern(".ext-unman-*")
         .setType(SystemIndexDescriptor.Type.EXTERNAL_UNMANAGED)
         .setOrigin(ORIGIN)
-        .setVersionMetaKey(VERSION_META_KEY)
         .setAllowedElasticProductOrigins(Collections.singletonList(ORIGIN))
         .setMinimumNodeVersion(NEEDS_UPGRADE_VERSION)
         .setPriorSystemIndexDescriptors(Collections.emptyList())
@@ -80,7 +79,6 @@ public abstract class AbstractFeatureMigrationIntegTest extends ESIntegTestCase 
         .setIndexPattern(".int-unman-*")
         .setType(SystemIndexDescriptor.Type.INTERNAL_UNMANAGED)
         .setOrigin(ORIGIN)
-        .setVersionMetaKey(VERSION_META_KEY)
         .setAllowedElasticProductOrigins(Collections.emptyList())
         .setMinimumNodeVersion(NEEDS_UPGRADE_VERSION)
         .setPriorSystemIndexDescriptors(Collections.emptyList())
@@ -142,10 +140,12 @@ public abstract class AbstractFeatureMigrationIntegTest extends ESIntegTestCase 
             descriptor.getIndexPattern(),
             endsWith("*")
         );
-        String indexName = Optional.ofNullable(descriptor.getPrimaryIndex()).orElse(descriptor.getIndexPattern().replace("*", "old"));
+        String indexName = descriptor.isAutomaticallyManaged()
+            ? descriptor.getPrimaryIndex()
+            : descriptor.getIndexPattern().replace("*" , "old");
         CreateIndexRequestBuilder createRequest = prepareCreate(indexName);
         createRequest.setWaitForActiveShards(ActiveShardCount.ALL);
-        if (SystemIndexDescriptor.DEFAULT_SETTINGS.equals(descriptor.getSettings())) {
+        if (descriptor.isAutomaticallyManaged() == false || SystemIndexDescriptor.DEFAULT_SETTINGS.equals(descriptor.getSettings())) {
             // unmanaged
             createRequest.setSettings(
                 createSettings(
@@ -162,7 +162,7 @@ public abstract class AbstractFeatureMigrationIntegTest extends ESIntegTestCase 
                     .build()
             );
         }
-        if (descriptor.getMappings() == null) {
+        if (descriptor.isAutomaticallyManaged() == false) {
             createRequest.setMapping(createMapping(false, descriptor.isInternal()));
         }
         CreateIndexResponse response = createRequest.get();

--- a/modules/reindex/src/internalClusterTest/java/org/elasticsearch/migration/AbstractFeatureMigrationIntegTest.java
+++ b/modules/reindex/src/internalClusterTest/java/org/elasticsearch/migration/AbstractFeatureMigrationIntegTest.java
@@ -41,7 +41,6 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BiConsumer;
@@ -142,7 +141,7 @@ public abstract class AbstractFeatureMigrationIntegTest extends ESIntegTestCase 
         );
         String indexName = descriptor.isAutomaticallyManaged()
             ? descriptor.getPrimaryIndex()
-            : descriptor.getIndexPattern().replace("*" , "old");
+            : descriptor.getIndexPattern().replace("*", "old");
         CreateIndexRequestBuilder createRequest = prepareCreate(indexName);
         createRequest.setWaitForActiveShards(ActiveShardCount.ALL);
         if (descriptor.isAutomaticallyManaged() == false || SystemIndexDescriptor.DEFAULT_SETTINGS.equals(descriptor.getSettings())) {

--- a/modules/reindex/src/internalClusterTest/java/org/elasticsearch/migration/FeatureMigrationIT.java
+++ b/modules/reindex/src/internalClusterTest/java/org/elasticsearch/migration/FeatureMigrationIT.java
@@ -37,7 +37,6 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
@@ -235,8 +234,8 @@ public class FeatureMigrationIT extends AbstractFeatureMigrationIntegTest {
     public void testMigrateIndexWithWriteBlock() throws Exception {
         createSystemIndexForDescriptor(INTERNAL_UNMANAGED);
 
-        String indexName = Optional.ofNullable(INTERNAL_UNMANAGED.getPrimaryIndex())
-            .orElse(INTERNAL_UNMANAGED.getIndexPattern().replace("*", "old"));
+        String indexName = INTERNAL_UNMANAGED.getIndexPattern().replace("*", "old");
+
         client().admin().indices().prepareUpdateSettings(indexName).setSettings(Settings.builder().put("index.blocks.write", true)).get();
 
         ensureGreen();

--- a/qa/system-indices/src/main/java/org/elasticsearch/system/indices/SystemIndicesQA.java
+++ b/qa/system-indices/src/main/java/org/elasticsearch/system/indices/SystemIndicesQA.java
@@ -82,8 +82,6 @@ public class SystemIndicesQA extends Plugin implements SystemIndexPlugin, Action
                 .setDescription("internal unmanaged system index")
                 .setType(SystemIndexDescriptor.Type.INTERNAL_UNMANAGED)
                 .setOrigin("qa")
-                .setVersionMetaKey("version")
-                .setPrimaryIndex(".internal-unmanaged-index-" + Version.CURRENT.major)
                 .setAliasName(".internal-unmanaged-alias")
                 .build(),
             SystemIndexDescriptor.builder()

--- a/server/src/main/java/org/elasticsearch/indices/SystemIndexDescriptor.java
+++ b/server/src/main/java/org/elasticsearch/indices/SystemIndexDescriptor.java
@@ -455,6 +455,7 @@ public class SystemIndexDescriptor implements IndexPatternMatcher, Comparable<Sy
     }
 
     public String getOrigin() {
+        // TODO[wrb]: most unmanaged system indices do not set origins; could we assert on that here?
         return this.origin;
     }
 

--- a/server/src/main/java/org/elasticsearch/indices/SystemIndexDescriptor.java
+++ b/server/src/main/java/org/elasticsearch/indices/SystemIndexDescriptor.java
@@ -264,7 +264,6 @@ public class SystemIndexDescriptor implements IndexPatternMatcher, Comparable<Sy
             assert Objects.isNull(mappings) : "Unmanaged index descriptors should not have mappings";
             assert Objects.isNull(primaryIndex) : "Unmanaged index descriptors should not have a primary index";
             assert Objects.isNull(versionMetaKey) : "Unmanaged index descriptors should not have a version meta key";
-            assert Objects.isNull(origin) : "Unmanaged index descriptors should not supply origins";
             this.mappingVersion = null;
         }
 
@@ -456,7 +455,6 @@ public class SystemIndexDescriptor implements IndexPatternMatcher, Comparable<Sy
     }
 
     public String getOrigin() {
-        assert isAutomaticallyManaged() : "Do not check origin for unmanaged system indices";
         return this.origin;
     }
 

--- a/server/src/main/java/org/elasticsearch/indices/SystemIndexDescriptor.java
+++ b/server/src/main/java/org/elasticsearch/indices/SystemIndexDescriptor.java
@@ -264,7 +264,9 @@ public class SystemIndexDescriptor implements IndexPatternMatcher, Comparable<Sy
             assert Objects.isNull(mappings) : "Unmanaged index descriptors should not have mappings";
             assert Objects.isNull(primaryIndex) : "Unmanaged index descriptors should not have a primary index";
             assert Objects.isNull(versionMetaKey) : "Unmanaged index descriptors should not have a version meta key";
-            assert Objects.isNull(origin) : "Unmanaged index descriptions should not supply origins";
+            assert Objects.isNull(origin) : "Unmanaged index descriptors should not supply origins";
+            assert Objects.isNull(indexFormat) : "Unmanaged index descriptors should not have index formats";
+            assert Objects.isNull(minimumNodeVersion) : "Unmanaged index descriptors should not have minimum node versions";
             this.mappingVersion = null;
         }
 

--- a/server/src/main/java/org/elasticsearch/indices/SystemIndexDescriptor.java
+++ b/server/src/main/java/org/elasticsearch/indices/SystemIndexDescriptor.java
@@ -260,6 +260,11 @@ public class SystemIndexDescriptor implements IndexPatternMatcher, Comparable<Sy
             }
             this.mappingVersion = extractVersionFromMappings(mappings, versionMetaKey);
         } else {
+            assert Objects.isNull(settings) : "Unmanaged index descriptors should not have settings";
+            assert Objects.isNull(mappings) : "Unmanaged index descriptors should not have mappings";
+            assert Objects.isNull(primaryIndex) : "Unmanaged index descriptors should not have a primary index";
+            assert Objects.isNull(versionMetaKey) : "Unmanaged index descriptors should not have a version meta key";
+            assert Objects.isNull(origin) : "Unmanaged index descriptions should not supply origins";
             this.mappingVersion = null;
         }
 
@@ -428,7 +433,6 @@ public class SystemIndexDescriptor implements IndexPatternMatcher, Comparable<Sy
     }
 
     public String getAliasName() {
-        assert isAutomaticallyManaged() : "Do not request aliases for unmanaged system indices";
         return aliasName;
     }
 
@@ -452,6 +456,7 @@ public class SystemIndexDescriptor implements IndexPatternMatcher, Comparable<Sy
     }
 
     public String getOrigin() {
+        assert isAutomaticallyManaged() : "Do not check origin for unmanaged system indices";
         return this.origin;
     }
 
@@ -473,7 +478,6 @@ public class SystemIndexDescriptor implements IndexPatternMatcher, Comparable<Sy
     }
 
     public boolean isNetNew() {
-        assert isAutomaticallyManaged() : "Do not check mapping properties for unmanaged system indices";
         return isNetNew;
     }
 

--- a/server/src/main/java/org/elasticsearch/indices/SystemIndexDescriptor.java
+++ b/server/src/main/java/org/elasticsearch/indices/SystemIndexDescriptor.java
@@ -265,8 +265,6 @@ public class SystemIndexDescriptor implements IndexPatternMatcher, Comparable<Sy
             assert Objects.isNull(primaryIndex) : "Unmanaged index descriptors should not have a primary index";
             assert Objects.isNull(versionMetaKey) : "Unmanaged index descriptors should not have a version meta key";
             assert Objects.isNull(origin) : "Unmanaged index descriptors should not supply origins";
-            assert Objects.isNull(indexFormat) : "Unmanaged index descriptors should not have index formats";
-            assert Objects.isNull(minimumNodeVersion) : "Unmanaged index descriptors should not have minimum node versions";
             this.mappingVersion = null;
         }
 

--- a/server/src/main/java/org/elasticsearch/indices/SystemIndexDescriptor.java
+++ b/server/src/main/java/org/elasticsearch/indices/SystemIndexDescriptor.java
@@ -378,6 +378,7 @@ public class SystemIndexDescriptor implements IndexPatternMatcher, Comparable<Sy
      * for indices managed externally to Elasticsearch.
      */
     public String getPrimaryIndex() {
+        assert isAutomaticallyManaged() : "Unmanaged indices should not have a primary index";
         return primaryIndex;
     }
 
@@ -417,26 +418,32 @@ public class SystemIndexDescriptor implements IndexPatternMatcher, Comparable<Sy
     }
 
     public String getMappings() {
+        assert isAutomaticallyManaged() : "Do not request mappings for unmanaged system indices";
         return mappings;
     }
 
     public Settings getSettings() {
+        assert isAutomaticallyManaged() : "Do not request settings for unmanaged system indices";
         return settings;
     }
 
     public String getAliasName() {
+        assert isAutomaticallyManaged() : "Do not request aliases for unmanaged system indices";
         return aliasName;
     }
 
     public int getIndexFormat() {
+        assert isAutomaticallyManaged() : "Do not request index format for unmanaged system indices";
         return this.indexFormat;
     }
 
     public String getVersionMetaKey() {
+        assert isAutomaticallyManaged() : "Do not request version meta keys for unmanaged system indices";
         return this.versionMetaKey;
     }
 
     public Version getMinimumNodeVersion() {
+        assert isAutomaticallyManaged() : "Do not request version minimum node version for unmanaged system indices";
         return minimumNodeVersion;
     }
 
@@ -449,6 +456,7 @@ public class SystemIndexDescriptor implements IndexPatternMatcher, Comparable<Sy
     }
 
     public boolean hasDynamicMappings() {
+        assert isAutomaticallyManaged() : "Do not check mapping properties for unmanaged system indices";
         return this.hasDynamicMappings;
     }
 
@@ -465,11 +473,12 @@ public class SystemIndexDescriptor implements IndexPatternMatcher, Comparable<Sy
     }
 
     public boolean isNetNew() {
+        assert isAutomaticallyManaged() : "Do not check mapping properties for unmanaged system indices";
         return isNetNew;
     }
 
     public Version getMappingVersion() {
-        if (type.isManaged() == false) {
+        if (isAutomaticallyManaged() == false) {
             throw new IllegalStateException(this + " is not managed so there are no mappings or version");
         }
         return mappingVersion;

--- a/server/src/main/java/org/elasticsearch/indices/SystemIndices.java
+++ b/server/src/main/java/org/elasticsearch/indices/SystemIndices.java
@@ -381,6 +381,7 @@ public class SystemIndices {
         Optional<Automaton> automaton = featureDescriptors.values()
             .stream()
             .flatMap(feature -> feature.getIndexDescriptors().stream())
+            .filter(SystemIndexDescriptor::isAutomaticallyManaged)
             .filter(SystemIndexDescriptor::isNetNew)
             .map(descriptor -> SystemIndexDescriptor.buildAutomaton(descriptor.getIndexPattern(), descriptor.getAliasName()))
             .reduce(Operations::union);

--- a/server/src/main/java/org/elasticsearch/upgrades/SystemIndexMigrationInfo.java
+++ b/server/src/main/java/org/elasticsearch/upgrades/SystemIndexMigrationInfo.java
@@ -181,15 +181,16 @@ class SystemIndexMigrationInfo implements Comparable<SystemIndexMigrationInfo> {
         SystemIndices.Feature feature,
         IndexScopedSettings indexScopedSettings
     ) {
-        Settings.Builder settingsBuilder = Settings.builder();
-        if (descriptor.getSettings() != null) {
+        final Settings settings;
+        final String mapping;
+        if (descriptor.isAutomaticallyManaged()) {
+            Settings.Builder settingsBuilder = Settings.builder();
             settingsBuilder.put(descriptor.getSettings());
             settingsBuilder.remove("index.version.created"); // Simplifies testing, should never impact real uses.
-        }
-        Settings settings = settingsBuilder.build();
+            settings = settingsBuilder.build();
 
-        String mapping = descriptor.getMappings();
-        if (descriptor.isAutomaticallyManaged() == false) {
+            mapping = descriptor.getMappings();
+        } else {
             // Get Settings from old index
             settings = copySettingsForNewIndex(currentIndex.getSettings(), indexScopedSettings);
 

--- a/server/src/test/java/org/elasticsearch/indices/SystemIndexManagerTests.java
+++ b/server/src/test/java/org/elasticsearch/indices/SystemIndexManagerTests.java
@@ -347,11 +347,11 @@ public class SystemIndexManagerTests extends ESTestCase {
         IndexMetadata.State state
     ) {
         IndexMetadata.Builder indexMetadata = IndexMetadata.builder(
-            descriptor.getPrimaryIndex() == null ? descriptor.getIndexPattern() : descriptor.getPrimaryIndex()
+            descriptor.isAutomaticallyManaged() ? descriptor.getPrimaryIndex() : descriptor.getIndexPattern()
         );
 
         final Settings.Builder settingsBuilder = Settings.builder();
-        if (SystemIndexDescriptor.DEFAULT_SETTINGS.equals(descriptor.getSettings())) {
+        if (descriptor.isAutomaticallyManaged() == false || SystemIndexDescriptor.DEFAULT_SETTINGS.equals(descriptor.getSettings())) {
             settingsBuilder.put(getSettings());
         } else {
             settingsBuilder.put(descriptor.getSettings());
@@ -359,7 +359,7 @@ public class SystemIndexManagerTests extends ESTestCase {
         settingsBuilder.put(IndexMetadata.INDEX_FORMAT_SETTING.getKey(), format);
         indexMetadata.settings(settingsBuilder.build());
 
-        if (descriptor.getAliasName() != null) {
+        if (descriptor.isAutomaticallyManaged() && descriptor.getAliasName() != null) {
             indexMetadata.putAlias(AliasMetadata.builder(descriptor.getAliasName()).build());
         }
         indexMetadata.state(state);


### PR DESCRIPTION
There are many properties in SystemIndexDescriptor that should only be accessed when dealing with managed system indices. Any code that accesses the getters for these properties should be inside of a block that checks whether an index is managed or not. Here, we add assertions to verify that this is the case, or to point us to places where our code may be buggy.