### PR TITLE
[DOCS] Add simple dev setup instructions back to the README

### DIFF
--- a/README.asciidoc
+++ b/README.asciidoc
@@ -37,6 +37,11 @@ To try out Elasticsearch on your own machine, we recommend using Docker
 and running both Elasticsearch and Kibana.
 Docker images are available from the https://www.docker.elastic.co[Elastic Docker registry].
 
+NOTE: Starting in Elasticsearch 8.0, security is enabled by default. 
+The first time you start Elasticsearch, TLS encryption is configured automatically, 
+a password is generated for the `elastic` user, 
+and a Kibana enrollment token is created so you can connect Kibana to your secured cluster.
+
 For other installation options, see the
 https://www.elastic.co/guide/en/elasticsearch/reference/current/install-elasticsearch.html[Elasticsearch installation documentation].
 

--- a/README.asciidoc
+++ b/README.asciidoc
@@ -93,7 +93,7 @@ You can interact with Elasticsearch using any client that sends HTTP requests,
 such as the https://www.elastic.co/guide/en/elasticsearch/client/index.html[Elasticsearch
 language clients] and https://curl.se[curl]. 
 Kibana's developer console provides an easy way to experiment and test requests. 
-To access the console, go to **Managment > Dev Tools**.
+To access the console, go to **Management > Dev Tools**.
 
 **Add data**
 

--- a/README.asciidoc
+++ b/README.asciidoc
@@ -30,6 +30,7 @@ https://www.elastic.co/downloads/elasticsearch[elastic.co/downloads/elasticsearc
 
 To try out Elasticsearch on your dev machine, we recommend using Docker
 and running both Elasticsearch and Kibana.
+Docker images are available from the https://www.docker.elastic.co[Elastic Docker registry].
 
 For other installation options, see the
 https://www.elastic.co/guide/en/elasticsearch/reference/current/install-elasticsearch.html[Elasticsearch installation documentation].
@@ -37,29 +38,53 @@ https://www.elastic.co/guide/en/elasticsearch/reference/current/install-elastics
 **Install and run Elasticsearch**
 
 . Install and start https://www.docker.com/products/docker-desktop[Docker
-Desktop].
+Desktop]. Go to **Preferences > Resources > Advanced** and set Memory to at least 4GB.
 
-. Run:
+. Start an Elasticsearch container:
 +
 ----
 docker network create elastic
-docker pull {docker-repo}:{version}
-docker run --name es01-test --net elastic -p 127.0.0.1:9200:9200 -p 127.0.0.1:9300:9300 -e "discovery.type=single-node" {docker-image}
+docker pull docker.elastic.co/elasticsearch/elasticsearch:{version}
+docker run --name es-node1 --net elastic -p 9200:9200 -p 9300:9300 -e "discovery.type=single-node" -t docker.elastic.co/elasticsearch/elasticsearch:{version}
 ----
++
+When you start Elasticsearch for the first time, the following security configuration 
+occurs automatically:
++
+* https://www.elastic.co/guide/en/elasticsearch/reference/current/configuring-stack-security.html#stack-security-certificates[Certificates and keys] 
+are generated for the transport and HTTP layers.
+* The Transport Layer Security (TLS) configuration settings are written to
+`elasticsearch.yml`.
+* A password is generated for the `elastic` user.
+* An enrollment token is generated for Kibana.
++
+NOTE: You might need to scroll back a bit in the terminal to view the password 
+and enrollment token.
+
+. Copy the generated password and enrollment token and save them in a secure 
+location. These values are shown only when you start Elasticsearch for the first time.
+You'll use these to enroll Kibana with your Elasticsearch cluster and log in.
 
 **Install and run Kibana**
 
-To easily send requests to Elasticsearch and analyze, visualize, and manage data 
-interactively, install Kibana.
+Kibana enables you to easily send requests to Elasticsearch and analyze, visualize, and manage data interactively.
 
-. In a new terminal session, run:
+. In a new terminal session, start Kibana and connect it to your Elasticsearch container:
 +
 ----
 docker pull docker.elastic.co/kibana/kibana:{version}
-docker run --name kib01-test --net elastic -p 127.0.0.1:5601:5601 -e "ELASTICSEARCH_HOSTS=http://es01-test:9200" docker.elastic.co/kibana/kibana:{version}
+docker run --name kib-01 --net elastic -p 5601:5601 docker.elastic.co/kibana/kibana:{version}
 ----
++
+When you start Kibana, a unique link is output to your terminal.
 
-. To access {kib}, go to http://localhost:5601[http://localhost:5601]
+. To access Kibana, open the generated link in your browser.
+
+  .. Paste the enrollment token that you copied when starting
+  Elasticsearch and click the button to connect your Kibana instance with Elasticsearch.
+
+  .. Log in to Kibana as the `elastic` user with the password that was generated
+  when you started Elasticsearch.
 
 **Send requests to Elasticsarch**
 
@@ -67,7 +92,8 @@ You send data and other requests to Elasticsearch through REST APIs.
 You can interact with Elasticsearch using any client that sends HTTP requests, 
 such as the https://www.elastic.co/guide/en/elasticsearch/client/index.html[Elasticsearch
 language clients] and https://curl.se[curl]. 
-Kibana's developer tools console provides an easy way to experiment and test requests. 
+Kibana's developer console provides an easy way to experiment and test requests. 
+To access the console, go to **Managment > Dev Tools**.
 
 **Add data**
 
@@ -75,7 +101,7 @@ You index data into Elasticsearch by sending JSON objects (documents) through th
 Whether you have structured or unstructured text, numerical data, or geospatial data, 
 Elasticsearch efficiently stores and indexes it in a way that supports fast searches. 
 
-For time series data, such as logs and metrics, you typically add documents to a
+For timestamped data such as logs and metrics, you typically add documents to a
 data stream made up of multiple auto-generated backing indices.
 
 To add a single document to an index, submit an HTTP post request that targets the index. 
@@ -88,14 +114,13 @@ POST /customer/_doc/1
 }
 ----
 
-This request automatically creates the `customer` index if it doesn't already exist, 
+This request automatically creates the `customer` index if it doesn't exist, 
 adds a new document that has an ID of 1, and 
 stores and indexes the `firstname` and `lastname` fields.
 
 The new document is available immediately from any node in the cluster. 
 You can retrieve it with a GET request that specifies its document ID:
 
-[source,console]
 ----
 GET /customer/_doc/1
 ----
