### PR TITLE
[Draft] Potential ECS mappings in Elasticsearch

### DIFF
--- a/x-pack/plugin/core/src/main/resources/ecs-template.yml
+++ b/x-pack/plugin/core/src/main/resources/ecs-template.yml
@@ -30,15 +30,17 @@ template:
         ignore_malformed: false
 
       # The data stream properties are required in any index following the data stream naming scheme
-      # Discuss: If there is an ecs: enabled flag it can also be used in indices so this would have to be skipped
-      # These fields might not even be needed in this template
-      data_stream.type:
-        type: constant_keyword
-        #value: logs
-      data_stream.dataset:
-        type: constant_keyword
-      data_stream.namespace:
-        type: constant_keyword
+      # But not all data streams or indices which use ECS are part of the data stream naming scheme.
+      # As an example logstash-* and *beats-*. Because of this, the data_stream.* fields are not part
+      # of this template. It is expected that these are set by another template for the data stream
+      # naming scheme.
+      #data_stream.type:
+      #  type: constant_keyword
+      #  #value: logs
+      #data_stream.dataset:
+      #  type: constant_keyword
+      #data_stream.namespace:
+      #  type: constant_keyword
 
 
     # To ensure no empty mappings are in an index, everything except the properties above are mapped as dynamic templates

--- a/x-pack/plugin/core/src/main/resources/ecs-template.yml
+++ b/x-pack/plugin/core/src/main/resources/ecs-template.yml
@@ -142,7 +142,7 @@ template:
           match_mapping_type: object
           match: location
           runtime:
-            type: geopoint
+            type: geo_point
 
       # Match location fields to geopoint
       - match_location:

--- a/x-pack/plugin/core/src/main/resources/ecs-template.yml
+++ b/x-pack/plugin/core/src/main/resources/ecs-template.yml
@@ -108,8 +108,7 @@ template:
       # Any message field except the top level one is matched as text but not indexed
       # TODO: Does this work? Which one has priority?
       - match_message:
-          match_mapping_type: string
-          match: message
+          path_match: message
           runtime:
             type: match_only_text
 

--- a/x-pack/plugin/core/src/main/resources/ecs-template.yml
+++ b/x-pack/plugin/core/src/main/resources/ecs-template.yml
@@ -1,5 +1,8 @@
 ---
+# This template should serve as a foundation for indices and data streams using ECS.
+
 template:
+
   settings:
     # This is a made up setting which does not exist today. The idea is that
     # any field that shows up after the first 1000 fields is kept in source
@@ -65,36 +68,53 @@ template:
           match_mapping_type: string
           runtime:
             type: keyword
-            # Do we need this for runtime?
-            ignore_above: 1024
+            # As it is a runtime field, ignore_above is not needed
+            #ignore_above: 1024
 
-      # Matching all long fields
+      # Matching all ECS core long fields
       # This matches the following fields: bytes, packets, port, duration, severity, pid
-      # No path matching is needed as it is assumed these fields are already in the json doc a long
-      # Elasticsearch would do this mapping automatically but it is specified here for documentation purpose
-      # DISCUSS: If a field "7" as string comes in, will it still be mapped correctly?
-      - long_as_long:
-          match_mapping_type: long
+      # Path matching on these fields is needed as otherwise if the first value of the field would be for example
+      # "7" as a string in JSON, it would have the wrong default mapping. As it is a runtime field, the mapping could
+      # still be adjusted but not something we should have the user do by default.
+      # TODO: if path_match would be an array, this could be defined much nicer and more compact
+      - bytes:
+          path_match: bytes
+          runtime:
+            type: long
+      - packets:
+          path_match: packets
+          runtime:
+            type: long
+      - port:
+          path_match: port
+          runtime:
+            type: long
+      - duration:
+          path_match: duration
+          runtime:
+            type: long
+      - severity:
+          path_match: severity
+          runtime:
+            type: long
+      - pid:
+          path_match: pid
           runtime:
             type: long
 
-      # Matching all long and double fields
+      # Matching all float and double fields
       # This matches the following fields: event.risk_score
-      # No path matching is needed as it is assumed these fields are already in the json doc a float or double
-      # Elasticsearch would do this mapping automatically but it is specified here for documentation purpose
-      # DISCUSS: If a field "7.7" as string comes in, will it still be mapped correctly?
-      - double_as_double:
-          match_mapping_type: double
+      # Why path_match is used, see discussion for long. For runtime fields, it does not matter if it is a float or a double
+      - risk_score:
+          match_path: risk_score
           runtime:
             type: double
 
       # Matching all boolean fields
       # This matches the following fields: exists
