### PR TITLE
[8.3] [DOCS] Remove 8.2.2 coming tags (#87176)

### DIFF
--- a/docs/reference/release-notes/8.2.2.asciidoc
+++ b/docs/reference/release-notes/8.2.2.asciidoc
@@ -1,8 +1,6 @@
 [[release-notes-8.2.2]]
 == {es} version 8.2.2
 
-coming[8.2.2]
-
 Also see <<breaking-changes-8.2,Breaking changes in 8.2>>.
 
 [[bug-8.2.2]]


### PR DESCRIPTION
Backports the following commits to 8.3:
 - [DOCS] Remove 8.2.2 coming tags (#87176)