### PR TITLE
Check for deprecated monitoring auth.password in cluster settings

### DIFF
--- a/docs/changelog/88351.yaml
+++ b/docs/changelog/88351.yaml
@@ -1,12 +1,12 @@
 pr: 88351
-summary: Set archived cluster settings deprecation level as critical
+summary: Set monitoring auth.password cluster settings deprecation level as critical
 area: Infra/Core
 type: deprecation
 issues:
  - 86022
 deprecation:
-  title: Set archived cluster settings deprecation level as critical
+  title: Set monitoring auth.password cluster settings deprecation level as critical
   area: Cluster and node setting
-  details: Changing the deprecation level for the monitoring settings from 
-    WARN to CRITICAL.
-  impact: The upgrade assistant will block 8.0 upgrades intead of only warn.
+  details: Changing the deprecation level for the monitoring auth.password settings in cluster state
+    to CRITICAL.
+  impact: The upgrade assistant will block 8.0 upgrades on monitoring auth.password set in cluster state.

--- a/docs/changelog/88351.yaml
+++ b/docs/changelog/88351.yaml
@@ -1,0 +1,12 @@
+pr: 88351
+summary: Set archived cluster settings deprecation level as critical
+area: Infra/Core
+type: deprecation
+issues:
+ - 86022
+deprecation:
+  title: Set archived cluster settings deprecation level as critical
+  area: Infra/Core
+  details: Please describe the details of this change for the release notes. You can
+    use asciidoc.
+  impact: Please describe the impact of this change to users

--- a/docs/changelog/88351.yaml
+++ b/docs/changelog/88351.yaml
@@ -6,7 +6,7 @@ issues:
  - 86022
 deprecation:
   title: Set archived cluster settings deprecation level as critical
-  area: Infra/Core
-  details: Please describe the details of this change for the release notes. You can
-    use asciidoc.
-  impact: Please describe the impact of this change to users
+  area: Cluster and node setting
+  details: Changing the deprecation level for the monitoring settings from 
+    WARN to CRITICAL.
+  impact: The upgrade assistant will block 8.0 upgrades intead of only warn.

--- a/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/NodeDeprecationChecks.java
+++ b/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/NodeDeprecationChecks.java
@@ -555,6 +555,7 @@ class NodeDeprecationChecks {
     }
 
     static DeprecationIssue checkDeprecatedSetting(
+        DeprecationIssue.Level level,
         final Settings clusterSettings,
         final Settings nodeSettings,
         final Setting<?> deprecatedSetting,
@@ -571,7 +572,7 @@ class NodeDeprecationChecks {
         final String message = String.format(Locale.ROOT, "Setting [%s] is deprecated", deprecatedSettingKey);
         final String details = String.format(Locale.ROOT, "Remove the [%s] setting.", deprecatedSettingKey, value);
         final Map<String, Object> meta = createMetaMapForRemovableSettings(canAutoRemoveSetting, deprecatedSettingKey);
-        return new DeprecationIssue(DeprecationIssue.Level.WARNING, message, url, details, false, meta);
+        return new DeprecationIssue(level, message, url, details, false, meta);
     }
 
     private static Map<String, Object> createMetaMapForRemovableSettings(boolean canAutoRemoveSetting, String removableSetting) {
@@ -1543,7 +1544,13 @@ class NodeDeprecationChecks {
         final Settings nodeSettings,
         final Setting<?> deprecated
     ) {
-        return checkDeprecatedSetting(clusterState.metadata().settings(), nodeSettings, deprecated, MONITORING_SETTING_DEPRECATION_LINK);
+        return checkDeprecatedSetting(
+            DeprecationIssue.Level.CRITICAL,
+            clusterState.metadata().settings(),
+            nodeSettings,
+            deprecated,
+            MONITORING_SETTING_DEPRECATION_LINK
+        );
     }
 
     static DeprecationIssue genericMonitoringAffixSetting(
@@ -1559,7 +1566,7 @@ class NodeDeprecationChecks {
             ),
             "Remove the following settings: [%s]",
             MONITORING_SETTING_DEPRECATION_LINK,
-            DeprecationIssue.Level.WARNING,
+            DeprecationIssue.Level.CRITICAL,
             clusterSettings,
             nodeSettings
         );
@@ -1574,7 +1581,7 @@ class NodeDeprecationChecks {
             Setting.affixKeySetting("xpack.monitoring.exporters.", deprecatedSuffix, k -> SecureSetting.secureString(k, null)),
             "Remove the following settings from the keystore: [%s]",
             MONITORING_SETTING_DEPRECATION_LINK,
-            DeprecationIssue.Level.WARNING,
+            DeprecationIssue.Level.CRITICAL,
             clusterSettings,
             nodeSettings
         );
@@ -1589,7 +1596,7 @@ class NodeDeprecationChecks {
             Setting.affixKeySetting("xpack.monitoring.exporters.", deprecatedSuffix, k -> Setting.groupSetting(k + ".")),
             "Remove the following settings: [%s]",
             MONITORING_SETTING_DEPRECATION_LINK,
-            DeprecationIssue.Level.WARNING,
+            DeprecationIssue.Level.CRITICAL,
             clusterSettings,
             nodeSettings
         );
@@ -1888,7 +1895,7 @@ class NodeDeprecationChecks {
             Setting.affixKeySetting("xpack.monitoring.exporters.", "use_ingest", key -> Setting.boolSetting(key, true)),
             "Remove the following settings: [%s]",
             "https://ela.st/es-deprecation-7-monitoring-exporter-use-ingest-setting",
-            DeprecationIssue.Level.WARNING,
+            DeprecationIssue.Level.CRITICAL,
             clusterState.metadata().settings(),
             settings
         );
@@ -1908,7 +1915,7 @@ class NodeDeprecationChecks {
             ),
             "Remove the following settings: [%s]",
             "https://ela.st/es-deprecation-7-monitoring-exporter-pipeline-timeout-setting",
-            DeprecationIssue.Level.WARNING,
+            DeprecationIssue.Level.CRITICAL,
             clusterState.metadata().settings(),
             settings
         );
@@ -1928,7 +1935,7 @@ class NodeDeprecationChecks {
             ),
             "Remove the following settings: [%s]",
             "https://ela.st/es-deprecation-7-monitoring-exporter-create-legacy-template-setting",
-            DeprecationIssue.Level.WARNING,
+            DeprecationIssue.Level.CRITICAL,
             clusterState.metadata().settings(),
             settings
         );

