### PR TITLE
[Test] More robust comparison for concurrent profile update

### DIFF
--- a/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/xpack/security/profile/ProfileDomainIntegTests.java
+++ b/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/xpack/security/profile/ProfileDomainIntegTests.java
@@ -302,9 +302,9 @@ public class ProfileDomainIntegTests extends AbstractProfileIntegTestCase {
                     final Authentication authentication = assembleAuthentication(username, randomRealmRef());
                     final ProfileService profileService = getInstanceFromRandomNode(ProfileService.class);
                     final PlainActionFuture<Profile> future = new PlainActionFuture<>();
-                    profileService.activateProfile(authentication, future);
                     readyLatch.countDown();
                     startLatch.await();
+                    profileService.activateProfile(authentication, future);
                     try {
                         final String uid = future.actionGet().uid();
                         logger.info("created profile [{}] for authentication [{}]", uid, authentication);
@@ -373,9 +373,9 @@ public class ProfileDomainIntegTests extends AbstractProfileIntegTestCase {
             threads[i] = new Thread(() -> {
                 try {
                     final PlainActionFuture<Profile> future = new PlainActionFuture<>();
-                    profileService.activateProfile(updatedAuthentication, future);
                     readyLatch.countDown();
                     startLatch.await();
+                    profileService.activateProfile(updatedAuthentication, future);
                     final Profile updatedProfile = future.actionGet();
                     assertThat(updatedProfile.uid(), equalTo(originalProfile.uid()));
                     assertThat(updatedProfile.user().roles(), contains("foo"));
@@ -393,14 +393,18 @@ public class ProfileDomainIntegTests extends AbstractProfileIntegTestCase {
             for (Thread thread : threads) {
                 thread.join();
             }
+            assertThat(updatedProfiles, not(emptyIterable()));
+            // Find the most recent version of the updated profile document using the seqNo which is monotonically increasing
+            final Profile updatedProfile = updatedProfiles.stream()
+                .max(Comparator.comparingLong(p -> p.versionControl().seqNo()))
+                .orElseThrow();
+            // Update again, this time it should simply skip due to grace period of 30 seconds
+            final PlainActionFuture<Profile> future = new PlainActionFuture<>();
+            profileService.activateProfile(updatedAuthentication, future);
+            assertThat(future.actionGet(), equalTo(updatedProfile));
+        } else {
+            fail("Not all threads are ready after waiting");
         }
-
-        assertThat(updatedProfiles, not(emptyIterable()));
-        final Profile updatedProfile = updatedProfiles.stream().max(Comparator.comparingLong(Profile::lastSynchronized)).orElseThrow();
-        // Update again, this time it should simply skip due to grace period of 30 seconds
-        final PlainActionFuture<Profile> future = new PlainActionFuture<>();
-        profileService.activateProfile(updatedAuthentication, future);
-        assertThat(future.actionGet(), equalTo(updatedProfile));
     }
 
     public void testDifferentiator() {


### PR DESCRIPTION
Using seqNo instead of last_synchronized for finding the most recent
updated profile document. SeqNo is guarnateed to be monotonically
increasing.

Some minor adjustments to the test setup.

Resolves: #89776
