### PR TITLE
[8.3] Enforce max values limit only when running a script (#88295)

### DIFF
--- a/docs/changelog/88295.yaml
+++ b/docs/changelog/88295.yaml
@@ -1,0 +1,5 @@
+pr: 88295
+summary: Enforce max values limit only when running a script
+area: Mapping
+type: bug
+issues: []

--- a/server/src/main/java/org/elasticsearch/script/AbstractFieldScript.java
+++ b/server/src/main/java/org/elasticsearch/script/AbstractFieldScript.java
@@ -99,8 +99,12 @@ public abstract class AbstractFieldScript extends DocBasedScript {
             return;
         }
         for (Object value : values) {
-            emitFromObject(value);
+            emitValueFromCompositeScript(value);
         }
+    }
+
+    protected void emitValueFromCompositeScript(Object value) {
+        emitFromObject(value);
     }
 
     protected abstract void emitFromObject(Object v);

--- a/server/src/main/java/org/elasticsearch/script/AbstractLongFieldScript.java
+++ b/server/src/main/java/org/elasticsearch/script/AbstractLongFieldScript.java
@@ -63,7 +63,6 @@ public abstract class AbstractLongFieldScript extends AbstractFieldScript {
     }
 
     public final void emit(long v) {
-        checkMaxSize(count);
         if (values.length < count + 1) {
             values = ArrayUtil.grow(values, count + 1);
         }

--- a/server/src/main/java/org/elasticsearch/script/CompositeFieldScript.java
+++ b/server/src/main/java/org/elasticsearch/script/CompositeFieldScript.java
@@ -64,6 +64,7 @@ public abstract class CompositeFieldScript extends AbstractFieldScript {
     protected final void emit(String field, Object value) {
         // fields will be emitted without the prefix, yet they will be looked up using their full name, hence we store the full name
         List<Object> values = this.fieldValues.computeIfAbsent(fieldName + "." + field, s -> new ArrayList<>());
+        checkMaxSize(values.size());
         values.add(value);
     }
 

--- a/server/src/main/java/org/elasticsearch/script/DateFieldScript.java
+++ b/server/src/main/java/org/elasticsearch/script/DateFieldScript.java
@@ -97,6 +97,7 @@ public abstract class DateFieldScript extends AbstractLongFieldScript {
         }
 
         public void emit(long v) {
+            script.checkMaxSize(script.count());
             script.emit(v);
         }
     }

--- a/server/src/main/java/org/elasticsearch/script/DoubleFieldScript.java
+++ b/server/src/main/java/org/elasticsearch/script/DoubleFieldScript.java
@@ -124,7 +124,6 @@ public abstract class DoubleFieldScript extends AbstractFieldScript {
     }
 
     public final void emit(double v) {
-        checkMaxSize(count);
         if (values.length < count + 1) {
             values = ArrayUtil.grow(values, count + 1);
         }
@@ -139,6 +138,7 @@ public abstract class DoubleFieldScript extends AbstractFieldScript {
         }
 
         public void emit(double v) {
+            script.checkMaxSize(script.count());
             script.emit(v);
         }
     }

--- a/server/src/main/java/org/elasticsearch/script/GeoPointFieldScript.java
+++ b/server/src/main/java/org/elasticsearch/script/GeoPointFieldScript.java
@@ -155,6 +155,7 @@ public abstract class GeoPointFieldScript extends AbstractLongFieldScript {
         }
 
         public void emit(double lat, double lon) {
+            script.checkMaxSize(script.count());
             script.emit(lat, lon);
         }
     }

--- a/server/src/main/java/org/elasticsearch/script/IpFieldScript.java
+++ b/server/src/main/java/org/elasticsearch/script/IpFieldScript.java
@@ -143,7 +143,6 @@ public abstract class IpFieldScript extends AbstractFieldScript {
     }
 
     public final void emit(String v) {
-        checkMaxSize(count);
         if (values.length < count + 1) {
             values = ArrayUtil.grow(values, count + 1);
         }
@@ -161,6 +160,7 @@ public abstract class IpFieldScript extends AbstractFieldScript {
         }
 
         public void emit(String v) {
+            script.checkMaxSize(script.count());
             script.emit(v);
         }
     }

