### PR TITLE
Speed up synthetic keyword, ip, and text fields

### DIFF
--- a/modules/mapper-extras/src/main/java/org/elasticsearch/index/mapper/extras/ScaledFloatFieldMapper.java
+++ b/modules/mapper-extras/src/main/java/org/elasticsearch/index/mapper/extras/ScaledFloatFieldMapper.java
@@ -678,7 +678,7 @@ public class ScaledFloatFieldMapper extends FieldMapper {
         }
         return new NumberFieldMapper.NumericSyntheticFieldLoader(name(), simpleName()) {
             @Override
-            protected void loadNextValue(XContentBuilder b, long value) throws IOException {
+            protected void writeValue(XContentBuilder b, long value) throws IOException {
                 b.value(decodeForSyntheticSource(value, scalingFactor));
             }
         };

--- a/modules/mapper-extras/src/test/java/org/elasticsearch/index/mapper/extras/ScaledFloatFieldMapperTests.java
+++ b/modules/mapper-extras/src/test/java/org/elasticsearch/index/mapper/extras/ScaledFloatFieldMapperTests.java
@@ -361,12 +361,12 @@ public class ScaledFloatFieldMapperTests extends MapperTestCase {
             private final Double nullValue = usually() ? null : round(randomValue());
 
             @Override
-            public SyntheticSourceExample example() {
+            public SyntheticSourceExample example(int maxValues) {
                 if (randomBoolean()) {
                     Tuple<Double, Double> v = generateValue();
                     return new SyntheticSourceExample(v.v1(), v.v2(), this::mapping);
                 }
-                List<Tuple<Double, Double>> values = randomList(1, 5, this::generateValue);
+                List<Tuple<Double, Double>> values = randomList(1, maxValues, this::generateValue);
                 List<Double> in = values.stream().map(Tuple::v1).toList();
                 List<Double> outList = values.stream().map(Tuple::v2).sorted().toList();
                 Object out = outList.size() == 1 ? outList.get(0) : outList;

--- a/server/src/main/java/org/elasticsearch/index/get/ShardGetService.java
+++ b/server/src/main/java/org/elasticsearch/index/get/ShardGetService.java
@@ -257,7 +257,7 @@ public final class ShardGetService extends AbstractIndexShardComponent {
             SourceLoader loader = forceSyntheticSource
                 ? new SourceLoader.Synthetic(mappingLookup.getMapping())
                 : mappingLookup.newSourceLoader();
-            source = loader.leaf(docIdAndVersion.reader).source(fieldVisitor, docIdAndVersion.docId);
+            source = loader.leaf(docIdAndVersion.reader, new int[] { docIdAndVersion.docId }).source(fieldVisitor, docIdAndVersion.docId);
 
             // put stored fields into result objects
             if (fieldVisitor.fields().isEmpty() == false) {

--- a/server/src/main/java/org/elasticsearch/index/mapper/BooleanFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/BooleanFieldMapper.java
@@ -439,7 +439,7 @@ public class BooleanFieldMapper extends FieldMapper {
         }
         return new NumberFieldMapper.NumericSyntheticFieldLoader(name(), simpleName()) {
             @Override
-            protected void loadNextValue(XContentBuilder b, long value) throws IOException {
+            protected void writeValue(XContentBuilder b, long value) throws IOException {
                 b.value(value == 1);
             }
         };

--- a/server/src/main/java/org/elasticsearch/index/mapper/DateFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/DateFieldMapper.java
@@ -917,7 +917,7 @@ public final class DateFieldMapper extends FieldMapper {
         }
         return new NumberFieldMapper.NumericSyntheticFieldLoader(name(), simpleName()) {
             @Override
-            protected void loadNextValue(XContentBuilder b, long value) throws IOException {
+            protected void writeValue(XContentBuilder b, long value) throws IOException {
                 b.value(fieldType().format(value, fieldType().dateTimeFormatter()));
             }
         };

--- a/server/src/main/java/org/elasticsearch/index/mapper/GeoPointFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/GeoPointFieldMapper.java
@@ -477,7 +477,7 @@ public class GeoPointFieldMapper extends AbstractPointGeometryFieldMapper<GeoPoi
             final GeoPoint point = new GeoPoint();
 
             @Override
-            protected void loadNextValue(XContentBuilder b, long value) throws IOException {
+            protected void writeValue(XContentBuilder b, long value) throws IOException {
                 point.reset(GeoEncodingUtils.decodeLatitude((int) (value >>> 32)), GeoEncodingUtils.decodeLongitude((int) value));
                 point.toXContent(b, ToXContent.EMPTY_PARAMS);
             }

--- a/server/src/main/java/org/elasticsearch/index/mapper/IpFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/IpFieldMapper.java
@@ -35,7 +35,6 @@ import org.elasticsearch.search.DocValueFormat;
 import org.elasticsearch.search.aggregations.support.CoreValuesSourceType;
 import org.elasticsearch.search.lookup.FieldValues;
 import org.elasticsearch.search.lookup.SearchLookup;
-import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xcontent.XContentParser;
 
 import java.io.IOException;
@@ -554,11 +553,11 @@ public class IpFieldMapper extends FieldMapper {
                 "field [" + name() + "] of type [" + typeName() + "] doesn't support synthetic source because it declares copy_to"
             );
         }
-        return new KeywordFieldMapper.BytesSyntheticFieldLoader(name(), simpleName()) {
+        return new KeywordFieldMapper.BytesSyntheticFieldLoader<String>(name(), simpleName()) {
             @Override
-            protected void loadNextValue(XContentBuilder b, BytesRef value) throws IOException {
+            protected String convert(BytesRef value) {
                 byte[] bytes = Arrays.copyOfRange(value.bytes, value.offset, value.offset + value.length);
-                b.value(NetworkAddress.format(InetAddressPoint.decode(bytes)));
+                return NetworkAddress.format(InetAddressPoint.decode(bytes));
             }
         };
     }

--- a/server/src/main/java/org/elasticsearch/index/mapper/IpFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/IpFieldMapper.java
@@ -555,9 +555,15 @@ public class IpFieldMapper extends FieldMapper {
         }
         return new KeywordFieldMapper.BytesSyntheticFieldLoader(name(), simpleName()) {
             @Override
-            protected String convert(BytesRef value) {
+            protected BytesRef convert(BytesRef value) {
                 byte[] bytes = Arrays.copyOfRange(value.bytes, value.offset, value.offset + value.length);
-                return NetworkAddress.format(InetAddressPoint.decode(bytes));
+                return new BytesRef(NetworkAddress.format(InetAddressPoint.decode(bytes)));
+            }
+
+            @Override
+            protected BytesRef preserve(BytesRef value) {
+                // No need to copy because convert has made a deep copy
+                return value;
             }
         };
     }

--- a/server/src/main/java/org/elasticsearch/index/mapper/IpFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/IpFieldMapper.java
@@ -553,7 +553,7 @@ public class IpFieldMapper extends FieldMapper {
                 "field [" + name() + "] of type [" + typeName() + "] doesn't support synthetic source because it declares copy_to"
             );
         }
-        return new KeywordFieldMapper.BytesSyntheticFieldLoader<String>(name(), simpleName()) {
+        return new KeywordFieldMapper.BytesSyntheticFieldLoader(name(), simpleName()) {
             @Override
             protected String convert(BytesRef value) {
                 byte[] bytes = Arrays.copyOfRange(value.bytes, value.offset, value.offset + value.length);

--- a/server/src/main/java/org/elasticsearch/index/mapper/KeywordFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/KeywordFieldMapper.java
@@ -1088,16 +1088,17 @@ public final class KeywordFieldMapper extends FieldMapper {
             if (dv.getValueCount() == 0) {
                 return SourceLoader.SyntheticFieldLoader.NOTHING_LEAF;
             }
-            if (docIdsInLeaf.length > 1) {
+            if (docIdsInLeaf.length == 1) {
                 /*
                  * The singleton optimization is mostly about looking up ordinals
                  * in sorted order and doesn't buy anything if there is only a single
                  * document.
                  */
-                SortedDocValues singleton = DocValues.unwrapSingleton(dv);
-                if (singleton != null) {
-                    return singletonLeaf(singleton, docIdsInLeaf);
-                }
+                return new ImmediateLeaf(dv);
+            }
+            SortedDocValues singleton = DocValues.unwrapSingleton(dv);
+            if (singleton != null) {
+                return singletonLeaf(singleton, docIdsInLeaf);
             }
             return new ImmediateLeaf(dv);
         }

--- a/server/src/main/java/org/elasticsearch/index/mapper/KeywordFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/KeywordFieldMapper.java
@@ -1156,7 +1156,7 @@ public final class KeywordFieldMapper extends FieldMapper {
                 @Override
                 public void write(XContentBuilder b) throws IOException {
                     if (ord < 0) {
-                        return; // NOCOMMIT make sure tests hit this
+                        return;
                     }
                     int idx = Arrays.binarySearch(uniqueOrds, ord);
                     if (idx < 0) {

--- a/server/src/main/java/org/elasticsearch/index/mapper/KeywordFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/KeywordFieldMapper.java
@@ -1061,7 +1061,7 @@ public final class KeywordFieldMapper extends FieldMapper {
                 "field [" + name() + "] of type [" + typeName() + "] doesn't support synthetic source because it declares a normalizer"
             );
         }
-        return new BytesSyntheticFieldLoader<String>(name(), simpleName) {
+        return new BytesSyntheticFieldLoader(name(), simpleName) {
             @Override
             protected String convert(BytesRef value) {
                 return value.utf8ToString();
@@ -1069,7 +1069,7 @@ public final class KeywordFieldMapper extends FieldMapper {
         };
     }
 
-    public abstract static class BytesSyntheticFieldLoader<T> implements SourceLoader.SyntheticFieldLoader {
+    public abstract static class BytesSyntheticFieldLoader implements SourceLoader.SyntheticFieldLoader {
         private final String name;
         private final String simpleName;
 
@@ -1146,7 +1146,7 @@ public final class KeywordFieldMapper extends FieldMapper {
             }
             int[] sortedOrds = ords.clone();
             Arrays.sort(sortedOrds);
-            LongObjectPagedHashMap<T> lookup = new LongObjectPagedHashMap<>(found, BigArrays.NON_RECYCLING_INSTANCE);
+            LongObjectPagedHashMap<String> lookup = new LongObjectPagedHashMap<>(found, BigArrays.NON_RECYCLING_INSTANCE);
             int prev = -1;
             for (int ord : sortedOrds) {
                 if (ord != prev) {
@@ -1182,6 +1182,6 @@ public final class KeywordFieldMapper extends FieldMapper {
             };
         }
 
-        protected abstract T convert(BytesRef value);
+        protected abstract String convert(BytesRef value);
     }
 }

--- a/server/src/main/java/org/elasticsearch/index/mapper/KeywordFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/KeywordFieldMapper.java
@@ -1095,7 +1095,7 @@ public final class KeywordFieldMapper extends FieldMapper {
                 }
 
                 @Override
-                public void load(XContentBuilder b) throws IOException {
+                public void write(XContentBuilder b) throws IOException {
                     if (false == hasValue) {
                         return;
                     }

--- a/server/src/main/java/org/elasticsearch/index/mapper/KeywordFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/KeywordFieldMapper.java
@@ -42,8 +42,6 @@ import org.elasticsearch.common.lucene.BytesRefs;
 import org.elasticsearch.common.lucene.Lucene;
 import org.elasticsearch.common.lucene.search.AutomatonQueries;
 import org.elasticsearch.common.unit.Fuzziness;
-import org.elasticsearch.common.util.BigArrays;
-import org.elasticsearch.common.util.LongObjectPagedHashMap;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.index.analysis.IndexAnalyzers;
 import org.elasticsearch.index.analysis.NamedAnalyzer;
@@ -74,6 +72,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -1146,7 +1145,7 @@ public final class KeywordFieldMapper extends FieldMapper {
             }
             int[] sortedOrds = ords.clone();
             Arrays.sort(sortedOrds);
-            LongObjectPagedHashMap<String> lookup = new LongObjectPagedHashMap<>(found, BigArrays.NON_RECYCLING_INSTANCE);
+            Map<Integer, String> lookup = new HashMap<>();
             int prev = -1;
             for (int ord : sortedOrds) {
                 if (ord != prev) {

--- a/server/src/main/java/org/elasticsearch/index/mapper/KeywordFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/KeywordFieldMapper.java
@@ -41,7 +41,6 @@ import org.elasticsearch.common.lucene.BytesRefs;
 import org.elasticsearch.common.lucene.Lucene;
 import org.elasticsearch.common.lucene.search.AutomatonQueries;
 import org.elasticsearch.common.unit.Fuzziness;
-import org.elasticsearch.core.CheckedRunnable;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.index.analysis.IndexAnalyzers;
 import org.elasticsearch.index.analysis.NamedAnalyzer;
@@ -1091,16 +1090,15 @@ public final class KeywordFieldMapper extends FieldMapper {
                 }
 
                 @Override
-                public void advanceToDoc(int docId) throws IOException {
-                    hasValue = leaf.advanceExact(docId);
+                public boolean advanceToDoc(int docId) throws IOException {
+                    return hasValue = leaf.advanceExact(docId);
                 }
 
                 @Override
-                public void load(XContentBuilder b, CheckedRunnable<IOException> before) throws IOException {
+                public void load(XContentBuilder b) throws IOException {
                     if (false == hasValue) {
                         return;
                     }
-                    before.run();
                     long first = leaf.nextOrd();
                     long next = leaf.nextOrd();
                     if (next == SortedSetDocValues.NO_MORE_ORDS) {

--- a/server/src/main/java/org/elasticsearch/index/mapper/NumberFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/NumberFieldMapper.java
@@ -1630,7 +1630,7 @@ public class NumberFieldMapper extends FieldMapper {
         }
 
         @Override
-        public Leaf leaf(LeafReader reader) throws IOException {
+        public Leaf leaf(LeafReader reader, int[] docIdsInLeaf) throws IOException {
             SortedNumericDocValues leaf = DocValues.getSortedNumeric(reader, name);
             return new SourceLoader.SyntheticFieldLoader.Leaf() {
                 private boolean hasValue;

--- a/server/src/main/java/org/elasticsearch/index/mapper/NumberFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/NumberFieldMapper.java
@@ -33,7 +33,6 @@ import org.elasticsearch.common.lucene.search.Queries;
 import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Setting.Property;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.core.CheckedRunnable;
 import org.elasticsearch.index.fielddata.IndexFieldData;
 import org.elasticsearch.index.fielddata.IndexNumericFieldData.NumericType;
 import org.elasticsearch.index.fielddata.plain.SortedDoublesIndexFieldData;
@@ -1646,16 +1645,15 @@ public class NumberFieldMapper extends FieldMapper {
                 }
 
                 @Override
-                public void advanceToDoc(int docId) throws IOException {
-                    hasValue = leaf.advanceExact(docId);
+                public boolean advanceToDoc(int docId) throws IOException {
+                    return hasValue = leaf.advanceExact(docId);
                 }
 
                 @Override
-                public void load(XContentBuilder b, CheckedRunnable<IOException> before) throws IOException {
+                public void load(XContentBuilder b) throws IOException {
                     if (false == hasValue) {
                         return;
                     }
-                    before.run();
                     if (leaf.docValueCount() == 1) {
                         b.field(simpleName);
                         loadNextValue(b, leaf.nextValue());

--- a/server/src/main/java/org/elasticsearch/index/mapper/NumberFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/NumberFieldMapper.java
@@ -379,7 +379,7 @@ public class NumberFieldMapper extends FieldMapper {
             SourceLoader.SyntheticFieldLoader syntheticFieldLoader(String fieldName, String fieldSimpleName) {
                 return new NumericSyntheticFieldLoader(fieldName, fieldSimpleName) {
                     @Override
-                    protected void loadNextValue(XContentBuilder b, long value) throws IOException {
+                    protected void writeValue(XContentBuilder b, long value) throws IOException {
                         b.value(HalfFloatPoint.sortableShortToHalfFloat((short) value));
                     }
                 };
@@ -514,7 +514,7 @@ public class NumberFieldMapper extends FieldMapper {
             SourceLoader.SyntheticFieldLoader syntheticFieldLoader(String fieldName, String fieldSimpleName) {
                 return new NumericSyntheticFieldLoader(fieldName, fieldSimpleName) {
                     @Override
-                    protected void loadNextValue(XContentBuilder b, long value) throws IOException {
+                    protected void writeValue(XContentBuilder b, long value) throws IOException {
                         b.value(NumericUtils.sortableIntToFloat((int) value));
                     }
                 };
@@ -627,7 +627,7 @@ public class NumberFieldMapper extends FieldMapper {
             SourceLoader.SyntheticFieldLoader syntheticFieldLoader(String fieldName, String fieldSimpleName) {
                 return new NumericSyntheticFieldLoader(fieldName, fieldSimpleName) {
                     @Override
-                    protected void loadNextValue(XContentBuilder b, long value) throws IOException {
+                    protected void writeValue(XContentBuilder b, long value) throws IOException {
                         b.value(NumericUtils.sortableLongToDouble(value));
                     }
                 };
@@ -1270,7 +1270,7 @@ public class NumberFieldMapper extends FieldMapper {
         private static SourceLoader.SyntheticFieldLoader syntheticLongFieldLoader(String fieldName, String fieldSimpleName) {
             return new NumericSyntheticFieldLoader(fieldName, fieldSimpleName) {
                 @Override
-                protected void loadNextValue(XContentBuilder b, long value) throws IOException {
+                protected void writeValue(XContentBuilder b, long value) throws IOException {
                     b.value(value);
                 }
             };
@@ -1656,19 +1656,19 @@ public class NumberFieldMapper extends FieldMapper {
                     }
                     if (leaf.docValueCount() == 1) {
                         b.field(simpleName);
-                        loadNextValue(b, leaf.nextValue());
+                        writeValue(b, leaf.nextValue());
                         return;
                     }
                     b.startArray(simpleName);
                     for (int i = 0; i < leaf.docValueCount(); i++) {
-                        loadNextValue(b, leaf.nextValue());
+                        writeValue(b, leaf.nextValue());
                     }
                     b.endArray();
                 }
             };
         }
 
-        protected abstract void loadNextValue(XContentBuilder b, long value) throws IOException;
+        protected abstract void writeValue(XContentBuilder b, long value) throws IOException;
 
         /**
          * Returns a {@link SortedNumericDocValues} or null if it doesn't have any doc values.

--- a/server/src/main/java/org/elasticsearch/index/mapper/NumberFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/NumberFieldMapper.java
@@ -1650,7 +1650,7 @@ public class NumberFieldMapper extends FieldMapper {
                 }
 
                 @Override
-                public void load(XContentBuilder b) throws IOException {
+                public void write(XContentBuilder b) throws IOException {
                     if (false == hasValue) {
                         return;
                     }

--- a/server/src/main/java/org/elasticsearch/index/mapper/NumberFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/NumberFieldMapper.java
@@ -1631,18 +1631,6 @@ public class NumberFieldMapper extends FieldMapper {
             this.simpleName = simpleName;
         }
 
-        private SortedNumericDocValues dv(LeafReader reader) throws IOException {
-            SortedNumericDocValues dv = reader.getSortedNumericDocValues(name);
-            if (dv != null) {
-                return dv;
-            }
-            NumericDocValues single = reader.getNumericDocValues(name);
-            if (single != null) {
-                return DocValues.singleton(single);
-            }
-            return null;
-        }
-
         @Override
         public Leaf leaf(LeafReader reader) throws IOException {
             SortedNumericDocValues leaf = dv(reader);
@@ -1683,5 +1671,23 @@ public class NumberFieldMapper extends FieldMapper {
         }
 
         protected abstract void loadNextValue(XContentBuilder b, long value) throws IOException;
+
+        /**
+         * Returns a {@link SortedNumericDocValues} or null if it doesn't have any doc values.
+         * See {@link DocValues#getSortedNumeric} which is *nearly* the same, but it returns
+         * an "empty" implementation if there aren't any doc values. We need to be able to
+         * tell if there aren't any and return our empty leaf source loader.
+         */
+        private SortedNumericDocValues dv(LeafReader reader) throws IOException {
+            SortedNumericDocValues dv = reader.getSortedNumericDocValues(name);
+            if (dv != null) {
+                return dv;
+            }
+            NumericDocValues single = reader.getNumericDocValues(name);
+            if (single != null) {
+                return DocValues.singleton(single);
+            }
+            return null;
+        }
     }
 }

--- a/server/src/main/java/org/elasticsearch/index/mapper/ObjectMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/ObjectMapper.java
@@ -563,10 +563,10 @@ public class ObjectMapper extends Mapper implements Cloneable {
         });
         return new SourceLoader.SyntheticFieldLoader() {
             @Override
-            public Leaf leaf(LeafReader reader) throws IOException {
+            public Leaf leaf(LeafReader reader, int[] docIdsInLeaf) throws IOException {
                 List<SourceLoader.SyntheticFieldLoader.Leaf> leaves = new ArrayList<>();
                 for (SourceLoader.SyntheticFieldLoader field : fields) {
-                    leaves.add(field.leaf(reader));
+                    leaves.add(field.leaf(reader, docIdsInLeaf));
                 }
                 return new SourceLoader.SyntheticFieldLoader.Leaf() {
                     @Override

--- a/server/src/main/java/org/elasticsearch/index/mapper/ObjectMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/ObjectMapper.java
@@ -590,13 +590,13 @@ public class ObjectMapper extends Mapper implements Cloneable {
                     }
 
                     @Override
-                    public void load(XContentBuilder b) throws IOException {
+                    public void write(XContentBuilder b) throws IOException {
                         if (hasValue == false) {
                             return;
                         }
                         startSyntheticField(b);
                         for (SourceLoader.SyntheticFieldLoader.Leaf leaf : leaves) {
-                            leaf.load(b);
+                            leaf.write(b);
                         }
                         b.endObject();
                     }

--- a/server/src/main/java/org/elasticsearch/index/mapper/SourceLoader.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/SourceLoader.java
@@ -99,7 +99,7 @@ public interface SourceLoader {
                     // TODO accept a requested xcontent type
                     try (XContentBuilder b = new XContentBuilder(JsonXContent.jsonXContent, new ByteArrayOutputStream())) {
                         if (leaf.advanceToDoc(docId)) {
-                            leaf.load(b);
+                            leaf.write(b);
                         } else {
                             b.startObject().endObject();
                         }
@@ -126,7 +126,7 @@ public interface SourceLoader {
             }
 
             @Override
-            public void load(XContentBuilder b) throws IOException {}
+            public void write(XContentBuilder b) throws IOException {}
         };
 
         /**
@@ -149,9 +149,9 @@ public interface SourceLoader {
             boolean advanceToDoc(int docId) throws IOException;
 
             /**
-             * Load values for this document.
+             * Write values for this document.
              */
-            void load(XContentBuilder b) throws IOException;
+            void write(XContentBuilder b) throws IOException;
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/index/mapper/SourceLoader.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/SourceLoader.java
@@ -29,7 +29,7 @@ public interface SourceLoader {
     /**
      * Build the loader for some segment.
      */
-    Leaf leaf(LeafReader reader) throws IOException;
+    Leaf leaf(LeafReader reader, int[] docIdsInLeaf) throws IOException;
 
     /**
      * Loads {@code _source} from some segment.
@@ -54,7 +54,7 @@ public interface SourceLoader {
         }
 
         @Override
-        public Leaf leaf(LeafReader reader) {
+        public Leaf leaf(LeafReader reader, int[] docIdsInLeaf) {
             return new Leaf() {
                 @Override
                 public BytesReference source(FieldsVisitor fieldsVisitor, int docId) {
@@ -80,8 +80,8 @@ public interface SourceLoader {
         }
 
         @Override
-        public Leaf leaf(LeafReader reader) throws IOException {
-            SyntheticFieldLoader.Leaf leaf = loader.leaf(reader);
+        public Leaf leaf(LeafReader reader, int[] docIdsInLeaf) throws IOException {
+            SyntheticFieldLoader.Leaf leaf = loader.leaf(reader, docIdsInLeaf);
             return new Leaf() {
                 @Override
                 public BytesReference source(FieldsVisitor fieldsVisitor, int docId) throws IOException {
@@ -107,7 +107,7 @@ public interface SourceLoader {
         /**
          * Load no values.
          */
-        SyntheticFieldLoader NOTHING = r -> new Leaf() {
+        SyntheticFieldLoader.Leaf NOTHING_LEAF = new Leaf() {
             @Override
             public void advanceToDoc(int docId) throws IOException {}
 
@@ -121,9 +121,14 @@ public interface SourceLoader {
         };
 
         /**
+         * Load no values.
+         */
+        SyntheticFieldLoader NOTHING = (reader, docIdsInLeaf) -> NOTHING_LEAF;
+
+        /**
          * Build a loader for this field in the provided segment.
          */
-        Leaf leaf(LeafReader reader) throws IOException;
+        Leaf leaf(LeafReader reader, int[] docIdsInLeaf) throws IOException;
 
         /**
          * Loads values for a field in a particular leaf.

--- a/server/src/test/java/org/elasticsearch/index/mapper/BooleanFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/BooleanFieldMapperTests.java
@@ -198,13 +198,13 @@ public class BooleanFieldMapperTests extends MapperTestCase {
     protected SyntheticSourceSupport syntheticSourceSupport() {
         return new SyntheticSourceSupport() {
             @Override
-            public SyntheticSourceExample example() throws IOException {
+            public SyntheticSourceExample example(int maxVals) throws IOException {
                 switch (randomInt(3)) {
                     case 0:
                         boolean v = randomBoolean();
                         return new SyntheticSourceExample(v, v, BooleanFieldMapperTests.this::minimalMapping);
                     case 1:
-                        List<Boolean> in = randomList(1, 5, ESTestCase::randomBoolean);
+                        List<Boolean> in = randomList(1, maxVals, ESTestCase::randomBoolean);
                         Object out = in.size() == 1 ? in.get(0) : in.stream().sorted().toList();
                         return new SyntheticSourceExample(in, out, BooleanFieldMapperTests.this::minimalMapping);
                     case 2:
@@ -215,7 +215,7 @@ public class BooleanFieldMapperTests extends MapperTestCase {
                         });
                     case 3:
                         boolean nullValue = randomBoolean();
-                        List<Boolean> vals = randomList(1, 5, ESTestCase::randomBoolean);
+                        List<Boolean> vals = randomList(1, maxVals, ESTestCase::randomBoolean);
                         in = vals.stream().map(b -> b == nullValue ? null : b).toList();
                         out = vals.size() == 1 ? vals.get(0) : vals.stream().sorted().toList();
                         return new SyntheticSourceExample(in, out, b -> {

--- a/server/src/test/java/org/elasticsearch/index/mapper/BooleanFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/BooleanFieldMapperTests.java
@@ -14,8 +14,8 @@ import org.apache.lucene.index.LeafReader;
 import org.apache.lucene.index.SortedNumericDocValues;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.Strings;
+import org.elasticsearch.core.Tuple;
 import org.elasticsearch.script.BooleanFieldScript;
-import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xcontent.ToXContent;
 import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xcontent.XContentFactory;
@@ -197,33 +197,33 @@ public class BooleanFieldMapperTests extends MapperTestCase {
     @Override
     protected SyntheticSourceSupport syntheticSourceSupport() {
         return new SyntheticSourceSupport() {
+            Boolean nullValue = usually() ? null : randomBoolean();
+
             @Override
             public SyntheticSourceExample example(int maxVals) throws IOException {
-                switch (randomInt(3)) {
-                    case 0:
-                        boolean v = randomBoolean();
-                        return new SyntheticSourceExample(v, v, BooleanFieldMapperTests.this::minimalMapping);
-                    case 1:
-                        List<Boolean> in = randomList(1, maxVals, ESTestCase::randomBoolean);
-                        Object out = in.size() == 1 ? in.get(0) : in.stream().sorted().toList();
-                        return new SyntheticSourceExample(in, out, BooleanFieldMapperTests.this::minimalMapping);
-                    case 2:
-                        v = randomBoolean();
-                        return new SyntheticSourceExample(null, v, b -> {
-                            minimalMapping(b);
-                            b.field("null_value", v);
-                        });
-                    case 3:
-                        boolean nullValue = randomBoolean();
-                        List<Boolean> vals = randomList(1, maxVals, ESTestCase::randomBoolean);
-                        in = vals.stream().map(b -> b == nullValue ? null : b).toList();
-                        out = vals.size() == 1 ? vals.get(0) : vals.stream().sorted().toList();
-                        return new SyntheticSourceExample(in, out, b -> {
-                            minimalMapping(b);
-                            b.field("null_value", nullValue);
-                        });
-                    default:
-                        throw new IllegalArgumentException();
+                if (randomBoolean()) {
+                    Tuple<Boolean, Boolean> v = generateValue();
+                    return new SyntheticSourceExample(v.v1(), v.v2(), this::mapping);
+                }
+                List<Tuple<Boolean, Boolean>> values = randomList(1, maxVals, this::generateValue);
+                List<Boolean> in = values.stream().map(Tuple::v1).toList();
+                List<Boolean> outList = values.stream().map(Tuple::v2).sorted().toList();
+                Object out = outList.size() == 1 ? outList.get(0) : outList;
+                return new SyntheticSourceExample(in, out, this::mapping);
+            }
+
+            private Tuple<Boolean, Boolean> generateValue() {
+                if (nullValue != null && randomBoolean()) {
+                    return Tuple.tuple(null, nullValue);
+                }
+                boolean b = randomBoolean();
+                return Tuple.tuple(b, b);
+            }
+
+            private void mapping(XContentBuilder b) throws IOException {
+                minimalMapping(b);
+                if (nullValue != null) {
+                    b.field("null_value", nullValue);
                 }
             }
 

--- a/server/src/test/java/org/elasticsearch/index/mapper/DateFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/DateFieldMapperTests.java
@@ -583,12 +583,12 @@ public class DateFieldMapperTests extends MapperTestCase {
                 : DateFieldMapper.DEFAULT_DATE_TIME_NANOS_FORMATTER;
 
             @Override
-            public SyntheticSourceExample example() {
+            public SyntheticSourceExample example(int maxValues) {
                 if (randomBoolean()) {
                     Tuple<Object, String> v = generateValue();
                     return new SyntheticSourceExample(v.v1(), v.v2(), this::mapping);
                 }
-                List<Tuple<Object, String>> values = randomList(1, 5, this::generateValue);
+                List<Tuple<Object, String>> values = randomList(1, maxValues, this::generateValue);
                 List<Object> in = values.stream().map(Tuple::v1).toList();
                 List<String> outList = values.stream()
                     .sorted(

--- a/server/src/test/java/org/elasticsearch/index/mapper/GeoPointFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/GeoPointFieldMapperTests.java
@@ -474,12 +474,12 @@ public class GeoPointFieldMapperTests extends MapperTestCase {
             private final GeoPoint nullValue = usually() ? null : randomGeoPoint();
 
             @Override
-            public SyntheticSourceExample example() {
+            public SyntheticSourceExample example(int maxVals) {
                 if (randomBoolean()) {
                     Tuple<Object, GeoPoint> v = generateValue();
                     return new SyntheticSourceExample(v.v1(), decode(encode(v.v2())), this::mapping);
                 }
-                List<Tuple<Object, GeoPoint>> values = randomList(1, 5, this::generateValue);
+                List<Tuple<Object, GeoPoint>> values = randomList(1, maxVals, this::generateValue);
                 List<Object> in = values.stream().map(Tuple::v1).toList();
                 List<Map<String, Object>> outList = values.stream().map(t -> encode(t.v2())).sorted().map(this::decode).toList();
                 Object out = outList.size() == 1 ? outList.get(0) : outList;

--- a/server/src/test/java/org/elasticsearch/index/mapper/IpFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/IpFieldMapperTests.java
@@ -308,12 +308,12 @@ public class IpFieldMapperTests extends MapperTestCase {
             private final InetAddress nullValue = usually() ? null : randomIp(randomBoolean());
 
             @Override
-            public SyntheticSourceExample example() {
+            public SyntheticSourceExample example(int maxValues) {
                 if (randomBoolean()) {
                     Tuple<String, InetAddress> v = generateValue();
                     return new SyntheticSourceExample(v.v1(), NetworkAddress.format(v.v2()), this::mapping);
                 }
-                List<Tuple<String, InetAddress>> values = randomList(1, 5, this::generateValue);
+                List<Tuple<String, InetAddress>> values = randomList(1, maxValues, this::generateValue);
                 List<String> in = values.stream().map(Tuple::v1).toList();
                 List<String> outList = values.stream()
                     .map(v -> new BytesRef(InetAddressPoint.encode(v.v2())))

--- a/server/src/test/java/org/elasticsearch/index/mapper/KeywordFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/KeywordFieldMapperTests.java
@@ -58,7 +58,6 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.instanceOf;
 
 public class KeywordFieldMapperTests extends MapperTestCase {
-
     /**
      * Creates a copy of the lowercase token filter which we use for testing merge errors.
      */
@@ -631,12 +630,12 @@ public class KeywordFieldMapperTests extends MapperTestCase {
         private final String nullValue = usually() ? null : randomAlphaOfLength(2);
 
         @Override
-        public SyntheticSourceExample example() {
+        public SyntheticSourceExample example(int maxValues) {
             if (randomBoolean()) {
                 Tuple<String, String> v = generateValue();
                 return new SyntheticSourceExample(v.v1(), v.v2(), this::mapping);
             }
-            List<Tuple<String, String>> values = randomList(1, 5, this::generateValue);
+            List<Tuple<String, String>> values = randomList(1, maxValues, this::generateValue);
             List<String> in = values.stream().map(Tuple::v1).toList();
             List<String> outList = values.stream().map(Tuple::v2).collect(Collectors.toSet()).stream().sorted().toList();
             Object out = outList.size() == 1 ? outList.get(0) : outList;

--- a/server/src/test/java/org/elasticsearch/index/mapper/KeywordFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/KeywordFieldMapperTests.java
@@ -8,7 +8,7 @@
 
 package org.elasticsearch.index.mapper;
 
-import com.carrotsearch.randomizedtesting.annotations.Seed;
+import com.carrotsearch.randomizedtesting.annotations.Repeat;
 
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.analysis.TokenStream;
@@ -59,7 +59,7 @@ import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.instanceOf;
 
-@Seed("15C15CAB82D77A6E:504FF8CCDCA26B0E")
+@Repeat(iterations=100)
 public class KeywordFieldMapperTests extends MapperTestCase {
     /**
      * Creates a copy of the lowercase token filter which we use for testing merge errors.

--- a/server/src/test/java/org/elasticsearch/index/mapper/KeywordFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/KeywordFieldMapperTests.java
@@ -8,6 +8,8 @@
 
 package org.elasticsearch.index.mapper;
 
+import com.carrotsearch.randomizedtesting.annotations.Seed;
+
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.analysis.TokenStream;
 import org.apache.lucene.analysis.core.LowerCaseFilter;
@@ -57,6 +59,7 @@ import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.instanceOf;
 
+@Seed("15C15CAB82D77A6E:504FF8CCDCA26B0E")
 public class KeywordFieldMapperTests extends MapperTestCase {
     /**
      * Creates a copy of the lowercase token filter which we use for testing merge errors.

--- a/server/src/test/java/org/elasticsearch/index/mapper/KeywordFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/KeywordFieldMapperTests.java
@@ -8,8 +8,6 @@
 
 package org.elasticsearch.index.mapper;
 
-import com.carrotsearch.randomizedtesting.annotations.Repeat;
-
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.analysis.TokenStream;
 import org.apache.lucene.analysis.core.LowerCaseFilter;
@@ -59,7 +57,6 @@ import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.instanceOf;
 
-@Repeat(iterations=100)
 public class KeywordFieldMapperTests extends MapperTestCase {
     /**
      * Creates a copy of the lowercase token filter which we use for testing merge errors.

--- a/server/src/test/java/org/elasticsearch/index/mapper/NumberFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/NumberFieldMapperTests.java
@@ -360,12 +360,12 @@ public abstract class NumberFieldMapperTests extends MapperTestCase {
         }
 
         @Override
-        public SyntheticSourceExample example() {
+        public SyntheticSourceExample example(int maxVals) {
             if (randomBoolean()) {
                 Tuple<Object, Number> v = generateValue();
                 return new SyntheticSourceExample(v.v1(), round.apply(v.v2()), this::mapping);
             }
-            List<Tuple<Object, Number>> values = randomList(1, 5, this::generateValue);
+            List<Tuple<Object, Number>> values = randomList(1, maxVals, this::generateValue);
             List<Object> in = values.stream().map(Tuple::v1).toList();
             List<Number> outList = values.stream().map(t -> round.apply(t.v2())).sorted().toList();
             Object out = outList.size() == 1 ? outList.get(0) : outList;

--- a/server/src/test/java/org/elasticsearch/index/mapper/TextFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/TextFieldMapperTests.java
@@ -1096,10 +1096,11 @@ public class TextFieldMapperTests extends MapperTestCase {
 
     @Override
     protected SyntheticSourceSupport syntheticSourceSupport() {
-        SyntheticSourceExample delegate = new KeywordFieldMapperTests.KeywordSyntheticSourceSupport().example();
+        SyntheticSourceSupport supportDelegate = new KeywordFieldMapperTests.KeywordSyntheticSourceSupport();
         return new SyntheticSourceSupport() {
             @Override
-            public SyntheticSourceExample example() throws IOException {
+            public SyntheticSourceExample example(int maxValues) throws IOException {
+                SyntheticSourceExample delegate = supportDelegate.example(maxValues);
                 return new SyntheticSourceExample(delegate.inputValue(), delegate.result(), b -> {
                     b.field("type", "text");
                     b.startObject("fields");

--- a/test/framework/src/main/java/org/elasticsearch/index/mapper/MapperServiceTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/index/mapper/MapperServiceTestCase.java
@@ -655,7 +655,7 @@ public abstract class MapperServiceTestCase extends ESTestCase {
             iw.close();
             try (DirectoryReader reader = DirectoryReader.open(directory)) {
                 SourceLoader loader = mapper.sourceMapper().newSourceLoader(mapper.mapping());
-                String syntheticSource = loader.leaf(getOnlyLeafReader(reader)).source(null, 0).utf8ToString();
+                String syntheticSource = loader.leaf(getOnlyLeafReader(reader), new int[] { 0 }).source(null, 0).utf8ToString();
                 roundTripSyntheticSource(mapper, syntheticSource, reader);
                 return syntheticSource;
             }
@@ -681,7 +681,9 @@ public abstract class MapperServiceTestCase extends ESTestCase {
             roundTripIw.close();
             try (DirectoryReader roundTripReader = DirectoryReader.open(roundTripDirectory)) {
                 SourceLoader loader = mapper.sourceMapper().newSourceLoader(mapper.mapping());
-                String roundTripSyntheticSource = loader.leaf(getOnlyLeafReader(roundTripReader)).source(null, 0).utf8ToString();
+                String roundTripSyntheticSource = loader.leaf(getOnlyLeafReader(roundTripReader), new int[] { 0 })
+                    .source(null, 0)
+                    .utf8ToString();
                 assertThat(roundTripSyntheticSource, equalTo(syntheticSource));
                 validateRoundTripReader(syntheticSource, reader, roundTripReader);
             }

--- a/test/framework/src/main/java/org/elasticsearch/index/mapper/MapperTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/index/mapper/MapperTestCase.java
@@ -823,11 +823,11 @@ public abstract class MapperTestCase extends MapperServiceTestCase {
                 if (rarely()) {
                     expected[i] = "{}";
                     iw.addDocument(mapper.parse(source(b -> b.startArray("field").endArray())).rootDoc());
-                } else {
-                    SyntheticSourceExample example = support.example(maxValues);
-                    expected[i] = Strings.toString(JsonXContent.contentBuilder().startObject().field("field", example.result).endObject());
-                    iw.addDocument(mapper.parse(source(b -> b.field("field", example.inputValue))).rootDoc());
+                    continue;
                 }
+                SyntheticSourceExample example = support.example(maxValues);
+                expected[i] = Strings.toString(JsonXContent.contentBuilder().startObject().field("field", example.result).endObject());
+                iw.addDocument(mapper.parse(source(b -> b.field("field", example.inputValue))).rootDoc());
             }
             iw.close();
             try (DirectoryReader reader = DirectoryReader.open(directory)) {
@@ -837,7 +837,7 @@ public abstract class MapperTestCase extends MapperServiceTestCase {
                     int[] docIds = IntStream.range(0, leaf.reader().maxDoc()).toArray();
                     SourceLoader.Leaf sourceLoaderLeaf = loader.leaf(leaf.reader(), docIds);
                     for (int docId : docIds) {
-                        assertThat(sourceLoaderLeaf.source(null, docId).utf8ToString(), equalTo(expected[i++]));
+                        assertThat("doc " + docId, sourceLoaderLeaf.source(null, docId).utf8ToString(), equalTo(expected[i++]));
                     }
                 }
             }

--- a/test/framework/src/main/java/org/elasticsearch/index/mapper/MapperTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/index/mapper/MapperTestCase.java
@@ -14,13 +14,16 @@ import org.apache.lucene.index.IndexOptions;
 import org.apache.lucene.index.IndexableField;
 import org.apache.lucene.index.IndexableFieldType;
 import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.index.NoMergePolicy;
 import org.apache.lucene.search.DocValuesFieldExistsQuery;
 import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.NormsFieldExistsQuery;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.TermQuery;
 import org.apache.lucene.store.Directory;
+import org.apache.lucene.tests.analysis.MockAnalyzer;
 import org.apache.lucene.tests.index.RandomIndexWriter;
+import org.apache.lucene.tests.util.LuceneTestCase;
 import org.apache.lucene.util.SetOnce;
 import org.elasticsearch.Version;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
@@ -818,7 +821,11 @@ public abstract class MapperTestCase extends MapperServiceTestCase {
         int count = between(2, 1000);
         String[] expected = new String[count];
         try (Directory directory = newDirectory()) {
-            RandomIndexWriter iw = new RandomIndexWriter(random(), directory);
+            RandomIndexWriter iw = new RandomIndexWriter(
+                random(),
+                directory,
+                LuceneTestCase.newIndexWriterConfig(random(), new MockAnalyzer(random())).setMergePolicy(NoMergePolicy.INSTANCE)
+            );
             for (int i = 0; i < count; i++) {
                 if (rarely()) {
                     expected[i] = "{}";

--- a/test/framework/src/main/java/org/elasticsearch/index/mapper/MapperTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/index/mapper/MapperTestCase.java
@@ -8,6 +8,7 @@
 
 package org.elasticsearch.index.mapper;
 
+import org.apache.lucene.index.DirectoryReader;
 import org.apache.lucene.index.DocValuesType;
 import org.apache.lucene.index.IndexOptions;
 import org.apache.lucene.index.IndexableField;
@@ -18,6 +19,8 @@ import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.NormsFieldExistsQuery;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.TermQuery;
+import org.apache.lucene.store.Directory;
+import org.apache.lucene.tests.index.RandomIndexWriter;
 import org.apache.lucene.util.SetOnce;
 import org.elasticsearch.Version;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
@@ -54,6 +57,7 @@ import java.util.Set;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 import static java.util.stream.Collectors.toList;
 import static org.hamcrest.Matchers.anyOf;
@@ -779,7 +783,7 @@ public abstract class MapperTestCase extends MapperServiceTestCase {
         /**
          * Examples that should work when source is generated from doc values.
          */
-        SyntheticSourceExample example() throws IOException;
+        SyntheticSourceExample example(int maxValues) throws IOException;
 
         /**
          * Examples of mappings that should be rejected when source is configured to
@@ -791,7 +795,7 @@ public abstract class MapperTestCase extends MapperServiceTestCase {
     protected abstract SyntheticSourceSupport syntheticSourceSupport();
 
     public final void testSyntheticSource() throws IOException {
-        SyntheticSourceExample syntheticSourceExample = syntheticSourceSupport().example();
+        SyntheticSourceExample syntheticSourceExample = syntheticSourceSupport().example(5);
         DocumentMapper mapper = createDocumentMapper(syntheticSourceMapping(b -> {
             b.startObject("field");
             syntheticSourceExample.mapping().accept(b);
@@ -801,6 +805,43 @@ public abstract class MapperTestCase extends MapperServiceTestCase {
             JsonXContent.contentBuilder().startObject().field("field", syntheticSourceExample.result).endObject()
         );
         assertThat(syntheticSource(mapper, b -> b.field("field", syntheticSourceExample.inputValue)), equalTo(expected));
+    }
+
+    public final void testSyntheticSourceMany() throws IOException {
+        int maxValues = randomBoolean() ? 1 : 5;
+        SyntheticSourceSupport support = syntheticSourceSupport();
+        DocumentMapper mapper = createDocumentMapper(syntheticSourceMapping(b -> {
+            b.startObject("field");
+            support.example(maxValues).mapping().accept(b);
+            b.endObject();
+        }));
+        int count = between(2, 1000);
+        String[] expected = new String[count];
+        try (Directory directory = newDirectory()) {
+            RandomIndexWriter iw = new RandomIndexWriter(random(), directory);
+            for (int i = 0; i < count; i++) {
+                if (rarely()) {
+                    expected[i] = "{}";
+                    iw.addDocument(mapper.parse(source(b -> b.startArray("field").endArray())).rootDoc());
+                } else {
+                    SyntheticSourceExample example = support.example(maxValues);
+                    expected[i] = Strings.toString(JsonXContent.contentBuilder().startObject().field("field", example.result).endObject());
+                    iw.addDocument(mapper.parse(source(b -> b.field("field", example.inputValue))).rootDoc());
+                }
+            }
+            iw.close();
+            try (DirectoryReader reader = DirectoryReader.open(directory)) {
+                int i = 0;
+                SourceLoader loader = mapper.sourceMapper().newSourceLoader(mapper.mapping());
+                for (LeafReaderContext leaf : reader.leaves()) {
+                    int[] docIds = IntStream.range(0, leaf.reader().maxDoc()).toArray();
+                    SourceLoader.Leaf sourceLoaderLeaf = loader.leaf(leaf.reader(), docIds);
+                    for (int docId : docIds) {
+                        assertThat(sourceLoaderLeaf.source(null, docId).utf8ToString(), equalTo(expected[i++]));
+                    }
+                }
+            }
+        }
     }
 
     public final void testNoSyntheticSourceForScript() throws IOException {
@@ -816,7 +857,7 @@ public abstract class MapperTestCase extends MapperServiceTestCase {
     }
 
     public final void testSyntheticSourceInObject() throws IOException {
-        SyntheticSourceExample syntheticSourceExample = syntheticSourceSupport().example();
+        SyntheticSourceExample syntheticSourceExample = syntheticSourceSupport().example(5);
         DocumentMapper mapper = createDocumentMapper(syntheticSourceMapping(b -> {
             b.startObject("obj").startObject("properties").startObject("field");
             syntheticSourceExample.mapping().accept(b);
@@ -837,7 +878,7 @@ public abstract class MapperTestCase extends MapperServiceTestCase {
     }
 
     public final void testSyntheticEmptyList() throws IOException {
-        SyntheticSourceExample syntheticSourceExample = syntheticSourceSupport().example();
+        SyntheticSourceExample syntheticSourceExample = syntheticSourceSupport().example(5);
         DocumentMapper mapper = createDocumentMapper(syntheticSourceMapping(b -> {
             b.startObject("field");
             syntheticSourceExample.mapping().accept(b);
@@ -852,7 +893,7 @@ public abstract class MapperTestCase extends MapperServiceTestCase {
             new SyntheticSourceInvalidExample(
                 matchesPattern("field \\[field] of type \\[.+] doesn't support synthetic source because it declares copy_to"),
                 b -> {
-                    syntheticSourceSupport().example().mapping().accept(b);
+                    syntheticSourceSupport().example(5).mapping().accept(b);
                     b.field("copy_to", "bar");
                 }
             )


### PR DESCRIPTION
This speeds up synthesizing _source for keywords, text, and ip fields by
converting from ordinal to utf-8 one time. When loading from disk blocks
that are hot in the page cache the speed up is 7-10%:

```
|  50th percentile service time | default_1k | 39.4338 | 35.6935 | ms |  -9.49% |
|  90th percentile service time | default_1k | 41.3508 | 38.3602 | ms |  -7.23% |
|  99th percentile service time | default_1k | 50.6734 | 45.4686 | ms | -10.27% |
| 100th percentile service time | default_1k | 61.3771 | 56.4886 | ms |  -7.96% |
```

This should be much more substantial when loading from scattered disk
blocks because it takes care to load the ordinals in increasing order.
