### PR TITLE
[8.4] Improve rejection of ambiguous voting config name (#89239)

### DIFF
--- a/docs/changelog/89239.yaml
+++ b/docs/changelog/89239.yaml
@@ -1,0 +1,5 @@
+pr: 89239
+summary: Improve rejection of ambiguous voting config name
+area: Cluster Coordination
+type: bug
+issues: []

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/configuration/AddVotingConfigExclusionsRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/configuration/AddVotingConfigExclusionsRequest.java
@@ -102,7 +102,16 @@ public class AddVotingConfigExclusionsRequest extends MasterNodeRequest<AddVotin
         } else {
             assert nodeNames.length > 0;
             Map<String, DiscoveryNode> existingNodes = allNodes.stream()
-                .collect(Collectors.toMap(DiscoveryNode::getName, Function.identity()));
+                .collect(Collectors.toMap(DiscoveryNode::getName, Function.identity(), (n1, n2) -> {
+                    throw new IllegalArgumentException(
+                        org.elasticsearch.core.Strings.format(
+                            "node name [%s] is ambiguous, matching [%s] and [%s]; specify node ID instead",
+                            n1.getName(),
+                            n1.descriptionWithoutAttributes(),
+                            n2.descriptionWithoutAttributes()
+                        )
+                    );
+                }));
 
             for (String nodeName : nodeNames) {
                 if (existingNodes.containsKey(nodeName)) {


### PR DESCRIPTION
Backports the following commits to 8.4:
 - Improve rejection of ambiguous voting config name (#89239)