### PR TITLE
Document hard linking limitation in Elasticsearch < 7.11

### DIFF
--- a/docs/reference/indices/split-index.asciidoc
+++ b/docs/reference/indices/split-index.asciidoc
@@ -163,9 +163,10 @@ for efficient file copying.
 [IMPORTANT]
 =====================================
 
-Hard links are not supported in Elasticsearch versions < 7.11.  When Split Index API
-is run on these earlier versions, it will not be able to reuse segments for efficiency 
-and require copying of full segment files with disk usage and IO implications.
+Hard links are not supported in Elasticsearch versions < 7.11 for quota aware file systems 
+like `xfs` in Elastic Cloud. When Split Index API is run on these earlier versions, 
+it will not be able to reuse segments for efficiency and require copying of full segment files 
+with disk usage and IO implications.
 
 =====================================
 

--- a/docs/reference/indices/split-index.asciidoc
+++ b/docs/reference/indices/split-index.asciidoc
@@ -164,9 +164,9 @@ for efficient file copying.
 =====================================
 
 Hard links are not supported in Elasticsearch versions < 7.11 for quota aware file systems 
-(e.g. `xfs` used in Elastic Cloud). When Split Index API is run on these earlier versions, 
-it will not be able to reuse segments for efficiency and require copying of full segment files 
-with disk usage and IO implications.
+(e.g. `xfs` used in Elastic Cloud). When Split Index API is run on these quota aware file systems 
+in earlier versions, it will not be able to reuse segments for efficiency and require copying of 
+full segment files with disk usage and IO implications.
 
 =====================================
 

--- a/docs/reference/indices/split-index.asciidoc
+++ b/docs/reference/indices/split-index.asciidoc
@@ -164,7 +164,7 @@ for efficient file copying.
 =====================================
 
 Hard links are not supported in Elasticsearch versions < 7.11 for quota aware file systems 
-like `xfs` in Elastic Cloud. When Split Index API is run on these earlier versions, 
+(e.g. `xfs` used in Elastic Cloud). When Split Index API is run on these earlier versions, 
 it will not be able to reuse segments for efficiency and require copying of full segment files 
 with disk usage and IO implications.
 

--- a/docs/reference/indices/split-index.asciidoc
+++ b/docs/reference/indices/split-index.asciidoc
@@ -160,6 +160,15 @@ split locally, which in-turn allows to perform the split at the index level
 rather than reindexing documents that need to move, as well as using hard links
 for efficient file copying.
 
+[IMPORTANT]
+=====================================
+
+Hard links are not supported in Elasticsearch versions < 7.11.  When Split Index API
+is run on these earlier versions, it will not be able to reuse segments for efficiency 
+and require copying of full segment files with disk usage and IO implications.
+
+=====================================
+
 In the case of append-only data, it is possible to get more flexibility by
 creating a new index and pushing new data to it, while adding an alias that
 covers both the old and the new index for read operations. Assuming that the


### PR DESCRIPTION
We are not currently documenting the limitation in Split Index API where hard linking does not work on quota aware file systems like `xfs` (e.g. Elastic Cloud) in earlier versions of Elasticsearch < 7.11.  This addresses the missed documentation.

Ref: https://github.com/elastic/elasticsearch/issues/61145

Please back port to all affected versions (6.1 is the first version in Elasticsearch with Split Index API).
