### PR TITLE
Fix Note in troubleshooting docs

### DIFF
--- a/docs/reference/tab-widgets/troubleshooting/data/add-tier.asciidoc
+++ b/docs/reference/tab-widgets/troubleshooting/data/add-tier.asciidoc
@@ -28,8 +28,7 @@ In order to get the shards assigned we need enable a new tier in the deployment.
 . On the **Elasticsearch Service** panel, click the name of your deployment. 
 +
 
-NOTE:
-If the name of your deployment is disabled your {kib} instances might be
+NOTE: If the name of your deployment is disabled your {kib} instances might be
 unhealthy, in which case please contact https://support.elastic.co[Elastic Support].
 If your deployment doesn't include {kib}, all you need to do is 
 {cloud}/ec-access-kibana.html[enable it first].

--- a/docs/reference/tab-widgets/troubleshooting/data/diagnose-unassigned-shards.asciidoc
+++ b/docs/reference/tab-widgets/troubleshooting/data/diagnose-unassigned-shards.asciidoc
@@ -23,8 +23,7 @@ In order to diagnose the unassigned shards, follow the next steps:
 . On the **Elasticsearch Service** panel, click the name of your deployment. 
 +
 
-NOTE:
-If the name of your deployment is disabled your {kib} instances might be
+NOTE: If the name of your deployment is disabled your {kib} instances might be
 unhealthy, in which case please contact https://support.elastic.co[Elastic Support].
 If your deployment doesn't include {kib}, all you need to do is 
 {cloud}/ec-access-kibana.html[enable it first].

--- a/docs/reference/tab-widgets/troubleshooting/data/enable-cluster-allocation.asciidoc
+++ b/docs/reference/tab-widgets/troubleshooting/data/enable-cluster-allocation.asciidoc
@@ -16,8 +16,7 @@ We'll achieve this by inspecting the system-wide `cluster.routing.allocation.ena
 . On the **Elasticsearch Service** panel, click the name of your deployment. 
 +
 
-NOTE:
-If the name of your deployment is disabled your {kib} instances might be
+NOTE: If the name of your deployment is disabled your {kib} instances might be
 unhealthy, in which case please contact https://support.elastic.co[Elastic Support].
 If your deployment doesn't include {kib}, all you need to do is 
 {cloud}/ec-access-kibana.html[enable it first].

--- a/docs/reference/tab-widgets/troubleshooting/data/enable-index-allocation.asciidoc
+++ b/docs/reference/tab-widgets/troubleshooting/data/enable-index-allocation.asciidoc
@@ -34,8 +34,7 @@ assignemnt of the shards to `all`.
 . On the **Elasticsearch Service** panel, click the name of your deployment. 
 +
 
-NOTE:
-If the name of your deployment is disabled your {kib} instances might be
+NOTE: If the name of your deployment is disabled your {kib} instances might be
 unhealthy, in which case please contact https://support.elastic.co[Elastic Support].
 If your deployment doesn't include {kib}, all you need to do is 
 {cloud}/ec-access-kibana.html[enable it first].

--- a/docs/reference/tab-widgets/troubleshooting/data/increase-cluster-shard-limit.asciidoc
+++ b/docs/reference/tab-widgets/troubleshooting/data/increase-cluster-shard-limit.asciidoc
@@ -37,8 +37,7 @@ We'll achieve this by inspecting the system-wide `cluster.routing.allocation.tot
 . On the **Elasticsearch Service** panel, click the name of your deployment. 
 +
 
-NOTE:
-If the name of your deployment is disabled your {kib} instances might be
+NOTE: If the name of your deployment is disabled your {kib} instances might be
 unhealthy, in which case please contact https://support.elastic.co[Elastic Support].
 If your deployment doesn't include {kib}, all you need to do is 
 {cloud}/ec-access-kibana.html[enable it first].

--- a/docs/reference/tab-widgets/troubleshooting/data/increase-tier-capacity.asciidoc
+++ b/docs/reference/tab-widgets/troubleshooting/data/increase-tier-capacity.asciidoc
@@ -37,8 +37,7 @@ Do this using {kib}.
 . On the **Elasticsearch Service** panel, click the name of your deployment.
 +
 
