### PR TITLE
Update release notes for 8.3.0-BC5

### DIFF
--- a/docs/reference/release-notes/8.3.0.asciidoc
+++ b/docs/reference/release-notes/8.3.0.asciidoc
@@ -63,6 +63,9 @@ Highlighting::
 ILM+SLM::
 * Make the ILM Move to Error Step Batched {es-pull}85565[#85565] (issue: {es-issue}81880[#81880])
 
+Indices APIs::
+* Make `GetIndexAction` cancellable {es-pull}87681[#87681]
+
 Infra/Core::
 * Adjust osprobe assertion for burst cpu {es-pull}86990[#86990]
 * Clean up `DeflateCompressor` after exception {es-pull}87163[#87163] (issue: {es-issue}87160[#87160])
@@ -149,6 +152,7 @@ TSDB::
 
 Transform::
 * Fix transform `_start` permissions to use stored headers in the config {es-pull}86802[#86802]
+* [Transforms] fix bug when unsetting retention policy {es-pull}87711[#87711]
 
 [[deprecation-8.3.0]]
 [float]


### PR DESCRIPTION
Regenerated release notes for BC5, and two new PRs were added. See generated docs at https://elasticsearch_87808.docs-preview.app.elstc.co/diff