### PR TITLE
Fix FileSettingsService hang on error update

### DIFF
--- a/docs/changelog/89630.yaml
+++ b/docs/changelog/89630.yaml
@@ -1,0 +1,5 @@
+pr: 89630
+summary: Fix `FileSettingsService` hang on error update
+area: Infra/Core
+type: bug
+issues: []

--- a/server/src/main/java/org/elasticsearch/reservedstate/service/ReservedStateUpdateTask.java
+++ b/server/src/main/java/org/elasticsearch/reservedstate/service/ReservedStateUpdateTask.java
@@ -28,7 +28,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.function.Consumer;
+import java.util.function.BiConsumer;
 
 import static org.elasticsearch.ExceptionsHelper.stackTrace;
 import static org.elasticsearch.core.Strings.format;
@@ -47,7 +47,7 @@ public class ReservedStateUpdateTask implements ClusterStateTaskListener {
     private final ReservedStateChunk stateChunk;
     private final Map<String, ReservedClusterStateHandler<?>> handlers;
     private final Collection<String> orderedHandlers;
-    private final Consumer<ErrorState> errorReporter;
+    private final BiConsumer<ClusterState, ErrorState> errorReporter;
     private final ActionListener<ActionResponse.Empty> listener;
 
     public ReservedStateUpdateTask(
@@ -55,7 +55,7 @@ public class ReservedStateUpdateTask implements ClusterStateTaskListener {
         ReservedStateChunk stateChunk,
         Map<String, ReservedClusterStateHandler<?>> handlers,
         Collection<String> orderedHandlers,
-        Consumer<ErrorState> errorReporter,
+        BiConsumer<ClusterState, ErrorState> errorReporter,
         ActionListener<ActionResponse.Empty> listener
     ) {
         this.namespace = namespace;
@@ -112,7 +112,7 @@ public class ReservedStateUpdateTask implements ClusterStateTaskListener {
                 ReservedStateErrorMetadata.ErrorKind.VALIDATION
             );
 
-            errorReporter.accept(errorState);
+            errorReporter.accept(currentState, errorState);
 
             throw new IllegalStateException("Error processing state change request for " + namespace + ", errors: " + errorState);
         }

--- a/server/src/test/java/org/elasticsearch/reservedstate/service/ReservedClusterStateServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/reservedstate/service/ReservedClusterStateServiceTests.java
@@ -143,7 +143,7 @@ public class ReservedClusterStateServiceTests extends ESTestCase {
                 null,
                 Collections.emptyMap(),
                 Collections.emptySet(),
-                (errorState) -> {},
+                (clusterState, errorState) -> {},
                 new ActionListener<>() {
                     @Override
                     public void onResponse(ActionResponse.Empty empty) {}
@@ -329,7 +329,7 @@ public class ReservedClusterStateServiceTests extends ESTestCase {
             new ReservedStateChunk(Map.of("one", "two", "maker", "three"), new ReservedStateVersion(2L, Version.CURRENT)),
             Map.of(exceptionThrower.name(), exceptionThrower, newStateMaker.name(), newStateMaker),
             List.of(exceptionThrower.name(), newStateMaker.name()),
-            (errorState) -> { assertFalse(ReservedClusterStateService.isNewError(operatorMetadata, errorState.version())); },
+            (clusterState, errorState) -> { assertFalse(ReservedClusterStateService.isNewError(operatorMetadata, errorState.version())); },
             new ActionListener<>() {
                 @Override
                 public void onResponse(ActionResponse.Empty empty) {}


### PR DESCRIPTION
While working on new tests for https://github.com/elastic/elasticsearch/pull/89567 I discovered a bug where on duplicate error update we don't unlock the file settings watcher thread properly.

It's a race condition where the settings file might be updated in succession quicker than the error state is updated. We check for duplicate error state and avoid the new cluster change update event, however we didn't call the error listener will null to unlock the watcher.

This is intermittent and should've been caught by our existing error state save integration tests, but just happened to be hit with the SLM specific test I was writing.