### PR TITLE
Replace health request with a state observer.

### DIFF
--- a/docs/changelog/88641.yaml
+++ b/docs/changelog/88641.yaml
@@ -1,0 +1,5 @@
+pr: 88641
+summary: Replace health request with a state observer
+area: Allocation
+type: bug
+issues: []

--- a/x-pack/plugin/fleet/src/main/java/org/elasticsearch/xpack/fleet/action/GetGlobalCheckpointsAction.java
+++ b/x-pack/plugin/fleet/src/main/java/org/elasticsearch/xpack/fleet/action/GetGlobalCheckpointsAction.java
@@ -16,11 +16,11 @@ import org.elasticsearch.action.ActionRunnable;
 import org.elasticsearch.action.ActionType;
 import org.elasticsearch.action.IndicesRequest;
 import org.elasticsearch.action.UnavailableShardsException;
-import org.elasticsearch.action.admin.cluster.health.ClusterHealthResponse;
 import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.client.internal.node.NodeClient;
 import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.ClusterStateObserver;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.routing.IndexRoutingTable;
@@ -35,8 +35,10 @@ import org.elasticsearch.index.Index;
 import org.elasticsearch.index.IndexNotFoundException;
 import org.elasticsearch.index.seqno.SequenceNumbers;
 import org.elasticsearch.index.shard.ShardId;
+import org.elasticsearch.node.NodeClosedException;
 import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.tasks.Task;
+import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
 import org.elasticsearch.xcontent.ToXContent;
 import org.elasticsearch.xcontent.ToXContentObject;
@@ -156,6 +158,7 @@ public class GetGlobalCheckpointsAction extends ActionType<GetGlobalCheckpointsA
         private final ClusterService clusterService;
         private final NodeClient client;
         private final IndexNameExpressionResolver resolver;
+        private final ThreadPool threadPool;
 
         @Inject
         public TransportAction(
@@ -163,12 +166,14 @@ public class GetGlobalCheckpointsAction extends ActionType<GetGlobalCheckpointsA
             final TransportService transportService,
             final ClusterService clusterService,
             final NodeClient client,
-            final IndexNameExpressionResolver resolver
+            final IndexNameExpressionResolver resolver,
+            final ThreadPool threadPool
         ) {
             super(NAME, actionFilters, transportService.getTaskManager());
             this.clusterService = clusterService;
             this.client = client;
             this.resolver = resolver;
+            this.threadPool = threadPool;
         }
 
         @Override
@@ -180,7 +185,7 @@ public class GetGlobalCheckpointsAction extends ActionType<GetGlobalCheckpointsA
                 index = resolver.concreteSingleIndex(state, request);
             } catch (IndexNotFoundException e) {
                 if (request.waitForIndex()) {
-                    handleIndexNotReady(request, listener);
+                    handleIndexNotReady(state, request, listener);
                 } else {
                     listener.onFailure(e);
                 }
@@ -194,7 +199,7 @@ public class GetGlobalCheckpointsAction extends ActionType<GetGlobalCheckpointsA
                 new CheckpointFetcher(client, request, listener, indexMetadata, request.timeout()).run();
             } else {
                 if (request.waitForIndex()) {
-                    handleIndexNotReady(request, listener);
+                    handleIndexNotReady(state, request, listener);
                 } else {
                     int active = routingTable.primaryShardsActive();
                     int total = indexMetadata.getNumberOfShards();
@@ -205,60 +210,61 @@ public class GetGlobalCheckpointsAction extends ActionType<GetGlobalCheckpointsA
             }
         }
 
