### PR TITLE
[7.17] Fix byte unit typo in ILM rollover doc (#87780)

### DIFF
--- a/docs/reference/ilm/actions/ilm-rollover.asciidoc
+++ b/docs/reference/ilm/actions/ilm-rollover.asciidoc
@@ -222,7 +222,7 @@ PUT /_ilm/policy/rollover_policy
       "hot": {
         "actions": {
           "rollover": {
-            "max_size": "50G"
+            "max_size": "50GB"
           }
         }
       },


### PR DESCRIPTION
Backports the following commits to 7.17:
 - Fix byte unit typo in ILM rollover doc (#87780)