### PR TITLE
Don't remove any field starting with _ in RemoveProcessorTests

### DIFF
--- a/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/RemoveProcessorTests.java
+++ b/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/RemoveProcessorTests.java
@@ -28,8 +28,10 @@ public class RemoveProcessorTests extends ESTestCase {
 
     public void testRemoveFields() throws Exception {
         IngestDocument ingestDocument = RandomDocumentPicks.randomIngestDocument(random());
-        String field = randomValueOtherThanMany(name -> name.startsWith("_"),
-            () -> RandomDocumentPicks.randomExistingFieldName(random(), ingestDocument));
+        String field = randomValueOtherThanMany(
+            name -> name.startsWith("_"),
+            () -> RandomDocumentPicks.randomExistingFieldName(random(), ingestDocument)
+        );
         Processor processor = new RemoveProcessor(
             randomAlphaOfLength(10),
             null,

--- a/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/RemoveProcessorTests.java
+++ b/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/RemoveProcessorTests.java
@@ -28,7 +28,8 @@ public class RemoveProcessorTests extends ESTestCase {
 
     public void testRemoveFields() throws Exception {
         IngestDocument ingestDocument = RandomDocumentPicks.randomIngestDocument(random());
-        String field = RandomDocumentPicks.randomExistingFieldName(random(), ingestDocument);
+        String field = randomValueOtherThanMany(name -> name.startsWith("_"),
+            () -> RandomDocumentPicks.randomExistingFieldName(random(), ingestDocument));
         Processor processor = new RemoveProcessor(
             randomAlphaOfLength(10),
             null,


### PR DESCRIPTION
This commit fixes an issue where `_version` was trying to be removed from a document, and causing  the validation to fail the test. For this test, we should not remove any field starting with `_`.

Resolves #88182
