### PR TITLE
Fix listener execution

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/allocator/DesiredBalanceShardsAllocator.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/allocator/DesiredBalanceShardsAllocator.java
@@ -100,6 +100,8 @@ public class DesiredBalanceShardsAllocator implements ShardsAllocator, ClusterSt
                         rerouteServiceSupplier.get().reroute("desired balance changed", Priority.NORMAL, ActionListener.noop());
                     } else {
                         logger.trace("Executing listeners up to [{}] as desired balance did not require reroute", lastConvergedIndex);
+                        // TODO desired balance this still does not guarantee the correct behaviour in case there is
+                        // extra unrelated allocation between one that triggered this computation and one produced by above reroute.
                         queue.complete(lastConvergedIndex);
                     }
                 }

--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/allocator/PendingListenersQueue.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/allocator/PendingListenersQueue.java
@@ -58,7 +58,11 @@ public class PendingListenersQueue {
         executeListeners(completedIndex, true);
     }
 
-    boolean isPaused() {
+    public long getCompletedIndex() {
+        return completedIndex;
+    }
+
+    public boolean isPaused() {
         return paused;
     }
 

--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/allocator/PendingListenersQueue.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/allocator/PendingListenersQueue.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.cluster.routing.allocation.allocator;
+
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.cluster.NotMasterException;
+import org.elasticsearch.threadpool.ThreadPool;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.LinkedList;
+import java.util.Queue;
+
+public class PendingListenersQueue {
+
+    private record PendingListener(long index, ActionListener<Void> listener) {}
+
+    private final ThreadPool threadPool;
+    private final Queue<PendingListener> pendingListeners = new LinkedList<>();
+    private volatile long completedIndex = -1;
+    private volatile boolean paused = false;
+
+    public PendingListenersQueue(ThreadPool threadPool) {
+        this.threadPool = threadPool;
+    }
+
+    public void add(long index, ActionListener<Void> listener) {
+        synchronized (pendingListeners) {
+            pendingListeners.add(new PendingListener(index, listener));
+        }
+    }
+
+    public void complete(long index) {
+        completedIndex = index;
+        if (paused == false) {
+            executeListeners(completedIndex, true);
+        }
+    }
+
+    public void completeAllAsNotMaster() {
+        completedIndex = -1;
+        paused = false;
+        executeListeners(Long.MAX_VALUE, false);
+    }
+
+    public void pause() {
+        paused = true;
+    }
+
+    public void resume() {
+        paused = false;
+        executeListeners(completedIndex, true);
+    }
+
+    boolean isPaused() {
+        return paused;
+    }
+
+    private void executeListeners(long convergedIndex, boolean isMaster) {
+        var listeners = pollListeners(convergedIndex);
+        if (listeners.isEmpty() == false) {
+            threadPool.generic().execute(() -> {
+                if (isMaster) {
+                    ActionListener.onResponse(listeners, null);
+                } else {
+                    ActionListener.onFailure(listeners, new NotMasterException("no longer master"));
+                }
+            });
+        }
+    }
+
+    private Collection<ActionListener<Void>> pollListeners(long maxIndex) {
+        var listeners = new ArrayList<ActionListener<Void>>();
+        PendingListener listener;
+        synchronized (pendingListeners) {
+            while ((listener = pendingListeners.peek()) != null && listener.index <= maxIndex) {
+                listeners.add(pendingListeners.poll().listener);
+            }
+        }
+        return listeners;
+    }
+}

--- a/server/src/test/java/org/elasticsearch/cluster/routing/allocation/allocator/PendingListenersQueueTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/allocation/allocator/PendingListenersQueueTests.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.cluster.routing.allocation.allocator;
+
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.threadpool.TestThreadPool;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import static org.hamcrest.Matchers.equalTo;
+
+public class PendingListenersQueueTests extends ESTestCase {
+
+    public void testShouldExecuteImmediatelyWhenNotPaused() throws InterruptedException {
+        var threadPool = new TestThreadPool(getTestName());
+        var queue = new PendingListenersQueue(threadPool);
+        var executed = new CountDownLatch(1);
+
+        queue.add(1, ActionListener.wrap(executed::countDown));
+        queue.complete(1);
+
+        try {
+            assertThat(executed.await(1, TimeUnit.SECONDS), equalTo(true));
+        } finally {
+            terminate(threadPool);
+        }
+    }
+
+    public void testShouldExecuteAfterUnPaused() throws InterruptedException {
+        var threadPool = new TestThreadPool(getTestName());
+        var queue = new PendingListenersQueue(threadPool);
+        var executed = new CountDownLatch(1);
+
+        queue.add(1, ActionListener.wrap(() -> {
+            assertThat(queue.isPaused(), equalTo(false));
+            executed.countDown();
+        }));
+        queue.pause();
+        queue.complete(1);
+        queue.resume();
+
+        try {
+            assertThat(executed.await(1, TimeUnit.SECONDS), equalTo(true));
+        } finally {
+            terminate(threadPool);
+        }
+    }
+
+    public void testShouldExecuteOnlyCompleted() throws InterruptedException {
+        var threadPool = new TestThreadPool(getTestName());
+        var queue = new PendingListenersQueue(threadPool);
+        var executed = new CountDownLatch(2);
+
+        queue.add(1, ActionListener.wrap(executed::countDown));
+        queue.add(2, ActionListener.wrap(executed::countDown));
+        queue.add(3, ActionListener.wrap(() -> fail("Should not complete in test")));
+        queue.complete(2);
+
+        try {
+            assertThat(executed.await(1, TimeUnit.SECONDS), equalTo(true));
+        } finally {
+            terminate(threadPool);
+        }
+    }
+
+    public void testShouldExecuteAllAsNonMaster() throws InterruptedException {
+        var threadPool = new TestThreadPool(getTestName());
+        var queue = new PendingListenersQueue(threadPool);
+        var executed = new CountDownLatch(2);
+
+        queue.add(1, ActionListener.wrap(ignored -> fail("Should not complete in test"), exception -> executed.countDown()));
+        queue.add(2, ActionListener.wrap(ignored -> fail("Should not complete in test"), exception -> executed.countDown()));
+        queue.pause();
+        queue.complete(1);
+        queue.completeAllAsNotMaster();
+
+        try {
+            assertThat(executed.await(1, TimeUnit.SECONDS), equalTo(true));
+        } finally {
+            terminate(threadPool);
+        }
+    }
+}


### PR DESCRIPTION
This pr introduces `PendingListenersQueue` that fixes a case when a listener might not have been executed in time.

Fixes: ` IndexRecoveryIT. testCancelRecoveryWithAutoExpandReplicas (stuck after creating index [0-all] index in a cluster with a single master and no data nodes)`