### PR TITLE
Log 'output of node' separators to stdout

### DIFF
--- a/build-tools/src/main/java/org/elasticsearch/gradle/testclusters/ElasticsearchNode.java
+++ b/build-tools/src/main/java/org/elasticsearch/gradle/testclusters/ElasticsearchNode.java
@@ -1141,7 +1141,7 @@ public class ElasticsearchNode implements TestClusterConfiguration {
         }
         if (tailLogs) {
             if (errorsAndWarnings.isEmpty() == false || ring.isEmpty() == false) {
-                LOGGER.error("\n=== {} `{}` ===", description, this);
+                LOGGER.lifecycle("\n=== {} `{}` ===", description, this);
             }
             if (errorsAndWarnings.isEmpty() == false) {
                 LOGGER.lifecycle("\n»    ↓ errors and warnings from " + from + " ↓");


### PR DESCRIPTION
Today when using Gradle-managed test clusters we separate the log output
from each node with a separator that looks like this:

    === Log output of node `node{:qa:mixed-cluster:v8.2.0-0}` ===

However, we write this to `stderr` and yet write the rest of the log
output to `stdout`. This commit moves the separators to the same log
level as the rest of this output so that they can all be redirected to
the same place.