### PR TITLE
[7.17] Keep test folders of failed build tools integration tests (#89296)

### DIFF
--- a/build-tools/src/testFixtures/groovy/org/elasticsearch/gradle/fixtures/AbstractGradleFuncTest.groovy
+++ b/build-tools/src/testFixtures/groovy/org/elasticsearch/gradle/fixtures/AbstractGradleFuncTest.groovy
@@ -11,6 +11,7 @@ package org.elasticsearch.gradle.fixtures
 import org.apache.commons.io.FileUtils
 import org.elasticsearch.gradle.internal.test.InternalAwareGradleRunner
 import org.elasticsearch.gradle.internal.test.NormalizeOutputGradleRunner
+import org.elasticsearch.gradle.internal.test.TestResultExtension
 import org.gradle.testkit.runner.BuildResult
 import org.gradle.testkit.runner.GradleRunner
 import org.junit.Rule
@@ -46,7 +47,7 @@ abstract class AbstractGradleFuncTest extends Specification {
     }
 
     def cleanup() {
-        if (Boolean.getBoolean('test.keep.samplebuild')) {
+        if (featureFailed()) {
             FileUtils.copyDirectory(testProjectDir.root, new File("build/test-debug/" + testProjectDir.root.name))
         }
     }
@@ -188,6 +189,13 @@ checkstyle = "com.puppycrawl.tools:checkstyle:10.3"
               }
             }
             '''
+    }
+
+    boolean featureFailed() {
+        specificationContext.currentSpec.listeners
+            .findAll { it instanceof TestResultExtension.ErrorListener }
+            .any {
+                (it as TestResultExtension.ErrorListener).errorInfo != null }
     }
 
     static class ProjectConfigurer {

--- a/build-tools/src/testFixtures/java/org/elasticsearch/gradle/internal/test/TestResultExtension.java
+++ b/build-tools/src/testFixtures/java/org/elasticsearch/gradle/internal/test/TestResultExtension.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.gradle.internal.test;
+
+import org.spockframework.runtime.AbstractRunListener;
+import org.spockframework.runtime.extension.IGlobalExtension;
+import org.spockframework.runtime.model.ErrorInfo;
+import org.spockframework.runtime.model.IterationInfo;
+import org.spockframework.runtime.model.SpecInfo;
+
+public class TestResultExtension implements IGlobalExtension {
+
+    @Override
+    public void visitSpec(SpecInfo spec) {
+        spec.addListener(new ErrorListener());
+    }
+
+    public static class ErrorListener extends AbstractRunListener {
+        ErrorInfo errorInfo;
+
+        @Override
+        public void beforeIteration(IterationInfo iteration) {
+            errorInfo = null;
+        }
+
+        @Override
+        public void error(ErrorInfo error) {
+            errorInfo = error;
+        }
+    }
+}

--- a/build-tools/src/testFixtures/resources/META-INF/services/org.spockframework.runtime.extension.IGlobalExtension
+++ b/build-tools/src/testFixtures/resources/META-INF/services/org.spockframework.runtime.extension.IGlobalExtension
@@ -1,0 +1,9 @@
+#
+# Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+# or more contributor license agreements. Licensed under the Elastic License
+# 2.0 and the Server Side Public License, v 1; you may not use this file except
+# in compliance with, at your election, the Elastic License 2.0 or the Server
+# Side Public License, v 1.
+#
+
+org.elasticsearch.gradle.internal.test.TestResultExtension


### PR DESCRIPTION
Backports the following commits to 7.17:
 - Keep test folders of failed build tools integration tests (#89296)