### PR TITLE
[Stack Monitoring] Switch cgroup memory fields to keyword

### DIFF
--- a/docs/changelog/88260.yaml
+++ b/docs/changelog/88260.yaml
@@ -1,0 +1,5 @@
+pr: 88260
+summary: "[Stack Monitoring] Switch cgroup memory fields to keyword"
+area: Monitoring
+type: bug
+issues: []

--- a/x-pack/plugin/core/src/main/resources/monitoring-es-mb.json
+++ b/x-pack/plugin/core/src/main/resources/monitoring-es-mb.json
@@ -732,14 +732,16 @@
                                 "usage": {
                                   "properties": {
                                     "bytes": {
-                                      "type": "long"
+                                      "ignore_above": 1024,
+                                      "type": "keyword"
                                     }
                                   }
                                 },
                                 "limit": {
                                   "properties": {
                                     "bytes": {
-                                      "type": "long"
+                                      "ignore_above": 1024,
+                                      "type": "keyword"
                                     }
                                   }
                                 }


### PR DESCRIPTION
Rel https://github.com/elastic/beats/issues/31765

Per https://www.elastic.co/guide/en/elasticsearch/reference/current/cluster-nodes-stats.html they should be strings. The internal collection template (monitoring-es.json) has them as keywords without any `ignore_above`.

This template uses `ignore_above` on all keywords, so keeping that convention for these mapping updates.

Opening as draft since we won't want to merge this until there's a corresponding beats change in place to match.

### Testing

So far I can't figure out how to get ES to respond with `max` in the cgroup memory setting:

```
$ curl -s -k -u elastic:'(password)' https://localhost:9200/_nodes/stats/os | jq '.nodes | values | .[].os.cgroup.memory'
{
  "control_group": "/",
  "limit_in_bytes": "9223372036854771712",
  "usage_in_bytes": "17973219328"
}
```

I'll need that before I can advise on how to test this.