### PR TITLE
[ML] Move method to compute current memory scale into NativeMemoryCap…

### DIFF
--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/JobNodeSelector.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/JobNodeSelector.java
@@ -15,7 +15,6 @@ import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.core.Tuple;
 import org.elasticsearch.persistent.PersistentTasksCustomMetadata;
 import org.elasticsearch.xpack.ml.MachineLearning;
-import org.elasticsearch.xpack.ml.autoscaling.MlAutoscalingDeciderService;
 import org.elasticsearch.xpack.ml.autoscaling.NativeMemoryCapacity;
 import org.elasticsearch.xpack.ml.process.MlMemoryTracker;
 import org.elasticsearch.xpack.ml.utils.NativeMemoryCalculator;
@@ -107,7 +106,7 @@ public class JobNodeSelector {
         int maxOpenJobs
     ) {
         List<DiscoveryNode> capableNodes = candidateNodes.stream().filter(n -> this.nodeFilter.apply(n) == null).toList();
-        NativeMemoryCapacity currentCapacityForMl = MlAutoscalingDeciderService.currentScale(
+        NativeMemoryCapacity currentCapacityForMl = NativeMemoryCapacity.currentScale(
             capableNodes,
             maxMachineMemoryPercent,
             useAutoMemoryPercentage


### PR DESCRIPTION
…acity

This commit moves method `currentScale` from `MlAutoscalingDeciderService`
to `NativeMemoryCapacity` as it allows for easier reuse without coupling
to the autoscaling service.