@@ -104,7 +129,6 @@ To add multiple documents in one request, use the `_bulk` API.
 Bulk data must be newline-delimited JSON (NDJSON). 
 Each line must end in a newline character (`\n`), including the last line.
 
-[source,console]
 ----
 PUT customer/_bulk
 { "create": { } }
@@ -140,12 +164,12 @@ From there, you can start creating visualizations and building and sharing dashb
 To get started, create a _data view_ that connects to one or more Elasticsearch indices,
 data streams, or index aliases.
 
-. Go to **Stack Management > Kibana > Data Views**.
+. Go to **Management > Stack Management > Kibana > Data Views**.
 . Select **Create data view**.
 . Enter a name that matches one or more indices, for example _customers_. 
-. Select **Create data view**.  
+. Select **Save data view to Kibana**.  
 
-To start exploring, select **Discover** from the main menu.
+To start exploring, go to **Analytics > Discover**.
 
 [[upgrade]]
 == Upgrade

--- a/README.asciidoc
+++ b/README.asciidoc
@@ -76,7 +76,7 @@ Kibana enables you to easily send requests to Elasticsearch and analyze, visuali
 docker pull docker.elastic.co/kibana/kibana:{version} <1>
 docker run --name kib-01 --net elastic -p 5601:5601 docker.elastic.co/kibana/kibana:{version}
 ----
-<1> Replace {version} with the version of Kibana you want to run, for example 8.4.1.
+<1> Replace {version} with the version of Kibana you want to run, such as 8.4.1.
 +
 When you start Kibana, a unique link is output to your terminal.
 

--- a/README.asciidoc
+++ b/README.asciidoc
@@ -47,7 +47,7 @@ docker network create elastic
 docker pull docker.elastic.co/elasticsearch/elasticsearch:{version} <1>
 docker run --name es-node1 --net elastic -p 9200:9200 -p 9300:9300 -e "discovery.type=single-node" -t docker.elastic.co/elasticsearch/elasticsearch:{version}
 ----
-<1> Replace {version} with the version of Elasticsearch you want to run, for example 8.4.1.
+<1> Replace {version} with the version of Elasticsearch you want to run, such as 8.4.1.
 +
 When you start Elasticsearch for the first time, the following security configuration 
 occurs automatically:

--- a/README.asciidoc
+++ b/README.asciidoc
@@ -30,6 +30,14 @@ For more installation options, see the
 https://www.elastic.co/guide/en/elasticsearch/reference/current/install-elasticsearch.html[Elasticsearch installation
 documentation].
 
+# tag::set-up-dev[] 
+
+=== Set up a local dev deployment
+
+TODO: Provide Docker compose instructions.
+
+# end::set-up-dev[]
+
 [[upgrade]]
 == Upgrade
 

--- a/README.asciidoc
+++ b/README.asciidoc
@@ -26,21 +26,21 @@ If you prefer to install and manage Elasticsearch yourself, you can download
 the latest version from 
 https://www.elastic.co/downloads/elasticsearch[elastic.co/downloads/elasticsearch].
 
-=== Set up a local dev deployment
+=== Run Elasticsearch locally
 
 //// 
 IMPORTANT: This content is replicated in the Elasticsearch guide. 
 If you make changes, you must also update setup/set-up-local-dev-deployment.asciidoc.
 ////
 
-To try out Elasticsearch on your dev machine, we recommend using Docker
+To try out Elasticsearch on your own machine, we recommend using Docker
 and running both Elasticsearch and Kibana.
 Docker images are available from the https://www.docker.elastic.co[Elastic Docker registry].
 
 For other installation options, see the
 https://www.elastic.co/guide/en/elasticsearch/reference/current/install-elasticsearch.html[Elasticsearch installation documentation].
 
-**Install and run Elasticsearch**
+**Start Elasticsearch**
 
 . Install and start https://www.docker.com/products/docker-desktop[Docker
 Desktop]. Go to **Preferences > Resources > Advanced** and set Memory to at least 4GB.
@@ -50,19 +50,12 @@ Desktop]. Go to **Preferences > Resources > Advanced** and set Memory to at leas
 ----
 docker network create elastic
 docker pull docker.elastic.co/elasticsearch/elasticsearch:{version} <1>
-docker run --name es-node1 --net elastic -p 9200:9200 -p 9300:9300 -e "discovery.type=single-node" -t docker.elastic.co/elasticsearch/elasticsearch:{version}
+docker run --name elasticsearch --net elastic -p 9200:9200 -p 9300:9300 -e "discovery.type=single-node" -t docker.elastic.co/elasticsearch/elasticsearch:{version}
 ----
 <1> Replace {version} with the version of Elasticsearch you want to run, such as 8.4.1.
 +
-When you start Elasticsearch for the first time, the following security configuration 
-occurs automatically:
-+
-* https://www.elastic.co/guide/en/elasticsearch/reference/current/configuring-stack-security.html#stack-security-certificates[Certificates and keys] 
-are generated for the transport and HTTP layers.
-* The Transport Layer Security (TLS) configuration settings are written to
-`elasticsearch.yml`.
-* A password is generated for the `elastic` user.
-* An enrollment token is generated for Kibana.
+When you start Elasticsearch for the first time, the generated `elastic` user password and
+Kibana enrollment token are output to the terminal.
 +
 NOTE: You might need to scroll back a bit in the terminal to view the password 
 and enrollment token.
@@ -71,7 +64,7 @@ and enrollment token.
 location. These values are shown only when you start Elasticsearch for the first time.
 You'll use these to enroll Kibana with your Elasticsearch cluster and log in.
 
-**Install and run Kibana**
+**Start Kibana**
 
 Kibana enables you to easily send requests to Elasticsearch and analyze, visualize, and manage data interactively.
 
@@ -79,13 +72,13 @@ Kibana enables you to easily send requests to Elasticsearch and analyze, visuali
 +
 ----
 docker pull docker.elastic.co/kibana/kibana:{version} <1>
-docker run --name kib-01 --net elastic -p 5601:5601 docker.elastic.co/kibana/kibana:{version}
+docker run --name kibana --net elastic -p 5601:5601 docker.elastic.co/kibana/kibana:{version}
 ----
 <1> Replace {version} with the version of Kibana you want to run, such as 8.4.1.
 +
-When you start Kibana, a unique link is output to your terminal.
+When you start Kibana, a unique URL is output to your terminal.
 
