### PR TITLE
[7.17] Increase assertAllCancellableTasksAreCancelled timeout (#89744)

### DIFF
--- a/qa/smoke-test-http/src/javaRestTest/java/org/elasticsearch/http/RestClusterInfoActionCancellationIT.java
+++ b/qa/smoke-test-http/src/javaRestTest/java/org/elasticsearch/http/RestClusterInfoActionCancellationIT.java
@@ -26,6 +26,7 @@ import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.test.ESIntegTestCase;
+import org.elasticsearch.test.junit.annotations.TestLogging;
 
 import java.util.EnumSet;
 import java.util.concurrent.CancellationException;
@@ -38,6 +39,7 @@ import static org.elasticsearch.test.TaskAssertions.awaitTaskWithPrefix;
 import static org.hamcrest.core.IsEqual.equalTo;
 
 @ESIntegTestCase.ClusterScope(scope = ESIntegTestCase.Scope.TEST, numDataNodes = 0, numClientNodes = 0)
+@TestLogging(value = "org.elasticsearch.tasks.TaskManager:TRACE,org.elasticsearch.test.TaskAssertions:TRACE", reason = "debugging")
 public class RestClusterInfoActionCancellationIT extends HttpSmokeTestCase {
 
     public void testGetMappingsCancellation() throws Exception {

--- a/test/framework/src/main/java/org/elasticsearch/test/TaskAssertions.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/TaskAssertions.java
@@ -17,6 +17,7 @@ import org.elasticsearch.tasks.TaskManager;
 import org.elasticsearch.transport.TransportService;
 
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
 import static junit.framework.TestCase.assertTrue;
@@ -70,7 +71,7 @@ public class TaskAssertions {
                 }
             }
             assertTrue("found no cancellable tasks", foundTask);
-        });
+        }, 30, TimeUnit.SECONDS);
     }
 
     public static void assertAllTasksHaveFinished(String actionPrefix) throws Exception {


### PR DESCRIPTION
Backports the following commits to 7.17:
 - Increase assertAllCancellableTasksAreCancelled timeout (#89744)