### PR TITLE
Wrap ML model loading task in new tracing context

### DIFF
--- a/server/src/main/java/org/elasticsearch/tasks/TaskManager.java
+++ b/server/src/main/java/org/elasticsearch/tasks/TaskManager.java
@@ -120,6 +120,15 @@ public class TaskManager implements ClusterStateApplier {
      * Registers a task without parent task
      */
     public Task register(String type, String action, TaskAwareRequest request) {
+        return register(type, action, request, true);
+    }
+
+    /**
+     * Registers a task without a parent task, and specifies whether to trace the request. You should prefer
+     * to call {@link #register(String, String, TaskAwareRequest)}, since it is rare to want to avoid
+     * tracing a task.
+     */
+    public Task register(String type, String action, TaskAwareRequest request, boolean traceRequest) {
         Map<String, String> headers = new HashMap<>();
         long headerSize = 0;
         long maxSize = maxHeaderSize.getBytes();
@@ -149,7 +158,9 @@ public class TaskManager implements ClusterStateApplier {
         } else {
             Task previousTask = tasks.put(task.getId(), task);
             assert previousTask == null;
-            startTrace(threadContext, task);
+            if (traceRequest) {
+                startTrace(threadContext, task);
+            }
         }
         return task;
     }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/assignment/TrainedModelAssignmentNodeService.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/assignment/TrainedModelAssignmentNodeService.java
@@ -456,19 +456,18 @@ public class TrainedModelAssignmentNodeService implements ClusterStateListener {
 
     void prepareModelToLoad(StartTrainedModelDeploymentAction.TaskParams taskParams) {
         logger.debug(() -> format("[%s] preparing to load model with task params: %s", taskParams.getModelId(), taskParams));
-        try (var ignored = threadPool.getThreadContext().newTraceContext()) {
-            TrainedModelDeploymentTask task = (TrainedModelDeploymentTask) taskManager.register(
-                TRAINED_MODEL_ASSIGNMENT_TASK_TYPE,
-                TRAINED_MODEL_ASSIGNMENT_TASK_ACTION,
-                taskAwareRequest(taskParams)
-            );
-            // threadsafe check to verify we are not loading/loaded the model
-            if (modelIdToTask.putIfAbsent(taskParams.getModelId(), task) == null) {
-                loadingModels.add(task);
-            } else {
-                // If there is already a task for the model, unregister the new task
-                taskManager.unregister(task);
-            }
+        TrainedModelDeploymentTask task = (TrainedModelDeploymentTask) taskManager.register(
+            TRAINED_MODEL_ASSIGNMENT_TASK_TYPE,
+            TRAINED_MODEL_ASSIGNMENT_TASK_ACTION,
+            taskAwareRequest(taskParams),
+            false
+        );
+        // threadsafe check to verify we are not loading/loaded the model
+        if (modelIdToTask.putIfAbsent(taskParams.getModelId(), task) == null) {
+            loadingModels.add(task);
+        } else {
+            // If there is already a task for the model, unregister the new task
+            taskManager.unregister(task);
         }
     }
 


### PR DESCRIPTION
Part of #84369.

ML uses the task framework to register a tasks for each loaded model.
These tasks are not executed in the usual sense, and it does not make
sense to trace them using APM. Therefore, make it possible to register
a task without also starting tracing.