### PR TITLE
Fix StableMasterHealthIndicatorServiceTests and `start-slm` doc test

### DIFF
--- a/docs/reference/tab-widgets/troubleshooting/data/start-ilm.asciidoc
+++ b/docs/reference/tab-widgets/troubleshooting/data/start-ilm.asciidoc
@@ -94,6 +94,7 @@ The reponse will look like this:
   "operation_mode": "RUNNING"
 }
 ----
+// TESTRESPONSE[skip:the result is for illustrating purposes only]
 
 // end::self-managed[]
 

--- a/docs/reference/tab-widgets/troubleshooting/data/start-slm.asciidoc
+++ b/docs/reference/tab-widgets/troubleshooting/data/start-slm.asciidoc
@@ -84,4 +84,5 @@ The reponse will look like this:
   "operation_mode": "RUNNING"
 }
 ----
+// TESTRESPONSE[skip:the result is for illustrating purposes only]
 // end::self-managed[]

--- a/server/src/main/java/org/elasticsearch/cluster/coordination/StableMasterHealthIndicatorService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/StableMasterHealthIndicatorService.java
@@ -39,6 +39,14 @@ public class StableMasterHealthIndicatorService implements HealthIndicatorServic
     public static final String NAME = "master_is_stable";
     private static final String HELP_URL = "https://ela.st/fix-master";
     public static final String GET_HELP_GUIDE = "https://ela.st/getting-help";
+    public static final UserAction CONTACT_SUPPORT_USER_ACTION = new UserAction(
+        new UserAction.Definition(
+            "contact_support",
+            "The Elasticsearch cluster does not have a stable master node. Get help at " + GET_HELP_GUIDE,
+            GET_HELP_GUIDE
+        ),
+        null
+    );
 
     private final CoordinationDiagnosticsService coordinationDiagnosticsService;
 
@@ -175,13 +183,7 @@ public class StableMasterHealthIndicatorService implements HealthIndicatorServic
      */
     private List<UserAction> getContactSupportUserActions(boolean explain) {
         if (explain) {
-            UserAction.Definition contactSupport = new UserAction.Definition(
-                "contact_support",
-                "The Elasticsearch cluster does not have a stable master node. Get help at " + GET_HELP_GUIDE,
-                GET_HELP_GUIDE
-            );
-            UserAction userAction = new UserAction(contactSupport, null);
-            return List.of(userAction);
+            return List.of(CONTACT_SUPPORT_USER_ACTION);
         } else {
             return List.of();
         }

--- a/server/src/test/java/org/elasticsearch/cluster/coordination/StableMasterHealthIndicatorServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/coordination/StableMasterHealthIndicatorServiceTests.java
@@ -41,9 +41,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
-import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.emptyOrNullString;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -125,7 +125,7 @@ public class StableMasterHealthIndicatorServiceTests extends AbstractCoordinator
         }
         List<UserAction> userActions = result.userActions();
         assertThat(userActions.size(), equalTo(1));
-        assertThat(userActions.get(0).definition().message(), containsString("contact Elastic Support"));
+        assertThat(userActions.get(0), is(StableMasterHealthIndicatorService.CONTACT_SUPPORT_USER_ACTION));
         assertThat(result.helpURL(), equalTo("https://ela.st/fix-master"));
     }
 


### PR DESCRIPTION
This fixes `StableMasterHealthIndicatorServiceTests` and the `start-slm` doc test.