### PR TITLE
Fix version in bwc test again

### DIFF
--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.aggregation/500_serial_diff.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.aggregation/500_serial_diff.yml
@@ -133,8 +133,8 @@ parent has gap:
 ---
 parent has min_doc_count:
   - skip:
-      version: " - 7.17.3, 8.0.0 - 8.2.99"
-      reason: allowed in 7.17.4
+      version: " - 7.17.4, 8.0.0 - 8.2.99"
+      reason: allowed in 7.17.5
 
   - do:
       bulk:


### PR DESCRIPTION
My change #86401 never made it into 7.17.4 so the test was confused.
This bumps the version. It'll make it into 7.17.5.

Closes #87103