### PR TITLE
[7.17] Reword #87076 changelog entry (#87109)

### DIFF
--- a/docs/changelog/87076.yaml
+++ b/docs/changelog/87076.yaml
@@ -1,6 +1,6 @@
 pr: 87076
-summary: Fix CCR following a datastream with closed indices on the follower corrupting
-  the datastream
+summary: Prevent invalid datastream metadata when CCR follows a datastream with
+  closed indices on the follower
 area: "CCR"
 type: bug
 issues:


### PR DESCRIPTION
Backports the following commits to 7.17:
 - Reword #87076 changelog entry (#87109)