### PR TITLE
Make AsyncPersistedState.resetVotingConfiguration fast

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/metadata/Metadata.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/Metadata.java
@@ -363,6 +363,34 @@ public class Metadata extends AbstractCollection<IndexMetadata> implements Diffa
         );
     }
 
+    public Metadata withCoordinationMetadata(CoordinationMetadata coordinationMetadata) {
+        return new Metadata(
+            clusterUUID,
+            clusterUUIDCommitted,
+            version,
+            coordinationMetadata,
+            transientSettings,
+            persistentSettings,
+            settings,
+            hashesOfConsistentSettings,
+            totalNumberOfShards,
+            totalOpenIndexShards,
+            indices,
+            aliasedIndices,
+            templates,
+            customs,
+            allIndices,
+            visibleIndices,
+            allOpenIndices,
+            visibleOpenIndices,
+            allClosedIndices,
+            visibleClosedIndices,
+            indicesLookup,
+            mappingsByHash,
+            oldestIndexVersion
+        );
+    }
+
     public long version() {
         return this.version;
     }

--- a/server/src/main/java/org/elasticsearch/gateway/GatewayMetaState.java
+++ b/server/src/main/java/org/elasticsearch/gateway/GatewayMetaState.java
@@ -396,7 +396,7 @@ public class GatewayMetaState implements Closeable {
                 .lastCommittedConfiguration(staleStateConfiguration)
                 .build();
             return ClusterState.builder(clusterState)
-                .metadata(Metadata.builder(clusterState.metadata()).coordinationMetadata(newCoordinationMetadata).build())
+                .metadata(clusterState.metadata().withCoordinationMetadata(newCoordinationMetadata))
                 .build();
         }
 


### PR DESCRIPTION
Using the builder just to update that one field in the metadata means
running through the name collision checks on the metadata which are very
expensive. In the many-shards benchmark run it takes ~2% of total CPU
time just for this operation.
Even though this is running async on a thread off the critical path I think
it's worthwhile fixing this to free up some CPU for other tasks.
