### PR TITLE
Ensure tests don't use flat polygons

### DIFF
--- a/x-pack/plugin/spatial/src/internalClusterTest/java/org/elasticsearch/xpack/spatial/search/CartesianShapeQueryTestCase.java
+++ b/x-pack/plugin/spatial/src/internalClusterTest/java/org/elasticsearch/xpack/spatial/search/CartesianShapeQueryTestCase.java
@@ -7,13 +7,11 @@
 
 package org.elasticsearch.xpack.spatial.search;
 
-import org.apache.lucene.tests.geo.GeoTestUtil;
 import org.elasticsearch.common.geo.GeometryNormalizer;
 import org.elasticsearch.common.geo.Orientation;
 import org.elasticsearch.geometry.Geometry;
 import org.elasticsearch.geometry.GeometryCollection;
 import org.elasticsearch.geometry.Line;
-import org.elasticsearch.geometry.LinearRing;
 import org.elasticsearch.geometry.Point;
 import org.elasticsearch.geometry.Polygon;
 import org.elasticsearch.search.geo.BaseShapeQueryTestCase;
@@ -71,8 +69,7 @@ public abstract class CartesianShapeQueryTestCase extends BaseShapeQueryTestCase
     }
 
     protected Polygon nextPolygon() {
-        org.apache.lucene.geo.Polygon randomPoly = GeoTestUtil.nextPolygon();
-        return new Polygon(new LinearRing(randomPoly.getPolyLons(), randomPoly.getPolyLats()));
+        return ShapeTestUtils.randomPolygon(false);
     }
 
     protected Polygon nextPolygon2() {

--- a/x-pack/plugin/spatial/src/internalClusterTest/java/org/elasticsearch/xpack/spatial/search/CartesianShapeQueryTests.java
+++ b/x-pack/plugin/spatial/src/internalClusterTest/java/org/elasticsearch/xpack/spatial/search/CartesianShapeQueryTests.java
@@ -21,7 +21,6 @@ public class CartesianShapeQueryTests extends CartesianShapeQueryTestCase {
     }
 
     @Override
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/88682")
     public void testQueryRandomGeoCollection() throws Exception {
         super.testQueryRandomGeoCollection();
     }

--- a/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/util/ShapeUtilTests.java
+++ b/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/util/ShapeUtilTests.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.spatial.util;
+
+import org.apache.lucene.geo.XShapeTestUtil;
+import org.apache.lucene.geo.XYPolygon;
+import org.apache.lucene.geo.XYRectangle;
+import org.elasticsearch.test.ESTestCase;
+
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.lessThan;
+
+public class ShapeUtilTests extends ESTestCase {
+    public void testBox() {
+        XYRectangle geom = XShapeTestUtil.nextBox();
+        assertThat("Box minX should be less than maxX", geom.minX, lessThan(geom.maxX));
+        assertThat("Box minY should be less than maxY", geom.minY, lessThan(geom.maxY));
+    }
+
+    public void testPolygon() {
+        XYPolygon geom = XShapeTestUtil.nextPolygon();
+        assertThat("Box minX should be less than maxX", geom.minX, lessThan(geom.maxX));
+        assertThat("Box minY should be less than maxY", geom.minY, lessThan(geom.maxY));
+        assertThat("Area should be non-zero", ShapeTestUtils.area(geom), greaterThan(0.0));
+    }
+
+    public void testFlatRectangle() {
+        XYPolygon geom = new XYPolygon(
+            new float[] { 54.69f, 54.69f, 180.0f, 180.0f, 54.69f },
+            new float[] { -2.80E-33f, 5.85E-33f, 5.85E-33f, -2.80E-33f, -2.80E-33f }
+        );
+        assertThat("Box minX should be less than maxX", geom.minX, lessThan(geom.maxX));
+        assertThat("Box minY should be less than maxY", geom.minY, lessThan(geom.maxY));
+        assertThat(
+            "This flat rectangle has area less than allowed threshold",
+            ShapeTestUtils.area(geom),
+            lessThan(ShapeTestUtils.MIN_VALID_AREA)
+        );
+    }
+}

--- a/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/util/ShapeUtilTests.java
+++ b/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/util/ShapeUtilTests.java
@@ -18,15 +18,15 @@ import static org.hamcrest.Matchers.lessThan;
 public class ShapeUtilTests extends ESTestCase {
     public void testBox() {
         XYRectangle geom = XShapeTestUtil.nextBox();
-        assertThat("Box minX should be less than maxX", geom.minX, lessThan(geom.maxX));
-        assertThat("Box minY should be less than maxY", geom.minY, lessThan(geom.maxY));
+        assertThat("Geometry minX should be less than maxX", geom.minX, lessThan(geom.maxX));
+        assertThat("Geometry minY should be less than maxY", geom.minY, lessThan(geom.maxY));
     }
 
     public void testPolygon() {
         XYPolygon geom = XShapeTestUtil.nextPolygon();
-        assertThat("Box minX should be less than maxX", geom.minX, lessThan(geom.maxX));
-        assertThat("Box minY should be less than maxY", geom.minY, lessThan(geom.maxY));
-        assertThat("Area should be non-zero", ShapeTestUtils.area(geom), greaterThan(0.0));
+        assertThat("Geometry minX should be less than maxX", geom.minX, lessThan(geom.maxX));
+        assertThat("Geometry minY should be less than maxY", geom.minY, lessThan(geom.maxY));
+        assertThat("Geometry area should be non-zero", ShapeTestUtils.area(geom), greaterThan(0.0));
     }
 
     public void testFlatRectangle() {
@@ -34,8 +34,8 @@ public class ShapeUtilTests extends ESTestCase {
             new float[] { 54.69f, 54.69f, 180.0f, 180.0f, 54.69f },
             new float[] { -2.80E-33f, 5.85E-33f, 5.85E-33f, -2.80E-33f, -2.80E-33f }
         );
-        assertThat("Box minX should be less than maxX", geom.minX, lessThan(geom.maxX));
-        assertThat("Box minY should be less than maxY", geom.minY, lessThan(geom.maxY));
+        assertThat("Geometry minX should be less than maxX", geom.minX, lessThan(geom.maxX));
+        assertThat("Geometry minY should be less than maxY", geom.minY, lessThan(geom.maxY));
         assertThat(
             "This flat rectangle has area less than allowed threshold",
             ShapeTestUtils.area(geom),


### PR DESCRIPTION
Polygons with colinear points cannot be tessellated.

Closes #88682