### PR TITLE
Use origin for the client when running _features/_reset

### DIFF
--- a/docs/changelog/88622.yaml
+++ b/docs/changelog/88622.yaml
@@ -1,0 +1,6 @@
+pr: 88622
+summary: Use origin for the client when running _features/_reset
+area: Infra/Core
+type: bug
+issues:
+ - 88617

--- a/qa/system-indices/src/main/java/org/elasticsearch/system/indices/SystemIndicesQA.java
+++ b/qa/system-indices/src/main/java/org/elasticsearch/system/indices/SystemIndicesQA.java
@@ -38,6 +38,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.function.Supplier;
 
+import static org.elasticsearch.action.admin.cluster.node.tasks.get.GetTaskAction.TASKS_ORIGIN;
 import static org.elasticsearch.index.mapper.MapperService.SINGLE_MAPPING_NAME;
 import static org.elasticsearch.rest.RestRequest.Method.POST;
 import static org.elasticsearch.rest.RestRequest.Method.PUT;
@@ -73,7 +74,7 @@ public class SystemIndicesQA extends Plugin implements SystemIndexPlugin, Action
                         .put(IndexMetadata.SETTING_AUTO_EXPAND_REPLICAS, "0-1")
                         .build()
                 )
-                .setOrigin("net-new")
+                .setOrigin(TASKS_ORIGIN)
                 .setVersionMetaKey("version")
                 .setPrimaryIndex(".net-new-system-index-" + Version.CURRENT.major)
                 .build(),
@@ -81,7 +82,7 @@ public class SystemIndicesQA extends Plugin implements SystemIndexPlugin, Action
                 .setIndexPattern(INTERNAL_UNMANAGED_INDEX_NAME)
                 .setDescription("internal unmanaged system index")
                 .setType(SystemIndexDescriptor.Type.INTERNAL_UNMANAGED)
-                .setOrigin("qa")
+                .setOrigin(TASKS_ORIGIN)
                 .setAliasName(".internal-unmanaged-alias")
                 .build(),
             SystemIndexDescriptor.builder()
@@ -96,7 +97,7 @@ public class SystemIndicesQA extends Plugin implements SystemIndexPlugin, Action
                         .put(IndexMetadata.SETTING_AUTO_EXPAND_REPLICAS, "0-1")
                         .build()
                 )
-                .setOrigin("qa")
+                .setOrigin(TASKS_ORIGIN)
                 .setVersionMetaKey("version")
                 .setPrimaryIndex(".internal-managed-index-" + Version.CURRENT.major)
                 .setAliasName(".internal-managed-alias")

--- a/server/src/main/java/org/elasticsearch/indices/SystemIndices.java
+++ b/server/src/main/java/org/elasticsearch/indices/SystemIndices.java
@@ -911,7 +911,7 @@ public class SystemIndices {
                 .flatMap(List::stream)
                 .toList();
 
-            final int taskCount = associatedIndices.size() + (int) indexDescriptors.stream()
+            final int taskCount = ((associatedIndices.size() > 0) ? 1 : 0) + (int) indexDescriptors.stream()
                 .filter(id -> id.getMatchingIndices(metadata).isEmpty() == false)
                 .count();
 
@@ -933,7 +933,7 @@ public class SystemIndices {
                         StringBuilder exceptions = new StringBuilder("[");
                         exceptions.append(errors.stream().map(e -> e.getException().getMessage()).collect(Collectors.joining(", ")));
                         exceptions.append(']');
-                        errors.forEach(e -> logger.warn(format("Encountered error while resetting feature [%s]", name), e));
+                        errors.forEach(e -> logger.warn(() -> "error while resetting feature [" + name + "]", e.getException()));
                         listener.onResponse(ResetFeatureStateStatus.failure(name, new Exception(exceptions.toString())));
                     }
                 }, listener::onFailure),