--- a/server/src/main/java/org/elasticsearch/script/LongFieldScript.java
+++ b/server/src/main/java/org/elasticsearch/script/LongFieldScript.java
@@ -87,6 +87,7 @@ public abstract class LongFieldScript extends AbstractLongFieldScript {
         }
 
         public void emit(long v) {
+            script.checkMaxSize(script.count());
             script.emit(v);
         }
     }

--- a/server/src/main/java/org/elasticsearch/script/StringFieldScript.java
+++ b/server/src/main/java/org/elasticsearch/script/StringFieldScript.java
@@ -100,6 +100,15 @@ public abstract class StringFieldScript extends AbstractFieldScript {
     }
 
     @Override
+    protected void emitValueFromCompositeScript(Object value) {
+        if (value != null) {
+            String string = value.toString();
+            checkMaxChars(string);
+            emit(string);
+        }
+    }
+
+    @Override
     protected void emitFromObject(Object v) {
         if (v != null) {
             emit(v.toString());
@@ -107,7 +116,10 @@ public abstract class StringFieldScript extends AbstractFieldScript {
     }
 
     public final void emit(String v) {
-        checkMaxSize(results.size());
+        results.add(v);
+    }
+
+    private void checkMaxChars(String v) {
         chars += v.length();
         if (chars > MAX_CHARS) {
             throw new IllegalArgumentException(
@@ -120,7 +132,6 @@ public abstract class StringFieldScript extends AbstractFieldScript {
                 )
             );
         }
-        results.add(v);
     }
 
     public static class Emit {
@@ -131,6 +142,8 @@ public abstract class StringFieldScript extends AbstractFieldScript {
         }
 
         public void emit(String v) {
+            script.checkMaxSize(script.results.size());
+            script.checkMaxChars(v);
             script.emit(v);
         }
     }

--- a/server/src/test/java/org/elasticsearch/index/mapper/BooleanFieldScriptTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/BooleanFieldScriptTests.java
@@ -63,7 +63,7 @@ public class BooleanFieldScriptTests extends FieldScriptTestCase<BooleanFieldScr
                     @Override
                     public void execute() {
                         for (int i = 0; i <= AbstractFieldScript.MAX_VALUES * 1000; i++) {
-                            emit(i % 2 == 0);
+                            new Emit(this).value(i % 2 == 0);
                         }
                     }
                 };

--- a/server/src/test/java/org/elasticsearch/index/mapper/DateFieldScriptTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/DateFieldScriptTests.java
@@ -13,13 +13,18 @@ import org.apache.lucene.index.DirectoryReader;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.tests.index.RandomIndexWriter;
 import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.time.DateFormatter;
 import org.elasticsearch.script.AbstractFieldScript;
 import org.elasticsearch.script.DateFieldScript;
 import org.elasticsearch.script.ScriptContext;
 import org.elasticsearch.search.lookup.SearchLookup;
+import org.elasticsearch.xcontent.XContentBuilder;
+import org.elasticsearch.xcontent.json.JsonXContent;
 
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -68,7 +73,7 @@ public class DateFieldScriptTests extends FieldScriptTestCase<DateFieldScript.Fa
                     @Override
                     public void execute() {
                         for (int i = 0; i <= AbstractFieldScript.MAX_VALUES; i++) {
-                            emit(0);
+                            new Emit(this).emit(0);
                         }
                     }
                 };
@@ -77,6 +82,33 @@ public class DateFieldScriptTests extends FieldScriptTestCase<DateFieldScript.Fa
                     e.getMessage(),
                     equalTo("Runtime field [test] is emitting [101] values while the maximum number of values allowed is [100]")
                 );
