### PR TITLE
Expanding switch statement to cover all cases in ConvertProcessorTests

### DIFF
--- a/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/ConvertProcessorTests.java
+++ b/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/ConvertProcessorTests.java
@@ -416,7 +416,7 @@ public class ConvertProcessorTests extends ESTestCase {
         for (int j = 0; j < numItems; j++) {
             Object randomValue;
             String randomValueString;
-            switch (randomIntBetween(0, 2)) {
+            switch (randomIntBetween(0, 4)) {
                 case 0 -> {
                     float randomFloat = randomFloat();
                     randomValue = randomFloat;


### PR DESCRIPTION
ConvertProcessorTests.testConvertStringList had 5 test cases but would only randomly run 3 of them.
Closes #88744