### PR TITLE
Reduce memory usage in field-caps responses

### DIFF
--- a/docs/changelog/88042.yaml
+++ b/docs/changelog/88042.yaml
@@ -1,0 +1,5 @@
+pr: 88042
+summary: Reduce memory usage in field-caps responses
+area: Search
+type: bug
+issues: []

--- a/server/src/main/java/org/elasticsearch/action/fieldcaps/FieldCapabilitiesFetcher.java
+++ b/server/src/main/java/org/elasticsearch/action/fieldcaps/FieldCapabilitiesFetcher.java
@@ -58,7 +58,7 @@ class FieldCapabilitiesFetcher {
             );
 
             if (canMatchShard(request, searchExecutionContext) == false) {
-                return new FieldCapabilitiesIndexResponse(request.index(), Collections.emptyMap(), false);
+                return new FieldCapabilitiesIndexResponse(request.index(), Collections.emptyList(), false);
             }
 
             Set<String> fieldNames = new HashSet<>();
@@ -118,7 +118,7 @@ class FieldCapabilitiesFetcher {
                     }
                 }
             }
-            return new FieldCapabilitiesIndexResponse(request.index(), responseMap, true);
+            return new FieldCapabilitiesIndexResponse(request.index(), responseMap.values(), true);
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/action/fieldcaps/TransportFieldCapabilitiesAction.java
+++ b/server/src/main/java/org/elasticsearch/action/fieldcaps/TransportFieldCapabilitiesAction.java
@@ -147,7 +147,7 @@ public class TransportFieldCapabilitiesAction extends HandledTransportAction<Fie
             remoteClusterClient.fieldCaps(remoteRequest, ActionListener.wrap(response -> {
                 for (FieldCapabilitiesIndexResponse resp : response.getIndexResponses()) {
                     String indexName = RemoteClusterAware.buildRemoteIndexName(clusterAlias, resp.getIndexName());
-                    indexResponses.putIfAbsent(indexName, new FieldCapabilitiesIndexResponse(indexName, resp.get(), resp.canMatch()));
+                    indexResponses.putIfAbsent(indexName, new FieldCapabilitiesIndexResponse(indexName, resp.getFields(), resp.canMatch()));
                 }
                 for (FieldCapabilitiesFailure failure : response.getFailures()) {
                     Exception ex = failure.getException();
@@ -265,17 +265,16 @@ public class TransportFieldCapabilitiesAction extends HandledTransportAction<Fie
         Map<String, Map<String, FieldCapabilities.Builder>> responseMapBuilder,
         FieldCapabilitiesIndexResponse response
     ) {
-        for (Map.Entry<String, IndexFieldCapabilities> entry : response.get().entrySet()) {
-            final String field = entry.getKey();
+        for (IndexFieldCapabilities fieldCap : response.getFields()) {
+            final String fieldName = fieldCap.getName();
             // best effort to detect metadata field coming from older nodes
             final boolean isMetadataField = response.getOriginVersion().onOrAfter(Version.V_7_13_0)
-                ? entry.getValue().isMetadatafield()
-                : metadataFieldPred.test(field);
-            final IndexFieldCapabilities fieldCap = entry.getValue();
-            Map<String, FieldCapabilities.Builder> typeMap = responseMapBuilder.computeIfAbsent(field, f -> new HashMap<>());
+                ? fieldCap.isMetadatafield()
+                : metadataFieldPred.test(fieldName);
+            Map<String, FieldCapabilities.Builder> typeMap = responseMapBuilder.computeIfAbsent(fieldName, f -> new HashMap<>());
             FieldCapabilities.Builder builder = typeMap.computeIfAbsent(
                 fieldCap.getType(),
-                key -> new FieldCapabilities.Builder(field, key)
+                key -> new FieldCapabilities.Builder(fieldName, key)
             );
             builder.add(response.getIndexName(), isMetadataField, fieldCap.isSearchable(), fieldCap.isAggregatable(), fieldCap.meta());
         }

--- a/server/src/test/java/org/elasticsearch/action/fieldcaps/FieldCapabilitiesIndexResponseTests.java
+++ b/server/src/test/java/org/elasticsearch/action/fieldcaps/FieldCapabilitiesIndexResponseTests.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.action.fieldcaps;
+
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.test.AbstractWireSerializingTestCase;
+
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.Collections;
+import java.util.List;
+
+import static com.carrotsearch.randomizedtesting.RandomizedTest.randomAsciiLettersOfLength;
+import static org.elasticsearch.action.fieldcaps.FieldCapabilitiesResponseTests.randomFieldCaps;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.equalTo;
+
+public class FieldCapabilitiesIndexResponseTests extends AbstractWireSerializingTestCase<FieldCapabilitiesIndexResponse> {
+    @Override
+    protected Writeable.Reader<FieldCapabilitiesIndexResponse> instanceReader() {
+        return FieldCapabilitiesIndexResponse::new;
+    }
+
+    static FieldCapabilitiesIndexResponse randomIndexResponse() {
+        return randomIndexResponse(randomAsciiLettersOfLength(10), randomBoolean());
+    }
+
+    static FieldCapabilitiesIndexResponse randomIndexResponse(String index, boolean canMatch) {
+        List<IndexFieldCapabilities> fields = new ArrayList<>();
+        if (canMatch) {
+            String[] fieldNames = generateRandomStringArray(5, 10, false, true);
+            assertNotNull(fieldNames);
+            for (String fieldName : fieldNames) {
+                fields.add(randomFieldCaps(fieldName));
+            }
+        }
+        return new FieldCapabilitiesIndexResponse(index, fields, canMatch);
+    }
+
+    @Override
+    protected FieldCapabilitiesIndexResponse createTestInstance() {
+        return randomIndexResponse();
+    }
+
+    public void testDeserializeFromBase64() throws Exception {
+        String base64 = "CWxvZ3MtMTAwMQMGcGVyaW9kBnBlcmlvZARsb25nAQABAQR1bml0BnNlY29uZApAdGltZXN0"
+            + "YW1wCkB0aW1lc3RhbXAEZGF0ZQEBAAAHbWVzc2FnZQdtZXNzYWdlBHRleHQAAQAAAQAAAAAAAAAAAA==";
+        StreamInput in = StreamInput.wrap(Base64.getDecoder().decode(base64));
+        FieldCapabilitiesIndexResponse resp = new FieldCapabilitiesIndexResponse(in);
+        assertTrue(resp.canMatch());
+        assertThat(resp.getIndexName(), equalTo("logs-1001"));
+        assertThat(
+            resp.getFields(),
+            containsInAnyOrder(
+                new IndexFieldCapabilities("@timestamp", "date", true, true, false, Collections.emptyMap()),
+                new IndexFieldCapabilities("message", "text", false, true, false, Collections.emptyMap()),
+                new IndexFieldCapabilities("period", "long", true, false, true, Collections.singletonMap("unit", "second"))
+            )
+        );
+    }
+}

--- a/server/src/test/java/org/elasticsearch/action/fieldcaps/FieldCapabilitiesNodeResponseTests.java
+++ b/server/src/test/java/org/elasticsearch/action/fieldcaps/FieldCapabilitiesNodeResponseTests.java
@@ -18,6 +18,8 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
+import static org.elasticsearch.action.fieldcaps.FieldCapabilitiesIndexResponseTests.randomIndexResponse;
+
 public class FieldCapabilitiesNodeResponseTests extends AbstractWireSerializingTestCase<FieldCapabilitiesNodeResponse> {
 
     @Override
@@ -25,7 +27,7 @@ public class FieldCapabilitiesNodeResponseTests extends AbstractWireSerializingT
         List<FieldCapabilitiesIndexResponse> responses = new ArrayList<>();
         int numResponse = randomIntBetween(0, 10);
         for (int i = 0; i < numResponse; i++) {
-            responses.add(FieldCapabilitiesResponseTests.createRandomIndexResponse());
+            responses.add(randomIndexResponse());
         }
         int numUnmatched = randomIntBetween(0, 3);
         Set<ShardId> shardIds = new HashSet<>();
@@ -46,7 +48,7 @@ public class FieldCapabilitiesNodeResponseTests extends AbstractWireSerializingT
         int mutation = response.getIndexResponses().isEmpty() ? 0 : randomIntBetween(0, 2);
         switch (mutation) {
             case 0:
-                newResponses.add(FieldCapabilitiesResponseTests.createRandomIndexResponse());
+                newResponses.add(randomIndexResponse());
                 break;
             case 1:
                 int toRemove = randomInt(newResponses.size() - 1);
@@ -54,7 +56,7 @@ public class FieldCapabilitiesNodeResponseTests extends AbstractWireSerializingT
                 break;
             case 2:
                 int toReplace = randomInt(newResponses.size() - 1);
-                newResponses.set(toReplace, FieldCapabilitiesResponseTests.createRandomIndexResponse());
+                newResponses.set(toReplace, randomIndexResponse());
                 break;
         }
         return new FieldCapabilitiesNodeResponse(newResponses, Collections.emptyMap(), response.getUnmatchedShardIds());

--- a/server/src/test/java/org/elasticsearch/action/fieldcaps/FieldCapabilitiesResponseTests.java
+++ b/server/src/test/java/org/elasticsearch/action/fieldcaps/FieldCapabilitiesResponseTests.java
@@ -56,15 +56,13 @@ public class FieldCapabilitiesResponseTests extends AbstractWireSerializingTestC
     }
 
     public static FieldCapabilitiesIndexResponse randomIndexResponse(String index, boolean canMatch) {
-        Map<String, IndexFieldCapabilities> responses = new HashMap<>();
-
-        String[] fields = generateRandomStringArray(5, 10, false, true);
-        assertNotNull(fields);
-
-        for (String field : fields) {
-            responses.put(field, randomFieldCaps(field));
+        List<IndexFieldCapabilities> fields = new ArrayList<>();
+        String[] fieldNames = generateRandomStringArray(5, 10, false, true);
+        assertNotNull(fieldNames);
+        for (String fieldName : fieldNames) {
+            fields.add(randomFieldCaps(fieldName));
         }
-        return new FieldCapabilitiesIndexResponse(index, responses, canMatch);
+        return new FieldCapabilitiesIndexResponse(index, fields, canMatch);
     }
 
     public static IndexFieldCapabilities randomFieldCaps(String fieldName) {

--- a/server/src/test/java/org/elasticsearch/action/fieldcaps/FieldCapabilitiesResponseTests.java
+++ b/server/src/test/java/org/elasticsearch/action/fieldcaps/FieldCapabilitiesResponseTests.java
@@ -29,8 +29,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import static com.carrotsearch.randomizedtesting.RandomizedTest.randomAsciiLettersOfLength;
-
 public class FieldCapabilitiesResponseTests extends AbstractWireSerializingTestCase<FieldCapabilitiesResponse> {
 
     @Override
@@ -40,7 +38,7 @@ public class FieldCapabilitiesResponseTests extends AbstractWireSerializingTestC
         int numResponse = randomIntBetween(0, 10);
 
         for (int i = 0; i < numResponse; i++) {
-            responses.add(createRandomIndexResponse());
+            responses.add(FieldCapabilitiesIndexResponseTests.randomIndexResponse());
         }
         randomResponse = new FieldCapabilitiesResponse(responses, Collections.emptyList());
         return randomResponse;
@@ -49,20 +47,6 @@ public class FieldCapabilitiesResponseTests extends AbstractWireSerializingTestC
     @Override
     protected Writeable.Reader<FieldCapabilitiesResponse> instanceReader() {
         return FieldCapabilitiesResponse::new;
-    }
-
-    public static FieldCapabilitiesIndexResponse createRandomIndexResponse() {
-        return randomIndexResponse(randomAsciiLettersOfLength(10), randomBoolean());
-    }
-
-    public static FieldCapabilitiesIndexResponse randomIndexResponse(String index, boolean canMatch) {
-        List<IndexFieldCapabilities> fields = new ArrayList<>();
-        String[] fieldNames = generateRandomStringArray(5, 10, false, true);
-        assertNotNull(fieldNames);
-        for (String fieldName : fieldNames) {
-            fields.add(randomFieldCaps(fieldName));
-        }
-        return new FieldCapabilitiesIndexResponse(index, fields, canMatch);
     }
 
     public static IndexFieldCapabilities randomFieldCaps(String fieldName) {

--- a/server/src/test/java/org/elasticsearch/action/fieldcaps/RequestDispatcherTests.java
+++ b/server/src/test/java/org/elasticsearch/action/fieldcaps/RequestDispatcherTests.java
@@ -81,7 +81,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
-import static org.elasticsearch.action.fieldcaps.FieldCapabilitiesResponseTests.randomIndexResponse;
+import static org.elasticsearch.action.fieldcaps.FieldCapabilitiesIndexResponseTests.randomIndexResponse;
 import static org.elasticsearch.action.fieldcaps.RequestDispatcher.GROUP_REQUESTS_VERSION;
 import static org.hamcrest.Matchers.anEmptyMap;
 import static org.hamcrest.Matchers.equalTo;


### PR DESCRIPTION
We have reduced the memory usage of field-caps requests targeting many indices in 8.2+ (see https://github.com/elastic/elasticsearch/pull/83494). Unfortunately, we still receive OOM reports in 7.17. I think we should push some contained improvements to reduce the memory usage for those requests in 7.17. I have looked into several options. This PR can reduce the memory usage of field-caps responses by replace HashMap with ArrayList for the field responses to eliminate duplicated string names and internal nodes of Map. I will look into other options, such as deduplicating field-name strings or field-responses.