### PR TITLE
Enable synthetic source support on constant keyword fields

### DIFF
--- a/docs/changelog/88603.yaml
+++ b/docs/changelog/88603.yaml
@@ -1,0 +1,5 @@
+pr: 88603
+summary: Enable synthetic source support on constant keyword fields
+area: Mapping
+type: enhancement
+issues: []

--- a/test/framework/src/main/java/org/elasticsearch/index/mapper/MapperTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/index/mapper/MapperTestCase.java
@@ -791,6 +791,10 @@ public abstract class MapperTestCase extends MapperServiceTestCase {
         assertThat(syntheticSource(mapper, b -> b.field("field", syntheticSourceExample.inputValue)), equalTo(expected));
     }
 
+    protected boolean supportsEmptyInputArray() {
+        return true;
+    }
+
     public final void testSyntheticSourceMany() throws IOException {
         int maxValues = randomBoolean() ? 1 : 5;
         SyntheticSourceSupport support = syntheticSourceSupport();
@@ -810,7 +814,7 @@ public abstract class MapperTestCase extends MapperServiceTestCase {
                 )
             ) {
                 for (int i = 0; i < count; i++) {
-                    if (rarely()) {
+                    if (rarely() && supportsEmptyInputArray()) {
                         expected[i] = "{}";
                         iw.addDocument(mapper.parse(source(b -> b.startArray("field").endArray())).rootDoc());
                         continue;
@@ -868,6 +872,7 @@ public abstract class MapperTestCase extends MapperServiceTestCase {
     }
 
     public final void testSyntheticEmptyList() throws IOException {
+        assumeTrue("Field does not support [] as input", supportsEmptyInputArray());
         SyntheticSourceExample syntheticSourceExample = syntheticSourceSupport().example(5);
         DocumentMapper mapper = createDocumentMapper(syntheticSourceMapping(b -> {
             b.startObject("field");

--- a/x-pack/plugin/mapper-constant-keyword/src/main/java/org/elasticsearch/xpack/constantkeyword/mapper/ConstantKeywordFieldMapper.java
+++ b/x-pack/plugin/mapper-constant-keyword/src/main/java/org/elasticsearch/xpack/constantkeyword/mapper/ConstantKeywordFieldMapper.java
@@ -34,6 +34,7 @@ import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.mapper.Mapper;
 import org.elasticsearch.index.mapper.MapperBuilderContext;
 import org.elasticsearch.index.mapper.MapperParsingException;
+import org.elasticsearch.index.mapper.SourceLoader;
 import org.elasticsearch.index.mapper.ValueFetcher;
 import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.search.aggregations.support.CoreValuesSourceType;
@@ -307,4 +308,25 @@ public class ConstantKeywordFieldMapper extends FieldMapper {
         return CONTENT_TYPE;
     }
 
+    @Override
+    public SourceLoader.SyntheticFieldLoader syntheticFieldLoader() {
+        return (reader, docIdsInLeaf) -> new SourceLoader.SyntheticFieldLoader.Leaf() {
+            @Override
+            public boolean empty() {
+                return fieldType().value == null;
+            }
+
+            @Override
+            public boolean advanceToDoc(int docId) throws IOException {
+                return fieldType().value != null;
+            }
+
+            @Override
+            public void write(XContentBuilder b) throws IOException {
+                if (fieldType().value != null) {
+                    b.field(simpleName(), fieldType().value);
+                }
+            }
+        };
+    }
 }

--- a/x-pack/plugin/mapper-constant-keyword/src/yamlRestTest/resources/rest-api-spec/test/20_synthetic_source.yml
+++ b/x-pack/plugin/mapper-constant-keyword/src/yamlRestTest/resources/rest-api-spec/test/20_synthetic_source.yml
@@ -1,0 +1,38 @@
+constant_keyword:
+  - skip:
+      version: " - 8.3.99"
+      reason: introduced in 8.4.0
+
+  - do:
+      indices.create:
+        index: test
+        body:
+          mappings:
+            _source:
+              mode: synthetic
+            properties:
+              const_kwd:
+                type: constant_keyword
+                value: bar
+              kwd:
+                type: keyword
+
+  - do:
+      index:
+        index:   test
+        id:      1
+        refresh: true
+        body:
+          kwd: foo
+
+  - do:
+      search:
+        index: test
+        body:
+          query:
+            ids:
+              values: [1]
+  - match:
+      hits.hits.0._source:
+        kwd: foo
+        const_kwd: bar


### PR DESCRIPTION
This commit implements synthetic source support on constant keyword fields,
which will now always emit their value as part of the retrieved source.