### PR TITLE
Use HashMap in admin get actions

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/admin/indices/alias/get/TransportGetAliasesAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/alias/get/TransportGetAliasesAction.java
@@ -19,7 +19,6 @@ import org.elasticsearch.cluster.metadata.IndexAbstraction;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.service.ClusterService;
-import org.elasticsearch.common.collect.ImmutableOpenMap;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.logging.DeprecationCategory;
 import org.elasticsearch.common.logging.DeprecationLogger;

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/alias/get/TransportGetAliasesAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/alias/get/TransportGetAliasesAction.java
@@ -95,7 +95,7 @@ public class TransportGetAliasesAction extends TransportMasterNodeReadAction<Get
     /**
      * Fills alias result with empty entries for requested indices when no specific aliases were requested.
      */
-    static ImmutableOpenMap<String, List<AliasMetadata>> postProcess(
+    static Map<String, List<AliasMetadata>> postProcess(
         GetAliasesRequest request,
         String[] concreteIndices,
         Map<String, List<AliasMetadata>> aliases,
@@ -105,7 +105,7 @@ public class TransportGetAliasesAction extends TransportMasterNodeReadAction<Get
         SystemIndices systemIndices
     ) {
         boolean noAliasesSpecified = request.getOriginalAliases() == null || request.getOriginalAliases().length == 0;
-        ImmutableOpenMap.Builder<String, List<AliasMetadata>> mapBuilder = ImmutableOpenMap.builder(aliases);
+        Map<String, List<AliasMetadata>> mapBuilder = new HashMap<>(aliases);
         for (String index : concreteIndices) {
             IndexAbstraction ia = state.metadata().getIndicesLookup().get(index);
             assert ia.getType() == IndexAbstraction.Type.CONCRETE_INDEX;
@@ -121,7 +121,7 @@ public class TransportGetAliasesAction extends TransportMasterNodeReadAction<Get
                 assert previous == null;
             }
         }
-        final ImmutableOpenMap<String, List<AliasMetadata>> finalResponse = mapBuilder.build();
+        final Map<String, List<AliasMetadata>> finalResponse = Collections.unmodifiableMap(mapBuilder);
         if (systemIndexAccessLevel != SystemIndexAccessLevel.ALL) {
             checkSystemIndexAccess(request, systemIndices, state, finalResponse, systemIndexAccessLevel, threadContext);
         }
@@ -155,7 +155,7 @@ public class TransportGetAliasesAction extends TransportMasterNodeReadAction<Get
         GetAliasesRequest request,
         SystemIndices systemIndices,
         ClusterState state,
-        ImmutableOpenMap<String, List<AliasMetadata>> aliasesMap,
+        Map<String, List<AliasMetadata>> aliasesMap,
         SystemIndexAccessLevel systemIndexAccessLevel,
         ThreadContext threadContext
     ) {

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/get/TransportGetIndexAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/get/TransportGetIndexAction.java
@@ -29,6 +29,8 @@ import org.elasticsearch.tasks.Task;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
 
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -78,17 +80,14 @@ public class TransportGetIndexAction extends TransportClusterInfoAction<GetIndex
     ) {
         Map<String, MappingMetadata> mappingsResult = ImmutableOpenMap.of();
         Map<String, List<AliasMetadata>> aliasesResult = Map.of();
-        ImmutableOpenMap<String, Settings> settings = ImmutableOpenMap.of();
-        ImmutableOpenMap<String, Settings> defaultSettings = ImmutableOpenMap.of();
-        ImmutableOpenMap<String, String> dataStreams = ImmutableOpenMap.<String, String>builder()
-            .putAllFromMap(
-                state.metadata()
+        Map<String, Settings> settings = Map.of();
+        Map<String, Settings> defaultSettings = Map.of();
+        Map<String, String> dataStreams = Map.copyOf(state.metadata()
                     .findDataStreams(concreteIndices)
                     .entrySet()
                     .stream()
                     .collect(Collectors.toMap(Map.Entry::getKey, v -> v.getValue().getName()))
-            )
-            .build();
+            );
         Feature[] features = request.features();
         boolean doneAliases = false;
         boolean doneMappings = false;
@@ -111,8 +110,8 @@ public class TransportGetIndexAction extends TransportClusterInfoAction<GetIndex
                     break;
                 case SETTINGS:
                     if (doneSettings == false) {
-                        ImmutableOpenMap.Builder<String, Settings> settingsMapBuilder = ImmutableOpenMap.builder();
-                        ImmutableOpenMap.Builder<String, Settings> defaultSettingsMapBuilder = ImmutableOpenMap.builder();
+                        Map<String, Settings> settingsMapBuilder = new HashMap<>();
+                        Map<String, Settings> defaultSettingsMapBuilder = new HashMap<>();
                         for (String index : concreteIndices) {
                             checkCancellation(task);
                             Settings indexSettings = state.metadata().index(index).getSettings();
@@ -127,8 +126,8 @@ public class TransportGetIndexAction extends TransportClusterInfoAction<GetIndex
                                 defaultSettingsMapBuilder.put(index, defaultIndexSettings);
                             }
                         }
-                        settings = settingsMapBuilder.build();
-                        defaultSettings = defaultSettingsMapBuilder.build();
+                        settings = Collections.unmodifiableMap(settingsMapBuilder);
+                        defaultSettings = Collections.unmodifiableMap(defaultSettingsMapBuilder);
                         doneSettings = true;
                     }
                     break;

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/get/TransportGetIndexAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/get/TransportGetIndexAction.java
@@ -82,12 +82,13 @@ public class TransportGetIndexAction extends TransportClusterInfoAction<GetIndex
         Map<String, List<AliasMetadata>> aliasesResult = Map.of();
         Map<String, Settings> settings = Map.of();
         Map<String, Settings> defaultSettings = Map.of();
