### PR TITLE
Remove ImmutableOpenMap from rollup tests

### DIFF
--- a/x-pack/plugin/rollup/src/test/java/org/elasticsearch/xpack/rollup/action/GetRollupCapsActionRequestTests.java
+++ b/x-pack/plugin/rollup/src/test/java/org/elasticsearch/xpack/rollup/action/GetRollupCapsActionRequestTests.java
@@ -9,7 +9,6 @@ package org.elasticsearch.xpack.rollup.action;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.metadata.MappingMetadata;
 import org.elasticsearch.cluster.metadata.Metadata;
-import org.elasticsearch.common.collect.ImmutableOpenMap;
 import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.test.AbstractWireSerializingTestCase;
@@ -129,14 +128,13 @@ public class GetRollupCapsActionRequestTests extends AbstractWireSerializingTest
     }
 
     public void testNoIndices() {
-        ImmutableOpenMap<String, IndexMetadata> indices = new ImmutableOpenMap.Builder<String, IndexMetadata>().build();
-        Map<String, RollableIndexCaps> caps = TransportGetRollupCapsAction.getCaps("foo", indices);
+        Map<String, RollableIndexCaps> caps = TransportGetRollupCapsAction.getCaps("foo", Map.of());
         assertThat(caps.size(), equalTo(0));
     }
 
     public void testAllIndices() throws IOException {
         int num = randomIntBetween(1, 5);
-        ImmutableOpenMap.Builder<String, IndexMetadata> indices = new ImmutableOpenMap.Builder<>(5);
+        Map<String, IndexMetadata> indices = Maps.newMapWithExpectedSize(5);
         int indexCounter = 0;
         for (int j = 0; j < 5; j++) {
 
@@ -161,13 +159,13 @@ public class GetRollupCapsActionRequestTests extends AbstractWireSerializingTest
             indices.put(randomAlphaOfLength(10), meta);
         }
 
-        Map<String, RollableIndexCaps> caps = TransportGetRollupCapsAction.getCaps(Metadata.ALL, indices.build());
+        Map<String, RollableIndexCaps> caps = TransportGetRollupCapsAction.getCaps(Metadata.ALL, indices);
         assertThat(caps.size(), equalTo(num * 5));
     }
 
     public void testOneIndex() throws IOException {
         int num = randomIntBetween(1, 5);
-        ImmutableOpenMap.Builder<String, IndexMetadata> indices = new ImmutableOpenMap.Builder<>(5);
+        Map<String, IndexMetadata> indices = Maps.newMapWithExpectedSize(5);
         String selectedIndexName = null;
         for (int j = 0; j < 5; j++) {
             String indexName = randomAlphaOfLength(10);
@@ -195,7 +193,7 @@ public class GetRollupCapsActionRequestTests extends AbstractWireSerializingTest
             indices.put(indexName, meta);
         }
 
-        Map<String, RollableIndexCaps> caps = TransportGetRollupCapsAction.getCaps(selectedIndexName, indices.build());
+        Map<String, RollableIndexCaps> caps = TransportGetRollupCapsAction.getCaps(selectedIndexName, indices);
         assertThat(caps.size(), equalTo(1));
     }
 

--- a/x-pack/plugin/rollup/src/test/java/org/elasticsearch/xpack/rollup/action/GetRollupIndexCapsActionRequestTests.java
+++ b/x-pack/plugin/rollup/src/test/java/org/elasticsearch/xpack/rollup/action/GetRollupIndexCapsActionRequestTests.java
@@ -9,7 +9,6 @@ package org.elasticsearch.xpack.rollup.action;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.metadata.MappingMetadata;
 import org.elasticsearch.cluster.metadata.Metadata;
-import org.elasticsearch.common.collect.ImmutableOpenMap;
 import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.test.AbstractWireSerializingTestCase;
