### PR TITLE
[7.17] Reenable TestingConventionsPrecommitPluginFuncTest on windows (#88240)

### DIFF
--- a/build-tools-internal/src/integTest/groovy/org/elasticsearch/gradle/fixtures/LocalRepositoryFixture.groovy
+++ b/build-tools-internal/src/integTest/groovy/org/elasticsearch/gradle/fixtures/LocalRepositoryFixture.groovy
@@ -44,7 +44,7 @@ class LocalRepositoryFixture extends ExternalResource{
         repositories {
           maven {
             name = "local-test"
-            url = "${getRepoDir()}"
+            url = "${getRepoDir().toURI()}"
             metadataSources {
               artifact()
             }

--- a/build-tools-internal/src/integTest/groovy/org/elasticsearch/gradle/internal/precommit/TestingConventionsPrecommitPluginFuncTest.groovy
+++ b/build-tools-internal/src/integTest/groovy/org/elasticsearch/gradle/internal/precommit/TestingConventionsPrecommitPluginFuncTest.groovy
@@ -200,11 +200,11 @@ class TestingConventionsPrecommitPluginFuncTest extends AbstractGradlePrecommitP
         clazz(dir('src/yamlRestTest/java'), "org.elasticsearch.test.rest.yaml.ESClientYamlSuiteTestCase")
         buildFile << """
         apply plugin:'elasticsearch.internal-yaml-rest-test'
-        
+
         dependencies {
             yamlRestTestImplementation "org.apache.lucene:tests.util:1.0"
             yamlRestTestImplementation "org.junit:junit:4.42"
-        }    
+        }
         """
 
         clazz(dir("src/yamlRestTest/java"), "org.acme.valid.SomeMatchingIT", "org.elasticsearch.test.rest.yaml.ESClientYamlSuiteTestCase") {
@@ -241,11 +241,11 @@ class TestingConventionsPrecommitPluginFuncTest extends AbstractGradlePrecommitP
         buildFile << """
         import org.elasticsearch.gradle.internal.precommit.TestingConventionsCheckTask
         apply plugin:'$pluginName'
-        
+
         dependencies {
             ${sourceSetName}Implementation "org.apache.lucene:tests.util:1.0"
             ${sourceSetName}Implementation "org.junit:junit:4.42"
-        }    
+        }
         tasks.withType(TestingConventionsCheckTask).configureEach {
             suffix 'IT'
             suffix 'Tests'
@@ -285,11 +285,11 @@ class TestingConventionsPrecommitPluginFuncTest extends AbstractGradlePrecommitP
     private void simpleJavaBuild() {
         buildFile << """
         apply plugin:'java'
-                
+
         dependencies {
             testImplementation "org.apache.lucene:tests.util:1.0"
             testImplementation "org.junit:junit:4.42"
-        }    
+        }
         """
     }
 }


### PR DESCRIPTION
Backports the following commits to 7.17:
 - Reenable TestingConventionsPrecommitPluginFuncTest on windows (#88240)