### PR TITLE
[7.17] Delete index commits last in CombinedDeletionPolicy (#87221)

### DIFF
--- a/server/src/test/java/org/elasticsearch/index/engine/CombinedDeletionPolicyTests.java
+++ b/server/src/test/java/org/elasticsearch/index/engine/CombinedDeletionPolicyTests.java
@@ -276,8 +276,12 @@ public class CombinedDeletionPolicyTests extends ESTestCase {
     ) {
         return new CombinedDeletionPolicy(logger, translogPolicy, softDeletesPolicy, globalCheckpoint::get) {
             @Override
-            protected int getDocCountOfCommit(IndexCommit indexCommit) {
-                return between(0, 1000);
+            protected int getDocCountOfCommit(IndexCommit indexCommit) throws IOException {
+                if (randomBoolean()) {
+                    throw new IOException("Simulated IO");
+                } else {
+                    return between(0, 1000);
+                }
             }
         };
     }


### PR DESCRIPTION
Backports the following commits to 7.17:
 - Delete index commits last in CombinedDeletionPolicy (#87221)