### PR TITLE
Speedup setting default values a little

### DIFF
--- a/modules/repository-azure/src/main/java/org/elasticsearch/repositories/azure/AzureRepository.java
+++ b/modules/repository-azure/src/main/java/org/elasticsearch/repositories/azure/AzureRepository.java
@@ -67,7 +67,7 @@ public class AzureRepository extends MeteredBlobStoreRepository {
         public static final Setting<String> BASE_PATH_SETTING = Setting.simpleString("base_path", Property.NodeScope);
         public static final Setting<LocationMode> LOCATION_MODE_SETTING = new Setting<>(
             "location_mode",
-            s -> LocationMode.PRIMARY_ONLY.toString(),
+            LocationMode.PRIMARY_ONLY.toString(),
             s -> LocationMode.valueOf(s.toUpperCase(Locale.ROOT)),
             Property.NodeScope
         );

--- a/server/src/main/java/org/elasticsearch/index/IndexSettings.java
+++ b/server/src/main/java/org/elasticsearch/index/IndexSettings.java
@@ -348,7 +348,7 @@ public final class IndexSettings {
      **/
     public static final Setting<TimeValue> INDEX_TRANSLOG_RETENTION_AGE_SETTING = Setting.timeSetting(
         "index.translog.retention.age",
-        settings -> TimeValue.MINUS_ONE,
+        TimeValue.MINUS_ONE,
         TimeValue.MINUS_ONE,
         Property.Dynamic,
         Property.IndexScope

--- a/server/src/main/java/org/elasticsearch/index/fielddata/IndexFieldDataService.java
+++ b/server/src/main/java/org/elasticsearch/index/fielddata/IndexFieldDataService.java
@@ -34,12 +34,10 @@ public class IndexFieldDataService extends AbstractIndexComponent implements Clo
     public static final String FIELDDATA_CACHE_KEY = "index.fielddata.cache";
     public static final Setting<String> INDEX_FIELDDATA_CACHE_KEY = new Setting<>(
         FIELDDATA_CACHE_KEY,
-        (s) -> FIELDDATA_CACHE_VALUE_NODE,
-        (s) -> {
-            return switch (s) {
-                case "node", "none" -> s;
-                default -> throw new IllegalArgumentException("failed to parse [" + s + "] must be one of [node,none]");
-            };
+        FIELDDATA_CACHE_VALUE_NODE,
+        (s) -> switch (s) {
+        case "node", "none" -> s;
+        default -> throw new IllegalArgumentException("failed to parse [" + s + "] must be one of [node,none]");
         },
         Property.IndexScope
     );

--- a/server/src/main/java/org/elasticsearch/indices/recovery/RecoverySettings.java
+++ b/server/src/main/java/org/elasticsearch/indices/recovery/RecoverySettings.java
@@ -128,7 +128,7 @@ public class RecoverySettings {
      * Bandwidth settings have a default value of -1 (meaning that they are undefined) or a value in (0, Long.MAX_VALUE).
      */
     private static Setting<ByteSizeValue> bandwidthSetting(String key) {
-        return new Setting<>(key, s -> ByteSizeValue.MINUS_ONE.getStringRep(), s -> {
+        return new Setting<>(key, ByteSizeValue.MINUS_ONE.getStringRep(), s -> {
             final ByteSizeValue value = ByteSizeValue.parseBytesSizeValue(s, key);
             if (ByteSizeValue.MINUS_ONE.equals(value)) {
                 return value;

--- a/server/src/main/java/org/elasticsearch/threadpool/FixedExecutorBuilder.java
+++ b/server/src/main/java/org/elasticsearch/threadpool/FixedExecutorBuilder.java
@@ -65,7 +65,7 @@ public final class FixedExecutorBuilder extends ExecutorBuilder<FixedExecutorBui
         final String sizeKey = settingsKey(prefix, "size");
         this.sizeSetting = new Setting<>(
             sizeKey,
-            s -> Integer.toString(size),
+            Integer.toString(size),
             s -> Setting.parseInt(s, 1, applyHardSizeLimit(settings, name), sizeKey),
             Setting.Property.NodeScope
         );

--- a/x-pack/plugin/autoscaling/src/main/java/org/elasticsearch/xpack/autoscaling/shards/FrozenShardsDeciderService.java
+++ b/x-pack/plugin/autoscaling/src/main/java/org/elasticsearch/xpack/autoscaling/shards/FrozenShardsDeciderService.java
@@ -38,7 +38,7 @@ public class FrozenShardsDeciderService implements AutoscalingDeciderService {
     static final ByteSizeValue DEFAULT_MEMORY_PER_SHARD = ByteSizeValue.ofBytes(MAX_MEMORY.getBytes() / 2000);
     public static final Setting<ByteSizeValue> MEMORY_PER_SHARD = Setting.byteSizeSetting(
         "memory_per_shard",
-        (ignored) -> DEFAULT_MEMORY_PER_SHARD.getStringRep(),
+        DEFAULT_MEMORY_PER_SHARD,
         ByteSizeValue.ZERO,
         ByteSizeValue.ofBytes(Long.MAX_VALUE)
     );

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/license/LicenseService.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/license/LicenseService.java
@@ -68,7 +68,7 @@ public class LicenseService extends AbstractLifecycleComponent implements Cluste
 
     public static final Setting<License.LicenseType> SELF_GENERATED_LICENSE_TYPE = new Setting<>(
         "xpack.license.self_generated.type",
-        (s) -> License.LicenseType.BASIC.getTypeName(),
+        License.LicenseType.BASIC.getTypeName(),
         (s) -> {
             final License.LicenseType type = License.LicenseType.parse(s);
             return SelfGeneratedLicense.validateSelfGeneratedType(type);

--- a/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/SearchableSnapshots.java
+++ b/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/SearchableSnapshots.java
@@ -205,8 +205,8 @@ public class SearchableSnapshots extends Plugin implements IndexStorePlugin, Eng
     public static final String SNAPSHOT_BLOB_CACHE_INDEX_PATTERN = SNAPSHOT_BLOB_CACHE_INDEX + "*";
     public static final String SNAPSHOT_BLOB_CACHE_METADATA_FILES_MAX_LENGTH = "index.store.snapshot.blob_cache.metadata_files.max_length";
     public static final Setting<ByteSizeValue> SNAPSHOT_BLOB_CACHE_METADATA_FILES_MAX_LENGTH_SETTING = new Setting<>(
-        new Setting.SimpleKey(SNAPSHOT_BLOB_CACHE_METADATA_FILES_MAX_LENGTH),
-        s -> new ByteSizeValue(64L, ByteSizeUnit.KB).getStringRep(),
+        SNAPSHOT_BLOB_CACHE_METADATA_FILES_MAX_LENGTH,
+        new ByteSizeValue(64L, ByteSizeUnit.KB).getStringRep(),
         s -> Setting.parseByteSize(
             s,
             new ByteSizeValue(1L, ByteSizeUnit.KB),


### PR DESCRIPTION
Many shards benchmarks have recently seen a bit of an increase in the time spent on
settings from new settings getting added. This makes some defaults quite a bit
cheaper by saving re-serialization of the same default value when its not a function
of the settings instance which helps with some cluster state application cases for large index counts.

relates #77466 