### PR TITLE
Fix serialization checks in force_synthetic_source

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/search/SearchRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/search/SearchRequest.java
@@ -273,6 +273,8 @@ public class SearchRequest extends ActionRequest implements IndicesRequest.Repla
         }
         if (in.getVersion().onOrAfter(Version.V_8_4_0)) {
             forceSyntheticSource = in.readBoolean();
+        } else {
+            forceSyntheticSource = false;
         }
     }
 
@@ -323,6 +325,10 @@ public class SearchRequest extends ActionRequest implements IndicesRequest.Repla
         }
         if (out.getVersion().onOrAfter(Version.V_8_4_0)) {
             out.writeBoolean(forceSyntheticSource);
+        } else {
+            if (forceSyntheticSource) {
+                throw new IllegalArgumentException("force_synthetic_source is not supported before 8.4.0");
+            }
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/search/internal/ShardSearchRequest.java
+++ b/server/src/main/java/org/elasticsearch/search/internal/ShardSearchRequest.java
@@ -385,7 +385,7 @@ public class ShardSearchRequest extends TransportRequest implements IndicesReque
             out.writeBoolean(forceSyntheticSource);
         } else {
             if (forceSyntheticSource) {
-                throw new IllegalArgumentException("force_synthetic_source is not supported before 8.3.0");
+                throw new IllegalArgumentException("force_synthetic_source is not supported before 8.4.0");
             }
         }
     }

--- a/server/src/test/java/org/elasticsearch/action/search/SearchRequestTests.java
+++ b/server/src/test/java/org/elasticsearch/action/search/SearchRequestTests.java
@@ -92,6 +92,10 @@ public class SearchRequestTests extends AbstractSearchTestCase {
             // Versions before 7.11.0 don't support runtime mappings
             searchRequest.source().runtimeMappings(emptyMap());
         }
+        if (version.before(Version.V_8_4_0)) {
+            // Versionse before 8.4.0 don't support force_synthetic_source
+            searchRequest.setForceSyntheticSource(false);
+        }
         SearchRequest deserializedRequest = copyWriteable(searchRequest, namedWriteableRegistry, SearchRequest::new, version);
         assertEquals(searchRequest.isCcsMinimizeRoundtrips(), deserializedRequest.isCcsMinimizeRoundtrips());
         assertEquals(searchRequest.getLocalClusterAlias(), deserializedRequest.getLocalClusterAlias());

--- a/server/src/test/java/org/elasticsearch/action/search/SearchRequestTests.java
+++ b/server/src/test/java/org/elasticsearch/action/search/SearchRequestTests.java
@@ -12,6 +12,8 @@ import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.io.stream.BytesStreamOutput;
+import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.util.ArrayUtils;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.index.query.QueryBuilders;
@@ -272,5 +274,14 @@ public class SearchRequestTests extends AbstractSearchTestCase {
 
     private String toDescription(SearchRequest request) {
         return request.createTask(0, "test", SearchAction.NAME, TaskId.EMPTY_TASK_ID, emptyMap()).getDescription();
+    }
+
+    public void testForceSyntheticUnsupported() {
+        SearchRequest request = new SearchRequest();
+        request.setForceSyntheticSource(true);
+        StreamOutput out = new BytesStreamOutput();
+        out.setVersion(Version.V_8_3_0);
+        Exception e = expectThrows(IllegalArgumentException.class, () -> request.writeTo(out));
+        assertEquals(e.getMessage(), "force_synthetic_source is not supported before 8.4.0");
     }
 }

--- a/server/src/test/java/org/elasticsearch/search/internal/ShardSearchRequestTests.java
+++ b/server/src/test/java/org/elasticsearch/search/internal/ShardSearchRequestTests.java
@@ -17,6 +17,7 @@ import org.elasticsearch.common.CheckedBiConsumer;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.UUIDs;
 import org.elasticsearch.common.compress.CompressedXContent;
+import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.core.Nullable;
@@ -73,7 +74,10 @@ public class ShardSearchRequestTests extends AbstractSearchTestCase {
     }
 
     private ShardSearchRequest createShardSearchRequest() throws IOException {
-        SearchRequest searchRequest = createSearchRequest();
+        return createShardSearchReqest(createSearchRequest());
+    }
+
+    private ShardSearchRequest createShardSearchReqest(SearchRequest searchRequest) {
         ShardId shardId = new ShardId(randomAlphaOfLengthBetween(2, 10), randomAlphaOfLengthBetween(2, 10), randomInt());
         final AliasFilter filteringAliases;
         if (randomBoolean()) {
@@ -237,5 +241,15 @@ public class ShardSearchRequestTests extends AbstractSearchTestCase {
         };
         shardSearchRequest.cacheKey(differentiator);
         assertThat(invoked.get(), is(true));
+    }
+
+    public void testForceSyntheticUnsupported() throws IOException {
+        SearchRequest request = createSearchRequest();
+        request.setForceSyntheticSource(true);
+        ShardSearchRequest shardRequest = createShardSearchReqest(request);
+        StreamOutput out = new BytesStreamOutput();
+        out.setVersion(Version.V_8_3_0);
+        Exception e = expectThrows(IllegalArgumentException.class, () -> shardRequest.writeTo(out));
+        assertEquals(e.getMessage(), "force_synthetic_source is not supported before 8.4.0");
     }
 }


### PR DESCRIPTION
This fixes a missing check for unsupported version logic that'd cause
`force_synthetic_source` to be silently dropped when sent to nodes
before 8.4. It also fixes an incorrect version number in an error
message.

Relates to #87068