### PR TITLE
Test dependency on jimfs should also depend upon guava

### DIFF
--- a/x-pack/qa/saml-idp-tests/build.gradle
+++ b/x-pack/qa/saml-idp-tests/build.gradle
@@ -8,6 +8,7 @@ apply plugin: 'elasticsearch.test.fixtures'
 dependencies {
   javaRestTestImplementation(testArtifact(project(xpackModule('core'))))
   javaRestTestImplementation "com.google.jimfs:jimfs:${versions.jimfs}"
+  javaRestTestImplementation "com.google.guava:guava:${versions.jimfs_guava}"
 }
 
 testFixtures.useFixture ":x-pack:test:idp-fixture"


### PR DESCRIPTION
While working on a completely separate issue I noticed failures because of a lack of guava when running a test that uses jimfs. The solution is simple; anywhere you see jimfs you need guava - since jimfs uses guava internally.

Looking at other usages of jimfs in tests, they already have the guava dependency. Note: I've not been able to reproduce the failure myself, but I have seen it in WIP-CI jobs. 