### PR TITLE
[Stack Monitoring] Cleanup unused mappings properties

### DIFF
--- a/x-pack/plugin/core/src/main/resources/monitoring-es-mb.json
+++ b/x-pack/plugin/core/src/main/resources/monitoring-es-mb.json
@@ -2118,126 +2118,6 @@
             "type": {
               "ignore_above": 1024,
               "type": "keyword"
-            },
-            "environment": {
-              "type": "keyword",
-              "ignore_above": 1024
-            },
-            "ephemeral_id": {
-              "type": "keyword",
-              "ignore_above": 1024
-            },
-            "hostname": {
-              "type": "keyword",
-              "ignore_above": 1024
-            },
-            "id": {
-              "type": "keyword",
-              "ignore_above": 1024
-            },
-            "node": {
-              "properties": {
-                "name": {
-                  "type": "keyword",
-                  "ignore_above": 1024
-                }
-              }
-            },
-            "origin": {
-              "properties": {
-                "address": {
-                  "type": "keyword",
-                  "ignore_above": 1024
-                },
-                "environment": {
-                  "type": "keyword",
-                  "ignore_above": 1024
-                },
-                "ephemeral_id": {
-                  "type": "keyword",
-                  "ignore_above": 1024
-                },
-                "id": {
-                  "type": "keyword",
-                  "ignore_above": 1024
-                },
-                "name": {
-                  "type": "keyword",
-                  "ignore_above": 1024
-                },
-                "node": {
-                  "properties": {
-                    "name": {
-                      "type": "keyword",
-                      "ignore_above": 1024
-                    }
-                  }
-                },
-                "state": {
-                  "type": "keyword",
-                  "ignore_above": 1024
-                },
-                "type": {
-                  "type": "keyword",
-                  "ignore_above": 1024
-                },
-                "version": {
-                  "type": "keyword",
-                  "ignore_above": 1024
-                }
-              }
-            },
-            "state": {
-              "type": "keyword",
-              "ignore_above": 1024
-            },
-            "target": {
-              "properties": {
-                "address": {
-                  "type": "keyword",
-                  "ignore_above": 1024
-                },
-                "environment": {
-                  "type": "keyword",
-                  "ignore_above": 1024
-                },
-                "ephemeral_id": {
-                  "type": "keyword",
-                  "ignore_above": 1024
-                },
-                "id": {
-                  "type": "keyword",
-                  "ignore_above": 1024
-                },
-                "name": {
-                  "type": "keyword",
-                  "ignore_above": 1024
-                },
-                "node": {
-                  "properties": {
-                    "name": {
-                      "type": "keyword",
-                      "ignore_above": 1024
-                    }
-                  }
-                },
-                "state": {
-                  "type": "keyword",
-                  "ignore_above": 1024
-                },
-                "type": {
-                  "type": "keyword",
-                  "ignore_above": 1024
-                },
-                "version": {
-                  "type": "keyword",
-                  "ignore_above": 1024
-                }
-              }
-            },
-            "version": {
-              "type": "keyword",
-              "ignore_above": 1024
             }
           }
         },
@@ -2973,14 +2853,6 @@
             "name": {
               "type": "keyword",
               "ignore_above": 1024
-            },
-            "architecture": {
-              "type": "keyword",
-              "ignore_above": 1024
-            },
-            "hostname": {
-              "type": "keyword",
-              "ignore_above": 1024
             }
           }
         },
