### PR TITLE
Fix possible NPE in startup exception handling

### DIFF
--- a/docs/changelog/87732.yaml
+++ b/docs/changelog/87732.yaml
@@ -1,0 +1,5 @@
+pr: 87732
+summary: Fix possible NPE in startup exception handling
+area: Infra/Core
+type: bug
+issues: []

--- a/docs/changelog/87732.yaml
+++ b/docs/changelog/87732.yaml
@@ -1,5 +1,0 @@
-pr: 87732
-summary: Fix possible NPE in startup exception handling
-area: Infra/Core
-type: bug
-issues: []

--- a/server/src/main/java/org/elasticsearch/bootstrap/StartupException.java
+++ b/server/src/main/java/org/elasticsearch/bootstrap/StartupException.java
@@ -41,10 +41,10 @@ final class StartupException {
             cause = getFirstGuiceCause((CreationException) cause);
         }
 
-        String message = cause.toString();
-        err.println(message);
-
         if (cause != null) {
+            String message = cause.toString();
+            err.println(message);
+
             // walk to the root cause
             while (cause.getCause() != null) {
                 cause = cause.getCause();


### PR DESCRIPTION
Trivially, move startup exception cause message output into the null-protected block (since the cause can be null). This is a lithely oversight of a recent refactoring.