### PR TITLE
Disallow explicitly setting search_type with knn search

### DIFF
--- a/modules/lang-mustache/src/main/java/org/elasticsearch/script/mustache/RestMultiSearchTemplateAction.java
+++ b/modules/lang-mustache/src/main/java/org/elasticsearch/script/mustache/RestMultiSearchTemplateAction.java
@@ -93,7 +93,7 @@ public class RestMultiSearchTemplateAction extends BaseRestHandler {
                 } else {
                     throw new IllegalArgumentException("Malformed search template");
                 }
-                RestSearchAction.checkRestTotalHits(restRequest, searchRequest);
+                RestSearchAction.validateSearchRequest(restRequest, searchRequest);
             }
         );
         return multiRequest;

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.vectors/40_knn_search.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.vectors/40_knn_search.yml
@@ -75,7 +75,6 @@ setup:
   - do:
       search:
         index: test
-        search_type: dfs_query_then_fetch
         body:
           fields: [ "name" ]
           knn:
@@ -111,6 +110,7 @@ setup:
             query_vector: [-0.5, 90.0, -10, 14.8, -156.0]
             k: 2
             num_candidates: 3
+
             filter:
               term:
                 name: "rabbit.jpg"
@@ -136,6 +136,27 @@ setup:
                   _id: 2
 
   - match: {hits.total.value: 0}
+
+---
+"kNN search with explicit search_type":
+  - skip:
+      version: ' - 8.3.99'
+      reason: 'kNN added to search endpoint in 8.4'
+  - do:
+      catch: bad_request
+      search:
+        index: test
+        search_type: query_then_fetch
+        body:
+          fields: [ "name" ]
+          knn:
+            field: vector
+            query_vector: [-0.5, 90.0, -10, 14.8, -156.0]
+            k: 2
+            num_candidates: 3
+
+  - match: { error.root_cause.0.type: "illegal_argument_exception" }
+  - match: { error.root_cause.0.reason: "cannot set [search_type] when using [knn] search, since the search type is determined automatically" }
 
 ---
 "kNN search in _knn_search endpoint":

--- a/server/src/main/java/org/elasticsearch/rest/action/search/RestMultiSearchAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/search/RestMultiSearchAction.java
@@ -135,7 +135,7 @@ public class RestMultiSearchAction extends BaseRestHandler {
 
         parseMultiLineRequest(restRequest, multiRequest.indicesOptions(), allowExplicitIndex, (searchRequest, parser) -> {
             searchRequest.source(SearchSourceBuilder.fromXContent(parser, false));
-            RestSearchAction.checkRestTotalHits(restRequest, searchRequest);
+            RestSearchAction.validateSearchRequest(restRequest, searchRequest);
             if (searchRequest.pointInTimeBuilder() != null) {
                 RestSearchAction.preparePointInTime(searchRequest, restRequest, namedWriteableRegistry);
             } else {

--- a/server/src/main/java/org/elasticsearch/rest/action/search/RestSearchAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/search/RestSearchAction.java
@@ -201,7 +201,6 @@ public class RestSearchAction extends BaseRestHandler {
         searchRequest.indicesOptions(IndicesOptions.fromRequest(request, searchRequest.indicesOptions()));
 
         validateSearchRequest(request, searchRequest);
-        checkSearchType(request, searchRequest);
 
         if (searchRequest.pointInTimeBuilder() != null) {
             preparePointInTime(searchRequest, request, namedWriteableRegistry);

--- a/server/src/main/java/org/elasticsearch/rest/action/search/RestSearchAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/search/RestSearchAction.java
@@ -200,7 +200,8 @@ public class RestSearchAction extends BaseRestHandler {
         searchRequest.preference(request.param("preference"));
         searchRequest.indicesOptions(IndicesOptions.fromRequest(request, searchRequest.indicesOptions()));
 
-        checkRestTotalHits(request, searchRequest);
+        validateSearchRequest(request, searchRequest);
+        checkSearchType(request, searchRequest);
 
         if (searchRequest.pointInTimeBuilder() != null) {
             preparePointInTime(searchRequest, request, namedWriteableRegistry);
@@ -399,6 +400,15 @@ public class RestSearchAction extends BaseRestHandler {
     }
 
     /**
+     * Validates that no search request parameters conflict. This method
+     * might modify the search request to align certain parameters.
+     */
+    public static void validateSearchRequest(RestRequest restRequest, SearchRequest searchRequest) {
+        checkRestTotalHits(restRequest, searchRequest);
+        checkSearchType(restRequest, searchRequest);
+    }
+
+    /**
      * Modify the search request to accurately count the total hits that match the query
      * if {@link #TOTAL_HITS_AS_INT_PARAM} is set.
      *
@@ -406,7 +416,7 @@ public class RestSearchAction extends BaseRestHandler {
      * is used in conjunction with a lower bound value (other than {@link SearchContext#DEFAULT_TRACK_TOTAL_HITS_UP_TO})
      * for the track_total_hits option.
      */
-    public static void checkRestTotalHits(RestRequest restRequest, SearchRequest searchRequest) {
+    private static void checkRestTotalHits(RestRequest restRequest, SearchRequest searchRequest) {
         boolean totalHitsAsInt = restRequest.paramAsBoolean(TOTAL_HITS_AS_INT_PARAM, false);
         if (totalHitsAsInt == false) {
             return;
@@ -427,6 +437,14 @@ public class RestSearchAction extends BaseRestHandler {
                         + trackTotalHitsUpTo
                 );
             }
+    }
+
+    private static void checkSearchType(RestRequest restRequest, SearchRequest searchRequest) {
+        if (restRequest.hasParam("search_type") && searchRequest.hasKnnSearch()) {
+            throw new IllegalArgumentException(
+                "cannot set [search_type] when using [knn] search, since the search type " + "is determined automatically"
+            );
+        }
     }
 
     @Override

--- a/x-pack/plugin/rollup/src/main/java/org/elasticsearch/xpack/rollup/rest/RestRollupSearchAction.java
+++ b/x-pack/plugin/rollup/src/main/java/org/elasticsearch/xpack/rollup/rest/RestRollupSearchAction.java
@@ -47,7 +47,7 @@ public class RestRollupSearchAction extends BaseRestHandler {
                 size -> searchRequest.source().size(size)
             )
         );
-        RestSearchAction.checkRestTotalHits(restRequest, searchRequest);
+        RestSearchAction.validateSearchRequest(restRequest, searchRequest);
         return channel -> client.execute(RollupSearchAction.INSTANCE, searchRequest, new RestToXContentListener<>(channel));
     }
 


### PR DESCRIPTION
When kNN search is enabled, it automatically uses the `dfs_query_then_fetch`
search type. The user can no longer control the search type that's used. This
commit throws an error if `search_type` is explicitly set when `knn` search is
used.

Addresses #87625.