### PR TITLE
Move the writeTo and read for get requests

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/get/GetRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/get/GetRequest.java
@@ -55,6 +55,8 @@ public class GetRequest extends SingleShardRequest<GetRequest> implements Realti
     private VersionType versionType = VersionType.INTERNAL;
     private long version = Versions.MATCH_ANY;
 
+    public GetRequest() {}
+
     GetRequest(StreamInput in) throws IOException {
         super(in);
         if (in.getVersion().before(Version.V_8_0_0)) {
@@ -72,7 +74,23 @@ public class GetRequest extends SingleShardRequest<GetRequest> implements Realti
         fetchSourceContext = in.readOptionalWriteable(FetchSourceContext::readFrom);
     }
 
-    public GetRequest() {}
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        super.writeTo(out);
+        if (out.getVersion().before(Version.V_8_0_0)) {
+            out.writeString(MapperService.SINGLE_MAPPING_NAME);
+        }
+        out.writeString(id);
+        out.writeOptionalString(routing);
+        out.writeOptionalString(preference);
+
+        out.writeBoolean(refresh);
+        out.writeOptionalStringArray(storedFields);
+        out.writeBoolean(realtime);
+        out.writeByte(versionType.getValue());
+        out.writeLong(version);
+        out.writeOptionalWriteable(fetchSourceContext);
+    }
 
     /**
      * Constructs a new get request against the specified index. The {@link #id(String)} must also be set.
@@ -222,24 +240,6 @@ public class GetRequest extends SingleShardRequest<GetRequest> implements Realti
 
     public VersionType versionType() {
         return this.versionType;
-    }
-
-    @Override
-    public void writeTo(StreamOutput out) throws IOException {
-        super.writeTo(out);
-        if (out.getVersion().before(Version.V_8_0_0)) {
-            out.writeString(MapperService.SINGLE_MAPPING_NAME);
-        }
-        out.writeString(id);
-        out.writeOptionalString(routing);
-        out.writeOptionalString(preference);
-
-        out.writeBoolean(refresh);
-        out.writeOptionalStringArray(storedFields);
-        out.writeBoolean(realtime);
-        out.writeByte(versionType.getValue());
-        out.writeLong(version);
-        out.writeOptionalWriteable(fetchSourceContext);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/action/get/MultiGetRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/get/MultiGetRequest.java
@@ -256,6 +256,15 @@ public class MultiGetRequest extends ActionRequest
         items = in.readList(Item::new);
     }
 
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        super.writeTo(out);
+        out.writeOptionalString(preference);
+        out.writeBoolean(refresh);
+        out.writeBoolean(realtime);
+        out.writeList(items);
+    }
+
     public List<Item> getItems() {
         return this.items;
     }
@@ -539,15 +548,6 @@ public class MultiGetRequest extends ActionRequest
     @Override
     public Iterator<Item> iterator() {
         return Collections.unmodifiableCollection(items).iterator();
-    }
-
-    @Override
-    public void writeTo(StreamOutput out) throws IOException {
-        super.writeTo(out);
-        out.writeOptionalString(preference);
-        out.writeBoolean(refresh);
-        out.writeBoolean(realtime);
-        out.writeList(items);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/action/get/MultiGetShardRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/get/MultiGetShardRequest.java
@@ -27,6 +27,16 @@ public class MultiGetShardRequest extends SingleShardRequest<MultiGetShardReques
     List<Integer> locations;
     List<MultiGetRequest.Item> items;
 
+    MultiGetShardRequest(MultiGetRequest multiGetRequest, String index, int shardId) {
+        super(index);
+        this.shardId = shardId;
+        locations = new ArrayList<>();
+        items = new ArrayList<>();
+        preference = multiGetRequest.preference;
+        realtime = multiGetRequest.realtime;
+        refresh = multiGetRequest.refresh;
+    }
+
     MultiGetShardRequest(StreamInput in) throws IOException {
         super(in);
         int size = in.readVInt();
@@ -43,14 +53,19 @@ public class MultiGetShardRequest extends SingleShardRequest<MultiGetShardReques
         realtime = in.readBoolean();
     }
 
-    MultiGetShardRequest(MultiGetRequest multiGetRequest, String index, int shardId) {
-        super(index);
-        this.shardId = shardId;
-        locations = new ArrayList<>();
-        items = new ArrayList<>();
-        preference = multiGetRequest.preference;
-        realtime = multiGetRequest.realtime;
-        refresh = multiGetRequest.refresh;
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        super.writeTo(out);
+        out.writeVInt(locations.size());
+
+        for (int i = 0; i < locations.size(); i++) {
+            out.writeVInt(locations.get(i));
+            items.get(i).writeTo(out);
+        }
+
+        out.writeOptionalString(preference);
+        out.writeBoolean(refresh);
+        out.writeBoolean(realtime);
     }
 
     @Override
@@ -106,20 +121,5 @@ public class MultiGetShardRequest extends SingleShardRequest<MultiGetShardReques
             indices[i] = items.get(i).index();
         }
         return indices;
-    }
-
-    @Override
-    public void writeTo(StreamOutput out) throws IOException {
-        super.writeTo(out);
-        out.writeVInt(locations.size());
-
-        for (int i = 0; i < locations.size(); i++) {
-            out.writeVInt(locations.get(i));
-            items.get(i).writeTo(out);
-        }
-
-        out.writeOptionalString(preference);
-        out.writeBoolean(refresh);
-        out.writeBoolean(realtime);
     }
 }

--- a/server/src/main/java/org/elasticsearch/search/internal/ShardSearchRequest.java
+++ b/server/src/main/java/org/elasticsearch/search/internal/ShardSearchRequest.java
@@ -242,6 +242,30 @@ public class ShardSearchRequest extends TransportRequest implements IndicesReque
         this.forceSyntheticSource = forceSyntheticSource;
     }
 
+    public ShardSearchRequest(ShardSearchRequest clone) {
+        this.shardId = clone.shardId;
+        this.shardRequestIndex = clone.shardRequestIndex;
+        this.searchType = clone.searchType;
+        this.numberOfShards = clone.numberOfShards;
+        this.scroll = clone.scroll;
+        this.source(clone.source);
+        this.aliasFilter = clone.aliasFilter;
+        this.indexBoost = clone.indexBoost;
+        this.nowInMillis = clone.nowInMillis;
+        this.requestCache = clone.requestCache;
+        this.clusterAlias = clone.clusterAlias;
+        this.allowPartialSearchResults = clone.allowPartialSearchResults;
+        this.canReturnNullResponseIfMatchNoDocs = clone.canReturnNullResponseIfMatchNoDocs;
+        this.bottomSortValues = clone.bottomSortValues;
+        this.originalIndices = clone.originalIndices;
+        this.readerId = clone.readerId;
+        this.keepAlive = clone.keepAlive;
+        this.channelVersion = clone.channelVersion;
+        this.waitForCheckpoint = clone.waitForCheckpoint;
+        this.waitForCheckpointsTimeout = clone.waitForCheckpointsTimeout;
+        this.forceSyntheticSource = clone.forceSyntheticSource;
+    }
+
     public ShardSearchRequest(StreamInput in) throws IOException {
         super(in);
         shardId = new ShardId(in);
@@ -300,30 +324,6 @@ public class ShardSearchRequest extends TransportRequest implements IndicesReque
             forceSyntheticSource = false;
         }
         originalIndices = OriginalIndices.readOriginalIndices(in);
-    }
-
-    public ShardSearchRequest(ShardSearchRequest clone) {
-        this.shardId = clone.shardId;
-        this.shardRequestIndex = clone.shardRequestIndex;
-        this.searchType = clone.searchType;
-        this.numberOfShards = clone.numberOfShards;
-        this.scroll = clone.scroll;
-        this.source(clone.source);
-        this.aliasFilter = clone.aliasFilter;
-        this.indexBoost = clone.indexBoost;
-        this.nowInMillis = clone.nowInMillis;
-        this.requestCache = clone.requestCache;
-        this.clusterAlias = clone.clusterAlias;
-        this.allowPartialSearchResults = clone.allowPartialSearchResults;
-        this.canReturnNullResponseIfMatchNoDocs = clone.canReturnNullResponseIfMatchNoDocs;
-        this.bottomSortValues = clone.bottomSortValues;
-        this.originalIndices = clone.originalIndices;
-        this.readerId = clone.readerId;
-        this.keepAlive = clone.keepAlive;
-        this.channelVersion = clone.channelVersion;
-        this.waitForCheckpoint = clone.waitForCheckpoint;
-        this.waitForCheckpointsTimeout = clone.waitForCheckpointsTimeout;
-        this.forceSyntheticSource = clone.forceSyntheticSource;
     }
 
     @Override


### PR DESCRIPTION
This moves the writeTo methods next to the read requests for GET, MGET,
and `_search` so they are easier to read.
