### PR TITLE
Disable URL connection caching in SPIClassIterator

### DIFF
--- a/docs/changelog/88586.yaml
+++ b/docs/changelog/88586.yaml
@@ -1,0 +1,6 @@
+pr: 88586
+summary: Disable URL connection caching in SPIClassIterator
+area: Infra/Plugins
+type: bug
+issues:
+ - 88275

--- a/server/src/main/java/org/elasticsearch/plugins/spi/SPIClassIterator.java
+++ b/server/src/main/java/org/elasticsearch/plugins/spi/SPIClassIterator.java
@@ -26,6 +26,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.net.URL;
+import java.net.URLConnection;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -106,7 +107,9 @@ public final class SPIClassIterator<S> implements Iterator<Class<? extends S>> {
             }
             final URL url = profilesEnum.nextElement();
             try {
-                final InputStream in = url.openStream();
+                URLConnection urlc = url.openConnection();
+                urlc.setUseCaches(false); // prevents retaining a handle to the underlying jar file, when the stream is closed
+                final InputStream in = urlc.getInputStream();
                 boolean success = false;
                 try {
                     final BufferedReader reader = new BufferedReader(new InputStreamReader(in, StandardCharsets.UTF_8));


### PR DESCRIPTION
This change disables URLConnection caching in SPIClassIterator - similar to what j.u.[ServiceLoader](https://github.com/openjdk/jdk/blob/master/src/java.base/share/classes/java/util/ServiceLoader.java#L1171) does.

Resources accessed in jar file, through the URLConnection API, cache by default. In terms of JarURLConnections, this means retaining an open handle to the underlying jar file. This open handle is problematic when attempting to delete the jar file, on Windows.  Disabling the jar file cache, for the URLConnections in SPIClassLoader should not negatively affect performance in any substantial way - since there are just a few service configuration files per jar.

The "workaround" here, disabling the cache per JAR URLConnection, is very common, and a consequence of the longstanding behaviour of the JarURLConnection API, as well as the URLClassLoader API.

closes  #88275