### PR TITLE
[ML] Make bucket_count_ks_test aggregation generally available

### DIFF
--- a/docs/changelog/88657.yaml
+++ b/docs/changelog/88657.yaml
@@ -1,0 +1,5 @@
+pr: 88657
+summary: Make `bucket_count_ks_test` aggregation generally available
+area: Machine Learning
+type: feature
+issues: []

--- a/docs/reference/aggregations/pipeline/bucket-count-ks-test-aggregation.asciidoc
+++ b/docs/reference/aggregations/pipeline/bucket-count-ks-test-aggregation.asciidoc
@@ -5,8 +5,6 @@
 <titleabbrev>Bucket count K-S test</titleabbrev>
 ++++
 
-experimental::[]
-
 A sibling pipeline aggregation which executes a two sample Kolmogorov–Smirnov test
 (referred to as a "K-S test" from now on) against a provided distribution, and the
 distribution implied by the documents counts in the configured sibling aggregation.


### PR DESCRIPTION
Initially released in 7.14, bucket_count_ks_test is now generally available.