### PR TITLE
Update references to master branch in build benchmark configuration

### DIFF
--- a/build-tools-internal/build.gradle
+++ b/build-tools-internal/build.gradle
@@ -314,12 +314,12 @@ tasks.register("bootstrapPerformanceTests", Copy) {
   inputs.property('branchWrapper', gradle.gradleVersion)
   filter(ReplaceTokens, tokens: [
           testGitCommit:GitInfo.gitInfo(root).revision,
-          masterWrapper:"${ -> resolveMasterWrapperVersion()}".toString(),
+          mainWrapper:"${ -> resolveMainWrapperVersion()}".toString(),
           branchWrapper:"${-> gradle.gradleVersion}".toString()])
 }
 
-def resolveMasterWrapperVersion() {
-  new URL("https://raw.githubusercontent.com/elastic/elasticsearch/master/build-tools-internal/src/main/resources/minimumGradleVersion").text.trim()
+def resolveMainWrapperVersion() {
+  new URL("https://raw.githubusercontent.com/elastic/elasticsearch/main/build-tools-internal/src/main/resources/minimumGradleVersion").text.trim()
 }
 
 abstract class JacksonAlignmentRule implements ComponentMetadataRule {

--- a/build-tools-internal/performance/elasticsearch-build-benchmark-part1.scenarios
+++ b/build-tools-internal/performance/elasticsearch-build-benchmark-part1.scenarios
@@ -1,9 +1,9 @@
 // ensure branch scenario is listed first as this is the gradle version that will picked for inspecting the build
-default-scenarios = ["buildConfiguration_branch", "buildConfiguration_master", "single_project_branch", "single_project_master"]
+default-scenarios = ["buildConfiguration_branch", "buildConfiguration_main", "single_project_branch", "single_project_main"]
 
-buildConfiguration_master {
-    title = "configuration phase (master)"
-    versions = ["@masterWrapper@"]
+buildConfiguration_main {
+    title = "configuration phase (main)"
+    versions = ["@mainWrapper@"]
     tasks = ["help"]
     gradle-args = ["--no-scan", "--no-build-cache", "--stacktrace"]
     run-using = cli // value can be "cli" or "tooling-api"
@@ -14,7 +14,7 @@ buildConfiguration_master {
         "BUILD_PERFORMANCE_TEST" = "true"
     }
     git-checkout = {
-        build = "master"
+        build = "main"
     }
 }
 
@@ -35,9 +35,9 @@ buildConfiguration_branch {
     }
 }
 
-single_project_master {
-    title = "single project (master)"
-    versions = ["@masterWrapper@"]
+single_project_main {
+    title = "single project (main)"
+    versions = ["@mainWrapper@"]
     tasks = [":server:precommit"]
     gradle-args = ["--no-scan", "--stacktrace"]
     apply-abi-change-to = "server/src/main/java/org/elasticsearch/bootstrap/BootstrapInfo.java"
@@ -49,7 +49,7 @@ single_project_master {
         "BUILD_PERFORMANCE_TEST" = "true"
     }
     git-checkout = {
-        build = "master"
+        build = "main"
     }
 }
 

--- a/build-tools-internal/performance/elasticsearch-build-benchmark-part2.scenarios
+++ b/build-tools-internal/performance/elasticsearch-build-benchmark-part2.scenarios
@@ -1,9 +1,9 @@
 // ensure branch scenario is listed first as this is the gradle version that will picked for inspecting the build
-default-scenarios = ["precommit_branch", "precommit_master"]
+default-scenarios = ["precommit_branch", "precommit_main"]
 
-precommit_master {
-    title = "precommit (master)"
-    versions = ["@masterWrapper@"]
+precommit_main {
+    title = "precommit (main)"
+    versions = ["@mainWrapper@"]
     cleanup-tasks = ["clean"]
     tasks = ["precommit"]
     gradle-args = ["--no-scan", "--no-build-cache", "--stacktrace"]
@@ -15,7 +15,7 @@ precommit_master {
         "BUILD_PERFORMANCE_TEST" = "true"
     }
     git-checkout = {
-        build = "master"
+        build = "main"
     }
 }
 


### PR DESCRIPTION
This updates our Gradle build benchmarks to use `main` instead of `master` for the baseline branch.