@@ -43,14 +42,13 @@ public class GetRollupIndexCapsActionRequestTests extends AbstractWireSerializin
     }
 
     public void testNoIndicesByRollup() {
-        ImmutableOpenMap<String, IndexMetadata> indices = new ImmutableOpenMap.Builder<String, IndexMetadata>().build();
-        Map<String, RollableIndexCaps> caps = getCapsByRollupIndex(Collections.singletonList("foo"), indices);
+        Map<String, RollableIndexCaps> caps = getCapsByRollupIndex(Collections.singletonList("foo"), Map.of());
         assertThat(caps.size(), equalTo(0));
     }
 
     public void testAllIndicesByRollupSingleRollup() throws IOException {
         int num = randomIntBetween(1, 5);
-        ImmutableOpenMap.Builder<String, IndexMetadata> indices = new ImmutableOpenMap.Builder<>(5);
+        Map<String, IndexMetadata> indices = Maps.newMapWithExpectedSize(5);
         int indexCounter = 0;
         for (int j = 0; j < 5; j++) {
 
@@ -75,12 +73,12 @@ public class GetRollupIndexCapsActionRequestTests extends AbstractWireSerializin
             indices.put("foo", meta);
         }
 
-        Map<String, RollableIndexCaps> caps = getCapsByRollupIndex(Collections.singletonList("foo"), indices.build());
+        Map<String, RollableIndexCaps> caps = getCapsByRollupIndex(Collections.singletonList("foo"), indices);
         assertThat(caps.size(), equalTo(1));
     }
 
     public void testAllIndicesByRollupManyRollup() throws IOException {
-        ImmutableOpenMap.Builder<String, IndexMetadata> indices = new ImmutableOpenMap.Builder<>(5);
+        Map<String, IndexMetadata> indices = Maps.newMapWithExpectedSize(5);
         int indexCounter = 0;
         for (int j = 0; j < 5; j++) {
 
@@ -103,12 +101,12 @@ public class GetRollupIndexCapsActionRequestTests extends AbstractWireSerializin
             indices.put("rollup_" + indexName, meta);
         }
 
-        Map<String, RollableIndexCaps> caps = getCapsByRollupIndex(Arrays.asList(indices.keys().toArray(new String[0])), indices.build());
+        Map<String, RollableIndexCaps> caps = getCapsByRollupIndex(Arrays.asList(indices.keySet().toArray(new String[0])), indices);
         assertThat(caps.size(), equalTo(5));
     }
 
     public void testOneIndexByRollupManyRollup() throws IOException {
-        ImmutableOpenMap.Builder<String, IndexMetadata> indices = new ImmutableOpenMap.Builder<>(5);
+        Map<String, IndexMetadata> indices = Maps.newMapWithExpectedSize(5);
         int indexCounter = 0;
         for (int j = 0; j < 5; j++) {
 
@@ -131,14 +129,14 @@ public class GetRollupIndexCapsActionRequestTests extends AbstractWireSerializin
             indices.put("rollup_" + indexName, meta);
         }
 
-        Map<String, RollableIndexCaps> caps = getCapsByRollupIndex(Collections.singletonList("rollup_1"), indices.build());
+        Map<String, RollableIndexCaps> caps = getCapsByRollupIndex(Collections.singletonList("rollup_1"), indices);
         assertThat(caps.size(), equalTo(1));
         assertThat(caps.get("rollup_1").getIndexName(), equalTo("rollup_1"));
         assertThat(caps.get("rollup_1").getJobCaps().size(), equalTo(1));
     }
 
     public void testOneIndexByRollupOneRollup() throws IOException {
-        ImmutableOpenMap.Builder<String, IndexMetadata> indices = new ImmutableOpenMap.Builder<>(5);
+        Map<String, IndexMetadata> indices = Maps.newMapWithExpectedSize(5);
         int indexCounter = 0;
         for (int j = 0; j < 5; j++) {
 
@@ -161,7 +159,7 @@ public class GetRollupIndexCapsActionRequestTests extends AbstractWireSerializin
             indices.put("rollup_foo", meta);
         }
 
-        Map<String, RollableIndexCaps> caps = getCapsByRollupIndex(Collections.singletonList("rollup_foo"), indices.build());
+        Map<String, RollableIndexCaps> caps = getCapsByRollupIndex(Collections.singletonList("rollup_foo"), indices);
         assertThat(caps.size(), equalTo(1));
         assertThat(caps.get("rollup_foo").getIndexName(), equalTo("rollup_foo"));
         assertThat(caps.get("rollup_foo").getJobCaps().size(), equalTo(1));


### PR DESCRIPTION
Some tests for rollup were still using ImmutableOpenMap for testing
internal methods, even though those methods were already converted to
Map. This commit changes those tests to use Map.

relates #86239