### PR TITLE
Reject unknown request body fields in Mount API

### DIFF
--- a/docs/changelog/88987.yaml
+++ b/docs/changelog/88987.yaml
@@ -2,4 +2,5 @@ pr: 88987
 summary: Reject unknown request body fields in Mount API
 area: Snapshot/Restore
 type: bug
-issues: []
+issues:
+ - 75982

--- a/docs/changelog/88987.yaml
+++ b/docs/changelog/88987.yaml
@@ -1,0 +1,5 @@
+pr: 88987
+summary: Reject unknown request body fields in Mount API
+area: Snapshot/Restore
+type: bug
+issues: []

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/searchablesnapshots/MountSearchableSnapshotRequest.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/searchablesnapshots/MountSearchableSnapshotRequest.java
@@ -38,7 +38,7 @@ public class MountSearchableSnapshotRequest extends MasterNodeRequest<MountSearc
 
     public static final ConstructingObjectParser<MountSearchableSnapshotRequest, RestRequest> PARSER = new ConstructingObjectParser<>(
         "mount_searchable_snapshot",
-        true,
+        false,
         (a, request) -> new MountSearchableSnapshotRequest(
             Objects.requireNonNullElse((String) a[1], (String) a[0]),
             Objects.requireNonNull(request.param("repository")),
@@ -56,6 +56,15 @@ public class MountSearchableSnapshotRequest extends MasterNodeRequest<MountSearc
     private static final ParseField INDEX_SETTINGS_FIELD = new ParseField("index_settings");
     private static final ParseField IGNORE_INDEX_SETTINGS_FIELD = new ParseField("ignore_index_settings");
 
+    /**
+     * This field only exists to be silently ignored when the body of a Mount API request contains a "ignored_index_settings" instead of
+     * "ignore_index_settings" (note the missing 'd'). We need to silently ignores this field instead of rejecting the request because the
+     * High Level REST Client uses the wrong field name. See https://github.com/elastic/elasticsearch/issues/75982.
+     * TODO: remove in 9.0.
+     */
+    @Deprecated
+    private static final ParseField IGNORED_INDEX_SETTINGS_FIELD = new ParseField("ignored_index_settings");
+
     static {
         PARSER.declareField(constructorArg(), XContentParser::text, INDEX_FIELD, ObjectParser.ValueType.STRING);
         PARSER.declareField(optionalConstructorArg(), XContentParser::text, RENAMED_INDEX_FIELD, ObjectParser.ValueType.STRING);
@@ -66,6 +75,10 @@ public class MountSearchableSnapshotRequest extends MasterNodeRequest<MountSearc
             IGNORE_INDEX_SETTINGS_FIELD,
             ObjectParser.ValueType.STRING_ARRAY
         );
+        PARSER.declareField(optionalConstructorArg(), (p, c) -> {
+            p.skipChildren();
+            return Strings.EMPTY_ARRAY;
+        }, IGNORED_INDEX_SETTINGS_FIELD, ObjectParser.ValueType.STRING_ARRAY);
     }
 
     /**

--- a/x-pack/plugin/searchable-snapshots/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/mount.yml
+++ b/x-pack/plugin/searchable-snapshots/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/mount.yml
@@ -1,0 +1,175 @@
+---
+setup:
+
+  - do:
+      indices.create:
+        index: docs
+        body:
+          settings:
+            number_of_shards:   1
+            number_of_replicas: 0
+            refresh_interval: "123s"
+
+  - do:
+      bulk:
+        body:
+          - index:
+              _index: docs
+              _id:    "1"
+          - field: foo
+          - index:
+              _index: docs
+              _id:    "2"
+          - field: bar
+          - index:
+              _index: docs
+              _id:    "3"
+          - field: baz
+          - index:
+              _index: docs
+              _id:    "4"
+          - field: bar
+          - index:
+              _index: docs
+              _id:    "5"
+          - field: baz
+          - index:
+              _index: docs
+              _id:    "6"
+          - field: baz
+
+  - do:
+      snapshot.create_repository:
+        repository: repository-fs
+        body:
+          type: fs
+          settings:
+            location: "repository-fs"
+
+  # Remove the snapshot if a previous test failed to delete it.
+  # Useful for third party tests that runs the test against a real external service.
+  - do:
+      snapshot.delete:
+        repository: repository-fs
+        snapshot: snapshot
+        ignore: 404
+
+  - do:
+      snapshot.create:
+        repository: repository-fs
+        snapshot: snapshot
+        wait_for_completion: true
+
+  - do:
+      indices.delete:
+        index: docs
+
+---
+teardown:
+
+  - do:
+      indices.delete:
+        index: docs-*
+
+---
+"Test Mount API with ignore_index_settings":
+  - do:
+      searchable_snapshots.mount:
+        repository: repository-fs
+        snapshot: snapshot
+        wait_for_completion: true
+        body:
+          index: docs
+          renamed_index: docs-mounted
+          ignore_index_settings: ["index.refresh_interval"]
+
+  - match: { snapshot.snapshot: snapshot }
+  - match: { snapshot.shards.failed: 0 }
+  - match: { snapshot.shards.successful: 1 }
+
+  - do:
+      indices.get_settings:
+        include_defaults: true
+        flat_settings: true
+        index: docs-mounted
+
+  - match: { docs-mounted.defaults.index\.refresh_interval: "1s" }
+
+  - do:
+      search:
+        index: docs-mounted
+        body:
+          query:
+            match_all: {}
+
+  - match: { hits.total.value: 6 }
+
+  - do:
+      search:
+        index: docs-mounted
+        body:
+          size: 0
+          query:
+            term:
+              field: bar
+
+  - match: { hits.total.value: 2 }
+
+---
+"Test Mount API silently ignored special field ignored_index_settings in request body":
+  - do:
+      searchable_snapshots.mount:
+        repository: repository-fs
+        snapshot: snapshot
+        wait_for_completion: true
+        body:
+          index: docs
+          renamed_index: docs-with-ignored-settings
+          ignored_index_settings: ["index.refresh_interval"]
+
+  - match: { snapshot.snapshot: snapshot }
+  - match: { snapshot.shards.failed: 0 }
+  - match: { snapshot.shards.successful: 1 }
+
+  - do:
+      indices.get_settings:
+        index: docs-with-ignored-settings
+
+  - match: { docs-with-ignored-settings.settings.index.refresh_interval: "123s" }
+
+  - do:
+      search:
+        index: docs-with-ignored-settings
+        body:
+          query:
+            match_all: {}
+
+  - match: { hits.total.value: 6 }
+
+  - do:
+      search:
+        index: docs-with-ignored-settings
+        body:
+          size: 0
+          query:
+            term:
+              field: bar
+
+  - match: { hits.total.value: 2 }
+
+
+---
+"Test Mount API with unknown request body field":
+  - skip:
+      version: " - 8.4.99"
+      reason: "unknown request body fields are rejected starting version 8.5.0"
+  - do:
+      catch:  bad_request
+      searchable_snapshots.mount:
+        repository: repository-fs
+        snapshot: snapshot
+        wait_for_completion: true
+        body:
+          index: docs
+          renamed_index: docs-with-wrong-request-body
+          wrong_request_body: "This is an unknown field"


### PR DESCRIPTION
The parser used to parse Mount API requests is configured to ignore unknown fields. I suspect we made it this way when it was created because we were expecting to change the request's body in the future, but that never happened.

This leniency confuses users (#75982) so we think it is better to simply reject requests with unknown fields starting v8.5.0.

Because the High Level REST Client has a bug (to be fixed in #79604 - I'll take that one to completion) that injects a wrong `ignored_index_settings` we decided to just ignore and not reject that one on purpose.

Closes #75982