-NOTE:
-If the name of your deployment is disabled your {kib} instances might be
+NOTE: If the name of your deployment is disabled your {kib} instances might be
 unhealthy, in which case please contact https://support.elastic.co[Elastic Support].
 If your deployment doesn't include {kib}, all you need to do is
 {cloud}/ec-access-kibana.html[enable it first].

--- a/docs/reference/tab-widgets/troubleshooting/data/migrate-to-data-tiers-routing-guide.asciidoc
+++ b/docs/reference/tab-widgets/troubleshooting/data/migrate-to-data-tiers-routing-guide.asciidoc
@@ -14,8 +14,7 @@ the index templates and ILM policies if needed.
 . On the **Elasticsearch Service** panel, click the name of your deployment. 
 +
 
-NOTE:
-If the name of your deployment is disabled your {kib} instances might be
+NOTE: If the name of your deployment is disabled your {kib} instances might be
 unhealthy, in which case please contact https://support.elastic.co[Elastic Support].
 If your deployment doesn't include {kib}, all you need to do is 
 {cloud}/ec-access-kibana.html[enable it first].

--- a/docs/reference/tab-widgets/troubleshooting/data/start-ilm.asciidoc
+++ b/docs/reference/tab-widgets/troubleshooting/data/start-ilm.asciidoc
@@ -10,8 +10,7 @@ In order to start {ilm} we need to go to Kibana and execute the <<ilm-start, sta
 . On the **Elasticsearch Service** panel, click the name of your deployment. 
 +
 
-NOTE:
-If the name of your deployment is disabled your {kib} instances might be
+NOTE: If the name of your deployment is disabled your {kib} instances might be
 unhealthy, in which case please contact https://support.elastic.co[Elastic Support].
 If your deployment doesn't include {kib}, all you need to do is 
 {cloud}/ec-access-kibana.html[enable it first].

--- a/docs/reference/tab-widgets/troubleshooting/data/start-slm.asciidoc
+++ b/docs/reference/tab-widgets/troubleshooting/data/start-slm.asciidoc
@@ -10,8 +10,7 @@ In order to start {slm} we need to go to Kibana and execute the <<slm-api-start,
 . On the **Elasticsearch Service** panel, click the name of your deployment. 
 +
 
-NOTE:
-If the name of your deployment is disabled your {kib} instances might be
+NOTE: If the name of your deployment is disabled your {kib} instances might be
 unhealthy, in which case please contact https://support.elastic.co[Elastic Support].
 If your deployment doesn't include {kib}, all you need to do is 
 {cloud}/ec-access-kibana.html[enable it first].

--- a/docs/reference/tab-widgets/troubleshooting/data/total-shards-per-node.asciidoc
+++ b/docs/reference/tab-widgets/troubleshooting/data/total-shards-per-node.asciidoc
@@ -37,8 +37,7 @@ indices that have shards unassigned.
 . On the **Elasticsearch Service** panel, click the name of your deployment. 
 +
 
-NOTE:
-If the name of your deployment is disabled your {kib} instances might be
+NOTE: If the name of your deployment is disabled your {kib} instances might be
 unhealthy, in which case please contact https://support.elastic.co[Elastic Support].
 If your deployment doesn't include {kib}, all you need to do is 
 {cloud}/ec-access-kibana.html[enable it first].

--- a/docs/reference/tab-widgets/troubleshooting/snapshot/corrupt-repository.asciidoc
+++ b/docs/reference/tab-widgets/troubleshooting/snapshot/corrupt-repository.asciidoc
@@ -17,8 +17,7 @@ First mark the repository as read-only on the secondary deployments:
 . On the **Elasticsearch Service** panel, click the name of your deployment. 
 +
 
-NOTE:
-If the name of your deployment is disabled your {kib} instances might be
+NOTE: If the name of your deployment is disabled your {kib} instances might be
 unhealthy, in which case please contact https://support.elastic.co[Elastic Support].
 If your deployment doesn't include {kib}, all you need to do is 
 {cloud}/ec-access-kibana.html[enable it first].


### PR DESCRIPTION
Fix asciidoc note mark in troubleshooting docs: https://elasticsearch_88846.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/diagnose-unassigned-shards.html

Keep in mind, there is something wrong with the formatting of the note but the docs team is on it.