### PR TITLE
Ensure that the extended socket options TCP_KEEPXXX are available

### DIFF
--- a/distribution/tools/server-cli/src/main/java/org/elasticsearch/server/cli/ServerProcess.java
+++ b/distribution/tools/server-cli/src/main/java/org/elasticsearch/server/cli/ServerProcess.java
@@ -216,6 +216,7 @@ public class ServerProcess {
         command.addAll(jvmOptions);
         command.add("--module-path");
         command.add(esHome.resolve("lib").toString());
+        command.add("--add-modules=jdk.net");
         command.add("-m");
         command.add("org.elasticsearch.server/org.elasticsearch.bootstrap.Elasticsearch");
 

--- a/distribution/tools/server-cli/src/main/java/org/elasticsearch/server/cli/ServerProcess.java
+++ b/distribution/tools/server-cli/src/main/java/org/elasticsearch/server/cli/ServerProcess.java
@@ -216,7 +216,7 @@ public class ServerProcess {
         command.addAll(jvmOptions);
         command.add("--module-path");
         command.add(esHome.resolve("lib").toString());
-        command.add("--add-modules=jdk.net");
+        command.add("--add-modules=jdk.net"); // very special circumstance; explicit modules should typically not be added here
         command.add("-m");
         command.add("org.elasticsearch.server/org.elasticsearch.bootstrap.Elasticsearch");
 

--- a/docs/changelog/88935.yaml
+++ b/docs/changelog/88935.yaml
@@ -1,0 +1,6 @@
+pr: 88935
+summary: Ensure that the extended socket options TCP_KEEPXXX are available
+area: Network
+type: bug
+issues:
+ - 88897

--- a/modules/transport-netty4/src/main/java/module-info.java
+++ b/modules/transport-netty4/src/main/java/module-info.java
@@ -7,6 +7,7 @@
  */
 
 module org.elasticsearch.transport.netty4 {
+    requires jdk.net;
     requires org.elasticsearch.base;
     requires org.elasticsearch.server;
     requires org.elasticsearch.xcontent;

--- a/modules/transport-netty4/src/main/java/org/elasticsearch/http/netty4/Netty4HttpServerTransport.java
+++ b/modules/transport-netty4/src/main/java/org/elasticsearch/http/netty4/Netty4HttpServerTransport.java
@@ -57,7 +57,6 @@ import org.elasticsearch.transport.netty4.SharedGroupFactory;
 import org.elasticsearch.xcontent.NamedXContentRegistry;
 
 import java.net.InetSocketAddress;
-import java.net.SocketOption;
 import java.util.concurrent.TimeUnit;
 
 import static org.elasticsearch.http.HttpTransportSettings.SETTING_HTTP_MAX_CHUNK_SIZE;
@@ -215,25 +214,22 @@ public class Netty4HttpServerTransport extends AbstractHttpServerTransport {
                 // Netty logs a warning if it can't set the option, so try this only on supported platforms
                 if (IOUtils.LINUX || IOUtils.MAC_OS_X) {
                     if (SETTING_HTTP_TCP_KEEP_IDLE.get(settings) >= 0) {
-                        final SocketOption<Integer> keepIdleOption = NetUtils.getTcpKeepIdleSocketOptionOrNull();
-                        if (keepIdleOption != null) {
-                            serverBootstrap.childOption(NioChannelOption.of(keepIdleOption), SETTING_HTTP_TCP_KEEP_IDLE.get(settings));
-                        }
+                        serverBootstrap.childOption(
+                            NioChannelOption.of(NetUtils.getTcpKeepIdleSocketOption()),
+                            SETTING_HTTP_TCP_KEEP_IDLE.get(settings)
+                        );
                     }
                     if (SETTING_HTTP_TCP_KEEP_INTERVAL.get(settings) >= 0) {
-                        final SocketOption<Integer> keepIntervalOption = NetUtils.getTcpKeepIntervalSocketOptionOrNull();
-                        if (keepIntervalOption != null) {
-                            serverBootstrap.childOption(
-                                NioChannelOption.of(keepIntervalOption),
-                                SETTING_HTTP_TCP_KEEP_INTERVAL.get(settings)
-                            );
-                        }
+                        serverBootstrap.childOption(
+                            NioChannelOption.of(NetUtils.getTcpKeepIntervalSocketOption()),
+                            SETTING_HTTP_TCP_KEEP_INTERVAL.get(settings)
+                        );
                     }
                     if (SETTING_HTTP_TCP_KEEP_COUNT.get(settings) >= 0) {
-                        final SocketOption<Integer> keepCountOption = NetUtils.getTcpKeepCountSocketOptionOrNull();
-                        if (keepCountOption != null) {
-                            serverBootstrap.childOption(NioChannelOption.of(keepCountOption), SETTING_HTTP_TCP_KEEP_COUNT.get(settings));
-                        }
+                        serverBootstrap.childOption(
+                            NioChannelOption.of(NetUtils.getTcpKeepCountSocketOption()),
+                            SETTING_HTTP_TCP_KEEP_COUNT.get(settings)
+                        );
                     }
                 }
             }

--- a/modules/transport-netty4/src/main/java/org/elasticsearch/transport/netty4/NetUtils.java
+++ b/modules/transport-netty4/src/main/java/org/elasticsearch/transport/netty4/NetUtils.java
@@ -8,12 +8,15 @@
 
 package org.elasticsearch.transport.netty4;
 
+import jdk.net.ExtendedSocketOptions;
+
+import org.elasticsearch.core.SuppressForbidden;
+
 import java.io.IOException;
-import java.lang.reflect.Field;
 import java.net.SocketOption;
 import java.net.StandardSocketOptions;
 import java.nio.channels.NetworkChannel;
-import java.util.Arrays;
+import java.util.Objects;
 
 /**
  * Utilities for network-related methods.
@@ -22,37 +25,31 @@ public class NetUtils {
 
     private NetUtils() {}
 
+    // Accessors to the extended socket options reduce the proliferation of the non-portable
+    // ExtendedSocketOptions type.
+
     /**
-     * Returns the extended TCP_KEEPIDLE socket option, if available on this JDK
+     * Returns the extended TCP_KEEPIDLE socket option.
      */
-    public static SocketOption<Integer> getTcpKeepIdleSocketOptionOrNull() {
-        return getExtendedSocketOptionOrNull("TCP_KEEPIDLE");
+    @SuppressForbidden(reason = "access to non-portable socket option requied")
+    public static SocketOption<Integer> getTcpKeepIdleSocketOption() {
+        return ExtendedSocketOptions.TCP_KEEPIDLE;
     }
 
     /**
-     * Returns the extended TCP_KEEPINTERVAL socket option, if available on this JDK
+     * Returns the extended TCP_KEEPINTERVAL socket option.
      */
-    public static SocketOption<Integer> getTcpKeepIntervalSocketOptionOrNull() {
-        return getExtendedSocketOptionOrNull("TCP_KEEPINTERVAL");
+    @SuppressForbidden(reason = "access to non-portable socket option requied")
+    public static SocketOption<Integer> getTcpKeepIntervalSocketOption() {
+        return ExtendedSocketOptions.TCP_KEEPINTERVAL;
     }
 
     /**
-     * Returns the extended TCP_KEEPCOUNT socket option, if available on this JDK
+     * Returns the extended TCP_KEEPCOUNT socket option.
      */
-    public static SocketOption<Integer> getTcpKeepCountSocketOptionOrNull() {
-        return getExtendedSocketOptionOrNull("TCP_KEEPCOUNT");
-    }
-
-    @SuppressWarnings("unchecked")
-    private static <T> SocketOption<T> getExtendedSocketOptionOrNull(String fieldName) {
-        try {
-            final Class<?> extendedSocketOptionsClass = Class.forName("jdk.net.ExtendedSocketOptions");
-            final Field field = extendedSocketOptionsClass.getField(fieldName);
-            return (SocketOption<T>) field.get(null);
-        } catch (Exception t) {
-            // ignore
-            return null;
-        }
+    @SuppressForbidden(reason = "access to non-portable socket option requied")
+    public static SocketOption<Integer> getTcpKeepCountSocketOption() {
+        return ExtendedSocketOptions.TCP_KEEPCOUNT;
     }
 
     /**
@@ -67,13 +64,9 @@ public class NetUtils {
             if (socketChannel.supportedOptions().contains(StandardSocketOptions.SO_KEEPALIVE)) {
                 final Boolean keepalive = socketChannel.getOption(StandardSocketOptions.SO_KEEPALIVE);
                 assert keepalive != null;
-                if (keepalive.booleanValue()) {
-                    for (SocketOption<Integer> option : Arrays.asList(
-                        NetUtils.getTcpKeepIdleSocketOptionOrNull(),
-                        NetUtils.getTcpKeepIntervalSocketOptionOrNull()
-                    )) {
-                        setMinValueForSocketOption(socketChannel, option, 300);
-                    }
+                if (keepalive) {
+                    setMinValueForSocketOption(socketChannel, getTcpKeepIdleSocketOption(), 300);
+                    setMinValueForSocketOption(socketChannel, getTcpKeepIntervalSocketOption(), 300);
                 }
             }
         } catch (Exception e) {
@@ -84,7 +77,8 @@ public class NetUtils {
     }
 
     private static void setMinValueForSocketOption(NetworkChannel socketChannel, SocketOption<Integer> option, int minValue) {
-        if (option != null && socketChannel.supportedOptions().contains(option)) {
+        Objects.requireNonNull(option);
+        if (socketChannel.supportedOptions().contains(option)) {
             try {
                 final Integer currentIdleVal = socketChannel.getOption(option);
                 assert currentIdleVal != null;

--- a/modules/transport-netty4/src/main/java/org/elasticsearch/transport/netty4/NetUtils.java
+++ b/modules/transport-netty4/src/main/java/org/elasticsearch/transport/netty4/NetUtils.java
@@ -31,7 +31,7 @@ public class NetUtils {
     /**
      * Returns the extended TCP_KEEPIDLE socket option.
      */
-    @SuppressForbidden(reason = "access to non-portable socket option requied")
+    @SuppressForbidden(reason = "access to non-portable socket option required")
     public static SocketOption<Integer> getTcpKeepIdleSocketOption() {
         return ExtendedSocketOptions.TCP_KEEPIDLE;
     }
@@ -39,7 +39,7 @@ public class NetUtils {
     /**
      * Returns the extended TCP_KEEPINTERVAL socket option.
      */
-    @SuppressForbidden(reason = "access to non-portable socket option requied")
+    @SuppressForbidden(reason = "access to non-portable socket option required")
     public static SocketOption<Integer> getTcpKeepIntervalSocketOption() {
         return ExtendedSocketOptions.TCP_KEEPINTERVAL;
     }
@@ -47,7 +47,7 @@ public class NetUtils {
     /**
      * Returns the extended TCP_KEEPCOUNT socket option.
      */
-    @SuppressForbidden(reason = "access to non-portable socket option requied")
+    @SuppressForbidden(reason = "access to non-portable socket option required")
     public static SocketOption<Integer> getTcpKeepCountSocketOption() {
         return ExtendedSocketOptions.TCP_KEEPCOUNT;
     }

--- a/modules/transport-netty4/src/main/java/org/elasticsearch/transport/netty4/Netty4Transport.java
+++ b/modules/transport-netty4/src/main/java/org/elasticsearch/transport/netty4/Netty4Transport.java
@@ -47,7 +47,6 @@ import org.elasticsearch.transport.TransportSettings;
 
 import java.io.IOException;
 import java.net.InetSocketAddress;
-import java.net.SocketOption;
 import java.util.Map;
 
 import static org.elasticsearch.common.settings.Setting.byteSizeSetting;
@@ -165,22 +164,19 @@ public class Netty4Transport extends TcpTransport {
         if (TransportSettings.TCP_KEEP_ALIVE.get(settings)) {
             // Note that Netty logs a warning if it can't set the option
             if (TransportSettings.TCP_KEEP_IDLE.get(settings) >= 0) {
-                final SocketOption<Integer> keepIdleOption = NetUtils.getTcpKeepIdleSocketOptionOrNull();
-                if (keepIdleOption != null) {
-                    bootstrap.option(NioChannelOption.of(keepIdleOption), TransportSettings.TCP_KEEP_IDLE.get(settings));
-                }
+                bootstrap.option(NioChannelOption.of(NetUtils.getTcpKeepIdleSocketOption()), TransportSettings.TCP_KEEP_IDLE.get(settings));
             }
             if (TransportSettings.TCP_KEEP_INTERVAL.get(settings) >= 0) {
-                final SocketOption<Integer> keepIntervalOption = NetUtils.getTcpKeepIntervalSocketOptionOrNull();
-                if (keepIntervalOption != null) {
-                    bootstrap.option(NioChannelOption.of(keepIntervalOption), TransportSettings.TCP_KEEP_INTERVAL.get(settings));
-                }
+                bootstrap.option(
+                    NioChannelOption.of(NetUtils.getTcpKeepIntervalSocketOption()),
+                    TransportSettings.TCP_KEEP_INTERVAL.get(settings)
+                );
             }
             if (TransportSettings.TCP_KEEP_COUNT.get(settings) >= 0) {
-                final SocketOption<Integer> keepCountOption = NetUtils.getTcpKeepCountSocketOptionOrNull();
-                if (keepCountOption != null) {
-                    bootstrap.option(NioChannelOption.of(keepCountOption), TransportSettings.TCP_KEEP_COUNT.get(settings));
-                }
+                bootstrap.option(
+                    NioChannelOption.of(NetUtils.getTcpKeepCountSocketOption()),
+                    TransportSettings.TCP_KEEP_COUNT.get(settings)
+                );
             }
         }
 
@@ -236,23 +232,16 @@ public class Netty4Transport extends TcpTransport {
         if (profileSettings.tcpKeepAlive) {
             // Note that Netty logs a warning if it can't set the option
             if (profileSettings.tcpKeepIdle >= 0) {
-                final SocketOption<Integer> keepIdleOption = NetUtils.getTcpKeepIdleSocketOptionOrNull();
-                if (keepIdleOption != null) {
-                    serverBootstrap.childOption(NioChannelOption.of(keepIdleOption), profileSettings.tcpKeepIdle);
-                }
+                serverBootstrap.childOption(NioChannelOption.of(NetUtils.getTcpKeepIdleSocketOption()), profileSettings.tcpKeepIdle);
             }
             if (profileSettings.tcpKeepInterval >= 0) {
-                final SocketOption<Integer> keepIntervalOption = NetUtils.getTcpKeepIntervalSocketOptionOrNull();
-                if (keepIntervalOption != null) {
-                    serverBootstrap.childOption(NioChannelOption.of(keepIntervalOption), profileSettings.tcpKeepInterval);
-                }
-
+                serverBootstrap.childOption(
+                    NioChannelOption.of(NetUtils.getTcpKeepIntervalSocketOption()),
+                    profileSettings.tcpKeepInterval
+                );
             }
             if (profileSettings.tcpKeepCount >= 0) {
-                final SocketOption<Integer> keepCountOption = NetUtils.getTcpKeepCountSocketOptionOrNull();
-                if (keepCountOption != null) {
-                    serverBootstrap.childOption(NioChannelOption.of(keepCountOption), profileSettings.tcpKeepCount);
-                }
+                serverBootstrap.childOption(NioChannelOption.of(NetUtils.getTcpKeepCountSocketOption()), profileSettings.tcpKeepCount);
             }
         }
 

--- a/modules/transport-netty4/src/test/java/org/elasticsearch/transport/netty4/NetUtilsTests.java
+++ b/modules/transport-netty4/src/test/java/org/elasticsearch/transport/netty4/NetUtilsTests.java
@@ -8,7 +8,6 @@
 
 package org.elasticsearch.transport.netty4;
 
-import org.apache.lucene.util.Constants;
 import org.elasticsearch.core.IOUtils;
 import org.elasticsearch.test.ESTestCase;
 

--- a/modules/transport-netty4/src/test/java/org/elasticsearch/transport/netty4/NetUtilsTests.java
+++ b/modules/transport-netty4/src/test/java/org/elasticsearch/transport/netty4/NetUtilsTests.java
@@ -21,13 +21,10 @@ import static org.hamcrest.Matchers.hasItem;
 public class NetUtilsTests extends ESTestCase {
 
     public void testExtendedSocketOptions() throws IOException {
-        assumeTrue(
+        assertTrue(
             "jdk.net module not resolved",
             ModuleLayer.boot().modules().stream().map(Module::getName).anyMatch(nm -> nm.equals("jdk.net"))
         );
-        assertNotNull(NetUtils.getTcpKeepIdleSocketOption());
-        assertNotNull(NetUtils.getTcpKeepIntervalSocketOption());
-        assertNotNull(NetUtils.getTcpKeepCountSocketOption());
 
         assumeTrue("Platform possibly not supported", IOUtils.LINUX || IOUtils.MAC_OS_X);
         try (var channel = networkChannel()) {

--- a/modules/transport-netty4/src/test/java/org/elasticsearch/transport/netty4/NetUtilsTests.java
+++ b/modules/transport-netty4/src/test/java/org/elasticsearch/transport/netty4/NetUtilsTests.java
@@ -22,7 +22,6 @@ import static org.hamcrest.Matchers.hasItem;
 public class NetUtilsTests extends ESTestCase {
 
     public void testExtendedSocketOptions() throws IOException {
-        assumeTrue("JDK possibly not supported", Constants.JVM_NAME.contains("HotSpot") || Constants.JVM_NAME.contains("OpenJDK"));
         assumeTrue(
             "jdk.net module not resolved",
             ModuleLayer.boot().modules().stream().map(Module::getName).anyMatch(nm -> nm.equals("jdk.net"))

--- a/modules/transport-netty4/src/test/java/org/elasticsearch/transport/netty4/NetUtilsTests.java
+++ b/modules/transport-netty4/src/test/java/org/elasticsearch/transport/netty4/NetUtilsTests.java
@@ -12,13 +12,18 @@ import org.apache.lucene.util.Constants;
 import org.elasticsearch.core.IOUtils;
 import org.elasticsearch.test.ESTestCase;
 
+import java.nio.channels.SocketChannel;
+
 public class NetUtilsTests extends ESTestCase {
 
-    public void testExtendedSocketOptions() {
+    public void testExtendedSocketOptions() throws Exception {
         assumeTrue("JDK possibly not supported", Constants.JVM_NAME.contains("HotSpot") || Constants.JVM_NAME.contains("OpenJDK"));
         assumeTrue("Platform possibly not supported", IOUtils.LINUX || IOUtils.MAC_OS_X);
-        assertNotNull(NetUtils.getTcpKeepIdleSocketOptionOrNull());
-        assertNotNull(NetUtils.getTcpKeepIntervalSocketOptionOrNull());
-        assertNotNull(NetUtils.getTcpKeepCountSocketOptionOrNull());
+        assertNotNull(NetUtils.getTcpKeepIdleSocketOption());
+        assertNotNull(NetUtils.getTcpKeepIntervalSocketOption());
+        assertNotNull(NetUtils.getTcpKeepCountSocketOption());
+        SocketChannel.open().supportedOptions().contains(NetUtils.getTcpKeepIdleSocketOption());
+        SocketChannel.open().supportedOptions().contains(NetUtils.getTcpKeepIntervalSocketOption());
+        SocketChannel.open().supportedOptions().contains(NetUtils.getTcpKeepCountSocketOption());
     }
 }

--- a/modules/transport-netty4/src/test/java/org/elasticsearch/transport/netty4/SimpleNetty4TransportTests.java
+++ b/modules/transport-netty4/src/test/java/org/elasticsearch/transport/netty4/SimpleNetty4TransportTests.java
@@ -125,12 +125,12 @@ public class SimpleNetty4TransportTests extends AbstractSimpleTransportTestCase 
         assertThat(nettyChannel.getNettyChannel(), instanceOf(Netty4NioSocketChannel.class));
         Netty4NioSocketChannel netty4NioSocketChannel = (Netty4NioSocketChannel) nettyChannel.getNettyChannel();
         SocketChannel socketChannel = netty4NioSocketChannel.javaChannel();
-        assertThat(socketChannel.supportedOptions(), hasItem(NetUtils.getTcpKeepIdleSocketOptionOrNull()));
-        Integer keepIdle = socketChannel.getOption(NetUtils.getTcpKeepIdleSocketOptionOrNull());
+        assertThat(socketChannel.supportedOptions(), hasItem(NetUtils.getTcpKeepIdleSocketOption()));
+        Integer keepIdle = socketChannel.getOption(NetUtils.getTcpKeepIdleSocketOption());
         assertNotNull(keepIdle);
         assertThat(keepIdle, lessThanOrEqualTo(500));
-        assertThat(socketChannel.supportedOptions(), hasItem(NetUtils.getTcpKeepIntervalSocketOptionOrNull()));
-        Integer keepInterval = socketChannel.getOption(NetUtils.getTcpKeepIntervalSocketOptionOrNull());
+        assertThat(socketChannel.supportedOptions(), hasItem(NetUtils.getTcpKeepIntervalSocketOption()));
+        Integer keepInterval = socketChannel.getOption(NetUtils.getTcpKeepIntervalSocketOption());
         assertNotNull(keepInterval);
         assertThat(keepInterval, lessThanOrEqualTo(500));
     }


### PR DESCRIPTION
A NIO socket channel supports setting and retrieving a set of socket
options. A socket channel supports a specified set of _standard_ socket
options, e.g. `SO_RCVBUF`, as well as optional implementation specific
_extended_ options. The network socket channels in the JDK support,
among others, the `TCP_KEEPIDLE`, `TCP_KEEPINTERVAL`, and
`TCP_KEEPCOUNT` _extended_ socket options (on certain platforms). These
extended socket options are only available when their defining module,
`jdk.net`, is present, and also when defined to the bootstrap class
loader - the socket channel implementation in `java.base` uses
its class loader (the bootstrap class loader) to indirectly initialize
`jdk.net.ExtendedSocketOptions`. Therefore, the `jdk.net` module must be
in the same class loader - the bootstrap class loader - for the extended
socket options to be available/supported **.

The transport-netty4 component sets a number of extended socket options
on its network channels. Specifically, the `TCP_KEEPIDLE`,
`TCP_KEEPINTERVAL`, and `TCP_KEEPCOUNT` socket options. The code
responsible for this uses reflection with a silent fallback if the
options are not available, see `o.e.transport.netty4.NetUtils`. The use
of reflection is because of the desire to compile and run on JDK 8 when
initially added. This is no longer a requirement, since the minimal
runtime version is now JDK 17 and the extended socket options are
available since JDK 11.

With the move to Java modules, only the explicitly required modules or
modules resolved during service binding, are resolved from the JDK. The
`jdk.net` module is not currently resolved, since the extended socket
options are not directly used by any code defined by the system class
loader. Therefore the extended socket options are not available /
supported by the NIO socket channels in the runtime.

The transport-netty4 component, and its dependencies, are defined as
modules by a module layer that is a child of the boot layer. The code in
the transport-netty4 component refers to the socket options and attempts
to set them on a socket channel. While this is all fine and as it should
be, it will not succeed unless the socket channel implementation
supports the extended socket options, which requires the `jdk.net`
module to be resolved in the boot module layer (and loaded by the
bootstrap class loader).

Finally, the solution is to simply resolve the `jdk.net` module in the
boot layer. We do this by adding the `--add-modules=jdk.net` option,
rather than an explicit `requires` directive in the server module-info,
since no code in server uses the extended socket options.  Additionally,
the transport-netty4 module-info has a requires directive added to
ensure that the `jdk.net` module is present. This directive doesn't
ensure that `jdk.net` is in the right module layer, but should be
sufficient for now, and will allow future refactorings in `NetUtils` to
replace the use of reflective access to the socket options with static
access.

Note: I'm still considering if or how best a test could be added to
assert this, but really once NetUtils is refactored that should be 
sufficient.

closes #88897

**
```
$ cat SupportedOptions.java

import java.net.SocketOption;
import java.nio.channels.SocketChannel;
public class SupportedOptions {
    public static void main(String... args) throws Exception {
        System.out.println(SocketChannel.open().supportedOptions().stream().map(SocketOption::toString).sorted().toList());
    }
}
```

```
$ java SupportedOptions
[IP_TOS, SO_KEEPALIVE, SO_LINGER, SO_OOBINLINE, SO_RCVBUF, SO_REUSEADDR, SO_REUSEPORT, SO_SNDBUF, TCP_KEEPCOUNT, TCP_KEEPIDLE, TCP_KEEPINTERVAL, TCP_NODELAY]
```

```
$ java --limit-modules=java.base SupportedOptions
[IP_TOS, SO_KEEPALIVE, SO_LINGER, SO_OOBINLINE, SO_RCVBUF, SO_REUSEADDR, SO_REUSEPORT, SO_SNDBUF, TCP_NODELAY]
```
