### PR TITLE
Discuss: Split metadata out from source and metadata map using new CtxMap

### DIFF
--- a/server/src/main/java/org/elasticsearch/ingest/ExternalIngestMetadata.java
+++ b/server/src/main/java/org/elasticsearch/ingest/ExternalIngestMetadata.java
@@ -1,0 +1,325 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.ingest;
+
+import org.elasticsearch.common.util.set.Sets;
+import org.elasticsearch.index.VersionType;
+import org.elasticsearch.script.Metadata;
+
+import java.time.ZonedDateTime;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * Ingest metadata available to user code.
+ *
+ * The Metadata values in {@link IngestDocument.Metadata} are validated when updated.
+ * _index, _id and _routing must be a String or null
+ * _version_type must be a lower case VersionType or null
+ * _version must be representable as a long without loss of precision or null
+ * _dyanmic_templates must be a map
+ * _if_seq_no must be a long or null
+ * _if_primary_term must be a long or null
+ *
+ * The map is expected to be used by processors, server code should the typed getter and setters where possible.
+ */
+class ExternalIngestMetadata extends Metadata {
+    protected final ZonedDateTime timestamp;
+    protected String index;
+    protected static final String INDEX = "_index";
+
+    protected String id;
+    protected static final String ID = "_id";
+
+    protected String routing;
+    protected static final String ROUTING = "_routing";
+
+    protected String versionType;
+    protected static final String VERSION_TYPE = "_version_type";
+
+    protected long version;
+    protected static final String VERSION = "_version";
+
+    protected Number ifSeqNo;
+    protected static final String IF_SEQ_NO = "_if_seq_no";
+
+    protected Number ifPrimaryTerm;
+    protected static final String IF_PRIMARY_TERM = "_if_primary_term";
+
+    protected Map<String, String> dynamicTemplates;
+    protected static final String DYNAMIC_TEMPLATES = "_dynamic_templates";
+
+    static final Set<String> VERSION_TYPE_VALUES = Arrays.stream(VersionType.values())
+        .map(vt -> VersionType.toString(vt))
+        .collect(Collectors.toSet());
+
+    public static Set<String> KEYS = Set.of(INDEX, ID, ROUTING, VERSION_TYPE, VERSION, IF_SEQ_NO, IF_PRIMARY_TERM, DYNAMIC_TEMPLATES);
+    protected Set<String> removed = Sets.newHashSetWithExpectedSize(KEYS.size());
+
+    ExternalIngestMetadata(ZonedDateTime timestamp, String index, String id, String routing, String versionType, long version) {
+        this.timestamp = timestamp;
+        this.index = index;
+        this.id = id;
+        this.routing = routing;
+        this.versionType = versionType;
+        this.version = version;
+    }
+
+    // These are available to scripts
+    public String getIndex() {
+        return index;
+    }
+
+    public void setIndex(String index) {
+        this.index = index;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public String getRouting() {
+        return routing;
+    }
+
+    public void setRouting(String routing) {
+        this.routing = routing;
+    }
+
+    public String getVersionType() {
+        return versionType;
+    }
+
+    public void setVersionType(String versionType) {
+        if (versionType != null && VERSION_TYPE_VALUES.contains(versionType) == false) {
+            throw new IllegalArgumentException(
+                "_version_type must be a null or one of ["
+                    + VERSION_TYPE_VALUES.stream().sorted().collect(Collectors.joining(", "))
+                    + "] but was ["
+                    + versionType
+                    + "]"
+            );
+        }
+        this.versionType = versionType;
+    }
+
+    public long getVersion() {
+        return version;
+    }
+
+    public void setVersion(long version) {
+        this.version = version;
+    }
+
+    public ZonedDateTime getTimestamp() {
+        return timestamp;
+    }
+
+    // These are not available to scripts
+    public Number getIfSeqNo() {
+        return ifSeqNo;
+    }
+
+    public Number getIfPrimaryTerm() {
+        return ifPrimaryTerm;
+    }
+
+    public Map<String, String> getDynamicTemplates() {
+        return dynamicTemplates;
+    }
+
+    protected static String toNullableString(String key, Object value) {
+        if (value == null) {
+            return null;
+        }
+        if (value instanceof String str) {
+            return str;
+        }
+        throw new IllegalArgumentException(
+            key + " must be null or a String but was [" + value + "] with type [" + value.getClass().getName() + "]"
+        );
+    }
+
+    protected static long toLong(String key, Object value) {
+        if (value instanceof Number number) {
+            long version = number.longValue();
+            // did we round?
+            if (number.doubleValue() == version) {
+                return version;
+            }
+        }
+        throw new IllegalArgumentException(
+            key
+                + " may only be set to an int or a long but was ["
+                + value
+                + "]"
+                + (value != null ? " with type [" + value.getClass().getName() + "]" : "")
+        );
+    }
+
+    protected static Number toNullableLong(String key, Object value) {
+        if (value == null) {
+            return null;
+        }
+        return toLong(key, value);
+    }
+
+    @SuppressWarnings("unchecked")
+    protected static Map<String, String> toMapOrNull(String key, Object value) {
+        if (value == null) {
+            return null;
+        }
+        if (value instanceof Map<?, ?>) {
+            return (Map<String, String>) value;
+        }
+        throw new IllegalArgumentException(
+            key + " must be a null or a Map but was [" + value + "] with type [" + value.getClass().getName() + "]"
+        );
+    }
+
+    @Override
+    public boolean isMetadata(Object key) {
+        if (key instanceof String str) {
+            return KEYS.contains(str);
+        }
+        return false;
+    }
+
+    @Override
+    public Object put(String key, Object value) {
+        Object old;
+        switch (key) {
+            case INDEX -> {
+                old = getIndex();
+                setIndex(toNullableString(key, value));
+            }
+            case ID -> {
+                old = getId();
+                setId(toNullableString(key, value));
+            }
+            case ROUTING -> {
+                old = getRouting();
+                setRouting(toNullableString(key, value));
+                return old;
+            }
+            case VERSION_TYPE -> {
+                old = getVersionType();
+                setVersionType(toNullableString(key, value));
+                return old;
+            }
+            case VERSION -> {
+                old = getVersion();
+                setVersion(toLong(key, value));
+            }
+            case IF_SEQ_NO -> {
+                old = getIfSeqNo();
+                ifSeqNo = toNullableLong(key, value);
+            }
+            case IF_PRIMARY_TERM -> {
+                old = getIfPrimaryTerm();
+                ifPrimaryTerm = toNullableLong(key, value);
+            }
+            case DYNAMIC_TEMPLATES -> {
+                old = getDynamicTemplates();
+                dynamicTemplates = toMapOrNull(key, value);
+            }
+            default -> throw new IllegalArgumentException(unexpectedMessage("put", key));
+        }
+        removed.remove(key);
+        return old;
+    }
+
+    public Object get(Object key) {
+        if (key instanceof String strKey) {
+            if (removed.contains(strKey)) {
+                return null;
+            }
+            switch (strKey) {
+                case INDEX:
+                    return getIndex();
+                case ID:
+                    return getId();
+                case ROUTING:
+                    return getRouting();
+                case VERSION_TYPE:
+                    return getVersionType();
+                case VERSION:
+                    return getVersion();
+                case IF_SEQ_NO:
+                    return getIfSeqNo();
+                case IF_PRIMARY_TERM:
+                    return getIfPrimaryTerm();
+                case DYNAMIC_TEMPLATES:
+                    return getDynamicTemplates();
+                default:
+            }
+        }
+        throw new IllegalArgumentException(unexpectedMessage("get", key));
+    }
+
+    public Object remove(Object key) {
+        if (key instanceof String strKey) {
+            if (isMetadata(key) == false) {
+                throw new IllegalArgumentException(unexpectedMessage("remove", key));
+            }
+            Object old = get(key);
+            switch (strKey) {
+                case INDEX -> setIndex(null);
+                case ID -> setId(null);
+                case ROUTING -> setRouting(null);
+                case VERSION_TYPE -> setVersionType(null);
+                case VERSION -> throw new IllegalArgumentException("Cannot remove [" + key + "]");
+                case IF_SEQ_NO -> ifSeqNo = null;
+                case IF_PRIMARY_TERM -> ifPrimaryTerm = null;
+                case DYNAMIC_TEMPLATES -> dynamicTemplates = null;
+                default -> throw new IllegalArgumentException(unexpectedMessage("remove", key));
+            }
+            removed.add(strKey);
+            return old;
+        }
+        throw new IllegalArgumentException(unexpectedMessage("remove", key));
+    }
+
+    protected String unexpectedMessage(String action, Object key) {
+        return "unexpected "
+            + action
+            + " with key ["
+            + key
+            + "] expected key to be one of ["
+            + KEYS.stream().sorted().collect(Collectors.joining(", "))
+            + "]";
+    }
+
+    public List<String> keys() {
+        Set<String> keys = new HashSet<>(KEYS);
+        keys.removeAll(removed);
+        return keys.stream().sorted().collect(Collectors.toList());
+    }
+
+    @Override
+    public boolean exists(Object key) {
+        if (key instanceof String str) {
+            return KEYS.contains(str) && removed.contains(str) == false;
+        }
+        return false;
+    }
+
+    @Override
+    public int size() {
+        return KEYS.size() - removed.size();
+    }
+}

--- a/server/src/main/java/org/elasticsearch/ingest/ExternalIngestMetadataMap.java
+++ b/server/src/main/java/org/elasticsearch/ingest/ExternalIngestMetadataMap.java
@@ -1,0 +1,195 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.ingest;
+
+import org.elasticsearch.common.util.Maps;
+import org.elasticsearch.index.VersionType;
+import org.elasticsearch.script.MetadataMap;
+
+import java.time.ZonedDateTime;
+import java.util.Arrays;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * Ingest metadata available to user code.
+ *
+ * The Metadata values in {@link IngestDocument.Metadata} are validated when updated.
+ * _index, _id and _routing must be a String or null
+ * _version_type must be a lower case VersionType or null
+ * _version must be representable as a long without loss of precision or null
+ * _dyanmic_templates must be a map
+ * _if_seq_no must be a long or null
+ * _if_primary_term must be a long or null
+ *
+ * The map is expected to be used by processors, server code should the typed getter and setters where possible.
+ */
+class ExternalIngestMetadataMap extends MetadataMap {
+    protected static final String INDEX = "_index";
+    protected static final String ID = "_id";
+    protected static final String ROUTING = "_routing";
+    protected static final String VERSION_TYPE = "_version_type";
+    protected static final String VERSION = "_version";
+    protected static final String IF_SEQ_NO = "_if_seq_no";
+    protected static final String IF_PRIMARY_TERM = "_if_primary_term";
+    protected static final String DYNAMIC_TEMPLATES = "_dynamic_templates";
+
+    static final Set<String> VERSION_TYPE_VALUES = Arrays.stream(VersionType.values())
+        .map(vt -> VersionType.toString(vt))
+        .collect(Collectors.toSet());
+
+    protected static final Map<String, Validator> VALIDATORS = Map.of(
+        INDEX,
+        MetadataMap::stringValidator,
+        ID,
+        MetadataMap::stringValidator,
+        ROUTING,
+        MetadataMap::stringValidator,
+        VERSION_TYPE,
+        setOrNullValidator(VERSION_TYPE_VALUES),
+        VERSION,
+        ExternalIngestMetadataMap::nonNullLongValidator,
+        IF_SEQ_NO,
+        MetadataMap::longValidator,
+        IF_PRIMARY_TERM,
+        MetadataMap::longValidator,
+        DYNAMIC_TEMPLATES,
+        ExternalIngestMetadataMap::mapValidator
+    );
+
+    protected final ZonedDateTime timestamp;
+
+    ExternalIngestMetadataMap(String index, String id, long version, String routing, VersionType versionType, ZonedDateTime timestamp) {
+        this(metadataMap(index, id, version, routing, versionType), timestamp, VALIDATORS);
+    }
+
+    ExternalIngestMetadataMap(Map<String, Object> map, ZonedDateTime timestamp, Map<String, Validator> validators) {
+        super(map, validators);
+        this.timestamp = timestamp;
+    }
+
+    /**
+     * Create the backing metadata map with the standard contents assuming default validators.
+     */
+    protected static Map<String, Object> metadataMap(String index, String id, long version, String routing, VersionType versionType) {
+        Map<String, Object> metadata = Maps.newHashMapWithExpectedSize(IngestDocument.Metadata.values().length);
+        metadata.put(IngestDocument.Metadata.INDEX.getFieldName(), index);
+        metadata.put(IngestDocument.Metadata.ID.getFieldName(), id);
+        metadata.put(IngestDocument.Metadata.VERSION.getFieldName(), version);
+        if (routing != null) {
+            metadata.put(IngestDocument.Metadata.ROUTING.getFieldName(), routing);
+        }
+        if (versionType != null) {
+            metadata.put(IngestDocument.Metadata.VERSION_TYPE.getFieldName(), VersionType.toString(versionType));
+        }
+        return metadata;
+    }
+
+    // These are available to scripts
+    public String getIndex() {
+        return getString(INDEX);
+    }
+
+    public void setIndex(String index) {
+        put(INDEX, index);
+    }
+
+    public String getId() {
+        return getString(ID);
+    }
+
+    public void setId(String id) {
+        put(ID, id);
+    }
+
+    public String getRouting() {
+        return getString(ROUTING);
+    }
+
+    public void setRouting(String routing) {
+        put(ROUTING, routing);
+    }
+
+    public String getVersionType() {
+        return getString(VERSION_TYPE);
+    }
+
+    public void setVersionType(String versionType) {
+        put(VERSION_TYPE, versionType);
+    }
+
+    public long getVersion() {
+        return getNumber(VERSION).longValue();
+    }
+
+    public void setVersion(long version) {
+        put(VERSION, version);
+    }
+
+    public ZonedDateTime getTimestamp() {
+        return timestamp;
+    }
+
+    // These are not available to scripts
+    public Number getIfSeqNo() {
+        return getNumber(IF_SEQ_NO);
+    }
+
+    public Number getIfPrimaryTerm() {
+        return getNumber(IF_PRIMARY_TERM);
+    }
+
+    @SuppressWarnings("unchecked")
+    public Map<String, String> getDynamicTemplates() {
+        return (Map<String, String>) get(DYNAMIC_TEMPLATES);
+    }
+
+    /**
+     * Allow maps
+     */
+    public static void mapValidator(MetadataMap.MapOperation op, String key, Object value) {
+        if (op == MetadataMap.MapOperation.REMOVE || value == null || value instanceof Map<?, ?>) {
+            return;
+        }
+        throw new IllegalArgumentException(
+            key + " must be a null or a Map but was [" + value + "] with type [" + value.getClass().getName() + "]"
+        );
+    }
+
+    protected static void nonNullLongValidator(MapOperation op, String key, Object value) {
+        if (op == MapOperation.REMOVE || value == null) {
+            throw new IllegalArgumentException("cannot remove or set [" + key + "] to null");
+        }
+        if (value instanceof Number number) {
+            long version = number.longValue();
+            // did we round?
+            if (number.doubleValue() == version) {
+                return;
+            }
+        }
+        throw new IllegalArgumentException(
+            key + " may only be set to an int or a long but was [" + value + "] with type [" + value.getClass().getName() + "]"
+        );
+    }
+
+    @SuppressWarnings("unchecked")
+    protected static Map<String, String> toMapOrNull(String key, Object value) {
+        if (value == null) {
+            return null;
+        }
+        if (value instanceof Map<?, ?>) {
+            return (Map<String, String>) value;
+        }
+        throw new IllegalArgumentException(
+            key + " must be a null or a Map but was [" + value + "] with type [" + value.getClass().getName() + "]"
+        );
+    }
+
+}

--- a/server/src/main/java/org/elasticsearch/ingest/IngestSourceAndMetadata.java
+++ b/server/src/main/java/org/elasticsearch/ingest/IngestSourceAndMetadata.java
@@ -11,7 +11,6 @@ package org.elasticsearch.ingest;
 import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.core.Tuple;
 import org.elasticsearch.index.VersionType;
-import org.elasticsearch.script.Metadata;
 
 import java.time.ZonedDateTime;
 import java.util.AbstractCollection;
@@ -41,7 +40,7 @@ import java.util.stream.Collectors;
  *
  * The map is expected to be used by processors, server code should the typed getter and setters where possible.
  */
-class IngestSourceAndMetadata extends AbstractMap<String, Object> implements Metadata {
+class IngestSourceAndMetadata extends AbstractMap<String, Object> {
     protected final ZonedDateTime timestamp;
 
     /**

--- a/server/src/main/java/org/elasticsearch/script/CtxMap.java
+++ b/server/src/main/java/org/elasticsearch/script/CtxMap.java
@@ -1,0 +1,229 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.script;
+
+import java.util.AbstractCollection;
+import java.util.AbstractMap;
+import java.util.AbstractSet;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+
+public class CtxMap extends AbstractMap<String, Object> {
+    protected Metadata metadata;
+    protected Map<String, Object> source;
+    protected Set<Map.Entry<String, Object>> entrySet;
+
+    public CtxMap(Metadata metadata, Map<String, Object> source) {
+        this.metadata = metadata;
+        this.source = source;
+    }
+
+    /**
+     * Returns an entrySet that respects the validators of the map.
+     */
+    @Override
+    public Set<Map.Entry<String, Object>> entrySet() {
+        if (entrySet == null) {
+            entrySet = new EntrySet(source.entrySet(), metadata.keys());
+        }
+        return entrySet;
+    }
+
+    /**
+     * Associate a key with a value.  If the key has a validator, it is applied before association.
+     * @throws IllegalArgumentException if value does not pass validation for the given key
+     */
+    @Override
+    public Object put(String key, Object value) {
+        if (metadata.isMetadata(key)) {
+            return metadata.put(key, value);
+        }
+        return source.put(key, value);
+    }
+
+    /**
+     * Remove the mapping of key.  If the key has a validator, it is checked before key removal.
+     * @throws IllegalArgumentException if the validator does not allow the key to be removed
+     */
+    @Override
+    public Object remove(Object key) {
+        // uses map directly to avoid AbstractMaps linear time implementation using entrySet()
+        if (metadata.isMetadata(key)) {
+            return metadata.remove(key);
+        }
+        return source.remove(key);
+    }
+
+    /**
+     * Clear entire map.  For each key in the map with a validator, that validator is checked as in {@link #remove(Object)}.
+     * @throws IllegalArgumentException if any validator does not allow the key to be removed, in this case the map is unmodified
+     */
+    @Override
+    public void clear() {
+        // AbstractMap uses entrySet().clear(), it should be quicker to run through the metadata keys, then call the wrapped maps clear
+        for (String key : metadata.keys()) {
+            metadata.remove(key);
+        }
+        source.clear();
+    }
+
+    @Override
+    public int size() {
+        // uses map directly to avoid creating an EntrySet via AbstractMaps implementation, which returns entrySet().size()
+        return source.size() + metadata.size();
+    }
+
+    @Override
+    public boolean containsValue(Object value) {
+        // uses map directly to avoid AbstractMaps linear time implementation using entrySet()
+        if (source.containsValue(value)) {
+            return true;
+        }
+        for (String key : metadata.keys()) {
+            if (Objects.equals(value, metadata.get(key))) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    @Override
+    public boolean containsKey(Object key) {
+        // uses map directly to avoid AbstractMaps linear time implementation using entrySet()
+        return metadata.exists(key) || source.containsKey(key);
+    }
+
+    @Override
+    public Object get(Object key) {
+        // uses map directly to avoid AbstractMaps linear time implementation using entrySet()
+        if (metadata.isMetadata(key)) {
+            return metadata.get(key);
+        }
+        return source.get(key);
+    }
+
+    /**
+     * Set of entries of the wrapped map that calls the appropriate validator before changing an entries value or removing an entry.
+     *
+     * Inherits {@link AbstractSet#removeAll(Collection)}, which calls the overridden {@link #remove(Object)} which performs validation.
+     *
+     * Inherits {@link AbstractCollection#retainAll(Collection)} and {@link AbstractCollection#clear()}, which both use
+     * {@link EntrySetIterator#remove()} for removal.
+     */
+    class EntrySet extends AbstractSet<Map.Entry<String, Object>> {
+        Set<Map.Entry<String, Object>> sourceSet;
+        List<String> metadataKeys;
+
+        EntrySet(Set<Map.Entry<String, Object>> sourceSet, List<String> metadataKeys) {
+            this.sourceSet = sourceSet;
+            this.metadataKeys = metadataKeys;
+        }
+
+        @Override
+        public Iterator<Map.Entry<String, Object>> iterator() {
+            return new EntrySetIterator(sourceSet.iterator(), metadataKeys.iterator());
+        }
+
+        @Override
+        public int size() {
+            return sourceSet.size() + metadataKeys.size();
+        }
+
+        @Override
+        public boolean remove(Object o) {
+            if (o instanceof Map.Entry<?, ?> entry) {
+                if (entry.getKey()instanceof String key) {
+                    if (metadata.isMetadata(key)) {
+                        if (Objects.equals(entry.getValue(), metadata.get(key)) && metadata.exists(key)) {
+                            metadata.remove(key);
+                            return true;
+                        } else {
+                            return false;
+                        }
+                    }
+                }
+            }
+            return sourceSet.remove(o);
+        }
+    }
+
+    /**
+     * Iterator over the wrapped map that returns a validating {@link Entry} on {@link #next()} and validates on {@link #remove()}.
+     *
+     * {@link #remove()} is called by remove in {@link AbstractMap#values()}, {@link AbstractMap#keySet()}, {@link AbstractMap#clear()} via
+     * {@link AbstractSet#clear()}
+     */
+    class EntrySetIterator implements Iterator<Map.Entry<String, Object>> {
+        final Iterator<Map.Entry<String, Object>> sourceIter;
+        final Iterator<String> metadataIter;
+
+        boolean sourceCur = true;
+        Map.Entry<String, Object> cur;
+
+        EntrySetIterator(Iterator<Map.Entry<String, Object>> sourceIter, Iterator<String> metadataIter) {
+            this.sourceIter = sourceIter;
+            this.metadataIter = metadataIter;
+        }
+
+        @Override
+        public boolean hasNext() {
+            return sourceIter.hasNext() || metadataIter.hasNext();
+        }
+
+        @Override
+        public Map.Entry<String, Object> next() {
+            sourceCur = sourceIter.hasNext();
+            return cur = (sourceCur ? sourceIter.next() : new MetadataEntry(metadataIter.next()));
+        }
+
+        /**
+         * Remove current entry from the backing Map.  Checks the Entry's key's validator, if one exists, before removal.
+         * @throws IllegalArgumentException if the validator does not allow the Entry to be removed
+         * @throws IllegalStateException if remove is called before {@link #next()}
+         */
+        @Override
+        public void remove() {
+            if (cur == null) {
+                throw new IllegalStateException();
+            }
+            if (sourceCur) {
+                sourceIter.remove();
+            } else {
+                metadata.remove(cur.getKey());
+            }
+        }
+    }
+
+    class MetadataEntry implements Map.Entry<String, Object> {
+        final String key;
+
+        MetadataEntry(String key) {
+            this.key = key;
+        }
+
+        @Override
+        public String getKey() {
+            return key;
+        }
+
+        @Override
+        public Object getValue() {
+            return metadata.get(key);
+        }
+
+        @Override
+        public Object setValue(Object value) {
+            return metadata.put(key, value);
+        }
+    }
+}

--- a/server/src/main/java/org/elasticsearch/script/MapWrappable.java
+++ b/server/src/main/java/org/elasticsearch/script/MapWrappable.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.script;
+
+import java.util.List;
+
+/**
+ * A class that can easily be wrapped in a Map interface by {@link MapWrapper}
+ */
+public interface MapWrappable {
+    boolean isAuthoritative(String key);
+    Object put(String key, Object value);
+    boolean containsKey(String key);
+    boolean containsValue(Object value);
+    Object get(String key);
+    Object remove(String key);
+    List<String> keys();
+    int size();
+    MapWrappable clone();
+}

--- a/server/src/main/java/org/elasticsearch/script/MapWrapper.java
+++ b/server/src/main/java/org/elasticsearch/script/MapWrapper.java
@@ -1,0 +1,212 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.script;
+
+import org.elasticsearch.ingest.IngestDocument;
+
+import java.util.AbstractCollection;
+import java.util.AbstractMap;
+import java.util.AbstractSet;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+
+/**
+ * Implements a Map interface, including {@link Map.Entry} and {@link Iterator<Map.Entry>} for classes that
+ * implement {@link MapWrappable}.
+ */
+class MapWrapper extends AbstractMap<String, Object> {
+    private EntrySet entrySet; // cache to avoid recreation
+    protected final MapWrappable wrapped;
+
+    MapWrapper(MapWrappable wrapped) {
+        this.wrapped = wrapped;
+    }
+
+    /**
+     * Returns an entrySet that respects the validators of the map.
+     */
+    @Override
+    public Set<Map.Entry<String, Object>> entrySet() {
+        if (entrySet == null) {
+            entrySet = new EntrySet(wrapped.keys());
+        }
+        return entrySet;
+    }
+
+    /**
+     * Associate a key with a value.  If the key has a validator, it is applied before association.
+     * @throws IllegalArgumentException if value does not pass validation for the given key
+     */
+    @Override
+    public Object put(String key, Object value) {
+        return wrapped.put(key, value);
+    }
+
+    /**
+     * Remove the mapping of key.  If the key has a validator, it is checked before key removal.
+     * @throws IllegalArgumentException if the validator does not allow the key to be removed
+     */
+    @Override
+    public Object remove(Object key) {
+        // uses map directly to avoid AbstractMaps linear time implementation using entrySet()
+        if (key instanceof String str) {
+            return wrapped.remove(str);
+        }
+        return null;
+    }
+
+    /**
+     * Clear entire map.  For each key in the map with a validator, that validator is checked as in {@link #remove(Object)}.
+     * @throws IllegalArgumentException if any validator does not allow the key to be removed, in this case the map is may have been
+     *                                  modified
+     */
+    @Override
+    public void clear() {
+        // AbstractMap uses entrySet().clear(), it should be quicker to run through the metadata keys, then call the wrapped maps clear
+        for (String key : wrapped.keys()) {
+            wrapped.remove(key);
+        }
+    }
+
+    @Override
+    public int size() {
+        // uses map directly to avoid creating an EntrySet via AbstractMaps implementation, which returns entrySet().size()
+        return wrapped.size();
+    }
+
+    @Override
+    public boolean containsValue(Object value) {
+        // uses map directly to avoid AbstractMaps linear time implementation using entrySet()
+        return wrapped.containsValue(value);
+    }
+
+    @Override
+    public boolean containsKey(Object key) {
+        // uses map directly to avoid AbstractMaps linear time implementation using entrySet()
+        if (key instanceof String str) {
+            return wrapped.containsKey(str);
+        }
+        return false;
+    }
+
+    @Override
+    public Object get(Object key) {
+        // uses map directly to avoid AbstractMaps linear time implementation using entrySet()
+        if (key instanceof String str) {
+            return wrapped.get(str);
+        }
+        return null;
+    }
+
+    /**
+     * Set of entries of the wrapped map that calls the appropriate validator before changing an entries value or removing an entry.
+     *
+     * Inherits {@link AbstractSet#removeAll(Collection)}, which calls the overridden {@link #remove(Object)} which performs validation.
+     *
+     * Inherits {@link AbstractCollection#retainAll(Collection)} and {@link AbstractCollection#clear()}, which both use
+     * {@link CtxMap.EntrySetIterator#remove()} for removal.
+     */
+    class EntrySet extends AbstractSet<Map.Entry<String, Object>> {
+        List<String> wrappedKeys;
+
+        EntrySet(List<String> wrappedKeys) {
+            this.wrappedKeys = wrappedKeys;
+        }
+
+        @Override
+        public Iterator<Map.Entry<String, Object>> iterator() {
+            return new EntrySetIterator(wrappedKeys.iterator());
+        }
+
+        @Override
+        public int size() {
+            return wrappedKeys.size();
+        }
+
+        @Override
+        public boolean remove(Object o) {
+            if (o instanceof Map.Entry<?, ?> entry) {
+                if (entry.getKey()instanceof String key) {
+                    if (wrapped.containsKey(key)) {
+                        if (Objects.equals(entry.getValue(), wrapped.get(key))) {
+                            wrapped.remove(key);
+                            return true;
+                        }
+                    }
+                }
+            }
+            return false;
+        }
+    }
+
+    /**
+     * Iterator over the wrapped map that returns a validating {@link Entry} on {@link #next()} and validates on {@link #remove()}.
+     *
+     * {@link #remove()} is called by remove in {@link AbstractMap#values()}, {@link AbstractMap#keySet()}, {@link AbstractMap#clear()} via
+     * {@link AbstractSet#clear()}
+     */
+    class EntrySetIterator implements Iterator<Map.Entry<String, Object>> {
+        final Iterator<String> wrappedIter;
+        Map.Entry<String, Object> cur;
+
+        EntrySetIterator(Iterator<String> wrappedIter) {
+            this.wrappedIter = wrappedIter;
+        }
+
+        @Override
+        public boolean hasNext() {
+            return wrappedIter.hasNext();
+        }
+
+        @Override
+        public Map.Entry<String, Object> next() {
+            return cur = new Entry(wrappedIter.next());
+        }
+
+        /**
+         * Remove current entry from the backing Map.  Checks the Entry's key's validator, if one exists, before removal.
+         * @throws IllegalArgumentException if the validator does not allow the Entry to be removed
+         * @throws IllegalStateException if remove is called before {@link #next()}
+         */
+        @Override
+        public void remove() {
+            if (cur == null) {
+                throw new IllegalStateException();
+            }
+            wrapped.remove(cur.getKey());
+        }
+    }
+
+    class Entry implements Map.Entry<String, Object> {
+        final String key;
+
+        Entry(String key) {
+            this.key = key;
+        }
+
+        @Override
+        public String getKey() {
+            return key;
+        }
+
+        @Override
+        public Object getValue() {
+            return wrapped.get(key);
+        }
+
+        @Override
+        public Object setValue(Object value) {
+            return wrapped.put(key, value);
+        }
+    }
+}

--- a/server/src/main/java/org/elasticsearch/script/MapWrapper.java
+++ b/server/src/main/java/org/elasticsearch/script/MapWrapper.java
@@ -8,8 +8,6 @@
 
 package org.elasticsearch.script;
 
-import org.elasticsearch.ingest.IngestDocument;
-
 import java.util.AbstractCollection;
 import java.util.AbstractMap;
 import java.util.AbstractSet;

--- a/server/src/main/java/org/elasticsearch/script/Metadata.java
+++ b/server/src/main/java/org/elasticsearch/script/Metadata.java
@@ -8,53 +8,23 @@
 
 package org.elasticsearch.script;
 
-import java.time.ZonedDateTime;
+import java.util.List;
 
 /**
  * Ingest and update metadata available to write scripts
  */
-public interface Metadata {
-    /**
-     * The destination index
-     */
-    String getIndex();
+public abstract class Metadata {
+    public abstract Object put(String key, Object value);
 
-    void setIndex(String index);
+    public abstract boolean isMetadata(Object key);
 
-    /**
-     * The document id
-     */
-    String getId();
+    public abstract Object get(Object key);
 
-    void setId(String id);
+    public abstract Object remove(Object key);
 
-    /**
-     * The document routing string
-     */
-    String getRouting();
+    public abstract boolean exists(Object key);
 
-    void setRouting(String routing);
+    public abstract List<String> keys();
 
-    /**
-     * The version of the document
-     */
-    long getVersion();
-
-    void setVersion(long version);
-
-    /**
-     * The version type of the document, {@link org.elasticsearch.index.VersionType} as a lower-case string.
-     */
-    String getVersionType();
-
-    /**
-     * Set the version type of the document.
-     * @param versionType {@link org.elasticsearch.index.VersionType} as a lower-case string
-     */
-    void setVersionType(String versionType);
-
-    /**
-     * Timestamp of this ingestion or update
-     */
-    ZonedDateTime getTimestamp();
+    public abstract int size();
 }

--- a/server/src/main/java/org/elasticsearch/script/MetadataMap.java
+++ b/server/src/main/java/org/elasticsearch/script/MetadataMap.java
@@ -1,0 +1,210 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.script;
+
+import org.elasticsearch.common.util.Maps;
+import org.elasticsearch.index.VersionType;
+import org.elasticsearch.ingest.IngestDocument;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * A {@link MapWrappable} that validates updates to the map using {@link Validator}s.
+ */
+public class MetadataMap implements MapWrappable {
+    protected final Map<String, Object> map;
+    protected final Map<String, Validator> validators;
+
+    protected MetadataMap(Map<String, Object> map, Map<String, Validator> validators) {
+        this.map = new HashMap<>(map);
+        this.validators = validators;
+        validateMetadata();
+    }
+
+    /**
+     * Check that all metadata map contains only valid metadata and no extraneous keys and source map contains no metadata
+     */
+    protected void validateMetadata() {
+        int numMetadata = 0;
+        for (Map.Entry<String, Validator> entry : validators.entrySet()) {
+            String key = entry.getKey();
+            if (map.containsKey(key)) {
+                numMetadata++;
+            }
+            entry.getValue().accept(MapOperation.INIT, key, map.get(key));
+        }
+        if (numMetadata < map.size()) {
+            Set<String> keys = new HashSet<>(map.keySet());
+            keys.removeAll(validators.keySet());
+            throw new IllegalArgumentException(
+                "Unexpected metadata keys ["
+                    + keys.stream().sorted().map(k -> k + ":" + map.get(k)).collect(Collectors.joining(", "))
+                    + "]"
+            );
+        }
+    }
+
+    @Override
+    public boolean isAuthoritative(String key) {
+        return validators.containsKey(key);
+    }
+
+    @Override
+    public Object put(String key, Object value) {
+        Validator v = validators.get(key);
+        if (v == null) {
+            throw new IllegalArgumentException("cannot set unknown key [" + key + "] to [" + value + "]");
+        }
+        v.accept(MapOperation.UPDATE, key, value);
+        return map.put(key, value);
+    }
+
+    @Override
+    public boolean containsKey(String key) {
+        return map.containsKey(key);
+    }
+
+    @Override
+    public boolean containsValue(Object value) {
+        return map.containsValue(value);
+    }
+
+    @Override
+    public Object get(String key) {
+        return map.get(key);
+    }
+
+    @Override
+    public Object remove(String key) {
+        Validator v = validators.get(key);
+        if (v == null) {
+            throw new IllegalArgumentException("cannot remove unknown key [" + key + "]");
+        }
+        v.accept(MapOperation.REMOVE, key, null);
+        return map.remove(key);
+    }
+
+    @Override
+    public List<String> keys() {
+        return new ArrayList<>(map.keySet());
+    }
+
+    @Override
+    public int size() {
+        return map.size();
+    }
+
+    @Override
+    public MapWrappable clone() {
+        return new MetadataMap(new HashMap<>(map), new HashMap<>(validators));
+    }
+
+    /**
+     * Get the String version of the value associated with {@code key}, or null
+     */
+    public String getString(String key) {
+        return Objects.toString(get(key), null);
+    }
+
+    /**
+     * Get the {@link Number} associated with key, or null
+     * @throws IllegalArgumentException if the value is not a {@link Number}
+     */
+    public Number getNumber(String key) {
+        Object value = get(key);
+        if (value == null) {
+            return null;
+        }
+        if (value instanceof Number number) {
+            return number;
+        }
+        throw new IllegalArgumentException(
+            "unexpected type for [" + key + "] with value [" + value + "], expected Number, got [" + value.getClass().getName() + "]"
+        );
+    }
+
+    /**
+     * Allow a String or null
+     */
+    protected static void stringValidator(MapOperation op, String key, Object value) {
+        if (op == MapOperation.REMOVE || value == null || value instanceof String) {
+            return;
+        }
+        throw new IllegalArgumentException(
+            key + " must be null or a String but was [" + value + "] with type [" + value.getClass().getName() + "]"
+        );
+    }
+
+    /**
+     * Allow Numbers that can be represented as longs without loss of precision
+     */
+    protected static void longValidator(MapOperation op, String key, Object value) {
+        if (op == MapOperation.REMOVE || value == null) {
+            return;
+        }
+        if (value instanceof Number number) {
+            long version = number.longValue();
+            // did we round?
+            if (number.doubleValue() == version) {
+                return;
+            }
+        }
+        throw new IllegalArgumentException(
+            key + " may only be set to an int or a long but was [" + value + "] with type [" + value.getClass().getName() + "]"
+        );
+    }
+
+
+    /**
+     * Build a validator that checks that mapping is being removed, value is null or value is one of the valid set
+     */
+    protected static Validator setOrNullValidator(Set<String> valid) {
+        return (o, k, v) ->
+        {
+            if (o == MapOperation.REMOVE || v == null) {
+                return;
+            }
+            if (v instanceof String str) {
+                if (valid.contains(str) == false) {
+                    return;
+                }
+            }
+            throw new IllegalArgumentException("Cannot set [" + k + "] to [" + v + "], need null or one of [" + valid.stream().sorted().collect(Collectors.joining(", ")) + "]");
+        };
+    }
+
+    /**
+     * The operation being performed on the value in the map.
+     * INIT: Initial value - the metadata value as passed into this class
+     * UPDATE: the metadata is being set to a different value
+     * REMOVE: the metadata mapping is being removed
+     */
+    public enum MapOperation {
+        INIT,
+        UPDATE,
+        REMOVE
+    }
+
+    /**
+     * A "TriConsumer" that tests if the {@link MapOperation}, the metadata key and value are valid.
+     *
+     * throws IllegalArgumentException if the given triple is invalid
+     */
+    @FunctionalInterface
+    public interface Validator {
+        void accept(MapOperation op, String key, Object value);
+    }
+}

--- a/server/src/main/java/org/elasticsearch/script/SourceAndMetadataMap.java
+++ b/server/src/main/java/org/elasticsearch/script/SourceAndMetadataMap.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.script;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class SourceAndMetadataMap implements MapWrappable {
+    protected Map<String, Object> source;
+    protected MapWrappable metadata;
+
+    public SourceAndMetadataMap(Map<String, Object> source, MapWrappable metadata) {
+        this.source = source;
+        this.metadata = metadata;
+    }
+
+    @Override
+    public boolean isAuthoritative(String key) {
+        return true;
+    }
+
+    @Override
+    public Object put(String key, Object value) {
+        if (metadata.isAuthoritative(key)) {
+            return metadata.put(key, value);
+        }
+        return source.put(key, value);
+    }
+
+    @Override
+    public boolean containsKey(String key) {
+        return source.containsKey(key) || metadata.containsKey(key);
+    }
+
+    @Override
+    public boolean containsValue(Object value) {
+        return source.containsValue(value) || metadata.containsValue(value);
+    }
+
+    @Override
+    public Object get(String key) {
+        if (metadata.isAuthoritative(key)) {
+            return metadata.get(key);
+        }
+        return source.get(key);
+    }
+
+    @Override
+    public Object remove(String key) {
+        if (metadata.isAuthoritative(key)) {
+            return metadata.remove(key);
+        }
+        return source.remove(key);
+    }
+
+    @Override
+    public List<String> keys() {
+        List<String> keys = new ArrayList<>(size());
+        keys.addAll(metadata.keys());
+        keys.addAll(source.keySet());
+        return keys;
+    }
+
+    @Override
+    public int size() {
+        return metadata.size() + source.size();
+    }
+
+    @Override
+    public MapWrappable clone() {
+        return new SourceAndMetadataMap(
+            new HashMap<>(source),
+            metadata.clone()
+        );
+    }
+}


### PR DESCRIPTION
Creates a CtxMap to take the role of the IngestSourceAndMetadata.

The Metadata abstract class contains the minimum methods necessary for CtxMap to work with it.

@rjernst @jdconrad what do you think about this?