### PR TITLE
Ensure APM module is always installed in release test clusters

### DIFF
--- a/distribution/build.gradle
+++ b/distribution/build.gradle
@@ -177,7 +177,7 @@ project.rootProject.subprojects.findAll { it.parent.path == ':modules' }.each { 
   }
 
   distro.copyModule(processDefaultOutputsTaskProvider, module)
-  if (module.name.startsWith('transport-')) {
+  if (module.name.startsWith('transport-') || (BuildParams.snapshotBuild == false && module.name == 'apm')) {
     distro.copyModule(processIntegTestOutputsTaskProvider, module)
   }
 

--- a/qa/apm/build.gradle
+++ b/qa/apm/build.gradle
@@ -8,7 +8,9 @@
 
 import org.elasticsearch.gradle.Architecture
 import org.elasticsearch.gradle.VersionProperties
-import static org.elasticsearch.gradle.internal.distribution.InternalElasticsearchDistributionTypes.DOCKER;
+import org.elasticsearch.gradle.internal.info.BuildParams
+
+import static org.elasticsearch.gradle.internal.distribution.InternalElasticsearchDistributionTypes.DOCKER
 
 apply plugin: 'elasticsearch.standalone-rest-test'
 apply plugin: 'elasticsearch.test.fixtures'
@@ -21,8 +23,7 @@ dependencies {
 }
 
 dockerCompose {
-  environment.put 'STACK_VERSION', VersionProperties.elasticsearch
-  // retainContainersOnStartupFailure = true
+  environment.put 'STACK_VERSION', BuildParams.snapshotBuild ? VersionProperties.elasticsearch : VersionProperties.elasticsearch + "-SNAPSHOT"
 }
 
 elasticsearch_distributions {


### PR DESCRIPTION
Our release builds have been failing because on [startup ES now checks](https://gradle-enterprise.elastic.co/s/yndbpn74kho24/console-log?task=:rest-api-spec:yamlRestTest#L7) to ensure the APM module is present in non-snapshot builds. To remedy this we simply need to ensure that the APM module is explicitly included in test distribution when performing release builds.