### PR TITLE
Limited-by role descriptors in Get/QueryApiKey response

### DIFF
--- a/docs/changelog/89273.yaml
+++ b/docs/changelog/89273.yaml
@@ -1,0 +1,5 @@
+pr: 89273
+summary: Limited-by role descriptors in Get/QueryApiKey response
+area: Security
+type: enhancement
+issues: []

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/apikey/ApiKey.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/apikey/ApiKey.java
@@ -26,6 +26,7 @@ import java.time.Instant;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 
 import static org.elasticsearch.xcontent.ConstructingObjectParser.constructorArg;
 import static org.elasticsearch.xcontent.ConstructingObjectParser.optionalConstructorArg;
@@ -70,7 +71,7 @@ public final class ApiKey implements ToXContentObject, Writeable {
             realm,
             metadata,
             roleDescriptors,
-            limitedByRoleDescriptors == null ? null : new RoleDescriptorsIntersection(List.of(limitedByRoleDescriptors))
+            limitedByRoleDescriptors == null ? null : new RoleDescriptorsIntersection(List.of(Set.copyOf(limitedByRoleDescriptors)))
         );
     }
 
@@ -97,9 +98,9 @@ public final class ApiKey implements ToXContentObject, Writeable {
         this.username = username;
         this.realm = realm;
         this.metadata = metadata == null ? Map.of() : metadata;
-        this.roleDescriptors = roleDescriptors;
+        this.roleDescriptors = roleDescriptors != null ? List.copyOf(roleDescriptors) : null;
         // This assertion will need to be changed (or removed) when derived keys are properly supported
-        assert limitedBy == null || limitedBy.roleDescriptorsList().size() == 1 : "cannot only have one set of limited-by role descriptors";
+        assert limitedBy == null || limitedBy.roleDescriptorsList().size() == 1 : "can only have one set of limited-by role descriptors";
         this.limitedBy = limitedBy;
     }
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/apikey/ApiKey.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/apikey/ApiKey.java
@@ -13,11 +13,13 @@ import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.xcontent.ConstructingObjectParser;
+import org.elasticsearch.xcontent.ObjectParser;
 import org.elasticsearch.xcontent.ParseField;
 import org.elasticsearch.xcontent.ToXContentObject;
 import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xcontent.XContentParser;
 import org.elasticsearch.xpack.core.security.authz.RoleDescriptor;
+import org.elasticsearch.xpack.core.security.authz.RoleDescriptorsIntersection;
 
 import java.io.IOException;
 import java.time.Instant;
@@ -43,6 +45,8 @@ public final class ApiKey implements ToXContentObject, Writeable {
     private final Map<String, Object> metadata;
     @Nullable
     private final List<RoleDescriptor> roleDescriptors;
+    @Nullable
+    private final RoleDescriptorsIntersection limitedBy;
 
     public ApiKey(
         String name,
@@ -53,7 +57,34 @@ public final class ApiKey implements ToXContentObject, Writeable {
         String username,
         String realm,
         @Nullable Map<String, Object> metadata,
-        @Nullable List<RoleDescriptor> roleDescriptors
+        @Nullable List<RoleDescriptor> roleDescriptors,
+        @Nullable List<RoleDescriptor> limitedByRoleDescriptors
+    ) {
+        this(
+            name,
+            id,
+            creation,
+            expiration,
+            invalidated,
+            username,
+            realm,
+            metadata,
+            roleDescriptors,
+            limitedByRoleDescriptors == null ? null : new RoleDescriptorsIntersection(List.of(limitedByRoleDescriptors))
+        );
+    }
+
+    private ApiKey(
+        String name,
+        String id,
+        Instant creation,
+        Instant expiration,
+        boolean invalidated,
+        String username,
+        String realm,
+        @Nullable Map<String, Object> metadata,
+        @Nullable List<RoleDescriptor> roleDescriptors,
+        @Nullable RoleDescriptorsIntersection limitedBy
     ) {
         this.name = name;
         this.id = id;
@@ -67,6 +98,9 @@ public final class ApiKey implements ToXContentObject, Writeable {
         this.realm = realm;
         this.metadata = metadata == null ? Map.of() : metadata;
         this.roleDescriptors = roleDescriptors;
+        // This assertion will need to be changed (or removed) when derived keys are properly supported
+        assert limitedBy == null || limitedBy.roleDescriptorsList().size() == 1 : "cannot only have one set of limited-by role descriptors";
+        this.limitedBy = limitedBy;
     }
 
     public ApiKey(StreamInput in) throws IOException {
@@ -89,8 +123,10 @@ public final class ApiKey implements ToXContentObject, Writeable {
         if (in.getVersion().onOrAfter(Version.V_8_5_0)) {
             final List<RoleDescriptor> roleDescriptors = in.readOptionalList(RoleDescriptor::new);
             this.roleDescriptors = roleDescriptors != null ? List.copyOf(roleDescriptors) : null;
+            this.limitedBy = in.readOptionalWriteable(RoleDescriptorsIntersection::new);
         } else {
             this.roleDescriptors = null;
+            this.limitedBy = null;
         }
     }
 
@@ -130,6 +166,10 @@ public final class ApiKey implements ToXContentObject, Writeable {
         return roleDescriptors;
     }
 
+    public RoleDescriptorsIntersection getLimitedBy() {
+        return limitedBy;
+    }
+
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
         builder.startObject();
@@ -153,6 +193,9 @@ public final class ApiKey implements ToXContentObject, Writeable {
             }
             builder.endObject();
         }
+        if (limitedBy != null) {
+            builder.field("limited_by", limitedBy);
+        }
         return builder;
     }
 
@@ -174,12 +217,13 @@ public final class ApiKey implements ToXContentObject, Writeable {
         }
         if (out.getVersion().onOrAfter(Version.V_8_5_0)) {
             out.writeOptionalCollection(roleDescriptors);
+            out.writeOptionalWriteable(limitedBy);
         }
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(name, id, creation, expiration, invalidated, username, realm, metadata, roleDescriptors);
+        return Objects.hash(name, id, creation, expiration, invalidated, username, realm, metadata, roleDescriptors, limitedBy);
     }
 
     @Override
@@ -202,7 +246,8 @@ public final class ApiKey implements ToXContentObject, Writeable {
             && Objects.equals(username, other.username)
             && Objects.equals(realm, other.realm)
             && Objects.equals(metadata, other.metadata)
-            && Objects.equals(roleDescriptors, other.roleDescriptors);
+            && Objects.equals(roleDescriptors, other.roleDescriptors)
+            && Objects.equals(limitedBy, other.limitedBy);
     }
 
     @SuppressWarnings("unchecked")
@@ -216,7 +261,8 @@ public final class ApiKey implements ToXContentObject, Writeable {
             (String) args[5],
             (String) args[6],
             (args[7] == null) ? null : (Map<String, Object>) args[7],
-            (List<RoleDescriptor>) args[8]
+            (List<RoleDescriptor>) args[8],
+            (RoleDescriptorsIntersection) args[9]
         );
     });
     static {
@@ -232,6 +278,12 @@ public final class ApiKey implements ToXContentObject, Writeable {
             p.nextToken();
             return RoleDescriptor.parse(n, p, false);
         }, new ParseField("role_descriptors"));
