### PR TITLE
[7.17] Run gradle integration tests with configuration cache enabled by default (#88148)

### DIFF
--- a/build-tools-internal/src/integTest/groovy/org/elasticsearch/gradle/ReaperPluginFuncTest.groovy
+++ b/build-tools-internal/src/integTest/groovy/org/elasticsearch/gradle/ReaperPluginFuncTest.groovy
@@ -23,9 +23,10 @@ class ReaperPluginFuncTest extends AbstractGradleFuncTest {
             import org.elasticsearch.gradle.ReaperPlugin;
             import org.elasticsearch.gradle.util.GradleUtils;
             
+            def serviceProvider = GradleUtils.getBuildService(project.getGradle().getSharedServices(), ReaperPlugin.REAPER_SERVICE_NAME);
+                
             tasks.register("launchReaper") {
               doLast {
-                def serviceProvider = GradleUtils.getBuildService(project.getGradle().getSharedServices(), ReaperPlugin.REAPER_SERVICE_NAME);
                 def reaper = serviceProvider.get()
                 reaper.registerCommand('test', 'true')
                 reaper.unregister('test')

--- a/build-tools-internal/src/integTest/groovy/org/elasticsearch/gradle/fixtures/LocalRepositoryFixture.groovy
+++ b/build-tools-internal/src/integTest/groovy/org/elasticsearch/gradle/fixtures/LocalRepositoryFixture.groovy
@@ -17,8 +17,20 @@ class LocalRepositoryFixture extends ExternalResource{
 
     private TemporaryFolder temporaryFolder
 
-    LocalRepositoryFixture(TemporaryFolder temporaryFolder){
-        this.temporaryFolder = temporaryFolder
+    LocalRepositoryFixture(){
+        this.temporaryFolder = new TemporaryFolder()
+    }
+
+    @Override
+    protected void before() throws Throwable {
+        super.before()
+        temporaryFolder.before()
+    }
+
+    @Override
+    protected void after() {
+        super.after()
+        temporaryFolder.after()
     }
 
     void generateJar(String group, String module, String version, String... clazzNames){

--- a/build-tools-internal/src/integTest/groovy/org/elasticsearch/gradle/internal/ElasticsearchJavaPluginFuncTest.groovy
+++ b/build-tools-internal/src/integTest/groovy/org/elasticsearch/gradle/internal/ElasticsearchJavaPluginFuncTest.groovy
@@ -8,24 +8,22 @@
 
 package org.elasticsearch.gradle.internal
 
-import org.elasticsearch.gradle.fixtures.AbstractGradleFuncTest
+import org.elasticsearch.gradle.fixtures.AbstractGradleInternalPluginFuncTest
+import org.gradle.api.Plugin
 
-class ElasticsearchJavaPluginFuncTest extends AbstractGradleFuncTest {
+class ElasticsearchJavaPluginFuncTest extends AbstractGradleInternalPluginFuncTest {
+
+    Class<? extends Plugin> pluginClassUnderTest = ElasticsearchJavaPlugin.class
 
     def "compatibility options are resolved from from build params minimum runtime version"() {
         when:
-        buildFile.text = """
-        plugins {
-          id 'elasticsearch.global-build-info'
-        }
+        buildFile.text << """
         import org.elasticsearch.gradle.Architecture
         import org.elasticsearch.gradle.internal.info.BuildParams
         BuildParams.init { it.setMinimumRuntimeVersion(JavaVersion.VERSION_1_10) }
 
-        apply plugin:'elasticsearch.java'
-
-        assert compileJava.sourceCompatibility == JavaVersion.VERSION_1_10.toString()
-        assert compileJava.targetCompatibility == JavaVersion.VERSION_1_10.toString()
+        assert tasks.named('compileJava').get().sourceCompatibility == JavaVersion.VERSION_1_10.toString()
+        assert tasks.named('compileJava').get().targetCompatibility == JavaVersion.VERSION_1_10.toString()
         """
 
         then:
@@ -34,14 +32,10 @@ class ElasticsearchJavaPluginFuncTest extends AbstractGradleFuncTest {
 
     def "compile option --release is configured from targetCompatibility"() {
         when:
-        buildFile.text = """
-            plugins {
-             id 'elasticsearch.java'
-            }
-
-            compileJava.targetCompatibility = "1.10"
+        buildFile.text << """
+            tasks.named('compileJava').get().targetCompatibility = "1.10"
             afterEvaluate {
-                assert compileJava.options.release.get() == 10
+                assert tasks.named('compileJava').get().options.release.get() == 10
             }
         """
         then:

--- a/build-tools-internal/src/integTest/groovy/org/elasticsearch/gradle/internal/InternalBwcGitPluginFuncTest.groovy
+++ b/build-tools-internal/src/integTest/groovy/org/elasticsearch/gradle/internal/InternalBwcGitPluginFuncTest.groovy
@@ -14,6 +14,8 @@ import org.gradle.testkit.runner.TaskOutcome
 class InternalBwcGitPluginFuncTest extends AbstractGitAwareGradleFuncTest {
 
     def setup() {
+        // using LoggedExec is not cc compatible
+        configurationCacheCompatible = false
         internalBuild()
         buildFile << """
             import org.elasticsearch.gradle.Version;

--- a/build-tools-internal/src/integTest/groovy/org/elasticsearch/gradle/internal/InternalDistributionBwcSetupPluginFuncTest.groovy
+++ b/build-tools-internal/src/integTest/groovy/org/elasticsearch/gradle/internal/InternalDistributionBwcSetupPluginFuncTest.groovy
@@ -22,6 +22,8 @@ import spock.lang.Unroll
 class InternalDistributionBwcSetupPluginFuncTest extends AbstractGitAwareGradleFuncTest {
 
     def setup() {
+        // used LoggedExec task is not configuration cache compatible and
+        configurationCacheCompatible = false
         internalBuild()
         buildFile << """
             apply plugin: 'elasticsearch.internal-distribution-bwc-setup'

--- a/build-tools-internal/src/integTest/groovy/org/elasticsearch/gradle/internal/JdkDownloadPluginFuncTest.groovy
+++ b/build-tools-internal/src/integTest/groovy/org/elasticsearch/gradle/internal/JdkDownloadPluginFuncTest.groovy
@@ -147,6 +147,7 @@ class JdkDownloadPluginFuncTest extends AbstractGradleFuncTest {
             plugins {
              id 'elasticsearch.jdk-download'
             }
+            import org.elasticsearch.gradle.internal.Jdk
             apply plugin: 'base'
             apply plugin: 'elasticsearch.jdk-download'
 
@@ -158,11 +159,18 @@ class JdkDownloadPluginFuncTest extends AbstractGradleFuncTest {
                 architecture = "x64"
               }
             }
-
-            tasks.register("getJdk") {
+            
+            tasks.register("getJdk", PrintJdk) {
                 dependsOn jdks.myJdk
-                doLast {
-                    println "JDK HOME: " + jdks.myJdk
+                jdkPath = jdks.myJdk.getPath()
+            }
+
+            class PrintJdk extends DefaultTask {
+                @Input
+                String jdkPath
+                
+                @TaskAction void print() {
+                    println "JDK HOME: " + jdkPath
                 }
             }
         """

--- a/build-tools-internal/src/integTest/groovy/org/elasticsearch/gradle/internal/JdkDownloadPluginFuncTest.groovy
+++ b/build-tools-internal/src/integTest/groovy/org/elasticsearch/gradle/internal/JdkDownloadPluginFuncTest.groovy
@@ -147,7 +147,7 @@ class JdkDownloadPluginFuncTest extends AbstractGradleFuncTest {
             plugins {
              id 'elasticsearch.jdk-download'
             }
-            import org.elasticsearch.gradle.internal.Jdk
+            import org.elasticsearch.gradle.Jdk
             apply plugin: 'base'
             apply plugin: 'elasticsearch.jdk-download'
 

--- a/build-tools-internal/src/integTest/groovy/org/elasticsearch/gradle/internal/PublishPluginFuncTest.groovy
+++ b/build-tools-internal/src/integTest/groovy/org/elasticsearch/gradle/internal/PublishPluginFuncTest.groovy
@@ -250,6 +250,8 @@ class PublishPluginFuncTest extends AbstractGradleFuncTest {
 
     def "generates artifacts for shadowed elasticsearch plugin"() {
         given:
+        // we use the esplugin plugin in this test that is not configuration cache compatible yet
+        configurationCacheCompatible = false
         file('license.txt') << "License file"
         file('notice.txt') << "Notice file"
         buildFile << """
@@ -334,6 +336,8 @@ class PublishPluginFuncTest extends AbstractGradleFuncTest {
 
     def "generates pom for elasticsearch plugin"() {
         given:
+        // we use the esplugin plugin in this test that is not configuration cache compatible yet
+        configurationCacheCompatible = false
         file('license.txt') << "License file"
         file('notice.txt') << "Notice file"
         buildFile << """

--- a/build-tools-internal/src/integTest/groovy/org/elasticsearch/gradle/internal/precommit/TestingConventionsPrecommitPluginFuncTest.groovy
+++ b/build-tools-internal/src/integTest/groovy/org/elasticsearch/gradle/internal/precommit/TestingConventionsPrecommitPluginFuncTest.groovy
@@ -21,13 +21,9 @@ class TestingConventionsPrecommitPluginFuncTest extends AbstractGradlePrecommitP
 
     Class<? extends PrecommitPlugin> pluginClassUnderTest = TestingConventionsPrecommitPlugin.class
 
-    @ClassRule
-    @Shared
-    public TemporaryFolder repoFolder = new TemporaryFolder()
-
     @Shared
     @ClassRule
-    public LocalRepositoryFixture repository = new LocalRepositoryFixture(repoFolder)
+    public LocalRepositoryFixture repository = new LocalRepositoryFixture()
 
     def setupSpec() {
         repository.generateJar('org.apache.lucene', 'tests.util', "1.0",

--- a/build-tools-internal/src/integTest/groovy/org/elasticsearch/gradle/internal/test/rest/InternalYamlRestTestPluginFuncTest.groovy
+++ b/build-tools-internal/src/integTest/groovy/org/elasticsearch/gradle/internal/test/rest/InternalYamlRestTestPluginFuncTest.groovy
@@ -15,6 +15,8 @@ class InternalYamlRestTestPluginFuncTest extends AbstractRestResourcesFuncTest {
 
     def "yamlRestTest does nothing when there are no tests"() {
         given:
+        // RestIntegTestTask not cc compatible due to
+        configurationCacheCompatible = false
         buildFile << """
         plugins {
           id 'elasticsearch.internal-yaml-rest-test'
@@ -32,6 +34,8 @@ class InternalYamlRestTestPluginFuncTest extends AbstractRestResourcesFuncTest {
 
     def "yamlRestTest executes and copies api and tests to correct source set"() {
         given:
+        // RestIntegTestTask not cc compatible due to
+        configurationCacheCompatible = false
         internalBuild()
         buildFile << """
             apply plugin: 'elasticsearch.internal-yaml-rest-test'

--- a/build-tools-internal/src/integTest/groovy/org/elasticsearch/gradle/internal/test/rest/RestResourcesPluginFuncTest.groovy
+++ b/build-tools-internal/src/integTest/groovy/org/elasticsearch/gradle/internal/test/rest/RestResourcesPluginFuncTest.groovy
@@ -170,7 +170,7 @@ class RestResourcesPluginFuncTest extends AbstractRestResourcesFuncTest {
         file("/build/restResources/yamlTests/rest-api-spec/test/" + coreTest).getText("UTF-8") == "replacedWithValue"
 
         when:
-        result = gradleRunner("copyRestApiSpecsTask").build()
+        result = gradleRunner("copyRestApiSpecsTask", '--stacktrace').build()
 
         then:
         result.task(':copyRestApiSpecsTask').outcome == TaskOutcome.UP_TO_DATE

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/ElasticsearchJavadocPlugin.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/ElasticsearchJavadocPlugin.java
@@ -32,11 +32,9 @@ import java.util.List;
 // other packages (e.g org.elasticsearch.client) will point to server rather than
 // their own artifacts.
 public class ElasticsearchJavadocPlugin implements Plugin<Project> {
-    private Project project;
 
     @Override
     public void apply(Project project) {
-        this.project = project;
         // ignore missing javadocs
         project.getTasks().withType(Javadoc.class).configureEach(javadoc -> {
             // the -quiet here is because of a bug in gradle, in that adding a string option
@@ -49,7 +47,7 @@ public class ElasticsearchJavadocPlugin implements Plugin<Project> {
         });
 
         // Relying on configurations introduced by the java plugin
-        this.project.getPlugins().withType(JavaPlugin.class, javaPlugin -> project.afterEvaluate(project1 -> {
+        project.getPlugins().withType(JavaPlugin.class, javaPlugin -> project.afterEvaluate(project1 -> {
             var withShadowPlugin = project1.getPlugins().hasPlugin(ShadowPlugin.class);
             var compileClasspath = project.getConfigurations().getByName("compileClasspath");
 
@@ -59,25 +57,25 @@ public class ElasticsearchJavadocPlugin implements Plugin<Project> {
                 var nonShadowedCompileClasspath = compileClasspath.copyRecursive(
                     dependency -> shadowedDependencies.contains(dependency) == false
                 );
-                configureJavadocForConfiguration(false, nonShadowedCompileClasspath);
-                configureJavadocForConfiguration(true, shadowConfiguration);
+                configureJavadocForConfiguration(project, false, nonShadowedCompileClasspath);
+                configureJavadocForConfiguration(project, true, shadowConfiguration);
             } else {
-                configureJavadocForConfiguration(false, compileClasspath);
+                configureJavadocForConfiguration(project, false, compileClasspath);
             }
         }));
     }
 
-    private void configureJavadocForConfiguration(boolean shadow, Configuration configuration) {
+    private void configureJavadocForConfiguration(Project project, boolean shadow, Configuration configuration) {
         configuration.getAllDependencies()
             .stream()
             .sorted(Comparator.comparing(Dependency::getGroup))
             .filter(d -> d instanceof ProjectDependency)
             .map(d -> (ProjectDependency) d)
             .filter(p -> p.getDependencyProject() != null)
-            .forEach(projectDependency -> configureDependency(shadow, projectDependency));
+            .forEach(projectDependency -> configureDependency(project, shadow, projectDependency));
     }
 
-    private void configureDependency(boolean shadowed, ProjectDependency dep) {
+    private void configureDependency(Project project, boolean shadowed, ProjectDependency dep) {
         var upstreamProject = dep.getDependencyProject();
         if (shadowed) {
             /*

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/precommit/CheckstylePrecommitPlugin.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/precommit/CheckstylePrecommitPlugin.java
@@ -85,9 +85,11 @@ public class CheckstylePrecommitPlugin extends PrecommitPlugin {
 
         DependencyHandler dependencies = project.getDependencies();
         String checkstyleVersion = VersionProperties.getVersions().get("checkstyle");
-        Provider<String> dependencyProvider = project.provider(() -> "org.elasticsearch:build-conventions:" + project.getVersion());
+        Provider<String> conventionsDependencyProvider = project.provider(
+            () -> "org.elasticsearch:build-conventions:" + project.getVersion()
+        );
         dependencies.add("checkstyle", "com.puppycrawl.tools:checkstyle:" + checkstyleVersion);
-        dependencies.addProvider("checkstyle", dependencyProvider, dep -> dep.setTransitive(false));
+        dependencies.addProvider("checkstyle", conventionsDependencyProvider, dep -> dep.setTransitive(false));
 
         project.getTasks().withType(Checkstyle.class).configureEach(t -> {
             t.dependsOn(copyCheckstyleConf);

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/precommit/ThirdPartyAuditPrecommitPlugin.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/precommit/ThirdPartyAuditPrecommitPlugin.java
@@ -50,7 +50,7 @@ public class ThirdPartyAuditPrecommitPlugin extends PrecommitPlugin {
             Configuration compileOnly = project.getConfigurations()
                 .getByName(CompileOnlyResolvePlugin.RESOLVEABLE_COMPILE_ONLY_CONFIGURATION_NAME);
             t.setClasspath(runtimeConfiguration.plus(compileOnly));
-            t.setJarsToScan(runtimeConfiguration.fileCollection(dep -> {
+            t.getJarsToScan().from(runtimeConfiguration.fileCollection(dep -> {
                 // These are SelfResolvingDependency, and some of them backed by file collections, like the Gradle API files,
                 // or dependencies added as `files(...)`, we can't be sure if those are third party or not.
                 // err on the side of scanning these to make sure we don't miss anything
@@ -60,8 +60,8 @@ public class ThirdPartyAuditPrecommitPlugin extends PrecommitPlugin {
             t.setJavaHome(BuildParams.getRuntimeJavaHome().toString());
             t.getTargetCompatibility().set(project.provider(BuildParams::getRuntimeJavaVersion));
             t.setSignatureFile(resourcesDir.resolve("forbidden/third-party-audit.txt").toFile());
-            t.setJdkJarHellClasspath(jdkJarHellConfig);
-            t.setForbiddenAPIsClasspath(project.getConfigurations().getByName("forbiddenApisCliJar").plus(compileOnly));
+            t.getJdkJarHellClasspath().from(jdkJarHellConfig);
+            t.getForbiddenAPIsClasspath().from(project.getConfigurations().getByName("forbiddenApisCliJar").plus(compileOnly));
         });
         return audit;
     }

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/test/rest/CopyRestApiTask.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/test/rest/CopyRestApiTask.java
@@ -7,6 +7,7 @@
  */
 package org.elasticsearch.gradle.internal.test.rest;
 
+import org.elasticsearch.gradle.internal.util.SerializableFunction;
 import org.gradle.api.DefaultTask;
 import org.gradle.api.file.DirectoryProperty;
 import org.gradle.api.file.FileCollection;
@@ -29,7 +30,6 @@ import org.gradle.internal.Factory;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
-import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import javax.inject.Inject;
@@ -54,8 +54,8 @@ public class CopyRestApiTask extends DefaultTask {
     private boolean skipHasRestTestCheck;
     private FileCollection config;
     private FileCollection additionalConfig;
-    private Function<FileCollection, FileTree> configToFileTree = FileCollection::getAsFileTree;
-    private Function<FileCollection, FileTree> additionalConfigToFileTree = FileCollection::getAsFileTree;
+    private SerializableFunction<FileCollection, FileTree> configToFileTree = FileCollection::getAsFileTree;
+    private SerializableFunction<FileCollection, FileTree> additionalConfigToFileTree = FileCollection::getAsFileTree;
 
     private final PatternFilterable patternSet;
     private final ProjectLayout projectLayout;
@@ -176,11 +176,11 @@ public class CopyRestApiTask extends DefaultTask {
         this.additionalConfig = additionalConfig;
     }
 
-    public void setConfigToFileTree(Function<FileCollection, FileTree> configToFileTree) {
+    public void setConfigToFileTree(SerializableFunction<FileCollection, FileTree> configToFileTree) {
         this.configToFileTree = configToFileTree;
     }
 
-    public void setAdditionalConfigToFileTree(Function<FileCollection, FileTree> additionalConfigToFileTree) {
+    public void setAdditionalConfigToFileTree(SerializableFunction<FileCollection, FileTree> additionalConfigToFileTree) {
         this.additionalConfigToFileTree = additionalConfigToFileTree;
     }
 

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/test/rest/CopyRestTestsTask.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/test/rest/CopyRestTestsTask.java
@@ -8,6 +8,7 @@
 package org.elasticsearch.gradle.internal.test.rest;
 
 import org.apache.tools.ant.filters.ReplaceTokens;
+import org.elasticsearch.gradle.internal.util.SerializableFunction;
 import org.gradle.api.DefaultTask;
 import org.gradle.api.file.DirectoryProperty;
 import org.gradle.api.file.FileCollection;
@@ -29,7 +30,6 @@ import org.gradle.internal.Factory;
 
 import java.io.File;
 import java.util.Map;
-import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import javax.inject.Inject;
@@ -53,9 +53,9 @@ public class CopyRestTestsTask extends DefaultTask {
     private FileCollection coreConfig;
     private FileCollection xpackConfig;
     private FileCollection additionalConfig;
-    private Function<FileCollection, FileTree> coreConfigToFileTree = FileCollection::getAsFileTree;
-    private Function<FileCollection, FileTree> xpackConfigToFileTree = FileCollection::getAsFileTree;
-    private Function<FileCollection, FileTree> additionalConfigToFileTree = FileCollection::getAsFileTree;
+    private SerializableFunction<FileCollection, FileTree> coreConfigToFileTree = FileCollection::getAsFileTree;
+    private SerializableFunction<FileCollection, FileTree> xpackConfigToFileTree = FileCollection::getAsFileTree;
+    private SerializableFunction<FileCollection, FileTree> additionalConfigToFileTree = FileCollection::getAsFileTree;
 
     private final PatternFilterable corePatternSet;
     private final PatternFilterable xpackPatternSet;
@@ -183,15 +183,15 @@ public class CopyRestTestsTask extends DefaultTask {
         this.additionalConfig = additionalConfig;
     }
 
-    public void setCoreConfigToFileTree(Function<FileCollection, FileTree> coreConfigToFileTree) {
+    public void setCoreConfigToFileTree(SerializableFunction<FileCollection, FileTree> coreConfigToFileTree) {
         this.coreConfigToFileTree = coreConfigToFileTree;
     }
 
-    public void setXpackConfigToFileTree(Function<FileCollection, FileTree> xpackConfigToFileTree) {
+    public void setXpackConfigToFileTree(SerializableFunction<FileCollection, FileTree> xpackConfigToFileTree) {
         this.xpackConfigToFileTree = xpackConfigToFileTree;
     }
 
-    public void setAdditionalConfigToFileTree(Function<FileCollection, FileTree> additionalConfigToFileTree) {
+    public void setAdditionalConfigToFileTree(SerializableFunction<FileCollection, FileTree> additionalConfigToFileTree) {
         this.additionalConfigToFileTree = additionalConfigToFileTree;
     }
 

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/util/SerializableFunction.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/util/SerializableFunction.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.gradle.internal.util;
+
+import java.io.Serializable;
+import java.util.function.Function;
+
+/**
+ * A functional interface that extends Function but also Serializable.
+ *
+ * Gradle configuration cache requires fields that represent a lambda to be serializable.
+ * */
+@FunctionalInterface
+public interface SerializableFunction<T, R> extends Function<T, R>, Serializable {}

--- a/build-tools/src/integTest/groovy/org/elasticsearch/gradle/TestClustersPluginFuncTest.groovy
+++ b/build-tools/src/integTest/groovy/org/elasticsearch/gradle/TestClustersPluginFuncTest.groovy
@@ -25,6 +25,8 @@ import static org.elasticsearch.gradle.fixtures.DistributionDownloadFixture.with
 class TestClustersPluginFuncTest extends AbstractGradleFuncTest {
 
     def setup() {
+        // TestClusterPlugin with adding task listeners is not cc compatible
+        configurationCacheCompatible = false
         buildFile << """
             import org.elasticsearch.gradle.testclusters.TestClustersAware
             import org.elasticsearch.gradle.testclusters.ElasticsearchCluster

--- a/build-tools/src/integTest/groovy/org/elasticsearch/gradle/test/JavaRestTestPluginFuncTest.groovy
+++ b/build-tools/src/integTest/groovy/org/elasticsearch/gradle/test/JavaRestTestPluginFuncTest.groovy
@@ -14,6 +14,11 @@ import org.gradle.testkit.runner.TaskOutcome
 
 class JavaRestTestPluginFuncTest extends AbstractGradleFuncTest {
 
+    def setup() {
+        // underlaying TestClusterPlugin and StandaloneRestIntegTestTask are not cc compatible
+        configurationCacheCompatible = false
+    }
+
     def "declares default dependencies"() {
         given:
         buildFile << """

--- a/build-tools/src/integTest/groovy/org/elasticsearch/gradle/test/YamlRestTestPluginFuncTest.groovy
+++ b/build-tools/src/integTest/groovy/org/elasticsearch/gradle/test/YamlRestTestPluginFuncTest.groovy
@@ -14,6 +14,11 @@ import org.gradle.testkit.runner.TaskOutcome
 
 class YamlRestTestPluginFuncTest extends AbstractGradleFuncTest {
 
+    def setup() {
+        // underlaying TestClusterPlugin and StandaloneRestIntegTestTask are not cc compatible
+        configurationCacheCompatible = false
+    }
+
     def "declares default dependencies"() {
         given:
         buildFile << """


### PR DESCRIPTION
Backports the following commits to 7.17:
 - Run gradle integration tests with configuration cache enabled by default (#88148)