### PR TITLE
[DOCS] Add authorization to anomaly detection job and datafeed API examples

### DIFF
--- a/docs/reference/ml/anomaly-detection/apis/get-datafeed.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/get-datafeed.asciidoc
@@ -86,25 +86,38 @@ The API returns the following results:
     {
       "datafeed_id" : "datafeed-high_sum_total_sales",
       "job_id" : "high_sum_total_sales",
+      "authorization" : {
+        "roles" : [
+          "superuser"
+        ]
+      },
       "query_delay" : "93169ms",
-      "indices" : [
-        "kibana_sample_data_ecommerce"
-      ],
+      "chunking_config" : {
+        "mode" : "auto"
+      },
+      "indices_options" : {
+        "expand_wildcards" : [
+          "open"
+        ],
+        "ignore_unavailable" : false,
+        "allow_no_indices" : true,
+        "ignore_throttled" : true
+      },
       "query" : {
         "bool" : {
           "filter" : [
             {
               "term" : {
-                "_index" : "kibana_sample_data_ecommerce"
+                "event.dataset" : "sample_ecommerce"
               }
             }
           ]
         }
       },
+      "indices" : [
+        "kibana_sample_data_ecommerce"
+      ],
       "scroll_size" : 1000,
-      "chunking_config" : {
-        "mode" : "auto"
-      },
       "delayed_data_check_config" : {
         "enabled" : true
       }
@@ -112,4 +125,3 @@ The API returns the following results:
   ]
 }
 ----
-// TESTRESPONSE[s/"query.boost": "93169ms"/"query.boost": $body.query.boost/]

--- a/docs/reference/ml/anomaly-detection/apis/put-datafeed.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/put-datafeed.asciidoc
@@ -157,24 +157,42 @@ include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=scroll-size]
 [[ml-put-datafeed-example]]
 == {api-examples-title}
 
+Create a {dfeed} for an {anomaly-job} (`test-job2`):
+
 [source,console]
 --------------------------------------------------
-PUT _ml/datafeeds/datafeed-total-requests
+PUT _ml/datafeeds/datafeed-test-job2?pretty
 {
-  "job_id": "total-requests",
-  "indices": ["server-metrics"]
+  "indices": [
+    "kibana_sample_data_logs"
+  ],
+  "query": {
+    "bool": {
+      "must": [
+        {
+          "match_all": {}
+        }
+      ]
+    }
+  },
+  "job_id": "test-job2"
 }
 --------------------------------------------------
-// TEST[skip:setup:server_metrics_job]
+// TEST[skip:setup ecommerce job]
 
 When the {dfeed} is created, you receive the following results:
 
 [source,console-result]
 ----
 {
-  "datafeed_id" : "datafeed-total-requests",
-  "job_id" : "total-requests",
-  "query_delay" : "83474ms",
+  "datafeed_id" : "datafeed-test-job2",
+  "job_id" : "test-job2",
+  "authorization" : {
+    "roles" : [
+      "superuser"
+    ]
+  },
+  "query_delay" : "91820ms",
   "chunking_config" : {
     "mode" : "auto"
   },
@@ -187,10 +205,16 @@ When the {dfeed} is created, you receive the following results:
     "ignore_throttled" : true
   },
   "query" : {
-    "match_all" : { }
+    "bool" : {
+      "must" : [
+        {
+          "match_all" : { }
+        }
+      ]
+    }
   },
   "indices" : [
-    "server-metrics"
+    "kibana_sample_data_logs"
   ],
   "scroll_size" : 1000,
   "delayed_data_check_config" : {
@@ -198,5 +222,5 @@ When the {dfeed} is created, you receive the following results:
   }
 }
 ----
-// TESTRESPONSE[s/"query_delay": "83474ms"/"query_delay": $body.query_delay/]
+// TESTRESPONSE[s/"query_delay": "91820ms"/"query_delay": $body.query_delay/]
 

--- a/docs/reference/ml/anomaly-detection/apis/put-datafeed.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/put-datafeed.asciidoc
@@ -157,11 +157,11 @@ include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=scroll-size]
 [[ml-put-datafeed-example]]
 == {api-examples-title}
 
-Create a {dfeed} for an {anomaly-job} (`test-job2`):
+Create a {dfeed} for an {anomaly-job} (`test-job`):
 
 [source,console]
 --------------------------------------------------
-PUT _ml/datafeeds/datafeed-test-job2?pretty
+PUT _ml/datafeeds/datafeed-test-job?pretty
 {
   "indices": [
     "kibana_sample_data_logs"
@@ -175,7 +175,7 @@ PUT _ml/datafeeds/datafeed-test-job2?pretty
       ]
     }
   },
-  "job_id": "test-job2"
+  "job_id": "test-job"
 }
 --------------------------------------------------
 // TEST[skip:setup ecommerce job]
