### PR TITLE
[ML] Sync changelogs between 8.4 and main

### DIFF
--- a/docs/changelog/83055.yaml
+++ b/docs/changelog/83055.yaml
@@ -3,3 +3,14 @@ summary: New `frequent_items` aggregation
 area: Machine Learning
 type: enhancement
 issues: []
+highlight:
+  title: Frequent itemset aggregation
+  body: |-
+   The 
+   {ref}/search-aggregations-bucket-frequent-items-aggregation.html[frequent items aggregation] 
+   is a new bucket aggregation which identifies items that often occur together. 
+   It is a form of association rules mining that helps to discover relationships 
+   between different data points. For example, the aggregation can find log 
+   events that tend to co-occur and may give a more informative explanation for 
+   the possible causes of a spike in the logs.
+  notable: true

--- a/docs/changelog/83055.yaml
+++ b/docs/changelog/83055.yaml
@@ -3,14 +3,3 @@ summary: New `frequent_items` aggregation
 area: Machine Learning
 type: enhancement
 issues: []
-highlight:
-  title: Frequent itemset aggregation
-  body: |-
-   The 
-   {ref}/search-aggregations-bucket-frequent-items-aggregation.html[frequent items aggregation] 
-   is a new bucket aggregation which identifies items that often occur together. 
-   It is a form of association rules mining that helps to discover relationships 
-   between different data points. For example, the aggregation can find log 
-   events that tend to co-occur and may give a more informative explanation for 
-   the possible causes of a spike in the logs.
-  notable: true

--- a/docs/changelog/87361.yaml
+++ b/docs/changelog/87361.yaml
@@ -3,4 +3,17 @@ summary: "Implement per-transform num_failure_retries setting"
 area: Transform
 type: enhancement
 issues: []
+highlight:
+  title: Infinite and adaptive retries for transforms
+  body: |-
+   Infinite and adaptive retries – available in 8.4 – makes it possible for 
+   transforms to recover after a failure without any user intervention. Retries 
+   can be configured per transform. The transform retries become less frequent 
+   progressively. The interval between retries doubles after reaching a one-hour 
+   threshold. This is because the possibility that retries solve the problem is 
+   less likely after each failed retry.
+   
+   In the *Transforms* page in *{stack-manage-app}* in {kib}, the number of retries 
+   can be configured when creating a new transform or editing an existing one.
+  notable: true
 

--- a/docs/changelog/88589.yaml
+++ b/docs/changelog/88589.yaml
@@ -1,0 +1,21 @@
+pr: 88589
+summary: Make composite aggs in datafeeds Generally Available
+area: Machine Learning
+type: feature
+issues: []
+highlight:
+  title: Composite aggregations in datafeeds are Generally Available
+  body: |-
+    The support for 
+    {ml-docs}/ml-configuring-aggregation.html#aggs-using-composite[composite aggregations]
+    in datafeeds is now generally available.
+
+    [discrete]
+    [[early-stopping-dfa]]
+    === Early stopping for data frame analytics
+    Data frame analytics is even faster in 8.4. The new function automatically 
+    stops the process of hyperparameter optimization early in case of the 
+    accuracy gain for a different set of hyperparameter values would be 
+    insignificant. The early stopping of the optimization process results in a 
+    shorter runtime for the data frame analytics job.
+  notable: true

--- a/docs/changelog/88589.yaml
+++ b/docs/changelog/88589.yaml
@@ -12,10 +12,10 @@ highlight:
 
     [discrete]
     [[early-stopping-dfa]]
-    === Early stopping for data frame analytics
-    Data frame analytics is even faster in 8.4. The new function automatically 
+    === Optimizing speed of {dfanalytics}
+    {dfanalytics-cap} is even faster in 8.4. The new function automatically 
     stops the process of hyperparameter optimization early in case of the 
     accuracy gain for a different set of hyperparameter values would be 
     insignificant. The early stopping of the optimization process results in a 
-    shorter runtime for the data frame analytics job.
+    shorter runtime for the {dfanalytics-job}.
   notable: true


### PR DESCRIPTION
Copies a few changelog edits from the 8.4 branch into main so that
people looking at the main branch see the same docs as people
looking at 8.4.

Relates #89078
Relates #89286 
Relates #89376