### PR TITLE
Clarify that TransportService#sendRequest never throws

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/coordination/CoordinationDiagnosticsService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/CoordinationDiagnosticsService.java
@@ -991,20 +991,16 @@ public class CoordinationDiagnosticsService implements ClusterStateListener {
                 logger.trace("Opened connection to {}, making transport request", masterEligibleNode);
                 // If we don't get a response in 10 seconds that is a failure worth capturing on its own:
                 final TimeValue transportTimeout = TimeValue.timeValueSeconds(10);
-                try {
-                    transportService.sendRequest(
-                        masterEligibleNode,
-                        transportActionType.name(),
-                        transportActionRequest,
-                        TransportRequestOptions.timeout(transportTimeout),
-                        new ActionListenerResponseHandler<>(
-                            ActionListener.runBefore(fetchRemoteResultListener, () -> Releasables.close(releasable)),
-                            transportActionType.getResponseReader()
-                        )
-                    );
-                } catch (Exception e) {
-                    responseConsumer.accept(responseTransformationFunction.apply(null, e));
-                }
+                transportService.sendRequest(
+                    masterEligibleNode,
+                    transportActionType.name(),
+                    transportActionRequest,
+                    TransportRequestOptions.timeout(transportTimeout),
+                    new ActionListenerResponseHandler<>(
+                        ActionListener.runBefore(fetchRemoteResultListener, () -> Releasables.close(releasable)),
+                        transportActionType.getResponseReader()
+                    )
+                );
             }
         }, e -> {
             logger.warn("Exception connecting to master masterEligibleNode", e);

--- a/server/src/main/java/org/elasticsearch/cluster/coordination/PublicationTransportHandler.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/PublicationTransportHandler.java
@@ -423,24 +423,18 @@ public class PublicationTransportHandler {
                 listener.onFailure(new IllegalStateException("serialized cluster state released before transmission"));
                 return;
             }
-            try {
-                transportService.sendChildRequest(
-                    destination,
-                    PUBLISH_STATE_ACTION_NAME,
-                    new BytesTransportRequest(bytes, destination.getVersion()),
-                    task,
-                    STATE_REQUEST_OPTIONS,
-                    new ActionListenerResponseHandler<>(
-                        ActionListener.runAfter(listener, bytes::decRef),
-                        PublishWithJoinResponse::new,
-                        ThreadPool.Names.CLUSTER_COORDINATION
-                    )
-                );
-            } catch (Exception e) {
-                assert false : e;
-                logger.warn(() -> format("error sending cluster state to %s", destination), e);
-                listener.onFailure(e);
-            }
+            transportService.sendChildRequest(
+                destination,
+                PUBLISH_STATE_ACTION_NAME,
+                new BytesTransportRequest(bytes, destination.getVersion()),
+                task,
+                STATE_REQUEST_OPTIONS,
+                new ActionListenerResponseHandler<>(
+                    ActionListener.runAfter(listener, bytes::decRef),
+                    PublishWithJoinResponse::new,
+                    ThreadPool.Names.CLUSTER_COORDINATION
+                )
+            );
         }
 
         @Override

--- a/test/framework/src/main/java/org/elasticsearch/transport/AbstractSimpleTransportTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/transport/AbstractSimpleTransportTestCase.java
@@ -3176,11 +3176,7 @@ public abstract class AbstractSimpleTransportTestCase extends ESTestCase {
         responseListener.whenComplete(handler::handleResponse, e -> handler.handleException((TransportException) e));
         final PlainActionFuture<T> future = PlainActionFuture.newFuture();
         responseListener.addListener(future);
-        try {
-            transportService.sendRequest(node, action, request, options, futureHandler);
-        } catch (NodeNotConnectedException ex) {
-            futureHandler.handleException(ex);
-        }
+        transportService.sendRequest(node, action, request, options, futureHandler);
         return future;
     }
 }


### PR DESCRIPTION
It's not obvious from reading the code that
`TransportService#sendRequest` and friends always catch exceptions and
pass them to the response handler, which means some callers are wrapping
calls to `sendRequest` in their own unnecessary try/catch blocks. This
commit makes it clear that all exceptions are handled and removes the
unnecessary exception handling in callers.

Closes #89274