### PR TITLE
[7.17] [Docs] Indicate that CCR does not auto-follow existing indices, only newly created ones (#89498)

### DIFF
--- a/docs/reference/ccr/apis/auto-follow/put-auto-follow-pattern.asciidoc
+++ b/docs/reference/ccr/apis/auto-follow/put-auto-follow-pattern.asciidoc
@@ -58,7 +58,10 @@ This API creates a new named collection of
 <<ccr-auto-follow,auto-follow patterns>> against the remote cluster
 specified in the request body. Newly created indices on the remote cluster
 matching any of the specified patterns will be automatically configured as follower
-indices. Additionally, this API can be used to update existing
+indices. Indices on the remote cluster that were created before the auto-follow
+pattern is created won't be auto-followed even if they match the pattern.
+
+This API can also be used to update existing
 <<ccr-auto-follow,auto-follow patterns>>. Note that follower indices that were configured automatically
 before updating an auto-follow pattern will remain unchanged even if they don't match against
 the new patterns.

--- a/docs/reference/ccr/getting-started.asciidoc
+++ b/docs/reference/ccr/getting-started.asciidoc
@@ -99,7 +99,7 @@ example, `cluster.es.eastus2.staging.azure.foundit.no:9400` or
 [%collapsible%open]
 .API example
 ====
-You can also use the <<cluster-update-settings,cluster update settings API>> to 
+You can also use the <<cluster-update-settings,cluster update settings API>> to
 add a remote cluster:
 
 [source,console]
@@ -200,8 +200,8 @@ image::images/ccr-follower-index.png["The Cross-Cluster Replication page in {kib
 [%collapsible%open]
 .API example
 ====
-You can also use the <<ccr-put-follow,create follower API>> to create follower 
-indices. When you create a follower index, you must reference the remote cluster 
+You can also use the <<ccr-put-follow,create follower API>> to create follower
+indices. When you create a follower index, you must reference the remote cluster
 and the leader index that you created in the remote cluster.
 
 When initiating the follower request, the response returns before the
@@ -255,7 +255,9 @@ POST /server-metrics-follower/_ccr/unfollow
 You use <<ccr-auto-follow,auto-follow patterns>> to automatically create new
 followers for rolling time series indices. Whenever the name of a new index on
 the remote cluster matches the auto-follow pattern, a corresponding follower
-index is added to the local cluster.
+index is added to the local cluster. Note that only indices created on the
+remote cluster after the auto-follow pattern is created will be auto-followed:
+existing indices on the remote cluster are ignored even if they match the pattern.
 
 An auto-follow pattern specifies the remote cluster you want to replicate from,
 and one or more index patterns that specify the rolling time series indices you


### PR DESCRIPTION
Backports the following commits to 7.17:
 - [Docs] Indicate that CCR does not auto-follow existing indices, only newly created ones (#89498)