### PR TITLE
Make NodeTaskRequest tasks cancellable

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/support/tasks/TransportTasksAction.java
+++ b/server/src/main/java/org/elasticsearch/action/support/tasks/TransportTasksAction.java
@@ -24,7 +24,9 @@ import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.util.concurrent.AtomicArray;
 import org.elasticsearch.core.Tuple;
+import org.elasticsearch.tasks.CancellableTask;
 import org.elasticsearch.tasks.Task;
+import org.elasticsearch.tasks.TaskId;
 import org.elasticsearch.transport.TransportChannel;
 import org.elasticsearch.transport.TransportException;
 import org.elasticsearch.transport.TransportRequest;
@@ -307,6 +309,9 @@ public abstract class TransportTasksAction<
         }
 
         private void finishHim() {
+            if ((task instanceof CancellableTask t) && t.notifyIfCancelled(listener)) {
+                return;
+            }
             TasksResponse finalResponse;
             try {
                 finalResponse = newResponse(request, responses);
@@ -323,6 +328,9 @@ public abstract class TransportTasksAction<
 
         @Override
         public void messageReceived(final NodeTaskRequest request, final TransportChannel channel, Task task) throws Exception {
+            if (task instanceof CancellableTask cancellableTask) {
+                cancellableTask.ensureNotCancelled();
+            }
             nodeOperation(task, request, ActionListener.wrap(channel::sendResponse, e -> {
                 try {
                     channel.sendResponse(e);
@@ -335,7 +343,7 @@ public abstract class TransportTasksAction<
     }
 
     private class NodeTaskRequest extends TransportRequest {
-        private TasksRequest tasksRequest;
+        private final TasksRequest tasksRequest;
 
         protected NodeTaskRequest(StreamInput in) throws IOException {
             super(in);
@@ -351,6 +359,11 @@ public abstract class TransportTasksAction<
         protected NodeTaskRequest(TasksRequest tasksRequest) {
             super();
             this.tasksRequest = tasksRequest;
+        }
+
+        @Override
+        public Task createTask(long id, String type, String action, TaskId parentTaskId, Map<String, String> headers) {
+            return new CancellableTask(id, type, action, getDescription(), parentTaskId, headers);
         }
 
     }

--- a/server/src/main/java/org/elasticsearch/action/support/tasks/TransportTasksAction.java
+++ b/server/src/main/java/org/elasticsearch/action/support/tasks/TransportTasksAction.java
@@ -328,9 +328,6 @@ public abstract class TransportTasksAction<
 
         @Override
         public void messageReceived(final NodeTaskRequest request, final TransportChannel channel, Task task) throws Exception {
-            if (task instanceof CancellableTask cancellableTask) {
-                cancellableTask.ensureNotCancelled();
-            }
             nodeOperation(task, request, ActionListener.wrap(channel::sendResponse, e -> {
                 try {
                     channel.sendResponse(e);

--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/node/tasks/TransportTasksActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/node/tasks/TransportTasksActionTests.java
@@ -103,7 +103,7 @@ public class TransportTasksActionTests extends TaskManagerTestCase {
     }
 
     public static class NodesRequest extends BaseNodesRequest<NodesRequest> {
-        private String requestName;
+        final private String requestName;
 
         NodesRequest(StreamInput in) throws IOException {
             super(in);
@@ -190,7 +190,7 @@ public class TransportTasksActionTests extends TaskManagerTestCase {
 
     static class TestTasksResponse extends BaseTasksResponse {
 
-        final private List<TestTaskResponse> tasks;
+        private final List<TestTaskResponse> tasks;
 
         TestTasksResponse(
             List<TestTaskResponse> tasks,
@@ -311,7 +311,7 @@ public class TransportTasksActionTests extends TaskManagerTestCase {
         CountDownLatch checkLatch = new CountDownLatch(1);
         CountDownLatch responseLatch = new CountDownLatch(1);
         final AtomicReference<NodesResponse> responseReference = new AtomicReference<>();
-        Task mainTask = startBlockingTestNodesAction(checkLatch, new ActionListener<NodesResponse>() {
+        Task mainTask = startBlockingTestNodesAction(checkLatch, new ActionListener<>() {
             @Override
             public void onResponse(NodesResponse listTasksResponse) {
                 responseReference.set(listTasksResponse);
@@ -628,7 +628,7 @@ public class TransportTasksActionTests extends TaskManagerTestCase {
         return taskDescriptions.toString();
     }
 
-    public void testActionParentCancellationPropagates() throws ExecutionException, InterruptedException, IOException {
+    public void testActionParentCancellationPropagates() throws ExecutionException, InterruptedException {
         setupTestNodes(Settings.EMPTY);
         connectNodes(testNodes);
         CountDownLatch checkLatch = new CountDownLatch(1);
@@ -702,7 +702,7 @@ public class TransportTasksActionTests extends TaskManagerTestCase {
         assertEquals(0, responses.failureCount());
     }
 
-    public void testTaskLevelActionFailures() throws ExecutionException, InterruptedException, IOException {
+    public void testTaskLevelActionFailures() throws ExecutionException, InterruptedException {
         setupTestNodes(Settings.EMPTY);
         connectNodes(testNodes);
         CountDownLatch checkLatch = new CountDownLatch(1);
@@ -770,7 +770,7 @@ public class TransportTasksActionTests extends TaskManagerTestCase {
      * it executes a tasks action that targets these blocked node actions. The test verifies that task actions are only
      * getting executed on nodes that are not listed in the node filter.
      */
-    public void testTaskNodeFiltering() throws ExecutionException, InterruptedException, IOException {
+    public void testTaskNodeFiltering() throws ExecutionException, InterruptedException {
         setupTestNodes(Settings.EMPTY);
         connectNodes(testNodes);
         CountDownLatch checkLatch = new CountDownLatch(1);
@@ -802,7 +802,7 @@ public class TransportTasksActionTests extends TaskManagerTestCase {
                             filteredNodes.add(node);
                         }
                     }
-                    return filteredNodes.toArray(new String[filteredNodes.size()]);
+                    return filteredNodes.toArray(new String[0]);
                 }
 
                 @Override

--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/node/tasks/TransportTasksActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/node/tasks/TransportTasksActionTests.java
@@ -103,7 +103,7 @@ public class TransportTasksActionTests extends TaskManagerTestCase {
     }
 
     public static class NodesRequest extends BaseNodesRequest<NodesRequest> {
-        final private String requestName;
+        private final String requestName;
 
         NodesRequest(StreamInput in) throws IOException {
             super(in);

--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/node/tasks/TransportTasksActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/node/tasks/TransportTasksActionTests.java
@@ -640,7 +640,6 @@ public class TransportTasksActionTests extends TaskManagerTestCase {
         TestTasksAction[] tasksActions = new TestTasksAction[numNodes];
         for (int j = 0; j < numNodes; j++) {
             final int nodeId = j;
-            // Simulate task action that fails on one of the tasks on one of the nodes
             tasksActions[j] = new TestTasksAction(
                 "internal:testTasksAction",
                 testNodes[nodeId].clusterService,


### PR DESCRIPTION
We pass the actionTask to the subsequent task action so that the task action can be cancelled if the upstream tasks are cancelled.

But, the actionTask passed is created by the `NodeTaskRequest`, which isn't cancellable. 

This commit addresses this discrepancy and allows for down stream task actions to be cancelled if the upstream http connections are closed.

Related to: #88081 