### PR TITLE
Clarify what to do if repo analysis fails

### DIFF
--- a/docs/reference/snapshot-restore/apis/repo-analysis-api.asciidoc
+++ b/docs/reference/snapshot-restore/apis/repo-analysis-api.asciidoc
@@ -63,6 +63,14 @@ You should run the analysis on a multi-node cluster of a similar size to your
 production cluster so that it can detect any problems that only arise when the
 repository is accessed by many nodes at once.
 
+If the analysis fails then {es} detected that your repository behaved
+unexpectedly. This usually means you are using a third-party storage system
+with an incorrect or incompatible implementation of the API it claims to
+support. If so, this storage system is not suitable for use as a snapshot
+repository. You will need to work with the supplier of your storage system to
+address the incompatibilities that {es} detects. See
+<<self-managed-repo-types>> for more information.
+
 If the analysis is successful this API returns details of the testing process,
 optionally including how long each operation took. You can use this information
 to determine the performance of your storage system. If any operation fails or


### PR DESCRIPTION
The docs for the repo analysis API don't really say how to react on a
failure. This commit adds a note about this case.