### PR TITLE
Fix ReactiveStorageDeciderServiceTests testNodeSizeForDataBelowLowWatermark

### DIFF
--- a/x-pack/plugin/autoscaling/src/main/java/org/elasticsearch/xpack/autoscaling/storage/ReactiveStorageDeciderService.java
+++ b/x-pack/plugin/autoscaling/src/main/java/org/elasticsearch/xpack/autoscaling/storage/ReactiveStorageDeciderService.java
@@ -225,7 +225,7 @@ public class ReactiveStorageDeciderService implements AutoscalingDeciderService 
         } else {
             double percentThreshold = thresholdSettings.getFreeDiskThresholdLow();
             if (percentThreshold >= 0.0 && percentThreshold < 100.0) {
-                return (long) (bytes / ((100.0 - percentThreshold) / 100));
+                return (long) (100 * bytes / (100 - percentThreshold));
             } else {
                 return bytes;
             }


### PR DESCRIPTION
Fix this test unexpectedly being off by one by increasing the accuracy of the fp division
(better to have a larger dividend and divisor) a little. I could easily reproduce the failure
without the fix but with it, the test cases we use at least run accurate with the change.

closes #88433
