### PR TITLE
[ML] Get categories endpoint to use ECS Grok patterns

### DIFF
--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/categorization/GrokPatternCreator.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/categorization/GrokPatternCreator.java
@@ -28,6 +28,8 @@ import static org.elasticsearch.core.Strings.format;
  */
 public final class GrokPatternCreator {
 
+    private static final boolean ECS_COMPATIBILITY = true;
+
     private static final Logger logger = LogManager.getLogger(GrokPatternCreator.class);
 
     private static final String PREFACE = "preface";
@@ -51,8 +53,8 @@ public final class GrokPatternCreator {
         new GrokPatternCandidate("CISCOTIMESTAMP", "timestamp"),
         new GrokPatternCandidate("DATE", "date"),
         new GrokPatternCandidate("TIME", "time"),
-        new GrokPatternCandidate("LOGLEVEL", "loglevel"),
-        new GrokPatternCandidate("URI", "uri"),
+        new GrokPatternCandidate("LOGLEVEL", "log.level"),
+        new GrokPatternCandidate("URI", "url.original"),
         new GrokPatternCandidate("UUID", "uuid"),
         new GrokPatternCandidate("MAC", "macaddress"),
         // Can't use \b as the breaks, because slashes are not "word" characters
@@ -284,7 +286,7 @@ public final class GrokPatternCreator {
             this.grokPatternName = grokPatternName;
             this.fieldName = fieldName;
             this.grok = new Grok(
-                Grok.getBuiltinPatterns(false),
+                Grok.getBuiltinPatterns(ECS_COMPATIBILITY),
                 "%{DATA:" + PREFACE + "}" + preBreak + "%{" + grokPatternName + ":this}" + postBreak + "%{GREEDYDATA:" + EPILOGUE + "}",
                 logger::warn
             );

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/categorization/GrokPatternCreator.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/categorization/GrokPatternCreator.java
@@ -41,7 +41,7 @@ public final class GrokPatternCreator {
      * such that more generic patterns come after more specific patterns.
      */
     private static final List<GrokPatternCandidate> ORDERED_CANDIDATE_GROK_PATTERNS = Arrays.asList(
-        new GrokPatternCandidate("TOMCAT_DATESTAMP", "timestamp"),
+        new GrokPatternCandidate("TOMCATLEGACY_DATESTAMP", "timestamp"),
         new GrokPatternCandidate("TIMESTAMP_ISO8601", "timestamp"),
         new GrokPatternCandidate("DATESTAMP_RFC822", "timestamp"),
         new GrokPatternCandidate("DATESTAMP_RFC2822", "timestamp"),

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/categorization/GrokPatternCreatorTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/categorization/GrokPatternCreatorTests.java
@@ -110,7 +110,7 @@ public class GrokPatternCreatorTests extends ESTestCase {
             mustMatchStrings
         );
 
-        assertEquals(".*?%{TOMCAT_DATESTAMP:timestamp}.+?%{LOGLEVEL:log.level}.+?", overallGrokPatternBuilder.toString());
+        assertEquals(".*?%{TOMCATLEGACY_DATESTAMP:timestamp}.+?%{LOGLEVEL:log.level}.+?", overallGrokPatternBuilder.toString());
     }
 
     public void testAppendBestGrokMatchForStringsGivenTrappyFloatCandidates() {
@@ -307,12 +307,8 @@ public class GrokPatternCreatorTests extends ESTestCase {
                 + "Invalid chunk ignored."
         );
 
-        // For ECS compliant Grok patterns TOMCAT_DATESTAMP is defined as:
-        // TOMCAT_DATESTAMP (?:%{CATALINA8_DATESTAMP})|(?:%{CATALINA7_DATESTAMP})|(?:%{TOMCATLEGACY_DATESTAMP})
-        // and since the timestamps in the example messages are in CATALINA7_DATESTAMP format, TOMCAT_DATESTAMP, being at the
-        // front of our ORDERED_CANDIDATE_GROK_PATTERNS list, matches.
         assertEquals(
-            ".*?%{TOMCAT_DATESTAMP:timestamp}.+?org\\.apache\\.tomcat\\.util\\.http\\.Parameters.+?processParameters.+?"
+            ".*?%{CATALINA_DATESTAMP:timestamp}.+?org\\.apache\\.tomcat\\.util\\.http\\.Parameters.+?processParameters.+?"
                 + "WARNING.+?Parameters.+?Invalid.+?chunk.+?ignored.*",
             GrokPatternCreator.findBestGrokMatchFromExamples("foo", regex, examples)
         );
@@ -334,12 +330,8 @@ public class GrokPatternCreatorTests extends ESTestCase {
                 + "Invalid chunk ignored."
         );
 
-        // For ECS compliant Grok patterns TOMCAT_DATESTAMP is defined as:
-        // TOMCAT_DATESTAMP (?:%{CATALINA8_DATESTAMP})|(?:%{CATALINA7_DATESTAMP})|(?:%{TOMCATLEGACY_DATESTAMP})
-        // and since the timestamps in the example messages are in CATALINA8_DATESTAMP format, TOMCAT_DATESTAMP, being at the
-        // front of our ORDERED_CANDIDATE_GROK_PATTERNS list matches.
         assertEquals(
-            ".*?%{TOMCAT_DATESTAMP:timestamp}.+?WARNING.+?org\\.apache\\.tomcat\\.util\\.http\\.Parameters.+?processParameters.+?"
+            ".*?%{CATALINA_DATESTAMP:timestamp}.+?WARNING.+?org\\.apache\\.tomcat\\.util\\.http\\.Parameters.+?processParameters.+?"
                 + "Parameters.+?Invalid.+?chunk.+?ignored.*",
             GrokPatternCreator.findBestGrokMatchFromExamples("foo", regex, examples)
         );

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/categorization/GrokPatternCreatorTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/categorization/GrokPatternCreatorTests.java
@@ -28,7 +28,7 @@ public class GrokPatternCreatorTests extends ESTestCase {
         assertEquals("field3", GrokPatternCreator.buildFieldName(fieldNameCountStore, "field"));
         assertEquals("timestamp", GrokPatternCreator.buildFieldName(fieldNameCountStore, "timestamp"));
         assertEquals("field4", GrokPatternCreator.buildFieldName(fieldNameCountStore, "field"));
-        assertEquals("uri", GrokPatternCreator.buildFieldName(fieldNameCountStore, "uri"));
+        assertEquals("url.original", GrokPatternCreator.buildFieldName(fieldNameCountStore, "url.original"));
         assertEquals("timestamp2", GrokPatternCreator.buildFieldName(fieldNameCountStore, "timestamp"));
         assertEquals("field5", GrokPatternCreator.buildFieldName(fieldNameCountStore, "field"));
     }
@@ -85,7 +85,7 @@ public class GrokPatternCreatorTests extends ESTestCase {
             mustMatchStrings
         );
 
-        assertEquals(".+?%{TIMESTAMP_ISO8601:timestamp}.+?%{LOGLEVEL:loglevel}.+?", overallGrokPatternBuilder.toString());
+        assertEquals(".+?%{TIMESTAMP_ISO8601:timestamp}.+?%{LOGLEVEL:log.level}.+?", overallGrokPatternBuilder.toString());
     }
 
     public void testAppendBestGrokMatchForStringsGivenTomcatDatestamps() {
@@ -110,7 +110,7 @@ public class GrokPatternCreatorTests extends ESTestCase {
             mustMatchStrings
         );
 
-        assertEquals(".*?%{TOMCAT_DATESTAMP:timestamp}.+?%{LOGLEVEL:loglevel}.+?", overallGrokPatternBuilder.toString());
+        assertEquals(".*?%{TOMCAT_DATESTAMP:timestamp}.+?%{LOGLEVEL:log.level}.+?", overallGrokPatternBuilder.toString());
     }
 
     public void testAppendBestGrokMatchForStringsGivenTrappyFloatCandidates() {
@@ -252,7 +252,7 @@ public class GrokPatternCreatorTests extends ESTestCase {
             mustMatchStrings
         );
 
-        assertEquals(".*?%{URI:uri}.*?", overallGrokPatternBuilder.toString());
+        assertEquals(".*?%{URI:url.original}.*?", overallGrokPatternBuilder.toString());
     }
 
     public void testAppendBestGrokMatchForStringsGivenPaths() {
@@ -307,9 +307,40 @@ public class GrokPatternCreatorTests extends ESTestCase {
                 + "Invalid chunk ignored."
         );
 
+        // For ECS compliant Grok patterns TOMCAT_DATESTAMP is defined as:
+        // TOMCAT_DATESTAMP (?:%{CATALINA8_DATESTAMP})|(?:%{CATALINA7_DATESTAMP})|(?:%{TOMCATLEGACY_DATESTAMP})
+        // and since the timestamps in the example messages are in CATALINA7_DATESTAMP format, TOMCAT_DATESTAMP, being at the
+        // front of our ORDERED_CANDIDATE_GROK_PATTERNS list, matches.
         assertEquals(
-            ".*?%{CATALINA_DATESTAMP:timestamp}.+?org\\.apache\\.tomcat\\.util\\.http\\.Parameters.+?processParameters.+?"
+            ".*?%{TOMCAT_DATESTAMP:timestamp}.+?org\\.apache\\.tomcat\\.util\\.http\\.Parameters.+?processParameters.+?"
                 + "WARNING.+?Parameters.+?Invalid.+?chunk.+?ignored.*",
+            GrokPatternCreator.findBestGrokMatchFromExamples("foo", regex, examples)
+        );
+    }
+
+    public void testFindBestGrokMatchFromExamplesGivenCatalina8Logs() {
+
+        String regex = ".*?WARNING.+?org\\.apache\\.tomcat\\.util\\.http\\.Parameters.+?processParameters.+?Parameters.+?"
+            + "Invalid.+?chunk.+?ignored.*";
+        // The embedded newline ensures the regular expressions we're using are compiled with Pattern.DOTALL
+        Collection<String> examples = Arrays.asList(
+            "29-Aug-2009 12:03:33 WARNING [main] org.apache.tomcat.util.http.Parameters processParameters: Parameters: \n"
+                + "Invalid chunk ignored.",
+            "29-Aug-2009 12:03:33 WARNING [main] org.apache.tomcat.util.http.Parameters processParameters: Parameters: \n"
+                + "Invalid chunk ignored.",
+            "29-Aug-2009 12:03:33 WARNING [main] org.apache.tomcat.util.http.Parameters processParameters: Parameters: \n"
+                + "Invalid chunk ignored.",
+            "29-Aug-2009 12:03:33 WARNING [main] org.apache.tomcat.util.http.Parameters processParameters: Parameters: \n"
+                + "Invalid chunk ignored."
+        );
+
+        // For ECS compliant Grok patterns TOMCAT_DATESTAMP is defined as:
+        // TOMCAT_DATESTAMP (?:%{CATALINA8_DATESTAMP})|(?:%{CATALINA7_DATESTAMP})|(?:%{TOMCATLEGACY_DATESTAMP})
+        // and since the timestamps in the example messages are in CATALINA8_DATESTAMP format, TOMCAT_DATESTAMP, being at the
+        // front of our ORDERED_CANDIDATE_GROK_PATTERNS list matches.
+        assertEquals(
+            ".*?%{TOMCAT_DATESTAMP:timestamp}.+?WARNING.+?org\\.apache\\.tomcat\\.util\\.http\\.Parameters.+?processParameters.+?"
+                + "Parameters.+?Invalid.+?chunk.+?ignored.*",
             GrokPatternCreator.findBestGrokMatchFromExamples("foo", regex, examples)
         );
     }


### PR DESCRIPTION
Change the Grok pattern creator for _ml/anomaly_detectors/<job_id>/results/categories to always use ECS Grok patterns

relates #77065
