### PR TITLE
Fix docker positional params (take 2)

### DIFF
--- a/distribution/docker/src/docker/bin/docker-entrypoint.sh
+++ b/distribution/docker/src/docker/bin/docker-entrypoint.sh
@@ -81,4 +81,4 @@ fi
 
 # Signal forwarding and child reaping is handled by `tini`, which is the
 # actual entrypoint of the container
-exec /usr/share/elasticsearch/bin/elasticsearch $POSITIONAL_PARAMETERS <<<"$KEYSTORE_PASSWORD"
+exec /usr/share/elasticsearch/bin/elasticsearch "$@" $POSITIONAL_PARAMETERS <<<"$KEYSTORE_PASSWORD"

--- a/docs/changelog/88502.yaml
+++ b/docs/changelog/88502.yaml
@@ -1,0 +1,5 @@
+pr: 88502
+summary: Fix passing positional args to ES in Docker
+area: Packaging
+type: bug
+issues: []

--- a/docs/changelog/88502.yaml
+++ b/docs/changelog/88502.yaml
@@ -1,5 +1,0 @@
-pr: 88502
-summary: Fix passing positional args to ES in Docker
-area: Packaging
-type: bug
-issues: []

--- a/docs/changelog/88584.yaml
+++ b/docs/changelog/88584.yaml
@@ -1,0 +1,5 @@
+pr: 88584
+summary: Fix docker positional params (take 2)
+area: Packaging
+type: bug
+issues: []

--- a/docs/changelog/88584.yaml
+++ b/docs/changelog/88584.yaml
@@ -1,5 +1,5 @@
 pr: 88584
-summary: Fix docker positional params (take 2)
+summary: Fix docker positional params
 area: Packaging
 type: bug
 issues: []

--- a/qa/os/src/test/java/org/elasticsearch/packaging/test/DockerTests.java
+++ b/qa/os/src/test/java/org/elasticsearch/packaging/test/DockerTests.java
@@ -1100,6 +1100,11 @@ public class DockerTests extends PackagingTestCase {
      * Ensure that it is possible to apply CLI options when running the image.
      */
     public void test171AdditionalCliOptionsAreForwarded() throws Exception {
+        assumeTrue(
+            "Does not apply to Cloud images, because they don't use the default entrypoint",
+            distribution.packaging != Packaging.DOCKER_CLOUD && distribution().packaging != Packaging.DOCKER_CLOUD_ESS
+        );
+
         runContainer(distribution(), builder().runArgs("bin/elasticsearch", "-Ecluster.name=kimchy").envVar("ELASTIC_PASSWORD", PASSWORD));
         waitForElasticsearch(installation, "elastic", PASSWORD);
 

--- a/qa/os/src/test/java/org/elasticsearch/packaging/test/DockerTests.java
+++ b/qa/os/src/test/java/org/elasticsearch/packaging/test/DockerTests.java
@@ -1097,6 +1097,18 @@ public class DockerTests extends PackagingTestCase {
     }
 
     /**
+     * Ensure that it is possible to apply CLI options when running the image.
+     */
+    public void test171AdditionalCliOptionsAreForwarded() throws Exception {
+        runContainer(distribution(), builder().runArgs("bin/elasticsearch", "-Ecluster.name=kimchy").envVar("ELASTIC_PASSWORD", PASSWORD));
+        waitForElasticsearch(installation, "elastic", PASSWORD);
+
+        final JsonNode node = getJson("/", "elastic", PASSWORD, ServerUtils.getCaCert(installation));
+
+        assertThat(node.get("cluster_name").textValue(), equalTo("kimchy"));
+    }
+
+    /**
      * Check that the UBI images has the correct license information in the correct place.
      */
     public void test200UbiImagesHaveLicenseDirectory() {
@@ -1193,7 +1205,7 @@ public class DockerTests extends PackagingTestCase {
     /**
      * Check that readiness listener works
      */
-    public void testReadiness001() throws Exception {
+    public void test500Readiness() throws Exception {
         assertFalse(readinessProbe(9399));
         // Disabling security so we wait for green
         installation = runContainer(

--- a/qa/os/src/test/java/org/elasticsearch/packaging/util/docker/DockerRun.java
+++ b/qa/os/src/test/java/org/elasticsearch/packaging/util/docker/DockerRun.java
@@ -34,6 +34,7 @@ public class DockerRun {
     private Integer uid;
     private Integer gid;
     private final List<String> extraArgs = new ArrayList<>();
+    private final List<String> runArgs = new ArrayList<>();
     private String memory = "2g"; // default to 2g memory limit
 
     private DockerRun() {}
@@ -95,6 +96,11 @@ public class DockerRun {
         return this;
     }
 
+    public DockerRun runArgs(String... args) {
+        Collections.addAll(this.runArgs, args);
+        return this;
+    }
+
     String build() {
         final List<String> cmd = new ArrayList<>();
 
@@ -143,6 +149,8 @@ public class DockerRun {
 
         // Image name
         cmd.add(getImageName(distribution));
+
+        cmd.addAll(this.runArgs);
 
         return String.join(" ", cmd);
     }


### PR DESCRIPTION
Follow-up to (and re-apply of) #88502, which we had to revert.

The change itself was good, but it turned out that the test we added only applies to non-Cloud images. This is because for the Cloud images, the `ENTRYPOINT` and `CMD` are different, such that defining the `ELASTIC_PASSWORD` doesn't set the `elastic` user's password. Since Cloud currently assumes control of image startup, there's little point working around this in the test since we have no control over what's happening at runtime in production.

@mark-vieira note that we didn't catch this during PRs, because we only run the `destructiveDistroTest.docker` task in CI, which only tests the default image. We only test all the Docker images on merged changes. What do you think about reworking this, so that we get better coverage when we're explicitly testing packaging changes?