### PR TITLE
Prepare synthetic source docs for tech-preview

### DIFF
--- a/docs/reference/mapping/fields/source-field.asciidoc
+++ b/docs/reference/mapping/fields/source-field.asciidoc
@@ -6,7 +6,6 @@ at index time. The `_source` field itself is not indexed (and thus is not
 searchable), but it is stored so that it can be returned when executing
 _fetch_ requests, like <<docs-get,get>> or <<search-search,search>>.
 
-ifeval::["{release-state}"=="unreleased"]
 If disk usage is important to you then have a look at
 <<synthetic-source,synthetic `_source`>> which shrinks disk usage at the cost of
 only supporting a subset of mappings and slower fetches or (not recommended)
@@ -14,8 +13,6 @@ only supporting a subset of mappings and slower fetches or (not recommended)
 usage but disables many features.
 
 include::synthetic-source.asciidoc[]
-endif::[]
-
 
 [[disable-source-field]]
 ==== Disabling the `_source` field

--- a/docs/reference/mapping/fields/synthetic-source.asciidoc
+++ b/docs/reference/mapping/fields/synthetic-source.asciidoc
@@ -1,5 +1,5 @@
 [[synthetic-source]]
-==== Synthetic `_source`
+==== Synthetic `_source` preview:[]
 
 Though very handy to have around, the source field takes up a significant amount
 of space on disk. Instead of storing source documents on disk exactly as you

--- a/docs/reference/mapping/types/aggregate-metric-double.asciidoc
+++ b/docs/reference/mapping/types/aggregate-metric-double.asciidoc
@@ -252,9 +252,8 @@ The search returns the following hit. The value of the `default_metric` field,
 ----
 // TESTRESPONSE[s/\.\.\./"took": $body.took,"timed_out": false,"_shards": $body._shards,/]
 
-ifeval::["{release-state}"=="unreleased"]
 [[aggregate-metric-double-synthetic-source]]
-==== Synthetic source
+==== Synthetic source preview:[]
 `aggregate_metric-double` fields support <<synthetic-source,synthetic `_source`>> in their default
 configuration. Synthetic `_source` cannot be used together with <<ignore-malformed,`ignore_malformed`>>.
 
@@ -301,5 +300,3 @@ Will become:
 }
 ----
 // TEST[s/^/{"_source":/ s/\n$/}/]
-
-endif::[]

--- a/docs/reference/mapping/types/boolean.asciidoc
+++ b/docs/reference/mapping/types/boolean.asciidoc
@@ -215,9 +215,8 @@ The following parameters are accepted by `boolean` fields:
 
     Metadata about the field.
 
-ifeval::["{release-state}"=="unreleased"]
 [[boolean-synthetic-source]]
-==== Synthetic source
+==== Synthetic source preview:[]
 `boolean` fields support <<synthetic-source,synthetic `_source`>> in their
 default configuration. Synthetic `_source` cannot be used together with
 <<copy-to,`copy_to`>> or with <<doc-values,`doc_values`>> disabled.
@@ -249,4 +248,3 @@ Will become:
 }
 ----
 // TEST[s/^/{"_source":/ s/\n$/}/]
-endif::[]

--- a/docs/reference/mapping/types/geo-point.asciidoc
+++ b/docs/reference/mapping/types/geo-point.asciidoc
@@ -204,9 +204,8 @@ def lat      = doc['location'].lat;
 def lon      = doc['location'].lon;
 --------------------------------------------------
 
-ifeval::["{release-state}"=="unreleased"]
 [[geo-point-synthetic-source]]
-==== Synthetic source
+==== Synthetic source preview:[]
 `geo_point` fields support <<synthetic-source,synthetic `_source`>> in their
 default configuration. Synthetic `_source` cannot be used together with
 <<ignore-malformed,`ignore_malformed`>>, <<copy-to,`copy_to`>>, or with
@@ -246,4 +245,3 @@ Will become:
 }
 ----
 // TEST[s/^/{"_source":/ s/\n$/}/]
