### PR TITLE
Fix RealmIdentifier XContent parser

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authc/RealmConfig.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authc/RealmConfig.java
@@ -267,7 +267,7 @@ public class RealmConfig {
     );
 
     static {
-        REALM_IDENTIFIER_PARSER.declareString(constructorArg(), new ParseField("name"));
         REALM_IDENTIFIER_PARSER.declareString(constructorArg(), new ParseField("type"));
+        REALM_IDENTIFIER_PARSER.declareString(constructorArg(), new ParseField("name"));
     }
 }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authc/RealmConfigTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authc/RealmConfigTests.java
@@ -11,10 +11,17 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.env.Environment;
 import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xcontent.ToXContent;
+import org.elasticsearch.xcontent.XContentBuilder;
+import org.elasticsearch.xcontent.XContentFactory;
+import org.elasticsearch.xcontent.XContentParser;
 import org.junit.Before;
 import org.mockito.Mockito;
 
+import java.io.IOException;
+
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 
 public class RealmConfigTests extends ESTestCase {
@@ -56,5 +63,14 @@ public class RealmConfigTests extends ESTestCase {
             .build();
         final RealmConfig realmConfig = new RealmConfig(realmIdentifier, settings, environment, threadContext);
         assertThat(realmConfig.enabled(), is(false));
+    }
+
+    public void testXContentSerialization() throws IOException {
+        try (XContentBuilder builder = XContentFactory.jsonBuilder()) {
+            realmIdentifier.toXContent(builder, ToXContent.EMPTY_PARAMS);
+            try (XContentParser parser = createParser(builder)) {
+                assertThat(RealmConfig.REALM_IDENTIFIER_PARSER.parse(parser, null), equalTo(realmIdentifier));
+            }
+        }
     }
 }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authc/RealmDomainTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authc/RealmDomainTests.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.core.security.authc;
+
+import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.test.AbstractSerializingTestCase;
+import org.elasticsearch.xcontent.XContentParser;
+
+import java.io.IOException;
+
+public class RealmDomainTests extends AbstractSerializingTestCase<RealmDomain> {
+
+    @Override
+    protected RealmDomain doParseInstance(XContentParser parser) throws IOException {
+        return RealmDomain.REALM_DOMAIN_PARSER.parse(parser, null);
+    }
+
+    @Override
+    protected Writeable.Reader<RealmDomain> instanceReader() {
+        return RealmDomain::readFrom;
+    }
+
+    @Override
+    protected RealmDomain createTestInstance() {
+        return AuthenticationTestHelper.randomDomain(randomBoolean());
+    }
+
+}


### PR DESCRIPTION
RealmIdentifier's constructor has type before name. But the parser had
it reserved. This PR fixes the parser to have the same argument order as
the constructor. It also adds relevant tests.

Since the parser is only used internally for the User Profile feature
which is not official released yet. This fix is a non-issue.
