### PR TITLE
Simplify bootstrap error logging

### DIFF
--- a/distribution/src/config/log4j2.properties
+++ b/distribution/src/config/log4j2.properties
@@ -3,7 +3,7 @@ status = error
 appender.console.type = Console
 appender.console.name = console
 appender.console.layout.type = PatternLayout
-appender.console.layout.pattern = [%d{ISO8601}][%-5p][%-25c{1.}] [%node_name]%marker %m%n
+appender.console.layout.pattern = [%d{ISO8601}][%-5p][%-25c{1.}] [%node_name]%marker %m%consoleException%n
 
 ######## Server JSON ############################
 appender.rolling.type = RollingFile

--- a/qa/os/src/test/java/org/elasticsearch/packaging/test/TemporaryDirectoryConfigTests.java
+++ b/qa/os/src/test/java/org/elasticsearch/packaging/test/TemporaryDirectoryConfigTests.java
@@ -103,7 +103,7 @@ public class TemporaryDirectoryConfigTests extends PackagingTestCase {
             distribution(),
             DockerRun.builder().volume(tmpDir, tmpDir).envVar("LIBFFI_TMPDIR", tmpFile.toString())
         );
-        assertThat(result.stderr(), containsString("LIBFFI_TMPDIR"));
+        assertThat(result.stdout(), containsString("LIBFFI_TMPDIR"));
     }
 
     private void withLibffiTmpdir(String tmpDir, CheckedConsumer<Path, Exception> action) throws Exception {

--- a/server/src/main/java/org/elasticsearch/bootstrap/Bootstrap.java
+++ b/server/src/main/java/org/elasticsearch/bootstrap/Bootstrap.java
@@ -16,10 +16,8 @@ import org.apache.lucene.util.Constants;
 import org.apache.lucene.util.StringHelper;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.Version;
-import org.elasticsearch.cli.ExitCodes;
 import org.elasticsearch.cli.UserException;
 import org.elasticsearch.common.filesystem.FileSystemNatives;
-import org.elasticsearch.common.inject.CreationException;
 import org.elasticsearch.common.logging.LogConfigurator;
 import org.elasticsearch.common.network.IfConfig;
 import org.elasticsearch.common.settings.SecureSettings;
@@ -37,10 +35,7 @@ import org.elasticsearch.node.InternalSettingsPreparer;
 import org.elasticsearch.node.Node;
 import org.elasticsearch.node.NodeValidationException;
 
-import java.io.ByteArrayOutputStream;
 import java.io.IOException;
-import java.io.PrintStream;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.util.Collections;
 import java.util.List;
@@ -263,7 +258,7 @@ final class Bootstrap {
      * This method is invoked by {@link Elasticsearch#main(String[])} to startup elasticsearch.
      */
     static void init(final boolean foreground, final Environment initialEnv, SecureString keystorePassword, Path pidFile)
-        throws BootstrapException, NodeValidationException, UserException {
+        throws BootstrapException, NodeValidationException, IOException, UserException {
 
         INSTANCE = new Bootstrap();
 
@@ -280,12 +275,8 @@ final class Bootstrap {
 
         INSTANCE.setup(environment, pidFile);
 
-        try {
-            // any secure settings must be read during node construction
-            IOUtils.close(keystore);
-        } catch (IOException e) {
-            throw new BootstrapException(e);
-        }
+        // any secure settings must be read during node construction
+        IOUtils.close(keystore);
 
         INSTANCE.start();
 

--- a/server/src/main/java/org/elasticsearch/bootstrap/Elasticsearch.java
+++ b/server/src/main/java/org/elasticsearch/bootstrap/Elasticsearch.java
@@ -42,8 +42,9 @@ class Elasticsearch {
 
         PrintStream out = getStdout();
         PrintStream err = getStderr();
+        final ServerArgs serverArgs = initPhase1(err);
+
         try {
-            final ServerArgs serverArgs = initPhase1();
             initPidFile(serverArgs.pidFile());
             Bootstrap.init(
                 serverArgs.daemonize() == false,
@@ -64,8 +65,8 @@ class Elasticsearch {
             exitWithUserException(err, ExitCodes.CONFIG, e);
         } catch (UserException e) {
             exitWithUserException(err, e.exitCode, e);
-        } catch (Exception e) {
-            exitWithUnknownException(err, e);
+        } catch (Throwable t) {
+            exitWithUnknownException(err, t);
         }
     }
 
@@ -75,16 +76,16 @@ class Elasticsearch {
         gracefullyExit(err, exitCode);
     }
 
-    private static void exitWithUnknownException(PrintStream err, Exception e) {
-        if (System.getProperty("es.logs.base_path") != null) {
-            // this is a horrible hack to see if logging has been initialized
-            // we need to find a better way!
-            Logger logger = LogManager.getLogger(Elasticsearch.class);
-            logger.error("fatal exception while booting Elasticsearch", e);
-        }
-        // format exceptions to the console in a special way to avoid 2MB stacktraces from guice, etc.
-        StartupException.printStackTrace(e, err);
+    private static void exitWithUnknownException(PrintStream err, Throwable e) {
+        Logger logger = LogManager.getLogger(Elasticsearch.class);
+        logger.error("fatal exception while booting Elasticsearch", e);
         gracefullyExit(err, 1); // mimic JDK exit code on exception
+    }
+
+    // sends a stacktrace of an exception to the controlling cli process
+    private static void sendGenericException(PrintStream err, Throwable t) {
+        t.printStackTrace(err);
+        err.flush();
     }
 
     private static void gracefullyExit(PrintStream err, int exitCode) {
@@ -116,37 +117,45 @@ class Elasticsearch {
      * finally initializing logging. As little as possible should be done in this phase because
      * initializing logging is the last step.
      */
-    private static ServerArgs initPhase1() throws IOException, UserException {
-        initSecurityProperties();
+    private static ServerArgs initPhase1(PrintStream err) {
+        final ServerArgs args;
+        try {
+            initSecurityProperties();
 
-        /*
-         * We want the JVM to think there is a security manager installed so that if internal policy decisions that would be based on the
-         * presence of a security manager or lack thereof act as if there is a security manager present (e.g., DNS cache policy). This
-         * forces such policies to take effect immediately.
-         */
-        org.elasticsearch.bootstrap.Security.setSecurityManager(new SecurityManager() {
-            @Override
-            public void checkPermission(Permission perm) {
-                // grant all permissions so that we can later set the security manager to the one that we want
-            }
-        });
-        LogConfigurator.registerErrorListener();
+            /*
+             * We want the JVM to think there is a security manager installed so that if internal policy decisions that would be based on the
+             * presence of a security manager or lack thereof act as if there is a security manager present (e.g., DNS cache policy). This
+             * forces such policies to take effect immediately.
+             */
+            org.elasticsearch.bootstrap.Security.setSecurityManager(new SecurityManager() {
+                @Override
+                public void checkPermission(Permission perm) {
+                    // grant all permissions so that we can later set the security manager to the one that we want
+                }
+            });
+            LogConfigurator.registerErrorListener();
 
-        BootstrapInfo.init();
+            BootstrapInfo.init();
 
-        // note that reading server args does *not* close System.in, as it will be read from later for shutdown notification
-        var in = new InputStreamStreamInput(System.in);
-        var args = new ServerArgs(in);
+            // note that reading server args does *not* close System.in, as it will be read from later for shutdown notification
+            var in = new InputStreamStreamInput(System.in);
+            args = new ServerArgs(in);
 
-        // mostly just paths are used in phase 1, so secure settings are not needed
-        Environment nodeEnv = new Environment(args.nodeSettings(), args.configDir());
+            // mostly just paths are used in phase 1, so secure settings are not needed
+            Environment nodeEnv = new Environment(args.nodeSettings(), args.configDir());
 
-        BootstrapInfo.setConsole(ConsoleLoader.loadConsole(nodeEnv));
+            BootstrapInfo.setConsole(ConsoleLoader.loadConsole(nodeEnv));
 
-        // DO NOT MOVE THIS
-        // Logging must remain the last step of phase 1. Anything init steps needing logging should be in phase 2.
-        LogConfigurator.setNodeName(Node.NODE_NAME_SETTING.get(args.nodeSettings()));
-        LogConfigurator.configure(nodeEnv, args.quiet() == false);
+            // DO NOT MOVE THIS
+            // Logging must remain the last step of phase 1. Anything init steps needing logging should be in phase 2.
+            LogConfigurator.setNodeName(Node.NODE_NAME_SETTING.get(args.nodeSettings()));
+            LogConfigurator.configure(nodeEnv, args.quiet() == false);
+        } catch (Throwable t) {
+            // any exception this early needs to be fully printed and fail startup
+            sendGenericException(err, t);
+            exit(1); // mimic JDK exit code on exception
+            return null; // unreachable, to satisfy compiler
+        }
 
         return args;
     }
@@ -157,17 +166,14 @@ class Elasticsearch {
      */
     static void printLogsSuggestion(PrintStream err) {
         final String basePath = System.getProperty("es.logs.base_path");
-        // It's possible to fail before logging has been configured, in which case there's no point
-        // suggesting that the user look in the log file.
-        if (basePath != null) {
-            err.println(
-                "ERROR: Elasticsearch did not exit normally - check the logs at "
-                    + basePath
-                    + System.getProperty("file.separator")
-                    + System.getProperty("es.logs.cluster_name")
-                    + ".log"
-            );
-        }
+        assert basePath != null : "logging wasn't initialized";
+        err.println(
+            "ERROR: Elasticsearch did not exit normally - check the logs at "
+                + basePath
+                + System.getProperty("file.separator")
+                + System.getProperty("es.logs.cluster_name")
+                + ".log"
+        );
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/bootstrap/Elasticsearch.java
+++ b/server/src/main/java/org/elasticsearch/bootstrap/Elasticsearch.java
@@ -123,9 +123,9 @@ class Elasticsearch {
             initSecurityProperties();
 
             /*
-             * We want the JVM to think there is a security manager installed so that if internal policy decisions that would be based on the
-             * presence of a security manager or lack thereof act as if there is a security manager present (e.g., DNS cache policy). This
-             * forces such policies to take effect immediately.
+             * We want the JVM to think there is a security manager installed so that if internal policy decisions that would be based on
+             * the presence of a security manager or lack thereof act as if there is a security manager present (e.g., DNS cache policy).
+             * This forces such policies to take effect immediately.
              */
             org.elasticsearch.bootstrap.Security.setSecurityManager(new SecurityManager() {
                 @Override

--- a/server/src/main/java/org/elasticsearch/bootstrap/StartupException.java
+++ b/server/src/main/java/org/elasticsearch/bootstrap/StartupException.java
@@ -12,72 +12,73 @@ import org.elasticsearch.common.inject.CreationException;
 import org.elasticsearch.common.inject.spi.Message;
 
 import java.io.PrintStream;
+import java.util.Objects;
 
 /**
- * Wraps an exception in a special way that it gets formatted
- * "reasonably". This means limits on stacktrace frames and
- * cleanup for guice, and some guidance about consulting full
- * logs for the whole exception.
+ * A wrapper for exceptions occurring during startup.
+ *
+ * <p> The stacktrack of a startup exception may be truncated if it is from Guice,
+ * which can have a large number of stack frames.
  */
-// TODO: remove this when guice is removed, and exceptions are cleaned up
-// this is horrible, but its what we must do
-final class StartupException {
+public final class StartupException extends Exception {
 
     /** maximum length of a stacktrace, before we truncate it */
     static final int STACKTRACE_LIMIT = 30;
     /** all lines from this package are RLE-compressed */
     static final String GUICE_PACKAGE = "org.elasticsearch.common.inject";
 
+    StartupException(Throwable cause) {
+        super(Objects.requireNonNull(cause));
+    }
+
     /**
      * Prints a stacktrace for an exception to a print stream, possibly truncating.
      *
-     * @param e The exception, which may have a long stack trace
      * @param err The error stream to print the stacktrace to
      */
-    static void printStackTrace(Exception e, PrintStream err) {
-        Throwable originalCause = e.getCause();
+    @Override
+    public void printStackTrace(PrintStream err) {
+        Throwable originalCause = getCause();
         Throwable cause = originalCause;
         if (cause instanceof CreationException) {
             cause = getFirstGuiceCause((CreationException) cause);
         }
 
-        if (cause != null) {
-            String message = cause.toString();
-            err.println(message);
+        String message = cause.toString();
+        err.println(message);
 
-            // walk to the root cause
-            while (cause.getCause() != null) {
-                cause = cause.getCause();
+        // walk to the root cause
+        while (cause.getCause() != null) {
+            cause = cause.getCause();
+        }
+
+        // print the root cause message, only if it differs!
+        if (cause != originalCause && (message.equals(cause.toString()) == false)) {
+            err.println("Likely root cause: " + cause);
+        }
+
+        // print stacktrace of cause
+        StackTraceElement[] stack = cause.getStackTrace();
+        int linesWritten = 0;
+        for (int i = 0; i < stack.length; i++) {
+            if (linesWritten == STACKTRACE_LIMIT) {
+                err.println("\t<<<truncated>>>");
+                break;
             }
+            String line = stack[i].toString();
 
-            // print the root cause message, only if it differs!
-            if (cause != originalCause && (message.equals(cause.toString()) == false)) {
-                err.println("Likely root cause: " + cause);
-            }
-
-            // print stacktrace of cause
-            StackTraceElement stack[] = cause.getStackTrace();
-            int linesWritten = 0;
-            for (int i = 0; i < stack.length; i++) {
-                if (linesWritten == STACKTRACE_LIMIT) {
-                    err.println("\t<<<truncated>>>");
-                    break;
+            // skip past contiguous runs of this garbage:
+            if (line.startsWith(GUICE_PACKAGE)) {
+                while (i + 1 < stack.length && stack[i + 1].toString().startsWith(GUICE_PACKAGE)) {
+                    i++;
                 }
-                String line = stack[i].toString();
-
-                // skip past contiguous runs of this garbage:
-                if (line.startsWith(GUICE_PACKAGE)) {
-                    while (i + 1 < stack.length && stack[i + 1].toString().startsWith(GUICE_PACKAGE)) {
-                        i++;
-                    }
-                    err.println("\tat <<<guice>>>");
-                    linesWritten++;
-                    continue;
-                }
-
-                err.println("\tat " + line);
+                err.println("\tat <<<guice>>>");
                 linesWritten++;
+                continue;
             }
+
+            err.println("\tat " + line);
+            linesWritten++;
         }
         // if its a guice exception, the whole thing really will not be in the log, its megabytes.
         // refer to the hack in bootstrap, where we don't log it

--- a/server/src/main/java/org/elasticsearch/common/logging/ConsoleThrowablePatternConverter.java
+++ b/server/src/main/java/org/elasticsearch/common/logging/ConsoleThrowablePatternConverter.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.common.logging;
+
+import org.apache.logging.log4j.core.LogEvent;
+import org.apache.logging.log4j.core.config.Configuration;
+import org.apache.logging.log4j.core.config.plugins.Plugin;
+import org.apache.logging.log4j.core.pattern.ConverterKeys;
+import org.apache.logging.log4j.core.pattern.PatternConverter;
+import org.apache.logging.log4j.core.pattern.ThrowablePatternConverter;
+import org.elasticsearch.bootstrap.StartupException;
+import org.elasticsearch.common.inject.CreationException;
+
+/**
+ * Outputs a very short version of exceptions for the console, pointing to full log for details.
+ */
+@Plugin(name = "consoleException", category = PatternConverter.CATEGORY)
+@ConverterKeys({ "consoleException" })
+public class ConsoleThrowablePatternConverter extends ThrowablePatternConverter {
+    private ConsoleThrowablePatternConverter(String[] options, Configuration config) {
+        super("ConsoleThrowablePatternConverter", "throwable", options, config);
+    }
+
+    /**
+     * Gets an instance of the class.
+     *
+     * @param config  The current Configuration.
+     * @return instance of class.
+     */
+    public static ConsoleThrowablePatternConverter newInstance(final Configuration config, final String[] options) {
+        return new ConsoleThrowablePatternConverter(options, config);
+    }
+
+    @Override
+    public void format(final LogEvent event, final StringBuilder toAppendTo) {
+        Throwable error = event.getThrown();
+        if (error == null) {
+            super.format(event, toAppendTo);
+            return;
+        }
+        if (error instanceof StartupException e) {
+            error = e.getCause();
+        }
+        toAppendTo.append("\n\nElasticsearch failed to startup normally.\n\n");
+        if (error instanceof CreationException) {
+            toAppendTo.append("There were problems initializing Guice. See log for more details.");
+        } else {
+            toAppendTo.append(error.getMessage());
+            toAppendTo.append("\n\nSee logs for more details.\n");
+        }
+    }
+}

--- a/server/src/main/java/org/elasticsearch/common/logging/LogConfigurator.java
+++ b/server/src/main/java/org/elasticsearch/common/logging/LogConfigurator.java
@@ -273,20 +273,6 @@ public class LogConfigurator {
         return appender;
     }
 
-    /**
-     * Temporarily removes the appender for the console, so that log messages go only to the log file.
-     * @param clazz a class to get a logger for
-     * @param callback The code to log while the appender is removed
-     */
-    public static void logWithoutConsole(Class<?> clazz, Consumer<Logger> callback) {
-        Appender appender = removeConsoleAppender();
-        Logger logger = LogManager.getLogger(clazz);
-        callback.accept(logger);
-        if (appender != null) {
-            Loggers.addAppender(LogManager.getRootLogger(), appender);
-        }
-    }
-
     private static void configureStatusLogger() {
         final ConfigurationBuilder<BuiltConfiguration> builder = ConfigurationBuilderFactory.newConfigurationBuilder();
         builder.setStatusLevel(Level.ERROR);

--- a/server/src/main/java/org/elasticsearch/common/logging/LogConfigurator.java
+++ b/server/src/main/java/org/elasticsearch/common/logging/LogConfigurator.java
@@ -57,7 +57,6 @@ import java.util.Objects;
 import java.util.Properties;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.function.Consumer;
 import java.util.stream.StreamSupport;
 
 public class LogConfigurator {


### PR DESCRIPTION
During startup of Elasticsearch we go to great lengths to present errors
in a meaningful way to users. Over time, though, the error handling has
been amended to address various issues, and that has resulted in a
complicated system of try/catches handling various cases. One
particularly kludgy piece is removing the console logger in special
cases to avoid printing exceptions to the console. Additionally, the
console removal wasn't actually effective because later in exception
handling the exception would be both logged anyways, and then also sent
to stderr, meaning that we could see the same exception several times.

This commit reworks how exceptions are logged during bootstrap. To
address the concern of printing full exceptions to the console, a new
log4j exception filter is added to the console appender which will only
print out the exception message and some additional explanatory info. To
address logging multiple times, the try/catch within init is removed so
that excpetions can propagate to the try/catch in main, which now
handles all exceptions. Additionally, phase 1 (before logging) handles
it's own failure cases since there is definitely no logging at that
time. This simplifies the other failure cases latere so that they do not
need to check if logging has been initialized through sysprops.