### PR TITLE
[8.4] Ensure secureString remain open when reloading secure settings (#88922)

### DIFF
--- a/docs/changelog/88922.yaml
+++ b/docs/changelog/88922.yaml
@@ -1,0 +1,5 @@
+pr: 88922
+summary: Ensure `secureString` remain open when reloading secure settings
+area: Security
+type: bug
+issues: []

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/node/reload/TransportNodesReloadSecureSettingsAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/node/reload/TransportNodesReloadSecureSettingsAction.java
@@ -18,16 +18,13 @@ import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.io.stream.StreamInput;
-import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.settings.KeyStoreWrapper;
-import org.elasticsearch.common.settings.SecureString;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.env.Environment;
 import org.elasticsearch.plugins.PluginsService;
 import org.elasticsearch.plugins.ReloadablePlugin;
 import org.elasticsearch.tasks.Task;
 import org.elasticsearch.threadpool.ThreadPool;
-import org.elasticsearch.transport.TransportRequest;
 import org.elasticsearch.transport.TransportService;
 
 import java.io.IOException;
@@ -37,7 +34,7 @@ import java.util.List;
 public class TransportNodesReloadSecureSettingsAction extends TransportNodesAction<
     NodesReloadSecureSettingsRequest,
     NodesReloadSecureSettingsResponse,
-    TransportNodesReloadSecureSettingsAction.NodeRequest,
+    NodesReloadSecureSettingsRequest.NodeRequest,
     NodesReloadSecureSettingsResponse.NodeResponse> {
 
     private final Environment environment;
@@ -59,7 +56,7 @@ public class TransportNodesReloadSecureSettingsAction extends TransportNodesActi
             transportService,
             actionFilters,
             NodesReloadSecureSettingsRequest::new,
-            NodeRequest::new,
+            NodesReloadSecureSettingsRequest.NodeRequest::new,
             ThreadPool.Names.GENERIC,
             NodesReloadSecureSettingsResponse.NodeResponse.class
         );
@@ -77,8 +74,8 @@ public class TransportNodesReloadSecureSettingsAction extends TransportNodesActi
     }
 
     @Override
-    protected NodeRequest newNodeRequest(NodesReloadSecureSettingsRequest request) {
-        return new NodeRequest(request);
+    protected NodesReloadSecureSettingsRequest.NodeRequest newNodeRequest(NodesReloadSecureSettingsRequest request) {
+        return request.newNodeRequest();
     }
 
     @Override
@@ -93,7 +90,7 @@ public class TransportNodesReloadSecureSettingsAction extends TransportNodesActi
         ActionListener<NodesReloadSecureSettingsResponse> listener
     ) {
         if (request.hasPassword() && isNodeLocal(request) == false && isNodeTransportTLSEnabled() == false) {
-            request.closePassword();
+            request.close();
             listener.onFailure(
                 new ElasticsearchException(
                     "Secure settings cannot be updated cluster wide when TLS for the transport layer"
@@ -101,23 +98,17 @@ public class TransportNodesReloadSecureSettingsAction extends TransportNodesActi
                 )
             );
         } else {
-            super.doExecute(task, request, ActionListener.wrap(response -> {
-                request.closePassword();
-                listener.onResponse(response);
-            }, e -> {
-                request.closePassword();
-                listener.onFailure(e);
-            }));
+            super.doExecute(task, request, ActionListener.runBefore(listener, request::close));
         }
     }
 
     @Override
-    protected NodesReloadSecureSettingsResponse.NodeResponse nodeOperation(NodeRequest nodeReloadRequest, Task task) {
+    protected NodesReloadSecureSettingsResponse.NodeResponse nodeOperation(
+        NodesReloadSecureSettingsRequest.NodeRequest nodeReloadRequest,
+        Task task
+    ) {
         final NodesReloadSecureSettingsRequest request = nodeReloadRequest.request;
         // We default to using an empty string as the keystore password so that we mimic pre 7.3 API behavior
-        final SecureString secureSettingsPassword = request.hasPassword()
-            ? request.getSecureSettingsPassword()
-            : new SecureString(new char[0]);
         try (KeyStoreWrapper keystore = KeyStoreWrapper.load(environment.configFile())) {
             // reread keystore from config file
             if (keystore == null) {
@@ -127,7 +118,7 @@ public class TransportNodesReloadSecureSettingsAction extends TransportNodesActi
                 );
             }
             // decrypt the keystore using the password from the request
-            keystore.decrypt(secureSettingsPassword.getChars());
+            keystore.decrypt(request.hasPassword() ? request.getSecureSettingsPassword().getChars() : new char[0]);
             // add the keystore to the original node settings object
             final Settings settingsWithKeystore = Settings.builder().put(environment.settings(), false).setSecureSettings(keystore).build();
             final List<Exception> exceptions = new ArrayList<>();
@@ -145,27 +136,7 @@ public class TransportNodesReloadSecureSettingsAction extends TransportNodesActi
         } catch (final Exception e) {
             return new NodesReloadSecureSettingsResponse.NodeResponse(clusterService.localNode(), e);
         } finally {
-            secureSettingsPassword.close();
-        }
-    }
-
-    public static class NodeRequest extends TransportRequest {
-
-        NodesReloadSecureSettingsRequest request;
-
-        public NodeRequest(StreamInput in) throws IOException {
-            super(in);
-            request = new NodesReloadSecureSettingsRequest(in);
-        }
-
-        NodeRequest(NodesReloadSecureSettingsRequest request) {
-            this.request = request;
-        }
-
-        @Override
-        public void writeTo(StreamOutput out) throws IOException {
-            super.writeTo(out);
-            request.writeTo(out);
+            request.close();
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/rest/action/admin/cluster/RestReloadSecureSettingsAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/admin/cluster/RestReloadSecureSettingsAction.java
@@ -78,7 +78,7 @@ public final class RestReloadSecureSettingsAction extends BaseRestHandler implem
                 builder.field("cluster_name", response.getClusterName().value());
                 response.toXContent(builder, channel.request());
                 builder.endObject();
-                nodesRequestBuilder.request().closePassword();
+                nodesRequestBuilder.request().close();
                 return new RestResponse(RestStatus.OK, builder);
             }
         });


### PR DESCRIPTION
Backports the following commits to 8.4:
 - Ensure secureString remain open when reloading secure settings (#88922)