### PR TITLE
Add stable indicator for plugin descriptor

### DIFF
--- a/server/src/main/java/org/elasticsearch/plugins/PluginDescriptor.java
+++ b/server/src/main/java/org/elasticsearch/plugins/PluginDescriptor.java
@@ -58,6 +58,7 @@ public class PluginDescriptor implements Writeable, ToXContentObject {
     private final boolean hasNativeController;
     private final boolean isLicensed;
     private final boolean isModular;
+    private final boolean isStable;
 
     /**
      * Construct plugin info.
@@ -85,7 +86,8 @@ public class PluginDescriptor implements Writeable, ToXContentObject {
         List<String> extendedPlugins,
         boolean hasNativeController,
         boolean isLicensed,
-        boolean isModular
+        boolean isModular,
+        boolean isStable
     ) {
         this.name = name;
         this.description = description;
@@ -98,6 +100,7 @@ public class PluginDescriptor implements Writeable, ToXContentObject {
         this.hasNativeController = hasNativeController;
         this.isLicensed = isLicensed;
         this.isModular = isModular;
+        this.isStable = isStable;
     }
 
     /**
@@ -133,8 +136,10 @@ public class PluginDescriptor implements Writeable, ToXContentObject {
 
         if (in.getVersion().onOrAfter(Version.V_8_4_0)) {
             isModular = in.readBoolean();
+            isStable = in.readBoolean();
         } else {
             isModular = moduleName != null;
+            isStable = false;
         }
     }
 
@@ -161,6 +166,7 @@ public class PluginDescriptor implements Writeable, ToXContentObject {
         }
         if (out.getVersion().onOrAfter(Version.V_8_4_0)) {
             out.writeBoolean(isModular);
+            out.writeBoolean(isStable);
         }
     }
 
@@ -236,8 +242,9 @@ public class PluginDescriptor implements Writeable, ToXContentObject {
         }
 
         boolean isLicensed = readBoolean(propsMap, name, "licensed");
+        boolean modular = module != null;
 
-        return new PluginDescriptor(name, desc, ver, esVer, javaVer, classname, module, extended, nativeCont, isLicensed, module != null);
+        return new PluginDescriptor(name, desc, ver, esVer, javaVer, classname, module, extended, nativeCont, isLicensed, modular, false);
     }
 
     private static PluginDescriptor readerStableDescriptor(Map<String, String> propsMap, String filename) {
@@ -248,7 +255,7 @@ public class PluginDescriptor implements Writeable, ToXContentObject {
         String javaVer = readJavaVersion(propsMap, name);
         boolean isModular = readBoolean(propsMap, name, "modular");
 
-        return new PluginDescriptor(name, desc, ver, esVer, javaVer, null, null, List.of(), false, false, isModular);
+        return new PluginDescriptor(name, desc, ver, esVer, javaVer, null, null, List.of(), false, false, isModular, true);
     }
 
     private static String readNonEmptyString(Map<String, String> propsMap, String pluginId, String name) {
@@ -387,6 +394,13 @@ public class PluginDescriptor implements Writeable, ToXContentObject {
      */
     public boolean isModular() {
         return isModular;
+    }
+
+    /**
+     * Whether this plugin uses only stable APIs.
+     */
+    public boolean isStable() {
+        return isStable;
     }
 
     @Override

--- a/server/src/test/java/org/elasticsearch/nodesinfo/NodeInfoStreamingTests.java
+++ b/server/src/test/java/org/elasticsearch/nodesinfo/NodeInfoStreamingTests.java
@@ -157,6 +157,7 @@ public class NodeInfoStreamingTests extends ESTestCase {
                         Collections.emptyList(),
                         randomBoolean(),
                         randomBoolean(),
+                        randomBoolean(),
                         randomBoolean()
                     )
                 );
