### PR TITLE
Desired balance calculator

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/allocator/DesiredBalance.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/allocator/DesiredBalance.java
@@ -28,7 +28,5 @@ public record DesiredBalance(long lastConvergedIndex, Map<ShardId, ShardAssignme
         return Objects.equals(a.assignments, b.assignments) == false;
     }
 
-    public static DesiredBalance initial() {
-        return new DesiredBalance(-1, Map.of());
-    }
+    public static DesiredBalance INITIAL = new DesiredBalance(-1, Map.of());
 }

--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/allocator/DesiredBalance.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/allocator/DesiredBalance.java
@@ -27,4 +27,8 @@ public record DesiredBalance(long lastConvergedIndex, Map<ShardId, ShardAssignme
     public static boolean hasChanges(DesiredBalance a, DesiredBalance b) {
         return Objects.equals(a.assignments, b.assignments) == false;
     }
+
+    public static DesiredBalance initial() {
+        return new DesiredBalance(-1, Map.of());
+    }
 }

--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/allocator/DesiredBalanceComputer.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/allocator/DesiredBalanceComputer.java
@@ -14,7 +14,6 @@ import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.routing.RoutingNodes;
 import org.elasticsearch.cluster.routing.ShardRouting;
 import org.elasticsearch.cluster.routing.UnassignedInfo;
-import org.elasticsearch.common.util.set.Sets;
 import org.elasticsearch.core.Tuple;
 import org.elasticsearch.index.shard.ShardId;
 
@@ -25,7 +24,6 @@ import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Set;
 import java.util.TreeSet;
 import java.util.function.Predicate;
@@ -258,40 +256,5 @@ public class DesiredBalanceComputer {
 
         long lastConvergedIndex = hasChanges ? previousDesiredBalance.lastConvergedIndex() : desiredBalanceInput.index();
         return new DesiredBalance(lastConvergedIndex, assignments);
-    }
-
-    private boolean setCurrentDesiredBalance(DesiredBalance newDesiredBalance) {
-        boolean hasChanges = DesiredBalance.hasChanges(currentDesiredBalance, newDesiredBalance);
-        if (logger.isTraceEnabled()) {
-            if (hasChanges) {
-                logChanges(currentDesiredBalance, newDesiredBalance);
-                logger.trace("desired balance changed : {}", newDesiredBalance);
-            } else {
-                logger.trace("desired balance unchanged: {}", newDesiredBalance);
-            }
-        }
-        currentDesiredBalance = newDesiredBalance;
-        return hasChanges;
-    }
-
-    private static void logChanges(DesiredBalance old, DesiredBalance updated) {
-        var intersection = Sets.intersection(old.assignments().keySet(), updated.assignments().keySet());
-        var diff = Sets.difference(Sets.union(old.assignments().keySet(), updated.assignments().keySet()), intersection);
-
-        var newLine = System.lineSeparator();
-        var builder = new StringBuilder();
-        for (ShardId shardId : intersection) {
-            var oldAssignment = old.getAssignment(shardId);
-            var updatedAssignment = updated.getAssignment(shardId);
-            if (Objects.equals(oldAssignment, updatedAssignment) == false) {
-                builder.append(newLine).append(shardId).append(": ").append(oldAssignment).append(" --> ").append(updatedAssignment);
-            }
-        }
-        for (ShardId shardId : diff) {
-            var oldAssignment = old.getAssignment(shardId);
-            var updatedAssignment = updated.getAssignment(shardId);
-            builder.append(newLine).append(shardId).append(": ").append(oldAssignment).append(" --> ").append(updatedAssignment);
-        }
-        logger.trace("desired balance updated: {}", builder.append(newLine).toString());
     }
 }

