### PR TITLE
Make CBE message creation more robust

### DIFF
--- a/docs/changelog/87881.yaml
+++ b/docs/changelog/87881.yaml
@@ -1,0 +1,5 @@
+pr: 87881
+summary: Make CBE message creation more robust
+area: Infra/Circuit Breakers
+type: bug
+issues: []

--- a/server/src/test/java/org/elasticsearch/indices/breaker/CircuitBreakerStatsTests.java
+++ b/server/src/test/java/org/elasticsearch/indices/breaker/CircuitBreakerStatsTests.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.indices.breaker;
+
+import org.elasticsearch.common.Strings;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xcontent.ToXContentObject;
+
+import static org.hamcrest.Matchers.equalTo;
+
+public class CircuitBreakerStatsTests extends ESTestCase {
+
+    public void testStringRepresentations() {
+        final CircuitBreakerStats circuitBreakerStats = new CircuitBreakerStats("t", 1L, 2L, 1.0, 3L);
+        assertThat(circuitBreakerStats.toString(), equalTo("[t,limit=1/1b,estimated=2/2b,overhead=1.0,tripped=3]"));
+        assertThat(
+            toJson(circuitBreakerStats),
+            equalTo(
+                "{\"t\":{\"limit_size_in_bytes\":1,\"limit_size\":\"1b\","
+                    + "\"estimated_size_in_bytes\":2,\"estimated_size\":\"2b\","
+                    + "\"overhead\":1.0,\"tripped\":3}}"
+            )
+        );
+    }
+
+    public void testStringRepresentationPermitsNegativeOne() {
+        final CircuitBreakerStats circuitBreakerStats = new CircuitBreakerStats("t", -1L, -1L, 1.0, 3L);
+        assertThat(circuitBreakerStats.toString(), equalTo("[t,limit=-1/-1b,estimated=-1/-1b,overhead=1.0,tripped=3]"));
+        assertThat(
+            toJson(circuitBreakerStats),
+            equalTo(
+                "{\"t\":{\"limit_size_in_bytes\":-1,\"limit_size\":\"-1b\","
+                    + "\"estimated_size_in_bytes\":-1,\"estimated_size\":\"-1b\","
+                    + "\"overhead\":1.0,\"tripped\":3}}"
+            )
+        );
+    }
+
+    public void testStringRepresentationsWithNegativeStats() {
+        try {
+            HierarchyCircuitBreakerService.permitNegativeValues = true;
+            final CircuitBreakerStats circuitBreakerStats = new CircuitBreakerStats("t", -2L, -3L, 1.0, 3L);
+            assertThat(circuitBreakerStats.toString(), equalTo("[t,limit=-2,estimated=-3,overhead=1.0,tripped=3]"));
+            assertThat(
+                toJson(circuitBreakerStats),
+                equalTo(
+                    "{\"t\":{\"limit_size_in_bytes\":-2,\"limit_size\":\"\","
+                        + "\"estimated_size_in_bytes\":-3,\"estimated_size\":\"\","
+                        + "\"overhead\":1.0,\"tripped\":3}}"
+                )
+            );
+        } finally {
+            HierarchyCircuitBreakerService.permitNegativeValues = false;
+        }
+    }
+
+    private static String toJson(CircuitBreakerStats circuitBreakerStats) {
+        return Strings.toString((ToXContentObject) (builder, params) -> {
+            builder.startObject();
+            circuitBreakerStats.toXContent(builder, params);
+            builder.endObject();
+            return builder;
+        }, false, true);
+    }
+}


### PR DESCRIPTION
Child circuit breakers rely on proper matching of acquire/release pairs.
This can be tricky to get right. If we get it wrong and accidentally
double-release a CB then it may end up with a negative `used` value.
This is definitely a bad situation in which to find ourselves, but today
in production it's made a whole lot worse because it causes exceptions
on every attempt to report a `CircuitBreakerStats` or to construct a
parent `CircuitBreakingException`.

This commit makes the message construction and stats serialization a
little more robust so that it's clearer what is going on in production.

Relates #86059
Backport of #87881