### PR TITLE
Update desired when there are no data nodes

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/allocator/DesiredBalance.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/allocator/DesiredBalance.java
@@ -24,7 +24,7 @@ public record DesiredBalance(long lastConvergedIndex, Map<ShardId, ShardAssignme
         return assignments.get(shardId);
     }
 
-    public static boolean areSame(DesiredBalance a, DesiredBalance b) {
-        return Objects.equals(a.assignments, b.assignments);
+    public static boolean hasChanges(DesiredBalance a, DesiredBalance b) {
+        return Objects.equals(a.assignments, b.assignments) == false;
     }
 }

--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/allocator/DesiredBalanceService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/allocator/DesiredBalanceService.java
@@ -64,13 +64,8 @@ public class DesiredBalanceService {
         final var knownNodeIds = routingAllocation.nodes().stream().map(DiscoveryNode::getId).collect(Collectors.toSet());
         final var unassignedPrimaries = new HashSet<ShardId>();
 
-        if (routingNodes.size() == 0) {
-            final var clearDesiredBalance = currentDesiredBalance.assignments().size() != 0;
-            if (clearDesiredBalance) {
-                currentDesiredBalance = new DesiredBalance(desiredBalanceInput.index(), Map.of());
-            }
-            return clearDesiredBalance;
-            // TODO test for this case
+        if (routingNodes.isEmpty()) {
+            return setCurrentDesiredBalance(new DesiredBalance(desiredBalanceInput.index(), Map.of()));
         }
 
         // we assume that all ongoing recoveries will complete
@@ -262,20 +257,23 @@ public class DesiredBalanceService {
                 : "desired balance computation converged"
         );
 
-        long lastConvergedIndex = hasChanges ? desiredBalance.lastConvergedIndex() : desiredBalanceInput.index();
-        final DesiredBalance newDesiredBalance = new DesiredBalance(lastConvergedIndex, assignments);
         assert desiredBalance == currentDesiredBalance;
-        currentDesiredBalance = newDesiredBalance;
-        if (DesiredBalance.areSame(newDesiredBalance, desiredBalance) == false) {
-            if (logger.isTraceEnabled()) {
-                logChanges(desiredBalance, newDesiredBalance);
+        long lastConvergedIndex = hasChanges ? desiredBalance.lastConvergedIndex() : desiredBalanceInput.index();
+        return setCurrentDesiredBalance(new DesiredBalance(lastConvergedIndex, assignments));
+    }
+
+    private boolean setCurrentDesiredBalance(DesiredBalance newDesiredBalance) {
+        boolean hasChanges = DesiredBalance.hasChanges(currentDesiredBalance, newDesiredBalance);
+        if (logger.isTraceEnabled()) {
+            if (hasChanges) {
+                logChanges(currentDesiredBalance, newDesiredBalance);
+                logger.trace("desired balance changed : {}", newDesiredBalance);
+            } else {
+                logger.trace("desired balance unchanged: {}", newDesiredBalance);
             }
-            logger.trace("desired balance changed : {}", newDesiredBalance);
-            return true;
-        } else {
-            logger.trace("desired balance unchanged: {}", desiredBalance);
-            return false;
         }
+        currentDesiredBalance = newDesiredBalance;
+        return hasChanges;
     }
 
     private static void logChanges(DesiredBalance old, DesiredBalance updated) {

--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/allocator/DesiredBalanceService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/allocator/DesiredBalanceService.java
@@ -66,6 +66,7 @@ public class DesiredBalanceService {
 
         if (routingNodes.isEmpty()) {
             return setCurrentDesiredBalance(new DesiredBalance(desiredBalanceInput.index(), Map.of()));
+            // TODO test for this case
         }
 
         // we assume that all ongoing recoveries will complete


### PR DESCRIPTION
This change ensures we advance converged index when executing reroutes in empty clusters.