### PR TITLE
[8.3] Add Lintian overrides to ignore Intel MKL not linked to libc (#87706)

### DIFF
--- a/distribution/packages/src/deb/lintian/elasticsearch
+++ b/distribution/packages/src/deb/lintian/elasticsearch
@@ -49,5 +49,13 @@ jar-contains-source usr/share/elasticsearch/modules/repository-gcs/api-common*.j
 
 # There's no `License` field in Debian control files, but earlier versions
 # of `lintian` were more permissive. Override this warning so that we can
-# run `lintian` on different releases of Debian.
+# run `lintian` on different releases of Debian. The format of this override
+# varies between `lintian` versions.
 unknown-field elasticsearch-*.deb License
+unknown-field License
+
+# Intel MKL libraries are not linked directly to libc. They are linked
+# indirectly to libc via libdl. This might not be best practice but we
+# don't build them ourselves and the license precludes us modifying them
+# to fix this.
+library-not-linked-against-libc usr/share/elasticsearch/modules/x-pack-ml/platform/linux-x86_64/lib/libmkl_*.so

--- a/qa/os/src/test/java/org/elasticsearch/packaging/test/DebMetadataTests.java
+++ b/qa/os/src/test/java/org/elasticsearch/packaging/test/DebMetadataTests.java
@@ -30,10 +30,16 @@ public class DebMetadataTests extends PackagingTestCase {
     public void test05CheckLintian() {
         String extraArgs = "";
         final String helpText = sh.run("lintian --help").stdout();
-        if (helpText.contains("fail-on-warnings")) {
+        if (helpText.contains("--fail-on-warnings")) {
             extraArgs = "--fail-on-warnings";
         } else if (helpText.contains("--fail-on error")) {
             extraArgs = "--fail-on warning";
+            // Recent lintian versions are picky about malformed or mismatched overrides.
+            // Unfortunately override syntax changes between lintian versions in a non-backwards compatible
+            // way, so we have to tolerate these (or maintain separate override files per lintian version).
+            if (helpText.contains("--suppress-tags")) {
+                extraArgs += " --suppress-tags malformed-override,mismatched-override";
+            }
         }
         sh.run("lintian %s %s".formatted(extraArgs, FileUtils.getDistributionFile(distribution())));
     }


### PR DESCRIPTION
Backports the following commits to 8.3:
 - Add Lintian overrides to ignore Intel MKL not linked to libc (#87706)