### PR TITLE
[DOCS] Reworks aggregating data for faster performance page

### DIFF
--- a/docs/reference/ml/anomaly-detection/ml-configuring-aggregations.asciidoc
+++ b/docs/reference/ml/anomaly-detection/ml-configuring-aggregations.asciidoc
@@ -26,13 +26,17 @@ reduces the volume of data that must be considered while detecting anomalies.
 time field. This requirement ensures that the aggregated data is a time series 
 and the timestamp of each bucket is the time of the last record in the bucket.
 
+* The `time_zone` parameter in the date histogram aggregation must be set to
+`UTC`, which is the default value.
+
 * The name of the aggregation and the name of the field that it operates on need 
 to match. For example, if you use a `max` aggregation on a time field called 
 `responsetime`, the name of the aggregation must also be `responsetime`.
 
-* If you use a terms aggregation and the cardinality of a term is high but still 
-significantly less than your total number of documents, use
-{ref}/search-aggregations-bucket-composite-aggregation.html[composite aggregations].
+* For `composite` aggregation support, there must be exactly one 
+`date_histogram` value source. That value source must not be sorted in 
+descending order. Additional `composite` aggregation value sources are allowed, 
+such as `terms`.
 
 
 [discrete]
@@ -48,16 +52,6 @@ significantly less than your total number of documents, use
 * {anomaly-jobs-cap} cannot use `date_histogram` or `composite` aggregations 
 with an interval measured in months because the length of the month is not 
 fixed; they can use weeks or smaller units.
-
-* If your detectors use <<ml-metric-functions,metric>> or 
-<<ml-sum-functions,sum>> analytical functions, it's recommended to set the 
-`date_histogram` or `composite` aggregation interval to a tenth of the bucket 
-span. This creates finer, more granular time buckets, which are ideal for this 
-type of analysis.
-
-* If your detectors use <<ml-count-functions,count>> or 
-<<ml-rare-functions,rare>> functions, set the interval to the same value as the 
-bucket span.
 
 
 [discrete]
@@ -75,11 +69,40 @@ that match values in the job configuration are fed to the job.
 
 
 [discrete]
-[[aggs-using-date-histogram]]
-=== Including aggregations in {anomaly-jobs}
+[[aggs-recommendations-dfeeds]]
+== Recommendations
 
-When you create or update an {anomaly-job}, you can include the names of
-aggregations, for example:
+* When your detectors use <<ml-metric-functions,metric>> or 
+<<ml-sum-functions,sum>> analytical functions, it's recommended to set the 
+`date_histogram` or `composite` aggregation interval to a tenth of the bucket 
+span. This creates finer, more granular time buckets, which are ideal for this 
+type of analysis.
+
+* When your detectors use <<ml-count-functions,count>> or 
+<<ml-rare-functions,rare>> functions, set the interval to the same value as the 
+bucket span.
+
+* When you use a terms aggregation and the cardinality of a term is high but still 
+significantly less than your total number of documents, use
+{ref}/search-aggregations-bucket-composite-aggregation.html[composite aggregations].
+
+* When you use a `term` aggregation to gather influencer or partition field 
+information, consider using a `composite` aggregation. It performs better than a 
+`date_histogram` with a nested `term` aggregation and also includes all the 
+values of the field instead of the top values per bucket.
+
+
+
+
+[discrete]
+[[aggs-using-date-histogram]]
+== Including aggregations in {anomaly-jobs}
+
+When you create or update an {anomaly-job}, you can include aggregated fields in 
+the analysis configuration and the job analyses these fields. In the  {dfeed} 
+configuration object, you can define the aggregations. The aggregations and the 
+fields that they operate on need to have the same name as the following example 
+shows:
 
 [source,console]
 ----------------------------------
@@ -92,7 +115,7 @@ PUT _ml/anomaly_detectors/farequote
       "field_name": "responsetime",  <1>
       "by_field_name": "airline"  <1>
     }],
