### PR TITLE
[8.4] [DOCs] Orders transform API parameters in alphabetical order. (#89746)

### DIFF
--- a/docs/reference/transform/apis/get-transform.asciidoc
+++ b/docs/reference/transform/apis/get-transform.asciidoc
@@ -49,6 +49,12 @@ include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=transform-id-wildcard]
 (Optional, Boolean)
 include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=allow-no-match-transforms1]
 
+`exclude_generated`::
+(Optional, Boolean)
+Excludes fields that were automatically added when creating the transform.
+This allows the configuration to be in an acceptable format to be retrieved
+and then added to another cluster. Default is false.
+
 `from`::
 (Optional, integer)
 include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=from-transforms]
@@ -57,11 +63,7 @@ include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=from-transforms]
 (Optional, integer)
 include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=size-transforms]
 
-`exclude_generated`::
-(Optional, Boolean)
-Excludes fields that were automatically added when creating the transform.
-This allows the configuration to be in an acceptable format to be retrieved
-and then added to another cluster. Default is false.
+
 
 [[get-transform-response]]
 == {api-response-body-title}

--- a/docs/reference/transform/apis/preview-transform.asciidoc
+++ b/docs/reference/transform/apis/preview-transform.asciidoc
@@ -138,7 +138,6 @@ include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=pivot]
 .Properties of `pivot`
 [%collapsible%open]
 ====
-
 `aggregations` or `aggs`:::
 (Required, object)
 include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=pivot-aggs]
@@ -183,7 +182,6 @@ include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=source-transforms]
 .Properties of `source`
 [%collapsible%open]
 ====
-
 `index`:::
 (Required, string or array)
 include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=source-index-transforms]
@@ -215,7 +213,6 @@ include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=sync-time]
 .Properties of `time`
 [%collapsible%open]
 =====
-
 `delay`::::
 (Optional, <<time-units, time units>>)
 include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=sync-time-delay]
@@ -236,18 +233,18 @@ include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=transform-settings]
 .Properties of `settings`
 [%collapsible%open]
 ====
-`dates_as_epoch_millis`:::
-(Optional, boolean)
-include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=transform-settings-dates-as-epoch-milli]
-`docs_per_second`:::
-(Optional, float)
-include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=transform-settings-docs-per-second]
 `align_checkpoints`:::
 (Optional, boolean)
 include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=transform-settings-align-checkpoints]
+`dates_as_epoch_millis`:::
+(Optional, boolean)
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=transform-settings-dates-as-epoch-milli]
 `deduce_mappings`:::
 (Optional, boolean)
 include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=transform-settings-deduce-mappings]
+`docs_per_second`:::
+(Optional, float)
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=transform-settings-docs-per-second]
 `max_page_search_size`:::
 (Optional, integer)
 include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=transform-settings-max-page-search-size]
@@ -258,10 +255,6 @@ include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=transform-settings-max
 [[preview-transform-response]]
 == {api-response-body-title}
 
-`preview`::
-(array) An array of documents. In particular, they are the JSON representation
-of the documents that would be created in the destination index by the
-{transform}.
 
 //Begin generated_dest_index
 `generated_dest_index`::
@@ -281,6 +274,12 @@ of the documents that would be created in the destination index by the
 (object) The <<index-modules-settings,index settings>> for the destination index.
 ====
 //End generated_dest_index
+
+`preview`::
+(array) An array of documents. In particular, they are the JSON representation
+of the documents that would be created in the destination index by the
+{transform}.
+
 
 == {api-examples-title}
 

--- a/docs/reference/transform/apis/put-transform.asciidoc
+++ b/docs/reference/transform/apis/put-transform.asciidoc
@@ -90,6 +90,7 @@ behavior may be desired if the source index does not exist until after the
 Period to wait for a response. If no response is received before the timeout
 expires, the request fails and returns an error. Defaults to `30s`.
 
+
 [role="child_attributes"]
 [[put-transform-request-body]]
 == {api-request-body-title}
@@ -200,18 +201,18 @@ include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=transform-settings]
 .Properties of `settings`
 [%collapsible%open]
 ====
-`dates_as_epoch_millis`:::
-(Optional, boolean)
-include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=transform-settings-dates-as-epoch-milli]
-`docs_per_second`:::
-(Optional, float)
-include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=transform-settings-docs-per-second]
 `align_checkpoints`:::
 (Optional, boolean)
 include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=transform-settings-align-checkpoints]
+`dates_as_epoch_millis`:::
+(Optional, boolean)
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=transform-settings-dates-as-epoch-milli]
 `deduce_mappings`:::
 (Optional, boolean)
 include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=transform-settings-deduce-mappings]
+`docs_per_second`:::
+(Optional, float)
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=transform-settings-docs-per-second]
 `max_page_search_size`:::
 (Optional, integer)
 include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=transform-settings-max-page-search-size]
@@ -261,7 +262,6 @@ include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=sync-time]
 .Properties of `time`
 [%collapsible%open]
 =====
-
 `delay`::::
 (Optional, <<time-units, time units>>)
 include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=sync-time-delay]

--- a/docs/reference/transform/apis/stop-transform.asciidoc
+++ b/docs/reference/transform/apis/stop-transform.asciidoc
@@ -40,8 +40,8 @@ comma-separated list or a wildcard expression. To stop all {transforms}, use
 == {api-query-parms-title}
 
 `allow_no_match`::
-(Optional, Boolean)
-include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=allow-no-match-transforms2]
+ (Optional, Boolean)
+ include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=allow-no-match-transforms2]
 
 `force`::
   (Optional, Boolean) Set to `true` to stop a failed {transform} or to 

--- a/docs/reference/transform/apis/update-transform.asciidoc
+++ b/docs/reference/transform/apis/update-transform.asciidoc
@@ -142,18 +142,18 @@ include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=transform-settings]
 .Properties of `settings`
 [%collapsible%open]
 ====
-`dates_as_epoch_millis`:::
-(Optional, boolean)
-include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=transform-settings-dates-as-epoch-milli]
-`docs_per_second`:::
-(Optional, float)
-include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=transform-settings-docs-per-second]
 `align_checkpoints`:::
 (Optional, boolean)
 include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=transform-settings-align-checkpoints]
+`dates_as_epoch_millis`:::
+(Optional, boolean)
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=transform-settings-dates-as-epoch-milli]
 `deduce_mappings`:::
 (Optional, boolean)
 include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=transform-settings-deduce-mappings]
+`docs_per_second`:::
+(Optional, float)
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=transform-settings-docs-per-second]
 `max_page_search_size`:::
 (Optional, integer)
 include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=transform-settings-max-page-search-size]


### PR DESCRIPTION
Backports the following commits to 8.4:
 - [DOCs] Orders transform API parameters in alphabetical order. (#89746)