### PR TITLE
[Test] Fix user profile YAML tests in a mixed cluster

### DIFF
--- a/x-pack/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/mixed_cluster/140_user_profile.yml
+++ b/x-pack/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/mixed_cluster/140_user_profile.yml
@@ -8,7 +8,7 @@
 
   - do:
       node_selector:
-        version: " 8.3.0 - "
+        version: " 8.4.0 - "
       security.activate_user_profile:
         body: >
           {
@@ -22,7 +22,7 @@
 
   - do:
       node_selector:
-        version: " 8.3.0 - "
+        version: " 8.4.0 - "
       security.get_user_profile:
         uid: "$profile_uid"
 


### PR DESCRIPTION
User profile is behind a feature flag in 8.3. When 8.3 is still a
snapshot build, the feature flag is enabled automatically. But now 8.3
is released, the feature flag is by default off. This PR adjust the node
selector to only select node version 8.4 or higher.

Resolves: #88202
