### PR TITLE
[8.3] [ML] Require that threads_per_allocation is a power of 2 (#87697)

### DIFF
--- a/docs/reference/ml/trained-models/apis/start-trained-model-deployment.asciidoc
+++ b/docs/reference/ml/trained-models/apis/start-trained-model-deployment.asciidoc
@@ -70,7 +70,7 @@ the inference speed. The inference process is a compute-bound process; any numbe
 greater than the number of available hardware threads on the machine does not increase the
 inference speed. If this setting is greater than the number of hardware threads
 it will automatically be changed to a value less than the number of hardware threads.
-Defaults to 1.
+Defaults to 1. Must be a power of 2. Max allowed value is 32.
 
 `timeout`::
 (Optional, time)

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/StartTrainedModelDeploymentAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/StartTrainedModelDeploymentAction.java
@@ -66,6 +66,9 @@ public class StartTrainedModelDeploymentAction extends ActionType<CreateTrainedM
             AllocationStatus.State.STARTED,
             AllocationStatus.State.STARTING,
             AllocationStatus.State.FULLY_ALLOCATED };
+
+        private static final int MAX_THREADS_PER_ALLOCATION = 32;
+
         public static final ParseField MODEL_ID = new ParseField("model_id");
         public static final ParseField TIMEOUT = new ParseField("timeout");
         public static final ParseField WAIT_FOR = new ParseField("wait_for");
@@ -209,10 +212,19 @@ public class StartTrainedModelDeploymentAction extends ActionType<CreateTrainedM
             if (threadsPerAllocation < 1) {
                 validationException.addValidationError("[" + THREADS_PER_ALLOCATION + "] must be a positive integer");
             }
+            if (threadsPerAllocation > MAX_THREADS_PER_ALLOCATION || isPowerOf2(threadsPerAllocation) == false) {
+                validationException.addValidationError(
+                    "[" + THREADS_PER_ALLOCATION + "] must be a power of 2 less than or equal to " + MAX_THREADS_PER_ALLOCATION
+                );
+            }
             if (queueCapacity < 1) {
                 validationException.addValidationError("[" + QUEUE_CAPACITY + "] must be a positive integer");
             }
             return validationException.validationErrors().isEmpty() ? null : validationException;
+        }
+
+        private static boolean isPowerOf2(int value) {
+            return Integer.bitCount(value) == 1;
         }
 
         @Override


### PR DESCRIPTION
Backports the following commits to 8.3:
 - [ML] Require that threads_per_allocation is a power of 2 (#87697)