### PR TITLE
Add queries section into the _nodes/usage API

### DIFF
--- a/benchmarks/src/main/java/org/elasticsearch/benchmark/search/QueryParserHelperBenchmark.java
+++ b/benchmarks/src/main/java/org/elasticsearch/benchmark/search/QueryParserHelperBenchmark.java
@@ -156,7 +156,8 @@ public class QueryParserHelperBenchmark {
             null,
             () -> true,
             null,
-            Collections.emptyMap()
+            Collections.emptyMap(),
+            null
         );
     }
 

--- a/docs/changelog/89084.yaml
+++ b/docs/changelog/89084.yaml
@@ -1,0 +1,6 @@
+pr: 89084
+summary: Add queries section into the _nodes/usage API
+area: "Search, Vector Search"
+type: enhancement
+issues:
+ - 88908

--- a/docs/changelog/89084.yaml
+++ b/docs/changelog/89084.yaml
@@ -1,6 +1,6 @@
 pr: 89084
 summary: Add queries section into the _nodes/usage API
-area: "Search, Vector Search"
+area: "Search"
 type: enhancement
 issues:
  - 88908

--- a/docs/reference/cluster/nodes-usage.asciidoc
+++ b/docs/reference/cluster/nodes-usage.asciidoc
@@ -46,6 +46,14 @@ of features for each node. All the nodes selective options are explained
     `rest_actions`::
         Returns the REST actions classname with a count of the number of times
         that action has been called on the node.
+
+    `aggregations`::
+        Returns the aggregation types with a count of the number of times
+        each aggregation type was used on the node.
+
+    `queries`::
+        Returns the queries types with a count of the number of times
+        each query type was used on the node.
 --
 
 include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=node-id]
@@ -92,6 +100,9 @@ The API returns the following response:
       },
       "aggregations": {
         ...
+      },
+      "queries": {
+        ...
       }
     }
   }
@@ -103,6 +114,7 @@ The API returns the following response:
 // TESTRESPONSE[s/1492553906606/$body.$_path/]
 // TESTRESPONSE[s/"rest_actions": [^}]+}/"rest_actions": $body.$_path/]
 // TESTRESPONSE[s/"aggregations": [^}]+}/"aggregations": $body.$_path/]
+// TESTRESPONSE[s/"queries": [^}]+}/"queries": $body.$_path/]
 <1> Timestamp for when this nodes usage request was performed.
 <2> Timestamp for when the usage information recording was started. This is
 equivalent to the time that the node was started.

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/nodes.usage.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/nodes.usage.json
@@ -39,7 +39,9 @@
               "type":"list",
               "options":[
                 "_all",
-                "rest_actions"
+                "rest_actions",
+                "aggregations",
+                "queries"
               ],
               "description":"Limit the information returned to the specified metrics"
             }
@@ -55,7 +57,9 @@
               "type":"list",
               "options":[
                 "_all",
-                "rest_actions"
+                "rest_actions",
+                "aggregations",
+                "queries"
               ],
               "description":"Limit the information returned to the specified metrics"
             },

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/node/usage/NodesUsageRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/node/usage/NodesUsageRequest.java
@@ -8,6 +8,7 @@
 
 package org.elasticsearch.action.admin.cluster.node.usage;
 
