### PR TITLE
Avoid capturing SnapshotsInProgress$Entry in queue

### DIFF
--- a/docs/changelog/88707.yaml
+++ b/docs/changelog/88707.yaml
@@ -1,0 +1,5 @@
+pr: 88707
+summary: Avoid capturing `SnapshotsInProgress$Entry` in queue
+area: Snapshot/Restore
+type: bug
+issues: []


### PR DESCRIPTION
Today each time there's shards to snapshot we enqueue a lambda which
captures the current `SnapshotsInProgress$Entry`. This is a pretty
heavyweight object, possibly several MB in size, most of which is not
necessary to capture, and with concurrent snapshots across thousands of
shards we may enqueue many hundreds of slightly different such objects.
With this commit we compute a more efficient representation of the work
to be done by each task in the queue instead.

Relates #77466
Backport of #88707