### PR TITLE
[8.3] Fix Geotile aggregations on geo_shapes for precision 0   (#87202)

### DIFF
--- a/docs/changelog/87202.yaml
+++ b/docs/changelog/87202.yaml
@@ -1,0 +1,6 @@
+pr: 87202
+summary: Fix Geotile aggregations on `geo_shapes` for precision 0
+area: Geo
+type: bug
+issues:
+ - 87201

--- a/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/search/aggregations/bucket/geogrid/AbstractGeoTileGridTiler.java
+++ b/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/search/aggregations/bucket/geogrid/AbstractGeoTileGridTiler.java
@@ -58,7 +58,7 @@ abstract class AbstractGeoTileGridTiler extends GeoGridTiler {
         }
 
         if (precision == 0) {
-            return validTile(0, 0, 0) ? 1 : 0;
+            return setValuesByBruteForceScan(values, geoValue, 0, 0, 0, 0);
         }
 
         final int minXTile = GeoTileUtils.getXTile(bounds.minX(), tiles);

--- a/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/search/aggregations/bucket/geogrid/GeoTileTilerTests.java
+++ b/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/search/aggregations/bucket/geogrid/GeoTileTilerTests.java
@@ -16,6 +16,7 @@ import org.elasticsearch.common.geo.GeometryNormalizer;
 import org.elasticsearch.common.geo.Orientation;
 import org.elasticsearch.geo.GeometryTestUtils;
 import org.elasticsearch.geometry.Geometry;
+import org.elasticsearch.geometry.MultiPoint;
 import org.elasticsearch.geometry.Point;
 import org.elasticsearch.geometry.Rectangle;
 import org.elasticsearch.search.aggregations.bucket.geogrid.GeoTileBoundedPredicate;
@@ -26,6 +27,7 @@ import org.elasticsearch.xpack.spatial.index.query.GeoGridQueryBuilder;
 
 import java.io.IOException;
 import java.util.Arrays;
+import java.util.List;
 
 import static org.elasticsearch.search.aggregations.bucket.geogrid.GeoTileUtils.LATITUDE_MASK;
 import static org.elasticsearch.search.aggregations.bucket.geogrid.GeoTileUtils.longEncodeTiles;
@@ -283,5 +285,17 @@ public class GeoTileTilerTests extends GeoGridTilerTestCase {
             long pointHash = GeoTileUtils.longEncode(encodeDecodeLon(point.getX()), encodeDecodeLat(point.getY()), precision);
             assertThat(tilerHash, equalTo(pointHash));
         }
+    }
+
+    public void testMultiPointOutOfBounds() throws Exception {
+        final double maxLat = randomDoubleBetween(GeoTileUtils.NORMALIZED_LATITUDE_MASK, 90, false);
+        final double minLat = randomDoubleBetween(-90, Math.nextDown(GeoTileUtils.NORMALIZED_NEGATIVE_LATITUDE_MASK), true);
+        // points are out of bounds, should not generate any bucket
+        MultiPoint points = new MultiPoint(List.of(new Point(0, maxLat), new Point(0, minLat)));
+        final GeoShapeValues.GeoShapeValue value = geoShapeValue(points);
+        final GeoGridTiler tiler = getUnboundedGridTiler(0);
+        final GeoShapeCellValues values = new GeoShapeCellValues(makeGeoShapeValues(value), tiler, NOOP_BREAKER);
+        assertTrue(values.advanceExact(0));
+        assertThat(values.docValueCount(), equalTo(0));
     }
 }


### PR DESCRIPTION
Backports the following commits to 8.3:
 - Fix Geotile aggregations on geo_shapes for precision 0   (#87202)