### PR TITLE
Improve the Health API documentation page with recent additions

### DIFF
--- a/docs/reference/health/health.asciidoc
+++ b/docs/reference/health/health.asciidoc
@@ -93,8 +93,6 @@ is controlled by the worst component status.
     (Optional, Boolean) If `true`, the response includes additional details that help explain the status of each non-green indicator.
     Defaults to `true`.
 
-include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=timeoutparms]
-
 [role="child_attributes"]
 [[health-api-response-body]]
 ==== {api-response-body-title}

--- a/docs/reference/health/health.asciidoc
+++ b/docs/reference/health/health.asciidoc
@@ -61,8 +61,9 @@ is controlled by the worst component status.
 
 `<indicator>`::
     (Optional, string) Limit the information returned for a `component` to
-    a specific indicator. It can be used only if `component` is specified.
-    Supported indicators in each component are:
+    a specific indicator. An indicator can be used only if its corresponding
+    `component` is specified. Supported indicators and their corresponding
+    components are:
 +
 --
   `instance_has_master`::
@@ -92,8 +93,6 @@ is controlled by the worst component status.
     (Optional, Boolean) If `true`, the response includes additional details that help explain the status of each non-green indicator.
     Defaults to `true`.
 
-include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=local]
-
 include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=timeoutparms]
 
 [role="child_attributes"]
@@ -105,7 +104,8 @@ include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=timeoutparms]
 
 `status`::
     (Optional, string) Health status of the cluster, based on the aggregated status of all components
-    in the cluster. Statuses are:
+    in the cluster. If the health of a specific component or indicator is being requested, this top
+    level status will be omitted. Statuses are:
 
     `green`:::
     The cluster is healthy.
@@ -119,9 +119,6 @@ include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=timeoutparms]
 
     `red`:::
     The cluster is experiencing an outage or certain features are unavailable for use.
-
-    If the health of a specific component or indicator is being requested, this top level status
-    will be omitted.
 
 `components`::
     (object) Information about the health of the cluster components.
@@ -137,7 +134,8 @@ include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=timeoutparms]
 =====
 `status`::
     (Optional, string) Health status of the component, based on the aggregated status of all indicators
-    in the component. Statuses are:
+    in the component. If the health of a specific indicator is being requested, this component level status
+    will be omitted. Statuses are:
 
     `green`:::
     The component is healthy.
@@ -151,9 +149,6 @@ include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=timeoutparms]
 
     `red`:::
     The component is experiencing an outage or certain features are unavailable for use.
-
-    If the health of a specific indicator is being requested, the component level status
-    will be omitted.
 
 `indicators`::
     (object) Information about the health of the indicators under a component

--- a/docs/reference/health/health.asciidoc
+++ b/docs/reference/health/health.asciidoc
@@ -13,7 +13,11 @@ NOTE: {cloud-only}
 [[health-api-request]]
 ==== {api-request-title}
 
-`GET /_internal/_health`
+`GET /_internal/_health` +
+
+`GET /_internal/_health/<component>` +
+
+`GET /_internal/_health/<component>/<indicator>` +
 
 [[health-api-prereqs]]
 ==== {api-prereq-title}
@@ -24,16 +28,62 @@ NOTE: {cloud-only}
 [[health-api-desc]]
 ==== {api-description-title}
 
-The health API returns a the health status of an Elasticsearch cluster. It
+The health API returns the health status of an Elasticsearch cluster. It
 returns a list of components that compose Elasticsearch functionality. Each
 component's health is determined by health indicators associated with the
 component.
 
-Each indicator has a health status of: `green`, `yellow` or `red`. The indicator will
+Each indicator has a health status of: `green`, `unknown`, `yellow` or `red`. The indicator will
 provide an explanation and metadata describing the reason for its current health status.
 
 A component's status is controlled by the worst indicator status. The cluster's status
 is controlled by the worst component status.
+
+[[health-api-path-params]]
+==== {api-path-parms-title}
+
+
+`<component>`::
+    (Optional, string) Limits the information returned to the specific component.
+    A comma-separated list of the following options:
++
+--
+  `cluster_coordination`::
+      All health reporting that pertains to successful, stable, and continued membership
+      in a cluster.
+
+  `data`::
+      All health reporting that pertains to data availability, lifecycle, and responsiveness.
+
+  `snapshot`::
+      All health reporting that pertains to data archival, backups, and searchable snapshots.
+--
+
+`<indicator>`::
+    (Optional, string) Limit the information returned for a `component` to
+    a specific indicator. It can be used only if `component` is specified.
+    Supported indicators in each component are:
++
+--
+  `instance_has_master`::
+      (Component `cluster_coordination`) Reports health issues regarding
+      connections to the master node.
+
+  `shards_availability`::
+      (Component `data`) Reports health issues regarding shard assignments.
+
+  `ilm`::
+      (Component `data`) Reports health issues related to
+      Indexing Lifecycle Management.
+
+  `repository_integrity`::
+      (Component `snapshot`) Tracks repository integrity and reports health issues
+      that arise if repositories become corrupted.
+
+  `slm`::
+      (Component `snapshot`) Reports health issues related to
+      Snapshot Lifecycle Management.
+--
 
 [[health-api-query-params]]
 ==== {api-query-parms-title}
