### PR TITLE
[8.4] Sort ranges in geo_distance aggregation (#89154)

### DIFF
--- a/docs/changelog/89154.yaml
+++ b/docs/changelog/89154.yaml
@@ -1,0 +1,6 @@
+pr: 89154
+summary: Sort ranges in `geo_distance` aggregation
+area: Geo
+type: bug
+issues:
+ - 89147

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/bucket/GeoDistanceIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/bucket/GeoDistanceIT.java
@@ -18,6 +18,7 @@ import org.elasticsearch.common.unit.DistanceUnit;
 import org.elasticsearch.search.aggregations.Aggregator.SubAggCollectionMode;
 import org.elasticsearch.search.aggregations.InternalAggregation;
 import org.elasticsearch.search.aggregations.bucket.histogram.Histogram;
+import org.elasticsearch.search.aggregations.bucket.range.GeoDistanceAggregationBuilder;
 import org.elasticsearch.search.aggregations.bucket.range.Range;
 import org.elasticsearch.search.aggregations.bucket.range.Range.Bucket;
 import org.elasticsearch.search.aggregations.bucket.terms.Terms;
@@ -28,9 +29,11 @@ import org.hamcrest.Matchers;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.function.Consumer;
 
 import static org.elasticsearch.index.query.QueryBuilders.matchAllQuery;
 import static org.elasticsearch.search.aggregations.AggregationBuilders.geoDistance;
@@ -128,15 +131,18 @@ public class GeoDistanceIT extends ESIntegTestCase {
     }
 
     public void testSimple() throws Exception {
-        SearchResponse response = client().prepareSearch("idx")
-            .addAggregation(
-                geoDistance("amsterdam_rings", new GeoPoint(52.3760, 4.894)).field("location")
-                    .unit(DistanceUnit.KILOMETERS)
-                    .addUnboundedTo(500)
-                    .addRange(500, 1000)
-                    .addUnboundedFrom(1000)
-            )
-            .get();
+        List<Consumer<GeoDistanceAggregationBuilder>> ranges = new ArrayList<>();
+        ranges.add(b -> b.addUnboundedTo(500));
+        ranges.add(b -> b.addRange(500, 1000));
+        ranges.add(b -> b.addUnboundedFrom(1000));
+        // add ranges in any order
+        Collections.shuffle(ranges, random());
+        GeoDistanceAggregationBuilder builder = geoDistance("amsterdam_rings", new GeoPoint(52.3760, 4.894)).field("location")
+            .unit(DistanceUnit.KILOMETERS);
+        for (Consumer<GeoDistanceAggregationBuilder> range : ranges) {
+            range.accept(builder);
+        }
+        SearchResponse response = client().prepareSearch("idx").addAggregation(builder).get();
 
         assertSearchResponse(response);
 

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/range/AbstractRangeBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/range/AbstractRangeBuilder.java
@@ -83,7 +83,10 @@ public abstract class AbstractRangeBuilder<AB extends AbstractRangeBuilder<AB, R
         return ranges;
     }
 
-    private static void sortRanges(final Range[] ranges) {
+    /**
+     * Sort the provided ranges in place.
+     */
+    static void sortRanges(final Range[] ranges) {
         new InPlaceMergeSorter() {
 
             @Override

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/range/GeoDistanceAggregationBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/range/GeoDistanceAggregationBuilder.java
@@ -456,7 +456,7 @@ public class GeoDistanceAggregationBuilder extends ValuesSourceAggregationBuilde
         if (ranges.length == 0) {
             throw new IllegalArgumentException("No [ranges] specified for the [" + this.getName() + "] aggregation");
         }
-
+        AbstractRangeBuilder.sortRanges(ranges);
         return new GeoDistanceRangeAggregatorFactory(
             name,
             config,


### PR DESCRIPTION
Backports the following commits to 8.4:
 - Sort ranges in geo_distance aggregation (#89154)