### PR TITLE
Upgrade randomized runner to 2.8.0 (#88194)

### DIFF
--- a/build-tools-internal/version.properties
+++ b/build-tools-internal/version.properties
@@ -30,7 +30,7 @@ commons_lang3                   = 3.9
 #  - x-pack/plugin/security
 bouncycastle=1.64
 # test dependencies
-randomizedrunner  = 2.7.1
+randomizedrunner  = 2.8.0
 junit             = 4.12
 junit5            = 5.7.1
 httpclient        = 4.5.10


### PR DESCRIPTION
This commit bumps the version of randomized runner that tests use to
2.8.0.