### PR TITLE
Remove obsolete test for realm domain setting registration

### DIFF
--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/XPackSettingsTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/XPackSettingsTests.java
@@ -12,12 +12,10 @@ import org.elasticsearch.test.ESTestCase;
 import java.security.NoSuchAlgorithmException;
 import javax.crypto.SecretKeyFactory;
 
-import static org.elasticsearch.xpack.core.security.authc.RealmSettings.DOMAIN_TO_REALM_ASSOC_SETTING;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasItem;
-import static org.hamcrest.Matchers.hasSize;
 
 public class XPackSettingsTests extends ESTestCase {
 
@@ -100,7 +98,7 @@ public class XPackSettingsTests extends ESTestCase {
     public void testDefaultServiceTokenHashingAlgorithm() {
         assertThat(XPackSettings.SERVICE_TOKEN_HASHING_ALGORITHM.get(Settings.EMPTY), equalTo("PBKDF2_STRETCH"));
     }
-    
+
     private boolean isSecretkeyFactoryAlgoAvailable(String algorithmId) {
         try {
             SecretKeyFactory.getInstance(algorithmId);

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/XPackSettingsTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/XPackSettingsTests.java
@@ -13,12 +13,10 @@ import java.security.NoSuchAlgorithmException;
 
 import javax.crypto.SecretKeyFactory;
 
-import static org.elasticsearch.xpack.core.security.authc.RealmSettings.DOMAIN_TO_REALM_ASSOC_SETTING;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasItem;
-import static org.hamcrest.Matchers.hasSize;
 
 public class XPackSettingsTests extends ESTestCase {
 
@@ -100,17 +98,6 @@ public class XPackSettingsTests extends ESTestCase {
 
     public void testDefaultServiceTokenHashingAlgorithm() {
         assertThat(XPackSettings.SERVICE_TOKEN_HASHING_ALGORITHM.get(Settings.EMPTY), equalTo("PBKDF2_STRETCH"));
-    }
-
-    // Whether the domain setting is registered by default depends on the build type
-    public void testRealmDomainSettingRegistrationDefault() {
-        assertThat(
-            XPackSettings.getAllSettings()
-                .stream()
-                .filter(setting -> setting.getKey().equals(DOMAIN_TO_REALM_ASSOC_SETTING.getKey()))
-                .toList(),
-            hasSize(1)
-        );
     }
 
     private boolean isSecretkeyFactoryAlgoAvailable(String algorithmId) {

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/XPackSettingsTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/XPackSettingsTests.java
@@ -10,12 +10,15 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.test.ESTestCase;
 
 import java.security.NoSuchAlgorithmException;
+
 import javax.crypto.SecretKeyFactory;
 
+import static org.elasticsearch.xpack.core.security.authc.RealmSettings.DOMAIN_TO_REALM_ASSOC_SETTING;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.hasSize;
 
 public class XPackSettingsTests extends ESTestCase {
 
@@ -97,6 +100,17 @@ public class XPackSettingsTests extends ESTestCase {
 
     public void testDefaultServiceTokenHashingAlgorithm() {
         assertThat(XPackSettings.SERVICE_TOKEN_HASHING_ALGORITHM.get(Settings.EMPTY), equalTo("PBKDF2_STRETCH"));
+    }
+
+    // Whether the domain setting is registered by default depends on the build type
+    public void testRealmDomainSettingRegistrationDefault() {
+        assertThat(
+            XPackSettings.getAllSettings()
+                .stream()
+                .filter(setting -> setting.getKey().equals(DOMAIN_TO_REALM_ASSOC_SETTING.getKey()))
+                .toList(),
+            hasSize(1)
+        );
     }
 
     private boolean isSecretkeyFactoryAlgoAvailable(String algorithmId) {

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/XPackSettingsTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/XPackSettingsTests.java
@@ -6,12 +6,10 @@
  */
 package org.elasticsearch.xpack.core;
 
-import org.elasticsearch.Build;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.test.ESTestCase;
 
 import java.security.NoSuchAlgorithmException;
-
 import javax.crypto.SecretKeyFactory;
 
 import static org.elasticsearch.xpack.core.security.authc.RealmSettings.DOMAIN_TO_REALM_ASSOC_SETTING;
@@ -102,18 +100,7 @@ public class XPackSettingsTests extends ESTestCase {
     public void testDefaultServiceTokenHashingAlgorithm() {
         assertThat(XPackSettings.SERVICE_TOKEN_HASHING_ALGORITHM.get(Settings.EMPTY), equalTo("PBKDF2_STRETCH"));
     }
-
-    // Whether the domain setting is registered by default depends on the build type
-    public void testRealmDomainSettingRegistrationDefault() {
-        assertThat(
-            XPackSettings.getAllSettings()
-                .stream()
-                .filter(setting -> setting.getKey().equals(DOMAIN_TO_REALM_ASSOC_SETTING.getKey()))
-                .toList(),
-            hasSize(1)
-        );
-    }
-
+    
     private boolean isSecretkeyFactoryAlgoAvailable(String algorithmId) {
         try {
             SecretKeyFactory.getInstance(algorithmId);

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/XPackSettingsTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/XPackSettingsTests.java
@@ -110,7 +110,7 @@ public class XPackSettingsTests extends ESTestCase {
                 .stream()
                 .filter(setting -> setting.getKey().equals(DOMAIN_TO_REALM_ASSOC_SETTING.getKey()))
                 .toList(),
-            hasSize(Build.CURRENT.isSnapshot() ? 1 : 0)
+            hasSize(1)
         );
     }
 


### PR DESCRIPTION
As part of feature flagging user profiles (#83347), we introduced
branching based on build type for setting
`DOMAIN_TO_REALM_ASSOC_SETTING` to enable easy downstream testing.
We've since removed the feature flag and the branching logic. The
outdated test fails for non-snapshot builds because the setting is now
always included. This PR removes the test since
`DOMAIN_TO_REALM_ASSOC_SETTING` is now a regular xpack setting like any
other. 

Closes https://github.com/elastic/elasticsearch/issues/87628