### PR TITLE
Improve rejection of ambiguous voting config name

### DIFF
--- a/docs/changelog/89239.yaml
+++ b/docs/changelog/89239.yaml
@@ -1,0 +1,5 @@
+pr: 89239
+summary: Improve rejection of ambiguous voting config name
+area: Cluster Coordination
+type: bug
+issues: []

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/configuration/AddVotingConfigExclusionsRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/configuration/AddVotingConfigExclusionsRequest.java
@@ -102,7 +102,16 @@ public class AddVotingConfigExclusionsRequest extends MasterNodeRequest<AddVotin
         } else {
             assert nodeNames.length > 0;
             Map<String, DiscoveryNode> existingNodes = allNodes.stream()
-                .collect(Collectors.toMap(DiscoveryNode::getName, Function.identity()));
+                .collect(Collectors.toMap(DiscoveryNode::getName, Function.identity(), (n1, n2) -> {
+                    throw new IllegalArgumentException(
+                        org.elasticsearch.core.Strings.format(
+                            "node name [%s] is ambiguous, matching [%s] and [%s]; specify node ID instead",
+                            n1.getName(),
+                            n1.descriptionWithoutAttributes(),
+                            n2.descriptionWithoutAttributes()
+                        )
+                    );
+                }));
 
             for (String nodeName : nodeNames) {
                 if (existingNodes.containsKey(nodeName)) {


### PR DESCRIPTION
Today if there are multiple nodes with the same name then
`POST /_cluster/voting_config_exclusions?node_names=ambiguous-name` will
return a `500 Internal Server Error` and a mysterious message. This
commit changes the behaviour to throw an `IllegalArgumentException`
(i.e. `400 Bad Request`) along with a more useful message describing the
problem.