### PR TITLE
[7.17] Fix pipeline id not present in ingest metadata inside on_failure block (#89632)

### DIFF
--- a/docs/changelog/89632.yaml
+++ b/docs/changelog/89632.yaml
@@ -1,0 +1,5 @@
+pr: 89632
+summary: Fix pipeline id not present in ingest metadata inside `on_failure` block
+area: Ingest Node
+type: bug
+issues: []

--- a/server/src/main/java/org/elasticsearch/ingest/CompoundProcessor.java
+++ b/server/src/main/java/org/elasticsearch/ingest/CompoundProcessor.java
@@ -247,9 +247,11 @@ public class CompoundProcessor implements Processor {
         if (processorTag != null) {
             exception.addHeader("processor_tag", processorTag);
         }
-        List<String> pipelineStack = document.getPipelineStack();
-        if (pipelineStack.size() > 1) {
-            exception.addHeader("pipeline_origin", pipelineStack);
+        if (document != null) {
+            List<String> pipelineStack = document.getPipelineStack();
+            if (pipelineStack.isEmpty() == false) {
+                exception.addHeader("pipeline_origin", pipelineStack);
+            }
         }
 
         return exception;

--- a/server/src/test/java/org/elasticsearch/action/ingest/SimulateExecutionServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/action/ingest/SimulateExecutionServiceTests.java
@@ -181,6 +181,7 @@ public class SimulateExecutionServiceTests extends ESTestCase {
         metadata.put(CompoundProcessor.ON_FAILURE_PROCESSOR_TYPE_FIELD, "mock");
         metadata.put(CompoundProcessor.ON_FAILURE_PROCESSOR_TAG_FIELD, "processor_0");
         metadata.put(CompoundProcessor.ON_FAILURE_MESSAGE_FIELD, "processor failed");
+        metadata.put(CompoundProcessor.ON_FAILURE_PIPELINE_FIELD, "_id");
         assertVerboseResult(
             simulateDocumentVerboseResult.getProcessorResults().get(1),
             pipeline.getId(),


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `7.17`:
 - [Fix pipeline id not present in ingest metadata inside on_failure block (#89632)](https://github.com/elastic/elasticsearch/pull/89632)

<!--- Backport version: 8.9.3 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)