### PR TITLE
[ML] Split node load counts by job type

### DIFF
--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/autoscaling/MlAutoscalingDeciderService.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/autoscaling/MlAutoscalingDeciderService.java
@@ -60,6 +60,7 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.OptionalLong;
 import java.util.PriorityQueue;
+import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.LongSupplier;
 import java.util.stream.Collectors;
@@ -189,6 +190,7 @@ public class MlAutoscalingDeciderService implements AutoscalingDeciderService, L
     static Optional<Tuple<NativeMemoryCapacity, List<NodeLoad>>> determineUnassignableJobs(
         List<String> unassignedJobs,
         Function<String, Long> sizeFunction,
+        Consumer<NodeLoad.Builder> incrementCountFunction,
         int maxNumInQueue,
         List<NodeLoad> nodeLoads
     ) {
@@ -226,10 +228,10 @@ public class MlAutoscalingDeciderService implements AutoscalingDeciderService, L
             if (nodeLoad.getFreeMemory() >= requiredMemory + requiredNativeCodeOverhead) {
                 assignmentIter.remove();
                 // Remove and add to the priority queue to make sure the biggest node with availability is first
+                nodeLoad = mostFreeMemoryFirst.poll();
+                incrementCountFunction.accept(nodeLoad);
                 mostFreeMemoryFirst.add(
-                    mostFreeMemoryFirst.poll()
-                        .incAssignedNativeCodeOverheadMemory(requiredNativeCodeOverhead)
-                        .incNumAssignedJobs()
+                    nodeLoad.incAssignedNativeCodeOverheadMemory(requiredNativeCodeOverhead)
                         .incAssignedAnomalyDetectorMemory(requiredMemory)
                 );
             }
@@ -858,6 +860,7 @@ public class MlAutoscalingDeciderService implements AutoscalingDeciderService, L
             Tuple<NativeMemoryCapacity, List<NodeLoad>> anomalyCapacityAndNewLoad = determineUnassignableJobs(
                 Stream.concat(waitingAnomalyJobs.stream(), waitingSnapshotUpgrades.stream()).toList(),
                 this::getAnomalyMemoryRequirement,
+                NodeLoad.Builder::incNumAssignedAnomalyDetectorJobs,
                 numAnomalyJobsInQueue,
                 nodeLoads
             ).orElse(Tuple.tuple(NativeMemoryCapacity.ZERO, nodeLoads));
@@ -865,6 +868,7 @@ public class MlAutoscalingDeciderService implements AutoscalingDeciderService, L
             Tuple<NativeMemoryCapacity, List<NodeLoad>> analyticsCapacityAndNewLoad = determineUnassignableJobs(
                 waitingAnalyticsJobs,
                 this::getAnalyticsMemoryRequirement,
+                NodeLoad.Builder::incNumAssignedDataFrameAnalyticsJobs,
                 numAnalyticsJobsInQueue,
                 anomalyCapacityAndNewLoad.v2()
             ).orElse(Tuple.tuple(NativeMemoryCapacity.ZERO, anomalyCapacityAndNewLoad.v2()));
@@ -872,6 +876,7 @@ public class MlAutoscalingDeciderService implements AutoscalingDeciderService, L
             Tuple<NativeMemoryCapacity, List<NodeLoad>> modelCapacityAndNewLoad = determineUnassignableJobs(
                 waitingAllocatedModels,
                 this::getAllocatedModelRequirement,
+                NodeLoad.Builder::incNumAssignedNativeInferenceJobs,
                 0,
                 analyticsCapacityAndNewLoad.v2()
             ).orElse(Tuple.tuple(NativeMemoryCapacity.ZERO, analyticsCapacityAndNewLoad.v2()));

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/NodeLoad.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/NodeLoad.java
@@ -25,9 +25,9 @@ public class NodeLoad {
     private final String nodeId;
     private final boolean useMemory;
     private final String error;
-    private int numAssignedAnomalyDetectorJobs;
-    private int numAssignedDataFrameAnalyticsJobs;
-    private int numAssignedNativeInferenceJobs;
+    private final int numAssignedAnomalyDetectorJobs;
+    private final int numAssignedDataFrameAnalyticsJobs;
+    private final int numAssignedNativeInferenceJobs;
     private final long assignedNativeCodeOverheadMemory;
     private final long assignedAnomalyDetectorMemory;
     private final long assignedDataFrameAnalyticsMemory;

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/NodeLoad.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/NodeLoad.java
@@ -25,7 +25,9 @@ public class NodeLoad {
     private final String nodeId;
     private final boolean useMemory;
     private final String error;
-    private final int numAssignedJobs;
+    private int numAssignedAnomalyDetectorJobs;
+    private int numAssignedDataFrameAnalyticsJobs;
+    private int numAssignedNativeInferenceJobs;
     private final long assignedNativeCodeOverheadMemory;
     private final long assignedAnomalyDetectorMemory;
     private final long assignedDataFrameAnalyticsMemory;
@@ -38,7 +40,9 @@ public class NodeLoad {
         String nodeId,
         boolean useMemory,
         String error,
-        int numAssignedJobs,
+        int numAssignedAnomalyDetectorJobs,
+        int numAssignedDataFrameAnalyticsJobs,
+        int numAssignedNativeInferenceJobs,
         long assignedNativeCodeOverheadMemory,
         long assignedAnomalyDetectorMemory,
         long assignedDataFrameAnalyticsMemory,
@@ -50,7 +54,9 @@ public class NodeLoad {
         this.nodeId = nodeId;
         this.useMemory = useMemory;
         this.error = error;
-        this.numAssignedJobs = numAssignedJobs;
+        this.numAssignedAnomalyDetectorJobs = numAssignedAnomalyDetectorJobs;
+        this.numAssignedDataFrameAnalyticsJobs = numAssignedDataFrameAnalyticsJobs;
+        this.numAssignedNativeInferenceJobs = numAssignedNativeInferenceJobs;
         this.assignedNativeCodeOverheadMemory = assignedNativeCodeOverheadMemory;
         this.assignedAnomalyDetectorMemory = assignedAnomalyDetectorMemory;
         this.assignedDataFrameAnalyticsMemory = assignedDataFrameAnalyticsMemory;
@@ -62,7 +68,7 @@ public class NodeLoad {
      * @return The total number of assigned jobs
      */
     public int getNumAssignedJobs() {
-        return numAssignedJobs;
+        return numAssignedAnomalyDetectorJobs + numAssignedDataFrameAnalyticsJobs + numAssignedNativeInferenceJobs;
     }
 
     /**
@@ -160,7 +166,7 @@ public class NodeLoad {
      * @return The number of jobs that can still be assigned to the node
      */
     public int remainingJobs() {
-        return Math.max(maxJobs - numAssignedJobs, 0);
+        return Math.max(maxJobs - getNumAssignedJobs(), 0);
     }
 
     /**
@@ -186,7 +192,9 @@ public class NodeLoad {
         return maxMemory == nodeLoad.maxMemory
             && maxJobs == nodeLoad.maxJobs
             && useMemory == nodeLoad.useMemory
-            && numAssignedJobs == nodeLoad.numAssignedJobs
+            && numAssignedAnomalyDetectorJobs == nodeLoad.numAssignedAnomalyDetectorJobs
+            && numAssignedDataFrameAnalyticsJobs == nodeLoad.numAssignedDataFrameAnalyticsJobs
+            && numAssignedNativeInferenceJobs == nodeLoad.numAssignedNativeInferenceJobs
             && assignedNativeCodeOverheadMemory == nodeLoad.assignedNativeCodeOverheadMemory
             && assignedAnomalyDetectorMemory == nodeLoad.assignedAnomalyDetectorMemory
             && assignedDataFrameAnalyticsMemory == nodeLoad.assignedDataFrameAnalyticsMemory
@@ -204,7 +212,9 @@ public class NodeLoad {
             nodeId,
             useMemory,
             error,
-            numAssignedJobs,
+            numAssignedAnomalyDetectorJobs,
+            numAssignedDataFrameAnalyticsJobs,
+            numAssignedNativeInferenceJobs,
             assignedNativeCodeOverheadMemory,
             assignedAnomalyDetectorMemory,
             assignedDataFrameAnalyticsMemory,
@@ -227,7 +237,9 @@ public class NodeLoad {
         private final String nodeId;
         private boolean useMemory;
         private String error;
-        private int numAssignedJobs;
+        private int numAssignedAnomalyDetectorJobs;
+        private int numAssignedDataFrameAnalyticsJobs;
+        private int numAssignedNativeInferenceJobs;
         private long assignedNativeCodeOverheadMemory;
         private long assignedAnomalyDetectorMemory;
         private long assignedDataFrameAnalyticsMemory;
@@ -240,7 +252,9 @@ public class NodeLoad {
             this.nodeId = nodeLoad.nodeId;
             this.useMemory = nodeLoad.useMemory;
             this.error = nodeLoad.error;
-            this.numAssignedJobs = nodeLoad.numAssignedJobs;
+            this.numAssignedAnomalyDetectorJobs = nodeLoad.numAssignedAnomalyDetectorJobs;
+            this.numAssignedDataFrameAnalyticsJobs = nodeLoad.numAssignedDataFrameAnalyticsJobs;
+            this.numAssignedNativeInferenceJobs = nodeLoad.numAssignedNativeInferenceJobs;
             this.assignedNativeCodeOverheadMemory = nodeLoad.assignedNativeCodeOverheadMemory;
             this.assignedAnomalyDetectorMemory = nodeLoad.assignedAnomalyDetectorMemory;
             this.assignedDataFrameAnalyticsMemory = nodeLoad.assignedDataFrameAnalyticsMemory;
@@ -261,7 +275,7 @@ public class NodeLoad {
         }
 
         public int remainingJobs() {
-            return Math.max(maxJobs - numAssignedJobs, 0);
+            return Math.max(maxJobs - getNumAssignedJobs(), 0);
         }
 
         public String getNodeId() {
@@ -269,7 +283,7 @@ public class NodeLoad {
         }
 
         public int getNumAssignedJobs() {
-            return numAssignedJobs;
+            return numAssignedAnomalyDetectorJobs + numAssignedDataFrameAnalyticsJobs + numAssignedNativeInferenceJobs;
         }
 
         public Builder setMaxMemory(long maxMemory) {
@@ -296,8 +310,18 @@ public class NodeLoad {
             return this;
         }
 
-        public Builder incNumAssignedJobs() {
-            ++this.numAssignedJobs;
+        public Builder incNumAssignedAnomalyDetectorJobs() {
+            ++this.numAssignedAnomalyDetectorJobs;
+            return this;
+        }
+
+        public Builder incNumAssignedDataFrameAnalyticsJobs() {
+            ++this.numAssignedDataFrameAnalyticsJobs;
+            return this;
+        }
+
+        public Builder incNumAssignedNativeInferenceJobs() {
+            ++this.numAssignedNativeInferenceJobs;
             return this;
         }
 
@@ -327,7 +351,14 @@ public class NodeLoad {
         }
 
         void addTask(String taskName, String taskId, boolean isAllocating, MlMemoryTracker memoryTracker) {
-            ++numAssignedJobs;
+            switch (taskName) {
+                case MlTasks.JOB_TASK_NAME, MlTasks.JOB_SNAPSHOT_UPGRADE_TASK_NAME -> incNumAssignedAnomalyDetectorJobs();
+                case MlTasks.DATA_FRAME_ANALYTICS_TASK_NAME -> incNumAssignedDataFrameAnalyticsJobs();
+                default -> {
+                    assert false : "Unexpected task could not be accounted for: " + taskName;
+                }
+            }
+
             if (isAllocating) {
                 ++numAllocatingJobs;
             }
@@ -357,7 +388,9 @@ public class NodeLoad {
                 nodeId,
                 useMemory,
                 error,
-                numAssignedJobs,
+                numAssignedAnomalyDetectorJobs,
+                numAssignedDataFrameAnalyticsJobs,
+                numAssignedNativeInferenceJobs,
                 assignedNativeCodeOverheadMemory,
                 assignedAnomalyDetectorMemory,
                 assignedDataFrameAnalyticsMemory,

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/NodeLoadDetector.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/NodeLoadDetector.java
@@ -137,7 +137,7 @@ public class NodeLoadDetector {
                     .map(RoutingStateAndReason::getState)
                     .orElse(RoutingState.STOPPED)
                     .consumesMemory()) {
-                    nodeLoad.incNumAssignedJobs();
+                    nodeLoad.incNumAssignedNativeInferenceJobs();
                     nodeLoad.incAssignedNativeInferenceMemory(assignment.getTaskParams().estimateMemoryUsageBytes());
                 }
             }

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/autoscaling/MlAutoscalingDeciderServiceTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/autoscaling/MlAutoscalingDeciderServiceTests.java
@@ -187,9 +187,9 @@ public class MlAutoscalingDeciderServiceTests extends ESTestCase {
                     ByteSizeValue.ofMb(200).getBytes() + ByteSizeValue.ofMb(10).getBytes() + ByteSizeValue.ofMb(9).getBytes()
                         + Job.PROCESS_MEMORY_OVERHEAD.getBytes() * 3
                 )
-                .incNumAssignedJobs()
-                .incNumAssignedJobs()
-                .incNumAssignedJobs()
+                .incNumAssignedAnomalyDetectorJobs()
+                .incNumAssignedAnomalyDetectorJobs()
+                .incNumAssignedAnomalyDetectorJobs()
                 .build()
         );
         MlScalingReason.Builder reasonBuilder = new MlScalingReason.Builder().setPassedConfiguration(Settings.EMPTY)
@@ -235,10 +235,10 @@ public class MlAutoscalingDeciderServiceTests extends ESTestCase {
                     ByteSizeValue.ofMb(200).getBytes() + ByteSizeValue.ofMb(10).getBytes() + ByteSizeValue.ofMb(9).getBytes()
                         + ByteSizeValue.ofMb(128).getBytes() + Job.PROCESS_MEMORY_OVERHEAD.getBytes() * 4
                 )
-                .incNumAssignedJobs()
-                .incNumAssignedJobs()
-                .incNumAssignedJobs()
-                .incNumAssignedJobs()
+                .incNumAssignedAnomalyDetectorJobs()
+                .incNumAssignedAnomalyDetectorJobs()
+                .incNumAssignedAnomalyDetectorJobs()
+                .incNumAssignedAnomalyDetectorJobs()
                 .build()
         );
         reasonBuilder = new MlScalingReason.Builder().setPassedConfiguration(Settings.EMPTY)
@@ -287,8 +287,8 @@ public class MlAutoscalingDeciderServiceTests extends ESTestCase {
                 while (forScaleUp.getFreeMemory() > Job.PROCESS_MEMORY_OVERHEAD.getBytes()) {
                     long jobSize = randomLongBetween(Job.PROCESS_MEMORY_OVERHEAD.getBytes(), forScaleUp.getFreeMemory());
                     maxJobSize = Math.max(jobSize, maxJobSize);
-                    forScaleUp.incNumAssignedJobs().incAssignedAnomalyDetectorMemory(jobSize);
-                    forScaleDown.incNumAssignedJobs().incAssignedAnomalyDetectorMemory(jobSize);
+                    forScaleUp.incNumAssignedAnomalyDetectorJobs().incAssignedAnomalyDetectorMemory(jobSize);
+                    forScaleDown.incNumAssignedAnomalyDetectorJobs().incAssignedAnomalyDetectorMemory(jobSize);
                 }
                 // Create jobs for scale up
                 NodeLoad nodeLoadForScaleUp = forScaleUp.build();
@@ -296,7 +296,7 @@ public class MlAutoscalingDeciderServiceTests extends ESTestCase {
                 while (forScaleDown.getFreeMemory() > Job.PROCESS_MEMORY_OVERHEAD.getBytes()) {
                     long jobSize = randomLongBetween(Job.PROCESS_MEMORY_OVERHEAD.getBytes(), forScaleDown.getFreeMemory());
                     maxJobSize = Math.max(jobSize, maxJobSize);
-                    forScaleDown.incNumAssignedJobs().incAssignedAnomalyDetectorMemory(jobSize);
+                    forScaleDown.incNumAssignedAnomalyDetectorJobs().incAssignedAnomalyDetectorMemory(jobSize);
                     String waitingJob = randomAlphaOfLength(10);
                     when(mlMemoryTracker.getAnomalyDetectorJobMemoryRequirement(eq(waitingJob))).thenReturn(jobSize);
                     when(mlMemoryTracker.getJobMemoryRequirement(eq(MlTasks.JOB_TASK_NAME), eq(waitingJob))).thenReturn(jobSize);
@@ -413,7 +413,7 @@ public class MlAutoscalingDeciderServiceTests extends ESTestCase {
                 .setUseMemory(true)
                 .incAssignedNativeCodeOverheadMemory(PER_NODE_OVERHEAD)
                 .incAssignedAnomalyDetectorMemory(anomalyDetectorJobSize.getBytes())
-                .incNumAssignedJobs()
+                .incNumAssignedAnomalyDetectorJobs()
                 .build()
         );
         NativeMemoryCapacity currentScale = new NativeMemoryCapacity(anomalyDetectorJobSize.getBytes(), anomalyDetectorJobSize.getBytes());
@@ -535,7 +535,7 @@ public class MlAutoscalingDeciderServiceTests extends ESTestCase {
                 .setUseMemory(true)
                 .incAssignedNativeCodeOverheadMemory(PER_NODE_OVERHEAD)
                 .incAssignedAnomalyDetectorMemory(ByteSizeValue.ofGb(1).getBytes())
-                .incNumAssignedJobs()
+                .incNumAssignedAnomalyDetectorJobs()
                 .build()
         );
         NativeMemoryCapacity currentScale = new NativeMemoryCapacity(ByteSizeValue.ofGb(1).getBytes(), ByteSizeValue.ofGb(1).getBytes());
@@ -649,7 +649,7 @@ public class MlAutoscalingDeciderServiceTests extends ESTestCase {
                 .setMaxJobs(10)
                 .incAssignedNativeCodeOverheadMemory(PER_NODE_OVERHEAD)
                 .incAssignedAnomalyDetectorMemory(TEST_JOB_SIZE)
-                .incNumAssignedJobs()
+                .incNumAssignedAnomalyDetectorJobs()
                 .build(),
             NodeLoad.builder("not_filled").setMaxMemory(TEST_JOB_SIZE + PER_NODE_OVERHEAD).setMaxJobs(10).setUseMemory(true).build()
         );
@@ -725,7 +725,7 @@ public class MlAutoscalingDeciderServiceTests extends ESTestCase {
                 .setUseMemory(true)
                 .incAssignedNativeCodeOverheadMemory(PER_NODE_OVERHEAD)
                 .incAssignedAnomalyDetectorMemory(ByteSizeValue.ofGb(1).getBytes())
-                .incNumAssignedJobs()
+                .incNumAssignedAnomalyDetectorJobs()
                 .build()
         );
         // Current scale needs to be set to total cluster allowance for ML excluding per-node overhead
@@ -818,7 +818,7 @@ public class MlAutoscalingDeciderServiceTests extends ESTestCase {
                 .setUseMemory(true)
                 .incAssignedNativeCodeOverheadMemory(PER_NODE_OVERHEAD)
                 .incAssignedAnomalyDetectorMemory(TEST_JOB_SIZE)
-                .incNumAssignedJobs()
+                .incNumAssignedAnomalyDetectorJobs()
                 .build()
         );
         // Current scale needs to be set to total cluster allowance for ML excluding per-node overhead
@@ -903,7 +903,7 @@ public class MlAutoscalingDeciderServiceTests extends ESTestCase {
                 .setUseMemory(true)
                 .incAssignedNativeCodeOverheadMemory(PER_NODE_OVERHEAD)
                 .incAssignedAnomalyDetectorMemory(ByteSizeValue.ofGb(1).getBytes() - PER_NODE_OVERHEAD)
-                .incNumAssignedJobs()
+                .incNumAssignedAnomalyDetectorJobs()
                 .build()
         );
         NativeMemoryCapacity currentScale = new NativeMemoryCapacity(
@@ -971,7 +971,7 @@ public class MlAutoscalingDeciderServiceTests extends ESTestCase {
                 .setUseMemory(true)
                 .incAssignedNativeCodeOverheadMemory(PER_NODE_OVERHEAD)
                 .incAssignedAnomalyDetectorMemory(ByteSizeValue.ofGb(1).getBytes())
-                .incNumAssignedJobs()
+                .incNumAssignedAnomalyDetectorJobs()
                 .build()
         );
         NativeMemoryCapacity currentScale = new NativeMemoryCapacity(ByteSizeValue.ofGb(1).getBytes(), ByteSizeValue.ofGb(1).getBytes());
@@ -1021,7 +1021,7 @@ public class MlAutoscalingDeciderServiceTests extends ESTestCase {
                 .setMaxJobs(10)
                 .incAssignedNativeCodeOverheadMemory(PER_NODE_OVERHEAD)
                 .incAssignedAnomalyDetectorMemory(TEST_JOB_SIZE)
-                .incNumAssignedJobs()
+                .incNumAssignedAnomalyDetectorJobs()
                 .build(),
             NodeLoad.builder("not_filled").setMaxMemory(TEST_JOB_SIZE + PER_NODE_OVERHEAD).setMaxJobs(10).setUseMemory(true).build()
         );
@@ -1071,19 +1071,19 @@ public class MlAutoscalingDeciderServiceTests extends ESTestCase {
                     .setMaxMemory(ByteSizeValue.ofGb(5).getBytes())
                     .incAssignedNativeCodeOverheadMemory(PER_NODE_OVERHEAD)
                     .incAssignedAnomalyDetectorMemory(ByteSizeValue.ofGb(1).getBytes() - PER_NODE_OVERHEAD)
-                    .incNumAssignedJobs()
+                    .incNumAssignedAnomalyDetectorJobs()
                     .build(),
                 NodeLoad.builder("bar")
                     .setMaxMemory(ByteSizeValue.ofGb(5).getBytes())
                     .incAssignedNativeCodeOverheadMemory(PER_NODE_OVERHEAD)
                     .incAssignedAnomalyDetectorMemory(ByteSizeValue.ofGb(1).getBytes() - PER_NODE_OVERHEAD)
-                    .incNumAssignedJobs()
+                    .incNumAssignedAnomalyDetectorJobs()
                     .build(),
                 NodeLoad.builder("baz")
                     .setMaxMemory(ByteSizeValue.ofGb(5).getBytes())
                     .incAssignedNativeCodeOverheadMemory(PER_NODE_OVERHEAD)
                     .incAssignedAnomalyDetectorMemory(ByteSizeValue.ofGb(1).getBytes() - PER_NODE_OVERHEAD)
-                    .incNumAssignedJobs()
+                    .incNumAssignedAnomalyDetectorJobs()
                     .build()
             );
             Optional<AutoscalingDeciderResult> result = service.checkForScaleDown(
@@ -1110,19 +1110,19 @@ public class MlAutoscalingDeciderServiceTests extends ESTestCase {
                     .setMaxMemory(ByteSizeValue.ofGb(1).getBytes())
                     .incAssignedNativeCodeOverheadMemory(PER_NODE_OVERHEAD)
                     .incAssignedAnomalyDetectorMemory(ByteSizeValue.ofMb(100).getBytes() - PER_NODE_OVERHEAD)
-                    .incNumAssignedJobs()
+                    .incNumAssignedAnomalyDetectorJobs()
                     .build(),
                 NodeLoad.builder("bar")
                     .setMaxMemory(ByteSizeValue.ofGb(1).getBytes())
                     .incAssignedNativeCodeOverheadMemory(PER_NODE_OVERHEAD)
                     .incAssignedAnomalyDetectorMemory(ByteSizeValue.ofMb(100).getBytes() - PER_NODE_OVERHEAD)
-                    .incNumAssignedJobs()
+                    .incNumAssignedAnomalyDetectorJobs()
                     .build(),
                 NodeLoad.builder("baz")
                     .setMaxMemory(ByteSizeValue.ofGb(1).getBytes())
                     .incAssignedNativeCodeOverheadMemory(PER_NODE_OVERHEAD)
                     .incAssignedAnomalyDetectorMemory(ByteSizeValue.ofMb(100).getBytes() - PER_NODE_OVERHEAD)
-                    .incNumAssignedJobs()
+                    .incNumAssignedAnomalyDetectorJobs()
                     .build()
             );
             Optional<AutoscalingDeciderResult> result = service.checkForScaleDown(
@@ -1152,19 +1152,19 @@ public class MlAutoscalingDeciderServiceTests extends ESTestCase {
                     .setMaxMemory(ByteSizeValue.ofMb(100).getBytes())
                     .incAssignedNativeCodeOverheadMemory(PER_NODE_OVERHEAD)
                     .incAssignedAnomalyDetectorMemory(ByteSizeValue.ofMb(100).getBytes() - PER_NODE_OVERHEAD)
-                    .incNumAssignedJobs()
+                    .incNumAssignedAnomalyDetectorJobs()
                     .build(),
                 NodeLoad.builder("bar")
                     .setMaxMemory(ByteSizeValue.ofMb(100).getBytes())
                     .incAssignedNativeCodeOverheadMemory(PER_NODE_OVERHEAD)
                     .incAssignedAnomalyDetectorMemory(ByteSizeValue.ofMb(100).getBytes() - PER_NODE_OVERHEAD)
-                    .incNumAssignedJobs()
+                    .incNumAssignedAnomalyDetectorJobs()
                     .build(),
                 NodeLoad.builder("baz")
                     .setMaxMemory(ByteSizeValue.ofMb(100).getBytes())
                     .incAssignedNativeCodeOverheadMemory(PER_NODE_OVERHEAD)
                     .incAssignedAnomalyDetectorMemory(ByteSizeValue.ofMb(100).getBytes() - PER_NODE_OVERHEAD)
-                    .incNumAssignedJobs()
+                    .incNumAssignedAnomalyDetectorJobs()
                     .build()
             );
             Optional<AutoscalingDeciderResult> result = service.checkForScaleDown(

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/NodeLoadTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/NodeLoadTests.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.ml.job;
+
+import org.elasticsearch.test.ESTestCase;
+
+import static org.hamcrest.Matchers.equalTo;
+
+public class NodeLoadTests extends ESTestCase {
+
+    public void testIncrementCounts() {
+        NodeLoad nodeLoad = NodeLoad.builder("test-node")
+            .setMaxJobs(10)
+            .incNumAssignedAnomalyDetectorJobs()
+            .incNumAssignedDataFrameAnalyticsJobs()
+            .incNumAssignedDataFrameAnalyticsJobs()
+            .incNumAssignedNativeInferenceJobs()
+            .incNumAssignedNativeInferenceJobs()
+            .incNumAssignedNativeInferenceJobs()
+            .build();
+
+        assertThat(nodeLoad.getNumAssignedJobs(), equalTo(6));
+        assertThat(nodeLoad.remainingJobs(), equalTo(4));
+    }
+}


### PR DESCRIPTION
This refactoring is in preparation to remove native inference jobs
from the jobs that account towards the max open jobs limit.
