### PR TITLE
Remove aliases list from IndexAbstraction

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/metadata/IndexAbstraction.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/IndexAbstraction.java
@@ -98,13 +98,6 @@ public interface IndexAbstraction {
     }
 
     /**
-     * @return the names of aliases referring to this instance.
-     *         Returns <code>null</code> if aliases can't point to this instance.
-     */
-    @Nullable
-    List<String> getAliases();
-
-    /**
      * An index abstraction type.
      */
     enum Type {
@@ -148,7 +141,6 @@ public interface IndexAbstraction {
         private final Index concreteIndex;
         private final boolean isHidden;
         private final boolean isSystem;
-        private final List<String> aliases;
         private final DataStream dataStream;
 
         public ConcreteIndex(IndexMetadata indexMetadata, DataStream dataStream) {
@@ -156,7 +148,6 @@ public interface IndexAbstraction {
             this.concreteIndex = indexMetadata.getIndex();
             this.isHidden = indexMetadata.isHidden();
             this.isSystem = indexMetadata.isSystem();
-            this.aliases = indexMetadata.getAliases() != null ? List.copyOf(indexMetadata.getAliases().keySet()) : null;
             this.dataStream = dataStream;
         }
 
@@ -200,11 +191,6 @@ public interface IndexAbstraction {
         }
 
         @Override
-        public List<String> getAliases() {
-            return aliases;
-        }
-
-        @Override
         public boolean equals(Object o) {
             if (this == o) return true;
             if (o == null || getClass() != o.getClass()) return false;
@@ -212,13 +198,12 @@ public interface IndexAbstraction {
             return isHidden == that.isHidden
                 && isSystem == that.isSystem
                 && concreteIndex.equals(that.concreteIndex)
-                && Objects.equals(aliases, that.aliases)
                 && Objects.equals(dataStream, that.dataStream);
         }
 
         @Override
         public int hashCode() {
-            return Objects.hash(concreteIndex, isHidden, isSystem, aliases, dataStream);
+            return Objects.hash(concreteIndex, isHidden, isSystem, dataStream);
         }
     }
 
@@ -311,11 +296,6 @@ public interface IndexAbstraction {
         }
 
         @Override
-        public List<String> getAliases() {
-            return null;
-        }
-
-        @Override
         public boolean equals(Object o) {
             if (this == o) return true;
             if (o == null || getClass() != o.getClass()) return false;
@@ -347,11 +327,9 @@ public interface IndexAbstraction {
         );
 
         private final org.elasticsearch.cluster.metadata.DataStream dataStream;
-        private final List<String> referencedByDataStreamAliases;
 
-        public DataStream(org.elasticsearch.cluster.metadata.DataStream dataStream, List<String> aliases) {
+        public DataStream(org.elasticsearch.cluster.metadata.DataStream dataStream) {
             this.dataStream = dataStream;
-            this.referencedByDataStreamAliases = aliases;
         }
 
         @Override
@@ -477,11 +455,6 @@ public interface IndexAbstraction {
             return true;
         }
 
-        @Override
-        public List<String> getAliases() {
-            return referencedByDataStreamAliases;
-        }
-
         public org.elasticsearch.cluster.metadata.DataStream getDataStream() {
             return dataStream;
         }
@@ -491,12 +464,12 @@ public interface IndexAbstraction {
             if (this == o) return true;
             if (o == null || getClass() != o.getClass()) return false;
             DataStream that = (DataStream) o;
-            return dataStream.equals(that.dataStream) && Objects.equals(referencedByDataStreamAliases, that.referencedByDataStreamAliases);
+            return dataStream.equals(that.dataStream);
         }
 
         @Override
         public int hashCode() {
-            return Objects.hash(dataStream, referencedByDataStreamAliases);
+            return Objects.hash(dataStream);
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/Metadata.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/Metadata.java
@@ -1961,12 +1961,8 @@ public class Metadata extends AbstractCollection<IndexMetadata> implements Diffa
                 for (DataStream dataStream : dataStreamMetadata.dataStreams().values()) {
                     assert dataStream.getIndices().isEmpty() == false;
 
-                    List<String> aliases = dataStreamToAliasLookup.getOrDefault(dataStream.getName(), List.of());
-                    final IndexAbstraction.DataStream dsAbstraction = new IndexAbstraction.DataStream(dataStream, aliases);
-                    IndexAbstraction existing = indicesLookup.put(
-                        dataStream.getName(),
-                        new IndexAbstraction.DataStream(dataStream, aliases)
-                    );
+                    final IndexAbstraction.DataStream dsAbstraction = new IndexAbstraction.DataStream(dataStream);
+                    IndexAbstraction existing = indicesLookup.put(dataStream.getName(), dsAbstraction);
                     assert existing == null : "duplicate data stream for " + dataStream.getName();
 
                     for (Index i : dataStream.getIndices()) {

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/MetadataTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/MetadataTests.java
@@ -1240,37 +1240,30 @@ public class MetadataTests extends ESTestCase {
         IndexAbstraction value = metadata.getIndicesLookup().get("d1");
         assertThat(value, notNullValue());
         assertThat(value.getType(), equalTo(IndexAbstraction.Type.DATA_STREAM));
-        assertThat(value.getAliases(), containsInAnyOrder("a1", "a3"));
 
         value = metadata.getIndicesLookup().get("d2");
         assertThat(value, notNullValue());
         assertThat(value.getType(), equalTo(IndexAbstraction.Type.DATA_STREAM));
-        assertThat(value.getAliases(), contains("a1"));
 
         value = metadata.getIndicesLookup().get("d3");
         assertThat(value, notNullValue());
         assertThat(value.getType(), equalTo(IndexAbstraction.Type.DATA_STREAM));
-        assertThat(value.getAliases(), contains("a2"));
 
         value = metadata.getIndicesLookup().get("d4");
         assertThat(value, notNullValue());
         assertThat(value.getType(), equalTo(IndexAbstraction.Type.DATA_STREAM));
-        assertThat(value.getAliases(), empty());
 
         value = metadata.getIndicesLookup().get("a1");
         assertThat(value, notNullValue());
         assertThat(value.getType(), equalTo(IndexAbstraction.Type.ALIAS));
-        assertThat(value.getAliases(), nullValue());
 
         value = metadata.getIndicesLookup().get("a2");
         assertThat(value, notNullValue());
         assertThat(value.getType(), equalTo(IndexAbstraction.Type.ALIAS));
-        assertThat(value.getAliases(), nullValue());
 
         value = metadata.getIndicesLookup().get("a3");
         assertThat(value, notNullValue());
         assertThat(value.getType(), equalTo(IndexAbstraction.Type.ALIAS));
-        assertThat(value.getAliases(), nullValue());
     }
 
     public void testDataStreamAliasValidation() {

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authz/RBACEngineTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authz/RBACEngineTests.java
@@ -1371,7 +1371,7 @@ public class RBACEngineTests extends ESTestCase {
             dataStreamName,
             backingIndices.stream().map(IndexMetadata::getIndex).collect(Collectors.toList())
         );
-        IndexAbstraction.DataStream iads = new IndexAbstraction.DataStream(ds, List.of());
+        IndexAbstraction.DataStream iads = new IndexAbstraction.DataStream(ds);
         lookup.put(ds.getName(), iads);
         for (IndexMetadata im : backingIndices) {
             lookup.put(im.getIndex().getName(), new IndexAbstraction.ConcreteIndex(im, iads));
@@ -1412,7 +1412,7 @@ public class RBACEngineTests extends ESTestCase {
             dataStreamName,
             backingIndices.stream().map(IndexMetadata::getIndex).collect(Collectors.toList())
         );
-        IndexAbstraction.DataStream iads = new IndexAbstraction.DataStream(ds, List.of());
+        IndexAbstraction.DataStream iads = new IndexAbstraction.DataStream(ds);
         lookup.put(ds.getName(), iads);
         for (IndexMetadata im : backingIndices) {
             lookup.put(im.getIndex().getName(), new IndexAbstraction.ConcreteIndex(im, iads));


### PR DESCRIPTION
We are not using this list outside of a couple of tests but setting it up
was a non-trivial contributor to the performance of building the indices lookup.

relates #77466 