### PR TITLE
[8.3] Clean up DeflateCompressor after exception (#87163)

### DIFF
--- a/docs/changelog/87163.yaml
+++ b/docs/changelog/87163.yaml
@@ -1,0 +1,6 @@
+pr: 87163
+summary: Clean up `DeflateCompressor` after exception
+area: Infra/Core
+type: bug
+issues:
+ - 87160

--- a/server/src/main/java/org/elasticsearch/common/compress/DeflateCompressor.java
+++ b/server/src/main/java/org/elasticsearch/common/compress/DeflateCompressor.java
@@ -207,15 +207,17 @@ public class DeflateCompressor implements Compressor {
     @Override
     public BytesReference uncompress(BytesReference bytesReference) throws IOException {
         final BytesStreamOutput buffer = baos.get();
-        final Inflater inflater = inflaterRef.get();
-        try (InflaterOutputStream ios = new InflaterOutputStream(buffer, inflater)) {
-            bytesReference.slice(HEADER.length, bytesReference.length() - HEADER.length).writeTo(ios);
+        try {
+            final Inflater inflater = inflaterRef.get();
+            try (InflaterOutputStream ios = new InflaterOutputStream(buffer, inflater)) {
+                bytesReference.slice(HEADER.length, bytesReference.length() - HEADER.length).writeTo(ios);
+            } finally {
+                inflater.reset();
+            }
+            return buffer.copyBytes();
         } finally {
-            inflater.reset();
+            buffer.reset();
         }
-        final BytesReference res = buffer.copyBytes();
-        buffer.reset();
-        return res;
     }
 
     // Reusable Deflater reference. Note: This is a separate instance from the one used for the compressing stream wrapper because we
@@ -225,15 +227,17 @@ public class DeflateCompressor implements Compressor {
     @Override
     public BytesReference compress(BytesReference bytesReference) throws IOException {
         final BytesStreamOutput buffer = baos.get();
-        buffer.write(HEADER);
-        final Deflater deflater = deflaterRef.get();
-        try (DeflaterOutputStream dos = new DeflaterOutputStream(buffer, deflater, true)) {
-            bytesReference.writeTo(dos);
+        try {
+            buffer.write(HEADER);
+            final Deflater deflater = deflaterRef.get();
+            try (DeflaterOutputStream dos = new DeflaterOutputStream(buffer, deflater, true)) {
+                bytesReference.writeTo(dos);
+            } finally {
+                deflater.reset();
+            }
+            return buffer.copyBytes();
         } finally {
-            deflater.reset();
+            buffer.reset();
         }
-        final BytesReference res = buffer.copyBytes();
-        buffer.reset();
-        return res;
     }
 }


### PR DESCRIPTION
Backports the following commits to 8.3:
 - Clean up DeflateCompressor after exception (#87163)