### PR TITLE
[8.3] [DOCS] Fix transform painless example syntax (#88364)

### DIFF
--- a/docs/reference/transform/painless-examples.asciidoc
+++ b/docs/reference/transform/painless-examples.asciidoc
@@ -573,7 +573,7 @@ POST _transform/_preview
                 all_docs.add(span); 
               }
             }
-            all_docs.sort((HashMap o1, HashMap o2)->o1['@timestamp'].toEpochMilli()compareTo(o2['@timestamp']-toEpochMilli())); 
+            all_docs.sort((HashMap o1, HashMap o2)->o1['@timestamp'].toEpochMilli().compareTo(o2['@timestamp'].toEpochMilli())); 
             def size = all_docs.size();
             def min_time = all_docs[0]['@timestamp'];
             def max_time = all_docs[size-1]['@timestamp'];


### PR DESCRIPTION
Backports the following commits to 8.3:
 - [DOCS] Fix transform painless example syntax (#88364)