### PR TITLE
Convert reconciler to service

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/allocator/DesiredBalanceReconciler.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/allocator/DesiredBalanceReconciler.java
@@ -281,12 +281,13 @@ public class DesiredBalanceReconciler {
 
             final var moveTarget = findRelocationTarget(allocation, shardRouting, assignment.nodeIds());
             if (moveTarget != null) {
-                allocation.routingNodes().relocateShard(
-                    shardRouting,
-                    moveTarget.getId(),
-                    allocation.clusterInfo().getShardSize(shardRouting, ShardRouting.UNAVAILABLE_EXPECTED_SHARD_SIZE),
-                    allocation.changes()
-                );
+                allocation.routingNodes()
+                    .relocateShard(
+                        shardRouting,
+                        moveTarget.getId(),
+                        allocation.clusterInfo().getShardSize(shardRouting, ShardRouting.UNAVAILABLE_EXPECTED_SHARD_SIZE),
+                        allocation.changes()
+                    );
             }
         }
     }
@@ -330,12 +331,13 @@ public class DesiredBalanceReconciler {
 
             final var rebalanceTarget = findRelocationTarget(allocation, shardRouting, assignment.nodeIds(), this::decideCanAllocate);
             if (rebalanceTarget != null) {
-                allocation.routingNodes().relocateShard(
-                    shardRouting,
-                    rebalanceTarget.getId(),
-                    allocation.clusterInfo().getShardSize(shardRouting, ShardRouting.UNAVAILABLE_EXPECTED_SHARD_SIZE),
-                    allocation.changes()
-                );
+                allocation.routingNodes()
+                    .relocateShard(
+                        shardRouting,
+                        rebalanceTarget.getId(),
+                        allocation.clusterInfo().getShardSize(shardRouting, ShardRouting.UNAVAILABLE_EXPECTED_SHARD_SIZE),
+                        allocation.changes()
+                    );
             }
         }
     }

--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/allocator/DesiredBalanceReconciler.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/allocator/DesiredBalanceReconciler.java
@@ -26,7 +26,6 @@ import org.elasticsearch.index.shard.ShardId;
 
 import java.util.Comparator;
 import java.util.Set;
