### PR TITLE
Change UBI docker user to `elasticsearch`

### DIFF
--- a/distribution/docker/src/docker/Dockerfile
+++ b/distribution/docker/src/docker/Dockerfile
@@ -250,7 +250,7 @@ RUN mkdir /licenses && cp LICENSE.txt /licenses/LICENSE
 COPY LICENSE /licenses/LICENSE.addendum
 <% } %>
 
-<% if (docker_base == 'iron_bank') { %>
+<% if (docker_base == 'ubi' || docker_base == 'iron_bank') { %>
 USER elasticsearch:root
 <% } %>
 

--- a/docs/changelog/88262.yaml
+++ b/docs/changelog/88262.yaml
@@ -1,0 +1,6 @@
+pr: 88262
+summary: Change UBI docker user to `elasticsearch`
+area: Packaging
+type: enhancement
+issues:
+ - 88218

--- a/qa/os/src/test/java/org/elasticsearch/packaging/test/DockerTests.java
+++ b/qa/os/src/test/java/org/elasticsearch/packaging/test/DockerTests.java
@@ -920,8 +920,8 @@ public class DockerTests extends PackagingTestCase {
 
         String expectedUid;
         switch (distribution.packaging) {
-            case Packaging.DOCKER_IRON_BANK:
-            case Packaging.DOCKER_UBI:
+            case DOCKER_IRON_BANK:
+            case DOCKER_UBI:
                 expectedUid = "1000";
                 break;
             default:

--- a/qa/os/src/test/java/org/elasticsearch/packaging/test/DockerTests.java
+++ b/qa/os/src/test/java/org/elasticsearch/packaging/test/DockerTests.java
@@ -918,9 +918,20 @@ public class DockerTests extends PackagingTestCase {
 
         final String[] fields = processes.get(0).trim().split("\\s+", 4);
 
+        String expectedUid;
+        switch (distribution.packaging) {
+            case Packaging.DOCKER_IRON_BANK:
+            case Packaging.DOCKER_UBI:
+                expectedUid = "1000";
+                break;
+            default:
+                expectedUid = "0";
+                break;
+        }
+
         assertThat(fields, arrayWithSize(4));
         assertThat("Incorrect PID", fields[0], equalTo("1"));
-        assertThat("Incorrect UID", fields[1], equalTo(distribution.packaging == Packaging.DOCKER_IRON_BANK ? "1000" : "0"));
+        assertThat("Incorrect UID", fields[1], equalTo(expectedUid));
         assertThat("Incorrect GID", fields[2], equalTo("0"));
         assertThat("Incorrect init command", fields[3], startsWith("/bin/tini"));
     }


### PR DESCRIPTION
Closes #88218.

Docker image scans have flagged up the `USER` that the UBI Docker image
runs with. Switch to `elasticsearch:root`, which is what the Iron Bank
image also uses, and is what we use for all images from
8.0 onwards.