### PR TITLE
Graph: fix race condition in timeout

### DIFF
--- a/docs/changelog/88946.yaml
+++ b/docs/changelog/88946.yaml
@@ -1,0 +1,6 @@
+pr: 88946
+summary: "Graph: fix race condition in timeout"
+area: Graph
+type: bug
+issues:
+ - 55396


### PR DESCRIPTION
Previously `graph` checked if the request timed out, then spent some
time doing work, then passed the timeout on to the next request. Over
and over again. It's quite possible that the response may not have timed
out for the first check but would have timed out for the second check.
This manifests as the timeout being sent to the next hop being a
negative number of milliseconds. We don't allow this sort of thing.

This fixes this by moving the timeout check to the same spot it is read
for setting the timeout on the next request - we just check if its `> 0`
to find the timeouts.

This does keep the request running slightly longer after it's officially
timed out - but it's just long enough to prepare the next layer of
request. Usually microseconds. Which should be fine.

Closes #55396