@@ -185,8 +185,8 @@ When the {dfeed} is created, you receive the following results:
 [source,console-result]
 ----
 {
-  "datafeed_id" : "datafeed-test-job2",
-  "job_id" : "test-job2",
+  "datafeed_id" : "datafeed-test-job",
+  "job_id" : "test-job",
   "authorization" : {
     "roles" : [
       "superuser"

--- a/docs/reference/ml/anomaly-detection/apis/put-datafeed.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/put-datafeed.asciidoc
@@ -172,22 +172,31 @@ When the {dfeed} is created, you receive the following results:
 [source,console-result]
 ----
 {
-  "datafeed_id": "datafeed-total-requests",
-  "job_id": "total-requests",
-  "query_delay": "83474ms",
-  "indices": [
+  "datafeed_id" : "datafeed-total-requests",
+  "job_id" : "total-requests",
+  "query_delay" : "83474ms",
+  "chunking_config" : {
+    "mode" : "auto"
+  },
+  "indices_options" : {
+    "expand_wildcards" : [
+      "open"
+    ],
+    "ignore_unavailable" : false,
+    "allow_no_indices" : true,
+    "ignore_throttled" : true
+  },
+  "query" : {
+    "match_all" : { }
+  },
+  "indices" : [
     "server-metrics"
   ],
-  "query": {
-    "match_all": {
-      "boost": 1.0
-    }
-  },
-  "scroll_size": 1000,
-  "chunking_config": {
-    "mode": "auto"
+  "scroll_size" : 1000,
+  "delayed_data_check_config" : {
+    "enabled" : true
   }
 }
 ----
 // TESTRESPONSE[s/"query_delay": "83474ms"/"query_delay": $body.query_delay/]
-// TESTRESPONSE[s/"query.boost": "1.0"/"query.boost": $body.query.boost/]
+

--- a/docs/reference/ml/anomaly-detection/apis/put-job.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/put-job.asciidoc
@@ -448,10 +448,11 @@ PUT _ml/anomaly_detectors/test-job1?pretty
   }
 }
 --------------------------------------------------
+// TEST[skip:setup Kibana sample data]
 
 The API returns the following results:
 
-[source,console-result]
+[source,js]
 ----
 {
   "job_id" : "test-job1",

--- a/docs/reference/ml/anomaly-detection/apis/put-job.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/put-job.asciidoc
@@ -394,64 +394,145 @@ include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=results-retention-days]
 [[ml-put-job-example]]
 == {api-examples-title}
 
+Create an {anomaly-job} and {dfeed}:
+
 [source,console]
 --------------------------------------------------
-PUT _ml/anomaly_detectors/total-requests
+PUT _ml/anomaly_detectors/test-job1?pretty
 {
-  "description" : "Total sum of requests",
-  "analysis_config" : {
-    "bucket_span":"10m",
+  "analysis_config": {
+    "bucket_span": "15m",
     "detectors": [
       {
-        "detector_description": "Sum of total",
+        "detector_description": "Sum of bytes",
         "function": "sum",
-        "field_name": "total"
+        "field_name": "bytes"
       }
     ]
   },
-  "data_description" : {
-    "time_field":"timestamp",
+  "data_description": {
+    "time_field": "timestamp",
     "time_format": "epoch_ms"
+  },
+  "analysis_limits": {
+    "model_memory_limit": "11MB"
+  },
+  "model_plot_config": {
+    "enabled": true,
+    "annotations_enabled": true
+  },
+  "results_index_name": "test-job1",
+  "datafeed_config":
+  {
+    "indices": [
+    "kibana_sample_data_logs"
+    ],
+    "query": {
+      "bool": {
+        "must": [
+          {
+            "match_all": {}
+          }
+        ]
+      }
+    },
+    "runtime_mappings": {
+      "hour_of_day": {
+        "type": "long",
+        "script": {
+          "source": "emit(doc['timestamp'].value.getHour());"
+        }
+      }
+    },
+    "datafeed_id": "datafeed-test-job1"
   }
 }
 --------------------------------------------------
 
-When the job is created, you receive the following results:
+The API returns the following results:
 
 [source,console-result]
 ----
 {
-  "job_id" : "total-requests",
+  "job_id" : "test-job1",
   "job_type" : "anomaly_detector",
-  "job_version" : "8.0.0",
-  "description" : "Total sum of requests",
-  "create_time" : 1562352500629,
+  "job_version" : "8.4.0",
+  "create_time" : 1656087283340,
+  "datafeed_config" : {
+    "datafeed_id" : "datafeed-test-job1",
+    "job_id" : "test-job1",
+    "authorization" : {
+      "roles" : [
+        "superuser"
+      ]
+    },
+    "query_delay" : "61499ms",
+    "chunking_config" : {
+      "mode" : "auto"
+    },
+    "indices_options" : {
+      "expand_wildcards" : [
+        "open"
+      ],
+      "ignore_unavailable" : false,
+      "allow_no_indices" : true,
+      "ignore_throttled" : true
+    },
+    "query" : {
+      "bool" : {
+        "must" : [
+          {
+            "match_all" : { }
+          }
+        ]
+      }
+    },
+    "indices" : [
+      "kibana_sample_data_logs"
+    ],
+    "scroll_size" : 1000,
+    "delayed_data_check_config" : {
+      "enabled" : true
+    },
+    "runtime_mappings" : {
+      "hour_of_day" : {
+        "type" : "long",
+        "script" : {
+          "source" : "emit(doc[timestamp].value.getHour());"
+        }
+      }
+    }
+  },
   "analysis_config" : {
-    "bucket_span" : "10m",
+    "bucket_span" : "15m",
     "detectors" : [
       {
-        "detector_description" : "Sum of total",
+        "detector_description" : "Sum of bytes",
         "function" : "sum",
-        "field_name" : "total",
+        "field_name" : "bytes",
         "detector_index" : 0
       }
     ],
     "influencers" : [ ],
-    "model_prune_window": "30d"
+    "model_prune_window" : "30d"
   },
   "analysis_limits" : {
-    "model_memory_limit" : "1024mb",
+    "model_memory_limit" : "11mb",
     "categorization_examples_limit" : 4
   },
   "data_description" : {
     "time_field" : "timestamp",
     "time_format" : "epoch_ms"
   },
+  "model_plot_config" : {
+    "enabled" : true,
+    "annotations_enabled" : true
+  },
   "model_snapshot_retention_days" : 10,
   "daily_model_snapshot_retention_after_days" : 1,
-  "results_index_name" : "shared",
+  "results_index_name" : "custom-test-job1",
   "allow_lazy_open" : false
 }
 ----
-// TESTRESPONSE[s/"job_version" : "8.0.0"/"job_version" : $body.job_version/]
-// TESTRESPONSE[s/1562352500629/$body.$_path/]
+// TESTRESPONSE[s/"job_version" : "8.4.0"/"job_version" : $body.job_version/]
+// TESTRESPONSE[s/1656087283340/$body.$_path/]

--- a/docs/reference/ml/anomaly-detection/apis/put-job.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/put-job.asciidoc
@@ -498,7 +498,7 @@ The API returns the following results:
       "hour_of_day" : {
         "type" : "long",
         "script" : {
-          "source" : "emit(doc[timestamp].value.getHour());"
+          "source" : "emit(doc['timestamp'].value.getHour());"
         }
       }
     }

--- a/docs/reference/ml/anomaly-detection/apis/update-job.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/update-job.asciidoc
@@ -268,13 +268,28 @@ configuration information, including the updated property values. For example:
 {
   "job_id" : "low_request_rate",
   "job_type" : "anomaly_detector",
-  "job_version" : "8.0.0",
+  "job_version" : "8.4.0",
+  "create_time" : 1656105950893,
+  "finished_time" : 1656105965744,
+  "model_snapshot_id" : "1656105964",
+  "custom_settings" : {
+    "created_by" : "ml-module-sample",
+    "custom_urls" : [
+      {
+        "url_name" : "Raw data",
+        "url_value" : "discover#/?_g=(time:(from:'$earliest$',mode:absolute,to:'$latest$'))&_a=(index:'90943e30-9a47-11e8-b64d-95841ca0b247')"
+      },
+      {
+        "url_name" : "Data dashboard",
+        "url_value" : "dashboards#/view/edf84fe0-e1a0-11e7-b6d5-4dc382ef7f5b?_g=(time:(from:'$earliest$',mode:absolute,to:'$latest$'))&_a=(filters:!(),query:(language:kuery,query:''))"
+      }
+    ]
+  },
   "groups" : [
     "kibana_sample_data",
     "kibana_sample_web_logs"
   ],
   "description" : "An updated job",
-  "create_time" : 1576623023709,
   "analysis_config" : {
     "bucket_span" : "1h",
     "summary_count_field_name" : "doc_count",
@@ -285,8 +300,27 @@ configuration information, including the updated property values. For example:
         "detector_index" : 0
       }
     ],
-    "influencers" : [ ]
+    "influencers" : [ ],
+    "model_prune_window" : "30d"
   },
-  ...
+  "analysis_limits" : {
+    "model_memory_limit" : "11mb",
+    "categorization_examples_limit" : 4
+  },
+  "data_description" : {
+    "time_field" : "timestamp",
+    "time_format" : "epoch_ms"
+  },
+  "model_plot_config" : {
+    "enabled" : true,
+    "annotations_enabled" : true
+  },
+  "renormalization_window_days" : 30,
+  "background_persist_interval" : "2h",
+  "model_snapshot_retention_days" : 7,
+  "daily_model_snapshot_retention_after_days" : 1,
+  "results_retention_days" : 60,
+  "results_index_name" : "custom-low_request_rate",
+  "allow_lazy_open" : false
 }
 ----


### PR DESCRIPTION
Relates to https://github.com/elastic/elasticsearch/issues/87905

This PR updates the example output in the https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-get-datafeed.html, https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-put-datafeed.html, and https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-put-job.html API reference pages.

NOTE: This PR disables code snippet testing in the "create anomaly detection job" API example, since otherwise it assumes security is disabled and omits authorization details.