### PR TITLE
Fix slow assertion running in production in RoutingNodes

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/routing/RoutingNodes.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/RoutingNodes.java
@@ -146,7 +146,12 @@ public class RoutingNodes extends AbstractCollection<RoutingNode> {
                 }
             }
         }
+        assert invariant();
+    }
+
+    private boolean invariant() {
         nodesToShards.values().forEach(RoutingNode::invariant);
+        return true;
     }
 
     private RoutingNodes(RoutingNodes routingNodes) {


### PR DESCRIPTION
This needs to be in a separate method, it's currently running in production
and uses significant CPU time.

Broken in #88794
