### PR TITLE
Disable openid connect tests due to missing fixture

### DIFF
--- a/x-pack/qa/oidc-op-tests/build.gradle
+++ b/x-pack/qa/oidc-op-tests/build.gradle
@@ -21,4 +21,7 @@ tasks.named("processJavaRestTestResources").configure {
 tasks.named("javaRestTest").configure {
   // OpenID Connect fixture does not support aarm64
   onlyIf { Architecture.current() == Architecture.X64 }
+
+  // AwaitsFix: https://github.com/elastic/elasticsearch/issues/89477
+  enabled = false
 }

--- a/x-pack/test/idp-fixture/docker-compose.yml
+++ b/x-pack/test/idp-fixture/docker-compose.yml
@@ -161,16 +161,17 @@ services:
       - ./idp/shibboleth-idp/metadata:/opt/shibboleth-idp/metadata
       - ./idp/shib-jetty-base/start.d/ssl.ini:/opt/shib-jetty-base/start.d/ssl.ini
 
-  oidc-provider:
-    image: "c2id/c2id-server:9.5"
-    depends_on:
-      - http-proxy
-    ports:
-      - "8080"
-    expose:
-      - "8080"
-    volumes:
-      - ./oidc/override.properties:/etc/c2id/override.properties
+# c2id/c2id-server image is no longer available
+#  oidc-provider:
+#    image: "c2id/c2id-server:9.5"
+#    depends_on:
+#      - http-proxy
+#    ports:
+#      - "8080"
+#    expose:
+#      - "8080"
+#    volumes:
+#      - ./oidc/override.properties:/etc/c2id/override.properties
 
   http-proxy:
     image: "nginx:latest"


### PR DESCRIPTION
Relates to https://github.com/elastic/elasticsearch/issues/89477. For now just disable these tests since they are guaranteed to fail.