### PR TITLE
Fix lost optimization from merge conflict in building metadata from diff

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/metadata/Metadata.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/Metadata.java
@@ -1215,7 +1215,7 @@ public class Metadata extends AbstractCollection<IndexMetadata> implements Diffa
             builder.templates(templates.apply(part.templates));
             builder.customs(customs.apply(part.customs));
             builder.put(immutableStateMetadata.apply(part.immutableStateMetadata));
-            return builder.build();
+            return builder.build(true);
         }
     }
 


### PR DESCRIPTION
The flag value was lost due to a merge mistake, bringing it back.

broken in #88250