+            }
+        }
+    }
+
+    public final void testFromSourceDoesNotEnforceValuesLimit() throws IOException {
+        try (Directory directory = newDirectory(); RandomIndexWriter iw = new RandomIndexWriter(random(), directory)) {
+            int numValues = AbstractFieldScript.MAX_VALUES + randomIntBetween(1, 100);
+            XContentBuilder builder = JsonXContent.contentBuilder();
+            builder.startObject();
+            builder.startArray("field");
+            for (int i = 0; i < numValues; i++) {
+                builder.value(i);
+            }
+            builder.endArray();
+            builder.endObject();
+            iw.addDocument(List.of(new StoredField("_source", new BytesRef(Strings.toString(builder)))));
+            try (DirectoryReader reader = iw.getReader()) {
+                DateFieldScript.LeafFactory leafFactory = fromSource().newFactory(
+                    "field",
+                    Collections.emptyMap(),
+                    new SearchLookup(field -> null, (ft, lookup) -> null),
+                    DateFormatter.forPattern("epoch_millis")
+                );
+                DateFieldScript dateFieldScript = leafFactory.newInstance(reader.leaves().get(0));
+                List<Long> results = new ArrayList<>();
+                dateFieldScript.runForDoc(0, results::add);
+                assertEquals(numValues, results.size());
             }
         }
     }

--- a/server/src/test/java/org/elasticsearch/index/mapper/DoubleFieldScriptTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/DoubleFieldScriptTests.java
@@ -13,12 +13,17 @@ import org.apache.lucene.index.DirectoryReader;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.tests.index.RandomIndexWriter;
 import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.common.Strings;
 import org.elasticsearch.script.AbstractFieldScript;
 import org.elasticsearch.script.DoubleFieldScript;
 import org.elasticsearch.script.ScriptContext;
 import org.elasticsearch.search.lookup.SearchLookup;
+import org.elasticsearch.xcontent.XContentBuilder;
+import org.elasticsearch.xcontent.json.JsonXContent;
 
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -65,7 +70,7 @@ public class DoubleFieldScriptTests extends FieldScriptTestCase<DoubleFieldScrip
                     @Override
                     public void execute() {
                         for (int i = 0; i <= AbstractFieldScript.MAX_VALUES; i++) {
-                            emit(1.0);
+                            new Emit(this).emit(1.0);
                         }
                     }
                 };
@@ -74,6 +79,32 @@ public class DoubleFieldScriptTests extends FieldScriptTestCase<DoubleFieldScrip
                     e.getMessage(),
                     equalTo("Runtime field [test] is emitting [101] values while the maximum number of values allowed is [100]")
                 );
+            }
+        }
+    }
+
+    public final void testFromSourceDoesNotEnforceValuesLimit() throws IOException {
+        try (Directory directory = newDirectory(); RandomIndexWriter iw = new RandomIndexWriter(random(), directory)) {
+            int numValues = AbstractFieldScript.MAX_VALUES + randomIntBetween(1, 100);
+            XContentBuilder builder = JsonXContent.contentBuilder();
+            builder.startObject();
+            builder.startArray("field");
+            for (int i = 0; i < numValues; i++) {
+                builder.value(i + 0.1);
+            }
+            builder.endArray();
+            builder.endObject();
+            iw.addDocument(List.of(new StoredField("_source", new BytesRef(Strings.toString(builder)))));
+            try (DirectoryReader reader = iw.getReader()) {
+                DoubleFieldScript.LeafFactory leafFactory = fromSource().newFactory(
+                    "field",
+                    Collections.emptyMap(),
+                    new SearchLookup(field -> null, (ft, lookup) -> null)
+                );
+                DoubleFieldScript doubleFieldScript = leafFactory.newInstance(reader.leaves().get(0));
+                List<Double> results = new ArrayList<>();
+                doubleFieldScript.runForDoc(0, results::add);
+                assertEquals(numValues, results.size());
             }
         }
     }

--- a/server/src/test/java/org/elasticsearch/index/mapper/GeoPointFieldScriptTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/GeoPointFieldScriptTests.java
@@ -65,7 +65,7 @@ public class GeoPointFieldScriptTests extends FieldScriptTestCase<GeoPointFieldS
                     @Override
                     public void execute() {
                         for (int i = 0; i <= AbstractFieldScript.MAX_VALUES; i++) {
-                            emit(0, 0);
+                            new Emit(this).emit(0, 0);
                         }
                     }
                 };

