### PR TITLE
[TEST] Fix SimpleThreadPoolIT file watcher thread name

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/threadpool/SimpleThreadPoolIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/threadpool/SimpleThreadPoolIT.java
@@ -84,7 +84,7 @@ public class SimpleThreadPoolIT extends ESIntegTestCase {
                 || threadName.contains("readiness-service")
                 || threadName.contains("JVMCI-native") // GraalVM Compiler Thread
                 || threadName.contains("file-settings-watcher")
-                || threadName.contains("FileSystemWatchService")) {
+                || threadName.contains("FileSystemWatch")) { // FileSystemWatchService(Linux/Windows), FileSystemWatcher(BSD/AIX)
                 continue;
             }
             String nodePrefix = "("


### PR DESCRIPTION
The JDK implementation of the Watcher service is platform dependent and the two base implementations: PollingWatchService and AbstractPoller differ in the internal thread name they use: FileSystemWatchService and FileSystemWatcher, respectively. 

The current SimpleThreadPoolIT test matches the JDK thread name for Linux and Windows, but you may get failures when running locally on MacOS (which uses the polling implementation).