### PR TITLE
[8.4] Fix object equals for SqlQueryRequest's binaryCommunication (#87887)

### DIFF
--- a/docs/changelog/87887.yaml
+++ b/docs/changelog/87887.yaml
@@ -1,0 +1,6 @@
+pr: 87887
+summary: fix object equals
+area: SQL
+type: bug
+issues:
+  - []

--- a/docs/changelog/87887.yaml
+++ b/docs/changelog/87887.yaml
@@ -2,5 +2,4 @@ pr: 87887
 summary: fix object equals
 area: SQL
 type: bug
-issues:
-  - []
+issues: []

--- a/x-pack/plugin/sql/sql-action/src/main/java/org/elasticsearch/xpack/sql/action/SqlQueryRequest.java
+++ b/x-pack/plugin/sql/sql-action/src/main/java/org/elasticsearch/xpack/sql/action/SqlQueryRequest.java
@@ -325,7 +325,7 @@ public class SqlQueryRequest extends AbstractSqlQueryRequest {
         return super.equals(obj)
             && fieldMultiValueLeniency == ((SqlQueryRequest) obj).fieldMultiValueLeniency
             && indexIncludeFrozen == ((SqlQueryRequest) obj).indexIncludeFrozen
-            && binaryCommunication == ((SqlQueryRequest) obj).binaryCommunication
+            && Objects.equals(binaryCommunication, ((SqlQueryRequest) obj).binaryCommunication)
             && keepOnCompletion == ((SqlQueryRequest) obj).keepOnCompletion
             && allowPartialSearchResults == ((SqlQueryRequest) obj).allowPartialSearchResults
             && Objects.equals(cursor, ((SqlQueryRequest) obj).cursor)


### PR DESCRIPTION
Backports the following commits to 8.4:
 - Fix object equals for SqlQueryRequest's binaryCommunication (#87887)