### PR TITLE
[Test] [IdP] Add test for multiple SSO roles

### DIFF
--- a/x-pack/plugin/identity-provider/src/internalClusterTest/java/org/elasticsearch/xpack/idp/action/SamlIdentityProviderTests.java
+++ b/x-pack/plugin/identity-provider/src/internalClusterTest/java/org/elasticsearch/xpack/idp/action/SamlIdentityProviderTests.java
@@ -20,7 +20,6 @@ import org.elasticsearch.core.Nullable;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.test.ESIntegTestCase;
-import org.elasticsearch.test.junit.annotations.TestLogging;
 import org.elasticsearch.test.rest.ObjectPath;
 import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xcontent.XContentFactory;
@@ -31,6 +30,7 @@ import org.elasticsearch.xpack.idp.saml.sp.SamlServiceProviderDocument;
 import org.elasticsearch.xpack.idp.saml.sp.SamlServiceProviderIndex;
 import org.elasticsearch.xpack.idp.saml.support.SamlFactory;
 import org.elasticsearch.xpack.idp.saml.test.IdentityProviderIntegTestCase;
+import org.hamcrest.Matchers;
 import org.opensaml.core.xml.util.XMLObjectSupport;
 import org.opensaml.saml.common.SAMLObject;
 import org.opensaml.saml.saml2.core.AuthnRequest;
@@ -65,11 +65,6 @@ import static org.hamcrest.Matchers.hasKey;
 import static org.opensaml.saml.saml2.core.NameIDType.TRANSIENT;
 
 @ESIntegTestCase.ClusterScope(scope = ESIntegTestCase.Scope.SUITE, numClientNodes = 0, numDataNodes = 0)
