### PR TITLE
Eliminating initial delay of CoordinationDiagnosticsService#beginPollingClusterFormationInfo for integration tests

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/cluster/coordination/CoordinationDiagnosticsServiceIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/cluster/coordination/CoordinationDiagnosticsServiceIT.java
@@ -11,6 +11,7 @@ package org.elasticsearch.cluster.coordination;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
 import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.test.ESIntegTestCase;
 import org.elasticsearch.test.disruption.BlockClusterStateProcessing;
 import org.elasticsearch.threadpool.Scheduler;
@@ -70,6 +71,7 @@ public class CoordinationDiagnosticsServiceIT extends ESIntegTestCase {
         diagnosticsOnBlockedNode.clusterFormationResponses = nodeToClusterFormationStateMap;
         diagnosticsOnBlockedNode.clusterFormationInfoTasks = cancellables;
 
+        diagnosticsOnBlockedNode.remoteRequestInitialDelay = TimeValue.ZERO;
         diagnosticsOnBlockedNode.beginPollingClusterFormationInfo(
             nodesWithoutBlockedNode,
             nodeToClusterFormationStateMap::put,
@@ -89,7 +91,7 @@ public class CoordinationDiagnosticsServiceIT extends ESIntegTestCase {
                 ClusterFormationFailureHelper.ClusterFormationState clusterFormationState = result.clusterFormationState();
                 assertThat(clusterFormationState.getDescription(), not(emptyOrNullString()));
             });
-        }, 30, TimeUnit.SECONDS);
+        });
 
         disruption.stopDisrupting();
     }

--- a/server/src/internalClusterTest/java/org/elasticsearch/cluster/coordination/CoordinationDiagnosticsServiceIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/cluster/coordination/CoordinationDiagnosticsServiceIT.java
@@ -20,6 +20,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
 import static org.hamcrest.Matchers.emptyOrNullString;
@@ -88,7 +89,7 @@ public class CoordinationDiagnosticsServiceIT extends ESIntegTestCase {
                 ClusterFormationFailureHelper.ClusterFormationState clusterFormationState = result.clusterFormationState();
                 assertThat(clusterFormationState.getDescription(), not(emptyOrNullString()));
             });
-        });
+        }, 30, TimeUnit.SECONDS);
 
         disruption.stopDisrupting();
     }

--- a/server/src/internalClusterTest/java/org/elasticsearch/cluster/coordination/CoordinationDiagnosticsServiceIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/cluster/coordination/CoordinationDiagnosticsServiceIT.java
@@ -21,7 +21,6 @@ import java.util.List;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
-import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
 import static org.hamcrest.Matchers.emptyOrNullString;

--- a/server/src/main/java/org/elasticsearch/cluster/coordination/CoordinationDiagnosticsService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/CoordinationDiagnosticsService.java
@@ -99,6 +99,13 @@ public class CoordinationDiagnosticsService implements ClusterStateListener {
     // Non-private for testing
     volatile ConcurrentMap<DiscoveryNode, ClusterFormationStateOrException> clusterFormationResponses = null;
 
+    /**
+     * This is the amount of time that we wait before scheduling a remote request to gather diagnostic information. It is not
+     * user-configurable, but is non-final so that integration tests don't have to waste 10 seconds.
+     */
+    // Non-private for testing
+    TimeValue remoteRequestInitialDelay = new TimeValue(10, TimeUnit.SECONDS);
+
     private static final Logger logger = LogManager.getLogger(CoordinationDiagnosticsService.class);
 
     /**
@@ -804,7 +811,7 @@ public class CoordinationDiagnosticsService implements ClusterStateListener {
                     connectionListener
                 );
             }
-        }, new TimeValue(10, TimeUnit.SECONDS), ThreadPool.Names.SAME);
+        }, remoteRequestInitialDelay, ThreadPool.Names.SAME);
     }
 
     // Non-private for testing


### PR DESCRIPTION
`CoordinationDiagnosticsService#beginPollingClusterFormationInfo` schedules a task to run after an initial delay of
10 seconds. `CoordinationDiagnosticsServiceIT` is asserting that we have results in 10 seconds or less (using the
default `assertBusy`). This commit exposes a way for integration tests to change that initial delay so that we don't
waste 10 seconds waiting for the task to be scheduled.