### PR TITLE
Bound ack time

### DIFF
--- a/test/framework/src/main/java/org/elasticsearch/test/hamcrest/ElasticsearchAssertions.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/hamcrest/ElasticsearchAssertions.java
@@ -17,7 +17,6 @@ import org.elasticsearch.action.ActionRequestBuilder;
 import org.elasticsearch.action.admin.cluster.health.ClusterHealthRequestBuilder;
 import org.elasticsearch.action.admin.cluster.health.ClusterHealthResponse;
 import org.elasticsearch.action.admin.indices.create.CreateIndexResponse;
-import org.elasticsearch.action.admin.indices.delete.DeleteIndexRequestBuilder;
 import org.elasticsearch.action.admin.indices.template.get.GetIndexTemplatesResponse;
 import org.elasticsearch.action.bulk.BulkResponse;
 import org.elasticsearch.action.get.GetResponse;
@@ -85,7 +84,11 @@ import static org.junit.Assert.fail;
 public class ElasticsearchAssertions {
 
     public static void assertAcked(AcknowledgedRequestBuilder<?, ?, ?> builder) {
-        assertAcked(builder.get());
+        assertAcked(builder, TimeValue.timeValueSeconds(30));
+    }
+
+    public static void assertAcked(AcknowledgedRequestBuilder<?, ?, ?> builder, TimeValue timeValue) {
+        assertAcked(builder.get(timeValue));
     }
 
     public static void assertNoTimeout(ClusterHealthRequestBuilder requestBuilder) {
@@ -98,10 +101,6 @@ public class ElasticsearchAssertions {
 
     public static void assertAcked(AcknowledgedResponse response) {
         assertThat(response.getClass().getSimpleName() + " failed - not acked", response.isAcknowledged(), equalTo(true));
-    }
-
-    public static void assertAcked(DeleteIndexRequestBuilder builder) {
-        assertAcked(builder.get());
     }
 
     /**

--- a/x-pack/plugin/autoscaling/src/internalClusterTest/java/org/elasticsearch/xpack/autoscaling/storage/ReactiveStorageIT.java
+++ b/x-pack/plugin/autoscaling/src/internalClusterTest/java/org/elasticsearch/xpack/autoscaling/storage/ReactiveStorageIT.java
@@ -178,7 +178,7 @@ public class ReactiveStorageIT extends AutoscalingStorageIntegTestCase {
                     .put(INDEX_STORE_STATS_REFRESH_INTERVAL_SETTING.getKey(), "0ms")
                     .put(IndexMetadata.INDEX_ROUTING_INCLUDE_GROUP_SETTING.getKey() + "data_tier", "hot")
                     .build()
-            )
+            ).setWaitForActiveShards(ActiveShardCount.NONE)
         );
 
         // the tier preference will have defaulted to data_content, set it back to null


### PR DESCRIPTION
Currently, our default wait time for ack is unbound. This could result
in an entire test suite timeout rather than individual test cases failures.

We should also consider merging this to master.