### PR TITLE
[Test] Increase timeout.response setting to 10s to avoid test failures

### DIFF
--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/ldap/GroupsResolverTestCase.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/ldap/GroupsResolverTestCase.java
@@ -19,7 +19,6 @@ import org.elasticsearch.env.TestEnvironment;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.core.security.authc.RealmConfig;
 import org.elasticsearch.xpack.core.security.authc.RealmSettings;
-import org.elasticsearch.xpack.core.security.authc.ldap.support.SessionFactorySettings;
 import org.elasticsearch.xpack.security.authc.ldap.support.LdapSession.GroupsResolver;
 import org.junit.After;
 import org.junit.Before;
@@ -40,7 +39,6 @@ public abstract class GroupsResolverTestCase extends ESTestCase {
                 .put(settings)
                 .put("path.home", createTempDir())
                 .put(getFullSettingKey(realmId, RealmSettings.ORDER_SETTING), 0)
-                .put(getFullSettingKey(realmId, SessionFactorySettings.TIMEOUT_RESPONSE_SETTING), "10s")
                 .build();
         }
         return new RealmConfig(realmId, settings, TestEnvironment.newEnvironment(settings), new ThreadContext(Settings.EMPTY));

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/ldap/GroupsResolverTestCase.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/ldap/GroupsResolverTestCase.java
@@ -19,6 +19,7 @@ import org.elasticsearch.env.TestEnvironment;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.core.security.authc.RealmConfig;
 import org.elasticsearch.xpack.core.security.authc.RealmSettings;
+import org.elasticsearch.xpack.core.security.authc.ldap.support.SessionFactorySettings;
 import org.elasticsearch.xpack.security.authc.ldap.support.LdapSession.GroupsResolver;
 import org.junit.After;
 import org.junit.Before;
@@ -39,6 +40,7 @@ public abstract class GroupsResolverTestCase extends ESTestCase {
                 .put(settings)
                 .put("path.home", createTempDir())
                 .put(getFullSettingKey(realmId, RealmSettings.ORDER_SETTING), 0)
+                .put(getFullSettingKey(realmId, SessionFactorySettings.TIMEOUT_RESPONSE_SETTING), "10s")
                 .build();
         }
         return new RealmConfig(realmId, settings, TestEnvironment.newEnvironment(settings), new ThreadContext(Settings.EMPTY));

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/ldap/LdapTestUtils.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/ldap/LdapTestUtils.java
@@ -15,15 +15,20 @@ import org.elasticsearch.common.settings.MockSecureSettings;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.ssl.SslConfiguration;
 import org.elasticsearch.common.ssl.SslVerificationMode;
+import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.env.Environment;
 import org.elasticsearch.env.TestEnvironment;
-import org.elasticsearch.xpack.core.security.authc.ldap.support.SessionFactorySettings;
 import org.elasticsearch.xpack.core.ssl.SSLService;
 import org.elasticsearch.xpack.security.authc.ldap.support.LdapUtils;
 
 import java.nio.file.Path;
 
 public class LdapTestUtils {
+
+    /**
+     * Timeout is set to 10 seconds in order to avoid timeouts of some test cases that use the Samba fixture.
+     */
+    private static final TimeValue DEFAULT_LDAP_TIMEOUT = TimeValue.timeValueSeconds(10);
 
     private LdapTestUtils() {
         // Utility class
@@ -48,8 +53,8 @@ public class LdapTestUtils {
         LDAPConnectionOptions options = new LDAPConnectionOptions();
         options.setFollowReferrals(true);
         options.setAllowConcurrentSocketFactoryUse(true);
-        options.setConnectTimeoutMillis(Math.toIntExact(SessionFactorySettings.TIMEOUT_DEFAULT.millis()));
-        options.setResponseTimeoutMillis(SessionFactorySettings.TIMEOUT_DEFAULT.millis());
+        options.setConnectTimeoutMillis(Math.toIntExact(DEFAULT_LDAP_TIMEOUT.millis()));
+        options.setResponseTimeoutMillis(DEFAULT_LDAP_TIMEOUT.millis());
 
         final SslConfiguration sslConfiguration = sslService.getSSLConfiguration("xpack.security.authc.realms.ldap.foo.ssl");
         return LdapUtils.privilegedConnect(


### PR DESCRIPTION
By default, [LDAP](https://www.elastic.co/guide/en/elasticsearch/reference/8.2/security-settings.html#ref-ldap-settings) and [Active Directory](https://www.elastic.co/guide/en/elasticsearch/reference/8.2/security-settings.html#ref-ad-settings)'s `timeout.response` is set to 5s.
This seems not to be enough when running AD and LDAP integration tests. 
Tests occasionally fail with `LDAPException`:
```
com.unboundid.ldap.sdk.LDAPException: A client-side timeout was encountered while waiting 5005ms for a response
 ```

Closes #86958
