### PR TITLE
[8.4] Fix BlobStoreIncrementalityIT.testRecordCorrectSegmentCountsWithBackgroundMerges (#89416)

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/snapshots/BlobStoreIncrementalityIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/snapshots/BlobStoreIncrementalityIT.java
@@ -197,7 +197,7 @@ public class BlobStoreIncrementalityIT extends AbstractSnapshotIntegTestCase {
 
         // create a situation where we temporarily have a bunch of segments until the merges can catch up
         long id = 0;
-        final int rounds = scaledRandomIntBetween(3, 5);
+        final int rounds = scaledRandomIntBetween(5, 9);
         for (int i = 0; i < rounds; ++i) {
             final int numDocs = scaledRandomIntBetween(100, 1000);
             BulkRequestBuilder request = client().prepareBulk().setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE);


### PR DESCRIPTION
Backports the following commits to 8.4:
 - Fix BlobStoreIncrementalityIT.testRecordCorrectSegmentCountsWithBackgroundMerges (#89416)