### PR TITLE
Reinstate test cluster throttling behavior

### DIFF
--- a/build-tools/src/main/java/org/elasticsearch/gradle/testclusters/StandaloneRestIntegTestTask.java
+++ b/build-tools/src/main/java/org/elasticsearch/gradle/testclusters/StandaloneRestIntegTestTask.java
@@ -90,7 +90,9 @@ public class StandaloneRestIntegTestTask extends Test implements TestClustersAwa
 
         int nodeCount = clusters.stream().mapToInt(cluster -> cluster.getNodes().size()).sum();
         if (nodeCount > 0) {
-            locks.add(resource.getResourceLock());
+            for (int i = 0; i < Math.min(nodeCount, resource.getMaxUsages()); i++) {
+                locks.add(resource.getResourceLock());
+            }
         }
         return Collections.unmodifiableList(locks);
     }


### PR DESCRIPTION
As a result of https://github.com/elastic/elasticsearch/pull/85141 upgrading to Gradle 7.5 we lost some previous behavior related to test cluster parallelism. Previously, when we registered a resource lock we also provided how many leases we were requesting. The reason for this is that some tests spin up a single node cluster and others multi-node clusters. To differentiate between these tasks we count each node as a lease towards to total allowed concurrent leases.

Since there's no longer an explicit API for this in Gradle 7.5, the ~~hack~~ workaround is simply to register multiple locks from the same shared resource. I've tested this locally in a simple standalone project to better demonstrate that the approach does indeed work as intended.

https://gradle-enterprise.elastic.co/s/2xgmqx2ika5si/timeline