### PR TITLE
Ensure Java compile module path is tracked as a task input

### DIFF
--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/ElasticsearchJavaModulePathPlugin.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/ElasticsearchJavaModulePathPlugin.java
@@ -23,6 +23,7 @@ import org.gradle.api.attributes.LibraryElements;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.logging.Logger;
 import org.gradle.api.plugins.JavaPlugin;
+import org.gradle.api.tasks.CompileClasspath;
 import org.gradle.api.tasks.Internal;
 import org.gradle.api.tasks.SourceSet;
 import org.gradle.api.tasks.compile.JavaCompile;
@@ -162,6 +163,11 @@ public class ElasticsearchJavaModulePathPlugin implements Plugin<Project> {
                 extraArgs.add("-Xlint:-module,-exports,-requires-automatic,-requires-transitive-automatic,-missing-explicit-ctor");
             }
             return List.copyOf(extraArgs);
+        }
+
+        @CompileClasspath
+        public FileCollection getModulePath() {
+            return modulePath;
         }
 
         @Internal


### PR DESCRIPTION
This is a follow up to #81066 which ensures that we track the module path as a input on Java compilation tasks. Since we truncate the compile classpath and pass the module path as separate CLI arguments we need to track those separately. We do that by simply annotating a getter on the `CommandLineArgumentProvider`.