### PR TITLE
Add detailed error messages for searchable snapshot shared folder assertions

### DIFF
--- a/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/BaseSearchableSnapshotsIntegTestCase.java
+++ b/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/BaseSearchableSnapshotsIntegTestCase.java
@@ -245,14 +245,22 @@ public abstract class BaseSearchableSnapshotsIntegTestCase extends AbstractSnaps
                     indexExists,
                     translogExists
                 );
-                assertThat(snapshotDirectory, not(indexExists));
-                assertTrue(translogExists);
+                assertThat(
+                    snapshotDirectory ? "Snapshot directory doesn't exist" : "Snapshot directory shouldn't exist",
+                    snapshotDirectory,
+                    not(indexExists)
+                );
+                assertTrue("Translog doesn't exist", translogExists);
                 try (Stream<Path> dir = Files.list(shardPath.resolveTranslog())) {
                     final long translogFiles = dir.filter(path -> path.getFileName().toString().contains("translog")).count();
                     if (snapshotDirectory) {
-                        assertEquals(2L, translogFiles);
+                        assertEquals("There should be 2 translog files for a snapshot directory", 2L, translogFiles);
                     } else {
-                        assertThat(translogFiles, greaterThanOrEqualTo(2L));
+                        assertThat(
+                            "There should be 2+ translog files non a non-snapshot directory",
+                            translogFiles,
+                            greaterThanOrEqualTo(2L)
+                        );
                     }
                 }
             }


### PR DESCRIPTION
#86186 doesn't reproduce locally. Let's add some additional information to assertions to have more information about how `assertShardFolders` fails on CI (in rare cases when it does).

Fixes #86186