### PR TITLE
Rest API Spec: Wraps YAML tests values with colon in quotes

### DIFF
--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.aggregation/500_serial_diff.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.aggregation/500_serial_diff.yml
@@ -29,9 +29,9 @@ basic:
                 d: {serial_diff: {buckets_path: v}}
   - match: { hits.total.value: 3 }
   - length: { aggregations.@timestamp.buckets: 3 }
-  - match: { aggregations.@timestamp.buckets.0.key_as_string: 2022-01-01T00:00:00.000Z }
-  - match: { aggregations.@timestamp.buckets.1.key_as_string: 2022-01-01T01:00:00.000Z }
-  - match: { aggregations.@timestamp.buckets.2.key_as_string: 2022-01-01T02:00:00.000Z }
+  - match: { aggregations.@timestamp.buckets.0.key_as_string: "2022-01-01T00:00:00.000Z" }
+  - match: { aggregations.@timestamp.buckets.1.key_as_string: "2022-01-01T01:00:00.000Z" }
+  - match: { aggregations.@timestamp.buckets.2.key_as_string: "2022-01-01T02:00:00.000Z" }
   - match: { aggregations.@timestamp.buckets.0.v.value: 1 }
   - match: { aggregations.@timestamp.buckets.1.v.value: 2 }
   - match: { aggregations.@timestamp.buckets.2.v.value: 1 }
@@ -72,10 +72,10 @@ lag:
                     d: { serial_diff: { buckets_path: v, lag: 2 } }
       - match: { hits.total.value: 4 }
       - length: { aggregations.@timestamp.buckets: 4 }
-      - match: { aggregations.@timestamp.buckets.0.key_as_string: 2022-01-01T00:00:00.000Z }
-      - match: { aggregations.@timestamp.buckets.1.key_as_string: 2022-01-01T01:00:00.000Z }
-      - match: { aggregations.@timestamp.buckets.2.key_as_string: 2022-01-01T02:00:00.000Z }
-      - match: { aggregations.@timestamp.buckets.3.key_as_string: 2022-01-01T03:00:00.000Z }
+      - match: { aggregations.@timestamp.buckets.0.key_as_string: "2022-01-01T00:00:00.000Z" }
+      - match: { aggregations.@timestamp.buckets.1.key_as_string: "2022-01-01T01:00:00.000Z" }
+      - match: { aggregations.@timestamp.buckets.2.key_as_string: "2022-01-01T02:00:00.000Z" }
+      - match: { aggregations.@timestamp.buckets.3.key_as_string: "2022-01-01T03:00:00.000Z" }
       - match: { aggregations.@timestamp.buckets.0.v.value: 1 }
       - match: { aggregations.@timestamp.buckets.1.v.value: 2 }
       - match: { aggregations.@timestamp.buckets.2.v.value: 3 }
@@ -117,10 +117,10 @@ parent has gap:
                 d: {serial_diff: {buckets_path: v}}
   - match: { hits.total.value: 3 }
   - length: { aggregations.@timestamp.buckets: 4 }
-  - match: { aggregations.@timestamp.buckets.0.key_as_string: 2022-01-01T00:00:00.000Z }
-  - match: { aggregations.@timestamp.buckets.1.key_as_string: 2022-01-01T01:00:00.000Z }
-  - match: { aggregations.@timestamp.buckets.2.key_as_string: 2022-01-01T02:00:00.000Z }
-  - match: { aggregations.@timestamp.buckets.3.key_as_string: 2022-01-01T03:00:00.000Z }
+  - match: { aggregations.@timestamp.buckets.0.key_as_string: "2022-01-01T00:00:00.000Z" }
+  - match: { aggregations.@timestamp.buckets.1.key_as_string: "2022-01-01T01:00:00.000Z" }
+  - match: { aggregations.@timestamp.buckets.2.key_as_string: "2022-01-01T02:00:00.000Z" }
+  - match: { aggregations.@timestamp.buckets.3.key_as_string: "2022-01-01T03:00:00.000Z" }
   - match: { aggregations.@timestamp.buckets.0.v.value: 1 }
   - match: { aggregations.@timestamp.buckets.1.v.value: 2 }
   - is_false: aggregations.@timestamp.buckets.2.v.value
@@ -163,9 +163,9 @@ parent has min_doc_count:
                 d: {serial_diff: {buckets_path: v}}
   - match: { hits.total.value: 3 }
   - length: { aggregations.@timestamp.buckets: 3 }
-  - match: { aggregations.@timestamp.buckets.0.key_as_string: 2022-01-01T00:00:00.000Z }
-  - match: { aggregations.@timestamp.buckets.1.key_as_string: 2022-01-01T01:00:00.000Z }
-  - match: { aggregations.@timestamp.buckets.2.key_as_string: 2022-01-01T03:00:00.000Z }
+  - match: { aggregations.@timestamp.buckets.0.key_as_string: "2022-01-01T00:00:00.000Z" }
+  - match: { aggregations.@timestamp.buckets.1.key_as_string: "2022-01-01T01:00:00.000Z" }
+  - match: { aggregations.@timestamp.buckets.2.key_as_string: "2022-01-01T03:00:00.000Z" }
   - match: { aggregations.@timestamp.buckets.0.v.value: 1 }
   - match: { aggregations.@timestamp.buckets.1.v.value: 2 }
   - match: { aggregations.@timestamp.buckets.2.v.value: 1 }


### PR DESCRIPTION
The Ruby client's YAML parser parses these values as Dates if they're not wrapped in quoted to be parsed as Strings.
