### PR TITLE
Speed up ClusterStateHealth constructor

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/health/ClusterStateHealth.java
+++ b/server/src/main/java/org/elasticsearch/cluster/health/ClusterStateHealth.java
@@ -10,7 +10,6 @@ package org.elasticsearch.cluster.health;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.routing.IndexRoutingTable;
-import org.elasticsearch.cluster.routing.RoutingNodes;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
@@ -55,6 +54,14 @@ public final class ClusterStateHealth implements Iterable<ClusterIndexHealth>, W
         numberOfNodes = clusterState.nodes().getSize();
         numberOfDataNodes = clusterState.nodes().getDataNodes().size();
         indices = new HashMap<>();
+        ClusterHealthStatus computeStatus = ClusterHealthStatus.GREEN;
+        int computeActivePrimaryShards = 0;
+        int computeActiveShards = 0;
+        int computeRelocatingShards = 0;
+        int computeInitializingShards = 0;
+        int computeUnassignedShards = 0;
+        int totalShardCount = 0;
+
         for (String index : concreteIndices) {
             IndexRoutingTable indexRoutingTable = clusterState.routingTable().index(index);
             IndexMetadata indexMetadata = clusterState.metadata().index(index);
@@ -63,18 +70,9 @@ public final class ClusterStateHealth implements Iterable<ClusterIndexHealth>, W
             }
 
             ClusterIndexHealth indexHealth = new ClusterIndexHealth(indexMetadata, indexRoutingTable);
-
             indices.put(indexHealth.getIndex(), indexHealth);
-        }
 
-        ClusterHealthStatus computeStatus = ClusterHealthStatus.GREEN;
-        int computeActivePrimaryShards = 0;
-        int computeActiveShards = 0;
-        int computeRelocatingShards = 0;
-        int computeInitializingShards = 0;
-        int computeUnassignedShards = 0;
-
-        for (ClusterIndexHealth indexHealth : indices.values()) {
+            totalShardCount += indexMetadata.getTotalNumberOfShards();
             computeActivePrimaryShards += indexHealth.getActivePrimaryShards();
             computeActiveShards += indexHealth.getActiveShards();
             computeRelocatingShards += indexHealth.getRelocatingShards();
@@ -102,10 +100,7 @@ public final class ClusterStateHealth implements Iterable<ClusterIndexHealth>, W
         if (computeStatus.equals(ClusterHealthStatus.GREEN)) {
             this.activeShardsPercent = 100;
         } else {
-            RoutingNodes routingNodes = clusterState.getRoutingNodes();
-            int activeShardCount = routingNodes.getActiveShardCount();
-            int totalShardCount = routingNodes.getTotalShardCount();
-            this.activeShardsPercent = (((double) activeShardCount) / totalShardCount) * 100;
+            this.activeShardsPercent = (((double) this.activeShards) / totalShardCount) * 100;
         }
     }
 


### PR DESCRIPTION
This does not need to build the routing nodes, nor do we need to iterate all indices
twice. Not as massive a win because we tend to then build the routing nodes elsewhere 
but not iterating all indices twice saves visibly and we remove a needless use of the
routing nodes.

relates #77466