### PR TITLE
[7.17] Fix SearchableSnapshotsPersistentCacheIntegTests.testPersistentCacheCleanUpAfterRelocation (#88819)

### DIFF
--- a/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/cache/full/SearchableSnapshotsPersistentCacheIntegTests.java
+++ b/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/cache/full/SearchableSnapshotsPersistentCacheIntegTests.java
@@ -37,6 +37,7 @@ import java.util.HashSet;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
 
 import static org.elasticsearch.cluster.metadata.IndexMetadata.INDEX_ROUTING_EXCLUDE_GROUP_PREFIX;
 import static org.elasticsearch.cluster.metadata.IndexMetadata.INDEX_ROUTING_REQUIRE_GROUP_PREFIX;
@@ -275,7 +276,7 @@ public class SearchableSnapshotsPersistentCacheIntegTests extends BaseSearchable
                     dataNode.equals(excludedDataNode) ? equalTo(0L) : greaterThan(0L)
                 );
             }
-        });
+        }, 30L, TimeUnit.SECONDS);
 
         logger.info("--> deleting mounted index {}", mountedIndex);
         assertAcked(client().admin().indices().prepareDelete(mountedIndexName));

--- a/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/cache/full/PersistentCache.java
+++ b/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/cache/full/PersistentCache.java
@@ -307,11 +307,12 @@ public class PersistentCache implements Closeable {
         }
     }
 
-    public long getNumDocs() {
+    // package private for tests
+    long getNumDocs() {
         ensureOpen();
         long count = 0L;
         for (CacheIndexWriter writer : writers) {
-            count += writer.indexWriter.getPendingNumDocs();
+            count += writer.indexWriter.getDocStats().numDocs;
         }
         return count;
     }


### PR DESCRIPTION
Backports the following commits to 7.17:
 - Fix SearchableSnapshotsPersistentCacheIntegTests.testPersistentCacheCleanUpAfterRelocation (#88819)