### PR TITLE
Fix DataStreamSecurityIT#testRemoveGhostReference() test

### DIFF
--- a/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/integration/DataStreamSecurityIT.java
+++ b/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/integration/DataStreamSecurityIT.java
@@ -143,7 +143,7 @@ public class DataStreamSecurityIT extends SecurityIntegTestCase {
         // Note, that old backing index still exists, but it is still hidden.
         // The modify data stream api only fixed the data stream by removing a broken reference to a backing index.
         indicesStatsResponse = client.admin().indices().stats(new IndicesStatsRequest()).actionGet();
-        assertThat(indicesStatsResponse.getIndices().size(), equalTo(1));
+        assertThat(indicesStatsResponse.getIndices().size(), equalTo(shouldBreakIndexName ? 1 : 2));
     }
 
 }


### PR DESCRIPTION
If the modify data stream api can find the IndexMetadata of
an index it tries to remove from a data stream then it can
unhide the index as well, otherwise it can't.

This determines whether the expected index stats is either 1 or 2
in the last get indices stats call.