### PR TITLE
Ensure CreateApiKey always creates a new document

### DIFF
--- a/docs/changelog/88413.yaml
+++ b/docs/changelog/88413.yaml
@@ -1,0 +1,5 @@
+pr: 88413
+summary: Ensure `CreateApiKey` always creates a new document
+area: Security
+type: bug
+issues: []

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/ApiKeyService.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/ApiKeyService.java
@@ -325,6 +325,7 @@ public class ApiKeyService {
                 final IndexRequest indexRequest = client.prepareIndex(SECURITY_MAIN_ALIAS)
                     .setSource(builder)
                     .setId(request.getId())
+                    .setOpType(DocWriteRequest.OpType.CREATE)
                     .setRefreshPolicy(request.getRefreshPolicy())
                     .request();
                 final BulkRequest bulkRequest = toSingleItemBulkRequest(indexRequest);
@@ -338,6 +339,7 @@ public class ApiKeyService {
                         bulkRequest,
                         TransportSingleItemBulkWriteAction.<IndexResponse>wrapBulkResponse(ActionListener.wrap(indexResponse -> {
                             assert request.getId().equals(indexResponse.getId());
+                            assert indexResponse.getResult() == DocWriteResponse.Result.CREATED;
                             final ListenableFuture<CachedApiKeyHashResult> listenableFuture = new ListenableFuture<>();
                             listenableFuture.onResponse(new CachedApiKeyHashResult(true, apiKey));
                             apiKeyAuthCache.put(request.getId(), listenableFuture);

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/ApiKeyServiceTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/ApiKeyServiceTests.java
@@ -209,6 +209,8 @@ public class ApiKeyServiceTests extends ESTestCase {
             assertThat(bulkRequest.requests().get(0), instanceOf(IndexRequest.class));
             IndexRequest indexRequest = (IndexRequest) bulkRequest.requests().get(0);
             assertThat(indexRequest.id(), is(createApiKeyRequest.getId()));
+            // The index request has opType create so that it will *not* override any existing document
+            assertThat(indexRequest.opType(), is(DocWriteRequest.OpType.CREATE));
             bulkActionInvoked.set(true);
             return null;
         }).when(client).execute(eq(BulkAction.INSTANCE), any(BulkRequest.class), any());


### PR DESCRIPTION
The OpType of the indexRequest used for creating new API keys does not
have its OpType configured. This means it defaults to OpType.INDEX which
allows it to replace an existing document. This PR fixes it by explicity
set OpType to CREATE so that it always create a new document (or throw
error if ID conflict does happen).

Since API key ID is time-based random base64 UUID, it is unlikely for
this to happen in practice and we are not aware of any related bug
report.
