### PR TITLE
Suppress response headers from reroute calls

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/admin/indices/create/AutoCreateAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/create/AutoCreateAction.java
@@ -121,7 +121,9 @@ public final class AutoCreateAction extends ActionType<CreateIndexResponse> {
                     }
                 }
                 if (state != batchExecutionContext.initialState()) {
-                    state = allocationService.reroute(state, "auto-create");
+                    try (var ignored = batchExecutionContext.dropHeadersContext()) {
+                        state = allocationService.reroute(state, "auto-create");
+                    }
                 }
                 return state;
             };

--- a/server/src/main/java/org/elasticsearch/cluster/coordination/JoinTaskExecutor.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/JoinTaskExecutor.java
@@ -84,7 +84,10 @@ public class JoinTaskExecutor implements ClusterStateTaskExecutor<JoinTask> {
             // use these joins to try and become the master.
             // Note that we don't have to do any validation of the amount of joining nodes - the commit
             // during the cluster state publishing guarantees that we have enough
-            newState = becomeMasterAndTrimConflictingNodes(initialState, joinTaskContexts, term);
+            try (var ignored = batchExecutionContext.dropHeadersContext()) {
+                // suppress deprecation warnings e.g. from reroute()
+                newState = becomeMasterAndTrimConflictingNodes(initialState, joinTaskContexts, term);
+            }
             nodesChanged = true;
         } else if (currentNodes.isLocalNodeElectedMaster()) {
             assert initialState.term() == term : "term should be stable for the same master";


### PR DESCRIPTION
Adds a call to `batchExecutionContext.dropHeadersContext()` to a couple
of places that #85525 missed.