### PR TITLE
[7.17] Fix incorrect switch cases in AggregationTests

### DIFF
--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/terms/SignificantLongTermsTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/terms/SignificantLongTermsTests.java
@@ -81,23 +81,13 @@ public class SignificantLongTermsTests extends InternalSignificantTermsTestCase 
             List<SignificantLongTerms.Bucket> buckets = longTerms.getBuckets();
             SignificanceHeuristic significanceHeuristic = longTerms.significanceHeuristic;
             Map<String, Object> metadata = longTerms.getMetadata();
-            switch (between(0, 5)) {
-                case 0:
-                    name += randomAlphaOfLength(5);
-                    break;
-                case 1:
-                    requiredSize += between(1, 100);
-                    break;
-                case 2:
-                    minDocCount += between(1, 100);
-                    break;
-                case 3:
-                    subsetSize += between(1, 100);
-                    break;
-                case 4:
-                    supersetSize += between(1, 100);
-                    break;
-                case 5:
+            switch (between(0, 6)) {
+                case 0 -> name += randomAlphaOfLength(5);
+                case 1 -> requiredSize += between(1, 100);
+                case 2 -> minDocCount += between(1, 100);
+                case 3 -> subsetSize += between(1, 100);
+                case 4 -> supersetSize += between(1, 100);
+                case 5 -> {
                     buckets = new ArrayList<>(buckets);
                     buckets.add(
                         new SignificantLongTerms.Bucket(
@@ -111,8 +101,8 @@ public class SignificantLongTermsTests extends InternalSignificantTermsTestCase 
                             0
                         )
                     );
-                    break;
-                case 8:
+                }
+                case 6 -> {
                     if (metadata == null) {
                         metadata = new HashMap<>(1);
                     } else {
@@ -140,25 +130,18 @@ public class SignificantLongTermsTests extends InternalSignificantTermsTestCase 
             long minDocCount = instance.minDocCount;
             Map<String, Object> metadata = instance.getMetadata();
             switch (between(0, 3)) {
-                case 0:
-                    name += randomAlphaOfLength(5);
-                    break;
-                case 1:
-                    requiredSize += between(1, 100);
-                    break;
-                case 2:
-                    minDocCount += between(1, 100);
-                    break;
-                case 3:
+                case 0 -> name += randomAlphaOfLength(5);
+                case 1 -> requiredSize += between(1, 100);
+                case 2 -> minDocCount += between(1, 100);
+                case 3 -> {
                     if (metadata == null) {
-                        metadata = new HashMap<>(1);
+                        metadata = Maps.newMapWithExpectedSize(1);
                     } else {
                         metadata = new HashMap<>(instance.getMetadata());
                     }
                     metadata.put(randomAlphaOfLength(15), randomInt());
-                    break;
-                default:
-                    throw new AssertionError("Illegal randomisation branch");
+                }
+                default -> throw new AssertionError("Illegal randomisation branch");
             }
             return new UnmappedSignificantTerms(name, requiredSize, minDocCount, metadata);
         }

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/terms/SignificantLongTermsTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/terms/SignificantLongTermsTests.java
@@ -82,12 +82,22 @@ public class SignificantLongTermsTests extends InternalSignificantTermsTestCase 
             SignificanceHeuristic significanceHeuristic = longTerms.significanceHeuristic;
             Map<String, Object> metadata = longTerms.getMetadata();
             switch (between(0, 6)) {
-                case 0 -> name += randomAlphaOfLength(5);
-                case 1 -> requiredSize += between(1, 100);
-                case 2 -> minDocCount += between(1, 100);
-                case 3 -> subsetSize += between(1, 100);
-                case 4 -> supersetSize += between(1, 100);
-                case 5 -> {
+                case 0:
+                    name += randomAlphaOfLength(5);
+                    break;
+                case 1:
+                    requiredSize += between(1, 100);
+                    break;
+                case 2:
+                    minDocCount += between(1, 100);
+                    break;
+                case 3:
+                    subsetSize += between(1, 100);
+                    break;
+                case 4:
+                    supersetSize += between(1, 100);
+                    break;
+                case 5:
                     buckets = new ArrayList<>(buckets);
                     buckets.add(
                         new SignificantLongTerms.Bucket(
@@ -101,8 +111,8 @@ public class SignificantLongTermsTests extends InternalSignificantTermsTestCase 
                             0
                         )
                     );
-                }
-                case 6 -> {
+                    break;
+                case 6:
                     if (metadata == null) {
                         metadata = new HashMap<>(1);
                     } else {
@@ -130,18 +140,25 @@ public class SignificantLongTermsTests extends InternalSignificantTermsTestCase 
             long minDocCount = instance.minDocCount;
             Map<String, Object> metadata = instance.getMetadata();
             switch (between(0, 3)) {
-                case 0 -> name += randomAlphaOfLength(5);
-                case 1 -> requiredSize += between(1, 100);
-                case 2 -> minDocCount += between(1, 100);
-                case 3 -> {
+                case 0:
+                    name += randomAlphaOfLength(5);
+                    break;
+                case 1:
+                    requiredSize += between(1, 100);
+                    break;
+                case 2:
+                    minDocCount += between(1, 100);
+                    break;
+                case 3:
                     if (metadata == null) {
-                        metadata = Maps.newMapWithExpectedSize(1);
+                        metadata = new HashMap<>(1);
                     } else {
                         metadata = new HashMap<>(instance.getMetadata());
                     }
                     metadata.put(randomAlphaOfLength(15), randomInt());
-                }
-                default -> throw new AssertionError("Illegal randomisation branch");
+                    break;
+                default:
+                    throw new AssertionError("Illegal randomisation branch");
             }
             return new UnmappedSignificantTerms(name, requiredSize, minDocCount, metadata);
         }

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/terms/SignificantStringTermsTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/terms/SignificantStringTermsTests.java
@@ -85,12 +85,22 @@ public class SignificantStringTermsTests extends InternalSignificantTermsTestCas
             SignificanceHeuristic significanceHeuristic = stringTerms.significanceHeuristic;
             Map<String, Object> metadata = stringTerms.getMetadata();
             switch (between(0, 6)) {
-                case 0 -> name += randomAlphaOfLength(5);
-                case 1 -> requiredSize += between(1, 100);
-                case 2 -> minDocCount += between(1, 100);
-                case 3 -> subsetSize += between(1, 100);
-                case 4 -> supersetSize += between(1, 100);
-                case 5 -> {
+                case 0:
+                    name += randomAlphaOfLength(5);
+                    break;
+                case 1:
+                    requiredSize += between(1, 100);
+                    break;
+                case 2:
+                    minDocCount += between(1, 100);
+                    break;
+                case 3:
+                    subsetSize += between(1, 100);
+                    break;
+                case 4:
+                    supersetSize += between(1, 100);
+                    break;
+                case 5:
                     buckets = new ArrayList<>(buckets);
                     buckets.add(
                         new SignificantStringTerms.Bucket(
@@ -104,8 +114,8 @@ public class SignificantStringTermsTests extends InternalSignificantTermsTestCas
                             0
                         )
                     );
-                }
-                case 6 -> {
+                    break;
+                case 6:
                     if (metadata == null) {
                         metadata = new HashMap<>(1);
                     } else {
@@ -133,18 +143,25 @@ public class SignificantStringTermsTests extends InternalSignificantTermsTestCas
             long minDocCount = instance.minDocCount;
             Map<String, Object> metadata = instance.getMetadata();
             switch (between(0, 3)) {
-                case 0 -> name += randomAlphaOfLength(5);
-                case 1 -> requiredSize += between(1, 100);
-                case 2 -> minDocCount += between(1, 100);
-                case 3 -> {
+                case 0:
+                    name += randomAlphaOfLength(5);
+                    break;
+                case 1:
+                    requiredSize += between(1, 100);
+                    break;
+                case 2:
+                    minDocCount += between(1, 100);
+                    break;
+                case 3:
                     if (metadata == null) {
-                        metadata = Maps.newMapWithExpectedSize(1);
+                        metadata = new HashMap<>(1);
                     } else {
                         metadata = new HashMap<>(instance.getMetadata());
                     }
                     metadata.put(randomAlphaOfLength(15), randomInt());
-                }
-                default -> throw new AssertionError("Illegal randomisation branch");
+                    break;
+                default:
+                    throw new AssertionError("Illegal randomisation branch");
             }
             return new UnmappedSignificantTerms(name, requiredSize, minDocCount, metadata);
         }

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/terms/SignificantStringTermsTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/terms/SignificantStringTermsTests.java
@@ -84,23 +84,13 @@ public class SignificantStringTermsTests extends InternalSignificantTermsTestCas
             List<SignificantStringTerms.Bucket> buckets = stringTerms.getBuckets();
             SignificanceHeuristic significanceHeuristic = stringTerms.significanceHeuristic;
             Map<String, Object> metadata = stringTerms.getMetadata();
-            switch (between(0, 5)) {
-                case 0:
-                    name += randomAlphaOfLength(5);
-                    break;
-                case 1:
-                    requiredSize += between(1, 100);
-                    break;
-                case 2:
-                    minDocCount += between(1, 100);
-                    break;
-                case 3:
-                    subsetSize += between(1, 100);
-                    break;
-                case 4:
-                    supersetSize += between(1, 100);
-                    break;
-                case 5:
+            switch (between(0, 6)) {
+                case 0 -> name += randomAlphaOfLength(5);
+                case 1 -> requiredSize += between(1, 100);
+                case 2 -> minDocCount += between(1, 100);
+                case 3 -> subsetSize += between(1, 100);
+                case 4 -> supersetSize += between(1, 100);
+                case 5 -> {
                     buckets = new ArrayList<>(buckets);
                     buckets.add(
                         new SignificantStringTerms.Bucket(
@@ -114,8 +104,8 @@ public class SignificantStringTermsTests extends InternalSignificantTermsTestCas
                             0
                         )
                     );
-                    break;
-                case 8:
+                }
+                case 6 -> {
                     if (metadata == null) {
                         metadata = new HashMap<>(1);
                     } else {
@@ -143,25 +133,18 @@ public class SignificantStringTermsTests extends InternalSignificantTermsTestCas
             long minDocCount = instance.minDocCount;
             Map<String, Object> metadata = instance.getMetadata();
             switch (between(0, 3)) {
-                case 0:
-                    name += randomAlphaOfLength(5);
-                    break;
-                case 1:
-                    requiredSize += between(1, 100);
-                    break;
-                case 2:
-                    minDocCount += between(1, 100);
-                    break;
-                case 3:
+                case 0 -> name += randomAlphaOfLength(5);
+                case 1 -> requiredSize += between(1, 100);
+                case 2 -> minDocCount += between(1, 100);
+                case 3 -> {
                     if (metadata == null) {
-                        metadata = new HashMap<>(1);
+                        metadata = Maps.newMapWithExpectedSize(1);
                     } else {
                         metadata = new HashMap<>(instance.getMetadata());
                     }
                     metadata.put(randomAlphaOfLength(15), randomInt());
-                    break;
-                default:
-                    throw new AssertionError("Illegal randomisation branch");
+                }
+                default -> throw new AssertionError("Illegal randomisation branch");
             }
             return new UnmappedSignificantTerms(name, requiredSize, minDocCount, metadata);
         }

--- a/server/src/test/java/org/elasticsearch/search/aggregations/metrics/InternalAvgTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/metrics/InternalAvgTests.java
@@ -96,34 +96,31 @@ public class InternalAvgTests extends InternalAggregationTestCase<InternalAvg> {
         long count = instance.getCount();
         DocValueFormat formatter = instance.getFormatter();
         Map<String, Object> metadata = instance.getMetadata();
-        switch (between(0, 2)) {
-            case 0:
-                name += randomAlphaOfLength(5);
-                break;
-            case 1:
+        switch (between(0, 3)) {
+            case 0 -> name += randomAlphaOfLength(5);
+            case 1 -> {
                 if (Double.isFinite(sum)) {
                     sum += between(1, 100);
                 } else {
                     sum = between(1, 100);
                 }
-                break;
-            case 2:
+            }
+            case 2 -> {
                 if (Double.isFinite(count)) {
                     count += between(1, 100);
                 } else {
                     count = between(1, 100);
                 }
-                break;
-            case 3:
+            }
+            case 3 -> {
                 if (metadata == null) {
                     metadata = new HashMap<>(1);
                 } else {
                     metadata = new HashMap<>(instance.getMetadata());
                 }
                 metadata.put(randomAlphaOfLength(15), randomInt());
-                break;
-            default:
-                throw new AssertionError("Illegal randomisation branch");
+            }
+            default -> throw new AssertionError("Illegal randomisation branch");
         }
         return new InternalAvg(name, sum, count, formatter, metadata);
     }

--- a/server/src/test/java/org/elasticsearch/search/aggregations/metrics/InternalAvgTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/metrics/InternalAvgTests.java
@@ -97,30 +97,33 @@ public class InternalAvgTests extends InternalAggregationTestCase<InternalAvg> {
         DocValueFormat formatter = instance.getFormatter();
         Map<String, Object> metadata = instance.getMetadata();
         switch (between(0, 3)) {
-            case 0 -> name += randomAlphaOfLength(5);
-            case 1 -> {
+            case 0:
+                name += randomAlphaOfLength(5);
+                break;
+            case 1:
                 if (Double.isFinite(sum)) {
                     sum += between(1, 100);
                 } else {
                     sum = between(1, 100);
                 }
-            }
-            case 2 -> {
+                break;
+            case 2:
                 if (Double.isFinite(count)) {
                     count += between(1, 100);
                 } else {
                     count = between(1, 100);
                 }
-            }
-            case 3 -> {
+                break;
+            case 3:
                 if (metadata == null) {
                     metadata = new HashMap<>(1);
                 } else {
                     metadata = new HashMap<>(instance.getMetadata());
                 }
                 metadata.put(randomAlphaOfLength(15), randomInt());
-            }
-            default -> throw new AssertionError("Illegal randomisation branch");
+                break;
+            default:
+                throw new AssertionError("Illegal randomisation branch");
         }
         return new InternalAvg(name, sum, count, formatter, metadata);
     }

--- a/server/src/test/java/org/elasticsearch/search/aggregations/metrics/InternalGeoCentroidTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/metrics/InternalGeoCentroidTests.java
@@ -84,19 +84,17 @@ public class InternalGeoCentroidTests extends InternalAggregationTestCase<Intern
         GeoPoint centroid = instance.centroid();
         long count = instance.count();
         Map<String, Object> metadata = instance.getMetadata();
-        switch (between(0, 2)) {
-            case 0:
-                name += randomAlphaOfLength(5);
-                break;
-            case 1:
+        switch (between(0, 3)) {
+            case 0 -> name += randomAlphaOfLength(5);
+            case 1 -> {
                 count += between(1, 100);
                 if (centroid == null) {
                     // if the new count is > 0 then we need to make sure there is a
                     // centroid or the constructor will throw an exception
                     centroid = new GeoPoint(randomDoubleBetween(-90, 90, false), randomDoubleBetween(-180, 180, false));
                 }
-                break;
-            case 2:
+            }
+            case 2 -> {
                 if (centroid == null) {
                     centroid = new GeoPoint(randomDoubleBetween(-90, 90, false), randomDoubleBetween(-180, 180, false));
                     count = between(1, 100);
@@ -109,17 +107,16 @@ public class InternalGeoCentroidTests extends InternalAggregationTestCase<Intern
                     }
                     centroid = newCentroid;
                 }
-                break;
-            case 3:
+            }
+            case 3 -> {
                 if (metadata == null) {
                     metadata = new HashMap<>(1);
                 } else {
                     metadata = new HashMap<>(instance.getMetadata());
                 }
                 metadata.put(randomAlphaOfLength(15), randomInt());
-                break;
-            default:
-                throw new AssertionError("Illegal randomisation branch");
+            }
+            default -> throw new AssertionError("Illegal randomisation branch");
         }
         return new InternalGeoCentroid(name, centroid, count, metadata);
     }

--- a/server/src/test/java/org/elasticsearch/search/aggregations/metrics/InternalGeoCentroidTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/metrics/InternalGeoCentroidTests.java
@@ -85,16 +85,18 @@ public class InternalGeoCentroidTests extends InternalAggregationTestCase<Intern
         long count = instance.count();
         Map<String, Object> metadata = instance.getMetadata();
         switch (between(0, 3)) {
-            case 0 -> name += randomAlphaOfLength(5);
-            case 1 -> {
+            case 0:
+                name += randomAlphaOfLength(5);
+                break;
+            case 1:
                 count += between(1, 100);
                 if (centroid == null) {
                     // if the new count is > 0 then we need to make sure there is a
                     // centroid or the constructor will throw an exception
                     centroid = new GeoPoint(randomDoubleBetween(-90, 90, false), randomDoubleBetween(-180, 180, false));
                 }
-            }
-            case 2 -> {
+                break;
+            case 2:
                 if (centroid == null) {
                     centroid = new GeoPoint(randomDoubleBetween(-90, 90, false), randomDoubleBetween(-180, 180, false));
                     count = between(1, 100);
@@ -107,16 +109,17 @@ public class InternalGeoCentroidTests extends InternalAggregationTestCase<Intern
                     }
                     centroid = newCentroid;
                 }
-            }
-            case 3 -> {
+                break;
+            case 3:
                 if (metadata == null) {
                     metadata = new HashMap<>(1);
                 } else {
                     metadata = new HashMap<>(instance.getMetadata());
                 }
                 metadata.put(randomAlphaOfLength(15), randomInt());
-            }
-            default -> throw new AssertionError("Illegal randomisation branch");
+                break;
+            default:
+                throw new AssertionError("Illegal randomisation branch");
         }
         return new InternalGeoCentroid(name, centroid, count, metadata);
     }

--- a/server/src/test/java/org/elasticsearch/search/aggregations/metrics/InternalWeightedAvgTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/metrics/InternalWeightedAvgTests.java
@@ -60,34 +60,31 @@ public class InternalWeightedAvgTests extends InternalAggregationTestCase<Intern
         double weight = instance.getWeight();
         DocValueFormat formatter = instance.getFormatter();
         Map<String, Object> metadata = instance.getMetadata();
-        switch (between(0, 2)) {
-            case 0:
-                name += randomAlphaOfLength(5);
-                break;
-            case 1:
+        switch (between(0, 3)) {
+            case 0 -> name += randomAlphaOfLength(5);
+            case 1 -> {
                 if (Double.isFinite(sum)) {
                     sum += between(1, 100);
                 } else {
                     sum = between(1, 100);
                 }
-                break;
-            case 2:
+            }
+            case 2 -> {
                 if (Double.isFinite(weight)) {
                     weight += between(1, 100);
                 } else {
                     weight = between(1, 100);
                 }
-                break;
-            case 3:
+            }
+            case 3 -> {
                 if (metadata == null) {
                     metadata = new HashMap<>(1);
                 } else {
                     metadata = new HashMap<>(instance.getMetadata());
                 }
                 metadata.put(randomAlphaOfLength(15), randomInt());
-                break;
-            default:
-                throw new AssertionError("Illegal randomisation branch");
+            }
+            default -> throw new AssertionError("Illegal randomisation branch");
         }
         return new InternalWeightedAvg(name, sum, weight, formatter, metadata);
     }

--- a/server/src/test/java/org/elasticsearch/search/aggregations/metrics/InternalWeightedAvgTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/metrics/InternalWeightedAvgTests.java
@@ -61,30 +61,33 @@ public class InternalWeightedAvgTests extends InternalAggregationTestCase<Intern
         DocValueFormat formatter = instance.getFormatter();
         Map<String, Object> metadata = instance.getMetadata();
         switch (between(0, 3)) {
-            case 0 -> name += randomAlphaOfLength(5);
-            case 1 -> {
+            case 0:
+                name += randomAlphaOfLength(5);
+                break;
+            case 1:
                 if (Double.isFinite(sum)) {
                     sum += between(1, 100);
                 } else {
                     sum = between(1, 100);
                 }
-            }
-            case 2 -> {
+                break;
+            case 2:
                 if (Double.isFinite(weight)) {
                     weight += between(1, 100);
                 } else {
                     weight = between(1, 100);
                 }
-            }
-            case 3 -> {
+                break;
+            case 3:
                 if (metadata == null) {
                     metadata = new HashMap<>(1);
                 } else {
                     metadata = new HashMap<>(instance.getMetadata());
                 }
                 metadata.put(randomAlphaOfLength(15), randomInt());
-            }
-            default -> throw new AssertionError("Illegal randomisation branch");
+                break;
+            default:
+                throw new AssertionError("Illegal randomisation branch");
         }
         return new InternalWeightedAvg(name, sum, weight, formatter, metadata);
     }

--- a/server/src/test/java/org/elasticsearch/search/aggregations/pipeline/InternalDerivativeTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/pipeline/InternalDerivativeTests.java
@@ -59,24 +59,29 @@ public class InternalDerivativeTests extends InternalAggregationTestCase<Interna
         DocValueFormat formatter = instance.formatter();
         Map<String, Object> metadata = instance.getMetadata();
         switch (between(0, 3)) {
-            case 0 -> name += randomAlphaOfLength(5);
-            case 1 -> {
+            case 0:
+                name += randomAlphaOfLength(5);
+                break;
+            case 1:
                 if (Double.isFinite(value)) {
                     value += between(1, 100);
                 } else {
                     value = randomDoubleBetween(0, 100000, true);
                 }
-            }
-            case 2 -> normalizationFactor += between(1, 100);
-            case 3 -> {
+                break;
+            case 2:
+                normalizationFactor += between(1, 100);
+                break;
+            case 3:
                 if (metadata == null) {
                     metadata = new HashMap<>(1);
                 } else {
                     metadata = new HashMap<>(instance.getMetadata());
                 }
                 metadata.put(randomAlphaOfLength(15), randomInt());
-            }
-            default -> throw new AssertionError("Illegal randomisation branch");
+                break;
+            default:
+                throw new AssertionError("Illegal randomisation branch");
         }
         return new InternalDerivative(name, value, normalizationFactor, formatter, metadata);
     }

--- a/server/src/test/java/org/elasticsearch/search/aggregations/pipeline/InternalDerivativeTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/pipeline/InternalDerivativeTests.java
@@ -58,30 +58,25 @@ public class InternalDerivativeTests extends InternalAggregationTestCase<Interna
         double normalizationFactor = instance.getNormalizationFactor();
         DocValueFormat formatter = instance.formatter();
         Map<String, Object> metadata = instance.getMetadata();
-        switch (between(0, 2)) {
-            case 0:
-                name += randomAlphaOfLength(5);
-                break;
-            case 1:
+        switch (between(0, 3)) {
+            case 0 -> name += randomAlphaOfLength(5);
+            case 1 -> {
                 if (Double.isFinite(value)) {
                     value += between(1, 100);
                 } else {
                     value = randomDoubleBetween(0, 100000, true);
                 }
-                break;
-            case 2:
-                normalizationFactor += between(1, 100);
-                break;
-            case 3:
+            }
+            case 2 -> normalizationFactor += between(1, 100);
+            case 3 -> {
                 if (metadata == null) {
                     metadata = new HashMap<>(1);
                 } else {
                     metadata = new HashMap<>(instance.getMetadata());
                 }
                 metadata.put(randomAlphaOfLength(15), randomInt());
-                break;
-            default:
-                throw new AssertionError("Illegal randomisation branch");
+            }
+            default -> throw new AssertionError("Illegal randomisation branch");
         }
         return new InternalDerivative(name, value, normalizationFactor, formatter, metadata);
     }


### PR DESCRIPTION
Backports https://github.com/elastic/elasticsearch/pull/88757 to 7.17

> Fixes aggregation tests that contain switch statements with branches that will never execute. The tests use a between(x, y) switch expression, but there are case values that are outside the randomised range.
> 
> Fixes https://github.com/elastic/elasticsearch/issues/88745