### PR TITLE
[ML] Fail model deployment if all allocations cannot be provided

### DIFF
--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportStartTrainedModelDeploymentAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportStartTrainedModelDeploymentAction.java
@@ -539,6 +539,7 @@ public class TransportStartTrainedModelDeploymentAction extends TransportMasterN
             // We can scale horizontally
             return maxLazyMLNodes > nodes.size()
                 // We can scale vertically
+                // TODO this currently only considers memory. We should also consider CPU when autoscaling by CPU is possible.
                 || (smallestMLNode.isEmpty() == false && smallestMLNode.getAsLong() < maxMLNodeSize);
         }
     }


### PR DESCRIPTION
When we cannot scale up (autoscaling is disabled) we should fail
requests to start a trained model deployment whose allocations
cannot be provided.
