### PR TITLE
Fix expand_wildcards default in docs

### DIFF
--- a/docs/reference/indices/get-settings.asciidoc
+++ b/docs/reference/indices/get-settings.asciidoc
@@ -50,7 +50,7 @@ Defaults to `true`.
 
 include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=expand-wildcards]
 +
-Defaults to `all`.
+Defaults to `open`.
 
 include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=flat-settings]
 


### PR DESCRIPTION
The get settings api has accepts the expand_wildcards option. The docs
state the default value is `all`, but it is actually now `open` (which
does not include hidden or closed indices by default). This commit
changes the docs to match the existing behavior.