### PR TITLE
Allocation reason

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/allocation/TransportClusterAllocationExplainAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/allocation/TransportClusterAllocationExplainAction.java
@@ -97,7 +97,8 @@ public class TransportClusterAllocationExplainAction extends TransportMasterNode
             state,
             clusterInfo,
             snapshotsInfoService.snapshotShardSizes(),
-            System.nanoTime()
+            System.nanoTime(),
+            "TransportClusterAllocationExplainAction"
         );
 
         ShardRouting shardRouting = findShardToExplain(request, allocation);

--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/AllocationService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/AllocationService.java
@@ -136,7 +136,8 @@ public class AllocationService {
             clusterState,
             clusterInfoService.getClusterInfo(),
             snapshotsInfoService.snapshotShardSizes(),
-            currentNanoTime()
+            currentNanoTime(),
+            "applyStartedShards"
         );
         // as starting a primary relocation target can reinitialize replica shards, start replicas first
         startedShards = new ArrayList<>(startedShards);
@@ -215,7 +216,8 @@ public class AllocationService {
             tmpState,
             clusterInfoService.getClusterInfo(),
             snapshotsInfoService.snapshotShardSizes(),
-            currentNanoTime
+            currentNanoTime,
+            "applyFailedShards"
         );
 
         for (FailedShard failedShardEntry : failedShards) {
@@ -289,7 +291,8 @@ public class AllocationService {
             clusterState,
             clusterInfoService.getClusterInfo(),
             snapshotsInfoService.snapshotShardSizes(),
-            currentNanoTime()
+            currentNanoTime(),
+            reason
         );
 
         // first, clear from the shards any node id they used to belong to that is now dead
@@ -451,7 +454,8 @@ public class AllocationService {
             clusterState,
             clusterInfoService.getClusterInfo(),
             snapshotsInfoService.snapshotShardSizes(),
-            currentNanoTime()
+            currentNanoTime(),
+            "reroute commands"
         );
         // don't short circuit deciders, we want a full explanation
         allocation.debugDecision(true);
@@ -496,7 +500,8 @@ public class AllocationService {
             fixedClusterState,
             clusterInfoService.getClusterInfo(),
             snapshotsInfoService.snapshotShardSizes(),
-            currentNanoTime()
+            currentNanoTime(),
+            reason
         );
         if (listener == DesiredBalanceShardsAllocator.REMOVE_ME) {
             logger.warn("Executing reroute [{}] using [REMOVE_ME] listener, async result is ignored", reason);

--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/AllocationService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/AllocationService.java
@@ -318,7 +318,8 @@ public class AllocationService {
             clusterState,
             clusterInfoService.getClusterInfo(),
             snapshotsInfoService.snapshotShardSizes(),
-            currentNanoTime()
+            currentNanoTime(),
+            "adaptAutoExpandReplicas"
         );
         final Map<Integer, List<String>> autoExpandReplicaChanges = AutoExpandReplicas.getAutoExpandReplicaChanges(
             clusterState.metadata(),

--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/RoutingAllocation.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/RoutingAllocation.java
@@ -86,17 +86,6 @@ public class RoutingAllocation {
         this(deciders, null, clusterState, clusterInfo, shardSizeInfo, currentNanoTime, false, null);
     }
 
-    public RoutingAllocation(
-        AllocationDeciders deciders,
-        @Nullable RoutingNodes routingNodes,
-        ClusterState clusterState,
-        ClusterInfo clusterInfo,
-        SnapshotShardSizeInfo shardSizeInfo,
-        long currentNanoTime
-    ) {
-        this(deciders, routingNodes, clusterState, clusterInfo, shardSizeInfo, currentNanoTime, false, null);
-    }
-
     /**
      * Creates a new {@link RoutingAllocation}
      * @param deciders {@link AllocationDeciders} to used to make decisions for routing allocations
@@ -373,6 +362,10 @@ public class RoutingAllocation {
      */
     public boolean isSimulating() {
         return isSimulating;
+    }
+
+    public String getReason() {
+        return reason;
     }
 
     public RoutingAllocation immutableClone() {

--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/RoutingAllocation.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/RoutingAllocation.java
@@ -62,7 +62,6 @@ public class RoutingAllocation {
 
     private final long currentNanoTime;
     private final boolean isSimulating;
-    @Nullable
     private final String reason;
 
     private final IndexMetadataUpdater indexMetadataUpdater = new IndexMetadataUpdater();
@@ -103,7 +102,7 @@ public class RoutingAllocation {
         ClusterInfo clusterInfo,
         SnapshotShardSizeInfo shardSizeInfo,
         long currentNanoTime,
-        @Nullable String reason
+        String reason
     ) {
         this(deciders, routingNodes, clusterState, clusterInfo, shardSizeInfo, currentNanoTime, false, reason);
     }
@@ -125,7 +124,7 @@ public class RoutingAllocation {
         SnapshotShardSizeInfo shardSizeInfo,
         long currentNanoTime,
         boolean isSimulating,
-        @Nullable String reason
+        String reason
     ) {
         this.deciders = deciders;
         this.routingNodes = routingNodes;

--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/RoutingAllocation.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/RoutingAllocation.java
@@ -80,9 +80,10 @@ public class RoutingAllocation {
         ClusterState clusterState,
         ClusterInfo clusterInfo,
         SnapshotShardSizeInfo shardSizeInfo,
-        long currentNanoTime
+        long currentNanoTime,
+        String reason
     ) {
-        this(deciders, null, clusterState, clusterInfo, shardSizeInfo, currentNanoTime, false, null);
+        this(deciders, null, clusterState, clusterInfo, shardSizeInfo, currentNanoTime, false, reason);
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/RoutingAllocation.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/RoutingAllocation.java
@@ -369,7 +369,7 @@ public class RoutingAllocation {
     }
 
     public RoutingAllocation immutableClone() {
-        return new RoutingAllocation(deciders, clusterState, clusterInfo, shardSizeInfo, currentNanoTime);
+        return new RoutingAllocation(deciders, null, clusterState, clusterInfo, shardSizeInfo, currentNanoTime, false, reason);
     }
 
     public RoutingAllocation mutableCloneForSimulation() {

--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/ShardsAvailabilityHealthIndicatorService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/ShardsAvailabilityHealthIndicatorService.java
@@ -444,7 +444,8 @@ public class ShardsAvailabilityHealthIndicatorService implements HealthIndicator
             state,
             ClusterInfo.EMPTY,
             SnapshotShardSizeInfo.EMPTY,
-            System.nanoTime()
+            System.nanoTime(),
+            "explainAllocationsAndDiagnoseDeciders"
         );
         allocation.setDebugMode(RoutingAllocation.DebugMode.ON);
         ShardAllocationDecision shardAllocationDecision = allocationService.explainShardAllocation(shardRouting, allocation);

--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/allocator/ContinuousComputation.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/allocator/ContinuousComputation.java
@@ -41,8 +41,11 @@ public abstract class ContinuousComputation<T> {
      */
     public void onNewInput(T input) {
         assert input != null;
-        if (enqueuedInput.getAndSet(Objects.requireNonNull(input)) == null) {
+        T previous = enqueuedInput.getAndSet(Objects.requireNonNull(input));
+        if (previous == null) {
             executorService.execute(processor);
+        } else {
+            onSupersedingInput(previous);
         }
     }
 
@@ -67,6 +70,8 @@ public abstract class ContinuousComputation<T> {
      * @param input the value that was last received by {@link #onNewInput} before invocation.
      */
     protected abstract void processInput(T input);
+
+    protected void onSupersedingInput(T value) {}
 
     private class Processor extends AbstractRunnable {
 

--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/allocator/DesiredBalanceInput.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/allocator/DesiredBalanceInput.java
@@ -19,4 +19,9 @@ import java.util.List;
  * @param routingAllocation a copy of (the immutable parts of) the context for the allocation decision process
  * @param ignoredShards     a list of the shards for which earlier allocators have claimed responsibility
  */
-public record DesiredBalanceInput(long index, RoutingAllocation routingAllocation, List<ShardRouting> ignoredShards) {}
+public record DesiredBalanceInput(long index, RoutingAllocation routingAllocation, List<ShardRouting> ignoredShards) {
+
+    public String getReason() {
+        return routingAllocation.getReason();
+    }
+}

--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/allocation/ClusterAllocationExplainActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/allocation/ClusterAllocationExplainActionTests.java
@@ -55,7 +55,8 @@ public class ClusterAllocationExplainActionTests extends ESTestCase {
             clusterState,
             null,
             null,
-            System.nanoTime()
+            System.nanoTime(),
+            "test"
         );
         ClusterAllocationExplanation cae = TransportClusterAllocationExplainAction.explainShard(
             shard,
@@ -269,6 +270,6 @@ public class ClusterAllocationExplainActionTests extends ESTestCase {
     }
 
     private static RoutingAllocation routingAllocation(ClusterState clusterState) {
-        return new RoutingAllocation(NOOP_DECIDERS, clusterState, null, null, System.nanoTime());
+        return new RoutingAllocation(NOOP_DECIDERS, clusterState, null, null, System.nanoTime(), "test");
     }
 }

--- a/server/src/test/java/org/elasticsearch/cluster/routing/allocation/AllocationCommandsTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/allocation/AllocationCommandsTests.java
@@ -772,7 +772,7 @@ public class AllocationCommandsTests extends ESAllocationTestCase {
             ClusterInfo.EMPTY,
             SnapshotShardSizeInfo.EMPTY,
             System.nanoTime(),
-            null
+            "test"
         );
         logger.info("--> executing move allocation command to non-data node");
         IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> command.execute(routingAllocation, false));
@@ -840,7 +840,7 @@ public class AllocationCommandsTests extends ESAllocationTestCase {
             ClusterInfo.EMPTY,
             SnapshotShardSizeInfo.EMPTY,
             System.nanoTime(),
-            null
+            "test"
         );
         logger.info("--> executing move allocation command from non-data node");
         IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> command.execute(routingAllocation, false));

--- a/server/src/test/java/org/elasticsearch/cluster/routing/allocation/AllocationCommandsTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/allocation/AllocationCommandsTests.java
@@ -771,7 +771,8 @@ public class AllocationCommandsTests extends ESAllocationTestCase {
             clusterState,
             ClusterInfo.EMPTY,
             SnapshotShardSizeInfo.EMPTY,
-            System.nanoTime()
+            System.nanoTime(),
+            null
         );
         logger.info("--> executing move allocation command to non-data node");
         IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> command.execute(routingAllocation, false));
@@ -838,7 +839,8 @@ public class AllocationCommandsTests extends ESAllocationTestCase {
             clusterState,
             ClusterInfo.EMPTY,
             SnapshotShardSizeInfo.EMPTY,
-            System.nanoTime()
+            System.nanoTime(),
+            null
         );
         logger.info("--> executing move allocation command from non-data node");
         IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> command.execute(routingAllocation, false));

--- a/server/src/test/java/org/elasticsearch/cluster/routing/allocation/AllocationServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/allocation/AllocationServiceTests.java
@@ -258,7 +258,8 @@ public class AllocationServiceTests extends ESTestCase {
             clusterState,
             ClusterInfo.EMPTY,
             null,
-            0L
+            0L,
+            "test"
         );
         allocation.setDebugMode(randomBoolean() ? RoutingAllocation.DebugMode.ON : RoutingAllocation.DebugMode.EXCLUDE_YES_DECISIONS);
 

--- a/server/src/test/java/org/elasticsearch/cluster/routing/allocation/AwarenessAllocationTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/allocation/AwarenessAllocationTests.java
@@ -1108,7 +1108,8 @@ public class AwarenessAllocationTests extends ESAllocationTestCase {
             clusterState,
             null,
             null,
-            0L
+            0L,
+            "test"
         );
         routingAllocation.debugDecision(true);
 

--- a/server/src/test/java/org/elasticsearch/cluster/routing/allocation/BalancedSingleShardTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/allocation/BalancedSingleShardTests.java
@@ -379,7 +379,8 @@ public class BalancedSingleShardTests extends ESAllocationTestCase {
             state,
             ClusterInfo.EMPTY,
             SnapshotShardSizeInfo.EMPTY,
-            System.nanoTime()
+            System.nanoTime(),
+            null
         );
         allocation.debugDecision(true);
         return allocation;

--- a/server/src/test/java/org/elasticsearch/cluster/routing/allocation/BalancedSingleShardTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/allocation/BalancedSingleShardTests.java
@@ -380,7 +380,7 @@ public class BalancedSingleShardTests extends ESAllocationTestCase {
             ClusterInfo.EMPTY,
             SnapshotShardSizeInfo.EMPTY,
             System.nanoTime(),
-            null
+            "test"
         );
         allocation.debugDecision(true);
         return allocation;

--- a/server/src/test/java/org/elasticsearch/cluster/routing/allocation/MaxRetryAllocationDeciderTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/allocation/MaxRetryAllocationDeciderTests.java
@@ -187,7 +187,7 @@ public class MaxRetryAllocationDeciderTests extends ESAllocationTestCase {
                 new MaxRetryAllocationDecider().canForceAllocatePrimary(
                     unassignedPrimary,
                     null,
-                    new RoutingAllocation(null, clusterState, null, null, 0)
+                    new RoutingAllocation(null, clusterState, null, null, 0, "test")
                 )
             );
         }
@@ -211,7 +211,7 @@ public class MaxRetryAllocationDeciderTests extends ESAllocationTestCase {
                 new MaxRetryAllocationDecider().canForceAllocatePrimary(
                     unassignedPrimary,
                     null,
-                    new RoutingAllocation(null, clusterState, null, null, 0)
+                    new RoutingAllocation(null, clusterState, null, null, 0, "test")
                 )
             );
         }
@@ -251,7 +251,7 @@ public class MaxRetryAllocationDeciderTests extends ESAllocationTestCase {
             new MaxRetryAllocationDecider().canForceAllocatePrimary(
                 routingTable.index("idx").shard(0).shard(0),
                 null,
-                new RoutingAllocation(null, clusterState, null, null, 0)
+                new RoutingAllocation(null, clusterState, null, null, 0, "test")
             )
         );
 
@@ -283,7 +283,7 @@ public class MaxRetryAllocationDeciderTests extends ESAllocationTestCase {
             new MaxRetryAllocationDecider().canForceAllocatePrimary(
                 unassignedPrimary,
                 null,
-                new RoutingAllocation(null, clusterState, null, null, 0)
+                new RoutingAllocation(null, clusterState, null, null, 0, "test")
             )
         );
     }

--- a/server/src/test/java/org/elasticsearch/cluster/routing/allocation/NodeVersionAllocationDeciderTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/allocation/NodeVersionAllocationDeciderTests.java
@@ -681,7 +681,7 @@ public class NodeVersionAllocationDeciderTests extends ESAllocationTestCase {
             routingNodes.initializeShard(primaryShard, "newNode", null, 0, routingChangesObserver),
             routingChangesObserver
         );
-        routingAllocation = new RoutingAllocation(null, routingNodes, clusterState, null, null, 0, null);
+        routingAllocation = new RoutingAllocation(null, routingNodes, clusterState, null, null, 0, "test");
         routingAllocation.debugDecision(true);
 
         decision = allocationDecider.canAllocate(replicaShard, oldNode, routingAllocation);
@@ -702,7 +702,7 @@ public class NodeVersionAllocationDeciderTests extends ESAllocationTestCase {
             routingNodes.relocateShard(startedPrimary, "oldNode", 0, routingChangesObserver).v2(),
             routingChangesObserver
         );
-        routingAllocation = new RoutingAllocation(null, routingNodes, clusterState, null, null, 0, null);
+        routingAllocation = new RoutingAllocation(null, routingNodes, clusterState, null, null, 0, "test");
         routingAllocation.debugDecision(true);
 
         decision = allocationDecider.canAllocate(replicaShard, newNode, routingAllocation);

--- a/server/src/test/java/org/elasticsearch/cluster/routing/allocation/NodeVersionAllocationDeciderTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/allocation/NodeVersionAllocationDeciderTests.java
@@ -681,7 +681,7 @@ public class NodeVersionAllocationDeciderTests extends ESAllocationTestCase {
             routingNodes.initializeShard(primaryShard, "newNode", null, 0, routingChangesObserver),
             routingChangesObserver
         );
-        routingAllocation = new RoutingAllocation(null, routingNodes, clusterState, null, null, 0);
+        routingAllocation = new RoutingAllocation(null, routingNodes, clusterState, null, null, 0, null);
         routingAllocation.debugDecision(true);
 
         decision = allocationDecider.canAllocate(replicaShard, oldNode, routingAllocation);
@@ -702,7 +702,7 @@ public class NodeVersionAllocationDeciderTests extends ESAllocationTestCase {
             routingNodes.relocateShard(startedPrimary, "oldNode", 0, routingChangesObserver).v2(),
             routingChangesObserver
         );
-        routingAllocation = new RoutingAllocation(null, routingNodes, clusterState, null, null, 0);
+        routingAllocation = new RoutingAllocation(null, routingNodes, clusterState, null, null, 0, null);
         routingAllocation.debugDecision(true);
 
         decision = allocationDecider.canAllocate(replicaShard, newNode, routingAllocation);

--- a/server/src/test/java/org/elasticsearch/cluster/routing/allocation/NodeVersionAllocationDeciderTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/allocation/NodeVersionAllocationDeciderTests.java
@@ -592,7 +592,7 @@ public class NodeVersionAllocationDeciderTests extends ESAllocationTestCase {
         final ShardRouting primaryShard = clusterState.routingTable().shardRoutingTable(shardId).primaryShard();
         final ShardRouting replicaShard = clusterState.routingTable().shardRoutingTable(shardId).replicaShards().get(0);
 
-        RoutingAllocation routingAllocation = new RoutingAllocation(null, clusterState, null, null, 0);
+        RoutingAllocation routingAllocation = new RoutingAllocation(null, clusterState, null, null, 0, "test");
         routingAllocation.debugDecision(true);
 
         final NodeVersionAllocationDecider allocationDecider = new NodeVersionAllocationDecider();

--- a/server/src/test/java/org/elasticsearch/cluster/routing/allocation/ResizeAllocationDeciderTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/allocation/ResizeAllocationDeciderTests.java
@@ -111,7 +111,7 @@ public class ResizeAllocationDeciderTests extends ESAllocationTestCase {
     public void testNonResizeRouting() {
         ClusterState clusterState = createInitialClusterState(true);
         ResizeAllocationDecider resizeAllocationDecider = new ResizeAllocationDecider();
-        RoutingAllocation routingAllocation = new RoutingAllocation(null, clusterState, null, null, 0);
+        RoutingAllocation routingAllocation = new RoutingAllocation(null, clusterState, null, null, 0, "test");
         ShardRouting shardRouting = TestShardRouting.newShardRouting("non-resize", 0, null, true, ShardRoutingState.UNASSIGNED);
         assertEquals(Decision.ALWAYS, resizeAllocationDecider.canAllocate(shardRouting, routingAllocation));
         assertEquals(
@@ -140,7 +140,7 @@ public class ResizeAllocationDeciderTests extends ESAllocationTestCase {
         Index idx = clusterState.metadata().index("target").getIndex();
 
         ResizeAllocationDecider resizeAllocationDecider = new ResizeAllocationDecider();
-        RoutingAllocation routingAllocation = new RoutingAllocation(null, clusterState, null, null, 0);
+        RoutingAllocation routingAllocation = new RoutingAllocation(null, clusterState, null, null, 0, "test");
         ShardRouting shardRouting = TestShardRouting.newShardRouting(
             new ShardId(idx, 0),
             null,
@@ -179,7 +179,7 @@ public class ResizeAllocationDeciderTests extends ESAllocationTestCase {
         Index idx = clusterState.metadata().index("target").getIndex();
 
         ResizeAllocationDecider resizeAllocationDecider = new ResizeAllocationDecider();
-        RoutingAllocation routingAllocation = new RoutingAllocation(null, clusterState, null, null, 0);
+        RoutingAllocation routingAllocation = new RoutingAllocation(null, clusterState, null, null, 0, "test");
         int shardId = randomIntBetween(0, 3);
         int sourceShardId = IndexMetadata.selectSplitShard(shardId, clusterState.metadata().index("source"), 4).id();
         ShardRouting shardRouting = TestShardRouting.newShardRouting(
@@ -236,7 +236,7 @@ public class ResizeAllocationDeciderTests extends ESAllocationTestCase {
         Index idx = clusterState.metadata().index("target").getIndex();
 
         ResizeAllocationDecider resizeAllocationDecider = new ResizeAllocationDecider();
-        RoutingAllocation routingAllocation = new RoutingAllocation(null, clusterState, null, null, 0);
+        RoutingAllocation routingAllocation = new RoutingAllocation(null, clusterState, null, null, 0, "test");
         int shardId = randomIntBetween(0, 3);
         int sourceShardId = IndexMetadata.selectSplitShard(shardId, clusterState.metadata().index("source"), 4).id();
         ShardRouting shardRouting = TestShardRouting.newShardRouting(
@@ -332,7 +332,7 @@ public class ResizeAllocationDeciderTests extends ESAllocationTestCase {
             .build();
 
         var decider = new ResizeAllocationDecider();
-        var allocation = new RoutingAllocation(new AllocationDeciders(List.of(decider)), clusterState, null, null, 0);
+        var allocation = new RoutingAllocation(new AllocationDeciders(List.of(decider)), clusterState, null, null, 0, "test");
 
         var localRecoveryShard = ShardRouting.newUnassigned(
             new ShardId(target.getIndex(), 0),

--- a/server/src/test/java/org/elasticsearch/cluster/routing/allocation/SameShardRoutingTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/allocation/SameShardRoutingTests.java
@@ -313,7 +313,7 @@ public class SameShardRoutingTests extends ESAllocationTestCase {
             ClusterInfo.EMPTY,
             SnapshotShardSizeInfo.EMPTY,
             System.nanoTime(),
-            null
+            "test"
         );
 
         // can't force allocate same shard copy to the same node

--- a/server/src/test/java/org/elasticsearch/cluster/routing/allocation/SameShardRoutingTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/allocation/SameShardRoutingTests.java
@@ -312,7 +312,8 @@ public class SameShardRoutingTests extends ESAllocationTestCase {
             clusterState,
             ClusterInfo.EMPTY,
             SnapshotShardSizeInfo.EMPTY,
-            System.nanoTime()
+            System.nanoTime(),
+            null
         );
 
         // can't force allocate same shard copy to the same node

--- a/server/src/test/java/org/elasticsearch/cluster/routing/allocation/SameShardRoutingTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/allocation/SameShardRoutingTests.java
@@ -221,7 +221,8 @@ public class SameShardRoutingTests extends ESAllocationTestCase {
                 clusterState,
                 null,
                 null,
-                0L
+                0L,
+                "test"
             );
             routingAllocation.debugDecision(true);
 

--- a/server/src/test/java/org/elasticsearch/cluster/routing/allocation/allocator/BalancedShardsAllocatorTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/allocation/allocator/BalancedShardsAllocatorTests.java
@@ -69,7 +69,8 @@ public class BalancedShardsAllocatorTests extends ESAllocationTestCase {
             clusterState,
             ClusterInfo.EMPTY,
             SnapshotShardSizeInfo.EMPTY,
-            System.nanoTime()
+            System.nanoTime(),
+            null
         );
 
         allocation.debugDecision(false);

--- a/server/src/test/java/org/elasticsearch/cluster/routing/allocation/allocator/BalancedShardsAllocatorTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/allocation/allocator/BalancedShardsAllocatorTests.java
@@ -70,7 +70,7 @@ public class BalancedShardsAllocatorTests extends ESAllocationTestCase {
             ClusterInfo.EMPTY,
             SnapshotShardSizeInfo.EMPTY,
             System.nanoTime(),
-            null
+            "test"
         );
 
         allocation.debugDecision(false);

--- a/server/src/test/java/org/elasticsearch/cluster/routing/allocation/allocator/DesiredBalanceComputerTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/allocation/allocator/DesiredBalanceComputerTests.java
@@ -579,7 +579,14 @@ public class DesiredBalanceComputerTests extends ESTestCase {
     }
 
     private static RoutingAllocation routingAllocationOf(ClusterState clusterState) {
-        return new RoutingAllocation(new AllocationDeciders(List.of()), clusterState, ClusterInfo.EMPTY, SnapshotShardSizeInfo.EMPTY, 0L);
+        return new RoutingAllocation(
+            new AllocationDeciders(List.of()),
+            clusterState,
+            ClusterInfo.EMPTY,
+            SnapshotShardSizeInfo.EMPTY,
+            0L,
+            "test"
+        );
     }
 
     private static RoutingAllocation routingAllocationWithDecidersOf(ClusterState clusterState) {
@@ -594,7 +601,8 @@ public class DesiredBalanceComputerTests extends ESTestCase {
             clusterState,
             ClusterInfo.EMPTY,
             SnapshotShardSizeInfo.EMPTY,
-            0L
+            0L,
+            "test"
         );
     }
 }

--- a/server/src/test/java/org/elasticsearch/cluster/routing/allocation/allocator/DesiredBalanceReconcilerTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/allocation/allocator/DesiredBalanceReconcilerTests.java
@@ -94,7 +94,8 @@ public class DesiredBalanceReconcilerTests extends ESTestCase {
             clusterState,
             ClusterInfo.EMPTY,
             SnapshotShardSizeInfo.EMPTY,
-            0L
+            0L,
+            null
         );
 
         reconcile(routingAllocation, new DesiredBalance(1, Map.of()));
@@ -152,7 +153,8 @@ public class DesiredBalanceReconcilerTests extends ESTestCase {
             clusterState,
             ClusterInfo.EMPTY,
             SnapshotShardSizeInfo.EMPTY,
-            0L
+            0L,
+            null
         );
 
         for (ShardRouting shardRouting : routingAllocation.routingNodes().unassigned()) {

--- a/server/src/test/java/org/elasticsearch/cluster/routing/allocation/allocator/DesiredBalanceReconcilerTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/allocation/allocator/DesiredBalanceReconcilerTests.java
@@ -95,7 +95,7 @@ public class DesiredBalanceReconcilerTests extends ESTestCase {
             ClusterInfo.EMPTY,
             SnapshotShardSizeInfo.EMPTY,
             0L,
-            null
+            "test"
         );
 
         reconcile(routingAllocation, new DesiredBalance(1, Map.of()));
@@ -154,7 +154,7 @@ public class DesiredBalanceReconcilerTests extends ESTestCase {
             ClusterInfo.EMPTY,
             SnapshotShardSizeInfo.EMPTY,
             0L,
-            null
+            "test"
         );
 
         for (ShardRouting shardRouting : routingAllocation.routingNodes().unassigned()) {

--- a/server/src/test/java/org/elasticsearch/cluster/routing/allocation/allocator/DesiredBalanceShardsAllocatorTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/allocation/allocator/DesiredBalanceShardsAllocatorTests.java
@@ -410,7 +410,8 @@ public class DesiredBalanceShardsAllocatorTests extends ESTestCase {
             createIndexState,
             ClusterInfo.EMPTY,
             SnapshotShardSizeInfo.EMPTY,
-            System.nanoTime()
+            System.nanoTime(),
+            null
         );
 
         desiredBalanceShardsAllocator.allocate(

--- a/server/src/test/java/org/elasticsearch/cluster/routing/allocation/decider/AllocationDecidersTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/allocation/decider/AllocationDecidersTests.java
@@ -99,7 +99,7 @@ public class AllocationDecidersTests extends ESTestCase {
         ClusterState clusterState = ClusterState.builder(new ClusterName("test"))
             .metadata(Metadata.builder().put(idx, false).put(testIdx, false).build())
             .build();
-        final RoutingAllocation allocation = new RoutingAllocation(deciders, clusterState, null, null, 0L);
+        final RoutingAllocation allocation = new RoutingAllocation(deciders, clusterState, null, null, 0L, "test");
 
         allocation.setDebugMode(mode);
         final ShardRouting shardRouting = createShardRouting(testIdx.getIndex());
@@ -248,7 +248,7 @@ public class AllocationDecidersTests extends ESTestCase {
             .metadata(Metadata.builder().put(testIdx, false).put(indexMetadata, false).build())
             .build();
 
-        final RoutingAllocation allocation = new RoutingAllocation(allocationDeciders, clusterState, null, null, 0L);
+        final RoutingAllocation allocation = new RoutingAllocation(allocationDeciders, clusterState, null, null, 0L, "test");
         assertSame(Decision.NO, allocationDeciders.canAllocate(shardRouting, routingNode, allocation));
         assertSame(Decision.NO, allocationDeciders.canRebalance(shardRouting, allocation));
         assertSame(Decision.NO, allocationDeciders.canRemain(shardRouting, routingNode, allocation));
@@ -337,7 +337,7 @@ public class AllocationDecidersTests extends ESTestCase {
     }
 
     private static RoutingAllocation createRoutingAllocation(AllocationDeciders deciders) {
-        return new RoutingAllocation(deciders, ClusterState.builder(new ClusterName("test")).build(), null, null, 0L);
+        return new RoutingAllocation(deciders, ClusterState.builder(new ClusterName("test")).build(), null, null, 0L, "test");
     }
 
     private static final class AnyNodeInitialShardAllocationDecider extends AllocationDecider {

--- a/server/src/test/java/org/elasticsearch/cluster/routing/allocation/decider/DiskThresholdDeciderTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/allocation/decider/DiskThresholdDeciderTests.java
@@ -917,7 +917,7 @@ public class DiskThresholdDeciderTests extends ESAllocationTestCase {
             clusterInfo,
             null,
             System.nanoTime(),
-            null
+            "test"
         );
         routingAllocation.debugDecision(true);
         Decision decision = diskThresholdDecider.canRemain(
@@ -955,7 +955,7 @@ public class DiskThresholdDeciderTests extends ESAllocationTestCase {
             clusterInfo,
             null,
             System.nanoTime(),
-            null
+            "test"
         );
         routingAllocation.debugDecision(true);
         decision = diskThresholdDecider.canRemain(
@@ -1119,7 +1119,7 @@ public class DiskThresholdDeciderTests extends ESAllocationTestCase {
             clusterInfo,
             null,
             System.nanoTime(),
-            null
+            "test"
         );
         routingAllocation.debugDecision(true);
         Decision decision = diskThresholdDecider.canRemain(

--- a/server/src/test/java/org/elasticsearch/cluster/routing/allocation/decider/DiskThresholdDeciderTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/allocation/decider/DiskThresholdDeciderTests.java
@@ -916,7 +916,8 @@ public class DiskThresholdDeciderTests extends ESAllocationTestCase {
             clusterState,
             clusterInfo,
             null,
-            System.nanoTime()
+            System.nanoTime(),
+            null
         );
         routingAllocation.debugDecision(true);
         Decision decision = diskThresholdDecider.canRemain(
@@ -953,7 +954,8 @@ public class DiskThresholdDeciderTests extends ESAllocationTestCase {
             clusterState,
             clusterInfo,
             null,
-            System.nanoTime()
+            System.nanoTime(),
+            null
         );
         routingAllocation.debugDecision(true);
         decision = diskThresholdDecider.canRemain(
@@ -1116,7 +1118,8 @@ public class DiskThresholdDeciderTests extends ESAllocationTestCase {
             clusterState,
             clusterInfo,
             null,
-            System.nanoTime()
+            System.nanoTime(),
+            null
         );
         routingAllocation.debugDecision(true);
         Decision decision = diskThresholdDecider.canRemain(

--- a/server/src/test/java/org/elasticsearch/cluster/routing/allocation/decider/DiskThresholdDeciderUnitTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/allocation/decider/DiskThresholdDeciderUnitTests.java
@@ -116,7 +116,8 @@ public class DiskThresholdDeciderUnitTests extends ESAllocationTestCase {
             clusterState,
             clusterInfo,
             null,
-            System.nanoTime()
+            System.nanoTime(),
+            "test"
         );
         allocation.debugDecision(true);
         Decision decision = decider.canAllocate(test_0, RoutingNodesHelper.routingNode("node_0", node_0), allocation);
@@ -194,7 +195,8 @@ public class DiskThresholdDeciderUnitTests extends ESAllocationTestCase {
             clusterState,
             clusterInfo,
             null,
-            System.nanoTime()
+            System.nanoTime(),
+            "test"
         );
         allocation.debugDecision(true);
         Decision decision = decider.canAllocate(test_0, RoutingNodesHelper.routingNode("node_0", node_0), allocation);
@@ -316,7 +318,8 @@ public class DiskThresholdDeciderUnitTests extends ESAllocationTestCase {
             clusterState,
             clusterInfo,
             null,
-            System.nanoTime()
+            System.nanoTime(),
+            "test"
         );
         allocation.debugDecision(true);
         Decision decision = decider.canRemain(indexMetadata, test_0, RoutingNodesHelper.routingNode("node_0", node_0), allocation);
@@ -390,7 +393,7 @@ public class DiskThresholdDeciderUnitTests extends ESAllocationTestCase {
         ClusterState clusterState = ClusterState.builder(
             org.elasticsearch.cluster.ClusterName.CLUSTER_NAME_SETTING.getDefault(Settings.EMPTY)
         ).metadata(metadata).routingTable(routingTableBuilder.build()).build();
-        RoutingAllocation allocation = new RoutingAllocation(null, clusterState, info, null, 0);
+        RoutingAllocation allocation = new RoutingAllocation(null, clusterState, info, null, 0, "test");
 
         final Index index = new Index("test", "1234");
         ShardRouting test_0 = ShardRouting.newUnassigned(
@@ -540,7 +543,7 @@ public class DiskThresholdDeciderUnitTests extends ESAllocationTestCase {
             clusterState.getRoutingTable().index("test").shardsWithState(ShardRoutingState.UNASSIGNED)
         );
 
-        RoutingAllocation allocation = new RoutingAllocation(null, clusterState, info, null, 0);
+        RoutingAllocation allocation = new RoutingAllocation(null, clusterState, info, null, 0, "test");
 
         final Index index = new Index("test", "1234");
         ShardRouting test_0 = ShardRouting.newUnassigned(
@@ -612,7 +615,14 @@ public class DiskThresholdDeciderUnitTests extends ESAllocationTestCase {
             .build();
 
         allocationService.reroute(clusterState, "foo");
-        RoutingAllocation allocationWithMissingSourceIndex = new RoutingAllocation(null, clusterStateWithMissingSourceIndex, info, null, 0);
+        RoutingAllocation allocationWithMissingSourceIndex = new RoutingAllocation(
+            null,
+            clusterStateWithMissingSourceIndex,
+            info,
+            null,
+            0,
+            "test"
+        );
         assertEquals(42L, getExpectedShardSize(target, 42L, allocationWithMissingSourceIndex));
         assertEquals(42L, getExpectedShardSize(target2, 42L, allocationWithMissingSourceIndex));
     }
@@ -754,7 +764,8 @@ public class DiskThresholdDeciderUnitTests extends ESAllocationTestCase {
             clusterState,
             clusterInfo,
             null,
-            System.nanoTime()
+            System.nanoTime(),
+            "test"
         );
         allocation.debugDecision(true);
         final RoutingNode routingNode = RoutingNodesHelper.routingNode("node_0", node_0);
@@ -826,7 +837,8 @@ public class DiskThresholdDeciderUnitTests extends ESAllocationTestCase {
             clusterState,
             clusterInfo,
             null,
-            System.nanoTime()
+            System.nanoTime(),
+            "test"
         );
         allocation.debugDecision(true);
         Decision decision = decider.canForceAllocateDuringReplace(test_0, RoutingNodesHelper.routingNode("node_0", node_0), allocation);

--- a/server/src/test/java/org/elasticsearch/cluster/routing/allocation/decider/FilterAllocationDeciderTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/allocation/decider/FilterAllocationDeciderTests.java
@@ -78,7 +78,7 @@ public class FilterAllocationDeciderTests extends ESAllocationTestCase {
         assertNull(routingTable.index("idx").shard(0).shard(0).currentNodeId());
 
         // after failing the shard we are unassigned since the node is blacklisted and we can't initialize on the other node
-        RoutingAllocation allocation = new RoutingAllocation(allocationDeciders, state, null, null, 0);
+        RoutingAllocation allocation = new RoutingAllocation(allocationDeciders, state, null, null, 0, "test");
         allocation.debugDecision(true);
         Decision.Single decision = (Decision.Single) filterAllocationDecider.canAllocate(
             routingTable.index("idx").shard(0).primaryShard(),
@@ -136,7 +136,7 @@ public class FilterAllocationDeciderTests extends ESAllocationTestCase {
         assertEquals(routingTable.index("idx").shard(0).primaryShard().state(), INITIALIZING);
         assertEquals(routingTable.index("idx").shard(0).primaryShard().currentNodeId(), "node1");
 
-        allocation = new RoutingAllocation(allocationDeciders, state, null, null, 0);
+        allocation = new RoutingAllocation(allocationDeciders, state, null, null, 0, "test");
         allocation.debugDecision(true);
         decision = (Decision.Single) filterAllocationDecider.canAllocate(
             routingTable.index("idx").shard(0).shard(0),
@@ -295,7 +295,7 @@ public class FilterAllocationDeciderTests extends ESAllocationTestCase {
 
         var clusterSettings = new ClusterSettings(Settings.EMPTY, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS);
         var decider = new FilterAllocationDecider(Settings.EMPTY, clusterSettings);
-        var allocation = new RoutingAllocation(new AllocationDeciders(List.of(decider)), clusterState, null, null, 0);
+        var allocation = new RoutingAllocation(new AllocationDeciders(List.of(decider)), clusterState, null, null, 0, "test");
 
         var localRecoveryShard = ShardRouting.newUnassigned(
             new ShardId(index.getIndex(), 0),

--- a/server/src/test/java/org/elasticsearch/cluster/routing/allocation/decider/NodeReplacementAllocationDeciderTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/allocation/decider/NodeReplacementAllocationDeciderTests.java
@@ -86,7 +86,7 @@ public class NodeReplacementAllocationDeciderTests extends ESAllocationTestCase 
             .nodes(DiscoveryNodes.builder().add(NODE_A).add(NODE_B).add(NODE_C).build())
             .build();
 
-        RoutingAllocation allocation = new RoutingAllocation(allocationDeciders, state, null, null, 0);
+        RoutingAllocation allocation = new RoutingAllocation(allocationDeciders, state, null, null, 0, "test");
         DiscoveryNode node = randomFrom(NODE_A, NODE_B, NODE_C);
         RoutingNode routingNode = RoutingNodesHelper.routingNode(node.getId(), node, shard);
         allocation.debugDecision(true);
@@ -102,7 +102,7 @@ public class NodeReplacementAllocationDeciderTests extends ESAllocationTestCase 
 
     public void testCanForceAllocate() {
         ClusterState state = prepareState(service.reroute(ClusterState.EMPTY_STATE, "initial state"), NODE_A.getId(), NODE_B.getName());
-        RoutingAllocation allocation = new RoutingAllocation(allocationDeciders, state, null, null, 0);
+        RoutingAllocation allocation = new RoutingAllocation(allocationDeciders, state, null, null, 0, "test");
         RoutingNode routingNode = RoutingNodesHelper.routingNode(NODE_A.getId(), NODE_A, shard);
         allocation.debugDecision(true);
 
@@ -145,7 +145,7 @@ public class NodeReplacementAllocationDeciderTests extends ESAllocationTestCase 
 
     public void testCannotRemainOnReplacedNode() {
         ClusterState state = prepareState(service.reroute(ClusterState.EMPTY_STATE, "initial state"), NODE_A.getId(), NODE_B.getName());
-        RoutingAllocation allocation = new RoutingAllocation(allocationDeciders, state, null, null, 0);
+        RoutingAllocation allocation = new RoutingAllocation(allocationDeciders, state, null, null, 0, "test");
         RoutingNode routingNode = RoutingNodesHelper.routingNode(NODE_A.getId(), NODE_A, shard);
         allocation.debugDecision(true);
 
@@ -171,7 +171,7 @@ public class NodeReplacementAllocationDeciderTests extends ESAllocationTestCase 
 
     public void testCanAllocateToNeitherSourceNorTarget() {
         ClusterState state = prepareState(service.reroute(ClusterState.EMPTY_STATE, "initial state"), NODE_A.getId(), NODE_B.getName());
-        RoutingAllocation allocation = new RoutingAllocation(allocationDeciders, state, null, null, 0);
+        RoutingAllocation allocation = new RoutingAllocation(allocationDeciders, state, null, null, 0, "test");
         RoutingNode routingNode = RoutingNodesHelper.routingNode(NODE_A.getId(), NODE_A, shard);
         allocation.debugDecision(true);
 

--- a/server/src/test/java/org/elasticsearch/cluster/routing/allocation/decider/NodeShutdownAllocationDeciderTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/allocation/decider/NodeShutdownAllocationDeciderTests.java
@@ -82,7 +82,7 @@ public class NodeShutdownAllocationDeciderTests extends ESAllocationTestCase {
             service.reroute(ClusterState.EMPTY_STATE, "initial state"),
             SingleNodeShutdownMetadata.Type.RESTART
         );
-        RoutingAllocation allocation = new RoutingAllocation(allocationDeciders, state, null, null, 0);
+        RoutingAllocation allocation = new RoutingAllocation(allocationDeciders, state, null, null, 0, "test");
         RoutingNode routingNode = RoutingNodesHelper.routingNode(DATA_NODE.getId(), DATA_NODE, shard);
         allocation.debugDecision(true);
 
@@ -99,7 +99,7 @@ public class NodeShutdownAllocationDeciderTests extends ESAllocationTestCase {
             service.reroute(ClusterState.EMPTY_STATE, "initial state"),
             randomFrom(SingleNodeShutdownMetadata.Type.REMOVE, SingleNodeShutdownMetadata.Type.REPLACE)
         );
-        RoutingAllocation allocation = new RoutingAllocation(allocationDeciders, state, null, null, 0);
+        RoutingAllocation allocation = new RoutingAllocation(allocationDeciders, state, null, null, 0, "test");
         RoutingNode routingNode = RoutingNodesHelper.routingNode(DATA_NODE.getId(), DATA_NODE, shard);
         allocation.debugDecision(true);
 
@@ -113,7 +113,7 @@ public class NodeShutdownAllocationDeciderTests extends ESAllocationTestCase {
             service.reroute(ClusterState.EMPTY_STATE, "initial state"),
             SingleNodeShutdownMetadata.Type.RESTART
         );
-        RoutingAllocation allocation = new RoutingAllocation(allocationDeciders, state, null, null, 0);
+        RoutingAllocation allocation = new RoutingAllocation(allocationDeciders, state, null, null, 0, "test");
         RoutingNode routingNode = RoutingNodesHelper.routingNode(DATA_NODE.getId(), DATA_NODE, shard);
         allocation.debugDecision(true);
 
@@ -130,7 +130,7 @@ public class NodeShutdownAllocationDeciderTests extends ESAllocationTestCase {
             service.reroute(ClusterState.EMPTY_STATE, "initial state"),
             randomFrom(SingleNodeShutdownMetadata.Type.REMOVE, SingleNodeShutdownMetadata.Type.REPLACE)
         );
-        RoutingAllocation allocation = new RoutingAllocation(allocationDeciders, state, null, null, 0);
+        RoutingAllocation allocation = new RoutingAllocation(allocationDeciders, state, null, null, 0, "test");
         RoutingNode routingNode = RoutingNodesHelper.routingNode(DATA_NODE.getId(), DATA_NODE, shard);
         allocation.debugDecision(true);
 
@@ -144,7 +144,7 @@ public class NodeShutdownAllocationDeciderTests extends ESAllocationTestCase {
             service.reroute(ClusterState.EMPTY_STATE, "initial state"),
             SingleNodeShutdownMetadata.Type.RESTART
         );
-        RoutingAllocation allocation = new RoutingAllocation(allocationDeciders, state, null, null, 0);
+        RoutingAllocation allocation = new RoutingAllocation(allocationDeciders, state, null, null, 0, "test");
         allocation.debugDecision(true);
 
         Decision decision = decider.shouldAutoExpandToNode(indexMetadata, DATA_NODE, allocation);
@@ -158,7 +158,7 @@ public class NodeShutdownAllocationDeciderTests extends ESAllocationTestCase {
     public void testCanAutoExpandToNodeThatIsNotShuttingDown() {
         ClusterState state = service.reroute(ClusterState.EMPTY_STATE, "initial state");
 
-        RoutingAllocation allocation = new RoutingAllocation(allocationDeciders, state, null, null, 0);
+        RoutingAllocation allocation = new RoutingAllocation(allocationDeciders, state, null, null, 0, "test");
         allocation.debugDecision(true);
 
         Decision decision = decider.shouldAutoExpandToNode(indexMetadata, DATA_NODE, allocation);
@@ -171,7 +171,7 @@ public class NodeShutdownAllocationDeciderTests extends ESAllocationTestCase {
             service.reroute(ClusterState.EMPTY_STATE, "initial state"),
             randomFrom(SingleNodeShutdownMetadata.Type.REMOVE, SingleNodeShutdownMetadata.Type.REPLACE)
         );
-        RoutingAllocation allocation = new RoutingAllocation(allocationDeciders, state, null, null, 0);
+        RoutingAllocation allocation = new RoutingAllocation(allocationDeciders, state, null, null, 0, "test");
         allocation.debugDecision(true);
 
         Decision decision = decider.shouldAutoExpandToNode(indexMetadata, DATA_NODE, allocation);

--- a/server/src/test/java/org/elasticsearch/cluster/routing/allocation/decider/RestoreInProgressAllocationDeciderTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/allocation/decider/RestoreInProgressAllocationDeciderTests.java
@@ -208,7 +208,8 @@ public class RestoreInProgressAllocationDeciderTests extends ESAllocationTestCas
             clusterState,
             null,
             null,
-            0L
+            0L,
+            "test"
         );
         allocation.debugDecision(true);
 

--- a/server/src/test/java/org/elasticsearch/gateway/PrimaryShardAllocatorTests.java
+++ b/server/src/test/java/org/elasticsearch/gateway/PrimaryShardAllocatorTests.java
@@ -490,7 +490,7 @@ public class PrimaryShardAllocatorTests extends ESAllocationTestCase {
             public Long getShardSize(ShardRouting shardRouting) {
                 return shardSize;
             }
-        }, System.nanoTime());
+        }, System.nanoTime(), null);
     }
 
     private RoutingAllocation routingAllocationWithOnePrimaryNoReplicas(
@@ -519,7 +519,7 @@ public class PrimaryShardAllocatorTests extends ESAllocationTestCase {
             .routingTable(routingTableBuilder.build())
             .nodes(DiscoveryNodes.builder().add(node1).add(node2).add(node3))
             .build();
-        return new RoutingAllocation(deciders, state.mutableRoutingNodes(), state, null, null, System.nanoTime());
+        return new RoutingAllocation(deciders, state.mutableRoutingNodes(), state, null, null, System.nanoTime(), null);
     }
 
     private void assertClusterHealthStatus(RoutingAllocation allocation, ClusterHealthStatus expectedStatus) {

--- a/server/src/test/java/org/elasticsearch/gateway/PrimaryShardAllocatorTests.java
+++ b/server/src/test/java/org/elasticsearch/gateway/PrimaryShardAllocatorTests.java
@@ -490,7 +490,7 @@ public class PrimaryShardAllocatorTests extends ESAllocationTestCase {
             public Long getShardSize(ShardRouting shardRouting) {
                 return shardSize;
             }
-        }, System.nanoTime(), null);
+        }, System.nanoTime(), "test");
     }
 
     private RoutingAllocation routingAllocationWithOnePrimaryNoReplicas(
@@ -519,7 +519,7 @@ public class PrimaryShardAllocatorTests extends ESAllocationTestCase {
             .routingTable(routingTableBuilder.build())
             .nodes(DiscoveryNodes.builder().add(node1).add(node2).add(node3))
             .build();
-        return new RoutingAllocation(deciders, state.mutableRoutingNodes(), state, null, null, System.nanoTime(), null);
+        return new RoutingAllocation(deciders, state.mutableRoutingNodes(), state, null, null, System.nanoTime(), "test");
     }
 
     private void assertClusterHealthStatus(RoutingAllocation allocation, ClusterHealthStatus expectedStatus) {

--- a/server/src/test/java/org/elasticsearch/gateway/ReplicaShardAllocatorTests.java
+++ b/server/src/test/java/org/elasticsearch/gateway/ReplicaShardAllocatorTests.java
@@ -581,7 +581,7 @@ public class ReplicaShardAllocatorTests extends ESAllocationTestCase {
             ClusterInfo.EMPTY,
             SnapshotShardSizeInfo.EMPTY,
             System.nanoTime(),
-            null
+            "test"
         );
     }
 
@@ -626,7 +626,7 @@ public class ReplicaShardAllocatorTests extends ESAllocationTestCase {
             ClusterInfo.EMPTY,
             SnapshotShardSizeInfo.EMPTY,
             System.nanoTime(),
-            null
+            "test"
         );
     }
 

--- a/server/src/test/java/org/elasticsearch/gateway/ReplicaShardAllocatorTests.java
+++ b/server/src/test/java/org/elasticsearch/gateway/ReplicaShardAllocatorTests.java
@@ -580,7 +580,8 @@ public class ReplicaShardAllocatorTests extends ESAllocationTestCase {
             state,
             ClusterInfo.EMPTY,
             SnapshotShardSizeInfo.EMPTY,
-            System.nanoTime()
+            System.nanoTime(),
+            null
         );
     }
 
@@ -624,7 +625,8 @@ public class ReplicaShardAllocatorTests extends ESAllocationTestCase {
             state,
             ClusterInfo.EMPTY,
             SnapshotShardSizeInfo.EMPTY,
-            System.nanoTime()
+            System.nanoTime(),
+            null
         );
     }
 

--- a/x-pack/plugin/autoscaling/src/main/java/org/elasticsearch/xpack/autoscaling/storage/ReactiveStorageDeciderService.java
+++ b/x-pack/plugin/autoscaling/src/main/java/org/elasticsearch/xpack/autoscaling/storage/ReactiveStorageDeciderService.java
@@ -283,7 +283,14 @@ public class ReactiveStorageDeciderService implements AutoscalingDeciderService 
         }
 
         public ShardsSize storagePreventsAllocation() {
-            RoutingAllocation allocation = new RoutingAllocation(allocationDeciders, state, info, shardSizeInfo, System.nanoTime());
+            RoutingAllocation allocation = new RoutingAllocation(
+                allocationDeciders,
+                state,
+                info,
+                shardSizeInfo,
+                System.nanoTime(),
+                "storagePreventsAllocation"
+            );
             List<ShardRouting> unassignedShards = StreamSupport.stream(state.getRoutingNodes().unassigned().spliterator(), false)
                 .filter(shard -> canAllocate(shard, allocation) == false)
                 .filter(shard -> cannotAllocateDueToStorage(shard, allocation))
@@ -295,7 +302,7 @@ public class ReactiveStorageDeciderService implements AutoscalingDeciderService 
         }
 
         public ShardsSize storagePreventsRemainOrMove() {
-            RoutingAllocation allocation = new RoutingAllocation(allocationDeciders, state, info, shardSizeInfo, System.nanoTime());
+            RoutingAllocation allocation = new RoutingAllocation(allocationDeciders, state, info, shardSizeInfo, System.nanoTime(), "test");
 
             List<ShardRouting> candidates = new LinkedList<>();
             for (RoutingNode routingNode : state.getRoutingNodes()) {

--- a/x-pack/plugin/autoscaling/src/test/java/org/elasticsearch/xpack/autoscaling/storage/ProactiveStorageDeciderServiceTests.java
+++ b/x-pack/plugin/autoscaling/src/test/java/org/elasticsearch/xpack/autoscaling/storage/ProactiveStorageDeciderServiceTests.java
@@ -305,7 +305,7 @@ public class ProactiveStorageDeciderServiceTests extends AutoscalingTestCase {
             null,
             null,
             System.nanoTime(),
-            null
+            "test"
         );
         randomAllocate(allocation);
         return ReactiveStorageDeciderServiceTests.updateClusterState(state, allocation);
@@ -337,7 +337,7 @@ public class ProactiveStorageDeciderServiceTests extends AutoscalingTestCase {
             null,
             null,
             System.nanoTime(),
-            null
+            "test"
         );
         startAll(allocation);
         return ReactiveStorageDeciderServiceTests.updateClusterState(state, allocation);

--- a/x-pack/plugin/autoscaling/src/test/java/org/elasticsearch/xpack/autoscaling/storage/ProactiveStorageDeciderServiceTests.java
+++ b/x-pack/plugin/autoscaling/src/test/java/org/elasticsearch/xpack/autoscaling/storage/ProactiveStorageDeciderServiceTests.java
@@ -304,7 +304,8 @@ public class ProactiveStorageDeciderServiceTests extends AutoscalingTestCase {
             state,
             null,
             null,
-            System.nanoTime()
+            System.nanoTime(),
+            null
         );
         randomAllocate(allocation);
         return ReactiveStorageDeciderServiceTests.updateClusterState(state, allocation);
@@ -335,7 +336,8 @@ public class ProactiveStorageDeciderServiceTests extends AutoscalingTestCase {
             state,
             null,
             null,
-            System.nanoTime()
+            System.nanoTime(),
+            null
         );
         startAll(allocation);
         return ReactiveStorageDeciderServiceTests.updateClusterState(state, allocation);

--- a/x-pack/plugin/autoscaling/src/test/java/org/elasticsearch/xpack/autoscaling/storage/ReactiveStorageDeciderDecisionTests.java
+++ b/x-pack/plugin/autoscaling/src/test/java/org/elasticsearch/xpack/autoscaling/storage/ReactiveStorageDeciderDecisionTests.java
@@ -489,7 +489,8 @@ public class ReactiveStorageDeciderDecisionTests extends AutoscalingTestCase {
             state,
             createClusterInfo(state),
             null,
-            System.nanoTime()
+            System.nanoTime(),
+            null
         );
     }
 

--- a/x-pack/plugin/autoscaling/src/test/java/org/elasticsearch/xpack/autoscaling/storage/ReactiveStorageDeciderDecisionTests.java
+++ b/x-pack/plugin/autoscaling/src/test/java/org/elasticsearch/xpack/autoscaling/storage/ReactiveStorageDeciderDecisionTests.java
@@ -490,7 +490,7 @@ public class ReactiveStorageDeciderDecisionTests extends AutoscalingTestCase {
             createClusterInfo(state),
             null,
             System.nanoTime(),
-            null
+            "test"
         );
     }
 

--- a/x-pack/plugin/autoscaling/src/test/java/org/elasticsearch/xpack/autoscaling/storage/ReactiveStorageDeciderServiceTests.java
+++ b/x-pack/plugin/autoscaling/src/test/java/org/elasticsearch/xpack/autoscaling/storage/ReactiveStorageDeciderServiceTests.java
@@ -660,7 +660,7 @@ public class ReactiveStorageDeciderServiceTests extends AutoscalingTestCase {
             Set.of(DiscoveryNodeRole.DATA_WARM_NODE_ROLE)
         );
 
-        RoutingAllocation allocation = new RoutingAllocation(allocationDeciders, clusterState, null, null, randomLong());
+        RoutingAllocation allocation = new RoutingAllocation(allocationDeciders, clusterState, null, null, randomLong(), "test");
         return allocationState.canRemainOnlyHighestTierPreference(shardRouting, allocation);
     }
 
@@ -763,7 +763,7 @@ public class ReactiveStorageDeciderServiceTests extends AutoscalingTestCase {
             Set.of(DiscoveryNodeRole.DATA_WARM_NODE_ROLE)
         );
 
-        RoutingAllocation allocation = new RoutingAllocation(allocationDeciders, clusterState, null, null, randomLong());
+        RoutingAllocation allocation = new RoutingAllocation(allocationDeciders, clusterState, null, null, randomLong(), "test");
 
         assertThat(allocationState.needsThisTier(shardRouting, allocation), is(expected));
     }

--- a/x-pack/plugin/autoscaling/src/test/java/org/elasticsearch/xpack/autoscaling/storage/ReactiveStorageDeciderServiceTests.java
+++ b/x-pack/plugin/autoscaling/src/test/java/org/elasticsearch/xpack/autoscaling/storage/ReactiveStorageDeciderServiceTests.java
@@ -238,7 +238,8 @@ public class ReactiveStorageDeciderServiceTests extends AutoscalingTestCase {
             initialClusterState,
             null,
             null,
-            System.nanoTime()
+            System.nanoTime(),
+            null
         );
         ShardRouting primaryShard = subjectRoutings.primaryShard();
         ShardRouting replicaShard = subjectRoutings.replicaShards().get(0);

--- a/x-pack/plugin/autoscaling/src/test/java/org/elasticsearch/xpack/autoscaling/storage/ReactiveStorageDeciderServiceTests.java
+++ b/x-pack/plugin/autoscaling/src/test/java/org/elasticsearch/xpack/autoscaling/storage/ReactiveStorageDeciderServiceTests.java
@@ -239,7 +239,7 @@ public class ReactiveStorageDeciderServiceTests extends AutoscalingTestCase {
             null,
             null,
             System.nanoTime(),
-            null
+            "test"
         );
         ShardRouting primaryShard = subjectRoutings.primaryShard();
         ShardRouting replicaShard = subjectRoutings.replicaShards().get(0);

--- a/x-pack/plugin/ccr/src/test/java/org/elasticsearch/xpack/ccr/allocation/CcrPrimaryFollowerAllocationDeciderTests.java
+++ b/x-pack/plugin/ccr/src/test/java/org/elasticsearch/xpack/ccr/allocation/CcrPrimaryFollowerAllocationDeciderTests.java
@@ -188,7 +188,7 @@ public class CcrPrimaryFollowerAllocationDeciderTests extends ESAllocationTestCa
             ClusterInfo.EMPTY,
             SnapshotShardSizeInfo.EMPTY,
             System.nanoTime(),
-            null
+            "test"
         );
         routingAllocation.debugDecision(true);
         return decider.canAllocate(shardRouting, RoutingNodesHelper.routingNode(node.getId(), node), routingAllocation);

--- a/x-pack/plugin/ccr/src/test/java/org/elasticsearch/xpack/ccr/allocation/CcrPrimaryFollowerAllocationDeciderTests.java
+++ b/x-pack/plugin/ccr/src/test/java/org/elasticsearch/xpack/ccr/allocation/CcrPrimaryFollowerAllocationDeciderTests.java
@@ -187,7 +187,8 @@ public class CcrPrimaryFollowerAllocationDeciderTests extends ESAllocationTestCa
             clusterState,
             ClusterInfo.EMPTY,
             SnapshotShardSizeInfo.EMPTY,
-            System.nanoTime()
+            System.nanoTime(),
+            null
         );
         routingAllocation.debugDecision(true);
         return decider.canAllocate(shardRouting, RoutingNodesHelper.routingNode(node.getId(), node), routingAllocation);

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/AllocationRoutedStep.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/AllocationRoutedStep.java
@@ -88,7 +88,14 @@ public class AllocationRoutedStep extends ClusterStateWaitStep {
     static int getPendingAllocations(Index index, AllocationDeciders allocationDeciders, ClusterState clusterState) {
         // All the allocation attributes are already set so just need to check
         // if the allocation has happened
-        RoutingAllocation allocation = new RoutingAllocation(allocationDeciders, clusterState, null, null, System.nanoTime());
+        RoutingAllocation allocation = new RoutingAllocation(
+            allocationDeciders,
+            clusterState,
+            null,
+            null,
+            System.nanoTime(),
+            "getPendingAllocations"
+        );
 
         int allocationPendingAllShards = 0;
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/SetSingleNodeAllocateStep.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/SetSingleNodeAllocateStep.java
@@ -79,7 +79,14 @@ public class SetSingleNodeAllocateStep extends AsyncActionStep {
                 new NodeReplacementAllocationDecider()
             )
         );
-        RoutingAllocation allocation = new RoutingAllocation(allocationDeciders, clusterState, null, null, System.nanoTime());
+        RoutingAllocation allocation = new RoutingAllocation(
+            allocationDeciders,
+            clusterState,
+            null,
+            null,
+            System.nanoTime(),
+            "SetSingleNodeAllocateStep"
+        );
         List<String> validNodeIds = new ArrayList<>();
         String indexName = indexMetadata.getIndex().getName();
         final Map<ShardId, List<ShardRouting>> routingsByShardId = clusterState.getRoutingTable()

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/cluster/routing/allocation/DataTierAllocationDeciderTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/cluster/routing/allocation/DataTierAllocationDeciderTests.java
@@ -635,7 +635,7 @@ public class DataTierAllocationDeciderTests extends ESAllocationTestCase {
     }
 
     private void assertAllocationDecision(ClusterState state, DiscoveryNode node, Decision.Type decisionType, String explanationMessage) {
-        final var allocation = new RoutingAllocation(allocationDeciders, null, state, null, null, 0, null);
+        final var allocation = new RoutingAllocation(allocationDeciders, null, state, null, null, 0, "test");
         allocation.debugDecision(true);
 
         final var routingNode = RoutingNodesHelper.routingNode(node.getId(), node, shard);

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/cluster/routing/allocation/DataTierAllocationDeciderTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/cluster/routing/allocation/DataTierAllocationDeciderTests.java
@@ -635,7 +635,7 @@ public class DataTierAllocationDeciderTests extends ESAllocationTestCase {
     }
 
     private void assertAllocationDecision(ClusterState state, DiscoveryNode node, Decision.Type decisionType, String explanationMessage) {
-        final var allocation = new RoutingAllocation(allocationDeciders, null, state, null, null, 0);
+        final var allocation = new RoutingAllocation(allocationDeciders, null, state, null, null, 0, null);
         allocation.debugDecision(true);
 
         final var routingNode = RoutingNodesHelper.routingNode(node.getId(), node, shard);

--- a/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/xpack/searchablesnapshots/allocation/SearchableSnapshotAllocatorTests.java
+++ b/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/xpack/searchablesnapshots/allocation/SearchableSnapshotAllocatorTests.java
@@ -254,7 +254,7 @@ public class SearchableSnapshotAllocatorTests extends ESAllocationTestCase {
             public Long getShardSize(ShardRouting shardRouting) {
                 return shardSize;
             }
-        }, TimeUnit.MILLISECONDS.toNanos(deterministicTaskQueue.getCurrentTimeMillis()), null);
+        }, TimeUnit.MILLISECONDS.toNanos(deterministicTaskQueue.getCurrentTimeMillis()), "test");
     }
 
     private static void allocateAllUnassigned(RoutingAllocation allocation, ExistingShardsAllocator allocator) {

--- a/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/xpack/searchablesnapshots/allocation/SearchableSnapshotAllocatorTests.java
+++ b/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/xpack/searchablesnapshots/allocation/SearchableSnapshotAllocatorTests.java
@@ -254,7 +254,7 @@ public class SearchableSnapshotAllocatorTests extends ESAllocationTestCase {
             public Long getShardSize(ShardRouting shardRouting) {
                 return shardSize;
             }
-        }, TimeUnit.MILLISECONDS.toNanos(deterministicTaskQueue.getCurrentTimeMillis()));
+        }, TimeUnit.MILLISECONDS.toNanos(deterministicTaskQueue.getCurrentTimeMillis()), null);
     }
 
     private static void allocateAllUnassigned(RoutingAllocation allocation, ExistingShardsAllocator allocator) {

--- a/x-pack/plugin/shutdown/src/main/java/org/elasticsearch/xpack/shutdown/TransportGetShutdownStatusAction.java
+++ b/x-pack/plugin/shutdown/src/main/java/org/elasticsearch/xpack/shutdown/TransportGetShutdownStatusAction.java
@@ -221,7 +221,8 @@ public class TransportGetShutdownStatusAction extends TransportMasterNodeAction<
             currentState,
             clusterInfoService.getClusterInfo(),
             snapshotsInfoService.snapshotShardSizes(),
-            System.nanoTime()
+            System.nanoTime(),
+            "TransportGetShutdownStatusAction"
         );
         allocation.setDebugMode(RoutingAllocation.DebugMode.EXCLUDE_YES_DECISIONS);
 


### PR DESCRIPTION
Record an allocation reason in `RoutingAllocation` objects so that it could be logged later while allocating for it, computing a balance or expiring outdated input. This should simplify debugging of some of the issues.