### PR TITLE
Remove static access to version properties

### DIFF
--- a/build-conventions/src/main/java/org/elasticsearch/gradle/internal/conventions/VersionInfo.java
+++ b/build-conventions/src/main/java/org/elasticsearch/gradle/internal/conventions/VersionInfo.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.gradle.internal.conventions;
+
+import groovy.lang.GroovyObject;
+import groovy.lang.MetaClass;
+
+import java.util.Properties;
+
+public class VersionInfo {
+    private final String elasticsearch;
+    private final String lucene;
+    private final String bundledJdkVendor;
+    private final String bundledJdkVersion;
+    private Properties properties;
+    private MetaClass metaClass;
+
+    public VersionInfo(Properties properties) {
+        elasticsearch = properties.getProperty("elasticsearch");
+        lucene = properties.getProperty("lucene");
+        bundledJdkVendor = properties.getProperty("bundled_jdk_vendor");
+        bundledJdkVersion = properties.getProperty("bundled_jdk");
+        this.properties = properties;
+    }
+
+    public String getElasticsearch() {
+        return elasticsearch;
+    }
+
+    public String getLucene() {
+        return lucene;
+    }
+
+    public String getBundledJdkVendor() {
+        return bundledJdkVendor;
+    }
+
+    public String getBundledJdkVersion() {
+        return bundledJdkVersion;
+    }
+    public boolean isElasticsearchSnapshot() {
+        return getElasticsearch().endsWith("-SNAPSHOT");
+    }
+
+    public Object get(Object key) {
+        return properties.getProperty(key.toString());
+    }
+
+    public Object propertyMissing(String name) {
+        return getProperty(name);
+    }
+
+    public String getProperty(String key) {
+        return properties.getProperty(key);
+    }
+
+    public Properties getProperties() {
+        return properties;
+    }
+}

--- a/build-conventions/src/main/java/org/elasticsearch/gradle/internal/conventions/VersionInfo.java
+++ b/build-conventions/src/main/java/org/elasticsearch/gradle/internal/conventions/VersionInfo.java
@@ -48,7 +48,7 @@ public class VersionInfo {
         return getElasticsearch().endsWith("-SNAPSHOT");
     }
 
