### PR TITLE
Clarify role mapping support and alternatives

### DIFF
--- a/x-pack/docs/en/security/authorization/mapping-roles.asciidoc
+++ b/x-pack/docs/en/security/authorization/mapping-roles.asciidoc
@@ -2,21 +2,24 @@
 [[mapping-roles]]
 === Mapping users and groups to roles
 
-Role mapping is supported by all realms except `native` and `file`. Those two realms
-assign roles directly to users, they do not support role mapping.
+Role mapping is supported by all realms except `native` and `file`.
 
-TIP: Native realms use <<managing-native-users,user management APIs>>.
+TIP:  Those two realms assign roles directly to users, they do not support role mapping.
+Native realms use <<managing-native-users,user management APIs>>.
 File realms use <<roles-management-file,File-based role management>>.
 
-If using Role Mapping, there are two supported sources,
+If using Role Mapping, there are two supported sources of role mapping rules,
 <<mapping-roles-api, Role Mapping API>> and <<mapping-roles-file, Role Mapping File>>.
 
-IMPORTANT: Role Mapping API is preferred over Role Mapping File, and is supported by more realms.
+IMPORTANT: Role Mapping API is preferred over Role Mapping File.
 
 The PKI, LDAP, AD, Kerberos, OpenID Connect, JWT, and SAML realms support
-<<mapping-roles-api, API>>. However, only the PKI, LDAP, and AD realms in that list
-also support <<mapping-roles-file, Role Mapping File>>. In addition, all seven of
-these realms support <<authorization_realms,Delegated Authorization>> too.
+<<mapping-roles-api, Role Mapping API>>. Only PKI, LDAP, and AD realms
+support <<mapping-roles-file, Role Mapping File>>.
+
+Besides Role Mapping, the PKI, LDAP, AD, Kerberos, OpenID Connect, JWT, and
+SAML realms realms support <<authorization_realms,Delegated Authorization>> too.
+Role Mapping and Delegated Authorization cannot be used simultaneously in a realm.
 Pick the best option available for each realm based on your requirements.
 
 If you choose role mapping, you will have to create roles and _role-mappings_.

--- a/x-pack/docs/en/security/authorization/mapping-roles.asciidoc
+++ b/x-pack/docs/en/security/authorization/mapping-roles.asciidoc
@@ -16,10 +16,9 @@ The PKI, LDAP, AD, Kerberos, OpenID Connect, JWT, and SAML realms support the
 <<mapping-roles-api, Role mapping API>>. Only PKI, LDAP, and AD realms
 support <<mapping-roles-file, Role mapping files>>.
 
-Besides Role Mapping, the PKI, LDAP, AD, Kerberos, OpenID Connect, JWT, and
-SAML realms realms support <<authorization_realms,Delegated Authorization>> too.
-Role Mapping and Delegated Authorization cannot be used simultaneously in a realm.
-Pick the best option available for each realm based on your requirements.
+The PKI, LDAP, AD, Kerberos, OpenID Connect, JWT, and
+SAML realms also support <<authorization_realms,delegated authorization>>.
+You can either map roles for a realm or use delegated authorization; you cannot use both simultaneously.
 
 If you choose role mapping, you will have to create roles and _role-mappings_.
 Role mapping rules can based on realm name, realm type, username, groups,

--- a/x-pack/docs/en/security/authorization/mapping-roles.asciidoc
+++ b/x-pack/docs/en/security/authorization/mapping-roles.asciidoc
@@ -2,17 +2,34 @@
 [[mapping-roles]]
 === Mapping users and groups to roles
 
-If you authenticate users with the `native` or `file` realms, you can manage
-role assignment by using the <<managing-native-users,user management APIs>> or
-the <<users-command,users>> command-line tool respectively.
+Role mapping is supported by all realms except `native` and `file`. Those two realms
+assign roles directly to users, so they do not support other role lookup methods such
+as role mapping.
 
-For other types of realms, you must create _role-mappings_ that define which
-roles should be assigned to each user based on their username, groups, or
-other metadata.
+TIP: Native realms use <<managing-native-users,user management APIs>>.
+
+TIP: File realms use <<roles-management-file,File-based role management>>.
+
+The realms that support role mapping also support alternative role lookup methods.
+Pick the best method for each realm based on your requirements, and these constraints.
+
+TIP: The PKI, LDAP, AD, Kerberos, OpenID Connect, JWT, and SAML realms
+support using role mapping or <<authorization_realms,authorization realms>>.
+For delegated authorization, a constraint is they can only delegate to other realms
+of type Native, File, LDAP, and AD.
+Examples are SAML to Native, Kerberos to File, PKI to AD, or LDAP to LDAP.
+
+TIP: The PKI, LDAP, and AD realms support <<roles-management-file,File-based role management>>.
+
+If you configure role mapping for a realm, you must create _role-mappings_ that define
+which roles should be assigned to each user. Role mapping rules can based on
+realm name, realm type, username, groups, other user metadata, or combinations of
+those values.
 
 NOTE: When <<anonymous-access,anonymous access>> is enabled, the roles
 of the anonymous user are assigned to all the other users as well.
 
