### PR TITLE
Filter out nulls in writeUpdatedShardMetaDataAndComputeDeletes

### DIFF
--- a/docs/changelog/87415.yaml
+++ b/docs/changelog/87415.yaml
@@ -1,0 +1,5 @@
+pr: 87415
+summary: Filter out nulls in `writeUpdatedShardMetaDataAndComputeDeletes`
+area: Snapshot/Restore
+type: bug
+issues: []

--- a/server/src/main/java/org/elasticsearch/repositories/blobstore/BlobStoreRepository.java
+++ b/server/src/main/java/org/elasticsearch/repositories/blobstore/BlobStoreRepository.java
@@ -1020,7 +1020,11 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
 
         // Listener that flattens out the delete results for each index
         final ActionListener<Collection<ShardSnapshotMetaDeleteResult>> deleteIndexMetadataListener = new GroupedActionListener<>(
-            onAllShardsCompleted.map(res -> res.stream().flatMap(Collection::stream).toList()),
+            onAllShardsCompleted.map(res -> res.stream()
+                .filter(Objects::nonNull)
+                .flatMap(Collection::stream)
+                .filter(Objects::nonNull)
+                .toList()),
             indices.size()
         );
 

--- a/server/src/main/java/org/elasticsearch/repositories/blobstore/BlobStoreRepository.java
+++ b/server/src/main/java/org/elasticsearch/repositories/blobstore/BlobStoreRepository.java
@@ -1020,11 +1020,9 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
 
         // Listener that flattens out the delete results for each index
         final ActionListener<Collection<ShardSnapshotMetaDeleteResult>> deleteIndexMetadataListener = new GroupedActionListener<>(
-            onAllShardsCompleted.map(res -> res.stream()
-                .filter(Objects::nonNull)
-                .flatMap(Collection::stream)
-                .filter(Objects::nonNull)
-                .toList()),
+            onAllShardsCompleted.map(
+                res -> res.stream().filter(Objects::nonNull).flatMap(Collection::stream).filter(Objects::nonNull).toList()
+            ),
             indices.size()
         );
 


### PR DESCRIPTION
We use `null` to represent failure/corruption cases in the result, but
we don't account for `null` values specially so these paths would result
in NPEs. This commit filters out these `null` markers.