### PR TITLE
Restore MemoryPool Peak getters

### DIFF
--- a/server/src/main/java/org/elasticsearch/monitor/jvm/JvmStats.java
+++ b/server/src/main/java/org/elasticsearch/monitor/jvm/JvmStats.java
@@ -469,7 +469,7 @@ public class JvmStats implements Writeable, ToXContentFragment {
 
         public ByteSizeValue getPeakMax() {
             return new ByteSizeValue(peakMax);
-        }        
+        }
     }
 
     public static class Mem implements Writeable, Iterable<MemoryPool> {

--- a/server/src/main/java/org/elasticsearch/monitor/jvm/JvmStats.java
+++ b/server/src/main/java/org/elasticsearch/monitor/jvm/JvmStats.java
@@ -463,6 +463,13 @@ public class JvmStats implements Writeable, ToXContentFragment {
             return new ByteSizeValue(max);
         }
 
+        public ByteSizeValue getPeakUsed() {
+            return new ByteSizeValue(peakUsed);
+        }
+
+        public ByteSizeValue getPeakMax() {
+            return new ByteSizeValue(peakMax);
+        }        
     }
 
     public static class Mem implements Writeable, Iterable<MemoryPool> {


### PR DESCRIPTION
- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)? *YES*
- Have you followed the [contributor guidelines](https://github.com/elastic/elasticsearch/blob/main/CONTRIBUTING.md)? *YES*
- If submitting code, have you built your formula locally prior to submission with `gradle check`? *YES*
- If submitting code, is your pull request against main? Unless there is a good reason otherwise, we prefer pull requests against main and will backport as needed. *YES*
- If submitting code, have you checked that your submission is for an [OS and architecture that we support](https://www.elastic.co/support/matrix#show_os)? *N/A*
- If you are submitting this code for a class then read our [policy](https://github.com/elastic/elasticsearch/blob/main/CONTRIBUTING.md#contributing-as-part-of-a-class) for that. *NO*

Restore Stat getters removed in #87664 .