### PR TITLE
Move logging config assertion to server cli

### DIFF
--- a/distribution/tools/server-cli/src/main/java/org/elasticsearch/server/cli/ServerCli.java
+++ b/distribution/tools/server-cli/src/main/java/org/elasticsearch/server/cli/ServerCli.java
@@ -78,9 +78,7 @@ class ServerCli extends EnvironmentAwareCommand {
             return;
         }
 
-        if (options.valuesOf(enrollmentTokenOption).size() > 1) {
-            throw new UserException(ExitCodes.USAGE, "Multiple --enrollment-token parameters are not allowed");
-        }
+        validateConfig(options, env);
 
         // setup security
         final SecureString keystorePassword = getKeystorePassword(env.configFile(), terminal);
@@ -115,6 +113,17 @@ class ServerCli extends EnvironmentAwareCommand {
             JvmInfo.jvmInfo().version()
         );
         terminal.println(versionOutput);
+    }
+
+    private void validateConfig(OptionSet options, Environment env) throws UserException {
+        if (options.valuesOf(enrollmentTokenOption).size() > 1) {
+            throw new UserException(ExitCodes.USAGE, "Multiple --enrollment-token parameters are not allowed");
+        }
+
+        Path log4jConfig = env.configFile().resolve("log4j2.properties");
+        if (Files.exists(log4jConfig) == false) {
+            throw new UserException(ExitCodes.CONFIG, "Missing logging config file at " + log4jConfig);
+        }
     }
 
     private static SecureString getKeystorePassword(Path configDir, Terminal terminal) throws IOException {

--- a/distribution/tools/server-cli/src/test/java/org/elasticsearch/server/cli/ServerCliTests.java
+++ b/distribution/tools/server-cli/src/test/java/org/elasticsearch/server/cli/ServerCliTests.java
@@ -28,6 +28,7 @@ import org.elasticsearch.monitor.jvm.JvmInfo;
 import org.hamcrest.Matcher;
 import org.junit.Before;
 
+import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Locale;
@@ -44,6 +45,11 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 
 public class ServerCliTests extends CommandTestCase {
+
+    @Before
+    public void setupMockConfig() throws IOException {
+        Files.createFile(configDir.resolve("log4j2.properties"));
+    }
 
     @Override
     protected void assertUsage(Matcher<String> matcher, String... args) throws Exception {
@@ -84,6 +90,13 @@ public class ServerCliTests extends CommandTestCase {
         assertOkWithOutput(versionOutput, emptyString(), "-V");
         terminal.reset();
         assertOkWithOutput(versionOutput, emptyString(), "--version");
+    }
+
+    public void testMissingLoggingConfig() throws Exception {
+        Files.delete(configDir.resolve("log4j2.properties"));
+        int status = executeMain();
+        assertThat(status, equalTo(ExitCodes.CONFIG));
+        assertThat(terminal.getErrorOutput(), containsString("Missing logging config file"));
     }
 
     public void testPositionalArgs() throws Exception {

--- a/qa/evil-tests/src/test/java/org/elasticsearch/common/logging/EvilLoggerConfigurationTests.java
+++ b/qa/evil-tests/src/test/java/org/elasticsearch/common/logging/EvilLoggerConfigurationTests.java
@@ -25,10 +25,8 @@ import java.io.IOException;
 import java.nio.file.Path;
 import java.util.Map;
 
-import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.Matchers.hasKey;
-import static org.hamcrest.Matchers.hasToString;
 import static org.hamcrest.Matchers.notNullValue;
 
 public class EvilLoggerConfigurationTests extends ESTestCase {

--- a/qa/evil-tests/src/test/java/org/elasticsearch/common/logging/EvilLoggerConfigurationTests.java
+++ b/qa/evil-tests/src/test/java/org/elasticsearch/common/logging/EvilLoggerConfigurationTests.java
@@ -129,14 +129,6 @@ public class EvilLoggerConfigurationTests extends ESTestCase {
         assertThat(LogManager.getLogger("x.y").getLevel(), equalTo(level));
     }
 
-    public void testMissingConfigFile() {
-        final Path configDir = getDataPath("does_not_exist");
-        final Settings settings = Settings.builder().put(Environment.PATH_HOME_SETTING.getKey(), createTempDir().toString()).build();
-        final Environment environment = new Environment(settings, configDir);
-        UserException e = expectThrows(UserException.class, () -> LogConfigurator.configure(environment, true));
-        assertThat(e, hasToString(containsString("no log4j2.properties found; tried")));
-    }
-
     public void testLoggingLevelsFromSettings() throws IOException, UserException {
         final Level rootLevel = randomFrom(Level.TRACE, Level.DEBUG, Level.INFO, Level.WARN, Level.ERROR);
         final Level fooLevel = randomFrom(Level.TRACE, Level.DEBUG, Level.INFO, Level.WARN, Level.ERROR);

--- a/qa/evil-tests/src/test/java/org/elasticsearch/common/logging/EvilLoggerTests.java
+++ b/qa/evil-tests/src/test/java/org/elasticsearch/common/logging/EvilLoggerTests.java
@@ -17,7 +17,6 @@ import org.apache.logging.log4j.core.appender.ConsoleAppender;
 import org.apache.logging.log4j.core.appender.CountingNoOpAppender;
 import org.apache.logging.log4j.core.config.Configurator;
 import org.apache.lucene.util.Constants;
-import org.elasticsearch.cli.UserException;
 import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.common.Randomness;
 import org.elasticsearch.common.settings.Setting;
@@ -68,7 +67,7 @@ public class EvilLoggerTests extends ESTestCase {
         super.tearDown();
     }
 
-    public void testLocationInfoTest() throws IOException, UserException {
+    public void testLocationInfoTest() throws IOException {
         setupLogging("location_info");
 
         final Logger testLogger = LogManager.getLogger("test");
@@ -93,7 +92,7 @@ public class EvilLoggerTests extends ESTestCase {
         assertLogLine(events.get(4), Level.TRACE, location, "This is a trace message");
     }
 
-    public void testConcurrentDeprecationLogger() throws IOException, UserException, BrokenBarrierException, InterruptedException {
+    public void testConcurrentDeprecationLogger() throws IOException, BrokenBarrierException, InterruptedException {
         setupLogging("deprecation");
 
         final DeprecationLogger deprecationLogger = DeprecationLogger.getLogger("deprecation");
@@ -184,7 +183,7 @@ public class EvilLoggerTests extends ESTestCase {
 
     }
 
-    public void testDeprecatedSettings() throws IOException, UserException {
+    public void testDeprecatedSettings() throws IOException {
         setupLogging("settings");
 
         final Setting<Boolean> setting = Setting.boolSetting("deprecated.foo", false, Setting.Property.Deprecated);
@@ -212,7 +211,7 @@ public class EvilLoggerTests extends ESTestCase {
         }
     }
 
-    public void testFindAppender() throws IOException, UserException {
+    public void testFindAppender() throws IOException {
         setupLogging("find_appender");
 
         final Logger hasConsoleAppender = LogManager.getLogger("has_console_appender");
@@ -226,7 +225,7 @@ public class EvilLoggerTests extends ESTestCase {
         assertThat(countingNoOpAppender.getName(), equalTo("counting_no_op"));
     }
 
-    public void testPrefixLogger() throws IOException, IllegalAccessException, UserException {
+    public void testPrefixLogger() throws IOException {
         setupLogging("prefix");
 
         final String prefix = randomAlphaOfLength(16);
@@ -253,7 +252,7 @@ public class EvilLoggerTests extends ESTestCase {
         }
     }
 
-    public void testPrefixLoggerMarkersCanBeCollected() throws IOException, UserException {
+    public void testPrefixLoggerMarkersCanBeCollected() throws IOException {
         setupLogging("prefix");
 
         final int prefixes = 1 << 19; // to ensure enough markers that the GC should collect some when we force a GC below
@@ -266,7 +265,7 @@ public class EvilLoggerTests extends ESTestCase {
         assertThat(PrefixLogger.markersSize(), lessThan(prefixes));
     }
 
-    public void testProperties() throws IOException, UserException {
+    public void testProperties() throws IOException {
         final Settings settings = Settings.builder()
             .put("cluster.name", randomAlphaOfLength(16))
             .put("node.name", randomAlphaOfLength(16))
@@ -279,7 +278,7 @@ public class EvilLoggerTests extends ESTestCase {
         assertThat(System.getProperty("es.logs.node_name"), equalTo(Node.NODE_NAME_SETTING.get(settings)));
     }
 
-    public void testNoNodeNameInPatternWarning() throws IOException, UserException {
+    public void testNoNodeNameInPatternWarning() throws IOException {
         String nodeName = randomAlphaOfLength(16);
         LogConfigurator.setNodeName(nodeName);
         setupLogging("no_node_name");
@@ -309,11 +308,11 @@ public class EvilLoggerTests extends ESTestCase {
         }
     }
 
-    private void setupLogging(final String config) throws IOException, UserException {
+    private void setupLogging(final String config) throws IOException {
         setupLogging(config, Settings.EMPTY);
     }
 
-    private void setupLogging(final String config, final Settings settings) throws IOException, UserException {
+    private void setupLogging(final String config, final Settings settings) throws IOException {
         assert Environment.PATH_HOME_SETTING.exists(settings) == false;
         final Path configDir = getDataPath(config);
         final Settings mergedSettings = Settings.builder()

--- a/server/src/main/java/org/elasticsearch/common/logging/LogConfigurator.java
+++ b/server/src/main/java/org/elasticsearch/common/logging/LogConfigurator.java
@@ -30,8 +30,6 @@ import org.apache.logging.log4j.status.StatusConsoleListener;
 import org.apache.logging.log4j.status.StatusData;
 import org.apache.logging.log4j.status.StatusListener;
 import org.apache.logging.log4j.status.StatusLogger;
-import org.elasticsearch.cli.ExitCodes;
-import org.elasticsearch.cli.UserException;
 import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.common.logging.internal.LoggerFactoryImpl;
 import org.elasticsearch.common.settings.Settings;
@@ -113,9 +111,8 @@ public class LogConfigurator {
      * @param useConsole whether a console appender should exist
      * @throws IOException   if there is an issue readings any log4j2.properties in the config
      *                       directory
-     * @throws UserException if there are no log4j2.properties in the specified configs path
      */
-    public static void configure(final Environment environment, boolean useConsole) throws IOException, UserException {
+    public static void configure(final Environment environment, boolean useConsole) throws IOException {
         Objects.requireNonNull(environment);
         try {
             // we are about to configure logging, check that the status logger did not log any error-level messages
@@ -160,7 +157,7 @@ public class LogConfigurator {
     }
 
     private static void configure(final Settings settings, final Path configsPath, final Path logsPath, boolean useConsole)
-        throws IOException, UserException {
+        throws IOException {
         Objects.requireNonNull(settings);
         Objects.requireNonNull(configsPath);
         Objects.requireNonNull(logsPath);
@@ -229,10 +226,7 @@ public class LogConfigurator {
                 return FileVisitResult.CONTINUE;
             }
         });
-
-        if (configurations.isEmpty()) {
-            throw new UserException(ExitCodes.CONFIG, "no log4j2.properties found; tried [" + configsPath + "] and its subdirectories");
-        }
+        assert configurations.isEmpty() == false;
 
         context.start(new CompositeConfiguration(configurations));
 

--- a/test/framework/src/main/java/org/elasticsearch/cli/CommandTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/cli/CommandTestCase.java
@@ -12,6 +12,8 @@ import org.elasticsearch.test.ESTestCase;
 import org.hamcrest.Matcher;
 import org.junit.Before;
 
+import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.HashMap;
 import java.util.Map;
@@ -36,21 +38,22 @@ public abstract class CommandTestCase extends ESTestCase {
     /** The working directory that execute uses */
     protected Path esHomeDir;
 
+    /** The ES config dir */
+    protected Path configDir;
+
     @Before
-    public void resetTerminal() {
+    public void resetTerminal() throws IOException {
         terminal.reset();
         terminal.setSupportsBinary(false);
         terminal.setVerbosity(Terminal.Verbosity.NORMAL);
         esHomeDir = createTempDir();
+        configDir = esHomeDir.resolve("config");
+        Files.createDirectory(configDir);
         sysprops.clear();
         sysprops.put("es.path.home", esHomeDir.toString());
         sysprops.put("es.path.conf", esHomeDir.resolve("config").toString());
         sysprops.put("os.name", "Linux"); // default to linux, tests can override to check specific OS behavior
         envVars.clear();
-    }
-
-    protected static Map<String, String> mockSystemProperties(Path homeDir) {
-        return Map.of("es.path.home", homeDir.toString(), "es.path.conf", homeDir.resolve("config").toString());
     }
 
     /** Creates a Command to test execution. */


### PR DESCRIPTION
The log4j configuration file is shipped with all ES distributions. We
also check recursively for files possibly added by plugins. If no files
are found, we give a helpful startup error message. However, since the
log4j2 configuration file shipped with ES should always exist, we can
check upfront in the cli before even initializing logging.

This commit moves the validation of an existing log4j2 properties file
to the server cli.