### PR TITLE
Auto-generate preview links for DOC PRs

### DIFF
--- a/.github/workflows/docs-preview-links.yml
+++ b/.github/workflows/docs-preview-links.yml
@@ -1,0 +1,25 @@
+name: Docs Preview Links
+
+on:
+  pull_request_target:
+    types: [opened]
+
+jobs:
+  doc-preview:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v6
+        name: Add doc preview links
+        with:
+          script: |
+            const pr = context.payload.pull_request;
+            const comment = `Documentation previews:
+              - ✨ [HTML diff](https://${context.repo.repo}_${pr.number}.docs-preview.app.elstc.co/diff)
+              - 📙 [Preview](https://${context.repo.repo}_${pr.number}.docs-preview.app.elstc.co/guide/en/security/master/index.html)`;
+            
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: comment,
+            });

--- a/.github/workflows/docs-preview-links.yml
+++ b/.github/workflows/docs-preview-links.yml
@@ -3,6 +3,8 @@ name: Docs Preview Links
 on:
   pull_request_target:
     types: [opened]
+    paths:
+      - '**.asciidoc'
 
 jobs:
   doc-preview:

--- a/.github/workflows/docs-preview-links.yml
+++ b/.github/workflows/docs-preview-links.yml
@@ -13,9 +13,8 @@ jobs:
         with:
           script: |
             const pr = context.payload.pull_request;
-            const comment = `Documentation previews:
-              - ✨ [HTML diff](https://${context.repo.repo}_${pr.number}.docs-preview.app.elstc.co/diff)
-              - 📙 [Preview](https://${context.repo.repo}_${pr.number}.docs-preview.app.elstc.co/guide/en/security/master/index.html)`;
+            const comment = `Documentation preview:
+              - ✨ [Changed pages](https://${context.repo.repo}_${pr.number}.docs-preview.app.elstc.co/diff)`;
             
             github.rest.issues.createComment({
               issue_number: context.issue.number,


### PR DESCRIPTION
Adds a GitHub Action that will automatically create preview links when a doc pull request is created. Links are added in a comment on the PR.

Borrowed from @richkuz -- Thanks!