-      # No path matching is needed as it is assumed these fields are already in the json doc as boolean
-      # Elasticsearch would do this mapping automatically but it is specified here for documentation purpose
-      # DISCUSS: If a field "true" as string comes in, will it still be mapped correctly?
-      - strings_as_boolean:
-          match_mapping_type: boolean
+      # Why path_match is used, see discussion for long.
+      - exists:
+          match_path: exists
           runtime:
             type: boolean
 
@@ -115,16 +135,13 @@ template:
             type: match_only_text
 
       # Match all ip fields to ip
-      - match_ip:
-          match_mapping_type: string
-          # DISCUSS: If match could be an array, these mappings could be written much more compact
+      # This matches the following fields: ip, network.forwarded_ip
+      - ip:
           match: ip
           runtime:
             type: ip
 
-      # Match all forwarded_ip fields to ip. This is for network.forwarded_ip
-      - match_ip:
-          match_mapping_type: string
+      - forwarded_ip:
           match: forwarded_ip
           runtime:
             type: ip
@@ -139,15 +156,15 @@ template:
             type: flattened
 
       # Match location fields to geopoint
-      - match_location:
+      - location:
           # TODO: What is the correct matching type here?
           match_mapping_type: object
           match: location
           runtime:
             type: geo_point
 
-      # Match location fields to geopoint
-      - match_location:
+      # Match name fields to text_keyword
+      - match_name:
           # TODO: What is the correct matching type here?
           match_mapping_type: string
           match: name

