### PR TITLE
Add more detail to assertion in TransportService

### DIFF
--- a/server/src/main/java/org/elasticsearch/transport/TransportService.java
+++ b/server/src/main/java/org/elasticsearch/transport/TransportService.java
@@ -303,7 +303,15 @@ public class TransportService extends AbstractLifecycleComponent
 
                     // Assertion only holds for TcpTransport only because other transports (used in tests) may not implement the proper
                     // close-connection behaviour. TODO fix this.
-                    assert transport instanceof TcpTransport == false || targetNode.equals(localNode) : targetNode + " vs " + localNode;
+                    assert transport instanceof TcpTransport == false || targetNode.equals(localNode)
+                        : "expected only responses for local "
+                            + localNode
+                            + " but found handler for ["
+                            + holderToNotify.action()
+                            + "] on ["
+                            + (holderToNotify.connection().isClosed() ? "closed" : "open")
+                            + "] connection to "
+                            + targetNode;
 
                     final var exception = new SendRequestTransportException(
                         targetNode,


### PR DESCRIPTION
#86315 was supposed to fix this but it looks like it still tripped in https://gradle-enterprise.elastic.co/s/gkje7i7ctfs6g. This commit adds a bit more detail to the message (action name, connection state) that might be helpful.