### PR TITLE
Mute ingest/70_bulk/Update with pipeline yaml mute_update_with_pipeline_yaml test

### DIFF
--- a/modules/ingest-common/build.gradle
+++ b/modules/ingest-common/build.gradle
@@ -46,4 +46,5 @@ tasks.named("thirdPartyAudit").configure {
 
 tasks.named("yamlRestTestV7CompatTransform").configure { task ->
   task.addAllowedWarningRegex("\\[types removal\\].*")
+  task.skipTest("ingest/70_bulk/Update with pipeline", "Muted due because #87719 was never backported to 8.2 branch")
 }


### PR DESCRIPTION
This test shouldn't run in 8.2 branch, because #87719 wasn't back ported to this branch.

Closes #88123 
