### PR TITLE
Make DiffableUtils.diff implementation agnostic

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/metadata/ImmutableStateMetadata.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/ImmutableStateMetadata.java
@@ -9,7 +9,6 @@
 package org.elasticsearch.cluster.metadata;
 
 import org.elasticsearch.cluster.Diff;
-import org.elasticsearch.cluster.DiffableUtils;
 import org.elasticsearch.cluster.SimpleDiffable;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -125,17 +124,6 @@ public record ImmutableStateMetadata(
     public static Diff<ImmutableStateMetadata> readDiffFrom(StreamInput in) throws IOException {
         return SimpleDiffable.readDiffFrom(ImmutableStateMetadata::readFrom, in);
     }
-
-    /**
-     * Empty {@link org.elasticsearch.cluster.DiffableUtils.MapDiff} helper for metadata backwards compatibility.
-     */
-    public static final DiffableUtils.MapDiff<String, ImmutableStateMetadata, Map<String, ImmutableStateMetadata>> EMPTY_DIFF =
-        new DiffableUtils.MapDiff<>(null, null, List.of(), List.of(), List.of()) {
-            @Override
-            public Map<String, ImmutableStateMetadata> apply(Map<String, ImmutableStateMetadata> part) {
-                return part;
-            }
-        };
 
     /**
      * Convenience method for creating a {@link Builder} for {@link ImmutableStateMetadata}

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/Metadata.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/Metadata.java
@@ -1175,7 +1175,7 @@ public class Metadata extends AbstractCollection<IndexMetadata> implements Diffa
                     IMMUTABLE_DIFF_VALUE_READER
                 );
             } else {
-                immutableStateMetadata = ImmutableStateMetadata.EMPTY_DIFF;
+                immutableStateMetadata = DiffableUtils.emptyDiff();
             }
         }
 

--- a/server/src/test/java/org/elasticsearch/cluster/serialization/DiffableTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/serialization/DiffableTests.java
@@ -149,7 +149,7 @@ public class DiffableTests extends ESTestCase {
      * @param <T> map type
      * @param <V> value type
      */
-    public abstract class MapDriver<T, V> {
+    public abstract class MapDriver<T extends Map<Integer, V>, V> {
         protected final Set<Integer> keys = randomPositiveIntSet();
         protected final Set<Integer> keysToRemove = new HashSet<>(randomSubsetOf(randomInt(keys.size()), keys.toArray(new Integer[0])));
         protected final Set<Integer> keysThatAreNotRemoved = Sets.difference(keys, keysToRemove);


### PR DESCRIPTION
DiffableUtils has methods for reading and creating diffs of maps. The
two implementation types, a JDK Map or ImmutableOpenMap, have different
methods and implementations. However, the format of the diff is always
the same, so the diff creation can be shared. This commit creates an
internal MapBuilder abstraction to allow both Map and ImmutableOpenMap
to produce diffs from the same MapDiff implementation.

relates #86239