+import org.elasticsearch.Version;
 import org.elasticsearch.action.support.nodes.BaseNodesRequest;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -18,11 +19,15 @@ public class NodesUsageRequest extends BaseNodesRequest<NodesUsageRequest> {
 
     private boolean restActions;
     private boolean aggregations;
+    private boolean queries;
 
     public NodesUsageRequest(StreamInput in) throws IOException {
         super(in);
         this.restActions = in.readBoolean();
         this.aggregations = in.readBoolean();
+        if (in.getVersion().onOrAfter(Version.V_8_5_0)) {
+            this.queries = in.readBoolean();
+        }
     }
 
     /**
@@ -39,6 +44,7 @@ public class NodesUsageRequest extends BaseNodesRequest<NodesUsageRequest> {
     public NodesUsageRequest all() {
         this.restActions = true;
         this.aggregations = true;
+        this.queries = true;
         return this;
     }
 
@@ -47,6 +53,8 @@ public class NodesUsageRequest extends BaseNodesRequest<NodesUsageRequest> {
      */
     public NodesUsageRequest clear() {
         this.restActions = false;
+        this.aggregations = false;
+        this.queries = false;
         return this;
     }
 
@@ -66,17 +74,32 @@ public class NodesUsageRequest extends BaseNodesRequest<NodesUsageRequest> {
     }
 
     /**
-     * Should the node rest actions usage statistics be returned.
+     * Should the node aggregations usage statistics be returned.
      */
     public boolean aggregations() {
         return this.aggregations;
     }
 
     /**
-     * Should the node rest actions usage statistics be returned.
+     * Should the node aggregations usage statistics be returned.
      */
     public NodesUsageRequest aggregations(boolean aggregations) {
         this.aggregations = aggregations;
+        return this;
+    }
+
+    /**
+     * Should the node queries usage statistics be returned.
+     */
+    public boolean queries() {
+        return this.queries;
+    }
+
+    /**
+     * Should the node queries usage statistics be returned.
+     */
+    public NodesUsageRequest queries(boolean queries) {
+        this.queries = queries;
         return this;
     }
 
@@ -85,5 +108,8 @@ public class NodesUsageRequest extends BaseNodesRequest<NodesUsageRequest> {
         super.writeTo(out);
         out.writeBoolean(restActions);
         out.writeBoolean(aggregations);
+        if (out.getVersion().onOrAfter(Version.V_8_5_0)) {
+            out.writeBoolean(queries);
+        }
     }
 }

--- a/server/src/main/java/org/elasticsearch/index/IndexModule.java
+++ b/server/src/main/java/org/elasticsearch/index/IndexModule.java
@@ -55,6 +55,7 @@ import org.elasticsearch.indices.recovery.RecoveryState;
 import org.elasticsearch.plugins.IndexStorePlugin;
 import org.elasticsearch.script.ScriptService;
 import org.elasticsearch.search.aggregations.support.ValuesSourceRegistry;
+import org.elasticsearch.search.usage.SearchUsageService;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.xcontent.XContentParserConfiguration;
 