--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/allocator/DesiredBalanceComputer.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/allocator/DesiredBalanceComputer.java
@@ -38,13 +38,9 @@ public class DesiredBalanceComputer {
 
     private final ShardsAllocator delegateAllocator;
 
-    private volatile DesiredBalance currentDesiredBalance = DesiredBalance.INITIAL;
-
     public DesiredBalanceComputer(ShardsAllocator delegateAllocator) {
         this.delegateAllocator = delegateAllocator;
     }
-
-    // TODO reset desired balance to empty if new master is elected?
 
     public DesiredBalance compute(
         DesiredBalance previousDesiredBalance,

--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/allocator/DesiredBalanceComputer.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/allocator/DesiredBalanceComputer.java
@@ -40,7 +40,7 @@ public class DesiredBalanceComputer {
 
     private final ShardsAllocator delegateAllocator;
 
-    private volatile DesiredBalance currentDesiredBalance = DesiredBalance.initial();
+    private volatile DesiredBalance currentDesiredBalance = DesiredBalance.INITIAL;
 
     public DesiredBalanceComputer(ShardsAllocator delegateAllocator) {
         this.delegateAllocator = delegateAllocator;
@@ -260,10 +260,6 @@ public class DesiredBalanceComputer {
         return new DesiredBalance(lastConvergedIndex, assignments);
     }
 
-    boolean updateDesiredBalanceAndReroute(DesiredBalanceInput desiredBalanceInput, Predicate<DesiredBalanceInput> isFresh) {
-        return setCurrentDesiredBalance(compute(currentDesiredBalance, desiredBalanceInput, isFresh));
-    }
-
     private boolean setCurrentDesiredBalance(DesiredBalance newDesiredBalance) {
         boolean hasChanges = DesiredBalance.hasChanges(currentDesiredBalance, newDesiredBalance);
         if (logger.isTraceEnabled()) {
@@ -297,9 +293,5 @@ public class DesiredBalanceComputer {
             builder.append(newLine).append(shardId).append(": ").append(oldAssignment).append(" --> ").append(updatedAssignment);
         }
         logger.trace("desired balance updated: {}", builder.append(newLine).toString());
-    }
-
-    public DesiredBalance getCurrentDesiredBalance() {
-        return currentDesiredBalance;
     }
 }

--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/allocator/DesiredBalanceShardsAllocator.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/allocator/DesiredBalanceShardsAllocator.java
@@ -94,6 +94,7 @@ public class DesiredBalanceShardsAllocator implements ShardsAllocator, ClusterSt
 
                 if (isFresh) {
                     if (DesiredBalance.hasChanges(currentDesiredBalance, appliedDesiredBalance)) {
+                        logger.trace("Current desired balance is different from applied one, scheduling a reroute");
                         rerouteServiceSupplier.get().reroute("desired balance changed", Priority.NORMAL, ActionListener.noop());
                     } else {
                         var lastConvergedIndex = currentDesiredBalance.lastConvergedIndex();
@@ -141,6 +142,7 @@ public class DesiredBalanceShardsAllocator implements ShardsAllocator, ClusterSt
         // Otherwise we will have to do a second cluster state update straight away.
 
         appliedDesiredBalance = currentDesiredBalance;
+        logger.info("Allocating using balance [{}]", appliedDesiredBalance);
         new DesiredBalanceReconciler(appliedDesiredBalance, allocation).run();
 
         queue.complete(appliedDesiredBalance.lastConvergedIndex());

--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/allocator/DesiredBalanceShardsAllocator.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/allocator/DesiredBalanceShardsAllocator.java
@@ -159,6 +159,7 @@ public class DesiredBalanceShardsAllocator implements ShardsAllocator, ClusterSt
             logger.trace("Executing listeners up to [{}] after cluster state was committed", queue.getCompletedIndex());
             queue.resume();
         } else {
+            reset();
             queue.completeAllAsNotMaster();
         }
     }
@@ -166,6 +167,13 @@ public class DesiredBalanceShardsAllocator implements ShardsAllocator, ClusterSt
     @Override
     public ShardAllocationDecision decideShardAllocation(ShardRouting shard, RoutingAllocation allocation) {
         return delegateAllocator.decideShardAllocation(shard, allocation);
+    }
+
+    private void reset() {
+        if (indexGenerator.getAndSet(-1) != -1) {
+            currentDesiredBalance = DesiredBalance.INITIAL;
+            appliedDesiredBalance = DesiredBalance.INITIAL;
+        }
     }
 
     private boolean setCurrentDesiredBalance(DesiredBalance newDesiredBalance) {

--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/allocator/DesiredBalanceShardsAllocator.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/allocator/DesiredBalanceShardsAllocator.java
@@ -90,7 +90,7 @@ public class DesiredBalanceShardsAllocator implements ShardsAllocator, ClusterSt
                 logger.trace("Computing balance for [{}]", desiredBalanceInput.index());
 
                 setCurrentDesiredBalance(desiredBalanceComputer.compute(currentDesiredBalance, desiredBalanceInput, this::isFresh));
-                var isFresh = isFresh(desiredBalanceInput);// needs to happen before publishing current desired state?
+                var isFresh = isFresh(desiredBalanceInput);
 
                 if (isFresh) {
                     if (DesiredBalance.hasChanges(currentDesiredBalance, appliedDesiredBalance)) {

--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/allocator/DesiredBalanceShardsAllocator.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/allocator/DesiredBalanceShardsAllocator.java
@@ -86,10 +86,6 @@ public class DesiredBalanceShardsAllocator implements ShardsAllocator, ClusterSt
 
                 logger.trace("Computing balance for [{}]", desiredBalanceInput.index());
 
-                if (DesiredBalance.hasChanges(currentDesiredBalance, appliedDesiredBalance)) {
-                    logger.info("--> Current [{}], Applied [{}]", currentDesiredBalance, appliedDesiredBalance);
-                }
-
                 currentDesiredBalance = desiredBalanceComputer.compute(currentDesiredBalance, desiredBalanceInput, this::isFresh);
                 var isFresh = isFresh(desiredBalanceInput);// needs to happen before publishing current desired state?
 

--- a/server/src/test/java/org/elasticsearch/cluster/routing/allocation/allocator/DesiredBalanceComputerTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/allocation/allocator/DesiredBalanceComputerTests.java
@@ -41,7 +41,6 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import static org.elasticsearch.cluster.metadata.IndexMetadata.SETTING_INDEX_VERSION_CREATED;
 import static org.elasticsearch.cluster.metadata.IndexMetadata.SETTING_NUMBER_OF_REPLICAS;
 import static org.elasticsearch.cluster.metadata.IndexMetadata.SETTING_NUMBER_OF_SHARDS;
-import static org.elasticsearch.cluster.routing.allocation.allocator.DesiredBalance.initial;
 import static org.hamcrest.Matchers.equalTo;
 
 public class DesiredBalanceComputerTests extends ESTestCase {
@@ -53,7 +52,7 @@ public class DesiredBalanceComputerTests extends ESTestCase {
         var clusterState = createInitialClusterState();
         var index = clusterState.metadata().index(TEST_INDEX).getIndex();
 
-        var desiredBalance = desiredBalanceComputer.compute(initial(), createInput(clusterState), input -> true);
+        var desiredBalance = desiredBalanceComputer.compute(DesiredBalance.INITIAL, createInput(clusterState), input -> true);
 
         assertDesiredAssignments(
             desiredBalance,
@@ -72,7 +71,7 @@ public class DesiredBalanceComputerTests extends ESTestCase {
         var index = clusterState.metadata().index(TEST_INDEX).getIndex();
 
         // if the isFresh flag is false then we only do one iteration, allocating the primaries but not the replicas
-        var desiredBalance0 = initial();
+        var desiredBalance0 = DesiredBalance.INITIAL;
         var desiredBalance1 = desiredBalanceComputer.compute(desiredBalance0, createInput(clusterState), input -> false);
         assertDesiredAssignments(
             desiredBalance1,
@@ -103,7 +102,7 @@ public class DesiredBalanceComputerTests extends ESTestCase {
         var index = clusterState.metadata().index(TEST_INDEX).getIndex();
         var primaryShard = clusterState.routingTable().shardRoutingTable(TEST_INDEX, 0).primaryShard();
 
-        var desiredBalance = desiredBalanceComputer.compute(initial(), createInput(clusterState, primaryShard), input -> true);
+        var desiredBalance = desiredBalanceComputer.compute(DesiredBalance.INITIAL, createInput(clusterState, primaryShard), input -> true);
 
         assertDesiredAssignments(
             desiredBalance,
@@ -123,7 +122,7 @@ public class DesiredBalanceComputerTests extends ESTestCase {
         var index = clusterState.metadata().index(TEST_INDEX).getIndex();
         var replicaShard = clusterState.routingTable().shardRoutingTable(TEST_INDEX, 0).replicaShards().get(0);
 
-        var desiredBalance = desiredBalanceComputer.compute(initial(), createInput(clusterState, replicaShard), input -> true);
+        var desiredBalance = desiredBalanceComputer.compute(DesiredBalance.INITIAL, createInput(clusterState, replicaShard), input -> true);
 
         assertDesiredAssignments(
             desiredBalance,
@@ -163,7 +162,7 @@ public class DesiredBalanceComputerTests extends ESTestCase {
             .routingTable(RoutingTable.of(clusterState.routingTable().version(), routingNodes))
             .build();
 
-        var desiredBalance = desiredBalanceComputer.compute(initial(), createInput(clusterState), input -> true);
+        var desiredBalance = desiredBalanceComputer.compute(DesiredBalance.INITIAL, createInput(clusterState), input -> true);
 
         assertDesiredAssignments(
             desiredBalance,
@@ -211,7 +210,7 @@ public class DesiredBalanceComputerTests extends ESTestCase {
             .routingTable(RoutingTable.of(clusterState.routingTable().version(), routingNodes))
             .build();
 
-        var desiredBalance = desiredBalanceComputer.compute(initial(), createInput(clusterState), input -> true);
+        var desiredBalance = desiredBalanceComputer.compute(DesiredBalance.INITIAL, createInput(clusterState), input -> true);
 
         assertDesiredAssignments(
             desiredBalance,
@@ -268,7 +267,7 @@ public class DesiredBalanceComputerTests extends ESTestCase {
             .routingTable(RoutingTable.of(clusterState.routingTable().version(), desiredRoutingNodes))
             .build();
 
-        var desiredBalance1 = desiredBalanceComputer.compute(initial(), createInput(clusterState), input -> true);
+        var desiredBalance1 = desiredBalanceComputer.compute(DesiredBalance.INITIAL, createInput(clusterState), input -> true);
         assertDesiredAssignments(
             desiredBalance1,
             Map.of(
@@ -362,7 +361,7 @@ public class DesiredBalanceComputerTests extends ESTestCase {
         var desiredBalanceComputer = createDesiredBalanceComputer();
         var clusterState = createInitialClusterState(0);
 
-        var desiredBalance = desiredBalanceComputer.compute(initial(), createInput(clusterState), input -> true);
+        var desiredBalance = desiredBalanceComputer.compute(DesiredBalance.INITIAL, createInput(clusterState), input -> true);
 
         assertDesiredAssignments(desiredBalance, Map.of());
     }

--- a/server/src/test/java/org/elasticsearch/cluster/routing/allocation/allocator/DesiredBalanceReconcilerTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/allocation/allocator/DesiredBalanceReconcilerTests.java
@@ -87,7 +87,7 @@ import static org.hamcrest.Matchers.oneOf;
 public class DesiredBalanceReconcilerTests extends ESTestCase {
 
     public void testNoChangesOnEmptyDesiredBalance() {
-        final var clusterState = DesiredBalanceServiceTests.getInitialClusterState();
+        final var clusterState = DesiredBalanceComputerTests.createInitialClusterState();
         final var routingAllocation = new RoutingAllocation(
             new AllocationDeciders(List.of()),
             clusterState.mutableRoutingNodes(),
@@ -102,7 +102,7 @@ public class DesiredBalanceReconcilerTests extends ESTestCase {
     }
 
     public void testFailsNewPrimariesIfNoDataNodes() {
-        final var clusterState = ClusterState.builder(DesiredBalanceServiceTests.getInitialClusterState())
+        final var clusterState = ClusterState.builder(DesiredBalanceComputerTests.createInitialClusterState())
             .nodes(
                 DiscoveryNodes.builder()
                     .add(
@@ -174,7 +174,7 @@ public class DesiredBalanceReconcilerTests extends ESTestCase {
                 randomBoolean()
                     ? Map.of()
                     : Map.of(
-                        new ShardId(clusterState.metadata().index(DesiredBalanceServiceTests.TEST_INDEX).getIndex(), 0),
+                        new ShardId(clusterState.metadata().index(DesiredBalanceComputerTests.TEST_INDEX).getIndex(), 0),
                         new ShardAssignment(Set.of("node-0"), 0, 0)
                     )
             )

--- a/server/src/test/java/org/elasticsearch/cluster/routing/allocation/allocator/DesiredBalanceShardsAllocatorTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/allocation/allocator/DesiredBalanceShardsAllocatorTests.java
@@ -528,7 +528,7 @@ public class DesiredBalanceShardsAllocatorTests extends ESTestCase {
         }
 
         try {
-            assertTrue("Should call all listeners", listenersCountdown.await(30, TimeUnit.SECONDS));
+            assertTrue("Should call all listeners", listenersCountdown.await(10, TimeUnit.SECONDS));
         } finally {
             clusterService.close();
             terminate(threadPool);


### PR DESCRIPTION
It is possible that `org.elasticsearch.cluster.routing.allocation.allocator.DesiredBalanceShardsAllocator#allocate` are executed very fast (because the current balance is empty or very small). On the other side even single iteration inside `desiredBalanceComputer.compute` is taking significant time (may be there were multiple many shard index just created).

This way there could be multiple allocates happening before we even detect that current desired balance computation is outdated. This will result in first one (even while being outdated) computing correct desired balance with (isFresh=false, shouldReroute=true) and the last one becoming (isFresh=true, shouldReroute=false).

To fix this situation we should update reroute check to compare computed desired balance with one that was actually applied last.

This was reproduce-able with ~6% probability in: org.elasticsearch.snapshots.BlobStoreIncrementalityIT#testIncrementalBehaviorOnPrimaryFailover (and is fixed in this pr)