### PR TITLE
[8.3] remove 8.3.0 coming tag (#89701)

### DIFF
--- a/docs/reference/release-notes/8.3.0.asciidoc
+++ b/docs/reference/release-notes/8.3.0.asciidoc
@@ -1,8 +1,6 @@
 [[release-notes-8.3.0]]
 == {es} version 8.3.0
 
-coming[8.3.0]
-
 Also see <<breaking-changes-8.3,Breaking changes in 8.3>>.
 
 [discrete]


### PR DESCRIPTION
Backports the following commits to 8.3:
 - remove 8.3.0 coming tag (#89701)