### PR TITLE
[ML] Add reason of stopping model deployment to logs

### DIFF
--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/assignment/TrainedModelAssignmentNodeService.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/assignment/TrainedModelAssignmentNodeService.java
@@ -248,7 +248,7 @@ public class TrainedModelAssignmentNodeService implements ClusterStateListener {
         updateStoredState(
             task.getModelId(),
             new RoutingStateAndReason(RoutingState.STOPPING, reason),
-            ActionListener.wrap(success -> stopDeploymentAsync(task, "task locally canceled", notifyDeploymentOfStopped), e -> {
+            ActionListener.wrap(success -> stopDeploymentAsync(task, reason, notifyDeploymentOfStopped), e -> {
                 if (ExceptionsHelper.unwrapCause(e) instanceof ResourceNotFoundException) {
                     logger.debug(
                         () -> format("[%s] failed to set routing state to stopping as assignment already removed", task.getModelId()),

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/deployment/DeploymentManager.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/deployment/DeploymentManager.java
@@ -224,7 +224,7 @@ public class DeploymentManager {
             processContext = processContextByAllocation.get(task.getId());
         }
         if (processContext != null) {
-            logger.info("[{}] Stopping deployment", task.getModelId());
+            logger.info("[{}] Stopping deployment, reason [{}]", task.getModelId(), task.stoppedReason().orElse("unknown"));
             processContext.stopProcess();
         } else {
             logger.warn("[{}] No process context to stop", task.getModelId());


### PR DESCRIPTION
The reason was not logged in INFO level. The reason is very
useful to debug issues.
