### PR TITLE
Limit concurrent msearch with preference in expand fetch phase

### DIFF
--- a/docs/changelog/89395.yaml
+++ b/docs/changelog/89395.yaml
@@ -1,0 +1,5 @@
+pr: 89395
+summary: Limit concurrent msearch in expand fetch phase with preference
+area: Search
+type: bug
+issues: []

--- a/server/src/main/java/org/elasticsearch/action/search/FetchSearchPhase.java
+++ b/server/src/main/java/org/elasticsearch/action/search/FetchSearchPhase.java
@@ -49,6 +49,7 @@ final class FetchSearchPhase extends SearchPhase {
             (response, queryPhaseResults) -> new ExpandSearchPhase(
                 context,
                 response,
+                queryPhaseResults,
                 () -> new FetchLookupFieldsPhase(context, response, queryPhaseResults)
             )
         );

--- a/server/src/main/java/org/elasticsearch/action/search/SearchTransportService.java
+++ b/server/src/main/java/org/elasticsearch/action/search/SearchTransportService.java
@@ -668,4 +668,8 @@ public class SearchTransportService {
     public NamedWriteableRegistry getNamedWriteableRegistry() {
         return client.getNamedWriteableRegistry();
     }
+
+    public ThreadPool getThreadPool() {
+        return transportService.getThreadPool();
+    }
 }


### PR DESCRIPTION
Today, a multi-search request from the expand-fetch-phase of a search request with `preference` can take over the search thread pool of some data nodes. This happens because we route all expanded requests to the same set of nodes (due to the inherited `preference` parameter), and the multi_search_action doesn't limit the number of concurrent search requests properly. I see two ways to alleviate this issue:
- Ensure that the number of shard requests doesn't exceed the max allowed shard requests on each node. This PR implements this strategy.
- Do not pass the preference to the expanded requests meaning routing them to as many nodes as possible.