### PR TITLE
[7.15] Change YAML test structure from list to object (#77700)

### DIFF
--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/data_stream/110_update_by_query.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/data_stream/110_update_by_query.yml
@@ -75,7 +75,7 @@
           query:
             range:
               number:
-                - gte: 4
+                gte: 4
 
   - match: {updated: 2}
   - match: {version_conflicts: 0}


### PR DESCRIPTION
Backports the following commits to 7.15:
 - Change YAML test structure from list to object (#77700)