### PR TITLE
Correct ctx.op value to valid 'noop'

### DIFF
--- a/docs/reference/docs/update.asciidoc
+++ b/docs/reference/docs/update.asciidoc
@@ -219,7 +219,7 @@ the `tags` field contains `green`, otherwise it does nothing (`noop`):
 POST test/_update/1
 {
   "script": {
-    "source": "if (ctx._source.tags.contains(params.tag)) { ctx.op = 'delete' } else { ctx.op = 'none' }",
+    "source": "if (ctx._source.tags.contains(params.tag)) { ctx.op = 'delete' } else { ctx.op = 'noop' }",
     "lang": "painless",
     "params": {
       "tag": "green"


### PR DESCRIPTION
The documentation mentions the `noop` value ("Otherwise it does nothing (`noop`)"), however, the value used in the example script is `none`. This change corrects the value in the example script to `noop`.