@@ -174,6 +175,7 @@ public class NodeInfoStreamingTests extends ESTestCase {
                         randomAlphaOfLengthBetween(3, 10),
                         randomBoolean() ? null : randomAlphaOfLengthBetween(3, 10),
                         Collections.emptyList(),
+                        randomBoolean(),
                         randomBoolean(),
                         randomBoolean(),
                         randomBoolean()

--- a/server/src/test/java/org/elasticsearch/plugins/PluginDescriptorTests.java
+++ b/server/src/test/java/org/elasticsearch/plugins/PluginDescriptorTests.java
@@ -234,6 +234,7 @@ public class PluginDescriptorTests extends ESTestCase {
             Collections.singletonList("foo"),
             randomBoolean(),
             randomBoolean(),
+            randomBoolean(),
             randomBoolean()
         );
         BytesStreamOutput output = new BytesStreamOutput();
@@ -256,6 +257,7 @@ public class PluginDescriptorTests extends ESTestCase {
             Collections.singletonList("foo"),
             randomBoolean(),
             randomBoolean(),
+            randomBoolean(),
             randomBoolean()
         );
         BytesStreamOutput output = new BytesStreamOutput();
@@ -276,6 +278,7 @@ public class PluginDescriptorTests extends ESTestCase {
             "dummyclass",
             null,
             List.of(),
+            randomBoolean(),
             randomBoolean(),
             randomBoolean(),
             randomBoolean()
@@ -319,6 +322,7 @@ public class PluginDescriptorTests extends ESTestCase {
             Collections.singletonList("foo"),
             randomBoolean(),
             randomBoolean(),
+            randomBoolean(),
             randomBoolean()
         );
         // everything but name is different from descriptor1
@@ -335,7 +339,8 @@ public class PluginDescriptorTests extends ESTestCase {
             ),
             descriptor1.hasNativeController() == false,
             descriptor1.isLicensed() == false,
-            descriptor1.isModular() == false
+            descriptor1.isModular() == false,
+            descriptor1.isStable() == false
         );
         // only name is different from descriptor1
         PluginDescriptor descriptor3 = new PluginDescriptor(
@@ -349,7 +354,8 @@ public class PluginDescriptorTests extends ESTestCase {
             descriptor1.getExtendedPlugins(),
             descriptor1.hasNativeController(),
             descriptor1.isLicensed(),
-            descriptor1.isModular()
+            descriptor1.isModular(),
+            descriptor1.isStable()
         );
 
         assertThat(descriptor1, equalTo(descriptor2));

--- a/server/src/test/java/org/elasticsearch/plugins/PluginsServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/plugins/PluginsServiceTests.java
@@ -456,7 +456,7 @@ public class PluginsServiceTests extends ESTestCase {
         PluginsService.loadExtensions(
             List.of(
                 new PluginsService.LoadedPlugin(
-                    new PluginDescriptor("extensible", null, null, null, null, null, null, List.of(), false, false, false),
+                    new PluginDescriptor("extensible", null, null, null, null, null, null, List.of(), false, false, false, false),
                     extensiblePlugin
                 )
             )
@@ -470,11 +470,11 @@ public class PluginsServiceTests extends ESTestCase {
         PluginsService.loadExtensions(
             List.of(
                 new PluginsService.LoadedPlugin(
-                    new PluginDescriptor("extensible", null, null, null, null, null, null, List.of(), false, false, false),
+                    new PluginDescriptor("extensible", null, null, null, null, null, null, List.of(), false, false, false, false),
                     extensiblePlugin
                 ),
                 new PluginsService.LoadedPlugin(
-                    new PluginDescriptor("test", null, null, null, null, null, null, List.of("extensible"), false, false, false),
+                    new PluginDescriptor("test", null, null, null, null, null, null, List.of("extensible"), false, false, false, false),
                     testPlugin
                 )
             )

--- a/server/src/test/java/org/elasticsearch/plugins/PluginsUtilsTests.java
+++ b/server/src/test/java/org/elasticsearch/plugins/PluginsUtilsTests.java
@@ -39,7 +39,7 @@ public class PluginsUtilsTests extends ESTestCase {
 
     PluginDescriptor newTestDescriptor(String name, List<String> deps) {
         String javaVersion = Runtime.version().toString();
-        return new PluginDescriptor(name, "desc", "1.0", Version.CURRENT, javaVersion, "MyPlugin", null, deps, false, false, false);
+        return new PluginDescriptor(name, "desc", "1.0", Version.CURRENT, javaVersion, "MyPlugin", null, deps, false, false, false, false);
     }
 
     public void testExistingPluginMissingDescriptor() throws Exception {
@@ -380,6 +380,7 @@ public class PluginsUtilsTests extends ESTestCase {
             Collections.emptyList(),
             false,
             false,
+            false,
             false
         );
         IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> PluginsUtils.verifyCompatibility(info));
@@ -396,6 +397,7 @@ public class PluginsUtilsTests extends ESTestCase {
             "FakePlugin",
             null,
             Collections.emptyList(),
+            false,
             false,
             false,
             false

--- a/test/framework/src/main/java/org/elasticsearch/plugins/MockPluginsService.java
+++ b/test/framework/src/main/java/org/elasticsearch/plugins/MockPluginsService.java
@@ -58,6 +58,7 @@ public class MockPluginsService extends PluginsService {
                 Collections.emptyList(),
                 false,
                 false,
+                false,
                 false
             );
             if (logger.isTraceEnabled()) {

--- a/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/collector/cluster/ClusterStatsMonitoringDocTests.java
+++ b/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/collector/cluster/ClusterStatsMonitoringDocTests.java
@@ -336,6 +336,7 @@ public class ClusterStatsMonitoringDocTests extends BaseMonitoringDocTestCase<Cl
             Collections.emptyList(),
             false,
             false,
+            false,
             false
         );
         final PluginRuntimeInfo pluginRuntimeInfo = new PluginRuntimeInfo(pluginDescriptor);


### PR DESCRIPTION
A forgotten piece of https://github.com/elastic/elasticsearch/pull/88731
is whether a plugin descriptor in memory came from a stable or internal
descriptor. This commit adds a flag for that. Note that this is implied
by the file that was loaded, so no new property is needed.