### PR TITLE
[DOCS] Remove feature flag from TSDS docs

### DIFF
--- a/docs/reference/data-streams/set-up-tsds.asciidoc
+++ b/docs/reference/data-streams/set-up-tsds.asciidoc
@@ -4,7 +4,7 @@
 <titleabbrev>Set up a TSDS</titleabbrev>
 ++++
 
-preview:[]
+preview::[]
 
 To set up a <<tsds,time series data stream (TSDS)>>, follow these steps:
 

--- a/docs/reference/data-streams/set-up-tsds.asciidoc
+++ b/docs/reference/data-streams/set-up-tsds.asciidoc
@@ -4,7 +4,7 @@
 <titleabbrev>Set up a TSDS</titleabbrev>
 ++++
 
-preview::[]
+preview:[]
 
 To set up a <<tsds,time series data stream (TSDS)>>, follow these steps:
 

--- a/docs/reference/data-streams/tsds-index-settings.asciidoc
+++ b/docs/reference/data-streams/tsds-index-settings.asciidoc
@@ -1,8 +1,7 @@
-ifeval::["{release-state}"=="unreleased"]
 [[tsds-index-settings]]
 === Time series index settings
 
-preview::[]
+preview:[]
 
 Backing indices in a <<tsds,time series data stream (TSDS)>> support the
 following index settings.
@@ -48,9 +47,6 @@ more information, refer to <<dimension-based-routing>>.
 // tag::dimensions-limit[]
 `index.mapping.dimension_fields.limit`::
 preview:[] (<<dynamic-index-settings,Dynamic>>, integer)
-//Maximum number of <<time-series-dimension,time series dimensions>> for the
-//index. Defaults to `16`.
-Maximum number of time series dimensions for the
+Maximum number of <<time-series-dimension,time series dimensions>> for the
 index. Defaults to `16`.
 // end::dimensions-limit[]
-endif::[]

--- a/docs/reference/data-streams/tsds-index-settings.asciidoc
+++ b/docs/reference/data-streams/tsds-index-settings.asciidoc
@@ -1,7 +1,7 @@
 [[tsds-index-settings]]
 === Time series index settings
 
-preview:[]
+preview::[]
 
 Backing indices in a <<tsds,time series data stream (TSDS)>> support the
 following index settings.

--- a/docs/reference/data-streams/tsds.asciidoc
+++ b/docs/reference/data-streams/tsds.asciidoc
@@ -1,8 +1,7 @@
-ifeval::["{release-state}"=="unreleased"]
 [[tsds]]
 == Time series data stream (TSDS)
 
-preview::[]
+preview:[]
 
 A time series data stream (TSDS) models timestamped metrics data as one or
 more time series.
@@ -305,4 +304,3 @@ Now that you know the basics, you're ready to <<set-up-tsds,create a TSDS>> or
 
 include::set-up-tsds.asciidoc[]
 include::tsds-index-settings.asciidoc[]
-endif::[]

--- a/docs/reference/data-streams/tsds.asciidoc
+++ b/docs/reference/data-streams/tsds.asciidoc
@@ -1,7 +1,7 @@
 [[tsds]]
 == Time series data stream (TSDS)
 
-preview:[]
+preview::[]
 
 A time series data stream (TSDS) models timestamped metrics data as one or
 more time series.

--- a/docs/reference/indices/put-index-template.asciidoc
+++ b/docs/reference/indices/put-index-template.asciidoc
@@ -111,14 +111,12 @@ See <<create-index-template,create an index template>>.
 (Optional, Boolean) If `true`, the data stream is <<hidden,hidden>>. Defaults to
 `false`.
 
-ifeval::["{release-state}"=="unreleased"]
 `index_mode`::
-(Optional, string) Type of data stream to create. Valid values are `null`
+preview:[] (Optional, string) Type of data stream to create. Valid values are `null`
 (regular data stream) and `time_series` (<<tsds,time series data stream>>).
 +
 If `time_series`, each backing index has an `index.mode` index setting of
 `time_series`.
-endif::[]
 ====
 
 `index_patterns`::

--- a/docs/reference/mapping/types/aggregate-metric-double.asciidoc
+++ b/docs/reference/mapping/types/aggregate-metric-double.asciidoc
@@ -57,7 +57,6 @@ specify at least one value.
 Default metric sub-field to use for queries, scripts, and aggregations that
 don't use a sub-field. Must be a value from the `metrics` array.
 
-ifeval::["{release-state}"=="unreleased"]
 `time_series_metric`::
 preview:[] (Optional, string)
 include::numeric.asciidoc[tag=time_series_metric]
@@ -73,7 +72,6 @@ include::{es-repo-dir}/data-streams/tsds.asciidoc[tag=time-series-metric-summary
 
 include::{es-repo-dir}/data-streams/tsds.asciidoc[tag=time-series-metric-null]
 ====
-endif::[]
 
 [[aggregate-metric-double-uses]]
 ==== Uses

--- a/docs/reference/mapping/types/keyword.asciidoc
+++ b/docs/reference/mapping/types/keyword.asciidoc
@@ -153,17 +153,12 @@ preview:[] (Optional, Boolean)
 +
 --
 // tag::dimension[]
-ifeval::["{release-state}"=="unreleased"]
-Marks the field as a `time-series-dimension,time series dimension`. Defaults
+Marks the field as a <<time-series-dimension,time series dimension>>. Defaults
 to `false`.
 
 The
 <<index-mapping-dimension-fields-limit,`index.mapping.dimension_fields.limit`>>
 index setting limits the number of dimensions in an index.
-endif::[]
-ifeval::["{release-state}"!="unreleased"]
-Marks the field as a time series dimension. Defaults to `false`.
-endif::[]
 
 Dimension fields have the following constraints:
 

--- a/docs/reference/mapping/types/numeric.asciidoc
+++ b/docs/reference/mapping/types/numeric.asciidoc
@@ -190,7 +190,6 @@ Of the numeric field types, only `byte`, `short`, `integer`, `long`, and
 A numeric field can't be both a time series dimension and a time series metric.
 --
 
-ifeval::["{release-state}"=="unreleased"]
 `time_series_metric`::
 preview:[] (Optional, string)
 // tag::time_series_metric[]
@@ -210,7 +209,6 @@ include::{es-repo-dir}/data-streams/tsds.asciidoc[tag=time-series-metric-null]
 +
 For a numeric time series metric, the `doc_values` parameter must be `true`. A
 numeric field can't be both a time series dimension and a time series metric.
-endif::[]
 
 [[scaled-float-params]]
 ==== Parameters for `scaled_float`


### PR DESCRIPTION
This removes the feature flags from the TSDS docs. We still have a `technical preview` marker on all of the content.