### PR TITLE
Avoid expensive loop in indicesDeletedFromClusterState() when possible

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/ClusterChangedEvent.java
+++ b/server/src/main/java/org/elasticsearch/cluster/ClusterChangedEvent.java
@@ -247,13 +247,15 @@ public class ClusterChangedEvent {
         final Metadata previousMetadata = previousState.metadata();
         final Metadata currentMetadata = state.metadata();
 
-        for (IndexMetadata index : previousMetadata.indices().values()) {
-            IndexMetadata current = currentMetadata.index(index.getIndex());
-            if (current == null) {
-                if (deleted == null) {
-                    deleted = new HashSet<>();
+        if (currentMetadata.indices() != previousMetadata.indices()) {
+            for (IndexMetadata index : previousMetadata.indices().values()) {
+                IndexMetadata current = currentMetadata.index(index.getIndex());
+                if (current == null) {
+                    if (deleted == null) {
+                        deleted = new HashSet<>();
+                    }
+                    deleted.add(index.getIndex());
                 }
-                deleted.add(index.getIndex());
             }
         }
 


### PR DESCRIPTION
The loop over all indices here gets very expensive for large states, we
can avoid it often when metadata changes but not the indices maps.

relates #77466 