### PR TITLE
Changing the URL for increasing tier capacity documentation

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/ShardsAvailabilityHealthIndicatorService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/ShardsAvailabilityHealthIndicatorService.java
@@ -315,13 +315,13 @@ public class ShardsAvailabilityHealthIndicatorService implements HealthIndicator
             )
         );
 
-    public static final String NODE_CAPACITY_ACTION_GUIDE = "http://ela.st/node-capacity";
+    public static final String TIER_CAPACITY_ACTION_GUIDE = "http://ela.st/tier-capacity";
     public static final UserAction.Definition ACTION_INCREASE_NODE_CAPACITY = new UserAction.Definition(
         "increase_node_capacity_for_allocations",
         "Elasticsearch isn't allowed to allocate some shards from these indices because there are not enough nodes in the cluster to "
             + "allocate each shard copy on a different node. Increase the number of nodes in the cluster or decrease the number of "
             + "replica shards in the affected indices.",
-        NODE_CAPACITY_ACTION_GUIDE
+        TIER_CAPACITY_ACTION_GUIDE
     );
 
     public static final Map<String, UserAction.Definition> ACTION_INCREASE_TIER_CAPACITY_LOOKUP = DataTier.ALL_DATA_TIERS.stream()
@@ -335,7 +335,7 @@ public class ShardsAvailabilityHealthIndicatorService implements HealthIndicator
                         + tier
                         + "] tier to allocate each shard copy on a different node. Increase the number of nodes in this tier or "
                         + "decrease the number of replica shards in the affected indices.",
-                    NODE_CAPACITY_ACTION_GUIDE
+                    TIER_CAPACITY_ACTION_GUIDE
                 )
             )
         );

--- a/server/src/test/java/org/elasticsearch/cluster/routing/allocation/ShardsAvailabilityActionGuideTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/allocation/ShardsAvailabilityActionGuideTests.java
@@ -29,8 +29,8 @@ import static org.elasticsearch.cluster.routing.allocation.ShardsAvailabilityHea
 import static org.elasticsearch.cluster.routing.allocation.ShardsAvailabilityHealthIndicatorService.INCREASE_CLUSTER_SHARD_LIMIT_ACTION_GUIDE;
 import static org.elasticsearch.cluster.routing.allocation.ShardsAvailabilityHealthIndicatorService.INCREASE_SHARD_LIMIT_ACTION_GUIDE;
 import static org.elasticsearch.cluster.routing.allocation.ShardsAvailabilityHealthIndicatorService.MIGRATE_TO_TIERS_ACTION_GUIDE;
-import static org.elasticsearch.cluster.routing.allocation.ShardsAvailabilityHealthIndicatorService.NODE_CAPACITY_ACTION_GUIDE;
 import static org.elasticsearch.cluster.routing.allocation.ShardsAvailabilityHealthIndicatorService.RESTORE_FROM_SNAPSHOT_ACTION_GUIDE;
+import static org.elasticsearch.cluster.routing.allocation.ShardsAvailabilityHealthIndicatorService.TIER_CAPACITY_ACTION_GUIDE;
 import static org.hamcrest.Matchers.is;
 
 public class ShardsAvailabilityActionGuideTests extends ESTestCase {
@@ -85,6 +85,6 @@ public class ShardsAvailabilityActionGuideTests extends ESTestCase {
     }
 
     public void testIncreaseTierCapacity() {
-        assertThat(ACTION_INCREASE_NODE_CAPACITY.helpURL(), is(NODE_CAPACITY_ACTION_GUIDE));
+        assertThat(ACTION_INCREASE_NODE_CAPACITY.helpURL(), is(TIER_CAPACITY_ACTION_GUIDE));
     }
 }


### PR DESCRIPTION
This commit changes the URL of the documentation for increasing node capacity in a tier in the shards availability
indicator in the heath API from http://ela.st/node-capacity to http://ela.st/tier-capacity.
Relates to #87188