-. To access Kibana, open the generated link in your browser.
+. To access Kibana, open the generated URL in your browser.
 
   .. Paste the enrollment token that you copied when starting
   Elasticsearch and click the button to connect your Kibana instance with Elasticsearch.

--- a/README.asciidoc
+++ b/README.asciidoc
@@ -34,8 +34,37 @@ documentation].
 
 === Set up a local dev deployment
 
-TODO: Provide Docker compose instructions.
+To try out Elasticsearch on your dev machine, we recommend using Docker and 
+running both Elasticsearch and Kibana.
 
+**Install and run Elasticsearch**
+
+. Install and start https://www.docker.com/products/docker-desktop[Docker
+Desktop].
+
+. Run:
++
+[source,sh,subs="attributes"]
+----
+docker network create elastic
+docker pull {docker-repo}:{version}
+docker run --name es01-test --net elastic -p 127.0.0.1:9200:9200 -p 127.0.0.1:9300:9300 -e "discovery.type=single-node" {docker-image}
+----
+
+**Install and run Kibana**
+
+To analyze, visualize, and manage {es} data using an intuitive UI, install
+Kibana.
+
+. In a new terminal session, run:
++
+["source","txt",subs="attributes"]
+----
+docker pull docker.elastic.co/kibana/kibana:{version}
+docker run --name kib01-test --net elastic -p 127.0.0.1:5601:5601 -e "ELASTICSEARCH_HOSTS=http://es01-test:9200" docker.elastic.co/kibana/kibana:{version}
+----
+
+. To access {kib}, go to http://localhost:5601[http://localhost:5601]
 # end::set-up-dev[]
 
 [[upgrade]]

--- a/README.asciidoc
+++ b/README.asciidoc
@@ -34,7 +34,7 @@ and running both Elasticsearch and Kibana.
 For other installation options, see the
 https://www.elastic.co/guide/en/elasticsearch/reference/current/install-elasticsearch.html[Elasticsearch installation documentation].
 
-====Install and run Elasticsearch====
+**Install and run Elasticsearch**
 
 . Install and start https://www.docker.com/products/docker-desktop[Docker
 Desktop].
@@ -47,7 +47,7 @@ docker pull {docker-repo}:{version}
 docker run --name es01-test --net elastic -p 127.0.0.1:9200:9200 -p 127.0.0.1:9300:9300 -e "discovery.type=single-node" {docker-image}
 ----
 
-====Install and run Kibana====
+**Install and run Kibana**
 
 To easily send requests to Elasticsearch and analyze, visualize, and manage data 
 interactively, install Kibana.
@@ -61,7 +61,7 @@ docker run --name kib01-test --net elastic -p 127.0.0.1:5601:5601 -e "ELASTICSEA
 
 . To access {kib}, go to http://localhost:5601[http://localhost:5601]
 
-====Send requests to Elasticsarch====
+**Send requests to Elasticsarch**
 
 You send data and other requests to Elasticsearch through REST APIs. 
 You can interact with Elasticsearch using any client that sends HTTP requests, 
@@ -69,7 +69,7 @@ such as the https://www.elastic.co/guide/en/elasticsearch/client/index.html[Elas
 language clients] and https://curl.se[curl]. 
 Kibana's developer tools console provides an easy way to experiment and test requests. 
 
-====Add data====
+**Add data**
 
 You index data into Elasticsearch by sending JSON objects (documents) through the REST APIs.  
 Whether you have structured or unstructured text, numerical data, or geospatial data, 
@@ -117,7 +117,7 @@ PUT customer/_bulk
 { "firstname": "Jennifer","lastname":"Takeda"}
 ----
 
-====Search====
+**Search**
 
 Indexed documents are available for search in near real-time. 
 The following search matches all customers with a first name of _Jennifer_ 
@@ -132,7 +132,7 @@ GET customer/_search
 }
 ----
 
-====Explore====
+**Explore**
 
 You can use Discover in Kibana to interactively search and filter your data.
 From there, you can start creating visualizations and building and sharing dashboards.
@@ -145,7 +145,7 @@ data streams, or index aliases.
 . Enter a name that matches one or more indices, for example _customers_. 
 . Select **Create data view**.  
 
-To start exploring, select **Discover** from the main menu. 
+To start exploring, select **Discover** from the main menu.  d
 
 [[upgrade]]
 == Upgrade

--- a/README.asciidoc
+++ b/README.asciidoc
@@ -52,7 +52,7 @@ docker network create elastic
 docker pull docker.elastic.co/elasticsearch/elasticsearch:{version} <1>
 docker run --name elasticsearch --net elastic -p 9200:9200 -p 9300:9300 -e "discovery.type=single-node" -t docker.elastic.co/elasticsearch/elasticsearch:{version}
 ----
-<1> Replace {version} with the version of Elasticsearch you want to run, such as 8.4.1.
+<1> Replace {version} with the version of Elasticsearch you want to run.
 +
 When you start Elasticsearch for the first time, the generated `elastic` user password and
 Kibana enrollment token are output to the terminal.
@@ -74,7 +74,7 @@ Kibana enables you to easily send requests to Elasticsearch and analyze, visuali
 docker pull docker.elastic.co/kibana/kibana:{version} <1>
 docker run --name kibana --net elastic -p 5601:5601 docker.elastic.co/kibana/kibana:{version}
 ----
-<1> Replace {version} with the version of Kibana you want to run, such as 8.4.1.
+<1> Replace {version} with the version of Kibana you want to run.
 +
 When you start Kibana, a unique URL is output to your terminal.
 

--- a/README.asciidoc
+++ b/README.asciidoc
@@ -86,7 +86,7 @@ When you start Kibana, a unique link is output to your terminal.
   .. Log in to Kibana as the `elastic` user with the password that was generated
   when you started Elasticsearch.
 
-**Send requests to Elasticsarch**
+**Send requests to Elasticsearch**
 
 You send data and other requests to Elasticsearch through REST APIs. 
 You can interact with Elasticsearch using any client that sends HTTP requests, 

--- a/README.asciidoc
+++ b/README.asciidoc
@@ -145,7 +145,7 @@ data streams, or index aliases.
 . Enter a name that matches one or more indices, for example _customers_. 
 . Select **Create data view**.  
 
-To start exploring, select **Discover** from the main menu.  d
+To start exploring, select **Discover** from the main menu.
 
 [[upgrade]]
 == Upgrade

--- a/README.asciidoc
+++ b/README.asciidoc
@@ -44,9 +44,10 @@ Desktop]. Go to **Preferences > Resources > Advanced** and set Memory to at leas
 +
 ----
 docker network create elastic
