### PR TITLE
[DOCS] Remove user profile API link

### DIFF
--- a/x-pack/docs/en/security/authorization/built-in-roles.asciidoc
+++ b/x-pack/docs/en/security/authorization/built-in-roles.asciidoc
@@ -85,7 +85,7 @@ This role does not have access to editing tools in {kib}.
 Grants access necessary for the {kib} system user to read from and write to the
 {kib} indices, manage index templates and tokens, and check the availability of
 the {es} cluster. It also permits
-<<security-user-profile-apis,activating, searching, and retrieving user profiles>>,
+activating, searching, and retrieving user profiles,
 as well as updating user profile data for the `kibana-*` namespace.
 This role grants read access to the `.monitoring-*` indices and read and write
 access to the `.reporting-*` indices. For more information,


### PR DESCRIPTION
This temporarily removes a link from the [Built in roles](https://www.elastic.co/guide/en/elasticsearch/reference/master/built-in-roles.html) docs page in order to resolve a docs build break.

```
13:28:53 INFO:build_docs:asciidoctor: WARNING: invalid reference: security-user-profile-apis
```

@lockewritesdocs Just FYI. We can add this back in once the feature flag is updated/removed from the target docs.