### PR TITLE
Add easier configuration cache test support in build logic tests

### DIFF
--- a/build-tools-internal/src/integTest/groovy/org/elasticsearch/gradle/fixtures/AbstractGradleInternalPluginFuncTest.groovy
+++ b/build-tools-internal/src/integTest/groovy/org/elasticsearch/gradle/fixtures/AbstractGradleInternalPluginFuncTest.groovy
@@ -8,11 +8,11 @@
 
 package org.elasticsearch.gradle.fixtures
 
-import org.elasticsearch.gradle.internal.conventions.precommit.PrecommitPlugin
+import org.gradle.api.Plugin
 
-abstract class AbstractGradlePrecommitPluginFuncTest extends AbstractJavaGradleFuncTest {
+abstract class AbstractGradleInternalPluginFuncTest extends AbstractJavaGradleFuncTest {
 
-    abstract <T extends PrecommitPlugin> Class<T> getPluginClassUnderTest();
+    abstract <T extends Plugin> Class<T> getPluginClassUnderTest();
 
     def setup() {
         buildFile << """

--- a/build-tools-internal/src/integTest/groovy/org/elasticsearch/gradle/internal/precommit/LicenseHeadersPrecommitPluginFuncTest.groovy
+++ b/build-tools-internal/src/integTest/groovy/org/elasticsearch/gradle/internal/precommit/LicenseHeadersPrecommitPluginFuncTest.groovy
@@ -8,20 +8,22 @@
 
 package org.elasticsearch.gradle.internal.precommit
 
-import org.elasticsearch.gradle.fixtures.AbstractGradlePrecommitPluginFuncTest
+import org.elasticsearch.gradle.fixtures.AbstractGradleInternalPluginFuncTest
 import org.elasticsearch.gradle.internal.conventions.precommit.LicenseHeadersPrecommitPlugin
 import org.elasticsearch.gradle.internal.conventions.precommit.PrecommitPlugin
 import org.gradle.testkit.runner.TaskOutcome
 
-class LicenseHeadersPrecommitPluginFuncTest extends AbstractGradlePrecommitPluginFuncTest {
+class LicenseHeadersPrecommitPluginFuncTest extends AbstractGradleInternalPluginFuncTest {
 
     Class<? extends PrecommitPlugin> pluginClassUnderTest = LicenseHeadersPrecommitPlugin.class
 
     def setup() {
+        configurationCacheCompatible = true
         buildFile << """
         apply plugin:'java'
         """
     }
+
     def "detects invalid files with invalid license header"() {
         given:
         dualLicensedFile()

--- a/build-tools-internal/src/integTest/groovy/org/elasticsearch/gradle/internal/precommit/TestingConventionsPrecommitPluginFuncTest.groovy
+++ b/build-tools-internal/src/integTest/groovy/org/elasticsearch/gradle/internal/precommit/TestingConventionsPrecommitPluginFuncTest.groovy
@@ -8,7 +8,7 @@
 
 package org.elasticsearch.gradle.internal.precommit
 
-import org.elasticsearch.gradle.fixtures.AbstractGradlePrecommitPluginFuncTest
+import org.elasticsearch.gradle.fixtures.AbstractGradleInternalPluginFuncTest
 import org.elasticsearch.gradle.fixtures.LocalRepositoryFixture
 import org.elasticsearch.gradle.internal.conventions.precommit.PrecommitPlugin
 import org.gradle.testkit.runner.TaskOutcome
@@ -20,7 +20,7 @@ import spock.lang.Unroll
 
 // see https://github.com/elastic/elasticsearch/issues/87913
 @IgnoreIf({ os.windows })
-class TestingConventionsPrecommitPluginFuncTest extends AbstractGradlePrecommitPluginFuncTest {
+class TestingConventionsPrecommitPluginFuncTest extends AbstractGradleInternalPluginFuncTest {
 
     Class<? extends PrecommitPlugin> pluginClassUnderTest = TestingConventionsPrecommitPlugin.class
 
@@ -45,6 +45,7 @@ class TestingConventionsPrecommitPluginFuncTest extends AbstractGradlePrecommitP
     }
 
     def setup() {
+        configurationCacheCompatible = true
         repository.configureBuild(buildFile)
     }
 
@@ -82,26 +83,6 @@ class TestingConventionsPrecommitPluginFuncTest extends AbstractGradlePrecommitP
         then:
         result.task(":testTestingConventions").outcome == TaskOutcome.UP_TO_DATE
         result.task(":testingConventions").outcome == TaskOutcome.UP_TO_DATE
-    }
-
-    def "testing convention plugin is configuration cache compatible"() {
-        given:
-        simpleJavaBuild()
-        testClazz("org.acme.valid.SomeTests", "org.apache.lucene.tests.util.LuceneTestCase") {
-            """
-            public void testMe() {
-            }
-            """
-        }
-        when:
-        def result = gradleRunner("precommit", "--configuration-cache").build()
-        then:
-        assertOutputContains(result.getOutput(), "0 problems were found storing the configuration cache.")
-
-        when:
-        result = gradleRunner("precommit", "--configuration-cache").build()
-        then:
-        assertOutputContains(result.getOutput(), "Configuration cache entry reused.")
     }
 
     def "checks base class convention"() {

--- a/build-tools/src/testFixtures/groovy/org/elasticsearch/gradle/fixtures/AbstractGradleFuncTest.groovy
+++ b/build-tools/src/testFixtures/groovy/org/elasticsearch/gradle/fixtures/AbstractGradleFuncTest.groovy
@@ -43,7 +43,7 @@ abstract class AbstractGradleFuncTest extends Specification {
         buildFile = testProjectDir.newFile('build.gradle')
         propertiesFile = testProjectDir.newFile('gradle.properties')
         propertiesFile <<
-                "org.gradle.java.installations.fromEnv=JAVA_HOME,RUNTIME_JAVA_HOME,JAVA15_HOME,JAVA14_HOME,JAVA13_HOME,JAVA12_HOME,JAVA11_HOME,JAVA8_HOME"
+            "org.gradle.java.installations.fromEnv=JAVA_HOME,RUNTIME_JAVA_HOME,JAVA15_HOME,JAVA14_HOME,JAVA13_HOME,JAVA12_HOME,JAVA11_HOME,JAVA8_HOME"
     }
 
     def cleanup() {

--- a/build-tools/src/testFixtures/java/org/elasticsearch/gradle/internal/test/ConfigurationCacheCompatibleAwareGradleRunner.java
+++ b/build-tools/src/testFixtures/java/org/elasticsearch/gradle/internal/test/ConfigurationCacheCompatibleAwareGradleRunner.java
@@ -20,8 +20,6 @@ import java.io.Writer;
 import java.net.URI;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 /**
  * A Gradle runner that delegates to another runner, optionally enabling the configuring cache parameter.
@@ -79,7 +77,7 @@ public class ConfigurationCacheCompatibleAwareGradleRunner extends GradleRunner 
     public GradleRunner withArguments(List<String> arguments) {
         List<String> effectiveArgs = arguments;
         if (ccCompatible) {
-            effectiveArgs  = new ArrayList<>(arguments);
+            effectiveArgs = new ArrayList<>(arguments);
             effectiveArgs.add("--configuration-cache");
         }
         delegate.withArguments(effectiveArgs);

--- a/build-tools/src/testFixtures/java/org/elasticsearch/gradle/internal/test/ConfigurationCacheCompatibleAwareGradleRunner.java
+++ b/build-tools/src/testFixtures/java/org/elasticsearch/gradle/internal/test/ConfigurationCacheCompatibleAwareGradleRunner.java
@@ -74,9 +74,11 @@ public class ConfigurationCacheCompatibleAwareGradleRunner extends GradleRunner 
 
     @Override
     public GradleRunner withArguments(List<String> arguments) {
-        List<String> effectiveArgs = ccCompatible
-            ? Stream.concat(arguments.stream(), Stream.of("--configuration-cache")).collect(Collectors.toList())
-            : arguments;
+        List<String> effectiveArgs = arguments;
+        if (ccCompatible) {
+            effectiveArgs  = new ArrayList<>(arguments);
+            effectiveArgs.add("--configuration-cache");
+        }
         delegate.withArguments(effectiveArgs);
         return this;
     }

--- a/build-tools/src/testFixtures/java/org/elasticsearch/gradle/internal/test/ConfigurationCacheCompatibleAwareGradleRunner.java
+++ b/build-tools/src/testFixtures/java/org/elasticsearch/gradle/internal/test/ConfigurationCacheCompatibleAwareGradleRunner.java
@@ -18,6 +18,7 @@ import org.gradle.testkit.runner.UnexpectedBuildSuccess;
 import java.io.File;
 import java.io.Writer;
 import java.net.URI;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 

--- a/build-tools/src/testFixtures/java/org/elasticsearch/gradle/internal/test/ConfigurationCacheCompatibleAwareGradleRunner.java
+++ b/build-tools/src/testFixtures/java/org/elasticsearch/gradle/internal/test/ConfigurationCacheCompatibleAwareGradleRunner.java
@@ -23,6 +23,9 @@ import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+/**
+ * A Gradle runner that delegates to another runner, optionally enabling the configuring cache parameter.
+ */
 public class ConfigurationCacheCompatibleAwareGradleRunner extends GradleRunner {
     private GradleRunner delegate;
     private boolean ccCompatible;

--- a/build-tools/src/testFixtures/java/org/elasticsearch/gradle/internal/test/ConfigurationCacheCompatibleAwareGradleRunner.java
+++ b/build-tools/src/testFixtures/java/org/elasticsearch/gradle/internal/test/ConfigurationCacheCompatibleAwareGradleRunner.java
@@ -1,0 +1,156 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.gradle.internal.test;
+
+import org.gradle.testkit.runner.BuildResult;
+import org.gradle.testkit.runner.GradleRunner;
+import org.gradle.testkit.runner.InvalidPluginMetadataException;
+import org.gradle.testkit.runner.InvalidRunnerConfigurationException;
+import org.gradle.testkit.runner.UnexpectedBuildFailure;
+import org.gradle.testkit.runner.UnexpectedBuildSuccess;
+
+import java.io.File;
+import java.io.Writer;
+import java.net.URI;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+public class ConfigurationCacheCompatibleAwareGradleRunner extends GradleRunner {
+    private GradleRunner delegate;
+    private boolean ccCompatible;
+
+    public ConfigurationCacheCompatibleAwareGradleRunner(GradleRunner delegate, boolean ccCompatible) {
+        this.delegate = delegate;
+        this.ccCompatible = ccCompatible;
+    }
+
+    @Override
+    public GradleRunner withGradleVersion(String gradleVersion) {
+        delegate.withGradleVersion(gradleVersion);
+        return this;
+    }
+
+    @Override
+    public GradleRunner withGradleInstallation(File file) {
+        delegate.withGradleInstallation(file);
+        return this;
+    }
+
+    @Override
+    public GradleRunner withGradleDistribution(URI uri) {
+        delegate.withGradleDistribution(uri);
+        return this;
+    }
+
+    @Override
+    public GradleRunner withTestKitDir(File file) {
+        delegate.withTestKitDir(file);
+        return this;
+    }
+
+    @Override
+    public File getProjectDir() {
+        return delegate.getProjectDir();
+    }
+
+    @Override
+    public GradleRunner withProjectDir(File projectDir) {
+        delegate.withProjectDir(projectDir);
+        return this;
+    }
+
+    @Override
+    public List<String> getArguments() {
+        return delegate.getArguments();
+    }
+
+    @Override
+    public GradleRunner withArguments(List<String> arguments) {
+        List<String> effectiveArgs = ccCompatible
+            ? Stream.concat(arguments.stream(), Stream.of("--configuration-cache")).collect(Collectors.toList())
+            : arguments;
+        delegate.withArguments(effectiveArgs);
+        return this;
+    }
+
+    @Override
+    public GradleRunner withArguments(String... arguments) {
+        withArguments(List.of(arguments));
+        return this;
+    }
+
+    @Override
+    public List<? extends File> getPluginClasspath() {
+        return delegate.getPluginClasspath();
+    }
+
+    @Override
+    public GradleRunner withPluginClasspath() throws InvalidPluginMetadataException {
+        delegate.withPluginClasspath();
+        return this;
+    }
+
+    @Override
+    public GradleRunner withPluginClasspath(Iterable<? extends File> iterable) {
+        delegate.withPluginClasspath(iterable);
+        return this;
+    }
+
+    @Override
+    public boolean isDebug() {
+        return delegate.isDebug();
+    }
+
+    @Override
+    public GradleRunner withDebug(boolean b) {
+        delegate.withDebug(b);
+        return this;
+    }
+
+    @Override
+    public Map<String, String> getEnvironment() {
+        return delegate.getEnvironment();
+    }
+
+    @Override
+    public GradleRunner withEnvironment(Map<String, String> map) {
+        delegate.withEnvironment(map);
+        return this;
+    }
+
+    @Override
+    public GradleRunner forwardStdOutput(Writer writer) {
+        delegate.forwardStdOutput(writer);
+        return this;
+    }
+
+    @Override
+    public GradleRunner forwardStdError(Writer writer) {
+        delegate.forwardStdOutput(writer);
+        return this;
+    }
+
+    @Override
+    public GradleRunner forwardOutput() {
+        delegate.forwardOutput();
+        return this;
+    }
+
+    @Override
+    public BuildResult build() throws InvalidRunnerConfigurationException, UnexpectedBuildFailure {
+        return delegate.build();
+    }
+
+    @Override
+    public BuildResult buildAndFail() throws InvalidRunnerConfigurationException, UnexpectedBuildSuccess {
+        return delegate.buildAndFail();
+    }
+}


### PR DESCRIPTION
This is intended to help us getting closer to #57918 by implicitly testing our build logic
configuration-cache support. Plugin and Task tests can be marked as configuration cache compatible
now and we will always run then with configuration cache enabled.

By default, gradle will fail the build if configuration cache problems have been detected during
build execution. That should be in general better then adding explicit tests for testing configuration
cache compatibility per Test class