### PR TITLE
Move synthetic source from behind the TSDB feature flag

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/mapper/SourceFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/SourceFieldMapper.java
@@ -20,7 +20,6 @@ import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.util.CollectionUtils;
 import org.elasticsearch.common.xcontent.XContentFieldFilter;
 import org.elasticsearch.core.Nullable;
-import org.elasticsearch.index.IndexSettings;
 import org.elasticsearch.index.query.QueryShardException;
 import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.xcontent.XContentType;
@@ -104,10 +103,7 @@ public class SourceFieldMapper extends MetadataFieldMapper {
 
         @Override
         protected Parameter<?>[] getParameters() {
-            if (IndexSettings.isTimeSeriesModeEnabled()) {
-                return new Parameter<?>[] { enabled, mode, includes, excludes };
-            }
-            return new Parameter<?>[] { enabled, includes, excludes };
+            return new Parameter<?>[] { enabled, mode, includes, excludes };
         }
 
         private boolean isDefault() {


### PR DESCRIPTION
To date, synthetic source has only been available in snapshot builds.  This
commit makes the `mode` parameter on the `_source` mapper public, meaning
that synthetic source will be available in 8.4.0.

Note that the `force_synthetic_source` parameter on search, get and mget
remains protected by the TSDB feature flag.