### PR TITLE
Fix ConcurrentSnapshotsIT.testAssertMultipleSnapshotsAndPrimaryFailOver

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/snapshots/ConcurrentSnapshotsIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/snapshots/ConcurrentSnapshotsIT.java
@@ -521,6 +521,7 @@ public class ConcurrentSnapshotsIT extends AbstractSnapshotIntegTestCase {
 
         final String secondSnapshot = "snapshot-two";
         final ActionFuture<CreateSnapshotResponse> secondSnapshotResponse = startFullSnapshotFromMasterClient(repoName, secondSnapshot);
+        awaitNumberOfSnapshotsInProgress(2);
 
         internalCluster().restartNode(dataNode);
 


### PR DESCRIPTION
We have to wait for the snapshot to actually have started before we restart
the data node. This is not guaranteed since we start the snapshot via an async
client call. Otherwise the expectation of partial snapshot failure will not hold
because we will only partially fail if the data node has actually started work on
the snapshot when it's restarted.

closes #89039
