### PR TITLE
Fixing an occasional testYellowWithTooManyMasterChanges failure

### DIFF
--- a/server/src/test/java/org/elasticsearch/cluster/coordination/StableMasterHealthIndicatorServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/coordination/StableMasterHealthIndicatorServiceTests.java
@@ -424,6 +424,7 @@ public class StableMasterHealthIndicatorServiceTests extends AbstractCoordinator
                 logger.info("--> blackholing leader {}", leader);
                 leader.disconnect();
                 cluster.stabilise();
+                leader.heal(); // putting it back in the cluster after another leader has been elected so that we always keep a quorum
             }
 
             final Cluster.ClusterNode currentLeader = cluster.getAnyLeader();


### PR DESCRIPTION
Since this test was disconnecting master nodes, it was possible that the test cluster could not form a quorum. This
puts the master nodes back in after another master has been elected so that we always have a quorum.