### PR TITLE
Fix date_histogram test

### DIFF
--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/histogram/DateHistogramAggregatorTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/histogram/DateHistogramAggregatorTests.java
@@ -54,6 +54,7 @@ import static org.elasticsearch.test.MapMatcher.assertMap;
 import static org.elasticsearch.test.MapMatcher.matchesMap;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.not;
@@ -997,7 +998,7 @@ public class DateHistogramAggregatorTests extends DateHistogramAggregatorTestCas
                                 "delegate_debug",
                                 matchesMap().entry("ranges", 2)
                                     .entry("average_docs_per_range", 5005.0)
-                                    .entry("singletons", greaterThan(1))
+                                    .entry("singletons", greaterThanOrEqualTo(1))
                                     .entry("non-singletons", 0)
                             )
                     )


### PR DESCRIPTION
The test for date_histogram expected the index it was testing not to be
force-merged to a single segment. But it's a lucene test case so all
kinds of weird things can happen - about 3.4% of the time the index was
indeed one segment. This fixes the assumption.

Closes #87203