-docker pull docker.elastic.co/elasticsearch/elasticsearch:{version}
+docker pull docker.elastic.co/elasticsearch/elasticsearch:{version} <1>
 docker run --name es-node1 --net elastic -p 9200:9200 -p 9300:9300 -e "discovery.type=single-node" -t docker.elastic.co/elasticsearch/elasticsearch:{version}
 ----
+<1> Replace {version} with the version of Elasticsearch you want to run, for example 8.4.1.
 +
 When you start Elasticsearch for the first time, the following security configuration 
 occurs automatically:
@@ -72,9 +73,10 @@ Kibana enables you to easily send requests to Elasticsearch and analyze, visuali
 . In a new terminal session, start Kibana and connect it to your Elasticsearch container:
 +
 ----
-docker pull docker.elastic.co/kibana/kibana:{version}
+docker pull docker.elastic.co/kibana/kibana:{version} <1>
 docker run --name kib-01 --net elastic -p 5601:5601 docker.elastic.co/kibana/kibana:{version}
 ----
+<1> Replace {version} with the version of Kibana you want to run, for example 8.4.1.
 +
 When you start Kibana, a unique link is output to your terminal.
 

--- a/README.asciidoc
+++ b/README.asciidoc
@@ -28,6 +28,11 @@ https://www.elastic.co/downloads/elasticsearch[elastic.co/downloads/elasticsearc
 
 === Set up a local dev deployment
 
+//// 
+IMPORTANT: This content is replicated in the Elasticsearch guide. 
+If you make changes, you must also update setup/set-up-local-dev-deployment.asciidoc.
+////
+
 To try out Elasticsearch on your dev machine, we recommend using Docker
 and running both Elasticsearch and Kibana.
 Docker images are available from the https://www.docker.elastic.co[Elastic Docker registry].

--- a/README.asciidoc
+++ b/README.asciidoc
@@ -26,46 +26,126 @@ If you prefer to install and manage Elasticsearch yourself, you can download
 the latest version from 
 https://www.elastic.co/downloads/elasticsearch[elastic.co/downloads/elasticsearch].
 
-For more installation options, see the
-https://www.elastic.co/guide/en/elasticsearch/reference/current/install-elasticsearch.html[Elasticsearch installation
-documentation].
-
-# tag::set-up-dev[] 
-
 === Set up a local dev deployment
 
-To try out Elasticsearch on your dev machine, we recommend using Docker and 
-running both Elasticsearch and Kibana.
+To try out Elasticsearch on your dev machine, we recommend using Docker
+and running both Elasticsearch and Kibana.
 
-**Install and run Elasticsearch**
+For other installation options, see the
+https://www.elastic.co/guide/en/elasticsearch/reference/current/install-elasticsearch.html[Elasticsearch installation documentation].
+
+====Install and run Elasticsearch====
 
 . Install and start https://www.docker.com/products/docker-desktop[Docker
 Desktop].
 
 . Run:
 +
-[source,sh,subs="attributes"]
 ----
 docker network create elastic
 docker pull {docker-repo}:{version}
 docker run --name es01-test --net elastic -p 127.0.0.1:9200:9200 -p 127.0.0.1:9300:9300 -e "discovery.type=single-node" {docker-image}
 ----
 
-**Install and run Kibana**
+====Install and run Kibana====
 
-To analyze, visualize, and manage {es} data using an intuitive UI, install
-Kibana.
+To easily send requests to Elasticsearch and analyze, visualize, and manage data 
+interactively, install Kibana.
 
 . In a new terminal session, run:
 +
-["source","txt",subs="attributes"]
 ----
 docker pull docker.elastic.co/kibana/kibana:{version}
 docker run --name kib01-test --net elastic -p 127.0.0.1:5601:5601 -e "ELASTICSEARCH_HOSTS=http://es01-test:9200" docker.elastic.co/kibana/kibana:{version}
 ----
 
 . To access {kib}, go to http://localhost:5601[http://localhost:5601]
-# end::set-up-dev[]
+
+====Send requests to Elasticsarch====
+
+You send data and other requests to Elasticsearch through REST APIs. 
+You can interact with Elasticsearch using any client that sends HTTP requests, 
+such as the https://www.elastic.co/guide/en/elasticsearch/client/index.html[Elasticsearch
+language clients] and https://curl.se[curl]. 
+Kibana's developer tools console provides an easy way to experiment and test requests. 
+
+====Add data====
+
+You index data into Elasticsearch by sending JSON objects (documents) through the REST APIs.  
+Whether you have structured or unstructured text, numerical data, or geospatial data, 
+Elasticsearch efficiently stores and indexes it in a way that supports fast searches. 
+
+For time series data, such as logs and metrics, you typically add documents to a
+data stream made up of multiple auto-generated backing indices.
+
+To add a single document to an index, submit an HTTP post request that targets the index. 
+
+----
+POST /customer/_doc/1
+{
+  "firstname": "Jennifer",
+  "lastname": "Walters"
+}
+----
+
+This request automatically creates the `customer` index if it doesn't already exist, 
+adds a new document that has an ID of 1, and 
+stores and indexes the `firstname` and `lastname` fields.
+
+The new document is available immediately from any node in the cluster. 
+You can retrieve it with a GET request that specifies its document ID:
+
+[source,console]
+----
+GET /customer/_doc/1
+----
+
+To add multiple documents in one request, use the `_bulk` API.
+Bulk data must be newline-delimited JSON (NDJSON). 
+Each line must end in a newline character (`\n`), including the last line.
+
+[source,console]
+----
+PUT customer/_bulk
+{ "create": { } }
+{ "firstname": "Monica","lastname":"Rambeau"}
+{ "create": { } }
+{ "firstname": "Carol","lastname":"Danvers"}
+{ "create": { } }
+{ "firstname": "Wanda","lastname":"Maximoff"}
+{ "create": { } }
+{ "firstname": "Jennifer","lastname":"Takeda"}
+----
+
+====Search====
+
+Indexed documents are available for search in near real-time. 
+The following search matches all customers with a first name of _Jennifer_ 
+in the `customer` index.
+
+----
+GET customer/_search
+{
+  "query" : {
+    "match" : { "firstname": "Jennifer" }  
+  }
+}
+----
+
+====Explore====
+
+You can use Discover in Kibana to interactively search and filter your data.
+From there, you can start creating visualizations and building and sharing dashboards.
+
+To get started, create a _data view_ that connects to one or more Elasticsearch indices,
+data streams, or index aliases.
+
+. Go to **Stack Management > Kibana > Data Views**.
+. Select **Create data view**.
+. Enter a name that matches one or more indices, for example _customers_. 
+. Select **Create data view**.  
+
+To start exploring, select **Discover** from the main menu. 
 
 [[upgrade]]
 == Upgrade

