### PR TITLE
[8.3.1] Tolerate GraalVM compiler threads in testThreadNames

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/threadpool/SimpleThreadPoolIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/threadpool/SimpleThreadPoolIT.java
@@ -81,6 +81,7 @@ public class SimpleThreadPoolIT extends ESIntegTestCase {
             // or the ones that are occasionally come up from ESSingleNodeTestCase
             if (threadName.contains("[node_s_0]") // TODO: this can't possibly be right! single node and integ test are unrelated!
                 || threadName.contains("Keep-Alive-Timer")
+                || threadName.contains("JVMCI-native") // GraalVM Compiler Thread
                 || threadName.contains("readiness-service")) {
                 continue;
             }


### PR DESCRIPTION
Backport of:

- Tolerate GraalVM compiler threads in testThreadNames #87105