### PR TITLE
Synthetic source: tests for disabling subobjects

### DIFF
--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/index/91_metrics_no_subobjects.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/index/91_metrics_no_subobjects.yml
@@ -46,6 +46,22 @@
   - match: {fields.metrics\.time\.min.long.searchable: true}
   - match: {fields.metrics\.time\.min.long.aggregatable: true}
 
+  - do:
+      get:
+        index: test-1
+        id:    1
+  - match: {_index: "test-1"}
+  - match: {_id: "1"}
+  - match: {_version: 1}
+  - match: {found: true}
+  - match:
+      _source:
+        metrics.host.name: localhost
+        metrics.host.id: 1
+        metrics.time: 10
+        metrics.time.max: 100
+        metrics.time.min: 1
+
 ---
 "Root without subobjects":
   - skip:
@@ -88,3 +104,147 @@
   - match: {fields.time\.max.long.aggregatable: true}
   - match: {fields.time\.min.long.searchable: true}
   - match: {fields.time\.min.long.aggregatable: true}
+
+  - do:
+      get:
+        index: test-1
+        id:    1
+  - match: {_index: "test-1"}
+  - match: {_id: "1"}
+  - match: {_version: 1}
+  - match: {found: true}
+  - match:
+      _source:
+        host.name: localhost
+        host.id: 1
+        time: 10
+        time.max: 100
+        time.min: 1
+
+---
+"Metrics object indexing with synthetic source":
+  - skip:
+      features: allowed_warnings_regex
+      version: " - 8.2.99"
+      reason: added in 8.3.0
+
+  - do:
+      indices.put_template:
+        name: test
+        body:
+          index_patterns: test-*
+          mappings:
+            _source:
+              synthetic: true
+            dynamic_templates:
+              - no_subobjects:
+                  match: metrics
+                  mapping:
+                    type: object
+                    subobjects: false
+                    properties:
+                      host.name:
+                        type: keyword
+
+  - do:
+      allowed_warnings_regex:
+        - "index \\[test-1\\] matches multiple legacy templates \\[global, test\\], composable templates will only match a single template"
+      index:
+        index: test-1
+        id: 1
+        refresh: true
+        body:
+          { metrics.host.name: localhost, metrics.host.id: 1, metrics.time: 10, metrics.time.max: 100, metrics.time.min: 1 }
+
+  - do:
+      field_caps:
+        index: test-1
+        fields: metrics*
+  - match: {fields.metrics\.host\.id.long.searchable: true}
+  - match: {fields.metrics\.host\.id.long.aggregatable: true}
+  - match: {fields.metrics\.host\.name.keyword.searchable: true}
+  - match: {fields.metrics\.host\.name.keyword.aggregatable: true}
+  - match: {fields.metrics\.time.long.searchable: true}
+  - match: {fields.metrics\.time.long.aggregatable: true}
+  - match: {fields.metrics\.time\.max.long.searchable: true}
+  - match: {fields.metrics\.time\.max.long.aggregatable: true}
+  - match: {fields.metrics\.time\.min.long.searchable: true}
+  - match: {fields.metrics\.time\.min.long.aggregatable: true}
+
+  - do:
+      get:
+        index: test-1
+        id:    1
+  - match: {_index: "test-1"}
+  - match: {_id: "1"}
+  - match: {_version: 1}
+  - match: {found: true}
+  - match:
+      _source:
+        metrics:
+          host.name: localhost
+          host.id: 1
+          time: 10
+          time.max: 100
+          time.min: 1
+
+---
+"Root without subobjects with synthetic source":
+  - skip:
+      features: allowed_warnings_regex
+      version: " - 8.2.99"
+      reason: added in 8.3.0
+
+  - do:
+      indices.put_template:
+        name: test
+        body:
+          index_patterns: test-*
+          mappings:
+            _source:
+              synthetic: true
+            subobjects: false
+            properties:
+              host.name:
+                type: keyword
+
+  - do:
+      allowed_warnings_regex:
+        - "index \\[test-1\\] matches multiple legacy templates \\[global, test\\], composable templates will only match a single template"
+      index:
+        index: test-1
+        id: 1
+        refresh: true
+        body:
+          { host.name: localhost, host.id: 1, time: 10, time.max: 100, time.min: 1 }
+
+  - do:
+      field_caps:
+        index: test-1
+        fields: [host*, time*]
+  - match: {fields.host\.name.keyword.searchable: true}
+  - match: {fields.host\.name.keyword.aggregatable: true}
+  - match: {fields.host\.id.long.searchable: true}
+  - match: {fields.host\.id.long.aggregatable: true}
+  - match: {fields.time.long.searchable: true}
+  - match: {fields.time.long.aggregatable: true}
+  - match: {fields.time\.max.long.searchable: true}
+  - match: {fields.time\.max.long.aggregatable: true}
+  - match: {fields.time\.min.long.searchable: true}
+  - match: {fields.time\.min.long.aggregatable: true}
+
+  - do:
+      get:
+        index: test-1
+        id:    1
+  - match: {_index: "test-1"}
+  - match: {_id: "1"}
+  - match: {_version: 1}
+  - match: {found: true}
+  - match:
+      _source:
+        host.name: localhost
+        host.id: 1
+        time: 10
+        time.max: 100
+        time.min: 1


### PR DESCRIPTION
This adds some paranoid tests for synthetic source with disabling
subobjects, as added by #86166. It turns out that synthetic source does
exactly what you'd expect with disabling subobjects - it creates fields
with dots in their names. This adds tests for that.
