### PR TITLE
Remove ingest attachment limitation for fips

### DIFF
--- a/x-pack/docs/en/security/fips-140-compliance.asciidoc
+++ b/x-pack/docs/en/security/fips-140-compliance.asciidoc
@@ -27,8 +27,8 @@ For {es}, adherence to FIPS 140-2 is ensured by
 [discrete]
 === Upgrade considerations
 
-[IMPORTANT] 
-==== 
+[IMPORTANT]
+====
 include::fips-java17.asciidoc[]
 ====
 
@@ -158,7 +158,6 @@ Due to the limitations that FIPS 140-2 compliance enforces, a small number of
 features are not available while running in FIPS 140-2 mode. The list is as follows:
 
 * Azure Classic Discovery Plugin
-* Ingest Attachment Plugin
 * The <<certutil,`elasticsearch-certutil`>> tool. However,
  `elasticsearch-certutil` can very well be used in a non FIPS 140-2
   configured JVM (pointing `ES_JAVA_HOME` environment variable to a different


### PR DESCRIPTION
The ingest attachment plugin was unsupported in FIPS mode. This was
because of bouncycastle being included by some tika processors. The
bouncycastle dependency of those processors has now been removed, so
this commit removes the limitation from the FIPS docs.

relates #88031