### PR TITLE
[8.4] Fix: Update geo-bounding-box-query.asciidoc (#87459)

### DIFF
--- a/docs/reference/query-dsl/geo-bounding-box-query.asciidoc
+++ b/docs/reference/query-dsl/geo-bounding-box-query.asciidoc
@@ -10,7 +10,7 @@ intersect a bounding box.
 [discrete]
 [[geo-bounding-box-query-ex]]
 ==== Example
-Assume the following the following documents are indexed:
+Assume the following documents are indexed:
 
 [source,console]
 --------------------------------------------------


### PR DESCRIPTION
# Backport

This will backport the following commits from `8.2` to `8.4`:
 - [Fix: Update geo-bounding-box-query.asciidoc (#87459)](https://github.com/elastic/elasticsearch/pull/87459)

<!--- Backport version: 8.9.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)