### PR TITLE
Faster DatastreamMetadata Diff application

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/metadata/DataStreamMetadata.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/DataStreamMetadata.java
@@ -288,12 +288,8 @@ public class DataStreamMetadata implements Metadata.Custom {
         @Override
         public Metadata.Custom apply(Metadata.Custom part) {
             return new DataStreamMetadata(
-                ImmutableOpenMap.<String, DataStream>builder()
-                    .putAllFromMap(dataStreamDiff.apply(((DataStreamMetadata) part).dataStreams))
-                    .build(),
-                dataStreamAliasDiff != null
-                    ? dataStreamAliasDiff.apply(((DataStreamMetadata) part).dataStreamAliases)
-                    : ImmutableOpenMap.of()
+                dataStreamDiff.apply(((DataStreamMetadata) part).dataStreams),
+                dataStreamAliasDiff.apply(((DataStreamMetadata) part).dataStreamAliases)
             );
         }
 


### PR DESCRIPTION
This was doing a needless copy which showed up in many shards benchmarking.

relates #77466 