### PR TITLE
Improve console exception messages

### DIFF
--- a/docs/changelog/87942.yaml
+++ b/docs/changelog/87942.yaml
@@ -1,0 +1,5 @@
+pr: 87942
+summary: Improve console exception messages
+area: Infra/Core
+type: enhancement
+issues: []

--- a/server/src/main/java/org/elasticsearch/bootstrap/StartupException.java
+++ b/server/src/main/java/org/elasticsearch/bootstrap/StartupException.java
@@ -27,7 +27,7 @@ public final class StartupException extends Exception {
     /** all lines from this package are RLE-compressed */
     static final String GUICE_PACKAGE = "org.elasticsearch.common.inject";
 
-    StartupException(Throwable cause) {
+    public StartupException(Throwable cause) {
         super(Objects.requireNonNull(cause));
     }
 

--- a/server/src/main/java/org/elasticsearch/common/logging/ConsoleThrowablePatternConverter.java
+++ b/server/src/main/java/org/elasticsearch/common/logging/ConsoleThrowablePatternConverter.java
@@ -46,13 +46,27 @@ public class ConsoleThrowablePatternConverter extends ThrowablePatternConverter 
         }
         if (error instanceof StartupException e) {
             error = e.getCause();
+            toAppendTo.append("\n\nElasticsearch failed to startup normally.\n\n");
         }
-        toAppendTo.append("\n\nElasticsearch failed to startup normally.\n\n");
+        appendShortStacktrace(error, toAppendTo);
         if (error instanceof CreationException) {
             toAppendTo.append("There were problems initializing Guice. See log for more details.");
         } else {
-            toAppendTo.append(error.getMessage());
             toAppendTo.append("\n\nSee logs for more details.\n");
+        }
+    }
+
+    // prints a very truncated stack trace, leaving the rest of the details for the log
+    private static void appendShortStacktrace(Throwable error, StringBuilder toAppendTo) {
+        toAppendTo.append(error.getClass().getName());
+        toAppendTo.append(": ");
+        toAppendTo.append(error.getMessage());
+
+        var stacktrace = error.getStackTrace();
+        int len = Math.min(stacktrace.length, 5);
+        for (int i = 0; i < len; ++i) {
+            toAppendTo.append("\n\tat ");
+            toAppendTo.append(stacktrace[i].toString());
         }
     }
 }

--- a/server/src/test/java/org/elasticsearch/common/logging/ConsoleThrowablePatternConverterTest.java
+++ b/server/src/test/java/org/elasticsearch/common/logging/ConsoleThrowablePatternConverterTest.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.common.logging;
+
+import org.apache.logging.log4j.core.LogEvent;
+import org.apache.logging.log4j.core.impl.Log4jLogEvent;
+import org.elasticsearch.bootstrap.StartupException;
+import org.elasticsearch.common.inject.CreationException;
+import org.elasticsearch.common.inject.spi.Message;
+import org.elasticsearch.test.ESTestCase;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.emptyString;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.not;
+
+public class ConsoleThrowablePatternConverterTest extends ESTestCase {
+    static final ConsoleThrowablePatternConverter converter = ConsoleThrowablePatternConverter.newInstance(null, null);
+
+    String format(Throwable e) {
+        LogEvent event = Log4jLogEvent.newBuilder().setThrown(e).build();
+        var builder = new StringBuilder();
+        converter.format(event, builder);
+        return builder.toString();
+    }
+
+    public void testNoException() {
+        assertThat(format(null), emptyString());
+    }
+
+    public void testStartupExceptionUnwrapped() {
+        var e = new StartupException(new RuntimeException("an error"));
+        assertThat(
+            format(e),
+            allOf(
+                containsString("Elasticsearch failed to startup normally"),
+                not(containsString("StartupException: ")),
+                containsString("RuntimeException: ")
+            )
+        );
+    }
+
+    public void testCreationException() {
+        var e = new CreationException(List.of(new Message("injection problem")));
+        assertThat(format(e), containsString("There were problems initializing Guice"));
+    }
+
+    public void testStackTruncation() {
+        var e = new NullPointerException();
+        var stacktrace = e.getStackTrace();
+        String output = format(e);
+        String[] lines = output.split("\n");
+        assertThat(lines.length, greaterThan(5));
+        assertThat(lines[0], equalTo("java.lang.NullPointerException: null"));
+        for (int i = 0; i < 5; ++i) {
+            assertThat(lines[i + 1], equalTo("\tat " + stacktrace[i]));
+        }
+        assertThat(lines[6], emptyString());
+    }
+
+    public void testShortStack() {
+        var e = new NullPointerException();
+        StackTraceElement[] stacktrace = Arrays.copyOf(e.getStackTrace(), randomIntBetween(1, 4));
+        e.setStackTrace(stacktrace);
+        String output = format(e);
+        String[] lines = output.split("\n");
+        assertThat(lines.length, greaterThan(stacktrace.length + 2));
+        assertThat(lines[0], equalTo("java.lang.NullPointerException: null"));
+        for (int i = 0; i < stacktrace.length; ++i) {
+            assertThat(lines[i + 1], equalTo("\tat " + stacktrace[i]));
+        }
+        assertThat(lines[stacktrace.length + 1], emptyString());
+    }
+}

--- a/server/src/test/java/org/elasticsearch/common/logging/ConsoleThrowablePatternConverterTests.java
+++ b/server/src/test/java/org/elasticsearch/common/logging/ConsoleThrowablePatternConverterTests.java
@@ -25,7 +25,7 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.not;
 
-public class ConsoleThrowablePatternConverterTest extends ESTestCase {
+public class ConsoleThrowablePatternConverterTests extends ESTestCase {
     static final ConsoleThrowablePatternConverter converter = ConsoleThrowablePatternConverter.newInstance(null, null);
 
     String format(Throwable e) {


### PR DESCRIPTION
This commit improves upon the recent console exception logging isolation
to emit more than just the exception message. The exception class is
also printed, as well as up to the first 5 elements of the stack. THe
stack trace is a hint, and can often be enough, yet the full stack trace
(or a truncated version if a guice exception) will still exist in the
logs. Addtionally, unit tests are added.