### PR TITLE
Fixing routing bug in 190_script_processor/Test metadata

### DIFF
--- a/modules/ingest-common/src/yamlRestTest/resources/rest-api-spec/test/ingest/190_script_processor.yml
+++ b/modules/ingest-common/src/yamlRestTest/resources/rest-api-spec/test/ingest/190_script_processor.yml
@@ -317,10 +317,6 @@ teardown:
 
 ---
 "Test metadata":
-  - skip:
-      version: all
-      reason: https://github.com/elastic/elasticsearch/issues/88387
-
   - do:
       ingest.put_pipeline:
         id: "my_pipeline"
@@ -357,6 +353,7 @@ teardown:
       get:
         index: test2
         id: "1extra"
+        routing: "myRouting"
   - match: { _source.source_field: "bazqux" }
   - match: { _version: 5 }
   - match: { _routing: "myRouting" }


### PR DESCRIPTION
In this test we were creating a second document in the same index but with different routing. So there's a chance that it does not go to the same shard as the original document with the same id. And then when we're fetching the document and asserting that we have the new one, we're not specifying the routing. So sometimes we get the wrong one back.
Closes #88387
Relates #87309