@@ -437,7 +438,8 @@ public final class IndexModule {
         IdFieldMapper idFieldMapper,
         ValuesSourceRegistry valuesSourceRegistry,
         IndexStorePlugin.IndexFoldersDeletionListener indexFoldersDeletionListener,
-        Map<String, IndexStorePlugin.SnapshotCommitSupplier> snapshotCommitSuppliers
+        Map<String, IndexStorePlugin.SnapshotCommitSupplier> snapshotCommitSuppliers,
+        SearchUsageService searchUsageService
     ) throws IOException {
         final IndexEventListener eventListener = freeze();
         Function<IndexService, CheckedFunction<DirectoryReader, DirectoryReader, IOException>> readerWrapperFactory = indexReaderWrapper
@@ -497,7 +499,8 @@ public final class IndexModule {
                 valuesSourceRegistry,
                 recoveryStateFactory,
                 indexFoldersDeletionListener,
-                snapshotCommitSupplier
+                snapshotCommitSupplier,
+                searchUsageService
             );
             success = true;
             return indexService;

--- a/server/src/main/java/org/elasticsearch/index/IndexService.java
+++ b/server/src/main/java/org/elasticsearch/index/IndexService.java
@@ -73,6 +73,7 @@ import org.elasticsearch.indices.recovery.RecoveryState;
 import org.elasticsearch.plugins.IndexStorePlugin;
 import org.elasticsearch.script.ScriptService;
 import org.elasticsearch.search.aggregations.support.ValuesSourceRegistry;
+import org.elasticsearch.search.usage.SearchUsageService;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.xcontent.XContentParserConfiguration;
 
@@ -143,6 +144,7 @@ public class IndexService extends AbstractIndexComponent implements IndicesClust
     private final IndexNameExpressionResolver expressionResolver;
     private final Supplier<Sort> indexSortSupplier;
     private final ValuesSourceRegistry valuesSourceRegistry;
+    private final SearchUsageService searchUsageService;
 
     public IndexService(
         IndexSettings indexSettings,
@@ -174,7 +176,8 @@ public class IndexService extends AbstractIndexComponent implements IndicesClust
         ValuesSourceRegistry valuesSourceRegistry,
         IndexStorePlugin.RecoveryStateFactory recoveryStateFactory,
         IndexStorePlugin.IndexFoldersDeletionListener indexFoldersDeletionListener,
-        IndexStorePlugin.SnapshotCommitSupplier snapshotCommitSupplier
+        IndexStorePlugin.SnapshotCommitSupplier snapshotCommitSupplier,
+        SearchUsageService searchUsageService
     ) {
         super(indexSettings);
         this.allowExpensiveQueries = allowExpensiveQueries;
@@ -186,6 +189,7 @@ public class IndexService extends AbstractIndexComponent implements IndicesClust
         this.expressionResolver = expressionResolver;
         this.valuesSourceRegistry = valuesSourceRegistry;
         this.snapshotCommitSupplier = snapshotCommitSupplier;
+        this.searchUsageService = searchUsageService;
         if (needsMapperService(indexSettings, indexCreationContext)) {
             assert indexAnalyzers != null;
             this.mapperService = new MapperService(
@@ -637,7 +641,8 @@ public class IndexService extends AbstractIndexComponent implements IndicesClust
             indexNameMatcher,
             allowExpensiveQueries,
             valuesSourceRegistry,
-            runtimeMappings
+            runtimeMappings,
+            searchUsageService
         );
     }
 

--- a/server/src/main/java/org/elasticsearch/index/query/AbstractQueryBuilder.java
+++ b/server/src/main/java/org/elasticsearch/index/query/AbstractQueryBuilder.java
@@ -115,6 +115,7 @@ public abstract class AbstractQueryBuilder<QB extends AbstractQueryBuilder<QB>> 
                 context.addNamedQuery(queryName, query);
             }
         }
+        context.addQueryUsage(this.getName());
         return query;
     }
 

--- a/server/src/main/java/org/elasticsearch/indices/IndicesService.java
+++ b/server/src/main/java/org/elasticsearch/indices/IndicesService.java
@@ -127,6 +127,7 @@ import org.elasticsearch.search.internal.SearchContext;
 import org.elasticsearch.search.internal.ShardSearchRequest;
 import org.elasticsearch.search.query.QueryPhase;
 import org.elasticsearch.search.query.QuerySearchResult;
+import org.elasticsearch.search.usage.SearchUsageService;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.xcontent.NamedXContentRegistry;
 import org.elasticsearch.xcontent.XContentFactory;
@@ -246,6 +247,7 @@ public class IndicesService extends AbstractLifecycleComponent
     private final ValuesSourceRegistry valuesSourceRegistry;
     private final TimestampFieldMapperService timestampFieldMapperService;
     private final CheckedBiConsumer<ShardSearchRequest, StreamOutput, IOException> requestCacheKeyDifferentiator;
+    private final SearchUsageService searchUsageService;
 
     @Override
     protected void doStart() {
@@ -279,7 +281,8 @@ public class IndicesService extends AbstractLifecycleComponent
         Map<String, IndexStorePlugin.RecoveryStateFactory> recoveryStateFactories,
         List<IndexStorePlugin.IndexFoldersDeletionListener> indexFoldersDeletionListeners,
         Map<String, IndexStorePlugin.SnapshotCommitSupplier> snapshotCommitSuppliers,
-        CheckedBiConsumer<ShardSearchRequest, StreamOutput, IOException> requestCacheKeyDifferentiator
+        CheckedBiConsumer<ShardSearchRequest, StreamOutput, IOException> requestCacheKeyDifferentiator,
+        SearchUsageService searchUsageService
     ) {
         this.settings = settings;
         this.threadPool = threadPool;
@@ -384,6 +387,7 @@ public class IndicesService extends AbstractLifecycleComponent
         clusterService.getClusterSettings().addSettingsUpdateConsumer(ALLOW_EXPENSIVE_QUERIES, this::setAllowExpensiveQueries);
 
         this.timestampFieldMapperService = new TimestampFieldMapperService(settings, threadPool, this);
+        this.searchUsageService = searchUsageService;
     }
 
     private static final String DANGLING_INDICES_UPDATE_THREAD_NAME = "DanglingIndices#updateTask";
