### PR TITLE
Avoid noisy exceptions on data nodes when aborting snapshots

### DIFF
--- a/server/src/main/java/org/elasticsearch/snapshots/SnapshotShardsService.java
+++ b/server/src/main/java/org/elasticsearch/snapshots/SnapshotShardsService.java
@@ -337,7 +337,10 @@ public class SnapshotShardsService extends AbstractLifecycleComponent implements
         ActionListener<ShardSnapshotResult> listener
     ) {
         try {
-            final IndexShard indexShard = indicesService.indexServiceSafe(shardId.getIndex()).getShardOrNull(shardId.id());
+            if (snapshotStatus.isAborted()) {
+                throw new AbortedSnapshotException();
+            }
+            final IndexShard indexShard = indicesService.indexServiceSafe(shardId.getIndex()).getShard(shardId.id());
             if (indexShard.routingEntry().primary() == false) {
                 throw new IndexShardSnapshotFailedException(shardId, "snapshot should be performed only on primary");
             }


### PR DESCRIPTION
Currently, an abort (especially when triggered an index delete) can
manifest as either an aborted snapshot exception, a missing index exception or
an NPE. The latter two show up as noise in logs.
This change catches effectively all of these cleanly as aborted snapshot
exceptions so they don't get logged as warnings and avoids the NPE if
a shard was removed from the index service concurrently by using the
API that throws on missing shards to look it up.

Seen in this noisy failure https://github.com/elastic/elasticsearch/issues/86724#issuecomment-1180783691