### PR TITLE
Move test-only code from RoutingNode to tests module

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/routing/RoutingNodes.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/RoutingNodes.java
@@ -33,7 +33,6 @@ import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.ListIterator;
 import java.util.Map;
@@ -105,12 +104,12 @@ public class RoutingNodes extends AbstractCollection<RoutingNode> {
         nodesToShards = Maps.newMapWithExpectedSize(discoveryNodes.getDataNodes().size());
         // fill in the nodeToShards with the "live" nodes
         for (var node : discoveryNodes.getDataNodes().keySet()) {
-            nodesToShards.put(node, new RoutingNode(node, discoveryNodes.get(node), new LinkedHashMap<>()));
+            nodesToShards.put(node, new RoutingNode(node, discoveryNodes.get(node)));
         }
 
         // fill in the inverse of node -> shards allocated
         // also fill replicaSet information
-        final Function<String, RoutingNode> createRoutingNode = k -> new RoutingNode(k, discoveryNodes.get(k), new LinkedHashMap<>());
+        final Function<String, RoutingNode> createRoutingNode = k -> new RoutingNode(k, discoveryNodes.get(k));
         for (IndexRoutingTable indexRoutingTable : routingTable.indicesRouting().values()) {
             for (int shardId = 0; shardId < indexRoutingTable.size(); shardId++) {
                 IndexShardRoutingTable indexShard = indexRoutingTable.shard(shardId);

--- a/server/src/test/java/org/elasticsearch/cluster/routing/RoutingNodeTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/RoutingNodeTests.java
@@ -43,7 +43,7 @@ public class RoutingNodeTests extends ESTestCase {
         InetAddress inetAddress = InetAddress.getByAddress("name1", new byte[] { (byte) 192, (byte) 168, (byte) 0, (byte) 1 });
         TransportAddress transportAddress = new TransportAddress(inetAddress, randomIntBetween(0, 65535));
         DiscoveryNode discoveryNode = new DiscoveryNode("name1", "node-1", transportAddress, emptyMap(), emptySet(), Version.CURRENT);
-        routingNode = new RoutingNode("node1", discoveryNode, unassignedShard0, initializingShard0, relocatingShard0);
+        routingNode = RoutingNodesHelper.routingNode("node1", discoveryNode, unassignedShard0, initializingShard0, relocatingShard0);
     }
 
     public void testAdd() {

--- a/server/src/test/java/org/elasticsearch/cluster/routing/allocation/NodeVersionAllocationDeciderTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/allocation/NodeVersionAllocationDeciderTests.java
@@ -26,6 +26,7 @@ import org.elasticsearch.cluster.routing.RecoverySource.SnapshotRecoverySource;
 import org.elasticsearch.cluster.routing.RoutingChangesObserver;
 import org.elasticsearch.cluster.routing.RoutingNode;
 import org.elasticsearch.cluster.routing.RoutingNodes;
+import org.elasticsearch.cluster.routing.RoutingNodesHelper;
 import org.elasticsearch.cluster.routing.RoutingTable;
 import org.elasticsearch.cluster.routing.ShardRouting;
 import org.elasticsearch.cluster.routing.ShardRoutingHelper;
@@ -578,8 +579,8 @@ public class NodeVersionAllocationDeciderTests extends ESAllocationTestCase {
 
         RoutingTable initialRoutingTable = RoutingTable.builder().addAsNew(metadata.index("test")).build();
 
-        RoutingNode newNode = new RoutingNode("newNode", newNode("newNode", Version.CURRENT));
-        RoutingNode oldNode = new RoutingNode("oldNode", newNode("oldNode", VersionUtils.getPreviousVersion()));
+        RoutingNode newNode = RoutingNodesHelper.routingNode("newNode", newNode("newNode", Version.CURRENT));
+        RoutingNode oldNode = RoutingNodesHelper.routingNode("oldNode", newNode("oldNode", VersionUtils.getPreviousVersion()));
 
         final ClusterName clusterName = ClusterName.CLUSTER_NAME_SETTING.getDefault(Settings.EMPTY);
         ClusterState clusterState = ClusterState.builder(clusterName)

--- a/server/src/test/java/org/elasticsearch/cluster/routing/allocation/decider/AllocationDecidersTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/allocation/decider/AllocationDecidersTests.java
@@ -15,6 +15,7 @@ import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.routing.RecoverySource;
 import org.elasticsearch.cluster.routing.RoutingNode;
+import org.elasticsearch.cluster.routing.RoutingNodesHelper;
 import org.elasticsearch.cluster.routing.ShardRouting;
 import org.elasticsearch.cluster.routing.UnassignedInfo;
 import org.elasticsearch.cluster.routing.allocation.RoutingAllocation;
@@ -91,7 +92,7 @@ public class AllocationDecidersTests extends ESTestCase {
         );
         IndexMetadata idx = IndexMetadata.builder("idx").settings(settings(Version.CURRENT)).numberOfShards(1).numberOfReplicas(0).build();
 
-        RoutingNode routingNode = new RoutingNode("testNode", null);
+        RoutingNode routingNode = RoutingNodesHelper.routingNode("testNode", null);
         verify(deciders.canAllocate(shardRouting, routingNode, allocation), matcher);
         verify(deciders.canAllocate(idx, routingNode, allocation), matcher);
         verify(deciders.canAllocate(shardRouting, allocation), matcher);
@@ -214,7 +215,7 @@ public class AllocationDecidersTests extends ESTestCase {
             RecoverySource.ExistingStoreRecoverySource.INSTANCE,
             new UnassignedInfo(UnassignedInfo.Reason.INDEX_CREATED, "_message")
         );
-        final RoutingNode routingNode = new RoutingNode("testNode", null);
+        final RoutingNode routingNode = RoutingNodesHelper.routingNode("testNode", null);
         final ClusterState clusterState = ClusterState.builder(new ClusterName("test")).build();
         final IndexMetadata indexMetadata = IndexMetadata.builder("idx")
             .settings(settings(Version.CURRENT))

--- a/server/src/test/java/org/elasticsearch/cluster/routing/allocation/decider/DiskThresholdDeciderTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/allocation/decider/DiskThresholdDeciderTests.java
@@ -27,6 +27,7 @@ import org.elasticsearch.cluster.routing.IndexShardRoutingTable;
 import org.elasticsearch.cluster.routing.RecoverySource;
 import org.elasticsearch.cluster.routing.RoutingNode;
 import org.elasticsearch.cluster.routing.RoutingNodes;
+import org.elasticsearch.cluster.routing.RoutingNodesHelper;
 import org.elasticsearch.cluster.routing.RoutingTable;
 import org.elasticsearch.cluster.routing.ShardRouting;
 import org.elasticsearch.cluster.routing.ShardRoutingState;
@@ -651,7 +652,7 @@ public class DiskThresholdDeciderTests extends ESAllocationTestCase {
     }
 
     public void testAverageUsage() {
-        RoutingNode rn = new RoutingNode("node1", newNode("node1"));
+        RoutingNode rn = RoutingNodesHelper.routingNode("node1", newNode("node1"));
         DiskThresholdDecider decider = makeDecider(Settings.EMPTY);
 
         Map<String, DiskUsage> usages = new HashMap<>();
@@ -902,7 +903,7 @@ public class DiskThresholdDeciderTests extends ESAllocationTestCase {
         // Two shards consuming each 80% of disk space while 70% is allowed, so shard 0 isn't allowed here
         ShardRouting firstRouting = TestShardRouting.newShardRouting("test", 0, "node1", null, true, ShardRoutingState.STARTED);
         ShardRouting secondRouting = TestShardRouting.newShardRouting("test", 1, "node1", null, true, ShardRoutingState.STARTED);
-        RoutingNode firstRoutingNode = new RoutingNode("node1", discoveryNode1, firstRouting, secondRouting);
+        RoutingNode firstRoutingNode = RoutingNodesHelper.routingNode("node1", discoveryNode1, firstRouting, secondRouting);
         RoutingTable.Builder builder = RoutingTable.builder()
             .add(
                 IndexRoutingTable.builder(firstRouting.index())
@@ -934,7 +935,7 @@ public class DiskThresholdDeciderTests extends ESAllocationTestCase {
         firstRouting = TestShardRouting.newShardRouting("test", 0, "node1", null, true, ShardRoutingState.STARTED);
         secondRouting = TestShardRouting.newShardRouting("test", 1, "node1", "node2", true, ShardRoutingState.RELOCATING);
         ShardRouting fooRouting = TestShardRouting.newShardRouting("foo", 0, null, true, ShardRoutingState.UNASSIGNED);
-        firstRoutingNode = new RoutingNode("node1", discoveryNode1, firstRouting, secondRouting);
+        firstRoutingNode = RoutingNodesHelper.routingNode("node1", discoveryNode1, firstRouting, secondRouting);
         builder = RoutingTable.builder()
             .add(
                 IndexRoutingTable.builder(firstRouting.index())

--- a/server/src/test/java/org/elasticsearch/cluster/routing/allocation/decider/DiskThresholdDeciderUnitTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/allocation/decider/DiskThresholdDeciderUnitTests.java
@@ -23,6 +23,7 @@ import org.elasticsearch.cluster.routing.RecoverySource.EmptyStoreRecoverySource
 import org.elasticsearch.cluster.routing.RecoverySource.LocalShardsRecoverySource;
 import org.elasticsearch.cluster.routing.RecoverySource.PeerRecoverySource;
 import org.elasticsearch.cluster.routing.RoutingNode;
+import org.elasticsearch.cluster.routing.RoutingNodesHelper;
 import org.elasticsearch.cluster.routing.RoutingTable;
 import org.elasticsearch.cluster.routing.ShardRouting;
 import org.elasticsearch.cluster.routing.ShardRoutingHelper;
@@ -119,10 +120,10 @@ public class DiskThresholdDeciderUnitTests extends ESAllocationTestCase {
             System.nanoTime()
         );
         allocation.debugDecision(true);
-        Decision decision = decider.canAllocate(test_0, new RoutingNode("node_0", node_0), allocation);
+        Decision decision = decider.canAllocate(test_0, RoutingNodesHelper.routingNode("node_0", node_0), allocation);
         assertEquals(mostAvailableUsage.toString(), Decision.Type.YES, decision.type());
         assertThat(((Decision.Single) decision).getExplanation(), containsString("enough disk for shard on node"));
-        decision = decider.canAllocate(test_0, new RoutingNode("node_1", node_1), allocation);
+        decision = decider.canAllocate(test_0, RoutingNodesHelper.routingNode("node_1", node_1), allocation);
         assertEquals(mostAvailableUsage.toString(), Decision.Type.NO, decision.type());
         assertThat(
             ((Decision.Single) decision).getExplanation(),
@@ -197,7 +198,7 @@ public class DiskThresholdDeciderUnitTests extends ESAllocationTestCase {
             System.nanoTime()
         );
         allocation.debugDecision(true);
-        Decision decision = decider.canAllocate(test_0, new RoutingNode("node_0", node_0), allocation);
+        Decision decision = decider.canAllocate(test_0, RoutingNodesHelper.routingNode("node_0", node_0), allocation);
         assertEquals(Decision.Type.NO, decision.type());
 
         assertThat(
@@ -319,13 +320,13 @@ public class DiskThresholdDeciderUnitTests extends ESAllocationTestCase {
             System.nanoTime()
         );
         allocation.debugDecision(true);
-        Decision decision = decider.canRemain(test_0, new RoutingNode("node_0", node_0), allocation);
+        Decision decision = decider.canRemain(test_0, RoutingNodesHelper.routingNode("node_0", node_0), allocation);
         assertEquals(Decision.Type.YES, decision.type());
         assertThat(
             ((Decision.Single) decision).getExplanation(),
             containsString("there is enough disk on this node for the shard to remain, free: [10b]")
         );
-        decision = decider.canRemain(test_1, new RoutingNode("node_1", node_1), allocation);
+        decision = decider.canRemain(test_1, RoutingNodesHelper.routingNode("node_1", node_1), allocation);
         assertEquals(Decision.Type.NO, decision.type());
         assertThat(
             ((Decision.Single) decision).getExplanation(),
@@ -336,26 +337,26 @@ public class DiskThresholdDeciderUnitTests extends ESAllocationTestCase {
             )
         );
         try {
-            decider.canRemain(test_0, new RoutingNode("node_1", node_1), allocation);
+            decider.canRemain(test_0, RoutingNodesHelper.routingNode("node_1", node_1), allocation);
             fail("not allocated on this node");
         } catch (IllegalArgumentException ex) {
             // not allocated on that node
         }
         try {
-            decider.canRemain(test_1, new RoutingNode("node_0", node_0), allocation);
+            decider.canRemain(test_1, RoutingNodesHelper.routingNode("node_0", node_0), allocation);
             fail("not allocated on this node");
         } catch (IllegalArgumentException ex) {
             // not allocated on that node
         }
 
-        decision = decider.canRemain(test_2, new RoutingNode("node_1", node_1), allocation);
+        decision = decider.canRemain(test_2, RoutingNodesHelper.routingNode("node_1", node_1), allocation);
         assertEquals("can stay since allocated on a different path with enough space", Decision.Type.YES, decision.type());
         assertThat(
             ((Decision.Single) decision).getExplanation(),
             containsString("this shard is not allocated on the most utilized disk and can remain")
         );
 
-        decision = decider.canRemain(test_2, new RoutingNode("node_1", node_1), allocation);
+        decision = decider.canRemain(test_2, RoutingNodesHelper.routingNode("node_1", node_1), allocation);
         assertEquals("can stay since we don't have information about this shard", Decision.Type.YES, decision.type());
         assertThat(
             ((Decision.Single) decision).getExplanation(),
@@ -426,7 +427,7 @@ public class DiskThresholdDeciderUnitTests extends ESAllocationTestCase {
         assertEquals(100L, getExpectedShardSize(test_1, 0L, allocation));
         assertEquals(10L, getExpectedShardSize(test_0, 0L, allocation));
 
-        RoutingNode node = new RoutingNode(
+        RoutingNode node = RoutingNodesHelper.routingNode(
             "node1",
             new DiscoveryNode("node1", buildNewFakeTransportAddress(), emptyMap(), emptySet(), Version.CURRENT),
             test_0,
@@ -458,7 +459,7 @@ public class DiskThresholdDeciderUnitTests extends ESAllocationTestCase {
         other_0 = ShardRoutingHelper.moveToStarted(other_0);
         other_0 = ShardRoutingHelper.relocate(other_0, "node1");
 
-        node = new RoutingNode(
+        node = RoutingNodesHelper.routingNode(
             "node1",
             new DiscoveryNode("node1", buildNewFakeTransportAddress(), emptyMap(), emptySet(), Version.CURRENT),
             test_0,
@@ -757,7 +758,7 @@ public class DiskThresholdDeciderUnitTests extends ESAllocationTestCase {
             System.nanoTime()
         );
         allocation.debugDecision(true);
-        final RoutingNode routingNode = new RoutingNode("node_0", node_0);
+        final RoutingNode routingNode = RoutingNodesHelper.routingNode("node_0", node_0);
         Decision decision = decider.canAllocate(test_0, routingNode, allocation);
         assertThat(decision.type(), equalTo(Decision.Type.YES));
         assertThat(decision.getExplanation(), containsString("disk watermarks are ignored on this index"));
@@ -824,7 +825,7 @@ public class DiskThresholdDeciderUnitTests extends ESAllocationTestCase {
             System.nanoTime()
         );
         allocation.debugDecision(true);
-        Decision decision = decider.canForceAllocateDuringReplace(test_0, new RoutingNode("node_0", node_0), allocation);
+        Decision decision = decider.canForceAllocateDuringReplace(test_0, RoutingNodesHelper.routingNode("node_0", node_0), allocation);
         assertEquals(Decision.Type.NO, decision.type());
 
         assertThat(

--- a/server/src/test/java/org/elasticsearch/cluster/routing/allocation/decider/NodeReplacementAllocationDeciderTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/allocation/decider/NodeReplacementAllocationDeciderTests.java
@@ -21,6 +21,7 @@ import org.elasticsearch.cluster.node.DiscoveryNodeRole;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
 import org.elasticsearch.cluster.routing.RecoverySource;
 import org.elasticsearch.cluster.routing.RoutingNode;
+import org.elasticsearch.cluster.routing.RoutingNodesHelper;
 import org.elasticsearch.cluster.routing.ShardRouting;
 import org.elasticsearch.cluster.routing.UnassignedInfo;
 import org.elasticsearch.cluster.routing.allocation.AllocationService;
@@ -87,7 +88,7 @@ public class NodeReplacementAllocationDeciderTests extends ESAllocationTestCase 
 
         RoutingAllocation allocation = new RoutingAllocation(allocationDeciders, state, null, null, 0);
         DiscoveryNode node = randomFrom(NODE_A, NODE_B, NODE_C);
-        RoutingNode routingNode = new RoutingNode(node.getId(), node, shard);
+        RoutingNode routingNode = RoutingNodesHelper.routingNode(node.getId(), node, shard);
         allocation.debugDecision(true);
 
         Decision decision = decider.canAllocate(shard, routingNode, allocation);
@@ -102,7 +103,7 @@ public class NodeReplacementAllocationDeciderTests extends ESAllocationTestCase 
     public void testCanForceAllocate() {
         ClusterState state = prepareState(service.reroute(ClusterState.EMPTY_STATE, "initial state"), NODE_A.getId(), NODE_B.getName());
         RoutingAllocation allocation = new RoutingAllocation(allocationDeciders, state, null, null, 0);
-        RoutingNode routingNode = new RoutingNode(NODE_A.getId(), NODE_A, shard);
+        RoutingNode routingNode = RoutingNodesHelper.routingNode(NODE_A.getId(), NODE_A, shard);
         allocation.debugDecision(true);
 
         ShardRouting assignedShard = ShardRouting.newUnassigned(
@@ -121,7 +122,7 @@ public class NodeReplacementAllocationDeciderTests extends ESAllocationTestCase 
             equalTo("shard is not on the source of a node replacement relocated to the replacement target")
         );
 
-        routingNode = new RoutingNode(NODE_B.getId(), NODE_B, assignedShard);
+        routingNode = RoutingNodesHelper.routingNode(NODE_B.getId(), NODE_B, assignedShard);
 
         decision = decider.canForceAllocateDuringReplace(assignedShard, routingNode, allocation);
         assertThat(decision.type(), equalTo(Decision.Type.YES));
@@ -132,7 +133,7 @@ public class NodeReplacementAllocationDeciderTests extends ESAllocationTestCase 
             )
         );
 
-        routingNode = new RoutingNode(NODE_C.getId(), NODE_C, assignedShard);
+        routingNode = RoutingNodesHelper.routingNode(NODE_C.getId(), NODE_C, assignedShard);
 
         decision = decider.canForceAllocateDuringReplace(assignedShard, routingNode, allocation);
         assertThat(decision.type(), equalTo(Decision.Type.NO));
@@ -145,7 +146,7 @@ public class NodeReplacementAllocationDeciderTests extends ESAllocationTestCase 
     public void testCannotRemainOnReplacedNode() {
         ClusterState state = prepareState(service.reroute(ClusterState.EMPTY_STATE, "initial state"), NODE_A.getId(), NODE_B.getName());
         RoutingAllocation allocation = new RoutingAllocation(allocationDeciders, state, null, null, 0);
-        RoutingNode routingNode = new RoutingNode(NODE_A.getId(), NODE_A, shard);
+        RoutingNode routingNode = RoutingNodesHelper.routingNode(NODE_A.getId(), NODE_A, shard);
         allocation.debugDecision(true);
 
         Decision decision = decider.canRemain(shard, routingNode, allocation);
@@ -155,13 +156,13 @@ public class NodeReplacementAllocationDeciderTests extends ESAllocationTestCase 
             equalTo("node [" + NODE_A.getId() + "] is being replaced by node [" + NODE_B.getId() + "], so no data may remain on it")
         );
 
-        routingNode = new RoutingNode(NODE_B.getId(), NODE_B, shard);
+        routingNode = RoutingNodesHelper.routingNode(NODE_B.getId(), NODE_B, shard);
 
         decision = decider.canRemain(shard, routingNode, allocation);
         assertThat(decision.type(), equalTo(Decision.Type.YES));
         assertThat(decision.getExplanation(), equalTo("node [" + NODE_B.getId() + "] is not being replaced"));
 
-        routingNode = new RoutingNode(NODE_C.getId(), NODE_C, shard);
+        routingNode = RoutingNodesHelper.routingNode(NODE_C.getId(), NODE_C, shard);
 
         decision = decider.canRemain(shard, routingNode, allocation);
         assertThat(decision.type(), equalTo(Decision.Type.YES));
@@ -171,7 +172,7 @@ public class NodeReplacementAllocationDeciderTests extends ESAllocationTestCase 
     public void testCanAllocateToNeitherSourceNorTarget() {
         ClusterState state = prepareState(service.reroute(ClusterState.EMPTY_STATE, "initial state"), NODE_A.getId(), NODE_B.getName());
         RoutingAllocation allocation = new RoutingAllocation(allocationDeciders, state, null, null, 0);
-        RoutingNode routingNode = new RoutingNode(NODE_A.getId(), NODE_A, shard);
+        RoutingNode routingNode = RoutingNodesHelper.routingNode(NODE_A.getId(), NODE_A, shard);
         allocation.debugDecision(true);
 
         ShardRouting testShard = this.shard;
@@ -186,7 +187,7 @@ public class NodeReplacementAllocationDeciderTests extends ESAllocationTestCase 
             equalTo("node [" + NODE_A.getId() + "] is being replaced by [" + NODE_B.getName() + "], so no data may be allocated to it")
         );
 
-        routingNode = new RoutingNode(NODE_B.getId(), NODE_B, testShard);
+        routingNode = RoutingNodesHelper.routingNode(NODE_B.getId(), NODE_B, testShard);
 
         decision = decider.canAllocate(testShard, routingNode, allocation);
         assertThat(decision.type(), equalTo(Decision.Type.NO));
@@ -202,7 +203,7 @@ public class NodeReplacementAllocationDeciderTests extends ESAllocationTestCase 
             )
         );
 
-        routingNode = new RoutingNode(NODE_C.getId(), NODE_C, testShard);
+        routingNode = RoutingNodesHelper.routingNode(NODE_C.getId(), NODE_C, testShard);
 
         decision = decider.canAllocate(testShard, routingNode, allocation);
         assertThat(decision.getExplanation(), decision.type(), equalTo(Decision.Type.YES));

--- a/server/src/test/java/org/elasticsearch/cluster/routing/allocation/decider/NodeShutdownAllocationDeciderTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/allocation/decider/NodeShutdownAllocationDeciderTests.java
@@ -21,6 +21,7 @@ import org.elasticsearch.cluster.node.DiscoveryNodeRole;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
 import org.elasticsearch.cluster.routing.RecoverySource;
 import org.elasticsearch.cluster.routing.RoutingNode;
+import org.elasticsearch.cluster.routing.RoutingNodesHelper;
 import org.elasticsearch.cluster.routing.ShardRouting;
 import org.elasticsearch.cluster.routing.UnassignedInfo;
 import org.elasticsearch.cluster.routing.allocation.AllocationService;
@@ -82,7 +83,7 @@ public class NodeShutdownAllocationDeciderTests extends ESAllocationTestCase {
             SingleNodeShutdownMetadata.Type.RESTART
         );
         RoutingAllocation allocation = new RoutingAllocation(allocationDeciders, state, null, null, 0);
-        RoutingNode routingNode = new RoutingNode(DATA_NODE.getId(), DATA_NODE, shard);
+        RoutingNode routingNode = RoutingNodesHelper.routingNode(DATA_NODE.getId(), DATA_NODE, shard);
         allocation.debugDecision(true);
 
         Decision decision = decider.canAllocate(shard, routingNode, allocation);
@@ -99,7 +100,7 @@ public class NodeShutdownAllocationDeciderTests extends ESAllocationTestCase {
             randomFrom(SingleNodeShutdownMetadata.Type.REMOVE, SingleNodeShutdownMetadata.Type.REPLACE)
         );
         RoutingAllocation allocation = new RoutingAllocation(allocationDeciders, state, null, null, 0);
-        RoutingNode routingNode = new RoutingNode(DATA_NODE.getId(), DATA_NODE, shard);
+        RoutingNode routingNode = RoutingNodesHelper.routingNode(DATA_NODE.getId(), DATA_NODE, shard);
         allocation.debugDecision(true);
 
         Decision decision = decider.canAllocate(shard, routingNode, allocation);
@@ -113,7 +114,7 @@ public class NodeShutdownAllocationDeciderTests extends ESAllocationTestCase {
             SingleNodeShutdownMetadata.Type.RESTART
         );
         RoutingAllocation allocation = new RoutingAllocation(allocationDeciders, state, null, null, 0);
-        RoutingNode routingNode = new RoutingNode(DATA_NODE.getId(), DATA_NODE, shard);
+        RoutingNode routingNode = RoutingNodesHelper.routingNode(DATA_NODE.getId(), DATA_NODE, shard);
         allocation.debugDecision(true);
 
         Decision decision = decider.canRemain(shard, routingNode, allocation);
@@ -130,7 +131,7 @@ public class NodeShutdownAllocationDeciderTests extends ESAllocationTestCase {
             randomFrom(SingleNodeShutdownMetadata.Type.REMOVE, SingleNodeShutdownMetadata.Type.REPLACE)
         );
         RoutingAllocation allocation = new RoutingAllocation(allocationDeciders, state, null, null, 0);
-        RoutingNode routingNode = new RoutingNode(DATA_NODE.getId(), DATA_NODE, shard);
+        RoutingNode routingNode = RoutingNodesHelper.routingNode(DATA_NODE.getId(), DATA_NODE, shard);
         allocation.debugDecision(true);
 
         Decision decision = decider.canRemain(shard, routingNode, allocation);

--- a/server/src/test/java/org/elasticsearch/cluster/routing/allocation/decider/RestoreInProgressAllocationDeciderTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/allocation/decider/RestoreInProgressAllocationDeciderTests.java
@@ -20,7 +20,7 @@ import org.elasticsearch.cluster.node.DiscoveryNodes;
 import org.elasticsearch.cluster.routing.IndexRoutingTable;
 import org.elasticsearch.cluster.routing.IndexShardRoutingTable;
 import org.elasticsearch.cluster.routing.RecoverySource;
-import org.elasticsearch.cluster.routing.RoutingNode;
+import org.elasticsearch.cluster.routing.RoutingNodesHelper;
 import org.elasticsearch.cluster.routing.RoutingTable;
 import org.elasticsearch.cluster.routing.ShardRouting;
 import org.elasticsearch.cluster.routing.ShardRoutingState;
@@ -214,7 +214,7 @@ public class RestoreInProgressAllocationDeciderTests extends ESAllocationTestCas
             decision = decider.canAllocate(shardRouting, allocation);
         } else {
             DiscoveryNode node = clusterState.getNodes().getMasterNode();
-            decision = decider.canAllocate(shardRouting, new RoutingNode(node.getId(), node), allocation);
+            decision = decider.canAllocate(shardRouting, RoutingNodesHelper.routingNode(node.getId(), node), allocation);
         }
         return decision;
     }

--- a/test/framework/src/main/java/org/elasticsearch/cluster/routing/RoutingNodesHelper.java
+++ b/test/framework/src/main/java/org/elasticsearch/cluster/routing/RoutingNodesHelper.java
@@ -8,6 +8,8 @@
 
 package org.elasticsearch.cluster.routing;
 
+import org.elasticsearch.cluster.node.DiscoveryNode;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.IntStream;
@@ -58,5 +60,14 @@ public final class RoutingNodesHelper {
      */
     public static Stream<ShardRouting> asStream(IndexShardRoutingTable indexShardRoutingTable) {
         return IntStream.range(0, indexShardRoutingTable.size()).mapToObj(indexShardRoutingTable::shard);
+    }
+
+    public static RoutingNode routingNode(String nodeId, DiscoveryNode node, ShardRouting... shards) {
+        final RoutingNode routingNode = new RoutingNode(nodeId, node);
+        for (ShardRouting shardRouting : shards) {
+            routingNode.add(shardRouting);
+        }
+
+        return routingNode;
     }
 }

--- a/x-pack/plugin/ccr/src/test/java/org/elasticsearch/xpack/ccr/allocation/CcrPrimaryFollowerAllocationDeciderTests.java
+++ b/x-pack/plugin/ccr/src/test/java/org/elasticsearch/xpack/ccr/allocation/CcrPrimaryFollowerAllocationDeciderTests.java
@@ -19,8 +19,8 @@ import org.elasticsearch.cluster.node.DiscoveryNodeRole;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
 import org.elasticsearch.cluster.routing.IndexShardRoutingTable;
 import org.elasticsearch.cluster.routing.RecoverySource;
-import org.elasticsearch.cluster.routing.RoutingNode;
 import org.elasticsearch.cluster.routing.RoutingNodes;
+import org.elasticsearch.cluster.routing.RoutingNodesHelper;
 import org.elasticsearch.cluster.routing.RoutingTable;
 import org.elasticsearch.cluster.routing.ShardRouting;
 import org.elasticsearch.cluster.routing.allocation.RoutingAllocation;
@@ -190,7 +190,7 @@ public class CcrPrimaryFollowerAllocationDeciderTests extends ESAllocationTestCa
             System.nanoTime()
         );
         routingAllocation.debugDecision(true);
-        return decider.canAllocate(shardRouting, new RoutingNode(node.getId(), node), routingAllocation);
+        return decider.canAllocate(shardRouting, RoutingNodesHelper.routingNode(node.getId(), node), routingAllocation);
     }
 
     static RecoverySource.SnapshotRecoverySource newSnapshotRecoverySource() {

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/cluster/routing/allocation/DataTierAllocationDeciderTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/cluster/routing/allocation/DataTierAllocationDeciderTests.java
@@ -20,6 +20,7 @@ import org.elasticsearch.cluster.node.DiscoveryNodeRole;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
 import org.elasticsearch.cluster.routing.RecoverySource;
 import org.elasticsearch.cluster.routing.RoutingNode;
+import org.elasticsearch.cluster.routing.RoutingNodesHelper;
 import org.elasticsearch.cluster.routing.ShardRouting;
 import org.elasticsearch.cluster.routing.UnassignedInfo;
 import org.elasticsearch.cluster.routing.allocation.AllocationService;
@@ -111,7 +112,7 @@ public class DataTierAllocationDeciderTests extends ESAllocationTestCase {
         RoutingNode node;
 
         for (DiscoveryNode n : Arrays.asList(HOT_NODE, WARM_NODE, COLD_NODE)) {
-            node = new RoutingNode(n.getId(), n, shard);
+            node = RoutingNodesHelper.routingNode(n.getId(), n, shard);
             d = DataTierAllocationDecider.INSTANCE.canAllocate(shard, node, allocation);
             assertThat(node.toString(), d.type(), equalTo(Decision.Type.NO));
             assertThat(
@@ -157,7 +158,7 @@ public class DataTierAllocationDeciderTests extends ESAllocationTestCase {
         allocation.debugDecision(true);
 
         for (DiscoveryNode n : Arrays.asList(HOT_NODE, WARM_NODE)) {
-            node = new RoutingNode(n.getId(), n, shard);
+            node = RoutingNodesHelper.routingNode(n.getId(), n, shard);
             d = DataTierAllocationDecider.INSTANCE.canAllocate(shard, node, allocation);
             assertThat(node.toString(), d.type(), equalTo(Decision.Type.NO));
             assertThat(
@@ -178,7 +179,7 @@ public class DataTierAllocationDeciderTests extends ESAllocationTestCase {
             );
         }
 
-        node = new RoutingNode(COLD_NODE.getId(), COLD_NODE, shard);
+        node = RoutingNodesHelper.routingNode(COLD_NODE.getId(), COLD_NODE, shard);
         d = DataTierAllocationDecider.INSTANCE.canAllocate(shard, node, allocation);
         assertThat(node.toString(), d.type(), equalTo(Decision.Type.YES));
         assertThat(


### PR DESCRIPTION
With recent refactoring we only instantiate these with an empty map in production
and mutate afterwards. We can do the same in tests and save the test only code
in server.
