### PR TITLE
Synthetic source: paranoid tests for configuration

### DIFF
--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/indices.put_mapping/10_basic.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/indices.put_mapping/10_basic.yml
@@ -144,3 +144,93 @@
   - is_false: test_index.mappings.properties.foo.meta.bar
   - match: { test_index.mappings.properties.foo.meta.baz: "quux" }
 
+---
+"disabling synthetic source fails":
+  - skip:
+      version:     " - 8.3.99"
+      reason:      "Added in 8.4.0"
+
+  - do:
+      indices.create:
+        index: test_index
+        body:
+          mappings:
+            _source:
+              synthetic: true
+
+  - do:
+      catch: /Cannot update parameter \[synthetic\] from \[true\] to \[false\]/
+      indices.put_mapping:
+        index: test_index
+        body:
+          _source:
+            synthetic: false
+
+---
+"enabling synthetic source from explicit fails":
+  - skip:
+      version:     " - 8.3.99"
+      reason:      "Added in 8.4.0"
+
+  - do:
+      indices.create:
+        index: test_index
+        body:
+          mappings:
+            _source:
+              synthetic: false
+
+  - do:
+      catch: /Cannot update parameter \[synthetic\] from \[false\] to \[true\]/
+      indices.put_mapping:
+        index: test_index
+        body:
+          _source:
+            synthetic: true
+
+---
+"enabling synthetic source fails":
+  - skip:
+      version:     " - 8.3.99"
+      reason:      "Added in 8.4.0"
+
+  - do:
+      indices.create:
+        index: test_index
+
+  # Index a document to cause the default mapping to be created
+  - do:
+      index:
+        index:   test_index
+        id:      1
+        refresh: true
+        body:
+          kwd: foo
+
+  - do:
+      catch: /Cannot update parameter \[synthetic\] from \[false\] to \[true\]/
+      indices.put_mapping:
+        index: test_index
+        body:
+          _source:
+            synthetic: true
+
+---
+"enabling synthetic source when no mapping succeeds":
+  - skip:
+      version:     " - 8.3.99"
+      reason:      "Added in 8.4.0"
+
+  - do:
+      indices.create:
+        index: test_index
+
+  # At this point there isn't a mapping in the index at all. So we can
+  # put the synthetic source mapping and it won't conflict. It's also safe
+  # because the mapping is entirely empty.
+  - do:
+      indices.put_mapping:
+        index: test_index
+        body:
+          _source:
+            synthetic: true


### PR DESCRIPTION
This adds some paranoid REST layer tests for modifying the `synthetic`
configuration.
