### PR TITLE
Remove redundant and slow null token check from KeywordFieldMapper

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/mapper/KeywordFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/KeywordFieldMapper.java
@@ -66,7 +66,6 @@ import org.elasticsearch.search.runtime.StringScriptFieldRegexpQuery;
 import org.elasticsearch.search.runtime.StringScriptFieldTermQuery;
 import org.elasticsearch.search.runtime.StringScriptFieldWildcardQuery;
 import org.elasticsearch.xcontent.XContentBuilder;
-import org.elasticsearch.xcontent.XContentParser;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
@@ -929,15 +928,8 @@ public final class KeywordFieldMapper extends FieldMapper {
 
     @Override
     protected void parseCreateField(DocumentParserContext context) throws IOException {
-        String value;
-        XContentParser parser = context.parser();
-        if (parser.currentToken() == XContentParser.Token.VALUE_NULL) {
-            value = fieldType().nullValue;
-        } else {
-            value = parser.textOrNull();
-        }
-
-        indexValue(context, value);
+        final String value = context.parser().textOrNull();
+        indexValue(context, value == null ? fieldType().nullValue : value);
     }
 
     @Override


### PR DESCRIPTION
Just found this old fix I had lying around :) This gives about a 10% speedup on the KW field mapper for me in the `BeatsMapperBenchmark` (through making things inline nicer I suspect).

No need to check for the null token manually and parse `textOrNull`.
Either we can just use `text()` since we know we don't have to deal
with a null token or use `textOrNull` and check the return value for
`null`.
I chose the latter because it benchmarked slightly faster in `BeatsMapperBenchmark`
but both save the expensive call to `currentToken` on the heavily nested x-content
parser that we use here.
