### PR TITLE
Always close directory streams

### DIFF
--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/precommit/JavaModulePrecommitTask.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/precommit/JavaModulePrecommitTask.java
@@ -126,9 +126,8 @@ public class JavaModulePrecommitTask extends PrecommitTask {
         Path servicesRoot = getResourcesDir().toPath().resolve("META-INF").resolve("services");
         getLogger().info("%s servicesRoot %s".formatted(this, servicesRoot));
         if (Files.exists(servicesRoot)) {
-            try {
-                Files.walk(servicesRoot)
-                    .filter(Files::isRegularFile)
+            try (var paths = Files.walk(servicesRoot)) {
+                paths.filter(Files::isRegularFile)
                     .map(p -> servicesRoot.relativize(p))
                     .map(Path::toString)
                     .peek(s -> getLogger().info("%s checking service %s".formatted(this, s)))

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/precommit/SplitPackagesAuditTask.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/precommit/SplitPackagesAuditTask.java
@@ -298,12 +298,13 @@ public class SplitPackagesAuditTask extends DefaultTask {
             if (Files.exists(root) == false) {
                 return;
             }
-            Files.walk(root)
-                .filter(p -> p.toString().endsWith(suffix))
-                .map(root::relativize)
-                .filter(p -> p.getNameCount() > 1) // module-info or other things without a package can be skipped
-                .filter(p -> p.toString().startsWith("META-INF") == false)
-                .forEach(classConsumer);
+            try (var paths = Files.walk(root)) {
+                paths.filter(p -> p.toString().endsWith(suffix))
+                    .map(root::relativize)
+                    .filter(p -> p.getNameCount() > 1) // module-info or other things without a package can be skipped
+                    .filter(p -> p.toString().startsWith("META-INF") == false)
+                    .forEach(classConsumer);
+            }
         }
 
         private static String getPackageName(Path path) {

--- a/docs/changelog/88560.yaml
+++ b/docs/changelog/88560.yaml
@@ -1,0 +1,5 @@
+pr: 88560
+summary: Always close directory streams
+area: Infra/Core
+type: bug
+issues: []


### PR DESCRIPTION
This change fixes a couple of directory streams that were not being explicitly closed - which could lead to a descriptor/memory leak.

There are other instances of this issue, but I want so quash these quickly so as to eliminate them from being test failure suspects (on Windows). Other instances of this issue can be done as a follow-up.