### PR TITLE
Improve rejection of ambiguous voting config name

### DIFF
--- a/docs/changelog/89239.yaml
+++ b/docs/changelog/89239.yaml
@@ -1,0 +1,5 @@
+pr: 89239
+summary: Improve rejection of ambiguous voting config name
+area: Cluster Coordination
+type: bug
+issues: []

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/configuration/AddVotingConfigExclusionsRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/configuration/AddVotingConfigExclusionsRequest.java
@@ -24,6 +24,7 @@ import org.elasticsearch.core.TimeValue;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.HashSet;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Function;
@@ -134,7 +135,17 @@ public class AddVotingConfigExclusionsRequest extends MasterNodeRequest<AddVotin
         } else {
             assert nodeNames.length >= 1;
             Map<String, DiscoveryNode> existingNodes = StreamSupport.stream(allNodes.spliterator(), false)
-                .collect(Collectors.toMap(DiscoveryNode::getName, Function.identity()));
+                .collect(Collectors.toMap(DiscoveryNode::getName, Function.identity(), (n1, n2) -> {
+                    throw new IllegalArgumentException(
+                        String.format(
+                            Locale.ROOT,
+                            "node name [%s] is ambiguous, matching [%s] and [%s]; specify node ID instead",
+                            n1.getName(),
+                            n1.descriptionWithoutAttributes(),
+                            n2.descriptionWithoutAttributes()
+                        )
+                    );
+                }));
 
             for (String nodeName : nodeNames) {
                 if (existingNodes.containsKey(nodeName)) {

--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/configuration/AddVotingConfigExclusionsRequestTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/configuration/AddVotingConfigExclusionsRequestTests.java
@@ -25,8 +25,10 @@ import java.io.IOException;
 import static java.util.Collections.emptyMap;
 import static java.util.Collections.emptySet;
 import static java.util.Collections.singleton;
+import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 
 public class AddVotingConfigExclusionsRequestTests extends ESTestCase {
@@ -315,6 +317,40 @@ public class AddVotingConfigExclusionsRequestTests extends ESTestCase {
         assertThat(
             new AddVotingConfigExclusionsRequest("nodeName1", "unresolvableNodeName").resolveVotingConfigExclusions(clusterState),
             containsInAnyOrder(node1Exclusion, unresolvableVotingConfigExclusion)
+        );
+    }
+
+    public void testResolveAmbiguousName() {
+        final DiscoveryNode node1 = new DiscoveryNode(
+            "ambiguous-name",
+            "nodeId1",
+            buildNewFakeTransportAddress(),
+            emptyMap(),
+            singleton(DiscoveryNodeRole.MASTER_ROLE),
+            Version.CURRENT
+        );
+
+        final DiscoveryNode node2 = new DiscoveryNode(
+            "ambiguous-name",
+            "nodeId2",
+            buildNewFakeTransportAddress(),
+            emptyMap(),
+            singleton(DiscoveryNodeRole.MASTER_ROLE),
+            Version.CURRENT
+        );
+
+        final ClusterState clusterState = ClusterState.builder(new ClusterName("cluster"))
+            .nodes(new Builder().add(node1).add(node2).localNodeId(node1.getId()))
+            .build();
+
+        final AddVotingConfigExclusionsRequest request = new AddVotingConfigExclusionsRequest("ambiguous-name");
+        assertThat(
+            expectThrows(IllegalArgumentException.class, () -> request.resolveVotingConfigExclusions(clusterState)).getMessage(),
+            allOf(
+                containsString("node name [ambiguous-name] is ambiguous"),
+                containsString(node1.descriptionWithoutAttributes()),
+                containsString(node2.descriptionWithoutAttributes())
+            )
         );
     }
 


### PR DESCRIPTION
Today if there are multiple nodes with the same name then
`POST /_cluster/voting_config_exclusions?node_names=ambiguous-name` will
return a `500 Internal Server Error` and a mysterious message. This
commit changes the behaviour to throw an `IllegalArgumentException`
(i.e. `400 Bad Request`) along with a more useful message describing the
problem.

Backport of #89239 to 7.17