### PR TITLE
[8.4] [DOCS] Update search_after section with an example (#89328)

### DIFF
--- a/docs/reference/search/search-your-data/paginate-search-results.asciidoc
+++ b/docs/reference/search/search-your-data/paginate-search-results.asciidoc
@@ -46,7 +46,53 @@ You can use the `search_after` parameter to retrieve the next page of hits
 using a set of <<sort-search-results,sort values>> from the previous page.
 
 Using `search_after` requires multiple search requests with the same `query` and
-`sort` values. If a <<near-real-time,refresh>> occurs between these requests,
+`sort` values. The first step is to run an initial request. The following
+example sorts the results by two fields (`date` and `tie_breaker_id`):
+[source,js]
+--------------------------------------------------
+GET twitter/_search
+{
+    "query": {
+        "match" : {
+            "title" : "elasticsearch"
+        }
+    },
+    "sort": [
+        {"date": "asc"},
+        {"tie_breaker_id": "asc"}      <1>
+    ]
+}
+--------------------------------------------------
+// CONSOLE
+// TEST[setup:twitter]
+// TEST[s/"tie_breaker_id": "asc"/"tie_breaker_id": {"unmapped_type": "keyword"}/]
+
+<1> A copy of the `_id` field with `doc_values` enabled
+
+The search response includes an array of `sort` values for each hit. To retrieve
+the next page of results, repeat the request, take the `sort` values from the
+last hit, and insert those into the `search_after` array:
+[source,js]
+--------------------------------------------------
+GET twitter/_search
+{
+    "query": {
+        "match" : 
+            "title" : "elasticsearch"
+        }
+    },
+    "search_after": [1463538857, "654323"],
+    "sort": [
+        {"date": "asc"},
+        {"tie_breaker_id": "asc"}
+    ]
+}
+--------------------------------------------------
+// CONSOLE
+// TEST[setup:twitter]
+// TEST[s/"tie_breaker_id": "asc"/"tie_breaker_id": {"unmapped_type": "keyword"}/]
+Repeat this process by updating the `search_after` array every time you retrieve a 
+new page of results. If a <<near-real-time,refresh>> occurs between these requests,
 the order of your results may change, causing inconsistent results across pages. To
 prevent this, you can create a <<point-in-time-api,point in time (PIT)>> to
 preserve the current index state over your searches.


### PR DESCRIPTION
Backports the following commits to 8.4:
 - [DOCS] Update search_after section with an example (#89328)