### PR TITLE
Fix checkstyle version drift and API change

### DIFF
--- a/build-conventions/src/main/java/org/elasticsearch/gradle/internal/checkstyle/MissingJavadocTypeCheck.java
+++ b/build-conventions/src/main/java/org/elasticsearch/gradle/internal/checkstyle/MissingJavadocTypeCheck.java
@@ -32,8 +32,6 @@ import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
 import com.puppycrawl.tools.checkstyle.utils.ScopeUtil;
 
 import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
 import java.util.Set;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;

--- a/build-conventions/src/main/java/org/elasticsearch/gradle/internal/checkstyle/MissingJavadocTypeCheck.java
+++ b/build-conventions/src/main/java/org/elasticsearch/gradle/internal/checkstyle/MissingJavadocTypeCheck.java
@@ -59,7 +59,7 @@ public class MissingJavadocTypeCheck extends AbstractCheck {
     private Pattern ignorePattern = Pattern.compile("^$");
 
     /**
-     * Specify the list of annotations that allow missed documentation.
+     * Specify the set of annotations that allow missed documentation.
      * Only short names are allowed, e.g. {@code Generated}.
      */
     private Set<String> skipAnnotations = Set.of("Generated");

--- a/build-conventions/src/main/java/org/elasticsearch/gradle/internal/checkstyle/MissingJavadocTypeCheck.java
+++ b/build-conventions/src/main/java/org/elasticsearch/gradle/internal/checkstyle/MissingJavadocTypeCheck.java
@@ -34,7 +34,9 @@ import com.puppycrawl.tools.checkstyle.utils.ScopeUtil;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Set;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 /**
  * This is a copy of Checkstyle's {@link com.puppycrawl.tools.checkstyle.checks.javadoc.MissingJavadocTypeCheck},
@@ -62,7 +64,7 @@ public class MissingJavadocTypeCheck extends AbstractCheck {
      * Specify the list of annotations that allow missed documentation.
      * Only short names are allowed, e.g. {@code Generated}.
      */
-    private List<String> skipAnnotations = Collections.singletonList("Generated");
+    private Set<String> skipAnnotations = Set.of("Generated");
 
     /**
      * Setter to specify the visibility scope where Javadoc comments are checked.
@@ -89,7 +91,7 @@ public class MissingJavadocTypeCheck extends AbstractCheck {
      * @param userAnnotations user's value.
      */
     public void setSkipAnnotations(String... userAnnotations) {
-        skipAnnotations = Arrays.asList(userAnnotations);
+        skipAnnotations = Arrays.stream(userAnnotations).collect(Collectors.toSet());
     }
 
     /**
@@ -149,10 +151,7 @@ public class MissingJavadocTypeCheck extends AbstractCheck {
 
         return customScope.isIn(scope)
             && (surroundingScope == null || surroundingScope.isIn(scope))
-            && (excludeScope == null
-                || !customScope.isIn(excludeScope)
-                || surroundingScope != null
-                && !surroundingScope.isIn(excludeScope))
+            && (excludeScope == null || !customScope.isIn(excludeScope) || surroundingScope != null && !surroundingScope.isIn(excludeScope))
             && !AnnotationUtil.containsAnnotation(ast, skipAnnotations)
             && ignorePattern.matcher(outerTypeName).find() == false;
     }

--- a/gradle/build.versions.toml
+++ b/gradle/build.versions.toml
@@ -11,7 +11,7 @@ apache-rat = "org.apache.rat:apache-rat:0.11"
 asm = { group = "org.ow2.asm", name="asm", version.ref="asm" }
 asm-tree = { group = "org.ow2.asm", name="asm-tree", version.ref="asm" }
 bytebuddy = "net.bytebuddy:byte-buddy:1.12.10"
-checkstyle = "com.puppycrawl.tools:checkstyle:10.1"
+checkstyle = "com.puppycrawl.tools:checkstyle:10.3"
 commons-codec = "commons-codec:commons-codec:1.11"
 commmons-io = "commons-io:commons-io:2.2"
 docker-compose = "com.avast.gradle:gradle-docker-compose-plugin:0.14.13"


### PR DESCRIPTION
It turns out we have the Checkstyle version in 2 places:

   * `build-tools-internal/version.properties`
   * `gradle/build.versions.toml`

This concealed that there was an API change between 10.1 and 10.3, and we needed to update one of our custom checks.