### PR TITLE
Preemptively initialize routing nodes and indices lookup on all node types

### DIFF
--- a/docs/changelog/89032.yaml
+++ b/docs/changelog/89032.yaml
@@ -1,0 +1,5 @@
+pr: 89032
+summary: Preemptively initialize routing nodes and indices lookup on all node types
+area: Cluster Coordination
+type: enhancement
+issues: []

--- a/server/src/main/java/org/elasticsearch/cluster/ClusterState.java
+++ b/server/src/main/java/org/elasticsearch/cluster/ClusterState.java
@@ -54,6 +54,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.concurrent.Executor;
 import java.util.function.Consumer;
 
 import static org.elasticsearch.gateway.GatewayService.STATE_NOT_RECOVERED_BLOCK;
@@ -349,6 +350,19 @@ public class ClusterState implements ToXContentFragment, Diffable<ClusterState> 
         // we don't have any routing nodes for this state, likely because it's a temporary state in the reroute logic, don't compute an
         // immutable copy that will never be used and instead directly build a mutable copy
         return RoutingNodes.mutable(routingTable, this.nodes);
+    }
+
+    /**
+     * Initialize data structures that lazy computed for this instance in the background by using the giving executor.
+     * @param executor executor to run initialization tasks on
+     */
+    public void initializeAsync(Executor executor) {
+        if (routingNodes == null) {
+            executor.execute(this::getRoutingNodes);
+        }
+        if (metadata.indicesLookupInitialized() == false) {
+            executor.execute(metadata::getIndicesLookup);
+        }
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/Metadata.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/Metadata.java
@@ -509,6 +509,10 @@ public class Metadata extends AbstractCollection<IndexMetadata> implements Diffa
         return true;
     }
 
+    public boolean indicesLookupInitialized() {
+        return indicesLookup != null;
+    }
+
     public SortedMap<String, IndexAbstraction> getIndicesLookup() {
         SortedMap<String, IndexAbstraction> lookup = indicesLookup;
         if (lookup == null) {

--- a/server/src/main/java/org/elasticsearch/cluster/service/MasterService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/service/MasterService.java
@@ -332,8 +332,7 @@ public class MasterService extends AbstractLifecycleComponent {
                     logger.debug("publishing cluster state version [{}]", newClusterState.version());
                     // initialize routing nodes and the indices lookup concurrently, we will need both of them for the cluster state
                     // application and can compute them while we wait for the other nodes during publication
-                    threadPool.generic().execute(newClusterState::getRoutingNodes);
-                    threadPool.generic().execute(newClusterState.metadata()::getIndicesLookup);
+                    newClusterState.initializeAsync(threadPool.generic());
                     publish(
                         clusterStatePublicationEvent,
                         new CompositeTaskAckListener(

--- a/test/framework/src/test/java/org/elasticsearch/cluster/service/FakeThreadPoolMasterServiceTests.java
+++ b/test/framework/src/test/java/org/elasticsearch/cluster/service/FakeThreadPoolMasterServiceTests.java
@@ -142,8 +142,7 @@ public class FakeThreadPoolMasterServiceTests extends ESTestCase {
 
         runnableTasks.remove(0).run(); // schedule again
 
-        // run tasks for computing routing nodes and indices lookup
-        runnableTasks.remove(0).run();
+        // run task for computing missing indices lookup
         runnableTasks.remove(0).run();
 
         runnableTasks.remove(0).run(); // publish again


### PR DESCRIPTION
Follow up to #89005 running the initialization as soon as possible on non-master
nodes as well.

relates https://github.com/elastic/elasticsearch/issues/77466