### PR TITLE
Tests ignore longitude=180 when index Legacy point

### DIFF
--- a/docs/changelog/87364.yaml
+++ b/docs/changelog/87364.yaml
@@ -1,6 +1,0 @@
-pr: 87364
-summary: Tests ignore longitude=180 when index Legacy point
-area: Geo
-type: bug
-issues:
- - 86118

--- a/docs/changelog/87364.yaml
+++ b/docs/changelog/87364.yaml
@@ -1,0 +1,6 @@
+pr: 87364
+summary: Tests ignore longitude=180 when index Legacy point
+area: Geo
+type: bug
+issues:
+ - 86118

--- a/modules/legacy-geo/src/test/java/org/elasticsearch/legacygeo/search/LegacyGeoShapeQueryTests.java
+++ b/modules/legacy-geo/src/test/java/org/elasticsearch/legacygeo/search/LegacyGeoShapeQueryTests.java
@@ -25,6 +25,7 @@ import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xcontent.XContentFactory;
 
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 
@@ -176,15 +177,13 @@ public class LegacyGeoShapeQueryTests extends GeoShapeQueryTestCase {
         assertEquals(1, response.getHits().getTotalHits().value);
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/86118")
+    /**
+     * It turns out that LegacyGeoShape has an issue indexing points with longitude=180,
+     * but since this is legacy, rather than fix that, we just skip it from tests.
+     * See https://github.com/elastic/elasticsearch/issues/86118
+     */
     @Override
-    public void testIndexPointsFromLine() throws Exception {
-        super.testIndexPointsFromLine();
-    }
-
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/86118")
-    @Override
-    public void testIndexPointsFromPolygon() throws Exception {
-        super.testIndexPointsFromPolygon();
+    protected boolean ignoreLons(double[] lons) {
+        return Arrays.stream(lons).anyMatch(v -> v == 180);
     }
 }

--- a/test/framework/src/main/java/org/elasticsearch/search/geo/GeoPointShapeQueryTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/search/geo/GeoPointShapeQueryTestCase.java
@@ -704,7 +704,7 @@ public abstract class GeoPointShapeQueryTestCase extends ESSingleNodeTestCase {
         ensureGreen();
 
         Line line = randomValueOtherThanMany(
-            l -> GeometryNormalizer.needsNormalize(Orientation.CCW, l),
+            l -> GeometryNormalizer.needsNormalize(Orientation.CCW, l) || ignoreLons(l.getLons()),
             () -> GeometryTestUtils.randomLine(false)
         );
         for (int i = 0; i < line.length(); i++) {
@@ -729,7 +729,7 @@ public abstract class GeoPointShapeQueryTestCase extends ESSingleNodeTestCase {
         ensureGreen();
 
         Polygon polygon = randomValueOtherThanMany(
-            p -> GeometryNormalizer.needsNormalize(Orientation.CCW, p),
+            p -> GeometryNormalizer.needsNormalize(Orientation.CCW, p) || ignoreLons(p.getPolygon().getLons()),
             () -> GeometryTestUtils.randomPolygon(false)
         );
         LinearRing linearRing = polygon.getPolygon();
@@ -748,5 +748,10 @@ public abstract class GeoPointShapeQueryTestCase extends ESSingleNodeTestCase {
         assertSearchResponse(searchResponse);
         SearchHits searchHits = searchResponse.getHits();
         assertThat(searchHits.getTotalHits().value, equalTo((long) linearRing.length()));
+    }
+
+    /** Only LegacyGeoShape has limited support, so other tests will ignore nothing */
+    protected boolean ignoreLons(double[] lons) {
+        return false;
     }
 }


### PR DESCRIPTION
It turns out that LegacyGeoShape has an issue indexing points with
longitude=180, but since this is legacy, rather than fix that,
we just skip it from tests involving LegacyGeoPoint.

Fixes https://github.com/elastic/elasticsearch/issues/86118
