### PR TITLE
Use Map in indices responses

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/aliases/IndexAliasesIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/aliases/IndexAliasesIT.java
@@ -62,7 +62,6 @@ import static org.elasticsearch.cluster.metadata.IndexMetadata.SETTING_BLOCKS_WR
 import static org.elasticsearch.cluster.metadata.IndexMetadata.SETTING_READ_ONLY;
 import static org.elasticsearch.index.query.QueryBuilders.rangeQuery;
 import static org.elasticsearch.index.query.QueryBuilders.termQuery;
-import static org.elasticsearch.test.hamcrest.CollectionAssertions.hasKey;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertBlocked;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertHitCount;
@@ -71,6 +70,7 @@ import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.emptyArray;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasKey;
 import static org.hamcrest.Matchers.lessThan;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/alias/get/GetAliasesResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/alias/get/GetAliasesResponse.java
@@ -11,7 +11,6 @@ package org.elasticsearch.action.admin.indices.alias.get;
 import org.elasticsearch.action.ActionResponse;
 import org.elasticsearch.cluster.metadata.AliasMetadata;
 import org.elasticsearch.cluster.metadata.DataStreamAlias;
-import org.elasticsearch.common.collect.ImmutableOpenMap;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 
@@ -22,10 +21,10 @@ import java.util.Objects;
 
 public class GetAliasesResponse extends ActionResponse {
 
-    private final ImmutableOpenMap<String, List<AliasMetadata>> aliases;
+    private final Map<String, List<AliasMetadata>> aliases;
     private final Map<String, List<DataStreamAlias>> dataStreamAliases;
 
-    public GetAliasesResponse(ImmutableOpenMap<String, List<AliasMetadata>> aliases, Map<String, List<DataStreamAlias>> dataStreamAliases) {
+    public GetAliasesResponse(Map<String, List<AliasMetadata>> aliases, Map<String, List<DataStreamAlias>> dataStreamAliases) {
         this.aliases = aliases;
         this.dataStreamAliases = dataStreamAliases;
     }
@@ -36,7 +35,7 @@ public class GetAliasesResponse extends ActionResponse {
         dataStreamAliases = in.readMap(StreamInput::readString, in1 -> in1.readList(DataStreamAlias::new));
     }
 
-    public ImmutableOpenMap<String, List<AliasMetadata>> getAliases() {
+    public Map<String, List<AliasMetadata>> getAliases() {
         return aliases;
     }
 

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/settings/get/GetSettingsResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/settings/get/GetSettingsResponse.java
@@ -10,7 +10,6 @@ package org.elasticsearch.action.admin.indices.settings.get;
 
 import org.elasticsearch.action.ActionResponse;
 import org.elasticsearch.common.Strings;
-import org.elasticsearch.common.collect.ImmutableOpenMap;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.settings.Settings;
@@ -29,21 +28,18 @@ import java.util.Objects;
 
 public class GetSettingsResponse extends ActionResponse implements ToXContentObject {
 
-    private final ImmutableOpenMap<String, Settings> indexToSettings;
-    private final ImmutableOpenMap<String, Settings> indexToDefaultSettings;
+    private final Map<String, Settings> indexToSettings;
+    private final Map<String, Settings> indexToDefaultSettings;
 
-    public GetSettingsResponse(
-        ImmutableOpenMap<String, Settings> indexToSettings,
-        ImmutableOpenMap<String, Settings> indexToDefaultSettings
-    ) {
+    public GetSettingsResponse(Map<String, Settings> indexToSettings, Map<String, Settings> indexToDefaultSettings) {
         this.indexToSettings = indexToSettings;
         this.indexToDefaultSettings = indexToDefaultSettings;
     }
 
     public GetSettingsResponse(StreamInput in) throws IOException {
         super(in);
-        indexToSettings = in.readImmutableOpenMap(StreamInput::readString, Settings::readSettingsFromStream);
-        indexToDefaultSettings = in.readImmutableOpenMap(StreamInput::readString, Settings::readSettingsFromStream);
+        indexToSettings = in.readImmutableMap(StreamInput::readString, Settings::readSettingsFromStream);
+        indexToDefaultSettings = in.readImmutableMap(StreamInput::readString, Settings::readSettingsFromStream);
     }
 
     /**
@@ -51,7 +47,7 @@ public class GetSettingsResponse extends ActionResponse implements ToXContentObj
      * objects contain only those settings explicitly set on a given index.  Any settings
      * taking effect as defaults must be accessed via {@link #getIndexToDefaultSettings()}.
      */
-    public ImmutableOpenMap<String, Settings> getIndexToSettings() {
+    public Map<String, Settings> getIndexToSettings() {
         return indexToSettings;
     }
 
@@ -63,7 +59,7 @@ public class GetSettingsResponse extends ActionResponse implements ToXContentObj
      * via {@link #getIndexToSettings()}.
      * See also {@link GetSettingsRequest#includeDefaults(boolean)}
      */
-    public ImmutableOpenMap<String, Settings> getIndexToDefaultSettings() {
+    public Map<String, Settings> getIndexToDefaultSettings() {
         return indexToDefaultSettings;
     }
 
@@ -150,14 +146,7 @@ public class GetSettingsResponse extends ActionResponse implements ToXContentObj
             }
         }
 
-        ImmutableOpenMap<String, Settings> settingsMap = ImmutableOpenMap.<String, Settings>builder()
-            .putAllFromMap(indexToSettings)
-            .build();
-        ImmutableOpenMap<String, Settings> defaultSettingsMap = ImmutableOpenMap.<String, Settings>builder()
-            .putAllFromMap(indexToDefaultSettings)
-            .build();
-
-        return new GetSettingsResponse(settingsMap, defaultSettingsMap);
+        return new GetSettingsResponse(Map.copyOf(indexToSettings), Map.copyOf(indexToDefaultSettings));
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/rest/action/admin/indices/RestGetAliasesAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/admin/indices/RestGetAliasesAction.java
@@ -16,7 +16,6 @@ import org.elasticsearch.cluster.metadata.AliasMetadata;
 import org.elasticsearch.cluster.metadata.DataStreamAlias;
 import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.common.Strings;
-import org.elasticsearch.common.collect.ImmutableOpenMap;
 import org.elasticsearch.common.regex.Regex;
 import org.elasticsearch.common.xcontent.XContentHelper;
 import org.elasticsearch.rest.BaseRestHandler;
@@ -67,7 +66,7 @@ public class RestGetAliasesAction extends BaseRestHandler {
     static RestResponse buildRestResponse(
         boolean aliasesExplicitlyRequested,
         String[] requestedAliases,
-        ImmutableOpenMap<String, List<AliasMetadata>> responseAliasMap,
+        Map<String, List<AliasMetadata>> responseAliasMap,
         Map<String, List<DataStreamAlias>> dataStreamAliases,
         XContentBuilder builder
     ) throws Exception {

--- a/server/src/test/java/org/elasticsearch/action/admin/indices/alias/get/GetAliasesResponseTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/indices/alias/get/GetAliasesResponseTests.java
@@ -18,6 +18,7 @@ import org.elasticsearch.test.AbstractWireSerializingTestCase;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.function.Predicate;
 
@@ -41,7 +42,7 @@ public class GetAliasesResponseTests extends AbstractWireSerializingTestCase<Get
         );
     }
 
-    private static ImmutableOpenMap<String, List<AliasMetadata>> mutateAliases(ImmutableOpenMap<String, List<AliasMetadata>> aliases) {
+    private static Map<String, List<AliasMetadata>> mutateAliases(Map<String, List<AliasMetadata>> aliases) {
         if (aliases.isEmpty()) {
             return createIndicesAliasesMap(1, 3).build();
         }

--- a/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/MlInitializationServiceIT.java
+++ b/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/MlInitializationServiceIT.java
@@ -14,7 +14,6 @@ import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.cluster.metadata.AliasMetadata;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.service.ClusterService;
-import org.elasticsearch.common.collect.ImmutableOpenMap;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.concurrent.EsExecutors;
 import org.elasticsearch.index.query.QueryBuilders;
@@ -25,6 +24,7 @@ import org.elasticsearch.xpack.ml.MlInitializationService;
 import org.junit.Before;
 
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Stream;
 
 import static java.util.stream.Collectors.toList;
@@ -74,7 +74,7 @@ public class MlInitializationServiceIT extends MlNativeAutodetectIntegTestCase {
             createIndex(indexName, Settings.EMPTY);
         }
 
-        ImmutableOpenMap<String, Settings> indexToSettings = getIndexToSettingsMap(allIndexNames);
+        Map<String, Settings> indexToSettings = getIndexToSettingsMap(allIndexNames);
         for (String indexName : mlHiddenIndexNames) {
             assertThat(indexToSettings.get(indexName), is(notNullValue()));
         }
@@ -165,7 +165,7 @@ public class MlInitializationServiceIT extends MlNativeAutodetectIntegTestCase {
         mlInitializationService.onMaster();
         assertBusy(() -> assertTrue(mlInitializationService.areMlInternalIndicesHidden()));
 
-        ImmutableOpenMap<String, List<AliasMetadata>> indexToAliasesMap = getIndexToAliasesMap(mlHiddenIndexNames);
+        Map<String, List<AliasMetadata>> indexToAliasesMap = getIndexToAliasesMap(mlHiddenIndexNames);
         assertThat("Aliases were: " + indexToAliasesMap, indexToAliasesMap.size(), is(equalTo(5)));
         assertThat(
             indexToAliasesMap.get(".ml-anomalies-7"),
@@ -198,7 +198,7 @@ public class MlInitializationServiceIT extends MlNativeAutodetectIntegTestCase {
         );
     }
 
-    private static ImmutableOpenMap<String, Settings> getIndexToSettingsMap(List<String> indexNames) {
+    private static Map<String, Settings> getIndexToSettingsMap(List<String> indexNames) {
         GetSettingsResponse getSettingsResponse = client().admin()
             .indices()
             .prepareGetSettings()
@@ -209,7 +209,7 @@ public class MlInitializationServiceIT extends MlNativeAutodetectIntegTestCase {
         return getSettingsResponse.getIndexToSettings();
     }
 
-    private static ImmutableOpenMap<String, List<AliasMetadata>> getIndexToAliasesMap(List<String> indexNames) {
+    private static Map<String, List<AliasMetadata>> getIndexToAliasesMap(List<String> indexNames) {
         GetAliasesResponse getAliasesResponse = client().admin()
             .indices()
             .prepareGetAliases()

--- a/x-pack/plugin/ml/src/internalClusterTest/java/org/elasticsearch/xpack/ml/integration/AnnotationIndexIT.java
+++ b/x-pack/plugin/ml/src/internalClusterTest/java/org/elasticsearch/xpack/ml/integration/AnnotationIndexIT.java
@@ -21,7 +21,6 @@ import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.cluster.metadata.AliasMetadata;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.service.ClusterService;
-import org.elasticsearch.common.collect.ImmutableOpenMap;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.xpack.core.XPackSettings;
@@ -36,6 +35,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.is;
@@ -170,7 +170,7 @@ public class AnnotationIndexIT extends MlSingleNodeTestCase {
         // switched to only point at the new index.
         assertBusy(() -> {
             assertTrue(annotationsIndexExists(AnnotationIndex.LATEST_INDEX_NAME));
-            ImmutableOpenMap<String, List<AliasMetadata>> aliases = client().admin()
+            Map<String, List<AliasMetadata>> aliases = client().admin()
                 .indices()
                 .prepareGetAliases(AnnotationIndex.READ_ALIAS_NAME, AnnotationIndex.WRITE_ALIAS_NAME)
                 .setIndicesOptions(IndicesOptions.LENIENT_EXPAND_OPEN_CLOSED_HIDDEN)
@@ -253,7 +253,7 @@ public class AnnotationIndexIT extends MlSingleNodeTestCase {
 
     private int numberOfAnnotationsAliases() {
         int count = 0;
-        ImmutableOpenMap<String, List<AliasMetadata>> aliases = client().admin()
+        Map<String, List<AliasMetadata>> aliases = client().admin()
             .indices()
             .prepareGetAliases(AnnotationIndex.READ_ALIAS_NAME, AnnotationIndex.WRITE_ALIAS_NAME, AnnotationIndex.LATEST_INDEX_NAME)
             .setIndicesOptions(IndicesOptions.LENIENT_EXPAND_OPEN_CLOSED_HIDDEN)

--- a/x-pack/plugin/ml/src/internalClusterTest/java/org/elasticsearch/xpack/ml/integration/JobResultsProviderIT.java
+++ b/x-pack/plugin/ml/src/internalClusterTest/java/org/elasticsearch/xpack/ml/integration/JobResultsProviderIT.java
@@ -31,7 +31,6 @@ import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.cluster.service.MasterService;
 import org.elasticsearch.common.CheckedSupplier;
 import org.elasticsearch.common.Strings;
-import org.elasticsearch.common.collect.ImmutableOpenMap;
 import org.elasticsearch.common.settings.ClusterSettings;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.core.TimeValue;
@@ -526,7 +525,7 @@ public class JobResultsProviderIT extends MlSingleNodeTestCase {
 
     private Set<String> getAliases(String index) {
         GetAliasesResponse getAliasesResponse = client().admin().indices().getAliases(new GetAliasesRequest().indices(index)).actionGet();
-        ImmutableOpenMap<String, List<AliasMetadata>> aliases = getAliasesResponse.getAliases();
+        Map<String, List<AliasMetadata>> aliases = getAliasesResponse.getAliases();
         assertThat(aliases.containsKey(index), is(true));
         List<AliasMetadata> aliasMetadataList = aliases.get(index);
         for (AliasMetadata aliasMetadata : aliasMetadataList) {

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/extractor/ExtractedFieldsDetectorFactory.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/extractor/ExtractedFieldsDetectorFactory.java
@@ -22,7 +22,6 @@ import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.client.internal.Client;
-import org.elasticsearch.common.collect.ImmutableOpenMap;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.index.IndexNotFoundException;
 import org.elasticsearch.index.IndexSettings;
@@ -186,7 +185,7 @@ public class ExtractedFieldsDetectorFactory {
         ActionListener<GetSettingsResponse> settingsListener = ActionListener.wrap(getSettingsResponse -> {
             Integer minDocValueFieldsLimit = Integer.MAX_VALUE;
 
-            ImmutableOpenMap<String, Settings> indexToSettings = getSettingsResponse.getIndexToSettings();
+            Map<String, Settings> indexToSettings = getSettingsResponse.getIndexToSettings();
             for (var indexSettings : indexToSettings.values()) {
                 Integer indexMaxDocValueFields = IndexSettings.MAX_DOCVALUE_FIELDS_SEARCH_SETTING.get(indexSettings);
                 if (indexMaxDocValueFields < minDocValueFieldsLimit) {

--- a/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/index/IndexResolver.java
+++ b/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/index/IndexResolver.java
@@ -21,7 +21,6 @@ import org.elasticsearch.action.support.IndicesOptions.WildcardStates;
 import org.elasticsearch.client.internal.Client;
 import org.elasticsearch.cluster.metadata.AliasMetadata;
 import org.elasticsearch.common.Strings;
-import org.elasticsearch.common.collect.ImmutableOpenMap;
 import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.core.Tuple;
 import org.elasticsearch.index.IndexNotFoundException;
@@ -618,7 +617,7 @@ public class IndexResolver {
         DataTypeRegistry typeRegistry,
         String javaRegex,
         FieldCapabilitiesResponse fieldCaps,
-        ImmutableOpenMap<String, List<AliasMetadata>> aliases
+        Map<String, List<AliasMetadata>> aliases
     ) {
         return buildIndices(typeRegistry, javaRegex, fieldCaps, aliases, Function.identity(), (s, cap) -> null);
     }
@@ -636,7 +635,7 @@ public class IndexResolver {
         DataTypeRegistry typeRegistry,
         String javaRegex,
         FieldCapabilitiesResponse fieldCapsResponse,
-        ImmutableOpenMap<String, List<AliasMetadata>> aliases,
+        Map<String, List<AliasMetadata>> aliases,
         Function<String, String> indexNameProcessor,
         BiFunction<String, Map<String, FieldCapabilities>, InvalidMappedField> validityVerifier
     ) {
@@ -820,7 +819,7 @@ public class IndexResolver {
     private static Map<String, InvalidMappedField> getInvalidFieldsForAliases(
         String fieldName,
         Map<String, FieldCapabilities> types,
-        ImmutableOpenMap<String, List<AliasMetadata>> aliases
+        Map<String, List<AliasMetadata>> aliases
     ) {
         if (aliases == null || aliases.isEmpty()) {
             return emptyMap();


### PR DESCRIPTION
This commit converts GetAliasesResponse and GetSettingsResponse to use
Map instead of ImmutableOpenMap.

relates #86239