### PR TITLE
[8.3] [ML] Rename trained model metadata after full cluster upgrade (#87806)

### DIFF
--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/assignment/TrainedModelAssignmentClusterService.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/assignment/TrainedModelAssignmentClusterService.java
@@ -13,6 +13,7 @@ import org.apache.logging.log4j.message.ParameterizedMessage;
 import org.elasticsearch.ElasticsearchStatusException;
 import org.elasticsearch.ResourceAlreadyExistsException;
 import org.elasticsearch.ResourceNotFoundException;
+import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.master.AcknowledgedResponse;
 import org.elasticsearch.cluster.ClusterChangedEvent;
@@ -57,6 +58,8 @@ import static org.elasticsearch.xpack.ml.inference.assignment.TrainedModelAssign
 public class TrainedModelAssignmentClusterService implements ClusterStateListener {
 
     private static final Logger logger = LogManager.getLogger(TrainedModelAssignmentClusterService.class);
+
+    private static final Version RENAME_ALLOCATION_TO_ASSIGNMENT_VERSION = Version.V_8_3_0;
 
     private final ClusterService clusterService;
     private final NodeLoadDetector nodeLoadDetector;
@@ -246,16 +249,21 @@ public class TrainedModelAssignmentClusterService implements ClusterStateListene
 
     private static ClusterState update(ClusterState currentState, TrainedModelAssignmentMetadata.Builder modelAssignments) {
         if (modelAssignments.isChanged()) {
-            return ClusterState.builder(currentState)
-                .metadata(
-                    Metadata.builder(currentState.metadata())
-                        .putCustom(TrainedModelAssignmentMetadata.NAME, modelAssignments.build())
-                        .removeCustom(TrainedModelAssignmentMetadata.DEPRECATED_NAME)
-                )
-                .build();
+            return forceUpdate(currentState, modelAssignments);
         } else {
             return currentState;
         }
+    }
+
+    private static ClusterState forceUpdate(ClusterState currentState, TrainedModelAssignmentMetadata.Builder modelAssignments) {
+        Metadata.Builder metadata = Metadata.builder(currentState.metadata());
+        if (currentState.getNodes().getMinNodeVersion().onOrAfter(RENAME_ALLOCATION_TO_ASSIGNMENT_VERSION)) {
+            metadata.putCustom(TrainedModelAssignmentMetadata.NAME, modelAssignments.build())
+                .removeCustom(TrainedModelAssignmentMetadata.DEPRECATED_NAME);
+        } else {
+            metadata.putCustom(TrainedModelAssignmentMetadata.DEPRECATED_NAME, modelAssignments.build());
+        }
+        return ClusterState.builder(currentState).metadata(metadata).build();
     }
 
     ClusterState createModelAssignment(ClusterState currentState, StartTrainedModelDeploymentAction.TaskParams params) {
@@ -362,14 +370,7 @@ public class TrainedModelAssignmentClusterService implements ClusterStateListene
         if (TrainedModelAssignmentMetadata.fromState(currentState).modelAssignments().isEmpty()) {
             return currentState;
         }
-        return ClusterState.builder(currentState)
-            .metadata(
-                Metadata.builder(currentState.metadata())
-                    .putCustom(TrainedModelAssignmentMetadata.NAME, TrainedModelAssignmentMetadata.Builder.empty().build())
-                    .removeCustom(TrainedModelAssignmentMetadata.DEPRECATED_NAME)
-                    .build()
-            )
-            .build();
+        return forceUpdate(currentState, TrainedModelAssignmentMetadata.Builder.empty());
     }
 
     ClusterState addRemoveAssignmentNodes(ClusterState currentState) {
@@ -438,8 +439,8 @@ public class TrainedModelAssignmentClusterService implements ClusterStateListene
 
     static boolean shouldAllocateModels(final ClusterChangedEvent event) {
         // If there are no assignments created at all, there is nothing to update
-        final TrainedModelAssignmentMetadata newMetadata = event.state().getMetadata().custom(TrainedModelAssignmentMetadata.NAME);
-        if (newMetadata == null) {
+        final TrainedModelAssignmentMetadata newMetadata = TrainedModelAssignmentMetadata.fromState(event.state());
+        if (newMetadata == null || newMetadata.modelAssignments().isEmpty()) {
             return false;
         }
 

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/assignment/TrainedModelAssignmentClusterServiceTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/assignment/TrainedModelAssignmentClusterServiceTests.java
@@ -200,6 +200,7 @@ public class TrainedModelAssignmentClusterServiceTests extends ESTestCase {
         );
 
         ClusterState clusterStateWithAssignment = ClusterState.builder(new ClusterName("testRemoveAssignment"))
+            .nodes(DiscoveryNodes.builder().add(buildNode("test-node", true, ByteSizeValue.ofGb(4).getBytes())).build())
             .metadata(
                 Metadata.builder()
                     .putCustom(
@@ -227,6 +228,7 @@ public class TrainedModelAssignmentClusterServiceTests extends ESTestCase {
         );
 
         ClusterState clusterStateWithAssignments = ClusterState.builder(new ClusterName("testRemoveAllAssignments"))
+            .nodes(DiscoveryNodes.builder().add(buildNode("test-node", true, ByteSizeValue.ofGb(4).getBytes())).build())
             .metadata(
                 Metadata.builder()
                     .putCustom(TrainedModelAssignmentMetadata.NAME, TrainedModelAssignmentMetadataTests.randomInstance())
@@ -304,7 +306,8 @@ public class TrainedModelAssignmentClusterServiceTests extends ESTestCase {
                 Metadata.builder()
                     .putCustom(NodesShutdownMetadata.TYPE, shutdownMetadata("ml-node-shutting-down"))
                     .putCustom(
-                        TrainedModelAssignmentMetadata.NAME,
+                        // We have to use deprecated name here as we have a node versioned before the rename
+                        TrainedModelAssignmentMetadata.DEPRECATED_NAME,
                         TrainedModelAssignmentMetadata.Builder.empty()
                             .addNewAssignment(
                                 "model-1",
@@ -373,7 +376,8 @@ public class TrainedModelAssignmentClusterServiceTests extends ESTestCase {
                 Metadata.builder()
                     .putCustom(NodesShutdownMetadata.TYPE, shutdownMetadata("ml-node-shutting-down"))
                     .putCustom(
-                        TrainedModelAssignmentMetadata.NAME,
+                        // We have to use deprecated name here as we have a node versioned before the rename
+                        TrainedModelAssignmentMetadata.DEPRECATED_NAME,
                         TrainedModelAssignmentMetadata.Builder.empty()
                             .addNewAssignment(
                                 "model-1",
@@ -1035,6 +1039,7 @@ public class TrainedModelAssignmentClusterServiceTests extends ESTestCase {
         );
 
         ClusterState clusterStateWithAllocation = ClusterState.builder(new ClusterName("testSetAllocationToStopping"))
+            .nodes(DiscoveryNodes.builder().add(buildNode("test-node", true, ByteSizeValue.ofGb(4).getBytes())).build())
             .metadata(
                 Metadata.builder()
                     .putCustom(


### PR DESCRIPTION
Backports the following commits to 8.3:
 - [ML] Rename trained model metadata after full cluster upgrade (#87806)