### PR TITLE
Mute GeoBoundingBoxQueryBuilderGeoShapeTests#testToQuery

### DIFF
--- a/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/index/query/GeoBoundingBoxQueryBuilderGeoShapeTests.java
+++ b/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/index/query/GeoBoundingBoxQueryBuilderGeoShapeTests.java
@@ -62,4 +62,9 @@ public class GeoBoundingBoxQueryBuilderGeoShapeTests extends GeoBoundingBoxQuery
         assertEquals(GeoShapeWithDocValuesFieldMapper.GeoShapeWithDocValuesFieldType.class, fieldType.getClass());
         assertEquals(IndexOrDocValuesQuery.class, query.getClass());
     }
+
+    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/88711")
+    public void testToQuery() throws IOException {
+        super.testToQuery();
+    }
 }


### PR DESCRIPTION
relates to https://github.com/elastic/elasticsearch/issues/88711