### PR TITLE
Fix testFollowIndex

### DIFF
--- a/x-pack/plugin/ccr/src/internalClusterTest/java/org/elasticsearch/xpack/ccr/RestartIndexFollowingIT.java
+++ b/x-pack/plugin/ccr/src/internalClusterTest/java/org/elasticsearch/xpack/ccr/RestartIndexFollowingIT.java
@@ -138,7 +138,7 @@ public class RestartIndexFollowingIT extends CcrIntegTestCase {
     }
 
     private Integer getRemoteMaxPendingConnectionListeners() {
-        var response = followerClient().admin().cluster().prepareNodesInfo().setSettings(true).get();
+        var response = followerClient().admin().cluster().prepareNodesInfo("_local").clear().setSettings(true).get();
         var settings = response.getNodes().get(0).getSettings();
         return RemoteConnectionStrategy.REMOTE_MAX_PENDING_CONNECTION_LISTENERS.get(settings);
     }

--- a/x-pack/plugin/ccr/src/internalClusterTest/java/org/elasticsearch/xpack/ccr/RestartIndexFollowingIT.java
+++ b/x-pack/plugin/ccr/src/internalClusterTest/java/org/elasticsearch/xpack/ccr/RestartIndexFollowingIT.java
@@ -15,7 +15,6 @@ import org.elasticsearch.action.admin.cluster.settings.ClusterUpdateSettingsRequ
 import org.elasticsearch.action.support.master.AcknowledgedResponse;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.core.TimeValue;
-import org.elasticsearch.test.junit.annotations.TestLogging;
 import org.elasticsearch.transport.RemoteConnectionInfo;
 import org.elasticsearch.transport.RemoteConnectionStrategy;
 import org.elasticsearch.transport.TransportService;
@@ -33,10 +32,6 @@ import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasItem;
 
-@TestLogging(
-    value = "org.elasticsearch.transport.RemoteClusterService:DEBUG,org.elasticsearch.transport.SniffConnectionStrategy:TRACE",
-    reason = "https://github.com/elastic/elasticsearch/issues/81302"
-)
 public class RestartIndexFollowingIT extends CcrIntegTestCase {
 
     @Override
@@ -121,13 +116,31 @@ public class RestartIndexFollowingIT extends CcrIntegTestCase {
     }
 
     private void setupRemoteCluster() throws Exception {
+        var remoteMaxPendingConnectionListeners = getRemoteMaxPendingConnectionListeners();
+
         ClusterUpdateSettingsRequest updateSettingsRequest = new ClusterUpdateSettingsRequest().masterNodeTimeout(TimeValue.MAX_VALUE);
         String address = getLeaderCluster().getAnyMasterNodeInstance(TransportService.class).boundAddress().publishAddress().toString();
         updateSettingsRequest.persistentSettings(Settings.builder().put("cluster.remote.leader_cluster.seeds", address));
         assertAcked(followerClient().admin().cluster().updateSettings(updateSettingsRequest).actionGet());
-        List<RemoteConnectionInfo> infos = followerClient().execute(RemoteInfoAction.INSTANCE, new RemoteInfoRequest()).get().getInfos();
-        assertThat(infos.size(), equalTo(1));
-        assertTrue(infos.get(0).isConnected());
+
+        if (remoteMaxPendingConnectionListeners == 1) {
+            // if queue is limited then update settings might fail to add a listener to wait for a connection
+            // however remote should be connected eventually by a concurrent task
+            assertBusy(this::isRemoteConnected);
+        } else {
+            assertTrue(isRemoteConnected());
+        }
+    }
+
+    private boolean isRemoteConnected() throws Exception {
+        var infos = followerClient().execute(RemoteInfoAction.INSTANCE, new RemoteInfoRequest()).get().getInfos();
+        return infos.size() == 1 && infos.get(0).isConnected();
+    }
+
+    private Integer getRemoteMaxPendingConnectionListeners() {
+        var response = followerClient().admin().cluster().prepareNodesInfo().setSettings(true).get();
+        var settings = response.getNodes().get(0).getSettings();
+        return RemoteConnectionStrategy.REMOTE_MAX_PENDING_CONNECTION_LISTENERS.get(settings);
     }
 
     private void cleanRemoteCluster() throws Exception {


### PR DESCRIPTION
If queue is limited then update settings might fail to add a listener to wait
for a connection, however remote should be connected eventually by a concurrent
task.

Closes: #81302