--- a/x-pack/plugin/core/src/main/resources/ecs-template.yml
+++ b/x-pack/plugin/core/src/main/resources/ecs-template.yml
@@ -1,0 +1,225 @@
+---
+template:
+  settings:
+    # This is a made up setting which does not exist today. The idea is that
+    # any field that shows up after the first 1000 fields is kept in source
+    # but does not show up as runtime for index field
+    #index.mapping.total_fields.soft_limit: 1000
+
+    # Ignores any malformed data. Data will still be persisted in _source
+    index.mapping.ignore_malformed": true
+
+  mappings:
+
+    # Any field that is discovered is mapped as a runtime field
+    dynamic: runtime
+
+    # DISCUSS: What are the pros / cons of having this enabled?
+    date_detection: false
+
+    ### All the properties which are set in each template
+    properties:
+
+      # This ensures all subobjects are flattened and prevents and object / keyword conflicts
+      # As subobject is set to false, no objects like host, error or similar are mapped.
+      subobject: false
+
+      # @timestamp is the only field that MUST exist.
+      "@timestamp":
+        type: date
+        ignore_malformed: false
+
+      # The data stream properties are required in any index following the data stream naming scheme
+      # Discuss: If there is an ecs: enabled flag it can also be used in indices so this would have to be skipped
+      # These fields might not even be needed in this template
+      data_stream.type:
+        type: constant_keyword
+        #value: logs
+      data_stream.dataset:
+        type: constant_keyword
+      data_stream.namespace:
+        type: constant_keyword
+
+
+    # To ensure no empty mappings are in an index, everything except the properties above are mapped as dynamic templates
+    # The dynamic mappings here are a best effort to map ECS core fields: https://github.com/elastic/ecs/blob/8.4/generated/csv/fields.csv
+    # As most fields are keyword, these will be automatically be matched correctly. Only core fields were taken into account.
+    # DISCUSS: Should @timestamp and data_stream.* also be moved under dynamic templates?
+    dynamic_templates:
+
+      ### Index mappings
+
+      # Message field is always index
+      - message:
+          path_match: message
+          mapping:
+            type: match_only_text
+
+      ### Runtime mappings
+
+      # Matching all string fields by default to keyword
+      # TODO: Does first / last match win in the list?
+      - strings_as_keyword:
+          match_mapping_type: string
+          runtime:
+            type: keyword
+            # Do we need this for runtime?
+            ignore_above: 1024
+
+      # Matching all long fields
+      # This matches the following fields: bytes, packets, port, duration, severity, pid
+      # No path matching is needed as it is assumed these fields are already in the json doc a long
+      # Elasticsearch would do this mapping automatically but it is specified here for documentation purpose
+      # DISCUSS: If a field "7" as string comes in, will it still be mapped correctly?
+      - long_as_long:
+          match_mapping_type: long
+          runtime:
+            type: long
+
+      # Matching all long and double fields
+      # This matches the following fields: event.risk_score
+      # No path matching is needed as it is assumed these fields are already in the json doc a float or double
+      # Elasticsearch would do this mapping automatically but it is specified here for documentation purpose
+      # DISCUSS: If a field "7.7" as string comes in, will it still be mapped correctly?
+      - float_as_double:
+          match_mapping_type: float
+          runtime:
+            type: double
+      - double_as_double:
+          match_mapping_type: double
+          runtime:
+            type: double
+
+      # Matching all boolean fields
+      # This matches the following fields: exists
+      # No path matching is needed as it is assumed these fields are already in the json doc as boolean
+      # Elasticsearch would do this mapping automatically but it is specified here for documentation purpose
+      # DISCUSS: If a field "true" as string comes in, will it still be mapped correctly?
+      - strings_as_boolean:
+          match_mapping_type: boolean
+          runtime:
+            type: boolean
+
+      # Matching all string fields by default to keyword
+      # TODO: Does first / last match win in the list?
+      - strings_as_keyword:
+          match_mapping_type: string
+          runtime:
+            type: keyword
+            # Do we need this for runtime?
+            ignore_above: 1024
+
+      # Any message field except the top level one is matched as text but not indexed
+      # TODO: Does this work? Which one has priority?
+      - match_message:
+          match_mapping_type: string
+          match: message
+          runtime:
+            type: match_only_text
+
+      # Match all ip fields to ip
+      - match_ip:
+          match_mapping_type: string
+          # DISCUSS: If match could be an array, these mappings could be written much more compact
+          match: ip
+          runtime:
+            type: ip
+
+      # Match all forwarded_ip fields to ip. This is for network.forwarded_ip
+      - match_ip:
+          match_mapping_type: string
+          match: forwarded_ip
+          runtime:
+            type: ip
+
+      # Match all labels fields. Flattened type instead of keyword is used to prevent too many fields to be created.
+      # DISCUSS: Is this the right choice?
+      - match_labels:
+          match_mapping_type: string
+          # TODO: Does this also match the top level labels?
+          match: labels
+          runtime:
+            type: flattened
+
+      # Match location fields to geopoint
+      - match_location:
+          # TODO: What is the correct matching type here?
+          match_mapping_type: object
+          match: location
+          runtime:
+            type: geopoint
+
+      # Match location fields to geopoint
+      - match_location:
+          # TODO: What is the correct matching type here?
+          match_mapping_type: string
+          match: name
+          runtime:
+            # TODO: This is a field type that does not exist today. What ECS does is that for all name fields, it
+            # has a subfield .text to also do text indexing
+            type: text_keyword
+
+      # Match strings fields to wildcard
+      # This matches the following fields: strings
+      # An example field is registry.data.strings
+      - match_strings:
+          # TODO: What is the correct matching type here?
+          match_mapping_type: string
+          match: strings
+          runtime:
+            type: wildcard
+
+      # Match created fields to date
+      # This matches the following fields: event.created
+      - match_created:
+          match_mapping_type: string
+          match: created
+          runtime:
+            type: date
+
+      # Match strings fields to wildcard
+      # This matches the following fields: event.ingested
+      - match_ingested:
+          match_mapping_type: string
+          match: ingested
+          runtime:
+            type: date
+
+# Keyword fields to discuss if should be indexed or not. Proposed rule for discussion. Quorum needs to be reached
+      # for a field to be indexed. Reason is going from runtime to index is easy, otherway around could be a breaking
+      # It should also be discussed if logs-*, metrics-* and traces-* have exact same default.
+      # change.
+      # This is list is initially copied from https://github.com/elastic/elasticsearch/pull/88181/files#diff-0fba05a9236d9aa3866db886f0b6c24759be01a775023e1663b8f44f91951e62
+      # - log.level
+      # - log.logger
+      # - trace.id
+      # - span.id
+      # - transaction.id
+      # - service.name
+      # - service.version
+      # - service.environment
+      # - process.id
+      # - process.thread.name
+      # - error.type
+      # - error.message
+      # - event.dataset
+      # - cloud.provider
+      # - cloud.availability_zone
+      # - cloud.region
+      # - cloud.provider
+      # - host.hostname
+      # - host.name
+      # - container.id
+      # - container.name
+      # - orchestrator.namespace
+      # - orchestrator.id
+      # - orchestrator.resource.id
+      # - orchestrator.resource.name
+
+
+
+# Meta information blocks
+_meta:
+  description: default mappings for the logs index template installed by x-pack
+  managed: true
+version: 2

