### PR TITLE
Add source fallback support for date and date_nanos mapped types

### DIFF
--- a/docs/changelog/89440.yaml
+++ b/docs/changelog/89440.yaml
@@ -1,0 +1,5 @@
+pr: 89440
+summary: Add source fallback support for date and `date_nanos` mapped types
+area: Mapping
+type: enhancement
+issues: []

--- a/modules/lang-painless/src/yamlRestTest/resources/rest-api-spec/test/painless/50_script_doc_values.yml
+++ b/modules/lang-painless/src/yamlRestTest/resources/rest-api-spec/test/painless/50_script_doc_values.yml
@@ -716,7 +716,7 @@ setup:
           script_fields:
             field:
               script:
-                source: "doc.date.get(0)"
+                source: "doc.date_no_doc_values.get(0)"
   - match: { error.failed_shards.0.reason.caused_by.type: "illegal_argument_exception" }
 
   - do:
@@ -728,7 +728,7 @@ setup:
           script_fields:
             field:
               script:
-                source: "doc.date.value"
+                source: "doc.date_no_doc_values.value"
   - match: { error.failed_shards.0.reason.caused_by.type: "illegal_argument_exception" }
 
   - do:
@@ -739,7 +739,7 @@ setup:
           script_fields:
             field:
               script:
-                source: "field('date').get(null)"
+                source: "field('date_no_doc_values').get(null)"
   - match: { hits.hits.0.fields.field.0: '2017-01-01T12:11:12.000Z' }
 
   - do:
@@ -750,7 +750,7 @@ setup:
           script_fields:
             field:
               script:
-                source: "/* avoid yaml stash */ $('date', null)"
+                source: "/* avoid yaml stash */ $('date_no_doc_values', null)"
   - match: { hits.hits.0.fields.field.0: '2017-01-01T12:11:12.000Z' }
 
   - do:
@@ -761,7 +761,7 @@ setup:
           script_fields:
             field:
               script:
-                source: "doc.date.get(0).getMillis()"
+                source: "field('date_no_doc_values').get(null).getMillis()"
   - match: { hits.hits.0.fields.field.0: 1483272672000 }
 
   - do:
@@ -772,7 +772,7 @@ setup:
           script_fields:
             field:
               script:
-                source: "doc.date.value.getMillis()"
+                source: "/* avoid yaml stash */ $('date_no_doc_values', null).getMillis()"
   - match: { hits.hits.0.fields.field.0: 1483272672000 }
 
   - do:
@@ -783,7 +783,7 @@ setup:
           script_fields:
             field:
               script:
-                source: "field('date').get(null).getMillis()"
+                source: "field('date_no_doc_values').get(null).millis"
   - match: { hits.hits.0.fields.field.0: 1483272672000 }
 
   - do:
@@ -794,51 +794,7 @@ setup:
           script_fields:
             field:
               script:
-                source: "/* avoid yaml stash */ $('date', null).getMillis()"
-  - match: { hits.hits.0.fields.field.0: 1483272672000 }
-
-  - do:
-      search:
-        rest_total_hits_as_int: true
-        body:
-          query: { term: { _id: 1 } }
-          script_fields:
-            field:
-              script:
-                source: "doc.date.get(0).millis"
-  - match: { hits.hits.0.fields.field.0: 1483272672000 }
-
-  - do:
-      search:
-        rest_total_hits_as_int: true
-        body:
-          query: { term: { _id: 1 } }
-          script_fields:
-            field:
-              script:
-                source: "doc.date.value.millis"
-  - match: { hits.hits.0.fields.field.0: 1483272672000 }
-
-  - do:
-      search:
-        rest_total_hits_as_int: true
-        body:
-          query: { term: { _id: 1 } }
-          script_fields:
-            field:
-              script:
-                source: "field('date').get(null).millis"
-  - match: { hits.hits.0.fields.field.0: 1483272672000 }
-
-  - do:
-      search:
-        rest_total_hits_as_int: true
-        body:
-          query: { term: { _id: 1 } }
-          script_fields:
-            field:
-              script:
-                source: "/* avoid yaml stash */ $('date', null).millis"
+                source: "/* avoid yaml stash */ $('date_no_doc_values', null).millis"
   - match: { hits.hits.0.fields.field.0: 1483272672000 }
 
   - do:
