### PR TITLE
[8.3] Hide system indices and their aliases in upgraded clusters (#87125)

### DIFF
--- a/docs/changelog/87125.yaml
+++ b/docs/changelog/87125.yaml
@@ -1,0 +1,5 @@
+pr: 87125
+summary: Hide system indices and their aliases in upgraded clusters
+area: Infra/Core
+type: bug
+issues: []

--- a/server/src/main/java/org/elasticsearch/indices/SystemIndexManager.java
+++ b/server/src/main/java/org/elasticsearch/indices/SystemIndexManager.java
@@ -46,6 +46,8 @@ import static org.elasticsearch.cluster.metadata.IndexMetadata.INDEX_FORMAT_SETT
  * those indices can be automatically managed. Only some system indices are managed
  * internally to Elasticsearch - others are created and managed externally, e.g.
  * Kibana indices.
+ *
+ * Other metadata updates are handled by {@link org.elasticsearch.cluster.metadata.SystemIndexMetadataUpgradeService}.
  */
 public class SystemIndexManager implements ClusterStateListener {
     private static final Logger logger = LogManager.getLogger(SystemIndexManager.class);

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/SystemIndexMetadataUpgradeServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/SystemIndexMetadataUpgradeServiceTests.java
@@ -57,9 +57,10 @@ public class SystemIndexMetadataUpgradeServiceTests extends ESTestCase {
      */
     public void testUpgradeVisibleIndexToSystemIndex() throws Exception {
         // create an initial cluster state with a hidden index that matches the system index descriptor
-        IndexMetadata.Builder hiddenIndexMetadata = IndexMetadata.builder(SYSTEM_INDEX_NAME)
+        IndexMetadata hiddenIndexMetadata = IndexMetadata.builder(SYSTEM_INDEX_NAME)
             .system(false)
-            .settings(getSettingsBuilder().put(IndexMetadata.SETTING_INDEX_HIDDEN, false));
+            .settings(getSettingsBuilder().put(IndexMetadata.SETTING_INDEX_HIDDEN, false))
+            .build();
 
         assertSystemUpgradeAppliesHiddenSetting(hiddenIndexMetadata);
     }
@@ -69,34 +70,139 @@ public class SystemIndexMetadataUpgradeServiceTests extends ESTestCase {
      */
     public void testHiddenSettingRemovedFromSystemIndices() throws Exception {
         // create an initial cluster state with a hidden index that matches the system index descriptor
-        IndexMetadata.Builder hiddenIndexMetadata = IndexMetadata.builder(SYSTEM_INDEX_NAME)
+        IndexMetadata hiddenIndexMetadata = IndexMetadata.builder(SYSTEM_INDEX_NAME)
             .system(true)
-            .settings(getSettingsBuilder().put(IndexMetadata.SETTING_INDEX_HIDDEN, false));
+            .settings(getSettingsBuilder().put(IndexMetadata.SETTING_INDEX_HIDDEN, false))
+            .build();
 
         assertSystemUpgradeAppliesHiddenSetting(hiddenIndexMetadata);
     }
 
     public void testUpgradeIndexWithVisibleAlias() throws Exception {
-        IndexMetadata.Builder visibleAliasMetadata = IndexMetadata.builder(SYSTEM_INDEX_NAME)
+        IndexMetadata visibleAliasMetadata = IndexMetadata.builder(SYSTEM_INDEX_NAME)
             .system(false)
             .settings(getSettingsBuilder())
-            .putAlias(AliasMetadata.builder(SYSTEM_ALIAS_NAME).isHidden(false));
+            .putAlias(AliasMetadata.builder(SYSTEM_ALIAS_NAME).isHidden(false))
+            .build();
 
         assertSystemUpgradeHidesAlias(visibleAliasMetadata);
     }
 
     public void testSystemAliasesBecomeHidden() throws Exception {
-        IndexMetadata.Builder visibleAliasMetadata = IndexMetadata.builder(SYSTEM_INDEX_NAME)
+        IndexMetadata visibleAliasMetadata = IndexMetadata.builder(SYSTEM_INDEX_NAME)
             .system(true)
             .settings(getSettingsBuilder())
-            .putAlias(AliasMetadata.builder(SYSTEM_ALIAS_NAME).isHidden(false));
+            .putAlias(AliasMetadata.builder(SYSTEM_ALIAS_NAME).isHidden(false))
+            .build();
 
         assertSystemUpgradeHidesAlias(visibleAliasMetadata);
     }
 
-    private void assertSystemUpgradeAppliesHiddenSetting(IndexMetadata.Builder hiddenIndexMetadata) throws Exception {
+    public void testHasVisibleAliases() {
+        IndexMetadata nonSystemHiddenAlias = IndexMetadata.builder("user-index")
+            .system(false)
+            .settings(getSettingsBuilder().put(SystemIndexDescriptor.DEFAULT_SETTINGS))
+            .putAlias(AliasMetadata.builder("user-alias").isHidden(true).build())
+            .build();
+        IndexMetadata nonSystemVisibleAlias = IndexMetadata.builder("user-index")
+            .system(false)
+            .settings(getSettingsBuilder().put(SystemIndexDescriptor.DEFAULT_SETTINGS))
+            .putAlias(AliasMetadata.builder("user-alias").isHidden(false).build())
+            .build();
+        IndexMetadata systemHiddenAlias = IndexMetadata.builder(SYSTEM_INDEX_NAME)
+            .system(true)
+            .settings(getSettingsBuilder().put(SystemIndexDescriptor.DEFAULT_SETTINGS))
+            .putAlias(AliasMetadata.builder(SYSTEM_ALIAS_NAME).isHidden(true).build())
+            .build();
+        IndexMetadata systemVisibleAlias = IndexMetadata.builder(SYSTEM_INDEX_NAME)
+            .system(true)
+            .settings(getSettingsBuilder().put(SystemIndexDescriptor.DEFAULT_SETTINGS))
+            .putAlias(AliasMetadata.builder(SYSTEM_ALIAS_NAME).isHidden(false).build())
+            .build();
+
+        // non-system indices should not require update
+        assertThat(service.hasVisibleAlias(nonSystemHiddenAlias), equalTo(false));
+        assertThat(service.requiresUpdate(nonSystemHiddenAlias), equalTo(false));
+        assertThat(service.hasVisibleAlias(nonSystemVisibleAlias), equalTo(true));
+        assertThat(service.requiresUpdate(nonSystemVisibleAlias), equalTo(false));
+
+        // hidden system alias should not require update
+        assertThat(service.hasVisibleAlias(systemHiddenAlias), equalTo(false));
+        assertThat(service.requiresUpdate(systemHiddenAlias), equalTo(false));
+
+        // visible system alias should require update
+        assertThat(service.hasVisibleAlias(systemVisibleAlias), equalTo(true));
+        assertThat(service.requiresUpdate(systemVisibleAlias), equalTo(true));
+    }
+
+    public void testShouldBeSystem() {
+        IndexMetadata shouldNotBeSystem = IndexMetadata.builder("user-index")
+            .system(true)
+            .settings(getSettingsBuilder().put(SystemIndexDescriptor.DEFAULT_SETTINGS))
+            .build();
+        IndexMetadata shouldBeSystem = IndexMetadata.builder(SYSTEM_INDEX_NAME)
+            .system(false)
+            .settings(getSettingsBuilder().put(SystemIndexDescriptor.DEFAULT_SETTINGS))
+            .build();
+        IndexMetadata correctlySystem = IndexMetadata.builder(SYSTEM_INDEX_NAME)
+            .system(true)
+            .settings(getSettingsBuilder().put(SystemIndexDescriptor.DEFAULT_SETTINGS))
+            .build();
+        IndexMetadata correctlyNonSystem = IndexMetadata.builder("user-index")
+            .system(false)
+            .settings(getSettingsBuilder().put(SystemIndexDescriptor.DEFAULT_SETTINGS))
+            .build();
+
+        // indices that should be toggled from system to non-system
+        assertThat(service.shouldBeSystem(shouldNotBeSystem), equalTo(false));
+        assertThat(service.requiresUpdate(shouldNotBeSystem), equalTo(true));
+
+        assertThat(service.shouldBeSystem(shouldBeSystem), equalTo(true));
+        assertThat(service.requiresUpdate(shouldBeSystem), equalTo(true));
+
+        // indices whose system flag needs no update
+        assertThat(service.shouldBeSystem(correctlySystem), equalTo(true));
+        assertThat(service.requiresUpdate(correctlySystem), equalTo(false));
+
+        assertThat(service.shouldBeSystem(correctlyNonSystem), equalTo(false));
+        assertThat(service.requiresUpdate(correctlyNonSystem), equalTo(false));
+    }
+
+    public void testIsVisible() {
+        IndexMetadata nonSystemHiddenIndex = IndexMetadata.builder("user-index")
+            .settings(getSettingsBuilder().put(IndexMetadata.SETTING_INDEX_HIDDEN, "true"))
+            .build();
+        IndexMetadata nonSystemVisibleIndex = IndexMetadata.builder("user-index")
+            .settings(getSettingsBuilder().put(IndexMetadata.SETTING_INDEX_HIDDEN, "false"))
+            .build();
+        IndexMetadata systemHiddenIndex = IndexMetadata.builder(SYSTEM_INDEX_NAME)
+            .system(true)
+            .settings(getSettingsBuilder().put(IndexMetadata.SETTING_INDEX_HIDDEN, "true"))
+            .build();
+        IndexMetadata systemVisibleIndex = IndexMetadata.builder(SYSTEM_INDEX_NAME)
+            .system(true)
+            .settings(getSettingsBuilder().put(IndexMetadata.SETTING_INDEX_HIDDEN, "false"))
+            .build();
+
+        // non-system indices should not require update
+        assertThat(service.isVisible(nonSystemHiddenIndex), equalTo(false));
+        assertThat(service.requiresUpdate(nonSystemHiddenIndex), equalTo(false));
+        assertThat(service.isVisible(nonSystemVisibleIndex), equalTo(true));
+        assertThat(service.requiresUpdate(nonSystemVisibleIndex), equalTo(false));
+
+        // hidden system index should not require update
+        assertThat(service.isVisible(systemHiddenIndex), equalTo(false));
+        assertThat(service.requiresUpdate(systemHiddenIndex), equalTo(false));
+
+        // visible system index should require update
+        assertThat(service.isVisible(systemVisibleIndex), equalTo(true));
+        assertThat(service.requiresUpdate(systemVisibleIndex), equalTo(true));
+    }
+
+    private void assertSystemUpgradeAppliesHiddenSetting(IndexMetadata hiddenIndexMetadata) throws Exception {
+        assertTrue("Metadata should require update but does not", service.requiresUpdate(hiddenIndexMetadata));
         Metadata.Builder clusterMetadata = new Metadata.Builder();
-        clusterMetadata.put(hiddenIndexMetadata);
+        clusterMetadata.put(IndexMetadata.builder(hiddenIndexMetadata));
 
         ClusterState clusterState = ClusterState.builder(new ClusterName("system-index-metadata-upgrade-service-tests"))
             .metadata(clusterMetadata.build())
@@ -111,9 +217,10 @@ public class SystemIndexMetadataUpgradeServiceTests extends ESTestCase {
         assertThat(result.isHidden(), equalTo(true));
     }
 
-    private void assertSystemUpgradeHidesAlias(IndexMetadata.Builder visibleAliasMetadata) throws Exception {
+    private void assertSystemUpgradeHidesAlias(IndexMetadata visibleAliasMetadata) throws Exception {
+        assertTrue("Metadata should require update but does not", service.requiresUpdate(visibleAliasMetadata));
         Metadata.Builder clusterMetadata = new Metadata.Builder();
-        clusterMetadata.put(visibleAliasMetadata);
+        clusterMetadata.put(IndexMetadata.builder(visibleAliasMetadata));
 
         ClusterState clusterState = ClusterState.builder(new ClusterName("system-index-metadata-upgrade-service-tests"))
             .metadata(clusterMetadata.build())


### PR DESCRIPTION
Backports the following commits to 8.3:
 - Hide system indices and their aliases in upgraded clusters (#87125)