### PR TITLE
[8.4] Ensure that the extended socket options TCP_KEEPXXX are available (#88935)

### DIFF
--- a/distribution/tools/server-cli/src/main/java/org/elasticsearch/server/cli/ServerProcess.java
+++ b/distribution/tools/server-cli/src/main/java/org/elasticsearch/server/cli/ServerProcess.java
@@ -220,6 +220,7 @@ public class ServerProcess {
         command.addAll(jvmOptions);
         command.add("--module-path");
         command.add(esHome.resolve("lib").toString());
+        command.add("--add-modules=jdk.net"); // very special circumstance; explicit modules should typically not be added here
         command.add("-m");
         command.add("org.elasticsearch.server/org.elasticsearch.bootstrap.Elasticsearch");
 

--- a/docs/changelog/88935.yaml
+++ b/docs/changelog/88935.yaml
@@ -1,0 +1,6 @@
+pr: 88935
+summary: Ensure that the extended socket options TCP_KEEPXXX are available
+area: Network
+type: bug
+issues:
+ - 88897

--- a/modules/transport-netty4/src/main/java/module-info.java
+++ b/modules/transport-netty4/src/main/java/module-info.java
@@ -7,6 +7,7 @@
  */
 
 module org.elasticsearch.transport.netty4 {
+    requires jdk.net;
     requires org.elasticsearch.base;
     requires org.elasticsearch.server;
     requires org.elasticsearch.xcontent;

--- a/modules/transport-netty4/src/main/java/org/elasticsearch/http/netty4/Netty4HttpServerTransport.java
+++ b/modules/transport-netty4/src/main/java/org/elasticsearch/http/netty4/Netty4HttpServerTransport.java
@@ -57,7 +57,6 @@ import org.elasticsearch.transport.netty4.SharedGroupFactory;
 import org.elasticsearch.xcontent.NamedXContentRegistry;
 
 import java.net.InetSocketAddress;
-import java.net.SocketOption;
 import java.util.concurrent.TimeUnit;
 
 import static org.elasticsearch.http.HttpTransportSettings.SETTING_HTTP_MAX_CHUNK_SIZE;
@@ -215,25 +214,22 @@ public class Netty4HttpServerTransport extends AbstractHttpServerTransport {
                 // Netty logs a warning if it can't set the option, so try this only on supported platforms
                 if (IOUtils.LINUX || IOUtils.MAC_OS_X) {
                     if (SETTING_HTTP_TCP_KEEP_IDLE.get(settings) >= 0) {
-                        final SocketOption<Integer> keepIdleOption = NetUtils.getTcpKeepIdleSocketOptionOrNull();
-                        if (keepIdleOption != null) {
-                            serverBootstrap.childOption(NioChannelOption.of(keepIdleOption), SETTING_HTTP_TCP_KEEP_IDLE.get(settings));
-                        }
+                        serverBootstrap.childOption(
+                            NioChannelOption.of(NetUtils.getTcpKeepIdleSocketOption()),
+                            SETTING_HTTP_TCP_KEEP_IDLE.get(settings)
+                        );
                     }
                     if (SETTING_HTTP_TCP_KEEP_INTERVAL.get(settings) >= 0) {
-                        final SocketOption<Integer> keepIntervalOption = NetUtils.getTcpKeepIntervalSocketOptionOrNull();
-                        if (keepIntervalOption != null) {
-                            serverBootstrap.childOption(
-                                NioChannelOption.of(keepIntervalOption),
-                                SETTING_HTTP_TCP_KEEP_INTERVAL.get(settings)
-                            );
-                        }
+                        serverBootstrap.childOption(
+                            NioChannelOption.of(NetUtils.getTcpKeepIntervalSocketOption()),
+                            SETTING_HTTP_TCP_KEEP_INTERVAL.get(settings)
+                        );
                     }
                     if (SETTING_HTTP_TCP_KEEP_COUNT.get(settings) >= 0) {
-                        final SocketOption<Integer> keepCountOption = NetUtils.getTcpKeepCountSocketOptionOrNull();
-                        if (keepCountOption != null) {
-                            serverBootstrap.childOption(NioChannelOption.of(keepCountOption), SETTING_HTTP_TCP_KEEP_COUNT.get(settings));
-                        }
+                        serverBootstrap.childOption(
+                            NioChannelOption.of(NetUtils.getTcpKeepCountSocketOption()),
+                            SETTING_HTTP_TCP_KEEP_COUNT.get(settings)
+                        );
                     }
                 }
             }

--- a/modules/transport-netty4/src/main/java/org/elasticsearch/transport/netty4/Netty4Transport.java
+++ b/modules/transport-netty4/src/main/java/org/elasticsearch/transport/netty4/Netty4Transport.java
@@ -47,7 +47,6 @@ import org.elasticsearch.transport.TransportSettings;
 
 import java.io.IOException;
 import java.net.InetSocketAddress;
-import java.net.SocketOption;
 import java.util.Map;
 
 import static org.elasticsearch.common.settings.Setting.byteSizeSetting;
@@ -165,22 +164,19 @@ public class Netty4Transport extends TcpTransport {
         if (TransportSettings.TCP_KEEP_ALIVE.get(settings)) {
             // Note that Netty logs a warning if it can't set the option
             if (TransportSettings.TCP_KEEP_IDLE.get(settings) >= 0) {
-                final SocketOption<Integer> keepIdleOption = NetUtils.getTcpKeepIdleSocketOptionOrNull();
-                if (keepIdleOption != null) {
-                    bootstrap.option(NioChannelOption.of(keepIdleOption), TransportSettings.TCP_KEEP_IDLE.get(settings));
-                }
+                bootstrap.option(NioChannelOption.of(NetUtils.getTcpKeepIdleSocketOption()), TransportSettings.TCP_KEEP_IDLE.get(settings));
             }
             if (TransportSettings.TCP_KEEP_INTERVAL.get(settings) >= 0) {
-                final SocketOption<Integer> keepIntervalOption = NetUtils.getTcpKeepIntervalSocketOptionOrNull();
-                if (keepIntervalOption != null) {
-                    bootstrap.option(NioChannelOption.of(keepIntervalOption), TransportSettings.TCP_KEEP_INTERVAL.get(settings));
-                }
+                bootstrap.option(
+                    NioChannelOption.of(NetUtils.getTcpKeepIntervalSocketOption()),
+                    TransportSettings.TCP_KEEP_INTERVAL.get(settings)
+                );
             }
             if (TransportSettings.TCP_KEEP_COUNT.get(settings) >= 0) {
-                final SocketOption<Integer> keepCountOption = NetUtils.getTcpKeepCountSocketOptionOrNull();
-                if (keepCountOption != null) {
-                    bootstrap.option(NioChannelOption.of(keepCountOption), TransportSettings.TCP_KEEP_COUNT.get(settings));
-                }
+                bootstrap.option(
+                    NioChannelOption.of(NetUtils.getTcpKeepCountSocketOption()),
+                    TransportSettings.TCP_KEEP_COUNT.get(settings)
+                );
             }
         }
 
@@ -236,23 +232,16 @@ public class Netty4Transport extends TcpTransport {
         if (profileSettings.tcpKeepAlive) {
             // Note that Netty logs a warning if it can't set the option
             if (profileSettings.tcpKeepIdle >= 0) {
-                final SocketOption<Integer> keepIdleOption = NetUtils.getTcpKeepIdleSocketOptionOrNull();
-                if (keepIdleOption != null) {
-                    serverBootstrap.childOption(NioChannelOption.of(keepIdleOption), profileSettings.tcpKeepIdle);
-                }
+                serverBootstrap.childOption(NioChannelOption.of(NetUtils.getTcpKeepIdleSocketOption()), profileSettings.tcpKeepIdle);
             }
             if (profileSettings.tcpKeepInterval >= 0) {
-                final SocketOption<Integer> keepIntervalOption = NetUtils.getTcpKeepIntervalSocketOptionOrNull();
-                if (keepIntervalOption != null) {
-                    serverBootstrap.childOption(NioChannelOption.of(keepIntervalOption), profileSettings.tcpKeepInterval);
-                }
-
+                serverBootstrap.childOption(
+                    NioChannelOption.of(NetUtils.getTcpKeepIntervalSocketOption()),
+                    profileSettings.tcpKeepInterval
+                );
             }
             if (profileSettings.tcpKeepCount >= 0) {
-                final SocketOption<Integer> keepCountOption = NetUtils.getTcpKeepCountSocketOptionOrNull();
-                if (keepCountOption != null) {
-                    serverBootstrap.childOption(NioChannelOption.of(keepCountOption), profileSettings.tcpKeepCount);
-                }
+                serverBootstrap.childOption(NioChannelOption.of(NetUtils.getTcpKeepCountSocketOption()), profileSettings.tcpKeepCount);
             }
         }
 

--- a/modules/transport-netty4/src/test/java/org/elasticsearch/transport/netty4/SimpleNetty4TransportTests.java
+++ b/modules/transport-netty4/src/test/java/org/elasticsearch/transport/netty4/SimpleNetty4TransportTests.java
@@ -125,12 +125,12 @@ public class SimpleNetty4TransportTests extends AbstractSimpleTransportTestCase 
         assertThat(nettyChannel.getNettyChannel(), instanceOf(Netty4NioSocketChannel.class));
         Netty4NioSocketChannel netty4NioSocketChannel = (Netty4NioSocketChannel) nettyChannel.getNettyChannel();
         SocketChannel socketChannel = netty4NioSocketChannel.javaChannel();
-        assertThat(socketChannel.supportedOptions(), hasItem(NetUtils.getTcpKeepIdleSocketOptionOrNull()));
-        Integer keepIdle = socketChannel.getOption(NetUtils.getTcpKeepIdleSocketOptionOrNull());
+        assertThat(socketChannel.supportedOptions(), hasItem(NetUtils.getTcpKeepIdleSocketOption()));
+        Integer keepIdle = socketChannel.getOption(NetUtils.getTcpKeepIdleSocketOption());
         assertNotNull(keepIdle);
         assertThat(keepIdle, lessThanOrEqualTo(500));
-        assertThat(socketChannel.supportedOptions(), hasItem(NetUtils.getTcpKeepIntervalSocketOptionOrNull()));
-        Integer keepInterval = socketChannel.getOption(NetUtils.getTcpKeepIntervalSocketOptionOrNull());
+        assertThat(socketChannel.supportedOptions(), hasItem(NetUtils.getTcpKeepIntervalSocketOption()));
+        Integer keepInterval = socketChannel.getOption(NetUtils.getTcpKeepIntervalSocketOption());
         assertNotNull(keepInterval);
         assertThat(keepInterval, lessThanOrEqualTo(500));
     }


### PR DESCRIPTION
Backports the following commits to 8.4:
 - Ensure that the extended socket options TCP_KEEPXXX are available (#88935)