### PR TITLE
Update troubleshooting.asciidoc

### DIFF
--- a/docs/reference/monitoring/troubleshooting.asciidoc
+++ b/docs/reference/monitoring/troubleshooting.asciidoc
@@ -25,7 +25,9 @@ there is a `.monitoring-kibana*` index for your {kib} monitoring data and a
 `.monitoring-es*` index for your {es} monitoring data. If you are collecting
 monitoring data by using {metricbeat} the indices have `-mb` in their names. If
 the indices do not exist, review your configuration. For example, see
-<<monitoring-production>>.
+<<monitoring-production>>. Additionally, check for any closed indices in the 
+monitored cluster. Closed indices cannot be monitored, and will prevent
+monitoring data from reaching your monitoring cluster.
 
 [discrete]
 [[monitoring-troubleshooting-uuid]]


### PR DESCRIPTION
When a monitored deployment has a closed index, the result of the _stats call is an index_closed_exception. The monitoring agent see's the exception, and doesn't ingest the monitoring data.

<!--
Thank you for your interest in and contributing to Elasticsearch! There
are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your
attention.
-->

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/elasticsearch/blob/main/CONTRIBUTING.md)?
- If submitting code, have you built your formula locally prior to submission with `gradle check`?
- If submitting code, is your pull request against main? Unless there is a good reason otherwise, we prefer pull requests against main and will backport as needed.
- If submitting code, have you checked that your submission is for an [OS and architecture that we support](https://www.elastic.co/support/matrix#show_os)?
- If you are submitting this code for a class then read our [policy](https://github.com/elastic/elasticsearch/blob/main/CONTRIBUTING.md#contributing-as-part-of-a-class) for that.
