### PR TITLE
Broadcast replication action support build response from shard level response

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/admin/indices/flush/TransportFlushAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/flush/TransportFlushAction.java
@@ -62,6 +62,7 @@ public class TransportFlushAction extends TransportBroadcastReplicationAction<
 
     @Override
     protected FlushResponse newResponse(
+        List<ReplicationResponse> shardsResponses,
         int successfulShards,
         int failedShards,
         int totalNumCopies,

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/refresh/TransportRefreshAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/refresh/TransportRefreshAction.java
@@ -66,6 +66,7 @@ public class TransportRefreshAction extends TransportBroadcastReplicationAction<
 
     @Override
     protected RefreshResponse newResponse(
+        List<ReplicationResponse> shardsResponses,
         int successfulShards,
         int failedShards,
         int totalNumCopies,

--- a/server/src/main/java/org/elasticsearch/action/support/replication/TransportBroadcastReplicationAction.java
+++ b/server/src/main/java/org/elasticsearch/action/support/replication/TransportBroadcastReplicationAction.java
@@ -171,10 +171,11 @@ public abstract class TransportBroadcastReplicationAction<
                 }
             }
         }
-        listener.onResponse(newResponse(successfulShards, failedShards, totalNumCopies, shardFailures));
+        listener.onResponse(newResponse(shardsResponses, successfulShards, failedShards, totalNumCopies, shardFailures));
     }
 
     protected abstract Response newResponse(
+        List<ShardResponse> shardsResponses,
         int successfulShards,
         int failedShards,
         int totalNumCopies,

--- a/server/src/test/java/org/elasticsearch/action/support/replication/BroadcastReplicationTests.java
+++ b/server/src/test/java/org/elasticsearch/action/support/replication/BroadcastReplicationTests.java
@@ -270,6 +270,7 @@ public class BroadcastReplicationTests extends ESTestCase {
 
         @Override
         protected BroadcastResponse newResponse(
+            List<ReplicationResponse> shardsResponses,
             int successfulShards,
             int failedShards,
             int totalNumCopies,


### PR DESCRIPTION
The broadcast replication action has been widely used in existing consistency tasks, suck as bulk , global checkpoint sync. However current broadcast replication action not support use shard level response to build broadcast response. see in org.elasticsearch.action.support.replication.TransportBroadcastReplicationAction#newResponse.
Additionally, the broadcast by node action can support use shard level response to build broadresponse. see in org.elasticsearch.action.support.broadcast.node.TransportBroadcastByNodeAction#newResponse.

This  feature will be helpful for additional consistency tasks develop such as decoupling storage and compute. 