### PR TITLE
Tests for synthetic _source from translog

### DIFF
--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/get/100_synthetic_source.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/get/100_synthetic_source.yml
@@ -35,6 +35,49 @@ keyword:
         kwd: foo
 
 ---
+fetch without refresh also produces synthetic source:
+  - skip:
+      version: " - 8.2.99"
+      reason: introduced in 8.3.0
+
+  - do:
+      indices.create:
+        index: test
+        body:
+          settings:
+            index:
+              refresh_interval: -1
+          mappings:
+            _source:
+              synthetic: true
+            properties:
+              obj:
+                properties:
+                  kwd:
+                    type: keyword
+
+  - do:
+      index:
+        index:   test
+        id:      1
+        refresh: false # no refreshing!
+        body:
+          obj.kwd: foo
+
+  - do:
+      get:
+        index: test
+        id:    1
+  - match: {_index: "test"}
+  - match: {_id: "1"}
+  - match: {_version: 1}
+  - match: {found: true}
+  - match:
+      _source: # synthetic source will convert the dotted field names into an object, even when loading from the translog
+        obj:
+          kwd: foo
+
+---
 force_synthetic_source_ok:
   - skip:
       version: " - 8.3.99"


### PR DESCRIPTION
This adds tests to make sure that we use all of the normal synthetic
source machinery, even when loading from the translog. So all GETs on
synthetic source indices will require an in memory index. That'll be an
extra cost on indices that are updated very very frequently.
