### PR TITLE
[8.4] Copy isHidden during ILM alias swap (#89650)

### DIFF
--- a/docs/changelog/89650.yaml
+++ b/docs/changelog/89650.yaml
@@ -1,0 +1,6 @@
+pr: 89650
+summary: Copy `isHidden` during ILM alias swap
+area: ILM+SLM
+type: bug
+issues:
+ - 89604

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/alias/IndicesAliasesRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/alias/IndicesAliasesRequest.java
@@ -554,6 +554,8 @@ public class IndicesAliasesRequest extends AcknowledgedRequest<IndicesAliasesReq
                 + searchRouting
                 + ",writeIndex="
                 + writeIndex
+                + ",isHidden="
+                + isHidden
                 + ",mustExist="
                 + mustExist
                 + "]";

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/SwapAliasesAndDeleteSourceIndexStep.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/SwapAliasesAndDeleteSourceIndexStep.java
@@ -132,6 +132,7 @@ public class SwapAliasesAndDeleteSourceIndexStep extends AsyncActionStep {
                     .searchRouting(aliasMetaDataToAdd.searchRouting())
                     .filter(aliasMetaDataToAdd.filter() == null ? null : aliasMetaDataToAdd.filter().string())
                     .writeIndex(null)
+                    .isHidden(aliasMetaDataToAdd.isHidden())
             );
         });
 

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/SwapAliasesAndDeleteSourceIndexStepTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/SwapAliasesAndDeleteSourceIndexStepTests.java
@@ -72,6 +72,7 @@ public class SwapAliasesAndDeleteSourceIndexStepTests extends AbstractStepTestCa
             .settings(settings(Version.CURRENT))
             .numberOfShards(randomIntBetween(1, 5))
             .numberOfReplicas(randomIntBetween(0, 5));
+        Boolean isHidden = randomFrom(Boolean.TRUE, Boolean.FALSE, null);
         AliasMetadata.Builder aliasBuilder = AliasMetadata.builder(randomAlphaOfLengthBetween(3, 10));
         if (randomBoolean()) {
             aliasBuilder.routing(randomAlphaOfLengthBetween(1, 10));
@@ -83,6 +84,7 @@ public class SwapAliasesAndDeleteSourceIndexStepTests extends AbstractStepTestCa
             aliasBuilder.indexRouting(randomAlphaOfLengthBetween(1, 10));
         }
         aliasBuilder.writeIndex(randomBoolean());
+        aliasBuilder.isHidden(isHidden);
         AliasMetadata aliasMetadata = aliasBuilder.build();
         IndexMetadata sourceIndexMetadata = sourceIndexMetadataBuilder.putAlias(aliasMetadata).build();
 
@@ -98,6 +100,7 @@ public class SwapAliasesAndDeleteSourceIndexStepTests extends AbstractStepTestCa
                 .searchRouting(aliasMetadata.searchRouting())
                 .indexRouting(aliasMetadata.indexRouting())
                 .writeIndex(null)
+                .isHidden(isHidden)
         );
 
         try (NoOpClient client = getIndicesAliasAssertingClient(expectedAliasActions)) {


### PR DESCRIPTION
Backports the following commits to 8.4:
 - Copy isHidden during ILM alias swap (#89650)