### PR TITLE
[8.4] Fix failing test RollupActionIT.testRollupIndex (#89101)

### DIFF
--- a/x-pack/plugin/ilm/qa/multi-node/src/javaRestTest/java/org/elasticsearch/xpack/ilm/actions/RollupActionIT.java
+++ b/x-pack/plugin/ilm/qa/multi-node/src/javaRestTest/java/org/elasticsearch/xpack/ilm/actions/RollupActionIT.java
@@ -146,6 +146,7 @@ public class RollupActionIT extends ESRestTestCase {
         String phaseName = randomFrom("warm", "cold");
         createNewSingletonPolicy(client(), policy, phaseName, new RollupILMAction(ConfigTestHelpers.randomInterval()));
         updatePolicy(client(), index, policy);
+        updateClusterSettings(client(), Settings.builder().put("indices.lifecycle.poll_interval", "5s").build());
 
         String rollupIndex = waitAndGetRollupIndexName(client(), index);
         assertNotNull("Cannot retrieve rollup index name", rollupIndex);


### PR DESCRIPTION
Backports the following commits to 8.4:
 - Fix failing test RollupActionIT.testRollupIndex (#89101)