### PR TITLE
Downgrade known bad containerd version during packaging tests

### DIFF
--- a/.ci/scripts/packaging-test.sh
+++ b/.ci/scripts/packaging-test.sh
@@ -43,6 +43,13 @@ if [ -f "/etc/os-release" ] ; then
             sudo apt-get install -y --allow-downgrades lintian=2.15.0
         fi
     fi
+    if [[ "$ID" == "rhel" ]] ; then
+      # Downgrade containerd if necessary to work around runc bug
+      # See: https://github.com/opencontainers/runc/issues/3551
+      if containerd -version | grep -sF 1.6.7; then
+        sudo dnf downgrade -y containerd.io
+      fi
+    fi
 else
     cat /etc/issue || true
 fi

--- a/.ci/scripts/packaging-test.sh
+++ b/.ci/scripts/packaging-test.sh
@@ -47,7 +47,7 @@ if [ -f "/etc/os-release" ] ; then
       # Downgrade containerd if necessary to work around runc bug
       # See: https://github.com/opencontainers/runc/issues/3551
       if containerd -version | grep -sF 1.6.7; then
-        sudo dnf downgrade -y containerd.io
+        sudo yum downgrade -y containerd.io
       fi
     fi
 else


### PR DESCRIPTION
Looks like `containerd` has been upgraded on the latest RHEL 9 CI workers. This updated package includes `runc` 1.1.3 which seems to include a bug which can cause a failure when trying to attach a terminal to a running container. This is causing our Docker packaging tests to fail when we attempt to do `docker exec --tty`. For now let's just add a bit to our packaging test execution script to downgrade the package if appropriate.

Closes https://github.com/elastic/elasticsearch/issues/89247