### PR TITLE
Ensure only snapshot jdbc driver versions are testing when running check

### DIFF
--- a/x-pack/plugin/sql/qa/jdbc/build.gradle
+++ b/x-pack/plugin/sql/qa/jdbc/build.gradle
@@ -2,7 +2,7 @@ import org.elasticsearch.gradle.internal.BwcVersions.UnreleasedVersionInfo
 import org.elasticsearch.gradle.Version
 import org.elasticsearch.gradle.VersionProperties
 import org.elasticsearch.gradle.internal.info.BuildParams
-import org.elasticsearch.gradle.internal.test.RestIntegTestTask
+import org.elasticsearch.gradle.testclusters.StandaloneRestIntegTestTask
 
 description = 'Integration tests for SQL JDBC driver'
 apply plugin: 'elasticsearch.java'
@@ -74,6 +74,7 @@ subprojects {
     // Compatibility testing for JDBC driver started with version 7.9.0
     BuildParams.bwcVersions.allIndexCompatible.findAll({ it.onOrAfter(Version.fromString("7.9.0")) && it != VersionProperties.elasticsearchVersion }).each { bwcVersion ->
       def baseName = "v${bwcVersion}"
+      def cluster = testClusters.maybeCreate(baseName)
 
       UnreleasedVersionInfo unreleasedVersion = BuildParams.bwcVersions.unreleasedInfo(bwcVersion)
       Configuration driverConfiguration = configurations.create("jdbcDriver${baseName}") {
@@ -92,14 +93,16 @@ subprojects {
 
       dependencies {
         "jdbcDriver${baseName}"(driverDependency)
-
       }
 
       final String bwcVersionString = bwcVersion.toString()
-      tasks.register(bwcTaskName(bwcVersion), RestIntegTestTask) {
+      tasks.register(bwcTaskName(bwcVersion), StandaloneRestIntegTestTask) {
+          useCluster cluster
           classpath = sourceSets.javaRestTest.runtimeClasspath + driverConfiguration
           testClassesDirs = sourceSets.javaRestTest.output.classesDirs
           systemProperty 'jdbc.driver.version', bwcVersionString
+          nonInputProperties.systemProperty('tests.rest.cluster', "${-> cluster.allHttpSocketURI.join(",")}")
+          nonInputProperties.systemProperty('tests.clustername', baseName)
       }
     }
   }


### PR DESCRIPTION
This was an interesting find. Because of the way we distinguish between `StandaloneRestIntegTestTask` and `RestIntegTestTask` we were mistakenly running _all_ BWC version tests when running the `check` task on the JDBC driver projects instead of only snapshot versions.

`RestTestBasePlugin` by convention wires all` RestIntegTestTask`s to the `check` task. For our BWC testing, we instead create `StandaloneRestIntegTest` tasks. These get fewer conventions applied, as they are typically used when manually wiring tasks, as is often the case with BWC testing. The JDBC driver tests are a form of BWC testing, but were mistakenly setup using `RestIntegTestTask`. We only want to test snapshot versions when running `check`. The _full_ suite of versions gets testing in the periodic BWC job. This PR fixes this behavior such that we are only testing snapshot (in development) versions as expected.

This is a very easy mistake to make so there definitely room for improvement here in terms of developer convenience. You can see in [this build scan](https://gradle-enterprise.elastic.co/s/366rmoigwm45m/timeline?details=sjymamms6tkj2&show=Predecessors&task-path=single-node) how the `check` task depends on the full suite of versions incorrectly.