### PR TITLE
[8.4] [DOCS] Move completion type asciidoc (#89086)

### DIFF
--- a/docs/reference/mapping/types.asciidoc
+++ b/docs/reference/mapping/types.asciidoc
@@ -137,6 +137,8 @@ include::types/binary.asciidoc[]
 
 include::types/boolean.asciidoc[]
 
+include::types/completion.asciidoc[]
+
 include::types/date.asciidoc[]
 
 include::types/date_nanos.asciidoc[]

--- a/docs/reference/mapping/types/completion.asciidoc
+++ b/docs/reference/mapping/types/completion.asciidoc
@@ -1,0 +1,61 @@
+[[completion]]
+=== Completion field type
+++++
+<titleabbrev>Completion</titleabbrev>
+++++
+// tag::completion-mapping[]
+To use the <<completion-suggester,`completion` suggester>>, map the field from
+which you want to generate suggestions as type `completion`. This indexes the 
+field values for fast completions.
+
+[source,console]
+--------------------------------------------------
+PUT music
+{
+  "mappings": {
+    "properties": {
+      "suggest": {
+        "type": "completion"
+      }
+    }
+  }
+}
+--------------------------------------------------
+
+==== Parameters for `completion` fields
+
+The following parameters are accepted by `completion` fields:
+
+[horizontal]
+<<analyzer,`analyzer`>>::
+
+    The index analyzer to use, defaults to `simple`.
+
+<<search-analyzer,`search_analyzer`>>::
+
+    The search analyzer to use, defaults to value of `analyzer`.
+
+`preserve_separators`::
+
+    Preserves the separators, defaults to `true`.
+    If disabled, you could find a field starting with `Foo Fighters`, if you
+    suggest for `foof`.
+
+`preserve_position_increments`::
+
+    Enables position increments, defaults to `true`.
+    If disabled and using stopwords analyzer, you could get a
+    field starting with `The Beatles`, if you suggest for `b`. *Note*: You
+    could also achieve this by indexing two inputs, `Beatles` and
+    `The Beatles`, no need to change a simple analyzer, if you are able to
+    enrich your data.
+
+`max_input_length`::
+
+    Limits the length of a single input, defaults to `50` UTF-16 code points.
+    This limit is only used at index time to reduce the total number of
+    characters per input string in order to prevent massive inputs from
+    bloating the underlying datastructure. Most use cases won't be influenced
+    by the default value since prefix completions seldom grow beyond prefixes longer
+    than a handful of characters.
+// end::completion-mapping[]

--- a/docs/reference/search/suggesters/completion-suggest.asciidoc
+++ b/docs/reference/search/suggesters/completion-suggest.asciidoc
@@ -15,57 +15,8 @@ but are costly to build and are stored in-memory.
 
 [[completion-suggester-mapping]]
 ===== Mapping
+include::../../mapping/types/completion.asciidoc[tag=completion-mapping]
 
-To use this feature, specify a special mapping for this field,
-which indexes the field values for fast completions.
-
-[source,console]
---------------------------------------------------
-PUT music
-{
-  "mappings": {
-    "properties": {
-      "suggest": {
-        "type": "completion"
-      },
-      "title": {
-        "type": "keyword"
-      }
-    }
-  }
-}
---------------------------------------------------
-// TESTSETUP
-
-Mapping supports the following parameters:
-
-[horizontal]
-`analyzer`::
-    The index analyzer to use, defaults to `simple`.
-
-`search_analyzer`::
-    The search analyzer to use, defaults to value of `analyzer`.
-
-`preserve_separators`::
-    Preserves the separators, defaults to `true`.
-    If disabled, you could find a field starting with `Foo Fighters`, if you
-    suggest for `foof`.
-
-`preserve_position_increments`::
-    Enables position increments, defaults to `true`.
-    If disabled and using stopwords analyzer, you could get a
-    field starting with `The Beatles`, if you suggest for `b`. *Note*: You
-    could also achieve this by indexing two inputs, `Beatles` and
-    `The Beatles`, no need to change a simple analyzer, if you are able to
-    enrich your data.
-
-`max_input_length`::
-    Limits the length of a single input, defaults to `50` UTF-16 code points.
-    This limit is only used at index time to reduce the total number of
-    characters per input string in order to prevent massive inputs from
-    bloating the underlying datastructure. Most use cases won't be influenced
-    by the default value since prefix completions seldom grow beyond prefixes longer
-    than a handful of characters.
 
 [[indexing]]
 ===== Indexing
@@ -74,6 +25,23 @@ You index suggestions like any other field. A suggestion is made of an
 `input` and an optional `weight` attribute. An `input` is the expected
 text to be matched by a suggestion query and the `weight` determines how
 the suggestions will be scored. Indexing a suggestion is as follows:
+
+////
+[source,console]
+--------------------------------------------------
+PUT music
+{
+  "mappings": {
+    "properties": {
+      "suggest": {
+        "type": "completion"
+      }
+    }
+  }
+}
+--------------------------------------------------
+// TESTSETUP
+////
 
 [source,console]
 --------------------------------------------------


### PR DESCRIPTION
Backports the following commits to 8.4:
 - [DOCS] Move completion type asciidoc (#89086)