### PR TITLE
Expand local JDBC driver compatibility testing on Apple Silicon

### DIFF
--- a/x-pack/plugin/sql/qa/jdbc/build.gradle
+++ b/x-pack/plugin/sql/qa/jdbc/build.gradle
@@ -72,7 +72,9 @@ subprojects {
 
     // Configure compatibility testing tasks
     // Compatibility testing for JDBC driver started with version 7.9.0
-    BuildParams.bwcVersions.withIndexCompatible({ it.onOrAfter(Version.fromString("7.9.0")) && it != VersionProperties.elasticsearchVersion }) { bwcVersion, baseName ->
+    BuildParams.bwcVersions.allIndexCompatible.findAll({ it.onOrAfter(Version.fromString("7.9.0")) && it != VersionProperties.elasticsearchVersion }).each { bwcVersion ->
+      def baseName = "v${bwcVersion}"
+
       UnreleasedVersionInfo unreleasedVersion = BuildParams.bwcVersions.unreleasedInfo(bwcVersion)
       Configuration driverConfiguration = configurations.create("jdbcDriver${baseName}") {
         // TODO: Temporary workaround for https://github.com/elastic/elasticsearch/issues/73433


### PR DESCRIPTION
Ensure that all possible versions of the JDBC driver are testable on Apple Silicon macs. The issue here is that the `withIndexCompatible` API automatically filters out Elasticsearch versions no compatible on ARM-based macs. That's actually not applicable here, since the artifact under test is the JDBC driver, not Elasticsearch itself, so this filter isn't required.