### PR TITLE
[DOCS] Adds unattended setting to transforms API docs

### DIFF
--- a/docs/reference/rest-api/common-parms.asciidoc
+++ b/docs/reference/rest-api/common-parms.asciidoc
@@ -1059,6 +1059,13 @@ The minimum value is `0` and the maximum is `100`.
 The default value is the cluster-level setting `num_transform_failure_retries`.
 end::transform-settings-num-failure-retries[]
 
+tag::transform-settings-unattended[]
+If `true`, the {transform} runs in unattended mode. In unattended mode, the 
+{transform} retries indefinitely in case of an error which means the {transform} 
+never fails. Setting the number of retries other than infinite fails in 
+validation. Defaults to `false`.
+end::transform-settings-unattended[]
+
 tag::transform-sort[]
 Specifies the date field that is used to identify the latest documents.
 end::transform-sort[]

--- a/docs/reference/transform/apis/preview-transform.asciidoc
+++ b/docs/reference/transform/apis/preview-transform.asciidoc
@@ -251,6 +251,9 @@ include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=transform-settings-ded
 `max_page_search_size`:::
 (Optional, integer)
 include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=transform-settings-max-page-search-size]
+`unattended`:::
+(Optional, boolean)
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=transform-settings-unattended]
 ====
 //End settings
 

--- a/docs/reference/transform/apis/put-transform.asciidoc
+++ b/docs/reference/transform/apis/put-transform.asciidoc
@@ -218,6 +218,9 @@ include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=transform-settings-max
 `num_failure_retries`:::
 (Optional, integer)
 include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=transform-settings-num-failure-retries]
+`unattended`:::
+(Optional, boolean)
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=transform-settings-unattended]
 ====
 //End settings
 

--- a/docs/reference/transform/apis/update-transform.asciidoc
+++ b/docs/reference/transform/apis/update-transform.asciidoc
@@ -160,6 +160,9 @@ include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=transform-settings-max
 `num_failure_retries`:::
 (Optional, integer)
 include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=transform-settings-num-failure-retries]
+`unattended`:::
+(Optional, boolean)
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=transform-settings-unattended]
 ====
 //End settings
 


### PR DESCRIPTION
## Overview

Related to https://github.com/elastic/elasticsearch/pull/89212.

This PR documents a new transform setting called `unattended`. The setting is added to the create, preview, and update transform API docs.

### Preview

[PUT transform](https://elasticsearch_89335.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/put-transform.html#put-transform-request-body)