### PR TITLE
Add ParameterizedMessage to forbidden api

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -450,11 +450,12 @@ causes and their causes, as well as any suppressed exceptions and so on:
     logger.debug("operation failed", exception);
 
 If you wish to use placeholders and an exception at the same time, construct a
-`ParameterizedMessage`:
+`Supplier<String>` and use `org.elasticsearch.core.Strings.format`
+- note java.util.Formatter syntax
 
-    logger.debug(() -> "failed at offset [" + offset + "]", exception);
+    logger.debug(() -> Strings.format("failed at offset [%s]", offset), exception);
 
-You can also use a `Supplier<ParameterizedMessage>` to avoid constructing
+You can also use a `java.util.Supplier<String>` to avoid constructing
 expensive messages that will usually be discarded:
 
     logger.debug(() -> "rarely seen output [" + expensiveMethod() + "]");

--- a/build-tools-internal/src/main/resources/forbidden/es-all-signatures.txt
+++ b/build-tools-internal/src/main/resources/forbidden/es-all-signatures.txt
@@ -54,3 +54,11 @@ java.util.concurrent.ScheduledThreadPoolExecutor#<init>(int)
 java.util.concurrent.ScheduledThreadPoolExecutor#<init>(int, java.util.concurrent.ThreadFactory)
 java.util.concurrent.ScheduledThreadPoolExecutor#<init>(int, java.util.concurrent.RejectedExecutionHandler)
 java.util.concurrent.ScheduledThreadPoolExecutor#<init>(int, java.util.concurrent.ThreadFactory, java.util.concurrent.RejectedExecutionHandler)
+
+
+@defaultMessage use java.util.Supplier<String> with String.format instead of ParameterizedMessage
+org.apache.logging.log4j.message.ParameterizedMessage#<init>(java.lang.String, java.lang.String[], java.lang.Throwable)
+org.apache.logging.log4j.message.ParameterizedMessage#<init>(java.lang.String, java.lang.Object[], java.lang.Throwable)
+org.apache.logging.log4j.message.ParameterizedMessage#<init>(java.lang.String, java.lang.Object[])
+org.apache.logging.log4j.message.ParameterizedMessage#<init>(java.lang.String, java.lang.Object)
+org.apache.logging.log4j.message.ParameterizedMessage#<init>(java.lang.String, java.lang.Object, java.lang.Object)

--- a/server/src/test/java/org/elasticsearch/common/logging/LoggersTests.java
+++ b/server/src/test/java/org/elasticsearch/common/logging/LoggersTests.java
@@ -23,7 +23,7 @@ import static org.hamcrest.Matchers.nullValue;
 
 public class LoggersTests extends ESTestCase {
 
-    public void testParameterizedMessageLambda() throws Exception {
+    public void testStringSupplierAndFormatting() throws Exception {
         // adding a random id to allow test to run multiple times. See AbstractConfiguration#addAppender
         final MockAppender appender = new MockAppender("trace_appender" + randomInt());
         appender.start();


### PR DESCRIPTION
ParameterizedMessage will not be part of the new ES logging API and therefore should not be used.
java.util.Supplier<String> and String.format should be used instead.

this commit adds ParameterizedMessage to forbidden api 

relates https://github.com/elastic/elasticsearch/issues/86549