### PR TITLE
[8.3] Be specific about the data type in each results column (#87797)

### DIFF
--- a/x-pack/plugin/sql/qa/server/src/main/resources/unsigned-long.csv-spec
+++ b/x-pack/plugin/sql/qa/server/src/main/resources/unsigned-long.csv-spec
@@ -487,10 +487,10 @@ null
 medianAbsoluteDeviationLargeInput
 SELECT status, MAD(bytes_in) AS mad FROM logs_unsigned_long GROUP BY status ORDER BY status;
 
-    status     |         mad
----------------+---------------------
-Error          |3.0183732936229658E18
-OK             |4.5240953206634045E18
+    status:s     |         mad:d
+-----------------+---------------------
+Error            |3.0183732936229658E18
+OK               |4.5240953206634045E18
 ;
 
 
@@ -565,10 +565,10 @@ FROM logs_unsigned_long
 GROUP BY status
 ORDER BY status;
 
-     percentile      | percentile_rank  |    status
----------------------+------------------+---------------
-1.8836190713044468E19|1.970336796004502 |Error
-1.7957483822449326E19|26.644793296251386|OK
+     percentile:d    | percentile_rank:d |    status:s
+---------------------+-------------------+---------------
+1.8836190713044468E19|1.970336796004502  |Error
+1.7957483822449326E19|26.644793296251386 |OK
 ;
 
 extendedStatsAggregateFunctionsWithScalarsLargeInput
@@ -582,7 +582,7 @@ FROM logs_unsigned_long
 GROUP BY status
 ORDER BY status;
 
-     stddev_pop      |     stddev_samp     |   sum_of_squares    |       var_pop       |      var_samp      |    status
+     stddev_pop:d    |     stddev_samp:d   |   sum_of_squares:d  |       var_pop:d     |      var_samp:d    |    status:s
 ---------------------+---------------------+---------------------+---------------------+--------------------+---------------
 5.1879845114777528E18|5.6831522898475694E18|1.1113551085273773E39|2.9979868907159907E37|3.597584268859189E37|Error
 6.7116742512203459E18|6.7484508237837148E18|1.4906887301541836E40|4.304729535850427E37 |4.352034256024607E37|OK
@@ -662,7 +662,7 @@ SELECT POWER(bytes_in, -1) m, id FROM logs_unsigned_long WHERE id < 10 ORDER BY 
 averageWithOneValueAndOrderLargeInput
 SELECT * FROM (SELECT id, status, bytes_out FROM logs_unsigned_long) PIVOT (AVG(bytes_out + 1) FOR status IN ('OK', 'Error')) ORDER BY id DESC LIMIT 4;
 
-      id:i       |        'OK':d       |    'Error':d
+      id:i     |        'OK':d       |    'Error':d
 ---------------+---------------------+---------------
 101            |null                 |null
 100            |1.5616395223975498E19|null


### PR DESCRIPTION
Backports the following commits to 8.3:
 - Be specific about the data type in each results column (#87797)