### PR TITLE
[7.17] Skip update of breaking changes and migration guide for patch releases (#89737)

### DIFF
--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/release/GenerateReleaseNotesTask.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/release/GenerateReleaseNotesTask.java
@@ -123,19 +123,22 @@ public class GenerateReleaseNotesTask extends DefaultTask {
             changelogsByVersion.getOrDefault(qualifiedVersion, Set.of())
         );
 
-        LOGGER.info("Generating release highlights...");
-        ReleaseHighlightsGenerator.update(
-            this.releaseHighlightsTemplate.get().getAsFile(),
-            this.releaseHighlightsFile.get().getAsFile(),
-            entries
-        );
+        // Only update breaking changes and migration guide for new minors
+        if (qualifiedVersion.revision() == 0) {
+            LOGGER.info("Generating release highlights...");
+            ReleaseHighlightsGenerator.update(
+                this.releaseHighlightsTemplate.get().getAsFile(),
+                this.releaseHighlightsFile.get().getAsFile(),
+                entries
+            );
 
-        LOGGER.info("Generating breaking changes / deprecations notes...");
-        BreakingChangesGenerator.update(
-            this.breakingChangesTemplate.get().getAsFile(),
-            this.breakingChangesMigrationFile.get().getAsFile(),
-            entries
-        );
+            LOGGER.info("Generating breaking changes / deprecations notes...");
+            BreakingChangesGenerator.update(
+                this.breakingChangesTemplate.get().getAsFile(),
+                this.breakingChangesMigrationFile.get().getAsFile(),
+                entries
+            );
+        }
     }
 
     /**


### PR DESCRIPTION
Backports the following commits to 7.17:
 - Skip update of breaking changes and migration guide for patch releases (#89737)