### PR TITLE
Synthetic _source: support version field type

### DIFF
--- a/docs/changelog/89706.yaml
+++ b/docs/changelog/89706.yaml
@@ -1,0 +1,5 @@
+pr: 89706
+summary: "Synthetic _source: support version field type"
+area: "Mapping, TSDB"
+type: enhancement
+issues: []

--- a/docs/changelog/89706.yaml
+++ b/docs/changelog/89706.yaml
@@ -1,5 +1,5 @@
 pr: 89706
 summary: "Synthetic _source: support version field type"
-area: "Mapping, TSDB"
+area: "TSDB"
 type: enhancement
 issues: []

--- a/docs/reference/mapping/fields/synthetic-source.asciidoc
+++ b/docs/reference/mapping/fields/synthetic-source.asciidoc
@@ -42,6 +42,7 @@ types:
 ** <<numeric-synthetic-source,`scaled_float`>>
 ** <<numeric-synthetic-source,`short`>>
 ** <<text-synthetic-source,`text`>> (with a `keyword` sub-field)
+** <<version-synthetic-source,`version`>>
 
 Runtime fields cannot, at this stage, use synthetic `_source`.
 

--- a/docs/reference/mapping/types/version.asciidoc
+++ b/docs/reference/mapping/types/version.asciidoc
@@ -9,7 +9,7 @@ The `version` field type is a specialization of the `keyword` field for
 handling software version values and to support specialized precedence
 rules for them. Precedence is defined following the rules outlined by
 https://semver.org/[Semantic Versioning], which for example means that
-major, minor and patch version parts are sorted numerically (i.e. 
+major, minor and patch version parts are sorted numerically (i.e.
 "2.1.0" < "2.4.1" < "2.11.2") and pre-release versions are sorted before
 release versions (i.e. "1.0.0-alpha" < "1.0.0").
 
@@ -30,7 +30,7 @@ PUT my-index-000001
 
 --------------------------------------------------
 
-The field offers the same search capabilities as a regular keyword field. It 
+The field offers the same search capabilities as a regular keyword field. It
 can e.g. be searched for exact matches using `match` or `term` queries and
 supports prefix and wildcard searches. The main benefit is that `range` queries
 will honor Semver ordering, so a `range` query between "1.0.0" and "1.5.0"
@@ -67,3 +67,37 @@ This field type isn't optimized for heavy wildcard, regex or fuzzy searches. Whi
 type of queries work in this field, you should consider using a regular `keyword` field if
 you strongly rely on these kind of queries.
 
+
+[[version-synthetic-source]]
+==== Synthetic source preview:[]
+`version` fields support <<synthetic-source,synthetic `_source`>> so long as they don't
+declare <<copy-to,`copy_to`>>.
+
+Synthetic source always sorts `version` fields and removes duplicates. For example:
+[source,console,id=synthetic-source-version-example]
+----
+PUT idx
+{
+  "mappings": {
+    "_source": { "mode": "synthetic" },
+    "properties": {
+      "versions": { "type": "version" }
+    }
+  }
+}
+PUT idx/_doc/1
+{
+  "versions": ["8.0.0-beta1", "8.5.0", "0.90.12", "2.6.1", "1.3.4", "1.3.4"]
+}
+----
+// TEST[s/$/\nGET idx\/_doc\/1?filter_path=_source\n/]
+
+Will become:
+
+[source,console-result]
+----
+{
+  "versions": ["0.90.12", "1.3.4", "2.6.1", "8.0.0-beta1", "8.5.0"]
+}
+----
+// TEST[s/^/{"_source":/ s/\n$/}/]

--- a/x-pack/plugin/mapper-version/src/main/java/org/elasticsearch/xpack/versionfield/Version.java
+++ b/x-pack/plugin/mapper-version/src/main/java/org/elasticsearch/xpack/versionfield/Version.java
@@ -27,7 +27,7 @@ public class Version implements ToXContentFragment, BytesRefProducer, Comparable
     }
 
     protected Version(BytesRef bytes) {
-        this.version = VersionEncoder.decodeVersion(bytes);
+        this.version = VersionEncoder.decodeVersion(bytes).utf8ToString();
         this.bytes = bytes;
     }
 

--- a/x-pack/plugin/mapper-version/src/main/java/org/elasticsearch/xpack/versionfield/VersionEncoder.java
+++ b/x-pack/plugin/mapper-version/src/main/java/org/elasticsearch/xpack/versionfield/VersionEncoder.java
@@ -11,7 +11,6 @@ import org.apache.commons.codec.Charsets;
 import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.BytesRefBuilder;
 
