### PR TITLE
[SearchSourceBuilderTests testNegativeSizeErrors] Bound random negative size test

### DIFF
--- a/server/src/test/java/org/elasticsearch/search/builder/SearchSourceBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/search/builder/SearchSourceBuilderTests.java
@@ -500,7 +500,9 @@ public class SearchSourceBuilderTests extends AbstractSearchTestCase {
         expected = expectThrows(IllegalArgumentException.class, () -> new SearchSourceBuilder().size(-1));
         assertEquals("[size] parameter cannot be negative, found [-1]", expected.getMessage());
 
-        String restContent = "{\"size\" : " + randomSize + "}";
+        // SearchSourceBuilder.fromXContent treats -1 as not-set
+        int boundedRandomSize = randomIntBetween(-100000, -2);
+        String restContent = "{\"size\" : " + boundedRandomSize + "}";
         try (XContentParser parser = createParser(JsonXContent.jsonXContent, restContent)) {
             IllegalArgumentException ex = expectThrows(IllegalArgumentException.class, () -> SearchSourceBuilder.fromXContent(parser));
             assertThat(ex.getMessage(), containsString(Integer.toString(randomSize)));

--- a/server/src/test/java/org/elasticsearch/search/builder/SearchSourceBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/search/builder/SearchSourceBuilderTests.java
@@ -505,7 +505,7 @@ public class SearchSourceBuilderTests extends AbstractSearchTestCase {
         String restContent = "{\"size\" : " + boundedRandomSize + "}";
         try (XContentParser parser = createParser(JsonXContent.jsonXContent, restContent)) {
             IllegalArgumentException ex = expectThrows(IllegalArgumentException.class, () -> SearchSourceBuilder.fromXContent(parser));
-            assertThat(ex.getMessage(), containsString(Integer.toString(randomSize)));
+            assertThat(ex.getMessage(), containsString(Integer.toString(boundedRandomSize)));
         }
 
         restContent = "{\"size\" : -1}";


### PR DESCRIPTION
-1 is handled differently by the xcontent code path so this test will fail when `randomIntBetween` lands on -1.

To fix, we add another integer for the xcontent test which starts at -2.

Fixes https://github.com/elastic/elasticsearch/issues/88423