### PR TITLE
Preserve `system_index_migration` cluster state when loading metadata from disk

### DIFF
--- a/docs/changelog/89397.yaml
+++ b/docs/changelog/89397.yaml
@@ -1,0 +1,7 @@
+pr: 89397
+summary: Preserve `system_index_migration` cluster state when loading metadata from
+  disk
+area: Infra/Core
+type: bug
+issues:
+ - 88983

--- a/server/src/main/java/org/elasticsearch/upgrades/SystemIndexMigrationExecutor.java
+++ b/server/src/main/java/org/elasticsearch/upgrades/SystemIndexMigrationExecutor.java
@@ -122,6 +122,11 @@ public class SystemIndexMigrationExecutor extends PersistentTasksExecutor<System
                 PersistentTaskState.class,
                 new ParseField(SystemIndexMigrationTaskParams.SYSTEM_INDEX_UPGRADE_TASK_NAME),
                 SystemIndexMigrationTaskState::fromXContent
+            ),
+            new NamedXContentRegistry.Entry(
+                FeatureMigrationResults.class,
+                new ParseField(FeatureMigrationResults.TYPE),
+                FeatureMigrationResults::fromXContent
             )
         );
     }
@@ -133,7 +138,8 @@ public class SystemIndexMigrationExecutor extends PersistentTasksExecutor<System
                 PersistentTaskParams.class,
                 SYSTEM_INDEX_UPGRADE_TASK_NAME,
                 SystemIndexMigrationTaskParams::new
-            )
+            ),
+            new NamedWriteableRegistry.Entry(FeatureMigrationResults.class, FeatureMigrationResults.TYPE, FeatureMigrationResults::new)
         );
     }
 }


### PR DESCRIPTION
We used a Metadata.Custom object to track the results of feature migration, but neglected to register it in the NamedXContentRegistry. This violates the expectations for `Metadata.Custom` and causes this metadata to be ignored when loading from disk.

Fixes #88983