### PR TITLE
Report better error for GCS credentials load failure

### DIFF
--- a/docs/changelog/89336.yaml
+++ b/docs/changelog/89336.yaml
@@ -1,0 +1,5 @@
+pr: 89336
+summary: Report better error for GCS credentials load failure
+area: Snapshot/Restore
+type: bug
+issues: []


### PR DESCRIPTION
Today if the GCS credentials file setting is invalid we report some kind
of JSON parsing error but it's not clear what JSON is being parsed so
the error is hard to track down. This commit adds the problematic
setting name to the exception message.