### PR TITLE
Make pidfile deletion more resilient

### DIFF
--- a/qa/evil-tests/src/test/java/org/elasticsearch/bootstrap/EvilSecurityTests.java
+++ b/qa/evil-tests/src/test/java/org/elasticsearch/bootstrap/EvilSecurityTests.java
@@ -45,7 +45,7 @@ public class EvilSecurityTests extends ESTestCase {
         try {
             System.setProperty("java.io.tmpdir", fakeTmpDir.toString());
             Environment environment = TestEnvironment.newEnvironment(settings);
-            permissions = Security.createPermissions(environment);
+            permissions = Security.createPermissions(environment, null);
         } finally {
             System.setProperty("java.io.tmpdir", realTmpDir);
         }
@@ -86,7 +86,7 @@ public class EvilSecurityTests extends ESTestCase {
         try {
             System.setProperty("java.io.tmpdir", fakeTmpDir.toString());
             environment = new Environment(settings, esHome.resolve("conf"));
-            permissions = Security.createPermissions(environment);
+            permissions = Security.createPermissions(environment, null);
         } finally {
             System.setProperty("java.io.tmpdir", realTmpDir);
         }
@@ -143,7 +143,7 @@ public class EvilSecurityTests extends ESTestCase {
             .build();
 
         final Environment environment = TestEnvironment.newEnvironment(settings);
-        final IllegalStateException e = expectThrows(IllegalStateException.class, () -> Security.createPermissions(environment));
+        final IllegalStateException e = expectThrows(IllegalStateException.class, () -> Security.createPermissions(environment, null));
         assertThat(e, hasToString(containsString("path [" + duplicate.toRealPath() + "] is duplicated by [" + duplicate + "]")));
     }
 

--- a/server/src/main/java/org/elasticsearch/bootstrap/Bootstrap.java
+++ b/server/src/main/java/org/elasticsearch/bootstrap/Bootstrap.java
@@ -162,7 +162,7 @@ final class Bootstrap {
         HotThreads.initializeRuntimeMonitoring();
     }
 
-    private void setup(boolean addShutdownHook, Environment environment) throws BootstrapException {
+    private void setup(boolean addShutdownHook, Environment environment, Path pidFile) throws BootstrapException {
         Settings settings = environment.settings();
 
         try {
@@ -222,7 +222,7 @@ final class Bootstrap {
 
         // install SM after natives, shutdown hooks, etc.
         try {
-            Security.configure(environment, BootstrapSettings.SECURITY_FILTER_BAD_DEFAULTS_SETTING.get(settings));
+            Security.configure(environment, BootstrapSettings.SECURITY_FILTER_BAD_DEFAULTS_SETTING.get(settings), pidFile);
         } catch (IOException | NoSuchAlgorithmException e) {
             throw new BootstrapException(e);
         }
@@ -282,8 +282,13 @@ final class Bootstrap {
     /**
      * This method is invoked by {@link Elasticsearch#main(String[])} to startup elasticsearch.
      */
-    static void init(final boolean foreground, final boolean quiet, final Environment initialEnv, SecureString keystorePassword)
-        throws BootstrapException, NodeValidationException, UserException {
+    static void init(
+        final boolean foreground,
+        final boolean quiet,
+        final Environment initialEnv,
+        SecureString keystorePassword,
+        Path pidFile
+    ) throws BootstrapException, NodeValidationException, UserException {
         // force the class initializer for BootstrapInfo to run before
         // the security manager is installed
         BootstrapInfo.init();
@@ -325,7 +330,7 @@ final class Bootstrap {
                 }
             }
 
-            INSTANCE.setup(true, environment);
+            INSTANCE.setup(true, environment, pidFile);
 
             try {
                 // any secure settings must be read during node construction

--- a/server/src/main/java/org/elasticsearch/bootstrap/BootstrapException.java
+++ b/server/src/main/java/org/elasticsearch/bootstrap/BootstrapException.java
@@ -12,9 +12,7 @@ package org.elasticsearch.bootstrap;
  * Wrapper exception for checked exceptions thrown during the bootstrap process. Methods invoked
  * during bootstrap should explicitly declare the checked exceptions that they can throw, rather
  * than declaring the top-level checked exception {@link Exception}. This exception exists to wrap
- * these checked exceptions so that
- * {@link Bootstrap#init(boolean, boolean, org.elasticsearch.env.Environment, org.elasticsearch.common.settings.SecureString)}
- * does not have to declare all of these checked exceptions.
+ * these checked exceptions so that init does not have to declare all of these checked exceptions.
  */
 class BootstrapException extends Exception {
 

--- a/server/src/main/java/org/elasticsearch/bootstrap/Elasticsearch.java
+++ b/server/src/main/java/org/elasticsearch/bootstrap/Elasticsearch.java
@@ -10,6 +10,7 @@ package org.elasticsearch.bootstrap;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.cli.ExitCodes;
 import org.elasticsearch.cli.UserException;
 import org.elasticsearch.common.io.stream.InputStreamStreamInput;
@@ -22,6 +23,7 @@ import org.elasticsearch.node.NodeValidationException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.PrintStream;
+import java.io.UncheckedIOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.security.Permission;
@@ -67,7 +69,8 @@ class Elasticsearch {
                 serverArgs.daemonize(),
                 serverArgs.quiet(),
                 new Environment(serverArgs.nodeSettings(), serverArgs.configDir()),
-                serverArgs.keystorePassword()
+                serverArgs.keystorePassword(),
+                serverArgs.pidFile()
             );
 
             err.println(BootstrapInfo.SERVER_READY_MARKER);
@@ -182,12 +185,10 @@ class Elasticsearch {
             return;
         }
         Runtime.getRuntime().addShutdownHook(new Thread(() -> {
-            if (Files.exists(pidFile)) {
-                try {
-                    Files.delete(pidFile);
-                } catch (IOException e) {
-                    // ignore, nothing we can do because are shutting down
-                }
+            try {
+                Files.deleteIfExists(pidFile);
+            } catch (IOException e) {
+                throw new ElasticsearchException("Failed to delete pid file " + pidFile, e);
             }
         }, "elasticsearch[pidfile-cleanup]"));
 
@@ -212,10 +213,10 @@ class Elasticsearch {
         }
     }
 
-    void init(final boolean daemonize, final boolean quiet, Environment initialEnv, SecureString keystorePassword)
+    void init(final boolean daemonize, final boolean quiet, Environment initialEnv, SecureString keystorePassword, Path pidFile)
         throws NodeValidationException, UserException {
         try {
-            Bootstrap.init(daemonize == false, quiet, initialEnv, keystorePassword);
+            Bootstrap.init(daemonize == false, quiet, initialEnv, keystorePassword, pidFile);
         } catch (BootstrapException | RuntimeException e) {
             // format exceptions to the console in a special way
             // to avoid 2MB stacktraces from guice, etc.

--- a/server/src/main/java/org/elasticsearch/bootstrap/Elasticsearch.java
+++ b/server/src/main/java/org/elasticsearch/bootstrap/Elasticsearch.java
@@ -23,7 +23,6 @@ import org.elasticsearch.node.NodeValidationException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.PrintStream;
-import java.io.UncheckedIOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.security.Permission;

--- a/server/src/main/java/org/elasticsearch/bootstrap/Security.java
+++ b/server/src/main/java/org/elasticsearch/bootstrap/Security.java
@@ -109,14 +109,14 @@ final class Security {
      * @param environment configuration for generating dynamic permissions
      * @param filterBadDefaults true if we should filter out bad java defaults in the system policy.
      */
-    static void configure(Environment environment, boolean filterBadDefaults) throws IOException, NoSuchAlgorithmException {
+    static void configure(Environment environment, boolean filterBadDefaults, Path pidFile) throws IOException, NoSuchAlgorithmException {
 
         // enable security policy: union of template and environment-based paths, and possibly plugin permissions
         Map<String, URL> codebases = PolicyUtil.getCodebaseJarMap(JarHell.parseModulesAndClassPath());
         Policy.setPolicy(
             new ESPolicy(
                 codebases,
-                createPermissions(environment),
+                createPermissions(environment, pidFile),
                 getPluginAndModulePermissions(environment),
                 filterBadDefaults,
                 createRecursiveDataPathPermission(environment)
@@ -166,10 +166,10 @@ final class Security {
     }
 
     /** returns dynamic Permissions to configured paths and bind ports */
-    static Permissions createPermissions(Environment environment) throws IOException {
+    static Permissions createPermissions(Environment environment, Path pidFile) throws IOException {
         Permissions policy = new Permissions();
         addClasspathPermissions(policy);
-        addFilePermissions(policy, environment);
+        addFilePermissions(policy, environment, pidFile);
         addBindPermissions(policy, environment.settings());
         return policy;
     }
@@ -206,7 +206,7 @@ final class Security {
     /**
      * Adds access to all configurable paths.
      */
-    static void addFilePermissions(Permissions policy, Environment environment) throws IOException {
+    static void addFilePermissions(Permissions policy, Environment environment, Path pidFile) throws IOException {
         // read-only dirs
         addDirectoryPath(policy, Environment.PATH_HOME_SETTING.getKey(), environment.binFile(), "read,readlink", false);
         addDirectoryPath(policy, Environment.PATH_HOME_SETTING.getKey(), environment.libFile(), "read,readlink", false);
@@ -244,6 +244,10 @@ final class Security {
         }
         for (Path path : environment.repoFiles()) {
             addDirectoryPath(policy, Environment.PATH_REPO_SETTING.getKey(), path, "read,readlink,write,delete", false);
+        }
+        if (pidFile != null) {
+            // we just need permission to remove the file if its elsewhere.
+            addSingleFilePath(policy, pidFile, "delete");
         }
     }
 


### PR DESCRIPTION
Deleting the pidfile when Elasticsearch is shutting down was moved in #86934.
However, the delete SM permission is still needed, since SM is installed
by the time we shutdown. This commit adds back to the pidfile delete
permission, and also rethrows any io exception so it can be logged by
our uncaught exception handler.