### PR TITLE
Adjust wording in frozen tier allocation deciders

### DIFF
--- a/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/cache/shared/PartiallyCachedShardAllocationIntegTests.java
+++ b/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/cache/shared/PartiallyCachedShardAllocationIntegTests.java
@@ -124,7 +124,7 @@ public class PartiallyCachedShardAllocationIntegTests extends BaseFrozenSearchab
                     .stream()
                     .anyMatch(
                         d -> d.getExplanation().contains(SHARED_CACHE_SIZE_SETTING.getKey())
-                            && d.getExplanation().contains("frozen searchable snapshot shards cannot be allocated to this node")
+                            && d.getExplanation().contains("shards of partially mounted indices cannot be allocated to this node")
                     )
             );
         }

--- a/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/allocation/decider/DedicatedFrozenNodeAllocationDecider.java
+++ b/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/allocation/decider/DedicatedFrozenNodeAllocationDecider.java
@@ -31,7 +31,7 @@ public class DedicatedFrozenNodeAllocationDecider extends AllocationDecider {
     private static final Decision YES_IS_PARTIAL_SEARCHABLE_SNAPSHOT = Decision.single(
         Decision.Type.YES,
         NAME,
-        "this index is a frozen searchable snapshot so it can be assigned to this dedicated frozen node"
+        "this index is a partially mounted index so it can be assigned to this dedicated frozen node"
     );
 
     private static final Decision NO = Decision.single(
@@ -39,7 +39,7 @@ public class DedicatedFrozenNodeAllocationDecider extends AllocationDecider {
         NAME,
         "this node's data roles are exactly ["
             + DATA_FROZEN_NODE_ROLE.roleName()
-            + "] so it may only hold shards from frozen searchable snapshots, but this index is not a frozen searchable snapshot"
+            + "] so it may only hold shards from partially mounted indices, but this index is not a partially mounted index"
     );
 
     @Override

--- a/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/allocation/decider/HasFrozenCacheAllocationDecider.java
+++ b/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/allocation/decider/HasFrozenCacheAllocationDecider.java
@@ -31,7 +31,7 @@ public class HasFrozenCacheAllocationDecider extends AllocationDecider {
     private static final Decision HAS_FROZEN_CACHE = Decision.single(
         Decision.Type.YES,
         NAME,
-        "this node has a frozen searchable snapshot shard cache"
+        "this node has a searchable snapshot shared cache"
     );
 
     private static final Decision NO_FROZEN_CACHE = Decision.single(
@@ -39,13 +39,13 @@ public class HasFrozenCacheAllocationDecider extends AllocationDecider {
         NAME,
         "node setting ["
             + SHARED_CACHE_SIZE_SETTING.getKey()
-            + "] is set to zero, so frozen searchable snapshot shards cannot be allocated to this node"
+            + "] is set to zero, so shards of partially mounted indices cannot be allocated to this node"
     );
 
     private static final Decision UNKNOWN_FROZEN_CACHE = Decision.single(
         Decision.Type.NO,
         NAME,
-        "there was an error fetching the frozen cache state from this node"
+        "there was an error fetching the searchable snapshot shared cache state from this node"
     );
 
     private final FrozenCacheInfoService frozenCacheService;


### PR DESCRIPTION
The allocation deciders for dedicated/non-dedicated
frozen nodes use the "frozen searchable snapshot" or 
"frozen cache" terms for what was renamed later 
(in #72699) to partially mounted indices and shared 
cache.

Hopefully not controversial, this changes makes the
wording of the deciders more coherent with the current
documentation starting v8.5.0.
