### PR TITLE
[ML] improve trained model stats API performance (#87978)

### DIFF
--- a/docs/changelog/87978.yaml
+++ b/docs/changelog/87978.yaml
@@ -1,0 +1,5 @@
+pr: 87978
+summary: Improve trained model stats API performance
+area: Machine Learning
+type: bug
+issues: []

--- a/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/TestFeatureResetIT.java
+++ b/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/TestFeatureResetIT.java
@@ -33,13 +33,13 @@ import java.util.HashSet;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
-import static org.elasticsearch.xpack.ml.inference.ingest.InferenceProcessor.Factory.countNumberInferenceProcessors;
 import static org.elasticsearch.xpack.ml.integration.ClassificationIT.KEYWORD_FIELD;
 import static org.elasticsearch.xpack.ml.integration.MlNativeDataFrameAnalyticsIntegTestCase.buildAnalytics;
 import static org.elasticsearch.xpack.ml.support.BaseMlIntegTestCase.createDatafeed;
 import static org.elasticsearch.xpack.ml.support.BaseMlIntegTestCase.createScheduledJob;
 import static org.elasticsearch.xpack.ml.support.BaseMlIntegTestCase.getDataCounts;
 import static org.elasticsearch.xpack.ml.support.BaseMlIntegTestCase.indexDocs;
+import static org.elasticsearch.xpack.ml.utils.InferenceProcessorInfoExtractor.countInferenceProcessors;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.emptyArray;
 import static org.hamcrest.Matchers.equalTo;
@@ -115,9 +115,7 @@ public class TestFeatureResetIT extends MlNativeAutodetectIntegTestCase {
         client().execute(DeletePipelineAction.INSTANCE, new DeletePipelineRequest("feature_reset_inference_pipeline")).actionGet();
         createdPipelines.remove("feature_reset_inference_pipeline");
 
-        assertBusy(
-            () -> assertThat(countNumberInferenceProcessors(client().admin().cluster().prepareState().get().getState()), equalTo(0))
-        );
+        assertBusy(() -> assertThat(countInferenceProcessors(client().admin().cluster().prepareState().get().getState()), equalTo(0)));
         client().execute(ResetFeatureStateAction.INSTANCE, new ResetFeatureStateRequest()).actionGet();
         assertBusy(() -> assertThat(client().admin().indices().prepareGetIndex().addIndices(".ml*").get().indices(), emptyArray()));
         assertThat(isResetMode(), is(false));

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MachineLearning.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MachineLearning.java
@@ -393,7 +393,7 @@ import static java.util.Collections.singletonList;
 import static org.elasticsearch.xpack.core.ClientHelper.ML_ORIGIN;
 import static org.elasticsearch.xpack.core.ml.job.persistence.AnomalyDetectorsIndexFields.RESULTS_INDEX_PREFIX;
 import static org.elasticsearch.xpack.core.ml.job.persistence.AnomalyDetectorsIndexFields.STATE_INDEX_PREFIX;
-import static org.elasticsearch.xpack.ml.inference.ingest.InferenceProcessor.Factory.countNumberInferenceProcessors;
+import static org.elasticsearch.xpack.ml.utils.InferenceProcessorInfoExtractor.countInferenceProcessors;
 
 public class MachineLearning extends Plugin
     implements
@@ -1700,7 +1700,7 @@ public class MachineLearning extends Plugin
 
         // validate no pipelines are using machine learning models
         ActionListener<AcknowledgedResponse> afterResetModeSet = ActionListener.wrap(acknowledgedResponse -> {
-            int numberInferenceProcessors = countNumberInferenceProcessors(clusterService.state());
+            int numberInferenceProcessors = countInferenceProcessors(clusterService.state());
             if (numberInferenceProcessors > 0) {
                 unsetResetModeListener.onFailure(
                     new RuntimeException(

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/utils/InferenceProcessorInfoExtractor.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/utils/InferenceProcessorInfoExtractor.java
@@ -1,0 +1,180 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.ml.utils;
+
+import org.apache.lucene.util.Counter;
+import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.metadata.Metadata;
+import org.elasticsearch.ingest.ConfigurationUtils;
+import org.elasticsearch.ingest.IngestMetadata;
+import org.elasticsearch.ingest.Pipeline;
+
+import java.util.HashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.function.Consumer;
+
+import static org.elasticsearch.ingest.Pipeline.PROCESSORS_KEY;
+import static org.elasticsearch.xpack.core.ml.inference.results.InferenceResults.MODEL_ID_RESULTS_FIELD;
+import static org.elasticsearch.xpack.ml.inference.ingest.InferenceProcessor.TYPE;
+
+/**
+ * Utilities for extracting information around inference processors from IngestMetadata
+ */
+public final class InferenceProcessorInfoExtractor {
+
+    private static final String FOREACH_PROCESSOR_NAME = "foreach";
+    // Any more than 10 nestings of processors, we stop searching for inference processor definitions
+    private static final int MAX_INFERENCE_PROCESSOR_SEARCH_RECURSIONS = 10;
+
+    private InferenceProcessorInfoExtractor() {}
+
+    /**
+     * @param state The current cluster state
+     * @return The current count of inference processors
+     */
+    @SuppressWarnings("unchecked")
+    public static int countInferenceProcessors(ClusterState state) {
+        Metadata metadata = state.getMetadata();
+        if (metadata == null) {
+            return 0;
+        }
+        IngestMetadata ingestMetadata = metadata.custom(IngestMetadata.TYPE);
+        if (ingestMetadata == null) {
+            return 0;
+        }
+        Counter counter = Counter.newCounter();
+        ingestMetadata.getPipelines().forEach((pipelineId, configuration) -> {
+            Map<String, Object> configMap = configuration.getConfigAsMap();
+            List<Map<String, Object>> processorConfigs = ConfigurationUtils.readList(null, null, configMap, PROCESSORS_KEY);
+            for (Map<String, Object> processorConfigWithKey : processorConfigs) {
+                for (Map.Entry<String, Object> entry : processorConfigWithKey.entrySet()) {
+                    addModelsAndPipelines(
+                        entry.getKey(),
+                        pipelineId,
+                        (Map<String, Object>) entry.getValue(),
+                        pam -> counter.addAndGet(1),
+                        0
+                    );
+                }
+            }
+        });
+        return (int) counter.get();
+    }
+
+    /**
+     * @param state Current cluster state
+     * @return a map from Model IDs or Aliases to each pipeline referencing them.
+     */
+    @SuppressWarnings("unchecked")
+    public static Map<String, Set<String>> pipelineIdsByModelIdsOrAliases(ClusterState state, Set<String> modelIds) {
+        Map<String, Set<String>> pipelineIdsByModelIds = new HashMap<>();
+        Metadata metadata = state.metadata();
+        if (metadata == null) {
+            return pipelineIdsByModelIds;
+        }
+        IngestMetadata ingestMetadata = metadata.custom(IngestMetadata.TYPE);
+        if (ingestMetadata == null) {
+            return pipelineIdsByModelIds;
+        }
+        ingestMetadata.getPipelines().forEach((pipelineId, configuration) -> {
+            Map<String, Object> configMap = configuration.getConfigAsMap();
+            List<Map<String, Object>> processorConfigs = ConfigurationUtils.readList(null, null, configMap, PROCESSORS_KEY);
+            for (Map<String, Object> processorConfigWithKey : processorConfigs) {
+                for (Map.Entry<String, Object> entry : processorConfigWithKey.entrySet()) {
+                    addModelsAndPipelines(entry.getKey(), pipelineId, (Map<String, Object>) entry.getValue(), pam -> {
+                        if (modelIds.contains(pam.modelIdOrAlias)) {
+                            pipelineIdsByModelIds.computeIfAbsent(pam.modelIdOrAlias, m -> new LinkedHashSet<>()).add(pipelineId);
+                        }
+                    }, 0);
+                }
+            }
+        });
+        return pipelineIdsByModelIds;
+    }
+
+    @SuppressWarnings("unchecked")
+    private static void addModelsAndPipelines(
+        String processorType,
+        String pipelineId,
+        Map<String, Object> processorDefinition,
+        Consumer<PipelineAndModel> handler,
+        int level
+    ) {
+        // arbitrary, but we must limit this somehow
+        if (level > MAX_INFERENCE_PROCESSOR_SEARCH_RECURSIONS) {
+            return;
+        }
+        if (processorType == null || processorDefinition == null) {
+            return;
+        }
+        if (TYPE.equals(processorType)) {
+            String modelId = (String) processorDefinition.get(MODEL_ID_RESULTS_FIELD);
+            if (modelId != null) {
+                handler.accept(new PipelineAndModel(pipelineId, modelId));
+            }
+            return;
+        }
+        if (FOREACH_PROCESSOR_NAME.equals(processorType)) {
+            Map<String, Object> innerProcessor = (Map<String, Object>) processorDefinition.get("processor");
+            if (innerProcessor != null) {
+                // a foreach processor should only have a SINGLE nested processor. Iteration is for simplicity's sake.
+                for (Map.Entry<String, Object> innerProcessorWithName : innerProcessor.entrySet()) {
+                    addModelsAndPipelines(
+                        innerProcessorWithName.getKey(),
+                        pipelineId,
+                        (Map<String, Object>) innerProcessorWithName.getValue(),
+                        handler,
+                        level + 1
+                    );
+                }
+            }
+            return;
+        }
+        if (processorDefinition.containsKey(Pipeline.ON_FAILURE_KEY)) {
+            List<Map<String, Object>> onFailureConfigs = ConfigurationUtils.readList(
+                null,
+                null,
+                processorDefinition,
+                Pipeline.ON_FAILURE_KEY
+            );
+            onFailureConfigs.stream()
+                .flatMap(map -> map.entrySet().stream())
+                .forEach(
+                    entry -> addModelsAndPipelines(entry.getKey(), pipelineId, (Map<String, Object>) entry.getValue(), handler, level + 1)
+                );
+        }
+    }
+
+    private static class PipelineAndModel {
+        private final String pipelineId;
+        private final String modelIdOrAlias;
+
+        private PipelineAndModel(String pipelineId, String modelIdOrAlias) {
+            this.pipelineId = pipelineId;
+            this.modelIdOrAlias = modelIdOrAlias;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            PipelineAndModel that = (PipelineAndModel) o;
+            return Objects.equals(pipelineId, that.pipelineId) && Objects.equals(modelIdOrAlias, that.modelIdOrAlias);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(pipelineId, modelIdOrAlias);
+        }
+    }
+
+}

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/utils/InferenceProcessorInfoExtractorTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/utils/InferenceProcessorInfoExtractorTests.java
@@ -1,0 +1,217 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.ml.utils;
+
+import org.elasticsearch.Version;
+import org.elasticsearch.cluster.ClusterName;
+import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.metadata.Metadata;
+import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.cluster.node.DiscoveryNodes;
+import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.common.transport.TransportAddress;
+import org.elasticsearch.ingest.IngestMetadata;
+import org.elasticsearch.ingest.PipelineConfiguration;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xcontent.XContentBuilder;
+import org.elasticsearch.xcontent.XContentFactory;
+import org.elasticsearch.xcontent.XContentType;
+import org.elasticsearch.xpack.core.ml.inference.results.InferenceResults;
+import org.elasticsearch.xpack.core.ml.inference.trainedmodel.RegressionConfig;
+import org.elasticsearch.xpack.ml.inference.ingest.InferenceProcessor;
+
+import java.io.IOException;
+import java.net.InetAddress;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasEntry;
+
+public class InferenceProcessorInfoExtractorTests extends ESTestCase {
+
+    public void testPipelineIdsByModelIds() throws IOException {
+        String modelId1 = "trained_model_1";
+        String modelId2 = "trained_model_2";
+        String modelId3 = "trained_model_3";
+        Set<String> modelIds = new HashSet<>(Arrays.asList(modelId1, modelId2, modelId3));
+
+        ClusterState clusterState = buildClusterStateWithModelReferences(2, modelId1, modelId2, modelId3);
+
+        Map<String, Set<String>> pipelineIdsByModelIds = InferenceProcessorInfoExtractor.pipelineIdsByModelIdsOrAliases(
+            clusterState,
+            modelIds
+        );
+
+        assertThat(pipelineIdsByModelIds.keySet(), equalTo(modelIds));
+        assertThat(
+            pipelineIdsByModelIds,
+            hasEntry(modelId1, new HashSet<>(Arrays.asList("pipeline_with_model_" + modelId1 + 0, "pipeline_with_model_" + modelId1 + 1)))
+        );
+        assertThat(
+            pipelineIdsByModelIds,
+            hasEntry(modelId2, new HashSet<>(Arrays.asList("pipeline_with_model_" + modelId2 + 0, "pipeline_with_model_" + modelId2 + 1)))
+        );
+        assertThat(
+            pipelineIdsByModelIds,
+            hasEntry(modelId3, new HashSet<>(Arrays.asList("pipeline_with_model_" + modelId3 + 0, "pipeline_with_model_" + modelId3 + 1)))
+        );
+    }
+
+    public void testNumInferenceProcessors() throws IOException {
+        assertThat(InferenceProcessorInfoExtractor.countInferenceProcessors(buildClusterState(null)), equalTo(0));
+        assertThat(InferenceProcessorInfoExtractor.countInferenceProcessors(buildClusterState(Metadata.EMPTY_METADATA)), equalTo(0));
+        assertThat(
+            InferenceProcessorInfoExtractor.countInferenceProcessors(buildClusterStateWithModelReferences(1, "model1", "model2", "model3")),
+            equalTo(3)
+        );
+    }
+
+    public void testNumInferenceProcessorsRecursivelyDefined() throws IOException {
+        Map<String, PipelineConfiguration> configurations = new HashMap<>();
+        configurations.put(
+            "pipeline_with_model_top_level",
+            randomBoolean()
+                ? newConfigurationWithInferenceProcessor("top_level")
+                : newConfigurationWithForeachProcessorProcessor("top_level")
+        );
+        try (
+            XContentBuilder xContentBuilder = XContentFactory.jsonBuilder()
+                .map(
+                    Collections.singletonMap(
+                        "processors",
+                        Collections.singletonList(Collections.singletonMap("set", new HashMap<String, Object>() {
+                            {
+                                put("field", "foo");
+                                put("value", "bar");
+                                put(
+                                    "on_failure",
+                                    Arrays.asList(inferenceProcessorForModel("second_level"), forEachProcessorWithInference("third_level"))
+                                );
+                            }
+                        }))
+                    )
+                )
+        ) {
+            configurations.put(
+                "pipeline_with_model_nested",
+                new PipelineConfiguration("pipeline_with_model_nested", BytesReference.bytes(xContentBuilder), XContentType.JSON)
+            );
+        }
+
+        IngestMetadata ingestMetadata = new IngestMetadata(configurations);
+
+        ClusterState cs = ClusterState.builder(new ClusterName("_name"))
+            .metadata(Metadata.builder().putCustom(IngestMetadata.TYPE, ingestMetadata))
+            .nodes(
+                DiscoveryNodes.builder()
+                    .add(new DiscoveryNode("min_node", new TransportAddress(InetAddress.getLoopbackAddress(), 9300), Version.CURRENT))
+                    .add(new DiscoveryNode("current_node", new TransportAddress(InetAddress.getLoopbackAddress(), 9302), Version.CURRENT))
+                    .add(new DiscoveryNode("_node_id", new TransportAddress(InetAddress.getLoopbackAddress(), 9304), Version.CURRENT))
+                    .localNodeId("_node_id")
+                    .masterNodeId("_node_id")
+            )
+            .build();
+
+        assertThat(InferenceProcessorInfoExtractor.countInferenceProcessors(cs), equalTo(3));
+    }
+
+    private static PipelineConfiguration newConfigurationWithOutInferenceProcessor(int i) throws IOException {
+        try (
+            XContentBuilder xContentBuilder = XContentFactory.jsonBuilder()
+                .map(
+                    Collections.singletonMap(
+                        "processors",
+                        Collections.singletonList(Collections.singletonMap("not_inference", Collections.emptyMap()))
+                    )
+                )
+        ) {
+            return new PipelineConfiguration("pipeline_without_model_" + i, BytesReference.bytes(xContentBuilder), XContentType.JSON);
+        }
+    }
+
+    private static ClusterState buildClusterState(Metadata metadata) {
+        return ClusterState.builder(new ClusterName("_name")).metadata(metadata).build();
+    }
+
+    private static ClusterState buildClusterStateWithModelReferences(int numPipelineReferences, String... modelId) throws IOException {
+        Map<String, PipelineConfiguration> configurations = new HashMap<>();
+        for (String id : modelId) {
+            for (int i = 0; i < numPipelineReferences; i++) {
+                configurations.put(
+                    "pipeline_with_model_" + id + i,
+                    randomBoolean() ? newConfigurationWithInferenceProcessor(id) : newConfigurationWithForeachProcessorProcessor(id)
+                );
+            }
+
+        }
+        int numPipelinesWithoutModel = randomInt(5);
+        for (int i = 0; i < numPipelinesWithoutModel; i++) {
+            configurations.put("pipeline_without_model_" + i, newConfigurationWithOutInferenceProcessor(i));
+        }
+        IngestMetadata ingestMetadata = new IngestMetadata(configurations);
+
+        return ClusterState.builder(new ClusterName("_name"))
+            .metadata(Metadata.builder().putCustom(IngestMetadata.TYPE, ingestMetadata))
+            .nodes(
+                DiscoveryNodes.builder()
+                    .add(new DiscoveryNode("min_node", new TransportAddress(InetAddress.getLoopbackAddress(), 9300), Version.CURRENT))
+                    .add(new DiscoveryNode("current_node", new TransportAddress(InetAddress.getLoopbackAddress(), 9302), Version.CURRENT))
+                    .add(new DiscoveryNode("_node_id", new TransportAddress(InetAddress.getLoopbackAddress(), 9304), Version.CURRENT))
+                    .localNodeId("_node_id")
+                    .masterNodeId("_node_id")
+            )
+            .build();
+    }
+
+    private static PipelineConfiguration newConfigurationWithInferenceProcessor(String modelId) throws IOException {
+        try (
+            XContentBuilder xContentBuilder = XContentFactory.jsonBuilder()
+                .map(Collections.singletonMap("processors", Collections.singletonList(inferenceProcessorForModel(modelId))))
+        ) {
+            return new PipelineConfiguration("pipeline_with_model_" + modelId, BytesReference.bytes(xContentBuilder), XContentType.JSON);
+        }
+    }
+
+    private static PipelineConfiguration newConfigurationWithForeachProcessorProcessor(String modelId) throws IOException {
+        try (
+            XContentBuilder xContentBuilder = XContentFactory.jsonBuilder()
+                .map(Collections.singletonMap("processors", Collections.singletonList(forEachProcessorWithInference(modelId))))
+        ) {
+            return new PipelineConfiguration("pipeline_with_model_" + modelId, BytesReference.bytes(xContentBuilder), XContentType.JSON);
+        }
+    }
+
+    private static Map<String, Object> forEachProcessorWithInference(String modelId) {
+        return Collections.singletonMap("foreach", new HashMap<String, Object>() {
+            {
+                put("field", "foo");
+                put("processor", inferenceProcessorForModel(modelId));
+            }
+        });
+    }
+
+    private static Map<String, Object> inferenceProcessorForModel(String modelId) {
+        return Collections.singletonMap(InferenceProcessor.TYPE, new HashMap<String, Object>() {
+            {
+                put(InferenceResults.MODEL_ID_RESULTS_FIELD, modelId);
+                put(
+                    InferenceProcessor.INFERENCE_CONFIG,
+                    Collections.singletonMap(RegressionConfig.NAME.getPreferredName(), Collections.emptyMap())
+                );
+                put(InferenceProcessor.TARGET_FIELD, "new_field");
+                put(InferenceProcessor.FIELD_MAP, Collections.singletonMap("source", "dest"));
+            }
+        });
+    }
+
+}


### PR DESCRIPTION
Previous, get trained model stats API would build every pipeline defined in cluster state.

This is problematic when MANY pipelines are defined. Especially if those pipelines take some time to parse (consider GROK).

This improvement is part of fixing: #87931
