### PR TITLE
[ML] make bucket_correlation aggregation generally available

### DIFF
--- a/docs/changelog/88655.yaml
+++ b/docs/changelog/88655.yaml
@@ -1,5 +1,5 @@
 pr: 88655
-summary: Make `bucket_correlation` generally available
+summary: Make `bucket_correlation` aggregation generally available
 area: Machine Learning
 type: feature
 issues: []

--- a/docs/changelog/88655.yaml
+++ b/docs/changelog/88655.yaml
@@ -1,0 +1,5 @@
+pr: 88655
+summary: Make `bucket_correlation` generally available
+area: Machine Learning
+type: feature
+issues: []

--- a/docs/reference/aggregations/pipeline/bucket-correlation-aggregation.asciidoc
+++ b/docs/reference/aggregations/pipeline/bucket-correlation-aggregation.asciidoc
@@ -5,8 +5,6 @@
 <titleabbrev>Bucket correlation</titleabbrev>
 ++++
 
-experimental::[]
-
 A sibling pipeline aggregation which executes a correlation function on the
 configured sibling multi-bucket aggregation.
 


### PR DESCRIPTION
Originally released in 7.14, bucket_correlation is now generally available.