### PR TITLE
Re-enable several tests since JDK-8287097 has been fixed

### DIFF
--- a/libs/core/src/test/java/org/elasticsearch/jdk/JarHellTests.java
+++ b/libs/core/src/test/java/org/elasticsearch/jdk/JarHellTests.java
@@ -119,8 +119,6 @@ public class JarHellTests extends ESTestCase {
     }
 
     public void testNonJDKModuleURLs() throws Throwable {
-        // Temporarily skip on JDK 19, until this issue is resolved https://bugs.openjdk.java.net/browse/JDK-8287097
-        assumeTrue("Skip on 19", Runtime.version().feature() < 19);
         var bootLayer = ModuleLayer.boot();
 
         Path fooDir = createTempDir(getTestName());

--- a/server/src/test/java/org/elasticsearch/module/BasicServerModuleTests.java
+++ b/server/src/test/java/org/elasticsearch/module/BasicServerModuleTests.java
@@ -36,9 +36,6 @@ public class BasicServerModuleTests extends ESTestCase {
     private static final String SERVER_MODULE_NAME = "org.elasticsearch.server";
 
     public void testQualifiedExports() {
-        // Temporarily skip on JDK 19, until this issue is resolved https://bugs.openjdk.java.net/browse/JDK-8287097
-        assumeTrue("Skip on 19", Runtime.version().feature() < 19);
-
         var md = getServerDescriptor();
 
         // The package containing the RestInterceptor type, org.elasticsearch.plugins.interceptor,
@@ -50,17 +47,11 @@ public class BasicServerModuleTests extends ESTestCase {
 
     // Ensures that there are no unqualified opens - too dangerous
     public void testEnsureNoUnqualifiedOpens() {
-        // Temporarily skip on JDK 19, until this issue is resolved https://bugs.openjdk.java.net/browse/JDK-8287097
-        assumeTrue("Skip on 19", Runtime.version().feature() < 19);
-
         var md = getServerDescriptor();
         assertThat(md.opens().stream().filter(not(ModuleDescriptor.Opens::isQualified)).collect(Collectors.toSet()), empty());
     }
 
     public void testQualifiedOpens() {
-        // Temporarily skip on JDK 19, until this issue is resolved https://bugs.openjdk.java.net/browse/JDK-8287097
-        assumeTrue("Skip on 19", Runtime.version().feature() < 19);
-
         var md = getServerDescriptor();
 
         // We tolerate introspection by log4j, for Plugins, e.g. ECSJsonLayout


### PR DESCRIPTION
With JDK-8287097 [1] now fixed in the latest JDK 19 build, b26, we can revert the test changes that were introduced to temporarily skip affected tests.

[1] https://bugs.openjdk.org/browse/JDK-8287097

relates #87000 #87019 