-endif::[]

--- a/docs/reference/mapping/types/ip.asciidoc
+++ b/docs/reference/mapping/types/ip.asciidoc
@@ -151,9 +151,8 @@ GET my-index-000001/_search
 }
 --------------------------------------------------
 
-ifeval::["{release-state}"=="unreleased"]
 [[ip-synthetic-source]]
-==== Synthetic source
+==== Synthetic source preview:[]
 `ip` fields support <<synthetic-source,synthetic `_source`>> in their default
 configuration. Synthetic `_source` cannot be used together with
 <<ignore-malformed,`ignore_malformed`>>, <<copy-to,`copy_to`>>, or with
@@ -192,5 +191,3 @@ Will become:
 NOTE: IPv4 addresses are sorted as though they were IPv6 addresses prefixed by
       `::ffff:0:0:0/96` as specified by
       https://datatracker.ietf.org/doc/html/rfc6144[rfc6144].
-
-endif::[]

--- a/docs/reference/mapping/types/keyword.asciidoc
+++ b/docs/reference/mapping/types/keyword.asciidoc
@@ -174,9 +174,8 @@ Dimension fields have the following constraints:
 * The field cannot use a <<normalizer,`normalizer`>>.
 --
 
-ifeval::["{release-state}"=="unreleased"]
 [[keyword-synthetic-source]]
-==== Synthetic source
+==== Synthetic source preview:[]
 `keyword` fields support <<synthetic-source,synthetic `_source`>> in their
 default configuration. Synthetic `_source` cannot be used together with
 <<ignore-above,`ignore_above`>>, a <<normalizer,`normalizer`>>,
@@ -211,8 +210,6 @@ Will become:
 }
 ----
 // TEST[s/^/{"_source":/ s/\n$/}/]
-
-endif::[]
 
 include::constant-keyword.asciidoc[]
 

--- a/docs/reference/mapping/types/numeric.asciidoc
+++ b/docs/reference/mapping/types/numeric.asciidoc
@@ -229,9 +229,8 @@ endif::[]
     of `scaling_factor` improve accuracy but also increase space requirements.
     This parameter is required.
 
-ifeval::["{release-state}"=="unreleased"]
 [[numeric-synthetic-source]]
-==== Synthetic source
+==== Synthetic source preview:[]
 All numeric fields except `unsigned_long` support <<synthetic-source,synthetic
 `_source`>> in their default configuration. Synthetic `_source` cannot be used
 together with <<ignore-malformed,`ignore_malformed`>>, <<copy-to,`copy_to`>>, or
@@ -293,5 +292,3 @@ Will become:
 }
 ----
 // TEST[s/^/{"_source":/ s/\n$/}/]
-
-endif::[]

--- a/docs/reference/mapping/types/text.asciidoc
+++ b/docs/reference/mapping/types/text.asciidoc
@@ -159,9 +159,8 @@ The following parameters are accepted by `text` fields:
 
     Metadata about the field.
 
-ifeval::["{release-state}"=="unreleased"]
 [[text-synthetic-source]]
-==== Synthetic source
+==== Synthetic source preview:[]
 `text` fields support <<synthetic-source,synthetic `_source`>> if they have
 a `keyword` sub-field that supports synthetic `_source` and *do not* have
 <<copy-to,`copy_to`>>.
@@ -214,7 +213,6 @@ NOTE: Reordering text fields can have an effect on <<query-dsl-match-query-phras
       <<position-increment-gap,`position_increment_gap`>> for more detail. You
       can avoid this by making sure the `slop` parameter on the phrase queries
       is lower than the `position_increment_gap`. This is the default.
-endif::[]
 
 [[fielddata-mapping-param]]
 ==== `fielddata` mapping parameter


### PR DESCRIPTION
Now that we're releasing synthetic _source as a tech preview feature, we
no longer want to remove the docs from the non-release builds. And we
want to mark all of the headings describing synthetic `_source` as a
preview.
