### PR TITLE
[ML] fixes inference timeout handling bug that throws unexpected NullPointerException

### DIFF
--- a/docs/changelog/87533.yaml
+++ b/docs/changelog/87533.yaml
@@ -1,0 +1,5 @@
+pr: 87533
+summary: Fixes inference timeout handling bug that throws unexpected `NullPointerException`
+area: Machine Learning
+type: bug
+issues: []

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/process/AbstractInitializableRunnable.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/process/AbstractInitializableRunnable.java
@@ -1,0 +1,17 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.ml.job.process;
+
+import org.elasticsearch.common.util.concurrent.AbstractRunnable;
+
+/**
+ * Abstract runnable that has an `init` function that can be called when passed to an executor
+ */
+public abstract class AbstractInitializableRunnable extends AbstractRunnable {
+    public abstract void init();
+}

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/process/ProcessWorkerExecutorService.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/process/ProcessWorkerExecutorService.java
@@ -33,6 +33,9 @@ public class ProcessWorkerExecutorService extends AbstractProcessWorkerExecutorS
 
     @Override
     public synchronized void execute(Runnable command) {
+        if (command instanceof AbstractInitializableRunnable initializableRunnable) {
+            initializableRunnable.init();
+        }
         if (isShutdown()) {
             EsRejectedExecutionException rejected = new EsRejectedExecutionException(processName + " worker service has shutdown", true);
             if (command instanceof AbstractRunnable runnable) {

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/deployment/ControlMessagePyTorchActionTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/deployment/ControlMessagePyTorchActionTests.java
@@ -65,7 +65,7 @@ public class ControlMessagePyTorchActionTests extends ESTestCase {
                 tp,
                 listener
             );
-
+            action.init();
             action.onTimeout();
             action.run();
             verify(resultProcessor, times(1)).ignoreResponseWithoutNotifying("1");
@@ -84,6 +84,7 @@ public class ControlMessagePyTorchActionTests extends ESTestCase {
                 tp,
                 listener
             );
+            action.init();
 
             action.onFailure(new IllegalStateException());
             action.run();
@@ -122,6 +123,7 @@ public class ControlMessagePyTorchActionTests extends ESTestCase {
             tp,
             listener
         );
+        action.init();
 
         action.run();
 

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/deployment/DeploymentManagerTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/deployment/DeploymentManagerTests.java
@@ -9,7 +9,6 @@ package org.elasticsearch.xpack.ml.inference.deployment;
 
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.client.internal.Client;
-import org.elasticsearch.common.util.concurrent.AbstractRunnable;
 import org.elasticsearch.common.util.concurrent.EsRejectedExecutionException;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.test.ESTestCase;
@@ -31,9 +30,6 @@ import static org.elasticsearch.xpack.ml.MachineLearning.JOB_COMMS_THREAD_POOL_N
 import static org.elasticsearch.xpack.ml.MachineLearning.UTILITY_THREAD_POOL_NAME;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.instanceOf;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyLong;
-import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -74,6 +70,7 @@ public class DeploymentManagerTests extends ESTestCase {
         Long taskId = 1L;
         when(task.getId()).thenReturn(taskId);
         when(task.isStopped()).thenReturn(Boolean.FALSE);
+        when(task.getModelId()).thenReturn("test-rejected");
 
         DeploymentManager deploymentManager = new DeploymentManager(
             mock(Client.class),
@@ -82,9 +79,12 @@ public class DeploymentManagerTests extends ESTestCase {
             mock(PyTorchProcessFactory.class)
         );
 
-        PriorityProcessWorkerExecutorService executorService = mock(PriorityProcessWorkerExecutorService.class);
-        doThrow(new EsRejectedExecutionException("mock executor rejection")).when(executorService)
-            .executeWithPriority(any(AbstractRunnable.class), any(), anyLong());
+        PriorityProcessWorkerExecutorService executorService = new PriorityProcessWorkerExecutorService(
+            tp.getThreadContext(),
+            "test reject",
+            10
+        );
+        executorService.shutdown();
 
         AtomicInteger rejectedCount = new AtomicInteger();
 

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/deployment/InferencePyTorchActionTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/deployment/InferencePyTorchActionTests.java
@@ -75,7 +75,7 @@ public class InferencePyTorchActionTests extends ESTestCase {
             tp,
             listener
         );
-
+        action.init();
         action.onSuccess(new WarningInferenceResults("foo"));
         for (int i = 0; i < 10; i++) {
             action.onSuccess(new WarningInferenceResults("foo"));
@@ -95,7 +95,7 @@ public class InferencePyTorchActionTests extends ESTestCase {
             tp,
             listener
         );
-
+        action.init();
         action.onTimeout();
         for (int i = 0; i < 10; i++) {
             action.onSuccess(new WarningInferenceResults("foo"));
@@ -116,7 +116,7 @@ public class InferencePyTorchActionTests extends ESTestCase {
             tp,
             listener
         );
-
+        action.init();
         action.onFailure(new Exception("bar"));
         for (int i = 0; i < 10; i++) {
             action.onSuccess(new WarningInferenceResults("foo"));
@@ -146,7 +146,7 @@ public class InferencePyTorchActionTests extends ESTestCase {
                 tp,
                 listener
             );
-
+            action.init();
             action.onTimeout();
             action.run();
             verify(resultProcessor, times(1)).ignoreResponseWithoutNotifying("1");
@@ -163,7 +163,7 @@ public class InferencePyTorchActionTests extends ESTestCase {
                 tp,
                 listener
             );
-
+            action.init();
             action.onFailure(new IllegalStateException());
             action.run();
             verify(resultProcessor, never()).registerRequest(anyString(), any());

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/process/ProcessWorkerExecutorServiceTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/process/ProcessWorkerExecutorServiceTests.java
@@ -42,11 +42,17 @@ public class ProcessWorkerExecutorServiceTests extends ESTestCase {
         threadPool.generic().execute(executor::start);
         executor.shutdown();
         AtomicBoolean rejected = new AtomicBoolean(false);
-        executor.execute(new AbstractRunnable() {
+        AtomicBoolean initialized = new AtomicBoolean(false);
+        executor.execute(new AbstractInitializableRunnable() {
             @Override
             public void onRejection(Exception e) {
                 assertThat(e, isA(EsRejectedExecutionException.class));
                 rejected.set(true);
+            }
+
+            @Override
+            public void init() {
+                initialized.set(true);
             }
 
             @Override
@@ -61,6 +67,7 @@ public class ProcessWorkerExecutorServiceTests extends ESTestCase {
         });
 
         assertTrue(rejected.get());
+        assertTrue(initialized.get());
     }
 
     public void testAutodetectWorkerExecutorService_TasksNotExecutedCallHandlerOnShutdown() throws Exception {


### PR DESCRIPTION
The timeout thread was being scheduled to be executed before all the requisite fields were populated. 

This would (usually only in extreme circumstances), would throw a null pointer exception that looked like:

```
2022-06-06T23:40:42,534][ERROR][o.e.b.ElasticsearchUncaughtExceptionHandler] [javaRestTest-2] uncaught exception in thread [elasticsearch[javaRestTest-2][ml_utility][T#4]]
java.lang.NullPointerException: Cannot invoke "org.elasticsearch.xpack.ml.inference.deployment.DeploymentManager$ProcessContext.getTimeoutCount()" because "this.processContext" is null
	at org.elasticsearch.xpack.ml.inference.deployment.AbstractPyTorchAction.onTimeout(AbstractPyTorchAction.java:58) ~[?:?]
	at org.elasticsearch.common.util.concurrent.ThreadContext$ContextPreservingRunnable.run(ThreadContext.java:709) ~[elasticsearch-8.4.0-SNAPSHOT.jar:?]
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136) ~[?:?]
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635) ~[?:?]
	at java.lang.Thread.run(Thread.java:833) [?:?]
```

This PR fixes this bug and an additional (more minor) bug where inference call rejections were not accurately counted.

closes: https://github.com/elastic/elasticsearch/issues/87457