### PR TITLE
Paranoid tests for `meta`

### DIFF
--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.aggregation/220_filters_bucket.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.aggregation/220_filters_bucket.yml
@@ -250,10 +250,11 @@ setup:
   - match: { aggregations.the_filter.meta.foo: "bar" }
 
 ---
-"Unexpected metadata test":
+no meta:
   - skip:
       version: " - 8.4.99"
       reason: "Fixed in 8.5"
+
   - do:
       search:
         rest_total_hits_as_int: true
@@ -274,6 +275,56 @@ setup:
   - match: { aggregations.the_filter.buckets.first_filter.doc_count: 1 }
   - match: { aggregations.the_filter.buckets.second_filter.doc_count: 1 }
   - is_false: aggregations.the_filter.meta
+
+---
+empty meta:
+  - skip:
+      version: " - 8.4.99"
+      reason: "Fixed in 8.5"
+
+  - do:
+      search:
+        size: 0
+        body:
+          aggs:
+            the_filter:
+              meta: {}
+              filters:
+                filters:
+                  first_filter:
+                    match:
+                      int_field: 101
+                  second_filter:
+                    match:
+                      int_field: 151
+
+  - match: { hits.total.value: 4 }
+  - match: { aggregations.the_filter.buckets.first_filter.doc_count: 1 }
+  - match: { aggregations.the_filter.buckets.second_filter.doc_count: 1 }
+  - match: { aggregations.the_filter.meta: {} }
+
+---
+null meta:
+  - skip:
+      version: " - 8.4.99"
+      reason: "Fixed in 8.5"
+
+  - do:
+      catch: /Expected \[START_OBJECT\] under \[meta\], but got a \[VALUE_NULL\] in \[the_filter\]/
+      search:
+        size: 0
+        body:
+          aggs:
+            the_filter:
+              meta: null
+              filters:
+                filters:
+                  first_filter:
+                    match:
+                      int_field: 101
+                  second_filter:
+                    match:
+                      int_field: 151
 
 ---
 "Bad params":


### PR DESCRIPTION
This adds some extra paranoid tests for the `meta` parameter in aggs,
specifically the `filters` agg. These tests are at the REST level so
they provide backwards compatibility tests as well. They make sure that
`meta: {}` and `meta: null` do what we expect - return a `meta: {}` and
return an error.

Relates to #89467
