### PR TITLE
[8.4] Split x-pack testing into multiple CI jobs (#88697)

### DIFF
--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/BaseInternalPluginBuildPlugin.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/BaseInternalPluginBuildPlugin.java
@@ -11,6 +11,7 @@ package org.elasticsearch.gradle.internal;
 import groovy.lang.Closure;
 
 import org.elasticsearch.gradle.internal.conventions.util.Util;
+import org.elasticsearch.gradle.internal.info.BuildParams;
 import org.elasticsearch.gradle.plugin.PluginBuildPlugin;
 import org.elasticsearch.gradle.plugin.PluginPropertiesExtension;
 import org.elasticsearch.gradle.testclusters.ElasticsearchCluster;
@@ -48,18 +49,21 @@ public class BaseInternalPluginBuildPlugin implements Plugin<Project> {
             .getExtraProperties()
             .set("addQaCheckDependencies", new Closure<Project>(BaseInternalPluginBuildPlugin.this, BaseInternalPluginBuildPlugin.this) {
                 public void doCall(Project proj) {
-                    proj.afterEvaluate(project1 -> {
-                        // let check depend on check tasks of qa sub-projects
-                        final var checkTaskProvider = project1.getTasks().named("check");
-                        Optional<Project> qaSubproject = project1.getSubprojects()
-                            .stream()
-                            .filter(p -> p.getPath().equals(project1.getPath() + ":qa"))
-                            .findFirst();
-                        qaSubproject.ifPresent(
-                            qa -> qa.getSubprojects()
-                                .forEach(p -> checkTaskProvider.configure(task -> task.dependsOn(p.getPath() + ":check")))
-                        );
-                    });
+                    // This is only a convenience for local developers so make this a noop when running in CI
+                    if (BuildParams.isCi() == false) {
+                        proj.afterEvaluate(project1 -> {
+                            // let check depend on check tasks of qa sub-projects
+                            final var checkTaskProvider = project1.getTasks().named("check");
+                            Optional<Project> qaSubproject = project1.getSubprojects()
+                                .stream()
+                                .filter(p -> p.getPath().equals(project1.getPath() + ":qa"))
+                                .findFirst();
+                            qaSubproject.ifPresent(
+                                qa -> qa.getSubprojects()
+                                    .forEach(p -> checkTaskProvider.configure(task -> task.dependsOn(p.getPath() + ":check")))
+                            );
+                        });
+                    }
                 }
 
                 public void doCall() {

--- a/build.gradle
+++ b/build.gradle
@@ -6,28 +6,26 @@
  * Side Public License, v 1.
  */
 
+
+import de.thetaphi.forbiddenapis.gradle.ForbiddenApisPlugin
 import com.avast.gradle.dockercompose.tasks.ComposePull
 import com.fasterxml.jackson.databind.JsonNode
 import com.fasterxml.jackson.databind.ObjectMapper
-import com.github.jengelman.gradle.plugins.shadow.ShadowPlugin
-import de.thetaphi.forbiddenapis.gradle.ForbiddenApisPlugin
-import org.elasticsearch.gradle.internal.BuildPlugin
-import org.elasticsearch.gradle.Version
-import org.elasticsearch.gradle.VersionProperties
-import org.elasticsearch.gradle.internal.BwcVersions
-import org.elasticsearch.gradle.internal.info.BuildParams
-import org.elasticsearch.gradle.plugin.PluginBuildPlugin
-import org.gradle.plugins.ide.eclipse.model.AccessRule
-import org.gradle.util.DistributionLocator
-import org.gradle.util.GradleVersion
-import org.elasticsearch.gradle.util.GradleUtils
 
-import static org.elasticsearch.gradle.util.GradleUtils.maybeConfigure
-import org.gradle.plugins.ide.eclipse.model.ProjectDependency
+import org.elasticsearch.gradle.Version
 import org.elasticsearch.gradle.internal.BaseInternalPluginBuildPlugin
 import org.elasticsearch.gradle.internal.ResolveAllDependencies
+import org.elasticsearch.gradle.internal.info.BuildParams
+import org.elasticsearch.gradle.util.GradleUtils
+import org.gradle.plugins.ide.eclipse.model.AccessRule
+import org.gradle.plugins.ide.eclipse.model.ProjectDependency
+import org.gradle.util.DistributionLocator
+import org.gradle.util.GradleVersion
+
 import java.nio.file.Files
+
 import static java.nio.file.StandardCopyOption.REPLACE_EXISTING
+import static org.elasticsearch.gradle.util.GradleUtils.maybeConfigure
 
 plugins {
   id 'lifecycle-base'
@@ -208,14 +206,15 @@ allprojects {
     }
   }
 
-  def checkPart1 = tasks.register('checkPart1')
-  def checkPart2 = tasks.register('checkPart2')
-  def checkPart3 = tasks.register('checkPart3')
   plugins.withId('lifecycle-base') {
     if (project.path.startsWith(":x-pack:")) {
-      checkPart2.configure { dependsOn 'check' }
+      if (project.path.contains("security") || project.path.contains(":ml")) {
+        tasks.register('checkPart3') { dependsOn 'check' }
+      } else {
+        tasks.register('checkPart2') { dependsOn 'check' }
+      }
     } else {
-      checkPart1.configure { dependsOn 'check' }
+      tasks.register('checkPart1') { dependsOn 'check' }
     }
   }
 


### PR DESCRIPTION
Backports the following commits to 8.4:
 - Split x-pack testing into multiple CI jobs (#88697)