### PR TITLE
Fix validation of close_pit request

### DIFF
--- a/docs/changelog/88702.yaml
+++ b/docs/changelog/88702.yaml
@@ -1,0 +1,5 @@
+pr: 88702
+summary: Fix validation of `close_pit` request
+area: Search
+type: bug
+issues: []

--- a/server/src/internalClusterTest/java/org/elasticsearch/action/search/PointInTimeIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/action/search/PointInTimeIT.java
@@ -29,6 +29,7 @@ import org.elasticsearch.search.builder.PointInTimeBuilder;
 import org.elasticsearch.search.sort.SortBuilder;
 import org.elasticsearch.search.sort.SortBuilders;
 import org.elasticsearch.search.sort.SortOrder;
+import org.elasticsearch.tasks.TaskInfo;
 import org.elasticsearch.test.ESIntegTestCase;
 
 import java.util.HashSet;
@@ -42,6 +43,7 @@ import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertFail
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertHitCount;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertNoFailures;
 import static org.hamcrest.Matchers.arrayWithSize;
+import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.everyItem;
 import static org.hamcrest.Matchers.in;
@@ -416,6 +418,12 @@ public class PointInTimeIT extends ESIntegTestCase {
         } finally {
             closePointInTime(pit);
         }
+    }
+
+    public void testCloseInvalidPointInTime() {
+        expectThrows(Exception.class, () -> client().execute(ClosePointInTimeAction.INSTANCE, new ClosePointInTimeRequest("")).actionGet());
+        List<TaskInfo> tasks = client().admin().cluster().prepareListTasks().setActions(ClosePointInTimeAction.NAME).get().getTasks();
+        assertThat(tasks, empty());
     }
 
     @SuppressWarnings({ "rawtypes", "unchecked" })

--- a/server/src/main/java/org/elasticsearch/action/search/ClosePointInTimeRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/search/ClosePointInTimeRequest.java
@@ -10,6 +10,7 @@ package org.elasticsearch.action.search;
 
 import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestValidationException;
+import org.elasticsearch.action.ValidateActions;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -41,7 +42,7 @@ public class ClosePointInTimeRequest extends ActionRequest implements ToXContent
     @Override
     public ActionRequestValidationException validate() {
         if (Strings.isEmpty(id)) {
-            throw new IllegalArgumentException("reader id must be specified");
+            return ValidateActions.addValidationError("id is empty", null);
         }
         return null;
     }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/action/PutLifecycleAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/action/PutLifecycleAction.java
@@ -8,6 +8,7 @@ package org.elasticsearch.xpack.core.ilm.action;
 
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.ActionType;
+import org.elasticsearch.action.ValidateActions;
 import org.elasticsearch.action.support.master.AcknowledgedRequest;
 import org.elasticsearch.action.support.master.AcknowledgedResponse;
 import org.elasticsearch.common.Strings;
@@ -62,8 +63,12 @@ public class PutLifecycleAction extends ActionType<AcknowledgedResponse> {
 
         @Override
         public ActionRequestValidationException validate() {
-            this.policy.validate();
             ActionRequestValidationException err = null;
+            try {
+                this.policy.validate();
+            } catch (IllegalArgumentException iae) {
+                err = ValidateActions.addValidationError(iae.getMessage(), null);
+            }
             String phaseTimingErr = TimeseriesLifecycleType.validateMonotonicallyIncreasingPhaseTimings(this.policy.getPhases().values());
             if (Strings.hasText(phaseTimingErr)) {
                 err = new ActionRequestValidationException();


### PR DESCRIPTION
`ClosePointInTimeRequest#validate` should return a validation error for an invalid pit_id, but it throws an IAE instead. This mistake prevents close_pit tasks of requests with empty pit_id from being removed.

I also looked at other `ActionRequest#validate` implementations. They do not throw exceptions.