### PR TITLE
[DOCS] Clarifies retention policy for transforms

### DIFF
--- a/docs/reference/rest-api/common-parms.asciidoc
+++ b/docs/reference/rest-api/common-parms.asciidoc
@@ -999,7 +999,8 @@ end::transform-metadata[]
 
 tag::transform-retention[]
 Defines a retention policy for the {transform}. Data that meets the defined
-criteria is deleted from the destination index.
+criteria is deleted from the destination index. Data is deleted if `time.field` 
+for the retention policy exists and contains data older than `max.age`.
 end::transform-retention[]
 
 tag::transform-retention-time[]
@@ -1007,7 +1008,8 @@ Specifies that the {transform} uses a time field to set the retention policy.
 end::transform-retention-time[]
 
 tag::transform-retention-time-field[]
-The date field that is used to calculate the age of the document.
+The date field that is used to calculate the age of the document. Set 
+`time.field` to an existing date field.
 end::transform-retention-time-field[]
 
 tag::transform-retention-time-max-age[]

--- a/docs/reference/rest-api/common-parms.asciidoc
+++ b/docs/reference/rest-api/common-parms.asciidoc
@@ -999,12 +999,13 @@ end::transform-metadata[]
 
 tag::transform-retention[]
 Defines a retention policy for the {transform}. Data that meets the defined
-criteria is deleted from the destination index. Data is deleted if `time.field` 
-for the retention policy exists and contains data older than `max.age`.
+criteria is deleted from the destination index.
 end::transform-retention[]
 
 tag::transform-retention-time[]
-Specifies that the {transform} uses a time field to set the retention policy.
+Specifies that the {transform} uses a time field to set the retention policy. 
+Data is deleted if `time.field` for the retention policy exists and contains 
+data older than `max.age`.
 end::transform-retention-time[]
 
 tag::transform-retention-time-field[]


### PR DESCRIPTION
## Overview

Related to: https://github.com/elastic/ml-team/issues/495#issuecomment-1210892164

This PR adds some details to the transform retention policy reference docs.

### Preview

[PUT transform API docs](https://elasticsearch_89685.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/put-transform.html#put-transform-request-body)