### PR TITLE
Faster NumberFieldMapper.value

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/mapper/NumberFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/NumberFieldMapper.java
@@ -1537,13 +1537,14 @@ public class NumberFieldMapper extends FieldMapper {
     private static Number value(XContentParser parser, NumberType numberType, Number nullValue, boolean coerce)
         throws IllegalArgumentException, IOException {
 
-        if (parser.currentToken() == Token.VALUE_NULL) {
+        final Token currentToken = parser.currentToken();
+        if (currentToken == Token.VALUE_NULL) {
             return nullValue;
         }
-        if (coerce && parser.currentToken() == Token.VALUE_STRING && parser.textLength() == 0) {
+        if (coerce && currentToken == Token.VALUE_STRING && parser.textLength() == 0) {
             return nullValue;
         }
-        if (parser.currentToken() == Token.START_OBJECT) {
+        if (currentToken == Token.START_OBJECT) {
             throw new IllegalArgumentException("Cannot parse object as number");
         }
         return numberType.parse(parser, coerce);


### PR DESCRIPTION
Calling `currentToken` isn't as cheap as a getter call since it hits a huge switch statement
and doesn't inline well. Even more so when a delegating x-content parser is called which has
a bunch of additional overhead -> saving the expensive call here to save a couple of % of runtime
for number field mappers.
