### PR TITLE
Synthetic source: paranoid test for hidden copy_to

### DIFF
--- a/server/src/test/java/org/elasticsearch/index/mapper/SourceLoaderTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/SourceLoaderTests.java
@@ -106,4 +106,20 @@ public class SourceLoaderTests extends MapperServiceTestCase {
         }), equalTo("""
             {"o":{"bar":["b","c","e","f"],"foo":["a","d"]}}"""));
     }
+
+    public void testHideTheCopyTo() {
+        Exception e = expectThrows(IllegalArgumentException.class, () -> createDocumentMapper(syntheticSourceMapping(b -> {
+            b.startObject("foo");
+            {
+                b.field("type", "keyword");
+                b.startObject("fields");
+                {
+                    b.startObject("hidden").field("type", "keyword").field("copy_to", "bar").endObject();
+                }
+                b.endObject();
+            }
+            b.endObject();
+        })));
+        assertThat(e.getMessage(), equalTo("[copy_to] may not be used to copy from a multi-field: [foo.hidden]"));
+    }
 }


### PR DESCRIPTION
This adds a paranoid test to make sure that you can't hide `copy_to`
under a multi field. We don't want to support `copy_to` for synthetic
source at this point because we can't figure out which values are being
copied vs the values that come in the original source.
