### PR TITLE
[Stack Monitoring] logstash timestamp mapping

### DIFF
--- a/x-pack/plugin/core/src/main/resources/monitoring-logstash-mb.json
+++ b/x-pack/plugin/core/src/main/resources/monitoring-logstash-mb.json
@@ -228,6 +228,9 @@
                           "type": "long"
                         }
                       }
+                    },
+                    "timestamp": {
+                      "type": "date"
                     }
                   }
                 },

--- a/x-pack/plugin/monitoring/src/main/java/org/elasticsearch/xpack/monitoring/MonitoringTemplateRegistry.java
+++ b/x-pack/plugin/monitoring/src/main/java/org/elasticsearch/xpack/monitoring/MonitoringTemplateRegistry.java
@@ -78,7 +78,7 @@ public class MonitoringTemplateRegistry extends IndexTemplateRegistry {
      * writes monitoring data in ECS format as of 8.0. These templates define the ECS schema as well as alias fields for the old monitoring
      * mappings that point to the corresponding ECS fields.
      */
-    public static final int STACK_MONITORING_REGISTRY_VERSION = Version.V_8_0_0.id + 2;
+    public static final int STACK_MONITORING_REGISTRY_VERSION = Version.V_8_0_0.id + 3;
     private static final String STACK_MONITORING_REGISTRY_VERSION_VARIABLE = "xpack.stack.monitoring.template.release.version";
     private static final String STACK_TEMPLATE_VERSION = "8";
     private static final String STACK_TEMPLATE_VERSION_VARIABLE = "xpack.stack.monitoring.template.version";


### PR DESCRIPTION
### Summary

Closes https://github.com/elastic/kibana/issues/134904

Adds a missing mapping to the monitoring logstash template

### Testing
- run ES [from source](https://github.com/elastic/kibana/blob/main/x-pack/plugins/monitoring/dev_docs/how_to/running_components_from_source.md#single-cluster-testing)
- start local kibana
- start local logstash with config reload and a dummy config
`./bin/logstash -f logstash.dev.conf --config.reload.automatic`

logstash.dev.conf
```
input {
  java_generator {
    eps => 5
  }
}

output {
  file {
    path => "/dev/null"
  }
}
```
- go to the pipeline viewer, pipeline versions dropdown should display accurate time boundaries[1]
- update logstash configuration (change eps value)
- a new version should appear in the dropdown

[1]
<img width="757" alt="Screenshot 2022-06-22 at 19 20 08" src="https://user-images.githubusercontent.com/5239883/175098936-24b0d15e-9e28-4624-9e8d-8332a604291e.png">

