### PR TITLE
Fixing a bug in testYellowWithTooManyMasterChanges

### DIFF
--- a/server/src/test/java/org/elasticsearch/cluster/coordination/StableMasterHealthIndicatorServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/coordination/StableMasterHealthIndicatorServiceTests.java
@@ -425,6 +425,7 @@ public class StableMasterHealthIndicatorServiceTests extends AbstractCoordinator
                 leader.disconnect();
                 cluster.stabilise();
                 leader.heal(); // putting it back in the cluster after another leader has been elected so that we always keep a quorum
+                cluster.stabilise();
             }
 
             final Cluster.ClusterNode currentLeader = cluster.getAnyLeader();


### PR DESCRIPTION
After calling `heal()` on a node we were not doing anything to actually have it join the new master. So it would never receive a clusterChanged event with that new master. So its master history would be missing an entry. This means that sometimes it would appear that the master history was more stable than it really was, causing the stable_master status to be GREEN rather than yellow.
Closes #87768 