### PR TITLE
[docs] Clarify that index template settings take precedence over comp…

### DIFF
--- a/docs/reference/indices/index-templates.asciidoc
+++ b/docs/reference/indices/index-templates.asciidoc
@@ -28,6 +28,8 @@ applied.
 template, the settings from the <<indices-create-index,create index>> request
 take precedence over settings specified in the index template and its component
 templates.
+* Settings specified in the index template itself take presedence over the settings 
+in its component templates.
 * If a new data stream or index matches more than one index template, the index
 template with the highest priority is used.
 

--- a/docs/reference/indices/index-templates.asciidoc
+++ b/docs/reference/indices/index-templates.asciidoc
@@ -28,7 +28,7 @@ applied.
 template, the settings from the <<indices-create-index,create index>> request
 take precedence over settings specified in the index template and its component
 templates.
-* Settings specified in the index template itself take presedence over the settings 
+* Settings specified in the index template itself take precedence over the settings 
 in its component templates.
 * If a new data stream or index matches more than one index template, the index
 template with the highest priority is used.


### PR DESCRIPTION
Clarify that index template settings take precedence over component templates.

When an index template contains index settings, e.g. `"number_of_shards" : 2` and one of its component templates has a different value, e.g. `"number_of_shards" : 3` then the index template settings take precedence over the composable template. In this example, the result would be `"number_of_shards" : 2`.

This should be backported to 7.17.x as well.