### PR TITLE
unmute test 

### DIFF
--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/security/authz/14_cat_indices.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/security/authz/14_cat_indices.yml
@@ -120,8 +120,6 @@ teardown:
 "Test empty request while single authorized closed index":
 
   - skip:
-      version: "all"
-      reason: "AwaitsFix https://github.com/elastic/elasticsearch/issues/47875"
       features: ["allowed_warnings"]
 
   - do:


### PR DESCRIPTION
This test has been muted for a while and can not reproduce the original error. 

closes #47875
