### PR TITLE
Delete index commits last in CombinedDeletionPolicy

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/engine/CombinedDeletionPolicy.java
+++ b/server/src/main/java/org/elasticsearch/index/engine/CombinedDeletionPolicy.java
@@ -76,38 +76,40 @@ public class CombinedDeletionPolicy extends IndexDeletionPolicy {
 
     @Override
     public void onCommit(List<? extends IndexCommit> commits) throws IOException {
-        final IndexCommit safeCommit;
+        assert Thread.holdsLock(this) == false : "should not block concurrent acquire or release";
+        final int keptPosition = indexOfKeptCommits(commits, globalCheckpointSupplier.getAsLong());
+        final IndexCommit safeCommit = commits.get(keptPosition);
+        final SafeCommitInfo safeCommitInfo = new SafeCommitInfo(
+            Long.parseLong(safeCommit.getUserData().get(SequenceNumbers.LOCAL_CHECKPOINT_KEY)),
+            getDocCountOfCommit(safeCommit)
+        );
         synchronized (this) {
-            final int keptPosition = indexOfKeptCommits(commits, globalCheckpointSupplier.getAsLong());
-            this.safeCommitInfo = SafeCommitInfo.EMPTY;
+            this.safeCommitInfo = safeCommitInfo;
             this.lastCommit = commits.get(commits.size() - 1);
-            this.safeCommit = commits.get(keptPosition);
-            for (int i = 0; i < keptPosition; i++) {
-                if (snapshottedCommits.containsKey(commits.get(i)) == false) {
-                    deleteCommit(commits.get(i));
-                }
-            }
+            this.safeCommit = safeCommit;
             updateRetentionPolicy();
             if (keptPosition == commits.size() - 1) {
                 this.maxSeqNoOfNextSafeCommit = Long.MAX_VALUE;
             } else {
                 this.maxSeqNoOfNextSafeCommit = Long.parseLong(commits.get(keptPosition + 1).getUserData().get(SequenceNumbers.MAX_SEQ_NO));
             }
-            safeCommit = this.safeCommit;
+            for (int i = 0; i < keptPosition; i++) {
+                if (snapshottedCommits.containsKey(commits.get(i)) == false) {
+                    deleteCommit(commits.get(i));
+                }
+            }
         }
+        assert assertSafeCommitUnchanged(safeCommit);
+    }
 
-        assert Thread.holdsLock(this) == false : "should not block concurrent acquire or relesase";
-        safeCommitInfo = new SafeCommitInfo(
-            Long.parseLong(safeCommit.getUserData().get(SequenceNumbers.LOCAL_CHECKPOINT_KEY)),
-            getDocCountOfCommit(safeCommit)
-        );
-
+    private boolean assertSafeCommitUnchanged(IndexCommit safeCommit) {
         // This is protected from concurrent calls by a lock on the IndexWriter, but this assertion makes sure that we notice if that ceases
         // to be true in future. It is not disastrous if safeCommitInfo refers to an older safeCommit, it just means that we might retain a
         // bit more history and do a few more ops-based recoveries than we would otherwise.
         final IndexCommit newSafeCommit = this.safeCommit;
         assert safeCommit == newSafeCommit
             : "onCommit called concurrently? " + safeCommit.getGeneration() + " vs " + newSafeCommit.getGeneration();
+        return true;
     }
 
     private void deleteCommit(IndexCommit commit) throws IOException {

--- a/server/src/test/java/org/elasticsearch/index/engine/CombinedDeletionPolicyTests.java
+++ b/server/src/test/java/org/elasticsearch/index/engine/CombinedDeletionPolicyTests.java
@@ -273,8 +273,12 @@ public class CombinedDeletionPolicyTests extends ESTestCase {
     ) {
         return new CombinedDeletionPolicy(logger, translogPolicy, softDeletesPolicy, globalCheckpoint::get) {
             @Override
-            protected int getDocCountOfCommit(IndexCommit indexCommit) {
-                return between(0, 1000);
+            protected int getDocCountOfCommit(IndexCommit indexCommit) throws IOException {
+                if (randomBoolean()) {
+                    throw new IOException("Simulated IO");
+                } else {
+                    return between(0, 1000);
+                }
             }
         };
     }


### PR DESCRIPTION
If we hit an IOException while reading the doc count of the safe commit (i.e., calling `getDocCountOfCommit`), then `IndexFileDeleter` will expose deleted index commits. This change re-arranges the `onCommit` method to ensure that deleting index commits is the last thing in the method.

I labelled this PR as test instead of bug as I think this is not a production issue.

Closes #87204