### PR TITLE
[8.4] [TEST] Fix SimpleThreadPoolIT file watcher thread name (#89624)

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/threadpool/SimpleThreadPoolIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/threadpool/SimpleThreadPoolIT.java
@@ -84,7 +84,7 @@ public class SimpleThreadPoolIT extends ESIntegTestCase {
                 || threadName.contains("readiness-service")
                 || threadName.contains("JVMCI-native") // GraalVM Compiler Thread
                 || threadName.contains("file-settings-watcher")
-                || threadName.contains("FileSystemWatchService")) {
+                || threadName.contains("FileSystemWatch")) { // FileSystemWatchService(Linux/Windows), FileSystemWatcher(BSD/AIX)
                 continue;
             }
             String nodePrefix = "("


### PR DESCRIPTION
Backports the following commits to 8.4:
 - [TEST] Fix SimpleThreadPoolIT file watcher thread name (#89624)