### PR TITLE
Assign the right path to objects merged when parsing mappings

### DIFF
--- a/docs/changelog/89389.yaml
+++ b/docs/changelog/89389.yaml
@@ -1,0 +1,6 @@
+pr: 89389
+summary: Assign the right path to objects merged when parsing mappings
+area: Mapping
+type: bug
+issues:
+ - 88573

--- a/server/src/main/java/org/elasticsearch/index/mapper/NestedObjectMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/NestedObjectMapper.java
@@ -170,7 +170,7 @@ public class NestedObjectMapper extends ObjectMapper {
     }
 
     @Override
-    public ObjectMapper merge(Mapper mergeWith, MapperService.MergeReason reason, MapperBuilderContext mapperBuilderContext) {
+    public ObjectMapper merge(Mapper mergeWith, MapperService.MergeReason reason, MapperBuilderContext parentBuilderContext) {
         if ((mergeWith instanceof NestedObjectMapper) == false) {
             throw new IllegalArgumentException("can't merge a non nested mapping [" + mergeWith.name() + "] with a nested mapping");
         }
@@ -191,7 +191,7 @@ public class NestedObjectMapper extends ObjectMapper {
                 throw new MapperException("the [include_in_root] parameter can't be updated on a nested object mapping");
             }
         }
-        toMerge.doMerge(mergeWithObject, reason, mapperBuilderContext);
+        toMerge.doMerge(mergeWithObject, reason, parentBuilderContext);
         return toMerge;
     }
 

--- a/server/src/main/java/org/elasticsearch/index/mapper/ObjectMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/ObjectMapper.java
@@ -155,7 +155,7 @@ public class ObjectMapper extends Mapper implements Cloneable {
                     // This can also happen due to multiple index templates being merged into a single mappings definition using
                     // XContentHelper#mergeDefaults, again in case some index templates contained mappings for the same field using a
                     // mix of object notation and dot notation.
-                    mapper = existing.merge(mapper, context);
+                    mapper = existing.merge(mapper, mapperBuilderContext);
                 }
                 mappers.put(mapper.simpleName(), mapper);
             }

