### PR TITLE
Make JdkMapDiff return immutable map

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/DiffableUtils.java
+++ b/server/src/main/java/org/elasticsearch/cluster/DiffableUtils.java
@@ -16,6 +16,7 @@ import org.elasticsearch.common.io.stream.Writeable.Reader;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -242,7 +243,7 @@ public final class DiffableUtils {
                 builder.put(upsert.getKey(), upsert.getValue());
             }
 
-            return builder;
+            return Collections.unmodifiableMap(builder);
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/Metadata.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/Metadata.java
@@ -1213,7 +1213,7 @@ public class Metadata extends AbstractCollection<IndexMetadata> implements Diffa
             builder.indices(indices.apply(part.indices));
             builder.templates(templates.apply(part.templates));
             builder.customs(customs.apply(part.customs));
-            builder.put(Collections.unmodifiableMap(immutableStateMetadata.apply(part.immutableStateMetadata)));
+            builder.put(immutableStateMetadata.apply(part.immutableStateMetadata));
             return builder.build();
         }
     }


### PR DESCRIPTION
When using the DiffableUtils.diff with a vanilla OpenJDK Map, instead of the legacy ImmutableOpenMap interface, we return a mutable map (generic HashMap), which isn't the expected behaviour of the API:

[elasticsearch/server/src/main/java/org/elasticsearch/cluster/DiffableUtils.java](https://github.com/elastic/elasticsearch/blob/45c56b22f946733712ad6d92600411c0885594c5/server/src/main/java/org/elasticsearch/cluster/DiffableUtils.java#L85)
Line 85 in [45c56b2](https://github.com/elastic/elasticsearch/commit/45c56b22f946733712ad6d92600411c0885594c5)
 public static <K, T extends Diffable<T>> MapDiff<K, T, Map<K, T>> diff( 

This PR wraps the Map returned from the `diff.apply()` method to return an immutable map collection.

Closes https://github.com/elastic/elasticsearch/issues/88019