@@ -46,6 +96,7 @@ include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=local]
 
 include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=timeoutparms]
 
+[role="child_attributes"]
 [[health-api-response-body]]
 ==== {api-response-body-title}
 
@@ -53,13 +104,148 @@ include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=timeoutparms]
     (string) The name of the cluster.
 
 `status`::
-include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=cluster-health-status]
+    (Optional, string) Health status of the cluster, based on the aggregated status of all components
+    in the cluster. Statuses are:
 
-`impacts`::
-    (list) A list of current health impacts to the cluster.
+    `green`:::
+    The cluster is healthy.
+
+    `unknown`:::
+    The health of the cluster could not be determined.
+
+    `yellow`:::
+    The functionality of a cluster is in a degraded state and may need remediation
+    to avoid the health becoming `red`.
+
+    `red`:::
+    The cluster is experiencing an outage or certain features are unavailable for use.
+
+    If the health of a specific component or indicator is being requested, this top level status
+    will be omitted.
 
 `components`::
     (object) Information about the health of the cluster components.
++
+.Properties of `components`
+[%collapsible%open]
+====
+`<component>`::
+    (object) Contains health results for a component.
++
+.Properties of `<component>`
+[%collapsible%open]
+=====
+`status`::
+    (Optional, string) Health status of the component, based on the aggregated status of all indicators
+    in the component. Statuses are:
+
+    `green`:::
+    The component is healthy.
+
+    `unknown`:::
+    The health of the component could not be determined.
+
+    `yellow`:::
+    The functionality of a component is in a degraded state and may need remediation
+    to avoid the health becoming `red`.
+
+    `red`:::
+    The component is experiencing an outage or certain features are unavailable for use.
+
+    If the health of a specific indicator is being requested, the component level status
+    will be omitted.
+
+`indicators`::
+    (object) Information about the health of the indicators under a component
++
+.Properties of `indicators`
+[%collapsible%open]
+======
+`<indicator>`::
+    (object) Contains health results for an indicator.
++
+.Properties of `<indicator>`
+[%collapsible%open]
+=======
+`status`::
+    (string) Health status of the indicator. Statuses are:
+
+    `green`:::
+    The indicator is healthy.
+
+    `unknown`:::
+    The health of the indicator could not be determined.
+
+    `yellow`:::
+    The functionality of an indicator is in a degraded state and may need remediation
+    to avoid the health becoming `red`.
+
+    `red`:::
+    The indicator is experiencing an outage or certain features are unavailable for use.
+
+`summary`::
+    (string) A message providing information about the current health status.
+
+`help_url`::
+    (Optional, string) A link to additional troubleshooting guides for this indicator.
+
+`details`::
+    (Optional, object) An object that contains additional information about the cluster that
+    has lead to the current health status result. This data is unstructured, and each
+    indicator may return a unique set of details. Details will not be calculated if the
+    `explain` property is set to false.
+
+`impacts`::
+    (Optional, array) If a non-healthy status is returned, indicators may include a list of
+    impacts that this health status will have on the cluster.
++
+.Properties of `impacts`
+[%collapsible%open]
+========
+`severity`::
+    (integer) How important this impact is to the functionality of the cluster. A value of 1
+    is the highest severity, with larger values indicating lower severity.
+
+`description`::
+    (string) A description of the impact on the cluster.
+
+`impact_areas`::
+    (array of strings) The areas of cluster functionality that this impact affects.
+    Possible values are:
++
+--
+    * `search`
+    * `ingest`
+    * `backup`
+    * `deployment_management`
+--
+
+========
+
+`user_actions`::
+    (Optional, array) If a non-healthy status is returned, indicators may include a list of
+    user actions to take in order to remediate the health issue. User actions and root cause
+    analysis will not be calculated if the `explain` property is false.
++
+.Properties of `user_actions`
+[%collapsible%open]
+========
+`message`::
+    (string) A description of a root cause of this health status and the steps that should
+    be taken to remediate the problem.
+
+`affected_resources`::
+    (Optional, array of strings) If the root cause pertains to multiple resources in the
+    cluster (like indices, shards, nodes, etc...) this will hold all resources that this
+    user action is applicable for.
+
+`help_url`::
+    (string) A link to additional troubleshooting information for this user action.
+========
+=======
+======
+=====
+====
 
 [[health-api-example]]
 ==== {api-examples-title}
