### PR TITLE
[ML] Stopping a model deployment should trigger rebalance

### DIFF
--- a/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/PyTorchModelIT.java
+++ b/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/PyTorchModelIT.java
@@ -137,7 +137,8 @@ public class PyTorchModelIT extends ESRestTestCase {
             {"persistent" : {
                     "logger.org.elasticsearch.xpack.ml.inference.assignment": null,
                     "logger.org.elasticsearch.xpack.ml.inference.deployment" : null,
-                    "logger.org.elasticsearch.xpack.ml.process.logging" : null
+                    "logger.org.elasticsearch.xpack.ml.process.logging" : null,
+                    "xpack.ml.max_lazy_ml_nodes": null
                 }}""");
         client().performRequest(loggingSettings);
 
@@ -687,6 +688,53 @@ public class PyTorchModelIT extends ESRestTestCase {
         assertThatTrainedModelAssignmentMetadataIsEmpty();
     }
 
+    public void testStoppingDeploymentShouldTriggerRebalance() throws Exception {
+        // We start 2 models. The first needs so many allocations it won't possibly
+        // get them all. This would leave no space to allocate the second model at all.
+        // We then stop the first model and should see the second one get allocations.
+
+        // Enable lazy starting so that the deployments start even if they cannot get fully allocated.
+        // The setting is cleared in the cleanup method of these tests.
+        Request loggingSettings = new Request("PUT", "_cluster/settings");
+        loggingSettings.setJsonEntity("""
+            {"persistent" : {
+                    "xpack.ml.max_lazy_ml_nodes": 5
+                }}""");
+        client().performRequest(loggingSettings);
+
+        String modelId1 = "model_1";
+        createTrainedModel(modelId1);
+        putModelDefinition(modelId1);
+        putVocabulary(List.of("these", "are", "my", "words"), modelId1);
+
+        String modelId2 = "model_2";
+        createTrainedModel(modelId2);
+        putModelDefinition(modelId2);
+        putVocabulary(List.of("these", "are", "my", "words"), modelId2);
+
+        startDeployment(modelId1, AllocationStatus.State.STARTED.toString(), 100, 1);
+        startDeployment(modelId2, AllocationStatus.State.STARTING.toString(), 1, 1);
+
+        // Check second model did not get any allocations
+        assertAllocationCount(modelId2, 0);
+
+        stopDeployment(modelId1);
+
+        assertBusy(() -> assertAllocationCount(modelId2, 1));
+
+        stopDeployment(modelId2);
+    }
+
+    @SuppressWarnings("unchecked")
+    private void assertAllocationCount(String modelId, int expectedAllocationCount) throws IOException {
+        Response response = getTrainedModelStats(modelId);
+        var responseMap = entityAsMap(response);
+        List<Map<String, Object>> stats = (List<Map<String, Object>>) responseMap.get("trained_model_stats");
+        assertThat(stats, hasSize(1));
+        int allocations = (int) XContentMapValues.extractValue("deployment_stats.allocation_status.allocation_count", stats.get(0));
+        assertThat(allocations, equalTo(expectedAllocationCount));
+    }
+
     private int sumInferenceCountOnNodes(List<Map<String, Object>> nodes) {
         int inferenceCount = 0;
         for (var node : nodes) {
@@ -740,13 +788,21 @@ public class PyTorchModelIT extends ESRestTestCase {
     }
 
     private Response startDeployment(String modelId, String waitForState) throws IOException {
+        return startDeployment(modelId, waitForState, 1, 1);
+    }
+
+    private Response startDeployment(String modelId, String waitForState, int numberOfAllocations, int threadsPerAllocation)
+        throws IOException {
         Request request = new Request(
             "POST",
             "/_ml/trained_models/"
                 + modelId
                 + "/deployment/_start?timeout=40s&wait_for="
                 + waitForState
-                + "&threads_per_allocation=1&number_of_allocations=1"
+                + "&threads_per_allocation="
+                + threadsPerAllocation
+                + "&number_of_allocations="
+                + numberOfAllocations
         );
         return client().performRequest(request);
     }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/assignment/TrainedModelAssignmentClusterService.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/assignment/TrainedModelAssignmentClusterService.java
@@ -322,6 +322,22 @@ public class TrainedModelAssignmentClusterService implements ClusterStateListene
 
             @Override
             public void clusterStateProcessed(ClusterState oldState, ClusterState newState) {
+                // As a model deployment has been stopped we should rebalance as we might now
+                // be able to satisfy more allocations for the rest of the deployments.
+                rebalanceAssignments(
+                    newState,
+                    Optional.empty(),
+                    "deployment for model [" + modelId + "] stopped",
+                    ActionListener.wrap(
+                        metadataAfterRebalance -> logger.debug(
+                            () -> format("Successfully rebalanced model deployments after deployment for model [%s] was stopped", modelId)
+                        ),
+                        e -> logger.error(
+                            format("Failed to rebalance model deployments after deployment for model [%s] was stopped", modelId),
+                            e
+                        )
+                    )
+                );
                 listener.onResponse(AcknowledgedResponse.TRUE);
             }
         });


### PR DESCRIPTION
When a model deployment is stopped we remove the allocations
it was using. This opens up capacity for granting more allocations
to existing deployments that may not be fully satisfied.

With this commit we attempt to rebalance model assignments
after a model deployment has been stopped.