--- a/server/src/test/java/org/elasticsearch/index/mapper/IpFieldScriptTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/IpFieldScriptTests.java
@@ -13,12 +13,18 @@ import org.apache.lucene.index.DirectoryReader;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.tests.index.RandomIndexWriter;
 import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.common.Strings;
 import org.elasticsearch.script.AbstractFieldScript;
 import org.elasticsearch.script.IpFieldScript;
 import org.elasticsearch.script.ScriptContext;
 import org.elasticsearch.search.lookup.SearchLookup;
+import org.elasticsearch.xcontent.XContentBuilder;
+import org.elasticsearch.xcontent.json.JsonXContent;
 
 import java.io.IOException;
+import java.net.InetAddress;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -65,7 +71,7 @@ public class IpFieldScriptTests extends FieldScriptTestCase<IpFieldScript.Factor
                     @Override
                     public void execute() {
                         for (int i = 0; i <= AbstractFieldScript.MAX_VALUES; i++) {
-                            emit("192.168.0.1");
+                            new Emit(this).emit("192.168.0.1");
                         }
                     }
                 };
@@ -74,6 +80,32 @@ public class IpFieldScriptTests extends FieldScriptTestCase<IpFieldScript.Factor
                     e.getMessage(),
                     equalTo("Runtime field [test] is emitting [101] values while the maximum number of values allowed is [100]")
                 );
+            }
+        }
+    }
+
+    public final void testFromSourceDoesNotEnforceValuesLimit() throws IOException {
+        try (Directory directory = newDirectory(); RandomIndexWriter iw = new RandomIndexWriter(random(), directory)) {
+            int numValues = AbstractFieldScript.MAX_VALUES + randomIntBetween(1, 100);
+            XContentBuilder builder = JsonXContent.contentBuilder();
+            builder.startObject();
+            builder.startArray("field");
+            for (int i = 0; i < numValues; i++) {
+                builder.value("192.168.0." + i);
+            }
+            builder.endArray();
+            builder.endObject();
+            iw.addDocument(List.of(new StoredField("_source", new BytesRef(Strings.toString(builder)))));
+            try (DirectoryReader reader = iw.getReader()) {
+                IpFieldScript.LeafFactory leafFactory = fromSource().newFactory(
+                    "field",
+                    Collections.emptyMap(),
+                    new SearchLookup(field -> null, (ft, lookup) -> null)
+                );
+                IpFieldScript ipFieldScript = leafFactory.newInstance(reader.leaves().get(0));
+                List<InetAddress> results = new ArrayList<>();
+                ipFieldScript.runForDoc(0, results::add);
+                assertEquals(numValues, results.size());
             }
         }
     }

--- a/server/src/test/java/org/elasticsearch/index/mapper/LongFieldScriptTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/LongFieldScriptTests.java
@@ -13,12 +13,17 @@ import org.apache.lucene.index.DirectoryReader;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.tests.index.RandomIndexWriter;
 import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.common.Strings;
 import org.elasticsearch.script.AbstractFieldScript;
 import org.elasticsearch.script.LongFieldScript;
 import org.elasticsearch.script.ScriptContext;
 import org.elasticsearch.search.lookup.SearchLookup;
+import org.elasticsearch.xcontent.XContentBuilder;
+import org.elasticsearch.xcontent.json.JsonXContent;
 
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -65,7 +70,7 @@ public class LongFieldScriptTests extends FieldScriptTestCase<LongFieldScript.Fa
                     @Override
                     public void execute() {
                         for (int i = 0; i <= AbstractFieldScript.MAX_VALUES; i++) {
-                            emit(0);
+                            new Emit(this).emit(0);
                         }
                     }
                 };
@@ -74,6 +79,32 @@ public class LongFieldScriptTests extends FieldScriptTestCase<LongFieldScript.Fa
                     e.getMessage(),
                     equalTo("Runtime field [test] is emitting [101] values while the maximum number of values allowed is [100]")
                 );
