### PR TITLE
[8.3] Script: Load Whitelists as Resource (#87539)

### DIFF
--- a/docs/changelog/87539.yaml
+++ b/docs/changelog/87539.yaml
@@ -1,0 +1,5 @@
+pr: 87539
+summary: "Script: Load Whitelists as Resource"
+area: Infra/Scripting
+type: bug
+issues: []

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/PainlessPlugin.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/PainlessPlugin.java
@@ -90,7 +90,7 @@ public final class PainlessPlugin extends Plugin implements ScriptPlugin, Extens
 
         for (ScriptContext<?> context : ScriptModule.CORE_CONTEXTS.values()) {
             List<Whitelist> contextWhitelists = new ArrayList<>();
-            if (PainlessPlugin.class.getResourceAsStream("org.elasticsearch.script." + context.name.replace('-', '_') + ".txt") != null) {
+            if (PainlessPlugin.class.getResource("org.elasticsearch.script." + context.name.replace('-', '_') + ".txt") != null) {
                 contextWhitelists.add(
                     WhitelistLoader.loadFromResourceFiles(
                         PainlessPlugin.class,


### PR DESCRIPTION
Backports the following commits to 8.3:
 - Script: Load Whitelists as Resource (#87539)