### PR TITLE
Configure all loggers without config

### DIFF
--- a/distribution/tools/cli-launcher/src/main/java/org/elasticsearch/launcher/CliToolLauncher.java
+++ b/distribution/tools/cli-launcher/src/main/java/org/elasticsearch/launcher/CliToolLauncher.java
@@ -108,9 +108,19 @@ class CliToolLauncher {
      * logging will be written to the console.
      */
     private static void configureLoggingWithoutConfig(Map<String, String> sysprops) {
+        final Settings.Builder settingsBuilder = Settings.builder();
+        for (final Map.Entry<String, String> sysprop : sysprops.entrySet()) {
+            final String key = sysprop.getKey();
+            if (key.startsWith("es.logger.") && key.endsWith(".level")) {
+                // es.logger.level => logger.level
+                // es.logger.org.elasticsearch.discovery.level => logger.org.elasticsearch.discovery.level
+                // es.logger.org.elasticsearch.xpack.security.level => logger.org.elasticsearch.xpack.security.level
+                settingsBuilder.put(key.substring("es.".length()), sysprop.getValue());
+            }
+        }
         // initialize default for es.logger.level because we will not read the log4j2.properties
         final String loggerLevel = sysprops.getOrDefault("es.logger.level", Level.INFO.name());
-        final Settings settings = Settings.builder().put("logger.level", loggerLevel).build();
+        final Settings settings = settingsBuilder.put("logger.level", loggerLevel).build();
         LogConfigurator.configureWithoutConfig(settings);
     }
 


### PR DESCRIPTION
The goal of this PR is for gradle CLI to pass all logging configuration from Java system properties into the logger. In other words, add the ability to enable DEBUG for packages/classes via command line arguments.

In elasticsearch.yml, it is possible to enable DEBUG logging globally or for individual packages/classes.
- https://www.elastic.co/guide/en/elasticsearch/reference/current/logging.html#configuring-logging-levels

In gradle CLI tests, it is only possible to use Java system properties to configure DEBUG logging globally.

Works: `-Dtests.es.logger.level=DEBUG`
Doesn't work: `-Dtests.es.logger.org.elasticsearch.xpack.security.level=DEBUG`

Root cause seems to be CliToolLauncher.java only passes `-Dtests.es.logger.level` through to logging configuration.


After the fix, it should be possible to run any tests, but only enable DEBUG for specific packages/classes.

```
./gradlew :x-pack:plugin:security:test --tests "org.elasticsearch.xpack.security.*" -Dtests.es.logger.org.elasticsearch.xpack.security.authc.level
```