### PR TITLE
[ML] adjust internal inference object to accept request_id in outer object

### DIFF
--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/pytorch/process/PyTorchResultProcessor.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/pytorch/process/PyTorchResultProcessor.java
@@ -117,10 +117,10 @@ public class PyTorchResultProcessor {
             pendingResults.forEach(
                 (id, pendingResult) -> pendingResult.listener.onResponse(
                     new PyTorchResult(
+                        id,
                         null,
                         null,
                         new ErrorResult(
-                            id,
                             isStopping
                                 ? "inference canceled as process is stopping"
                                 : "inference native process died unexpectedly with failure [" + e.getMessage() + "]"
@@ -132,7 +132,7 @@ public class PyTorchResultProcessor {
         } finally {
             pendingResults.forEach(
                 (id, pendingResult) -> pendingResult.listener.onResponse(
-                    new PyTorchResult(null, null, new ErrorResult(id, "inference canceled as process is stopping"))
+                    new PyTorchResult(id, null, null, new ErrorResult("inference canceled as process is stopping"))
                 )
             );
             pendingResults.clear();
@@ -144,11 +144,11 @@ public class PyTorchResultProcessor {
         PyTorchInferenceResult inferenceResult = result.inferenceResult();
         assert inferenceResult != null;
 
-        logger.trace(() -> format("[%s] Parsed result with id [%s]", deploymentId, inferenceResult.getRequestId()));
+        logger.trace(() -> format("[%s] Parsed result with id [%s]", deploymentId, result.requestId()));
         processResult(inferenceResult);
-        PendingResult pendingResult = pendingResults.remove(inferenceResult.getRequestId());
+        PendingResult pendingResult = pendingResults.remove(result.requestId());
         if (pendingResult == null) {
-            logger.debug(() -> format("[%s] no pending result for [%s]", deploymentId, inferenceResult.getRequestId()));
+            logger.debug(() -> format("[%s] no pending result for [%s]", deploymentId, result.requestId()));
         } else {
             pendingResult.listener.onResponse(result);
         }
@@ -158,10 +158,10 @@ public class PyTorchResultProcessor {
         ThreadSettings threadSettings = result.threadSettings();
         assert threadSettings != null;
 
-        logger.trace(() -> format("[%s] Parsed result with id [%s]", deploymentId, threadSettings.requestId()));
-        PendingResult pendingResult = pendingResults.remove(threadSettings.requestId());
+        logger.trace(() -> format("[%s] Parsed result with id [%s]", deploymentId, result.requestId()));
+        PendingResult pendingResult = pendingResults.remove(result.requestId());
         if (pendingResult == null) {
-            logger.debug(() -> format("[%s] no pending result for [%s]", deploymentId, threadSettings.requestId()));
+            logger.debug(() -> format("[%s] no pending result for [%s]", deploymentId, result.requestId()));
         } else {
             pendingResult.listener.onResponse(result);
         }
@@ -173,10 +173,10 @@ public class PyTorchResultProcessor {
 
         errorCount++;
 
-        logger.trace(() -> format("[%s] Parsed error with id [%s]", deploymentId, errorResult.requestId()));
-        PendingResult pendingResult = pendingResults.remove(errorResult.requestId());
+        logger.trace(() -> format("[%s] Parsed error with id [%s]", deploymentId, result.requestId()));
+        PendingResult pendingResult = pendingResults.remove(result.requestId());
         if (pendingResult == null) {
-            logger.debug(() -> format("[%s] no pending result for [%s]", deploymentId, errorResult.requestId()));
+            logger.debug(() -> format("[%s] no pending result for [%s]", deploymentId, result.requestId()));
         } else {
             pendingResult.listener.onResponse(result);
         }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/pytorch/results/ErrorResult.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/pytorch/results/ErrorResult.java
@@ -13,8 +13,10 @@ import org.elasticsearch.xcontent.ToXContentObject;
 import org.elasticsearch.xcontent.XContentBuilder;
 
 import java.io.IOException;
+import java.util.Objects;
+import java.util.Optional;
 
-public record ErrorResult(String requestId, String error) implements ToXContentObject {
+public class ErrorResult implements ToXContentObject {
 
     public static final ParseField ERROR = new ParseField("error");
 
@@ -28,6 +30,27 @@ public record ErrorResult(String requestId, String error) implements ToXContentO
         PARSER.declareString(ConstructingObjectParser.constructorArg(), ERROR);
     }
 
+    private final String requestId;
+    private final String error;
+
+    ErrorResult(String requestId, String error) {
+        this.requestId = requestId;
+        this.error = error;
+    }
+
+    public ErrorResult(String error) {
+        this.requestId = null;
+        this.error = error;
+    }
+
+    public String error() {
+        return error;
+    }
+
+    Optional<String> requestId() {
+        return Optional.ofNullable(requestId);
+    }
+
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
         builder.startObject();
@@ -37,5 +60,18 @@ public record ErrorResult(String requestId, String error) implements ToXContentO
         builder.field(ERROR.getPreferredName(), error);
         builder.endObject();
         return builder;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        ErrorResult that = (ErrorResult) o;
+        return Objects.equals(requestId, that.requestId) && Objects.equals(error, that.error);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(requestId, error);
     }
 }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/pytorch/results/PyTorchInferenceResult.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/pytorch/results/PyTorchInferenceResult.java
@@ -37,7 +37,7 @@ public class PyTorchInferenceResult implements ToXContentObject {
     );
 
     static {
-        PARSER.declareString(ConstructingObjectParser.constructorArg(), PyTorchResult.REQUEST_ID);
+        PARSER.declareString(ConstructingObjectParser.optionalConstructorArg(), PyTorchResult.REQUEST_ID);
         PARSER.declareField(
             ConstructingObjectParser.optionalConstructorArg(),
             (p, c) -> MlParserUtils.parse3DArrayOfDoubles(INFERENCE.getPreferredName(), p),
@@ -57,14 +57,26 @@ public class PyTorchInferenceResult implements ToXContentObject {
     private final Long timeMs;
     private final boolean cacheHit;
 
-    public PyTorchInferenceResult(String requestId, @Nullable double[][][] inference, @Nullable Long timeMs, @Nullable Boolean cacheHit) {
-        this.requestId = Objects.requireNonNull(requestId);
+    PyTorchInferenceResult(
+        @Nullable String requestId,
+        @Nullable double[][][] inference,
+        @Nullable Long timeMs,
+        @Nullable Boolean cacheHit
+    ) {
+        this.requestId = requestId;
         this.inference = inference;
         this.timeMs = timeMs;
         this.cacheHit = cacheHit != null && cacheHit;
     }
 
-    public String getRequestId() {
+    public PyTorchInferenceResult(@Nullable double[][][] inference, @Nullable Long timeMs, @Nullable Boolean cacheHit) {
+        this.requestId = null;
+        this.inference = inference;
+        this.timeMs = timeMs;
+        this.cacheHit = cacheHit != null && cacheHit;
+    }
+
+    String getRequestId() {
         return requestId;
     }
 
@@ -83,7 +95,9 @@ public class PyTorchInferenceResult implements ToXContentObject {
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
         builder.startObject();
-        builder.field(PyTorchResult.REQUEST_ID.getPreferredName(), requestId);
+        if (requestId != null) {
+            builder.field(PyTorchResult.REQUEST_ID.getPreferredName(), requestId);
+        }
         if (inference != null) {
             builder.startArray(INFERENCE.getPreferredName());
             for (double[][] doubles : inference) {

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/pytorch/results/ThreadSettings.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/pytorch/results/ThreadSettings.java
@@ -13,8 +13,10 @@ import org.elasticsearch.xcontent.ToXContentObject;
 import org.elasticsearch.xcontent.XContentBuilder;
 
 import java.io.IOException;
+import java.util.Objects;
+import java.util.Optional;
 
-public record ThreadSettings(int numThreadsPerAllocation, int numAllocations, String requestId) implements ToXContentObject {
+public class ThreadSettings implements ToXContentObject {
 
     private static final ParseField NUM_ALLOCATIONS = new ParseField("num_allocations");
     private static final ParseField NUM_THREADS_PER_ALLOCATION = new ParseField("num_threads_per_allocation");
@@ -30,6 +32,34 @@ public record ThreadSettings(int numThreadsPerAllocation, int numAllocations, St
         PARSER.declareString(ConstructingObjectParser.optionalConstructorArg(), PyTorchResult.REQUEST_ID);
     }
 
+    private final int numThreadsPerAllocation;
+    private final int numAllocations;
+    private final String requestId;
+
+    ThreadSettings(int numThreadsPerAllocation, int numAllocations, String requestId) {
+        this.numThreadsPerAllocation = numThreadsPerAllocation;
+        this.numAllocations = numAllocations;
+        this.requestId = requestId;
+    }
+
+    public ThreadSettings(int numThreadsPerAllocation, int numAllocations) {
+        this.numThreadsPerAllocation = numThreadsPerAllocation;
+        this.numAllocations = numAllocations;
+        this.requestId = null;
+    }
+
+    public int numThreadsPerAllocation() {
+        return numThreadsPerAllocation;
+    }
+
+    public int numAllocations() {
+        return numAllocations;
+    }
+
+    Optional<String> requestId() {
+        return Optional.ofNullable(requestId);
+    }
+
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
         builder.startObject();
@@ -40,5 +70,20 @@ public record ThreadSettings(int numThreadsPerAllocation, int numAllocations, St
         }
         builder.endObject();
         return builder;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        ThreadSettings that = (ThreadSettings) o;
+        return numThreadsPerAllocation == that.numThreadsPerAllocation
+            && numAllocations == that.numAllocations
+            && Objects.equals(requestId, that.requestId);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(numThreadsPerAllocation, numAllocations, requestId);
     }
 }

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/nlp/FillMaskProcessorTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/nlp/FillMaskProcessorTests.java
@@ -66,7 +66,7 @@ public class FillMaskProcessorTests extends ESTestCase {
         String resultsField = randomAlphaOfLength(10);
         FillMaskResults result = (FillMaskResults) FillMaskProcessor.processResult(
             tokenization,
-            new PyTorchInferenceResult("1", scores, 0L, null),
+            new PyTorchInferenceResult(scores, 0L, null),
             tokenizer,
             4,
             resultsField
@@ -93,7 +93,7 @@ public class FillMaskProcessorTests extends ESTestCase {
             0
         );
 
-        PyTorchInferenceResult pyTorchResult = new PyTorchInferenceResult("1", new double[][][] { { {} } }, 0L, null);
+        PyTorchInferenceResult pyTorchResult = new PyTorchInferenceResult(new double[][][] { { {} } }, 0L, null);
         expectThrows(
             ElasticsearchStatusException.class,
             () -> FillMaskProcessor.processResult(tokenization, pyTorchResult, tokenizer, 5, randomAlphaOfLength(10))

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/nlp/NerProcessorTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/nlp/NerProcessorTests.java
@@ -72,7 +72,7 @@ public class NerProcessorTests extends ESTestCase {
 
         var e = expectThrows(
             ElasticsearchStatusException.class,
-            () -> processor.processResult(tokenization, new PyTorchInferenceResult("test", null, 0L, null))
+            () -> processor.processResult(tokenization, new PyTorchInferenceResult(null, 0L, null))
         );
         assertThat(e, instanceOf(ElasticsearchStatusException.class));
     }
@@ -113,7 +113,7 @@ public class NerProcessorTests extends ESTestCase {
                     { 0, 0, 0, 0, 0, 0, 0, 6, 0 }, // london
                     { 7, 0, 0, 0, 0, 0, 0, 0, 0 } // sep
                 } };
-            NerResults result = (NerResults) processor.processResult(tokenization, new PyTorchInferenceResult("1", scores, 1L, null));
+            NerResults result = (NerResults) processor.processResult(tokenization, new PyTorchInferenceResult(scores, 1L, null));
 
             assertThat(result.getAnnotatedResult(), equalTo("Many use [Elasticsearch](ORG&Elasticsearch) in [London](LOC&London)"));
             assertThat(result.getEntityGroups().size(), equalTo(2));
@@ -141,7 +141,7 @@ public class NerProcessorTests extends ESTestCase {
                 { 0, 0, 0, 0, 0, 0, 0, 0, 0 }, // in
                 { 0, 0, 0, 0, 0, 0, 0, 6, 0 } // london
             } };
-        NerResults result = (NerResults) processor.processResult(tokenization, new PyTorchInferenceResult("1", scores, 1L, null));
+        NerResults result = (NerResults) processor.processResult(tokenization, new PyTorchInferenceResult(scores, 1L, null));
 
         assertThat(result.getAnnotatedResult(), equalTo("Many use [Elasticsearch](ORG&Elasticsearch) in [London](LOC&London)"));
         assertThat(result.getEntityGroups().size(), equalTo(2));
@@ -178,7 +178,7 @@ public class NerProcessorTests extends ESTestCase {
                 { 0, 0, 0, 0, 0, 0, 0, 0, 5 }, // in
                 { 6, 0, 0, 0, 0, 0, 0, 0, 0 } // london
             } };
-        NerResults result = (NerResults) processor.processResult(tokenization, new PyTorchInferenceResult("1", scores, 1L, null));
+        NerResults result = (NerResults) processor.processResult(tokenization, new PyTorchInferenceResult(scores, 1L, null));
 
         assertThat(result.getAnnotatedResult(), equalTo("[Elasticsearch](ORG&Elasticsearch) in [London](LOC&London)"));
         assertThat(result.getEntityGroups().size(), equalTo(2));
@@ -211,7 +211,7 @@ public class NerProcessorTests extends ESTestCase {
                 { 0, 0, 0, 0, 5 }, // in
                 { 6, 0, 0, 0, 0 } // london
             } };
-        NerResults result = (NerResults) processor.processResult(tokenization, new PyTorchInferenceResult("1", scores, 1L, null));
+        NerResults result = (NerResults) processor.processResult(tokenization, new PyTorchInferenceResult(scores, 1L, null));
 
         assertThat(result.getAnnotatedResult(), equalTo("[Elasticsearch](SOFTWARE&Elasticsearch) in [London](LOC&London)"));
         assertThat(result.getEntityGroups().size(), equalTo(2));

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/nlp/QuestionAnsweringProcessorTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/nlp/QuestionAnsweringProcessorTests.java
@@ -87,7 +87,7 @@ public class QuestionAnsweringProcessorTests extends ESTestCase {
         assertThat(tokenizationResult.getTokenization(0).seqPairOffset(), equalTo(7));
         double[][][] scores = { { START_TOKEN_SCORES }, { END_TOKEN_SCORES } };
         NlpTask.ResultProcessor resultProcessor = processor.getResultProcessor(config);
-        PyTorchInferenceResult pyTorchResult = new PyTorchInferenceResult("1", scores, 1L, null);
+        PyTorchInferenceResult pyTorchResult = new PyTorchInferenceResult(scores, 1L, null);
         QuestionAnsweringInferenceResults result = (QuestionAnsweringInferenceResults) resultProcessor.processResult(
             tokenizationResult,
             pyTorchResult

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/nlp/TextClassificationProcessorTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/nlp/TextClassificationProcessorTests.java
@@ -32,7 +32,7 @@ public class TextClassificationProcessorTests extends ESTestCase {
 
     public void testInvalidResult() {
         {
-            PyTorchInferenceResult torchResult = new PyTorchInferenceResult("foo", new double[][][] {}, 0L, null);
+            PyTorchInferenceResult torchResult = new PyTorchInferenceResult(new double[][][] {}, 0L, null);
             var e = expectThrows(
                 ElasticsearchStatusException.class,
                 () -> TextClassificationProcessor.processResult(null, torchResult, randomInt(), List.of("a", "b"), randomAlphaOfLength(10))
@@ -41,7 +41,7 @@ public class TextClassificationProcessorTests extends ESTestCase {
             assertThat(e.getMessage(), containsString("Text classification result has no data"));
         }
         {
-            PyTorchInferenceResult torchResult = new PyTorchInferenceResult("foo", new double[][][] { { { 1.0 } } }, 0L, null);
+            PyTorchInferenceResult torchResult = new PyTorchInferenceResult(new double[][][] { { { 1.0 } } }, 0L, null);
             var e = expectThrows(
                 ElasticsearchStatusException.class,
                 () -> TextClassificationProcessor.processResult(null, torchResult, randomInt(), List.of("a", "b"), randomAlphaOfLength(10))

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/pytorch/process/PyTorchResultProcessorTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/pytorch/process/PyTorchResultProcessorTests.java
@@ -37,18 +37,18 @@ public class PyTorchResultProcessorTests extends ESTestCase {
         var settingsHolder = new AtomicReference<ThreadSettings>();
         var processor = new PyTorchResultProcessor("deployment-foo", settingsHolder::set);
 
-        var settings = new ThreadSettings(1, 1, "thread-setting");
+        var settings = new ThreadSettings(1, 1);
         processor.registerRequest("thread-setting", new AssertingResultListener(r -> assertEquals(settings, r.threadSettings())));
 
-        processor.process(mockNativeProcess(List.of(new PyTorchResult(null, settings, null)).iterator()));
+        processor.process(mockNativeProcess(List.of(new PyTorchResult("thread-setting", null, settings, null)).iterator()));
 
         assertEquals(settings, settingsHolder.get());
     }
 
     public void testResultsProcessing() {
-        var inferenceResult = new PyTorchInferenceResult("a", null, 1000L, null);
-        var threadSettings = new ThreadSettings(1, 1, "b");
-        var errorResult = new ErrorResult("c", "a bad thing has happened");
+        var inferenceResult = new PyTorchInferenceResult(null, 1000L, null);
+        var threadSettings = new ThreadSettings(1, 1);
+        var errorResult = new ErrorResult("a bad thing has happened");
 
         var inferenceListener = new AssertingResultListener(r -> assertEquals(inferenceResult, r.inferenceResult()));
         var threadSettingsListener = new AssertingResultListener(r -> assertEquals(threadSettings, r.threadSettings()));
@@ -62,9 +62,9 @@ public class PyTorchResultProcessorTests extends ESTestCase {
         processor.process(
             mockNativeProcess(
                 List.of(
-                    new PyTorchResult(inferenceResult, null, null),
-                    new PyTorchResult(null, threadSettings, null),
-                    new PyTorchResult(null, null, errorResult)
+                    new PyTorchResult("a", inferenceResult, null, null),
+                    new PyTorchResult("b", null, threadSettings, null),
+                    new PyTorchResult("c", null, null, errorResult)
                 ).iterator()
             )
         );
@@ -86,9 +86,9 @@ public class PyTorchResultProcessorTests extends ESTestCase {
         );
         processor.registerRequest("b", calledOnShutdown);
 
-        var inferenceResult = new PyTorchInferenceResult("a", null, 1000L, null);
+        var inferenceResult = new PyTorchInferenceResult(null, 1000L, null);
 
-        processor.process(mockNativeProcess(List.of(new PyTorchResult(inferenceResult, null, null)).iterator()));
+        processor.process(mockNativeProcess(List.of(new PyTorchResult("a", inferenceResult, null, null)).iterator()));
         assertSame(inferenceResult, resultHolder.get());
         assertTrue(calledOnShutdown.hasResponse);
     }
@@ -100,8 +100,8 @@ public class PyTorchResultProcessorTests extends ESTestCase {
 
         processor.ignoreResponseWithoutNotifying("a");
 
-        var inferenceResult = new PyTorchInferenceResult("a", null, 1000L, null);
-        processor.process(mockNativeProcess(List.of(new PyTorchResult(inferenceResult, null, null)).iterator()));
+        var inferenceResult = new PyTorchInferenceResult(null, 1000L, null);
+        processor.process(mockNativeProcess(List.of(new PyTorchResult("a", inferenceResult, null, null)).iterator()));
     }
 
     public void testPendingRequestAreCalledAtShutdown() {
@@ -146,8 +146,8 @@ public class PyTorchResultProcessorTests extends ESTestCase {
         }
     }
 
-    private PyTorchResult wrapInferenceResult(PyTorchInferenceResult result) {
-        return new PyTorchResult(result, null, null);
+    private PyTorchResult wrapInferenceResult(String requestId, PyTorchInferenceResult result) {
+        return new PyTorchResult(requestId, result, null, null);
     }
 
     public void testsStats() {
@@ -161,9 +161,9 @@ public class PyTorchResultProcessorTests extends ESTestCase {
         processor.registerRequest("b", pendingB);
         processor.registerRequest("c", pendingC);
 
-        var a = wrapInferenceResult(new PyTorchInferenceResult("a", null, 1000L, null));
-        var b = wrapInferenceResult(new PyTorchInferenceResult("b", null, 900L, false));
-        var c = wrapInferenceResult(new PyTorchInferenceResult("c", null, 200L, true));
+        var a = wrapInferenceResult("a", new PyTorchInferenceResult(null, 1000L, null));
+        var b = wrapInferenceResult("b", new PyTorchInferenceResult(null, 900L, false));
+        var c = wrapInferenceResult("c", new PyTorchInferenceResult(null, 200L, true));
 
         processor.processInferenceResult(a);
         var stats = processor.getResultStats();
@@ -227,9 +227,9 @@ public class PyTorchResultProcessorTests extends ESTestCase {
         var processor = new PyTorchResultProcessor("foo", s -> {}, timeSupplier);
 
         // 1st period
-        processor.processInferenceResult(wrapInferenceResult(new PyTorchInferenceResult("foo", null, 200L, null)));
-        processor.processInferenceResult(wrapInferenceResult(new PyTorchInferenceResult("foo", null, 200L, null)));
-        processor.processInferenceResult(wrapInferenceResult(new PyTorchInferenceResult("foo", null, 200L, null)));
+        processor.processInferenceResult(wrapInferenceResult("foo", new PyTorchInferenceResult(null, 200L, null)));
+        processor.processInferenceResult(wrapInferenceResult("foo", new PyTorchInferenceResult(null, 200L, null)));
+        processor.processInferenceResult(wrapInferenceResult("foo", new PyTorchInferenceResult(null, 200L, null)));
         // first call has no results as is in the same period
         var stats = processor.getResultStats();
         assertThat(stats.recentStats().requestsProcessed(), equalTo(0L));
@@ -243,7 +243,7 @@ public class PyTorchResultProcessorTests extends ESTestCase {
         assertThat(stats.peakThroughput(), equalTo(3L));
 
         // 2nd period
-        processor.processInferenceResult(wrapInferenceResult(new PyTorchInferenceResult("foo", null, 100L, null)));
+        processor.processInferenceResult(wrapInferenceResult("foo", new PyTorchInferenceResult(null, 100L, null)));
         stats = processor.getResultStats();
         assertNotNull(stats.recentStats());
         assertThat(stats.recentStats().requestsProcessed(), equalTo(1L));
@@ -255,7 +255,7 @@ public class PyTorchResultProcessorTests extends ESTestCase {
         assertThat(stats.recentStats().requestsProcessed(), equalTo(0L));
 
         // 4th period
-        processor.processInferenceResult(wrapInferenceResult(new PyTorchInferenceResult("foo", null, 300L, null)));
+        processor.processInferenceResult(wrapInferenceResult("foo", new PyTorchInferenceResult(null, 300L, null)));
         stats = processor.getResultStats();
         assertNotNull(stats.recentStats());
         assertThat(stats.recentStats().requestsProcessed(), equalTo(1L));
@@ -263,8 +263,8 @@ public class PyTorchResultProcessorTests extends ESTestCase {
         assertThat(stats.lastUsed(), equalTo(Instant.ofEpochMilli(resultTimestamps[9])));
 
         // 7th period
-        processor.processInferenceResult(wrapInferenceResult(new PyTorchInferenceResult("foo", null, 410L, null)));
-        processor.processInferenceResult(wrapInferenceResult(new PyTorchInferenceResult("foo", null, 390L, null)));
+        processor.processInferenceResult(wrapInferenceResult("foo", new PyTorchInferenceResult(null, 410L, null)));
+        processor.processInferenceResult(wrapInferenceResult("foo", new PyTorchInferenceResult(null, 390L, null)));
         stats = processor.getResultStats();
         assertThat(stats.recentStats().requestsProcessed(), equalTo(0L));
         assertThat(stats.recentStats().avgInferenceTime(), nullValue());
@@ -275,9 +275,9 @@ public class PyTorchResultProcessorTests extends ESTestCase {
         assertThat(stats.lastUsed(), equalTo(Instant.ofEpochMilli(resultTimestamps[12])));
 
         // 8th period
-        processor.processInferenceResult(wrapInferenceResult(new PyTorchInferenceResult("foo", null, 510L, null)));
-        processor.processInferenceResult(wrapInferenceResult(new PyTorchInferenceResult("foo", null, 500L, null)));
-        processor.processInferenceResult(wrapInferenceResult(new PyTorchInferenceResult("foo", null, 490L, null)));
+        processor.processInferenceResult(wrapInferenceResult("foo", new PyTorchInferenceResult(null, 510L, null)));
+        processor.processInferenceResult(wrapInferenceResult("foo", new PyTorchInferenceResult(null, 500L, null)));
+        processor.processInferenceResult(wrapInferenceResult("foo", new PyTorchInferenceResult(null, 490L, null)));
         stats = processor.getResultStats();
         assertNotNull(stats.recentStats());
         assertThat(stats.recentStats().requestsProcessed(), equalTo(3L));

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/pytorch/results/PyTorchInferenceResultTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/pytorch/results/PyTorchInferenceResultTests.java
@@ -30,8 +30,6 @@ public class PyTorchInferenceResultTests extends AbstractXContentTestCase<PyTorc
     }
 
     public static PyTorchInferenceResult createRandom() {
-        String id = randomAlphaOfLength(6);
-
         int rows = randomIntBetween(1, 10);
         int columns = randomIntBetween(1, 10);
         int depth = randomIntBetween(1, 10);
@@ -43,6 +41,6 @@ public class PyTorchInferenceResultTests extends AbstractXContentTestCase<PyTorc
                 }
             }
         }
-        return new PyTorchInferenceResult(id, arr, randomLong(), randomBoolean() ? null : randomBoolean());
+        return new PyTorchInferenceResult(arr, randomLong(), randomBoolean() ? null : randomBoolean());
     }
 }

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/pytorch/results/PyTorchResultTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/pytorch/results/PyTorchResultTests.java
@@ -7,10 +7,17 @@
 
 package org.elasticsearch.xpack.ml.inference.pytorch.results;
 
+import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.common.xcontent.XContentHelper;
+import org.elasticsearch.core.CheckedConsumer;
 import org.elasticsearch.test.AbstractXContentTestCase;
+import org.elasticsearch.xcontent.XContentFactory;
 import org.elasticsearch.xcontent.XContentParser;
+import org.elasticsearch.xcontent.XContentType;
 
 import java.io.IOException;
+
+import static org.hamcrest.Matchers.equalTo;
 
 public class PyTorchResultTests extends AbstractXContentTestCase<PyTorchResult> {
 
@@ -18,9 +25,9 @@ public class PyTorchResultTests extends AbstractXContentTestCase<PyTorchResult> 
     protected PyTorchResult createTestInstance() {
         int type = randomIntBetween(0, 2);
         return switch (type) {
-            case 0 -> new PyTorchResult(PyTorchInferenceResultTests.createRandom(), null, null);
-            case 1 -> new PyTorchResult(null, ThreadSettingsTests.createRandom(), null);
-            default -> new PyTorchResult(null, null, ErrorResultTests.createRandom());
+            case 0 -> new PyTorchResult(randomAlphaOfLength(10), PyTorchInferenceResultTests.createRandom(), null, null);
+            case 1 -> new PyTorchResult(randomAlphaOfLength(10), null, ThreadSettingsTests.createRandom(), null);
+            default -> new PyTorchResult(randomAlphaOfLength(10), null, null, ErrorResultTests.createRandom());
         };
     }
 
@@ -32,5 +39,18 @@ public class PyTorchResultTests extends AbstractXContentTestCase<PyTorchResult> 
     @Override
     protected boolean supportsUnknownFields() {
         return false;
+    }
+
+    public void testRequestIdSetFromSubObject() throws IOException {
+        String testId = randomAlphaOfLength(10);
+        CheckedConsumer<PyTorchResult, IOException> tester = r -> {
+            BytesReference xcontent = XContentHelper.toXContent(r, XContentType.JSON, false);
+            try (XContentParser parser = createParser(XContentFactory.xContent(XContentType.JSON), xcontent)) {
+                assertThat(PyTorchResult.PARSER.parse(parser, null).requestId(), equalTo(testId));
+            }
+        };
+        tester.accept(new PyTorchResult(null, new PyTorchInferenceResult(testId, null, null, null), null, null));
+        tester.accept(new PyTorchResult(null, null, new ThreadSettings(1, 1, testId), null));
+        tester.accept(new PyTorchResult(null, null, null, new ErrorResult(testId, "some error")));
     }
 }


### PR DESCRIPTION
Since `request_id` is effectively required for all messages sent to the native process, this bubbles up the request_id to the outer object.

It is currently optional (until the native side is changed). 

If an inner object has the request_id set, and the outer object does not, the outer object request ID is set to that inner one.