### PR TITLE
Allow configuring snyk target reference and lifecycle properties

### DIFF
--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/snyk/SnykDependencyMonitoringGradlePlugin.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/snyk/SnykDependencyMonitoringGradlePlugin.java
@@ -37,8 +37,11 @@ public class SnykDependencyMonitoringGradlePlugin implements Plugin<Project> {
             .register("generateSnykDependencyGraph", GenerateSnykDependencyGraph.class, generateSnykDependencyGraph -> {
                 generateSnykDependencyGraph.getProjectPath().set(project.getPath());
                 generateSnykDependencyGraph.getProjectName().set(project.getName());
-                generateSnykDependencyGraph.getVersion().set(project.getVersion().toString());
+                String projectVersion = project.getVersion().toString();
+                generateSnykDependencyGraph.getVersion().set(projectVersion);
                 generateSnykDependencyGraph.getGradleVersion().set(project.getGradle().getGradleVersion());
+                generateSnykDependencyGraph.getTargetReference()
+                    .set(providerFactory.gradleProperty("snykTargetReference").orElse(projectVersion));
                 generateSnykDependencyGraph.getOutputFile().set(projectLayout.getBuildDirectory().file("snyk/dependencies.json"));
             });
 


### PR DESCRIPTION
We will use target reference to distinguish between different versions or branches of our elasticsearch project
to be able to trace vulnerable dependencies down to the version.

snyk lifecycle property allows filtering the project overview by `production` or `development`. When version
is ending with SNAPSHOT we configure the lifecycle as development. Otherwise its production.

Related to #87620