### PR TITLE
Make bootstrap stacktrace printing less cumbersome

### DIFF
--- a/server/src/main/java/org/elasticsearch/bootstrap/Bootstrap.java
+++ b/server/src/main/java/org/elasticsearch/bootstrap/Bootstrap.java
@@ -337,7 +337,7 @@ final class Bootstrap {
                     // guice: log the shortened exc to the log file
                     ByteArrayOutputStream os = new ByteArrayOutputStream();
                     PrintStream ps = new PrintStream(os, false, StandardCharsets.UTF_8);
-                    new StartupException(e).printStackTrace(ps);
+                    StartupException.printStackTrace(e, ps);
                     ps.flush();
                     logger.error("Guice Exception: {}", os.toString(StandardCharsets.UTF_8));
                 } else if (e instanceof NodeValidationException) {


### PR DESCRIPTION
The special StartupException is a class that exists to allow truncating
long stacktraces from the terminal output on startup. This is
particularly important for guice errors, which can be enormous.
Currently BootstrapExceptions are wrapped with StartupException to
handle possibly truncating them when printing. However, since main no
longer throws Exception, all handling of stacktrace printing is within
exitWithUnknownException. This commit makes the truncated stacktrace
printing a utility method instead of a full blown RuntimeException
wrapper.