-@TestLogging(
-    value = "org.elasticsearch.xpack.idp.action.TransportPutSamlServiceProviderAction:TRACE,"
-        + "org.elasticsearch.xpack.idp.saml.sp.SamlServiceProviderIndex:TRACE",
-    reason = "https://github.com/elastic/elasticsearch/issues/54423"
-)
 public class SamlIdentityProviderTests extends IdentityProviderIntegTestCase {
 
     private final SamlFactory samlFactory = new SamlFactory();
@@ -77,45 +72,60 @@ public class SamlIdentityProviderTests extends IdentityProviderIntegTestCase {
     public void testIdpInitiatedSso() throws Exception {
         String acsUrl = "https://" + randomAlphaOfLength(12) + ".elastic-cloud.com/saml/acs";
         String entityId = SP_ENTITY_ID;
-        registerServiceProvider(entityId, acsUrl);
-        registerApplicationPrivileges();
-        ensureGreen(SamlServiceProviderIndex.INDEX_NAME);
+        setupTestData(entityId, acsUrl);
 
-        // User login a.k.a exchange the user credentials for an API Key
-        final String apiKeyCredentials = getApiKeyFromCredentials(
-            SAMPLE_IDPUSER_NAME,
-            new SecureString(SAMPLE_IDPUSER_PASSWORD.toCharArray())
-        );
-        // Make a request to init an SSO flow with the API Key as secondary authentication
-        Request request = new Request("POST", "/_idp/saml/init");
-        request.setOptions(
-            RequestOptions.DEFAULT.toBuilder()
-                .addHeader("Authorization", basicAuthHeaderValue(CONSOLE_USER_NAME, new SecureString(CONSOLE_USER_PASSWORD.toCharArray())))
-                .addHeader("es-secondary-authorization", "ApiKey " + apiKeyCredentials)
-                .build()
-        );
-        request.setJsonEntity("{ \"entity_id\": \"" + entityId + "\", \"acs\": \"" + acsUrl + "\" }");
-        Response initResponse = getRestClient().performRequest(request);
-        ObjectPath objectPath = ObjectPath.createFromResponse(initResponse);
+        ObjectPath objectPath = performSso(entityId, acsUrl, SAMPLE_IDPUSER_NAME, new SecureString(SAMPLE_IDPUSER_PASSWORD.toCharArray()));
         assertThat(objectPath.evaluate("post_url").toString(), equalTo(acsUrl));
-        final String body = objectPath.evaluate("saml_response").toString();
-        assertThat(body, containsString("Destination=\"" + acsUrl + "\""));
-        assertThat(body, containsString("<saml2:Audience>" + entityId + "</saml2:Audience>"));
-        assertThat(body, containsString("<saml2:NameID Format=\"" + TRANSIENT + "\">"));
-        Map<String, String> serviceProvider = objectPath.evaluate("service_provider");
-        assertThat(serviceProvider, hasKey("entity_id"));
-        assertThat(serviceProvider.get("entity_id"), equalTo(entityId));
+        assertSamlResponseForServiceProvider(objectPath, entityId, acsUrl);
+        assertSamlResponseUserData(objectPath, SAMPLE_IDPUSER_NAME, "superuser");
+    }
 
-        assertContainsAttributeWithValue(body, "principal", SAMPLE_IDPUSER_NAME);
-        assertContainsAttributeWithValue(body, "roles", "superuser");
+    public void testIdpInitiatedSsoWithMultipleRoles() throws Exception {
+        final String acsUrl = "https://" + randomAlphaOfLength(12) + ".elastic-cloud.com/saml/acs";
+        final String entityId = SP_ENTITY_ID;
+
+        setupTestData(entityId, acsUrl);
+
+        final String entityWildcard = entityId.substring(0, entityId.lastIndexOf(':')) + "*";
+        final String username = "user_" + randomAlphaOfLength(5);
+        final SecureString password = new SecureString(randomAlphaOfLength(8).toCharArray());
+        final String roleName = "role_" + username;
+        final RequestOptions adminOptions = RequestOptions.DEFAULT.toBuilder()
+            .addHeader(
+                "Authorization",
+                UsernamePasswordToken.basicAuthHeaderValue(SAMPLE_USER_NAME, new SecureString(SAMPLE_USER_PASSWORD.toCharArray()))
+            )
+            .build();
+        // This role has "editor" on the deployment itself, and "viewer" for the organization that owns the deployment
+        createRole(roleName, """
+            {
+              "cluster": [ "manage_own_api_key" ],
+              "applications": [
+                {
+                  "application": "elastic-cloud",
+                  "resources": [ "%s" ],
+                  "privileges": [ "sso:editor" ]
+                },
+                {
+                  "application": "elastic-cloud",
+                  "resources": [ "%s" ],
+                  "privileges": [ "sso:viewer" ]
+                }
+              ]
+            }
+            """.formatted(SP_ENTITY_ID, entityWildcard), adminOptions);
+        createUser(username, password, roleName, adminOptions);
+
+        ObjectPath objectPath = performSso(entityId, acsUrl, username, password);
+        assertThat(objectPath.evaluate("post_url").toString(), equalTo(acsUrl));
+        assertSamlResponseForServiceProvider(objectPath, entityId, acsUrl);
+        assertSamlResponseUserData(objectPath, username, "editor", "viewer");
     }
 
     public void testIdPInitiatedSsoFailsForUnknownSP() throws Exception {
         String acsUrl = "https://" + randomAlphaOfLength(12) + ".elastic-cloud.com/saml/acs";
         String entityId = SP_ENTITY_ID;
-        registerServiceProvider(entityId, acsUrl);
-        registerApplicationPrivileges();
-        ensureGreen(SamlServiceProviderIndex.INDEX_NAME);
+        setupTestData(entityId, acsUrl);
         // User login a.k.a exchange the user credentials for an API Key
         final String apiKeyCredentials = getApiKeyFromCredentials(
             SAMPLE_IDPUSER_NAME,
@@ -138,9 +148,7 @@ public class SamlIdentityProviderTests extends IdentityProviderIntegTestCase {
     public void testIdPInitiatedSsoFailsWithoutSecondaryAuthentication() throws Exception {
         String acsUrl = "https://" + randomAlphaOfLength(12) + ".elastic-cloud.com/saml/acs";
         String entityId = SP_ENTITY_ID;
-        registerServiceProvider(entityId, acsUrl);
-        registerApplicationPrivileges();
-        ensureGreen(SamlServiceProviderIndex.INDEX_NAME);
+        setupTestData(entityId, acsUrl);
         // Make a request to init an SSO flow with the API Key as secondary authentication
         Request request = new Request("POST", "/_idp/saml/init");
         request.setOptions(REQUEST_OPTIONS_AS_CONSOLE_USER);
@@ -152,9 +160,7 @@ public class SamlIdentityProviderTests extends IdentityProviderIntegTestCase {
     public void testSpInitiatedSso() throws Exception {
         String acsUrl = "https://" + randomAlphaOfLength(12) + ".elastic-cloud.com/saml/acs";
         String entityId = SP_ENTITY_ID;
-        registerServiceProvider(entityId, acsUrl);
-        registerApplicationPrivileges();
-        ensureGreen(SamlServiceProviderIndex.INDEX_NAME);
+        setupTestData(entityId, acsUrl);
         // Validate incoming authentication request
         Request validateRequest = new Request("POST", "/_idp/saml/validate");
         validateRequest.setOptions(REQUEST_OPTIONS_AS_CONSOLE_USER);
@@ -215,8 +221,8 @@ public class SamlIdentityProviderTests extends IdentityProviderIntegTestCase {
         Map<String, String> sp = initResponseObject.evaluate("service_provider");
         assertThat(sp, hasKey("entity_id"));
         assertThat(sp.get("entity_id"), equalTo(entityId));
-        assertContainsAttributeWithValue(body, "principal", SAMPLE_IDPUSER_NAME);
-        assertContainsAttributeWithValue(body, "roles", "superuser");
+        assertContainsAttributeWithValues(body, "principal", SAMPLE_IDPUSER_NAME);
+        assertContainsAttributeWithValues(body, "roles", "superuser");
     }
 
     public void testSpInitiatedSsoFailsForUserWithNoAccess() throws Exception {
@@ -286,9 +292,7 @@ public class SamlIdentityProviderTests extends IdentityProviderIntegTestCase {
     public void testSpInitiatedSsoFailsForUnknownSp() throws Exception {
         String acsUrl = "https://" + randomAlphaOfLength(12) + ".elastic-cloud.com/saml/acs";
         String entityId = SP_ENTITY_ID;
-        registerServiceProvider(entityId, acsUrl);
-        registerApplicationPrivileges();
-        ensureGreen(SamlServiceProviderIndex.INDEX_NAME);
+        setupTestData(entityId, acsUrl);
         // Validate incoming authentication request
         Request validateRequest = new Request("POST", "/_idp/saml/validate");
         validateRequest.setOptions(REQUEST_OPTIONS_AS_CONSOLE_USER);
@@ -312,9 +316,7 @@ public class SamlIdentityProviderTests extends IdentityProviderIntegTestCase {
     public void testSpInitiatedSsoFailsForMalformedRequest() throws Exception {
         String acsUrl = "https://" + randomAlphaOfLength(12) + ".elastic-cloud.com/saml/acs";
         String entityId = SP_ENTITY_ID;
-        registerServiceProvider(entityId, acsUrl);
-        registerApplicationPrivileges();
-        ensureGreen(SamlServiceProviderIndex.INDEX_NAME);
+        setupTestData(entityId, acsUrl);
 
         // Validate incoming authentication request
         Request validateRequest = new Request("POST", "/_idp/saml/validate");
@@ -343,6 +345,45 @@ public class SamlIdentityProviderTests extends IdentityProviderIntegTestCase {
         validateRequest.setJsonEntity("{\"authn_request_query\":\"" + malformedRequestQuery + "\"}");
         ResponseException e1 = expectThrows(ResponseException.class, () -> getRestClient().performRequest(validateRequest));
         assertThat(e1.getResponse().getStatusLine().getStatusCode(), equalTo(RestStatus.BAD_REQUEST.getStatus()));
+    }
+
+    private ObjectPath performSso(String entityId, String acsUrl, String username, SecureString password) throws IOException {
+        // User login a.k.a exchange the user credentials for an API Key
+        final String apiKeyCredentials = getApiKeyFromCredentials(username, password);
+        // Make a request to init an SSO flow with the API Key as secondary authentication
+        Request request = new Request("POST", "/_idp/saml/init");
+        request.setOptions(
+            RequestOptions.DEFAULT.toBuilder()
+                .addHeader("Authorization", basicAuthHeaderValue(CONSOLE_USER_NAME, new SecureString(CONSOLE_USER_PASSWORD.toCharArray())))
+                .addHeader("es-secondary-authorization", "ApiKey " + apiKeyCredentials)
+                .build()
+        );
+        request.setJsonEntity("{ \"entity_id\": \"" + entityId + "\", \"acs\": \"" + acsUrl + "\" }");
+        Response initResponse = getRestClient().performRequest(request);
+        ObjectPath objectPath = ObjectPath.createFromResponse(initResponse);
+        return objectPath;
+    }
+
+    private void assertSamlResponseForServiceProvider(ObjectPath objectPath, String entityId, String acsUrl) throws IOException {
+        String body = objectPath.evaluate("saml_response").toString();
+        assertThat(body, containsString("Destination=\"" + acsUrl + "\""));
+        assertThat(body, containsString("<saml2:Audience>" + entityId + "</saml2:Audience>"));
+        assertThat(body, containsString("<saml2:NameID Format=\"" + TRANSIENT + "\">"));
+        Map<String, String> serviceProvider = objectPath.evaluate("service_provider");
+        assertThat(serviceProvider, hasKey("entity_id"));
+        assertThat(serviceProvider.get("entity_id"), equalTo(entityId));
+    }
+
+    private void assertSamlResponseUserData(ObjectPath objectPath, String idpuserName, String... roles) throws IOException {
+        var body = objectPath.evaluate("saml_response").toString();
+        assertContainsAttributeWithValues(body, "principal", idpuserName);
+        assertContainsAttributeWithValues(body, "roles", roles);
+    }
+
+    private void setupTestData(String entityId, String acsUrl) throws Exception {
+        registerServiceProvider(entityId, acsUrl);
+        registerApplicationPrivileges();
+        ensureGreen(SamlServiceProviderIndex.INDEX_NAME);
     }
 
     private void registerServiceProvider(String entityId, String acsUrl) throws Exception {
@@ -386,7 +427,13 @@ public class SamlIdentityProviderTests extends IdentityProviderIntegTestCase {
     }
 
     private void registerApplicationPrivileges() throws IOException {
-        registerApplicationPrivileges(Map.of("deployment_admin", Set.of("sso:superuser"), "deployment_viewer", Set.of("sso:viewer")));
+        registerApplicationPrivileges(
+            Map.ofEntries(
+                Map.entry("deployment_admin", Set.of("sso:superuser")),
+                Map.entry("deployment_editor", Set.of("sso:editor")),
+                Map.entry("deployment_viewer", Set.of("sso:viewer"))
+            )
+        );
     }
 
     private void registerApplicationPrivileges(Map<String, Set<String>> privileges) throws IOException {
@@ -410,6 +457,28 @@ public class SamlIdentityProviderTests extends IdentityProviderIntegTestCase {
 
         Response response = getRestClient().performRequest(request);
         assertThat(response.getStatusLine().getStatusCode(), equalTo(200));
+    }
+
+    private void createRole(String roleName, String roleBody, RequestOptions options) throws IOException {
+        Request req = new Request("PUT", "/_security/role/" + roleName);
+        req.setJsonEntity(roleBody);
+        req.setOptions(options);
+        getRestClient().performRequest(req);
+    }
+
+    private void createUser(String userName, SecureString password, String roleName, RequestOptions options) throws IOException {
+        final Request req = new Request("PUT", "/_security/user/" + userName);
+        final String body = """
+            {
+              "username": "%s",
+              "full_name": "Test User (%s)",
+              "password": "%s",
+              "roles": [ "%s" ]
+            }
+            """.formatted(userName, getTestName(), password, roleName);
+        req.setJsonEntity(body);
+        req.setOptions(options);
+        getRestClient().performRequest(req);
     }
 
     private String getApiKeyFromCredentials(String username, SecureString password) {
@@ -487,11 +556,30 @@ public class SamlIdentityProviderTests extends IdentityProviderIntegTestCase {
         return XMLSigningUtil.signWithURI(credential, algo, content);
     }
 
-    private void assertContainsAttributeWithValue(String message, String attribute, String value) {
-        assertThat(message, containsString("""
+    private void assertContainsAttributeWithValues(String message, String attribute, String... values) {
+        final String startAttribute = """
             <saml2:Attribute FriendlyName="%s" Name="https://saml.elasticsearch.org/attributes/%s" \
-            NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri"><saml2:AttributeValue \
-            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="xsd:string">%s</saml2:AttributeValue>\
-            </saml2:Attribute>""".formatted(attribute, attribute, value)));
+            NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri">""".formatted(attribute, attribute);
+        assertThat(message, containsString(startAttribute));
+        final int posStart = message.indexOf(startAttribute);
+        assertThat(posStart, Matchers.greaterThan(0));
+
+        final String endAttribute = "</saml2:Attribute>";
+        assertThat(message, containsString(endAttribute));
+        final int posEnd = message.indexOf(endAttribute, posStart);
+        assertThat(posEnd, Matchers.greaterThan(posStart));
+
+        final String attributeContent = message.substring(posStart + startAttribute.length(), posEnd);
+
+        for (String value : values) {
+            assertThat(
+                attributeContent,
+                containsString(
+                    "<saml2:AttributeValue xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xsi:type=\"xsd:string\">"
+                        + value
+                        + "</saml2:AttributeValue>"
+                )
+            );
+        }
     }
 }


### PR DESCRIPTION
Within the Identity Provider we support SSO roles (via application
privileges) being assigned directly to an SP (by entity id) or via a
wildcard.

It is possible that a user has a role via a wildcard (e.g. "viewer" on
"marvel:avengers:*") and a different role via a direct assignment (e.g.
"editor" on "marvel:avengers:thor"). In this case the SAML assertion
should contain both attributes ("viewer" and "editor").

This commit adds a test for this behaviour. No other code changes were
required because the functionality works as intended, it just didn't
have an integration test.
