### PR TITLE
[TEST] Verify that nested type is not supported when subobjects is false 

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/mapper/ObjectMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/ObjectMapper.java
@@ -152,7 +152,7 @@ public class ObjectMapper extends Mapper implements Cloneable {
                     throw new IllegalArgumentException(
                         "Object ["
                             + context.buildFullName(name)
-                            + "] has subobjects set to false hence it does not support inner object or nested ["
+                            + "] has subobjects set to false hence it does not support inner object ["
                             + mapper.simpleName()
                             + "]"
                     );

--- a/server/src/main/java/org/elasticsearch/index/mapper/ObjectMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/ObjectMapper.java
@@ -149,7 +149,7 @@ public class ObjectMapper extends Mapper implements Cloneable {
             for (Mapper.Builder builder : mappersBuilders) {
                 Mapper mapper = builder.build(mapperBuilderContext);
                 if (subobjects.value() == false && mapper instanceof ObjectMapper) {
-                    throw new IllegalStateException(
+                    throw new IllegalArgumentException(
                         "Object ["
                             + context.buildFullName(name)
                             + "] has subobjects set to false hence it does not support inner object or nested ["

--- a/server/src/main/java/org/elasticsearch/index/mapper/ObjectMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/ObjectMapper.java
@@ -151,7 +151,7 @@ public class ObjectMapper extends Mapper implements Cloneable {
                 if (subobjects.value() == false && mapper instanceof ObjectMapper) {
                     // we already check this at parse time (parseProperties) but we need to check again
                     // here as dynamic mapping updates don't go through parsing.
-                    //Nested can only be dynamically mapped through dynamic templates, which are parsed and validated earlier.
+                    // Nested can only be dynamically mapped through dynamic templates, which are parsed and validated earlier.
                     assert mapper instanceof NestedObjectMapper == false;
                     throw new IllegalArgumentException(
                         "Object ["

--- a/server/src/main/java/org/elasticsearch/index/mapper/ObjectMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/ObjectMapper.java
@@ -149,6 +149,8 @@ public class ObjectMapper extends Mapper implements Cloneable {
             for (Mapper.Builder builder : mappersBuilders) {
                 Mapper mapper = builder.build(mapperBuilderContext);
                 if (subobjects.value() == false && mapper instanceof ObjectMapper) {
+                    //we already check this at parse time (parseProperties) but we need to check again
+                    // here as dynamic mapping updates don't go through parsing.
                     throw new IllegalArgumentException(
                         "Object ["
                             + context.buildFullName(name)

--- a/server/src/main/java/org/elasticsearch/index/mapper/ObjectMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/ObjectMapper.java
@@ -280,7 +280,7 @@ public class ObjectMapper extends Mapper implements Cloneable {
                     }
 
                     if (objBuilder.subobjects.value() == false && type.equals(ObjectMapper.CONTENT_TYPE)) {
-                        throw new MapperException(
+                        throw new MapperParsingException(
                             "Object ["
                                 + objBuilder.name()
                                 + "] has subobjects set to false hence it does not support inner object ["
@@ -289,7 +289,7 @@ public class ObjectMapper extends Mapper implements Cloneable {
                         );
                     }
                     if (objBuilder.subobjects.value() == false && type.equals(NestedObjectMapper.CONTENT_TYPE)) {
-                        throw new MapperException(
+                        throw new MapperParsingException(
                             "Object ["
                                 + objBuilder.name()
                                 + "] has subobjects set to false hence it does not support nested object ["

--- a/server/src/main/java/org/elasticsearch/index/mapper/ObjectMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/ObjectMapper.java
@@ -151,6 +151,8 @@ public class ObjectMapper extends Mapper implements Cloneable {
                 if (subobjects.value() == false && mapper instanceof ObjectMapper) {
                     // we already check this at parse time (parseProperties) but we need to check again
                     // here as dynamic mapping updates don't go through parsing.
+                    //Nested can only be dynamically mapped through dynamic templates, which are parsed and validated earlier.
+                    assert mapper instanceof NestedObjectMapper == false;
                     throw new IllegalArgumentException(
                         "Object ["
                             + context.buildFullName(name)

--- a/server/src/main/java/org/elasticsearch/index/mapper/ObjectMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/ObjectMapper.java
@@ -149,7 +149,7 @@ public class ObjectMapper extends Mapper implements Cloneable {
             for (Mapper.Builder builder : mappersBuilders) {
                 Mapper mapper = builder.build(mapperBuilderContext);
                 if (subobjects.value() == false && mapper instanceof ObjectMapper) {
-                    //we already check this at parse time (parseProperties) but we need to check again
+                    // we already check this at parse time (parseProperties) but we need to check again
                     // here as dynamic mapping updates don't go through parsing.
                     throw new IllegalArgumentException(
                         "Object ["

--- a/server/src/main/java/org/elasticsearch/index/mapper/ObjectMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/ObjectMapper.java
@@ -149,10 +149,10 @@ public class ObjectMapper extends Mapper implements Cloneable {
             for (Mapper.Builder builder : mappersBuilders) {
                 Mapper mapper = builder.build(mapperBuilderContext);
                 if (subobjects.value() == false && mapper instanceof ObjectMapper) {
-                    throw new IllegalArgumentException(
+                    throw new IllegalStateException(
                         "Object ["
                             + context.buildFullName(name)
-                            + "] has subobjects set to false hence it does not support inner object ["
+                            + "] has subobjects set to false hence it does not support inner object or nested ["
                             + mapper.simpleName()
                             + "]"
                     );
@@ -284,6 +284,15 @@ public class ObjectMapper extends Mapper implements Cloneable {
                             "Object ["
                                 + objBuilder.name()
                                 + "] has subobjects set to false hence it does not support inner object ["
+                                + fieldName
+                                + "]"
+                        );
+                    }
+                    if (objBuilder.subobjects.value() == false && type.equals(NestedObjectMapper.CONTENT_TYPE)) {
+                        throw new MapperException(
+                            "Object ["
+                                + objBuilder.name()
+                                + "] has subobjects set to false hence it does not support nested object ["
                                 + fieldName
                                 + "]"
                         );

--- a/server/src/test/java/org/elasticsearch/index/mapper/DynamicTemplatesTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/DynamicTemplatesTests.java
@@ -1174,4 +1174,45 @@ public class DynamicTemplatesTests extends MapperServiceTestCase {
         merge(mapperService, dynamicMapping(doc.dynamicMappingsUpdate()));
         assertNoSubobjects(mapperService);
     }
+
+    public void testSubobjectsFalseWithInnerNestedFromDynamicTemplate() throws IOException {
+        MapperParsingException exception = expectThrows(MapperParsingException.class, () -> createMapperService(topMapping(b -> {
+            b.startArray("dynamic_templates");
+            {
+                b.startObject();
+                {
+                    b.startObject("test");
+                    {
+                        b.field("match", "metric");
+                        b.startObject("mapping");
+                        {
+                            b.field("type", "object").field("subobjects", false);
+                            b.startObject("properties");
+                            {
+                                b.startObject("time");
+                                b.field("type", "nested");
+                                b.endObject();
+                            }
+                            b.endObject();
+                        }
+                        b.endObject();
+                    }
+                    b.endObject();
+                }
+                b.endObject();
+            }
+            b.endArray();
+        })));
+        assertEquals(
+            "Failed to parse mapping: dynamic template [test] has invalid content [{\"match\":\"metric\",\"mapping\":"
+                + "{\"properties\":{\"time\":{\"type\":\"nested\"}},\"subobjects\":false,\"type\":\"object\"}}], "
+                + "attempted to validate it with the following match_mapping_type: [object, string, long, double, boolean, date, binary]",
+            exception.getMessage()
+        );
+        assertThat(exception.getRootCause(), instanceOf(MapperException.class));
+        assertEquals(
+            "Object [__dynamic__test] has subobjects set to false hence it does not support nested object [time]",
+            exception.getRootCause().getMessage()
+        );
+    }
 }

--- a/server/src/test/java/org/elasticsearch/index/mapper/DynamicTemplatesTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/DynamicTemplatesTests.java
@@ -1209,7 +1209,7 @@ public class DynamicTemplatesTests extends MapperServiceTestCase {
                 + "attempted to validate it with the following match_mapping_type: [object, string, long, double, boolean, date, binary]",
             exception.getMessage()
         );
-        assertThat(exception.getRootCause(), instanceOf(MapperException.class));
+        assertThat(exception.getRootCause(), instanceOf(MapperParsingException.class));
         assertEquals(
             "Object [__dynamic__test] has subobjects set to false hence it does not support nested object [time]",
             exception.getRootCause().getMessage()

--- a/server/src/test/java/org/elasticsearch/index/mapper/DynamicTemplatesTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/DynamicTemplatesTests.java
@@ -1174,45 +1174,4 @@ public class DynamicTemplatesTests extends MapperServiceTestCase {
         merge(mapperService, dynamicMapping(doc.dynamicMappingsUpdate()));
         assertNoSubobjects(mapperService);
     }
-
-    public void testSubobjectsFalseWithInnerNestedFromDynamicTemplate() throws IOException {
-        MapperParsingException exception = expectThrows(MapperParsingException.class, () -> createMapperService(topMapping(b -> {
-            b.startArray("dynamic_templates");
-            {
-                b.startObject();
-                {
-                    b.startObject("test");
-                    {
-                        b.field("match", "metric");
-                        b.startObject("mapping");
-                        {
-                            b.field("type", "object").field("subobjects", false);
-                            b.startObject("properties");
-                            {
-                                b.startObject("time");
-                                b.field("type", "nested");
-                                b.endObject();
-                            }
-                            b.endObject();
-                        }
-                        b.endObject();
-                    }
-                    b.endObject();
-                }
-                b.endObject();
-            }
-            b.endArray();
-        })));
-        assertEquals(
-            "Failed to parse mapping: dynamic template [test] has invalid content [{\"match\":\"metric\",\"mapping\":"
-                + "{\"properties\":{\"time\":{\"type\":\"nested\"}},\"subobjects\":false,\"type\":\"object\"}}], "
-                + "attempted to validate it with the following match_mapping_type: [object, string, long, double, boolean, date, binary]",
-            exception.getMessage()
-        );
-        assertThat(exception.getRootCause(), instanceOf(MapperParsingException.class));
-        assertEquals(
-            "Object [__dynamic__test] has subobjects set to false hence it does not support nested object [time]",
-            exception.getRootCause().getMessage()
-        );
-    }
 }

--- a/server/src/test/java/org/elasticsearch/index/mapper/ObjectMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/ObjectMapperTests.java
@@ -401,6 +401,27 @@ public class ObjectMapperTests extends MapperServiceTestCase {
         );
     }
 
+    public void testSubobjectsFalseWithInnerNested() {
+        MapperParsingException exception = expectThrows(MapperParsingException.class, () -> createMapperService(mapping(b -> {
+            b.startObject("metrics.service");
+            {
+                b.field("subobjects", false);
+                b.startObject("properties");
+                {
+                    b.startObject("time");
+                    b.field("type", "nested");
+                    b.endObject();
+                }
+                b.endObject();
+            }
+            b.endObject();
+        })));
+        assertEquals(
+            "Failed to parse mapping: Object [service] has subobjects set to false hence it does not support nested object [time]",
+            exception.getMessage()
+        );
+    }
+
     public void testSubobjectsFalseRoot() throws Exception {
         MapperService mapperService = createMapperService(topMapping(b -> {
             b.field("subobjects", false);
@@ -446,6 +467,24 @@ public class ObjectMapperTests extends MapperServiceTestCase {
         assertEquals(
             "Failed to parse mapping: Object [_doc] has subobjects set to false hence it does not support inner object "
                 + "[metrics.service.time]",
+            exception.getMessage()
+        );
+    }
+
+    public void testSubobjectsFalseRootWithInnerNested() {
+        MapperParsingException exception = expectThrows(MapperParsingException.class, () -> createMapperService(topMapping(b -> {
+            b.field("subobjects", false);
+            b.startObject("properties");
+            {
+                b.startObject("metrics.service");
+                b.field("type", "nested");
+                b.endObject();
+            }
+            b.endObject();
+        })));
+        assertEquals(
+            "Failed to parse mapping: Object [_doc] has subobjects set to false hence it does not support nested object "
+                + "[metrics.service]",
             exception.getMessage()
         );
     }


### PR DESCRIPTION
We have tests that verify that objects can't be created in the mapping under an object that has subobjects set to false. The existing checks work also for the nested type, as NestedObjectMapper extends ObjectMapper, yet this commit adds specific tests for this scenario.

This helps clarify that we do need to check this in two places, once at parse time and once in buildMappers, for objects that are dynamically mapped while parsing incoming documents.
