### PR TITLE
[8.3] Add tier information on health api migrate tiers user actions (#87486)

### DIFF
--- a/docs/changelog/87486.yaml
+++ b/docs/changelog/87486.yaml
@@ -1,0 +1,5 @@
+pr: 87486
+summary: Add tier information on health api migrate tiers user actions
+area: Health
+type: enhancement
+issues: []

--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/ShardsAvailabilityHealthIndicatorService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/ShardsAvailabilityHealthIndicatorService.java
@@ -265,6 +265,26 @@ public class ShardsAvailabilityHealthIndicatorService implements HealthIndicator
         MIGRATE_TO_TIERS_ACTION_GUIDE
     );
 
+    public static final Map<String, UserAction.Definition> ACTION_MIGRATE_TIERS_AWAY_FROM_REQUIRE_DATA_LOOKUP = DataTier.ALL_DATA_TIERS
+        .stream()
+        .collect(
+            Collectors.toUnmodifiableMap(
+                tier -> tier,
+                tier -> new UserAction.Definition(
+                    "migrate_data_tiers_require_data_" + tier,
+                    "Elasticsearch isn't allowed to allocate some shards from these indices to any nodes in the ["
+                        + tier
+                        + "] data tier because the indices are configured with allocation filter rules that are incompatible with the "
+                        + "nodes in this tier. Remove ["
+                        + INDEX_ROUTING_REQUIRE_GROUP_PREFIX
+                        + ".data] from the index settings or try migrating to data tiers by first stopping ILM [POST /_ilm/stop] and then "
+                        + "using the data tier migration action [POST /_ilm/migrate_to_data_tiers]. "
+                        + "Finally, restart ILM [POST /_ilm/start].",
+                    MIGRATE_TO_TIERS_ACTION_GUIDE
+                )
+            )
+        );
+
     public static final UserAction.Definition ACTION_MIGRATE_TIERS_AWAY_FROM_INCLUDE_DATA = new UserAction.Definition(
         "migrate_data_tiers_include_data",
         "Elasticsearch isn't allowed to allocate some shards from these indices to any nodes in the desired data tiers because the "
@@ -274,6 +294,26 @@ public class ShardsAvailabilityHealthIndicatorService implements HealthIndicator
             + "the data tier migration action [POST /_ilm/migrate_to_data_tiers]. Finally, restart ILM [POST /_ilm/start].",
         MIGRATE_TO_TIERS_ACTION_GUIDE
     );
+
+    public static final Map<String, UserAction.Definition> ACTION_MIGRATE_TIERS_AWAY_FROM_INCLUDE_DATA_LOOKUP = DataTier.ALL_DATA_TIERS
+        .stream()
+        .collect(
+            Collectors.toUnmodifiableMap(
+                tier -> tier,
+                tier -> new UserAction.Definition(
+                    "migrate_data_tiers_include_data_" + tier,
+                    "Elasticsearch isn't allowed to allocate some shards from these indices to any nodes in the ["
+                        + tier
+                        + "] data tier because the indices are configured with allocation filter rules that are incompatible with the "
+                        + "nodes in this tier. Remove ["
+                        + INDEX_ROUTING_INCLUDE_GROUP_PREFIX
+                        + ".data] from the index settings or try migrating to data tiers by first stopping ILM [POST /_ilm/stop] and then "
+                        + "using the data tier migration action [POST /_ilm/migrate_to_data_tiers]. "
+                        + "Finally, restart ILM [POST /_ilm/start].",
+                    MIGRATE_TO_TIERS_ACTION_GUIDE
+                )
+            )
+        );
 
     public static final String NODE_CAPACITY_ACTION_GUIDE = "http://ela.st/node-capacity";
     public static final UserAction.Definition ACTION_INCREASE_NODE_CAPACITY = new UserAction.Definition(
@@ -552,7 +592,7 @@ public class ShardsAvailabilityHealthIndicatorService implements HealthIndicator
                 actions.addAll(
                     checkDataTierAtShardLimit(indexMetadata, clusterState, dataTierAllocationResults, dataTierNodes, preferredTier)
                 );
-                actions.addAll(checkDataTierShouldMigrate(indexMetadata, dataTierAllocationResults, dataTierNodes));
+                actions.addAll(checkDataTierShouldMigrate(indexMetadata, dataTierAllocationResults, preferredTier, dataTierNodes));
                 checkNotEnoughNodesInDataTier(dataTierAllocationResults, preferredTier).ifPresent(actions::add);
             }
         }
