### PR TITLE
[ML] Defer GA of `bucket_correlation` and `bucket_count_ks_test` aggregations to 8.5

### DIFF
--- a/docs/changelog/88655.yaml
+++ b/docs/changelog/88655.yaml
@@ -1,5 +1,0 @@
-pr: 88655
-summary: Make `bucket_correlation` aggregation generally available
-area: Machine Learning
-type: feature
-issues: []

--- a/docs/changelog/88657.yaml
+++ b/docs/changelog/88657.yaml
@@ -1,5 +1,0 @@
-pr: 88657
-summary: Make `bucket_count_ks_test` aggregation generally available
-area: Machine Learning
-type: feature
-issues: []

--- a/docs/reference/aggregations/pipeline/bucket-correlation-aggregation.asciidoc
+++ b/docs/reference/aggregations/pipeline/bucket-correlation-aggregation.asciidoc
@@ -5,6 +5,8 @@
 <titleabbrev>Bucket correlation</titleabbrev>
 ++++
 
+experimental::[]
+
 A sibling pipeline aggregation which executes a correlation function on the
 configured sibling multi-bucket aggregation.
 

--- a/docs/reference/aggregations/pipeline/bucket-count-ks-test-aggregation.asciidoc
+++ b/docs/reference/aggregations/pipeline/bucket-count-ks-test-aggregation.asciidoc
@@ -5,6 +5,8 @@
 <titleabbrev>Bucket count K-S test</titleabbrev>
 ++++
 
+experimental::[]
+
 A sibling pipeline aggregation which executes a two sample Kolmogorov–Smirnov test
 (referred to as a "K-S test" from now on) against a provided distribution, and the
 distribution implied by the documents counts in the configured sibling aggregation.


### PR DESCRIPTION
This PR reverts #88655 and #88657 from the 8.4 branch, thus
deferring general availability of the `bucket_correlation` and
`bucket_count_ks_test` aggregations to 8.5.