### PR TITLE
Use Map in IndexTemplateMetadata

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/metadata/IndexTemplateMetadata.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/IndexTemplateMetadata.java
@@ -11,7 +11,6 @@ import org.elasticsearch.ElasticsearchParseException;
 import org.elasticsearch.cluster.Diff;
 import org.elasticsearch.cluster.SimpleDiffable;
 import org.elasticsearch.common.Strings;
-import org.elasticsearch.common.collect.ImmutableOpenMap;
 import org.elasticsearch.common.collect.MapBuilder;
 import org.elasticsearch.common.compress.CompressedXContent;
 import org.elasticsearch.common.io.stream.StreamInput;
@@ -30,6 +29,7 @@ import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -69,9 +69,9 @@ public class IndexTemplateMetadata implements SimpleDiffable<IndexTemplateMetada
     private final Settings settings;
 
     // the mapping source should always include the type as top level
-    private final ImmutableOpenMap<String, CompressedXContent> mappings;
+    private final Map<String, CompressedXContent> mappings;
 
-    private final ImmutableOpenMap<String, AliasMetadata> aliases;
+    private final Map<String, AliasMetadata> aliases;
 
     public IndexTemplateMetadata(
         String name,
@@ -79,8 +79,8 @@ public class IndexTemplateMetadata implements SimpleDiffable<IndexTemplateMetada
         Integer version,
         List<String> patterns,
         Settings settings,
-        ImmutableOpenMap<String, CompressedXContent> mappings,
-        ImmutableOpenMap<String, AliasMetadata> aliases
+        Map<String, CompressedXContent> mappings,
+        Map<String, AliasMetadata> aliases
     ) {
         if (patterns == null || patterns.isEmpty()) {
             throw new IllegalArgumentException("Index patterns must not be null or empty; got " + patterns);
@@ -239,14 +239,14 @@ public class IndexTemplateMetadata implements SimpleDiffable<IndexTemplateMetada
 
         private Settings settings = Settings.EMPTY;
 
-        private final ImmutableOpenMap.Builder<String, CompressedXContent> mappings;
+        private final Map<String, CompressedXContent> mappings;
 
-        private final ImmutableOpenMap.Builder<String, AliasMetadata> aliases;
+        private final Map<String, AliasMetadata> aliases;
 
         public Builder(String name) {
             this.name = name;
-            mappings = ImmutableOpenMap.builder();
-            aliases = ImmutableOpenMap.builder();
+            mappings = new HashMap<>();
+            aliases = new HashMap<>();
         }
 
         public Builder(IndexTemplateMetadata indexTemplateMetadata) {
@@ -256,8 +256,8 @@ public class IndexTemplateMetadata implements SimpleDiffable<IndexTemplateMetada
             patterns(indexTemplateMetadata.patterns());
             settings(indexTemplateMetadata.settings());
 
-            mappings = ImmutableOpenMap.builder(indexTemplateMetadata.mappings);
-            aliases = ImmutableOpenMap.builder(indexTemplateMetadata.aliases());
+            mappings = new HashMap<>(indexTemplateMetadata.mappings);
+            aliases = new HashMap<>(indexTemplateMetadata.aliases());
         }
 
         public Builder order(int order) {
@@ -306,7 +306,7 @@ public class IndexTemplateMetadata implements SimpleDiffable<IndexTemplateMetada
         }
 
         public IndexTemplateMetadata build() {
-            return new IndexTemplateMetadata(name, order, version, indexPatterns, settings, mappings.build(), aliases.build());
+            return new IndexTemplateMetadata(name, order, version, indexPatterns, settings, Map.copyOf(mappings), Map.copyOf(aliases));
         }
 
         /**

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/IndexTemplateMetadataTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/IndexTemplateMetadataTests.java
@@ -9,7 +9,6 @@ package org.elasticsearch.cluster.metadata;
 
 import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.bytes.BytesReference;
-import org.elasticsearch.common.collect.ImmutableOpenMap;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.XContentHelper;
 import org.elasticsearch.test.ESTestCase;
@@ -23,6 +22,7 @@ import org.elasticsearch.xcontent.json.JsonXContent;
 
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.Map;
 
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.equalTo;
@@ -93,8 +93,8 @@ public class IndexTemplateMetadataTests extends ESTestCase {
                 randomInt(),
                 Collections.emptyList(),
                 Settings.EMPTY,
-                ImmutableOpenMap.of(),
-                ImmutableOpenMap.of()
+                Map.of(),
+                Map.of()
             );
         });
         assertThat(emptyPatternError.getMessage(), equalTo("Index patterns must not be null or empty; got []"));
@@ -106,8 +106,8 @@ public class IndexTemplateMetadataTests extends ESTestCase {
                 randomInt(),
                 null,
                 Settings.EMPTY,
-                ImmutableOpenMap.of(),
-                ImmutableOpenMap.of()
+                Map.of(),
+                Map.of()
             );
         });
         assertThat(nullPatternError.getMessage(), equalTo("Index patterns must not be null or empty; got null"));

--- a/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/cluster/metadata/MetadataMigrateToDataTiersRoutingServiceTests.java
+++ b/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/cluster/metadata/MetadataMigrateToDataTiersRoutingServiceTests.java
@@ -19,7 +19,6 @@ import org.elasticsearch.cluster.metadata.LifecycleExecutionState;
 import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.cluster.metadata.Template;
 import org.elasticsearch.cluster.routing.allocation.DataTier;
-import org.elasticsearch.common.collect.ImmutableOpenMap;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.XContentHelper;
 import org.elasticsearch.core.TimeValue;
@@ -1174,8 +1173,8 @@ public class MetadataMigrateToDataTiersRoutingServiceTests extends ESTestCase {
             randomInt(),
             List.of("test-*"),
             Settings.builder().put(requireRoutingSetting, "hot").put(LifecycleSettings.LIFECYCLE_NAME, "testLifecycle").build(),
-            ImmutableOpenMap.of(),
-            ImmutableOpenMap.of()
+            Map.of(),
+            Map.of()
         );
 
         IndexTemplateMetadata templateWithIncludeRouting = new IndexTemplateMetadata(
@@ -1184,8 +1183,8 @@ public class MetadataMigrateToDataTiersRoutingServiceTests extends ESTestCase {
             randomInt(),
             List.of("test-*"),
             Settings.builder().put(includeRoutingSetting, "hot").put(LifecycleSettings.LIFECYCLE_NAME, "testLifecycle").build(),
-            ImmutableOpenMap.of(),
-            ImmutableOpenMap.of()
+            Map.of(),
+            Map.of()
         );
 
         IndexTemplateMetadata templateWithExcludeRouting = new IndexTemplateMetadata(
@@ -1194,8 +1193,8 @@ public class MetadataMigrateToDataTiersRoutingServiceTests extends ESTestCase {
             randomInt(),
             List.of("test-*"),
             Settings.builder().put(excludeRoutingSetting, "hot").put(LifecycleSettings.LIFECYCLE_NAME, "testLifecycle").build(),
-            ImmutableOpenMap.of(),
-            ImmutableOpenMap.of()
+            Map.of(),
+            Map.of()
         );
 
         IndexTemplateMetadata templateWithRequireAndIncludeRoutings = new IndexTemplateMetadata(
@@ -1208,8 +1207,8 @@ public class MetadataMigrateToDataTiersRoutingServiceTests extends ESTestCase {
                 .put(includeRoutingSetting, "rack1")
                 .put(LifecycleSettings.LIFECYCLE_NAME, "testLifecycle")
                 .build(),
-            ImmutableOpenMap.of(),
-            ImmutableOpenMap.of()
+            Map.of(),
+            Map.of()
         );
 
         IndexTemplateMetadata templateWithoutCustomRoutings = new IndexTemplateMetadata(
@@ -1221,8 +1220,8 @@ public class MetadataMigrateToDataTiersRoutingServiceTests extends ESTestCase {
                 .put(LifecycleSettings.LIFECYCLE_NAME, "testLifecycle")
                 .put(LifecycleSettings.LIFECYCLE_PARSE_ORIGINATION_DATE, true)
                 .build(),
-            ImmutableOpenMap.of(),
-            ImmutableOpenMap.of()
+            Map.of(),
+            Map.of()
         );
 
         ClusterState clusterState = ClusterState.builder(ClusterName.DEFAULT)
@@ -1492,8 +1491,8 @@ public class MetadataMigrateToDataTiersRoutingServiceTests extends ESTestCase {
             randomInt(),
             List.of("test-*"),
             Settings.builder().put(requireRoutingSetting, "hot").build(),
-            ImmutableOpenMap.of(),
-            ImmutableOpenMap.of()
+            Map.of(),
+            Map.of()
         );
 
         ComponentTemplate compTemplateWithoutCustomRoutings = new ComponentTemplate(


### PR DESCRIPTION
This commit converts IndexTemplateMetadata to use Maps instead of
ImmutableOpenMap internally.

relates #86239