### PR TITLE
Add help guide to the contact support user action

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/coordination/StableMasterHealthIndicatorService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/StableMasterHealthIndicatorService.java
@@ -56,6 +56,7 @@ public class StableMasterHealthIndicatorService implements HealthIndicatorServic
 
     public static final String NAME = "master_is_stable";
     private static final String HELP_URL = "https://ela.st/fix-master";
+    public static final String GET_HELP_GUIDE = "https://ela.st/getting-help";
 
     private final ClusterService clusterService;
     private final MasterHistoryService masterHistoryService;
@@ -269,9 +270,8 @@ public class StableMasterHealthIndicatorService implements HealthIndicatorServic
         if (explain) {
             UserAction.Definition contactSupport = new UserAction.Definition(
                 "contact_support",
-                "The Elasticsearch cluster does not have a stable master node. Please contact Elastic Support "
-                    + "(https://support.elastic.co) to discuss available options.",
-                null
+                "The Elasticsearch cluster does not have a stable master node. Get help at " + GET_HELP_GUIDE,
+                GET_HELP_GUIDE
             );
             UserAction userAction = new UserAction(contactSupport, null);
             return List.of(userAction);


### PR DESCRIPTION
This adds a help URL for the "contact support" user action
and rewords a bit the message to "get help".