### PR TITLE
Print full exception when console is non-interactive

### DIFF
--- a/docs/changelog/88297.yaml
+++ b/docs/changelog/88297.yaml
@@ -1,0 +1,5 @@
+pr: 88297
+summary: Print full exception when console is non-interactive
+area: Infra/Core
+type: enhancement
+issues: []

--- a/server/src/main/java/org/elasticsearch/bootstrap/BootstrapInfo.java
+++ b/server/src/main/java/org/elasticsearch/bootstrap/BootstrapInfo.java
@@ -9,6 +9,7 @@
 package org.elasticsearch.bootstrap;
 
 import org.apache.lucene.util.SetOnce;
+import org.elasticsearch.core.Nullable;
 import org.elasticsearch.core.SuppressForbidden;
 
 import java.util.Dictionary;
@@ -50,8 +51,10 @@ public final class BootstrapInfo {
     }
 
     /**
-     * Returns a reference to a stream attached to Standard Output, iff we have determined that stdout is a console (tty)
+     * Returns information about the console (tty) attached to the server process, or {@code null}
+     * if no console is attached.
      */
+    @Nullable
     public static ConsoleLoader.Console getConsole() {
         return console.get();
     }
@@ -143,7 +146,7 @@ public final class BootstrapInfo {
 
     public static void init() {}
 
-    static void setConsole(ConsoleLoader.Console console) {
+    static void setConsole(@Nullable ConsoleLoader.Console console) {
         BootstrapInfo.console.set(console);
     }
 

--- a/server/src/main/java/org/elasticsearch/common/logging/ConsoleThrowablePatternConverter.java
+++ b/server/src/main/java/org/elasticsearch/common/logging/ConsoleThrowablePatternConverter.java
@@ -14,17 +14,25 @@ import org.apache.logging.log4j.core.config.plugins.Plugin;
 import org.apache.logging.log4j.core.pattern.ConverterKeys;
 import org.apache.logging.log4j.core.pattern.PatternConverter;
 import org.apache.logging.log4j.core.pattern.ThrowablePatternConverter;
+import org.elasticsearch.bootstrap.BootstrapInfo;
 import org.elasticsearch.bootstrap.StartupException;
 import org.elasticsearch.common.inject.CreationException;
 
 /**
- * Outputs a very short version of exceptions for the console, pointing to full log for details.
+ * Outputs a very short version of exceptions for an interactive console, pointing to full log for details.
+ *
+ * <p> If a non-interactive console is attached, the full exception is always printed.
  */
 @Plugin(name = "consoleException", category = PatternConverter.CATEGORY)
 @ConverterKeys({ "consoleException" })
 public class ConsoleThrowablePatternConverter extends ThrowablePatternConverter {
-    private ConsoleThrowablePatternConverter(String[] options, Configuration config) {
+
+    // true if exceptions shoudwhether exception formatting should always be delegated to the super class
+    private final boolean enabled;
+
+    private ConsoleThrowablePatternConverter(String[] options, Configuration config, boolean enabled) {
         super("ConsoleThrowablePatternConverter", "throwable", options, config);
+        this.enabled = enabled;
     }
 
     /**
@@ -34,13 +42,18 @@ public class ConsoleThrowablePatternConverter extends ThrowablePatternConverter 
      * @return instance of class.
      */
     public static ConsoleThrowablePatternConverter newInstance(final Configuration config, final String[] options) {
-        return new ConsoleThrowablePatternConverter(options, config);
+        return newInstance(config, options, BootstrapInfo.getConsole() != null);
+    }
+
+    // package private for tests
+    static ConsoleThrowablePatternConverter newInstance(final Configuration config, final String[] options, boolean enabled) {
+        return new ConsoleThrowablePatternConverter(options, config, enabled);
     }
 
     @Override
     public void format(final LogEvent event, final StringBuilder toAppendTo) {
         Throwable error = event.getThrown();
-        if (error == null) {
+        if (enabled == false | error == null) {
             super.format(event, toAppendTo);
             return;
         }
@@ -48,6 +61,7 @@ public class ConsoleThrowablePatternConverter extends ThrowablePatternConverter 
             error = e.getCause();
             toAppendTo.append("\n\nElasticsearch failed to startup normally.\n\n");
         }
+
         appendShortStacktrace(error, toAppendTo);
         if (error instanceof CreationException) {
             toAppendTo.append("There were problems initializing Guice. See log for more details.");

--- a/server/src/main/java/org/elasticsearch/common/logging/ConsoleThrowablePatternConverter.java
+++ b/server/src/main/java/org/elasticsearch/common/logging/ConsoleThrowablePatternConverter.java
@@ -27,7 +27,7 @@ import org.elasticsearch.common.inject.CreationException;
 @ConverterKeys({ "consoleException" })
 public class ConsoleThrowablePatternConverter extends ThrowablePatternConverter {
 
-    // true if exceptions shoudwhether exception formatting should always be delegated to the super class
+    // true if exceptions should be truncated, false if they should be delegated to the super class
     private final boolean enabled;
 
     private ConsoleThrowablePatternConverter(String[] options, Configuration config, boolean enabled) {


### PR DESCRIPTION
The console logger truncates stack traces so a user is not bombarded
with enormouse messages on startup. However, when the output is
redirected to a file, there is no need to avoid large messages, and in
fact it is a hinderance to debugging. This commit adds an internal flag
to the console logging exception convert which disables the truncation
when attached to a non-interactive console.