### PR TITLE
Fix validation of MovAvgPipelineAggregationBuilder

### DIFF
--- a/server/src/main/java/org/elasticsearch/search/aggregations/pipeline/MovAvgPipelineAggregationBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/pipeline/MovAvgPipelineAggregationBuilder.java
@@ -253,7 +253,11 @@ public class MovAvgPipelineAggregationBuilder extends AbstractPipelineAggregatio
             return;
         }
         // Validate any model-specific window requirements
-        model.validate(window, name);
+        try {
+            model.validate(window, name);
+        } catch (IllegalArgumentException iae) {
+            context.addValidationError(iae.getMessage());
+        }
         context.validateParentAggSequentiallyOrdered(NAME, name);
     }
 

--- a/server/src/test/java/org/elasticsearch/search/aggregations/pipeline/MovAvgPipelineAggregationBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/pipeline/MovAvgPipelineAggregationBuilderTests.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.search.aggregations.pipeline;
+
+import org.elasticsearch.search.aggregations.AggregationBuilder;
+import org.elasticsearch.search.aggregations.PipelineAggregationBuilder;
+import org.elasticsearch.test.ESTestCase;
+
+import java.util.Collections;
+import java.util.List;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.mockito.Mockito.mock;
+
+public class MovAvgPipelineAggregationBuilderTests extends ESTestCase {
+
+    public void testValidate() {
+        String name = randomAlphaOfLength(10);
+        MovAvgPipelineAggregationBuilder aggregationBuilder = new MovAvgPipelineAggregationBuilder(name, randomAlphaOfLength(10));
+        PipelineAggregationBuilder.ValidationContext validationContext = PipelineAggregationBuilder.ValidationContext.forInsideTree(
+            mock(AggregationBuilder.class),
+            null
+        );
+        aggregationBuilder.model(new HoltWintersModel.HoltWintersModelBuilder().period(20).build());
+        aggregationBuilder.validate(validationContext);
+        List<String> errors = validationContext.getValidationException().validationErrors();
+        assertThat(
+            errors,
+            equalTo(
+                Collections.singletonList(
+                    "Field [window] must be at least twice as large as the period when using Holt-Winters.  "
+                        + "Value provided was [5], which is less than (2*period) == 40"
+                )
+            )
+        );
+    }
+}


### PR DESCRIPTION
The `validate` method should not throw exceptions but collect validation errors. `MovAvgPipelineAggregationBuilder`
 violates this assumption. This [issue](https://gradle-enterprise.elastic.co/s/j4omqqnfu6ey4/console-log/raw) is detected by the recently added [safeguard](https://github.com/elastic/elasticsearch/commit/a7b591b03f27a40d63865ed30fd3fe37b85b3b34#diff-4bf516d2a8a8dfe9f79ccb38316dc5516486adf9ea462ebfc605b56b4b8cacd4R47.) to TransportAction.

Relates #88729