### PR TITLE
Don't fail validation on archived settings

### DIFF
--- a/docs/changelog/88286.yaml
+++ b/docs/changelog/88286.yaml
@@ -1,0 +1,6 @@
+pr: 88286
+summary: Don't fail validation on archived settings
+area: Infra/Settings
+type: bug
+issues:
+ - 86022

--- a/server/src/internalClusterTest/java/org/elasticsearch/cluster/settings/ClusterSettingsIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/cluster/settings/ClusterSettingsIT.java
@@ -402,17 +402,6 @@ public class ClusterSettingsIT extends ESIntegTestCase {
         state = client().admin().cluster().prepareState().get().getState();
         assertTrue(state.getMetadata().persistentSettings().getAsBoolean("archived.this.is.unknown", false));
 
-        // cannot remove read only block due to archived settings
-        final IllegalArgumentException e1 = expectThrows(IllegalArgumentException.class, () -> {
-            Settings.Builder builder = Settings.builder();
-            clearOrSetFalse(builder, readOnly, Metadata.SETTING_READ_ONLY_SETTING);
-            clearOrSetFalse(builder, readOnlyAllowDelete, Metadata.SETTING_READ_ONLY_ALLOW_DELETE_SETTING);
-            assertAcked(
-                client().admin().cluster().prepareUpdateSettings().setPersistentSettings(builder).setTransientSettings(builder).get()
-            );
-        });
-        assertTrue(e1.getMessage().contains("unknown setting [archived.this.is.unknown]"));
-
         // fail to clear archived settings with non-archived settings
         final ClusterBlockException e2 = expectThrows(
             ClusterBlockException.class,

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/settings/SettingsUpdater.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/settings/SettingsUpdater.java
@@ -89,8 +89,8 @@ final class SettingsUpdater {
             Settings persistentFinalSettings = persistentSettings.build();
             // both transient and persistent settings must be consistent by itself we can't allow dependencies to be
             // in either of them otherwise a full cluster restart will break the settings validation
-            clusterSettings.validate(transientFinalSettings, true);
-            clusterSettings.validate(persistentFinalSettings, true);
+            clusterSettings.validate(transientFinalSettings, true, false, true);
+            clusterSettings.validate(persistentFinalSettings, true, false, true);
 
             Metadata.Builder metadata = Metadata.builder(currentState.metadata())
                 .transientSettings(Settings.builder().put(transientFinalSettings).put(unknownOrInvalidTransientSettings).build())


### PR DESCRIPTION
Skip validating existing archived settings in SettingsUpdater. This is consistent with how
we treat any newly archived settings.

Closes #86022