### PR TITLE
Adding the ability to register a PeerFinderListener to Coordinator

### DIFF
--- a/docs/changelog/88626.yaml
+++ b/docs/changelog/88626.yaml
@@ -1,0 +1,5 @@
+pr: 88626
+summary: Adding the ability to register a `PeerFinderListener` to Coordinator
+area: Distributed
+type: enhancement
+issues: []

--- a/server/src/main/java/org/elasticsearch/cluster/coordination/ClusterBootstrapService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/ClusterBootstrapService.java
@@ -147,6 +147,7 @@ public class ClusterBootstrapService implements Coordinator.PeerFinderListener {
         }
     }
 
+    @Override
     public void onFoundPeersUpdated() {
         final Set<DiscoveryNode> nodes = getDiscoveredNodes();
         if (bootstrappingPermitted.get()

--- a/server/src/main/java/org/elasticsearch/cluster/coordination/ClusterBootstrapService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/ClusterBootstrapService.java
@@ -43,7 +43,7 @@ import static java.util.Collections.unmodifiableSet;
 import static org.elasticsearch.discovery.DiscoveryModule.DISCOVERY_SEED_PROVIDERS_SETTING;
 import static org.elasticsearch.discovery.SettingsBasedSeedHostsProvider.DISCOVERY_SEED_HOSTS_SETTING;
 
-public class ClusterBootstrapService {
+public class ClusterBootstrapService implements Coordinator.PeerFinderListener {
 
     public static final Setting<List<String>> INITIAL_MASTER_NODES_SETTING = Setting.listSetting(
         "cluster.initial_master_nodes",
@@ -147,7 +147,7 @@ public class ClusterBootstrapService {
         }
     }
 
-    void onFoundPeersUpdated() {
+    public void onFoundPeersUpdated() {
         final Set<DiscoveryNode> nodes = getDiscoveredNodes();
         if (bootstrappingPermitted.get()
             && transportService.getLocalNode().isMasterNode()


### PR DESCRIPTION
This came out of #88562. The problem there is that if we are a non-master-eligible node we want to start polling a master-eligible node whenever we realize that there is no elected master. We are notified that there is no elected master in a `ClusterChangedEvent`. We get the list of master-eligible nodes from `PeerFinder#getFoundPeers`. However at that the time that we are notified of the `ClusterChangeEvent`, `PeerFinder#getFoundPeers` returns an empty `Iterable`. That collection is populated in another thread, and there is currently no way to get notified of when it is populated. This PR adds the ability to register a `PeerFinderListener` with `Coordinator`. The listener has an `onFoundPeersUpdated` that is called whenever the collection of peers changes (whether added to or removed from). 