### PR TITLE
Clamp auto-expand replicas to the closest value

### DIFF
--- a/docs/changelog/87505.yaml
+++ b/docs/changelog/87505.yaml
@@ -1,0 +1,6 @@
+pr: 87505
+summary: Clamp auto-expand replicas to the closest value
+area: Allocation
+type: bug
+issues:
+ - 84788

--- a/server/src/internalClusterTest/java/org/elasticsearch/cluster/metadata/AutoExpandReplicasIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/cluster/metadata/AutoExpandReplicasIT.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.cluster.metadata;
+
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.test.ESIntegTestCase;
+
+import static org.hamcrest.Matchers.equalTo;
+
+@ESIntegTestCase.ClusterScope(scope = ESIntegTestCase.Scope.TEST, minNumDataNodes = 2, numClientNodes = 0)
+public class AutoExpandReplicasIT extends ESIntegTestCase {
+
+    /**
+     * Verifies that when no data node is available to host a replica, number of replicas are contracted to 0.
+     */
+    public void testAutoExpandToClosesValue() throws Exception {
+        final String indexName = "myindex";
+        final String autoExpandValue = randomFrom("0-1", "0-all");
+        createIndex(
+            indexName,
+            Settings.builder()
+                .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1)
+                .put(IndexMetadata.SETTING_AUTO_EXPAND_REPLICAS, autoExpandValue)
+                .build()
+        );
+
+        final int initialReplicas = autoExpandValue.equals("0-1") ? 1 : internalCluster().numDataNodes() - 1;
+
+        assertBusy(() -> {
+            assertThat(
+                client().admin()
+                    .indices()
+                    .prepareGetSettings(indexName)
+                    .setNames("index.number_of_replicas")
+                    .get()
+                    .getSetting(indexName, "index.number_of_replicas"),
+                equalTo(String.valueOf(initialReplicas))
+            );
+        });
+        ensureGreen(indexName);
+
+        updateIndexSettings(indexName, Settings.builder().put("index.routing.allocation.require._id", "non-existing-node"));
+
+        assertBusy(() -> {
+            assertThat(
+                client().admin()
+                    .indices()
+                    .prepareGetSettings(indexName)
+                    .setNames("index.number_of_replicas")
+                    .get()
+                    .getSetting(indexName, "index.number_of_replicas"),
+                equalTo("0")
+            );
+        });
+
+        ensureGreen(indexName);
+    }
+}

--- a/server/src/internalClusterTest/java/org/elasticsearch/cluster/metadata/AutoExpandReplicasIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/cluster/metadata/AutoExpandReplicasIT.java
@@ -43,7 +43,6 @@ public class AutoExpandReplicasIT extends ESIntegTestCase {
                 equalTo(String.valueOf(initialReplicas))
             );
         });
-        ensureGreen(indexName);
 
         updateIndexSettings(indexName, Settings.builder().put("index.routing.allocation.require._id", "non-existing-node"));
 
@@ -58,7 +57,6 @@ public class AutoExpandReplicasIT extends ESIntegTestCase {
                 equalTo("0")
             );
         });
-        ensureGreen(indexName);
 
         // Remove the setting
         updateIndexSettings(indexName, Settings.builder().put("index.routing.allocation.require._id", ""));
@@ -74,6 +72,5 @@ public class AutoExpandReplicasIT extends ESIntegTestCase {
                 equalTo(String.valueOf(initialReplicas))
             );
         });
-        ensureGreen(indexName);
     }
 }

--- a/server/src/internalClusterTest/java/org/elasticsearch/cluster/metadata/AutoExpandReplicasIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/cluster/metadata/AutoExpandReplicasIT.java
@@ -19,7 +19,7 @@ public class AutoExpandReplicasIT extends ESIntegTestCase {
     /**
      * Verifies that when no data node is available to host a replica, number of replicas are contracted to 0.
      */
-    public void testAutoExpandToClosesValue() throws Exception {
+    public void testClampToMinMax() throws Exception {
         final String indexName = "myindex";
         final String autoExpandValue = randomFrom("0-1", "0-all");
         createIndex(

--- a/server/src/internalClusterTest/java/org/elasticsearch/cluster/metadata/AutoExpandReplicasIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/cluster/metadata/AutoExpandReplicasIT.java
@@ -58,7 +58,22 @@ public class AutoExpandReplicasIT extends ESIntegTestCase {
                 equalTo("0")
             );
         });
+        ensureGreen(indexName);
 
+        // Remove the setting
+        updateIndexSettings(indexName, Settings.builder().put("index.routing.allocation.require._id", ""));
+
+        assertBusy(() -> {
+            assertThat(
+                client().admin()
+                    .indices()
+                    .prepareGetSettings(indexName)
+                    .setNames("index.number_of_replicas")
+                    .get()
+                    .getSetting(indexName, "index.number_of_replicas"),
+                equalTo(String.valueOf(initialReplicas))
+            );
+        });
         ensureGreen(indexName);
     }
 }

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/AutoExpandReplicas.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/AutoExpandReplicas.java
@@ -112,7 +112,7 @@ public record AutoExpandReplicas(int minReplicas, int maxReplicas, boolean enabl
         return calculateDesiredNumberOfReplicas(numMatchingDataNodes);
     }
 
-    // Package private only for testing purposes!
+    // package private for testing
     int calculateDesiredNumberOfReplicas(int numMatchingDataNodes) {
         final int min = minReplicas();
         final int max = getMaxReplicas(numMatchingDataNodes);

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/AutoExpandReplicas.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/AutoExpandReplicas.java
@@ -92,10 +92,6 @@ public record AutoExpandReplicas(int minReplicas, int maxReplicas, boolean enabl
         }
     }
 
