### PR TITLE
Add 8.5 migration docs

### DIFF
--- a/docs/reference/migration/index.asciidoc
+++ b/docs/reference/migration/index.asciidoc
@@ -1,11 +1,13 @@
 include::migration_intro.asciidoc[]
 
+* <<migrating-8.5,Migrating to 8.5>>
 * <<migrating-8.4,Migrating to 8.4>>
 * <<migrating-8.3,Migrating to 8.3>>
 * <<migrating-8.2,Migrating to 8.2>>
 * <<migrating-8.1,Migrating to 8.1>>
 * <<migrating-8.0,Migrating to 8.0>>
 
+include::migrate_8_5.asciidoc[]
 include::migrate_8_4.asciidoc[]
 include::migrate_8_3.asciidoc[]
 include::migrate_8_2.asciidoc[]

--- a/docs/reference/migration/migrate_8_5.asciidoc
+++ b/docs/reference/migration/migrate_8_5.asciidoc
@@ -1,0 +1,22 @@
+[[migrating-8.5]]
+== Migrating to 8.5
+++++
+<titleabbrev>8.5</titleabbrev>
+++++
+
+This section discusses the changes that you need to be aware of when migrating
+your application to {es} 8.5.
+
+See also <<release-highlights>> and <<es-release-notes>>.
+
+coming::[8.5.0]
+
+
+[discrete]
+[[breaking-changes-8.5]]
+=== Breaking changes
+
+// tag::notable-breaking-changes[]
+There are no breaking changes in {es} 8.5.
+// end::notable-breaking-changes[]
+


### PR DESCRIPTION
This commit adds the a migration docs file for 8.5. This was copied from
the 8.4 file, which had no migration notes.