### PR TITLE
[7.17] Fail shard if STARTED after master failover (#87451)

### DIFF
--- a/docs/changelog/87451.yaml
+++ b/docs/changelog/87451.yaml
@@ -1,0 +1,6 @@
+pr: 87451
+summary: Fail shard if STARTED after master failover
+area: Recovery
+type: bug
+issues:
+ - 87367

--- a/server/src/test/java/org/elasticsearch/index/shard/IndexShardTests.java
+++ b/server/src/test/java/org/elasticsearch/index/shard/IndexShardTests.java
@@ -2057,6 +2057,18 @@ public class IndexShardTests extends IndexShardTestCase {
         closeShards(shard);
     }
 
+    public void testRecoveringShardFailsIfStartedTooSoon() throws IOException {
+        final IndexShard shard = newShard(false);
+        final ShardRouting originalRouting = shard.routingEntry();
+        final ShardRouting startedRouting = ShardRoutingHelper.moveToStarted(originalRouting);
+        assertThat(
+            expectThrows(IllegalIndexShardStateException.class, () -> IndexShardTestCase.updateRoutingEntry(shard, startedRouting))
+                .getMessage(),
+            containsString("stale shard-started event")
+        );
+        closeShards(shard);
+    }
+
     public void testShardCanNotBeMarkedAsRelocatedIfRelocationCancelled() throws IOException {
         final IndexShard shard = newStartedShard(true);
         final ShardRouting originalRouting = shard.routingEntry();


### PR DESCRIPTION
Backports the following commits to 7.17:
 - Fail shard if STARTED after master failover (#87451)