### PR TITLE
Track the count of failed invocations since last successful policy snapshot

### DIFF
--- a/docs/changelog/88398.yaml
+++ b/docs/changelog/88398.yaml
@@ -1,0 +1,5 @@
+pr: 88398
+summary: Track the count of failed invocations since last successful policy snapshot
+area: ILM+SLM
+type: enhancement
+issues: []

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/slm/SnapshotLifecyclePolicyMetadata.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/slm/SnapshotLifecyclePolicyMetadata.java
@@ -7,6 +7,7 @@
 
 package org.elasticsearch.xpack.core.slm;
 
+import org.elasticsearch.Version;
 import org.elasticsearch.cluster.SimpleDiffable;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -40,6 +41,7 @@ public class SnapshotLifecyclePolicyMetadata implements SimpleDiffable<SnapshotL
     static final ParseField MODIFIED_DATE = new ParseField("modified_date");
     static final ParseField LAST_SUCCESS = new ParseField("last_success");
     static final ParseField LAST_FAILURE = new ParseField("last_failure");
+    static final ParseField INVOCATIONS_SINCE_LAST_SUCCESS = new ParseField("invocations_since_last_success");
     static final ParseField NEXT_EXECUTION_MILLIS = new ParseField("next_execution_millis");
     static final ParseField NEXT_EXECUTION = new ParseField("next_execution");
 
@@ -51,6 +53,8 @@ public class SnapshotLifecyclePolicyMetadata implements SimpleDiffable<SnapshotL
     private final SnapshotInvocationRecord lastSuccess;
     @Nullable
     private final SnapshotInvocationRecord lastFailure;
+    @Nullable
+    private final Long invocationsSinceLastSuccess;
 
     @SuppressWarnings("unchecked")
     public static final ConstructingObjectParser<SnapshotLifecyclePolicyMetadata, String> PARSER = new ConstructingObjectParser<>(
@@ -66,6 +70,7 @@ public class SnapshotLifecyclePolicyMetadata implements SimpleDiffable<SnapshotL
                 .setModifiedDate((long) a[3])
                 .setLastSuccess(lastSuccess)
                 .setLastFailure(lastFailure)
+                .setInvocationsSinceLastSuccess((Long) a[6])
                 .build();
         }
     );
@@ -77,6 +82,7 @@ public class SnapshotLifecyclePolicyMetadata implements SimpleDiffable<SnapshotL
         PARSER.declareLong(ConstructingObjectParser.constructorArg(), MODIFIED_DATE_MILLIS);
         PARSER.declareObject(ConstructingObjectParser.optionalConstructorArg(), SnapshotInvocationRecord::parse, LAST_SUCCESS);
         PARSER.declareObject(ConstructingObjectParser.optionalConstructorArg(), SnapshotInvocationRecord::parse, LAST_FAILURE);
+        PARSER.declareLong(ConstructingObjectParser.optionalConstructorArg(), INVOCATIONS_SINCE_LAST_SUCCESS);
     }
 
     public static SnapshotLifecyclePolicyMetadata parse(XContentParser parser, String name) {
@@ -89,7 +95,8 @@ public class SnapshotLifecyclePolicyMetadata implements SimpleDiffable<SnapshotL
         long version,
         long modifiedDate,
         SnapshotInvocationRecord lastSuccess,
-        SnapshotInvocationRecord lastFailure
+        SnapshotInvocationRecord lastFailure,
+        Long invocationsSinceLastSuccess
     ) {
         this.policy = policy;
         this.headers = headers;
@@ -98,6 +105,7 @@ public class SnapshotLifecyclePolicyMetadata implements SimpleDiffable<SnapshotL
         this.modifiedDate = modifiedDate;
         this.lastSuccess = lastSuccess;
         this.lastFailure = lastFailure;
+        this.invocationsSinceLastSuccess = invocationsSinceLastSuccess;
     }
 
     @SuppressWarnings("unchecked")
@@ -109,6 +117,7 @@ public class SnapshotLifecyclePolicyMetadata implements SimpleDiffable<SnapshotL
         this.modifiedDate = in.readVLong();
         this.lastSuccess = in.readOptionalWriteable(SnapshotInvocationRecord::new);
         this.lastFailure = in.readOptionalWriteable(SnapshotInvocationRecord::new);
+        this.invocationsSinceLastSuccess = in.getVersion().onOrAfter(Version.V_8_4_0) ? in.readOptionalVLong() : null;
     }
 
     @Override
@@ -119,6 +128,9 @@ public class SnapshotLifecyclePolicyMetadata implements SimpleDiffable<SnapshotL
         out.writeVLong(this.modifiedDate);
         out.writeOptionalWriteable(this.lastSuccess);
         out.writeOptionalWriteable(this.lastFailure);
