### PR TITLE
[ML] make trained model rest APIs cancellable

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/action/AbstractGetResourcesRequest.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/action/AbstractGetResourcesRequest.java
@@ -10,9 +10,13 @@ import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.tasks.CancellableTask;
+import org.elasticsearch.tasks.Task;
+import org.elasticsearch.tasks.TaskId;
 import org.elasticsearch.xpack.core.action.util.PageParams;
 
 import java.io.IOException;
+import java.util.Map;
 import java.util.Objects;
 
 public abstract class AbstractGetResourcesRequest extends ActionRequest {
@@ -92,6 +96,13 @@ public abstract class AbstractGetResourcesRequest extends ActionRequest {
             && Objects.equals(pageParams, other.pageParams)
             && allowNoResources == other.allowNoResources;
     }
+
+    @Override
+    public Task createTask(long id, String type, String action, TaskId parentTaskId, Map<String, String> headers) {
+        return new CancellableTask(id, type, action, getCancelableTaskDescription(), parentTaskId, headers);
+    }
+
+    public abstract String getCancelableTaskDescription();
 
     public abstract String getResourceIdField();
 }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/action/AbstractTransportGetResourcesAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/action/AbstractTransportGetResourcesAction.java
@@ -26,6 +26,7 @@ import org.elasticsearch.index.query.QueryBuilders;
 import org.elasticsearch.search.SearchHit;
 import org.elasticsearch.search.builder.SearchSourceBuilder;
 import org.elasticsearch.search.sort.SortBuilders;
+import org.elasticsearch.tasks.TaskId;
 import org.elasticsearch.transport.TransportService;
 import org.elasticsearch.xcontent.NamedXContentRegistry;
 import org.elasticsearch.xcontent.ParseField;
@@ -73,7 +74,7 @@ public abstract class AbstractTransportGetResourcesAction<
         this.xContentRegistry = Objects.requireNonNull(xContentRegistry);
     }
 
