### PR TITLE
Collapse IndexMode#getConfiguredTimestampRange(...) into IndexMode#getTimestampBound(...)

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/metadata/IndexMetadata.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/IndexMetadata.java
@@ -44,6 +44,7 @@ import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.index.seqno.SequenceNumbers;
 import org.elasticsearch.index.shard.IndexLongFieldRange;
 import org.elasticsearch.index.shard.ShardId;
+import org.elasticsearch.index.shard.ShardLongFieldRange;
 import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.snapshots.SearchableSnapshotsSettings;
 import org.elasticsearch.xcontent.ToXContent;
@@ -1006,8 +1007,9 @@ public class IndexMetadata implements Diffable<IndexMetadata>, ToXContentFragmen
      */
     @Nullable
     public IndexLongFieldRange getTimeSeriesTimestampRange() {
-        if (indexMode != null) {
-            return indexMode.getConfiguredTimestampRange(this);
+        var bounds = indexMode != null ? indexMode.getTimestampBound(this, null) : null;
+        if (bounds != null) {
+            return IndexLongFieldRange.NO_SHARDS.extendWithShardRange(0, 1, ShardLongFieldRange.of(bounds.startTime(), bounds.endTime()));
         } else {
             return null;
         }

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/IndexMetadata.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/IndexMetadata.java
@@ -1007,7 +1007,7 @@ public class IndexMetadata implements Diffable<IndexMetadata>, ToXContentFragmen
      */
     @Nullable
     public IndexLongFieldRange getTimeSeriesTimestampRange() {
-        var bounds = indexMode != null ? indexMode.getTimestampBound(this, null) : null;
+        var bounds = indexMode != null ? indexMode.getTimestampBound(this) : null;
         if (bounds != null) {
             return IndexLongFieldRange.NO_SHARDS.extendWithShardRange(0, 1, ShardLongFieldRange.of(bounds.startTime(), bounds.endTime()));
         } else {

--- a/server/src/main/java/org/elasticsearch/index/IndexMode.java
+++ b/server/src/main/java/org/elasticsearch/index/IndexMode.java
@@ -11,7 +11,6 @@ package org.elasticsearch.index;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.metadata.MetadataCreateDataStreamService;
 import org.elasticsearch.common.compress.CompressedXContent;
-import org.elasticsearch.common.settings.IndexScopedSettings;
 import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.core.Nullable;
@@ -80,7 +79,7 @@ public enum IndexMode {
         }
 
         @Override
-        public TimestampBounds getTimestampBound(IndexMetadata indexMetadata, IndexScopedSettings settings) {
+        public TimestampBounds getTimestampBound(IndexMetadata indexMetadata) {
             return null;
         }
 
@@ -158,8 +157,8 @@ public enum IndexMode {
         }
 
         @Override
-        public TimestampBounds getTimestampBound(IndexMetadata indexMetadata, IndexScopedSettings settings) {
-            return new TimestampBounds(indexMetadata, settings);
+        public TimestampBounds getTimestampBound(IndexMetadata indexMetadata) {
+            return new TimestampBounds(indexMetadata.getTimeSeriesStart(), indexMetadata.getTimeSeriesEnd());
         }
 
         private static String routingRequiredBad() {
@@ -275,7 +274,7 @@ public enum IndexMode {
      *         Otherwise <code>null</code> is returned.
      */
     @Nullable
-    public abstract TimestampBounds getTimestampBound(IndexMetadata indexMetadata, IndexScopedSettings settings);
+    public abstract TimestampBounds getTimestampBound(IndexMetadata indexMetadata);
 
     /**
      * Return an instance of the {@link TimeSeriesIdFieldMapper} that generates

--- a/server/src/main/java/org/elasticsearch/index/IndexMode.java
+++ b/server/src/main/java/org/elasticsearch/index/IndexMode.java
@@ -104,6 +104,10 @@ public enum IndexMode {
             return new DocumentDimensions.OnlySingleValueAllowed();
         }
 
+        @Override
+        public boolean shouldValidateTimestamp() {
+            return false;
+        }
     },
     TIME_SERIES("time_series") {
         @Override
@@ -186,6 +190,10 @@ public enum IndexMode {
             return new TimeSeriesIdFieldMapper.TimeSeriesIdBuilder();
         }
 
+        @Override
+        public boolean shouldValidateTimestamp() {
+            return true;
+        }
     };
 
     protected static String tsdbMode() {
@@ -287,6 +295,11 @@ public enum IndexMode {
      * How {@code time_series_dimension} fields are handled by indices in this mode.
      */
     public abstract DocumentDimensions buildDocumentDimensions();
+
+    /**
+     * @return Whether timestamps should be validated for being withing the time range of an index.
+     */
+    public abstract boolean shouldValidateTimestamp();
 
     public static IndexMode fromString(String value) {
         return switch (value) {

--- a/server/src/main/java/org/elasticsearch/index/IndexSettings.java
+++ b/server/src/main/java/org/elasticsearch/index/IndexSettings.java
@@ -698,7 +698,7 @@ public final class IndexSettings {
         numberOfShards = settings.getAsInt(IndexMetadata.SETTING_NUMBER_OF_SHARDS, null);
         mode = isTimeSeriesModeEnabled() ? scopedSettings.get(MODE) : IndexMode.STANDARD;
         this.timestampBounds = mode.getTimestampBound(indexMetadata);
-        if (mode != IndexMode.TIME_SERIES) {
+        if (timestampBounds != null) {
             scopedSettings.addSettingsUpdateConsumer(
                 IndexSettings.TIME_SERIES_END_TIME,
                 endTime -> { this.timestampBounds = new TimestampBounds(this.timestampBounds, endTime); }

--- a/server/src/main/java/org/elasticsearch/index/IndexSettings.java
+++ b/server/src/main/java/org/elasticsearch/index/IndexSettings.java
@@ -697,7 +697,7 @@ public final class IndexSettings {
         this.indexMetadata = indexMetadata;
         numberOfShards = settings.getAsInt(IndexMetadata.SETTING_NUMBER_OF_SHARDS, null);
         mode = isTimeSeriesModeEnabled() ? scopedSettings.get(MODE) : IndexMode.STANDARD;
-        this.timestampBounds = mode.getTimestampBound(scopedSettings);
+        this.timestampBounds = mode.getTimestampBound(indexMetadata, scopedSettings);
         this.searchThrottled = INDEX_SEARCH_THROTTLED.get(settings);
         this.queryStringLenient = QUERY_STRING_LENIENT_SETTING.get(settings);
         this.queryStringAnalyzeWildcard = QUERY_STRING_ANALYZE_WILDCARD.get(nodeSettings);

--- a/server/src/main/java/org/elasticsearch/index/IndexSettings.java
+++ b/server/src/main/java/org/elasticsearch/index/IndexSettings.java
@@ -698,10 +698,11 @@ public final class IndexSettings {
         numberOfShards = settings.getAsInt(IndexMetadata.SETTING_NUMBER_OF_SHARDS, null);
         mode = isTimeSeriesModeEnabled() ? scopedSettings.get(MODE) : IndexMode.STANDARD;
         this.timestampBounds = mode.getTimestampBound(indexMetadata);
-        if (mode == IndexMode.TIME_SERIES) {
-            scopedSettings.addSettingsUpdateConsumer(IndexSettings.TIME_SERIES_END_TIME, endTime -> {
-                this.timestampBounds = new TimestampBounds(this.timestampBounds, endTime);
-            });
+        if (mode != IndexMode.TIME_SERIES) {
+            scopedSettings.addSettingsUpdateConsumer(
+                IndexSettings.TIME_SERIES_END_TIME,
+                endTime -> { this.timestampBounds = new TimestampBounds(this.timestampBounds, endTime); }
+            );
         }
         this.searchThrottled = INDEX_SEARCH_THROTTLED.get(settings);
         this.queryStringLenient = QUERY_STRING_LENIENT_SETTING.get(settings);

--- a/server/src/main/java/org/elasticsearch/index/IndexSettings.java
+++ b/server/src/main/java/org/elasticsearch/index/IndexSettings.java
@@ -552,7 +552,7 @@ public final class IndexSettings {
      * The bounds for {@code @timestamp} on this index or
      * {@code null} if there are no bounds.
      */
-    private final TimestampBounds timestampBounds;
+    private volatile TimestampBounds timestampBounds;
 
     // volatile fields are updated via #updateIndexMetadata(IndexMetadata) under lock
     private volatile Settings settings;
@@ -697,7 +697,12 @@ public final class IndexSettings {
         this.indexMetadata = indexMetadata;
         numberOfShards = settings.getAsInt(IndexMetadata.SETTING_NUMBER_OF_SHARDS, null);
         mode = isTimeSeriesModeEnabled() ? scopedSettings.get(MODE) : IndexMode.STANDARD;
-        this.timestampBounds = mode.getTimestampBound(indexMetadata, scopedSettings);
+        this.timestampBounds = mode.getTimestampBound(indexMetadata);
+        if (mode == IndexMode.TIME_SERIES) {
+            scopedSettings.addSettingsUpdateConsumer(IndexSettings.TIME_SERIES_END_TIME, endTime -> {
+                this.timestampBounds = new TimestampBounds(this.timestampBounds, endTime);
+            });
+        }
         this.searchThrottled = INDEX_SEARCH_THROTTLED.get(settings);
         this.queryStringLenient = QUERY_STRING_LENIENT_SETTING.get(settings);
         this.queryStringAnalyzeWildcard = QUERY_STRING_ANALYZE_WILDCARD.get(nodeSettings);

--- a/server/src/main/java/org/elasticsearch/index/IndexSettings.java
+++ b/server/src/main/java/org/elasticsearch/index/IndexSettings.java
@@ -701,7 +701,7 @@ public final class IndexSettings {
         if (timestampBounds != null) {
             scopedSettings.addSettingsUpdateConsumer(
                 IndexSettings.TIME_SERIES_END_TIME,
-                endTime -> { this.timestampBounds = new TimestampBounds(this.timestampBounds, endTime); }
+                endTime -> { this.timestampBounds = TimestampBounds.updateEndTime(this.timestampBounds, endTime); }
             );
         }
         this.searchThrottled = INDEX_SEARCH_THROTTLED.get(settings);

--- a/server/src/main/java/org/elasticsearch/index/TimestampBounds.java
+++ b/server/src/main/java/org/elasticsearch/index/TimestampBounds.java
@@ -13,23 +13,30 @@ import java.time.Instant;
  * Bounds for the {@code @timestamp} field on this index.
  */
 public class TimestampBounds {
+
+    /**
+     * @return an updated instance based on current instance with a new end time.
+     */
+    public static TimestampBounds updateEndTime(TimestampBounds current, Instant newEndTime) {
+        long newEndTimeMillis = newEndTime.toEpochMilli();
+        if (current.endTime > newEndTimeMillis) {
+            throw new IllegalArgumentException(
+                "index.time_series.end_time must be larger than current value [" + current.endTime + "] but was [" + newEndTime + "]"
+            );
+        }
+        return new TimestampBounds(current.startTime(), newEndTimeMillis);
+    }
+
     private final long startTime;
     private final long endTime;
 
     public TimestampBounds(Instant startTime, Instant endTime) {
-        this.startTime = startTime.toEpochMilli();
-        this.endTime = endTime.toEpochMilli();
+        this(startTime.toEpochMilli(), endTime.toEpochMilli());
     }
 
-    public TimestampBounds(TimestampBounds previous, Instant newEndTime) {
-        long newEndTimeMillis = newEndTime.toEpochMilli();
-        if (previous.endTime > newEndTimeMillis) {
-            throw new IllegalArgumentException(
-                "index.time_series.end_time must be larger than current value [" + previous.endTime + "] but was [" + newEndTime + "]"
-            );
-        }
-        this.startTime = previous.startTime();
-        this.endTime = newEndTimeMillis;
+    private TimestampBounds(long startTime, long endTime) {
+        this.startTime = startTime;
+        this.endTime = endTime;
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/index/TimestampBounds.java
+++ b/server/src/main/java/org/elasticsearch/index/TimestampBounds.java
@@ -7,7 +7,9 @@
  */
 package org.elasticsearch.index;
 
+import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.common.settings.IndexScopedSettings;
+import org.elasticsearch.core.Nullable;
 
 import java.time.Instant;
 
@@ -18,10 +20,12 @@ public class TimestampBounds {
     private final long startTime;
     private volatile long endTime;
 
-    TimestampBounds(IndexScopedSettings scopedSettings) {
-        startTime = scopedSettings.get(IndexSettings.TIME_SERIES_START_TIME).toEpochMilli();
-        endTime = scopedSettings.get(IndexSettings.TIME_SERIES_END_TIME).toEpochMilli();
-        scopedSettings.addSettingsUpdateConsumer(IndexSettings.TIME_SERIES_END_TIME, this::updateEndTime);
+    TimestampBounds(IndexMetadata indexMetadata, @Nullable IndexScopedSettings scopedSettings) {
+        startTime = indexMetadata.getTimeSeriesStart().toEpochMilli();
+        endTime = indexMetadata.getTimeSeriesEnd().toEpochMilli();
+        if (scopedSettings != null) {
+            scopedSettings.addSettingsUpdateConsumer(IndexSettings.TIME_SERIES_END_TIME, this::updateEndTime);
+        }
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/index/mapper/DataStreamTimestampFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/DataStreamTimestampFieldMapper.java
@@ -13,7 +13,6 @@ import org.apache.lucene.index.IndexableField;
 import org.apache.lucene.search.Query;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.xcontent.XContentHelper;
-import org.elasticsearch.index.IndexMode;
 import org.elasticsearch.index.TimestampBounds;
 import org.elasticsearch.index.mapper.DateFieldMapper.Resolution;
 import org.elasticsearch.index.query.SearchExecutionContext;
@@ -219,7 +218,7 @@ public class DataStreamTimestampFieldMapper extends MetadataFieldMapper {
             throw new IllegalArgumentException("data stream timestamp field [" + DEFAULT_PATH + "] is missing");
         }
         var indexMode = context.indexSettings().getMode();
-        if (indexMode == IndexMode.TIME_SERIES) {
+        if (indexMode.shouldValidateTimestamp()) {
             TimestampBounds bounds = context.indexSettings().getTimestampBounds();
             validateTimestamp(bounds, first, context);
         }

--- a/server/src/main/java/org/elasticsearch/index/mapper/DataStreamTimestampFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/DataStreamTimestampFieldMapper.java
@@ -13,6 +13,7 @@ import org.apache.lucene.index.IndexableField;
 import org.apache.lucene.search.Query;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.xcontent.XContentHelper;
+import org.elasticsearch.index.IndexMode;
 import org.elasticsearch.index.TimestampBounds;
 import org.elasticsearch.index.mapper.DateFieldMapper.Resolution;
 import org.elasticsearch.index.query.SearchExecutionContext;
@@ -217,8 +218,9 @@ public class DataStreamTimestampFieldMapper extends MetadataFieldMapper {
         if (first == null) {
             throw new IllegalArgumentException("data stream timestamp field [" + DEFAULT_PATH + "] is missing");
         }
-        TimestampBounds bounds = context.indexSettings().getTimestampBounds();
-        if (bounds != null) {
+        var indexMode = context.indexSettings().getMode();
+        if (indexMode == IndexMode.TIME_SERIES) {
+            TimestampBounds bounds = context.indexSettings().getTimestampBounds();
             validateTimestamp(bounds, first, context);
         }
     }


### PR DESCRIPTION
`IndexMode#getConfiguredTimestampRange(...)` functionally overlaps a lot with `IndexMode#getTimestampBound(...)`.
In order to reuse `IndexMode#getTimestampBound(...)` for the use case `IndexMode#getConfiguredTimestampRange(...)`
is reused a change had to be made to TimestampBounds.

During query rewrite and in `TimestampFieldMapperService` no `IndexScopedSettings` is available,
so made this an optional parameter. Only the usage in `IndexSettings` needs this, so that the
instance is updated in the case `index.time_series.end_time` setting is updated. In the case of
query rewrite and in `TimestampFieldMapperService` this isn't needed,  since the instance is
kept around and reused.

Followup from #85162