### PR TITLE
Create ILM not running user action

### DIFF
--- a/docs/changelog/87852.yaml
+++ b/docs/changelog/87852.yaml
@@ -1,5 +1,0 @@
-pr: 87852
-summary: Create ILM not running user action
-area: ILM+SLM
-type: feature
-issues: []

--- a/docs/changelog/87852.yaml
+++ b/docs/changelog/87852.yaml
@@ -1,0 +1,5 @@
+pr: 87852
+summary: Create ILM not running user action
+area: ILM+SLM
+type: feature
+issues: []

--- a/docs/reference/tab-widgets/troubleshooting/data/start-ilm-widget.asciidoc
+++ b/docs/reference/tab-widgets/troubleshooting/data/start-ilm-widget.asciidoc
@@ -1,0 +1,40 @@
+++++
+<div class="tabs" data-tab-group="host">
+  <div role="tablist" aria-label="Start ILM">
+    <button role="tab"
+            aria-selected="true"
+            aria-controls="cloud-tab-start-ilm"
+            id="cloud-start-ilm">
+      Elasticsearch Service
+    </button>
+    <button role="tab"
+            aria-selected="false"
+            aria-controls="self-managed-tab-start-ilm"
+            id="self-managed-start-ilm"
+            tabindex="-1">
+      Self-managed
+    </button>
+  </div>
+  <div tabindex="0"
+       role="tabpanel"
+       id="cloud-tab-start-ilm"
+       aria-labelledby="cloud-start-ilm">
+++++
+
+include::start-ilm.asciidoc[tag=cloud]
+
+++++
+  </div>
+  <div tabindex="0"
+       role="tabpanel"
+       id="self-managed-tab-start-ilm"
+       aria-labelledby="self-managed-start-ilm"
+       hidden="">
+++++
+
+include::start-ilm.asciidoc[tag=self-managed]
+
+++++
+  </div>
+</div>
+++++

--- a/docs/reference/tab-widgets/troubleshooting/data/start-ilm.asciidoc
+++ b/docs/reference/tab-widgets/troubleshooting/data/start-ilm.asciidoc
@@ -1,0 +1,99 @@
+// tag::cloud[]
+In order to start {ilm} we need to go to Kibana and execute the <<ilm-start, start command>>.
+
+**Use {kib}**
+
+//tag::kibana-api-ex[]
+. Log in to the {ess-console}[{ecloud} console].
++
+
+. On the **Elasticsearch Service** panel, click the name of your deployment. 
++
+
+NOTE:
+If the name of your deployment is disabled your {kib} instances might be
+unhealthy, in which case please contact https://support.elastic.co[Elastic Support].
+If your deployment doesn't include {kib}, all you need to do is 
+{cloud}/ec-access-kibana.html[enable it first].
+
+. Open your deployment's side navigation menu (placed under the Elastic logo in the upper left corner)
+and go to **Dev Tools > Console**.
++
+[role="screenshot"]
+image::images/kibana-console.png[{kib} Console,align="center"]
+
+. <<ilm-start, Start>> {ilm}:
++
+[source,console]
+----
+POST _ilm/start
+----
++
+The reponse will look like this:
++
+[source,console-result]
+----
+{
+  "acknowledged": true
+}
+----
+// TESTRESPONSE[skip:the result is for illustrating purposes only]
++
+
+. Verify {ilm} is now running:
++
+[source,console]
+----
+GET _ilm/status
+----
++
+The reponse will look like this:
++
+[source,console-result]
+----
+{
+  "operation_mode": "RUNNING"
+}
+----
+// TESTRESPONSE[skip:the result is for illustrating purposes only]
+
+//end::kibana-api-ex[]
+// end::cloud[]
+
+// tag::self-managed[]
+<<ilm-start, Start ILM>>:
+
+[source,console]
+----
+POST _ilm/start
+----
+
+The reponse will look like this:
+
+[source,console-result]
+----
+{
+  "acknowledged": true
+}
+----
+// TESTRESPONSE[skip:the result is for illustrating purposes only]
+
+
+Verify {ilm} is now running:
+
+[source,console]
+----
+GET _ilm/status
+----
+
+The reponse will look like this:
+
+[source,console-result]
+----
+{
+  "operation_mode": "RUNNING"
+}
+----
+
+// end::self-managed[]
+

--- a/docs/reference/troubleshooting.asciidoc
+++ b/docs/reference/troubleshooting.asciidoc
@@ -52,6 +52,8 @@ include::troubleshooting/data/diagnose-unassigned-shards.asciidoc[]
 
 include::troubleshooting/data/increase-tier-capacity.asciidoc[]
 
+include::troubleshooting/data/start-ilm.asciidoc[]
+
 include::monitoring/troubleshooting.asciidoc[]
 
 include::transform/troubleshooting.asciidoc[leveloffset=+1]

--- a/docs/reference/troubleshooting/data/start-ilm.asciidoc
+++ b/docs/reference/troubleshooting/data/start-ilm.asciidoc
@@ -1,0 +1,11 @@
+[[start-ilm]]
+== Start {ilm}
+
+Automatic index lifecycle and data retention management is currently disabled.
+
+In order to start the automatic {ilm} service, follow these steps:
+
+include::{es-repo-dir}/tab-widgets/troubleshooting/data/start-ilm-widget.asciidoc[]
+
+
+

