### PR TITLE
Better handling for missing bind_dn for AD impersonate

### DIFF
--- a/docs/changelog/88594.yaml
+++ b/docs/changelog/88594.yaml
@@ -1,0 +1,5 @@
+pr: 88594
+summary: Better handling for missing `bind_dn` for AD impersonate
+area: Authentication
+type: bug
+issues: []

--- a/docs/changelog/88594.yaml
+++ b/docs/changelog/88594.yaml
@@ -2,4 +2,5 @@ pr: 88594
 summary: Better handling for missing `bind_dn` for AD impersonate
 area: Authentication
 type: bug
-issues: []
+issues:
+ - 81137

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/ldap/ActiveDirectorySessionFactory.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/ldap/ActiveDirectorySessionFactory.java
@@ -26,6 +26,7 @@ import org.elasticsearch.common.logging.DeprecationCategory;
 import org.elasticsearch.common.logging.DeprecationLogger;
 import org.elasticsearch.common.settings.SecureString;
 import org.elasticsearch.common.settings.Setting;
+import org.elasticsearch.common.settings.SettingsException;
 import org.elasticsearch.common.util.concurrent.AbstractRunnable;
 import org.elasticsearch.core.CharArrays;
 import org.elasticsearch.core.IOUtils;
@@ -182,7 +183,7 @@ class ActiveDirectorySessionFactory extends PoolingSessionFactory {
     @Override
     void getUnauthenticatedSessionWithoutPool(String user, ActionListener<LdapSession> listener) {
         if (config.hasSetting(PoolingSessionFactorySettings.BIND_DN) == false) {
-            listener.onResponse(null);
+            listener.onFailure(new SettingsException("A bind_dn is required for the " + this.config.name() + " realm"));
             return;
         }
         try {

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/ldap/LdapRealm.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/ldap/LdapRealm.java
@@ -13,6 +13,7 @@ import org.elasticsearch.ElasticsearchTimeoutException;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.ContextPreservingActionListener;
 import org.elasticsearch.common.collect.MapBuilder;
+import org.elasticsearch.common.settings.SettingsException;
 import org.elasticsearch.common.util.concurrent.AbstractRunnable;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.core.IOUtils;
@@ -306,7 +307,13 @@ public final class LdapRealm extends CachingUsernamePasswordRealm {
             if (logger.isDebugEnabled()) {
                 logger.debug(() -> format("Exception occurred during %s for %s", action, LdapRealm.this), e);
             }
-            resultListener.onResponse(AuthenticationResult.unsuccessful(action + " failed", e));
+
+            // setting validation should generally be done earlier, however in some cases the settings may not be compatible at runtime.
+            if (e instanceof SettingsException) {
+                resultListener.onFailure(e);
+            } else {
+                resultListener.onResponse(AuthenticationResult.unsuccessful(action + " failed", e));
+            }
         }
 
     }


### PR DESCRIPTION
This commit allows the authentication to stop processing if a setting is not 
compatible with the given workflow for LDAP/AD realms. Specifically, the
authentication can now be stopped when a bind_dn user is not configured 
for the AD realm when doing impersonation. 

Normally, we would not want to halt authentication for the in-ability to authenticate (or lookup)
to a realm. However, this is a special case such that if it were possible we would block
startup due to a mis configuration we would. However, in this case the configuration is correct
except for when you are impersonating which is only known at runtime. Without this 
change the authentication is succesful, lookup fails, and the user see the result of the 
authz (is unauthorized to run as) which is not very helpful nor correct error message. 

With this change a more specific and actionable error is returned. This does 
however slightly change the contract such that authentication is halted early.
I believe this is fine if used sparingly. The usage in this commit would only impact
a scenario where a user had 2 or more AD realms and was trying to authenticate 
to one and impersonate (or delegate authz) from another and only had the bind_dn 
setup for one of the AD realms. I think this would be a very rare case and a more 
meaningful error message should be preferred. 

closes #81137