### PR TITLE
Add known issue for Azure Blob Storage (SAS token) connection error

### DIFF
--- a/docs/reference/release-notes/8.3.0.asciidoc
+++ b/docs/reference/release-notes/8.3.0.asciidoc
@@ -10,7 +10,7 @@ Also see <<breaking-changes-8.3,Breaking changes in 8.3>>.
 
 * 8.3.0 has an issue that could cause creating and accessing snapshots against Azure snapshot repositories 
 to fail authenticating when using SAS tokens. This impacts self-managed customers who have deployed 8.3.0. 
-Elastic Cloud Azure deployments are not currently being upgraded to 8.3.0 and are not impacted as a result (issue: https://github.com/elastic/elasticsearch/issues/88140)
+Elastic Cloud Azure deployments are not currently being upgraded to 8.3.0 and are not impacted as a result (issue: {es-issue}88140[#88140])
 
 [[bug-8.3.0]]
 [float]

--- a/docs/reference/release-notes/8.3.0.asciidoc
+++ b/docs/reference/release-notes/8.3.0.asciidoc
@@ -5,6 +5,13 @@ coming[8.3.0]
 
 Also see <<breaking-changes-8.3,Breaking changes in 8.3>>.
 
+[discrete]
+=== Known issues
+
+* 8.3.0 has an issue that could cause creating and accessing snapshots against Azure snapshot repositories 
+to fail authenticating when using SAS tokens. This impacts self-managed customers who have deployed 8.3.0. 
+Elastic Cloud Azure deployments are not currently being upgraded to 8.3.0 and are not impacted as a result (issue: https://github.com/elastic/elasticsearch/issues/88140)
+
 [[bug-8.3.0]]
 [float]
 === Bug fixes


### PR DESCRIPTION
This adds the known issue reference for https://github.com/elastic/elasticsearch/issues/88140 related to Azure Blob Storage connection issues when SAS token is used.