### PR TITLE
Handle ordering in plain highlighter for multiple inputs

### DIFF
--- a/docs/changelog/87414.yaml
+++ b/docs/changelog/87414.yaml
@@ -1,0 +1,6 @@
+pr: 87414
+summary: Handle ordering in plain highlighter for multiple inputs
+area: Highlighting
+type: bug
+issues:
+ - 87210

--- a/server/src/main/java/org/elasticsearch/search/fetch/subphase/highlight/PlainHighlighter.java
+++ b/server/src/main/java/org/elasticsearch/search/fetch/subphase/highlight/PlainHighlighter.java
@@ -170,12 +170,12 @@ public class PlainHighlighter implements Highlighter {
             }
         }
 
-        // For single text inputs, the fragments are already ordered by score.  If we have multiple
+        // For single text inputs, the fragments are already ordered by score. If we have multiple
         // inputs, or if we are ordering by fragment number, then we need to resort the output list
         if (textsToHighlight.size() > 1 || field.fieldOptions().scoreOrdered() == false) {
-            Comparator<OrderedTextFragment> comparator = field.fieldOptions().scoreOrdered() ?
-                Comparator.comparingDouble(OrderedTextFragment::score).reversed() :
-                Comparator.comparingInt(OrderedTextFragment::fragNum);
+            Comparator<OrderedTextFragment> comparator = field.fieldOptions().scoreOrdered()
+                ? Comparator.comparingDouble(OrderedTextFragment::score).reversed()
+                : Comparator.comparingInt(OrderedTextFragment::fragNum);
             fragsList.sort(comparator);
         }
 

--- a/server/src/main/java/org/elasticsearch/search/fetch/subphase/highlight/PlainHighlighter.java
+++ b/server/src/main/java/org/elasticsearch/search/fetch/subphase/highlight/PlainHighlighter.java
@@ -22,7 +22,6 @@ import org.apache.lucene.search.highlight.SimpleHTMLFormatter;
 import org.apache.lucene.search.highlight.SimpleSpanFragmenter;
 import org.apache.lucene.search.highlight.TextFragment;
 import org.apache.lucene.util.BytesRefHash;
-import org.apache.lucene.util.CollectionUtil;
 import org.elasticsearch.common.lucene.Lucene;
 import org.elasticsearch.common.text.Text;
 import org.elasticsearch.index.IndexSettings;
