### PR TITLE
Catch an exception due to incorrect pattern in Strings.format

### DIFF
--- a/docs/changelog/87132.yaml
+++ b/docs/changelog/87132.yaml
@@ -1,0 +1,5 @@
+pr: 87132
+summary: Catch an exception when formatting a string fails
+area: Infra/Logging
+type: enhancement
+issues: []

--- a/libs/core/src/main/java/org/elasticsearch/core/Strings.java
+++ b/libs/core/src/main/java/org/elasticsearch/core/Strings.java
@@ -21,8 +21,14 @@ public class Strings {
      *
      * This method calls {@link String#format(Locale, String, Object...)}
      * with Locale.ROOT
+     * If format is incorrect the function will return format without populating
+     * its variable placeholders.
      */
     public static String format(String format, Object... args) {
-        return String.format(Locale.ROOT, format, args);
+        try {
+            return String.format(Locale.ROOT, format, args);
+        } catch (Throwable e) {
+            return format;
+        }
     }
 }

--- a/libs/core/src/main/java/org/elasticsearch/core/Strings.java
+++ b/libs/core/src/main/java/org/elasticsearch/core/Strings.java
@@ -18,7 +18,7 @@ public class Strings {
     /**
      * Returns a formatted string using the specified format string and
      * arguments.
-     *
+     * <p>
      * This method calls {@link String#format(Locale, String, Object...)}
      * with Locale.ROOT
      * If format is incorrect the function will return format without populating
@@ -27,7 +27,8 @@ public class Strings {
     public static String format(String format, Object... args) {
         try {
             return String.format(Locale.ROOT, format, args);
-        } catch (Throwable e) {
+        } catch (Exception e) {
+            assert false : "Exception thrown when formatting [" + format + "]. " + e.getClass().getCanonicalName() + ". " + e.getMessage();
             return format;
         }
     }

--- a/libs/core/src/test/java/org/elasticsearch/core/StringsTests.java
+++ b/libs/core/src/test/java/org/elasticsearch/core/StringsTests.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.core;
+
+import org.elasticsearch.test.ESTestCase;
+
+import static org.hamcrest.Matchers.equalTo;
+
+public class StringsTests extends ESTestCase {
+
+    public void testIncorrectPattern() {
+        AssertionError assertionError = expectThrows(AssertionError.class, () -> Strings.format("%s %s", 1));
+        assertThat(
+            assertionError.getMessage(),
+            equalTo("Exception thrown when formatting [%s %s]. java.util.MissingFormatArgumentException. Format specifier '%s'")
+        );
+    }
+
+}


### PR DESCRIPTION
Strings.format method, which is used heavily in logging with
Supplier<String> should handle exceptions when a format is incorrect.
This will prevent a hard to catch mistakes to blow up in server.
Those mistakes are especially hard to detect in logging when a
code to create a message might be only executed when logger is debug
or trace. Which is not always the case in CI.

relates https://github.com/elastic/elasticsearch/pull/87077#discussion_r881794589

relates #86549

<!--
Thank you for your interest in and contributing to Elasticsearch! There
are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your
attention.
-->

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/elasticsearch/blob/master/CONTRIBUTING.md)?
- If submitting code, have you built your formula locally prior to submission with `gradle check`?
- If submitting code, is your pull request against master? Unless there is a good reason otherwise, we prefer pull requests against master and will backport as needed.
- If submitting code, have you checked that your submission is for an [OS and architecture that we support](https://www.elastic.co/support/matrix#show_os)?
- If you are submitting this code for a class then read our [policy](https://github.com/elastic/elasticsearch/blob/master/CONTRIBUTING.md#contributing-as-part-of-a-class) for that.
