### PR TITLE
Speed up iteration over ImmutableOpenMap on hot paths

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/metadata/Metadata.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/Metadata.java
@@ -1845,7 +1845,7 @@ public class Metadata extends AbstractCollection<IndexMetadata> implements Diffa
             final ArrayList<String> duplicates = new ArrayList<>();
             final Set<String> aliasDuplicatesWithIndices = new HashSet<>();
             final Set<String> aliasDuplicatesWithDataStreams = new HashSet<>();
-            final Set<String> allDataStreams = dataStreamMetadata.dataStreams().keySet();
+            final var allDataStreams = dataStreamMetadata.dataStreams();
             // Adding data stream aliases:
             for (String dataStreamAlias : dataStreamMetadata.getDataStreamAliases().keySet()) {
                 if (indexAliases.contains(dataStreamAlias)) {
@@ -1854,23 +1854,23 @@ public class Metadata extends AbstractCollection<IndexMetadata> implements Diffa
                 if (indicesMap.containsKey(dataStreamAlias)) {
                     aliasDuplicatesWithIndices.add(dataStreamAlias);
                 }
-                if (allDataStreams.contains(dataStreamAlias)) {
+                if (allDataStreams.containsKey(dataStreamAlias)) {
                     aliasDuplicatesWithDataStreams.add(dataStreamAlias);
                 }
             }
             for (String alias : indexAliases) {
-                if (allDataStreams.contains(alias)) {
+                if (allDataStreams.containsKey(alias)) {
                     aliasDuplicatesWithDataStreams.add(alias);
                 }
                 if (indicesMap.containsKey(alias)) {
                     aliasDuplicatesWithIndices.add(alias);
                 }
             }
-            for (String ds : allDataStreams) {
-                if (indicesMap.containsKey(ds)) {
-                    duplicates.add("data stream [" + ds + "] conflicts with index");
+            allDataStreams.forEach((key, value) -> {
+                if (indicesMap.containsKey(key)) {
+                    duplicates.add("data stream [" + key + "] conflicts with index");
                 }
-            }
+            });
             if (aliasDuplicatesWithIndices.isEmpty() == false) {
                 collectAliasDuplicates(indicesMap, aliasDuplicatesWithIndices, duplicates);
             }

--- a/server/src/main/java/org/elasticsearch/common/collect/ImmutableOpenMap.java
+++ b/server/src/main/java/org/elasticsearch/common/collect/ImmutableOpenMap.java
@@ -12,6 +12,7 @@ import com.carrotsearch.hppc.ObjectCollection;
 import com.carrotsearch.hppc.ObjectObjectHashMap;
 import com.carrotsearch.hppc.cursors.ObjectCursor;
 import com.carrotsearch.hppc.cursors.ObjectObjectCursor;
+import com.carrotsearch.hppc.procedures.ObjectObjectProcedure;
 
 import java.util.AbstractCollection;
 import java.util.AbstractMap;
@@ -23,6 +24,7 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.Spliterator;
 import java.util.Spliterators;
+import java.util.function.BiConsumer;
 import java.util.function.BiPredicate;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
@@ -310,6 +312,11 @@ public final class ImmutableOpenMap<KType, VType> extends AbstractMap<KType, VTy
         };
     }
 
+    @Override
+    public void forEach(BiConsumer<? super KType, ? super VType> action) {
+        map.forEach((ObjectObjectProcedure<KType, VType>) action::accept);
+    }
+
     static <T> Iterator<T> iterator(ObjectCollection<T> collection) {
         final Iterator<ObjectCursor<T>> iterator = collection.iterator();
         return new Iterator<>() {
@@ -492,13 +499,6 @@ public final class ImmutableOpenMap<KType, VType> extends AbstractMap<KType, VTy
             return mutableMap.removeAll(predicate::test);
         }
 
-        public void removeAllFromCollection(Collection<KType> collection) {
-            maybeCloneMap();
-            for (var k : collection) {
-                mutableMap.remove(k);
-            }
-        }
-
         public void clear() {
             maybeCloneMap();
             mutableMap.clear();
@@ -529,29 +529,10 @@ public final class ImmutableOpenMap<KType, VType> extends AbstractMap<KType, VTy
             return mutableMap.indexExists(index);
         }
 
-        public VType indexGet(int index) {
-            maybeCloneMap();
-            return mutableMap.indexGet(index);
-        }
-
-        public VType indexReplace(int index, VType newValue) {
-            maybeCloneMap();
-            return mutableMap.indexReplace(index, newValue);
-        }
-
-        public void indexInsert(int index, KType key, VType value) {
-            maybeCloneMap();
-            mutableMap.indexInsert(index, key, value);
-        }
-
         public void release() {
             maybeCloneMap();
             mutableMap.release();
         }
 
-        public String visualizeKeyDistribution(int characters) {
-            maybeCloneMap();
-            return mutableMap.visualizeKeyDistribution(characters);
-        }
     }
 }

--- a/server/src/main/java/org/elasticsearch/gateway/PersistedClusterStateService.java
+++ b/server/src/main/java/org/elasticsearch/gateway/PersistedClusterStateService.java
@@ -907,10 +907,10 @@ public class PersistedClusterStateService {
             }
 
             final Map<String, Long> indexMetadataVersionByUUID = Maps.newMapWithExpectedSize(previouslyWrittenMetadata.indices().size());
-            for (IndexMetadata indexMetadata : previouslyWrittenMetadata.indices().values()) {
+            previouslyWrittenMetadata.indices().forEach((name, indexMetadata) -> {
                 final Long previousValue = indexMetadataVersionByUUID.putIfAbsent(indexMetadata.getIndexUUID(), indexMetadata.getVersion());
                 assert previousValue == null : indexMetadata.getIndexUUID() + " already mapped to " + previousValue;
-            }
+            });
 
             int numIndicesAdded = 0;
             int numIndicesUpdated = 0;


### PR DESCRIPTION
The adjusted spots can see very large maps of O(index_count) getting iterated.
Moving them to the efficient `forEach` that iterates the action in a tight loop
over an array instead of using the indirection of the iterator loop gives
a measurable speedup in many-shards benchmark bootstrapping.
Also, removed some dead code from the immutable open map.

relates #77466 