### PR TITLE
[8.3] [Doc] Precise that shared cache is shared across shards, not nodes (#88834)

### DIFF
--- a/docs/reference/searchable-snapshots/index.asciidoc
+++ b/docs/reference/searchable-snapshots/index.asciidoc
@@ -138,8 +138,9 @@ Indices managed by {ilm-init} are prefixed with `restored-` when fully mounted.
 [[partially-mounted]]
 Partially mounted index::
 Uses a local cache containing only recently searched parts of the snapshotted
-index's data. This cache has a fixed size and is shared across nodes in the
-frozen tier. {ilm-init} uses this option in the `frozen` phase.
+index's data. This cache has a fixed size and is shared across shards of partially
+mounted indices allocated on the same data node. {ilm-init} uses this option in the
+`frozen` phase.
 +
 If a search requires data that is not in the cache, {es} fetches the missing
 data from the snapshot repository. Searches that require these fetches are


### PR DESCRIPTION
Backports the following commits to 8.3:
 - [Doc] Precise that shared cache is shared across shards, not nodes (#88834)