### PR TITLE
[TRANSFORM] Add YAML test assertions for roles in transform configs

### DIFF
--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/transform/transforms_crud.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/transform/transforms_crud.yml
@@ -165,6 +165,7 @@ setup:
   - match: { transforms.0.pivot.group_by.airline.terms.field: "airline" }
   - match: { transforms.0.pivot.aggregations.avg_response.avg.field: "responsetime" }
   - match: { transforms.0.description: "yaml test transform on airline-data" }
+  - is_true: transforms.0.authorization.roles
 
   - do:
       transform.get_transform:
@@ -186,6 +187,8 @@ setup:
   - match: { count: 2 }
   - match: { transforms.0.id: "airline-transform" }
   - match: { transforms.1.id: "airline-transform-dos" }
+  - is_true: transforms.0.authorization.roles
+  - is_true: transforms.1.authorization.roles
 
   - do:
       transform.get_transform:
@@ -254,6 +257,7 @@ setup:
   - match: { transforms.0.dest.index: "airline-data-by-airline" }
   - match: { transforms.0.pivot.group_by.airline.terms.field: "airline" }
   - match: { transforms.0.pivot.aggregations.avg_response.avg.field: "responsetime" }
+
 ---
 "Test PUT continuous transform":
   - do:
@@ -288,6 +292,8 @@ setup:
   - match: { transforms.0.pivot.aggregations.avg_response.avg.field: "responsetime" }
   - match: { transforms.0.sync.time.field: "time" }
   - match: { transforms.0.sync.time.delay: "90m" }
+  - is_true: transforms.0.authorization.roles
+
 ---
 "Test PUT continuous transform without delay set":
   - do:

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/transform/transforms_update.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/transform/transforms_update.yml
@@ -188,6 +188,7 @@ setup:
   - match: { sync.time.field: "time" }
   - match: { sync.time.delay: "120m" }
   - match: { frequency: "5s" }
+  - is_true: authorization.roles
 
   - do:
       transform.get_transform:
@@ -205,6 +206,7 @@ setup:
   - match: { transforms.0.sync.time.field: "time" }
   - match: { transforms.0.sync.time.delay: "120m" }
   - match: { transforms.0.frequency: "5s" }
+  - is_true: transforms.0.authorization.roles
 
 ---
 "Test update retention policy":
@@ -235,6 +237,7 @@ setup:
   - match: { transforms.0.id: "updating-airline-transform" }
   - match: { transforms.0.retention_policy.time.field: "time" }
   - match: { transforms.0.retention_policy.time.max_age: "24h" }
+  - is_true: transforms.0.authorization.roles
 
   - do:
       transform.update_transform:
@@ -390,6 +393,7 @@ setup:
   - match: { _meta.baz.a1: 11 }
   - match: { _meta.baz.a2: 22 }
   - is_false: _meta.baz.a3
+  - is_true: authorization.roles
 
   - do:
       transform.get_transform:
@@ -401,6 +405,7 @@ setup:
   - match: { transforms.0._meta.baz.a1: 11 }
   - match: { transforms.0._meta.baz.a2: 22 }
   - is_false: transforms.0._meta.baz.a3
+  - is_true: transforms.0.authorization.roles
 
   - do:
       transform.update_transform:
@@ -421,6 +426,7 @@ setup:
   - is_false: _meta.baz.a1  # "baz.a1" disappeared as the metadata update is implemented as full replace
   - match: { _meta.baz.a2: 222 }
   - match: { _meta.baz.a3: 333 }
+  - is_true: authorization.roles
 
   - do:
       transform.get_transform:
@@ -432,3 +438,4 @@ setup:
   - is_false: transforms.0._meta.baz.a1
   - match: { transforms.0._meta.baz.a2: 222 }
   - match: { transforms.0._meta.baz.a3: 333 }
+  - is_true: transforms.0.authorization.roles


### PR DESCRIPTION
In #87570 authorization info was added to transform listings.
Authorization information was also implicitly added to transform
update responses. However, YAML tests were not added to either.
This PR adds some assertions to the YAML tests for getting transforms
and transform updates to prove that the responses really do include
authorization information.