+        if (out.getVersion().onOrAfter(Version.V_8_4_0)) {
+            out.writeOptionalVLong(this.invocationsSinceLastSuccess);
+        }
     }
 
     public static Builder builder() {
@@ -134,7 +146,8 @@ public class SnapshotLifecyclePolicyMetadata implements SimpleDiffable<SnapshotL
             .setVersion(metadata.getVersion())
             .setModifiedDate(metadata.getModifiedDate())
             .setLastSuccess(metadata.getLastSuccess())
-            .setLastFailure(metadata.getLastFailure());
+            .setLastFailure(metadata.getLastFailure())
+            .setInvocationsSinceLastSuccess(metadata.getInvocationsSinceLastSuccess());
     }
 
     public Map<String, String> getHeaders() {
@@ -165,6 +178,10 @@ public class SnapshotLifecyclePolicyMetadata implements SimpleDiffable<SnapshotL
         return lastFailure;
     }
 
+    public Long getInvocationsSinceLastSuccess() {
+        return invocationsSinceLastSuccess;
+    }
+
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
         builder.startObject();
@@ -178,13 +195,16 @@ public class SnapshotLifecyclePolicyMetadata implements SimpleDiffable<SnapshotL
         if (Objects.nonNull(lastFailure)) {
             builder.field(LAST_FAILURE.getPreferredName(), lastFailure);
         }
+        if (Objects.nonNull(invocationsSinceLastSuccess)) {
+            builder.field(INVOCATIONS_SINCE_LAST_SUCCESS.getPreferredName(), invocationsSinceLastSuccess);
+        }
         builder.endObject();
         return builder;
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(policy, headers, version, modifiedDate, lastSuccess, lastFailure);
+        return Objects.hash(policy, headers, version, modifiedDate, lastSuccess, lastFailure, invocationsSinceLastSuccess);
     }
 
     @Override
@@ -201,7 +221,8 @@ public class SnapshotLifecyclePolicyMetadata implements SimpleDiffable<SnapshotL
             && Objects.equals(version, other.version)
             && Objects.equals(modifiedDate, other.modifiedDate)
             && Objects.equals(lastSuccess, other.lastSuccess)
-            && Objects.equals(lastFailure, other.lastFailure);
+            && Objects.equals(lastFailure, other.lastFailure)
+            && Objects.equals(invocationsSinceLastSuccess, other.invocationsSinceLastSuccess);
     }
 
     @Override
@@ -222,6 +243,7 @@ public class SnapshotLifecyclePolicyMetadata implements SimpleDiffable<SnapshotL
         private Long modifiedDate;
         private SnapshotInvocationRecord lastSuccessDate;
         private SnapshotInvocationRecord lastFailureDate;
+        private Long invocationsSinceLastSuccess;
 
         public Builder setPolicy(SnapshotLifecyclePolicy policy) {
             this.policy = policy;
@@ -253,6 +275,11 @@ public class SnapshotLifecyclePolicyMetadata implements SimpleDiffable<SnapshotL
             return this;
         }
 
+        public Builder setInvocationsSinceLastSuccess(Long invocationsSinceLastSuccess) {
+            this.invocationsSinceLastSuccess = invocationsSinceLastSuccess;
+            return this;
+        }
+
         public SnapshotLifecyclePolicyMetadata build() {
             return new SnapshotLifecyclePolicyMetadata(
                 Objects.requireNonNull(policy),
@@ -260,7 +287,8 @@ public class SnapshotLifecyclePolicyMetadata implements SimpleDiffable<SnapshotL
                 version,
                 Objects.requireNonNull(modifiedDate, "modifiedDate must be set"),
                 lastSuccessDate,
-                lastFailureDate
+                lastFailureDate,
+                invocationsSinceLastSuccess
             );
         }
     }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/slm/SnapshotLifecyclePolicyMetadata.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/slm/SnapshotLifecyclePolicyMetadata.java
@@ -281,6 +281,9 @@ public class SnapshotLifecyclePolicyMetadata implements SimpleDiffable<SnapshotL
         }
 
         public SnapshotLifecyclePolicyMetadata build() {
+            assert lastSuccessDate != null || invocationsSinceLastSuccess == null
+                : "Cannot have invocations since last success with no recorded success date";
+
             return new SnapshotLifecyclePolicyMetadata(
                 Objects.requireNonNull(policy),
                 Optional.ofNullable(headers).orElse(new HashMap<>()),

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/slm/SnapshotLifecyclePolicyMetadata.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/slm/SnapshotLifecyclePolicyMetadata.java
@@ -69,7 +69,7 @@ public class SnapshotLifecyclePolicyMetadata implements SimpleDiffable<SnapshotL
                 .setModifiedDate((long) a[3])
                 .setLastSuccess(lastSuccess)
                 .setLastFailure(lastFailure)
-                .setInvocationsSinceLastSuccess((Long) a[6])
+                .setInvocationsSinceLastSuccess(a[6] == null ? 0L : ((long) a[6]))
                 .build();
         }
     );

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/slm/SnapshotLifecyclePolicyMetadataTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/slm/SnapshotLifecyclePolicyMetadataTests.java
@@ -84,11 +84,16 @@ public class SnapshotLifecyclePolicyMetadataTests extends AbstractSerializingTes
         if (randomBoolean()) {
             builder.setHeaders(randomHeaders());
         }
