### PR TITLE
Improve RandomSamplerIT reliability

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/bucket/RandomSamplerIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/bucket/RandomSamplerIT.java
@@ -37,6 +37,8 @@ public class RandomSamplerIT extends ESIntegTestCase {
     private static final String UPPER_KEYWORD = "upper";
     private static final double PROBABILITY = 0.25;
     private static int numDocs;
+    private static double varMonotonic = 0.0;
+    private static double varNumeric = 0.0;
 
     private static final int NUM_SAMPLE_RUNS = 25;
 
@@ -45,16 +47,18 @@ public class RandomSamplerIT extends ESIntegTestCase {
         createIndex("idx");
         numDocs = randomIntBetween(5000, 10000);
         List<IndexRequestBuilder> builders = new ArrayList<>();
+        double avgMonotonic = 0.0;
+        double avgNumeric = 0.0;
         for (int i = 0; i < numDocs; i++) {
             final String keywordValue;
-            final double randomNumber;
+            final double numericValue;
             final double monotonicValue = randomDouble() + i;
             if (i % 2 == 0) {
                 keywordValue = LOWER_KEYWORD;
-                randomNumber = randomDoubleBetween(0.0, 3.0, false);
+                numericValue = randomDoubleBetween(0.0, 3.0, false);
             } else {
                 keywordValue = UPPER_KEYWORD;
-                randomNumber = randomDoubleBetween(5.0, 9.0, false);
+                numericValue = randomDoubleBetween(5.0, 9.0, false);
             }
             builders.add(
                 client().prepareIndex("idx")
@@ -62,10 +66,18 @@ public class RandomSamplerIT extends ESIntegTestCase {
                         jsonBuilder().startObject()
                             .field(KEYWORD_VALUE, keywordValue)
                             .field(MONOTONIC_VALUE, monotonicValue)
-                            .field(NUMERIC_VALUE, randomNumber)
+                            .field(NUMERIC_VALUE, numericValue)
                             .endObject()
                     )
             );
+
+            final double oldAvgMonotonic = avgMonotonic;
+            final double oldAvgNumeric = avgNumeric;
+            avgMonotonic = (i * avgMonotonic + monotonicValue) / (i + 1);
+            avgNumeric = (i * avgNumeric + numericValue) / (i + 1);
+            varMonotonic = (i * (varMonotonic + Math.pow(avgMonotonic - oldAvgMonotonic, 2.0)) + Math.pow(monotonicValue - avgMonotonic, 2.0)) / (i + 1);
+            varNumeric = (i * (varNumeric + Math.pow(avgNumeric - oldAvgNumeric, 2.0)) + Math.pow(numericValue - avgNumeric, 2.0)) / (i + 1);
+
         }
         indexRandom(true, builders);
         ensureSearchable();
@@ -73,7 +85,7 @@ public class RandomSamplerIT extends ESIntegTestCase {
 
     public void testRandomSampler() {
         double sampleMonotonicValue = 0.0;
-        double sampleRandomValue = 0.0;
+        double sampleNumericValue = 0.0;
         double sampledDocCount = 0.0;
 
         SearchRequest sampledRequest = client().prepareSearch("idx")
@@ -86,28 +98,34 @@ public class RandomSamplerIT extends ESIntegTestCase {
         for (int i = 0; i < NUM_SAMPLE_RUNS; i++) {
             InternalRandomSampler sampler = client().search(sampledRequest).actionGet().getAggregations().get("sampler");
             sampleMonotonicValue += ((Avg) sampler.getAggregations().get("mean_monotonic")).getValue();
-            sampleRandomValue += ((Avg) sampler.getAggregations().get("mean_numeric")).getValue();
+            sampleNumericValue += ((Avg) sampler.getAggregations().get("mean_numeric")).getValue();
             sampledDocCount += sampler.getDocCount();
         }
         sampledDocCount /= NUM_SAMPLE_RUNS;
         sampleMonotonicValue /= NUM_SAMPLE_RUNS;
-        sampleRandomValue /= NUM_SAMPLE_RUNS;
-        double countError = (numDocs * 0.25) * 0.1;
-        assertThat(Math.abs(sampledDocCount - (numDocs * 0.25)), lessThan(countError));
+        sampleNumericValue /= NUM_SAMPLE_RUNS;
+        double expectedDocCount = PROBABILITY * numDocs;
+        // We're taking the mean of NUM_SAMPLE_RUNS for which each run has standard deviation
+        // sqrt(PROBABILITY * numDocs) so the 6 sigma error, for which we expect 1 failure in
+        // 500M runs, is 6 * sqrt(PROBABILITY * numDocs / NUM_SAMPLE_RUNS).
+        double maxCountError = 6.0 * Math.sqrt(PROBABILITY * numDocs / NUM_SAMPLE_RUNS);
+        assertThat(Math.abs(sampledDocCount - expectedDocCount), lessThan(maxCountError));
 
         SearchResponse trueValueResponse = client().prepareSearch("idx")
             .addAggregation(avg("mean_monotonic").field(MONOTONIC_VALUE))
             .addAggregation(avg("mean_numeric").field(NUMERIC_VALUE))
             .get();
         double trueMonotonic = ((Avg) trueValueResponse.getAggregations().get("mean_monotonic")).getValue();
-        double trueRandom = ((Avg) trueValueResponse.getAggregations().get("mean_numeric")).getValue();
-        assertThat(Math.abs(sampleMonotonicValue - trueMonotonic), lessThan(trueMonotonic * 0.1));
-        assertThat(Math.abs(sampleRandomValue - trueRandom), lessThan(trueRandom * 0.1));
+        double trueNumeric = ((Avg) trueValueResponse.getAggregations().get("mean_numeric")).getValue();
+        double maxMonotonicError = 6.0 * Math.sqrt(varMonotonic / (numDocs * PROBABILITY * NUM_SAMPLE_RUNS));
+        double maxNumericError = 6.0 * Math.sqrt(varNumeric / (numDocs * PROBABILITY * NUM_SAMPLE_RUNS));
+        assertThat(Math.abs(sampleMonotonicValue - trueMonotonic), lessThan(maxMonotonicError));
+        assertThat(Math.abs(sampleNumericValue - trueNumeric), lessThan(maxNumericError));
     }
 
     public void testRandomSamplerHistogram() {
         Map<String, Double> sampleMonotonicValue = new HashMap<>();
-        Map<String, Double> sampleRandomValue = new HashMap<>();
+        Map<String, Double> sampleNumericValue = new HashMap<>();
         Map<String, Double> sampledDocCount = new HashMap<>();
 
         SearchRequest sampledRequest = client().prepareSearch("idx")
@@ -129,7 +147,7 @@ public class RandomSamplerIT extends ESIntegTestCase {
                     bucket.getKeyAsString(),
                     (k, v) -> ((Avg) bucket.getAggregations().get("mean_monotonic")).getValue() + (v == null ? 0 : v)
                 );
-                sampleRandomValue.compute(
+                sampleNumericValue.compute(
                     bucket.getKeyAsString(),
                     (k, v) -> ((Avg) bucket.getAggregations().get("mean_numeric")).getValue() + (v == null ? 0 : v)
                 );
@@ -138,7 +156,7 @@ public class RandomSamplerIT extends ESIntegTestCase {
         }
         for (String key : sampledDocCount.keySet()) {
             sampledDocCount.put(key, sampledDocCount.get(key) / NUM_SAMPLE_RUNS);
-            sampleRandomValue.put(key, sampleRandomValue.get(key) / NUM_SAMPLE_RUNS);
+            sampleNumericValue.put(key, sampleNumericValue.get(key) / NUM_SAMPLE_RUNS);
             sampleMonotonicValue.put(key, sampleMonotonicValue.get(key) / NUM_SAMPLE_RUNS);
         }
 
@@ -153,13 +171,15 @@ public class RandomSamplerIT extends ESIntegTestCase {
         Histogram histogram = trueValueResponse.getAggregations().get("histo");
         for (Histogram.Bucket bucket : histogram.getBuckets()) {
             long numDocs = bucket.getDocCount();
-            double errorRate = Math.pow(1.0 / (0.5 * numDocs), 0.35);
-            double countError = errorRate * numDocs;
-            assertThat(Math.abs(sampledDocCount.get(bucket.getKeyAsString()) - numDocs), lessThan(countError));
+            // Note the true count is estimated by dividing the bucket sample doc count by PROBABILITY.
+            double maxCountError = 6.0 * Math.sqrt(numDocs / NUM_SAMPLE_RUNS / (0.5 * PROBABILITY));
+            assertThat(Math.abs(sampledDocCount.get(bucket.getKeyAsString()) - numDocs), lessThan(maxCountError));
             double trueMonotonic = ((Avg) bucket.getAggregations().get("mean_monotonic")).getValue();
-            double trueRandom = ((Avg) bucket.getAggregations().get("mean_numeric")).getValue();
-            assertThat(Math.abs(sampleMonotonicValue.get(bucket.getKeyAsString()) - trueMonotonic), lessThan(trueMonotonic * errorRate));
-            assertThat(Math.abs(sampleRandomValue.get(bucket.getKeyAsString()) - trueRandom), lessThan(trueRandom * errorRate));
+            double trueNumeric = ((Avg) bucket.getAggregations().get("mean_numeric")).getValue();
+            double maxMonotonicError = 6.0 * Math.sqrt(varMonotonic / (numDocs * 0.5 * PROBABILITY * NUM_SAMPLE_RUNS));
+            double maxNumericError = 6.0 * Math.sqrt(varNumeric / (numDocs * 0.5 * PROBABILITY * NUM_SAMPLE_RUNS));
+            assertThat(Math.abs(sampleMonotonicValue.get(bucket.getKeyAsString()) - trueMonotonic), lessThan(maxMonotonicError));
+            assertThat(Math.abs(sampleNumericValue.get(bucket.getKeyAsString()) - trueNumeric), lessThan(maxNumericError));
         }
     }
 

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/bucket/RandomSamplerIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/bucket/RandomSamplerIT.java
@@ -75,9 +75,12 @@ public class RandomSamplerIT extends ESIntegTestCase {
             final double oldAvgNumeric = avgNumeric;
             avgMonotonic = (i * avgMonotonic + monotonicValue) / (i + 1);
             avgNumeric = (i * avgNumeric + numericValue) / (i + 1);
-            varMonotonic = (i * (varMonotonic + Math.pow(avgMonotonic - oldAvgMonotonic, 2.0)) + Math.pow(monotonicValue - avgMonotonic, 2.0)) / (i + 1);
-            varNumeric = (i * (varNumeric + Math.pow(avgNumeric - oldAvgNumeric, 2.0)) + Math.pow(numericValue - avgNumeric, 2.0)) / (i + 1);
-
+            final double avgMonotonicDiff = avgMonotonic - oldAvgMonotonic;
+            final double avgNumericDiff = avgNumeric - oldAvgNumeric;
+            final double resMonotonic = monotonicValue - avgMonotonic;
+            final double resNumeric = numericValue - avgNumeric;
+            varMonotonic = (i * (varMonotonic + Math.pow(avgMonotonicDiff, 2.0)) + Math.pow(resMonotonic, 2.0)) / (i + 1);
+            varNumeric = (i * (varNumeric + Math.pow(avgNumericDiff, 2.0)) + Math.pow(resNumeric, 2.0)) / (i + 1);
         }
         indexRandom(true, builders);
         ensureSearchable();


### PR DESCRIPTION
We are getting intermittent failures from `RandomSamplerIT`. The assertions in these tests do not properly account for the expected distribution of the sample aggregate values. I've updated them to estimate the standard deviation for the sample aggregate values based on the test parameters and set the test thresholds at 6 standard deviations. This gives us a probability of failure of about 1 in 500M which should be acceptable.

Closes #88930.