### PR TITLE
[8.3] Mute testGeoPointGeoHex #87391 (#87606)

### DIFF
--- a/x-pack/plugin/spatial/src/internalClusterTest/java/org/elasticsearch/xpack/spatial/search/GeoGridAggAndQueryConsistencyIT.java
+++ b/x-pack/plugin/spatial/src/internalClusterTest/java/org/elasticsearch/xpack/spatial/search/GeoGridAggAndQueryConsistencyIT.java
@@ -76,6 +76,7 @@ public class GeoGridAggAndQueryConsistencyIT extends ESIntegTestCase {
         );
     }
 
+    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/87391")
     public void testGeoPointGeoHex() throws IOException {
         doTestGeohexGrid(GeoPointFieldMapper.CONTENT_TYPE, GeometryTestUtils::randomPoint);
     }


### PR DESCRIPTION
Backports the following commits to 8.3:
 - Mute testGeoPointGeoHex #87391 (#87606)