### PR TITLE
Use 'monitor' instead of 'read' permission for resolve index test

### DIFF
--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/security/authz/60_resolve_index.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/security/authz/60_resolve_index.yml
@@ -25,7 +25,7 @@ setup:
         body:  >
           {
             "indices": [
-              { "names": ["matches_none"], "privileges": ["read"] }
+              { "names": ["matches_none"], "privileges": ["monitor"] }
             ]
           }
 


### PR DESCRIPTION
This commit changes no production code, but uses the `monitor` instead of `read` permission for the negative index resolve test (testing that a request is rejected). This is required because we have no way to handle the transform for a test like this in order to merge #87052
