### PR TITLE
[7.17] Tasks doc: fix a mistake about the reindex task description (#88669)

### DIFF
--- a/docs/reference/cluster/tasks.asciidoc
+++ b/docs/reference/cluster/tasks.asciidoc
@@ -183,8 +183,8 @@ The API returns the following result:
 The new `description` field contains human readable text that identifies the
 particular request that the task is performing such as identifying the search
 request being performed by a search task like the example above. Other kinds of
-task have different descriptions, like <<docs-reindex,`_reindex`>> which
-has the search and the destination, or <<docs-bulk,`_bulk`>> which just has the
+tasks have different descriptions, like <<docs-reindex,`_reindex`>> which
+has the source and the destination, or <<docs-bulk,`_bulk`>> which just has the
 number of requests and the destination indices. Many requests will only have an
 empty description because more detailed information about the request is not
 easily available or particularly helpful in identifying the request.


### PR DESCRIPTION
Manual backport because automatic failed.