### PR TITLE
Use pre-parsed index mode when figuring out timestamp range

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/metadata/IndexMetadata.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/IndexMetadata.java
@@ -1006,7 +1006,11 @@ public class IndexMetadata implements Diffable<IndexMetadata>, ToXContentFragmen
      */
     @Nullable
     public IndexLongFieldRange getTimeSeriesTimestampRange() {
-        return IndexSettings.MODE.get(settings).getConfiguredTimestampRange(this);
+        if (indexMode != null) {
+            return indexMode.getConfiguredTimestampRange(this);
+        } else {
+            return null;
+        }
     }
 
     @Override


### PR DESCRIPTION
Use `indexMode` field instead of parsing IndexMode from settings in order
to determine time series timestamp range. Parsing the index mode isn't
necessary, because we read the index mode when IndexMetadata is constructed,
and this just burns unnecessary CPU cycles.