### PR TITLE
[Transform] allow unattended transforms that don't validate on start

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/common/notifications/AbstractAuditor.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/common/notifications/AbstractAuditor.java
@@ -100,6 +100,10 @@ public abstract class AbstractAuditor<T extends AbstractAuditMessage> {
         this.putTemplateInProgress = new AtomicBoolean();
     }
 
+    public void audit(Level level, String resourceId, String message) {
+        indexDoc(messageFactory.newMessage(resourceId, message, level, new Date(), nodeName));
+    }
+
     public void info(String resourceId, String message) {
         indexDoc(messageFactory.newMessage(resourceId, message, Level.INFO, new Date(), nodeName));
     }

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/transform/preview_transforms.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/transform/preview_transforms.yml
@@ -601,3 +601,20 @@ setup:
               }
             }
           }
+
+---
+"Test preview of unattended transform":
+  - do:
+      transform.preview_transform:
+        body: >
+          {
+            "source": { "index": "airline-data" },
+            "dest": { "index": "dest-airline-data-by-airline-unattended" },
+            "pivot": {
+              "group_by": { "airline": {"terms": {"field": "airline"}}},
+              "aggs": {"avg_response": {"avg": {"field": "responsetime"}}}
+            },
+            "settings": {
+              "unattended": true
+            }
+          }

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/transform/transforms_unattended.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/transform/transforms_unattended.yml
@@ -1,0 +1,74 @@
+setup:
+  - do:
+      cluster.put_settings:
+        body: >
+          {
+            "persistent": {
+              "logger.org.elasticsearch.xpack.transform.action": "DEBUG"
+            }
+          }
+
+
+---
+teardown:
+  - do:
+      transform.stop_transform:
+        wait_for_checkpoint: false
+        transform_id: "transform-unattended"
+        timeout: "10m"
+        wait_for_completion: true
+  - do:
+      transform.delete_transform:
+        transform_id: "transform-unattended"
+  - do:
+      cluster.put_settings:
+        body: >
+          {
+            "persistent": {
+              "logger.org.elasticsearch.xpack.transform.action": "INFO"
+            }
+          }
+
+---
+"Test unattended put and start":
+  - do:
+      transform.put_transform:
+        transform_id: "transform-unattended"
+        defer_validation: true
+        body: >
+          {
+            "source": { "index": "airline-data" },
+            "dest": { "index": "dest-airline-data-by-airline-start-stop" },
+            "pivot": {
+              "group_by": { "airline": {"terms": {"field": "airline"}}},
+              "aggs": {"avg_response": {"avg": {"field": "responsetime"}}}
+            },
+            "settings": {
+              "unattended": true
+            }
+          }
+  - do:
+      transform.start_transform:
+        transform_id: "transform-unattended"
+
+
+---
+"Test unattended put and start wildcard":
+  - do:
+      transform.put_transform:
+        transform_id: "transform-unattended"
+        body: >
+          {
+            "source": { "index": "airline-data*" },
+            "dest": { "index": "dest-airline-data-by-airline-start-stop" },
+            "pivot": {
+              "group_by": { "airline": {"terms": {"field": "airline"}}},
+              "aggs": {"avg_response": {"avg": {"field": "responsetime"}}}
+            },
+            "settings": {
+              "unattended": true
+            }
+          }
+  - do:
+      transform.start_transform:
+        transform_id: "transform-unattended"

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/TransportStartTransformAction.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/TransportStartTransformAction.java
@@ -53,6 +53,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
 
+import static org.elasticsearch.core.Strings.format;
 import static org.elasticsearch.xpack.core.transform.TransformMessages.CANNOT_START_FAILED_TRANSFORM;
 
 public class TransportStartTransformAction extends TransportMasterNodeAction<StartTransformAction.Request, StartTransformAction.Response> {
@@ -176,44 +177,30 @@ public class TransportStartTransformAction extends TransportMasterNodeAction<Sta
             }
         }, listener::onFailure);
 