@@ -726,7 +730,8 @@ public class IndicesService extends AbstractLifecycleComponent
             idFieldMappers.apply(idxSettings.getMode()),
             valuesSourceRegistry,
             indexFoldersDeletionListeners,
-            snapshotCommitSuppliers
+            snapshotCommitSuppliers,
+            searchUsageService
         );
     }
 

--- a/server/src/main/java/org/elasticsearch/node/Node.java
+++ b/server/src/main/java/org/elasticsearch/node/Node.java
@@ -181,6 +181,7 @@ import org.elasticsearch.search.SearchService;
 import org.elasticsearch.search.SearchUtils;
 import org.elasticsearch.search.aggregations.support.AggregationUsageService;
 import org.elasticsearch.search.fetch.FetchPhase;
+import org.elasticsearch.search.usage.SearchUsageService;
 import org.elasticsearch.shutdown.PluginShutdownService;
 import org.elasticsearch.snapshots.InternalSnapshotsInfoService;
 import org.elasticsearch.snapshots.RepositoryIntegrityHealthIndicatorService;
@@ -658,7 +659,8 @@ public class Node implements Closeable {
                 recoveryStateFactories,
                 indexFoldersDeletionListeners,
                 snapshotCommitSuppliers,
-                searchModule.getRequestCacheKeyDifferentiator()
+                searchModule.getRequestCacheKeyDifferentiator(),
+                searchModule.getSearchUsageService()
             );
 
             final var parameters = new IndexSettingProvider.Parameters(indicesService::createIndexMapperServiceForValidation);
