### PR TITLE
Deduplicate field-caps fields in node and ccs responses

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/fieldcaps/FieldCapabilitiesFetcher.java
+++ b/server/src/main/java/org/elasticsearch/action/fieldcaps/FieldCapabilitiesFetcher.java
@@ -39,9 +39,9 @@ class FieldCapabilitiesFetcher {
     private final IndicesService indicesService;
     private final IndexFieldCapabilities.Deduplicator fieldDeduplicator;
 
-    FieldCapabilitiesFetcher(IndicesService indicesService, boolean dedupFields) {
+    FieldCapabilitiesFetcher(IndicesService indicesService) {
         this.indicesService = indicesService;
-        this.fieldDeduplicator = dedupFields ? IndexFieldCapabilities.deduplicatorWithMap() : f -> f;
+        this.fieldDeduplicator = IndexFieldCapabilities.deduplicatorWithMap();
     }
 
     public FieldCapabilitiesIndexResponse fetch(final FieldCapabilitiesIndexRequest request) throws IOException {

--- a/server/src/main/java/org/elasticsearch/action/fieldcaps/FieldCapabilitiesFetcher.java
+++ b/server/src/main/java/org/elasticsearch/action/fieldcaps/FieldCapabilitiesFetcher.java
@@ -41,7 +41,7 @@ class FieldCapabilitiesFetcher {
 
     FieldCapabilitiesFetcher(IndicesService indicesService) {
         this.indicesService = indicesService;
-        this.fieldDeduplicator = IndexFieldCapabilities.deduplicatorWithMap();
+        this.fieldDeduplicator = new IndexFieldCapabilities.Deduplicator();
     }
 
     public FieldCapabilitiesIndexResponse fetch(final FieldCapabilitiesIndexRequest request) throws IOException {

--- a/server/src/main/java/org/elasticsearch/action/fieldcaps/FieldCapabilitiesFetcher.java
+++ b/server/src/main/java/org/elasticsearch/action/fieldcaps/FieldCapabilitiesFetcher.java
@@ -37,9 +37,11 @@ import java.util.function.Predicate;
  */
 class FieldCapabilitiesFetcher {
     private final IndicesService indicesService;
+    private final IndexFieldCapabilities.Deduplicator fieldDeduplicator;
 
-    FieldCapabilitiesFetcher(IndicesService indicesService) {
+    FieldCapabilitiesFetcher(IndicesService indicesService, boolean dedupFields) {
         this.indicesService = indicesService;
+        this.fieldDeduplicator = dedupFields ? IndexFieldCapabilities.deduplicatorWithMap() : f -> f;
     }
 
     public FieldCapabilitiesIndexResponse fetch(final FieldCapabilitiesIndexRequest request) throws IOException {
@@ -80,7 +82,7 @@ class FieldCapabilitiesFetcher {
                         ft.isAggregatable(),
                         ft.meta()
                     );
-                    responseMap.put(field, fieldCap);
+                    responseMap.put(field, fieldDeduplicator.deduplicate(fieldCap));
                 } else {
                     continue;
                 }
@@ -111,7 +113,7 @@ class FieldCapabilitiesFetcher {
                                     false,
                                     Collections.emptyMap()
                                 );
-                                responseMap.put(parentField, fieldCap);
+                                responseMap.put(parentField, fieldDeduplicator.deduplicate(fieldCap));
                             }
                         }
                         dotIndex = parentField.lastIndexOf('.');

--- a/server/src/main/java/org/elasticsearch/action/fieldcaps/FieldCapabilitiesNodeResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/fieldcaps/FieldCapabilitiesNodeResponse.java
@@ -37,7 +37,7 @@ class FieldCapabilitiesNodeResponse extends ActionResponse implements Writeable 
 
     FieldCapabilitiesNodeResponse(StreamInput in) throws IOException {
         super(in);
-        final IndexFieldCapabilities.Deduplicator fieldDeduplicator = IndexFieldCapabilities.deduplicatorWithMap();
+        final IndexFieldCapabilities.Deduplicator fieldDeduplicator = new IndexFieldCapabilities.Deduplicator();
         this.indexResponses = in.readList(is -> new FieldCapabilitiesIndexResponse(is, fieldDeduplicator));
         this.failures = in.readMap(ShardId::new, StreamInput::readException);
         this.unmatchedShardIds = in.readSet(ShardId::new);

--- a/server/src/main/java/org/elasticsearch/action/fieldcaps/FieldCapabilitiesNodeResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/fieldcaps/FieldCapabilitiesNodeResponse.java
@@ -37,7 +37,8 @@ class FieldCapabilitiesNodeResponse extends ActionResponse implements Writeable 
 
     FieldCapabilitiesNodeResponse(StreamInput in) throws IOException {
         super(in);
-        this.indexResponses = in.readList(FieldCapabilitiesIndexResponse::new);
+        final IndexFieldCapabilities.Deduplicator fieldDeduplicator = IndexFieldCapabilities.deduplicatorWithMap();
+        this.indexResponses = in.readList(is -> new FieldCapabilitiesIndexResponse(is, fieldDeduplicator));
         this.failures = in.readMap(ShardId::new, StreamInput::readException);
         this.unmatchedShardIds = in.readSet(ShardId::new);
     }

--- a/server/src/main/java/org/elasticsearch/action/fieldcaps/FieldCapabilitiesResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/fieldcaps/FieldCapabilitiesResponse.java
@@ -80,7 +80,8 @@ public class FieldCapabilitiesResponse extends ActionResponse implements ToXCont
             indices = Strings.EMPTY_ARRAY;
         }
         this.responseMap = in.readMap(StreamInput::readString, FieldCapabilitiesResponse::readField);
-        indexResponses = in.readList(FieldCapabilitiesIndexResponse::new);
+        final IndexFieldCapabilities.Deduplicator fieldDeduplicator = IndexFieldCapabilities.deduplicatorWithMap();
+        indexResponses = in.readList(is -> new FieldCapabilitiesIndexResponse(is, fieldDeduplicator));
         if (in.getVersion().onOrAfter(Version.V_7_13_0)) {
             this.failures = in.readList(FieldCapabilitiesFailure::new);
         } else {

--- a/server/src/main/java/org/elasticsearch/action/fieldcaps/FieldCapabilitiesResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/fieldcaps/FieldCapabilitiesResponse.java
@@ -80,7 +80,7 @@ public class FieldCapabilitiesResponse extends ActionResponse implements ToXCont
             indices = Strings.EMPTY_ARRAY;
         }
         this.responseMap = in.readMap(StreamInput::readString, FieldCapabilitiesResponse::readField);
-        final IndexFieldCapabilities.Deduplicator fieldDeduplicator = IndexFieldCapabilities.deduplicatorWithMap();
+        final IndexFieldCapabilities.Deduplicator fieldDeduplicator = new IndexFieldCapabilities.Deduplicator();
         indexResponses = in.readList(is -> new FieldCapabilitiesIndexResponse(is, fieldDeduplicator));
         if (in.getVersion().onOrAfter(Version.V_7_13_0)) {
             this.failures = in.readList(FieldCapabilitiesFailure::new);

--- a/server/src/main/java/org/elasticsearch/action/fieldcaps/IndexFieldCapabilities.java
+++ b/server/src/main/java/org/elasticsearch/action/fieldcaps/IndexFieldCapabilities.java
@@ -154,14 +154,10 @@ public class IndexFieldCapabilities implements Writeable {
             && Objects.equals(meta, that.meta);
     }
 
-    @FunctionalInterface
-    interface Deduplicator {
-        IndexFieldCapabilities deduplicate(IndexFieldCapabilities field);
-    }
+    static final class Deduplicator {
+        private final Map<String, IndexFieldCapabilities> caches = new HashMap<>();
 
-    static Deduplicator deduplicatorWithMap() {
-        final Map<String, IndexFieldCapabilities> caches = new HashMap<>();
-        return field -> {
+        IndexFieldCapabilities deduplicate(IndexFieldCapabilities field) {
             final IndexFieldCapabilities existing = caches.putIfAbsent(field.getName(), field);
             if (existing != null) {
                 if (existing.equalsWithoutName(field)) {
@@ -178,7 +174,7 @@ public class IndexFieldCapabilities implements Writeable {
             } else {
                 return field;
             }
-        };
+        }
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/action/fieldcaps/IndexFieldCapabilities.java
+++ b/server/src/main/java/org/elasticsearch/action/fieldcaps/IndexFieldCapabilities.java
@@ -12,6 +12,7 @@ import org.elasticsearch.Version;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.common.util.StringLiteralDeduplicator;
 
 import java.io.IOException;
 import java.util.Collections;
@@ -25,6 +26,8 @@ import java.util.stream.Collectors;
  * Describes the capabilities of a field in a single index.
  */
 public class IndexFieldCapabilities implements Writeable {
+
+    private static final StringLiteralDeduplicator typeStringDeduplicator = new StringLiteralDeduplicator();
 
     private final String name;
     private final String type;
@@ -60,7 +63,7 @@ public class IndexFieldCapabilities implements Writeable {
     IndexFieldCapabilities(StreamInput in) throws IOException {
         if (in.getVersion().onOrAfter(Version.V_7_7_0)) {
             this.name = in.readString();
-            this.type = in.readString();
+            this.type = typeStringDeduplicator.deduplicate(in.readString());
             this.isMetadatafield = in.getVersion().onOrAfter(Version.V_7_13_0) ? in.readBoolean() : false;
             this.isSearchable = in.readBoolean();
             this.isAggregatable = in.readBoolean();

--- a/server/src/main/java/org/elasticsearch/action/fieldcaps/RequestDispatcher.java
+++ b/server/src/main/java/org/elasticsearch/action/fieldcaps/RequestDispatcher.java
@@ -227,7 +227,7 @@ final class RequestDispatcher {
                     shardRequest,
                     parentTask,
                     TransportRequestOptions.EMPTY,
-                    new ActionListenerResponseHandler<>(listener, FieldCapabilitiesIndexResponse::new)
+                    new ActionListenerResponseHandler<>(listener, is -> new FieldCapabilitiesIndexResponse(is, f -> f))
                 );
             }
         }

--- a/server/src/main/java/org/elasticsearch/action/fieldcaps/RequestDispatcher.java
+++ b/server/src/main/java/org/elasticsearch/action/fieldcaps/RequestDispatcher.java
@@ -227,7 +227,10 @@ final class RequestDispatcher {
                     shardRequest,
                     parentTask,
                     TransportRequestOptions.EMPTY,
-                    new ActionListenerResponseHandler<>(listener, is -> new FieldCapabilitiesIndexResponse(is, f -> f))
+                    new ActionListenerResponseHandler<>(
+                        listener,
+                        is -> new FieldCapabilitiesIndexResponse(is, new IndexFieldCapabilities.Deduplicator())
+                    )
                 );
             }
         }

--- a/server/src/main/java/org/elasticsearch/action/fieldcaps/TransportFieldCapabilitiesAction.java
+++ b/server/src/main/java/org/elasticsearch/action/fieldcaps/TransportFieldCapabilitiesAction.java
@@ -337,10 +337,7 @@ public class TransportFieldCapabilitiesAction extends HandledTransportAction<Fie
                 final Map<String, List<ShardId>> groupedShardIds = request.shardIds()
                     .stream()
                     .collect(Collectors.groupingBy(ShardId::getIndexName));
-                final FieldCapabilitiesFetcher fieldCapabilitiesFetcher = new FieldCapabilitiesFetcher(
-                    indicesService,
-                    groupedShardIds.size() > 1
-                );
+                final FieldCapabilitiesFetcher fieldCapabilitiesFetcher = new FieldCapabilitiesFetcher(indicesService);
                 for (List<ShardId> shardIds : groupedShardIds.values()) {
                     final Map<ShardId, Exception> failures = new HashMap<>();
                     final Set<ShardId> unmatched = new HashSet<>();
@@ -379,7 +376,7 @@ public class TransportFieldCapabilitiesAction extends HandledTransportAction<Fie
         @Override
         public void messageReceived(FieldCapabilitiesIndexRequest request, TransportChannel channel, Task task) throws Exception {
             ActionListener<FieldCapabilitiesIndexResponse> listener = new ChannelActionListener<>(channel, ACTION_SHARD_NAME, request);
-            FieldCapabilitiesFetcher fieldCapabilitiesFetcher = new FieldCapabilitiesFetcher(indicesService, false);
+            FieldCapabilitiesFetcher fieldCapabilitiesFetcher = new FieldCapabilitiesFetcher(indicesService);
             ActionListener.completeWith(listener, () -> fieldCapabilitiesFetcher.fetch(request));
         }
     }

--- a/server/src/test/java/org/elasticsearch/action/fieldcaps/FieldCapabilitiesIndexResponseTests.java
+++ b/server/src/test/java/org/elasticsearch/action/fieldcaps/FieldCapabilitiesIndexResponseTests.java
@@ -25,8 +25,7 @@ import static org.hamcrest.Matchers.equalTo;
 public class FieldCapabilitiesIndexResponseTests extends AbstractWireSerializingTestCase<FieldCapabilitiesIndexResponse> {
     @Override
     protected Writeable.Reader<FieldCapabilitiesIndexResponse> instanceReader() {
-        IndexFieldCapabilities.Deduplicator deduplicator = IndexFieldCapabilities.deduplicatorWithMap();
-        return in -> new FieldCapabilitiesIndexResponse(in, deduplicator);
+        return in -> new FieldCapabilitiesIndexResponse(in, new IndexFieldCapabilities.Deduplicator());
     }
 
     static FieldCapabilitiesIndexResponse randomIndexResponse() {
@@ -54,7 +53,7 @@ public class FieldCapabilitiesIndexResponseTests extends AbstractWireSerializing
         String base64 = "CWxvZ3MtMTAwMQMGcGVyaW9kBnBlcmlvZARsb25nAQABAQR1bml0BnNlY29uZApAdGltZXN0"
             + "YW1wCkB0aW1lc3RhbXAEZGF0ZQEBAAAHbWVzc2FnZQdtZXNzYWdlBHRleHQAAQAAAQAAAAAAAAAAAA==";
         StreamInput in = StreamInput.wrap(Base64.getDecoder().decode(base64));
-        FieldCapabilitiesIndexResponse resp = new FieldCapabilitiesIndexResponse(in, f -> f);
+        FieldCapabilitiesIndexResponse resp = new FieldCapabilitiesIndexResponse(in, new IndexFieldCapabilities.Deduplicator());
         assertTrue(resp.canMatch());
         assertThat(resp.getIndexName(), equalTo("logs-1001"));
         assertThat(

--- a/server/src/test/java/org/elasticsearch/action/fieldcaps/FieldCapabilitiesIndexResponseTests.java
+++ b/server/src/test/java/org/elasticsearch/action/fieldcaps/FieldCapabilitiesIndexResponseTests.java
@@ -25,7 +25,8 @@ import static org.hamcrest.Matchers.equalTo;
 public class FieldCapabilitiesIndexResponseTests extends AbstractWireSerializingTestCase<FieldCapabilitiesIndexResponse> {
     @Override
     protected Writeable.Reader<FieldCapabilitiesIndexResponse> instanceReader() {
-        return FieldCapabilitiesIndexResponse::new;
+        IndexFieldCapabilities.Deduplicator deduplicator = IndexFieldCapabilities.deduplicatorWithMap();
+        return in -> new FieldCapabilitiesIndexResponse(in, deduplicator);
     }
 
     static FieldCapabilitiesIndexResponse randomIndexResponse() {
@@ -53,7 +54,7 @@ public class FieldCapabilitiesIndexResponseTests extends AbstractWireSerializing
         String base64 = "CWxvZ3MtMTAwMQMGcGVyaW9kBnBlcmlvZARsb25nAQABAQR1bml0BnNlY29uZApAdGltZXN0"
             + "YW1wCkB0aW1lc3RhbXAEZGF0ZQEBAAAHbWVzc2FnZQdtZXNzYWdlBHRleHQAAQAAAQAAAAAAAAAAAA==";
         StreamInput in = StreamInput.wrap(Base64.getDecoder().decode(base64));
-        FieldCapabilitiesIndexResponse resp = new FieldCapabilitiesIndexResponse(in);
+        FieldCapabilitiesIndexResponse resp = new FieldCapabilitiesIndexResponse(in, f -> f);
         assertTrue(resp.canMatch());
         assertThat(resp.getIndexName(), equalTo("logs-1001"));
         assertThat(

--- a/server/src/test/java/org/elasticsearch/action/fieldcaps/FieldCapabilitiesNodeResponseTests.java
+++ b/server/src/test/java/org/elasticsearch/action/fieldcaps/FieldCapabilitiesNodeResponseTests.java
@@ -12,13 +12,17 @@ import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.test.AbstractWireSerializingTestCase;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 import static org.elasticsearch.action.fieldcaps.FieldCapabilitiesIndexResponseTests.randomIndexResponse;
+import static org.hamcrest.Matchers.equalTo;
 
 public class FieldCapabilitiesNodeResponseTests extends AbstractWireSerializingTestCase<FieldCapabilitiesNodeResponse> {
 
@@ -60,5 +64,46 @@ public class FieldCapabilitiesNodeResponseTests extends AbstractWireSerializingT
                 break;
         }
         return new FieldCapabilitiesNodeResponse(newResponses, Collections.emptyMap(), response.getUnmatchedShardIds());
+    }
+
+    public void testSharedFieldsBetweenIndexResponses() throws IOException {
+        List<FieldCapabilitiesIndexResponse> responses = new ArrayList<>();
+        final FieldCapabilitiesIndexResponse firstResponse = randomIndexResponse();
+        int extraResponses = randomIntBetween(2, 10);
+        for (int i = 0; i < extraResponses; i++) {
+            final List<IndexFieldCapabilities> fields = new ArrayList<>();
+            for (IndexFieldCapabilities f : firstResponse.getFields()) {
+                if (frequently()) {
+                    if (randomBoolean()) {
+                        fields.add(f);
+                    } else {
+                        fields.add(copyWriteable(f, getNamedWriteableRegistry(), IndexFieldCapabilities::new));
+                    }
+                }
+            }
+            FieldCapabilitiesIndexResponse indexResponse = new FieldCapabilitiesIndexResponse(
+                randomAlphaOfLength(100),
+                fields,
+                firstResponse.canMatch()
+            );
+            responses.add(indexResponse);
+        }
+        int numUnmatched = randomIntBetween(0, 3);
+        Set<ShardId> shardIds = new HashSet<>();
+        for (int i = 0; i < numUnmatched; i++) {
+            shardIds.add(new ShardId(randomAlphaOfLength(10), randomAlphaOfLength(10), between(0, 10)));
+        }
+        FieldCapabilitiesNodeResponse origResp = new FieldCapabilitiesNodeResponse(responses, Collections.emptyMap(), shardIds);
+        FieldCapabilitiesNodeResponse serializedResp = copyInstance(origResp);
+        assertThat(serializedResp, equalTo(origResp));
+        final Map<String, IndexFieldCapabilities> sharedFields = new HashMap<>();
+        for (IndexFieldCapabilities f : origResp.getIndexResponses().get(0).getFields()) {
+            sharedFields.putIfAbsent(f.getName(), f);
+        }
+        for (int i = 1; i < origResp.getIndexResponses().size(); i++) {
+            for (IndexFieldCapabilities f : origResp.getIndexResponses().get(i).getFields()) {
+                assertSame(sharedFields.get(f.getName()), f);
+            }
+        }
     }
 }


### PR DESCRIPTION
We can reduce the memory usage of field-caps responses from node and remote-cluster responses by sharing field responses with the same name.  I think we can also remove the type deduplicating as we now deduplicate the whole field response.

This change can handle more concurrent field-caps requests targeting many indices.