### PR TITLE
Avoid expensive search stats updates

### DIFF
--- a/docs/changelog/87428.yaml
+++ b/docs/changelog/87428.yaml
@@ -1,6 +1,6 @@
 pr: 87428
 summary: Avoid expensive search stats updates
-area: "Search, Stats"
+area: "Stats"
 type: bug
 issues:
  - 85586

--- a/docs/changelog/87428.yaml
+++ b/docs/changelog/87428.yaml
@@ -1,0 +1,6 @@
+pr: 87428
+summary: Avoid expensive search stats updates
+area: "Search, Stats"
+type: bug
+issues:
+ - 85586

--- a/docs/reference/search/search.asciidoc
+++ b/docs/reference/search/search.asciidoc
@@ -654,7 +654,8 @@ exclude fields from this subset using the `excludes` property.
 (Optional, array of strings)
 Stats groups to associate with the search. Each group maintains a statistics
 aggregation for its associated searches. You can retrieve these stats using the
-<<indices-stats,indices stats API>>.
+<<indices-stats,indices stats API>>. At maximum, only 1,000 groups will be
+tracked. Beyond this number, no new groups will be added to the stats.
 
 include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=terminate_after]
 +

--- a/server/src/main/java/org/elasticsearch/index/search/stats/ShardSearchStats.java
+++ b/server/src/main/java/org/elasticsearch/index/search/stats/ShardSearchStats.java
@@ -16,7 +16,6 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.CollectionUtils;
 import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.common.util.concurrent.ConcurrentCollections;
-import org.elasticsearch.index.IndexSettings;
 import org.elasticsearch.index.shard.SearchOperationListener;
 import org.elasticsearch.search.internal.ReaderContext;
 import org.elasticsearch.search.internal.SearchContext;
@@ -39,8 +38,8 @@ public final class ShardSearchStats implements SearchOperationListener {
     private final Map<String, StatsHolder> groupsStats = ConcurrentCollections.newConcurrentMap();
     private final int maxGroups;
 
-    public ShardSearchStats(IndexSettings indexSettings) {
-        this.maxGroups = indexSettings.getValue(MAX_SEARCH_STATS_GROUPS_SETTING);
+    public ShardSearchStats(Settings indexSettings) {
+        this.maxGroups = MAX_SEARCH_STATS_GROUPS_SETTING.get(indexSettings);
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/index/shard/IndexShard.java
+++ b/server/src/main/java/org/elasticsearch/index/shard/IndexShard.java
@@ -327,7 +327,7 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
         this.mapperService = mapperService;
         this.indexCache = indexCache;
         this.internalIndexingStats = new InternalIndexingStats();
-        this.searchStats = new ShardSearchStats(indexSettings);
+        this.searchStats = new ShardSearchStats(settings);
         final List<IndexingOperationListener> listenersList = new ArrayList<>(listeners);
         listenersList.add(internalIndexingStats);
         this.indexingOperationListeners = new IndexingOperationListener.CompositeListener(listenersList, logger);

--- a/server/src/main/java/org/elasticsearch/index/shard/IndexShard.java
+++ b/server/src/main/java/org/elasticsearch/index/shard/IndexShard.java
@@ -194,7 +194,7 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
     private final IndexCache indexCache;
     private final Store store;
     private final InternalIndexingStats internalIndexingStats;
-    private final ShardSearchStats searchStats = new ShardSearchStats();
+    private final ShardSearchStats searchStats;
     private final ShardFieldUsageTracker fieldUsageTracker;
     private final String shardUuid = UUIDs.randomBase64UUID();
     private final long shardCreationTime;
@@ -327,6 +327,7 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
         this.mapperService = mapperService;
         this.indexCache = indexCache;
         this.internalIndexingStats = new InternalIndexingStats();
+        this.searchStats = new ShardSearchStats(indexSettings);
         final List<IndexingOperationListener> listenersList = new ArrayList<>(listeners);
         listenersList.add(internalIndexingStats);
         this.indexingOperationListeners = new IndexingOperationListener.CompositeListener(listenersList, logger);

--- a/test/framework/src/main/java/org/elasticsearch/test/InternalSettingsPlugin.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/InternalSettingsPlugin.java
@@ -14,6 +14,7 @@ import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.index.IndexModule;
 import org.elasticsearch.index.IndexService;
 import org.elasticsearch.index.IndexSettings;
+import org.elasticsearch.index.search.stats.ShardSearchStats;
 import org.elasticsearch.monitor.fs.FsService;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.transport.RemoteConnectionStrategy;
@@ -62,6 +63,7 @@ public final class InternalSettingsPlugin extends Plugin {
             IndexService.RETENTION_LEASE_SYNC_INTERVAL_SETTING,
             IndexSettings.FILE_BASED_RECOVERY_THRESHOLD_SETTING,
             IndexModule.INDEX_QUERY_CACHE_EVERYTHING_SETTING,
+            ShardSearchStats.MAX_SEARCH_STATS_GROUPS_SETTING,
             FsService.ALWAYS_REFRESH_SETTING
         );
     }


### PR DESCRIPTION
Search stats can be grouped by a custom key. Currently the grouped stats are
stored in an immutable map, which is copied every time a new group is added.
This can be really expensive when there are a large number of unique groups.

This PR makes two changes:
* Switch to a concurrent map to avoid copying the map when groups are added.
* Bound the total number of groups at 1,000 to prevent the stats from taking
too much memory. Beyond this number, new groups will not be tracked.

Closes #85586.