### PR TITLE
Script: Add UpdateByQuery and Reindex contexts

### DIFF
--- a/modules/lang-painless/src/main/resources/org/elasticsearch/painless/org.elasticsearch.script.reindex.txt
+++ b/modules/lang-painless/src/main/resources/org/elasticsearch/painless/org.elasticsearch.script.reindex.txt
@@ -1,0 +1,20 @@
+#
+# Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+# or more contributor license agreements. Licensed under the Elastic License
+# 2.0 and the Server Side Public License, v 1; you may not use this file except
+# in compliance with, at your election, the Elastic License 2.0 or the Server
+# Side Public License, v 1.
+#
+
+# This file contains a whitelist for reindex scripts
+
+class java.lang.String {
+  String org.elasticsearch.painless.api.Augmentation sha1()
+  String org.elasticsearch.painless.api.Augmentation sha256()
+}
+
+class org.elasticsearch.painless.api.Json {
+  def load(String)
+  String dump(def)
+  String dump(def, boolean)
+}

--- a/modules/lang-painless/src/main/resources/org/elasticsearch/painless/org.elasticsearch.script.update.txt
+++ b/modules/lang-painless/src/main/resources/org/elasticsearch/painless/org.elasticsearch.script.update.txt
@@ -1,0 +1,20 @@
+#
+# Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+# or more contributor license agreements. Licensed under the Elastic License
+# 2.0 and the Server Side Public License, v 1; you may not use this file except
+# in compliance with, at your election, the Elastic License 2.0 or the Server
+# Side Public License, v 1.
+#
+
+# This file contains a whitelist for update scripts
+
+class java.lang.String {
+  String org.elasticsearch.painless.api.Augmentation sha1()
+  String org.elasticsearch.painless.api.Augmentation sha256()
+}
+
+class org.elasticsearch.painless.api.Json {
+  def load(String)
+  String dump(def)
+  String dump(def, boolean)
+}

--- a/modules/lang-painless/src/main/resources/org/elasticsearch/painless/org.elasticsearch.script.update_by_query.txt
+++ b/modules/lang-painless/src/main/resources/org/elasticsearch/painless/org.elasticsearch.script.update_by_query.txt
@@ -1,0 +1,20 @@
+#
+# Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+# or more contributor license agreements. Licensed under the Elastic License
+# 2.0 and the Server Side Public License, v 1; you may not use this file except
+# in compliance with, at your election, the Elastic License 2.0 or the Server
+# Side Public License, v 1.
+#
+
+# This file contains a whitelist for update_by_query scripts
+
+class java.lang.String {
+  String org.elasticsearch.painless.api.Augmentation sha1()
+  String org.elasticsearch.painless.api.Augmentation sha256()
+}
+
+class org.elasticsearch.painless.api.Json {
+  def load(String)
+  String dump(def)
+  String dump(def, boolean)
+}

--- a/modules/reindex/src/main/java/org/elasticsearch/reindex/AbstractAsyncBulkByScrollAction.java
+++ b/modules/reindex/src/main/java/org/elasticsearch/reindex/AbstractAsyncBulkByScrollAction.java
@@ -839,6 +839,7 @@ public abstract class AbstractAsyncBulkByScrollAction<
         }
 
         @Override
+        @SuppressWarnings("unchecked")
         public RequestWrapper<?> apply(RequestWrapper<?> request, ScrollableHitSource.Hit doc) {
             if (script == null) {
                 return request;

--- a/modules/reindex/src/main/java/org/elasticsearch/reindex/TransportUpdateByQueryAction.java
+++ b/modules/reindex/src/main/java/org/elasticsearch/reindex/TransportUpdateByQueryAction.java
@@ -29,6 +29,7 @@ import org.elasticsearch.index.reindex.UpdateByQueryRequest;
 import org.elasticsearch.index.reindex.WorkerBulkByScrollTaskState;
 import org.elasticsearch.script.Script;
 import org.elasticsearch.script.ScriptService;
+import org.elasticsearch.script.UpdateByQueryScript;
 import org.elasticsearch.tasks.Task;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
@@ -134,6 +135,7 @@ public class TransportUpdateByQueryAction extends HandledTransportAction<UpdateB
         }
 
         class UpdateByQueryScriptApplier extends ScriptApplier {
+            private UpdateByQueryScript.Factory update = null;
 
             UpdateByQueryScriptApplier(
                 WorkerBulkByScrollTaskState taskWorker,
@@ -164,6 +166,13 @@ public class TransportUpdateByQueryAction extends HandledTransportAction<UpdateB
                 throw new IllegalArgumentException("Modifying [" + RoutingFieldMapper.NAME + "] not allowed");
             }
 
+            @Override
+            protected void execute(Map<String, Object> ctx) {
+                if (update == null) {
+                    update = scriptService.compile(script, UpdateByQueryScript.CONTEXT);
+                }
+                update.newInstance(params, ctx).execute();
+            }
         }
     }
 }

