### PR TITLE
REST tests for percentiles_bucket agg

### DIFF
--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.aggregation/500_percentiles_bucket.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.aggregation/500_percentiles_bucket.yml
@@ -1,0 +1,293 @@
+setup:
+  - do:
+      bulk:
+        index: no_gaps
+        refresh: true
+        body:
+          - { "index": { } }
+          - { "@timestamp": "2022-01-01T00:00:00", "v": 1 }
+          - { "index": { } }
+          - { "@timestamp": "2022-01-01T01:00:00", "v": 2 }
+          - { "index": { } }
+          - { "@timestamp": "2022-01-01T02:00:00", "v": 1 }
+
+  - do:
+      bulk:
+        index: gaps
+        refresh: true
+        body:
+          - { "index": { } }
+          - { "@timestamp": "2022-01-01T00:00:00", "v": 1 }
+          - { "index": { } }
+          - { "@timestamp": "2022-01-01T02:00:00", "v": 2 }
+          - { "index": { } }
+          - { "@timestamp": "2022-01-01T03:00:00", "v": 1 }
+
+---
+basic:
+  - do:
+      search:
+        index: no_gaps
+        body:
+          size: 0
+          aggs:
+            "@timestamp":
+              date_histogram:
+                field: "@timestamp"
+                fixed_interval: 1h
+              aggs:
+                v: {avg: {field: v}}
+            d:
+              percentiles_bucket:
+                buckets_path: "@timestamp>v"
+  - match: { hits.total.value: 3 }
+  - length: { aggregations.@timestamp.buckets: 3 }
+  - match:
+      aggregations.d.values:
+        1.0: 1.0
+        5.0: 1.0
+        25.0: 1.0
+        50.0: 1.0
+        75.0: 2.0
+        95.0: 2.0
+        99.0: 2.0
+
+---
+format:
+  - do:
+      search:
+        index: no_gaps
+        body:
+          size: 0
+          aggs:
+            "@timestamp":
+              date_histogram:
+                field: "@timestamp"
+                fixed_interval: 1h
+              aggs:
+                v: {avg: {field: v}}
+            d:
+              percentiles_bucket:
+                buckets_path: "@timestamp>v"
+                format: "0.00"
+  - match: { hits.total.value: 3 }
+  - length: { aggregations.@timestamp.buckets: 3 }
+  - match:
+      aggregations.d.values:
+        1.0: 1.0
+        5.0: 1.0
+        25.0: 1.0
+        50.0: 1.0
+        75.0: 2.0
+        95.0: 2.0
+        99.0: 2.0
+        1.0_as_string: "1.00"
+        5.0_as_string: "1.00"
+        50.0_as_string: "1.00"
+        25.0_as_string: "1.00"
+        75.0_as_string: "2.00"
+        95.0_as_string: "2.00"
+        99.0_as_string: "2.00"
+
+---
+gap_policy=skip:
+  - do:
+      search:
+        index: gaps
+        body:
+          size: 0
+          aggs:
+            "@timestamp":
+              date_histogram:
+                field: "@timestamp"
+                fixed_interval: 1h
+              aggs:
+                v: {avg: {field: v}}
+            d:
+              percentiles_bucket:
+                buckets_path: "@timestamp>v"
+                gap_policy: skip
+  - match: { hits.total.value: 3 }
+  - length: { aggregations.@timestamp.buckets: 4 }
+  - match:
+      aggregations.d.values:
+        1.0: 1.0
+        5.0: 1.0
+        25.0: 1.0
+        50.0: 1.0
+        75.0: 2.0
+        95.0: 2.0
+        99.0: 2.0
+
+---
+gap_policy=insert_zeros:
+  - do:
+      search:
+        index: gaps
+        body:
+          size: 0
+          aggs:
+            "@timestamp":
+              date_histogram:
+                field: "@timestamp"
+                fixed_interval: 1h
+              aggs:
+                v: {avg: {field: v}}
+            d:
+              percentiles_bucket:
+                buckets_path: "@timestamp>v"
+                gap_policy: insert_zeros
+  - match: { hits.total.value: 3 }
+  - length: { aggregations.@timestamp.buckets: 4 }
+  - match:
+      aggregations.d.values:
+        1.0: 0.0
+        5.0: 0.0
+        25.0: 1.0
+        50.0: 1.0
+        75.0: 1.0
+        95.0: 2.0
+        99.0: 2.0
+
+---
+gap_policy=keep_value:
+  - do:
+      search:
+        index: gaps
+        body:
+          size: 0
+          aggs:
+            "@timestamp":
+              date_histogram:
+                field: "@timestamp"
+                fixed_interval: 1h
+              aggs:
+                v: {avg: {field: v}}
+            d:
+              percentiles_bucket:
+                buckets_path: "@timestamp>v"
+                gap_policy: keep_values
+  - match: { hits.total.value: 3 }
+  - length: { aggregations.@timestamp.buckets: 4 }
+  - match:
+      aggregations.d.values:
+        1.0: 1.0
+        5.0: 1.0
+        25.0: 1.0
+        50.0: 1.0
+        75.0: 2.0
+        95.0: 2.0
+        99.0: 2.0
+
+---
+dotted name:
+  - do:
+      search:
+        index: no_gaps
+        body:
+          size: 0
+          aggs:
+            "@time.stamp":
+              date_histogram:
+                field: "@timestamp"
+                fixed_interval: 1h
+              aggs:
+                v: {avg: {field: v}}
+            d:
+              percentiles_bucket:
+                buckets_path: "@time.stamp>v"
+  - match: { hits.total.value: 3 }
+  - length: { aggregations.@time\.stamp.buckets: 3 }
+  - match:
+      aggregations.d.values:
+        1.0: 1.0
+        5.0: 1.0
+        25.0: 1.0
+        50.0: 1.0
+        75.0: 2.0
+        95.0: 2.0
+        99.0: 2.0
+
+---
+dotted value:
+  - do:
+      search:
+        index: no_gaps
+        body:
+          size: 0
+          aggs:
+            "@timestamp":
+              date_histogram:
+                field: "@timestamp"
+                fixed_interval: 1h
+              aggs:
+                v:
+                  percentiles:
+                    field: v
+                    percents: [ 50, 99.9 ]
+            d:
+              percentiles_bucket:
+                buckets_path: "@timestamp>v[99.9]"
+  - match: { hits.total.value: 3 }
+  - length: { aggregations.@timestamp.buckets: 3 }
+  - match:
+      aggregations.d.values:
+        1.0: 1.0
+        5.0: 1.0
+        25.0: 1.0
+        50.0: 1.0
+        75.0: 2.0
+        95.0: 2.0
+        99.0: 2.0
+
+---
+no results:
+  - do:
+      search:
+        index: no_gaps
+        body:
+          size: 0
+          query:
+            match:
+              missing_field: not_found
+          aggs:
+            "@timestamp":
+              date_histogram:
+                field: "@timestamp"
+                fixed_interval: 1h
+              aggs:
+                v: {avg: {field: v}}
+            d:
+              percentiles_bucket:
+                buckets_path: "@timestamp>v"
+  - match: { hits.total.value: 0 }
+  - length: { aggregations.@timestamp.buckets: 0 }
+  - match:
+      aggregations.d.values:
+        1.0: null
+        5.0: null
+        25.0: null
+        50.0: null
+        75.0: null
+        95.0: null
+        99.0: null
+
+---
+bad path:
+  - do:
+      catch: '/Validation Failed: 1: No aggregation \[v\] found for path \[@timestamp>v\];/'
+      search:
+        index: no_gaps
+        body:
+          size: 0
+          query:
+            match:
+              missing_field: not_found
+          aggs:
+            "@timestamp":
+              date_histogram:
+                field: "@timestamp"
+                fixed_interval: 1h
+            d:
+              percentiles_bucket:
+                buckets_path: "@timestamp>v"


### PR DESCRIPTION
Adds REST tests for the `percentiles_bucket` pipeline bucket
aggregation. This gives us forwards and backwards compatibility tests
for these aggs as well as mixed version cluster tests for these aggs.

Relates to #26220
