### PR TITLE
Add explicit host entry for localhost to kerberos test fixture

### DIFF
--- a/test/fixtures/krb5kdc-fixture/docker-compose.yml
+++ b/test/fixtures/krb5kdc-fixture/docker-compose.yml
@@ -7,6 +7,7 @@ services:
       dockerfile: Dockerfile
     extra_hosts:
       - "kerberos.build.elastic.co:127.0.0.1"
+      - "kerberos.build.elastic.co:localhost"
     command: "bash /fixture/src/main/resources/provision/peppa.sh"
     volumes:
       - ./testfixtures_shared/shared/peppa:/fixture/build
@@ -22,6 +23,7 @@ services:
       dockerfile: Dockerfile
     extra_hosts:
       - "kerberos.build.elastic.co:127.0.0.1"
+      - "kerberos.build.elastic.co:localhost"
     command: "bash /fixture/src/main/resources/provision/hdfs.sh"
     volumes:
       - ./testfixtures_shared/shared/hdfs:/fixture/build


### PR DESCRIPTION
Attempt at fixing https://github.com/elastic/elasticsearch/issues/89324 on certain platforms.