### PR TITLE
Move geo_shape query string test to the spatial module

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/search/query/QueryStringIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/query/QueryStringIT.java
@@ -13,17 +13,14 @@ import org.elasticsearch.action.index.IndexRequestBuilder;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.index.query.Operator;
-import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.search.SearchHit;
 import org.elasticsearch.search.SearchHits;
 import org.elasticsearch.test.ESIntegTestCase;
-import org.elasticsearch.test.TestGeoShapeFieldMapperPlugin;
 import org.elasticsearch.xcontent.XContentType;
 import org.junit.Before;
 
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -37,12 +34,6 @@ import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 
 public class QueryStringIT extends ESIntegTestCase {
-
-    @SuppressWarnings("deprecation")
-    @Override
-    protected Collection<Class<? extends Plugin>> nodePlugins() {
-        return List.of(TestGeoShapeFieldMapperPlugin.class);
-    }
 
     @Before
     public void setup() throws Exception {
@@ -156,7 +147,6 @@ public class QueryStringIT extends ESIntegTestCase {
         // binary doesn't match
         // suggest doesn't match
         // geo_point doesn't match
-        // geo_shape doesn't match
     }
 
     public void testKeywordWithWhitespace() throws Exception {

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/query/SimpleQueryStringIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/query/SimpleQueryStringIT.java
@@ -28,7 +28,6 @@ import org.elasticsearch.search.SearchHit;
 import org.elasticsearch.search.SearchHits;
 import org.elasticsearch.search.builder.SearchSourceBuilder;
 import org.elasticsearch.test.ESIntegTestCase;
-import org.elasticsearch.test.TestGeoShapeFieldMapperPlugin;
 import org.elasticsearch.xcontent.XContentFactory;
 import org.elasticsearch.xcontent.XContentType;
 
@@ -65,7 +64,7 @@ public class SimpleQueryStringIT extends ESIntegTestCase {
 
     @Override
     protected Collection<Class<? extends Plugin>> nodePlugins() {
-        return List.of(MockAnalysisPlugin.class, TestGeoShapeFieldMapperPlugin.class);
+        return List.of(MockAnalysisPlugin.class);
     }
 
     public void testSimpleQueryString() throws ExecutionException, InterruptedException {

--- a/server/src/test/resources/org/elasticsearch/search/query/all-example-document.json
+++ b/server/src/test/resources/org/elasticsearch/search/query/all-example-document.json
@@ -27,9 +27,5 @@
     "input": ["Nevermind", "Nirvana"],
     "weight": 34
   },
-  "f_geop": "41.12,-71.34",
-  "f_geos": {
-    "type": "point",
-    "coordinates": [-77.03653, 38.897676]
-  }
+  "f_geop": "41.12,-71.34"
 }

--- a/server/src/test/resources/org/elasticsearch/search/query/all-query-index.json
+++ b/server/src/test/resources/org/elasticsearch/search/query/all-query-index.json
@@ -59,8 +59,7 @@
         "f_geop_alias": {
           "type": "alias",
           "path": "f_geop"
-        },
-        "f_geos": {"type": "geo_shape"}
+        }
       }
     }
   }

--- a/x-pack/plugin/spatial/src/internalClusterTest/java/org/elasticsearch/xpack/spatial/search/SpatialQueryStringIT.java
+++ b/x-pack/plugin/spatial/src/internalClusterTest/java/org/elasticsearch/xpack/spatial/search/SpatialQueryStringIT.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.spatial.search;
+
+import org.elasticsearch.action.index.IndexRequestBuilder;
+import org.elasticsearch.action.search.SearchResponse;
+import org.elasticsearch.plugins.Plugin;
+import org.elasticsearch.test.ESIntegTestCase;
+import org.elasticsearch.xcontent.XContentType;
+import org.elasticsearch.xpack.spatial.LocalStateSpatialPlugin;
+import org.junit.Before;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+import static org.elasticsearch.index.query.QueryBuilders.queryStringQuery;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertHitCount;
+import static org.hamcrest.Matchers.containsString;
+
+public class SpatialQueryStringIT extends ESIntegTestCase {
+
+    @Override
+    protected Collection<Class<? extends Plugin>> nodePlugins() {
+        return List.of(LocalStateSpatialPlugin.class);
+    }
+
+    @Before
+    public void setup() {
+        String mapping = """
+            {
+              "settings": {
+                "index": {
+                  "number_of_shards": 1,
+                  "number_of_replicas": 0
+                }
+              },
+              "mappings": {
+                "_doc": {
+                  "properties": {
+                    "geo_shape": {"type": "geo_shape"},
+                    "shape": {"type": "shape"},
+                    "point": {"type": "point"}
+                    }
+                  }
+                }
+              }
+            }
+
+            """;
+        prepareCreate("test").setSource(mapping, XContentType.JSON).get();
+        ensureGreen("test");
+    }
+
+    public void testBasicAllQuery() throws Exception {
+        List<IndexRequestBuilder> reqs = new ArrayList<>();
+        reqs.add(
+            client().prepareIndex("test").setId("1").setSource("geo_shape", "POINT(0 0)", "shape", "POINT(0 0)", "point", "POINT(0 0)")
+        );
+        // nothing matches
+        indexRandom(true, false, reqs);
+        SearchResponse resp = client().prepareSearch("test").setQuery(queryStringQuery("foo")).get();
+        assertHitCount(resp, 0L);
+
+        resp = client().prepareSearch("test").setQuery(queryStringQuery("\"2015/09/02\"")).get();
+        assertHitCount(resp, 0L);
+
+        resp = client().prepareSearch("test").setQuery(queryStringQuery("127.0.0.1 OR 1.8")).get();
+        assertHitCount(resp, 0L);
+
+        resp = client().prepareSearch("test").setQuery(queryStringQuery("POINT(0 0)")).get();
+        assertHitCount(resp, 0L);
+
+        Exception e = expectThrows(
+            Exception.class,
+            () -> client().prepareSearch("test").setQuery(queryStringQuery("POINT(0 0)").field("geo_shape")).get()
+        );
+        assertThat(e.getCause().getMessage(), containsString("Field [geo_shape] of type [geo_shape] does not support match queries"));
+
+        e = expectThrows(
+            Exception.class,
+            () -> client().prepareSearch("test").setQuery(queryStringQuery("POINT(0 0)").field("shape")).get()
+        );
+        assertThat(e.getCause().getMessage(), containsString("Field [shape] of type [shape] does not support match queries"));
+
+        e = expectThrows(
+            Exception.class,
+            () -> client().prepareSearch("test").setQuery(queryStringQuery("POINT(0 0)").field("point")).get()
+        );
+        assertThat(e.getCause().getMessage(), containsString("Field [point] of type [point] does not support match queries"));
+
+        resp = client().prepareSearch("test").setQuery(queryStringQuery("POINT(0 0)").field("*shape")).get();
+        assertHitCount(resp, 0L);
+    }
+}


### PR DESCRIPTION
Adds a new SpatialQueryStringIT test in the spatial module to test fields that the module adds.