### PR TITLE
[7.17] Unify handling of custom Gradle User home in build tool tests (#89304)

### DIFF
--- a/build-tools-internal/src/integTest/groovy/org/elasticsearch/gradle/internal/InternalDistributionDownloadPluginFuncTest.groovy
+++ b/build-tools-internal/src/integTest/groovy/org/elasticsearch/gradle/internal/InternalDistributionDownloadPluginFuncTest.groovy
@@ -39,7 +39,7 @@ class InternalDistributionDownloadPluginFuncTest extends AbstractGradleFuncTest 
         """
 
         when:
-        def result = gradleRunner("setupDistro", '-g', testProjectDir.newFolder('GUH').path).build()
+        def result = gradleRunner("setupDistro", '-g', gradleUserHome).build()
 
         then:
         result.task(":distribution:archives:${testArchiveProjectName}:buildExpanded").outcome == TaskOutcome.SUCCESS

--- a/build-tools-internal/src/integTest/groovy/org/elasticsearch/gradle/internal/JdkDownloadPluginFuncTest.groovy
+++ b/build-tools-internal/src/integTest/groovy/org/elasticsearch/gradle/internal/JdkDownloadPluginFuncTest.groovy
@@ -8,6 +8,7 @@
 
 package org.elasticsearch.gradle.internal
 
+import spock.lang.TempDir
 import spock.lang.Unroll
 import com.github.tomakehurst.wiremock.WireMockServer
 
@@ -126,7 +127,7 @@ class JdkDownloadPluginFuncTest extends AbstractGradleFuncTest {
         when:
         def result = WiremockFixture.withWireMock(mockRepoUrl, mockedContent) { server ->
             buildFile << repositoryMockSetup(server, jdkVendor, jdkVersion)
-            gradleRunner('getJdk', '-i', '-g', testProjectDir.newFolder().toString()).build()
+            gradleRunner('getJdk', '-i', '-g', gradleUserHome).build()
         }
 
         then:
@@ -179,13 +180,12 @@ class JdkDownloadPluginFuncTest extends AbstractGradleFuncTest {
         def result = WiremockFixture.withWireMock(mockRepoUrl, mockedContent) { server ->
             buildFile << repositoryMockSetup(server, VENDOR_ADOPTIUM, ADOPT_JDK_VERSION)
 
-            def commonGradleUserHome = testProjectDir.newFolder().toString()
             // initial run
-            def firstResult = gradleRunner('clean', 'getJdk', '-i', '--warning-mode', 'all', '-g', commonGradleUserHome).build()
+            def firstResult = gradleRunner('clean', 'getJdk', '-i', '--warning-mode', 'all', '-g', gradleUserHome).build()
             // assert the output of an executed transform is shown
             assertOutputContains(firstResult.output, "Unpacking $expectedArchiveName using $transformType")
             // run against up-to-date transformations
-            gradleRunner('clean', 'getJdk', '-i', '--warning-mode', 'all', '-g', commonGradleUserHome).build()
+            gradleRunner('clean', 'getJdk', '-i', '--warning-mode', 'all', '-g', gradleUserHome).build()
         }
 
         then:

--- a/build-tools/src/integTest/groovy/org/elasticsearch/gradle/DistributionDownloadPluginFuncTest.groovy
+++ b/build-tools/src/integTest/groovy/org/elasticsearch/gradle/DistributionDownloadPluginFuncTest.groovy
@@ -49,8 +49,7 @@ class DistributionDownloadPluginFuncTest extends AbstractGradleFuncTest {
         """
 
         when:
-        def guh = new File(testProjectDir.getRoot(), "gradle-user-home").absolutePath;
-        def runner = gradleRunner('clean', 'setupDistro', '-i', '-g', guh)
+        def runner = gradleRunner('clean', 'setupDistro', '-i', '-g', gradleUserHome)
         def unpackingMessage = "Unpacking elasticsearch-${version}-linux-${Architecture.current().classifier}.tar.gz " +
                 "using SymbolicLinkPreservingUntarTransform"
         def result = withMockedDistributionDownload(version, platform, runner) {
@@ -92,8 +91,7 @@ class DistributionDownloadPluginFuncTest extends AbstractGradleFuncTest {
         """
 
         when:
-        def customGradleUserHome = testProjectDir.newFolder().absolutePath;
-        def runner = gradleRunner('setupDistro', '-i', '-g', customGradleUserHome)
+        def runner = gradleRunner('setupDistro', '-i', '-g', gradleUserHome)
         def result = withMockedDistributionDownload(version, platform, runner) {
             build()
         }

--- a/build-tools/src/integTest/groovy/org/elasticsearch/gradle/TestClustersPluginFuncTest.groovy
+++ b/build-tools/src/integTest/groovy/org/elasticsearch/gradle/TestClustersPluginFuncTest.groovy
@@ -103,7 +103,7 @@ class TestClustersPluginFuncTest extends AbstractGradleFuncTest {
         """
 
         when:
-        def runner = gradleRunner("myTask", '-i', '-g', 'guh')
+        def runner = gradleRunner("myTask", '-i', '-g', gradleUserHome)
         def runningClosure = { GradleRunner r -> r.build() }
         withMockedDistributionDownload(runner, runningClosure)
         def result = inputProperty == "distributionClasspath" ?
@@ -155,12 +155,12 @@ class TestClustersPluginFuncTest extends AbstractGradleFuncTest {
         """
 
         when:
-        withMockedDistributionDownload(gradleRunner("myTask", '-g', 'guh')) {
+        withMockedDistributionDownload(gradleRunner("myTask", '-g', gradleUserHome)) {
             build()
         }
         fileChange.delegate = this
         fileChange.call(this)
-        def result = withMockedDistributionDownload(gradleRunner("myTask", '-i', '-g', 'guh')) {
+        def result = withMockedDistributionDownload(gradleRunner("myTask", '-i', '-g', gradleUserHome)) {
             build()
         }
 

--- a/build-tools/src/integTest/groovy/org/elasticsearch/gradle/test/GradleTestPolicySetupPluginFuncTest.groovy
+++ b/build-tools/src/integTest/groovy/org/elasticsearch/gradle/test/GradleTestPolicySetupPluginFuncTest.groovy
@@ -50,13 +50,13 @@ class GradleTestPolicySetupPluginFuncTest extends AbstractGradleFuncTest {
         """
 
         when:
-        def result = gradleRunner('test', '-g', "guh1").build()
+        def result = gradleRunner('test', '-g', gradleUserHome).build()
 
         then:
         result.task(":test").outcome == TaskOutcome.SUCCESS
 
         when: // changing gradle user home
-        result = gradleRunner('test', '-g', "guh2").build()
+        result = gradleRunner('test', '-g', gradleUserHome).build()
         then: // still up-to-date
         result.task(":test").outcome == TaskOutcome.UP_TO_DATE
     }

--- a/build-tools/src/testFixtures/groovy/org/elasticsearch/gradle/fixtures/AbstractGradleFuncTest.groovy
+++ b/build-tools/src/testFixtures/groovy/org/elasticsearch/gradle/fixtures/AbstractGradleFuncTest.groovy
@@ -17,6 +17,7 @@ import org.gradle.testkit.runner.GradleRunner
 import org.junit.Rule
 import org.junit.rules.TemporaryFolder
 import spock.lang.Specification
+import spock.lang.TempDir
 
 import java.lang.management.ManagementFactory
 import java.util.jar.JarEntry
@@ -28,6 +29,9 @@ abstract class AbstractGradleFuncTest extends Specification {
 
     @Rule
     TemporaryFolder testProjectDir = new TemporaryFolder()
+
+    @TempDir
+    File gradleUserHome
 
     File settingsFile
     File buildFile
@@ -68,23 +72,22 @@ abstract class AbstractGradleFuncTest extends Specification {
         subProjectBuild
     }
 
-    GradleRunner gradleRunner(String... arguments) {
+    GradleRunner gradleRunner(Object... arguments) {
         return gradleRunner(testProjectDir.root, arguments)
     }
 
-    GradleRunner gradleRunner(File projectDir, String... arguments) {
+    GradleRunner gradleRunner(File projectDir, Object... arguments) {
         return new NormalizeOutputGradleRunner(
-                new InternalAwareGradleRunner(
-                        GradleRunner.create()
-                                .withDebug(ManagementFactory.getRuntimeMXBean().getInputArguments()
-                                        .toString().indexOf("-agentlib:jdwp") > 0
-                                )
-                                .withProjectDir(projectDir)
-                                .withPluginClasspath()
-                                .forwardOutput()
-                ),
-                projectDir
-        ).withArguments(arguments)
+            new InternalAwareGradleRunner(
+                GradleRunner.create()
+                    .withDebug(ManagementFactory.getRuntimeMXBean().getInputArguments()
+                                            .toString().indexOf("-agentlib:jdwp") > 0
+                    )
+                    .withProjectDir(projectDir)
+                    .withPluginClasspath()
+                    .forwardOutput()
+            ).withArguments(arguments.collect { it.toString() })
+        )
     }
 
     def assertOutputContains(String givenOutput, String expected) {

--- a/build-tools/src/testFixtures/java/org/elasticsearch/gradle/internal/test/NormalizeOutputGradleRunner.java
+++ b/build-tools/src/testFixtures/java/org/elasticsearch/gradle/internal/test/NormalizeOutputGradleRunner.java
@@ -27,9 +27,10 @@ import static org.elasticsearch.gradle.internal.test.TestUtils.normalizeString;
 
 public class NormalizeOutputGradleRunner extends GradleRunner {
 
-    public NormalizeOutputGradleRunner(GradleRunner delegate, File projectRootDir) {
+    private GradleRunner delegate;
+
+    public NormalizeOutputGradleRunner(GradleRunner delegate) {
         this.delegate = delegate;
-        this.projectRootDir = projectRootDir;
     }
 
     @Override
@@ -74,7 +75,8 @@ public class NormalizeOutputGradleRunner extends GradleRunner {
 
     @Override
     public GradleRunner withArguments(List<String> arguments) {
-        return delegate.withArguments(arguments);
+        delegate.withArguments(arguments);
+        return this;
     }
 
     @Override
@@ -150,9 +152,6 @@ public class NormalizeOutputGradleRunner extends GradleRunner {
         return new NormalizedBuildResult(delegate.buildAndFail());
     }
 
-    private GradleRunner delegate;
-    private File projectRootDir;
-
     private class NormalizedBuildResult implements BuildResult {
         private BuildResult delegate;
         private String normalizedString;
@@ -164,7 +163,7 @@ public class NormalizeOutputGradleRunner extends GradleRunner {
         @Override
         public String getOutput() {
             if (normalizedString == null) {
-                normalizedString = normalizeString(delegate.getOutput(), projectRootDir);
+                normalizedString = normalizeString(delegate.getOutput(), getProjectDir());
             }
             return normalizedString;
         }


### PR DESCRIPTION
Backports the following commits to 7.17:
 - Unify handling of custom Gradle User home in build tool tests (#89304)