### PR TITLE
Script: Common base class for write scripts

### DIFF
--- a/modules/ingest-common/src/main/java/org/elasticsearch/ingest/common/ScriptProcessor.java
+++ b/modules/ingest-common/src/main/java/org/elasticsearch/ingest/common/ScriptProcessor.java
@@ -75,7 +75,7 @@ public final class ScriptProcessor extends AbstractProcessor {
         if (factory == null) {
             factory = scriptService.compile(script, IngestScript.CONTEXT);
         }
-        factory.newInstance(script.getParams(), document.getMetadata(), document.getSourceAndMetadata()).execute();
+        factory.newInstance(script.getParams(), document.getCtxMap()).execute();
         return document;
     }
 

--- a/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/ScriptProcessorFactoryTests.java
+++ b/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/ScriptProcessorFactoryTests.java
@@ -10,8 +10,8 @@ package org.elasticsearch.ingest.common;
 
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.ingest.IngestDocument;
 import org.elasticsearch.ingest.TestIngestDocument;
+import org.elasticsearch.script.CtxMap;
 import org.elasticsearch.script.IngestScript;
 import org.elasticsearch.script.MockScriptEngine;
 import org.elasticsearch.script.Script;
@@ -158,9 +158,8 @@ public class ScriptProcessorFactoryTests extends ESTestCase {
         assertThat(processor.getScript().getType(), equalTo(ScriptType.INLINE));
         assertThat(processor.getScript().getParams(), equalTo(Collections.emptyMap()));
         assertNotNull(processor.getPrecompiledIngestScriptFactory());
-        IngestDocument doc = TestIngestDocument.emptyIngestDocument();
-        Map<String, Object> ctx = TestIngestDocument.emptyIngestDocument().getSourceAndMetadata();
-        processor.getPrecompiledIngestScriptFactory().newInstance(null, doc.getMetadata(), ctx).execute();
+        CtxMap<?> ctx = TestIngestDocument.emptyIngestDocument().getCtxMap();
+        processor.getPrecompiledIngestScriptFactory().newInstance(null, ctx).execute();
         assertThat(ctx.get("foo"), equalTo("bar"));
     }
 

--- a/server/src/main/java/org/elasticsearch/script/IngestScript.java
+++ b/server/src/main/java/org/elasticsearch/script/IngestScript.java
@@ -16,7 +16,7 @@ import java.util.Map;
 /**
  * A script used by the Ingest Script Processor.
  */
