### PR TITLE
Fixing a version check for master stability functionality

### DIFF
--- a/docs/changelog/89322.yaml
+++ b/docs/changelog/89322.yaml
@@ -1,0 +1,5 @@
+pr: 89322
+summary: Fixing a version check for master stability functionality
+area: Health
+type: bug
+issues: []

--- a/server/src/main/java/org/elasticsearch/cluster/coordination/MasterHistoryService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/MasterHistoryService.java
@@ -115,7 +115,7 @@ public class MasterHistoryService {
      */
     public void refreshRemoteMasterHistory(DiscoveryNode node) {
         Version minSupportedVersion = Version.V_8_4_0;
-        if (node.getVersion().onOrAfter(minSupportedVersion) == false) { // This was introduced in 8.3.0 and modified in 8.4.0
+        if (node.getVersion().before(minSupportedVersion)) { // This was introduced in 8.3.0 and modified in 8.4.0
             logger.trace(
                 "Cannot get master history for {} because it is at version {} and {} is required",
                 node,

--- a/server/src/main/java/org/elasticsearch/cluster/coordination/MasterHistoryService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/MasterHistoryService.java
@@ -115,7 +115,7 @@ public class MasterHistoryService {
      */
     public void refreshRemoteMasterHistory(DiscoveryNode node) {
         Version minSupportedVersion = Version.V_8_4_0;
-        if (node.getVersion().onOrAfter(minSupportedVersion)) { // This was introduced in 8.3.0
+        if (node.getVersion().onOrAfter(minSupportedVersion) == false) { // This was introduced in 8.3.0 and modified in 8.4.0
             logger.trace(
                 "Cannot get master history for {} because it is at version {} and {} is required",
                 node,

--- a/server/src/main/java/org/elasticsearch/cluster/coordination/MasterHistoryService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/MasterHistoryService.java
@@ -115,7 +115,7 @@ public class MasterHistoryService {
      */
     public void refreshRemoteMasterHistory(DiscoveryNode node) {
         Version minSupportedVersion = Version.V_8_4_0;
-        if (node.getVersion().before(minSupportedVersion)) { // This was introduced in 8.3.0 and modified in 8.4.0
+        if (node.getVersion().before(minSupportedVersion)) { // This was introduced in 8.3.0 (and the action name changed in 8.4.0)
             logger.trace(
                 "Cannot get master history for {} because it is at version {} and {} is required",
                 node,


### PR DESCRIPTION
The version check for fetching remote master. history was backwards.