### PR TITLE
Make the bucket_path full path optional if the target multi value aggregation has a single value

### DIFF
--- a/docs/changelog/87117.yaml
+++ b/docs/changelog/87117.yaml
@@ -1,0 +1,5 @@
+pr: 87117
+summary: Make top metrics field name optional when used in bucket script
+area: Aggregations
+type: bug
+issues: []

--- a/docs/changelog/87158.yaml
+++ b/docs/changelog/87158.yaml
@@ -1,0 +1,6 @@
+pr: 87158
+summary: Make the `bucket_path` full path optional if the target multi value aggregation
+  has a single value
+area: Aggregations
+type: bug
+issues: []

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.aggregation/300_pipeline.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.aggregation/300_pipeline.yml
@@ -81,12 +81,14 @@ setup:
 
 ---
 "Max pipeline on percentiles agg without specifying percent":
+  - skip:
+      features: close_to
 
   - do:
-      catch: /buckets_path must reference either a number value or a single value numeric metric aggregation, but \[the_percentiles\] contains multiple values. Please specify which to use\./
       search:
         rest_total_hits_as_int: true
         body:
+          size: 0
           aggs:
             the_terms:
               terms:
@@ -95,9 +97,42 @@ setup:
                 the_percentiles:
                   percentiles:
                     field: "int_field"
-            the_bad_max:
+                    keyed: false
+                    percents: [99]
+            the_max:
               max_bucket:
                 buckets_path: "the_terms>the_percentiles"
+
+  - match: { hits.total: 4 }
+  - length: { aggregations.the_terms.buckets: 4 }
+
+  - match: { aggregations.the_terms.buckets.0.key: 1 }
+  - match: { aggregations.the_terms.buckets.0.doc_count: 1 }
+  - length: { aggregations.the_terms.buckets.0.the_percentiles.values: 1 }
+  - close_to: { aggregations.the_terms.buckets.0.the_percentiles.values.0.key: { value: 99.000000, error: 0.000001 } }
+  - close_to: { aggregations.the_terms.buckets.0.the_percentiles.values.0.value: { value: 1.000000, error: 0.000001 } }
+
+  - match: { aggregations.the_terms.buckets.1.key: 2 }
+  - match: { aggregations.the_terms.buckets.1.doc_count: 1 }
+  - length: { aggregations.the_terms.buckets.1.the_percentiles.values: 1 }
+  - close_to: { aggregations.the_terms.buckets.1.the_percentiles.values.0.key: { value: 99.000000, error: 0.000001 } }
+  - close_to: { aggregations.the_terms.buckets.1.the_percentiles.values.0.value: { value: 2.000000, error: 0.000001 } }
+
+  - match: { aggregations.the_terms.buckets.2.key: 3 }
+  - match: { aggregations.the_terms.buckets.2.doc_count: 1 }
+  - length: { aggregations.the_terms.buckets.2.the_percentiles.values: 1 }
+  - close_to: { aggregations.the_terms.buckets.2.the_percentiles.values.0.key: { value: 99.000000, error: 0.000001 } }
+  - close_to: { aggregations.the_terms.buckets.2.the_percentiles.values.0.value: { value: 3.000000, error: 0.000001 } }
+
+  - match: { aggregations.the_terms.buckets.3.key: 4 }
+  - match: { aggregations.the_terms.buckets.3.doc_count: 1 }
+  - length: { aggregations.the_terms.buckets.3.the_percentiles.values: 1 }
+  - close_to: { aggregations.the_terms.buckets.3.the_percentiles.values.0.key: { value: 99.000000, error: 0.000001 } }
+  - close_to: { aggregations.the_terms.buckets.3.the_percentiles.values.0.value: { value: 4.000000, error: 0.000001 } }
+
+  - close_to: { aggregations.the_max.value: { value: 4.000000, error: 0.000001 } }
+  - length: { aggregations.the_max.keys: 1 }
+  - match: { aggregations.the_max.keys.0: "4" }
 
 ---
 "Top level bucket_sort":

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/InternalTDigestPercentiles.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/InternalTDigestPercentiles.java
@@ -71,7 +71,7 @@ public class InternalTDigestPercentiles extends AbstractInternalTDigestPercentil
                         + name
                         + "] no percentiles available matching key ["
                         + keyName
-                        + "], available metrics ["
+                        + "], available keys ["
                         + String.join(", ", Arrays.stream(keys).mapToObj(String::valueOf).collect(Collectors.joining()))
                         + "]"
                 );

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/InternalTDigestPercentiles.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/InternalTDigestPercentiles.java
@@ -76,7 +76,7 @@ public class InternalTDigestPercentiles extends AbstractInternalTDigestPercentil
                         + "]"
                 );
             }
