### PR TITLE
FastVectorHighlighter should use ValueFetchers to load source data

### DIFF
--- a/docs/changelog/85815.yaml
+++ b/docs/changelog/85815.yaml
@@ -1,0 +1,9 @@
+pr: 85815
+summary: '`FastVectorHighlighter` should use `ValueFetchers` to load source data'
+area: Highlighting
+type: bug
+issues:
+ - 75011
+ - 84690
+ - 82458
+ - 80895

--- a/docs/changelog/87445.yaml
+++ b/docs/changelog/87445.yaml
@@ -1,0 +1,9 @@
+pr: 87445
+summary: '`FastVectorHighlighter` should use `ValueFetchers` to load source data'
+area: Highlighting
+type: bug
+issues:
+ - 75011
+ - 84690
+ - 82458
+ - 80895

--- a/server/src/main/java/org/elasticsearch/search/fetch/subphase/highlight/FastVectorHighlighter.java
+++ b/server/src/main/java/org/elasticsearch/search/fetch/subphase/highlight/FastVectorHighlighter.java
@@ -27,6 +27,7 @@ import org.elasticsearch.common.text.Text;
 import org.elasticsearch.common.util.CollectionUtils;
 import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.mapper.TextSearchInfo;
+import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.search.fetch.FetchSubPhase;
 import org.elasticsearch.search.fetch.subphase.highlight.SearchHighlightContext.Field;
 import org.elasticsearch.search.fetch.subphase.highlight.SearchHighlightContext.FieldOptions;
@@ -98,6 +99,7 @@ public class FastVectorHighlighter implements Highlighter {
             Function<SourceLookup, FragmentsBuilder> fragmentsBuilderSupplier = fragmentsBuilderSupplier(
                 field,
                 fieldType,
+                fieldContext.context.getSearchExecutionContext(),
                 forceSource,
                 fixBrokenAnalysis
             );
@@ -217,6 +219,7 @@ public class FastVectorHighlighter implements Highlighter {
     private Function<SourceLookup, FragmentsBuilder> fragmentsBuilderSupplier(
         SearchHighlightContext.Field field,
         MappedFieldType fieldType,
+        SearchExecutionContext context,
         boolean forceSource,
         boolean fixBrokenAnalysis
     ) {
@@ -239,6 +242,7 @@ public class FastVectorHighlighter implements Highlighter {
             if (options.numberOfFragments() != 0 && options.scoreOrdered()) {
                 supplier = lookup -> new SourceScoreOrderFragmentsBuilder(
                     fieldType,
+                    context,
                     fixBrokenAnalysis,
                     lookup,
                     options.preTags(),
@@ -248,6 +252,7 @@ public class FastVectorHighlighter implements Highlighter {
             } else {
                 supplier = lookup -> new SourceSimpleFragmentsBuilder(
                     fieldType,
+                    context,
                     fixBrokenAnalysis,
                     lookup,
                     options.preTags(),

--- a/server/src/main/java/org/elasticsearch/search/lookup/SourceLookup.java
+++ b/server/src/main/java/org/elasticsearch/search/lookup/SourceLookup.java
@@ -172,8 +172,7 @@ public class SourceLookup implements Map<String, Object> {
     /**
      * For the provided path, return its value in the source.
      *
-     * Note that in contrast with {@link SourceLookup#extractRawValues}, array and object values
-     * can be returned.
+     * Both array and object values can be returned.
      *
      * @param path the value's path in the source.
      * @param nullValue a value to return if the path exists, but the value is 'null'. This helps

--- a/server/src/test/java/org/elasticsearch/search/fetch/subphase/highlight/FastVectorHighlighterTests.java
+++ b/server/src/test/java/org/elasticsearch/search/fetch/subphase/highlight/FastVectorHighlighterTests.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.search.fetch.subphase.highlight;
+
+import org.elasticsearch.index.mapper.MapperService;
+import org.elasticsearch.index.mapper.ParsedDocument;
+import org.elasticsearch.index.query.QueryBuilders;
+import org.elasticsearch.search.builder.SearchSourceBuilder;
+import org.elasticsearch.search.fetch.HighlighterTestCase;
+
+import java.io.IOException;
+
+public class FastVectorHighlighterTests extends HighlighterTestCase {
+
+    public void testHighlightingMultiFields() throws IOException {
+
+        MapperService mapperService = createMapperService(fieldMapping(b -> {
+            b.field("type", "text");
+            b.startObject("fields");
+            b.startObject("stemmed");
+            b.field("type", "text");
+            b.field("term_vector", "with_positions_offsets");
+            b.endObject();
+            b.endObject();
+        }));
+
+        ParsedDocument doc = mapperService.documentMapper()
+            .parse(source(b -> b.field("field", "here is some text, which is followed by some more text")));
+
+        {
+            // test SimpleFragmentsBuilder case
+            SearchSourceBuilder search = new SearchSourceBuilder().query(QueryBuilders.termQuery("field.stemmed", "some"))
+                .highlighter(new HighlightBuilder().field("field.stemmed").highlighterType("fvh"));
+
+            assertHighlights(
+                highlight(mapperService, doc, search),
+                "field.stemmed",
+                "here is <em>some</em> text, which is followed by <em>some</em> more text"
+            );
+        }
+
+        {
+            // test ScoreOrderFragmentsBuilder case
+            SearchSourceBuilder search = new SearchSourceBuilder().query(QueryBuilders.termQuery("field.stemmed", "some"))
+                .highlighter(new HighlightBuilder().field("field.stemmed").highlighterType("fvh").numOfFragments(2).fragmentSize(18));
+
+            assertHighlights(
+                highlight(mapperService, doc, search),
+                "field.stemmed",
+                "here is <em>some</em> text, which",
+                "followed by <em>some</em> more text"
+            );
+        }
+
+    }
+
+}

--- a/test/framework/src/main/java/org/elasticsearch/search/fetch/HighlighterTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/search/fetch/HighlighterTestCase.java
@@ -73,7 +73,7 @@ public class HighlighterTestCase extends MapperServiceTestCase {
      * Given a set of highlights, assert that any particular field has the expected fragments
      */
     protected static void assertHighlights(Map<String, HighlightField> highlights, String field, String... fragments) {
-        assertNotNull(highlights.get(field));
+        assertNotNull("No highlights reported for field [" + field + "]", highlights.get(field));
         Set<String> actualFragments = Arrays.stream(highlights.get(field).getFragments()).map(Text::toString).collect(Collectors.toSet());
         Set<String> expectedFragments = new HashSet<>(Arrays.asList(fragments));
         assertEquals(expectedFragments, actualFragments);


### PR DESCRIPTION
FVH was relying on `SourceLookup.extractRawValues()` to load its data, but this no
longer works for multifields. It should instead use value fetchers which will correctly
locate the input for multifields and/or copy fields.

Fixes #84690
Fixes #82458
Fixes #80895
Fixes #75011

Backport of #85815 