-        Map<String, String> dataStreams = Map.copyOf(state.metadata()
-                    .findDataStreams(concreteIndices)
-                    .entrySet()
-                    .stream()
-                    .collect(Collectors.toMap(Map.Entry::getKey, v -> v.getValue().getName()))
-            );
+        Map<String, String> dataStreams = Map.copyOf(
+            state.metadata()
+                .findDataStreams(concreteIndices)
+                .entrySet()
+                .stream()
+                .collect(Collectors.toMap(Map.Entry::getKey, v -> v.getValue().getName()))
+        );
         Feature[] features = request.features();
         boolean doneAliases = false;
         boolean doneMappings = false;

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/get/TransportGetIndexAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/get/TransportGetIndexAction.java
@@ -87,7 +87,7 @@ public class TransportGetIndexAction extends TransportClusterInfoAction<GetIndex
                 .findDataStreams(concreteIndices)
                 .entrySet()
                 .stream()
-                .collect(Collectors.toMap(Map.Entry::getKey, v -> v.getValue().getName()))
+                .collect(Collectors.toUnmodifiableMap(Map.Entry::getKey, v -> v.getValue().getName()))
         );
         Feature[] features = request.features();
         boolean doneAliases = false;

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/settings/get/TransportGetSettingsAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/settings/get/TransportGetSettingsAction.java
@@ -17,7 +17,6 @@ import org.elasticsearch.cluster.block.ClusterBlockLevel;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.service.ClusterService;
-import org.elasticsearch.common.collect.ImmutableOpenMap;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.regex.Regex;
 import org.elasticsearch.common.settings.IndexScopedSettings;
@@ -28,6 +27,11 @@ import org.elasticsearch.index.Index;
 import org.elasticsearch.tasks.Task;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static java.util.Collections.unmodifiableMap;
 
 public class TransportGetSettingsAction extends TransportMasterNodeReadAction<GetSettingsRequest, GetSettingsResponse> {
 
@@ -77,8 +81,8 @@ public class TransportGetSettingsAction extends TransportMasterNodeReadAction<Ge
         ActionListener<GetSettingsResponse> listener
     ) {
         Index[] concreteIndices = indexNameExpressionResolver.concreteIndices(state, request);
-        ImmutableOpenMap.Builder<String, Settings> indexToSettingsBuilder = ImmutableOpenMap.builder();
-        ImmutableOpenMap.Builder<String, Settings> indexToDefaultSettingsBuilder = ImmutableOpenMap.builder();
+        Map<String, Settings> indexToSettings = new HashMap<>();
+        Map<String, Settings> indexToDefaultSettings = new HashMap<>();
         for (Index concreteIndex : concreteIndices) {
             IndexMetadata indexMetadata = state.getMetadata().index(concreteIndex);
             if (indexMetadata == null) {
@@ -94,15 +98,15 @@ public class TransportGetSettingsAction extends TransportMasterNodeReadAction<Ge
                 indexSettings = indexSettings.filter(k -> Regex.simpleMatch(request.names(), k));
             }
 
-            indexToSettingsBuilder.put(concreteIndex.getName(), indexSettings);
+            indexToSettings.put(concreteIndex.getName(), indexSettings);
             if (request.includeDefaults()) {
                 Settings defaultSettings = settingsFilter.filter(indexScopedSettings.diff(indexSettings, Settings.EMPTY));
                 if (isFilteredRequest(request)) {
                     defaultSettings = defaultSettings.filter(k -> Regex.simpleMatch(request.names(), k));
                 }
-                indexToDefaultSettingsBuilder.put(concreteIndex.getName(), defaultSettings);
+                indexToDefaultSettings.put(concreteIndex.getName(), defaultSettings);
             }
         }
-        listener.onResponse(new GetSettingsResponse(indexToSettingsBuilder.build(), indexToDefaultSettingsBuilder.build()));
+        listener.onResponse(new GetSettingsResponse(unmodifiableMap(indexToSettings), unmodifiableMap(indexToDefaultSettings)));
     }
 }

