### PR TITLE
Undeprecate function_score query

### DIFF
--- a/docs/reference/query-dsl/script-score-query.asciidoc
+++ b/docs/reference/query-dsl/script-score-query.asciidoc
@@ -241,10 +241,11 @@ can efficiently skip non-competitive hits:
 
 [[script-score-function-score-transition]]
 ===== Transition from the function score query
-We are deprecating the <<query-dsl-function-score-query, `function_score`>>
-query. We recommend using the `script_score` query instead.
+We recommend using the `script_score` query instead of
+<<query-dsl-function-score-query, `function_score`>> query for the simplicity
+of the `script_score` query.
 
-You can implement the following functions from the `function_score` query using
+You can implement the following functions of the `function_score` query using
 the `script_score` query:
 
 * <<script-score>>


### PR DESCRIPTION
We had a plan to deprecate function_score query with
script_score query, but ran into a roadblock of missing
functionality to combine scores from different
functions (particularly "first" script_score).
Wee have several proposal to address this missing
functionality:
 [scripted_boolean](https://github.com/elastic/elasticsearch/issues/27588#issuecomment-444887726)
 [compound_query](https://github.com/elastic/elasticsearch/issues/51967)
 [first_query](https://github.com/elastic/elasticsearch/issues/52482)

But for now, we decided not to deprecate function_score query,
and hence we need to remove any mention that we are deprecating it.

Relates to #42811
Closes #71934