-import java.util.function.BiFunction;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
@@ -368,12 +367,12 @@ public class DesiredBalanceReconciler {
     private DiscoveryNode findRelocationTarget(
         ShardRouting shardRouting,
         Set<String> desiredNodeIds,
-        BiFunction<ShardRouting, RoutingNode, Decision> canAllocateDecider
+        AllocateDecider allocateDecider
     ) {
         for (final var nodeId : desiredNodeIds) {
             if (nodeId.equals(shardRouting.currentNodeId()) == false) {
                 final var currentNode = routingNodes.node(nodeId);
-                if (canAllocateDecider.apply(shardRouting, currentNode).type() == Decision.Type.YES) {
+                if (allocateDecider.canAllocate(shardRouting, currentNode).type() == Decision.Type.YES) {
                     return currentNode.node();
                 }
             }
@@ -390,4 +389,8 @@ public class DesiredBalanceReconciler {
         return allocation.deciders().canForceAllocateDuringReplace(shardRouting, target, allocation);
     }
 
+    @FunctionalInterface
+    private interface AllocateDecider {
+        Decision canAllocate(ShardRouting shardRouting, RoutingNode target);
+    }
 }

--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/allocator/DesiredBalanceShardsAllocator.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/allocator/DesiredBalanceShardsAllocator.java
@@ -143,7 +143,7 @@ public class DesiredBalanceShardsAllocator implements ShardsAllocator, ClusterSt
         // Otherwise we will have to do a second cluster state update straight away.
 
         DesiredBalance currentDesiredBalance = getCurrentDesiredBalance();
-        new DesiredBalanceReconciler(currentDesiredBalance, allocation).run();
+        new DesiredBalanceReconciler().reconcile(currentDesiredBalance, allocation);
 
         queue.complete(currentDesiredBalance.lastConvergedIndex());
         if (allocation.routingNodesChanged()) {

--- a/server/src/test/java/org/elasticsearch/cluster/routing/allocation/allocator/DesiredBalanceReconcilerTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/allocation/allocator/DesiredBalanceReconcilerTests.java
@@ -97,7 +97,7 @@ public class DesiredBalanceReconcilerTests extends ESTestCase {
             0L
         );
 
-        reconcile(routingAllocation, new DesiredBalance(1, Map.of()));
+        new DesiredBalanceReconciler().reconcile(new DesiredBalance(1, Map.of()), routingAllocation);
         assertFalse(routingAllocation.routingNodesChanged());
     }
 
@@ -167,18 +167,16 @@ public class DesiredBalanceReconcilerTests extends ESTestCase {
             );
         }
 
-        reconcile(
-            routingAllocation,
-            new DesiredBalance(
-                1,
-                randomBoolean()
-                    ? Map.of()
-                    : Map.of(
-                        new ShardId(clusterState.metadata().index(DesiredBalanceServiceTests.TEST_INDEX).getIndex(), 0),
-                        new ShardAssignment(Set.of("node-0"), 0, 0)
-                    )
-            )
+        DesiredBalance desiredBalance = new DesiredBalance(
+            1,
+            randomBoolean()
+                ? Map.of()
+                : Map.of(
+                    new ShardId(clusterState.metadata().index(DesiredBalanceServiceTests.TEST_INDEX).getIndex(), 0),
+                    new ShardAssignment(Set.of("node-0"), 0, 0)
+                )
         );
+        new DesiredBalanceReconciler().reconcile(desiredBalance, routingAllocation);
         assertTrue(routingAllocation.routingNodesChanged());
 
         for (ShardRouting shardRouting : routingAllocation.routingNodes().unassigned()) {
@@ -227,7 +225,7 @@ public class DesiredBalanceReconcilerTests extends ESTestCase {
         );
 
         final var allocationService = createTestAllocationService(
-            routingAllocation -> reconcile(routingAllocation, desiredBalance),
+            routingAllocation -> new DesiredBalanceReconciler().reconcile(desiredBalance, routingAllocation),
             new SameShardAllocationDecider(settings, clusterSettings),
             new ReplicaAfterPrimaryActiveAllocationDecider(),
             new ThrottlingAllocationDecider(settings, clusterSettings),
@@ -310,7 +308,7 @@ public class DesiredBalanceReconcilerTests extends ESTestCase {
         final var desiredBalance = desiredBalance(clusterState, (shardId, nodeId) -> true);
 
         final var allocationService = createTestAllocationService(
-            routingAllocation -> reconcile(routingAllocation, desiredBalance),
+            routingAllocation -> new DesiredBalanceReconciler().reconcile(desiredBalance, routingAllocation),
             new SameShardAllocationDecider(settings, clusterSettings),
             new ReplicaAfterPrimaryActiveAllocationDecider(),
             new ThrottlingAllocationDecider(settings, clusterSettings)
@@ -404,7 +402,7 @@ public class DesiredBalanceReconcilerTests extends ESTestCase {
         final var assignReplicas = new AtomicBoolean(false);
 
         final var allocationService = createTestAllocationService(
-            routingAllocation -> reconcile(routingAllocation, desiredBalance),
+            routingAllocation -> new DesiredBalanceReconciler().reconcile(desiredBalance, routingAllocation),
             new SameShardAllocationDecider(settings, clusterSettings),
             new ReplicaAfterPrimaryActiveAllocationDecider(),
             new ThrottlingAllocationDecider(settings, clusterSettings),
@@ -512,7 +510,7 @@ public class DesiredBalanceReconcilerTests extends ESTestCase {
 
         final var desiredBalance = desiredBalance(clusterState, (shardId, nodeId) -> randomBoolean());
         final var allocationService = createTestAllocationService(
-            routingAllocation -> reconcile(routingAllocation, desiredBalance),
+            routingAllocation -> new DesiredBalanceReconciler().reconcile(desiredBalance, routingAllocation),
             new SameShardAllocationDecider(settings, clusterSettings),
             new ReplicaAfterPrimaryActiveAllocationDecider()
         );
@@ -603,7 +601,7 @@ public class DesiredBalanceReconcilerTests extends ESTestCase {
 
         final var desiredBalance = desiredBalance(clusterState, (shardId, nodeId) -> true);
         final var allocationService = createTestAllocationService(
-            routingAllocation -> reconcile(routingAllocation, desiredBalance),
+            routingAllocation -> new DesiredBalanceReconciler().reconcile(desiredBalance, routingAllocation),
             () -> clusterInfo,
             () -> snapshotShardSizeInfo,
             new SameShardAllocationDecider(settings, clusterSettings),
@@ -643,7 +641,7 @@ public class DesiredBalanceReconcilerTests extends ESTestCase {
         final var replicaDecision = randomFrom(Decision.THROTTLE, Decision.NO);
         final var desiredBalance = desiredBalance(clusterState, (shardId, nodeId) -> true);
         final var allocationService = createTestAllocationService(
-            routingAllocation -> reconcile(routingAllocation, desiredBalance),
+            routingAllocation -> new DesiredBalanceReconciler().reconcile(desiredBalance, routingAllocation),
             new SameShardAllocationDecider(settings, clusterSettings),
             new ReplicaAfterPrimaryActiveAllocationDecider(),
             new AllocationDecider() {
@@ -702,7 +700,7 @@ public class DesiredBalanceReconcilerTests extends ESTestCase {
         final var nonYesDecision = randomFrom(Decision.THROTTLE, Decision.NO);
         final var desiredBalance = desiredBalance(clusterState, (shardId, nodeId) -> true);
         final var allocationService = createTestAllocationService(
-            routingAllocation -> reconcile(routingAllocation, desiredBalance),
+            routingAllocation -> new DesiredBalanceReconciler().reconcile(desiredBalance, routingAllocation),
             new SameShardAllocationDecider(settings, clusterSettings),
             new ReplicaAfterPrimaryActiveAllocationDecider(),
             new AllocationDecider() {
@@ -764,7 +762,7 @@ public class DesiredBalanceReconcilerTests extends ESTestCase {
 
         final var desiredBalance = new AtomicReference<>(desiredBalance(clusterState, (shardId, nodeId) -> true));
         final var allocationService = createTestAllocationService(
-            routingAllocation -> reconcile(routingAllocation, desiredBalance.get()),
+            routingAllocation -> new DesiredBalanceReconciler().reconcile(desiredBalance.get(), routingAllocation),
             new SameShardAllocationDecider(settings, clusterSettings),
             new ReplicaAfterPrimaryActiveAllocationDecider(),
             new ThrottlingAllocationDecider(settings, clusterSettings),
@@ -883,7 +881,7 @@ public class DesiredBalanceReconcilerTests extends ESTestCase {
             desiredBalance(clusterState, (shardId, nodeId) -> nodeId.equals("node-0") || nodeId.equals("node-1"))
         );
         final var allocationService = createTestAllocationService(
-            routingAllocation -> reconcile(routingAllocation, desiredBalance.get()),
+            routingAllocation -> new DesiredBalanceReconciler().reconcile(desiredBalance.get(), routingAllocation),
             new SameShardAllocationDecider(settings, clusterSettings),
             new ReplicaAfterPrimaryActiveAllocationDecider(),
             new ThrottlingAllocationDecider(settings, clusterSettings),
@@ -938,10 +936,6 @@ public class DesiredBalanceReconcilerTests extends ESTestCase {
         final var reroutedState = allocationService.reroute(clusterState, "test");
         assertThat(reroutedState.getRoutingNodes().node("node-0").shardsWithState(ShardRoutingState.RELOCATING), hasSize(1));
         assertThat(reroutedState.getRoutingNodes().node("node-1").shardsWithState(ShardRoutingState.RELOCATING), hasSize(1));
-    }
-
-    private static void reconcile(RoutingAllocation routingAllocation, DesiredBalance desiredBalance) {
-        new DesiredBalanceReconciler(desiredBalance, routingAllocation).run();
     }
 
     private static AllocationService createTestAllocationService(


### PR DESCRIPTION
This converts `DesiredBalanceReconciler` to a service that would allow to mock it for unit and concurrency tests.