### PR TITLE
maybeScheduleNow with delay 0 instead of 1

### DIFF
--- a/modules/ingest-geoip/src/main/java/org/elasticsearch/ingest/geoip/GeoIpDownloader.java
+++ b/modules/ingest-geoip/src/main/java/org/elasticsearch/ingest/geoip/GeoIpDownloader.java
@@ -121,7 +121,7 @@ public class GeoIpDownloader extends AllocatedPersistentTask {
     public void setPollInterval(TimeValue pollInterval) {
         this.pollInterval = pollInterval;
         if (scheduled != null && scheduled.cancel()) {
-            scheduleNextRun(new TimeValue(1));
+            scheduleNextRun(TimeValue.ZERO);
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/health/node/LocalHealthMonitor.java
+++ b/server/src/main/java/org/elasticsearch/health/node/LocalHealthMonitor.java
@@ -99,7 +99,7 @@ public class LocalHealthMonitor implements ClusterStateListener {
 
     // Helper method that starts the monitoring without a delay.
     private void maybeScheduleNow() {
-        maybeScheduleNextRun(TimeValue.timeValueMillis(1));
+        maybeScheduleNextRun(TimeValue.ZERO);
     }
 
     @Override


### PR DESCRIPTION
Replace the 1 millisecond delay to 0 when we want to schedule a monitoring task now.