### PR TITLE
Clean up desired nodes in between dry run tests

### DIFF
--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/cluster.desired_nodes/20_dry_run.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/cluster.desired_nodes/20_dry_run.yml
@@ -3,6 +3,10 @@ setup:
   - skip:
       version: " - 8.3.99"
       reason: "Support for the dry run option was added in in 8.4.0"
+---
+teardown:
+  - do:
+      _internal.delete_desired_nodes: { }
 
 ---
 "Test dry run doesn't update empty desired nodes":


### PR DESCRIPTION
Follow up for #88305

Otherwise the test can fail on a cluster with multiple nodes depending on the execution order of the tests.
```
./gradlew ':qa:smoke-test-multinode:yamlRestTest' --tests "org.elasticsearch.smoketest.SmokeTestMultiNodeClientYamlTestSuiteIT" -Dtests.method="test {yaml=cluster.desired_nodes/20_dry_run/*}" -Dtests.seed=7B172B81BCF7C19C -Dtests.locale=cs -Dtests.timezone=Africa/Lusaka -Druntime.java=17
```