@@ -980,6 +982,7 @@ public class Node implements Closeable {
                 b.bind(IndexingPressure.class).toInstance(indexingLimits);
                 b.bind(UsageService.class).toInstance(usageService);
                 b.bind(AggregationUsageService.class).toInstance(searchModule.getValuesSourceRegistry().getUsageService());
+                b.bind(SearchUsageService.class).toInstance(searchModule.getSearchUsageService());
                 b.bind(NamedWriteableRegistry.class).toInstance(namedWriteableRegistry);
                 b.bind(MetadataUpgrader.class).toInstance(metadataUpgrader);
                 b.bind(MetaStateService.class).toInstance(metaStateService);

--- a/server/src/main/java/org/elasticsearch/rest/action/admin/cluster/RestNodesUsageAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/admin/cluster/RestNodesUsageAction.java
@@ -62,6 +62,7 @@ public class RestNodesUsageAction extends BaseRestHandler {
             nodesUsageRequest.clear();
             nodesUsageRequest.restActions(metrics.contains("rest_actions"));
             nodesUsageRequest.aggregations(metrics.contains("aggregations"));
+            nodesUsageRequest.queries(metrics.contains("queries"));
         }
 
         return channel -> client.admin().cluster().nodesUsage(nodesUsageRequest, new RestBuilderListener<NodesUsageResponse>(channel) {

--- a/server/src/main/java/org/elasticsearch/search/SearchService.java
+++ b/server/src/main/java/org/elasticsearch/search/SearchService.java
@@ -1663,6 +1663,8 @@ public class SearchService extends AbstractLifecycleComponent implements IndexEv
                         listener.onFetchPhase(context, afterQueryTime - time);
                     } else {
                         listener.onQueryPhase(context, afterQueryTime - time);
+                        // report what queries were used in this request
+                        context.getSearchExecutionContext().reportQueriesUsage();
                     }
                 } else {
                     if (fetch) {

--- a/server/src/main/java/org/elasticsearch/search/usage/SearchUsageService.java
+++ b/server/src/main/java/org/elasticsearch/search/usage/SearchUsageService.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.search.usage;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.atomic.LongAdder;
+
+public class SearchUsageService {
+    private final Map<String, LongAdder> queriesUsage;
+
+    public static class Builder {
+        private final Map<String, LongAdder> queriesUsage;
+
+        public Builder() {
+            queriesUsage = new HashMap<>();
+        }
+
+        public void registerQuery(String queryName) {
+            if (queriesUsage.put(queryName, new LongAdder()) != null) {
+                throw new IllegalArgumentException("stats for the query type [" + queryName + "] already registered!");
+            }
+        }
+
+        public SearchUsageService build() {
+            return new SearchUsageService(this);
+        }
+    }
+
+    private SearchUsageService(Builder builder) {
+        this.queriesUsage = Collections.unmodifiableMap(builder.queriesUsage);
+    }
+
+    public void incrementQueryUsage(String query) {
+        LongAdder adder = queriesUsage.get(query);
+        // Not all queries register their usage at the moment
+        if (adder != null) {
+            adder.increment();
+        }
+    }
+
+    public Map<String, Long> getUsageStats() {
+        Map<String, Long> queriesUsageMap = new HashMap<>();
+        queriesUsage.forEach((query, adder) -> {
+            long usageCount = adder.longValue();
+            if (usageCount > 0) {
+                queriesUsageMap.put(query, usageCount);
+            }
+        });
+        return queriesUsageMap;
+    }
+
+}

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/MetadataCreateIndexServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/MetadataCreateIndexServiceTests.java
@@ -136,7 +136,8 @@ public class MetadataCreateIndexServiceTests extends ESTestCase {
             null,
             () -> true,
             null,
-            emptyMap()
+            emptyMap(),
+            null
         );
     }
 

--- a/server/src/test/java/org/elasticsearch/index/IndexModuleTests.java
+++ b/server/src/test/java/org/elasticsearch/index/IndexModuleTests.java
@@ -197,7 +197,8 @@ public class IndexModuleTests extends ESTestCase {
             module.indexSettings().getMode().idFieldMapperWithoutFieldData(),
             null,
             indexDeletionListener,
-            emptyMap()
+            emptyMap(),
+            null
         );
     }
 

--- a/server/src/test/java/org/elasticsearch/index/mapper/DateFieldTypeTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/DateFieldTypeTests.java
@@ -192,7 +192,8 @@ public class DateFieldTypeTests extends FieldTypeTestCase {
             null,
             () -> true,
             null,
-            emptyMap()
+            emptyMap(),
+            null
         );
         MappedFieldType ft = new DateFieldType("field");
         String date = "2015-10-12T14:10:55";
@@ -247,7 +248,8 @@ public class DateFieldTypeTests extends FieldTypeTestCase {
             null,
             () -> true,
             null,
-            emptyMap()
+            emptyMap(),
+            null
         );
         MappedFieldType ft = new DateFieldType("field");
         String date1 = "2015-10-12T14:10:55";
@@ -325,7 +327,8 @@ public class DateFieldTypeTests extends FieldTypeTestCase {
             null,
             () -> true,
             null,
-            emptyMap()
+            emptyMap(),
+            null
         );
 
         MappedFieldType ft = new DateFieldType("field");

--- a/server/src/test/java/org/elasticsearch/index/mapper/FieldNamesFieldTypeTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/FieldNamesFieldTypeTests.java
@@ -55,7 +55,8 @@ public class FieldNamesFieldTypeTests extends ESTestCase {
             null,
             () -> true,
             null,
-            emptyMap()
+            emptyMap(),
+            null
         );
         Query termQuery = fieldNamesFieldType.termQuery("field_name", searchExecutionContext);
         assertEquals(new TermQuery(new Term(FieldNamesFieldMapper.CONTENT_TYPE, "field_name")), termQuery);

--- a/server/src/test/java/org/elasticsearch/index/mapper/IndexFieldTypeTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/IndexFieldTypeTests.java
@@ -79,7 +79,8 @@ public class IndexFieldTypeTests extends ESTestCase {
             indexNameMatcher,
             () -> true,
             null,
-            emptyMap()
+            emptyMap(),
+            null
         );
     }
 }

