### PR TITLE
[DOCS] Replace ES_JAVA_OPTS with CLI_JAVA_OPTS

### DIFF
--- a/docs/reference/index-modules.asciidoc
+++ b/docs/reference/index-modules.asciidoc
@@ -39,7 +39,7 @@ specific index module:
 `index.number_of_shards`::
 The number of primary shards that an index should have. Defaults to `1`. This setting can only be set at index creation time. It cannot be changed on a closed index.
 +
-NOTE: The number of shards are limited to `1024` per index. This limitation is a safety limit to prevent accidental creation of indices that can destabilize a cluster due to resource allocation. The limit can be modified by specifying `export ES_JAVA_OPTS="-Des.index.max_number_of_shards=128"` system property on every node that is part of the cluster.
+NOTE: The number of shards are limited to `1024` per index. This limitation is a safety limit to prevent accidental creation of indices that can destabilize a cluster due to resource allocation. The limit can be modified by specifying `export CLI_JAVA_OPTS="-Des.index.max_number_of_shards=128"` system property on every node that is part of the cluster.
 
 // end::index-number-of-shards-tag[]
 

--- a/docs/reference/setup/advanced-configuration.asciidoc
+++ b/docs/reference/setup/advanced-configuration.asciidoc
@@ -9,7 +9,7 @@ is recommended in most circumstances.
 ==== Set JVM options
 
 If needed, you can override the default JVM options by adding custom options
-files (preferred) or setting the `ES_JAVA_OPTS` environment variable.
+files (preferred) or setting the `CLI_JAVA_OPTS` environment variable.
 
 JVM options files must have the suffix '.options' and contain a line-delimited
 list of JVM arguments. JVM processes options files in lexicographic order.
@@ -70,16 +70,16 @@ as valid JVM arguments are rejected and {es} will fail to start.
 
 In production, use JVM options files to override the
 default settings. In testing and development environments,
-you can also set JVM options through the `ES_JAVA_OPTS` environment variable.
+you can also set JVM options through the `CLI_JAVA_OPTS` environment variable.
 
 [source,sh]
 ---------------------------------
-export ES_JAVA_OPTS="$ES_JAVA_OPTS -Djava.io.tmpdir=/path/to/temp/dir"
+export CLI_JAVA_OPTS="$CLI_JAVA_OPTS -Djava.io.tmpdir=/path/to/temp/dir"
 ./bin/elasticsearch
 ---------------------------------
 
 If you're using the RPM or Debian packages, you can specify
-`ES_JAVA_OPTS` in the <<sysconfig,system configuration file>>.
+`CLI_JAVA_OPTS` in the <<sysconfig,system configuration file>>.
 
 NOTE: {es} ignores the `JAVA_TOOL_OPTIONS` and `JAVA_OPTS` environment variables.
 
