### PR TITLE
Preventing exceptions on node shutdown in integration tests

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/coordination/CoordinationDiagnosticsService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/CoordinationDiagnosticsService.java
@@ -585,6 +585,7 @@ public class CoordinationDiagnosticsService implements ClusterStateListener {
             logger.warn("Exception in cluster coordination info request to master node", e);
             responseConsumer.accept(new ClusterFormationStateOrException(e));
         });
+
         return transportService.getThreadPool().schedule(() -> {
             Version minSupportedVersion = Version.V_8_4_0;
             if (node.getVersion().onOrAfter(minSupportedVersion) == false) { // This was introduced in 8.4.0

--- a/server/src/main/java/org/elasticsearch/cluster/coordination/CoordinationDiagnosticsService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/CoordinationDiagnosticsService.java
@@ -597,8 +597,12 @@ public class CoordinationDiagnosticsService implements ClusterStateListener {
                 return getNoopCancellable();
             }
         } catch (EsRejectedExecutionException e) {
-            logger.info("Cancelling request for cluster coordination info because this node is being shutdown", e);
-            return getNoopCancellable();
+            if (e.isExecutorShutdown()) {
+                logger.info("Cancelling request for cluster coordination info because this node is being shutdown", e);
+                return getNoopCancellable();
+            } else {
+                throw e;
+            }
         }
     }
 

--- a/test/framework/src/main/java/org/elasticsearch/common/util/concurrent/DeterministicTaskQueue.java
+++ b/test/framework/src/main/java/org/elasticsearch/common/util/concurrent/DeterministicTaskQueue.java
@@ -451,7 +451,7 @@ public class DeterministicTaskQueue {
 
                     @Override
                     public boolean isShutdown() {
-                        return false;
+                        throw new UnsupportedOperationException();
                     }
 
                     @Override

--- a/test/framework/src/main/java/org/elasticsearch/common/util/concurrent/DeterministicTaskQueue.java
+++ b/test/framework/src/main/java/org/elasticsearch/common/util/concurrent/DeterministicTaskQueue.java
@@ -451,7 +451,7 @@ public class DeterministicTaskQueue {
 
                     @Override
                     public boolean isShutdown() {
-                        throw new UnsupportedOperationException();
+                        return false;
                     }
 
                     @Override


### PR DESCRIPTION
On node shutdown, `CoordinationDiagnosticsService.fetchClusterFormationInfo()` can throw an exception because we schedule a task without checking whether the node is being shut down.
Closes #88759