### PR TITLE
Fix test in synthetic source

### DIFF
--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search/400_synthetic_source.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search/400_synthetic_source.yml
@@ -96,6 +96,8 @@ force_synthetic_source_bad_mapping:
       indices.create:
         index: test
         body:
+          settings:
+            number_of_shards: 1 # Use a single shard to get consistent error messages
           mappings:
             _source:
               synthetic: false


### PR DESCRIPTION
Fixes a test for forcing synthetic source that sometimes fails if the
index has more than one shard. We're just looking for a sensible failure
message here so we can lock it to one shard.
