### PR TITLE
Moving deprecation info API checks off the transport_worker thread (#86811)

### DIFF
--- a/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/DeprecationInfoAction.java
+++ b/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/DeprecationInfoAction.java
@@ -27,6 +27,7 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.set.Sets;
 import org.elasticsearch.core.Tuple;
 import org.elasticsearch.rest.RestStatus;
+import org.elasticsearch.transport.Transports;
 import org.elasticsearch.xcontent.ToXContentObject;
 import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xpack.core.deprecation.DeprecationIssue;
@@ -270,6 +271,7 @@ public class DeprecationInfoAction extends ActionType<DeprecationInfoAction.Resp
             Map<String, List<DeprecationIssue>> pluginSettingIssues,
             List<String> skipTheseDeprecatedSettings
         ) {
+            assert Transports.assertNotTransportThread("walking mappings in indexSettingsChecks is expensive");
             // Allow system index access here to prevent deprecation warnings when we call this API
             String[] concreteIndexNames = indexNameExpressionResolver.concreteIndexNamesWithSystemIndexAccess(state, request);
             ClusterState stateWithSkippedSettingsRemoved = removeSkippedSettings(state, concreteIndexNames, skipTheseDeprecatedSettings);

--- a/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/TransportDeprecationInfoAction.java
+++ b/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/TransportDeprecationInfoAction.java
@@ -12,6 +12,7 @@ import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.FailedNodeException;
 import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.GroupedActionListener;
+import org.elasticsearch.action.support.ThreadedActionListener;
 import org.elasticsearch.action.support.master.TransportMasterNodeReadAction;
 import org.elasticsearch.client.OriginSettingClient;
 import org.elasticsearch.client.node.NodeClient;
@@ -125,20 +126,29 @@ public class TransportDeprecationInfoAction extends TransportMasterNodeReadActio
                     new OriginSettingClient(client, ClientHelper.DEPRECATION_ORIGIN, true),
                     state
                 );
-                pluginSettingIssues(PLUGIN_CHECKERS, components, ActionListener.wrap(deprecationIssues -> {
-                    listener.onResponse(
-                        DeprecationInfoAction.Response.from(
-                            state,
-                            indexNameExpressionResolver,
-                            request,
-                            response,
-                            INDEX_SETTINGS_CHECKS,
-                            CLUSTER_SETTINGS_CHECKS,
-                            deprecationIssues,
-                            skipTheseDeprecations
-                        )
-                    );
-                }, listener::onFailure));
+                pluginSettingIssues(
+                    PLUGIN_CHECKERS,
+                    components,
+                    new ThreadedActionListener<>(
+                        logger,
+                        client.threadPool(),
+                        ThreadPool.Names.GENERIC,
+                        listener.map(
+                            deprecationIssues -> DeprecationInfoAction.Response.from(
+                                state,
+                                indexNameExpressionResolver,
+                                request,
+                                response,
+                                INDEX_SETTINGS_CHECKS,
+                                CLUSTER_SETTINGS_CHECKS,
+                                deprecationIssues,
+                                skipTheseDeprecations
+                            )
+                        ),
+                        false
+                    )
+                );
+
             }, listener::onFailure)
         );
     }


### PR DESCRIPTION
Doing a lot of work on the tranport_worker thread can cause the cluster to become unstable because nodes can't 
communicate quickly enough. With a lot of indices, the deprecation info API check can take tens of seconds. This change 
moves those checks off of the transport_worker thread.