### PR TITLE
[7.17] Mute RestClientMultipleHostsIntegTests#testNonRetryableException (#87316)

### DIFF
--- a/client/rest/src/test/java/org/elasticsearch/client/RestClientMultipleHostsIntegTests.java
+++ b/client/rest/src/test/java/org/elasticsearch/client/RestClientMultipleHostsIntegTests.java
@@ -326,6 +326,7 @@ public class RestClientMultipleHostsIntegTests extends RestClientTestCase {
         }
     }
 
+    @Ignore("https://github.com/elastic/elasticsearch/issues/87314")
     public void testNonRetryableException() throws Exception {
         RequestOptions.Builder options = RequestOptions.DEFAULT.toBuilder();
         options.setHttpAsyncResponseConsumerFactory(


### PR DESCRIPTION
Backports the following commits to 7.17:

* Mute RestClientMultipleHostsIntegTests#testNonRetryableException (https://github.com/elastic/elasticsearch/pull/87316)