### PR TITLE
[8.3] Add error message when searchable snapshot cache wasn't cleared (#87503)

### DIFF
--- a/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/xpack/searchablesnapshots/AbstractSearchableSnapshotsRestTestCase.java
+++ b/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/xpack/searchablesnapshots/AbstractSearchableSnapshotsRestTestCase.java
@@ -335,7 +335,7 @@ public abstract class AbstractSearchableSnapshotsRestTestCase extends ESRestTest
             clearCache(restoredIndexName);
 
             final long bytesInCacheAfterClear = sumCachedBytesWritten.apply(searchableSnapshotStats(restoredIndexName));
-            assertThat(bytesInCacheAfterClear, equalTo(bytesInCacheBeforeClear));
+            assertThat("Searchable snapshot cache wasn't cleared", bytesInCacheAfterClear, equalTo(bytesInCacheBeforeClear));
 
             searchResults = search(restoredIndexName, QueryBuilders.matchAllQuery(), Boolean.TRUE);
             assertThat(extractValue(searchResults, "hits.total.value"), equalTo(numDocs));


### PR DESCRIPTION
Backports the following commits to 8.3:
 - Add error message when searchable snapshot cache wasn't cleared (#87503)