### PR TITLE
Extract utility for asserting current thread pool

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/stats/TransportClusterStatsAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/stats/TransportClusterStatsAction.java
@@ -112,7 +112,7 @@ public class TransportClusterStatsAction extends TransportNodesAction<
             "Computation of mapping/analysis stats runs expensive computations on mappings found in "
                 + "the cluster state that are too slow for a transport thread"
         );
-        assert Thread.currentThread().getName().contains("[" + ThreadPool.Names.MANAGEMENT + "]") : Thread.currentThread().getName();
+        assert ThreadPool.assertCurrentThreadPool(ThreadPool.Names.MANAGEMENT);
         assert task instanceof CancellableTask;
         final CancellableTask cancellableTask = (CancellableTask) task;
         final ClusterState state = clusterService.state();

--- a/server/src/main/java/org/elasticsearch/action/search/CanMatchPreFilterSearchPhase.java
+++ b/server/src/main/java/org/elasticsearch/action/search/CanMatchPreFilterSearchPhase.java
@@ -129,9 +129,7 @@ final class CanMatchPreFilterSearchPhase extends SearchPhase {
     }
 
     private static boolean assertSearchCoordinationThread() {
-        assert Thread.currentThread().getName().contains(ThreadPool.Names.SEARCH_COORDINATION)
-            : "not called from the right thread " + Thread.currentThread().getName();
-        return true;
+        return ThreadPool.assertCurrentThreadPool(ThreadPool.Names.SEARCH_COORDINATION);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/cluster/coordination/Coordinator.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/Coordinator.java
@@ -64,6 +64,7 @@ import org.elasticsearch.discovery.TransportAddressConnector;
 import org.elasticsearch.monitor.NodeHealthService;
 import org.elasticsearch.monitor.StatusInfo;
 import org.elasticsearch.threadpool.Scheduler;
+import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.threadpool.ThreadPool.Names;
 import org.elasticsearch.transport.NodeDisconnectedException;
 import org.elasticsearch.transport.TransportRequest;
@@ -396,8 +397,7 @@ public class Coordinator extends AbstractLifecycleComponent implements ClusterSt
     }
 
     private void onClusterStateApplied() {
-        assert Thread.currentThread().getName().contains('[' + ClusterApplierService.CLUSTER_UPDATE_THREAD_NAME + ']')
-            || Thread.currentThread().getName().startsWith("TEST-") : Thread.currentThread().getName();
+        assert ThreadPool.assertCurrentThreadPool(ClusterApplierService.CLUSTER_UPDATE_THREAD_NAME);
         if (getMode() != Mode.CANDIDATE) {
             joinHelper.onClusterStateApplied();
         }

--- a/server/src/main/java/org/elasticsearch/cluster/coordination/JoinHelper.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/JoinHelper.java
@@ -246,10 +246,7 @@ public class JoinHelper {
                         new ActionListener<>() {
                             @Override
                             public void onResponse(Void unused) {
-                                assert Thread.currentThread()
-                                    .getName()
-                                    .contains('[' + ClusterApplierService.CLUSTER_UPDATE_THREAD_NAME + ']')
-                                    || Thread.currentThread().getName().startsWith("TEST-") : Thread.currentThread().getName();
+                                assert ThreadPool.assertCurrentThreadPool(ClusterApplierService.CLUSTER_UPDATE_THREAD_NAME);
                                 pendingJoinInfo.message = PENDING_JOIN_WAITING_RESPONSE;
                                 transportService.sendRequest(
                                     destination,

--- a/server/src/main/java/org/elasticsearch/cluster/coordination/JoinReasonService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/JoinReasonService.java
@@ -17,6 +17,7 @@ import org.elasticsearch.common.util.concurrent.ConcurrentCollections;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.core.Tuple;
+import org.elasticsearch.threadpool.ThreadPool;
 
 import java.util.ArrayList;
 import java.util.Comparator;
@@ -50,8 +51,7 @@ public class JoinReasonService {
      * Called when a new cluster state was applied by a master-eligible node, possibly adding or removing some nodes.
      */
     public void onClusterStateApplied(DiscoveryNodes discoveryNodes) {
-        assert Thread.currentThread().getName().contains('[' + ClusterApplierService.CLUSTER_UPDATE_THREAD_NAME + ']')
-            || Thread.currentThread().getName().startsWith("TEST-") : Thread.currentThread().getName();
+        assert ThreadPool.assertCurrentThreadPool(ClusterApplierService.CLUSTER_UPDATE_THREAD_NAME);
         assert discoveryNodes.getLocalNode().isMasterNode();
 
         if (this.discoveryNodes != discoveryNodes) {
@@ -98,8 +98,7 @@ public class JoinReasonService {
      * absent node is still tracked then this adds the removal reason ({@code disconnected}, {@code lagging}, etc.) to the tracker.
      */
     public void onNodeRemoved(DiscoveryNode discoveryNode, String reason) {
-        assert MasterService.isMasterUpdateThread() || Thread.currentThread().getName().startsWith("TEST-")
-            : Thread.currentThread().getName();
+        assert MasterService.assertMasterUpdateOrTestThread();
         trackedNodes.computeIfPresent(discoveryNode.getId(), (ignored, trackedNode) -> trackedNode.withRemovalReason(reason));
     }
 

--- a/server/src/main/java/org/elasticsearch/cluster/routing/RoutingNodes.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/RoutingNodes.java
@@ -275,8 +275,7 @@ public class RoutingNodes extends AbstractCollection<RoutingNode> {
 
     public Set<String> getAttributeValues(String attributeName) {
         // Only ever accessed on the master service thread so no need for synchronization
-        assert MasterService.isMasterUpdateThread() || Thread.currentThread().getName().startsWith("TEST-")
-            : Thread.currentThread().getName() + " should be the master service thread";
+        assert MasterService.assertMasterUpdateOrTestThread();
         return attributeValuesByAttribute.computeIfAbsent(
             attributeName,
             ignored -> stream().map(r -> r.node().getAttributes().get(attributeName)).filter(Objects::nonNull).collect(Collectors.toSet())

--- a/server/src/main/java/org/elasticsearch/cluster/service/ClusterService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/service/ClusterService.java
@@ -195,10 +195,10 @@ public class ClusterService extends AbstractLifecycleComponent {
     }
 
     public static boolean assertClusterOrMasterStateThread() {
-        assert Thread.currentThread().getName().contains(ClusterApplierService.CLUSTER_UPDATE_THREAD_NAME)
-            || Thread.currentThread().getName().contains(MasterService.MASTER_UPDATE_THREAD_NAME)
-            : "not called from the master/cluster state update thread";
-        return true;
+        return ThreadPool.assertCurrentThreadPool(
+            ClusterApplierService.CLUSTER_UPDATE_THREAD_NAME,
+            MasterService.MASTER_UPDATE_THREAD_NAME
+        );
     }
 
     public ClusterName getClusterName() {

--- a/server/src/main/java/org/elasticsearch/cluster/service/MasterService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/service/MasterService.java
@@ -225,6 +225,10 @@ public class MasterService extends AbstractLifecycleComponent {
         return Thread.currentThread().getName().contains('[' + MASTER_UPDATE_THREAD_NAME + ']');
     }
 
+    public static boolean assertMasterUpdateOrTestThread() {
+        return ThreadPool.assertCurrentThreadPool(MASTER_UPDATE_THREAD_NAME);
+    }
+
     public static boolean assertNotMasterUpdateThread(String reason) {
         assert isMasterUpdateThread() == false
             : "Expected current thread [" + Thread.currentThread() + "] to not be the master service thread. Reason: [" + reason + "]";
@@ -794,8 +798,7 @@ public class MasterService extends AbstractLifecycleComponent {
         }
 
         private boolean incomplete() {
-            assert MasterService.isMasterUpdateThread() || Thread.currentThread().getName().startsWith("TEST-")
-                : Thread.currentThread().getName();
+            assert assertMasterUpdateOrTestThread();
             return publishedStateConsumer == null && onPublicationSuccess == null && failure == null;
         }
 

--- a/server/src/main/java/org/elasticsearch/common/io/DiskIoBufferPool.java
+++ b/server/src/main/java/org/elasticsearch/common/io/DiskIoBufferPool.java
@@ -13,7 +13,6 @@ import org.elasticsearch.core.Nullable;
 import org.elasticsearch.threadpool.ThreadPool;
 
 import java.nio.ByteBuffer;
-import java.util.Arrays;
 
 public class DiskIoBufferPool {
 
@@ -50,14 +49,15 @@ public class DiskIoBufferPool {
         return ioBuffer.clear();
     }
 
+    private static final String[] WRITE_OR_FLUSH_THREAD_NAMES = new String[] {
+        "[" + ThreadPool.Names.WRITE + "]",
+        "[" + ThreadPool.Names.FLUSH + "]",
+        "[" + ThreadPool.Names.SYSTEM_WRITE + "]",
+        "[" + ThreadPool.Names.SYSTEM_CRITICAL_WRITE + "]" };
+
     private static boolean isWriteOrFlushThread() {
         String threadName = Thread.currentThread().getName();
-        for (String s : Arrays.asList(
-            "[" + ThreadPool.Names.WRITE + "]",
-            "[" + ThreadPool.Names.FLUSH + "]",
-            "[" + ThreadPool.Names.SYSTEM_WRITE + "]",
-            "[" + ThreadPool.Names.SYSTEM_CRITICAL_WRITE + "]"
-        )) {
+        for (String s : WRITE_OR_FLUSH_THREAD_NAMES) {
             if (threadName.contains(s)) {
                 return true;
             }

--- a/server/src/main/java/org/elasticsearch/index/shard/StoreRecovery.java
+++ b/server/src/main/java/org/elasticsearch/index/shard/StoreRecovery.java
@@ -545,9 +545,7 @@ public final class StoreRecovery {
             }
             assert indexShard.getEngineOrNull() == null;
             indexIdListener.whenComplete(idx -> {
-                assert Thread.currentThread().getName().contains('[' + ThreadPool.Names.GENERIC + ']')
-                    || Thread.currentThread().getName().contains('[' + ThreadPool.Names.SNAPSHOT + ']')
-                    || Thread.currentThread().getName().startsWith("TEST-") : Thread.currentThread().getName();
+                assert ThreadPool.assertCurrentThreadPool(ThreadPool.Names.GENERIC, ThreadPool.Names.SNAPSHOT);
                 repository.restoreShard(
                     indexShard.store(),
                     restoreSource.snapshot().getSnapshotId(),

--- a/server/src/main/java/org/elasticsearch/indices/recovery/plan/ShardSnapshotsService.java
+++ b/server/src/main/java/org/elasticsearch/indices/recovery/plan/ShardSnapshotsService.java
@@ -109,7 +109,7 @@ public class ShardSnapshotsService {
     }
 
     private Optional<ShardSnapshot> fetchSnapshotFiles(GetShardSnapshotResponse shardSnapshotResponse) {
-        assert Thread.currentThread().getName().contains(ThreadPool.Names.GENERIC);
+        assert ThreadPool.assertCurrentThreadPool(ThreadPool.Names.GENERIC);
 
         final Optional<ShardSnapshotInfo> latestShardSnapshotOpt = shardSnapshotResponse.getLatestShardSnapshot();
         if (latestShardSnapshotOpt.isEmpty()) {

--- a/server/src/main/java/org/elasticsearch/repositories/IndexSnapshotsService.java
+++ b/server/src/main/java/org/elasticsearch/repositories/IndexSnapshotsService.java
@@ -95,8 +95,7 @@ public class IndexSnapshotsService {
         }, listener::onFailure);
 
         snapshotInfoStepListener.whenComplete(fetchSnapshotContext -> {
-            assert Thread.currentThread().getName().contains('[' + ThreadPool.Names.SNAPSHOT_META + ']')
-                : "Expected current thread [" + Thread.currentThread() + "] to be a snapshot meta thread.";
+            assert ThreadPool.assertCurrentThreadPool(ThreadPool.Names.SNAPSHOT_META);
             final SnapshotInfo snapshotInfo = fetchSnapshotContext.getSnapshotInfo();
 
             if (snapshotInfo == null || snapshotInfo.state() != SnapshotState.SUCCESS) {

--- a/server/src/main/java/org/elasticsearch/repositories/Repository.java
+++ b/server/src/main/java/org/elasticsearch/repositories/Repository.java
@@ -317,9 +317,6 @@ public interface Repository extends LifecycleComponent {
     void awaitIdle();
 
     static boolean assertSnapshotMetaThread() {
-        final String threadName = Thread.currentThread().getName();
-        assert threadName.contains('[' + ThreadPool.Names.SNAPSHOT_META + ']') || threadName.startsWith("TEST-")
-            : "Expected current thread [" + Thread.currentThread() + "] to be a snapshot meta thread.";
-        return true;
+        return ThreadPool.assertCurrentThreadPool(ThreadPool.Names.SNAPSHOT_META);
     }
 }

--- a/server/src/main/java/org/elasticsearch/repositories/blobstore/BlobStoreRepository.java
+++ b/server/src/main/java/org/elasticsearch/repositories/blobstore/BlobStoreRepository.java
@@ -1636,10 +1636,7 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
     }
 
     protected void assertSnapshotOrGenericThread() {
-        assert Thread.currentThread().getName().contains('[' + ThreadPool.Names.SNAPSHOT + ']')
-            || Thread.currentThread().getName().contains('[' + ThreadPool.Names.SNAPSHOT_META + ']')
-            || Thread.currentThread().getName().contains('[' + ThreadPool.Names.GENERIC + ']')
-            : "Expected current thread [" + Thread.currentThread() + "] to be the snapshot or generic thread.";
+        assert ThreadPool.assertCurrentThreadPool(ThreadPool.Names.SNAPSHOT, ThreadPool.Names.SNAPSHOT_META, ThreadPool.Names.GENERIC);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/threadpool/ThreadPool.java
+++ b/server/src/main/java/org/elasticsearch/threadpool/ThreadPool.java
@@ -908,6 +908,15 @@ public class ThreadPool implements ReportingService<ThreadPoolInfo>, Scheduler {
         return true;
     }
 
+    public static boolean assertCurrentThreadPool(String... permittedThreadPoolNames) {
+        final var threadName = Thread.currentThread().getName();
+        assert threadName.startsWith("TEST-")
+            || threadName.startsWith("LuceneTestCase")
+            || Arrays.stream(permittedThreadPoolNames).anyMatch(n -> threadName.contains('[' + n + ']'))
+            : threadName + " not in " + Arrays.toString(permittedThreadPoolNames) + " nor a test thread";
+        return true;
+    }
+
     public static boolean assertCurrentMethodIsNotCalledRecursively() {
         final StackTraceElement[] stackTraceElements = Thread.currentThread().getStackTrace();
         assert stackTraceElements.length >= 3 : stackTraceElements.length;

--- a/server/src/main/java/org/elasticsearch/transport/Transports.java
+++ b/server/src/main/java/org/elasticsearch/transport/Transports.java
@@ -12,7 +12,6 @@ import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.http.HttpServerTransport;
 import org.elasticsearch.tasks.Task;
 
-import java.util.Arrays;
 import java.util.Set;
 
 public enum Transports {
@@ -26,6 +25,11 @@ public enum Transports {
     /** threads whose name is prefixed by this string will be considered network threads, even though they aren't */
     public static final String TEST_MOCK_TRANSPORT_THREAD_PREFIX = "__mock_network_thread";
 
+    private static final String[] TRANSPORT_THREAD_NAMES = new String[] {
+        '[' + HttpServerTransport.HTTP_SERVER_WORKER_THREAD_NAME_PREFIX + ']',
+        '[' + TcpTransport.TRANSPORT_WORKER_THREAD_NAME_PREFIX + ']',
+        TEST_MOCK_TRANSPORT_THREAD_PREFIX };
+
     /**
      * Utility method to detect whether a thread is a network thread. Typically
      * used in assertions to make sure that we do not call blocking code from
@@ -33,11 +37,7 @@ public enum Transports {
      */
     public static boolean isTransportThread(Thread t) {
         final String threadName = t.getName();
-        for (String s : Arrays.asList(
-            HttpServerTransport.HTTP_SERVER_WORKER_THREAD_NAME_PREFIX,
-            TcpTransport.TRANSPORT_WORKER_THREAD_NAME_PREFIX,
-            TEST_MOCK_TRANSPORT_THREAD_PREFIX
-        )) {
+        for (String s : TRANSPORT_THREAD_NAMES) {
             if (threadName.contains(s)) {
                 return true;
             }

--- a/x-pack/plugin/enrich/src/main/java/org/elasticsearch/xpack/enrich/action/EnrichCoordinatorProxyAction.java
+++ b/x-pack/plugin/enrich/src/main/java/org/elasticsearch/xpack/enrich/action/EnrichCoordinatorProxyAction.java
@@ -71,10 +71,12 @@ public class EnrichCoordinatorProxyAction extends ActionType<SearchResponse> {
             // Management tp is expected when executing enrich processor from ingest simulate api
             // Search tp is allowed for now - After enriching, the remaining parts of the pipeline are processed on the
             // search thread, which could end up here again if there is more than one enrich processor in a pipeline.
-            assert Thread.currentThread().getName().contains(ThreadPool.Names.WRITE)
-                || Thread.currentThread().getName().contains(ThreadPool.Names.SYSTEM_WRITE)
-                || Thread.currentThread().getName().contains(ThreadPool.Names.SEARCH)
-                || Thread.currentThread().getName().contains(ThreadPool.Names.MANAGEMENT);
+            assert ThreadPool.assertCurrentThreadPool(
+                ThreadPool.Names.WRITE,
+                ThreadPool.Names.SYSTEM_WRITE,
+                ThreadPool.Names.SEARCH,
+                ThreadPool.Names.MANAGEMENT
+            );
             coordinator.schedule(request, listener);
         }
     }

--- a/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/allocation/SearchableSnapshotIndexEventListener.java
+++ b/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/allocation/SearchableSnapshotIndexEventListener.java
@@ -56,7 +56,7 @@ public class SearchableSnapshotIndexEventListener implements IndexEventListener 
      */
     @Override
     public void beforeIndexShardRecovery(IndexShard indexShard, IndexSettings indexSettings) {
-        assert Thread.currentThread().getName().contains(ThreadPool.Names.GENERIC);
+        assert ThreadPool.assertCurrentThreadPool(ThreadPool.Names.GENERIC);
         ensureSnapshotIsLoaded(indexShard);
     }
 

--- a/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/cache/blob/BlobStoreCacheMaintenanceService.java
+++ b/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/cache/blob/BlobStoreCacheMaintenanceService.java
@@ -368,7 +368,7 @@ public class BlobStoreCacheMaintenanceService implements ClusterStateListener {
         }
 
         void executeNextCleanUp(final Queue<Tuple<DeleteByQueryRequest, ActionListener<BulkByScrollResponse>>> queue) {
-            assert Thread.currentThread().getName().contains(ThreadPool.Names.GENERIC);
+            assert ThreadPool.assertCurrentThreadPool(ThreadPool.Names.GENERIC);
             final Tuple<DeleteByQueryRequest, ActionListener<BulkByScrollResponse>> next = queue.poll();
             if (next != null) {
                 cleanUp(next.v1(), next.v2(), queue);
@@ -380,7 +380,7 @@ public class BlobStoreCacheMaintenanceService implements ClusterStateListener {
             final ActionListener<BulkByScrollResponse> listener,
             final Queue<Tuple<DeleteByQueryRequest, ActionListener<BulkByScrollResponse>>> queue
         ) {
-            assert Thread.currentThread().getName().contains(ThreadPool.Names.GENERIC);
+            assert ThreadPool.assertCurrentThreadPool(ThreadPool.Names.GENERIC);
             clientWithOrigin.execute(DeleteByQueryAction.INSTANCE, request, ActionListener.runAfter(listener, () -> {
                 if (queue.isEmpty() == false) {
                     threadPool.generic().execute(() -> executeNextCleanUp(queue));
@@ -429,7 +429,7 @@ public class BlobStoreCacheMaintenanceService implements ClusterStateListener {
 
         @Override
         public void run() {
-            assert assertGenericThread();
+            assert ThreadPool.assertCurrentThreadPool(ThreadPool.Names.GENERIC);
             try {
                 ensureOpen();
                 if (pointIntTimeId == null) {
@@ -680,12 +680,6 @@ public class BlobStoreCacheMaintenanceService implements ClusterStateListener {
 
     private void executeNext(PeriodicMaintenanceTask maintenanceTask) {
         threadPool.generic().execute(maintenanceTask);
-    }
-
-    private static boolean assertGenericThread() {
-        final String threadName = Thread.currentThread().getName();
-        assert threadName.contains(ThreadPool.Names.GENERIC) : threadName;
-        return true;
     }
 
     private static Instant getCreationTime(SearchHit searchHit) {

--- a/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/cache/full/CacheService.java
+++ b/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/cache/full/CacheService.java
@@ -370,7 +370,7 @@ public class CacheService extends AbstractLifecycleComponent {
      * @param shardId           the {@link ShardId}
      */
     public void waitForCacheFilesEvictionIfNeeded(String snapshotUUID, String snapshotIndexName, ShardId shardId) {
-        assert assertGenericThreadPool();
+        assert ThreadPool.assertCurrentThreadPool(ThreadPool.Names.GENERIC);
         final Future<?> future;
         synchronized (shardsEvictionsMutex) {
             if (allowShardsEvictions == false) {
@@ -391,7 +391,7 @@ public class CacheService extends AbstractLifecycleComponent {
      */
     private void processShardEviction(ShardEviction shardEviction) {
         assert isPendingShardEviction(shardEviction) : "shard is not marked as evicted: " + shardEviction;
-        assert assertGenericThreadPool();
+        assert ThreadPool.assertCurrentThreadPool(ThreadPool.Names.GENERIC);
 
         shardsEvictionsLock.readLock().lock();
         try {
@@ -733,13 +733,6 @@ public class CacheService extends AbstractLifecycleComponent {
                 && Objects.equals(snapshotIndexName, cacheKey.getSnapshotIndexName())
                 && Objects.equals(shardId, cacheKey.getShardId());
         }
-    }
-
-    private static boolean assertGenericThreadPool() {
-        final String threadName = Thread.currentThread().getName();
-        assert threadName.contains('[' + ThreadPool.Names.GENERIC + ']') || threadName.startsWith("TEST-")
-            : "expected generic thread pool but got " + threadName;
-        return true;
     }
 
     private enum CacheFileEventType {

--- a/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/store/SearchableSnapshotDirectory.java
+++ b/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/store/SearchableSnapshotDirectory.java
@@ -193,15 +193,6 @@ public class SearchableSnapshotDirectory extends BaseDirectory {
         return true;
     }
 
-    protected final boolean assertCurrentThreadMayLoadSnapshot() {
-        final String threadName = Thread.currentThread().getName();
-        assert threadName.contains('[' + ThreadPool.Names.GENERIC + ']')
-            // Unit tests access the blob store on the main test thread; simplest just to permit this rather than have them override this
-            // method somehow.
-            || threadName.startsWith("TEST-") : "current thread [" + Thread.currentThread() + "] may not load " + snapshotId;
-        return true;
-    }
-
     /**
      * Loads the snapshot if and only if the snapshot is not loaded yet.
      *
@@ -213,7 +204,7 @@ public class SearchableSnapshotDirectory extends BaseDirectory {
         assert snapshotRecoveryState.getRecoverySource().getType() == RecoverySource.Type.SNAPSHOT
             || snapshotRecoveryState.getRecoverySource().getType() == RecoverySource.Type.PEER
             : snapshotRecoveryState.getRecoverySource().getType();
-        assert assertCurrentThreadMayLoadSnapshot();
+        assert ThreadPool.assertCurrentThreadPool(ThreadPool.Names.GENERIC);
         // noinspection ConstantConditions in case assertions are disabled
         if (snapshotRecoveryState instanceof SearchableSnapshotRecoveryState == false) {
             throw new IllegalArgumentException("A SearchableSnapshotRecoveryState instance was expected");

--- a/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/store/input/BaseSearchableSnapshotIndexInput.java
+++ b/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/store/input/BaseSearchableSnapshotIndexInput.java
@@ -288,22 +288,18 @@ public abstract class BaseSearchableSnapshotIndexInput extends BufferedIndexInpu
     }
 
     protected final boolean assertCurrentThreadMayAccessBlobStore() {
-        final String threadName = Thread.currentThread().getName();
-        assert threadName.contains('[' + ThreadPool.Names.SNAPSHOT + ']')
-            || threadName.contains('[' + ThreadPool.Names.GENERIC + ']')
-            || threadName.contains('[' + ThreadPool.Names.SEARCH + ']')
-            || threadName.contains('[' + ThreadPool.Names.SEARCH_THROTTLED + ']')
+        return ThreadPool.assertCurrentThreadPool(
+            ThreadPool.Names.SNAPSHOT,
+            ThreadPool.Names.GENERIC,
+            ThreadPool.Names.SEARCH,
+            ThreadPool.Names.SEARCH_THROTTLED,
 
             // Cache asynchronous fetching runs on a dedicated thread pool.
-            || threadName.contains('[' + SearchableSnapshots.CACHE_FETCH_ASYNC_THREAD_POOL_NAME + ']')
+            SearchableSnapshots.CACHE_FETCH_ASYNC_THREAD_POOL_NAME,
 
             // Cache prewarming also runs on a dedicated thread pool.
-            || threadName.contains('[' + SearchableSnapshots.CACHE_PREWARMING_THREAD_POOL_NAME + ']')
-
-            // Unit tests access the blob store on the main test thread; simplest just to permit this rather than have them override this
-            || threadName.startsWith("TEST-")
-            || threadName.startsWith("LuceneTestCase") : "current thread [" + Thread.currentThread() + "] may not read " + fileInfo;
-        return true;
+            SearchableSnapshots.CACHE_PREWARMING_THREAD_POOL_NAME
+        );
     }
 
     protected static boolean isCacheFetchAsyncThread(final String threadName) {

--- a/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/store/input/FrozenIndexInput.java
+++ b/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/store/input/FrozenIndexInput.java
@@ -16,6 +16,8 @@ import org.apache.lucene.store.IndexInput;
 import org.elasticsearch.action.StepListener;
 import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.index.snapshots.blobstore.BlobStoreIndexShardSnapshot.FileInfo;
+import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.xpack.searchablesnapshots.SearchableSnapshots;
 import org.elasticsearch.xpack.searchablesnapshots.cache.common.ByteRange;
 import org.elasticsearch.xpack.searchablesnapshots.cache.shared.FrozenCacheService.FrozenCacheFile;
 import org.elasticsearch.xpack.searchablesnapshots.cache.shared.SharedBytes;
@@ -177,7 +179,7 @@ public class FrozenIndexInput extends MetadataCachingIndexInput {
     }
 
     private static int positionalWrite(SharedBytes.IO fc, long start, ByteBuffer byteBuffer) throws IOException {
-        assert assertCurrentThreadMayWriteCacheFile();
+        assert ThreadPool.assertCurrentThreadPool(SearchableSnapshots.CACHE_FETCH_ASYNC_THREAD_POOL_NAME);
         byteBuffer.flip();
         int written = fc.write(byteBuffer, start);
         assert byteBuffer.hasRemaining() == false;
@@ -303,7 +305,7 @@ public class FrozenIndexInput extends MetadataCachingIndexInput {
         final Consumer<Long> progressUpdater,
         final long startTimeNanos
     ) throws IOException {
-        assert assertCurrentThreadMayWriteCacheFile();
+        assert ThreadPool.assertCurrentThreadPool(SearchableSnapshots.CACHE_FETCH_ASYNC_THREAD_POOL_NAME);
         logger.trace(
             "{}: writing channel {} pos {} length {} (details: {})",
             fileInfo.physicalName(),

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/TransformIndexer.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/TransformIndexer.java
@@ -772,7 +772,7 @@ public abstract class TransformIndexer extends AsyncTwoPhaseIndexer<TransformInd
      */
     final void setStopAtCheckpoint(boolean shouldStopAtCheckpoint, ActionListener<Void> shouldStopAtCheckpointListener) {
         // this should be called from the generic threadpool
-        assert Thread.currentThread().getName().contains(ThreadPool.Names.GENERIC);
+        assert ThreadPool.assertCurrentThreadPool(ThreadPool.Names.GENERIC);
 
         try {
             if (addSetStopAtCheckpointListener(shouldStopAtCheckpoint, shouldStopAtCheckpointListener) == false) {

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/TransformTask.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/TransformTask.java
@@ -302,7 +302,7 @@ public class TransformTask extends AllocatedPersistentTask implements TransformS
      */
     public void setShouldStopAtCheckpoint(boolean shouldStopAtCheckpoint, ActionListener<Void> shouldStopAtCheckpointListener) {
         // this should be called from the generic threadpool
-        assert Thread.currentThread().getName().contains(ThreadPool.Names.GENERIC);
+        assert ThreadPool.assertCurrentThreadPool(ThreadPool.Names.GENERIC);
         logger.debug(
             "[{}] attempted to set task to stop at checkpoint [{}] with state [{}]",
             getTransformId(),


### PR DESCRIPTION
It's useful to assert we're running on a particular thread pool. Today
we do this by checking the current thread's name, but the actual
implementation of this check varies quite a bit across the codebase.
Some of them are quite verbose, and others fail to include the
delimeters around the thread name. This commit introduces a utility
method to standardize this kind of assertion.