### PR TITLE
Remove LegacyClusterTaskResultActionListener

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/admin/indices/create/AutoCreateAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/create/AutoCreateAction.java
@@ -161,11 +161,6 @@ public final class AutoCreateAction extends ActionType<CreateIndexResponse> {
                 listener.onFailure(e);
             }
 
-            @Override
-            public void clusterStateProcessed(ClusterState oldState, ClusterState newState) {
-                assert false : "should not be called";
-            }
-
             private ClusterStateAckListener getAckListener(String indexName) {
                 return new ClusterStateAckListener() {
                     @Override

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/rollover/TransportRolloverAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/rollover/TransportRolloverAction.java
@@ -241,15 +241,9 @@ public class TransportRolloverAction extends TransportMasterNodeAction<RolloverR
         RolloverResponse trialRolloverResponse,
         ActionListener<RolloverResponse> listener
     ) implements ClusterStateTaskListener {
-
         @Override
         public void onFailure(Exception e) {
             listener.onFailure(e);
-        }
-
-        @Override
-        public void clusterStateProcessed(ClusterState oldState, ClusterState newState) {
-            assert false : "not called";
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/cluster/ClusterStateTaskExecutor.java
+++ b/server/src/main/java/org/elasticsearch/cluster/ClusterStateTaskExecutor.java
@@ -74,23 +74,6 @@ public interface ClusterStateTaskExecutor<T extends ClusterStateTaskListener> {
     }
 
     /**
-     * A {@link Consumer} for passing to {@link ClusterStateTaskExecutor.TaskContext#success} which preserves the
-     * legacy behaviour of calling {@link ClusterStateTaskListener#clusterStateProcessed} or {@link ClusterStateTaskListener#onFailure}.
-     * <p>
-     * New implementations should use a dedicated listener rather than relying on this legacy behaviour.
-     */
-    // TODO remove all remaining usages of this listener
-    @Deprecated
-    record LegacyClusterTaskResultActionListener(ClusterStateTaskListener task, ClusterState originalState)
-        implements
-            Consumer<ClusterState> {
-        @Override
-        public void accept(ClusterState publishedState) {
-            task.clusterStateProcessed(originalState, publishedState);
-        }
-    }
-
-    /**
      * A task to be executed, along with callbacks for the executor to record the outcome of this task's execution. The executor must
      * call exactly one of these methods for every task in its batch.
      */
@@ -108,10 +91,7 @@ public interface ClusterStateTaskExecutor<T extends ClusterStateTaskListener> {
          * method and must instead call {@link #success(Runnable, ClusterStateAckListener)}, passing the task itself as the {@code
          * clusterStateAckListener} argument.
          *
-         * @param onPublicationSuccess An action executed when (if?) the cluster state update succeeds. The task's {@link
-         *                             ClusterStateTaskListener#clusterStateProcessed} method is not called directly by the master
-         *                             service once the task execution has succeeded, but legacy implementations may supply a listener
-         *                             which calls this methods.
+         * @param onPublicationSuccess An action executed when (if?) the cluster state update succeeds.
          */
         void success(Runnable onPublicationSuccess);
 
@@ -122,10 +102,7 @@ public interface ClusterStateTaskExecutor<T extends ClusterStateTaskListener> {
          * method and must instead call {@link #success(Consumer, ClusterStateAckListener)}, passing the task itself as the {@code
          * clusterStateAckListener} argument.
          *
-         * @param publishedStateConsumer A consumer of the cluster state that was ultimately published. The task's {@link
-         *                               ClusterStateTaskListener#clusterStateProcessed} method is not called directly by the master
-         *                               service once the task execution has succeeded, but legacy implementations may supply a listener
-         *                               which calls this methods.
+         * @param publishedStateConsumer A consumer of the cluster state that was ultimately published.
          *                               <p>
          *                               The consumer should prefer not to use the published state for things like determining the result
          *                               of a task. The task may have been executed as part of a batch, and later tasks in the batch may
@@ -143,10 +120,7 @@ public interface ClusterStateTaskExecutor<T extends ClusterStateTaskListener> {
          * Note that some tasks implement {@link ClusterStateAckListener} and can listen for acks themselves. If so, you must pass the task
          * itself as the {@code clusterStateAckListener} argument.
          *
-         * @param onPublicationSuccess An action executed when (if?) the cluster state update succeeds. The task's {@link
-         *                             ClusterStateTaskListener#clusterStateProcessed} method is not called directly by the master
-         *                             service once the task execution has succeeded, but legacy implementations may supply a listener
-         *                             which calls this methods.
+         * @param onPublicationSuccess An action executed when (if?) the cluster state update succeeds.
          *
          * @param clusterStateAckListener A listener for acknowledgements from nodes. If the publication succeeds then this listener is
          *                                completed as nodes ack the state update. If the publication fails then the failure
@@ -160,10 +134,7 @@ public interface ClusterStateTaskExecutor<T extends ClusterStateTaskListener> {
          * Note that some tasks implement {@link ClusterStateAckListener} and can listen for acks themselves. If so, you must pass the task
          * itself as the {@code clusterStateAckListener} argument.
          *
-         * @param publishedStateConsumer A consumer of the cluster state that was ultimately published. The task's {@link
-         *                               ClusterStateTaskListener#clusterStateProcessed} method is not called directly by the master
-         *                               service once the task execution has succeeded, but legacy implementations may supply a listener
-         *                               which calls this methods.
+         * @param publishedStateConsumer A consumer of the cluster state that was ultimately published.
          *                               <p>
          *                               The consumer should prefer not to use the published state for things like determining the result
          *                               of a task. The task may have been executed as part of a batch, and later tasks in the batch may

--- a/server/src/main/java/org/elasticsearch/cluster/ClusterStateTaskListener.java
+++ b/server/src/main/java/org/elasticsearch/cluster/ClusterStateTaskListener.java
@@ -12,7 +12,6 @@ import org.elasticsearch.cluster.metadata.ProcessClusterEventTimeoutException;
 import org.elasticsearch.cluster.service.MasterService;
 
 public interface ClusterStateTaskListener {
-
     /**
      * A callback for when task execution fails. May receive a {@link NotMasterException} if this node stopped being the master before this
      * task was executed or a {@link ProcessClusterEventTimeoutException} if the task timed out before it was executed. If the task fails
@@ -28,19 +27,4 @@ public interface ClusterStateTaskListener {
      * implementations must do so themselves, typically using a more specific logger and at a less dramatic log level.
      */
     void onFailure(Exception e);
-
-    /**
-     * Called when the result of the {@link ClusterStateTaskExecutor#execute} method has been processed properly by all listeners.
-     *
-     * The {@param newState} parameter is the state that was ultimately published. This can lead to surprising behaviour if tasks are
-     * batched together: a later task in the batch may undo or overwrite the changes made by an earlier task. In general you should prefer
-     * to ignore the published state and instead handle the success of a publication via the listener that the executor passes to
-     * {@link ClusterStateTaskExecutor.TaskContext#success}.
-     *
-     * Implementations of this callback must not throw exceptions: an exception thrown here is logged by the master service at {@code ERROR}
-     * level and otherwise ignored, except in tests where it raises an {@link AssertionError}. If log-and-ignore is the right behaviour then
-     * implementations must do so themselves, typically using a more specific logger and at a less dramatic log level.
-     */
-    // TODO: replace all remaining usages of this method with dedicated listeners and then remove it.
-    default void clusterStateProcessed(ClusterState oldState, ClusterState newState) {}
 }

--- a/server/src/main/java/org/elasticsearch/cluster/ClusterStateUpdateTask.java
+++ b/server/src/main/java/org/elasticsearch/cluster/ClusterStateUpdateTask.java
@@ -8,9 +8,6 @@
 
 package org.elasticsearch.cluster;
 
-import org.elasticsearch.cluster.coordination.FailedToCommitClusterStateException;
-import org.elasticsearch.cluster.metadata.ProcessClusterEventTimeoutException;
-import org.elasticsearch.cluster.service.MasterService;
 import org.elasticsearch.common.Priority;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.core.TimeValue;
@@ -50,20 +47,15 @@ public abstract class ClusterStateUpdateTask implements ClusterStateTaskConfig, 
     public abstract ClusterState execute(ClusterState currentState) throws Exception;
 
     /**
-     * A callback for when task execution fails. May receive a {@link NotMasterException} if this node stopped being the master before this
-     * task was executed or a {@link ProcessClusterEventTimeoutException} if the task timed out before it was executed. If the task fails
-     * during execution then this method receives the corresponding exception. If the task executes successfully but the resulting cluster
-     * state publication fails then this method receives a {@link FailedToCommitClusterStateException}. If publication fails then a new
-     * master is elected and the update might or might not take effect, depending on whether or not the newly-elected master accepted the
-     * published state that failed to be committed.
-     * <p>
-     * Use {@link MasterService#isPublishFailureException} to detect the "expected" master failure cases if needed.
-     * <p>
-     * Implementations of this callback should not throw exceptions: an exception thrown here is logged by the master service at {@code
-     * ERROR} level and otherwise ignored. If log-and-ignore is the right behaviour then implementations should do so themselves, typically
-     * using a more specific logger and at a less dramatic log level.
+     * Called when the result of the {@link #execute} method has been processed properly by all listeners.
+     *
+     * The {@param newState} parameter is the state that was ultimately published.
+     *
+     * Implementations of this callback must not throw exceptions: an exception thrown here is logged by the master service at {@code ERROR}
+     * level and otherwise ignored, except in tests where it raises an {@link AssertionError}. If log-and-ignore is the right behaviour then
+     * implementations must do so themselves, typically using a more specific logger and at a less dramatic log level.
      */
-    public abstract void onFailure(Exception e);
+    public void clusterStateProcessed(ClusterState initialState, ClusterState newState) {}
 
     /**
      * If the cluster state update task wasn't processed by the provided timeout, call

--- a/server/src/main/java/org/elasticsearch/cluster/LocalMasterServiceTask.java
+++ b/server/src/main/java/org/elasticsearch/cluster/LocalMasterServiceTask.java
@@ -25,11 +25,6 @@ public abstract class LocalMasterServiceTask implements ClusterStateTaskListener
 
     protected void execute(ClusterState currentState) {}
 
-    @Override
-    public final void clusterStateProcessed(ClusterState oldState, ClusterState newState) {
-        assert false : "not called";
-    }
-
     protected void onPublicationComplete() {}
 
     public void submit(MasterService masterService, String source) {

--- a/server/src/main/java/org/elasticsearch/cluster/action/shard/ShardStateAction.java
+++ b/server/src/main/java/org/elasticsearch/cluster/action/shard/ShardStateAction.java
@@ -538,7 +538,6 @@ public class ShardStateAction {
     public record FailedShardUpdateTask(FailedShardEntry entry, ActionListener<TransportResponse.Empty> listener)
         implements
             ClusterStateTaskListener {
-
         @Override
         public void onFailure(Exception e) {
             logger.log(
@@ -547,11 +546,6 @@ public class ShardStateAction {
                 e
             );
             listener.onFailure(e);
-        }
-
-        @Override
-        public void clusterStateProcessed(ClusterState oldState, ClusterState newState) {
-            assert false : "should not be called";
         }
     }
 
@@ -857,11 +851,6 @@ public class ShardStateAction {
                 logger.error(() -> format("%s unexpected failure while starting shard [%s]", entry.shardId, entry), e);
             }
             listener.onFailure(e);
-        }
-
-        @Override
-        public void clusterStateProcessed(ClusterState oldState, ClusterState newState) {
-            assert false : "should not be called";
         }
 
         @Override

--- a/server/src/main/java/org/elasticsearch/cluster/coordination/JoinTask.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/JoinTask.java
@@ -9,7 +9,6 @@
 package org.elasticsearch.cluster.coordination;
 
 import org.elasticsearch.action.ActionListener;
-import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.ClusterStateTaskListener;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 
@@ -36,11 +35,6 @@ public record JoinTask(List<NodeJoinTask> nodeJoinTasks, boolean isBecomingMaste
         for (NodeJoinTask nodeJoinTask : nodeJoinTasks) {
             nodeJoinTask.listener.onFailure(e);
         }
-    }
-
-    @Override
-    public void clusterStateProcessed(ClusterState oldState, ClusterState newState) {
-        assert false : "not called";
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/cluster/coordination/NodeRemovalClusterStateTaskExecutor.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/NodeRemovalClusterStateTaskExecutor.java
@@ -33,11 +33,6 @@ public class NodeRemovalClusterStateTaskExecutor implements ClusterStateTaskExec
         }
 
         @Override
-        public void clusterStateProcessed(ClusterState oldState, ClusterState newState) {
-            assert false : "not called";
-        }
-
-        @Override
         public String toString() {
             final StringBuilder stringBuilder = new StringBuilder();
             node.appendDescriptionWithoutAttributes(stringBuilder);

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataIndexStateService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataIndexStateService.java
@@ -211,15 +211,9 @@ public class MetadataIndexStateService {
     private record AddBlocksToCloseTask(CloseIndexClusterStateUpdateRequest request, ActionListener<CloseIndexResponse> listener)
         implements
             ClusterStateTaskListener {
-
         @Override
         public void onFailure(Exception e) {
             listener.onFailure(e);
-        }
-
-        @Override
-        public void clusterStateProcessed(ClusterState oldState, ClusterState newState) {
-            assert false : "not called";
         }
     }
 
@@ -292,15 +286,9 @@ public class MetadataIndexStateService {
         Map<Index, CloseIndexResponse.IndexResult> verifyResults,
         ActionListener<CloseIndexResponse> listener
     ) implements ClusterStateTaskListener {
-
         @Override
         public void onFailure(Exception e) {
             listener.onFailure(e);
-        }
-
-        @Override
-        public void clusterStateProcessed(ClusterState oldState, ClusterState newState) {
-            assert false : "not called";
         }
     }
 
@@ -547,11 +535,6 @@ public class MetadataIndexStateService {
         public void onFailure(Exception e) {
             listener.onFailure(e);
         }
-
-        @Override
-        public void clusterStateProcessed(ClusterState oldState, ClusterState newState) {
-            assert false : "not called";
-        }
     }
 
     private static class FinalizeBlocksExecutor implements ClusterStateTaskExecutor<FinalizeBlocksTask> {
@@ -592,15 +575,9 @@ public class MetadataIndexStateService {
         Map<Index, AddBlockResult> verifyResults,
         ActionListener<AddIndexBlockResponse> listener
     ) implements ClusterStateTaskListener {
-
         @Override
         public void onFailure(Exception e) {
             listener.onFailure(e);
-        }
-
-        @Override
-        public void clusterStateProcessed(ClusterState oldState, ClusterState newState) {
-            assert false : "not called";
         }
     }
 
@@ -1242,11 +1219,6 @@ public class MetadataIndexStateService {
         @Override
         public TimeValue ackTimeout() {
             return request.ackTimeout();
-        }
-
-        @Override
-        public void clusterStateProcessed(ClusterState oldState, ClusterState newState) {
-            assert false : "not called";
         }
     }
 }

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataIndexTemplateService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataIndexTemplateService.java
@@ -158,11 +158,6 @@ public class MetadataIndexTemplateService {
         public void onFailure(Exception e) {
             listener.onFailure(e);
         }
-
-        @Override
-        public void clusterStateProcessed(ClusterState oldState, ClusterState newState) {
-            assert false : "not called";
-        }
     }
 
     @Inject

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataUpdateSettingsService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataUpdateSettingsService.java
@@ -136,11 +136,6 @@ public class MetadataUpdateSettingsService {
             listener.onFailure(e);
         }
 
-        @Override
-        public void clusterStateProcessed(ClusterState oldState, ClusterState newState) {
-            assert false : "should not be called";
-        }
-
         ClusterState execute(ClusterState currentState) {
             final Settings normalizedSettings = Settings.builder()
                 .put(request.settings())

--- a/server/src/main/java/org/elasticsearch/health/metadata/HealthMetadataService.java
+++ b/server/src/main/java/org/elasticsearch/health/metadata/HealthMetadataService.java
@@ -156,11 +156,6 @@ public class HealthMetadataService {
     abstract static class UpsertHealthMetadataTask implements ClusterStateTaskListener {
 
         @Override
-        public void clusterStateProcessed(ClusterState oldState, ClusterState newState) {
-            assert false : "never called";
-        }
-
-        @Override
         public void onFailure(@Nullable Exception e) {
             logger.error("failure during health metadata update", e);
         }

--- a/server/src/main/java/org/elasticsearch/ingest/IngestService.java
+++ b/server/src/main/java/org/elasticsearch/ingest/IngestService.java
@@ -146,11 +146,6 @@ public class IngestService implements ClusterStateApplier, ReportingService<Inge
         public void onFailure(Exception e) {
             listener.onFailure(e);
         }
-
-        @Override
-        public void clusterStateProcessed(ClusterState oldState, ClusterState newState) {
-            assert false : "should not be called";
-        }
     }
 
     public IngestService(

--- a/server/src/main/java/org/elasticsearch/snapshots/SnapshotsService.java
+++ b/server/src/main/java/org/elasticsearch/snapshots/SnapshotsService.java
@@ -3382,11 +3382,6 @@ public class SnapshotsService extends AbstractLifecycleComponent implements Clus
         }
 
         @Override
-        public void clusterStateProcessed(ClusterState oldState, ClusterState newState) {
-            assert false : "never called";
-        }
-
-        @Override
         public boolean equals(Object other) {
             if (this == other) {
                 return true;

--- a/server/src/test/java/org/elasticsearch/cluster/coordination/CoordinatorTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/coordination/CoordinatorTests.java
@@ -16,7 +16,6 @@ import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.Version;
 import org.elasticsearch.cluster.AbstractNamedDiffable;
 import org.elasticsearch.cluster.ClusterState;
-import org.elasticsearch.cluster.ClusterStateTaskListener;
 import org.elasticsearch.cluster.SimpleDiffable;
 import org.elasticsearch.cluster.block.ClusterBlock;
 import org.elasticsearch.cluster.coordination.AbstractCoordinatorTestCase.Cluster.ClusterNode;
@@ -1133,7 +1132,7 @@ public class CoordinatorTests extends AbstractCoordinatorTestCase {
             leader.submitUpdateTask("unchanged", cs -> {
                 computeAdvancer.advanceTime();
                 return cs;
-            }, new ClusterStateTaskListener() {
+            }, new CoordinatorTestClusterStateUpdateTask() {
                 @Override
                 public void clusterStateProcessed(ClusterState oldState, ClusterState newState) {
                     notifyAdvancer.advanceTime();
@@ -1220,7 +1219,7 @@ public class CoordinatorTests extends AbstractCoordinatorTestCase {
             leader.submitUpdateTask("update", cs -> {
                 computeAdvancer.advanceTime();
                 return ClusterState.builder(cs).putCustom(customName, new DelayedCustom(contextAdvancer)).build();
-            }, new ClusterStateTaskListener() {
+            }, new CoordinatorTestClusterStateUpdateTask() {
                 @Override
                 public void clusterStateProcessed(ClusterState oldState, ClusterState newState) {
                     notifyAdvancer.advanceTime();
@@ -1281,7 +1280,7 @@ public class CoordinatorTests extends AbstractCoordinatorTestCase {
             leader.submitUpdateTask("update", cs -> {
                 computeAdvancer.advanceTime();
                 return ClusterState.builder(cs).build();
-            }, new ClusterStateTaskListener() {
+            }, new CoordinatorTestClusterStateUpdateTask() {
                 @Override
                 public void clusterStateProcessed(ClusterState oldState, ClusterState newState) {
                     fail("shouldn't have processed cluster state");

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/MetadataIndexStateServiceBatchingTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/MetadataIndexStateServiceBatchingTests.java
@@ -8,7 +8,6 @@
 
 package org.elasticsearch.cluster.metadata;
 
-import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.ClusterStateListener;
 import org.elasticsearch.cluster.ClusterStateTaskConfig;
 import org.elasticsearch.cluster.ClusterStateTaskListener;
@@ -234,12 +233,6 @@ public class MetadataIndexStateServiceBatchingTests extends ESSingleNodeTestCase
         @Override
         public void onFailure(Exception e) {
             throw new AssertionError("should not be called", e);
-        }
-
-        @Override
-        public void clusterStateProcessed(ClusterState oldState, ClusterState newState) {
-            // see parent method javadoc, we use dedicated listeners rather than calling this method
-            throw new AssertionError("should not be called");
         }
     }
 }

--- a/server/src/test/java/org/elasticsearch/cluster/service/MasterServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/service/MasterServiceTests.java
@@ -668,11 +668,6 @@ public class MasterServiceTests extends ESTestCase {
             }
 
             @Override
-            public void clusterStateProcessed(ClusterState oldState, ClusterState newState) {
-                throw new AssertionError("should not be called");
-            }
-
-            @Override
             public boolean equals(Object o) {
                 if (this == o) {
                     return true;
@@ -850,11 +845,6 @@ public class MasterServiceTests extends ESTestCase {
             }
 
             @Override
-            public void clusterStateProcessed(ClusterState oldState, ClusterState newState) {
-                throw new AssertionError("should not complete task");
-            }
-
-            @Override
             public void onFailure(Exception e) {
                 assertThat(e, instanceOf(RuntimeException.class));
                 assertThat(e.getMessage(), equalTo("simulated"));
@@ -925,11 +915,6 @@ public class MasterServiceTests extends ESTestCase {
             Task(String responseHeaderValue, ActionListener<ClusterState> publishListener) {
                 this.responseHeaderValue = responseHeaderValue;
                 this.publishListener = publishListener;
-            }
-
-            @Override
-            public void clusterStateProcessed(ClusterState oldState, ClusterState newState) {
-                throw new AssertionError("should not complete task");
             }
 
             @Override
@@ -1419,11 +1404,6 @@ public class MasterServiceTests extends ESTestCase {
                     public void onFailure(Exception e) {
                         throw new AssertionError(e);
                     }
-
-                    @Override
-                    public void clusterStateProcessed(ClusterState oldState, ClusterState newState) {
-                        fail();
-                    }
                 }
 
                 masterService.submitStateUpdateTask(
@@ -1466,15 +1446,9 @@ public class MasterServiceTests extends ESTestCase {
                 });
 
                 class Task implements ClusterStateTaskListener {
-
                     @Override
                     public void onFailure(Exception e) {
                         throw new AssertionError(e);
-                    }
-
-                    @Override
-                    public void clusterStateProcessed(ClusterState oldState, ClusterState newState) {
-                        fail();
                     }
                 }
 
@@ -1508,15 +1482,9 @@ public class MasterServiceTests extends ESTestCase {
                 });
 
                 class Task implements ClusterStateTaskListener {
-
                     @Override
                     public void onFailure(Exception e) {
                         throw new AssertionError(e);
-                    }
-
-                    @Override
-                    public void clusterStateProcessed(ClusterState oldState, ClusterState newState) {
-                        fail();
                     }
                 }
 
@@ -1550,15 +1518,9 @@ public class MasterServiceTests extends ESTestCase {
                 });
 
                 class Task implements ClusterStateTaskListener {
-
                     @Override
                     public void onFailure(Exception e) {
                         throw new AssertionError(e);
-                    }
-
-                    @Override
-                    public void clusterStateProcessed(ClusterState oldState, ClusterState newState) {
-                        fail();
                     }
                 }
 
@@ -1990,12 +1952,6 @@ public class MasterServiceTests extends ESTestCase {
         @Override
         public void onFailure(Exception e) {
             throw new AssertionError("should not be called", e);
-        }
-
-        @Override
-        public void clusterStateProcessed(ClusterState oldState, ClusterState newState) {
-            // see parent method javadoc, we use dedicated listeners rather than calling this method
-            throw new AssertionError("should not be called");
         }
     }
 }

--- a/test/framework/src/main/java/org/elasticsearch/cluster/coordination/AbstractCoordinatorTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/cluster/coordination/AbstractCoordinatorTestCase.java
@@ -1435,7 +1435,7 @@ public class AbstractCoordinatorTestCase extends ESTestCase {
                 return submitUpdateTask(
                     "new value [" + key + "=" + value + "]",
                     cs -> setValue(cs, key, value),
-                    new ClusterStateTaskListener() {
+                    new CoordinatorTestClusterStateUpdateTask() {
                         @Override
                         public void clusterStateProcessed(ClusterState oldState, ClusterState newState) {
                             history.respond(eventId, value(oldState, key));
@@ -1460,7 +1460,7 @@ public class AbstractCoordinatorTestCase extends ESTestCase {
 
             void readValue(int key) {
                 final int eventId = history.invoke(new Tuple<>(key, null));
-                submitUpdateTask("read value", cs -> ClusterState.builder(cs).build(), new ClusterStateTaskListener() {
+                submitUpdateTask("read value", cs -> ClusterState.builder(cs).build(), new CoordinatorTestClusterStateUpdateTask() {
                     @Override
                     public void clusterStateProcessed(ClusterState oldState, ClusterState newState) {
                         history.respond(eventId, value(newState, key));
@@ -1478,7 +1478,7 @@ public class AbstractCoordinatorTestCase extends ESTestCase {
             AckCollector submitUpdateTask(
                 String source,
                 UnaryOperator<ClusterState> clusterStateUpdate,
-                ClusterStateTaskListener taskListener
+                CoordinatorTestClusterStateUpdateTask taskListener
             ) {
                 final AckCollector ackCollector = new AckCollector();
                 onNode(() -> {
@@ -1955,5 +1955,9 @@ public class AbstractCoordinatorTestCase extends ESTestCase {
             assert trackedRefs.isEmpty() : trackedRefs;
         }
 
+    }
+
+    public interface CoordinatorTestClusterStateUpdateTask extends ClusterStateTaskListener {
+        default void clusterStateProcessed(ClusterState oldState, ClusterState newState) {}
     }
 }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/license/StartBasicClusterTask.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/license/StartBasicClusterTask.java
@@ -49,11 +49,6 @@ public class StartBasicClusterTask implements ClusterStateTaskListener {
         this.clock = clock;
     }
 
-    @Override
-    public void clusterStateProcessed(ClusterState oldState, ClusterState newState) {
-        assert false : "never called";
-    }
-
     public LicensesMetadata execute(
         LicensesMetadata currentLicensesMetadata,
         DiscoveryNodes discoveryNodes,

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/license/StartTrialClusterTask.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/license/StartTrialClusterTask.java
@@ -56,11 +56,6 @@ public class StartTrialClusterTask implements ClusterStateTaskListener {
         this.clock = clock;
     }
 
-    @Override
-    public void clusterStateProcessed(ClusterState oldState, ClusterState newState) {
-        assert false : "never called";
-    }
-
     private LicensesMetadata execute(
         LicensesMetadata currentLicensesMetadata,
         DiscoveryNodes discoveryNodes,

--- a/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/IndexLifecycleClusterStateUpdateTask.java
+++ b/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/IndexLifecycleClusterStateUpdateTask.java
@@ -10,6 +10,7 @@ package org.elasticsearch.xpack.ilm;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.ClusterStateTaskListener;
+import org.elasticsearch.cluster.ClusterStateUpdateTask;
 import org.elasticsearch.common.util.concurrent.ListenableFuture;
 import org.elasticsearch.index.Index;
 import org.elasticsearch.xpack.core.ilm.Step;
@@ -52,7 +53,6 @@ public abstract class IndexLifecycleClusterStateUpdateTask implements ClusterSta
 
     protected abstract ClusterState doExecute(ClusterState currentState) throws Exception;
 
-    @Override
     public final void clusterStateProcessed(ClusterState oldState, ClusterState newState) {
         listener.onResponse(null);
         if (executed) {
@@ -76,9 +76,9 @@ public abstract class IndexLifecycleClusterStateUpdateTask implements ClusterSta
     }
 
     /**
-     * This method is functionally the same as {@link ClusterStateTaskListener#clusterStateProcessed(ClusterState, ClusterState)}
+     * This method is functionally the same as {@link ClusterStateUpdateTask#clusterStateProcessed}
      * and implementations can override it as they would override {@code ClusterStateUpdateTask#clusterStateProcessed}.
-     * The only difference to  {@code ClusterStateUpdateTask#clusterStateProcessed} is that if the {@link #execute(ClusterState)}
+     * The only difference to  {@link ClusterStateUpdateTask#clusterStateProcessed} is that if the {@link #execute(ClusterState)}
      * implementation was a noop and returned the input cluster state, then this method will not be invoked.
      */
     protected void onClusterStateProcessed(ClusterState newState) {}

--- a/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/IndexLifecycleRunner.java
+++ b/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/IndexLifecycleRunner.java
@@ -69,7 +69,7 @@ class IndexLifecycleRunner {
                             state = task.execute(state);
                         }
                         taskContext.success(
-                            new ClusterStateTaskExecutor.LegacyClusterTaskResultActionListener(task, batchExecutionContext.initialState())
+                            publishedState -> task.clusterStateProcessed(batchExecutionContext.initialState(), publishedState)
                         );
                     } catch (Exception e) {
                         taskContext.onFailure(e);

--- a/x-pack/plugin/rollup/src/main/java/org/elasticsearch/xpack/rollup/v2/TransportRollupAction.java
+++ b/x-pack/plugin/rollup/src/main/java/org/elasticsearch/xpack/rollup/v2/TransportRollupAction.java
@@ -658,10 +658,5 @@ public class TransportRollupAction extends AcknowledgedTransportMasterNodeAction
         public void onFailure(Exception e) {
             listener.onFailure(e);
         }
-
-        @Override
-        public void clusterStateProcessed(ClusterState oldState, ClusterState newState) {
-            assert false : "not called";
-        }
     }
 }


### PR DESCRIPTION
Also removes the now-unused legacy method
`ClusterStateTaskListener#onClusterStateProcessed`.

Closes #83784