### PR TITLE
[8.3] Temporarily provide SystemPropertiesPropertySource (#87149)

### DIFF
--- a/docs/changelog/87149.yaml
+++ b/docs/changelog/87149.yaml
@@ -1,0 +1,5 @@
+pr: 87149
+summary: Temporarily provide `SystemPropertiesPropertySource`
+area: Infra/Logging
+type: bug
+issues: []

--- a/server/src/main/java/module-info.java
+++ b/server/src/main/java/module-info.java
@@ -353,4 +353,5 @@ module org.elasticsearch.server {
         with
             org.elasticsearch.cluster.coordination.NodeToolCliProvider,
             org.elasticsearch.index.shard.ShardToolCliProvider;
+    provides org.apache.logging.log4j.util.PropertySource with org.elasticsearch.common.logging.ESSystemPropertiesPropertySource;
 }

--- a/server/src/main/java/org/elasticsearch/common/logging/ESSystemPropertiesPropertySource.java
+++ b/server/src/main/java/org/elasticsearch/common/logging/ESSystemPropertiesPropertySource.java
@@ -1,0 +1,17 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.common.logging;
+
+import org.apache.logging.log4j.util.SystemPropertiesPropertySource;
+
+// This sucks!, but is resolved in log4J 2.18, as part of https://issues.apache.org/jira/browse/LOG4J2-3427
+public class ESSystemPropertiesPropertySource extends SystemPropertiesPropertySource {
+
+    public ESSystemPropertiesPropertySource() {}
+}


### PR DESCRIPTION
Backports the following commits to 8.3:
 - Temporarily provide SystemPropertiesPropertySource (#87149)