### PR TITLE
Fix Azure repository tests randomly taking many minutes

### DIFF
--- a/modules/repository-azure/src/internalClusterTest/java/org/elasticsearch/repositories/azure/AzureBlobStoreRepositoryTests.java
+++ b/modules/repository-azure/src/internalClusterTest/java/org/elasticsearch/repositories/azure/AzureBlobStoreRepositoryTests.java
@@ -131,8 +131,8 @@ public class AzureBlobStoreRepositoryTests extends ESMockAPIBasedRepositoryInteg
                         RetryPolicyType.EXPONENTIAL,
                         azureStorageSettings.getMaxRetries() + 1,
                         60,
-                        50L,
-                        100L,
+                        5L,
+                        10L,
                         null
                     );
                 }


### PR DESCRIPTION
If we run into a seed that causes many fake exceptions and thus retries,
a 100ms retry interval will add up to minutes of test time for tests like
`testLargeBlobCountDeletion` that trigger thousands of requests.
There's no reason not to speed this up by 10x via more aggressive retry
timings as far as I can see so I reduced the timings to avoid randomly
blocked tests.
