### PR TITLE
[8.4] Override bulk visit methods of exitable point visitor (#82120)

### DIFF
--- a/docs/changelog/82120.yaml
+++ b/docs/changelog/82120.yaml
@@ -1,0 +1,5 @@
+pr: 82120
+summary: Override bulk visit methods of exitable point visitor
+area: Search
+type: bug
+issues: []

--- a/server/src/main/java/org/elasticsearch/search/internal/ExitableDirectoryReader.java
+++ b/server/src/main/java/org/elasticsearch/search/internal/ExitableDirectoryReader.java
@@ -18,6 +18,7 @@ import org.apache.lucene.index.PointValues;
 import org.apache.lucene.index.QueryTimeout;
 import org.apache.lucene.index.Terms;
 import org.apache.lucene.index.TermsEnum;
+import org.apache.lucene.search.DocIdSetIterator;
 import org.apache.lucene.search.suggest.document.CompletionTerms;
 import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.automaton.CompiledAutomaton;
@@ -347,9 +348,21 @@ class ExitableDirectoryReader extends FilterDirectoryReader {
         }
 
         @Override
+        public void visit(DocIdSetIterator iterator) throws IOException {
+            checkAndThrowWithSampling();
+            in.visit(iterator);
+        }
+
+        @Override
         public void visit(int docID, byte[] packedValue) throws IOException {
             checkAndThrowWithSampling();
             in.visit(docID, packedValue);
+        }
+
+        @Override
+        public void visit(DocIdSetIterator iterator, byte[] packedValue) throws IOException {
+            checkAndThrowWithSampling();
+            in.visit(iterator, packedValue);
         }
 
         @Override


### PR DESCRIPTION
Backports the following commits to 8.4:
 - Override bulk visit methods of exitable point visitor (#82120)