### PR TITLE
[7.17] [Refactor] Use Lists instead of Maps for SystemIndices features (#87004)

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/migration/TransportGetFeatureUpgradeStatusAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/migration/TransportGetFeatureUpgradeStatusAction.java
@@ -85,7 +85,6 @@ public class TransportGetFeatureUpgradeStatusAction extends TransportMasterNodeA
     ) throws Exception {
 
         List<GetFeatureUpgradeStatusResponse.FeatureUpgradeStatus> features = systemIndices.getFeatures()
-            .values()
             .stream()
             .sorted(Comparator.comparing(SystemIndices.Feature::getName))
             .map(feature -> getFeatureUpgradeStatus(state, feature))

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/migration/TransportPostFeatureUpgradeAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/migration/TransportPostFeatureUpgradeAction.java
@@ -80,7 +80,6 @@ public class TransportPostFeatureUpgradeAction extends TransportMasterNodeAction
             GetFeatureUpgradeStatusResponse.UpgradeStatus.ERROR
         );
         List<PostFeatureUpgradeResponse.Feature> featuresToMigrate = systemIndices.getFeatures()
-            .values()
             .stream()
             .map(feature -> getFeatureUpgradeStatus(state, feature))
             .filter(status -> upgradableStatuses.contains(status.getUpgradeStatus()))

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/features/TransportResetFeatureStateAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/features/TransportResetFeatureStateAction.java
@@ -75,7 +75,7 @@ public class TransportResetFeatureStateAction extends TransportMasterNodeAction<
             systemIndices.getFeatures().size()
         );
 
-        for (SystemIndices.Feature feature : systemIndices.getFeatures().values()) {
+        for (SystemIndices.Feature feature : systemIndices.getFeatures()) {
             feature.getCleanUpFunction().apply(clusterService, client, groupedActionListener);
         }
     }

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/features/TransportSnapshottableFeaturesAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/features/TransportSnapshottableFeaturesAction.java
@@ -61,14 +61,8 @@ public class TransportSnapshottableFeaturesAction extends TransportMasterNodeAct
         listener.onResponse(
             new GetSnapshottableFeaturesResponse(
                 systemIndices.getFeatures()
-                    .entrySet()
                     .stream()
-                    .map(
-                        featureEntry -> new GetSnapshottableFeaturesResponse.SnapshottableFeature(
-                            featureEntry.getKey(),
-                            featureEntry.getValue().getDescription()
-                        )
-                    )
+                    .map(feature -> new GetSnapshottableFeaturesResponse.SnapshottableFeature(feature.getName(), feature.getDescription()))
                     .collect(Collectors.toList())
             )
         );

--- a/server/src/main/java/org/elasticsearch/client/transport/TransportClient.java
+++ b/server/src/main/java/org/elasticsearch/client/transport/TransportClient.java
@@ -64,7 +64,6 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static java.util.Collections.emptyList;
-import static java.util.Collections.emptyMap;
 import static java.util.Collections.emptySet;
 import static java.util.Collections.unmodifiableList;
 import static java.util.stream.Collectors.toList;
@@ -206,7 +205,7 @@ public abstract class TransportClient extends AbstractClient {
                 null,
                 null,
                 null,
-                new SystemIndices(emptyMap())
+                new SystemIndices(emptyList())
             );
             modules.add(actionModule);
 