@@ -69,5 +255,30 @@ include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=cluster-health-status]
 GET _internal/_health
 --------------------------------------------------
 
-The API returns the a response with all the components and indicators regardless
+The API returns a response with all the components and indicators regardless
 of current status.
+
+[source,console]
+--------------------------------------------------
+GET _internal/_health/data
+--------------------------------------------------
+
+The API returns a response with just the data component.
+
+[source,console]
+--------------------------------------------------
+GET _internal/_health/data/shard_availability
+--------------------------------------------------
+
+The API returns a response for just the shard availability indicator
+within the data component.
+
+[source,console]
+--------------------------------------------------
+GET _internal/_health?explain=false
+--------------------------------------------------
+
+The API returns a response with all components and indicators health but will
+not calculate details or root cause analysis for the response. This is helpful
+if you would like to monitor the health API and do not want the overhead of
+calculating additional troubleshooting details each call.

--- a/docs/reference/health/health.asciidoc
+++ b/docs/reference/health/health.asciidoc
@@ -49,8 +49,12 @@ is controlled by the worst component status.
 +
 --
   `cluster_coordination`::
-      All health reporting that pertains to successful, stable, and continued membership
-      in a cluster.
+    All health reporting that pertains to a single, stable elected master which 
+coordinates other nodes to ensure they all have a consistent view of the
+<<cluster-state, cluster state>>.  If your cluster doesn’t have a stable
+master, many of its features won’t work correctly. You must fix the master
+node’s instability before addressing these other issues. It will not be
+possible to solve any other issues while the master node is unstable.
 
   `data`::
       All health reporting that pertains to data availability, lifecycle, and responsiveness.

--- a/docs/reference/health/health.asciidoc
+++ b/docs/reference/health/health.asciidoc
@@ -39,6 +39,17 @@ provide an explanation and metadata describing the reason for its current health
 A component's status is controlled by the worst indicator status. The cluster's status
 is controlled by the worst component status.
 
+In the event that an indicator's status is non-green, a list of impacts may be present in the
+indicator result which detail the parts of a cluster that are negatively affected by the health issue.
+Each impact carries with it a severity level, an area of the cluster that is affected, and a simple
+description of the impact on the system.
+
+Some health indicators can determine the root cause of a health problem and prescribe a set of
+user actions that can be performed in order to improve the health status of an indicator. User
+actions contain a message detailing a root cause analysis, the list of affected resources (if
+applicable) and steps to take that will improve the health of your cluster. User actions can
+also optionally provide URLs to troubleshooting documentation.
+
 [[health-api-path-params]]
 ==== {api-path-parms-title}
 
@@ -49,12 +60,12 @@ is controlled by the worst component status.
 +
 --
   `cluster_coordination`::
-    All health reporting that pertains to a single, stable elected master which 
-coordinates other nodes to ensure they all have a consistent view of the
-<<cluster-state, cluster state>>.  If your cluster doesn’t have a stable
-master, many of its features won’t work correctly. You must fix the master
-node’s instability before addressing these other issues. It will not be
-possible to solve any other issues while the master node is unstable.
+    All health reporting that pertains to a single, stable elected master which
+    coordinates other nodes to ensure they all have a consistent view of the
+    <<cluster-state, cluster state>>.  If your cluster doesn't have a stable
+    master, many of its features won't work correctly. You must fix the master
+    node's instability before addressing these other issues. It will not be
+    possible to solve any other issues while the master node is unstable.
 
   `data`::
       All health reporting that pertains to data availability, lifecycle, and responsiveness.

--- a/docs/reference/health/health.asciidoc
+++ b/docs/reference/health/health.asciidoc
@@ -40,12 +40,12 @@ A component's status is controlled by the worst indicator status. The cluster's 
 is controlled by the worst component status.
 
 In the event that an indicator's status is non-green, a list of impacts may be present in the
-indicator result which detail the parts of a cluster that are negatively affected by the health issue.
-Each impact carries with it a severity level, an area of the cluster that is affected, and a simple
+indicator result which detail the functionalities that are negatively affected by the health issue.
+Each impact carries with it a severity level, an area of the system that is affected, and a simple
 description of the impact on the system.
 
 Some health indicators can determine the root cause of a health problem and prescribe a set of
-user actions that can be performed in order to improve the health status of an indicator. User
+user actions that can be performed in order to improve the health of the system. User
 actions contain a message detailing a root cause analysis, the list of affected resources (if
 applicable) and steps to take that will improve the health of your cluster. User actions can
 also optionally provide URLs to troubleshooting documentation.

