### PR TITLE
Fix ConfigDatabasesTests#testDatabasesDynamicUpdateConfigDir() test

### DIFF
--- a/modules/ingest-geoip/src/test/java/org/elasticsearch/ingest/geoip/ConfigDatabasesTests.java
+++ b/modules/ingest-geoip/src/test/java/org/elasticsearch/ingest/geoip/ConfigDatabasesTests.java
@@ -28,6 +28,7 @@ import java.nio.file.StandardCopyOption;
 
 import static org.hamcrest.Matchers.anEmptyMap;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
 
 public class ConfigDatabasesTests extends ESTestCase {
@@ -100,12 +101,15 @@ public class ConfigDatabasesTests extends ESTestCase {
             assertThat(loader.getDatabaseType(), equalTo("GeoLite2-ASN"));
 
             loader = configDatabases.getDatabase("GeoLite2-City.mmdb");
+            assertThat(loader, notNullValue());
             assertThat(loader.getDatabaseType(), equalTo("GeoLite2-City"));
 
             loader = configDatabases.getDatabase("GeoLite2-Country.mmdb");
+            assertThat(loader, notNullValue());
             assertThat(loader.getDatabaseType(), equalTo("GeoLite2-Country"));
 
             loader = configDatabases.getDatabase("GeoIP2-City.mmdb");
+            assertThat(loader, notNullValue());
             assertThat(loader.getDatabaseType(), equalTo("GeoIP2-City"));
         });
     }


### PR DESCRIPTION
ConfigDatabases#getDatabase(...) can return null and that is ok,
but an assertBusy() block in testDatabasesDynamicUpdateConfigDir() test
expects that the loader is always not null and that may not the case.
Adjusted this assertBusy() to check for null. Otherwise, a NPE may be
thrown and assertBusy() doesn't retry that, it only retries assertion
errors.

Closes #86805