### PR TITLE
Update .fleet-agents mapping

### DIFF
--- a/x-pack/plugin/core/src/main/resources/fleet-agents.json
+++ b/x-pack/plugin/core/src/main/resources/fleet-agents.json
@@ -29,6 +29,26 @@
             }
           }
         },
+        "outputs": {
+          "properties": {
+            "api_key": {
+              "type": "keyword"
+            },
+            "api_key_id": {
+              "type": "keyword"
+            },
+            "type": {
+              "type": "keyword"
+            },
+            "policy_permissions_hash": {
+              "type": "keyword"
+            },
+            "to_retire_api_key_ids": {
+              "type": "object",
+              "enabled": false
+            }
+          }
+        },
         "default_api_key": {
           "type": "keyword"
         },


### PR DESCRIPTION
Update the .fleet-agents mapping to add the new outputs field. Due to https://github.com/elastic/fleet-server/issues/1672 ther is the need to extend the current agent model. This PR updates the index mapping to reflect the changes made on fleet-server codebase.

Related issue: https://github.com/elastic/fleet-server/issues/1672
Related PR: https://github.com/elastic/fleet-server/pull/1684