### PR TITLE
[Transform] Make default transform scheduler frequency 1s again

### DIFF
--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/Transform.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/Transform.java
@@ -148,12 +148,12 @@ public class Transform extends Plugin implements SystemIndexPlugin, PersistentTa
         Setting.Property.Dynamic
     );
 
-    public static final TimeValue DEFAULT_SCHEDULER_FREQUENCY = TimeValue.timeValueMillis(500);
+    public static final TimeValue DEFAULT_SCHEDULER_FREQUENCY = TimeValue.timeValueSeconds(1);
     // How often does the transform scheduler process the tasks
     public static final Setting<TimeValue> SCHEDULER_FREQUENCY = Setting.timeSetting(
         "xpack.transform.transform_scheduler_frequency",
         DEFAULT_SCHEDULER_FREQUENCY,
-        TimeValue.timeValueMillis(500),
+        TimeValue.timeValueSeconds(1),
         TimeValue.timeValueMinutes(1),
         Setting.Property.NodeScope
     );

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/TransformTask.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/TransformTask.java
@@ -395,7 +395,7 @@ public class TransformTask extends AllocatedPersistentTask implements TransformS
 
     @Override
     public void triggered(TransformScheduler.Event event) {
-        logger.trace(() -> format("[{}] triggered(event={}) ", getTransformId(), event));
+        logger.trace(() -> format("[%s] triggered(event=%s) ", getTransformId(), event));
         // Ignore if event is not for this job
         if (event.transformId().equals(getTransformId()) == false) {
             return;

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/scheduling/TransformScheduler.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/scheduling/TransformScheduler.java
@@ -116,10 +116,7 @@ public final class TransformScheduler {
         if (isTraceEnabled) {
             Instant processingFinished = clock.instant();
             logger.trace(
-                format(
-                    "Processing scheduled tasks finished, took %dms",
-                    Duration.between(processingStarted, processingFinished).toMillis()
-                )
+                format("Processing scheduled tasks finished, took %dms", Duration.between(processingStarted, processingFinished).toMillis())
             );
         }
         if (taskWasProcessed == false) {

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/scheduling/TransformScheduler.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/scheduling/TransformScheduler.java
@@ -10,7 +10,6 @@ package org.elasticsearch.xpack.transform.transforms.scheduling;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.core.Strings;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.threadpool.Scheduler;
 import org.elasticsearch.threadpool.ThreadPool;
@@ -23,6 +22,8 @@ import java.time.Instant;
 import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.elasticsearch.core.Strings.format;
 
 /**
  * {@link TransformScheduler} class is responsible for scheduling transform tasks according to their configured frequency as well as
@@ -115,8 +116,8 @@ public final class TransformScheduler {
         if (isTraceEnabled) {
             Instant processingFinished = clock.instant();
             logger.trace(
-                Strings.format(
-                    "Processing scheduled tasks finished, took {}ms",
+                format(
+                    "Processing scheduled tasks finished, took %dms",
                     Duration.between(processingStarted, processingFinished).toMillis()
                 )
             );
@@ -152,8 +153,8 @@ public final class TransformScheduler {
         scheduledTasks.update(scheduledTask.getTransformId(), task -> {
             if (task.equals(scheduledTask) == false) {
                 logger.debug(
-                    () -> Strings.format(
-                        "[{}] task object got modified while processing. Expected: {}, was: {}",
+                    () -> format(
+                        "[%s] task object got modified while processing. Expected: %s, was: %s",
                         scheduledTask.getTransformId(),
                         scheduledTask,
                         task
@@ -191,7 +192,7 @@ public final class TransformScheduler {
      */
     public void registerTransform(TransformTaskParams transformTaskParams, Listener listener) {
         String transformId = transformTaskParams.getId();
-        logger.trace(() -> Strings.format("[{}] register the transform", transformId));
+        logger.trace(() -> format("[%s] register the transform", transformId));
         long currentTimeMillis = clock.millis();
         TransformScheduledTask transformScheduledTask = new TransformScheduledTask(
             transformId,
@@ -214,7 +215,7 @@ public final class TransformScheduler {
      * @param failureCount new value of transform task's failure count
      */
     public void handleTransformFailureCountChanged(String transformId, int failureCount) {
-        logger.trace(() -> Strings.format("[{}] handle transform failure count change to {}", transformId, failureCount));
+        logger.trace(() -> format("[%s] handle transform failure count change to %d", transformId, failureCount));
         // Update the task's failure count (next_scheduled_time gets automatically re-calculated)
         scheduledTasks.update(
             transformId,
@@ -235,7 +236,7 @@ public final class TransformScheduler {
      */
     public void deregisterTransform(String transformId) {
         Objects.requireNonNull(transformId);
-        logger.trace(() -> Strings.format("[{}] de-register the transform", transformId));
+        logger.trace(() -> format("[%s] de-register the transform", transformId));
         scheduledTasks.remove(transformId);
     }
 


### PR DESCRIPTION
This PR partially reverts https://github.com/elastic/elasticsearch/pull/88153. As the effect the default scheduler frequency is made to be `1s` again and this is most likely a correct value.
Additionally, this PR fixes the placeholders in `Strings.format`.

Relates https://github.com/elastic/elasticsearch/issues/88063