### PR TITLE
Do not wait for the health node task (#87784)

### DIFF
--- a/server/src/main/java/module-info.java
+++ b/server/src/main/java/module-info.java
@@ -212,6 +212,7 @@ module org.elasticsearch.server {
     exports org.elasticsearch.env;
     exports org.elasticsearch.gateway;
     exports org.elasticsearch.health;
+    exports org.elasticsearch.health.node.selection;
     exports org.elasticsearch.http;
     exports org.elasticsearch.index;
     exports org.elasticsearch.index.analysis;


### PR DESCRIPTION
The health node task is a persistent task that is designed to be always running. In https://github.com/elastic/elasticsearch/issues/87784 we see that this is causing problems in the clean up phase of many tests.

When implementing the feature we took the approach that every test should be responsible to define which tasks is waiting for and which one it is not. I believe this is a good approach for unit tests, but in the case of integration tests that do not control the environment, I do see the value of changing the `waitForPendingTasks` to expect that this task does not complete. I believe this will simplify the development overhead and the health node task will not spill all over the place.

Any thoughts?

Resolves #87784 