### PR TITLE
Speed up DocumentParser.innerParseObject

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/mapper/DocumentParser.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/DocumentParser.java
@@ -294,17 +294,18 @@ public final class DocumentParser {
 
     private static void innerParseObject(DocumentParserContext context, ObjectMapper mapper) throws IOException {
 
-        XContentParser.Token token = context.parser().currentToken();
-        String currentFieldName = context.parser().currentName();
+        final XContentParser parser = context.parser();
+        XContentParser.Token token = parser.currentToken();
+        String currentFieldName = null;
         assert token == XContentParser.Token.FIELD_NAME || token == XContentParser.Token.END_OBJECT;
 
         while (token != XContentParser.Token.END_OBJECT) {
             if (token == null) {
-                throwEOF(mapper, currentFieldName);
+                throwEOF(mapper, context);
             }
             switch (token) {
                 case FIELD_NAME:
-                    currentFieldName = context.parser().currentName();
+                    currentFieldName = parser.currentName();
                     if (currentFieldName.isBlank()) {
                         throwFieldNameBlank(context, currentFieldName);
                     }
@@ -324,7 +325,7 @@ public final class DocumentParser {
                     }
                     break;
             }
-            token = context.parser().nextToken();
+            token = parser.nextToken();
         }
     }
 
@@ -334,12 +335,12 @@ public final class DocumentParser {
         );
     }
 
-    private static void throwEOF(ObjectMapper mapper, String currentFieldName) {
+    private static void throwEOF(ObjectMapper mapper, DocumentParserContext context) throws IOException {
         throw new MapperParsingException(
             "object mapping for ["
                 + mapper.name()
                 + "] tried to parse field ["
-                + currentFieldName
+                + context.parser().currentName()
                 + "] as object, but got EOF, has a concrete value been provided to it?"
         );
     }


### PR DESCRIPTION
Making this a little smaller so it inlines more often and more importantly
avoid getting the current field name redundantly before entering the loop which
is not free when the parser is a `DotExpandingXContentParser`.
This change gives a significant boost to `BeatsMapperBenchmark.benchmarkParseKeywordFields`.

Results below are pretty stable, running with a large number of iterations.

before:

```
Result "org.elasticsearch.benchmark.index.mapper.BeatsMapperBenchmark.benchmarkParseKeywordFields":
  9039.270 ±(99.9%) 28.001 ns/op [Average]
  (min, avg, max) = (9008.778, 9039.270, 9062.246), stdev = 18.521
  CI (99.9%): [9011.269, 9067.271] (assumes normal distribution)
```

after:

```
Result "org.elasticsearch.benchmark.index.mapper.BeatsMapperBenchmark.benchmarkParseKeywordFields":
  8645.649 ±(99.9%) 53.677 ns/op [Average]
  (min, avg, max) = (8568.319, 8645.649, 8688.210), stdev = 35.504
  CI (99.9%): [8591.972, 8699.327] (assumes normal distribution)
```


