### PR TITLE
[7.17] Don't ignore pipeline for upserts in bulk api (#87719)

### DIFF
--- a/docs/changelog/87719.yaml
+++ b/docs/changelog/87719.yaml
@@ -1,0 +1,6 @@
+pr: 87719
+summary: Don't ignore pipeline for upserts in bulk api
+area: Ingest
+type: bug
+issues:
+ - 87131

--- a/modules/ingest-common/src/yamlRestTest/resources/rest-api-spec/test/ingest/70_bulk.yml
+++ b/modules/ingest-common/src/yamlRestTest/resources/rest-api-spec/test/ingest/70_bulk.yml
@@ -144,3 +144,40 @@ teardown:
 
   - is_false: _source.field1
   - match: {_source.field2: value2}
+
+---
+"Update with pipeline":
+  - skip:
+      version: " - 8.3.99"
+      reason: "fixed in 8.4.0"
+
+  - do:
+      ingest.put_pipeline:
+        id: "lowercase-pipeline"
+        body: >
+          {
+            "processors": [
+              {
+                "lowercase" : {
+                  "field" : "my_field"
+                }
+              }
+            ]
+          }
+  - match: { acknowledged: true }
+
+  - do:
+      bulk:
+        refresh: true
+        body:
+          - '{"update":{"_id":"1","_index":"test_index","pipeline":"lowercase-pipeline"}}'
+          - '{"upsert":{"my_field":"UPPER"},"script":{"source":"ctx._source.my_field = ctx._source.my_field.toLowercase()"}}'
+
+  - match: { errors: false }
+  - match: { items.0.update.result: created }
+
+  - do:
+      get:
+        index: test_index
+        id: 1
+  - match: { _source:  { my_field: "upper" } }

--- a/modules/ingest-common/src/yamlRestTest/resources/rest-api-spec/test/ingest/70_bulk.yml
+++ b/modules/ingest-common/src/yamlRestTest/resources/rest-api-spec/test/ingest/70_bulk.yml
@@ -148,8 +148,8 @@ teardown:
 ---
 "Update with pipeline":
   - skip:
-      version: " - 8.3.99"
-      reason: "fixed in 8.4.0"
+      version: " - 7.17.4"
+      reason: "fixed in 7.17.5"
 
   - do:
       ingest.put_pipeline:

--- a/server/src/main/java/org/elasticsearch/action/bulk/BulkRequestParser.java
+++ b/server/src/main/java/org/elasticsearch/action/bulk/BulkRequestParser.java
@@ -409,7 +409,7 @@ public final class BulkRequestParser {
                         }
                         IndexRequest upsertRequest = updateRequest.upsertRequest();
                         if (upsertRequest != null) {
-                            upsertRequest.setPipeline(defaultPipeline);
+                            upsertRequest.setPipeline(pipeline);
                         }
 
                         updateRequestConsumer.accept(updateRequest);


### PR DESCRIPTION
Backports the following commits to 7.17:
 - Don't ignore pipeline for upserts in bulk api (#87719)