### PR TITLE
Ensure new privs in API key update test

### DIFF
--- a/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/xpack/security/authc/ApiKeyIntegTests.java
+++ b/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/xpack/security/authc/ApiKeyIntegTests.java
@@ -1550,15 +1550,12 @@ public class ApiKeyIntegTests extends SecurityIntegTestCase {
         final String apiKeyId = createdApiKey.getId();
         expectRoleDescriptorsForApiKey("limited_by_role_descriptors", Set.of(roleDescriptorBeforeUpdate), getApiKeyDocument(apiKeyId));
 
-        final List<String> newClusterPrivileges = randomValueOtherThanMany(
-            privs -> privs.equals(clusterPrivileges),
-            () -> {
-                final List<String> privs = new ArrayList<>(randomSubsetOf(ClusterPrivilegeResolver.names()));
-                // At a minimum include privilege to manage own API key to ensure no 403
-                privs.add(randomFrom("manage_api_key", "manage_own_api_key"));
-                return privs;
-            }
-        );
+        final List<String> newClusterPrivileges = randomValueOtherThan(clusterPrivileges, () -> {
+            final List<String> privs = new ArrayList<>(randomSubsetOf(ClusterPrivilegeResolver.names()));
+            // At a minimum include privilege to manage own API key to ensure no 403
+            privs.add(randomFrom("manage_api_key", "manage_own_api_key"));
+            return privs;
+        });
 
         // Update user role
         final RoleDescriptor roleDescriptorAfterUpdate = putRoleWithClusterPrivileges(

--- a/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/xpack/security/authc/ApiKeyIntegTests.java
+++ b/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/xpack/security/authc/ApiKeyIntegTests.java
@@ -99,7 +99,6 @@ import java.util.Base64;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -1560,7 +1559,7 @@ public class ApiKeyIntegTests extends SecurityIntegTestCase {
                 return privs;
             }
         );
-        
+
         // Update user role
         final RoleDescriptor roleDescriptorAfterUpdate = putRoleWithClusterPrivileges(
             nativeRealmRole,

--- a/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/xpack/security/authc/ApiKeyIntegTests.java
+++ b/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/xpack/security/authc/ApiKeyIntegTests.java
@@ -1552,13 +1552,15 @@ public class ApiKeyIntegTests extends SecurityIntegTestCase {
         expectRoleDescriptorsForApiKey("limited_by_role_descriptors", Set.of(roleDescriptorBeforeUpdate), getApiKeyDocument(apiKeyId));
 
         final List<String> newClusterPrivileges = randomValueOtherThanMany(
-            privs -> privs.equals(clusterPrivileges)
-                // At a minimum include privilege to manage own API key
-                // to ensure no 403
-                || (privs.contains("manage_api_key") == false && privs.contains("manage_own_api_key") == false),
-            () -> randomNonEmptySubsetOf(ClusterPrivilegeResolver.names())
+            privs -> privs.equals(clusterPrivileges),
+            () -> {
+                final List<String> privs = new ArrayList<>(randomSubsetOf(ClusterPrivilegeResolver.names()));
+                // At a minimum include privilege to manage own API key to ensure no 403
+                privs.add(randomFrom("manage_api_key", "manage_own_api_key"));
+                return privs;
+            }
         );
-
+        
         // Update user role
         final RoleDescriptor roleDescriptorAfterUpdate = putRoleWithClusterPrivileges(
             nativeRealmRole,


### PR DESCRIPTION
This PR ensures that we pick new cluster privileges when making a
non-noop API key update in tests for auto updating user fields.

Closes #88596.