### PR TITLE
[8.3] Relax geo_grid query test for max geo_tile zoom (#87357)

### DIFF
--- a/x-pack/plugin/spatial/src/internalClusterTest/java/org/elasticsearch/xpack/spatial/search/GeoGridAggAndQueryConsistencyIT.java
+++ b/x-pack/plugin/spatial/src/internalClusterTest/java/org/elasticsearch/xpack/spatial/search/GeoGridAggAndQueryConsistencyIT.java
@@ -105,7 +105,7 @@ public class GeoGridAggAndQueryConsistencyIT extends ESIntegTestCase {
     private void doTestGeotileGrid(String fieldType, Supplier<Geometry> randomGeometriesSupplier) throws IOException {
         doTestGrid(
             0,
-            GeoTileUtils.MAX_ZOOM,
+            GeoTileUtils.MAX_ZOOM - 1,
             fieldType,
             (precision, point) -> GeoTileUtils.stringEncode(GeoTileUtils.longEncode(point.getLon(), point.getLat(), precision)),
             tile -> toPoints(GeoTileUtils.toBoundingBox(tile)),

--- a/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/index/query/GeoGridQueryBuilderTests.java
+++ b/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/index/query/GeoGridQueryBuilderTests.java
@@ -264,7 +264,7 @@ public class GeoGridQueryBuilderTests extends AbstractQueryTestCase<GeoGridQuery
         double lon = randomDoubleBetween(-180d, 180d, true);
         double qLat = GeoEncodingUtils.decodeLatitude(GeoEncodingUtils.encodeLatitude(lat));
         double qLon = GeoEncodingUtils.decodeLongitude(GeoEncodingUtils.encodeLongitude(lon));
-        for (int zoom = 0; zoom <= MAX_ZOOM; zoom++) {
+        for (int zoom = 0; zoom < MAX_ZOOM; zoom++) {
             long tile = GeoTileUtils.longEncode(qLon, qLat, zoom);
             Rectangle qRect = GeoGridQueryBuilder.getQueryTile(stringEncode(tile));
             assertBoundingBox(tile, zoom, qLon, qLat, qRect);


### PR DESCRIPTION
Backports the following commits to 8.3:
 - Relax geo_grid query test for max geo_tile zoom (#87357)