### PR TITLE
Limit test to zoom 25 to avoid rounding errors

### DIFF
--- a/docs/changelog/88376.yaml
+++ b/docs/changelog/88376.yaml
@@ -1,0 +1,6 @@
+pr: 88376
+summary: Limit test to zoom 25 to avoid rounding errors
+area: Geo
+type: bug
+issues:
+ - 88259

--- a/docs/changelog/88376.yaml
+++ b/docs/changelog/88376.yaml
@@ -1,6 +1,0 @@
-pr: 88376
-summary: Limit test to zoom 25 to avoid rounding errors
-area: Geo
-type: bug
-issues:
- - 88259

--- a/x-pack/plugin/spatial/src/internalClusterTest/java/org/elasticsearch/xpack/spatial/search/GeoGridAggAndQueryConsistencyIT.java
+++ b/x-pack/plugin/spatial/src/internalClusterTest/java/org/elasticsearch/xpack/spatial/search/GeoGridAggAndQueryConsistencyIT.java
@@ -68,6 +68,7 @@ public class GeoGridAggAndQueryConsistencyIT extends ESIntegTestCase {
     public void testGeoPointGeoTile() throws IOException {
         doTestGeotileGrid(
             GeoPointFieldMapper.CONTENT_TYPE,
+            GeoTileUtils.MAX_ZOOM - 4,  // levels 26 and above have some rounding errors, but this is past the index resolution
             // just generate points on bounds
             () -> randomValueOtherThanMany(
                 p -> p.getLat() > GeoTileUtils.NORMALIZED_LATITUDE_MASK || p.getLat() < GeoTileUtils.NORMALIZED_NEGATIVE_LATITUDE_MASK,
@@ -86,7 +87,11 @@ public class GeoGridAggAndQueryConsistencyIT extends ESIntegTestCase {
     }
 
     public void testGeoShapeGeoTile() throws IOException {
-        doTestGeotileGrid(GeoShapeWithDocValuesFieldMapper.CONTENT_TYPE, () -> GeometryTestUtils.randomGeometryWithoutCircle(0, false));
+        doTestGeotileGrid(
+            GeoShapeWithDocValuesFieldMapper.CONTENT_TYPE,
+            GeoTileUtils.MAX_ZOOM - 1,
+            () -> GeometryTestUtils.randomGeometryWithoutCircle(0, false)
+        );
     }
 
     private void doTestGeohashGrid(String fieldType, Supplier<Geometry> randomGeometriesSupplier) throws IOException {
@@ -103,10 +108,10 @@ public class GeoGridAggAndQueryConsistencyIT extends ESIntegTestCase {
         );
     }
 
-    private void doTestGeotileGrid(String fieldType, Supplier<Geometry> randomGeometriesSupplier) throws IOException {
+    private void doTestGeotileGrid(String fieldType, int maxPrecision, Supplier<Geometry> randomGeometriesSupplier) throws IOException {
         doTestGrid(
             0,
-            GeoTileUtils.MAX_ZOOM - 1,
+            maxPrecision,
             fieldType,
             (precision, point) -> GeoTileUtils.stringEncode(GeoTileUtils.longEncode(point.getLon(), point.getLat(), precision)),
             tile -> toPoints(GeoTileUtils.toBoundingBox(tile)),
@@ -181,7 +186,7 @@ public class GeoGridAggAndQueryConsistencyIT extends ESIntegTestCase {
             GeoGridAggregationBuilder builderPoint = aggBuilder.apply("geometry").field("geometry").precision(i);
             SearchResponse response = client().prepareSearch("test").addAggregation(builderPoint).setSize(0).get();
             InternalGeoGrid<?> gridPoint = response.getAggregations().get("geometry");
-            assertQuery(gridPoint.getBuckets(), queryBuilder);
+            assertQuery(gridPoint.getBuckets(), queryBuilder, i);
         }
 
         builder = client().prepareBulk();
@@ -209,16 +214,20 @@ public class GeoGridAggAndQueryConsistencyIT extends ESIntegTestCase {
                 .size(256 * 256);
             SearchResponse response = client().prepareSearch("test").addAggregation(builderPoint).setSize(0).get();
             InternalGeoGrid<?> gridPoint = response.getAggregations().get("geometry");
-            assertQuery(gridPoint.getBuckets(), queryBuilder);
+            assertQuery(gridPoint.getBuckets(), queryBuilder, i);
         }
     }
 
-    private void assertQuery(List<InternalGeoGridBucket> buckets, BiFunction<String, String, QueryBuilder> queryFunction) {
+    private void assertQuery(List<InternalGeoGridBucket> buckets, BiFunction<String, String, QueryBuilder> queryFunction, int precision) {
         for (InternalGeoGridBucket bucket : buckets) {
             assertThat(bucket.getDocCount(), Matchers.greaterThan(0L));
             QueryBuilder queryBuilder = queryFunction.apply("geometry", bucket.getKeyAsString());
             SearchResponse response = client().prepareSearch("test").setTrackTotalHits(true).setQuery(queryBuilder).get();
-            assertThat(response.getHits().getTotalHits().value, Matchers.equalTo(bucket.getDocCount()));
+            assertThat(
+                "Expected hits at precision " + precision,
+                response.getHits().getTotalHits().value,
+                Matchers.equalTo(bucket.getDocCount())
+            );
         }
     }
 


### PR DESCRIPTION
We have flaky tests with rare rounding errors at higher precision.
Since the index only really works well to this level, we feel it is best to simply limit the test.

Fixes #88259 