@@ -2997,25 +2869,6 @@
         },
         "event": {
           "properties": {
-            "action": {
-              "type": "keyword",
-              "ignore_above": 1024
-            },
-            "agent_id_status": {
-              "type": "keyword",
-              "ignore_above": 1024
-            },
-            "category": {
-              "type": "keyword",
-              "ignore_above": 1024
-            },
-            "code": {
-              "type": "keyword",
-              "ignore_above": 1024
-            },
-            "created": {
-              "type": "date"
-            },
             "dataset": {
               "type": "keyword",
               "ignore_above": 1024
@@ -3023,74 +2876,7 @@
             "duration": {
               "type": "long"
             },
-            "end": {
-              "type": "date"
-            },
-            "hash": {
-              "type": "keyword",
-              "ignore_above": 1024
-            },
-            "id": {
-              "type": "keyword",
-              "ignore_above": 1024
-            },
-            "ingested": {
-              "type": "date"
-            },
-            "kind": {
-              "type": "keyword",
-              "ignore_above": 1024
-            },
             "module": {
-              "type": "keyword",
-              "ignore_above": 1024
-            },
-            "original": {
-              "type": "keyword",
-              "index": false,
-              "doc_values": false,
-              "ignore_above": 1024
-            },
-            "outcome": {
-              "type": "keyword",
-              "ignore_above": 1024
-            },
-            "provider": {
-              "type": "keyword",
-              "ignore_above": 1024
-            },
-            "reason": {
-              "type": "keyword",
-              "ignore_above": 1024
-            },
-            "reference": {
-              "type": "keyword",
-              "ignore_above": 1024
-            },
-            "risk_score": {
-              "type": "float"
-            },
-            "risk_score_norm": {
-              "type": "float"
-            },
-            "sequence": {
-              "type": "long"
-            },
-            "severity": {
-              "type": "long"
-            },
-            "start": {
-              "type": "date"
-            },
-            "timezone": {
-              "type": "keyword",
-              "ignore_above": 1024
-            },
-            "type": {
-              "type": "keyword",
-              "ignore_above": 1024
-            },
-            "url": {
               "type": "keyword",
               "ignore_above": 1024
             }

--- a/x-pack/plugin/core/src/main/resources/monitoring-es-mb.json
+++ b/x-pack/plugin/core/src/main/resources/monitoring-es-mb.json
@@ -2325,9 +2325,6 @@
             }
           }
         },
-        "version": {
-          "type": "long"
-        },
         "ccr_auto_follow_stats": {
           "properties": {
             "number_of_failed_remote_cluster_state_requests": {

--- a/x-pack/plugin/core/src/main/resources/monitoring-kibana-mb.json
+++ b/x-pack/plugin/core/src/main/resources/monitoring-kibana-mb.json
@@ -29,10 +29,6 @@
               "ignore_above": 1024,
               "type": "keyword"
             },
-            "name": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
             "id": {
               "ignore_above": 1024,
               "type": "keyword"
@@ -44,118 +40,6 @@
             "version": {
               "ignore_above": 1024,
               "type": "keyword"
-            },
-            "environment": {
-              "type": "keyword",
-              "ignore_above": 1024
-            },
-            "ephemeral_id": {
-              "type": "keyword",
-              "ignore_above": 1024
-            },
-            "hostname": {
-              "type": "keyword",
-              "ignore_above": 1024
-            },
-            "node": {
-              "properties": {
-                "name": {
-                  "type": "keyword",
-                  "ignore_above": 1024
-                }
-              }
-            },
-            "origin": {
-              "properties": {
-                "address": {
-                  "type": "keyword",
-                  "ignore_above": 1024
-                },
-                "environment": {
-                  "type": "keyword",
-                  "ignore_above": 1024
-                },
-                "ephemeral_id": {
-                  "type": "keyword",
-                  "ignore_above": 1024
-                },
-                "id": {
-                  "type": "keyword",
-                  "ignore_above": 1024
-                },
-                "name": {
-                  "type": "keyword",
-                  "ignore_above": 1024
-                },
-                "node": {
-                  "properties": {
-                    "name": {
-                      "type": "keyword",
-                      "ignore_above": 1024
-                    }
-                  }
-                },
-                "state": {
-                  "type": "keyword",
-                  "ignore_above": 1024
-                },
-                "type": {
-                  "type": "keyword",
-                  "ignore_above": 1024
-                },
-                "version": {
-                  "type": "keyword",
-                  "ignore_above": 1024
-                }
-              }
-            },
-            "state": {
-              "type": "keyword",
-              "ignore_above": 1024
-            },
-            "target": {
-              "properties": {
-                "address": {
-                  "type": "keyword",
-                  "ignore_above": 1024
-                },
-                "environment": {
-                  "type": "keyword",
-                  "ignore_above": 1024
-                },
-                "ephemeral_id": {
-                  "type": "keyword",
-                  "ignore_above": 1024
-                },
-                "id": {
-                  "type": "keyword",
-                  "ignore_above": 1024
-                },
-                "name": {
-                  "type": "keyword",
-                  "ignore_above": 1024
-                },
-                "node": {
-                  "properties": {
-                    "name": {
-                      "type": "keyword",
-                      "ignore_above": 1024
-                    }
-                  }
-                },
-                "state": {
-                  "type": "keyword",
-                  "ignore_above": 1024
-                },
-                "type": {
-                  "type": "keyword",
-                  "ignore_above": 1024
-                },
-                "version": {
-                  "type": "keyword",
-                  "ignore_above": 1024
-                }
-              }
             }
           }
         },
@@ -587,14 +471,6 @@
             "name": {
               "type": "keyword",
               "ignore_above": 1024
-            },
-            "architecture": {
-              "type": "keyword",
-              "ignore_above": 1024
-            },
-            "hostname": {
-              "type": "keyword",
-              "ignore_above": 1024
             }
           }
         },
