### PR TITLE
[s3-repository] Eagerly verify that web identity tokens work

### DIFF
--- a/modules/repository-s3/src/main/java/org/elasticsearch/repositories/s3/S3Service.java
+++ b/modules/repository-s3/src/main/java/org/elasticsearch/repositories/s3/S3Service.java
@@ -345,8 +345,14 @@ class S3Service implements Closeable {
                     roleSessionName,
                     webIdentityTokenFileSymlink.toString()
                 ).withStsClient(stsClient).build();
+
+                // Fail-fast if we can't access the STS
+                credentialsProvider.getCredentials();
             } catch (Exception e) {
-                stsClient.shutdown();
+                LOGGER.warn("Unable to exchange web identity token to credentials from the AWS Security Token Service", e);
+                try {
+                    shutdown();
+                } catch (IOException ignore) {}
                 throw e;
             }
         }


### PR DESCRIPTION
Currently, we only verify that local environment for web identity tokens is correctly set up, but we don't verify whether it's
possible to exchange the token to credentials from the STS. If we can't get credentials from the STS, we silently fall back
to the EC2 credentials provider. Let's try to eagerly load credentials, so the users get a clear message in the logs in case
the STS is unavailable for the ES server.