### PR TITLE
[8.4] Fix pipeline id not present in ingest metadata inside on_failure block (#89632)

### DIFF
--- a/docs/changelog/89632.yaml
+++ b/docs/changelog/89632.yaml
@@ -1,0 +1,5 @@
+pr: 89632
+summary: Fix pipeline id not present in ingest metadata inside `on_failure` block
+area: Ingest Node
+type: bug
+issues: []

--- a/server/src/main/java/org/elasticsearch/ingest/CompoundProcessor.java
+++ b/server/src/main/java/org/elasticsearch/ingest/CompoundProcessor.java
@@ -327,7 +327,7 @@ public class CompoundProcessor implements Processor {
         }
         if (document != null) {
             List<String> pipelineStack = document.getPipelineStack();
-            if (pipelineStack.size() > 1) {
+            if (pipelineStack.isEmpty() == false) {
                 exception.addHeader("pipeline_origin", pipelineStack);
             }
         }

--- a/server/src/test/java/org/elasticsearch/action/ingest/SimulateExecutionServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/action/ingest/SimulateExecutionServiceTests.java
@@ -181,6 +181,7 @@ public class SimulateExecutionServiceTests extends ESTestCase {
         metadata.put(CompoundProcessor.ON_FAILURE_PROCESSOR_TYPE_FIELD, "mock");
         metadata.put(CompoundProcessor.ON_FAILURE_PROCESSOR_TAG_FIELD, "processor_0");
         metadata.put(CompoundProcessor.ON_FAILURE_MESSAGE_FIELD, "processor failed");
+        metadata.put(CompoundProcessor.ON_FAILURE_PIPELINE_FIELD, "_id");
         assertVerboseResult(
             simulateDocumentVerboseResult.getProcessorResults().get(1),
             pipeline.getId(),


### PR DESCRIPTION
Backports the following commits to 8.4:
 - Fix pipeline id not present in ingest metadata inside on_failure block (#89632)