### PR TITLE
Explicate network.tcp.keep_alive is in boolean

### DIFF
--- a/docs/reference/modules/network.asciidoc
+++ b/docs/reference/modules/network.asciidoc
@@ -206,7 +206,7 @@ setting. Defaults to `true`.
 
 `network.tcp.keep_alive`::
 (<<static-cluster-setting,Static>>)
-Configures the `SO_KEEPALIVE` option for this socket, which
+Configures the boolean `SO_KEEPALIVE` option for this socket, which
 determines whether it sends TCP keepalive probes.
 
 `network.tcp.keep_idle`::


### PR DESCRIPTION
👶🏼 PR but can we explicate that this setting is a boolean? 🙏🏼  

If possible, can we also note if it's default value? (I'm not sure what that is but assuming `true`.)