### PR TITLE
[8.2] Support removing ignore filters for audit logging (#87675)

### DIFF
--- a/docs/changelog/87675.yaml
+++ b/docs/changelog/87675.yaml
@@ -1,0 +1,6 @@
+pr: 87675
+summary: Support removing ignore filters for audit logging
+area: Audit
+type: bug
+issues:
+  - 68588

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/audit/logfile/LoggingAuditTrail.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/audit/logfile/LoggingAuditTrail.java
@@ -399,32 +399,24 @@ public class LoggingAuditTrail implements AuditTrail, ClusterStateListener {
                 INCLUDE_REQUEST_BODY
             )
         );
-        clusterService.getClusterSettings().addAffixUpdateConsumer(FILTER_POLICY_IGNORE_PRINCIPALS, (policyName, filtersList) -> {
-            final Optional<EventFilterPolicy> policy = eventFilterPolicyRegistry.get(policyName);
-            final EventFilterPolicy newPolicy = policy.orElse(new EventFilterPolicy(policyName, settings))
-                .changePrincipalsFilter(filtersList);
-            this.eventFilterPolicyRegistry.set(policyName, newPolicy);
-        }, (policyName, filtersList) -> EventFilterPolicy.parsePredicate(filtersList));
-        clusterService.getClusterSettings().addAffixUpdateConsumer(FILTER_POLICY_IGNORE_REALMS, (policyName, filtersList) -> {
-            final Optional<EventFilterPolicy> policy = eventFilterPolicyRegistry.get(policyName);
-            final EventFilterPolicy newPolicy = policy.orElse(new EventFilterPolicy(policyName, settings)).changeRealmsFilter(filtersList);
-            this.eventFilterPolicyRegistry.set(policyName, newPolicy);
-        }, (policyName, filtersList) -> EventFilterPolicy.parsePredicate(filtersList));
-        clusterService.getClusterSettings().addAffixUpdateConsumer(FILTER_POLICY_IGNORE_ROLES, (policyName, filtersList) -> {
-            final Optional<EventFilterPolicy> policy = eventFilterPolicyRegistry.get(policyName);
-            final EventFilterPolicy newPolicy = policy.orElse(new EventFilterPolicy(policyName, settings)).changeRolesFilter(filtersList);
-            this.eventFilterPolicyRegistry.set(policyName, newPolicy);
-        }, (policyName, filtersList) -> EventFilterPolicy.parsePredicate(filtersList));
-        clusterService.getClusterSettings().addAffixUpdateConsumer(FILTER_POLICY_IGNORE_INDICES, (policyName, filtersList) -> {
-            final Optional<EventFilterPolicy> policy = eventFilterPolicyRegistry.get(policyName);
-            final EventFilterPolicy newPolicy = policy.orElse(new EventFilterPolicy(policyName, settings)).changeIndicesFilter(filtersList);
-            this.eventFilterPolicyRegistry.set(policyName, newPolicy);
-        }, (policyName, filtersList) -> EventFilterPolicy.parsePredicate(filtersList));
-        clusterService.getClusterSettings().addAffixUpdateConsumer(FILTER_POLICY_IGNORE_ACTIONS, (policyName, filtersList) -> {
-            final Optional<EventFilterPolicy> policy = eventFilterPolicyRegistry.get(policyName);
-            final EventFilterPolicy newPolicy = policy.orElse(new EventFilterPolicy(policyName, settings)).changeActionsFilter(filtersList);
-            this.eventFilterPolicyRegistry.set(policyName, newPolicy);
-        }, (policyName, filtersList) -> EventFilterPolicy.parsePredicate(filtersList));
+        clusterService.getClusterSettings()
+            .addAffixGroupUpdateConsumer(
+                List.of(
+                    FILTER_POLICY_IGNORE_PRINCIPALS,
+                    FILTER_POLICY_IGNORE_REALMS,
+                    FILTER_POLICY_IGNORE_ROLES,
+                    FILTER_POLICY_IGNORE_INDICES,
+                    FILTER_POLICY_IGNORE_ACTIONS
+                ),
+                (policyName, updatedSettings) -> {
+                    if (updatedSettings.keySet().isEmpty()) {
+                        this.eventFilterPolicyRegistry.remove(policyName);
+                    } else {
+                        this.eventFilterPolicyRegistry.set(policyName, new EventFilterPolicy(policyName, updatedSettings));
+                    }
+                }
+            );
+
         // this log filter ensures that audit events are not filtered out because of the log level
         final LoggerContext ctx = LoggerContext.getContext(false);
         MarkerFilter auditMarkerFilter = MarkerFilter.createFilter(AUDIT_MARKER.getName(), Result.ACCEPT, Result.NEUTRAL);
