### PR TITLE
Speedup RoutingNodes constructor

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/routing/RoutingNode.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/RoutingNode.java
@@ -136,20 +136,20 @@ public class RoutingNode implements Iterable<ShardRouting> {
      */
     void add(ShardRouting shard) {
         assert invariant();
-        if (shards.containsKey(shard.shardId())) {
+        final ShardRouting existing = shards.putIfAbsent(shard.shardId(), shard);
+        if (existing != null) {
             throw new IllegalStateException(
                 "Trying to add a shard "
                     + shard.shardId()
                     + " to a node ["
                     + nodeId
                     + "] where it already exists. current ["
-                    + shards.get(shard.shardId())
+                    + existing
                     + "]. new ["
                     + shard
                     + "]"
             );
         }
-        shards.put(shard.shardId(), shard);
 
         if (shard.initializing()) {
             initializingShards.add(shard);

--- a/server/src/main/java/org/elasticsearch/cluster/routing/RoutingNode.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/RoutingNode.java
@@ -138,17 +138,19 @@ public class RoutingNode implements Iterable<ShardRouting> {
         assert invariant();
         final ShardRouting existing = shards.putIfAbsent(shard.shardId(), shard);
         if (existing != null) {
-            throw new IllegalStateException(
+            final IllegalStateException e = new IllegalStateException(
                 "Trying to add a shard "
                     + shard.shardId()
                     + " to a node ["
                     + nodeId
                     + "] where it already exists. current ["
-                    + existing
+                    + shards.get(shard.shardId())
                     + "]. new ["
                     + shard
                     + "]"
             );
+            assert false : e;
+            throw e;
         }
 
         if (shard.initializing()) {

--- a/server/src/main/java/org/elasticsearch/cluster/routing/RoutingNodes.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/RoutingNodes.java
@@ -41,6 +41,7 @@ import java.util.NoSuchElementException;
 import java.util.Objects;
 import java.util.Queue;
 import java.util.Set;
+import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
@@ -101,16 +102,15 @@ public class RoutingNodes extends AbstractCollection<RoutingNode> {
         this.unassignedShards = new UnassignedShards(this);
         this.attributeValuesByAttribute = new HashMap<>();
 
-        final Map<String, LinkedHashMap<ShardId, ShardRouting>> nodesToShards = Maps.newMapWithExpectedSize(
-            discoveryNodes.getDataNodes().size()
-        );
+        nodesToShards = Maps.newMapWithExpectedSize(discoveryNodes.getDataNodes().size());
         // fill in the nodeToShards with the "live" nodes
         for (var node : discoveryNodes.getDataNodes().keySet()) {
-            nodesToShards.put(node, new LinkedHashMap<>()); // LinkedHashMap to preserve order
+            nodesToShards.put(node, new RoutingNode(node, discoveryNodes.get(node), new LinkedHashMap<>()));
         }
 
         // fill in the inverse of node -> shards allocated
         // also fill replicaSet information
+        final Function<String, RoutingNode> createRoutingNode = k -> new RoutingNode(k, discoveryNodes.get(k), new LinkedHashMap<>());
         for (IndexRoutingTable indexRoutingTable : routingTable.indicesRouting().values()) {
             for (int shardId = 0; shardId < indexRoutingTable.size(); shardId++) {
                 IndexShardRoutingTable indexShard = indexRoutingTable.shard(shardId);
@@ -124,11 +124,7 @@ public class RoutingNodes extends AbstractCollection<RoutingNode> {
                     // A replica Set might have one (and not more) replicas with the state of RELOCATING.
                     if (shard.assignedToNode()) {
                         // LinkedHashMap to preserve order
-                        ShardRouting previousValue = nodesToShards.computeIfAbsent(shard.currentNodeId(), k -> new LinkedHashMap<>())
-                            .put(shard.shardId(), shard);
-                        if (previousValue != null) {
-                            throw new IllegalArgumentException("Cannot have two different shards with same shard id on same node");
-                        }
+                        nodesToShards.computeIfAbsent(shard.currentNodeId(), createRoutingNode).add(shard);
                         assignedShardsAdd(shard);
                         if (shard.active()) {
                             activeShardCount++;
@@ -139,11 +135,7 @@ public class RoutingNodes extends AbstractCollection<RoutingNode> {
                             addInitialRecovery(targetShardRouting, indexShard.primary);
                             // LinkedHashMap to preserve order.
                             // Add the counterpart shard with relocatingNodeId reflecting the source from which it's relocating from.
-                            previousValue = nodesToShards.computeIfAbsent(shard.relocatingNodeId(), k -> new LinkedHashMap<>())
-                                .put(targetShardRouting.shardId(), targetShardRouting);
-                            if (previousValue != null) {
-                                throw new IllegalArgumentException("Cannot have two different shards with same shard id on same node");
-                            }
+                            nodesToShards.computeIfAbsent(shard.relocatingNodeId(), createRoutingNode).add(targetShardRouting);
                             assignedShardsAdd(targetShardRouting);
                         } else if (shard.initializing()) {
                             if (shard.primary()) {
@@ -157,11 +149,6 @@ public class RoutingNodes extends AbstractCollection<RoutingNode> {
                     }
                 }
             }
-        }
-        this.nodesToShards = Maps.newMapWithExpectedSize(nodesToShards.size());
-        for (Map.Entry<String, LinkedHashMap<ShardId, ShardRouting>> entry : nodesToShards.entrySet()) {
-            String nodeId = entry.getKey();
-            this.nodesToShards.put(nodeId, new RoutingNode(nodeId, discoveryNodes.get(nodeId), entry.getValue()));
         }
     }
 


### PR DESCRIPTION
The RoutingNode instances are mutable. This PR leverages
that fact by building them directly instead of first collecting
a shards map and then building from that which saves quite
a few cycles since no per-data-node map has to be iterated.

relates #77466