### PR TITLE
Backport: Fields API to allow fetching values when _source is disabled

### DIFF
--- a/docs/changelog/87267.yaml
+++ b/docs/changelog/87267.yaml
@@ -1,0 +1,6 @@
+pr: 87267
+summary: Fields API to allow fetching values when `_source` is disabled
+area: Search
+type: bug
+issues:
+ - 87072

--- a/docs/reference/search/search-your-data/retrieve-selected-fields.asciidoc
+++ b/docs/reference/search/search-your-data/retrieve-selected-fields.asciidoc
@@ -42,6 +42,7 @@ Other mapping options are also respected, including
 The `fields` option returns values in the way that matches how {es} indexes
 them. For standard fields, this means that the `fields` option looks in
 `_source` to find the values, then parses and formats them using the mappings.
+Selected fields that can't be found in `_source` are skipped.
 
 [discrete]
 [[search-fields-request]]

--- a/rest-api-spec/build.gradle
+++ b/rest-api-spec/build.gradle
@@ -81,6 +81,7 @@ tasks.named("yamlRestTestV7CompatTransform").configure { task ->
   task.skipTest("search.aggregation/20_terms/string profiler via map", "The profiler results aren't backwards compatible.")
   task.skipTest("search.aggregation/20_terms/numeric profiler", "The profiler results aren't backwards compatible.")
   task.skipTest("migration/10_get_feature_upgrade_status/Get feature upgrade status", "Awaits backport")
+  task.skipTest("search/330_fetch_fields/Test disable source", "Error no longer thrown")
 
   task.replaceValueInMatch("_type", "_doc")
   task.addAllowedWarningRegex("\\[types removal\\].*")

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search/330_fetch_fields.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search/330_fetch_fields.yml
@@ -1,8 +1,3 @@
-setup:
-  - skip:
-      version: " - 7.9.99"
-      reason: "the 'fields' parameter was added in 7.10"
-
 ---
 "Test basic field retrieval":
   - do:
@@ -95,6 +90,10 @@ setup:
 
 ---
 "Test disable source":
+  - skip:
+      version: " - 8.3.99"
+      reason: "behaviour of fields when source is disabled changed in 8.4.0"
+
   - do:
       indices.create:
         index:  test
@@ -107,6 +106,8 @@ setup:
             properties:
               keyword:
                 type: keyword
+              location:
+                type: geo_point
 
   - do:
       index:
@@ -114,20 +115,20 @@ setup:
         id:     "1"
         body:
           keyword: [ "a" ]
+          location: [12, 12]
 
   - do:
       indices.refresh:
         index: [ test ]
 
   - do:
-      catch: bad_request
       search:
         index: test
         body:
-          fields: [keyword]
-  - match: { error.root_cause.0.type: "illegal_argument_exception" }
-  - match: { error.root_cause.0.reason: "Unable to retrieve the requested [fields] since _source is disabled
-        in the mappings for index [test]" }
+          fields: [_id,keyword,location]
+
+  - length: { hits.hits.0.fields: 1 }
+  - match: { hits.hits.0.fields._id.0: "1" }
 
 ---
 "Test ignore malformed":

--- a/server/src/main/java/org/elasticsearch/index/mapper/ArraySourceValueFetcher.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/ArraySourceValueFetcher.java
@@ -13,6 +13,7 @@ import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.search.lookup.SourceLookup;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 
@@ -38,7 +39,7 @@ public abstract class ArraySourceValueFetcher implements ValueFetcher {
      * @param nullValue A optional substitute value if the _source value is 'null'.
      */
     public ArraySourceValueFetcher(String fieldName, SearchExecutionContext context, Object nullValue) {
-        this.sourcePaths = context.sourcePath(fieldName);
+        this.sourcePaths = context.isSourceEnabled() ? context.sourcePath(fieldName) : Collections.emptySet();
         this.nullValue = nullValue;
     }
 

--- a/server/src/main/java/org/elasticsearch/index/mapper/SourceValueFetcher.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/SourceValueFetcher.java
@@ -14,6 +14,7 @@ import org.elasticsearch.search.lookup.SourceLookup;
 
 import java.util.ArrayDeque;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Queue;
 import java.util.Set;
@@ -38,14 +39,14 @@ public abstract class SourceValueFetcher implements ValueFetcher {
      * @param nullValue An optional substitute value if the _source value is 'null'.
      */
     public SourceValueFetcher(String fieldName, SearchExecutionContext context, Object nullValue) {
-        this(context.sourcePath(fieldName), nullValue);
+        this(context.isSourceEnabled() ? context.sourcePath(fieldName) : Collections.emptySet(), nullValue);
     }
 
     /**
      * @param sourcePaths   The paths to pull source values from
      * @param nullValue     An optional substitute value if the _source value is `null`
      */
-    public SourceValueFetcher(Set<String> sourcePaths, Object nullValue) {
+    private SourceValueFetcher(Set<String> sourcePaths, Object nullValue) {
         this.sourcePaths = sourcePaths;
         this.nullValue = nullValue;
     }

--- a/server/src/main/java/org/elasticsearch/search/fetch/subphase/FetchFieldsPhase.java
+++ b/server/src/main/java/org/elasticsearch/search/fetch/subphase/FetchFieldsPhase.java
@@ -21,7 +21,8 @@ import java.util.Map;
 
 /**
  * A fetch sub-phase for high-level field retrieval. Given a list of fields, it
- * retrieves the field values from _source and returns them as document fields.
+ * retrieves the field values through the relevant {@link org.elasticsearch.index.mapper.ValueFetcher}
+ * and returns them as document fields.
  */
 public final class FetchFieldsPhase implements FetchSubPhase {
     @Override
@@ -29,15 +30,6 @@ public final class FetchFieldsPhase implements FetchSubPhase {
         FetchFieldsContext fetchFieldsContext = fetchContext.fetchFieldsContext();
         if (fetchFieldsContext == null) {
             return null;
-        }
-
-        if (fetchContext.getSearchExecutionContext().isSourceEnabled() == false) {
-            throw new IllegalArgumentException(
-                "Unable to retrieve the requested [fields] since _source is disabled "
-                    + "in the mappings for index ["
-                    + fetchContext.getIndexName()
-                    + "]"
-            );
         }
 
         FieldFetcher fieldFetcher = FieldFetcher.create(fetchContext.getSearchExecutionContext(), fetchFieldsContext.fields());

--- a/server/src/main/java/org/elasticsearch/search/fetch/subphase/FieldFetcher.java
+++ b/server/src/main/java/org/elasticsearch/search/fetch/subphase/FieldFetcher.java
@@ -33,7 +33,7 @@ import java.util.stream.Collectors;
 
 /**
  * A helper class to {@link FetchFieldsPhase} that's initialized with a list of field patterns to fetch.
- * Then given a specific document, it can retrieve the corresponding fields from the document's source.
+ * Then given a specific document, it can retrieve the corresponding fields through their corresponding {@link ValueFetcher}s.
  */
 public class FieldFetcher {
 

--- a/server/src/test/java/org/elasticsearch/index/mapper/flattened/KeyedFlattenedFieldTypeTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/flattened/KeyedFlattenedFieldTypeTests.java
@@ -176,6 +176,7 @@ public class KeyedFlattenedFieldTypeTests extends FieldTypeTestCase {
         Map<String, Object> sourceValue = Map.of("key", "value");
 
         SearchExecutionContext searchExecutionContext = mock(SearchExecutionContext.class);
+        when(searchExecutionContext.isSourceEnabled()).thenReturn(true);
         when(searchExecutionContext.sourcePath("field.key")).thenReturn(Set.of("field.key"));
 
         ValueFetcher fetcher = ft.valueFetcher(searchExecutionContext, null);

--- a/test/framework/src/main/java/org/elasticsearch/index/mapper/FieldTypeTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/index/mapper/FieldTypeTestCase.java
@@ -51,6 +51,7 @@ public abstract class FieldTypeTestCase extends ESTestCase {
     public static List<?> fetchSourceValue(MappedFieldType fieldType, Object sourceValue, String format) throws IOException {
         String field = fieldType.name();
         SearchExecutionContext searchExecutionContext = mock(SearchExecutionContext.class);
+        when(searchExecutionContext.isSourceEnabled()).thenReturn(true);
         when(searchExecutionContext.sourcePath(field)).thenReturn(Set.of(field));
 
         ValueFetcher fetcher = fieldType.valueFetcher(searchExecutionContext, format);
@@ -62,6 +63,7 @@ public abstract class FieldTypeTestCase extends ESTestCase {
     public static List<?> fetchSourceValues(MappedFieldType fieldType, Object... values) throws IOException {
         String field = fieldType.name();
         SearchExecutionContext searchExecutionContext = mock(SearchExecutionContext.class);
+        when(searchExecutionContext.isSourceEnabled()).thenReturn(true);
         when(searchExecutionContext.sourcePath(field)).thenReturn(Set.of(field));
 
         ValueFetcher fetcher = fieldType.valueFetcher(searchExecutionContext, null);

--- a/test/framework/src/main/java/org/elasticsearch/index/mapper/MapperTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/index/mapper/MapperTestCase.java
@@ -590,9 +590,10 @@ public abstract class MapperTestCase extends MapperServiceTestCase {
             ft.fielddataBuilder("test", () -> null).build(new IndexFieldDataCache.None(), new NoneCircuitBreakerService())
         );
         SearchExecutionContext searchExecutionContext = mock(SearchExecutionContext.class);
+        when(searchExecutionContext.isSourceEnabled()).thenReturn(true);
         when(searchExecutionContext.sourcePath(field)).thenReturn(Set.of(field));
         when(searchExecutionContext.getForField(ft)).thenAnswer(
-            inv -> { return fieldDataLookup().apply(ft, () -> { throw new UnsupportedOperationException(); }); }
+            inv -> fieldDataLookup().apply(ft, () -> { throw new UnsupportedOperationException(); })
         );
         ValueFetcher nativeFetcher = ft.valueFetcher(searchExecutionContext, format);
         ParsedDocument doc = mapperService.documentMapper().parse(source);

--- a/x-pack/plugin/sql/qa/server/src/main/java/org/elasticsearch/xpack/sql/qa/FieldExtractorTestCase.java
+++ b/x-pack/plugin/sql/qa/server/src/main/java/org/elasticsearch/xpack/sql/qa/FieldExtractorTestCase.java
@@ -37,8 +37,6 @@ import static java.util.Collections.singletonList;
 import static org.elasticsearch.common.xcontent.XContentHelper.stripWhitespace;
 import static org.elasticsearch.xpack.sql.qa.rest.RestSqlTestCase.assertResponse;
 import static org.elasticsearch.xpack.sql.qa.rest.RestSqlTestCase.columnInfo;
-import static org.elasticsearch.xpack.sql.qa.rest.RestSqlTestCase.expectBadRequest;
-import static org.hamcrest.Matchers.containsString;
 
 /**
  * Test class covering parameters/settings that can be used in the mapping of an index
@@ -46,6 +44,30 @@ import static org.hamcrest.Matchers.containsString;
  * values from Elasticsearch.
  */
 public abstract class FieldExtractorTestCase extends BaseRestSqlTestCase {
+
+    boolean explicitSourceSetting;
+    boolean enableSource;
+    Map<String, Object> indexProps;
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        explicitSourceSetting = randomBoolean(); // default (no _source setting) or explicit setting
+        enableSource = randomBoolean(); // enable _source at index level
+        indexProps = Maps.newMapWithExpectedSize(1);
+        indexProps.put("_source", enableSource);
+    }
+
+    private Object getExpectedValueFromSource(Object value) {
+        if (explicitSourceSetting && enableSource == false) {
+            return null;
+        }
+        return value;
+    }
+
+    private Map<String, Object> getIndexProps() {
+        return explicitSourceSetting ? indexProps : null;
+    }
 
     /*
      *    "text_field": {
@@ -55,23 +77,14 @@ public abstract class FieldExtractorTestCase extends BaseRestSqlTestCase {
     public void testTextField() throws IOException {
         String query = "SELECT text_field FROM test";
         String text = randomAlphaOfLength(20);
-        boolean explicitSourceSetting = randomBoolean(); // default (no _source setting) or explicit setting
-        boolean enableSource = randomBoolean(); // enable _source at index level
 
-        Map<String, Object> indexProps = Maps.newMapWithExpectedSize(1);
-        indexProps.put("_source", enableSource);
-
-        createIndexWithFieldTypeAndProperties("text", null, explicitSourceSetting ? indexProps : null);
+        createIndexWithFieldTypeAndProperties("text", null, getIndexProps());
         index("{\"text_field\":\"" + text + "\"}");
 
-        if (explicitSourceSetting == false || enableSource) {
-            Map<String, Object> expected = new HashMap<>();
-            expected.put("columns", asList(columnInfo("plain", "text_field", "text", JDBCType.VARCHAR, Integer.MAX_VALUE)));
-            expected.put("rows", singletonList(singletonList(text)));
-            assertResponse(expected, runSql(query));
-        } else {
-            expectSourceDisabledError(query);
-        }
+        Map<String, Object> expected = new HashMap<>();
+        expected.put("columns", asList(columnInfo("plain", "text_field", "text", JDBCType.VARCHAR, Integer.MAX_VALUE)));
+        expected.put("rows", singletonList(singletonList(getExpectedValueFromSource(text))));
+        assertResponse(expected, runSql(query));
     }
 
     /*
@@ -83,12 +96,7 @@ public abstract class FieldExtractorTestCase extends BaseRestSqlTestCase {
     public void testKeywordField() throws IOException {
         String query = "SELECT keyword_field FROM test";
         String keyword = randomAlphaOfLength(20);
-        boolean explicitSourceSetting = randomBoolean(); // default (no _source setting) or explicit setting
-        boolean enableSource = randomBoolean(); // enable _source at index level
         boolean ignoreAbove = randomBoolean();
-
-        Map<String, Object> indexProps = Maps.newMapWithExpectedSize(1);
-        indexProps.put("_source", enableSource);
 
         Map<String, Map<String, Object>> fieldProps = null;
         if (ignoreAbove) {
@@ -98,17 +106,13 @@ public abstract class FieldExtractorTestCase extends BaseRestSqlTestCase {
             fieldProps.put("keyword_field", fieldProp);
         }
 
-        createIndexWithFieldTypeAndProperties("keyword", fieldProps, explicitSourceSetting ? indexProps : null);
+        createIndexWithFieldTypeAndProperties("keyword", fieldProps, getIndexProps());
         index("{\"keyword_field\":\"" + keyword + "\"}");
 
-        if (explicitSourceSetting == false || enableSource) {
-            Map<String, Object> expected = new HashMap<>();
-            expected.put("columns", asList(columnInfo("plain", "keyword_field", "keyword", JDBCType.VARCHAR, Integer.MAX_VALUE)));
-            expected.put("rows", singletonList(singletonList(ignoreAbove ? null : keyword)));
-            assertResponse(expected, runSql(query));
-        } else {
-            expectSourceDisabledError(query);
-        }
+        Map<String, Object> expected = new HashMap<>();
+        expected.put("columns", asList(columnInfo("plain", "keyword_field", "keyword", JDBCType.VARCHAR, Integer.MAX_VALUE)));
+        expected.put("rows", singletonList(singletonList(getExpectedValueFromSource(ignoreAbove ? null : keyword))));
+        assertResponse(expected, runSql(query));
     }
 
     /*
@@ -120,11 +124,6 @@ public abstract class FieldExtractorTestCase extends BaseRestSqlTestCase {
     public void testConstantKeywordField() throws IOException {
         String query = "SELECT constant_keyword_field FROM test";
         String value = randomAlphaOfLength(20);
-        boolean explicitSourceSetting = randomBoolean(); // default (no _source setting) or explicit setting
-        boolean enableSource = randomBoolean(); // enable _source at index level
-
-        Map<String, Object> indexProps = Maps.newMapWithExpectedSize(1);
-        indexProps.put("_source", enableSource);
 
         Map<String, Map<String, Object>> fieldProps = null;
         if (randomBoolean()) {
@@ -134,17 +133,13 @@ public abstract class FieldExtractorTestCase extends BaseRestSqlTestCase {
             fieldProps.put("constant_keyword_field", fieldProp);
         }
 
-        createIndexWithFieldTypeAndProperties("constant_keyword", fieldProps, explicitSourceSetting ? indexProps : null);
+        createIndexWithFieldTypeAndProperties("constant_keyword", fieldProps, getIndexProps());
         index("{\"constant_keyword_field\":\"" + value + "\"}");
 
-        if (explicitSourceSetting == false || enableSource) {
-            Map<String, Object> expected = new HashMap<>();
-            expected.put("columns", asList(columnInfo("plain", "constant_keyword_field", "keyword", JDBCType.VARCHAR, Integer.MAX_VALUE)));
-            expected.put("rows", singletonList(singletonList(value)));
-            assertResponse(expected, runSql(query));
-        } else {
-            expectSourceDisabledError(query);
-        }
+        Map<String, Object> expected = new HashMap<>();
+        expected.put("columns", asList(columnInfo("plain", "constant_keyword_field", "keyword", JDBCType.VARCHAR, Integer.MAX_VALUE)));
+        expected.put("rows", singletonList(singletonList(value)));
+        assertResponse(expected, runSql(query));
     }
 
     /*
@@ -156,12 +151,7 @@ public abstract class FieldExtractorTestCase extends BaseRestSqlTestCase {
     public void testWildcardField() throws IOException {
         String query = "SELECT wildcard_field FROM test";
         String wildcard = randomAlphaOfLength(20);
-        boolean explicitSourceSetting = randomBoolean(); // default (no _source setting) or explicit setting
-        boolean enableSource = randomBoolean(); // enable _source at index level
         boolean ignoreAbove = randomBoolean();
-
-        Map<String, Object> indexProps = Maps.newMapWithExpectedSize(1);
-        indexProps.put("_source", enableSource);
 
         Map<String, Map<String, Object>> fieldProps = null;
         if (ignoreAbove) {
@@ -171,17 +161,13 @@ public abstract class FieldExtractorTestCase extends BaseRestSqlTestCase {
             fieldProps.put("wildcard_field", fieldProp);
         }
 
-        createIndexWithFieldTypeAndProperties("wildcard", fieldProps, explicitSourceSetting ? indexProps : null);
+        createIndexWithFieldTypeAndProperties("wildcard", fieldProps, getIndexProps());
         index("{\"wildcard_field\":\"" + wildcard + "\"}");
 
-        if (explicitSourceSetting == false || enableSource) {
-            Map<String, Object> expected = new HashMap<>();
-            expected.put("columns", asList(columnInfo("plain", "wildcard_field", "keyword", JDBCType.VARCHAR, Integer.MAX_VALUE)));
-            expected.put("rows", singletonList(singletonList(ignoreAbove ? null : wildcard)));
-            assertResponse(expected, runSql(query));
-        } else {
-            expectSourceDisabledError(query);
-        }
+        Map<String, Object> expected = new HashMap<>();
+        expected.put("columns", asList(columnInfo("plain", "wildcard_field", "keyword", JDBCType.VARCHAR, Integer.MAX_VALUE)));
+        expected.put("rows", singletonList(singletonList(getExpectedValueFromSource(ignoreAbove ? null : wildcard))));
+        assertResponse(expected, runSql(query));
     }
 
     /*
@@ -298,12 +284,7 @@ public abstract class FieldExtractorTestCase extends BaseRestSqlTestCase {
         String fieldName = fieldType + "_field";
         String query = "SELECT " + fieldName + " FROM test";
         Object actualValue = value;
-        boolean explicitSourceSetting = randomBoolean(); // default (no _source setting) or explicit setting
-        boolean enableSource = randomBoolean(); // enable _source at index level
         boolean ignoreMalformed = randomBoolean();       // ignore_malformed is true, thus test a non-number value
-
-        Map<String, Object> indexProps = Maps.newMapWithExpectedSize(1);
-        indexProps.put("_source", enableSource);
 
         Map<String, Map<String, Object>> fieldProps = null;
         if (ignoreMalformed) {
@@ -315,17 +296,13 @@ public abstract class FieldExtractorTestCase extends BaseRestSqlTestCase {
             actualValue = "\"foo\"";
         }
 
-        createIndexWithFieldTypeAndProperties(fieldType, fieldProps, explicitSourceSetting ? indexProps : null);
+        createIndexWithFieldTypeAndProperties(fieldType, fieldProps, getIndexProps());
         index("{\"" + fieldName + "\":" + actualValue + "}");
 
-        if (explicitSourceSetting == false || enableSource) {
-            Map<String, Object> expected = new HashMap<>();
-            expected.put("columns", asList(columnInfo("plain", fieldName, fieldType, jdbcTypeFor(fieldType), Integer.MAX_VALUE)));
-            expected.put("rows", singletonList(singletonList(ignoreMalformed ? null : actualValue)));
-            assertResponse(expected, runSql(query));
-        } else {
-            expectSourceDisabledError(query);
-        }
+        Map<String, Object> expected = new HashMap<>();
+        expected.put("columns", asList(columnInfo("plain", fieldName, fieldType, jdbcTypeFor(fieldType), Integer.MAX_VALUE)));
+        expected.put("rows", singletonList(singletonList(getExpectedValueFromSource(ignoreMalformed ? null : actualValue))));
+        assertResponse(expected, runSql(query));
     }
 
     /*
@@ -336,29 +313,20 @@ public abstract class FieldExtractorTestCase extends BaseRestSqlTestCase {
     public void testBooleanField() throws IOException {
         String query = "SELECT boolean_field FROM test";
         boolean booleanField = randomBoolean();
-        boolean explicitSourceSetting = randomBoolean(); // default (no _source setting) or explicit setting
-        boolean enableSource = randomBoolean(); // enable _source at index level
         boolean asString = randomBoolean();              // pass true or false as string "true" or "false
 
-        Map<String, Object> indexProps = Maps.newMapWithExpectedSize(1);
-        indexProps.put("_source", enableSource);
-
-        createIndexWithFieldTypeAndProperties("boolean", null, explicitSourceSetting ? indexProps : null);
+        createIndexWithFieldTypeAndProperties("boolean", null, getIndexProps());
         if (asString) {
             index("{\"boolean_field\":\"" + booleanField + "\"}");
         } else {
             index("{\"boolean_field\":" + booleanField + "}");
         }
 
-        if (explicitSourceSetting == false || enableSource) {
-            Map<String, Object> expected = new HashMap<>();
-            expected.put("columns", asList(columnInfo("plain", "boolean_field", "boolean", JDBCType.BOOLEAN, Integer.MAX_VALUE)));
-            // adding the boolean as a String here because parsing the response will yield a "true"/"false" String
-            expected.put("rows", singletonList(singletonList(booleanField)));
-            assertResponse(expected, runSql(query));
-        } else {
-            expectSourceDisabledError(query);
-        }
+        Map<String, Object> expected = new HashMap<>();
+        expected.put("columns", asList(columnInfo("plain", "boolean_field", "boolean", JDBCType.BOOLEAN, Integer.MAX_VALUE)));
+        // adding the boolean as a String here because parsing the response will yield a "true"/"false" String
+        expected.put("rows", singletonList(singletonList(getExpectedValueFromSource(booleanField))));
+        assertResponse(expected, runSql(query));
     }
 
     /*
@@ -369,14 +337,8 @@ public abstract class FieldExtractorTestCase extends BaseRestSqlTestCase {
      */
     public void testIpField() throws IOException {
         String query = "SELECT ip_field FROM test";
-        String ipField = "192.168.1.1";
-        String actualValue = ipField;
-        boolean explicitSourceSetting = randomBoolean(); // default (no _source setting) or explicit setting
-        boolean enableSource = randomBoolean(); // enable _source at index level
+        String actualValue = "192.168.1.1";
         boolean ignoreMalformed = randomBoolean();
-
-        Map<String, Object> indexProps = Maps.newMapWithExpectedSize(1);
-        indexProps.put("_source", enableSource);
 
         Map<String, Map<String, Object>> fieldProps = null;
         if (ignoreMalformed) {
@@ -387,17 +349,13 @@ public abstract class FieldExtractorTestCase extends BaseRestSqlTestCase {
             fieldProps.put("ip_field", fieldProp);
             actualValue = "foo";
         }
-        createIndexWithFieldTypeAndProperties("ip", fieldProps, explicitSourceSetting ? indexProps : null);
+        createIndexWithFieldTypeAndProperties("ip", fieldProps, getIndexProps());
         index("{\"ip_field\":\"" + actualValue + "\"}");
 
-        if (explicitSourceSetting == false || enableSource) {
-            Map<String, Object> expected = new HashMap<>();
-            expected.put("columns", asList(columnInfo("plain", "ip_field", "ip", JDBCType.VARCHAR, Integer.MAX_VALUE)));
-            expected.put("rows", singletonList(singletonList(ignoreMalformed ? null : actualValue)));
-            assertResponse(expected, runSql(query));
-        } else {
-            expectSourceDisabledError(query);
-        }
+        Map<String, Object> expected = new HashMap<>();
+        expected.put("columns", asList(columnInfo("plain", "ip_field", "ip", JDBCType.VARCHAR, Integer.MAX_VALUE)));
+        expected.put("rows", singletonList(singletonList(getExpectedValueFromSource(ignoreMalformed ? null : actualValue))));
+        assertResponse(expected, runSql(query));
     }
 
     /*
@@ -410,12 +368,7 @@ public abstract class FieldExtractorTestCase extends BaseRestSqlTestCase {
         String query = "SELECT geo_point_field FROM test";
         String geoPointField = "41.12,-71.34";
         String actualValue = geoPointField;
-        boolean explicitSourceSetting = randomBoolean(); // default (no _source setting) or explicit setting
-        boolean enableSource = randomBoolean();          // enable _source at index level
         boolean ignoreMalformed = randomBoolean();
-
-        Map<String, Object> indexProps = Maps.newMapWithExpectedSize(1);
-        indexProps.put("_source", enableSource);
 
         Map<String, Map<String, Object>> fieldProps = null;
         if (ignoreMalformed) {
@@ -426,17 +379,13 @@ public abstract class FieldExtractorTestCase extends BaseRestSqlTestCase {
             fieldProps.put("geo_point_field", fieldProp);
             actualValue = "foo";
         }
-        createIndexWithFieldTypeAndProperties("geo_point", fieldProps, explicitSourceSetting ? indexProps : null);
+        createIndexWithFieldTypeAndProperties("geo_point", fieldProps, getIndexProps());
         index("{\"geo_point_field\":\"" + actualValue + "\"}");
 
-        if (explicitSourceSetting == false || enableSource) {
-            Map<String, Object> expected = new HashMap<>();
-            expected.put("columns", asList(columnInfo("plain", "geo_point_field", "geo_point", JDBCType.VARCHAR, Integer.MAX_VALUE)));
-            expected.put("rows", singletonList(singletonList(ignoreMalformed ? null : "POINT (-71.34 41.12)")));
-            assertResponse(expected, runSql(query));
-        } else {
-            expectSourceDisabledError(query);
-        }
+        Map<String, Object> expected = new HashMap<>();
+        expected.put("columns", asList(columnInfo("plain", "geo_point_field", "geo_point", JDBCType.VARCHAR, Integer.MAX_VALUE)));
+        expected.put("rows", singletonList(singletonList(getExpectedValueFromSource(ignoreMalformed ? null : "POINT (-71.34 41.12)"))));
+        assertResponse(expected, runSql(query));
     }
 
     /*
@@ -448,12 +397,7 @@ public abstract class FieldExtractorTestCase extends BaseRestSqlTestCase {
     public void testGeoShapeField() throws IOException {
         String query = "SELECT geo_shape_field FROM test";
         String actualValue = "[-77.03653, 38.897676]";
-        boolean explicitSourceSetting = randomBoolean(); // default (no _source setting) or explicit setting
-        boolean enableSource = randomBoolean();          // enable _source at index level
         boolean ignoreMalformed = randomBoolean();
-
-        Map<String, Object> indexProps = Maps.newMapWithExpectedSize(1);
-        indexProps.put("_source", enableSource);
 
         Map<String, Map<String, Object>> fieldProps = null;
         if (ignoreMalformed) {
@@ -464,19 +408,18 @@ public abstract class FieldExtractorTestCase extends BaseRestSqlTestCase {
             fieldProps.put("geo_shape_field", fieldProp);
             actualValue = "\"foo\"";
         }
-        createIndexWithFieldTypeAndProperties("geo_shape", fieldProps, explicitSourceSetting ? indexProps : null);
+        createIndexWithFieldTypeAndProperties("geo_shape", fieldProps, getIndexProps());
         index("""
             {"geo_shape_field":{"type":"point","coordinates":%s}}
             """.formatted(actualValue));
 
-        if (explicitSourceSetting == false || enableSource) {
-            Map<String, Object> expected = new HashMap<>();
-            expected.put("columns", asList(columnInfo("plain", "geo_shape_field", "geo_shape", JDBCType.VARCHAR, Integer.MAX_VALUE)));
-            expected.put("rows", singletonList(singletonList(ignoreMalformed ? null : "POINT (-77.03653 38.897676)")));
-            assertResponse(expected, runSql(query));
-        } else {
-            expectSourceDisabledError(query);
-        }
+        Map<String, Object> expected = new HashMap<>();
+        expected.put("columns", asList(columnInfo("plain", "geo_shape_field", "geo_shape", JDBCType.VARCHAR, Integer.MAX_VALUE)));
+        expected.put(
+            "rows",
+            singletonList(singletonList(getExpectedValueFromSource(ignoreMalformed ? null : "POINT (-77.03653 38.897676)")))
+        );
+        assertResponse(expected, runSql(query));
     }
 
     /*
@@ -489,12 +432,7 @@ public abstract class FieldExtractorTestCase extends BaseRestSqlTestCase {
         String query = "SELECT shape_field FROM test";
         String shapeField = "POINT (-377.03653 389.897676)";
         String actualValue = shapeField;
-        boolean explicitSourceSetting = randomBoolean(); // default (no _source setting) or explicit setting
-        boolean enableSource = randomBoolean();          // enable _source at index level
         boolean ignoreMalformed = randomBoolean();
-
-        Map<String, Object> indexProps = Maps.newMapWithExpectedSize(1);
-        indexProps.put("_source", enableSource);
 
         Map<String, Map<String, Object>> fieldProps = null;
         if (ignoreMalformed) {
@@ -505,17 +443,13 @@ public abstract class FieldExtractorTestCase extends BaseRestSqlTestCase {
             fieldProps.put("shape_field", fieldProp);
             actualValue = "foo";
         }
-        createIndexWithFieldTypeAndProperties("shape", fieldProps, explicitSourceSetting ? indexProps : null);
+        createIndexWithFieldTypeAndProperties("shape", fieldProps, getIndexProps());
         index("{\"shape_field\":\"" + actualValue + "\"}");
 
-        if (explicitSourceSetting == false || enableSource) {
-            Map<String, Object> expected = new HashMap<>();
-            expected.put("columns", asList(columnInfo("plain", "shape_field", "shape", JDBCType.VARCHAR, Integer.MAX_VALUE)));
-            expected.put("rows", singletonList(singletonList(ignoreMalformed ? null : shapeField)));
-            assertResponse(expected, runSql(query));
-        } else {
-            expectSourceDisabledError(query);
-        }
+        Map<String, Object> expected = new HashMap<>();
+        expected.put("columns", asList(columnInfo("plain", "shape_field", "shape", JDBCType.VARCHAR, Integer.MAX_VALUE)));
+        expected.put("rows", singletonList(singletonList(getExpectedValueFromSource(ignoreMalformed ? null : shapeField))));
+        assertResponse(expected, runSql(query));
     }
 
     /*
@@ -627,15 +561,10 @@ public abstract class FieldExtractorTestCase extends BaseRestSqlTestCase {
      */
     public void testTextFieldWithKeywordSubfield() throws IOException {
         String text = randomAlphaOfLength(10) + " " + randomAlphaOfLength(10);
-        boolean explicitSourceSetting = randomBoolean(); // default (no _source setting) or explicit setting
-        boolean enableSource = randomBoolean(); // enable _source at index level
         boolean ignoreAbove = randomBoolean();
         String fieldName = "text_field";
         String subFieldName = "text_field.keyword_subfield";
         String query = "SELECT " + fieldName + "," + subFieldName + " FROM test";
-
-        Map<String, Object> indexProps = Maps.newMapWithExpectedSize(1);
-        indexProps.put("_source", enableSource);
 
         Map<String, Map<String, Object>> subFieldsProps = null;
         if (ignoreAbove) {
@@ -645,25 +574,23 @@ public abstract class FieldExtractorTestCase extends BaseRestSqlTestCase {
             subFieldsProps.put(subFieldName, fieldProp);
         }
 
-        createIndexWithFieldTypeAndSubFields("text", null, explicitSourceSetting ? indexProps : null, subFieldsProps, "keyword");
+        createIndexWithFieldTypeAndSubFields("text", null, getIndexProps(), subFieldsProps, "keyword");
         index("{\"" + fieldName + "\":\"" + text + "\"}");
 
-        if (explicitSourceSetting == false || enableSource) {
-            Map<String, Object> expected = new HashMap<>();
-            expected.put(
-                "columns",
-                asList(
-                    columnInfo("plain", fieldName, "text", JDBCType.VARCHAR, Integer.MAX_VALUE),
-                    columnInfo("plain", subFieldName, "keyword", JDBCType.VARCHAR, Integer.MAX_VALUE)
-                )
-            );
+        Map<String, Object> expected = new HashMap<>();
+        expected.put(
+            "columns",
+            asList(
+                columnInfo("plain", fieldName, "text", JDBCType.VARCHAR, Integer.MAX_VALUE),
+                columnInfo("plain", subFieldName, "keyword", JDBCType.VARCHAR, Integer.MAX_VALUE)
+            )
+        );
 
-            expected.put("rows", singletonList(asList(text, ignoreAbove ? null : text)));
-            assertResponse(expected, runSql(query));
-        } else {
-            expectSourceDisabledError(query);
-            expectSourceDisabledError("SELECT " + subFieldName + " FROM test");
-        }
+        expected.put(
+            "rows",
+            singletonList(asList(getExpectedValueFromSource(text), getExpectedValueFromSource(ignoreAbove ? null : text)))
+        );
+        assertResponse(expected, runSql(query));
     }
 
     /*
@@ -709,16 +636,11 @@ public abstract class FieldExtractorTestCase extends BaseRestSqlTestCase {
      */
     public void testTextFieldWithIntegerNumberSubfield() throws IOException {
         Integer number = randomInt();
-        boolean explicitSourceSetting = randomBoolean(); // default (no _source setting) or explicit setting
-        boolean enableSource = randomBoolean(); // enable _source at index level
         boolean ignoreMalformed = randomBoolean();       // ignore_malformed is true, thus test a non-number value
         Object actualValue = number;
         String fieldName = "text_field";
         String subFieldName = "text_field.integer_subfield";
         String query = "SELECT " + fieldName + "," + subFieldName + " FROM test";
-
-        Map<String, Object> indexProps = Maps.newMapWithExpectedSize(1);
-        indexProps.put("_source", enableSource);
 
         Map<String, Map<String, Object>> subFieldsProps = null;
         if (ignoreMalformed) {
@@ -730,29 +652,27 @@ public abstract class FieldExtractorTestCase extends BaseRestSqlTestCase {
             actualValue = "foo";
         }
 
-        createIndexWithFieldTypeAndSubFields("text", null, explicitSourceSetting ? indexProps : null, subFieldsProps, "integer");
+        createIndexWithFieldTypeAndSubFields("text", null, getIndexProps(), subFieldsProps, "integer");
         index("{\"" + fieldName + "\":\"" + actualValue + "\"}");
 
-        if (explicitSourceSetting == false || enableSource) {
-            Map<String, Object> expected = new HashMap<>();
-            expected.put(
-                "columns",
-                asList(
-                    columnInfo("plain", fieldName, "text", JDBCType.VARCHAR, Integer.MAX_VALUE),
-                    columnInfo("plain", subFieldName, "integer", JDBCType.INTEGER, Integer.MAX_VALUE)
-                )
-            );
-            if (ignoreMalformed) {
-                expected.put("rows", singletonList(asList("foo", null)));
-            } else {
-                expected.put("rows", singletonList(asList(String.valueOf(number), number)));
-            }
-            assertResponse(expected, runSql(query));
+        // (explicitSourceSetting && enableSource == false)
+        Map<String, Object> expected = new HashMap<>();
+        expected.put(
+            "columns",
+            asList(
+                columnInfo("plain", fieldName, "text", JDBCType.VARCHAR, Integer.MAX_VALUE),
+                columnInfo("plain", subFieldName, "integer", JDBCType.INTEGER, Integer.MAX_VALUE)
+            )
+        );
+        if (ignoreMalformed) {
+            expected.put("rows", singletonList(asList(getExpectedValueFromSource("foo"), null)));
         } else {
-            expectSourceDisabledError(query);
-            // if the _source is disabled, selecting only the integer sub-field shouldn't work as well
-            expectSourceDisabledError("SELECT " + subFieldName + " FROM test");
+            expected.put(
+                "rows",
+                singletonList(asList(getExpectedValueFromSource(String.valueOf(number)), getExpectedValueFromSource(number)))
+            );
         }
+        assertResponse(expected, runSql(query));
     }
 
     /*
@@ -768,16 +688,11 @@ public abstract class FieldExtractorTestCase extends BaseRestSqlTestCase {
      */
     public void testTextFieldWithIpSubfield() throws IOException {
         String ip = "123.123.123.123";
-        boolean explicitSourceSetting = randomBoolean(); // default (no _source setting) or explicit setting
-        boolean enableSource = randomBoolean();          // enable _source at index level
         boolean ignoreMalformed = randomBoolean();       // ignore_malformed is true, thus test a non-IP value
         String actualValue = ip;
         String fieldName = "text_field";
         String subFieldName = "text_field.ip_subfield";
         String query = "SELECT " + fieldName + "," + subFieldName + " FROM test";
-
-        Map<String, Object> indexProps = Maps.newMapWithExpectedSize(1);
-        indexProps.put("_source", enableSource);
 
         Map<String, Map<String, Object>> subFieldsProps = null;
         if (ignoreMalformed) {
@@ -789,29 +704,24 @@ public abstract class FieldExtractorTestCase extends BaseRestSqlTestCase {
             actualValue = "foo";
         }
 
-        createIndexWithFieldTypeAndSubFields("text", null, explicitSourceSetting ? indexProps : null, subFieldsProps, "ip");
+        createIndexWithFieldTypeAndSubFields("text", null, getIndexProps(), subFieldsProps, "ip");
         index("{\"" + fieldName + "\":\"" + actualValue + "\"}");
 
-        if (explicitSourceSetting == false || enableSource) {
-            Map<String, Object> expected = new HashMap<>();
-            expected.put(
-                "columns",
-                asList(
-                    columnInfo("plain", fieldName, "text", JDBCType.VARCHAR, Integer.MAX_VALUE),
-                    columnInfo("plain", subFieldName, "ip", JDBCType.VARCHAR, Integer.MAX_VALUE)
-                )
-            );
-            if (ignoreMalformed) {
-                expected.put("rows", singletonList(asList("foo", null)));
-            } else {
-                expected.put("rows", singletonList(asList(ip, ip)));
-            }
-            assertResponse(expected, runSql(query));
+        Map<String, Object> expected = new HashMap<>();
+        expected.put(
+            "columns",
+            asList(
+                columnInfo("plain", fieldName, "text", JDBCType.VARCHAR, Integer.MAX_VALUE),
+                columnInfo("plain", subFieldName, "ip", JDBCType.VARCHAR, Integer.MAX_VALUE)
+            )
+        );
+        if (ignoreMalformed) {
+            expected.put("rows", singletonList(asList(getExpectedValueFromSource("foo"), null)));
         } else {
-            expectSourceDisabledError(query);
-            // if the _source is disabled, selecting only the ip sub-field shouldn't work as well
-            expectSourceDisabledError("SELECT " + subFieldName + " FROM test");
+            Object expectedValueFromSource = getExpectedValueFromSource(ip);
+            expected.put("rows", singletonList(asList(expectedValueFromSource, expectedValueFromSource)));
         }
+        assertResponse(expected, runSql(query));
     }
 
     /*
@@ -827,17 +737,12 @@ public abstract class FieldExtractorTestCase extends BaseRestSqlTestCase {
      */
     public void testNumberFieldWithTextOrKeywordSubfield() throws IOException {
         Integer number = randomInt();
-        boolean explicitSourceSetting = randomBoolean(); // default (no _source setting) or explicit setting
-        boolean enableSource = randomBoolean(); // enable _source at index level
         boolean ignoreMalformed = randomBoolean();       // ignore_malformed is true, thus test a non-number value
         boolean isKeyword = randomBoolean();             // text or keyword subfield
         Object actualValue = number;
         String fieldName = "integer_field";
         String subFieldName = "integer_field." + (isKeyword ? "keyword_subfield" : "text_subfield");
         String query = "SELECT " + fieldName + "," + subFieldName + " FROM test";
-
-        Map<String, Object> indexProps = Maps.newMapWithExpectedSize(1);
-        indexProps.put("_source", enableSource);
 
         Map<String, Map<String, Object>> fieldProps = null;
         if (ignoreMalformed) {
@@ -849,39 +754,26 @@ public abstract class FieldExtractorTestCase extends BaseRestSqlTestCase {
             actualValue = "foo";
         }
 
-        createIndexWithFieldTypeAndSubFields(
-            "integer",
-            fieldProps,
-            explicitSourceSetting ? indexProps : null,
-            null,
-            isKeyword ? "keyword" : "text"
-        );
+        createIndexWithFieldTypeAndSubFields("integer", fieldProps, getIndexProps(), null, isKeyword ? "keyword" : "text");
         index("{\"" + fieldName + "\":\"" + actualValue + "\"}");
 
-        if (explicitSourceSetting == false || enableSource) {
-            Map<String, Object> expected = new HashMap<>();
-            expected.put(
-                "columns",
-                asList(
-                    columnInfo("plain", fieldName, "integer", JDBCType.INTEGER, Integer.MAX_VALUE),
-                    columnInfo("plain", subFieldName, isKeyword ? "keyword" : "text", JDBCType.VARCHAR, Integer.MAX_VALUE)
-                )
-            );
-            if (ignoreMalformed) {
-                expected.put("rows", singletonList(asList(null, "foo")));
-            } else {
-                expected.put("rows", singletonList(asList(number, String.valueOf(number))));
-            }
-            assertResponse(expected, runSql(query));
+        Map<String, Object> expected = new HashMap<>();
+        expected.put(
+            "columns",
+            asList(
+                columnInfo("plain", fieldName, "integer", JDBCType.INTEGER, Integer.MAX_VALUE),
+                columnInfo("plain", subFieldName, isKeyword ? "keyword" : "text", JDBCType.VARCHAR, Integer.MAX_VALUE)
+            )
+        );
+        if (ignoreMalformed) {
+            expected.put("rows", singletonList(asList(null, getExpectedValueFromSource("foo"))));
         } else {
-            // disabling the _source means that nothing should be retrieved by the "fields" API
-            if (isKeyword) {
-                expectSourceDisabledError("SELECT integer_field.keyword_subfield FROM test");
-            } else {
-                expectSourceDisabledError(query);
-            }
-            expectSourceDisabledError("SELECT " + fieldName + " FROM test");
+            expected.put(
+                "rows",
+                singletonList(asList(getExpectedValueFromSource(number), getExpectedValueFromSource(String.valueOf(number))))
+            );
         }
+        assertResponse(expected, runSql(query));
     }
 
     /*
@@ -897,17 +789,12 @@ public abstract class FieldExtractorTestCase extends BaseRestSqlTestCase {
      */
     public void testIpFieldWithTextOrKeywordSubfield() throws IOException {
         String ip = "123.123.123.123";
-        boolean explicitSourceSetting = randomBoolean(); // default (no _source setting) or explicit setting
-        boolean enableSource = randomBoolean();          // enable _source at index level
         boolean ignoreMalformed = randomBoolean();       // ignore_malformed is true, thus test a non-number value
         boolean isKeyword = randomBoolean();             // text or keyword subfield
         String actualValue = ip;
         String fieldName = "ip_field";
         String subFieldName = "ip_field." + (isKeyword ? "keyword_subfield" : "text_subfield");
         String query = "SELECT " + fieldName + "," + subFieldName + " FROM test";
-
-        Map<String, Object> indexProps = Maps.newMapWithExpectedSize(1);
-        indexProps.put("_source", enableSource);
 
         Map<String, Map<String, Object>> fieldProps = null;
         if (ignoreMalformed) {
@@ -919,35 +806,24 @@ public abstract class FieldExtractorTestCase extends BaseRestSqlTestCase {
             actualValue = "foo";
         }
 
-        createIndexWithFieldTypeAndSubFields(
-            "ip",
-            fieldProps,
-            explicitSourceSetting ? indexProps : null,
-            null,
-            isKeyword ? "keyword" : "text"
-        );
+        createIndexWithFieldTypeAndSubFields("ip", fieldProps, getIndexProps(), null, isKeyword ? "keyword" : "text");
         index("{\"" + fieldName + "\":\"" + actualValue + "\"}");
 
-        if (explicitSourceSetting == false || enableSource) {
-            Map<String, Object> expected = new HashMap<>();
-            expected.put(
-                "columns",
-                asList(
-                    columnInfo("plain", fieldName, "ip", JDBCType.VARCHAR, Integer.MAX_VALUE),
-                    columnInfo("plain", subFieldName, isKeyword ? "keyword" : "text", JDBCType.VARCHAR, Integer.MAX_VALUE)
-                )
-            );
-            if (ignoreMalformed) {
-                expected.put("rows", singletonList(asList(null, "foo")));
-            } else {
-                expected.put("rows", singletonList(asList(ip, ip)));
-            }
-            assertResponse(expected, runSql(query));
+        Map<String, Object> expected = new HashMap<>();
+        expected.put(
+            "columns",
+            asList(
+                columnInfo("plain", fieldName, "ip", JDBCType.VARCHAR, Integer.MAX_VALUE),
+                columnInfo("plain", subFieldName, isKeyword ? "keyword" : "text", JDBCType.VARCHAR, Integer.MAX_VALUE)
+            )
+        );
+        if (ignoreMalformed) {
+            expected.put("rows", singletonList(asList(null, getExpectedValueFromSource("foo"))));
         } else {
-            expectSourceDisabledError(query);
-            expectSourceDisabledError("SELECT " + fieldName + " FROM test");
-            expectSourceDisabledError("SELECT " + subFieldName + " FROM test");
+            Object expectedValueFromSource = getExpectedValueFromSource(ip);
+            expected.put("rows", singletonList(asList(expectedValueFromSource, expectedValueFromSource)));
         }
+        assertResponse(expected, runSql(query));
     }
 
     /*
@@ -965,16 +841,11 @@ public abstract class FieldExtractorTestCase extends BaseRestSqlTestCase {
     public void testIntegerFieldWithByteSubfield() throws IOException {
         boolean isByte = randomBoolean();
         Integer number = isByte ? randomByte() : randomIntBetween(Byte.MAX_VALUE + 1, Integer.MAX_VALUE);
-        boolean explicitSourceSetting = randomBoolean();   // default (no _source setting) or explicit setting
-        boolean enableSource = randomBoolean(); // enable _source at index level
         boolean rootIgnoreMalformed = randomBoolean();     // root field ignore_malformed
         boolean subFieldIgnoreMalformed = randomBoolean(); // sub-field ignore_malformed
         String fieldName = "integer_field";
         String subFieldName = "integer_field.byte_subfield";
         String query = "SELECT " + fieldName + "," + subFieldName + " FROM test";
-
-        Map<String, Object> indexProps = Maps.newMapWithExpectedSize(1);
-        indexProps.put("_source", enableSource);
 
         Map<String, Map<String, Object>> fieldProps = null;
         if (rootIgnoreMalformed) {
@@ -991,7 +862,7 @@ public abstract class FieldExtractorTestCase extends BaseRestSqlTestCase {
             subFieldProps.put(subFieldName, fieldProp);
         }
 
-        createIndexWithFieldTypeAndSubFields("integer", fieldProps, explicitSourceSetting ? indexProps : null, subFieldProps, "byte");
+        createIndexWithFieldTypeAndSubFields("integer", fieldProps, getIndexProps(), subFieldProps, "byte");
         index("{\"" + fieldName + "\":" + number + "}");
 
         Map<String, Object> expected = new HashMap<>();
@@ -1002,21 +873,13 @@ public abstract class FieldExtractorTestCase extends BaseRestSqlTestCase {
                 columnInfo("plain", subFieldName, "byte", JDBCType.TINYINT, Integer.MAX_VALUE)
             )
         );
-        if (explicitSourceSetting == false || enableSource) {
-            if (isByte || subFieldIgnoreMalformed) {
-                expected.put("rows", singletonList(asList(number, isByte ? number : null)));
-            } else {
-                expected.put("rows", Collections.emptyList());
-            }
-            assertResponse(expected, runSql(query));
+        if (isByte || subFieldIgnoreMalformed) {
+            Object expectedValueFromSource = getExpectedValueFromSource(number);
+            expected.put("rows", singletonList(asList(expectedValueFromSource, isByte ? expectedValueFromSource : null)));
         } else {
-            if (isByte || subFieldIgnoreMalformed) {
-                expectSourceDisabledError(query);
-            } else {
-                expected.put("rows", Collections.emptyList());
-                assertResponse(expected, runSql(query));
-            }
+            expected.put("rows", Collections.emptyList());
         }
+        assertResponse(expected, runSql(query));
     }
 
     /*
@@ -1034,16 +897,11 @@ public abstract class FieldExtractorTestCase extends BaseRestSqlTestCase {
     public void testByteFieldWithIntegerSubfield() throws IOException {
         boolean isByte = randomBoolean();
         Integer number = isByte ? randomByte() : randomIntBetween(Byte.MAX_VALUE + 1, Integer.MAX_VALUE);
-        boolean explicitSourceSetting = randomBoolean();   // default (no _source setting) or explicit setting
-        boolean enableSource = randomBoolean(); // enable _source at index level
         boolean rootIgnoreMalformed = randomBoolean();     // root field ignore_malformed
         boolean subFieldIgnoreMalformed = randomBoolean(); // sub-field ignore_malformed
         String fieldName = "byte_field";
         String subFieldName = "byte_field.integer_subfield";
         String query = "SELECT " + fieldName + "," + subFieldName + " FROM test";
-
-        Map<String, Object> indexProps = Maps.newMapWithExpectedSize(1);
-        indexProps.put("_source", enableSource);
 
         Map<String, Map<String, Object>> fieldProps = null;
         if (rootIgnoreMalformed) {
@@ -1060,7 +918,7 @@ public abstract class FieldExtractorTestCase extends BaseRestSqlTestCase {
             subFieldProps.put(subFieldName, fieldProp);
         }
 
-        createIndexWithFieldTypeAndSubFields("byte", fieldProps, explicitSourceSetting ? indexProps : null, subFieldProps, "integer");
+        createIndexWithFieldTypeAndSubFields("byte", fieldProps, getIndexProps(), subFieldProps, "integer");
         index("{\"" + fieldName + "\":" + number + "}");
 
         Map<String, Object> expected = new HashMap<>();
@@ -1071,21 +929,13 @@ public abstract class FieldExtractorTestCase extends BaseRestSqlTestCase {
                 columnInfo("plain", subFieldName, "integer", JDBCType.INTEGER, Integer.MAX_VALUE)
             )
         );
-        if (explicitSourceSetting == false || enableSource) {
-            if (isByte || rootIgnoreMalformed) {
-                expected.put("rows", singletonList(asList(isByte ? number : null, number)));
-            } else {
-                expected.put("rows", Collections.emptyList());
-            }
-            assertResponse(expected, runSql(query));
+        if (isByte || rootIgnoreMalformed) {
+            Object expectedValueFromSource = getExpectedValueFromSource(number);
+            expected.put("rows", singletonList(asList(isByte ? expectedValueFromSource : null, expectedValueFromSource)));
         } else {
-            if (isByte || rootIgnoreMalformed) {
-                expectSourceDisabledError(query);
-            } else {
-                expected.put("rows", Collections.emptyList());
-                assertResponse(expected, runSql(query));
-            }
+            expected.put("rows", Collections.emptyList());
         }
+        assertResponse(expected, runSql(query));
     }
 
     public void testNestedFieldsHierarchyWithMultiNestedValues() throws IOException {
@@ -1475,13 +1325,6 @@ public abstract class FieldExtractorTestCase extends BaseRestSqlTestCase {
 
     private boolean shouldAddNestedField() {
         return randomBoolean();
-    }
-
-    private void expectSourceDisabledError(String query) {
-        expectBadRequest(() -> {
-            client().performRequest(buildRequest(query));
-            return Collections.emptyMap();
-        }, containsString("Unable to retrieve the requested [fields] since _source is disabled in the mappings for index [test]"));
     }
 
     private void createIndexWithFieldTypeAndAlias(String type, Map<String, Map<String, Object>> fieldProps, Map<String, Object> indexProps)


### PR DESCRIPTION
Back when we introduced the fields parameter to the search API, it could only fetch values from _source, hence
the corresponding sub-fetch phase fails early whenever _source is disabled. Today though runtime fields can
be retrieved from a separate value fetcher that reads from fielddata, and metadata fields can be retrieved
from stored fields. These two scenarios currently throw an unnecessary error whenever _source is disabled.

This commit removes the check for disabled _source, so that runtime fields and metadata fields can be retrieved even when _source is disabled. Fields that need to be loaded from _source are simply skipped whenever _source is disabled, similar to when a field is not found in _source.

Closes #87072