### PR TITLE
Add log4j.core to requires for the security module

### DIFF
--- a/x-pack/plugin/security/src/main/java/module-info.java
+++ b/x-pack/plugin/security/src/main/java/module-info.java
@@ -25,6 +25,7 @@ module org.elasticsearch.security {
     requires org.apache.httpcomponents.httpcore.nio;
     requires org.apache.log4j;
     requires org.apache.logging.log4j;
+    requires org.apache.logging.log4j.core;
     requires org.apache.lucene.core;
     requires org.apache.lucene.queries;
     requires org.apache.lucene.sandbox;


### PR DESCRIPTION
org.apache.logging.log4j.core is referenced in the LoggingAuditTrail
class. This PR adds it to the requires list of the security module.

Relates: #81066
