### PR TITLE
Test fix: Ensure a node role will not be used as an attr

### DIFF
--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/SetSingleNodeAllocateStepTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/SetSingleNodeAllocateStepTests.java
@@ -35,7 +35,6 @@ import org.mockito.Mockito;
 
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -112,12 +111,8 @@ public class SetSingleNodeAllocateStepTests extends AbstractStepTestCase<SetSing
     }
 
     public void testPerformActionAttrsAllNodesValid() throws Exception {
-        int numAttrs = randomIntBetween(1, 10);
         final int numNodes = randomIntBetween(1, 20);
-        String[][] validAttrs = new String[numAttrs][2];
-        for (int i = 0; i < numAttrs; i++) {
-            validAttrs[i] = new String[] { randomAlphaOfLengthBetween(1, 20), randomAlphaOfLengthBetween(1, 20) };
-        }
+        String[][] validAttrs = generateRandomValidAttributes(randomIntBetween(1, 10));
         Settings.Builder indexSettings = settings(Version.CURRENT);
         for (String[] attr : validAttrs) {
             indexSettings.put(IndexMetadata.INDEX_ROUTING_INCLUDE_GROUP_SETTING.getKey() + attr[0], attr[1]);
@@ -258,22 +253,11 @@ public class SetSingleNodeAllocateStepTests extends AbstractStepTestCase<SetSing
 
     public void testPerformActionAttrsRequestFails() {
         final int numNodes = randomIntBetween(1, 20);
-        int numAttrs = randomIntBetween(1, 10);
-        Map<String, String> validAttributes = new HashMap<>();
-        for (int i = 0; i < numAttrs; i++) {
-            validAttributes.put(
-                randomValueOtherThanMany(
-                    attr -> validAttributes.containsKey(attr) || DiscoveryNodeRole.roleNames().contains(attr),
-                    () -> randomAlphaOfLengthBetween(1, 20)
-                ),
-                randomAlphaOfLengthBetween(1, 20)
-            );
-        }
+        String[][] validAttrs = generateRandomValidAttributes(randomIntBetween(1, 10));
         Settings.Builder indexSettings = settings(Version.CURRENT);
-        validAttributes.forEach((k, v) -> {
-            indexSettings.put(IndexMetadata.INDEX_ROUTING_INCLUDE_GROUP_SETTING.getKey() + k, v);
-
-        });
+        for (String[] attr : validAttrs) {
+            indexSettings.put(IndexMetadata.INDEX_ROUTING_INCLUDE_GROUP_SETTING.getKey() + attr[0], attr[1]);
+        }
         IndexMetadata indexMetadata = IndexMetadata.builder(randomAlphaOfLength(10))
             .settings(indexSettings)
             .numberOfShards(randomIntBetween(1, 5))
@@ -287,11 +271,11 @@ public class SetSingleNodeAllocateStepTests extends AbstractStepTestCase<SetSing
             String nodeId = "node_id_" + i;
             String nodeName = "node_" + i;
             int nodePort = 9300 + i;
-            Map.Entry<String, String> nodeAttr = randomFrom(validAttributes.entrySet());
+            String[] nodeAttr = randomFrom(validAttrs);
             Settings nodeSettings = Settings.builder()
                 .put(validNodeSettings)
                 .put(Node.NODE_NAME_SETTING.getKey(), nodeName)
-                .put(Node.NODE_ATTRIBUTES.getKey() + nodeAttr.getKey(), nodeAttr.getValue())
+                .put(Node.NODE_ATTRIBUTES.getKey() + nodeAttr[0], nodeAttr[1])
                 .build();
             nodes.add(DiscoveryNode.createLocal(nodeSettings, new TransportAddress(TransportAddress.META_ADDRESS, nodePort), nodeId));
             validNodeIds.add(nodeId);
@@ -338,12 +322,8 @@ public class SetSingleNodeAllocateStepTests extends AbstractStepTestCase<SetSing
     }
 
     public void testPerformActionAttrsNoShard() {
-        int numAttrs = randomIntBetween(1, 10);
         final int numNodes = randomIntBetween(1, 20);
-        String[][] validAttrs = new String[numAttrs][2];
-        for (int i = 0; i < numAttrs; i++) {
-            validAttrs[i] = new String[] { "na_" + randomAlphaOfLengthBetween(1, 20), randomAlphaOfLengthBetween(1, 20) };
-        }
+        String[][] validAttrs = generateRandomValidAttributes(randomIntBetween(1, 10), "na_");
         Settings.Builder indexSettings = settings(Version.CURRENT);
         for (String[] attr : validAttrs) {
             indexSettings.put(IndexMetadata.INDEX_ROUTING_INCLUDE_GROUP_SETTING.getKey() + attr[0], attr[1]);
@@ -591,6 +571,21 @@ public class SetSingleNodeAllocateStepTests extends AbstractStepTestCase<SetSing
         IndexRoutingTable.Builder indexRoutingTable = createRoutingTableWithOneShardOnSubset(indexMetadata, oldNodeIds, oldNodeIds);
 
         assertNodeSelected(indexMetadata, indexMetadata.getIndex(), oldNodeIds, discoveryNodes, indexRoutingTable.build());
+    }
+
+    private String[][] generateRandomValidAttributes(int numAttrs) {
+        return generateRandomValidAttributes(numAttrs, "");
+    }
+
+    private String[][] generateRandomValidAttributes(int numAttrs, String prefix) {
+        Set<String> reservedNames = new HashSet<>(DiscoveryNodeRole.roleNames());
+        String[][] validAttrs = new String[numAttrs][2];
+        for (int i = 0; i < numAttrs; i++) {
+            validAttrs[i] = new String[] {
+                prefix + randomValueOtherThanMany(attr -> reservedNames.contains(prefix + attr), () -> randomAlphaOfLengthBetween(1, 20)),
+                randomAlphaOfLengthBetween(1, 20) };
+        }
+        return validAttrs;
     }
 
     private void assertNodeSelected(IndexMetadata indexMetadata, Index index, Set<String> validNodeIds, DiscoveryNodes.Builder nodes)


### PR DESCRIPTION
Test `SetSingleNodeAllocateStepTests.testPerformActionAttrsAllNodesValid` is failing when it picks a random attribute name that happens to be a node role. In this PR: 
- we create a new method that generates an attribute and ensures that an attribute is not generated twice during the test and it is not a node role, and
- we refactor all test cases that are generating random attribute names to use it. 

Resolves #87447 
