### PR TITLE
[7.17] Update build tools changelog schema for label rename (#88033)

### DIFF
--- a/build-tools-internal/src/main/resources/changelog-schema.json
+++ b/build-tools-internal/src/main/resources/changelog-schema.json
@@ -56,6 +56,7 @@
             "Infra/Settings",
             "Infra/Transport API",
             "Ingest",
+            "Ingest Node",
             "Java High Level REST Client",
             "Java Low Level REST Client",
             "License",


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `7.17`:
 - [Update build tools changelog schema for label rename (#88033)](https://github.com/elastic/elasticsearch/pull/88033)

<!--- Backport version: 8.4.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)