-            if (!this.iterator().hasNext()) {
+            if (this.iterator().hasNext() == false) {
                 throw new IllegalArgumentException("percentiles [" + name + "] no percentile value available");
             }
             return this.iterator().next().getValue();

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/InternalTDigestPercentiles.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/InternalTDigestPercentiles.java
@@ -79,7 +79,7 @@ public class InternalTDigestPercentiles extends AbstractInternalTDigestPercentil
             if (!this.iterator().hasNext()) {
                 throw new IllegalArgumentException("percentiles [" + name + "] no percentile value available");
             }
-                return this.iterator().next().getValue();
+            return this.iterator().next().getValue();
         }
 
         );

--- a/server/src/main/java/org/elasticsearch/search/aggregations/pipeline/BucketHelpers.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/pipeline/BucketHelpers.java
@@ -8,6 +8,7 @@
 
 package org.elasticsearch.search.aggregations.pipeline;
 
+import org.elasticsearch.Version;
 import org.elasticsearch.common.ParsingException;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -208,7 +209,7 @@ public class BucketHelpers {
                     value = ((Number) propertyValue).doubleValue();
                 } else if (propertyValue instanceof InternalNumericMetricsAggregation.SingleValue) {
                     value = ((InternalNumericMetricsAggregation.SingleValue) propertyValue).value();
-                } else if (propertyValue instanceof NumericMetricsAggregation.MultiValue) {
+                } else if (Version.V_7_0_1.onOrAfter(Version.V_8_4_0) && propertyValue instanceof NumericMetricsAggregation.MultiValue) {
                     final String metricName = aggPathAsList.get(aggPathAsList.size() - 1);
                     value = ((NumericMetricsAggregation.MultiValue) propertyValue).value(metricName);
                 } else {

--- a/server/src/main/java/org/elasticsearch/search/aggregations/pipeline/BucketHelpers.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/pipeline/BucketHelpers.java
@@ -18,7 +18,6 @@ import org.elasticsearch.search.aggregations.InternalMultiBucketAggregation;
 import org.elasticsearch.search.aggregations.InvalidAggregationPathException;
 import org.elasticsearch.search.aggregations.bucket.MultiBucketsAggregation;
 import org.elasticsearch.search.aggregations.metrics.InternalNumericMetricsAggregation;
-import org.elasticsearch.search.aggregations.metrics.NumericMetricsAggregation;
 import org.elasticsearch.search.aggregations.support.AggregationPath;
 import org.elasticsearch.xcontent.ParseField;
 import org.elasticsearch.xcontent.XContentLocation;
@@ -208,9 +207,6 @@ public class BucketHelpers {
                     value = ((Number) propertyValue).doubleValue();
                 } else if (propertyValue instanceof InternalNumericMetricsAggregation.SingleValue) {
                     value = ((InternalNumericMetricsAggregation.SingleValue) propertyValue).value();
-                } else if (propertyValue instanceof NumericMetricsAggregation.MultiValue) {
-                    final String metricName = aggPathAsList.get(aggPathAsList.size() - 1);
-                    value = ((NumericMetricsAggregation.MultiValue) propertyValue).value(metricName);
                 } else {
                     throw formatResolutionError(agg, aggPathAsList, propertyValue);
                 }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/pipeline/BucketHelpers.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/pipeline/BucketHelpers.java
@@ -18,6 +18,7 @@ import org.elasticsearch.search.aggregations.InternalMultiBucketAggregation;
 import org.elasticsearch.search.aggregations.InvalidAggregationPathException;
 import org.elasticsearch.search.aggregations.bucket.MultiBucketsAggregation;
 import org.elasticsearch.search.aggregations.metrics.InternalNumericMetricsAggregation;
+import org.elasticsearch.search.aggregations.metrics.NumericMetricsAggregation;
 import org.elasticsearch.search.aggregations.support.AggregationPath;
 import org.elasticsearch.xcontent.ParseField;
 import org.elasticsearch.xcontent.XContentLocation;
@@ -207,6 +208,9 @@ public class BucketHelpers {
                     value = ((Number) propertyValue).doubleValue();
                 } else if (propertyValue instanceof InternalNumericMetricsAggregation.SingleValue) {
                     value = ((InternalNumericMetricsAggregation.SingleValue) propertyValue).value();
+                } else if (propertyValue instanceof NumericMetricsAggregation.MultiValue) {
+                    final String metricName = aggPathAsList.get(aggPathAsList.size() - 1);
+                    value = ((NumericMetricsAggregation.MultiValue) propertyValue).value(metricName);
                 } else {
                     throw formatResolutionError(agg, aggPathAsList, propertyValue);
                 }

--- a/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/topmetrics/InternalTopMetrics.java
+++ b/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/topmetrics/InternalTopMetrics.java
@@ -245,9 +245,9 @@ public class InternalTopMetrics extends InternalMultiValueAggregation implements
 
     @Override
     public String getValueAsString() {
-        final String metricName = metricNames.stream().findFirst().orElseThrow(
-            () -> new IllegalArgumentException("top_metrics [" + name + "] has no metric field")
-        );
+        final String metricName = metricNames.stream()
+            .findFirst()
+            .orElseThrow(() -> new IllegalArgumentException("top_metrics [" + name + "] has no metric field"));
         return getValuesAsStrings(metricName).get(0);
     }
 

--- a/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/topmetrics/InternalTopMetrics.java
+++ b/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/topmetrics/InternalTopMetrics.java
@@ -34,7 +34,7 @@ import static java.util.Collections.emptyList;
 import static org.elasticsearch.search.builder.SearchSourceBuilder.SORT_FIELD;
 import static org.elasticsearch.xpack.analytics.topmetrics.TopMetricsAggregationBuilder.METRIC_FIELD;
 
-public class InternalTopMetrics extends InternalMultiValueAggregation implements NumericMetricsAggregation.SingleValue {
+public class InternalTopMetrics extends InternalMultiValueAggregation implements NumericMetricsAggregation.MultiValue {
     private final SortOrder sortOrder;
     private final int size;
     private final List<String> metricNames;
@@ -217,6 +217,35 @@ public class InternalTopMetrics extends InternalMultiValueAggregation implements
         return metricNames;
     }
 
+    /**
+     * Return the result of a value by name or the only available value,
+     * if only one metric is present.
+     *
+     * @param metricName
+     * @return
+     */
+    @Override
+    public double value(final String metricName) {
+        return Double.parseDouble(getValuesAsStrings(metricValueByNameOrSingleMetricValue(metricName)).get(0));
+    }
+
+    private String metricValueByNameOrSingleMetricValue(final String metricName) {
+        return metricNames.stream().filter(metricName::equals).findFirst().orElseGet(() -> {
+            if (metricNames.size() != 1) {
+                throw new IllegalArgumentException(
+                    "top_metrics ["
+                        + name
+                        + "] no numeric metric available matching ["
+                        + metricName
+                        + "], available metrics ["
+                        + String.join(", ", metricNames)
+                        + "]"
+                );
+            }
+            return metricNames.get(0);
+        });
+    }
+
     @Override
     protected boolean mustReduceOnSingleInternalAgg() {
         return false;
@@ -236,19 +265,6 @@ public class InternalTopMetrics extends InternalMultiValueAggregation implements
 
     List<TopMetric> getTopMetrics() {
         return topMetrics;
-    }
-
-    @Override
-    public double value() {
-        return Double.parseDouble(getValueAsString());
-    }
-
-    @Override
-    public String getValueAsString() {
-        final String metricName = metricNames.stream()
-            .findFirst()
-            .orElseThrow(() -> new IllegalArgumentException("top_metrics [" + name + "] has no metric field"));
-        return getValuesAsStrings(metricName).get(0);
     }
 
     private class ReduceState {

--- a/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/topmetrics/InternalTopMetrics.java
+++ b/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/topmetrics/InternalTopMetrics.java
@@ -235,9 +235,9 @@ public class InternalTopMetrics extends InternalMultiValueAggregation implements
                 throw new IllegalArgumentException(
                     "top_metrics ["
                         + name
-                        + "] no such numeric metric ["
+                        + "] no numeric metric available matching ["
                         + metricName
-                        + "] or multiple metrics available ["
+                        + "], available metrics ["
                         + String.join(", ", metricNames)
                         + "]"
                 );

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/analytics/bucket_script.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/analytics/bucket_script.yml
@@ -1,0 +1,495 @@
+setup:
+  - skip:
+      version: " - 8.2.0"
+      reason: bug fixed in 8.2.1
+  - do:
+      indices.create:
+        index: test
+        body:
+          settings:
+            number_of_replicas: 0
+          mappings:
+            properties:
+              date:
+                type: date
+                format: "yyyy-MM-dd"
+              size:
+                type: keyword
+              price:
+                type: double
+              discount:
+                type: double
+
+  - do:
+      bulk:
+        index: test
+        refresh: true
+        body:
+          - '{ "index": { } }'
+          - '{ "date": "2020-05-01", "size": "small", "price": "33.90", "discount": 0.13 }'
+          - '{ "index": { } }'
+          - '{ "date": "2020-05-02", "size": "small", "price": "31.90", "discount": 0.14 }'
+          - '{ "index": { } }'
+          - '{ "date": "2020-05-01", "size": "medium", "price": "45.00", "discount": 0.25 }'
+          - '{ "index": { } }'
+          - '{ "date": "2020-05-01", "size": "medium", "price": "35.89", "discount": 0.20 }'
+          - '{ "index": { } }'
+          - '{ "date": "2020-05-02", "size": "small", "price": "33.90", "discount": 0.12 }'
+          - '{ "index": { } }'
+          - '{ "date": "2020-05-01", "size": "small", "price": "29.90", "discount": 0.05 }'
+          - '{ "index": { } }'
+          - '{ "date": "2020-05-02", "size": "medium", "price": "19.89", "discount": 0.12 }'
+          - '{ "index": { } }'
+          - '{ "date": "2020-05-01", "size": "medium", "price": "16.90", "discount": 0.13 }'
+          - '{ "index": { } }'
+          - '{ "date": "2020-05-02", "size": "small", "price": "23.90", "discount": 0.20 }'
+          - '{ "index": { } }'
+          - '{ "date": "2020-05-01", "size": "small", "price": "17.90", "discount": 0.15 }'
+          - '{ "index": { } }'
+          - '{ "date": "2020-05-02", "size": "medium", "price": "14.90", "discount": 0.12 }'
+
+---
+"bucket script sales percentage using greather than separator":
+  - skip:
+      version: " - 8.2.0"
+      reason: bug fixed in 8.2.1
+      features: close_to
+
+  - do:
+      search:
+        index: test
+        body:
+          size: 0
+          aggs:
+            sales_per_month:
+              date_histogram:
+                field: date
+                calendar_interval: month
+              aggs:
+                total_sales:
+                  sum:
+                    field: price
+                small_size:
+                  filter:
+                    term:
+                      size: small
+                  aggs:
+                    sales:
+                      sum:
+                        field: price
+                small_size_percentage:
+                  bucket_script:
+                    buckets_path:
+                      small_size_sales: small_size>sales
+                      total_sales: total_sales
+                    script: "params.small_size_sales / params.total_sales * 100"
+
+
+  - match: { hits.total.value: 11 }
+  - match: { hits.total.relation: "eq" }
+  - length: { aggregations.sales_per_month.buckets: 1 }
+  - match: { aggregations.sales_per_month.buckets.0.doc_count: 11 }
+  - match: { aggregations.sales_per_month.buckets.0.small_size.doc_count: 6 }
+  - close_to: { aggregations.sales_per_month.buckets.0.small_size.sales.value: { value: 171.39, error: 0.01 } }
+  - close_to: { aggregations.sales_per_month.buckets.0.total_sales.value: { value: 303.98, error: 0.01 } }
+  - close_to: { aggregations.sales_per_month.buckets.0.small_size_percentage.value: { value: 56.38, error: 0.01 } }
+
+
+---
+"bucket script sales percentage using dot separator":
+  - skip:
+      version: " - 8.2.0"
+      reason: bug fixed in 8.2.1
+      features: close_to
+
+  - do:
+      search:
+        index: test
+        body:
+          size: 0
+          aggs:
+            sales_per_month:
+              date_histogram:
+                field: date
+                calendar_interval: month
+              aggs:
+                total_sales:
+                  sum:
+                    field: price
+                small_size:
+                  filter:
+                    term:
+                      size: small
+                  aggs:
+                    sales:
+                      sum:
+                        field: price
+                small_size_percentage:
+                  bucket_script:
+                    buckets_path:
+                      small_size_sales: small_size.sales
+                      total_sales: total_sales
+                    script: "params.small_size_sales / params.total_sales * 100"
+
+
+  - match: { hits.total.value: 11 }
+  - match: { hits.total.relation: "eq" }
+  - length: { aggregations.sales_per_month.buckets: 1 }
+  - match: { aggregations.sales_per_month.buckets.0.doc_count: 11 }
+  - match: { aggregations.sales_per_month.buckets.0.small_size.doc_count: 6 }
+  - close_to: { aggregations.sales_per_month.buckets.0.small_size.sales.value: { value: 171.39, error: 0.01 } }
+  - close_to: { aggregations.sales_per_month.buckets.0.total_sales.value: { value: 303.98, error: 0.01 } }
+  - close_to: { aggregations.sales_per_month.buckets.0.small_size_percentage.value: { value: 56.38, error: 0.01 } }
+
+
+---
+"bucket script sales percentage using top_metrics with metric field":
+  - skip:
+      version: " - 8.2.0"
+      reason: bug fixed in 8.2.1
+      features: close_to
+
+  - do:
+      search:
+        index: test
+        body:
+          size: 0
+          aggs:
+            sales_per_month:
+              date_histogram:
+                field: date
+                calendar_interval: month
+              aggs:
+                total_sales:
+                  sum:
+                    field: price
+                small_size:
+                  filter:
+                    term:
+                      size: small
+                  aggs:
+                    sales:
+                      sum:
+                        field: price
+                    best_discount:
+                      top_metrics:
+                        metrics:
+                          field: discount
+                        sort:
+                          discount: desc
+                        size: 1
+                small_size_percentage:
+                  bucket_script:
+                    buckets_path:
+                      small_size_sales: small_size.sales
+                      total_sales: total_sales
+                      # NOTE: we keep this notation valid for backward compatibility, but we make the additional
+                      # `.discount` metric qualifier not required (see next test)
+                      best_discount: small_size>best_discount.discount
+                    script: "(params.small_size_sales - params.small_size_sales * params.best_discount) / params.total_sales * 100"
+
+
+  - match: { hits.total.value: 11 }
+  - match: { hits.total.relation: "eq" }
+  - length: { aggregations.sales_per_month.buckets: 1 }
+  - match: { aggregations.sales_per_month.buckets.0.doc_count: 11 }
+  - match: { aggregations.sales_per_month.buckets.0.small_size.doc_count: 6 }
+  - length: { aggregations.sales_per_month.buckets.0.small_size.best_discount.top: 1 }
+  - close_to: { aggregations.sales_per_month.buckets.0.small_size.best_discount.top.0.sort.0: { value: 0.200, error: 0.001 }}
+  - close_to: { aggregations.sales_per_month.buckets.0.small_size.best_discount.top.0.metrics.discount: { value: 0.200, error: 0.001 }}
+  - close_to: { aggregations.sales_per_month.buckets.0.small_size.sales.value: { value: 171.39, error: 0.01 } }
+  - close_to: { aggregations.sales_per_month.buckets.0.total_sales.value: { value: 303.98, error: 0.01 } }
+  - close_to: { aggregations.sales_per_month.buckets.0.small_size_percentage.value: { value: 45.10, error: 0.01 } }
+
+---
+"bucket script sales percentage using top_metrics without metric field":
+  - skip:
+      version: " - 8.2.0"
+      reason: bug fixed in 8.2.1
+      features: close_to
+
+  - do:
+      search:
+        index: test
+        body:
+          size: 0
+          aggs:
+            sales_per_month:
+              date_histogram:
+                field: date
+                calendar_interval: month
+              aggs:
+                total_sales:
+                  sum:
+                    field: price
+                small_size:
+                  filter:
+                    term:
+                      size: small
+                  aggs:
+                    sales:
+                      sum:
+                        field: price
+                    best_discount:
+                      top_metrics:
+                        metrics:
+                          field: discount
+                        sort:
+                          discount: desc
+                        size: 1
+                small_size_percentage:
+                  bucket_script:
+                    buckets_path:
+                      small_size_sales: small_size.sales
+                      total_sales: total_sales
+                      best_discount: small_size>best_discount
+                    script: "(params.small_size_sales - params.small_size_sales * params.best_discount) / params.total_sales * 100"
+
+
+  - match: { hits.total.value: 11 }
+  - match: { hits.total.relation: "eq" }
+  - length: { aggregations.sales_per_month.buckets: 1 }
+  - match: { aggregations.sales_per_month.buckets.0.doc_count: 11 }
+  - match: { aggregations.sales_per_month.buckets.0.small_size.doc_count: 6 }
+  - length: { aggregations.sales_per_month.buckets.0.small_size.best_discount.top: 1 }
+  - close_to: { aggregations.sales_per_month.buckets.0.small_size.best_discount.top.0.sort.0: { value: 0.200, error: 0.001 }}
+  - close_to: { aggregations.sales_per_month.buckets.0.small_size.best_discount.top.0.metrics.discount: { value: 0.200, error: 0.001 }}
+  - close_to: { aggregations.sales_per_month.buckets.0.small_size.sales.value: { value: 171.39, error: 0.01 } }
+  - close_to: { aggregations.sales_per_month.buckets.0.total_sales.value: { value: 303.98, error: 0.01 } }
+  - close_to: { aggregations.sales_per_month.buckets.0.small_size_percentage.value: { value: 45.10, error: 0.01 } }
+
+---
+"bucket script with invalid top metrics aggregation":
+  - skip:
+      version: " - 8.2.0"
+      reason: bug fixed in 8.2.1
+
+  - do:
+      catch: bad_request
+      search:
+        index: test
+        body:
+          size: 0
+          aggs:
+            sales_per_month:
+              date_histogram:
+                field: date
+                calendar_interval: month
+              aggs:
+                total_sales:
+                  sum:
+                    field: price
+                small_size:
+                  filter:
+                    term:
+                      size: small
+                  aggs:
+                    sales:
+                      sum:
+                        field: price
+                    best_discount:
+                      top_metrics:
+                        metrics:
+                          field: discount
+                        sort:
+                          discount: desc
+                        size: 1
+                small_size_percentage:
+                  bucket_script:
+                    buckets_path:
+                      small_size_sales: small_size.sales
+                      total_sales: total_sales
+                      best_discount: small_size>unknown_metric
+                    script: "(params.small_size_sales - params.small_size_sales * params.best_discount) / params.total_sales * 100"
+
+---
+"bucket script with invalid top metrics aggregation field":
+  - skip:
+      version: " - 8.2.0"
+      reason: bug fixed in 8.2.1
+
+  - do:
+      catch: bad_request
+      search:
+        index: test
+        body:
+          size: 0
+          aggs:
+            sales_per_month:
+              date_histogram:
+                field: date
+                calendar_interval: month
+              aggs:
+                total_sales:
+                  sum:
+                    field: price
+                small_size:
+                  filter:
+                    term:
+                      size: small
+                  aggs:
+                    sales:
+                      sum:
+                        field: price
+                    best_discount:
+                      top_metrics:
+                        metrics:
+                          field: discount
+                        sort:
+                          discount: desc
+                        size: 1
+                small_size_percentage:
+                  bucket_script:
+                    buckets_path:
+                      small_size_sales: small_size.sales
+                      total_sales: total_sales
+                      best_discount: small_size>best_discount>unknown_metric
+                    script: "(params.small_size_sales - params.small_size_sales * params.best_discount) / params.total_sales * 100"
+
+---
+"bucket script with invalid top metrics non-numeric field":
+  - skip:
+      version: " - 8.2.0"
+      reason: bug fixed in 8.2.1
+
+  - do:
+      catch: bad_request
+      search:
+        index: test
+        body:
+          size: 0
+          aggs:
+            sales_per_month:
+              date_histogram:
+                field: date
+                calendar_interval: month
+              aggs:
+                total_sales:
+                  sum:
+                    field: price
+                small_size:
+                  filter:
+                    term:
+                      size: small
+                  aggs:
+                    sales:
+                      sum:
+                        field: price
+                    best_size:
+                      top_metrics:
+                        metrics:
+                          field: size
+                        sort:
+                          discount: desc
+                        size: 1
+                small_size_percentage:
+                  bucket_script:
+                    buckets_path:
+                      small_size_sales: small_size.sales
+                      total_sales: total_sales
+                      best_size: small_size>best_size
+                    script: "(params.small_size_sales - params.small_size_sales * params.best_discount) / params.total_sales * 100"
+
+---
+"bucket script with multiple top metric fields using top metrics name":
+  - skip:
+      version: " - 8.2.0"
+      reason: bug fixed in 8.2.1
+
+  - do:
+      catch: bad_request
+      search:
+        index: test
+        body:
+          size: 0
+          aggs:
+            sales_per_month:
+              date_histogram:
+                field: date
+                calendar_interval: month
+              aggs:
+                total_sales:
+                  sum:
+                    field: price
+                small_size:
+                  filter:
+                    term:
+                      size: small
+                  aggs:
+                    sales:
+                      sum:
+                        field: price
+                    best_size:
+                      top_metrics:
+                        metrics:
+                          - field: size
+                          - field: discount
+                        sort:
+                          discount: desc
+                        size: 1
+                small_size_percentage:
+                  bucket_script:
+                    buckets_path:
+                      small_size_sales: small_size.sales
+                      total_sales: total_sales
+                      best_size: small_size>best_size
+                    script: "(params.small_size_sales - params.small_size_sales * params.best_discount) / params.total_sales * 100"
+
+---
+"bucket script with multiple top metric fields using fully qualified top metrics field":
+  - skip:
+      version: " - 8.2.0"
+      reason: bug fixed in 8.2.1
+      features: close_to
+
+  - do:
+      search:
+        index: test
+        body:
+          size: 0
+          aggs:
+            sales_per_month:
+              date_histogram:
+                field: date
+                calendar_interval: month
+              aggs:
+                total_sales:
+                  sum:
+                    field: price
+                small_size:
+                  filter:
+                    term:
+                      size: small
+                  aggs:
+                    sales:
+                      sum:
+                        field: price
+                    best_discount:
+                      top_metrics:
+                        metrics:
+                          - field: discount
+                          - field: size
+                        sort:
+                          discount: desc
+                        size: 1
+                small_size_percentage:
+                  bucket_script:
+                    buckets_path:
+                      small_size_sales: small_size.sales
+                      total_sales: total_sales
+                      # NOTE: the additional `.discount` qualifier is required since the top metrics includes two metric fields
+                      best_discount: small_size>best_discount.discount
+                    script: "(params.small_size_sales - params.small_size_sales * params.best_discount) / params.total_sales * 100"
+
+
+  - match: { hits.total.value: 11 }
+  - match: { hits.total.relation: "eq" }
+  - length: { aggregations.sales_per_month.buckets: 1 }
+  - match: { aggregations.sales_per_month.buckets.0.doc_count: 11 }
+  - match: { aggregations.sales_per_month.buckets.0.small_size.doc_count: 6 }
+  - length: { aggregations.sales_per_month.buckets.0.small_size.best_discount.top: 1 }
+  - close_to: { aggregations.sales_per_month.buckets.0.small_size.best_discount.top.0.sort.0: { value: 0.200, error: 0.001 }}
+  - close_to: { aggregations.sales_per_month.buckets.0.small_size.best_discount.top.0.metrics.discount: { value: 0.200, error: 0.001 }}
+  - close_to: { aggregations.sales_per_month.buckets.0.small_size.sales.value: { value: 171.39, error: 0.01 } }
+  - close_to: { aggregations.sales_per_month.buckets.0.total_sales.value: { value: 303.98, error: 0.01 } }
+  - close_to: { aggregations.sales_per_month.buckets.0.small_size_percentage.value: { value: 45.10, error: 0.01 } }

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/analytics/bucket_script.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/analytics/bucket_script.yml
@@ -1,7 +1,7 @@
 setup:
   - skip:
-      version: " - 8.2.0"
-      reason: bug fixed in 8.2.1
+      version: " - 8.3.99"
+      reason: bug fixed in 8.4.0
   - do:
       indices.create:
         index: test
@@ -51,8 +51,8 @@ setup:
 ---
 "bucket script sales percentage using greather than separator":
   - skip:
-      version: " - 8.2.0"
-      reason: bug fixed in 8.2.1
+      version: " - 8.3.99"
+      reason: bug fixed in 8.4.0
       features: close_to
 
   - do:
@@ -98,8 +98,8 @@ setup:
 ---
 "bucket script sales percentage using dot separator":
   - skip:
-      version: " - 8.2.0"
-      reason: bug fixed in 8.2.1
+      version: " - 8.3.99"
+      reason: bug fixed in 8.4.0
       features: close_to
 
   - do:
@@ -145,8 +145,8 @@ setup:
 ---
 "bucket script sales percentage using top_metrics with metric field":
   - skip:
-      version: " - 8.2.0"
-      reason: bug fixed in 8.2.1
+      version: " - 8.3.99"
+      reason: bug fixed in 8.4.0
       features: close_to
 
   - do:
@@ -204,8 +204,8 @@ setup:
 ---
 "bucket script sales percentage using top_metrics without metric field":
   - skip:
-      version: " - 8.2.0"
-      reason: bug fixed in 8.2.1
+      version: " - 8.3.99"
+      reason: bug fixed in 8.4.0
       features: close_to
 
   - do:
@@ -261,8 +261,8 @@ setup:
 ---
 "bucket script with invalid top metrics aggregation":
   - skip:
-      version: " - 8.2.0"
-      reason: bug fixed in 8.2.1
+      version: " - 8.3.99"
+      reason: bug fixed in 8.4.0
 
   - do:
       catch: bad_request
@@ -305,8 +305,8 @@ setup:
 ---
 "bucket script with invalid top metrics aggregation field":
   - skip:
-      version: " - 8.2.0"
-      reason: bug fixed in 8.2.1
+      version: " - 8.3.99"
+      reason: bug fixed in 8.4.0
 
   - do:
       catch: bad_request
@@ -349,8 +349,8 @@ setup:
 ---
 "bucket script with invalid top metrics non-numeric field":
   - skip:
-      version: " - 8.2.0"
-      reason: bug fixed in 8.2.1
+      version: " - 8.3.99"
+      reason: bug fixed in 8.4.0
 
   - do:
       catch: bad_request
@@ -393,8 +393,8 @@ setup:
 ---
 "bucket script with multiple top metric fields using top metrics name":
   - skip:
-      version: " - 8.2.0"
-      reason: bug fixed in 8.2.1
+      version: " - 8.3.99"
+      reason: bug fixed in 8.4.0
 
   - do:
       catch: bad_request
@@ -438,8 +438,8 @@ setup:
 ---
 "bucket script with multiple top metric fields using fully qualified top metrics field":
   - skip:
-      version: " - 8.2.0"
-      reason: bug fixed in 8.2.1
+      version: " - 8.3.99"
+      reason: bug fixed in 8.4.0
       features: close_to
 
   - do:

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/analytics/bucket_script.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/analytics/bucket_script.yml
@@ -260,6 +260,63 @@ setup:
   - close_to: { aggregations.sales_per_month.buckets.0.small_size_percentage.value: { value: 45.10, error: 0.01 } }
 
 ---
+"bucket script sales percentage using top_metrics without metric field and size greather than 1":
+  - skip:
+      version: " - 8.3.99"
+      reason: bug fixed in 8.4.0
+      features: close_to
+
+  - do:
+      search:
+        index: test
+        body:
+          size: 0
+          aggs:
+            sales_per_month:
+              date_histogram:
+                field: date
+                calendar_interval: month
+              aggs:
+                total_sales:
+                  sum:
+                    field: price
+                small_size:
+                  filter:
+                    term:
+                      size: small
+                  aggs:
+                    sales:
+                      sum:
+                        field: price
+                    best_discount:
+                      top_metrics:
+                        metrics:
+                          field: discount
+                        sort:
+                          discount: desc
+                        size: 2
+                small_size_percentage:
+                  bucket_script:
+                    buckets_path:
+                      small_size_sales: small_size.sales
+                      total_sales: total_sales
+                      best_discount: small_size>best_discount
+                    script: "(params.small_size_sales - params.small_size_sales * params.best_discount) / params.total_sales * 100"
+
+
+  - match: { hits.total.value: 11 }
+  - match: { hits.total.relation: "eq" }
+  - length: { aggregations.sales_per_month.buckets: 1 }
+  - match: { aggregations.sales_per_month.buckets.0.doc_count: 11 }
+  - match: { aggregations.sales_per_month.buckets.0.small_size.doc_count: 6 }
+  - length: { aggregations.sales_per_month.buckets.0.small_size.best_discount.top: 1 }
+  - close_to: { aggregations.sales_per_month.buckets.0.small_size.best_discount.top.0.sort.0: { value: 0.200, error: 0.001 }}
+  - close_to: { aggregations.sales_per_month.buckets.0.small_size.best_discount.top.0.metrics.discount: { value: 0.200, error: 0.001 }}
+  - close_to: { aggregations.sales_per_month.buckets.0.small_size.sales.value: { value: 171.39, error: 0.01 } }
+  - close_to: { aggregations.sales_per_month.buckets.0.total_sales.value: { value: 303.98, error: 0.01 } }
+  - close_to: { aggregations.sales_per_month.buckets.0.small_size_percentage.value: { value: 45.10, error: 0.01 } }
+
+---
 "bucket script with invalid top metrics aggregation":
   - skip:
       version: " - 8.3.99"

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/analytics/bucket_script.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/analytics/bucket_script.yml
@@ -184,7 +184,8 @@ setup:
                       small_size_sales: small_size.sales
                       total_sales: total_sales
                       # NOTE: we keep this notation valid for backward compatibility, but we make the additional
-                      # `.discount` metric qualifier not required (see next test)
+                      # `.discount` metric qualifier not required (see next test) if top_metrics includes a single
+                      # metric field
                       best_discount: small_size>best_discount.discount
                     script: "(params.small_size_sales - params.small_size_sales * params.best_discount) / params.total_sales * 100"
 


### PR DESCRIPTION
Before this change having `bucket_path` fully qualify the target 
field path in the params section was required.
With this change the field full path becomes optional. If the path points
to a multi value aggregation including more than one metric the field
is still required. If, instead, only one value is available that single value
is used just specifying the multi value aggregation name.

The old notation is still supported for backward compatibility.