### PR TITLE
[DOCS] Add notable breaking changes section in 8.3

### DIFF
--- a/docs/reference/migration/migrate_8_3.asciidoc
+++ b/docs/reference/migration/migrate_8_3.asciidoc
@@ -9,15 +9,15 @@ your application to {es} 8.3.
 
 See also <<release-highlights>> and <<es-release-notes>>.
 
-coming::[8.3.0-SNAPSHOT]
-
+coming::[8.3.0]
 
 [discrete]
 [[breaking-changes-8.3]]
 === Breaking changes
 
+// tag::notable-breaking-changes[]
 There are no breaking changes in {es} 8.3.
-
+// end::notable-breaking-changes[]
 
 [discrete]
 [[deprecated-8.3]]


### PR DESCRIPTION
Relates to https://github.com/elastic/stack-docs/pull/2152,
where the Installation and Upgrade Guide fails with the following build error:

> 10:00:29 INFO:build_docs:asciidoctor: WARNING: breaking.asciidoc: line 60: tag 'notable-breaking-changes' not found in include file: /tmp/docsbuild/LSUZU8uU7p/elasticsearch/docs/reference/migration/migrate_8_3.asciidoc
