### PR TITLE
Specify proper port range in InternalTestCluster

### DIFF
--- a/test/framework/src/main/java/org/elasticsearch/test/InternalTestCluster.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/InternalTestCluster.java
@@ -381,8 +381,8 @@ public final class InternalTestCluster extends TestCluster {
         Builder builder = Settings.builder();
         builder.put(Environment.PATH_HOME_SETTING.getKey(), baseDir);
         builder.put(Environment.PATH_REPO_SETTING.getKey(), baseDir.resolve("repos"));
-        builder.put(TransportSettings.PORT.getKey(), 0);
-        builder.put("http.port", 0);
+        builder.put(TransportSettings.PORT.getKey(), ESTestCase.getPortRange());
+        builder.put("http.port", ESTestCase.getPortRange());
         if (Strings.hasLength(System.getProperty("tests.es.logger.level"))) {
             builder.put("logger.level", System.getProperty("tests.es.logger.level"));
         }


### PR DESCRIPTION
Today nodes started in an `InternalTestCluster` use `transport.port: 0`
and `http.port: 0` which selects a port from the ephemeral range. This
range is also used by other tests, notably REST tests, and this can lead
to collisions and consequent failures when nodes restart.

This commit restricts the range of ports using the same algorithm as in
`ESTestCase`, avoiding[^1] such collisions.

[^1]: technically this isn't quite enough because the ephemeral range on
some CI workers overlaps the ranges chosen by `ESTestCase`, but that's a
separate issue tracked in #87734

Closes #87448