-    protected void searchResources(AbstractGetResourcesRequest request, ActionListener<QueryPage<Resource>> listener) {
+    protected void searchResources(AbstractGetResourcesRequest request, TaskId parentTaskId, ActionListener<QueryPage<Resource>> listener) {
         String[] tokens = Strings.tokenizeToStringArray(request.getResourceId(), ",");
         SearchSourceBuilder sourceBuilder = new SearchSourceBuilder().sort(
             SortBuilders.fieldSort(request.getResourceIdField())
@@ -96,6 +97,7 @@ public abstract class AbstractTransportGetResourcesAction<
                 indicesOptions
             )
         ).source(customSearchOptions(sourceBuilder));
+        searchRequest.setParentTask(parentTaskId);
 
         executeAsyncWithOrigin(
             client.threadPool().getThreadContext(),

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/GetDataFrameAnalyticsAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/GetDataFrameAnalyticsAction.java
@@ -16,6 +16,8 @@ import org.elasticsearch.xpack.core.ml.dataframe.DataFrameAnalyticsConfig;
 
 import java.io.IOException;
 
+import static org.elasticsearch.core.Strings.format;
+
 public class GetDataFrameAnalyticsAction extends ActionType<GetDataFrameAnalyticsAction.Response> {
 
     public static final GetDataFrameAnalyticsAction INSTANCE = new GetDataFrameAnalyticsAction();
@@ -45,6 +47,11 @@ public class GetDataFrameAnalyticsAction extends ActionType<GetDataFrameAnalytic
         @Override
         public String getResourceIdField() {
             return DataFrameAnalyticsConfig.ID.getPreferredName();
+        }
+
+        @Override
+        public String getCancelableTaskDescription() {
+            return format("get_data_frame_analytics[%s]", getResourceId());
         }
     }
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/GetFiltersAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/GetFiltersAction.java
@@ -17,6 +17,8 @@ import org.elasticsearch.xpack.core.ml.job.config.MlFilter;
 
 import java.io.IOException;
 
+import static org.elasticsearch.core.Strings.format;
+
 public class GetFiltersAction extends ActionType<GetFiltersAction.Response> {
 
     public static final GetFiltersAction INSTANCE = new GetFiltersAction();
@@ -39,6 +41,11 @@ public class GetFiltersAction extends ActionType<GetFiltersAction.Response> {
 
         public Request(StreamInput in) throws IOException {
             super(in);
+        }
+
+        @Override
+        public String getCancelableTaskDescription() {
+            return format("get_filters[%s]", getResourceId());
         }
 
         @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/GetTrainedModelsAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/GetTrainedModelsAction.java
@@ -25,6 +25,8 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Set;
 
+import static org.elasticsearch.core.Strings.format;
+
 public class GetTrainedModelsAction extends ActionType<GetTrainedModelsAction.Response> {
 
     public static final GetTrainedModelsAction INSTANCE = new GetTrainedModelsAction();
@@ -118,7 +120,6 @@ public class GetTrainedModelsAction extends ActionType<GetTrainedModelsAction.Re
     public static class Request extends AbstractGetResourcesRequest {
 
         public static final ParseField INCLUDE = new ParseField("include");
-        public static final String DEFINITION = "definition";
         public static final ParseField ALLOW_NO_MATCH = new ParseField("allow_no_match");
         public static final ParseField TAGS = new ParseField("tags");
 
@@ -177,6 +178,11 @@ public class GetTrainedModelsAction extends ActionType<GetTrainedModelsAction.Re
             }
             Request other = (Request) obj;
             return super.equals(obj) && this.includes.equals(other.includes) && Objects.equals(tags, other.tags);
+        }
+
+        @Override
+        public String getCancelableTaskDescription() {
+            return format("get_trained_models[%s]", getResourceId());
         }
     }
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/GetTrainedModelsStatsAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/GetTrainedModelsStatsAction.java
@@ -35,6 +35,7 @@ import java.util.Objects;
 import java.util.Set;
 
 import static org.elasticsearch.core.RestApiVersion.onOrAfter;
+import static org.elasticsearch.core.Strings.format;
 
 public class GetTrainedModelsStatsAction extends ActionType<GetTrainedModelsStatsAction.Response> {
 
@@ -66,6 +67,11 @@ public class GetTrainedModelsStatsAction extends ActionType<GetTrainedModelsStat
 
         public Request(StreamInput in) throws IOException {
             super(in);
+        }
+
+        @Override
+        public String getCancelableTaskDescription() {
+            return format("get_trained_model_stats[%s]", getResourceId());
         }
 
         @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/InferModelAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/InferModelAction.java
@@ -14,6 +14,9 @@ import org.elasticsearch.action.ActionType;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.core.TimeValue;
+import org.elasticsearch.tasks.CancellableTask;
+import org.elasticsearch.tasks.Task;
+import org.elasticsearch.tasks.TaskId;
 import org.elasticsearch.xcontent.ObjectParser;
 import org.elasticsearch.xcontent.ParseField;
 import org.elasticsearch.xcontent.ToXContentObject;
@@ -30,6 +33,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.stream.Collectors;
+
+import static org.elasticsearch.core.Strings.format;
 
 public class InferModelAction extends ActionType<InferModelAction.Response> {
     public static final String NAME = "cluster:internal/xpack/ml/inference/infer";
@@ -174,6 +179,11 @@ public class InferModelAction extends ActionType<InferModelAction.Response> {
                 && Objects.equals(previouslyLicensed, that.previouslyLicensed)
                 && Objects.equals(timeout, that.timeout)
                 && Objects.equals(objectsToInfer, that.objectsToInfer);
+        }
+
+        @Override
+        public Task createTask(long id, String type, String action, TaskId parentTaskId, Map<String, String> headers) {
+            return new CancellableTask(id, type, action, format("infer_trained_model[%s]", modelId), parentTaskId, headers);
         }
 
         @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/InferTrainedModelDeploymentAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/InferTrainedModelDeploymentAction.java
@@ -17,7 +17,9 @@ import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.core.TimeValue;
+import org.elasticsearch.tasks.CancellableTask;
 import org.elasticsearch.tasks.Task;
+import org.elasticsearch.tasks.TaskId;
 import org.elasticsearch.xcontent.ObjectParser;
 import org.elasticsearch.xcontent.ParseField;
 import org.elasticsearch.xcontent.ToXContentObject;
@@ -36,6 +38,7 @@ import java.util.Objects;
 import java.util.Optional;
 
 import static org.elasticsearch.action.ValidateActions.addValidationError;
+import static org.elasticsearch.core.Strings.format;
 
 public class InferTrainedModelDeploymentAction extends ActionType<InferTrainedModelDeploymentAction.Response> {
 
@@ -190,6 +193,11 @@ public class InferTrainedModelDeploymentAction extends ActionType<InferTrainedMo
         @Override
         public int hashCode() {
             return Objects.hash(deploymentId, update, docs, inferenceTimeout);
+        }
+
+        @Override
+        public Task createTask(long id, String type, String action, TaskId parentTaskId, Map<String, String> headers) {
+            return new CancellableTask(id, type, action, format("infer_trained_model_deployment[%s]", deploymentId), parentTaskId, headers);
         }
 
         public static class Builder {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/action/GetTransformAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/action/GetTransformAction.java
@@ -32,6 +32,7 @@ import java.util.List;
 import java.util.Objects;
 
 import static org.elasticsearch.action.ValidateActions.addValidationError;
+import static org.elasticsearch.core.Strings.format;
 
 public class GetTransformAction extends ActionType<GetTransformAction.Response> {
 
@@ -74,6 +75,11 @@ public class GetTransformAction extends ActionType<GetTransformAction.Response> 
                 );
             }
             return exception;
+        }
+
+        @Override
+        public String getCancelableTaskDescription() {
+            return format("get_transforms[%s]", getResourceId());
         }
 
         @Override

--- a/x-pack/plugin/ml/src/internalClusterTest/java/org/elasticsearch/xpack/ml/integration/ChunkedTrainedModelPersisterIT.java
+++ b/x-pack/plugin/ml/src/internalClusterTest/java/org/elasticsearch/xpack/ml/integration/ChunkedTrainedModelPersisterIT.java
@@ -110,6 +110,7 @@ public class ChunkedTrainedModelPersisterIT extends MlSingleNodeTestCase {
             PageParams.defaultParams(),
             Collections.emptySet(),
             ModelAliasMetadata.EMPTY,
+            null,
             getIdsFuture
         );
         Tuple<Long, Map<String, Set<String>>> ids = getIdsFuture.actionGet();
@@ -117,7 +118,7 @@ public class ChunkedTrainedModelPersisterIT extends MlSingleNodeTestCase {
         String inferenceModelId = ids.v2().keySet().iterator().next();
 
         PlainActionFuture<TrainedModelConfig> getTrainedModelFuture = new PlainActionFuture<>();
-        trainedModelProvider.getTrainedModel(inferenceModelId, GetTrainedModelsAction.Includes.all(), getTrainedModelFuture);
+        trainedModelProvider.getTrainedModel(inferenceModelId, GetTrainedModelsAction.Includes.all(), null, getTrainedModelFuture);
 
         TrainedModelConfig storedConfig = getTrainedModelFuture.actionGet();
         assertThat(storedConfig.getCompressedDefinition(), equalTo(compressedDefinition));
@@ -128,7 +129,7 @@ public class ChunkedTrainedModelPersisterIT extends MlSingleNodeTestCase {
         assertThat(storedConfig.getMetadata(), hasKey("hyperparameters"));
 
         PlainActionFuture<Map<String, TrainedModelMetadata>> getTrainedMetadataFuture = new PlainActionFuture<>();
-        trainedModelProvider.getTrainedModelMetadata(Collections.singletonList(inferenceModelId), getTrainedMetadataFuture);
+        trainedModelProvider.getTrainedModelMetadata(Collections.singletonList(inferenceModelId), null, getTrainedMetadataFuture);
 
         TrainedModelMetadata storedMetadata = getTrainedMetadataFuture.actionGet().get(inferenceModelId);
         assertThat(storedMetadata.getModelId(), startsWith(modelId));

--- a/x-pack/plugin/ml/src/internalClusterTest/java/org/elasticsearch/xpack/ml/integration/TrainedModelProviderIT.java
+++ b/x-pack/plugin/ml/src/internalClusterTest/java/org/elasticsearch/xpack/ml/integration/TrainedModelProviderIT.java
@@ -118,7 +118,7 @@ public class TrainedModelProviderIT extends MlSingleNodeTestCase {
 
         AtomicReference<TrainedModelConfig> getConfigHolder = new AtomicReference<>();
         blockingCall(
-            listener -> trainedModelProvider.getTrainedModel(modelId, GetTrainedModelsAction.Includes.forModelDefinition(), listener),
+            listener -> trainedModelProvider.getTrainedModel(modelId, GetTrainedModelsAction.Includes.forModelDefinition(), null, listener),
             getConfigHolder,
             exceptionHolder
         );
@@ -132,7 +132,7 @@ public class TrainedModelProviderIT extends MlSingleNodeTestCase {
 
         getConfigHolder = new AtomicReference<>();
         blockingCall(
-            listener -> trainedModelProvider.getTrainedModel(modelId, GetTrainedModelsAction.Includes.all(), listener),
+            listener -> trainedModelProvider.getTrainedModel(modelId, GetTrainedModelsAction.Includes.all(), null, listener),
             getConfigHolder,
             exceptionHolder
         );
@@ -204,7 +204,7 @@ public class TrainedModelProviderIT extends MlSingleNodeTestCase {
 
         AtomicReference<TrainedModelConfig> getConfigHolder = new AtomicReference<>();
         blockingCall(
-            listener -> trainedModelProvider.getTrainedModel(modelId, GetTrainedModelsAction.Includes.forModelDefinition(), listener),
+            listener -> trainedModelProvider.getTrainedModel(modelId, GetTrainedModelsAction.Includes.forModelDefinition(), null, listener),
             getConfigHolder,
             exceptionHolder
         );
@@ -248,7 +248,7 @@ public class TrainedModelProviderIT extends MlSingleNodeTestCase {
 
         AtomicReference<TrainedModelConfig> getConfigHolder = new AtomicReference<>();
         blockingCall(
-            listener -> trainedModelProvider.getTrainedModel(modelId, GetTrainedModelsAction.Includes.empty(), listener),
+            listener -> trainedModelProvider.getTrainedModel(modelId, GetTrainedModelsAction.Includes.empty(), null, listener),
             getConfigHolder,
             exceptionHolder
         );
@@ -263,7 +263,7 @@ public class TrainedModelProviderIT extends MlSingleNodeTestCase {
         AtomicReference<TrainedModelConfig> getConfigHolder = new AtomicReference<>();
         AtomicReference<Exception> exceptionHolder = new AtomicReference<>();
         blockingCall(
-            listener -> trainedModelProvider.getTrainedModel(modelId, GetTrainedModelsAction.Includes.forModelDefinition(), listener),
+            listener -> trainedModelProvider.getTrainedModel(modelId, GetTrainedModelsAction.Includes.forModelDefinition(), null, listener),
             getConfigHolder,
             exceptionHolder
         );
@@ -288,7 +288,7 @@ public class TrainedModelProviderIT extends MlSingleNodeTestCase {
 
         AtomicReference<TrainedModelConfig> getConfigHolder = new AtomicReference<>();
         blockingCall(
-            listener -> trainedModelProvider.getTrainedModel(modelId, GetTrainedModelsAction.Includes.forModelDefinition(), listener),
+            listener -> trainedModelProvider.getTrainedModel(modelId, GetTrainedModelsAction.Includes.forModelDefinition(), null, listener),
             getConfigHolder,
             exceptionHolder
         );
@@ -335,7 +335,7 @@ public class TrainedModelProviderIT extends MlSingleNodeTestCase {
 
         AtomicReference<TrainedModelConfig> getConfigHolder = new AtomicReference<>();
         blockingCall(
-            listener -> trainedModelProvider.getTrainedModel(modelId, GetTrainedModelsAction.Includes.forModelDefinition(), listener),
+            listener -> trainedModelProvider.getTrainedModel(modelId, GetTrainedModelsAction.Includes.forModelDefinition(), null, listener),
             getConfigHolder,
             exceptionHolder
         );
@@ -388,7 +388,7 @@ public class TrainedModelProviderIT extends MlSingleNodeTestCase {
 
         AtomicReference<TrainedModelConfig> getConfigHolder = new AtomicReference<>();
         blockingCall(
-            listener -> trainedModelProvider.getTrainedModel(modelId, GetTrainedModelsAction.Includes.forModelDefinition(), listener),
+            listener -> trainedModelProvider.getTrainedModel(modelId, GetTrainedModelsAction.Includes.forModelDefinition(), null, listener),
             getConfigHolder,
             exceptionHolder
         );

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportGetDataFrameAnalyticsAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportGetDataFrameAnalyticsAction.java
@@ -10,11 +10,13 @@ import org.elasticsearch.ResourceNotFoundException;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.client.internal.Client;
+import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.index.query.QueryBuilders;
 import org.elasticsearch.tasks.Task;
+import org.elasticsearch.tasks.TaskId;
 import org.elasticsearch.transport.TransportService;
 import org.elasticsearch.xcontent.NamedXContentRegistry;
 import org.elasticsearch.xcontent.ParseField;
@@ -31,12 +33,14 @@ public class TransportGetDataFrameAnalyticsAction extends AbstractTransportGetRe
     DataFrameAnalyticsConfig,
     GetDataFrameAnalyticsAction.Request,
     GetDataFrameAnalyticsAction.Response> {
+    private final ClusterService clusterService;
 
     @Inject
     public TransportGetDataFrameAnalyticsAction(
         TransportService transportService,
         ActionFilters actionFilters,
         Client client,
+        ClusterService clusterService,
         NamedXContentRegistry xContentRegistry
     ) {
         super(
@@ -47,6 +51,7 @@ public class TransportGetDataFrameAnalyticsAction extends AbstractTransportGetRe
             client,
             xContentRegistry
         );
+        this.clusterService = clusterService;
     }
 
     @Override
@@ -77,6 +82,7 @@ public class TransportGetDataFrameAnalyticsAction extends AbstractTransportGetRe
     ) {
         searchResources(
             request,
+            new TaskId(clusterService.localNode().getId(), task.getId()),
             ActionListener.wrap(queryPage -> listener.onResponse(new GetDataFrameAnalyticsAction.Response(queryPage)), listener::onFailure)
         );
     }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportGetFiltersAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportGetFiltersAction.java
@@ -10,10 +10,12 @@ import org.elasticsearch.ResourceNotFoundException;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.client.internal.Client;
+import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.index.query.QueryBuilders;
 import org.elasticsearch.tasks.Task;
+import org.elasticsearch.tasks.TaskId;
 import org.elasticsearch.transport.TransportService;
 import org.elasticsearch.xcontent.NamedXContentRegistry;
 import org.elasticsearch.xcontent.ParseField;
@@ -32,14 +34,18 @@ public class TransportGetFiltersAction extends AbstractTransportGetResourcesActi
     GetFiltersAction.Request,
     GetFiltersAction.Response> {
 
+    private final ClusterService clusterService;
+
     @Inject
     public TransportGetFiltersAction(
         TransportService transportService,
         ActionFilters actionFilters,
         Client client,
+        ClusterService clusterService,
         NamedXContentRegistry xContentRegistry
     ) {
         super(GetFiltersAction.NAME, transportService, actionFilters, GetFiltersAction.Request::new, client, xContentRegistry);
+        this.clusterService = clusterService;
     }
 
     @Override
@@ -47,6 +53,7 @@ public class TransportGetFiltersAction extends AbstractTransportGetResourcesActi
         request.setAllowNoResources(true);
         searchResources(
             request,
+            new TaskId(clusterService.localNode().getId(), task.getId()),
             ActionListener.wrap(filters -> listener.onResponse(new GetFiltersAction.Response(filters)), listener::onFailure)
         );
     }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportGetTrainedModelsAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportGetTrainedModelsAction.java
@@ -13,6 +13,7 @@ import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.core.Tuple;
 import org.elasticsearch.tasks.Task;
+import org.elasticsearch.tasks.TaskId;
 import org.elasticsearch.transport.TransportService;
 import org.elasticsearch.xpack.core.ml.action.GetTrainedModelsAction;
 import org.elasticsearch.xpack.core.ml.action.GetTrainedModelsAction.Request;
@@ -46,6 +47,7 @@ public class TransportGetTrainedModelsAction extends HandledTransportAction<Requ
 
     @Override
     protected void doExecute(Task task, Request request, ActionListener<Response> listener) {
+        final TaskId parentTaskId = new TaskId(clusterService.localNode().getId(), task.getId());
 
         Response.Builder responseBuilder = Response.builder();
 
@@ -68,6 +70,7 @@ public class TransportGetTrainedModelsAction extends HandledTransportAction<Requ
                     modelIdAndAliases.getKey(),
                     modelIdAndAliases.getValue(),
                     request.getIncludes(),
+                    parentTaskId,
                     ActionListener.wrap(
                         config -> listener.onResponse(responseBuilder.setModels(Collections.singletonList(config)).build()),
                         listener::onFailure
@@ -78,6 +81,7 @@ public class TransportGetTrainedModelsAction extends HandledTransportAction<Requ
                     totalAndIds.v2(),
                     request.getIncludes(),
                     request.isAllowNoResources(),
+                    parentTaskId,
                     ActionListener.wrap(configs -> listener.onResponse(responseBuilder.setModels(configs).build()), listener::onFailure)
                 );
             }
@@ -88,6 +92,7 @@ public class TransportGetTrainedModelsAction extends HandledTransportAction<Requ
             request.getPageParams(),
             new HashSet<>(request.getTags()),
             ModelAliasMetadata.fromState(clusterService.state()),
+            parentTaskId,
             idExpansionListener
         );
     }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportInternalInferModelAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportInternalInferModelAction.java
@@ -16,7 +16,9 @@ import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.license.License;
 import org.elasticsearch.license.LicenseUtils;
 import org.elasticsearch.license.XPackLicenseState;
+import org.elasticsearch.tasks.CancellableTask;
 import org.elasticsearch.tasks.Task;
+import org.elasticsearch.tasks.TaskCancelledException;
 import org.elasticsearch.tasks.TaskId;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
@@ -38,6 +40,7 @@ import org.elasticsearch.xpack.ml.utils.TypedChainTaskExecutor;
 import java.util.Collections;
 import java.util.Map;
 
+import static org.elasticsearch.core.Strings.format;
 import static org.elasticsearch.xpack.core.ClientHelper.ML_ORIGIN;
 import static org.elasticsearch.xpack.core.ClientHelper.executeAsyncWithOrigin;
 
@@ -93,21 +96,23 @@ public class TransportInternalInferModelAction extends HandledTransportAction<Re
     protected void doExecute(Task task, Request request, ActionListener<Response> listener) {
 
         Response.Builder responseBuilder = Response.builder();
+        TaskId parentTaskId = new TaskId(clusterService.getNodeName(), task.getId());
 
         if (MachineLearningField.ML_API_FEATURE.check(licenseState)) {
             responseBuilder.setLicensed(true);
-            doInfer(task, request, responseBuilder, listener);
+            doInfer(task, request, responseBuilder, parentTaskId, listener);
         } else {
             trainedModelProvider.getTrainedModel(
                 request.getModelId(),
                 GetTrainedModelsAction.Includes.empty(),
+                parentTaskId,
                 ActionListener.wrap(trainedModelConfig -> {
                     // Since we just checked MachineLearningField.ML_API_FEATURE.check(licenseState) and that check failed
                     // That means we don't have a plat+ license. The only licenses for trained models are basic (free) and plat.
                     boolean allowed = trainedModelConfig.getLicenseLevel() == License.OperationMode.BASIC;
                     responseBuilder.setLicensed(allowed);
                     if (allowed || request.isPreviouslyLicensed()) {
-                        doInfer(task, request, responseBuilder, listener);
+                        doInfer(task, request, responseBuilder, parentTaskId, listener);
                     } else {
                         listener.onFailure(LicenseUtils.newComplianceException(XPackField.MACHINE_LEARNING));
                     }
@@ -116,11 +121,17 @@ public class TransportInternalInferModelAction extends HandledTransportAction<Re
         }
     }
 
-    private void doInfer(Task task, Request request, Response.Builder responseBuilder, ActionListener<Response> listener) {
+    private void doInfer(
+        Task task,
+        Request request,
+        Response.Builder responseBuilder,
+        TaskId parentTaskId,
+        ActionListener<Response> listener
+    ) {
         if (isAllocatedModel(request.getModelId())) {
-            inferAgainstAllocatedModel(task, request, responseBuilder, listener);
+            inferAgainstAllocatedModel(request, responseBuilder, parentTaskId, listener);
         } else {
-            getModelAndInfer(request, responseBuilder, listener);
+            getModelAndInfer(request, responseBuilder, parentTaskId, (CancellableTask) task, listener);
         }
     }
 
@@ -129,7 +140,13 @@ public class TransportInternalInferModelAction extends HandledTransportAction<Re
         return trainedModelAssignmentMetadata.isAssigned(modelId);
     }
 
-    private void getModelAndInfer(Request request, Response.Builder responseBuilder, ActionListener<Response> listener) {
+    private void getModelAndInfer(
+        Request request,
+        Response.Builder responseBuilder,
+        TaskId parentTaskId,
+        CancellableTask task,
+        ActionListener<Response> listener
+    ) {
         ActionListener<LocalModel> getModelListener = ActionListener.wrap(model -> {
             TypedChainTaskExecutor<InferenceResults> typedChainTaskExecutor = new TypedChainTaskExecutor<>(
                 client.threadPool().executor(ThreadPool.Names.SAME),
@@ -138,12 +155,12 @@ public class TransportInternalInferModelAction extends HandledTransportAction<Re
                 // Always fail immediately and return an error
                 ex -> true
             );
-            request.getObjectsToInfer()
-                .forEach(
-                    stringObjectMap -> typedChainTaskExecutor.add(
-                        chainedTask -> model.infer(stringObjectMap, request.getUpdate(), chainedTask)
-                    )
-                );
+            request.getObjectsToInfer().forEach(stringObjectMap -> typedChainTaskExecutor.add(chainedTask -> {
+                if (task.isCancelled()) {
+                    throw new TaskCancelledException(format("Inference task cancelled with reason [%s]", task.getReasonCancelled()));
+                }
+                model.infer(stringObjectMap, request.getUpdate(), chainedTask);
+            }));
 
             typedChainTaskExecutor.execute(ActionListener.wrap(inferenceResultsInterfaces -> {
                 model.release();
@@ -154,13 +171,13 @@ public class TransportInternalInferModelAction extends HandledTransportAction<Re
             }));
         }, listener::onFailure);
 
-        modelLoadingService.getModelForPipeline(request.getModelId(), getModelListener);
+        modelLoadingService.getModelForPipeline(request.getModelId(), parentTaskId, getModelListener);
     }
 
     private void inferAgainstAllocatedModel(
-        Task task,
         Request request,
         Response.Builder responseBuilder,
+        TaskId parentTaskId,
         ActionListener<Response> listener
     ) {
         TypedChainTaskExecutor<InferenceResults> typedChainTaskExecutor = new TypedChainTaskExecutor<>(
@@ -174,11 +191,11 @@ public class TransportInternalInferModelAction extends HandledTransportAction<Re
             .forEach(
                 stringObjectMap -> typedChainTaskExecutor.add(
                     chainedTask -> inferSingleDocAgainstAllocatedModel(
-                        task,
                         request.getModelId(),
                         request.getTimeout(),
                         request.getUpdate(),
                         stringObjectMap,
+                        parentTaskId,
                         chainedTask
                     )
                 )
@@ -195,21 +212,20 @@ public class TransportInternalInferModelAction extends HandledTransportAction<Re
     }
 
     private void inferSingleDocAgainstAllocatedModel(
-        Task task,
         String modelId,
         TimeValue timeValue,
         InferenceConfigUpdate inferenceConfigUpdate,
         Map<String, Object> doc,
+        TaskId parentTaskId,
         ActionListener<InferenceResults> listener
     ) {
-        TaskId taskId = new TaskId(clusterService.localNode().getId(), task.getId());
         InferTrainedModelDeploymentAction.Request request = new InferTrainedModelDeploymentAction.Request(
             modelId,
             inferenceConfigUpdate,
             Collections.singletonList(doc),
             timeValue
         );
-        request.setParentTask(taskId);
+        request.setParentTask(parentTaskId);
         executeAsyncWithOrigin(
             client,
             ML_ORIGIN,

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportPutTrainedModelAliasAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportPutTrainedModelAliasAction.java
@@ -116,7 +116,7 @@ public class TransportPutTrainedModelAliasAction extends AcknowledgedTransportMa
         if (oldModelId != null) {
             modelIds.add(oldModelId);
         }
-        trainedModelProvider.getTrainedModels(modelIds, GetTrainedModelsAction.Includes.empty(), true, ActionListener.wrap(models -> {
+        trainedModelProvider.getTrainedModels(modelIds, GetTrainedModelsAction.Includes.empty(), true, null, ActionListener.wrap(models -> {
             TrainedModelConfig newModel = null;
             TrainedModelConfig oldModel = null;
             for (TrainedModelConfig config : models) {

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportPutTrainedModelDefinitionPartAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportPutTrainedModelDefinitionPartAction.java
@@ -114,6 +114,6 @@ public class TransportPutTrainedModelDefinitionPartAction extends HandledTranspo
             );
         }, listener::onFailure);
 
-        trainedModelProvider.getTrainedModel(request.getModelId(), GetTrainedModelsAction.Includes.empty(), configActionListener);
+        trainedModelProvider.getTrainedModel(request.getModelId(), GetTrainedModelsAction.Includes.empty(), null, configActionListener);
     }
 }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportPutTrainedModelVocabularyAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportPutTrainedModelVocabularyAction.java
@@ -99,7 +99,7 @@ public class TransportPutTrainedModelVocabularyAction extends TransportMasterNod
             );
         }, listener::onFailure);
 
-        trainedModelProvider.getTrainedModel(request.getModelId(), GetTrainedModelsAction.Includes.empty(), configActionListener);
+        trainedModelProvider.getTrainedModel(request.getModelId(), GetTrainedModelsAction.Includes.empty(), null, configActionListener);
     }
 
     @Override

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/loadingservice/ModelLoadingService.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/loadingservice/ModelLoadingService.java
@@ -31,6 +31,7 @@ import org.elasticsearch.ingest.IngestMetadata;
 import org.elasticsearch.license.License;
 import org.elasticsearch.license.XPackLicenseState;
 import org.elasticsearch.rest.RestStatus;
+import org.elasticsearch.tasks.TaskId;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.xpack.core.ml.action.GetTrainedModelsAction;
 import org.elasticsearch.xpack.core.ml.inference.TrainedModelConfig;
@@ -163,8 +164,7 @@ public class ModelLoadingService implements ClusterStateListener {
         this.localModelCache = CacheBuilder.<String, ModelAndConsumer>builder()
             .setMaximumWeight(this.maxCacheSize.getBytes())
             .weigher((id, modelAndConsumer) -> modelAndConsumer.model.ramBytesUsed())
-            // explicit declaration of the listener lambda necessary for Eclipse IDE 4.14
-            .removalListener(notification -> cacheEvictionListener(notification))
+            .removalListener(this::cacheEvictionListener)
             .setExpireAfterAccess(INFERENCE_MODEL_CACHE_TTL.get(settings))
             .build();
         clusterService.addListener(this);
@@ -203,8 +203,8 @@ public class ModelLoadingService implements ClusterStateListener {
      * @param modelId  the model to get
      * @param modelActionListener the listener to alert when the model has been retrieved
      */
-    public void getModelForPipeline(String modelId, ActionListener<LocalModel> modelActionListener) {
-        getModel(modelId, Consumer.PIPELINE, modelActionListener);
+    public void getModelForPipeline(String modelId, TaskId parentTaskId, ActionListener<LocalModel> modelActionListener) {
+        getModel(modelId, Consumer.PIPELINE, parentTaskId, modelActionListener);
     }
 
     /**
@@ -214,7 +214,7 @@ public class ModelLoadingService implements ClusterStateListener {
      * @param modelActionListener the listener to alert when the model has been retrieved
      */
     public void getModelForInternalInference(String modelId, ActionListener<LocalModel> modelActionListener) {
-        getModel(modelId, Consumer.INTERNAL, modelActionListener);
+        getModel(modelId, Consumer.INTERNAL, null, modelActionListener);
     }
 
     /**
@@ -224,7 +224,7 @@ public class ModelLoadingService implements ClusterStateListener {
      * @param modelActionListener the listener to alert when the model has been retrieved
      */
     public void getModelForSearch(String modelId, ActionListener<LocalModel> modelActionListener) {
-        getModel(modelId, Consumer.SEARCH, modelActionListener);
+        getModel(modelId, Consumer.SEARCH, null, modelActionListener);
     }
 
     /**
@@ -249,11 +249,12 @@ public class ModelLoadingService implements ClusterStateListener {
      * The main difference being that models for search are always cached whereas pipeline models
      * are only cached if they are referenced by an ingest pipeline
      *
-     * @param modelIdOrAlias       the model id or model alias to get
+     * @param modelIdOrAlias      the model id or model alias to get
      * @param consumer            which feature is requesting the model
+     * @param parentTaskId        The parent task id
      * @param modelActionListener the listener to alert when the model has been retrieved.
      */
-    private void getModel(String modelIdOrAlias, Consumer consumer, ActionListener<LocalModel> modelActionListener) {
+    private void getModel(String modelIdOrAlias, Consumer consumer, TaskId parentTaskId, ActionListener<LocalModel> modelActionListener) {
         final String modelId = modelAliasToId.getOrDefault(modelIdOrAlias, modelIdOrAlias);
         ModelAndConsumer cachedModel = localModelCache.get(modelId);
         if (cachedModel != null) {
@@ -269,7 +270,7 @@ public class ModelLoadingService implements ClusterStateListener {
             return;
         }
 
-        if (loadModelIfNecessary(modelIdOrAlias, consumer, modelActionListener)) {
+        if (loadModelIfNecessary(modelIdOrAlias, consumer, parentTaskId, modelActionListener)) {
             logger.trace(
                 () -> format("[%s] (model_alias [%s]) is loading or loaded, added new listener to queue", modelId, modelIdOrAlias)
             );
@@ -284,10 +285,16 @@ public class ModelLoadingService implements ClusterStateListener {
      * @param modelIdOrAlias The model to get
      * @param consumer The model consumer
      * @param modelActionListener The listener
+     * @param parentTaskId The parent task id
      * @return If the model is cached or currently being loaded true is returned. If a new load is started
      * false is returned to indicate a new load event
      */
-    private boolean loadModelIfNecessary(String modelIdOrAlias, Consumer consumer, ActionListener<LocalModel> modelActionListener) {
+    private boolean loadModelIfNecessary(
+        String modelIdOrAlias,
+        Consumer consumer,
+        TaskId parentTaskId,
+        ActionListener<LocalModel> modelActionListener
+    ) {
         synchronized (loadingListeners) {
             final String modelId = modelAliasToId.getOrDefault(modelIdOrAlias, modelIdOrAlias);
             ModelAndConsumer cachedModel = localModelCache.get(modelId);
@@ -320,7 +327,7 @@ public class ModelLoadingService implements ClusterStateListener {
                 logger.trace(
                     () -> format("[%s] (model_alias [%s]) not actively loading, eager loading without cache", modelId, modelIdOrAlias)
                 );
-                loadWithoutCaching(modelId, consumer, modelActionListener);
+                loadWithoutCaching(modelId, consumer, parentTaskId, modelActionListener);
             } else {
                 logger.trace(() -> format("[%s] (model_alias [%s]) attempting to load and cache", modelId, modelIdOrAlias));
                 loadingListeners.put(modelId, addFluently(new ArrayDeque<>(), modelActionListener));
@@ -331,7 +338,10 @@ public class ModelLoadingService implements ClusterStateListener {
     }
 
     private void loadModel(String modelId, Consumer consumer) {
-        provider.getTrainedModel(modelId, GetTrainedModelsAction.Includes.empty(), ActionListener.wrap(trainedModelConfig -> {
+        // We cannot use parentTaskId here as multiple listeners may be wanting this model to be loaded
+        // We don't want to cancel the loading if only ONE of them stops listening or closes connection
+        // TODO Is there a way to only signal a cancel if all the listener tasks cancel???
+        provider.getTrainedModel(modelId, GetTrainedModelsAction.Includes.empty(), null, ActionListener.wrap(trainedModelConfig -> {
             if (trainedModelConfig.isAllocateOnly()) {
                 if (consumer == Consumer.SEARCH) {
                     handleLoadFailure(
@@ -377,10 +387,15 @@ public class ModelLoadingService implements ClusterStateListener {
         }));
     }
 
-    private void loadWithoutCaching(String modelId, Consumer consumer, ActionListener<LocalModel> modelActionListener) {
+    private void loadWithoutCaching(
+        String modelId,
+        Consumer consumer,
+        TaskId parentTaskId,
+        ActionListener<LocalModel> modelActionListener
+    ) {
         // If we the model is not loaded and we did not kick off a new loading attempt, this means that we may be getting called
         // by a simulated pipeline
-        provider.getTrainedModel(modelId, GetTrainedModelsAction.Includes.empty(), ActionListener.wrap(trainedModelConfig -> {
+        provider.getTrainedModel(modelId, GetTrainedModelsAction.Includes.empty(), parentTaskId, ActionListener.wrap(trainedModelConfig -> {
             // If the model should be allocated, we should fail here
             if (trainedModelConfig.isAllocateOnly()) {
                 if (consumer == Consumer.SEARCH) {

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/persistence/TrainedModelProvider.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/persistence/TrainedModelProvider.java
@@ -40,6 +40,7 @@ import org.elasticsearch.common.bytes.CompositeBytesReference;
 import org.elasticsearch.common.regex.Regex;
 import org.elasticsearch.common.util.set.Sets;
 import org.elasticsearch.common.xcontent.LoggingDeprecationHandler;
+import org.elasticsearch.core.Nullable;
 import org.elasticsearch.core.Tuple;
 import org.elasticsearch.index.IndexNotFoundException;
 import org.elasticsearch.index.engine.VersionConflictEngineException;
@@ -56,12 +57,14 @@ import org.elasticsearch.search.aggregations.metrics.Sum;
 import org.elasticsearch.search.builder.SearchSourceBuilder;
 import org.elasticsearch.search.sort.SortBuilders;
 import org.elasticsearch.search.sort.SortOrder;
+import org.elasticsearch.tasks.TaskId;
 import org.elasticsearch.xcontent.NamedXContentRegistry;
 import org.elasticsearch.xcontent.ToXContent;
 import org.elasticsearch.xcontent.ToXContentObject;
 import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xcontent.XContentFactory;
 import org.elasticsearch.xcontent.XContentParser;
+import org.elasticsearch.xcontent.XContentParserConfiguration;
 import org.elasticsearch.xcontent.XContentType;
 import org.elasticsearch.xcontent.json.JsonXContent;
 import org.elasticsearch.xpack.core.action.util.ExpandedIdsMatcher;
@@ -336,7 +339,11 @@ public class TrainedModelProvider {
         );
     }
 
-    public void getTrainedModelMetadata(Collection<String> modelIds, ActionListener<Map<String, TrainedModelMetadata>> listener) {
+    public void getTrainedModelMetadata(
+        Collection<String> modelIds,
+        @Nullable TaskId parentTaskId,
+        ActionListener<Map<String, TrainedModelMetadata>> listener
+    ) {
         SearchRequest searchRequest = client.prepareSearch(InferenceIndexConstants.INDEX_PATTERN)
             .setQuery(
                 QueryBuilders.constantScoreQuery(
@@ -349,6 +356,9 @@ public class TrainedModelProvider {
             // First find the latest index
             .addSort("_index", SortOrder.DESC)
             .request();
+        if (parentTaskId != null) {
+            searchRequest.setParentTask(parentTaskId);
+        }
         executeAsyncWithOrigin(client, ML_ORIGIN, SearchAction.INSTANCE, searchRequest, ActionListener.wrap(searchResponse -> {
             if (searchResponse.getHits().getHits().length == 0) {
                 listener.onFailure(new ResourceNotFoundException(Messages.getMessage(Messages.MODEL_METADATA_NOT_FOUND, modelIds)));
@@ -541,15 +551,17 @@ public class TrainedModelProvider {
     public void getTrainedModel(
         final String modelId,
         final GetTrainedModelsAction.Includes includes,
+        @Nullable TaskId parentTaskId,
         final ActionListener<TrainedModelConfig> finalListener
     ) {
-        getTrainedModel(modelId, Collections.emptySet(), includes, finalListener);
+        getTrainedModel(modelId, Collections.emptySet(), includes, parentTaskId, finalListener);
     }
 
     public void getTrainedModel(
         final String modelId,
         final Set<String> modelAliases,
         final GetTrainedModelsAction.Includes includes,
+        @Nullable TaskId parentTaskId,
         final ActionListener<TrainedModelConfig> finalListener
     ) {
 
@@ -571,7 +583,7 @@ public class TrainedModelProvider {
                 finalListener.onResponse(modelBuilder.build());
                 return;
             }
-            this.getTrainedModelMetadata(Collections.singletonList(modelId), ActionListener.wrap(metadata -> {
+            this.getTrainedModelMetadata(Collections.singletonList(modelId), parentTaskId, ActionListener.wrap(metadata -> {
                 TrainedModelMetadata modelMetadata = metadata.get(modelId);
                 if (modelMetadata != null) {
                     if (includes.isIncludeTotalFeatureImportance()) {
@@ -604,6 +616,9 @@ public class TrainedModelProvider {
             .addSort("_index", SortOrder.DESC)
             .setSize(1)
             .request();
+        if (parentTaskId != null) {
+            trainedModelConfigSearch.setParentTask(parentTaskId);
+        }
 
         ActionListener<SearchResponse> trainedModelSearchHandler = ActionListener.wrap(modelSearchResponse -> {
             TrainedModelConfig.Builder builder;
@@ -636,7 +651,13 @@ public class TrainedModelProvider {
                 client,
                 ML_ORIGIN,
                 SearchAction.INSTANCE,
-                ChunkedTrainedModelRestorer.buildSearch(client, modelId, InferenceIndexConstants.INDEX_PATTERN, MAX_NUM_DEFINITION_DOCS),
+                ChunkedTrainedModelRestorer.buildSearch(
+                    client,
+                    modelId,
+                    InferenceIndexConstants.INDEX_PATTERN,
+                    MAX_NUM_DEFINITION_DOCS,
+                    parentTaskId
+                ),
                 ActionListener.wrap(definitionSearchResponse -> {
                     try {
                         List<TrainedModelDefinitionDoc> docs = handleHits(
@@ -676,12 +697,14 @@ public class TrainedModelProvider {
         Set<String> modelIds,
         GetTrainedModelsAction.Includes includes,
         boolean allowNoResources,
+        @Nullable TaskId parentTaskId,
         final ActionListener<List<TrainedModelConfig>> finalListener
     ) {
         getTrainedModels(
             modelIds.stream().collect(Collectors.toMap(Function.identity(), _k -> Collections.emptySet())),
             includes,
             allowNoResources,
+            parentTaskId,
             finalListener
         );
     }
@@ -697,6 +720,7 @@ public class TrainedModelProvider {
         Map<String, Set<String>> modelIds,
         GetTrainedModelsAction.Includes includes,
         boolean allowNoResources,
+        @Nullable TaskId parentTaskId,
         final ActionListener<List<TrainedModelConfig>> finalListener
     ) {
         QueryBuilder queryBuilder = QueryBuilders.constantScoreQuery(
@@ -709,6 +733,9 @@ public class TrainedModelProvider {
             .setQuery(queryBuilder)
             .setSize(modelIds.size())
             .request();
+        if (parentTaskId != null) {
+            searchRequest.setParentTask(parentTaskId);
+        }
         List<TrainedModelConfig.Builder> configs = new ArrayList<>(modelIds.size());
         Set<String> modelsInIndex = Sets.difference(modelIds.keySet(), MODELS_STORED_AS_RESOURCE);
         Set<String> modelsAsResource = Sets.intersection(MODELS_STORED_AS_RESOURCE, modelIds.keySet());
@@ -744,6 +771,7 @@ public class TrainedModelProvider {
             }
             this.getTrainedModelMetadata(
                 modelIds.keySet(),
+                parentTaskId,
                 ActionListener.wrap(metadata -> finalListener.onResponse(modelBuilders.stream().map(builder -> {
                     TrainedModelMetadata modelMetadata = metadata.get(builder.getModelId());
                     if (modelMetadata != null) {
@@ -841,6 +869,7 @@ public class TrainedModelProvider {
         PageParams pageParams,
         Set<String> tags,
         ModelAliasMetadata modelAliasMetadata,
+        @Nullable TaskId parentTaskId,
         ActionListener<Tuple<Long, Map<String, Set<String>>>> idsListener
     ) {
         String[] tokens = Strings.tokenizeToStringArray(idExpression, ",");
@@ -902,6 +931,9 @@ public class TrainedModelProvider {
                 indicesOptions
             )
         ).source(sourceBuilder);
+        if (parentTaskId != null) {
+            searchRequest.setParentTask(parentTaskId);
+        }
 
         executeAsyncWithOrigin(
             client.threadPool().getThreadContext(),
@@ -951,12 +983,15 @@ public class TrainedModelProvider {
         );
     }
 
-    public void getInferenceStats(String[] modelIds, ActionListener<List<InferenceStats>> listener) {
+    public void getInferenceStats(String[] modelIds, @Nullable TaskId parentTaskId, ActionListener<List<InferenceStats>> listener) {
         MultiSearchRequest multiSearchRequest = new MultiSearchRequest();
         Arrays.stream(modelIds).map(this::buildStatsSearchRequest).forEach(multiSearchRequest::add);
         if (multiSearchRequest.requests().isEmpty()) {
             listener.onResponse(Collections.emptyList());
             return;
+        }
+        if (parentTaskId != null) {
+            multiSearchRequest.setParentTask(parentTaskId);
         }
         executeAsyncWithOrigin(
             client.threadPool().getThreadContext(),
@@ -1107,8 +1142,7 @@ public class TrainedModelProvider {
         }
         try (
             XContentParser parser = JsonXContent.jsonXContent.createParser(
-                xContentRegistry,
-                LoggingDeprecationHandler.INSTANCE,
+                XContentParserConfiguration.EMPTY.withRegistry(xContentRegistry).withDeprecationHandler(LoggingDeprecationHandler.INSTANCE),
                 getClass().getResourceAsStream(MODEL_RESOURCE_PATH + modelId + MODEL_RESOURCE_FILE_EXT)
             )
         ) {
@@ -1174,30 +1208,6 @@ public class TrainedModelProvider {
         return Collections.unmodifiableSet(matchedModels);
     }
 
-    private static <T> T handleSearchItem(
-        MultiSearchResponse.Item item,
-        String resourceId,
-        CheckedBiFunction<BytesReference, String, T, Exception> parseLeniently
-    ) throws Exception {
-        return handleSearchItems(item, resourceId, parseLeniently).get(0);
-    }
-
-    // NOTE: This ignores any results that are in a different index than the first one seen in the search response.
-    private static <T> List<T> handleSearchItems(
-        MultiSearchResponse.Item item,
-        String resourceId,
-        CheckedBiFunction<BytesReference, String, T, Exception> parseLeniently
-    ) throws Exception {
-        if (item.isFailure()) {
-            throw item.getFailure();
-        }
-        if (item.getResponse().getHits().getHits().length == 0) {
-            throw new ResourceNotFoundException(resourceId);
-        }
-        return handleHits(item.getResponse().getHits().getHits(), resourceId, parseLeniently);
-
-    }
-
     private static <T> List<T> handleHits(
         SearchHit[] hits,
         String resourceId,
@@ -1255,7 +1265,11 @@ public class TrainedModelProvider {
         try (
             InputStream stream = source.streamInput();
             XContentParser parser = XContentFactory.xContent(XContentType.JSON)
-                .createParser(xContentRegistry, LoggingDeprecationHandler.INSTANCE, stream)
+                .createParser(
+                    XContentParserConfiguration.EMPTY.withRegistry(xContentRegistry)
+                        .withDeprecationHandler(LoggingDeprecationHandler.INSTANCE),
+                    stream
+                )
         ) {
             TrainedModelConfig.Builder builder = TrainedModelConfig.fromXContent(parser, true);
 
@@ -1277,7 +1291,11 @@ public class TrainedModelProvider {
         try (
             InputStream stream = source.streamInput();
             XContentParser parser = XContentFactory.xContent(XContentType.JSON)
-                .createParser(xContentRegistry, LoggingDeprecationHandler.INSTANCE, stream)
+                .createParser(
+                    XContentParserConfiguration.EMPTY.withRegistry(xContentRegistry)
+                        .withDeprecationHandler(LoggingDeprecationHandler.INSTANCE),
+                    stream
+                )
         ) {
             return TrainedModelMetadata.fromXContent(parser, true);
         } catch (IOException e) {

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/rest/dataframe/RestGetDataFrameAnalyticsAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/rest/dataframe/RestGetDataFrameAnalyticsAction.java
@@ -10,6 +10,7 @@ import org.elasticsearch.client.internal.node.NodeClient;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.rest.BaseRestHandler;
 import org.elasticsearch.rest.RestRequest;
+import org.elasticsearch.rest.action.RestCancellableNodeClient;
 import org.elasticsearch.rest.action.RestToXContentListener;
 import org.elasticsearch.xpack.core.action.util.PageParams;
 import org.elasticsearch.xpack.core.ml.action.GetDataFrameAnalyticsAction;
@@ -57,7 +58,11 @@ public class RestGetDataFrameAnalyticsAction extends BaseRestHandler {
         request.setAllowNoResources(
             restRequest.paramAsBoolean(GetDataFrameAnalyticsAction.Request.ALLOW_NO_MATCH.getPreferredName(), request.isAllowNoResources())
         );
-        return channel -> client.execute(GetDataFrameAnalyticsAction.INSTANCE, request, new RestToXContentListener<>(channel));
+        return channel -> new RestCancellableNodeClient(client, restRequest.getHttpChannel()).execute(
+            GetDataFrameAnalyticsAction.INSTANCE,
+            request,
+            new RestToXContentListener<>(channel)
+        );
     }
 
     @Override

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/rest/filter/RestGetFiltersAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/rest/filter/RestGetFiltersAction.java
@@ -11,6 +11,7 @@ import org.elasticsearch.common.Strings;
 import org.elasticsearch.core.RestApiVersion;
 import org.elasticsearch.rest.BaseRestHandler;
 import org.elasticsearch.rest.RestRequest;
+import org.elasticsearch.rest.action.RestCancellableNodeClient;
 import org.elasticsearch.rest.action.RestStatusToXContentListener;
 import org.elasticsearch.xpack.core.action.util.PageParams;
 import org.elasticsearch.xpack.core.ml.action.GetFiltersAction;
@@ -55,7 +56,11 @@ public class RestGetFiltersAction extends BaseRestHandler {
                 )
             );
         }
-        return channel -> client.execute(GetFiltersAction.INSTANCE, request, new RestStatusToXContentListener<>(channel));
+        return channel -> new RestCancellableNodeClient(client, restRequest.getHttpChannel()).execute(
+            GetFiltersAction.INSTANCE,
+            request,
+            new RestStatusToXContentListener<>(channel)
+        );
     }
 
 }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/rest/inference/RestGetTrainedModelsAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/rest/inference/RestGetTrainedModelsAction.java
@@ -16,6 +16,7 @@ import org.elasticsearch.rest.BaseRestHandler;
 import org.elasticsearch.rest.RestChannel;
 import org.elasticsearch.rest.RestRequest;
 import org.elasticsearch.rest.RestResponse;
+import org.elasticsearch.rest.action.RestCancellableNodeClient;
 import org.elasticsearch.rest.action.RestToXContentListener;
 import org.elasticsearch.xcontent.ToXContent;
 import org.elasticsearch.xcontent.ToXContentObject;
@@ -99,7 +100,7 @@ public class RestGetTrainedModelsAction extends BaseRestHandler {
             );
         }
         request.setAllowNoResources(restRequest.paramAsBoolean(ALLOW_NO_MATCH.getPreferredName(), request.isAllowNoResources()));
-        return channel -> client.execute(
+        return channel -> new RestCancellableNodeClient(client, restRequest.getHttpChannel()).execute(
             GetTrainedModelsAction.INSTANCE,
             request,
             new RestToXContentListenerWithDefaultValues<>(channel, DEFAULT_TO_XCONTENT_VALUES)

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/rest/inference/RestGetTrainedModelsStatsAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/rest/inference/RestGetTrainedModelsStatsAction.java
@@ -12,6 +12,7 @@ import org.elasticsearch.common.Strings;
 import org.elasticsearch.core.RestApiVersion;
 import org.elasticsearch.rest.BaseRestHandler;
 import org.elasticsearch.rest.RestRequest;
+import org.elasticsearch.rest.action.RestCancellableNodeClient;
 import org.elasticsearch.rest.action.RestToXContentListener;
 import org.elasticsearch.xpack.core.action.util.PageParams;
 import org.elasticsearch.xpack.core.ml.action.GetTrainedModelsStatsAction;
@@ -59,6 +60,10 @@ public class RestGetTrainedModelsStatsAction extends BaseRestHandler {
             );
         }
         request.setAllowNoResources(restRequest.paramAsBoolean(ALLOW_NO_MATCH.getPreferredName(), request.isAllowNoResources()));
-        return channel -> client.execute(GetTrainedModelsStatsAction.INSTANCE, request, new RestToXContentListener<>(channel));
+        return channel -> new RestCancellableNodeClient(client, restRequest.getHttpChannel()).execute(
+            GetTrainedModelsStatsAction.INSTANCE,
+            request,
+            new RestToXContentListener<>(channel)
+        );
     }
 }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/rest/inference/RestInferTrainedModelAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/rest/inference/RestInferTrainedModelAction.java
@@ -11,6 +11,7 @@ import org.elasticsearch.client.internal.node.NodeClient;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.rest.BaseRestHandler;
 import org.elasticsearch.rest.RestRequest;
+import org.elasticsearch.rest.action.RestCancellableNodeClient;
 import org.elasticsearch.rest.action.RestToXContentListener;
 import org.elasticsearch.xpack.core.ml.action.InferModelAction;
 import org.elasticsearch.xpack.core.ml.action.InferTrainedModelDeploymentAction;
@@ -58,6 +59,10 @@ public class RestInferTrainedModelAction extends BaseRestHandler {
             request.setUpdate(new EmptyConfigUpdate());
         }
 
-        return channel -> client.execute(InferModelAction.EXTERNAL_INSTANCE, request.build(), new RestToXContentListener<>(channel));
+        return channel -> new RestCancellableNodeClient(client, restRequest.getHttpChannel()).execute(
+            InferModelAction.EXTERNAL_INSTANCE,
+            request.build(),
+            new RestToXContentListener<>(channel)
+        );
     }
 }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/rest/inference/RestInferTrainedModelDeploymentAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/rest/inference/RestInferTrainedModelDeploymentAction.java
@@ -12,6 +12,7 @@ import org.elasticsearch.core.RestApiVersion;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.rest.BaseRestHandler;
 import org.elasticsearch.rest.RestRequest;
+import org.elasticsearch.rest.action.RestCancellableNodeClient;
 import org.elasticsearch.rest.action.RestToXContentListener;
 import org.elasticsearch.xpack.core.ml.action.InferTrainedModelDeploymentAction;
 import org.elasticsearch.xpack.core.ml.inference.TrainedModelConfig;
@@ -72,7 +73,7 @@ public class RestInferTrainedModelDeploymentAction extends BaseRestHandler {
             request.setInferenceTimeout(inferTimeout);
         }
 
-        return channel -> client.execute(
+        return channel -> new RestCancellableNodeClient(client, restRequest.getHttpChannel()).execute(
             InferTrainedModelDeploymentAction.INSTANCE,
             request.build(),
             new RestToXContentListener<>(channel)

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/loadingservice/ModelLoadingServiceTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/loadingservice/ModelLoadingServiceTests.java
@@ -152,7 +152,7 @@ public class ModelLoadingServiceTests extends ESTestCase {
         for (int i = 0; i < 10; i++) {
             String model = modelIds[i % 3];
             PlainActionFuture<LocalModel> future = new PlainActionFuture<>();
-            modelLoadingService.getModelForPipeline(model, future);
+            modelLoadingService.getModelForPipeline(model, null, future);
             assertThat(future.get(), is(not(nullValue())));
         }
 
@@ -169,7 +169,7 @@ public class ModelLoadingServiceTests extends ESTestCase {
         for (int i = 0; i < 10; i++) {
             String model = modelIds[i % 3];
             PlainActionFuture<LocalModel> future = new PlainActionFuture<>();
-            modelLoadingService.getModelForPipeline(model, future);
+            modelLoadingService.getModelForPipeline(model, null, future);
             assertThat(future.get(), is(not(nullValue())));
         }
 
@@ -224,7 +224,7 @@ public class ModelLoadingServiceTests extends ESTestCase {
             // Only reference models 1 and 2, so that cache is only invalidated once for model3 (after initial load)
             String model = modelIds[i % 2];
             PlainActionFuture<LocalModel> future = new PlainActionFuture<>();
-            modelLoadingService.getModelForPipeline(model, future);
+            modelLoadingService.getModelForPipeline(model, null, future);
             assertThat(future.get(), is(not(nullValue())));
         }
 
@@ -242,7 +242,7 @@ public class ModelLoadingServiceTests extends ESTestCase {
         // Load model 3, should invalidate 1 and 2
         for (int i = 0; i < 10; i++) {
             PlainActionFuture<LocalModel> future3 = new PlainActionFuture<>();
-            modelLoadingService.getModelForPipeline(model3, future3);
+            modelLoadingService.getModelForPipeline(model3, null, future3);
             assertThat(future3.get(), is(not(nullValue())));
         }
         verify(trainedModelProvider, times(2)).getTrainedModelForInference(eq(model3), eq(false), any());
@@ -253,7 +253,7 @@ public class ModelLoadingServiceTests extends ESTestCase {
         // Load model 1, should invalidate 3
         for (int i = 0; i < 10; i++) {
             PlainActionFuture<LocalModel> future1 = new PlainActionFuture<>();
-            modelLoadingService.getModelForPipeline(model1, future1);
+            modelLoadingService.getModelForPipeline(model1, null, future1);
             assertThat(future1.get(), is(not(nullValue())));
         }
         verify(trainedModelProvider, atMost(3)).getTrainedModelForInference(eq(model1), eq(false), any());
@@ -262,7 +262,7 @@ public class ModelLoadingServiceTests extends ESTestCase {
         // Load model 2
         for (int i = 0; i < 10; i++) {
             PlainActionFuture<LocalModel> future2 = new PlainActionFuture<>();
-            modelLoadingService.getModelForPipeline(model2, future2);
+            modelLoadingService.getModelForPipeline(model2, null, future2);
             assertThat(future2.get(), is(not(nullValue())));
         }
         verify(trainedModelProvider, atMost(3)).getTrainedModelForInference(eq(model2), eq(false), any());
@@ -273,7 +273,7 @@ public class ModelLoadingServiceTests extends ESTestCase {
         for (int i = 0; i < 10; i++) {
             String model = modelIds[i % 3];
             PlainActionFuture<LocalModel> future = new PlainActionFuture<>();
-            modelLoadingService.getModelForPipeline(model, future);
+            modelLoadingService.getModelForPipeline(model, null, future);
             assertThat(future.get(), is(not(nullValue())));
         }
 
@@ -302,7 +302,7 @@ public class ModelLoadingServiceTests extends ESTestCase {
 
         for (int i = 0; i < 10; i++) {
             PlainActionFuture<LocalModel> future = new PlainActionFuture<>();
-            modelLoadingService.getModelForPipeline(model1, future);
+            modelLoadingService.getModelForPipeline(model1, null, future);
             assertThat(future.get(), is(not(nullValue())));
         }
 
@@ -329,7 +329,7 @@ public class ModelLoadingServiceTests extends ESTestCase {
         modelLoadingService.clusterChanged(ingestChangedEvent(model));
 
         PlainActionFuture<LocalModel> future = new PlainActionFuture<>();
-        modelLoadingService.getModelForPipeline(model, future);
+        modelLoadingService.getModelForPipeline(model, null, future);
 
         try {
             future.get();
@@ -360,7 +360,7 @@ public class ModelLoadingServiceTests extends ESTestCase {
         );
 
         PlainActionFuture<LocalModel> future = new PlainActionFuture<>();
-        modelLoadingService.getModelForPipeline(model, future);
+        modelLoadingService.getModelForPipeline(model, null, future);
         try {
             future.get();
             fail("Should not have succeeded");
@@ -388,7 +388,7 @@ public class ModelLoadingServiceTests extends ESTestCase {
 
         for (int i = 0; i < 3; i++) {
             PlainActionFuture<LocalModel> future = new PlainActionFuture<>();
-            modelLoadingService.getModelForPipeline(model, future);
+            modelLoadingService.getModelForPipeline(model, null, future);
             assertThat(future.get(), is(not(nullValue())));
         }
 
@@ -459,9 +459,9 @@ public class ModelLoadingServiceTests extends ESTestCase {
         // the loading occurred or which models are currently in the cache due to evictions.
         // Verify that we have at least loaded all three
         assertBusy(() -> {
-            verify(trainedModelProvider, times(1)).getTrainedModel(eq(model1), eq(GetTrainedModelsAction.Includes.empty()), any());
-            verify(trainedModelProvider, times(1)).getTrainedModel(eq(model2), eq(GetTrainedModelsAction.Includes.empty()), any());
-            verify(trainedModelProvider, times(1)).getTrainedModel(eq(model3), eq(GetTrainedModelsAction.Includes.empty()), any());
+            verify(trainedModelProvider, times(1)).getTrainedModel(eq(model1), eq(GetTrainedModelsAction.Includes.empty()), any(), any());
+            verify(trainedModelProvider, times(1)).getTrainedModel(eq(model2), eq(GetTrainedModelsAction.Includes.empty()), any(), any());
+            verify(trainedModelProvider, times(1)).getTrainedModel(eq(model3), eq(GetTrainedModelsAction.Includes.empty()), any(), any());
         });
         assertBusy(() -> {
             assertThat(circuitBreaker.getUsed(), equalTo(10L));
@@ -470,7 +470,7 @@ public class ModelLoadingServiceTests extends ESTestCase {
 
         modelLoadingService.clusterChanged(ingestChangedEvent(model1));
 
-        assertBusy(() -> { assertThat(circuitBreaker.getUsed(), equalTo(5L)); });
+        assertBusy(() -> assertThat(circuitBreaker.getUsed(), equalTo(5L)));
     }
 
     public void testReferenceCounting() throws Exception {
@@ -492,12 +492,12 @@ public class ModelLoadingServiceTests extends ESTestCase {
         modelLoadingService.clusterChanged(ingestChangedEvent(modelId));
 
         PlainActionFuture<LocalModel> forPipeline = new PlainActionFuture<>();
-        modelLoadingService.getModelForPipeline(modelId, forPipeline);
+        modelLoadingService.getModelForPipeline(modelId, null, forPipeline);
         final LocalModel model = forPipeline.get();
         assertBusy(() -> assertEquals(2, model.getReferenceCount()));
 
         PlainActionFuture<LocalModel> forSearch = new PlainActionFuture<>();
-        modelLoadingService.getModelForPipeline(modelId, forSearch);
+        modelLoadingService.getModelForPipeline(modelId, null, forSearch);
         forSearch.get();
         assertBusy(() -> assertEquals(3, model.getReferenceCount()));
 
@@ -505,7 +505,7 @@ public class ModelLoadingServiceTests extends ESTestCase {
         assertBusy(() -> assertEquals(2, model.getReferenceCount()));
 
         PlainActionFuture<LocalModel> forSearch2 = new PlainActionFuture<>();
-        modelLoadingService.getModelForPipeline(modelId, forSearch2);
+        modelLoadingService.getModelForPipeline(modelId, null, forSearch2);
         forSearch2.get();
         assertBusy(() -> assertEquals(3, model.getReferenceCount()));
     }
@@ -529,12 +529,12 @@ public class ModelLoadingServiceTests extends ESTestCase {
         modelLoadingService.clusterChanged(ingestChangedEvent(modelId));
 
         PlainActionFuture<LocalModel> forPipeline = new PlainActionFuture<>();
-        modelLoadingService.getModelForPipeline(modelId, forPipeline);
+        modelLoadingService.getModelForPipeline(modelId, null, forPipeline);
         final LocalModel model = forPipeline.get();
         assertBusy(() -> assertEquals(2, model.getReferenceCount()));
 
         PlainActionFuture<LocalModel> forPipeline2 = new PlainActionFuture<>();
-        modelLoadingService.getModelForPipeline(modelId, forPipeline2);
+        modelLoadingService.getModelForPipeline(modelId, null, forPipeline2);
         forPipeline2.get();
         assertBusy(() -> assertEquals(3, model.getReferenceCount()));
 
@@ -560,7 +560,7 @@ public class ModelLoadingServiceTests extends ESTestCase {
         );
 
         PlainActionFuture<LocalModel> future = new PlainActionFuture<>();
-        modelLoadingService.getModelForPipeline(modelId, future);
+        modelLoadingService.getModelForPipeline(modelId, null, future);
         LocalModel model = future.get();
         assertEquals(1, model.getReferenceCount());
     }
@@ -584,14 +584,14 @@ public class ModelLoadingServiceTests extends ESTestCase {
         );
 
         modelLoadingService.clusterChanged(
-            aliasChangeEvent(true, new String[] { "loaded_model" }, true, Arrays.asList(Tuple.tuple(model1, "loaded_model")))
+            aliasChangeEvent(true, new String[] { "loaded_model" }, true, List.of(Tuple.tuple(model1, "loaded_model")))
         );
 
         String[] modelIds = new String[] { model1, "loaded_model" };
         for (int i = 0; i < 10; i++) {
             String model = modelIds[i % 2];
             PlainActionFuture<LocalModel> future = new PlainActionFuture<>();
-            modelLoadingService.getModelForPipeline(model, future);
+            modelLoadingService.getModelForPipeline(model, null, future);
             assertThat(future.get(), is(not(nullValue())));
         }
 
@@ -602,14 +602,14 @@ public class ModelLoadingServiceTests extends ESTestCase {
 
         // alias change only
         modelLoadingService.clusterChanged(
-            aliasChangeEvent(true, new String[] { "loaded_model" }, false, Arrays.asList(Tuple.tuple(model2, "loaded_model")))
+            aliasChangeEvent(true, new String[] { "loaded_model" }, false, List.of(Tuple.tuple(model2, "loaded_model")))
         );
 
         modelIds = new String[] { model2, "loaded_model" };
         for (int i = 0; i < 10; i++) {
             String model = modelIds[i % 2];
             PlainActionFuture<LocalModel> future = new PlainActionFuture<>();
-            modelLoadingService.getModelForPipeline(model, future);
+            modelLoadingService.getModelForPipeline(model, null, future);
             assertThat(future.get(), is(not(nullValue())));
         }
 
@@ -636,9 +636,7 @@ public class ModelLoadingServiceTests extends ESTestCase {
             mock(XPackLicenseState.class)
         );
 
-        modelLoadingService.clusterChanged(
-            aliasChangeEvent(false, new String[0], false, Arrays.asList(Tuple.tuple(model1, "loaded_model")))
-        );
+        modelLoadingService.clusterChanged(aliasChangeEvent(false, new String[0], false, List.of(Tuple.tuple(model1, "loaded_model"))));
 
         assertThat(modelLoadingService.getModelId("loaded_model"), equalTo(model1));
 
@@ -676,10 +674,10 @@ public class ModelLoadingServiceTests extends ESTestCase {
         }).when(trainedModelProvider).getTrainedModelForInference(eq(modelId), eq(false), any());
         doAnswer(invocationOnMock -> {
             @SuppressWarnings("rawtypes")
-            ActionListener listener = (ActionListener) invocationOnMock.getArguments()[2];
+            ActionListener listener = (ActionListener) invocationOnMock.getArguments()[3];
             listener.onResponse(trainedModelConfig);
             return null;
-        }).when(trainedModelProvider).getTrainedModel(eq(modelId), eq(GetTrainedModelsAction.Includes.empty()), any());
+        }).when(trainedModelProvider).getTrainedModel(eq(modelId), eq(GetTrainedModelsAction.Includes.empty()), any(), any());
     }
 
     @SuppressWarnings("unchecked")
@@ -687,19 +685,19 @@ public class ModelLoadingServiceTests extends ESTestCase {
         if (randomBoolean()) {
             doAnswer(invocationOnMock -> {
                 @SuppressWarnings("rawtypes")
-                ActionListener listener = (ActionListener) invocationOnMock.getArguments()[2];
+                ActionListener listener = (ActionListener) invocationOnMock.getArguments()[3];
                 listener.onFailure(new ResourceNotFoundException(Messages.getMessage(Messages.INFERENCE_NOT_FOUND, modelId)));
                 return null;
-            }).when(trainedModelProvider).getTrainedModel(eq(modelId), eq(GetTrainedModelsAction.Includes.empty()), any());
+            }).when(trainedModelProvider).getTrainedModel(eq(modelId), eq(GetTrainedModelsAction.Includes.empty()), any(), any());
         } else {
             TrainedModelConfig trainedModelConfig = mock(TrainedModelConfig.class);
             when(trainedModelConfig.getModelSize()).thenReturn(0L);
             doAnswer(invocationOnMock -> {
                 @SuppressWarnings("rawtypes")
-                ActionListener listener = (ActionListener) invocationOnMock.getArguments()[2];
+                ActionListener listener = (ActionListener) invocationOnMock.getArguments()[3];
                 listener.onResponse(trainedModelConfig);
                 return null;
-            }).when(trainedModelProvider).getTrainedModel(eq(modelId), eq(GetTrainedModelsAction.Includes.empty()), any());
+            }).when(trainedModelProvider).getTrainedModel(eq(modelId), eq(GetTrainedModelsAction.Includes.empty()), any(), any());
             doAnswer(invocationOnMock -> {
                 @SuppressWarnings("rawtypes")
                 ActionListener listener = (ActionListener) invocationOnMock.getArguments()[2];

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/persistence/TrainedModelProviderTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/persistence/TrainedModelProviderTests.java
@@ -68,14 +68,14 @@ public class TrainedModelProviderTests extends ESTestCase {
         TrainedModelProvider trainedModelProvider = new TrainedModelProvider(mock(Client.class), xContentRegistry());
         for (String modelId : TrainedModelProvider.MODELS_STORED_AS_RESOURCE) {
             PlainActionFuture<TrainedModelConfig> future = new PlainActionFuture<>();
-            trainedModelProvider.getTrainedModel(modelId, GetTrainedModelsAction.Includes.forModelDefinition(), future);
+            trainedModelProvider.getTrainedModel(modelId, GetTrainedModelsAction.Includes.forModelDefinition(), null, future);
             TrainedModelConfig configWithDefinition = future.actionGet();
 
             assertThat(configWithDefinition.getModelId(), equalTo(modelId));
             assertThat(configWithDefinition.ensureParsedDefinition(xContentRegistry()).getModelDefinition(), is(not(nullValue())));
 
             PlainActionFuture<TrainedModelConfig> futureNoDefinition = new PlainActionFuture<>();
-            trainedModelProvider.getTrainedModel(modelId, GetTrainedModelsAction.Includes.empty(), futureNoDefinition);
+            trainedModelProvider.getTrainedModel(modelId, GetTrainedModelsAction.Includes.empty(), null, futureNoDefinition);
             TrainedModelConfig configWithoutDefinition = futureNoDefinition.actionGet();
 
             assertThat(configWithoutDefinition.getModelId(), equalTo(modelId));
@@ -123,12 +123,12 @@ public class TrainedModelProviderTests extends ESTestCase {
 
         assertThat(
             TrainedModelProvider.collectIds(new PageParams(1, 1), Collections.singleton("c"), new HashSet<>(Arrays.asList("a", "b"))),
-            equalTo(new TreeSet<>(Arrays.asList("b")))
+            equalTo(new TreeSet<>(List.of("b")))
         );
 
         assertThat(
             TrainedModelProvider.collectIds(new PageParams(1, 1), Collections.singleton("b"), new HashSet<>(Arrays.asList("a", "c"))),
-            equalTo(new TreeSet<>(Arrays.asList("b")))
+            equalTo(new TreeSet<>(List.of("b")))
         );
 
         assertThat(

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/trainedmodels/langident/LangIdentNeuralNetworkInferenceTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/trainedmodels/langident/LangIdentNeuralNetworkInferenceTests.java
@@ -179,7 +179,7 @@ public class LangIdentNeuralNetworkInferenceTests extends ESTestCase {
         TrainedModelProvider trainedModelProvider = new TrainedModelProvider(mock(Client.class), xContentRegistry());
         PlainActionFuture<TrainedModelConfig> future = new PlainActionFuture<>();
         // Should be OK as we don't make any client calls
-        trainedModelProvider.getTrainedModel("lang_ident_model_1", GetTrainedModelsAction.Includes.forModelDefinition(), future);
+        trainedModelProvider.getTrainedModel("lang_ident_model_1", GetTrainedModelsAction.Includes.forModelDefinition(), null, future);
         TrainedModelConfig config = future.actionGet();
 
         config.ensureParsedDefinition(xContentRegistry());

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/TransportGetTransformAction.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/TransportGetTransformAction.java
@@ -21,6 +21,7 @@ import org.elasticsearch.persistent.PersistentTasksCustomMetadata;
 import org.elasticsearch.search.builder.SearchSourceBuilder;
 import org.elasticsearch.search.sort.SortOrder;
 import org.elasticsearch.tasks.Task;
+import org.elasticsearch.tasks.TaskId;
 import org.elasticsearch.transport.TransportService;
 import org.elasticsearch.xcontent.NamedXContentRegistry;
 import org.elasticsearch.xcontent.ParseField;
@@ -87,7 +88,7 @@ public class TransportGetTransformAction extends AbstractTransportGetResourcesAc
         }, listener::onFailure);
 
         // Step 1: Search for all the transform configs matching the request.
-        searchResources(request, searchTransformConfigsListener);
+        searchResources(request, new TaskId(clusterService.localNode().getId(), task.getId()), searchTransformConfigsListener);
     }
 
     @Override

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/rest/action/RestGetTransformAction.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/rest/action/RestGetTransformAction.java
@@ -10,6 +10,7 @@ package org.elasticsearch.xpack.transform.rest.action;
 import org.elasticsearch.client.internal.node.NodeClient;
 import org.elasticsearch.rest.BaseRestHandler;
 import org.elasticsearch.rest.RestRequest;
+import org.elasticsearch.rest.action.RestCancellableNodeClient;
 import org.elasticsearch.rest.action.RestToXContentListener;
 import org.elasticsearch.xpack.core.action.util.PageParams;
 import org.elasticsearch.xpack.core.transform.TransformField;
@@ -48,7 +49,11 @@ public class RestGetTransformAction extends BaseRestHandler {
                 )
             );
         }
-        return channel -> client.execute(GetTransformAction.INSTANCE, request, new RestToXContentListener<>(channel));
+        return channel -> new RestCancellableNodeClient(client, restRequest.getHttpChannel()).execute(
+            GetTransformAction.INSTANCE,
+            request,
+            new RestToXContentListener<>(channel)
+        );
     }
 
     @Override


### PR DESCRIPTION
This change makes all the trained model APIs cancellable, and addresses the handful of APIs that rely on our abstract resource structure.

closes: https://github.com/elastic/elasticsearch/issues/87931
relates: #88010