### PR TITLE
Add publishing plugin to elasticsearch-grok project

### DIFF
--- a/libs/grok/build.gradle
+++ b/libs/grok/build.gradle
@@ -5,6 +5,7 @@
  * in compliance with, at your election, the Elastic License 2.0 or the Server
  * Side Public License, v 1.
  */
+apply plugin: 'elasticsearch.publish'
 
 dependencies {
   api 'org.jruby.joni:joni:2.1.29'


### PR DESCRIPTION
It seems https://github.com/elastic/elasticsearch/pull/88982 introduced a dependency on `elasticsearch-grok` to `x-pack-core`. Since the latter is published to Maven Central, this means consumers will have issues resolving it's dependencies since `elasticsearch-grok` isn't published. This pull request resolves this, by adding the publishing plugin to the `grok` library. We'll then follow up separately to add that to our release configuration.