### PR TITLE
Run gradle integration tests with configuration cache enabled by default

### DIFF
--- a/build-tools-internal/src/integTest/groovy/org/elasticsearch/gradle/fixtures/LocalRepositoryFixture.groovy
+++ b/build-tools-internal/src/integTest/groovy/org/elasticsearch/gradle/fixtures/LocalRepositoryFixture.groovy
@@ -17,8 +17,20 @@ class LocalRepositoryFixture extends ExternalResource{
 
     private TemporaryFolder temporaryFolder
 
-    LocalRepositoryFixture(TemporaryFolder temporaryFolder){
-        this.temporaryFolder = temporaryFolder
+    LocalRepositoryFixture(){
+        this.temporaryFolder = new TemporaryFolder()
+    }
+
+    @Override
+    protected void before() throws Throwable {
+        super.before()
+        temporaryFolder.before()
+    }
+
+    @Override
+    protected void after() {
+        super.after()
+        temporaryFolder.after()
     }
 
     void generateJar(String group, String module, String version, String... clazzNames){

--- a/build-tools-internal/src/integTest/groovy/org/elasticsearch/gradle/internal/BuildPluginFuncTest.groovy
+++ b/build-tools-internal/src/integTest/groovy/org/elasticsearch/gradle/internal/BuildPluginFuncTest.groovy
@@ -10,7 +10,11 @@ package org.elasticsearch.gradle.internal
 
 import org.apache.commons.io.IOUtils
 import org.elasticsearch.gradle.fixtures.AbstractGradleFuncTest
+import org.elasticsearch.gradle.fixtures.LocalRepositoryFixture
 import org.gradle.testkit.runner.TaskOutcome
+import org.junit.ClassRule
+import org.junit.rules.TemporaryFolder
+import spock.lang.Shared
 
 import java.nio.charset.StandardCharsets
 import java.util.zip.ZipEntry
@@ -19,6 +23,14 @@ import java.util.zip.ZipFile
 import static org.elasticsearch.gradle.fixtures.TestClasspathUtils.setupJarHellJar
 
 class BuildPluginFuncTest extends AbstractGradleFuncTest {
+
+    @ClassRule
+    @Shared
+    public TemporaryFolder repoFolder = new TemporaryFolder()
+
+    @Shared
+    @ClassRule
+    public LocalRepositoryFixture repository = new LocalRepositoryFixture(repoFolder)
 
     def EXAMPLE_LICENSE = """\
         Redistribution and use in source and binary forms, with or without
@@ -120,6 +132,8 @@ class BuildPluginFuncTest extends AbstractGradleFuncTest {
 
     def "applies checks"() {
         given:
+        repository.generateJar("org.elasticsearch", "build-conventions", "unspecified", 'org.acme.CheckstyleStuff')
+        repository.configureBuild(buildFile)
         setupJarHellJar(dir('local-repo/org/elasticsearch/elasticsearch-core/current/'))
         file("licenses/hamcrest-core-1.3.jar.sha1").text = "42a25dc3219429f0e5d060061f71acb49bf010a0"
         file("licenses/hamcrest-core-LICENSE.txt").text = EXAMPLE_LICENSE

--- a/build-tools-internal/src/integTest/groovy/org/elasticsearch/gradle/internal/BuildPluginFuncTest.groovy
+++ b/build-tools-internal/src/integTest/groovy/org/elasticsearch/gradle/internal/BuildPluginFuncTest.groovy
@@ -24,13 +24,9 @@ import static org.elasticsearch.gradle.fixtures.TestClasspathUtils.setupJarHellJ
 
 class BuildPluginFuncTest extends AbstractGradleFuncTest {
 
-    @ClassRule
-    @Shared
-    public TemporaryFolder repoFolder = new TemporaryFolder()
-
     @Shared
     @ClassRule
-    public LocalRepositoryFixture repository = new LocalRepositoryFixture(repoFolder)
+    public LocalRepositoryFixture repository = new LocalRepositoryFixture()
 
     def EXAMPLE_LICENSE = """\
         Redistribution and use in source and binary forms, with or without

--- a/build-tools-internal/src/integTest/groovy/org/elasticsearch/gradle/internal/ElasticsearchJavaPluginFuncTest.groovy
+++ b/build-tools-internal/src/integTest/groovy/org/elasticsearch/gradle/internal/ElasticsearchJavaPluginFuncTest.groovy
@@ -8,24 +8,22 @@
 
 package org.elasticsearch.gradle.internal
 
-import org.elasticsearch.gradle.fixtures.AbstractGradleFuncTest
+import org.elasticsearch.gradle.fixtures.AbstractGradleInternalPluginFuncTest
+import org.gradle.api.Plugin
 
-class ElasticsearchJavaPluginFuncTest extends AbstractGradleFuncTest {
+class ElasticsearchJavaPluginFuncTest extends AbstractGradleInternalPluginFuncTest {
+
+    Class<? extends Plugin> pluginClassUnderTest = ElasticsearchJavaPlugin.class
 
     def "compatibility options are resolved from from build params minimum runtime version"() {
         when:
-        buildFile.text = """
-        plugins {
-          id 'elasticsearch.global-build-info'
-        }
+        buildFile.text << """
         import org.elasticsearch.gradle.Architecture
         import org.elasticsearch.gradle.internal.info.BuildParams
         BuildParams.init { it.setMinimumRuntimeVersion(JavaVersion.VERSION_1_10) }
 
-        apply plugin:'elasticsearch.java'
-
-        assert compileJava.sourceCompatibility == JavaVersion.VERSION_1_10.toString()
-        assert compileJava.targetCompatibility == JavaVersion.VERSION_1_10.toString()
+        assert tasks.named('compileJava').get().sourceCompatibility == JavaVersion.VERSION_1_10.toString()
+        assert tasks.named('compileJava').get().targetCompatibility == JavaVersion.VERSION_1_10.toString()
         """
 
         then:
@@ -34,14 +32,10 @@ class ElasticsearchJavaPluginFuncTest extends AbstractGradleFuncTest {
 
     def "compile option --release is configured from targetCompatibility"() {
         when:
-        buildFile.text = """
-            plugins {
-             id 'elasticsearch.java'
-            }
-
-            compileJava.targetCompatibility = "1.10"
+        buildFile.text << """
+            tasks.named('compileJava').get().targetCompatibility = "1.10"
             afterEvaluate {
-                assert compileJava.options.release.get() == 10
+                assert tasks.named('compileJava').get().options.release.get() == 10
             }
         """
         then:

--- a/build-tools-internal/src/integTest/groovy/org/elasticsearch/gradle/internal/InternalBwcGitPluginFuncTest.groovy
+++ b/build-tools-internal/src/integTest/groovy/org/elasticsearch/gradle/internal/InternalBwcGitPluginFuncTest.groovy
@@ -14,6 +14,8 @@ import org.gradle.testkit.runner.TaskOutcome
 class InternalBwcGitPluginFuncTest extends AbstractGitAwareGradleFuncTest {
 
     def setup() {
+        // using LoggedExec is not cc compatible
+        configurationCacheCompatible = false
         internalBuild()
         buildFile << """
             import org.elasticsearch.gradle.Version;

--- a/build-tools-internal/src/integTest/groovy/org/elasticsearch/gradle/internal/InternalDistributionBwcSetupPluginFuncTest.groovy
+++ b/build-tools-internal/src/integTest/groovy/org/elasticsearch/gradle/internal/InternalDistributionBwcSetupPluginFuncTest.groovy
@@ -22,6 +22,8 @@ import spock.lang.Unroll
 class InternalDistributionBwcSetupPluginFuncTest extends AbstractGitAwareGradleFuncTest {
 
     def setup() {
+        // used LoggedExec task is not configuration cache compatible and
+        configurationCacheCompatible = false
         internalBuild()
         buildFile << """
             apply plugin: 'elasticsearch.internal-distribution-bwc-setup'

--- a/build-tools-internal/src/integTest/groovy/org/elasticsearch/gradle/internal/JdkDownloadPluginFuncTest.groovy
+++ b/build-tools-internal/src/integTest/groovy/org/elasticsearch/gradle/internal/JdkDownloadPluginFuncTest.groovy
@@ -147,6 +147,7 @@ class JdkDownloadPluginFuncTest extends AbstractGradleFuncTest {
             plugins {
              id 'elasticsearch.jdk-download'
             }
+            import org.elasticsearch.gradle.internal.Jdk
             apply plugin: 'base'
             apply plugin: 'elasticsearch.jdk-download'
 
@@ -158,11 +159,18 @@ class JdkDownloadPluginFuncTest extends AbstractGradleFuncTest {
                 architecture = "x64"
               }
             }
-
-            tasks.register("getJdk") {
+            
+            tasks.register("getJdk", PrintJdk) {
                 dependsOn jdks.myJdk
-                doLast {
-                    println "JDK HOME: " + jdks.myJdk
+                jdkPath = jdks.myJdk.getPath()
+            }
+
+            class PrintJdk extends DefaultTask {
+                @Input
+                String jdkPath
+                
+                @TaskAction void print() {
+                    println "JDK HOME: " + jdkPath
                 }
             }
         """

--- a/build-tools-internal/src/integTest/groovy/org/elasticsearch/gradle/internal/PublishPluginFuncTest.groovy
+++ b/build-tools-internal/src/integTest/groovy/org/elasticsearch/gradle/internal/PublishPluginFuncTest.groovy
@@ -250,6 +250,8 @@ class PublishPluginFuncTest extends AbstractGradleFuncTest {
 
     def "generates artifacts for shadowed elasticsearch plugin"() {
         given:
+        // we use the esplugin plugin in this test that is not configuration cache compatible yet
+        configurationCacheCompatible = false
         file('license.txt') << "License file"
         file('notice.txt') << "Notice file"
         buildFile << """
@@ -334,6 +336,8 @@ class PublishPluginFuncTest extends AbstractGradleFuncTest {
 
     def "generates pom for elasticsearch plugin"() {
         given:
+        // we use the esplugin plugin in this test that is not configuration cache compatible yet
+        configurationCacheCompatible = false
         file('license.txt') << "License file"
         file('notice.txt') << "Notice file"
         buildFile << """

--- a/build-tools-internal/src/integTest/groovy/org/elasticsearch/gradle/internal/distibution/ElasticsearchDistributionPluginFuncTest.groovy
+++ b/build-tools-internal/src/integTest/groovy/org/elasticsearch/gradle/internal/distibution/ElasticsearchDistributionPluginFuncTest.groovy
@@ -15,6 +15,8 @@ class ElasticsearchDistributionPluginFuncTest extends AbstractGradleFuncTest {
 
     def "copied modules are resolved from explodedBundleZip"() {
         given:
+        // we use the esplugin plugin in this test that is not configuration cache compatible yet
+        configurationCacheCompatible = false
         moduleSubProject()
 
         buildFile << """plugins {

--- a/build-tools-internal/src/integTest/groovy/org/elasticsearch/gradle/internal/precommit/LicenseHeadersPrecommitPluginFuncTest.groovy
+++ b/build-tools-internal/src/integTest/groovy/org/elasticsearch/gradle/internal/precommit/LicenseHeadersPrecommitPluginFuncTest.groovy
@@ -18,7 +18,6 @@ class LicenseHeadersPrecommitPluginFuncTest extends AbstractGradleInternalPlugin
     Class<? extends PrecommitPlugin> pluginClassUnderTest = LicenseHeadersPrecommitPlugin.class
 
     def setup() {
-        configurationCacheCompatible = true
         buildFile << """
         apply plugin:'java'
         """

--- a/build-tools-internal/src/integTest/groovy/org/elasticsearch/gradle/internal/precommit/TestingConventionsPrecommitPluginFuncTest.groovy
+++ b/build-tools-internal/src/integTest/groovy/org/elasticsearch/gradle/internal/precommit/TestingConventionsPrecommitPluginFuncTest.groovy
@@ -45,7 +45,6 @@ class TestingConventionsPrecommitPluginFuncTest extends AbstractGradleInternalPl
     }
 
     def setup() {
-        configurationCacheCompatible = true
         repository.configureBuild(buildFile)
     }
 

--- a/build-tools-internal/src/integTest/groovy/org/elasticsearch/gradle/internal/precommit/TestingConventionsPrecommitPluginFuncTest.groovy
+++ b/build-tools-internal/src/integTest/groovy/org/elasticsearch/gradle/internal/precommit/TestingConventionsPrecommitPluginFuncTest.groovy
@@ -24,13 +24,9 @@ class TestingConventionsPrecommitPluginFuncTest extends AbstractGradleInternalPl
 
     Class<? extends PrecommitPlugin> pluginClassUnderTest = TestingConventionsPrecommitPlugin.class
 
-    @ClassRule
-    @Shared
-    public TemporaryFolder repoFolder = new TemporaryFolder()
-
     @Shared
     @ClassRule
-    public LocalRepositoryFixture repository = new LocalRepositoryFixture(repoFolder)
+    public LocalRepositoryFixture repository = new LocalRepositoryFixture()
 
     def setupSpec() {
         repository.generateJar('org.apache.lucene', 'tests.util', "1.0",

--- a/build-tools-internal/src/integTest/groovy/org/elasticsearch/gradle/internal/precommit/ThirdPartyAuditTaskFuncTest.groovy
+++ b/build-tools-internal/src/integTest/groovy/org/elasticsearch/gradle/internal/precommit/ThirdPartyAuditTaskFuncTest.groovy
@@ -15,25 +15,24 @@ import net.bytebuddy.dynamic.DynamicType
 import net.bytebuddy.implementation.FixedValue
 import org.apache.logging.log4j.LogManager
 import org.elasticsearch.gradle.fixtures.AbstractGradleFuncTest
+import org.elasticsearch.gradle.fixtures.AbstractGradleInternalPluginFuncTest
+import org.elasticsearch.gradle.internal.conventions.precommit.LicenseHeadersPrecommitPlugin
+import org.elasticsearch.gradle.internal.conventions.precommit.PrecommitPlugin
 import org.gradle.testkit.runner.TaskOutcome
 
 
 import static org.elasticsearch.gradle.fixtures.TestClasspathUtils.setupJarJdkClasspath
 
-class ThirdPartyAuditTaskFuncTest extends AbstractGradleFuncTest {
+class ThirdPartyAuditTaskFuncTest extends AbstractGradleInternalPluginFuncTest {
+
+    Class<? extends PrecommitPlugin> pluginClassUnderTest = ThirdPartyAuditPrecommitPlugin.class
 
     def setup() {
         buildFile << """
         import org.elasticsearch.gradle.internal.precommit.ThirdPartyAuditPrecommitPlugin
         import org.elasticsearch.gradle.internal.precommit.ThirdPartyAuditTask
         
-        plugins {
-          id 'java'
-          // bring in build-tools onto the classpath
-          id 'elasticsearch.global-build-info'
-        }
-        
-        plugins.apply(ThirdPartyAuditPrecommitPlugin)
+        apply plugin:'java'
         
         group = 'org.elasticsearch'
         version = 'current'
@@ -48,7 +47,7 @@ class ThirdPartyAuditTaskFuncTest extends AbstractGradleFuncTest {
           mavenCentral()
         }    
         
-        tasks.register("thirdPartyCheck", ThirdPartyAuditTask) {
+        tasks.named("thirdPartyAudit").configure {
           signatureFile = file('signature-file.txt')
         }
         """
@@ -58,6 +57,7 @@ class ThirdPartyAuditTaskFuncTest extends AbstractGradleFuncTest {
         given:
         def group = "org.elasticsearch.gradle"
         generateDummyJars(group)
+        setupJarJdkClasspath(dir('local-repo/org/elasticsearch/elasticsearch-core/current/'))
         file('signature-file.txt') << "@defaultMessage non-public internal runtime class"
 
         buildFile << """
@@ -68,9 +68,9 @@ class ThirdPartyAuditTaskFuncTest extends AbstractGradleFuncTest {
             }
             """
         when:
-        def result = gradleRunner("thirdPartyCheck").build()
+        def result = gradleRunner("thirdPartyAudit").build()
         then:
-        result.task(":thirdPartyCheck").outcome == TaskOutcome.NO_SOURCE
+        result.task(":thirdPartyAudit").outcome == TaskOutcome.NO_SOURCE
         assertNoDeprecationWarning(result)
     }
 
@@ -91,9 +91,9 @@ class ThirdPartyAuditTaskFuncTest extends AbstractGradleFuncTest {
             }
             """
         when:
-        def result = gradleRunner(":thirdPartyCheck").buildAndFail()
+        def result = gradleRunner(":thirdPartyAudit").buildAndFail()
         then:
-        result.task(":thirdPartyCheck").outcome == TaskOutcome.FAILED
+        result.task(":thirdPartyAudit").outcome == TaskOutcome.FAILED
 
         def output = normalized(result.getOutput())
         assertOutputContains(output, """\
@@ -127,9 +127,9 @@ class ThirdPartyAuditTaskFuncTest extends AbstractGradleFuncTest {
             }
             """
         when:
-        def result = gradleRunner(":thirdPartyCheck").buildAndFail()
+        def result = gradleRunner(":thirdPartyAudit").buildAndFail()
         then:
-        result.task(":thirdPartyCheck").outcome == TaskOutcome.FAILED
+        result.task(":thirdPartyAudit").outcome == TaskOutcome.FAILED
 
         def output = normalized(result.getOutput())
         assertOutputContains(output, """\
@@ -163,9 +163,9 @@ class ThirdPartyAuditTaskFuncTest extends AbstractGradleFuncTest {
             }
             """
         when:
-        def result = gradleRunner(":thirdPartyCheck").buildAndFail()
+        def result = gradleRunner(":thirdPartyAudit").buildAndFail()
         then:
-        result.task(":thirdPartyCheck").outcome == TaskOutcome.FAILED
+        result.task(":thirdPartyAudit").outcome == TaskOutcome.FAILED
 
         def output = normalized(result.getOutput())
         assertOutputContains(output, """\
@@ -174,7 +174,7 @@ class ThirdPartyAuditTaskFuncTest extends AbstractGradleFuncTest {
             """.stripIndent())
         assertOutputContains(output, """\
             * What went wrong:
-            Execution failed for task ':thirdPartyCheck'.
+            Execution failed for task ':thirdPartyAudit'.
             > Audit of third party dependencies failed:
                 Jar Hell with the JDK:
                 * 

--- a/build-tools-internal/src/integTest/groovy/org/elasticsearch/gradle/internal/test/rest/InternalYamlRestTestPluginFuncTest.groovy
+++ b/build-tools-internal/src/integTest/groovy/org/elasticsearch/gradle/internal/test/rest/InternalYamlRestTestPluginFuncTest.groovy
@@ -19,6 +19,8 @@ class InternalYamlRestTestPluginFuncTest extends AbstractRestResourcesFuncTest {
 
     def "yamlRestTest does nothing when there are no tests"() {
         given:
+        // RestIntegTestTask not cc compatible due to
+        configurationCacheCompatible = false
         buildFile << """
         plugins {
           id 'elasticsearch.internal-yaml-rest-test'
@@ -36,6 +38,8 @@ class InternalYamlRestTestPluginFuncTest extends AbstractRestResourcesFuncTest {
 
     def "yamlRestTest executes and copies api and tests to correct source set"() {
         given:
+        // RestIntegTestTask not cc compatible due to
+        configurationCacheCompatible = false
         internalBuild()
         buildFile << """
             apply plugin: 'elasticsearch.internal-yaml-rest-test'

--- a/build-tools-internal/src/integTest/groovy/org/elasticsearch/gradle/internal/test/rest/RestResourcesPluginFuncTest.groovy
+++ b/build-tools-internal/src/integTest/groovy/org/elasticsearch/gradle/internal/test/rest/RestResourcesPluginFuncTest.groovy
@@ -122,6 +122,8 @@ class RestResourcesPluginFuncTest extends AbstractRestResourcesFuncTest {
 
     def "restResources copies Tests and API by configuration"() {
         given:
+        // CopyRestTestsTask has troubles loading correctly in cc mode
+        configurationCacheCompatible = false
         internalBuild()
         buildFile << """
             apply plugin: 'elasticsearch.java'
@@ -170,7 +172,7 @@ class RestResourcesPluginFuncTest extends AbstractRestResourcesFuncTest {
         file("/build/restResources/yamlTests/rest-api-spec/test/" + coreTest).getText("UTF-8") == "replacedWithValue"
 
         when:
-        result = gradleRunner("copyRestApiSpecsTask").build()
+        result = gradleRunner("copyRestApiSpecsTask", '--stacktrace').build()
 
         then:
         result.task(':copyRestApiSpecsTask').outcome == TaskOutcome.UP_TO_DATE

--- a/build-tools-internal/src/integTest/groovy/org/elasticsearch/gradle/internal/test/rest/RestResourcesPluginFuncTest.groovy
+++ b/build-tools-internal/src/integTest/groovy/org/elasticsearch/gradle/internal/test/rest/RestResourcesPluginFuncTest.groovy
@@ -122,8 +122,6 @@ class RestResourcesPluginFuncTest extends AbstractRestResourcesFuncTest {
 
     def "restResources copies Tests and API by configuration"() {
         given:
-        // CopyRestTestsTask has troubles loading correctly in cc mode
-        configurationCacheCompatible = false
         internalBuild()
         buildFile << """
             apply plugin: 'elasticsearch.java'

--- a/build-tools-internal/src/integTest/groovy/org/elasticsearch/gradle/internal/test/rest/YamlRestCompatTestPluginFuncTest.groovy
+++ b/build-tools-internal/src/integTest/groovy/org/elasticsearch/gradle/internal/test/rest/YamlRestCompatTestPluginFuncTest.groovy
@@ -28,6 +28,12 @@ class YamlRestCompatTestPluginFuncTest extends AbstractRestResourcesFuncTest {
     def READER = MAPPER.readerFor(ObjectNode.class)
     def WRITER = MAPPER.writerFor(ObjectNode.class)
 
+    def setup() {
+        // not cc compatible due to:
+        // 1. TestClustersPlugin not cc compatible due to listener registration
+        // 2. RestIntegTestTask not cc compatible due to
+        configurationCacheCompatible = false
+    }
     def "yamlRestTestVxCompatTest does nothing when there are no tests"() {
         given:
         subProject(":distribution:bwc:maintenance") << """

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/ElasticsearchJavadocPlugin.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/ElasticsearchJavadocPlugin.java
@@ -32,11 +32,9 @@ import java.util.List;
 // other packages (e.g org.elasticsearch.client) will point to server rather than
 // their own artifacts.
 public class ElasticsearchJavadocPlugin implements Plugin<Project> {
-    private Project project;
 
     @Override
     public void apply(Project project) {
-        this.project = project;
         // ignore missing javadocs
         project.getTasks().withType(Javadoc.class).configureEach(javadoc -> {
             // the -quiet here is because of a bug in gradle, in that adding a string option
@@ -57,7 +55,7 @@ public class ElasticsearchJavadocPlugin implements Plugin<Project> {
         });
 
         // Relying on configurations introduced by the java plugin
-        this.project.getPlugins().withType(JavaPlugin.class, javaPlugin -> project.afterEvaluate(project1 -> {
+        project.getPlugins().withType(JavaPlugin.class, javaPlugin -> project.afterEvaluate(project1 -> {
             var withShadowPlugin = project1.getPlugins().hasPlugin(ShadowPlugin.class);
             var compileClasspath = project.getConfigurations().getByName("compileClasspath");
 
@@ -67,25 +65,25 @@ public class ElasticsearchJavadocPlugin implements Plugin<Project> {
                 var nonShadowedCompileClasspath = compileClasspath.copyRecursive(
                     dependency -> shadowedDependencies.contains(dependency) == false
                 );
-                configureJavadocForConfiguration(false, nonShadowedCompileClasspath);
-                configureJavadocForConfiguration(true, shadowConfiguration);
+                configureJavadocForConfiguration(project, false, nonShadowedCompileClasspath);
+                configureJavadocForConfiguration(project, true, shadowConfiguration);
             } else {
-                configureJavadocForConfiguration(false, compileClasspath);
+                configureJavadocForConfiguration(project, false, compileClasspath);
             }
         }));
     }
 
-    private void configureJavadocForConfiguration(boolean shadow, Configuration configuration) {
+    private void configureJavadocForConfiguration(Project project, boolean shadow, Configuration configuration) {
         configuration.getAllDependencies()
             .stream()
             .sorted(Comparator.comparing(Dependency::getGroup))
             .filter(d -> d instanceof ProjectDependency)
             .map(d -> (ProjectDependency) d)
             .filter(p -> p.getDependencyProject() != null)
-            .forEach(projectDependency -> configureDependency(shadow, projectDependency));
+            .forEach(projectDependency -> configureDependency(project, shadow, projectDependency));
     }
 
-    private void configureDependency(boolean shadowed, ProjectDependency dep) {
+    private void configureDependency(Project project, boolean shadowed, ProjectDependency dep) {
         var upstreamProject = dep.getDependencyProject();
         if (shadowed) {
             /*

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/precommit/CheckstylePrecommitPlugin.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/precommit/CheckstylePrecommitPlugin.java
@@ -86,9 +86,9 @@ public class CheckstylePrecommitPlugin extends PrecommitPlugin implements Intern
 
         DependencyHandler dependencies = project.getDependencies();
         String checkstyleVersion = VersionProperties.getVersions().get("checkstyle");
-        Provider<String> dependencyProvider = project.provider(() -> "org.elasticsearch:build-conventions:" + project.getVersion());
+        Provider<String> conventionsDependencyProvider = project.provider(() -> "org.elasticsearch:build-conventions:" + project.getVersion());
         dependencies.add("checkstyle", "com.puppycrawl.tools:checkstyle:" + checkstyleVersion);
-        dependencies.addProvider("checkstyle", dependencyProvider, dep -> dep.setTransitive(false));
+        dependencies.addProvider("checkstyle", conventionsDependencyProvider, dep -> dep.setTransitive(false));
 
         project.getTasks().withType(Checkstyle.class).configureEach(t -> {
             t.dependsOn(copyCheckstyleConf);

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/precommit/CheckstylePrecommitPlugin.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/precommit/CheckstylePrecommitPlugin.java
@@ -86,7 +86,9 @@ public class CheckstylePrecommitPlugin extends PrecommitPlugin implements Intern
 
         DependencyHandler dependencies = project.getDependencies();
         String checkstyleVersion = VersionProperties.getVersions().get("checkstyle");
-        Provider<String> conventionsDependencyProvider = project.provider(() -> "org.elasticsearch:build-conventions:" + project.getVersion());
+        Provider<String> conventionsDependencyProvider = project.provider(
+            () -> "org.elasticsearch:build-conventions:" + project.getVersion()
+        );
         dependencies.add("checkstyle", "com.puppycrawl.tools:checkstyle:" + checkstyleVersion);
         dependencies.addProvider("checkstyle", conventionsDependencyProvider, dep -> dep.setTransitive(false));
 

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/precommit/ThirdPartyAuditPrecommitPlugin.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/precommit/ThirdPartyAuditPrecommitPlugin.java
@@ -55,7 +55,7 @@ public class ThirdPartyAuditPrecommitPlugin extends PrecommitPlugin implements I
             Configuration compileOnly = project.getConfigurations()
                 .getByName(CompileOnlyResolvePlugin.RESOLVEABLE_COMPILE_ONLY_CONFIGURATION_NAME);
             t.setClasspath(runtimeConfiguration.plus(compileOnly));
-            t.setJarsToScan(runtimeConfiguration.fileCollection(dep -> {
+            t.getJarsToScan().from(runtimeConfiguration.fileCollection(dep -> {
                 // These are SelfResolvingDependency, and some of them backed by file collections, like the Gradle API files,
                 // or dependencies added as `files(...)`, we can't be sure if those are third party or not.
                 // err on the side of scanning these to make sure we don't miss anything
@@ -65,8 +65,8 @@ public class ThirdPartyAuditPrecommitPlugin extends PrecommitPlugin implements I
             t.setJavaHome(Jvm.current().getJavaHome().getPath());
             t.getTargetCompatibility().set(project.provider(BuildParams::getRuntimeJavaVersion));
             t.setSignatureFile(resourcesDir.resolve("forbidden/third-party-audit.txt").toFile());
-            t.setJdkJarHellClasspath(jdkJarHellConfig);
-            t.setForbiddenAPIsClasspath(project.getConfigurations().getByName("forbiddenApisCliJar").plus(compileOnly));
+            t.getJdkJarHellClasspath().from(jdkJarHellConfig);
+            t.getForbiddenAPIsClasspath().from(project.getConfigurations().getByName("forbiddenApisCliJar").plus(compileOnly));
         });
         return audit;
     }

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/test/rest/CopyRestApiTask.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/test/rest/CopyRestApiTask.java
@@ -7,6 +7,7 @@
  */
 package org.elasticsearch.gradle.internal.test.rest;
 
+import org.elasticsearch.gradle.internal.util.SerializableFunction;
 import org.gradle.api.DefaultTask;
 import org.gradle.api.file.DirectoryProperty;
 import org.gradle.api.file.FileCollection;
@@ -28,6 +29,7 @@ import org.gradle.internal.Factory;
 
 import java.io.File;
 import java.io.IOException;
+import java.io.Serializable;
 import java.nio.file.Files;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -54,8 +56,8 @@ public class CopyRestApiTask extends DefaultTask {
     private boolean skipHasRestTestCheck;
     private FileCollection config;
     private FileCollection additionalConfig;
-    private Function<FileCollection, FileTree> configToFileTree = FileCollection::getAsFileTree;
-    private Function<FileCollection, FileTree> additionalConfigToFileTree = FileCollection::getAsFileTree;
+    private SerializableFunction<FileCollection, FileTree> configToFileTree = FileCollection::getAsFileTree;
+    private SerializableFunction<FileCollection, FileTree> additionalConfigToFileTree = FileCollection::getAsFileTree;
 
     private final PatternFilterable patternSet;
     private final ProjectLayout projectLayout;
@@ -176,11 +178,11 @@ public class CopyRestApiTask extends DefaultTask {
         this.additionalConfig = additionalConfig;
     }
 
-    public void setConfigToFileTree(Function<FileCollection, FileTree> configToFileTree) {
+    public void setConfigToFileTree(SerializableFunction<FileCollection, FileTree> configToFileTree) {
         this.configToFileTree = configToFileTree;
     }
 
-    public void setAdditionalConfigToFileTree(Function<FileCollection, FileTree> additionalConfigToFileTree) {
+    public void setAdditionalConfigToFileTree(SerializableFunction<FileCollection, FileTree> additionalConfigToFileTree) {
         this.additionalConfigToFileTree = additionalConfigToFileTree;
     }
 

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/test/rest/CopyRestApiTask.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/test/rest/CopyRestApiTask.java
@@ -29,9 +29,7 @@ import org.gradle.internal.Factory;
 
 import java.io.File;
 import java.io.IOException;
-import java.io.Serializable;
 import java.nio.file.Files;
-import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import javax.inject.Inject;

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/test/rest/CopyRestTestsTask.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/test/rest/CopyRestTestsTask.java
@@ -8,6 +8,7 @@
 package org.elasticsearch.gradle.internal.test.rest;
 
 import org.apache.tools.ant.filters.ReplaceTokens;
+import org.elasticsearch.gradle.internal.util.SerializableFunction;
 import org.gradle.api.DefaultTask;
 import org.gradle.api.file.DirectoryProperty;
 import org.gradle.api.file.FileCollection;
@@ -28,6 +29,7 @@ import org.gradle.api.tasks.util.PatternSet;
 import org.gradle.internal.Factory;
 
 import java.io.File;
+import java.io.Serializable;
 import java.util.Map;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -53,9 +55,9 @@ public class CopyRestTestsTask extends DefaultTask {
     private FileCollection coreConfig;
     private FileCollection xpackConfig;
     private FileCollection additionalConfig;
-    private Function<FileCollection, FileTree> coreConfigToFileTree = FileCollection::getAsFileTree;
-    private Function<FileCollection, FileTree> xpackConfigToFileTree = FileCollection::getAsFileTree;
-    private Function<FileCollection, FileTree> additionalConfigToFileTree = FileCollection::getAsFileTree;
+    private SerializableFunction<FileCollection, FileTree> coreConfigToFileTree = FileCollection::getAsFileTree;
+    private SerializableFunction<FileCollection, FileTree> xpackConfigToFileTree = FileCollection::getAsFileTree;
+    private SerializableFunction<FileCollection, FileTree> additionalConfigToFileTree = FileCollection::getAsFileTree;
 
     private final PatternFilterable corePatternSet;
     private final PatternFilterable xpackPatternSet;
@@ -183,15 +185,15 @@ public class CopyRestTestsTask extends DefaultTask {
         this.additionalConfig = additionalConfig;
     }
 
-    public void setCoreConfigToFileTree(Function<FileCollection, FileTree> coreConfigToFileTree) {
+    public void setCoreConfigToFileTree(SerializableFunction<FileCollection, FileTree> coreConfigToFileTree) {
         this.coreConfigToFileTree = coreConfigToFileTree;
     }
 
-    public void setXpackConfigToFileTree(Function<FileCollection, FileTree> xpackConfigToFileTree) {
+    public void setXpackConfigToFileTree(SerializableFunction<FileCollection, FileTree> xpackConfigToFileTree) {
         this.xpackConfigToFileTree = xpackConfigToFileTree;
     }
 
-    public void setAdditionalConfigToFileTree(Function<FileCollection, FileTree> additionalConfigToFileTree) {
+    public void setAdditionalConfigToFileTree(SerializableFunction<FileCollection, FileTree> additionalConfigToFileTree) {
         this.additionalConfigToFileTree = additionalConfigToFileTree;
     }
 

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/test/rest/CopyRestTestsTask.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/test/rest/CopyRestTestsTask.java
@@ -29,9 +29,7 @@ import org.gradle.api.tasks.util.PatternSet;
 import org.gradle.internal.Factory;
 
 import java.io.File;
-import java.io.Serializable;
 import java.util.Map;
-import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import javax.inject.Inject;

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/test/rest/CopyRestTestsTask.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/test/rest/CopyRestTestsTask.java
@@ -28,7 +28,6 @@ import org.gradle.api.tasks.util.PatternSet;
 import org.gradle.internal.Factory;
 
 import java.io.File;
-import java.io.Serializable;
 import java.util.Map;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -54,9 +53,9 @@ public class CopyRestTestsTask extends DefaultTask {
     private FileCollection coreConfig;
     private FileCollection xpackConfig;
     private FileCollection additionalConfig;
-    private SerializableFunction<FileCollection, FileTree> coreConfigToFileTree = FileCollection::getAsFileTree;
-    private SerializableFunction<FileCollection, FileTree> xpackConfigToFileTree = FileCollection::getAsFileTree;
-    private SerializableFunction<FileCollection, FileTree> additionalConfigToFileTree = FileCollection::getAsFileTree;
+    private Function<FileCollection, FileTree> coreConfigToFileTree = FileCollection::getAsFileTree;
+    private Function<FileCollection, FileTree> xpackConfigToFileTree = FileCollection::getAsFileTree;
+    private Function<FileCollection, FileTree> additionalConfigToFileTree = FileCollection::getAsFileTree;
 
     private final PatternFilterable corePatternSet;
     private final PatternFilterable xpackPatternSet;
@@ -184,17 +183,16 @@ public class CopyRestTestsTask extends DefaultTask {
         this.additionalConfig = additionalConfig;
     }
 
-    public void setCoreConfigToFileTree(SerializableFunction<FileCollection, FileTree> coreConfigToFileTree) {
+    public void setCoreConfigToFileTree(Function<FileCollection, FileTree> coreConfigToFileTree) {
         this.coreConfigToFileTree = coreConfigToFileTree;
     }
 
-    public void setXpackConfigToFileTree(SerializableFunction<FileCollection, FileTree> xpackConfigToFileTree) {
+    public void setXpackConfigToFileTree(Function<FileCollection, FileTree> xpackConfigToFileTree) {
         this.xpackConfigToFileTree = xpackConfigToFileTree;
     }
 
-    public void setAdditionalConfigToFileTree(SerializableFunction<FileCollection, FileTree> additionalConfigToFileTree) {
+    public void setAdditionalConfigToFileTree(Function<FileCollection, FileTree> additionalConfigToFileTree) {
         this.additionalConfigToFileTree = additionalConfigToFileTree;
     }
 
-    public interface SerializableFunction<T,R> extends Function<T,R>, Serializable {}
 }

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/test/rest/CopyRestTestsTask.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/test/rest/CopyRestTestsTask.java
@@ -28,6 +28,7 @@ import org.gradle.api.tasks.util.PatternSet;
 import org.gradle.internal.Factory;
 
 import java.io.File;
+import java.io.Serializable;
 import java.util.Map;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -53,9 +54,9 @@ public class CopyRestTestsTask extends DefaultTask {
     private FileCollection coreConfig;
     private FileCollection xpackConfig;
     private FileCollection additionalConfig;
-    private Function<FileCollection, FileTree> coreConfigToFileTree = FileCollection::getAsFileTree;
-    private Function<FileCollection, FileTree> xpackConfigToFileTree = FileCollection::getAsFileTree;
-    private Function<FileCollection, FileTree> additionalConfigToFileTree = FileCollection::getAsFileTree;
+    private SerializableFunction<FileCollection, FileTree> coreConfigToFileTree = FileCollection::getAsFileTree;
+    private SerializableFunction<FileCollection, FileTree> xpackConfigToFileTree = FileCollection::getAsFileTree;
+    private SerializableFunction<FileCollection, FileTree> additionalConfigToFileTree = FileCollection::getAsFileTree;
 
     private final PatternFilterable corePatternSet;
     private final PatternFilterable xpackPatternSet;
@@ -183,16 +184,17 @@ public class CopyRestTestsTask extends DefaultTask {
         this.additionalConfig = additionalConfig;
     }
 
-    public void setCoreConfigToFileTree(Function<FileCollection, FileTree> coreConfigToFileTree) {
+    public void setCoreConfigToFileTree(SerializableFunction<FileCollection, FileTree> coreConfigToFileTree) {
         this.coreConfigToFileTree = coreConfigToFileTree;
     }
 
-    public void setXpackConfigToFileTree(Function<FileCollection, FileTree> xpackConfigToFileTree) {
+    public void setXpackConfigToFileTree(SerializableFunction<FileCollection, FileTree> xpackConfigToFileTree) {
         this.xpackConfigToFileTree = xpackConfigToFileTree;
     }
 
-    public void setAdditionalConfigToFileTree(Function<FileCollection, FileTree> additionalConfigToFileTree) {
+    public void setAdditionalConfigToFileTree(SerializableFunction<FileCollection, FileTree> additionalConfigToFileTree) {
         this.additionalConfigToFileTree = additionalConfigToFileTree;
     }
 
+    public interface SerializableFunction<T,R> extends Function<T,R>, Serializable {}
 }

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/util/SerializableFunction.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/util/SerializableFunction.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.gradle.internal.util;
+
+import java.io.Serializable;
+import java.util.function.Function;
+
+/**
+ * A functional interface that extends Function but also Serializable.
+ *
+ * Gradle configuration cache requires fields that represent a lambda must be serializable.
+ * */
+@FunctionalInterface
+public interface SerializableFunction<T, R> extends Function<T, R>, Serializable {
+}

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/util/SerializableFunction.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/util/SerializableFunction.java
@@ -14,8 +14,7 @@ import java.util.function.Function;
 /**
  * A functional interface that extends Function but also Serializable.
  *
- * Gradle configuration cache requires fields that represent a lambda must be serializable.
+ * Gradle configuration cache requires fields that represent a lambda to be serializable.
  * */
 @FunctionalInterface
-public interface SerializableFunction<T, R> extends Function<T, R>, Serializable {
-}
+public interface SerializableFunction<T, R> extends Function<T, R>, Serializable {}

--- a/build-tools/src/integTest/groovy/org/elasticsearch/gradle/TestClustersPluginFuncTest.groovy
+++ b/build-tools/src/integTest/groovy/org/elasticsearch/gradle/TestClustersPluginFuncTest.groovy
@@ -25,6 +25,8 @@ import static org.elasticsearch.gradle.fixtures.DistributionDownloadFixture.with
 class TestClustersPluginFuncTest extends AbstractGradleFuncTest {
 
     def setup() {
+        // TestClusterPlugin with adding task listeners is not cc compatible
+        configurationCacheCompatible = false
         buildFile << """
             import org.elasticsearch.gradle.testclusters.TestClustersAware
             import org.elasticsearch.gradle.testclusters.ElasticsearchCluster

--- a/build-tools/src/integTest/groovy/org/elasticsearch/gradle/plugin/PluginBuildPluginFuncTest.groovy
+++ b/build-tools/src/integTest/groovy/org/elasticsearch/gradle/plugin/PluginBuildPluginFuncTest.groovy
@@ -18,6 +18,11 @@ import java.util.stream.Collectors
 
 class PluginBuildPluginFuncTest extends AbstractGradleFuncTest {
 
+    def setup() {
+        // underlaying TestClusterPlugin and StandaloneRestIntegTestTask are not cc compatible
+        configurationCacheCompatible = false
+    }
+
     def "can assemble plugin via #taskName"() {
         given:
         buildFile << """plugins {

--- a/build-tools/src/integTest/groovy/org/elasticsearch/gradle/reaper/ReaperPluginFuncTest.groovy
+++ b/build-tools/src/integTest/groovy/org/elasticsearch/gradle/reaper/ReaperPluginFuncTest.groovy
@@ -23,9 +23,10 @@ class ReaperPluginFuncTest extends AbstractGradleFuncTest {
             import org.elasticsearch.gradle.ReaperPlugin;
             import org.elasticsearch.gradle.util.GradleUtils;
             
+            def serviceProvider = GradleUtils.getBuildService(project.getGradle().getSharedServices(), ReaperPlugin.REAPER_SERVICE_NAME);
+                
             tasks.register("launchReaper") {
               doLast {
-                def serviceProvider = GradleUtils.getBuildService(project.getGradle().getSharedServices(), ReaperPlugin.REAPER_SERVICE_NAME);
                 def reaper = serviceProvider.get()
                 reaper.registerCommand('test', 'true')
                 reaper.unregister('test')

--- a/build-tools/src/integTest/groovy/org/elasticsearch/gradle/test/JavaRestTestPluginFuncTest.groovy
+++ b/build-tools/src/integTest/groovy/org/elasticsearch/gradle/test/JavaRestTestPluginFuncTest.groovy
@@ -14,6 +14,11 @@ import org.gradle.testkit.runner.TaskOutcome
 
 class JavaRestTestPluginFuncTest extends AbstractGradleFuncTest {
 
+    def setup() {
+        // underlaying TestClusterPlugin and StandaloneRestIntegTestTask are not cc compatible
+        configurationCacheCompatible = false
+    }
+
     def "declares default dependencies"() {
         given:
         buildFile << """

--- a/build-tools/src/integTest/groovy/org/elasticsearch/gradle/test/YamlRestTestPluginFuncTest.groovy
+++ b/build-tools/src/integTest/groovy/org/elasticsearch/gradle/test/YamlRestTestPluginFuncTest.groovy
@@ -14,6 +14,11 @@ import org.gradle.testkit.runner.TaskOutcome
 
 class YamlRestTestPluginFuncTest extends AbstractGradleFuncTest {
 
+    def setup() {
+        // underlaying TestClusterPlugin and StandaloneRestIntegTestTask are not cc compatible
+        configurationCacheCompatible = false
+    }
+
     def "declares default dependencies"() {
         given:
         buildFile << """

--- a/build-tools/src/testFixtures/groovy/org/elasticsearch/gradle/fixtures/AbstractGradleFuncTest.groovy
+++ b/build-tools/src/testFixtures/groovy/org/elasticsearch/gradle/fixtures/AbstractGradleFuncTest.groovy
@@ -47,9 +47,9 @@ abstract class AbstractGradleFuncTest extends Specification {
     }
 
     def cleanup() {
-        if (Boolean.getBoolean('test.keep.samplebuild')) {
+//        if (Boolean.getBoolean('test.keep.samplebuild')) {
             FileUtils.copyDirectory(testProjectDir.root, new File("build/test-debug/" + testProjectDir.root.name))
-        }
+//        }
     }
 
     File subProject(String subProjectPath) {

--- a/build-tools/src/testFixtures/groovy/org/elasticsearch/gradle/fixtures/AbstractGradleFuncTest.groovy
+++ b/build-tools/src/testFixtures/groovy/org/elasticsearch/gradle/fixtures/AbstractGradleFuncTest.groovy
@@ -34,7 +34,7 @@ abstract class AbstractGradleFuncTest extends Specification {
     File propertiesFile
     File projectDir
 
-    boolean configurationCacheCompatible = false
+    boolean configurationCacheCompatible = true
 
     def setup() {
         projectDir = testProjectDir.root
@@ -47,9 +47,9 @@ abstract class AbstractGradleFuncTest extends Specification {
     }
 
     def cleanup() {
-//        if (Boolean.getBoolean('test.keep.samplebuild')) {
+        if (Boolean.getBoolean('test.keep.samplebuild')) {
             FileUtils.copyDirectory(testProjectDir.root, new File("build/test-debug/" + testProjectDir.root.name))
-//        }
+        }
     }
 
     File subProject(String subProjectPath) {


### PR DESCRIPTION
This changes AbstractGradleFuncTest to run with configuration cache enabled by default. That gives us better test coverage on how our build logic works with configuration cache enabled and makes it explicit which parts are not yet working. 
We fixed some minor configuration cache related issues in our code  