### PR TITLE
Resolve byte unit typo in ILM rollover doc

### DIFF
--- a/docs/changelog/87780.yaml
+++ b/docs/changelog/87780.yaml
@@ -1,5 +1,0 @@
-pr: 87780
-summary: Resolve typo referencing incorrect unit type for max_size attribute
-area: ILM Rollover Documentation
-type: bug
-issues: []

--- a/docs/changelog/87780.yaml
+++ b/docs/changelog/87780.yaml
@@ -1,0 +1,5 @@
+pr: 87780
+summary: Resolve typo referencing incorrect unit type for max_size attribute
+area: ILM Rollover Documentation
+type: bug
+issues: []

--- a/docs/reference/ilm/actions/ilm-rollover.asciidoc
+++ b/docs/reference/ilm/actions/ilm-rollover.asciidoc
@@ -254,7 +254,7 @@ PUT /_ilm/policy/rollover_policy
       "hot": {
         "actions": {
           "rollover": {
-            "max_size": "50G"
+            "max_size": "50GB"
           }
         }
       },


### PR DESCRIPTION
Identified by https://github.com/elastic/terraform-provider-elasticstack/issues/113

g is not supported as a byte unit (should be gb) - https://www.elastic.co/guide/en/elasticsearch/reference/current/api-conventions.html#byte-units

Supersedes #87587 