--- a/x-pack/plugin/core/src/main/resources/ecs-template.yml
+++ b/x-pack/plugin/core/src/main/resources/ecs-template.yml
@@ -1,6 +1,5 @@
 ---
-# This template should serve as a foundation for indices and data streams using ECS.
-
+# This template serves as a foundation for indices and data streams using ECS.
 template:
 
   settings:
@@ -48,28 +47,35 @@ template:
 
     # To ensure no empty mappings are in an index, everything except the properties above are mapped as dynamic templates
     # The dynamic mappings here are a best effort to map ECS core fields: https://github.com/elastic/ecs/blob/8.4/generated/csv/fields.csv
-    # As most fields are keyword, these will be automatically be matched correctly. Only core fields were taken into account.
-    # DISCUSS: Should @timestamp and data_stream.* also be moved under dynamic templates?
+    # As most fields are keyword, these will be automatically be matched correctly. Only ECS core fields were taken into account.
     dynamic_templates:
 
       ### Index mappings
 
       # Message field is always index
-      - message:
+      # DISCUSS: Should only the top level message field always be indexed?
+      - match_message:
           path_match: message
           mapping:
             type: match_only_text
 
       ### Runtime mappings
 
+      # Set the ECS version
+      - match_ecs.version:
+          path_match: ecs.version
+          # DISCUSS: In ECS this is still a keyword field
+          type: version
+          # TODO: Can this somehow be set?
+          #value: ${xpack.stack.template.version}
+
       # Matching all string fields by default to keyword
+      # As it is a runtime field, ignore_above is not needed
       # TODO: Does first / last match win in the list?
       - strings_as_keyword:
           match_mapping_type: string
           runtime:
             type: keyword
-            # As it is a runtime field, ignore_above is not needed
-            #ignore_above: 1024
 
       # Matching all ECS core long fields
       # This matches the following fields: bytes, packets, port, duration, severity, pid
@@ -77,27 +83,27 @@ template:
       # "7" as a string in JSON, it would have the wrong default mapping. As it is a runtime field, the mapping could
       # still be adjusted but not something we should have the user do by default.
       # TODO: if path_match would be an array, this could be defined much nicer and more compact
-      - bytes:
+      - match_bytes:
           path_match: bytes
           runtime:
             type: long
-      - packets:
+      - match_packets:
           path_match: packets
           runtime:
             type: long
-      - port:
+      - match_port:
           path_match: port
           runtime:
             type: long
-      - duration:
+      - match_duration:
           path_match: duration
           runtime:
             type: long
-      - severity:
+      - match_severity:
           path_match: severity
           runtime:
             type: long
-      - pid:
+      - match_pid:
           path_match: pid
           runtime:
             type: long
@@ -105,7 +111,7 @@ template:
       # Matching all float and double fields
       # This matches the following fields: event.risk_score
       # Why path_match is used, see discussion for long. For runtime fields, it does not matter if it is a float or a double
-      - risk_score:
+      - match_risk_score:
           match_path: risk_score
           runtime:
             type: double
@@ -113,35 +119,18 @@ template:
       # Matching all boolean fields
       # This matches the following fields: exists
       # Why path_match is used, see discussion for long.
-      - exists:
+      - match_exists:
           match_path: exists
           runtime:
             type: boolean
 
-      # Matching all string fields by default to keyword
-      # TODO: Does first / last match win in the list?
-      - strings_as_keyword:
-          match_mapping_type: string
-          runtime:
-            type: keyword
-            # Do we need this for runtime?
-            ignore_above: 1024
-
-      # Any message field except the top level one is matched as text but not indexed
-      # TODO: Does this work? Which one has priority?
-      - match_message:
-          path_match: message
-          runtime:
-            type: match_only_text
-
       # Match all ip fields to ip
       # This matches the following fields: ip, network.forwarded_ip
-      - ip:
+      - match_ip:
           match: ip
           runtime:
             type: ip
-
-      - forwarded_ip:
+      - match_forwarded_ip:
           match: forwarded_ip
           runtime:
             type: ip
@@ -156,17 +145,14 @@ template:
             type: flattened
 
       # Match location fields to geopoint
