### PR TITLE
Fix optimization in BalancedShardsAllocator

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/MoveDecision.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/MoveDecision.java
@@ -90,12 +90,11 @@ public final class MoveDecision extends AbstractAllocationDecision {
      * be forced to move to another node.
      */
     public static MoveDecision stay(Decision canRemainDecision) {
-        if (canRemainDecision != null) {
-            assert canRemainDecision.type() != Type.NO;
-            return new MoveDecision(canRemainDecision, null, AllocationDecision.NO_ATTEMPT, null, null, 0);
-        } else {
+        if (canRemainDecision == Decision.YES) {
             return CACHED_STAY_DECISION;
         }
+        assert canRemainDecision.type() != Type.NO;
+        return new MoveDecision(canRemainDecision, null, AllocationDecision.NO_ATTEMPT, null, null, 0);
     }
 
     /**

--- a/server/src/test/java/org/elasticsearch/cluster/routing/allocation/MoveDecisionTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/allocation/MoveDecisionTests.java
@@ -29,11 +29,12 @@ public class MoveDecisionTests extends ESTestCase {
 
     public void testCachedDecisions() {
         // cached stay decision
-        MoveDecision stay1 = MoveDecision.stay(null);
-        MoveDecision stay2 = MoveDecision.stay(null);
+        MoveDecision stay1 = MoveDecision.stay(Decision.YES);
+        MoveDecision stay2 = MoveDecision.stay(Decision.YES);
         assertSame(stay1, stay2); // not in explain mode, so should use cached decision
-        stay1 = MoveDecision.stay(Decision.YES);
-        stay2 = MoveDecision.stay(Decision.YES);
+
+        stay1 = MoveDecision.stay(new Decision.Single(Type.YES, null, null, (Object[]) null));
+        stay2 = MoveDecision.stay(new Decision.Single(Type.YES, null, null, (Object[]) null));
         assertNotSame(stay1, stay2);
 
         // cached cannot move decision


### PR DESCRIPTION
The optimization for a `null` does not apply today as we never pass `null` to this method, it should special case plain `YES` instead.

relates #77466 