--- a/docs/reference/health/health.asciidoc
+++ b/docs/reference/health/health.asciidoc
@@ -267,7 +267,7 @@ The API returns a response with just the data component.
 
 [source,console]
 --------------------------------------------------
-GET _internal/_health/data/shard_availability
+GET _internal/_health/data/shards_availability
 --------------------------------------------------
 
 The API returns a response for just the shard availability indicator

--- a/docs/reference/health/health.asciidoc
+++ b/docs/reference/health/health.asciidoc
@@ -106,7 +106,12 @@ also optionally provide URLs to troubleshooting documentation.
 
 `explain`::
     (Optional, Boolean) If `true`, the response includes additional details that help explain the status of each non-green indicator.
+    These details include additional troubleshooting metrics and sometimes a root cause analysis of a health status.
     Defaults to `true`.
+
+NOTE: Some health indicators perform root cause analysis of non-green health statuses. This can
+be computationally expensive when called frequently. When setting up automated polling of the API
+for health status set `explain` to `false` to disable the more expensive analysis logic.
 
 [role="child_attributes"]
 [[health-api-response-body]]

--- a/docs/reference/health/health.asciidoc
+++ b/docs/reference/health/health.asciidoc
@@ -132,7 +132,7 @@ is controlled by the worst component status.
 =====
 `status`::
     (Optional, string) Health status of the component, based on the aggregated status of all indicators
-    in the component. If the health of a specific indicator is being requested, this component level status
+    in the component. If only the health of a specific indicator is being requested, this component level status
     will be omitted. Statuses are:
 
     `green`:::

--- a/docs/reference/health/health.asciidoc
+++ b/docs/reference/health/health.asciidoc
@@ -133,7 +133,7 @@ is controlled by the worst component status.
 `status`::
     (Optional, string) Health status of the component, based on the aggregated status of all indicators
     in the component. If only the health of a specific indicator is being requested, this component level status
-    will be omitted. Statuses are:
+    will be omitted. The component status is not displayed in this case in order to avoid reporting a false component status given that not all indicators are evaluated. Statuses are:
 
     `green`:::
     The component is healthy.

--- a/docs/reference/rest-api/index.asciidoc
+++ b/docs/reference/rest-api/index.asciidoc
@@ -25,7 +25,6 @@ not be included yet.
 * <<find-structure,Find structure API>>
 * <<fleet-apis,Fleet APIs>>
 * <<graph-explore-api,Graph explore API>>
-* <<health-api,Health API>>
 * <<indices, Index APIs>>
 * <<index-lifecycle-management-api,Index lifecycle management APIs>>
 * <<ingest-apis,Ingest APIs>>
@@ -68,7 +67,6 @@ include::{es-repo-dir}/features/apis/features-apis.asciidoc[]
 include::{es-repo-dir}/fleet/index.asciidoc[]
 include::{es-repo-dir}/text-structure/apis/find-structure.asciidoc[leveloffset=+1]
 include::{es-repo-dir}/graph/explore.asciidoc[]
-include::{es-repo-dir}/health/health.asciidoc[]
 include::{es-repo-dir}/indices.asciidoc[]
 include::{es-repo-dir}/ilm/apis/ilm-api.asciidoc[]
 include::{es-repo-dir}/ingest/apis/index.asciidoc[]

--- a/docs/reference/rest-api/index.asciidoc
+++ b/docs/reference/rest-api/index.asciidoc
@@ -25,6 +25,7 @@ not be included yet.
 * <<find-structure,Find structure API>>
 * <<fleet-apis,Fleet APIs>>
 * <<graph-explore-api,Graph explore API>>
+* <<health-api,Health API>>
 * <<indices, Index APIs>>
 * <<index-lifecycle-management-api,Index lifecycle management APIs>>
 * <<ingest-apis,Ingest APIs>>
@@ -67,6 +68,7 @@ include::{es-repo-dir}/features/apis/features-apis.asciidoc[]
 include::{es-repo-dir}/fleet/index.asciidoc[]
 include::{es-repo-dir}/text-structure/apis/find-structure.asciidoc[leveloffset=+1]
 include::{es-repo-dir}/graph/explore.asciidoc[]
+include::{es-repo-dir}/health/health.asciidoc[]
 include::{es-repo-dir}/indices.asciidoc[]
 include::{es-repo-dir}/ilm/apis/ilm-api.asciidoc[]
 include::{es-repo-dir}/ingest/apis/index.asciidoc[]


### PR DESCRIPTION
This PR overhauls the new health API documentation page, updating it with information on the new request formatting and response features. 

New examples have been added for the different drill down features.

A complete reference of the request and response format has been added. Feedback on writing style here is greatly appreciated.

### Preview
https://elasticsearch_87139.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/health-api.html