### PR TITLE
Remove apm_user role

### DIFF
--- a/docs/changelog/87233.yaml
+++ b/docs/changelog/87233.yaml
@@ -1,0 +1,12 @@
+pr: 87233
+summary: Remove `apm_user` role
+area: Authorization
+type: breaking
+issues: []
+breaking:
+  title: Remove `apm_user` role
+  area: Authorization
+  details: Please describe the details of this change for the release notes. You can
+    use asciidoc.
+  impact: Please describe the impact of this change to users
+  notable: false

--- a/docs/changelog/87233.yaml
+++ b/docs/changelog/87233.yaml
@@ -1,7 +1,7 @@
 pr: 87233
 summary: Remove `apm_user` role
 area: Authorization
-type: breaking
+type: deprecation
 issues: []
 breaking:
   title: Remove `apm_user` role
@@ -10,3 +10,9 @@ breaking:
     use asciidoc.
   impact: Please describe the impact of this change to users
   notable: false
+deprecation:
+  title: Remove `apm_user` role
+  area: Authorization
+  details: Please describe the details of this change for the release notes. You can
+    use asciidoc.
+  impact: Please describe the impact of this change to users

--- a/x-pack/docs/en/security/authorization/built-in-roles.asciidoc
+++ b/x-pack/docs/en/security/authorization/built-in-roles.asciidoc
@@ -14,11 +14,6 @@ roles have a fixed set of privileges and cannot be updated.
 Grants access necessary for the APM system user to send system-level data
 (such as monitoring) to {es}.
 