@@ -849,7 +805,7 @@ setup:
           script_fields:
             field:
               script:
-                source: "field('date').get(ZonedDateTime.parse('2018-01-01T12:11:12.000Z'))"
+                source: "field('date_no_doc_values').get(ZonedDateTime.parse('2018-01-01T12:11:12.000Z'))"
   - match: { hits.hits.0.fields.field.0: '2018-01-01T12:11:12.000Z' }
 
   - do:
@@ -860,7 +816,7 @@ setup:
           script_fields:
             field:
               script:
-                source: "/* avoid yaml stash */ $('date', ZonedDateTime.parse('2018-01-01T12:11:12.000Z'))"
+                source: "/* avoid yaml stash */ $('date_no_doc_values', ZonedDateTime.parse('2018-01-01T12:11:12.000Z'))"
   - match: { hits.hits.0.fields.field.0: '2018-01-01T12:11:12.000Z' }
 
   - do:
@@ -871,7 +827,7 @@ setup:
           script_fields:
             field:
               script:
-                source: "doc['nanos'].value"
+                source: "field('nanos_no_doc_values').get(null)"
   - match: { hits.hits.0.fields.field.0: '2015-01-01T12:10:30.123456789Z' }
 
   - do:
@@ -882,18 +838,7 @@ setup:
           script_fields:
             field:
               script:
-                source: "field('nanos').get(null)"
-  - match: { hits.hits.0.fields.field.0: '2015-01-01T12:10:30.123456789Z' }
-
-  - do:
-      search:
-        rest_total_hits_as_int: true
-        body:
-          query: { term: { _id: "1" } }
-          script_fields:
-            field:
-              script:
-                source: "/* avoid yaml stash */ $('nanos', null)"
+                source: "/* avoid yaml stash */ $('nanos_no_doc_values', null)"
   - match: { hits.hits.0.fields.field.0: '2015-01-01T12:10:30.123456789Z' }
 
   - do:
@@ -904,7 +849,7 @@ setup:
           script_fields:
             field:
               script:
-                source: "field('nanos').get(ZonedDateTime.parse('2016-01-01T12:10:30.123Z'))"
+                source: "field('nanos_no_doc_values').get(ZonedDateTime.parse('2016-01-01T12:10:30.123Z'))"
   - match: { hits.hits.0.fields.field.0: '2016-01-01T12:10:30.123Z' }
 
   - do:
@@ -915,7 +860,7 @@ setup:
           script_fields:
             field:
               script:
-                source: "/* avoid yaml stash */ $('nanos', ZonedDateTime.parse('2016-01-01T12:10:30.123Z'))"
+                source: "/* avoid yaml stash */ $('nanos_no_doc_values', ZonedDateTime.parse('2016-01-01T12:10:30.123Z'))"
   - match: { hits.hits.0.fields.field.0: '2016-01-01T12:10:30.123Z' }
 
   - do:
@@ -926,7 +871,7 @@ setup:
           script_fields:
             field:
               script:
-                source: "doc['nanos'].value.getNano()"
+                source: "field('nanos_no_doc_values').get(null).getNano()"
   - match: { hits.hits.0.fields.field.0: 123456789 }
 
   - do:
@@ -937,18 +882,7 @@ setup:
           script_fields:
             field:
               script:
-                source: "field('nanos').get(null).getNano()"
-  - match: { hits.hits.0.fields.field.0: 123456789 }
-
-  - do:
-      search:
-        rest_total_hits_as_int: true
-        body:
-          query: { term: { _id: "1" } }
-          script_fields:
-            field:
-              script:
-                source: "/* avoid yaml stash */ $('nanos', null).getNano()"
+                source: "/* avoid yaml stash */ $('nanos_no_doc_values', null).getNano()"
   - match: { hits.hits.0.fields.field.0: 123456789 }
 
   - do:
@@ -959,7 +893,7 @@ setup:
           script_fields:
             field:
               script:
