### PR TITLE
Add test in vector tiles with runtime fields

### DIFF
--- a/x-pack/plugin/vector-tile/src/javaRestTest/java/org/elasticsearch/xpack/vectortile/VectorTileRestIT.java
+++ b/x-pack/plugin/vector-tile/src/javaRestTest/java/org/elasticsearch/xpack/vectortile/VectorTileRestIT.java
@@ -878,6 +878,19 @@ public class VectorTileRestIT extends ESRestTestCase {
         assertThat(response.getStatusLine().getStatusCode(), Matchers.equalTo(HttpStatus.SC_OK));
     }
 
+    public void testGetRuntimeField() throws Exception {
+        final Request mvtRequest = new Request(getHttpMethod(), INDEX_POINTS + "/_mvt/location_rf/" + z + "/" + x + "/" + y);
+        mvtRequest.setJsonEntity(
+            "{\"size\" : 100, \"runtime_mappings\": { \"location_rf\": {\"type\": \"geo_point\", \"script\": "
+                + "{ \"source\": \"emit(doc['location'].lat, doc['location'].lon)\" }}}}"
+        );
+        final VectorTile.Tile tile = execute(mvtRequest);
+        assertThat(tile.getLayersCount(), Matchers.equalTo(3));
+        assertLayer(tile, HITS_LAYER, 4096, 33, 2);
+        assertLayer(tile, AGGS_LAYER, 4096, 1, 2);
+        assertLayer(tile, META_LAYER, 4096, 1, 13);
+    }
+
     private String getHttpMethod() {
         return random().nextBoolean() ? HttpGet.METHOD_NAME : HttpPost.METHOD_NAME;
     }


### PR DESCRIPTION
In https://github.com/elastic/elasticsearch/pull/85449, we fixed an issue with geo_point runtime fields that prevent user to use vector tiles with geo_point runtime fields. ThisPR adds a test to make sure the functionality is no broken.