### PR TITLE
Add troubleshooting doc for missing tier

### DIFF
--- a/docs/reference/tab-widgets/troubleshooting/data/add-tier-widget.asciidoc
+++ b/docs/reference/tab-widgets/troubleshooting/data/add-tier-widget.asciidoc
@@ -1,0 +1,40 @@
+++++
+<div class="tabs" data-tab-group="host">
+  <div role="tablist" aria-label="Enable tier">
+    <button role="tab"
+            aria-selected="true"
+            aria-controls="cloud-tab-enable-tier"
+            id="cloud-enable-tier">
+      Elasticsearch Service
+    </button>
+    <button role="tab"
+            aria-selected="false"
+            aria-controls="self-managed-tab-enable-tier"
+            id="self-managed-enable-tier"
+            tabindex="-1">
+      Self-managed
+    </button>
+  </div>
+  <div tabindex="0"
+       role="tabpanel"
+       id="cloud-tab-enable-tier"
+       aria-labelledby="cloud-enable-tier">
+++++
+
+include::add-tier.asciidoc[tag=cloud]
+
+++++
+  </div>
+  <div tabindex="0"
+       role="tabpanel"
+       id="self-managed-tab-enable-tier"
+       aria-labelledby="self-managed-enable-tier"
+       hidden="">
+++++
+
+include::add-tier.asciidoc[tag=self-managed]
+
+++++
+  </div>
+</div>
+++++

--- a/docs/reference/tab-widgets/troubleshooting/data/add-tier.asciidoc
+++ b/docs/reference/tab-widgets/troubleshooting/data/add-tier.asciidoc
@@ -90,7 +90,7 @@ In order to get the shards assigned you can add more nodes to your {es} cluster
 and assign the index's target tier <<assign-data-tier, node role>> to the new 
 nodes. 
 
-To inspect which tier is an index targeting for assignment, use the <<indices-get-settings, get index setting>>
+To determine which tier an index requires for assignment, use the <<indices-get-settings, get index setting>>
 API to retrieve the configured value for the `index.routing.allocation.include._tier_preference`
 setting:
 

--- a/docs/reference/tab-widgets/troubleshooting/data/add-tier.asciidoc
+++ b/docs/reference/tab-widgets/troubleshooting/data/add-tier.asciidoc
@@ -1,0 +1,128 @@
+//////////////////////////
+
+[source,console]
+--------------------------------------------------
+PUT my-index-000001
+
+--------------------------------------------------
+// TESTSETUP
+
+[source,console]
+--------------------------------------------------
+DELETE my-index-000001
+--------------------------------------------------
+// TEARDOWN
+
+//////////////////////////
+
+
+// tag::cloud[]
+In order to get the shards assigned we need enable a new tier in the deployment.
+
+**Use {kib}**
+
+//tag::kibana-api-ex[]
+. Log in to the {ess-console}[{ecloud} console].
++
+
+. On the **Elasticsearch Service** panel, click the name of your deployment. 
++
+
+NOTE:
+If the name of your deployment is disabled your {kib} instances might be
+unhealthy, in which case please contact https://support.elastic.co[Elastic Support].
+If your deployment doesn't include {kib}, all you need to do is 
+{cloud}/ec-access-kibana.html[enable it first].
+
+. Open your deployment's side navigation menu (placed under the Elastic logo in the upper left corner)
+and go to **Dev Tools > Console**.
++
+[role="screenshot"]
+image::images/kibana-console.png[{kib} Console,align="center"]
+
+. Inspect which tier is an index targeting for assignment. <<indices-get-settings, Retrieve>>
+the configured value for the `index.routing.allocation.include._tier_preference`
+setting:
++
+[source,console]
+----
+GET /my-index-000001/_settings/index.routing.allocation.include._tier_preference?flat_settings
+----
+// TEST[continued]
++
+The reponse will look like this:
++
+[source,console-result]
+----
+{
+  "my-index-000001": {
+    "settings": {
+      "index.routing.allocation.include._tier_preference": "data_warm,data_hot" <1>
+    }
+  }
+}
+----
+// TESTRESPONSE[skip:the result is for illustrating purposes only]
++
+<1> Represents a comma separated list of data tier node roles this index is allowed
+to be allocated on, the first one in the list being the one with the higher priority
+i.e. the tier the index is targeting.
+e.g. in this example the tier preference is `data_warm,data_hot` so the index is
+targeting the `warm` tier and more nodes with the `data_warm` role are needed in
+the {es} cluster.
+
+. Open your deployment's side navigation menu (placed under the Elastic logo in the upper left corner)
+and go to **Manage this deployment**.
+
+. From the right hand side, click to expand the **Manage** dropdown button and
+select **Edit deployment** from the list of options.
+
+. On the **Edit** page, click on **+ Add Capacity** for the tier you identified
+you need to enable in your deployment. Choose the desired size and availability
+zones for the new tier.
+
+. Navigate to the bottom of the page and click the **Save** button.
+
+//end::kibana-api-ex[]
+// end::cloud[]
+
+// tag::self-managed[]
+In order to get the shards assigned you can add more nodes to your {es} cluster 
+and assign the index's target tier <<assign-data-tier, node role>> to the new 
+nodes. 
+
+To inspect which tier is an index targeting for assignment, use the <<indices-get-settings, get index setting>>
+API to retrieve the configured value for the `index.routing.allocation.include._tier_preference`
+setting:
+
+[source,console]
+----
+GET /my-index-000001/_settings/index.routing.allocation.include._tier_preference?flat_settings
+----
+// TEST[continued]
+
+
+The reponse will look like this:
+
+[source,console-result]
+----
+{
+  "my-index-000001": {
+    "settings": {
+      "index.routing.allocation.include._tier_preference": "data_warm,data_hot" <1>
+    }
+  }
+}
+----
+// TESTRESPONSE[skip:the result is for illustrating purposes only]
+
+
+<1> Represents a comma separated list of data tier node roles this index is allowed
+to be allocated on, the first one in the list being the one with the higher priority
+i.e. the tier the index is targeting.
+e.g. in this example the tier preference is `data_warm,data_hot` so the index is
+targeting the `warm` tier and more nodes with the `data_warm` role are needed in
+the {es} cluster.
+
+// end::self-managed[]
+

