### PR TITLE
Speed up synthetic source again

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/mapper/ObjectMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/ObjectMapper.java
@@ -604,7 +604,21 @@ public class ObjectMapper extends Mapper implements Cloneable {
                     loaders.add(loader);
                 }
             }
-            return docId -> {
+            if (loaders.isEmpty()) {
+                return null;
+            }
+            return new ObjectDocValuesLoader(loaders);
+        }
+
+        private class ObjectDocValuesLoader implements DocValuesLoader {
+            private final List<SourceLoader.SyntheticFieldLoader.DocValuesLoader> loaders;
+
+            private ObjectDocValuesLoader(List<DocValuesLoader> loaders) {
+                this.loaders = loaders;
+            }
+
+            @Override
+            public boolean advanceToDoc(int docId) throws IOException {
                 for (SourceLoader.SyntheticFieldLoader.DocValuesLoader docValueLoader : loaders) {
                     boolean leafHasValue = docValueLoader.advanceToDoc(docId);
                     hasValue |= leafHasValue;
@@ -616,7 +630,7 @@ public class ObjectMapper extends Mapper implements Cloneable {
                  * stored field.
                  */
                 return hasValue;
-            };
+            }
         }
 
         @Override

--- a/server/src/main/java/org/elasticsearch/index/mapper/ObjectMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/ObjectMapper.java
@@ -619,18 +619,19 @@ public class ObjectMapper extends Mapper implements Cloneable {
 
             @Override
             public boolean advanceToDoc(int docId) throws IOException {
+                boolean anyLeafHasDocValues = false;
                 for (SourceLoader.SyntheticFieldLoader.DocValuesLoader docValueLoader : loaders) {
                     boolean leafHasValue = docValueLoader.advanceToDoc(docId);
-                    hasValue |= leafHasValue;
+                    anyLeafHasDocValues |= leafHasValue;
                 }
-                /*
-                 * Important and kind of sneaky note: this will return true
-                 * if there were any values loaded from stored fields as
-                 * well. That *is* how we "wake up" objects that contain just
-                 * stored field.
-                 */
-                return hasValue;
+                hasValue |= anyLeafHasDocValues;
+                return anyLeafHasDocValues;
             }
+        }
+
+        @Override
+        public boolean hasValue() {
+            return hasValue;
         }
 
         @Override
@@ -640,7 +641,9 @@ public class ObjectMapper extends Mapper implements Cloneable {
             }
             startSyntheticField(b);
             for (SourceLoader.SyntheticFieldLoader field : fields) {
-                field.write(b);
+                if (field.hasValue()) {
+                    field.write(b);
+                }
             }
             b.endObject();
             hasValue = false;

--- a/server/src/main/java/org/elasticsearch/index/mapper/SortedNumericDocValuesSyntheticFieldLoader.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/SortedNumericDocValuesSyntheticFieldLoader.java
@@ -64,6 +64,11 @@ public abstract class SortedNumericDocValuesSyntheticFieldLoader implements Sour
     }
 
     @Override
