### PR TITLE
Force rejection of unsupported bulk actions in v9

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/bulk/BulkRequestParser.java
+++ b/server/src/main/java/org/elasticsearch/action/bulk/BulkRequestParser.java
@@ -8,6 +8,7 @@
 
 package org.elasticsearch.action.bulk;
 
+import org.elasticsearch.Version;
 import org.elasticsearch.action.DocWriteRequest;
 import org.elasticsearch.action.delete.DeleteRequest;
 import org.elasticsearch.action.index.IndexRequest;
@@ -184,6 +185,7 @@ public final class BulkRequestParser {
                 }
                 String action = parser.currentName();
                 if (SUPPORTED_ACTIONS.contains(action) == false) {
+                    assert Version.CURRENT.major == Version.V_7_17_0.major + 1;
                     deprecationLogger.compatibleCritical(
                         STRICT_ACTION_PARSING_WARNING_KEY,
                         "Unsupported action: [{}]. Supported values are [create], [delete], [index], and [update]. "
@@ -424,6 +426,7 @@ public final class BulkRequestParser {
         try {
             token = parser.nextToken();
         } catch (XContentEOFException ignore) {
+            assert Version.CURRENT.major == Version.V_7_17_0.major + 1;
             deprecationLogger.compatibleCritical(
                 STRICT_ACTION_PARSING_WARNING_KEY,
                 "A bulk action wasn't closed properly with the closing brace. Malformed objects are currently accepted but will be "
@@ -432,6 +435,7 @@ public final class BulkRequestParser {
             return;
         }
         if (token != XContentParser.Token.END_OBJECT) {
+            assert Version.CURRENT.major == Version.V_7_17_0.major + 1;
             deprecationLogger.compatibleCritical(
                 STRICT_ACTION_PARSING_WARNING_KEY,
                 "A bulk action object contained multiple keys. Additional keys are currently ignored but will be rejected in a "
@@ -440,6 +444,7 @@ public final class BulkRequestParser {
             return;
         }
         if (parser.nextToken() != null) {
+            assert Version.CURRENT.major == Version.V_7_17_0.major + 1;
             deprecationLogger.compatibleCritical(
                 STRICT_ACTION_PARSING_WARNING_KEY,
                 "A bulk action contained trailing data after the closing brace. This is currently ignored but will be rejected in a "


### PR DESCRIPTION
Adds a mention of `Version.V_7_17_0` so that we don't forget to remove
this deprecated behaviour in the next major version.

Relates #78876