### PR TITLE
[7.17] Use Azul Zulu JDK8 distribution instead of Adoptium/OpenJDK on MacOS with Apple Silicon (#87733)

### DIFF
--- a/build-tools/src/main/java/org/elasticsearch/gradle/Jdk.java
+++ b/build-tools/src/main/java/org/elasticsearch/gradle/Jdk.java
@@ -23,7 +23,7 @@ import java.util.regex.Pattern;
 public class Jdk implements Buildable, Iterable<File> {
 
     private static final List<String> ALLOWED_ARCHITECTURES = List.of("aarch64", "x64");
-    private static final List<String> ALLOWED_VENDORS = List.of("adoptium", "openjdk");
+    private static final List<String> ALLOWED_VENDORS = List.of("adoptium", "openjdk", "zulu");
     private static final List<String> ALLOWED_PLATFORMS = List.of("darwin", "linux", "windows", "mac");
     private static final Pattern VERSION_PATTERN = Pattern.compile(
         "(\\d+)(\\.\\d+\\.\\d+(?:\\.\\d+)?)?\\+(\\d+(?:\\.\\d+)?)(@([a-f0-9]{32}))?"
@@ -37,6 +37,7 @@ public class Jdk implements Buildable, Iterable<File> {
     private final Property<String> version;
     private final Property<String> platform;
     private final Property<String> architecture;
+    private final Property<String> distributionVersion;
     private String baseVersion;
     private String major;
     private String build;
@@ -49,6 +50,7 @@ public class Jdk implements Buildable, Iterable<File> {
         this.version = objectFactory.property(String.class);
         this.platform = objectFactory.property(String.class);
         this.architecture = objectFactory.property(String.class);
+        this.distributionVersion = objectFactory.property(String.class);
     }
 
     public String getName() {
@@ -102,6 +104,14 @@ public class Jdk implements Buildable, Iterable<File> {
             );
         }
         this.architecture.set(architecture);
+    }
+
+    public String getDistributionVersion() {
+        return distributionVersion.get();
+    }
+
+    public void setDistributionVersion(String distributionVersion) {
+        this.distributionVersion.set(distributionVersion);
     }
 
     public String getBaseVersion() {
@@ -179,6 +189,7 @@ public class Jdk implements Buildable, Iterable<File> {
         platform.finalizeValue();
         vendor.finalizeValue();
         architecture.finalizeValue();
+        distributionVersion.finalizeValue();
     }
 
     @Override

--- a/build-tools/src/main/java/org/elasticsearch/gradle/JdkDownloadPlugin.java
+++ b/build-tools/src/main/java/org/elasticsearch/gradle/JdkDownloadPlugin.java
@@ -26,6 +26,7 @@ public class JdkDownloadPlugin implements Plugin<Project> {
 
     public static final String VENDOR_ADOPTIUM = "adoptium";
     public static final String VENDOR_OPENJDK = "openjdk";
+    public static final String VENDOR_ZULU = "zulu";
 
     private static final String REPO_NAME_PREFIX = "jdk_repo_";
     private static final String EXTENSION_NAME = "jdks";
@@ -125,6 +126,17 @@ public class JdkDownloadPlugin implements Plugin<Project> {
                     + jdk.getBuild()
                     + "/GPL/openjdk-[revision]_[module]-[classifier]_bin.[ext]";
             }
+        } else if (jdk.getVendor().equals(VENDOR_ZULU)) {
+            repoUrl = "https://cdn.azul.com";
+            if (jdk.getMajor().equals("8") && isJdkOnMacOsPlatform(jdk) && jdk.getArchitecture().equals("aarch64")) {
+                artifactPattern = "zulu/bin/zulu"
+                    + jdk.getDistributionVersion()
+                    + "-ca-jdk"
+                    + jdk.getBaseVersion().replace("u", ".0.")
+                    + "-[module]x_[classifier].[ext]";
+            } else {
+                throw new GradleException("JDK vendor zulu is supported only for JDK8 on MacOS with Apple Silicon.");
+            }
         } else {
             throw new GradleException("Unknown JDK vendor [" + jdk.getVendor() + "]");
         }
@@ -147,12 +159,14 @@ public class JdkDownloadPlugin implements Plugin<Project> {
     }
 
     private static String dependencyNotation(Jdk jdk) {
-        String platformDep = jdk.getPlatform().equals("darwin") || jdk.getPlatform().equals("mac")
-            ? (jdk.getVendor().equals(VENDOR_ADOPTIUM) ? "mac" : "macos")
-            : jdk.getPlatform();
+        String platformDep = isJdkOnMacOsPlatform(jdk) ? (jdk.getVendor().equals(VENDOR_ADOPTIUM) ? "mac" : "macos") : jdk.getPlatform();
         String extension = jdk.getPlatform().equals("windows") ? "zip" : "tar.gz";
 
         return groupName(jdk) + ":" + platformDep + ":" + jdk.getBaseVersion() + ":" + jdk.getArchitecture() + "@" + extension;
+    }
+
+    private static boolean isJdkOnMacOsPlatform(Jdk jdk) {
+        return jdk.getPlatform().equals("darwin") || jdk.getPlatform().equals("mac");
     }
 
     private static String groupName(Jdk jdk) {

--- a/build-tools/src/test/java/org/elasticsearch/gradle/JdkDownloadPluginTests.java
+++ b/build-tools/src/test/java/org/elasticsearch/gradle/JdkDownloadPluginTests.java
@@ -36,7 +36,7 @@ public class JdkDownloadPluginTests extends GradleUnitTestCase {
             "11.0.2+33",
             "linux",
             "x64",
-            "unknown vendor [unknown] for jdk [testjdk], must be one of [adoptium, openjdk]"
+            "unknown vendor [unknown] for jdk [testjdk], must be one of [adoptium, openjdk, zulu]"
         );
     }
 

--- a/modules/reindex/build.gradle
+++ b/modules/reindex/build.gradle
@@ -93,6 +93,11 @@ jdks {
   }
 }
 
+if (Os.isFamily(Os.FAMILY_MAC) && Architecture.current() == Architecture.AARCH64) {
+  jdks.legacy.vendor = 'zulu'
+  jdks.legacy.distributionVersion = '8.56.0.23'
+}
+
 if (Os.isFamily(Os.FAMILY_WINDOWS)) {
   logger.warn("Disabling reindex-from-old tests because we can't get the pid file on windows")
   tasks.named("javaRestTest").configure {


### PR DESCRIPTION
Backports the following commits to 7.17:
 - Use Azul Zulu JDK8 distribution instead of Adoptium/OpenJDK on MacOS with Apple Silicon (#87733)