### PR TITLE
[8.3] [ML] fix BERT and MPNet tokenization bug when handling unicode accents (#88907)

### DIFF
--- a/docs/changelog/88907.yaml
+++ b/docs/changelog/88907.yaml
@@ -1,0 +1,6 @@
+pr: 88907
+summary: Fix BERT and MPNet tokenization bug when handling unicode accents
+area: Machine Learning
+type: bug
+issues:
+ - 88900

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/deployment/DeploymentManager.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/deployment/DeploymentManager.java
@@ -202,7 +202,7 @@ public class DeploymentManager {
                     stream
                 )
         ) {
-            return Vocabulary.createParser(true).apply(parser, null);
+            return Vocabulary.PARSER.apply(parser, null);
         } catch (IOException e) {
             logger.error(() -> "failed to parse trained model vocabulary [" + hit.getId() + "]", e);
             throw e;

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/nlp/Vocabulary.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/nlp/Vocabulary.java
@@ -45,6 +45,8 @@ public class Vocabulary implements Writeable, ToXContentObject {
         return parser;
     }
 
+    public static ConstructingObjectParser<Vocabulary, Void> PARSER = createParser(true);
+
     private final List<String> vocab;
     private final List<String> merges;
     private final String modelId;

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/nlp/tokenizers/BasicTokenFilterTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/nlp/tokenizers/BasicTokenFilterTests.java
@@ -67,6 +67,7 @@ public class BasicTokenFilterTests extends BaseTokenStreamTestCase {
     public void testStripAccents() throws Exception {
         Analyzer analyzer = basicAnalyzerFromSettings(true, true, List.of("[UNK]"));
         assertAnalyzesToNoCharFilter(analyzer, "HäLLo how are you", new String[] { "HaLLo", "how", "are", "you" });
+        assertAnalyzesToNoCharFilter(analyzer, "ÎÎÎÏÎ½ÎÎÎÎ±Î¿Ï", new String[] { "IIIII½IIII±I", "¿", "I" });
     }
 
     private static void assertAnalyzesToNoCharFilter(Analyzer a, String input, String[] output) throws IOException {


### PR DESCRIPTION
Backports the following commits to 8.3:
 - [ML] fix BERT and MPNet tokenization bug when handling unicode accents (#88907)