### PR TITLE
List rp.signature_algorithm supported values in docs

### DIFF
--- a/docs/reference/settings/security-settings.asciidoc
+++ b/docs/reference/settings/security-settings.asciidoc
@@ -39,10 +39,10 @@ Defaults to `true`, which enables
 <<configuring-stack-security,security auto configuration>>.
 +
 --
-If set to `false`, security auto configuration is disabled, which is not 
-recommended. When disabled, security is not configured automatically when 
+If set to `false`, security auto configuration is disabled, which is not
+recommended. When disabled, security is not configured automatically when
 starting {es} for the first time, which means that you must
-<<manually-configure-security,manually configure security>>. 
+<<manually-configure-security,manually configure security>>.
 --
 
 `xpack.security.hide_settings`::
@@ -1694,7 +1694,10 @@ or one of `id_token`, `id_token token` for the implicit flow.
 (<<static-cluster-setting,Static>>)
 The signature algorithm that will be used by {es} in order to verify the
 signature of the id tokens it will receive from the OpenID Connect Provider.
-Defaults to `RSA256`.
+Defaults to `RS256`.
+Allowed values are `HS256`, `HS384`, `HS512`, `ES256`, `ES384`, `ES512`,
+`RS256`, `RS384`, `RS512`, `PS256`, `PS384`, `PS512`.
+
 // end::rp-signature-algorithm-tag[]
 
 // tag::rp-requested-scopes-tag[]

--- a/docs/reference/settings/security-settings.asciidoc
+++ b/docs/reference/settings/security-settings.asciidoc
@@ -1694,9 +1694,9 @@ or one of `id_token`, `id_token token` for the implicit flow.
 (<<static-cluster-setting,Static>>)
 The signature algorithm that will be used by {es} in order to verify the
 signature of the id tokens it will receive from the OpenID Connect Provider.
-Defaults to `RS256`.
 Allowed values are `HS256`, `HS384`, `HS512`, `ES256`, `ES384`, `ES512`,
 `RS256`, `RS384`, `RS512`, `PS256`, `PS384`, `PS512`.
+Defaults to `RS256`.
 
 // end::rp-signature-algorithm-tag[]
 


### PR DESCRIPTION
The goal of this PR is to list the 12 allowed signature algorithm values for OIDC setting `rp.signature_algorithm`.
- https://www.elastic.co/guide/en/elasticsearch/reference/current/security-settings.html#ref-oidc-settings

For `rp.client_auth_jwt_signature_algorithm`, there are only 3 supported algorithms, with default `HS256`. No doc change is required.

For `rp.signature_algorithm`, there are 12 supported algorithms, with default `RS256`. The 12 supported algorithms are not listed, so a doc change is required. Also, the default is misspelled. It should be `RS256, not `RSA256`. Signature names are defined in [RFC 7518: JSON Web Algorithms (JWA)](https://datatracker.ietf.org/doc/html/rfc7518#section-3.1).

Doc PR previews are available for a short while after a build:
- https://elasticsearch_87365.docs-preview.app.elstc.co/diff