### PR TITLE
Fix module and package names for stable plugin api

### DIFF
--- a/libs/plugin-analysis-api/src/main/java/module-info.java
+++ b/libs/plugin-analysis-api/src/main/java/module-info.java
@@ -6,7 +6,7 @@
  * Side Public License, v 1.
  */
 
-module org.elasticsearch.analysis.plugin.api {
+module org.elasticsearch.plugin.analysis.api {
     requires org.apache.lucene.core;
     requires org.elasticsearch.plugin.api;
 

--- a/libs/plugin-api/src/main/java/org/elasticsearch/plugin/api/NamedComponent.java
+++ b/libs/plugin-api/src/main/java/org/elasticsearch/plugin/api/NamedComponent.java
@@ -20,7 +20,7 @@ import java.lang.annotation.Target;
 @Target({ ElementType.TYPE })
 public @interface NamedComponent {
     /**
-     * A name used for registration and lookup
+     * The name used for registration and lookup
      * @return a name
      */
     String name();

--- a/libs/plugin-api/src/main/java/org/elasticsearch/plugin/api/package-info.java
+++ b/libs/plugin-api/src/main/java/org/elasticsearch/plugin/api/package-info.java
@@ -12,12 +12,12 @@
  * <ul>
  *      <li> The root package is org.elasticsearch.plugin</li>
  *      <li> Specialised API jars have their name following the root package.
- *           i.e. org.elasticsearch.analysis
+ *           i.e. org.elasticsearch.plugin.analysis
  *      </li>
  *      <li> Interfaces and annotations used by plugin developers are in `api` package
- *           i.e org.elasticsearch.analysis.api or org.elasticsearch.api
+ *           i.e org.elasticsearch.plugin.analysis.api or org.elasticsearch.plugin.api
  *      <li> packages which are not meant to be used by plugin developers should not be subpackages of api
- *           i.e org.elasticsearch.analysis.internal
+ *           i.e org.elasticsearch.plugin.analysis.internal
  *      </li>
  * </ul>
  */


### PR DESCRIPTION
the convention for packages and module names is:
org.elasticsearch.plugin[.analysis].api

module-info.java and package-info.java were using incorrect names
and not following the convention
relates https://github.com/elastic/elasticsearch/issues/88980