### PR TITLE
Ensure the test version is always pre-8.3.0

### DIFF
--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/histogram/InternalAutoDateHistogramTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/histogram/InternalAutoDateHistogramTests.java
@@ -468,7 +468,7 @@ public class InternalAutoDateHistogramTests extends InternalMultiBucketAggregati
         Version version = VersionUtils.randomVersionBetween(
             random(),
             Version.CURRENT.minimumCompatibilityVersion(),
-            VersionUtils.getPreviousVersion(Version.CURRENT)
+            VersionUtils.getPreviousVersion(Version.V_8_3_0)
         );
         InternalAutoDateHistogram deserialized = copyInstance(instance, version);
         assertEquals(1, deserialized.getBucketInnerInterval());


### PR DESCRIPTION
Closes #88137

`git bisect` blames the 8.3.1 as the bad commit, but that's because once that commit increased `Version.CURRENT` then `8.3.0` itself was now available to sometimes be the selected by `randomVersionBetween(...)`.