### PR TITLE
WIP: accept objects in documents when subobjects are disabled

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/mapper/ContentPath.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/ContentPath.java
@@ -20,6 +20,10 @@ public final class ContentPath {
 
     private String[] path = new String[10];
 
+    private int dottedFieldNamePrefixIndex = 0;
+
+    private String[] dottedFieldNamePrefix = new String[10];
+
     private boolean withinLeafObject = false;
 
     public ContentPath() {
@@ -33,13 +37,11 @@ public final class ContentPath {
     public ContentPath(int offset) {
         this.sb = new StringBuilder();
         this.offset = offset;
-        this.index = 0;
     }
 
     public ContentPath(String path) {
         this.sb = new StringBuilder();
         this.offset = 0;
-        this.index = 0;
         add(path);
     }
 
@@ -54,6 +56,28 @@ public final class ContentPath {
 
     public void remove() {
         path[index--] = null;
+    }
+
+    public void addDottedFieldNamePrefix(String name) {
+        dottedFieldNamePrefix[dottedFieldNamePrefixIndex++] = name;
+        if (dottedFieldNamePrefixIndex == dottedFieldNamePrefix.length) { // expand if needed
+            String[] newPath = new String[dottedFieldNamePrefix.length + 10];
+            System.arraycopy(path, 0, newPath, 0, dottedFieldNamePrefix.length);
+            dottedFieldNamePrefix = newPath;
+        }
+    }
+
+    public void removeDottedFieldNamePrefix() {
+        dottedFieldNamePrefix[dottedFieldNamePrefixIndex--] = null;
+    }
+
+    public String dottedFieldName(String name) {
+        sb.setLength(0);
+        for (int i = 0; i < dottedFieldNamePrefixIndex; i++) {
+            sb.append(dottedFieldNamePrefix[i]).append(DELIMITER);
+        }
+        sb.append(name);
+        return sb.toString();
     }
 
     public void setWithinLeafObject(boolean withinLeafObject) {

--- a/server/src/main/java/org/elasticsearch/index/mapper/DocumentParser.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/DocumentParser.java
@@ -444,7 +444,7 @@ public final class DocumentParser {
         assert currentFieldName != null;
         Mapper objectMapper = getMapper(context, mapper, currentFieldName);
         if (mapper.subobjects() == false) {
-            //TODO here we want to check that the mapper is a field mapper that can handle objects, otherwise pretend we found no mapper
+            // TODO here we want to check that the mapper is a field mapper that can handle objects, otherwise pretend we found no mapper
         }
         if (objectMapper != null) {
             context.path().add(currentFieldName);
@@ -477,7 +477,7 @@ public final class DocumentParser {
                 // with dynamic:runtime all leaf fields will be runtime fields unless explicitly mapped,
                 // hence we don't dynamically create empty objects under properties, but rather carry around an artificial object mapper
                 dynamicObjectMapper = new NoOpObjectMapper(currentFieldName, context.path().pathAsText(currentFieldName));
-            } else if (mapper.subobjects() == false){
+            } else if (mapper.subobjects() == false) {
                 dynamicObjectMapper = mapper;
                 dottedFieldName = true;
             } else {

--- a/server/src/test/java/org/elasticsearch/index/mapper/DocumentParserTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/DocumentParserTests.java
@@ -1981,7 +1981,7 @@ public class DocumentParserTests extends MapperServiceTestCase {
         DocumentMapper mapper = createDocumentMapper(
             mapping(b -> b.startObject("metrics.service").field("type", "object").field("subobjects", false).endObject())
         );
-        //service cannot hold subobjects, yet incoming docs may have objects in it, which are treated as if flat paths were provided
+        // service cannot hold subobjects, yet incoming docs may have objects in it, which are treated as if flat paths were provided
         ParsedDocument parsedDocument = mapper.parse(source("""
             {
               "metrics": {
@@ -2020,7 +2020,7 @@ public class DocumentParserTests extends MapperServiceTestCase {
             }
             b.endObject();
         }));
-        //the root cannot hold subobjects, yet incoming docs may have objects in it, which means that no intermediate objects are mapped
+        // the root cannot hold subobjects, yet incoming docs may have objects in it, which means that no intermediate objects are mapped
         ParsedDocument parsedDocument = mapper.parse(source("""
             {
               "host" : {
@@ -2056,8 +2056,8 @@ public class DocumentParserTests extends MapperServiceTestCase {
             }
             b.endObject();
         }));
-        //the root cannot hold subobjects, yet incoming docs may have objects in it. This verifies that different ways of
-        //specifying the same path in a document are treated in the same way
+        // the root cannot hold subobjects, yet incoming docs may have objects in it. This verifies that different ways of
+        // specifying the same path in a document are treated in the same way
         ParsedDocument parsedDocument = mapper.parse(source("""
             {
               "service.time" : 100,
@@ -2090,42 +2090,40 @@ public class DocumentParserTests extends MapperServiceTestCase {
     }
 
     public void testSubobjectsFalseDocWithInnerObjectsNullValues() throws Exception {
-        //null values are handled separately while parsing hence we want to make sure that the field paths are propagated correctly
-        DocumentMapper mapper = createDocumentMapper(
-            mapping(b -> {
-                b.startObject("metrics");
+        // null values are handled separately while parsing hence we want to make sure that the field paths are propagated correctly
+        DocumentMapper mapper = createDocumentMapper(mapping(b -> {
+            b.startObject("metrics");
+            {
+                b.field("type", "object").field("subobjects", false);
+                b.startObject("properties");
                 {
-                    b.field("type", "object").field("subobjects", false);
-                    b.startObject("properties");
-                    {
-                        b.startObject("service.time");
-                        b.field("type", "long");
-                        b.field("null_value", -1);
-                        b.endObject();
-                    }
-                    {
-                        b.startObject("service.time.max");
-                        b.field("type", "long");
-                        b.field("null_value", -1);
-                        b.endObject();
-                    }
-                    {
-                        b.startObject("service.time.min");
-                        b.field("type", "long");
-                        b.field("null_value", -1);
-                        b.endObject();
-                    }
-                    {
-                        b.startObject("service.time.avg");
-                        b.field("type", "long");
-                        b.field("null_value", -1);
-                        b.endObject();
-                    }
+                    b.startObject("service.time");
+                    b.field("type", "long");
+                    b.field("null_value", -1);
+                    b.endObject();
+                }
+                {
+                    b.startObject("service.time.max");
+                    b.field("type", "long");
+                    b.field("null_value", -1);
+                    b.endObject();
+                }
+                {
+                    b.startObject("service.time.min");
+                    b.field("type", "long");
+                    b.field("null_value", -1);
+                    b.endObject();
+                }
+                {
+                    b.startObject("service.time.avg");
+                    b.field("type", "long");
+                    b.field("null_value", -1);
                     b.endObject();
                 }
                 b.endObject();
-            })
-        );
+            }
+            b.endObject();
+        }));
 
         ParsedDocument parsedDocument = mapper.parse(source("""
             {
@@ -2151,22 +2149,20 @@ public class DocumentParserTests extends MapperServiceTestCase {
 
     @AwaitsFix(bugUrl = "will fix as part of this same PR")
     public void testSubobjectsFalseDocsWithInnerObjectMappedAsNonObject() throws Exception {
-        DocumentMapper mapper = createDocumentMapper(
-            mapping(b -> {
-                b.startObject("metrics");
+        DocumentMapper mapper = createDocumentMapper(mapping(b -> {
+            b.startObject("metrics");
+            {
+                b.field("type", "object").field("subobjects", false);
+                b.startObject("properties");
                 {
-                    b.field("type", "object").field("subobjects", false);
-                    b.startObject("properties");
-                    {
-                        b.startObject("service.time");
-                        b.field("type", "long");
-                        b.endObject();
-                    }
+                    b.startObject("service.time");
+                    b.field("type", "long");
                     b.endObject();
                 }
                 b.endObject();
-            })
-        );
+            }
+            b.endObject();
+        }));
         ParsedDocument parsedDocument = mapper.parse(source("""
             {
               "metrics": {
@@ -2221,7 +2217,7 @@ public class DocumentParserTests extends MapperServiceTestCase {
         assertNotNull(parsedDocument.dynamicMappingsUpdate());
         RootObjectMapper root = parsedDocument.dynamicMappingsUpdate().getRoot();
         assertEquals(1, root.mappers.size());
-        ObjectMapper metrics = (ObjectMapper)root.getMapper("metrics");
+        ObjectMapper metrics = (ObjectMapper) root.getMapper("metrics");
         assertEquals(4, metrics.mappers.size());
         assertNotNull(metrics.getMapper("service.time"));
         assertNotNull(metrics.getMapper("service.time.min"));
@@ -2250,29 +2246,27 @@ public class DocumentParserTests extends MapperServiceTestCase {
         assertNotNull(parsedDocument.dynamicMappingsUpdate());
         RootObjectMapper root = parsedDocument.dynamicMappingsUpdate().getRoot();
         assertEquals(1, root.mappers.size());
-        ObjectMapper metrics = (ObjectMapper)root.getMapper("metrics");
+        ObjectMapper metrics = (ObjectMapper) root.getMapper("metrics");
         assertEquals(2, metrics.mappers.size());
         assertNotNull(metrics.getMapper("service.time"));
         assertNotNull(metrics.getMapper("service.time.max"));
     }
 
     public void testSubobjectsFalseParseGeoPoint() throws Exception {
-        DocumentMapper mapper = createDocumentMapper(
-            mapping(b -> {
-                b.startObject("metrics");
+        DocumentMapper mapper = createDocumentMapper(mapping(b -> {
+            b.startObject("metrics");
+            {
+                b.field("type", "object").field("subobjects", false);
+                b.startObject("properties");
                 {
-                    b.field("type", "object").field("subobjects", false);
-                    b.startObject("properties");
-                    {
-                        b.startObject("location");
-                        b.field("type", "geo_point");
-                        b.endObject();
-                    }
+                    b.startObject("location");
+                    b.field("type", "geo_point");
                     b.endObject();
                 }
                 b.endObject();
-            })
-        );
+            }
+            b.endObject();
+        }));
 
         ParsedDocument parsedDocument = mapper.parse(source("""
             {


### PR DESCRIPTION
An object that has subobjects set to false cannot hold further objects. This is true for the mappings of an index, but it would be great to accept documents holding objects when possible instead of rejecting them. The trick would be to not dynamically map intermediate objects, and only map the leaf fields.