### PR TITLE
[DOCS] Adds section about how to use ingest timestamp to sync a transform

### DIFF
--- a/docs/reference/transform/apis/put-transform.asciidoc
+++ b/docs/reference/transform/apis/put-transform.asciidoc
@@ -271,7 +271,7 @@ include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=sync-time-delay]
 include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=sync-time-field]
 +
 --
-TIP: In general, it is strongly recommended to use a field that contains the
+TIP: It is strongly recommended to use a field that contains the
 <<access-ingest-metadata,ingest timestamp>>. If you use a different field,
 you might need to set the `delay` such that it accounts for data transmission
 delays.

--- a/docs/reference/transform/apis/put-transform.asciidoc
+++ b/docs/reference/transform/apis/put-transform.asciidoc
@@ -271,7 +271,7 @@ include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=sync-time-delay]
 include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=sync-time-field]
 +
 --
-TIP: In general, it’s a good idea to use a field that contains the
+TIP: In general, it is strongly recommended to use a field that contains the
 <<access-ingest-metadata,ingest timestamp>>. If you use a different field,
 you might need to set the `delay` such that it accounts for data transmission
 delays.

--- a/docs/reference/transform/checkpoints.asciidoc
+++ b/docs/reference/transform/checkpoints.asciidoc
@@ -56,17 +56,25 @@ TIP: If the cluster experiences unsuitable performance degradation due to the
 
 
 [discrete]
-[[sync-field]]
+[[sync-field-ingest-timestamp]]
 == Using the ingest timestamp for syncing the {transform}
+
+
 
 In most cases, it is strongly recommended to use the ingest timestamp of the 
 source indices for syncing the {transform}. This is the most optimal way for 
-{transforms} to be able to identify new changes. It can be set by using an 
-ingest pipeline. You can create an ingest pipeline either using the 
+{transforms} to be able to identify new changes. If your data source follows the 
+https://www.elastic.co/guide/en/ecs/current/ecs-reference.html[ECS standard] you 
+might already have an <<field-event-ingested,`event.ingested`>> field. In this 
+case, use `event.ingested` as the `sync`.`time`.`field` property of your 
+{transform}.
+
+If you don't have a `event.ingested` field or it isn't populated, you can set it 
+by using an ingest pipeline. Create an ingest pipeline either using the 
 <<put-pipeline-api, ingest pipeline API>> (like the example below) or via {kib} 
-under **Stack Management > Ingest Pipelines**. Use a `set` processor to set a 
-field – in the example, this is `_source.@timestamp_ingest` – and associate it 
-with the value of the ingest timestamp.
+under **Stack Management > Ingest Pipelines**. Use a 
+<<set-processor,`set` processor>> to set the field and associate it with the 
+value of the ingest timestamp.
 
 [source,console]
 ----------------------------------
