### PR TITLE
[DOCS] Remove the sentence on deleting document in .tasks

### DIFF
--- a/docs/reference/docs/reindex.asciidoc
+++ b/docs/reference/docs/reindex.asciidoc
@@ -141,8 +141,6 @@ If the request contains `wait_for_completion=false`, {es}
 performs some preflight checks, launches the request, and returns a
 <<tasks,`task`>> you can use to cancel or get the status of the task.
 {es} creates a record of this task as a document at `_tasks/<task_id>`.
-When you are done with a task, you should delete the task document so
-{es} can reclaim the space.
 
 [[docs-reindex-from-multiple-sources]]
 ===== Reindex from multiple sources

--- a/docs/reference/docs/update-by-query.asciidoc
+++ b/docs/reference/docs/update-by-query.asciidoc
@@ -99,8 +99,6 @@ If the request contains `wait_for_completion=false`, {es}
 performs some preflight checks, launches the request, and returns a
 <<tasks,`task`>> you can use to cancel or get the status of the task.
 {es} creates a record of this task as a document at `.tasks/task/${taskId}`.
-When you are done with a task, you should delete the task document so
-{es} can reclaim the space.
 
 ===== Waiting for active shards
 


### PR DESCRIPTION
Before 8.0, one should run`DELETE .tasks/_doc/<node_id>:<task_id>` to reclaim the space. 
e restriction on system indices are tightened since 8.0, deleting old documents from `.tasks` is no longer possible. See 
https://github.com/elastic/elasticsearch/issues/77383

This PR only updates the documentation by removing the following sentence to avoid confusion, the automatic mechanism is still to be implemented.
~When you are done with a task, you should delete the task document so Elasticsearch can reclaim the space.~

