### PR TITLE
[ML] Rebalance should not notify listener before update is applied

### DIFF
--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportStartTrainedModelDeploymentAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportStartTrainedModelDeploymentAction.java
@@ -450,6 +450,7 @@ public class TransportStartTrainedModelDeploymentAction extends TransportMasterN
                 .orElse(null);
             if (trainedModelAssignment == null) {
                 // Something weird happened, it should NEVER be null...
+                logger.trace(() -> format("[%s] assignment was null while waiting for state [%s]", modelId, waitForState));
                 return true;
             }
 

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/assignment/TrainedModelAssignmentMetadata.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/assignment/TrainedModelAssignmentMetadata.java
@@ -16,6 +16,7 @@ import org.elasticsearch.cluster.DiffableUtils;
 import org.elasticsearch.cluster.NamedDiff;
 import org.elasticsearch.cluster.SimpleDiffable;
 import org.elasticsearch.cluster.metadata.Metadata;
+import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.xcontent.XContentBuilder;
@@ -147,6 +148,11 @@ public class TrainedModelAssignmentMetadata implements Metadata.Custom {
     @Override
     public int hashCode() {
         return Objects.hash(modelRoutingEntries);
+    }
+
+    @Override
+    public String toString() {
+        return Strings.toString(this);
     }
 
     public static class Builder {


### PR DESCRIPTION
When we are rebalancing trained model assignments, we eventually
update cluster state with the new metadata. We only want to
notify the listener after we have applied the cluster state update.
This commit fixes a bug where we could notify before the update
was actually applied resulting in NPE when writing the response
of the `CreateTrainedModelAssignmentAction`.

This is a fix following the work done in #87366.
