### PR TITLE
Use threadpool instead of mock in some Repository tests

### DIFF
--- a/server/src/test/java/org/elasticsearch/repositories/RepositoriesServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/repositories/RepositoriesServiceTests.java
@@ -30,7 +30,6 @@ import org.elasticsearch.common.component.Lifecycle;
 import org.elasticsearch.common.component.LifecycleListener;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.MockBigArrays;
-import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.index.snapshots.IndexShardSnapshotStatus;
 import org.elasticsearch.index.store.Store;
@@ -40,6 +39,7 @@ import org.elasticsearch.repositories.blobstore.MeteredBlobStoreRepository;
 import org.elasticsearch.snapshots.SnapshotDeleteListener;
 import org.elasticsearch.snapshots.SnapshotId;
 import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.threadpool.TestThreadPool;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.Transport;
 import org.elasticsearch.transport.TransportService;
@@ -53,7 +53,6 @@ import java.util.Map;
 import java.util.function.Consumer;
 import java.util.function.Function;
 
-import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.isA;
 import static org.mockito.Mockito.mock;
@@ -62,13 +61,12 @@ import static org.mockito.Mockito.when;
 public class RepositoriesServiceTests extends ESTestCase {
 
     private RepositoriesService repositoriesService;
+    private ThreadPool threadPool;
 
     @Override
     public void setUp() throws Exception {
         super.setUp();
-        ThreadContext threadContext = new ThreadContext(Settings.EMPTY);
-        ThreadPool threadPool = mock(ThreadPool.class);
-        when(threadPool.getThreadContext()).thenReturn(threadContext);
+        threadPool = new TestThreadPool("test");
         final TransportService transportService = new TransportService(
             Settings.EMPTY,
             mock(Transport.class),
@@ -102,6 +100,12 @@ public class RepositoriesServiceTests extends ESTestCase {
             List.of()
         );
         repositoriesService.start();
+    }
+
+    @Override
+    public void tearDown() throws Exception {
+        super.tearDown();
+        terminate(threadPool);
     }
 
     public void testRegisterInternalRepository() {

--- a/x-pack/plugin/repository-encrypted/src/test/java/org/elasticsearch/repositories/encrypted/EncryptedRepositoryTests.java
+++ b/x-pack/plugin/repository-encrypted/src/test/java/org/elasticsearch/repositories/encrypted/EncryptedRepositoryTests.java
@@ -17,16 +17,15 @@ import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.settings.SecureString;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.BigArrays;
-import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.core.Tuple;
 import org.elasticsearch.indices.recovery.RecoverySettings;
 import org.elasticsearch.license.XPackLicenseState;
 import org.elasticsearch.repositories.RepositoryException;
 import org.elasticsearch.repositories.blobstore.BlobStoreRepository;
 import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.threadpool.TestThreadPool;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.xcontent.NamedXContentRegistry;
-import org.junit.Before;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -57,9 +56,11 @@ public class EncryptedRepositoryTests extends ESTestCase {
     private EncryptedRepository encryptedRepository;
     private EncryptedRepository.EncryptedBlobStore encryptedBlobStore;
     private Map<BlobPath, byte[]> blobsMap;
+    private ThreadPool threadPool;
 
-    @Before
-    public void setUpMocks() throws Exception {
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
         this.repoPassword = new SecureString(randomAlphaOfLength(20).toCharArray());
         this.delegatedPath = randomFrom(
             BlobPath.EMPTY,
@@ -76,9 +77,7 @@ public class EncryptedRepositoryTests extends ESTestCase {
             Settings.EMPTY
         );
         ClusterApplierService clusterApplierService = mock(ClusterApplierService.class);
-        final var threadContext = new ThreadContext(Settings.EMPTY);
-        final var threadPool = mock(ThreadPool.class);
-        when(threadPool.getThreadContext()).thenReturn(threadContext);
+        threadPool = new TestThreadPool("test");
         when(clusterApplierService.threadPool()).thenReturn(threadPool);
         ClusterService clusterService = mock(ClusterService.class);
         when(clusterService.getClusterApplierService()).thenReturn(clusterApplierService);
@@ -111,6 +110,12 @@ public class EncryptedRepositoryTests extends ESTestCase {
             }).when(blobContainer).readBlob(any(String.class));
             return blobContainer;
         }).when(this.delegatedBlobStore).blobContainer(any(BlobPath.class));
+    }
+
+    @Override
+    public void tearDown() throws Exception {
+        super.tearDown();
+        terminate(threadPool);
     }
 
     public void testStoreDEKSuccess() throws Exception {


### PR DESCRIPTION
Some test changes needed for https://github.com/elastic/elasticsearch/pull/88209. Just to keep the other PR light!

Using mocks in this tests causes NPEs on https://github.com/elastic/elasticsearch/pull/88209. Instead of more mocking, I'd rather use an actual threadpool.