### PR TITLE
[7.17] Adjust assertion for responses without successful shards (#87195)

### DIFF
--- a/server/src/test/java/org/elasticsearch/action/admin/indices/diskusage/TransportAnalyzeIndexDiskUsageActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/indices/diskusage/TransportAnalyzeIndexDiskUsageActionTests.java
@@ -219,7 +219,6 @@ public class TransportAnalyzeIndexDiskUsageActionTests extends ESTestCase {
     /**
      * Make sure that we don't hit StackOverflow if responses are replied on the same thread.
      */
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/85760")
     public void testManyShards() {
         DiscoveryNodes discoNodes = newNodes(10);
         int numberOfShards = randomIntBetween(200, 10000);
@@ -258,7 +257,11 @@ public class TransportAnalyzeIndexDiskUsageActionTests extends ESTestCase {
         AnalyzeIndexDiskUsageResponse resp = future.actionGet();
         assertThat(resp.getTotalShards(), equalTo(numberOfShards));
         assertThat(resp.getSuccessfulShards(), equalTo(successfulShards.size()));
-        assertThat(resp.getStats().get("test_index").getIndexSizeInBytes(), equalTo(totalIndexSize.get()));
+        if (successfulShards.isEmpty()) {
+            assertTrue(resp.getStats().isEmpty());
+        } else {
+            assertThat(resp.getStats().get("test_index").getIndexSizeInBytes(), equalTo(totalIndexSize.get()));
+        }
     }
 
     private static DiscoveryNodes newNodes(int numNodes) {


### PR DESCRIPTION
Backports the following commits to 7.17:
 - Adjust assertion for responses without successful shards (#87195)