### PR TITLE
[ML] Fix parsing of pytorch thread settings

### DIFF
--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/pytorch/results/ThreadSettings.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/pytorch/results/ThreadSettings.java
@@ -16,8 +16,8 @@ import java.io.IOException;
 
 public record ThreadSettings(int numThreadsPerAllocation, int numAllocations, String requestId) implements ToXContentObject {
 
-    private static final ParseField NUM_ALLOCATIONS = new ParseField("num_threads_per_allocation");
-    private static final ParseField NUM_THREADS_PER_ALLOCATION = new ParseField("num_allocations");
+    private static final ParseField NUM_ALLOCATIONS = new ParseField("num_allocations");
+    private static final ParseField NUM_THREADS_PER_ALLOCATION = new ParseField("num_threads_per_allocation");
 
     public static ConstructingObjectParser<ThreadSettings, Void> PARSER = new ConstructingObjectParser<>(
         "thread_settings",


### PR DESCRIPTION
During #86277 an error was introduced in parsing of pytorch
thread settings. This commit fixes the issue.