--- a/server/src/main/java/org/elasticsearch/indices/SystemIndices.java
+++ b/server/src/main/java/org/elasticsearch/indices/SystemIndices.java
@@ -888,7 +888,7 @@ public class SystemIndices {
             Collection<SystemIndexDescriptor> indexDescriptors,
             List<String> associatedIndices
         ) {
-            return associatedIndices.size() + (int)indexDescriptors.stream()
+            return associatedIndices.size() + (int) indexDescriptors.stream()
                 .filter(id -> id.getMatchingIndices(metadata).isEmpty() == false)
                 .count();
         }
@@ -927,8 +927,7 @@ public class SystemIndices {
 
             GroupedActionListener<ResetFeatureStateStatus> groupedListener = new GroupedActionListener<>(
                 ActionListener.wrap(listenerResults -> {
-                    List<ResetFeatureStateStatus> errors = listenerResults
-                        .stream()
+                    List<ResetFeatureStateStatus> errors = listenerResults.stream()
                         .filter(status -> status.getStatus() == ResetFeatureStateResponse.ResetFeatureStateStatus.Status.FAILURE)
                         .collect(Collectors.toList());
 

--- a/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/integration/SecurityFeatureResetTests.java
+++ b/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/integration/SecurityFeatureResetTests.java
@@ -12,29 +12,57 @@ import org.elasticsearch.action.admin.cluster.snapshots.features.ResetFeatureSta
 import org.elasticsearch.action.admin.cluster.snapshots.features.ResetFeatureStateRequest;
 import org.elasticsearch.action.admin.cluster.snapshots.features.ResetFeatureStateResponse;
 import org.elasticsearch.common.settings.SecureString;
-import org.elasticsearch.test.SecurityIntegTestCase;
+import org.elasticsearch.test.NativeRealmIntegTestCase;
+import org.elasticsearch.test.SecuritySettingsSource;
 import org.elasticsearch.test.SecuritySettingsSourceField;
+import org.elasticsearch.test.TestSecurityClient;
+import org.elasticsearch.xpack.core.security.user.User;
+import org.junit.Before;
 
 import java.util.Collections;
 
 import static org.elasticsearch.xpack.core.security.authc.support.UsernamePasswordToken.BASIC_AUTH_HEADER;
 import static org.elasticsearch.xpack.core.security.authc.support.UsernamePasswordToken.basicAuthHeaderValue;
 
-public class SecurityFeatureResetTests extends SecurityIntegTestCase {
+public class SecurityFeatureResetTests extends NativeRealmIntegTestCase {
     private static final SecureString SUPER_USER_PASSWD = SecuritySettingsSourceField.TEST_PASSWORD_SECURE_STRING;
+
+    @Override
+    public boolean shouldDeleteSecurityIndex() {
+        return false;
+    }
+
+    @Before
+    public void setupForTests() throws Exception {
+        // adds a dummy user to the native realm to force .security index creation
+        new TestSecurityClient(getRestClient(), SecuritySettingsSource.SECURITY_REQUEST_OPTIONS).putUser(
+            new User("dummy_user", "missing_role"),
+            SecuritySettingsSourceField.TEST_PASSWORD_SECURE_STRING
+        );
+        assertSecurityIndexActive();
+    }
 
     @Override
     protected String configUsers() {
         final String usersPasswHashed = new String(getFastStoredHashAlgoForTests().hash(SUPER_USER_PASSWD));
-        return super.configUsers() + "su:" + usersPasswHashed + "\n" + "manager:" + usersPasswHashed + "\n";
-
+        return super.configUsers()
+            + "su:"
+            + usersPasswHashed
+            + "\n"
+            + "manager:"
+            + usersPasswHashed
+            + "\n"
+            + "usr:"
+            + usersPasswHashed
+            + "\n";
     }
 
     @Override
     protected String configUsersRoles() {
         return super.configUsersRoles() + """
             superuser:su
-            role1:manager""";
+            role1:manager
+            role2:usr""";
     }
 
     @Override
@@ -46,18 +74,27 @@ public class SecurityFeatureResetTests extends SecurityIntegTestCase {
               indices:
                 - names: '*'
                   privileges: [ manage ]
+            role2:
+              cluster: [ all ]
+              indices:
+                - names: '*'
+                  privileges: [ read ]
             """;
     }
 
     public void testFeatureResetSuperuser() {
-        assertCanReset("su", SUPER_USER_PASSWD);
+        assertReset("su", SUPER_USER_PASSWD, 0);
     }
 
     public void testFeatureResetManageRole() {
-        assertCanReset("manager", SUPER_USER_PASSWD);
+        assertReset("manager", SUPER_USER_PASSWD, 0);
     }
 
-    private void assertCanReset(String user, SecureString password) {
+    /*public void testFeatureResetUsrRole() {
+        assertReset("usr", SUPER_USER_PASSWD, 1);
+    }*/
+
+    private void assertReset(String user, SecureString password, final int numFailures) {
         final ResetFeatureStateRequest req = new ResetFeatureStateRequest();
 
         client().filterWithHeader(Collections.singletonMap(BASIC_AUTH_HEADER, basicAuthHeaderValue(user, password)))
@@ -70,7 +107,7 @@ public class SecurityFeatureResetTests extends SecurityIntegTestCase {
                         .stream()
                         .filter(status -> status.getStatus() == ResetFeatureStateResponse.ResetFeatureStateStatus.Status.FAILURE)
                         .count();
-                    assertEquals(0, failures);
+                    assertEquals(numFailures, failures);
                 }
 
                 @Override

--- a/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/integration/SecurityFeatureResetTests.java
+++ b/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/integration/SecurityFeatureResetTests.java
@@ -25,6 +25,11 @@ import static org.elasticsearch.xpack.core.security.authc.support.UsernamePasswo
 import static org.elasticsearch.xpack.core.security.authc.support.UsernamePasswordToken.basicAuthHeaderValue;
 import static org.hamcrest.Matchers.containsString;
 
+/** 
+ * These tests ensure that the Feature Reset API works for users with default superuser and manage roles.
+ * This can be complex due to restrictions on system indices and the need to use the correct origin for
+ * each index. See also https://github.com/elastic/elasticsearch/issues/88617
+ */
 public class SecurityFeatureResetTests extends SecurityIntegTestCase {
     private static final SecureString SUPER_USER_PASSWD = SecuritySettingsSourceField.TEST_PASSWORD_SECURE_STRING;
 

--- a/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/integration/SecurityFeatureResetTests.java
+++ b/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/integration/SecurityFeatureResetTests.java
@@ -25,7 +25,7 @@ import static org.elasticsearch.xpack.core.security.authc.support.UsernamePasswo
 import static org.elasticsearch.xpack.core.security.authc.support.UsernamePasswordToken.basicAuthHeaderValue;
 import static org.hamcrest.Matchers.containsString;
 
-/** 
+/**
  * These tests ensure that the Feature Reset API works for users with default superuser and manage roles.
  * This can be complex due to restrictions on system indices and the need to use the correct origin for
  * each index. See also https://github.com/elastic/elasticsearch/issues/88617

--- a/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/integration/SecurityFeatureResetTests.java
+++ b/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/integration/SecurityFeatureResetTests.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.integration;
+
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.admin.cluster.snapshots.features.ResetFeatureStateAction;
+import org.elasticsearch.action.admin.cluster.snapshots.features.ResetFeatureStateRequest;
+import org.elasticsearch.action.admin.cluster.snapshots.features.ResetFeatureStateResponse;
+import org.elasticsearch.common.settings.SecureString;
+import org.elasticsearch.test.SecurityIntegTestCase;
+import org.elasticsearch.test.SecuritySettingsSourceField;
+
+import java.util.Collections;
+
+import static org.elasticsearch.xpack.core.security.authc.support.UsernamePasswordToken.BASIC_AUTH_HEADER;
+import static org.elasticsearch.xpack.core.security.authc.support.UsernamePasswordToken.basicAuthHeaderValue;
+
+public class SecurityFeatureResetTests extends SecurityIntegTestCase {
+    private static final SecureString SUPER_USER_PASSWD = SecuritySettingsSourceField.TEST_PASSWORD_SECURE_STRING;
+
+    @Override
+    protected String configUsers() {
+        final String usersPasswHashed = new String(getFastStoredHashAlgoForTests().hash(SUPER_USER_PASSWD));
+        return super.configUsers() + "su:" + usersPasswHashed + "\n" + "manager:" + usersPasswHashed + "\n";
+
+    }
+
+    @Override
+    protected String configUsersRoles() {
+        return super.configUsersRoles() + """
+            superuser:su
+            role1:manager""";
+    }
+
+    @Override
+    protected String configRoles() {
+        return super.configRoles() + """
+            %s
+            role1:
+              cluster: [ all ]
+              indices:
+                - names: '*'
+                  privileges: [ manage ]
+            """;
+    }
+
+    public void testFeatureResetSuperuser() {
+        assertCanReset("su", SUPER_USER_PASSWD);
+    }
+
+    public void testFeatureResetManageRole() {
+        assertCanReset("manager", SUPER_USER_PASSWD);
+    }
+
+    private void assertCanReset(String user, SecureString password) {
+        final ResetFeatureStateRequest req = new ResetFeatureStateRequest();
+
+        client().filterWithHeader(Collections.singletonMap(BASIC_AUTH_HEADER, basicAuthHeaderValue(user, password)))
+            .admin()
+            .cluster()
+            .execute(ResetFeatureStateAction.INSTANCE, req, new ActionListener<>() {
+                @Override
+                public void onResponse(ResetFeatureStateResponse response) {
+                    long failures = response.getFeatureStateResetStatuses()
+                        .stream()
+                        .filter(status -> status.getStatus() == ResetFeatureStateResponse.ResetFeatureStateStatus.Status.FAILURE)
+                        .count();
+                    assertEquals(0, failures);
+                }
+
+                @Override
+                public void onFailure(Exception e) {
+                    fail("Shouldn't reach here");
+                }
+            });
+    }
+}

--- a/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/test/NativeRealmIntegTestCase.java
+++ b/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/test/NativeRealmIntegTestCase.java
@@ -43,15 +43,9 @@ public abstract class NativeRealmIntegTestCase extends SecurityIntegTestCase {
         }
     }
 
-    public boolean shouldDeleteSecurityIndex() {
-        return true;
-    }
-
     @After
     public void stopESNativeStores() throws Exception {
-        if (shouldDeleteSecurityIndex()) {
-            deleteSecurityIndex();
-        }
+        deleteSecurityIndex();
 
         if (getCurrentClusterScope() == Scope.SUITE) {
             // Clear the realm cache for all realms since we use a SUITE scoped cluster

--- a/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/test/NativeRealmIntegTestCase.java
+++ b/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/test/NativeRealmIntegTestCase.java
@@ -43,9 +43,15 @@ public abstract class NativeRealmIntegTestCase extends SecurityIntegTestCase {
         }
     }
 
+    public boolean shouldDeleteSecurityIndex() {
+        return true;
+    }
+
     @After
     public void stopESNativeStores() throws Exception {
-        deleteSecurityIndex();
+        if (shouldDeleteSecurityIndex()) {
+            deleteSecurityIndex();
+        }
 
         if (getCurrentClusterScope() == Scope.SUITE) {
             // Clear the realm cache for all realms since we use a SUITE scoped cluster


### PR DESCRIPTION
The current implementation of `POST /_features/_reset` doesn't pass the index descriptor origin when calling `DELETE` on the system indices, therefore, we fail to reset the respective indices.

Closes #88617