### PR TITLE
Fixing a race condition in CoordinationDiagnosticsServiceIT

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/cluster/coordination/CoordinationDiagnosticsServiceIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/cluster/coordination/CoordinationDiagnosticsServiceIT.java
@@ -35,7 +35,6 @@ public class CoordinationDiagnosticsServiceIT extends ESIntegTestCase {
         internalCluster().setBootstrapMasterNodeIndex(0);
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/89015")
     public void testBlockClusterStateProcessingOnOneNode() throws Exception {
         /*
          * This test picks a node that is not elected master, and then blocks cluster state processing on it. The reason is so that we
@@ -48,6 +47,7 @@ public class CoordinationDiagnosticsServiceIT extends ESIntegTestCase {
         assertThat(nodeNames, hasItem(master));
         String blockedNode = nodeNames.stream().filter(n -> n.equals(master) == false).findAny().get();
         assertNotNull(blockedNode);
+        ensureStableCluster(3);
 
         DiscoveryNodes discoveryNodes = internalCluster().getInstance(ClusterService.class, master).state().nodes();
         Set<DiscoveryNode> nodesWithoutBlockedNode = discoveryNodes.getNodes()


### PR DESCRIPTION
This makes sure that the test cluster is stable in CoordinationDiagnosticsServiceIT::testBlockClusterStateProcessingOnOneNode before proceeding with the rest of test. Previously sometimes (around 1%-3% of the time in my testing) the cluster state disruption would start before the node had received all of the initial cluster state changes. So it didn't know about all master-eligible nodes and the test would fail.
Closes #89015