-        if (randomBoolean()) {
+        boolean hasSuccess = randomBoolean();
+        if (hasSuccess) {
             builder.setLastSuccess(randomSnapshotInvocationRecord());
+            builder.setInvocationsSinceLastSuccess(0L);
         }
         if (randomBoolean()) {
             builder.setLastFailure(randomSnapshotInvocationRecord());
+            if (hasSuccess) {
+                builder.setInvocationsSinceLastSuccess(randomLongBetween(1, Long.MAX_VALUE));
+            }
         }
         return builder.build();
     }

--- a/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/slm/SnapshotLifecycleTask.java
+++ b/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/slm/SnapshotLifecycleTask.java
@@ -276,9 +276,11 @@ public class SnapshotLifecycleTask implements SchedulerEngine.Listener {
                         exception.map(SnapshotLifecycleTask::exceptionToString).orElse(null)
                     )
                 );
-                Long invocations = policyMetadata.getInvocationsSinceLastSuccess();
-                invocations = invocations == null ? 0L : invocations;
-                newPolicyMetadata.setInvocationsSinceLastSuccess(invocations + 1);
+                if (policyMetadata.getLastSuccess() != null) {
+                    Long invocations = policyMetadata.getInvocationsSinceLastSuccess();
+                    invocations = invocations == null ? 1L : invocations + 1L;
+                    newPolicyMetadata.setInvocationsSinceLastSuccess(invocations);
+                }
             } else {
                 stats.snapshotTaken(policyName);
                 newPolicyMetadata.setLastSuccess(new SnapshotInvocationRecord(snapshotName, snapshotStartTime, snapshotFinishTime, null));

--- a/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/slm/SnapshotLifecycleTask.java
+++ b/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/slm/SnapshotLifecycleTask.java
@@ -276,11 +276,7 @@ public class SnapshotLifecycleTask implements SchedulerEngine.Listener {
                         exception.map(SnapshotLifecycleTask::exceptionToString).orElse(null)
                     )
                 );
-                if (policyMetadata.getLastSuccess() != null) {
-                    Long invocations = policyMetadata.getInvocationsSinceLastSuccess();
-                    invocations = invocations == null ? 1L : invocations + 1L;
-                    newPolicyMetadata.setInvocationsSinceLastSuccess(invocations);
-                }
+                newPolicyMetadata.setInvocationsSinceLastSuccess(policyMetadata.getInvocationsSinceLastSuccess() + 1L);
             } else {
                 stats.snapshotTaken(policyName);
                 newPolicyMetadata.setLastSuccess(new SnapshotInvocationRecord(snapshotName, snapshotStartTime, snapshotFinishTime, null));

--- a/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/slm/SnapshotLifecycleTask.java
+++ b/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/slm/SnapshotLifecycleTask.java
@@ -276,9 +276,13 @@ public class SnapshotLifecycleTask implements SchedulerEngine.Listener {
                         exception.map(SnapshotLifecycleTask::exceptionToString).orElse(null)
                     )
                 );
+                Long invocations = policyMetadata.getInvocationsSinceLastSuccess();
+                invocations = invocations == null ? 0L : invocations;
+                newPolicyMetadata.setInvocationsSinceLastSuccess(invocations + 1);
             } else {
                 stats.snapshotTaken(policyName);
                 newPolicyMetadata.setLastSuccess(new SnapshotInvocationRecord(snapshotName, snapshotStartTime, snapshotFinishTime, null));
+                newPolicyMetadata.setInvocationsSinceLastSuccess(0L);
             }
 
             snapLifecycles.put(policyName, newPolicyMetadata.build());


### PR DESCRIPTION
When an automated snapshot fails, the last failure for a policy is captured and stored in the cluster state. Similarly, we store the last successful snapshot invocation as well. We do not track how many invocations have passed between a successful snapshot and the most recent failure. These stats would be helpful for reporting on SLM policy health. 

Instead of a fixed delay, snapshot lifecycle policies are scheduled using a cron expression which can produce variable execution times between snapshot attempts. This makes it difficult to select a window of time where continuous snapshot failure becomes indicative of a problem instead of a transient issue. By including the count of failed invocations since last success we can provide health reporting logic that allows for some transient failures while remaining agnostic of variable execution times that cron can produce.