### PR TITLE
Fixing internal action names

### DIFF
--- a/docs/changelog/89182.yaml
+++ b/docs/changelog/89182.yaml
@@ -1,0 +1,5 @@
+pr: 89182
+summary: Fixing internal action names
+area: Health
+type: bug
+issues: []

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/coordination/ClusterFormationInfoAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/coordination/ClusterFormationInfoAction.java
@@ -33,7 +33,7 @@ import java.util.Objects;
 public class ClusterFormationInfoAction extends ActionType<ClusterFormationInfoAction.Response> {
 
     public static final ClusterFormationInfoAction INSTANCE = new ClusterFormationInfoAction();
-    public static final String NAME = "cluster:internal/formation/info";
+    public static final String NAME = "internal:cluster/formation/info";
 
     private ClusterFormationInfoAction() {
         super(NAME, ClusterFormationInfoAction.Response::new);

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/coordination/CoordinationDiagnosticsAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/coordination/CoordinationDiagnosticsAction.java
@@ -34,7 +34,7 @@ import static org.elasticsearch.cluster.coordination.CoordinationDiagnosticsServ
 public class CoordinationDiagnosticsAction extends ActionType<CoordinationDiagnosticsAction.Response> {
 
     public static final CoordinationDiagnosticsAction INSTANCE = new CoordinationDiagnosticsAction();
-    public static final String NAME = "cluster:internal/coordination_diagnostics/info";
+    public static final String NAME = "internal:cluster/coordination_diagnostics/info";
 
     private CoordinationDiagnosticsAction() {
         super(NAME, CoordinationDiagnosticsAction.Response::new);

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/coordination/MasterHistoryAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/coordination/MasterHistoryAction.java
@@ -34,7 +34,7 @@ import java.util.Objects;
 public class MasterHistoryAction extends ActionType<MasterHistoryAction.Response> {
 
     public static final MasterHistoryAction INSTANCE = new MasterHistoryAction();
-    public static final String NAME = "cluster:internal/master_history/get";
+    public static final String NAME = "internal:cluster/master_history/get";
 
     private MasterHistoryAction() {
         super(NAME, MasterHistoryAction.Response::new);

--- a/server/src/main/java/org/elasticsearch/cluster/coordination/MasterHistoryService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/MasterHistoryService.java
@@ -114,7 +114,7 @@ public class MasterHistoryService {
      * @param node The node whose view of the master history we want to fetch
      */
     public void refreshRemoteMasterHistory(DiscoveryNode node) {
-        Version minSupportedVersion = Version.V_8_3_0;
+        Version minSupportedVersion = Version.V_8_4_0;
         if (node.getVersion().onOrAfter(minSupportedVersion)) { // This was introduced in 8.3.0
             logger.trace(
                 "Cannot get master history for {} because it is at version {} and {} is required",

--- a/x-pack/plugin/security/qa/operator-privileges-tests/src/javaRestTest/java/org/elasticsearch/xpack/security/operator/Constants.java
+++ b/x-pack/plugin/security/qa/operator-privileges-tests/src/javaRestTest/java/org/elasticsearch/xpack/security/operator/Constants.java
@@ -247,9 +247,6 @@ public class Constants {
         "cluster:internal/xpack/ml/trained_models/cache/info",
         "cluster:internal/xpack/ml/trained_models/deployments/stats/get",
         "cluster:internal/xpack/transform/reset_mode",
-        "cluster:internal/master_history/get",
-        "cluster:internal/coordination_diagnostics/info",
-        "cluster:internal/formation/info",
         "cluster:monitor/allocation/explain",
         "cluster:monitor/async_search/status",
         "cluster:monitor/ccr/follow_info",
@@ -483,6 +480,9 @@ public class Constants {
         "internal:admin/xpack/searchable_snapshots/frozen_cache_info",
         "internal:admin/xpack/searchable_snapshots/frozen_cache_info[n]",
         "internal:cluster/nodes/indices/shard/store",
+        "internal:cluster/master_history/get",
+        "internal:cluster/coordination_diagnostics/info",
+        "internal:cluster/formation/info",
         "internal:gateway/local/started_shards"
     );
 }


### PR DESCRIPTION
The names of the internal actions used by CoordinationDiagnosticsService did not begin with "internal:", so they could not be used in the system context.