### PR TITLE
Brought back missing changelog for 87235

### DIFF
--- a/docs/changelog/87235.yaml
+++ b/docs/changelog/87235.yaml
@@ -1,0 +1,5 @@
+pr: 87235
+summary: Remove some blocking in CcrRepository
+area: CCR
+type: bug
+issues: []


### PR DESCRIPTION
While doing the release notes for 8.3.0 it was discovered that there was a PR 87016 with a missing changelog.

Investigation showed that this PR was merged (with changelog), reverted and the merged again (as a new PR with no changelog). It is not clear why the second time around the changelog was not added.

* Original PR merged on 31st May https://github.com/elastic/elasticsearch/commit/9c9bc8797b34994d0a1117debd2e8058658b407d
* Later that day the entire PR was reverted: https://github.com/elastic/elasticsearch/commit/088af81a653f85cd4525455fffd620e4aedcdf92
* Then on the 1st June a new PR with the same content (minus the changelog) was merged (now in PR 87235):  https://github.com/elastic/elasticsearch/commit/64d716b9928263bf49dff2b308fac440de945481