+            }
+        }
+    }
+
+    public final void testFromSourceDoesNotEnforceValuesLimit() throws IOException {
+        try (Directory directory = newDirectory(); RandomIndexWriter iw = new RandomIndexWriter(random(), directory)) {
+            int numValues = AbstractFieldScript.MAX_VALUES + randomIntBetween(1, 100);
+            XContentBuilder builder = JsonXContent.contentBuilder();
+            builder.startObject();
+            builder.startArray("field");
+            for (int i = 0; i < numValues; i++) {
+                builder.value(i);
+            }
+            builder.endArray();
+            builder.endObject();
+            iw.addDocument(List.of(new StoredField("_source", new BytesRef(Strings.toString(builder)))));
+            try (DirectoryReader reader = iw.getReader()) {
+                LongFieldScript.LeafFactory leafFactory = fromSource().newFactory(
+                    "field",
+                    Collections.emptyMap(),
+                    new SearchLookup(field -> null, (ft, lookup) -> null)
+                );
+                LongFieldScript longFieldScript = leafFactory.newInstance(reader.leaves().get(0));
+                List<Long> results = new ArrayList<>();
+                longFieldScript.runForDoc(0, results::add);
+                assertEquals(numValues, results.size());
             }
         }
     }

--- a/server/src/test/java/org/elasticsearch/index/mapper/StringFieldScriptTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/StringFieldScriptTests.java
@@ -13,12 +13,16 @@ import org.apache.lucene.index.DirectoryReader;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.tests.index.RandomIndexWriter;
 import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.common.Strings;
 import org.elasticsearch.script.AbstractFieldScript;
 import org.elasticsearch.script.ScriptContext;
 import org.elasticsearch.script.StringFieldScript;
 import org.elasticsearch.search.lookup.SearchLookup;
+import org.elasticsearch.xcontent.XContentBuilder;
+import org.elasticsearch.xcontent.json.JsonXContent;
 
 import java.io.IOException;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -65,7 +69,7 @@ public class StringFieldScriptTests extends FieldScriptTestCase<StringFieldScrip
                     @Override
                     public void execute() {
                         for (int i = 0; i <= AbstractFieldScript.MAX_VALUES; i++) {
-                            emit("test");
+                            new Emit(this).emit("test");
                         }
                     }
                 };
@@ -96,7 +100,7 @@ public class StringFieldScriptTests extends FieldScriptTestCase<StringFieldScrip
                         }
                         String bigString = big.toString();
                         for (int i = 0; i <= 4; i++) {
-                            emit(bigString);
+                            new Emit(this).emit(bigString);
                         }
                     }
                 };
@@ -105,6 +109,60 @@ public class StringFieldScriptTests extends FieldScriptTestCase<StringFieldScrip
                     e.getMessage(),
                     equalTo("Runtime field [test] is emitting [1310720] characters while the maximum number of values allowed is [1048576]")
                 );
+            }
+        }
+    }
+
+    public final void testFromSourceDoesNotEnforceValuesLimit() throws IOException {
+        try (Directory directory = newDirectory(); RandomIndexWriter iw = new RandomIndexWriter(random(), directory)) {
+            int numValues = AbstractFieldScript.MAX_VALUES + randomIntBetween(1, 100);
+            XContentBuilder builder = JsonXContent.contentBuilder();
+            builder.startObject();
+            builder.startArray("field");
+            for (int i = 0; i < numValues; i++) {
+                builder.value("value" + i);
+            }
+            builder.endArray();
+            builder.endObject();
+            iw.addDocument(List.of(new StoredField("_source", new BytesRef(Strings.toString(builder)))));
+            try (DirectoryReader reader = iw.getReader()) {
+                StringFieldScript.LeafFactory leafFactory = fromSource().newFactory(
+                    "field",
+                    Collections.emptyMap(),
+                    new SearchLookup(field -> null, (ft, lookup) -> null)
+                );
+                StringFieldScript stringFieldScript = leafFactory.newInstance(reader.leaves().get(0));
+                List<String> results = stringFieldScript.resultsForDoc(0);
+                assertEquals(numValues, results.size());
+            }
+        }
+    }
+
+    public final void testFromSourceDoesNotEnforceCharsLimit() throws IOException {
+        try (Directory directory = newDirectory(); RandomIndexWriter iw = new RandomIndexWriter(random(), directory)) {
+            StringBuilder big = new StringBuilder();
+            while (big.length() < StringFieldScript.MAX_CHARS / 4) {
+                big.append("test");
+            }
+            String bigString = big.toString();
+            XContentBuilder builder = JsonXContent.contentBuilder();
+            builder.startObject();
+            builder.startArray("field");
+            for (int i = 0; i <= 4; i++) {
+                builder.value(bigString);
+            }
+            builder.endArray();
+            builder.endObject();
+            iw.addDocument(List.of(new StoredField("_source", new BytesRef(Strings.toString(builder)))));
+            try (DirectoryReader reader = iw.getReader()) {
+                StringFieldScript.LeafFactory leafFactory = fromSource().newFactory(
+                    "field",
+                    Collections.emptyMap(),
+                    new SearchLookup(field -> null, (ft, lookup) -> null)
+                );
+                StringFieldScript stringFieldScript = leafFactory.newInstance(reader.leaves().get(0));
+                List<String> results = stringFieldScript.resultsForDoc(0);
+                assertEquals(5, results.size());
             }
         }
     }

