### PR TITLE
[8.3] [DOCS] Clarifies retention policy for transforms (#89685)

### DIFF
--- a/docs/reference/rest-api/common-parms.asciidoc
+++ b/docs/reference/rest-api/common-parms.asciidoc
@@ -1004,11 +1004,14 @@ criteria is deleted from the destination index.
 end::transform-retention[]
 
 tag::transform-retention-time[]
-Specifies that the {transform} uses a time field to set the retention policy.
+Specifies that the {transform} uses a time field to set the retention policy. 
+Data is deleted if `time.field` for the retention policy exists and contains 
+data older than `max.age`.
 end::transform-retention-time[]
 
 tag::transform-retention-time-field[]
-The date field that is used to calculate the age of the document.
+The date field that is used to calculate the age of the document. Set 
+`time.field` to an existing date field.
 end::transform-retention-time-field[]
 
 tag::transform-retention-time-max-age[]


### PR DESCRIPTION
Backports the following commits to 8.3:
 - [DOCS] Clarifies retention policy for transforms (#89685)