### PR TITLE
[7.17] Brought back missing changelog for 87235 (#87369)

### DIFF
--- a/docs/changelog/87235.yaml
+++ b/docs/changelog/87235.yaml
@@ -1,0 +1,5 @@
+pr: 87235
+summary: Remove some blocking in CcrRepository
+area: CCR
+type: bug
+issues: []


### PR DESCRIPTION
Backports the following commits to 7.17:
 - Brought back missing changelog for 87235 (#87369)