### PR TITLE
[8.3] Update disabling _source doc mentioning highlight (#87582)

### DIFF
--- a/docs/reference/how-to/disk-usage.asciidoc
+++ b/docs/reference/how-to/disk-usage.asciidoc
@@ -77,7 +77,7 @@ Keep in mind that large shard sizes come with drawbacks, such as long full recov
 [[disable-source]]
 === Disable `_source`
 
-The <<mapping-source-field,`_source`>> field stores the original JSON body of the document. If you don’t need access to it you can disable it. However, APIs that needs access to `_source` such as update and reindex won’t work.
+The <<mapping-source-field,`_source`>> field stores the original JSON body of the document. If you don’t need access to it you can disable it. However, APIs that needs access to `_source` such as update, highlight and reindex won’t work.
 
 [discrete]
 [[best-compression]]


### PR DESCRIPTION
Backports the following commits to 8.3:
 - Update disabling _source doc mentioning highlight (#87582)