### PR TITLE
[7.17] ensure transform has done something before stop gets called with (#88696)

### DIFF
--- a/x-pack/plugin/transform/qa/multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/TransformIT.java
+++ b/x-pack/plugin/transform/qa/multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/TransformIT.java
@@ -286,8 +286,8 @@ public class TransformIT extends TransformIntegTestCase {
 
         // wait until transform has been triggered and indexed at least 1 document
         assertBusy(() -> {
-            var stateAndStats = getTransformStats(config.getId());
-            assertThat((Integer) XContentMapValues.extractValue("stats.documents_indexed", stateAndStats), greaterThan(1));
+            TransformStats stateAndStats = getTransformStats(config.getId()).getTransformsStats().get(0);
+            assertThat(stateAndStats.getIndexerStats().getDocumentsIndexed(), greaterThan(1));
         });
 
         // waitForCheckpoint: true should make the transform continue until we hit the first checkpoint, then it will stop

--- a/x-pack/plugin/transform/qa/multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/TransformIT.java
+++ b/x-pack/plugin/transform/qa/multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/TransformIT.java
@@ -284,6 +284,12 @@ public class TransformIT extends TransformIntegTestCase {
 
         assertTrue(startTransform(config.getId(), RequestOptions.DEFAULT).isAcknowledged());
 
+        // wait until transform has been triggered and indexed at least 1 document
+        assertBusy(() -> {
+            var stateAndStats = getTransformStats(config.getId());
+            assertThat((Integer) XContentMapValues.extractValue("stats.documents_indexed", stateAndStats), greaterThan(1));
+        });
+
         // waitForCheckpoint: true should make the transform continue until we hit the first checkpoint, then it will stop
         assertTrue(stopTransform(transformId, false, null, true).isAcknowledged());
 

--- a/x-pack/plugin/transform/qa/multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/TransformIT.java
+++ b/x-pack/plugin/transform/qa/multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/TransformIT.java
@@ -287,7 +287,7 @@ public class TransformIT extends TransformIntegTestCase {
         // wait until transform has been triggered and indexed at least 1 document
         assertBusy(() -> {
             TransformStats stateAndStats = getTransformStats(config.getId()).getTransformsStats().get(0);
-            assertThat(stateAndStats.getIndexerStats().getDocumentsIndexed(), greaterThan(1));
+            assertThat(stateAndStats.getIndexerStats().getDocumentsIndexed(), greaterThan(1L));
         });
 
         // waitForCheckpoint: true should make the transform continue until we hit the first checkpoint, then it will stop


### PR DESCRIPTION
Backports the following commits to 7.17:
 - ensure transform has done something before stop gets called with (#88696)