### PR TITLE
[8.3] Don't run include_in_parent when in copy_to context (#87123)

### DIFF
--- a/docs/changelog/87123.yaml
+++ b/docs/changelog/87123.yaml
@@ -1,0 +1,6 @@
+pr: 87123
+summary: Don't run `include_in_parent` when in `copy_to` context
+area: Mapping
+type: bug
+issues:
+ - 87036

--- a/server/src/main/java/org/elasticsearch/index/mapper/DocumentParser.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/DocumentParser.java
@@ -278,7 +278,7 @@ public final class DocumentParser {
         innerParseObject(context, mapper);
         // restore the enable path flag
         if (mapper.isNested()) {
-            nested(context, (NestedObjectMapper) mapper);
+            copyNestedFields(context, (NestedObjectMapper) mapper);
         }
     }
 
@@ -344,7 +344,14 @@ public final class DocumentParser {
         );
     }
 
-    private static void nested(DocumentParserContext context, NestedObjectMapper nested) {
+    private static void copyNestedFields(DocumentParserContext context, NestedObjectMapper nested) {
+        if (context.isWithinCopyTo()) {
+            // Only process the nested document after we've finished parsing the actual
+            // doc; we can't copy_to outside of the current nested context, so if we are
+            // in a copy_to context then we're adding data within the doc and we haven't
+            // finished parsing yet.
+            return;
+        }
         LuceneDocument nestedDoc = context.doc();
         LuceneDocument parentDoc = nestedDoc.getParent();
         Version indexVersion = context.indexSettings().getIndexVersionCreated();
@@ -363,7 +370,7 @@ public final class DocumentParser {
     private static void addFields(Version indexCreatedVersion, LuceneDocument nestedDoc, LuceneDocument rootDoc) {
         String nestedPathFieldName = NestedPathFieldMapper.name(indexCreatedVersion);
         for (IndexableField field : nestedDoc.getFields()) {
-            if (field.name().equals(nestedPathFieldName) == false) {
+            if (field.name().equals(nestedPathFieldName) == false && field.name().equals(IdFieldMapper.NAME) == false) {
                 rootDoc.add(field);
             }
         }


### PR DESCRIPTION
Backports the following commits to 8.3:
 - Don't run include_in_parent when in copy_to context (#87123)