### PR TITLE
[7.17] Fix mount snapshot api ignoring unknown request parameter

### DIFF
--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/searchable_snapshots/MountSnapshotRequest.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/searchable_snapshots/MountSnapshotRequest.java
@@ -115,19 +115,19 @@ public class MountSnapshotRequest implements ToXContentObject, Validatable {
         return this;
     }
 
-    private String[] ignoredIndexSettings;
+    private String[] ignoreIndexSettings;
 
-    public String[] getIgnoredIndexSettings() {
-        return ignoredIndexSettings;
+    public String[] getIgnoreIndexSettings() {
+        return ignoreIndexSettings;
     }
 
-    public MountSnapshotRequest ignoredIndexSettings(final String[] ignoredIndexSettings) {
-        if (ignoredIndexSettings != null) {
-            for (final String ignoredIndexSetting : ignoredIndexSettings) {
-                Objects.requireNonNull(ignoredIndexSetting);
+    public MountSnapshotRequest ignoreIndexSettings(final String[] ignoreIndexSettings) {
+        if (ignoreIndexSettings != null) {
+            for (final String ignoreIndexSetting : ignoreIndexSettings) {
+                Objects.requireNonNull(ignoreIndexSetting);
             }
         }
-        this.ignoredIndexSettings = ignoredIndexSettings;
+        this.ignoreIndexSettings = ignoreIndexSettings;
         return this;
     }
 
@@ -146,8 +146,8 @@ public class MountSnapshotRequest implements ToXContentObject, Validatable {
                 }
                 builder.endObject();
             }
-            if (ignoredIndexSettings != null) {
-                builder.array("ignored_index_settings", ignoredIndexSettings);
+            if (ignoreIndexSettings != null) {
+                builder.array("ignore_index_settings", ignoreIndexSettings);
             }
         }
         builder.endObject();

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/documentation/SearchableSnapshotsDocumentationIT.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/documentation/SearchableSnapshotsDocumentationIT.java
@@ -29,6 +29,7 @@ import org.elasticsearch.client.searchable_snapshots.CachesStatsResponse.NodeCac
 import org.elasticsearch.client.searchable_snapshots.MountSnapshotRequest;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.core.TimeValue;
+import org.elasticsearch.index.IndexSettings;
 import org.elasticsearch.repositories.fs.FsRepository;
 import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.snapshots.RestoreInfo;
@@ -36,9 +37,11 @@ import org.elasticsearch.xcontent.XContentType;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
+import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 
 @SuppressWarnings("removal")
@@ -47,7 +50,9 @@ public class SearchableSnapshotsDocumentationIT extends ESRestHighLevelClientTes
     public void testMountSnapshot() throws IOException, InterruptedException {
         final RestHighLevelClient client = highLevelClient();
         {
-            final CreateIndexRequest request = new CreateIndexRequest("index");
+            final CreateIndexRequest request = new CreateIndexRequest("index").settings(
+                Settings.builder().put(IndexSettings.INDEX_REFRESH_INTERVAL_SETTING.getKey(), TimeValue.timeValueHours(1L)).build()
+            );
             final CreateIndexResponse response = client.indices().create(request, RequestOptions.DEFAULT);
             assertTrue(response.isAcknowledged());
         }
@@ -96,6 +101,18 @@ public class SearchableSnapshotsDocumentationIT extends ESRestHighLevelClientTes
             .searchableSnapshots()
             .mountSnapshot(request, RequestOptions.DEFAULT);
         // end::searchable-snapshots-mount-snapshot-execute
+
+        Map<String, Object> settings = getIndexSettings("renamed_index", true);
+        @SuppressWarnings("unchecked")
+        Map<String, Object> renamedIndexSettings = (Map<String, Object>) settings.get("renamed_index");
+        @SuppressWarnings("unchecked")
+        Map<String, Object> defaultIndexSettings = (Map<String, Object>) renamedIndexSettings.get("defaults");
+
+        assertThat(
+            "Original index refresh interval setting should have been ignored when mounting the index: " + settings,
+            defaultIndexSettings.get(IndexSettings.INDEX_REFRESH_INTERVAL_SETTING.getKey()),
+            equalTo("1s")
+        );
 
         // tag::searchable-snapshots-mount-snapshot-response
         final RestoreInfo restoreInfo = response.getRestoreInfo(); // <1>

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/documentation/SearchableSnapshotsDocumentationIT.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/documentation/SearchableSnapshotsDocumentationIT.java
@@ -87,7 +87,7 @@ public class SearchableSnapshotsDocumentationIT extends ESRestHighLevelClientTes
             .put("index.number_of_replicas", 0)
             .build();
         request.indexSettings(indexSettings); // <8>
-        request.ignoredIndexSettings(
+        request.ignoreIndexSettings(
             new String[]{"index.refresh_interval"}); // <9>
         // end::searchable-snapshots-mount-snapshot-request
 

--- a/docs/changelog/89061.yaml
+++ b/docs/changelog/89061.yaml
@@ -1,0 +1,5 @@
+pr: 89061
+summary: "[7.17] Fix mount snapshot api ignoring unknown request parameter"
+area: "Snapshot/Restore, Java High Level REST Client"
+type: bug
+issues: []

--- a/docs/changelog/89061.yaml
+++ b/docs/changelog/89061.yaml
@@ -1,5 +1,6 @@
 pr: 89061
 summary: "[7.17] Fix mount snapshot api ignoring unknown request parameter"
-area: "Snapshot/Restore, Java High Level REST Client"
+area: "Java High Level REST Client"
 type: bug
-issues: []
+issues:
+  - 75982

--- a/test/framework/src/main/java/org/elasticsearch/test/rest/ESRestTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/rest/ESRestTestCase.java
@@ -1555,8 +1555,15 @@ public abstract class ESRestTestCase extends ESTestCase {
     }
 
     protected static Map<String, Object> getIndexSettings(String index) throws IOException {
+        return getIndexSettings(index, false);
+    }
+
+    protected static Map<String, Object> getIndexSettings(String index, boolean includeDefaults) throws IOException {
         Request request = new Request("GET", "/" + index + "/_settings");
         request.addParameter("flat_settings", "true");
+        if (includeDefaults) {
+            request.addParameter("include_defaults", "true");
+        }
         Response response = client().performRequest(request);
         try (InputStream is = response.getEntity().getContent()) {
             return XContentHelper.convertToMap(XContentType.JSON.xContent(), is, true);


### PR DESCRIPTION
The High Level REST Client provides a `MountSnapshotRequest#ignoredIndexSettings(String[])` method to define some index settings to ignore when mounting a snapshot as a searchable snapshot index.

Sadly the client generates a wrong request body field `ignored_index_settings` instead of `ignore_index_settings`. This wasn't caught until #75982 was reported because the parser of Mount API request ignores unknown fields in request body. 

We fixed the wrong leniency of the request parser on the Elasticsearch side (#88987) starting version 8.5.0, and we decided to continue to ignore the `ignored_index_settings` generated by the HLRC bug to avoid breaking HLRC client usages.

This pull request fixes the request body generated by the HLRC to pass the correct field name. This fix is for versions 7.17.6+ (we do not expect to release new versions of HLRC in 8.x). 

It also renames the HLRC methods to expose the change to client users.