### PR TITLE
Reword #87076 changelog entry

### DIFF
--- a/docs/changelog/87076.yaml
+++ b/docs/changelog/87076.yaml
@@ -1,6 +1,6 @@
 pr: 87076
-summary: Fix CCR following a datastream with closed indices on the follower corrupting
-  the datastream
+summary: Prevent invalid datastream metadata when CCR follows a datastream with
+  closed indices on the follower
 area: "CCR"
 type: bug
 issues:


### PR DESCRIPTION
The phrase "corrupting the datastream" sounds like data loss (or worse)
but in fact it's just bad metadata and the situation is recoverable.
