### PR TITLE
Removing redundant method in server org.elasticsearch.common.inject.internal.Strings

### DIFF
--- a/docs/changelog/87892.yaml
+++ b/docs/changelog/87892.yaml
@@ -1,0 +1,6 @@
+pr: 87892
+summary: Removing redundant method in server org.elasticsearch.common.inject.internal.Strings
+area: Core/Infra
+type: refactoring
+issues:
+  - 87892

--- a/server/src/main/java/org/elasticsearch/common/inject/internal/Strings.java
+++ b/server/src/main/java/org/elasticsearch/common/inject/internal/Strings.java
@@ -15,6 +15,7 @@
  */
 
 package org.elasticsearch.common.inject.internal;
+import org.elasticsearch.common.Strings;
 
 /**
  * String utilities.
@@ -44,12 +45,4 @@ public class Strings {
      *         converted to uppercase
      * @throws NullPointerException if {@code s} is null
      */
-    public static String capitalize(String s) {
-        if (s.length() == 0) {
-            return s;
-        }
-        char first = s.charAt(0);
-        char capitalized = Character.toUpperCase(first);
-        return (first == capitalized) ? s : capitalized + s.substring(1);
-    }
 }


### PR DESCRIPTION
This is my attempt to remove redundancy in server org.elasticsearch.common.inject.internal.Strings. Given the fact server org.elasticsearch.common.Strings already has a method to capitalize characters, an import should do the same as creating a new method in the previous code. It is a pull request to solve some parts of issue #87610.