--- a/server/src/test/java/org/elasticsearch/script/CompositeFieldScriptTests.java
+++ b/server/src/test/java/org/elasticsearch/script/CompositeFieldScriptTests.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.script;
+
+import org.apache.lucene.document.StoredField;
+import org.apache.lucene.index.DirectoryReader;
+import org.apache.lucene.store.Directory;
+import org.apache.lucene.tests.index.RandomIndexWriter;
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.search.lookup.SearchLookup;
+import org.elasticsearch.test.ESTestCase;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+
+import static org.hamcrest.Matchers.equalTo;
+
+public class CompositeFieldScriptTests extends ESTestCase {
+
+    public void testTooManyValues() throws IOException {
+        try (Directory directory = newDirectory(); RandomIndexWriter iw = new RandomIndexWriter(random(), directory)) {
+            iw.addDocument(List.of(new StoredField("_source", new BytesRef("{}"))));
+            try (DirectoryReader reader = iw.getReader()) {
+                CompositeFieldScript script = new CompositeFieldScript(
+                    "composite",
+                    Collections.emptyMap(),
+                    new SearchLookup(field -> null, (ft, lookup) -> null),
+                    reader.leaves().get(0)
+                ) {
+                    @Override
+                    public void execute() {
+                        for (int i = 0; i <= AbstractFieldScript.MAX_VALUES; i++) {
+                            emit("leaf", "value" + i);
+                        }
+                    }
+                };
+                Exception e = expectThrows(IllegalArgumentException.class, script::execute);
+                assertThat(
+                    e.getMessage(),
+                    equalTo("Runtime field [composite] is emitting [101] values while the maximum number of values allowed is [100]")
+                );
+            }
+        }
+    }
+
+    public void testTooManyChars() throws IOException {
+        try (Directory directory = newDirectory(); RandomIndexWriter iw = new RandomIndexWriter(random(), directory)) {
+            iw.addDocument(List.of(new StoredField("_source", new BytesRef("{}"))));
+            try (DirectoryReader reader = iw.getReader()) {
+                StringBuilder big = new StringBuilder();
+                while (big.length() < StringFieldScript.MAX_CHARS / 4) {
+                    big.append("test");
+                }
+                String bigString = big.toString();
+                CompositeFieldScript script = new CompositeFieldScript(
+                    "composite",
+                    Collections.emptyMap(),
+                    new SearchLookup(field -> null, (ft, lookup) -> null),
+                    reader.leaves().get(0)
+                ) {
+                    @Override
+                    public void execute() {
+                        for (int i = 0; i <= 4; i++) {
+                            emit("leaf", bigString);
+                        }
+                    }
+                };
+                StringFieldScript stringFieldScript = new StringFieldScript(
+                    "composite.leaf",
+                    Collections.emptyMap(),
+                    new SearchLookup(field -> null, (ft, lookup) -> null),
+                    reader.leaves().get(0)
+                ) {
+                    @Override
+                    public void execute() {
+                        emitFromCompositeScript(script);
+                    }
+                };
+
+                Exception e = expectThrows(IllegalArgumentException.class, stringFieldScript::execute);
+                assertThat(
+                    e.getMessage(),
+                    equalTo(
+                        "Runtime field [composite.leaf] is emitting [1310720] characters "
+                            + "while the maximum number of values allowed is [1048576]"
+                    )
+                );
+            }
+        }
+    }
+}