--- a/server/src/test/java/org/elasticsearch/index/mapper/NumberFieldTypeTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/NumberFieldTypeTests.java
@@ -622,7 +622,8 @@ public class NumberFieldTypeTests extends FieldTypeTestCase {
             null,
             () -> true,
             null,
-            emptyMap()
+            emptyMap(),
+            null
         );
 
         final int iters = 10;

--- a/server/src/test/java/org/elasticsearch/index/mapper/RangeFieldTypeTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/RangeFieldTypeTests.java
@@ -221,7 +221,8 @@ public class RangeFieldTypeTests extends FieldTypeTestCase {
             null,
             () -> true,
             null,
-            emptyMap()
+            emptyMap(),
+            null
         );
     }
 

--- a/server/src/test/java/org/elasticsearch/index/query/RangeQueryRewriteTests.java
+++ b/server/src/test/java/org/elasticsearch/index/query/RangeQueryRewriteTests.java
@@ -48,7 +48,8 @@ public class RangeQueryRewriteTests extends ESSingleNodeTestCase {
             null,
             () -> true,
             null,
-            emptyMap()
+            emptyMap(),
+            null
         );
         RangeQueryBuilder range = new RangeQueryBuilder("foo");
         assertEquals(Relation.DISJOINT, range.getRelation(context));
@@ -88,7 +89,8 @@ public class RangeQueryRewriteTests extends ESSingleNodeTestCase {
             null,
             () -> true,
             null,
-            emptyMap()
+            emptyMap(),
+            null
         );
         RangeQueryBuilder range = new RangeQueryBuilder("foo");
         // can't make assumptions on a missing reader, so it must return INTERSECT
@@ -130,7 +132,8 @@ public class RangeQueryRewriteTests extends ESSingleNodeTestCase {
             null,
             () -> true,
             null,
-            emptyMap()
+            emptyMap(),
+            null
         );
         RangeQueryBuilder range = new RangeQueryBuilder("foo");
         // no values -> DISJOINT

--- a/server/src/test/java/org/elasticsearch/index/query/SearchExecutionContextTests.java
+++ b/server/src/test/java/org/elasticsearch/index/query/SearchExecutionContextTests.java
@@ -193,7 +193,8 @@ public class SearchExecutionContextTests extends ESTestCase {
             null,
             () -> true,
             null,
-            emptyMap()
+            emptyMap(),
+            null
         );
 
         assertTrue(context.indexSortedOnField("sort_field"));
@@ -440,7 +441,8 @@ public class SearchExecutionContextTests extends ESTestCase {
             null,
             () -> true,
             null,
-            runtimeMappings
+            runtimeMappings,
+            null
         );
     }
 

--- a/server/src/test/java/org/elasticsearch/search/fetch/subphase/FieldFetcherTests.java
+++ b/server/src/test/java/org/elasticsearch/search/fetch/subphase/FieldFetcherTests.java
@@ -1270,7 +1270,8 @@ public class FieldFetcherTests extends MapperServiceTestCase {
             null,
             null,
             null,
-            emptyMap()
+            emptyMap(),
+            null
         );
     }
 

