### PR TITLE
Fix ClusterHealthIT

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/cluster/ClusterHealthIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/cluster/ClusterHealthIT.java
@@ -258,18 +258,14 @@ public class ClusterHealthIT extends ESIntegTestCase {
 
     public void testHealthOnIndexCreation() throws Exception {
         final AtomicBoolean finished = new AtomicBoolean(false);
-        Thread clusterHealthThread = new Thread() {
-            @Override
-            public void run() {
-                while (finished.get() == false) {
-                    ClusterHealthResponse health = client().admin().cluster().prepareHealth().get();
-                    assertThat(health.getStatus(), not(equalTo(ClusterHealthStatus.RED)));
-                }
+        Thread clusterHealthThread = new Thread(() -> {
+            while (finished.get() == false) {
+                assertThat(client().admin().cluster().prepareHealth().get().getStatus(), not(equalTo(ClusterHealthStatus.RED)));
             }
-        };
+        });
         clusterHealthThread.start();
         for (int i = 0; i < 10; i++) {
-            createIndex("test" + i);
+            createIndex("test-" + i);
         }
         finished.set(true);
         clusterHealthThread.join();

--- a/server/src/internalClusterTest/java/org/elasticsearch/cluster/ClusterHealthIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/cluster/ClusterHealthIT.java
@@ -258,14 +258,18 @@ public class ClusterHealthIT extends ESIntegTestCase {
 
     public void testHealthOnIndexCreation() throws Exception {
         final AtomicBoolean finished = new AtomicBoolean(false);
-        Thread clusterHealthThread = new Thread(() -> {
-            while (finished.get() == false) {
-                assertThat(client().admin().cluster().prepareHealth().get().getStatus(), not(equalTo(ClusterHealthStatus.RED)));
+        Thread clusterHealthThread = new Thread() {
+            @Override
+            public void run() {
+                while (finished.get() == false) {
+                    ClusterHealthResponse health = client().admin().cluster().prepareHealth().get();
+                    assertThat(health.getStatus(), not(equalTo(ClusterHealthStatus.RED)));
+                }
             }
-        });
+        };
         clusterHealthThread.start();
         for (int i = 0; i < 10; i++) {
-            createIndex("test-" + i);
+            createIndex("test" + i);
         }
         finished.set(true);
         clusterHealthThread.join();

--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/allocator/DesiredBalance.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/allocator/DesiredBalance.java
@@ -25,6 +25,10 @@ public record DesiredBalance(long lastConvergedIndex, Map<ShardId, Set<String>> 
         return desiredAssignments.getOrDefault(shardId, Set.of());
     }
 
+    public boolean isBalanceComputed(ShardId shardId) {
+        return desiredAssignments.containsKey(shardId) || unassigned.containsKey(shardId);
+    }
+
     public static boolean areSame(DesiredBalance a, DesiredBalance b) {
         return Objects.equals(a.desiredAssignments, b.desiredAssignments) && Objects.equals(a.unassigned, b.unassigned);
     }

--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/allocator/DesiredBalanceReconciler.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/allocator/DesiredBalanceReconciler.java
@@ -228,8 +228,9 @@ public class DesiredBalanceReconciler {
                 }
 
                 final var allocationStatus = UnassignedInfo.AllocationStatus.fromDecision(
-                    isThrottled ? Decision.Type.THROTTLE : Decision.Type.NO
+                    isThrottled || desiredNodeIds.isEmpty() ? Decision.Type.THROTTLE : Decision.Type.NO
                 );
+
                 unassigned.ignoreShard(shard, allocationStatus, allocation.changes());
                 if (shard.primary() == false) {
                     // we could not allocate it and we are a replica - check if we can ignore the other replicas

--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/allocator/DesiredBalanceReconciler.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/allocator/DesiredBalanceReconciler.java
@@ -228,10 +228,10 @@ public class DesiredBalanceReconciler {
                 }
 
                 final UnassignedInfo.AllocationStatus allocationStatus;
-                if (isThrottled) {
-                    allocationStatus = UnassignedInfo.AllocationStatus.DECIDERS_THROTTLED;
-                } else if (desiredBalance.isBalanceComputed(shard.shardId()) == false) {
+                if (desiredBalance.isBalanceComputed(shard.shardId()) == false) {
                     allocationStatus = UnassignedInfo.AllocationStatus.NO_ATTEMPT;
+                } else if (isThrottled) {
+                    allocationStatus = UnassignedInfo.AllocationStatus.DECIDERS_THROTTLED;
                 } else {
                     allocationStatus = UnassignedInfo.AllocationStatus.DECIDERS_NO;
                 }

--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/allocator/DesiredBalanceReconciler.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/allocator/DesiredBalanceReconciler.java
@@ -227,9 +227,14 @@ public class DesiredBalanceReconciler {
                     logger.trace("No eligible node found to assign shard [{}] amongst [{}]", shard, desiredNodeIds);
                 }
 
-                final var allocationStatus = UnassignedInfo.AllocationStatus.fromDecision(
-                    isThrottled || desiredBalance.isBalanceComputed(shard.shardId()) == false ? Decision.Type.THROTTLE : Decision.Type.NO
-                );
+                final UnassignedInfo.AllocationStatus allocationStatus;
+                if (isThrottled) {
+                    allocationStatus = UnassignedInfo.AllocationStatus.DECIDERS_THROTTLED;
+                } else if (desiredBalance.isBalanceComputed(shard.shardId()) == false) {
+                    allocationStatus = UnassignedInfo.AllocationStatus.NO_ATTEMPT;
+                } else {
+                    allocationStatus = UnassignedInfo.AllocationStatus.DECIDERS_NO;
+                }
 
                 unassigned.ignoreShard(shard, allocationStatus, allocation.changes());
                 if (shard.primary() == false) {

--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/allocator/DesiredBalanceReconciler.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/allocator/DesiredBalanceReconciler.java
@@ -228,7 +228,7 @@ public class DesiredBalanceReconciler {
                 }
 
                 final var allocationStatus = UnassignedInfo.AllocationStatus.fromDecision(
-                    isThrottled || desiredNodeIds.isEmpty() ? Decision.Type.THROTTLE : Decision.Type.NO
+                    isThrottled || desiredBalance.isBalanceComputed(shard.shardId()) == false ? Decision.Type.THROTTLE : Decision.Type.NO
                 );
 
                 unassigned.ignoreShard(shard, allocationStatus, allocation.changes());

--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/allocator/DesiredBalanceService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/allocator/DesiredBalanceService.java
@@ -190,7 +190,7 @@ public class DesiredBalanceService {
         do {
 
             if (hasChanges) {
-                final var unassigned = routingAllocation.routingNodes().unassigned();
+                final var unassigned = routingNodes.unassigned();
 
                 // Not the first iteration, so every remaining unassigned shard has been ignored, perhaps due to throttling. We must bring
                 // them all back out of the ignored list to give the allocator another go...
@@ -209,7 +209,7 @@ public class DesiredBalanceService {
 
             logger.trace("running delegate allocator");
             delegateAllocator.allocate(routingAllocation);
-            assert routingAllocation.routingNodes().unassigned().size() == 0; // any unassigned shards should now be ignored
+            assert routingNodes.unassigned().size() == 0; // any unassigned shards should now be ignored
 
             hasChanges = false;
             for (final var routingNode : routingNodes) {

--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/allocator/DesiredBalanceService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/allocator/DesiredBalanceService.java
@@ -239,7 +239,7 @@ public class DesiredBalanceService {
         }
 
         final var unassigned = new HashMap<ShardId, Integer>();
-        for (var ignored : routingAllocation.routingNodes().unassigned().ignored()) {
+        for (var ignored : routingNodes.unassigned().ignored()) {
             assert ignored.unassignedInfo() != null;
             assert ignored.unassignedInfo().getLastAllocationStatus() == UnassignedInfo.AllocationStatus.DECIDERS_NO
                 || ignored.unassignedInfo().getLastAllocationStatus() == UnassignedInfo.AllocationStatus.NO_ATTEMPT


### PR DESCRIPTION
This change treats no desired nodes as `NO_ATTEMPT` and expects a followup reroute to allocate the shard.