### PR TITLE
[Doc] Clarify unsupported operations with DLS/FLS

### DIFF
--- a/x-pack/docs/en/security/limitations.asciidoc
+++ b/x-pack/docs/en/security/limitations.asciidoc
@@ -50,6 +50,12 @@ When a user's role enables document or <<field-level-security,field level securi
 * The user cannot perform write operations:
 ** The update API isn't supported.
 ** Update requests included in bulk requests aren't supported.
+* The user cannot perform operations that effectively make contents accessible under another name, including:
+** <<indices-clone-index,Clone index API>>
+** <<indices-shrink-index,Shrink index API>>
+** <<indices-split-index,Split index API>>
+** <<indices-aliases,Aliases API>>
+
 * The request cache is disabled for search requests if either of the following are true:
 ** The role query that defines document level security is <<templating-role-query,templated>>
 using a <<script-stored-scripts,stored script>>.

--- a/x-pack/docs/en/security/limitations.asciidoc
+++ b/x-pack/docs/en/security/limitations.asciidoc
@@ -50,7 +50,8 @@ When a user's role enables document or <<field-level-security,field level securi
 * The user cannot perform write operations:
 ** The update API isn't supported.
 ** Update requests included in bulk requests aren't supported.
-* The user cannot perform operations that effectively make contents accessible under another name, including:
+* The user cannot perform operations that effectively make contents accessible
+under another name, including actions from the following APIs:
 ** <<indices-clone-index,Clone index API>>
 ** <<indices-shrink-index,Shrink index API>>
 ** <<indices-split-index,Split index API>>


### PR DESCRIPTION
When DLS/FLS is enabled on an index for a user, the user will not be
able to perform operations that can make data content accessible under a
different name. This is intentional. This PR makes it clear in the doc.

doc preview link: https://elasticsearch_89606.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/security-limitations.html#field-document-limitations