### PR TITLE
[8.3] Use all lucene index compatible versions for bwc version generation (#87133)

### DIFF
--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/BwcVersions.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/BwcVersions.java
@@ -229,10 +229,21 @@ public class BwcVersions {
         return versions.stream().map(v -> v.elasticsearch).filter(v -> unreleased.containsKey(v) == false).toList();
     }
 
+    /**
+     * Return versions of Elasticsearch which are index compatible with the current version, and also work on the local machine.
+     */
     public List<Version> getIndexCompatible() {
-        return filterSupportedVersions(
-            versions.stream().filter(v -> v.lucene.getMajor() >= (currentVersion.lucene.getMajor() - 1)).map(v -> v.elasticsearch).toList()
-        );
+        return filterSupportedVersions(getAllIndexCompatible());
+    }
+
+    /**
+     * Return all versions of Elasticsearch which are index compatible with the current version.
+     */
+    public List<Version> getAllIndexCompatible() {
+        return versions.stream()
+            .filter(v -> v.lucene.getMajor() >= (currentVersion.lucene.getMajor() - 1))
+            .map(v -> v.elasticsearch)
+            .toList();
     }
 
     public void withIndexCompatible(BiConsumer<Version, String> versionAction) {

--- a/build.gradle
+++ b/build.gradle
@@ -76,7 +76,7 @@ tasks.register("updateCIBwcVersions") {
     }
   }
   doLast {
-    writeVersions(file(".ci/bwcVersions"), BuildParams.bwcVersions.indexCompatible)
+    writeVersions(file(".ci/bwcVersions"), BuildParams.bwcVersions.allIndexCompatible)
     writeVersions(file(".ci/snapshotBwcVersions"), BuildParams.bwcVersions.unreleasedIndexCompatible)
   }
 }
@@ -105,7 +105,7 @@ tasks.register("verifyVersions") {
           .collect { Version.fromString(it) }
       )
     }
-    verifyCiYaml(file(".ci/bwcVersions"), BuildParams.bwcVersions.indexCompatible)
+    verifyCiYaml(file(".ci/bwcVersions"), BuildParams.bwcVersions.allIndexCompatible)
     verifyCiYaml(file(".ci/snapshotBwcVersions"), BuildParams.bwcVersions.unreleasedIndexCompatible)
 
     // Make sure backport bot config file is up to date


### PR DESCRIPTION
Backports the following commits to 8.3:
 - Use all lucene index compatible versions for bwc version generation (#87133)