### PR TITLE
fix: extract matrix stats using bucket_selector buckets_path

### DIFF
--- a/docs/changelog/88271.yaml
+++ b/docs/changelog/88271.yaml
@@ -1,0 +1,6 @@
+pr: 88271
+summary: "Fix: extract matrix stats using `bucket_selector` `buckets_path`"
+area: Aggregations
+type: bug
+issues:
+ - 87454

--- a/modules/aggs-matrix-stats/src/main/java/org/elasticsearch/search/aggregations/matrix/stats/InternalMatrixStats.java
+++ b/modules/aggs-matrix-stats/src/main/java/org/elasticsearch/search/aggregations/matrix/stats/InternalMatrixStats.java
@@ -204,6 +204,26 @@ public class InternalMatrixStats extends InternalAggregation implements MatrixSt
     public Object getProperty(List<String> path) {
         if (path.isEmpty()) {
             return this;
+        } else if (path.size() == 2) {
+            if (results == null) {
+                return emptyMap();
+            }
+            final String field = path.get(0)
+                .replaceAll("^\"", "") // remove leading "
+                .replaceAll("^'", "") // remove leading '
+                .replaceAll("\"$", "") // remove trailing "
+                .replaceAll("'$", ""); // remove trailing '
+            final String element = path.get(1);
+            return switch (element) {
+                case "counts" -> results.getFieldCount(field);
+                case "means" -> results.getMean(field);
+                case "variances" -> results.getVariance(field);
+                case "skewness" -> results.getSkewness(field);
+                case "kurtosis" -> results.getKurtosis(field);
+                case "covariance" -> results.getCovariance(field, field);
+                case "correlation" -> results.getCorrelation(field, field);
+                default -> throw new IllegalArgumentException("Found unknown path element [" + element + "] in [" + getName() + "]");
+            };
         } else if (path.size() == 1) {
             String element = path.get(0);
             if (results == null) {

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/analytics/matrix_stats.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/analytics/matrix_stats.yml
@@ -148,3 +148,65 @@ setup:
   - match: { error.type: search_phase_execution_exception }
   - match: { error.caused_by.type: illegal_argument_exception }
   - match: { error.caused_by.reason: "Aggregation [stats] all fields must exist in all indices, but some indices are missing these fields [value3, value4]" }
+
+---
+"matrix stats with bucket_selector":
+  - skip:
+      version: " - 8.3.99"
+      reason: bug fixed in 8.4.0
+      features: close_to
+
+  - do:
+      search:
+        index: test1,test2
+        body:
+          size: 0
+          aggs:
+            matrix:
+              filters:
+                filters:
+                  - match_all: {}
+              aggs:
+                stats:
+                  matrix_stats:
+                    fields: ["value1", "value2"]
+                selector:
+                  bucket_selector:
+                    buckets_path:
+                      count: "stats[value1].counts"
+                      mean: "stats['value2'].means"
+                      variance: "stats['value1'].variances"
+                      skewness: "stats[value2].skewness"
+                      kurtosis: "stats[value1].kurtosis"
+                      covariance: "stats['value2'].covariance"
+                      correlation: "stats[value1].correlation"
+                    script:
+                      source: "params.count + params.mean + params.variance + params.skewness + params.kurtosis + params.covariance + params.correlation > params.threshold"
+                      lang: painless
+                      params:
+                        threshold: 1.0
+
+  - match: { hits.total.value: 6 }
+  - match: { hits.total.relation: "eq" }
+
+  - match: { aggregations.matrix.buckets.0.stats.fields.0.name: "value2" }
+  - match: { aggregations.matrix.buckets.0.stats.fields.0.count: 6 }
+  - close_to: { aggregations.matrix.buckets.0.stats.fields.0.mean: { value: 13.3333, error: 0.0001 } }
+  - close_to: { aggregations.matrix.buckets.0.stats.fields.0.variance: { value: 26.6666, error: 0.0001 } }
+  - close_to: { aggregations.matrix.buckets.0.stats.fields.0.skewness: { value: 0.7071, error: 0.0001 } }
+  - close_to: { aggregations.matrix.buckets.0.stats.fields.0.kurtosis: { value: 1.4999, error: 0.0001 } }
+  - close_to: { aggregations.matrix.buckets.0.stats.fields.0.covariance.value1: { value: 0.0, error: 0.0001 } }
+  - close_to: { aggregations.matrix.buckets.0.stats.fields.0.covariance.value2: { value: 26.6666, error: 0.0001 } }
+  - close_to: { aggregations.matrix.buckets.0.stats.fields.0.correlation.value1: { value: 0.0, error: 0.0001 } }
+  - close_to: { aggregations.matrix.buckets.0.stats.fields.0.correlation.value2: { value: 1.0, error: 0.0001 } }
+
+  - match: { aggregations.matrix.buckets.0.stats.fields.1.name: "value1" }
+  - match: { aggregations.matrix.buckets.0.stats.fields.1.count: 6 }
+  - close_to: { aggregations.matrix.buckets.0.stats.fields.1.mean: { value: 2.0, error: 0.0001 } }
+  - close_to: { aggregations.matrix.buckets.0.stats.fields.1.variance: { value: 0.8, error: 0.0001 } }
+  - close_to: { aggregations.matrix.buckets.0.stats.fields.1.skewness: { value: 0.0, error: 0.0001 } }
+  - close_to: { aggregations.matrix.buckets.0.stats.fields.1.kurtosis: { value: 1.5, error: 0.0001 } }
+  - close_to: { aggregations.matrix.buckets.0.stats.fields.1.covariance.value1: { value: 0.8, error: 0.0001 } }
+  - close_to: { aggregations.matrix.buckets.0.stats.fields.1.covariance.value2: { value: 0.0, error: 0.0001 } }
+  - close_to: { aggregations.matrix.buckets.0.stats.fields.1.correlation.value1: { value: 1.0, error: 0.0001 } }
+  - close_to: { aggregations.matrix.buckets.0.stats.fields.1.correlation.value2: { value: 0.0, error: 0.0001 } }


### PR DESCRIPTION
When using a `bucket_selector` and the `buckets_path`
to refer a matrix stats aggregation we need to use the
metric stats element and the field name to correctly extract
the referred value. Note also that, when extracting the
covariance and correlation values with notation
`stats[value1].covariance` or `stats[value1].correlation`
we extract `covariance[value1, value1]` and
`correlation[value1, value1]`. This patch does not address
extraction of arbitrary covariance and correlation values
such as `covariance[value1, value2]` or
`correlation[value1, value2]`.

Resolves #87454  
