### PR TITLE
Don't migrate system indices that match user templates

### DIFF
--- a/docs/changelog/87262.yaml
+++ b/docs/changelog/87262.yaml
@@ -1,0 +1,6 @@
+pr: 87262
+summary: Don't migrate system indices that match user templates
+area: Infra/Core
+type: bug
+issues:
+ - 86801

--- a/modules/reindex/src/internalClusterTest/java/org/elasticsearch/migration/FeatureMigrationIT.java
+++ b/modules/reindex/src/internalClusterTest/java/org/elasticsearch/migration/FeatureMigrationIT.java
@@ -310,4 +310,7 @@ public class FeatureMigrationIT extends AbstractFeatureMigrationIntegTest {
             assertThat(statusResp.getUpgradeStatus(), equalTo(GetFeatureUpgradeStatusResponse.UpgradeStatus.NO_MIGRATION_NEEDED));
         });
     }
+
+    // TODO[wrb]: Test that migrations quit when a destination index would match a legacy template
+    // TODO[wrb]: Test that migrations quit when a destination index would match a composable template
 }

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/IndexTemplateMetadata.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/IndexTemplateMetadata.java
@@ -162,6 +162,11 @@ public class IndexTemplateMetadata extends AbstractDiffable<IndexTemplateMetadat
     }
 
     @Override
+    public String toString() {
+        return name;
+    }
+
+    @Override
     public boolean equals(Object o) {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;

--- a/server/src/main/java/org/elasticsearch/upgrades/SystemIndexMigrator.java
+++ b/server/src/main/java/org/elasticsearch/upgrades/SystemIndexMigrator.java
@@ -26,8 +26,10 @@ import org.elasticsearch.client.ParentTaskAssigningClient;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.ClusterStateUpdateTask;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
+import org.elasticsearch.cluster.metadata.IndexTemplateMetadata;
 import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.cluster.metadata.MetadataCreateIndexService;
+import org.elasticsearch.cluster.metadata.MetadataIndexTemplateService;
 import org.elasticsearch.cluster.metadata.MetadataUpdateSettingsService;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.Strings;
@@ -381,6 +383,41 @@ public class SystemIndexMigrator extends AllocatedPersistentTask {
         }
         Index oldIndex = imd.getIndex();
         String newIndexName = migrationInfo.getNextIndexName();
+
+        final String v2template = MetadataIndexTemplateService.findV2Template(clusterState.metadata(), newIndexName, false);
+        if (Objects.nonNull(v2template)) {
+            logger.error(
+                "unable to create new index [{}] from feature [{}] because it would match composable template [{}]",
+                newIndexName,
+                migrationInfo.getFeatureName(),
+                v2template
+            );
+            markAsFailed(
+                new IllegalStateException(
+                    "unable to create new index [" + newIndexName + "] because it would match composable template [" + v2template + "]"
+                )
+            );
+            return;
+        }
+        final List<IndexTemplateMetadata> v1templates = MetadataIndexTemplateService.findV1Templates(
+            clusterState.metadata(),
+            newIndexName,
+            false
+        );
+        if (v1templates.isEmpty() == false) {
+            logger.error(
+                "unable to create new index [{}] from feature [{}] because it would match legacy templates [{}]",
+                newIndexName,
+                migrationInfo.getFeatureName(),
+                v1templates
+            );
+            markAsFailed(
+                new IllegalStateException(
+                    "unable to create new index [" + newIndexName + "] because it would match legacy templates [" + v1templates + "]"
+                )
+            );
+            return;
+        }
         logger.info("migrating index [{}] from feature [{}] to new index [{}]", oldIndexName, migrationInfo.getFeatureName(), newIndexName);
         ActionListener<BulkByScrollResponse> innerListener = ActionListener.wrap(listener::accept, this::markAsFailed);
         try {


### PR DESCRIPTION
In 7.x, legacy and composable templates may apply to system indices. We don't want this behavior during feature migration. The destination index should get its settings, mappings, and aliases from its system index descriptor. A user who gets this warning should modify their templates so that they do not match system indices, at least during the migration.

Fixes https://github.com/elastic/elasticsearch/issues/86801