-        private void handleIndexNotReady(final Request request, final ActionListener<Response> responseListener) {
+        private void handleIndexNotReady(ClusterState initialState, Request request, ActionListener<Response> listener) {
             long startNanos = System.nanoTime();
-            client.admin()
-                .cluster()
-                .prepareHealth(request.index)
-                .setLocal(true)
-                .setTimeout(request.timeout())
-                .setWaitForYellowStatus()
-                .setWaitForNoInitializingShards(true)
-                .execute(new ActionListener<>() {
-                    @Override
-                    public void onResponse(ClusterHealthResponse healthResponse) {
-                        final long elapsedNanos = System.nanoTime() - startNanos;
-                        final ClusterState state = clusterService.state();
-                        final Index index;
-                        try {
-                            index = resolver.concreteSingleIndex(state, request);
-                        } catch (Exception e) {
-                            responseListener.onFailure(e);
-                            return;
-                        }
+            var observer = new ClusterStateObserver(initialState, clusterService, request.timeout(), logger, threadPool.getThreadContext());
 
-                        final IndexMetadata indexMetadata = state.getMetadata().index(index);
-                        final IndexRoutingTable routingTable = state.routingTable().index(index);
-
+            observer.waitForNextChange(new ClusterStateObserver.Listener() {
+                @Override
+                public void onNewClusterState(ClusterState state) {
+                    try {
+                        var index = resolver.concreteSingleIndex(state, request);
+                        long elapsedNanos = System.nanoTime() - startNanos;
                         long remainingNanos = request.timeout().nanos() - elapsedNanos;
-                        if (routingTable.allPrimaryShardsActive() && remainingNanos > 0) {
-                            new CheckpointFetcher(
-                                client,
-                                request,
-                                responseListener,
-                                indexMetadata,
-                                TimeValue.timeValueNanos(remainingNanos)
-                            ).run();
-                        } else {
-                            int active = routingTable.primaryShardsActive();
-                            int total = indexMetadata.getNumberOfShards();
-                            responseListener.onFailure(
-                                new UnavailableShardsException(
-                                    null,
-                                    "Primary shards were not active within timeout [timeout={}, shards={}, active={}]",
-                                    request.timeout(),
-                                    total,
-                                    active
-                                )
-                            );
-                        }
+                        new CheckpointFetcher(
+                            client,
+                            request,
+                            listener,
+                            state.getMetadata().index(index),
+                            TimeValue.timeValueNanos(remainingNanos)
+                        ).run();
+                    } catch (Exception e) {
+                        listener.onFailure(e);
                     }
+                }
 
-                    @Override
-                    public void onFailure(Exception e) {
-                        responseListener.onFailure(e);
+                @Override
+                public void onTimeout(TimeValue timeout) {
+                    final ClusterState state = clusterService.state();
+                    final Index index;
+                    try {
+                        index = resolver.concreteSingleIndex(state, request);
+                        listener.onFailure(
+                            new UnavailableShardsException(
+                                null,
+                                "Primary shards were not active within timeout [timeout={}, shards={}, active={}]",
+                                request.timeout(),
+                                state.getMetadata().index(index).getNumberOfShards(),
+                                state.routingTable().index(index).primaryShardsActive()
+                            )
+                        );
+                    } catch (Exception e) {
+                        listener.onFailure(e);
                     }
-                });
+                }
+
+                @Override
+                public void onClusterServiceClose() {
+                    listener.onFailure(new NodeClosedException(clusterService.localNode()));
+                }
+            }, state -> {
+                try {
+                    var index = resolver.concreteSingleIndex(state, request);
+                    return state.routingTable().index(index).allPrimaryShardsActive();
+                } catch (Exception e) {
+                    return false;
+                }
+            }, request.timeout());
         }
 
         private static class CheckpointFetcher extends ActionRunnable<Response> {

--- a/x-pack/plugin/fleet/src/main/java/org/elasticsearch/xpack/fleet/action/GetGlobalCheckpointsAction.java
+++ b/x-pack/plugin/fleet/src/main/java/org/elasticsearch/xpack/fleet/action/GetGlobalCheckpointsAction.java
@@ -271,9 +271,7 @@ public class GetGlobalCheckpointsAction extends ActionType<GetGlobalCheckpointsA
             }, state -> {
                 try {
                     var index = resolver.concreteSingleIndex(state, request);
-                    boolean b = state.routingTable().index(index).allPrimaryShardsActive();
-                    logger.info("---> {}", b);
-                    return b;
+                    return state.routingTable().index(index).allPrimaryShardsActive();
                 } catch (Exception e) {
                     return false;
                 }


### PR DESCRIPTION
This was using health request assuming yellow index is one with all primaries
initialized. This is not true as newly created index remain yellow when
primaries allocation is throttled. This was discovered while working on a new
shards allocator.
