### PR TITLE
[7.17] Override bulk visit methods of exitable point visitor (#82120)

### DIFF
--- a/docs/changelog/82120.yaml
+++ b/docs/changelog/82120.yaml
@@ -1,0 +1,5 @@
+pr: 82120
+summary: Override bulk visit methods of exitable point visitor
+area: Search
+type: bug
+issues: []

--- a/server/src/main/java/org/elasticsearch/search/internal/ExitableDirectoryReader.java
+++ b/server/src/main/java/org/elasticsearch/search/internal/ExitableDirectoryReader.java
@@ -17,6 +17,7 @@ import org.apache.lucene.index.LeafReader;
 import org.apache.lucene.index.PointValues;
 import org.apache.lucene.index.Terms;
 import org.apache.lucene.index.TermsEnum;
+import org.apache.lucene.search.DocIdSetIterator;
 import org.apache.lucene.search.suggest.document.CompletionTerms;
 import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.automaton.CompiledAutomaton;
@@ -267,9 +268,21 @@ class ExitableDirectoryReader extends FilterDirectoryReader {
         }
 
         @Override
+        public void visit(DocIdSetIterator iterator) throws IOException {
+            checkAndThrowWithSampling();
+            in.visit(iterator);
+        }
+
+        @Override
         public void visit(int docID, byte[] packedValue) throws IOException {
             checkAndThrowWithSampling();
             in.visit(docID, packedValue);
+        }
+
+        @Override
+        public void visit(DocIdSetIterator iterator, byte[] packedValue) throws IOException {
+            checkAndThrowWithSampling();
+            in.visit(iterator, packedValue);
         }
 
         @Override

--- a/server/src/main/java/org/elasticsearch/search/internal/ExitableDirectoryReader.java
+++ b/server/src/main/java/org/elasticsearch/search/internal/ExitableDirectoryReader.java
@@ -268,12 +268,6 @@ class ExitableDirectoryReader extends FilterDirectoryReader {
         }
 
         @Override
-        public void visit(DocIdSetIterator iterator) throws IOException {
-            checkAndThrowWithSampling();
-            in.visit(iterator);
-        }
-
-        @Override
         public void visit(int docID, byte[] packedValue) throws IOException {
             checkAndThrowWithSampling();
             in.visit(docID, packedValue);


### PR DESCRIPTION
Backports the following commits to 7.17:
 - Override bulk visit methods of exitable point visitor (#82120)