### PR TITLE
[ML] Use normalized memory in bin packing node prioritization

### DIFF
--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/assignment/planning/AssignmentPlan.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/assignment/planning/AssignmentPlan.java
@@ -125,6 +125,10 @@ public class AssignmentPlan implements Comparable<AssignmentPlan> {
         return remainingModelAllocations.getOrDefault(m, 0) == 0;
     }
 
+    public boolean satisfiesAllModels() {
+        return models().stream().allMatch(this::satisfiesAllocations);
+    }
+
     public int getRemainingNodeCores(String nodeId) {
         return remainingNodeCores.getOrDefault(nodeId, 0);
     }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/assignment/planning/LinearProgrammingPlanSolver.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/assignment/planning/LinearProgrammingPlanSolver.java
@@ -180,7 +180,7 @@ class LinearProgrammingPlanSolver {
     private double descendingSizeAnyFitsNodeOrder(Node n, Model m, AssignmentPlan.Builder assignmentPlan) {
         return (m.currentAllocationsByNodeId().containsKey(n.id()) ? 0 : 1) + (assignmentPlan.getRemainingCores(n) >= assignmentPlan
             .getRemainingThreads(m) ? 0 : 1) + (0.01 * distance(assignmentPlan.getRemainingCores(n), assignmentPlan.getRemainingThreads(m)))
-            - (0.01 * assignmentPlan.getRemainingMemory(n));
+            - (0.01 * normalizedMemoryPerNode.get(n));
     }
 
     @SuppressForbidden(reason = "Math#abs(int) is safe here as we protect against MIN_VALUE")

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/assignment/planning/AssignmentPlanTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/assignment/planning/AssignmentPlanTests.java
@@ -277,4 +277,34 @@ public class AssignmentPlanTests extends ESTestCase {
         assertThat(planUsingLessMemory.compareTo(planUsingMoreMemory), greaterThan(0));
         assertThat(planUsingMoreMemory.compareTo(planUsingLessMemory), lessThan(0));
     }
+
+    public void testSatisfiesAllModels_GivenAllModelsAreSatisfied() {
+        Node node1 = new Node("n_1", 100, 4);
+        Node node2 = new Node("n_2", 100, 4);
+        Model model1 = new Model("m_1", 50, 1, 2, Map.of());
+        Model model2 = new Model("m_2", 30, 2, 1, Map.of());
+        Model model3 = new Model("m_3", 20, 4, 1, Map.of());
+        AssignmentPlan plan = AssignmentPlan.builder(List.of(node1, node2), List.of(model1, model2, model3))
+            .assignModelToNode(model1, node1, 1)
+            .assignModelToNode(model2, node2, 2)
+            .assignModelToNode(model3, node1, 2)
+            .assignModelToNode(model3, node2, 2)
+            .build();
+        assertThat(plan.satisfiesAllModels(), is(true));
+    }
+
+    public void testSatisfiesAllModels_GivenOneModelHasOneAllocationLess() {
+        Node node1 = new Node("n_1", 100, 4);
+        Node node2 = new Node("n_2", 100, 4);
+        Model model1 = new Model("m_1", 50, 1, 2, Map.of());
+        Model model2 = new Model("m_2", 30, 2, 1, Map.of());
+        Model model3 = new Model("m_3", 20, 4, 1, Map.of());
+        AssignmentPlan plan = AssignmentPlan.builder(List.of(node1, node2), List.of(model1, model2, model3))
+            .assignModelToNode(model1, node1, 1)
+            .assignModelToNode(model2, node2, 2)
+            .assignModelToNode(model3, node1, 1)
+            .assignModelToNode(model3, node2, 2)
+            .build();
+        assertThat(plan.satisfiesAllModels(), is(false));
+    }
 }


### PR DESCRIPTION
This commit fixes a bug in the `LinearProgrammingPlanSolver`
used for distributing model allocations. When we are doing the
initial bin-packing, we should be using normalized memory
as a factor. Instead, we were using actual memory which would
dominate the heuristic and result in always prioritize the
largest nodes in terms of memory and completely disregard existing
allocations.

The linear solver would still provide a good solution most of
the times but in some edge cases we'd end up with a bad solution.
This commit adds a test with an edge case like this.

In addition, we improve the `AssignmentPlanner` by trying out
both approaches (1. preserve one allocation per assignment,
2. preserve all allocations) when the first try does not give
a result that satisfies all models.

