### PR TITLE
Speed up synthetic source

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/mapper/KeywordFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/KeywordFieldMapper.java
@@ -1095,7 +1095,7 @@ public final class KeywordFieldMapper extends FieldMapper {
                 }
 
                 @Override
-                public void load(XContentBuilder b) throws IOException {
+                public void write(XContentBuilder b) throws IOException {
                     if (false == hasValue) {
                         return;
                     }

--- a/server/src/main/java/org/elasticsearch/index/mapper/KeywordFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/KeywordFieldMapper.java
@@ -41,7 +41,6 @@ import org.elasticsearch.common.lucene.BytesRefs;
 import org.elasticsearch.common.lucene.Lucene;
 import org.elasticsearch.common.lucene.search.AutomatonQueries;
 import org.elasticsearch.common.unit.Fuzziness;
-import org.elasticsearch.core.CheckedRunnable;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.index.analysis.IndexAnalyzers;
 import org.elasticsearch.index.analysis.NamedAnalyzer;
@@ -1091,16 +1090,15 @@ public final class KeywordFieldMapper extends FieldMapper {
                 }
 
                 @Override
-                public void advanceToDoc(int docId) throws IOException {
-                    hasValue = leaf.advanceExact(docId);
+                public boolean advanceToDoc(int docId) throws IOException {
+                    return hasValue = leaf.advanceExact(docId);
                 }
 
                 @Override
-                public void load(XContentBuilder b, CheckedRunnable<IOException> before) throws IOException {
+                public void load(XContentBuilder b) throws IOException {
                     if (false == hasValue) {
                         return;
                     }
-                    before.run();
                     long first = leaf.nextOrd();
                     long next = leaf.nextOrd();
                     if (next == SortedSetDocValues.NO_MORE_ORDS) {

--- a/server/src/main/java/org/elasticsearch/index/mapper/NumberFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/NumberFieldMapper.java
@@ -33,7 +33,6 @@ import org.elasticsearch.common.lucene.search.Queries;
 import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Setting.Property;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.core.CheckedRunnable;
 import org.elasticsearch.index.fielddata.IndexFieldData;
 import org.elasticsearch.index.fielddata.IndexNumericFieldData.NumericType;
 import org.elasticsearch.index.fielddata.plain.SortedDoublesIndexFieldData;
@@ -1646,16 +1645,15 @@ public class NumberFieldMapper extends FieldMapper {
                 }
 
                 @Override
-                public void advanceToDoc(int docId) throws IOException {
-                    hasValue = leaf.advanceExact(docId);
+                public boolean advanceToDoc(int docId) throws IOException {
+                    return hasValue = leaf.advanceExact(docId);
                 }
 
                 @Override
-                public void load(XContentBuilder b, CheckedRunnable<IOException> before) throws IOException {
+                public void load(XContentBuilder b) throws IOException {
                     if (false == hasValue) {
                         return;
                     }
-                    before.run();
                     if (leaf.docValueCount() == 1) {
                         b.field(simpleName);
                         loadNextValue(b, leaf.nextValue());

--- a/server/src/main/java/org/elasticsearch/index/mapper/NumberFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/NumberFieldMapper.java
@@ -1650,7 +1650,7 @@ public class NumberFieldMapper extends FieldMapper {
                 }
 
                 @Override
-                public void load(XContentBuilder b) throws IOException {
+                public void write(XContentBuilder b) throws IOException {
                     if (false == hasValue) {
                         return;
                     }

--- a/server/src/main/java/org/elasticsearch/index/mapper/NumberFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/NumberFieldMapper.java
@@ -1631,18 +1631,6 @@ public class NumberFieldMapper extends FieldMapper {
             this.simpleName = simpleName;
         }
 
-        private SortedNumericDocValues dv(LeafReader reader) throws IOException {
-            SortedNumericDocValues dv = reader.getSortedNumericDocValues(name);
-            if (dv != null) {
-                return dv;
-            }
-            NumericDocValues single = reader.getNumericDocValues(name);
-            if (single != null) {
-                return DocValues.singleton(single);
-            }
-            return null;
-        }
-
         @Override
         public Leaf leaf(LeafReader reader) throws IOException {
             SortedNumericDocValues leaf = dv(reader);
@@ -1683,5 +1671,23 @@ public class NumberFieldMapper extends FieldMapper {
         }
 
         protected abstract void loadNextValue(XContentBuilder b, long value) throws IOException;
+
+        /**
+         * Returns a {@link SortedNumericDocValues} or null if it doesn't have any doc values.
+         * See {@link DocValues#getSortedNumeric} which is *nearly* the same, but it returns
+         * an "empty" implementation if there aren't any doc values. We need to be able to
+         * tell if there aren't any and return our empty leaf source loader.
+         */
+        private SortedNumericDocValues dv(LeafReader reader) throws IOException {
+            SortedNumericDocValues dv = reader.getSortedNumericDocValues(name);
+            if (dv != null) {
+                return dv;
+            }
+            NumericDocValues single = reader.getNumericDocValues(name);
+            if (single != null) {
+                return DocValues.singleton(single);
+            }
+            return null;
+        }
     }
 }

--- a/server/src/main/java/org/elasticsearch/index/mapper/ObjectMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/ObjectMapper.java
@@ -590,13 +590,13 @@ public class ObjectMapper extends Mapper implements Cloneable {
                     }
 
                     @Override
-                    public void load(XContentBuilder b) throws IOException {
+                    public void write(XContentBuilder b) throws IOException {
                         if (hasValue == false) {
                             return;
                         }
                         startSyntheticField(b);
                         for (SourceLoader.SyntheticFieldLoader.Leaf leaf : leaves) {
-                            leaf.load(b);
+                            leaf.write(b);
                         }
                         b.endObject();
                     }

--- a/server/src/main/java/org/elasticsearch/index/mapper/SourceLoader.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/SourceLoader.java
@@ -99,7 +99,7 @@ public interface SourceLoader {
                     // TODO accept a requested xcontent type
                     try (XContentBuilder b = new XContentBuilder(JsonXContent.jsonXContent, new ByteArrayOutputStream())) {
                         if (leaf.advanceToDoc(docId)) {
-                            leaf.load(b);
+                            leaf.write(b);
                         } else {
                             b.startObject().endObject();
                         }
@@ -126,7 +126,7 @@ public interface SourceLoader {
             }
 
             @Override
-            public void load(XContentBuilder b) throws IOException {}
+            public void write(XContentBuilder b) throws IOException {}
         };
 
         /**
@@ -149,9 +149,9 @@ public interface SourceLoader {
             boolean advanceToDoc(int docId) throws IOException;
 
             /**
-             * Load values for this document.
+             * Write values for this document.
              */
-            void load(XContentBuilder b) throws IOException;
+            void write(XContentBuilder b) throws IOException;
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/index/mapper/SourceLoader.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/SourceLoader.java
@@ -42,6 +42,15 @@ public interface SourceLoader {
          * @param docId the doc to load
          */
         BytesReference source(FieldsVisitor fieldsVisitor, int docId) throws IOException;
+
+        Leaf EMPTY_OBJECT = new Leaf() {
+            @Override public BytesReference source(FieldsVisitor fieldsVisitor, int docId) throws IOException {
+                // TODO accept a requested xcontent type
+                try (XContentBuilder b = new XContentBuilder(JsonXContent.jsonXContent, new ByteArrayOutputStream())) {
+                    return BytesReference.bytes(b.startObject().endObject());
+                }
+            }
+        };
     }
 
     /**
@@ -83,15 +92,7 @@ public interface SourceLoader {
         public Leaf leaf(LeafReader reader) throws IOException {
             SyntheticFieldLoader.Leaf leaf = loader.leaf(reader);
             if (leaf.empty()) {
-                return new Leaf() {
-                    @Override
-                    public BytesReference source(FieldsVisitor fieldsVisitor, int docId) throws IOException {
-                        // TODO accept a requested xcontent type
-                        try (XContentBuilder b = new XContentBuilder(JsonXContent.jsonXContent, new ByteArrayOutputStream())) {
-                            return BytesReference.bytes(b.startObject().endObject());
-                        }
-                    }
-                };
+                return Leaf.EMPTY_OBJECT;
             }
             return new Leaf() {
                 @Override
@@ -114,6 +115,9 @@ public interface SourceLoader {
      * Load a field for {@link Synthetic}.
      */
     interface SyntheticFieldLoader {
+        /**
+         * Load no values.
+         */
         SyntheticFieldLoader NOTHING = r -> new Leaf() {
             @Override
             public boolean empty() {

--- a/server/src/main/java/org/elasticsearch/index/mapper/SourceLoader.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/SourceLoader.java
@@ -44,7 +44,8 @@ public interface SourceLoader {
         BytesReference source(FieldsVisitor fieldsVisitor, int docId) throws IOException;
 
         Leaf EMPTY_OBJECT = new Leaf() {
-            @Override public BytesReference source(FieldsVisitor fieldsVisitor, int docId) throws IOException {
+            @Override
+            public BytesReference source(FieldsVisitor fieldsVisitor, int docId) throws IOException {
                 // TODO accept a requested xcontent type
                 try (XContentBuilder b = new XContentBuilder(JsonXContent.jsonXContent, new ByteArrayOutputStream())) {
                     return BytesReference.bytes(b.startObject().endObject());


### PR DESCRIPTION
This speeds up synthetic source, especially when there are many fields
in the index that are declared in the mapping but don't have values.
This is fairly common with ECS, and the tsdb rally track uses that. And
this improves fetch performance of that track:
```
|  50th percentile service time |    default |   6.24029 |  4.85568 | ms | -22.19% |
|  90th percentile service time |    default |   7.89923 |  6.52069 | ms | -17.45% |
|  99th percentile service time |    default |  12.0306  | 16.435   | ms | +36.61% |
| 100th percentile service time |    default |  14.2873  | 17.1175  | ms | +19.81% |
|  50th percentile service time | default_1k | 158.425   | 25.3236  | ms | -84.02% |
|  90th percentile service time | default_1k | 165.46    | 30.8655  | ms | -81.35% |
|  99th percentile service time | default_1k | 168.954   | 33.3342  | ms | -80.27% |
| 100th percentile service time | default_1k | 174.341   | 34.8344  | ms | -80.02% |
```

There's a slight increase in the 99th and 100th percentile service time
for fetching ten document which think is unlucky jitter. Hopefully. The
average performance of fetching ten docs improves anyway so I think
we're ok. Fetching a thousand documents improves 80% across the board
which is lovely.

This works by doing three things:
1. Teach the "leaf" layer of source loader to detect when the field is
   empty in that segment and remove it from the synthesis process
   entirely. This brings most of the speed up in tsdb.
2. Replace `hasValue` with `advanceToDoc` returning `boolean` and
    cache the result.
3. Replace the `ArrayList` of leaf loaders with an array. Before fixing
   the other two issues the `ArrayList`'s iterator really showed up in
   the profiling. Probably much less worth it now, but it's small.

All of this brings synthetic source much closer to the fetch performance
of standard _source:
```
|  50th percentile service time | default_1k |  11.4016  | 25.3236  | ms | +122.11% |
|  90th percentile service time | default_1k |  13.7212  | 30.8655  | ms | +124.95% |
|  99th percentile service time | default_1k |  15.8785  | 33.3342  | ms | +109.93% |
| 100th percentile service time | default_1k |  16.9715  | 34.8344  | ms | +105.25% |
```

One important thing, these perf numbers come from fetching *hot* blocks
on disk. They mostly compare CPU overhead and not disk overhead.

![image](https://user-images.githubusercontent.com/215970/174795592-dae78e69-4871-4698-911c-fb559eb5a78a.png)

