### PR TITLE
Don't try to disable ML on incompatible versions

### DIFF
--- a/x-pack/qa/repository-old-versions/build.gradle
+++ b/x-pack/qa/repository-old-versions/build.gradle
@@ -115,7 +115,7 @@ if (Os.isFamily(Os.FAMILY_WINDOWS)) {
         false,
         "path.repo: ${repoLocation}",
         "path.data: ${dataPath}"
-      if ((version.onOrAfter('6.8.0') && Architecture.current() == Architecture.AARCH64) || BwcVersions.isMlCompatible(version) == false) {
+      if ((version.onOrAfter('6.8.0') && Architecture.current() == Architecture.AARCH64) || (version.onOrAfter("6.4.0") && BwcVersions.isMlCompatible(version) == false)) {
         // We need to explicitly disable ML when running old ES versions on ARM or on systems with newer GLIBC
         args 'xpack.ml.enabled: false'
       }


### PR DESCRIPTION
Follow up to #89517 to ensure we don't mistakenly pass the `xpack.ml.enabled` flag on versions of ES that have no such setting.