### PR TITLE
[8.4] Complete listener in ReservedStateErrorTaskExecutor (#89191)

### DIFF
--- a/server/src/main/java/org/elasticsearch/reservedstate/service/ReservedStateErrorTaskExecutor.java
+++ b/server/src/main/java/org/elasticsearch/reservedstate/service/ReservedStateErrorTaskExecutor.java
@@ -27,10 +27,9 @@ record ReservedStateErrorTaskExecutor() implements ClusterStateTaskExecutor<Rese
     @Override
     public ClusterState execute(ClusterState currentState, List<TaskContext<ReservedStateErrorTask>> taskContexts) {
         for (final var taskContext : taskContexts) {
-            currentState = taskContext.getTask().execute(currentState);
-            taskContext.success(
-                () -> taskContext.getTask().listener().delegateFailure((l, s) -> l.onResponse(ActionResponse.Empty.INSTANCE))
-            );
+            final var task = taskContext.getTask();
+            currentState = task.execute(currentState);
+            taskContext.success(() -> task.listener().onResponse(ActionResponse.Empty.INSTANCE));
         }
         return currentState;
     }


### PR DESCRIPTION
Backports the following commits to 8.4:
 - Complete listener in ReservedStateErrorTaskExecutor (#89191)