### PR TITLE
geo_line aggregation returns a geojson point when the resulting line has only one point

### DIFF
--- a/docs/changelog/89199.yaml
+++ b/docs/changelog/89199.yaml
@@ -1,0 +1,7 @@
+pr: 89199
+summary: Geo_line aggregation returns a geojson point when the resulting line has
+  only one point
+area: Geo
+type: bug
+issues:
+ - 85748

--- a/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/search/aggregations/InternalGeoLine.java
+++ b/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/search/aggregations/InternalGeoLine.java
@@ -227,8 +227,13 @@ public class InternalGeoLine extends InternalAggregation implements GeoShapeMetr
             );
         }
         final Map<String, Object> geoJSON = new HashMap<>();
-        geoJSON.put("type", "LineString");
-        geoJSON.put("coordinates", coordinates.toArray());
+        if (coordinates.size() == 1) {
+            geoJSON.put("type", "Point");
+            geoJSON.put("coordinates", coordinates.get(0));
+        } else {
+            geoJSON.put("type", "LineString");
+            geoJSON.put("coordinates", coordinates.toArray());
+        }
         return geoJSON;
     }
 }

--- a/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/search/aggregations/GeoLineAggregatorTests.java
+++ b/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/search/aggregations/GeoLineAggregatorTests.java
@@ -263,6 +263,40 @@ public class GeoLineAggregatorTests extends AggregatorTestCase {
         testCase(new MatchAllDocsQuery(), aggregationBuilder, iw -> {}, terms -> { assertTrue(terms.getBuckets().isEmpty()); });
     }
 
+    public void testOnePoint() throws IOException {
+        int size = randomIntBetween(1, GeoLineAggregationBuilder.MAX_PATH_SIZE);
+        MultiValuesSourceFieldConfig valueConfig = new MultiValuesSourceFieldConfig.Builder().setFieldName("value_field").build();
+        MultiValuesSourceFieldConfig sortConfig = new MultiValuesSourceFieldConfig.Builder().setFieldName("sort_field").build();
+        GeoLineAggregationBuilder lineAggregationBuilder = new GeoLineAggregationBuilder("_name").point(valueConfig)
+            .sortOrder(SortOrder.ASC)
+            .sort(sortConfig)
+            .size(size);
+        TermsAggregationBuilder aggregationBuilder = new TermsAggregationBuilder("_name").field("group_id")
+            .subAggregation(lineAggregationBuilder);
+        double lon = GeoEncodingUtils.decodeLongitude(randomInt());
+        double lat = GeoEncodingUtils.decodeLatitude(randomInt());
+        testCase(new MatchAllDocsQuery(), aggregationBuilder, iw -> {
+            iw.addDocument(
+                Arrays.asList(
+                    new LatLonDocValuesField("value_field", lat, lon),
+                    new SortedNumericDocValuesField("sort_field", NumericUtils.doubleToSortableLong(randomDouble())),
+                    new SortedDocValuesField("group_id", new BytesRef("groupOrd"))
+                )
+            );
+        }, terms -> {
+            assertEquals(1, terms.getBuckets().size());
+            InternalGeoLine geoLine = terms.getBuckets().get(0).getAggregations().get("_name");
+            assertNotNull(geoLine);
+            Map<String, Object> geojson = geoLine.geoJSONGeometry();
+            assertEquals("Point", geojson.get("type"));
+            assertTrue(geojson.get("coordinates") instanceof double[]);
+            double[] coordinates = (double[]) geojson.get("coordinates");
+            assertEquals(2, coordinates.length);
+            assertEquals(lon, coordinates[0], 1e-6);
+            assertEquals(lat, coordinates[1], 1e-6);
+        });
+    }
+
     private void testAggregator(SortOrder sortOrder) throws IOException {
         int size = randomIntBetween(1, GeoLineAggregationBuilder.MAX_PATH_SIZE);
         MultiValuesSourceFieldConfig valueConfig = new MultiValuesSourceFieldConfig.Builder().setFieldName("value_field").build();


### PR DESCRIPTION
geo_line aggregation currently returns a geojson line containing one point if there is only one point in the result of the aggregation. That result is invalid geo_json and parsers will throw an error when parsing it. This PR changes the geojson output to return a point instead in the cases a geo_line aggregation only contains one point.

fixes https://github.com/elastic/elasticsearch/issues/85748