--- a/server/src/test/java/org/elasticsearch/search/fetch/subphase/highlight/HighlightBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/search/fetch/subphase/highlight/HighlightBuilderTests.java
@@ -312,7 +312,8 @@ public class HighlightBuilderTests extends ESTestCase {
             null,
             () -> true,
             null,
-            emptyMap()
+            emptyMap(),
+            null
         ) {
             @Override
             public MappedFieldType getFieldType(String name) {

--- a/server/src/test/java/org/elasticsearch/search/rescore/QueryRescorerBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/search/rescore/QueryRescorerBuilderTests.java
@@ -150,7 +150,8 @@ public class QueryRescorerBuilderTests extends ESTestCase {
             null,
             () -> true,
             null,
-            emptyMap()
+            emptyMap(),
+            null
         ) {
             @Override
             public MappedFieldType getFieldType(String name) {
@@ -212,7 +213,8 @@ public class QueryRescorerBuilderTests extends ESTestCase {
             null,
             () -> true,
             null,
-            emptyMap()
+            emptyMap(),
+            null
         ) {
             @Override
             public MappedFieldType getFieldType(String name) {

--- a/server/src/test/java/org/elasticsearch/search/sort/AbstractSortTestCase.java
+++ b/server/src/test/java/org/elasticsearch/search/sort/AbstractSortTestCase.java
@@ -214,7 +214,8 @@ public abstract class AbstractSortTestCase<T extends SortBuilder<T>> extends EST
             null,
             () -> true,
             null,
-            emptyMap()
+            emptyMap(),
+            null
         ) {
 
             @Override

--- a/server/src/test/java/org/elasticsearch/search/suggest/AbstractSuggestionBuilderTestCase.java
+++ b/server/src/test/java/org/elasticsearch/search/suggest/AbstractSuggestionBuilderTestCase.java
@@ -192,7 +192,8 @@ public abstract class AbstractSuggestionBuilderTestCase<SB extends SuggestionBui
                 null,
                 () -> true,
                 null,
-                emptyMap()
+                emptyMap(),
+                null
             );
 
             SuggestionContext suggestionContext = suggestionBuilder.build(mockContext);
@@ -248,7 +249,8 @@ public abstract class AbstractSuggestionBuilderTestCase<SB extends SuggestionBui
             null,
             () -> true,
             null,
-            emptyMap()
+            emptyMap(),
+            null
         );
         if (randomBoolean()) {
             mockContext.setAllowUnmappedFields(randomBoolean());

--- a/server/src/test/java/org/elasticsearch/snapshots/SnapshotResiliencyTests.java
+++ b/server/src/test/java/org/elasticsearch/snapshots/SnapshotResiliencyTests.java
@@ -1787,6 +1787,7 @@ public class SnapshotResiliencyTests extends ESTestCase {
                     emptyMap(),
                     List.of(),
                     emptyMap(),
+                    null,
                     null
                 );
                 final RecoverySettings recoverySettings = new RecoverySettings(settings, clusterSettings);

--- a/test/framework/src/main/java/org/elasticsearch/index/mapper/MapperServiceTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/index/mapper/MapperServiceTestCase.java
@@ -640,7 +640,8 @@ public abstract class MapperServiceTestCase extends ESTestCase {
             null,
             () -> true,
             null,
-            Collections.emptyMap()
+            Collections.emptyMap(),
+            null
         );
     }
 

--- a/test/framework/src/main/java/org/elasticsearch/search/aggregations/AggregatorTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/search/aggregations/AggregatorTestCase.java
@@ -326,7 +326,8 @@ public abstract class AggregatorTestCase extends ESTestCase {
             null,
             () -> true,
             valuesSourceRegistry,
-            emptyMap()
+            emptyMap(),
+            null
         );
 
         MultiBucketConsumer consumer = new MultiBucketConsumer(maxBucket, breakerService.getBreaker(CircuitBreaker.REQUEST));

--- a/test/framework/src/main/java/org/elasticsearch/test/AbstractBuilderTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/AbstractBuilderTestCase.java
@@ -508,7 +508,8 @@ public abstract class AbstractBuilderTestCase extends ESTestCase {
                 indexNameMatcher(),
                 () -> true,
                 null,
-                emptyMap()
+                emptyMap(),
+                null
             );
         }
 

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/cluster/routing/allocation/mapper/DataTierFieldTypeTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/cluster/routing/allocation/mapper/DataTierFieldTypeTests.java
@@ -131,7 +131,8 @@ public class DataTierFieldTypeTests extends MapperServiceTestCase {
             indexNameMatcher,
             () -> true,
             null,
-            emptyMap()
+            emptyMap(),
+            null
         );
     }
 
@@ -161,7 +162,8 @@ public class DataTierFieldTypeTests extends MapperServiceTestCase {
             value -> true,
             () -> true,
             null,
-            emptyMap()
+            emptyMap(),
+            null
         );
     }
 }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/accesscontrol/DocumentSubsetBitsetCacheTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/accesscontrol/DocumentSubsetBitsetCacheTests.java