+    public boolean hasValue() {
+        return values.count() > 0;
+    }
+
+    @Override
     public void write(XContentBuilder b) throws IOException {
         switch (values.count()) {
             case 0:

--- a/server/src/main/java/org/elasticsearch/index/mapper/SortedSetDocValuesSyntheticFieldLoader.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/SortedSetDocValuesSyntheticFieldLoader.java
@@ -68,6 +68,11 @@ public abstract class SortedSetDocValuesSyntheticFieldLoader implements SourceLo
     }
 
     @Override
+    public boolean hasValue() {
+        return values.count() > 0;
+    }
+
+    @Override
     public void write(XContentBuilder b) throws IOException {
         switch (values.count()) {
             case 0:

--- a/server/src/main/java/org/elasticsearch/index/mapper/SourceLoader.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/SourceLoader.java
@@ -126,9 +126,12 @@ public interface SourceLoader {
                         }
                     }
                 }
+                if (docValuesLoader != null) {
+                    docValuesLoader.advanceToDoc(docId);
+                }
                 // TODO accept a requested xcontent type
                 try (XContentBuilder b = new XContentBuilder(JsonXContent.jsonXContent, new ByteArrayOutputStream())) {
-                    if (docValuesLoader.advanceToDoc(docId)) {
+                    if (loader.hasValue()) {
                         loader.write(b);
                     } else {
                         b.startObject().endObject();
@@ -186,6 +189,11 @@ public interface SourceLoader {
             }
 
             @Override
+            public boolean hasValue() {
+                return false;
+            }
+
+            @Override
             public void write(XContentBuilder b) {}
         };
 
@@ -201,6 +209,8 @@ public interface SourceLoader {
          * load.
          */
         DocValuesLoader docValuesLoader(LeafReader leafReader, int[] docIdsInLeaf) throws IOException;
+
+        boolean hasValue();
 
         /**
          * Write values for this document.

--- a/server/src/main/java/org/elasticsearch/index/mapper/StringStoredFieldFieldLoader.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/StringStoredFieldFieldLoader.java
@@ -40,6 +40,11 @@ public class StringStoredFieldFieldLoader
     }
 
     @Override
+    public boolean hasValue() {
+        return values != null && values.isEmpty() == false;
+    }
+
+    @Override
     public void write(XContentBuilder b) throws IOException {
         if (values == null || values.isEmpty()) {
             return;

--- a/x-pack/plugin/mapper-aggregate-metric/src/main/java/org/elasticsearch/xpack/aggregatemetric/mapper/AggregateDoubleMetricFieldMapper.java
+++ b/x-pack/plugin/mapper-aggregate-metric/src/main/java/org/elasticsearch/xpack/aggregatemetric/mapper/AggregateDoubleMetricFieldMapper.java
@@ -726,6 +726,11 @@ public class AggregateDoubleMetricFieldMapper extends FieldMapper {
         }
 
         @Override
+        public boolean hasValue() {
+            return metricHasValue.isEmpty() == false;
+        }
+
+        @Override
         public void write(XContentBuilder b) throws IOException {
             if (metricHasValue.isEmpty()) {
                 return;

--- a/x-pack/plugin/mapper-constant-keyword/src/main/java/org/elasticsearch/xpack/constantkeyword/mapper/ConstantKeywordFieldMapper.java
+++ b/x-pack/plugin/mapper-constant-keyword/src/main/java/org/elasticsearch/xpack/constantkeyword/mapper/ConstantKeywordFieldMapper.java
@@ -311,6 +311,11 @@ public class ConstantKeywordFieldMapper extends FieldMapper {
 
     @Override
     public SourceLoader.SyntheticFieldLoader syntheticFieldLoader() {
+        String value = fieldType().value();
+        ;
+        if (value == null) {
+            return SourceLoader.SyntheticFieldLoader.NOTHING;
+        }
         return new SourceLoader.SyntheticFieldLoader() {
             @Override
             public Stream<Map.Entry<String, StoredFieldLoader>> storedFieldLoaders() {
@@ -319,17 +324,12 @@ public class ConstantKeywordFieldMapper extends FieldMapper {
 
             @Override
             public DocValuesLoader docValuesLoader(LeafReader reader, int[] docIdsInLeaf) {
-                /*
-                 * If there is a value we need to enable objects containing these
-                 * fields. We could build something special for fields that are
-                 * always "on", but constant_keyword fields are rare enough that
-                 * having an extra doc values loader that always returns `true`
-                 * isn't a big performance hit and gets the job done.
-                 */
-                if (fieldType().value == null) {
-                    return null;
-                }
                 return docId -> true;
+            }
+
+            @Override
+            public boolean hasValue() {
+                return true;
             }
 
             @Override


### PR DESCRIPTION
When I added support for stored fields to synthetic _source (#87480) I
accidentally caused a performance regression. Our friends working on
building the nightly charts for tsdb caught it. It looked like:
![image](https://user-images.githubusercontent.com/215970/186497649-acb65479-aa73-49e5-a716-869e2b98c0c7.png)

on my laptop that recreates to something like:
```
|   50th percentile latency | default_1k | 20.1228 | 41.289  | 21.1662  | ms | +105.18% |
|   90th percentile latency | default_1k | 26.7402 | 42.5878 | 15.8476  | ms |  +59.27% |
|   99th percentile latency | default_1k | 37.0881 | 45.586  |  8.49786 | ms |  +22.91% |
| 99.9th percentile latency | default_1k | 43.7346 | 48.222  |  4.48742 | ms |  +10.26% |
|  100th percentile latency | default_1k | 46.057  | 56.8676 | 10.8106  | ms |  +23.47% |
```

This fixes the regression and puts us in line with how we were:
```
|   50th percentile latency | default_1k | 20.1228 | 24.023  |  3.90022 | ms |  +19.38% |
|   90th percentile latency | default_1k | 26.7402 | 29.7841 |  3.04392 | ms |  +11.38% |
|   99th percentile latency | default_1k | 37.0881 | 36.8038 | -0.28428 | ms |   -0.77% |
| 99.9th percentile latency | default_1k | 43.7346 | 39.0192 | -4.71531 | ms |  -10.78% |
|  100th percentile latency | default_1k | 46.057  | 42.9181 | -3.13889 | ms |   -6.82% |
```

A 20% bump in the 50% latency isn't great, but it four microseconds per
document which is acceptable.
