### PR TITLE
[8.4] Fix typo in geo-distance-query doc (#89148)

### DIFF
--- a/docs/reference/query-dsl/geo-distance-query.asciidoc
+++ b/docs/reference/query-dsl/geo-distance-query.asciidoc
@@ -11,7 +11,7 @@ a given distance of a geopoint.
 [[geo-distance-query-ex]]
 ==== Example
 
-Assume the following the following documents are indexed:
+Assume the following documents are indexed:
 
 [source,console]
 --------------------------------------------------


### PR DESCRIPTION
Backports the following commits to 8.4:
 - Fix typo in geo-distance-query doc (#89148)