### PR TITLE
Refactor snapshot finalization code to prepare for batched finalizations

### DIFF
--- a/server/src/main/java/org/elasticsearch/repositories/ShardGenerations.java
+++ b/server/src/main/java/org/elasticsearch/repositories/ShardGenerations.java
@@ -213,9 +213,9 @@ public final class ShardGenerations {
             return this;
         }
 
-        public Builder put(IndexId indexId, int shardId, SnapshotsInProgress.ShardSnapshotStatus status) {
+        public Builder put(RepositoryShardId shardId, SnapshotsInProgress.ShardSnapshotStatus status) {
             // only track generations for successful shard status values
-            return put(indexId, shardId, status.state().failed() ? null : status.generation());
+            return put(shardId.index(), shardId.shardId(), status.state().failed() ? null : status.generation());
         }
 
         public Builder put(IndexId indexId, int shardId, ShardGeneration generation) {


### PR DESCRIPTION
This sets up batched snapshot finalizations by breaking the finalization method up a little
and inlining the repository generations building. This makes a follow-up that loops over multiple snapshots
a lot less noisy.
Also, this change in isolation makes the method easier to read IMO.