### PR TITLE
fix a typo in Security.java

### DIFF
--- a/docs/changelog/89248.yaml
+++ b/docs/changelog/89248.yaml
@@ -1,5 +1,5 @@
 pr: 89248
-summary: fix a typo in Security.java
+summary: fix "path.conf'" typo in Security.java
 area: Bootstrap
 type: bug
 issues:

--- a/docs/changelog/89248.yaml
+++ b/docs/changelog/89248.yaml
@@ -1,0 +1,6 @@
+pr: 89248
+summary: fix a typo in Security.java
+area: Bootstrap
+type: bug
+issues:
+  - 89327

--- a/docs/changelog/89248.yaml
+++ b/docs/changelog/89248.yaml
@@ -1,6 +1,6 @@
 pr: 89248
 summary: fix "path.conf'" typo in Security.java
-area: Bootstrap
+area: Engine
 type: bug
 issues:
   - 89327

--- a/server/src/main/java/org/elasticsearch/bootstrap/Security.java
+++ b/server/src/main/java/org/elasticsearch/bootstrap/Security.java
@@ -216,7 +216,7 @@ final class Security {
         addDirectoryPath(policy, Environment.PATH_HOME_SETTING.getKey(), environment.libFile(), "read,readlink", false);
         addDirectoryPath(policy, Environment.PATH_HOME_SETTING.getKey(), environment.modulesFile(), "read,readlink", false);
         addDirectoryPath(policy, Environment.PATH_HOME_SETTING.getKey(), environment.pluginsFile(), "read,readlink", false);
-        addDirectoryPath(policy, "path.conf'", environment.configFile(), "read,readlink", false);
+        addDirectoryPath(policy, "path.conf", environment.configFile(), "read,readlink", false);
         // read-write dirs
         addDirectoryPath(policy, "java.io.tmpdir", environment.tmpFile(), "read,readlink,write,delete", false);
         addDirectoryPath(policy, Environment.PATH_LOGS_SETTING.getKey(), environment.logsFile(), "read,readlink,write,delete", false);


### PR DESCRIPTION
"path.conf'" has an extra “'”