### PR TITLE
[DOCS] Update docs for v8.2.2 release (#87092)

### DIFF
--- a/docs/reference/release-notes.asciidoc
+++ b/docs/reference/release-notes.asciidoc
@@ -6,6 +6,7 @@
 
 This section summarizes the changes in each release.
 
+* <<release-notes-8.2.2>>
 * <<release-notes-8.2.1>>
 * <<release-notes-8.2.0>>
 * <<release-notes-8.1.3>>
@@ -22,6 +23,7 @@ This section summarizes the changes in each release.
 
 --
 
+include::release-notes/8.2.2.asciidoc[]
 include::release-notes/8.2.1.asciidoc[]
 include::release-notes/8.2.0.asciidoc[]
 include::release-notes/8.1.3.asciidoc[]

--- a/docs/reference/release-notes/8.1.2.asciidoc
+++ b/docs/reference/release-notes/8.1.2.asciidoc
@@ -1,8 +1,6 @@
 [[release-notes-8.1.2]]
 == {es} version 8.1.2
 
-coming[8.1.2]
-
 Also see <<breaking-changes-8.1,Breaking changes in 8.1>>.
 
 [[bug-8.1.2]]

--- a/docs/reference/release-notes/8.1.3.asciidoc
+++ b/docs/reference/release-notes/8.1.3.asciidoc
@@ -1,8 +1,6 @@
 [[release-notes-8.1.3]]
 == {es} version 8.1.3
 
-coming[8.1.3]
-
 Also see <<breaking-changes-8.1,Breaking changes in 8.1>>.
 
 [[bug-8.1.3]]

--- a/docs/reference/release-notes/8.2.0.asciidoc
+++ b/docs/reference/release-notes/8.2.0.asciidoc
@@ -1,8 +1,6 @@
 [[release-notes-8.2.0]]
 == {es} version 8.2.0
 
-coming[8.2.0]
-
 // Also see <<breaking-changes-8.2,Breaking changes in 8.2>>.
 
 [[bug-8.2.0]]

--- a/docs/reference/release-notes/8.2.1.asciidoc
+++ b/docs/reference/release-notes/8.2.1.asciidoc
@@ -1,8 +1,6 @@
 [[release-notes-8.2.1]]
 == {es} version 8.2.1
 
-coming[8.2.1]
-
 Also see <<breaking-changes-8.2,Breaking changes in 8.2>>.
 
 [[bug-8.2.1]]

--- a/docs/reference/release-notes/8.2.2.asciidoc
+++ b/docs/reference/release-notes/8.2.2.asciidoc
@@ -1,0 +1,33 @@
+[[release-notes-8.2.2]]
+== {es} version 8.2.2
+
+coming[8.2.2]
+
+Also see <<breaking-changes-8.2,Breaking changes in 8.2>>.
+
+[[bug-8.2.2]]
+[float]
+=== Bug fixes
+
+Audit::
+* Fix audit logging to consistently include port number in `origin.address` {es-pull}86732[#86732]
+
+CCR::
+* Fix CCR following a datastream with closed indices on the follower corrupting the datastream {es-pull}87076[#87076] (issue: {es-issue}87048[#87048])
+
+Geo::
+* Guard for adding null value tags to vector tiles {es-pull}87051[#87051]
+
+Infra/Core::
+* Adjust osprobe assertion for burst cpu {es-pull}86990[#86990]
+
+Machine Learning::
+* Fix ML task auditor exception early in cluster lifecycle {es-pull}87023[#87023] (issue: {es-issue}87002[#87002])
+* Adjacency weighting fixes in categorization {ml-pull}2277[#2277]
+
+[[enhancement-8.2.2]]
+[float]
+=== Enhancements
+
+Machine Learning::
+* Make ML native processes work with glibc 2.35 (required for Ubuntu 22.04) {ml-pull}2272[#2272]

--- a/docs/reference/release-notes/highlights.asciidoc
+++ b/docs/reference/release-notes/highlights.asciidoc
@@ -11,7 +11,7 @@ endif::[]
 Other versions:
 
 {ref-bare}/8.2/release-highlights.html[8.2]
-{ref-bare}/8.1/release-highlights.html[8.1]
+| {ref-bare}/8.1/release-highlights.html[8.1]
 | {ref-bare}/8.0/release-highlights.html[8.0]
 
 // The notable-highlights tag marks entries that


### PR DESCRIPTION
This PR forward-ports https://github.com/elastic/elasticsearch/pull/87092, omitting the changes that were reverted via https://github.com/elastic/elasticsearch/pull/87135