### PR TITLE
Fix EmbeddedImplClassLoaderTests on Windows

### DIFF
--- a/libs/core/src/test/java/org/elasticsearch/core/internal/provider/EmbeddedImplClassLoaderTests.java
+++ b/libs/core/src/test/java/org/elasticsearch/core/internal/provider/EmbeddedImplClassLoaderTests.java
@@ -590,7 +590,11 @@ public class EmbeddedImplClassLoaderTests extends ESTestCase {
     @SuppressForbidden(reason = "file urls")
     static String urlToString(URL url) {
         try {
-            return new String(url.openStream().readAllBytes(), UTF_8);
+            var urlc = url.openConnection();
+            urlc.setUseCaches(false);
+            try (var is = urlc.getInputStream()) {
+                return new String(is.readAllBytes(), UTF_8);
+            }
         } catch (IOException e) {
             throw new UncheckedIOException(e);
         }


### PR DESCRIPTION
This change ensures that URL resources opened by the test are closed - which allows for post-test cleanup by the framework. Disabling URL caching prevents the underlying JarFile from remaining open after the inputstream has been closed.

closes #88799 