### PR TITLE
[8.4] Delete invalid settings for system indices (#88903)

### DIFF
--- a/docs/changelog/88903.yaml
+++ b/docs/changelog/88903.yaml
@@ -1,0 +1,5 @@
+pr: 88903
+summary: Delete invalid settings for system indices
+area: Infra/Core
+type: bug
+issues: [88324]

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/IndexMetadataVerifier.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/IndexMetadataVerifier.java
@@ -89,7 +89,7 @@ public class IndexMetadataVerifier {
         newMetadata = removeTierFiltering(newMetadata);
         // Next we have to run this otherwise if we try to create IndexSettings
         // with broken settings it would fail in checkMappingsCompatibility
-        newMetadata = archiveBrokenIndexSettings(newMetadata);
+        newMetadata = archiveOrDeleteBrokenIndexSettings(newMetadata);
         checkMappingsCompatibility(newMetadata);
         return newMetadata;
     }
@@ -205,27 +205,54 @@ public class IndexMetadataVerifier {
     /**
      * Identify invalid or unknown index settings and archive them. This leniency allows Elasticsearch to load
      * indices even if they contain old settings that are no longer valid.
+     *
+     * When we find an invalid setting on a system index, we simply remove it instead of archiving. System indices
+     * are managed by Elasticsearch and manual modification of settings is limited and sometimes impossible.
      */
-    IndexMetadata archiveBrokenIndexSettings(IndexMetadata indexMetadata) {
+    IndexMetadata archiveOrDeleteBrokenIndexSettings(IndexMetadata indexMetadata) {
         final Settings settings = indexMetadata.getSettings();
-        final Settings newSettings = indexScopedSettings.archiveUnknownOrInvalidSettings(
-            settings,
-            e -> logger.warn(
-                "{} ignoring unknown index setting: [{}] with value [{}]; archiving",
-                indexMetadata.getIndex(),
-                e.getKey(),
-                e.getValue()
-            ),
-            (e, ex) -> logger.warn(
-                () -> format(
-                    "%s ignoring invalid index setting: [%s] with value [%s]; archiving",
+        final Settings newSettings;
+
+        if (indexMetadata.isSystem()) {
+            newSettings = indexScopedSettings.deleteUnknownOrInvalidSettings(
+                settings,
+                e -> logger.warn(
+                    "{} deleting unknown system index setting: [{}] with value [{}]",
                     indexMetadata.getIndex(),
                     e.getKey(),
                     e.getValue()
                 ),
-                ex
-            )
-        );
+                (e, ex) -> logger.warn(
+                    () -> format(
+                        "%s deleting invalid system index setting: [%s] with value [%s]",
+                        indexMetadata.getIndex(),
+                        e.getKey(),
+                        e.getValue()
+                    ),
+                    ex
+                )
+            );
+        } else {
+            newSettings = indexScopedSettings.archiveUnknownOrInvalidSettings(
+                settings,
+                e -> logger.warn(
+                    "{} ignoring unknown index setting: [{}] with value [{}]; archiving",
+                    indexMetadata.getIndex(),
+                    e.getKey(),
+                    e.getValue()
+                ),
+                (e, ex) -> logger.warn(
+                    () -> format(
+                        "%s ignoring invalid index setting: [%s] with value [%s]; archiving",
+                        indexMetadata.getIndex(),
+                        e.getKey(),
+                        e.getValue()
+                    ),
+                    ex
+                )
+            );
+        }
+
         if (newSettings != settings) {
             return IndexMetadata.builder(indexMetadata).settings(newSettings).build();
         } else {

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/IndexMetadataVerifierTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/IndexMetadataVerifierTests.java
@@ -26,26 +26,61 @@ public class IndexMetadataVerifierTests extends ESTestCase {
     public void testArchiveBrokenIndexSettings() {
         IndexMetadataVerifier service = getIndexMetadataVerifier();
         IndexMetadata src = newIndexMeta("foo", Settings.EMPTY);
-        IndexMetadata indexMetadata = service.archiveBrokenIndexSettings(src);
+        IndexMetadata indexMetadata = service.archiveOrDeleteBrokenIndexSettings(src);
         assertSame(indexMetadata, src);
 
         src = newIndexMeta("foo", Settings.builder().put("index.refresh_interval", "-200").build());
-        indexMetadata = service.archiveBrokenIndexSettings(src);
+        indexMetadata = service.archiveOrDeleteBrokenIndexSettings(src);
         assertNotSame(indexMetadata, src);
         assertEquals("-200", indexMetadata.getSettings().get("archived.index.refresh_interval"));
 
         src = newIndexMeta("foo", Settings.builder().put("index.codec", "best_compression1").build());
-        indexMetadata = service.archiveBrokenIndexSettings(src);
+        indexMetadata = service.archiveOrDeleteBrokenIndexSettings(src);
         assertNotSame(indexMetadata, src);
         assertEquals("best_compression1", indexMetadata.getSettings().get("archived.index.codec"));
 
         src = newIndexMeta("foo", Settings.builder().put("index.refresh.interval", "-1").build());
-        indexMetadata = service.archiveBrokenIndexSettings(src);
+        indexMetadata = service.archiveOrDeleteBrokenIndexSettings(src);
         assertNotSame(indexMetadata, src);
         assertEquals("-1", indexMetadata.getSettings().get("archived.index.refresh.interval"));
 
         src = newIndexMeta("foo", indexMetadata.getSettings()); // double archive?
-        indexMetadata = service.archiveBrokenIndexSettings(src);
+        indexMetadata = service.archiveOrDeleteBrokenIndexSettings(src);
+        assertSame(indexMetadata, src);
+    }
+
+    public void testDeleteBrokenSystemIndexSettings() {
+        IndexMetadataVerifier service = getIndexMetadataVerifier();
+        IndexMetadata src = newSystemIndexMeta("foo", Settings.EMPTY);
+        IndexMetadata indexMetadata = service.archiveOrDeleteBrokenIndexSettings(src);
+        assertSame(indexMetadata, src);
+
+        src = newSystemIndexMeta("foo", Settings.builder().put("index.refresh_interval", "-200").build());
+        indexMetadata = service.archiveOrDeleteBrokenIndexSettings(src);
+        assertNotSame(indexMetadata, src);
+        assertNull(indexMetadata.getSettings().get("archived.index.refresh_interval"));
+        assertNull(indexMetadata.getSettings().get("index.refresh_interval"));
+
+        // previously archived settings are removed
+        src = newSystemIndexMeta("foo", Settings.builder().put("archived.index.refresh_interval", "200").build());
+        indexMetadata = service.archiveOrDeleteBrokenIndexSettings(src);
+        assertNotSame(indexMetadata, src);
+        assertNull(indexMetadata.getSettings().get("archived.index.refresh_interval"));
+
+        src = newSystemIndexMeta("foo", Settings.builder().put("index.codec", "best_compression1").build());
+        indexMetadata = service.archiveOrDeleteBrokenIndexSettings(src);
+        assertNotSame(indexMetadata, src);
+        assertNull(indexMetadata.getSettings().get("archived.index.codec"));
+        assertNull(indexMetadata.getSettings().get("index.codec"));
+
+        src = newSystemIndexMeta("foo", Settings.builder().put("index.refresh.interval", "-1").build());
+        indexMetadata = service.archiveOrDeleteBrokenIndexSettings(src);
+        assertNotSame(indexMetadata, src);
+        assertNull(indexMetadata.getSettings().get("archived.index.refresh.interval"));
+        assertNull(indexMetadata.getSettings().get("index.refresh.interval"));
+
+        src = newSystemIndexMeta("foo", indexMetadata.getSettings()); // double archive?
+        indexMetadata = service.archiveOrDeleteBrokenIndexSettings(src);
         assertSame(indexMetadata, src);
     }
 
@@ -108,6 +143,14 @@ public class IndexMetadataVerifierTests extends ESTestCase {
     }
 
     public static IndexMetadata newIndexMeta(String name, Settings indexSettings) {
+        return newIndexMetaBuilder(name, indexSettings).build();
+    }
+
+    public static IndexMetadata newSystemIndexMeta(String name, Settings indexSettings) {
+        return newIndexMetaBuilder(name, indexSettings).system(true).build();
+    }
+
+    private static IndexMetadata.Builder newIndexMetaBuilder(String name, Settings indexSettings) {
         final Settings settings = Settings.builder()
             .put(IndexMetadata.SETTING_VERSION_CREATED, randomIndexCompatibleVersion(random()))
             .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, between(0, 5))
@@ -120,6 +163,7 @@ public class IndexMetadataVerifierTests extends ESTestCase {
         if (randomBoolean()) {
             indexMetadataBuilder.state(IndexMetadata.State.CLOSE);
         }
-        return indexMetadataBuilder.build();
+        return indexMetadataBuilder;
     }
+
 }


### PR DESCRIPTION
Backports the following commits to 8.4:
 - Delete invalid settings for system indices (#88903)