### PR TITLE
[8.3] Mute CancellableRateLimitedFluxIteratorTests testCancellation (#87524)

### DIFF
--- a/modules/repository-azure/src/test/java/org/elasticsearch/repositories/azure/CancellableRateLimitedFluxIteratorTests.java
+++ b/modules/repository-azure/src/test/java/org/elasticsearch/repositories/azure/CancellableRateLimitedFluxIteratorTests.java
@@ -148,6 +148,7 @@ public class CancellableRateLimitedFluxIteratorTests extends ESTestCase {
         iterator.cancel();
     }
 
+    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/87112")
     public void testCancellation() throws Exception {
         int requestedElements = 4;
         final AtomicBoolean cancelled = new AtomicBoolean();


### PR DESCRIPTION
Backports the following commits to 8.3:
 - Mute CancellableRateLimitedFluxIteratorTests testCancellation (#87524)