### PR TITLE
Allow easing testing of java ea versions using gradle java tool chain support

### DIFF
--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/ElasticsearchJavaBasePlugin.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/ElasticsearchJavaBasePlugin.java
@@ -26,7 +26,6 @@ import org.gradle.api.tasks.compile.AbstractCompile;
 import org.gradle.api.tasks.compile.CompileOptions;
 import org.gradle.api.tasks.compile.GroovyCompile;
 import org.gradle.api.tasks.compile.JavaCompile;
-import org.gradle.jvm.toolchain.JavaToolchainSpec;
 
 import java.util.List;
 
@@ -107,21 +106,8 @@ public class ElasticsearchJavaBasePlugin implements Plugin<Project> {
      */
     public static void configureCompile(Project project) {
         project.getExtensions().getExtraProperties().set("compactProfile", "full");
-
         JavaPluginExtension java = project.getExtensions().getByType(JavaPluginExtension.class);
-        Provider<JavaToolchainSpec> optionalJavaToolChain = BuildParams.getJavaToolChain();
-        if (optionalJavaToolChain.isPresent()) {
-            java.toolchain(spec -> {
-                JavaToolchainSpec givenToolChain = optionalJavaToolChain.get();
-                System.out.println("givenToolChain = " + givenToolChain.getDisplayName());
-                System.out.println("vendor = " + givenToolChain.getVendor().get());
-                System.out.println("language = " + givenToolChain.getLanguageVersion().get());
-                System.out.println("implementation = " + givenToolChain.getImplementation().get());
-                spec.getImplementation().set(givenToolChain.getImplementation().get());
-                spec.getLanguageVersion().set(givenToolChain.getLanguageVersion().get());
-                spec.getVendor().set(givenToolChain.getVendor().get());
-            });
-        }
+        BuildParams.getJavaToolChainSpec().map(spec -> java.toolchain(spec)).getOrNull();
         java.setSourceCompatibility(BuildParams.getMinimumRuntimeVersion());
         java.setTargetCompatibility(BuildParams.getMinimumRuntimeVersion());
         project.getTasks().withType(JavaCompile.class).configureEach(compileTask -> {

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/ElasticsearchJavaBasePlugin.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/ElasticsearchJavaBasePlugin.java
@@ -26,6 +26,7 @@ import org.gradle.api.tasks.compile.AbstractCompile;
 import org.gradle.api.tasks.compile.CompileOptions;
 import org.gradle.api.tasks.compile.GroovyCompile;
 import org.gradle.api.tasks.compile.JavaCompile;
+import org.gradle.jvm.toolchain.JavaToolchainSpec;
 
 import java.util.List;
 
@@ -108,9 +109,21 @@ public class ElasticsearchJavaBasePlugin implements Plugin<Project> {
         project.getExtensions().getExtraProperties().set("compactProfile", "full");
 
         JavaPluginExtension java = project.getExtensions().getByType(JavaPluginExtension.class);
+        Provider<JavaToolchainSpec> optionalJavaToolChain = BuildParams.getJavaToolChain();
+        if (optionalJavaToolChain.isPresent()) {
+            java.toolchain(spec -> {
+                JavaToolchainSpec givenToolChain = optionalJavaToolChain.get();
+                System.out.println("givenToolChain = " + givenToolChain.getDisplayName());
+                System.out.println("vendor = " + givenToolChain.getVendor().get());
+                System.out.println("language = " + givenToolChain.getLanguageVersion().get());
+                System.out.println("implementation = " + givenToolChain.getImplementation().get());
+                spec.getImplementation().set(givenToolChain.getImplementation().get());
+                spec.getLanguageVersion().set(givenToolChain.getLanguageVersion().get());
+                spec.getVendor().set(givenToolChain.getVendor().get());
+            });
+        }
         java.setSourceCompatibility(BuildParams.getMinimumRuntimeVersion());
         java.setTargetCompatibility(BuildParams.getMinimumRuntimeVersion());
-
         project.getTasks().withType(JavaCompile.class).configureEach(compileTask -> {
             CompileOptions compileOptions = compileTask.getOptions();
             /*

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/ElasticsearchJavaBasePlugin.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/ElasticsearchJavaBasePlugin.java
@@ -107,7 +107,9 @@ public class ElasticsearchJavaBasePlugin implements Plugin<Project> {
     public static void configureCompile(Project project) {
         project.getExtensions().getExtraProperties().set("compactProfile", "full");
         JavaPluginExtension java = project.getExtensions().getByType(JavaPluginExtension.class);
-        BuildParams.getJavaToolChainSpec().map(spec -> java.toolchain(spec)).getOrNull();
+        if(BuildParams.getJavaToolChainSpec().isPresent()) {
+            java.toolchain(BuildParams.getJavaToolChainSpec().get());
+        }
         java.setSourceCompatibility(BuildParams.getMinimumRuntimeVersion());
         java.setTargetCompatibility(BuildParams.getMinimumRuntimeVersion());
         project.getTasks().withType(JavaCompile.class).configureEach(compileTask -> {

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/ElasticsearchJavaBasePlugin.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/ElasticsearchJavaBasePlugin.java
@@ -107,7 +107,7 @@ public class ElasticsearchJavaBasePlugin implements Plugin<Project> {
     public static void configureCompile(Project project) {
         project.getExtensions().getExtraProperties().set("compactProfile", "full");
         JavaPluginExtension java = project.getExtensions().getByType(JavaPluginExtension.class);
-        if(BuildParams.getJavaToolChainSpec().isPresent()) {
+        if (BuildParams.getJavaToolChainSpec().isPresent()) {
             java.toolchain(BuildParams.getJavaToolChainSpec().get());
         }
         java.setSourceCompatibility(BuildParams.getMinimumRuntimeVersion());

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/info/BuildParams.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/info/BuildParams.java
@@ -10,6 +10,7 @@ package org.elasticsearch.gradle.internal.info;
 import org.elasticsearch.gradle.internal.BwcVersions;
 import org.gradle.api.JavaVersion;
 import org.gradle.api.provider.Provider;
+import org.gradle.jvm.toolchain.JavaToolchainSpec;
 
 import java.io.File;
 import java.lang.reflect.Modifier;
@@ -28,6 +29,7 @@ public class BuildParams {
     private static JavaVersion minimumRuntimeVersion;
     private static JavaVersion gradleJavaVersion;
     private static JavaVersion runtimeJavaVersion;
+    private static Provider<JavaToolchainSpec> javaToolChain;
     private static String runtimeJavaDetails;
     private static Boolean inFipsJvm;
     private static String gitRevision;
@@ -117,6 +119,10 @@ public class BuildParams {
 
     public static boolean isSnapshotBuild() {
         return value(BuildParams.isSnapshotBuild);
+    }
+
+    public static Provider<JavaToolchainSpec> getJavaToolChain() {
+        return javaToolChain;
     }
 
     private static <T> T value(T object) {
@@ -226,6 +232,10 @@ public class BuildParams {
 
         public void setBwcVersions(Provider<BwcVersions> bwcVersions) {
             BuildParams.bwcVersions = requireNonNull(bwcVersions);
+        }
+
+        public void setJavaToolChain(Provider<JavaToolchainSpec> javaToolChain) {
+            BuildParams.javaToolChain = javaToolChain;
         }
     }
 }

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/info/BuildParams.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/info/BuildParams.java
@@ -8,6 +8,7 @@
 package org.elasticsearch.gradle.internal.info;
 
 import org.elasticsearch.gradle.internal.BwcVersions;
+import org.gradle.api.Action;
 import org.gradle.api.JavaVersion;
 import org.gradle.api.provider.Provider;
 import org.gradle.jvm.toolchain.JavaToolchainSpec;
@@ -29,7 +30,7 @@ public class BuildParams {
     private static JavaVersion minimumRuntimeVersion;
     private static JavaVersion gradleJavaVersion;
     private static JavaVersion runtimeJavaVersion;
-    private static Provider<JavaToolchainSpec> javaToolChain;
+    private static Provider<? extends Action<JavaToolchainSpec>> javaToolChainSpec;
     private static String runtimeJavaDetails;
     private static Boolean inFipsJvm;
     private static String gitRevision;
@@ -121,8 +122,8 @@ public class BuildParams {
         return value(BuildParams.isSnapshotBuild);
     }
 
-    public static Provider<JavaToolchainSpec> getJavaToolChain() {
-        return javaToolChain;
+    public static Provider<? extends Action<JavaToolchainSpec>> getJavaToolChainSpec() {
+        return javaToolChainSpec;
     }
 
     private static <T> T value(T object) {
@@ -234,8 +235,8 @@ public class BuildParams {
             BuildParams.bwcVersions = requireNonNull(bwcVersions);
         }
 
-        public void setJavaToolChain(Provider<JavaToolchainSpec> javaToolChain) {
-            BuildParams.javaToolChain = javaToolChain;
+        public void setJavaToolChainSpec(Provider<? extends Action<JavaToolchainSpec>> javaToolChain) {
+            BuildParams.javaToolChainSpec = javaToolChain;
         }
     }
 }

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/info/GlobalBuildInfoPlugin.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/info/GlobalBuildInfoPlugin.java
@@ -133,7 +133,7 @@ public class GlobalBuildInfoPlugin implements Plugin<Project> {
             JvmInstallationMetadata metadata = metadataDetector.getMetadata(toolChainDir);
             if (metadata.isValidInstallation() == false) {
                 throw new GradleException(
-                    "configured JAVA_TOOLCHAIN_HOME " + toolChainEnvVariable + " does not point to a valid jdk installation"
+                    "Configured JAVA_TOOLCHAIN_HOME " + toolChainEnvVariable + " does not point to a valid jdk installation."
                 );
             }
             return new MetadataBasedToolChainMatcher(metadata);
@@ -181,6 +181,10 @@ public class GlobalBuildInfoPlugin implements Plugin<Project> {
         } else {
             LOGGER.quiet("  JDK Version           : " + gradleJvmImplementationVersion + " (" + gradleJvmVendorDetails + ")");
             LOGGER.quiet("  JAVA_HOME             : " + gradleJvm.getJavaHome());
+        }
+        String javaToolchainHome = System.getenv("JAVA_TOOLCHAIN_HOME");
+        if (javaToolchainHome != null) {
+            LOGGER.quiet("  JAVA TOOLCHAIN HOME   : " + javaToolchainHome);
         }
         LOGGER.quiet("  Random Testing Seed   : " + BuildParams.getTestSeed());
         LOGGER.quiet("  In FIPS 140 mode      : " + BuildParams.isInFipsJvm());

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/info/GlobalBuildInfoPlugin.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/info/GlobalBuildInfoPlugin.java
@@ -183,7 +183,7 @@ public class GlobalBuildInfoPlugin implements Plugin<Project> {
         }
         String javaToolchainHome = System.getenv("JAVA_TOOLCHAIN_HOME");
         if (javaToolchainHome != null) {
-            LOGGER.quiet("  JAVA TOOLCHAIN HOME   : " + javaToolchainHome);
+            LOGGER.quiet("  JAVA_TOOLCHAIN_HOME   : " + javaToolchainHome);
         }
         LOGGER.quiet("  Random Testing Seed   : " + BuildParams.getTestSeed());
         LOGGER.quiet("  In FIPS 140 mode      : " + BuildParams.isInFipsJvm());

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/info/GlobalBuildInfoPlugin.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/info/GlobalBuildInfoPlugin.java
@@ -93,12 +93,11 @@ public class GlobalBuildInfoPlugin implements Plugin<Project> {
             params.reset();
             params.setRuntimeJavaHome(runtimeJavaHome);
             params.setJavaToolChainSpec(resolveToolchainSpecFromEnv());
-            // TODO: Temporarily hard-code this to 17 until we upgrade to Gradle 7.3 and bump minimumRuntimeVersion
             params.setRuntimeJavaVersion(
                 determineJavaVersion(
                     "runtime java.home",
                     runtimeJavaHome,
-                    isRuntimeJavaHomeSet ? JavaVersion.VERSION_17 : Jvm.current().getJavaVersion()
+                    isRuntimeJavaHomeSet ? minimumRuntimeVersion : Jvm.current().getJavaVersion()
                 )
             );
             params.setIsRuntimeJavaHomeSet(isRuntimeJavaHomeSet);
@@ -280,8 +279,13 @@ public class GlobalBuildInfoPlugin implements Plugin<Project> {
         if (runtimeJavaProperty != null) {
             return new File(findJavaHome(runtimeJavaProperty));
         }
-
-        return System.getenv("RUNTIME_JAVA_HOME") == null ? Jvm.current().getJavaHome() : new File(System.getenv("RUNTIME_JAVA_HOME"));
+        String env = System.getenv("RUNTIME_JAVA_HOME");
+        if (env != null) {
+            return new File(env);
+        }
+        // fall back to tool chain if set.
+        env = System.getenv("JAVA_TOOLCHAIN_HOME");
+        return env == null ? Jvm.current().getJavaHome() : new File(env);
     }
 
     private String findJavaHome(String version) {

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/info/GlobalBuildInfoPlugin.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/info/GlobalBuildInfoPlugin.java
@@ -92,7 +92,7 @@ public class GlobalBuildInfoPlugin implements Plugin<Project> {
         BuildParams.init(params -> {
             params.reset();
             params.setRuntimeJavaHome(runtimeJavaHome);
-            params.setJavaToolChainSpec(resolveOptionalToolchainSpec());
+            params.setJavaToolChainSpec(resolveToolchainSpecFromEnv());
             // TODO: Temporarily hard-code this to 17 until we upgrade to Gradle 7.3 and bump minimumRuntimeVersion
             params.setRuntimeJavaVersion(
                 determineJavaVersion(
@@ -127,7 +127,7 @@ public class GlobalBuildInfoPlugin implements Plugin<Project> {
         project.getGradle().getTaskGraph().whenReady(graph -> logGlobalBuildInfo());
     }
 
-    private Provider<MetadataBasedToolChainMatcher> resolveOptionalToolchainSpec() {
+    private Provider<MetadataBasedToolChainMatcher> resolveToolchainSpecFromEnv() {
         return providers.environmentVariable("JAVA_TOOLCHAIN_HOME").map(toolChainEnvVariable -> {
             File toolChainDir = new File(toolChainEnvVariable);
             JvmInstallationMetadata metadata = metadataDetector.getMetadata(toolChainDir);

--- a/gradle.properties
+++ b/gradle.properties
@@ -16,4 +16,4 @@ systemProp.jdk.tls.client.protocols=TLSv1.2
 
 # java homes resolved by environment variables
 org.gradle.java.installations.auto-detect=false
-org.gradle.java.installations.fromEnv=JAVA_HOME,RUNTIME_JAVA_HOME,JAVA19_HOME,JAVA18_HOME,JAVA17_HOME,JAVA16_HOME,JAVA15_HOME,JAVA14_HOME,JAVA13_HOME,JAVA12_HOME,JAVA11_HOME,JAVA8_HOME
+org.gradle.java.installations.fromEnv=JAVA_TOOLCHAIN_HOME,JAVA_HOME,RUNTIME_JAVA_HOME,JAVA19_HOME,JAVA18_HOME,JAVA17_HOME,JAVA16_HOME,JAVA15_HOME,JAVA14_HOME,JAVA13_HOME,JAVA12_HOME,JAVA11_HOME,JAVA8_HOME


### PR DESCRIPTION
This introduces the ability to simply configure a java tool chain for elasticsearch java projects to be used.
If an environment variable `JAVA_TOOLCHAIN_HOME `is declared, this JDK will be used as toolChain in elasticsearch.java projects.

This should make testing our build with java `ea` versions easier and allows detangling the used compiler jdk from the gradle java runtime.