### PR TITLE
[8.3] Add build_flavor back to info api rest response (#88336)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -138,9 +138,9 @@ tasks.register("verifyVersions") {
  * after the backport of the backcompat code is complete.
  */
 
-boolean bwc_tests_enabled = true
+boolean bwc_tests_enabled = false
 // place a PR link here when committing bwc changes:
-String bwc_tests_disabled_issue = ""
+String bwc_tests_disabled_issue = "https://github.com/elastic/elasticsearch/pull/88336"
 if (bwc_tests_enabled == false) {
   if (bwc_tests_disabled_issue.isEmpty()) {
     throw new GradleException("bwc_tests_disabled_issue must be set when bwc_tests_enabled == false")

--- a/docs/changelog/88336.yaml
+++ b/docs/changelog/88336.yaml
@@ -1,0 +1,6 @@
+pr: 88336
+summary: Add `build_flavor` back to info api rest response
+area: Infra/Core
+type: bug
+issues:
+ - 88318

--- a/docs/plugins/discovery-azure-classic.asciidoc
+++ b/docs/plugins/discovery-azure-classic.asciidoc
@@ -352,6 +352,7 @@ This command should give you a JSON result:
     "number" : "{version_qualified}",
     "build_type" : "{build_type}",
     "build_hash" : "f27399d",
+    "build_flavor": "default",
     "build_date" : "2016-03-30T09:51:41.449Z",
     "build_snapshot" : false,
     "lucene_version" : "{lucene_version}",

--- a/docs/reference/setup/install/check-running.asciidoc
+++ b/docs/reference/setup/install/check-running.asciidoc
@@ -36,6 +36,7 @@ GET /
     "number" : "{version_qualified}",
     "build_type" : "{build_type}",
     "build_hash" : "f27399d",
+    "build_flavor" : "default",
     "build_date" : "2016-03-30T09:51:41.449Z",
     "build_snapshot" : false,
     "lucene_version" : "{lucene_version}",

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/info/10_info.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/info/10_info.yml
@@ -7,3 +7,11 @@
     - is_true:    tagline
     - is_true:    version
     - is_true:    version.number
+
+---
+"Info build flavor":
+    - skip:
+        version: "8.3.0 - 8.3.2"
+        reason: "build flavor in info was missing in 8.3.0 to 8.3.2"
+    - do:         {info: {}}
+    - match:      { version.build_flavor: default }

--- a/server/src/main/java/org/elasticsearch/action/main/MainResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/main/MainResponse.java
@@ -87,6 +87,7 @@ public class MainResponse extends ActionResponse implements ToXContentObject {
         builder.field("cluster_uuid", clusterUuid);
         builder.startObject("version")
             .field("number", build.qualifiedVersion())
+            .field("build_flavor", "default")
             .field("build_type", build.type().displayName())
             .field("build_hash", build.hash())
             .field("build_date", build.date())

--- a/server/src/test/java/org/elasticsearch/action/main/MainResponseTests.java
+++ b/server/src/test/java/org/elasticsearch/action/main/MainResponseTests.java
@@ -64,6 +64,7 @@ public class MainResponseTests extends AbstractSerializingTestCase<MainResponse>
                         "cluster_uuid": "%s",
                         "version": {
                             "number": "%s",
+                            "build_flavor": "default",
                             "build_type": "%s",
                             "build_hash": "%s",
                             "build_date": "%s",


### PR DESCRIPTION
Backports the following commits to 8.3:
 - Add build_flavor back to info api rest response (#88336)