### PR TITLE
Example for Nested field type exists query

### DIFF
--- a/docs/reference/query-dsl/exists-query.asciidoc
+++ b/docs/reference/query-dsl/exists-query.asciidoc
@@ -67,3 +67,29 @@ GET /_search
   }
 }
 ----
+
+The following search returns documents that are missing an indexed value for
+a <<nested, nested>> type `user`.
+
+[source,console]
+----
+GET /_search
+{
+  "query": {
+        "bool": {
+            "must_not": [
+                {
+                    "nested": {
+                        "path": "user",
+                        "query": {
+                            "exists": {
+                                "field": "user"
+                            }
+                        }
+                    }
+                }
+            ]
+        }
+    }
+}
+----


### PR DESCRIPTION
Changes include a solution for working with a Nested field type when searching for documents missing the nested field type field as seen here https://stackoverflow.com/a/41461613/2741245

<!--
Thank you for your interest in and contributing to Elasticsearch! There
are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your
attention.
-->

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/elasticsearch/blob/main/CONTRIBUTING.md)?
- If submitting code, have you built your formula locally prior to submission with `gradle check`?
- If submitting code, is your pull request against main? Unless there is a good reason otherwise, we prefer pull requests against main and will backport as needed.
- If submitting code, have you checked that your submission is for an [OS and architecture that we support](https://www.elastic.co/support/matrix#show_os)?
- If you are submitting this code for a class then read our [policy](https://github.com/elastic/elasticsearch/blob/main/CONTRIBUTING.md#contributing-as-part-of-a-class) for that.
