### PR TITLE
Skip ensureNoSelfReferences check in IngestService

### DIFF
--- a/docs/changelog/87337.yaml
+++ b/docs/changelog/87337.yaml
@@ -1,0 +1,5 @@
+pr: 87337
+summary: Skip `ensureNoSelfReferences` check in `IngestService`
+area: Ingest
+type: enhancement
+issues: []

--- a/modules/ingest-common/src/yamlRestTest/resources/rest-api-spec/test/ingest/190_script_processor.yml
+++ b/modules/ingest-common/src/yamlRestTest/resources/rest-api-spec/test/ingest/190_script_processor.yml
@@ -281,7 +281,7 @@ teardown:
 ---
 "Test adding circular references fails pipeline":
   - skip:
-      version: " - 8.2.999"
+      version: " - 8.2.99"
       reason: "Test causes fatal error prior to 8.3.0"
 
   - do:
@@ -313,4 +313,4 @@ teardown:
               "foo": "bar"
             }
           }
-  - match: { error.root_cause.0.reason: "Iterable object is self-referencing itself (ingest pipeline [my_pipeline])" }
+  - match: { error.root_cause.0.reason: "Failed to generate the source document for ingest pipeline [my_pipeline]" }


### PR DESCRIPTION
A self reference check is performed by the XContentBuilder when the document map is serialized using the `indexRequest.source(...)` call. This means we can remove the call to `CollectionUtils.ensureNoSelfReferences` above and only do the check once instead of twice.

Relates to #85926 and (subsequent work in) #87335