@@ -32,6 +31,7 @@ import org.elasticsearch.search.fetch.FetchSubPhase;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -41,6 +41,17 @@ import static org.elasticsearch.search.fetch.subphase.highlight.UnifiedHighlight
 
 public class PlainHighlighter implements Highlighter {
     private static final String CACHE_KEY = "highlight-plain";
+
+    private record OrderedTextFragment(TextFragment textFragment, int fragNum) {
+        float score() {
+            return textFragment.getScore();
+        }
+
+        @Override
+        public String toString() {
+            return textFragment.toString();
+        }
+    }
 
     @Override
     public HighlightField highlight(FieldHighlightContext fieldContext) throws IOException {
@@ -92,7 +103,7 @@ public class PlainHighlighter implements Highlighter {
 
         // a HACK to make highlighter do highlighting, even though its using the single frag list builder
         int numberOfFragments = field.fieldOptions().numberOfFragments() == 0 ? 1 : field.fieldOptions().numberOfFragments();
-        ArrayList<TextFragment> fragsList = new ArrayList<>();
+        ArrayList<OrderedTextFragment> fragsList = new ArrayList<>();
         List<Object> textsToHighlight;
         final int maxAnalyzedOffset = context.getSearchExecutionContext().getIndexSettings().getHighlightMaxAnalyzedOffset();
         Integer queryMaxAnalyzedOffset = fieldContext.field.fieldOptions().maxAnalyzedOffset();
@@ -108,6 +119,7 @@ public class PlainHighlighter implements Highlighter {
             fieldContext.forceSource
         );
 
+        int fragNumBase = 0;
         for (Object textToHighlight : textsToHighlight) {
             String text = convertFieldValue(fieldType, textToHighlight);
             int textLength = text.length();
@@ -144,9 +156,10 @@ public class PlainHighlighter implements Highlighter {
                 TextFragment[] bestTextFragments = entry.getBestTextFragments(tokenStream, text, false, numberOfFragments);
                 for (TextFragment bestTextFragment : bestTextFragments) {
                     if (bestTextFragment != null && bestTextFragment.getScore() > 0) {
-                        fragsList.add(bestTextFragment);
+                        fragsList.add(new OrderedTextFragment(bestTextFragment, bestTextFragment.getFragNum() + fragNumBase));
                     }
                 }
+                fragNumBase += bestTextFragments.length;
             } catch (BytesRefHash.MaxBytesLengthExceededException e) {
                 // this can happen if for example a field is not_analyzed and ignore_above option is set.
                 // the field will be ignored when indexing but the huge term is still in the source and
@@ -157,10 +170,15 @@ public class PlainHighlighter implements Highlighter {
             }
         }
 
-        // fragments are ordered by score by default since we add them in best
-        if (field.fieldOptions().scoreOrdered() == false) {
-            CollectionUtil.introSort(fragsList, (o1, o2) -> o1.getFragNum() - o2.getFragNum());
+        // For single text inputs, the fragments are already ordered by score.  If we have multiple
+        // inputs, or if we are ordering by fragment number, then we need to resort the output list
+        if (textsToHighlight.size() > 1 || field.fieldOptions().scoreOrdered() == false) {
+            Comparator<OrderedTextFragment> comparator = field.fieldOptions().scoreOrdered() ?
+                Comparator.comparingDouble(OrderedTextFragment::score).reversed() :
+                Comparator.comparingInt(OrderedTextFragment::fragNum);
+            fragsList.sort(comparator);
         }
+
         String[] fragments;
         // number_of_fragments is set to 0 but we have a multivalued field
         if (field.fieldOptions().numberOfFragments() == 0 && textsToHighlight.size() > 1 && fragsList.size() > 0) {

--- a/server/src/test/java/org/elasticsearch/search/fetch/subphase/highlight/PlainHighlighterTests.java
+++ b/server/src/test/java/org/elasticsearch/search/fetch/subphase/highlight/PlainHighlighterTests.java
@@ -13,9 +13,15 @@ import org.apache.lucene.search.PhraseQuery;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.highlight.QueryScorer;
 import org.apache.lucene.tests.analysis.MockAnalyzer;
-import org.apache.lucene.tests.util.LuceneTestCase;
+import org.elasticsearch.index.mapper.MapperService;
+import org.elasticsearch.index.mapper.ParsedDocument;
+import org.elasticsearch.index.query.QueryBuilders;
+import org.elasticsearch.search.builder.SearchSourceBuilder;
+import org.elasticsearch.search.fetch.HighlighterTestCase;
 
-public class PlainHighlighterTests extends LuceneTestCase {
+import java.util.Map;
+
+public class PlainHighlighterTests extends HighlighterTestCase {
 
     public void testHighlightPhrase() throws Exception {
         Query query = new PhraseQuery.Builder().add(new Term("field", "foo")).add(new Term("field", "bar")).build();
@@ -23,5 +29,64 @@ public class PlainHighlighterTests extends LuceneTestCase {
         org.apache.lucene.search.highlight.Highlighter highlighter = new org.apache.lucene.search.highlight.Highlighter(queryScorer);
         String[] frags = highlighter.getBestFragments(new MockAnalyzer(random()), "field", "bar foo bar foo", 10);
         assertArrayEquals(new String[] { "bar <B>foo</B> <B>bar</B> foo" }, frags);
+    }
+
+    public void testOrdering() throws Exception {
+
+        MapperService mapperService = createMapperService("""
+            { "_doc" : { "properties" : {
+                "description" : { "type" : "text" }
+            }}}
+            """);
+
+        ParsedDocument doc = mapperService.documentMapper().parse(source("""
+            {
+              "description": [
+                "Lorem Ipsum string Generator that helps to create dummy text for all layout needs.",
+                "It has roots in a piece of classical Latin literature from 45 BC, making it search string over 2000 years old."
+              ]
+            }
+            """));
+
+        {
+
+            SearchSourceBuilder search = new SearchSourceBuilder()
+                .query(QueryBuilders.matchQuery("description", "search string"))
+                .highlighter(new HighlightBuilder().field("description").highlighterType("plain").order("score").fragmentSize(50));
+
+            Map<String, HighlightField> highlights = highlight(mapperService, doc, search);
+            assertHighlights(highlights, "description",
+                " literature from 45 BC, making it <em>search</em> <em>string</em> over 2000 years old.",
+                "Lorem Ipsum <em>string</em> Generator that helps to create");
+
+        }
+
+        {
+
+            SearchSourceBuilder search = new SearchSourceBuilder()
+                .query(QueryBuilders.matchQuery("description", "string generator"))
+                .highlighter(new HighlightBuilder().field("description").highlighterType("plain").order("score").fragmentSize(50));
+
+            Map<String, HighlightField> highlights = highlight(mapperService, doc, search);
+            assertHighlights(highlights, "description",
+                "Lorem Ipsum <em>string</em> <em>Generator</em> that helps to create",
+                " literature from 45 BC, making it search <em>string</em> over 2000 years old.");
+
+        }
+
+        {
+
+            SearchSourceBuilder search = new SearchSourceBuilder()
+                .query(QueryBuilders.matchQuery("description", "lorem layout needs roots years"))
+                .highlighter(new HighlightBuilder().field("description").highlighterType("plain").fragmentSize(20));
+
+            Map<String, HighlightField> highlights = highlight(mapperService, doc, search);
+            assertHighlights(highlights, "description",
+                "<em>Lorem</em> Ipsum string",
+                " text for all <em>layout</em> <em>needs</em>.",
+                "It has <em>roots</em> in a",
+                " search string over 2000 <em>years</em> old.");
+
+        }
     }
 }

--- a/server/src/test/java/org/elasticsearch/search/fetch/subphase/highlight/PlainHighlighterTests.java
+++ b/server/src/test/java/org/elasticsearch/search/fetch/subphase/highlight/PlainHighlighterTests.java
@@ -50,42 +50,49 @@ public class PlainHighlighterTests extends HighlighterTestCase {
 
         {
 
-            SearchSourceBuilder search = new SearchSourceBuilder()
-                .query(QueryBuilders.matchQuery("description", "search string"))
+            SearchSourceBuilder search = new SearchSourceBuilder().query(QueryBuilders.matchQuery("description", "search string"))
                 .highlighter(new HighlightBuilder().field("description").highlighterType("plain").order("score").fragmentSize(50));
 
             Map<String, HighlightField> highlights = highlight(mapperService, doc, search);
-            assertHighlights(highlights, "description",
+            assertHighlights(
+                highlights,
+                "description",
                 " literature from 45 BC, making it <em>search</em> <em>string</em> over 2000 years old.",
-                "Lorem Ipsum <em>string</em> Generator that helps to create");
+                "Lorem Ipsum <em>string</em> Generator that helps to create"
+            );
 
         }
 
         {
 
-            SearchSourceBuilder search = new SearchSourceBuilder()
-                .query(QueryBuilders.matchQuery("description", "string generator"))
+            SearchSourceBuilder search = new SearchSourceBuilder().query(QueryBuilders.matchQuery("description", "string generator"))
                 .highlighter(new HighlightBuilder().field("description").highlighterType("plain").order("score").fragmentSize(50));
 
             Map<String, HighlightField> highlights = highlight(mapperService, doc, search);
-            assertHighlights(highlights, "description",
+            assertHighlights(
+                highlights,
+                "description",
                 "Lorem Ipsum <em>string</em> <em>Generator</em> that helps to create",
-                " literature from 45 BC, making it search <em>string</em> over 2000 years old.");
+                " literature from 45 BC, making it search <em>string</em> over 2000 years old."
+            );
 
         }
 
         {
 
-            SearchSourceBuilder search = new SearchSourceBuilder()
-                .query(QueryBuilders.matchQuery("description", "lorem layout needs roots years"))
-                .highlighter(new HighlightBuilder().field("description").highlighterType("plain").fragmentSize(20));
+            SearchSourceBuilder search = new SearchSourceBuilder().query(
+                QueryBuilders.matchQuery("description", "lorem layout needs roots years")
+            ).highlighter(new HighlightBuilder().field("description").highlighterType("plain").fragmentSize(20));
 
             Map<String, HighlightField> highlights = highlight(mapperService, doc, search);
-            assertHighlights(highlights, "description",
+            assertHighlights(
+                highlights,
+                "description",
                 "<em>Lorem</em> Ipsum string",
                 " text for all <em>layout</em> <em>needs</em>.",
                 "It has <em>roots</em> in a",
-                " search string over 2000 <em>years</em> old.");
+                " search string over 2000 <em>years</em> old."
+            );
 
         }
     }

--- a/test/framework/src/main/java/org/elasticsearch/search/fetch/HighlighterTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/search/fetch/HighlighterTestCase.java
@@ -27,8 +27,8 @@ import org.elasticsearch.search.fetch.subphase.highlight.UnifiedHighlighter;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.stream.Collectors;
 
 import static org.mockito.Mockito.mock;
@@ -72,8 +72,8 @@ public class HighlighterTestCase extends MapperServiceTestCase {
      */
     protected static void assertHighlights(Map<String, HighlightField> highlights, String field, String... fragments) {
         assertNotNull("No highlights reported for field [" + field + "]", highlights.get(field));
-        Set<String> actualFragments = Arrays.stream(highlights.get(field).getFragments()).map(Text::toString).collect(Collectors.toSet());
-        Set<String> expectedFragments = Set.of(fragments);
+        List<String> actualFragments = Arrays.stream(highlights.get(field).getFragments()).map(Text::toString).collect(Collectors.toList());
+        List<String> expectedFragments = List.of(fragments);
         assertEquals(expectedFragments, actualFragments);
     }
 


### PR DESCRIPTION
The ordering logic in the plain highlighter only worked for single-valued
inputs.  If you had multiple inputs, then order-by-score would only do this
ordering for fragments within each input, and order-by-position would 
interleave fragments from the different inputs.  This commit fixes both
issues.

Fixes #87210 