### PR TITLE
[8.4] Autoscaling after clone fix (#89768)

### DIFF
--- a/docs/changelog/89768.yaml
+++ b/docs/changelog/89768.yaml
@@ -1,0 +1,6 @@
+pr: 89768
+summary: Autoscaling after clone fix
+area: Autoscaling
+type: bug
+issues:
+ - 89758

--- a/x-pack/plugin/autoscaling/src/internalClusterTest/java/org/elasticsearch/xpack/autoscaling/storage/ReactiveStorageIT.java
+++ b/x-pack/plugin/autoscaling/src/internalClusterTest/java/org/elasticsearch/xpack/autoscaling/storage/ReactiveStorageIT.java
@@ -382,6 +382,13 @@ public class ReactiveStorageIT extends AutoscalingStorageIntegTestCase {
         setTotalSpace(dataNode1Name, tooLittleSpaceForShrink + 1);
         assertAcked(client().admin().cluster().prepareReroute());
         ensureGreen();
+
+        client().admin().indices().prepareDelete(indexName).get();
+        response = capacity();
+        assertThat(
+            response.results().get(policyName).requiredCapacity().total().storage(),
+            equalTo(response.results().get(policyName).currentCapacity().total().storage())
+        );
     }
 
     @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/88478")
@@ -481,6 +488,13 @@ public class ReactiveStorageIT extends AutoscalingStorageIntegTestCase {
         setTotalSpace(dataNode1Name, requiredSpaceForClone);
         assertAcked(client().admin().cluster().prepareReroute());
         ensureGreen();
+
+        client().admin().indices().prepareDelete(indexName).get();
+        response = capacity();
+        assertThat(
+            response.results().get(policyName).requiredCapacity().total().storage().getBytes(),
+            equalTo(requiredSpaceForClone + enoughSpace)
+        );
     }
 
     /**


### PR DESCRIPTION
Backports the following commits to 8.4:
 - Autoscaling after clone fix (#89768)