### PR TITLE
Remove needless flush call from Netty4 write handlers

### DIFF
--- a/modules/transport-netty4/src/main/java/org/elasticsearch/http/netty4/Netty4HttpPipeliningHandler.java
+++ b/modules/transport-netty4/src/main/java/org/elasticsearch/http/netty4/Netty4HttpPipeliningHandler.java
@@ -225,23 +225,14 @@ public class Netty4HttpPipeliningHandler extends ChannelDuplexHandler {
             failQueuedWrites();
             return false;
         }
-        boolean needsFlush = true;
         while (channel.isWritable()) {
             final WriteOperation currentWrite = queuedWrites.poll();
             if (currentWrite == null) {
                 break;
             }
             ctx.write(currentWrite.msg, currentWrite.promise);
-            needsFlush = true;
-            if (channel.isWritable() == false) {
-                // try flushing to make channel writable again, loop will only continue if channel becomes writable again
-                ctx.flush();
-                needsFlush = false;
-            }
         }
-        if (needsFlush) {
-            ctx.flush();
-        }
+        ctx.flush();
         if (channel.isActive() == false) {
             failQueuedWrites();
         }


### PR DESCRIPTION
These inline flush calls will never make the channel writable since
they will just get queued on the executor and run a redundant flush
execution later.
We can simplify the code here and save some cycles by simply giving up
and forwarding the flush once the channel stops being writable and
then have the logic pick up again on the next writability changed
call.
