### PR TITLE
[8.2] Add Resolve Index API to the "read" permission for an index (#87052)

### DIFF
--- a/docs/changelog/87052.yaml
+++ b/docs/changelog/87052.yaml
@@ -1,0 +1,6 @@
+pr: 87052
+summary: Add Resolve Index API to the "read" permission for an index
+area: Indices APIs
+type: bug
+issues:
+ - 86977

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/privilege/IndexPrivilege.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/privilege/IndexPrivilege.java
@@ -68,7 +68,7 @@ public final class IndexPrivilege extends Privilege {
     private static final Logger logger = LogManager.getLogger(IndexPrivilege.class);
 
     private static final Automaton ALL_AUTOMATON = patterns("indices:*", "internal:transport/proxy/indices:*");
-    private static final Automaton READ_AUTOMATON = patterns("indices:data/read/*");
+    private static final Automaton READ_AUTOMATON = patterns("indices:data/read/*", ResolveIndexAction.NAME);
     private static final Automaton READ_CROSS_CLUSTER_AUTOMATON = patterns(
         "internal:transport/proxy/indices:data/read/*",
         ClusterSearchShardsAction.NAME

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/security/authz/60_resolve_index.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/security/authz/60_resolve_index.yml
@@ -25,7 +25,7 @@ setup:
         body:  >
           {
             "indices": [
-              { "names": ["matches_none"], "privileges": ["read"] }
+              { "names": ["matches_none"], "privileges": ["monitor"] }
             ]
           }
 


### PR DESCRIPTION
Backports the following commits to 8.2:
 - Add Resolve Index API to the "read" permission for an index (#87052)