### PR TITLE
Add one test for execution context in watcher compare condition

### DIFF
--- a/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/condition/CompareConditionTests.java
+++ b/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/condition/CompareConditionTests.java
@@ -188,6 +188,17 @@ public class CompareConditionTests extends ESTestCase {
         assertThat(condition.execute(ctx).met(), is(met));
     }
 
+    public void testExecuteDateMathExecutionContext() throws Exception {
+        ClockMock clock = ClockMock.frozen();
+        boolean met = true;
+        Op op = CompareCondition.Op.GTE;
+        String value = "<{now-5m}>";
+
+        CompareCondition condition = new CompareCondition("ctx.execution_time", op, value, clock);
+        WatchExecutionContext ctx = mockExecutionContext("_name", null);
+        assertThat(condition.execute(ctx).met(), is(met));
+    }
+
     public void testExecutePath() throws Exception {
         ClockMock clock = ClockMock.frozen();
         boolean met = randomBoolean();


### PR DESCRIPTION
Issue: https://github.com/elastic/elasticsearch/issues/88408

This PR adds one test for execution context in the watcher compare condition, which is equivalent to the below compare condition.

```json
{
  "condition" : {
    "compare" : {
      "ctx.execution_time" : {
        "gte" : "<{now-5m}>"
      }
    }
  }
}
```

This test should always pass and actually passes in master branch but fails in 7.17 branch. So, backport PR will append necessary adjustment (bug fix) on top of this.

**Question**: I don't think this PR needs a changelog, right?
