### PR TITLE
[8.3] Geoip processor should respect the ignore_missing parameter in case of missing database (#87793)

### DIFF
--- a/docs/changelog/87793.yaml
+++ b/docs/changelog/87793.yaml
@@ -1,0 +1,6 @@
+pr: 87793
+summary: Geoip processor should respect the `ignore_missing` in case of missing database
+area: Ingest
+type: bug
+issues:
+ - 87345

--- a/modules/ingest-geoip/src/main/java/org/elasticsearch/ingest/geoip/GeoIpProcessor.java
+++ b/modules/ingest-geoip/src/main/java/org/elasticsearch/ingest/geoip/GeoIpProcessor.java
@@ -127,7 +127,9 @@ public final class GeoIpProcessor extends AbstractProcessor {
 
         DatabaseReaderLazyLoader lazyLoader = this.supplier.get();
         if (lazyLoader == null) {
-            tag(ingestDocument, databaseFile);
+            if (ignoreMissing == false) {
+                tag(ingestDocument, databaseFile);
+            }
             return ingestDocument;
         }
 


### PR DESCRIPTION
Backports the following commits to 8.3:
 - Geoip processor should respect the ignore_missing parameter in case of missing database (#87793)