--- a/server/src/main/java/org/elasticsearch/index/mapper/ObjectMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/ObjectMapper.java
@@ -143,7 +143,6 @@ public class ObjectMapper extends Mapper implements Cloneable {
         }
 
         protected final Map<String, Mapper> buildMappers(boolean root, MapperBuilderContext context) {
-            // TODO can't we provide the right context directly?
             MapperBuilderContext mapperBuilderContext = root ? context : context.createChildContext(name);
             Map<String, Mapper> mappers = new HashMap<>();
             for (Mapper.Builder builder : mappersBuilders) {

--- a/server/src/main/java/org/elasticsearch/index/mapper/RootObjectMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/RootObjectMapper.java
@@ -322,13 +322,19 @@ public class RootObjectMapper extends ObjectMapper {
     }
 
     @Override
-    public RootObjectMapper merge(Mapper mergeWith, MergeReason reason, MapperBuilderContext mapperBuilderContext) {
-        return (RootObjectMapper) super.merge(mergeWith, reason, mapperBuilderContext);
+    protected MapperBuilderContext createChildContext(MapperBuilderContext mapperBuilderContext, String name) {
+        assert mapperBuilderContext == MapperBuilderContext.ROOT;
+        return mapperBuilderContext;
     }
 
     @Override
-    protected void doMerge(ObjectMapper mergeWith, MergeReason reason, MapperBuilderContext mapperBuilderContext) {
-        super.doMerge(mergeWith, reason, mapperBuilderContext);
+    public RootObjectMapper merge(Mapper mergeWith, MergeReason reason, MapperBuilderContext parentBuilderContext) {
+        return (RootObjectMapper) super.merge(mergeWith, reason, parentBuilderContext);
+    }
+
+    @Override
+    protected void doMerge(ObjectMapper mergeWith, MergeReason reason, MapperBuilderContext parentBuilderContext) {
+        super.doMerge(mergeWith, reason, parentBuilderContext);
         RootObjectMapper mergeWithObject = (RootObjectMapper) mergeWith;
         if (mergeWithObject.numericDetection.explicit()) {
             this.numericDetection = mergeWithObject.numericDetection;

--- a/server/src/test/java/org/elasticsearch/index/mapper/MapperServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/MapperServiceTests.java
@@ -8,8 +8,10 @@
 
 package org.elasticsearch.index.mapper;
 
+import org.apache.lucene.index.IndexableField;
 import org.elasticsearch.Version;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
+import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.compress.CompressedXContent;
 import org.elasticsearch.common.settings.Settings;
@@ -360,4 +362,68 @@ public class MapperServiceTests extends MapperServiceTestCase {
         assertFalse(mapperService.isMultiField("object.subfield1"));
     }
 
+    public void testMergeObjectSubfieldWhileParsing() throws IOException {
+        /*
+        If we are parsing mappings that hold the definition of the same field twice, the two are merged together. This can happen when
+        mappings have the same field specified using the object notation as well as the dot notation, as well as when applying index
+        templates, in which case the two definitions may come from separate index templates that end up in the same map (through
+        XContentHelper#mergeDefaults, see MetadataCreateIndexService#parseV1Mappings).
+        We had a bug (https://github.com/elastic/elasticsearch/issues/88573) triggered by this scenario that caused the merged leaf fields
+        to get the wrong path (missing the first portion).
+         */
+        MapperService mapperService = createMapperService("""
+            {
+              "_doc": {
+                "properties": {
+                  "obj": {
+                    "properties": {
+                      "sub": {
+                        "properties": {
+                          "string": {
+                            "type": "keyword"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "obj.sub.string" : {
+                    "type" : "keyword"
+                  }
+                }
+              }
+            }
+            """);
+
+        assertNotNull(mapperService.mappingLookup().getMapper("obj.sub.string"));
+        MappedFieldType fieldType = mapperService.mappingLookup().getFieldType("obj.sub.string");
+        assertNotNull(fieldType);
+        assertEquals("""
+            {
+              "_doc" : {
+                "properties" : {
+                  "obj" : {
+                    "properties" : {
+                      "sub" : {
+                        "properties" : {
+                          "string" : {
+                            "type" : "keyword"
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }""", Strings.toString(mapperService.documentMapper().mapping(), true, true));
+
+        // check that with the resulting mappings a new document has the previously merged field indexed properly
+        ParsedDocument parsedDocument = mapperService.documentMapper().parse(source("""
+            {
+              "obj.sub.string" : "value"
+            }"""));
+
+        assertNull(parsedDocument.dynamicMappingsUpdate());
+        IndexableField[] fields = parsedDocument.rootDoc().getFields("obj.sub.string");
+        assertEquals(2, fields.length);
+    }
 }

--- a/server/src/test/java/org/elasticsearch/index/mapper/MappingParserTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/MappingParserTests.java
@@ -143,4 +143,67 @@ public class MappingParserTests extends MapperServiceTestCase {
         );
         assertEquals("[_routing] config must be an object", e.getMessage());
     }
+
+    public void testMergeSubfieldWhileParsing() throws Exception {
+        /*
+        If we are parsing mappings that hold the definition of the same field twice, the two are merged together. This can happen when
+        mappings have the same field specified using the object notation as well as the dot notation, as well as when applying index
+        templates, in which case the two definitions may come from separate index templates that end up in the same map (through
+        XContentHelper#mergeDefaults, see MetadataCreateIndexService#parseV1Mappings).
+        We had a bug (https://github.com/elastic/elasticsearch/issues/88573) triggered by this scenario that caused the merged leaf fields
+        to get the wrong path (missing the first portion).
+         */
+        String mappingAsString = """
+            {
+               "_doc": {
+                 "properties": {
+                   "obj": {
+                     "properties": {
+                       "source": {
+                         "properties": {
+                           "geo": {
+                             "properties": {
+                               "location": {
+                                 "type": "geo_point"
+                               }
+                             }
+                           }
+                         }
+                       }
+                     }
+                   },
+                   "obj.source.geo.location" : {
+                     "type": "geo_point"
+                   }
+                 }
+               }
+            }
+            """;
+        Mapping mapping = createMappingParser(Settings.EMPTY).parse("_doc", new CompressedXContent(mappingAsString));
+        assertEquals(1, mapping.getRoot().mappers.size());
+        Mapper object = mapping.getRoot().getMapper("obj");
+        assertThat(object, CoreMatchers.instanceOf(ObjectMapper.class));
+        assertEquals("obj", object.simpleName());
+        assertEquals("obj", object.name());
+        ObjectMapper objectMapper = (ObjectMapper) object;
+        assertEquals(1, objectMapper.mappers.size());
+        object = objectMapper.getMapper("source");
+        assertThat(object, CoreMatchers.instanceOf(ObjectMapper.class));
+        assertEquals("source", object.simpleName());
+        assertEquals("obj.source", object.name());
+        objectMapper = (ObjectMapper) object;
+        assertEquals(1, objectMapper.mappers.size());
+        object = objectMapper.getMapper("geo");
+        assertThat(object, CoreMatchers.instanceOf(ObjectMapper.class));
+        assertEquals("geo", object.simpleName());
+        assertEquals("obj.source.geo", object.name());
+        objectMapper = (ObjectMapper) object;
+        assertEquals(1, objectMapper.mappers.size());
+        Mapper location = objectMapper.getMapper("location");
+        assertThat(location, CoreMatchers.instanceOf(GeoPointFieldMapper.class));
+        GeoPointFieldMapper geoPointFieldMapper = (GeoPointFieldMapper) location;
+        assertEquals("obj.source.geo.location", geoPointFieldMapper.name());
+        assertEquals("location", geoPointFieldMapper.simpleName());
+        assertEquals("obj.source.geo.location", geoPointFieldMapper.mappedFieldType.name());
+    }
 }


### PR DESCRIPTION
When parsing mappings, we may find a field with same name specified twice, either
because JSON duplicate keys are allowed, or because a mix of object notation and dot
notation is used when providing mappings. The same can happen when applying dynamic
mappings as part of parsing an incoming document, as well as when merging separate
index templates that may contain the definition for the same field using a
mix of object notation and dot notation.

While we propagate the MapperBuilderContext across merge calls thanks to #86946, we do not
propagate the right context when we call merge on objects as part of parsing/building
mappings. This causes a situation in which the leaf fields that result from the merge
have the wrong path, which misses the first portion e.g. sub.field instead of obj.sub.field.

This commit applies the correct mapper builder context when building the object mapper builder
and two objects with same name are found.

The scenario in which this bug was triggered is limited: the same document or mappings need to have the same field specified twice, using the object notation as well as the dot notation. In this case, we would end up indexing the leaf fields that were merged (the leaves that both object held) in the wrong lucene fields, which can only be fixed through a reindex. Closing and reopening the index triggers a reparsing of the mappings that addressed the problem though.

Relates to #86946

Closes #88573