### PR TITLE
More REST tests for avg/max/min/sum_bucket aggs

### DIFF
--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.aggregation/500_avg_bucket.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.aggregation/500_avg_bucket.yml
@@ -147,3 +147,98 @@ gap_policy=keep_value:
   - match: { hits.total.value: 3 }
   - length: { aggregations.@timestamp.buckets: 4 }
   - close_to: { aggregations.d.value: { value: 1.333, error: 0.0005 }}
+
+---
+dotted name:
+  - skip:
+      features: close_to
+
+  - do:
+      search:
+        index: no_gaps
+        body:
+          size: 0
+          aggs:
+            "@time.stamp":
+              date_histogram:
+                field: "@timestamp"
+                fixed_interval: 1h
+              aggs:
+                v: {avg: {field: v}}
+            d:
+              avg_bucket:
+                buckets_path: "@time.stamp>v"
+  - match: { hits.total.value: 3 }
+  - length: { aggregations.@time\.stamp.buckets: 3 }
+  - close_to: { aggregations.d.value: { value: 1.333, error: 0.0005 }}
+
+---
+dotted value:
+  - skip:
+      features: close_to
+
+  - do:
+      search:
+        index: no_gaps
+        body:
+          size: 0
+          aggs:
+            "@timestamp":
+              date_histogram:
+                field: "@timestamp"
+                fixed_interval: 1h
+              aggs:
+                v:
+                  percentiles:
+                    field: v
+                    percents: [ 50, 99.9 ]
+            d:
+              avg_bucket:
+                buckets_path: "@timestamp>v[99.9]"
+  - match: { hits.total.value: 3 }
+  - length: { aggregations.@timestamp.buckets: 3 }
+  - close_to: { aggregations.d.value: { value: 1.333, error: 0.0005 }}
+
+---
+no results:
+  - do:
+      search:
+        index: no_gaps
+        body:
+          size: 0
+          query:
+            match:
+              missing_field: not_found
+          aggs:
+            "@timestamp":
+              date_histogram:
+                field: "@timestamp"
+                fixed_interval: 1h
+              aggs:
+                v: {avg: {field: v}}
+            d:
+              avg_bucket:
+                buckets_path: "@timestamp>v"
+  - match: { hits.total.value: 0 }
+  - length: { aggregations.@timestamp.buckets: 0 }
+  - is_false: aggregations.d.value
+
+---
+bad path:
+  - do:
+      catch: '/Validation Failed: 1: No aggregation \[v\] found for path \[@timestamp>v\];/'
+      search:
+        index: no_gaps
+        body:
+          size: 0
+          query:
+            match:
+              missing_field: not_found
+          aggs:
+            "@timestamp":
+              date_histogram:
+                field: "@timestamp"
+                fixed_interval: 1h
+            d:
+              avg_bucket:
+                buckets_path: "@timestamp>v"

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.aggregation/500_max_bucket.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.aggregation/500_max_bucket.yml
@@ -132,3 +132,92 @@ gap_policy=keep_value:
   - match: { hits.total.value: 3 }
   - length: { aggregations.@timestamp.buckets: 4 }
   - match: { aggregations.d.value: -1.0 }
+
+---
+dotted name:
+  - do:
+      search:
+        index: no_gaps
+        body:
+          size: 0
+          aggs:
+            "@time.stamp":
+              date_histogram:
+                field: "@timestamp"
+                fixed_interval: 1h
+              aggs:
+                v: {avg: {field: v}}
+            d:
+              max_bucket:
+                buckets_path: "@time.stamp>v"
+  - match: { hits.total.value: 3 }
+  - length: { aggregations.@time\.stamp.buckets: 3 }
+  - match: { aggregations.d.value: 2.0 }
+
+---
+dotted value:
+  - do:
+      search:
+        index: no_gaps
+        body:
+          size: 0
+          aggs:
+            "@timestamp":
+              date_histogram:
+                field: "@timestamp"
+                fixed_interval: 1h
+              aggs:
+                v:
+                  percentiles:
+                    field: v
+                    percents: [ 50, 99.9 ]
+            d:
+              max_bucket:
+                buckets_path: "@timestamp>v[99.9]"
+  - match: { hits.total.value: 3 }
+  - length: { aggregations.@timestamp.buckets: 3 }
+  - match: { aggregations.d.value: 2.0 }
+
+---
+no results:
+  - do:
+      search:
+        index: no_gaps
+        body:
+          size: 0
+          query:
+            match:
+              missing_field: not_found
+          aggs:
+            "@timestamp":
+              date_histogram:
+                field: "@timestamp"
+                fixed_interval: 1h
+              aggs:
+                v: {avg: {field: v}}
+            d:
+              max_bucket:
+                buckets_path: "@timestamp>v"
+  - match: { hits.total.value: 0 }
+  - length: { aggregations.@timestamp.buckets: 0 }
+  - is_false: aggregations.d.value
+
+---
+bad path:
+  - do:
+      catch: '/Validation Failed: 1: No aggregation \[v\] found for path \[@timestamp>v\];/'
+      search:
+        index: no_gaps
+        body:
+          size: 0
+          query:
+            match:
+              missing_field: not_found
+          aggs:
+            "@timestamp":
+              date_histogram:
+                field: "@timestamp"
+                fixed_interval: 1h
+            d:
+              max_bucket:
+                buckets_path: "@timestamp>v"

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.aggregation/500_min_bucket.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.aggregation/500_min_bucket.yml
@@ -132,3 +132,92 @@ gap_policy=keep_value:
   - match: { hits.total.value: 3 }
   - length: { aggregations.@timestamp.buckets: 4 }
   - match: { aggregations.d.value: 1.0 }
