### PR TITLE
Update ES.ILM.Action.ReadOnly

### DIFF
--- a/docs/reference/ilm/actions/ilm-readonly.asciidoc
+++ b/docs/reference/ilm/actions/ilm-readonly.asciidoc
@@ -4,8 +4,8 @@
 
 Phases allowed: hot, warm, cold.
 
-Makes the index read-only;
-writes and metadata changes are no longer allowed.
+Makes the index data read-only;
+disables data write operations against the index.
 
 To use the `readonly` action in the `hot` phase, the `rollover` action *must* be present.
 If no rollover action is configured, {ilm-init} will reject the policy.


### PR DESCRIPTION
Related to [Discuss#311070](https://discuss.elastic.co/t/action-readonly-appears-to-set-index-blocks-write-not-index-blocks-read-only/311070), @joegallo explains

> The [ReadOnlyAction](https://github.com/elastic/elasticsearch/blob/main/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/ReadOnlyAction.java#L58-L65) is composed of a series of steps, the most important to this conversation being the [ReadOnlyStep](https://github.com/elastic/elasticsearch/blob/main/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/ReadOnlyStep.java#L42). That step does indeed add a write block (as opposed to a ‘read_only’) block, almost certainly the reasoning is that a ‘read_only’ block makes the index metadata read only, also, and we can’t have that — it would prevent the index from moving through the rest of the ILM process.  E.g. can’t reassign tiers, can’t change replicas, can’t even change the currently assigned ilm phase/action/step, etc, if you can’t change the index’s metadata.

So, the intention of ILM Action "Read Only" is to make an index's data read only and not also the index's metadata. This also decouples "read only" from understanding overlapping to `index.blocks.read_only` which appears to be an accidental thought overlap.