--- a/docs/reference/tab-widgets/troubleshooting/data/add-tier.asciidoc
+++ b/docs/reference/tab-widgets/troubleshooting/data/add-tier.asciidoc
@@ -63,7 +63,7 @@ The reponse will look like this:
 ----
 // TESTRESPONSE[skip:the result is for illustrating purposes only]
 +
-<1> Represents a comma separated list of data tier node roles this index is allowed
+<1> Represents a comma-separated list of data tier node roles this index is allowed
 to be allocated on, the first one in the list being the one with the higher priority
 i.e. the tier the index is targeting.
 e.g. in this example the tier preference is `data_warm,data_hot` so the index is

--- a/docs/reference/tab-widgets/troubleshooting/data/add-tier.asciidoc
+++ b/docs/reference/tab-widgets/troubleshooting/data/add-tier.asciidoc
@@ -40,7 +40,7 @@ and go to **Dev Tools > Console**.
 [role="screenshot"]
 image::images/kibana-console.png[{kib} Console,align="center"]
 
-. Inspect which tier is an index targeting for assignment. <<indices-get-settings, Retrieve>>
+. Determine which tier an index expects for assignment. <<indices-get-settings, Retrieve>>
 the configured value for the `index.routing.allocation.include._tier_preference`
 setting:
 +

--- a/docs/reference/tab-widgets/troubleshooting/data/add-tier.asciidoc
+++ b/docs/reference/tab-widgets/troubleshooting/data/add-tier.asciidoc
@@ -116,7 +116,7 @@ The reponse will look like this:
 // TESTRESPONSE[skip:the result is for illustrating purposes only]
 
 
-<1> Represents a comma separated list of data tier node roles this index is allowed
+<1> Represents a comma-separated list of data tier node roles this index is allowed
 to be allocated on, the first one in the list being the one with the higher priority
 i.e. the tier the index is targeting.
 e.g. in this example the tier preference is `data_warm,data_hot` so the index is

--- a/docs/reference/tab-widgets/troubleshooting/data/add-tier.asciidoc
+++ b/docs/reference/tab-widgets/troubleshooting/data/add-tier.asciidoc
@@ -48,7 +48,6 @@ setting:
 ----
 GET /my-index-000001/_settings/index.routing.allocation.include._tier_preference?flat_settings
 ----
-// TEST[continued]
 +
 The reponse will look like this:
 +

--- a/docs/reference/troubleshooting.asciidoc
+++ b/docs/reference/troubleshooting.asciidoc
@@ -44,6 +44,8 @@ include::troubleshooting/data/enable-cluster-allocation.asciidoc[]
 
 include::troubleshooting/data/data-tiers-mixed-with-node-attr.asciidoc[]
 
+include::troubleshooting/data/add-tier.asciidoc[]
+
 include::troubleshooting/data/diagnose-unassigned-shards.asciidoc[]
 
 include::monitoring/troubleshooting.asciidoc[]

--- a/docs/reference/troubleshooting/data/add-tier.asciidoc
+++ b/docs/reference/troubleshooting/data/add-tier.asciidoc
@@ -1,7 +1,7 @@
 [[add-tier]]
 == Add a missing tier to the system
 
-The allocation of data in an {es} deployment can be targeted towards <<data-tiers, data tiers>>.
+The allocation of indices in an {es} deployment can be allocated on <<data-tiers, data tiers>>.
 
 In order to allow data to be allocated follow these steps to add the <<data-tiers, data tier>>
 they target to your deployment:

--- a/docs/reference/troubleshooting/data/add-tier.asciidoc
+++ b/docs/reference/troubleshooting/data/add-tier.asciidoc
@@ -1,0 +1,12 @@
+[[add-tier]]
+== Add a missing tier to the system
+
+The allocation of data in an {es} deployment can be targeted towards <<data-tiers, data tiers>>.
+
+In order to allow data to be allocated follow these steps to add the <<data-tiers, data tier>>
+they target to your deployment:
+
+include::{es-repo-dir}/tab-widgets/troubleshooting/data/add-tier-widget.asciidoc[]
+
+
+

--- a/docs/reference/troubleshooting/data/add-tier.asciidoc
+++ b/docs/reference/troubleshooting/data/add-tier.asciidoc
@@ -3,8 +3,8 @@
 
 The allocation of indices in an {es} deployment can be allocated on <<data-tiers, data tiers>>.
 
-In order to allow data to be allocated follow these steps to add the <<data-tiers, data tier>>
-they target to your deployment:
+In order to allow indices to be allocated, follow these steps to add the <<data-tiers, data tier>>
+the indices expect to be allocated on to your deployment:
 
 include::{es-repo-dir}/tab-widgets/troubleshooting/data/add-tier-widget.asciidoc[]
 


### PR DESCRIPTION
This adds a troubleshooting guide for the user action that identifies 
a tier is missing from the deployment.