### PR TITLE
[8.4] Script: Rename TIMESTAMP constant NOW in Metadata (#88870)

### DIFF
--- a/modules/lang-painless/src/main/resources/org/elasticsearch/painless/org.elasticsearch.script.ingest.txt
+++ b/modules/lang-painless/src/main/resources/org/elasticsearch/painless/org.elasticsearch.script.ingest.txt
@@ -35,7 +35,7 @@ class org.elasticsearch.script.Metadata {
     String getVersionType()
     void setVersionType(String)
 
-    ZonedDateTime getTimestamp()
+    ZonedDateTime getNow()
 }
 
 class org.elasticsearch.script.IngestScript {

--- a/modules/lang-painless/src/main/resources/org/elasticsearch/painless/org.elasticsearch.script.update.txt
+++ b/modules/lang-painless/src/main/resources/org/elasticsearch/painless/org.elasticsearch.script.update.txt
@@ -26,7 +26,7 @@ class org.elasticsearch.script.Metadata {
     long getVersion()
     String getOp()
     void setOp(String)
-    ZonedDateTime getTimestamp()
+    ZonedDateTime getNow()
 }
 
 class org.elasticsearch.script.UpdateScript {

--- a/server/src/main/java/org/elasticsearch/ingest/IngestDocMetadata.java
+++ b/server/src/main/java/org/elasticsearch/ingest/IngestDocMetadata.java
@@ -84,7 +84,7 @@ class IngestDocMetadata extends Metadata {
     }
 
     @Override
-    public ZonedDateTime getTimestamp() {
+    public ZonedDateTime getNow() {
         return timestamp;
     }
 }

--- a/server/src/main/java/org/elasticsearch/ingest/IngestDocument.java
+++ b/server/src/main/java/org/elasticsearch/ingest/IngestDocument.java
@@ -59,7 +59,7 @@ public final class IngestDocument {
     public IngestDocument(String index, String id, long version, String routing, VersionType versionType, Map<String, Object> source) {
         this.sourceAndMetadata = new IngestCtxMap(index, id, version, routing, versionType, ZonedDateTime.now(ZoneOffset.UTC), source);
         this.ingestMetadata = new HashMap<>();
-        this.ingestMetadata.put(TIMESTAMP, sourceAndMetadata.getMetadata().getTimestamp());
+        this.ingestMetadata.put(TIMESTAMP, sourceAndMetadata.getMetadata().getNow());
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/script/Metadata.java
+++ b/server/src/main/java/org/elasticsearch/script/Metadata.java
@@ -44,7 +44,7 @@ public class Metadata {
     protected static final String VERSION_TYPE = "_version_type";
     protected static final String VERSION = "_version";
     protected static final String TYPE = "_type"; // type is deprecated, so it's supported in the map but not available as a getter
-    protected static final String TIMESTAMP = "_now";
+    protected static final String NOW = "_now";
     protected static final String OP = "op";
     protected static final String IF_SEQ_NO = "_if_seq_no";
     protected static final String IF_PRIMARY_TERM = "_if_primary_term";
@@ -122,8 +122,8 @@ public class Metadata {
         put(VERSION, version);
     }
 
-    public ZonedDateTime getTimestamp() {
-        return ZonedDateTime.ofInstant(Instant.ofEpochMilli(getNumber(TIMESTAMP).longValue()), ZoneOffset.UTC);
+    public ZonedDateTime getNow() {
+        return ZonedDateTime.ofInstant(Instant.ofEpochMilli(getNumber(NOW).longValue()), ZoneOffset.UTC);
     }
 
     public String getOp() {

--- a/server/src/main/java/org/elasticsearch/script/UpdateCtxMap.java
+++ b/server/src/main/java/org/elasticsearch/script/UpdateCtxMap.java
@@ -22,10 +22,10 @@ public class UpdateCtxMap extends CtxMap {
         String routing,
         String type,
         String op,
-        long timestamp,
+        long now,
         Map<String, Object> source
     ) {
-        super(source, new UpdateMetadata(index, id, version, routing, type, op, timestamp));
+        super(source, new UpdateMetadata(index, id, version, routing, type, op, now));
     }
 
     protected UpdateCtxMap(Map<String, Object> source, Metadata metadata) {

--- a/server/src/main/java/org/elasticsearch/script/UpdateMetadata.java
+++ b/server/src/main/java/org/elasticsearch/script/UpdateMetadata.java
@@ -47,14 +47,14 @@ public class UpdateMetadata extends Metadata {
         SET_ONCE_STRING,
         OP,
         new FieldProperty<>(String.class, true, true, null),
-        TIMESTAMP,
+        NOW,
         SET_ONCE_LONG
     );
 
     protected final Set<String> validOps;
 
-    public UpdateMetadata(String index, String id, long version, String routing, String type, String op, long timestamp) {
-        this(metadataMap(index, id, version, routing, type, op, timestamp), Set.of("noop", "index", "delete"), PROPERTIES);
+    public UpdateMetadata(String index, String id, long version, String routing, String type, String op, long now) {
+        this(metadataMap(index, id, version, routing, type, op, now), Set.of("noop", "index", "delete"), PROPERTIES);
     }
 
     protected UpdateMetadata(Map<String, Object> metadata, Set<String> validOps, Map<String, FieldProperty<?>> properties) {
@@ -69,7 +69,7 @@ public class UpdateMetadata extends Metadata {
         String routing,
         String type,
         String op,
-        long timestamp
+        long now
     ) {
         Map<String, Object> metadata = Maps.newHashMapWithExpectedSize(PROPERTIES.size());
         metadata.put(INDEX, index);
@@ -78,7 +78,7 @@ public class UpdateMetadata extends Metadata {
         metadata.put(ROUTING, routing);
         metadata.put(TYPE, type);
         metadata.put(OP, op);
-        metadata.put(TIMESTAMP, timestamp);
+        metadata.put(NOW, now);
         return metadata;
     }
 

--- a/server/src/main/java/org/elasticsearch/script/UpsertCtxMap.java
+++ b/server/src/main/java/org/elasticsearch/script/UpsertCtxMap.java
@@ -14,7 +14,7 @@ import java.util.Map;
  * Metadata for insert via upsert in the Update context
  */
 public class UpsertCtxMap extends UpdateCtxMap {
-    public UpsertCtxMap(String index, String id, String op, long timestamp, Map<String, Object> source) {
-        super(source, new UpsertMetadata(index, id, op, timestamp));
+    public UpsertCtxMap(String index, String id, String op, long now, Map<String, Object> source) {
+        super(source, new UpsertMetadata(index, id, op, now));
     }
 }

--- a/server/src/main/java/org/elasticsearch/script/UpsertMetadata.java
+++ b/server/src/main/java/org/elasticsearch/script/UpsertMetadata.java
@@ -21,20 +21,20 @@ class UpsertMetadata extends UpdateMetadata {
         SET_ONCE_STRING,
         OP,
         new FieldProperty<>(String.class, true, true, null),
-        TIMESTAMP,
+        NOW,
         SET_ONCE_LONG
     );
 
-    UpsertMetadata(String index, String id, String op, long timestamp) {
-        super(metadataMap(index, id, op, timestamp), Set.of("noop", "create"), PROPERTIES);
+    UpsertMetadata(String index, String id, String op, long now) {
+        super(metadataMap(index, id, op, now), Set.of("noop", "create"), PROPERTIES);
     }
 
-    protected static Map<String, Object> metadataMap(String index, String id, String op, long timestamp) {
+    protected static Map<String, Object> metadataMap(String index, String id, String op, long now) {
         Map<String, Object> metadata = Maps.newHashMapWithExpectedSize(PROPERTIES.size());
         metadata.put(INDEX, index);
         metadata.put(ID, id);
         metadata.put(OP, op);
-        metadata.put(TIMESTAMP, timestamp);
+        metadata.put(NOW, now);
         return metadata;
     }
 

--- a/server/src/test/java/org/elasticsearch/script/UpdateCtxMapTests.java
+++ b/server/src/test/java/org/elasticsearch/script/UpdateCtxMapTests.java
@@ -91,7 +91,7 @@ public class UpdateCtxMapTests extends ESTestCase {
         IllegalArgumentException err = expectThrows(IllegalArgumentException.class, () -> meta.put("_now", 1234));
         assertEquals("_now cannot be updated", err.getMessage());
         assertEquals(TS, meta.get("_now"));
-        ZonedDateTime zdt = meta.getTimestamp();
+        ZonedDateTime zdt = meta.getNow();
         assertEquals(4, zdt.getMonthValue());
         assertEquals(26, zdt.getDayOfMonth());
         assertEquals(1992, zdt.getYear());


### PR DESCRIPTION
Backports the following commits to 8.4:
 - Script: Rename TIMESTAMP constant NOW in Metadata (#88870)