### PR TITLE
[DOCS] Remove refs to Stack GS

### DIFF
--- a/docs/plugins/discovery-azure-classic.asciidoc
+++ b/docs/plugins/discovery-azure-classic.asciidoc
@@ -331,7 +331,7 @@ scp /tmp/azurekeystore.pkcs12 azure-elasticsearch-cluster.cloudapp.net:/home/ela
 ssh azure-elasticsearch-cluster.cloudapp.net
 ----
 
-Once connected, {stack-gs}/get-started-elastic-stack.html#install-elasticsearch[install {es}]:
+Once connected,  {ref}/install-elasticsearch.html[install {es}].
 
 Check that Elasticsearch is running:
 

--- a/docs/plugins/discovery-gce.asciidoc
+++ b/docs/plugins/discovery-gce.asciidoc
@@ -182,7 +182,7 @@ Failing to set this will result in unauthorized messages when starting Elasticse
 See <<discovery-gce-usage-tips-permissions>>.
 ==============================================
 
-Once connected, {stack-gs}/get-started-elastic-stack.html#install-elasticsearch[install {es}]:
+Once connected,  {ref}/install-elasticsearch.html[install {es}].
 
 [[discovery-gce-usage-long-install-plugin]]
 ===== Install Elasticsearch discovery gce plugin


### PR DESCRIPTION
We're retiring the Stack GS in favor of the new onboarding content introduced in 8.2.