### PR TITLE
Add note on per-segment field name overhead

### DIFF
--- a/docs/reference/how-to/size-your-shards.asciidoc
+++ b/docs/reference/how-to/size-your-shards.asciidoc
@@ -76,8 +76,8 @@ Moreover every segment requires a small amount of heap memory for each mapped
 field. This per-segment-per-field heap overhead includes a copy of the field
 name, encoded using ISO-8859-1 if applicable or UTF-16 otherwise. Usually this
 is not noticeable, but you may need to account for this overhead if your shards
-have high segment counts and the corresponding mappings contain very long field
-names or high field counts.
+have high segment counts and the corresponding mappings contain high field
+counts and/or very long field names.
 
 [discrete]
 [[shard-auto-balance]]

--- a/docs/reference/how-to/size-your-shards.asciidoc
+++ b/docs/reference/how-to/size-your-shards.asciidoc
@@ -55,14 +55,14 @@ thread pool>>. This can result in low throughput and slow search speeds.
 
 [discrete]
 [[each-shard-has-overhead]]
-==== Each index, shard and field has overhead
+==== Each index, shard, segment and field has overhead
 
 Every index and every shard requires some memory and CPU resources. In most
 cases, a small set of large shards uses fewer resources than many small shards.
 
 Segments play a big role in a shard's resource usage. Most shards contain
-several segments, which store its index data. {es} keeps segment metadata in
-JVM heap memory so it can be quickly retrieved for searches. As a shard grows,
+several segments, which store its index data. {es} keeps some segment metadata
+in heap memory so it can be quickly retrieved for searches. As a shard grows,
 its segments are <<index-modules-merge,merged>> into fewer, larger segments.
 This decreases the number of segments, which means less metadata is kept in
 heap memory.
@@ -71,6 +71,13 @@ Every mapped field also carries some overhead in terms of memory usage and disk
 space. By default {es} will automatically create a mapping for every field in
 every document it indexes, but you can switch off this behaviour to
 <<explicit-mapping,take control of your mappings>>.
+
+Moreover every segment requires a small amount of heap memory for each mapped
+field. This per-segment-per-field heap overhead includes a copy of the field
+name, encoded using UTF-8. Usually this is not noticeable, but you may need to
+account for this overhead if you have very long field names or high field
+counts in any of your mappings, or if any of your shards have high segment
+counts.
 
 [discrete]
 [[shard-auto-balance]]

--- a/docs/reference/how-to/size-your-shards.asciidoc
+++ b/docs/reference/how-to/size-your-shards.asciidoc
@@ -74,10 +74,10 @@ every document it indexes, but you can switch off this behaviour to
 
 Moreover every segment requires a small amount of heap memory for each mapped
 field. This per-segment-per-field heap overhead includes a copy of the field
-name, encoded using UTF-8. Usually this is not noticeable, but you may need to
-account for this overhead if you have very long field names or high field
-counts in any of your mappings, or if any of your shards have high segment
-counts.
+name, encoded using ISO-8859-1 if applicable or UTF-16 otherwise. Usually this
+is not noticeable, but you may need to account for this overhead if your shards
+have high segment counts and the corresponding mappings contain very long field
+names or high field counts.
 
 [discrete]
 [[shard-auto-balance]]


### PR DESCRIPTION
We encountered a case where a substantial fraction of the heap usage was
due to per-segment-per-field `FieldInfo` objects, particularly
`FieldInfo#name`. This commit adds a note to the sizing docs about this
overhead.

Relates #77466