### PR TITLE
[DOCS] Add ml-cpp PRs to release notes

### DIFF
--- a/docs/reference/release-notes.asciidoc
+++ b/docs/reference/release-notes.asciidoc
@@ -6,6 +6,7 @@
 
 This section summarizes the changes in each release.
 
+* <<release-notes-7.17.5>>
 * <<release-notes-7.17.4>>
 * <<release-notes-7.17.3>>
 * <<release-notes-7.17.2>>
@@ -65,6 +66,7 @@ This section summarizes the changes in each release.
 
 --
 
+include::release-notes/7.17.5.asciidoc[]
 include::release-notes/7.17.4.asciidoc[]
 include::release-notes/7.17.3.asciidoc[]
 include::release-notes/7.17.2.asciidoc[]

--- a/docs/reference/release-notes/7.17.5.asciidoc
+++ b/docs/reference/release-notes/7.17.5.asciidoc
@@ -17,7 +17,7 @@ corrects bias which could cause our scoring to be too low for these jobs
 === Bug fixes
 
 Machine Learning::
-* * Adjacency weighting fixes in categorization {ml-pull}2277[#2277]
+* Adjacency weighting fixes in categorization {ml-pull}2277[#2277]
 * Fix a source of "Discarding sample = nan, weights = ..." log errors for time series
   anomaly detection {ml-pull}2286[#2286]
 

--- a/docs/reference/release-notes/7.17.5.asciidoc
+++ b/docs/reference/release-notes/7.17.5.asciidoc
@@ -1,0 +1,23 @@
+[[release-notes-7.17.5]]
+== {es} version 7.17.5
+
+Also see <<breaking-changes-7.17,Breaking changes in 7.17>>.
+
+
+[[enhancement-7.17.5]]
+[float]
+=== Enhancements
+* Make ML native processes work with glibc 2.35 (required for Ubuntu 22.04) {ml-pull}2272[#2272]
+* Improve normalization of anomaly detection results for short bucket lengths. This
+corrects bias which could cause our scoring to be too low for these jobs
+{ml-pull}2285[#2285] (issue: {ml-issue}2276[#2276])
+
+[[bug-7.17.5]]
+[float]
+=== Bug fixes
+
+Machine Learning::
+* * Adjacency weighting fixes in categorization {ml-pull}2277[#2277]
+* Fix a source of "Discarding sample = nan, weights = ..." log errors for time series
+  anomaly detection {ml-pull}2286[#2286]
+

--- a/docs/reference/release-notes/7.17.5.asciidoc
+++ b/docs/reference/release-notes/7.17.5.asciidoc
@@ -7,6 +7,8 @@ Also see <<breaking-changes-7.17,Breaking changes in 7.17>>.
 [[enhancement-7.17.5]]
 [float]
 === Enhancements
+
+Machine Learning::
 * Make ML native processes work with glibc 2.35 (required for Ubuntu 22.04) {ml-pull}2272[#2272]
 * Improve normalization of anomaly detection results for short bucket lengths. This
 corrects bias which could cause our scoring to be too low for these jobs


### PR DESCRIPTION
This PR adds the content from https://raw.githubusercontent.com/elastic/ml-cpp/7.17/docs/CHANGELOG.asciidoc to the 7.17.5 release notes

### Preview

https://elasticsearch_88083.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/7.17/release-notes-7.17.5.html