### PR TITLE
Cleanup indirection in batch close utils

### DIFF
--- a/libs/core/src/test/java/org/elasticsearch/core/IOUtilsTests.java
+++ b/libs/core/src/test/java/org/elasticsearch/core/IOUtilsTests.java
@@ -117,10 +117,6 @@ public class IOUtilsTests extends ESTestCase {
         runDeleteFilesIgnoringExceptionsTest(Function.identity(), IOUtils::deleteFilesIgnoringExceptions);
     }
 
-    public void testDeleteFilesIgnoringExceptionsIterable() throws IOException {
-        runDeleteFilesIgnoringExceptionsTest((Function<Path[], List<Path>>) Arrays::asList, IOUtils::deleteFilesIgnoringExceptions);
-    }
-
     private <T> void runDeleteFilesIgnoringExceptionsTest(
         final Function<Path[], T> function,
         CheckedConsumer<T, IOException> deleteFilesIgnoringExceptions

--- a/server/src/main/java/org/elasticsearch/index/shard/IndexShard.java
+++ b/server/src/main/java/org/elasticsearch/index/shard/IndexShard.java
@@ -1515,7 +1515,7 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
             throw new ElasticsearchException("failed to wrap searcher", ex);
         } finally {
             if (success == false) {
-                Releasables.close(success, searcher);
+                Releasables.closeWhileHandlingException(searcher);
             }
         }
     }


### PR DESCRIPTION
Some of these show up in profiling of heavy transport load.
It's not a big thing but it's always nice to save a few cycles
on transport threads and save a few LoC.
