### PR TITLE
[DOCS] Add authorization info to get and update transform APIs

### DIFF
--- a/docs/reference/transform/apis/get-transform.asciidoc
+++ b/docs/reference/transform/apis/get-transform.asciidoc
@@ -1,4 +1,3 @@
-[role="xpack"]
 [[get-transform]]
 = Get {transforms} API
 
@@ -98,11 +97,11 @@ GET _transform?size=10
 // TEST[skip:setup kibana sample data]
 
 The following example gets configuration information for the
-`ecommerce_transform` {transform}:
+`ecommerce_transform1` {transform}:
 
 [source,console]
 --------------------------------------------------
-GET _transform/ecommerce_transform
+GET _transform/ecommerce_transform1
 --------------------------------------------------
 // TEST[skip:setup kibana sample data]
 
@@ -114,7 +113,14 @@ The API returns the following results:
   "count" : 1,
   "transforms" : [
     {
-      "id" : "ecommerce_transform",
+      "id" : "ecommerce_transform1",
+      "authorization" : {
+        "roles" : [
+          "superuser"
+        ]
+      },
+      "version" : "8.4.0",
+      "create_time" : 1656023416565,
       "source" : {
         "index" : [
           "kibana_sample_data_ecommerce"
@@ -128,9 +134,16 @@ The API returns the following results:
         }
       },
       "dest" : {
-        "index" : "kibana_sample_data_ecommerce_transform"
+        "index" : "kibana_sample_data_ecommerce_transform1",
+        "pipeline" : "add_timestamp_pipeline"
       },
-      "frequency": "1m",
+      "frequency" : "5m",
+      "sync" : {
+        "time" : {
+          "field" : "order_date",
+          "delay" : "60s"
+        }
+      },
       "pivot" : {
         "group_by" : {
           "customer_id" : {
@@ -149,10 +162,13 @@ The API returns the following results:
       },
       "description" : "Maximum priced ecommerce data by customer_id in Asia",
       "settings" : { },
-      "version" : "7.5.0",
-      "create_time" : 1576094542936
+      "retention_policy" : {
+        "time" : {
+          "field" : "order_date",
+          "max_age" : "30d"
+        }
+      }
     }
   ]
 }
-
 ----

--- a/docs/reference/transform/apis/update-transform.asciidoc
+++ b/docs/reference/transform/apis/update-transform.asciidoc
@@ -232,7 +232,7 @@ delays.
 
 [source,console]
 --------------------------------------------------
-POST _transform/simple-kibana-ecomm-pivot/_update
+POST _transform/ecommerce_transform1/_update
 {
   "source": {
     "index": "kibana_sample_data_ecommerce",
@@ -265,49 +265,56 @@ When the {transform} is updated, you receive the updated configuration:
 [source,console-result]
 ----
 {
-  "id": "simple-kibana-ecomm-pivot",
-  "source": {
-    "index": ["kibana_sample_data_ecommerce"],
-    "query": {
-      "term": {
-        "geoip.continent_name": {
-          "value": "Asia"
+  "id" : "simple-kibana-ecomm-pivot",
+  "authorization" : {
+    "roles" : [
+      "superuser"
+    ]
+  },
+  "version" : "8.4.0",
+  "create_time" : 1656113450613,
+  "source" : {
+    "index" : [
+      "kibana_sample_data_ecommerce"
+    ],
+    "query" : {
+      "term" : {
+        "geoip.continent_name" : {
+          "value" : "Asia"
         }
       }
     }
   },
-  "pivot": {
-    "group_by": {
-      "customer_id": {
-        "terms": {
-          "field": "customer_id"
+  "dest" : {
+    "index" : "kibana_sample_data_ecommerce_transform_v2",
+    "pipeline" : "add_timestamp_pipeline"
+  },
+  "frequency" : "15m",
+  "sync" : {
+    "time" : {
+      "field" : "order_date",
+      "delay" : "120s"
+    }
+  },
+  "pivot" : {
+    "group_by" : {
+      "customer_id" : {
+        "terms" : {
+          "field" : "customer_id"
         }
       }
     },
-    "aggregations": {
-      "max_price": {
-        "max": {
-          "field": "taxful_total_price"
+    "aggregations" : {
+      "max_price" : {
+        "max" : {
+          "field" : "taxful_total_price"
         }
       }
     }
   },
-  "description": "Maximum priced ecommerce data by customer_id in Asia",
-  "dest": {
-    "index": "kibana_sample_data_ecommerce_transform_v2",
-    "pipeline": "add_timestamp_pipeline"
-  },
-  "frequency": "15m",
-  "sync": {
-    "time": {
-      "field": "order_date",
-      "delay": "120s"
-    }
-  },
-  "settings": { },
-  "version": "7.5.0",
-  "create_time": 1518808660505
+  "description" : "Maximum priced ecommerce data by customer_id in Asia",
+  "settings" : { }
 }
 ----
-// TESTRESPONSE[s/"version": "7.5.0"/"version": $body.version/]
-// TESTRESPONSE[s/"create_time": 1518808660505/"create_time": $body.create_time/]
+// TESTRESPONSE[s/"version": "8.4.0"/"version": $body.version/]
+// TESTRESPONSE[s/"create_time": 1656113450613/"create_time": $body.create_time/]

--- a/docs/reference/transform/apis/update-transform.asciidoc
+++ b/docs/reference/transform/apis/update-transform.asciidoc
@@ -232,7 +232,7 @@ delays.
 
 [source,console]
 --------------------------------------------------
-POST _transform/ecommerce_transform1/_update
+POST _transform/simple-kibana-ecomm-pivot/_update
 {
   "source": {
     "index": "kibana_sample_data_ecommerce",

--- a/docs/reference/transform/apis/update-transform.asciidoc
+++ b/docs/reference/transform/apis/update-transform.asciidoc
@@ -316,5 +316,6 @@ When the {transform} is updated, you receive the updated configuration:
   "settings" : { }
 }
 ----
-// TESTRESPONSE[s/"version": "8.4.0"/"version": $body.version/]
-// TESTRESPONSE[s/"create_time": 1656113450613/"create_time": $body.create_time/]
+// TESTRESPONSE[s/"version" : "8.4.0"/"version" : $body.version/]
+// TESTRESPONSE[s/"create_time" : 1656113450613/"create_time" : $body.create_time/]
+// TESTRESPONSE[s/"authorization" : \{[^}]*\},//]


### PR DESCRIPTION
Relates to https://github.com/elastic/elasticsearch/issues/87905

This PR refreshes the examples in https://www.elastic.co/guide/en/elasticsearch/reference/master/get-transform.html and https://www.elastic.co/guide/en/elasticsearch/reference/master/update-transform.html such that the example output contains the `authorization` object.

### Preview

- https://elasticsearch_87994.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/update-transform.html
- https://elasticsearch_87994.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/get-transform.html