### PR TITLE
Set metadata on initial request in API key noop test

### DIFF
--- a/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/xpack/security/authc/ApiKeyIntegTests.java
+++ b/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/xpack/security/authc/ApiKeyIntegTests.java
@@ -1775,11 +1775,11 @@ public class ApiKeyIntegTests extends SecurityIntegTestCase {
         // Update with different role descriptors is not a noop
         final List<RoleDescriptor> newRoleDescriptors = List.of(
             randomValueOtherThanMany(
-                rd -> (RoleDescriptorRequestValidator.validate(rd) != null) && initialRequest.getRoleDescriptors().contains(rd) == false,
+                rd -> RoleDescriptorRequestValidator.validate(rd) != null || initialRequest.getRoleDescriptors().contains(rd),
                 () -> RoleDescriptorTests.randomRoleDescriptor(false)
             ),
             randomValueOtherThanMany(
-                rd -> (RoleDescriptorRequestValidator.validate(rd) != null) && initialRequest.getRoleDescriptors().contains(rd) == false,
+                rd -> RoleDescriptorRequestValidator.validate(rd) != null || initialRequest.getRoleDescriptors().contains(rd),
                 () -> RoleDescriptorTests.randomRoleDescriptor(false)
             )
         );

--- a/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/xpack/security/authc/ApiKeyIntegTests.java
+++ b/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/xpack/security/authc/ApiKeyIntegTests.java
@@ -101,6 +101,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
@@ -1744,11 +1745,13 @@ public class ApiKeyIntegTests extends SecurityIntegTestCase {
         final var initialRequest = new UpdateApiKeyRequest(
             apiKeyId,
             List.of(new RoleDescriptor(randomAlphaOfLength(10), new String[] { "all" }, null, null)),
-            ApiKeyTests.randomMetadata()
+            // Ensure not `null` to set metadata since we use the initialRequest further down in the test to check assert whether
+            // metadata updates are noops or not
+            randomValueOtherThanMany(Objects::isNull, ApiKeyTests::randomMetadata)
         );
         UpdateApiKeyResponse response = executeUpdateApiKey(TEST_USER_NAME, initialRequest);
         assertNotNull(response);
-        // First update is not noop, because role descriptors changed and possibly metadata
+        // First update is not noop, because role descriptors and metadata changed
         assertTrue(response.isUpdated());
 
         // Update with same request is a noop and does not clear cache

--- a/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/xpack/security/authc/ApiKeyIntegTests.java
+++ b/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/xpack/security/authc/ApiKeyIntegTests.java
@@ -1745,13 +1745,13 @@ public class ApiKeyIntegTests extends SecurityIntegTestCase {
         final var initialRequest = new UpdateApiKeyRequest(
             apiKeyId,
             List.of(new RoleDescriptor(randomAlphaOfLength(10), new String[] { "all" }, null, null)),
-            // Ensure not `null` to set metadata since we use the initialRequest further down in the test to check assert whether
-            // metadata updates are noops or not
+            // Ensure not `null` to set metadata since we use the initialRequest further down in the test to ensure that
+            // metadata updates are non-noops
             randomValueOtherThanMany(Objects::isNull, ApiKeyTests::randomMetadata)
         );
         UpdateApiKeyResponse response = executeUpdateApiKey(TEST_USER_NAME, initialRequest);
         assertNotNull(response);
-        // First update is not noop, because role descriptors and metadata changed
+        // First update is not noop, because role descriptors changed and possibly metadata
         assertTrue(response.isUpdated());
 
         // Update with same request is a noop and does not clear cache


### PR DESCRIPTION
This PR fixes API key integration test setup for noops. In the noop
test, we use the initial update request as a reference to choose
suitable values to force non-noop updates, including metadata. However,
metadata can be `null` on the initial request, meaning that the
underlying API key will retain the metadata it was assigned on
creation. This can lead to test failure when the metadata on the
initial request is `null`, and the subsequent metadata update matches
the metadata chosen at API key creation time.

Closes #88503.