### PR TITLE
[DOCS] fixing a typo in cat snapshots options

### DIFF
--- a/docs/reference/cat/snapshots.asciidoc
+++ b/docs/reference/cat/snapshots.asciidoc
@@ -103,7 +103,7 @@ units>>.
 `total_shards`, `ts`::
 (Default) Total number of shards in the snapshot.
 
-`reason, `r`::
+`reason`, `r`::
 Reason for any snapshot failures.
 --
 


### PR DESCRIPTION
Adding a typo ``` in the doc
