### PR TITLE
Update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -15,3 +15,7 @@ x-pack/plugin/core/src/main/resources/monitoring-logstash-mb.json @elastic/infra
 x-pack/plugin/core/src/main/resources/monitoring-logstash.json @elastic/infra-monitoring-ui
 x-pack/plugin/core/src/main/resources/monitoring-mb-ilm-policy.json @elastic/infra-monitoring-ui
 x-pack/plugin/monitoring/src/main/java/org/elasticsearch/xpack/monitoring/MonitoringTemplateRegistry.java @elastic/infra-monitoring-ui
+
+# Elastic Agent
+x-pack/plugin/fleet/src/main/java/org/elasticsearch/xpack/fleet @elastic/elastic-agent-control-plane
+x-pack/plugin/core/src/main/resources/fleet-* @elastic/elastic-agent-control-plane


### PR DESCRIPTION
Add Elastic Agent Control Plane team ownership in oder to be aware of changes happening on those files.
Closes #84414 