### PR TITLE
[8.3] Ignore beats artifacts when resolving all artifact dependencies (#88960)

### DIFF
--- a/distribution/docker/build.gradle
+++ b/distribution/docker/build.gradle
@@ -487,3 +487,8 @@ subprojects { Project subProject ->
     }
   }
 }
+
+tasks.named('resolveAllDependencies') {
+  // Don't try and resolve filebeat or metricbeat snapshots as they may not always be available
+  configs = configurations.matching { it.name.endsWith('beat') == false }
+}


### PR DESCRIPTION
Backports the following commits to 8.3:
 - Ignore beats artifacts when resolving all artifact dependencies (#88960)