-    int getMaxReplicas(int numDataNodes) {
-        return Math.min(maxReplicas, numDataNodes - 1);
-    }
-
     public boolean expandToAllNodes() {
         return maxReplicas == Integer.MAX_VALUE;
     }
@@ -114,14 +110,12 @@ public record AutoExpandReplicas(int minReplicas, int maxReplicas, boolean enabl
 
     // package private for testing
     int calculateDesiredNumberOfReplicas(int numMatchingDataNodes) {
-        final int min = minReplicas();
-        final int max = getMaxReplicas(numMatchingDataNodes);
         int numberOfReplicas = numMatchingDataNodes - 1;
         // Make sure number of replicas is always between min and max
-        if (numberOfReplicas < min) {
-            numberOfReplicas = min;
-        } else if (numberOfReplicas > max) {
-            numberOfReplicas = max;
+        if (numberOfReplicas < minReplicas) {
+            numberOfReplicas = minReplicas;
+        } else if (numberOfReplicas > maxReplicas) {
+            numberOfReplicas = maxReplicas;
         }
         return numberOfReplicas;
     }

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/AutoExpandReplicasTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/AutoExpandReplicasTests.java
@@ -50,22 +50,18 @@ public class AutoExpandReplicasTests extends ESTestCase {
             Settings.builder().put("index.auto_expand_replicas", "0-5").build()
         );
         assertEquals(0, autoExpandReplicas.minReplicas());
-        assertEquals(5, autoExpandReplicas.getMaxReplicas(8));
-        assertEquals(2, autoExpandReplicas.getMaxReplicas(3));
+        assertEquals(5, autoExpandReplicas.maxReplicas());
         assertFalse(autoExpandReplicas.expandToAllNodes());
 
         autoExpandReplicas = AutoExpandReplicas.SETTING.get(Settings.builder().put("index.auto_expand_replicas", "0-all").build());
         assertEquals(0, autoExpandReplicas.minReplicas());
-        assertEquals(5, autoExpandReplicas.getMaxReplicas(6));
-        assertEquals(2, autoExpandReplicas.getMaxReplicas(3));
+        assertEquals(Integer.MAX_VALUE, autoExpandReplicas.maxReplicas());
         assertTrue(autoExpandReplicas.expandToAllNodes());
 
         autoExpandReplicas = AutoExpandReplicas.SETTING.get(Settings.builder().put("index.auto_expand_replicas", "1-all").build());
         assertEquals(1, autoExpandReplicas.minReplicas());
-        assertEquals(5, autoExpandReplicas.getMaxReplicas(6));
-        assertEquals(2, autoExpandReplicas.getMaxReplicas(3));
+        assertEquals(Integer.MAX_VALUE, autoExpandReplicas.maxReplicas());
         assertTrue(autoExpandReplicas.expandToAllNodes());
-
     }
 
     public void testInvalidValues() {
@@ -284,14 +280,15 @@ public class AutoExpandReplicasTests extends ESTestCase {
     }
 
     public void testCalculateDesiredNumberOfReplicas() {
-        String settingValue = randomFrom("0-all", "0-3");
+        int lowerBound = between(0, 9);
+        int upperBound = between(lowerBound + 1, 10);
+        String settingValue = lowerBound + "-" + randomFrom(upperBound, "all");
         AutoExpandReplicas autoExpandReplicas = AutoExpandReplicas.SETTING.get(
             Settings.builder().put(SETTING_AUTO_EXPAND_REPLICAS, settingValue).build()
         );
         int max = autoExpandReplicas.maxReplicas();
-        assertThat(autoExpandReplicas.calculateDesiredNumberOfReplicas(0), equalTo(0));
-        assertThat(autoExpandReplicas.calculateDesiredNumberOfReplicas(1), equalTo(0));
-        assertThat(autoExpandReplicas.calculateDesiredNumberOfReplicas(2), equalTo(1));
-        assertThat(autoExpandReplicas.calculateDesiredNumberOfReplicas(max), equalTo(max - 1));
+        int matchingNodes = between(0, max);
+        assertThat(autoExpandReplicas.calculateDesiredNumberOfReplicas(matchingNodes), equalTo(Math.max(lowerBound, matchingNodes - 1)));
+        assertThat(autoExpandReplicas.calculateDesiredNumberOfReplicas(max + 1), equalTo(max));
     }
 }

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/AutoExpandReplicasTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/AutoExpandReplicasTests.java
@@ -282,4 +282,16 @@ public class AutoExpandReplicasTests extends ESTestCase {
             terminate(threadPool);
         }
     }
+
+    public void testCalculateDesiredNumberOfReplicas() {
+        String settingValue = randomFrom("0-all", "0-3");
+        AutoExpandReplicas autoExpandReplicas = AutoExpandReplicas.SETTING.get(
+            Settings.builder().put(SETTING_AUTO_EXPAND_REPLICAS, settingValue).build()
+        );
+        int max = autoExpandReplicas.maxReplicas();
+        assertThat(autoExpandReplicas.calculateDesiredNumberOfReplicas(0), equalTo(0));
+        assertThat(autoExpandReplicas.calculateDesiredNumberOfReplicas(1), equalTo(0));
+        assertThat(autoExpandReplicas.calculateDesiredNumberOfReplicas(2), equalTo(1));
+        assertThat(autoExpandReplicas.calculateDesiredNumberOfReplicas(max), equalTo(max - 1));
+    }
 }


### PR DESCRIPTION
Ensure that the number of replicas chosen for an auto-expand-able index
is within the range of the available data nodes, i.e., excluding those
nodes that cannot be assigned a replica.

Closes #84788

<!--
Thank you for your interest in and contributing to Elasticsearch! There
are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your
attention.
-->