--- a/x-pack/plugin/deprecation/src/test/java/org/elasticsearch/xpack/deprecation/NodeDeprecationChecksTests.java
+++ b/x-pack/plugin/deprecation/src/test/java/org/elasticsearch/xpack/deprecation/NodeDeprecationChecksTests.java
@@ -961,6 +961,9 @@ public class NodeDeprecationChecksTests extends ESTestCase {
     }
 
     public void testCheckSearchRemoteSettings() {
+        DiscoveryNode node1 = new DiscoveryNode(randomAlphaOfLength(5), buildNewFakeTransportAddress(), Version.CURRENT);
+        ClusterState state = ClusterStateCreationUtils.state(node1, node1, node1);
+
         // test for presence of deprecated exporter passwords
         final int numClusters = randomIntBetween(1, 3);
         final String[] clusterNames = new String[numClusters];
@@ -1011,7 +1014,7 @@ public class NodeDeprecationChecksTests extends ESTestCase {
         );
 
         // test for absence of deprecated exporter passwords
-        issue = NodeDeprecationChecks.checkMonitoringExporterPassword(Settings.builder().build(), null, null, licenseState);
+        issue = NodeDeprecationChecks.checkMonitoringExporterPassword(Settings.builder().build(), null, state, licenseState);
         assertThat(issue, nullValue());
     }
 

--- a/x-pack/plugin/deprecation/src/test/java/org/elasticsearch/xpack/deprecation/NodeDeprecationChecksTests.java
+++ b/x-pack/plugin/deprecation/src/test/java/org/elasticsearch/xpack/deprecation/NodeDeprecationChecksTests.java
@@ -889,6 +889,9 @@ public class NodeDeprecationChecksTests extends ESTestCase {
     }
 
     public void testMonitoringExporterPassword() {
+        DiscoveryNode node1 = new DiscoveryNode(randomAlphaOfLength(5), buildNewFakeTransportAddress(), Version.CURRENT);
+        ClusterState state = ClusterStateCreationUtils.state(node1, node1, node1);
+
         // test for presence of deprecated exporter passwords
         final int numExporterPasswords = randomIntBetween(1, 3);
         final String[] exporterNames = new String[numExporterPasswords];
@@ -899,7 +902,7 @@ public class NodeDeprecationChecksTests extends ESTestCase {
         }
         final Settings settings = b.build();
         final XPackLicenseState licenseState = new XPackLicenseState(Settings.EMPTY, () -> 0);
-        DeprecationIssue issue = NodeDeprecationChecks.checkMonitoringExporterPassword(settings, null, null, licenseState);
+        DeprecationIssue issue = NodeDeprecationChecks.checkMonitoringExporterPassword(settings, null, state, licenseState);
         final String expectedUrl = "https://ela.st/es-deprecation-7-monitoring-exporter-passwords";
         final String joinedNames = Arrays.stream(exporterNames)
             .map(s -> "xpack.monitoring.exporters." + s + ".auth.password")
@@ -926,7 +929,7 @@ public class NodeDeprecationChecksTests extends ESTestCase {
         );
 
         // test for absence of deprecated exporter passwords
-        issue = NodeDeprecationChecks.checkMonitoringExporterPassword(Settings.builder().build(), null, null, licenseState);
+        issue = NodeDeprecationChecks.checkMonitoringExporterPassword(Settings.builder().build(), null, state, licenseState);
         assertThat(issue, nullValue());
     }
 


### PR DESCRIPTION
The monitoring auth.password setting was only being checked for CRITICAL deprecation in node settings, however cloud sets it in cluster settings. This PR changes the code so that both node and cluster settings verify the existence of the monitoring auth.password setting.

Fixes #86022