### PR TITLE
Modularize the ingest.common component (as well as dissect and grok dependent libs)

### DIFF
--- a/libs/dissect/src/main/java/module-info.java
+++ b/libs/dissect/src/main/java/module-info.java
@@ -1,0 +1,11 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+module org.elasticsearch.dissect {
+    exports org.elasticsearch.dissect;
+}

--- a/libs/grok/src/main/java/module-info.java
+++ b/libs/grok/src/main/java/module-info.java
@@ -1,0 +1,14 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+module org.elasticsearch.grok {
+    requires org.jruby.jcodings;
+    requires org.jruby.joni;
+
+    exports org.elasticsearch.grok;
+}

--- a/modules/ingest-common/build.gradle
+++ b/modules/ingest-common/build.gradle
@@ -16,7 +16,7 @@ esplugin {
 }
 
 dependencies {
-  compileOnly project(':modules:lang-painless')
+  compileOnly project(':modules:lang-painless:spi')
   api project(':libs:elasticsearch-grok')
   api project(':libs:elasticsearch-dissect')
   implementation "org.apache.httpcomponents:httpclient:${versions.httpclient}"

--- a/modules/ingest-common/src/main/java/module-info.java
+++ b/modules/ingest-common/src/main/java/module-info.java
@@ -19,7 +19,7 @@ module org.elasticsearch.ingest.common {
     requires org.apache.lucene.analysis.common;
 
     exports org.elasticsearch.ingest.common; // for painless
-    
+
     opens org.elasticsearch.ingest.common to org.elasticsearch.painless.spi; // whitelist resource access
 
     provides org.elasticsearch.painless.spi.PainlessExtension with org.elasticsearch.ingest.common.ProcessorsWhitelistExtension;

--- a/modules/ingest-common/src/main/java/module-info.java
+++ b/modules/ingest-common/src/main/java/module-info.java
@@ -18,5 +18,9 @@ module org.elasticsearch.ingest.common {
     requires org.apache.logging.log4j;
     requires org.apache.lucene.analysis.common;
 
+    exports org.elasticsearch.ingest.common; // for painless
+    
+    opens org.elasticsearch.ingest.common to org.elasticsearch.painless.spi; // whitelist resource access
+
     provides org.elasticsearch.painless.spi.PainlessExtension with org.elasticsearch.ingest.common.ProcessorsWhitelistExtension;
 }

--- a/modules/ingest-common/src/main/java/module-info.java
+++ b/modules/ingest-common/src/main/java/module-info.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+module org.elasticsearch.ingest.common {
+    requires org.elasticsearch.base;
+    requires org.elasticsearch.dissect;
+    requires org.elasticsearch.grok;
+    requires org.elasticsearch.painless.spi;
+    requires org.elasticsearch.server;
+    requires org.elasticsearch.xcontent;
+
+    requires org.apache.httpcomponents.httpclient;
+    requires org.apache.logging.log4j;
+    requires org.apache.lucene.analysis.common;
+
+    provides org.elasticsearch.painless.spi.PainlessExtension with org.elasticsearch.ingest.common.ProcessorsWhitelistExtension;
+}


### PR DESCRIPTION
This is change modularizes the ingest.common component, by adding a module-info.java. As well as two dependent libs.

The project only requires painless SPI to compile, so that was fixed along the way ( so that the compile module path can be inferred directly from the dependencies ).

relates #78744