### PR TITLE
Fix synthetic source highlighting tests

### DIFF
--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.highlight/50_synthetic_source.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.highlight/50_synthetic_source.yml
@@ -7,6 +7,8 @@ setup:
       indices.create:
         index: test
         body:
+          settings:
+            number_of_shards: 1
           mappings:
             _source:
               synthetic: true


### PR DESCRIPTION
The synthetic source highlighting tests would sometimes fail in a
strange way - they expect the entire search request to fail but it
*didn't* - only a single shard would fail. This locks the tests to
always make single shard indices so the failures are consistent.

Closes #87730
