### PR TITLE
Cleanup dead branch and duplication in ThreadContext

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/service/MasterService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/service/MasterService.java
@@ -910,7 +910,7 @@ public class MasterService extends AbstractLifecycleComponent {
         @Override
         public Releasable captureResponseHeaders() {
             final var threadContext = updateTask.getThreadContext();
-            final var storedContext = threadContext.newStoredContext(false);
+            final var storedContext = threadContext.newStoredContext();
             return Releasables.wrap(() -> {
                 final var newResponseHeaders = threadContext.getResponseHeaders();
                 if (newResponseHeaders.isEmpty()) {
@@ -1044,7 +1044,7 @@ public class MasterService extends AbstractLifecycleComponent {
         ThreadContext threadContext
     ) {
         final var taskContexts = castTaskContexts(executionResults);
-        try (var ignored = threadContext.newStoredContext(false)) {
+        try (var ignored = threadContext.newStoredContext()) {
             // if the executor leaks a response header then this will cause a test failure, but we also store the context here to be sure
             // to avoid leaking headers in production that were missed by tests
 
@@ -1053,7 +1053,7 @@ public class MasterService extends AbstractLifecycleComponent {
                     new ClusterStateTaskExecutor.BatchExecutionContext<>(
                         previousClusterState,
                         taskContexts,
-                        () -> threadContext.newStoredContext(false)
+                        threadContext::newStoredContext
                     )
                 );
             } catch (Exception e) {

--- a/server/src/main/java/org/elasticsearch/common/util/concurrent/ThreadContext.java
+++ b/server/src/main/java/org/elasticsearch/common/util/concurrent/ThreadContext.java
@@ -135,12 +135,9 @@ public final class ThreadContext implements Writeable {
         }
         threadLocal.set(threadContextStruct);
 
-        return () -> {
-            // If the node and thus the threadLocal get closed while this task
-            // is still executing, we don't want this runnable to fail with an
-            // uncaught exception
-            threadLocal.set(context);
-        };
+        // If the node and thus the threadLocal get closed while this task is still executing, we don't want this runnable to fail with an
+        // uncaught exception
+        return storedOriginalContext(context);
     }
 
     /**
@@ -171,22 +168,21 @@ public final class ThreadContext implements Writeable {
             newTransientHeaders.put("parent_" + Task.APM_TRACE_CONTEXT, previousTraceContext);
         }
 
-        threadLocal.set(
-            new ThreadContextStruct(
-                newRequestHeaders,
-                originalContext.responseHeaders,
-                newTransientHeaders,
-                originalContext.isSystemContext,
-                originalContext.warningHeadersSize
-            )
-        );
         // this is the context when this method returns
-        final ThreadContextStruct newContext = threadLocal.get();
+        final ThreadContextStruct newContext = new ThreadContextStruct(
+            newRequestHeaders,
+            originalContext.responseHeaders,
+            newTransientHeaders,
+            originalContext.isSystemContext,
+            originalContext.warningHeadersSize
+        );
+        threadLocal.set(newContext);
+        // Tracing shouldn't interrupt the propagation of response headers, so in the same as
+        // #newStoredContextPreservingResponseHeaders(), pass on any potential changes to the response headers.
         return () -> {
-            if (threadLocal.get() != newContext) {
-                // Tracing shouldn't interrupt the propagation of response headers, so in the same as #newStoredContext(...),
-                // pass on any potential changes to the response headers.
-                threadLocal.set(originalContext.putResponseHeaders(threadLocal.get().responseHeaders));
+            var found = threadLocal.get();
+            if (found != newContext) {
+                threadLocal.set(originalContext.putResponseHeaders(found.responseHeaders));
             } else {
                 threadLocal.set(originalContext);
             }
@@ -229,7 +225,11 @@ public final class ThreadContext implements Writeable {
                 context.warningHeadersSize
             )
         );
-        return () -> threadLocal.set(context);
+        return storedOriginalContext(context);
+    }
+
+    private StoredContext storedOriginalContext(ThreadContextStruct originalContext) {
+        return () -> threadLocal.set(originalContext);
     }
 
     private static Map<String, String> getHeadersToCopy(ThreadContextStruct context) {
@@ -286,15 +286,28 @@ public final class ThreadContext implements Writeable {
         Map<String, String> newHeader = new HashMap<>(headers);
         newHeader.putAll(context.requestHeaders);
         threadLocal.set(DEFAULT_CONTEXT.putHeaders(newHeader));
-        return () -> threadLocal.set(context);
+        return storedOriginalContext(context);
+    }
+
+    /**
+     * Just like {@link #stashContext()} but no default context is set and the response headers of the restore thread will be preserved.
+     */
+    public StoredContext newStoredContextPreservingResponseHeaders() {
+        final ThreadContextStruct originalContext = threadLocal.get();
+        return () -> {
+            var found = threadLocal.get();
+            if (found != originalContext) {
+                threadLocal.set(originalContext.putResponseHeaders(found.responseHeaders));
+            }
+        };
     }
 
     /**
      * Just like {@link #stashContext()} but no default context is set.
-     * @param preserveResponseHeaders if set to <code>true</code> the response headers of the restore thread will be preserved.
      */
-    public StoredContext newStoredContext(boolean preserveResponseHeaders) {
-        return newStoredContext(preserveResponseHeaders, List.of());
+    public StoredContext newStoredContext() {
+        final ThreadContextStruct originalContext = threadLocal.get();
+        return storedOriginalContext(originalContext);
     }
 
     /**
@@ -302,9 +315,8 @@ public final class ThreadContext implements Writeable {
      * to clear specific transient headers in the new context. All headers (with the possible exception of {@code responseHeaders}) are
      * restored by closing the returned {@link StoredContext}.
      *
-     * @param preserveResponseHeaders if set to <code>true</code> the response headers of the restore thread will be preserved.
      */
-    public StoredContext newStoredContext(boolean preserveResponseHeaders, Collection<String> transientHeadersToClear) {
+    public StoredContext newStoredContext(Collection<String> transientHeadersToClear) {
         final ThreadContextStruct originalContext = threadLocal.get();
         // clear specific transient headers from the current context
         Map<String, Object> newTransientHeaders = null;
@@ -316,6 +328,7 @@ public final class ThreadContext implements Writeable {
                 newTransientHeaders.remove(transientHeaderToClear);
             }
         }
+        // this is the context when this method returns
         if (newTransientHeaders != null) {
             ThreadContextStruct threadContextStruct = new ThreadContextStruct(
                 originalContext.requestHeaders,
@@ -326,19 +339,11 @@ public final class ThreadContext implements Writeable {
             );
             threadLocal.set(threadContextStruct);
         }
-        // this is the context when this method returns
-        final ThreadContextStruct newContext = threadLocal.get();
-        return () -> {
-            if (preserveResponseHeaders && threadLocal.get() != newContext) {
-                threadLocal.set(originalContext.putResponseHeaders(threadLocal.get().responseHeaders));
-            } else {
-                threadLocal.set(originalContext);
-            }
-        };
+        return storedOriginalContext(originalContext);
     }
 
     /**
-     * Returns a supplier that gathers a {@link #newStoredContext(boolean)} and restores it once the
+     * Returns a supplier that gathers a {@link #newStoredContextPreservingResponseHeaders()} and restores it once the
      * returned supplier is invoked. The context returned from the supplier is a stored version of the
      * suppliers callers context that should be restored once the originally gathered context is not needed anymore.
      * For instance this method should be used like this:
@@ -359,7 +364,7 @@ public final class ThreadContext implements Writeable {
      * @return a restorable context supplier
      */
     public Supplier<StoredContext> newRestorableContext(boolean preserveResponseHeaders) {
-        return wrapRestorable(newStoredContext(preserveResponseHeaders));
+        return wrapRestorable(preserveResponseHeaders ? newStoredContextPreservingResponseHeaders() : newStoredContext());
     }
 
     /**
@@ -368,7 +373,7 @@ public final class ThreadContext implements Writeable {
      */
     public Supplier<StoredContext> wrapRestorable(StoredContext storedContext) {
         return () -> {
-            StoredContext context = newStoredContext(false);
+            StoredContext context = newStoredContext();
             storedContext.restore();
             return context;
         };
@@ -809,7 +814,7 @@ public final class ThreadContext implements Writeable {
         private final ThreadContext.StoredContext ctx;
 
         private ContextPreservingRunnable(Runnable in) {
-            ctx = newStoredContext(false);
+            ctx = newStoredContext();
             this.in = in;
         }
 
@@ -844,7 +849,7 @@ public final class ThreadContext implements Writeable {
         private ThreadContext.StoredContext threadsOriginalContext = null;
 
         private ContextPreservingAbstractRunnable(AbstractRunnable in, boolean useNewTraceContext) {
-            creatorsContext = newStoredContext(false);
+            creatorsContext = newStoredContext();
             this.in = in;
             this.useNewTraceContext = useNewTraceContext;
         }

--- a/server/src/main/java/org/elasticsearch/index/shard/RefreshListeners.java
+++ b/server/src/main/java/org/elasticsearch/index/shard/RefreshListeners.java
@@ -144,7 +144,7 @@ public final class RefreshListeners implements ReferenceManager.RefreshListener,
             List<Tuple<Translog.Location, Consumer<Boolean>>> listeners = locationRefreshListeners;
             final int maxRefreshes = getMaxRefreshListeners.getAsInt();
             if (refreshForcers == 0 && roomForListener(maxRefreshes, listeners, checkpointRefreshListeners)) {
-                ThreadContext.StoredContext storedContext = threadContext.newStoredContext(true);
+                ThreadContext.StoredContext storedContext = threadContext.newStoredContextPreservingResponseHeaders();
                 Consumer<Boolean> contextPreservingListener = forced -> {
                     try (ThreadContext.StoredContext ignore = threadContext.stashContext()) {
                         storedContext.restore();

--- a/server/src/test/java/org/elasticsearch/cluster/service/MasterServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/service/MasterServiceTests.java
@@ -891,7 +891,7 @@ public class MasterServiceTests extends ESTestCase {
             );
 
             for (int i = 0; i < taskCount; i++) {
-                try (ThreadContext.StoredContext ignored = threadContext.newStoredContext(false)) {
+                try (ThreadContext.StoredContext ignored = threadContext.newStoredContext()) {
                     final String testContextHeaderValue = randomAlphaOfLength(10);
                     threadContext.putHeader(testContextHeaderName, testContextHeaderValue);
                     final var task = new Task(testContextHeaderValue);
@@ -975,7 +975,7 @@ public class MasterServiceTests extends ESTestCase {
             final CountDownLatch publishSuccessCountdown = new CountDownLatch(toSubmit);
 
             for (int i = 0; i < toSubmit; i++) {
-                try (ThreadContext.StoredContext ignored = threadContext.newStoredContext(false)) {
+                try (ThreadContext.StoredContext ignored = threadContext.newStoredContext()) {
                     final var testContextHeaderValue = randomAlphaOfLength(10);
                     final var testResponseHeaderValue = randomAlphaOfLength(10);
                     threadContext.putHeader(testContextHeaderName, testContextHeaderValue);
@@ -1017,7 +1017,7 @@ public class MasterServiceTests extends ESTestCase {
             final CountDownLatch publishFailureCountdown = new CountDownLatch(toSubmit);
 
             for (int i = 0; i < toSubmit; i++) {
-                try (ThreadContext.StoredContext ignored = threadContext.newStoredContext(false)) {
+                try (ThreadContext.StoredContext ignored = threadContext.newStoredContext()) {
                     final String testContextHeaderValue = randomAlphaOfLength(10);
                     final String testResponseHeaderValue = randomAlphaOfLength(10);
                     threadContext.putHeader(testContextHeaderName, testContextHeaderValue);

--- a/server/src/test/java/org/elasticsearch/common/util/concurrent/ThreadContextTests.java
+++ b/server/src/test/java/org/elasticsearch/common/util/concurrent/ThreadContextTests.java
@@ -64,7 +64,6 @@ public class ThreadContextTests extends ESTestCase {
         // foo is the only existing transient header that is cleared
         try (
             ThreadContext.StoredContext stashed = threadContext.newStoredContext(
-                false,
                 randomFrom(List.of("foo", "foo"), List.of("foo"), List.of("foo", "acme"))
             )
         ) {
@@ -105,7 +104,6 @@ public class ThreadContextTests extends ESTestCase {
         // test stashed missing header stays missing
         try (
             ThreadContext.StoredContext stashed = threadContext.newStoredContext(
-                randomBoolean(),
                 randomFrom(Arrays.asList("acme", "acme"), Arrays.asList("acme"))
             )
         ) {
@@ -113,22 +111,6 @@ public class ThreadContextTests extends ESTestCase {
             threadContext.putTransient("acme", "foo");
         }
         assertNull(threadContext.getTransient("acme"));
-
-        // test preserved response headers
-        try (
-            ThreadContext.StoredContext stashed = threadContext.newStoredContext(
-                true,
-                randomFrom(List.of("foo", "foo"), List.of("foo"), List.of("foo", "acme"))
-            )
-        ) {
-            threadContext.addResponseHeader("baz", "bar");
-            threadContext.addResponseHeader("foo", "baz");
-        }
-        assertEquals("bar", threadContext.getResponseHeaders().get("foo").get(0));
-        assertEquals("baz", threadContext.getResponseHeaders().get("foo").get(1));
-        assertEquals(2, threadContext.getResponseHeaders().get("foo").size());
-        assertEquals("bar", threadContext.getResponseHeaders().get("baz").get(0));
-        assertEquals(1, threadContext.getResponseHeaders().get("baz").size());
     }
 
     public void testStashWithOrigin() {
@@ -188,7 +170,7 @@ public class ThreadContextTests extends ESTestCase {
         assertEquals("bar", threadContext.getHeader("foo"));
         assertEquals(Integer.valueOf(1), threadContext.getTransient("ctx.foo"));
         assertEquals("1", threadContext.getHeader("default"));
-        ThreadContext.StoredContext storedContext = threadContext.newStoredContext(false);
+        ThreadContext.StoredContext storedContext = threadContext.newStoredContext();
         threadContext.putHeader("foo.bar", "baz");
         try (ThreadContext.StoredContext ctx = threadContext.stashContext()) {
             assertNull(threadContext.getHeader("foo"));

--- a/server/src/test/java/org/elasticsearch/index/shard/IndexShardOperationPermitsTests.java
+++ b/server/src/test/java/org/elasticsearch/index/shard/IndexShardOperationPermitsTests.java
@@ -279,7 +279,7 @@ public class IndexShardOperationPermitsTests extends ESTestCase {
         try (Releasable ignored = blockAndWait()) {
             // we preserve the thread context here so that we have a different context in the call to acquire than the context present
             // when the releasable is closed
-            try (ThreadContext.StoredContext ignore = context.newStoredContext(false)) {
+            try (ThreadContext.StoredContext ignore = context.newStoredContext()) {
                 context.putHeader("foo", "bar");
                 context.putTransient("bar", "baz");
                 // test both with and without a executor name

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/common/IteratingActionListener.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/common/IteratingActionListener.java
@@ -113,7 +113,7 @@ public final class IteratingActionListener<T, U> implements ActionListener<T>, R
         } else if (position < 0 || position >= consumables.size()) {
             onFailure(new IllegalStateException("invalid position [" + position + "]. List size [" + consumables.size() + "]"));
         } else {
-            try (ThreadContext.StoredContext ignore = threadContext.newStoredContext(false)) {
+            try (ThreadContext.StoredContext ignore = threadContext.newStoredContext()) {
                 consumer.accept(consumables.get(position++), this);
             } catch (Exception e) {
                 onFailure(e);
@@ -125,7 +125,7 @@ public final class IteratingActionListener<T, U> implements ActionListener<T>, R
     public void onResponse(T response) {
         // we need to store the context here as there is a chance that this method is called from a thread outside of the ThreadPool
         // like a LDAP connection reader thread and we can pollute the context in certain cases
-        try (ThreadContext.StoredContext ignore = threadContext.newStoredContext(false)) {
+        try (ThreadContext.StoredContext ignore = threadContext.newStoredContext()) {
             final boolean continueIteration = iterationPredicate.test(response);
             if (continueIteration) {
                 if (position == consumables.size()) {
@@ -147,7 +147,7 @@ public final class IteratingActionListener<T, U> implements ActionListener<T>, R
     public void onFailure(Exception e) {
         // we need to store the context here as there is a chance that this method is called from a thread outside of the ThreadPool
         // like a LDAP connection reader thread and we can pollute the context in certain cases
-        try (ThreadContext.StoredContext ignore = threadContext.newStoredContext(false)) {
+        try (ThreadContext.StoredContext ignore = threadContext.newStoredContext()) {
             delegate.onFailure(e);
         }
     }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/SecurityContext.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/SecurityContext.java
@@ -115,7 +115,7 @@ public class SecurityContext {
      */
     public void executeAsInternalUser(User internalUser, Version version, Consumer<StoredContext> consumer) {
         assert User.isInternal(internalUser);
-        final StoredContext original = threadContext.newStoredContext(true);
+        final StoredContext original = threadContext.newStoredContextPreservingResponseHeaders();
         try (ThreadContext.StoredContext ignore = threadContext.stashContext()) {
             setInternalUser(internalUser, version);
             consumer.accept(original);
@@ -135,7 +135,7 @@ public class SecurityContext {
      * returns, the original context is restored.
      */
     public <T> T executeWithAuthentication(Authentication authentication, Function<StoredContext, T> consumer) {
-        final StoredContext original = threadContext.newStoredContext(true);
+        final StoredContext original = threadContext.newStoredContextPreservingResponseHeaders();
         try (ThreadContext.StoredContext ignore = threadContext.stashContext()) {
             setAuthentication(authentication);
             return consumer.apply(original);
@@ -149,7 +149,7 @@ public class SecurityContext {
     public void executeAfterRewritingAuthentication(Consumer<StoredContext> consumer, Version version) {
         // Preserve request headers other than authentication
         final Map<String, String> existingRequestHeaders = threadContext.getRequestHeadersOnly();
-        final StoredContext original = threadContext.newStoredContext(true);
+        final StoredContext original = threadContext.newStoredContextPreservingResponseHeaders();
         final Authentication authentication = getAuthentication();
         try (ThreadContext.StoredContext ignore = threadContext.stashContext()) {
             setAuthentication(authentication.maybeRewriteForOlderVersion(version));

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authc/support/SecondaryAuthenticationTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authc/support/SecondaryAuthenticationTests.java
@@ -94,7 +94,7 @@ public class SecondaryAuthenticationTests extends ESTestCase {
             secondaryAuth.execute(storedContext -> {
                 assertThat(securityContext.getUser().principal(), equalTo("u2"));
                 assertThat(securityContext.getAuthentication(), sameInstance(authentication2));
-                secondaryContext.set(threadPool.getThreadContext().newStoredContext(false));
+                secondaryContext.set(threadPool.getThreadContext().newStoredContext());
                 storedContext.restore();
                 assertThat(securityContext.getUser().principal(), equalTo("u1"));
                 return null;

--- a/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/xpack/security/authz/SecuritySearchOperationListenerTests.java
+++ b/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/xpack/security/authz/SecuritySearchOperationListenerTests.java
@@ -128,7 +128,7 @@ public class SecuritySearchOperationListenerTests extends ESSingleNodeTestCase {
             AuditTrailService auditTrailService = new AuditTrailService(Collections.singletonList(auditTrail), licenseState);
 
             SecuritySearchOperationListener listener = new SecuritySearchOperationListener(securityContext, auditTrailService);
-            try (StoredContext ignore = threadContext.newStoredContext(false)) {
+            try (StoredContext ignore = threadContext.newStoredContext()) {
                 Authentication authentication = AuthenticationTestHelper.builder()
                     .user(new User("test", "role"))
                     .realmRef(new RealmRef("realm", "file", "node"))
@@ -139,7 +139,7 @@ public class SecuritySearchOperationListenerTests extends ESSingleNodeTestCase {
                 verifyNoMoreInteractions(auditTrail);
             }
 
-            try (StoredContext ignore = threadContext.newStoredContext(false)) {
+            try (StoredContext ignore = threadContext.newStoredContext()) {
                 final String nodeName = randomAlphaOfLengthBetween(1, 8);
                 final String realmName = randomAlphaOfLengthBetween(1, 16);
                 Authentication authentication = AuthenticationTestHelper.builder()
@@ -152,7 +152,7 @@ public class SecuritySearchOperationListenerTests extends ESSingleNodeTestCase {
                 verifyNoMoreInteractions(auditTrail);
             }
 
-            try (StoredContext ignore = threadContext.newStoredContext(false)) {
+            try (StoredContext ignore = threadContext.newStoredContext()) {
                 final String nodeName = randomBoolean() ? "node" : randomAlphaOfLengthBetween(1, 8);
                 final String realmName = randomBoolean() ? "realm" : randomAlphaOfLengthBetween(1, 16);
                 final String type = randomAlphaOfLengthBetween(5, 16);
@@ -183,7 +183,7 @@ public class SecuritySearchOperationListenerTests extends ESSingleNodeTestCase {
             }
 
             // another user running as the original user
-            try (StoredContext ignore = threadContext.newStoredContext(false)) {
+            try (StoredContext ignore = threadContext.newStoredContext()) {
                 final String nodeName = randomBoolean() ? "node" : randomAlphaOfLengthBetween(1, 8);
                 final String realmName = randomBoolean() ? "realm" : randomAlphaOfLengthBetween(1, 16);
                 final String type = randomAlphaOfLengthBetween(5, 16);
@@ -203,7 +203,7 @@ public class SecuritySearchOperationListenerTests extends ESSingleNodeTestCase {
             }
 
             // the user that authenticated for the run as request
-            try (StoredContext ignore = threadContext.newStoredContext(false)) {
+            try (StoredContext ignore = threadContext.newStoredContext()) {
                 final String nodeName = randomBoolean() ? "node" : randomAlphaOfLengthBetween(1, 8);
                 final String realmName = randomBoolean() ? "realm" : randomAlphaOfLengthBetween(1, 16);
                 final String type = randomAlphaOfLengthBetween(5, 16);

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/filter/SecurityActionFilter.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/filter/SecurityActionFilter.java
@@ -110,7 +110,7 @@ public class SecurityActionFilter implements ActionFilter {
                     (original) -> { applyInternal(task, chain, action, request, contextPreservingListener); }
                 );
             } else {
-                try (ThreadContext.StoredContext ignore = threadContext.newStoredContext(true)) {
+                try (ThreadContext.StoredContext ignore = threadContext.newStoredContextPreservingResponseHeaders()) {
                     applyInternal(task, chain, action, request, contextPreservingListener);
                 }
             }

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authz/AuthorizationService.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authz/AuthorizationService.java
@@ -226,7 +226,7 @@ public class AuthorizationService {
          * previous parent action that ran under the same thread context (also on the same node).
          * When the returned {@code StoredContext} is closed, ALL the original headers are restored.
          */
-        try (ThreadContext.StoredContext ignore = threadContext.newStoredContext(false, ACTION_SCOPE_AUTHORIZATION_KEYS)) {
+        try (ThreadContext.StoredContext ignore = threadContext.newStoredContext(ACTION_SCOPE_AUTHORIZATION_KEYS)) {
             // this does not clear {@code AuthorizationServiceField.ORIGINATING_ACTION_KEY}
             // prior to doing any authorization lets set the originating action in the thread context
             // the originating action is the current action if no originating action has yet been set in the current thread context

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/transport/SecurityServerTransportInterceptor.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/transport/SecurityServerTransportInterceptor.java
@@ -277,7 +277,7 @@ public class SecurityServerTransportInterceptor implements TransportInterceptor 
 
         @Override
         public void messageReceived(T request, TransportChannel channel, Task task) {
-            try (ThreadContext.StoredContext ctx = threadContext.newStoredContext(true)) {
+            try (ThreadContext.StoredContext ctx = threadContext.newStoredContextPreservingResponseHeaders()) {
                 String profile = channel.getProfileName();
                 ServerTransportFilter filter = profileFilters.get(profile);
 

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/AuthenticationServiceTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/AuthenticationServiceTests.java
@@ -2217,7 +2217,7 @@ public class AuthenticationServiceTests extends ESTestCase {
     public void testCanAuthenticateServiceAccount() {
         Mockito.reset(serviceAccountService);
         final Authentication authentication = AuthenticationTestHelper.builder().serviceAccount().build();
-        try (ThreadContext.StoredContext ignored = threadContext.newStoredContext(false)) {
+        try (ThreadContext.StoredContext ignored = threadContext.newStoredContext()) {
             boolean requestIdAlreadyPresent = randomBoolean();
             SetOnce<String> reqId = new SetOnce<>();
             if (requestIdAlreadyPresent) {
@@ -2246,7 +2246,7 @@ public class AuthenticationServiceTests extends ESTestCase {
     public void testServiceAccountFailureWillNotFallthrough() throws IOException {
         Mockito.reset(serviceAccountService);
         final ElasticsearchSecurityException bailOut = new ElasticsearchSecurityException("bail out", RestStatus.UNAUTHORIZED);
-        try (ThreadContext.StoredContext ignored = threadContext.newStoredContext(false)) {
+        try (ThreadContext.StoredContext ignored = threadContext.newStoredContext()) {
             boolean requestIdAlreadyPresent = randomBoolean();
             SetOnce<String> reqId = new SetOnce<>();
             if (requestIdAlreadyPresent) {

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/TokenServiceTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/TokenServiceTests.java
@@ -262,7 +262,7 @@ public class TokenServiceTests extends ESTestCase {
         ThreadContext requestContext = new ThreadContext(Settings.EMPTY);
         requestContext.putHeader("Authorization", randomFrom("Bearer ", "BEARER ", "bearer ") + accessToken);
 
-        try (ThreadContext.StoredContext ignore = requestContext.newStoredContext(true)) {
+        try (ThreadContext.StoredContext ignore = requestContext.newStoredContextPreservingResponseHeaders()) {
             PlainActionFuture<UserToken> future = new PlainActionFuture<>();
             final SecureString bearerToken = Authenticator.extractBearerTokenFromHeader(requestContext);
             tokenService.tryAuthenticateToken(bearerToken, future);
@@ -270,7 +270,7 @@ public class TokenServiceTests extends ESTestCase {
             assertAuthentication(authentication, serialized.getAuthentication());
         }
 
-        try (ThreadContext.StoredContext ignore = requestContext.newStoredContext(true)) {
+        try (ThreadContext.StoredContext ignore = requestContext.newStoredContextPreservingResponseHeaders()) {
             // verify a second separate token service with its own salt can also verify
             TokenService anotherService = createTokenService(tokenServiceEnabledSettings, systemUTC());
             anotherService.refreshMetadata(tokenService.getTokenMetadata());
@@ -289,7 +289,7 @@ public class TokenServiceTests extends ESTestCase {
         String authScheme = randomFrom("Bearer ", "BEARER ", "bearer ", "Basic ");
         requestContext.putHeader("Authorization", authScheme + token);
 
-        try (ThreadContext.StoredContext ignore = requestContext.newStoredContext(true)) {
+        try (ThreadContext.StoredContext ignore = requestContext.newStoredContextPreservingResponseHeaders()) {
             PlainActionFuture<UserToken> future = new PlainActionFuture<>();
             final SecureString bearerToken = Authenticator.extractBearerTokenFromHeader(requestContext);
             tokenService.tryAuthenticateToken(bearerToken, future);
@@ -319,7 +319,7 @@ public class TokenServiceTests extends ESTestCase {
         ThreadContext requestContext = new ThreadContext(Settings.EMPTY);
         storeTokenHeader(requestContext, accessToken);
 
-        try (ThreadContext.StoredContext ignore = requestContext.newStoredContext(true)) {
+        try (ThreadContext.StoredContext ignore = requestContext.newStoredContextPreservingResponseHeaders()) {
             PlainActionFuture<UserToken> future = new PlainActionFuture<>();
             final SecureString bearerToken = Authenticator.extractBearerTokenFromHeader(requestContext);
             tokenService.tryAuthenticateToken(bearerToken, future);
@@ -327,7 +327,7 @@ public class TokenServiceTests extends ESTestCase {
             assertAuthentication(authentication, serialized.getAuthentication());
         }
 
-        try (ThreadContext.StoredContext ignore = requestContext.newStoredContext(true)) {
+        try (ThreadContext.StoredContext ignore = requestContext.newStoredContextPreservingResponseHeaders()) {
             // verify a second separate token service with its own passphrase cannot verify
             TokenService anotherService = createTokenService(tokenServiceEnabledSettings, systemUTC());
             PlainActionFuture<UserToken> future = new PlainActionFuture<>();
@@ -380,7 +380,7 @@ public class TokenServiceTests extends ESTestCase {
         ThreadContext requestContext = new ThreadContext(Settings.EMPTY);
         storeTokenHeader(requestContext, accessToken);
 
-        try (ThreadContext.StoredContext ignore = requestContext.newStoredContext(true)) {
+        try (ThreadContext.StoredContext ignore = requestContext.newStoredContextPreservingResponseHeaders()) {
             PlainActionFuture<UserToken> future = new PlainActionFuture<>();
             final SecureString bearerToken = Authenticator.extractBearerTokenFromHeader(requestContext);
             tokenService.tryAuthenticateToken(bearerToken, future);
@@ -410,7 +410,7 @@ public class TokenServiceTests extends ESTestCase {
         ThreadContext requestContext = new ThreadContext(Settings.EMPTY);
         storeTokenHeader(requestContext, accessToken);
 
-        try (ThreadContext.StoredContext ignore = requestContext.newStoredContext(true)) {
+        try (ThreadContext.StoredContext ignore = requestContext.newStoredContextPreservingResponseHeaders()) {
             PlainActionFuture<TokensInvalidationResult> future = new PlainActionFuture<>();
             tokenService.invalidateRefreshToken(clientRefreshToken, future);
             final TokensInvalidationResult result = future.get();
@@ -440,7 +440,7 @@ public class TokenServiceTests extends ESTestCase {
         ThreadContext requestContext = new ThreadContext(Settings.EMPTY);
         storeTokenHeader(requestContext, accessToken);
 
-        try (ThreadContext.StoredContext ignore = requestContext.newStoredContext(true)) {
+        try (ThreadContext.StoredContext ignore = requestContext.newStoredContextPreservingResponseHeaders()) {
             PlainActionFuture<TokensInvalidationResult> future = new PlainActionFuture<>();
             tokenService.invalidateRefreshToken(clientRefreshToken, future);
             final TokensInvalidationResult result = future.get();
@@ -548,7 +548,7 @@ public class TokenServiceTests extends ESTestCase {
         ThreadContext requestContext = new ThreadContext(Settings.EMPTY);
         storeTokenHeader(requestContext, accessToken);
 
-        try (ThreadContext.StoredContext ignore = requestContext.newStoredContext(true)) {
+        try (ThreadContext.StoredContext ignore = requestContext.newStoredContextPreservingResponseHeaders()) {
             // the clock is still frozen, so the cookie should be valid
             PlainActionFuture<UserToken> future = new PlainActionFuture<>();
             final SecureString bearerToken = Authenticator.extractBearerTokenFromHeader(requestContext);
@@ -558,7 +558,7 @@ public class TokenServiceTests extends ESTestCase {
 
         final TimeValue defaultExpiration = TokenService.TOKEN_EXPIRATION.get(Settings.EMPTY);
         final int fastForwardAmount = randomIntBetween(1, Math.toIntExact(defaultExpiration.getSeconds()) - 5);
-        try (ThreadContext.StoredContext ignore = requestContext.newStoredContext(true)) {
+        try (ThreadContext.StoredContext ignore = requestContext.newStoredContextPreservingResponseHeaders()) {
             // move the clock forward but don't go to expiry
             clock.fastForwardSeconds(fastForwardAmount);
             PlainActionFuture<UserToken> future = new PlainActionFuture<>();
@@ -567,7 +567,7 @@ public class TokenServiceTests extends ESTestCase {
             assertAuthentication(authentication, future.get().getAuthentication());
         }
 
-        try (ThreadContext.StoredContext ignore = requestContext.newStoredContext(true)) {
+        try (ThreadContext.StoredContext ignore = requestContext.newStoredContextPreservingResponseHeaders()) {
             // move to expiry, stripping nanoseconds, as we don't store them in the security-tokens index
             clock.setTime(userToken.getExpirationTime().truncatedTo(ChronoUnit.MILLIS).atZone(clock.getZone()));
             PlainActionFuture<UserToken> future = new PlainActionFuture<>();
@@ -576,7 +576,7 @@ public class TokenServiceTests extends ESTestCase {
             assertAuthentication(authentication, future.get().getAuthentication());
         }
 
-        try (ThreadContext.StoredContext ignore = requestContext.newStoredContext(true)) {
+        try (ThreadContext.StoredContext ignore = requestContext.newStoredContextPreservingResponseHeaders()) {
             // move one second past expiry
             clock.fastForwardSeconds(1);
             PlainActionFuture<UserToken> future = new PlainActionFuture<>();
@@ -657,7 +657,7 @@ public class TokenServiceTests extends ESTestCase {
         ThreadContext requestContext = new ThreadContext(Settings.EMPTY);
         storeTokenHeader(requestContext, Base64.getEncoder().encodeToString(randomBytes));
 
-        try (ThreadContext.StoredContext ignore = requestContext.newStoredContext(true)) {
+        try (ThreadContext.StoredContext ignore = requestContext.newStoredContextPreservingResponseHeaders()) {
             PlainActionFuture<UserToken> future = new PlainActionFuture<>();
             final SecureString bearerToken = Authenticator.extractBearerTokenFromHeader(requestContext);
             tokenService.tryAuthenticateToken(bearerToken, future);
@@ -676,7 +676,7 @@ public class TokenServiceTests extends ESTestCase {
         ThreadContext requestContext = new ThreadContext(Settings.EMPTY);
         storeTokenHeader(requestContext, generateAccessToken(tokenService, Version.V_7_1_0));
 
-        try (ThreadContext.StoredContext ignore = requestContext.newStoredContext(true)) {
+        try (ThreadContext.StoredContext ignore = requestContext.newStoredContextPreservingResponseHeaders()) {
             PlainActionFuture<UserToken> future = new PlainActionFuture<>();
             final SecureString bearerToken = Authenticator.extractBearerTokenFromHeader(requestContext);
             tokenService.tryAuthenticateToken(bearerToken, future);
@@ -695,7 +695,7 @@ public class TokenServiceTests extends ESTestCase {
         ThreadContext requestContext = new ThreadContext(Settings.EMPTY);
         storeTokenHeader(requestContext, generateAccessToken(tokenService, randomFrom(Version.V_7_2_0, Version.V_7_3_2)));
 
-        try (ThreadContext.StoredContext ignore = requestContext.newStoredContext(true)) {
+        try (ThreadContext.StoredContext ignore = requestContext.newStoredContextPreservingResponseHeaders()) {
             PlainActionFuture<UserToken> future = new PlainActionFuture<>();
             final SecureString bearerToken = Authenticator.extractBearerTokenFromHeader(requestContext);
             tokenService.tryAuthenticateToken(bearerToken, future);
@@ -738,7 +738,7 @@ public class TokenServiceTests extends ESTestCase {
             when(securityMainIndex.indexExists()).thenReturn(false);
             when(securityMainIndex.freeze()).thenReturn(securityMainIndex);
         }
-        try (ThreadContext.StoredContext ignore = requestContext.newStoredContext(true)) {
+        try (ThreadContext.StoredContext ignore = requestContext.newStoredContextPreservingResponseHeaders()) {
             PlainActionFuture<UserToken> future = new PlainActionFuture<>();
             final SecureString bearerToken3 = Authenticator.extractBearerTokenFromHeader(requestContext);
             tokenService.tryAuthenticateToken(bearerToken3, future);

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/support/SecondaryAuthenticatorTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/support/SecondaryAuthenticatorTests.java
@@ -239,7 +239,7 @@ public class SecondaryAuthenticatorTests extends ESTestCase {
         final PlainActionFuture<SecondaryAuthentication> future = new PlainActionFuture<>();
         final AtomicReference<ThreadContext.StoredContext> listenerContext = new AtomicReference<>();
         consumer.accept(ActionListener.wrap(result -> {
-            listenerContext.set(securityContext.getThreadContext().newStoredContext(false));
+            listenerContext.set(securityContext.getThreadContext().newStoredContext());
             future.onResponse(result);
         }, e -> future.onFailure(e)));
 
@@ -282,7 +282,7 @@ public class SecondaryAuthenticatorTests extends ESTestCase {
         final PlainActionFuture<SecondaryAuthentication> future = new PlainActionFuture<>();
         final AtomicReference<ThreadContext.StoredContext> listenerContext = new AtomicReference<>();
         consumer.accept(ActionListener.wrap(future::onResponse, e -> {
-            listenerContext.set(securityContext.getThreadContext().newStoredContext(false));
+            listenerContext.set(securityContext.getThreadContext().newStoredContext());
             future.onFailure(e);
         }));
 

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authz/AuthorizationServiceTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authz/AuthorizationServiceTests.java
@@ -2136,7 +2136,7 @@ public class AuthorizationServiceTests extends ESTestCase {
         for (final Tuple<String, TransportRequest> requestTuple : requests) {
             final String action = requestTuple.v1();
             final TransportRequest request = requestTuple.v2();
-            try (ThreadContext.StoredContext ignore = threadContext.newStoredContext(false)) {
+            try (ThreadContext.StoredContext ignore = threadContext.newStoredContext()) {
                 final Authentication authentication = createAuthentication(superuser);
                 authorize(authentication, action, request);
                 verify(auditTrail).accessGranted(
@@ -2206,7 +2206,7 @@ public class AuthorizationServiceTests extends ESTestCase {
         for (final Tuple<String, TransportRequest> requestTuple : requests) {
             final String action = requestTuple.v1();
             final TransportRequest request = requestTuple.v2();
-            try (ThreadContext.StoredContext ignore = threadContext.newStoredContext(false)) {
+            try (ThreadContext.StoredContext ignore = threadContext.newStoredContext()) {
                 final Authentication authentication = createAuthentication(superuser);
                 assertThrowsAuthorizationException(
                     "authentication=[" + authentication + "], action=[" + action + "], request=[" + request + "]",
@@ -2372,7 +2372,7 @@ public class AuthorizationServiceTests extends ESTestCase {
         );
         AuditUtil.getOrGenerateRequestId(threadContext);
         mockEmptyMetadata();
-        try (ThreadContext.StoredContext ignore = threadContext.newStoredContext(false)) {
+        try (ThreadContext.StoredContext ignore = threadContext.newStoredContext()) {
             authorize(createAuthentication(userAllowed), action, request);
         }
         assertThrowsAuthorizationException(() -> authorize(createAuthentication(userDenied), action, request), action, "userDenied");


### PR DESCRIPTION
The context stashing keeps showing up in profiling on the network thread. It's not a big deal but easy to simplify and speed up a little:

We never create a stored context that has transient headers to clear while at the same
time preserves response headers. Not supporting this path allows for splitting up
the logic into 3 distinct methods that are much easier to follow logically.

Also, this commit removes a few redundant threadlocal.get and set calls.