### PR TITLE
User Profile - audit support for security domain

### DIFF
--- a/docs/changelog/87097.yaml
+++ b/docs/changelog/87097.yaml
@@ -1,0 +1,5 @@
+pr: 87097
+summary: User Profile - audit support for security domain
+area: Audit
+type: enhancement
+issues: []

--- a/x-pack/plugin/core/src/main/config/log4j2.properties
+++ b/x-pack/plugin/core/src/main/config/log4j2.properties
@@ -18,8 +18,11 @@ appender.audit_rolling.layout.pattern = {\
                 %varsNotEmpty{, "user.run_by.name":"%enc{%map{user.run_by.name}}{JSON}"}\
                 %varsNotEmpty{, "user.run_as.name":"%enc{%map{user.run_as.name}}{JSON}"}\
                 %varsNotEmpty{, "user.realm":"%enc{%map{user.realm}}{JSON}"}\
+                %varsNotEmpty{, "user.realm_domain":"%enc{%map{user.realm_domain}}{JSON}"}\
                 %varsNotEmpty{, "user.run_by.realm":"%enc{%map{user.run_by.realm}}{JSON}"}\
+                %varsNotEmpty{, "user.run_by.realm_domain":"%enc{%map{user.run_by.realm_domain}}{JSON}"}\
                 %varsNotEmpty{, "user.run_as.realm":"%enc{%map{user.run_as.realm}}{JSON}"}\
+                %varsNotEmpty{, "user.run_as.realm_domain":"%enc{%map{user.run_as.realm_domain}}{JSON}"}\
                 %varsNotEmpty{, "user.roles":%map{user.roles}}\
                 %varsNotEmpty{, "apikey.id":"%enc{%map{apikey.id}}{JSON}"}\
                 %varsNotEmpty{, "apikey.name":"%enc{%map{apikey.name}}{JSON}"}\
@@ -28,6 +31,7 @@ appender.audit_rolling.layout.pattern = {\
                 %varsNotEmpty{, "origin.type":"%enc{%map{origin.type}}{JSON}"}\
                 %varsNotEmpty{, "origin.address":"%enc{%map{origin.address}}{JSON}"}\
                 %varsNotEmpty{, "realm":"%enc{%map{realm}}{JSON}"}\
+                %varsNotEmpty{, "realm_domain":"%enc{%map{realm_domain}}{JSON}"}\
                 %varsNotEmpty{, "url.path":"%enc{%map{url.path}}{JSON}"}\
                 %varsNotEmpty{, "url.query":"%enc{%map{url.query}}{JSON}"}\
                 %varsNotEmpty{, "request.method":"%enc{%map{request.method}}{JSON}"}\
@@ -58,8 +62,11 @@ appender.audit_rolling.layout.pattern = {\
 # "user.run_by.name" the original authenticated subject name that is impersonating another one.
 # "user.run_as.name" if this "event.action" is of a run_as type, this is the subject name to be impersonated as.
 # "user.realm" the name of the realm that authenticated "user.name"
+# "user.realm_domain" if "user.realm" is under a domain, this is the name of the domain
 # "user.run_by.realm" the realm name of the impersonating subject ("user.run_by.name")
+# "user.run_by.realm_domain" if "user.run_by.realm" is under a domain, this is the name of the domain
 # "user.run_as.realm" if this "event.action" is of a run_as type, this is the realm name the impersonated user is looked up from
+# "user.run_as.realm_domain" if "user.run_as.realm" is under a domain, this is the name of the domain
 # "user.roles" the roles array of the user; these are the roles that are granting privileges
 # "apikey.id" this field is present if and only if the "authentication.type" is "api_key"
 # "apikey.name" this field is present if and only if the "authentication.type" is "api_key"
@@ -68,6 +75,7 @@ appender.audit_rolling.layout.pattern = {\
 # "event.type" informs about what internal system generated the event; possible values are "rest", "transport", "ip_filter" and "security_config_change"
 # "origin.address" the remote address and port of the first network hop, i.e. a REST proxy or another cluster node
 # "realm" name of a realm that has generated an "authentication_failed" or an "authentication_successful"; the subject is not yet authenticated
+# "realm_domain" if "realm" is under a domain, this is the name of the domain
 # "url.path" the URI component between the port and the query string; it is percent (URL) encoded
 # "url.query" the URI component after the path and before the fragment; it is percent (URL) encoded
 # "request.method" the method of the HTTP request, i.e. one of GET, POST, PUT, DELETE, OPTIONS, HEAD, PATCH, TRACE, CONNECT

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authc/AuthenticationTestHelper.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authc/AuthenticationTestHelper.java
@@ -108,6 +108,10 @@ public class AuthenticationTestHelper {
         return new RealmDomain(ESTestCase.randomAlphaOfLengthBetween(3, 8), domainRealms);
     }
 
+    public static Authentication.RealmRef randomRealmRef() {
+        return randomRealmRef(ESTestCase.randomBoolean());
+    }
+
     public static Authentication.RealmRef randomRealmRef(boolean underDomain) {
         return randomRealmRef(underDomain, true);
     }


### PR DESCRIPTION
Security domain allows sharing resources across different realms which
means it is now part of the authorization process. Hence we should
capture it in relevant audit entries for completeness.

In theory, the domain name should be captured in all the places realm
name is captured. However, it is not necessary in practice because:

1. The field `realm` in authentication_success event is for BWC purpose.
   Hence we don't need pair it with domain.
2. API Keys cannot be under any domain.
3. No need to audit domain for authentication_failed events because no
   authorization is possible in these cases.
