### PR TITLE
[Docs] Fix runtime grok script example

### DIFF
--- a/docs/reference/mapping/runtime.asciidoc
+++ b/docs/reference/mapping/runtime.asciidoc
@@ -1358,9 +1358,9 @@ field within a document. A grok pattern is like a regular expression that
 supports aliased expressions that you can reuse.
 
 The script matches on the `%{COMMONAPACHELOG}` log pattern, which understands
-the structure of Apache logs. If the pattern matches, the script emits the
-value of the matching IP address. If the pattern doesn't match
-(`clientip != null`), the script just returns the field value without crashing.
+the structure of Apache logs. If the pattern matches The script matches on the,
+the script emits the value of the matching IP address. If the pattern doesn't
+match, the script just returns the field value without crashing.
 
 [source,console]
 ----

--- a/docs/reference/mapping/runtime.asciidoc
+++ b/docs/reference/mapping/runtime.asciidoc
@@ -1358,7 +1358,7 @@ field within a document. A grok pattern is like a regular expression that
 supports aliased expressions that you can reuse.
 
 The script matches on the `%{COMMONAPACHELOG}` log pattern, which understands
-the structure of Apache logs. If the pattern matches,
+the structure of Apache logs. If the pattern matches (`clientip != null`),
 the script emits the value of the matching IP address. If the pattern doesn't
 match, the script just returns the field value without crashing.
 

--- a/docs/reference/mapping/runtime.asciidoc
+++ b/docs/reference/mapping/runtime.asciidoc
@@ -1358,7 +1358,7 @@ field within a document. A grok pattern is like a regular expression that
 supports aliased expressions that you can reuse.
 
 The script matches on the `%{COMMONAPACHELOG}` log pattern, which understands
-the structure of Apache logs. If the pattern matches The script matches on the,
+the structure of Apache logs. If the pattern matches,
 the script emits the value of the matching IP address. If the pattern doesn't
 match, the script just returns the field value without crashing.
 

--- a/docs/reference/scripting/common-script-uses.asciidoc
+++ b/docs/reference/scripting/common-script-uses.asciidoc
@@ -76,9 +76,9 @@ field as a runtime field in the mapping. The following runtime script defines a
 grok pattern that extracts structured fields out of the `message` field. 
 
 The script matches on the `%{COMMONAPACHELOG}` log pattern, which understands
-the structure of Apache logs. If the pattern matches, the script emits the
-value matching the IP address. If the pattern doesn't match
-(`clientip != null`), the script just returns the field value without crashing.
+the structure of Apache logs. If the pattern matches (`clientip != null`), the
+script emits the value matching the IP address. If the pattern doesn't match,
+the script just returns the field value without crashing.
 
 [source,console]
 ----

--- a/docs/reference/scripting/common-script-uses.asciidoc
+++ b/docs/reference/scripting/common-script-uses.asciidoc
@@ -77,7 +77,7 @@ grok pattern that extracts structured fields out of the `message` field.
 
 The script matches on the `%{COMMONAPACHELOG}` log pattern, which understands
 the structure of Apache logs. If the pattern matches (`clientip != null`), the
-script emits the value of the matching the IP address. If the pattern doesn't match,
+script emits the value of the matching IP address. If the pattern doesn't match,
 the script just returns the field value without crashing.
 
 [source,console]

--- a/docs/reference/scripting/common-script-uses.asciidoc
+++ b/docs/reference/scripting/common-script-uses.asciidoc
@@ -77,7 +77,7 @@ grok pattern that extracts structured fields out of the `message` field.
 
 The script matches on the `%{COMMONAPACHELOG}` log pattern, which understands
 the structure of Apache logs. If the pattern matches (`clientip != null`), the
-script emits the value matching the IP address. If the pattern doesn't match,
+script emits the value of the matching the IP address. If the pattern doesn't match,
 the script just returns the field value without crashing.
 
 [source,console]


### PR DESCRIPTION
This corrects a small mistake in the "Define a runtime field with a grok pattern" example. The example snippet `clientip != null` should go with the text "If the pattern matches" rather than "If the pattern doesn't match".

Closes: #87848 