### PR TITLE
[8.4] Quote paths with whitespace in Windows service CLIs

### DIFF
--- a/distribution/tools/windows-service-cli/src/main/java/org/elasticsearch/windows/service/ProcrunCommand.java
+++ b/distribution/tools/windows-service-cli/src/main/java/org/elasticsearch/windows/service/ProcrunCommand.java
@@ -67,7 +67,7 @@ abstract class ProcrunCommand extends Command {
         preExecute(terminal, processInfo, serviceId);
 
         List<String> procrunCmd = new ArrayList<>();
-        procrunCmd.add(procrun.toString());
+        procrunCmd.add(quote(procrun.toString()));
         procrunCmd.add("//%s/%s".formatted(cmd, serviceId));
         if (includeLogArgs()) {
             procrunCmd.add(getLogArgs(serviceId, processInfo.workingDir(), processInfo.envVars()));
@@ -84,6 +84,11 @@ abstract class ProcrunCommand extends Command {
         } else {
             terminal.println(getSuccessMessage(serviceId));
         }
+    }
+
+    /** Quotes the given String. */
+    static String quote(String s) {
+        return '"' + s + '"';
     }
 
     /** Determines the service id for the Elasticsearch service that should be used */

--- a/distribution/tools/windows-service-cli/src/test/java/org/elasticsearch/windows/service/ProcrunCommandTests.java
+++ b/distribution/tools/windows-service-cli/src/test/java/org/elasticsearch/windows/service/ProcrunCommandTests.java
@@ -25,6 +25,10 @@ import static org.hamcrest.Matchers.equalTo;
 
 public class ProcrunCommandTests extends WindowsServiceCliTestCase {
 
+    public ProcrunCommandTests(boolean spaceInPath) {
+        super(spaceInPath);
+    }
+
     PreExecuteHook preExecuteHook;
     boolean includeLogArgs;
     String additionalArgs;

--- a/distribution/tools/windows-service-cli/src/test/java/org/elasticsearch/windows/service/WindowsServiceInstallCommandTests.java
+++ b/distribution/tools/windows-service-cli/src/test/java/org/elasticsearch/windows/service/WindowsServiceInstallCommandTests.java
@@ -31,6 +31,10 @@ public class WindowsServiceInstallCommandTests extends WindowsServiceCliTestCase
 
     Path jvmDll;
 
+    public WindowsServiceInstallCommandTests(boolean spaceInPath) {
+        super(spaceInPath);
+    }
+
     @Before
     public void setupJvm() throws Exception {
         jvmDll = javaHome.resolve("jre/bin/server/jvm.dll");
@@ -80,7 +84,7 @@ public class WindowsServiceInstallCommandTests extends WindowsServiceCliTestCase
     }
 
     public void testDll() throws Exception {
-        assertServiceArgs(Map.of("Jvm", jvmDll.toString()));
+        assertServiceArgs(Map.of("Jvm", quote(jvmDll.toString())));
     }
 
     public void testPreExecuteOutput() throws Exception {
@@ -95,9 +99,9 @@ public class WindowsServiceInstallCommandTests extends WindowsServiceCliTestCase
         sysprops.put("es.distribution.type", "testdistro");
         List<String> expectedOptions = List.of(
             "" + "-XX:+UseSerialGC",
-            "-Des.path.home=" + esHomeDir.toString(),
-            "-Des.path.conf=" + esHomeDir.resolve("config").toString(),
-            "-Des.distribution.type=testdistro"
+            "-Des.path.home=" + quote(esHomeDir.toString()),
+            "-Des.path.conf=" + quote(esHomeDir.resolve("config").toString()),
+            "-Des.distribution.type=" + quote("testdistro")
         );
         mockProcessValidator = (environment, procrunCall) -> {
             List<String> options = procrunCall.args().get("JvmOptions");
@@ -136,7 +140,7 @@ public class WindowsServiceInstallCommandTests extends WindowsServiceCliTestCase
                 entry("StopMode", "jvm"),
                 entry("JvmMs", "4m"),
                 entry("JvmMx", "64m"),
-                entry("StartPath", esHomeDir.toString()),
+                entry("StartPath", quote(esHomeDir.toString())),
                 entry("Classpath", "javaclasspath") // dummy value for tests
             )
         );

--- a/distribution/tools/windows-service-cli/src/test/java/org/elasticsearch/windows/service/WindowsServiceManagerCommandTests.java
+++ b/distribution/tools/windows-service-cli/src/test/java/org/elasticsearch/windows/service/WindowsServiceManagerCommandTests.java
@@ -13,6 +13,11 @@ import org.elasticsearch.cli.Command;
 import java.io.IOException;
 
 public class WindowsServiceManagerCommandTests extends WindowsServiceCliTestCase {
+
+    public WindowsServiceManagerCommandTests(boolean spaceInPath) {
+        super(spaceInPath);
+    }
+
     @Override
     protected Command newCommand() {
         return new WindowsServiceManagerCommand() {
@@ -25,7 +30,7 @@ public class WindowsServiceManagerCommandTests extends WindowsServiceCliTestCase
 
     @Override
     protected String getExe() {
-        return mgrExe.toString();
+        return quote(mgrExe.toString());
     }
 
     @Override

--- a/distribution/tools/windows-service-cli/src/test/java/org/elasticsearch/windows/service/WindowsServiceRemoveCommandTests.java
+++ b/distribution/tools/windows-service-cli/src/test/java/org/elasticsearch/windows/service/WindowsServiceRemoveCommandTests.java
@@ -13,6 +13,11 @@ import org.elasticsearch.cli.Command;
 import java.io.IOException;
 
 public class WindowsServiceRemoveCommandTests extends WindowsServiceCliTestCase {
+
+    public WindowsServiceRemoveCommandTests(boolean spaceInPath) {
+        super(spaceInPath);
+    }
+
     @Override
     protected Command newCommand() {
         return new WindowsServiceRemoveCommand() {

--- a/distribution/tools/windows-service-cli/src/test/java/org/elasticsearch/windows/service/WindowsServiceStartCommandTests.java
+++ b/distribution/tools/windows-service-cli/src/test/java/org/elasticsearch/windows/service/WindowsServiceStartCommandTests.java
@@ -13,6 +13,11 @@ import org.elasticsearch.cli.Command;
 import java.io.IOException;
 
 public class WindowsServiceStartCommandTests extends WindowsServiceCliTestCase {
+
+    public WindowsServiceStartCommandTests(boolean spaceInPath) {
+        super(spaceInPath);
+    }
+
     @Override
     protected Command newCommand() {
         return new WindowsServiceStartCommand() {

--- a/distribution/tools/windows-service-cli/src/test/java/org/elasticsearch/windows/service/WindowsServiceStopCommandTests.java
+++ b/distribution/tools/windows-service-cli/src/test/java/org/elasticsearch/windows/service/WindowsServiceStopCommandTests.java
@@ -13,6 +13,11 @@ import org.elasticsearch.cli.Command;
 import java.io.IOException;
 
 public class WindowsServiceStopCommandTests extends WindowsServiceCliTestCase {
+
+    public WindowsServiceStopCommandTests(boolean spaceInPath) {
+        super(spaceInPath);
+    }
+
     @Override
     protected Command newCommand() {
         return new WindowsServiceStopCommand() {

--- a/docs/changelog/89072.yaml
+++ b/docs/changelog/89072.yaml
@@ -1,0 +1,6 @@
+pr: 89072
+summary: Quote paths with whitespace in Windows service CLIs
+area: Infra/CLI
+type: bug
+issues:
+ - 89043

--- a/test/framework/src/main/java/org/elasticsearch/cli/CommandTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/cli/CommandTestCase.java
@@ -41,12 +41,27 @@ public abstract class CommandTestCase extends ESTestCase {
     /** The ES config dir */
     protected Path configDir;
 
+    /** Whether to include a whitespace in the file-system path. */
+    private final boolean spaceInPath;
+
+    protected CommandTestCase() {
+        this(false);
+    }
+
+    protected CommandTestCase(boolean spaceInPath) {
+        this.spaceInPath = spaceInPath;
+    }
+
     @Before
     public void resetTerminal() throws IOException {
         terminal.reset();
         terminal.setSupportsBinary(false);
         terminal.setVerbosity(Terminal.Verbosity.NORMAL);
-        esHomeDir = createTempDir();
+        if (spaceInPath) {
+            esHomeDir = createTempDir("a b"); // contains a whitespace
+        } else {
+            esHomeDir = createTempDir();
+        }
         configDir = esHomeDir.resolve("config");
         Files.createDirectory(configDir);
         sysprops.clear();


### PR DESCRIPTION
Backport of:
 * Quote paths with whitespace in Windows service CLIs (#89072)