### PR TITLE
[ML] fixing bwc for trained model deployment inference

### DIFF
--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/assignment/TrainedModelAssignmentMetadata.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/assignment/TrainedModelAssignmentMetadata.java
@@ -129,7 +129,7 @@ public class TrainedModelAssignmentMetadata implements Metadata.Custom {
 
     @Override
     public Version getMinimalSupportedVersion() {
-        return Version.V_8_3_0;
+        return Version.V_8_0_0;
     }
 
     @Override
@@ -274,7 +274,7 @@ public class TrainedModelAssignmentMetadata implements Metadata.Custom {
 
         @Override
         public Version getMinimalSupportedVersion() {
-            return Version.V_8_3_0;
+            return Version.V_8_0_0;
         }
 
         @Override

--- a/x-pack/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/MLModelDeploymentsUpgradeIT.java
+++ b/x-pack/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/MLModelDeploymentsUpgradeIT.java
@@ -8,7 +8,6 @@
 package org.elasticsearch.upgrades;
 
 import org.apache.http.util.EntityUtils;
-import org.apache.lucene.tests.util.LuceneTestCase;
 import org.elasticsearch.Version;
 import org.elasticsearch.client.Request;
 import org.elasticsearch.client.Response;
@@ -30,7 +29,6 @@ import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
 
-@LuceneTestCase.AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/87959")
 public class MLModelDeploymentsUpgradeIT extends AbstractUpgradeTestCase {
 
     // See PyTorchModelIT for how this model was created
@@ -113,8 +111,10 @@ public class MLModelDeploymentsUpgradeIT extends AbstractUpgradeTestCase {
                     request.addParameter("timeout", "70s");
                 }));
                 waitForDeploymentStarted(modelId);
-                assertInfer(modelId);
-                assertInfer(modelId);
+                // attempt inference on new and old nodes multiple times
+                for (int i = 0; i < 100; i++) {
+                    assertInfer(modelId);
+                }
             }
             case UPGRADED -> {
                 ensureHealth(".ml-inference-*,.ml-config*", (request -> {

--- a/x-pack/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/MLModelDeploymentsUpgradeIT.java
+++ b/x-pack/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/MLModelDeploymentsUpgradeIT.java
@@ -112,7 +112,7 @@ public class MLModelDeploymentsUpgradeIT extends AbstractUpgradeTestCase {
                 }));
                 waitForDeploymentStarted(modelId);
                 // attempt inference on new and old nodes multiple times
-                for (int i = 0; i < 100; i++) {
+                for (int i = 0; i < 10; i++) {
                     assertInfer(modelId);
                 }
             }


### PR DESCRIPTION
When the internal objects were renamed, an inappropriate bwc version restriction was put in place.

This commit fixes this by allowing trained model assignment metadata updates to be serialized to nodes > 8.0.0. 

This is OK as the object serialization handles its BWC conditions when serializing over the wire. 

This closes: https://github.com/elastic/elasticsearch/issues/87959