-public abstract class IngestScript {
+public abstract class IngestScript extends WriteScript {
 
     public static final String[] PARAMETERS = {};
 
@@ -33,27 +33,14 @@ public abstract class IngestScript {
     /** The generic runtime parameters for the script. */
     private final Map<String, Object> params;
 
-    /** The metadata and source available to the script */
-    private final CtxMap<?> ctxMap;
-
     public IngestScript(Map<String, Object> params, CtxMap<?> ctxMap) {
+        super(ctxMap);
         this.params = params;
-        this.ctxMap = ctxMap;
     }
 
     /** Return the parameters for this script. */
     public Map<String, Object> getParams() {
         return params;
-    }
-
-    /** Provides backwards compatibility access to ctx */
-    public Map<String, Object> getCtx() {
-        return ctxMap;
-    }
-
-    /** Return the ingest metadata object */
-    public Metadata metadata() {
-        return ctxMap.getMetadata();
     }
 
     public abstract void execute();

--- a/server/src/main/java/org/elasticsearch/script/IngestScript.java
+++ b/server/src/main/java/org/elasticsearch/script/IngestScript.java
@@ -33,16 +33,12 @@ public abstract class IngestScript {
     /** The generic runtime parameters for the script. */
     private final Map<String, Object> params;
 
-    /** The metadata available to the script */
-    private final Metadata metadata;
-
     /** The metadata and source available to the script */
-    private final Map<String, Object> ctx;
+    private final CtxMap<?> ctxMap;
 
-    public IngestScript(Map<String, Object> params, Metadata metadata, Map<String, Object> ctx) {
+    public IngestScript(Map<String, Object> params, CtxMap<?> ctxMap) {
         this.params = params;
-        this.metadata = metadata;
-        this.ctx = ctx;
+        this.ctxMap = ctxMap;
     }
 
     /** Return the parameters for this script. */
@@ -52,17 +48,17 @@ public abstract class IngestScript {
 
     /** Provides backwards compatibility access to ctx */
     public Map<String, Object> getCtx() {
-        return ctx;
+        return ctxMap;
     }
 
     /** Return the ingest metadata object */
     public Metadata metadata() {
-        return metadata;
+        return ctxMap.getMetadata();
     }
 
     public abstract void execute();
 
     public interface Factory {
-        IngestScript newInstance(Map<String, Object> params, Metadata metadata, Map<String, Object> ctx);
+        IngestScript newInstance(Map<String, Object> params, CtxMap<?> ctx);
     }
 }

--- a/server/src/main/java/org/elasticsearch/script/ReindexScript.java
+++ b/server/src/main/java/org/elasticsearch/script/ReindexScript.java
@@ -14,7 +14,7 @@ import java.util.Map;
 /**
  * A script used in the reindex api
  */
-public abstract class ReindexScript {
+public abstract class ReindexScript extends WriteScript {
 
     public static final String[] PARAMETERS = {};
 
@@ -24,9 +24,6 @@ public abstract class ReindexScript {
     /** The generic runtime parameters for the script. */
     private final Map<String, Object> params;
 
-    /** The context map for the script */
-    private final CtxMap<ReindexMetadata> ctxMap;
-
     /**
      * Metadata available to the script
      * _index can't be null
@@ -34,23 +31,13 @@ public abstract class ReindexScript {
      * op must be 'noop', 'index' or 'delete'
      */
     public ReindexScript(Map<String, Object> params, CtxMap<ReindexMetadata> ctxMap) {
+        super(ctxMap);
         this.params = params;
-        this.ctxMap = ctxMap;
     }
 
     /** Return the parameters for this script. */
     public Map<String, Object> getParams() {
         return params;
-    }
-
-    /** Return the context map for this script */
-    public Map<String, Object> getCtx() {
-        return ctxMap;
-    }
-
-    /** Return the update metadata for this script */
-    public Metadata metadata() {
-        return ctxMap.getMetadata();
     }
 
     public abstract void execute();

--- a/server/src/main/java/org/elasticsearch/script/UpdateByQueryScript.java
+++ b/server/src/main/java/org/elasticsearch/script/UpdateByQueryScript.java
@@ -14,7 +14,7 @@ import java.util.Map;
 /**
  * A script used by the update by query api
  */
-public abstract class UpdateByQueryScript {
+public abstract class UpdateByQueryScript extends WriteScript {
 
     public static final String[] PARAMETERS = {};
 
@@ -24,27 +24,14 @@ public abstract class UpdateByQueryScript {
     /** The generic runtime parameters for the script. */
     private final Map<String, Object> params;
 
-    /** The context map for the script */
-    private final CtxMap<UpdateByQueryMetadata> ctxMap;
-
     public UpdateByQueryScript(Map<String, Object> params, CtxMap<UpdateByQueryMetadata> ctxMap) {
+        super(ctxMap);
         this.params = params;
-        this.ctxMap = ctxMap;
     }
 
     /** Return the parameters for this script. */
     public Map<String, Object> getParams() {
         return params;
-    }
-
-    /** Return the context map for this script */
-    public Map<String, Object> getCtx() {
-        return ctxMap;
-    }
-
-    /** Return the update metadata for this script */
-    public Metadata metadata() {
-        return ctxMap.getMetadata();
     }
 
     public abstract void execute();

--- a/server/src/main/java/org/elasticsearch/script/UpdateScript.java
+++ b/server/src/main/java/org/elasticsearch/script/UpdateScript.java
@@ -14,7 +14,7 @@ import java.util.Map;
 /**
  * A script used in the update API
  */
-public abstract class UpdateScript {
+public abstract class UpdateScript extends WriteScript {
 
     public static final String[] PARAMETERS = {};
 
@@ -24,26 +24,14 @@ public abstract class UpdateScript {
     /** The generic runtime parameters for the script. */
     private final Map<String, Object> params;
 
-    private final UpdateCtxMap ctxMap;
-
     public UpdateScript(Map<String, Object> params, UpdateCtxMap ctxMap) {
+        super(ctxMap);
         this.params = params;
-        this.ctxMap = ctxMap;
     }
 
     /** Return the parameters for this script. */
     public Map<String, Object> getParams() {
         return params;
-    }
-
-    /** Return the update context for this script. */
-    public Map<String, Object> getCtx() {
-        return ctxMap;
-    }
-
-    /** Return the update metadata for this script */
-    public Metadata metadata() {
-        return ctxMap.getMetadata();
     }
 
     public abstract void execute();

--- a/server/src/main/java/org/elasticsearch/script/WriteScript.java
+++ b/server/src/main/java/org/elasticsearch/script/WriteScript.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.script;
+
+import java.util.Map;
+
+/**
+ * Abstract base class for scripts that write documents.
+ * These scripts provide {@code ctx} for backwards compatibility and expose {@link Metadata}.
+ */
+public abstract class WriteScript {
+    protected final CtxMap<?> ctxMap;
+
+    public WriteScript(CtxMap<?> ctxMap) {
+        this.ctxMap = ctxMap;
+    }
+
+    /** Provides backwards compatibility access to ctx */
+    public Map<String, Object> getCtx() {
+        return ctxMap;
+    }
+
+    /** Return the metadata for this script */
+    public Metadata metadata() {
+        return ctxMap.getMetadata();
+    }
+}

--- a/test/framework/src/main/java/org/elasticsearch/script/MockScriptEngine.java
+++ b/test/framework/src/main/java/org/elasticsearch/script/MockScriptEngine.java
@@ -148,7 +148,7 @@ public class MockScriptEngine implements ScriptEngine {
         } else if (context.instanceClazz.equals(BytesRefSortScript.class)) {
             return context.factoryClazz.cast(new MockBytesRefSortScriptFactory(script));
         } else if (context.instanceClazz.equals(IngestScript.class)) {
-            IngestScript.Factory factory = (parameters, metadata, ctx) -> new IngestScript(parameters, metadata, ctx) {
+            IngestScript.Factory factory = (parameters, ctx) -> new IngestScript(parameters, ctx) {
                 @Override
                 public void execute() {
                     script.apply(ctx);

--- a/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/MlNativeIntegTestCase.java
+++ b/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/MlNativeIntegTestCase.java
@@ -440,7 +440,7 @@ abstract class MlNativeIntegTestCase extends ESIntegTestCase {
                 return context.factoryClazz.cast(new MockScoreScript(MockDeterministicScript.asDeterministic(p -> 0.0)));
             }
             if (context.name.equals("ingest")) {
-                IngestScript.Factory factory = (params, metadata, ctx) -> new IngestScript(params, metadata, ctx) {
+                IngestScript.Factory factory = (params, ctx) -> new IngestScript(params, ctx) {
                     @Override
                     public void execute() {}
                 };

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/MlSingleNodeTestCase.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/MlSingleNodeTestCase.java
@@ -200,7 +200,7 @@ public abstract class MlSingleNodeTestCase extends ESSingleNodeTestCase {
                 return context.factoryClazz.cast(new MockScoreScript(MockDeterministicScript.asDeterministic(p -> 0.0)));
             }
             if (context.name.equals("ingest")) {
-                IngestScript.Factory factory = (vars, metadata, ctx) -> new IngestScript(vars, metadata, ctx) {
+                IngestScript.Factory factory = (vars, ctx) -> new IngestScript(vars, ctx) {
                     @Override
                     public void execute() {}
                 };

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/support/BaseMlIntegTestCase.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/support/BaseMlIntegTestCase.java
@@ -554,7 +554,7 @@ public abstract class BaseMlIntegTestCase extends ESIntegTestCase {
                 return context.factoryClazz.cast(new MockScoreScript(MockDeterministicScript.asDeterministic(p -> 0.0)));
             }
             if (context.name.equals("ingest")) {
-                IngestScript.Factory factory = (vars, metadata, ctx) -> new IngestScript(vars, metadata, ctx) {
+                IngestScript.Factory factory = (vars, ctx) -> new IngestScript(vars, ctx) {
                     @Override
                     public void execute() {}
                 };


### PR DESCRIPTION
Adds `WriteScript` as the common base class for the write scripts: `IngestScript`, `UpdateScript`, `UpdateByQueryScript` and `ReindexScript`.

This pulls the common `getCtx()` and `metadata()` methods into the base class and prepares for the implementation of the ingest fields api (https://github.com/elastic/elasticsearch/issues/79155).

As part of the refactor, `IngestScript` now takes a `CtxMap` directly rather than taking "sourceAndMetadata" (`CtxMap`) and `Metadata` (from `CtxMap`).  There is a new `getCtxMap()` getter to get the typed `CtxMap`.  `getSourceAndMetadata` could have been refactored to do this, but most of the callers of that don't need to know about `CtxMap` and are happy with a `Map<String, Object>`.