### PR TITLE
Skip building redundant set in `org.elasticsearch.indices.cluster.IndicesClusterStateService#removeIndices`

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/routing/RoutingNode.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/RoutingNode.java
@@ -100,6 +100,10 @@ public class RoutingNode implements Iterable<ShardRouting> {
         return shards.get(id);
     }
 
+    public boolean hasIndex(Index index) {
+        return shardsByIndex.containsKey(index);
+    }
+
     /**
      * Get the id of this node
      * @return id of the node


### PR DESCRIPTION
No need to build a fresh set of all the indices, we already have a map of all of them
in the routing nodes that we can check. This saves quite a bit of work on applying CS
to data nodes with many indices.

relates #77466 