### PR TITLE
Provide additional info in assertion

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/allocator/DesiredBalanceService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/allocator/DesiredBalanceService.java
@@ -242,7 +242,11 @@ public class DesiredBalanceService {
             assert ignored.unassignedInfo() != null;
             assert ignored.unassignedInfo().getLastAllocationStatus() == UnassignedInfo.AllocationStatus.DECIDERS_NO
                 || ignored.unassignedInfo().getLastAllocationStatus() == UnassignedInfo.AllocationStatus.NO_ATTEMPT
-                : "Unexpected status: " + ignored.unassignedInfo().getLastAllocationStatus();
+                : "Unexpected status: "
+                    + ignored.unassignedInfo().getLastAllocationStatus()
+                    + " caused by ["
+                    + ignored.unassignedInfo()
+                    + "]";
 
             assignments.merge(ignored.shardId(), ShardAssignment.UNASSIGNED, ShardAssignment::merge);
         }


### PR DESCRIPTION
I observed once that this assertion has failed with `Unexpected status: DECIDERS_THROTTLED`.

According to the code there are two possible sources for that:
* SnapshotInProgressAllocationDecider::canMove
* ConcurrentRebalanceAllocationDecider::canRebalance

I suspect it is the first once, but was unable to reproduce it so far. I am expanding assertion message to have more details next time this happens.