### PR TITLE
Add deprecation message for deprecated plugin APIs

### DIFF
--- a/docs/changelog/88961.yaml
+++ b/docs/changelog/88961.yaml
@@ -1,0 +1,5 @@
+pr: 88961
+summary: Add deprecation message for deprecated plugin APIs
+area: Infra/Plugins
+type: enhancement
+issues: []

--- a/server/src/main/java/org/elasticsearch/plugins/DiscoveryPlugin.java
+++ b/server/src/main/java/org/elasticsearch/plugins/DiscoveryPlugin.java
@@ -76,6 +76,7 @@ public interface DiscoveryPlugin {
      * join attempt but might be called multiple times during the lifetime of a node. Validators are expected to throw a
      * {@link IllegalStateException} if the node and the cluster-state are incompatible.
      */
+    @Deprecated
     default BiConsumer<DiscoveryNode, ClusterState> getJoinValidator() {
         return null;
     }
@@ -83,6 +84,7 @@ public interface DiscoveryPlugin {
     /**
      * Allows plugging in election strategies (see {@link ElectionStrategy}) that define a customized notion of an election quorum.
      */
+    @Deprecated
     default Map<String, ElectionStrategy> getElectionStrategies() {
         return Collections.emptyMap();
     }

--- a/server/src/main/java/org/elasticsearch/plugins/PluginIntrospector.java
+++ b/server/src/main/java/org/elasticsearch/plugins/PluginIntrospector.java
@@ -12,13 +12,15 @@ import org.elasticsearch.core.SuppressForbidden;
 
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
-import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Function;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static java.util.stream.Collectors.toMap;
@@ -49,12 +51,22 @@ final class PluginIntrospector {
         SystemIndexPlugin.class
     );
 
-    private record MethodType(String name, Class<?>[] parameterTypes) {}
+    private final Set<Class<?>> deprecatedPluginClasses = pluginClasses.stream()
+        .filter(c -> c.isAnnotationPresent(Deprecated.class))
+        .collect(Collectors.toUnmodifiableSet());
+
+    private record MethodType(String name, Class<?>[] parameterTypes, boolean isDeprecated) {}
 
     private final Map<Class<?>, List<MethodType>> pluginMethodsMap;
+    private final Map<Class<?>, List<MethodType>> pluginDeprecatedMethodsMap;
 
     private PluginIntrospector() {
         pluginMethodsMap = pluginClasses.stream().collect(toMap(Function.identity(), PluginIntrospector::findMethods));
+        pluginDeprecatedMethodsMap = pluginMethodsMap.entrySet()
+            .stream()
+            .map(e -> Map.entry(e.getKey(), e.getValue().stream().filter(MethodType::isDeprecated).toList()))
+            .filter(e -> e.getValue().isEmpty() == false)
+            .collect(toMap(Map.Entry::getKey, Map.Entry::getValue));
     }
 
     static PluginIntrospector getInstance() {
@@ -67,7 +79,7 @@ final class PluginIntrospector {
      */
     List<String> interfaces(final Class<?> pluginClass) {
         assert Plugin.class.isAssignableFrom(pluginClass);
-        return interfaceClasses(pluginClass).map(Class::getSimpleName).sorted().toList();
+        return interfaceClasses(pluginClass, pluginClasses::contains).map(Class::getSimpleName).sorted().toList();
     }
 
     /**
@@ -75,28 +87,58 @@ final class PluginIntrospector {
      * contains the simple names of the methods.
      */
     List<String> overriddenMethods(final Class<?> pluginClass) {
-        assert Plugin.class.isAssignableFrom(pluginClass);
-        List<Class<?>> esPluginClasses = Stream.concat(Stream.of(Plugin.class), interfaceClasses(pluginClass)).toList();
+        return List.copyOf(findOverriddenMethods(pluginClass, pluginMethodsMap).keySet());
+    }
 
-        List<String> overriddenMethods = new ArrayList<>();
-        for (var esPluginClass : esPluginClasses) {
-            List<MethodType> esPluginMethods = pluginMethodsMap.get(esPluginClass);
-            assert esPluginMethods != null : "no plugin methods for " + esPluginClass;
-            for (var mt : esPluginMethods) {
+    /**
+     * Returns the list of deprecated Elasticsearch plugin interfaces which are implemented by the
+     * given plugin implementation class. The list contains the simple names of the interfaces.
+     */
+    List<String> deprecatedInterfaces(final Class<?> pluginClass) {
+        assert Plugin.class.isAssignableFrom(pluginClass);
+        return interfaceClasses(pluginClass, deprecatedPluginClasses::contains).map(Class::getSimpleName).sorted().toList();
+    }
+
+    /**
+     * Returns the deprecated methods from Elasticsearch plugin interfaces which are implemented by
+     * the given plugin implementation class. The map is from the simple method name to the simple interface class name.
+     *
+     * @apiNote The simple names work as a key because they are unique across all plugin interfaces.
+     */
+    Map<String, String> deprecatedMethods(final Class<?> pluginClass) {
+        return findOverriddenMethods(pluginClass, pluginDeprecatedMethodsMap);
+    }
+
+    // finds the subset of given methods that are overridden by the given class
+    // returns a map of method name to interface name the method was declared in
+    private Map<String, String> findOverriddenMethods(final Class<?> pluginClass, Map<Class<?>, List<MethodType>> methodsMap) {
+        assert Plugin.class.isAssignableFrom(pluginClass);
+        List<Class<?>> clazzes = Stream.concat(Stream.of(Plugin.class), interfaceClasses(pluginClass, methodsMap::containsKey)).toList();
+        if (clazzes.isEmpty()) {
+            return Map.of();
+        }
+
+        Map<String, String> overriddenMethods = new HashMap<>();
+        for (var clazz : clazzes) {
+            List<MethodType> methods = methodsMap.get(clazz);
+            if (methods == null) {
+                continue;
+            }
+            for (var mt : methods) {
                 try {
                     Method m = pluginClass.getMethod(mt.name(), mt.parameterTypes());
-                    if (m.getDeclaringClass() == esPluginClass) {
+                    if (m.getDeclaringClass() == clazz) {
                         // it's not overridden
                     } else {
-                        assert esPluginClass.isAssignableFrom(m.getDeclaringClass());
-                        overriddenMethods.add(mt.name());
+                        assert clazz.isAssignableFrom(m.getDeclaringClass());
+                        overriddenMethods.put(mt.name(), clazz.getSimpleName());
                     }
                 } catch (NoSuchMethodException unexpected) {
                     throw new AssertionError(unexpected);
                 }
             }
         }
-        return overriddenMethods.stream().sorted().toList();
+        return Map.copyOf(overriddenMethods);
     }
 
     // Returns the non-static methods declared in the given class.
@@ -106,28 +148,24 @@ final class PluginIntrospector {
         assert cls.isInterface() || cls == Plugin.class : cls;
         return Arrays.stream(cls.getDeclaredMethods())
             .filter(m -> Modifier.isStatic(m.getModifiers()) == false)
-            .map(m -> new MethodType(m.getName(), m.getParameterTypes()))
+            .map(m -> new MethodType(m.getName(), m.getParameterTypes(), m.isAnnotationPresent(Deprecated.class)))
             .toList();
     }
 
     // Returns a stream of o.e.XXXPlugin interfaces, that the given plugin class implements.
-    private Stream<Class<?>> interfaceClasses(Class<?> pluginClass) {
+    private static Stream<Class<?>> interfaceClasses(Class<?> pluginClass, Predicate<Class<?>> classPredicate) {
         assert Plugin.class.isAssignableFrom(pluginClass);
         Set<Class<?>> pluginInterfaces = new HashSet<>();
         do {
-            Arrays.stream(pluginClass.getInterfaces()).forEach(inf -> superInterfaces(inf, pluginInterfaces));
+            Arrays.stream(pluginClass.getInterfaces()).forEach(inf -> superInterfaces(inf, pluginInterfaces, classPredicate));
         } while ((pluginClass = pluginClass.getSuperclass()) != java.lang.Object.class);
         return pluginInterfaces.stream();
     }
 
-    private void superInterfaces(Class<?> c, Set<Class<?>> interfaces) {
-        if (isESPlugin(c)) {
+    private static void superInterfaces(Class<?> c, Set<Class<?>> interfaces, Predicate<Class<?>> classPredicate) {
+        if (classPredicate.test(c)) {
             interfaces.add(c);
         }
-        Arrays.stream(c.getInterfaces()).forEach(inf -> superInterfaces(inf, interfaces));
-    }
-
-    private boolean isESPlugin(Class<?> c) {
-        return pluginClasses.contains(c);
+        Arrays.stream(c.getInterfaces()).forEach(inf -> superInterfaces(inf, interfaces, classPredicate));
     }
 }

--- a/server/src/main/java/org/elasticsearch/plugins/PluginIntrospector.java
+++ b/server/src/main/java/org/elasticsearch/plugins/PluginIntrospector.java
@@ -131,7 +131,8 @@ final class PluginIntrospector {
                         // it's not overridden
                     } else {
                         assert clazz.isAssignableFrom(m.getDeclaringClass());
-                        overriddenMethods.put(mt.name(), clazz.getSimpleName());
+                        var existing = overriddenMethods.put(mt.name(), clazz.getSimpleName());
+                        assert existing == null;
                     }
                 } catch (NoSuchMethodException unexpected) {
                     throw new AssertionError(unexpected);

--- a/server/src/main/java/org/elasticsearch/plugins/PluginIntrospector.java
+++ b/server/src/main/java/org/elasticsearch/plugins/PluginIntrospector.java
@@ -87,7 +87,7 @@ final class PluginIntrospector {
      * contains the simple names of the methods.
      */
     List<String> overriddenMethods(final Class<?> pluginClass) {
-        return List.copyOf(findOverriddenMethods(pluginClass, pluginMethodsMap).keySet());
+        return findOverriddenMethods(pluginClass, pluginMethodsMap).keySet().stream().sorted().toList();
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/plugins/PluginsService.java
+++ b/server/src/main/java/org/elasticsearch/plugins/PluginsService.java
@@ -16,6 +16,8 @@ import org.apache.lucene.codecs.PostingsFormat;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.action.admin.cluster.node.info.PluginsAndModules;
 import org.elasticsearch.common.io.Streams;
+import org.elasticsearch.common.logging.DeprecationCategory;
+import org.elasticsearch.common.logging.DeprecationLogger;
 import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Setting.Property;
 import org.elasticsearch.common.settings.Settings;
@@ -89,6 +91,7 @@ public class PluginsService implements ReportingService<PluginsAndModules> {
     }
 
     private static final Logger logger = LogManager.getLogger(PluginsService.class);
+    private static final DeprecationLogger deprecationLogger = DeprecationLogger.getLogger(PluginsService.class);
 
     private final Settings settings;
     private final Path configPath;
@@ -148,8 +151,12 @@ public class PluginsService implements ReportingService<PluginsAndModules> {
         }
 
         Map<String, LoadedPlugin> loadedPlugins = loadBundles(seenBundles);
-        this.info = new PluginsAndModules(getRuntimeInfos(pluginsList, loadedPlugins), modulesList);
+
+        var inspector = PluginIntrospector.getInstance();
+        this.info = new PluginsAndModules(getRuntimeInfos(inspector, pluginsList, loadedPlugins), modulesList);
         this.plugins = List.copyOf(loadedPlugins.values());
+
+        checkDeprecations(inspector, pluginsList, loadedPlugins);
 
         checkMandatoryPlugins(
             pluginsList.stream().map(PluginDescriptor::getName).collect(Collectors.toSet()),
@@ -190,8 +197,11 @@ public class PluginsService implements ReportingService<PluginsAndModules> {
         }
     }
 
-    private static List<PluginRuntimeInfo> getRuntimeInfos(List<PluginDescriptor> pluginDescriptors, Map<String, LoadedPlugin> plugins) {
-        var plugInspector = PluginIntrospector.getInstance();
+    private static List<PluginRuntimeInfo> getRuntimeInfos(
+        PluginIntrospector inspector,
+        List<PluginDescriptor> pluginDescriptors,
+        Map<String, LoadedPlugin> plugins
+    ) {
         var officialPlugins = getOfficialPlugins();
         List<PluginRuntimeInfo> runtimeInfos = new ArrayList<>();
         for (PluginDescriptor descriptor : pluginDescriptors) {
@@ -201,7 +211,7 @@ public class PluginsService implements ReportingService<PluginsAndModules> {
             boolean isOfficial = officialPlugins.contains(descriptor.getName());
             PluginApiInfo apiInfo = null;
             if (isOfficial == false) {
-                apiInfo = new PluginApiInfo(plugInspector.interfaces(pluginClazz), plugInspector.overriddenMethods(pluginClazz));
+                apiInfo = new PluginApiInfo(inspector.interfaces(pluginClazz), inspector.overriddenMethods(pluginClazz));
             }
             runtimeInfos.add(new PluginRuntimeInfo(descriptor, isOfficial, apiInfo));
         }
@@ -496,6 +506,42 @@ public class PluginsService implements ReportingService<PluginsAndModules> {
         } else {
             logger.debug(() -> "Loading bundle: " + plugin.getName() + ", non-modular");
             return LayerAndLoader.ofLoader(URLClassLoader.newInstance(bundle.urls.toArray(URL[]::new), pluginParentLoader));
+        }
+    }
+
+    private static void checkDeprecations(
+        PluginIntrospector inspector,
+        List<PluginDescriptor> pluginDescriptors,
+        Map<String, LoadedPlugin> plugins
+    ) {
+        for (PluginDescriptor descriptor : pluginDescriptors) {
+            LoadedPlugin plugin = plugins.get(descriptor.getName());
+            Class<?> pluginClazz = plugin.instance.getClass();
+            for (String deprecatedInterface : inspector.deprecatedInterfaces(pluginClazz)) {
+                deprecationLogger.warn(
+                    DeprecationCategory.PLUGINS,
+                    pluginClazz.getName() + deprecatedInterface,
+                    "Plugin class {} from plugin {} implements deprecated plugin interface {}. "
+                        + "This plugin interface will be removed in a future release.",
+                    pluginClazz.getName(),
+                    descriptor.getName(),
+                    deprecatedInterface
+                );
+            }
+            for (var deprecatedMethodInInterface : inspector.deprecatedMethods(pluginClazz).entrySet()) {
+                String methodName = deprecatedMethodInInterface.getKey();
+                String interfaceName = deprecatedMethodInInterface.getValue();
+                deprecationLogger.warn(
+                    DeprecationCategory.PLUGINS,
+                    pluginClazz.getName() + methodName + interfaceName,
+                    "Plugin class {} from plugin {} implements deprecated method {} from plugin interface {}. "
+                        + "This method will be removed in a future release.",
+                    pluginClazz.getName(),
+                    descriptor.getName(),
+                    methodName,
+                    interfaceName
+                );
+            }
         }
     }
 

--- a/server/src/test/java/org/elasticsearch/plugins/PluginsServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/plugins/PluginsServiceTests.java
@@ -804,8 +804,4 @@ public class PluginsServiceTests extends ESTestCase {
     public static class PluginOther extends Plugin {
         public PluginOther() {}
     }
-
-    public static class DeprecatedPlugin extends Plugin implements NetworkPlugin {
-        public DeprecatedPlugin() {}
-    }
 }

--- a/server/src/test/java/org/elasticsearch/plugins/PluginsServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/plugins/PluginsServiceTests.java
@@ -711,6 +711,56 @@ public class PluginsServiceTests extends ESTestCase {
         assertThat(providers, allOf(hasSize(1), everyItem(instanceOf(BarTestService.class))));
     }
 
+    public void testDeprecatedPluginInterface() throws Exception {
+        final Path home = createTempDir();
+        final Settings settings = Settings.builder().put(Environment.PATH_HOME_SETTING.getKey(), home).build();
+        final Path plugins = home.resolve("plugins");
+        final Path plugin = plugins.resolve("deprecated-plugin");
+        Files.createDirectories(plugin);
+        PluginTestUtil.writeSimplePluginDescriptor(plugin, "deprecated-plugin", "p.DeprecatedPlugin");
+        Path jar = plugin.resolve("impl.jar");
+        JarUtils.createJarWithEntries(jar, Map.of("p/DeprecatedPlugin.class", InMemoryJavaCompiler.compile("p.DeprecatedPlugin", """
+            package p;
+            import org.elasticsearch.plugins.*;
+            public class DeprecatedPlugin extends Plugin implements NetworkPlugin {}
+            """)));
+
+        newPluginsService(settings);
+        assertWarnings(
+            "Plugin class p.DeprecatedPlugin from plugin deprecated-plugin implements "
+                + "deprecated plugin interface NetworkPlugin. "
+                + "This plugin interface will be removed in a future release."
+        );
+    }
+
+    public void testDeprecatedPluginMethod() throws Exception {
+        final Path home = createTempDir();
+        final Settings settings = Settings.builder().put(Environment.PATH_HOME_SETTING.getKey(), home).build();
+        final Path plugins = home.resolve("plugins");
+        final Path plugin = plugins.resolve("deprecated-plugin");
+        Files.createDirectories(plugin);
+        PluginTestUtil.writeSimplePluginDescriptor(plugin, "deprecated-plugin", "p.DeprecatedPlugin");
+        Path jar = plugin.resolve("impl.jar");
+        JarUtils.createJarWithEntries(jar, Map.of("p/DeprecatedPlugin.class", InMemoryJavaCompiler.compile("p.DeprecatedPlugin", """
+            package p;
+            import java.util.Map;
+            import org.elasticsearch.plugins.*;
+            import org.elasticsearch.cluster.coordination.ElectionStrategy;
+            public class DeprecatedPlugin extends Plugin implements DiscoveryPlugin {
+                @Override
+                public Map<String, ElectionStrategy> getElectionStrategies() {
+                    return Map.of();
+                }
+            }
+            """)));
+
+        newPluginsService(settings);
+        assertWarnings(
+            "Plugin class p.DeprecatedPlugin from plugin deprecated-plugin implements deprecated method "
+                + "getElectionStrategies from plugin interface DiscoveryPlugin. This method will be removed in a future release."
+        );
+    }
+
     private static class TestExtensiblePlugin extends Plugin implements ExtensiblePlugin {
         private List<TestExtensionPoint> extensions;
 
@@ -753,5 +803,9 @@ public class PluginsServiceTests extends ESTestCase {
 
     public static class PluginOther extends Plugin {
         public PluginOther() {}
+    }
+
+    public static class DeprecatedPlugin extends Plugin implements NetworkPlugin {
+        public DeprecatedPlugin() {}
     }
 }

--- a/test/framework/src/main/java/org/elasticsearch/plugins/PluginTestUtil.java
+++ b/test/framework/src/main/java/org/elasticsearch/plugins/PluginTestUtil.java
@@ -8,6 +8,8 @@
 
 package org.elasticsearch.plugins;
 
+import org.elasticsearch.Version;
+
 import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.file.Files;
@@ -23,6 +25,24 @@ public class PluginTestUtil {
 
     public static void writeStablePluginProperties(Path pluginDir, String... stringProps) throws IOException {
         writeProperties(pluginDir.resolve(PluginDescriptor.STABLE_DESCRIPTOR_FILENAME), stringProps);
+    }
+
+    public static void writeSimplePluginDescriptor(Path pluginDir, String name, String classname) throws IOException {
+        PluginTestUtil.writePluginProperties(
+            pluginDir,
+            "description",
+            "description",
+            "name",
+            name,
+            "version",
+            "1.0.0",
+            "elasticsearch.version",
+            Version.CURRENT.toString(),
+            "java.version",
+            System.getProperty("java.specification.version"),
+            "classname",
+            classname
+        );
     }
 
     /** convenience method to write a plugin properties file */


### PR DESCRIPTION
Plugin APIs are defined by a set of interfaces from server. Many of
these APIs are actually implementation details of the system. As we move
these implementation details to use different hook mechanisms so that
internals are only implementable by builtin components, the existing
plugin APIs need to be deprecated. Java provides a means to indicate
deprecation - through the `@Deprecated` annotation. But that annotation
is only seen when compiling a plugin implementing deprecated hooks, and
only then if deprecation warnings are not disabled.

This commit adds an introspection step to plugin initialization which
inspects each loaded plugin and looks for any APIs marked with the
@Deprecated annotation which are overridden by the plugin. If any are
found, deprecation log messages are then emitted to the deprecation log.