### PR TITLE
[DOCS] Document autoscaling processors

### DIFF
--- a/docs/reference/autoscaling/apis/get-autoscaling-capacity.asciidoc
+++ b/docs/reference/autoscaling/apis/get-autoscaling-capacity.asciidoc
@@ -85,6 +85,10 @@ Bytes of storage required per node.
 (integer)
 Bytes of memory required per node.
 
+`processors`::
+(float)
+Number of processors (vCPUs) required per node.
+
 =======
 `total`::
 (object)
@@ -100,6 +104,11 @@ Total bytes of storage required for the policy.
 `memory`::
 (integer)
 Total bytes of memory required for the policy.
+
+`processors`::
+(float)
+Total number of processors (vCPUs) required for the policy.
+
 =======
 ======
 `current_capacity`::
@@ -125,6 +134,10 @@ Maximum bytes of storage of a node.
 (integer)
 Maximum bytes of memory of a node.
 
+`processors`::
+(float)
+Maximum number of processors (vCPUs) of a node.
+
 =======
 `total`::
 (object)
@@ -140,6 +153,10 @@ Current bytes of storage available for the policy.
 `memory`::
 (integer)
 Current bytes of memory available for the policy.
+
+`processors`::
+Current number of processors (vCPUs) available for the policy.
+
 =======
 ======
 `current_nodes`::
@@ -191,6 +208,10 @@ Bytes of storage required per node.
 (integer)
 Bytes of memory required per node.
 
+`processors`::
+(float)
+Number of processors (vCPUs) required per node.
+
 ==========
 `total`::
 (object)
@@ -206,6 +227,11 @@ Total bytes of storage required for the policy.
 `memory`::
 (integer)
 Total bytes of memory required for the policy.
+
+`processors`::
+(float)
+Total number of processors (vCPUs) required for the policy.
+
 ==========
 =========
 `reason_summary`::

--- a/docs/reference/autoscaling/deciders/fixed-decider.asciidoc
+++ b/docs/reference/autoscaling/deciders/fixed-decider.asciidoc
@@ -19,6 +19,10 @@ Required amount of node-level storage. Defaults to `-1` (disabled).
 (Optional, <<byte-units,byte value>>)
 Required amount of node-level memory. Defaults to `-1` (disabled).
 
+`processors`::
+(Optional, float)
+Required number of processors. Defaults to disabled.
+
 `nodes`::
 (Optional, integer)
 Number of nodes to use when calculating capacity. Defaults to `1`.
@@ -38,6 +42,7 @@ PUT /_autoscaling/policy/my_autoscaling_policy
     "fixed": {
       "storage": "1tb",
       "memory": "32gb",
+      "processors": 2.3,
       "nodes": 8
     }
   }


### PR DESCRIPTION
Add documentation for new `processors` response in autoscaling capacity API.

Relates #87895