@@ -611,25 +487,6 @@
         },
         "event": {
           "properties": {
-            "action": {
-              "type": "keyword",
-              "ignore_above": 1024
-            },
-            "agent_id_status": {
-              "type": "keyword",
-              "ignore_above": 1024
-            },
-            "category": {
-              "type": "keyword",
-              "ignore_above": 1024
-            },
-            "code": {
-              "type": "keyword",
-              "ignore_above": 1024
-            },
-            "created": {
-              "type": "date"
-            },
             "dataset": {
               "type": "keyword",
               "ignore_above": 1024
@@ -637,74 +494,7 @@
             "duration": {
               "type": "long"
             },
-            "end": {
-              "type": "date"
-            },
-            "hash": {
-              "type": "keyword",
-              "ignore_above": 1024
-            },
-            "id": {
-              "type": "keyword",
-              "ignore_above": 1024
-            },
-            "ingested": {
-              "type": "date"
-            },
-            "kind": {
-              "type": "keyword",
-              "ignore_above": 1024
-            },
             "module": {
-              "type": "keyword",
-              "ignore_above": 1024
-            },
-            "original": {
-              "type": "keyword",
-              "index": false,
-              "doc_values": false,
-              "ignore_above": 1024
-            },
-            "outcome": {
-              "type": "keyword",
-              "ignore_above": 1024
-            },
-            "provider": {
-              "type": "keyword",
-              "ignore_above": 1024
-            },
-            "reason": {
-              "type": "keyword",
-              "ignore_above": 1024
-            },
-            "reference": {
-              "type": "keyword",
-              "ignore_above": 1024
-            },
-            "risk_score": {
-              "type": "float"
-            },
-            "risk_score_norm": {
-              "type": "float"
-            },
-            "sequence": {
-              "type": "long"
-            },
-            "severity": {
-              "type": "long"
-            },
-            "start": {
-              "type": "date"
-            },
-            "timezone": {
-              "type": "keyword",
-              "ignore_above": 1024
-            },
-            "type": {
-              "type": "keyword",
-              "ignore_above": 1024
-            },
-            "url": {
               "type": "keyword",
               "ignore_above": 1024
             }

--- a/x-pack/plugin/core/src/main/resources/monitoring-logstash-mb.json
+++ b/x-pack/plugin/core/src/main/resources/monitoring-logstash-mb.json
@@ -504,128 +504,12 @@
             "version": {
               "ignore_above": 1024,
               "type": "keyword"
-            },
-            "environment": {
-              "type": "keyword",
-              "ignore_above": 1024
-            },
-            "ephemeral_id": {
-              "type": "keyword",
-              "ignore_above": 1024
-            },
-            "node": {
-              "properties": {
-                "name": {
-                  "type": "keyword",
-                  "ignore_above": 1024
-                }
-              }
-            },
-            "origin": {
-              "properties": {
-                "address": {
-                  "type": "keyword",
-                  "ignore_above": 1024
-                },
-                "environment": {
-                  "type": "keyword",
-                  "ignore_above": 1024
-                },
-                "ephemeral_id": {
-                  "type": "keyword",
-                  "ignore_above": 1024
-                },
-                "id": {
-                  "type": "keyword",
-                  "ignore_above": 1024
-                },
-                "name": {
-                  "type": "keyword",
-                  "ignore_above": 1024
-                },
-                "node": {
-                  "properties": {
-                    "name": {
-                      "type": "keyword",
-                      "ignore_above": 1024
-                    }
-                  }
-                },
-                "state": {
-                  "type": "keyword",
-                  "ignore_above": 1024
-                },
-                "type": {
-                  "type": "keyword",
-                  "ignore_above": 1024
-                },
-                "version": {
-                  "type": "keyword",
-                  "ignore_above": 1024
-                }
-              }
-            },
-            "state": {
-              "type": "keyword",
-              "ignore_above": 1024
-            },
-            "target": {
-              "properties": {
-                "address": {
-                  "type": "keyword",
-                  "ignore_above": 1024
-                },
-                "environment": {
-                  "type": "keyword",
-                  "ignore_above": 1024
-                },
-                "ephemeral_id": {
-                  "type": "keyword",
-                  "ignore_above": 1024
-                },
-                "id": {
-                  "type": "keyword",
-                  "ignore_above": 1024
-                },
-                "name": {
-                  "type": "keyword",
-                  "ignore_above": 1024
-                },
-                "node": {
-                  "properties": {
-                    "name": {
-                      "type": "keyword",
-                      "ignore_above": 1024
-                    }
-                  }
-                },
-                "state": {
-                  "type": "keyword",
-                  "ignore_above": 1024
-                },
-                "type": {
-                  "type": "keyword",
-                  "ignore_above": 1024
-                },
-                "version": {
-                  "type": "keyword",
-                  "ignore_above": 1024
-                }
-              }
             }
           }
         },
         "host": {
           "properties": {
-            "hostname": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
             "name": {
-              "type": "keyword",
-              "ignore_above": 1024
-            },
-            "architecture": {
               "type": "keyword",
               "ignore_above": 1024
             }
@@ -648,25 +532,6 @@
         },
         "event": {
           "properties": {
-            "action": {
-              "type": "keyword",
-              "ignore_above": 1024
-            },
-            "agent_id_status": {
-              "type": "keyword",
-              "ignore_above": 1024
-            },
-            "category": {
-              "type": "keyword",
-              "ignore_above": 1024
-            },
-            "code": {
-              "type": "keyword",
-              "ignore_above": 1024
-            },
-            "created": {
-              "type": "date"
-            },
             "dataset": {
               "type": "keyword",
               "ignore_above": 1024
@@ -674,74 +539,7 @@
             "duration": {
               "type": "long"
             },
-            "end": {
-              "type": "date"
-            },
-            "hash": {
-              "type": "keyword",
-              "ignore_above": 1024
-            },
-            "id": {
-              "type": "keyword",
-              "ignore_above": 1024
-            },
-            "ingested": {
-              "type": "date"
-            },
-            "kind": {
-              "type": "keyword",
-              "ignore_above": 1024
-            },
             "module": {
-              "type": "keyword",
-              "ignore_above": 1024
-            },
-            "original": {
-              "type": "keyword",
-              "index": false,
-              "doc_values": false,
-              "ignore_above": 1024
-            },
-            "outcome": {
-              "type": "keyword",
-              "ignore_above": 1024
-            },
-            "provider": {
-              "type": "keyword",
-              "ignore_above": 1024
-            },
-            "reason": {
-              "type": "keyword",
-              "ignore_above": 1024
-            },
-            "reference": {
-              "type": "keyword",
-              "ignore_above": 1024
-            },
-            "risk_score": {
-              "type": "float"
-            },
-            "risk_score_norm": {
-              "type": "float"
-            },
-            "sequence": {
-              "type": "long"
-            },
-            "severity": {
-              "type": "long"
-            },
-            "start": {
-              "type": "date"
-            },
-            "timezone": {
-              "type": "keyword",
-              "ignore_above": 1024
-            },
-            "type": {
-              "type": "keyword",
-              "ignore_above": 1024
-            },
-            "url": {
               "type": "keyword",
               "ignore_above": 1024
             }

--- a/x-pack/plugin/monitoring/src/main/java/org/elasticsearch/xpack/monitoring/MonitoringTemplateRegistry.java
+++ b/x-pack/plugin/monitoring/src/main/java/org/elasticsearch/xpack/monitoring/MonitoringTemplateRegistry.java
@@ -78,7 +78,7 @@ public class MonitoringTemplateRegistry extends IndexTemplateRegistry {
      * writes monitoring data in ECS format as of 8.0. These templates define the ECS schema as well as alias fields for the old monitoring
      * mappings that point to the corresponding ECS fields.
      */
-    public static final int STACK_MONITORING_REGISTRY_VERSION = Version.V_8_0_0.id + 3;
+    public static final int STACK_MONITORING_REGISTRY_VERSION = Version.V_8_0_0.id + 4;
     private static final String STACK_MONITORING_REGISTRY_VERSION_VARIABLE = "xpack.stack.monitoring.template.release.version";
     private static final String STACK_TEMPLATE_VERSION = "8";
     private static final String STACK_TEMPLATE_VERSION_VARIABLE = "xpack.stack.monitoring.template.version";


### PR DESCRIPTION
### Summary

Part of https://github.com/elastic/kibana/issues/135379

Remove unused `service.*`, `event.*` and `host.*` properties from the stack monitoring templates. This is a cleanup change with no functional impact.
Context on how the properties ended up being defined in the first place [here](https://github.com/elastic/kibana/issues/135379#issuecomment-1197284221). Now the approach to detect which properties were not used:
- we performed a diff between the monitoring ES mappings and the one defined in the integration packages and realized differences in these fields
- verified which properties were actually populated by looking at the metricbeat document references as well as the "Available fields" column in Kibana Discover app
- only kept the fields appearing in both places