@@ -626,6 +666,7 @@ public class ShardsAvailabilityHealthIndicatorService implements HealthIndicator
     private List<UserAction.Definition> checkDataTierShouldMigrate(
         IndexMetadata indexMetadata,
         List<NodeAllocationResult> dataTierAllocationResults,
+        @Nullable String preferredTier,
         Set<DiscoveryNode> dataTierNodes
     ) {
         // Check if index has filter requirements on the old "data" attribute that might be keeping it from allocating.
@@ -646,11 +687,19 @@ public class ShardsAvailabilityHealthIndicatorService implements HealthIndicator
                 // Check if the data tier nodes this shard is allowed on have data attributes that match
                 if (requireFilter != null && dataTierNodes.stream().noneMatch(requireFilter::match)) {
                     // No data tier nodes match the required data attribute
-                    actions.add(ACTION_MIGRATE_TIERS_AWAY_FROM_REQUIRE_DATA);
+                    actions.add(
+                        Optional.ofNullable(preferredTier)
+                            .map(ACTION_MIGRATE_TIERS_AWAY_FROM_REQUIRE_DATA_LOOKUP::get)
+                            .orElse(ACTION_MIGRATE_TIERS_AWAY_FROM_REQUIRE_DATA)
+                    );
                 }
                 if (includeFilter != null && dataTierNodes.stream().noneMatch(includeFilter::match)) {
                     // No data tier nodes match the included data attributes
-                    actions.add(ACTION_MIGRATE_TIERS_AWAY_FROM_INCLUDE_DATA);
+                    actions.add(
+                        Optional.ofNullable(preferredTier)
+                            .map(ACTION_MIGRATE_TIERS_AWAY_FROM_INCLUDE_DATA_LOOKUP::get)
+                            .orElse(ACTION_MIGRATE_TIERS_AWAY_FROM_INCLUDE_DATA)
+                    );
                 }
             }
             return actions;

--- a/server/src/test/java/org/elasticsearch/cluster/routing/allocation/ShardsAvailabilityHealthIndicatorServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/allocation/ShardsAvailabilityHealthIndicatorServiceTests.java
@@ -70,8 +70,8 @@ import static org.elasticsearch.cluster.routing.allocation.ShardsAvailabilityHea
 import static org.elasticsearch.cluster.routing.allocation.ShardsAvailabilityHealthIndicatorService.ACTION_INCREASE_SHARD_LIMIT_INDEX_SETTING;
 import static org.elasticsearch.cluster.routing.allocation.ShardsAvailabilityHealthIndicatorService.ACTION_INCREASE_SHARD_LIMIT_INDEX_SETTING_LOOKUP;
 import static org.elasticsearch.cluster.routing.allocation.ShardsAvailabilityHealthIndicatorService.ACTION_INCREASE_TIER_CAPACITY_LOOKUP;
-import static org.elasticsearch.cluster.routing.allocation.ShardsAvailabilityHealthIndicatorService.ACTION_MIGRATE_TIERS_AWAY_FROM_INCLUDE_DATA;
-import static org.elasticsearch.cluster.routing.allocation.ShardsAvailabilityHealthIndicatorService.ACTION_MIGRATE_TIERS_AWAY_FROM_REQUIRE_DATA;
+import static org.elasticsearch.cluster.routing.allocation.ShardsAvailabilityHealthIndicatorService.ACTION_MIGRATE_TIERS_AWAY_FROM_INCLUDE_DATA_LOOKUP;
+import static org.elasticsearch.cluster.routing.allocation.ShardsAvailabilityHealthIndicatorService.ACTION_MIGRATE_TIERS_AWAY_FROM_REQUIRE_DATA_LOOKUP;
 import static org.elasticsearch.cluster.routing.allocation.ShardsAvailabilityHealthIndicatorService.ACTION_RESTORE_FROM_SNAPSHOT;
 import static org.elasticsearch.cluster.routing.allocation.ShardsAvailabilityHealthIndicatorService.NAME;
 import static org.elasticsearch.cluster.routing.allocation.ShardsAvailabilityHealthIndicatorServiceTests.ShardState.AVAILABLE;
@@ -1002,7 +1002,7 @@ public class ShardsAvailabilityHealthIndicatorServiceTests extends ESTestCase {
         );
 
         assertThat(actions, hasSize(1));
-        assertThat(actions, contains(ACTION_MIGRATE_TIERS_AWAY_FROM_REQUIRE_DATA));
+        assertThat(actions, contains(ACTION_MIGRATE_TIERS_AWAY_FROM_REQUIRE_DATA_LOOKUP.get(DataTier.DATA_HOT)));
     }
 
     public void testDiagnoseMigrateDataIncludedToDataTiers() {
@@ -1038,7 +1038,7 @@ public class ShardsAvailabilityHealthIndicatorServiceTests extends ESTestCase {
         );
 
         assertThat(actions, hasSize(1));
-        assertThat(actions, contains(ACTION_MIGRATE_TIERS_AWAY_FROM_INCLUDE_DATA));
+        assertThat(actions, contains(ACTION_MIGRATE_TIERS_AWAY_FROM_INCLUDE_DATA_LOOKUP.get(DataTier.DATA_HOT)));
     }
 
     public void testDiagnoseOtherFilteringIssue() {


### PR DESCRIPTION
Backports the following commits to 8.3:
 - Add tier information on health api migrate tiers user actions (#87486)