### PR TITLE
Docs: synthetic source doesn't dedupe numbers

### DIFF
--- a/docs/reference/mapping/types/numeric.asciidoc
+++ b/docs/reference/mapping/types/numeric.asciidoc
@@ -237,7 +237,7 @@ All numeric fields except `unsigned_long` support <<synthetic-source,synthetic
 together with <<ignore-malformed,`ignore_malformed`>>, <<copy-to,`copy_to`>>, or
 with <<doc-values,`doc_values`>> disabled.
 
-Synthetic source always sorts numeric fields and removes duplicates. For example:
+Synthetic source always sorts numeric fields. For example:
 [source,console,id=synthetic-source-numeric-example]
 ----
 PUT idx


### PR DESCRIPTION
The docs for synthetic `_source` incorrectly claimed that synthetic
`_source` deduplicates numbers. It doesn't. The example below the prose
shows it *not* removing duplicates.