@@ -607,7 +607,8 @@ public class DocumentSubsetBitsetCacheTests extends ESTestCase {
                 null,
                 () -> true,
                 null,
-                emptyMap()
+                emptyMap(),
+                null
             );
 
             context = new TestIndexContext(directory, iw, directoryReader, searchExecutionContext, leaf);

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/accesscontrol/SecurityIndexReaderWrapperIntegrationTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/accesscontrol/SecurityIndexReaderWrapperIntegrationTests.java
@@ -104,7 +104,8 @@ public class SecurityIndexReaderWrapperIntegrationTests extends AbstractBuilderT
             null,
             () -> true,
             null,
-            emptyMap()
+            emptyMap(),
+            null
         );
         SearchExecutionContext searchExecutionContext = spy(realSearchExecutionContext);
         DocumentSubsetBitsetCache bitsetCache = new DocumentSubsetBitsetCache(Settings.EMPTY, Executors.newSingleThreadExecutor());
@@ -264,7 +265,8 @@ public class SecurityIndexReaderWrapperIntegrationTests extends AbstractBuilderT
             null,
             () -> true,
             null,
-            emptyMap()
+            emptyMap(),
+            null
         );
         SearchExecutionContext searchExecutionContext = spy(realSearchExecutionContext);
         DocumentSubsetBitsetCache bitsetCache = new DocumentSubsetBitsetCache(Settings.EMPTY, Executors.newSingleThreadExecutor());

--- a/x-pack/plugin/rollup/src/test/java/org/elasticsearch/xpack/rollup/job/RollupIndexerIndexingTests.java
+++ b/x-pack/plugin/rollup/src/test/java/org/elasticsearch/xpack/rollup/job/RollupIndexerIndexingTests.java
@@ -110,7 +110,8 @@ public class RollupIndexerIndexingTests extends AggregatorTestCase {
             null,
             () -> true,
             null,
-            emptyMap()
+            emptyMap(),
+            null
         );
     }
 

--- a/x-pack/plugin/rollup/src/test/java/org/elasticsearch/xpack/rollup/v2/MetricFieldProducerTests.java
+++ b/x-pack/plugin/rollup/src/test/java/org/elasticsearch/xpack/rollup/v2/MetricFieldProducerTests.java
@@ -203,7 +203,8 @@ public class MetricFieldProducerTests extends AggregatorTestCase {
             null,
             () -> true,
             null,
-            emptyMap()
+            emptyMap(),
+            null
         ) {
             @Override
             public MappedFieldType getFieldType(String name) {

--- a/x-pack/plugin/wildcard/src/test/java/org/elasticsearch/xpack/wildcard/mapper/WildcardFieldMapperTests.java
+++ b/x-pack/plugin/wildcard/src/test/java/org/elasticsearch/xpack/wildcard/mapper/WildcardFieldMapperTests.java
@@ -1097,7 +1097,8 @@ public class WildcardFieldMapperTests extends MapperTestCase {
             null,
             () -> true,
             null,
-            emptyMap()
+            emptyMap(),
+            null
         ) {
             @Override
             public MappedFieldType getFieldType(String name) {


### PR DESCRIPTION
Similarly, how GET _nodes/usage API has a section for aggregations,
this adds a similar section for query types.

Interface details:
- Unlike aggregations section, queries section is without a break up on
  field types.
- Query types are deduplicated per search request  (e.g. if a search request
  has 1 bool query and 5 term queries, this is counted as 1 bool query and
  1 term query).

Implementation details:
- A new SearchUsageService is started on a node start. It tracks the
  usage of registered query types.
- Usage of queries is tracked on the successfull completion of
  Query phase. Queries are already rewritten by this stage, thus
  the reported query types could be different from query types
  submitted by a user (e.g. match query could be reported as term query)
- Reported stats besides user submitted queries include internally
  submitted queries (e.g. queries used by Security)
- knn search is reported as "knn_score_doc" query, that is how it is
  represented internally.

Closes #88908, #88821