### PR TITLE
Remove ImmutableOpenMap from most xpack tests

### DIFF
--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/DataTiersUsageTransportActionTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/DataTiersUsageTransportActionTests.java
@@ -85,14 +85,13 @@ public class DataTiersUsageTransportActionTests extends ESTestCase {
         IndexMetadata coldIndex2 = indexMetadata("cold-2", 1, 0, DataTier.DATA_COLD, DataTier.DATA_WARM); // Prefers cold over warm
         IndexMetadata nonTiered = indexMetadata("non-tier", 1, 0); // No tier
 
-        ImmutableOpenMap.Builder<String, IndexMetadata> indicesBuilder = ImmutableOpenMap.builder();
-        indicesBuilder.put("hot-1", hotIndex1);
-        indicesBuilder.put("hot-2", hotIndex2);
-        indicesBuilder.put("warm-1", warmIndex1);
-        indicesBuilder.put("cold-1", coldIndex1);
-        indicesBuilder.put("cold-2", coldIndex2);
-        indicesBuilder.put("non-tier", nonTiered);
-        ImmutableOpenMap<String, IndexMetadata> indices = indicesBuilder.build();
+        Map<String, IndexMetadata> indices = new HashMap<>();
+        indices.put("hot-1", hotIndex1);
+        indices.put("hot-2", hotIndex2);
+        indices.put("warm-1", warmIndex1);
+        indices.put("cold-1", coldIndex1);
+        indices.put("cold-2", coldIndex2);
+        indices.put("non-tier", nonTiered);
 
         Map<String, String> tiers = DataTiersUsageTransportAction.tierIndices(indices);
         assertThat(tiers.size(), equalTo(5));

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/DataTiersUsageTransportActionTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/DataTiersUsageTransportActionTests.java
@@ -29,7 +29,6 @@ import org.elasticsearch.cluster.routing.ShardRouting;
 import org.elasticsearch.cluster.routing.ShardRoutingState;
 import org.elasticsearch.cluster.routing.TestShardRouting;
 import org.elasticsearch.cluster.routing.allocation.DataTier;
-import org.elasticsearch.common.collect.ImmutableOpenMap;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.core.PathUtils;
 import org.elasticsearch.index.Index;

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/AllocationRoutedStepTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/AllocationRoutedStepTests.java
@@ -154,13 +154,12 @@ public class AllocationRoutedStepTests extends AbstractStepTestCase<AllocationRo
             .numberOfShards(1)
             .numberOfReplicas(1)
             .build();
-        ImmutableOpenMap.Builder<String, IndexMetadata> indices = ImmutableOpenMap.<String, IndexMetadata>builder()
-            .fPut(index.getName(), indexMetadata);
+        Map<String, IndexMetadata> indices = Map.of(index.getName(), indexMetadata);
 
         Settings clusterSettings = Settings.builder().put("cluster.routing.allocation.exclude._id", "node1").build();
         Settings.Builder nodeSettingsBuilder = Settings.builder();
         ClusterState clusterState = ClusterState.builder(ClusterState.EMPTY_STATE)
-            .metadata(Metadata.builder().indices(indices.build()).transientSettings(clusterSettings))
+            .metadata(Metadata.builder().indices(indices).transientSettings(clusterSettings))
             .nodes(
                 DiscoveryNodes.builder()
                     .add(
@@ -527,11 +526,10 @@ public class AllocationRoutedStepTests extends AbstractStepTestCase<AllocationRo
             .numberOfShards(shards)
             .numberOfReplicas(replicas)
             .build();
-        ImmutableOpenMap.Builder<String, IndexMetadata> indices = ImmutableOpenMap.<String, IndexMetadata>builder()
-            .fPut(index.getName(), indexMetadata);
+        Map<String, IndexMetadata> indices = Map.of(index.getName(), indexMetadata);
 
         ClusterState clusterState = ClusterState.builder(ClusterState.EMPTY_STATE)
-            .metadata(Metadata.builder().indices(indices.build()))
+            .metadata(Metadata.builder().indices(indices))
             .nodes(
                 DiscoveryNodes.builder()
                     .add(

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/AllocationRoutedStepTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/AllocationRoutedStepTests.java
@@ -19,7 +19,6 @@ import org.elasticsearch.cluster.routing.ShardRoutingState;
 import org.elasticsearch.cluster.routing.TestShardRouting;
 import org.elasticsearch.cluster.routing.UnassignedInfo;
 import org.elasticsearch.cluster.routing.UnassignedInfo.Reason;
-import org.elasticsearch.common.collect.ImmutableOpenMap;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.transport.TransportAddress;
 import org.elasticsearch.index.Index;

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/CheckShrinkReadyStepTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/CheckShrinkReadyStepTests.java
@@ -453,8 +453,7 @@ public class CheckShrinkReadyStepTests extends AbstractStepTestCase<CheckShrinkR
             .numberOfShards(1)
             .numberOfReplicas(1)
             .build();
-        ImmutableOpenMap.Builder<String, IndexMetadata> indices = ImmutableOpenMap.<String, IndexMetadata>builder()
-            .fPut(index.getName(), indexMetadata);
+        Map<String, IndexMetadata> indices = Map.of(index.getName(), indexMetadata);
 
         final SingleNodeShutdownMetadata.Type type = randomFrom(
             SingleNodeShutdownMetadata.Type.REMOVE,
@@ -464,7 +463,7 @@ public class CheckShrinkReadyStepTests extends AbstractStepTestCase<CheckShrinkR
         ClusterState clusterState = ClusterState.builder(ClusterState.EMPTY_STATE)
             .metadata(
                 Metadata.builder()
-                    .indices(indices.build())
+                    .indices(indices)
                     .putCustom(
                         NodesShutdownMetadata.TYPE,
                         new NodesShutdownMetadata(
@@ -531,8 +530,7 @@ public class CheckShrinkReadyStepTests extends AbstractStepTestCase<CheckShrinkR
             .numberOfShards(1)
             .numberOfReplicas(1)
             .build();
-        ImmutableOpenMap.Builder<String, IndexMetadata> indices = ImmutableOpenMap.<String, IndexMetadata>builder()
-            .fPut(index.getName(), indexMetadata);
+        Map<String, IndexMetadata> indices = Map.of(index.getName(), indexMetadata);
 
         final SingleNodeShutdownMetadata.Type type = randomFrom(
             SingleNodeShutdownMetadata.Type.REMOVE,
@@ -542,7 +540,7 @@ public class CheckShrinkReadyStepTests extends AbstractStepTestCase<CheckShrinkR
         ClusterState clusterState = ClusterState.builder(ClusterState.EMPTY_STATE)
             .metadata(
                 Metadata.builder()
-                    .indices(indices.build())
+                    .indices(indices)
                     .putCustom(
                         NodesShutdownMetadata.TYPE,
                         new NodesShutdownMetadata(
@@ -604,11 +602,10 @@ public class CheckShrinkReadyStepTests extends AbstractStepTestCase<CheckShrinkR
             .numberOfShards(shards)
             .numberOfReplicas(replicas)
             .build();
-        ImmutableOpenMap.Builder<String, IndexMetadata> indices = ImmutableOpenMap.<String, IndexMetadata>builder()
-            .fPut(index.getName(), indexMetadata);
+        Map<String, IndexMetadata> indices = Map.of(index.getName(), indexMetadata);
 
         ClusterState clusterState = ClusterState.builder(ClusterState.EMPTY_STATE)
-            .metadata(Metadata.builder().indices(indices.build()))
+            .metadata(Metadata.builder().indices(indices))
             .nodes(
                 DiscoveryNodes.builder()
                     .add(

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/CheckShrinkReadyStepTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/CheckShrinkReadyStepTests.java
@@ -22,7 +22,6 @@ import org.elasticsearch.cluster.routing.ShardRoutingState;
 import org.elasticsearch.cluster.routing.TestShardRouting;
 import org.elasticsearch.cluster.routing.UnassignedInfo;
 import org.elasticsearch.common.Strings;
-import org.elasticsearch.common.collect.ImmutableOpenMap;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.transport.TransportAddress;
 import org.elasticsearch.index.Index;

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/SetSingleNodeAllocateStepTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/SetSingleNodeAllocateStepTests.java
@@ -207,12 +207,11 @@ public class SetSingleNodeAllocateStepTests extends AbstractStepTestCase<SetSing
         );
 
         Settings clusterSettings = Settings.builder().put("cluster.routing.allocation.exclude._id", "node_id_0").build();
-        ImmutableOpenMap.Builder<String, IndexMetadata> indices = ImmutableOpenMap.<String, IndexMetadata>builder()
-            .fPut(index.getName(), indexMetadata);
+        Map<String, IndexMetadata> indices = Map.of(index.getName(), indexMetadata);
         IndexRoutingTable.Builder indexRoutingTable = IndexRoutingTable.builder(index)
             .addShard(TestShardRouting.newShardRouting(new ShardId(index, 0), "node_id_0", true, ShardRoutingState.STARTED));
         ClusterState clusterState = ClusterState.builder(ClusterState.EMPTY_STATE)
-            .metadata(Metadata.builder().indices(indices.build()).transientSettings(clusterSettings))
+            .metadata(Metadata.builder().indices(indices).transientSettings(clusterSettings))
             .nodes(nodes)
             .routingTable(RoutingTable.builder().add(indexRoutingTable).build())
             .build();
@@ -299,12 +298,11 @@ public class SetSingleNodeAllocateStepTests extends AbstractStepTestCase<SetSing
             validNodeIds.add(nodeId);
         }
 
-        ImmutableOpenMap.Builder<String, IndexMetadata> indices = ImmutableOpenMap.<String, IndexMetadata>builder()
-            .fPut(index.getName(), indexMetadata);
+        Map<String, IndexMetadata> indices = Map.of(index.getName(), indexMetadata);
         IndexRoutingTable.Builder indexRoutingTable = IndexRoutingTable.builder(index)
             .addShard(TestShardRouting.newShardRouting(new ShardId(index, 0), "node_id_0", true, ShardRoutingState.STARTED));
         ClusterState clusterState = ClusterState.builder(ClusterState.EMPTY_STATE)
-            .metadata(Metadata.builder().indices(indices.build()))
+            .metadata(Metadata.builder().indices(indices))
             .nodes(nodes)
             .routingTable(RoutingTable.builder().add(indexRoutingTable).build())
             .build();
@@ -372,11 +370,10 @@ public class SetSingleNodeAllocateStepTests extends AbstractStepTestCase<SetSing
             nodes.add(DiscoveryNode.createLocal(nodeSettings, new TransportAddress(TransportAddress.META_ADDRESS, nodePort), nodeId));
         }
 
-        ImmutableOpenMap.Builder<String, IndexMetadata> indices = ImmutableOpenMap.<String, IndexMetadata>builder()
-            .fPut(index.getName(), indexMetadata);
+        Map<String, IndexMetadata> indices = Map.of(index.getName(), indexMetadata);
         IndexRoutingTable.Builder indexRoutingTable = IndexRoutingTable.builder(index);
         ClusterState clusterState = ClusterState.builder(ClusterState.EMPTY_STATE)
-            .metadata(Metadata.builder().indices(indices.build()))
+            .metadata(Metadata.builder().indices(indices))
             .nodes(nodes)
             .routingTable(RoutingTable.builder().add(indexRoutingTable).build())
             .build();
@@ -611,10 +608,9 @@ public class SetSingleNodeAllocateStepTests extends AbstractStepTestCase<SetSing
         DiscoveryNodes nodes,
         IndexRoutingTable indexRoutingTable
     ) throws Exception {
-        ImmutableOpenMap.Builder<String, IndexMetadata> indices = ImmutableOpenMap.<String, IndexMetadata>builder()
-            .fPut(index.getName(), indexMetadata);
+        Map<String, IndexMetadata> indices = Map.of(index.getName(), indexMetadata);
         ClusterState clusterState = ClusterState.builder(ClusterState.EMPTY_STATE)
-            .metadata(Metadata.builder().indices(indices.build()))
+            .metadata(Metadata.builder().indices(indices))
             .nodes(nodes)
             .routingTable(RoutingTable.builder().add(indexRoutingTable).build())
             .build();
@@ -652,10 +648,9 @@ public class SetSingleNodeAllocateStepTests extends AbstractStepTestCase<SetSing
 
     private void assertNoValidNode(IndexMetadata indexMetadata, Index index, DiscoveryNodes nodes, IndexRoutingTable indexRoutingTable) {
 
-        ImmutableOpenMap.Builder<String, IndexMetadata> indices = ImmutableOpenMap.<String, IndexMetadata>builder()
-            .fPut(index.getName(), indexMetadata);
+        Map<String, IndexMetadata> indices = Map.of(index.getName(), indexMetadata);
         ClusterState clusterState = ClusterState.builder(ClusterState.EMPTY_STATE)
-            .metadata(Metadata.builder().indices(indices.build()))
+            .metadata(Metadata.builder().indices(indices))
             .nodes(nodes)
             .routingTable(RoutingTable.builder().add(indexRoutingTable).build())
             .build();

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/SetSingleNodeAllocateStepTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/SetSingleNodeAllocateStepTests.java
@@ -22,7 +22,6 @@ import org.elasticsearch.cluster.routing.IndexRoutingTable;
 import org.elasticsearch.cluster.routing.RoutingTable;
 import org.elasticsearch.cluster.routing.ShardRoutingState;
 import org.elasticsearch.cluster.routing.TestShardRouting;
-import org.elasticsearch.common.collect.ImmutableOpenMap;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.settings.Settings.Builder;
 import org.elasticsearch.common.transport.TransportAddress;

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/ShrinkStepTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/ShrinkStepTests.java
@@ -17,7 +17,6 @@ import org.elasticsearch.cluster.metadata.AliasMetadata;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.metadata.LifecycleExecutionState;
 import org.elasticsearch.cluster.metadata.Metadata;
-import org.elasticsearch.common.collect.ImmutableOpenMap;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.xpack.core.ilm.Step.StepKey;
@@ -155,9 +154,7 @@ public class ShrinkStepTests extends AbstractStepTestCase<ShrinkStep> {
             .numberOfReplicas(0)
             .build();
         Map<String, IndexMetadata> indices = Map.of(generatedShrunkenIndexName, indexMetadata);
-        ClusterState clusterState = ClusterState.builder(ClusterState.EMPTY_STATE)
-            .metadata(Metadata.builder().indices(indices))
-            .build();
+        ClusterState clusterState = ClusterState.builder(ClusterState.EMPTY_STATE).metadata(Metadata.builder().indices(indices)).build();
 
         step.performAction(sourceIndexMetadata, clusterState, null, new ActionListener<>() {
             @Override

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/ShrinkStepTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/ShrinkStepTests.java
@@ -24,6 +24,7 @@ import org.elasticsearch.xpack.core.ilm.Step.StepKey;
 import org.mockito.Mockito;
 
 import java.util.Collections;
+import java.util.Map;
 
 import static org.elasticsearch.cluster.metadata.LifecycleExecutionState.ILM_CUSTOM_METADATA_KEY;
 import static org.elasticsearch.xpack.core.ilm.ShrinkIndexNameSupplier.SHRUNKEN_INDEX_PREFIX;
@@ -153,10 +154,9 @@ public class ShrinkStepTests extends AbstractStepTestCase<ShrinkStep> {
             .numberOfShards(1)
             .numberOfReplicas(0)
             .build();
-        ImmutableOpenMap.Builder<String, IndexMetadata> indices = ImmutableOpenMap.<String, IndexMetadata>builder()
-            .fPut(generatedShrunkenIndexName, indexMetadata);
+        Map<String, IndexMetadata> indices = Map.of(generatedShrunkenIndexName, indexMetadata);
         ClusterState clusterState = ClusterState.builder(ClusterState.EMPTY_STATE)
-            .metadata(Metadata.builder().indices(indices.build()))
+            .metadata(Metadata.builder().indices(indices))
             .build();
 
         step.performAction(sourceIndexMetadata, clusterState, null, new ActionListener<>() {

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/WaitForSnapshotStepTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/WaitForSnapshotStepTests.java
@@ -57,9 +57,8 @@ public class WaitForSnapshotStepTests extends AbstractStepTestCase<WaitForSnapsh
             .numberOfShards(randomIntBetween(1, 5))
             .numberOfReplicas(randomIntBetween(0, 5))
             .build();
-        ImmutableOpenMap.Builder<String, IndexMetadata> indices = ImmutableOpenMap.<String, IndexMetadata>builder()
-            .fPut(indexMetadata.getIndex().getName(), indexMetadata);
-        Metadata.Builder meta = Metadata.builder().indices(indices.build());
+        Map<String, IndexMetadata> indices = Map.of(indexMetadata.getIndex().getName(), indexMetadata);
+        Metadata.Builder meta = Metadata.builder().indices(indices);
         ClusterState clusterState = ClusterState.builder(ClusterName.DEFAULT).metadata(meta).build();
         WaitForSnapshotStep instance = createRandomInstance();
         IllegalStateException e = expectThrows(
@@ -87,9 +86,8 @@ public class WaitForSnapshotStepTests extends AbstractStepTestCase<WaitForSnapsh
             .numberOfShards(randomIntBetween(1, 5))
             .numberOfReplicas(randomIntBetween(0, 5))
             .build();
-        ImmutableOpenMap.Builder<String, IndexMetadata> indices = ImmutableOpenMap.<String, IndexMetadata>builder()
-            .fPut(indexMetadata.getIndex().getName(), indexMetadata);
-        Metadata.Builder meta = Metadata.builder().indices(indices.build()).putCustom(SnapshotLifecycleMetadata.TYPE, smlMetadata);
+        Map<String, IndexMetadata> indices = Map.of(indexMetadata.getIndex().getName(), indexMetadata);
+        Metadata.Builder meta = Metadata.builder().indices(indices).putCustom(SnapshotLifecycleMetadata.TYPE, smlMetadata);
         ClusterState clusterState = ClusterState.builder(ClusterName.DEFAULT).metadata(meta).build();
         ClusterStateWaitStep.Result result = instance.isConditionMet(indexMetadata.getIndex(), clusterState);
         assertFalse(result.isComplete());
@@ -139,9 +137,8 @@ public class WaitForSnapshotStepTests extends AbstractStepTestCase<WaitForSnapsh
             .numberOfShards(randomIntBetween(1, 5))
             .numberOfReplicas(randomIntBetween(0, 5))
             .build();
-        ImmutableOpenMap.Builder<String, IndexMetadata> indices = ImmutableOpenMap.<String, IndexMetadata>builder()
-            .fPut(indexMetadata.getIndex().getName(), indexMetadata);
-        Metadata.Builder meta = Metadata.builder().indices(indices.build()).putCustom(SnapshotLifecycleMetadata.TYPE, smlMetadata);
+        Map<String, IndexMetadata> indices = Map.of(indexMetadata.getIndex().getName(), indexMetadata);
+        Metadata.Builder meta = Metadata.builder().indices(indices).putCustom(SnapshotLifecycleMetadata.TYPE, smlMetadata);
         ClusterState clusterState = ClusterState.builder(ClusterName.DEFAULT).metadata(meta).build();
         ClusterStateWaitStep.Result result = instance.isConditionMet(indexMetadata.getIndex(), clusterState);
         if (startTimeAfterPhaseTime) {
@@ -174,9 +171,8 @@ public class WaitForSnapshotStepTests extends AbstractStepTestCase<WaitForSnapsh
             .numberOfShards(randomIntBetween(1, 5))
             .numberOfReplicas(randomIntBetween(0, 5))
             .build();
-        ImmutableOpenMap.Builder<String, IndexMetadata> indices = ImmutableOpenMap.<String, IndexMetadata>builder()
-            .fPut(indexMetadata.getIndex().getName(), indexMetadata);
-        Metadata.Builder meta = Metadata.builder().indices(indices.build()).putCustom(SnapshotLifecycleMetadata.TYPE, smlMetadata);
+        Map<String, IndexMetadata> indices = Map.of(indexMetadata.getIndex().getName(), indexMetadata);
+        Metadata.Builder meta = Metadata.builder().indices(indices).putCustom(SnapshotLifecycleMetadata.TYPE, smlMetadata);
         ClusterState clusterState = ClusterState.builder(ClusterName.DEFAULT).metadata(meta).build();
         IllegalStateException e = expectThrows(
             IllegalStateException.class,

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/WaitForSnapshotStepTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/WaitForSnapshotStepTests.java
@@ -13,7 +13,6 @@ import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.metadata.LifecycleExecutionState;
 import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.common.Strings;
-import org.elasticsearch.common.collect.ImmutableOpenMap;
 import org.elasticsearch.xpack.core.slm.SnapshotInvocationRecord;
 import org.elasticsearch.xpack.core.slm.SnapshotLifecycleMetadata;
 import org.elasticsearch.xpack.core.slm.SnapshotLifecyclePolicy;

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/utils/MlIndexAndAliasTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/utils/MlIndexAndAliasTests.java
@@ -413,8 +413,8 @@ public class MlIndexAndAliasTests extends ESTestCase {
             )
             .metadata(
                 Metadata.builder()
-                    .indices(ImmutableOpenMap.<String, IndexMetadata>builder().putAllFromMap(indices).build())
-                    .templates(ImmutableOpenMap.<String, IndexTemplateMetadata>builder().putAllFromMap(legacyTemplates).build())
+                    .indices(indices)
+                    .templates(legacyTemplates)
                     .indexTemplates(composableTemplates)
                     .build()
             )

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/utils/MlIndexAndAliasTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/utils/MlIndexAndAliasTests.java
@@ -35,7 +35,6 @@ import org.elasticsearch.cluster.metadata.IndexTemplateMetadata;
 import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
-import org.elasticsearch.common.collect.ImmutableOpenMap;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.transport.TransportAddress;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
@@ -411,13 +410,7 @@ public class MlIndexAndAliasTests extends ESTestCase {
                     .add(new DiscoveryNode("bar", new TransportAddress(inetAddress2, 9202), minNodeVersion))
                     .build()
             )
-            .metadata(
-                Metadata.builder()
-                    .indices(indices)
-                    .templates(legacyTemplates)
-                    .indexTemplates(composableTemplates)
-                    .build()
-            )
+            .metadata(Metadata.builder().indices(indices).templates(legacyTemplates).indexTemplates(composableTemplates).build())
             .build();
     }
 

--- a/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/DeprecationInfoAction.java
+++ b/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/DeprecationInfoAction.java
@@ -19,7 +19,6 @@ import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.metadata.Metadata;
-import org.elasticsearch.common.collect.ImmutableOpenMap;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.regex.Regex;

--- a/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/DeprecationInfoAction.java
+++ b/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/DeprecationInfoAction.java
@@ -312,7 +312,7 @@ public class DeprecationInfoAction extends ActionType<DeprecationInfoAction.Resp
         metadataBuilder.persistentSettings(
             metadataBuilder.persistentSettings().filter(setting -> Regex.simpleMatch(skipTheseDeprecatedSettings, setting) == false)
         );
-        ImmutableOpenMap.Builder<String, IndexMetadata> indicesBuilder = ImmutableOpenMap.builder(state.getMetadata().indices());
+        Map<String, IndexMetadata> indicesBuilder = new HashMap<>(state.getMetadata().indices());
         for (String indexName : indexNames) {
             IndexMetadata indexMetadata = state.getMetadata().index(indexName);
             IndexMetadata.Builder filteredIndexMetadataBuilder = new IndexMetadata.Builder(indexMetadata);
@@ -321,7 +321,7 @@ public class DeprecationInfoAction extends ActionType<DeprecationInfoAction.Resp
             filteredIndexMetadataBuilder.settings(filteredSettings);
             indicesBuilder.put(indexName, filteredIndexMetadataBuilder.build());
         }
-        metadataBuilder.indices(indicesBuilder.build());
+        metadataBuilder.indices(indicesBuilder);
         clusterStateBuilder.metadata(metadataBuilder);
         return clusterStateBuilder.build();
     }

--- a/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/ilm/IndexLifecycleServiceTests.java
+++ b/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/ilm/IndexLifecycleServiceTests.java
@@ -57,6 +57,7 @@ import java.time.Clock;
 import java.time.Instant;
 import java.time.ZoneId;
 import java.util.Collections;
+import java.util.Map;
 import java.util.SortedMap;
 import java.util.TreeMap;
 import java.util.UUID;
@@ -162,11 +163,10 @@ public class IndexLifecycleServiceTests extends ESTestCase {
             .numberOfShards(randomIntBetween(1, 5))
             .numberOfReplicas(randomIntBetween(0, 5))
             .build();
-        ImmutableOpenMap.Builder<String, IndexMetadata> indices = ImmutableOpenMap.<String, IndexMetadata>builder()
-            .fPut(index.getName(), indexMetadata);
+        Map<String, IndexMetadata> indices = Map.of(index.getName(), indexMetadata);
         Metadata metadata = Metadata.builder()
             .putCustom(IndexLifecycleMetadata.TYPE, new IndexLifecycleMetadata(policyMap, OperationMode.STOPPED))
-            .indices(indices.build())
+            .indices(indices)
             .persistentSettings(settings(Version.CURRENT).build())
             .build();
         ClusterState currentState = ClusterState.builder(ClusterName.DEFAULT)
@@ -205,11 +205,10 @@ public class IndexLifecycleServiceTests extends ESTestCase {
             .numberOfShards(randomIntBetween(1, 5))
             .numberOfReplicas(randomIntBetween(0, 5))
             .build();
-        ImmutableOpenMap.Builder<String, IndexMetadata> indices = ImmutableOpenMap.<String, IndexMetadata>builder()
-            .fPut(index.getName(), indexMetadata);
+        Map<String, IndexMetadata> indices = Map.of(index.getName(), indexMetadata);
         Metadata metadata = Metadata.builder()
             .putCustom(IndexLifecycleMetadata.TYPE, new IndexLifecycleMetadata(policyMap, OperationMode.STOPPING))
-            .indices(indices.build())
+            .indices(indices)
             .persistentSettings(settings(Version.CURRENT).build())
             .build();
         ClusterState currentState = ClusterState.builder(ClusterName.DEFAULT)
@@ -265,11 +264,10 @@ public class IndexLifecycleServiceTests extends ESTestCase {
             .numberOfShards(randomIntBetween(1, 5))
             .numberOfReplicas(randomIntBetween(0, 5))
             .build();
-        ImmutableOpenMap.Builder<String, IndexMetadata> indices = ImmutableOpenMap.<String, IndexMetadata>builder()
-            .fPut(index.getName(), indexMetadata);
+        Map<String, IndexMetadata> indices = Map.of(index.getName(), indexMetadata);
         Metadata metadata = Metadata.builder()
             .putCustom(IndexLifecycleMetadata.TYPE, new IndexLifecycleMetadata(policyMap, OperationMode.STOPPING))
-            .indices(indices.build())
+            .indices(indices)
             .persistentSettings(settings(Version.CURRENT).build())
             .build();
         ClusterState currentState = ClusterState.builder(ClusterName.DEFAULT)
@@ -318,11 +316,10 @@ public class IndexLifecycleServiceTests extends ESTestCase {
             .numberOfShards(randomIntBetween(1, 5))
             .numberOfReplicas(randomIntBetween(0, 5))
             .build();
-        ImmutableOpenMap.Builder<String, IndexMetadata> indices = ImmutableOpenMap.<String, IndexMetadata>builder()
-            .fPut(index.getName(), indexMetadata);
+        Map<String, IndexMetadata> indices = Map.of(index.getName(), indexMetadata);
         Metadata metadata = Metadata.builder()
             .putCustom(IndexLifecycleMetadata.TYPE, new IndexLifecycleMetadata(policyMap, OperationMode.STOPPING))
-            .indices(indices.build())
+            .indices(indices)
             .persistentSettings(settings(Version.CURRENT).build())
             .build();
         ClusterState currentState = ClusterState.builder(ClusterName.DEFAULT)
@@ -441,13 +438,11 @@ public class IndexLifecycleServiceTests extends ESTestCase {
             .numberOfShards(randomIntBetween(1, 5))
             .numberOfReplicas(randomIntBetween(0, 5))
             .build();
-        ImmutableOpenMap.Builder<String, IndexMetadata> indices = ImmutableOpenMap.<String, IndexMetadata>builder()
-            .fPut(index1.getName(), i1indexMetadata)
-            .fPut(index2.getName(), i2indexMetadata);
+        Map<String, IndexMetadata> indices = Map.of(index1.getName(), i1indexMetadata, index2.getName(), i2indexMetadata);
 
         Metadata metadata = Metadata.builder()
             .putCustom(IndexLifecycleMetadata.TYPE, new IndexLifecycleMetadata(policyMap, OperationMode.RUNNING))
-            .indices(indices.build())
+            .indices(indices)
             .persistentSettings(settings(Version.CURRENT).build())
             .build();
 
@@ -572,13 +567,11 @@ public class IndexLifecycleServiceTests extends ESTestCase {
             .numberOfShards(randomIntBetween(1, 5))
             .numberOfReplicas(randomIntBetween(0, 5))
             .build();
-        ImmutableOpenMap.Builder<String, IndexMetadata> indices = ImmutableOpenMap.<String, IndexMetadata>builder()
-            .fPut("no_danger", nonDangerousIndex)
-            .fPut("danger", dangerousIndex);
+        Map<String, IndexMetadata> indices = Map.of("no_danger", nonDangerousIndex, "danger", dangerousIndex);
 
         Metadata metadata = Metadata.builder()
             .putCustom(IndexLifecycleMetadata.TYPE, new IndexLifecycleMetadata(Collections.emptyMap(), OperationMode.RUNNING))
-            .indices(indices.build())
+            .indices(indices)
             .persistentSettings(settings(Version.CURRENT).build())
             .build();
 

--- a/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/ilm/IndexLifecycleServiceTests.java
+++ b/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/ilm/IndexLifecycleServiceTests.java
@@ -23,7 +23,6 @@ import org.elasticsearch.cluster.metadata.SingleNodeShutdownMetadata;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
 import org.elasticsearch.cluster.service.ClusterService;
-import org.elasticsearch.common.collect.ImmutableOpenMap;
 import org.elasticsearch.common.component.Lifecycle.State;
 import org.elasticsearch.common.settings.ClusterSettings;
 import org.elasticsearch.common.settings.Settings;

--- a/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/ilm/OperationModeUpdateTaskTests.java
+++ b/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/ilm/OperationModeUpdateTaskTests.java
@@ -10,7 +10,6 @@ import org.elasticsearch.Version;
 import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.metadata.Metadata;
-import org.elasticsearch.common.collect.ImmutableOpenMap;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.core.ilm.IndexLifecycleMetadata;
 import org.elasticsearch.xpack.core.ilm.OperationMode;
@@ -70,7 +69,9 @@ public class OperationModeUpdateTaskTests extends ESTestCase {
         );
         Metadata.Builder metadata = Metadata.builder().persistentSettings(settings(Version.CURRENT).build());
         if (metadataInstalled) {
-            metadata.customs(Map.of(IndexLifecycleMetadata.TYPE, indexLifecycleMetadata, SnapshotLifecycleMetadata.TYPE, snapshotLifecycleMetadata));
+            metadata.customs(
+                Map.of(IndexLifecycleMetadata.TYPE, indexLifecycleMetadata, SnapshotLifecycleMetadata.TYPE, snapshotLifecycleMetadata)
+            );
         }
         ClusterState state = ClusterState.builder(ClusterName.DEFAULT).metadata(metadata).build();
         OperationModeUpdateTask task = OperationModeUpdateTask.ilmMode(requestMode);

--- a/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/ilm/OperationModeUpdateTaskTests.java
+++ b/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/ilm/OperationModeUpdateTaskTests.java
@@ -18,6 +18,7 @@ import org.elasticsearch.xpack.core.slm.SnapshotLifecycleMetadata;
 import org.elasticsearch.xpack.core.slm.SnapshotLifecycleStats;
 
 import java.util.Collections;
+import java.util.Map;
 
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.not;
@@ -67,14 +68,9 @@ public class OperationModeUpdateTaskTests extends ESTestCase {
             currentMode,
             new SnapshotLifecycleStats()
         );
-        ImmutableOpenMap.Builder<String, Metadata.Custom> customsMapBuilder = ImmutableOpenMap.builder();
         Metadata.Builder metadata = Metadata.builder().persistentSettings(settings(Version.CURRENT).build());
         if (metadataInstalled) {
-            metadata.customs(
-                customsMapBuilder.fPut(IndexLifecycleMetadata.TYPE, indexLifecycleMetadata)
-                    .fPut(SnapshotLifecycleMetadata.TYPE, snapshotLifecycleMetadata)
-                    .build()
-            );
+            metadata.customs(Map.of(IndexLifecycleMetadata.TYPE, indexLifecycleMetadata, SnapshotLifecycleMetadata.TYPE, snapshotLifecycleMetadata));
         }
         ClusterState state = ClusterState.builder(ClusterName.DEFAULT).metadata(metadata).build();
         OperationModeUpdateTask task = OperationModeUpdateTask.ilmMode(requestMode);

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/MlInitializationServiceTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/MlInitializationServiceTests.java
@@ -14,7 +14,6 @@ import org.elasticsearch.client.internal.Client;
 import org.elasticsearch.client.internal.IndicesAdminClient;
 import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.cluster.service.ClusterService;
-import org.elasticsearch.common.collect.ImmutableOpenMap;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.threadpool.Scheduler;

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/MlInitializationServiceTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/MlInitializationServiceTests.java
@@ -21,6 +21,7 @@ import org.elasticsearch.threadpool.Scheduler;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.junit.Before;
 
+import java.util.Map;
 import java.util.concurrent.ExecutorService;
 
 import static org.hamcrest.Matchers.is;
@@ -63,7 +64,7 @@ public class MlInitializationServiceTests extends ESTestCase {
 
         @SuppressWarnings("unchecked")
         ActionFuture<GetSettingsResponse> getSettingsResponseActionFuture = mock(ActionFuture.class);
-        when(getSettingsResponseActionFuture.actionGet()).thenReturn(new GetSettingsResponse(ImmutableOpenMap.of(), ImmutableOpenMap.of()));
+        when(getSettingsResponseActionFuture.actionGet()).thenReturn(new GetSettingsResponse(Map.of(), Map.of()));
         IndicesAdminClient indicesAdminClient = mock(IndicesAdminClient.class);
         when(indicesAdminClient.getSettings(any())).thenReturn(getSettingsResponseActionFuture);
         AdminClient adminClient = mock(AdminClient.class);
@@ -71,7 +72,7 @@ public class MlInitializationServiceTests extends ESTestCase {
         when(client.admin()).thenReturn(adminClient);
         @SuppressWarnings("unchecked")
         ActionFuture<GetSettingsResponse> actionFuture = mock(ActionFuture.class);
-        when(actionFuture.actionGet()).thenReturn(new GetSettingsResponse(ImmutableOpenMap.of(), ImmutableOpenMap.of()));
+        when(actionFuture.actionGet()).thenReturn(new GetSettingsResponse(Map.of(), Map.of()));
         when(client.execute(eq(GetSettingsAction.INSTANCE), any())).thenReturn(actionFuture);
     }
 

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/dataframe/DestinationIndexTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/dataframe/DestinationIndexTests.java
@@ -29,7 +29,6 @@ import org.elasticsearch.action.support.master.AcknowledgedResponse;
 import org.elasticsearch.client.internal.Client;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.metadata.MappingMetadata;
-import org.elasticsearch.common.collect.ImmutableOpenMap;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.test.ESTestCase;

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/dataframe/DestinationIndexTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/dataframe/DestinationIndexTests.java
@@ -120,11 +120,9 @@ public class DestinationIndexTests extends ESTestCase {
         ArgumentCaptor<GetMappingsRequest> getMappingsRequestCaptor = ArgumentCaptor.forClass(GetMappingsRequest.class);
         ArgumentCaptor<FieldCapabilitiesRequest> fieldCapabilitiesRequestCaptor = ArgumentCaptor.forClass(FieldCapabilitiesRequest.class);
 
-        ImmutableOpenMap.Builder<String, Settings> indexToSettings = ImmutableOpenMap.builder();
-        indexToSettings.put("index_1", index1Settings);
-        indexToSettings.put("index_2", index2Settings);
+        Map<String, Settings> indexToSettings = Map.of("index_1", index1Settings, "index_2", index2Settings);
 
-        GetSettingsResponse getSettingsResponse = new GetSettingsResponse(indexToSettings.build(), ImmutableOpenMap.of());
+        GetSettingsResponse getSettingsResponse = new GetSettingsResponse(indexToSettings, Map.of());
 
         doAnswer(callListenerOnResponse(getSettingsResponse)).when(client)
             .execute(eq(GetSettingsAction.INSTANCE), getSettingsRequestCaptor.capture(), any());
@@ -149,11 +147,9 @@ public class DestinationIndexTests extends ESTestCase {
         MappingMetadata index1MappingMetadata = new MappingMetadata("_doc", indexMappings);
         MappingMetadata index2MappingMetadata = new MappingMetadata("_doc", indexMappings);
 
-        ImmutableOpenMap.Builder<String, MappingMetadata> mappings = ImmutableOpenMap.builder();
-        mappings.put("index_1", index1MappingMetadata);
-        mappings.put("index_2", index2MappingMetadata);
+        Map<String, MappingMetadata> mappings = Map.of("index_1", index1MappingMetadata, "index_2", index2MappingMetadata);
 
-        GetMappingsResponse getMappingsResponse = new GetMappingsResponse(mappings.build());
+        GetMappingsResponse getMappingsResponse = new GetMappingsResponse(mappings);
 
         doAnswer(callListenerOnResponse(getMappingsResponse)).when(client)
             .execute(eq(GetMappingsAction.INSTANCE), getMappingsRequestCaptor.capture(), any());
@@ -237,11 +233,10 @@ public class DestinationIndexTests extends ESTestCase {
     public void testCreateDestinationIndex_ResultsFieldsExistsInSourceIndex() {
         DataFrameAnalyticsConfig config = createConfig(new OutlierDetection.Builder().build());
 
-        GetSettingsResponse getSettingsResponse = new GetSettingsResponse(ImmutableOpenMap.of(), ImmutableOpenMap.of());
+        GetSettingsResponse getSettingsResponse = new GetSettingsResponse(Map.of(), Map.of());
 
-        ImmutableOpenMap.Builder<String, MappingMetadata> mappings = ImmutableOpenMap.builder();
-        mappings.put("", new MappingMetadata("_doc", Map.of("properties", Map.of("ml", "some-mapping"))));
-        GetMappingsResponse getMappingsResponse = new GetMappingsResponse(mappings.build());
+        Map<String, MappingMetadata> mappings = Map.of("", new MappingMetadata("_doc", Map.of("properties", Map.of("ml", "some-mapping"))));
+        GetMappingsResponse getMappingsResponse = new GetMappingsResponse(mappings);
 
         doAnswer(callListenerOnResponse(getSettingsResponse)).when(client).execute(eq(GetSettingsAction.INSTANCE), any(), any());
         doAnswer(callListenerOnResponse(getMappingsResponse)).when(client).execute(eq(GetMappingsAction.INSTANCE), any(), any());
@@ -273,15 +268,14 @@ public class DestinationIndexTests extends ESTestCase {
             ALIAS_TO_NESTED_FIELD,
             Map.of("type", "alias", "path", OUTER_FIELD + "." + INNER_FIELD)
         );
-        ImmutableOpenMap.Builder<String, MappingMetadata> mappings = ImmutableOpenMap.builder();
-        mappings.put("", new MappingMetadata("_doc", Map.of("properties", properties)));
+        Map<String, MappingMetadata> mappings = Map.of("", new MappingMetadata("_doc", Map.of("properties", properties)));
         GetIndexResponse getIndexResponse = new GetIndexResponse(
             new String[] { DEST_INDEX },
-            mappings.build(),
-            ImmutableOpenMap.of(),
-            ImmutableOpenMap.of(),
-            ImmutableOpenMap.of(),
-            ImmutableOpenMap.of()
+            mappings,
+            Map.of(),
+            Map.of(),
+            Map.of(),
+            Map.of()
         );
 
         ArgumentCaptor<PutMappingRequest> putMappingRequestCaptor = ArgumentCaptor.forClass(PutMappingRequest.class);
@@ -359,15 +353,14 @@ public class DestinationIndexTests extends ESTestCase {
     public void testUpdateMappingsToDestIndex_ResultsFieldsExistsInSourceIndex() {
         DataFrameAnalyticsConfig config = createConfig(new OutlierDetection.Builder().build());
 
-        ImmutableOpenMap.Builder<String, MappingMetadata> mappings = ImmutableOpenMap.builder();
-        mappings.put("", new MappingMetadata("_doc", Map.of("properties", Map.of("ml", "some-mapping"))));
+        Map<String, MappingMetadata> mappings = Map.of("", new MappingMetadata("_doc", Map.of("properties", Map.of("ml", "some-mapping"))));
         GetIndexResponse getIndexResponse = new GetIndexResponse(
             new String[] { DEST_INDEX },
-            mappings.build(),
-            ImmutableOpenMap.of(),
-            ImmutableOpenMap.of(),
-            ImmutableOpenMap.of(),
-            ImmutableOpenMap.of()
+            mappings,
+            Map.of(),
+            Map.of(),
+            Map.of(),
+            Map.of()
         );
 
         ElasticsearchStatusException e = expectThrows(

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/dataframe/MappingsMergerTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/dataframe/MappingsMergerTests.java
@@ -9,7 +9,6 @@ package org.elasticsearch.xpack.ml.dataframe;
 import org.elasticsearch.ElasticsearchStatusException;
 import org.elasticsearch.action.admin.indices.mapping.get.GetMappingsResponse;
 import org.elasticsearch.cluster.metadata.MappingMetadata;
-import org.elasticsearch.common.collect.ImmutableOpenMap;
 import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.search.fetch.subphase.FetchSourceContext;
 import org.elasticsearch.test.ESTestCase;

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/dataframe/MappingsMergerTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/dataframe/MappingsMergerTests.java
@@ -32,11 +32,9 @@ public class MappingsMergerTests extends ESTestCase {
         Map<String, Object> index2Mappings = Map.of("properties", Map.of("field_1", "field_1_mappings", "field_2", "field_2_mappings"));
         MappingMetadata index2MappingMetadata = new MappingMetadata("_doc", index2Mappings);
 
-        ImmutableOpenMap.Builder<String, MappingMetadata> mappings = ImmutableOpenMap.builder();
-        mappings.put("index_1", index1MappingMetadata);
-        mappings.put("index_2", index2MappingMetadata);
+        Map<String, MappingMetadata> mappings = Map.of("index_1", index1MappingMetadata, "index_2", index2MappingMetadata);
 
-        GetMappingsResponse getMappingsResponse = new GetMappingsResponse(mappings.build());
+        GetMappingsResponse getMappingsResponse = new GetMappingsResponse(mappings);
 
         MappingMetadata mergedMappings = MappingsMerger.mergeMappings(newSource(), getMappingsResponse);
 
@@ -53,11 +51,8 @@ public class MappingsMergerTests extends ESTestCase {
         Map<String, Object> index2Mappings = Map.of("properties", Map.of("field_1", "different_field_1_mappings"));
         MappingMetadata index2MappingMetadata = new MappingMetadata("_doc", index2Mappings);
 
-        ImmutableOpenMap.Builder<String, MappingMetadata> mappings = ImmutableOpenMap.builder();
-        mappings.put("index_1", index1MappingMetadata);
-        mappings.put("index_2", index2MappingMetadata);
-
-        GetMappingsResponse getMappingsResponse = new GetMappingsResponse(mappings.build());
+        Map<String, MappingMetadata> mappings = Map.of("index_1", index1MappingMetadata, "index_2", index2MappingMetadata);
+        GetMappingsResponse getMappingsResponse = new GetMappingsResponse(mappings);
 
         ElasticsearchStatusException e = expectThrows(
             ElasticsearchStatusException.class,
@@ -76,11 +71,8 @@ public class MappingsMergerTests extends ESTestCase {
         Map<String, Object> index2Mappings = Map.of("properties", Map.of("field_1", "field_1_mappings", "field_3", "field_3_mappings"));
         MappingMetadata index2MappingMetadata = new MappingMetadata("_doc", index2Mappings);
 
-        ImmutableOpenMap.Builder<String, MappingMetadata> mappings = ImmutableOpenMap.builder();
-        mappings.put("index_1", index1MappingMetadata);
-        mappings.put("index_2", index2MappingMetadata);
-
-        GetMappingsResponse getMappingsResponse = new GetMappingsResponse(mappings.build());
+        Map<String, MappingMetadata> mappings = Map.of("index_1", index1MappingMetadata, "index_2", index2MappingMetadata);
+        GetMappingsResponse getMappingsResponse = new GetMappingsResponse(mappings);
 
         MappingMetadata mergedMappings = MappingsMerger.mergeMappings(newSource(), getMappingsResponse);
 
@@ -104,11 +96,8 @@ public class MappingsMergerTests extends ESTestCase {
         Map<String, Object> index2Mappings = Map.of("runtime", Map.of("field_1", "field_1_mappings", "field_2", "field_2_mappings"));
         MappingMetadata index2MappingMetadata = new MappingMetadata("_doc", index2Mappings);
 
-        ImmutableOpenMap.Builder<String, MappingMetadata> mappings = ImmutableOpenMap.builder();
-        mappings.put("index_1", index1MappingMetadata);
-        mappings.put("index_2", index2MappingMetadata);
-
-        GetMappingsResponse getMappingsResponse = new GetMappingsResponse(mappings.build());
+        Map<String, MappingMetadata> mappings = Map.of("index_1", index1MappingMetadata, "index_2", index2MappingMetadata);
+        GetMappingsResponse getMappingsResponse = new GetMappingsResponse(mappings);
 
         MappingMetadata mergedMappings = MappingsMerger.mergeMappings(newSource(), getMappingsResponse);
 
@@ -125,11 +114,8 @@ public class MappingsMergerTests extends ESTestCase {
         Map<String, Object> index2Mappings = Map.of("runtime", Map.of("field_1", "different_field_1_mappings"));
         MappingMetadata index2MappingMetadata = new MappingMetadata("_doc", index2Mappings);
 
-        ImmutableOpenMap.Builder<String, MappingMetadata> mappings = ImmutableOpenMap.builder();
-        mappings.put("index_1", index1MappingMetadata);
-        mappings.put("index_2", index2MappingMetadata);
-
-        GetMappingsResponse getMappingsResponse = new GetMappingsResponse(mappings.build());
+        Map<String, MappingMetadata> mappings = Map.of("index_1", index1MappingMetadata, "index_2", index2MappingMetadata);
+        GetMappingsResponse getMappingsResponse = new GetMappingsResponse(mappings);
 
         ElasticsearchStatusException e = expectThrows(
             ElasticsearchStatusException.class,
@@ -148,11 +134,8 @@ public class MappingsMergerTests extends ESTestCase {
         Map<String, Object> index2Mappings = Map.of("runtime", Map.of("field_1", "field_1_mappings", "field_3", "field_3_mappings"));
         MappingMetadata index2MappingMetadata = new MappingMetadata("_doc", index2Mappings);
 
-        ImmutableOpenMap.Builder<String, MappingMetadata> mappings = ImmutableOpenMap.builder();
-        mappings.put("index_1", index1MappingMetadata);
-        mappings.put("index_2", index2MappingMetadata);
-
-        GetMappingsResponse getMappingsResponse = new GetMappingsResponse(mappings.build());
+        Map<String, MappingMetadata> mappings = Map.of("index_1", index1MappingMetadata, "index_2", index2MappingMetadata);
+        GetMappingsResponse getMappingsResponse = new GetMappingsResponse(mappings);
 
         MappingMetadata mergedMappings = MappingsMerger.mergeMappings(newSource(), getMappingsResponse);
 
@@ -194,11 +177,8 @@ public class MappingsMergerTests extends ESTestCase {
         }
         MappingMetadata index2MappingMetadata = new MappingMetadata("_doc", index2Mappings);
 
-        ImmutableOpenMap.Builder<String, MappingMetadata> mappings = ImmutableOpenMap.builder();
-        mappings.put("index_1", index1MappingMetadata);
-        mappings.put("index_2", index2MappingMetadata);
-
-        GetMappingsResponse getMappingsResponse = new GetMappingsResponse(mappings.build());
+        Map<String, MappingMetadata> mappings = Map.of("index_1", index1MappingMetadata, "index_2", index2MappingMetadata);
+        GetMappingsResponse getMappingsResponse = new GetMappingsResponse(mappings);
 
         MappingMetadata mergedMappings = MappingsMerger.mergeMappings(newSource(), getMappingsResponse);
 
@@ -229,10 +209,8 @@ public class MappingsMergerTests extends ESTestCase {
         indexMappings.put("runtime", runtime);
         MappingMetadata indexMappingMetadata = new MappingMetadata("_doc", indexMappings);
 
-        ImmutableOpenMap.Builder<String, MappingMetadata> mappings = ImmutableOpenMap.builder();
-        mappings.put("index", indexMappingMetadata);
-
-        GetMappingsResponse getMappingsResponse = new GetMappingsResponse(mappings.build());
+        Map<String, MappingMetadata> mappings = Map.of("index", indexMappingMetadata);
+        GetMappingsResponse getMappingsResponse = new GetMappingsResponse(mappings);
 
         MappingMetadata mergedMappings = MappingsMerger.mergeMappings(
             newSourceWithExcludes("field_1", "runtime_field_2"),

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/process/autodetect/AutodetectProcessManagerTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/process/autodetect/AutodetectProcessManagerTests.java
@@ -18,7 +18,6 @@ import org.elasticsearch.cluster.metadata.AliasMetadata;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.cluster.service.ClusterService;
-import org.elasticsearch.common.collect.ImmutableOpenMap;
 import org.elasticsearch.common.settings.ClusterSettings;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.concurrent.EsExecutors;
@@ -207,32 +206,32 @@ public class AutodetectProcessManagerTests extends ESTestCase {
         Metadata metadata = Metadata.builder()
             .indices(
                 Map.of(
-                        AnomalyDetectorsIndexFields.STATE_INDEX_PREFIX + "-000001",
-                        IndexMetadata.builder(AnomalyDetectorsIndexFields.STATE_INDEX_PREFIX + "-000001")
-                            .settings(
-                                Settings.builder()
-                                    .put(SETTING_NUMBER_OF_SHARDS, 1)
-                                    .put(SETTING_NUMBER_OF_REPLICAS, 0)
-                                    .put(SETTING_INDEX_HIDDEN, true)
-                                    .put(SETTING_VERSION_CREATED, Version.CURRENT)
-                                    .build()
-                            )
-                            .putAlias(AliasMetadata.builder(AnomalyDetectorsIndex.jobStateIndexWriteAlias()).isHidden(true).build())
-                            .build(),
-                        AnnotationIndex.LATEST_INDEX_NAME,
-                        IndexMetadata.builder(AnnotationIndex.LATEST_INDEX_NAME)
-                            .settings(
-                                Settings.builder()
-                                    .put(SETTING_NUMBER_OF_SHARDS, 1)
-                                    .put(SETTING_NUMBER_OF_REPLICAS, 0)
-                                    .put(SETTING_INDEX_HIDDEN, true)
-                                    .put(SETTING_VERSION_CREATED, Version.CURRENT)
-                                    .build()
-                            )
-                            .putAlias(AliasMetadata.builder(AnnotationIndex.READ_ALIAS_NAME).isHidden(true).build())
-                            .putAlias(AliasMetadata.builder(AnnotationIndex.WRITE_ALIAS_NAME).isHidden(true).build())
-                            .build()
-                    )
+                    AnomalyDetectorsIndexFields.STATE_INDEX_PREFIX + "-000001",
+                    IndexMetadata.builder(AnomalyDetectorsIndexFields.STATE_INDEX_PREFIX + "-000001")
+                        .settings(
+                            Settings.builder()
+                                .put(SETTING_NUMBER_OF_SHARDS, 1)
+                                .put(SETTING_NUMBER_OF_REPLICAS, 0)
+                                .put(SETTING_INDEX_HIDDEN, true)
+                                .put(SETTING_VERSION_CREATED, Version.CURRENT)
+                                .build()
+                        )
+                        .putAlias(AliasMetadata.builder(AnomalyDetectorsIndex.jobStateIndexWriteAlias()).isHidden(true).build())
+                        .build(),
+                    AnnotationIndex.LATEST_INDEX_NAME,
+                    IndexMetadata.builder(AnnotationIndex.LATEST_INDEX_NAME)
+                        .settings(
+                            Settings.builder()
+                                .put(SETTING_NUMBER_OF_SHARDS, 1)
+                                .put(SETTING_NUMBER_OF_REPLICAS, 0)
+                                .put(SETTING_INDEX_HIDDEN, true)
+                                .put(SETTING_VERSION_CREATED, Version.CURRENT)
+                                .build()
+                        )
+                        .putAlias(AliasMetadata.builder(AnnotationIndex.READ_ALIAS_NAME).isHidden(true).build())
+                        .putAlias(AliasMetadata.builder(AnnotationIndex.WRITE_ALIAS_NAME).isHidden(true).build())
+                        .build()
+                )
             )
             .build();
         clusterState = mock(ClusterState.class);

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/process/autodetect/AutodetectProcessManagerTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/process/autodetect/AutodetectProcessManagerTests.java
@@ -206,8 +206,7 @@ public class AutodetectProcessManagerTests extends ESTestCase {
         when(clusterService.getClusterSettings()).thenReturn(clusterSettings);
         Metadata metadata = Metadata.builder()
             .indices(
-                ImmutableOpenMap.<String, IndexMetadata>builder()
-                    .fPut(
+                Map.of(
                         AnomalyDetectorsIndexFields.STATE_INDEX_PREFIX + "-000001",
                         IndexMetadata.builder(AnomalyDetectorsIndexFields.STATE_INDEX_PREFIX + "-000001")
                             .settings(
@@ -219,9 +218,7 @@ public class AutodetectProcessManagerTests extends ESTestCase {
                                     .build()
                             )
                             .putAlias(AliasMetadata.builder(AnomalyDetectorsIndex.jobStateIndexWriteAlias()).isHidden(true).build())
-                            .build()
-                    )
-                    .fPut(
+                            .build(),
                         AnnotationIndex.LATEST_INDEX_NAME,
                         IndexMetadata.builder(AnnotationIndex.LATEST_INDEX_NAME)
                             .settings(
@@ -236,7 +233,6 @@ public class AutodetectProcessManagerTests extends ESTestCase {
                             .putAlias(AliasMetadata.builder(AnnotationIndex.WRITE_ALIAS_NAME).isHidden(true).build())
                             .build()
                     )
-                    .build()
             )
             .build();
         clusterState = mock(ClusterState.class);

--- a/x-pack/plugin/rollup/src/test/java/org/elasticsearch/xpack/rollup/action/PutJobStateMachineTests.java
+++ b/x-pack/plugin/rollup/src/test/java/org/elasticsearch/xpack/rollup/action/PutJobStateMachineTests.java
@@ -205,10 +205,7 @@ public class PutJobStateMachineTests extends ESTestCase {
             GetMappingsResponse response = mock(GetMappingsResponse.class);
             MappingMetadata meta = new MappingMetadata(RollupField.TYPE_NAME, Collections.emptyMap());
 
-            ImmutableOpenMap.Builder<String, MappingMetadata> builder2 = ImmutableOpenMap.builder(1);
-            builder2.put(job.getConfig().getRollupIndex(), meta);
-
-            when(response.getMappings()).thenReturn(builder2.build());
+            when(response.getMappings()).thenReturn(Map.of(job.getConfig().getRollupIndex(), meta));
             requestCaptor.getValue().onResponse(response);
             return null;
         }).when(client).execute(eq(GetMappingsAction.INSTANCE), any(GetMappingsRequest.class), requestCaptor.capture());
@@ -246,10 +243,7 @@ public class PutJobStateMachineTests extends ESTestCase {
             m.put("random", Collections.singletonMap(job.getConfig().getId(), job.getConfig()));
             MappingMetadata meta = new MappingMetadata(RollupField.TYPE_NAME, Collections.singletonMap("_meta", m));
 
-            ImmutableOpenMap.Builder<String, MappingMetadata> builder2 = ImmutableOpenMap.builder(1);
-            builder2.put(job.getConfig().getRollupIndex(), meta);
-
-            when(response.getMappings()).thenReturn(builder2.build());
+            when(response.getMappings()).thenReturn(Map.of(job.getConfig().getRollupIndex(), meta));
             requestCaptor.getValue().onResponse(response);
             return null;
         }).when(client).execute(eq(GetMappingsAction.INSTANCE), any(GetMappingsRequest.class), requestCaptor.capture());
@@ -282,10 +276,7 @@ public class PutJobStateMachineTests extends ESTestCase {
             m.put(RollupField.ROLLUP_META, Collections.singletonMap(job.getConfig().getId(), job.getConfig()));
             MappingMetadata meta = new MappingMetadata(RollupField.TYPE_NAME, Collections.singletonMap("_meta", m));
 
-            ImmutableOpenMap.Builder<String, MappingMetadata> builder2 = ImmutableOpenMap.builder(1);
-            builder2.put(job.getConfig().getRollupIndex(), meta);
-
-            when(response.getMappings()).thenReturn(builder2.build());
+            when(response.getMappings()).thenReturn(Map.of(job.getConfig().getRollupIndex(), meta));
             requestCaptor.getValue().onResponse(response);
             return null;
         }).when(client).execute(eq(GetMappingsAction.INSTANCE), any(GetMappingsRequest.class), requestCaptor.capture());
@@ -319,10 +310,7 @@ public class PutJobStateMachineTests extends ESTestCase {
             m.put(RollupField.ROLLUP_META, Collections.singletonMap(job.getConfig().getId(), job.getConfig()));
             MappingMetadata meta = new MappingMetadata(RollupField.TYPE_NAME, Collections.singletonMap("_meta", m));
 
-            ImmutableOpenMap.Builder<String, MappingMetadata> builder2 = ImmutableOpenMap.builder(1);
-            builder2.put(job.getConfig().getRollupIndex(), meta);
-
-            when(response.getMappings()).thenReturn(builder2.build());
+            when(response.getMappings()).thenReturn(Map.of(job.getConfig().getRollupIndex(), meta));
             requestCaptor.getValue().onResponse(response);
             return null;
         }).when(client).execute(eq(GetMappingsAction.INSTANCE), any(GetMappingsRequest.class), requestCaptor.capture());
@@ -363,10 +351,7 @@ public class PutJobStateMachineTests extends ESTestCase {
             m.put(RollupField.ROLLUP_META, Collections.singletonMap(unrelatedJob.getId(), unrelatedJob));
             MappingMetadata meta = new MappingMetadata(RollupField.TYPE_NAME, Collections.singletonMap("_meta", m));
 
-            ImmutableOpenMap.Builder<String, MappingMetadata> builder2 = ImmutableOpenMap.builder(1);
-            builder2.put(unrelatedJob.getRollupIndex(), meta);
-
-            when(response.getMappings()).thenReturn(builder2.build());
+            when(response.getMappings()).thenReturn(Map.of(unrelatedJob.getRollupIndex(), meta));
             requestCaptor.getValue().onResponse(response);
             return null;
         }).when(client).execute(eq(GetMappingsAction.INSTANCE), any(GetMappingsRequest.class), requestCaptor.capture());

--- a/x-pack/plugin/rollup/src/test/java/org/elasticsearch/xpack/rollup/action/PutJobStateMachineTests.java
+++ b/x-pack/plugin/rollup/src/test/java/org/elasticsearch/xpack/rollup/action/PutJobStateMachineTests.java
@@ -20,7 +20,6 @@ import org.elasticsearch.action.admin.indices.mapping.put.PutMappingRequest;
 import org.elasticsearch.action.support.master.AcknowledgedResponse;
 import org.elasticsearch.client.internal.Client;
 import org.elasticsearch.cluster.metadata.MappingMetadata;
-import org.elasticsearch.common.collect.ImmutableOpenMap;
 import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.persistent.PersistentTasksCustomMetadata;
 import org.elasticsearch.persistent.PersistentTasksService;

--- a/x-pack/plugin/rollup/src/test/java/org/elasticsearch/xpack/rollup/action/SearchActionTests.java
+++ b/x-pack/plugin/rollup/src/test/java/org/elasticsearch/xpack/rollup/action/SearchActionTests.java
@@ -13,7 +13,6 @@ import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.metadata.MappingMetadata;
 import org.elasticsearch.cluster.metadata.Metadata;
-import org.elasticsearch.common.collect.ImmutableOpenMap;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.Maps;
@@ -823,10 +822,7 @@ public class SearchActionTests extends ESTestCase {
         when(liveIndexMeta.mapping()).thenReturn(liveMappingMetadata);
 
         Map<String, IndexMetadata> metaMap = Map.of("foo", indexMeta, "bar", liveIndexMeta);
-        TransportRollupSearchAction.RollupSearchContext separateIndices = TransportRollupSearchAction.separateIndices(
-            indices,
-            metaMap
-        );
+        TransportRollupSearchAction.RollupSearchContext separateIndices = TransportRollupSearchAction.separateIndices(indices, metaMap);
 
         SearchResponse protoResponse = mock(SearchResponse.class);
         when(protoResponse.getTook()).thenReturn(new TimeValue(100));

--- a/x-pack/plugin/rollup/src/test/java/org/elasticsearch/xpack/rollup/action/SearchActionTests.java
+++ b/x-pack/plugin/rollup/src/test/java/org/elasticsearch/xpack/rollup/action/SearchActionTests.java
@@ -614,25 +614,21 @@ public class SearchActionTests extends ESTestCase {
     }
 
     public void testNoIndicesToSeparate() {
-        String[] indices = new String[] {};
-        ImmutableOpenMap<String, IndexMetadata> meta = ImmutableOpenMap.<String, IndexMetadata>builder().build();
-        expectThrows(IllegalArgumentException.class, () -> TransportRollupSearchAction.separateIndices(indices, meta));
+        expectThrows(IllegalArgumentException.class, () -> TransportRollupSearchAction.separateIndices(new String[0], Map.of()));
     }
 
     public void testSeparateAll() {
         String[] indices = new String[] { Metadata.ALL, "foo" };
-        ImmutableOpenMap<String, IndexMetadata> meta = ImmutableOpenMap.<String, IndexMetadata>builder().build();
         IllegalArgumentException e = expectThrows(
             IllegalArgumentException.class,
-            () -> TransportRollupSearchAction.separateIndices(indices, meta)
+            () -> TransportRollupSearchAction.separateIndices(indices, Map.of())
         );
         assertThat(e.getMessage(), equalTo("Searching _all via RollupSearch endpoint is not supported at this time."));
     }
 
     public void testEmptyMetadata() {
         String[] indices = new String[] { "foo", "bar" };
-        ImmutableOpenMap<String, IndexMetadata> meta = ImmutableOpenMap.<String, IndexMetadata>builder().build();
-        TransportRollupSearchAction.RollupSearchContext result = TransportRollupSearchAction.separateIndices(indices, meta);
+        TransportRollupSearchAction.RollupSearchContext result = TransportRollupSearchAction.separateIndices(indices, Map.of());
         assertThat(result.getLiveIndices().length, equalTo(2));
         assertThat(result.getRollupIndices().length, equalTo(0));
         assertThat(result.getJobCaps().size(), equalTo(0));
@@ -641,9 +637,8 @@ public class SearchActionTests extends ESTestCase {
     public void testNoMatchingIndexInMetadata() {
         String[] indices = new String[] { "foo" };
         IndexMetadata indexMetadata = mock(IndexMetadata.class);
-        ImmutableOpenMap.Builder<String, IndexMetadata> meta = ImmutableOpenMap.builder(1);
-        meta.put("bar", indexMetadata);
-        TransportRollupSearchAction.RollupSearchContext result = TransportRollupSearchAction.separateIndices(indices, meta.build());
+        Map<String, IndexMetadata> meta = Map.of("bar", indexMetadata);
+        TransportRollupSearchAction.RollupSearchContext result = TransportRollupSearchAction.separateIndices(indices, meta);
         assertThat(result.getLiveIndices().length, equalTo(1));
         assertThat(result.getRollupIndices().length, equalTo(0));
         assertThat(result.getJobCaps().size(), equalTo(0));
@@ -666,9 +661,8 @@ public class SearchActionTests extends ESTestCase {
         IndexMetadata meta = Mockito.mock(IndexMetadata.class);
         when(meta.mapping()).thenReturn(mappingMeta);
 
-        ImmutableOpenMap.Builder<String, IndexMetadata> metaMap = ImmutableOpenMap.builder(1);
-        metaMap.put("foo", meta);
-        TransportRollupSearchAction.RollupSearchContext result = TransportRollupSearchAction.separateIndices(indices, metaMap.build());
+        Map<String, IndexMetadata> metaMap = Map.of("foo", meta);
+        TransportRollupSearchAction.RollupSearchContext result = TransportRollupSearchAction.separateIndices(indices, metaMap);
         assertThat(result.getLiveIndices().length, equalTo(0));
         assertThat(result.getRollupIndices().length, equalTo(1));
         assertThat(result.getRollupIndices()[0], equalTo("foo"));
@@ -678,9 +672,8 @@ public class SearchActionTests extends ESTestCase {
     public void testLiveOnlyProcess() throws Exception {
         String[] indices = new String[] { "foo" };
         IndexMetadata indexMetadata = mock(IndexMetadata.class);
-        ImmutableOpenMap.Builder<String, IndexMetadata> meta = ImmutableOpenMap.builder(1);
-        meta.put("bar", indexMetadata);
-        TransportRollupSearchAction.RollupSearchContext result = TransportRollupSearchAction.separateIndices(indices, meta.build());
+        Map<String, IndexMetadata> meta = Map.of("bar", indexMetadata);
+        TransportRollupSearchAction.RollupSearchContext result = TransportRollupSearchAction.separateIndices(indices, meta);
 
         SearchResponse response = mock(SearchResponse.class);
         MultiSearchResponse.Item item = new MultiSearchResponse.Item(response, null);
@@ -711,9 +704,8 @@ public class SearchActionTests extends ESTestCase {
         IndexMetadata indexMeta = Mockito.mock(IndexMetadata.class);
         when(indexMeta.mapping()).thenReturn(mappingMeta);
 
-        ImmutableOpenMap.Builder<String, IndexMetadata> metaMap = ImmutableOpenMap.builder(1);
-        metaMap.put("foo", indexMeta);
-        TransportRollupSearchAction.RollupSearchContext result = TransportRollupSearchAction.separateIndices(indices, metaMap.build());
+        Map<String, IndexMetadata> metaMap = Map.of("foo", indexMeta);
+        TransportRollupSearchAction.RollupSearchContext result = TransportRollupSearchAction.separateIndices(indices, metaMap);
 
         SearchResponse response = mock(SearchResponse.class);
         when(response.getTook()).thenReturn(new TimeValue(100));
@@ -775,12 +767,10 @@ public class SearchActionTests extends ESTestCase {
         IndexMetadata indexMeta = Mockito.mock(IndexMetadata.class);
         when(indexMeta.mapping()).thenReturn(mappingMeta);
 
-        ImmutableOpenMap.Builder<String, IndexMetadata> metaMap = ImmutableOpenMap.builder(2);
-        metaMap.put("foo", indexMeta);
-        metaMap.put("bar", indexMeta);
+        Map<String, IndexMetadata> metaMap = Map.of("foo", indexMeta, "bar", indexMeta);
         IllegalArgumentException e = expectThrows(
             IllegalArgumentException.class,
-            () -> TransportRollupSearchAction.separateIndices(indices, metaMap.build())
+            () -> TransportRollupSearchAction.separateIndices(indices, metaMap)
         );
         assertThat(
             e.getMessage(),
@@ -832,12 +822,10 @@ public class SearchActionTests extends ESTestCase {
         IndexMetadata liveIndexMeta = Mockito.mock(IndexMetadata.class);
         when(liveIndexMeta.mapping()).thenReturn(liveMappingMetadata);
 
-        ImmutableOpenMap.Builder<String, IndexMetadata> metaMap = ImmutableOpenMap.builder(2);
-        metaMap.put("foo", indexMeta);
-        metaMap.put("bar", liveIndexMeta);
+        Map<String, IndexMetadata> metaMap = Map.of("foo", indexMeta, "bar", liveIndexMeta);
         TransportRollupSearchAction.RollupSearchContext separateIndices = TransportRollupSearchAction.separateIndices(
             indices,
-            metaMap.build()
+            metaMap
         );
 
         SearchResponse protoResponse = mock(SearchResponse.class);

--- a/x-pack/plugin/shutdown/src/test/java/org/elasticsearch/xpack/shutdown/TransportGetShutdownStatusActionTests.java
+++ b/x-pack/plugin/shutdown/src/test/java/org/elasticsearch/xpack/shutdown/TransportGetShutdownStatusActionTests.java
@@ -46,7 +46,9 @@ import org.hamcrest.Matcher;
 import org.junit.Before;
 
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static org.hamcrest.Matchers.allOf;
@@ -416,13 +418,13 @@ public class TransportGetShutdownStatusActionTests extends ESTestCase {
 
     public void testNodeNotInCluster() {
         String bogusNodeId = randomAlphaOfLength(10);
-        ImmutableOpenMap.Builder<String, IndexMetadata> indicesTable = ImmutableOpenMap.<String, IndexMetadata>builder();
+        Map<String, IndexMetadata> indicesTable = new HashMap<>();
         RoutingTable.Builder routingTable = RoutingTable.builder();
 
         ClusterState state = ClusterState.builder(ClusterState.EMPTY_STATE)
             .metadata(
                 Metadata.builder()
-                    .indices(indicesTable.build())
+                    .indices(indicesTable)
                     .putCustom(
                         NodesShutdownMetadata.TYPE,
                         new NodesShutdownMetadata(
@@ -513,13 +515,13 @@ public class TransportGetShutdownStatusActionTests extends ESTestCase {
         List<IndexMetadata> indices,
         SingleNodeShutdownMetadata.Type shutdownType
     ) {
-        ImmutableOpenMap.Builder<String, IndexMetadata> indicesTable = ImmutableOpenMap.<String, IndexMetadata>builder();
-        indices.forEach(imd -> { indicesTable.fPut(imd.getIndex().getName(), imd); });
+        Map<String, IndexMetadata> indicesTable = new HashMap<>();
+        indices.forEach(imd -> { indicesTable.put(imd.getIndex().getName(), imd); });
 
         return ClusterState.builder(ClusterState.EMPTY_STATE)
             .metadata(
                 Metadata.builder()
-                    .indices(indicesTable.build())
+                    .indices(indicesTable)
                     .putCustom(
                         NodesShutdownMetadata.TYPE,
                         new NodesShutdownMetadata(

--- a/x-pack/plugin/transform/src/internalClusterTest/java/org/elasticsearch/xpack/transform/persistence/TransformConfigManagerTests.java
+++ b/x-pack/plugin/transform/src/internalClusterTest/java/org/elasticsearch/xpack/transform/persistence/TransformConfigManagerTests.java
@@ -52,8 +52,10 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Comparator;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -749,7 +751,7 @@ public class TransformConfigManagerTests extends TransformSingleNodeTestCase {
     }
 
     private static ClusterState createClusterStateWithTransformIndex(String... indexes) throws IOException {
-        ImmutableOpenMap.Builder<String, IndexMetadata> indexMapBuilder = ImmutableOpenMap.builder();
+        Map<String, IndexMetadata> indexMapBuilder = new HashMap<>();
         Metadata.Builder metaBuilder = Metadata.builder();
         ClusterState.Builder csBuilder = ClusterState.builder(ClusterName.DEFAULT);
         RoutingTable.Builder routingTableBuilder = RoutingTable.builder();
@@ -780,7 +782,7 @@ public class TransformConfigManagerTests extends TransformSingleNodeTestCase {
 
         }
         csBuilder.routingTable(routingTableBuilder.build());
-        metaBuilder.indices(indexMapBuilder.build());
+        metaBuilder.indices(indexMapBuilder);
         csBuilder.metadata(metaBuilder.build());
 
         return csBuilder.build();

--- a/x-pack/plugin/transform/src/internalClusterTest/java/org/elasticsearch/xpack/transform/persistence/TransformConfigManagerTests.java
+++ b/x-pack/plugin/transform/src/internalClusterTest/java/org/elasticsearch/xpack/transform/persistence/TransformConfigManagerTests.java
@@ -25,7 +25,6 @@ import org.elasticsearch.cluster.routing.ShardRoutingState;
 import org.elasticsearch.cluster.routing.TestShardRouting;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.Strings;
-import org.elasticsearch.common.collect.ImmutableOpenMap;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.core.Tuple;
 import org.elasticsearch.index.IndexNotFoundException;

--- a/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/persistence/TransformIndexTests.java
+++ b/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/persistence/TransformIndexTests.java
@@ -82,7 +82,7 @@ public class TransformIndexTests extends ESTestCase {
         assertTrue(latch.await(10, TimeUnit.SECONDS));
     }
 
-    private void testIsDestinationIndexCreatedByTransform(ImmutableOpenMap<String, MappingMetadata> mappings, boolean expectedValue)
+    private void testIsDestinationIndexCreatedByTransform(Map<String, MappingMetadata> mappings, boolean expectedValue)
         throws Exception {
         GetIndexResponse getIndexResponse = new GetIndexResponse(new String[] { DEST_INDEX }, mappings, null, null, null, null);
         doAnswer(withResponse(getIndexResponse)).when(client).execute(eq(GetIndexAction.INSTANCE), any(), any());
@@ -104,34 +104,25 @@ public class TransformIndexTests extends ESTestCase {
     }
 
     public void testIsDestinationIndexCreatedByTransform_NoIndexInMappings() throws Exception {
-        testIsDestinationIndexCreatedByTransform(ImmutableOpenMap.of(), false);
+        testIsDestinationIndexCreatedByTransform(Map.of(), false);
     }
 
     public void testIsDestinationIndexCreatedByTransform_NoMeta() throws Exception {
-        ImmutableOpenMap<String, MappingMetadata> mappings = ImmutableOpenMap.<String, MappingMetadata>builder()
-            .fPut(DEST_INDEX, MappingMetadata.EMPTY_MAPPINGS)
-            .build();
-        testIsDestinationIndexCreatedByTransform(mappings, false);
+        testIsDestinationIndexCreatedByTransform(Map.of(DEST_INDEX, MappingMetadata.EMPTY_MAPPINGS), false);
     }
 
     public void testIsDestinationIndexCreatedByTransform_NoCreatedBy() throws Exception {
-        ImmutableOpenMap<String, MappingMetadata> mappings = ImmutableOpenMap.<String, MappingMetadata>builder()
-            .fPut(DEST_INDEX, new MappingMetadata("_doc", Map.of("_meta", Map.of())))
-            .build();
+        Map<String, MappingMetadata> mappings = Map.of(DEST_INDEX, new MappingMetadata("_doc", Map.of("_meta", Map.of())));
         testIsDestinationIndexCreatedByTransform(mappings, false);
     }
 
     public void testIsDestinationIndexCreatedByTransform_CreatedByDoesNotMatch() throws Exception {
-        ImmutableOpenMap<String, MappingMetadata> mappings = ImmutableOpenMap.<String, MappingMetadata>builder()
-            .fPut(DEST_INDEX, new MappingMetadata("_doc", Map.of("_meta", Map.of("created_by", "some-user"))))
-            .build();
+        Map<String, MappingMetadata> mappings = Map.of(DEST_INDEX, new MappingMetadata("_doc", Map.of("_meta", Map.of("created_by", "some-user"))));
         testIsDestinationIndexCreatedByTransform(mappings, false);
     }
 
     public void testIsDestinationIndexCreatedByTransform_Ok() throws Exception {
-        ImmutableOpenMap<String, MappingMetadata> mappings = ImmutableOpenMap.<String, MappingMetadata>builder()
-            .fPut(DEST_INDEX, new MappingMetadata("_doc", Map.of("_meta", Map.of("created_by", CREATED_BY))))
-            .build();
+        Map<String, MappingMetadata> mappings = Map.of(DEST_INDEX, new MappingMetadata("_doc", Map.of("_meta", Map.of("created_by", CREATED_BY))));
         testIsDestinationIndexCreatedByTransform(mappings, true);
     }
 

--- a/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/persistence/TransformIndexTests.java
+++ b/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/persistence/TransformIndexTests.java
@@ -14,7 +14,6 @@ import org.elasticsearch.action.admin.indices.get.GetIndexAction;
 import org.elasticsearch.action.admin.indices.get.GetIndexResponse;
 import org.elasticsearch.client.internal.Client;
 import org.elasticsearch.cluster.metadata.MappingMetadata;
-import org.elasticsearch.common.collect.ImmutableOpenMap;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.index.IndexNotFoundException;
@@ -82,8 +81,7 @@ public class TransformIndexTests extends ESTestCase {
         assertTrue(latch.await(10, TimeUnit.SECONDS));
     }
 
-    private void testIsDestinationIndexCreatedByTransform(Map<String, MappingMetadata> mappings, boolean expectedValue)
-        throws Exception {
+    private void testIsDestinationIndexCreatedByTransform(Map<String, MappingMetadata> mappings, boolean expectedValue) throws Exception {
         GetIndexResponse getIndexResponse = new GetIndexResponse(new String[] { DEST_INDEX }, mappings, null, null, null, null);
         doAnswer(withResponse(getIndexResponse)).when(client).execute(eq(GetIndexAction.INSTANCE), any(), any());
 
@@ -117,12 +115,18 @@ public class TransformIndexTests extends ESTestCase {
     }
 
     public void testIsDestinationIndexCreatedByTransform_CreatedByDoesNotMatch() throws Exception {
-        Map<String, MappingMetadata> mappings = Map.of(DEST_INDEX, new MappingMetadata("_doc", Map.of("_meta", Map.of("created_by", "some-user"))));
+        Map<String, MappingMetadata> mappings = Map.of(
+            DEST_INDEX,
+            new MappingMetadata("_doc", Map.of("_meta", Map.of("created_by", "some-user")))
+        );
         testIsDestinationIndexCreatedByTransform(mappings, false);
     }
 
     public void testIsDestinationIndexCreatedByTransform_Ok() throws Exception {
-        Map<String, MappingMetadata> mappings = Map.of(DEST_INDEX, new MappingMetadata("_doc", Map.of("_meta", Map.of("created_by", CREATED_BY))));
+        Map<String, MappingMetadata> mappings = Map.of(
+            DEST_INDEX,
+            new MappingMetadata("_doc", Map.of("_meta", Map.of("created_by", CREATED_BY)))
+        );
         testIsDestinationIndexCreatedByTransform(mappings, true);
     }
 

--- a/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/persistence/TransformInternalIndexTests.java
+++ b/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/persistence/TransformInternalIndexTests.java
@@ -39,6 +39,8 @@ import org.junit.Before;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import static org.mockito.ArgumentMatchers.any;
@@ -58,7 +60,7 @@ public class TransformInternalIndexTests extends ESTestCase {
     }
 
     public static ClusterState randomTransformClusterState(boolean shardsReady) {
-        ImmutableOpenMap.Builder<String, IndexMetadata> indexMapBuilder = ImmutableOpenMap.builder();
+        Map<String, IndexMetadata> indexMapBuilder = new HashMap<>();
         try {
             IndexMetadata.Builder builder = new IndexMetadata.Builder(TransformInternalIndexConstants.LATEST_INDEX_VERSIONED_NAME).settings(
                 Settings.builder()
@@ -71,7 +73,7 @@ public class TransformInternalIndexTests extends ESTestCase {
             throw new UncheckedIOException(e);
         }
         Metadata.Builder metaBuilder = Metadata.builder();
-        metaBuilder.indices(indexMapBuilder.build());
+        metaBuilder.indices(indexMapBuilder);
         ClusterState.Builder csBuilder = ClusterState.builder(ClusterName.DEFAULT);
         csBuilder.metadata(metaBuilder.build());
 

--- a/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/persistence/TransformInternalIndexTests.java
+++ b/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/persistence/TransformInternalIndexTests.java
@@ -27,7 +27,6 @@ import org.elasticsearch.cluster.routing.TestShardRouting;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.UUIDs;
-import org.elasticsearch.common.collect.ImmutableOpenMap;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.index.Index;

--- a/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/WatcherIndexingListenerTests.java
+++ b/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/WatcherIndexingListenerTests.java
@@ -721,9 +721,7 @@ public class WatcherIndexingListenerTests extends ESTestCase {
                 AliasMetadata aliasMetadata = mock(AliasMetadata.class);
                 when(aliasMetadata.writeIndex()).thenReturn(true);
                 when(aliasMetadata.getAlias()).thenReturn(Watch.INDEX);
-                ImmutableOpenMap.Builder<String, AliasMetadata> aliases = ImmutableOpenMap.builder();
-                aliases.put(Watch.INDEX, aliasMetadata);
-                when(indexMetadata.getAliases()).thenReturn(aliases.build());
+                when(indexMetadata.getAliases()).thenReturn(Map.of(Watch.INDEX, aliasMetadata));
                 indices.put(Watch.INDEX, new IndexAbstraction.Alias(aliasMetadata, List.of(indexMetadata)));
                 when(metadata.index(any(Index.class))).thenReturn(indexMetadata);
             }

--- a/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/WatcherIndexingListenerTests.java
+++ b/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/WatcherIndexingListenerTests.java
@@ -28,7 +28,6 @@ import org.elasticsearch.cluster.routing.ShardRouting;
 import org.elasticsearch.cluster.routing.ShardRoutingState;
 import org.elasticsearch.cluster.routing.TestShardRouting;
 import org.elasticsearch.common.bytes.BytesArray;
-import org.elasticsearch.common.collect.ImmutableOpenMap;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.time.DateUtils;
 import org.elasticsearch.index.Index;

--- a/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/support/WatcherIndexTemplateRegistryTests.java
+++ b/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/support/WatcherIndexTemplateRegistryTests.java
@@ -25,7 +25,6 @@ import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
 import org.elasticsearch.cluster.service.ClusterService;
-import org.elasticsearch.common.collect.ImmutableOpenMap;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.concurrent.EsExecutors;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
@@ -318,7 +317,7 @@ public class WatcherIndexTemplateRegistryTests extends ESTestCase {
         Map<String, LifecyclePolicy> existingPolicies,
         DiscoveryNodes nodes
     ) {
-        ImmutableOpenMap.Builder<String, IndexTemplateMetadata> indexTemplates = ImmutableOpenMap.builder();
+        Map<String, IndexTemplateMetadata> indexTemplates = new HashMap<>();
         for (Map.Entry<String, Integer> template : existingTemplates.entrySet()) {
             final IndexTemplateMetadata mockTemplate = mock(IndexTemplateMetadata.class);
             when(mockTemplate.version()).thenReturn(template.getValue());
@@ -334,7 +333,7 @@ public class WatcherIndexTemplateRegistryTests extends ESTestCase {
         return ClusterState.builder(new ClusterName("test"))
             .metadata(
                 Metadata.builder()
-                    .templates(indexTemplates.build())
+                    .templates(indexTemplates)
                     .transientSettings(nodeSettings)
                     .putCustom(IndexLifecycleMetadata.TYPE, ilmMeta)
                     .build()

--- a/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/watch/WatchStoreUtilsTests.java
+++ b/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/watch/WatchStoreUtilsTests.java
@@ -31,16 +31,16 @@ public class WatchStoreUtilsTests extends ESTestCase {
     public void testGetConcreteIndexForDataStream() {
         String dataStreamName = randomAlphaOfLength(20);
         Metadata.Builder metadataBuilder = Metadata.builder();
-        ImmutableOpenMap.Builder<String, Metadata.Custom> customsBuilder = ImmutableOpenMap.builder();
+        Map<String, Metadata.Custom> customsBuilder = new HashMap<>();
         Map<String, DataStream> dataStreams = new HashMap<>();
-        ImmutableOpenMap.Builder<String, IndexMetadata> indexMetadataMapBuilder = ImmutableOpenMap.builder();
+        Map<String, IndexMetadata> indexMetadataMapBuilder = new HashMap<>();
         List<String> indexNames = new ArrayList<>();
         for (int i = 0; i < randomIntBetween(2, 10); i++) {
             String indexName = dataStreamName + "_" + i;
             indexNames.add(indexName);
             indexMetadataMapBuilder.put(indexName, createIndexMetaData(indexName, null));
         }
-        metadataBuilder.indices(indexMetadataMapBuilder.build());
+        metadataBuilder.indices(indexMetadataMapBuilder);
         dataStreams.put(
             dataStreamName,
             DataStreamTestHelper.newInstance(
@@ -54,7 +54,7 @@ public class WatchStoreUtilsTests extends ESTestCase {
             dataStreamAliases
         );
         customsBuilder.put(DataStreamMetadata.TYPE, dataStreamMetadata);
-        metadataBuilder.customs(customsBuilder.build());
+        metadataBuilder.customs(customsBuilder);
         IndexMetadata concreteIndex = WatchStoreUtils.getConcreteIndex(dataStreamName, metadataBuilder.build());
         assertNotNull(concreteIndex);
         assertEquals(indexNames.get(indexNames.size() - 1), concreteIndex.getIndex().getName());
@@ -66,12 +66,12 @@ public class WatchStoreUtilsTests extends ESTestCase {
         AliasMetadata.Builder aliasMetadataBuilder = new AliasMetadata.Builder(aliasName);
         aliasMetadataBuilder.writeIndex(false);
         AliasMetadata aliasMetadata = aliasMetadataBuilder.build();
-        ImmutableOpenMap.Builder<String, IndexMetadata> indexMetadataMapBuilder = ImmutableOpenMap.builder();
+        Map<String, IndexMetadata> indexMetadataMapBuilder = new HashMap<>();
         for (int i = 0; i < randomIntBetween(2, 10); i++) {
             String indexName = aliasName + "_" + i;
             indexMetadataMapBuilder.put(indexName, createIndexMetaData(indexName, aliasMetadata));
         }
-        metadataBuilder.indices(indexMetadataMapBuilder.build());
+        metadataBuilder.indices(indexMetadataMapBuilder);
         expectThrows(IllegalStateException.class, () -> WatchStoreUtils.getConcreteIndex(aliasName, metadataBuilder.build()));
     }
 
@@ -84,7 +84,7 @@ public class WatchStoreUtilsTests extends ESTestCase {
         AliasMetadata.Builder writableAliasMetadataBuilder = new AliasMetadata.Builder(aliasName);
         writableAliasMetadataBuilder.writeIndex(true);
         AliasMetadata writableAliasMetadata = writableAliasMetadataBuilder.build();
-        ImmutableOpenMap.Builder<String, IndexMetadata> indexMetadataMapBuilder = ImmutableOpenMap.builder();
+        Map<String, IndexMetadata> indexMetadataMapBuilder = new HashMap<>();
         List<String> indexNames = new ArrayList<>();
         int indexCount = randomIntBetween(2, 10);
         int writableIndexIndex = randomIntBetween(0, indexCount - 1);
@@ -99,7 +99,7 @@ public class WatchStoreUtilsTests extends ESTestCase {
             }
             indexMetadataMapBuilder.put(indexName, createIndexMetaData(indexName, aliasMetadata));
         }
-        metadataBuilder.indices(indexMetadataMapBuilder.build());
+        metadataBuilder.indices(indexMetadataMapBuilder);
         IndexMetadata concreteIndex = WatchStoreUtils.getConcreteIndex(aliasName, metadataBuilder.build());
         assertNotNull(concreteIndex);
         assertEquals(indexNames.get(writableIndexIndex), concreteIndex.getIndex().getName());
@@ -111,10 +111,10 @@ public class WatchStoreUtilsTests extends ESTestCase {
         AliasMetadata.Builder aliasMetadataBuilder = new AliasMetadata.Builder(aliasName);
         aliasMetadataBuilder.writeIndex(false);
         AliasMetadata aliasMetadata = aliasMetadataBuilder.build();
-        ImmutableOpenMap.Builder<String, IndexMetadata> indexMetadataMapBuilder = ImmutableOpenMap.builder();
+        Map<String, IndexMetadata> indexMetadataMapBuilder = new HashMap<>();
         String indexName = aliasName + "_" + 0;
         indexMetadataMapBuilder.put(indexName, createIndexMetaData(indexName, aliasMetadata));
-        metadataBuilder.indices(indexMetadataMapBuilder.build());
+        metadataBuilder.indices(indexMetadataMapBuilder);
         IndexMetadata concreteIndex = WatchStoreUtils.getConcreteIndex(aliasName, metadataBuilder.build());
         assertNotNull(concreteIndex);
         assertEquals(indexName, concreteIndex.getIndex().getName());
@@ -123,9 +123,9 @@ public class WatchStoreUtilsTests extends ESTestCase {
     public void testGetConcreteIndexForConcreteIndex() {
         String indexName = randomAlphaOfLength(20);
         Metadata.Builder metadataBuilder = Metadata.builder();
-        ImmutableOpenMap.Builder<String, IndexMetadata> indexMetadataMapBuilder = ImmutableOpenMap.builder();
+        Map<String, IndexMetadata> indexMetadataMapBuilder = new HashMap<>();
         indexMetadataMapBuilder.put(indexName, createIndexMetaData(indexName, null));
-        metadataBuilder.indices(indexMetadataMapBuilder.build());
+        metadataBuilder.indices(indexMetadataMapBuilder);
         IndexMetadata concreteIndex = WatchStoreUtils.getConcreteIndex(indexName, metadataBuilder.build());
         assertNotNull(concreteIndex);
         assertEquals(indexName, concreteIndex.getIndex().getName());


### PR DESCRIPTION
Many tests in xpack create ImmutableOpenMap for building mock cluster
states. However, since most of the API signatures for the cluster state
have changed to be Map, it is no longer necessary to build
ImmutableOpenMap. This commit converts most tests in xpack to build Maps
for their mock cluster states.

relates #86239