### PR TITLE
[7.17] Handle empty result in testRandomLimitConcurrentRequests (#87619)

### DIFF
--- a/server/src/test/java/org/elasticsearch/action/admin/indices/diskusage/TransportAnalyzeIndexDiskUsageActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/indices/diskusage/TransportAnalyzeIndexDiskUsageActionTests.java
@@ -209,7 +209,12 @@ public class TransportAnalyzeIndexDiskUsageActionTests extends ESTestCase {
             assertThat(response.getTotalShards(), equalTo(numberOfShards));
             assertThat(response.getFailedShards(), equalTo(failedShards.size()));
             assertThat(response.getSuccessfulShards(), equalTo(numberOfShards - failedShards.size()));
-            assertThat(response.getStats().get("test_index").getIndexSizeInBytes(), equalTo(totalIndexSize.get()));
+            if (numberOfShards == failedShards.size()) {
+                assertTrue(response.getStats().isEmpty());
+                assertThat(totalIndexSize.get(), equalTo(0L));
+            } else {
+                assertThat(response.getStats().get("test_index").getIndexSizeInBytes(), equalTo(totalIndexSize.get()));
+            }
         } finally {
             stopped.set(true);
             handlingThread.join();


### PR DESCRIPTION
Backports the following commits to 7.17:
 - Handle empty result in testRandomLimitConcurrentRequests (#87619)