### PR TITLE
[8.3] Remove leftover debugging statement on error (#87128)

### DIFF
--- a/server/src/main/java/org/elasticsearch/bootstrap/Elasticsearch.java
+++ b/server/src/main/java/org/elasticsearch/bootstrap/Elasticsearch.java
@@ -105,7 +105,6 @@ class Elasticsearch {
     }
 
     private static void gracefullyExit(PrintStream err, int exitCode) {
-        err.println("EXITING with non-zero status: " + exitCode);
         printLogsSuggestion(err);
         err.flush();
         exit(exitCode);


### PR DESCRIPTION
Backports the following commits to 8.3:
 - Remove leftover debugging statement on error (#87128)