### PR TITLE
Add 'filter' to 'knn' search section

### DIFF
--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.vectors/40_knn_search.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.vectors/40_knn_search.yml
@@ -97,6 +97,47 @@ setup:
   - match: {hits.hits.2.fields.name.0: "rabbit.jpg"}
 
 ---
+"kNN search with filter":
+  - skip:
+      version: ' - 8.3.99'
+      reason: 'kNN added to search endpoint in 8.4'
+  - do:
+      search:
+        index: test
+        body:
+          fields: [ "name" ]
+          knn:
+            field: vector
+            query_vector: [-0.5, 90.0, -10, 14.8, -156.0]
+            k: 2
+            num_candidates: 3
+            filter:
+              term:
+                name: "rabbit.jpg"
+
+  - match: {hits.total.value: 1}
+  - match: {hits.hits.0._id: "3"}
+  - match: {hits.hits.0.fields.name.0: "rabbit.jpg"}
+
+  - do:
+      search:
+        index: test
+        body:
+          fields: [ "name" ]
+          knn:
+            field: vector
+            query_vector: [-0.5, 90.0, -10, 14.8, -156.0]
+            k: 2
+            num_candidates: 3
+            filter:
+              - term:
+                  name: "rabbit.jpg"
+              - term:
+                  _id: 2
+
+  - match: {hits.total.value: 0}
+
+---
 "kNN search in _knn_search endpoint":
   - do:
       knn_search:

