### PR TITLE
Disable ML when testing old ES versions on newer GLIBC

### DIFF
--- a/x-pack/qa/repository-old-versions/build.gradle
+++ b/x-pack/qa/repository-old-versions/build.gradle
@@ -9,6 +9,7 @@ import org.apache.tools.ant.taskdefs.condition.Os
 import org.elasticsearch.gradle.Architecture
 import org.elasticsearch.gradle.OS
 import org.elasticsearch.gradle.Version
+import org.elasticsearch.gradle.internal.BwcVersions
 import org.elasticsearch.gradle.internal.info.BuildParams
 import org.elasticsearch.gradle.internal.test.AntFixture
 import org.elasticsearch.gradle.testclusters.StandaloneRestIntegTestTask
@@ -114,8 +115,8 @@ if (Os.isFamily(Os.FAMILY_WINDOWS)) {
         false,
         "path.repo: ${repoLocation}",
         "path.data: ${dataPath}"
-      if (version.onOrAfter('6.8.0') && Architecture.current() == Architecture.AARCH64) {
-        // We need to explicitly disable ML when running old ES versions on ARM
+      if ((version.onOrAfter('6.8.0') && Architecture.current() == Architecture.AARCH64) || BwcVersions.isMlCompatible(version) == false) {
+        // We need to explicitly disable ML when running old ES versions on ARM or on systems with newer GLIBC
         args 'xpack.ml.enabled: false'
       }
       doFirst {


### PR DESCRIPTION
When testing on systems with later GLIBC versions (> 2.34) we need to ensure we disable ML for ES versions that have not been patched with this fix. This PR updates the old repository integration tests appropriately.

Example failure: https://gradle-enterprise.elastic.co/s/do3qaak77usde