--- a/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/IlmHealthIndicatorService.java
+++ b/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/IlmHealthIndicatorService.java
@@ -40,7 +40,7 @@ public class IlmHealthIndicatorService implements HealthIndicatorService {
 
     public static final String HELP_URL = "https://ela.st/fix-ilm";
     public static final UserAction ILM_NOT_RUNNING = new UserAction(
-        new UserAction.Definition("ilm-not-running", "ILM is not running", HELP_URL),
+        new UserAction.Definition("ilm-not-running", "Start ILM using [POST /_ilm/start].", HELP_URL),
         null
     );
 
@@ -87,7 +87,7 @@ public class IlmHealthIndicatorService implements HealthIndicatorService {
             );
             return createIndicator(
                 YELLOW,
-                "ILM is not running. Start ILM using [POST /_ilm/start].",
+                "ILM is not running",
                 createDetails(explain, ilmMetadata),
                 impacts,
                 List.of(ILM_NOT_RUNNING)

--- a/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/IlmHealthIndicatorService.java
+++ b/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/IlmHealthIndicatorService.java
@@ -85,8 +85,7 @@ public class IlmHealthIndicatorService implements HealthIndicatorService {
                     List.of(ImpactArea.DEPLOYMENT_MANAGEMENT)
                 )
             );
-            return createIndicator(YELLOW, "ILM is not running", createDetails(explain, ilmMetadata), impacts,
-                List.of(ILM_NOT_RUNNING));
+            return createIndicator(YELLOW, "ILM is not running", createDetails(explain, ilmMetadata), impacts, List.of(ILM_NOT_RUNNING));
         } else {
             return createIndicator(
                 GREEN,

--- a/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/IlmHealthIndicatorService.java
+++ b/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/IlmHealthIndicatorService.java
@@ -85,13 +85,7 @@ public class IlmHealthIndicatorService implements HealthIndicatorService {
                     List.of(ImpactArea.DEPLOYMENT_MANAGEMENT)
                 )
             );
-            return createIndicator(
-                YELLOW,
-                "ILM is not running",
-                createDetails(explain, ilmMetadata),
-                impacts,
-                List.of(ILM_NOT_RUNNING)
-            );
+            return createIndicator(YELLOW, "ILM is not running", createDetails(explain, ilmMetadata), impacts, List.of(ILM_NOT_RUNNING));
         } else {
             return createIndicator(
                 GREEN,

--- a/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/IlmHealthIndicatorService.java
+++ b/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/IlmHealthIndicatorService.java
@@ -85,7 +85,13 @@ public class IlmHealthIndicatorService implements HealthIndicatorService {
                     List.of(ImpactArea.DEPLOYMENT_MANAGEMENT)
                 )
             );
-            return createIndicator(YELLOW, "ILM is not running", createDetails(explain, ilmMetadata), impacts, List.of(ILM_NOT_RUNNING));
+            return createIndicator(
+                YELLOW,
+                "ILM is not running. Start ILM using [POST /_ilm/start].",
+                createDetails(explain, ilmMetadata),
+                impacts,
+                List.of(ILM_NOT_RUNNING)
+            );
         } else {
             return createIndicator(
                 GREEN,

--- a/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/IlmHealthIndicatorService.java
+++ b/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/IlmHealthIndicatorService.java
@@ -14,6 +14,7 @@ import org.elasticsearch.health.HealthIndicatorResult;
 import org.elasticsearch.health.HealthIndicatorService;
 import org.elasticsearch.health.ImpactArea;
 import org.elasticsearch.health.SimpleHealthIndicatorDetails;
+import org.elasticsearch.health.UserAction;
 import org.elasticsearch.xpack.core.ilm.IndexLifecycleMetadata;
 import org.elasticsearch.xpack.core.ilm.OperationMode;
 
@@ -38,6 +39,10 @@ public class IlmHealthIndicatorService implements HealthIndicatorService {
     public static final String NAME = "ilm";
 
     public static final String HELP_URL = "https://ela.st/fix-ilm";
+    public static final UserAction ILM_NOT_RUNNING = new UserAction(
+        new UserAction.Definition("ilm-not-running", "ILM is not running", HELP_URL),
+        null
+    );
 
     private final ClusterService clusterService;
 
@@ -80,7 +85,8 @@ public class IlmHealthIndicatorService implements HealthIndicatorService {
                     List.of(ImpactArea.DEPLOYMENT_MANAGEMENT)
                 )
             );
-            return createIndicator(YELLOW, "ILM is not running", createDetails(explain, ilmMetadata), impacts, Collections.emptyList());
+            return createIndicator(YELLOW, "ILM is not running", createDetails(explain, ilmMetadata), impacts,
+                List.of(ILM_NOT_RUNNING));
         } else {
             return createIndicator(
                 GREEN,

--- a/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/ilm/IlmHealthIndicatorServiceTests.java
+++ b/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/ilm/IlmHealthIndicatorServiceTests.java
@@ -81,7 +81,7 @@ public class IlmHealthIndicatorServiceTests extends ESTestCase {
                             List.of(ImpactArea.DEPLOYMENT_MANAGEMENT)
                         )
                     ),
-                    Collections.emptyList()
+                    List.of(IlmHealthIndicatorService.ILM_NOT_RUNNING)
                 )
             )
         );


### PR DESCRIPTION
This creates a user action for the ilm health indicator that will help
the user to start ILM.

Relates to #https://github.com/elastic/elasticsearch/issues/87721