### PR TITLE
Update build tools changelog schema for label rename

### DIFF
--- a/build-tools-internal/src/main/resources/changelog-schema.json
+++ b/build-tools-internal/src/main/resources/changelog-schema.json
@@ -55,6 +55,7 @@
             "Infra/Scripting",
             "Infra/Settings",
             "Infra/Transport API",
+            "Ingest",
             "Ingest Node",
             "Java High Level REST Client",
             "Java Low Level REST Client",

--- a/build-tools-internal/src/main/resources/changelog-schema.json
+++ b/build-tools-internal/src/main/resources/changelog-schema.json
@@ -55,7 +55,7 @@
             "Infra/Scripting",
             "Infra/Settings",
             "Infra/Transport API",
-            "Ingest",
+            "Ingest Node",
             "Java High Level REST Client",
             "Java Low Level REST Client",
             "License",


### PR DESCRIPTION
The `:Data Management/Ingest` label was recently renamed to `:Data Management/Ingest Node`. This commit changes the build tools changelog schema to know about the rename.