-[[built-in-roles-apm-user]] `apm_user` ::
-Grants the privileges required for APM users (such as `read` and
-`view_index_metadata` privileges on the `apm-*` and `.ml-anomalies*` indices).
-deprecated:[7.13.0,"See {kibana-ref}/apm-app-users.html[APM app users and privileges\] for alternatives."].
-
 [[built-in-roles-beats-admin]] `beats_admin` ::
 Grants access to the `.management-beats` index, which contains configuration
 information for the Beats.

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStore.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStore.java
@@ -246,60 +246,6 @@ public class ReservedRolesStore implements BiConsumer<Set<String>, ActionListene
                 )
             )
             .put(
-                "apm_user",
-                new RoleDescriptor(
-                    "apm_user",
-                    null,
-                    new RoleDescriptor.IndicesPrivileges[] {
-                        // Self managed APM Server
-                        // Can be removed in 8.0
-                        RoleDescriptor.IndicesPrivileges.builder().indices("apm-*").privileges("read", "view_index_metadata").build(),
-
-                        // APM Server under fleet (data streams)
-                        RoleDescriptor.IndicesPrivileges.builder().indices("logs-apm.*").privileges("read", "view_index_metadata").build(),
-                        RoleDescriptor.IndicesPrivileges.builder().indices("logs-apm-*").privileges("read", "view_index_metadata").build(),
-                        RoleDescriptor.IndicesPrivileges.builder()
-                            .indices("metrics-apm.*")
-                            .privileges("read", "view_index_metadata")
-                            .build(),
-                        RoleDescriptor.IndicesPrivileges.builder()
-                            .indices("metrics-apm-*")
-                            .privileges("read", "view_index_metadata")
-                            .build(),
-                        RoleDescriptor.IndicesPrivileges.builder()
-                            .indices("traces-apm.*")
-                            .privileges("read", "view_index_metadata")
-                            .build(),
-                        RoleDescriptor.IndicesPrivileges.builder()
-                            .indices("traces-apm-*")
-                            .privileges("read", "view_index_metadata")
-                            .build(),
-
-                        // Machine Learning indices. Only needed for legacy reasons
-                        // Can be removed in 8.0
-                        RoleDescriptor.IndicesPrivileges.builder()
-                            .indices(".ml-anomalies*")
-                            .privileges("read", "view_index_metadata")
-                            .build(),
-
-                        // Annotations
-                        RoleDescriptor.IndicesPrivileges.builder()
-                            .indices("observability-annotations")
-                            .privileges("read", "view_index_metadata")
-                            .build() },
-                    new RoleDescriptor.ApplicationResourcePrivileges[] {
-                        RoleDescriptor.ApplicationResourcePrivileges.builder()
-                            .application("kibana-*")
-                            .resources("*")
-                            .privileges("reserved_ml_apm_user")
-                            .build() },
-                    null,
-                    null,
-                    MetadataUtils.getDeprecatedReservedMetadata("This role will be removed in 8.0"),
-                    null
-                )
-            )
-            .put(
                 "machine_learning_user",
                 new RoleDescriptor(
                     "machine_learning_user",

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStoreTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStoreTests.java
@@ -2080,58 +2080,6 @@ public class ReservedRolesStoreTests extends ESTestCase {
         assertNoAccessAllowed(APMSystemRole, XPackPlugin.ASYNC_RESULTS_INDEX + randomAlphaOfLengthBetween(0, 2));
     }
 
-    public void testAPMUserRole() {
-        final TransportRequest request = mock(TransportRequest.class);
-        final Authentication authentication = AuthenticationTestHelper.builder().build();
-
-        final RoleDescriptor roleDescriptor = new ReservedRolesStore().roleDescriptor("apm_user");
-        assertNotNull(roleDescriptor);
-        assertThat(roleDescriptor.getMetadata(), hasEntry("_reserved", true));
-
-        Role role = Role.builder(roleDescriptor, null, RESTRICTED_INDICES).build();
-
-        assertThat(role.cluster().check(DelegatePkiAuthenticationAction.NAME, request, authentication), is(false));
-        assertThat(role.runAs().check(randomAlphaOfLengthBetween(1, 12)), is(false));
-
-        assertNoAccessAllowed(role, "foo");
-        assertNoAccessAllowed(role, "foo-apm");
-        assertNoAccessAllowed(role, "foo-logs-apm.bar");
-        assertNoAccessAllowed(role, "foo-logs-apm-bar");
-        assertNoAccessAllowed(role, "foo-traces-apm.bar");
-        assertNoAccessAllowed(role, "foo-traces-apm-bar");
-        assertNoAccessAllowed(role, "foo-metrics-apm.bar");
-        assertNoAccessAllowed(role, "foo-metrics-apm-bar");
-
-        assertOnlyReadAllowed(role, "logs-apm." + randomIntBetween(0, 5));
-        assertOnlyReadAllowed(role, "logs-apm-" + randomIntBetween(0, 5));
-        assertOnlyReadAllowed(role, "traces-apm." + randomIntBetween(0, 5));
-        assertOnlyReadAllowed(role, "traces-apm-" + randomIntBetween(0, 5));
-        assertOnlyReadAllowed(role, "metrics-apm." + randomIntBetween(0, 5));
-        assertOnlyReadAllowed(role, "metrics-apm-" + randomIntBetween(0, 5));
-        assertOnlyReadAllowed(role, "apm-" + randomIntBetween(0, 5));
-        assertOnlyReadAllowed(role, AnomalyDetectorsIndexFields.RESULTS_INDEX_PREFIX + AnomalyDetectorsIndexFields.RESULTS_INDEX_DEFAULT);
-
-        assertOnlyReadAllowed(role, "observability-annotations");
-
-        final String kibanaApplicationWithRandomIndex = "kibana-" + randomFrom(randomAlphaOfLengthBetween(8, 24), ".kibana");
-        assertThat(role.application().grants(new ApplicationPrivilege(kibanaApplicationWithRandomIndex, "app-foo", "foo"), "*"), is(false));
-        assertThat(
-            role.application()
-                .grants(
-                    new ApplicationPrivilege(kibanaApplicationWithRandomIndex, "app-reserved_ml_apm_user", "reserved_ml_apm_user"),
-                    "*"
-                ),
-            is(true)
-        );
-
-        final String otherApplication = "logstash-" + randomAlphaOfLengthBetween(8, 24);
-        assertThat(role.application().grants(new ApplicationPrivilege(otherApplication, "app-foo", "foo"), "*"), is(false));
-        assertThat(
-            role.application().grants(new ApplicationPrivilege(otherApplication, "app-reserved_ml_apm_user", "reserved_ml_apm_user"), "*"),
-            is(false)
-        );
-    }
-
     public void testMachineLearningAdminRole() {
         final TransportRequest request = mock(TransportRequest.class);
         final Authentication authentication = AuthenticationTestHelper.builder().build();


### PR DESCRIPTION
Meta issue: https://github.com/elastic/kibana/issues/116760
The `apm_user` role was [marked as deprecated](https://github.com/elastic/elasticsearch/pull/68749) in 7.13 and was supposed to be removed in 8.0.
All mentions of `apm_user` role was finally removed in https://github.com/elastic/kibana/pull/132790 and this PR removes the actual role