### PR TITLE
[DOCS] Add authorization details to update datafeed API

### DIFF
--- a/docs/reference/ml/anomaly-detection/apis/put-job.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/put-job.asciidoc
@@ -448,7 +448,6 @@ PUT _ml/anomaly_detectors/test-job1?pretty
   }
 }
 --------------------------------------------------
-// TEST[skip:setup Kibana sample data]
 
 The API returns the following results:
 
@@ -537,3 +536,4 @@ The API returns the following results:
 ----
 // TESTRESPONSE[s/"job_version" : "8.4.0"/"job_version" : $body.job_version/]
 // TESTRESPONSE[s/1656087283340/$body.$_path/]
+// TESTRESPONSE[s/"authorization" : \{[^}]*\},//]

--- a/docs/reference/ml/anomaly-detection/apis/update-datafeed.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/update-datafeed.asciidoc
@@ -159,16 +159,16 @@ include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=scroll-size]
 
 [source,console]
 --------------------------------------------------
-POST _ml/datafeeds/datafeed-total-requests/_update
+POST _ml/datafeeds/datafeed-test-job/_update
 {
   "query": {
     "term": {
-      "level": "error"
+      "geo.src": "US"
     }
   }
 }
 --------------------------------------------------
-// TEST[skip:setup:server_metrics_datafeed]
+// TEST[skip:setup sample web logs]
 
 When the {dfeed} is updated, you receive the full {dfeed} configuration with
 the updated values:
@@ -176,22 +176,36 @@ the updated values:
 [source,console-result]
 ----
 {
-  "datafeed_id": "datafeed-total-requests",
-  "job_id": "total-requests",
-  "query_delay": "83474ms",
-  "indices": ["server-metrics"],
-  "query": {
-    "term": {
-      "level": {
-        "value": "error",
-        "boost": 1.0
-      }
+  "datafeed_id" : "datafeed-test-job",
+  "job_id" : "test-job",
+  "authorization" : {
+    "roles" : [
+      "superuser"
+    ]
+  },
+  "query_delay" : "64489ms",
+  "chunking_config" : {
+    "mode" : "auto"
+  },
+  "indices_options" : {
+    "expand_wildcards" : [
+      "open"
+    ],
+    "ignore_unavailable" : false,
+    "allow_no_indices" : true,
+    "ignore_throttled" : true
+  },
+  "query" : {
+    "term" : {
+      "geo.src" : "US"
     }
   },
-  "scroll_size": 1000,
-  "chunking_config": {
-    "mode": "auto"
+  "indices" : [
+    "kibana_sample_data_logs"
+  ],
+  "scroll_size" : 1000,
+  "delayed_data_check_config" : {
+    "enabled" : true
   }
 }
 ----
-// TESTRESPONSE[s/"query.boost": "1.0"/"query.boost": $body.query.boost/]


### PR DESCRIPTION
Relates to https://github.com/elastic/elasticsearch/issues/87905

This PR updates the example in the [update datafeed API](https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-update-datafeed.html) documentation to use the same datafeed as the "create datafeed API" example and includes the authorization details in the response.

It also re-enables the code snippet testing in the create anomaly detection job API example, but skips checking the authorization details.

### Preview

https://elasticsearch_88099.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/ml-update-datafeed.html