--- a/README.asciidoc
+++ b/README.asciidoc
@@ -171,7 +171,8 @@ data streams, or index aliases.
 
 . Go to **Management > Stack Management > Kibana > Data Views**.
 . Select **Create data view**.
-. Enter a name that matches one or more indices, for example _customers_. 
+. Enter a name for the data view and a pattern that matches one or more indices, 
+such as _customer_. 
 . Select **Save data view to Kibana**.  
 
 To start exploring, go to **Analytics > Discover**.

--- a/docs/reference/setup.asciidoc
+++ b/docs/reference/setup.asciidoc
@@ -45,6 +45,8 @@ resource-heavy {ls} deployment should be on its own host.
 
 include::setup/install.asciidoc[]
 
+include::setup/set-up-local-dev-deployment.asciidoc[]
+
 include::setup/configuration.asciidoc[]
 
 include::setup/important-settings.asciidoc[]

--- a/docs/reference/setup.asciidoc
+++ b/docs/reference/setup.asciidoc
@@ -45,7 +45,7 @@ resource-heavy {ls} deployment should be on its own host.
 
 include::setup/install.asciidoc[]
 
-include::setup/set-up-local-dev-deployment.asciidoc[]
+include::setup/run-elasticsearch-locally.asciidoc[]
 
 include::setup/configuration.asciidoc[]
 

--- a/docs/reference/setup/install.asciidoc
+++ b/docs/reference/setup/install.asciidoc
@@ -20,6 +20,8 @@ If you want to install and manage {es} yourself, you can:
 * Run {es} in a <<docker, Docker container>>. 
 * Set up and manage {es}, {kib}, {agent}, and the rest of the Elastic Stack on Kubernetes with {eck-ref}[{eck}].
 
+TIP: To try out Elasticsearch on your own machine, we recommend using Docker and running both Elasticsearch and Kibana. For more information, see <<run-elasticsearch-locally,Run Elasticsearch locally>>.
+
 [discrete]
 [[elasticsearch-install-packages]]
 === Elasticsearch install packages

--- a/docs/reference/setup/run-elasticsearch-locally.asciidoc
+++ b/docs/reference/setup/run-elasticsearch-locally.asciidoc
@@ -1,5 +1,5 @@
 [[run-elasticsearch-locally]]
-=== Run Elasticsearch locally
+== Run Elasticsearch locally
 
 //// 
 IMPORTANT: This content is replicated in the Elasticsearch repo 
@@ -25,19 +25,27 @@ and a Kibana enrollment token is created so you can connect Kibana to your secur
 For other installation options, see the
 https://www.elastic.co/guide/en/elasticsearch/reference/current/install-elasticsearch.html[Elasticsearch installation documentation].
 
-==== Start Elasticsearch
+[discrete]
+=== Start Elasticsearch
 
 . Install and start https://www.docker.com/products/docker-desktop[Docker
 Desktop]. Go to **Preferences > Resources > Advanced** and set Memory to at least 4GB.
 
 . Start an Elasticsearch container:
+ifeval::["{release-state}"=="unreleased"]
++
+NOTE: Version {version} of {es} has not yet been released, so no
+Docker image is currently available for this version.
+endif::[]
+ifeval::["{release-state}"!="unreleased"]
 +
 [source,sh,subs="attributes"]
 ----
 docker network create elastic
-docker pull docker.elastic.co/Elasticsearch/Elasticsearch:{version}
-docker run --name elasticsearch --net elastic -p 9200:9200 -p 9300:9300 -e "discovery.type=single-node" -t docker.elastic.co/Elasticsearch/Elasticsearch:{version}
+docker pull docker.elastic.co/elasticsearch/elasticsearch:{version}
+docker run --name elasticsearch --net elastic -p 9200:9200 -p 9300:9300 -e "discovery.type=single-node" -t docker.elastic.co/elasticsearch/elasticsearch:{version}
 ----
+endif::[]
 +
 When you start Elasticsearch for the first time, the generated `elastic` user password and
 Kibana enrollment token are output to the terminal.
@@ -49,17 +57,25 @@ and enrollment token.
 location. These values are shown only when you start Elasticsearch for the first time.
 You'll use these to enroll Kibana with your Elasticsearch cluster and log in.
 
-==== Start Kibana
+[discrete]
+=== Start Kibana
 
 Kibana enables you to easily send requests to Elasticsearch and analyze, visualize, and manage data interactively.
 
 . In a new terminal session, start Kibana and connect it to your Elasticsearch container:
+ifeval::["{release-state}"=="unreleased"]
++
+NOTE: Version {version} of {kib} has not yet been released, so no
+Docker image is currently available for this version.
+endif::[]
+ifeval::["{release-state}"!="unreleased"]
 +
 [source,sh,subs="attributes"]
 ----
-docker pull docker.elastic.co/Kibana/Kibana:{version}
-docker run --name kibana --net elastic -p 5601:5601 docker.elastic.co/Kibana/Kibana:{version}
+docker pull docker.elastic.co/kibana/kibana:{version}
+docker run --name kibana --net elastic -p 5601:5601 docker.elastic.co/kibana/kibana:{version}
 ----
+endif::[]
 +
 When you start Kibana, a unique URL is output to your terminal.
 
@@ -71,7 +87,8 @@ When you start Kibana, a unique URL is output to your terminal.
   .. Log in to Kibana as the `elastic` user with the password that was generated
   when you started Elasticsearch.
 
-==== Send requests to Elasticsearch
+[discrete]
+=== Send requests to Elasticsearch
 
 You send data and other requests to Elasticsearch through REST APIs. 
 You can interact with Elasticsearch using any client that sends HTTP requests, 
@@ -80,7 +97,8 @@ language clients] and https://curl.se[curl].
 Kibana's developer console provides an easy way to experiment and test requests. 
 To access the console, go to **Management > Dev Tools**.
 
-==== Add data
+[discrete]
+=== Add data
 
 You index data into Elasticsearch by sending JSON objects (documents) through the REST APIs.  
 Whether you have structured or unstructured text, numerical data, or geospatial data, 
