### PR TITLE
Remove cluster block preflight check from health api

### DIFF
--- a/docs/changelog/87520.yaml
+++ b/docs/changelog/87520.yaml
@@ -1,0 +1,6 @@
+pr: 87520
+summary: Remove cluster block preflight check from health api
+area: Health
+type: enhancement
+issues:
+ - 87464

--- a/server/src/main/java/org/elasticsearch/health/HealthService.java
+++ b/server/src/main/java/org/elasticsearch/health/HealthService.java
@@ -9,7 +9,6 @@
 package org.elasticsearch.health;
 
 import org.elasticsearch.ResourceNotFoundException;
-import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.core.Nullable;
 
 import java.util.Collections;
@@ -100,8 +99,9 @@ public class HealthService {
         } else {
             // Mark remaining indicators as UNKNOWN
             HealthIndicatorDetails unknownDetails = healthUnknownReason(preflightResults, explain);
-            filteredIndicatorResults = filteredIndicators
-                .map(service -> generateUnknownResult(service, UNKNOWN_RESULT_SUMMARY_PREFLIGHT_FAILED, unknownDetails));
+            filteredIndicatorResults = filteredIndicators.map(
+                service -> generateUnknownResult(service, UNKNOWN_RESULT_SUMMARY_PREFLIGHT_FAILED, unknownDetails)
+            );
         }
 
         // Filter the cluster indicator results by component name and indicator name if present