-    public Object get(Object key) {
+    public String get(Object key) {
         return properties.getProperty(key.toString());
     }
 

--- a/build-conventions/src/main/java/org/elasticsearch/gradle/internal/conventions/VersionPropertiesPlugin.java
+++ b/build-conventions/src/main/java/org/elasticsearch/gradle/internal/conventions/VersionPropertiesPlugin.java
@@ -16,6 +16,8 @@ import java.io.File;
 
 public class VersionPropertiesPlugin implements Plugin<Project> {
 
+    private VersionInfo versionInfo;
+
     @Override
     public void apply(Project project) {
         File workspaceDir;
@@ -32,6 +34,13 @@ public class VersionPropertiesPlugin implements Plugin<Project> {
                 .registerIfAbsent("versions", VersionPropertiesBuildService.class, spec -> {
             spec.getParameters().getInfoPath().set(infoPath);
         });
-        project.getExtensions().add("versions", serviceProvider.get().getProperties());
+        VersionPropertiesBuildService versionPropertiesBuildService = serviceProvider.get();
+        versionInfo = versionPropertiesBuildService.getVersionInfo();
+        project.getExtensions().add("versions", versionInfo);
+        project.setVersion(versionInfo.getElasticsearch());
+    }
+
+    public VersionInfo getVersionInfo() {
+        return versionInfo;
     }
 }

--- a/build-tools-internal/build.gradle
+++ b/build-tools-internal/build.gradle
@@ -24,7 +24,7 @@ group = 'org.elasticsearch.gradle'
 // we update the version property to reflect if we are building a snapshot or a release build
 // we write this back out below to load it in the Build.java which will be shown in rest main action
 // to indicate this being a snapshot build or a release build.
-version = versions.getProperty("elasticsearch")
+version = versions.elasticsearch
 
 gradlePlugin {
   // We already configure publication and we don't need or want the one that comes

--- a/build-tools-internal/src/main/groovy/elasticsearch.base.gradle
+++ b/build-tools-internal/src/main/groovy/elasticsearch.base.gradle
@@ -7,8 +7,11 @@
  */
 
 import org.elasticsearch.gradle.VersionProperties
+import org.elasticsearch.gradle.Version
+import org.elasticsearch.gradle.internal.conventions.VersionPropertiesPlugin
 
 project.setDescription("Elasticsearch subproject " + project.getPath());
 // common maven publishing configuration
-project.setGroup("org.elasticsearch");
-project.setVersion(VersionProperties.getElasticsearch())
+project.setGroup("org.elasticsearch")
+def apply = project.getPlugins().apply(VersionPropertiesPlugin)
+ext.elasticsearchVersion = Version.fromString(apply.versionInfo.elasticsearch)

--- a/build-tools-internal/src/main/groovy/elasticsearch.base.gradle
+++ b/build-tools-internal/src/main/groovy/elasticsearch.base.gradle
@@ -6,7 +6,6 @@
  * Side Public License, v 1.
  */
 
-import org.elasticsearch.gradle.VersionProperties
 import org.elasticsearch.gradle.Version
 import org.elasticsearch.gradle.internal.conventions.VersionPropertiesPlugin
 

--- a/build-tools-internal/src/main/groovy/elasticsearch.local-distribution.gradle
+++ b/build-tools-internal/src/main/groovy/elasticsearch.local-distribution.gradle
@@ -13,7 +13,6 @@
  * build/distributions/local
  * */
 import org.elasticsearch.gradle.Architecture
-import org.elasticsearch.gradle.VersionProperties
 
 // gradle has an open issue of failing applying plugins in
 // precompiled script plugins (see https://github.com/gradle/gradle/issues/17004)
@@ -30,6 +29,6 @@ tasks.register('localDistro', Sync) {
   from(elasticsearch_distributions.local)
   into("build/distribution/local")
   doLast {
-    logger.lifecycle("Elasticsearch distribution installed to ${destinationDir}/elasticsearch-${VersionProperties.elasticsearch}")
+    logger.lifecycle("Elasticsearch distribution installed to ${destinationDir}/elasticsearch-${project.version}")
   }
 }

--- a/build-tools-internal/src/main/groovy/elasticsearch.run.gradle
+++ b/build-tools-internal/src/main/groovy/elasticsearch.run.gradle
@@ -6,7 +6,6 @@
  * Side Public License, v 1.
  */
 
-import org.elasticsearch.gradle.VersionProperties
 import org.elasticsearch.gradle.testclusters.RunTask
 
 // gradle has an open issue of failing applying plugins in

--- a/build-tools-internal/src/main/groovy/elasticsearch.runtime-jdk-provision.gradle
+++ b/build-tools-internal/src/main/groovy/elasticsearch.runtime-jdk-provision.gradle
@@ -8,20 +8,18 @@
 
 import org.elasticsearch.gradle.Architecture
 import org.elasticsearch.gradle.OS
-import org.elasticsearch.gradle.VersionProperties
 import org.elasticsearch.gradle.internal.info.BuildParams
 
 // gradle has an open issue of failing applying plugins in
 // precompiled script plugins (see https://github.com/gradle/gradle/issues/17004)
 
-
-configure(allprojects) {
+configure(subprojects) {
     apply plugin: 'elasticsearch.jdk-download'
-
+    apply plugin: 'elasticsearch.versions'
     jdks {
         provisioned_runtime {
-            vendor = VersionProperties.bundledJdkVendor
-            version = VersionProperties.bundledJdkVersion
+            vendor = versions.bundledJdkVendor
+            version = versions.getBundledJdkVersion()
             platform = OS.current().name().toLowerCase()
             architecture = Architecture.current().name().toLowerCase()
         }
@@ -31,7 +29,7 @@ configure(allprojects) {
             test.executable = "${BuildParams.runtimeJavaHome}/bin/java"
         } else {
             test.dependsOn(project.jdks.provisioned_runtime)
-            test.executable = rootProject.jdks.provisioned_runtime.getBinJavaPath()
+            test.executable = project.jdks.provisioned_runtime.getBinJavaPath()
         }
     }
     project.plugins.withId("elasticsearch.testclusters") { testClustersPlugin ->

--- a/build-tools-internal/src/main/groovy/org/elasticsearch/gradle/internal/doc/DocsTestPlugin.groovy
+++ b/build-tools-internal/src/main/groovy/org/elasticsearch/gradle/internal/doc/DocsTestPlugin.groovy
@@ -9,9 +9,8 @@ package org.elasticsearch.gradle.internal.doc
 
 import org.elasticsearch.gradle.OS
 import org.elasticsearch.gradle.Version
-import org.elasticsearch.gradle.VersionProperties
-import org.elasticsearch.gradle.internal.test.rest.CopyRestApiTask
-import org.elasticsearch.gradle.internal.test.rest.CopyRestTestsTask
+import org.elasticsearch.gradle.internal.conventions.VersionInfo
+import org.elasticsearch.gradle.internal.conventions.VersionPropertiesPlugin
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.file.Directory
@@ -26,6 +25,8 @@ class DocsTestPlugin implements Plugin<Project> {
     @Override
     void apply(Project project) {
         project.pluginManager.apply('elasticsearch.internal-yaml-rest-test')
+        project.pluginManager.apply('elasticsearch.internal-yaml-rest-test')
+        VersionInfo versionInfo = project.getPlugins().apply(VersionPropertiesPlugin.class).getVersionInfo();
 
         String distribution = System.getProperty('tests.distribution', 'default')
         // The distribution can be configured with -Dtests.distribution on the command line
@@ -38,9 +39,9 @@ class DocsTestPlugin implements Plugin<Project> {
                  * the values may differ. In particular {version} needs to resolve
                  * to the version being built for testing but needs to resolve to
                  * the last released version for docs. */
-            '\\{version\\}': Version.fromString(VersionProperties.elasticsearch).toString(),
-            '\\{version_qualified\\}': VersionProperties.elasticsearch,
-            '\\{lucene_version\\}' : VersionProperties.lucene.replaceAll('-snapshot-\\w+$', ''),
+            '\\{version\\}': Version.fromString(versionInfo.elasticsearch).toString(),
+            '\\{version_qualified\\}': versionInfo.elasticsearch,
+            '\\{lucene_version\\}' : versionInfo.lucene.replaceAll('-snapshot-\\w+$', ''),
             '\\{build_flavor\\}' : distribution,
             '\\{build_type\\}' : OS.conditionalString().onWindows({"zip"}).onUnix({"tar"}).supply(),
         ]

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/BwcVersions.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/BwcVersions.java
@@ -10,7 +10,6 @@ package org.elasticsearch.gradle.internal;
 import org.elasticsearch.gradle.Architecture;
 import org.elasticsearch.gradle.ElasticsearchDistribution;
 import org.elasticsearch.gradle.Version;
-import org.elasticsearch.gradle.VersionProperties;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -72,10 +71,6 @@ public class BwcVersions {
     private final List<VersionPair> versions;
     private final Map<Version, UnreleasedVersionInfo> unreleased;
 
-    public BwcVersions(List<String> versionLines) {
-        this(versionLines, Version.fromString(VersionProperties.getElasticsearch()));
-    }
-
     public BwcVersions(Version currentVersionProperty, List<VersionPair> allVersions) {
         if (allVersions.isEmpty()) {
             throw new IllegalArgumentException("Could not parse any versions");
@@ -88,8 +83,7 @@ public class BwcVersions {
         this.unreleased = computeUnreleased();
     }
 
-    // Visible for testing
-    BwcVersions(List<String> versionLines, Version currentVersionProperty) {
+    public BwcVersions(List<String> versionLines, Version currentVersionProperty) {
         this(currentVersionProperty, parseVersionLines(versionLines));
     }
 

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/ElasticsearchJavaBasePlugin.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/ElasticsearchJavaBasePlugin.java
@@ -8,7 +8,6 @@
 
 package org.elasticsearch.gradle.internal;
 
-import org.elasticsearch.gradle.VersionProperties;
 import org.elasticsearch.gradle.internal.conventions.precommit.PrecommitTaskPlugin;
 import org.elasticsearch.gradle.internal.info.BuildParams;
 import org.elasticsearch.gradle.internal.info.GlobalBuildInfoPlugin;
@@ -47,9 +46,6 @@ public class ElasticsearchJavaBasePlugin implements Plugin<Project> {
         configureConfigurations(project);
         configureCompile(project);
         configureInputNormalization(project);
-
-        // convenience access to common versions used in dependencies
-        project.getExtensions().getExtraProperties().set("versions", VersionProperties.getVersions());
     }
 
     /**

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/ElasticsearchJavaPlugin.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/ElasticsearchJavaPlugin.java
@@ -12,7 +12,8 @@ import nebula.plugin.info.InfoBrokerPlugin;
 
 import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar;
 
-import org.elasticsearch.gradle.VersionProperties;
+import org.elasticsearch.gradle.internal.conventions.VersionInfo;
+import org.elasticsearch.gradle.internal.conventions.VersionPropertiesPlugin;
 import org.elasticsearch.gradle.internal.conventions.util.Util;
 import org.elasticsearch.gradle.internal.info.BuildParams;
 import org.gradle.api.Action;
@@ -103,13 +104,15 @@ public class ElasticsearchJavaPlugin implements Plugin<Project> {
 
     private static void configureJarManifest(Project project) {
         project.getPlugins().withType(InfoBrokerPlugin.class).whenPluginAdded(manifestPlugin -> {
+            VersionInfo versionInfo = project.getPlugins().apply(VersionPropertiesPlugin.class).getVersionInfo();
+
             manifestPlugin.add("Module-Origin", toStringable(BuildParams::getGitOrigin));
             manifestPlugin.add("Change", toStringable(BuildParams::getGitRevision));
-            manifestPlugin.add("X-Compile-Elasticsearch-Version", toStringable(VersionProperties::getElasticsearch));
-            manifestPlugin.add("X-Compile-Lucene-Version", toStringable(VersionProperties::getLucene));
+            manifestPlugin.add("X-Compile-Elasticsearch-Version", toStringable(versionInfo::getElasticsearch));
+            manifestPlugin.add("X-Compile-Lucene-Version", toStringable(versionInfo::getLucene));
             manifestPlugin.add(
                 "X-Compile-Elasticsearch-Snapshot",
-                toStringable(() -> Boolean.toString(VersionProperties.isElasticsearchSnapshot()))
+                toStringable(() -> Boolean.toString(versionInfo.isElasticsearchSnapshot()))
             );
         });
 

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/InternalDistributionArchiveCheckPlugin.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/InternalDistributionArchiveCheckPlugin.java
@@ -110,7 +110,7 @@ public class InternalDistributionArchiveCheckPlugin implements InternalPlugin {
                     final Path noticePath = checkExtraction.get()
                         .getDestinationDir()
                         .toPath()
-                        .resolve("elasticsearch-" + VersionProperties.getElasticsearch() + "/modules/x-pack-ml/NOTICE.txt");
+                        .resolve("elasticsearch-" + project.getVersion() + "/modules/x-pack-ml/NOTICE.txt");
                     final List<String> actualLines;
                     try {
                         actualLines = Files.readAllLines(noticePath);

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/InternalDistributionArchiveCheckPlugin.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/InternalDistributionArchiveCheckPlugin.java
@@ -8,7 +8,6 @@
 
 package org.elasticsearch.gradle.internal;
 
-import org.elasticsearch.gradle.VersionProperties;
 import org.elasticsearch.gradle.internal.conventions.GUtils;
 import org.elasticsearch.gradle.internal.conventions.LicensingPlugin;
 import org.gradle.api.Action;
@@ -54,8 +53,9 @@ public class InternalDistributionArchiveCheckPlugin implements InternalPlugin {
 
         // sanity checks if archives can be extracted
         TaskProvider<Copy> checkExtraction = registerCheckExtractionTask(project, buildDistTask, archiveExtractionDir);
-        TaskProvider<Task> checkLicense = registerCheckLicenseTask(project, checkExtraction);
-        TaskProvider<Task> checkNotice = registerCheckNoticeTask(project, checkExtraction);
+        String version = project.getVersion().toString();
+        TaskProvider<Task> checkLicense = registerCheckLicenseTask(project, version, checkExtraction);
+        TaskProvider<Task> checkNotice = registerCheckNoticeTask(project, version, checkExtraction);
         TaskProvider<Task> checkModulesTask = InternalDistributionModuleCheckTaskProvider.registerCheckModulesTask(
             project,
             checkExtraction
@@ -128,7 +128,7 @@ public class InternalDistributionArchiveCheckPlugin implements InternalPlugin {
         return checkMlCppNoticeTask;
     }
 
-    private TaskProvider<Task> registerCheckNoticeTask(Project project, TaskProvider<Copy> checkExtraction) {
+    private TaskProvider<Task> registerCheckNoticeTask(Project project, String version, TaskProvider<Copy> checkExtraction) {
         return project.getTasks().register("checkNotice", task -> {
             task.dependsOn(checkExtraction);
             task.doLast(new Action<Task>() {
@@ -138,14 +138,14 @@ public class InternalDistributionArchiveCheckPlugin implements InternalPlugin {
                     final Path noticePath = checkExtraction.get()
                         .getDestinationDir()
                         .toPath()
-                        .resolve("elasticsearch-" + VersionProperties.getElasticsearch() + "/NOTICE.txt");
+                        .resolve("elasticsearch-" + version + "/NOTICE.txt");
                     assertLinesInFile(noticePath, noticeLines);
                 }
             });
         });
     }
 
-    private TaskProvider<Task> registerCheckLicenseTask(Project project, TaskProvider<Copy> checkExtraction) {
+    private TaskProvider<Task> registerCheckLicenseTask(Project project, String version, TaskProvider<Copy> checkExtraction) {
         TaskProvider<Task> checkLicense = project.getTasks().register("checkLicense", task -> {
             task.dependsOn(checkExtraction);
             task.doLast(new Action<Task>() {
@@ -163,7 +163,7 @@ public class InternalDistributionArchiveCheckPlugin implements InternalPlugin {
                         final Path licensePath = checkExtraction.get()
                             .getDestinationDir()
                             .toPath()
-                            .resolve("elasticsearch-" + VersionProperties.getElasticsearch() + "/LICENSE.txt");
+                            .resolve("elasticsearch-" + version + "/LICENSE.txt");
                         assertLinesInFile(licensePath, licenseLines);
                     } catch (IOException ioException) {
                         ioException.printStackTrace();

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/InternalDistributionModuleCheckTaskProvider.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/InternalDistributionModuleCheckTaskProvider.java
@@ -8,7 +8,6 @@
 
 package org.elasticsearch.gradle.internal;
 
-import org.elasticsearch.gradle.VersionProperties;
 import org.gradle.api.Action;
 import org.gradle.api.GradleException;
 import org.gradle.api.Project;
@@ -76,13 +75,14 @@ public class InternalDistributionModuleCheckTaskProvider {
     static TaskProvider<Task> registerCheckModulesTask(Project project, TaskProvider<Copy> checkExtraction) {
         return project.getTasks().register("checkModules", task -> {
             task.dependsOn(checkExtraction);
+            String version = project.getVersion().toString();
             task.doLast(new Action<Task>() {
                 @Override
                 public void execute(Task task) {
                     final Path libPath = checkExtraction.get()
                         .getDestinationDir()
                         .toPath()
-                        .resolve("elasticsearch-" + VersionProperties.getElasticsearch())
+                        .resolve("elasticsearch-" + version)
                         .resolve("lib");
                     try {
                         assertAllESJarsAreModular(libPath);

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/InternalTestClustersPlugin.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/InternalTestClustersPlugin.java
@@ -8,7 +8,7 @@
 
 package org.elasticsearch.gradle.internal;
 
-import org.elasticsearch.gradle.VersionProperties;
+import org.elasticsearch.gradle.Version;
 import org.elasticsearch.gradle.internal.info.BuildParams;
 import org.elasticsearch.gradle.testclusters.TestClustersPlugin;
 import org.gradle.api.Plugin;
@@ -32,8 +32,9 @@ public class InternalTestClustersPlugin implements Plugin<Project> {
         project.getRootProject().getPluginManager().apply(InternalReaperPlugin.class);
         TestClustersPlugin testClustersPlugin = project.getPlugins().apply(TestClustersPlugin.class);
         testClustersPlugin.setRuntimeJava(providerFactory.provider(() -> BuildParams.getRuntimeJavaHome()));
+        Version elasticsearchVersion = Version.fromString(project.getVersion().toString());
         testClustersPlugin.setIsReleasedVersion(
-            version -> (version.equals(VersionProperties.getElasticsearchVersion()) && BuildParams.isSnapshotBuild() == false)
+            version -> (version.equals(elasticsearchVersion) && BuildParams.isSnapshotBuild() == false)
                 || BuildParams.getBwcVersions().unreleasedInfo(version) == null
         );
     }

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/RepositoriesSetupPlugin.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/RepositoriesSetupPlugin.java
@@ -8,7 +8,8 @@
 
 package org.elasticsearch.gradle.internal;
 
-import org.elasticsearch.gradle.VersionProperties;
+import org.elasticsearch.gradle.internal.conventions.VersionInfo;
+import org.elasticsearch.gradle.internal.conventions.VersionPropertiesPlugin;
 import org.gradle.api.GradleException;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
@@ -24,13 +25,15 @@ public class RepositoriesSetupPlugin implements Plugin<Project> {
 
     @Override
     public void apply(Project project) {
-        configureRepositories(project);
+        VersionInfo versionInfo = project.getPlugins().apply(VersionPropertiesPlugin.class).getVersionInfo();
+
+        configureRepositories(project, versionInfo.getLucene());
     }
 
     /**
      * Adds repositories used by ES projects and dependencies
      */
-    public static void configureRepositories(Project project) {
+    public static void configureRepositories(Project project, String luceneVersion) {
         RepositoryHandler repos = project.getRepositories();
         if (System.getProperty("repos.mavenLocal") != null) {
             // with -Drepos.mavenLocal=true we can force checking the local .m2 repo which is
@@ -40,7 +43,6 @@ public class RepositoriesSetupPlugin implements Plugin<Project> {
         }
         repos.mavenCentral();
 
-        String luceneVersion = VersionProperties.getLucene();
         if (luceneVersion.contains("-snapshot")) {
             // extract the revision number from the version with a regex matcher
             Matcher matcher = LUCENE_SNAPSHOT_REGEX.matcher(luceneVersion);

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/precommit/CheckstylePrecommitPlugin.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/precommit/CheckstylePrecommitPlugin.java
@@ -8,8 +8,9 @@
 
 package org.elasticsearch.gradle.internal.precommit;
 
-import org.elasticsearch.gradle.VersionProperties;
 import org.elasticsearch.gradle.internal.InternalPlugin;
+import org.elasticsearch.gradle.internal.conventions.VersionInfo;
+import org.elasticsearch.gradle.internal.conventions.VersionPropertiesPlugin;
 import org.elasticsearch.gradle.internal.conventions.precommit.PrecommitPlugin;
 import org.gradle.api.Action;
 import org.gradle.api.Project;
@@ -33,6 +34,8 @@ import java.nio.file.StandardCopyOption;
 public class CheckstylePrecommitPlugin extends PrecommitPlugin implements InternalPlugin {
     @Override
     public TaskProvider<? extends Task> createTask(Project project) {
+        VersionInfo versionInfo = project.getPlugins().apply(VersionPropertiesPlugin.class).getVersionInfo();
+
         // Always copy the checkstyle configuration files to 'buildDir/checkstyle' since the resources could be located in a jar
         // file. If the resources are located in a jar, Gradle will fail when it tries to turn the URL into a file
         URL checkstyleConfUrl = CheckstylePrecommitPlugin.class.getResource("/checkstyle.xml");
@@ -85,7 +88,7 @@ public class CheckstylePrecommitPlugin extends PrecommitPlugin implements Intern
         checkstyle.getConfigDirectory().set(checkstyleDir);
 
         DependencyHandler dependencies = project.getDependencies();
-        String checkstyleVersion = VersionProperties.getVersions().get("checkstyle");
+        String checkstyleVersion = versionInfo.get("checkstyle");
         Provider<String> dependencyProvider = project.provider(() -> "org.elasticsearch:build-conventions:" + project.getVersion());
         dependencies.add("checkstyle", "com.puppycrawl.tools:checkstyle:" + checkstyleVersion);
         dependencies.addProvider("checkstyle", dependencyProvider, dep -> dep.setTransitive(false));

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/precommit/JavaModulePrecommitPlugin.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/precommit/JavaModulePrecommitPlugin.java
@@ -30,6 +30,7 @@ public class JavaModulePrecommitPlugin extends PrecommitPlugin implements Intern
             t.setClasspath(project.getConfigurations().getByName(JavaPlugin.COMPILE_CLASSPATH_CONFIGURATION_NAME));
             t.setClassesDirs(mainSourceSet.getOutput().getClassesDirs());
             t.setResourcesDirs(mainSourceSet.getOutput().getResourcesDir());
+            t.setExpectedVersion(project.getVersion().toString());
         });
         return task;
     }

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/precommit/JavaModulePrecommitTask.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/precommit/JavaModulePrecommitTask.java
@@ -8,13 +8,13 @@
 
 package org.elasticsearch.gradle.internal.precommit;
 
-import org.elasticsearch.gradle.VersionProperties;
 import org.elasticsearch.gradle.internal.conventions.precommit.PrecommitTask;
 import org.gradle.api.GradleException;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.provider.SetProperty;
 import org.gradle.api.tasks.Classpath;
+import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.InputFiles;
 import org.gradle.api.tasks.PathSensitive;
 import org.gradle.api.tasks.PathSensitivity;
@@ -39,8 +39,6 @@ import static java.util.stream.Collectors.toSet;
 
 public class JavaModulePrecommitTask extends PrecommitTask {
 
-    private static final String expectedVersion = VersionProperties.getElasticsearch();
-
     private final SetProperty<File> srcDirs;
 
     private FileCollection classesDirs;
@@ -48,6 +46,8 @@ public class JavaModulePrecommitTask extends PrecommitTask {
     private FileCollection classpath;
 
     private File resourcesDir;
+
+    private String expectedVersion;
 
     @Inject
     public JavaModulePrecommitTask(ObjectFactory objectFactory) {
@@ -62,6 +62,15 @@ public class JavaModulePrecommitTask extends PrecommitTask {
     public void setClassesDirs(FileCollection classesDirs) {
         Objects.requireNonNull(classesDirs, "classesDirs");
         this.classesDirs = classesDirs;
+    }
+
+    @Input
+    public String getExpectedVersion() {
+        return expectedVersion;
+    }
+
+    public void setExpectedVersion(String expectedVersion) {
+        this.expectedVersion = expectedVersion;
     }
 
     @InputFiles

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/release/BreakingChangesGenerator.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/release/BreakingChangesGenerator.java
@@ -10,8 +10,6 @@ package org.elasticsearch.gradle.internal.release;
 
 import com.google.common.annotations.VisibleForTesting;
 
-import org.elasticsearch.gradle.VersionProperties;
-
 import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
@@ -31,15 +29,14 @@ import static java.util.stream.Collectors.toList;
  */
 public class BreakingChangesGenerator {
 
-    static void update(File migrationTemplateFile, File migrationOutputFile, List<ChangelogEntry> entries) throws IOException {
+    static void update(
+        File migrationTemplateFile,
+        File migrationOutputFile,
+        QualifiedVersion qualifiedVersion,
+        List<ChangelogEntry> entries
+    ) throws IOException {
         try (FileWriter output = new FileWriter(migrationOutputFile)) {
-            output.write(
-                generateMigrationFile(
-                    QualifiedVersion.of(VersionProperties.getElasticsearch()),
-                    Files.readString(migrationTemplateFile.toPath()),
-                    entries
-                )
-            );
+            output.write(generateMigrationFile(qualifiedVersion, Files.readString(migrationTemplateFile.toPath()), entries));
         }
     }
 

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/release/ReleaseHighlightsGenerator.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/release/ReleaseHighlightsGenerator.java
@@ -10,8 +10,6 @@ package org.elasticsearch.gradle.internal.release;
 
 import com.google.common.annotations.VisibleForTesting;
 
-import org.elasticsearch.gradle.VersionProperties;
-
 import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
@@ -27,11 +25,10 @@ import java.util.stream.Collectors;
  * Generates the release highlights notes, for changelog files that contain the <code>highlight</code> field.
  */
 public class ReleaseHighlightsGenerator {
-    static void update(File templateFile, File outputFile, List<ChangelogEntry> entries) throws IOException {
+    static void update(File templateFile, File outputFile, QualifiedVersion qualifiedVersion, List<ChangelogEntry> entries)
+        throws IOException {
         try (FileWriter output = new FileWriter(outputFile)) {
-            output.write(
-                generateFile(QualifiedVersion.of(VersionProperties.getElasticsearch()), Files.readString(templateFile.toPath()), entries)
-            );
+            output.write(generateFile(qualifiedVersion, Files.readString(templateFile.toPath()), entries));
         }
     }
 

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/test/DistroTestPlugin.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/test/DistroTestPlugin.java
@@ -14,7 +14,6 @@ import org.elasticsearch.gradle.ElasticsearchDistribution;
 import org.elasticsearch.gradle.ElasticsearchDistribution.Platform;
 import org.elasticsearch.gradle.ElasticsearchDistributionType;
 import org.elasticsearch.gradle.Version;
-import org.elasticsearch.gradle.VersionProperties;
 import org.elasticsearch.gradle.internal.InternalDistributionDownloadPlugin;
 import org.elasticsearch.gradle.internal.Jdk;
 import org.elasticsearch.gradle.internal.JdkDownloadPlugin;
@@ -387,17 +386,13 @@ public class DistroTestPlugin implements Plugin<Project> {
         for (Architecture architecture : Architecture.values()) {
             ALL_INTERNAL.stream()
                 .forEach(
-                    type -> currentDistros.add(
-                        createDistro(distributions, architecture, type, null, true, VersionProperties.getElasticsearch())
-                    )
+                    type -> currentDistros.add(createDistro(distributions, architecture, type, null, true, project.getVersion().toString()))
                 );
         }
 
         for (Architecture architecture : Architecture.values()) {
             for (Platform platform : Arrays.asList(Platform.LINUX, Platform.WINDOWS)) {
-                currentDistros.add(
-                    createDistro(distributions, architecture, ARCHIVE, platform, true, VersionProperties.getElasticsearch())
-                );
+                currentDistros.add(createDistro(distributions, architecture, ARCHIVE, platform, true, project.getVersion().toString()));
             }
         }
 

--- a/build-tools-internal/src/test/java/org/elasticsearch/gradle/internal/InternalDistributionDownloadPluginTests.java
+++ b/build-tools-internal/src/test/java/org/elasticsearch/gradle/internal/InternalDistributionDownloadPluginTests.java
@@ -10,7 +10,6 @@ package org.elasticsearch.gradle.internal;
 
 import org.elasticsearch.gradle.AbstractDistributionDownloadPluginTests;
 import org.elasticsearch.gradle.ElasticsearchDistributionType;
-import org.elasticsearch.gradle.VersionProperties;
 import org.elasticsearch.gradle.internal.distribution.InternalElasticsearchDistributionTypes;
 import org.gradle.api.Project;
 import org.gradle.testfixtures.ProjectBuilder;
@@ -28,7 +27,7 @@ public class InternalDistributionDownloadPluginTests extends AbstractDistributio
                 Project packageProject = ProjectBuilder.builder().withParent(packagesProject).withName(projectName).build();
                 packageProject.getConfigurations().create("default");
                 packageProject.getArtifacts().add("default", new File("doesnotmatter"));
-                createDistro(project, "distro", VersionProperties.getElasticsearch(), packageType, null, bundledJdk);
+                createDistro(project, "distro", "8.2.0", packageType, null, bundledJdk);
             }
         }
     }

--- a/build-tools/build.gradle
+++ b/build-tools/build.gradle
@@ -20,10 +20,9 @@ plugins {
 description = "The elasticsearch build tools"
 
 group = "org.elasticsearch.gradle"
-version = versions.getProperty("elasticsearch")
+version = versions.elasticsearch
 targetCompatibility = versions.get("minimumRuntimeJava")
 sourceCompatibility = versions.get("minimumRuntimeJava")
-
 gradlePlugin {
     // We already configure publication and we don't need or want the one that comes
     // with the java-gradle-plugin
@@ -66,7 +65,7 @@ gradlePlugin {
 def generateVersionProperties = tasks.register("generateVersionProperties", WriteProperties) {
     outputFile = "${buildDir}/version.properties"
     comment = 'Generated version properties'
-    properties(versions)
+    properties = versions.getProperties()
 }
 
 tasks.named("processResources").configure {

--- a/build-tools/src/integTest/groovy/org/elasticsearch/gradle/plugin/PluginBuildPluginFuncTest.groovy
+++ b/build-tools/src/integTest/groovy/org/elasticsearch/gradle/plugin/PluginBuildPluginFuncTest.groovy
@@ -117,7 +117,7 @@ class PluginBuildPluginFuncTest extends AbstractGradleFuncTest {
         props.get("modulename") == ""
         props.get("type") == "isolated"
         props.get("java.version") == Integer.toString(Runtime.version().feature())
-        props.get("elasticsearch.version") == VersionProperties.elasticsearchVersion.toString()
+        props.get("elasticsearch.version") == VersionProperties.elasticsearch.toString()
         props.get("extended.plugins") == ""
         props.get("has.native.controller") == "false"
         props.size() == 10

--- a/build-tools/src/main/java/org/elasticsearch/gradle/plugin/PluginBuildPlugin.java
+++ b/build-tools/src/main/java/org/elasticsearch/gradle/plugin/PluginBuildPlugin.java
@@ -8,7 +8,6 @@
 
 package org.elasticsearch.gradle.plugin;
 
-import org.elasticsearch.gradle.Version;
 import org.elasticsearch.gradle.VersionProperties;
 import org.elasticsearch.gradle.dependencies.CompileOnlyResolvePlugin;
 import org.elasticsearch.gradle.jarhell.JarHellPlugin;
@@ -113,7 +112,7 @@ public class PluginBuildPlugin implements Plugin<Project> {
             task.getPluginName().set(providerFactory.provider(extension::getName));
             task.getPluginDescription().set(providerFactory.provider(extension::getDescription));
             task.getPluginVersion().set(providerFactory.provider(extension::getVersion));
-            task.getElasticsearchVersion().set(Version.fromString(VersionProperties.getElasticsearch()).toString());
+            task.getElasticsearchVersion().set(VersionProperties.getElasticsearch());
             var javaExtension = project.getExtensions().getByType(JavaPluginExtension.class);
             task.getJavaVersion().set(providerFactory.provider(() -> javaExtension.getTargetCompatibility().toString()));
             task.getClassname().set(providerFactory.provider(extension::getClassname));

--- a/build-tools/src/main/java/org/elasticsearch/gradle/plugin/PluginBuildPlugin.java
+++ b/build-tools/src/main/java/org/elasticsearch/gradle/plugin/PluginBuildPlugin.java
@@ -8,6 +8,7 @@
 
 package org.elasticsearch.gradle.plugin;
 
+import org.elasticsearch.gradle.Version;
 import org.elasticsearch.gradle.VersionProperties;
 import org.elasticsearch.gradle.dependencies.CompileOnlyResolvePlugin;
 import org.elasticsearch.gradle.jarhell.JarHellPlugin;
@@ -112,7 +113,7 @@ public class PluginBuildPlugin implements Plugin<Project> {
             task.getPluginName().set(providerFactory.provider(extension::getName));
             task.getPluginDescription().set(providerFactory.provider(extension::getDescription));
             task.getPluginVersion().set(providerFactory.provider(extension::getVersion));
-            task.getElasticsearchVersion().set(VersionProperties.getElasticsearch());
+            task.getElasticsearchVersion().set(Version.fromString(VersionProperties.getElasticsearch()).toString());
             var javaExtension = project.getExtensions().getByType(JavaPluginExtension.class);
             task.getJavaVersion().set(providerFactory.provider(() -> javaExtension.getTargetCompatibility().toString()));
             task.getClassname().set(providerFactory.provider(extension::getClassname));

--- a/build.gradle
+++ b/build.gradle
@@ -9,14 +9,9 @@
 import com.avast.gradle.dockercompose.tasks.ComposePull
 import com.fasterxml.jackson.databind.JsonNode
 import com.fasterxml.jackson.databind.ObjectMapper
-import com.github.jengelman.gradle.plugins.shadow.ShadowPlugin
 import de.thetaphi.forbiddenapis.gradle.ForbiddenApisPlugin
-import org.elasticsearch.gradle.internal.BuildPlugin
 import org.elasticsearch.gradle.Version
-import org.elasticsearch.gradle.VersionProperties
-import org.elasticsearch.gradle.internal.BwcVersions
 import org.elasticsearch.gradle.internal.info.BuildParams
-import org.elasticsearch.gradle.plugin.PluginBuildPlugin
 import org.gradle.plugins.ide.eclipse.model.AccessRule
 import org.gradle.util.DistributionLocator
 import org.gradle.util.GradleVersion

--- a/client/rest/build.gradle
+++ b/client/rest/build.gradle
@@ -18,7 +18,6 @@
  */
 import de.thetaphi.forbiddenapis.gradle.CheckForbiddenApis
 
-import org.elasticsearch.gradle.VersionProperties
 import org.elasticsearch.gradle.internal.conventions.precommit.LicenseHeadersTask
 
 apply plugin: 'elasticsearch.build'
@@ -51,7 +50,7 @@ dependencies {
 
 tasks.named("processResources").configure {
   expand versions: [
-    elasticsearch: VersionProperties.getElasticsearch()
+    elasticsearch: project.version
   ]
 }
 

--- a/distribution/build.gradle
+++ b/distribution/build.gradle
@@ -9,7 +9,7 @@
 
 import org.apache.tools.ant.filters.FixCrLfFilter
 import org.apache.tools.ant.filters.ReplaceTokens
-import org.elasticsearch.gradle.VersionProperties
+import org.elasticsearch.gradle.Version
 import org.elasticsearch.gradle.internal.ConcatFilesTask
 import org.elasticsearch.gradle.internal.DependenciesInfoTask
 import org.elasticsearch.gradle.internal.NoticeTask
@@ -41,7 +41,7 @@ tasks.register("generateDependenciesReport", ConcatFilesTask) {
                       .get()
   )
   // explicitly add our dependency on the JDK
-  String jdkVersion = VersionProperties.versions.get('bundled_jdk').split('@')[0]
+  String jdkVersion = versions.get('bundled_jdk').split('@')[0]
   String jdkMajorVersion = jdkVersion.split('[+.]')[0]
   String sourceUrl = "https://github.com/openjdk/jdk${jdkMajorVersion}u/archive/refs/tags/jdk-${jdkVersion}.tar.gz"
   additionalLines << "OpenJDK,${jdkVersion},https://openjdk.java.net/,GPL-2.0-with-classpath-exception,${sourceUrl}".toString()
@@ -217,8 +217,8 @@ configure(subprojects.findAll { ['archives', 'packages'].contains(it.name) }) {
       (platform == 'linux' || platform == 'darwin' ? ['x64', 'aarch64'] : ['x64']).each { architecture ->
         "bundled_${platform}_${architecture}" {
           it.platform = platform
-          it.version = VersionProperties.bundledJdkVersion
-          it.vendor = VersionProperties.bundledJdkVendor
+          it.version = versions.bundledJdkVersion
+          it.vendor = versions.bundledJdkVendor
           it.architecture = architecture
         }
       }
@@ -464,7 +464,7 @@ subprojects {
     Map<String, Object> expansions = [
       'project.name': project.name,
       'project.version': version,
-      'project.minor.version': "${VersionProperties.elasticsearchVersion.major}.${VersionProperties.elasticsearchVersion.minor}",
+      'project.minor.version': "${elasticsearchVersion.major}.${elasticsearchVersion.minor}",
 
       'path.conf': [
         'deb': '/etc/elasticsearch',

--- a/distribution/docker/build.gradle
+++ b/distribution/docker/build.gradle
@@ -1,6 +1,5 @@
 import org.elasticsearch.gradle.Architecture
 import org.elasticsearch.gradle.LoggedExec
-import org.elasticsearch.gradle.VersionProperties
 import org.elasticsearch.gradle.internal.DockerBase
 import org.elasticsearch.gradle.internal.distribution.InternalElasticsearchDistributionTypes
 import org.elasticsearch.gradle.internal.docker.DockerBuildTask
@@ -41,7 +40,7 @@ repositories {
         artifact '/[organisation]/[module]-[revision]-linux-[classifier].[ext]'
       }
     } else {
-      url "https://${VersionProperties.isElasticsearchSnapshot() ? 'snapshots' : 'artifacts'}-no-kpi.elastic.co/"
+      url "https://${versions.isElasticsearchSnapshot() ? 'snapshots' : 'artifacts'}-no-kpi.elastic.co/"
       patternLayout {
         artifact '/downloads/[organization]/[module]/[module]-[revision]-linux-[classifier].[ext]'
       }
@@ -72,12 +71,12 @@ dependencies {
   log4jConfig project(path: ":distribution", configuration: 'log4jConfig')
   tini "krallin:tini:0.19.0:${tiniArch}"
   allPlugins project(path: ':plugins', configuration: 'allPlugins')
-  filebeat "beats:filebeat:${VersionProperties.elasticsearch}:${beatsArch}@tar.gz"
-  metricbeat "beats:metricbeat:${VersionProperties.elasticsearch}:${beatsArch}@tar.gz"
+  filebeat "beats:filebeat:${versions.elasticsearch}:${beatsArch}@tar.gz"
+  metricbeat "beats:metricbeat:${versions.elasticsearch}:${beatsArch}@tar.gz"
 }
 
 ext.expansions = { Architecture architecture, DockerBase base ->
-  def (major,minor) = VersionProperties.elasticsearch.split("\\.")
+  def (major,minor) = project.version.split("\\.")
 
   // We tag our Docker images with various pieces of information, including a timestamp
   // for when the image was built. However, this makes it impossible completely cache
@@ -96,7 +95,7 @@ ext.expansions = { Architecture architecture, DockerBase base ->
     'license'            : base == DockerBase.IRON_BANK ? 'Elastic License 2.0' : 'Elastic-License-2.0',
     'package_manager'    : base == DockerBase.IRON_BANK ? 'yum' : (base == DockerBase.UBI ? 'microdnf' : 'apt-get'),
     'docker_base'        : base.name().toLowerCase(),
-    'version'            : VersionProperties.elasticsearch,
+    'version'            : versionInfo.elasticsearch,
     'major_minor_version': "${major}.${minor}",
     'retry'              : ShellRetry
   ]
@@ -180,7 +179,7 @@ elasticsearch_distributions {
     "docker_${eachArchitecture == Architecture.AARCH64 ? '_aarch64' : ''}" {
       architecture = eachArchitecture
       type = InternalElasticsearchDistributionTypes.DOCKER
-      version = VersionProperties.getElasticsearch()
+      version = project.version
       failIfUnavailable = false // This ensures we don't attempt to build images if docker is unavailable
     }
   }
@@ -254,14 +253,14 @@ void addBuildDockerContextTask(Architecture architecture, DockerBase base) {
         // infer that we're not at the Docker building stage of the build, and therefore
         // we should skip the beats part of the build.
         String buildId = providers.systemProperty('build.id').forUseAtConfigurationTime().getOrNull()
-        boolean includeBeats = VersionProperties.isElasticsearchSnapshot() == true || buildId != null
+        boolean includeBeats = versions.isElasticsearchSnapshot() == true || buildId != null
 
         if (includeBeats) {
           from configurations.filebeat
           from configurations.metricbeat
         }
         // For some reason, the artifact name can differ depending on what repository we used.
-        rename ~/((?:file|metric)beat)-.*\.tar\.gz$/, "\$1-${VersionProperties.elasticsearch}.tar.gz"
+        rename ~/((?:file|metric)beat)-.*\.tar\.gz$/, "\$1-${project.version}.tar.gz"
       }
 
       onlyIf { Architecture.current() == architecture }
@@ -280,8 +279,8 @@ void addTransformDockerContextTask(Architecture architecture, DockerBase base) {
     dependsOn(buildContextTask)
 
     String arch = architecture == Architecture.AARCH64 ? '-aarch64' : ''
-    String archiveName = "elasticsearch${base.suffix}-${VersionProperties.elasticsearch}-docker-build-context${arch}"
-    String distributionName = "elasticsearch-${VersionProperties.elasticsearch}-linux-${architecture.classifier}.tar.gz"
+    String archiveName = "elasticsearch${base.suffix}-${versions.elasticsearch}-docker-build-context${arch}"
+    String distributionName = "elasticsearch-${project.version}-linux-${architecture.classifier}.tar.gz"
 
     from(tarTree("${project.buildDir}/distributions/${archiveName}.tar.gz")) {
       eachFile { FileCopyDetails details ->
@@ -316,9 +315,7 @@ void addTransformDockerContextTask(Architecture architecture, DockerBase base) {
 }
 
 
-private static List<String> generateTags(DockerBase base) {
-  final String version = VersionProperties.elasticsearch
-
+private static List<String> generateTags(DockerBase base, String version) {
   String image = "elasticsearch${base.suffix}"
 
   String namespace = 'elasticsearch'
@@ -343,7 +340,7 @@ void addBuildDockerImageTask(Architecture architecture, DockerBase base) {
       dockerContext.fileProvider(transformTask.map { Sync task -> task.getDestinationDir() })
 
       noCache = BuildParams.isCi
-      tags = generateTags(base)
+      tags = generateTags(base, project.version)
 
       // We don't build the Iron Bank image when we release Elasticsearch, as there's
       // separate process for submitting new releases. However, for testing we do a
@@ -381,7 +378,7 @@ void addBuildDockerImageTask(Architecture architecture, DockerBase base) {
 void addBuildEssDockerImageTask(Architecture architecture) {
   DockerBase base = DockerBase.CLOUD_ESS
   String arch = architecture == Architecture.AARCH64 ? '-aarch64' : ''
-  String contextDir = "${project.buildDir}/docker-context/elasticsearch${base.suffix}-${VersionProperties.elasticsearch}-docker-build-context${arch}"
+  String contextDir = "${project.buildDir}/docker-context/elasticsearch${base.suffix}-${project.version}-docker-build-context${arch}"
 
   final TaskProvider<Sync> buildContextTask =
     tasks.register(taskName('build', architecture, base, 'DockerContext'), Sync) {
@@ -395,7 +392,7 @@ void addBuildEssDockerImageTask(Architecture architecture) {
 
       from(projectDir.resolve("src/docker/Dockerfile.cloud-ess")) {
         expand([
-          base_image: "elasticsearch${DockerBase.CLOUD.suffix}:${VersionProperties.elasticsearch}"
+          base_image: "elasticsearch${DockerBase.CLOUD.suffix}:${project.version}"
         ])
         filter SquashNewlinesFilter
         rename ~/Dockerfile\.cloud-ess$/, 'Dockerfile'
@@ -412,7 +409,7 @@ void addBuildEssDockerImageTask(Architecture architecture) {
 
       noCache = BuildParams.isCi
       baseImages = []
-      tags = generateTags(base)
+      tags = generateTags(base, project.version)
 
       onlyIf { Architecture.current() == architecture }
     }
@@ -465,7 +462,7 @@ subprojects { Project subProject ->
 
     final String exportTaskName = taskName("export", architecture, base, 'DockerImage')
     final String buildTaskName = taskName('build', architecture, base, 'DockerImage')
-    final String tarFile = "${parent.projectDir}/build/${artifactName}_${VersionProperties.elasticsearch}.${extension}"
+    final String tarFile = "${parent.projectDir}/build/${artifactName}_${subProject.version}.${extension}"
 
     tasks.register(exportTaskName, LoggedExec) {
       inputs.file("${parent.projectDir}/build/markers/${buildTaskName}.marker")

--- a/distribution/docker/build.gradle
+++ b/distribution/docker/build.gradle
@@ -95,7 +95,7 @@ ext.expansions = { Architecture architecture, DockerBase base ->
     'license'            : base == DockerBase.IRON_BANK ? 'Elastic License 2.0' : 'Elastic-License-2.0',
     'package_manager'    : base == DockerBase.IRON_BANK ? 'yum' : (base == DockerBase.UBI ? 'microdnf' : 'apt-get'),
     'docker_base'        : base.name().toLowerCase(),
-    'version'            : versionInfo.elasticsearch,
+    'version'            : versions.elasticsearch,
     'major_minor_version': "${major}.${minor}",
     'retry'              : ShellRetry
   ]

--- a/docs/build.gradle
+++ b/docs/build.gradle
@@ -1,4 +1,3 @@
-import org.elasticsearch.gradle.VersionProperties
 import org.elasticsearch.gradle.internal.info.BuildParams
 
 import static org.elasticsearch.gradle.testclusters.TestDistribution.DEFAULT

--- a/modules/repository-azure/build.gradle
+++ b/modules/repository-azure/build.gradle
@@ -22,7 +22,7 @@ esplugin {
   classname 'org.elasticsearch.repositories.azure.AzureRepositoryPlugin'
 }
 
-versions << [
+versions.properties << [
   'azure': '12.16.0',
   'azureCommon': '12.15.1',
   'azureCore': '1.27.0',

--- a/modules/repository-s3/build.gradle
+++ b/modules/repository-s3/build.gradle
@@ -22,7 +22,7 @@ esplugin {
   classname 'org.elasticsearch.repositories.s3.S3RepositoryPlugin'
 }
 
-versions << [
+versions.properties << [
   'aws': '1.11.749'
 ]
 

--- a/plugins/discovery-azure-classic/build.gradle
+++ b/plugins/discovery-azure-classic/build.gradle
@@ -16,7 +16,7 @@ esplugin {
   classname 'org.elasticsearch.plugin.discovery.azure.classic.AzureDiscoveryPlugin'
 }
 
-def localVersions = versions + [
+def localVersions = versions.properties + [
   'azure' : '0.9.3',
   'jersey': '1.13'
 ]

--- a/plugins/discovery-ec2/build.gradle
+++ b/plugins/discovery-ec2/build.gradle
@@ -15,7 +15,7 @@ esplugin {
   classname 'org.elasticsearch.discovery.ec2.Ec2DiscoveryPlugin'
 }
 
-versions << [
+versions.properties << [
   'aws': '1.11.749'
 ]
 

--- a/plugins/discovery-gce/build.gradle
+++ b/plugins/discovery-gce/build.gradle
@@ -6,7 +6,7 @@ esplugin {
   classname 'org.elasticsearch.plugin.discovery.gce.GceDiscoveryPlugin'
 }
 
-versions << [
+versions.properties << [
   'google'              : '1.41.1',
   'google_api_client'   : '1.33.1',
   'api_services_compute': 'v1-rev20220322-1.32.1',

--- a/plugins/examples/build.gradle
+++ b/plugins/examples/build.gradle
@@ -1,5 +1,3 @@
-import org.elasticsearch.gradle.VersionProperties
-
 buildscript {
   repositories {
     maven {
@@ -31,7 +29,7 @@ subprojects {
     }
 
     // Same for Lucene, add the snapshot repo based on the currently used Lucene version
-    def luceneVersion = VersionProperties.getLucene()
+    def luceneVersion = verions.getLucene()
     if (luceneVersion.contains('-snapshot')) {
       def matcher = luceneVersion =~ /[0-9\.]+-snapshot-([a-z0-9]+)/
       assert matcher.matches(): "Invalid Lucene snapshot version '${luceneVersion}'"

--- a/plugins/ingest-attachment/build.gradle
+++ b/plugins/ingest-attachment/build.gradle
@@ -15,7 +15,7 @@ esplugin {
   classname 'org.elasticsearch.ingest.attachment.IngestAttachmentPlugin'
 }
 
-versions << [
+versions.properties << [
   'tika'  : '2.4.0',
   'pdfbox': '2.0.26',
   'poi'   : '5.2.2',

--- a/plugins/repository-hdfs/build.gradle
+++ b/plugins/repository-hdfs/build.gradle
@@ -23,7 +23,7 @@ esplugin {
     classname 'org.elasticsearch.repositories.hdfs.HdfsPlugin'
 }
 
-versions << [
+versions.properties << [
         'hadoop': '3.3.1'
 ]
 

--- a/qa/mixed-cluster/build.gradle
+++ b/qa/mixed-cluster/build.gradle
@@ -8,7 +8,6 @@
 
 
 import org.elasticsearch.gradle.Version
-import org.elasticsearch.gradle.VersionProperties
 import org.elasticsearch.gradle.internal.info.BuildParams
 import org.elasticsearch.gradle.testclusters.StandaloneRestIntegTestTask
 
@@ -25,7 +24,7 @@ restResources {
 
 BuildParams.bwcVersions.withWireCompatible { bwcVersion, baseName ->
 
-  if (bwcVersion != VersionProperties.getElasticsearchVersion()) {
+  if (bwcVersion != elasticsearchVersion) {
     /* This project runs the core REST tests against a 4 node cluster where two of
      the nodes has a different minor.  */
     def baseCluster = testClusters.register(baseName) {

--- a/qa/remote-clusters/build.gradle
+++ b/qa/remote-clusters/build.gradle
@@ -7,8 +7,6 @@
  */
 
 import org.elasticsearch.gradle.Architecture
-import org.elasticsearch.gradle.VersionProperties
-import org.elasticsearch.gradle.internal.testfixtures.TestFixturesPlugin
 import static org.elasticsearch.gradle.internal.distribution.InternalElasticsearchDistributionTypes.DOCKER;
 
 apply plugin: 'elasticsearch.standalone-rest-test'
@@ -39,7 +37,7 @@ elasticsearch_distributions {
   docker {
     type = DOCKER
     architecture = Architecture.current()
-    version = VersionProperties.getElasticsearch()
+    version = project.version
     failIfUnavailable = false // This ensures we skip this testing if Docker is unavailable
   }
 }

--- a/qa/verify-version-constants/build.gradle
+++ b/qa/verify-version-constants/build.gradle
@@ -6,7 +6,6 @@
  * Side Public License, v 1.
  */
 
-import org.elasticsearch.gradle.VersionProperties
 import org.elasticsearch.gradle.internal.info.BuildParams
 import org.elasticsearch.gradle.testclusters.StandaloneRestIntegTestTask
 
@@ -45,7 +44,7 @@ tasks.register("verifyDocsLuceneVersion") {
     if (docsLuceneVersion == null) {
       throw new GradleException('Could not find lucene version in docs version file')
     }
-    String expectedLuceneVersion = VersionProperties.lucene
+    String expectedLuceneVersion = versions.lucene
     // remove potential -snapshot-{gitrev} suffix
     expectedLuceneVersion -= ~/-snapshot-[0-9a-f]+$/
     if (docsLuceneVersion != expectedLuceneVersion) {

--- a/x-pack/plugin/build.gradle
+++ b/x-pack/plugin/build.gradle
@@ -1,5 +1,4 @@
 import org.elasticsearch.gradle.Version
-import org.elasticsearch.gradle.VersionProperties
 import org.elasticsearch.gradle.internal.info.BuildParams
 import org.elasticsearch.gradle.internal.test.RestIntegTestTask
 import org.elasticsearch.gradle.util.GradleUtils
@@ -20,7 +19,7 @@ dependencies {
 
 // let the yamlRestTests see the classpath of test
 GradleUtils.extendSourceSet(project, "test", "yamlRestTest", tasks.named("yamlRestTest"))
-int compatVersion = VersionProperties.getElasticsearchVersion().getMajor() - 1;
+int compatVersion = elasticsearchVersion.getMajor() - 1;
 GradleUtils.extendSourceSet(project, "test", "yamlRestTestV${compatVersion}Compat")
 
 restResources {

--- a/x-pack/plugin/eql/qa/mixed-node/build.gradle
+++ b/x-pack/plugin/eql/qa/mixed-node/build.gradle
@@ -1,7 +1,6 @@
 apply plugin: 'elasticsearch.internal-java-rest-test'
 apply plugin: 'elasticsearch.bwc-test'
 
-import org.elasticsearch.gradle.VersionProperties
 import org.elasticsearch.gradle.internal.info.BuildParams
 import org.elasticsearch.gradle.testclusters.StandaloneRestIntegTestTask
 
@@ -14,7 +13,7 @@ dependencies {
 tasks.named("javaRestTest").configure { enabled = false }
 
 BuildParams.bwcVersions.withWireCompatible(v -> v.onOrAfter("7.10.0") &&
-        v != VersionProperties.getElasticsearchVersion()) { bwcVersion, baseName ->
+        v != elasticsearchVersion) { bwcVersion, baseName ->
     def cluster = testClusters.register(baseName) {
         versions = [bwcVersion.toString(), project.version]
         numberOfNodes = 3

--- a/x-pack/plugin/shutdown/build.gradle
+++ b/x-pack/plugin/shutdown/build.gradle
@@ -1,5 +1,3 @@
-import org.elasticsearch.gradle.VersionProperties
-
 apply plugin: 'elasticsearch.internal-es-plugin'
 apply plugin: 'elasticsearch.internal-cluster-test'
 

--- a/x-pack/plugin/shutdown/qa/multi-node/build.gradle
+++ b/x-pack/plugin/shutdown/qa/multi-node/build.gradle
@@ -1,5 +1,3 @@
-import org.elasticsearch.gradle.VersionProperties
-
 apply plugin: 'elasticsearch.internal-java-rest-test'
 apply plugin: 'elasticsearch.authenticated-testclusters'
 

--- a/x-pack/plugin/shutdown/qa/rolling-upgrade/build.gradle
+++ b/x-pack/plugin/shutdown/qa/rolling-upgrade/build.gradle
@@ -4,8 +4,6 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-
-import org.elasticsearch.gradle.VersionProperties
 import org.elasticsearch.gradle.internal.info.BuildParams
 import org.elasticsearch.gradle.testclusters.StandaloneRestIntegTestTask
 

--- a/x-pack/plugin/sql/qa/jdbc/build.gradle
+++ b/x-pack/plugin/sql/qa/jdbc/build.gradle
@@ -1,6 +1,5 @@
 import org.elasticsearch.gradle.internal.BwcVersions.UnreleasedVersionInfo
 import org.elasticsearch.gradle.Version
-import org.elasticsearch.gradle.VersionProperties
 import org.elasticsearch.gradle.internal.info.BuildParams
 import org.elasticsearch.gradle.internal.test.RestIntegTestTask
 
@@ -67,12 +66,12 @@ subprojects {
 
     tasks.named("javaRestTest").configure {
         classpath += configurations.jdbcDriver
-        systemProperty 'jdbc.driver.version', VersionProperties.elasticsearch
+        systemProperty 'jdbc.driver.version', project.version
     }
 
     // Configure compatibility testing tasks
     // Compatibility testing for JDBC driver started with version 7.9.0
-    BuildParams.bwcVersions.withIndexCompatible({ it.onOrAfter(Version.fromString("7.9.0")) && it != VersionProperties.elasticsearchVersion }) { bwcVersion, baseName ->
+    BuildParams.bwcVersions.withIndexCompatible({ it.onOrAfter(Version.fromString("7.9.0")) && it != elasticsearchVersion }) { bwcVersion, baseName ->
       UnreleasedVersionInfo unreleasedVersion = BuildParams.bwcVersions.unreleasedInfo(bwcVersion)
       Configuration driverConfiguration = configurations.create("jdbcDriver${baseName}") {
         // TODO: Temporary workaround for https://github.com/elastic/elasticsearch/issues/73433

--- a/x-pack/plugin/sql/qa/mixed-node/build.gradle
+++ b/x-pack/plugin/sql/qa/mixed-node/build.gradle
@@ -1,7 +1,6 @@
 apply plugin: 'elasticsearch.internal-java-rest-test'
 apply plugin: 'elasticsearch.bwc-test'
 
-import org.elasticsearch.gradle.VersionProperties
 import org.elasticsearch.gradle.internal.info.BuildParams
 import org.elasticsearch.gradle.testclusters.StandaloneRestIntegTestTask
 
@@ -20,7 +19,7 @@ tasks.named("javaRestTest").configure{ enabled = false}
 
 // A bug (https://github.com/elastic/elasticsearch/issues/68439) limits us to perform tests with versions from 7.10.3 onwards
 BuildParams.bwcVersions.withWireCompatible(v -> v.onOrAfter("7.10.3") &&
-        v != VersionProperties.getElasticsearchVersion()) { bwcVersion, baseName ->
+        v != elasticsearchVersion) { bwcVersion, baseName ->
 
   def baseCluster = testClusters.register(baseName) {
       versions = [bwcVersion.toString(), project.version]

--- a/x-pack/plugin/transform/qa/multi-cluster-tests-with-security/build.gradle
+++ b/x-pack/plugin/transform/qa/multi-cluster-tests-with-security/build.gradle
@@ -1,6 +1,5 @@
 import org.elasticsearch.gradle.internal.test.RestIntegTestTask
 import org.elasticsearch.gradle.Version
-import org.elasticsearch.gradle.VersionProperties
 
 apply plugin: 'elasticsearch.internal-testclusters'
 apply plugin: 'elasticsearch.standalone-rest-test'
@@ -11,7 +10,7 @@ dependencies {
   testImplementation project(':client:rest-high-level')
 }
 
-Version ccsCompatVersion = new Version(VersionProperties.getElasticsearchVersion().getMajor(), VersionProperties.getElasticsearchVersion().getMinor() - 1, 0)
+Version ccsCompatVersion = new Version(elasticsearchVersion.getMajor(), elasticsearchVersion.getMinor() - 1, 0)
 
 restResources {
   restApi {

--- a/x-pack/qa/mixed-tier-cluster/build.gradle
+++ b/x-pack/qa/mixed-tier-cluster/build.gradle
@@ -1,7 +1,6 @@
 apply plugin: 'elasticsearch.internal-java-rest-test'
 apply plugin: 'elasticsearch.bwc-test'
 
-import org.elasticsearch.gradle.VersionProperties
 import org.elasticsearch.gradle.internal.info.BuildParams
 import org.elasticsearch.gradle.testclusters.StandaloneRestIntegTestTask
 
@@ -11,7 +10,7 @@ dependencies {
 
 // Only run tests for 7.9+, since the node.roles setting was introduced in 7.9.0
 BuildParams.bwcVersions.withWireCompatible(v -> v.onOrAfter("7.9.0") &&
-        v != VersionProperties.getElasticsearchVersion()) { bwcVersion, baseName ->
+        v != elasticsearchVersion) { bwcVersion, baseName ->
 
   def baseCluster = testClusters.register(baseName) {
     versions = [bwcVersion.toString(), project.version]

--- a/x-pack/qa/repository-old-versions/build.gradle
+++ b/x-pack/qa/repository-old-versions/build.gradle
@@ -62,7 +62,7 @@ if (Os.isFamily(Os.FAMILY_WINDOWS)) {
     transformSpec.getTo().attribute(ArtifactTypeDefinition.ARTIFACT_TYPE_ATTRIBUTE, ArtifactTypeDefinition.DIRECTORY_TYPE);
   });
 
-  int currentMajorVersion = org.elasticsearch.gradle.VersionProperties.elasticsearchVersion.major
+  int currentMajorVersion = elasticsearchVersion.major
   assert (currentMajorVersion - 2) == 6 : "add archive BWC tests for major version " + (currentMajorVersion - 2)
   for (String versionString : ['5.0.0', '5.6.16', '6.0.0', '6.8.20']) {
     Version version = Version.fromString(versionString)

--- a/x-pack/qa/rolling-upgrade/build.gradle
+++ b/x-pack/qa/rolling-upgrade/build.gradle
@@ -1,5 +1,4 @@
 import org.elasticsearch.gradle.Version
-import org.elasticsearch.gradle.VersionProperties
 import org.elasticsearch.gradle.internal.info.BuildParams
 import org.elasticsearch.gradle.testclusters.StandaloneRestIntegTestTask
 

--- a/x-pack/qa/xpack-prefix-rest-compat/build.gradle
+++ b/x-pack/qa/xpack-prefix-rest-compat/build.gradle
@@ -8,7 +8,6 @@
 
 
 import org.elasticsearch.gradle.Version
-import org.elasticsearch.gradle.VersionProperties
 import org.elasticsearch.gradle.internal.info.BuildParams
 import org.elasticsearch.gradle.internal.test.rest.CopyRestTestsTask
 import org.elasticsearch.gradle.util.GradleUtils
@@ -24,7 +23,7 @@ configurations {
   compatXpackTests
 }
 
-int compatVersion = VersionProperties.getElasticsearchVersion().getMajor() - 1;
+int compatVersion = elasticsearchVersion.getMajor() - 1;
 
 dependencies {
   "yamlRestTestV${compatVersion}CompatImplementation" project(':test:framework')

--- a/x-pack/test/idp-fixture/build.gradle
+++ b/x-pack/test/idp-fixture/build.gradle
@@ -1,4 +1,3 @@
-import org.elasticsearch.gradle.VersionProperties
 import org.elasticsearch.gradle.Architecture
 import static org.elasticsearch.gradle.internal.distribution.InternalElasticsearchDistributionTypes.DOCKER;
 
@@ -19,7 +18,7 @@ elasticsearch_distributions {
   docker {
     type = DOCKER
     architecture = Architecture.current()
-    version = VersionProperties.getElasticsearch()
+    version = project.version
     failIfUnavailable = false // This ensures we skip this testing if Docker is unavailable
   }
 }


### PR DESCRIPTION
This is a first step towards using gradle idiomatic version catalogues for managing
all of our dependencies