### PR TITLE
Allow cluster start with unreachable remote clusters

### DIFF
--- a/docs/changelog/87298.yaml
+++ b/docs/changelog/87298.yaml
@@ -1,0 +1,5 @@
+pr: 87298
+summary: Allow start cluster with unreachable remote clusters
+area: Network
+type: enhancement
+issues: []

--- a/server/src/main/java/org/elasticsearch/transport/RemoteClusterService.java
+++ b/server/src/main/java/org/elasticsearch/transport/RemoteClusterService.java
@@ -349,7 +349,7 @@ public final class RemoteClusterService extends RemoteClusterAware implements Cl
         } catch (TimeoutException ex) {
             logger.warn("failed to connect to remote clusters within {}", timeValue.toString());
         } catch (Exception e) {
-            throw new IllegalStateException("failed to connect to remote clusters", e);
+            logger.warn("failed to connect to remote clusters", e);
         }
     }
 


### PR DESCRIPTION
If the local cluster has a remote_cluster setting defined in YAML file and the remote cluster is not reachable, then the local cluster won't start. This PR relaxes that constraint as it's too restricted and requires manual intervene.

I hit this constraint while setting two clusters using Rally.