### PR TITLE
Remove leftover debugging statement on error

### DIFF
--- a/server/src/main/java/org/elasticsearch/bootstrap/Elasticsearch.java
+++ b/server/src/main/java/org/elasticsearch/bootstrap/Elasticsearch.java
@@ -105,7 +105,6 @@ class Elasticsearch {
     }
 
     private static void gracefullyExit(PrintStream err, int exitCode) {
-        err.println("EXITING with non-zero status: " + exitCode);
         printLogsSuggestion(err);
         err.flush();
         exit(exitCode);


### PR DESCRIPTION
A debugging statement was left being printed when ES exits with a
non-zero status. This commit removes the debug statement.

relates #85758