### PR TITLE
[8.4][DOCS] Adds ML-related release highlights

### DIFF
--- a/docs/changelog/83055.yaml
+++ b/docs/changelog/83055.yaml
@@ -3,3 +3,14 @@ summary: New `frequent_items` aggregation
 area: Machine Learning
 type: enhancement
 issues: []
+highlight:
+  title: Frequent itemset aggregation
+  body: |-
+   The 
+   {ref}/search-aggregations-bucket-frequent-items-aggregation.html[frequent items aggregation] 
+   is a new bucket aggregation which identifies items that often occur together. 
+   It is a form of association rules mining that helps to discover relationships 
+   between different data points. For example, the aggregation can find log 
+   events that tend to co-occur and may give a more informative explanation for 
+   the possible causes of a spike in the logs.
+  notable: true

--- a/docs/changelog/87361.yaml
+++ b/docs/changelog/87361.yaml
@@ -4,16 +4,16 @@ area: Transform
 type: enhancement
 issues: []
 highlight:
-  title: Infinite and adaptive retries for Transforms
+  title: Infinite and adaptive retries for transforms
   body: |-
-   Infinite and adaptive retires – available in 8.4 – makes it possible for 
+   Infinite and adaptive retries – available in 8.4 – makes it possible for 
    transforms to recover after a failure without any user intervention. Retries 
    can be configured per transform. The transform retries become less frequent 
    progressively. The interval between retries doubles after reaching a one-hour 
    threshold. This is because the possibility that retries solve the problem is 
    less likely after each failed retry.
    
-   In the Transforms page in Stack Management in Kibana, the number of retries 
+   In the *Transforms* page in *{stack-manage-app}* in {kib}, the number of retries 
    can be configured when creating a new transform or editing an existing one.
   notable: true
 

--- a/docs/changelog/87361.yaml
+++ b/docs/changelog/87361.yaml
@@ -3,4 +3,17 @@ summary: "Implement per-transform num_failure_retries setting"
 area: Transform
 type: enhancement
 issues: []
+highlight:
+  title: Infinite and adaptive retries for Transforms
+  body: |-
+   Infinite and adaptive retires – available in 8.4 – makes it possible for 
+   transforms to recover after a failure without any user intervention. Retries 
+   can be configured per transform. The transform retries become less frequent 
+   progressively. The interval between retries doubles after reaching a one-hour 
+   threshold. This is because the possibility that retries solve the problem is 
+   less likely after each failed retry.
+   
+   In the Transforms page in Stack Management in Kibana, the number of retries 
+   can be configured when creating a new transform or editing an existing one.
+  notable: true
 

--- a/docs/changelog/88589.yaml
+++ b/docs/changelog/88589.yaml
@@ -13,9 +13,9 @@ highlight:
     [discrete]
     [[early-stopping-dfa]]
     === Early stopping for data frame analytics
-    Data frame analytics is even faster in 8.4. The new function makes it 
-    possible to stop the process of hyperparameter optimization early in case of 
-    the accuracy gain for a different set of hyperparameter values would be 
+    Data frame analytics is even faster in 8.4. The new function automatically 
+    stops the process of hyperparameter optimization early in case of the 
+    accuracy gain for a different set of hyperparameter values would be 
     insignificant. The early stopping of the optimization process results in a 
     shorter runtime for the data frame analytics job.
   notable: true

--- a/docs/changelog/88589.yaml
+++ b/docs/changelog/88589.yaml
@@ -1,0 +1,12 @@
+pr: 88589
+summary: Make composite aggs in datafeeds Generally Available
+area: Machine Learning
+type: feature
+issues: []
+highlight:
+  title: Composite aggregations in datafeeds are Generally Available
+  body: |-
+    The support for 
+    {ml-docs}/ml-configuring-aggregation.html#aggs-using-composite[composite aggregations]
+    in datafeeds is now generally available.
+  notable: true

--- a/docs/changelog/88589.yaml
+++ b/docs/changelog/88589.yaml
@@ -9,4 +9,13 @@ highlight:
     The support for 
     {ml-docs}/ml-configuring-aggregation.html#aggs-using-composite[composite aggregations]
     in datafeeds is now generally available.
+
+    [discrete]
+    [[early-stopping-dfa]]
+    === Early stopping for data frame analytics
+    Data frame analytics is even faster in 8.4. The new function makes it 
+    possible to stop the process of hyperparameter optimization early in case of 
+    the accuracy gain for a different set of hyperparameter values would be 
+    insignificant. The early stopping of the optimization process results in a 
+    shorter runtime for the data frame analytics job.
   notable: true


### PR DESCRIPTION
## Overview

This PR adds the `highlight` property with title and some description to the YAML files in the changelog that contain ML-related changes that need to be highlighted.

It also adds the item about "Early stopping for data frame analytics" to the YAML file of the "aggregations in datafeeds are GA". As the early stopping functionality has been added to the stack via a PR in the ML-CPP repo, there is no corresponding YAML file in the elasticsearch repo. This situation and the nature of the highlight generation process necessitate this less elegant way to add the highlight item to the "What's new" section.