### PR TITLE
Ignore beats artifacts when resolving all artifact dependencies

### DIFF
--- a/distribution/docker/build.gradle
+++ b/distribution/docker/build.gradle
@@ -487,3 +487,8 @@ subprojects { Project subProject ->
     }
   }
 }
+
+tasks.named('resolveAllDependencies') {
+  // Don't try and resolve filebeat or metricbeat snapshots as they may not always be available
+  configs = configurations.matching { it.name.endsWith('beat') == false }
+}


### PR DESCRIPTION
After version bumps due to releases or feature freeze, snapshot versions of beats artifacts may not be published for some time. During that time attempts to run `resolveAllDependencies` to seed our CI worker images will fail, meaning they'll be out of date. We don't really need to seed these images with snapshot dependencies that are likely to change anyhow so let's just ignore them.