### PR TITLE
[8.4][ML] Previously assigned models should get at least one allocati…

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/assignment/TrainedModelAssignment.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/assignment/TrainedModelAssignment.java
@@ -9,6 +9,7 @@ package org.elasticsearch.xpack.core.ml.inference.assignment;
 
 import org.elasticsearch.ResourceAlreadyExistsException;
 import org.elasticsearch.ResourceNotFoundException;
+import org.elasticsearch.Version;
 import org.elasticsearch.cluster.SimpleDiffable;
 import org.elasticsearch.common.Randomness;
 import org.elasticsearch.common.io.stream.StreamInput;
@@ -48,6 +49,7 @@ public class TrainedModelAssignment implements SimpleDiffable<TrainedModelAssign
     private static final ParseField ROUTING_TABLE = new ParseField("routing_table");
     private static final ParseField TASK_PARAMETERS = new ParseField("task_parameters");
     private static final ParseField START_TIME = new ParseField("start_time");
+    private static final ParseField MAX_ASSIGNED_ALLOCATIONS = new ParseField("max_assigned_allocations");
 
     @SuppressWarnings("unchecked")
     private static final ConstructingObjectParser<TrainedModelAssignment, Void> PARSER = new ConstructingObjectParser<>(
@@ -59,7 +61,8 @@ public class TrainedModelAssignment implements SimpleDiffable<TrainedModelAssign
             a[2] == null ? null : AssignmentState.fromString((String) a[2]),
             a[3] == null ? null : AssignmentState.fromString((String) a[3]),
             (String) a[4],
-            (Instant) a[5]
+            (Instant) a[5],
+            (Integer) a[6]
         )
     );
     static {
@@ -82,6 +85,7 @@ public class TrainedModelAssignment implements SimpleDiffable<TrainedModelAssign
             START_TIME,
             ObjectParser.ValueType.VALUE
         );
+        PARSER.declareInt(ConstructingObjectParser.optionalConstructorArg(), MAX_ASSIGNED_ALLOCATIONS);
     }
 
     private final StartTrainedModelDeploymentAction.TaskParams taskParams;
@@ -89,6 +93,7 @@ public class TrainedModelAssignment implements SimpleDiffable<TrainedModelAssign
     private final AssignmentState assignmentState;
     private final String reason;
     private final Instant startTime;
+    private final int maxAssignedAllocations;
 
     public static TrainedModelAssignment fromXContent(XContentParser parser) throws IOException {
         return PARSER.apply(parser, null);
@@ -100,9 +105,17 @@ public class TrainedModelAssignment implements SimpleDiffable<TrainedModelAssign
         AssignmentState assignmentState,
         AssignmentState legacyAssignmentState,
         String reason,
-        Instant startTime
+        Instant startTime,
+        Integer maxAssignedAllocations
     ) {
-        this(taskParams, nodeRoutingTable, Optional.ofNullable(assignmentState).orElse(legacyAssignmentState), reason, startTime);
+        this(
+            taskParams,
+            nodeRoutingTable,
+            Optional.ofNullable(assignmentState).orElse(legacyAssignmentState),
+            reason,
+            startTime,
+            maxAssignedAllocations
+        );
     }
 
     TrainedModelAssignment(
@@ -110,13 +123,17 @@ public class TrainedModelAssignment implements SimpleDiffable<TrainedModelAssign
         Map<String, RoutingInfo> nodeRoutingTable,
         AssignmentState assignmentState,
         String reason,
-        Instant startTime
+        Instant startTime,
+        Integer maxAssignedAllocations
     ) {
         this.taskParams = ExceptionsHelper.requireNonNull(taskParams, TASK_PARAMETERS);
         this.nodeRoutingTable = ExceptionsHelper.requireNonNull(nodeRoutingTable, ROUTING_TABLE);
         this.assignmentState = ExceptionsHelper.requireNonNull(assignmentState, ASSIGNMENT_STATE);
         this.reason = reason;
         this.startTime = ExceptionsHelper.requireNonNull(startTime, START_TIME);
+        this.maxAssignedAllocations = maxAssignedAllocations == null
+            ? totalCurrentAllocations()
+            : Math.max(maxAssignedAllocations, totalCurrentAllocations());
     }
 
     public TrainedModelAssignment(StreamInput in) throws IOException {
@@ -125,6 +142,11 @@ public class TrainedModelAssignment implements SimpleDiffable<TrainedModelAssign
         this.assignmentState = in.readEnum(AssignmentState.class);
         this.reason = in.readOptionalString();
         this.startTime = in.readInstant();
+        if (in.getVersion().onOrAfter(Version.V_8_4_0)) {
+            this.maxAssignedAllocations = in.readVInt();
+        } else {
+            this.maxAssignedAllocations = totalCurrentAllocations();
+        }
     }
 
     public boolean isRoutedToNode(String nodeId) {
@@ -189,6 +211,10 @@ public class TrainedModelAssignment implements SimpleDiffable<TrainedModelAssign
         return startTime;
     }
 
+    public int getMaxAssignedAllocations() {
+        return maxAssignedAllocations;
+    }
+
     public boolean isSatisfied(Set<String> assignableNodeIds) {
         int allocations = nodeRoutingTable.entrySet()
             .stream()
@@ -203,6 +229,10 @@ public class TrainedModelAssignment implements SimpleDiffable<TrainedModelAssign
         return nodeRoutingTable.values().stream().anyMatch(RoutingInfo::isOutdated);
     }
 
+    public int totalCurrentAllocations() {
+        return nodeRoutingTable.values().stream().mapToInt(RoutingInfo::getCurrentAllocations).sum();
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
@@ -212,12 +242,13 @@ public class TrainedModelAssignment implements SimpleDiffable<TrainedModelAssign
             && Objects.equals(taskParams, that.taskParams)
             && Objects.equals(reason, that.reason)
             && Objects.equals(assignmentState, that.assignmentState)
-            && Objects.equals(startTime, that.startTime);
+            && Objects.equals(startTime, that.startTime)
+            && maxAssignedAllocations == that.maxAssignedAllocations;
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(nodeRoutingTable, taskParams, assignmentState, reason, startTime);
+        return Objects.hash(nodeRoutingTable, taskParams, assignmentState, reason, startTime, maxAssignedAllocations);
     }
 
     @Override
@@ -230,6 +261,7 @@ public class TrainedModelAssignment implements SimpleDiffable<TrainedModelAssign
             builder.field(REASON.getPreferredName(), reason);
         }
         builder.timeField(START_TIME.getPreferredName(), startTime);
+        builder.field(MAX_ASSIGNED_ALLOCATIONS.getPreferredName(), maxAssignedAllocations);
         builder.endObject();
         return builder;
     }
@@ -241,6 +273,9 @@ public class TrainedModelAssignment implements SimpleDiffable<TrainedModelAssign
         out.writeEnum(assignmentState);
         out.writeOptionalString(reason);
         out.writeInstant(startTime);
+        if (out.getVersion().onOrAfter(Version.V_8_4_0)) {
+            out.writeVInt(maxAssignedAllocations);
+        }
     }
 
     public Optional<AllocationStatus> calculateAllocationStatus() {
@@ -261,6 +296,7 @@ public class TrainedModelAssignment implements SimpleDiffable<TrainedModelAssign
         private AssignmentState assignmentState;
         private String reason;
         private Instant startTime;
+        private int maxAssignedAllocations;
 
         public static Builder fromAssignment(TrainedModelAssignment assignment) {
             return new Builder(
@@ -268,7 +304,8 @@ public class TrainedModelAssignment implements SimpleDiffable<TrainedModelAssign
                 assignment.nodeRoutingTable,
                 assignment.assignmentState,
                 assignment.reason,
-                assignment.startTime
+                assignment.startTime,
+                assignment.maxAssignedAllocations
             );
         }
 
@@ -281,21 +318,28 @@ public class TrainedModelAssignment implements SimpleDiffable<TrainedModelAssign
             Map<String, RoutingInfo> nodeRoutingTable,
             AssignmentState assignmentState,
             String reason,
-            Instant startTime
+            Instant startTime,
+            int maxAssignedAllocations
         ) {
             this.taskParams = taskParams;
             this.nodeRoutingTable = new LinkedHashMap<>(nodeRoutingTable);
             this.assignmentState = assignmentState;
             this.reason = reason;
             this.startTime = startTime;
+            this.maxAssignedAllocations = maxAssignedAllocations;
         }
 
         private Builder(StartTrainedModelDeploymentAction.TaskParams taskParams) {
-            this(taskParams, new LinkedHashMap<>(), AssignmentState.STARTING, null, Instant.now());
+            this(taskParams, new LinkedHashMap<>(), AssignmentState.STARTING, null, Instant.now(), 0);
         }
 
         public Builder setStartTime(Instant startTime) {
             this.startTime = startTime;
+            return this;
+        }
+
+        public Builder setMaxAssignedAllocations(int maxAssignedAllocations) {
+            this.maxAssignedAllocations = maxAssignedAllocations;
             return this;
         }
 
