### PR TITLE
[7.17] Ignore beats artifacts when resolving all artifact dependencies (#88960)

### DIFF
--- a/distribution/docker/build.gradle
+++ b/distribution/docker/build.gradle
@@ -385,3 +385,8 @@ subprojects { Project subProject ->
     }
   }
 }
+
+tasks.named('resolveAllDependencies') {
+  // Don't try and resolve filebeat or metricbeat snapshots as they may not always be available
+  configs = configurations.matching { it.name.endsWith('beat') == false }
+}


### PR DESCRIPTION
Backports the following commits to 7.17:
 - Ignore beats artifacts when resolving all artifact dependencies (#88960)