### PR TITLE
Use status code 500 for errors if no shard failed

### DIFF
--- a/docs/changelog/88551.yaml
+++ b/docs/changelog/88551.yaml
@@ -1,5 +1,5 @@
 pr: 88551
-summary: "Fix: use status code 500 for errors if no shard failed"
+summary: "Fix: use status code 500 for aggregation reduce phase errors if no shard failed"
 area: Search
 type: bug
 issues:

--- a/docs/changelog/88551.yaml
+++ b/docs/changelog/88551.yaml
@@ -1,0 +1,6 @@
+pr: 88551
+summary: "Fix: use status code 500 for errors if no shard failed"
+area: Search
+type: bug
+issues:
+ - 20004

--- a/server/src/main/java/org/elasticsearch/action/search/ReduceSearchPhaseException.java
+++ b/server/src/main/java/org/elasticsearch/action/search/ReduceSearchPhaseException.java
@@ -8,7 +8,9 @@
 
 package org.elasticsearch.action.search;
 
+import org.elasticsearch.ExceptionsHelper;
 import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.rest.RestStatus;
 
 import java.io.IOException;
 
@@ -26,5 +28,22 @@ public class ReduceSearchPhaseException extends SearchPhaseExecutionException {
 
     public ReduceSearchPhaseException(StreamInput in) throws IOException {
         super(in);
+    }
+
+    @Override
+    public RestStatus status() {
+        ShardSearchFailure[] shardFailures = getShardFailures();
+        if (shardFailures.length == 0) {
+            return getCause() == null ? RestStatus.INTERNAL_SERVER_ERROR : ExceptionsHelper.status(getCause());
+        }
+        RestStatus status = shardFailures[0].status();
+        if (shardFailures.length > 1) {
+            for (int i = 1; i < shardFailures.length; i++) {
+                if (shardFailures[i].status().getStatus() >= 500) {
+                    status = shardFailures[i].status();
+                }
+            }
+        }
+        return status;
     }
 }

--- a/server/src/main/java/org/elasticsearch/action/search/ReduceSearchPhaseException.java
+++ b/server/src/main/java/org/elasticsearch/action/search/ReduceSearchPhaseException.java
@@ -32,18 +32,10 @@ public class ReduceSearchPhaseException extends SearchPhaseExecutionException {
 
     @Override
     public RestStatus status() {
-        ShardSearchFailure[] shardFailures = getShardFailures();
+        final ShardSearchFailure[] shardFailures = getShardFailures();
         if (shardFailures.length == 0) {
             return getCause() == null ? RestStatus.INTERNAL_SERVER_ERROR : ExceptionsHelper.status(getCause());
         }
-        RestStatus status = shardFailures[0].status();
-        if (shardFailures.length > 1) {
-            for (int i = 1; i < shardFailures.length; i++) {
-                if (shardFailures[i].status().getStatus() >= RestStatus.INTERNAL_SERVER_ERROR.getStatus()) {
-                    status = shardFailures[i].status();
-                }
-            }
-        }
-        return status;
+        return super.status();
     }
 }

--- a/server/src/main/java/org/elasticsearch/action/search/ReduceSearchPhaseException.java
+++ b/server/src/main/java/org/elasticsearch/action/search/ReduceSearchPhaseException.java
@@ -39,7 +39,7 @@ public class ReduceSearchPhaseException extends SearchPhaseExecutionException {
         RestStatus status = shardFailures[0].status();
         if (shardFailures.length > 1) {
             for (int i = 1; i < shardFailures.length; i++) {
-                if (shardFailures[i].status().getStatus() >= 500) {
+                if (shardFailures[i].status().getStatus() >= RestStatus.INTERNAL_SERVER_ERROR.getStatus()) {
                     status = shardFailures[i].status();
                 }
             }

--- a/server/src/main/java/org/elasticsearch/action/search/ReduceSearchPhaseException.java
+++ b/server/src/main/java/org/elasticsearch/action/search/ReduceSearchPhaseException.java
@@ -32,7 +32,7 @@ public class ReduceSearchPhaseException extends SearchPhaseExecutionException {
 
     @Override
     public RestStatus status() {
-        final ShardSearchFailure[] shardFailures = getShardFailures();
+        final ShardSearchFailure[] shardFailures = shardFailures();
         if (shardFailures.length == 0) {
             return getCause() == null ? RestStatus.INTERNAL_SERVER_ERROR : ExceptionsHelper.status(getCause());
         }

--- a/server/src/main/java/org/elasticsearch/action/search/SearchPhaseExecutionException.java
+++ b/server/src/main/java/org/elasticsearch/action/search/SearchPhaseExecutionException.java
@@ -75,7 +75,7 @@ public class SearchPhaseExecutionException extends ElasticsearchException {
         RestStatus status = shardFailures[0].status();
         if (shardFailures.length > 1) {
             for (int i = 1; i < shardFailures.length; i++) {
-                if (shardFailures[i].status().getStatus() >= 500) {
+                if (shardFailures[i].status().getStatus() >= RestStatus.INTERNAL_SERVER_ERROR.getStatus()) {
                     status = shardFailures[i].status();
                 }
             }

--- a/server/src/main/java/org/elasticsearch/action/search/SearchPhaseExecutionException.java
+++ b/server/src/main/java/org/elasticsearch/action/search/SearchPhaseExecutionException.java
@@ -83,7 +83,7 @@ public class SearchPhaseExecutionException extends ElasticsearchException {
         return status;
     }
 
-    public ShardSearchFailure[] shardFailures() {
+    ShardSearchFailure[] shardFailures() {
         return shardFailures;
     }
 

--- a/server/src/main/java/org/elasticsearch/action/search/SearchPhaseExecutionException.java
+++ b/server/src/main/java/org/elasticsearch/action/search/SearchPhaseExecutionException.java
@@ -83,7 +83,7 @@ public class SearchPhaseExecutionException extends ElasticsearchException {
         return status;
     }
 
-    ShardSearchFailure[] shardFailures() {
+    protected ShardSearchFailure[] shardFailures() {
         return shardFailures;
     }
 
@@ -160,9 +160,5 @@ public class SearchPhaseExecutionException extends ElasticsearchException {
 
     public String getPhaseName() {
         return phaseName;
-    }
-
-    public ShardSearchFailure[] getShardFailures() {
-        return shardFailures;
     }
 }

--- a/server/src/main/java/org/elasticsearch/action/search/SearchPhaseExecutionException.java
+++ b/server/src/main/java/org/elasticsearch/action/search/SearchPhaseExecutionException.java
@@ -161,4 +161,8 @@ public class SearchPhaseExecutionException extends ElasticsearchException {
     public String getPhaseName() {
         return phaseName;
     }
+
+    public ShardSearchFailure[] getShardFailures() {
+        return shardFailures;
+    }
 }

--- a/server/src/main/java/org/elasticsearch/action/search/SearchPhaseExecutionException.java
+++ b/server/src/main/java/org/elasticsearch/action/search/SearchPhaseExecutionException.java
@@ -83,7 +83,7 @@ public class SearchPhaseExecutionException extends ElasticsearchException {
         return status;
     }
 
-    protected ShardSearchFailure[] shardFailures() {
+    public ShardSearchFailure[] shardFailures() {
         return shardFailures;
     }
 


### PR DESCRIPTION
If there is no shard failure we would like to use a generic
Internal Server Error other than a Service Unavailable.
Moreover, if the cause is known we use a status code that
reflects the cause.

Resolves #20004