### PR TITLE
Autoscaling after clone fix

### DIFF
--- a/docs/changelog/89768.yaml
+++ b/docs/changelog/89768.yaml
@@ -2,4 +2,5 @@ pr: 89768
 summary: Autoscaling after clone fix
 area: Autoscaling
 type: bug
-issues: []
+issues:
+ - 89758

--- a/docs/changelog/89768.yaml
+++ b/docs/changelog/89768.yaml
@@ -1,0 +1,5 @@
+pr: 89768
+summary: Autoscaling after clone fix
+area: Autoscaling
+type: bug
+issues: []

--- a/x-pack/plugin/autoscaling/src/internalClusterTest/java/org/elasticsearch/xpack/autoscaling/storage/ReactiveStorageIT.java
+++ b/x-pack/plugin/autoscaling/src/internalClusterTest/java/org/elasticsearch/xpack/autoscaling/storage/ReactiveStorageIT.java
@@ -383,6 +383,13 @@ public class ReactiveStorageIT extends AutoscalingStorageIntegTestCase {
         setTotalSpace(dataNode1Name, tooLittleSpaceForShrink + 1);
         assertAcked(client().admin().cluster().prepareReroute());
         ensureGreen();
+
+        client().admin().indices().prepareDelete(indexName).get();
+        response = capacity();
+        assertThat(
+            response.results().get(policyName).requiredCapacity().total().storage(),
+            equalTo(response.results().get(policyName).currentCapacity().total().storage())
+        );
     }
 
     public void testScaleDuringSplitOrClone() throws Exception {
@@ -489,6 +496,13 @@ public class ReactiveStorageIT extends AutoscalingStorageIntegTestCase {
         setTotalSpace(dataNode1Name, requiredSpaceForClone);
         assertAcked(client().admin().cluster().prepareReroute());
         ensureGreen();
+
+        client().admin().indices().prepareDelete(indexName).get();
+        response = capacity();
+        assertThat(
+            response.results().get(policyName).requiredCapacity().total().storage().getBytes(),
+            equalTo(requiredSpaceForClone + enoughSpace)
+        );
     }
 
     /**


### PR DESCRIPTION
Autoscaling could start failing after a clone or split, if the source of
the clone/split is deleted.

Closes #89758