### PR TITLE
[7.17] Fix erroneous switch/cases in ILM tests

### DIFF
--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/CopyExecutionStateStepTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/CopyExecutionStateStepTests.java
@@ -39,7 +39,7 @@ public class CopyExecutionStateStepTests extends AbstractStepTestCase<CopyExecut
         BiFunction<String, LifecycleExecutionState, String> indexNameSupplier = instance.getTargetIndexNameSupplier();
         StepKey targetNextStepKey = instance.getTargetNextStepKey();
 
-        switch (between(0, 2)) {
+        switch (between(0, 3)) {
             case 0:
                 key = new StepKey(key.getPhase(), key.getAction(), key.getName() + randomAlphaOfLength(5));
                 break;

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/WaitForIndexColorStepTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/WaitForIndexColorStepTests.java
@@ -53,7 +53,7 @@ public class WaitForIndexColorStepTests extends AbstractStepTestCase<WaitForInde
             newColor = randomColor();
         }
 
-        switch (between(0, 2)) {
+        switch (between(0, 3)) {
             case 0:
                 key = new StepKey(key.getPhase(), key.getAction(), key.getName() + randomAlphaOfLength(5));
                 break;

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/step/info/AllocationRoutedStepInfoTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/step/info/AllocationRoutedStepInfoTests.java
@@ -50,7 +50,7 @@ public class AllocationRoutedStepInfoTests extends AbstractXContentTestCase<Allo
         long shardsToAllocate = instance.getNumberShardsLeftToAllocate();
         boolean allShardsActive = instance.allShardsActive();
         String message = instance.getMessage();
-        switch (between(0, 2)) {
+        switch (between(0, 3)) {
             case 0:
                 shardsToAllocate += between(1, 20);
                 break;


### PR DESCRIPTION
Related to https://github.com/elastic/elasticsearch/issues/88743, backport of #88748

This is a backport of the intent of #88748. The code is actually mostly different -- some of the issues that I fixed on #88748 just don't exist on 7.17, and some issues existed only on 7.17 and didn't need to be fixed on #88748.

/cc @pugnascotia 