@@ -142,10 +142,7 @@ public class HealthService {
      * @param computeDetails If details should be calculated on which indicators are causing the UNKNOWN state.
      * @return Details explaining why results are UNKNOWN, or an empty detail set if computeDetails is false.
      */
-    private HealthIndicatorDetails healthUnknownReason(
-        List<HealthIndicatorResult> preflightResults,
-        boolean computeDetails
-    ) {
+    private HealthIndicatorDetails healthUnknownReason(List<HealthIndicatorResult> preflightResults, boolean computeDetails) {
         assert preflightResults.isEmpty() == false : "Requires at least one non-GREEN preflight result";
         HealthIndicatorDetails unknownDetails;
         if (computeDetails) {

--- a/server/src/main/java/org/elasticsearch/health/HealthService.java
+++ b/server/src/main/java/org/elasticsearch/health/HealthService.java
@@ -11,7 +11,6 @@ package org.elasticsearch.health;
 import org.elasticsearch.ResourceNotFoundException;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.core.Nullable;
-import org.elasticsearch.gateway.GatewayService;
 
 import java.util.Collections;
 import java.util.HashSet;
@@ -37,23 +36,14 @@ public class HealthService {
     // Visible for testing
     static final String UNKNOWN_RESULT_SUMMARY_PREFLIGHT_FAILED = "Could not determine health status. Check details on critical issues "
         + "preventing the health status from reporting.";
-    static final String UNKNOWN_RESULT_SUMMARY_NOT_RECOVERED =
-        "Could not determine health status. This node is not ready to assess the cluster health. Try again later or run the health API "
-            + "against a different node.";
 
     /**
      * Detail map key that contains the reasons a result was marked as UNKNOWN
      */
     private static final String REASON = "reasons";
 
-    private static final String CLUSTER_STATE_RECOVERED = "cluster_state_recovered";
-    private static final SimpleHealthIndicatorDetails DETAILS_UNKNOWN_STATE_NOT_RECOVERED = new SimpleHealthIndicatorDetails(
-        Map.of(REASON, Map.of(CLUSTER_STATE_RECOVERED, false))
-    );
-
     private final List<HealthIndicatorService> preflightHealthIndicatorServices;
     private final List<HealthIndicatorService> healthIndicatorServices;
-    private final ClusterService clusterService;
 
     /**
      * Creates a new HealthService.
@@ -68,12 +58,10 @@ public class HealthService {
      */
     public HealthService(
         List<HealthIndicatorService> preflightHealthIndicatorServices,
-        List<HealthIndicatorService> healthIndicatorServices,
-        ClusterService clusterService
+        List<HealthIndicatorService> healthIndicatorServices
     ) {
         this.preflightHealthIndicatorServices = preflightHealthIndicatorServices;
         this.healthIndicatorServices = healthIndicatorServices;
-        this.clusterService = clusterService;
     }
 
     /**
@@ -91,22 +79,10 @@ public class HealthService {
         final boolean shouldDrillDownToIndicatorLevel = indicatorName != null;
         final boolean showRolledUpComponentStatus = shouldDrillDownToIndicatorLevel == false;
 
-        // Is the cluster state recovered? If not, ALL indicators should return UNKNOWN
-        boolean clusterStateRecovered = clusterService.state()
-            .getBlocks()
-            .hasGlobalBlock(GatewayService.STATE_NOT_RECOVERED_BLOCK) == false;
-
-        List<HealthIndicatorResult> preflightResults;
-        if (clusterStateRecovered) {
-            // Determine if cluster is stable enough to calculate health before running other indicators
-            preflightResults = preflightHealthIndicatorServices.stream().map(service -> service.calculate(explain)).toList();
-        } else {
-            // Mark preflight indicators as UNKNOWN
-            HealthIndicatorDetails details = explain ? DETAILS_UNKNOWN_STATE_NOT_RECOVERED : HealthIndicatorDetails.EMPTY;
-            preflightResults = preflightHealthIndicatorServices.stream()
-                .map(service -> generateUnknownResult(service, UNKNOWN_RESULT_SUMMARY_NOT_RECOVERED, details))
-                .toList();
-        }
+        // Determine if cluster is stable enough to calculate health before running other indicators
+        List<HealthIndicatorResult> preflightResults = preflightHealthIndicatorServices.stream()
+            .map(service -> service.calculate(explain))
+            .toList();
 
         // If any of these are not GREEN, then we cannot obtain health from other indicators
         boolean clusterHealthIsObtainable = preflightResults.isEmpty()
@@ -118,14 +94,14 @@ public class HealthService {
             .filter(service -> indicatorName == null || service.name().equals(indicatorName));
 
         Stream<HealthIndicatorResult> filteredIndicatorResults;
-        if (clusterStateRecovered && clusterHealthIsObtainable) {
+        if (clusterHealthIsObtainable) {
             // Calculate remaining indicators
             filteredIndicatorResults = filteredIndicators.map(service -> service.calculate(explain));
         } else {
             // Mark remaining indicators as UNKNOWN
-            String unknownSummary = clusterStateRecovered ? UNKNOWN_RESULT_SUMMARY_PREFLIGHT_FAILED : UNKNOWN_RESULT_SUMMARY_NOT_RECOVERED;
-            HealthIndicatorDetails unknownDetails = healthUnknownReason(preflightResults, clusterStateRecovered, explain);
-            filteredIndicatorResults = filteredIndicators.map(service -> generateUnknownResult(service, unknownSummary, unknownDetails));
+            HealthIndicatorDetails unknownDetails = healthUnknownReason(preflightResults, explain);
+            filteredIndicatorResults = filteredIndicators
+                .map(service -> generateUnknownResult(service, UNKNOWN_RESULT_SUMMARY_PREFLIGHT_FAILED, unknownDetails));
         }
 
         // Filter the cluster indicator results by component name and indicator name if present
@@ -168,23 +144,17 @@ public class HealthService {
      */
     private HealthIndicatorDetails healthUnknownReason(
         List<HealthIndicatorResult> preflightResults,
-        boolean clusterStateRecovered,
         boolean computeDetails
     ) {
-        assert clusterStateRecovered == false || preflightResults.isEmpty() == false
-            : "Requires at least one non-GREEN preflight result or cluster state not recovered";
+        assert preflightResults.isEmpty() == false : "Requires at least one non-GREEN preflight result";
         HealthIndicatorDetails unknownDetails;
         if (computeDetails) {
-            if (clusterStateRecovered) {
-                // Determine why the cluster is not stable enough for running remaining indicators
-                Map<String, String> clusterUnstableReasons = preflightResults.stream()
-                    .filter(result -> HealthStatus.GREEN.equals(result.status()) == false)
-                    .collect(toMap(HealthIndicatorResult::name, result -> result.status().xContentValue()));
-                assert clusterUnstableReasons.isEmpty() == false : "Requires at least one non-GREEN preflight result";
-                unknownDetails = new SimpleHealthIndicatorDetails(Map.of(REASON, clusterUnstableReasons));
-            } else {
-                unknownDetails = DETAILS_UNKNOWN_STATE_NOT_RECOVERED;
-            }
+            // Determine why the cluster is not stable enough for running remaining indicators
+            Map<String, String> clusterUnstableReasons = preflightResults.stream()
+                .filter(result -> HealthStatus.GREEN.equals(result.status()) == false)
+                .collect(toMap(HealthIndicatorResult::name, result -> result.status().xContentValue()));
+            assert clusterUnstableReasons.isEmpty() == false : "Requires at least one non-GREEN preflight result";
+            unknownDetails = new SimpleHealthIndicatorDetails(Map.of(REASON, clusterUnstableReasons));
         } else {
             unknownDetails = HealthIndicatorDetails.EMPTY;
         }

--- a/server/src/main/java/org/elasticsearch/node/Node.java
+++ b/server/src/main/java/org/elasticsearch/node/Node.java
@@ -1042,8 +1042,7 @@ public class Node implements Closeable {
             .toList();
         return new HealthService(
             preflightHealthIndicatorServices,
-            concatLists(serverHealthIndicatorServices, pluginHealthIndicatorServices),
-            clusterService
+            concatLists(serverHealthIndicatorServices, pluginHealthIndicatorServices)
         );
     }
 

--- a/server/src/test/java/org/elasticsearch/health/HealthServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/health/HealthServiceTests.java
@@ -9,11 +9,6 @@
 package org.elasticsearch.health;
 
 import org.elasticsearch.ResourceNotFoundException;
-import org.elasticsearch.cluster.ClusterName;
-import org.elasticsearch.cluster.ClusterState;
-import org.elasticsearch.cluster.block.ClusterBlocks;
-import org.elasticsearch.cluster.service.ClusterService;
-import org.elasticsearch.gateway.GatewayService;
 import org.elasticsearch.test.ESTestCase;
 
 import java.util.Collections;
@@ -30,9 +25,6 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasItems;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
-import static org.hamcrest.Matchers.oneOf;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 public class HealthServiceTests extends ESTestCase {
 
@@ -48,8 +40,7 @@ public class HealthServiceTests extends ESTestCase {
                 createMockHealthIndicatorService(networkLatency),
                 createMockHealthIndicatorService(slowTasks),
                 createMockHealthIndicatorService(shardsAvailable)
-            ),
-            mockEmptyClusterService()
+            )
         );
 
         assertThat(
@@ -116,8 +107,7 @@ public class HealthServiceTests extends ESTestCase {
                 createMockHealthIndicatorService(networkLatency),
                 createMockHealthIndicatorService(slowTasks),
                 createMockHealthIndicatorService(shardsAvailable)
-            ),
-            mockEmptyClusterService()
+            )
         );
 
         expectThrows(
@@ -147,8 +137,7 @@ public class HealthServiceTests extends ESTestCase {
                 createMockHealthIndicatorService(networkLatency),
                 createMockHealthIndicatorService(slowTasks),
                 createMockHealthIndicatorService(shardsAvailable)
-            ),
-            mockEmptyClusterService()
+            )
         );
 
         // Get all indicators returns preflight result mixed in with appropriate component
@@ -212,7 +201,7 @@ public class HealthServiceTests extends ESTestCase {
         assertThat(result.status(), is(equalTo(UNKNOWN)));
         assertThat(
             result.summary(),
-            is(oneOf(HealthService.UNKNOWN_RESULT_SUMMARY_NOT_RECOVERED, HealthService.UNKNOWN_RESULT_SUMMARY_PREFLIGHT_FAILED))
+            is(HealthService.UNKNOWN_RESULT_SUMMARY_PREFLIGHT_FAILED)
         );
     }
 
@@ -231,8 +220,7 @@ public class HealthServiceTests extends ESTestCase {
                 createMockHealthIndicatorService(networkLatency),
                 createMockHealthIndicatorService(slowTasks),
                 createMockHealthIndicatorService(shardsAvailable)
-            ),
-            mockEmptyClusterService()
+            )
         );
 
         List<HealthComponentResult> health = service.getHealth(null, null, false);
@@ -321,113 +309,6 @@ public class HealthServiceTests extends ESTestCase {
         }
     }
 
