### PR TITLE
[Transform] Finetune Schedule to be less noisy on retry and retry slower

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/notifications/TransformAuditMessage.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/notifications/TransformAuditMessage.java
@@ -6,6 +6,7 @@
  */
 package org.elasticsearch.xpack.core.transform.notifications;
 
+import org.elasticsearch.common.Strings;
 import org.elasticsearch.xcontent.ConstructingObjectParser;
 import org.elasticsearch.xcontent.ParseField;
 import org.elasticsearch.xpack.core.common.notifications.AbstractAuditMessage;
@@ -36,5 +37,10 @@ public class TransformAuditMessage extends AbstractAuditMessage {
     @Override
     protected Optional<String> getResourceField() {
         return Optional.of(TRANSFORM_ID.getPreferredName());
+    }
+
+    @Override
+    public String toString() {
+        return Strings.toString(this, true, true);
     }
 }

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/scheduling/TransformScheduledTask.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/scheduling/TransformScheduledTask.java
@@ -23,7 +23,7 @@ final class TransformScheduledTask {
     /**
      * Minimum delay that can be applied after a failure.
      */
-    private static final long MIN_DELAY_MILLIS = Duration.ofSeconds(1).toMillis();
+    private static final long MIN_DELAY_MILLIS = Duration.ofSeconds(5).toMillis();
     /**
      * Maximum delay that can be applied after a failure.
      */

--- a/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/notifications/MockTransformAuditor.java
+++ b/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/notifications/MockTransformAuditor.java
@@ -102,7 +102,7 @@ public class MockTransformAuditor extends TransformAuditor {
     }
 
     public abstract static class AbstractAuditExpectation implements AuditExpectation {
-        protected final String expectedName;
+        protected final String name;
         protected final Level expectedLevel;
         protected final String expectedResourceId;
         protected final String expectedMessage;
@@ -110,13 +110,13 @@ public class MockTransformAuditor extends TransformAuditor {
         volatile int count;
 
         public AbstractAuditExpectation(
-            String expectedName,
+            String name,
             Level expectedLevel,
             String expectedResourceId,
             String expectedMessage,
             int expectedCount
         ) {
-            this.expectedName = expectedName;
+            this.name = name;
             this.expectedLevel = expectedLevel;
             this.expectedResourceId = expectedResourceId;
             this.expectedMessage = expectedMessage;
@@ -144,49 +144,64 @@ public class MockTransformAuditor extends TransformAuditor {
         }
     }
 
+    /**
+     * Expectation to assert a certain audit message has been issued once or multiple times.
+     */
     public static class SeenAuditExpectation extends AbstractAuditExpectation {
 
-        public SeenAuditExpectation(String expectedName, Level expectedLevel, String expectedResourceId, String expectedMessage) {
-            super(expectedName, expectedLevel, expectedResourceId, expectedMessage, 1);
+        /**
+         * Expectation to match an audit exactly once.
+         *
+         * @param name name of the expected audit, free of choice, used for the assert message
+         * @param expectedLevel The expected level of the audit
+         * @param expectedResourceId The expected resource id
+         * @param expectedMessage Expected message of the audit, supports simple wildcard matching
+         */
+        public SeenAuditExpectation(String name, Level expectedLevel, String expectedResourceId, String expectedMessage) {
+            super(name, expectedLevel, expectedResourceId, expectedMessage, 1);
         }
 
-        @Override
-        public void assertMatched() {
-            assertThat("expected to see " + expectedName + " but did not", count, equalTo(expectedCount));
-        }
-    }
-
-    public static class UnseenAuditExpectation extends AbstractAuditExpectation {
-
-        public UnseenAuditExpectation(String expectedName, Level expectedLevel, String expectedResourceId, String expectedMessage) {
-            super(expectedName, expectedLevel, expectedResourceId, expectedMessage, 0);
-        }
-
-        @Override
-        public void assertMatched() {
-            assertThat("expected not to see " + expectedName + " but did", count, equalTo(expectedCount));
-        }
-    }
-
-    public static class MultipleSeenAuditExpectation extends AbstractAuditExpectation {
-
-        public MultipleSeenAuditExpectation(
-            String expectedName,
+        /**
+         * Expectation to match an audit a certain number of times.
+         *
+         * @param name name of the expected audit, free of choice, used for the assert message
+         * @param expectedLevel The expected level of the audit
+         * @param expectedResourceId The expected resource id
+         * @param expectedMessage Expected message of the audit, supports simple wildcard matching
+         * @param expectedCount Expected number of times the audit should be matched
+         */
+        public SeenAuditExpectation(
+            String name,
             Level expectedLevel,
             String expectedResourceId,
             String expectedMessage,
             int expectedCount
         ) {
-            super(expectedName, expectedLevel, expectedResourceId, expectedMessage, expectedCount);
+            super(name, expectedLevel, expectedResourceId, expectedMessage, expectedCount);
         }
 
         @Override
         public void assertMatched() {
             assertThat(
-                "expected to see " + expectedName + " " + expectedCount + " times but saw it " + count + " times ",
+                "expected to see " + name + " " + expectedCount + " times but saw it " + count + " times ",
                 count,
                 equalTo(expectedCount)
             );
+        }
+    }
+
+    /**
+     * Expectation to assert a certain audit message is not issued.
+     */
+    public static class UnseenAuditExpectation extends AbstractAuditExpectation {
+
+        public UnseenAuditExpectation(String name, Level expectedLevel, String expectedResourceId, String expectedMessage) {
+            super(name, expectedLevel, expectedResourceId, expectedMessage, 0);
+        }
+
+        @Override
+        public void assertMatched() {
+            assertThat("expected not to see " + name + " but did", count, equalTo(expectedCount));
         }
     }
 

--- a/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/TransformContextTests.java
+++ b/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/TransformContextTests.java
@@ -36,12 +36,13 @@ public class TransformContextTests extends ESTestCase {
 
     public void testFailureCount() {
         TransformContext context = new TransformContext(null, null, 0, listener);
-        assertThat(context.incrementAndGetFailureCount(), is(equalTo(1)));
+        assertThat(context.incrementAndGetFailureCount("some_exception"), is(equalTo(1)));
         assertThat(context.getFailureCount(), is(equalTo(1)));
-        assertThat(context.incrementAndGetFailureCount(), is(equalTo(2)));
+        assertThat(context.incrementAndGetFailureCount("some_other_exception"), is(equalTo(2)));
         assertThat(context.getFailureCount(), is(equalTo(2)));
         context.resetReasonAndFailureCounter();
         assertThat(context.getFailureCount(), is(equalTo(0)));
+        assertThat(context.getLastFailure(), is(nullValue()));
 
         // Verify that the listener is notified every time the failure count is incremented or reset
         verify(listener, times(3)).failureCountChanged();

--- a/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/TransformIndexerFailureHandlingTests.java
+++ b/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/TransformIndexerFailureHandlingTests.java
@@ -1032,7 +1032,7 @@ public class TransformIndexerFailureHandlingTests extends ESTestCase {
             : contextNumFailureRetries != null ? contextNumFailureRetries
             : Transform.DEFAULT_FAILURE_RETRIES;
         auditor.addExpectation(
-            new MockTransformAuditor.MultipleSeenAuditExpectation(
+            new MockTransformAuditor.SeenAuditExpectation(
                 getTestName(),
                 Level.WARNING,
                 transformId,

--- a/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/TransformIndexerFailureHandlingTests.java
+++ b/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/TransformIndexerFailureHandlingTests.java
@@ -23,6 +23,7 @@ import org.elasticsearch.client.internal.Client;
 import org.elasticsearch.common.breaker.CircuitBreaker.Durability;
 import org.elasticsearch.common.breaker.CircuitBreakingException;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.util.concurrent.EsRejectedExecutionException;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.index.reindex.BulkByScrollResponse;
 import org.elasticsearch.index.reindex.DeleteByQueryRequest;
@@ -689,8 +690,8 @@ public class TransformIndexerFailureHandlingTests extends ESTestCase {
                 "timed out during dbq",
                 Level.WARNING,
                 transformId,
-                "Transform encountered an exception: org.elasticsearch.ElasticsearchTimeoutException: timed out during dbq;"
-                    + " Will attempt again at next scheduled trigger."
+                "Transform encountered an exception: [org.elasticsearch.ElasticsearchTimeoutException: timed out during dbq];"
+                    + " Will automatically retry [1/10]"
             )
         );
         TransformContext.Listener contextListener = mock(TransformContext.Listener.class);
@@ -835,28 +836,170 @@ public class TransformIndexerFailureHandlingTests extends ESTestCase {
         assertEquals(0, context.getFailureCount());
     }
 
+    // tests throttling of audits on logs based on repeated exception types
+    public void testHandleFailureAuditing() {
+        String transformId = randomAlphaOfLength(10);
+        TransformConfig config = new TransformConfig.Builder().setId(transformId)
+            .setSource(randomSourceConfig())
+            .setDest(randomDestConfig())
+            .setSyncConfig(new TimeSyncConfig("time", TimeSyncConfig.DEFAULT_DELAY))
+            .setPivotConfig(randomPivotConfig())
+            .build();
+
+        AtomicReference<IndexerState> state = new AtomicReference<>(IndexerState.STOPPED);
+        Function<SearchRequest, SearchResponse> searchFunction = request -> mock(SearchResponse.class);
+        Function<BulkRequest, BulkResponse> bulkFunction = request -> mock(BulkResponse.class);
+
+        final AtomicBoolean failIndexerCalled = new AtomicBoolean(false);
+        final AtomicReference<String> failureMessage = new AtomicReference<>();
+        Consumer<String> failureConsumer = message -> {
+            failIndexerCalled.compareAndSet(false, true);
+            failureMessage.compareAndSet(null, message);
+        };
+
+        MockTransformAuditor auditor = MockTransformAuditor.createMockAuditor();
+        TransformContext.Listener contextListener = mock(TransformContext.Listener.class);
+        TransformContext context = new TransformContext(TransformTaskState.STARTED, "", 0, contextListener);
+
+        auditor.addExpectation(
+            new MockTransformAuditor.SeenAuditExpectation(
+                "timeout_exception_1",
+                Level.WARNING,
+                transformId,
+                "Transform encountered an exception: [*ElasticsearchTimeoutException: timeout_1]; Will automatically retry [1/"
+                    + Transform.DEFAULT_FAILURE_RETRIES
+                    + "]"
+            )
+        );
+
+        auditor.addExpectation(
+            new MockTransformAuditor.SeenAuditExpectation(
+                "bulk_exception_1",
+                Level.WARNING,
+                transformId,
+                "Transform encountered an exception: [*BulkIndexingException: bulk_exception_1*]; Will automatically retry [2/"
+                    + Transform.DEFAULT_FAILURE_RETRIES
+                    + "]"
+            )
+        );
+
+        auditor.addExpectation(
+            new MockTransformAuditor.SeenAuditExpectation(
+                "timeout_exception_2",
+                Level.WARNING,
+                transformId,
+                "Transform encountered an exception: [*ElasticsearchTimeoutException: timeout_2]; Will automatically retry [3/"
+                    + Transform.DEFAULT_FAILURE_RETRIES
+                    + "]"
+            )
+        );
+
+        auditor.addExpectation(
+            new MockTransformAuditor.SeenAuditExpectation(
+                "bulk_exception_2",
+                Level.WARNING,
+                transformId,
+                "Transform encountered an exception: [*BulkIndexingException: bulk_exception_2*]; Will automatically retry [6/"
+                    + Transform.DEFAULT_FAILURE_RETRIES
+                    + "]"
+            )
+        );
+
+        MockedTransformIndexer indexer = createMockIndexer(
+            config,
+            state,
+            searchFunction,
+            bulkFunction,
+            null,
+            failureConsumer,
+            threadPool,
+            ThreadPool.Names.GENERIC,
+            auditor,
+            context
+        );
+
+        indexer.handleFailure(
+            new SearchPhaseExecutionException(
+                "query",
+                "Partial shards failure",
+                new ShardSearchFailure[] { new ShardSearchFailure(new ElasticsearchTimeoutException("timeout_1")) }
+            )
+        );
+
+        indexer.handleFailure(
+            new SearchPhaseExecutionException(
+                "query",
+                "Partial shards failure",
+                new ShardSearchFailure[] {
+                    new ShardSearchFailure(
+                        new BulkIndexingException("bulk_exception_1", new EsRejectedExecutionException("full queue"), false)
+                    ) }
+            )
+        );
+
+        indexer.handleFailure(
+            new SearchPhaseExecutionException(
+                "query",
+                "Partial shards failure",
+                new ShardSearchFailure[] { new ShardSearchFailure(new ElasticsearchTimeoutException("timeout_2")) }
+            )
+        );
+
+        // not logged
+        indexer.handleFailure(
+            new SearchPhaseExecutionException(
+                "query",
+                "Partial shards failure",
+                new ShardSearchFailure[] { new ShardSearchFailure(new ElasticsearchTimeoutException("timeout_2")) }
+            )
+        );
+
+        // not logged
+        indexer.handleFailure(
+            new SearchPhaseExecutionException(
+                "query",
+                "Partial shards failure",
+                new ShardSearchFailure[] { new ShardSearchFailure(new ElasticsearchTimeoutException("timeout_2")) }
+            )
+        );
+
+        indexer.handleFailure(
+            new SearchPhaseExecutionException(
+                "query",
+                "Partial shards failure",
+                new ShardSearchFailure[] {
+                    new ShardSearchFailure(
+                        new BulkIndexingException("bulk_exception_2", new EsRejectedExecutionException("full queue"), false)
+                    ) }
+            )
+        );
+
+        auditor.assertAllExpectationsMatched();
+    }
+
     public void testHandleFailure() {
-        testHandleFailure(0, 5, 0);
-        testHandleFailure(5, 0, 5);
-        testHandleFailure(3, 5, 3);
-        testHandleFailure(5, 3, 5);
-        testHandleFailure(0, null, 0);
-        testHandleFailure(3, null, 3);
-        testHandleFailure(5, null, 5);
-        testHandleFailure(7, null, 7);
-        testHandleFailure(Transform.DEFAULT_FAILURE_RETRIES, null, Transform.DEFAULT_FAILURE_RETRIES);
-        testHandleFailure(null, 0, 0);
-        testHandleFailure(null, 3, 3);
-        testHandleFailure(null, 5, 5);
-        testHandleFailure(null, 7, 7);
-        testHandleFailure(null, Transform.DEFAULT_FAILURE_RETRIES, Transform.DEFAULT_FAILURE_RETRIES);
-        testHandleFailure(null, null, Transform.DEFAULT_FAILURE_RETRIES);
+        testHandleFailure(0, 5, 0, 0);
+        testHandleFailure(5, 0, 5, 2);
+        testHandleFailure(3, 5, 3, 2);
+        testHandleFailure(5, 3, 5, 2);
+        testHandleFailure(0, null, 0, 0);
+        testHandleFailure(3, null, 3, 2);
+        testHandleFailure(5, null, 5, 2);
+        testHandleFailure(7, null, 7, 2);
+        testHandleFailure(Transform.DEFAULT_FAILURE_RETRIES, null, Transform.DEFAULT_FAILURE_RETRIES, 2);
+        testHandleFailure(null, 0, 0, 0);
+        testHandleFailure(null, 3, 3, 2);
+        testHandleFailure(null, 5, 5, 2);
+        testHandleFailure(null, 7, 7, 2);
+        testHandleFailure(null, Transform.DEFAULT_FAILURE_RETRIES, Transform.DEFAULT_FAILURE_RETRIES, 2);
+        testHandleFailure(null, null, Transform.DEFAULT_FAILURE_RETRIES, 2);
     }
 
     private void testHandleFailure(
         Integer configNumFailureRetries,
         Integer contextNumFailureRetries,
-        int expectedEffectiveNumFailureRetries
+        int expectedEffectiveNumFailureRetries,
+        int expecedNumberOfRetryAudits
     ) {
         String transformId = randomAlphaOfLength(10);
         TransformConfig config = new TransformConfig.Builder().setId(transformId)
@@ -884,6 +1027,19 @@ public class TransformIndexerFailureHandlingTests extends ESTestCase {
         if (contextNumFailureRetries != null) {
             context.setNumFailureRetries(contextNumFailureRetries);
         }
+
+        int indexerRetries = configNumFailureRetries != null ? configNumFailureRetries
+            : contextNumFailureRetries != null ? contextNumFailureRetries
+            : Transform.DEFAULT_FAILURE_RETRIES;
+        auditor.addExpectation(
+            new MockTransformAuditor.MultipleSeenAuditExpectation(
+                getTestName(),
+                Level.WARNING,
+                transformId,
+                "Transform encountered an exception: [*]; Will automatically retry [*/" + indexerRetries + "]",
+                expecedNumberOfRetryAudits
+            )
+        );
 
         MockedTransformIndexer indexer = createMockIndexer(
             config,

--- a/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/scheduling/TransformScheduledTaskTests.java
+++ b/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/scheduling/TransformScheduledTaskTests.java
@@ -58,16 +58,16 @@ public class TransformScheduledTaskTests extends ESTestCase {
         {
             TransformScheduledTask task = new TransformScheduledTask(TRANSFORM_ID, FREQUENCY, LAST_TRIGGERED_TIME_MILLIS, 1, LISTENER);
             // Verify that the next scheduled time is calculated properly when failure count is greater than 0
-            assertThat(task.getNextScheduledTimeMillis(), is(equalTo(102000L)));
+            assertThat(task.getNextScheduledTimeMillis(), is(equalTo(105000L)));
         }
     }
 
     public void testCalculateNextScheduledTimeAfterFailure() {
         long lastTriggeredTimeMillis = Instant.now().toEpochMilli();
         long[] expectedDelayMillis = {
-            1000,    // 1s
-            2000,    // 2s
-            4000,    // 4s
+            5000,    // 5s
+            5000,    // 5s
+            5000,    // 5s
             8000,    // 8s
             16000,   // 16s
             32000,   // 32s

--- a/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/scheduling/TransformSchedulerTests.java
+++ b/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/scheduling/TransformSchedulerTests.java
@@ -149,20 +149,20 @@ public class TransformSchedulerTests extends ESTestCase {
         transformScheduler.handleTransformFailureCountChanged(transformId, 1);
         assertThat(
             transformScheduler.getTransformScheduledTasks(),
-            contains(new TransformScheduledTask(transformId, frequency, 0L, 1, 2 * 1000, listener))
+            contains(new TransformScheduledTask(transformId, frequency, 0L, 1, 5 * 1000, listener))
         );
         assertThat(events, hasSize(1));
 
         transformScheduler.processScheduledTasks();
         assertThat(
             transformScheduler.getTransformScheduledTasks(),
-            contains(new TransformScheduledTask(transformId, frequency, 60 * 1000L, 1, 62 * 1000, listener))
+            contains(new TransformScheduledTask(transformId, frequency, 60 * 1000L, 1, 65 * 1000, listener))
         );
         assertThat(events, hasSize(2));
 
         assertThat(
             events,
-            contains(new TransformScheduler.Event(transformId, 0, 0), new TransformScheduler.Event(transformId, 2 * 1000, 60 * 1000))
+            contains(new TransformScheduler.Event(transformId, 0, 0), new TransformScheduler.Event(transformId, 5 * 1000, 60 * 1000))
         );
 
         transformScheduler.deregisterTransform(transformId);
@@ -396,6 +396,7 @@ public class TransformSchedulerTests extends ESTestCase {
             setCurrentTime(currentTime.plus(duration));
         }
 
+        @Override
         public Instant instant() {
             return currentTime;
         }


### PR DESCRIPTION
reduce amount of log and audits if the same failure happens in a row
and change the minimum wait time for retrying to 5s

This finetunes changes done in #84657 which makes retrying independent of frequency, which as a result triggers retry faster than before with the side-effect of producing more noise. For this change I investigated the log/audit behavior and adjusted it.

Notes:

 - the change contains mostly test changes, the important code changes are:
   -  [set MIN_DELAY_MILLIS to 5s (from 1s)](https://github.com/elastic/elasticsearch/compare/master...hendrikmuhs:transform-scheduler-reduce-noise?expand=1#diff-654470ab2a56583eaa9410e6f943ad5c41cc66111a0382b9a6704642465d91c0)
   - [dedup logs/audits based on exception class](https://github.com/elastic/elasticsearch/compare/master...hendrikmuhs:transform-scheduler-reduce-noise?expand=1#diff-84dcc4eb8ca941f4a67a6e32bb071461b20338c64a47d1cabba32b26ca8de1d3)
      - the 1st (retry-able) failure gets logged/audited, consequent failures only if they differ from the last one. The last retry is logged as well
      - exceptions are usually wrapped in a `SearchPhaseExecutionException`, so it is important to unwrap this as a 1st step. Just taking the message from the unwrapped class would still produce a lot of noise, because the messages can slightly differ although they have the same root cause. Using the class name of the unwrapped exception seems like a pragmatic way to dedup them.
      - I moved the last error into the context, note: there is no need to persist this as we do not stop the transform after such a failure, but keep the error in-memory only
 - Testing:
   - because testing this change as a system test isn't possible with the current infrastructure, I created mock module tests, [see TransformIndexerFailureHandlingTests](https://github.com/elastic/elasticsearch/compare/master...hendrikmuhs:transform-scheduler-reduce-noise?expand=1#diff-31a950d0df14254a662a2f4ca810d717049c8cfcdfdaba97e3c5da05ba6c0934)
 - Log/Audit message:
   - "Transform encountered an exception: [{Exception}]; Will automatically retry [1/10]"

relates #84657

(marked as non-issue as this is an addition to #84657)