### PR TITLE
[8.3] Add easier configuration cache test support in build logic tests (#88047)

### DIFF
--- a/build-tools-internal/src/integTest/groovy/org/elasticsearch/gradle/fixtures/AbstractGradleInternalPluginFuncTest.groovy
+++ b/build-tools-internal/src/integTest/groovy/org/elasticsearch/gradle/fixtures/AbstractGradleInternalPluginFuncTest.groovy
@@ -1,0 +1,31 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.gradle.fixtures
+
+import org.gradle.api.Plugin
+
+abstract class AbstractGradleInternalPluginFuncTest extends AbstractJavaGradleFuncTest {
+
+    abstract <T extends Plugin> Class<T> getPluginClassUnderTest();
+
+    def setup() {
+        buildFile << """
+        import ${getPluginClassUnderTest().getName()}
+        
+        plugins {
+          // bring in build-tools-internal onto the classpath
+          id 'elasticsearch.global-build-info'
+        }
+        // internally used plugins do not have a plugin id as they are
+        // not intended to be used directly from build scripts 
+        plugins.apply(${getPluginClassUnderTest().getSimpleName()})
+        
+        """
+    }
+}

--- a/build-tools-internal/src/integTest/groovy/org/elasticsearch/gradle/internal/precommit/LicenseHeadersPrecommitPluginFuncTest.groovy
+++ b/build-tools-internal/src/integTest/groovy/org/elasticsearch/gradle/internal/precommit/LicenseHeadersPrecommitPluginFuncTest.groovy
@@ -8,19 +8,24 @@
 
 package org.elasticsearch.gradle.internal.precommit
 
-import org.elasticsearch.gradle.fixtures.AbstractGradleFuncTest
+import org.elasticsearch.gradle.fixtures.AbstractGradleInternalPluginFuncTest
+import org.elasticsearch.gradle.internal.conventions.precommit.LicenseHeadersPrecommitPlugin
+import org.elasticsearch.gradle.internal.conventions.precommit.PrecommitPlugin
 import org.gradle.testkit.runner.TaskOutcome
 
-class LicenseHeadersPrecommitPluginFuncTest extends AbstractGradleFuncTest {
+class LicenseHeadersPrecommitPluginFuncTest extends AbstractGradleInternalPluginFuncTest {
+
+    Class<? extends PrecommitPlugin> pluginClassUnderTest = LicenseHeadersPrecommitPlugin.class
+
+    def setup() {
+        configurationCacheCompatible = true
+        buildFile << """
+        apply plugin:'java'
+        """
+    }
 
     def "detects invalid files with invalid license header"() {
         given:
-        buildFile << """
-        plugins {
-            id 'java'
-            id 'elasticsearch.internal-licenseheaders'
-        }
-        """
         dualLicensedFile()
         unknownSourceFile()
         unapprovedSourceFile()
@@ -39,11 +44,6 @@ class LicenseHeadersPrecommitPluginFuncTest extends AbstractGradleFuncTest {
     def "can filter source files"() {
         given:
         buildFile << """
-        plugins {
-            id 'java'
-            id 'elasticsearch.internal-licenseheaders'
-        }
-
         tasks.named("licenseHeaders").configure {
             excludes << 'org/acme/filtered/**/*'
         }
@@ -61,12 +61,6 @@ class LicenseHeadersPrecommitPluginFuncTest extends AbstractGradleFuncTest {
 
     def "supports sspl by convention"() {
         given:
-        buildFile << """
-        plugins {
-            id 'java'
-            id 'elasticsearch.internal-licenseheaders'
-        }
-        """
         dualLicensedFile()
 
         when:
@@ -79,11 +73,6 @@ class LicenseHeadersPrecommitPluginFuncTest extends AbstractGradleFuncTest {
     def "sspl default additional license can be overridden"() {
         given:
         buildFile << """
-        plugins {
-            id 'java'
-            id 'elasticsearch.internal-licenseheaders'
-        }
-
         tasks.named("licenseHeaders").configure {
             additionalLicense 'ELAST', 'Elastic License 2.0', '2.0; you may not use this file except in compliance with the Elastic License'
         }

--- a/build-tools/src/testFixtures/groovy/org/elasticsearch/gradle/fixtures/AbstractGradleFuncTest.groovy
+++ b/build-tools/src/testFixtures/groovy/org/elasticsearch/gradle/fixtures/AbstractGradleFuncTest.groovy
@@ -9,6 +9,7 @@
 package org.elasticsearch.gradle.fixtures
 
 import org.apache.commons.io.FileUtils
+import org.elasticsearch.gradle.internal.test.ConfigurationCacheCompatibleAwareGradleRunner
 import org.elasticsearch.gradle.internal.test.InternalAwareGradleRunner
 import org.elasticsearch.gradle.internal.test.NormalizeOutputGradleRunner
 import org.gradle.testkit.runner.BuildResult
@@ -32,6 +33,8 @@ abstract class AbstractGradleFuncTest extends Specification {
     File buildFile
     File propertiesFile
     File projectDir
+
+    boolean configurationCacheCompatible = false
 
     def setup() {
         projectDir = testProjectDir.root
@@ -71,14 +74,17 @@ abstract class AbstractGradleFuncTest extends Specification {
 
     GradleRunner gradleRunner(File projectDir, String... arguments) {
         return new NormalizeOutputGradleRunner(
-            new InternalAwareGradleRunner(
-                GradleRunner.create()
-                    .withDebug(ManagementFactory.getRuntimeMXBean().getInputArguments().toString().indexOf("-agentlib:jdwp") > 0)
-                    .withProjectDir(projectDir)
-                    .withPluginClasspath()
-                    .forwardOutput()
-            ),
-            projectDir
+                new ConfigurationCacheCompatibleAwareGradleRunner(
+                        new InternalAwareGradleRunner(
+                                GradleRunner.create()
+                                        .withDebug(ManagementFactory.getRuntimeMXBean().getInputArguments()
+                                                .toString().indexOf("-agentlib:jdwp") > 0
+                                        )
+                                        .withProjectDir(projectDir)
+                                        .withPluginClasspath()
+                                        .forwardOutput()
+                        ), configurationCacheCompatible),
+                projectDir
         ).withArguments(arguments)
     }
 
@@ -127,13 +133,13 @@ abstract class AbstractGradleFuncTest extends Specification {
     }
 
     File internalBuild(
-        List<String> extraPlugins = [],
-        String bugfix = "7.15.2",
-        String bugfixLucene = "8.9.0",
-        String staged = "7.16.0",
-        String stagedLucene = "8.10.0",
-        String minor = "8.0.0",
-        String minorLucene = "9.0.0"
+            List<String> extraPlugins = [],
+            String bugfix = "7.15.2",
+            String bugfixLucene = "8.9.0",
+            String staged = "7.16.0",
+            String stagedLucene = "8.10.0",
+            String minor = "8.0.0",
+            String minorLucene = "9.0.0"
     ) {
         buildFile << """plugins {
           id 'elasticsearch.global-build-info'

--- a/build-tools/src/testFixtures/java/org/elasticsearch/gradle/internal/test/ConfigurationCacheCompatibleAwareGradleRunner.java
+++ b/build-tools/src/testFixtures/java/org/elasticsearch/gradle/internal/test/ConfigurationCacheCompatibleAwareGradleRunner.java
@@ -1,0 +1,160 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.gradle.internal.test;
+
+import org.gradle.testkit.runner.BuildResult;
+import org.gradle.testkit.runner.GradleRunner;
+import org.gradle.testkit.runner.InvalidPluginMetadataException;
+import org.gradle.testkit.runner.InvalidRunnerConfigurationException;
+import org.gradle.testkit.runner.UnexpectedBuildFailure;
+import org.gradle.testkit.runner.UnexpectedBuildSuccess;
+
+import java.io.File;
+import java.io.Writer;
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * A Gradle runner that delegates to another runner, optionally enabling the configuring cache parameter.
+ */
+public class ConfigurationCacheCompatibleAwareGradleRunner extends GradleRunner {
+    private GradleRunner delegate;
+    private boolean ccCompatible;
+
+    public ConfigurationCacheCompatibleAwareGradleRunner(GradleRunner delegate, boolean ccCompatible) {
+        this.delegate = delegate;
+        this.ccCompatible = ccCompatible;
+    }
+
+    @Override
+    public GradleRunner withGradleVersion(String gradleVersion) {
+        delegate.withGradleVersion(gradleVersion);
+        return this;
+    }
+
+    @Override
+    public GradleRunner withGradleInstallation(File file) {
+        delegate.withGradleInstallation(file);
+        return this;
+    }
+
+    @Override
+    public GradleRunner withGradleDistribution(URI uri) {
+        delegate.withGradleDistribution(uri);
+        return this;
+    }
+
+    @Override
+    public GradleRunner withTestKitDir(File file) {
+        delegate.withTestKitDir(file);
+        return this;
+    }
+
+    @Override
+    public File getProjectDir() {
+        return delegate.getProjectDir();
+    }
+
+    @Override
+    public GradleRunner withProjectDir(File projectDir) {
+        delegate.withProjectDir(projectDir);
+        return this;
+    }
+
+    @Override
+    public List<String> getArguments() {
+        return delegate.getArguments();
+    }
+
+    @Override
+    public GradleRunner withArguments(List<String> arguments) {
+        List<String> effectiveArgs = arguments;
+        if (ccCompatible) {
+            effectiveArgs = new ArrayList<>(arguments);
+            effectiveArgs.add("--configuration-cache");
+        }
+        delegate.withArguments(effectiveArgs);
+        return this;
+    }
+
+    @Override
+    public GradleRunner withArguments(String... arguments) {
+        withArguments(List.of(arguments));
+        return this;
+    }
+
+    @Override
+    public List<? extends File> getPluginClasspath() {
+        return delegate.getPluginClasspath();
+    }
+
+    @Override
+    public GradleRunner withPluginClasspath() throws InvalidPluginMetadataException {
+        delegate.withPluginClasspath();
+        return this;
+    }
+
+    @Override
+    public GradleRunner withPluginClasspath(Iterable<? extends File> iterable) {
+        delegate.withPluginClasspath(iterable);
+        return this;
+    }
+
+    @Override
+    public boolean isDebug() {
+        return delegate.isDebug();
+    }
+
+    @Override
+    public GradleRunner withDebug(boolean b) {
+        delegate.withDebug(b);
+        return this;
+    }
+
+    @Override
+    public Map<String, String> getEnvironment() {
+        return delegate.getEnvironment();
+    }
+
+    @Override
+    public GradleRunner withEnvironment(Map<String, String> map) {
+        delegate.withEnvironment(map);
+        return this;
+    }
+
+    @Override
+    public GradleRunner forwardStdOutput(Writer writer) {
+        delegate.forwardStdOutput(writer);
+        return this;
+    }
+
+    @Override
+    public GradleRunner forwardStdError(Writer writer) {
+        delegate.forwardStdOutput(writer);
+        return this;
+    }
+
+    @Override
+    public GradleRunner forwardOutput() {
+        delegate.forwardOutput();
+        return this;
+    }
+
+    @Override
+    public BuildResult build() throws InvalidRunnerConfigurationException, UnexpectedBuildFailure {
+        return delegate.build();
+    }
+
+    @Override
+    public BuildResult buildAndFail() throws InvalidRunnerConfigurationException, UnexpectedBuildSuccess {
+        return delegate.buildAndFail();
+    }
+}


### PR DESCRIPTION
Backports the following commits to 8.3:
 - Add easier configuration cache test support in build logic tests (#88047)