-    public void testAllIndicatorsUnknownWhenClusterStateNotRecovered() {
-        var hasMaster = new HealthIndicatorResult("has_master", "coordination", RED, null, null, null, null, null);
-        var hasStorage = new HealthIndicatorResult("has_storage", "data", GREEN, null, null, null, null, null);
-        var networkLatency = new HealthIndicatorResult("network_latency", "coordination", GREEN, null, null, null, null, null);
-        var slowTasks = new HealthIndicatorResult("slow_task_assignment", "coordination", YELLOW, null, null, null, null, null);
-        var shardsAvailable = new HealthIndicatorResult("shards_availability", "data", GREEN, null, null, null, null, null);
-
-        var service = new HealthService(
-            List.of(createMockHealthIndicatorService(hasMaster), createMockHealthIndicatorService(hasStorage)),
-            List.of(
-                createMockHealthIndicatorService(networkLatency),
-                createMockHealthIndicatorService(slowTasks),
-                createMockHealthIndicatorService(shardsAvailable)
-            ),
-            mockClusterService(
-                ClusterState.builder(new ClusterName("test-cluster"))
-                    .blocks(ClusterBlocks.builder().addGlobalBlock(GatewayService.STATE_NOT_RECOVERED_BLOCK).build())
-                    .build()
-            )
-        );
-
-        List<HealthComponentResult> health = service.getHealth(null, null, false);
-        assertThat(health.size(), is(equalTo(2)));
-        {
-            HealthComponentResult component1 = health.stream()
-                .filter(result -> result.name().equals("coordination"))
-                .findAny()
-                .orElseThrow();
-            // UNKNOWN because cluster state not recovered
-            assertThat(component1.status(), is(equalTo(UNKNOWN)));
-            assertThat(component1.indicators(), is(notNullValue()));
-            assertThat(component1.indicators().size(), is(equalTo(3)));
-            // Preflight 1 should be UNKNOWN
-            HealthIndicatorResult hasMasterResult = component1.findIndicator("has_master");
-            assertIndicatorIsUnknownStatus(hasMasterResult);
-            // Indicator 1 should be UNKNOWN
-            HealthIndicatorResult networkLatencyResult = component1.findIndicator("network_latency");
-            assertIndicatorIsUnknownStatus(networkLatencyResult);
-            // Indicator 2 should be UNKNOWN
-            HealthIndicatorResult slowTasksResult = component1.findIndicator("slow_task_assignment");
-            assertIndicatorIsUnknownStatus(slowTasksResult);
-        }
-        {
-            HealthComponentResult component2 = health.stream().filter(result -> result.name().equals("data")).findAny().orElseThrow();
-            // UNKNOWN because cluster state not recovered
-            assertThat(component2.status(), is(equalTo(UNKNOWN)));
-            assertThat(component2.indicators(), is(notNullValue()));
-            assertThat(component2.indicators().size(), is(equalTo(2)));
-            // Preflight 2 should be UNKNOWN
-            HealthIndicatorResult hasStorageResult = component2.findIndicator("has_storage");
-            assertIndicatorIsUnknownStatus(hasStorageResult);
-            // Indicator 3 should be UNKNOWN
-            HealthIndicatorResult shardsAvailableResult = component2.findIndicator("shards_availability");
-            assertIndicatorIsUnknownStatus(shardsAvailableResult);
-        }
-
-        health = service.getHealth("coordination", null, false);
-        assertThat(health.size(), is(equalTo(1)));
-        {
-            HealthComponentResult component1 = health.stream()
-                .filter(result -> result.name().equals("coordination"))
-                .findAny()
-                .orElseThrow();
-            // UNKNOWN because cluster state not recovered
-            assertThat(component1.status(), is(equalTo(UNKNOWN)));
-            assertThat(component1.indicators(), is(notNullValue()));
-            assertThat(component1.indicators().size(), is(equalTo(3)));
-            // Preflight 1 should be UNKNOWN
-            HealthIndicatorResult hasMasterResult = component1.findIndicator("has_master");
-            assertIndicatorIsUnknownStatus(hasMasterResult);
-            // Indicator 1 should be UNKNOWN
-            HealthIndicatorResult networkLatencyResult = component1.findIndicator("network_latency");
-            assertIndicatorIsUnknownStatus(networkLatencyResult);
-            // Indicator 2 should be UNKNOWN
-            HealthIndicatorResult slowTasksResult = component1.findIndicator("slow_task_assignment");
-            assertIndicatorIsUnknownStatus(slowTasksResult);
-        }
-
-        health = service.getHealth("coordination", "slow_task_assignment", false);
-        assertThat(health.size(), is(equalTo(1)));
-        {
-            HealthComponentResult component1 = health.stream()
-                .filter(result -> result.name().equals("coordination"))
-                .findAny()
-                .orElseThrow();
-            assertThat(component1.indicators(), is(notNullValue()));
-            assertThat(component1.indicators().size(), is(equalTo(1)));
-            // Indicator 2 should be UNKNOWN
-            HealthIndicatorResult slowTasksResult = component1.findIndicator("slow_task_assignment");
-            assertIndicatorIsUnknownStatus(slowTasksResult);
-        }
-
-        health = service.getHealth("coordination", "has_master", false);
-        assertThat(health.size(), is(equalTo(1)));
-        {
-            HealthComponentResult component1 = health.stream()
-                .filter(result -> result.name().equals("coordination"))
-                .findAny()
-                .orElseThrow();
-            assertThat(component1.indicators(), is(notNullValue()));
-            assertThat(component1.indicators().size(), is(equalTo(1)));
-            // Preflight 1 should be UNKNOWN
-            HealthIndicatorResult hasMasterResult = component1.findIndicator("has_master");
-            assertIndicatorIsUnknownStatus(hasMasterResult);
-        }
-    }
-
     private static HealthIndicatorService createMockHealthIndicatorService(HealthIndicatorResult result) {
         return new HealthIndicatorService() {
             @Override
@@ -452,13 +333,4 @@ public class HealthServiceTests extends ESTestCase {
         };
     }
 
-    private static ClusterService mockEmptyClusterService() {
-        return mockClusterService(ClusterState.EMPTY_STATE);
-    }
-
-    private static ClusterService mockClusterService(ClusterState clusterState) {
-        var clusterService = mock(ClusterService.class);
-        when(clusterService.state()).thenReturn(clusterState);
-        return clusterService;
-    }
 }

--- a/server/src/test/java/org/elasticsearch/health/HealthServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/health/HealthServiceTests.java
@@ -199,10 +199,7 @@ public class HealthServiceTests extends ESTestCase {
 
     private void assertIndicatorIsUnknownStatus(HealthIndicatorResult result) {
         assertThat(result.status(), is(equalTo(UNKNOWN)));
-        assertThat(
-            result.summary(),
-            is(HealthService.UNKNOWN_RESULT_SUMMARY_PREFLIGHT_FAILED)
-        );
+        assertThat(result.summary(), is(HealthService.UNKNOWN_RESULT_SUMMARY_PREFLIGHT_FAILED));
     }
 
     public void testPreflightIndicatorFailureTriggersUnknownResults() {


### PR DESCRIPTION
Removes the logic at the start of the health service that returns UNKNOWN status in case the cluster state not recovered block is in place. Instead, we will defer directly to the master-is-stable indicator and all following preflight indicators.

fixes #87464 