### PR TITLE
Add user action for repository_integrity indicator

### DIFF
--- a/docs/changelog/87920.yaml
+++ b/docs/changelog/87920.yaml
@@ -1,0 +1,5 @@
+pr: 87920
+summary: Add user action for `repository_integrity` indicator
+area: Health
+type: feature
+issues: []

--- a/docs/changelog/87920.yaml
+++ b/docs/changelog/87920.yaml
@@ -1,5 +1,0 @@
-pr: 87920
-summary: Add user action for `repository_integrity` indicator
-area: Health
-type: feature
-issues: []

--- a/server/src/main/java/org/elasticsearch/snapshots/RepositoryIntegrityHealthIndicatorService.java
+++ b/server/src/main/java/org/elasticsearch/snapshots/RepositoryIntegrityHealthIndicatorService.java
@@ -44,8 +44,11 @@ public class RepositoryIntegrityHealthIndicatorService implements HealthIndicato
     public static final String NAME = "repository_integrity";
 
     public static final String HELP_URL = "https://ela.st/fix-repository-integrity";
-    public static final UserAction.Definition CORRUPTED_REPOSITORY = new UserAction.Definition("corrupt-repo-integrity",
-        "Corrupted data detected in snapshot repository", HELP_URL);
+    public static final UserAction.Definition CORRUPTED_REPOSITORY = new UserAction.Definition(
+        "corrupt-repo-integrity",
+        "Corrupted data detected in snapshot repository",
+        HELP_URL
+    );
 
     public static final String NO_REPOS_CONFIGURED = "No snapshot repositories configured.";
     public static final String NO_CORRUPT_REPOS = "No corrupted snapshot repositories.";
@@ -120,15 +123,15 @@ public class RepositoryIntegrityHealthIndicatorService implements HealthIndicato
             createCorruptedRepositorySummary(corrupted),
             explain
                 ? new SimpleHealthIndicatorDetails(
-                Map.of(
-                    "total_repositories",
-                    totalRepositories,
-                    "corrupted_repositories",
-                    corruptedRepositories,
-                    "corrupted",
-                    limitSize(corrupted, 10)
+                    Map.of(
+                        "total_repositories",
+                        totalRepositories,
+                        "corrupted_repositories",
+                        corruptedRepositories,
+                        "corrupted",
+                        limitSize(corrupted, 10)
+                    )
                 )
-            )
                 : HealthIndicatorDetails.EMPTY,
             impacts,
             List.of(new UserAction(CORRUPTED_REPOSITORY, corrupted))

--- a/server/src/main/java/org/elasticsearch/snapshots/RepositoryIntegrityHealthIndicatorService.java
+++ b/server/src/main/java/org/elasticsearch/snapshots/RepositoryIntegrityHealthIndicatorService.java
@@ -46,7 +46,8 @@ public class RepositoryIntegrityHealthIndicatorService implements HealthIndicato
     public static final String HELP_URL = "https://ela.st/fix-repository-integrity";
     public static final UserAction.Definition CORRUPTED_REPOSITORY = new UserAction.Definition(
         "corrupt-repo-integrity",
-        "Corrupted data detected in snapshot repository",
+        "Corrupted data detected in snapshot repository. Multiple clusters are writing to the same repository. Remove the repository " +
+            "from the other cluster(s), or mark it as read-only in the other cluster(s), and then re-add the repository to this cluster.",
         HELP_URL
     );
 

--- a/server/src/main/java/org/elasticsearch/snapshots/RepositoryIntegrityHealthIndicatorService.java
+++ b/server/src/main/java/org/elasticsearch/snapshots/RepositoryIntegrityHealthIndicatorService.java
@@ -46,8 +46,8 @@ public class RepositoryIntegrityHealthIndicatorService implements HealthIndicato
     public static final String HELP_URL = "https://ela.st/fix-repository-integrity";
     public static final UserAction.Definition CORRUPTED_REPOSITORY = new UserAction.Definition(
         "corrupt-repo-integrity",
-        "Corrupted data detected in snapshot repository. Multiple clusters are writing to the same repository. Remove the repository " +
-            "from the other cluster(s), or mark it as read-only in the other cluster(s), and then re-add the repository to this cluster.",
+        "Corrupted data detected in snapshot repository. Multiple clusters are writing to the same repository. Remove the repository "
+            + "from the other cluster(s), or mark it as read-only in the other cluster(s), and then re-add the repository to this cluster.",
         HELP_URL
     );
 

--- a/server/src/main/java/org/elasticsearch/snapshots/RepositoryIntegrityHealthIndicatorService.java
+++ b/server/src/main/java/org/elasticsearch/snapshots/RepositoryIntegrityHealthIndicatorService.java
@@ -17,6 +17,7 @@ import org.elasticsearch.health.HealthIndicatorResult;
 import org.elasticsearch.health.HealthIndicatorService;
 import org.elasticsearch.health.ImpactArea;
 import org.elasticsearch.health.SimpleHealthIndicatorDetails;
+import org.elasticsearch.health.UserAction;
 import org.elasticsearch.repositories.RepositoryData;
 
 import java.util.Collections;
@@ -43,6 +44,8 @@ public class RepositoryIntegrityHealthIndicatorService implements HealthIndicato
     public static final String NAME = "repository_integrity";
 
     public static final String HELP_URL = "https://ela.st/fix-repository-integrity";
+    public static final UserAction.Definition CORRUPTED_REPOSITORY = new UserAction.Definition("corrupt-repo-integrity",
+        "Corrupted data detected in snapshot repository", HELP_URL);
 
     public static final String NO_REPOS_CONFIGURED = "No snapshot repositories configured.";
     public static final String NO_CORRUPT_REPOS = "No corrupted snapshot repositories.";
