### PR TITLE
[DOCS] Fixes broken image in highlights

### DIFF
--- a/docs/reference/release-notes/highlights.asciidoc
+++ b/docs/reference/release-notes/highlights.asciidoc
@@ -69,7 +69,7 @@ can see an example of extracting an answer from a larger wiki article about
 Tower Bridge below.
 
 [role="screenshot"]
-image::../images/nlp-qa-rh.png[A screenshot of a question answering NLP task in {kib}]
+image::images/nlp-qa-rh.png[A screenshot of a question answering NLP task in {kib}]
 
 [discrete]
 [[add_support_for_dots_in_field_names_for_metrics_usecases]]


### PR DESCRIPTION
This PR fixes a broken image link in https://www.elastic.co/guide/en/elasticsearch/reference/8.3/release-highlights.html#question_answering_nlp_task and https://www.elastic.co/guide/en/elastic-stack/8.3/elasticsearch-highlights.html#question_answering_nlp_task

### Preview

- https://elasticsearch_88782.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/8.3/release-highlights.html
- https://elasticsearch_88782.docs-preview.app.elstc.co/guide/en/elastic-stack/8.3/elasticsearch-highlights.html
