### PR TITLE
[ML] Rebalance model assignments when outdated assignments exist

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/assignment/RoutingInfo.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/assignment/RoutingInfo.java
@@ -95,6 +95,10 @@ public class RoutingInfo implements ToXContentObject, Writeable {
         return reason;
     }
 
+    public boolean isOutdated() {
+        return currentAllocations == 0 && targetAllocations == 0;
+    }
+
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         if (out.getVersion().onOrAfter(Version.V_8_4_0)) {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/assignment/TrainedModelAssignment.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/assignment/TrainedModelAssignment.java
@@ -199,6 +199,10 @@ public class TrainedModelAssignment implements SimpleDiffable<TrainedModelAssign
         return allocations >= taskParams.getNumberOfAllocations();
     }
 
+    public boolean hasOutdatedRoutingEntries() {
+        return nodeRoutingTable.values().stream().anyMatch(RoutingInfo::isOutdated);
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
@@ -288,6 +292,11 @@ public class TrainedModelAssignment implements SimpleDiffable<TrainedModelAssign
 
         private Builder(StartTrainedModelDeploymentAction.TaskParams taskParams) {
             this(taskParams, new LinkedHashMap<>(), AssignmentState.STARTING, null, Instant.now());
+        }
+
+        public Builder setStartTime(Instant startTime) {
+            this.startTime = startTime;
+            return this;
         }
 
         public Builder addRoutingEntry(String nodeId, RoutingInfo routingInfo) {

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/assignment/TrainedModelAssignmentClusterService.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/assignment/TrainedModelAssignmentClusterService.java
@@ -566,9 +566,15 @@ public class TrainedModelAssignmentClusterService implements ClusterStateListene
 
         // If an ML persistent task with process stopped we should rebalance as we could have
         // available memory that we did not have before.
-        return detectReasonIfMlJobsStopped(event).or(
-            () -> Optional.ofNullable(haveMlNodesChanged(event, newMetadata) ? "nodes changed" : null)
-        );
+        return detectReasonIfMlJobsStopped(event).or(() -> {
+            String reason = null;
+            if (haveMlNodesChanged(event, newMetadata)) {
+                reason = "nodes changed";
+            } else if (newMetadata.hasOutdatedAssignments()) {
+                reason = "outdated assignments detected";
+            }
+            return Optional.ofNullable(reason);
+        });
     }
 
     static Optional<String> detectReasonIfMlJobsStopped(ClusterChangedEvent event) {

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/assignment/TrainedModelAssignmentMetadata.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/assignment/TrainedModelAssignmentMetadata.java
@@ -155,6 +155,14 @@ public class TrainedModelAssignmentMetadata implements Metadata.Custom {
         return Strings.toString(this);
     }
 
+    public boolean hasOutdatedAssignments() {
+        return modelRoutingEntries.values().stream().anyMatch(TrainedModelAssignment::hasOutdatedRoutingEntries);
+    }
+
+    public boolean hasModel(String modelId) {
+        return modelRoutingEntries.containsKey(modelId);
+    }
+
     public static class Builder {
 
         public static Builder empty() {

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/assignment/TrainedModelAssignmentRebalancer.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/assignment/TrainedModelAssignmentRebalancer.java
@@ -54,25 +54,23 @@ class TrainedModelAssignmentRebalancer {
     }
 
     TrainedModelAssignmentMetadata.Builder rebalance() throws Exception {
-        TrainedModelAssignmentMetadata.Builder builder = TrainedModelAssignmentMetadata.Builder.fromMetadata(currentMetadata);
-        if (modelToAdd.isPresent() && builder.hasModel(modelToAdd.get().getModelId())) {
+        if (modelToAdd.isPresent() && currentMetadata.hasModel(modelToAdd.get().getModelId())) {
             throw new ResourceAlreadyExistsException("assignment for model with id [{}] already exists", modelToAdd.get().getModelId());
         }
 
-        if (modelToAdd.isEmpty() && areAllModelsSatisfied()) {
+        if (modelToAdd.isEmpty() && areAllModelsSatisfiedAndNoOutdatedRoutingEntries()) {
             logger.trace(() -> "No need to rebalance as all model deployments are satisfied");
-            return builder;
+            return TrainedModelAssignmentMetadata.Builder.fromMetadata(currentMetadata);
         }
 
         AssignmentPlan assignmentPlan = computeAssignmentPlan();
-        buildAssignmentsFromPlan(assignmentPlan, builder);
-        return builder;
+        return buildAssignmentsFromPlan(assignmentPlan);
     }
 
-    private boolean areAllModelsSatisfied() {
+    private boolean areAllModelsSatisfiedAndNoOutdatedRoutingEntries() {
         Set<String> assignableNodeIds = nodeLoads.keySet().stream().map(DiscoveryNode::getId).collect(Collectors.toSet());
         for (TrainedModelAssignment model : currentMetadata.modelAssignments().values()) {
-            if (model.isSatisfied(assignableNodeIds) == false) {
+            if (model.isSatisfied(assignableNodeIds) == false || model.hasOutdatedRoutingEntries()) {
                 return false;
             }
         }
@@ -147,7 +145,8 @@ class TrainedModelAssignmentRebalancer {
         return load.getFreeMemoryExcludingPerNodeOverhead() - load.getAssignedNativeInferenceMemory();
     }
 
-    private void buildAssignmentsFromPlan(AssignmentPlan assignmentPlan, TrainedModelAssignmentMetadata.Builder builder) {
+    private TrainedModelAssignmentMetadata.Builder buildAssignmentsFromPlan(AssignmentPlan assignmentPlan) {
+        TrainedModelAssignmentMetadata.Builder builder = TrainedModelAssignmentMetadata.Builder.empty();
         for (AssignmentPlan.Model model : assignmentPlan.models()) {
             TrainedModelAssignment existingAssignment = currentMetadata.getModelAssignment(model.id());
 
@@ -156,6 +155,9 @@ class TrainedModelAssignmentRebalancer {
                     ? modelToAdd.get()
                     : currentMetadata.getModelAssignment(model.id()).getTaskParams()
             );
+            if (existingAssignment != null) {
+                assignmentBuilder.setStartTime(existingAssignment.getStartTime());
+            }
 
             Map<AssignmentPlan.Node, Integer> assignments = assignmentPlan.assignments(model).orElseGet(Map::of);
             for (Map.Entry<AssignmentPlan.Node, Integer> assignment : assignments.entrySet()) {
@@ -181,12 +183,9 @@ class TrainedModelAssignmentRebalancer {
             assignmentBuilder.calculateAndSetAssignmentState();
 
             explainAssignments(assignmentPlan, nodeLoads, model).ifPresent(assignmentBuilder::setReason);
-            if (existingAssignment == null) {
-                builder.addNewAssignment(model.id(), assignmentBuilder);
-            } else {
-                builder.updateAssignment(model.id(), assignmentBuilder);
-            }
+            builder.addNewAssignment(model.id(), assignmentBuilder);
         }
+        return builder;
     }
 
     private Optional<String> explainAssignments(

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/assignment/TrainedModelAssignmentRebalancerTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/assignment/TrainedModelAssignmentRebalancerTests.java
@@ -23,6 +23,7 @@ import org.elasticsearch.xpack.ml.MachineLearning;
 import org.elasticsearch.xpack.ml.job.NodeLoad;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
@@ -43,6 +44,74 @@ public class TrainedModelAssignmentRebalancerTests extends ESTestCase {
             Optional.empty()
         ).rebalance().build();
         assertThat(result.modelAssignments().isEmpty(), is(true));
+    }
+
+    public void testRebalance_GivenAllAssignmentsAreSatisfied_ShouldMakeNoChanges() throws Exception {
+        String modelId1 = "model-1";
+        String modelId2 = "model-2";
+        StartTrainedModelDeploymentAction.TaskParams taskParams1 = newParams(modelId1, 1024L, 1, 2);
+        StartTrainedModelDeploymentAction.TaskParams taskParams2 = newParams(modelId2, 1024L, 4, 1);
+        TrainedModelAssignmentMetadata currentMetadata = TrainedModelAssignmentMetadata.Builder.empty()
+            .addNewAssignment(
+                modelId1,
+                TrainedModelAssignment.Builder.empty(taskParams1).addRoutingEntry("node-1", new RoutingInfo(1, 1, RoutingState.STARTED, ""))
+            )
+            .addNewAssignment(
+                modelId2,
+                TrainedModelAssignment.Builder.empty(taskParams2)
+                    .addRoutingEntry("node-1", new RoutingInfo(1, 1, RoutingState.STARTED, ""))
+                    .addRoutingEntry("node-2", new RoutingInfo(3, 3, RoutingState.STARTED, ""))
+            )
+            .build();
+        Map<DiscoveryNode, NodeLoad> nodeLoads = new HashMap<>();
+        long oneGbBytes = ByteSizeValue.ofGb(1).getBytes();
+        nodeLoads.put(buildNode("node-1", oneGbBytes, 4), NodeLoad.builder("node-1").setMaxMemory(oneGbBytes).build());
+        nodeLoads.put(buildNode("node-2", oneGbBytes, 4), NodeLoad.builder("node-2").setMaxMemory(oneGbBytes).build());
+
+        TrainedModelAssignmentMetadata result = new TrainedModelAssignmentRebalancer(currentMetadata, nodeLoads, Optional.empty())
+            .rebalance()
+            .build();
+
+        assertThat(currentMetadata, equalTo(result));
+    }
+
+    public void testRebalance_GivenAllAssignmentsAreSatisfied_GivenOutdatedRoutingEntry_ShouldRebalance() throws Exception {
+        String modelId1 = "model-1";
+        String modelId2 = "model-2";
+        StartTrainedModelDeploymentAction.TaskParams taskParams1 = newParams(modelId1, 1024L, 1, 2);
+        StartTrainedModelDeploymentAction.TaskParams taskParams2 = newParams(modelId2, 1024L, 4, 1);
+        TrainedModelAssignmentMetadata currentMetadata = TrainedModelAssignmentMetadata.Builder.empty()
+            .addNewAssignment(
+                modelId1,
+                TrainedModelAssignment.Builder.empty(taskParams1).addRoutingEntry("node-1", new RoutingInfo(0, 0, RoutingState.STARTED, ""))
+            )
+            .addNewAssignment(
+                modelId2,
+                TrainedModelAssignment.Builder.empty(taskParams2)
+                    .addRoutingEntry("node-1", new RoutingInfo(1, 1, RoutingState.STARTED, ""))
+                    .addRoutingEntry("node-2", new RoutingInfo(3, 3, RoutingState.STARTED, ""))
+            )
+            .build();
+        Map<DiscoveryNode, NodeLoad> nodeLoads = new HashMap<>();
+        long oneGbBytes = ByteSizeValue.ofGb(1).getBytes();
+        nodeLoads.put(buildNode("node-1", oneGbBytes, 4), NodeLoad.builder("node-1").setMaxMemory(oneGbBytes).build());
+        nodeLoads.put(buildNode("node-2", oneGbBytes, 4), NodeLoad.builder("node-2").setMaxMemory(oneGbBytes).build());
+
+        TrainedModelAssignmentMetadata result = new TrainedModelAssignmentRebalancer(currentMetadata, nodeLoads, Optional.empty())
+            .rebalance()
+            .build();
+
+        assertThat(result.modelAssignments(), is(aMapWithSize(2)));
+
+        for (String modelId : List.of(modelId1, modelId2)) {
+            TrainedModelAssignment assignment = result.getModelAssignment(modelId);
+            assertThat(assignment, is(notNullValue()));
+            assertThat(assignment.hasOutdatedRoutingEntries(), is(false));
+            assertThat(
+                assignment.getNodeRoutingTable().values().stream().mapToInt(RoutingInfo::getTargetAllocations).sum(),
+                equalTo(currentMetadata.getModelAssignment(modelId).getTaskParams().getNumberOfAllocations())
+            );
+        }
     }
 
     public void testRebalance_GivenModelToAddAlreadyExists() {


### PR DESCRIPTION
When a cluster has been updated from a version prior to the version
when distributed model allocation was introduced (8.4), there is
a possibility that after the full cluster has been upgraded there
still are assignments with routing entries that have `current_allocations`
and `target_allocations` equal to `0`. Those are outdated and we
should trigger a rebalance in order to apply the new distributed
model allocation.

This commit detects that and ensures a rebalance is done in such
scenario.

In addition, this fixes a bug where previous routing entries on
nodes where the planner does not assign any allocations for a model
would stick around.
