### PR TITLE
Fixing bug in StableMasterDisruptionIT.testRepeatedNullMasterRecognizedAsGreenIfMasterDoesNotKnowItIsUnstable()

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/discovery/StableMasterDisruptionIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/discovery/StableMasterDisruptionIT.java
@@ -23,6 +23,7 @@ import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.set.Sets;
+import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.core.Tuple;
 import org.elasticsearch.health.GetHealthAction;
 import org.elasticsearch.health.HealthStatus;
@@ -424,6 +425,10 @@ public class StableMasterDisruptionIT extends ESIntegTestCase {
                 .put(LeaderChecker.LEADER_CHECK_TIMEOUT_SETTING.getKey(), "1s")
                 .put(Coordinator.PUBLISH_TIMEOUT_SETTING.getKey(), "1s")
                 .put(StableMasterHealthIndicatorService.NO_MASTER_TRANSITIONS_THRESHOLD_SETTING.getKey(), 1)
+                .put(
+                    StableMasterHealthIndicatorService.NODE_HAS_MASTER_LOOKUP_TIMEFRAME_SETTING.getKey(),
+                    new TimeValue(60, TimeUnit.SECONDS)
+                )
                 .build()
         );
         ensureStableCluster(3);

--- a/server/src/main/java/org/elasticsearch/common/settings/ClusterSettings.java
+++ b/server/src/main/java/org/elasticsearch/common/settings/ClusterSettings.java
@@ -515,6 +515,7 @@ public final class ClusterSettings extends AbstractScopedSettings {
         DataTier.ENFORCE_DEFAULT_TIER_PREFERENCE_SETTING,
         StableMasterHealthIndicatorService.IDENTITY_CHANGES_THRESHOLD_SETTING,
         StableMasterHealthIndicatorService.NO_MASTER_TRANSITIONS_THRESHOLD_SETTING,
+        StableMasterHealthIndicatorService.NODE_HAS_MASTER_LOOKUP_TIMEFRAME_SETTING,
         MasterHistory.MAX_HISTORY_AGE_SETTING,
         ReadinessService.PORT
     );


### PR DESCRIPTION
The test could wait up to 30 seconds for a master to step down. In that case, the start of the "null" master could be
30 seconds ago, which put it outside of the range of the default acceptable time for there to have been a master
for the stability check. So the stability check returned RED since there was no master in the last 30 seconds. This
changes that setting to 60 seconds so that it is always picked up.
Closes #87446