### PR TITLE
[7.17] Skip ML tests on later glibc for incompatible BWC versions

### DIFF
--- a/.ci/scripts/run-gradle.sh
+++ b/.ci/scripts/run-gradle.sh
@@ -19,5 +19,9 @@ if pwd | grep -v -q ^/dev/shm ; then
    echo "Not running on a ramdisk, reducing number of workers"
    MAX_WORKERS=$(($MAX_WORKERS*2/3))
 fi
+
+# Export glibc version as environment variable since some BWC tests are incompatible with later versions
+export GLIBC_VERSION=$(ldd --version | grep '^ldd' | sed 's/.* \([1-9]\.[0-9]*\).*/\1/')
+
 set -e
 $GRADLEW -S --max-workers=$MAX_WORKERS $@

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/BwcVersions.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/BwcVersions.java
@@ -415,7 +415,7 @@ public class BwcVersions {
         Version glibcVersion = Optional.ofNullable(System.getenv(GLIBC_VERSION_ENV_VAR)).map(Version::fromString).orElse(null);
 
         // glibc version 2.35 introduced incompatibilities in ML syscall filters that were fixed in 7.17.5+ and 8.2.2+
-        if (glibcVersion != null && glibcVersion.onOrAfter(Version.fromString("2.35"))) {
+        if (glibcVersion != null && glibcVersion.onOrAfter(Version.fromString("2.35", Version.Mode.RELAXED))) {
             if (version.before(Version.fromString("7.17.5"))) {
                 return false;
             } else if (version.getMajor() > 7 && version.before(Version.fromString("8.2.2"))) {

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/BwcVersions.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/BwcVersions.java
@@ -412,7 +412,9 @@ public class BwcVersions {
      * @see <a href="https://github.com/elastic/elasticsearch/issues/86877">https://github.com/elastic/elasticsearch/issues/86877</a>
      */
     public static boolean isMlCompatible(Version version) {
-        Version glibcVersion = Optional.ofNullable(System.getenv(GLIBC_VERSION_ENV_VAR)).map(Version::fromString).orElse(null);
+        Version glibcVersion = Optional.ofNullable(System.getenv(GLIBC_VERSION_ENV_VAR))
+            .map(v -> Version.fromString(v, Version.Mode.RELAXED))
+            .orElse(null);
 
         // glibc version 2.35 introduced incompatibilities in ML syscall filters that were fixed in 7.17.5+ and 8.2.2+
         if (glibcVersion != null && glibcVersion.onOrAfter(Version.fromString("2.35", Version.Mode.RELAXED))) {

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/BwcVersions.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/BwcVersions.java
@@ -19,6 +19,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.SortedSet;
 import java.util.TreeSet;
@@ -83,6 +84,8 @@ public class BwcVersions {
     private static final Pattern LINE_PATTERN = Pattern.compile(
         "\\W+public static final Version V_(\\d+)_(\\d+)_(\\d+)(_alpha\\d+|_beta\\d+|_rc\\d+)? .*"
     );
+    private static final Version MINIMUM_WIRE_COMPATIBLE_VERSION = Version.fromString("7.17.0");
+    private static final String GLIBC_VERSION_ENV_VAR = "GLIBC_VERSION";
 
     private final Version currentVersion;
     private final Map<Integer, List<Version>> groupByMajor;
@@ -403,4 +406,23 @@ public class BwcVersions {
         return unmodifiableList(unreleasedWireCompatible);
     }
 
+    /**
+     * Determine whether the given version of Elasticsearch is compatible with ML features on the host system.
+     *
+     * @see <a href="https://github.com/elastic/elasticsearch/issues/86877">https://github.com/elastic/elasticsearch/issues/86877</a>
+     */
+    public static boolean isMlCompatible(Version version) {
+        Version glibcVersion = Optional.ofNullable(System.getenv(GLIBC_VERSION_ENV_VAR)).map(Version::fromString).orElse(null);
+
+        // glibc version 2.35 introduced incompatibilities in ML syscall filters that were fixed in 7.17.5+ and 8.2.2+
+        if (glibcVersion != null && glibcVersion.onOrAfter(Version.fromString("2.35"))) {
+            if (version.before(Version.fromString("7.17.5"))) {
+                return false;
+            } else if (version.getMajor() > 7 && version.before(Version.fromString("8.2.2"))) {
+                return false;
+            }
+        }
+
+        return true;
+    }
 }

--- a/build-tools/src/main/java/org/elasticsearch/gradle/Version.java
+++ b/build-tools/src/main/java/org/elasticsearch/gradle/Version.java
@@ -72,18 +72,12 @@ public final class Version implements Comparable<Version> {
             throw new IllegalArgumentException("Invalid version format: '" + s + "'. Should be " + expected);
         }
 
-
         String major = matcher.group(1);
         String minor = matcher.group(2);
         String revision = matcher.group(3);
         String qualifier = matcher.group(4);
 
-        return new Version(
-            Integer.parseInt(major),
-            Integer.parseInt(minor),
-            revision == null ? 0 : Integer.parseInt(revision),
-            qualifier
-        );
+        return new Version(Integer.parseInt(major), Integer.parseInt(minor), revision == null ? 0 : Integer.parseInt(revision), qualifier);
     }
 
     @Override

--- a/build-tools/src/main/java/org/elasticsearch/gradle/Version.java
+++ b/build-tools/src/main/java/org/elasticsearch/gradle/Version.java
@@ -40,7 +40,7 @@ public final class Version implements Comparable<Version> {
     private static final Pattern pattern = Pattern.compile("(\\d+)\\.(\\d+)\\.(\\d+)(?:-(alpha\\d+|beta\\d+|rc\\d+|SNAPSHOT))?");
 
     private static final Pattern relaxedPattern = Pattern.compile(
-        "v?(\\d+)\\.(\\d+)\\.(\\d+)(?:[\\-+]+([a-zA-Z0-9_]+(?:-[a-zA-Z0-9]+)*))?"
+        "v?(\\d+)\\.(\\d+)(?:\\.(\\d+))?(?:[\\-+]+([a-zA-Z0-9_]+(?:-[a-zA-Z0-9]+)*))?"
     );
 
     public Version(int major, int minor, int revision) {
@@ -74,10 +74,14 @@ public final class Version implements Comparable<Version> {
 
         String qualifier = matcher.group(4);
 
+        String major = matcher.group(1);
+        String minor = matcher.group(2);
+        String revision = matcher.group(3);
+
         return new Version(
-            Integer.parseInt(matcher.group(1)),
-            Integer.parseInt(matcher.group(2)),
-            Integer.parseInt(matcher.group(3)),
+            Integer.parseInt(major),
+            Integer.parseInt(minor),
+            revision == null ? 0 : Integer.parseInt(revision),
             qualifier
         );
     }

--- a/build-tools/src/main/java/org/elasticsearch/gradle/Version.java
+++ b/build-tools/src/main/java/org/elasticsearch/gradle/Version.java
@@ -72,11 +72,11 @@ public final class Version implements Comparable<Version> {
             throw new IllegalArgumentException("Invalid version format: '" + s + "'. Should be " + expected);
         }
 
-        String qualifier = matcher.group(4);
 
         String major = matcher.group(1);
         String minor = matcher.group(2);
         String revision = matcher.group(3);
+        String qualifier = matcher.group(4);
 
         return new Version(
             Integer.parseInt(major),

--- a/build-tools/src/test/java/org/elasticsearch/gradle/VersionTests.java
+++ b/build-tools/src/test/java/org/elasticsearch/gradle/VersionTests.java
@@ -115,6 +115,13 @@ public class VersionTests extends GradleUnitTestCase {
         assertThat(v.getQualifier(), equalTo("SNAPSHOT-EXTRA"));
     }
 
+    public void testRelaxedMode() {
+        Version v = Version.fromString("2.10", Version.Mode.RELAXED);
+        assertThat(v.getMajor(), equalTo(2));
+        assertThat(v.getMinor(), equalTo(10));
+        assertThat(v.getRevision(), equalTo(0));
+    }
+
     private void assertOrder(Version smaller, Version bigger) {
         assertEquals(smaller + " should be smaller than " + bigger, -1, smaller.compareTo(bigger));
     }

--- a/build-tools/src/test/java/org/elasticsearch/gradle/VersionTests.java
+++ b/build-tools/src/test/java/org/elasticsearch/gradle/VersionTests.java
@@ -42,6 +42,7 @@ public class VersionTests extends GradleUnitTestCase {
         assertVersionEquals("6.1.2-foo-bar", 6, 1, 2, Version.Mode.RELAXED);
         assertVersionEquals("16.01.22", 16, 1, 22, Version.Mode.RELAXED);
         assertVersionEquals("20.10.10+dfsg1", 20, 10, 10, Version.Mode.RELAXED);
+        assertVersionEquals("2.15", 2, 15, 0, Version.Mode.RELAXED);
     }
 
     public void testCompareWithStringVersions() {
@@ -113,13 +114,6 @@ public class VersionTests extends GradleUnitTestCase {
 
         v = Version.fromString("1.2.3-SNAPSHOT-EXTRA", Version.Mode.RELAXED);
         assertThat(v.getQualifier(), equalTo("SNAPSHOT-EXTRA"));
-    }
-
-    public void testRelaxedMode() {
-        Version v = Version.fromString("2.10", Version.Mode.RELAXED);
-        assertThat(v.getMajor(), equalTo(2));
-        assertThat(v.getMinor(), equalTo(10));
-        assertThat(v.getRevision(), equalTo(0));
     }
 
     private void assertOrder(Version smaller, Version bigger) {

--- a/x-pack/qa/rolling-upgrade/build.gradle
+++ b/x-pack/qa/rolling-upgrade/build.gradle
@@ -1,4 +1,6 @@
-import org.elasticsearch.gradle.VersionProperties
+import org.elasticsearch.gradle.Version
+import org.elasticsearch.gradle.internal.BwcVersions
+import org.elasticsearch.gradle.internal.BwcVersions
 import org.elasticsearch.gradle.internal.info.BuildParams
 import org.elasticsearch.gradle.testclusters.StandaloneRestIntegTestTask
 
@@ -133,6 +135,13 @@ BuildParams.bwcVersions.withWireCompatiple { bwcVersion, baseName ->
         'old_cluster/90_ml_data_frame_analytics_crud/Put classification job on the old cluster'
       ])
     }
+
+    // Disable ML tests for incompatible systems
+    if (BwcVersions.isMlCompatible(bwcVersion) == false) {
+      exclude '**/MlJobSnapshotUpgradeIT.class', '**/MlMappingsUpgradeIT.class', '**/MLModelDeploymentsUpgradeIT.class', '**/MlTrainedModelsUpgradeIT.class'
+      toBlackList.addAll(['old_cluster/30_ml_jobs_crud/*', 'old_cluster/40_ml_datafeed_crud/*', 'old_cluster/90_ml_data_frame_analytics_crud'])
+    }
+
     if (!toBlackList.empty) {
       systemProperty 'tests.rest.blacklist', toBlackList.join(',')
     }
@@ -184,6 +193,13 @@ BuildParams.bwcVersions.withWireCompatiple { bwcVersion, baseName ->
         'mixed_cluster/90_ml_data_frame_analytics_crud/Get old classification job stats',
       ])
     }
+
+    // Disable ML tests for incompatible systems
+    if (BwcVersions.isMlCompatible(bwcVersion) == false) {
+      exclude '**/MlJobSnapshotUpgradeIT.class', '**/MlMappingsUpgradeIT.class', '**/MLModelDeploymentsUpgradeIT.class', '**/MlTrainedModelsUpgradeIT.class'
+      toBlackList.addAll(['mixed_cluster/30_ml_jobs_crud/*', 'mixed_cluster/40_ml_datafeed_crud/*', 'mixed_cluster/90_ml_data_frame_analytics_crud'])
+    }
+
     systemProperty 'tests.rest.blacklist', toBlackList.join(',')
   }
 
@@ -227,6 +243,13 @@ BuildParams.bwcVersions.withWireCompatiple { bwcVersion, baseName ->
         'mixed_cluster/121_api_key/Create API key with metadata in a mixed cluster'
       ])
     }
+
+    // Disable ML tests for incompatible systems
+    if (BwcVersions.isMlCompatible(bwcVersion) == false) {
+      exclude '**/MlJobSnapshotUpgradeIT.class', '**/MlMappingsUpgradeIT.class', '**/MLModelDeploymentsUpgradeIT.class', '**/MlTrainedModelsUpgradeIT.class'
+      toBlackList.addAll(['mixed_cluster/30_ml_jobs_crud/*', 'mixed_cluster/40_ml_datafeed_crud/*', 'mixed_cluster/90_ml_data_frame_analytics_crud'])
+    }
+
     if (!toBlackList.empty) {
       systemProperty 'tests.rest.blacklist', toBlackList.join(',')
     }
@@ -277,6 +300,12 @@ BuildParams.bwcVersions.withWireCompatiple { bwcVersion, baseName ->
       toBlackList.addAll([
         'upgraded_cluster/121_api_key/Get the mixed API key in the upgraded cluster'
       ])
+    }
+
+    // Disable ML tests for incompatible systems
+    if (BwcVersions.isMlCompatible(bwcVersion) == false) {
+      exclude '**/MlJobSnapshotUpgradeIT.class', '**/MlMappingsUpgradeIT.class', '**/MLModelDeploymentsUpgradeIT.class', '**/MlTrainedModelsUpgradeIT.class'
+      toBlackList.addAll(['upgraded_cluster/30_ml_jobs_crud/*', 'upgraded_cluster/40_ml_datafeed_crud/*', 'upgraded_cluster/90_ml_data_frame_analytics_crud'])
     }
 
     if (!toBlackList.empty) {


### PR DESCRIPTION
Backport of #87476