-        // <2> If the destination index exists, start the task, otherwise deduce our mappings for the destination index and create it
-        ActionListener<ValidateTransformAction.Response> validationListener = ActionListener.wrap(validationResponse -> {
-            final String destinationIndex = transformConfigHolder.get().getDestination().getIndex();
-            String[] dest = indexNameExpressionResolver.concreteIndexNames(state, IndicesOptions.lenientExpandOpen(), destinationIndex);
-
-            if (dest.length == 0) {
-                createDestinationIndex(transformConfigHolder.get(), validationResponse.getDestIndexMappings(), ActionListener.wrap(r -> {
-                    String message = Boolean.FALSE.equals(transformConfigHolder.get().getSettings().getDeduceMappings())
-                        ? "Created destination index [" + destinationIndex + "]."
-                        : "Created destination index [" + destinationIndex + "] with deduced mappings.";
-                    auditor.info(request.getId(), message);
-                    createOrGetIndexListener.onResponse(r);
-                }, createOrGetIndexListener::onFailure));
-            } else {
-                auditor.info(request.getId(), "Using existing destination index [" + destinationIndex + "].");
-                ClientHelper.executeAsyncWithOrigin(
-                    client.threadPool().getThreadContext(),
-                    ClientHelper.TRANSFORM_ORIGIN,
-                    client.admin().indices().prepareStats(dest).clear().setDocs(true).request(),
-                    ActionListener.<IndicesStatsResponse>wrap(r -> {
-                        long docTotal = r.getTotal().docs.getCount();
-                        if (docTotal > 0L) {
-                            auditor.warning(
-                                request.getId(),
-                                "Non-empty destination index [" + destinationIndex + "]. " + "Contains [" + docTotal + "] total documents."
-                            );
-                        }
-                        createOrGetIndexListener.onResponse(true);
-                    }, e -> {
-                        String msg = "Unable to determine destination index stats, error: " + e.getMessage();
-                        logger.warn(msg, e);
-                        auditor.warning(request.getId(), msg);
-                        createOrGetIndexListener.onResponse(true);
-                    }),
-                    client.admin().indices()::stats
+        // <3> If the destination index exists, start the task, otherwise deduce our mappings for the destination index and create it
+        ActionListener<ValidateTransformAction.Response> validationListener = ActionListener.wrap(
+            validationResponse -> {
+                createDestinationIndex(
+                    state,
+                    transformConfigHolder.get(),
+                    validationResponse.getDestIndexMappings(),
+                    createOrGetIndexListener
                 );
+            },
+            e -> {
+                if (Boolean.TRUE.equals(transformConfigHolder.get().getSettings().getUnattended())) {
+                    logger.debug(
+                        () -> format(
+                            "[%s] Skip dest index creation as this is an unattended transform",
+                            transformConfigHolder.get().getId()
+                        )
+                    );
+                    createOrGetIndexListener.onResponse(true);
+                    return;
+                }
+                listener.onFailure(e);
             }
-        }, listener::onFailure);
+        );
 
         // <2> run transform validations
         ActionListener<TransformConfig> getTransformListener = ActionListener.wrap(config -> {
@@ -255,17 +242,57 @@ public class TransportStartTransformAction extends TransportMasterNodeAction<Sta
     }
 
     private void createDestinationIndex(
-        final TransformConfig config,
-        final Map<String, String> mappings,
-        final ActionListener<Boolean> listener
+        ClusterState state,
+        TransformConfig config,
+        Map<String, String> destIndexMappings,
+        ActionListener<Boolean> listener
     ) {
+        if (Boolean.TRUE.equals(config.getSettings().getUnattended())) {
+            logger.debug(() -> format("[%s] Skip dest index creation as this is an unattended transform", config.getId()));
+            listener.onResponse(true);
+            return;
+        }
 
-        TransformDestIndexSettings generatedDestIndexSettings = TransformIndex.createTransformDestIndexSettings(
-            mappings,
-            config.getId(),
-            Clock.systemUTC()
-        );
-        TransformIndex.createDestinationIndex(client, config, generatedDestIndexSettings, listener);
+        final String destinationIndex = config.getDestination().getIndex();
+        String[] dest = indexNameExpressionResolver.concreteIndexNames(state, IndicesOptions.lenientExpandOpen(), destinationIndex);
+
+        if (dest.length == 0) {
+            TransformDestIndexSettings generatedDestIndexSettings = TransformIndex.createTransformDestIndexSettings(
+                destIndexMappings,
+                config.getId(),
+                Clock.systemUTC()
+            );
+            TransformIndex.createDestinationIndex(client, config, generatedDestIndexSettings, ActionListener.wrap(r -> {
+                String message = Boolean.FALSE.equals(config.getSettings().getDeduceMappings())
+                    ? "Created destination index [" + destinationIndex + "]."
+                    : "Created destination index [" + destinationIndex + "] with deduced mappings.";
+                auditor.info(config.getId(), message);
+                listener.onResponse(r);
+            }, listener::onFailure));
+        } else {
+            auditor.info(config.getId(), "Using existing destination index [" + destinationIndex + "].");
+            ClientHelper.executeAsyncWithOrigin(
+                client.threadPool().getThreadContext(),
+                ClientHelper.TRANSFORM_ORIGIN,
+                client.admin().indices().prepareStats(dest).clear().setDocs(true).request(),
+                ActionListener.<IndicesStatsResponse>wrap(r -> {
+                    long docTotal = r.getTotal().docs.getCount();
+                    if (docTotal > 0L) {
+                        auditor.warning(
+                            config.getId(),
+                            "Non-empty destination index [" + destinationIndex + "]. " + "Contains [" + docTotal + "] total documents."
+                        );
+                    }
+                    listener.onResponse(true);
+                }, e -> {
+                    String msg = "Unable to determine destination index stats, error: " + e.getMessage();
+                    logger.warn(msg, e);
+                    auditor.warning(config.getId(), msg);
+                    listener.onResponse(true);
+                }),
+                client.admin().indices()::stats
+            );
+        }
     }
 
     @Override

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/TransformContext.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/TransformContext.java
@@ -31,7 +31,7 @@ class TransformContext {
     private final Listener taskListener;
     private volatile int numFailureRetries = Transform.DEFAULT_FAILURE_RETRIES;
     private final AtomicInteger failureCount;
-    // Keeps track of the last failure that occured, used for throttling logs and audit
+    // Keeps track of the last failure that occurred, used for throttling logs and audit
     private final AtomicReference<String> lastFailure = new AtomicReference<>();
     private final AtomicInteger statePersistenceFailureCount = new AtomicInteger();
     private volatile Instant changesLastDetectedAt;

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/TransformFailureHandler.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/TransformFailureHandler.java
@@ -7,6 +7,7 @@
 
 package org.elasticsearch.xpack.transform.transforms;
 
+import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.elasticsearch.ElasticsearchException;
@@ -21,6 +22,8 @@ import org.elasticsearch.xpack.transform.utils.ExceptionRootCauseFinder;
 import java.util.Optional;
 
 import static org.elasticsearch.core.Strings.format;
+import static org.elasticsearch.xpack.core.common.notifications.Level.INFO;
+import static org.elasticsearch.xpack.core.common.notifications.Level.WARNING;
 
 /**
  * Handles all failures a transform can run into when searching, indexing as well as internal
@@ -240,8 +243,9 @@ class TransformFailureHandler {
                 failureCount,
                 numFailureRetries
             );
-            logger.warn(() -> "[" + transformId + "] " + retryMessage);
-            auditor.warning(transformId, retryMessage);
+
+            logger.log(unattended ? Level.INFO : Level.WARN, () -> "[" + transformId + "] " + retryMessage);
+            auditor.audit(unattended ? INFO : WARNING, transformId, retryMessage);
         }
     }
 

--- a/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/notifications/MockTransformAuditor.java
+++ b/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/notifications/MockTransformAuditor.java
@@ -74,19 +74,23 @@ public class MockTransformAuditor extends TransformAuditor {
         expectations.clear();
     }
 
+    public void audit(Level level, String resourceId, String message) {
+        doAudit(level, resourceId, message);
+    }
+
     @Override
     public void info(String resourceId, String message) {
-        audit(Level.INFO, resourceId, message);
+        doAudit(Level.INFO, resourceId, message);
     }
 
     @Override
     public void warning(String resourceId, String message) {
-        audit(Level.WARNING, resourceId, message);
+        doAudit(Level.WARNING, resourceId, message);
     }
 
     @Override
     public void error(String resourceId, String message) {
-        audit(Level.ERROR, resourceId, message);
+        doAudit(Level.ERROR, resourceId, message);
     }
 
     public void assertAllExpectationsMatched() {
@@ -205,7 +209,7 @@ public class MockTransformAuditor extends TransformAuditor {
         }
     }
 
-    private void audit(Level level, String resourceId, String message) {
+    private void doAudit(Level level, String resourceId, String message) {
         logger.info("AUDIT: {}", new TransformAuditMessage(resourceId, message, level, new Date(), MOCK_NODE_NAME));
 
         for (AuditExpectation expectation : expectations) {

--- a/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/TransformIndexerStateTests.java
+++ b/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/TransformIndexerStateTests.java
@@ -247,6 +247,11 @@ public class TransformIndexerStateTests extends ESTestCase {
             persistedState = state;
             listener.onResponse(null);
         }
+
+        @Override
+        void validate(ActionListener<Void> listener) {
+            listener.onResponse(null);
+        }
     }
 
     @Before

--- a/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/TransformIndexerTests.java
+++ b/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/TransformIndexerTests.java
@@ -269,6 +269,11 @@ public class TransformIndexerTests extends ESTestCase {
         void persistState(TransformState state, ActionListener<Void> listener) {
             listener.onResponse(null);
         }
+
+        @Override
+        void validate(ActionListener<Void> listener) {
+            listener.onResponse(null);
+        }
     }
 
     @Before


### PR DESCRIPTION
allow to start a transform if validation fails and let it start working once validation passes

relates #89212

how it works:
> `_start` validates the transform (it doesn't have the `defer_validation` parameter). That's a problem for unattended, because it might be, that not everything is setup yet. That's why the PR changes the behavior: If - and only if - the transform is unattended it allows it to start even if validation fails. It periodically retries validation according to our retry logic (with exponential backoff, reduced loggig, etc.) and starts working once validation passed.


(this is a follow up PR, therefore marking this as non-issue to avoid a duplicate in the changelog)