### PR TITLE
[ML] Fix version substitution in put DFA docs

### DIFF
--- a/docs/reference/ml/df-analytics/apis/put-dfanalytics.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/put-dfanalytics.asciidoc
@@ -699,7 +699,7 @@ The API returns the following result:
 
 ----
 // TESTRESPONSE[s/1656364565517/$body.$_path/]
-// TESTRESPONSE[s/"version": "8.4.0"/"version": $body.version/]
+// TESTRESPONSE[s/"version" : "8.4.0"/"version": $body.version/]
 // TESTRESPONSE[s/"authorization" : \{[^}]*\},//]
 
 
@@ -772,7 +772,7 @@ The API returns the following result:
 
 ----
 // TESTRESPONSE[s/1656364845151/$body.$_path/]
-// TESTRESPONSE[s/"version": "8.4.0"/"version": $body.version/]
+// TESTRESPONSE[s/"version" : "8.4.0"/"version": $body.version/]
 // TESTRESPONSE[s/"authorization" : \{[^}]*\},//]
 // TESTRESPONSE[s/-3578554885299300212/$body.$_path/]
 


### PR DESCRIPTION
This fixes the version substitution in a couple of response
examples in the put DFA docs.