-      - location:
-          # TODO: What is the correct matching type here?
-          match_mapping_type: object
+      - match_location:
+          # TODO: What happens if this is a string and not an object?
           match: location
           runtime:
             type: geo_point
 
       # Match name fields to text_keyword
       - match_name:
-          # TODO: What is the correct matching type here?
-          match_mapping_type: string
           match: name
           runtime:
             # TODO: This is a field type that does not exist today. What ECS does is that for all name fields, it
@@ -189,7 +175,6 @@ template:
           match: created
           runtime:
             type: date
-
       - match_ingested:
           match: ingested
           runtime:
@@ -230,7 +215,7 @@ template:
 
 # Meta information blocks
 _meta:
-  description: Base mappings for indices and data streams using ECS
+  description: Base mappings for indices and data streams using core ECS
   managed: true
 
 # TODO: What should the version here be? Put in brackets for now to make it valid yaml

--- a/x-pack/plugin/core/src/main/resources/ecs-template.yml
+++ b/x-pack/plugin/core/src/main/resources/ecs-template.yml
@@ -215,6 +215,8 @@ template:
 
 # Meta information blocks
 _meta:
-  description: default mappings for the logs index template installed by x-pack
+  description: Base mappings for indices and data streams using ECS
   managed: true
-version: 2
+
+# TODO: What should the version here be? Put in brackets for now to make it valid yaml
+version: "${xpack.stack.template.version}"

--- a/x-pack/plugin/core/src/main/resources/ecs-template.yml
+++ b/x-pack/plugin/core/src/main/resources/ecs-template.yml
@@ -81,10 +81,6 @@ template:
       # No path matching is needed as it is assumed these fields are already in the json doc a float or double
       # Elasticsearch would do this mapping automatically but it is specified here for documentation purpose
       # DISCUSS: If a field "7.7" as string comes in, will it still be mapped correctly?
-      - float_as_double:
-          match_mapping_type: float
-          runtime:
-            type: double
       - double_as_double:
           match_mapping_type: double
           runtime:

--- a/x-pack/plugin/core/src/main/resources/ecs-template.yml
+++ b/x-pack/plugin/core/src/main/resources/ecs-template.yml
@@ -183,23 +183,19 @@ template:
           runtime:
             type: wildcard
 
-      # Match created fields to date
-      # This matches the following fields: event.created
+      # Match date fields to date
+      # This matches the following fields: event.created, event.ingested
       - match_created:
-          match_mapping_type: string
           match: created
           runtime:
             type: date
 
-      # Match strings fields to wildcard
-      # This matches the following fields: event.ingested
       - match_ingested:
-          match_mapping_type: string
           match: ingested
           runtime:
             type: date
 
-# Keyword fields to discuss if should be indexed or not. Proposed rule for discussion. Quorum needs to be reached
+      # Keyword fields to discuss if should be indexed or not. Proposed rule for discussion. Quorum needs to be reached
       # for a field to be indexed. Reason is going from runtime to index is easy, otherway around could be a breaking
       # It should also be discussed if logs-*, metrics-* and traces-* have exact same default.
       # change.


### PR DESCRIPTION
This PR is intended to have a conversation about potential mappings for ECS in Elasticsearch. It might not ever get merged into the ES code based but allows to keep a history of the conversation and changes. The core idea of the PR are as following:

* Map all core ECS fields through dynamic mappings on the paths. This will make sure only the fields that are contained in each index will be part of the mapping itself
* All fields except `@timestamp` are runtime fields by default and not indexed
* long and double values are matched with a path to ensure also string values are mapped correct. For example `"7"` in JSON needs to be mapped to long.
* `subobject: false` is set to flatten all the documents that are ingested. This ensures no conflicts can happen on fields like `host` and `host.name`


## Implementation

Even though this PR contains the potential template that could be used for ECS it does not contain any code around the implementation. Implementation could happen in multipel phases:

1. ECS component template for each ECS version exists in Elasticsearch that can easily be used
2. ECS config flag in data stream / mapping to use ECS template. This heavily simplifies the usage

## Discussions

* ECS versions: Should this template be versioned? The current suggestion is yes to prevent any unexpected changes to users. At the same time not versioning it would have the benefits of users get the benefits automatically when upgrading Elasticsearch.
* Fields indexed by default: Which fields should be indexed by default?
* How do we handle keyword_text multifields?
* What about extended ECS fields?