### PR TITLE
Fix performance regression in DataTierAllocationDecider

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/cluster/routing/allocation/DataTierAllocationDecider.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/cluster/routing/allocation/DataTierAllocationDecider.java
@@ -215,13 +215,23 @@ public final class DataTierAllocationDecider extends AllocationDecider {
     static boolean tierNodesPresent(String singleTier, Collection<DesiredNode> nodes) {
         assert singleTier.equals(DiscoveryNodeRole.DATA_ROLE.roleName()) || DataTier.validTierName(singleTier)
             : "tier " + singleTier + " is an invalid tier name";
-        return nodes.stream().anyMatch(node -> allocationAllowed(singleTier, node.getRoles()));
+        for (DesiredNode node : nodes) {
+            if (allocationAllowed(singleTier, node.getRoles())) {
+                return true;
+            }
+        }
+        return false;
     }
 
     static boolean tierNodesPresent(String singleTier, DiscoveryNodes nodes) {
         assert singleTier.equals(DiscoveryNodeRole.DATA_ROLE.roleName()) || DataTier.validTierName(singleTier)
             : "tier " + singleTier + " is an invalid tier name";
-        return nodes.stream().anyMatch(node -> allocationAllowed(singleTier, node.getRoles()));
+        for (DiscoveryNode node : nodes) {
+            if (allocationAllowed(singleTier, node.getRoles())) {
+                return true;
+            }
+        }
+        return false;
     }
 
     private static boolean allocationAllowed(String tierName, Set<DiscoveryNodeRole> roles) {


### PR DESCRIPTION
In #87735 we moved to using streams here. This results in a visible
regression in the many shards benchmarks that gets bigger the larger
the cluster is.
Using streams here adds a lot of alloction and indirection but does not
come with any advantages since `DiscoveryNodes` does not implement
`stream` so it's just an indirection on top of the existing iterator
that gets instantiated for every shard and then runs a compartively
short loop over the nodes.

-> move this back to iterator

relates #77466