### PR TITLE
[DOCS] Fixes collapsible section title in preview transform API docs

### DIFF
--- a/docs/reference/transform/apis/preview-transform.asciidoc
+++ b/docs/reference/transform/apis/preview-transform.asciidoc
@@ -212,7 +212,7 @@ include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=sync]
 (Optional, object)
 include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=sync-time]
 +
-.Properties of `analysis_config`
+.Properties of `time`
 [%collapsible%open]
 =====
 


### PR DESCRIPTION
## Overview

The collapsible section title of the `time` property was mistakenly named as `analysis_config`. This PR fixes the section title.

### Preview

<img width="879" alt="Screenshot 2022-06-29 at 12 19 03" src="https://user-images.githubusercontent.com/22324794/176413586-9e75d4d8-958f-471c-bfa3-61abbbbb17d6.png">

[Preview transform API docs](https://elasticsearch_88161.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/preview-transform.html)