### PR TITLE
Add documentation for `knn` option

### DIFF
--- a/docs/reference/mapping/types/dense-vector.asciidoc
+++ b/docs/reference/mapping/types/dense-vector.asciidoc
@@ -152,6 +152,7 @@ NOTE: Although they are conceptually related, the `similarity` parameter is
 different from <<text,`text`>> field <<similarity,`similarity`>> and accepts
 a distinct set of options.
 
+[[dense-vector-index-options]]
 `index_options`::
 (Optional, object)
 An optional section that configures the kNN indexing algorithm. The HNSW

--- a/docs/reference/search/knn-search.asciidoc
+++ b/docs/reference/search/knn-search.asciidoc
@@ -75,8 +75,8 @@ that sacrifices result accuracy for improved search speed. This means the
 results returned are not always the true _k_ closest neighbors.
 //end::hnsw-algorithm[]
 
-The kNN search API supports <<knn-search-api-filter-example, restricting the search using a filter>>.
-The search will return the top `k` documents that also match the filter query.
+The kNN search API supports restricting the search using a filter. The search
+will return the top `k` documents that also match the filter query.
 
 [[knn-search-api-path-params]]
 ==== {api-path-parms-title}
@@ -152,106 +152,3 @@ the similarity between the query and document vector. See
 * The `hits.total` object contains the total number of nearest neighbor
 candidates considered, which is `num_candidates * num_shards`. The
 `hits.total.relation` will always be `eq`, indicating an exact value.
-
-[[knn-search-api-example]]
-==== {api-examples-title}
-
-===== Basic kNN search
-
-The following requests create a `dense_vector` field with indexing enabled and
-add sample documents:
-
-[source,console]
-----
-PUT my-index
-{
-  "mappings": {
-    "properties": {
-      "image_vector": {
-        "type": "dense_vector",
-        "dims": 3,
-        "index": true,
-        "similarity": "l2_norm"
-      },
-      "name": {
-        "type": "keyword"
-      },
-      "file_type": {
-        "type": "keyword"
-      }
-    }
-  }
-}
-
-PUT my-index/_doc/1?refresh
-{
-  "image_vector" : [0.5, 0.1, 2.6],
-  "name": "moose family",
-  "file_type": "jpeg"
-}
-
-PUT my-index/_doc/2?refresh
-{
-  "image_vector" : [1.0, 0.8, -0.2],
-  "name": "alpine lake",
-  "file_type": "svg"
-}
-----
-
-[[knn-search-api-filter-example]]
-===== Filtered kNN search
-
-The next request performs a kNN search filtered by the `file_type` field:
-
-[source,console]
-----
-GET my-index/_knn_search
-{
-  "knn": {
-    "field": "image_vector",
-    "query_vector": [0.3, 0.1, 1.2],
-    "k": 5,
-    "num_candidates": 50
-  },
-  "filter": {
-    "term": {
-      "file_type": "svg"
-    }
-  },
-  "_source": ["name"]
-}
-----
-// TEST[continued]
-
-[source,console-result]
-----
-{
-  "took": 5,
-  "timed_out": false,
-  "_shards": {
-    "total": 1,
-    "successful": 1,
-    "skipped": 0,
-    "failed": 0
-  },
-  "hits": {
-    "total": {
-      "value": 1,
-      "relation": "eq"
-    },
-    "max_score": 0.2538071,
-    "hits": [
-      {
-        "_index": "my-index",
-        "_id": "2",
-        "_score": 0.2538071,
-        "_source": {
-          "name": "alpine lake"
-        }
-      }
-    ]
-  }
-}
-----
-// TESTRESPONSE[s/"took": 5/"took": $body.took/]
-// TESTRESPONSE[s/,\n      \.\.\.//]

--- a/docs/reference/search/search-your-data/knn-search.asciidoc
+++ b/docs/reference/search/search-your-data/knn-search.asciidoc
@@ -113,7 +113,7 @@ significantly increase search latency.
 +
 [source,console]
 ----
