### PR TITLE
[ML] Skip ML BWC tests against versions before 7.17.5 and 8.2.2 on RHEL 9

### DIFF
--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/BwcVersions.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/BwcVersions.java
@@ -321,8 +321,8 @@ public class BwcVersions {
             .map(v -> Version.fromString(v, Version.Mode.RELAXED))
             .orElse(null);
 
-        // glibc version 2.35 introduced incompatibilities in ML syscall filters that were fixed in 7.17.5+ and 8.2.2+
-        if (glibcVersion != null && glibcVersion.onOrAfter(Version.fromString("2.35", Version.Mode.RELAXED))) {
+        // glibc version 2.34 introduced incompatibilities in ML syscall filters that were fixed in 7.17.5+ and 8.2.2+
+        if (glibcVersion != null && glibcVersion.onOrAfter(Version.fromString("2.34", Version.Mode.RELAXED))) {
             if (version.before(Version.fromString("7.17.5"))) {
                 return false;
             } else if (version.getMajor() > 7 && version.before(Version.fromString("8.2.2"))) {


### PR DESCRIPTION
RHEL 9 suffers the same problems as Ubuntu 22.04 that were fixed by
https://github.com/elastic/ml-cpp/pull/2272.

The glibc version on RHEL 9 is 2.34 (versus 2.35 on Ubuntu 22.04),
so we need to adjust the skip logic.