### PR TITLE
Use faster maths to project WGS84 to mercator

### DIFF
--- a/docs/changelog/88231.yaml
+++ b/docs/changelog/88231.yaml
@@ -1,0 +1,5 @@
+pr: 88231
+summary: Use faster maths to project WGS84 to mercator
+area: Geo
+type: enhancement
+issues: []

--- a/server/src/test/java/org/elasticsearch/common/geo/SphericalMercatorUtilTests.java
+++ b/server/src/test/java/org/elasticsearch/common/geo/SphericalMercatorUtilTests.java
@@ -66,4 +66,17 @@ public class SphericalMercatorUtilTests extends ESTestCase {
         assertThat(mercatorRect.getMinY(), Matchers.equalTo(latToSphericalMercator(rect.getMinY())));
         assertThat(mercatorRect.getMaxY(), Matchers.equalTo(latToSphericalMercator(rect.getMaxY())));
     }
+
+    public void testLatitudeExactMath() {
+        // check that the maths we are using are precise to 1mm from the strict maths
+        for (int i = 0; i < 10000; i++) {
+            double lat = randomDoubleBetween(-GeoTileUtils.LATITUDE_MASK, GeoTileUtils.LATITUDE_MASK, true);
+            assertEquals(lat + "", strictLatToSphericalMercator(lat), latToSphericalMercator(lat), 1e-3);
+        }
+    }
+
+    private static double strictLatToSphericalMercator(double lat) {
+        double y = Math.log(Math.tan((90 + Math.max(lat, Math.nextUp(-90.0))) * Math.PI / 360)) / (Math.PI / 180);
+        return y * SphericalMercatorUtils.MERCATOR_BOUNDS / 180;
+    }
 }

--- a/x-pack/plugin/build.gradle
+++ b/x-pack/plugin/build.gradle
@@ -143,6 +143,7 @@ tasks.named("yamlRestTestV7CompatTransform").configure { task ->
   task.skipTest("indices.freeze/10_basic/Test index options", "#70192 -- the freeze index API is removed from 8.0")
   task.skipTest("sql/sql/Paging through results", "scrolling through search hit queries no longer produces empty last page in 8.2")
   task.skipTest("service_accounts/10_basic/Test get service accounts", "new service accounts are added")
+  task.skipTest("spatial/70_script_doc_values/diagonal length", "precision changed in 8.4.0")
 
   task.replaceValueInMatch("_type", "_doc")
   task.addAllowedWarningRegex("\\[types removal\\].*")

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/spatial/70_script_doc_values.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/spatial/70_script_doc_values.yml
@@ -143,4 +143,4 @@ setup:
               script:
                 source: "doc['geo_shape'].getMercatorHeight()"
   - match: { hits.hits.0.fields.width.0: 389.62170283915475 }
-  - match: { hits.hits.0.fields.height.0: 333.37976840604097 }
+  - match: { hits.hits.0.fields.height.0: 333.37976841442287 }

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/spatial/70_script_doc_values.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/spatial/70_script_doc_values.yml
@@ -131,6 +131,10 @@ setup:
 
 ---
 "diagonal length":
+  - skip:
+      reason: "precision changed in 8.4.0"
+      version: "8.3.99 - "
+
   - do:
       search:
         rest_total_hits_as_int: true

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/spatial/70_script_doc_values.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/spatial/70_script_doc_values.yml
@@ -131,10 +131,6 @@ setup:
 
 ---
 "diagonal length":
-  - skip:
-      reason: "precision changed in 8.4.0"
-      version: "8.3.99 - "
-
   - do:
       search:
         rest_total_hits_as_int: true


### PR DESCRIPTION
This commit changes the from strict maths to sloppy maths  when we compute the projection from WGS84 to spherical mercator. Precision is more than enough and test shows a meaningful speed up when doing it for big geometries. the test performed locally shows a ~15% improvement. 