### PR TITLE
Remove unstable Assertion in IndexMetadataUpdater#applyChanges (#86159)

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/IndexMetadataUpdater.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/IndexMetadataUpdater.java
@@ -130,9 +130,7 @@ public class IndexMetadataUpdater extends RoutingChangesObserver.AbstractRouting
         }
 
         if (metadataBuilder != null) {
-            Metadata newMetadata = metadataBuilder.build();
-            assert oldMetadata.sameIndicesLookup(newMetadata);
-            return newMetadata;
+            return metadataBuilder.build();
         } else {
             return oldMetadata;
         }


### PR DESCRIPTION
This assertion here isn't stable unfortunately even though it would be nice to assert this. The problem is that the same cluster
state instance that is updated here might be concurrently used and the index lookup could have been created in it while we update
index metadata (from all kinds of actions that set it up).
I don't see a way to stabilize it that would actually be safe since the index lookup is cached in `Metadata` on a best effort basis
and we can't read the field on an instance of `Metadata` in a manner that would deterministically that a subsequent read
returns the same value.

-> removing the assertion

closes #86090

backport of #86159