### PR TITLE
Assignment record

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/allocator/DesiredBalance.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/allocator/DesiredBalance.java
@@ -12,24 +12,19 @@ import org.elasticsearch.index.shard.ShardId;
 
 import java.util.Map;
 import java.util.Objects;
-import java.util.Set;
 
 /**
  * The desired balance of the cluster, indicating which nodes should hold a copy of each shard.
  *
- * @param desiredAssignments a set of the (persistent) node IDs to which each {@link ShardId} should be allocated
- * @param unassigned a map of {@link  ShardId} that could not be assigned at the moment
+ * @param assignments a set of the (persistent) node IDs to which each {@link ShardId} should be allocated
  */
-public record DesiredBalance(long lastConvergedIndex, Map<ShardId, Set<String>> desiredAssignments, Map<ShardId, Integer> unassigned) {
-    public Set<String> getDesiredNodeIds(ShardId shardId) {
-        return desiredAssignments.getOrDefault(shardId, Set.of());
-    }
+public record DesiredBalance(long lastConvergedIndex, Map<ShardId, ShardAssignment> assignments) {
 
-    public boolean isBalanceComputed(ShardId shardId) {
-        return desiredAssignments.containsKey(shardId) || unassigned.containsKey(shardId);
+    public ShardAssignment getAssignment(ShardId shardId) {
+        return assignments.get(shardId);
     }
 
     public static boolean areSame(DesiredBalance a, DesiredBalance b) {
-        return Objects.equals(a.desiredAssignments, b.desiredAssignments) && Objects.equals(a.unassigned, b.unassigned);
+        return Objects.equals(a.assignments, b.assignments);
     }
 }

--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/allocator/DesiredBalanceReconciler.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/allocator/DesiredBalanceReconciler.java
@@ -59,7 +59,7 @@ public class DesiredBalanceReconciler {
             // TODO test that we do this even if desired balance is empty
         }
 
-        if (desiredBalance.desiredAssignments().isEmpty() && desiredBalance.unassigned().isEmpty()) {
+        if (desiredBalance.assignments().isEmpty()) {
             // no desired state yet but it is on its way and we'll reroute again when it is ready
             logger.trace("desired balance is empty, nothing to reconcile");
             return;
@@ -186,49 +186,51 @@ public class DesiredBalanceReconciler {
         do {
             nextShard: for (int i = 0; i < primaryLength; i++) {
                 final var shard = primary[i];
-                final var desiredNodeIds = desiredBalance.getDesiredNodeIds(shard.shardId());
+                final var assignment = desiredBalance.getAssignment(shard.shardId());
                 var isThrottled = false;
-                for (final var desiredNodeId : desiredNodeIds) {
-                    final var routingNode = routingNodes.node(desiredNodeId);
-                    if (routingNode == null) {
-                        // desired node no longer exists
-                        continue;
-                    }
-
-                    final var canAllocateDecision = allocation.deciders().canAllocate(shard, routingNode, allocation);
-                    switch (canAllocateDecision.type()) {
-                        case YES -> {
-                            if (logger.isTraceEnabled()) {
-                                logger.trace("Assigned shard [{}] to [{}]", shard, desiredNodeId);
-                            }
-                            final long shardSize = DiskThresholdDecider.getExpectedShardSize(
-                                shard,
-                                ShardRouting.UNAVAILABLE_EXPECTED_SHARD_SIZE,
-                                allocation.clusterInfo(),
-                                allocation.snapshotShardSizeInfo(),
-                                allocation.metadata(),
-                                allocation.routingTable()
-                            );
-                            routingNodes.initializeShard(shard, desiredNodeId, null, shardSize, allocation.changes());
-                            if (shard.primary() == false) {
-                                // copy over the same replica shards to the secondary array so they will get allocated
-                                // in a subsequent iteration, allowing replicas of other shards to be allocated first
-                                while (i < primaryLength - 1 && comparator.compare(primary[i], primary[i + 1]) == 0) {
-                                    secondary[secondaryLength++] = primary[++i];
-                                }
-                            }
-                            continue nextShard;
+                if (assignment != null) {
+                    for (final var desiredNodeId : assignment.nodeIds()) {
+                        final var routingNode = routingNodes.node(desiredNodeId);
+                        if (routingNode == null) {
+                            // desired node no longer exists
+                            continue;
                         }
-                        case THROTTLE -> isThrottled = true;
+
+                        final var canAllocateDecision = allocation.deciders().canAllocate(shard, routingNode, allocation);
+                        switch (canAllocateDecision.type()) {
+                            case YES -> {
+                                if (logger.isTraceEnabled()) {
+                                    logger.trace("Assigned shard [{}] to [{}]", shard, desiredNodeId);
+                                }
+                                final long shardSize = DiskThresholdDecider.getExpectedShardSize(
+                                    shard,
+                                    ShardRouting.UNAVAILABLE_EXPECTED_SHARD_SIZE,
+                                    allocation.clusterInfo(),
+                                    allocation.snapshotShardSizeInfo(),
+                                    allocation.metadata(),
+                                    allocation.routingTable()
+                                );
+                                routingNodes.initializeShard(shard, desiredNodeId, null, shardSize, allocation.changes());
+                                if (shard.primary() == false) {
+                                    // copy over the same replica shards to the secondary array so they will get allocated
+                                    // in a subsequent iteration, allowing replicas of other shards to be allocated first
+                                    while (i < primaryLength - 1 && comparator.compare(primary[i], primary[i + 1]) == 0) {
+                                        secondary[secondaryLength++] = primary[++i];
+                                    }
+                                }
+                                continue nextShard;
+                            }
+                            case THROTTLE -> isThrottled = true;
+                        }
                     }
                 }
 
                 if (logger.isTraceEnabled()) {
-                    logger.trace("No eligible node found to assign shard [{}] amongst [{}]", shard, desiredNodeIds);
+                    logger.trace("No eligible node found to assign shard [{}] amongst [{}]", shard, assignment);
                 }
 
                 final UnassignedInfo.AllocationStatus allocationStatus;
-                if (desiredBalance.isBalanceComputed(shard.shardId()) == false) {
+                if (assignment == null) {
                     allocationStatus = UnassignedInfo.AllocationStatus.NO_ATTEMPT;
                 } else if (isThrottled) {
                     allocationStatus = UnassignedInfo.AllocationStatus.DECIDERS_THROTTLED;
@@ -264,8 +266,13 @@ public class DesiredBalanceReconciler {
                 continue;
             }
 
-            final var desiredNodeIds = desiredBalance.getDesiredNodeIds(shardRouting.shardId());
-            if (desiredNodeIds.contains(shardRouting.currentNodeId())) {
+            final var assignment = desiredBalance.getAssignment(shardRouting.shardId());
+            if (assignment == null) {
+                // balance is not computed
+                continue;
+            }
+
+            if (assignment.nodeIds().contains(shardRouting.currentNodeId())) {
                 // shard is already on a desired node
                 continue;
             }
@@ -283,7 +290,7 @@ public class DesiredBalanceReconciler {
                 continue;
             }
 
-            final var moveTarget = findRelocationTarget(shardRouting, desiredNodeIds);
+            final var moveTarget = findRelocationTarget(shardRouting, assignment.nodeIds());
             if (moveTarget != null) {
                 routingNodes.relocateShard(
                     shardRouting,
@@ -311,8 +318,13 @@ public class DesiredBalanceReconciler {
                 continue;
             }
 
-            final var desiredNodeIds = desiredBalance.getDesiredNodeIds(shardRouting.shardId());
-            if (desiredNodeIds.contains(shardRouting.currentNodeId())) {
+            final var assignment = desiredBalance.getAssignment(shardRouting.shardId());
+            if (assignment == null) {
+                // balance is not computed
+                continue;
+            }
+
+            if (assignment.nodeIds().contains(shardRouting.currentNodeId())) {
                 // shard is already on a desired node
                 continue;
             }
@@ -327,7 +339,7 @@ public class DesiredBalanceReconciler {
                 continue;
             }
 
-            final var rebalanceTarget = findRelocationTarget(shardRouting, desiredNodeIds, this::decideCanAllocate);
+            final var rebalanceTarget = findRelocationTarget(shardRouting, assignment.nodeIds(), this::decideCanAllocate);
             if (rebalanceTarget != null) {
                 routingNodes.relocateShard(
                     shardRouting,

--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/allocator/DesiredBalanceShardsAllocator.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/allocator/DesiredBalanceShardsAllocator.java
@@ -168,8 +168,8 @@ public class DesiredBalanceShardsAllocator implements ShardsAllocator, ClusterSt
 
     @Override
     public void clusterChanged(ClusterChangedEvent event) {
-        logger.trace("Executing listeners up to [{}] after cluster state was committed", lastConvergedIndex);
         if (event.state().nodes().isLocalNodeElectedMaster()) {
+            logger.trace("Executing listeners up to [{}] after cluster state was committed", lastConvergedIndex);
             executeListeners(lastConvergedIndex, true);
         } else {
             lastConvergedIndex = -1;

--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/allocator/ShardAssignment.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/allocator/ShardAssignment.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.cluster.routing.allocation.allocator;
+
+import org.elasticsearch.cluster.routing.ShardRouting;
+
+import java.util.List;
+import java.util.Set;
+
+import static java.util.stream.Collectors.toUnmodifiableSet;
+
+public record ShardAssignment(Set<String> nodeIds, int unassigned) {
+
+    public static ShardAssignment of(List<ShardRouting> routings) {
+        return new ShardAssignment(routings.stream().map(ShardRouting::currentNodeId).collect(toUnmodifiableSet()), 0);
+    }
+
+    public static ShardAssignment merge(ShardAssignment a, ShardAssignment b) {
+        return new ShardAssignment(a.nodeIds.isEmpty() ? b.nodeIds : a.nodeIds, a.unassigned + b.unassigned);
+    }
+
+    public static ShardAssignment UNASSIGNED = new ShardAssignment(Set.of(), 1);
+}

--- a/server/src/test/java/org/elasticsearch/cluster/routing/allocation/allocator/DesiredBalanceReconcilerTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/allocation/allocator/DesiredBalanceReconcilerTests.java
@@ -97,7 +97,7 @@ public class DesiredBalanceReconcilerTests extends ESTestCase {
             0L
         );
 
-        reconcile(routingAllocation, new DesiredBalance(1, Map.of(), Map.of()));
+        reconcile(routingAllocation, new DesiredBalance(1, Map.of()));
         assertFalse(routingAllocation.routingNodesChanged());
     }
 
@@ -175,9 +175,8 @@ public class DesiredBalanceReconcilerTests extends ESTestCase {
                     ? Map.of()
                     : Map.of(
                         new ShardId(clusterState.metadata().index(DesiredBalanceServiceTests.TEST_INDEX).getIndex(), 0),
-                        Set.of("node-0")
-                    ),
-                Map.of()
+                        new ShardAssignment(Set.of("node-0"), 0)
+                    )
             )
         );
         assertTrue(routingAllocation.routingNodesChanged());
@@ -540,11 +539,11 @@ public class DesiredBalanceReconcilerTests extends ESTestCase {
                         assertTrue(shardRouting.unassigned());
                     }
                 }
-                assertTrue(desiredBalance.getDesiredNodeIds(indexShardRoutingTable.shardId()).containsAll(nodeIds));
+                assertTrue(desiredBalance.getAssignment(indexShardRoutingTable.shardId()).nodeIds().containsAll(nodeIds));
             }
         }
 
-        assertNotEquals(anyAssigned, desiredBalance.desiredAssignments().values().stream().allMatch(Set::isEmpty));
+        assertNotEquals(anyAssigned, desiredBalance.assignments().values().stream().map(ShardAssignment::nodeIds).allMatch(Set::isEmpty));
     }
 
     public void testUnassignedAllocationPredictsDiskUsage() {
@@ -1027,10 +1026,9 @@ public class DesiredBalanceReconcilerTests extends ESTestCase {
                             .stream()
                             .map(DiscoveryNode::getId)
                             .filter(nodeId -> isDesiredPredicate.test(indexShardRoutingTable.shardId(), nodeId))
-                            .collect(Collectors.toSet())
+                            .collect(Collectors.collectingAndThen(Collectors.toSet(), set -> new ShardAssignment(set, 0)))
                     )
-                ),
-            Map.of()
+                )
         );
     }
 


### PR DESCRIPTION
This change combines shard assignments and number of unassigned shards into a single record so that it is easier to compute and log the difference when tracing.