### PR TITLE
Update running snapshot state value to `STARTED`

### DIFF
--- a/docs/reference/snapshot-restore/apis/get-snapshot-status-api.asciidoc
+++ b/docs/reference/snapshot-restore/apis/get-snapshot-status-api.asciidoc
@@ -169,7 +169,7 @@ Indicates the current snapshot state.
 `FAILED`::
   The snapshot finished with an error and failed to store any data.
 
-`IN_PROGRESS`::
+`STARTED`::
   The snapshot is currently running.
 
 `PARTIAL`::


### PR DESCRIPTION
The get snapshot status API will currently return a value of `STARTED` for the state of a snapshot that is currently running. The documentation says that the `state` value for a running snapshot is `IN_PROGRESS`. This documentation change will align the docs with the actual result of the get snapshot status API.