--- a/server/src/main/java/org/elasticsearch/indices/SystemIndices.java
+++ b/server/src/main/java/org/elasticsearch/indices/SystemIndices.java
@@ -66,26 +66,36 @@ public class SystemIndices {
 
     private static final Automaton EMPTY = Automata.makeEmpty();
 
-    private static final Map<String, Feature> SERVER_SYSTEM_INDEX_DESCRIPTORS = singletonMap(
+    /**
+     * This is the source for non-plugin system features.
+     */
+    private static final Map<String, Feature> SERVER_SYSTEM_FEATURE_DESCRIPTORS = singletonMap(
         TASKS_FEATURE_NAME,
         new Feature(TASKS_FEATURE_NAME, "Manages task results", singletonList(TASKS_DESCRIPTOR))
     );
+
+    /**
+     * The node's full list of system features is stored here. The map is keyed
+     * on the value of {@link Feature#getName()}, and is used for fast lookup of
+     * feature objects via {@link #getFeature(String)}.
+     */
+    private final Map<String, Feature> featureDescriptors;
 
     private final CharacterRunAutomaton systemIndexAutomaton;
     private final CharacterRunAutomaton systemDataStreamIndicesAutomaton;
     private final CharacterRunAutomaton netNewSystemIndexAutomaton;
     private final Predicate<String> systemDataStreamAutomaton;
-    private final Map<String, Feature> featureDescriptors;
     private final Map<String, CharacterRunAutomaton> productToSystemIndicesMatcher;
     private final ExecutorSelector executorSelector;
 
     /**
      * Initialize the SystemIndices object
-     * @param pluginAndModulesDescriptors A map of this node's feature names to
-     *                                    feature objects.
+     * @param pluginAndModuleFeatures A list of features from which we will load system indices.
+     *                                These features come from plugins and modules. Non-plugin system
+     *                                features such as Tasks will be added automatically.
      */
-    public SystemIndices(Map<String, Feature> pluginAndModulesDescriptors) {
-        featureDescriptors = buildSystemIndexDescriptorMap(pluginAndModulesDescriptors);
+    public SystemIndices(List<Feature> pluginAndModuleFeatures) {
+        featureDescriptors = buildFeatureMap(pluginAndModuleFeatures);
         checkForOverlappingPatterns(featureDescriptors);
         ensurePatternsAllowSuffix(featureDescriptors);
         checkForDuplicateAliases(this.getSystemIndexDescriptors());
@@ -97,13 +107,12 @@ public class SystemIndices {
         this.executorSelector = new ExecutorSelector(this);
     }
 
-    static void ensurePatternsAllowSuffix(Map<String, Feature> features) {
+    static void ensurePatternsAllowSuffix(Map<String, Feature> featureDescriptors) {
         String suffixPattern = "*" + UPGRADED_INDEX_SUFFIX;
-        final List<String> descriptorsWithNoRoomForSuffix = features.entrySet()
+        final List<String> descriptorsWithNoRoomForSuffix = featureDescriptors.values()
             .stream()
             .flatMap(
-                feature -> feature.getValue()
-                    .getIndexDescriptors()
+                feature -> feature.getIndexDescriptors()
                     .stream()
                     // The below filter & map are inside the enclosing flapMap so we have access to both the feature and the descriptor
                     .filter(descriptor -> overlaps(descriptor.getIndexPattern(), suffixPattern) == false)
@@ -111,7 +120,7 @@ public class SystemIndices {
                         descriptor -> new ParameterizedMessage(
                             "pattern [{}] from feature [{}]",
                             descriptor.getIndexPattern(),
-                            feature.getKey()
+                            feature.getName()
                         ).getFormattedMessage()
                     )
             )
@@ -149,9 +158,9 @@ public class SystemIndices {
         }
     }
 
-    private static Map<String, CharacterRunAutomaton> getProductToSystemIndicesMap(Map<String, Feature> descriptors) {
+    private static Map<String, CharacterRunAutomaton> getProductToSystemIndicesMap(Map<String, Feature> featureDescriptors) {
         Map<String, Automaton> productToSystemIndicesMap = new HashMap<>();
-        for (Feature feature : descriptors.values()) {
+        for (Feature feature : featureDescriptors.values()) {
             feature.getIndexDescriptors().forEach(systemIndexDescriptor -> {
                 if (systemIndexDescriptor.isExternal()) {
                     systemIndexDescriptor.getAllowedElasticProductOrigins()
@@ -363,8 +372,30 @@ public class SystemIndices {
         return automaton::run;
     }
 
-    public Map<String, Feature> getFeatures() {
-        return featureDescriptors;
+    /**
+     * Get a set of feature names. This is useful for checking whether particular
+     * features are present on the node.
+     * @return A set of all feature names
+     */
+    public Set<String> getFeatureNames() {
+        return Collections.unmodifiableSet(featureDescriptors.keySet());
+    }
+
+    /**
+     * Get a feature by name.
+     * @param name Name of a feature.
+     * @return The corresponding feature if it exists on this node, null otherwise.
+     */
+    public Feature getFeature(String name) {
+        return featureDescriptors.get(name);
+    }
+
+    /**
+     * Get a collection of the Features this SystemIndices object is managing.
+     * @return A collection of Features.
+     */
+    public Collection<Feature> getFeatures() {
+        return Collections.unmodifiableCollection(featureDescriptors.values());
     }
 
     private static CharacterRunAutomaton buildIndexCharacterRunAutomaton(Map<String, Feature> descriptors) {
@@ -525,21 +556,19 @@ public class SystemIndices {
      * Given a collection of {@link SystemIndexDescriptor}s and their sources, checks to see if the index patterns of the listed
      * descriptors overlap with any of the other patterns. If any do, throws an exception.
      *
-     * @param sourceToFeature A map of source (plugin) names to the SystemIndexDescriptors they provide.
+     * @param featureDescriptors A map of feature names to the Features that will provide SystemIndexDescriptors
      * @throws IllegalStateException Thrown if any of the index patterns overlaps with another.
      */
-    static void checkForOverlappingPatterns(Map<String, Feature> sourceToFeature) {
-        List<Tuple<String, SystemIndexDescriptor>> sourceDescriptorPair = sourceToFeature.entrySet()
+    static void checkForOverlappingPatterns(Map<String, Feature> featureDescriptors) {
+        List<Tuple<String, SystemIndexDescriptor>> sourceDescriptorPair = featureDescriptors.values()
             .stream()
-            .flatMap(entry -> entry.getValue().getIndexDescriptors().stream().map(descriptor -> new Tuple<>(entry.getKey(), descriptor)))
+            .flatMap(feature -> feature.getIndexDescriptors().stream().map(descriptor -> new Tuple<>(feature.getName(), descriptor)))
             .sorted(Comparator.comparing(d -> d.v1() + ":" + d.v2().getIndexPattern())) // Consistent ordering -> consistent error message
             .collect(Collectors.toList());
-        List<Tuple<String, SystemDataStreamDescriptor>> sourceDataStreamDescriptorPair = sourceToFeature.entrySet()
+        List<Tuple<String, SystemDataStreamDescriptor>> sourceDataStreamDescriptorPair = featureDescriptors.values()
             .stream()
-            .filter(entry -> entry.getValue().getDataStreamDescriptors().isEmpty() == false)
-            .flatMap(
-                entry -> entry.getValue().getDataStreamDescriptors().stream().map(descriptor -> new Tuple<>(entry.getKey(), descriptor))
-            )
+            .filter(feature -> feature.getDataStreamDescriptors().isEmpty() == false)
+            .flatMap(feature -> feature.getDataStreamDescriptors().stream().map(descriptor -> new Tuple<>(feature.getName(), descriptor)))
             .sorted(Comparator.comparing(d -> d.v1() + ":" + d.v2().getDataStreamName())) // Consistent ordering -> consistent error message
             .collect(Collectors.toList());
 
@@ -598,11 +627,11 @@ public class SystemIndices {
         return Operations.isEmpty(Operations.intersection(a1Automaton, a2Automaton)) == false;
     }
 
-    private static Map<String, Feature> buildSystemIndexDescriptorMap(Map<String, Feature> featuresMap) {
-        final Map<String, Feature> map = new HashMap<>(featuresMap.size() + SERVER_SYSTEM_INDEX_DESCRIPTORS.size());
-        map.putAll(featuresMap);
+    private static Map<String, Feature> buildFeatureMap(List<Feature> features) {
+        final Map<String, Feature> map = new HashMap<>(features.size() + SERVER_SYSTEM_FEATURE_DESCRIPTORS.size());
+        features.forEach(feature -> map.put(feature.getName(), feature));
         // put the server items last since we expect less of them
-        SERVER_SYSTEM_INDEX_DESCRIPTORS.forEach((source, feature) -> {
+        SERVER_SYSTEM_FEATURE_DESCRIPTORS.forEach((source, feature) -> {
             if (map.putIfAbsent(source, feature) != null) {
                 throw new IllegalArgumentException(
                     "plugin or module attempted to define the same source [" + source + "] as a built-in system index"

--- a/server/src/main/java/org/elasticsearch/snapshots/RestoreService.java
+++ b/server/src/main/java/org/elasticsearch/snapshots/RestoreService.java
@@ -325,9 +325,8 @@ public class RestoreService implements ClusterStateApplier {
             .flatMap(Collection::stream)
             .collect(Collectors.toSet());
 
-        final Map<String, SystemIndices.Feature> featureSet = systemIndices.getFeatures();
         final Set<String> featureStateDataStreams = featureStatesToRestore.keySet().stream().filter(featureName -> {
-            if (featureSet.containsKey(featureName)) {
+            if (systemIndices.getFeatureNames().contains(featureName)) {
                 return true;
             }
             logger.warn(
@@ -339,7 +338,7 @@ public class RestoreService implements ClusterStateApplier {
             );
             return false;
         })
-            .map(name -> systemIndices.getFeatures().get(name))
+            .map(systemIndices::getFeature)
             .flatMap(feature -> feature.getDataStreamDescriptors().stream())
             .map(SystemDataStreamDescriptor::getDataStreamName)
             .collect(Collectors.toSet());
@@ -585,7 +584,7 @@ public class RestoreService implements ClusterStateApplier {
 
         final List<String> featuresNotOnThisNode = featureStatesToRestore.keySet()
             .stream()
-            .filter(featureName -> systemIndices.getFeatures().containsKey(featureName) == false)
+            .filter(s -> systemIndices.getFeatureNames().contains(s) == false)
             .collect(Collectors.toList());
         if (featuresNotOnThisNode.isEmpty() == false) {
             throw new SnapshotRestoreException(
@@ -614,7 +613,7 @@ public class RestoreService implements ClusterStateApplier {
 
         return Collections.unmodifiableSet(
             featureStatesToRestore.stream()
-                .map(featureName -> systemIndices.getFeatures().get(featureName))
+                .map(systemIndices::getFeature)
                 .filter(Objects::nonNull) // Features that aren't present on this node will be warned about in `getFeatureStatesToRestore`
                 .flatMap(feature -> feature.getIndexDescriptors().stream())
                 .flatMap(descriptor -> descriptor.getMatchingIndices(currentState.metadata()).stream())

--- a/server/src/main/java/org/elasticsearch/upgrades/SystemIndexMigrationInfo.java
+++ b/server/src/main/java/org/elasticsearch/upgrades/SystemIndexMigrationInfo.java
@@ -281,7 +281,7 @@ class SystemIndexMigrationInfo implements Comparable<SystemIndexMigrationInfo> {
         IndexScopedSettings indexScopedSettings
     ) {
         SystemIndexDescriptor descriptor = systemIndices.findMatchingDescriptor(taskState.getCurrentIndex());
-        SystemIndices.Feature feature = systemIndices.getFeatures().get(taskState.getCurrentFeature());
+        SystemIndices.Feature feature = systemIndices.getFeature(taskState.getCurrentFeature());
         IndexMetadata imd = metadata.index(taskState.getCurrentIndex());
 
         // It's possible for one or both of these to happen if the executing node fails during execution and:

--- a/server/src/main/java/org/elasticsearch/upgrades/SystemIndexMigrator.java
+++ b/server/src/main/java/org/elasticsearch/upgrades/SystemIndexMigrator.java
@@ -117,7 +117,7 @@ public class SystemIndexMigrator extends AllocatedPersistentTask {
             stateIndexName = taskState.getCurrentIndex();
             stateFeatureName = taskState.getCurrentFeature();
 
-            SystemIndices.Feature feature = systemIndices.getFeatures().get(stateFeatureName);
+            SystemIndices.Feature feature = systemIndices.getFeature(stateFeatureName);
             if (feature == null) {
                 markAsFailed(
                     new IllegalStateException(
@@ -144,7 +144,6 @@ public class SystemIndexMigrator extends AllocatedPersistentTask {
             }
 
             systemIndices.getFeatures()
-                .values()
                 .stream()
                 .flatMap(feature -> SystemIndexMigrationInfo.fromFeature(feature, clusterState.metadata(), indexScopedSettings))
                 .filter(migrationInfo -> needsToBeMigrated(clusterState.metadata().index(migrationInfo.getCurrentIndexName())))

--- a/server/src/test/java/org/elasticsearch/action/admin/indices/alias/get/TransportGetAliasesActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/indices/alias/get/TransportGetAliasesActionTests.java
@@ -299,8 +299,7 @@ public class TransportGetAliasesActionTests extends ESTestCase {
             .setNetNew()
             .build();
         SystemIndices systemIndices = new SystemIndices(
-            Collections.singletonMap(
-                this.getTestName(),
+            Collections.singletonList(
                 new SystemIndices.Feature(this.getTestName(), "test feature", Collections.singletonList(netNewDescriptor))
             )
         );

--- a/server/src/test/java/org/elasticsearch/action/admin/indices/settings/put/TransportUpdateSettingsActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/indices/settings/put/TransportUpdateSettingsActionTests.java
@@ -22,7 +22,6 @@ import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.core.List;
-import org.elasticsearch.core.Map;
 import org.elasticsearch.indices.SystemIndexDescriptor;
 import org.elasticsearch.indices.SystemIndices;
 import org.elasticsearch.test.ESTestCase;
@@ -60,8 +59,7 @@ public class TransportUpdateSettingsActionTests extends ESTestCase {
 
     private static final String SYSTEM_INDEX_NAME = ".my-system";
     private static final SystemIndices SYSTEM_INDICES = new SystemIndices(
-        Map.of(
-            "test-feature",
+        List.of(
             new SystemIndices.Feature("test-feature", "a test feature", List.of(new SystemIndexDescriptor(SYSTEM_INDEX_NAME + "*", "test")))
         )
     );

--- a/server/src/test/java/org/elasticsearch/action/bulk/TransportBulkActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/bulk/TransportBulkActionTests.java
@@ -31,7 +31,6 @@ import org.elasticsearch.cluster.node.DiscoveryNodeRole;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.concurrent.EsRejectedExecutionException;
-import org.elasticsearch.core.Map;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.index.IndexNotFoundException;
 import org.elasticsearch.index.IndexingPressure;
@@ -294,8 +293,7 @@ public class TransportBulkActionTests extends ESTestCase {
             new ConcreteIndex(IndexMetadata.builder(".bar").settings(settings).system(true).numberOfShards(1).numberOfReplicas(0).build())
         );
         SystemIndices systemIndices = new SystemIndices(
-            Map.of(
-                "plugin",
+            org.elasticsearch.core.List.of(
                 new SystemIndices.Feature("plugin", "test feature", org.elasticsearch.core.List.of(new SystemIndexDescriptor(".test*", "")))
             )
         );

--- a/server/src/test/java/org/elasticsearch/action/support/AutoCreateIndexTests.java
+++ b/server/src/test/java/org/elasticsearch/action/support/AutoCreateIndexTests.java
@@ -323,12 +323,11 @@ public class AutoCreateIndexTests extends ESTestCase {
 
     private AutoCreateIndex newAutoCreateIndex(Settings settings) {
         SystemIndices systemIndices = new SystemIndices(
-            org.elasticsearch.core.Map.of(
-                "plugin",
+            org.elasticsearch.core.List.of(
                 new SystemIndices.Feature(
                     "plugin",
                     "test feature",
-                    singletonList(new SystemIndexDescriptor(TEST_SYSTEM_INDEX_NAME + "*", ""))
+                    org.elasticsearch.core.List.of(new SystemIndexDescriptor(TEST_SYSTEM_INDEX_NAME + "*", ""))
                 )
             )
         );

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/IndexNameExpressionResolverTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/IndexNameExpressionResolverTests.java
@@ -25,7 +25,6 @@ import org.elasticsearch.cluster.metadata.IndexMetadata.State;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
-import org.elasticsearch.core.Map;
 import org.elasticsearch.index.Index;
 import org.elasticsearch.index.IndexNotFoundException;
 import org.elasticsearch.index.IndexSettings;
@@ -2379,8 +2378,7 @@ public class IndexNameExpressionResolverTests extends ESTestCase {
             )
             .build();
         SystemIndices systemIndices = new SystemIndices(
-            Map.of(
-                "ml",
+            org.elasticsearch.core.List.of(
                 new Feature(
                     "ml",
                     "ml indices",
@@ -2389,13 +2387,11 @@ public class IndexNameExpressionResolverTests extends ESTestCase {
                         new SystemIndexDescriptor(".ml-stuff*", "other ml")
                     )
                 ),
-                "watcher",
                 new Feature(
                     "watcher",
                     "watcher indices",
                     org.elasticsearch.core.List.of(new SystemIndexDescriptor(".watches*", "watches index"))
                 ),
-                "stack-component",
                 new Feature(
                     "stack-component",
                     "stack component",
@@ -2971,8 +2967,7 @@ public class IndexNameExpressionResolverTests extends ESTestCase {
             .put(indexBuilder(".ml-stuff", settings).state(State.OPEN).system(true))
             .put(indexBuilder("some-other-index").state(State.OPEN));
         SystemIndices systemIndices = new SystemIndices(
-            Map.of(
-                "ml",
+            org.elasticsearch.core.List.of(
                 new Feature(
                     "ml",
                     "ml indices",
@@ -2981,7 +2976,6 @@ public class IndexNameExpressionResolverTests extends ESTestCase {
                         new SystemIndexDescriptor(".ml-stuff*", "other ml")
                     )
                 ),
-                "watcher",
                 new Feature(
                     "watcher",
                     "watcher indices",

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/MetadataCreateDataStreamServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/MetadataCreateDataStreamServiceTests.java
@@ -356,17 +356,16 @@ public class MetadataCreateDataStreamServiceTests extends ESTestCase {
     }
 
     private static SystemIndices getSystemIndices() {
-        Map<String, Feature> map = Collections.singletonMap(
-            "system",
+        List<Feature> features = org.elasticsearch.core.List.of(
             new Feature(
                 "systemFeature",
                 "system feature description",
-                Collections.emptyList(),
-                Collections.singletonList(systemDataStreamDescriptor())
+                org.elasticsearch.core.List.of(),
+                org.elasticsearch.core.List.of(systemDataStreamDescriptor())
             )
         );
 
-        return new SystemIndices(map);
+        return new SystemIndices(features);
     }
 
     private static SystemDataStreamDescriptor systemDataStreamDescriptor() {

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/MetadataCreateIndexServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/MetadataCreateIndexServiceTests.java
@@ -678,9 +678,7 @@ public class MetadataCreateIndexServiceTests extends ESTestCase {
                 null,
                 threadPool,
                 null,
-                new SystemIndices(
-                    Collections.singletonMap("foo", new SystemIndices.Feature("foo", "test feature", systemIndexDescriptors))
-                ),
+                new SystemIndices(Collections.singletonList(new SystemIndices.Feature("foo", "test feature", systemIndexDescriptors))),
                 false
             );
             // Check deprecations

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/SystemIndexMetadataUpgradeServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/SystemIndexMetadataUpgradeServiceTests.java
@@ -15,7 +15,6 @@ import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.collect.ImmutableOpenMap;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.core.List;
-import org.elasticsearch.core.Map;
 import org.elasticsearch.indices.SystemIndexDescriptor;
 import org.elasticsearch.indices.SystemIndices;
 import org.elasticsearch.test.ESTestCase;
@@ -43,7 +42,7 @@ public class SystemIndexMetadataUpgradeServiceTests extends ESTestCase {
     public void setUpTest() {
         // set up a system index upgrade service
         this.service = new SystemIndexMetadataUpgradeService(
-            new SystemIndices(Map.of("MyIndex", new SystemIndices.Feature("foo", "a test feature", List.of(DESCRIPTOR)))),
+            new SystemIndices(List.of(new SystemIndices.Feature("foo", "a test feature", List.of(DESCRIPTOR)))),
             mock(ClusterService.class)
         );
     }

--- a/server/src/test/java/org/elasticsearch/indices/ExecutorSelectorTests.java
+++ b/server/src/test/java/org/elasticsearch/indices/ExecutorSelectorTests.java
@@ -24,8 +24,7 @@ public class ExecutorSelectorTests extends ESTestCase {
     public void testNonCriticalSystemIndexThreadPools() {
         ExecutorSelector service = new ExecutorSelector(
             new SystemIndices(
-                Map.of(
-                    "normal system index",
+                List.of(
                     new SystemIndices.Feature(
                         "normal",
                         "normal system index",
@@ -43,8 +42,7 @@ public class ExecutorSelectorTests extends ESTestCase {
     public void testCriticalSystemIndexThreadPools() {
         ExecutorSelector service = new ExecutorSelector(
             new SystemIndices(
-                Map.of(
-                    "critical system index",
+                List.of(
                     new SystemIndices.Feature(
                         "critical",
                         "critical system index",
@@ -69,8 +67,7 @@ public class ExecutorSelectorTests extends ESTestCase {
     public void testDefaultSystemDataStreamThreadPools() {
         ExecutorSelector service = new ExecutorSelector(
             new SystemIndices(
-                Map.of(
-                    "normal system index",
+                List.of(
                     new SystemIndices.Feature(
                         "data stream",
                         "data stream feature with default thread pools",
@@ -107,8 +104,7 @@ public class ExecutorSelectorTests extends ESTestCase {
     public void testCustomSystemDataStreamThreadPools() {
         ExecutorSelector service = new ExecutorSelector(
             new SystemIndices(
-                Map.of(
-                    "normal system index",
+                List.of(
                     new SystemIndices.Feature(
                         "data stream",
                         "data stream feature with custom thread pools",

--- a/server/src/test/java/org/elasticsearch/indices/SystemIndexManagerTests.java
+++ b/server/src/test/java/org/elasticsearch/indices/SystemIndexManagerTests.java
@@ -33,7 +33,6 @@ import org.elasticsearch.common.util.concurrent.EsExecutors;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.common.xcontent.XContentHelper;
 import org.elasticsearch.core.CheckedConsumer;
-import org.elasticsearch.core.Map;
 import org.elasticsearch.index.Index;
 import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.indices.SystemIndexManager.UpgradeStatus;
@@ -109,10 +108,8 @@ public class SystemIndexManagerTests extends ESTestCase {
             .build();
 
         SystemIndices systemIndices = new SystemIndices(
-            Map.of(
-                "index 1",
+            org.elasticsearch.core.List.of(
                 new SystemIndices.Feature("index 1", "index 1 feature", org.elasticsearch.core.List.of(d1)),
-                "index 2",
                 new SystemIndices.Feature("index 2", "index 2 feature", org.elasticsearch.core.List.of(d2))
             )
         );
@@ -154,10 +151,8 @@ public class SystemIndexManagerTests extends ESTestCase {
             .build();
 
         SystemIndices systemIndices = new SystemIndices(
-            Map.of(
-                "index 1",
+            org.elasticsearch.core.List.of(
                 new SystemIndices.Feature("index 1", "index 1 feature", org.elasticsearch.core.List.of(d1)),
-                "index 2",
                 new SystemIndices.Feature("index 2", "index 2 feature", org.elasticsearch.core.List.of(d2))
             )
         );
@@ -176,7 +171,7 @@ public class SystemIndexManagerTests extends ESTestCase {
      * Check that the manager won't try to upgrade closed indices.
      */
     public void testManagerSkipsClosedIndices() {
-        SystemIndices systemIndices = new SystemIndices(Map.of("MyIndex", FEATURE));
+        SystemIndices systemIndices = new SystemIndices(org.elasticsearch.core.List.of(FEATURE));
         SystemIndexManager manager = new SystemIndexManager(systemIndices, client);
 
         final ClusterState.Builder clusterStateBuilder = createClusterState(IndexMetadata.State.CLOSE);
@@ -188,7 +183,7 @@ public class SystemIndexManagerTests extends ESTestCase {
      * Check that the manager won't try to upgrade unhealthy indices.
      */
     public void testManagerSkipsIndicesWithRedStatus() {
-        SystemIndices systemIndices = new SystemIndices(Map.of("MyIndex", FEATURE));
+        SystemIndices systemIndices = new SystemIndices(org.elasticsearch.core.List.of(FEATURE));
         SystemIndexManager manager = new SystemIndexManager(systemIndices, client);
 
         assertThat(manager.getUpgradeStatus(markShardsUnavailable(createClusterState()), DESCRIPTOR), equalTo(UpgradeStatus.UNHEALTHY));
@@ -199,7 +194,7 @@ public class SystemIndexManagerTests extends ESTestCase {
      * is earlier than an expected value.
      */
     public void testManagerSkipsIndicesWithOutdatedFormat() {
-        SystemIndices systemIndices = new SystemIndices(Map.of("MyIndex", FEATURE));
+        SystemIndices systemIndices = new SystemIndices(org.elasticsearch.core.List.of(FEATURE));
         SystemIndexManager manager = new SystemIndexManager(systemIndices, client);
 
         assertThat(manager.getUpgradeStatus(markShardsAvailable(createClusterState(5)), DESCRIPTOR), equalTo(UpgradeStatus.NEEDS_UPGRADE));
@@ -210,7 +205,7 @@ public class SystemIndexManagerTests extends ESTestCase {
      * differs from the type specified in the descriptor.
      */
     public void testManagerSkipsIndicesWithWrongType() {
-        SystemIndices systemIndices = new SystemIndices(Map.of("MyIndex", FEATURE));
+        SystemIndices systemIndices = new SystemIndices(org.elasticsearch.core.List.of(FEATURE));
         SystemIndexManager manager = new SystemIndexManager(systemIndices, client);
 
         assertThat(
@@ -223,7 +218,7 @@ public class SystemIndexManagerTests extends ESTestCase {
      * Check that the manager won't try to upgrade indices where their mappings are already up-to-date.
      */
     public void testManagerSkipsIndicesWithUpToDateMappings() {
-        SystemIndices systemIndices = new SystemIndices(Map.of("MyIndex", FEATURE));
+        SystemIndices systemIndices = new SystemIndices(org.elasticsearch.core.List.of(FEATURE));
         SystemIndexManager manager = new SystemIndexManager(systemIndices, client);
 
         assertThat(manager.getUpgradeStatus(markShardsAvailable(createClusterState()), DESCRIPTOR), equalTo(UpgradeStatus.UP_TO_DATE));
@@ -233,7 +228,7 @@ public class SystemIndexManagerTests extends ESTestCase {
      * Check that the manager will try to upgrade indices where their mappings are out-of-date.
      */
     public void testManagerProcessesIndicesWithOutdatedMappings() {
-        SystemIndices systemIndices = new SystemIndices(Map.of("MyIndex", FEATURE));
+        SystemIndices systemIndices = new SystemIndices(org.elasticsearch.core.List.of(FEATURE));
         SystemIndexManager manager = new SystemIndexManager(systemIndices, client);
 
         assertThat(
@@ -246,7 +241,7 @@ public class SystemIndexManagerTests extends ESTestCase {
      * Check that the manager will try to upgrade indices where the mappings metadata is null or absent.
      */
     public void testManagerProcessesIndicesWithNullMetadata() {
-        SystemIndices systemIndices = new SystemIndices(Map.of("MyIndex", FEATURE));
+        SystemIndices systemIndices = new SystemIndices(org.elasticsearch.core.List.of(FEATURE));
         SystemIndexManager manager = new SystemIndexManager(systemIndices, client);
 
         assertThat(
@@ -259,7 +254,7 @@ public class SystemIndexManagerTests extends ESTestCase {
      * Check that the manager will try to upgrade indices where the version in the metadata is null or absent.
      */
     public void testManagerProcessesIndicesWithNullVersionMetadata() {
-        SystemIndices systemIndices = new SystemIndices(Map.of("MyIndex", FEATURE));
+        SystemIndices systemIndices = new SystemIndices(org.elasticsearch.core.List.of(FEATURE));
         SystemIndexManager manager = new SystemIndexManager(systemIndices, client);
 
         assertThat(
@@ -272,7 +267,7 @@ public class SystemIndexManagerTests extends ESTestCase {
      * Check that the manager submits the expected request for an index whose mappings are out-of-date.
      */
     public void testManagerSubmitsPutRequest() {
-        SystemIndices systemIndices = new SystemIndices(Map.of("MyIndex", FEATURE));
+        SystemIndices systemIndices = new SystemIndices(org.elasticsearch.core.List.of(FEATURE));
         SystemIndexManager manager = new SystemIndexManager(systemIndices, client);
 
         manager.clusterChanged(event(markShardsAvailable(createClusterState(Strings.toString(getMappings("1.0.0"))))));
@@ -284,7 +279,7 @@ public class SystemIndexManagerTests extends ESTestCase {
      * Check that this
      */
     public void testCanHandleIntegerMetaVersion() {
-        SystemIndices systemIndices = new SystemIndices(Map.of("MyIndex", FEATURE));
+        SystemIndices systemIndices = new SystemIndices(org.elasticsearch.core.List.of(FEATURE));
         SystemIndexManager manager = new SystemIndexManager(systemIndices, client);
 
         assertThat(

--- a/server/src/test/java/org/elasticsearch/indices/SystemIndicesTests.java
+++ b/server/src/test/java/org/elasticsearch/indices/SystemIndicesTests.java
@@ -15,9 +15,8 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
-import static java.util.Collections.emptyMap;
+import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
-import static java.util.Collections.singletonMap;
 import static org.elasticsearch.tasks.TaskResultsService.TASKS_FEATURE_NAME;
 import static org.elasticsearch.tasks.TaskResultsService.TASK_INDEX;
 import static org.hamcrest.Matchers.allOf;
@@ -66,7 +65,10 @@ public class SystemIndicesTests extends ESTestCase {
         assertThat(exception.getMessage(), containsString(overlapping3.toString() + fromPluginString));
         assertThat(exception.getMessage(), not(containsString(notOverlapping.toString())));
 
-        IllegalStateException constructorException = expectThrows(IllegalStateException.class, () -> new SystemIndices(descriptors));
+        IllegalStateException constructorException = expectThrows(
+            IllegalStateException.class,
+            () -> new SystemIndices(List.copyOf(descriptors.values()))
+        );
         assertThat(constructorException.getMessage(), equalTo(exception.getMessage()));
     }
 
@@ -95,24 +97,26 @@ public class SystemIndicesTests extends ESTestCase {
         );
         assertThat(exception.getMessage(), containsString(pattern2.toString() + " from [" + source2 + "]"));
 
-        IllegalStateException constructorException = expectThrows(IllegalStateException.class, () -> new SystemIndices(descriptors));
+        IllegalStateException constructorException = expectThrows(
+            IllegalStateException.class,
+            () -> new SystemIndices(List.copyOf(descriptors.values()))
+        );
         assertThat(constructorException.getMessage(), equalTo(exception.getMessage()));
     }
 
     public void testBuiltInSystemIndices() {
-        SystemIndices systemIndices = new SystemIndices(emptyMap());
+        SystemIndices systemIndices = new SystemIndices(emptyList());
         assertTrue(systemIndices.isSystemIndex(".tasks"));
         assertTrue(systemIndices.isSystemIndex(".tasks1"));
         assertTrue(systemIndices.isSystemIndex(".tasks-old"));
     }
 
     public void testPluginCannotOverrideBuiltInSystemIndex() {
-        Map<String, SystemIndices.Feature> pluginMap = singletonMap(
-            TASKS_FEATURE_NAME,
+        java.util.List<SystemIndices.Feature> pluginMap = singletonList(
             new SystemIndices.Feature(
                 TASKS_FEATURE_NAME,
                 "test",
-                singletonList(new SystemIndexDescriptor(TASK_INDEX + "*", "Task Result " + "Index"))
+                Collections.singletonList(new SystemIndexDescriptor(TASK_INDEX + "*", "Task Result Index"))
             )
         );
         IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> new SystemIndices(pluginMap));
@@ -121,8 +125,7 @@ public class SystemIndicesTests extends ESTestCase {
 
     public void testPatternWithSimpleRange() {
         final SystemIndices systemIndices = new SystemIndices(
-            singletonMap(
-                "test",
+            List.of(
                 new SystemIndices.Feature(
                     "test",
                     "test feature",
@@ -143,8 +146,7 @@ public class SystemIndicesTests extends ESTestCase {
 
     public void testPatternWithSimpleRangeAndRepeatOperator() {
         final SystemIndices systemIndices = new SystemIndices(
-            singletonMap(
-                "test",
+            singletonList(
                 new SystemIndices.Feature(
                     "test",
                     "test feature",
@@ -162,8 +164,7 @@ public class SystemIndicesTests extends ESTestCase {
 
     public void testPatternWithComplexRange() {
         final SystemIndices systemIndices = new SystemIndices(
-            singletonMap(
-                "test",
+            singletonList(
                 new SystemIndices.Feature(
                     "test",
                     "test feature",

--- a/test/framework/src/main/java/org/elasticsearch/indices/EmptySystemIndices.java
+++ b/test/framework/src/main/java/org/elasticsearch/indices/EmptySystemIndices.java
@@ -19,6 +19,6 @@ public class EmptySystemIndices extends SystemIndices {
     public static final SystemIndices INSTANCE = new EmptySystemIndices();
 
     private EmptySystemIndices() {
-        super(Collections.emptyMap());
+        super(Collections.emptyList());
     }
 }

--- a/x-pack/plugin/fleet/src/test/java/org/elasticsearch/xpack/fleet/FleetTests.java
+++ b/x-pack/plugin/fleet/src/test/java/org/elasticsearch/xpack/fleet/FleetTests.java
@@ -53,7 +53,7 @@ public class FleetTests extends ESTestCase {
     public void testFleetFeature() {
         Fleet module = new Fleet();
         Feature fleet = Feature.fromSystemIndexPlugin(module, Settings.EMPTY);
-        SystemIndices systemIndices = new SystemIndices(Collections.singletonMap(module.getFeatureName(), fleet));
+        SystemIndices systemIndices = new SystemIndices(Collections.singletonList(fleet));
         assertNotNull(systemIndices);
     }
 }


### PR DESCRIPTION
The SystemIndices constructor should take a list instead of a map as an argument so that we can guarantee that the map we use for feature lookups is keyed on the feature name.

We also provide some new getter methods so that calling code does not have to handle the map directly.