### PR TITLE
fix: use status code 500 for errors if no shard failed

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/search/SearchPhaseExecutionException.java
+++ b/server/src/main/java/org/elasticsearch/action/search/SearchPhaseExecutionException.java
@@ -70,7 +70,7 @@ public class SearchPhaseExecutionException extends ElasticsearchException {
         if (shardFailures.length == 0) {
             // if no successful shards, the failure can be due to EsRejectedExecutionException during fetch phase
             // on coordinator node. so get the status from cause instead of returning SERVICE_UNAVAILABLE blindly
-            return getCause() == null ? RestStatus.SERVICE_UNAVAILABLE : ExceptionsHelper.status(getCause());
+            return getCause() == null ? RestStatus.INTERNAL_SERVER_ERROR : ExceptionsHelper.status(getCause());
         }
         RestStatus status = shardFailures[0].status();
         if (shardFailures.length > 1) {


### PR DESCRIPTION
If there is no shard failure we would like to use a generic
`Internal Server Error` other than a `Service Unavailable`.
Moreover, if the cause is known we use a status code that
reflects the cause.

Resolves #20004