### PR TITLE
[main] Update the Link of "Expected reciprocal rank for graded relevance" (#88763)

### DIFF
--- a/docs/reference/search/rank-eval.asciidoc
+++ b/docs/reference/search/rank-eval.asciidoc
@@ -430,7 +430,7 @@ in the query. Defaults to 10.
 Expected Reciprocal Rank (ERR) is an extension of the classical reciprocal rank
 for the graded relevance case (Olivier Chapelle, Donald Metzler, Ya Zhang, and
 Pierre Grinspan. 2009.
-https://olivier.chapelle.cc/pub/err.pdf[Expected reciprocal rank for graded relevance].)
+https://www.researchgate.net/publication/220269787_Expected_reciprocal_rank_for_graded_relevance[Expected reciprocal rank for graded relevance].)
 
 It is based on the assumption of a cascade model of search, in which a user
 scans through ranked search results in order and stops at the first document


### PR DESCRIPTION
# Backport

This will backport the following commits from `8.3` to `main`:
 - [Update the Link of "Expected reciprocal rank for graded relevance" (#88763)](https://github.com/elastic/elasticsearch/pull/88763)

<!--- Backport version: 8.9.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)