### PR TITLE
Add force_synthetic_source to mget

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/api/mget.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/mget.json
@@ -35,6 +35,12 @@
       ]
     },
     "params":{
+      "force_synthetic_source": {
+        "type": "boolean",
+        "description": "Should this request force synthetic _source? Use this to test if the mapping supports synthetic _source and to get a sense of the worst case performance. Fetches with this enabled will be slower the enabling synthetic source natively in the index.",
+        "visibility": "feature_flag",
+        "feature_flag": "es.index_mode_feature_flag_registered"
+      },
       "stored_fields":{
         "type":"list",
         "description":"A comma-separated list of stored fields to return in the response"

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/mget/90_synthetic_source.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/mget/90_synthetic_source.yml
@@ -45,3 +45,117 @@ keyword:
   - match:
       docs.1._source:
         kwd: bar
+
+---
+force_synthetic_source_ok:
+  - skip:
+      version: " - 8.3.99"
+      reason: introduced in 8.4.0
+
+  - do:
+      indices.create:
+        index: test
+        body:
+          mappings:
+            _source:
+              synthetic: false
+            properties:
+              kwd:
+                type: keyword
+
+  - do:
+      index:
+        index:   test
+        id:      1
+        body:
+          kwd: foo
+
+  - do:
+      index:
+        index:   test
+        id:      2
+        body:
+          kwd: bar
+
+  # When _source is used in the fetch the original _source is perfect
+  - do:
+      mget:
+        index: test
+        body:
+          ids: [1, 2]
+  - match:
+      docs.0._source:
+        kwd: foo
+  - match:
+      docs.1._source:
+        kwd: bar
+
+  # When we force synthetic source dots in field names get turned into objects
+  - do:
+      mget:
+        index: test
+        force_synthetic_source: true
+        body:
+          ids: [ 1, 2 ]
+  - match:
+      docs.0._source:
+        kwd: foo
+  - match:
+      docs.1._source:
+        kwd: bar
+
+---
+force_synthetic_source_bad_mapping:
+  - skip:
+      version: " - 8.3.99"
+      reason: introduced in 8.4.0
+
+  - do:
+      indices.create:
+        index: test
+        body:
+          settings:
+            number_of_shards: 1 # Use a single shard to get consistent error messages
+          mappings:
+            _source:
+              synthetic: false
+            properties:
+              text:
+                type: text
+
+  - do:
+      index:
+        index:   test
+        id:      1
+        body:
+          text: foo
+
+  - do:
+      index:
+        index:   test
+        id:      2
+        body:
+          text: bar
+
+  # When _source is used in the fetch the original _source is perfect
+  - do:
+      mget:
+        index: test
+        body:
+          ids: [ 1, 2 ]
+  - match:
+      docs.0._source:
+        text: foo
+  - match:
+      docs.1._source:
+        text: bar
+
+  # Forcing synthetic source fails because the mapping is invalid
+  - do:
+      mget:
+        index: test
+        force_synthetic_source: true
+        body:
+          ids: [ 1, 2 ]
+  - match: {docs.0.error.reason: "field [text] of type [text] doesn't support synthetic source unless it has a sub-field of type [keyword] with doc values enabled and without ignore_above or a normalizer"}
+  - match: {docs.1.error.reason: "field [text] of type [text] doesn't support synthetic source unless it has a sub-field of type [keyword] with doc values enabled and without ignore_above or a normalizer"}

--- a/server/src/main/java/org/elasticsearch/action/get/TransportShardMultiGetAction.java
+++ b/server/src/main/java/org/elasticsearch/action/get/TransportShardMultiGetAction.java
@@ -124,7 +124,7 @@ public class TransportShardMultiGetAction extends TransportSingleShardAction<Mul
                         item.version(),
                         item.versionType(),
                         item.fetchSourceContext(),
-                        false
+                        request.isForceSyntheticSource()
                     );
                 response.add(request.locations.get(i), new GetResponse(getResult));
             } catch (RuntimeException e) {

--- a/server/src/main/java/org/elasticsearch/rest/action/document/RestMultiGetAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/document/RestMultiGetAction.java
@@ -13,6 +13,7 @@ import org.elasticsearch.client.internal.node.NodeClient;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.core.RestApiVersion;
+import org.elasticsearch.index.IndexSettings;
 import org.elasticsearch.rest.BaseRestHandler;
 import org.elasticsearch.rest.RestRequest;
 import org.elasticsearch.rest.action.RestToXContentListener;
@@ -60,6 +61,10 @@ public class RestMultiGetAction extends BaseRestHandler {
         multiGetRequest.refresh(request.paramAsBoolean("refresh", multiGetRequest.refresh()));
         multiGetRequest.preference(request.param("preference"));
         multiGetRequest.realtime(request.paramAsBoolean("realtime", multiGetRequest.realtime()));
+        if (IndexSettings.isTimeSeriesModeEnabled() && request.paramAsBoolean("force_synthetic_source", false)) {
+            multiGetRequest.setForceSyntheticSource(true);
+        }
+
         if (request.param("fields") != null) {
             throw new IllegalArgumentException(
                 "The parameter [fields] is no longer supported, "

--- a/server/src/test/java/org/elasticsearch/action/get/GetRequestTests.java
+++ b/server/src/test/java/org/elasticsearch/action/get/GetRequestTests.java
@@ -7,7 +7,10 @@
  */
 package org.elasticsearch.action.get;
 
+import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionRequestValidationException;
+import org.elasticsearch.common.io.stream.BytesStreamOutput;
+import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.test.ESTestCase;
 
 import static org.hamcrest.CoreMatchers.hasItems;
@@ -32,5 +35,14 @@ public class GetRequestTests extends ESTestCase {
             assertEquals(1, validate.validationErrors().size());
             assertThat(validate.validationErrors(), hasItems("id is missing"));
         }
+    }
+
+    public void testForceSyntheticUnsupported() {
+        GetRequest request = new GetRequest("index", "id");
+        request.setForceSyntheticSource(true);
+        StreamOutput out = new BytesStreamOutput();
+        out.setVersion(Version.V_8_3_0);
+        Exception e = expectThrows(IllegalArgumentException.class, () -> request.writeTo(out));
+        assertEquals(e.getMessage(), "force_synthetic_source is not supported before 8.4.0");
     }
 }

--- a/server/src/test/java/org/elasticsearch/action/get/MultiGetRequestTests.java
+++ b/server/src/test/java/org/elasticsearch/action/get/MultiGetRequestTests.java
@@ -8,8 +8,11 @@
 
 package org.elasticsearch.action.get;
 
+import org.elasticsearch.Version;
 import org.elasticsearch.common.ParsingException;
 import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.common.io.stream.BytesStreamOutput;
+import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.index.VersionType;
 import org.elasticsearch.search.fetch.subphase.FetchSourceContext;
 import org.elasticsearch.test.ESTestCase;
@@ -117,6 +120,15 @@ public class MultiGetRequestTests extends ESTestCase {
         }
     }
 
+    public void testForceSyntheticUnsupported() {
+        MultiGetRequest request = createTestInstance();
+        request.setForceSyntheticSource(true);
+        StreamOutput out = new BytesStreamOutput();
+        out.setVersion(Version.V_8_3_0);
+        Exception e = expectThrows(IllegalArgumentException.class, () -> request.writeTo(out));
+        assertEquals(e.getMessage(), "force_synthetic_source is not supported before 8.4.0");
+    }
+
     private MultiGetRequest createTestInstance() {
         int numItems = randomIntBetween(0, 128);
         MultiGetRequest request = new MultiGetRequest();
@@ -148,6 +160,9 @@ public class MultiGetRequestTests extends ESTestCase {
                 item.routing(randomAlphaOfLength(4));
             }
             request.add(item);
+        }
+        if (randomBoolean()) {
+            request.setForceSyntheticSource(true);
         }
         return request;
     }

