### PR TITLE
Update changelog (release highlight) for #89106

### DIFF
--- a/docs/changelog/89106.yaml
+++ b/docs/changelog/89106.yaml
@@ -4,3 +4,15 @@ area: SQL
 type: enhancement
 issues:
  - 88764
+highlight:
+  title: Speed up SQL queries by not tracking total hits by default
+  body: |-
+    SQL query translator now explicitly sets track_total_hits to false when
+    not needed.
+    This has a significant impact on SQL query performance in cases where total hits
+    are not needed to calculate the final result, in particular when the cost of evaluation
+    of a single document is particularly high (eg. queries that involve script evaluation)
+    and in queries with a small LIMIT value.
+    In our tests, on some specific queries, we see a speed-up of more than 50%,
+    with peaks of ~95% (from 600ms to 20ms).
+  notable: true


### PR DESCRIPTION
Adding highlight section to the changelog of the [PR about SQL track_total_hits](https://github.com/elastic/elasticsearch/pull/89106), since `release highlight` label was added after the PR was already merged.