+There are two sources of role-mapping rules.
 You can define role-mappings via an
 <<mapping-roles-api, API>> or manage them through <<mapping-roles-file, files>>.
 These two sources of role-mapping are combined inside of the {es}
@@ -21,17 +38,17 @@ possible for a single user to have some roles that have been mapped through
 the API, and other roles that are mapped through files.
 
 NOTE: Users with no roles assigned will be unauthorized for any action.
+They may be able to authenticate, but they will not have any privileges
+to request any actions.
 
-When you use role-mappings, you assign existing roles to users.
+When you use role-mappings to assign roles to users, the roles must exist.
+There are two sources of roles.
 The available roles should either be added using the
 <<security-role-apis,role management APIs>> or defined in the
 <<roles-management-file,roles file>>. Either role-mapping method can use
 either role management method. For example, when you use the role mapping API,
 you are able to map users to both API-managed roles and file-managed roles
 (and likewise for file-based role-mappings).
-
-TIP: The PKI, LDAP, Kerberos, OpenID Connect, JWT, and SAML realms support using
-<<authorization_realms,authorization realms>> as an alternative to role mapping.
 
 [[mapping-roles-api]]
 ==== Using the role mapping API

--- a/x-pack/docs/en/security/authorization/mapping-roles.asciidoc
+++ b/x-pack/docs/en/security/authorization/mapping-roles.asciidoc
@@ -43,7 +43,7 @@ In other words, they may be able to authenticate, but they will have no roles.
 No roles means no privileges, and no privileges means no authorizations to
 make requests.
 
-When you use role-mappings to assign roles to users, the roles must exist.
+When you use role mappings to assign roles to users, the roles must exist.
 There are two sources of roles.
 The available roles should either be added using the
 <<security-role-apis,role management APIs>> or defined in the

--- a/x-pack/docs/en/security/authorization/mapping-roles.asciidoc
+++ b/x-pack/docs/en/security/authorization/mapping-roles.asciidoc
@@ -20,7 +20,7 @@ The PKI, LDAP, AD, Kerberos, OpenID Connect, JWT, and
 SAML realms also support <<authorization_realms,delegated authorization>>.
 You can either map roles for a realm or use delegated authorization; you cannot use both simultaneously.
 
-If you choose role mapping, you will have to create roles and _role-mappings_.
+To use role mapping, you create roles and role mapping rules.
 Role mapping rules can based on realm name, realm type, username, groups,
 other user metadata, or combinations of those values.
 

--- a/x-pack/docs/en/security/authorization/mapping-roles.asciidoc
+++ b/x-pack/docs/en/security/authorization/mapping-roles.asciidoc
@@ -27,7 +27,10 @@ other user metadata, or combinations of those values.
 NOTE: When <<anonymous-access,anonymous access>> is enabled, the roles
 of the anonymous user are assigned to all the other users as well.
 
-There are two sources of role-mapping rules.
+If there are role-mapping rules created through the API as well as a role mapping file, 
+the rules are combined. 
+It's possible for a single user to have some roles that were mapped through the API, 
+and others assigned based on the role mapping file.
 You can define role-mappings via an
 <<mapping-roles-api, API>> or manage them through <<mapping-roles-file, files>>.
 These two sources of role-mapping are combined inside of the {es}

--- a/x-pack/docs/en/security/authorization/mapping-roles.asciidoc
+++ b/x-pack/docs/en/security/authorization/mapping-roles.asciidoc
@@ -3,28 +3,28 @@
 === Mapping users and groups to roles
 
 Role mapping is supported by all realms except `native` and `file`. Those two realms
-assign roles directly to users, so they do not support other role lookup methods such
-as role mapping.
+assign roles directly to users, so they do not support role mapping.
 
 TIP: Native realms use <<managing-native-users,user management APIs>>.
 
 TIP: File realms use <<roles-management-file,File-based role management>>.
 
-The realms that support role mapping also support alternative role lookup methods.
-Pick the best method for each realm based on your requirements, and these constraints.
+If using Role Mapping, there are two supported sources,
+<<mapping-roles-api, API>> and <<mapping-roles-file, files>>.
 
