### PR TITLE
[CI] Mute ReactiveStorageIT#testScaleDuringSplitOrClone

### DIFF
--- a/x-pack/plugin/autoscaling/src/internalClusterTest/java/org/elasticsearch/xpack/autoscaling/storage/ReactiveStorageIT.java
+++ b/x-pack/plugin/autoscaling/src/internalClusterTest/java/org/elasticsearch/xpack/autoscaling/storage/ReactiveStorageIT.java
@@ -356,6 +356,7 @@ public class ReactiveStorageIT extends AutoscalingStorageIntegTestCase {
         ensureGreen();
     }
 
+    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/88478")
     public void testScaleDuringSplitOrClone() throws Exception {
         internalCluster().startMasterOnlyNode();
         final String dataNode1Name = internalCluster().startDataOnlyNode();


### PR DESCRIPTION
Relates to https://github.com/elastic/elasticsearch/issues/88478.