### PR TITLE
Deprecate network plugins

### DIFF
--- a/docs/changelog/88924.yaml
+++ b/docs/changelog/88924.yaml
@@ -5,6 +5,6 @@ type: deprecation
 issues: []
 deprecation:
   title: Deprecate network plugins
-  area: Infra/Plugins
+  area: Java API
   details: Plugins extending NetworkPlugin are deprecated.
   impact: Users should discontinue using plugins which extend NetworkPlugin.

--- a/docs/changelog/88924.yaml
+++ b/docs/changelog/88924.yaml
@@ -6,6 +6,5 @@ issues: []
 deprecation:
   title: Deprecate network plugins
   area: Infra/Plugins
-  details: Please describe the details of this change for the release notes. You can
-    use asciidoc.
-  impact: Please describe the impact of this change to users
+  details: Plugins extending NetworkPlugin are deprecated.
+  impact: Users should discontinue using plugins which extend NetworkPlugin.

--- a/docs/changelog/88924.yaml
+++ b/docs/changelog/88924.yaml
@@ -1,0 +1,11 @@
+pr: 88924
+summary: Deprecate network plugins
+area: Infra/Plugins
+type: deprecation
+issues: []
+deprecation:
+  title: Deprecate network plugins
+  area: Infra/Plugins
+  details: Please describe the details of this change for the release notes. You can
+    use asciidoc.
+  impact: Please describe the impact of this change to users

--- a/docs/reference/migration/migrate_8_5.asciidoc
+++ b/docs/reference/migration/migrate_8_5.asciidoc
@@ -20,3 +20,36 @@ coming::[8.5.0]
 There are no breaking changes in {es} 8.5.
 // end::notable-breaking-changes[]
 
+[discrete]
+[[deprecated-8.5]]
+=== Deprecations
+
+The following functionality has been deprecated in {es} 8.3
+and will be removed in a future version.
+While this won't have an immediate impact on your applications,
+we strongly encourage you take the described steps to update your code
+after upgrading to 8.3.
+
+To find out if you are using any deprecated functionality,
+enable <<deprecation-logging, deprecation logging>>.
+
+
+[discrete]
+[[deprecations_85_network_plugins]]
+==== Plugin deprecations
+
+[[network_plugins_deprecated]]
+Plugins that extend the NetworkPlugin interface are deprecated.
+[%collapsible]
+====
+*Details* +
+Plugins may override funcionality that controls how nodes connect
+with other nodes over TCP/IP. These plugins extend the NetworkPlugin
+interface. In the next major release, these plugins will fail
+to install.
+
+*Impact* +
+Discontinue using any plugins which extend NetworkPlugin. You can
+see if any plugins use deprecated functionality by checking
+the Elasticsearch deprecation log.
+====

--- a/docs/reference/migration/migrate_8_5.asciidoc
+++ b/docs/reference/migration/migrate_8_5.asciidoc
@@ -36,7 +36,7 @@ enable <<deprecation-logging, deprecation logging>>.
 
 [discrete]
 [[deprecations_85_network_plugins]]
-==== Java API deprecations
+==== Plugin API deprecations
 
 [[network_plugins_deprecated]]
 Plugins that extend the NetworkPlugin interface are deprecated.

--- a/docs/reference/migration/migrate_8_5.asciidoc
+++ b/docs/reference/migration/migrate_8_5.asciidoc
@@ -27,7 +27,7 @@ There are no breaking changes in {es} 8.5.
 The following functionality has been deprecated in {es} 8.5
 and will be removed in a future version.
 While this won't have an immediate impact on your applications,
-we strongly encourage you take the described steps to update your code
+we strongly encourage you to take the described steps to update your code
 after upgrading to 8.5.
 
 To find out if you are using any deprecated functionality,

--- a/docs/reference/migration/migrate_8_5.asciidoc
+++ b/docs/reference/migration/migrate_8_5.asciidoc
@@ -24,11 +24,11 @@ There are no breaking changes in {es} 8.5.
 [[deprecated-8.5]]
 === Deprecations
 
-The following functionality has been deprecated in {es} 8.3
+The following functionality has been deprecated in {es} 8.5
 and will be removed in a future version.
 While this won't have an immediate impact on your applications,
 we strongly encourage you take the described steps to update your code
-after upgrading to 8.3.
+after upgrading to 8.5.
 
 To find out if you are using any deprecated functionality,
 enable <<deprecation-logging, deprecation logging>>.
@@ -36,7 +36,7 @@ enable <<deprecation-logging, deprecation logging>>.
 
 [discrete]
 [[deprecations_85_network_plugins]]
-==== Plugin deprecations
+==== Java API deprecations
 
 [[network_plugins_deprecated]]
 Plugins that extend the NetworkPlugin interface are deprecated.

--- a/server/src/main/java/org/elasticsearch/plugins/NetworkPlugin.java
+++ b/server/src/main/java/org/elasticsearch/plugins/NetworkPlugin.java
@@ -30,6 +30,7 @@ import java.util.function.Supplier;
 /**
  * Plugin for extending network and transport related classes
  */
+@Deprecated
 public interface NetworkPlugin {
 
     /**


### PR DESCRIPTION
Network plugins provide network implementations. In the past this has
been used for alternatives to netty based networking, using the JDK's
nio. However, nio has now been removed, and it is inadvisable for a
plugin to implement this low level part of the system.
Therefore, this commit marks the NetworkPlugin interface as deprecated.