@@ -1660,92 +1652,21 @@ public class LoggingAuditTrail implements AuditTrail, ClusterStateListener {
         private final Predicate<String> ignoreIndicesPredicate;
         private final Predicate<String> ignoreActionsPredicate;
 
-        EventFilterPolicy(String name, Settings settings) {
-            this(
-                name,
-                parsePredicate(FILTER_POLICY_IGNORE_PRINCIPALS.getConcreteSettingForNamespace(name).get(settings)),
-                parsePredicate(FILTER_POLICY_IGNORE_REALMS.getConcreteSettingForNamespace(name).get(settings)),
-                parsePredicate(FILTER_POLICY_IGNORE_ROLES.getConcreteSettingForNamespace(name).get(settings)),
-                parsePredicate(FILTER_POLICY_IGNORE_INDICES.getConcreteSettingForNamespace(name).get(settings)),
-                parsePredicate(FILTER_POLICY_IGNORE_ACTIONS.getConcreteSettingForNamespace(name).get(settings))
-            );
-        }
-
         /**
          * An empty filter list for a field will match events with that field missing.
          * An event with an undefined field has the field value the empty string ("") or
          * a singleton list of the empty string ([""]).
          */
-        EventFilterPolicy(
-            String name,
-            Predicate<String> ignorePrincipalsPredicate,
-            Predicate<String> ignoreRealmsPredicate,
-            Predicate<String> ignoreRolesPredicate,
-            Predicate<String> ignoreIndicesPredicate,
-            Predicate<String> ignoreActionsPredicate
-        ) {
+        EventFilterPolicy(String name, Settings settings) {
             this.name = name;
             // "null" values are "unexpected" and should not match any ignore policy
-            this.ignorePrincipalsPredicate = ignorePrincipalsPredicate;
-            this.ignoreRealmsPredicate = ignoreRealmsPredicate;
-            this.ignoreRolesPredicate = ignoreRolesPredicate;
-            this.ignoreIndicesPredicate = ignoreIndicesPredicate;
-            this.ignoreActionsPredicate = ignoreActionsPredicate;
-        }
-
-        private EventFilterPolicy changePrincipalsFilter(List<String> filtersList) {
-            return new EventFilterPolicy(
-                name,
-                parsePredicate(filtersList),
-                ignoreRealmsPredicate,
-                ignoreRolesPredicate,
-                ignoreIndicesPredicate,
-                ignoreActionsPredicate
+            this.ignorePrincipalsPredicate = parsePredicate(
+                FILTER_POLICY_IGNORE_PRINCIPALS.getConcreteSettingForNamespace(name).get(settings)
             );
-        }
-
-        private EventFilterPolicy changeRealmsFilter(List<String> filtersList) {
-            return new EventFilterPolicy(
-                name,
-                ignorePrincipalsPredicate,
-                parsePredicate(filtersList),
-                ignoreRolesPredicate,
-                ignoreIndicesPredicate,
-                ignoreActionsPredicate
-            );
-        }
-
-        private EventFilterPolicy changeRolesFilter(List<String> filtersList) {
-            return new EventFilterPolicy(
-                name,
-                ignorePrincipalsPredicate,
-                ignoreRealmsPredicate,
-                parsePredicate(filtersList),
-                ignoreIndicesPredicate,
-                ignoreActionsPredicate
-            );
-        }
-
-        private EventFilterPolicy changeIndicesFilter(List<String> filtersList) {
-            return new EventFilterPolicy(
-                name,
-                ignorePrincipalsPredicate,
-                ignoreRealmsPredicate,
-                ignoreRolesPredicate,
-                parsePredicate(filtersList),
-                ignoreActionsPredicate
-            );
-        }
-
-        private EventFilterPolicy changeActionsFilter(List<String> filtersList) {
-            return new EventFilterPolicy(
-                name,
-                ignorePrincipalsPredicate,
-                ignoreRealmsPredicate,
-                ignoreRolesPredicate,
-                ignoreIndicesPredicate,
-                parsePredicate(filtersList)
-            );
+            this.ignoreRealmsPredicate = parsePredicate(FILTER_POLICY_IGNORE_REALMS.getConcreteSettingForNamespace(name).get(settings));
+            this.ignoreRolesPredicate = parsePredicate(FILTER_POLICY_IGNORE_ROLES.getConcreteSettingForNamespace(name).get(settings));
+            this.ignoreIndicesPredicate = parsePredicate(FILTER_POLICY_IGNORE_INDICES.getConcreteSettingForNamespace(name).get(settings));
+            this.ignoreActionsPredicate = parsePredicate(FILTER_POLICY_IGNORE_ACTIONS.getConcreteSettingForNamespace(name).get(settings));
         }
 
         static Predicate<String> parsePredicate(List<String> l) {
@@ -1816,12 +1737,14 @@ public class LoggingAuditTrail implements AuditTrail, ClusterStateListener {
             predicate = buildIgnorePredicate(policyMap);
         }
 
-        private Optional<EventFilterPolicy> get(String policyName) {
-            return Optional.ofNullable(policyMap.get(policyName));
-        }
-
         private synchronized void set(String policyName, EventFilterPolicy eventFilterPolicy) {
             policyMap = Maps.copyMapWithAddedOrReplacedEntry(policyMap, policyName, eventFilterPolicy);
+            // precompute predicate
+            predicate = buildIgnorePredicate(policyMap);
+        }
+
+        private synchronized void remove(String policyName) {
+            policyMap = Maps.copyMapWithRemovedEntry(policyMap, policyName);
             // precompute predicate
             predicate = buildIgnorePredicate(policyMap);
         }

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/audit/logfile/LoggingAuditTrailFilterTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/audit/logfile/LoggingAuditTrailFilterTests.java
@@ -34,6 +34,7 @@ import org.elasticsearch.xpack.core.security.audit.logfile.CapturingLogger;
 import org.elasticsearch.xpack.core.security.authc.Authentication;
 import org.elasticsearch.xpack.core.security.authc.Authentication.RealmRef;
 import org.elasticsearch.xpack.core.security.authc.AuthenticationField;
+import org.elasticsearch.xpack.core.security.authc.AuthenticationTests;
 import org.elasticsearch.xpack.core.security.authc.AuthenticationToken;
 import org.elasticsearch.xpack.core.security.authz.AuthorizationEngine.AuthorizationInfo;
 import org.elasticsearch.xpack.core.security.user.SystemUser;
@@ -2808,7 +2809,7 @@ public class LoggingAuditTrailFilterTests extends ESTestCase {
                 realmName != null ? realmName : randomAlphaOfLengthBetween(3, 10),
                 randomAlphaOfLengthBetween(3, 10),
                 randomAlphaOfLengthBetween(3, 8),
-                randomFrom(AuthenticationTestHelper.randomDomain(randomBoolean()), null)
+                randomFrom(AuthenticationTests.randomDomain(randomBoolean()), null)
             )
         );
         final MockIndicesRequest request = new MockIndicesRequest(

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/audit/logfile/LoggingAuditTrailFilterTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/audit/logfile/LoggingAuditTrailFilterTests.java
@@ -76,6 +76,7 @@ public class LoggingAuditTrailFilterTests extends ESTestCase {
     private Settings settings;
     private DiscoveryNode localNode;
     private ClusterService clusterService;
+    private ClusterSettings clusterSettings;
     private ApiKeyService apiKeyService;
 
     @Before
@@ -101,7 +102,7 @@ public class LoggingAuditTrailFilterTests extends ESTestCase {
         when(clusterService.getClusterName()).thenReturn(ClusterName.CLUSTER_NAME_SETTING.get(settings));
         when(clusterService.lifecycleState()).thenReturn(Lifecycle.State.STARTED);
         when(clusterService.state()).thenReturn(clusterState);
-        final ClusterSettings clusterSettings = mockClusterSettings();
+        clusterSettings = mockClusterSettings();
         when(clusterService.getClusterSettings()).thenReturn(clusterSettings);
         Mockito.doAnswer((Answer) invocation -> {
             final LoggingAuditTrail arg0 = (LoggingAuditTrail) invocation.getArguments()[0];
@@ -2730,6 +2731,110 @@ public class LoggingAuditTrailFilterTests extends ESTestCase {
 
         auditTrail.authenticationSuccess(randomAlphaOfLength(8), createAuthentication(user, "realm"), unfilteredAction, request);
         assertThat("AuthenticationSuccess message: unfiltered action is filtered out", logOutput.size(), is(1));
+        logOutput.clear();
+        threadContext.stashContext();
+    }
+
+    public void testRemoveIgnoreFilter() throws IllegalAccessException, IOException {
+        final Logger logger = CapturingLogger.newCapturingLogger(Level.INFO, null);
+        final ThreadContext threadContext = new ThreadContext(Settings.EMPTY);
+
+        final String policyName = randomAlphaOfLengthBetween(5, 8);
+        final List<String> filteredUsers = randomNonEmptyListOfFilteredNames();
+        final List<String> filteredRoles = randomNonEmptyListOfFilteredNames();
+        final List<String> filteredRealms = randomNonEmptyListOfFilteredNames();
+        final List<String> filteredIndices = randomNonEmptyListOfFilteredNames();
+        final List<String> filteredActions = randomNonEmptyListOfFilteredActions();
+
+        // First create an auditTrail with no filtering
+        final LoggingAuditTrail auditTrail = new LoggingAuditTrail(
+            Settings.builder().put(settings).build(),
+            clusterService,
+            logger,
+            threadContext
+        );
+        final List<String> logOutput = CapturingLogger.output(logger.getName(), Level.INFO);
+
+        // First create a working ignore filter
+        final Settings.Builder settingsBuilder = Settings.builder();
+        final String username;
+        if (randomBoolean()) {
+            settingsBuilder.putList("xpack.security.audit.logfile.events.ignore_filters." + policyName + ".users", filteredUsers);
+            username = randomFrom(filteredUsers);
+        } else {
+            username = null;
+        }
+
+        final String realmName;
+        if (randomBoolean()) {
+            settingsBuilder.putList("xpack.security.audit.logfile.events.ignore_filters." + policyName + ".realms", filteredRealms);
+            realmName = randomFrom(filteredRealms);
+        } else {
+            realmName = null;
+        }
+
+        final String roleName;
+        if (randomBoolean()) {
+            settingsBuilder.putList("xpack.security.audit.logfile.events.ignore_filters." + policyName + ".roles", filteredRoles);
+            roleName = randomFrom(filteredRoles);
+        } else {
+            roleName = null;
+        }
+
+        final String indexName;
+        if (randomBoolean()) {
+            settingsBuilder.putList("xpack.security.audit.logfile.events.ignore_filters." + policyName + ".indices", filteredIndices);
+            indexName = randomFrom(filteredIndices);
+        } else {
+            indexName = null;
+        }
+
+        // If nothing is filtered so far due to randomisation, always filter on action name
+        final String actionName;
+        if (randomBoolean() || (username == null && realmName == null && roleName == null && indexName == null)) {
+            settingsBuilder.putList("xpack.security.audit.logfile.events.ignore_filters." + policyName + ".actions", filteredActions);
+            actionName = randomFrom(filteredActions);
+        } else {
+            actionName = null;
+        }
+
+        final String requestId = randomAlphaOfLength(10);
+        final Authentication authentication = Authentication.newRealmAuthentication(
+            new User(
+                username != null ? username : randomAlphaOfLengthBetween(3, 10),
+                roleName != null ? roleName : randomAlphaOfLengthBetween(3, 10)
+            ),
+            new RealmRef(
+                realmName != null ? realmName : randomAlphaOfLengthBetween(3, 10),
+                randomAlphaOfLengthBetween(3, 10),
+                randomAlphaOfLengthBetween(3, 8),
+                randomFrom(AuthenticationTestHelper.randomDomain(randomBoolean()), null)
+            )
+        );
+        final MockIndicesRequest request = new MockIndicesRequest(
+            threadContext,
+            indexName != null ? indexName : randomAlphaOfLengthBetween(3, 10)
+        );
+        final AuthorizationInfo authorizationInfo = authzInfo(authentication.getUser().roles());
+        final String action = actionName != null ? actionName : randomAlphaOfLengthBetween(3, 10);
+
+        // Filter not created yet, message should be logged
+        auditTrail.accessGranted(requestId, authentication, action, request, authorizationInfo);
+        assertThat("AccessGranted message: should not filter since we have no filter", logOutput.size(), is(1));
+        logOutput.clear();
+        threadContext.stashContext();
+
+        // Create the filter, the same message should be filtered
+        clusterSettings.applySettings(settingsBuilder.build());
+        auditTrail.accessGranted(requestId, authentication, action, request, authorizationInfo);
+        assertThat("AccessGranted message: should be filtered out", logOutput.size(), is(0));
+        logOutput.clear();
+        threadContext.stashContext();
+
+        // Remove the filter, the message is logged again
+        clusterSettings.applySettings(Settings.EMPTY);
+        auditTrail.accessGranted(requestId, authentication, action, request, authorizationInfo);
+        assertThat("AccessGranted message: should not filter since filter is removed", logOutput.size(), is(1));
         logOutput.clear();
         threadContext.stashContext();
     }


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `8.2`:
 - [Support removing ignore filters for audit logging (#87675)](https://github.com/elastic/elasticsearch/pull/87675)

<!--- Backport version: 8.8.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)