### PR TITLE
Adding chunk_size for random_sampler agg

### DIFF
--- a/docs/changelog/87418.yaml
+++ b/docs/changelog/87418.yaml
@@ -1,0 +1,5 @@
+pr: 87418
+summary: Adding `chunk_size` for `random_sampler` agg
+area: Aggregations
+type: enhancement
+issues: []

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/sampler/random/RandomSamplerAggregatorFactory.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/sampler/random/RandomSamplerAggregatorFactory.java
@@ -25,6 +25,7 @@ import java.util.Optional;
 
 public class RandomSamplerAggregatorFactory extends AggregatorFactory {
 
+    private final int chunkSize;
     private final int seed;
     private final double probability;
     private final SamplingContext samplingContext;
@@ -33,6 +34,7 @@ public class RandomSamplerAggregatorFactory extends AggregatorFactory {
     RandomSamplerAggregatorFactory(
         String name,
         int seed,
+        int chunkSize,
         double probability,
         AggregationContext context,
         AggregatorFactory parent,
@@ -42,6 +44,7 @@ public class RandomSamplerAggregatorFactory extends AggregatorFactory {
         super(name, context, parent, subFactories, metadata);
         this.probability = probability;
         this.seed = seed;
+        this.chunkSize = chunkSize;
         this.samplingContext = new SamplingContext(probability, seed);
     }
 
@@ -66,7 +69,7 @@ public class RandomSamplerAggregatorFactory extends AggregatorFactory {
      */
     private Weight getWeight() throws IOException {
         if (weight == null) {
-            RandomSamplingQuery query = new RandomSamplingQuery(probability, seed, context.shardRandomSeed());
+            RandomSamplingQuery query = new RandomSamplingQuery(probability, seed, context.shardRandomSeed(), chunkSize);
             BooleanQuery booleanQuery = new BooleanQuery.Builder().add(query, BooleanClause.Occur.FILTER)
                 .add(context.query(), BooleanClause.Occur.FILTER)
                 .build();

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/sampler/random/RandomDocIDSetIteratorTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/sampler/random/RandomDocIDSetIteratorTests.java
@@ -16,8 +16,21 @@ import java.util.List;
 import java.util.SplittableRandom;
 
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThan;
 
 public class RandomDocIDSetIteratorTests extends ESTestCase {
+
+    public void testRandomSamplingWithChunk() {
+        double p = 0.01;
+        int maxDoc = 10000;
+        SplittableRandom random = new SplittableRandom(randomInt());
+        RandomSamplingQuery.RandomSamplingIterator iter = new RandomSamplingQuery.RandomSamplingIterator(maxDoc, p, 10, random::nextInt);
+        int count = 0;
+        while (iter.nextDoc() != DocIdSetIterator.NO_MORE_DOCS) {
+            count += 1;
+        }
+        assertThat(count, greaterThan((int) (maxDoc * p) - 1));
+    }
 
     public void testRandomSampler() {
         int maxDoc = 10000;
@@ -26,7 +39,7 @@ public class RandomDocIDSetIteratorTests extends ESTestCase {
         for (int i = 1; i < 100; i++) {
             double p = i / 100.0;
             int count = 0;
-            RandomSamplingQuery.RandomSamplingIterator iter = new RandomSamplingQuery.RandomSamplingIterator(maxDoc, p, random::nextInt);
+            RandomSamplingQuery.RandomSamplingIterator iter = new RandomSamplingQuery.RandomSamplingIterator(maxDoc, p, 1, random::nextInt);
             while (iter.nextDoc() != DocIdSetIterator.NO_MORE_DOCS) {
                 count += 1;
             }
@@ -55,13 +68,13 @@ public class RandomDocIDSetIteratorTests extends ESTestCase {
             double p = i / 100.0;
             SplittableRandom random = new SplittableRandom(seed);
             List<Integer> iterationOne = new ArrayList<>();
-            RandomSamplingQuery.RandomSamplingIterator iter = new RandomSamplingQuery.RandomSamplingIterator(maxDoc, p, random::nextInt);
+            RandomSamplingQuery.RandomSamplingIterator iter = new RandomSamplingQuery.RandomSamplingIterator(maxDoc, p, 1, random::nextInt);
             while (iter.nextDoc() != DocIdSetIterator.NO_MORE_DOCS) {
                 iterationOne.add(iter.docID());
             }
             random = new SplittableRandom(seed);
             List<Integer> iterationTwo = new ArrayList<>();
-            iter = new RandomSamplingQuery.RandomSamplingIterator(maxDoc, p, random::nextInt);
+            iter = new RandomSamplingQuery.RandomSamplingIterator(maxDoc, p, 1, random::nextInt);
             while (iter.nextDoc() != DocIdSetIterator.NO_MORE_DOCS) {
                 iterationTwo.add(iter.docID());
             }


### PR DESCRIPTION
This adds a new parameter called `chunk_size` to the random_sampler agg. 

This allows for groups of documents to be sampled together which may allow for greater speed improvements by taking advantage of disk locality and pre-fetching.