### PR TITLE
Check buffer too short when decompressing with deflate

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/compress/DeflateCompressor.java
+++ b/server/src/main/java/org/elasticsearch/common/compress/DeflateCompressor.java
@@ -203,7 +203,14 @@ public class DeflateCompressor implements Compressor {
     @Override
     public BytesReference uncompress(BytesReference bytesReference) throws IOException {
         if (bytesReference.length() < HEADER.length) {
-            throw new IOException(String.format(Locale.ROOT, "Input bytes length %d is less than DEFLATE header size %d", bytesReference.length(), HEADER.length));
+            throw new IOException(
+                String.format(
+                    Locale.ROOT,
+                    "Input bytes length %d is less than DEFLATE header size %d",
+                    bytesReference.length(),
+                    HEADER.length
+                )
+            );
         }
         final BytesStreamOutput buffer = baos.get();
         try {

--- a/server/src/main/java/org/elasticsearch/common/compress/DeflateCompressor.java
+++ b/server/src/main/java/org/elasticsearch/common/compress/DeflateCompressor.java
@@ -20,6 +20,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.util.Arrays;
+import java.util.Locale;
 import java.util.zip.Deflater;
 import java.util.zip.DeflaterOutputStream;
 import java.util.zip.Inflater;
@@ -201,6 +202,9 @@ public class DeflateCompressor implements Compressor {
 
     @Override
     public BytesReference uncompress(BytesReference bytesReference) throws IOException {
+        if (bytesReference.length() < HEADER.length) {
+            throw new IOException(String.format(Locale.ROOT, "Input bytes length %d is less than DEFLATE header size %d", bytesReference.length(), HEADER.length));
+        }
         final BytesStreamOutput buffer = baos.get();
         try {
             final Inflater inflater = inflaterRef.get();


### PR DESCRIPTION
This commit checks for an edge case in decompression with deflate where
the input is shorter than the deflate header size. Before this commit
a slice error would occur with a negative bound. With this commit an IOException is thrown.

closes #88471