### PR TITLE
Pipeline setting missing in reindex.asciidoc

### DIFF
--- a/docs/reference/docs/reindex.asciidoc
+++ b/docs/reference/docs/reindex.asciidoc
@@ -576,7 +576,7 @@ IMPORTANT: To reindex to a data stream destination, this argument must be
 `create`.
 
 `pipeline`:::
-(Optional, string) the name of the pipeline to utilize <<ingest>>.
+(Optional, string) the name of the <<reindex-with-an-ingest-pipeline,pipeline>> to use.
 
 `script`::
 `source`:::

--- a/docs/reference/docs/reindex.asciidoc
+++ b/docs/reference/docs/reindex.asciidoc
@@ -575,6 +575,9 @@ Valid values: `index`, `create`. Defaults to `index`.
 IMPORTANT: To reindex to a data stream destination, this argument must be
 `create`.
 
+`pipeline`:::
+(Optional, string) the name of the pipeline to utilize <<ingest>>.
+
 `script`::
 `source`:::
 (Optional, string) The script to run to update the document source or metadata when reindexing.


### PR DESCRIPTION
Using pipelines is described but when describing the request it is missing.