### PR TITLE
[8.3] Add more debugging for readiness test timeout (#87652)

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/readiness/ReadinessClusterIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/readiness/ReadinessClusterIT.java
@@ -132,9 +132,13 @@ public class ReadinessClusterIT extends ESIntegTestCase implements ReadinessClie
             public Settings onNodeStopped(String nodeName) throws Exception {
                 expectMasterNotFound();
 
+                logger.info("--> master node [{}] stopped", nodeName);
+
                 for (String dataNode : dataNodes) {
+                    logger.info("--> checking data node [{}] for readiness", dataNode);
                     ReadinessService s = internalCluster().getInstance(ReadinessService.class, dataNode);
-                    s.listenerThreadLatch.await(10, TimeUnit.SECONDS);
+                    boolean awaitSuccessful = s.listenerThreadLatch.await(10, TimeUnit.SECONDS);
+                    assertTrue(awaitSuccessful);
                     tcpReadinessProbeFalse(s);
                 }
 

--- a/server/src/main/java/org/elasticsearch/readiness/ReadinessService.java
+++ b/server/src/main/java/org/elasticsearch/readiness/ReadinessService.java
@@ -183,6 +183,10 @@ public class ReadinessService extends AbstractLifecycleComponent implements Clus
     synchronized void stopListener() {
         assert enabled(environment);
         try {
+            logger.info(
+                "stopping readiness service on channel {}",
+                (this.serverChannel == null) ? "None" : this.serverChannel.getLocalAddress()
+            );
             if (this.serverChannel != null) {
                 this.serverChannel.close();
                 listenerThreadLatch.await();

--- a/test/framework/src/main/java/org/elasticsearch/test/readiness/ReadinessClientProbe.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/readiness/ReadinessClientProbe.java
@@ -8,6 +8,8 @@
 
 package org.elasticsearch.test.readiness;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.elasticsearch.core.SuppressForbidden;
 import org.elasticsearch.readiness.ReadinessService;
 
@@ -29,14 +31,16 @@ import static org.junit.Assert.fail;
  * the readiness service for testing purposes
  */
 public interface ReadinessClientProbe {
+    Logger probeLogger = LogManager.getLogger(ReadinessClientProbe.class);
+
     default void tcpReadinessProbeTrue(ReadinessService readinessService) throws Exception {
         tcpReadinessProbeTrue(readinessService.boundAddress().publishAddress().getPort());
     }
 
     // extracted because suppress forbidden checks have issues with lambdas
     @SuppressForbidden(reason = "Intentional socket open")
-    default void channelConnect(SocketChannel channel, InetSocketAddress socketAddress) throws IOException {
-        channel.connect(socketAddress);
+    default boolean channelConnect(SocketChannel channel, InetSocketAddress socketAddress) throws IOException {
+        return channel.connect(socketAddress);
     }
 
     @SuppressForbidden(reason = "Intentional socket open")
@@ -66,7 +70,10 @@ public interface ReadinessClientProbe {
 
         try (SocketChannel channel = SocketChannel.open(StandardProtocolFamily.INET)) {
             AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
-                String message = expectThrows(IOException.class, () -> channelConnect(channel, socketAddress)).getMessage();
+                String message = expectThrows(IOException.class, () -> {
+                    var result = channelConnect(channel, socketAddress);
+                    probeLogger.info("No exception on channel connect, connection success [{}]", result);
+                }).getMessage();
                 assertThat(message, containsString("Connection refused"));
                 return null;
             });


### PR DESCRIPTION
Backports the following commits to 8.3:
 - Add more debugging for readiness test timeout (#87652)