### PR TITLE
[8.2] Fix expand_wildcards default in docs (#87086)

### DIFF
--- a/docs/reference/indices/get-settings.asciidoc
+++ b/docs/reference/indices/get-settings.asciidoc
@@ -50,7 +50,7 @@ Defaults to `true`.
 
 include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=expand-wildcards]
 +
-Defaults to `all`.
+Defaults to `open`.
 
 include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=flat-settings]
 


### PR DESCRIPTION
Backports the following commits to 8.2:
 - Fix expand_wildcards default in docs (#87086)