### PR TITLE
[Transforms] fix bug when unsetting retention policy

### DIFF
--- a/docs/changelog/87711.yaml
+++ b/docs/changelog/87711.yaml
@@ -1,0 +1,5 @@
+pr: 87711
+summary: "[Transforms] fix bug when unsetting retention policy"
+area: Transform
+type: bug
+issues: []

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/XPackClientPlugin.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/XPackClientPlugin.java
@@ -212,6 +212,7 @@ import org.elasticsearch.xpack.core.transform.action.PreviewTransformAction;
 import org.elasticsearch.xpack.core.transform.action.PutTransformAction;
 import org.elasticsearch.xpack.core.transform.action.StartTransformAction;
 import org.elasticsearch.xpack.core.transform.action.StopTransformAction;
+import org.elasticsearch.xpack.core.transform.transforms.NullRetentionPolicyConfig;
 import org.elasticsearch.xpack.core.transform.transforms.RetentionPolicyConfig;
 import org.elasticsearch.xpack.core.transform.transforms.SyncConfig;
 import org.elasticsearch.xpack.core.transform.transforms.TimeRetentionPolicyConfig;
@@ -533,6 +534,11 @@ public class XPackClientPlugin extends Plugin implements ActionPlugin, NetworkPl
                     RetentionPolicyConfig.class,
                     TransformField.TIME.getPreferredName(),
                     TimeRetentionPolicyConfig::new
+                ),
+                new NamedWriteableRegistry.Entry(
+                    RetentionPolicyConfig.class,
+                    NullRetentionPolicyConfig.NAME.getPreferredName(),
+                    i -> NullRetentionPolicyConfig.INSTANCE
                 ),
                 // Voting Only Node
                 new NamedWriteableRegistry.Entry(XPackFeatureSet.Usage.class, XPackField.VOTING_ONLY, VotingOnlyNodeFeatureSetUsage::new),

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/TransformNamedXContentProvider.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/TransformNamedXContentProvider.java
@@ -9,6 +9,7 @@ package org.elasticsearch.xpack.core.transform;
 
 import org.elasticsearch.plugins.spi.NamedXContentProvider;
 import org.elasticsearch.xcontent.NamedXContentRegistry;
+import org.elasticsearch.xpack.core.transform.transforms.NullRetentionPolicyConfig;
 import org.elasticsearch.xpack.core.transform.transforms.RetentionPolicyConfig;
 import org.elasticsearch.xpack.core.transform.transforms.SyncConfig;
 import org.elasticsearch.xpack.core.transform.transforms.TimeRetentionPolicyConfig;
@@ -23,7 +24,12 @@ public class TransformNamedXContentProvider implements NamedXContentProvider {
     public List<NamedXContentRegistry.Entry> getNamedXContentParsers() {
         return Arrays.asList(
             new NamedXContentRegistry.Entry(SyncConfig.class, TransformField.TIME, TimeSyncConfig::parse),
-            new NamedXContentRegistry.Entry(RetentionPolicyConfig.class, TransformField.TIME, TimeRetentionPolicyConfig::parse)
+            new NamedXContentRegistry.Entry(RetentionPolicyConfig.class, TransformField.TIME, TimeRetentionPolicyConfig::parse),
+            new NamedXContentRegistry.Entry(
+                RetentionPolicyConfig.class,
+                NullRetentionPolicyConfig.NAME,
+                (p, c) -> NullRetentionPolicyConfig.INSTANCE
+            )
         );
     }
 }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/transforms/NullRetentionPolicyConfig.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/transforms/NullRetentionPolicyConfig.java
@@ -38,7 +38,7 @@ public class NullRetentionPolicyConfig implements RetentionPolicyConfig {
 
     @Override
     public ActionRequestValidationException validate(ActionRequestValidationException validationException) {
-        throw new UnsupportedOperationException();
+        return null;
     }
 
     @Override

--- a/x-pack/plugin/transform/qa/multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/TransformIT.java
+++ b/x-pack/plugin/transform/qa/multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/TransformIT.java
@@ -22,6 +22,7 @@ import org.elasticsearch.search.aggregations.bucket.histogram.DateHistogramInter
 import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xpack.core.transform.transforms.QueryConfig;
 import org.elasticsearch.xpack.core.transform.transforms.SettingsConfig;
+import org.elasticsearch.xpack.core.transform.transforms.TimeRetentionPolicyConfig;
 import org.elasticsearch.xpack.core.transform.transforms.TimeSyncConfig;
 import org.elasticsearch.xpack.core.transform.transforms.TransformConfig;
 import org.elasticsearch.xpack.core.transform.transforms.pivot.SingleGroupSource;
@@ -38,7 +39,9 @@ import java.util.concurrent.TimeUnit;
 import static org.elasticsearch.xcontent.XContentFactory.jsonBuilder;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.hasKey;
 import static org.hamcrest.Matchers.lessThan;
+import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.oneOf;
 
 @SuppressWarnings("removal")
@@ -261,6 +264,35 @@ public class TransformIT extends TransformRestTestCase {
 
         stopTransform(config.getId());
         deleteTransform(config.getId());
+    }
+
+    public void testRetentionPolicyDelete() throws Exception {
+        String indexName = "retention-index";
+        String transformId = "transform-retention-update";
+        String dest = "retention-policy-dest";
+        createReviewsIndex(indexName, 10, NUM_USERS, TransformIT::getUserIdForRow, TransformIT::getDateStringForRow);
+
+        Map<String, SingleGroupSource> groups = new HashMap<>();
+        groups.put("by-user", new TermsGroupSource("user_id", null, false));
+
+        AggregatorFactories.Builder aggs = AggregatorFactories.builder()
+            .addAggregator(AggregationBuilders.max("timestamp").field("timestamp"));
+
+        TransformConfig config = createTransformConfigBuilder(transformId, dest, QueryConfig.matchAll(), indexName).setPivotConfig(
+            createPivotConfig(groups, aggs)
+        )
+            .setSyncConfig(new TimeSyncConfig("timestamp", TimeValue.timeValueSeconds(1)))
+            .setRetentionPolicyConfig(new TimeRetentionPolicyConfig("timestamp", TimeValue.timeValueDays(1)))
+            .build();
+        putTransform(transformId, Strings.toString(config), RequestOptions.DEFAULT);
+        assertThat(getTransform(transformId), hasKey("retention_policy"));
+        String update = """
+            {
+                "retention_policy": null
+            }
+            """;
+        updateConfig(transformId, update);
+        assertThat(getTransform(transformId), not(hasKey("retention_policy")));
     }
 
     public void testStopWaitForCheckpoint() throws Exception {


### PR DESCRIPTION
It is currently not possible to unset the retention policy in a typical multi-node cluster. 

This commit fixes that bug. If unsetting the retention policy failed, it would fail looking like the following error:

```
An error occurred calling the API endpoint to update transforms.
Bad Request: [illegal_argument_exception: [illegal_argument_exception] Reason: 
Unknown NamedWriteable [org.elasticsearch.xpack.core.transform.transforms.RetentionPolicyConfig][null_retention_policy]]:
Unknown NamedWriteable [org.elasticsearch.xpack.core.transform.transforms.RetentionPolicyConfig][null_retention_policy]
```

closes: https://github.com/elastic/elasticsearch/issues/87688

