### PR TITLE
[8.3] [Stack Monitoring] Switch cgroup memory fields to keyword (#88260)

### DIFF
--- a/docs/changelog/88260.yaml
+++ b/docs/changelog/88260.yaml
@@ -1,0 +1,5 @@
+pr: 88260
+summary: "[Stack Monitoring] Switch cgroup memory fields to keyword"
+area: Monitoring
+type: bug
+issues: []

--- a/x-pack/plugin/core/src/main/resources/monitoring-es-mb.json
+++ b/x-pack/plugin/core/src/main/resources/monitoring-es-mb.json
@@ -732,14 +732,16 @@
                                 "usage": {
                                   "properties": {
                                     "bytes": {
-                                      "type": "long"
+                                      "ignore_above": 1024,
+                                      "type": "keyword"
                                     }
                                   }
                                 },
                                 "limit": {
                                   "properties": {
                                     "bytes": {
-                                      "type": "long"
+                                      "ignore_above": 1024,
+                                      "type": "keyword"
                                     }
                                   }
                                 }


### PR DESCRIPTION
Backports the following commits to 8.3:
 - [Stack Monitoring] Switch cgroup memory fields to keyword (#88260)