### PR TITLE
Fixed NullPointerException on bulk request

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/bulk/Retry.java
+++ b/server/src/main/java/org/elasticsearch/action/bulk/Retry.java
@@ -195,7 +195,7 @@ public class Retry {
         private BulkResponse getAccumulatedResponse() {
             BulkItemResponse[] itemResponses;
             synchronized (responses) {
-                itemResponses = responses.toArray(new BulkItemResponse[1]);
+                itemResponses = responses.toArray(new BulkItemResponse[0]);
             }
             long stopTimestamp = System.nanoTime();
             long totalLatencyMs = TimeValue.timeValueNanos(stopTimestamp - startTimestampNanos).millis();


### PR DESCRIPTION
Java's `ArrayList.toArray()` returns provided array when collection is empty.

Here is created a one-element array which contains null element.

Thus, returned `BulkResponse` may contains a null element as `BulkItemResponse`.

How to achieve:
1. Sent a request to `/_bulk?filter_path=took,errors`
2. call inside `BulkProcessor.Listener` a `BulkResponse.hasFailures()`
