### PR TITLE
Extract least/most available paths to DiskUsage

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/DiskUsage.java
+++ b/server/src/main/java/org/elasticsearch/cluster/DiskUsage.java
@@ -8,11 +8,16 @@
 
 package org.elasticsearch.cluster;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.elasticsearch.action.admin.cluster.node.stats.NodeStats;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.unit.ByteSizeValue;
+import org.elasticsearch.core.Nullable;
+import org.elasticsearch.monitor.fs.FsInfo;
 import org.elasticsearch.xcontent.ToXContentFragment;
 import org.elasticsearch.xcontent.XContentBuilder;
 
@@ -23,6 +28,9 @@ import java.util.Objects;
  * Encapsulation class used to represent the amount of disk used on a node.
  */
 public class DiskUsage implements ToXContentFragment, Writeable {
+
+    private static final Logger logger = LogManager.getLogger(DiskUsage.class);
+
     final String nodeId;
     final String nodeName;
     final String path;
@@ -147,5 +155,113 @@ public class DiskUsage implements ToXContentFragment, Writeable {
             + "["
             + Strings.format1Decimals(getFreeDiskAsPercentage(), "%")
             + "]";
+    }
+
+    /**
+     * Finds the path with the least available disk space and returns its disk usage. It returns null if there is no
+     * file system data in the NodeStats or if the total bytes are a negative number.
+     */
+    @Nullable
+    public static DiskUsage findLeastAvailablePath(NodeStats nodeStats) {
+        if (nodeStats.getFs() == null) {
+            logger.warn("node [{}/{}] did not return any filesystem stats", nodeStats.getNode().getName(), nodeStats.getNode().getId());
+            return null;
+        }
+
+        FsInfo.Path leastAvailablePath = null;
+        for (FsInfo.Path info : nodeStats.getFs()) {
+            if (leastAvailablePath == null) {
+                leastAvailablePath = info;
+            } else if (leastAvailablePath.getAvailable().getBytes() > info.getAvailable().getBytes()) {
+                leastAvailablePath = info;
+            }
+        }
+        if (leastAvailablePath == null) {
+            logger.warn("node [{}/{}] did not return any filesystem stats", nodeStats.getNode().getName(), nodeStats.getNode().getId());
+            return null;
+        }
+
+        final String nodeId = nodeStats.getNode().getId();
+        final String nodeName = nodeStats.getNode().getName();
+        if (logger.isTraceEnabled()) {
+            logger.trace(
+                "node [{}]: least available: total: {}, available: {}",
+                nodeId,
+                leastAvailablePath.getTotal(),
+                leastAvailablePath.getAvailable()
+            );
+        }
+        if (leastAvailablePath.getTotal().getBytes() < 0) {
+            if (logger.isTraceEnabled()) {
+                logger.trace(
+                    "node: [{}] least available path has less than 0 total bytes of disk [{}]",
+                    nodeId,
+                    leastAvailablePath.getTotal().getBytes()
+                );
+            }
+            return null;
+        } else {
+            return new DiskUsage(
+                nodeId,
+                nodeName,
+                leastAvailablePath.getPath(),
+                leastAvailablePath.getTotal().getBytes(),
+                leastAvailablePath.getAvailable().getBytes()
+            );
+        }
+    }
+
+    /**
+     * Finds the path with the most available disk space and returns its disk usage. It returns null if there are no
+     * file system data in the node stats or if the total bytes are a negative number.
+     */
+    @Nullable
+    public static DiskUsage findMostAvailable(NodeStats nodeStats) {
+        if (nodeStats.getFs() == null) {
+            logger.warn("node [{}/{}] did not return any filesystem stats", nodeStats.getNode().getName(), nodeStats.getNode().getId());
+            return null;
+        }
+
+        FsInfo.Path mostAvailablePath = null;
+        for (FsInfo.Path info : nodeStats.getFs()) {
+            if (mostAvailablePath == null) {
+                mostAvailablePath = info;
+            } else if (mostAvailablePath.getAvailable().getBytes() < info.getAvailable().getBytes()) {
+                mostAvailablePath = info;
+            }
+        }
+        if (mostAvailablePath == null) {
+            logger.warn("node [{}/{}] did not return any filesystem stats", nodeStats.getNode().getName(), nodeStats.getNode().getId());
+            return null;
+        }
+
+        final String nodeId = nodeStats.getNode().getId();
+        final String nodeName = nodeStats.getNode().getName();
+        if (logger.isTraceEnabled()) {
+            logger.trace(
+                "node [{}]: most available: total: {}, available: {}",
+                nodeId,
+                mostAvailablePath.getTotal(),
+                mostAvailablePath.getAvailable()
+            );
+        }
+        if (mostAvailablePath.getTotal().getBytes() < 0) {
+            if (logger.isTraceEnabled()) {
+                logger.trace(
+                    "node: [{}] most available path has less than 0 total bytes of disk [{}]",
+                    nodeId,
+                    mostAvailablePath.getTotal().getBytes()
+                );
+            }
+            return null;
+        } else {
+            return new DiskUsage(
+                nodeId,
+                nodeName,
+                mostAvailablePath.getPath(),
+                mostAvailablePath.getTotal().getBytes(),
+                mostAvailablePath.getAvailable().getBytes()
+            );
+        }
     }
 }


### PR DESCRIPTION
In the `InternalClusterInfoService` we collect the paths with the most and least available disk spaces. 

For the health API we are also interested in the path with the least available disk space, for this reason, we propose this refactoring. We extract the calculation of the least and most available disk space to separate methods and moved them to the `DiskUsage`.

Trade-off:
Obviously, the code now is less efficient because it needs two passes to calculate the least and most available disk space, if there are no objections, I think this is not too bad.

Relates to: #88390