### PR TITLE
[7.17] Add YAML spec docs about matching errors (#89370)

### DIFF
--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/README.asciidoc
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/README.asciidoc
@@ -308,8 +308,15 @@ be caught and tested. For instance:
         catch:        missing
         get:
             index:    test
-            type:    test
+            type:     test
             id:        1
+
+# And, optionally, you can assert on the contents of the precise contents of the error message:
+
+    - match: { error.type: "illegal_argument_exception" }
+    - match: { error.reason: "The request contained an illegal argument" }
+    - match: { error.caused_by.reason: "The argument was illegal because ..." }
+    - match: { error.root_cause.0.type: "illegal_argument_exception" }
 ....
 
 The argument to `catch` can be any of:


### PR DESCRIPTION
Backports the following commits to 7.17:
 - Add YAML spec docs about matching errors (#89370)