### PR TITLE
Presize RoutingNode

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/routing/RoutingNode.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/RoutingNode.java
@@ -17,7 +17,6 @@ import org.elasticsearch.index.shard.ShardId;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
@@ -48,13 +47,19 @@ public class RoutingNode implements Iterable<ShardRouting> {
 
     private final Map<Index, Set<ShardRouting>> shardsByIndex;
 
-    RoutingNode(String nodeId, @Nullable DiscoveryNode node) {
+    /**
+     * @param nodeId    node id of this routing node
+     * @param node      discovery node for this routing node
+     * @param sizeGuess estimate for the number of shards that will be added to this instance to save re-hashing on subsequent calls to
+     *                  {@link #add(ShardRouting)}
+     */
+    RoutingNode(String nodeId, @Nullable DiscoveryNode node, int sizeGuess) {
         this.nodeId = nodeId;
         this.node = node;
-        this.shards = new LinkedHashMap<>();
+        this.shards = Maps.newLinkedHashMapWithExpectedSize(sizeGuess);
         this.relocatingShards = new LinkedHashSet<>();
         this.initializingShards = new LinkedHashSet<>();
-        this.shardsByIndex = new HashMap<>();
+        this.shardsByIndex = Maps.newHashMapWithExpectedSize(sizeGuess);
         assert invariant();
     }
 

--- a/test/framework/src/main/java/org/elasticsearch/cluster/routing/RoutingNodesHelper.java
+++ b/test/framework/src/main/java/org/elasticsearch/cluster/routing/RoutingNodesHelper.java
@@ -60,7 +60,7 @@ public final class RoutingNodesHelper {
     }
 
     public static RoutingNode routingNode(String nodeId, DiscoveryNode node, ShardRouting... shards) {
-        final RoutingNode routingNode = new RoutingNode(nodeId, node);
+        final RoutingNode routingNode = new RoutingNode(nodeId, node, shards.length);
         for (ShardRouting shardRouting : shards) {
             routingNode.add(shardRouting);
         }


### PR DESCRIPTION
Presize maps in `RoutingNode` with the best-guess that every node
holds it's proportionate share of double the number of indices which
seems like the best possible guess (1 shards + 1 replica per index,
all nodes homogeneous).
This saves a lot of re-hashing when data nodes hold lots of shards
and speeds up bootstrapping 50k indices in the many-shards benchmark
by more than 2 percent.

relates #77466 