### PR TITLE
[DOCS] Use CJKWidthCharFilter in JapaneseAnalyzer

### DIFF
--- a/docs/plugins/analysis-kuromoji.asciidoc
+++ b/docs/plugins/analysis-kuromoji.asciidoc
@@ -10,9 +10,9 @@ include::install_remove.asciidoc[]
 [[analysis-kuromoji-analyzer]]
 ==== `kuromoji` analyzer
 
-The `kuromoji` analyzer consists of the following tokenizer and token filters:
+The `kuromoji` analyzer consists of the following char filters, tokenizer, and token filters:
 
-* `cjk_width` char filter
+* `CJKWidthCharFilter` from Lucene
 * <<analysis-kuromoji-tokenizer,`kuromoji_tokenizer`>>
 * <<analysis-kuromoji-baseform,`kuromoji_baseform`>> token filter
 * <<analysis-kuromoji-speech,`kuromoji_part_of_speech`>> token filter

--- a/docs/plugins/analysis-kuromoji.asciidoc
+++ b/docs/plugins/analysis-kuromoji.asciidoc
@@ -12,10 +12,10 @@ include::install_remove.asciidoc[]
 
 The `kuromoji` analyzer consists of the following tokenizer and token filters:
 
+* `cjk_width` char filter
 * <<analysis-kuromoji-tokenizer,`kuromoji_tokenizer`>>
 * <<analysis-kuromoji-baseform,`kuromoji_baseform`>> token filter
 * <<analysis-kuromoji-speech,`kuromoji_part_of_speech`>> token filter
-* {ref}/analysis-cjk-width-tokenfilter.html[`cjk_width`] token filter
 * <<analysis-kuromoji-stop,`ja_stop`>> token filter
 * <<analysis-kuromoji-stemmer,`kuromoji_stemmer`>> token filter
 * {ref}/analysis-lowercase-tokenfilter.html[`lowercase`] token filter

--- a/docs/plugins/analysis-kuromoji.asciidoc
+++ b/docs/plugins/analysis-kuromoji.asciidoc
@@ -10,7 +10,7 @@ include::install_remove.asciidoc[]
 [[analysis-kuromoji-analyzer]]
 ==== `kuromoji` analyzer
 
-The `kuromoji` analyzer consists of the following char filters, tokenizer, and token filters:
+The `kuromoji` analyzer uses the following analysis chain:
 
 * `CJKWidthCharFilter` from Lucene
 * <<analysis-kuromoji-tokenizer,`kuromoji_tokenizer`>>


### PR DESCRIPTION
After Lucene 9.0, JapaneseAnalyzer uses CJKWidthCharFilter instead of CJKWidthFilter.

See details https://issues.apache.org/jira/browse/LUCENE-9853

<!--
Thank you for your interest in and contributing to Elasticsearch! There
are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your
attention.
-->

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/elasticsearch/blob/master/CONTRIBUTING.md)?
- If submitting code, have you built your formula locally prior to submission with `gradle check`?
- If submitting code, is your pull request against master? Unless there is a good reason otherwise, we prefer pull requests against master and will backport as needed.
- If submitting code, have you checked that your submission is for an [OS and architecture that we support](https://www.elastic.co/support/matrix#show_os)?
- If you are submitting this code for a class then read our [policy](https://github.com/elastic/elasticsearch/blob/master/CONTRIBUTING.md#contributing-as-part-of-a-class) for that.
