### PR TITLE
[7.17] [DOCS] Typo in time functions (#87373)

### DIFF
--- a/docs/reference/ml/anomaly-detection/functions/ml-time-functions.asciidoc
+++ b/docs/reference/ml/anomaly-detection/functions/ml-time-functions.asciidoc
@@ -14,7 +14,7 @@ The {ml-features} include the following time functions:
 
 [NOTE]
 ====
-* NOTE: You cannot create forecasts for {anomaly-jobs} that contain time
+* You cannot create forecasts for {anomaly-jobs} that contain time
 functions. 
 * The `time_of_day` function is not aware of the difference between days, for
 instance work days and weekends. When modeling different days, use the


### PR DESCRIPTION
Backports the following commits to 7.17:
 - [DOCS] Typo in time functions (#87373)