### PR TITLE
Add variable shadowing to Painless

### DIFF
--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/phase/DefaultSemanticAnalysisPhase.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/phase/DefaultSemanticAnalysisPhase.java
@@ -2685,7 +2685,7 @@ public class DefaultSemanticAnalysisPhase extends UserTreeBaseVisitor<SemanticSc
             }
 
             semanticScope.putDecoration(userSymbolNode, new StaticType(staticType));
-        } else if (semanticScope.isVariableDefined(symbol)) {
+        } else if (semanticScope.isVariableDefined(symbol, false)) {
             if (read == false && write == false) {
                 throw userSymbolNode.createError(new IllegalArgumentException("not a statement: variable [" + symbol + "] not used"));
             }

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/symbol/SemanticScope.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/symbol/SemanticScope.java
@@ -70,7 +70,7 @@ public abstract class SemanticScope {
         }
 
         @Override
-        public boolean isVariableDefined(String name) {
+        public boolean isVariableDefined(String name, boolean local) {
             return variables.containsKey(name);
         }
 
@@ -129,12 +129,12 @@ public abstract class SemanticScope {
         }
 
         @Override
-        public boolean isVariableDefined(String name) {
+        public boolean isVariableDefined(String name, boolean local) {
             if (variables.containsKey(name)) {
                 return true;
             }
 
-            return parent.isVariableDefined(name);
+            return local == false && parent.isVariableDefined(name, false);
         }
 
         /**
@@ -210,12 +210,12 @@ public abstract class SemanticScope {
         }
 
         @Override
-        public boolean isVariableDefined(String name) {
+        public boolean isVariableDefined(String name, boolean local) {
             if (variables.containsKey(name)) {
                 return true;
             }
 
-            return parent.isVariableDefined(name);
+            return local == false && parent.isVariableDefined(name, false);
         }
 
         /**
@@ -334,7 +334,7 @@ public abstract class SemanticScope {
     public abstract String getReturnCanonicalTypeName();
 
     public Variable defineVariable(Location location, Class<?> type, String name, boolean isReadOnly) {
-        if (isVariableDefined(name)) {
+        if (isVariableDefined(name, true)) {
             throw location.createError(new IllegalArgumentException("variable [" + name + "] is already defined"));
         }
 
@@ -344,7 +344,7 @@ public abstract class SemanticScope {
         return variable;
     }
 
-    public abstract boolean isVariableDefined(String name);
+    public abstract boolean isVariableDefined(String name, boolean local);
 
     public abstract Variable getVariable(Location location, String name);
 
@@ -360,8 +360,8 @@ public abstract class SemanticScope {
         return defineVariable(location, type, "#" + name, isReadOnly);
     }
 
-    public boolean isInternalVariableDefined(String name) {
-        return isVariableDefined("#" + name);
+    public boolean isInternalVariableDefined(String name, boolean local) {
+        return isVariableDefined("#" + name, local);
     }
 
     public Variable getInternalVariable(Location location, String name) {

--- a/modules/lang-painless/src/test/java/org/elasticsearch/painless/LambdaTests.java
+++ b/modules/lang-painless/src/test/java/org/elasticsearch/painless/LambdaTests.java
@@ -160,18 +160,14 @@ public class LambdaTests extends ScriptTestCase {
         assertTrue(expected.getMessage().contains("is read-only"));
     }
 
-    /** Lambda parameters shouldn't be able to mask a variable already in scope */
-    public void testNoParamMasking() {
-        IllegalArgumentException expected = expectScriptThrows(
-            IllegalArgumentException.class,
-            () -> {
-                exec(
-                    "int x = 0; List l = new ArrayList(); l.add(1); l.add(1); "
-                        + "return l.stream().mapToInt(x -> { x += 1; return x }).sum();"
-                );
-            }
+    public void testParamMasking() {
+        assertEquals(
+            4,
+            exec(
+                "Map x = [:]; List l = new ArrayList(); l.add(1); l.add(1); "
+                    + "return l.stream().mapToInt(x -> { int l = x; return l + 1 }).sum();"
+            )
         );
-        assertTrue(expected.getMessage().contains("already defined"));
     }
 
     public void testCaptureDef() {


### PR DESCRIPTION
This adds variable shadowing to Painless where a variable with the same name in a parent block may be re-declared as a different type and different value in a sub block.

WIP as this needs extensive testing added.