### PR TITLE
Force property expansion for security policy (#87396)

### DIFF
--- a/docs/changelog/87396.yaml
+++ b/docs/changelog/87396.yaml
@@ -1,0 +1,5 @@
+pr: 87396
+summary: Force property expansion for security policy
+area: Infra/Core
+type: enhancement
+issues: []

--- a/server/src/main/java/org/elasticsearch/bootstrap/Elasticsearch.java
+++ b/server/src/main/java/org/elasticsearch/bootstrap/Elasticsearch.java
@@ -59,7 +59,7 @@ class Elasticsearch extends EnvironmentAwareCommand {
      * Main entry point for starting elasticsearch
      */
     public static void main(final String[] args) throws Exception {
-        overrideDnsCachePolicyProperties();
+        bootstrapSecurityProperties();
         org.elasticsearch.bootstrap.Security.prepopulateSecurityCaller();
 
         /*
@@ -103,7 +103,7 @@ class Elasticsearch extends EnvironmentAwareCommand {
         }
     }
 
-    private static void overrideDnsCachePolicyProperties() {
+    private static void bootstrapSecurityProperties() {
         for (final String property : new String[] { "networkaddress.cache.ttl", "networkaddress.cache.negative.ttl" }) {
             final String overrideProperty = "es." + property;
             final String overrideValue = System.getProperty(overrideProperty);
@@ -116,6 +116,9 @@ class Elasticsearch extends EnvironmentAwareCommand {
                 }
             }
         }
+
+        // policy file codebase declarations in security.policy rely on property expansion, see PolicyUtil.readPolicy
+        Security.setProperty("policy.expandProperties", "true");
     }
 
     static int main(final String[] args, final Elasticsearch elasticsearch, final Terminal terminal) throws Exception {


### PR DESCRIPTION
When resolving the security policy files for server and components of
Elasticsearch, each jar file location is put into a special system
property value so that policy files may contain codeBase specific
grants. The mechanism for substituting system properties is part of the
JDK's policy parser. However, a security property exists,
policy.expandProperties, which controls whether properties will actually
be expanded. If a user ends up setting this, Elasticsearch will fail to
start.

This commit forces the value of the security property to ensure the
policy files can always be parsed correctly.