@@ -383,7 +427,7 @@ public class TrainedModelAssignment implements SimpleDiffable<TrainedModelAssign
         }
 
         public TrainedModelAssignment build() {
-            return new TrainedModelAssignment(taskParams, nodeRoutingTable, assignmentState, reason, startTime);
+            return new TrainedModelAssignment(taskParams, nodeRoutingTable, assignmentState, reason, startTime, maxAssignedAllocations);
         }
     }
 }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/assignment/TrainedModelAssignmentTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/assignment/TrainedModelAssignmentTests.java
@@ -257,6 +257,21 @@ public class TrainedModelAssignmentTests extends AbstractSerializingTestCase<Tra
         assertThat(assignment.isSatisfied(Sets.newHashSet("node-1", "node-2", "node-3")), is(false));
     }
 
+    public void testMaxAssignedAllocations() {
+        TrainedModelAssignment assignment = TrainedModelAssignment.Builder.empty(randomTaskParams(10))
+            .addRoutingEntry("node-1", new RoutingInfo(1, 2, RoutingState.STARTED, ""))
+            .addRoutingEntry("node-2", new RoutingInfo(2, 1, RoutingState.STARTED, ""))
+            .addRoutingEntry("node-3", new RoutingInfo(3, 3, RoutingState.STARTING, ""))
+            .build();
+        assertThat(assignment.getMaxAssignedAllocations(), equalTo(6));
+
+        TrainedModelAssignment assignmentAfterRemovingNode = TrainedModelAssignment.Builder.fromAssignment(assignment)
+            .removeRoutingEntry("node-1")
+            .build();
+        assertThat(assignmentAfterRemovingNode.getMaxAssignedAllocations(), equalTo(6));
+        assertThat(assignmentAfterRemovingNode.totalCurrentAllocations(), equalTo(5));
+    }
+
     private void assertValueWithinPercentageOfExpectedRatio(long value, long totalCount, double ratio, double tolerance) {
         double expected = totalCount * ratio;
         double lowerBound = (1.0 - tolerance) * expected;

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/assignment/TrainedModelAssignmentRebalancer.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/assignment/TrainedModelAssignmentRebalancer.java
@@ -111,7 +111,8 @@ class TrainedModelAssignmentRebalancer {
                 assignment.getTaskParams().estimateMemoryUsageBytes(),
                 assignment.getTaskParams().getNumberOfAllocations(),
                 assignment.getTaskParams().getThreadsPerAllocation(),
-                currentAssignments
+                currentAssignments,
+                assignment.getMaxAssignedAllocations()
             );
         }).forEach(planModels::add);
         modelToAdd.ifPresent(
@@ -121,7 +122,8 @@ class TrainedModelAssignmentRebalancer {
                     taskParams.estimateMemoryUsageBytes(),
                     taskParams.getNumberOfAllocations(),
                     taskParams.getThreadsPerAllocation(),
-                    Map.of()
+                    Map.of(),
+                    0
                 )
             )
         );
@@ -157,6 +159,7 @@ class TrainedModelAssignmentRebalancer {
             );
             if (existingAssignment != null) {
                 assignmentBuilder.setStartTime(existingAssignment.getStartTime());
+                assignmentBuilder.setMaxAssignedAllocations(existingAssignment.getMaxAssignedAllocations());
             }
 
             Map<AssignmentPlan.Node, Integer> assignments = assignmentPlan.assignments(model).orElseGet(Map::of);

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/assignment/planning/AbstractPreserveAllocations.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/assignment/planning/AbstractPreserveAllocations.java
@@ -57,7 +57,8 @@ abstract class AbstractPreserveAllocations {
             m.memoryBytes(),
             m.allocations() - calculatePreservedAllocations(m),
             m.threadsPerAllocation(),
-            calculateAllocationsPerNodeToPreserve(m)
+            calculateAllocationsPerNodeToPreserve(m),
+            m.maxAssignedAllocations()
         );
     }
 

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/assignment/planning/AssignmentPlanner.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/assignment/planning/AssignmentPlanner.java
@@ -14,7 +14,11 @@ import org.elasticsearch.xpack.ml.inference.assignment.planning.AssignmentPlan.M
 import org.elasticsearch.xpack.ml.inference.assignment.planning.AssignmentPlan.Node;
 
 import java.util.Comparator;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
 
 import static org.elasticsearch.core.Strings.format;
 
@@ -34,6 +38,9 @@ import static org.elasticsearch.core.Strings.format;
  * Furthermore, the planner preserves at least one allocation for all existing
  * assignments. This way, the new plan will only have new assignments and the
  * transition can happen with minimal impact on performance of started deployments.