@@ -131,7 +149,8 @@ PUT customer/_bulk
 ----
 // TEST[continued]
 
-==== Search
+[discrete]
+=== Search
 
 Indexed documents are available for search in near real-time. 
 The following search matches all customers with a first name of _Jennifer_ 
@@ -148,7 +167,8 @@ GET customer/_search
 ----
 // TEST[continued]
 
-==== Explore
+[discrete]
+=== Explore
 
 You can use Discover in Kibana to interactively search and filter your data.
 From there, you can start creating visualizations and building and sharing dashboards.
@@ -158,7 +178,8 @@ data streams, or index aliases.
 
 . Go to **Management > Stack Management > Kibana > Data Views**.
 . Select **Create data view**.
-. Enter a name that matches one or more indices, for example _customers_. 
+. Enter a name for the data view and a pattern that matches one or more indices, 
+for example _customer_. 
 . Select **Save data view to Kibana**.  
 
 To start exploring, go to **Analytics > Discover**.

--- a/docs/reference/setup/run-elasticsearch-locally.asciidoc
+++ b/docs/reference/setup/run-elasticsearch-locally.asciidoc
@@ -23,7 +23,7 @@ a password is generated for the `elastic` user,
 and a Kibana enrollment token is created so you can connect Kibana to your secured cluster.
 
 For other installation options, see the
-https://www.elastic.co/guide/en/Elasticsearch/reference/current/install-Elasticsearch.html[Elasticsearch installation documentation].
+https://www.elastic.co/guide/en/Elasticsearch/reference/current/install-elasticsearch.html[Elasticsearch installation documentation].
 
 **Start Elasticsearch**
 
@@ -75,7 +75,7 @@ When you start Kibana, a unique URL is output to your terminal.
 
 You send data and other requests to Elasticsearch through REST APIs. 
 You can interact with Elasticsearch using any client that sends HTTP requests, 
-such as the https://www.elastic.co/guide/en/Elasticsearch/client/index.html[Elasticsearch
+such as the https://www.elastic.co/guide/en/elasticsearch/client/index.html[Elasticsearch
 language clients] and https://curl.se[curl]. 
 Kibana's developer console provides an easy way to experiment and test requests. 
 To access the console, go to **Management > Dev Tools**.

--- a/docs/reference/setup/run-elasticsearch-locally.asciidoc
+++ b/docs/reference/setup/run-elasticsearch-locally.asciidoc
@@ -25,7 +25,7 @@ and a Kibana enrollment token is created so you can connect Kibana to your secur
 For other installation options, see the
 https://www.elastic.co/guide/en/elasticsearch/reference/current/install-elasticsearch.html[Elasticsearch installation documentation].
 
-**Start Elasticsearch**
+==== Start Elasticsearch
 
 . Install and start https://www.docker.com/products/docker-desktop[Docker
 Desktop]. Go to **Preferences > Resources > Advanced** and set Memory to at least 4GB.
@@ -49,7 +49,7 @@ and enrollment token.
 location. These values are shown only when you start Elasticsearch for the first time.
 You'll use these to enroll Kibana with your Elasticsearch cluster and log in.
 
-**Start Kibana**
+==== Start Kibana
 
 Kibana enables you to easily send requests to Elasticsearch and analyze, visualize, and manage data interactively.
 
@@ -71,7 +71,7 @@ When you start Kibana, a unique URL is output to your terminal.
   .. Log in to Kibana as the `elastic` user with the password that was generated
   when you started Elasticsearch.
 
-**Send requests to Elasticsearch**
+==== Send requests to Elasticsearch
 
 You send data and other requests to Elasticsearch through REST APIs. 
 You can interact with Elasticsearch using any client that sends HTTP requests, 
@@ -80,7 +80,7 @@ language clients] and https://curl.se[curl].
 Kibana's developer console provides an easy way to experiment and test requests. 
 To access the console, go to **Management > Dev Tools**.
 
-**Add data**
+==== Add data
 
 You index data into Elasticsearch by sending JSON objects (documents) through the REST APIs.  
 Whether you have structured or unstructured text, numerical data, or geospatial data, 
@@ -131,7 +131,7 @@ PUT customer/_bulk
 ----
 // TEST[continued]
 
-**Search**
+==== Search
 
 Indexed documents are available for search in near real-time. 
 The following search matches all customers with a first name of _Jennifer_ 
@@ -148,7 +148,7 @@ GET customer/_search
 ----
 // TEST[continued]
 
-**Explore**
+==== Explore
 
 You can use Discover in Kibana to interactively search and filter your data.
 From there, you can start creating visualizations and building and sharing dashboards.

--- a/docs/reference/setup/run-elasticsearch-locally.asciidoc
+++ b/docs/reference/setup/run-elasticsearch-locally.asciidoc
@@ -17,6 +17,11 @@ To try out Elasticsearch on your own machine, we recommend using Docker
 and running both Elasticsearch and Kibana.
 Docker images are available from the https://www.docker.elastic.co[Elastic Docker registry].
 
+NOTE: Starting in Elasticsearch 8.0, security is enabled by default. 
+The first time you start Elasticsearch, TLS encryption is configured automatically, 
+a password is generated for the `elastic` user, 
+and a Kibana enrollment token is created so you can connect Kibana to your secured cluster.
+
 For other installation options, see the
 https://www.elastic.co/guide/en/Elasticsearch/reference/current/install-Elasticsearch.html[Elasticsearch installation documentation].
 

--- a/docs/reference/setup/run-elasticsearch-locally.asciidoc
+++ b/docs/reference/setup/run-elasticsearch-locally.asciidoc
@@ -23,7 +23,7 @@ a password is generated for the `elastic` user,
 and a Kibana enrollment token is created so you can connect Kibana to your secured cluster.
 
 For other installation options, see the
-https://www.elastic.co/guide/en/Elasticsearch/reference/current/install-elasticsearch.html[Elasticsearch installation documentation].
+https://www.elastic.co/guide/en/elasticsearch/reference/current/install-elasticsearch.html[Elasticsearch installation documentation].
 
 **Start Elasticsearch**
 

--- a/docs/reference/setup/run-elasticsearch-locally.asciidoc
+++ b/docs/reference/setup/run-elasticsearch-locally.asciidoc
@@ -1,4 +1,4 @@
-[[run-Elasticsearch-locally]]
+[[run-elasticsearch-locally]]
 === Run Elasticsearch locally
 
 //// 

