### PR TITLE
Make org.elasticsearch.cluster.routing.RoutingNode#copyShards use Array

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/routing/RoutingNode.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/RoutingNode.java
@@ -334,8 +334,8 @@ public class RoutingNode implements Iterable<ShardRouting> {
         return sb.toString();
     }
 
-    public List<ShardRouting> copyShards() {
-        return new ArrayList<>(shards.values());
+    public ShardRouting[] copyShards() {
+        return shards.values().toArray(EMPTY_SHARD_ROUTING_ARRAY);
     }
 
     public boolean isEmpty() {

--- a/server/src/main/java/org/elasticsearch/cluster/routing/RoutingNodes.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/RoutingNodes.java
@@ -19,6 +19,7 @@ import org.elasticsearch.cluster.node.DiscoveryNodes;
 import org.elasticsearch.cluster.routing.UnassignedInfo.AllocationStatus;
 import org.elasticsearch.cluster.routing.allocation.ExistingShardsAllocator;
 import org.elasticsearch.cluster.service.MasterService;
+import org.elasticsearch.common.collect.Iterators;
 import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.core.Tuple;
@@ -1265,9 +1266,9 @@ public class RoutingNodes extends AbstractCollection<RoutingNode> {
     public Iterator<ShardRouting> nodeInterleavedShardIterator() {
         final Queue<Iterator<ShardRouting>> queue = new ArrayDeque<>(nodesToShards.size());
         for (final var routingNode : nodesToShards.values()) {
-            final var iterator = routingNode.copyShards().iterator();
-            if (iterator.hasNext()) {
-                queue.add(iterator);
+            final var shards = routingNode.copyShards();
+            if (shards.length > 0) {
+                queue.add(Iterators.forArray(shards));
             }
         }
         return new Iterator<>() {

--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/DiskThresholdMonitor.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/DiskThresholdMonitor.java
@@ -31,7 +31,6 @@ import org.elasticsearch.common.settings.ClusterSettings;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.common.util.set.Sets;
-import org.elasticsearch.index.Index;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -373,9 +372,12 @@ public class DiskThresholdMonitor {
             .collect(Collectors.toSet());
 
         // Generate a set of all the indices that exist on either the target or source of a node replacement
-        final Set<String> indicesOnReplaceSourceOrTarget = nodesIdsPartOfReplacement.stream()
-            .flatMap(nodeId -> state.getRoutingNodes().node(nodeId).copyShards().stream().map(ShardRouting::index).map(Index::getName))
-            .collect(Collectors.toSet());
+        final Set<String> indicesOnReplaceSourceOrTarget = new HashSet<>();
+        for (String nodeId : nodesIdsPartOfReplacement) {
+            for (ShardRouting shardRouting : state.getRoutingNodes().node(nodeId)) {
+                indicesOnReplaceSourceOrTarget.add(shardRouting.index().getName());
+            }
+        }
 
         final Set<String> indicesToAutoRelease = state.routingTable()
             .indicesRouting()


### PR DESCRIPTION
We used this in three spots, where it copies potentially huge arrays.
One of those spots doesn't need the `copyShards` call at all
and can use the normal iterator as there's no concurrent modfication.

The other two spots can at least just use an array, which will iterate
a little faster than a mutable list and also potentially saves another
round copying the array in the `ArrayList` constructor that the compiler
seems to not be able to eliminate in all cases.

relates #77466 