### PR TITLE
Correct span gap position in graph-producing match_phrase queries

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/search/MatchQueryParser.java
+++ b/server/src/main/java/org/elasticsearch/index/search/MatchQueryParser.java
@@ -446,11 +446,11 @@ public class MatchQueryParser {
             SpanNearQuery.Builder builder = new SpanNearQuery.Builder(field, true);
             Term lastTerm = null;
             while (in.incrementToken()) {
-                if (posIncAtt.getPositionIncrement() > 1) {
-                    builder.addGap(posIncAtt.getPositionIncrement() - 1);
-                }
                 if (lastTerm != null) {
                     builder.addClause(new SpanTermQuery(lastTerm));
+                }
+                if (posIncAtt.getPositionIncrement() > 1) {
+                    builder.addGap(posIncAtt.getPositionIncrement() - 1);
                 }
                 lastTerm = new Term(field, termAtt.getBytesRef());
             }


### PR DESCRIPTION
Re-order the span near query building operation to append the _previous_ term in the token stream before appending the gap preceding the _current_ term.

Fixes https://github.com/elastic/elasticsearch/issues/86021

Things I haven't done:
- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
