### PR TITLE
[TEST] Rename DynamicTemplateTests to DynamicTemplateParseTests

### DIFF
--- a/server/src/test/java/org/elasticsearch/index/mapper/DynamicTemplateParseTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/DynamicTemplateParseTests.java
@@ -25,7 +25,7 @@ import java.util.Map;
 
 import static org.hamcrest.Matchers.equalTo;
 
-public class DynamicTemplateTests extends ESTestCase {
+public class DynamicTemplateParseTests extends ESTestCase {
 
     public void testMappingTypeTypeNotSet() {
         Map<String, Object> templateDef = new HashMap<>();


### PR DESCRIPTION
We have had until today DynamicTemplateTests as well as DynamicTemplatesTests. When adding a new test for dynamic templates, naming does not help understanding what the right place is. This commit addressed this by renaming DynamicTemplateTests to DynamicTemplateParseTests as it holds only tests around the static parse method that parse a dynamic template into its corresponding object.