-import java.nio.charset.StandardCharsets;
 import java.util.regex.Pattern;
 
 /**
@@ -142,7 +141,7 @@ class VersionEncoder {
         return mainVersionComponents;
     }
 
-    public static String decodeVersion(BytesRef version) {
+    public static BytesRef decodeVersion(BytesRef version) {
         int inputPos = version.offset;
         int resultPos = 0;
         byte[] result = new byte[version.length];
@@ -159,7 +158,7 @@ class VersionEncoder {
             }
             inputPos++;
         }
-        return new String(result, 0, resultPos, StandardCharsets.UTF_8);
+        return new BytesRef(result, 0, resultPos);
     }
 
     static boolean legalVersionString(VersionParts versionParts) {

--- a/x-pack/plugin/mapper-version/src/main/java/org/elasticsearch/xpack/versionfield/VersionStringDocValuesField.java
+++ b/x-pack/plugin/mapper-version/src/main/java/org/elasticsearch/xpack/versionfield/VersionStringDocValuesField.java
@@ -56,7 +56,7 @@ public class VersionStringDocValuesField extends AbstractScriptFieldFactory<Vers
 
     @Override
     public String getInternal(int index) {
-        return VersionEncoder.decodeVersion(getBytesRefInternal(index));
+        return VersionEncoder.decodeVersion(getBytesRefInternal(index)).utf8ToString();
     }
 
     private BytesRef getBytesRefInternal(int index) {

--- a/x-pack/plugin/mapper-version/src/test/java/org/elasticsearch/xpack/versionfield/VersionEncoderTests.java
+++ b/x-pack/plugin/mapper-version/src/test/java/org/elasticsearch/xpack/versionfield/VersionEncoderTests.java
@@ -95,7 +95,7 @@ public class VersionEncoderTests extends ESTestCase {
      */
     public void testRandomRoundtrip() {
         String versionString = randomVersionString();
-        assertEquals(versionString, decodeVersion(encodeVersion(versionString)));
+        assertEquals(versionString, decodeVersion(encodeVersion(versionString)).utf8ToString());
     }
 
     private String randomVersionString() {
@@ -182,7 +182,7 @@ public class VersionEncoderTests extends ESTestCase {
         for (String version : validSemverVersions) {
             assertTrue("should be valid: " + version, VersionEncoder.encodeVersion(version).isLegal);
             // since we're here, also check encoding / decoding rountrip
-            assertEquals(version, decodeVersion(encodeVersion(version)));
+            assertEquals(version, decodeVersion(encodeVersion(version)).utf8ToString());
         }
 
         String[] invalidSemverVersions = new String[] {
@@ -229,7 +229,7 @@ public class VersionEncoderTests extends ESTestCase {
         for (String version : invalidSemverVersions) {
             assertFalse("should be invalid: " + version, VersionEncoder.encodeVersion(version).isLegal);
             // since we're here, also check encoding / decoding rountrip
-            assertEquals(version, decodeVersion(encodeVersion(version)));
+            assertEquals(version, decodeVersion(encodeVersion(version)).utf8ToString());
         }
     }
 }

--- a/x-pack/plugin/mapper-version/src/yamlRestTest/resources/rest-api-spec/test/40_synthetic_source.yml
+++ b/x-pack/plugin/mapper-version/src/yamlRestTest/resources/rest-api-spec/test/40_synthetic_source.yml
@@ -1,0 +1,67 @@
+setup:
+  - skip:
+      version: " - 8.4.99"
+      reason: "synthetic source support added in 8.5.0"
+
+  - do:
+      indices.create:
+        index:  test1
+        body:
+          mappings:
+            _source:
+              mode: synthetic
+            properties:
+              ver:
+                type: version
+
+  - do:
+      bulk:
+        index: test1
+        refresh: true
+        body: |
+          { "index": {"_id" : "1"} }
+          { "ver": "1.0.0" }
+          { "index": {"_id" : "2"} }
+          { "ver": "1.2.3-abc+def" }
+          { "index": {"_id" : "3"} }
+          { "ver": "1.2.3.4.5" }
+          { "index": {"_id" : "4"} }
+          { "ver": ["6.7.8", "5.4.3"] }
+
+---
+fetch source:
+  - do:
+      search:
+        index: test1
+        body:
+          sort: [ { ver: desc } ]
+
+  - match:
+      hits.hits.0._source:
+        ver: ["5.4.3", "6.7.8"]
+  - match:
+      hits.hits.1._source:
+        ver: "1.2.3.4.5"
+  - match:
+      hits.hits.2._source:
+        ver: "1.2.3-abc+def"
+  - match:
+      hits.hits.3._source:
+        ver: "1.0.0"
+
+---
+script values:
+  - do:
+      search:
+        index: test1
+        body:
+          sort: [ { ver: desc } ]
+          script_fields:
+            field:
+              script:
+                source: "field('ver').get(new Version(''))"
+
+  - match: { hits.hits.0.fields.field.0: "5.4.3" }
+  - match: { hits.hits.1.fields.field.0: "1.2.3.4.5" }
+  - match: { hits.hits.2.fields.field.0: "1.2.3-abc+def" }
+  - match: { hits.hits.3.fields.field.0: "1.0.0" }


### PR DESCRIPTION
This adds support for synthetic _source to the `version` field type. It
works very similarly to `keyword` but with an extra decode step.

I modified the decoder to return a `BytesRef` instead of a `String`
because many of the callers seemed to be converting that string directly
into bytes again. Synthetic source would have wanted to do that. As was
the query infrastructure.