-                source: "field('nanos').get(ZonedDateTime.parse('2016-01-01T12:10:30.123Z')).getNano()"
+                source: "field('nanos_no_doc_values').get(ZonedDateTime.parse('2016-01-01T12:10:30.123Z')).getNano()"
   - match: { hits.hits.0.fields.field.0: 123000000 }
 
   - do:
@@ -970,7 +904,7 @@ setup:
           script_fields:
             field:
               script:
-                source: "field('date').get(1, null)"
+                source: "field('date_no_doc_values').get(1, null)"
   - match: { hits.hits.0.fields.field.0: "2018-01-01T12:11:12.000Z" }
 
   - do:
@@ -981,7 +915,7 @@ setup:
           script_fields:
             field:
               script:
-                source: "field('nanos').get(1, null)"
+                source: "field('nanos_no_doc_values').get(1, null)"
   - match: { hits.hits.0.fields.field.0: "2015-01-01T12:10:30.987654321Z" }
 
   - do:
@@ -992,7 +926,7 @@ setup:
           script_fields:
             field:
               script:
-                source: "List times = new ArrayList(); for (ZonedDateTime zdt : field('date')) times.add(zdt); times"
+                source: "List times = new ArrayList(); for (ZonedDateTime zdt : field('date_no_doc_values')) times.add(zdt); times"
   - match: { hits.hits.0.fields.field: ["2017-01-01T12:11:12.000Z", "2018-01-01T12:11:12.000Z"] }
 
   - do:
@@ -1003,7 +937,7 @@ setup:
           script_fields:
             field:
               script:
-                source: "List times = new ArrayList(); for (ZonedDateTime zdt : field('nanos')) times.add(zdt); times"
+                source: "List times = new ArrayList(); for (ZonedDateTime zdt : field('nanos_no_doc_values')) times.add(zdt); times"
   - match: { hits.hits.0.fields.field: ["2015-01-01T12:10:30.123456789Z", "2015-01-01T12:10:30.987654321Z"] }
 
 ---

--- a/modules/lang-painless/src/yamlRestTest/resources/rest-api-spec/test/painless/50_script_doc_values.yml
+++ b/modules/lang-painless/src/yamlRestTest/resources/rest-api-spec/test/painless/50_script_doc_values.yml
@@ -14,8 +14,14 @@ setup:
                             doc_values: false
                         date:
                             type: date
+                        date_no_doc_values:
+                            type: date
+                            doc_values: false
                         nanos:
                             type: date_nanos
+                        nanos_no_doc_values:
+                            type: date_nanos
+                            doc_values: false
                         geo_point:
                             type: geo_point
                         geo_point_no_doc_values:
@@ -93,7 +99,9 @@ setup:
                 boolean: true
                 boolean_no_doc_values: true
                 date: 2017-01-01T12:11:12
+                date_no_doc_values: 2017-01-01T12:11:12
                 nanos: 2015-01-01T12:10:30.123456789Z
+                nanos_no_doc_values: 2015-01-01T12:10:30.123456789Z
                 geo_point: 41.12,-71.34
                 geo_point_no_doc_values: 41.12,-71.34
                 ip: 192.168.0.19
@@ -136,7 +144,9 @@ setup:
               boolean_no_doc_values: [true, false, true]
               ip: ["10.1.2.3", "2001:db8::2:1"]
               date: [2017-01-01T12:11:12, 2018-01-01T12:11:12]
+              date_no_doc_values: [2017-01-01T12:11:12, 2018-01-01T12:11:12]
               nanos: [2015-01-01T12:10:30.123456789Z, 2015-01-01T12:10:30.987654321Z]
+              nanos_no_doc_values: [2015-01-01T12:10:30.123456789Z, 2015-01-01T12:10:30.987654321Z]
               geo_point: [[-71.34,41.12],[60.32,21.25]]
               geo_point_no_doc_values: [[60.32,21.25],[-71.34,41.12]]
               keyword: ["one string", "another string"]
