### PR TITLE
Mention internal user `_async_search` in docs

### DIFF
--- a/x-pack/docs/en/security/authentication/internal-users.asciidoc
+++ b/x-pack/docs/en/security/authentication/internal-users.asciidoc
@@ -2,9 +2,9 @@
 [[internal-users]]
 === Internal users
 
-The {stack-security-features} use three _internal_ users (`_system`, `_xpack`,
-and `_xpack_security`), which are responsible for the operations that take place
-inside an {es} cluster.
+The {stack-security-features} use four _internal_ users (`_system`, `_xpack`,
+`_xpack_security`, and `_async_search`), which are responsible for the operations
+that take place inside an {es} cluster.
 
 These users are only used by requests that originate from within the cluster.
 For this reason, they cannot be used to authenticate against the API and there


### PR DESCRIPTION
This PR will add internal user `_async_search` to the 7.x and 8.x docs.

Internal user `_async_search` was added in v7.7 by #52141.

Doc previews are available for a short time after a build
- https://elasticsearch_89050.docs-preview.app.elstc.co/diff