### PR TITLE
[8.0] [DOCS] Add missing OIDC defaults (#87165)

### DIFF
--- a/docs/reference/settings/security-settings.asciidoc
+++ b/docs/reference/settings/security-settings.asciidoc
@@ -1756,6 +1756,7 @@ As per `claim_patterns.principal`, but for the _dn_ property.
 (<<static-cluster-setting,Static>>)
 The maximum allowed clock skew to be taken into consideration when validating
 id tokens with regards to their creation and expiration times.
+Defaults to `60s`.
 // end::oidc-allowed-clock-skew-tag[]
 
 // tag::oidc-populate-user-metadata-tag[]
@@ -1817,7 +1818,7 @@ a maximum period inactivity between two consecutive data packets). Defaults to
 (<<static-cluster-setting,Static>>)
 Controls the behavior of the http client used for back-channel communication to
 the OpenID Connect Provider endpoints. Specifies the maximum number of
-connections allowed across all endpoints.
+connections allowed across all endpoints. Defaults to `200`.
 // end::oidc-http-max-connections-tag[]
 
 // tag::oidc-http-max-endpoint-connections-tag[]
@@ -1825,7 +1826,7 @@ connections allowed across all endpoints.
 (<<static-cluster-setting,Static>>)
 Controls the behavior of the http client used for back-channel communication to
 the OpenID Connect Provider endpoints. Specifies the maximum number of
-connections allowed per endpoint.
+connections allowed per endpoint. Defaults to `200`.
 // end::oidc-http-max-endpoint-connections-tag[]
 
 [discrete]


### PR DESCRIPTION
# Backport

This will backport the following commits from `8.1` to `8.0`:
 - [[DOCS] Add missing OIDC defaults (#87165)](https://github.com/elastic/elasticsearch/pull/87165)

<!--- Backport version: 8.4.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)