@@ -691,6 +701,310 @@ setup:
                 script:
                   source: "List times = new ArrayList(); for (ZonedDateTime zdt : field('nanos')) times.add(zdt); times"
     - match: { hits.hits.0.fields.field: ["2015-01-01T12:10:30.123456789Z", "2015-01-01T12:10:30.987654321Z"] }
+
+---
+"date_no_doc_values":
+  - skip:
+      features: "warnings"
+
+  - do:
+      catch: bad_request
+      search:
+        rest_total_hits_as_int: true
+        body:
+          query: { term: { _id: "1" } }
+          script_fields:
+            field:
+              script:
+                source: "doc.date.get(0)"
+  - match: { error.failed_shards.0.reason.caused_by.type: "illegal_argument_exception" }
+
+  - do:
+      catch: bad_request
+      search:
+        rest_total_hits_as_int: true
+        body:
+          query: { term: { _id: "1" } }
+          script_fields:
+            field:
+              script:
+                source: "doc.date.value"
+  - match: { error.failed_shards.0.reason.caused_by.type: "illegal_argument_exception" }
+
+  - do:
+      search:
+        rest_total_hits_as_int: true
+        body:
+          query: { term: { _id: "1" } }
+          script_fields:
+            field:
+              script:
+                source: "field('date').get(null)"
+  - match: { hits.hits.0.fields.field.0: '2017-01-01T12:11:12.000Z' }
+
+  - do:
+      search:
+        rest_total_hits_as_int: true
+        body:
+          query: { term: { _id: "1" } }
+          script_fields:
+            field:
+              script:
+                source: "/* avoid yaml stash */ $('date', null)"
+  - match: { hits.hits.0.fields.field.0: '2017-01-01T12:11:12.000Z' }
+
+  - do:
+      search:
+        rest_total_hits_as_int: true
+        body:
+          query: { term: { _id: 1 } }
+          script_fields:
+            field:
+              script:
+                source: "doc.date.get(0).getMillis()"
+  - match: { hits.hits.0.fields.field.0: 1483272672000 }
+
+  - do:
+      search:
+        rest_total_hits_as_int: true
+        body:
+          query: { term: { _id: 1 } }
+          script_fields:
+            field:
+              script:
+                source: "doc.date.value.getMillis()"
+  - match: { hits.hits.0.fields.field.0: 1483272672000 }
+
+  - do:
+      search:
+        rest_total_hits_as_int: true
+        body:
+          query: { term: { _id: 1 } }
+          script_fields:
+            field:
+              script:
+                source: "field('date').get(null).getMillis()"
+  - match: { hits.hits.0.fields.field.0: 1483272672000 }
+
+  - do:
+      search:
+        rest_total_hits_as_int: true
+        body:
+          query: { term: { _id: 1 } }
+          script_fields:
+            field:
+              script:
+                source: "/* avoid yaml stash */ $('date', null).getMillis()"
+  - match: { hits.hits.0.fields.field.0: 1483272672000 }
+
+  - do:
+      search:
+        rest_total_hits_as_int: true
+        body:
+          query: { term: { _id: 1 } }
+          script_fields:
+            field:
+              script:
+                source: "doc.date.get(0).millis"
+  - match: { hits.hits.0.fields.field.0: 1483272672000 }
+
+  - do:
+      search:
+        rest_total_hits_as_int: true
+        body:
+          query: { term: { _id: 1 } }
+          script_fields:
+            field:
+              script:
+                source: "doc.date.value.millis"
+  - match: { hits.hits.0.fields.field.0: 1483272672000 }
+
+  - do:
+      search:
+        rest_total_hits_as_int: true
+        body:
+          query: { term: { _id: 1 } }
+          script_fields:
+            field:
+              script:
+                source: "field('date').get(null).millis"
+  - match: { hits.hits.0.fields.field.0: 1483272672000 }
+
+  - do:
+      search:
+        rest_total_hits_as_int: true
+        body:
+          query: { term: { _id: 1 } }
+          script_fields:
+            field:
+              script:
+                source: "/* avoid yaml stash */ $('date', null).millis"
+  - match: { hits.hits.0.fields.field.0: 1483272672000 }
+
+  - do:
+      search:
+        rest_total_hits_as_int: true
+        body:
+          query: { term: { _id: "2" } }
+          script_fields:
+            field:
+              script:
+                source: "field('date').get(ZonedDateTime.parse('2018-01-01T12:11:12.000Z'))"
+  - match: { hits.hits.0.fields.field.0: '2018-01-01T12:11:12.000Z' }
+
+  - do:
+      search:
+        rest_total_hits_as_int: true
+        body:
+          query: { term: { _id: "2" } }
+          script_fields:
+            field:
+              script:
+                source: "/* avoid yaml stash */ $('date', ZonedDateTime.parse('2018-01-01T12:11:12.000Z'))"
+  - match: { hits.hits.0.fields.field.0: '2018-01-01T12:11:12.000Z' }
+
+  - do:
+      search:
+        rest_total_hits_as_int: true
+        body:
+          query: { term: { _id: "1" } }
+          script_fields:
+            field:
+              script:
+                source: "doc['nanos'].value"
+  - match: { hits.hits.0.fields.field.0: '2015-01-01T12:10:30.123456789Z' }
+
+  - do:
+      search:
+        rest_total_hits_as_int: true
+        body:
+          query: { term: { _id: "1" } }
+          script_fields:
+            field:
+              script:
+                source: "field('nanos').get(null)"
+  - match: { hits.hits.0.fields.field.0: '2015-01-01T12:10:30.123456789Z' }
+
+  - do:
+      search:
+        rest_total_hits_as_int: true
+        body:
+          query: { term: { _id: "1" } }
+          script_fields:
+            field:
+              script:
+                source: "/* avoid yaml stash */ $('nanos', null)"
+  - match: { hits.hits.0.fields.field.0: '2015-01-01T12:10:30.123456789Z' }
+
+  - do:
+      search:
+        rest_total_hits_as_int: true
+        body:
+          query: { term: { _id: "2" } }
+          script_fields:
+            field:
+              script:
+                source: "field('nanos').get(ZonedDateTime.parse('2016-01-01T12:10:30.123Z'))"
+  - match: { hits.hits.0.fields.field.0: '2016-01-01T12:10:30.123Z' }
+
+  - do:
+      search:
+        rest_total_hits_as_int: true
+        body:
+          query: { term: { _id: "2" } }
+          script_fields:
+            field:
+              script:
+                source: "/* avoid yaml stash */ $('nanos', ZonedDateTime.parse('2016-01-01T12:10:30.123Z'))"
+  - match: { hits.hits.0.fields.field.0: '2016-01-01T12:10:30.123Z' }
+
+  - do:
+      search:
+        rest_total_hits_as_int: true
+        body:
+          query: { term: { _id: "1" } }
+          script_fields:
+            field:
+              script:
+                source: "doc['nanos'].value.getNano()"
+  - match: { hits.hits.0.fields.field.0: 123456789 }
+
+  - do:
+      search:
+        rest_total_hits_as_int: true
+        body:
+          query: { term: { _id: "1" } }
+          script_fields:
+            field:
+              script:
+                source: "field('nanos').get(null).getNano()"
+  - match: { hits.hits.0.fields.field.0: 123456789 }
+
+  - do:
+      search:
+        rest_total_hits_as_int: true
+        body:
+          query: { term: { _id: "1" } }
+          script_fields:
+            field:
+              script:
+                source: "/* avoid yaml stash */ $('nanos', null).getNano()"
+  - match: { hits.hits.0.fields.field.0: 123456789 }
+
+  - do:
+      search:
+        rest_total_hits_as_int: true
+        body:
+          query: { term: { _id: "2" } }
+          script_fields:
+            field:
+              script:
+                source: "field('nanos').get(ZonedDateTime.parse('2016-01-01T12:10:30.123Z')).getNano()"
+  - match: { hits.hits.0.fields.field.0: 123000000 }
+
+  - do:
+      search:
+        rest_total_hits_as_int: true
+        body:
+          query: { term: { _id: "3" } }
+          script_fields:
+            field:
+              script:
+                source: "field('date').get(1, null)"
+  - match: { hits.hits.0.fields.field.0: "2018-01-01T12:11:12.000Z" }
+
+  - do:
+      search:
+        rest_total_hits_as_int: true
+        body:
+          query: { term: { _id: "3" } }
+          script_fields:
+            field:
+              script:
+                source: "field('nanos').get(1, null)"
+  - match: { hits.hits.0.fields.field.0: "2015-01-01T12:10:30.987654321Z" }
+
+  - do:
+      search:
+        rest_total_hits_as_int: true
+        body:
+          query: { term: { _id: "3" } }
+          script_fields:
+            field:
+              script:
+                source: "List times = new ArrayList(); for (ZonedDateTime zdt : field('date')) times.add(zdt); times"
+  - match: { hits.hits.0.fields.field: ["2017-01-01T12:11:12.000Z", "2018-01-01T12:11:12.000Z"] }
+
+  - do:
+      search:
+        rest_total_hits_as_int: true
+        body:
+          query: { term: { _id: "3" } }
+          script_fields:
+            field:
+              script:
+                source: "List times = new ArrayList(); for (ZonedDateTime zdt : field('nanos')) times.add(zdt); times"
+  - match: { hits.hits.0.fields.field: ["2015-01-01T12:10:30.123456789Z", "2015-01-01T12:10:30.987654321Z"] }
 
 ---
 "geo_point":