--- a/docs/reference/setup/run-elasticsearch-locally.asciidoc
+++ b/docs/reference/setup/run-elasticsearch-locally.asciidoc
@@ -1,5 +1,5 @@
-[[set-up-local-dev-deployment]]
-=== Set up a local dev deployment
+[[run-Elasticsearch-locally]]
+=== Run Elasticsearch locally
 
 //// 
 IMPORTANT: This content is replicated in the Elasticsearch repo 
@@ -13,14 +13,14 @@ Also note that there are similar instructions in the Kibana guide:
 https://www.elastic.co/guide/en/kibana/current/docker.html
 ////
 
-To try out Elasticsearch on your dev machine, we recommend using Docker
+To try out Elasticsearch on your own machine, we recommend using Docker
 and running both Elasticsearch and Kibana.
 Docker images are available from the https://www.docker.elastic.co[Elastic Docker registry].
 
 For other installation options, see the
-https://www.elastic.co/guide/en/elasticsearch/reference/current/install-elasticsearch.html[Elasticsearch installation documentation].
+https://www.elastic.co/guide/en/Elasticsearch/reference/current/install-Elasticsearch.html[Elasticsearch installation documentation].
 
-**Install and run Elasticsearch**
+**Start Elasticsearch**
 
 . Install and start https://www.docker.com/products/docker-desktop[Docker
 Desktop]. Go to **Preferences > Resources > Advanced** and set Memory to at least 4GB.
@@ -30,19 +30,12 @@ Desktop]. Go to **Preferences > Resources > Advanced** and set Memory to at leas
 [source,sh,subs="attributes"]
 ----
 docker network create elastic
-docker pull docker.elastic.co/elasticsearch/elasticsearch:{version}
-docker run --name es-node1 --net elastic -p 9200:9200 -p 9300:9300 -e "discovery.type=single-node" -t docker.elastic.co/elasticsearch/elasticsearch:{version}
+docker pull docker.elastic.co/Elasticsearch/Elasticsearch:{version}
+docker run --name elasticsearch --net elastic -p 9200:9200 -p 9300:9300 -e "discovery.type=single-node" -t docker.elastic.co/Elasticsearch/Elasticsearch:{version}
 ----
 +
-When you start Elasticsearch for the first time, the following security configuration 
-occurs automatically:
-+
-* https://www.elastic.co/guide/en/elasticsearch/reference/current/configuring-stack-security.html#stack-security-certificates[Certificates and keys] 
-are generated for the transport and HTTP layers.
-* The Transport Layer Security (TLS) configuration settings are written to
-`elasticsearch.yml`.
-* A password is generated for the `elastic` user.
-* An enrollment token is generated for Kibana.
+When you start Elasticsearch for the first time, the generated `elastic` user password and
+Kibana enrollment token are output to the terminal.
 +
 NOTE: You might need to scroll back a bit in the terminal to view the password 
 and enrollment token.
@@ -51,7 +44,7 @@ and enrollment token.
 location. These values are shown only when you start Elasticsearch for the first time.
 You'll use these to enroll Kibana with your Elasticsearch cluster and log in.
 
-**Install and run Kibana**
+**Start Kibana**
 
 Kibana enables you to easily send requests to Elasticsearch and analyze, visualize, and manage data interactively.
 
@@ -59,13 +52,13 @@ Kibana enables you to easily send requests to Elasticsearch and analyze, visuali
 +
 [source,sh,subs="attributes"]
 ----
-docker pull docker.elastic.co/kibana/kibana:{version}
-docker run --name kib-01 --net elastic -p 5601:5601 docker.elastic.co/kibana/kibana:{version}
+docker pull docker.elastic.co/Kibana/Kibana:{version}
+docker run --name kibana --net elastic -p 5601:5601 docker.elastic.co/Kibana/Kibana:{version}
 ----
 +
-When you start Kibana, a unique link is output to your terminal.
+When you start Kibana, a unique URL is output to your terminal.
 
-. To access Kibana, open the generated link in your browser.
+. To access Kibana, open the generated URL in your browser.
 
   .. Paste the enrollment token that you copied when starting
   Elasticsearch and click the button to connect your Kibana instance with Elasticsearch.
@@ -77,7 +70,7 @@ When you start Kibana, a unique link is output to your terminal.
 
 You send data and other requests to Elasticsearch through REST APIs. 
 You can interact with Elasticsearch using any client that sends HTTP requests, 
-such as the https://www.elastic.co/guide/en/elasticsearch/client/index.html[Elasticsearch
+such as the https://www.elastic.co/guide/en/Elasticsearch/client/index.html[Elasticsearch
 language clients] and https://curl.se[curl]. 
 Kibana's developer console provides an easy way to experiment and test requests. 
 To access the console, go to **Management > Dev Tools**.

--- a/docs/reference/setup/run-elasticsearch-locally.asciidoc
+++ b/docs/reference/setup/run-elasticsearch-locally.asciidoc
@@ -179,7 +179,7 @@ data streams, or index aliases.
 . Go to **Management > Stack Management > Kibana > Data Views**.
 . Select **Create data view**.
 . Enter a name for the data view and a pattern that matches one or more indices, 
-for example _customer_. 
+such as _customer_. 
 . Select **Save data view to Kibana**.  
 
 To start exploring, go to **Analytics > Discover**.

--- a/docs/reference/setup/set-up-local-dev-deployment.asciidoc
+++ b/docs/reference/setup/set-up-local-dev-deployment.asciidoc
@@ -5,8 +5,161 @@
 IMPORTANT: This content is replicated in the Elasticsearch repo 
 README.ascidoc file. If you make changes, you must also update the 
 Elasticsearch README.
-
++
 GitHub renders the tagged region directives when you view the README, 
 so it's not possible to just include the content from the README. Darn.
++
+Also note that there are similar instructions in the Kibana guide:
+https://www.elastic.co/guide/en/kibana/current/docker.html
 ////
