### PR TITLE
[8.4] [ML] Improve reason when autoscaling capacity cannot be computed (#89316)

### DIFF
--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/autoscaling/MlAutoscalingDeciderService.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/autoscaling/MlAutoscalingDeciderService.java
@@ -507,7 +507,7 @@ public class MlAutoscalingDeciderService implements AutoscalingDeciderService, L
                 "view of job memory is stale given duration [{}]. Not attempting to make scaling decision",
                 mlMemoryTracker.getStalenessDuration()
             );
-            return buildDecisionAndRequestRefresh(reasonBuilder);
+            return buildDecisionAndRequestRefresh(reasonBuilder.setSimpleReason(MEMORY_STALE));
         }
         // We need the current node loads to determine if we need to scale up or down
         List<NodeLoad> nodeLoads = new ArrayList<>(mlNodes.size());
@@ -1163,7 +1163,7 @@ public class MlAutoscalingDeciderService implements AutoscalingDeciderService, L
 
     private AutoscalingDeciderResult buildDecisionAndRequestRefresh(MlScalingReason.Builder reasonBuilder) {
         mlMemoryTracker.asyncRefresh();
-        return new AutoscalingDeciderResult(null, reasonBuilder.setSimpleReason(MEMORY_STALE).build());
+        return new AutoscalingDeciderResult(null, reasonBuilder.build());
     }
 
     private Long getAnalyticsMemoryRequirement(String analyticsId) {


### PR DESCRIPTION
Backports the following commits to 8.4:
 - [ML] Improve reason when autoscaling capacity cannot be computed (#89316)