### PR TITLE
[8.3] [DOCS] Clarify index_prefix in prefix query docs (#87450)

### DIFF
--- a/docs/reference/query-dsl/prefix-query.asciidoc
+++ b/docs/reference/query-dsl/prefix-query.asciidoc
@@ -67,9 +67,9 @@ GET /_search
 [[prefix-query-index-prefixes]]
 ===== Speed up prefix queries
 You can speed up prefix queries using the <<index-prefixes,`index_prefixes`>>
-mapping parameter. If enabled, {es} indexes prefixes between 2 and 5
-characters in a separate field. This lets {es} run prefix queries more
-efficiently at the cost of a larger index.
+mapping parameter. If enabled, {es} indexes prefixes in a separate field,
+according to the configuration settings. This lets {es} run prefix queries
+more efficiently at the cost of a larger index.
 
 [[prefix-query-allow-expensive-queries]]
 ===== Allow expensive queries


### PR DESCRIPTION
Backports the following commits to 8.3:
 - [DOCS] Clarify index_prefix in prefix query docs (#87450)