@@ -76,7 +84,7 @@ PUT _ingest/pipeline/set_ingest_time
   "processors": [
     {
       "set": {
-        "field": "_source.@timestamp_ingest",
+        "field": "event.ingested",
         "value": "{{{_ingest.timestamp}}}"
       }
     }
@@ -85,12 +93,12 @@ PUT _ingest/pipeline/set_ingest_time
 ----------------------------------
 
 After you created the ingest pipeline, apply it to the source indices of your 
-{transform}. The pipeline adds a field `_source.@timestamp_ingest` to every 
-document with the value of the ingest timestamp. Configure the 
-`sync`.`time`.`field` property of your {transform} to use the field by using the 
-<<put-transform,create {transform} API>> for new {transforms} or the <<update-transform, update {transform} API>> for existing 
-{transforms}. The `_source.@timestamp_ingest` field is used for syncing the 
-{transform}. 
+{transform}. The pipeline adds the field `event.ingested` to every document with 
+the value of the ingest timestamp. Configure the `sync`.`time`.`field` property 
+of your {transform} to use the field by using the 
+<<put-transform,create {transform} API>> for new {transforms} or the 
+<<update-transform, update {transform} API>> for existing {transforms}. The 
+`event.ingested` field is used for syncing the {transform}. 
 
 Refer to <<add-pipeline-to-indexing-request>> and <<ingest>> to learn more about 
 how to use an ingest pipeline.

--- a/docs/reference/transform/checkpoints.asciidoc
+++ b/docs/reference/transform/checkpoints.asciidoc
@@ -72,7 +72,7 @@ with the value of the ingest timestamp.
 ----------------------------------
 PUT _ingest/pipeline/set_ingest_time
 {
-  "description": "Set `_source.@timestamp_ingest` to `ingest.timestamp` value.",
+  "description": "Set ingest timestamp.",
   "processors": [
     {
       "set": {

--- a/docs/reference/transform/checkpoints.asciidoc
+++ b/docs/reference/transform/checkpoints.asciidoc
@@ -64,9 +64,9 @@ TIP: If the cluster experiences unsuitable performance degradation due to the
 In most cases, it is strongly recommended to use the ingest timestamp of the 
 source indices for syncing the {transform}. This is the most optimal way for 
 {transforms} to be able to identify new changes. If your data source follows the 
-https://www.elastic.co/guide/en/ecs/current/ecs-reference.html[ECS standard] you 
-might already have an <<field-event-ingested,`event.ingested`>> field. In this 
-case, use `event.ingested` as the `sync`.`time`.`field` property of your 
+https://www.elastic.co/guide/en/ecs/current/ecs-reference.html[ECS standard], 
+you might already have an <<field-event-ingested,`event.ingested`>> field. In 
+this case, use `event.ingested` as the `sync`.`time`.`field` property of your 
 {transform}.
 
 If you don't have a `event.ingested` field or it isn't populated, you can set it 

--- a/docs/reference/transform/checkpoints.asciidoc
+++ b/docs/reference/transform/checkpoints.asciidoc
@@ -64,7 +64,9 @@ source indices for syncing the {transform}. This is the most optimal way for
 {transforms} to be able to identify new changes. It can be set by using an 
 ingest pipeline. You can create an ingest pipeline either using the 
 <<put-pipeline-api, ingest pipeline API>> (like the example below) or via {kib} 
-under **Stack Management > Ingest Pipelines**.
+under **Stack Management > Ingest Pipelines**. Use a `set` processor to set a 
+field – in the example, this is `_source.@timestamp_ingest` – and associate it 
+with the value of the ingest timestamp.
 
 [source,console]
 ----------------------------------
@@ -85,10 +87,10 @@ PUT _ingest/pipeline/set_ingest_time
 After you created the ingest pipeline, apply it to the source indices of your 
 {transform}. The pipeline adds a field `_source.@timestamp_ingest` to every 
 document with the value of the ingest timestamp. Configure the 
-`sync`.`time`.`field` property of your {transform} to use the new field by using 
-the <<put-transform>> for new {transforms} or the <<update-transform>> for 
-existing {transforms}. The `_source.@timestamp_ingest` field is used for 
-syncing the {transform}. 
+`sync`.`time`.`field` property of your {transform} to use the field by using the 
+<<put-transform>> for new {transforms} or the <<update-transform>> for existing 
+{transforms}. The `_source.@timestamp_ingest` field is used for syncing the 
+{transform}. 
 
 Refer to <<add-pipeline-to-indexing-request>> and <<ingest>> to learn more about 
 how to use an ingest pipeline.

--- a/docs/reference/transform/checkpoints.asciidoc
+++ b/docs/reference/transform/checkpoints.asciidoc
@@ -40,8 +40,8 @@ The {transform} applies changes related to either new or changed entities or
 time buckets to the destination index. The set of changes can be paginated. The
 {transform} performs a composite aggregation similarly to the batch {transform} 
 operation, however it also injects query filters based on the previous step to 
-reduce the amount of work. After all changes have been applied, the checkpoint is 
-complete.
+reduce the amount of work. After all changes have been applied, the checkpoint 
+is complete.
 --
 
 This checkpoint process involves both search and indexing activity on the
@@ -53,6 +53,45 @@ support both the composite aggregation search and the indexing of its results.
 
 TIP: If the cluster experiences unsuitable performance degradation due to the
 {transform}, stop the {transform} and refer to <<transform-performance>>.
+
+
+[discrete]
+[[sync-field]]
+== Using the ingest timestamp for syncing the {transform}
+
+In most cases, it is strongly recommended to use the ingest timestamp of the 
+source indices for syncing the {transform}. This is the most optimal way for 
+{transforms} to be able to identify new changes. It can be set by using an 
+ingest pipeline. You can create an ingest pipeline either using the 
+<<put-pipeline-api, ingest pipeline API>> (like the example below) or via {kib} 
+under **Stack Management > Ingest Pipelines**.
+
+[source,console]
+----------------------------------
+PUT _ingest/pipeline/set_ingest_time
+{
+  "description": "Set `_source.@timestamp_ingest` to `ingest.timestamp` value.",
+  "processors": [
+    {
+      "set": {
+        "field": "_source.@timestamp_ingest",
+        "value": "{{{_ingest.timestamp}}}"
+      }
+    }
+  ]
+}
+----------------------------------
+
+After you created the ingest pipeline, apply it to the source indices of your 
+{transform}. The pipeline adds a field `_source.@timestamp_ingest` to every 
+document with the value of the ingest timestamp. Configure the 
+`sync`.`time`.`field` property of your {transform} to use the new field by using 
+the <<put-transform>> for new {transforms} or the <<update-transform>> for 
+existing {transforms}. The `_source.@timestamp_ingest` field is used for 
+syncing the {transform}. 
+
+Refer to <<add-pipeline-to-indexing-request>> and <<ingest>> to learn more about 
+how to use an ingest pipeline.
 
 
 [discrete]

--- a/docs/reference/transform/checkpoints.asciidoc
+++ b/docs/reference/transform/checkpoints.asciidoc
@@ -88,7 +88,7 @@ After you created the ingest pipeline, apply it to the source indices of your
 {transform}. The pipeline adds a field `_source.@timestamp_ingest` to every 
 document with the value of the ingest timestamp. Configure the 
 `sync`.`time`.`field` property of your {transform} to use the field by using the 
-<<put-transform>> for new {transforms} or the <<update-transform>> for existing 
+<<put-transform,create {transform} API>> for new {transforms} or the <<update-transform, update {transform} API>> for existing 
 {transforms}. The `_source.@timestamp_ingest` field is used for syncing the 
 {transform}. 
 

--- a/docs/reference/transform/checkpoints.asciidoc
+++ b/docs/reference/transform/checkpoints.asciidoc
@@ -64,9 +64,9 @@ TIP: If the cluster experiences unsuitable performance degradation due to the
 In most cases, it is strongly recommended to use the ingest timestamp of the 
 source indices for syncing the {transform}. This is the most optimal way for 
 {transforms} to be able to identify new changes. If your data source follows the 
-https://www.elastic.co/guide/en/ecs/current/ecs-reference.html[ECS standard], 
-you might already have an <<field-event-ingested,`event.ingested`>> field. In 
-this case, use `event.ingested` as the `sync`.`time`.`field` property of your 
+{ecs-ref}/ecs-reference.html[ECS standard], you might already have an 
+{ecs-ref}/ecs-event.html#field-event-ingested[`event.ingested`] field. In this 
+case, use `event.ingested` as the `sync`.`time`.`field` property of your 
 {transform}.
 
 If you don't have a `event.ingested` field or it isn't populated, you can set it 


### PR DESCRIPTION
## Overview

This PR:
* amends tip in PUT transform API docs to make the recommendation stronger,
* adds a section to `How transform checkpoints work` about how to use an ingest timestamp as a `sync.time.field`.

### Preview

* [Using the ingest timestamp for syncing the transform](https://elasticsearch_87650.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/transform-checkpoints.html#sync-field)