### PR TITLE
Docs: Data streams only support `create`

### DIFF
--- a/docs/reference/docs/bulk.asciidoc
+++ b/docs/reference/docs/bulk.asciidoc
@@ -281,7 +281,7 @@ Indexes the specified document if it does not already exist.
 The following line must contain the source data to be indexed.
 +
 --
-include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=bulk-index]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=bulk-index-ds]
 
 include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=bulk-id]
 

--- a/docs/reference/rest-api/common-parms.asciidoc
+++ b/docs/reference/rest-api/common-parms.asciidoc
@@ -450,9 +450,16 @@ end::index-total[]
 tag::bulk-index[]
 `_index`::
 (Optional, string)
-Name of the data stream, index, or index alias to perform the action on. This
+Name of the index or index alias to perform the action on. This
 parameter is required if a `<target>` is not specified in the request path.
 end::bulk-index[]
+
+tag::bulk-index-ds[]
+`_index`::
+(Optional, string)
+Name of the data stream, index, or index alias to perform the action on. This
+parameter is required if a `<target>` is not specified in the request path.
+end::bulk-index-ds[]
 
 tag::index-metric[]
 `<index-metric>`::


### PR DESCRIPTION
This removes "data streams" from the docs for the `index`, `delete`,
and `update` actions because data streams only support the `update`
action.

Closes #87231
