### PR TITLE
Fix SearchableSnapshotsPersistentCacheIntegTests.testPersistentCacheCleanUpAfterRelocation

### DIFF
--- a/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/cache/full/SearchableSnapshotsPersistentCacheIntegTests.java
+++ b/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/cache/full/SearchableSnapshotsPersistentCacheIntegTests.java
@@ -38,6 +38,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
 
 import static org.elasticsearch.cluster.metadata.IndexMetadata.INDEX_ROUTING_EXCLUDE_GROUP_PREFIX;
 import static org.elasticsearch.cluster.metadata.IndexMetadata.INDEX_ROUTING_REQUIRE_GROUP_PREFIX;
@@ -274,7 +275,7 @@ public class SearchableSnapshotsPersistentCacheIntegTests extends BaseSearchable
                     dataNode.equals(excludedDataNode) ? equalTo(0L) : greaterThan(0L)
                 );
             }
-        });
+        }, 30L, TimeUnit.SECONDS);
 
         logger.info("--> deleting mounted index {}", mountedIndex);
         assertAcked(client().admin().indices().prepareDelete(mountedIndexName));

--- a/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/cache/full/PersistentCache.java
+++ b/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/cache/full/PersistentCache.java
@@ -307,11 +307,12 @@ public class PersistentCache implements Closeable {
         }
     }
 
-    public long getNumDocs() {
+    // package private for tests
+    long getNumDocs() {
         ensureOpen();
         long count = 0L;
         for (CacheIndexWriter writer : writers) {
-            count += writer.indexWriter.getPendingNumDocs();
+            count += writer.indexWriter.getDocStats().numDocs;
         }
         return count;
     }


### PR DESCRIPTION
This test failed twice in the last year,
(always on 7.17 branch) and I suspect that
10 seconds are not enough for the persistent
cache to process cluster state updates and
deletes docs. This change gives a bit more
time to the test. It also uses IndexWriter
getDocStats() method to have more accurate
number of docs that includes deletions.

Closes #86060