--- a/server/src/main/java/org/elasticsearch/script/ReindexScript.java
+++ b/server/src/main/java/org/elasticsearch/script/ReindexScript.java
@@ -1,0 +1,50 @@
+
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.script;
+
+import java.util.Map;
+
+/**
+ * A script used in the reindex api
+ */
+public abstract class ReindexScript {
+
+    public static final String[] PARAMETERS = {};
+
+    /** The context used to compile {@link ReindexScript} factories. */
+    public static final ScriptContext<Factory> CONTEXT = new ScriptContext<>("reindex", Factory.class);
+
+    /** The generic runtime parameters for the script. */
+    private final Map<String, Object> params;
+
+    /** The context map for the script */
+    private final Map<String, Object> ctx;
+
+    public ReindexScript(Map<String, Object> params, Map<String, Object> ctx) {
+        this.params = params;
+        this.ctx = ctx;
+    }
+
+    /** Return the parameters for this script. */
+    public Map<String, Object> getParams() {
+        return params;
+    }
+
+    /** Return the context map for this script */
+    public Map<String, Object> getCtx() {
+        return ctx;
+    }
+
+    public abstract void execute();
+
+    public interface Factory {
+        ReindexScript newInstance(Map<String, Object> params, Map<String, Object> ctx);
+    }
+}

--- a/server/src/main/java/org/elasticsearch/script/ScriptModule.java
+++ b/server/src/main/java/org/elasticsearch/script/ScriptModule.java
@@ -51,6 +51,8 @@ public class ScriptModule {
                 BytesRefSortScript.CONTEXT,
                 TermsSetQueryScript.CONTEXT,
                 UpdateScript.CONTEXT,
+                ReindexScript.CONTEXT,
+                UpdateByQueryScript.CONTEXT,
                 BucketAggregationScript.CONTEXT,
                 BucketAggregationSelectorScript.CONTEXT,
                 SignificantTermsHeuristicScoreScript.CONTEXT,

--- a/server/src/main/java/org/elasticsearch/script/UpdateByQueryScript.java
+++ b/server/src/main/java/org/elasticsearch/script/UpdateByQueryScript.java
@@ -1,0 +1,50 @@
+
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.script;
+
+import java.util.Map;
+
+/**
+ * A script used by the update by query api
+ */
+public abstract class UpdateByQueryScript {
+
+    public static final String[] PARAMETERS = {};
+
+    /** The context used to compile {@link UpdateByQueryScript} factories. */
+    public static final ScriptContext<Factory> CONTEXT = new ScriptContext<>("update_by_query", Factory.class);
+
+    /** The generic runtime parameters for the script. */
+    private final Map<String, Object> params;
+
+    /** The context map for the script */
+    private final Map<String, Object> ctx;
+
+    public UpdateByQueryScript(Map<String, Object> params, Map<String, Object> ctx) {
+        this.params = params;
+        this.ctx = ctx;
+    }
+
+    /** Return the parameters for this script. */
+    public Map<String, Object> getParams() {
+        return params;
+    }
+
+    /** Return the context map for this script */
+    public Map<String, Object> getCtx() {
+        return ctx;
+    }
+
+    public abstract void execute();
+
+    public interface Factory {
+        UpdateByQueryScript newInstance(Map<String, Object> params, Map<String, Object> ctx);
+    }
+}

--- a/test/framework/src/main/java/org/elasticsearch/script/MockScriptEngine.java
+++ b/test/framework/src/main/java/org/elasticsearch/script/MockScriptEngine.java
@@ -177,6 +177,30 @@ public class MockScriptEngine implements ScriptEngine {
                 }
             };
             return context.factoryClazz.cast(factory);
+        } else if (context.instanceClazz.equals(ReindexScript.class)) {
+            ReindexScript.Factory factory = (parameters, ctx) -> new ReindexScript(parameters, ctx) {
+                @Override
+                public void execute() {
+                    final Map<String, Object> vars = new HashMap<>();
+                    vars.put("ctx", ctx);
+                    vars.put("params", parameters);
+                    vars.putAll(parameters);
+                    script.apply(vars);
+                }
+            };
+            return context.factoryClazz.cast(factory);
+        } else if (context.instanceClazz.equals(UpdateByQueryScript.class)) {
+            UpdateByQueryScript.Factory factory = (parameters, ctx) -> new UpdateByQueryScript(parameters, ctx) {
+                @Override
+                public void execute() {
+                    final Map<String, Object> vars = new HashMap<>();
+                    vars.put("ctx", ctx);
+                    vars.put("params", parameters);
+                    vars.putAll(parameters);
+                    script.apply(vars);
+                }
+            };
+            return context.factoryClazz.cast(factory);
         } else if (context.instanceClazz.equals(BucketAggregationScript.class)) {
             BucketAggregationScript.Factory factory = parameters -> new BucketAggregationScript(parameters) {
                 @Override


### PR DESCRIPTION
Add two new scripting contexts, UpdateByQuery and Reindex, in addition
to the Update context.  These three contexts have different sets of
metadata and so their Metadata classes will be different.  This split
prepares for the addition of their own Metadata classes.

Refs: #86472