### PR TITLE
Fix BlobStoreIncrementalityIT.testRecordCorrectSegmentCountsWithBackgroundMerges

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/snapshots/BlobStoreIncrementalityIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/snapshots/BlobStoreIncrementalityIT.java
@@ -197,7 +197,7 @@ public class BlobStoreIncrementalityIT extends AbstractSnapshotIntegTestCase {
 
         // create a situation where we temporarily have a bunch of segments until the merges can catch up
         long id = 0;
-        final int rounds = scaledRandomIntBetween(3, 5);
+        final int rounds = scaledRandomIntBetween(5, 9);
         for (int i = 0; i < rounds; ++i) {
             final int numDocs = scaledRandomIntBetween(100, 1000);
             BulkRequestBuilder request = client().prepareBulk().setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE);


### PR DESCRIPTION
Create more segments here to make sure the background merge always merges.
With just 3 segments and a max-segments-per-tier of 2 we don't have the guarantee
that a merge will actually run and hence the test will fail when waiting for the background
merge.

closes #89412
