### PR TITLE
[ML] mute TermsOnDateGroupBy cont. test #88063

### DIFF
--- a/x-pack/plugin/transform/qa/multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/continuous/TermsOnDateGroupByIT.java
+++ b/x-pack/plugin/transform/qa/multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/continuous/TermsOnDateGroupByIT.java
@@ -7,6 +7,7 @@
 
 package org.elasticsearch.xpack.transform.integration.continuous;
 
+import org.apache.lucene.tests.util.LuceneTestCase;
 import org.elasticsearch.client.Response;
 import org.elasticsearch.common.xcontent.support.XContentMapValues;
 import org.elasticsearch.search.aggregations.AggregationBuilders;
@@ -32,6 +33,7 @@ import static org.hamcrest.Matchers.equalTo;
  *
  * Note: dates are currently written as long (epoch_ms) into the transform dest index.
  */
+@LuceneTestCase.AwaitsFix(bugUrl="https://github.com/elastic/elasticsearch/issues/88063")
 public class TermsOnDateGroupByIT extends ContinuousTestCase {
 
     private static final String NAME = "continuous-terms-on-date-pivot-test";

--- a/x-pack/plugin/transform/qa/multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/continuous/TermsOnDateGroupByIT.java
+++ b/x-pack/plugin/transform/qa/multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/continuous/TermsOnDateGroupByIT.java
@@ -33,7 +33,7 @@ import static org.hamcrest.Matchers.equalTo;
  *
  * Note: dates are currently written as long (epoch_ms) into the transform dest index.
  */
-@LuceneTestCase.AwaitsFix(bugUrl="https://github.com/elastic/elasticsearch/issues/88063")
+@LuceneTestCase.AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/88063")
 public class TermsOnDateGroupByIT extends ContinuousTestCase {
 
     private static final String NAME = "continuous-terms-on-date-pivot-test";


### PR DESCRIPTION
relates: https://github.com/elastic/elasticsearch/issues/88063