--- a/server/src/main/java/org/elasticsearch/index/mapper/DateFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/DateFieldMapper.java
@@ -33,14 +33,11 @@ import org.elasticsearch.common.time.DateUtils;
 import org.elasticsearch.common.util.LocaleUtils;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.core.TimeValue;
-import org.elasticsearch.index.fielddata.FieldData;
 import org.elasticsearch.index.fielddata.FieldDataContext;
 import org.elasticsearch.index.fielddata.IndexFieldData;
 import org.elasticsearch.index.fielddata.IndexNumericFieldData.NumericType;
-import org.elasticsearch.index.fielddata.SourceValueFetcherSortedBinaryIndexFieldData;
 import org.elasticsearch.index.fielddata.SourceValueFetcherSortedNumericIndexFieldData;
 import org.elasticsearch.index.fielddata.plain.SortedNumericIndexFieldData;
-import org.elasticsearch.index.fielddata.plain.SortedSetOrdinalsIndexFieldData;
 import org.elasticsearch.index.query.DateRangeIncludingNowQuery;
 import org.elasticsearch.index.query.QueryRewriteContext;
 import org.elasticsearch.index.query.SearchExecutionContext;
@@ -50,10 +47,8 @@ import org.elasticsearch.script.ScriptCompiler;
 import org.elasticsearch.script.SortedNumericDocValuesLongFieldScript;
 import org.elasticsearch.script.field.DateMillisDocValuesField;
 import org.elasticsearch.script.field.DateNanosDocValuesField;
-import org.elasticsearch.script.field.KeywordDocValuesField;
 import org.elasticsearch.script.field.ToScriptFieldFactory;
 import org.elasticsearch.search.DocValueFormat;
-import org.elasticsearch.search.aggregations.support.CoreValuesSourceType;
 import org.elasticsearch.search.lookup.FieldValues;
 import org.elasticsearch.search.lookup.SearchLookup;
 import org.elasticsearch.search.runtime.LongScriptFieldDistanceFeatureQuery;
@@ -775,7 +770,11 @@ public final class DateFieldMapper extends FieldMapper {
             }
 
             if ((operation == FielddataOperation.SEARCH || operation == FielddataOperation.SCRIPT) && hasDocValues()) {
-                return new SortedNumericIndexFieldData.Builder(name(), resolution.numericType(), resolution.getDefaultToScriptFieldFactory());
+                return new SortedNumericIndexFieldData.Builder(
+                    name(),
+                    resolution.numericType(),
+                    resolution.getDefaultToScriptFieldFactory()
+                );
             }
 
             if (operation == FielddataOperation.SCRIPT) {


### PR DESCRIPTION
This change adds source fallback support for date and date_nanos by using the existing `SourceValueFetcherSortedNumericIndexFieldData` to emulate doc values.