### PR TITLE
[8.3] Add more GraalThread filtering in tests (#87571)

### DIFF
--- a/client/test/src/main/java/org/elasticsearch/client/ClientsGraalVMThreadsFilter.java
+++ b/client/test/src/main/java/org/elasticsearch/client/ClientsGraalVMThreadsFilter.java
@@ -25,7 +25,7 @@ import com.carrotsearch.randomizedtesting.ThreadFilter;
  * The GraalVM spawns extra threads, which causes our thread leak
  * detection to fail. Filter these threads out since we can't clean them up.
  */
-public class GraalVMThreadsFilter implements ThreadFilter {
+public class ClientsGraalVMThreadsFilter implements ThreadFilter {
     @Override
     public boolean reject(Thread t) {
         return t.getName().startsWith("Libgraal");

--- a/client/test/src/main/java/org/elasticsearch/client/RestClientTestCase.java
+++ b/client/test/src/main/java/org/elasticsearch/client/RestClientTestCase.java
@@ -52,7 +52,7 @@ import static org.junit.Assert.assertTrue;
 @ThreadLeakAction({ ThreadLeakAction.Action.WARN, ThreadLeakAction.Action.INTERRUPT })
 @ThreadLeakZombies(ThreadLeakZombies.Consequence.IGNORE_REMAINING_TESTS)
 @ThreadLeakLingering(linger = 5000) // 5 sec lingering
-@ThreadLeakFilters(filters = { GraalVMThreadsFilter.class })
+@ThreadLeakFilters(filters = { ClientsGraalVMThreadsFilter.class })
 @TimeoutSuite(millis = 2 * 60 * 60 * 1000)
 public abstract class RestClientTestCase extends RandomizedTest {
 

--- a/plugins/analysis-icu/src/test/java/org/elasticsearch/plugin/analysis/icu/IndexableBinaryStringToolsTests.java
+++ b/plugins/analysis-icu/src/test/java/org/elasticsearch/plugin/analysis/icu/IndexableBinaryStringToolsTests.java
@@ -18,6 +18,7 @@
 package org.elasticsearch.plugin.analysis.icu;
 
 import com.carrotsearch.randomizedtesting.annotations.Listeners;
+import com.carrotsearch.randomizedtesting.annotations.ThreadLeakFilters;
 import com.carrotsearch.randomizedtesting.annotations.ThreadLeakScope;
 import com.carrotsearch.randomizedtesting.annotations.ThreadLeakScope.Scope;
 import com.carrotsearch.randomizedtesting.annotations.TimeoutSuite;
@@ -25,6 +26,7 @@ import com.carrotsearch.randomizedtesting.annotations.TimeoutSuite;
 import org.apache.lucene.tests.util.LuceneTestCase;
 import org.apache.lucene.tests.util.TimeUnits;
 import org.apache.lucene.util.ArrayUtil;
+import org.elasticsearch.test.GraalVMThreadsFilter;
 import org.elasticsearch.test.junit.listeners.ReproduceInfoPrinter;
 import org.junit.BeforeClass;
 
@@ -35,6 +37,7 @@ import java.util.Locale;
  */
 @Deprecated
 @Listeners({ ReproduceInfoPrinter.class })
+@ThreadLeakFilters(filters = { GraalVMThreadsFilter.class })
 @ThreadLeakScope(Scope.NONE)
 @TimeoutSuite(millis = TimeUnits.HOUR)
 @LuceneTestCase.SuppressSysoutChecks(bugUrl = "we log a lot on purpose")

--- a/qa/no-bootstrap-tests/src/test/java/org/elasticsearch/bootstrap/SpawnerNoBootstrapTests.java
+++ b/qa/no-bootstrap-tests/src/test/java/org/elasticsearch/bootstrap/SpawnerNoBootstrapTests.java
@@ -8,6 +8,8 @@
 
 package org.elasticsearch.bootstrap;
 
+import com.carrotsearch.randomizedtesting.annotations.ThreadLeakFilters;
+
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -22,6 +24,7 @@ import org.elasticsearch.env.Environment;
 import org.elasticsearch.env.TestEnvironment;
 import org.elasticsearch.plugins.Platforms;
 import org.elasticsearch.plugins.PluginTestUtil;
+import org.elasticsearch.test.GraalVMThreadsFilter;
 import org.elasticsearch.test.MockLogAppender;
 
 import java.io.IOException;
@@ -52,6 +55,7 @@ import static org.hamcrest.Matchers.instanceOf;
  * that prevents the Spawner class from doing its job. Also needs to run in a separate JVM to other
  * tests that extend ESTestCase for the same reason.
  */
+@ThreadLeakFilters(filters = { GraalVMThreadsFilter.class })
 public class SpawnerNoBootstrapTests extends LuceneTestCase {
 
     private static final String CONTROLLER_SOURCE = """

--- a/server/src/test/java/org/elasticsearch/bootstrap/NoSecurityManagerTests.java
+++ b/server/src/test/java/org/elasticsearch/bootstrap/NoSecurityManagerTests.java
@@ -8,10 +8,14 @@
 
 package org.elasticsearch.bootstrap;
 
+import com.carrotsearch.randomizedtesting.annotations.ThreadLeakFilters;
+
 import org.apache.lucene.tests.util.LuceneTestCase;
+import org.elasticsearch.test.GraalVMThreadsFilter;
 
 import static org.hamcrest.Matchers.is;
 
+@ThreadLeakFilters(filters = { GraalVMThreadsFilter.class })
 public class NoSecurityManagerTests extends LuceneTestCase {
 
     public void testPrepopulateSecurityCaller() {

--- a/server/src/test/java/org/elasticsearch/lucene/index/LazySoftDeletesDirectoryReaderWrapperTests.java
+++ b/server/src/test/java/org/elasticsearch/lucene/index/LazySoftDeletesDirectoryReaderWrapperTests.java
@@ -8,6 +8,8 @@
 
 package org.elasticsearch.lucene.index;
 
+import com.carrotsearch.randomizedtesting.annotations.ThreadLeakFilters;
+
 import org.apache.lucene.document.Document;
 import org.apache.lucene.document.Field;
 import org.apache.lucene.document.NumericDocValuesField;
@@ -26,12 +28,14 @@ import org.apache.lucene.store.Directory;
 import org.apache.lucene.tests.util.LuceneTestCase;
 import org.elasticsearch.core.IOUtils;
 import org.elasticsearch.index.engine.LazySoftDeletesDirectoryReaderWrapper;
+import org.elasticsearch.test.GraalVMThreadsFilter;
 
 import java.io.IOException;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 
+@ThreadLeakFilters(filters = { GraalVMThreadsFilter.class })
 public class LazySoftDeletesDirectoryReaderWrapperTests extends LuceneTestCase {
 
     public void testDropFullyDeletedSegments() throws IOException {

--- a/test/framework/src/main/java/org/elasticsearch/test/ESTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/ESTestCase.java
@@ -9,6 +9,7 @@ package org.elasticsearch.test;
 
 import com.carrotsearch.randomizedtesting.RandomizedTest;
 import com.carrotsearch.randomizedtesting.annotations.Listeners;
+import com.carrotsearch.randomizedtesting.annotations.ThreadLeakFilters;
 import com.carrotsearch.randomizedtesting.annotations.ThreadLeakLingering;
 import com.carrotsearch.randomizedtesting.annotations.ThreadLeakScope;
 import com.carrotsearch.randomizedtesting.annotations.ThreadLeakScope.Scope;
@@ -170,6 +171,7 @@ import static org.hamcrest.Matchers.startsWith;
 @ThreadLeakScope(Scope.SUITE)
 @ThreadLeakLingering(linger = 5000) // 5 sec lingering
 @TimeoutSuite(millis = 20 * TimeUnits.MINUTE)
+@ThreadLeakFilters(filters = { GraalVMThreadsFilter.class })
 @LuceneTestCase.SuppressSysoutChecks(bugUrl = "we log a lot on purpose")
 // we suppress pretty much all the lucene codecs for now, except asserting
 // assertingcodec is the winner for a codec here: it finds bugs and gives clear exceptions.

--- a/test/framework/src/main/java/org/elasticsearch/test/GraalVMThreadsFilter.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/GraalVMThreadsFilter.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.test;
+
+import com.carrotsearch.randomizedtesting.ThreadFilter;
+
+/**
+ * The GraalVM spawns extra threads, which causes our thread leak
+ * detection to fail. Filter these threads out since we can't clean them up.
+ */
+public class GraalVMThreadsFilter implements ThreadFilter {
+    @Override
+    public boolean reject(Thread t) {
+        return t.getName().startsWith("Libgraal");
+    }
+}

--- a/x-pack/plugin/ml/qa/no-bootstrap-tests/src/test/java/org/elasticsearch/xpack/ml/utils/NamedPipeHelperNoBootstrapTests.java
+++ b/x-pack/plugin/ml/qa/no-bootstrap-tests/src/test/java/org/elasticsearch/xpack/ml/utils/NamedPipeHelperNoBootstrapTests.java
@@ -6,6 +6,7 @@
  */
 package org.elasticsearch.xpack.ml.utils;
 
+import com.carrotsearch.randomizedtesting.annotations.ThreadLeakFilters;
 import com.sun.jna.IntegerType;
 import com.sun.jna.Native;
 import com.sun.jna.Pointer;
@@ -19,6 +20,7 @@ import org.elasticsearch.core.PathUtils;
 import org.elasticsearch.env.Environment;
 import org.elasticsearch.env.TestEnvironment;
 import org.elasticsearch.monitor.jvm.JvmInfo;
+import org.elasticsearch.test.GraalVMThreadsFilter;
 
 import java.io.BufferedReader;
 import java.io.IOException;
@@ -40,6 +42,7 @@ import java.time.Duration;
  * The way that pipes are managed in this class, e.g. using the mkfifo shell command, is
  * not suitable for production, but adequate for this test.
  */
+@ThreadLeakFilters(filters = { GraalVMThreadsFilter.class })
 public class NamedPipeHelperNoBootstrapTests extends LuceneTestCase {
 
     private static final NamedPipeHelper NAMED_PIPE_HELPER = new NamedPipeHelper();

--- a/x-pack/plugin/old-lucene-versions/src/test/java/org/elasticsearch/xpack/lucene/bwc/codecs/lucene50/BlockPostingsFormat2Tests.java
+++ b/x-pack/plugin/old-lucene-versions/src/test/java/org/elasticsearch/xpack/lucene/bwc/codecs/lucene50/BlockPostingsFormat2Tests.java
@@ -32,11 +32,11 @@ import org.apache.lucene.index.IndexableField;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.tests.analysis.MockAnalyzer;
 import org.apache.lucene.tests.index.RandomIndexWriter;
-import org.apache.lucene.tests.util.LuceneTestCase;
 import org.apache.lucene.tests.util.TestUtil;
+import org.elasticsearch.test.ESTestCase;
 
 /** Tests special cases of BlockPostingsFormat */
-public class BlockPostingsFormat2Tests extends LuceneTestCase {
+public class BlockPostingsFormat2Tests extends ESTestCase {
     Directory dir;
     RandomIndexWriter iw;
 

--- a/x-pack/plugin/old-lucene-versions/src/test/java/org/elasticsearch/xpack/lucene/bwc/codecs/lucene50/BlockPostingsFormat3Tests.java
+++ b/x-pack/plugin/old-lucene-versions/src/test/java/org/elasticsearch/xpack/lucene/bwc/codecs/lucene50/BlockPostingsFormat3Tests.java
@@ -45,12 +45,12 @@ import org.apache.lucene.tests.analysis.MockTokenizer;
 import org.apache.lucene.tests.analysis.MockVariableLengthPayloadFilter;
 import org.apache.lucene.tests.index.RandomIndexWriter;
 import org.apache.lucene.tests.util.English;
-import org.apache.lucene.tests.util.LuceneTestCase;
 import org.apache.lucene.tests.util.TestUtil;
 import org.apache.lucene.tests.util.automaton.AutomatonTestUtil;
 import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.automaton.CompiledAutomaton;
 import org.apache.lucene.util.automaton.RegExp;
+import org.elasticsearch.test.ESTestCase;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -58,7 +58,7 @@ import java.util.HashSet;
 import java.util.Random;
 
 /** Tests partial enumeration (only pulling a subset of the indexed data) */
-public class BlockPostingsFormat3Tests extends LuceneTestCase {
+public class BlockPostingsFormat3Tests extends ESTestCase {
     private final int MAXDOC = TEST_NIGHTLY ? Lucene50PostingsFormat.BLOCK_SIZE * 20 : Lucene50PostingsFormat.BLOCK_SIZE * 3;
 
     // creates 8 fields with different options and does "duels" of fields against each other

--- a/x-pack/plugin/old-lucene-versions/src/test/java/org/elasticsearch/xpack/lucene/bwc/codecs/lucene50/BlockPostingsFormatTests.java
+++ b/x-pack/plugin/old-lucene-versions/src/test/java/org/elasticsearch/xpack/lucene/bwc/codecs/lucene50/BlockPostingsFormatTests.java
@@ -19,6 +19,8 @@
  */
 package org.elasticsearch.xpack.lucene.bwc.codecs.lucene50;
 
+import com.carrotsearch.randomizedtesting.annotations.ThreadLeakFilters;
+
 import org.apache.lucene.backward_codecs.store.EndiannessReverserUtil;
 import org.apache.lucene.codecs.Codec;
 import org.apache.lucene.codecs.CompetitiveImpactAccumulator;
@@ -36,6 +38,7 @@ import org.apache.lucene.store.IndexOutput;
 import org.apache.lucene.tests.analysis.MockAnalyzer;
 import org.apache.lucene.tests.index.BasePostingsFormatTestCase;
 import org.apache.lucene.tests.util.TestUtil;
+import org.elasticsearch.test.GraalVMThreadsFilter;
 import org.elasticsearch.xpack.lucene.bwc.codecs.lucene40.blocktree.FieldReader;
 import org.elasticsearch.xpack.lucene.bwc.codecs.lucene40.blocktree.Stats;
 import org.elasticsearch.xpack.lucene.bwc.codecs.lucene50.Lucene50ScoreSkipReader.MutableImpactList;
@@ -46,6 +49,7 @@ import java.util.Collections;
 import java.util.List;
 
 /** Tests BlockPostingsFormat */
+@ThreadLeakFilters(filters = { GraalVMThreadsFilter.class })
 public class BlockPostingsFormatTests extends BasePostingsFormatTestCase {
     private final Codec codec = TestUtil.alwaysPostingsFormat(new Lucene50RWPostingsFormat());
 

--- a/x-pack/plugin/old-lucene-versions/src/test/java/org/elasticsearch/xpack/lucene/bwc/codecs/lucene54/Lucene54DocValuesFormatTests.java
+++ b/x-pack/plugin/old-lucene-versions/src/test/java/org/elasticsearch/xpack/lucene/bwc/codecs/lucene54/Lucene54DocValuesFormatTests.java
@@ -7,10 +7,14 @@
 
 package org.elasticsearch.xpack.lucene.bwc.codecs.lucene54;
 
+import com.carrotsearch.randomizedtesting.annotations.ThreadLeakFilters;
+
 import org.apache.lucene.codecs.Codec;
 import org.apache.lucene.tests.index.BaseDocValuesFormatTestCase;
 import org.apache.lucene.tests.util.TestUtil;
+import org.elasticsearch.test.GraalVMThreadsFilter;
 
+@ThreadLeakFilters(filters = { GraalVMThreadsFilter.class })
 public class Lucene54DocValuesFormatTests extends BaseDocValuesFormatTestCase {
 
     private final Codec codec = TestUtil.alwaysDocValuesFormat(new Lucene54DocValuesFormat());

--- a/x-pack/plugin/sql/sql-cli/src/test/java/org/elasticsearch/xpack/sql/cli/SqlCliTestCase.java
+++ b/x-pack/plugin/sql/sql-cli/src/test/java/org/elasticsearch/xpack/sql/cli/SqlCliTestCase.java
@@ -8,12 +8,14 @@
 package org.elasticsearch.xpack.sql.cli;
 
 import com.carrotsearch.randomizedtesting.annotations.Listeners;
+import com.carrotsearch.randomizedtesting.annotations.ThreadLeakFilters;
 import com.carrotsearch.randomizedtesting.annotations.ThreadLeakLingering;
 import com.carrotsearch.randomizedtesting.annotations.ThreadLeakScope;
 import com.carrotsearch.randomizedtesting.annotations.TimeoutSuite;
 
 import org.apache.lucene.tests.util.LuceneTestCase;
 import org.apache.lucene.tests.util.TimeUnits;
+import org.elasticsearch.test.GraalVMThreadsFilter;
 import org.elasticsearch.test.junit.listeners.LoggingListener;
 import org.elasticsearch.test.junit.listeners.ReproduceInfoPrinter;
 
@@ -21,6 +23,7 @@ import static com.carrotsearch.randomizedtesting.RandomizedTest.randomAsciiLette
 
 @Listeners({ ReproduceInfoPrinter.class, LoggingListener.class })
 @ThreadLeakScope(ThreadLeakScope.Scope.SUITE)
+@ThreadLeakFilters(filters = { GraalVMThreadsFilter.class })
 @ThreadLeakLingering(linger = 5000) // 5 sec lingering
 @TimeoutSuite(millis = 20 * TimeUnits.MINUTE)
 @LuceneTestCase.SuppressSysoutChecks(bugUrl = "we log a lot on purpose")


### PR DESCRIPTION
Backports the following commits to 8.3:
 - Add more GraalThread filtering in tests (#87571)