### PR TITLE
Upgrade randomized runner to 2.8.0

### DIFF
--- a/build-tools-internal/version.properties
+++ b/build-tools-internal/version.properties
@@ -33,7 +33,7 @@ bouncycastle=1.64
 opensaml = 4.0.1
 
 # test dependencies
-randomizedrunner  = 2.7.7
+randomizedrunner  = 2.8.0
 junit             = 4.12
 junit5            = 5.7.1
 httpclient        = 4.5.13


### PR DESCRIPTION
This commit bumps the version of randomized runner that tests use to
2.8.0.