### PR TITLE
Fix errors in geo test introduced during refactoring

### DIFF
--- a/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/index/query/GeoBoundingBoxQueryBuilderGeoShapeTests.java
+++ b/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/index/query/GeoBoundingBoxQueryBuilderGeoShapeTests.java
@@ -60,11 +60,10 @@ public class GeoBoundingBoxQueryBuilderGeoShapeTests extends GeoBoundingBoxQuery
             assertTrue("Found no indexed geo query.", query instanceof MatchNoDocsQuery);
         }
         assertEquals(GeoShapeWithDocValuesFieldMapper.GeoShapeWithDocValuesFieldType.class, fieldType.getClass());
-        assertEquals(IndexOrDocValuesQuery.class, query.getClass());
-    }
-
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/88711")
-    public void testToQuery() throws IOException {
-        super.testToQuery();
+        if (fieldType.hasDocValues()) {
+            assertEquals(IndexOrDocValuesQuery.class, query.getClass());
+        } else {
+            assertNotEquals(IndexOrDocValuesQuery.class, query.getClass());
+        }
     }
 }

--- a/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/index/query/GeoDistanceQueryBuilderGeoShapeTests.java
+++ b/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/index/query/GeoDistanceQueryBuilderGeoShapeTests.java
@@ -61,11 +61,10 @@ public class GeoDistanceQueryBuilderGeoShapeTests extends GeoDistanceQueryBuilde
             assertTrue("Found no indexed geo query.", query instanceof MatchNoDocsQuery);
         }
         assertEquals(GeoShapeWithDocValuesFieldMapper.GeoShapeWithDocValuesFieldType.class, fieldType.getClass());
-        assertEquals(IndexOrDocValuesQuery.class, query.getClass());
-    }
-
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/88712")
-    public void testToQuery() throws IOException {
-        super.testToQuery();
+        if (fieldType.hasDocValues()) {
+            assertEquals(IndexOrDocValuesQuery.class, query.getClass());
+        } else {
+            assertNotEquals(IndexOrDocValuesQuery.class, query.getClass());
+        }
     }
 }


### PR DESCRIPTION
This errors where introduced in https://github.com/elastic/elasticsearch/pull/88588, the fix is trivial as IndexOrDocValues query should only be present if the field has doc values.

fixes https://github.com/elastic/elasticsearch/issues/88711
fixes https://github.com/elastic/elasticsearch/issues/88712