-    "summary_count_field_name": "doc_count"
+    "summary_count_field_name": "doc_count" <2>
   },
   "data_description": {
     "time_field":"time"  <1>
@@ -107,16 +130,16 @@ PUT _ml/anomaly_detectors/farequote
           "time_zone": "UTC"
         },
         "aggregations": {
-          "time": {  <2>
+          "time": {  <3>
             "max": {"field": "time"}
           },
-          "airline": {  <3>
+          "airline": {  <4>
             "terms": {
              "field": "airline",
               "size": 100
             },
             "aggregations": {
-              "responsetime": {  <4>
+              "responsetime": {  <5>
                 "avg": {
                   "field": "responsetime"
                 }
@@ -134,41 +157,34 @@ PUT _ml/anomaly_detectors/farequote
 <1> The `airline`, `responsetime`, and `time` fields are aggregations. Only the
 aggregated fields defined in the `analysis_config` object are analyzed by the
 {anomaly-job}.
-<2> The aggregations have names that match the fields that they operate on. The
+<2> The `summary_count_field_name` property is set to the `doc_count` field that 
+is an aggregated field and contains the count of the aggregated data points.
+<3> The aggregations have names that match the fields that they operate on. The
 `max` aggregation is named `time` and its field also needs to be `time`.
-<3> The `term` aggregation is named `airline` and its field is also named
+<4> The `term` aggregation is named `airline` and its field is also named
 `airline`.
-<4> The `avg` aggregation is named `responsetime` and its field is also named
+<5> The `avg` aggregation is named `responsetime` and its field is also named
 `responsetime`.
 
-When the `summary_count_field_name` property is set to a non-null value, the job
-expects to receive aggregated input. The property must be set to the name of the
-field that contains the count of raw data points that have been aggregated. It
-applies to all detectors in the job.
+NOTE: When you set the `summary_count_field_name` property to a non-null value, 
+the job expects to receive aggregated input. The property must be set to the 
+name of the field that contains the count of raw data points that have been 
+aggregated. It applies to all detectors in the job.
 
-TIP: If you are using a `term` aggregation to gather influencer or partition
-field information, consider using a `composite` aggregation. It performs
-better than a `date_histogram` with a nested `term` aggregation and also
-includes all the values of the field instead of the top values per bucket.
 
 [discrete]
 [[aggs-using-composite]]
 === Using composite aggregations in {anomaly-jobs}
 
-For `composite` aggregation support, there must be exactly one `date_histogram` 
-value source. That value source must not be sorted in descending order. 
-Additional `composite` aggregation value sources are allowed, such as `terms`.
-
 NOTE: A {dfeed} that uses composite aggregations may not be as performant as
 {dfeeds} that use scrolling or date histogram aggregations. Composite
 aggregations are optimized for queries that are either `match_all` or `range`
-filters. Other types of
-queries may cause the `composite` aggregation to be inefficient.
+filters. Other types of queries may cause the `composite` aggregation to be 
+inefficient.
 
-Here is an example that uses a `composite` aggregation instead of a
-`date_histogram`.
+The following example 
 
-This is an example of a job with a {dfeed} that uses a `composite` aggregation
+of a job with a {dfeed} that uses a `composite` aggregation
 to bucket the metrics based on time and terms:
 
 [source,console]
@@ -229,9 +245,8 @@ PUT _ml/anomaly_detectors/farequote-composite
   }
 }
 ----------------------------------
-<1> Provide the `size` to the composite agg to control how many resources
-are used when aggregating the data. A larger `size` means a faster {dfeed} but
-more cluster resources are used when searching.
+<1> The number of resources to use when aggregating the data. A larger `size` 
+means a faster {dfeed} but more cluster resources are used when searching.
 <2> The required `date_histogram` composite aggregation source. Make sure it
 is named differently than your desired time field.
 <3> Instead of using a regular `term` aggregation, adding a composite
@@ -244,7 +259,7 @@ job analysis config.
 
 [discrete]
 [[aggs-dfeeds]]
-== Nested aggregations in {dfeeds}
+=== Using nested aggregations in {dfeeds}
 
 {dfeeds-cap} support complex nested aggregations. This example uses the
 `derivative` pipeline aggregation to find the first order derivative of the
@@ -294,7 +309,7 @@ aggregations. See
 
 [discrete]
 [[aggs-single-dfeeds]]
-== Single bucket aggregations in {dfeeds}
+=== Using single bucket aggregations in {dfeeds}
 
 {dfeeds-cap} not only supports multi-bucket aggregations, but also single bucket
 aggregations. The following shows two `filter` aggregations, each gathering the
@@ -344,13 +359,16 @@ number of unique entries for the `error` field.
 // NOTCONSOLE
 
 
+
 [discrete]
 [[aggs-define-dfeeds]]
 == Defining aggregations in {dfeeds}
 
-When you define an aggregation in a {dfeed}, it must have one of the following forms:
+When you define an aggregation in a {dfeed}, it must be in one of the following 
+formats:
 
 When using a `date_histogram` aggregation to bucket by time:
+
 [source,js]
 ----------------------------------
 "aggregations": {
@@ -420,17 +438,16 @@ When using a `composite` aggregation:
 
 The top level aggregation must be exclusively one of the following:
 
-*  A {ref}/search-aggregations-bucket.html[bucket aggregation] containing a single
-sub-aggregation that is a `date_histogram`
-*  A top level aggregation that is a `date_histogram`
-*  A top level aggregation is a `composite` aggregation
+* A {ref}/search-aggregations-bucket.html[bucket aggregation] containing a 
+single sub-aggregation that is a `date_histogram`.
+* A top level aggregation that is a `date_histogram`.
+* A top level aggregation is a `composite` aggregation.
 
-There must be exactly one `date_histogram`, `composite` aggregation. For more information, see
-{ref}/search-aggregations-bucket-datehistogram-aggregation.html[Date histogram aggregation] and
+There must be exactly one `date_histogram`, `composite` aggregation. For more 
+information, see
+{ref}/search-aggregations-bucket-datehistogram-aggregation.html[Date histogram aggregation] 
+and
 {ref}/search-aggregations-bucket-composite-aggregation.html[Composite aggregation].
-
-NOTE: The `time_zone` parameter in the date histogram aggregation must be set to
-`UTC`, which is the default value.
 
 Each histogram or composite bucket has a key, which is the bucket start time.
 This key cannot be used for aggregations in {dfeeds}, however, because
@@ -443,7 +460,7 @@ the time of the latest record within a bucket.
 You can optionally specify a terms aggregation, which creates buckets for
 different values of a field.
 
-IMPORTANT: If you use a terms aggregation, by default it returns buckets for
+If you use a terms aggregation, by default it returns buckets for
 the top ten terms. Thus if the cardinality of the term is greater than 10, not
 all terms are analyzed. In this case, consider using `composite` aggregations.
 

--- a/docs/reference/ml/anomaly-detection/ml-configuring-aggregations.asciidoc
+++ b/docs/reference/ml/anomaly-detection/ml-configuring-aggregations.asciidoc
@@ -16,44 +16,60 @@ still significantly less than your total number of documents, use
 {ref}/search-aggregations-bucket-composite-aggregation.html[composite aggregations].
 
 [discrete]
+[[aggs-requs-dfeeds]]
+== Requirements
+
+[discrete]
+[[aggs-]]
+=== Aggregations
+
+* Your aggregation must include a `date_histogram` aggregation or a top level 
+`composite` aggregation, which in turn must contain a `max` aggregation on the 
+time field. This requirement ensures that the aggregated data is a time series 
+and the timestamp of each bucket is the time of the last record in the bucket.
+
+* The name of the aggregation and the name of the field that it operates on need 
+to match, otherwise the aggregation doesn't work. For example, if you use a 
+`max` aggregation on a time field called `responsetime`, the name of the 
+aggregation must be also `responsetime`.
+
+[discrete]
+[[aggs-interval]]
+=== Intervals
+
+* The bucket span of your {anomaly-job} must be divisible by the value of the 
+`calendar_interval` or `fixed_interval` in your aggregation (with no remainder).
+
+* If you specify a `frequency` for your {dfeed}, it must be divisible by the 
+`calendar_interval` or the `fixed_ineterval`.
+
+* {anomaly-jobs-cap} cannot use `date_histogram` or `composite` aggregations 
+with an interval measured in months because the length of the month is not 
+fixed; they can use weeks or smaller units.
+
+* If your detectors use <<ml-metric-functions,metric>> or 
+<<ml-sum-functions,sum>> analytical functions, set the `date_histogram` or 
+`composite` aggregation interval to a tenth of the bucket span. This creates 
+finer, more granular time buckets, which are ideal for this type of analysis.
+
+* If your detectors use <<ml-count-functions,count>> or 
+<<ml-rare-functions,rare>> functions, set the interval to the same value as the 
+bucket span.
+
+[discrete]
 [[aggs-limits-dfeeds]]
-== Requirements and limitations
+== Limitations
 
-There are some limitations to using aggregations in {dfeeds}.
-
-Your aggregation must include a `date_histogram` aggregation or a top level `composite` aggregation,
-which in turn must contain a `max` aggregation on the time field.
-This requirement ensures that the aggregated data is a time series and the timestamp
-of each bucket is the time of the last record in the bucket.
-
-IMPORTANT: The name of the aggregation and the name of the field that it
-operates on need to match, otherwise the aggregation doesn't work. For example,
-if you use a `max` aggregation on a time field called `responsetime`, the name
-of the aggregation must be also `responsetime`.
-
-You must consider the interval of the `date_histogram` or `composite`
-aggregation carefully. The bucket span of your {anomaly-job} must be divisible
-by the value of the `calendar_interval` or `fixed_interval` in your aggregation
-(with no remainder). If you specify a `frequency` for your {dfeed},
-it must also be divisible by this interval. {anomaly-jobs-cap} cannot use
-`date_histogram` or `composite` aggregations with an interval measured in months
-because the length of the month is not fixed; they can use weeks or smaller units.
-
-TIP: As a rule of thumb, if your detectors use <<ml-metric-functions,metric>> or
-<<ml-sum-functions,sum>> analytical functions, set the `date_histogram` or `composite`
-aggregation interval to a tenth of the bucket span. This suggestion creates
-finer, more granular time buckets, which are ideal for this type of analysis. If
-your detectors use <<ml-count-functions,count>> or <<ml-rare-functions,rare>>
-functions, set the interval to the same value as the bucket span.
-
-If your <<aggs-dfeeds,{dfeed} uses aggregations with nested `terms` aggs>> and
-model plot is not enabled for the {anomaly-job}, neither the **Single Metric
-Viewer** nor the **Anomaly Explorer** can plot and display an anomaly
-chart for the job. In these cases, the charts are not visible and an explanatory
+* If your <<aggs-dfeeds,{dfeed} uses aggregations with nested `terms` aggs>> and
+model plot is not enabled for the {anomaly-job}, neither the 
+**Single Metric Viewer** nor the **Anomaly Explorer** can plot and display an 
+anomaly chart. In these cases, the charts are not visible and an explanatory
 message is shown.
 
-Your {dfeed} can contain multiple aggregations, but only the ones with names
+* Your {dfeed} can contain multiple aggregations, but only the ones with names
 that match values in the job configuration are fed to the job.
+
+
 
 [discrete]
 [[aggs-using-date-histogram]]

--- a/docs/reference/ml/anomaly-detection/ml-configuring-aggregations.asciidoc
+++ b/docs/reference/ml/anomaly-detection/ml-configuring-aggregations.asciidoc
@@ -2,20 +2,20 @@
 [[ml-configuring-aggregation]]
 = Aggregating data for faster performance
 
-By default, {dfeeds} fetch data from {es} using search and scroll requests. It 
-can be significantly more efficient, however, to aggregate data in {es} and to 
-configure your {anomaly-jobs} to analyze aggregated data.
+Aggregating data in {es} and configuring the {anomaly-jobs} to analyze this
+aggregated data is more efficient than the default behavior when {dfeeds} fetch 
+data from {es} using search and scroll requests. 
 
-One of the benefits of aggregating data this way is that {es} automatically
-distributes these calculations across your cluster. You can then feed this
-aggregated data into the {ml-features} instead of raw results, which
-reduces the volume of data that must be considered while detecting anomalies.
+When you aggregate data, {es} automatically distributes the calculations across 
+your cluster. Then you can feed this aggregated data into the {ml-features} 
+instead of raw results. It reduces the volume of data that must be analyzed.
 
 
 [discrete]
 [[aggs-requs-dfeeds]]
 == Requirements
 
+There are a number of requirements for using aggregations in {dfeeds}.
 
 [discrete]
 [[aggs-aggs]]
@@ -23,8 +23,8 @@ reduces the volume of data that must be considered while detecting anomalies.
 
 * Your aggregation must include a `date_histogram` aggregation or a top level 
 `composite` aggregation, which in turn must contain a `max` aggregation on the 
-time field. This requirement ensures that the aggregated data is a time series 
-and the timestamp of each bucket is the time of the last record in the bucket.
+time field. It ensures that the aggregated data is a time series and the 
+timestamp of each bucket is the time of the last record in the bucket.
 
 * The `time_zone` parameter in the date histogram aggregation must be set to
 `UTC`, which is the default value.
@@ -37,6 +37,11 @@ to match. For example, if you use a `max` aggregation on a time field called
 `date_histogram` value source. That value source must not be sorted in 
 descending order. Additional `composite` aggregation value sources are allowed, 
 such as `terms`.
+
+* If you set the `summary_count_field_name` property to a non-null value, the 
+{anomaly-job} expects to receive aggregated input. The property must be set to 
+the name of the field that contains the count of raw data points that have been 
+aggregated. It applies to all detectors in the job.
 
 
 [discrete]
@@ -61,8 +66,8 @@ fixed; they can use weeks or smaller units.
 * If your <<aggs-dfeeds,{dfeed} uses aggregations with nested `terms` aggs>> and
 model plot is not enabled for the {anomaly-job}, neither the 
 **Single Metric Viewer** nor the **Anomaly Explorer** can plot and display an 
-anomaly chart. In these cases, the charts are not visible and an explanatory
-message is shown.
+anomaly chart. In these cases, an explanatory message is shown instead of the 
+chart.
 
 * Your {dfeed} can contain multiple aggregations, but only the ones with names
 that match values in the job configuration are fed to the job.
@@ -82,9 +87,31 @@ type of analysis.
 <<ml-rare-functions,rare>> functions, set the interval to the same value as the 
 bucket span.
 
-* When you use a terms aggregation and the cardinality of a term is high but still 
+* By default, {es} limits the maximum number of terms returned to 10000. For 
+high cardinality fields, the query might not run. It might return errors related 
+to circuit breaking exceptions that indicate that the data is too large. When 
+you use a terms aggregation and the cardinality of a term is high but still 
 significantly less than your total number of documents, use
 {ref}/search-aggregations-bucket-composite-aggregation.html[composite aggregations].
++
+--
+To determine the cardinality of your data, you can run searches such as:
+
+[source,js]
+--------------------------------------------------
+GET .../_search
+{
+  "aggs": {
+    "service_cardinality": {
+      "cardinality": {
+        "field": "service"
+      }
+    }
+  }
+}
+--------------------------------------------------
+// NOTCONSOLE
+--
 
 * When you use a `term` aggregation to gather influencer or partition field 
 information, consider using a `composite` aggregation. It performs better than a 
@@ -92,21 +119,17 @@ information, consider using a `composite` aggregation. It performs better than a
 values of the field instead of the top values per bucket.
 
 
-
-
 [discrete]
 [[aggs-using-date-histogram]]
 == Including aggregations in {anomaly-jobs}
 
 When you create or update an {anomaly-job}, you can include aggregated fields in 
-the analysis configuration and the job analyses these fields. In the  {dfeed} 
-configuration object, you can define the aggregations. The aggregations and the 
-fields that they operate on need to have the same name as the following example 
-shows:
+the analysis configuration and the job analyses these fields. In the {dfeed} 
+configuration object, you can define the aggregations.
 
 [source,console]
 ----------------------------------
-PUT _ml/anomaly_detectors/farequote
+PUT _ml/anomaly_detectors/kibana-sample-data-flights
 {
   "analysis_config": {
     "bucket_span": "60m",
@@ -121,7 +144,7 @@ PUT _ml/anomaly_detectors/farequote
     "time_field":"time"  <1>
   },
   "datafeed_config":{
-    "indices": ["farequote"],
+    "indices": ["kibana-sample-data-flights"],
     "aggregations": {
       "buckets": {
         "date_histogram": {
@@ -166,30 +189,58 @@ is an aggregated field and contains the count of the aggregated data points.
 <5> The `avg` aggregation is named `responsetime` and its field is also named
 `responsetime`.
 
-NOTE: When you set the `summary_count_field_name` property to a non-null value, 
-the job expects to receive aggregated input. The property must be set to the 
-name of the field that contains the count of raw data points that have been 
-aggregated. It applies to all detectors in the job.
+Use the following format to define a `date_histogram` aggregation to bucket by 
+time in your {dfeed}:
+
+[source,js]
+----------------------------------
+"aggregations": {
+  ["bucketing_aggregation": {
+    "bucket_agg": {
+      ...
+    },
+    "aggregations": {
+      "data_histogram_aggregation": {
+        "date_histogram": {
+          "field": "time",
+        },
+        "aggregations": {
+          "timestamp": {
+            "max": {
+              "field": "time"
+            }
+          },
+          [,"<first_term>": {
+            "terms":{...
+            }
+            [,"aggregations" : {
+              [<sub_aggregation>]+
+            } ]
+          }]
+        }
+      }
+    }
+  }
+}
+----------------------------------
+// NOTCONSOLE
 
 
 [discrete]
 [[aggs-using-composite]]
-=== Using composite aggregations in {anomaly-jobs}
+== Using composite aggregations in {dfeeds}
 
-NOTE: A {dfeed} that uses composite aggregations may not be as performant as
-{dfeeds} that use scrolling or date histogram aggregations. Composite
-aggregations are optimized for queries that are either `match_all` or `range`
-filters. Other types of queries may cause the `composite` aggregation to be 
-inefficient.
+Composite aggregations are optimized for queries that are either `match_all` or 
+`range` filters. Use composite aggregations in your {dfeeds} for these cases. 
+Other types of queries may cause the `composite` aggregation to be inefficient, 
+so as your {dfeeds}.
 
-The following example 
-
-of a job with a {dfeed} that uses a `composite` aggregation
-to bucket the metrics based on time and terms:
+The following is an example of a job with a {dfeed} that uses a `composite` 
+aggregation to bucket the metrics based on time and terms:
 
 [source,console]
 ----------------------------------
-PUT _ml/anomaly_detectors/farequote-composite
+PUT _ml/anomaly_detectors/kibana-sample-data-flights-composite
 {
   "analysis_config": {
     "bucket_span": "60m",
@@ -204,7 +255,7 @@ PUT _ml/anomaly_detectors/farequote-composite
     "time_field":"time"
   },
   "datafeed_config":{
-    "indices": ["farequote"],
+    "indices": ["kibana-sample-data-flights"],
     "aggregations": {
       "buckets": {
         "composite": {
@@ -257,16 +308,55 @@ job analysis config.
 <5> The `avg` aggregation is named `responsetime` and its field is also named
 `responsetime`.
 
+
+Use the following format to define a composite aggregation in your {dfeed}:
+
+[source,js]
+----------------------------------
+"aggregations": {
+  "composite_agg": {
+    "sources": [
+      {
+        "date_histogram_agg": {
+          "field": "time",
+          ...settings...
+        }
+      },
+      ...other valid sources...
+      ],
+      ...composite agg settings...,
+      "aggregations": {
+        "timestamp": {
+            "max": {
+              "field": "time"
+            }
+          },
+          ...other aggregations...
+          [
+            [,"aggregations" : {
+              [<sub_aggregation>]+
+            } ]
+          }]
+      }
+   }
+}
+----------------------------------
+// NOTCONSOLE
+
+
 [discrete]
 [[aggs-dfeeds]]
-=== Using nested aggregations in {dfeeds}
+== Using nested aggregations in {dfeeds}
 
-{dfeeds-cap} support complex nested aggregations. This example uses the
-`derivative` pipeline aggregation to find the first order derivative of the
-counter `system.network.out.bytes` for each value of the field `beat.name`.
+You can also use complex nested aggregations in {dfeeds}.
 
-NOTE: `derivative` or other pipeline aggregations may not work within `composite`
-aggregations. See
+The next example uses the
+{ref}/search-aggregations-pipeline-derivative-aggregation.html[`derivative` pipeline aggregation] 
+to find the first order derivative of the counter `system.network.out.bytes` for 
+each value of the field `beat.name`.
+
+NOTE: `derivative` or other pipeline aggregations may not work within 
+`composite` aggregations. See
 {ref}/search-aggregations-bucket-composite-aggregation.html#search-aggregations-bucket-composite-aggregation-pipeline-aggregations[composite aggregations and pipeline aggregations].
 
 [source,js]
@@ -309,11 +399,11 @@ aggregations. See
 
 [discrete]
 [[aggs-single-dfeeds]]
-=== Using single bucket aggregations in {dfeeds}
+== Using single bucket aggregations in {dfeeds}
 
-{dfeeds-cap} not only supports multi-bucket aggregations, but also single bucket
-aggregations. The following shows two `filter` aggregations, each gathering the
-number of unique entries for the `error` field.
+You can also use single bucket aggregations in {dfeeds}. The example below shows 
+two `filter` aggregations, each gathering the number of unique entries for the 
+`error` field.
 
 [source,js]
 ----------------------------------
@@ -357,138 +447,3 @@ number of unique entries for the `error` field.
 }
 ----------------------------------
 // NOTCONSOLE
-
-
-
-[discrete]
-[[aggs-define-dfeeds]]
-== Defining aggregations in {dfeeds}
-
-When you define an aggregation in a {dfeed}, it must be in one of the following 
-formats:
-
-When using a `date_histogram` aggregation to bucket by time:
-
-[source,js]
-----------------------------------
-"aggregations": {
-  ["bucketing_aggregation": {
-    "bucket_agg": {
-      ...
-    },
-    "aggregations": {
-      "data_histogram_aggregation": {
-        "date_histogram": {
-          "field": "time",
-        },
-        "aggregations": {
-          "timestamp": {
-            "max": {
-              "field": "time"
-            }
-          },
-          [,"<first_term>": {
-            "terms":{...
-            }
-            [,"aggregations" : {
-              [<sub_aggregation>]+
-            } ]
-          }]
-        }
-      }
-    }
-  }
-}
-----------------------------------
-// NOTCONSOLE
-
-When using a `composite` aggregation:
-
-[source,js]
-----------------------------------
-"aggregations": {
-  "composite_agg": {
-    "sources": [
-      {
-        "date_histogram_agg": {
-          "field": "time",
-          ...settings...
-        }
-      },
-      ...other valid sources...
-      ],
-      ...composite agg settings...,
-      "aggregations": {
-        "timestamp": {
-            "max": {
-              "field": "time"
-            }
-          },
-          ...other aggregations...
-          [
-            [,"aggregations" : {
-              [<sub_aggregation>]+
-            } ]
-          }]
-      }
-   }
-}
-----------------------------------
-// NOTCONSOLE
-
-The top level aggregation must be exclusively one of the following:
-
-* A {ref}/search-aggregations-bucket.html[bucket aggregation] containing a 
-single sub-aggregation that is a `date_histogram`.
-* A top level aggregation that is a `date_histogram`.
-* A top level aggregation is a `composite` aggregation.
-
-There must be exactly one `date_histogram`, `composite` aggregation. For more 
-information, see
-{ref}/search-aggregations-bucket-datehistogram-aggregation.html[Date histogram aggregation] 
-and
-{ref}/search-aggregations-bucket-composite-aggregation.html[Composite aggregation].
-
-Each histogram or composite bucket has a key, which is the bucket start time.
-This key cannot be used for aggregations in {dfeeds}, however, because
-they need to know the time of the latest record within a bucket.
-Otherwise, when you restart a {dfeed}, it continues from the start time of the
-histogram or composite bucket and possibly fetches the same data twice.
-The max aggregation for the time field is therefore necessary to provide
-the time of the latest record within a bucket.
-
-You can optionally specify a terms aggregation, which creates buckets for
-different values of a field.
-
-If you use a terms aggregation, by default it returns buckets for
-the top ten terms. Thus if the cardinality of the term is greater than 10, not
-all terms are analyzed. In this case, consider using `composite` aggregations.
-
-You can change this behavior by setting the `size` parameter. To
-determine the cardinality of your data, you can run searches such as:
-
-[source,js]
---------------------------------------------------
-GET .../_search
-{
-  "aggs": {
-    "service_cardinality": {
-      "cardinality": {
-        "field": "service"
-      }
-    }
-  }
-}
---------------------------------------------------
-// NOTCONSOLE
-
-
-By default, {es} limits the maximum number of terms returned to 10000. For high
-cardinality fields, the query might not run. It might return errors related to
-circuit breaking exceptions that indicate that the data is too large. In such
-cases, use `composite` aggregations in your {dfeed}. For more information, see
-{ref}/search-aggregations-bucket-terms-aggregation.html[Terms aggregation].
-
-You can also optionally specify multiple sub-aggregations. The sub-aggregations
-are aggregated for the buckets that were created by their parent aggregation.
-For more information, see {ref}/search-aggregations.html[Aggregations].

--- a/docs/reference/ml/anomaly-detection/ml-configuring-aggregations.asciidoc
+++ b/docs/reference/ml/anomaly-detection/ml-configuring-aggregations.asciidoc
@@ -2,25 +2,23 @@
 [[ml-configuring-aggregation]]
 = Aggregating data for faster performance
 
-By default, {dfeeds} fetch data from {es} using search and scroll requests.
-It can be significantly more efficient, however, to aggregate data in {es}
-and to configure your {anomaly-jobs} to analyze aggregated data.
+By default, {dfeeds} fetch data from {es} using search and scroll requests. It 
+can be significantly more efficient, however, to aggregate data in {es} and to 
+configure your {anomaly-jobs} to analyze aggregated data.
 
 One of the benefits of aggregating data this way is that {es} automatically
 distributes these calculations across your cluster. You can then feed this
 aggregated data into the {ml-features} instead of raw results, which
 reduces the volume of data that must be considered while detecting anomalies.
 
-TIP: If you use a terms aggregation and the cardinality of a term is high but
-still significantly less than your total number of documents, use
-{ref}/search-aggregations-bucket-composite-aggregation.html[composite aggregations].
 
 [discrete]
 [[aggs-requs-dfeeds]]
 == Requirements
 
+
 [discrete]
-[[aggs-]]
+[[aggs-aggs]]
 === Aggregations
 
 * Your aggregation must include a `date_histogram` aggregation or a top level 
@@ -29,9 +27,13 @@ time field. This requirement ensures that the aggregated data is a time series
 and the timestamp of each bucket is the time of the last record in the bucket.
 
 * The name of the aggregation and the name of the field that it operates on need 
-to match, otherwise the aggregation doesn't work. For example, if you use a 
-`max` aggregation on a time field called `responsetime`, the name of the 
-aggregation must be also `responsetime`.
+to match. For example, if you use a `max` aggregation on a time field called 
+`responsetime`, the name of the aggregation must also be `responsetime`.
+
+* If you use a terms aggregation and the cardinality of a term is high but still 
+significantly less than your total number of documents, use
+{ref}/search-aggregations-bucket-composite-aggregation.html[composite aggregations].
+
 
 [discrete]
 [[aggs-interval]]
@@ -48,13 +50,15 @@ with an interval measured in months because the length of the month is not
 fixed; they can use weeks or smaller units.
 
 * If your detectors use <<ml-metric-functions,metric>> or 
-<<ml-sum-functions,sum>> analytical functions, set the `date_histogram` or 
-`composite` aggregation interval to a tenth of the bucket span. This creates 
-finer, more granular time buckets, which are ideal for this type of analysis.
+<<ml-sum-functions,sum>> analytical functions, it's recommended to set the 
+`date_histogram` or `composite` aggregation interval to a tenth of the bucket 
+span. This creates finer, more granular time buckets, which are ideal for this 
+type of analysis.
 
 * If your detectors use <<ml-count-functions,count>> or 
 <<ml-rare-functions,rare>> functions, set the interval to the same value as the 
 bucket span.
+
 
 [discrete]
 [[aggs-limits-dfeeds]]
@@ -68,7 +72,6 @@ message is shown.
 
 * Your {dfeed} can contain multiple aggregations, but only the ones with names
 that match values in the job configuration are fed to the job.
-
 
 
 [discrete]

--- a/docs/reference/ml/anomaly-detection/ml-configuring-aggregations.asciidoc
+++ b/docs/reference/ml/anomaly-detection/ml-configuring-aggregations.asciidoc
@@ -136,9 +136,9 @@ includes all the values of the field instead of the top values per bucket.
 [[aggs-using-composite]]
 === Using composite aggregations in {anomaly-jobs}
 
-For `composite` aggregation support, there must be exactly one `date_histogram` value
-source. That value source must not be sorted in descending order. Additional
-`composite` aggregation value sources are allowed, such as `terms`.
+For `composite` aggregation support, there must be exactly one `date_histogram` 
+value source. That value source must not be sorted in descending order. 
+Additional `composite` aggregation value sources are allowed, such as `terms`.
 
 NOTE: A {dfeed} that uses composite aggregations may not be as performant as
 {dfeeds} that use scrolling or date histogram aggregations. Composite

--- a/docs/reference/ml/anomaly-detection/ml-configuring-aggregations.asciidoc
+++ b/docs/reference/ml/anomaly-detection/ml-configuring-aggregations.asciidoc
@@ -116,7 +116,8 @@ GET .../_search
 * When you use a `term` aggregation to gather influencer or partition field 
 information, consider using a `composite` aggregation. It performs better than a 
 `date_histogram` with a nested `term` aggregation and also includes all the 
-values of the field instead of the top values per bucket.
+values of the field instead of the top values per bucket. For more information 
+on influencers, refer to <<ml-ad-influencers>>.
 
 
 [discrete]

--- a/docs/reference/ml/anomaly-detection/ml-configuring-aggregations.asciidoc
+++ b/docs/reference/ml/anomaly-detection/ml-configuring-aggregations.asciidoc
@@ -2,10 +2,6 @@
 [[ml-configuring-aggregation]]
 = Aggregating data for faster performance
 
-Aggregating data in {es} and configuring the {anomaly-jobs} to analyze this
-aggregated data is more efficient than the default behavior when {dfeeds} fetch 
-data from {es} using search and scroll requests. 
-
 When you aggregate data, {es} automatically distributes the calculations across 
 your cluster. Then you can feed this aggregated data into the {ml-features} 
 instead of raw results. It reduces the volume of data that must be analyzed.
@@ -52,7 +48,7 @@ aggregated. It applies to all detectors in the job.
 `calendar_interval` or `fixed_interval` in your aggregation (with no remainder).
 
 * If you specify a `frequency` for your {dfeed}, it must be divisible by the 
-`calendar_interval` or the `fixed_ineterval`.
+`calendar_interval` or the `fixed_interval`.
 
 * {anomaly-jobs-cap} cannot use `date_histogram` or `composite` aggregations 
 with an interval measured in months because the length of the month is not 
@@ -125,8 +121,8 @@ on influencers, refer to <<ml-ad-influencers>>.
 == Including aggregations in {anomaly-jobs}
 
 When you create or update an {anomaly-job}, you can include aggregated fields in 
-the analysis configuration and the job analyses these fields. In the {dfeed} 
-configuration object, you can define the aggregations.
+the analysis configuration. In the {dfeed} configuration object, you can define 
+the aggregations.
 
 [source,console]
 ----------------------------------
@@ -229,12 +225,11 @@ time in your {dfeed}:
 
 [discrete]
 [[aggs-using-composite]]
-== Using composite aggregations in {dfeeds}
+== Composite aggregations
 
 Composite aggregations are optimized for queries that are either `match_all` or 
 `range` filters. Use composite aggregations in your {dfeeds} for these cases. 
-Other types of queries may cause the `composite` aggregation to be inefficient, 
-so as your {dfeeds}.
+Other types of queries may cause the `composite` aggregation to be inefficient.
 
 The following is an example of a job with a {dfeed} that uses a `composite` 
 aggregation to bucket the metrics based on time and terms:
@@ -347,7 +342,7 @@ Use the following format to define a composite aggregation in your {dfeed}:
 
 [discrete]
 [[aggs-dfeeds]]
-== Using nested aggregations in {dfeeds}
+== Nested aggregations
 
 You can also use complex nested aggregations in {dfeeds}.
 
@@ -400,11 +395,11 @@ NOTE: `derivative` or other pipeline aggregations may not work within
 
 [discrete]
 [[aggs-single-dfeeds]]
-== Using single bucket aggregations in {dfeeds}
+== Single bucket aggregations
 
-You can also use single bucket aggregations in {dfeeds}. The example below shows 
-two `filter` aggregations, each gathering the number of unique entries for the 
-`error` field.
+You can also use single bucket aggregations in {dfeeds}. The following example 
+shows two `filter` aggregations, each gathering the number of unique entries for 
+the `error` field.
 
 [source,js]
 ----------------------------------
@@ -448,3 +443,4 @@ two `filter` aggregations, each gathering the number of unique entries for the
 }
 ----------------------------------
 // NOTCONSOLE
+


### PR DESCRIPTION
## Overview

Related issue https://github.com/elastic/ml-team/issues/843.

This PR makes numerous improvements, edits, and changes on the `Aggregating data for faster performance` page.
* simplifies text and edits out repeated info,
* applies a how-to structure and tone,
* segments `Requirements` and `Limitations` into separate sections,
* orders `Requirements` into logical groups,
* uses bullet points for requirements and limitations,
* creates a `Recommendations` section with bullet points of list items collected across the page,
* incorporates `Defining aggregations in datafeeds` section content into other relevant sections.