### PR TITLE
Support async for disk usage API

### DIFF
--- a/docs/changelog/88255.yaml
+++ b/docs/changelog/88255.yaml
@@ -1,0 +1,5 @@
+pr: 88255
+summary: Support async for disk usage API
+area: Search
+type: enhancement
+issues: []

--- a/docs/reference/indices/diskusage.asciidoc
+++ b/docs/reference/indices/diskusage.asciidoc
@@ -180,3 +180,13 @@ files are ignored and some parts of data files might not be scanned by the API.
 together in a compressed format, the estimated sizes of stored fields are
 best efforts and can be inaccurate. The stored size of the `_id` field
 is likely underestimated while the `_source` field is overestimated.
+
+
+===== Running disk usage API asynchronously
+
+If the request contains `wait_for_completion=false`, {es}
+performs some preflight checks, launches the request, and returns a
+<<tasks,`task`>> you can use to cancel or get the status of the task.
+{es} creates a record of this task as a document at `_tasks/<task_id>`.
+When you are done with a task, you should delete the task document so
+{es} can reclaim the space.

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.disk_usage.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.disk_usage.json
@@ -32,6 +32,10 @@
         "type": "boolean",
         "description": "Must be set to [true] in order for the task to be performed. Defaults to false."
       },
+      "wait_for_completion": {
+        "type": "boolean",
+        "description": "Should the request should block until the analyze is complete."
+      },
       "flush": {
         "type": "boolean",
         "description": "Whether flush or not before analyzing the index disk usage. Defaults to true"

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/indices.stats/50_disk_usage.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/indices.stats/50_disk_usage.yml
@@ -126,3 +126,33 @@ setup:
   - gt: { testindex.all_fields.doc_values_in_bytes: 0 }
   - gt: { testindex.all_fields.points_in_bytes: 0 }
   - match: { testindex.all_fields.term_vectors_in_bytes: 0 }
+
+---
+"Async":
+  - skip:
+      version: " - 8.3.99"
+      reason: async is added in 8.4+
+
+  - do:
+      indices.disk_usage:
+        index: testindex
+        run_expensive_tasks: true
+        wait_for_completion: false
+  - set: { task: task_id }
+  - do:
+      tasks.get:
+        task_id: $task_id
+        wait_for_completion: true
+  # all_fields
+  - gt: { response.testindex.store_size_in_bytes: 100 }
+  - gt: { response.testindex.all_fields.total_in_bytes: 0 }
+  - gt: { response.testindex.all_fields.inverted_index.total_in_bytes: 0 }
+  - gt: { response.testindex.all_fields.stored_fields_in_bytes: 0 }
+  - gt: { response.testindex.all_fields.doc_values_in_bytes: 0 }
+  - gt: { response.testindex.all_fields.points_in_bytes: 0 }
+  - match: { response.testindex.all_fields.term_vectors_in_bytes: 0 }
+
+  - do:
+      delete:
+        index: .tasks
+        id: $task_id

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/indices.stats/50_disk_usage.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/indices.stats/50_disk_usage.yml
@@ -132,6 +132,7 @@ setup:
   - skip:
       version: " - 8.3.99"
       reason: async is added in 8.4+
+      features: allowed_warnings
 
   - do:
       indices.disk_usage:
@@ -156,3 +157,5 @@ setup:
       delete:
         index: .tasks
         id: $task_id
+      allowed_warnings:
+        - "this request accesses system indices: [.tasks], but in a future major version, direct access to system indices will be prevented by default"

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/diskusage/AnalyzeIndexDiskUsageRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/diskusage/AnalyzeIndexDiskUsageRequest.java
@@ -25,6 +25,7 @@ import static org.elasticsearch.action.ValidateActions.addValidationError;
 public class AnalyzeIndexDiskUsageRequest extends BroadcastRequest<AnalyzeIndexDiskUsageRequest> {
     public static final IndicesOptions DEFAULT_INDICES_OPTIONS = IndicesOptions.fromOptions(false, false, true, true);
     final boolean flush;
+    private boolean shouldStoreResult;
 
     public AnalyzeIndexDiskUsageRequest(String[] indices, IndicesOptions indicesOptions, boolean flush) {
         super(indices, indicesOptions);
@@ -64,6 +65,15 @@ public class AnalyzeIndexDiskUsageRequest extends BroadcastRequest<AnalyzeIndexD
                 return AnalyzeIndexDiskUsageRequest.this.getDescription();
             }
         };
+    }
+
+    public void setShouldStoreResult(boolean shouldStoreResult) {
+        this.shouldStoreResult = shouldStoreResult;
+    }
+
+    @Override
+    public boolean getShouldStoreResult() {
+        return shouldStoreResult;
     }
 
     @Override


### PR DESCRIPTION
This change adds async support to the DiskUsage API - which is useful when analyzing a large index. It might be better to have separate REST endpoints for retrieving and deleting responses like async_search. However, this PR relies on the `tasks` index instead as the implementation is simpler.