### PR TITLE
Fix failure on GeoShapeQueryTestCase#testRandomGeoCollectionQuery (#87916)

### DIFF
--- a/test/framework/src/main/java/org/elasticsearch/search/geo/GeoShapeQueryTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/search/geo/GeoShapeQueryTestCase.java
@@ -157,8 +157,7 @@ public abstract class GeoShapeQueryTestCase extends GeoPointShapeQueryTestCase {
     public void testRandomGeoCollectionQuery() throws Exception {
         // Create a random geometry collection to index.
         GeometryCollection<Geometry> randomIndexCollection = GeometryTestUtils.randomGeometryCollectionWithoutCircle(false);
-        org.apache.lucene.geo.Polygon randomPoly = GeoTestUtil.nextPolygon();
-        Polygon polygon = new Polygon(new LinearRing(randomPoly.getPolyLons(), randomPoly.getPolyLats()));
+        Polygon polygon = GeometryTestUtils.randomPolygon(false);
         List<Geometry> indexGeometries = new ArrayList<>();
         for (Geometry geometry : randomIndexCollection) {
             indexGeometries.add(geometry);


### PR DESCRIPTION
Use the safer GeometryTestUtils instead of Lucene GeoTestUtil to generate random polygons.

backport #87916