### PR TITLE
Fix assertion for single-node cluster and periodic warning w/ seed hosts

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/coordination/Coordinator.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/Coordinator.java
@@ -1093,7 +1093,9 @@ public class Coordinator extends AbstractLifecycleComponent implements ClusterSt
                         + coordinationState.get().getLastCommittedConfiguration();
 
                 if (coordinationState.get().getLastAcceptedState().nodes().size() == 1) {
-                    assert singleNodeClusterChecker != null;
+                    final boolean seedHostsExist = DISCOVERY_SEED_HOSTS_SETTING.exists(settings);
+                    assert singleNodeClusterChecker != null || seedHostsExist == false
+                        : "should have a single-node cluster checker when seed hosts are configured";
                 }
             } else if (mode == Mode.FOLLOWER) {
                 assert coordinationState.get().electionWon() == false : getLocalNode() + " is FOLLOWER so electionWon() should be false";


### PR DESCRIPTION
The test CoordinatorTests.testDoesNotPerformElectionWhenRestartingFollower
failed for a 2 nodes cluster after a follower node is restarted (the last
accepted cluster state has 1 node but no periodic checker, which looks OK
to me).

This commit changes the assertion to check the existence of the periodic
checker only when seed hosts have been configured.

Closes #89543