### PR TITLE
Run TransportClusterInfoActions on MANAGEMENT pool

### DIFF
--- a/docs/changelog/87679.yaml
+++ b/docs/changelog/87679.yaml
@@ -1,0 +1,5 @@
+pr: 87679
+summary: Run `TransportClusterInfoActions` on MANAGEMENT pool
+area: Stats
+type: bug
+issues: []

--- a/server/src/main/java/org/elasticsearch/action/support/master/info/TransportClusterInfoAction.java
+++ b/server/src/main/java/org/elasticsearch/action/support/master/info/TransportClusterInfoAction.java
@@ -43,7 +43,7 @@ public abstract class TransportClusterInfoAction<Request extends ClusterInfoRequ
             request,
             indexNameExpressionResolver,
             response,
-            ThreadPool.Names.SAME
+            ThreadPool.Names.MANAGEMENT
         );
     }
 


### PR DESCRIPTION
Today subclasses of `TransportClusterInfoAction` execute
`masterOperation` on `SAME` which often means a transport worker. This
includes nontrivial things like decompressing mappings in
`TransportGetMappingsAction` and `TransportGetIndexAction` (if a field
filter is specified) and iterating over index settings and aliases in
`TransportGetIndexAction`.

This commit moves this work to the `MANAGEMENT` threadpool instead.

Backport of #87679