+ * However, if previously assigned models do not receive any allocation, then we
+ * attempt to find a solution that provides at least one allocation to
+ * previously assigned models.
  */
 public class AssignmentPlanner {
 
@@ -48,44 +55,122 @@ public class AssignmentPlanner {
     }
 
     public AssignmentPlan computePlan() {
+        return computePlan(true);
+    }
+
+    private AssignmentPlan computePlan(boolean tryAssigningPreviouslyAssignedModels) {
         logger.debug(() -> format("Computing plan for nodes = %s; models = %s", nodes, models));
 
         AssignmentPlan bestPlan;
-        // First solve preserving one allocation per assignment because that is most flexible
-        AssignmentPlan planKeepingOneAllocationOnPreviousAssignments = solveKeepingOneAllocationOnPreviousAssignments();
-        if (planKeepingOneAllocationOnPreviousAssignments.satisfiesPreviousAssignments() == false) {
-            bestPlan = solvePreservingAllPreviousAssignments();
-        } else if (planKeepingOneAllocationOnPreviousAssignments.satisfiesAllModels() == false) {
-            AssignmentPlan planKeepingAllAllocationsOnPreviousAssignments = solvePreservingAllPreviousAssignments();
-            bestPlan = planKeepingAllAllocationsOnPreviousAssignments.compareTo(planKeepingOneAllocationOnPreviousAssignments) >= 0
-                ? planKeepingAllAllocationsOnPreviousAssignments
-                : planKeepingOneAllocationOnPreviousAssignments;
+        AssignmentPlan planSatisfyingCurrentAssignments = solveSatisfyingCurrentAssignments();
+        logger.debug(() -> "Plan satisfying current assignments =\n" + planSatisfyingCurrentAssignments.prettyPrint());
+        if (planSatisfyingCurrentAssignments.arePreviouslyAssignedModelsAssigned() == false && tryAssigningPreviouslyAssignedModels) {
+            AssignmentPlan planAllocatingAtLeastOnceModelsThatWerePreviouslyAllocated =
+                solveAllocatingAtLeastOnceModelsThatWerePreviouslyAllocated();
+            logger.debug(
+                () -> "Plan with at least one allocation for previously assigned models =\n"
+                    + planAllocatingAtLeastOnceModelsThatWerePreviouslyAllocated.prettyPrint()
+            );
+            if (planAllocatingAtLeastOnceModelsThatWerePreviouslyAllocated.arePreviouslyAssignedModelsAssigned()) {
+                bestPlan = planAllocatingAtLeastOnceModelsThatWerePreviouslyAllocated;
+            } else {
+                bestPlan = planSatisfyingCurrentAssignments
+                    .countPreviouslyAssignedModelsThatAreStillAssigned() >= planAllocatingAtLeastOnceModelsThatWerePreviouslyAllocated
+                        .countPreviouslyAssignedModelsThatAreStillAssigned()
+                            ? planSatisfyingCurrentAssignments
+                            : planAllocatingAtLeastOnceModelsThatWerePreviouslyAllocated;
+            }
         } else {
-            bestPlan = planKeepingOneAllocationOnPreviousAssignments;
+            bestPlan = planSatisfyingCurrentAssignments;
         }
+
         logger.debug(() -> "Best plan =\n" + bestPlan.prettyPrint());
         logger.debug(() -> prettyPrintOverallStats(bestPlan));
         return bestPlan;
     }
 
-    private AssignmentPlan solveKeepingOneAllocationOnPreviousAssignments() {
+    private AssignmentPlan solveSatisfyingCurrentAssignments() {
+        AssignmentPlan bestPlan;
+        // First solve preserving one allocation per assignment because that is most flexible
+        AssignmentPlan planKeepingOneAllocationOnCurrentAssignments = solveKeepingOneAllocationOnCurrentAssignments();
+        if (planKeepingOneAllocationOnCurrentAssignments.satisfiesCurrentAssignments() == false) {
+            bestPlan = solvePreservingAllAllocationsOnCurrentAssignments();
+        } else if (planKeepingOneAllocationOnCurrentAssignments.satisfiesAllModels() == false) {
+            AssignmentPlan planKeepingAllAllocationsOnCurrentAssignments = solvePreservingAllAllocationsOnCurrentAssignments();
+            bestPlan = planKeepingAllAllocationsOnCurrentAssignments.compareTo(planKeepingOneAllocationOnCurrentAssignments) >= 0
+                ? planKeepingAllAllocationsOnCurrentAssignments
+                : planKeepingOneAllocationOnCurrentAssignments;
+        } else {
+            bestPlan = planKeepingOneAllocationOnCurrentAssignments;
+        }
+        return bestPlan;
+    }
+
+    private AssignmentPlan solveAllocatingAtLeastOnceModelsThatWerePreviouslyAllocated() {
+        logger.debug(() -> "Attempting to solve assigning at least one allocations to previously assigned models");
+        List<Model> previouslyAssignedModelsOnly = models.stream()
+            .filter(m -> m.hasEverBeenAllocated())
+            .map(
+                m -> new Model(
+                    m.id(),
+                    m.memoryBytes(),
+                    1,
+                    m.threadsPerAllocation(),
+                    m.currentAllocationsByNodeId(),
+                    m.maxAssignedAllocations()
+                )
+            )
+            .toList();
+        AssignmentPlan planWithSingleAllocationForPreviouslyAssignedModels = new LinearProgrammingPlanSolver(
+            nodes,
+            previouslyAssignedModelsOnly
+        ).solvePlan(true);
+
+        Map<String, String> modelIdToNodeIdWithSingleAllocation = new HashMap<>();
+        for (Model m : planWithSingleAllocationForPreviouslyAssignedModels.models()) {
+            Optional<Map<Node, Integer>> assignments = planWithSingleAllocationForPreviouslyAssignedModels.assignments(m);
+            Set<Node> nodes = assignments.orElse(Map.of()).keySet();
+            if (nodes.isEmpty() == false) {
+                assert nodes.size() == 1;
+                modelIdToNodeIdWithSingleAllocation.put(m.id(), nodes.iterator().next().id());
+            }
+        }
+
+        List<Model> planModels = models.stream().map(m -> {
+            Map<String, Integer> currentAllocationsByNodeId = modelIdToNodeIdWithSingleAllocation.containsKey(m.id())
+                ? Map.of(modelIdToNodeIdWithSingleAllocation.get(m.id()), 1)
+                : Map.of();
+            return new Model(
+                m.id(),
+                m.memoryBytes(),
+                m.allocations(),
+                m.threadsPerAllocation(),
+                currentAllocationsByNodeId,
+                m.maxAssignedAllocations()
+            );
+        }).toList();
+
+        return new AssignmentPlanner(nodes, planModels).computePlan(false);
+    }
+
+    private AssignmentPlan solveKeepingOneAllocationOnCurrentAssignments() {
         // We do not want to ever completely unassign a model from a node so we
         // can move allocations without having temporary impact on performance.
-        logger.trace(() -> format("Solving preserving one allocation on previous assignments"));
-        return solvePreservingPreviousAssignments(new PreserveOneAllocation(nodes, models));
+        logger.trace(() -> format("Solving preserving one allocation on current assignments"));
+        return solvePreservingCurrentAssignments(new PreserveOneAllocation(nodes, models));
     }
 
-    private AssignmentPlan solvePreservingAllPreviousAssignments() {
-        logger.trace(() -> format("Solving preserving all allocations on previous assignments"));
-        return solvePreservingPreviousAssignments(new PreserveAllAllocations(nodes, models));
+    private AssignmentPlan solvePreservingAllAllocationsOnCurrentAssignments() {
+        logger.trace(() -> format("Solving preserving all allocations on current assignments"));
+        return solvePreservingCurrentAssignments(new PreserveAllAllocations(nodes, models));
     }
 
-    private AssignmentPlan solvePreservingPreviousAssignments(AbstractPreserveAllocations preserveAllocations) {
+    private AssignmentPlan solvePreservingCurrentAssignments(AbstractPreserveAllocations preserveAllocations) {
         List<Node> planNodes = preserveAllocations.nodesPreservingAllocations();
         List<Model> planModels = preserveAllocations.modelsPreservingAllocations();
         logger.trace(() -> format("Nodes after applying allocation preserving strategy = %s", planNodes));
         logger.trace(() -> format("Models after applying allocation preserving strategy = %s", planModels));
-        AssignmentPlan assignmentPlan = new LinearProgrammingPlanSolver(planNodes, planModels).solvePlan();
+        AssignmentPlan assignmentPlan = new LinearProgrammingPlanSolver(planNodes, planModels).solvePlan(false);
         return preserveAllocations.mergePreservedAllocations(assignmentPlan);
     }
 

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/assignment/TrainedModelAssignmentRebalancerTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/assignment/TrainedModelAssignmentRebalancerTests.java
@@ -418,7 +418,7 @@ public class TrainedModelAssignmentRebalancerTests extends ESTestCase {
             assertThat(assignment.getNodeRoutingTable(), is(aMapWithSize(1)));
             assertThat(assignment.getNodeRoutingTable(), hasKey("node-1"));
             assertThat(assignment.getNodeRoutingTable().get("node-1").getCurrentAllocations(), equalTo(2));
-            assertThat(assignment.getNodeRoutingTable().get("node-1").getTargetAllocations(), equalTo(2));
+            assertThat(assignment.getNodeRoutingTable().get("node-1").getTargetAllocations(), equalTo(1));
             assertThat(assignment.getNodeRoutingTable().get("node-1").getState(), equalTo(RoutingState.STARTED));
             assertThat(assignment.getReason().isPresent(), is(true));
             assertThat(
@@ -433,7 +433,11 @@ public class TrainedModelAssignmentRebalancerTests extends ESTestCase {
             TrainedModelAssignment assignment = result.getModelAssignment(previousModel2Id);
             assertThat(assignment, is(notNullValue()));
             assertThat(assignment.getAssignmentState(), equalTo(AssignmentState.STARTING));
-            assertThat(assignment.getNodeRoutingTable(), is(anEmptyMap()));
+            assertThat(assignment.getNodeRoutingTable(), is(aMapWithSize(1)));
+            assertThat(assignment.getNodeRoutingTable(), hasKey("node-1"));
+            assertThat(assignment.getNodeRoutingTable().get("node-1").getCurrentAllocations(), equalTo(2));
+            assertThat(assignment.getNodeRoutingTable().get("node-1").getTargetAllocations(), equalTo(2));
+            assertThat(assignment.getNodeRoutingTable().get("node-1").getState(), equalTo(RoutingState.STARTING));
             assertThat(assignment.getReason().isPresent(), is(true));
             assertThat(
                 assignment.getReason().get(),

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/assignment/planning/AssignmentPlanTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/assignment/planning/AssignmentPlanTests.java
@@ -24,21 +24,21 @@ public class AssignmentPlanTests extends ESTestCase {
 
     public void testBuilderCtor_GivenDuplicateNode() {
         Node n = new Node("n_1", 100, 4);
-        Model m = new Model("m_1", 40, 1, 2, Map.of());
+        Model m = new Model("m_1", 40, 1, 2, Map.of(), 0);
 
         expectThrows(IllegalArgumentException.class, () -> AssignmentPlan.builder(List.of(n, n), List.of(m)));
     }
 
     public void testBuilderCtor_GivenDuplicateModel() {
         Node n = new Node("n_1", 100, 4);
-        Model m = new Model("m_1", 40, 1, 2, Map.of());
+        Model m = new Model("m_1", 40, 1, 2, Map.of(), 0);
 
         expectThrows(IllegalArgumentException.class, () -> AssignmentPlan.builder(List.of(n), List.of(m, m)));
     }
 
     public void testAssignModelToNode_GivenNoPreviousAssignment() {
         Node n = new Node("n_1", 100, 4);
-        Model m = new Model("m_1", 40, 1, 2, Map.of());
+        Model m = new Model("m_1", 40, 1, 2, Map.of(), 0);
 
         AssignmentPlan.Builder builder = AssignmentPlan.builder(List.of(n), List.of(m));
 
@@ -57,13 +57,13 @@ public class AssignmentPlanTests extends ESTestCase {
         AssignmentPlan plan = builder.build();
 
         assertThat(plan.models(), contains(m));
-        assertThat(plan.satisfiesPreviousAssignments(), is(true));
+        assertThat(plan.satisfiesCurrentAssignments(), is(true));
         assertThat(plan.assignments(m).get(), equalTo(Map.of(n, 1)));
     }
 
-    public void testAssignModelToNode_GivenNewPlanSatisfiesPreviousAssignment() {
+    public void testAssignModelToNode_GivenNewPlanSatisfiesCurrentAssignment() {
         Node n = new Node("n_1", 100, 4);
-        Model m = new Model("m_1", 40, 2, 2, Map.of("n_1", 1));
+        Model m = new Model("m_1", 40, 2, 2, Map.of("n_1", 1), 0);
 
         AssignmentPlan.Builder builder = AssignmentPlan.builder(List.of(n), List.of(m));
 
@@ -77,13 +77,13 @@ public class AssignmentPlanTests extends ESTestCase {
         AssignmentPlan plan = builder.build();
 
         assertThat(plan.models(), contains(m));
-        assertThat(plan.satisfiesPreviousAssignments(), is(true));
+        assertThat(plan.satisfiesCurrentAssignments(), is(true));
         assertThat(plan.assignments(m).get(), equalTo(Map.of(n, 1)));
     }
 
-    public void testAssignModelToNode_GivenNewPlanDoesNotSatisfyPreviousAssignment() {
+    public void testAssignModelToNode_GivenNewPlanDoesNotSatisfyCurrentAssignment() {
         Node n = new Node("n_1", 100, 4);
-        Model m = new Model("m_1", 40, 2, 2, Map.of("n_1", 2));
+        Model m = new Model("m_1", 40, 2, 2, Map.of("n_1", 2), 0);
 
         AssignmentPlan.Builder builder = AssignmentPlan.builder(List.of(n), List.of(m));
 
@@ -97,13 +97,13 @@ public class AssignmentPlanTests extends ESTestCase {
         AssignmentPlan plan = builder.build();
 
         assertThat(plan.models(), contains(m));
-        assertThat(plan.satisfiesPreviousAssignments(), is(false));
+        assertThat(plan.satisfiesCurrentAssignments(), is(false));
         assertThat(plan.assignments(m).get(), equalTo(Map.of(n, 1)));
     }
 
     public void testAssignModelToNode_GivenPreviouslyUnassignedModelDoesNotFit() {
         Node n = new Node("n_1", 100, 4);
-        Model m = new Model("m_1", 101, 2, 2, Map.of());
+        Model m = new Model("m_1", 101, 2, 2, Map.of(), 0);
 
         AssignmentPlan.Builder builder = AssignmentPlan.builder(List.of(n), List.of(m));
         Exception e = expectThrows(IllegalArgumentException.class, () -> builder.assignModelToNode(m, n, 1));
@@ -113,20 +113,20 @@ public class AssignmentPlanTests extends ESTestCase {
 
     public void testAssignModelToNode_GivenPreviouslyAssignedModelDoesNotFit() {
         Node n = new Node("n_1", 100, 4);
-        Model m = new Model("m_1", 101, 2, 2, Map.of("n_1", 1));
+        Model m = new Model("m_1", 101, 2, 2, Map.of("n_1", 1), 0);
 
         AssignmentPlan.Builder builder = AssignmentPlan.builder(List.of(n), List.of(m));
         builder.assignModelToNode(m, n, 2);
         AssignmentPlan plan = builder.build();
 
         assertThat(plan.models(), contains(m));
-        assertThat(plan.satisfiesPreviousAssignments(), is(true));
+        assertThat(plan.satisfiesCurrentAssignments(), is(true));
         assertThat(plan.assignments(m).get(), equalTo(Map.of(n, 2)));
     }
 
     public void testAssignModelToNode_GivenNotEnoughCores_AndSingleThreadPerAllocation() {
         Node n = new Node("n_1", 100, 4);
-        Model m = new Model("m_1", 100, 5, 1, Map.of());
+        Model m = new Model("m_1", 100, 5, 1, Map.of(), 0);
 
         AssignmentPlan.Builder builder = AssignmentPlan.builder(List.of(n), List.of(m));
         Exception e = expectThrows(IllegalArgumentException.class, () -> builder.assignModelToNode(m, n, 5));
@@ -139,7 +139,7 @@ public class AssignmentPlanTests extends ESTestCase {
 
     public void testAssignModelToNode_GivenNotEnoughCores_AndMultipleThreadsPerAllocation() {
         Node n = new Node("n_1", 100, 5);
-        Model m = new Model("m_1", 100, 3, 2, Map.of());
+        Model m = new Model("m_1", 100, 3, 2, Map.of(), 0);
 
         AssignmentPlan.Builder builder = AssignmentPlan.builder(List.of(n), List.of(m));
         Exception e = expectThrows(IllegalArgumentException.class, () -> builder.assignModelToNode(m, n, 3));
@@ -152,7 +152,7 @@ public class AssignmentPlanTests extends ESTestCase {
 
     public void testAssignModelToNode_GivenSameModelAssignedTwice() {
         Node n = new Node("n_1", 100, 8);
-        Model m = new Model("m_1", 60, 4, 2, Map.of());
+        Model m = new Model("m_1", 60, 4, 2, Map.of(), 0);
 
         AssignmentPlan.Builder builder = AssignmentPlan.builder(List.of(n), List.of(m));
 
@@ -180,13 +180,13 @@ public class AssignmentPlanTests extends ESTestCase {
         AssignmentPlan plan = builder.build();
 
         assertThat(plan.models(), contains(m));
-        assertThat(plan.satisfiesPreviousAssignments(), is(true));
+        assertThat(plan.satisfiesCurrentAssignments(), is(true));
         assertThat(plan.assignments(m).get(), equalTo(Map.of(n, 3)));
     }
 
     public void testCanAssign_GivenPreviouslyUnassignedModelDoesNotFit() {
         Node n = new Node("n_1", 100, 5);
-        Model m = new Model("m_1", 101, 1, 1, Map.of());
+        Model m = new Model("m_1", 101, 1, 1, Map.of(), 0);
 
         AssignmentPlan.Builder builder = AssignmentPlan.builder(List.of(n), List.of(m));
 
@@ -195,7 +195,7 @@ public class AssignmentPlanTests extends ESTestCase {
 
     public void testCanAssign_GivenPreviouslyAssignedModelDoesNotFit() {
         Node n = new Node("n_1", 100, 5);
-        Model m = new Model("m_1", 101, 1, 1, Map.of("n_1", 1));
+        Model m = new Model("m_1", 101, 1, 1, Map.of("n_1", 1), 0);
 
         AssignmentPlan.Builder builder = AssignmentPlan.builder(List.of(n), List.of(m));
 
@@ -204,7 +204,7 @@ public class AssignmentPlanTests extends ESTestCase {
 
     public void testCanAssign_GivenEnoughMemory() {
         Node n = new Node("n_1", 100, 5);
-        Model m = new Model("m_1", 100, 3, 2, Map.of());
+        Model m = new Model("m_1", 100, 3, 2, Map.of(), 0);
 
         AssignmentPlan.Builder builder = AssignmentPlan.builder(List.of(n), List.of(m));
 
@@ -219,13 +219,13 @@ public class AssignmentPlanTests extends ESTestCase {
         Node n = new Node("n_1", 100, 5);
 
         {
-            Model m = new Model("m_1", 100, 3, 2, Map.of("n_1", 2));
+            Model m = new Model("m_1", 100, 3, 2, Map.of("n_1", 2), 0);
             AssignmentPlan.Builder builder = AssignmentPlan.builder(List.of(n), List.of(m));
             builder.assignModelToNode(m, n, 2);
             planSatisfyingPreviousAssignments = builder.build();
         }
         {
-            Model m = new Model("m_1", 100, 3, 2, Map.of("n_1", 3));
+            Model m = new Model("m_1", 100, 3, 2, Map.of("n_1", 3), 0);
             AssignmentPlan.Builder builder = AssignmentPlan.builder(List.of(n), List.of(m));
             builder.assignModelToNode(m, n, 2);
             planNotSatisfyingPreviousAssignments = builder.build();
@@ -239,7 +239,7 @@ public class AssignmentPlanTests extends ESTestCase {
         AssignmentPlan planWithMoreAllocations;
         AssignmentPlan planWithFewerAllocations;
         Node n = new Node("n_1", 100, 5);
-        Model m = new Model("m_1", 100, 3, 2, Map.of("n_1", 1));
+        Model m = new Model("m_1", 100, 3, 2, Map.of("n_1", 1), 0);
 
         {
             AssignmentPlan.Builder builder = AssignmentPlan.builder(List.of(n), List.of(m));
@@ -262,13 +262,13 @@ public class AssignmentPlanTests extends ESTestCase {
         Node n = new Node("n_1", 100, 5);
 
         {
-            Model m = new Model("m_1", 100, 3, 2, Map.of("n_1", 1));
+            Model m = new Model("m_1", 100, 3, 2, Map.of("n_1", 1), 0);
             AssignmentPlan.Builder builder = AssignmentPlan.builder(List.of(n), List.of(m));
             builder.assignModelToNode(m, n, 2);
             planUsingMoreMemory = builder.build();
         }
         {
-            Model m = new Model("m_1", 99, 3, 2, Map.of("n_1", 1));
+            Model m = new Model("m_1", 99, 3, 2, Map.of("n_1", 1), 0);
             AssignmentPlan.Builder builder = AssignmentPlan.builder(List.of(n), List.of(m));
             builder.assignModelToNode(m, n, 2);
             planUsingLessMemory = builder.build();
@@ -281,9 +281,9 @@ public class AssignmentPlanTests extends ESTestCase {
     public void testSatisfiesAllModels_GivenAllModelsAreSatisfied() {
         Node node1 = new Node("n_1", 100, 4);
         Node node2 = new Node("n_2", 100, 4);
-        Model model1 = new Model("m_1", 50, 1, 2, Map.of());
-        Model model2 = new Model("m_2", 30, 2, 1, Map.of());
-        Model model3 = new Model("m_3", 20, 4, 1, Map.of());
+        Model model1 = new Model("m_1", 50, 1, 2, Map.of(), 0);
+        Model model2 = new Model("m_2", 30, 2, 1, Map.of(), 0);
+        Model model3 = new Model("m_3", 20, 4, 1, Map.of(), 0);
         AssignmentPlan plan = AssignmentPlan.builder(List.of(node1, node2), List.of(model1, model2, model3))
             .assignModelToNode(model1, node1, 1)
             .assignModelToNode(model2, node2, 2)
@@ -296,9 +296,9 @@ public class AssignmentPlanTests extends ESTestCase {
     public void testSatisfiesAllModels_GivenOneModelHasOneAllocationLess() {
         Node node1 = new Node("n_1", 100, 4);
         Node node2 = new Node("n_2", 100, 4);
-        Model model1 = new Model("m_1", 50, 1, 2, Map.of());
-        Model model2 = new Model("m_2", 30, 2, 1, Map.of());
-        Model model3 = new Model("m_3", 20, 4, 1, Map.of());
+        Model model1 = new Model("m_1", 50, 1, 2, Map.of(), 0);
+        Model model2 = new Model("m_2", 30, 2, 1, Map.of(), 0);
+        Model model3 = new Model("m_3", 20, 4, 1, Map.of(), 0);
         AssignmentPlan plan = AssignmentPlan.builder(List.of(node1, node2), List.of(model1, model2, model3))
             .assignModelToNode(model1, node1, 1)
             .assignModelToNode(model2, node2, 2)
@@ -306,5 +306,43 @@ public class AssignmentPlanTests extends ESTestCase {
             .assignModelToNode(model3, node2, 2)
             .build();
         assertThat(plan.satisfiesAllModels(), is(false));
+    }
+
+    public void testArePreviouslyAssignedModelsAssigned_GivenTrue() {
+        Node node1 = new Node("n_1", 100, 4);
+        Node node2 = new Node("n_2", 100, 4);
+        Model model1 = new Model("m_1", 50, 1, 2, Map.of(), 3);
+        Model model2 = new Model("m_2", 30, 2, 1, Map.of(), 4);
+        Model model3 = new Model("m_3", 20, 4, 1, Map.of(), 0);
+        AssignmentPlan plan = AssignmentPlan.builder(List.of(node1, node2), List.of(model1, model2, model3))
+            .assignModelToNode(model1, node1, 1)
+            .assignModelToNode(model2, node2, 1)
+            .build();
+        assertThat(plan.arePreviouslyAssignedModelsAssigned(), is(true));
+    }
+
+    public void testArePreviouslyAssignedModelsAssigned_GivenFalse() {
+        Node node1 = new Node("n_1", 100, 4);
+        Node node2 = new Node("n_2", 100, 4);
+        Model model1 = new Model("m_1", 50, 1, 2, Map.of(), 3);
+        Model model2 = new Model("m_2", 30, 2, 1, Map.of(), 4);
+        AssignmentPlan plan = AssignmentPlan.builder(List.of(node1, node2), List.of(model1, model2))
+            .assignModelToNode(model1, node1, 1)
+            .build();
+        assertThat(plan.arePreviouslyAssignedModelsAssigned(), is(false));
+    }
+
+    public void testCountPreviouslyAssignedThatAreStillAssigned() {
+        Node node1 = new Node("n_1", 100, 4);
+        Node node2 = new Node("n_2", 100, 4);
+        Model model1 = new Model("m_1", 50, 1, 2, Map.of(), 3);
+        Model model2 = new Model("m_2", 30, 2, 1, Map.of(), 4);
+        Model model3 = new Model("m_3", 20, 4, 1, Map.of(), 1);
+        Model model4 = new Model("m_4", 20, 4, 1, Map.of(), 0);
+        AssignmentPlan plan = AssignmentPlan.builder(List.of(node1, node2), List.of(model1, model2, model3, model4))
+            .assignModelToNode(model1, node1, 1)
+            .assignModelToNode(model2, node2, 1)
+            .build();
+        assertThat(plan.countPreviouslyAssignedModelsThatAreStillAssigned(), equalTo(2L));
     }
 }

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/assignment/planning/AssignmentPlannerTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/assignment/planning/AssignmentPlannerTests.java
@@ -14,16 +14,19 @@ import org.elasticsearch.xpack.ml.inference.assignment.planning.AssignmentPlan.M
 import org.elasticsearch.xpack.ml.inference.assignment.planning.AssignmentPlan.Node;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.everyItem;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.hamcrest.Matchers.hasItems;
 import static org.hamcrest.Matchers.in;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
@@ -32,14 +35,14 @@ public class AssignmentPlannerTests extends ESTestCase {
 
     public void testModelThatDoesNotFitInMemory() {
         List<Node> nodes = List.of(new Node("n_1", 100, 4));
-        Model model = new Model("m_1", 101, 4, 1, Map.of());
+        Model model = new Model("m_1", 101, 4, 1, Map.of(), 0);
         AssignmentPlan plan = new AssignmentPlanner(nodes, List.of(model)).computePlan();
         assertThat(plan.assignments(model).isEmpty(), is(true));
     }
 
     public void testModelWithThreadsPerAllocationNotFittingOnAnyNode() {
         List<Node> nodes = List.of(new Node("n_1", 100, 4), new Node("n_2", 100, 5));
-        Model model = new Model("m_1", 1, 1, 6, Map.of());
+        Model model = new Model("m_1", 1, 1, 6, Map.of(), 0);
         AssignmentPlan plan = new AssignmentPlanner(nodes, List.of(model)).computePlan();
         assertThat(plan.assignments(model).isEmpty(), is(true));
     }
@@ -47,19 +50,19 @@ public class AssignmentPlannerTests extends ESTestCase {
     public void testSingleModelThatFitsFullyOnSingleNode() {
         {
             Node node = new Node("n_1", 100, 4);
-            Model model = new Model("m_1", 100, 1, 1, Map.of());
+            Model model = new Model("m_1", 100, 1, 1, Map.of(), 0);
             AssignmentPlan plan = new AssignmentPlanner(List.of(node), List.of(model)).computePlan();
             assertModelFullyAssignedToNode(plan, model, node);
         }
         {
             Node node = new Node("n_1", 1000, 8);
-            Model model = new Model("m_1", 1000, 8, 1, Map.of());
+            Model model = new Model("m_1", 1000, 8, 1, Map.of(), 0);
             AssignmentPlan plan = new AssignmentPlanner(List.of(node), List.of(model)).computePlan();
             assertModelFullyAssignedToNode(plan, model, node);
         }
         {
             Node node = new Node("n_1", 10000, 16);
-            Model model = new Model("m_1", 10000, 1, 16, Map.of());
+            Model model = new Model("m_1", 10000, 1, 16, Map.of(), 0);
             AssignmentPlan plan = new AssignmentPlanner(List.of(node), List.of(model)).computePlan();
             assertModelFullyAssignedToNode(plan, model, node);
         }
@@ -68,7 +71,7 @@ public class AssignmentPlannerTests extends ESTestCase {
     public void testSingleModelThatFitsFullyOnSingleNode_GivenTwoNodes_ShouldBeFullyAssignedOnOneNode() {
         Node node1 = new Node("n_1", 100, 4);
         Node node2 = new Node("n_2", 100, 4);
-        Model model = new Model("m_1", 100, 4, 1, Map.of());
+        Model model = new Model("m_1", 100, 4, 1, Map.of(), 0);
 
         AssignmentPlan plan = new AssignmentPlanner(List.of(node1, node2), List.of(model)).computePlan();
 
@@ -81,7 +84,7 @@ public class AssignmentPlannerTests extends ESTestCase {
     }
 
     public void testModelWithMoreAllocationsThanAvailableCores_GivenSingleThreadPerAllocation() {
-        Model model = new Model("m_1", 30, 10, 1, Map.of());
+        Model model = new Model("m_1", 30, 10, 1, Map.of(), 0);
         // Single node
         {
             Node node = new Node("n_1", 100, 4);
@@ -119,10 +122,10 @@ public class AssignmentPlannerTests extends ESTestCase {
         Node node2 = new Node("n_2", 100, 7);
         Node node3 = new Node("n_3", 100, 2);
         Node node4 = new Node("n_4", 100, 2);
-        Model model1 = new Model("m_1", 50, 2, 4, Map.of());
-        Model model2 = new Model("m_2", 50, 2, 3, Map.of());
-        Model model3 = new Model("m_3", 50, 1, 2, Map.of());
-        Model model4 = new Model("m_4", 50, 2, 1, Map.of());
+        Model model1 = new Model("m_1", 50, 2, 4, Map.of(), 0);
+        Model model2 = new Model("m_2", 50, 2, 3, Map.of(), 0);
+        Model model3 = new Model("m_3", 50, 1, 2, Map.of(), 0);
+        Model model4 = new Model("m_4", 50, 2, 1, Map.of(), 0);
 
         AssignmentPlan plan = new AssignmentPlanner(List.of(node1, node2, node3, node4), List.of(model1, model2, model3, model4))
             .computePlan();
@@ -168,7 +171,7 @@ public class AssignmentPlannerTests extends ESTestCase {
     }
 
     public void testModelWithMoreAllocationsThanAvailableCores_GivenThreeThreadsPerAllocation() {
-        Model model = new Model("m_1", 30, 10, 3, Map.of());
+        Model model = new Model("m_1", 30, 10, 3, Map.of(), 0);
         // Single node
         {
             Node node = new Node("n_1", 100, 4);
@@ -203,7 +206,7 @@ public class AssignmentPlannerTests extends ESTestCase {
 
     public void testModelWithPreviousAssignmentAndNoMoreCoresAvailable() {
         Node node = new Node("n_1", 100, 4);
-        Model model = new Model("m_1", 30, 4, 1, Map.of("n_1", 4));
+        Model model = new Model("m_1", 30, 4, 1, Map.of("n_1", 4), 0);
         AssignmentPlan plan = new AssignmentPlanner(List.of(node), List.of(model)).computePlan();
 
         assertThat(plan.assignments(model).isPresent(), is(true));
@@ -220,18 +223,18 @@ public class AssignmentPlannerTests extends ESTestCase {
             new Node("n_6", ByteSizeValue.ofGb(8).getBytes(), 16)
         );
         List<Model> models = List.of(
-            new Model("m_1", ByteSizeValue.ofGb(4).getBytes(), 10, 1, Map.of("n_1", 5)),
-            new Model("m_2", ByteSizeValue.ofGb(2).getBytes(), 3, 1, Map.of("n_3", 2)),
-            new Model("m_3", ByteSizeValue.ofGb(3).getBytes(), 3, 1, Map.of()),
-            new Model("m_4", ByteSizeValue.ofGb(1).getBytes(), 4, 1, Map.of("n_3", 2)),
-            new Model("m_5", ByteSizeValue.ofGb(6).getBytes(), 2, 1, Map.of()),
-            new Model("m_6", ByteSizeValue.ofGb(1).getBytes(), 12, 1, Map.of()),
-            new Model("m_7", ByteSizeValue.ofGb(1).getBytes() / 2, 12, 1, Map.of("n_2", 6)),
-            new Model("m_8", ByteSizeValue.ofGb(2).getBytes(), 4, 1, Map.of()),
-            new Model("m_9", ByteSizeValue.ofGb(1).getBytes(), 4, 1, Map.of()),
-            new Model("m_10", ByteSizeValue.ofGb(7).getBytes(), 7, 1, Map.of()),
-            new Model("m_11", ByteSizeValue.ofGb(2).getBytes(), 3, 1, Map.of()),
-            new Model("m_12", ByteSizeValue.ofGb(1).getBytes(), 10, 1, Map.of())
+            new Model("m_1", ByteSizeValue.ofGb(4).getBytes(), 10, 1, Map.of("n_1", 5), 0),
+            new Model("m_2", ByteSizeValue.ofGb(2).getBytes(), 3, 1, Map.of("n_3", 2), 0),
+            new Model("m_3", ByteSizeValue.ofGb(3).getBytes(), 3, 1, Map.of(), 0),
+            new Model("m_4", ByteSizeValue.ofGb(1).getBytes(), 4, 1, Map.of("n_3", 2), 0),
+            new Model("m_5", ByteSizeValue.ofGb(6).getBytes(), 2, 1, Map.of(), 0),
+            new Model("m_6", ByteSizeValue.ofGb(1).getBytes(), 12, 1, Map.of(), 0),
+            new Model("m_7", ByteSizeValue.ofGb(1).getBytes() / 2, 12, 1, Map.of("n_2", 6), 0),
+            new Model("m_8", ByteSizeValue.ofGb(2).getBytes(), 4, 1, Map.of(), 0),
+            new Model("m_9", ByteSizeValue.ofGb(1).getBytes(), 4, 1, Map.of(), 0),
+            new Model("m_10", ByteSizeValue.ofGb(7).getBytes(), 7, 1, Map.of(), 0),
+            new Model("m_11", ByteSizeValue.ofGb(2).getBytes(), 3, 1, Map.of(), 0),
+            new Model("m_12", ByteSizeValue.ofGb(1).getBytes(), 10, 1, Map.of(), 0)
         );
 
         AssignmentPlan assignmentPlan = new AssignmentPlanner(nodes, models).computePlan();
@@ -330,7 +333,9 @@ public class AssignmentPlannerTests extends ESTestCase {
             Map<String, Integer> previousAssignments = assignments.entrySet()
                 .stream()
                 .collect(Collectors.toMap(e -> e.getKey().id(), Map.Entry::getValue));
-            previousModelsPlusNew.add(new Model(m.id(), m.memoryBytes(), m.allocations(), m.threadsPerAllocation(), previousAssignments));
+            previousModelsPlusNew.add(
+                new Model(m.id(), m.memoryBytes(), m.allocations(), m.threadsPerAllocation(), previousAssignments, 0)
+            );
         }
         previousModelsPlusNew.add(randomModel("new"));
 
@@ -343,8 +348,8 @@ public class AssignmentPlannerTests extends ESTestCase {
         Node node1 = new Node("n_1", ByteSizeValue.ofGb(2).getBytes(), 2);
         Node node2 = new Node("n_2", ByteSizeValue.ofGb(2).getBytes(), 2);
         Node node3 = new Node("n_3", ByteSizeValue.ofGb(2).getBytes(), 2);
-        Model model1 = new Model("m_1", ByteSizeValue.ofMb(1200).getBytes(), 3, 1, Map.of("n_1", 2, "n_2", 1));
-        Model model2 = new Model("m_2", ByteSizeValue.ofMb(1100).getBytes(), 2, 1, Map.of());
+        Model model1 = new Model("m_1", ByteSizeValue.ofMb(1200).getBytes(), 3, 1, Map.of("n_1", 2, "n_2", 1), 0);
+        Model model2 = new Model("m_2", ByteSizeValue.ofMb(1100).getBytes(), 2, 1, Map.of(), 0);
         AssignmentPlan assignmentPlan = new AssignmentPlanner(List.of(node1, node2, node3), List.of(model1, model2)).computePlan();
         {
             assertThat(assignmentPlan.assignments(model1).isPresent(), is(true));
@@ -360,6 +365,131 @@ public class AssignmentPlannerTests extends ESTestCase {
             assertThat(assignments.get(node2), is(nullValue()));
             assertThat(assignments.get(node3), equalTo(2));
         }
+    }
+
+    public void testModelWithoutCurrentAllocationsGetsAssignedIfAllocatedPreviously() {
+        Node node1 = new Node("n_1", ByteSizeValue.ofGb(4).getBytes(), 2);
+        Node node2 = new Node("n_2", ByteSizeValue.ofGb(4).getBytes(), 2);
+        Model model1 = new Model("m_1", ByteSizeValue.ofMb(1200).getBytes(), 3, 1, Map.of("n_1", 2, "n_2", 1), 3);
+        Model model2 = new Model("m_2", ByteSizeValue.ofMb(1100).getBytes(), 1, 2, Map.of(), 1);
+
+        AssignmentPlan assignmentPlan = new AssignmentPlanner(List.of(node1, node2), List.of(model1, model2)).computePlan();
+
+        Map<String, Map<String, Integer>> indexedBasedPlan = convertToIdIndexed(assignmentPlan);
+        assertThat(indexedBasedPlan.keySet(), hasItems("m_1", "m_2"));
+        assertThat(indexedBasedPlan.get("m_1"), equalTo(Map.of("n_1", 2)));
+        assertThat(indexedBasedPlan.get("m_2"), equalTo(Map.of("n_2", 1)));
+    }
+
+    public void testGivenPreviouslyAssignedModels_CannotAllBeAllocated() {
+        Node node1 = new Node("n_1", ByteSizeValue.ofGb(2).getBytes(), 2);
+        Model model1 = new Model("m_1", ByteSizeValue.ofMb(1200).getBytes(), 1, 1, Map.of(), 1);
+        Model model2 = new Model("m_2", ByteSizeValue.ofMb(1100).getBytes(), 1, 1, Map.of(), 1);
+
+        AssignmentPlan assignmentPlan = new AssignmentPlanner(List.of(node1), List.of(model1, model2)).computePlan();
+
+        assertThat(assignmentPlan.countPreviouslyAssignedModelsThatAreStillAssigned(), equalTo(1L));
+    }
+
+    public void testGivenClusterResize_ShouldAllocateEachModelAtLeastOnce() {
+        Node node1 = new Node("n_1", ByteSizeValue.ofMb(1200).getBytes(), 2);
+        Node node2 = new Node("n_2", ByteSizeValue.ofMb(1200).getBytes(), 2);
+        Model model1 = new Model("m_1", ByteSizeValue.ofMb(800).getBytes(), 2, 1, Map.of(), 0);
+        Model model2 = new Model("m_2", ByteSizeValue.ofMb(800).getBytes(), 1, 1, Map.of(), 0);
+        Model model3 = new Model("m_3", ByteSizeValue.ofMb(250).getBytes(), 4, 1, Map.of(), 0);
+
+        // First only start m_1
+        AssignmentPlan assignmentPlan = new AssignmentPlanner(List.of(node1, node2), List.of(model1)).computePlan();
+
+        Map<String, Map<String, Integer>> indexedBasedPlan = convertToIdIndexed(assignmentPlan);
+        assertThat(indexedBasedPlan.keySet(), hasItems("m_1"));
+        assertThat(indexedBasedPlan.get("m_1"), equalTo(Map.of("n_1", 2)));
+
+        // Then start m_2
+        assignmentPlan = new AssignmentPlanner(
+            List.of(node1, node2),
+            Stream.concat(createModelsFromPlan(assignmentPlan).stream(), Stream.of(model2)).toList()
+        ).computePlan();
+
+        indexedBasedPlan = convertToIdIndexed(assignmentPlan);
+        assertThat(indexedBasedPlan.keySet(), hasItems("m_1", "m_2"));
+        assertThat(indexedBasedPlan.get("m_1"), equalTo(Map.of("n_1", 2)));
+        assertThat(indexedBasedPlan.get("m_2"), equalTo(Map.of("n_2", 1)));
+
+        // Then start m_3
+        assignmentPlan = new AssignmentPlanner(
+            List.of(node1, node2),
+            Stream.concat(createModelsFromPlan(assignmentPlan).stream(), Stream.of(model3)).toList()
+        ).computePlan();
+
+        indexedBasedPlan = convertToIdIndexed(assignmentPlan);
+        assertThat(indexedBasedPlan.keySet(), hasItems("m_1", "m_2", "m_3"));
+        assertThat(indexedBasedPlan.get("m_1"), equalTo(Map.of("n_1", 2)));
+        assertThat(indexedBasedPlan.get("m_2"), equalTo(Map.of("n_2", 1)));
+        assertThat(indexedBasedPlan.get("m_3"), equalTo(Map.of("n_2", 1)));
+
+        // Now the cluster starts getting resized.
+        Node node3 = new Node("n_3", ByteSizeValue.ofMb(2400).getBytes(), 2);
+        Node node4 = new Node("n_4", ByteSizeValue.ofMb(2400).getBytes(), 2);
+
+        // First, one node goes away.
+        assignmentPlan = new AssignmentPlanner(List.of(node1), createModelsFromPlan(assignmentPlan)).computePlan();
+
+        // Then, a node double in memory size is added.
+        assignmentPlan = new AssignmentPlanner(List.of(node1, node3), createModelsFromPlan(assignmentPlan)).computePlan();
+        // And another.
+        assignmentPlan = new AssignmentPlanner(List.of(node1, node3, node4), createModelsFromPlan(assignmentPlan)).computePlan();
+        // Finally, the remaining smaller node is removed
+        assignmentPlan = new AssignmentPlanner(List.of(node3, node4), createModelsFromPlan(assignmentPlan)).computePlan();
+
+        indexedBasedPlan = convertToIdIndexed(assignmentPlan);
+        assertThat(indexedBasedPlan.keySet(), hasItems("m_1", "m_2", "m_3"));
+        assertThat(indexedBasedPlan.get("m_1").values().stream().mapToInt(Integer::intValue).sum(), greaterThanOrEqualTo(1));
+        assertThat(indexedBasedPlan.get("m_2").values().stream().mapToInt(Integer::intValue).sum(), greaterThanOrEqualTo(1));
+        assertThat(indexedBasedPlan.get("m_3").values().stream().mapToInt(Integer::intValue).sum(), greaterThanOrEqualTo(1));
+
+        // Assert that all cores are utilized
+        assertThat(assignmentPlan.getRemainingNodeCores("n_1"), equalTo(0));
+        assertThat(assignmentPlan.getRemainingNodeCores("n_2"), equalTo(0));
+    }
+
+    private static List<Model> createModelsFromPlan(AssignmentPlan plan) {
+        List<Model> models = new ArrayList<>();
+        for (Model m : plan.models()) {
+            Optional<Map<Node, Integer>> assignments = plan.assignments(m);
+            Map<String, Integer> currentAllocations = Map.of();
+            if (assignments.isPresent()) {
+                currentAllocations = new HashMap<>();
+                for (Map.Entry<Node, Integer> nodeAssignments : assignments.get().entrySet()) {
+                    currentAllocations.put(nodeAssignments.getKey().id(), nodeAssignments.getValue());
+                }
+            }
+            int totalAllocations = currentAllocations.values().stream().mapToInt(Integer::intValue).sum();
+            models.add(
+                new Model(
+                    m.id(),
+                    m.memoryBytes(),
+                    m.allocations(),
+                    m.threadsPerAllocation(),
+                    currentAllocations,
+                    Math.max(m.maxAssignedAllocations(), totalAllocations)
+                )
+            );
+        }
+        return models;
+    }
+
+    private static Map<String, Map<String, Integer>> convertToIdIndexed(AssignmentPlan plan) {
+        Map<String, Map<String, Integer>> result = new HashMap<>();
+        for (Model m : plan.models()) {
+            Optional<Map<Node, Integer>> assignments = plan.assignments(m);
+            Map<String, Integer> allocationsPerNodeId = assignments.isPresent() ? new HashMap<>() : Map.of();
+            for (Map.Entry<Node, Integer> nodeAssignments : assignments.orElse(Map.of()).entrySet()) {
+                allocationsPerNodeId.put(nodeAssignments.getKey().id(), nodeAssignments.getValue());
+            }
+            result.put(m.id(), allocationsPerNodeId);
+        }
+        return result;
     }
 
     private static void assertModelFullyAssignedToNode(AssignmentPlan plan, Model m, Node n) {
@@ -395,12 +525,14 @@ public class AssignmentPlannerTests extends ESTestCase {
     }
 
     private static Model randomModel(String idSuffix) {
+        int allocations = randomIntBetween(1, 32);
         return new Model(
             "m_" + idSuffix,
             randomLongBetween(ByteSizeValue.ofMb(100).getBytes(), ByteSizeValue.ofGb(10).getBytes()),
             randomIntBetween(1, 32),
             randomIntBetween(1, 4),
-            Map.of()
+            Map.of(),
+            0
         );
     }
 
@@ -417,7 +549,7 @@ public class AssignmentPlannerTests extends ESTestCase {
                 allocations += e.getValue();
             }
             assertThat(m.currentAllocationsByNodeId().keySet(), everyItem(in(assignedNodeIds)));
-            assertThat(allocations, greaterThanOrEqualTo(m.getPreviouslyAssignedAllocations()));
+            assertThat(allocations, greaterThanOrEqualTo(m.getCurrentAssignedAllocations()));
         }
     }
 
@@ -428,7 +560,7 @@ public class AssignmentPlannerTests extends ESTestCase {
         }
         List<Model> models = new ArrayList<>();
         for (int i = 0; i < modelsSize; i++) {
-            models.add(new Model("m_" + i, ByteSizeValue.ofMb(200).getBytes(), 2, 1, Map.of()));
+            models.add(new Model("m_" + i, ByteSizeValue.ofMb(200).getBytes(), 2, 1, Map.of(), 0));
         }
 
         // Check plan is computed without OOM exception

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/assignment/planning/PreserveAllAllocationsTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/assignment/planning/PreserveAllAllocationsTests.java
@@ -24,8 +24,8 @@ public class PreserveAllAllocationsTests extends ESTestCase {
     public void testGivenNoPreviousAssignments() {
         Node node1 = new Node("n_1", 100, 4);
         Node node2 = new Node("n_2", 100, 4);
-        Model model1 = new Model("m_1", 30, 2, 1, Map.of());
-        Model model2 = new Model("m_2", 30, 2, 4, Map.of());
+        Model model1 = new Model("m_1", 30, 2, 1, Map.of(), 0);
+        Model model2 = new Model("m_2", 30, 2, 4, Map.of(), 0);
         PreserveAllAllocations preserveAllAllocations = new PreserveAllAllocations(List.of(node1, node2), List.of(model1, model2));
 
         List<Node> nodesPreservingAllocations = preserveAllAllocations.nodesPreservingAllocations();
@@ -38,8 +38,8 @@ public class PreserveAllAllocationsTests extends ESTestCase {
     public void testGivenPreviousAssignments() {
         Node node1 = new Node("n_1", 100, 8);
         Node node2 = new Node("n_2", 100, 8);
-        Model model1 = new Model("m_1", 30, 2, 1, Map.of("n_1", 1));
-        Model model2 = new Model("m_2", 50, 6, 4, Map.of("n_1", 1, "n_2", 2));
+        Model model1 = new Model("m_1", 30, 2, 1, Map.of("n_1", 1), 1);
+        Model model2 = new Model("m_2", 50, 6, 4, Map.of("n_1", 1, "n_2", 2), 3);
         PreserveAllAllocations preserveAllAllocations = new PreserveAllAllocations(List.of(node1, node2), List.of(model1, model2));
 
         List<Node> nodesPreservingAllocations = preserveAllAllocations.nodesPreservingAllocations();
@@ -86,7 +86,7 @@ public class PreserveAllAllocationsTests extends ESTestCase {
 
     public void testGivenModelWithPreviousAssignments_AndPlanToMergeHasNoAssignments() {
         Node node = new Node("n_1", 100, 4);
-        Model model = new Model("m_1", 30, 2, 2, Map.of("n_1", 2));
+        Model model = new Model("m_1", 30, 2, 2, Map.of("n_1", 2), 2);
         PreserveAllAllocations preserveAllAllocations = new PreserveAllAllocations(List.of(node), List.of(model));
 
         AssignmentPlan plan = AssignmentPlan.builder(List.of(node), List.of(model)).build();

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/assignment/planning/PreserveOneAllocationTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/assignment/planning/PreserveOneAllocationTests.java
@@ -24,8 +24,8 @@ public class PreserveOneAllocationTests extends ESTestCase {
     public void testGivenNoPreviousAssignments() {
         Node node1 = new Node("n_1", 100, 4);
         Node node2 = new Node("n_2", 100, 4);
-        Model model1 = new Model("m_1", 30, 2, 1, Map.of());
-        Model model2 = new Model("m_2", 30, 2, 4, Map.of());
+        Model model1 = new Model("m_1", 30, 2, 1, Map.of(), 0);
+        Model model2 = new Model("m_2", 30, 2, 4, Map.of(), 0);
         PreserveOneAllocation preserveOneAllocation = new PreserveOneAllocation(List.of(node1, node2), List.of(model1, model2));
 
         List<Node> nodesPreservingAllocations = preserveOneAllocation.nodesPreservingAllocations();
@@ -38,8 +38,8 @@ public class PreserveOneAllocationTests extends ESTestCase {
     public void testGivenPreviousAssignments() {
         Node node1 = new Node("n_1", 100, 8);
         Node node2 = new Node("n_2", 100, 8);
-        Model model1 = new Model("m_1", 30, 2, 1, Map.of("n_1", 1));
-        Model model2 = new Model("m_2", 50, 6, 4, Map.of("n_1", 1, "n_2", 2));
+        Model model1 = new Model("m_1", 30, 2, 1, Map.of("n_1", 1), 1);
+        Model model2 = new Model("m_2", 50, 6, 4, Map.of("n_1", 1, "n_2", 2), 3);
         PreserveOneAllocation preserveOneAllocation = new PreserveOneAllocation(List.of(node1, node2), List.of(model1, model2));
 
         List<Node> nodesPreservingAllocations = preserveOneAllocation.nodesPreservingAllocations();
@@ -87,7 +87,7 @@ public class PreserveOneAllocationTests extends ESTestCase {
 
     public void testGivenModelWithPreviousAssignments_AndPlanToMergeHasNoAssignments() {
         Node node = new Node("n_1", 100, 4);
-        Model model = new Model("m_1", 30, 2, 2, Map.of("n_1", 2));
+        Model model = new Model("m_1", 30, 2, 2, Map.of("n_1", 2), 2);
         PreserveOneAllocation preserveOneAllocation = new PreserveOneAllocation(List.of(node), List.of(model));
 
         AssignmentPlan plan = AssignmentPlan.builder(List.of(node), List.of(model)).build();


### PR DESCRIPTION
…on (#88855)

When for some reason ML nodes are replaced (cluster resize, upgrade, etc.),
it is possible that some models cannot be allocated at all. Then, while
the cluster is temporarily undersized, all cores are given for allocations
of the models that have survived. If those ML nodes return later, there may
be model deployments that were previously allocated that now do not get any
allocations. The reason is that our planner will try to preserve all current
allocations.

Operationally, this is not what serves best our users. Instead, as we are
already in a cluster that does not have enough resources to fully allocate
all model deployments, we should try to give at least one allocation to each
model that has previously been allocated.

In order to know a model has previously been allocated, this commit adds a field
to `TrainedModelAssignment` called `max_assigned_allocations` which records the
max number of allocations a deployment has received in its life. We can then use
this to establish whether a deployment has ever been allocated.

Finally, we modify the `AssignmentPlanner` so that after computing a plan we
check whether the plan gives at least one allocation to all previously allocated models.
If not, we then compute a plan that tries to give at least one allocation to each
previously allocated model. We can solve this just using bin-packing. Having that
plan we can invoke the planner one more time to optimize the rest of the allocations
whilst preserving the single allocations for previously allocated models.

Backport of #88855