--- a/server/src/test/java/org/elasticsearch/action/get/MultiGetShardRequestTests.java
+++ b/server/src/test/java/org/elasticsearch/action/get/MultiGetShardRequestTests.java
@@ -18,7 +18,7 @@ import org.elasticsearch.test.ESTestCase;
 
 import java.io.IOException;
 
-import static org.elasticsearch.test.VersionUtils.randomVersion;
+import static org.elasticsearch.test.VersionUtils.randomVersionBetween;
 import static org.hamcrest.CoreMatchers.equalTo;
 
 public class MultiGetShardRequestTests extends ESTestCase {
@@ -26,7 +26,11 @@ public class MultiGetShardRequestTests extends ESTestCase {
         MultiGetShardRequest multiGetShardRequest = createTestInstance(randomBoolean());
 
         BytesStreamOutput out = new BytesStreamOutput();
-        out.setVersion(randomVersion(random()));
+        Version minVersion = Version.CURRENT.minimumCompatibilityVersion();
+        if (multiGetShardRequest.isForceSyntheticSource()) {
+            minVersion = Version.V_8_4_0;
+        }
+        out.setVersion(randomVersionBetween(random(), minVersion, Version.CURRENT));
         multiGetShardRequest.writeTo(out);
 
         StreamInput in = out.bytes().streamInput();

--- a/server/src/test/java/org/elasticsearch/action/get/MultiGetShardRequestTests.java
+++ b/server/src/test/java/org/elasticsearch/action/get/MultiGetShardRequestTests.java
@@ -8,8 +8,10 @@
 
 package org.elasticsearch.action.get;
 
+import org.elasticsearch.Version;
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.index.VersionType;
 import org.elasticsearch.search.fetch.subphase.FetchSourceContext;
 import org.elasticsearch.test.ESTestCase;
@@ -21,37 +23,7 @@ import static org.hamcrest.CoreMatchers.equalTo;
 
 public class MultiGetShardRequestTests extends ESTestCase {
     public void testSerialization() throws IOException {
-        MultiGetRequest multiGetRequest = new MultiGetRequest();
-        if (randomBoolean()) {
-            multiGetRequest.preference(randomAlphaOfLength(randomIntBetween(1, 10)));
-        }
-        if (randomBoolean()) {
-            multiGetRequest.realtime(false);
-        }
-        if (randomBoolean()) {
-            multiGetRequest.refresh(true);
-        }
-        MultiGetShardRequest multiGetShardRequest = new MultiGetShardRequest(multiGetRequest, "index", 0);
-        int numItems = iterations(10, 30);
-        for (int i = 0; i < numItems; i++) {
-            MultiGetRequest.Item item = new MultiGetRequest.Item("alias-" + randomAlphaOfLength(randomIntBetween(1, 10)), "id-" + i);
-            if (randomBoolean()) {
-                int numFields = randomIntBetween(1, 5);
-                String[] fields = new String[numFields];
-                for (int j = 0; j < fields.length; j++) {
-                    fields[j] = randomAlphaOfLength(randomIntBetween(1, 10));
-                }
-                item.storedFields(fields);
-            }
-            if (randomBoolean()) {
-                item.version(randomIntBetween(1, Integer.MAX_VALUE));
-                item.versionType(randomFrom(VersionType.values()));
-            }
-            if (randomBoolean()) {
-                item.fetchSourceContext(FetchSourceContext.of(randomBoolean()));
-            }
-            multiGetShardRequest.add(0, item);
-        }
+        MultiGetShardRequest multiGetShardRequest = createTestInstance(randomBoolean());
 
         BytesStreamOutput out = new BytesStreamOutput();
         out.setVersion(randomVersion(random()));
@@ -78,4 +50,51 @@ public class MultiGetShardRequestTests extends ESTestCase {
         assertThat(multiGetShardRequest2.indices(), equalTo(multiGetShardRequest.indices()));
         assertThat(multiGetShardRequest2.indicesOptions(), equalTo(multiGetShardRequest.indicesOptions()));
     }
+
+    public void testForceSyntheticUnsupported() {
+        MultiGetShardRequest request = createTestInstance(true);
+        StreamOutput out = new BytesStreamOutput();
+        out.setVersion(Version.V_8_3_0);
+        Exception e = expectThrows(IllegalArgumentException.class, () -> request.writeTo(out));
+        assertEquals(e.getMessage(), "force_synthetic_source is not supported before 8.4.0");
+    }
+
+    private MultiGetShardRequest createTestInstance(boolean forceSyntheticSource) {
+        MultiGetRequest multiGetRequest = new MultiGetRequest();
+        if (randomBoolean()) {
+            multiGetRequest.preference(randomAlphaOfLength(randomIntBetween(1, 10)));
+        }
+        if (randomBoolean()) {
+            multiGetRequest.realtime(false);
+        }
+        if (randomBoolean()) {
+            multiGetRequest.refresh(true);
+        }
+        if (forceSyntheticSource) {
+            multiGetRequest.setForceSyntheticSource(true);
+        }
+        MultiGetShardRequest multiGetShardRequest = new MultiGetShardRequest(multiGetRequest, "index", 0);
+        int numItems = iterations(10, 30);
+        for (int i = 0; i < numItems; i++) {
+            MultiGetRequest.Item item = new MultiGetRequest.Item("alias-" + randomAlphaOfLength(randomIntBetween(1, 10)), "id-" + i);
+            if (randomBoolean()) {
+                int numFields = randomIntBetween(1, 5);
+                String[] fields = new String[numFields];
+                for (int j = 0; j < fields.length; j++) {
+                    fields[j] = randomAlphaOfLength(randomIntBetween(1, 10));
+                }
+                item.storedFields(fields);
+            }
+            if (randomBoolean()) {
+                item.version(randomIntBetween(1, Integer.MAX_VALUE));
+                item.versionType(randomFrom(VersionType.values()));
+            }
+            if (randomBoolean()) {
+                item.fetchSourceContext(FetchSourceContext.of(randomBoolean()));
+            }
+            multiGetShardRequest.add(0, item);
+        }
+        return multiGetShardRequest;
+    }
+
 }


### PR DESCRIPTION
This adds the option to force synthetic source to the MGET API. See
 #87068 for more discussion on why you'd want to do that - the short
version is to get an upper bound on the performance cost of using
synthetic source in MGET.
