### PR TITLE
Fix multi-value handling in composite agg

### DIFF
--- a/docs/changelog/88638.yaml
+++ b/docs/changelog/88638.yaml
@@ -1,5 +1,5 @@
 pr: 88638
 summary: Fix multi-value handling in composite agg
-area: CompositeAggs
+area: Aggregations
 type: bug
 issues: []

--- a/docs/changelog/88638.yaml
+++ b/docs/changelog/88638.yaml
@@ -1,0 +1,5 @@
+pr: 88638
+summary: Fix multi-value handling in composite agg
+area: CompositeAggs
+type: bug
+issues: []

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/composite/DoubleValuesSource.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/composite/DoubleValuesSource.java
@@ -161,10 +161,14 @@ class DoubleValuesSource extends SingleDimensionValuesSource<Double> {
             public void collect(int doc, long bucket) throws IOException {
                 if (dvs.advanceExact(doc)) {
                     int num = dvs.docValueCount();
+                    double previous = Double.MAX_VALUE;
                     for (int i = 0; i < num; i++) {
                         currentValue = dvs.nextValue();
                         missingCurrentValue = false;
-                        next.collect(doc, bucket);
+                        if (i == 0 || previous != currentValue) {
+                            next.collect(doc, bucket);
+                            previous = currentValue;
+                        }
                     }
                 } else if (missingBucket) {
                     missingCurrentValue = true;

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/composite/LongValuesSource.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/composite/LongValuesSource.java
@@ -177,10 +177,14 @@ class LongValuesSource extends SingleDimensionValuesSource<Long> {
             public void collect(int doc, long bucket) throws IOException {
                 if (dvs.advanceExact(doc)) {
                     int num = dvs.docValueCount();
+                    long previous = Long.MAX_VALUE;
                     for (int i = 0; i < num; i++) {
                         currentValue = dvs.nextValue();
                         missingCurrentValue = false;
-                        next.collect(doc, bucket);
+                        if (i == 0 || previous != currentValue) {
+                            next.collect(doc, bucket);
+                            previous = currentValue;
+                        }
                     }
                 } else if (missingBucket) {
                     missingCurrentValue = true;


### PR DESCRIPTION
Multi-valued number fields are handled differently by the composite terms agg in comparison to the regular terms agg. In particular, we use set semantics when grouping on multi-valued numeric fields using terms / multi-terms aggs (see e.g. https://github.com/elastic/elasticsearch/blob/d1ba276587dd033120240a74a6a83f1f372fbd4a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/NumericTermsAggregator.java#L96) while we don't do the same for composite terms aggs. The following example in particular shows some discrepancies, which are fixed in this PR:

```
DELETE test

PUT test/_doc/id1?refresh=true
{
  "foo" : [1, 1]
}

GET test/_search
{
  "docvalue_fields": ["foo"],
  "aggs": {
    "terms_foo": {
      "terms": {
        "field": "foo"
      },
      "aggs": {
        "stats": {
          "sum": {
            "field": "foo"
          }
        }
      }
    },
    "comp_foo": {
      "composite": {
        "sources": [
          {
            "foo": {
              "terms": {
                "field": "foo"
              }
            }
          }
        ]
      },
      "aggs": {
        "stats": {
          "sum": {
            "field": "foo"
          }
        }
      }
    }
  }
}
```

which yields

```
{
  "took": 2,
  "timed_out": false,
  "_shards": {
    "total": 1,
    "successful": 1,
    "skipped": 0,
    "failed": 0
  },
  "hits": {
    "total": {
      "value": 1,
      "relation": "eq"
    },
    "max_score": 1,
    "hits": [
      {
        "_index": "test",
        "_id": "id1",
        "_score": 1,
        "_source": {
          "foo": [
            1,
            1
          ]
        },
        "fields": {
          "foo": [
            1,
            1
          ]
        }
      }
    ]
  },
  "aggregations": {
    "comp_foo": {
      "after_key": {
        "foo": 1
      },
      "buckets": [
        {
          "key": {
            "foo": 1
          },
          "doc_count": 1,
          "stats": {
            "value": 4
          }
        }
      ]
    },
    "terms_foo": {
      "doc_count_error_upper_bound": 0,
      "sum_other_doc_count": 0,
      "buckets": [
        {
          "key": 1,
          "doc_count": 1,
          "stats": {
            "value": 2
          }
        }
      ]
    }
  }
}
```


Relates #88598