@@ -117,18 +120,18 @@ public class RepositoryIntegrityHealthIndicatorService implements HealthIndicato
             createCorruptedRepositorySummary(corrupted),
             explain
                 ? new SimpleHealthIndicatorDetails(
-                    Map.of(
-                        "total_repositories",
-                        totalRepositories,
-                        "corrupted_repositories",
-                        corruptedRepositories,
-                        "corrupted",
-                        limitSize(corrupted, 10)
-                    )
+                Map.of(
+                    "total_repositories",
+                    totalRepositories,
+                    "corrupted_repositories",
+                    corruptedRepositories,
+                    "corrupted",
+                    limitSize(corrupted, 10)
                 )
+            )
                 : HealthIndicatorDetails.EMPTY,
             impacts,
-            Collections.emptyList()
+            List.of(new UserAction(CORRUPTED_REPOSITORY, corrupted))
         );
     }
 

--- a/server/src/main/java/org/elasticsearch/snapshots/RepositoryIntegrityHealthIndicatorService.java
+++ b/server/src/main/java/org/elasticsearch/snapshots/RepositoryIntegrityHealthIndicatorService.java
@@ -46,7 +46,7 @@ public class RepositoryIntegrityHealthIndicatorService implements HealthIndicato
     public static final String HELP_URL = "https://ela.st/fix-repository-integrity";
     public static final UserAction.Definition CORRUPTED_REPOSITORY = new UserAction.Definition(
         "corrupt-repo-integrity",
-        "Corrupted data detected in snapshot repository. Multiple clusters are writing to the same repository. Remove the repository "
+        "Multiple clusters are writing to the same repository. Remove the repository "
             + "from the other cluster(s), or mark it as read-only in the other cluster(s), and then re-add the repository to this cluster.",
         HELP_URL
     );

--- a/server/src/test/java/org/elasticsearch/snapshots/RepositoryIntegrityHealthIndicatorServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/snapshots/RepositoryIntegrityHealthIndicatorServiceTests.java
@@ -20,6 +20,7 @@ import org.elasticsearch.health.HealthIndicatorImpact;
 import org.elasticsearch.health.HealthIndicatorResult;
 import org.elasticsearch.health.ImpactArea;
 import org.elasticsearch.health.SimpleHealthIndicatorDetails;
+import org.elasticsearch.health.UserAction;
 import org.elasticsearch.test.ESTestCase;
 
 import java.util.Collections;
@@ -32,6 +33,7 @@ import static org.elasticsearch.health.HealthStatus.RED;
 import static org.elasticsearch.health.ServerHealthComponents.SNAPSHOT;
 import static org.elasticsearch.repositories.RepositoryData.CORRUPTED_REPO_GEN;
 import static org.elasticsearch.repositories.RepositoryData.EMPTY_REPO_GEN;
+import static org.elasticsearch.snapshots.RepositoryIntegrityHealthIndicatorService.CORRUPTED_REPOSITORY;
 import static org.elasticsearch.snapshots.RepositoryIntegrityHealthIndicatorService.NAME;
 import static org.hamcrest.Matchers.equalTo;
 import static org.mockito.Mockito.mock;
@@ -69,6 +71,7 @@ public class RepositoryIntegrityHealthIndicatorServiceTests extends ESTestCase {
         var clusterState = createClusterStateWith(new RepositoriesMetadata(repos));
         var service = createRepositoryCorruptionHealthIndicatorService(clusterState);
 
+        List<String> corruptedRepos = List.of("corrupted-repo");
         assertThat(
             service.calculate(true),
             equalTo(
@@ -79,7 +82,7 @@ public class RepositoryIntegrityHealthIndicatorServiceTests extends ESTestCase {
                     "Detected [1] corrupted snapshot repositories: [corrupted-repo].",
                     RepositoryIntegrityHealthIndicatorService.HELP_URL,
                     new SimpleHealthIndicatorDetails(
-                        Map.of("total_repositories", repos.size(), "corrupted_repositories", 1, "corrupted", List.of("corrupted-repo"))
+                        Map.of("total_repositories", repos.size(), "corrupted_repositories", 1, "corrupted", corruptedRepos)
                     ),
                     Collections.singletonList(
                         new HealthIndicatorImpact(
@@ -88,7 +91,7 @@ public class RepositoryIntegrityHealthIndicatorServiceTests extends ESTestCase {
                             List.of(ImpactArea.BACKUP)
                         )
                     ),
-                    Collections.emptyList()
+                   List.of(new UserAction(CORRUPTED_REPOSITORY, corruptedRepos))
                 )
             )
         );

--- a/server/src/test/java/org/elasticsearch/snapshots/RepositoryIntegrityHealthIndicatorServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/snapshots/RepositoryIntegrityHealthIndicatorServiceTests.java
@@ -91,7 +91,7 @@ public class RepositoryIntegrityHealthIndicatorServiceTests extends ESTestCase {
                             List.of(ImpactArea.BACKUP)
                         )
                     ),
-                   List.of(new UserAction(CORRUPTED_REPOSITORY, corruptedRepos))
+                    List.of(new UserAction(CORRUPTED_REPOSITORY, corruptedRepos))
                 )
             )
         );


### PR DESCRIPTION
This adds a user action to the repository_integrity health indicator. 
The action maintains the same `help_url` as the indicator level `help_url` for now,
but a specialised troubleshooting guide will come as a separate PR.