-TIP: The PKI, LDAP, AD, Kerberos, OpenID Connect, JWT, and SAML realms
-support using role mapping or <<authorization_realms,authorization realms>>.
-For delegated authorization, a constraint is they can only delegate to other realms
-of type Native, File, LDAP, and AD.
-Examples are SAML to Native, Kerberos to File, PKI to AD, or LDAP to LDAP.
+IMPORTANT: <<mapping-roles-api, API>> is preferred over <<mapping-roles-file, files>>.
+More realms support <<mapping-roles-api, API>> versus <<mapping-roles-file, files>>.
 
-TIP: The PKI, LDAP, and AD realms support <<roles-management-file,File-based role management>>.
+The PKI, LDAP, AD, Kerberos, OpenID Connect, JWT, and SAML realms support
+<<mapping-roles-api, API>>. Only the PKI, LDAP, and AD realms in that list
+also support <<mapping-roles-file, files>>. However, all seven of these realms
+also support <<mapping-roles-api, API>>.
 
-If you configure role mapping for a realm, you must create _role-mappings_ that define
-which roles should be assigned to each user. Role mapping rules can based on
-realm name, realm type, username, groups, other user metadata, or combinations of
-those values.
+Pick the best option available for each realm based on your requirements.
+
+If you choose role mapping, you will have to create roles and _role-mappings_.
+Role mapping rules can based on realm name, realm type, username, groups,
+other user metadata, or combinations of those values.
 
 NOTE: When <<anonymous-access,anonymous access>> is enabled, the roles
 of the anonymous user are assigned to all the other users as well.
@@ -38,8 +38,9 @@ possible for a single user to have some roles that have been mapped through
 the API, and other roles that are mapped through files.
 
 NOTE: Users with no roles assigned will be unauthorized for any action.
-They may be able to authenticate, but they will not have any privileges
-to request any actions.
+In other words, they may be able to authenticate, but they will have no roles.
+No roles means no privileges, and no privileges means no authorizations to
+make requests.
 
 When you use role-mappings to assign roles to users, the roles must exist.
 There are two sources of roles.

--- a/x-pack/docs/en/security/authorization/mapping-roles.asciidoc
+++ b/x-pack/docs/en/security/authorization/mapping-roles.asciidoc
@@ -11,7 +11,6 @@ File realms use <<roles-management-file,File-based role management>>.
 You can map roles through the 
 <<mapping-roles-api, Role mapping API>> (recommended) or a <<mapping-roles-file, Role mapping file>>.
 
-IMPORTANT: Role Mapping API is preferred over Role Mapping File.
 
 The PKI, LDAP, AD, Kerberos, OpenID Connect, JWT, and SAML realms support
 <<mapping-roles-api, Role Mapping API>>. Only PKI, LDAP, and AD realms

--- a/x-pack/docs/en/security/authorization/mapping-roles.asciidoc
+++ b/x-pack/docs/en/security/authorization/mapping-roles.asciidoc
@@ -8,7 +8,7 @@ The native and file realms assign roles directly to users.
 Native realms use <<managing-native-users,user management APIs>>.
 File realms use <<roles-management-file,File-based role management>>.
 
-You can map roles through the 
+You can map roles through the
 <<mapping-roles-api, Role mapping API>> (recommended) or a <<mapping-roles-file, Role mapping file>>.
 
 
@@ -21,15 +21,15 @@ SAML realms also support <<authorization_realms,delegated authorization>>.
 You can either map roles for a realm or use delegated authorization; you cannot use both simultaneously.
 
 To use role mapping, you create roles and role mapping rules.
-Role mapping rules can based on realm name, realm type, username, groups,
+Role mapping rules can be based on realm name, realm type, username, groups,
 other user metadata, or combinations of those values.
 
 NOTE: When <<anonymous-access,anonymous access>> is enabled, the roles
 of the anonymous user are assigned to all the other users as well.
 
-If there are role-mapping rules created through the API as well as a role mapping file, 
-the rules are combined. 
-It's possible for a single user to have some roles that were mapped through the API, 
+If there are role-mapping rules created through the API as well as a role mapping file,
+the rules are combined.
+It's possible for a single user to have some roles that were mapped through the API,
 and others assigned based on the role mapping file.
 You can define role-mappings via an
 <<mapping-roles-api, API>> or manage them through <<mapping-roles-file, files>>.

--- a/x-pack/docs/en/security/authorization/mapping-roles.asciidoc
+++ b/x-pack/docs/en/security/authorization/mapping-roles.asciidoc
@@ -8,8 +8,8 @@ The native and file realms assign roles directly to users.
 Native realms use <<managing-native-users,user management APIs>>.
 File realms use <<roles-management-file,File-based role management>>.
 