--- a/server/src/main/java/org/elasticsearch/search/builder/SearchSourceBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/builder/SearchSourceBuilder.java
@@ -1036,7 +1036,7 @@ public final class SearchSourceBuilder implements Writeable, ToXContentObject, R
     @SuppressWarnings({ "unchecked", "rawtypes" })
     public SearchSourceBuilder rewrite(QueryRewriteContext context) throws IOException {
         assert (this.equals(
-            shallowCopy(queryBuilder, postQueryBuilder, aggregations, sliceBuilder, sorts, rescoreBuilders, highlightBuilder)
+            shallowCopy(queryBuilder, postQueryBuilder, knnSearch, aggregations, sliceBuilder, sorts, rescoreBuilders, highlightBuilder)
         ));
         QueryBuilder queryBuilder = null;
         if (this.queryBuilder != null) {
@@ -1045,6 +1045,10 @@ public final class SearchSourceBuilder implements Writeable, ToXContentObject, R
         QueryBuilder postQueryBuilder = null;
         if (this.postQueryBuilder != null) {
             postQueryBuilder = this.postQueryBuilder.rewrite(context);
+        }
+        KnnSearchBuilder knnSearch = null;
+        if (this.knnSearch != null) {
+            knnSearch = this.knnSearch.rewrite(context);
         }
         AggregatorFactories.Builder aggregations = null;
         if (this.aggregations != null) {
@@ -1060,12 +1064,22 @@ public final class SearchSourceBuilder implements Writeable, ToXContentObject, R
 
         boolean rewritten = queryBuilder != this.queryBuilder
             || postQueryBuilder != this.postQueryBuilder
+            || knnSearch != this.knnSearch
             || aggregations != this.aggregations
             || rescoreBuilders != this.rescoreBuilders
             || sorts != this.sorts
             || this.highlightBuilder != highlightBuilder;
         if (rewritten) {
-            return shallowCopy(queryBuilder, postQueryBuilder, aggregations, this.sliceBuilder, sorts, rescoreBuilders, highlightBuilder);
+            return shallowCopy(
+                queryBuilder,
+                postQueryBuilder,
+                knnSearch,
+                aggregations,
+                this.sliceBuilder,
+                sorts,
+                rescoreBuilders,
+                highlightBuilder
+            );
         }
         return this;
     }
@@ -1074,7 +1088,7 @@ public final class SearchSourceBuilder implements Writeable, ToXContentObject, R
      * Create a shallow copy of this builder with a new slice configuration.
      */
     public SearchSourceBuilder shallowCopy() {
-        return shallowCopy(queryBuilder, postQueryBuilder, aggregations, sliceBuilder, sorts, rescoreBuilders, highlightBuilder);
+        return shallowCopy(queryBuilder, postQueryBuilder, knnSearch, aggregations, sliceBuilder, sorts, rescoreBuilders, highlightBuilder);
     }
 
     /**
@@ -1085,6 +1099,7 @@ public final class SearchSourceBuilder implements Writeable, ToXContentObject, R
     private SearchSourceBuilder shallowCopy(
         QueryBuilder queryBuilder,
         QueryBuilder postQueryBuilder,
+        KnnSearchBuilder knnSearch,
         AggregatorFactories.Builder aggregations,
         SliceBuilder slice,
         List<SortBuilder<?>> sorts,

--- a/server/src/main/java/org/elasticsearch/search/vectors/KnnSearchBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/vectors/KnnSearchBuilder.java
@@ -173,7 +173,7 @@ public class KnnSearchBuilder implements Writeable, ToXContentFragment, Rewritea
 
     @Override
     public int hashCode() {
-        return Objects.hash(field, k, numCands, Arrays.hashCode(queryVector), boost);
+        return Objects.hash(field, k, numCands, Arrays.hashCode(queryVector), Objects.hashCode(filterQueries), boost);
     }
 
     @Override
@@ -204,10 +204,7 @@ public class KnnSearchBuilder implements Writeable, ToXContentFragment, Rewritea
         out.writeVInt(k);
         out.writeVInt(numCands);
         out.writeFloatArray(queryVector);
-        out.writeVInt(filterQueries.size());
-        for (QueryBuilder query : filterQueries) {
-            out.writeNamedWriteable(query);
-        }
+        out.writeNamedWriteableList(filterQueries);
         out.writeFloat(boost);
     }
 }

--- a/server/src/main/java/org/elasticsearch/search/vectors/KnnSearchBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/vectors/KnnSearchBuilder.java
@@ -12,13 +12,18 @@ import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.index.query.AbstractQueryBuilder;
+import org.elasticsearch.index.query.QueryBuilder;
+import org.elasticsearch.index.query.QueryRewriteContext;
+import org.elasticsearch.index.query.Rewriteable;
 import org.elasticsearch.xcontent.ConstructingObjectParser;
+import org.elasticsearch.xcontent.ObjectParser;
 import org.elasticsearch.xcontent.ParseField;
 import org.elasticsearch.xcontent.ToXContentFragment;
 import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xcontent.XContentParser;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
@@ -28,12 +33,13 @@ import static org.elasticsearch.xcontent.ConstructingObjectParser.constructorArg
 /**
  * Defines a kNN search to run in the search request.
  */
-public class KnnSearchBuilder implements Writeable, ToXContentFragment {
+public class KnnSearchBuilder implements Writeable, ToXContentFragment, Rewriteable<KnnSearchBuilder> {
     private static final int NUM_CANDS_LIMIT = 10000;
     static final ParseField FIELD_FIELD = new ParseField("field");
     static final ParseField K_FIELD = new ParseField("k");
     static final ParseField NUM_CANDS_FIELD = new ParseField("num_candidates");
     static final ParseField QUERY_VECTOR_FIELD = new ParseField("query_vector");
+    static final ParseField FILTER_FIELD = new ParseField("filter");
     static final ParseField BOOST_FIELD = AbstractQueryBuilder.BOOST_FIELD;
 
     private static final ConstructingObjectParser<KnnSearchBuilder, Void> PARSER = new ConstructingObjectParser<>("knn", args -> {
@@ -51,6 +57,12 @@ public class KnnSearchBuilder implements Writeable, ToXContentFragment {
         PARSER.declareFloatArray(constructorArg(), QUERY_VECTOR_FIELD);
         PARSER.declareInt(constructorArg(), K_FIELD);
         PARSER.declareInt(constructorArg(), NUM_CANDS_FIELD);
+        PARSER.declareFieldArray(
+            KnnSearchBuilder::addFilterQueries,
+            (p, c) -> AbstractQueryBuilder.parseInnerQueryBuilder(p),
+            FILTER_FIELD,
+            ObjectParser.ValueType.OBJECT_ARRAY
+        );
         PARSER.declareFloat(KnnSearchBuilder::boost, BOOST_FIELD);
     }
 
@@ -62,6 +74,7 @@ public class KnnSearchBuilder implements Writeable, ToXContentFragment {
     final float[] queryVector;
     final int k;
     final int numCands;
+    final List<QueryBuilder> filterQueries;
     float boost = AbstractQueryBuilder.DEFAULT_BOOST;
 
     /**
@@ -73,33 +86,6 @@ public class KnnSearchBuilder implements Writeable, ToXContentFragment {
      * @param numCands    the number of nearest neighbor candidates to consider per shard
      */
     public KnnSearchBuilder(String field, float[] queryVector, int k, int numCands) {
-        this.field = field;
-        this.queryVector = queryVector;
-        this.k = k;
-        this.numCands = numCands;
-    }
-
-    public KnnSearchBuilder(StreamInput in) throws IOException {
-        this.field = in.readString();
-        this.k = in.readVInt();
-        this.numCands = in.readVInt();
-        this.queryVector = in.readFloatArray();
-        this.boost = in.readFloat();
-    }
-
-    public int k() {
-        return k;
-    }
-
-    /**
-     * Set a boost to apply to the kNN search scores.
-     */
-    public KnnSearchBuilder boost(float boost) {
-        this.boost = boost;
-        return this;
-    }
-
-    public KnnVectorQueryBuilder toQueryBuilder() {
         if (k < 1) {
             throw new IllegalArgumentException("[" + K_FIELD.getPreferredName() + "] must be greater than 0");
         }
@@ -111,7 +97,65 @@ public class KnnSearchBuilder implements Writeable, ToXContentFragment {
         if (numCands > NUM_CANDS_LIMIT) {
             throw new IllegalArgumentException("[" + NUM_CANDS_FIELD.getPreferredName() + "] cannot exceed [" + NUM_CANDS_LIMIT + "]");
         }
-        return new KnnVectorQueryBuilder(field, queryVector, numCands).boost(boost);
+        this.field = field;
+        this.queryVector = queryVector;
+        this.k = k;
+        this.numCands = numCands;
+        this.filterQueries = new ArrayList<>();
+    }
+
+    public KnnSearchBuilder(StreamInput in) throws IOException {
+        this.field = in.readString();
+        this.k = in.readVInt();
+        this.numCands = in.readVInt();
+        this.queryVector = in.readFloatArray();
+        this.filterQueries = in.readNamedWriteableList(QueryBuilder.class);
+        this.boost = in.readFloat();
+    }
+
+    public int k() {
+        return k;
+    }
+
+    public KnnSearchBuilder addFilterQuery(QueryBuilder filterQuery) {
+        Objects.requireNonNull(filterQuery);
+        this.filterQueries.add(filterQuery);
+        return this;
+    }
+
+    public KnnSearchBuilder addFilterQueries(List<QueryBuilder> filterQueries) {
+        Objects.requireNonNull(filterQueries);
+        this.filterQueries.addAll(filterQueries);
+        return this;
+    }
+
+    /**
+     * Set a boost to apply to the kNN search scores.
+     */
+    public KnnSearchBuilder boost(float boost) {
+        this.boost = boost;
+        return this;
+    }
+
+    @Override
+    public KnnSearchBuilder rewrite(QueryRewriteContext ctx) throws IOException {
+        boolean changed = false;
+        List<QueryBuilder> rewrittenQueries = new ArrayList<>(filterQueries.size());
+        for (QueryBuilder query : filterQueries) {
+            QueryBuilder rewrittenQuery = query.rewrite(ctx);
+            if (rewrittenQuery != query) {
+                changed = true;
+            }
+            rewrittenQueries.add(rewrittenQuery);
+        }
+        if (changed) {
+            return new KnnSearchBuilder(field, queryVector, k, numCands).boost(boost).addFilterQueries(rewrittenQueries);
+        }
+        return this;
+    }
+
+    public KnnVectorQueryBuilder toQueryBuilder() {
+        return new KnnVectorQueryBuilder(field, queryVector, numCands).boost(boost).addFilterQueries(filterQueries);
     }
 
     @Override
@@ -123,6 +167,7 @@ public class KnnSearchBuilder implements Writeable, ToXContentFragment {
             && numCands == that.numCands
             && Objects.equals(field, that.field)
             && Arrays.equals(queryVector, that.queryVector)
+            && Objects.equals(filterQueries, that.filterQueries)
             && boost == that.boost;
     }
 
@@ -138,6 +183,14 @@ public class KnnSearchBuilder implements Writeable, ToXContentFragment {
             .field(NUM_CANDS_FIELD.getPreferredName(), numCands)
             .array(QUERY_VECTOR_FIELD.getPreferredName(), queryVector);
 
+        if (filterQueries.isEmpty() == false) {
+            builder.startArray(FILTER_FIELD.getPreferredName());
+            for (QueryBuilder filterQuery : filterQueries) {
+                filterQuery.toXContent(builder, params);
+            }
+            builder.endArray();
+        }
+
         if (boost != AbstractQueryBuilder.DEFAULT_BOOST) {
             builder.field(BOOST_FIELD.getPreferredName(), boost);
         }
@@ -151,6 +204,10 @@ public class KnnSearchBuilder implements Writeable, ToXContentFragment {
         out.writeVInt(k);
         out.writeVInt(numCands);
         out.writeFloatArray(queryVector);
+        out.writeVInt(filterQueries.size());
+        for (QueryBuilder query : filterQueries) {
+            out.writeNamedWriteable(query);
+        }
         out.writeFloat(boost);
     }
 }

--- a/server/src/main/java/org/elasticsearch/search/vectors/KnnVectorQueryBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/vectors/KnnVectorQueryBuilder.java
@@ -104,6 +104,14 @@ public class KnnVectorQueryBuilder extends AbstractQueryBuilder<KnnVectorQueryBu
     @Override
     protected void doXContent(XContentBuilder builder, Params params) throws IOException {
         builder.startObject(NAME).field("field", fieldName).field("vector", queryVector).field("num_candidates", numCands);
+        if (filterQueries.isEmpty() == false) {
+            builder.startArray("filters");
+            for (QueryBuilder filterQuery : filterQueries) {
+                filterQuery.toXContent(builder, params);
+            }
+            builder.endArray();
+        }
+
         builder.endObject();
     }
 

--- a/server/src/test/java/org/elasticsearch/search/vectors/KnnSearchBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/search/vectors/KnnSearchBuilderTests.java
@@ -12,7 +12,6 @@ import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.index.query.AbstractQueryBuilder;
-import org.elasticsearch.index.query.MatchNoneQueryBuilder;
 import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.index.query.QueryBuilders;
 import org.elasticsearch.search.SearchModule;


### PR DESCRIPTION
This PR introduces a 'filter' subsection where filters can be provided to the
kNN search:

```
POST index/_search
{
  "knn": {
    "field": "image_vector",
    "query_vector": [0.3f, 0.1f, ...],
    "k": 10,
    "num_candidates": 100,
    "filter": {
      "term": {
       "file_type": "jpeg"
      }
    }
  }
}
```

Like all other queries, the filters are rewritten on the coordinating nodes as
well as data nodes.

Addresses #87625.