### PR TITLE
[DOCS] Fixes a link that breaks the docs build

### DIFF
--- a/docs/reference/ingest/processors/foreach.asciidoc
+++ b/docs/reference/ingest/processors/foreach.asciidoc
@@ -163,9 +163,8 @@ After processing the result is:
 --------------------------------------------------
 // NOTCONSOLE
 
-For another array of objects example, see
-{plugins}/ingest-attachment-with-arrays.html[attachment processor
-documentation].
+For another array of objects example, refer to the 
+<<attachment-with-arrays,attachment processor documentation>>.
 
 [discrete]
 [[foreach-object-ex]]


### PR DESCRIPTION
## Overview

This PR fixes a link that breaks the docs build.

Related to https://github.com/elastic/elasticsearch/pull/87989