### PR TITLE
[8.4] Autoscaling requirement for empty tier (#89266)

### DIFF
--- a/x-pack/plugin/autoscaling/src/internalClusterTest/java/org/elasticsearch/xpack/autoscaling/storage/ReactiveStorageIT.java
+++ b/x-pack/plugin/autoscaling/src/internalClusterTest/java/org/elasticsearch/xpack/autoscaling/storage/ReactiveStorageIT.java
@@ -135,6 +135,7 @@ public class ReactiveStorageIT extends AutoscalingStorageIntegTestCase {
             refresh();
         }
         assertThat(capacity().results().get("warm").requiredCapacity().total().storage().getBytes(), equalTo(0L));
+        assertThat(capacity().results().get("warm").requiredCapacity().node().storage().getBytes(), equalTo(0L));
 
         assertAcked(
             client().admin()
@@ -149,6 +150,10 @@ public class ReactiveStorageIT extends AutoscalingStorageIntegTestCase {
         }
 
         assertThat(capacity().results().get("warm").requiredCapacity().total().storage().getBytes(), Matchers.greaterThan(0L));
+        assertThat(
+            capacity().results().get("warm").requiredCapacity().node().storage().getBytes(),
+            Matchers.greaterThan(ReactiveStorageDeciderService.NODE_DISK_OVERHEAD)
+        );
 
     }
 
@@ -196,7 +201,9 @@ public class ReactiveStorageIT extends AutoscalingStorageIntegTestCase {
 
         refresh(indexName);
         assertThat(capacity().results().get("warm").requiredCapacity().total().storage().getBytes(), equalTo(0L));
+        assertThat(capacity().results().get("warm").requiredCapacity().node().storage().getBytes(), equalTo(0L));
         assertThat(capacity().results().get("cold").requiredCapacity().total().storage().getBytes(), equalTo(0L));
+        assertThat(capacity().results().get("cold").requiredCapacity().node().storage().getBytes(), equalTo(0L));
 
         assertAcked(
             client().admin()
@@ -210,8 +217,16 @@ public class ReactiveStorageIT extends AutoscalingStorageIntegTestCase {
         );
 
         assertThat(capacity().results().get("warm").requiredCapacity().total().storage().getBytes(), Matchers.greaterThan(0L));
+        assertThat(
+            capacity().results().get("warm").requiredCapacity().node().storage().getBytes(),
+            Matchers.greaterThan(ReactiveStorageDeciderService.NODE_DISK_OVERHEAD)
+        );
         // this is not desirable, but one of the caveats of not using data tiers in the ILM policy.
         assertThat(capacity().results().get("cold").requiredCapacity().total().storage().getBytes(), Matchers.greaterThan(0L));
+        assertThat(
+            capacity().results().get("cold").requiredCapacity().node().storage().getBytes(),
+            Matchers.greaterThan(ReactiveStorageDeciderService.NODE_DISK_OVERHEAD)
+        );
     }
 
     public void testScaleWhileShrinking() throws Exception {


### PR DESCRIPTION
Backports the following commits to 8.4:
 - Autoscaling requirement for empty tier (#89266)