### PR TITLE
Unmute Lintian test

### DIFF
--- a/qa/os/src/test/java/org/elasticsearch/packaging/test/DebMetadataTests.java
+++ b/qa/os/src/test/java/org/elasticsearch/packaging/test/DebMetadataTests.java
@@ -27,7 +27,6 @@ public class DebMetadataTests extends PackagingTestCase {
         assumeTrue("only deb", distribution.packaging == Distribution.Packaging.DEB);
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/88090")
     public void test05CheckLintian() {
         String extraArgs = "";
         final String helpText = sh.run("lintian --help").stdout();


### PR DESCRIPTION
The fix for the problems identified in #88090 is in
elastic/ml-cpp#2337, so the test can be unmuted now.

Closes #88090