### PR TITLE
[DOCS] Warn only one date format is added to the field date formats when using dynamic_date_formats

### DIFF
--- a/docs/reference/mapping/dynamic/field-mapping.asciidoc
+++ b/docs/reference/mapping/dynamic/field-mapping.asciidoc
@@ -114,6 +114,8 @@ PUT my-index-000001/_doc/1
 }
 --------------------------------------------------
 
+When multiple date formats are provided, only the format which matched the contents
+of one of the fields will actually be added to the allowed date formats.
 
 [[numeric-detection]]
 ==== Numeric detection

--- a/docs/reference/mapping/dynamic/field-mapping.asciidoc
+++ b/docs/reference/mapping/dynamic/field-mapping.asciidoc
@@ -114,8 +114,45 @@ PUT my-index-000001/_doc/1
 }
 --------------------------------------------------
 
-When multiple date formats are provided, only the format which matched the contents
-of one of the fields will actually be added to the allowed date formats.
+It is possible to provide multiple date formats. The format in the first 
+document with an unmapped date field will determine the mapping of that field:
+
+[source,console]
+--------------------------------------------------
+PUT my-index-000001
+{
+  "mappings": {
+    "dynamic_date_formats": [ "yyyy/MM", "MM/dd/yyyy"]
+  }
+}
+
+PUT my-index-000001/_doc/1
+{
+  "create_date": "09/25/2015"
+}
+--------------------------------------------------
+
+The resulting mapping will be:
+
+[source,console-result]
+--------------------------------------------------
+{
+  "my-index-000001": {
+    "mappings": {
+      "dynamic_date_formats": [
+        "yyyy/MM",
+        "MM/dd/yyyy"
+      ],
+      "properties": {
+        "create_date": {
+          "type": "date",
+          "format": "MM/dd/yyyy"
+        }
+      }
+    }
+  }
+}
+--------------------------------------------------
 
 [[numeric-detection]]
 ==== Numeric detection

--- a/docs/reference/mapping/dynamic/field-mapping.asciidoc
+++ b/docs/reference/mapping/dynamic/field-mapping.asciidoc
@@ -139,6 +139,14 @@ PUT my-index-000001/_doc/1
 
 The resulting mapping will be:
 
+////
+[source,console]
+----
+GET my-index-000001/_mapping
+----
+//TEST[continued]
+////
+
 [source,console-result]
 --------------------------------------------------
 {
@@ -179,6 +187,14 @@ PUT my-index-000001/_doc/1
 --------------------------------------------------
 
 The resulting mapping will be:
+
+////
+[source,console]
+----
+GET my-index-000001/_mapping
+----
+//TEST[continued]
+////
 
 [source,console-result]
 --------------------------------------------------

--- a/docs/reference/mapping/dynamic/field-mapping.asciidoc
+++ b/docs/reference/mapping/dynamic/field-mapping.asciidoc
@@ -114,8 +114,13 @@ PUT my-index-000001/_doc/1
 }
 --------------------------------------------------
 
-It is possible to provide multiple date formats. The format in the first 
-document with an unmapped date field will determine the mapping of that field:
+[NOTE]
+====
+There is a difference between configuring an array of date patterns and
+configuring multiple patterns in a single string separated by `||`. When you
+configure an array of date patterns, the pattern that matches the date in the
+first document with an unmapped date field will determine the mapping of that
+field:
 
 [source,console]
 --------------------------------------------------
@@ -153,6 +158,47 @@ The resulting mapping will be:
   }
 }
 --------------------------------------------------
+
+Configuring multiple patterns in a single string separated by `||` results in a
+mapping that supports any of the date formats. This enables you to index
+documents that use different formats:
+
+[source,console]
+--------------------------------------------------
+PUT my-index-000001
+{
+  "mappings": {
+    "dynamic_date_formats": [ "yyyy/MM||MM/dd/yyyy"]
+  }
+}
+
+PUT my-index-000001/_doc/1
+{
+  "create_date": "09/25/2015"
+}
+--------------------------------------------------
+
+The resulting mapping will be:
+
+[source,console-result]
+--------------------------------------------------
+{
+  "my-index-000001": {
+    "mappings": {
+      "dynamic_date_formats": [
+        "yyyy/MM||MM/dd/yyyy"
+      ],
+      "properties": {
+        "create_date": {
+          "type": "date",
+          "format": "yyyy/MM||MM/dd/yyyy"
+        }
+      }
+    }
+  }
+}
+--------------------------------------------------
+====
 
 [[numeric-detection]]
 ==== Numeric detection


### PR DESCRIPTION
When using multiple options in `dynamic_date_formats`, only one of the formats of the first document having a date matching one of the date formats provided will be used.

E.g.
```
PUT my-index-000001
{
  "mappings": {
    "dynamic_date_formats": [ "yyyy/MM", "MM/dd/yyyy"]
  }
}

PUT my-index-000001/_doc/1
{
  "create_date": "09/25/2015"
}
```

The generated mappings will be:
```
    "mappings": {
      "dynamic_date_formats": [
        "yyyy/MM",
        "MM/dd/yyyy"
      ],
      "properties": {
        "create_date": {
          "type": "date",
          "format": "MM/dd/yyyy"
        }
      }
    },
```

Indexing a document with `2015/12` would lead to the `format` `"yyyy/MM"` being used for the `create_date`.

This can be misleading especially if the user is using multiple date formats on the same field.
The first document will determine the format of the `date` field being detected.

Maybe we should provide an additional example, such as:
```
PUT my-index-000001
{
  "mappings": {
    "dynamic_date_formats": [ "yyyy/MM||MM/dd/yyyy"]
  }
}
```

My wording is not great, so feel free to amend/edit.

<!--
Thank you for your interest in and contributing to Elasticsearch! There
are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your
attention.
-->

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/elasticsearch/blob/master/CONTRIBUTING.md)?
- If submitting code, have you built your formula locally prior to submission with `gradle check`?
- If submitting code, is your pull request against master? Unless there is a good reason otherwise, we prefer pull requests against master and will backport as needed.
- If submitting code, have you checked that your submission is for an [OS and architecture that we support](https://www.elastic.co/support/matrix#show_os)?
- If you are submitting this code for a class then read our [policy](https://github.com/elastic/elasticsearch/blob/master/CONTRIBUTING.md#contributing-as-part-of-a-class) for that.