--- a/server/src/test/java/org/elasticsearch/script/field/SortedNumericDocValuesLongFieldScriptTests.java
+++ b/server/src/test/java/org/elasticsearch/script/field/SortedNumericDocValuesLongFieldScriptTests.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.script.field;
+
+import org.apache.lucene.document.FieldType;
+import org.apache.lucene.document.SortedNumericDocValuesField;
+import org.apache.lucene.index.DirectoryReader;
+import org.apache.lucene.index.DocValuesType;
+import org.apache.lucene.index.IndexableField;
+import org.apache.lucene.store.Directory;
+import org.apache.lucene.tests.index.RandomIndexWriter;
+import org.elasticsearch.script.AbstractFieldScript;
+import org.elasticsearch.search.lookup.SearchLookup;
+import org.elasticsearch.test.ESTestCase;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+public class SortedNumericDocValuesLongFieldScriptTests extends ESTestCase {
+
+    public void testValuesLimitIsNotEnforced() throws IOException {
+        try (Directory directory = newDirectory(); RandomIndexWriter iw = new RandomIndexWriter(random(), directory)) {
+            FieldType fieldType = new FieldType();
+            fieldType.setDocValuesType(DocValuesType.BINARY);
+            List<IndexableField> fields = new ArrayList<>();
+            int numValues = AbstractFieldScript.MAX_VALUES + randomIntBetween(1, 100);
+            for (int i = 0; i < numValues; i++) {
+                fields.add(new SortedNumericDocValuesField("test", i));
+            }
+            iw.addDocument(fields);
+            try (DirectoryReader reader = iw.getReader()) {
+                SortedNumericDocValuesLongFieldScript docValues = new SortedNumericDocValuesLongFieldScript(
+                    "test",
+                    new SearchLookup(field -> null, (ft, lookup) -> null),
+                    reader.leaves().get(0)
+                );
+                List<Long> values = new ArrayList<>();
+                docValues.runForDoc(0, values::add);
+                assertEquals(numValues, values.size());
+            }
+        }
+    }
+}

--- a/server/src/test/java/org/elasticsearch/script/field/SortedSetDocValuesStringFieldScriptTests.java
+++ b/server/src/test/java/org/elasticsearch/script/field/SortedSetDocValuesStringFieldScriptTests.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.script.field;
+
+import org.apache.lucene.document.FieldType;
+import org.apache.lucene.document.SortedSetDocValuesField;
+import org.apache.lucene.index.DirectoryReader;
+import org.apache.lucene.index.DocValuesType;
+import org.apache.lucene.index.IndexableField;
+import org.apache.lucene.store.Directory;
+import org.apache.lucene.tests.index.RandomIndexWriter;
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.script.AbstractFieldScript;
+import org.elasticsearch.search.lookup.SearchLookup;
+import org.elasticsearch.test.ESTestCase;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+public class SortedSetDocValuesStringFieldScriptTests extends ESTestCase {
+
+    public void testValuesLimitIsNotEnforced() throws IOException {
+        try (Directory directory = newDirectory(); RandomIndexWriter iw = new RandomIndexWriter(random(), directory)) {
+            FieldType fieldType = new FieldType();
+            fieldType.setDocValuesType(DocValuesType.BINARY);
+            List<IndexableField> fields = new ArrayList<>();
+            int numValues = AbstractFieldScript.MAX_VALUES + randomIntBetween(1, 100);
+            for (int i = 0; i < numValues; i++) {
+                fields.add(new SortedSetDocValuesField("test", new BytesRef("term" + i)));
+            }
+            iw.addDocument(fields);
+            try (DirectoryReader reader = iw.getReader()) {
+                SortedSetDocValuesStringFieldScript docValues = new SortedSetDocValuesStringFieldScript(
+                    "test",
+                    new SearchLookup(field -> null, (ft, lookup) -> null),
+                    reader.leaves().get(0)
+                );
+                List<String> values = new ArrayList<>();
+                docValues.runForDoc(0, values::add);
+                assertEquals(numValues, values.size());
+            }
+        }
+    }
+}


### PR DESCRIPTION
Backports the following commits to 8.3:
 - Enforce max values limit only when running a script (#88295)