@@ -141,16 +141,16 @@ For example, to set the maximum heap size to 2GB, set both `Xms` and `Xmx` to `2
 -Xmx2g
 ------------------
 
-For testing, you can also set the heap sizes using the `ES_JAVA_OPTS`
+For testing, you can also set the heap sizes using the `CLI_JAVA_OPTS`
 environment variable:
 
 [source,sh]
 ------------------
-ES_JAVA_OPTS="-Xms2g -Xmx2g" ./bin/elasticsearch
+CLI_JAVA_OPTS="-Xms2g -Xmx2g" ./bin/elasticsearch
 ------------------
 
-The `ES_JAVA_OPTS` variable overrides all other JVM
-options. We do not recommend using `ES_JAVA_OPTS` in production.
+The `CLI_JAVA_OPTS` variable overrides all other JVM
+options. We do not recommend using `CLI_JAVA_OPTS` in production.
 
 NOTE: If you are running {es} as a Windows service, you can change the heap size
 using the service manager. See <<windows-service>>.

--- a/docs/reference/setup/important-settings/gc-logging.asciidoc
+++ b/docs/reference/setup/important-settings/gc-logging.asciidoc
@@ -42,11 +42,11 @@ Change the default GC log output location to `/opt/my-app/gc.log` by
 
 Configure an {es} <<docker,Docker container>> to send GC debug logs to
   standard error (`stderr`). This lets the container orchestrator
-  handle the output. If using the `ES_JAVA_OPTS` environment variable,
+  handle the output. If using the `CLI_JAVA_OPTS` environment variable,
   specify:
 
 [source,sh]
 ----
 MY_OPTS="-Xlog:disable -Xlog:all=warning:stderr:utctime,level,tags -Xlog:gc=debug:stderr:utctime"
-docker run -e ES_JAVA_OPTS="$MY_OPTS" # etc
+docker run -e CLI_JAVA_OPTS="$MY_OPTS" # etc
 ----

--- a/docs/reference/setup/install/docker.asciidoc
+++ b/docs/reference/setup/install/docker.asciidoc
@@ -192,13 +192,13 @@ endif::[]
 If you experience issues where the container where your first node is running
 exits when your second node starts, explicitly set values for the JVM heap size.
 To <<set-jvm-heap-size,manually configure the heap size>>, include the
-`ES_JAVA_OPTS` variable and set values for `-Xms` and `-Xmx` when starting each
+`CLI_JAVA_OPTS` variable and set values for `-Xms` and `-Xmx` when starting each
 node. For example, the following command starts node `es02` and sets the
 minimum and maximum JVM heap size to 1 GB:
 
 [source,sh,subs="attributes"]
 ----
-docker run -e ES_JAVA_OPTS="-Xms1g -Xmx1g" -e ENROLLMENT_TOKEN="<token>" --name es02 -p 9201:9200 --net elastic -it docker.elastic.co/elasticsearch/elasticsearch:{docker-image}
+docker run -e CLI_JAVA_OPTS="-Xms1g -Xmx1g" -e ENROLLMENT_TOKEN="<token>" --name es02 -p 9201:9200 --net elastic -it docker.elastic.co/elasticsearch/elasticsearch:{docker-image}
 ----
 
 ===== Next steps
@@ -500,10 +500,10 @@ To manually set the heap size in production, bind mount a <<set-jvm-options,JVM
 options>> file under `/usr/share/elasticsearch/config/jvm.options.d` that
 includes your desired <<set-jvm-heap-size,heap size>> settings.
 
-For testing, you can also manually set the heap size using the `ES_JAVA_OPTS`
+For testing, you can also manually set the heap size using the `CLI_JAVA_OPTS`
 environment variable. For example, to use 16GB, specify `-e
-ES_JAVA_OPTS="-Xms16g -Xmx16g"` with `docker run`. The `ES_JAVA_OPTS` variable
-overrides all other JVM options. We do not recommend using `ES_JAVA_OPTS` in
+CLI_JAVA_OPTS="-Xms16g -Xmx16g"` with `docker run`. The `CLI_JAVA_OPTS` variable
+overrides all other JVM options. We do not recommend using `CLI_JAVA_OPTS` in
 production. The `docker-compose.yml` file above sets the heap size to 512MB.
 
 

--- a/docs/reference/setup/install/sysconfig-file.asciidoc
+++ b/docs/reference/setup/install/sysconfig-file.asciidoc
@@ -9,7 +9,7 @@
     `jvm.options`, and `log4j2.properties` files); defaults to
     `/etc/elasticsearch`.
 
-`ES_JAVA_OPTS`::
+`CLI_JAVA_OPTS`::
 
     Any additional JVM system properties you may want to apply.
 

--- a/docs/reference/setup/install/zip-windows.asciidoc
+++ b/docs/reference/setup/install/zip-windows.asciidoc
@@ -210,7 +210,7 @@ The {es} service can be configured prior to installation by setting the followin
     `jvm.options`, and `log4j2.properties` files), defaults to
     `%ES_HOME%\config`.
 
-`ES_JAVA_OPTS`::
+`CLI_JAVA_OPTS`::
 
     Any additional JVM system properties you may want to apply.
 

--- a/docs/reference/setup/sysconfig/swap.asciidoc
+++ b/docs/reference/setup/sysconfig/swap.asciidoc
@@ -104,11 +104,11 @@ RPM and Debian::
 Another possible reason why `mlockall` can fail is that
 <<executable-jna-tmpdir,the JNA temporary directory (usually a sub-directory of
 `/tmp`) is mounted with the `noexec` option>>. This can be solved by specifying
-a new temporary directory for JNA using the `ES_JAVA_OPTS` environment variable:
+a new temporary directory for JNA using the `CLI_JAVA_OPTS` environment variable:
 
 [source,sh]
 --------------
-export ES_JAVA_OPTS="$ES_JAVA_OPTS -Djna.tmpdir=<path>"
+export CLI_JAVA_OPTS="$CLI_JAVA_OPTS -Djna.tmpdir=<path>"
 ./bin/elasticsearch
 --------------
 


### PR DESCRIPTION
Replaces remaining instances of `ES_JAVA_OPTS` with `CLI_JAVA_OPTS`. 

Extends this change from #89003 to the remainder of the Elasticsearch docs.

Relates to #85821