### PR TITLE
Fix testWaitOnPrimaryShardThrottled

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/ThrottlingAllocationDecider.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/ThrottlingAllocationDecider.java
@@ -135,7 +135,9 @@ public class ThrottlingAllocationDecider extends AllocationDecider {
                     primariesInRecovery++;
                 }
             }
-            if (primariesInRecovery >= primariesInitialRecoveries) {
+            if (allocation.isSimulating()) {
+                return allocation.decision(Decision.YES, NAME, "primary allocation is not throttled when simulating");
+            } else if (primariesInRecovery >= primariesInitialRecoveries) {
                 // TODO: Should index creation not be throttled for primary shards?
                 return allocation.decision(
                     THROTTLE,

--- a/x-pack/plugin/fleet/src/internalClusterTest/java/org/elasticsearch/xpack/fleet/action/GetGlobalCheckpointsActionIT.java
+++ b/x-pack/plugin/fleet/src/internalClusterTest/java/org/elasticsearch/xpack/fleet/action/GetGlobalCheckpointsActionIT.java
@@ -400,7 +400,6 @@ public class GetGlobalCheckpointsActionIT extends ESIntegTestCase {
         assertFalse(response.timedOut());
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/86429")
     public void testWaitOnPrimaryShardThrottled() throws Exception {
 
         client().admin()


### PR DESCRIPTION
Bypass initializing primaries throttling when simulating

