### PR TITLE
[8.3] Skip ensureNoSelfReferences check in IngestService (#87337)

### DIFF
--- a/docs/changelog/87337.yaml
+++ b/docs/changelog/87337.yaml
@@ -1,0 +1,5 @@
+pr: 87337
+summary: Skip `ensureNoSelfReferences` check in `IngestService`
+area: Ingest
+type: enhancement
+issues: []

--- a/modules/ingest-common/src/yamlRestTest/resources/rest-api-spec/test/ingest/190_script_processor.yml
+++ b/modules/ingest-common/src/yamlRestTest/resources/rest-api-spec/test/ingest/190_script_processor.yml
@@ -281,7 +281,7 @@ teardown:
 ---
 "Test adding circular references fails pipeline":
   - skip:
-      version: " - 8.2.999"
+      version: " - 8.2.99"
       reason: "Test causes fatal error prior to 8.3.0"
 
   - do:
@@ -313,4 +313,4 @@ teardown:
               "foo": "bar"
             }
           }
-  - match: { error.root_cause.0.reason: "Iterable object is self-referencing itself (ingest pipeline [my_pipeline])" }
+  - match: { error.root_cause.0.reason: "Failed to generate the source document for ingest pipeline [my_pipeline]" }


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `8.3`:
 - [Skip ensureNoSelfReferences check in IngestService (#87337)](https://github.com/elastic/elasticsearch/pull/87337)

<!--- Backport version: 8.4.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)