### PR TITLE
Throw exception on illegal RepositoryData updates

### DIFF
--- a/docs/changelog/87654.yaml
+++ b/docs/changelog/87654.yaml
@@ -1,0 +1,5 @@
+pr: 87654
+summary: Throw exception on illegal `RepositoryData` updates
+area: Snapshot/Restore
+type: bug
+issues: []

--- a/server/src/main/java/org/elasticsearch/repositories/RepositoryData.java
+++ b/server/src/main/java/org/elasticsearch/repositories/RepositoryData.java
@@ -682,18 +682,32 @@ public final class RepositoryData {
 
         if (shouldWriteUUIDS) {
             if (uuid.equals(MISSING_UUID)) {
-                assert permitMissingUuid : "missing uuid";
+                if (permitMissingUuid == false) {
+                    assert false : "missing uuid";
+                    throw new IllegalStateException("missing uuid");
+                }
             } else {
                 builder.field(UUID, uuid);
             }
             if (clusterUUID.equals(MISSING_UUID)) {
-                assert permitMissingUuid : "missing clusterUUID";
+                if (permitMissingUuid == false) {
+                    assert false : "missing clusterUUID";
+                    throw new IllegalStateException("missing clusterUUID");
+                }
             } else {
                 builder.field(CLUSTER_UUID, clusterUUID);
             }
         } else {
-            assert uuid.equals(MISSING_UUID) : "lost uuid " + uuid;
-            assert clusterUUID.equals(MISSING_UUID) : "lost clusterUUID " + clusterUUID;
+            if (uuid.equals(MISSING_UUID) == false) {
+                final IllegalStateException e = new IllegalStateException("lost uuid + [" + uuid + "]");
+                assert false : e;
+                throw e;
+            }
+            if (clusterUUID.equals(MISSING_UUID) == false) {
+                final IllegalStateException e = new IllegalStateException("lost clusterUUID + [" + uuid + "]");
+                assert false : e;
+                throw e;
+            }
         }
 
         // write the snapshots list


### PR DESCRIPTION
In some edge cases we could attempt a broken write here today,
lets throw in addition to the assertion to not corrupt the repository
until a solution for the underlying problem is found.

relates #86889
