### PR TITLE
[DOCS] Add warning on restarting nodes exceeding low disk watermark

### DIFF
--- a/docs/reference/setup/restart-cluster.asciidoc
+++ b/docs/reference/setup/restart-cluster.asciidoc
@@ -8,6 +8,9 @@ nodes in the cluster while in the case of
 <<restart-cluster-rolling,rolling restart>>, you shut down only one node at a
 time, so the service remains uninterrupted.
 
+[WARNING]
+Nodes exceed low watermark will be slow to restart. You may want to reduce disk
+usage below low watermark before proceeding to restart nodes.
 
 [discrete]
 [[restart-cluster-full]]

--- a/docs/reference/setup/restart-cluster.asciidoc
+++ b/docs/reference/setup/restart-cluster.asciidoc
@@ -9,8 +9,10 @@ nodes in the cluster while in the case of
 time, so the service remains uninterrupted.
 
 [WARNING]
-Nodes exceed low watermark will be slow to restart. You may want to reduce disk
-usage below low watermark before proceeding to restart nodes.
+====
+Nodes exceeding the low watermark threshold will be slow to restart. Reduce the disk
+usage below the <<cluster-routing-watermark-low,low watermark>> before to restarting nodes.
+====
 
 [discrete]
 [[restart-cluster-full]]


### PR DESCRIPTION
As per https://github.com/elastic/elasticsearch/issues/49972 and https://github.com/elastic/elasticsearch/issues/56578, if a node is above low disk threshold when being restarted (rolling restart, network disruption or crash), the disk threshold decider prevents reusing the shard content on the restarted node.

The consequence of the event is the node may take a long time to start.
