### PR TITLE
[8.4] Ensure only snapshot jdbc driver versions are testing when running check (#89560)

### DIFF
--- a/x-pack/plugin/sql/qa/jdbc/build.gradle
+++ b/x-pack/plugin/sql/qa/jdbc/build.gradle
@@ -2,7 +2,7 @@ import org.elasticsearch.gradle.internal.BwcVersions.UnreleasedVersionInfo
 import org.elasticsearch.gradle.Version
 import org.elasticsearch.gradle.VersionProperties
 import org.elasticsearch.gradle.internal.info.BuildParams
-import org.elasticsearch.gradle.internal.test.RestIntegTestTask
+import org.elasticsearch.gradle.testclusters.StandaloneRestIntegTestTask
 
 description = 'Integration tests for SQL JDBC driver'
 apply plugin: 'elasticsearch.java'
@@ -74,6 +74,7 @@ subprojects {
     // Compatibility testing for JDBC driver started with version 7.9.0
     BuildParams.bwcVersions.allIndexCompatible.findAll({ it.onOrAfter(Version.fromString("7.9.0")) && it != VersionProperties.elasticsearchVersion }).each { bwcVersion ->
       def baseName = "v${bwcVersion}"
+      def cluster = testClusters.maybeCreate(baseName)
 
       UnreleasedVersionInfo unreleasedVersion = BuildParams.bwcVersions.unreleasedInfo(bwcVersion)
       Configuration driverConfiguration = configurations.create("jdbcDriver${baseName}") {
@@ -92,14 +93,16 @@ subprojects {
 
       dependencies {
         "jdbcDriver${baseName}"(driverDependency)
-
       }
 
       final String bwcVersionString = bwcVersion.toString()
-      tasks.register(bwcTaskName(bwcVersion), RestIntegTestTask) {
+      tasks.register(bwcTaskName(bwcVersion), StandaloneRestIntegTestTask) {
+          useCluster cluster
           classpath = sourceSets.javaRestTest.runtimeClasspath + driverConfiguration
           testClassesDirs = sourceSets.javaRestTest.output.classesDirs
           systemProperty 'jdbc.driver.version', bwcVersionString
+          nonInputProperties.systemProperty('tests.rest.cluster', "${-> cluster.allHttpSocketURI.join(",")}")
+          nonInputProperties.systemProperty('tests.clustername', baseName)
       }
     }
   }


### PR DESCRIPTION
Backports the following commits to 8.4:
 - Ensure only snapshot jdbc driver versions are testing when running check (#89560)