### PR TITLE
Fix incorrect switch cases in `ConvertProcessorTests`

### DIFF
--- a/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/ConvertProcessorTests.java
+++ b/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/ConvertProcessorTests.java
@@ -416,7 +416,7 @@ public class ConvertProcessorTests extends ESTestCase {
         for (int j = 0; j < numItems; j++) {
             Object randomValue;
             String randomValueString;
-            switch (randomIntBetween(0, 2)) {
+            switch (randomIntBetween(0, 4)) {
                 case 0 -> {
                     float randomFloat = randomFloat();
                     randomValue = randomFloat;


### PR DESCRIPTION
The test `ConvertProcessorTests` contain switch statements with branches that will never execute. The tests use a between(x, y) switch expression, but there are case values that are outside the randomised range.

This PR fixes the test by extending the randomized range.

Fixes https://github.com/elastic/elasticsearch/issues/88744
