### PR TITLE
[7.17] Security plugin close realms (#87429)

### DIFF
--- a/docs/changelog/87429.yaml
+++ b/docs/changelog/87429.yaml
@@ -1,0 +1,6 @@
+pr: 87429
+summary: Security plugin close releasable realms
+area: Security
+type: bug
+issues:
+ - 86286

--- a/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/xpack/security/SecurityPluginTests.java
+++ b/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/xpack/security/SecurityPluginTests.java
@@ -6,16 +6,36 @@
  */
 package org.elasticsearch.xpack.security;
 
+import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.client.Request;
 import org.elasticsearch.client.RequestOptions;
 import org.elasticsearch.client.Response;
 import org.elasticsearch.client.ResponseException;
 import org.elasticsearch.common.settings.SecureString;
+import org.elasticsearch.common.settings.Setting;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.util.concurrent.ThreadContext;
+import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.test.SecurityIntegTestCase;
 import org.elasticsearch.test.SecuritySettingsSource;
 import org.elasticsearch.test.SecuritySettingsSourceField;
+import org.elasticsearch.xpack.core.security.SecurityExtension;
+import org.elasticsearch.xpack.core.security.authc.AuthenticationResult;
+import org.elasticsearch.xpack.core.security.authc.AuthenticationToken;
+import org.elasticsearch.xpack.core.security.authc.Realm;
+import org.elasticsearch.xpack.core.security.authc.RealmConfig;
+import org.elasticsearch.xpack.core.security.authc.RealmSettings;
+import org.elasticsearch.xpack.core.security.authc.support.UsernamePasswordToken;
+import org.elasticsearch.xpack.core.security.user.User;
 
+import java.io.Closeable;
 import java.io.IOException;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import static org.elasticsearch.rest.RestStatus.OK;
 import static org.elasticsearch.rest.RestStatus.UNAUTHORIZED;
@@ -27,6 +47,33 @@ public class SecurityPluginTests extends SecurityIntegTestCase {
     @Override
     protected boolean addMockHttpTransport() {
         return false; // enable http
+    }
+
+    @Override
+    protected Collection<Class<? extends Plugin>> nodePlugins() {
+        final List<Class<? extends Plugin>> plugins = new ArrayList<>(super.nodePlugins());
+        {
+            // replace the security plugin with the security plugin that contains a dummy realm
+            plugins.remove(LocalStateSecurity.class);
+            plugins.add(SecurityPluginTests.LocalStateWithDummyRealmAuthorizationEngineExtension.class);
+        }
+        return List.copyOf(plugins);
+    }
+
+    @Override
+    protected Class<?> xpackPluginClass() {
+        return SecurityPluginTests.LocalStateWithDummyRealmAuthorizationEngineExtension.class;
+    }
+
+    private static final AtomicBoolean REALM_CLOSE_FLAG = new AtomicBoolean(false);
+    private static final AtomicBoolean REALM_INIT_FLAG = new AtomicBoolean(false);
+
+    @Override
+    protected Settings nodeSettings(int nodeOrdinal, Settings otherSettings) {
+        final Settings.Builder settingsBuilder = Settings.builder();
+        settingsBuilder.put(super.nodeSettings(nodeOrdinal, otherSettings));
+        settingsBuilder.put("xpack.security.authc.realms.dummy.dummy10.order", "10");
+        return settingsBuilder.build();
     }
 
     public void testThatPluginIsLoaded() throws IOException {
@@ -53,4 +100,80 @@ public class SecurityPluginTests extends SecurityIntegTestCase {
         Response response = getRestClient().performRequest(request);
         assertThat(response.getStatusLine().getStatusCode(), is(OK.getStatus()));
     }
+
+    public void testThatPluginRealmIsLoadedAndClosed() throws IOException {
+        REALM_CLOSE_FLAG.set(false);
+        REALM_INIT_FLAG.set(false);
+        String nodeName = internalCluster().startNode();
+        assertThat(REALM_INIT_FLAG.get(), is(true));
+        internalCluster().stopNode(nodeName);
+        assertThat(REALM_CLOSE_FLAG.get(), is(true));
+    }
+
+    public static class LocalStateWithDummyRealmAuthorizationEngineExtension extends LocalStateSecurity {
+
+        public LocalStateWithDummyRealmAuthorizationEngineExtension(Settings settings, Path configPath) throws Exception {
+            super(settings, configPath);
+        }
+
+        @Override
+        protected List<SecurityExtension> securityExtensions() {
+            return List.of(new DummyRealmAuthorizationEngineExtension());
+        }
+
+        @Override
+        public List<Setting<?>> getSettings() {
+            ArrayList<Setting<?>> settings = new ArrayList<>();
+            settings.addAll(super.getSettings());
+            settings.addAll(RealmSettings.getStandardSettings(DummyRealm.TYPE));
+            return settings;
+        }
+    }
+
+    public static class DummyRealmAuthorizationEngineExtension implements SecurityExtension {
+
+        DummyRealmAuthorizationEngineExtension() {}
+
+        @Override
+        public Map<String, Realm.Factory> getRealms(SecurityComponents components) {
+            return Map.of(DummyRealm.TYPE, DummyRealm::new);
+        }
+    }
+
+    public static class DummyRealm extends Realm implements Closeable {
+
+        public static final String TYPE = "dummy";
+
+        public DummyRealm(RealmConfig config) {
+            super(config);
+            REALM_INIT_FLAG.set(true);
+        }
+
+        @Override
+        public boolean supports(AuthenticationToken token) {
+            return false;
+        }
+
+        @Override
+        public UsernamePasswordToken token(ThreadContext threadContext) {
+            return null;
+        }
+
+        @Override
+        public void authenticate(AuthenticationToken authToken, ActionListener<AuthenticationResult<User>> listener) {
+            listener.onResponse(AuthenticationResult.notHandled());
+        }
+
+        @Override
+        public void lookupUser(String username, ActionListener<User> listener) {
+            // Lookup (run-as) is not supported in this realm
+            listener.onResponse(null);
+        }
+
+        @Override
+        public void close() {
+            REALM_CLOSE_FLAG.set(true);
+        }
+    }
+
 }

--- a/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/xpack/security/SecurityPluginTests.java
+++ b/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/xpack/security/SecurityPluginTests.java
@@ -33,6 +33,7 @@ import java.io.IOException;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -57,7 +58,7 @@ public class SecurityPluginTests extends SecurityIntegTestCase {
             plugins.remove(LocalStateSecurity.class);
             plugins.add(SecurityPluginTests.LocalStateWithDummyRealmAuthorizationEngineExtension.class);
         }
-        return List.copyOf(plugins);
+        return plugins;
     }
 
     @Override
@@ -118,7 +119,7 @@ public class SecurityPluginTests extends SecurityIntegTestCase {
 
         @Override
         protected List<SecurityExtension> securityExtensions() {
-            return List.of(new DummyRealmAuthorizationEngineExtension());
+            return Collections.singletonList(new DummyRealmAuthorizationEngineExtension());
         }
 
         @Override
@@ -160,7 +161,7 @@ public class SecurityPluginTests extends SecurityIntegTestCase {
         }
 
         @Override
-        public void authenticate(AuthenticationToken authToken, ActionListener<AuthenticationResult<User>> listener) {
+        public void authenticate(AuthenticationToken token, ActionListener<AuthenticationResult> listener) {
             listener.onResponse(AuthenticationResult.notHandled());
         }
 

--- a/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/xpack/security/SecurityPluginTests.java
+++ b/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/xpack/security/SecurityPluginTests.java
@@ -137,7 +137,7 @@ public class SecurityPluginTests extends SecurityIntegTestCase {
 
         @Override
         public Map<String, Realm.Factory> getRealms(SecurityComponents components) {
-            return Map.of(DummyRealm.TYPE, DummyRealm::new);
+            return Collections.singletonMap(DummyRealm.TYPE, DummyRealm::new);
         }
     }
 

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/Realms.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/Realms.java
@@ -11,6 +11,7 @@ import org.apache.logging.log4j.Logger;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.collect.MapBuilder;
+import org.elasticsearch.common.component.AbstractLifecycleComponent;
 import org.elasticsearch.common.logging.DeprecationCategory;
 import org.elasticsearch.common.logging.DeprecationLogger;
 import org.elasticsearch.common.settings.Settings;
@@ -18,6 +19,7 @@ import org.elasticsearch.common.util.concurrent.CountDown;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.common.util.set.Sets;
 import org.elasticsearch.core.Nullable;
+import org.elasticsearch.core.internal.io.IOUtils;
 import org.elasticsearch.env.Environment;
 import org.elasticsearch.license.LicensedFeature;
 import org.elasticsearch.license.XPackLicenseState;
@@ -31,6 +33,8 @@ import org.elasticsearch.xpack.core.security.authc.kerberos.KerberosRealmSetting
 import org.elasticsearch.xpack.security.Security;
 import org.elasticsearch.xpack.security.authc.esnative.ReservedRealm;
 
+import java.io.Closeable;
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -49,7 +53,7 @@ import java.util.stream.StreamSupport;
 /**
  * Serves as a realms registry (also responsible for ordering the realms appropriately)
  */
-public class Realms implements Iterable<Realm> {
+public class Realms extends AbstractLifecycleComponent implements Iterable<Realm> {
 
     private static final Logger logger = LogManager.getLogger(Realms.class);
     private static final DeprecationLogger deprecationLogger = DeprecationLogger.getLogger(logger.getName());
@@ -407,6 +411,17 @@ public class Realms implements Iterable<Realm> {
                 }));
             }
         }
+    }
+
+    @Override
+    protected void doStart() {}
+
+    @Override
+    protected void doStop() {}
+
+    @Override
+    protected void doClose() throws IOException {
+        IOUtils.close(allConfiguredRealms.stream().filter(r -> r instanceof Closeable).map(r -> (Closeable) r).toList());
     }
 
     private void addNativeRealms(List<Realm> realms) throws Exception {

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/Realms.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/Realms.java
@@ -421,7 +421,9 @@ public class Realms extends AbstractLifecycleComponent implements Iterable<Realm
 
     @Override
     protected void doClose() throws IOException {
-        IOUtils.close(allConfiguredRealms.stream().filter(r -> r instanceof Closeable).map(r -> (Closeable) r).toList());
+        IOUtils.close(
+            allConfiguredRealms.stream().filter(r -> r instanceof Closeable).map(r -> (Closeable) r).collect(Collectors.toList())
+        );
     }
 
     private void addNativeRealms(List<Realm> realms) throws Exception {

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/test/SecurityIntegTestCase.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/test/SecurityIntegTestCase.java
@@ -240,11 +240,15 @@ public abstract class SecurityIntegTestCase extends ESIntegTestCase {
                 .map(p -> p.getClassname())
                 .collect(Collectors.toList());
             assertThat(
-                "plugin [" + LocalStateSecurity.class.getName() + "] not found in [" + pluginNames + "]",
+                "plugin [" + xpackPluginClass().getName() + "] not found in [" + pluginNames + "]",
                 pluginNames,
-                hasItem(LocalStateSecurity.class.getName())
+                hasItem(xpackPluginClass().getName())
             );
         }
+    }
+
+    protected Class<?> xpackPluginClass() {
+        return LocalStateSecurity.class;
     }
 
     @Override

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/LocalStateSecurity.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/LocalStateSecurity.java
@@ -39,7 +39,7 @@ public class LocalStateSecurity extends LocalStateCompositeXPackPlugin {
                 return thisVar.getLicenseState();
             }
         });
