### PR TITLE
Fix message for stalled shutdown

### DIFF
--- a/docs/changelog/89254.yaml
+++ b/docs/changelog/89254.yaml
@@ -1,0 +1,5 @@
+pr: 89254
+summary: Fix message for stalled shutdown
+area: Infra/Node Lifecycle
+type: bug
+issues: []

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/ShutdownShardMigrationStatus.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/ShutdownShardMigrationStatus.java
@@ -24,6 +24,8 @@ import java.util.Objects;
 public class ShutdownShardMigrationStatus implements Writeable, ToXContentObject {
     private static final Version ALLOCATION_DECISION_ADDED_VERSION = Version.V_7_16_0;
 
+    public static final String NODE_ALLOCATION_DECISION_KEY = "node_allocation_decision";
+
     private final SingleNodeShutdownMetadata.Status status;
     private final long shardsRemaining;
     @Nullable
@@ -83,7 +85,7 @@ public class ShutdownShardMigrationStatus implements Writeable, ToXContentObject
             builder.field("explanation", explanation);
         }
         if (Objects.nonNull(allocationDecision)) {
-            builder.startObject("node_allocation_decision");
+            builder.startObject(NODE_ALLOCATION_DECISION_KEY);
             {
                 allocationDecision.toXContent(builder, params);
             }

--- a/x-pack/plugin/shutdown/qa/multi-node/src/javaRestTest/java/org/elasticsearch/xpack/shutdown/NodeShutdownIT.java
+++ b/x-pack/plugin/shutdown/qa/multi-node/src/javaRestTest/java/org/elasticsearch/xpack/shutdown/NodeShutdownIT.java
@@ -303,9 +303,10 @@ public class NodeShutdownIT extends ESRestTestCase {
                 ObjectPath.eval("nodes.0.shard_migration.explanation", status),
                 allOf(
                     containsString(indexName),
-                    containsString("cannot move, use the Cluster Allocation Explain API on this shard for details")
+                    containsString("cannot move, see [node_allocation_decision] for details or use the cluster allocation explain API")
                 )
             );
+            assertThat(ObjectPath.eval("nodes.0.shard_migration.node_allocation_decision", status), notNullValue());
         }
 
         // Now update the allocation requirements to unblock shard relocation

--- a/x-pack/plugin/shutdown/src/main/java/org/elasticsearch/xpack/shutdown/TransportGetShutdownStatusAction.java
+++ b/x-pack/plugin/shutdown/src/main/java/org/elasticsearch/xpack/shutdown/TransportGetShutdownStatusAction.java
@@ -49,6 +49,8 @@ import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 
+import static org.elasticsearch.cluster.metadata.ShutdownShardMigrationStatus.NODE_ALLOCATION_DECISION_KEY;
+
 public class TransportGetShutdownStatusAction extends TransportMasterNodeAction<
     GetShutdownStatusAction.Request,
     GetShutdownStatusAction.Response> {
@@ -289,10 +291,11 @@ public class TransportGetShutdownStatusAction extends TransportMasterNodeAction<
                 SingleNodeShutdownMetadata.Status.STALLED,
                 totalRemainingShards,
                 new ParameterizedMessage(
-                    "shard [{}] [{}] of index [{}] cannot move, use the Cluster Allocation Explain API on this shard for details",
+                    "shard [{}] [{}] of index [{}] cannot move, see [{}] for details or use the cluster allocation explain API",
                     shardRouting.shardId().getId(),
                     shardRouting.primary() ? "primary" : "replica",
-                    shardRouting.index().getName()
+                    shardRouting.index().getName(),
+                    NODE_ALLOCATION_DECISION_KEY
                 ).getFormattedMessage(),
                 decision
             );


### PR DESCRIPTION
Today if a node shutdown is stalled due to unmoveable shards then we say
to use the allocation explain API to find details. In fact, since #78727
we include the allocation explanation in the response already so we
should tell users just to look at that instead. This commit adjusts the
message to address this.

Backport of #89254