### PR TITLE
Make KeywordFieldMapper more compact

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/mapper/KeywordFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/KeywordFieldMapper.java
@@ -140,19 +140,19 @@ public final class KeywordFieldMapper extends FieldMapper {
         private final Parameter<Boolean> hasDocValues = Parameter.docValuesParam(m -> toType(m).hasDocValues, true);
         private final Parameter<Boolean> stored = Parameter.storeParam(m -> toType(m).fieldType.stored(), false);
 
-        private final Parameter<String> nullValue = Parameter.stringParam("null_value", false, m -> toType(m).nullValue, null)
+        private final Parameter<String> nullValue = Parameter.stringParam("null_value", false, m -> toType(m).fieldType().nullValue, null)
             .acceptsNull();
 
         private final Parameter<Boolean> eagerGlobalOrdinals = Parameter.boolParam(
             "eager_global_ordinals",
             true,
-            m -> toType(m).eagerGlobalOrdinals,
+            m -> toType(m).fieldType().eagerGlobalOrdinals(),
             false
         );
         private final Parameter<Integer> ignoreAbove = Parameter.intParam(
             "ignore_above",
             true,
-            m -> toType(m).ignoreAbove,
+            m -> toType(m).fieldType().ignoreAbove(),
             Defaults.IGNORE_ABOVE
         );
 
@@ -193,7 +193,7 @@ public final class KeywordFieldMapper extends FieldMapper {
             this.script.precludesParameters(nullValue);
             addScriptValidation(script, indexed, hasDocValues);
 
-            this.dimension = TimeSeriesParams.dimensionParam(m -> toType(m).dimension).addValidator(v -> {
+            this.dimension = TimeSeriesParams.dimensionParam(m -> toType(m).fieldType().isDimension()).addValidator(v -> {
                 if (v && (indexed.getValue() == false || hasDocValues.getValue() == false)) {
                     throw new IllegalArgumentException(
                         "Field ["
@@ -862,18 +862,13 @@ public final class KeywordFieldMapper extends FieldMapper {
 
     private final boolean indexed;
     private final boolean hasDocValues;
-    private final String nullValue;
-    private final boolean eagerGlobalOrdinals;
-    private final int ignoreAbove;
     private final String indexOptions;
     private final FieldType fieldType;
     private final SimilarityProvider similarity;
     private final String normalizerName;
     private final boolean splitQueriesOnWhitespace;
     private final Script script;
-    private final FieldValues<String> scriptValues;
     private final ScriptCompiler scriptCompiler;
-    private final boolean dimension;
     private final Version indexCreatedVersion;
 
     private final IndexAnalyzers indexAnalyzers;
@@ -890,19 +885,14 @@ public final class KeywordFieldMapper extends FieldMapper {
         assert fieldType.indexOptions().compareTo(IndexOptions.DOCS_AND_FREQS) <= 0;
         this.indexed = builder.indexed.getValue();
         this.hasDocValues = builder.hasDocValues.getValue();
-        this.nullValue = builder.nullValue.getValue();
-        this.eagerGlobalOrdinals = builder.eagerGlobalOrdinals.getValue();
-        this.ignoreAbove = builder.ignoreAbove.getValue();
         this.indexOptions = builder.indexOptions.getValue();
         this.fieldType = fieldType;
         this.similarity = builder.similarity.getValue();
         this.normalizerName = builder.normalizer.getValue();
         this.splitQueriesOnWhitespace = builder.splitQueriesOnWhitespace.getValue();
         this.script = builder.script.get();
-        this.scriptValues = builder.scriptValues();
         this.indexAnalyzers = builder.indexAnalyzers;
         this.scriptCompiler = builder.scriptCompiler;
-        this.dimension = builder.dimension.getValue();
         this.indexCreatedVersion = builder.indexCreatedVersion;
     }
 
@@ -916,7 +906,7 @@ public final class KeywordFieldMapper extends FieldMapper {
         String value;
         XContentParser parser = context.parser();
         if (parser.currentToken() == XContentParser.Token.VALUE_NULL) {
-            value = nullValue;
+            value = fieldType().nullValue;
         } else {
             value = parser.textOrNull();
         }
@@ -931,7 +921,7 @@ public final class KeywordFieldMapper extends FieldMapper {
         int doc,
         DocumentParserContext documentParserContext
     ) {
-        this.scriptValues.valuesForDoc(searchLookup, readerContext, doc, value -> indexValue(documentParserContext, value));
+        this.fieldType().scriptValues.valuesForDoc(searchLookup, readerContext, doc, value -> indexValue(documentParserContext, value));
     }
 
     private void indexValue(DocumentParserContext context, String value) {
@@ -939,13 +929,13 @@ public final class KeywordFieldMapper extends FieldMapper {
             return;
         }
 
-        if (value.length() > ignoreAbove) {
+        if (value.length() > fieldType().ignoreAbove()) {
             context.addIgnoredField(name());
             return;
         }
 
         value = normalizeValue(fieldType().normalizer(), name(), value);
-        if (dimension) {
+        if (fieldType().isDimension()) {
             context.getDimensions().addString(fieldType().name(), value);
         }
 
@@ -1025,12 +1015,13 @@ public final class KeywordFieldMapper extends FieldMapper {
 
     @Override
     public FieldMapper.Builder getMergeBuilder() {
-        return new Builder(simpleName(), indexAnalyzers, scriptCompiler, indexCreatedVersion).dimension(dimension).init(this);
+        return new Builder(simpleName(), indexAnalyzers, scriptCompiler, indexCreatedVersion).dimension(fieldType().isDimension())
+            .init(this);
     }
 
     @Override
     public void doValidate(MappingLookup lookup) {
-        if (dimension && null != lookup.nestedLookup().getNestedParent(name())) {
+        if (fieldType().isDimension() && null != lookup.nestedLookup().getNestedParent(name())) {
             throw new IllegalArgumentException(
                 TimeSeriesParams.TIME_SERIES_DIMENSION_PARAM + " can't be configured in nested field [" + name() + "]"
             );
@@ -1055,7 +1046,7 @@ public final class KeywordFieldMapper extends FieldMapper {
                 "field [" + name() + "] of type [" + typeName() + "] doesn't support synthetic source because it doesn't have doc values"
             );
         }
-        if (ignoreAbove != Defaults.IGNORE_ABOVE) {
+        if (fieldType().ignoreAbove() != Defaults.IGNORE_ABOVE) {
             throw new IllegalArgumentException(
                 "field [" + name() + "] of type [" + typeName() + "] doesn't support synthetic source because it declares ignore_above"
             );


### PR DESCRIPTION
Removing some redundant fields that we store both on the mapper and the field type 
to make these objects smaller.
This change saves almost 200M on heap per data node in the many-shards
benchmark by saving an estimated 14b-16b (didn't do the alignment math)
per instance.

relates #77466 
