### PR TITLE
[8.3] Disable ML when testing old ES versions on newer GLIBC (#89517)

### DIFF
--- a/x-pack/qa/repository-old-versions/build.gradle
+++ b/x-pack/qa/repository-old-versions/build.gradle
@@ -9,6 +9,7 @@ import org.apache.tools.ant.taskdefs.condition.Os
 import org.elasticsearch.gradle.Architecture
 import org.elasticsearch.gradle.OS
 import org.elasticsearch.gradle.Version
+import org.elasticsearch.gradle.internal.BwcVersions
 import org.elasticsearch.gradle.internal.info.BuildParams
 import org.elasticsearch.gradle.internal.test.AntFixture
 import org.elasticsearch.gradle.testclusters.StandaloneRestIntegTestTask
@@ -115,8 +116,8 @@ if (Os.isFamily(Os.FAMILY_WINDOWS)) {
         false,
         "path.repo: ${repoLocation}",
         "path.data: ${dataPath}"
-      if (version.onOrAfter('6.8.0') && Architecture.current() == Architecture.AARCH64) {
-        // We need to explicitly disable ML when running old ES versions on ARM
+      if ((version.onOrAfter('6.8.0') && Architecture.current() == Architecture.AARCH64) || BwcVersions.isMlCompatible(version) == false) {
+        // We need to explicitly disable ML when running old ES versions on ARM or on systems with newer GLIBC
         args 'xpack.ml.enabled: false'
       }
       doFirst {


### PR DESCRIPTION
Backports the following commits to 8.3:
 - Disable ML when testing old ES versions on newer GLIBC (#89517)