### PR TITLE
Serialize ID last for `UpdateApiKeyRequest`

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/apikey/UpdateApiKeyRequest.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/apikey/UpdateApiKeyRequest.java
@@ -43,9 +43,9 @@ public final class UpdateApiKeyRequest extends ActionRequest {
 
     public UpdateApiKeyRequest(StreamInput in) throws IOException {
         super(in);
-        this.id = in.readString();
         this.roleDescriptors = in.readOptionalList(RoleDescriptor::new);
         this.metadata = in.readMap();
+        this.id = in.readString();
     }
 
     @Override
@@ -68,9 +68,9 @@ public final class UpdateApiKeyRequest extends ActionRequest {
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         super.writeTo(out);
-        out.writeString(id);
         out.writeOptionalCollection(roleDescriptors);
         out.writeGenericMap(metadata);
+        out.writeString(id);
     }
 
     public static UpdateApiKeyRequest usingApiKeyId(String id) {


### PR DESCRIPTION
This PR changes the order in which fields are read and written for
`UpdateApiKeyRequest` to better accommodate generalization for bulk
updates. Fields other than `id` will be shared between single operation
and bulk update requests and may therefore be extracted into a base
class; unlike constructor parameters, the order in which we read/write
fields matters for inheritance.