### PR TITLE
Ensure that the FileSettingService closes the config file input stream

### DIFF
--- a/docs/changelog/88953.yaml
+++ b/docs/changelog/88953.yaml
@@ -1,5 +1,0 @@
-pr: 88953
-summary: Ensure that the `FileSettingService` closes the config file input stream
-area: Infra/Core
-type: bug
-issues: []

--- a/docs/changelog/88953.yaml
+++ b/docs/changelog/88953.yaml
@@ -1,0 +1,5 @@
+pr: 88953
+summary: Ensure that the `FileSettingService` closes the config file input stream
+area: Infra/Core
+type: bug
+issues: []

--- a/server/src/main/java/org/elasticsearch/reservedstate/service/FileSettingsService.java
+++ b/server/src/main/java/org/elasticsearch/reservedstate/service/FileSettingsService.java
@@ -16,7 +16,6 @@ import org.elasticsearch.cluster.ClusterStateListener;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.component.AbstractLifecycleComponent;
 import org.elasticsearch.env.Environment;
-import org.elasticsearch.xcontent.XContentParser;
 import org.elasticsearch.xcontent.XContentParserConfiguration;
 
 import java.io.BufferedInputStream;
@@ -303,9 +302,11 @@ public class FileSettingsService extends AbstractLifecycleComponent implements C
     CountDownLatch processFileSettings(Path path, Consumer<Exception> errorHandler) throws IOException {
         CountDownLatch waitForCompletion = new CountDownLatch(1);
         logger.info("processing path [{}] for [{}]", path, NAMESPACE);
-        try (var fis = Files.newInputStream(path);
-             var bis = new BufferedInputStream(fis);
-             var parser = JSON.xContent().createParser(XContentParserConfiguration.EMPTY, bis)) {
+        try (
+            var fis = Files.newInputStream(path);
+            var bis = new BufferedInputStream(fis);
+            var parser = JSON.xContent().createParser(XContentParserConfiguration.EMPTY, bis)
+        ) {
             stateService.process(NAMESPACE, parser, (e) -> {
                 try {
                     if (e != null) {

--- a/server/src/main/java/org/elasticsearch/reservedstate/service/FileSettingsService.java
+++ b/server/src/main/java/org/elasticsearch/reservedstate/service/FileSettingsService.java
@@ -303,15 +303,18 @@ public class FileSettingsService extends AbstractLifecycleComponent implements C
     CountDownLatch processFileSettings(Path path, Consumer<Exception> errorHandler) throws IOException {
         CountDownLatch waitForCompletion = new CountDownLatch(1);
         logger.info("processing path [{}] for [{}]", path, NAMESPACE);
-        try (var json = new BufferedInputStream(Files.newInputStream(path))) {
-            try (XContentParser parser = JSON.xContent().createParser(XContentParserConfiguration.EMPTY, json)) {
-                stateService.process(NAMESPACE, parser, (e) -> {
+        try (var fis = Files.newInputStream(path);
+             var bis = new BufferedInputStream(fis);
+             var parser = JSON.xContent().createParser(XContentParserConfiguration.EMPTY, bis)) {
+            stateService.process(NAMESPACE, parser, (e) -> {
+                try {
                     if (e != null) {
                         errorHandler.accept(e);
                     }
+                } finally {
                     waitForCompletion.countDown();
-                });
-            }
+                }
+            });
         }
 
         return waitForCompletion;


### PR DESCRIPTION
Minor change to restructure the try-with-resources so that the underlying file input stream is guaranteed to have its close method called.

I've not diagnosed this as the root cause of intermittent failures we're seeing on Windows, but rather eliminating it as a potential suspect. Additionally, the countdown latch should always be decremented, even if the error handler throws, as this has been noticed on a few stack traces from blocked processes, e.g.

```
16:50:19   2> "TEST-FileSettingsServiceIT.testSettingsApplied-seed#[4A2D28AE60BF1D89]" ID=12791 WAITING on java.util.concurrent.CountDownLatch$Sync@31b54ba6
16:50:19   2> 	at java.base@18.0.2/jdk.internal.misc.Unsafe.park(Native Method)
16:50:19   2> 	- waiting on java.util.concurrent.CountDownLatch$Sync@31b54ba6
16:50:19   2> 	at java.base@18.0.2/java.util.concurrent.locks.LockSupport.park(LockSupport.java:211)
16:50:19   2> 	at java.base@18.0.2/java.util.concurrent.locks.AbstractQueuedSynchronizer.acquire(AbstractQueuedSynchronizer.java:715)
16:50:19   2> 	at java.base@18.0.2/java.util.concurrent.locks.AbstractQueuedSynchronizer.acquireSharedInterruptibly(AbstractQueuedSynchronizer.java:1047)
16:50:19   2> 	at java.base@18.0.2/java.util.concurrent.CountDownLatch.await(CountDownLatch.java:230)
16:50:19   2> 	at app//org.elasticsearch.reservedstate.service.FileSettingsService.stopWatcher(FileSettingsService.java:276)
16:50:19   2> 	- locked org.elasticsearch.reservedstate.service.FileSettingsService@7ff93397
16:50:19   2> 	at app//org.elasticsearch.reservedstate.service.FileSettingsService.doStop(FileSettingsService.java:120)
16:50:19   2> 	at app//org.elasticsearch.common.component.AbstractLifecycleComponent.stop(AbstractLifecycleComponent.java:63)
16:50:19   2> 	- locked org.elasticsearch.common.component.Lifecycle@24d0ddfb
```

relates #88806