### PR TITLE
[7.17] Adjust date conversion for execution context in watcher compare condition

### DIFF
--- a/docs/changelog/88467.yaml
+++ b/docs/changelog/88467.yaml
@@ -1,0 +1,6 @@
+pr: 88467
+summary: Adjust date conversion for execution context in watcher compare condition
+area: Infra/Scripting
+type: bug
+issues:
+ - 88408

--- a/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/condition/LenientCompare.java
+++ b/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/condition/LenientCompare.java
@@ -6,6 +6,7 @@
  */
 package org.elasticsearch.xpack.watcher.condition;
 
+import org.elasticsearch.script.JodaCompatibleZonedDateTime;
 import org.elasticsearch.xpack.core.watcher.support.WatcherDateTimeUtils;
 
 import java.time.Instant;
@@ -69,6 +70,9 @@ public class LenientCompare {
                 }
             } else if (v1 instanceof Number) {
                 v1 = Instant.ofEpochMilli(((Number) v1).longValue()).atZone(ZoneOffset.UTC);
+            } else if (v1 instanceof JodaCompatibleZonedDateTime) {
+                // this can only occur in versions prior to #78417
+                v1 = ((JodaCompatibleZonedDateTime) v1).getZonedDateTime();
             } else {
                 // cannot convert to date...
                 return null;

--- a/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/condition/CompareConditionTests.java
+++ b/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/condition/CompareConditionTests.java
@@ -188,6 +188,17 @@ public class CompareConditionTests extends ESTestCase {
         assertThat(condition.execute(ctx).met(), is(met));
     }
 
+    public void testExecuteDateMathExecutionContext() throws Exception {
+        ClockMock clock = ClockMock.frozen();
+        boolean met = true;
+        Op op = CompareCondition.Op.GTE;
+        String value = "<{now-5m}>";
+
+        CompareCondition condition = new CompareCondition("ctx.execution_time", op, value, clock);
+        WatchExecutionContext ctx = mockExecutionContext("_name", null);
+        assertThat(condition.execute(ctx).met(), is(met));
+    }
+
     public void testExecutePath() throws Exception {
         ClockMock clock = ClockMock.frozen();
         boolean met = randomBoolean();


### PR DESCRIPTION
Issue: https://github.com/elastic/elasticsearch/issues/88408

This PR backports the commit in the below PR to 7.17:
- https://github.com/elastic/elasticsearch/pull/88466

In addition to that, [58d57be](https://github.com/sakurai-youhei/elasticsearch/commit/58d57bed48d31b1c9d842d70889003106477b9a4) will be cherry-picked once confirming CI build fails on the added test.

**Question**: Does the following changelog look ok?

```yml
pr: <to be replaced with PR #>
summary: Adjust date conversion for execution context in watcher compare condition
area: Infra/Scripting
type: bug
issues:
 - 88408
```