### PR TITLE
[8.4] Fixing a race condition in CoordinationDiagnosticsServiceIT #89055 (#89055)

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/cluster/coordination/CoordinationDiagnosticsServiceIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/cluster/coordination/CoordinationDiagnosticsServiceIT.java
@@ -47,6 +47,7 @@ public class CoordinationDiagnosticsServiceIT extends ESIntegTestCase {
         assertThat(nodeNames, hasItem(master));
         String blockedNode = nodeNames.stream().filter(n -> n.equals(master) == false).findAny().get();
         assertNotNull(blockedNode);
+        ensureStableCluster(3);
 
         DiscoveryNodes discoveryNodes = internalCluster().getInstance(ClusterService.class, master).state().nodes();
         Set<DiscoveryNode> nodesWithoutBlockedNode = discoveryNodes.getNodes()


### PR DESCRIPTION
Backports the following commits to 8.4:
 - Fixing a race condition in CoordinationDiagnosticsServiceIT #89055 (#89055)