### PR TITLE
Use all lucene index compatible versions for bwc version generation (#87133)

### DIFF
--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/BwcVersions.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/BwcVersions.java
@@ -337,14 +337,17 @@ public class BwcVersions {
     }
 
     public List<Version> getIndexCompatible() {
-        return unmodifiableList(
-            filterSupportedVersions(
-                Stream.concat(
-                    groupByMajor.get(currentVersion.getMajor() - 1).stream(),
-                    groupByMajor.get(currentVersion.getMajor()).stream()
-                ).filter(version -> version.equals(currentVersion) == false).collect(Collectors.toList())
-            )
-        );
+        return filterSupportedVersions(getAllIndexCompatible());
+    }
+
+    /**
+     * Return all versions of Elasticsearch which are index compatible with the current version.
+     */
+    public List<Version> getAllIndexCompatible() {
+        return Stream.concat(
+            groupByMajor.get(currentVersion.getMajor() - 1).stream(),
+            groupByMajor.get(currentVersion.getMajor()).stream()
+        ).filter(version -> version.equals(currentVersion) == false).collect(Collectors.toList());
     }
 
     public void withIndexCompatiple(BiConsumer<Version, String> versionAction) {

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/BwcVersions.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/BwcVersions.java
@@ -344,10 +344,9 @@ public class BwcVersions {
      * Return all versions of Elasticsearch which are index compatible with the current version.
      */
     public List<Version> getAllIndexCompatible() {
-        return Stream.concat(
-            groupByMajor.get(currentVersion.getMajor() - 1).stream(),
-            groupByMajor.get(currentVersion.getMajor()).stream()
-        ).filter(version -> version.equals(currentVersion) == false).collect(Collectors.toList());
+        return Stream.concat(groupByMajor.get(currentVersion.getMajor() - 1).stream(), groupByMajor.get(currentVersion.getMajor()).stream())
+            .filter(version -> version.equals(currentVersion) == false)
+            .collect(Collectors.toList());
     }
 
     public void withIndexCompatiple(BiConsumer<Version, String> versionAction) {

--- a/build.gradle
+++ b/build.gradle
@@ -75,7 +75,7 @@ tasks.register("updateCIBwcVersions") {
     }
   }
   doLast {
-    writeVersions(file(".ci/bwcVersions"), BuildParams.bwcVersions.indexCompatible)
+    writeVersions(file(".ci/bwcVersions"), BuildParams.bwcVersions.allIndexCompatible)
     writeVersions(file(".ci/snapshotBwcVersions"), BuildParams.bwcVersions.unreleasedIndexCompatible)
   }
 }
@@ -104,7 +104,7 @@ tasks.register("verifyVersions") {
           .collect { Version.fromString(it) }
       )
     }
-    verifyCiYaml(file(".ci/bwcVersions"), BuildParams.bwcVersions.indexCompatible)
+    verifyCiYaml(file(".ci/bwcVersions"), BuildParams.bwcVersions.allIndexCompatible)
     verifyCiYaml(file(".ci/snapshotBwcVersions"), BuildParams.bwcVersions.unreleasedIndexCompatible)
   }
 }


### PR DESCRIPTION
The updateCIBwcVersions task regenerates the list of versions that are
tested in CI. This task internally calls a filter method which filters
out incompatible versions for the local system. That means it can change
depending on the type of system the task is run on. This commit adds a
new variant of the internal method to return all actual index compatible
versions, and renames the existing method to make it clear it is for
running actual tests on the local system.