### PR TITLE
Add rollover permissions for remote_monitoring_agent

### DIFF
--- a/docs/changelog/87717.yaml
+++ b/docs/changelog/87717.yaml
@@ -1,0 +1,6 @@
+pr: 87717
+summary: Add rollover permissions for `remote_monitoring_agent`
+area: Authorization
+type: bug
+issues:
+ - 84161

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStore.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStore.java
@@ -139,6 +139,7 @@ public class ReservedRolesStore implements BiConsumer<Set<String>, ActionListene
                         "monitor",
                         GetLifecycleAction.NAME,
                         PutLifecycleAction.NAME,
+                        RolloverAction.NAME,
                         "cluster:monitor/xpack/watcher/watch/get",
                         "cluster:admin/xpack/watcher/watch/put",
                         "cluster:admin/xpack/watcher/watch/delete" },

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStore.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStore.java
@@ -139,7 +139,6 @@ public class ReservedRolesStore implements BiConsumer<Set<String>, ActionListene
                         "monitor",
                         GetLifecycleAction.NAME,
                         PutLifecycleAction.NAME,
-                        RolloverAction.NAME,
                         "cluster:monitor/xpack/watcher/watch/get",
                         "cluster:admin/xpack/watcher/watch/put",
                         "cluster:admin/xpack/watcher/watch/delete" },
@@ -147,7 +146,7 @@ public class ReservedRolesStore implements BiConsumer<Set<String>, ActionListene
                         RoleDescriptor.IndicesPrivileges.builder().indices(".monitoring-*").privileges("all").build(),
                         RoleDescriptor.IndicesPrivileges.builder()
                             .indices("metricbeat-*")
-                            .privileges("index", "create_index", "view_index_metadata", IndicesAliasesAction.NAME)
+                            .privileges("index", "create_index", "view_index_metadata", IndicesAliasesAction.NAME, RolloverAction.NAME)
                             .build() },
                     null,
                     MetadataUtils.DEFAULT_RESERVED_METADATA

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStoreTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStoreTests.java
@@ -1426,9 +1426,7 @@ public class ReservedRolesStoreTests extends ESTestCase {
             is(true)
         );
         assertThat(
-            remoteMonitoringAgentRole.indices()
-                .allowedIndicesMatcher(RolloverAction.NAME)
-                .test(mockIndexAbstraction(metricbeatIndex)),
+            remoteMonitoringAgentRole.indices().allowedIndicesMatcher(RolloverAction.NAME).test(mockIndexAbstraction(metricbeatIndex)),
             is(true)
         );
         assertThat(

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStoreTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStoreTests.java
@@ -1427,6 +1427,12 @@ public class ReservedRolesStoreTests extends ESTestCase {
         );
         assertThat(
             remoteMonitoringAgentRole.indices()
+                .allowedIndicesMatcher(RolloverAction.NAME)
+                .test(mockIndexAbstraction(metricbeatIndex)),
+            is(true)
+        );
+        assertThat(
+            remoteMonitoringAgentRole.indices()
                 .allowedIndicesMatcher(IndicesSegmentsAction.NAME)
                 .test(mockIndexAbstraction(metricbeatIndex)),
             is(false)


### PR DESCRIPTION
This avoids an `IndexLifecycleRunner` error the prevents index rollover after running metricbeat outputting as the `remote_monitoring_user`. This user (or the `remote_monitoring_agent` role) is recommended by https://www.elastic.co/guide/en/elasticsearch/reference/master/configuring-metricbeat.html

Fixes https://github.com/elastic/elasticsearch/issues/84161

### Testing

1. Build and run elasticsearch from [source](https://github.com/elastic/kibana/blob/main/x-pack/plugins/monitoring/dev_docs/how_to/running_components_from_source.md#multi-cluster-tests-for-ccrccs-or-listing)
2. Additionally reset the password for `remote_monitoring_user`
   ```sh
   curl -u elastic:changeme -H 'Content-Type: application/json' \
   http://localhost:9200/_security/user/remote_monitoring_user/_password -d'{"password": "changeme"}'
   ```
3. Start metricbeat monitoring and reporting to elasticsearch as `remote_monitoring_user`
   ```yaml
   metricbeat.modules:
     - module: elasticsearch
       xpack.enabled: true
       period: 10s
       hosts:
         - "localhost:9200"
       username: "remote_monitoring_user"
       password: "changeme"
   
   output.elasticsearch:
     hosts: [ "localhost:9200" ]
     username: "remote_monitoring_user"
     password: "changeme"
   ```
4. Check for one metricbeat index
   ```sh
   curl -s -u elastic:changeme localhost:9200/_data_stream/metricbeat-'*' | jq '.data_streams | .[].indices'
   [
     {
       "index_name": ".ds-metricbeat-8.4.0-2022.06.17-000001",
       "index_uuid": "Xznusm42QsSRBiaUxbw4kg"
     }
   ]
   ```
5. Update the metricbeat policy to rollover after 1 minute
   ```sh
   curl -s -u remote_monitoring_user:changeme localhost:9200/_ilm/policy/metricbeat -XPUT -H'Content-Type: application/json' -d @- <<JSON
   {
     "policy": {
       "phases": {
         "hot": {
           "min_age": "0ms",
           "actions": {
             "rollover": {
               "max_primary_shard_size": "50gb",
               "max_age": "1m"
             }
           }
         }
       }
     }
   }
   JSON
   ```
6. Confirm that the metricbeat policy is owned by `remote_monitoring_user`
   ```sh
   curl -s -u elastic:changeme localhost:9200/_cluster/state | jq -r '.metadata.index_lifecycle.policies.metricbeat.headers._xpack_security_authentication' | base64 -d
   ```
7. Check for a second metricbeat index after a few minutes (in my testing it takes ~ 10min for `IndexLifecycleRunner` to kick in)
   ```sh
   curl -s -u elastic:changeme localhost:9200/_data_stream/metricbeat-'*' | jq '.data_streams | .[].indices'
   [
     {
       "index_name": ".ds-metricbeat-8.4.0-2022.06.17-000001",
       "index_uuid": "Xznusm42QsSRBiaUxbw4kg"
     },
     {
       "index_name": ".ds-metricbeat-8.4.0-2022.06.17-000002",
       "index_uuid": "XuRFWXBjST-4hFb46Q3UQg"
     }
   ]
   ```

If you run the above steps against `main` you'll see this in the ES stdout when the rollover attempt happens:

```
[2022-06-17T17:24:15,260][ERROR][o.e.x.i.IndexLifecycleRunner] [matschaffer-mbp2019.lan] policy [metricbeat] for index [.ds-metricbeat-8.4.0-2022.06.17-000001] failed on step [{"phase":"hot","action":"rollover","name":"check-rollover-ready"}]. Moving to ERROR step
org.elasticsearch.ElasticsearchSecurityException: action [indices:admin/rollover] is unauthorized for user [remote_monitoring_user] with roles [remote_monitoring_collector,remote_monitoring_agent] on indices [metricbeat-8.4.0,.ds-metricbeat-8.4.0-2022.06.17-000001], this action is granted by the index privileges [manage_follow_index,manage,all]
```