### PR TITLE
[Test] Random domain names are now unique

### DIFF
--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/RealmsTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/RealmsTests.java
@@ -54,6 +54,7 @@ import org.mockito.Mockito;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -247,7 +248,7 @@ public class RealmsTests extends ESTestCase {
             orders.add(i);
         }
         Collections.shuffle(orders, random());
-        List<String> domains = randomList(1, 3, () -> randomAlphaOfLengthBetween(1, 3)).stream().distinct().collect(Collectors.toList());
+        Collection<String> domains = new HashSet<>(randomList(1, 3, () -> randomAlphaOfLengthBetween(1, 3)));
         domains.add(null); // not all realms ought to have a domain
         Map<Integer, Integer> orderToIndex = new HashMap<>();
         Map<Integer, String> indexToDomain = new HashMap<>();

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/RealmsTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/RealmsTests.java
@@ -247,7 +247,7 @@ public class RealmsTests extends ESTestCase {
             orders.add(i);
         }
         Collections.shuffle(orders, random());
-        List<String> domains = randomList(1, 3, () -> randomAlphaOfLengthBetween(1, 3));
+        List<String> domains = randomList(1, 3, () -> randomAlphaOfLengthBetween(1, 3)).stream().distinct().collect(Collectors.toList());
         domains.add(null); // not all realms ought to have a domain
         Map<Integer, Integer> orderToIndex = new HashMap<>();
         Map<Integer, String> indexToDomain = new HashMap<>();


### PR DESCRIPTION
Duplicate domain names can cause settings builder to override each
other but in a not complete way. This leads to partially configured
settings which in turn leads to assertion failure.

This PR fixes it by ensure unique domain names in test. This is
reasonable because settings deduplication in production is done before
they reach to the realms code.

Resolves: #87226

