### PR TITLE
[8.4] Fix mutator for TermsEnumRequestTests. (#89643)

### DIFF
--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/termsenum/TermsEnumRequestTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/termsenum/TermsEnumRequestTests.java
@@ -93,7 +93,7 @@ public class TermsEnumRequestTests extends AbstractSerializingTestCase<TermsEnum
     @Override
     protected TermsEnumRequest mutateInstance(TermsEnumRequest instance) throws IOException {
         List<Consumer<TermsEnumRequest>> mutators = new ArrayList<>();
-        mutators.add(request -> { request.field(randomAlphaOfLengthBetween(3, 10)); });
+        mutators.add(request -> { request.field(randomValueOtherThan(request.field(), () -> randomAlphaOfLengthBetween(3, 10))); });
         mutators.add(request -> {
             String[] indices = ArrayUtils.concat(instance.indices(), generateRandomStringArray(5, 10, false, false));
             request.indices(indices);


### PR DESCRIPTION
Backports the following commits to 8.4:
 - Fix mutator for TermsEnumRequestTests. (#89643)