### PR TITLE
Add support for Git submodules to GitInfo

### DIFF
--- a/build-conventions/src/main/java/org/elasticsearch/gradle/internal/conventions/info/GitInfo.java
+++ b/build-conventions/src/main/java/org/elasticsearch/gradle/internal/conventions/info/GitInfo.java
@@ -75,18 +75,25 @@ public class GitInfo {
                 head = dotGit.resolve("HEAD");
                 gitDir = dotGit;
             } else {
-                // this is a git worktree, follow the pointer to the repository
-                final Path workTree = Paths.get(readFirstLine(dotGit).substring("gitdir:".length()).trim());
-                if (Files.exists(workTree) == false) {
-                    return new GitInfo("unknown", "unknown");
-                }
-                head = workTree.resolve("HEAD");
-                final Path commonDir = Paths.get(readFirstLine(workTree.resolve("commondir")));
-                if (commonDir.isAbsolute()) {
-                    gitDir = commonDir;
+                // this is a git worktree or submodule, follow the pointer to the repository
+                final Path reference = Paths.get(readFirstLine(dotGit).substring("gitdir:".length()).trim());
+                if (reference.getParent().endsWith("modules")) {
+                    // this is a git submodule so follow the reference to the git repo
+                    gitDir = rootDir.toPath().resolve(reference);
+                    head = gitDir.resolve("HEAD");
                 } else {
-                    // this is the common case
-                    gitDir = workTree.resolve(commonDir);
+                    // this is a worktree so resolve the root repo directory
+                    if (Files.exists(reference) == false) {
+                        return new GitInfo("unknown", "unknown");
+                    }
+                    head = reference.resolve("HEAD");
+                    final Path commonDir = Paths.get(readFirstLine(reference.resolve("commondir")));
+                    if (commonDir.isAbsolute()) {
+                        gitDir = commonDir;
+                    } else {
+                        // this is the common case
+                        gitDir = reference.resolve(commonDir);
+                    }
                 }
             }
             final String ref = readFirstLine(head);


### PR DESCRIPTION
Extend our `GitInfo` class to [support Git submodules](https://git-scm.com/docs/git-submodule). This will allow the build to work in cases where the Elasticsearch repository is included in another as a Git submodule in addition to current scenarios such as a standalone checkout or a Git worktree.