--- a/server/src/test/java/org/elasticsearch/action/admin/indices/alias/get/TransportGetAliasesActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/indices/alias/get/TransportGetAliasesActionTests.java
@@ -29,6 +29,7 @@ import org.elasticsearch.test.ESTestCase;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsInAnyOrder;
@@ -47,7 +48,7 @@ public class TransportGetAliasesActionTests extends ESTestCase {
         ImmutableOpenMap<String, List<AliasMetadata>> aliases = ImmutableOpenMap.<String, List<AliasMetadata>>builder()
             .fPut("b", Collections.singletonList(new AliasMetadata.Builder("y").build()))
             .build();
-        ImmutableOpenMap<String, List<AliasMetadata>> result = TransportGetAliasesAction.postProcess(
+        Map<String, List<AliasMetadata>> result = TransportGetAliasesAction.postProcess(
             request,
             new String[] { "a", "b", "c" },
             aliases,
@@ -107,7 +108,7 @@ public class TransportGetAliasesActionTests extends ESTestCase {
             .build();
         final String[] concreteIndices = { "a", ".b", "c" };
         assertEquals(state.metadata().findAliases(request.aliases(), concreteIndices), aliases);
-        ImmutableOpenMap<String, List<AliasMetadata>> result = TransportGetAliasesAction.postProcess(
+        Map<String, List<AliasMetadata>> result = TransportGetAliasesAction.postProcess(
             request,
             concreteIndices,
             aliases,
@@ -140,7 +141,7 @@ public class TransportGetAliasesActionTests extends ESTestCase {
             .build();
         final String[] concreteIndices = { ".b" };
         assertEquals(state.metadata().findAliases(request.aliases(), concreteIndices), aliases);
-        ImmutableOpenMap<String, List<AliasMetadata>> result = TransportGetAliasesAction.postProcess(
+        Map<String, List<AliasMetadata>> result = TransportGetAliasesAction.postProcess(
             request,
             concreteIndices,
             aliases,
@@ -170,7 +171,7 @@ public class TransportGetAliasesActionTests extends ESTestCase {
             .build();
         final String[] concreteIndices = { "a", ".b", "c" };
         assertEquals(state.metadata().findAliases(request.aliases(), concreteIndices), aliases);
-        ImmutableOpenMap<String, List<AliasMetadata>> result = TransportGetAliasesAction.postProcess(
+        Map<String, List<AliasMetadata>> result = TransportGetAliasesAction.postProcess(
             request,
             concreteIndices,
             aliases,
@@ -200,7 +201,7 @@ public class TransportGetAliasesActionTests extends ESTestCase {
             .build();
         final String[] concreteIndices = { "a", ".b", "c" };
         assertEquals(state.metadata().findAliases(request.aliases(), concreteIndices), aliases);
-        ImmutableOpenMap<String, List<AliasMetadata>> result = TransportGetAliasesAction.postProcess(
+        Map<String, List<AliasMetadata>> result = TransportGetAliasesAction.postProcess(
             request,
             concreteIndices,
             aliases,
@@ -226,7 +227,7 @@ public class TransportGetAliasesActionTests extends ESTestCase {
             .build();
         final String[] concreteIndices = { "c" };
         assertEquals(state.metadata().findAliases(request.aliases(), concreteIndices), aliases);
-        ImmutableOpenMap<String, List<AliasMetadata>> result = TransportGetAliasesAction.postProcess(
+        Map<String, List<AliasMetadata>> result = TransportGetAliasesAction.postProcess(
             request,
             concreteIndices,
             aliases,
@@ -302,11 +303,10 @@ public class TransportGetAliasesActionTests extends ESTestCase {
         final IndexNameExpressionResolver indexNameExpressionResolver = new IndexNameExpressionResolver(threadContext, systemIndices);
         concreteIndices = indexNameExpressionResolver.concreteIndexNamesWithSystemIndexAccess(clusterState, aliasesRequest);
 
-        ImmutableOpenMap<String, List<AliasMetadata>> initialAliases = ImmutableOpenMap.<String, List<AliasMetadata>>builder().build();
-        ImmutableOpenMap<String, List<AliasMetadata>> finalResponse = TransportGetAliasesAction.postProcess(
+        Map<String, List<AliasMetadata>> finalResponse = TransportGetAliasesAction.postProcess(
             aliasesRequest,
             concreteIndices,
-            initialAliases,
+            Map.of(),
             clusterState,
             SystemIndexAccessLevel.NONE,
             threadContext,


### PR DESCRIPTION
Actions for getting aliases, indices, and settings all return a Map. Yet
internally these unnecessarily ImmutableOpenMap. This commit converts
these actions to use HashMap.

relates #86239