### PR TITLE
Add configure_test_clusters_with_one_processor to repro line printer

### DIFF
--- a/test/framework/src/main/java/org/elasticsearch/test/junit/listeners/ReproduceInfoPrinter.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/junit/listeners/ReproduceInfoPrinter.java
@@ -172,7 +172,8 @@ public class ReproduceInfoPrinter extends RunListener {
                 "tests.heap.size",
                 "tests.bwc",
                 "tests.bwc.version",
-                "build.snapshot"
+                "build.snapshot",
+                "tests.configure_test_clusters_with_one_processor"
             );
             if (System.getProperty("tests.jvm.argline") != null && System.getProperty("tests.jvm.argline").isEmpty() == false) {
                 appendOpt("tests.jvm.argline", "\"" + System.getProperty("tests.jvm.argline") + "\"");


### PR DESCRIPTION
Ass a follow up to #89234, we want to also include this system property in reproduction lines so that developers are actually enabling this setting when trying to reproduce these failures.