### PR TITLE
[ML] Add authorization info to ML config listings

### DIFF
--- a/docs/changelog/87884.yaml
+++ b/docs/changelog/87884.yaml
@@ -1,0 +1,5 @@
+pr: 87884
+summary: Add authorization info to ML config listings
+area: Machine Learning
+type: enhancement
+issues: []

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/ml/data_frame_analytics_crud.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/ml/data_frame_analytics_crud.yml
@@ -83,6 +83,9 @@ setup:
   - match: { data_frame_analytics.0.analyzed_fields: {"includes" : ["obj1.*", "obj2.*" ], "excludes": [] } }
   - is_true: data_frame_analytics.0.create_time
   - is_true: data_frame_analytics.0.version
+  # We cannot assert an exact role here because this test is run by
+  # different users in the main REST tests and ML-with-security tests
+  - is_true: data_frame_analytics.0.authorization.roles
 
 ---
 "Test put config with security headers in the body":

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/ml/datafeeds_crud.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/ml/datafeeds_crud.yml
@@ -379,6 +379,8 @@ setup:
   - match: { datafeeds.0.aggregations.histogram_buckets.aggs.bytes_in_avg.avg.field: "system.network.in.bytes" }
   - match: { datafeeds.0.aggregations.histogram_buckets.aggs.non_negative_bytes.bucket_script.buckets_path.bytes: "bytes_in_derivative" }
   - is_false: max_empty_searches
+  # This next one is because the x_pack_rest_user has the role _es_test_root
+  - match: { datafeeds.0.authorization.roles.0: "_es_test_root" }
 
 ---
 "Test delete datafeed":

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/ml/datafeeds_crud.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/ml/datafeeds_crud.yml
@@ -379,8 +379,9 @@ setup:
   - match: { datafeeds.0.aggregations.histogram_buckets.aggs.bytes_in_avg.avg.field: "system.network.in.bytes" }
   - match: { datafeeds.0.aggregations.histogram_buckets.aggs.non_negative_bytes.bucket_script.buckets_path.bytes: "bytes_in_derivative" }
   - is_false: max_empty_searches
-  # This next one is because the x_pack_rest_user has the role _es_test_root
-  - match: { datafeeds.0.authorization.roles.0: "_es_test_root" }
+  # We cannot assert an exact role here because this test is run by users
+  # with different roles in the main REST tests and ML-with-security tests
+  - is_true: datafeeds.0.authorization.roles
 
 ---
 "Test delete datafeed":


### PR DESCRIPTION
ML datafeeds and data frame analytics jobs remember permissions
from their time of creation or most recent update. It can be
quite hard to determine what these are when listing their
configs, which can lead to uncertainty about whether some minor
update changed the permissions.

This change adds information about the permissions to the
config listings.

If the last update was from a user then the permissions used
are the roles they had at the time, and a list of these roles
is added to the new `authorization` field of the datafeed or
data frame analytics job config listing.

If the last update was using an API key then the permissions
of that API key are used for subsequent searches and the new
`authorization` field of the datafeed or data frame analytics
job config listing shows the API key name and ID.

If a service account did the last update then the service
account name is added to the new `authorization` field of the
datafeed or data frame analytics job config listing.