### PR TITLE
[TEST] Reliable settings.json update in FileSettingsIT

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/reservedstate/service/FileSettingsServiceIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/reservedstate/service/FileSettingsServiceIT.java
@@ -86,7 +86,7 @@ public class FileSettingsServiceIT extends ESIntegTestCase {
         FileSettingsService fileSettingsService = internalCluster().getInstance(FileSettingsService.class, node);
 
         Files.createDirectories(fileSettingsService.operatorSettingsDir());
-        Path tempFilePath = fileSettingsService.operatorSettingsFile().resolveSibling("settings.tmp");
+        Path tempFilePath = createTempFile();
 
         Files.write(tempFilePath, Strings.format(json, version).getBytes(StandardCharsets.UTF_8));
         Files.move(tempFilePath, fileSettingsService.operatorSettingsFile(), StandardCopyOption.ATOMIC_MOVE);

--- a/server/src/internalClusterTest/java/org/elasticsearch/reservedstate/service/FileSettingsServiceIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/reservedstate/service/FileSettingsServiceIT.java
@@ -25,6 +25,8 @@ import org.elasticsearch.test.ESIntegTestCase;
 
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
@@ -84,7 +86,10 @@ public class FileSettingsServiceIT extends ESIntegTestCase {
         FileSettingsService fileSettingsService = internalCluster().getInstance(FileSettingsService.class, node);
 
         Files.createDirectories(fileSettingsService.operatorSettingsDir());
-        Files.write(fileSettingsService.operatorSettingsFile(), Strings.format(json, version).getBytes(StandardCharsets.UTF_8));
+        Path tempFilePath = fileSettingsService.operatorSettingsFile().resolveSibling("settings.tmp");
+
+        Files.write(tempFilePath, Strings.format(json, version).getBytes(StandardCharsets.UTF_8));
+        Files.move(tempFilePath, fileSettingsService.operatorSettingsFile(), StandardCopyOption.ATOMIC_MOVE);
     }
 
     private CountDownLatch setupClusterStateListener(String node) {


### PR DESCRIPTION
The automatic nature of reading settings.json in file settings can potentially read an incomplete or empty file if the file update isn't performed atomically. 

This PR changes the way we write the settings.json file to use a temporary file and atomic file system move.

Closes #88948