### PR TITLE
[7.17] Log more details in TaskAssertions (#88864)

### DIFF
--- a/qa/smoke-test-http/src/javaRestTest/java/org/elasticsearch/http/IndicesSegmentsRestCancellationIT.java
+++ b/qa/smoke-test-http/src/javaRestTest/java/org/elasticsearch/http/IndicesSegmentsRestCancellationIT.java
@@ -11,7 +11,9 @@ package org.elasticsearch.http;
 import org.apache.http.client.methods.HttpGet;
 import org.elasticsearch.action.admin.indices.segments.IndicesSegmentsAction;
 import org.elasticsearch.client.Request;
+import org.elasticsearch.test.junit.annotations.TestLogging;
 
+@TestLogging(value = "org.elasticsearch.tasks.TaskManager:TRACE,org.elasticsearch.test.TaskAssertions:TRACE", reason = "debugging")
 public class IndicesSegmentsRestCancellationIT extends BlockedSearcherRestCancellationTestCase {
     public void testIndicesSegmentsRestCancellation() throws Exception {
         runTest(new Request(HttpGet.METHOD_NAME, "/_segments"), IndicesSegmentsAction.NAME);

--- a/test/framework/src/main/java/org/elasticsearch/test/TaskAssertions.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/TaskAssertions.java
@@ -11,11 +11,13 @@ package org.elasticsearch.test;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.elasticsearch.tasks.CancellableTask;
+import org.elasticsearch.tasks.Task;
 import org.elasticsearch.tasks.TaskInfo;
 import org.elasticsearch.tasks.TaskManager;
 import org.elasticsearch.transport.TransportService;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 import static junit.framework.TestCase.assertTrue;
 import static junit.framework.TestCase.fail;
@@ -33,7 +35,14 @@ public class TaskAssertions {
 
         assertBusy(() -> {
             for (TransportService transportService : internalCluster().getInstances(TransportService.class)) {
-                if (transportService.getTaskManager().getTasks().values().stream().anyMatch(t -> t.getAction().startsWith(actionPrefix))) {
+                List<Task> matchingTasks = transportService.getTaskManager()
+                    .getTasks()
+                    .values()
+                    .stream()
+                    .filter(t -> t.getAction().startsWith(actionPrefix))
+                    .collect(Collectors.toList());
+                if (matchingTasks.isEmpty() == false) {
+                    logger.trace("--> found {} tasks with prefix [{}]: {}", matchingTasks.size(), actionPrefix, matchingTasks);
                     return;
                 }
             }
@@ -51,6 +60,7 @@ public class TaskAssertions {
                 assertTrue(taskManager.assertCancellableTaskConsistency());
                 for (CancellableTask cancellableTask : taskManager.getCancellableTasks().values()) {
                     if (cancellableTask.getAction().startsWith(actionPrefix)) {
+                        logger.trace("--> found task with prefix [{}] marked as cancelled: [{}]", actionPrefix, cancellableTask);
                         foundTask = true;
                         assertTrue(
                             "task " + cancellableTask.getId() + "/" + cancellableTask.getAction() + " not cancelled",


### PR DESCRIPTION
Backports the following commits to 7.17:
 - Log more details in TaskAssertions (#88864)