### PR TITLE
Don't check contains query for multi-shapes in LatLonShapeDocValuesQueryTests

### DIFF
--- a/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/index/mapper/LatLonShapeDocValuesQueryTests.java
+++ b/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/index/mapper/LatLonShapeDocValuesQueryTests.java
@@ -136,6 +136,10 @@ public class LatLonShapeDocValuesQueryTests extends ESTestCase {
         for (int i = 0; i < 25; i++) {
             LatLonGeometry[] geometries = randomLuceneQueryGeometries();
             for (ShapeField.QueryRelation relation : ShapeField.QueryRelation.values()) {
+                if (relation == ShapeField.QueryRelation.CONTAINS) {
+                    // We don't check this here as it might fail due to LUCENE-10514
+                    continue;
+                }
                 Query indexQuery = LatLonShape.newGeometryQuery(FIELD_NAME, relation, geometries);
                 Query docValQuery = new LatLonShapeDocValuesQuery(FIELD_NAME, relation, geometries);
                 assertQueries(s, indexQuery, docValQuery, numDocs);


### PR DESCRIPTION
Due to a rare bug in lucene (LUCENE-10514), this test might fail for CONTAINS queries. The fix has been fixed upstream but not back-ported to this lucene version. That's ok as the bug is rare and affects only multishapes where one shape contains another shape.

So we just skip CONTAINS queries for multishapes so the test doesn't fail.

fixes  #85177
