### PR TITLE
Fix RandomSamplerIT#testRandomSamplerHistogram test input

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/bucket/RandomSamplerIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/bucket/RandomSamplerIT.java
@@ -54,7 +54,7 @@ public class RandomSamplerIT extends ESIntegTestCase {
                 randomNumber = randomDoubleBetween(0.0, 3.0, false);
             } else {
                 keywordValue = UPPER_KEYWORD;
-                randomNumber = randomDoubleBetween(5.0, 10.0, false);
+                randomNumber = randomDoubleBetween(5.0, 9.0, false);
             }
             builders.add(
                 client().prepareIndex("idx")


### PR DESCRIPTION
Periodically, a single `10` value is included which causes a 3rd histogram bucket to be created with very few values. Meaning sampling wouldn't get any docs that hit that bucket (especially with the randomly included deleted docs). 

The failures that I saw had the `10.0` bucket with just one document.

closes: https://github.com/elastic/elasticsearch/issues/88108