### PR TITLE
Initialize ES logging api for tests

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/logging/LogConfigurator.java
+++ b/server/src/main/java/org/elasticsearch/common/logging/LogConfigurator.java
@@ -124,7 +124,7 @@ public class LogConfigurator {
         configure(environment.settings(), environment.configFile(), environment.logsFile(), useConsole);
     }
 
-    private static void configureESLogging() {
+    public static void configureESLogging() {
         LoggerFactory.setInstance(new LoggerFactoryImpl());
     }
 

--- a/test/framework/src/main/java/org/elasticsearch/test/ESTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/ESTestCase.java
@@ -221,7 +221,9 @@ public abstract class ESTestCase extends LuceneTestCase {
     static {
         TEST_WORKER_VM_ID = System.getProperty(TEST_WORKER_SYS_PROPERTY, DEFAULT_TEST_WORKER_ID);
         setTestSysProps();
+        // TODO: consolidate logging initialization for tests so it all occurs in logconfigurator
         LogConfigurator.loadLog4jPlugins();
+        LogConfigurator.configureESLogging();
 
         for (String leakLoggerName : Arrays.asList("io.netty.util.ResourceLeakDetector", LeakTracker.class.getName())) {
             Logger leakLogger = LogManager.getLogger(leakLoggerName);


### PR DESCRIPTION
This commit adds initialization of the new ES logging api into
ESTestCase, so that tests can begin using the new logging api.