### PR TITLE
Show -Dlicense.key value in test repro info (7.x backport) (#66179) 

### DIFF
--- a/test/framework/src/main/java/org/elasticsearch/test/junit/listeners/ReproduceInfoPrinter.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/junit/listeners/ReproduceInfoPrinter.java
@@ -89,7 +89,6 @@ public class ReproduceInfoPrinter extends RunListener {
             }
         }
         b.append("\"");
-
         GradleMessageBuilder gradleMessageBuilder = new GradleMessageBuilder(b);
         gradleMessageBuilder.appendAllOpts(failure.getDescription());
 
@@ -171,6 +170,7 @@ public class ReproduceInfoPrinter extends RunListener {
             appendOpt("tests.timezone", TimeZone.getDefault().getID());
             appendOpt("tests.distribution", System.getProperty("tests.distribution"));
             appendOpt("runtime.java", Integer.toString(JavaVersion.current().getVersion().get(0)));
+            appendOpt("license.key", System.getProperty("licence.key"));
             appendOpt(ESTestCase.FIPS_SYSPROP, System.getProperty(ESTestCase.FIPS_SYSPROP));
             return this;
         }

--- a/x-pack/plugin/core/build.gradle
+++ b/x-pack/plugin/core/build.gradle
@@ -86,10 +86,11 @@ tasks.named("processResources").configure {
   } else {
     throw new IllegalArgumentException('Property license.key must be set for release build')
   }
-  if (Files.exists(Paths.get(licenseKey)) == false) {
+  File licenseKeyFile = rootProject.file(licenseKey)
+  if (licenseKeyFile.exists() == false) {
     throw new IllegalArgumentException('license.key at specified path [' + licenseKey + '] does not exist')
   }
-  from(licenseKey) {
+  from(licenseKeyFile) {
     rename { String filename -> 'public.key' }
   }
 }


### PR DESCRIPTION
- When a -Dlicense.key sys property is passed to the build we want to consider
this in the test reproduction info message
- Absolute Paths tried to be converted to relative paths relative to workspace
root to allow simply copy & paste
- Also fixes a inconsistency for checking license existence in x-pack plugin core build