### PR TITLE
Remove ImmutableOpenMap from autoscaling

### DIFF
--- a/x-pack/plugin/autoscaling/src/main/java/org/elasticsearch/xpack/autoscaling/capacity/memory/AutoscalingMemoryInfoService.java
+++ b/x-pack/plugin/autoscaling/src/main/java/org/elasticsearch/xpack/autoscaling/capacity/memory/AutoscalingMemoryInfoService.java
@@ -20,7 +20,6 @@ import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.DiscoveryNodeRole;
 import org.elasticsearch.cluster.service.ClusterService;
-import org.elasticsearch.common.collect.ImmutableOpenMap;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.core.TimeValue;
@@ -28,12 +27,17 @@ import org.elasticsearch.xpack.autoscaling.AutoscalingMetadata;
 import org.elasticsearch.xpack.autoscaling.policy.AutoscalingPolicy;
 import org.elasticsearch.xpack.autoscaling.policy.AutoscalingPolicyMetadata;
 
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Set;
 import java.util.SortedSet;
 import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
+
+import static java.util.stream.Collectors.toUnmodifiableMap;
 
 public class AutoscalingMemoryInfoService {
     public static final Setting<TimeValue> FETCH_TIMEOUT = Setting.timeSetting(
@@ -46,7 +50,7 @@ public class AutoscalingMemoryInfoService {
 
     private static final Logger logger = LogManager.getLogger(AutoscalingMemoryInfoService.class);
 
-    private volatile ImmutableOpenMap<String, Long> nodeToMemory = ImmutableOpenMap.<String, Long>builder().build();
+    private volatile Map<String, Long> nodeToMemory = Map.of();
     private volatile TimeValue fetchTimeout;
 
     private final Client client;
@@ -54,7 +58,6 @@ public class AutoscalingMemoryInfoService {
 
     @Inject
     public AutoscalingMemoryInfoService(ClusterService clusterService, Client client) {
-
         this.client = client;
         this.fetchTimeout = FETCH_TIMEOUT.get(clusterService.getSettings());
         if (DiscoveryNode.isMasterNode(clusterService.getSettings())) {
@@ -95,10 +98,9 @@ public class AutoscalingMemoryInfoService {
                 .filter(dn -> nodeToMemory.containsKey(dn.getEphemeralId()) == false)
                 .collect(Collectors.toSet());
             if (missingNodes.size() > 0) {
-                ImmutableOpenMap.Builder<String, Long> builder = ImmutableOpenMap.<String, Long>builder(nodeToMemory);
+                var builder = new HashMap<>(nodeToMemory);
                 missingNodes.stream().map(DiscoveryNode::getEphemeralId).forEach(id -> builder.put(id, FETCHING_SENTINEL));
-                nodeToMemory = builder.build();
-
+                nodeToMemory = Collections.unmodifiableMap(builder);
                 return missingNodes;
             }
         }
@@ -117,7 +119,7 @@ public class AutoscalingMemoryInfoService {
                     @Override
                     public void onResponse(NodesStatsResponse nodesStatsResponse) {
                         synchronized (mutex) {
-                            ImmutableOpenMap.Builder<String, Long> builder = ImmutableOpenMap.<String, Long>builder(nodeToMemory);
+                            Map<String, Long> builder = new HashMap<>(nodeToMemory);
                             nodesStatsResponse.failures()
                                 .stream()
                                 .map(FailedNodeException::nodeId)
@@ -126,16 +128,16 @@ public class AutoscalingMemoryInfoService {
                                 .forEach(builder::remove);
 
                             nodesStatsResponse.getNodes().forEach(nodeStats -> addNodeStats(builder, nodeStats));
-                            nodeToMemory = builder.build();
+                            nodeToMemory = Collections.unmodifiableMap(builder);
                         }
                     }
 
                     @Override
                     public void onFailure(Exception e) {
                         synchronized (mutex) {
-                            ImmutableOpenMap.Builder<String, Long> builder = ImmutableOpenMap.<String, Long>builder(nodeToMemory);
+                            var builder = new HashMap<>(nodeToMemory);
                             missingNodes.stream().map(DiscoveryNode::getEphemeralId).forEach(builder::remove);
-                            nodeToMemory = builder.build();
+                            nodeToMemory = Collections.unmodifiableMap(builder);
                         }
 
                         logger.warn("Unable to obtain memory info from [{}]", missingNodes);
@@ -169,20 +171,18 @@ public class AutoscalingMemoryInfoService {
             .filter(Predicate.not(ephemeralIds::contains))
             .collect(Collectors.toSet());
         if (toRemove.isEmpty() == false) {
-            ImmutableOpenMap.Builder<String, Long> builder = ImmutableOpenMap.<String, Long>builder(nodeToMemory);
-            builder.removeAll(toRemove::contains);
-            nodeToMemory = builder.build();
+            nodeToMemory = nodeToMemory.entrySet().stream().filter(n -> toRemove.contains(n.getKey()) == false).collect(toUnmodifiableMap(Map.Entry::getKey, Map.Entry::getValue));
         }
     }
 
-    private void addNodeStats(ImmutableOpenMap.Builder<String, Long> builder, NodeStats nodeStats) {
+    private void addNodeStats(Map<String, Long> builder, NodeStats nodeStats) {
         // we might add nodes that already died here, but those will be removed on next cluster state update anyway and is only a small
         // waste.
         builder.put(nodeStats.getNode().getEphemeralId(), nodeStats.getOs().getMem().getAdjustedTotal().getBytes());
     }
 
     public AutoscalingMemoryInfo snapshot() {
-        final ImmutableOpenMap<String, Long> nodeToMemoryRef = this.nodeToMemory;
+        final Map<String, Long> nodeToMemoryRef = this.nodeToMemory;
         return node -> {
             Long result = nodeToMemoryRef.get(node.getEphemeralId());
             // noinspection NumberEquality

--- a/x-pack/plugin/autoscaling/src/main/java/org/elasticsearch/xpack/autoscaling/capacity/memory/AutoscalingMemoryInfoService.java
+++ b/x-pack/plugin/autoscaling/src/main/java/org/elasticsearch/xpack/autoscaling/capacity/memory/AutoscalingMemoryInfoService.java
@@ -171,7 +171,10 @@ public class AutoscalingMemoryInfoService {
             .filter(Predicate.not(ephemeralIds::contains))
             .collect(Collectors.toSet());
         if (toRemove.isEmpty() == false) {
-            nodeToMemory = nodeToMemory.entrySet().stream().filter(n -> toRemove.contains(n.getKey()) == false).collect(toUnmodifiableMap(Map.Entry::getKey, Map.Entry::getValue));
+            nodeToMemory = nodeToMemory.entrySet()
+                .stream()
+                .filter(n -> toRemove.contains(n.getKey()) == false)
+                .collect(toUnmodifiableMap(Map.Entry::getKey, Map.Entry::getValue));
         }
     }
 

--- a/x-pack/plugin/autoscaling/src/main/java/org/elasticsearch/xpack/autoscaling/storage/ReactiveStorageDeciderService.java
+++ b/x-pack/plugin/autoscaling/src/main/java/org/elasticsearch/xpack/autoscaling/storage/ReactiveStorageDeciderService.java
@@ -477,7 +477,7 @@ public class ReactiveStorageDeciderService implements AutoscalingDeciderService 
                 metadataBuilder.put(updatedDataStream);
             }
 
-            public void applySize(ImmutableOpenMap.Builder<String, Long> builder, RoutingTable updatedRoutingTable) {
+            public void applySize(Map<String, Long> builder, RoutingTable updatedRoutingTable) {
                 for (Map.Entry<IndexMetadata, Long> entry : additionalIndices.entrySet()) {
                     List<ShardRouting> shardRoutings = updatedRoutingTable.allShards(entry.getKey().getIndex().getName());
                     long size = entry.getValue() / shardRoutings.size();
@@ -508,13 +508,13 @@ public class ReactiveStorageDeciderService implements AutoscalingDeciderService 
             }
             Metadata.Builder metadataBuilder = Metadata.builder(state.metadata());
             RoutingTable.Builder routingTableBuilder = RoutingTable.builder(state.routingTable());
-            ImmutableOpenMap.Builder<String, Long> sizeBuilder = ImmutableOpenMap.builder();
+            Map<String, Long> sizeBuilder = new HashMap<>();
             singleForecasts.forEach(p -> p.applyMetadata(metadataBuilder));
             singleForecasts.forEach(p -> p.applyRouting(routingTableBuilder));
             RoutingTable routingTable = routingTableBuilder.build();
             singleForecasts.forEach(p -> p.applySize(sizeBuilder, routingTable));
             ClusterState forecastClusterState = ClusterState.builder(state).metadata(metadataBuilder).routingTable(routingTable).build();
-            ClusterInfo forecastInfo = new ExtendedClusterInfo(sizeBuilder.build(), AllocationState.this.info);
+            ClusterInfo forecastInfo = new ExtendedClusterInfo(Collections.unmodifiableMap(sizeBuilder), AllocationState.this.info);
 
             return new AllocationState(
                 forecastClusterState,

--- a/x-pack/plugin/autoscaling/src/main/java/org/elasticsearch/xpack/autoscaling/storage/ReactiveStorageDeciderService.java
+++ b/x-pack/plugin/autoscaling/src/main/java/org/elasticsearch/xpack/autoscaling/storage/ReactiveStorageDeciderService.java
@@ -34,7 +34,6 @@ import org.elasticsearch.cluster.routing.allocation.decider.FilterAllocationDeci
 import org.elasticsearch.cluster.routing.allocation.decider.SameShardAllocationDecider;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.UUIDs;
-import org.elasticsearch.common.collect.ImmutableOpenMap;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.settings.ClusterSettings;


### PR DESCRIPTION
Autoscaling uses ImmutableOpenMap to keep track of the memory used on
each node. A Map should work just fine here. Note that the wrapper
Collections.unmodifiableMap is used because of the way modifications are
made to the map. Map.copyOf could be used, but it's unclear if the extra
indirection is worse than the extra copying since this should not be
changing or being accessed in any hot loops.

relates #86239