### PR TITLE
Throw an error when parent object is not found while parsing field

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/mapper/DocumentParser.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/DocumentParser.java
@@ -692,6 +692,8 @@ public final class DocumentParser {
         ObjectMapper.Dynamic dynamic = parentMapper.dynamic();
         String parentName = parentMapper.name();
         while (dynamic == null) {
+            //splitting on dots is fine as long as it's done on the name of the parent object
+            //and not on the leaf field name (which could contain dots of its own when subobjects are disabled)
             int lastDotNdx = parentName.lastIndexOf('.');
             if (lastDotNdx == -1) {
                 // no dot means that the parent is the root

--- a/server/src/main/java/org/elasticsearch/index/mapper/DocumentParser.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/DocumentParser.java
@@ -703,8 +703,7 @@ public final class DocumentParser {
                 // If parentMapper is null, it means the parent of the current mapper is being dynamically created right now
                 ObjectMapper.Builder dynamicObjectMapperBuilder = context.getDynamicObjectMapperBuilder(parentName);
                 if (dynamicObjectMapperBuilder == null) {
-                    // it can still happen that the path is ambiguous and we are not able to locate the parent
-                    break;
+                    throw new IllegalStateException("Missing intermediate object [" + parentName + "]");
                 }
                 dynamic = dynamicObjectMapperBuilder.dynamic;
             } else {


### PR DESCRIPTION
When parsing fields from incoming documents, we check the dynamic settings of their parent objects, effectively going up the tree structure until we found an object that set a specific dynamic value. The object mapper of the parent could either already be part of the mappings, or part of the dynamic mappers to be mapped as a result of indexing the current document. In this last case, we have a conditional to cover for a situation where the parent is not found, which should never hold.

This commit replaces the leniency around the previous conditional , which simply went out of the loop, with throwing an illegal state exception so that issues in this area are surfaced.