### PR TITLE
Fix incorrect failed shards count in APIs for current snapshots

### DIFF
--- a/docs/changelog/89534.yaml
+++ b/docs/changelog/89534.yaml
@@ -1,0 +1,5 @@
+pr: 89534
+summary: Fix incorrect failed shards count in APIs for current snapshots
+area: Snapshot/Restore
+type: bug
+issues: []

--- a/server/src/internalClusterTest/java/org/elasticsearch/snapshots/GetSnapshotsIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/snapshots/GetSnapshotsIT.java
@@ -191,6 +191,13 @@ public class GetSnapshotsIT extends AbstractSnapshotIntegTestCase {
         assertStablePagination(repos, allSnapshotNames, GetSnapshotsRequest.SortBy.START_TIME);
         assertStablePagination(repos, allSnapshotNames, GetSnapshotsRequest.SortBy.NAME);
         assertStablePagination(repos, allSnapshotNames, GetSnapshotsRequest.SortBy.INDICES);
+        final List<SnapshotInfo> currentSnapshots = clusterAdmin().prepareGetSnapshots(matchAllPattern())
+            .setSnapshots(GetSnapshotsRequest.CURRENT_SNAPSHOT)
+            .get()
+            .getSnapshots();
+        for (SnapshotInfo currentSnapshot : currentSnapshots) {
+            assertThat(currentSnapshot.toString(), currentSnapshot.failedShards(), is(0));
+        }
 
         assertThat(
             clusterAdmin().prepareGetSnapshots(matchAllPattern())

--- a/server/src/main/java/org/elasticsearch/snapshots/SnapshotInfo.java
+++ b/server/src/main/java/org/elasticsearch/snapshots/SnapshotInfo.java
@@ -627,13 +627,12 @@ public final class SnapshotInfo implements Comparable<SnapshotInfo>, ToXContentF
     }
 
     /**
-     * Number of failed shards; a value of {@code 0} will be returned if there were no
-     * failed shards, or if {@link #state()} returns {@code null}.
+     * Number of failed shards.
      *
      * @return number of failed shards
      */
     public int failedShards() {
-        return totalShards - successfulShards;
+        return shardFailures.size();
     }
 
     /**


### PR DESCRIPTION
The failed shards count approach is wrong, if we have an in-progress snapshot
the difference in counts does not work out to the failed shards count.
Since every failed shard has an entry in the failure list anyway we can just
return its size instead for the correct answer.