### PR TITLE
[8.3] Fix troubleshooting doc tab to point to self-managed (#87465)

### DIFF
--- a/docs/reference/tab-widgets/troubleshooting/data/diagnose-unassigned-shards-widget.asciidoc
+++ b/docs/reference/tab-widgets/troubleshooting/data/diagnose-unassigned-shards-widget.asciidoc
@@ -32,7 +32,7 @@ include::diagnose-unassigned-shards.asciidoc[tag=cloud]
        hidden="">
 ++++
 
-include::diagnose-unassigned-shards.asciidoc[tag=cloud]
+include::diagnose-unassigned-shards.asciidoc[tag=self-managed]
 
 ++++
   </div>


### PR DESCRIPTION
Backports the following commits to 8.3:
 - Fix troubleshooting doc tab to point to self-managed (#87465)