### PR TITLE
Update macOS install steps to use curl instead of wget

### DIFF
--- a/docs/reference/setup/install/targz.asciidoc
+++ b/docs/reference/setup/install/targz.asciidoc
@@ -56,12 +56,13 @@ The MacOS archive for {es} v{version} can be downloaded and installed as follows
 
 ["source","sh",subs="attributes"]
 --------------------------------------------
-wget https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-{version}-darwin-x86_64.tar.gz
-wget https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-{version}-darwin-x86_64.tar.gz.sha512
-shasum -a 512 -c elasticsearch-{version}-darwin-x86_64.tar.gz.sha512 <1>
+curl -O https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-{version}-darwin-x86_64.tar.gz
+curl https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-{version}-darwin-x86_64.tar.gz.sha512 | shasum -a 512 -c - <1>
 tar -xzf elasticsearch-{version}-darwin-x86_64.tar.gz
 cd elasticsearch-{version}/ <2>
 --------------------------------------------
+// NOTCONSOLE
+
 <1> Compares the SHA of the downloaded `.tar.gz` archive and the published checksum, which should output
     `elasticsearch-{version}-darwin-x86_64.tar.gz: OK`.
 <2> This directory is known as `$ES_HOME`.


### PR DESCRIPTION
I don't believe WGET is included automatically on macOS. This updates the Elasticsearch [install instructions for macOS](https://www.elastic.co/guide/en/elasticsearch/reference/current/targz.html#install-macos) to match the [similar instructions for Kibana](https://www.elastic.co/guide/en/kibana/current/targz.html#install-darwin64), which use curl.