-If using Role Mapping, there are two supported sources of role mapping rules,
-<<mapping-roles-api, Role Mapping API>> and <<mapping-roles-file, Role Mapping File>>.
+You can map roles through the 
+<<mapping-roles-api, Role mapping API>> (recommended) or a <<mapping-roles-file, Role mapping file>>.
 
 IMPORTANT: Role Mapping API is preferred over Role Mapping File.
 

--- a/x-pack/docs/en/security/authorization/mapping-roles.asciidoc
+++ b/x-pack/docs/en/security/authorization/mapping-roles.asciidoc
@@ -12,9 +12,9 @@ You can map roles through the
 <<mapping-roles-api, Role mapping API>> (recommended) or a <<mapping-roles-file, Role mapping file>>.
 
 
-The PKI, LDAP, AD, Kerberos, OpenID Connect, JWT, and SAML realms support
-<<mapping-roles-api, Role Mapping API>>. Only PKI, LDAP, and AD realms
-support <<mapping-roles-file, Role Mapping File>>.
+The PKI, LDAP, AD, Kerberos, OpenID Connect, JWT, and SAML realms support the
+<<mapping-roles-api, Role mapping API>>. Only PKI, LDAP, and AD realms
+support <<mapping-roles-file, Role mapping files>>.
 
 Besides Role Mapping, the PKI, LDAP, AD, Kerberos, OpenID Connect, JWT, and
 SAML realms realms support <<authorization_realms,Delegated Authorization>> too.

--- a/x-pack/docs/en/security/authorization/mapping-roles.asciidoc
+++ b/x-pack/docs/en/security/authorization/mapping-roles.asciidoc
@@ -3,23 +3,20 @@
 === Mapping users and groups to roles
 
 Role mapping is supported by all realms except `native` and `file`. Those two realms
-assign roles directly to users, so they do not support role mapping.
+assign roles directly to users, they do not support role mapping.
 
 TIP: Native realms use <<managing-native-users,user management APIs>>.
-
-TIP: File realms use <<roles-management-file,File-based role management>>.
+File realms use <<roles-management-file,File-based role management>>.
 
 If using Role Mapping, there are two supported sources,
-<<mapping-roles-api, API>> and <<mapping-roles-file, files>>.
+<<mapping-roles-api, Role Mapping API>> and <<mapping-roles-file, Role Mapping File>>.
 
-IMPORTANT: <<mapping-roles-api, API>> is preferred over <<mapping-roles-file, files>>.
-More realms support <<mapping-roles-api, API>> versus <<mapping-roles-file, files>>.
+IMPORTANT: Role Mapping API is preferred over Role Mapping File, and is supported by more realms.
 
 The PKI, LDAP, AD, Kerberos, OpenID Connect, JWT, and SAML realms support
-<<mapping-roles-api, API>>. Only the PKI, LDAP, and AD realms in that list
-also support <<mapping-roles-file, files>>. However, all seven of these realms
-also support <<mapping-roles-api, API>>.
-
+<<mapping-roles-api, API>>. However, only the PKI, LDAP, and AD realms in that list
+also support <<mapping-roles-file, Role Mapping File>>. In addition, all seven of
+these realms support <<authorization_realms,Delegated Authorization>> too.
 Pick the best option available for each realm based on your requirements.
 
 If you choose role mapping, you will have to create roles and _role-mappings_.

--- a/x-pack/docs/en/security/authorization/mapping-roles.asciidoc
+++ b/x-pack/docs/en/security/authorization/mapping-roles.asciidoc
@@ -4,7 +4,7 @@
 
 Role mapping is supported by all realms except `native` and `file`.
 
-TIP:  Those two realms assign roles directly to users, they do not support role mapping.
+The native and file realms assign roles directly to users.
 Native realms use <<managing-native-users,user management APIs>>.
 File realms use <<roles-management-file,File-based role management>>.
 


### PR DESCRIPTION
The goal of this PR is to clarify the list of which realms support role mapping, and to clarify which alternatives are available to use instead of role mapping.

- Role mapping API: All realms except native and file. Directly mention PKI, LDAP, AD, Kerberos, SAML, OIDC, and JWT in a TIP.
- Alternative 1 (Role mapping File): Alternative to role mapping API, but it is only available for LDAP, AD, and PKI in the above list.
- Alternative 2 (Delegated authorization): Same list of 7 realms as role mapping API.

Heads up @tvernum and @gwbrown. You might be interested in reviewing these clarifications, based on a recent issue you worked on 2 days ago.

Tag @lockewritesdocs too. The content in here came from our discussion last week with @albertzaharovits.

Note: This PR should not be auto-backported to 7.x because it mentions JWT realm which was only added in 8.2.0.

Doc previews are available for a short time after a build:
- https://elasticsearch_87572.docs-preview.app.elstc.co/diff
- https://elasticsearch_87572.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/mapping-roles.html