-        plugins.add(new Security(settings, thisVar.securityExtensions()) {
+        plugins.add(new Security(settings, configPath, thisVar.securityExtensions()) {
             @Override
             protected SSLService getSslService() {
                 return thisVar.getSslService();

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/LocalStateSecurity.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/LocalStateSecurity.java
@@ -10,10 +10,13 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.license.LicenseService;
 import org.elasticsearch.license.XPackLicenseState;
 import org.elasticsearch.xpack.core.LocalStateCompositeXPackPlugin;
+import org.elasticsearch.xpack.core.security.SecurityExtension;
 import org.elasticsearch.xpack.core.ssl.SSLService;
 import org.elasticsearch.xpack.monitoring.Monitoring;
 
 import java.nio.file.Path;
+import java.util.Collections;
+import java.util.List;
 
 public class LocalStateSecurity extends LocalStateCompositeXPackPlugin {
 
@@ -36,7 +39,7 @@ public class LocalStateSecurity extends LocalStateCompositeXPackPlugin {
                 return thisVar.getLicenseState();
             }
         });
-        plugins.add(new Security(settings, configPath) {
+        plugins.add(new Security(settings, thisVar.securityExtensions()) {
             @Override
             protected SSLService getSslService() {
                 return thisVar.getSslService();
@@ -48,4 +51,9 @@ public class LocalStateSecurity extends LocalStateCompositeXPackPlugin {
             }
         });
     }
+
+    protected List<SecurityExtension> securityExtensions() {
+        return Collections.emptyList();
+    }
+
 }


### PR DESCRIPTION
The `Closeable#close` method on `Realm`s was never called upon node
shutdown. This is a problem when realms (eg OIDC) create non-daemon
threads that expect to be stopped when the `close` method is invoked.
Specifically, it is a problem on Windows where the graceful shutdown is
implemented by terminatting all non-daemon threads (see `Bootstrap#stop`
and `Bootstrap#initializeNatives`).

Backport of https://github.com/elastic/elasticsearch/pull/87429
Closes https://github.com/elastic/elasticsearch/issues/86286