### PR TITLE
Fix rest AzureSearchableSnapshotsIT

### DIFF
--- a/x-pack/plugin/searchable-snapshots/qa/azure/src/javaRestTest/java/org/elasticsearch/xpack/searchablesnapshots/AzureSearchableSnapshotsIT.java
+++ b/x-pack/plugin/searchable-snapshots/qa/azure/src/javaRestTest/java/org/elasticsearch/xpack/searchablesnapshots/AzureSearchableSnapshotsIT.java
@@ -8,11 +8,23 @@
 package org.elasticsearch.xpack.searchablesnapshots;
 
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.test.rest.ESRestTestCase;
 
 import static org.hamcrest.Matchers.blankOrNullString;
 import static org.hamcrest.Matchers.not;
 
 public class AzureSearchableSnapshotsIT extends AbstractSearchableSnapshotsRestTestCase {
+
+    @Override
+    protected final Settings restClientSettings() {
+        return Settings.builder()
+            .put(super.restClientSettings())
+            // increase the timeout here to 90 seconds
+            // this ensures that we don't retry the test requests when azure is misbehaving
+            // (the azure sdk timeout is 60s) see #87389
+            .put(ESRestTestCase.CLIENT_SOCKET_TIMEOUT, "90s")
+            .build();
+    }
 
     @Override
     protected String writeRepositoryType() {


### PR DESCRIPTION
This commit increases the rest client socket timeout to 90 seconds
so the client do not retry the tests requests when Azure is not
responding in a timely manner, this avoids confusing tests errors.

Closes #87389
Closes #86813
