### PR TITLE
[8.4] Ensure that the FileSettingService closes the config file input stream (#88953)

### DIFF
--- a/server/src/main/java/org/elasticsearch/reservedstate/service/FileSettingsService.java
+++ b/server/src/main/java/org/elasticsearch/reservedstate/service/FileSettingsService.java
@@ -16,7 +16,6 @@ import org.elasticsearch.cluster.ClusterStateListener;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.component.AbstractLifecycleComponent;
 import org.elasticsearch.env.Environment;
-import org.elasticsearch.xcontent.XContentParser;
 import org.elasticsearch.xcontent.XContentParserConfiguration;
 
 import java.io.BufferedInputStream;
@@ -303,15 +302,20 @@ public class FileSettingsService extends AbstractLifecycleComponent implements C
     CountDownLatch processFileSettings(Path path, Consumer<Exception> errorHandler) throws IOException {
         CountDownLatch waitForCompletion = new CountDownLatch(1);
         logger.info("processing path [{}] for [{}]", path, NAMESPACE);
-        try (var json = new BufferedInputStream(Files.newInputStream(path))) {
-            try (XContentParser parser = JSON.xContent().createParser(XContentParserConfiguration.EMPTY, json)) {
-                stateService.process(NAMESPACE, parser, (e) -> {
+        try (
+            var fis = Files.newInputStream(path);
+            var bis = new BufferedInputStream(fis);
+            var parser = JSON.xContent().createParser(XContentParserConfiguration.EMPTY, bis)
+        ) {
+            stateService.process(NAMESPACE, parser, (e) -> {
+                try {
                     if (e != null) {
                         errorHandler.accept(e);
                     }
+                } finally {
                     waitForCompletion.countDown();
-                });
-            }
+                }
+            });
         }
 
         return waitForCompletion;


### PR DESCRIPTION
Backports the following commits to 8.4:
 - Ensure that the FileSettingService closes the config file input stream (#88953)