### PR TITLE
[ML] frequent_items should not be a release highlight for 8.4

### DIFF
--- a/docs/changelog/83055.yaml
+++ b/docs/changelog/83055.yaml
@@ -3,14 +3,3 @@ summary: New `frequent_items` aggregation
 area: Machine Learning
 type: enhancement
 issues: []
-highlight:
-  title: Frequent itemset aggregation
-  body: |-
-   The 
-   {ref}/search-aggregations-bucket-frequent-items-aggregation.html[frequent items aggregation] 
-   is a new bucket aggregation which identifies items that often occur together. 
-   It is a form of association rules mining that helps to discover relationships 
-   between different data points. For example, the aggregation can find log 
-   events that tend to co-occur and may give a more informative explanation for 
-   the possible causes of a spike in the logs.
-  notable: true


### PR DESCRIPTION
The frequent_items aggregation is experimental in 8.4, and we
want to gain confidence in it for internal use cases before
publicising more widely, so we'll just give it a single bullet
point release note rather than a whole section in the release
highlights.