### PR TITLE
Disallow three-digit minor and revision versions

### DIFF
--- a/docs/changelog/87338.yaml
+++ b/docs/changelog/87338.yaml
@@ -1,0 +1,5 @@
+pr: 87338
+summary: Disallow three-digit minor and revision versions
+area: Infra/Core
+type: bug
+issues: []

--- a/server/src/main/java/org/elasticsearch/Version.java
+++ b/server/src/main/java/org/elasticsearch/Version.java
@@ -254,6 +254,16 @@ public class Version implements Comparable<Version>, ToXContentFragment {
             if (rawMajor >= 7 && parts.length == 4) { // we don't support qualifier as part of the version anymore
                 throw new IllegalArgumentException("illegal version format - qualifiers are only supported until version 6.x");
             }
+            if (parts[1].length() > 2) {
+                throw new IllegalArgumentException(
+                    "illegal minor version format - only one or two digit numbers are supported but found " + parts[1]
+                );
+            }
+            if (parts[2].length() > 2) {
+                throw new IllegalArgumentException(
+                    "illegal revision version format - only one or two digit numbers are supported but found " + parts[2]
+                );
+            }
             // we reverse the version id calculation based on some assumption as we can't reliably reverse the modulo
             final int major = rawMajor * 1000000;
             final int minor = Integer.parseInt(parts[1]) * 10000;

--- a/server/src/test/java/org/elasticsearch/VersionTests.java
+++ b/server/src/test/java/org/elasticsearch/VersionTests.java
@@ -336,4 +336,18 @@ public class VersionTests extends ESTestCase {
         VersionTests.assertUnknownVersion(VERSION_5_1_0_UNRELEASED);
     }
 
+    public void testIllegalMinorAndPatchNumbers() {
+        IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> Version.fromString("8.2.999"));
+        assertThat(
+            e.getMessage(),
+            containsString("illegal revision version format - only one or two digit numbers are supported but found 999")
+        );
+
+        e = expectThrows(IllegalArgumentException.class, () -> Version.fromString("8.888.99"));
+        assertThat(
+            e.getMessage(),
+            containsString("illegal minor version format - only one or two digit numbers are supported but found 888")
+        );
+    }
+
 }

--- a/test/yaml-rest-runner/src/test/java/org/elasticsearch/test/rest/yaml/section/SkipSectionTests.java
+++ b/test/yaml-rest-runner/src/test/java/org/elasticsearch/test/rest/yaml/section/SkipSectionTests.java
@@ -15,6 +15,7 @@ import org.elasticsearch.xcontent.yaml.YamlXContent;
 
 import java.util.Collections;
 
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
@@ -187,5 +188,18 @@ public class SkipSectionTests extends AbstractClientYamlTestFragmentParserTestCa
 
         Exception e = expectThrows(ParsingException.class, () -> SkipSection.parse(parser));
         assertThat(e.getMessage(), is("if os is specified, feature skip_os must be set"));
+    }
+
+    public void testParseSkipSectionWithThreeDigitVersion() throws Exception {
+        parser = createParser(YamlXContent.yamlXContent, """
+            version:     " - 8.2.999"
+            features:     regex
+            reason:      Now you have two problems""");
+
+        IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> SkipSection.parse(parser));
+        assertThat(
+            e.getMessage(),
+            containsString("illegal revision version format - only one or two digit numbers are supported but found 999")
+        );
     }
 }


### PR DESCRIPTION
This came up because a yml test erroneously had 8.2.999 as a skip version, however, when the yml
test parser calls `Version.fromString("8.2.999")` the version `8.11.99` is what is actually
parsed out. This commit makes the minor and revision numbers have a limit of two digits, to match
our existing version conceptions. There is no limit on the number of major version digits.

Hopefully we don't need more than 100 minor versions within a single major (yet), or more than 100
patch releases.