+
+To try out Elasticsearch on your dev machine, we recommend using Docker
+and running both Elasticsearch and Kibana.
+Docker images are available from the https://www.docker.elastic.co[Elastic Docker registry].
+
+For other installation options, see the
+https://www.elastic.co/guide/en/elasticsearch/reference/current/install-elasticsearch.html[Elasticsearch installation documentation].
+
+**Install and run Elasticsearch**
+
+. Install and start https://www.docker.com/products/docker-desktop[Docker
+Desktop]. Go to **Preferences > Resources > Advanced** and set Memory to at least 4GB.
+
+. Start an Elasticsearch container:
++
+[source,sh,subs="attributes"]
+----
+docker network create elastic
+docker pull docker.elastic.co/elasticsearch/elasticsearch:{version}
+docker run --name es-node1 --net elastic -p 9200:9200 -p 9300:9300 -e "discovery.type=single-node" -t docker.elastic.co/elasticsearch/elasticsearch:{version}
+----
++
+When you start Elasticsearch for the first time, the following security configuration 
+occurs automatically:
++
+* https://www.elastic.co/guide/en/elasticsearch/reference/current/configuring-stack-security.html#stack-security-certificates[Certificates and keys] 
+are generated for the transport and HTTP layers.
+* The Transport Layer Security (TLS) configuration settings are written to
+`elasticsearch.yml`.
+* A password is generated for the `elastic` user.
+* An enrollment token is generated for Kibana.
++
+NOTE: You might need to scroll back a bit in the terminal to view the password 
+and enrollment token.
+
+. Copy the generated password and enrollment token and save them in a secure 
+location. These values are shown only when you start Elasticsearch for the first time.
+You'll use these to enroll Kibana with your Elasticsearch cluster and log in.
+
+**Install and run Kibana**
+
+Kibana enables you to easily send requests to Elasticsearch and analyze, visualize, and manage data interactively.
+
+. In a new terminal session, start Kibana and connect it to your Elasticsearch container:
++
+[source,sh,subs="attributes"]
+----
+docker pull docker.elastic.co/kibana/kibana:{version}
+docker run --name kib-01 --net elastic -p 5601:5601 docker.elastic.co/kibana/kibana:{version}
+----
++
+When you start Kibana, a unique link is output to your terminal.
+
+. To access Kibana, open the generated link in your browser.
+
+  .. Paste the enrollment token that you copied when starting
+  Elasticsearch and click the button to connect your Kibana instance with Elasticsearch.
+
+  .. Log in to Kibana as the `elastic` user with the password that was generated
+  when you started Elasticsearch.
+
+**Send requests to Elasticsearch**
+
+You send data and other requests to Elasticsearch through REST APIs. 
+You can interact with Elasticsearch using any client that sends HTTP requests, 
+such as the https://www.elastic.co/guide/en/elasticsearch/client/index.html[Elasticsearch
+language clients] and https://curl.se[curl]. 
+Kibana's developer console provides an easy way to experiment and test requests. 
+To access the console, go to **Management > Dev Tools**.
+
+**Add data**
+
+You index data into Elasticsearch by sending JSON objects (documents) through the REST APIs.  
+Whether you have structured or unstructured text, numerical data, or geospatial data, 
+Elasticsearch efficiently stores and indexes it in a way that supports fast searches. 
+
+For timestamped data such as logs and metrics, you typically add documents to a
+data stream made up of multiple auto-generated backing indices.
+
+To add a single document to an index, submit an HTTP post request that targets the index. 
+
+[source,console]
+----
+POST /customer/_doc/1
+{
+  "firstname": "Jennifer",
+  "lastname": "Walters"
+}
+----
+
+This request automatically creates the `customer` index if it doesn't exist, 
+adds a new document that has an ID of 1, and 
+stores and indexes the `firstname` and `lastname` fields.
+
+The new document is available immediately from any node in the cluster. 
+You can retrieve it with a GET request that specifies its document ID:
+
+[source,console]
+----
+GET /customer/_doc/1
+----
+
+To add multiple documents in one request, use the `_bulk` API.
+Bulk data must be newline-delimited JSON (NDJSON). 
+Each line must end in a newline character (`\n`), including the last line.
+
+[source,console]
+----
+PUT customer/_bulk
+{ "create": { } }
+{ "firstname": "Monica","lastname":"Rambeau"}
+{ "create": { } }
+{ "firstname": "Carol","lastname":"Danvers"}
+{ "create": { } }
+{ "firstname": "Wanda","lastname":"Maximoff"}
+{ "create": { } }
+{ "firstname": "Jennifer","lastname":"Takeda"}
+----
+
+**Search**
+
+Indexed documents are available for search in near real-time. 
+The following search matches all customers with a first name of _Jennifer_ 
+in the `customer` index.
+
+[source,console]
+----
+GET customer/_search
+{
+  "query" : {
+    "match" : { "firstname": "Jennifer" }  
+  }
+}
+----
+
+**Explore**
+
+You can use Discover in Kibana to interactively search and filter your data.
+From there, you can start creating visualizations and building and sharing dashboards.
+
+To get started, create a _data view_ that connects to one or more Elasticsearch indices,
+data streams, or index aliases.
+
+. Go to **Management > Stack Management > Kibana > Data Views**.
+. Select **Create data view**.
+. Enter a name that matches one or more indices, for example _customers_. 
+. Select **Save data view to Kibana**.  
+
+To start exploring, go to **Analytics > Discover**.
+
 

--- a/docs/reference/setup/set-up-local-dev-deployment.asciidoc
+++ b/docs/reference/setup/set-up-local-dev-deployment.asciidoc
@@ -113,6 +113,7 @@ You can retrieve it with a GET request that specifies its document ID:
 ----
 GET /customer/_doc/1
 ----
+// TEST[continued]
 
 To add multiple documents in one request, use the `_bulk` API.
 Bulk data must be newline-delimited JSON (NDJSON). 
@@ -130,6 +131,7 @@ PUT customer/_bulk
 { "create": { } }
 { "firstname": "Jennifer","lastname":"Takeda"}
 ----
+// TEST[continued]
 
 **Search**
 
@@ -146,6 +148,7 @@ GET customer/_search
   }
 }
 ----
+// TEST[continued]
 
 **Explore**
 

--- a/docs/reference/setup/set-up-local-dev-deployment.asciidoc
+++ b/docs/reference/setup/set-up-local-dev-deployment.asciidoc
@@ -1,0 +1,12 @@
+[[set-up-local-dev-deployment]]
+=== Set up a local dev deployment
+
+//// 
+IMPORTANT: This content is replicated in the Elasticsearch repo 
+README.ascidoc file. If you make changes, you must also update the 
+Elasticsearch README.
+
+GitHub renders the tagged region directives when you view the README, 
+so it's not possible to just include the content from the README. Darn.
+////
+


### PR DESCRIPTION
Closes: [89739](https://github.com/elastic/elasticsearch/issues/89739)