### PR TITLE
Bring back lost optimization to building metadata from a diff

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/metadata/Metadata.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/Metadata.java
@@ -1258,7 +1258,7 @@ public class Metadata extends AbstractCollection<IndexMetadata> implements Diffa
             builder.templates(templates.apply(part.templates));
             builder.customs(customs.apply(part.customs));
             builder.put(reservedStateMetadata.apply(part.reservedStateMetadata));
-            return builder.build();
+            return builder.build(true);
         }
     }
 


### PR DESCRIPTION
This was lost again due to another merge conflict.

Same as https://github.com/elastic/elasticsearch/pull/88497 :)