+
+---
+dotted name:
+  - do:
+      search:
+        index: no_gaps
+        body:
+          size: 0
+          aggs:
+            "@time.stamp":
+              date_histogram:
+                field: "@timestamp"
+                fixed_interval: 1h
+              aggs:
+                v: {avg: {field: v}}
+            d:
+              min_bucket:
+                buckets_path: "@time.stamp>v"
+  - match: { hits.total.value: 3 }
+  - length: { aggregations.@time\.stamp.buckets: 3 }
+  - match: { aggregations.d.value: 1.0 }
+
+---
+dotted value:
+  - do:
+      search:
+        index: no_gaps
+        body:
+          size: 0
+          aggs:
+            "@timestamp":
+              date_histogram:
+                field: "@timestamp"
+                fixed_interval: 1h
+              aggs:
+                v:
+                  percentiles:
+                    field: v
+                    percents: [ 50, 99.9 ]
+            d:
+              min_bucket:
+                buckets_path: "@timestamp>v[99.9]"
+  - match: { hits.total.value: 3 }
+  - length: { aggregations.@timestamp.buckets: 3 }
+  - match: { aggregations.d.value: 1.0 }
+
+---
+no results:
+  - do:
+      search:
+        index: no_gaps
+        body:
+          size: 0
+          query:
+            match:
+              missing_field: not_found
+          aggs:
+            "@timestamp":
+              date_histogram:
+                field: "@timestamp"
+                fixed_interval: 1h
+              aggs:
+                v: {avg: {field: v}}
+            d:
+              min_bucket:
+                buckets_path: "@timestamp>v"
+  - match: { hits.total.value: 0 }
+  - length: { aggregations.@timestamp.buckets: 0 }
+  - is_false: aggregations.d.value
+
+---
+bad path:
+  - do:
+      catch: '/Validation Failed: 1: No aggregation \[v\] found for path \[@timestamp>v\];/'
+      search:
+        index: no_gaps
+        body:
+          size: 0
+          query:
+            match:
+              missing_field: not_found
+          aggs:
+            "@timestamp":
+              date_histogram:
+                field: "@timestamp"
+                fixed_interval: 1h
+            d:
+              min_bucket:
+                buckets_path: "@timestamp>v"

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.aggregation/500_sum_bucket.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.aggregation/500_sum_bucket.yml
@@ -132,3 +132,92 @@ gap_policy=keep_value:
   - match: { hits.total.value: 3 }
   - length: { aggregations.@timestamp.buckets: 4 }
   - match: { aggregations.d.value: 4.0 }
+
+---
+dotted name:
+  - do:
+      search:
+        index: no_gaps
+        body:
+          size: 0
+          aggs:
+            "@time.stamp":
+              date_histogram:
+                field: "@timestamp"
+                fixed_interval: 1h
+              aggs:
+                v: {avg: {field: v}}
+            d:
+              sum_bucket:
+                buckets_path: "@time.stamp>v"
+  - match: { hits.total.value: 3 }
+  - length: { aggregations.@time\.stamp.buckets: 3 }
+  - match: { aggregations.d.value: 4.0 }
+
+---
+dotted value:
+  - do:
+      search:
+        index: no_gaps
+        body:
+          size: 0
+          aggs:
+            "@timestamp":
+              date_histogram:
+                field: "@timestamp"
+                fixed_interval: 1h
+              aggs:
+                v:
+                  percentiles:
+                    field: v
+                    percents: [ 50, 99.9 ]
+            d:
+              sum_bucket:
+                buckets_path: "@timestamp>v[99.9]"
+  - match: { hits.total.value: 3 }
+  - length: { aggregations.@timestamp.buckets: 3 }
+  - match: { aggregations.d.value: 4.0 }
+
+---
+no results:
+  - do:
+      search:
+        index: no_gaps
+        body:
+          size: 0
+          query:
+            match:
+              missing_field: not_found
+          aggs:
+            "@timestamp":
+              date_histogram:
+                field: "@timestamp"
+                fixed_interval: 1h
+              aggs:
+                v: {avg: {field: v}}
+            d:
+              sum_bucket:
+                buckets_path: "@timestamp>v"
+  - match: { hits.total.value: 0 }
+  - length: { aggregations.@timestamp.buckets: 0 }
+  - match: { aggregations.d.value: 0.0 }
+
+---
+bad path:
+  - do:
+      catch: '/Validation Failed: 1: No aggregation \[v\] found for path \[@timestamp>v\];/'
+      search:
+        index: no_gaps
+        body:
+          size: 0
+          query:
+            match:
+              missing_field: not_found
+          aggs:
+            "@timestamp":
+              date_histogram:
+                field: "@timestamp"
+                fixed_interval: 1h
+            d:
+              sum_bucket:
+                buckets_path: "@timestamp>v"


### PR DESCRIPTION
Adds REST layer tests for some sneaky cases in the the `avg_bucket`,
`max_bucket`, `min_bucket`, and `sum_bucket` pipeline aggregations.
This gives us forwards and backwards compatibility tests for these
aggs as well as mixed version cluster tests for these aggs.

Relates to #26220
