### PR TITLE
[8.2] [DOCS] Fixes collapsible section title in preview transform API docs. (#88161)

### DIFF
--- a/docs/reference/transform/apis/preview-transform.asciidoc
+++ b/docs/reference/transform/apis/preview-transform.asciidoc
@@ -203,7 +203,7 @@ include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=sync]
 (Optional, object)
 include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=sync-time]
 +
-.Properties of `analysis_config`
+.Properties of `time`
 [%collapsible%open]
 =====
 


### PR DESCRIPTION
Backports the following commits to 8.2:
 - [DOCS] Fixes collapsible section title in preview transform API docs. (#88161)