### PR TITLE
Simplify azure discovery installation docs

### DIFF
--- a/docs/plugins/discovery-azure-classic.asciidoc
+++ b/docs/plugins/discovery-azure-classic.asciidoc
@@ -333,53 +333,11 @@ ssh azure-elasticsearch-cluster.cloudapp.net
 
 Once connected,  {ref}/install-elasticsearch.html[install {es}].
 
-Check that Elasticsearch is running:
-
-[source,console]
-----
-GET /
-----
-
-This command should give you a JSON result:
-
-["source","js",subs="attributes,callouts"]
---------------------------------------------
-{
-  "name" : "Cp8oag6",
-  "cluster_name" : "elasticsearch",
-  "cluster_uuid" : "AT69_T_DTp-1qgIJlatQqA",
-  "version" : {
-    "number" : "{version_qualified}",
-    "build_type" : "{build_type}",
-    "build_hash" : "f27399d",
-    "build_flavor": "default",
-    "build_date" : "2016-03-30T09:51:41.449Z",
-    "build_snapshot" : false,
-    "lucene_version" : "{lucene_version}",
-    "minimum_wire_compatibility_version" : "1.2.3",
-    "minimum_index_compatibility_version" : "1.2.3"
-  },
-  "tagline" : "You Know, for Search"
-}
---------------------------------------------
-// TESTRESPONSE[s/"name" : "Cp8oag6",/"name" : "$body.name",/]
-// TESTRESPONSE[s/"cluster_name" : "elasticsearch",/"cluster_name" : "$body.cluster_name",/]
-// TESTRESPONSE[s/"cluster_uuid" : "AT69_T_DTp-1qgIJlatQqA",/"cluster_uuid" : "$body.cluster_uuid",/]
-// TESTRESPONSE[s/"build_hash" : "f27399d",/"build_hash" : "$body.version.build_hash",/]
-// TESTRESPONSE[s/"build_date" : "2016-03-30T09:51:41.449Z",/"build_date" : $body.version.build_date,/]
-// TESTRESPONSE[s/"build_snapshot" : false,/"build_snapshot" : $body.version.build_snapshot,/]
-// TESTRESPONSE[s/"minimum_wire_compatibility_version" : "1.2.3"/"minimum_wire_compatibility_version" : $body.version.minimum_wire_compatibility_version/]
-// TESTRESPONSE[s/"minimum_index_compatibility_version" : "1.2.3"/"minimum_index_compatibility_version" : $body.version.minimum_index_compatibility_version/]
-// So much s/// but at least we test that the layout is close to matching....
-
 [[discovery-azure-classic-long-plugin]]
 ===== Install Elasticsearch cloud azure plugin
 
 [source,sh]
 ----
-# Stop Elasticsearch
-sudo service elasticsearch stop
-
 # Install the plugin
 sudo /usr/share/elasticsearch/bin/elasticsearch-plugin install discovery-azure-classic
 
@@ -408,7 +366,7 @@ discovery:
 # path.data: /mnt/resource/elasticsearch/data
 ----
 
-Restart Elasticsearch:
+Start Elasticsearch:
 
 [source,sh]
 ----

--- a/docs/plugins/discovery-azure-classic.asciidoc
+++ b/docs/plugins/discovery-azure-classic.asciidoc
@@ -370,7 +370,7 @@ Start Elasticsearch:
 
 [source,sh]
 ----
-sudo service elasticsearch start
+sudo systemctl start elasticsearch
 ----
 
 If anything goes wrong, check your logs in `/var/log/elasticsearch`.


### PR DESCRIPTION
The installation docs for azure discovery suggest installing
Elasticsearch, and then verifying it is running. However, installation
packages do not generally automatically start an installed service. For
example, with systemd, once a package is installed it must be enabled
and/or started explicitly. This commit removes wording about verifying
Elasticsearch is running, as well as adjusts later docs about restarting
it. Additionally, the command to start Elasticsearch is fixed to use
systemctl, as SystemV init is no longer supported by our packages.
