### PR TITLE
[8.4] Extend the date rounding logic to be conditional  (#89693)

### DIFF
--- a/docs/changelog/89693.yaml
+++ b/docs/changelog/89693.yaml
@@ -1,0 +1,7 @@
+pr: 89693
+summary: Extend the date rounding logic to be conditional
+area: Infra/Core
+type: bug
+issues:
+ - 89096
+ - 58986

--- a/server/src/main/java/org/elasticsearch/common/time/DateFormatters.java
+++ b/server/src/main/java/org/elasticsearch/common/time/DateFormatters.java
@@ -574,7 +574,7 @@ public class DateFormatters {
 
     /*
      * Returns a basic formatter for a full date as four digit weekyear, two
-     * digit week of weekyear, and one digit day of week (xxxx'W'wwe).
+     * digit week of weekyear, and one digit day of week (YYYY'W'wwe).
      */
     private static final DateFormatter STRICT_BASIC_WEEK_DATE = new JavaDateFormatter(
         "strict_basic_week_date",
@@ -584,7 +584,7 @@ public class DateFormatters {
 
     /*
      * Returns a basic formatter that combines a basic weekyear date and time
-     * without millis, separated by a 'T' (xxxx'W'wwe'T'HHmmssX).
+     * without millis, separated by a 'T' (YYYY'W'wwe'T'HHmmssX).
      */
     private static final DateFormatter STRICT_BASIC_WEEK_DATE_TIME_NO_MILLIS = new JavaDateFormatter(
         "strict_basic_week_date_time_no_millis",
@@ -616,7 +616,7 @@ public class DateFormatters {
 
     /*
      * Returns a basic formatter that combines a basic weekyear date and time,
-     * separated by a 'T' (xxxx'W'wwe'T'HHmmss.SSSX).
+     * separated by a 'T' (YYYY'W'wwe'T'HHmmss.SSSX).
      */
     private static final DateFormatter STRICT_BASIC_WEEK_DATE_TIME = new JavaDateFormatter(
         "strict_basic_week_date_time",
@@ -1080,13 +1080,13 @@ public class DateFormatters {
 
     /*
      * Returns a formatter for a full date as four digit weekyear, two digit
-     * week of weekyear, and one digit day of week (xxxx-'W'ww-e).
+     * week of weekyear, and one digit day of week (YYYY-'W'ww-e).
      */
     private static final DateFormatter STRICT_WEEK_DATE = new JavaDateFormatter("strict_week_date", ISO_WEEK_DATE);
 
     /*
      * Returns a formatter that combines a full weekyear date and time without millis,
-     * separated by a 'T' (xxxx-'W'ww-e'T'HH:mm:ssZZ).
+     * separated by a 'T' (YYYY-'W'ww-e'T'HH:mm:ssZZ).
      */
     private static final DateFormatter STRICT_WEEK_DATE_TIME_NO_MILLIS = new JavaDateFormatter(
         "strict_week_date_time_no_millis",
@@ -1109,7 +1109,7 @@ public class DateFormatters {
 
     /*
      * Returns a formatter that combines a full weekyear date and time,
-     * separated by a 'T' (xxxx-'W'ww-e'T'HH:mm:ss.SSSZZ).
+     * separated by a 'T' (YYYY-'W'ww-e'T'HH:mm:ss.SSSZZ).
      */
     private static final DateFormatter STRICT_WEEK_DATE_TIME = new JavaDateFormatter(
         "strict_week_date_time",
@@ -1153,13 +1153,13 @@ public class DateFormatters {
 
     /*
      * Returns a formatter for a four digit weekyear and two digit week of
-     * weekyear. (xxxx-'W'ww)
+     * weekyear. (YYYY-'W'ww)
      */
     private static final DateFormatter STRICT_WEEKYEAR_WEEK = new JavaDateFormatter("strict_weekyear_week", STRICT_WEEKYEAR_WEEK_FORMATTER);
 
     /*
      * Returns a formatter for a four digit weekyear, two digit week of
-     * weekyear, and one digit day of week. (xxxx-'W'ww-e)
+     * weekyear, and one digit day of week. (YYYY-'W'ww-e)
      */
     private static final DateFormatter STRICT_WEEKYEAR_WEEK_DAY = new JavaDateFormatter(
         "strict_weekyear_week_day",
@@ -1693,7 +1693,7 @@ public class DateFormatters {
 
     /*
      * Returns a formatter that combines a full weekyear date and time,
-     * separated by a 'T' (xxxx-'W'ww-e'T'HH:mm:ss.SSSZZ).
+     * separated by a 'T' (YYYY-'W'ww-e'T'HH:mm:ss.SSSZZ).
      */
     private static final DateFormatter WEEK_DATE_TIME = new JavaDateFormatter(
         "week_date_time",
@@ -1718,7 +1718,7 @@ public class DateFormatters {
 
     /*
      * Returns a formatter that combines a full weekyear date and time,
-     * separated by a 'T' (xxxx-'W'ww-e'T'HH:mm:ssZZ).
+     * separated by a 'T' (YYYY-'W'ww-e'T'HH:mm:ssZZ).
      */
     private static final DateFormatter WEEK_DATE_TIME_NO_MILLIS = new JavaDateFormatter(
         "week_date_time_no_millis",
@@ -1741,7 +1741,7 @@ public class DateFormatters {
 
     /*
      * Returns a basic formatter that combines a basic weekyear date and time,
-     * separated by a 'T' (xxxx'W'wwe'T'HHmmss.SSSX).
+     * separated by a 'T' (YYYY'W'wwe'T'HHmmss.SSSX).
      */
     private static final DateFormatter BASIC_WEEK_DATE_TIME = new JavaDateFormatter(
         "basic_week_date_time",
@@ -1763,7 +1763,7 @@ public class DateFormatters {
 
     /*
      * Returns a basic formatter that combines a basic weekyear date and time,
-     * separated by a 'T' (xxxx'W'wwe'T'HHmmssX).
+     * separated by a 'T' (YYYY'W'wwe'T'HHmmssX).
      */
     private static final DateFormatter BASIC_WEEK_DATE_TIME_NO_MILLIS = new JavaDateFormatter(
         "basic_week_date_time_no_millis",
@@ -1906,13 +1906,13 @@ public class DateFormatters {
 
     /*
      * Returns a formatter for a full date as four digit weekyear, two digit
-     * week of weekyear, and one digit day of week (xxxx-'W'ww-e).
+     * week of weekyear, and one digit day of week (YYYY-'W'ww-e).
      */
     private static final DateFormatter WEEK_DATE = new JavaDateFormatter("week_date", ISO_WEEK_DATE, WEEK_DATE_FORMATTER);
 
     /*
      * Returns a formatter for a four digit weekyear and two digit week of
-     * weekyear. (xxxx-'W'ww)
+     * weekyear. (YYYY-'W'ww)
      */
     private static final DateFormatter WEEKYEAR_WEEK = new JavaDateFormatter(
         "weekyear_week",
@@ -1926,7 +1926,7 @@ public class DateFormatters {
 
     /*
      * Returns a formatter for a four digit weekyear, two digit week of
-     * weekyear, and one digit day of week. (xxxx-'W'ww-e)
+     * weekyear, and one digit day of week. (YYYY-'W'ww-e)
      */
     private static final DateFormatter WEEKYEAR_WEEK_DAY = new JavaDateFormatter(
         "weekyear_week_day",

--- a/server/src/main/java/org/elasticsearch/common/time/EpochTime.java
+++ b/server/src/main/java/org/elasticsearch/common/time/EpochTime.java
@@ -252,7 +252,7 @@ class EpochTime {
     static final DateFormatter SECONDS_FORMATTER = new JavaDateFormatter(
         "epoch_second",
         SECONDS_FORMATTER1,
-        builder -> builder.parseDefaulting(ChronoField.NANO_OF_SECOND, 999_999_999L),
+        (builder, parser) -> builder.parseDefaulting(ChronoField.NANO_OF_SECOND, 999_999_999L),
         SECONDS_FORMATTER1,
         SECONDS_FORMATTER2
     );
@@ -260,7 +260,7 @@ class EpochTime {
     static final DateFormatter MILLIS_FORMATTER = new JavaDateFormatter(
         "epoch_millis",
         MILLISECONDS_FORMATTER1,
-        builder -> builder.parseDefaulting(EpochTime.NANOS_OF_MILLI, 999_999L),
+        (builder, parser) -> builder.parseDefaulting(EpochTime.NANOS_OF_MILLI, 999_999L),
         MILLISECONDS_FORMATTER1,
         MILLISECONDS_FORMATTER2
     );

--- a/server/src/test/java/org/elasticsearch/common/time/JavaDateMathParserTests.java
+++ b/server/src/test/java/org/elasticsearch/common/time/JavaDateMathParserTests.java
@@ -85,6 +85,38 @@ public class JavaDateMathParserTests extends ESTestCase {
         assertDateEquals(gotMillis, "297276785531", "297276785531");
     }
 
+    public void testWeekBasedDate() {
+        DateFormatter formatter = DateFormatter.forPattern("strict_basic_week_date");// YYYY'W'wwe
+        // first week of 2022 is starting on Monday 3rd Jan
+        assertDateMathEquals(formatter.toDateMathParser(), "2022W0101", "2022-01-03T23:59:59.999Z", 0, true, ZoneOffset.UTC);
+
+        // defaulting missing day of week
+        formatter = DateFormatter.forPattern("YYYY'W'ww[e]");// YYYY'W'wwe
+        // second week of 2022 is starting on Monday 10th Jan
+        assertDateMathEquals(formatter.toDateMathParser(), "2022W02", "2022-01-10T23:59:59.999Z", 0, true, ZoneOffset.UTC);
+    }
+
+    public void testDayOfYear() {
+        DateFormatter formatter = DateFormatter.forPattern("yyyy-DDD'T'HH:mm:ss.SSS");
+        assertDateMathEquals(formatter.toDateMathParser(), "2022-104T14:08:30.293", "2022-04-14T14:08:30.293", 0, true, ZoneOffset.UTC);
+    }
+
+    public void testAMPM() {
+        DateFormatter formatter = DateFormatter.forPattern("MM/dd/yyyy hh:mm a"); // h clock-hour-of-am-pm (1-12)
+        assertDateMathEquals(formatter.toDateMathParser(), "04/30/2020 12:48 AM", "2020-04-30T00:48:59.999Z", 0, true, ZoneOffset.UTC);
+
+        formatter = DateFormatter.forPattern("MM/dd/yyyy KK:mm a"); // K hour-of-am-pm (0-11)
+        assertDateMathEquals(formatter.toDateMathParser(), "04/30/2020 00:48 AM", "2020-04-30T00:48:59.999Z", 0, true, ZoneOffset.UTC);
+    }
+
+    public void testAMPMWithTimeMissing() {
+        DateFormatter formatter = DateFormatter.forPattern("MM/dd/yyyy[ hh:mm a]"); // h clock-hour-of-am-pm (1-12)
+        assertDateMathEquals(formatter.toDateMathParser(), "04/30/2020", "2020-04-30T23:59:59.999Z", 0, true, ZoneOffset.UTC);
+
+        formatter = DateFormatter.forPattern("MM/dd/yyyy[ KK:mm a]"); // K hour-of-am-pm (0-11)
+        assertDateMathEquals(formatter.toDateMathParser(), "04/30/2020", "2020-04-30T23:59:59.999Z", 0, true, ZoneOffset.UTC);
+    }
+
     public void testWeekDates() {
         DateFormatter formatter = DateFormatter.forPattern("YYYY-ww");
         assertDateMathEquals(formatter.toDateMathParser(), "2016-01", "2016-01-04T23:59:59.999Z", 0, true, ZoneOffset.UTC);


### PR DESCRIPTION
Date rounding logic should take into account the fields that will be
parsed be a parser. If a parser has a DayOfYear field, the rounding logic
should not try to default DayOfMonth as it will conflict with DayOfYear

However the DateTimeFormatter does not have a public method to return
information of fields that will be parsed. The hacky workaround is
to rely on toString() implementation that will return a field info when
it was defined with textual pattern.

This commits introduced conditional logic for DayOfMonth, MonthOfYear, ClockHourOfAMPM and HourOfAmPM

closes #89096
closes #58986
backports #89693

<!--
Thank you for your interest in and contributing to Elasticsearch! There
are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your
attention.
-->

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/elasticsearch/blob/main/CONTRIBUTING.md)?
- If submitting code, have you built your formula locally prior to submission with `gradle check`?
- If submitting code, is your pull request against main? Unless there is a good reason otherwise, we prefer pull requests against main and will backport as needed.
- If submitting code, have you checked that your submission is for an [OS and architecture that we support](https://www.elastic.co/support/matrix#show_os)?
- If you are submitting this code for a class then read our [policy](https://github.com/elastic/elasticsearch/blob/main/CONTRIBUTING.md#contributing-as-part-of-a-class) for that.