+        PARSER.declareField(
+            optionalConstructorArg(),
+            (p, c) -> RoleDescriptorsIntersection.fromXContent(p),
+            new ParseField("limited_by"),
+            ObjectParser.ValueType.OBJECT_ARRAY
+        );
     }
 
     public static ApiKey fromXContent(XContentParser parser) throws IOException {
@@ -258,6 +310,8 @@ public final class ApiKey implements ToXContentObject, Writeable {
             + metadata
             + ", role_descriptors="
             + roleDescriptors
+            + ", limited_by="
+            + limitedBy
             + "]";
     }
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/apikey/GetApiKeyRequest.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/apikey/GetApiKeyRequest.java
@@ -30,10 +30,7 @@ public final class GetApiKeyRequest extends ActionRequest {
     private final String apiKeyId;
     private final String apiKeyName;
     private final boolean ownedByAuthenticatedUser;
-
-    public GetApiKeyRequest() {
-        this(null, null, null, null, false);
-    }
+    private final boolean withLimitedBy;
 
     public GetApiKeyRequest(StreamInput in) throws IOException {
         super(in);
@@ -46,20 +43,27 @@ public final class GetApiKeyRequest extends ActionRequest {
         } else {
             ownedByAuthenticatedUser = false;
         }
+        if (in.getVersion().onOrAfter(Version.V_8_5_0)) {
+            withLimitedBy = in.readBoolean();
+        } else {
+            withLimitedBy = false;
+        }
     }
 
-    public GetApiKeyRequest(
+    private GetApiKeyRequest(
         @Nullable String realmName,
         @Nullable String userName,
         @Nullable String apiKeyId,
         @Nullable String apiKeyName,
-        boolean ownedByAuthenticatedUser
+        boolean ownedByAuthenticatedUser,
+        boolean withLimitedBy
     ) {
         this.realmName = textOrNull(realmName);
         this.userName = textOrNull(userName);
         this.apiKeyId = textOrNull(apiKeyId);
         this.apiKeyName = textOrNull(apiKeyName);
         this.ownedByAuthenticatedUser = ownedByAuthenticatedUser;
+        this.withLimitedBy = withLimitedBy;
     }
 
     private static String textOrNull(@Nullable String arg) {
@@ -86,13 +90,18 @@ public final class GetApiKeyRequest extends ActionRequest {
         return ownedByAuthenticatedUser;
     }
 
+    public boolean withLimitedBy() {
+        return withLimitedBy;
+    }
+
     /**
      * Creates get API key request for given realm name
      * @param realmName realm name
      * @return {@link GetApiKeyRequest}
      */
+    @Deprecated
     public static GetApiKeyRequest usingRealmName(String realmName) {
-        return new GetApiKeyRequest(realmName, null, null, null, false);
+        return new GetApiKeyRequest(realmName, null, null, null, false, false);
     }
 
     /**
@@ -100,8 +109,9 @@ public final class GetApiKeyRequest extends ActionRequest {
      * @param userName user name
      * @return {@link GetApiKeyRequest}
      */
+    @Deprecated
     public static GetApiKeyRequest usingUserName(String userName) {
-        return new GetApiKeyRequest(null, userName, null, null, false);
+        return new GetApiKeyRequest(null, userName, null, null, false, false);
     }
 
     /**
@@ -110,8 +120,9 @@ public final class GetApiKeyRequest extends ActionRequest {
      * @param userName user name
      * @return {@link GetApiKeyRequest}
      */
+    @Deprecated
     public static GetApiKeyRequest usingRealmAndUserName(String realmName, String userName) {
-        return new GetApiKeyRequest(realmName, userName, null, null, false);
+        return new GetApiKeyRequest(realmName, userName, null, null, false, false);
     }
 
     /**
@@ -121,8 +132,9 @@ public final class GetApiKeyRequest extends ActionRequest {
      * {@code false}
      * @return {@link GetApiKeyRequest}
      */
+    @Deprecated
     public static GetApiKeyRequest usingApiKeyId(String apiKeyId, boolean ownedByAuthenticatedUser) {
-        return new GetApiKeyRequest(null, null, apiKeyId, null, ownedByAuthenticatedUser);
+        return new GetApiKeyRequest(null, null, apiKeyId, null, ownedByAuthenticatedUser, false);
     }
 
     /**
@@ -133,21 +145,23 @@ public final class GetApiKeyRequest extends ActionRequest {
      * @return {@link GetApiKeyRequest}
      */
     public static GetApiKeyRequest usingApiKeyName(String apiKeyName, boolean ownedByAuthenticatedUser) {
-        return new GetApiKeyRequest(null, null, null, apiKeyName, ownedByAuthenticatedUser);
+        return new GetApiKeyRequest(null, null, null, apiKeyName, ownedByAuthenticatedUser, false);
     }
 
     /**
      * Creates get api key request to retrieve api key information for the api keys owned by the current authenticated user.
      */
+    @Deprecated
     public static GetApiKeyRequest forOwnedApiKeys() {
-        return new GetApiKeyRequest(null, null, null, null, true);
+        return new GetApiKeyRequest(null, null, null, null, true, false);
     }
 
     /**
      * Creates get api key request to retrieve api key information for all api keys if the authenticated user is authorized to do so.
      */
+    @Deprecated
     public static GetApiKeyRequest forAllApiKeys() {
-        return new GetApiKeyRequest();
+        return GetApiKeyRequest.builder().build();
     }
 
     @Override
@@ -185,6 +199,9 @@ public final class GetApiKeyRequest extends ActionRequest {
         if (out.getVersion().onOrAfter(Version.V_7_4_0)) {
             out.writeOptionalBoolean(ownedByAuthenticatedUser);
         }
+        if (out.getVersion().onOrAfter(Version.V_8_5_0)) {
+            out.writeBoolean(withLimitedBy);
+        }
     }
 
     @Override
@@ -200,11 +217,67 @@ public final class GetApiKeyRequest extends ActionRequest {
             && Objects.equals(realmName, that.realmName)
             && Objects.equals(userName, that.userName)
             && Objects.equals(apiKeyId, that.apiKeyId)
-            && Objects.equals(apiKeyName, that.apiKeyName);
+            && Objects.equals(apiKeyName, that.apiKeyName)
+            && withLimitedBy == that.withLimitedBy;
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(realmName, userName, apiKeyId, apiKeyName, ownedByAuthenticatedUser);
+        return Objects.hash(realmName, userName, apiKeyId, apiKeyName, ownedByAuthenticatedUser, withLimitedBy);
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static class Builder {
+        private String realmName = null;
+        private String userName = null;
+        private String apiKeyId = null;
+        private String apiKeyName = null;
+        private boolean ownedByAuthenticatedUser = false;
+        private boolean withLimitedBy = false;
+
+        public Builder realmName(String realmName) {
+            this.realmName = realmName;
+            return this;
+        }
+
+        public Builder userName(String userName) {
+            this.userName = userName;
+            return this;
+        }
+
+        public Builder apiKeyId(String apiKeyId) {
+            this.apiKeyId = apiKeyId;
+            return this;
+        }
+
+        public Builder apiKeyName(String apiKeyName) {
+            this.apiKeyName = apiKeyName;
+            return this;
+        }
+
+        public Builder ownedByAuthenticatedUser() {
+            return ownedByAuthenticatedUser(true);
+        }
+
+        public Builder ownedByAuthenticatedUser(boolean ownedByAuthenticatedUser) {
+            this.ownedByAuthenticatedUser = ownedByAuthenticatedUser;
+            return this;
+        }
+
+        public Builder withLimitedBy() {
+            return withLimitedBy(true);
+        }
+
+        public Builder withLimitedBy(boolean withLimitedBy) {
+            this.withLimitedBy = withLimitedBy;
+            return this;
+        }
+
+        public GetApiKeyRequest build() {
+            return new GetApiKeyRequest(realmName, userName, apiKeyId, apiKeyName, ownedByAuthenticatedUser, withLimitedBy);
+        }
     }
 }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/apikey/QueryApiKeyRequest.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/apikey/QueryApiKeyRequest.java
@@ -7,6 +7,7 @@
 
 package org.elasticsearch.xpack.core.security.action.apikey;
 
+import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.common.io.stream.StreamInput;
@@ -33,6 +34,7 @@ public final class QueryApiKeyRequest extends ActionRequest {
     private final List<FieldSortBuilder> fieldSortBuilders;
     @Nullable
     private final SearchAfterBuilder searchAfterBuilder;
+    private final boolean withLimitedBy;
     private boolean filterForCurrentUser;
 
     public QueryApiKeyRequest() {
@@ -40,7 +42,7 @@ public final class QueryApiKeyRequest extends ActionRequest {
     }
 
     public QueryApiKeyRequest(QueryBuilder queryBuilder) {
-        this(queryBuilder, null, null, null, null);
+        this(queryBuilder, null, null, null, null, false);
     }
 
     public QueryApiKeyRequest(
@@ -48,13 +50,15 @@ public final class QueryApiKeyRequest extends ActionRequest {
         @Nullable Integer from,
         @Nullable Integer size,
         @Nullable List<FieldSortBuilder> fieldSortBuilders,
-        @Nullable SearchAfterBuilder searchAfterBuilder
+        @Nullable SearchAfterBuilder searchAfterBuilder,
+        boolean withLimitedBy
     ) {
         this.queryBuilder = queryBuilder;
         this.from = from;
         this.size = size;
         this.fieldSortBuilders = fieldSortBuilders;
         this.searchAfterBuilder = searchAfterBuilder;
+        this.withLimitedBy = withLimitedBy;
     }
 
     public QueryApiKeyRequest(StreamInput in) throws IOException {
@@ -68,6 +72,11 @@ public final class QueryApiKeyRequest extends ActionRequest {
             this.fieldSortBuilders = null;
         }
         this.searchAfterBuilder = in.readOptionalWriteable(SearchAfterBuilder::new);
+        if (in.getVersion().onOrAfter(Version.V_8_5_0)) {
+            this.withLimitedBy = in.readBoolean();
+        } else {
+            this.withLimitedBy = false;
+        }
     }
 
     public QueryBuilder getQueryBuilder() {
@@ -98,6 +107,10 @@ public final class QueryApiKeyRequest extends ActionRequest {
         filterForCurrentUser = true;
     }
 
+    public boolean isWithLimitedBy() {
+        return withLimitedBy;
+    }
+
     @Override
     public ActionRequestValidationException validate() {
         ActionRequestValidationException validationException = null;
@@ -123,5 +136,8 @@ public final class QueryApiKeyRequest extends ActionRequest {
             out.writeList(fieldSortBuilders);
         }
         out.writeOptionalWriteable(searchAfterBuilder);
+        if (out.getVersion().onOrAfter(Version.V_8_5_0)) {
+            out.writeBoolean(withLimitedBy);
+        }
     }
 }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/apikey/QueryApiKeyRequest.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/apikey/QueryApiKeyRequest.java
@@ -107,7 +107,7 @@ public final class QueryApiKeyRequest extends ActionRequest {
         filterForCurrentUser = true;
     }
 
-    public boolean isWithLimitedBy() {
+    public boolean withLimitedBy() {
         return withLimitedBy;
     }
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/RoleDescriptorsIntersection.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/RoleDescriptorsIntersection.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.core.security.authz;
+
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.common.xcontent.XContentParserUtils;
+import org.elasticsearch.xcontent.ToXContentObject;
+import org.elasticsearch.xcontent.XContentBuilder;
+import org.elasticsearch.xcontent.XContentParser;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+public record RoleDescriptorsIntersection(List<List<RoleDescriptor>> roleDescriptorsList) implements ToXContentObject, Writeable {
+
+    public RoleDescriptorsIntersection(StreamInput in) throws IOException {
+        this(RoleDescriptorsIntersection.readRoleDescriptorsListFrom(in));
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        out.writeVInt(roleDescriptorsList.size());
+        for (List<RoleDescriptor> roleDescriptors : roleDescriptorsList) {
+            out.writeList(roleDescriptors);
+        }
+    }
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        builder.startArray();
+        {
+            for (List<RoleDescriptor> roleDescriptors : roleDescriptorsList) {
+                builder.startObject();
+                for (RoleDescriptor roleDescriptor : roleDescriptors) {
+                    builder.field(roleDescriptor.getName(), roleDescriptor);
+                }
+                builder.endObject();
+            }
+        }
+        builder.endArray();
+        return builder;
+    }
+
+    public static RoleDescriptorsIntersection fromXContent(XContentParser p) throws IOException {
+        XContentParser.Token token = p.currentToken();
+        if (token == null) {
+            token = p.nextToken();
+        }
+        XContentParserUtils.ensureExpectedToken(XContentParser.Token.START_ARRAY, token, p);
+        final List<List<RoleDescriptor>> roleDescriptorsList = new ArrayList<>();
+        while ((token = p.nextToken()) != XContentParser.Token.END_ARRAY) {
+            XContentParserUtils.ensureExpectedToken(XContentParser.Token.START_OBJECT, token, p);
+            final List<RoleDescriptor> roleDescriptors = new ArrayList<>();
+            while ((token = p.nextToken()) != XContentParser.Token.END_OBJECT) {
+                XContentParserUtils.ensureExpectedToken(XContentParser.Token.FIELD_NAME, token, p);
+                XContentParserUtils.ensureExpectedToken(XContentParser.Token.START_OBJECT, p.nextToken(), p);
+                roleDescriptors.add(RoleDescriptor.parse(p.currentName(), p, false));
+            }
+            roleDescriptorsList.add(List.copyOf(roleDescriptors));
+        }
+        return new RoleDescriptorsIntersection(List.copyOf(roleDescriptorsList));
+    }
+
+    private static List<List<RoleDescriptor>> readRoleDescriptorsListFrom(StreamInput in) throws IOException {
+        final List<List<RoleDescriptor>> roleDescriptorsList = new ArrayList<>();
+        final int size = in.readVInt();
+        assert size >= 0;
+        if (size < 0) {
+            throw new IllegalArgumentException("list of role descriptors size must be greater than 0");
+        }
+        for (int i = 0; i < size; i++) {
+            roleDescriptorsList.add(List.copyOf(in.readList(RoleDescriptor::new)));
+        }
+        return List.copyOf(roleDescriptorsList);
+    }
+}

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/privilege/ManageOwnApiKeyClusterPrivilege.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/privilege/ManageOwnApiKeyClusterPrivilege.java
@@ -70,7 +70,7 @@ public class ManageOwnApiKeyClusterPrivilege implements NamedClusterPrivilege {
                 // Ownership of an API key, for regular users, is enforced at the service layer.
                 return true;
             } else if (request instanceof final GetApiKeyRequest getApiKeyRequest) {
-                // An API key with no manage_api_key privilege or higher is not allowed to view any limited-by role descriptors
+                // An API key requires manage_api_key privilege or higher to view any limited-by role descriptors
                 if (authentication.isApiKey() && getApiKeyRequest.withLimitedBy()) {
                     return false;
                 }
@@ -104,8 +104,8 @@ public class ManageOwnApiKeyClusterPrivilege implements NamedClusterPrivilege {
                         );
                 }
             } else if (request instanceof final QueryApiKeyRequest queryApiKeyRequest) {
-                // An API key with no manage_api_key privilege or higher is not allowed to view any limited-by role descriptors
-                if (authentication.isApiKey() && queryApiKeyRequest.isWithLimitedBy()) {
+                // An API key requires manage_api_key privilege or higher to view any limited-by role descriptors
+                if (authentication.isApiKey() && queryApiKeyRequest.withLimitedBy()) {
                     return false;
                 }
                 return queryApiKeyRequest.isFilterForCurrentUser();

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/privilege/ManageOwnApiKeyClusterPrivilege.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/privilege/ManageOwnApiKeyClusterPrivilege.java
@@ -70,6 +70,10 @@ public class ManageOwnApiKeyClusterPrivilege implements NamedClusterPrivilege {
                 // Ownership of an API key, for regular users, is enforced at the service layer.
                 return true;
             } else if (request instanceof final GetApiKeyRequest getApiKeyRequest) {
+                // An API key with no manage_api_key privilege or higher is not allowed to view any limited-by role descriptors
+                if (authentication.isApiKey() && getApiKeyRequest.withLimitedBy()) {
+                    return false;
+                }
                 return checkIfUserIsOwnerOfApiKeys(
                     authentication,
                     getApiKeyRequest.getApiKeyId(),
@@ -100,6 +104,10 @@ public class ManageOwnApiKeyClusterPrivilege implements NamedClusterPrivilege {
                         );
                 }
             } else if (request instanceof final QueryApiKeyRequest queryApiKeyRequest) {
+                // An API key with no manage_api_key privilege or higher is not allowed to view any limited-by role descriptors
+                if (authentication.isApiKey() && queryApiKeyRequest.isWithLimitedBy()) {
+                    return false;
+                }
                 return queryApiKeyRequest.isFilterForCurrentUser();
             } else if (request instanceof GrantApiKeyRequest) {
                 return false;

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/test/SecuritySettingsSourceField.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/test/SecuritySettingsSourceField.java
@@ -7,6 +7,9 @@
 package org.elasticsearch.test;
 
 import org.elasticsearch.common.settings.SecureString;
+import org.elasticsearch.xpack.core.security.authz.RoleDescriptor;
+
+import java.util.Map;
 
 public final class SecuritySettingsSourceField {
     public static final SecureString TEST_PASSWORD_SECURE_STRING = new SecureString("x-pack-test-password".toCharArray());
@@ -22,9 +25,24 @@ public final class SecuritySettingsSourceField {
               allow_restricted_indices: true
               privileges: [ "ALL" ]
           run_as: [ "*" ]
-          # The _es_test_root role doesn't have any application privileges because that would require loading data (Application Privileges)
-          # from the security index, which can causes problems if the index is not available
+          applications:
+            - application: "*"
+              privileges: [ "*" ]
+              resources: [ "*" ]
         """;
+
+    public static final RoleDescriptor ES_TEST_ROOT_ROLE_DESCRIPTOR = new RoleDescriptor(
+        "_es_test_root",
+        new String[] { "ALL" },
+        new RoleDescriptor.IndicesPrivileges[] {
+            RoleDescriptor.IndicesPrivileges.builder().indices("*").privileges("ALL").allowRestrictedIndices(true).build() },
+        new RoleDescriptor.ApplicationResourcePrivileges[] {
+            RoleDescriptor.ApplicationResourcePrivileges.builder().application("*").privileges("*").resources("*").build() },
+        null,
+        new String[] { "*" },
+        Map.of(),
+        Map.of("enabled", true)
+    );
 
     private SecuritySettingsSourceField() {}
 }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/action/apikey/ApiKeyTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/action/apikey/ApiKeyTests.java
@@ -7,13 +7,16 @@
 
 package org.elasticsearch.xpack.core.security.action.apikey;
 
-import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.xcontent.XContentHelper;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.XContentTestUtils;
 import org.elasticsearch.xcontent.ToXContent;
 import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xcontent.XContentFactory;
+import org.elasticsearch.xcontent.XContentParser;
+import org.elasticsearch.xcontent.XContentParserConfiguration;
+import org.elasticsearch.xcontent.json.JsonXContent;
 import org.elasticsearch.xpack.core.security.authz.RoleDescriptor;
 
 import java.io.IOException;
@@ -31,6 +34,7 @@ import static org.hamcrest.Matchers.notNullValue;
 
 public class ApiKeyTests extends ESTestCase {
 
+    @SuppressWarnings("unchecked")
     public void testXContent() throws IOException {
         final String name = randomAlphaOfLengthBetween(4, 10);
         final String id = randomAlphaOfLength(20);
@@ -44,14 +48,31 @@ public class ApiKeyTests extends ESTestCase {
         final String realmName = randomAlphaOfLengthBetween(3, 8);
         final Map<String, Object> metadata = randomMetadata();
         final List<RoleDescriptor> roleDescriptors = randomBoolean() ? null : randomUniquelyNamedRoleDescriptors(0, 3);
+        final List<RoleDescriptor> limitedByRoleDescriptors = randomUniquelyNamedRoleDescriptors(0, 3);
 
-        final ApiKey apiKey = new ApiKey(name, id, creation, expiration, invalidated, username, realmName, metadata, roleDescriptors);
+        final ApiKey apiKey = new ApiKey(
+            name,
+            id,
+            creation,
+            expiration,
+            invalidated,
+            username,
+            realmName,
+            metadata,
+            roleDescriptors,
+            limitedByRoleDescriptors
+        );
         // The metadata will never be null because the constructor convert it to empty map if a null is passed in
         assertThat(apiKey.getMetadata(), notNullValue());
 
         XContentBuilder builder = XContentFactory.jsonBuilder();
         apiKey.toXContent(builder, ToXContent.EMPTY_PARAMS);
-        final Map<String, Object> map = XContentHelper.convertToMap(BytesReference.bytes(builder), false, builder.contentType()).v2();
+        final String jsonString = Strings.toString(builder);
+        final Map<String, Object> map = XContentHelper.convertToMap(JsonXContent.jsonXContent, jsonString, false);
+
+        try (XContentParser parser = JsonXContent.jsonXContent.createParser(XContentParserConfiguration.EMPTY, jsonString)) {
+            assertThat(ApiKey.fromXContent(parser), equalTo(apiKey));
+        }
 
         assertThat(map.get("name"), equalTo(name));
         assertThat(map.get("id"), equalTo(id));
@@ -69,13 +90,20 @@ public class ApiKeyTests extends ESTestCase {
         if (roleDescriptors == null) {
             assertThat(map, not(hasKey("role_descriptors")));
         } else {
-            @SuppressWarnings("unchecked")
-            final Map<String, Object> rdMap = (Map<String, Object>) map.get("role_descriptors");
+            final var rdMap = (Map<String, Object>) map.get("role_descriptors");
             assertThat(rdMap.size(), equalTo(roleDescriptors.size()));
             for (var roleDescriptor : roleDescriptors) {
                 assertThat(rdMap, hasKey(roleDescriptor.getName()));
                 assertThat(XContentTestUtils.convertToMap(roleDescriptor), equalTo(rdMap.get(roleDescriptor.getName())));
             }
+        }
+
+        final var limitedByList = (List<Map<String, Object>>) map.get("limited_by");
+        assertThat(limitedByList.size(), equalTo(1));
+        final Map<String, Object> limitedByMap = limitedByList.get(0);
+        for (RoleDescriptor roleDescriptor : limitedByRoleDescriptors) {
+            assertThat(limitedByMap, hasKey(roleDescriptor.getName()));
+            assertThat(XContentTestUtils.convertToMap(roleDescriptor), equalTo(limitedByMap.get(roleDescriptor.getName())));
         }
     }
 

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/action/apikey/ApiKeyTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/action/apikey/ApiKeyTests.java
@@ -101,6 +101,7 @@ public class ApiKeyTests extends ESTestCase {
         final var limitedByList = (List<Map<String, Object>>) map.get("limited_by");
         assertThat(limitedByList.size(), equalTo(1));
         final Map<String, Object> limitedByMap = limitedByList.get(0);
+        assertThat(limitedByMap.size(), equalTo(limitedByRoleDescriptors.size()));
         for (RoleDescriptor roleDescriptor : limitedByRoleDescriptors) {
             assertThat(limitedByMap, hasKey(roleDescriptor.getName()));
             assertThat(XContentTestUtils.convertToMap(roleDescriptor), equalTo(limitedByMap.get(roleDescriptor.getName())));

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/action/apikey/GetApiKeyRequestTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/action/apikey/GetApiKeyRequestTests.java
@@ -75,6 +75,7 @@ public class GetApiKeyRequestTests extends ESTestCase {
                 out.writeOptionalString(apiKeyId);
                 out.writeOptionalString(apiKeyName);
                 out.writeOptionalBoolean(ownedByAuthenticatedUser);
+                out.writeBoolean(randomBoolean());
             }
         }
 
@@ -151,13 +152,14 @@ public class GetApiKeyRequestTests extends ESTestCase {
 
     public void testEmptyStringsAreCoercedToNull() {
         Supplier<String> randomBlankString = () -> " ".repeat(randomIntBetween(0, 5));
-        final GetApiKeyRequest request = new GetApiKeyRequest(
-            randomBlankString.get(), // realm name
-            randomBlankString.get(), // user name
-            randomBlankString.get(), // key id
-            randomBlankString.get(), // key name
-            randomBoolean() // owned by user
-        );
+        final GetApiKeyRequest request = GetApiKeyRequest.builder()
+            .realmName(randomBlankString.get())
+            .userName(randomBlankString.get())
+            .apiKeyId(randomBlankString.get())
+            .apiKeyName(randomBlankString.get())
+            .ownedByAuthenticatedUser(randomBoolean())
+            .withLimitedBy(randomBoolean())
+            .build();
         assertThat(request.getRealmName(), nullValue());
         assertThat(request.getUserName(), nullValue());
         assertThat(request.getApiKeyId(), nullValue());

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/action/apikey/QueryApiKeyRequestTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/action/apikey/QueryApiKeyRequestTests.java
@@ -84,7 +84,7 @@ public class QueryApiKeyRequestTests extends ESTestCase {
                 assertThat(deserialized.getSize(), equalTo(request3.getSize()));
                 assertThat(deserialized.getFieldSortBuilders(), equalTo(request3.getFieldSortBuilders()));
                 assertThat(deserialized.getSearchAfterBuilder(), equalTo(request3.getSearchAfterBuilder()));
-                assertThat(deserialized.isWithLimitedBy(), equalTo(request3.isWithLimitedBy()));
+                assertThat(deserialized.withLimitedBy(), equalTo(request3.withLimitedBy()));
             }
         }
     }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/action/apikey/QueryApiKeyRequestTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/action/apikey/QueryApiKeyRequestTests.java
@@ -72,7 +72,8 @@ public class QueryApiKeyRequestTests extends ESTestCase {
                 new FieldSortBuilder("creation_time").setFormat("strict_date_time").order(SortOrder.DESC),
                 new FieldSortBuilder("username")
             ),
-            new SearchAfterBuilder().setSortValues(new String[] { "key-2048", "2021-07-01T00:00:59.000Z" })
+            new SearchAfterBuilder().setSortValues(new String[] { "key-2048", "2021-07-01T00:00:59.000Z" }),
+            randomBoolean()
         );
         try (BytesStreamOutput out = new BytesStreamOutput()) {
             request3.writeTo(out);
@@ -83,6 +84,7 @@ public class QueryApiKeyRequestTests extends ESTestCase {
                 assertThat(deserialized.getSize(), equalTo(request3.getSize()));
                 assertThat(deserialized.getFieldSortBuilders(), equalTo(request3.getFieldSortBuilders()));
                 assertThat(deserialized.getSearchAfterBuilder(), equalTo(request3.getSearchAfterBuilder()));
+                assertThat(deserialized.isWithLimitedBy(), equalTo(request3.isWithLimitedBy()));
             }
         }
     }
@@ -93,7 +95,8 @@ public class QueryApiKeyRequestTests extends ESTestCase {
             randomIntBetween(0, Integer.MAX_VALUE),
             randomIntBetween(0, Integer.MAX_VALUE),
             null,
-            null
+            null,
+            randomBoolean()
         );
         assertThat(request1.validate(), nullValue());
 
@@ -102,7 +105,8 @@ public class QueryApiKeyRequestTests extends ESTestCase {
             randomIntBetween(Integer.MIN_VALUE, -1),
             randomIntBetween(0, Integer.MAX_VALUE),
             null,
-            null
+            null,
+            randomBoolean()
         );
         assertThat(request2.validate().getMessage(), containsString("[from] parameter cannot be negative"));
 
@@ -111,7 +115,8 @@ public class QueryApiKeyRequestTests extends ESTestCase {
             randomIntBetween(0, Integer.MAX_VALUE),
             randomIntBetween(Integer.MIN_VALUE, -1),
             null,
-            null
+            null,
+            randomBoolean()
         );
         assertThat(request3.validate().getMessage(), containsString("[size] parameter cannot be negative"));
     }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/action/apikey/QueryApiKeyResponseTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/action/apikey/QueryApiKeyResponseTests.java
@@ -95,7 +95,18 @@ public class QueryApiKeyResponseTests extends AbstractWireSerializingTestCase<Qu
         final Instant expiration = randomBoolean() ? Instant.ofEpochMilli(randomMillisUpToYear9999()) : null;
         final Map<String, Object> metadata = ApiKeyTests.randomMetadata();
         final List<RoleDescriptor> roleDescriptors = randomFrom(randomUniquelyNamedRoleDescriptors(0, 3), null);
-        return new ApiKey(name, id, creation, expiration, false, username, realm_name, metadata, roleDescriptors);
+        return new ApiKey(
+            name,
+            id,
+            creation,
+            expiration,
+            false,
+            username,
+            realm_name,
+            metadata,
+            roleDescriptors,
+            randomUniquelyNamedRoleDescriptors(1, 3)
+        );
     }
 
     private Object[] randomSortValues() {

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/RoleDescriptorsIntersectionTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/RoleDescriptorsIntersectionTests.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.core.security.authz;
+
+import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.io.stream.BytesStreamOutput;
+import org.elasticsearch.common.io.stream.NamedWriteableAwareStreamInput;
+import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.xcontent.XContentHelper;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xcontent.ToXContent;
+import org.elasticsearch.xcontent.XContentBuilder;
+import org.elasticsearch.xcontent.XContentFactory;
+import org.elasticsearch.xcontent.XContentParser;
+import org.elasticsearch.xcontent.XContentParserConfiguration;
+import org.elasticsearch.xcontent.json.JsonXContent;
+import org.elasticsearch.xpack.core.security.authz.privilege.ConfigurableClusterPrivilege;
+import org.elasticsearch.xpack.core.security.authz.privilege.ConfigurableClusterPrivileges;
+
+import java.io.IOException;
+import java.util.List;
+
+import static org.elasticsearch.xpack.core.security.authz.RoleDescriptorTests.randomUniquelyNamedRoleDescriptors;
+import static org.hamcrest.Matchers.equalTo;
+
+public class RoleDescriptorsIntersectionTests extends ESTestCase {
+
+    public void testSerialization() throws IOException {
+        final RoleDescriptorsIntersection roleDescriptorsIntersection = new RoleDescriptorsIntersection(
+            List.of(randomUniquelyNamedRoleDescriptors(1, 3), randomUniquelyNamedRoleDescriptors(1, 3))
+        );
+
+        final NamedWriteableRegistry namedWriteableRegistry = new NamedWriteableRegistry(
+            List.of(
+                new NamedWriteableRegistry.Entry(
+                    ConfigurableClusterPrivilege.class,
+                    ConfigurableClusterPrivileges.ManageApplicationPrivileges.WRITEABLE_NAME,
+                    ConfigurableClusterPrivileges.ManageApplicationPrivileges::createFrom
+                ),
+                new NamedWriteableRegistry.Entry(
+                    ConfigurableClusterPrivilege.class,
+                    ConfigurableClusterPrivileges.WriteProfileDataPrivileges.WRITEABLE_NAME,
+                    ConfigurableClusterPrivileges.WriteProfileDataPrivileges::createFrom
+                )
+            )
+        );
+
+        try (BytesStreamOutput output = new BytesStreamOutput()) {
+            roleDescriptorsIntersection.writeTo(output);
+            try (StreamInput input = new NamedWriteableAwareStreamInput(output.bytes().streamInput(), namedWriteableRegistry)) {
+                RoleDescriptorsIntersection deserialized = new RoleDescriptorsIntersection(input);
+                assertThat(deserialized.roleDescriptorsList(), equalTo(roleDescriptorsIntersection.roleDescriptorsList()));
+            }
+        }
+    }
+
+    public void testXContent() throws IOException {
+        final RoleDescriptorsIntersection roleDescriptorsIntersection = new RoleDescriptorsIntersection(
+            List.of(
+                List.of(new RoleDescriptor("role_0", new String[] { "monitor" }, null, null)),
+                List.of(new RoleDescriptor("role_1", new String[] { "all" }, null, null))
+            )
+        );
+
+        final XContentBuilder builder = XContentFactory.jsonBuilder();
+        roleDescriptorsIntersection.toXContent(builder, ToXContent.EMPTY_PARAMS);
+        final String jsonString = Strings.toString(builder);
+
+        assertThat(jsonString, equalTo(XContentHelper.stripWhitespace("""
+            [
+              {
+                "role_0": {
+                  "cluster": ["monitor"],
+                  "indices": [],
+                  "applications": [],
+                  "run_as": [],
+                  "metadata": {},
+                  "transient_metadata": {"enabled": true}
+                }
+              },
+              {
+                "role_1": {
+                  "cluster": ["all"],
+                  "indices": [],
+                  "applications": [],
+                  "run_as": [],
+                  "metadata": {},
+                  "transient_metadata": {"enabled": true}
+                }
+              }
+            ]""")));
+
+        try (XContentParser p = JsonXContent.jsonXContent.createParser(XContentParserConfiguration.EMPTY, jsonString)) {
+            assertThat(RoleDescriptorsIntersection.fromXContent(p), equalTo(roleDescriptorsIntersection));
+        }
+    }
+}

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/RoleDescriptorsIntersectionTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/RoleDescriptorsIntersectionTests.java
@@ -25,6 +25,7 @@ import org.elasticsearch.xpack.core.security.authz.privilege.ConfigurableCluster
 
 import java.io.IOException;
 import java.util.List;
+import java.util.Set;
 
 import static org.elasticsearch.xpack.core.security.authz.RoleDescriptorTests.randomUniquelyNamedRoleDescriptors;
 import static org.hamcrest.Matchers.equalTo;
@@ -33,7 +34,7 @@ public class RoleDescriptorsIntersectionTests extends ESTestCase {
 
     public void testSerialization() throws IOException {
         final RoleDescriptorsIntersection roleDescriptorsIntersection = new RoleDescriptorsIntersection(
-            List.of(randomUniquelyNamedRoleDescriptors(1, 3), randomUniquelyNamedRoleDescriptors(1, 3))
+            randomList(0, 3, () -> Set.copyOf(randomUniquelyNamedRoleDescriptors(0, 3)))
         );
 
         final NamedWriteableRegistry namedWriteableRegistry = new NamedWriteableRegistry(
@@ -63,8 +64,8 @@ public class RoleDescriptorsIntersectionTests extends ESTestCase {
     public void testXContent() throws IOException {
         final RoleDescriptorsIntersection roleDescriptorsIntersection = new RoleDescriptorsIntersection(
             List.of(
-                List.of(new RoleDescriptor("role_0", new String[] { "monitor" }, null, null)),
-                List.of(new RoleDescriptor("role_1", new String[] { "all" }, null, null))
+                Set.of(new RoleDescriptor("role_0", new String[] { "monitor" }, null, null)),
+                Set.of(new RoleDescriptor("role_1", new String[] { "all" }, null, null))
             )
         );
 

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/privilege/ManageOwnApiKeyClusterPrivilegeTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/privilege/ManageOwnApiKeyClusterPrivilegeTests.java
@@ -35,18 +35,30 @@ import static org.mockito.Mockito.mock;
 
 public class ManageOwnApiKeyClusterPrivilegeTests extends ESTestCase {
 
-    public void testAuthenticationWithApiKeyAllowsAccessToApiKeyActionsWhenItIsOwner() {
+    public void testAuthenticationWithApiKeyAllowsAccessToApiKeyActionsWhenItIsItself() {
         final ClusterPermission clusterPermission = ManageOwnApiKeyClusterPrivilege.INSTANCE.buildPermission(ClusterPermission.builder())
             .build();
 
         final String apiKeyId = randomAlphaOfLengthBetween(4, 7);
         final User userJoe = new User("joe");
         final Authentication authentication = AuthenticationTests.randomApiKeyAuthentication(userJoe, apiKeyId);
-        final TransportRequest getApiKeyRequest = GetApiKeyRequest.usingApiKeyId(apiKeyId, randomBoolean());
+        final TransportRequest getApiKeyRequest = GetApiKeyRequest.builder()
+            .apiKeyId(apiKeyId)
+            .ownedByAuthenticatedUser(randomBoolean())
+            .build();
         final TransportRequest invalidateApiKeyRequest = InvalidateApiKeyRequest.usingApiKeyId(apiKeyId, randomBoolean());
         assertTrue(clusterPermission.check("cluster:admin/xpack/security/api_key/get", getApiKeyRequest, authentication));
         assertTrue(clusterPermission.check("cluster:admin/xpack/security/api_key/invalidate", invalidateApiKeyRequest, authentication));
         assertFalse(clusterPermission.check("cluster:admin/something", mock(TransportRequest.class), authentication));
+
+        // But it is not allowed to view any limited-by role descriptors including its own
+        assertFalse(
+            clusterPermission.check(
+                "cluster:admin/xpack/security/api_key/get",
+                GetApiKeyRequest.builder().apiKeyId(apiKeyId).withLimitedBy().build(),
+                authentication
+            )
+        );
     }
 
     public void testAuthenticationForUpdateApiKeyAllowsAll() {
@@ -76,7 +88,11 @@ public class ManageOwnApiKeyClusterPrivilegeTests extends ESTestCase {
         final String apiKeyId = randomAlphaOfLengthBetween(4, 7);
         final User userJoe = new User("joe");
         final Authentication authentication = AuthenticationTests.randomApiKeyAuthentication(userJoe, randomAlphaOfLength(20));
-        final TransportRequest getApiKeyRequest = GetApiKeyRequest.usingApiKeyId(apiKeyId, randomBoolean());
+        final TransportRequest getApiKeyRequest = GetApiKeyRequest.builder()
+            .apiKeyId(apiKeyId)
+            .ownedByAuthenticatedUser(randomBoolean())
+            .withLimitedBy(randomBoolean())
+            .build();
         final TransportRequest invalidateApiKeyRequest = InvalidateApiKeyRequest.usingApiKeyId(apiKeyId, randomBoolean());
 
         assertFalse(clusterPermission.check("cluster:admin/xpack/security/api_key/get", getApiKeyRequest, authentication));
@@ -90,7 +106,11 @@ public class ManageOwnApiKeyClusterPrivilegeTests extends ESTestCase {
         final Authentication.RealmRef realmRef = AuthenticationTests.randomRealmRef(randomBoolean());
         final Authentication authentication = AuthenticationTests.randomAuthentication(new User("joe"), realmRef);
 
-        TransportRequest getApiKeyRequest = GetApiKeyRequest.usingRealmAndUserName(realmRef.getName(), "joe");
+        TransportRequest getApiKeyRequest = GetApiKeyRequest.builder()
+            .realmName(realmRef.getName())
+            .userName("joe")
+            .withLimitedBy(randomBoolean())
+            .build();
         TransportRequest invalidateApiKeyRequest = InvalidateApiKeyRequest.usingRealmAndUserName(realmRef.getName(), "joe");
         TransportRequest updateApiKeyRequest = UpdateApiKeyRequest.usingApiKeyId(randomAlphaOfLength(10));
         assertTrue(clusterPermission.check("cluster:admin/xpack/security/api_key/get", getApiKeyRequest, authentication));
@@ -99,7 +119,7 @@ public class ManageOwnApiKeyClusterPrivilegeTests extends ESTestCase {
 
         assertFalse(clusterPermission.check("cluster:admin/something", mock(TransportRequest.class), authentication));
 
-        getApiKeyRequest = GetApiKeyRequest.usingRealmAndUserName(realmRef.getName(), "jane");
+        getApiKeyRequest = GetApiKeyRequest.builder().realmName(realmRef.getName()).userName("jane").withLimitedBy(randomBoolean()).build();
         assertFalse(clusterPermission.check("cluster:admin/xpack/security/api_key/get", getApiKeyRequest, authentication));
         invalidateApiKeyRequest = InvalidateApiKeyRequest.usingRealmAndUserName(realmRef.getName(), "jane");
         assertFalse(clusterPermission.check("cluster:admin/xpack/security/api_key/invalidate", invalidateApiKeyRequest, authentication));
@@ -108,7 +128,11 @@ public class ManageOwnApiKeyClusterPrivilegeTests extends ESTestCase {
         final String otherRealmName;
         if (realmDomain != null) {
             for (RealmConfig.RealmIdentifier realmIdentifier : realmDomain.realms()) {
-                getApiKeyRequest = GetApiKeyRequest.usingRealmAndUserName(realmIdentifier.getName(), "joe");
+                getApiKeyRequest = GetApiKeyRequest.builder()
+                    .realmName(realmIdentifier.getName())
+                    .userName("joe")
+                    .withLimitedBy(randomBoolean())
+                    .build();
                 assertTrue(clusterPermission.check("cluster:admin/xpack/security/api_key/get", getApiKeyRequest, authentication));
                 invalidateApiKeyRequest = InvalidateApiKeyRequest.usingRealmAndUserName(realmIdentifier.getName(), "joe");
                 assertTrue(
@@ -122,7 +146,7 @@ public class ManageOwnApiKeyClusterPrivilegeTests extends ESTestCase {
         } else {
             otherRealmName = randomValueOtherThan(realmRef.getName(), () -> randomAlphaOfLengthBetween(2, 10));
         }
-        getApiKeyRequest = GetApiKeyRequest.usingRealmAndUserName(otherRealmName, "joe");
+        getApiKeyRequest = GetApiKeyRequest.builder().realmName(otherRealmName).userName("joe").withLimitedBy(randomBoolean()).build();
         assertFalse(clusterPermission.check("cluster:admin/xpack/security/api_key/get", getApiKeyRequest, authentication));
         invalidateApiKeyRequest = InvalidateApiKeyRequest.usingRealmAndUserName(otherRealmName, "joe");
         assertFalse(clusterPermission.check("cluster:admin/xpack/security/api_key/invalidate", invalidateApiKeyRequest, authentication));
@@ -148,7 +172,10 @@ public class ManageOwnApiKeyClusterPrivilegeTests extends ESTestCase {
             authentication = AuthenticationTests.randomAuthentication(userJoe, realmRef);
         }
 
-        final TransportRequest getApiKeyRequest = GetApiKeyRequest.forOwnedApiKeys();
+        final TransportRequest getApiKeyRequest = GetApiKeyRequest.builder()
+            .ownedByAuthenticatedUser()
+            .withLimitedBy(randomBoolean())
+            .build();
         final TransportRequest invalidateApiKeyRequest = InvalidateApiKeyRequest.forOwnedApiKeys();
 
         assertTrue(clusterPermission.check("cluster:admin/xpack/security/api_key/get", getApiKeyRequest, authentication));
@@ -177,9 +204,9 @@ public class ManageOwnApiKeyClusterPrivilegeTests extends ESTestCase {
         }
 
         final TransportRequest getApiKeyRequest = randomFrom(
-            GetApiKeyRequest.usingRealmAndUserName("realm1", randomAlphaOfLength(7)),
-            GetApiKeyRequest.usingRealmAndUserName(randomAlphaOfLength(5), "joe"),
-            new GetApiKeyRequest(randomAlphaOfLength(5), randomAlphaOfLength(7), null, null, false)
+            GetApiKeyRequest.builder().realmName("realm1").userName(randomAlphaOfLength(7)).withLimitedBy(randomBoolean()).build(),
+            GetApiKeyRequest.builder().realmName(randomAlphaOfLength(5)).userName("joe").withLimitedBy(randomBoolean()).build(),
+            GetApiKeyRequest.builder().realmName(randomAlphaOfLength(5)).userName(randomAlphaOfLength(7)).build()
         );
         final TransportRequest invalidateApiKeyRequest = randomFrom(
             InvalidateApiKeyRequest.usingRealmAndUserName("realm1", randomAlphaOfLength(7)),
@@ -203,7 +230,7 @@ public class ManageOwnApiKeyClusterPrivilegeTests extends ESTestCase {
         assertTrue(
             clusterPermission.check(
                 "cluster:admin/xpack/security/api_key/get",
-                GetApiKeyRequest.usingRealmAndUserName("realm_b", "user_b"),
+                GetApiKeyRequest.builder().realmName("realm_b").userName("user_b").withLimitedBy(randomBoolean()).build(),
                 authentication
             )
         );
@@ -220,14 +247,28 @@ public class ManageOwnApiKeyClusterPrivilegeTests extends ESTestCase {
         final ClusterPermission clusterPermission = ManageOwnApiKeyClusterPrivilege.INSTANCE.buildPermission(ClusterPermission.builder())
             .build();
 
-        final QueryApiKeyRequest queryApiKeyRequest = new QueryApiKeyRequest();
+        final QueryApiKeyRequest queryApiKeyRequest1 = new QueryApiKeyRequest(null, null, null, null, null, randomBoolean());
         if (randomBoolean()) {
-            queryApiKeyRequest.setFilterForCurrentUser();
+            queryApiKeyRequest1.setFilterForCurrentUser();
         }
         assertThat(
-            clusterPermission.check(QueryApiKeyAction.NAME, queryApiKeyRequest, AuthenticationTestHelper.builder().build()),
-            is(queryApiKeyRequest.isFilterForCurrentUser())
+            clusterPermission.check(
+                QueryApiKeyAction.NAME,
+                queryApiKeyRequest1,
+                randomValueOtherThanMany(Authentication::isApiKey, () -> AuthenticationTestHelper.builder().build())
+            ),
+            is(queryApiKeyRequest1.isFilterForCurrentUser())
         );
+
+        // An API key cannot view limited-by role descriptors
+        final boolean withLimitedBy = randomBoolean();
+        final QueryApiKeyRequest queryApiKeyRequest2 = new QueryApiKeyRequest(null, null, null, null, null, withLimitedBy);
+        queryApiKeyRequest2.setFilterForCurrentUser();
+        assertThat(
+            clusterPermission.check(QueryApiKeyAction.NAME, queryApiKeyRequest2, AuthenticationTestHelper.builder().apiKey().build(false)),
+            is(false == queryApiKeyRequest2.isWithLimitedBy())
+        );
+
     }
 
     public void testCheckGrantApiKeyRequestDenied() {

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStoreTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStoreTests.java
@@ -416,9 +416,9 @@ public class ReservedRolesStoreTests extends ESTestCase {
         final CreateApiKeyRequest createApiKeyRequest = new CreateApiKeyRequest(randomAlphaOfLength(8), null, null);
         assertThat(kibanaRole.cluster().check(CreateApiKeyAction.NAME, createApiKeyRequest, authentication), is(true));
         // Can only get and query its own API keys
-        assertThat(kibanaRole.cluster().check(GetApiKeyAction.NAME, new GetApiKeyRequest(), authentication), is(false));
+        assertThat(kibanaRole.cluster().check(GetApiKeyAction.NAME, GetApiKeyRequest.forAllApiKeys(), authentication), is(false));
         assertThat(
-            kibanaRole.cluster().check(GetApiKeyAction.NAME, new GetApiKeyRequest(null, null, null, null, true), authentication),
+            kibanaRole.cluster().check(GetApiKeyAction.NAME, GetApiKeyRequest.builder().ownedByAuthenticatedUser().build(), authentication),
             is(true)
         );
         final QueryApiKeyRequest queryApiKeyRequest = new QueryApiKeyRequest();

--- a/x-pack/plugin/security/qa/security-trial/src/javaRestTest/java/org/elasticsearch/xpack/security/apikey/ApiKeyRestIT.java
+++ b/x-pack/plugin/security/qa/security-trial/src/javaRestTest/java/org/elasticsearch/xpack/security/apikey/ApiKeyRestIT.java
@@ -32,6 +32,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import static org.elasticsearch.test.SecuritySettingsSourceField.ES_TEST_ROOT_ROLE;
+import static org.elasticsearch.test.SecuritySettingsSourceField.ES_TEST_ROOT_ROLE_DESCRIPTOR;
 import static org.elasticsearch.xpack.core.security.authc.AuthenticationServiceField.RUN_AS_USER_HEADER;
 import static org.hamcrest.Matchers.anEmptyMap;
 import static org.hamcrest.Matchers.contains;
@@ -144,14 +146,29 @@ public class ApiKeyRestIT extends SecurityOnTrialLicenseRestTestCase {
         assertOK(adminClient().performRequest(createApiKeyRequest3));
 
         // Role descriptors are returned by both get and query api key calls
+        final boolean withLimitedBy = randomBoolean();
         final List<Map<String, Object>> apiKeyMaps;
         if (randomBoolean()) {
             final Request getApiKeyRequest = new Request("GET", "_security/api_key");
+            if (withLimitedBy) {
+                getApiKeyRequest.addParameter("with_limited_by", "true");
+            } else {
+                if (randomBoolean()) {
+                    getApiKeyRequest.addParameter("with_limited_by", "false");
+                }
+            }
             final Response getApiKeyResponse = adminClient().performRequest(getApiKeyRequest);
             assertOK(getApiKeyResponse);
             apiKeyMaps = (List<Map<String, Object>>) responseAsMap(getApiKeyResponse).get("api_keys");
         } else {
             final Request queryApiKeyRequest = new Request("POST", "_security/_query/api_key");
+            if (withLimitedBy) {
+                queryApiKeyRequest.addParameter("with_limited_by", "true");
+            } else {
+                if (randomBoolean()) {
+                    queryApiKeyRequest.addParameter("with_limited_by", "false");
+                }
+            }
             final Response queryApiKeyResponse = adminClient().performRequest(queryApiKeyRequest);
             assertOK(queryApiKeyResponse);
             apiKeyMaps = (List<Map<String, Object>>) responseAsMap(queryApiKeyResponse).get("api_keys");
@@ -162,6 +179,18 @@ public class ApiKeyRestIT extends SecurityOnTrialLicenseRestTestCase {
             final String name = (String) apiKeyMap.get("name");
             @SuppressWarnings("unchecked")
             final var roleDescriptors = (Map<String, Object>) apiKeyMap.get("role_descriptors");
+
+            if (withLimitedBy) {
+                final List<Map<String, Object>> limitedBy = (List<Map<String, Object>>) apiKeyMap.get("limited_by");
+                assertThat(limitedBy.size(), equalTo(1));
+                assertThat(
+                    limitedBy.get(0),
+                    equalTo(Map.of(ES_TEST_ROOT_ROLE, XContentTestUtils.convertToMap(ES_TEST_ROOT_ROLE_DESCRIPTOR)))
+                );
+            } else {
+                assertThat(apiKeyMap, not(hasKey("limited_by")));
+            }
+
             switch (name) {
                 case "k1" -> {
                     assertThat(roleDescriptors, anEmptyMap());

--- a/x-pack/plugin/security/qa/security-trial/src/javaRestTest/java/org/elasticsearch/xpack/security/apikey/ApiKeyRestIT.java
+++ b/x-pack/plugin/security/qa/security-trial/src/javaRestTest/java/org/elasticsearch/xpack/security/apikey/ApiKeyRestIT.java
@@ -152,10 +152,8 @@ public class ApiKeyRestIT extends SecurityOnTrialLicenseRestTestCase {
             final Request getApiKeyRequest = new Request("GET", "_security/api_key");
             if (withLimitedBy) {
                 getApiKeyRequest.addParameter("with_limited_by", "true");
-            } else {
-                if (randomBoolean()) {
-                    getApiKeyRequest.addParameter("with_limited_by", "false");
-                }
+            } else if (randomBoolean()) {
+                getApiKeyRequest.addParameter("with_limited_by", "false");
             }
             final Response getApiKeyResponse = adminClient().performRequest(getApiKeyRequest);
             assertOK(getApiKeyResponse);
@@ -164,10 +162,8 @@ public class ApiKeyRestIT extends SecurityOnTrialLicenseRestTestCase {
             final Request queryApiKeyRequest = new Request("POST", "_security/_query/api_key");
             if (withLimitedBy) {
                 queryApiKeyRequest.addParameter("with_limited_by", "true");
-            } else {
-                if (randomBoolean()) {
-                    queryApiKeyRequest.addParameter("with_limited_by", "false");
-                }
+            } else if (randomBoolean()) {
+                queryApiKeyRequest.addParameter("with_limited_by", "false");
             }
             final Response queryApiKeyResponse = adminClient().performRequest(queryApiKeyRequest);
             assertOK(queryApiKeyResponse);

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/apikey/TransportGetApiKeyAction.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/apikey/TransportGetApiKeyAction.java
@@ -12,7 +12,6 @@ import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.HandledTransportAction;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.inject.Inject;
-import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.tasks.Task;
 import org.elasticsearch.transport.TransportService;
 import org.elasticsearch.xpack.core.security.SecurityContext;
@@ -34,7 +33,7 @@ public final class TransportGetApiKeyAction extends HandledTransportAction<GetAp
         ApiKeyService apiKeyService,
         SecurityContext context
     ) {
-        super(GetApiKeyAction.NAME, transportService, actionFilters, (Writeable.Reader<GetApiKeyRequest>) GetApiKeyRequest::new);
+        super(GetApiKeyAction.NAME, transportService, actionFilters, GetApiKeyRequest::new);
         this.apiKeyService = apiKeyService;
         this.securityContext = context;
     }
@@ -58,7 +57,7 @@ public final class TransportGetApiKeyAction extends HandledTransportAction<GetAp
             realms = ApiKeyService.getOwnersRealmNames(authentication);
         }
 
-        apiKeyService.getApiKeys(realms, username, apiKeyName, apiKeyIds, listener);
+        apiKeyService.getApiKeys(realms, username, apiKeyName, apiKeyIds, request.withLimitedBy(), listener);
     }
 
 }

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/apikey/TransportQueryApiKeyAction.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/apikey/TransportQueryApiKeyAction.java
@@ -80,7 +80,7 @@ public final class TransportQueryApiKeyAction extends HandledTransportAction<Que
         }
 
         final SearchRequest searchRequest = new SearchRequest(new String[] { SECURITY_MAIN_ALIAS }, searchSourceBuilder);
-        apiKeyService.queryApiKeys(searchRequest, listener);
+        apiKeyService.queryApiKeys(searchRequest, request.isWithLimitedBy(), listener);
     }
 
     // package private for testing

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/apikey/TransportQueryApiKeyAction.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/apikey/TransportQueryApiKeyAction.java
@@ -80,7 +80,7 @@ public final class TransportQueryApiKeyAction extends HandledTransportAction<Que
         }
 
         final SearchRequest searchRequest = new SearchRequest(new String[] { SECURITY_MAIN_ALIAS }, searchSourceBuilder);
-        apiKeyService.queryApiKeys(searchRequest, request.isWithLimitedBy(), listener);
+        apiKeyService.queryApiKeys(searchRequest, request.withLimitedBy(), listener);
     }
 
     // package private for testing

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authz/RBACEngine.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authz/RBACEngine.java
@@ -207,7 +207,8 @@ public class RBACEngine implements AuthorizationEngine {
                     // if the authentication is an API key then the request must also contain same API key id
                     String authenticatedApiKeyId = (String) authentication.getMetadata().get(AuthenticationField.API_KEY_ID_KEY);
                     if (Strings.hasText(getApiKeyRequest.getApiKeyId())) {
-                        return getApiKeyRequest.getApiKeyId().equals(authenticatedApiKeyId);
+                        // An API key with no manage_api_key or higher is not allowed to view its own limited-by role descriptors
+                        return getApiKeyRequest.getApiKeyId().equals(authenticatedApiKeyId) && false == getApiKeyRequest.withLimitedBy();
                     } else {
                         return false;
                     }

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authz/RBACEngine.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authz/RBACEngine.java
@@ -207,7 +207,7 @@ public class RBACEngine implements AuthorizationEngine {
                     // if the authentication is an API key then the request must also contain same API key id
                     String authenticatedApiKeyId = (String) authentication.getMetadata().get(AuthenticationField.API_KEY_ID_KEY);
                     if (Strings.hasText(getApiKeyRequest.getApiKeyId())) {
-                        // An API key with no manage_api_key or higher is not allowed to view its own limited-by role descriptors
+                        // An API key requires manage_api_key privilege or higher to view any limited-by role descriptors
                         return getApiKeyRequest.getApiKeyId().equals(authenticatedApiKeyId) && false == getApiKeyRequest.withLimitedBy();
                     } else {
                         return false;

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/rest/action/apikey/RestGetApiKeyAction.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/rest/action/apikey/RestGetApiKeyAction.java
@@ -46,8 +46,16 @@ public final class RestGetApiKeyAction extends ApiKeyBaseRestHandler {
         final String userName = request.param("username");
         final String realmName = request.param("realm_name");
         final boolean myApiKeysOnly = request.paramAsBoolean("owner", false);
-        final GetApiKeyRequest getApiKeyRequest = new GetApiKeyRequest(realmName, userName, apiKeyId, apiKeyName, myApiKeysOnly);
-        return channel -> client.execute(GetApiKeyAction.INSTANCE, getApiKeyRequest, new RestBuilderListener<GetApiKeyResponse>(channel) {
+        final boolean withLimitedBy = request.paramAsBoolean("with_limited_by", false);
+        final GetApiKeyRequest getApiKeyRequest = GetApiKeyRequest.builder()
+            .realmName(realmName)
+            .userName(userName)
+            .apiKeyId(apiKeyId)
+            .apiKeyName(apiKeyName)
+            .ownedByAuthenticatedUser(myApiKeysOnly)
+            .withLimitedBy(withLimitedBy)
+            .build();
+        return channel -> client.execute(GetApiKeyAction.INSTANCE, getApiKeyRequest, new RestBuilderListener<>(channel) {
             @Override
             public RestResponse buildResponse(GetApiKeyResponse getApiKeyResponse, XContentBuilder builder) throws Exception {
                 getApiKeyResponse.toXContent(builder, channel.request());

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/rest/action/apikey/RestQueryApiKeyAction.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/rest/action/apikey/RestQueryApiKeyAction.java
@@ -10,6 +10,7 @@ package org.elasticsearch.xpack.security.rest.action.apikey;
 import org.elasticsearch.client.internal.node.NodeClient;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.XContentParserUtils;
+import org.elasticsearch.core.Nullable;
 import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.license.XPackLicenseState;
 import org.elasticsearch.rest.RestRequest;
@@ -37,15 +38,9 @@ import static org.elasticsearch.xcontent.ConstructingObjectParser.optionalConstr
 public final class RestQueryApiKeyAction extends ApiKeyBaseRestHandler {
 
     @SuppressWarnings("unchecked")
-    private static final ConstructingObjectParser<QueryApiKeyRequest, Void> PARSER = new ConstructingObjectParser<>(
+    private static final ConstructingObjectParser<Payload, Void> PARSER = new ConstructingObjectParser<>(
         "query_api_key_request",
-        a -> new QueryApiKeyRequest(
-            (QueryBuilder) a[0],
-            (Integer) a[1],
-            (Integer) a[2],
-            (List<FieldSortBuilder>) a[3],
-            (SearchAfterBuilder) a[4]
-        )
+        a -> new Payload((QueryBuilder) a[0], (Integer) a[1], (Integer) a[2], (List<FieldSortBuilder>) a[3], (SearchAfterBuilder) a[4])
     );
 
     static {
@@ -93,10 +88,30 @@ public final class RestQueryApiKeyAction extends ApiKeyBaseRestHandler {
 
     @Override
     protected RestChannelConsumer innerPrepareRequest(final RestRequest request, final NodeClient client) throws IOException {
-        final QueryApiKeyRequest queryApiKeyRequest = request.hasContentOrSourceParam()
-            ? PARSER.parse(request.contentOrSourceParamParser(), null)
-            : new QueryApiKeyRequest();
+        final boolean withLimitedBy = request.paramAsBoolean("with_limited_by", false);
 
+        final QueryApiKeyRequest queryApiKeyRequest;
+        if (request.hasContentOrSourceParam()) {
+            final Payload payload = PARSER.parse(request.contentOrSourceParamParser(), null);
+            queryApiKeyRequest = new QueryApiKeyRequest(
+                payload.queryBuilder,
+                payload.from,
+                payload.size,
+                payload.fieldSortBuilders,
+                payload.searchAfterBuilder,
+                withLimitedBy
+            );
+        } else {
+            queryApiKeyRequest = new QueryApiKeyRequest(null, null, null, null, null, withLimitedBy);
+        }
         return channel -> client.execute(QueryApiKeyAction.INSTANCE, queryApiKeyRequest, new RestToXContentListener<>(channel));
     }
+
+    private record Payload(
+        @Nullable QueryBuilder queryBuilder,
+        @Nullable Integer from,
+        @Nullable Integer size,
+        @Nullable List<FieldSortBuilder> fieldSortBuilders,
+        @Nullable SearchAfterBuilder searchAfterBuilder
+    ) {}
 }

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/rest/action/apikey/RestQueryApiKeyAction.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/rest/action/apikey/RestQueryApiKeyAction.java
@@ -39,7 +39,7 @@ public final class RestQueryApiKeyAction extends ApiKeyBaseRestHandler {
 
     @SuppressWarnings("unchecked")
     private static final ConstructingObjectParser<Payload, Void> PARSER = new ConstructingObjectParser<>(
-        "query_api_key_request",
+        "query_api_key_request_payload",
         a -> new Payload((QueryBuilder) a[0], (Integer) a[1], (Integer) a[2], (List<FieldSortBuilder>) a[3], (SearchAfterBuilder) a[4])
     );
 

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/ApiKeyServiceTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/ApiKeyServiceTests.java
@@ -242,7 +242,7 @@ public class ApiKeyServiceTests extends ESTestCase {
         String apiKeyName = randomFrom(randomAlphaOfLengthBetween(3, 8), null);
         String[] apiKeyIds = generateRandomStringArray(4, 4, true, true);
         PlainActionFuture<GetApiKeyResponse> getApiKeyResponsePlainActionFuture = new PlainActionFuture<>();
-        service.getApiKeys(realmNames, username, apiKeyName, apiKeyIds, getApiKeyResponsePlainActionFuture);
+        service.getApiKeys(realmNames, username, apiKeyName, apiKeyIds, randomBoolean(), getApiKeyResponsePlainActionFuture);
         final BoolQueryBuilder boolQuery = QueryBuilders.boolQuery().filter(QueryBuilders.termQuery("doc_type", "api_key"));
         if (realmNames != null && realmNames.length > 0) {
             if (realmNames.length == 1) {
@@ -832,7 +832,14 @@ public class ApiKeyServiceTests extends ESTestCase {
 
         ElasticsearchException e = expectThrows(
             ElasticsearchException.class,
-            () -> service.getApiKeys(new String[] { randomAlphaOfLength(6) }, randomAlphaOfLength(8), null, null, new PlainActionFuture<>())
+            () -> service.getApiKeys(
+                new String[] { randomAlphaOfLength(6) },
+                randomAlphaOfLength(8),
+                null,
+                null,
+                randomBoolean(),
+                new PlainActionFuture<>()
+            )
         );
 
         assertThat(e, instanceOf(FeatureNotEnabledException.class));

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authz/RBACEngineTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authz/RBACEngineTests.java
@@ -302,8 +302,16 @@ public class RBACEngineTests extends ESTestCase {
         final User user = new User("joe");
         final String apiKeyId = randomAlphaOfLengthBetween(4, 7);
         final Authentication authentication = AuthenticationTests.randomApiKeyAuthentication(user, apiKeyId);
-        final TransportRequest request = GetApiKeyRequest.usingApiKeyId(apiKeyId, false);
+        final TransportRequest request = GetApiKeyRequest.builder().apiKeyId(apiKeyId).build();
         assertTrue(RBACEngine.checkSameUserPermissions(GetApiKeyAction.NAME, request, authentication));
+    }
+
+    public void testSameUserPermissionDeniesSelfApiKeyInfoRetrievalWithLimitedByWhenAuthenticatedByApiKey() {
+        final User user = new User("joe");
+        final String apiKeyId = randomAlphaOfLengthBetween(4, 7);
+        final Authentication authentication = AuthenticationTests.randomApiKeyAuthentication(user, apiKeyId);
+        final TransportRequest request = GetApiKeyRequest.builder().apiKeyId(apiKeyId).withLimitedBy(true).build();
+        assertFalse(RBACEngine.checkSameUserPermissions(GetApiKeyAction.NAME, request, authentication));
     }
 
     public void testSameUserPermissionDeniesApiKeyInfoRetrievalWhenAuthenticatedByADifferentApiKey() {

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/rest/action/apikey/RestGetApiKeyActionTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/rest/action/apikey/RestGetApiKeyActionTests.java
@@ -75,6 +75,14 @@ public class RestGetApiKeyActionTests extends ESTestCase {
         final Map<String, String> param4 = mapBuilder().put("id", "api-key-id-1").map();
         final Map<String, String> param5 = mapBuilder().put("name", "api-key-name-1").map();
         final Map<String, String> params = randomFrom(param1, param2, param3, param4, param5);
+        final boolean withLimitedBy = randomBoolean();
+        if (withLimitedBy) {
+            params.put("with_limited_by", "true");
+        } else {
+            if (randomBoolean()) {
+                params.put("with_limited_by", "false");
+            }
+        }
         final boolean replyEmptyResponse = rarely();
         final FakeRestRequest restRequest = new FakeRestRequest.Builder(NamedXContentRegistry.EMPTY).withParams(params).build();
 
@@ -90,9 +98,21 @@ public class RestGetApiKeyActionTests extends ESTestCase {
         @SuppressWarnings("unchecked")
         final Map<String, Object> metadata = ApiKeyTests.randomMetadata();
         final List<RoleDescriptor> roleDescriptors = randomUniquelyNamedRoleDescriptors(0, 3);
+        final List<RoleDescriptor> limitedByRoleDescriptors = withLimitedBy ? randomUniquelyNamedRoleDescriptors(1, 3) : null;
         final GetApiKeyResponse getApiKeyResponseExpected = new GetApiKeyResponse(
             Collections.singletonList(
-                new ApiKey("api-key-name-1", "api-key-id-1", creation, expiration, false, "user-x", "realm-1", metadata, roleDescriptors)
+                new ApiKey(
+                    "api-key-name-1",
+                    "api-key-id-1",
+                    creation,
+                    expiration,
+                    false,
+                    "user-x",
+                    "realm-1",
+                    metadata,
+                    roleDescriptors,
+                    limitedByRoleDescriptors
+                )
             )
         );
 
@@ -152,7 +172,8 @@ public class RestGetApiKeyActionTests extends ESTestCase {
                             "user-x",
                             "realm-1",
                             metadata,
-                            roleDescriptors
+                            roleDescriptors,
+                            limitedByRoleDescriptors
                         )
                     )
                 );
@@ -168,6 +189,14 @@ public class RestGetApiKeyActionTests extends ESTestCase {
             param = mapBuilder().put("owner", Boolean.TRUE.toString()).map();
         } else {
             param = mapBuilder().put("owner", Boolean.FALSE.toString()).put("realm_name", "realm-1").map();
+        }
+        final boolean withLimitedBy = randomBoolean();
+        if (withLimitedBy) {
+            param.put("with_limited_by", "true");
+        } else {
+            if (randomBoolean()) {
+                param.put("with_limited_by", "false");
+            }
         }
 
         final FakeRestRequest restRequest = new FakeRestRequest.Builder(NamedXContentRegistry.EMPTY).withParams(param).build();
@@ -191,7 +220,8 @@ public class RestGetApiKeyActionTests extends ESTestCase {
             "user-x",
             "realm-1",
             ApiKeyTests.randomMetadata(),
-            randomUniquelyNamedRoleDescriptors(0, 3)
+            randomUniquelyNamedRoleDescriptors(0, 3),
+            withLimitedBy ? randomUniquelyNamedRoleDescriptors(1, 3) : null
         );
         final ApiKey apiKey2 = new ApiKey(
             "api-key-name-2",
@@ -202,7 +232,8 @@ public class RestGetApiKeyActionTests extends ESTestCase {
             "user-y",
             "realm-1",
             ApiKeyTests.randomMetadata(),
-            randomUniquelyNamedRoleDescriptors(0, 3)
+            randomUniquelyNamedRoleDescriptors(0, 3),
+            withLimitedBy ? randomUniquelyNamedRoleDescriptors(1, 3) : null
         );
         final GetApiKeyResponse getApiKeyResponseExpectedWhenOwnerFlagIsTrue = new GetApiKeyResponse(Collections.singletonList(apiKey1));
         final GetApiKeyResponse getApiKeyResponseExpectedWhenOwnerFlagIsFalse = new GetApiKeyResponse(List.of(apiKey1, apiKey2));


### PR DESCRIPTION
An API key's effective permission is an intersection between its
assigned role descriptors and a snapshot of its owner user's role
descriptors (limited-by role descriptors). In #89166, the assigned
role descriptors are now returned by default in Get/Query API key
responses.

This PR further adds support to optionally return limited-by role
descriptors in the responses. Unlike assign role descriptors,
an API key cannot view any limited-by role descriptors unless it
has manage_api_key or higher privileges.

Relates: #89058

