### PR TITLE
Skip update of breaking changes and migration guide for patch releases

### DIFF
--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/release/GenerateReleaseNotesTask.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/release/GenerateReleaseNotesTask.java
@@ -128,26 +128,29 @@ public class GenerateReleaseNotesTask extends DefaultTask {
             changelogsByVersion.getOrDefault(qualifiedVersion, Set.of())
         );
 
-        LOGGER.info("Generating release highlights...");
-        ReleaseHighlightsGenerator.update(
-            this.releaseHighlightsTemplate.get().getAsFile(),
-            this.releaseHighlightsFile.get().getAsFile(),
-            entries
-        );
+        // Only update breaking changes and migration guide for new minors
+        if (qualifiedVersion.revision() == 0) {
+            LOGGER.info("Generating release highlights...");
+            ReleaseHighlightsGenerator.update(
+                this.releaseHighlightsTemplate.get().getAsFile(),
+                this.releaseHighlightsFile.get().getAsFile(),
+                entries
+            );
 
-        LOGGER.info("Generating breaking changes / deprecations notes...");
-        BreakingChangesGenerator.update(
-            this.breakingChangesTemplate.get().getAsFile(),
-            this.breakingChangesMigrationFile.get().getAsFile(),
-            entries
-        );
+            LOGGER.info("Generating breaking changes / deprecations notes...");
+            BreakingChangesGenerator.update(
+                this.breakingChangesTemplate.get().getAsFile(),
+                this.breakingChangesMigrationFile.get().getAsFile(),
+                entries
+            );
 
-        LOGGER.info("Updating migration/index...");
-        MigrationIndexGenerator.update(
-            getMinorVersions(versions),
-            this.migrationIndexTemplate.get().getAsFile(),
-            this.migrationIndexFile.get().getAsFile()
-        );
+            LOGGER.info("Updating migration/index...");
+            MigrationIndexGenerator.update(
+                getMinorVersions(versions),
+                this.migrationIndexTemplate.get().getAsFile(),
+                this.migrationIndexFile.get().getAsFile()
+            );
+        }
     }
 
     /**


### PR DESCRIPTION
As a follow up to [this comment](https://github.com/elastic/elasticsearch/pull/89636#discussion_r957378349) we shouldn't be updating the breaking changes or migration guide for patch releases. These things don't change after the initial release of a new minor (or shouldn't) and since we prune old changelogs after each release, we have no way of rebuilding a consolidated document based on all changes across a minor anyhow.