### PR TITLE
Allocation commands related refactoring

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/routing/RoutingNodes.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/RoutingNodes.java
@@ -985,6 +985,30 @@ public class RoutingNodes extends AbstractCollection<RoutingNode> {
             ignored.add(shard);
         }
 
+        public void resetFailedAllocationCounter(RoutingChangesObserver routingChangesObserver) {
+            final RoutingNodes.UnassignedShards.UnassignedIterator unassignedIterator = iterator();
+            while (unassignedIterator.hasNext()) {
+                ShardRouting shardRouting = unassignedIterator.next();
+                UnassignedInfo unassignedInfo = shardRouting.unassignedInfo();
+                unassignedIterator.updateUnassigned(
+                    new UnassignedInfo(
+                        unassignedInfo.getNumFailedAllocations() > 0 ? UnassignedInfo.Reason.MANUAL_ALLOCATION : unassignedInfo.getReason(),
+                        unassignedInfo.getMessage(),
+                        unassignedInfo.getFailure(),
+                        0,
+                        unassignedInfo.getUnassignedTimeInNanos(),
+                        unassignedInfo.getUnassignedTimeInMillis(),
+                        unassignedInfo.isDelayed(),
+                        unassignedInfo.getLastAllocationStatus(),
+                        Collections.emptySet(),
+                        unassignedInfo.getLastAllocatedNodeId()
+                    ),
+                    shardRouting.recoverySource(),
+                    routingChangesObserver
+                );
+            }
+        }
+
         public class UnassignedIterator implements Iterator<ShardRouting>, ExistingShardsAllocator.UnassignedAllocationHandler {
 
             private final ListIterator<ShardRouting> iterator;

--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/AllocationService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/AllocationService.java
@@ -353,33 +353,6 @@ public class AllocationService {
     }
 
     /**
-     * Reset failed allocation counter for unassigned shards
-     */
-    private void resetFailedAllocationCounter(RoutingAllocation allocation) {
-        final RoutingNodes.UnassignedShards.UnassignedIterator unassignedIterator = allocation.routingNodes().unassigned().iterator();
-        while (unassignedIterator.hasNext()) {
-            ShardRouting shardRouting = unassignedIterator.next();
-            UnassignedInfo unassignedInfo = shardRouting.unassignedInfo();
-            unassignedIterator.updateUnassigned(
-                new UnassignedInfo(
-                    unassignedInfo.getNumFailedAllocations() > 0 ? UnassignedInfo.Reason.MANUAL_ALLOCATION : unassignedInfo.getReason(),
-                    unassignedInfo.getMessage(),
-                    unassignedInfo.getFailure(),
-                    0,
-                    unassignedInfo.getUnassignedTimeInNanos(),
-                    unassignedInfo.getUnassignedTimeInMillis(),
-                    unassignedInfo.isDelayed(),
-                    unassignedInfo.getLastAllocationStatus(),
-                    Collections.emptySet(),
-                    unassignedInfo.getLastAllocatedNodeId()
-                ),
-                shardRouting.recoverySource(),
-                allocation.changes()
-            );
-        }
-    }
-
-    /**
      * Internal helper to cap the number of elements in a potentially long list for logging.
      *
      * @param elements  The elements to log. May be any non-null list. Must not be null.
@@ -414,7 +387,7 @@ public class AllocationService {
         allocation.ignoreDisable(true);
 
         if (retryFailed) {
-            resetFailedAllocationCounter(allocation);
+            allocation.routingNodes().unassigned().resetFailedAllocationCounter(allocation.changes());
         }
 
         RoutingExplanations explanations = commands.execute(allocation, explain);

--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/reroute/ClusterRerouteTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/reroute/ClusterRerouteTests.java
@@ -15,7 +15,9 @@ import org.elasticsearch.cluster.EmptyClusterInfoService;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
+import org.elasticsearch.cluster.routing.IndexRoutingTable;
 import org.elasticsearch.cluster.routing.RoutingTable;
+import org.elasticsearch.cluster.routing.ShardRoutingState;
 import org.elasticsearch.cluster.routing.allocation.AllocationService;
 import org.elasticsearch.cluster.routing.allocation.FailedShard;
 import org.elasticsearch.cluster.routing.allocation.allocator.BalancedShardsAllocator;
@@ -34,7 +36,6 @@ import org.elasticsearch.snapshots.EmptySnapshotsInfoService;
 import org.elasticsearch.test.gateway.TestGatewayAllocator;
 
 import java.io.IOException;
-import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -67,92 +68,96 @@ public class ClusterRerouteTests extends ESAllocationTestCase {
         assertEquals(req.getCommands().commands().size(), deserializedReq.getCommands().commands().size());
     }
 
-    public void testClusterStateUpdateTask() {
+    public void testClusterStateUpdateTaskInDryRun() {
         AllocationService allocationService = new AllocationService(
-            new AllocationDeciders(Collections.singleton(new MaxRetryAllocationDecider())),
+            new AllocationDeciders(List.of(new MaxRetryAllocationDecider())),
             new TestGatewayAllocator(),
             new BalancedShardsAllocator(Settings.EMPTY),
             EmptyClusterInfoService.INSTANCE,
             EmptySnapshotsInfoService.INSTANCE
         );
         ClusterState clusterState = createInitialClusterState(allocationService);
-        ClusterRerouteRequest req = new ClusterRerouteRequest();
-        req.dryRun(true);
-        AtomicReference<ClusterRerouteResponse> responseRef = new AtomicReference<>();
-        ActionListener<ClusterRerouteResponse> responseActionListener = new ActionListener<ClusterRerouteResponse>() {
-            @Override
-            public void onResponse(ClusterRerouteResponse clusterRerouteResponse) {
-                responseRef.set(clusterRerouteResponse);
-            }
 
-            @Override
-            public void onFailure(Exception e) {
+        var responseRef = new AtomicReference<ClusterRerouteResponse>();
+        var responseActionListener = ActionListener.<ClusterRerouteResponse>wrap(
+            responseRef::set,
+            exception -> { throw new AssertionError("Should not fail in test", exception); }
+        );
 
-            }
-        };
-        TransportClusterRerouteAction.ClusterRerouteResponseAckedClusterStateUpdateTask task =
-            new TransportClusterRerouteAction.ClusterRerouteResponseAckedClusterStateUpdateTask(
-                logger,
-                allocationService,
-                req,
-                responseActionListener
-            );
+        var request = new ClusterRerouteRequest().dryRun(true);
+        var task = new TransportClusterRerouteAction.ClusterRerouteResponseAckedClusterStateUpdateTask(
+            logger,
+            allocationService,
+            request,
+            responseActionListener
+        );
+
         ClusterState execute = task.execute(clusterState);
-        assertSame(execute, clusterState); // dry-run
+        assertSame(execute, clusterState); // dry-run should keep the current cluster state
         task.onAllNodesAcked();
         assertNotSame(responseRef.get().getState(), execute);
+    }
 
-        req.dryRun(false);// now we allocate
+    public void testClusterStateUpdateTask() {
+        AllocationService allocationService = new AllocationService(
+            new AllocationDeciders(List.of(new MaxRetryAllocationDecider())),
+            new TestGatewayAllocator(),
+            new BalancedShardsAllocator(Settings.EMPTY),
+            EmptyClusterInfoService.INSTANCE,
+            EmptySnapshotsInfoService.INSTANCE
+        );
+        ClusterState clusterState = createInitialClusterState(allocationService);
+
+        var req = new ClusterRerouteRequest().dryRun(false);
+        var task = new TransportClusterRerouteAction.ClusterRerouteResponseAckedClusterStateUpdateTask(
+            logger,
+            allocationService,
+            req,
+            ActionListener.noop()
+        );
 
         final int retries = MaxRetryAllocationDecider.SETTING_ALLOCATION_MAX_RETRY.get(Settings.EMPTY);
         // now fail it N-1 times
         for (int i = 0; i < retries; i++) {
+            // execute task
             ClusterState newState = task.execute(clusterState);
-            assertNotSame(newState, clusterState); // dry-run=false
+            assertNotSame(newState, clusterState);
+            assertStateAndFailedAllocations(newState.routingTable().index("idx"), INITIALIZING, i);
             clusterState = newState;
-            RoutingTable routingTable = clusterState.routingTable();
-            assertEquals(routingTable.index("idx").size(), 1);
-            assertEquals(routingTable.index("idx").shard(0).shard(0).state(), INITIALIZING);
-            assertEquals(routingTable.index("idx").shard(0).shard(0).unassignedInfo().getNumFailedAllocations(), i);
-            List<FailedShard> failedShards = Collections.singletonList(
-                new FailedShard(
-                    routingTable.index("idx").shard(0).shard(0),
-                    "boom" + i,
-                    new UnsupportedOperationException(),
-                    randomBoolean()
-                )
+
+            // apply failed shards
+            newState = allocationService.applyFailedShards(
+                clusterState,
+                List.of(
+                    new FailedShard(
+                        clusterState.routingTable().index("idx").shard(0).shard(0),
+                        "boom" + i,
+                        new RuntimeException("test-failure"),
+                        randomBoolean()
+                    )
+                ),
+                List.of()
             );
-            newState = allocationService.applyFailedShards(clusterState, failedShards, List.of());
             assertThat(newState, not(equalTo(clusterState)));
+            assertStateAndFailedAllocations(newState.routingTable().index("idx"), i == retries - 1 ? UNASSIGNED : INITIALIZING, i + 1);
             clusterState = newState;
-            routingTable = clusterState.routingTable();
-            assertEquals(routingTable.index("idx").size(), 1);
-            if (i == retries - 1) {
-                assertEquals(routingTable.index("idx").shard(0).shard(0).state(), UNASSIGNED);
-            } else {
-                assertEquals(routingTable.index("idx").shard(0).shard(0).state(), INITIALIZING);
-            }
-            assertEquals(routingTable.index("idx").shard(0).shard(0).unassignedInfo().getNumFailedAllocations(), i + 1);
         }
 
         // without retry_failed we won't allocate that shard
         ClusterState newState = task.execute(clusterState);
-        assertNotSame(newState, clusterState); // dry-run=false
-        task.onAllNodesAcked();
-        assertSame(responseRef.get().getState(), newState);
-        RoutingTable routingTable = clusterState.routingTable();
-        assertEquals(routingTable.index("idx").size(), 1);
-        assertEquals(routingTable.index("idx").shard(0).shard(0).state(), UNASSIGNED);
-        assertEquals(routingTable.index("idx").shard(0).shard(0).unassignedInfo().getNumFailedAllocations(), retries);
+        assertNotSame(newState, clusterState);
+        assertStateAndFailedAllocations(clusterState.routingTable().index("idx"), UNASSIGNED, retries);
 
         req.setRetryFailed(true); // now we manually retry and get the shard back into initializing
         newState = task.execute(clusterState);
         assertNotSame(newState, clusterState); // dry-run=false
-        clusterState = newState;
-        routingTable = clusterState.routingTable();
-        assertEquals(1, routingTable.index("idx").size());
-        assertEquals(INITIALIZING, routingTable.index("idx").shard(0).shard(0).state());
-        assertEquals(0, routingTable.index("idx").shard(0).shard(0).unassignedInfo().getNumFailedAllocations());
+        assertStateAndFailedAllocations(newState.routingTable().index("idx"), INITIALIZING, 0);
+    }
+
+    private void assertStateAndFailedAllocations(IndexRoutingTable indexRoutingTable, ShardRoutingState state, int failedAllocations) {
+        assertThat(indexRoutingTable.size(), equalTo(1));
+        assertThat(indexRoutingTable.shard(0).shard(0).state(), equalTo(state));
+        assertThat(indexRoutingTable.shard(0).shard(0).unassignedInfo().getNumFailedAllocations(), equalTo(failedAllocations));
     }
 
     private ClusterState createInitialClusterState(AllocationService service) {


### PR DESCRIPTION
This pr ports some of the changes from https://github.com/elastic/elasticsearch/pull/88848 to the main branch to minimize the feature branch diff. They are:
* moving `resetFailedAllocationCounter` to a common place in `RoutingNodes` so that it is accessible from multiple allocation service implementation
* splitting `ClusterRerouteTests#testClusterStateUpdateTask` into 2 distinct test scenarios to avoid reusing the task