### PR TITLE
Improve kNN with filtering docs

### DIFF
--- a/docs/reference/search/knn-search.asciidoc
+++ b/docs/reference/search/knn-search.asciidoc
@@ -75,6 +75,9 @@ that sacrifices result accuracy for improved search speed. This means the
 results returned are not always the true _k_ closest neighbors.
 //end::hnsw-algorithm[]
 
+The kNN search API supports <<knn-search-api-filter-example, restricting the search using a filter>>.
+The search will return the top `k` documents that also match the filter query.
+
 [[knn-search-api-path-params]]
 ==== {api-path-parms-title}
 
@@ -153,6 +156,8 @@ candidates considered, which is `num_candidates * num_shards`. The
 [[knn-search-api-example]]
 ==== {api-examples-title}
 
+===== Basic kNN search
+
 The following requests create a `dense_vector` field with indexing enabled and
 add sample documents:
 
@@ -192,6 +197,9 @@ PUT my-index/_doc/2?refresh
   "file_type": "svg"
 }
 ----
+
+[[knn-search-api-filter-example]]
+===== Filtered kNN search
 
 The next request performs a kNN search filtered by the `file_type` field:
 

--- a/docs/reference/search/search-your-data/knn-search.asciidoc
+++ b/docs/reference/search/search-your-data/knn-search.asciidoc
@@ -62,8 +62,8 @@ performance using this approach.
 
 experimental::[]
 
-To run an approximate kNN search, use the kNN search API to search a
-`dense_vector` field with indexing enabled.
+To run an approximate kNN search, use the <<knn-search-api, kNN search API>>
+to search a `dense_vector` field with indexing enabled.
 
 . Explicitly map one or more `dense_vector` fields. Approximate kNN search
 requires the following mapping options:
@@ -186,7 +186,6 @@ You should only force merge an index if it is no longer being written to.
 <<nested,`nested`>> mapping.
 
 * {blank}
-+
 include::{es-repo-dir}/search/knn-search.asciidoc[tag=hnsw-algorithm]
 
 [discrete]


### PR DESCRIPTION
This change tries to make it easier to find kNN with filtering in the docs:
* Mention filtering support in the kNN API description
* In kNN tutorial, link to the kNN search API page more prominently