### PR TITLE
[8.4] Docs: Remove paragraph that applies only before Elasticsearch 7.0 (#86209)

### DIFF
--- a/docs/reference/ccr/getting-started.asciidoc
+++ b/docs/reference/ccr/getting-started.asciidoc
@@ -159,14 +159,6 @@ cluster with cluster alias `leader`.
     connected to.
 ====
 
-[[ccr-enable-soft-deletes]]
-==== Enable soft deletes on leader indices
-To follow an index, it must have been created with
-<<ccr-leader-requirements,soft deletes>> enabled. If the index doesn’t have
-soft deletes enabled, you must reindex it and use the new index as the leader
-index. Soft deletes are enabled by default on new indices
-created with {es} 7.0.0 and later.
-
 include::../../../x-pack/docs/en/security/authentication/remote-clusters-privileges.asciidoc[tag=configure-ccr-privileges]
 
 [[ccr-getting-started-follower-index]]


### PR DESCRIPTION
Backports the following commits to 8.4:
 - Docs: Remove paragraph that applies only before Elasticsearch 7.0 (#86209)