### PR TITLE
[ML] Optimize frequent items transaction lookup

### DIFF
--- a/docs/changelog/89062.yaml
+++ b/docs/changelog/89062.yaml
@@ -1,0 +1,5 @@
+pr: 89062
+summary: Optimize frequent items transaction lookup
+area: Machine Learning
+type: enhancement
+issues: []

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/aggs/frequentitemsets/CountingItemSetTraverser.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/aggs/frequentitemsets/CountingItemSetTraverser.java
@@ -111,28 +111,28 @@ final class CountingItemSetTraverser implements Releasable {
             // we recalculate the row for this depth, so we have to clear the bits first
             transactionSkipList.clear((depth - 1) * cacheNumberOfTransactions, ((depth) * cacheNumberOfTransactions));
 
-            int transactionId = 0;
+            int topTransactionPos = 0;
             long occurrences = 0;
 
             // for whatever reason this turns out to be faster than a for loop
-            while (transactionId < topTransactionIds.size()) {
+            while (topTransactionPos < topTransactionIds.size()) {
                 // caching: if the transaction is already marked for skipping, quickly continue
-                if (transactionId < cacheNumberOfTransactions
-                    && transactionSkipList.get(cacheNumberOfTransactions * (depth - 2) + transactionId)) {
+                if (topTransactionPos < cacheNumberOfTransactions
+                    && transactionSkipList.get(cacheNumberOfTransactions * (depth - 2) + topTransactionPos)) {
                     // set the bit for the next iteration
-                    transactionSkipList.set(cacheNumberOfTransactions * (depth - 1) + transactionId);
-                    transactionId++;
+                    transactionSkipList.set(cacheNumberOfTransactions * (depth - 1) + topTransactionPos);
+                    topTransactionPos++;
                     continue;
                 }
 
-                long transactionCount = transactionStore.getTransactionCount(topTransactionIds.getItemIdAt(transactionId));
+                long transactionCount = transactionStore.getTransactionCount(topTransactionIds.getItemIdAt(topTransactionPos));
 
-                if (transactionsLookupTable.isSubsetOf(transactionId, topItemSetTraverser.getItemSetBitSet())) {
+                if (transactionsLookupTable.isSubsetOf(topTransactionPos, topItemSetTraverser.getItemSetBitSet())) {
                     occurrences += transactionCount;
-                } else if (transactionId < cacheNumberOfTransactions) {
+                } else if (topTransactionPos < cacheNumberOfTransactions) {
                     // put this transaction to the skip list
                     skipCount += transactionCount;
-                    transactionSkipList.set(cacheNumberOfTransactions * (depth - 1) + transactionId);
+                    transactionSkipList.set(cacheNumberOfTransactions * (depth - 1) + topTransactionPos);
                 }
 
                 maxReachableTransactionCount -= transactionCount;
@@ -141,7 +141,7 @@ final class CountingItemSetTraverser implements Releasable {
                     break;
                 }
 
-                transactionId++;
+                topTransactionPos++;
             }
             transactionSkipCounts[depth - 1] = skipCount;
 

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/aggs/frequentitemsets/CountingItemSetTraverser.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/aggs/frequentitemsets/CountingItemSetTraverser.java
@@ -9,14 +9,13 @@ package org.elasticsearch.xpack.ml.aggs.frequentitemsets;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.apache.lucene.util.BitSet;
-import org.apache.lucene.util.FixedBitSet;
 import org.elasticsearch.core.Releasable;
 import org.elasticsearch.core.Releasables;
 import org.elasticsearch.xpack.ml.aggs.frequentitemsets.TransactionStore.TopItemIds;
 
 import java.io.IOException;
 import java.util.Arrays;
+import java.util.BitSet;
 
 /**
  * Item set traverser to find the next interesting item set.
@@ -31,7 +30,7 @@ import java.util.Arrays;
  *      that do not pass a previous step:
  *          if [a, b] is not in T, [a, b, c] can not be in T either
  */
-class CountingItemSetTraverser implements Releasable {
+final class CountingItemSetTraverser implements Releasable {
     private static final Logger logger = LogManager.getLogger(CountingItemSetTraverser.class);
 
     // start size and size increment for the occurences stack
@@ -40,6 +39,8 @@ class CountingItemSetTraverser implements Releasable {
     private final TransactionStore transactionStore;
     private final ItemSetTraverser topItemSetTraverser;
     private final TransactionStore.TopTransactionIds topTransactionIds;
+
+    private final TransactionsLookupTable transactionsLookupTable;
     private final int cacheTraversalDepth;
     private final int cacheNumberOfTransactions;
 
@@ -49,7 +50,7 @@ class CountingItemSetTraverser implements Releasable {
 
     private long[] occurencesStack;
     // growable bit set from java util
-    private java.util.BitSet visited;
+    private BitSet visited;
 
     CountingItemSetTraverser(
         TransactionStore transactionStore,
@@ -57,7 +58,7 @@ class CountingItemSetTraverser implements Releasable {
         int cacheTraversalDepth,
         int cacheNumberOfTransactions,
         long minCount
-    ) {
+    ) throws IOException {
         this.transactionStore = transactionStore;
 
         boolean success = false;
@@ -65,6 +66,7 @@ class CountingItemSetTraverser implements Releasable {
             // we allocate 2 big arrays, if the 2nd allocation fails, ensure we clean up
             this.topItemSetTraverser = new ItemSetTraverser(topItemIds);
             this.topTransactionIds = transactionStore.getTopTransactionIds();
+            this.transactionsLookupTable = transactionStore.createLookupTableByTopTransactions(topItemIds, topTransactionIds);
             success = true;
         } finally {
             if (false == success) {
@@ -75,7 +77,7 @@ class CountingItemSetTraverser implements Releasable {
         this.cacheTraversalDepth = cacheTraversalDepth;
         this.cacheNumberOfTransactions = cacheNumberOfTransactions;
         transactionSkipCounts = new long[cacheTraversalDepth - 1];
-        transactionSkipList = new FixedBitSet((cacheTraversalDepth - 1) * cacheNumberOfTransactions);
+        transactionSkipList = new BitSet((cacheTraversalDepth - 1) * cacheNumberOfTransactions);
         occurencesStack = new long[OCCURENCES_SIZE_INCREMENT];
         visited = new java.util.BitSet();
     }
@@ -109,41 +111,41 @@ class CountingItemSetTraverser implements Releasable {
             // we recalculate the row for this depth, so we have to clear the bits first
             transactionSkipList.clear((depth - 1) * cacheNumberOfTransactions, ((depth) * cacheNumberOfTransactions));
 
-            int transactionNumber = 0;
-            long occurences = 0;
+            int transactionId = 0;
+            long occurrences = 0;
 
-            for (Long transactionId : topTransactionIds) {
+            // for whatever reason this turns out to be faster than a for loop
+            while (transactionId < topTransactionIds.size()) {
                 // caching: if the transaction is already marked for skipping, quickly continue
-                if (transactionNumber < cacheNumberOfTransactions
-                    && transactionSkipList.get(cacheNumberOfTransactions * (depth - 2) + transactionNumber)) {
+                if (transactionId < cacheNumberOfTransactions
+                    && transactionSkipList.get(cacheNumberOfTransactions * (depth - 2) + transactionId)) {
                     // set the bit for the next iteration
-                    transactionSkipList.set(cacheNumberOfTransactions * (depth - 1) + transactionNumber);
-                    transactionNumber++;
+                    transactionSkipList.set(cacheNumberOfTransactions * (depth - 1) + transactionId);
+                    transactionId++;
                     continue;
                 }
 
-                long transactionCount = transactionStore.getTransactionCount(transactionId);
+                long transactionCount = transactionStore.getTransactionCount(topTransactionIds.getItemIdAt(transactionId));
 
-                if (transactionStore.transactionContainsAllIds(topItemSetTraverser.getItemSet(), transactionId)) {
-                    occurences += transactionCount;
-                } else if (transactionNumber < cacheNumberOfTransactions) {
+                if (transactionsLookupTable.isSubsetOf(transactionId, topItemSetTraverser.getItemSetBitSet())) {
+                    occurrences += transactionCount;
+                } else if (transactionId < cacheNumberOfTransactions) {
                     // put this transaction to the skip list
                     skipCount += transactionCount;
-                    transactionSkipList.set(cacheNumberOfTransactions * (depth - 1) + transactionNumber);
+                    transactionSkipList.set(cacheNumberOfTransactions * (depth - 1) + transactionId);
                 }
 
                 maxReachableTransactionCount -= transactionCount;
                 // exit early if min support given for early stop can't be reached
-                if (maxReachableTransactionCount + occurences < earlyStopMinCount) {
+                if (maxReachableTransactionCount + occurrences < earlyStopMinCount) {
                     break;
                 }
 
-                transactionNumber++;
+                transactionId++;
             }
-
             transactionSkipCounts[depth - 1] = skipCount;
 
-            rememberCountInStack(depth, occurences);
+            rememberCountInStack(depth, occurrences);
             return true;
         }
 
@@ -158,7 +160,7 @@ class CountingItemSetTraverser implements Releasable {
         long maxReachableTransactionCount = totalTransactionCount - skipCount;
 
         int transactionNumber = 0;
-        long occurences = 0;
+        long occurrences = 0;
         for (Long transactionId : topTransactionIds) {
             // caching: if the transaction is already marked for skipping, quickly continue
             if (transactionNumber < cacheNumberOfTransactions
@@ -169,21 +171,21 @@ class CountingItemSetTraverser implements Releasable {
             }
             long transactionCount = transactionStore.getTransactionCount(transactionId);
 
-            if (transactionStore.transactionContainsAllIds(topItemSetTraverser.getItemSet(), transactionId)) {
-                occurences += transactionCount;
+            if (transactionsLookupTable.isSubsetOf(transactionNumber, topItemSetTraverser.getItemSetBitSet())) {
+                occurrences += transactionCount;
             }
 
             maxReachableTransactionCount -= transactionCount;
 
             // exit early if min support given for early stop can't be reached
-            if (maxReachableTransactionCount + occurences < earlyStopMinCount) {
+            if (maxReachableTransactionCount + occurrences < earlyStopMinCount) {
                 break;
             }
 
             transactionNumber++;
         }
 
-        rememberCountInStack(depth, occurences);
+        rememberCountInStack(depth, occurrences);
         return true;
     }
 
@@ -268,7 +270,7 @@ class CountingItemSetTraverser implements Releasable {
 
     @Override
     public void close() {
-        Releasables.close(topTransactionIds);
+        Releasables.close(topTransactionIds, transactionsLookupTable);
     }
 
     // remember the count in the stack without tracking push and pop

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/aggs/frequentitemsets/ItemSetBitSet.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/aggs/frequentitemsets/ItemSetBitSet.java
@@ -32,8 +32,9 @@ class ItemSetBitSet implements Cloneable {
     /* Used to shift left or right for a partial word mask */
     private static final long WORD_MASK = 0xffffffffffffffffL;
 
-    private long[] words;
-    private transient int wordsInUse = 0;
+    // allow direct access for transaction lookup table
+    long[] words;
+    transient int wordsInUse = 0;
     private int cardinality = 0;
 
     ItemSetBitSet() {
@@ -88,6 +89,13 @@ class ItemSetBitSet implements Cloneable {
             cardinality--;
         }
         recalculateWordsInUse();
+    }
+
+    public void clear() {
+        while (wordsInUse > 0) {
+            words[--wordsInUse] = 0;
+        }
+        cardinality = 0;
     }
 
     /**

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/aggs/frequentitemsets/TransactionStore.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/aggs/frequentitemsets/TransactionStore.java
@@ -15,6 +15,7 @@ import org.elasticsearch.common.io.stream.ByteArrayStreamInput;
 import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.common.util.BytesRefArray;
+import org.elasticsearch.common.util.IntArray;
 import org.elasticsearch.common.util.LongArray;
 import org.elasticsearch.core.Releasable;
 import org.elasticsearch.core.Releasables;
@@ -136,6 +137,10 @@ abstract class TransactionStore implements Writeable, Releasable, Accountable {
 
         public long size() {
             return sortedTransactions.size();
+        }
+
+        public long getItemIdAt(long index) {
+            return sortedTransactions.get(index);
         }
 
         @Override
@@ -348,6 +353,45 @@ abstract class TransactionStore implements Writeable, Releasable, Accountable {
      */
     public TopItemIds getTopItemIds() {
         return getTopItemIds(getItems().size());
+    }
+
+    /**
+     * Create a lookup table (bit matrix) containing a so-called "horizontal" representation of transactions to item ids.
+     *
+     * A bit is set according to the position in topItems, if a transaction contains an item the bit is set.
+     * The lookup table rows correspond to the order in top transactions.
+     *
+     * @param topItems the top items
+     * @param topTransactions the top transactions
+     * @return a transaction lookup table
+     * @throws IOException
+     */
+    public TransactionsLookupTable createLookupTableByTopTransactions(TopItemIds topItems, TopTransactionIds topTransactions)
+        throws IOException {
+        try (IntArray positions = bigArrays.newIntArray(topItems.size())) {
+
+            // helper lookup table that maps an item id to the position in the top items vector
+            for (int i = 0; i < topItems.size(); ++i) {
+                positions.set(topItems.getItemIdAt(i), i);
+            }
+
+            BytesRefArray transactions = getTransactions();
+            TransactionsLookupTable lookupTable = new TransactionsLookupTable(transactions.size(), bigArrays);
+            ItemSetBitSet bitSet = new ItemSetBitSet();
+
+            for (Long id : topTransactions) {
+                bitSet.clear();
+                transactions.get(id, scratchBytesRef);
+                scratchByteArrayStreamInput.reset(scratchBytesRef.bytes, scratchBytesRef.offset, scratchBytesRef.length);
+
+                while (scratchByteArrayStreamInput.available() > 0) {
+                    // flip the bit according to the position in top items
+                    bitSet.set(1 + positions.get(scratchByteArrayStreamInput.readVLong()));
+                }
+                lookupTable.append(bitSet);
+            }
+            return lookupTable;
+        }
     }
 
     /**

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/aggs/frequentitemsets/TransactionsLookupTable.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/aggs/frequentitemsets/TransactionsLookupTable.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.ml.aggs.frequentitemsets;
+
+import org.apache.lucene.util.Accountable;
+import org.apache.lucene.util.RamUsageEstimator;
+import org.elasticsearch.common.util.BigArrays;
+import org.elasticsearch.common.util.LongArray;
+import org.elasticsearch.core.Releasable;
+import org.elasticsearch.core.Releasables;
+
+/**
+ * Lookup table to represent transactions as bit sets.
+ */
+public class TransactionsLookupTable implements Accountable, Releasable {
+
+    private static final long BASE_RAM_BYTES_USED = RamUsageEstimator.shallowSizeOfInstance(TransactionsLookupTable.class);
+
+    private final BigArrays bigArrays;
+    private LongArray startOffsets;
+    private LongArray longs;
+    private long size;
+
+    public TransactionsLookupTable(long capacity, BigArrays bigArrays) {
+        this.bigArrays = bigArrays;
+        boolean success = false;
+        try {
+            startOffsets = bigArrays.newLongArray(capacity + 1, false);
+            startOffsets.set(0, 0);
+            longs = bigArrays.newLongArray(capacity * 3, false);
+            success = true;
+        } finally {
+            if (false == success) {
+                close();
+            }
+        }
+        size = 0;
+    }
+
+    public void append(ItemSetBitSet itemSetBitSet) {
+        final long startOffset = startOffsets.get(size);
+        longs = bigArrays.grow(longs, startOffset + itemSetBitSet.wordsInUse);
+        for (int i = 0; i < itemSetBitSet.wordsInUse; ++i) {
+            longs.set(startOffset + i, itemSetBitSet.words[i]);
+        }
+        startOffsets = bigArrays.grow(startOffsets, size + 2);
+        startOffsets.set(size + 1, startOffset + itemSetBitSet.wordsInUse);
+        ++size;
+    }
+
+    boolean isSubsetOf(long row, ItemSetBitSet set) {
+        final long startOffset = startOffsets.get(row);
+        final int wordsInUse = (int) (startOffsets.get(row + 1) - startOffset);
+
+        if (set.wordsInUse > wordsInUse) {
+            return false;
+        }
+
+        for (int i = set.wordsInUse - 1; i >= 0; i--) {
+            final long word = longs.get(startOffset + i);
+            if ((word & set.words[i]) != set.words[i]) return false;
+        }
+
+        return true;
+    }
+
+    public long size() {
+        return size;
+    }
+
+    @Override
+    public void close() {
+        Releasables.close(longs, startOffsets);
+    }
+
+    @Override
+    public long ramBytesUsed() {
+        return BASE_RAM_BYTES_USED + startOffsets.ramBytesUsed() + longs.ramBytesUsed();
+    }
+}

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/aggs/frequentitemsets/ItemSetBitSetTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/aggs/frequentitemsets/ItemSetBitSetTests.java
@@ -171,6 +171,13 @@ public class ItemSetBitSetTests extends ESTestCase {
         set.reset(set2);
         assertEquals(0, set.cardinality());
         set.clear(999);
+
+        set.set(54);
+        set.set(20);
+        assertEquals(2, set.cardinality());
+
+        set.clear();
+        assertEquals(0, set.cardinality());
     }
 
     public void testHashCode() {

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/aggs/frequentitemsets/TransactionLookupTableTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/aggs/frequentitemsets/TransactionLookupTableTests.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.ml.aggs.frequentitemsets;
+
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.util.BigArrays;
+import org.elasticsearch.common.util.MockBigArrays;
+import org.elasticsearch.common.util.MockPageCacheRecycler;
+import org.elasticsearch.indices.breaker.NoneCircuitBreakerService;
+import org.elasticsearch.test.ESTestCase;
+
+public class TransactionLookupTableTests extends ESTestCase {
+
+    static BigArrays mockBigArrays() {
+        return new MockBigArrays(new MockPageCacheRecycler(Settings.EMPTY), new NoneCircuitBreakerService());
+    }
+
+    public void testBasic() {
+        try (TransactionsLookupTable transactions = new TransactionsLookupTable(10, mockBigArrays())) {
+
+            // setup 3 transactions
+            ItemSetBitSet set = new ItemSetBitSet();
+            set.set(0);
+            set.set(3);
+            set.set(200);
+            set.set(5);
+            set.set(65);
+            transactions.append(set);
+            set.clear();
+            set.set(2);
+            set.set(33);
+            set.set(44);
+            transactions.append(set);
+            assertEquals(2, transactions.size());
+            set.clear();
+            set.set(3);
+            set.set(5);
+            set.set(65);
+            set.set(99);
+            transactions.append(set);
+            assertEquals(3, transactions.size());
+
+            // lookup
+            set.clear();
+            set.set(3);
+            set.set(65);
+            assertTrue(transactions.isSubsetOf(0, set));
+            assertFalse(transactions.isSubsetOf(1, set));
+            assertTrue(transactions.isSubsetOf(2, set));
+
+            set.set(64);
+            assertFalse(transactions.isSubsetOf(0, set));
+            assertFalse(transactions.isSubsetOf(1, set));
+            assertFalse(transactions.isSubsetOf(2, set));
+            set.clear(64);
+
+            set.set(258);
+            assertFalse(transactions.isSubsetOf(0, set));
+            assertFalse(transactions.isSubsetOf(1, set));
+            assertFalse(transactions.isSubsetOf(2, set));
+            set.clear(258);
+
+            set.set(400);
+            assertFalse(transactions.isSubsetOf(0, set));
+            assertFalse(transactions.isSubsetOf(1, set));
+            assertFalse(transactions.isSubsetOf(2, set));
+            set.clear(400);
+
+            set.set(99);
+            assertFalse(transactions.isSubsetOf(0, set));
+            assertFalse(transactions.isSubsetOf(1, set));
+            assertTrue(transactions.isSubsetOf(2, set));
+        }
+    }
+
+}


### PR DESCRIPTION
represent transactions as bitsets for faster lookups when iterating over candidate sets. This PR implements a lookup table and
a subset check based on bits. It uses this lookup table to map transactions to items, this so-called horizontal representation is used to speedup the lookup that checks if a transaction contains the candidate item set

![Screenshot_20220803_105849](https://user-images.githubusercontent.com/7126422/182568330-fcf52b42-d727-4e7d-8096-5048002f2eae.png)


Follow up:

The lookup table is kept generic to explore other usages. The next step is to explore if a vertical representation - a lookup table that maps items to transactions - executes faster (a vertical representation is used by fp-growth and other eclat implementations):

- requires some rewrite of the lookup code in `CountingItemSetTraverser`
  - might make the cache there unnecessary (the vertical representation is basically a cache already)
- requires further bit logic (intersection) in the lookup table
- explore usage of skipping via `nextClearBit`/`nextSetBit` to shortcut some loops

relates #88943