### PR TITLE
Fix incorrect switch cases in AggregationTests

### DIFF
--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/histogram/InternalAutoDateHistogramTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/histogram/InternalAutoDateHistogramTests.java
@@ -276,7 +276,7 @@ public class InternalAutoDateHistogramTests extends InternalMultiBucketAggregati
         BucketInfo bucketInfo = instance.getBucketInfo();
         Map<String, Object> metadata = instance.getMetadata();
         long interval = instance.getBucketInnerInterval();
-        switch (between(0, 3)) {
+        switch (between(0, 4)) {
             case 0 -> name += randomAlphaOfLength(5);
             case 1 -> {
                 buckets = new ArrayList<>(buckets);

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/terms/SignificantLongTermsTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/terms/SignificantLongTermsTests.java
@@ -81,7 +81,7 @@ public class SignificantLongTermsTests extends InternalSignificantTermsTestCase 
             List<SignificantLongTerms.Bucket> buckets = longTerms.getBuckets();
             SignificanceHeuristic significanceHeuristic = longTerms.significanceHeuristic;
             Map<String, Object> metadata = longTerms.getMetadata();
-            switch (between(0, 5)) {
+            switch (between(0, 6)) {
                 case 0 -> name += randomAlphaOfLength(5);
                 case 1 -> requiredSize += between(1, 100);
                 case 2 -> minDocCount += between(1, 100);
@@ -102,7 +102,7 @@ public class SignificantLongTermsTests extends InternalSignificantTermsTestCase 
                         )
                     );
                 }
-                case 8 -> {
+                case 6 -> {
                     if (metadata == null) {
                         metadata = Maps.newMapWithExpectedSize(1);
                     } else {

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/terms/SignificantStringTermsTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/terms/SignificantStringTermsTests.java
@@ -84,7 +84,7 @@ public class SignificantStringTermsTests extends InternalSignificantTermsTestCas
             List<SignificantStringTerms.Bucket> buckets = stringTerms.getBuckets();
             SignificanceHeuristic significanceHeuristic = stringTerms.significanceHeuristic;
             Map<String, Object> metadata = stringTerms.getMetadata();
-            switch (between(0, 5)) {
+            switch (between(0, 6)) {
                 case 0 -> name += randomAlphaOfLength(5);
                 case 1 -> requiredSize += between(1, 100);
                 case 2 -> minDocCount += between(1, 100);
@@ -105,7 +105,7 @@ public class SignificantStringTermsTests extends InternalSignificantTermsTestCas
                         )
                     );
                 }
-                case 8 -> {
+                case 6 -> {
                     if (metadata == null) {
                         metadata = Maps.newMapWithExpectedSize(1);
                     } else {

--- a/server/src/test/java/org/elasticsearch/search/aggregations/metrics/InternalAvgTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/metrics/InternalAvgTests.java
@@ -108,34 +108,31 @@ public class InternalAvgTests extends InternalAggregationTestCase<InternalAvg> {
         long count = instance.getCount();
         DocValueFormat formatter = instance.getFormatter();
         Map<String, Object> metadata = instance.getMetadata();
-        switch (between(0, 2)) {
-            case 0:
-                name += randomAlphaOfLength(5);
-                break;
-            case 1:
+        switch (between(0, 3)) {
+            case 0 -> name += randomAlphaOfLength(5);
+            case 1 -> {
                 if (Double.isFinite(sum)) {
                     sum += between(1, 100);
                 } else {
                     sum = between(1, 100);
                 }
-                break;
-            case 2:
+            }
+            case 2 -> {
                 if (Double.isFinite(count)) {
                     count += between(1, 100);
                 } else {
                     count = between(1, 100);
                 }
-                break;
-            case 3:
+            }
+            case 3 -> {
                 if (metadata == null) {
                     metadata = Maps.newMapWithExpectedSize(1);
                 } else {
                     metadata = new HashMap<>(instance.getMetadata());
                 }
                 metadata.put(randomAlphaOfLength(15), randomInt());
-                break;
-            default:
-                throw new AssertionError("Illegal randomisation branch");
+            }
+            default -> throw new AssertionError("Illegal randomisation branch");
         }
         return new InternalAvg(name, sum, count, formatter, metadata);
     }

--- a/server/src/test/java/org/elasticsearch/search/aggregations/metrics/InternalGeoCentroidTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/metrics/InternalGeoCentroidTests.java
@@ -98,19 +98,17 @@ public class InternalGeoCentroidTests extends InternalAggregationTestCase<Intern
         GeoPoint centroid = instance.centroid();
         long count = instance.count();
         Map<String, Object> metadata = instance.getMetadata();
-        switch (between(0, 2)) {
-            case 0:
-                name += randomAlphaOfLength(5);
-                break;
-            case 1:
+        switch (between(0, 3)) {
+            case 0 -> name += randomAlphaOfLength(5);
+            case 1 -> {
                 count += between(1, 100);
                 if (centroid == null) {
                     // if the new count is > 0 then we need to make sure there is a
                     // centroid or the constructor will throw an exception
                     centroid = new GeoPoint(randomDoubleBetween(-90, 90, false), randomDoubleBetween(-180, 180, false));
                 }
-                break;
-            case 2:
+            }
+            case 2 -> {
                 if (centroid == null) {
                     centroid = new GeoPoint(randomDoubleBetween(-90, 90, false), randomDoubleBetween(-180, 180, false));
                     count = between(1, 100);
@@ -123,17 +121,16 @@ public class InternalGeoCentroidTests extends InternalAggregationTestCase<Intern
                     }
                     centroid = newCentroid;
                 }
-                break;
-            case 3:
+            }
+            case 3 -> {
                 if (metadata == null) {
                     metadata = Maps.newMapWithExpectedSize(1);
                 } else {
                     metadata = new HashMap<>(instance.getMetadata());
                 }
                 metadata.put(randomAlphaOfLength(15), randomInt());
-                break;
-            default:
-                throw new AssertionError("Illegal randomisation branch");
+            }
+            default -> throw new AssertionError("Illegal randomisation branch");
         }
         return new InternalGeoCentroid(name, centroid, count, metadata);
     }

--- a/server/src/test/java/org/elasticsearch/search/aggregations/metrics/InternalWeightedAvgTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/metrics/InternalWeightedAvgTests.java
@@ -74,34 +74,31 @@ public class InternalWeightedAvgTests extends InternalAggregationTestCase<Intern
         double weight = instance.getWeight();
         DocValueFormat formatter = instance.getFormatter();
         Map<String, Object> metadata = instance.getMetadata();
-        switch (between(0, 2)) {
-            case 0:
-                name += randomAlphaOfLength(5);
-                break;
-            case 1:
+        switch (between(0, 3)) {
+            case 0 -> name += randomAlphaOfLength(5);
+            case 1 -> {
                 if (Double.isFinite(sum)) {
                     sum += between(1, 100);
                 } else {
                     sum = between(1, 100);
                 }
-                break;
-            case 2:
+            }
+            case 2 -> {
                 if (Double.isFinite(weight)) {
                     weight += between(1, 100);
                 } else {
                     weight = between(1, 100);
                 }
-                break;
-            case 3:
+            }
+            case 3 -> {
                 if (metadata == null) {
                     metadata = Maps.newMapWithExpectedSize(1);
                 } else {
                     metadata = new HashMap<>(instance.getMetadata());
                 }
                 metadata.put(randomAlphaOfLength(15), randomInt());
-                break;
-            default:
-                throw new AssertionError("Illegal randomisation branch");
+            }
+            default -> throw new AssertionError("Illegal randomisation branch");
         }
         return new InternalWeightedAvg(name, sum, weight, formatter, metadata);
     }

--- a/server/src/test/java/org/elasticsearch/search/aggregations/pipeline/InternalDerivativeTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/pipeline/InternalDerivativeTests.java
@@ -59,30 +59,25 @@ public class InternalDerivativeTests extends InternalAggregationTestCase<Interna
         double normalizationFactor = instance.getNormalizationFactor();
         DocValueFormat formatter = instance.formatter();
         Map<String, Object> metadata = instance.getMetadata();
-        switch (between(0, 2)) {
-            case 0:
-                name += randomAlphaOfLength(5);
-                break;
-            case 1:
+        switch (between(0, 3)) {
+            case 0 -> name += randomAlphaOfLength(5);
+            case 1 -> {
                 if (Double.isFinite(value)) {
                     value += between(1, 100);
                 } else {
                     value = randomDoubleBetween(0, 100000, true);
                 }
-                break;
-            case 2:
-                normalizationFactor += between(1, 100);
-                break;
-            case 3:
+            }
+            case 2 -> normalizationFactor += between(1, 100);
+            case 3 -> {
                 if (metadata == null) {
                     metadata = Maps.newMapWithExpectedSize(1);
                 } else {
                     metadata = new HashMap<>(instance.getMetadata());
                 }
                 metadata.put(randomAlphaOfLength(15), randomInt());
-                break;
-            default:
-                throw new AssertionError("Illegal randomisation branch");
+            }
+            default -> throw new AssertionError("Illegal randomisation branch");
         }
         return new InternalDerivative(name, value, normalizationFactor, formatter, metadata);
     }


### PR DESCRIPTION
Fixes aggregation tests that contain switch statements with branches that will never execute. The tests use a between(x, y) switch expression, but there are case values that are outside the randomised range. 

Fixes #88745
