### PR TITLE
[8.4] [DOCS] Remove coming tag from 8.4.1 RNs (#89727)

### DIFF
--- a/docs/reference/release-notes/8.4.1.asciidoc
+++ b/docs/reference/release-notes/8.4.1.asciidoc
@@ -1,8 +1,6 @@
 [[release-notes-8.4.1]]
 == {es} version 8.4.1
 
-coming[8.4.1]
-
 Also see <<breaking-changes-8.4,Breaking changes in 8.4>>.
 
 [[bug-8.4.1]]


### PR DESCRIPTION
Backports the following commits to 8.4:
 - [DOCS] Remove coming tag from 8.4.1 RNs (#89727)