### PR TITLE
Handling the master stability health case where there has never been an elected master node

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/cluster/coordination/CoordinationDiagnosticsServiceIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/cluster/coordination/CoordinationDiagnosticsServiceIT.java
@@ -11,19 +11,25 @@ package org.elasticsearch.cluster.coordination;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
 import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.core.TimeValue;
+import org.elasticsearch.node.Node;
 import org.elasticsearch.test.ESIntegTestCase;
+import org.elasticsearch.test.InternalTestCluster;
 import org.elasticsearch.test.disruption.BlockClusterStateProcessing;
 import org.elasticsearch.threadpool.Scheduler;
 import org.junit.Before;
 
+import java.io.IOException;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.stream.Collectors;
 
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.emptyOrNullString;
+import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
@@ -94,5 +100,45 @@ public class CoordinationDiagnosticsServiceIT extends ESIntegTestCase {
         });
 
         disruption.stopDisrupting();
+    }
+
+    public void testNoMasterElected() throws Exception {
+        /*
+         * This test starts up a 3-node cluster where all nodes are master eligible. It then shuts down two of the nodes and restarts one
+         *  of them. We then assert that diagnoseMasterStability returns a red status because a quorum can't be formed. This is an edge
+         * case because since there is no elected master, clusterChanged() is never called (which is what usually kicks off the polling
+         * that drives the quorum check).
+         */
+        final List<String> nodeNames = internalCluster().startMasterOnlyNodes(
+            3,
+            Settings.builder().put(Node.INITIAL_STATE_TIMEOUT_SETTING.getKey(), "0s").build()
+        );
+        ensureStableCluster(3);
+        String randomNodeName = internalCluster().getRandomNodeName();
+        nodeNames.stream().filter(nodeName -> nodeName.equals(randomNodeName) == false).forEach(nodeName -> {
+            try {
+                internalCluster().stopNode(nodeName);
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        });
+        internalCluster().restartNode(randomNodeName, new InternalTestCluster.RestartCallback() {
+            public boolean validateClusterForming() {
+                return false;
+            }
+        });
+
+        CoordinationDiagnosticsService diagnosticsOnBlockedNode = internalCluster().getInstance(
+            CoordinationDiagnosticsService.class,
+            randomNodeName
+        );
+        try {
+            diagnosticsOnBlockedNode.remoteRequestInitialDelay = TimeValue.ZERO;
+            CoordinationDiagnosticsService.CoordinationDiagnosticsResult result = diagnosticsOnBlockedNode.diagnoseMasterStability(true);
+            assertThat(result.status(), equalTo(CoordinationDiagnosticsService.CoordinationDiagnosticsStatus.RED));
+            assertThat(result.summary(), containsString("the master eligible nodes are unable to form a quorum"));
+        } finally {
+            internalCluster().stopNode(randomNodeName); // This is needed for the test to clean itself up happily
+        }
     }
 }

--- a/server/src/main/java/org/elasticsearch/cluster/coordination/CoordinationDiagnosticsService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/CoordinationDiagnosticsService.java
@@ -375,7 +375,9 @@ public class CoordinationDiagnosticsService implements ClusterStateListener {
          * We want to make sure that the same elements are in this set every time we loop through it. We don't care if values are added
          * while we're copying it, which is why this is not synchronized. We only care that once we have a copy it is not changed.
          */
-        final Map<DiscoveryNode, ClusterFormationStateOrException> nodeToClusterFormationResponses = Map.copyOf(clusterFormationResponses);
+        final Map<DiscoveryNode, ClusterFormationStateOrException> nodeToClusterFormationResponses = clusterFormationResponses == null
+            ? Map.of()
+            : Map.copyOf(clusterFormationResponses);
         for (Map.Entry<DiscoveryNode, ClusterFormationStateOrException> entry : nodeToClusterFormationResponses.entrySet()) {
             Exception remoteException = entry.getValue().exception();
             if (remoteException != null) {
@@ -400,6 +402,13 @@ public class CoordinationDiagnosticsService implements ClusterStateListener {
             nodeToClusterFormationResponses.entrySet()
                 .stream()
                 .collect(Collectors.toMap(Map.Entry::getKey, entry -> entry.getValue().clusterFormationState()));
+        if (nodeClusterFormationStateMap.isEmpty()) {
+            /*
+            * The most likely reason we are here is that polling for cluster formation info never began because there has been no cluster
+            * changed event because there has never been a master node. So we just use the local cluster formation state.
+            */
+            nodeClusterFormationStateMap = Map.of(coordinator.getLocalNode(), coordinator.getClusterFormationState());
+        }
         Map<String, String> nodeIdToClusterFormationDescription = nodeClusterFormationStateMap.entrySet()
             .stream()
             .collect(Collectors.toMap(entry -> entry.getKey().getId(), entry -> entry.getValue().getDescription()));


### PR DESCRIPTION
If a master-eligible node comes up and has never seen an elected master node (and assuming that a quorum requires more than one node), then it ought to report that the master stability health is red because it cannot form a quorum.