### PR TITLE
[ML] fix NLP inference_config bwc serialization tests

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/ZeroShotClassificationConfig.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/ZeroShotClassificationConfig.java
@@ -248,8 +248,8 @@ public class ZeroShotClassificationConfig implements NlpConfig {
         return hypothesisTemplate;
     }
 
-    public List<String> getLabels() {
-        return Optional.ofNullable(labels).orElse(List.of());
+    public Optional<List<String>> getLabels() {
+        return Optional.ofNullable(labels);
     }
 
     @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/ZeroShotClassificationConfigUpdate.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/ZeroShotClassificationConfigUpdate.java
@@ -147,13 +147,13 @@ public class ZeroShotClassificationConfigUpdate extends NlpConfigUpdate implemen
             tokenizationUpdate == null ? zeroShotConfig.getTokenization() : tokenizationUpdate.apply(zeroShotConfig.getTokenization()),
             zeroShotConfig.getHypothesisTemplate(),
             Optional.ofNullable(isMultiLabel).orElse(zeroShotConfig.isMultiLabel()),
-            Optional.ofNullable(labels).orElse(zeroShotConfig.getLabels()),
+            Optional.ofNullable(labels).orElse(zeroShotConfig.getLabels().orElse(null)),
             Optional.ofNullable(resultsField).orElse(zeroShotConfig.getResultsField())
         );
     }
 
     boolean isNoop(ZeroShotClassificationConfig originalConfig) {
-        return (labels == null || labels.equals(originalConfig.getLabels()))
+        return (labels == null || labels.equals(originalConfig.getLabels().orElse(null)))
             && (isMultiLabel == null || isMultiLabel.equals(originalConfig.isMultiLabel()))
             && (resultsField == null || resultsField.equals(originalConfig.getResultsField()))
             && super.isNoop();

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/InferenceConfigItemTestCase.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/InferenceConfigItemTestCase.java
@@ -15,6 +15,24 @@ import org.elasticsearch.search.SearchModule;
 import org.elasticsearch.xcontent.NamedXContentRegistry;
 import org.elasticsearch.xcontent.ToXContent;
 import org.elasticsearch.xpack.core.ml.AbstractBWCSerializationTestCase;
+import org.elasticsearch.xpack.core.ml.inference.trainedmodel.FillMaskConfig;
+import org.elasticsearch.xpack.core.ml.inference.trainedmodel.FillMaskConfigTests;
+import org.elasticsearch.xpack.core.ml.inference.trainedmodel.InferenceConfig;
+import org.elasticsearch.xpack.core.ml.inference.trainedmodel.NerConfig;
+import org.elasticsearch.xpack.core.ml.inference.trainedmodel.NerConfigTests;
+import org.elasticsearch.xpack.core.ml.inference.trainedmodel.NlpConfig;
+import org.elasticsearch.xpack.core.ml.inference.trainedmodel.PassThroughConfig;
+import org.elasticsearch.xpack.core.ml.inference.trainedmodel.PassThroughConfigTests;
+import org.elasticsearch.xpack.core.ml.inference.trainedmodel.QuestionAnsweringConfig;
+import org.elasticsearch.xpack.core.ml.inference.trainedmodel.QuestionAnsweringConfigTests;
+import org.elasticsearch.xpack.core.ml.inference.trainedmodel.TextClassificationConfig;
+import org.elasticsearch.xpack.core.ml.inference.trainedmodel.TextClassificationConfigTests;
+import org.elasticsearch.xpack.core.ml.inference.trainedmodel.TextEmbeddingConfig;
+import org.elasticsearch.xpack.core.ml.inference.trainedmodel.TextEmbeddingConfigTests;
+import org.elasticsearch.xpack.core.ml.inference.trainedmodel.TextSimilarityConfig;
+import org.elasticsearch.xpack.core.ml.inference.trainedmodel.TextSimilarityConfigTests;
+import org.elasticsearch.xpack.core.ml.inference.trainedmodel.ZeroShotClassificationConfig;
+import org.elasticsearch.xpack.core.ml.inference.trainedmodel.ZeroShotClassificationConfigTests;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -25,6 +43,29 @@ import static org.elasticsearch.xpack.core.ml.AbstractBWCWireSerializationTestCa
 
 public abstract class InferenceConfigItemTestCase<T extends VersionedNamedWriteable & ToXContent> extends AbstractBWCSerializationTestCase<
     T> {
+
+    static InferenceConfig mutateForVersion(NlpConfig inferenceConfig, Version version) {
+        if (inferenceConfig instanceof TextClassificationConfig textClassificationConfig) {
+            return TextClassificationConfigTests.mutateForVersion(textClassificationConfig, version);
+        } else if (inferenceConfig instanceof FillMaskConfig fillMaskConfig) {
+            return FillMaskConfigTests.mutateForVersion(fillMaskConfig, version);
+        } else if (inferenceConfig instanceof QuestionAnsweringConfig questionAnsweringConfig) {
+            return QuestionAnsweringConfigTests.mutateForVersion(questionAnsweringConfig, version);
+        } else if (inferenceConfig instanceof NerConfig nerConfig) {
+            return NerConfigTests.mutateForVersion(nerConfig, version);
+        } else if (inferenceConfig instanceof PassThroughConfig passThroughConfig) {
+            return PassThroughConfigTests.mutateForVersion(passThroughConfig, version);
+        } else if (inferenceConfig instanceof TextEmbeddingConfig textEmbeddingConfig) {
+            return TextEmbeddingConfigTests.mutateForVersion(textEmbeddingConfig, version);
+        } else if (inferenceConfig instanceof TextSimilarityConfig textSimilarityConfig) {
+            return TextSimilarityConfigTests.mutateForVersion(textSimilarityConfig, version);
+        } else if (inferenceConfig instanceof ZeroShotClassificationConfig zeroShotClassificationConfig) {
+            return ZeroShotClassificationConfigTests.mutateForVersion(zeroShotClassificationConfig, version);
+        } else {
+            throw new IllegalArgumentException("unknown inference config [" + inferenceConfig.getName() + "]");
+        }
+    }
+
     @Override
     protected NamedXContentRegistry xContentRegistry() {
         List<NamedXContentRegistry.Entry> namedXContent = new ArrayList<>();

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/TrainedModelConfigTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/TrainedModelConfigTests.java
@@ -6,7 +6,6 @@
  */
 package org.elasticsearch.xpack.core.ml.inference;
 
-import org.apache.lucene.tests.util.LuceneTestCase;
 import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.common.bytes.BytesReference;
@@ -29,10 +28,10 @@ import org.elasticsearch.xpack.core.ml.inference.trainedmodel.FillMaskConfigTest
 import org.elasticsearch.xpack.core.ml.inference.trainedmodel.IndexLocationTests;
 import org.elasticsearch.xpack.core.ml.inference.trainedmodel.InferenceConfig;
 import org.elasticsearch.xpack.core.ml.inference.trainedmodel.NerConfigTests;
+import org.elasticsearch.xpack.core.ml.inference.trainedmodel.NlpConfig;
 import org.elasticsearch.xpack.core.ml.inference.trainedmodel.PassThroughConfigTests;
 import org.elasticsearch.xpack.core.ml.inference.trainedmodel.QuestionAnsweringConfigTests;
 import org.elasticsearch.xpack.core.ml.inference.trainedmodel.RegressionConfigTests;
-import org.elasticsearch.xpack.core.ml.inference.trainedmodel.TextClassificationConfig;
 import org.elasticsearch.xpack.core.ml.inference.trainedmodel.TextClassificationConfigTests;
 import org.elasticsearch.xpack.core.ml.inference.trainedmodel.TextEmbeddingConfigTests;
 import org.elasticsearch.xpack.core.ml.inference.trainedmodel.TextSimilarityConfigTests;
@@ -60,7 +59,6 @@ import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.not;
 
-@LuceneTestCase.AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/89008")
 public class TrainedModelConfigTests extends AbstractBWCSerializationTestCase<TrainedModelConfig> {
 
     private boolean lenient;
@@ -397,8 +395,8 @@ public class TrainedModelConfigTests extends AbstractBWCSerializationTestCase<Tr
             builder.setModelType(null);
             builder.setLocation(null);
         }
-        if (instance.getInferenceConfig()instanceof TextClassificationConfig textClassificationConfig) {
-            builder.setInferenceConfig(TextClassificationConfigTests.mutateInstance(textClassificationConfig, version));
+        if (instance.getInferenceConfig()instanceof NlpConfig nlpConfig) {
+            builder.setInferenceConfig(InferenceConfigItemTestCase.mutateForVersion(nlpConfig, version));
         }
         return builder.build();
     }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/BertTokenizationTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/BertTokenizationTests.java
@@ -19,6 +19,19 @@ public class BertTokenizationTests extends AbstractBWCSerializationTestCase<Bert
 
     private boolean lenient;
 
+    public static BertTokenization mutateForVersion(BertTokenization instance, Version version) {
+        if (version.before(Version.V_8_2_0)) {
+            return new BertTokenization(
+                instance.doLowerCase,
+                instance.withSpecialTokens,
+                instance.maxSequenceLength,
+                instance.truncate,
+                null
+            );
+        }
+        return instance;
+    }
+
     @Before
     public void chooseStrictOrLenient() {
         lenient = randomBoolean();
@@ -41,7 +54,7 @@ public class BertTokenizationTests extends AbstractBWCSerializationTestCase<Bert
 
     @Override
     protected BertTokenization mutateInstanceForVersion(BertTokenization instance, Version version) {
-        return instance;
+        return mutateForVersion(instance, version);
     }
 
     public static BertTokenization createRandom() {

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/FillMaskConfigTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/FillMaskConfigTests.java
@@ -22,6 +22,15 @@ public class FillMaskConfigTests extends InferenceConfigItemTestCase<FillMaskCon
         return true;
     }
 
+    public static FillMaskConfig mutateForVersion(FillMaskConfig instance, Version version) {
+        return new FillMaskConfig(
+            instance.getVocabularyConfig(),
+            InferenceConfigTestScaffolding.mutateTokenizationForVersion(instance.getTokenization(), version),
+            instance.getNumTopClasses(),
+            instance.getResultsField()
+        );
+    }
+
     @Override
     protected Predicate<String> getRandomFieldsExcludeFilter() {
         return field -> field.isEmpty() == false;
@@ -44,7 +53,7 @@ public class FillMaskConfigTests extends InferenceConfigItemTestCase<FillMaskCon
 
     @Override
     protected FillMaskConfig mutateInstanceForVersion(FillMaskConfig instance, Version version) {
-        return instance;
+        return mutateForVersion(instance, version);
     }
 
     public static FillMaskConfig createRandom() {

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/InferenceConfigTestScaffolding.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/InferenceConfigTestScaffolding.java
@@ -7,7 +7,21 @@
 
 package org.elasticsearch.xpack.core.ml.inference.trainedmodel;
 
+import org.elasticsearch.Version;
+
 public final class InferenceConfigTestScaffolding {
+
+    static Tokenization mutateTokenizationForVersion(Tokenization tokenization, Version version) {
+        if (tokenization instanceof BertTokenization bertTokenization) {
+            return BertTokenizationTests.mutateForVersion(bertTokenization, version);
+        } else if (tokenization instanceof MPNetTokenization mpNetTokenization) {
+            return MPNetTokenizationTests.mutateForVersion(mpNetTokenization, version);
+        } else if (tokenization instanceof RobertaTokenization robertaTokenization) {
+            return RobertaTokenizationTests.mutateForVersion(robertaTokenization, version);
+        } else {
+            throw new IllegalArgumentException("unknown tokenization [" + tokenization.getName() + "]");
+        }
+    }
 
     static Tokenization cloneWithNewTruncation(Tokenization tokenization, Tokenization.Truncate truncate) {
         if (tokenization instanceof MPNetTokenization) {

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/MPNetTokenizationTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/MPNetTokenizationTests.java
@@ -19,6 +19,19 @@ public class MPNetTokenizationTests extends AbstractBWCSerializationTestCase<MPN
 
     private boolean lenient;
 
+    static MPNetTokenization mutateForVersion(MPNetTokenization instance, Version version) {
+        if (version.before(Version.V_8_2_0)) {
+            return new MPNetTokenization(
+                instance.doLowerCase,
+                instance.withSpecialTokens,
+                instance.maxSequenceLength,
+                instance.truncate,
+                null
+            );
+        }
+        return instance;
+    }
+
     @Before
     public void chooseStrictOrLenient() {
         lenient = randomBoolean();
@@ -41,7 +54,7 @@ public class MPNetTokenizationTests extends AbstractBWCSerializationTestCase<MPN
 
     @Override
     protected MPNetTokenization mutateInstanceForVersion(MPNetTokenization instance, Version version) {
-        return instance;
+        return mutateForVersion(instance, version);
     }
 
     public static MPNetTokenization createRandom() {

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/NerConfigTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/NerConfigTests.java
@@ -21,6 +21,15 @@ import java.util.stream.Stream;
 
 public class NerConfigTests extends InferenceConfigItemTestCase<NerConfig> {
 
+    public static NerConfig mutateForVersion(NerConfig instance, Version version) {
+        return new NerConfig(
+            instance.getVocabularyConfig(),
+            InferenceConfigTestScaffolding.mutateTokenizationForVersion(instance.getTokenization(), version),
+            instance.getClassificationLabels(),
+            instance.getResultsField()
+        );
+    }
+
     @Override
     protected boolean supportsUnknownFields() {
         return true;
@@ -48,7 +57,7 @@ public class NerConfigTests extends InferenceConfigItemTestCase<NerConfig> {
 
     @Override
     protected NerConfig mutateInstanceForVersion(NerConfig instance, Version version) {
-        return instance;
+        return mutateForVersion(instance, version);
     }
 
     public static NerConfig createRandom() {

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/PassThroughConfigTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/PassThroughConfigTests.java
@@ -17,6 +17,14 @@ import java.util.function.Predicate;
 
 public class PassThroughConfigTests extends InferenceConfigItemTestCase<PassThroughConfig> {
 
+    public static PassThroughConfig mutateForVersion(PassThroughConfig instance, Version version) {
+        return new PassThroughConfig(
+            instance.getVocabularyConfig(),
+            InferenceConfigTestScaffolding.mutateTokenizationForVersion(instance.getTokenization(), version),
+            instance.getResultsField()
+        );
+    }
+
     @Override
     protected boolean supportsUnknownFields() {
         return true;
@@ -44,7 +52,7 @@ public class PassThroughConfigTests extends InferenceConfigItemTestCase<PassThro
 
     @Override
     protected PassThroughConfig mutateInstanceForVersion(PassThroughConfig instance, Version version) {
-        return instance;
+        return mutateForVersion(instance, version);
     }
 
     public static PassThroughConfig createRandom() {

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/QuestionAnsweringConfigTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/QuestionAnsweringConfigTests.java
@@ -7,7 +7,6 @@
 
 package org.elasticsearch.xpack.core.ml.inference.trainedmodel;
 
-import org.apache.lucene.tests.util.LuceneTestCase;
 import org.elasticsearch.Version;
 import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.xcontent.XContentParser;
@@ -16,8 +15,17 @@ import org.elasticsearch.xpack.core.ml.inference.InferenceConfigItemTestCase;
 import java.io.IOException;
 import java.util.function.Predicate;
 
-@LuceneTestCase.AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/89008")
 public class QuestionAnsweringConfigTests extends InferenceConfigItemTestCase<QuestionAnsweringConfig> {
+
+    public static QuestionAnsweringConfig mutateForVersion(QuestionAnsweringConfig instance, Version version) {
+        return new QuestionAnsweringConfig(
+            instance.getNumTopClasses(),
+            instance.getMaxAnswerLength(),
+            instance.getVocabularyConfig(),
+            InferenceConfigTestScaffolding.mutateTokenizationForVersion(instance.getTokenization(), version),
+            instance.getResultsField()
+        );
+    }
 
     @Override
     protected boolean supportsUnknownFields() {
@@ -46,7 +54,7 @@ public class QuestionAnsweringConfigTests extends InferenceConfigItemTestCase<Qu
 
     @Override
     protected QuestionAnsweringConfig mutateInstanceForVersion(QuestionAnsweringConfig instance, Version version) {
-        return instance;
+        return mutateForVersion(instance, version);
     }
 
     public static QuestionAnsweringConfig createRandom() {

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/RobertaTokenizationTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/RobertaTokenizationTests.java
@@ -19,6 +19,19 @@ public class RobertaTokenizationTests extends AbstractBWCSerializationTestCase<R
 
     private boolean lenient;
 
+    public static RobertaTokenization mutateForVersion(RobertaTokenization instance, Version version) {
+        if (version.before(Version.V_8_2_0)) {
+            return new RobertaTokenization(
+                instance.withSpecialTokens,
+                instance.isAddPrefixSpace(),
+                instance.maxSequenceLength,
+                instance.truncate,
+                null
+            );
+        }
+        return instance;
+    }
+
     @Before
     public void chooseStrictOrLenient() {
         lenient = randomBoolean();
@@ -41,7 +54,7 @@ public class RobertaTokenizationTests extends AbstractBWCSerializationTestCase<R
 
     @Override
     protected RobertaTokenization mutateInstanceForVersion(RobertaTokenization instance, Version version) {
-        return instance;
+        return mutateForVersion(instance, version);
     }
 
     public static RobertaTokenization createRandom() {

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/TextClassificationConfigTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/TextClassificationConfigTests.java
@@ -21,37 +21,14 @@ import static org.hamcrest.Matchers.containsString;
 
 public class TextClassificationConfigTests extends InferenceConfigItemTestCase<TextClassificationConfig> {
 
-    public static TextClassificationConfig mutateInstance(TextClassificationConfig instance, Version version) {
-        if (version.before(Version.V_8_2_0)) {
-            final Tokenization tokenization;
-            if (instance.getTokenization() instanceof BertTokenization) {
-                tokenization = new BertTokenization(
-                    instance.getTokenization().doLowerCase,
-                    instance.getTokenization().withSpecialTokens,
-                    instance.getTokenization().maxSequenceLength,
-                    instance.getTokenization().truncate,
-                    null
-                );
-            } else if (instance.getTokenization() instanceof MPNetTokenization) {
-                tokenization = new MPNetTokenization(
-                    instance.getTokenization().doLowerCase,
-                    instance.getTokenization().withSpecialTokens,
-                    instance.getTokenization().maxSequenceLength,
-                    instance.getTokenization().truncate,
-                    null
-                );
-            } else {
-                throw new UnsupportedOperationException("unknown tokenization type: " + instance.getTokenization().getName());
-            }
-            return new TextClassificationConfig(
-                instance.getVocabularyConfig(),
-                tokenization,
-                instance.getClassificationLabels(),
-                instance.getNumTopClasses(),
-                instance.getResultsField()
-            );
-        }
-        return instance;
+    public static TextClassificationConfig mutateForVersion(TextClassificationConfig instance, Version version) {
+        return new TextClassificationConfig(
+            instance.getVocabularyConfig(),
+            InferenceConfigTestScaffolding.mutateTokenizationForVersion(instance.getTokenization(), version),
+            instance.getClassificationLabels(),
+            instance.getNumTopClasses(),
+            instance.getResultsField()
+        );
     }
 
     @Override
@@ -81,7 +58,7 @@ public class TextClassificationConfigTests extends InferenceConfigItemTestCase<T
 
     @Override
     protected TextClassificationConfig mutateInstanceForVersion(TextClassificationConfig instance, Version version) {
-        return mutateInstance(instance, version);
+        return mutateForVersion(instance, version);
     }
 
     public void testInvalidClassificationLabels() {

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/TextEmbeddingConfigTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/TextEmbeddingConfigTests.java
@@ -17,6 +17,14 @@ import java.util.function.Predicate;
 
 public class TextEmbeddingConfigTests extends InferenceConfigItemTestCase<TextEmbeddingConfig> {
 
+    public static TextEmbeddingConfig mutateForVersion(TextEmbeddingConfig instance, Version version) {
+        return new TextEmbeddingConfig(
+            instance.getVocabularyConfig(),
+            InferenceConfigTestScaffolding.mutateTokenizationForVersion(instance.getTokenization(), version),
+            instance.getResultsField()
+        );
+    }
+
     @Override
     protected boolean supportsUnknownFields() {
         return true;
@@ -44,7 +52,7 @@ public class TextEmbeddingConfigTests extends InferenceConfigItemTestCase<TextEm
 
     @Override
     protected TextEmbeddingConfig mutateInstanceForVersion(TextEmbeddingConfig instance, Version version) {
-        return instance;
+        return mutateForVersion(instance, version);
     }
 
     public static TextEmbeddingConfig createRandom() {

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/TextSimilarityConfigTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/TextSimilarityConfigTests.java
@@ -7,7 +7,6 @@
 
 package org.elasticsearch.xpack.core.ml.inference.trainedmodel;
 
-import org.apache.lucene.tests.util.LuceneTestCase;
 import org.elasticsearch.Version;
 import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.xcontent.XContentParser;
@@ -17,8 +16,16 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.function.Predicate;
 
-@LuceneTestCase.AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/89008")
 public class TextSimilarityConfigTests extends InferenceConfigItemTestCase<TextSimilarityConfig> {
+
+    public static TextSimilarityConfig mutateForVersion(TextSimilarityConfig instance, Version version) {
+        return new TextSimilarityConfig(
+            instance.getVocabularyConfig(),
+            InferenceConfigTestScaffolding.mutateTokenizationForVersion(instance.getTokenization(), version),
+            instance.getResultsField(),
+            instance.getSpanScoreFunction().toString()
+        );
+    }
 
     @Override
     protected boolean supportsUnknownFields() {
@@ -47,7 +54,7 @@ public class TextSimilarityConfigTests extends InferenceConfigItemTestCase<TextS
 
     @Override
     protected TextSimilarityConfig mutateInstanceForVersion(TextSimilarityConfig instance, Version version) {
-        return instance;
+        return mutateForVersion(instance, version);
     }
 
     public static TextSimilarityConfig createRandom() {

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/ZeroShotClassificationConfigTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/ZeroShotClassificationConfigTests.java
@@ -18,6 +18,18 @@ import java.util.function.Predicate;
 
 public class ZeroShotClassificationConfigTests extends InferenceConfigItemTestCase<ZeroShotClassificationConfig> {
 
+    public static ZeroShotClassificationConfig mutateForVersion(ZeroShotClassificationConfig instance, Version version) {
+        return new ZeroShotClassificationConfig(
+            instance.getClassificationLabels(),
+            instance.getVocabularyConfig(),
+            InferenceConfigTestScaffolding.mutateTokenizationForVersion(instance.getTokenization(), version),
+            instance.getHypothesisTemplate(),
+            instance.isMultiLabel(),
+            instance.getLabels().orElse(null),
+            instance.getResultsField()
+        );
+    }
+
     @Override
     protected boolean supportsUnknownFields() {
         return true;
@@ -45,7 +57,7 @@ public class ZeroShotClassificationConfigTests extends InferenceConfigItemTestCa
 
     @Override
     protected ZeroShotClassificationConfig mutateInstanceForVersion(ZeroShotClassificationConfig instance, Version version) {
-        return instance;
+        return mutateForVersion(instance, version);
     }
 
     public static ZeroShotClassificationConfig createRandom() {

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/ZeroShotClassificationConfigUpdateTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/ZeroShotClassificationConfigUpdateTests.java
@@ -125,7 +125,7 @@ public class ZeroShotClassificationConfigUpdateTests extends AbstractNlpConfigUp
                 originalConfig.getTokenization(),
                 originalConfig.getHypothesisTemplate(),
                 true,
-                originalConfig.getLabels(),
+                originalConfig.getLabels().orElse(null),
                 originalConfig.getResultsField()
             ),
             equalTo(new ZeroShotClassificationConfigUpdate.Builder().setMultiLabel(true).build().apply(originalConfig))
@@ -137,7 +137,7 @@ public class ZeroShotClassificationConfigUpdateTests extends AbstractNlpConfigUp
                 originalConfig.getTokenization(),
                 originalConfig.getHypothesisTemplate(),
                 originalConfig.isMultiLabel(),
-                originalConfig.getLabels(),
+                originalConfig.getLabels().orElse(null),
                 "updated-field"
             ),
             equalTo(new ZeroShotClassificationConfigUpdate.Builder().setResultsField("updated-field").build().apply(originalConfig))
@@ -152,7 +152,7 @@ public class ZeroShotClassificationConfigUpdateTests extends AbstractNlpConfigUp
                 tokenization,
                 originalConfig.getHypothesisTemplate(),
                 originalConfig.isMultiLabel(),
-                originalConfig.getLabels(),
+                originalConfig.getLabels().orElse(null),
                 originalConfig.getResultsField()
             ),
             equalTo(

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/nlp/ZeroShotClassificationProcessor.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/nlp/ZeroShotClassificationProcessor.java
@@ -67,7 +67,7 @@ public class ZeroShotClassificationProcessor extends NlpTask.Processor {
     public NlpTask.RequestBuilder getRequestBuilder(NlpConfig nlpConfig) {
         final String[] labelsValue;
         if (nlpConfig instanceof ZeroShotClassificationConfig zeroShotConfig) {
-            labelsValue = zeroShotConfig.getLabels().toArray(new String[0]);
+            labelsValue = zeroShotConfig.getLabels().orElse(List.of()).toArray(new String[0]);
         } else {
             labelsValue = this.labels;
         }
@@ -83,7 +83,7 @@ public class ZeroShotClassificationProcessor extends NlpTask.Processor {
         final boolean isMultiLabelValue;
         final String resultsFieldValue;
         if (nlpConfig instanceof ZeroShotClassificationConfig zeroShotConfig) {
-            labelsValue = zeroShotConfig.getLabels().toArray(new String[0]);
+            labelsValue = zeroShotConfig.getLabels().orElse(List.of()).toArray(new String[0]);
             isMultiLabelValue = zeroShotConfig.isMultiLabel();
             resultsFieldValue = zeroShotConfig.getResultsField();
         } else {

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/nlp/ZeroShotClassificationProcessor.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/nlp/ZeroShotClassificationProcessor.java
@@ -52,7 +52,7 @@ public class ZeroShotClassificationProcessor extends NlpTask.Processor {
                 "zero_shot_classification requires [entailment] and [contradiction] in classification_labels"
             );
         }
-        this.labels = Optional.ofNullable(config.getLabels()).orElse(List.of()).toArray(String[]::new);
+        this.labels = config.getLabels().orElse(List.of()).toArray(String[]::new);
         this.hypothesisTemplate = config.getHypothesisTemplate();
         this.isMultiLabel = config.isMultiLabel();
         this.resultsField = config.getResultsField();


### PR DESCRIPTION
The tests were failing because of `span` not being nulled out for question_answering and text_similarity tasks. 

But, this change also attempts to make it more future proof so that if changes occur to the nlp task or tokenization configurations it will cause a failure more quickly and require handling the bwc testing.

closes: https://github.com/elastic/elasticsearch/issues/89008