-GET product-index/_search
+POST product-index/_search
 {
   "query": {
     "script_score": {
@@ -190,11 +190,11 @@ PUT image-index
 ----
 POST image-index/_bulk?refresh=true
 { "index": { "_id": "1" } }
-{ "image-vector": [0.5, 0.1, 2.6], "title": "moose family", "file-type": "jpg" }
+{ "image-vector": [1, 5, -20], "title": "moose family", "file-type": "jpg" }
 { "index": { "_id": "2" } }
-{ "image-vector": [1.0, 0.8, -0.2], "title": "alpine lake", "file-type": "png" }
+{ "image-vector": [42, 8, -15], "title": "alpine lake", "file-type": "png" }
 { "index": { "_id": "3" } }
-{ "image-vector": [1.5, 1.1, 2.3], "title": "full moon", "file-type": "jpg" }
+{ "image-vector": [15, 11, 23], "title": "full moon", "file-type": "jpg" }
 ...
 ----
 //TEST[continued]
@@ -204,11 +204,11 @@ POST image-index/_bulk?refresh=true
 +
 [source,console]
 ----
-GET image-index/_search
+POST image-index/_search
 {
   "knn": {
     "field": "image-vector",
-    "query_vector": [-0.5, 90.0, -10, 14.8, -156.0],
+    "query_vector": [-5, 9, -12],
     "k": 10,
     "num_candidates": 100
   },
@@ -260,11 +260,11 @@ The following request performs an approximate kNN search filtered by the
 
 [source,console]
 ----
-GET image-index/_search
+POST image-index/_search
 {
   "knn": {
     "field": "image-vector",
-    "query_vector": [0.3, 0.1, 1.2],
+    "query_vector": [54, 10, -2],
     "k": 5,
     "num_candidates": 50,
     "filter": {
@@ -273,7 +273,8 @@ GET image-index/_search
       }
     }
   },
-  "fields": ["title"]
+  "fields": ["title"],
+  "_source": false
 }
 ----
 // TEST[continued]
@@ -294,14 +295,14 @@ GET image-index/_search
       "value": 1,
       "relation": "eq"
     },
-    "max_score": 0.2538071,
+    "max_score": 0.003144654,
     "hits": [
       {
         "_index": "image-index",
         "_id": "2",
-        "_score": 0.2538071,
-        "_source": {
-          "title": "alpine lake"
+        "_score": 0.003144654,
+        "fields": {
+          "title": ["alpine lake"]
         }
       }
     ]
@@ -319,17 +320,19 @@ You can perform 'hybrid retrieval' by providing both the
 
 [source,console]
 ----
-GET image-index/_search
+POST image-index/_search
 {
   "query": {
     "match": {
-      "title": "mountain lake"
-    },
-    "boost": 0.9
+      "title": {
+        "query": "mountain lake",
+        "boost": 0.9
+      }
+    }
   },
   "knn": {
     "field": "image-vector",
-    "query_vector": [0.3, 0.1, 0.25],
+    "query_vector": [54, 10, -2],
     "k": 5,
     "num_candidates": 50,
     "boost": 0.1
@@ -381,7 +384,7 @@ PUT image-index
     "properties": {
       "image-vector": {
         "type": "dense_vector",
-        "dims": 5,
+        "dims": 3,
         "index": true,
         "similarity": "l2_norm",
         "index_options": {

--- a/docs/reference/search/search-your-data/knn-search.asciidoc
+++ b/docs/reference/search/search-your-data/knn-search.asciidoc
@@ -40,10 +40,11 @@ based on a similarity metric, the better its match.
 
 {es} supports two methods for kNN search:
 
-* experimental:[] <<approximate-knn,Approximate kNN>> using the kNN search API
-
 * <<exact-knn,Exact, brute-force kNN>> using a `script_score` query with a
 vector function
+
+* experimental:[] <<approximate-knn,Approximate kNN>> using the `knn` search
+option
 
 In most cases, you'll want to use approximate kNN. Approximate kNN offers lower
 latency at the cost of slower indexing and imperfect accuracy.
@@ -57,12 +58,95 @@ filter your data to a small subset of documents, you can get good search
 performance using this approach.
 
 [discrete]
+[[exact-knn]]
+=== Exact kNN
+
+To run an exact kNN search, use a `script_score` query with a vector function.
+
+. Explicitly map one or more `dense_vector` fields. If you don't intend to use
+the field for approximate kNN, omit the `index` mapping option or set it to
+`false`. This can significantly improve indexing speed.
++
+[source,console]
+----
+PUT product-index
+{
+  "mappings": {
+    "properties": {
+      "product-vector": {
+        "type": "dense_vector",
+        "dims": 5,
+        "index": false
+      },
+      "price": {
+        "type": "long"
+      }
+    }
+  }
+}
+----
+
+. Index your data.
++
+[source,console]
+----
+POST product-index/_bulk?refresh=true
+{ "index": { "_id": "1" } }
+{ "product-vector": [230.0, 300.33, -34.8988, 15.555, -200.0], "price": 1599 }
+{ "index": { "_id": "2" } }
+{ "product-vector": [-0.5, 100.0, -13.0, 14.8, -156.0], "price": 799 }
+{ "index": { "_id": "3" } }
+{ "product-vector": [0.5, 111.3, -13.0, 14.8, -156.0], "price": 1099 }
+...
+----
+//TEST[continued]
+//TEST[s/\.\.\.//]
+
+. Use the <<search-search,search API>> to run a `script_score` query containing
+a <<vector-functions,vector function>>.
++
+TIP: To limit the number of matched documents passed to the vector function, we
+recommend you specify a filter query in the `script_score.query` parameter. If
+needed, you can use a <<query-dsl-match-all-query,`match_all` query>> in this
+parameter to match all documents. However, matching all documents can
+significantly increase search latency.
++
+[source,console]
+----
+GET product-index/_search
+{
+  "query": {
+    "script_score": {
+      "query" : {
+        "bool" : {
+          "filter" : {
+            "range" : {
+              "price" : {
+                "gte": 1000
+              }
+            }
+          }
+        }
+      },
+      "script": {
+        "source": "cosineSimilarity(params.queryVector, 'product-vector') + 1.0",
+        "params": {
+          "queryVector": [-0.5, 90.0, -10, 14.8, -156.0]
+        }
+      }
+    }
+  }
+}
+----
+//TEST[continued]
+
+[discrete]
 [[approximate-knn]]
 === Approximate kNN
 
 experimental::[]
 
-To run an approximate kNN search, use the <<knn-search-api, kNN search API>>
+To run an approximate kNN search, use the <<search-api-knn, `knn` option>>
 to search a `dense_vector` field with indexing enabled.
 
 . Explicitly map one or more `dense_vector` fields. Approximate kNN search
@@ -78,17 +162,20 @@ parameter documentation.
 
 [source,console]
 ----
-PUT my-approx-knn-index
+PUT image-index
 {
   "mappings": {
     "properties": {
-      "my-image-vector": {
+      "image-vector": {
         "type": "dense_vector",
-        "dims": 5,
+        "dims": 3,
         "index": true,
         "similarity": "l2_norm"
       },
-      "my-tag": {
+      "title": {
+        "type": "text"
+      },
+      "file-type": {
         "type": "keyword"
       }
     }
@@ -101,39 +188,41 @@ PUT my-approx-knn-index
 +
 [source,console]
 ----
-POST my-approx-knn-index/_bulk?refresh=true
+POST image-index/_bulk?refresh=true
 { "index": { "_id": "1" } }
-{ "my-image-vector": [230.0, 300.33, -34.8988, 15.555, -200.0], "my-tag": "cow.jpg" }
+{ "image-vector": [0.5, 0.1, 2.6], "title": "moose family", "file-type": "jpg" }
 { "index": { "_id": "2" } }
-{ "my-image-vector": [-0.5, 100.0, -13.0, 14.8, -156.0], "my-tag": "moose.jpg" }
+{ "image-vector": [1.0, 0.8, -0.2], "title": "alpine lake", "file-type": "png" }
 { "index": { "_id": "3" } }
-{ "my-image-vector": [0.5, 111.3, -13.0, 14.8, -156.0], "my-tag": "rabbit.jpg" }
+{ "image-vector": [1.5, 1.1, 2.3], "title": "full moon", "file-type": "jpg" }
 ...
 ----
 //TEST[continued]
 //TEST[s/\.\.\.//]
 
-. Run the search using the <<knn-search-api,kNN search API>>.
+. Run the search using the <<search-api-knn, `knn` option>>.
 +
 [source,console]
 ----
-GET my-approx-knn-index/_knn_search
+GET image-index/_search
 {
   "knn": {
-    "field": "my-image-vector",
+    "field": "image-vector",
     "query_vector": [-0.5, 90.0, -10, 14.8, -156.0],
     "k": 10,
     "num_candidates": 100
   },
-  "fields": [
-    "my-image-vector",
-    "my-tag"
-  ]
+  "fields": [ "title", "file-type" ]
 }
 ----
 //TEST[continued]
 // TEST[s/"k": 10/"k": 3/]
 // TEST[s/"num_candidates": 100/"num_candidates": 3/]
+
+The <<search-api-response-body-score,document `_score`>> is determined by
+the similarity between the query and document vector. See
+<<dense-vector-similarity, `similarity`>> for more information on how kNN
+search scores are computed.
 
 NOTE: Support for approximate kNN search was added in version 8.0. Before
 this, `dense_vector` fields did not support enabling `index` in the mapping.
@@ -160,6 +249,109 @@ Similarly, you can decrease `num_candidates` for faster searches with
 potentially less accurate results.
 
 [discrete]
+[[knn-search-filter-example]]
+==== Filtered kNN search
+
+The kNN search API supports restricting the search using a filter. The search
+will return the top `k` documents that also match the filter query.
+
+The following request performs an approximate kNN search filtered by the
+`file-type` field:
+
+[source,console]
+----
+GET image-index/_search
+{
+  "knn": {
+    "field": "image-vector",
+    "query_vector": [0.3, 0.1, 1.2],
+    "k": 5,
+    "num_candidates": 50,
+    "filter": {
+      "term": {
+        "file-type": "png"
+      }
+    }
+  },
+  "fields": ["title"]
+}
+----
+// TEST[continued]
+
+[source,console-result]
+----
+{
+  "took": 5,
+  "timed_out": false,
+  "_shards": {
+    "total": 1,
+    "successful": 1,
+    "skipped": 0,
+    "failed": 0
+  },
+  "hits": {
+    "total": {
+      "value": 1,
+      "relation": "eq"
+    },
+    "max_score": 0.2538071,
+    "hits": [
+      {
+        "_index": "image-index",
+        "_id": "2",
+        "_score": 0.2538071,
+        "_source": {
+          "title": "alpine lake"
+        }
+      }
+    ]
+  }
+}
+----
+// TESTRESPONSE[s/"took": 5/"took": $body.took/]
+// TESTRESPONSE[s/,\n      \.\.\.//]
+
+[discrete]
+==== Combine approximate kNN and a query
+
+You can perform 'hybrid retrieval' by providing both the
+<<search-api-knn, `knn` option>> and a <<request-body-search-query, `query`>>:
+
+[source,console]
+----
+GET image-index/_search
+{
+  "query": {
+    "match": {
+      "title": "mountain lake"
+    },
+    "boost": 0.9
+  },
+  "knn": {
+    "field": "image-vector",
+    "query_vector": [0.3, 0.1, 0.25],
+    "k": 5,
+    "num_candidates": 50,
+    "boost": 0.1
+  },
+  "size": 10
+}
+----
+// TEST[continued]
+
+This search finds the global top `k = 5` vector matches, combines them with the matches from the `match` query, and
+finally returns the 10 top-scoring results. The `knn` and `query` matches are combined through a disjunction, as if you
+took a boolean 'or' between them. The top `k` vector results represent the global nearest neighbors across all index
+shards.
+
+The score of each hit is the sum of the `knn` and `query` scores. You can specify a `boost` value to give a weight to
+each score in the sum. In the example above, the scores will be calculated as
+
+```
+score = 0.9 * match_score + 0.1 * knn_score
+```
+
+[discrete]
 [[knn-indexing-considerations]]
 ==== Indexing considerations
 
@@ -176,97 +368,52 @@ all-inclusive HNSW graph. When there are multiple segments, kNN search must
 check several smaller HNSW graphs as it searches each segment after another.
 You should only force merge an index if it is no longer being written to.
 
+The HNSW algorithm has index-time parameters that trade off between the cost of
+building the graph, search speed, and accuracy. When setting up the
+`dense_vector` mapping, you can use the <<dense-vector-index-options, `index_options`>>
+argument to adjust these parameters:
+
+[source,console]
+----
+PUT image-index
+{
+  "mappings": {
+    "properties": {
+      "image-vector": {
+        "type": "dense_vector",
+        "dims": 5,
+        "index": true,
+        "similarity": "l2_norm",
+        "index_options": {
+          "type": "hnsw",
+          "m": 32,
+          "ef_construction": 100
+        }
+      }
+    }
+  }
+}
+----
+
 [discrete]
 [[approximate-knn-limitations]]
 ==== Limitations for approximate kNN search
 
 * You can't run an approximate kNN search on a <<filter-alias,filtered alias>>.
+Running a kNN search against a filtered alias may incorrectly result in fewer
+than `k` hits.
 
 * You can't run an approximate kNN search on a `dense_vector` field within a
 <<nested,`nested`>> mapping.
 
+* When using kNN search in <<modules-cross-cluster-search,{ccs}>>, the <<ccs-min-roundtrips,`ccs_minimize_roundtrips`>>
+option is not supported.
+
 * {blank}
 include::{es-repo-dir}/search/knn-search.asciidoc[tag=hnsw-algorithm]
 
-[discrete]
-[[exact-knn]]
-=== Exact kNN
+NOTE: Approximate kNN search always uses the
+<<dfs-query-then-fetch,`dfs_query_then_fetch`>> search type in order to gather
+the global top `k` matches across shards. You cannot set the
+`search_type` explicitly when running kNN search.
 
-To run an exact kNN search, use a `script_score` query with a vector function.
-
-. Explicitly map one or more `dense_vector` fields. If you don't intend to use
-the field for approximate kNN, omit the `index` mapping option or set it to
-`false`. This can significantly improve indexing speed.
-+
-[source,console]
-----
-PUT my-exact-knn-index
-{
-  "mappings": {
-    "properties": {
-      "my-product-vector": {
-        "type": "dense_vector",
-        "dims": 5,
-        "index": false
-      },
-      "my-price": {
-        "type": "long"
-      }
-    }
-  }
-}
-----
-
-. Index your data.
-+
-[source,console]
-----
-POST my-exact-knn-index/_bulk?refresh=true
-{ "index": { "_id": "1" } }
-{ "my-product-vector": [230.0, 300.33, -34.8988, 15.555, -200.0], "my-price": 1599 }
-{ "index": { "_id": "2" } }
-{ "my-product-vector": [-0.5, 100.0, -13.0, 14.8, -156.0], "my-price": 799 }
-{ "index": { "_id": "3" } }
-{ "my-product-vector": [0.5, 111.3, -13.0, 14.8, -156.0], "my-price": 1099 }
-...
-----
-//TEST[continued]
-//TEST[s/\.\.\.//]
-
-. Use the <<search-search,search API>> to run a `script_score` query containing
-a <<vector-functions,vector function>>.
-+
-TIP: To limit the number of matched documents passed to the vector function, we
-recommend you specify a filter query in the `script_score.query` parameter. If
-needed, you can use a <<query-dsl-match-all-query,`match_all` query>> in this
-parameter to match all documents. However, matching all documents can
-significantly increase search latency.
-+
-[source,console]
-----
-GET my-exact-knn-index/_search
-{
-  "query": {
-    "script_score": {
-      "query" : {
-        "bool" : {
-          "filter" : {
-            "range" : {
-              "my-price" : {
-                "gte": 1000
-              }
-            }
-          }
-        }
-      },
-      "script": {
-        "source": "cosineSimilarity(params.queryVector, 'my-product-vector') + 1.0",
-        "params": {
-          "queryVector": [-0.5, 90.0, -10, 14.8, -156.0]
-        }
-      }
-    }
-  }
-}
-----
-//TEST[continued]

--- a/docs/reference/search/search.asciidoc
+++ b/docs/reference/search/search.asciidoc
@@ -483,7 +483,8 @@ A boost value greater than `1.0` increases the score. A boost value between
 experimental::[]
 [[search-api-knn]]
 `knn`::
-(Required, object) Defines the kNN query to run.
+(Optional, object) Defines the <<approximate-knn, approximate kNN search>> to
+run.
 +
 .Properties of `knn` object
 [%collapsible%open]

--- a/docs/reference/search/search.asciidoc
+++ b/docs/reference/search/search.asciidoc
@@ -480,6 +480,39 @@ A boost value greater than `1.0` increases the score. A boost value between
 `0` and `1.0` decreases the score.
 ====
 
+experimental::[]
+[[search-api-knn]]
+`knn`::
+(Required, object) Defines the kNN query to run.
++
+.Properties of `knn` object
+[%collapsible%open]
+====
+`field`::
+(Required, string) The name of the vector field to search against. Must be a
+<<index-vectors-knn-search, `dense_vector` field with indexing enabled>>.
+
+`query_vector`::
+(Required, array of floats) Query vector. Must have the same number of
+dimensions as the vector field you are searching against.
+
+`k`::
+(Required, integer) Number of nearest neighbors to return as top hits. This
+value must be less than `num_candidates`.
+
+`num_candidates`::
+(Required, integer) The number of nearest neighbor candidates to consider per
+shard. Cannot exceed 10,000. {es} collects `num_candidates` results from each
+shard, then merges them to find the top `k` results. Increasing
+`num_candidates` tends to improve the accuracy of the final `k` results.
+
+`filter`::
+(Optional, <<query-dsl,Query DSL object>>) Query to filter the documents that
+can match. The kNN search will return the top `k` documents that also match
+this filter. The value can be a single query or a list of queries. If `filter`
+is not provided, all documents are allowed to match.
+====
+
 [[search-api-min-score]]
 `min_score`::
 (Optional, float)


### PR DESCRIPTION
This change adds docs for the new search `knn` option:
* Add `knn` option to `_search` API docs.
* Update the kNN search guide to use the `_search` endpoint instead of
`_knn_search` endpoint. Move relevant information from the `_knn_search` API
docs to this guide, like the filtering example.
* Add an example to the kNN search guide of configuring `index_options` (just
seemed nice to have, not core to this change).

The PR doesn't deprecate the `_knn_search` endpoint yet.

Addresses #87625.