### PR TITLE
Synthetic _source: support histogram field

### DIFF
--- a/docs/changelog/89833.yaml
+++ b/docs/changelog/89833.yaml
@@ -1,0 +1,5 @@
+pr: 89833
+summary: "Synthetic _source: support histogram field"
+area: TSDB
+type: enhancement
+issues: []

--- a/docs/reference/mapping/fields/synthetic-source.asciidoc
+++ b/docs/reference/mapping/fields/synthetic-source.asciidoc
@@ -35,6 +35,7 @@ types:
 ** <<numeric-synthetic-source,`float`>>
 ** <<geo-point-synthetic-source,`geo_point`>>
 ** <<numeric-synthetic-source,`half_float`>>
+** <<histogram-synthetic-source,`histogram`>>
 ** <<numeric-synthetic-source,`integer`>>
 ** <<ip-synthetic-source,`ip`>>
 ** <<keyword-synthetic-source,`keyword`>>

--- a/docs/reference/mapping/types/histogram.asciidoc
+++ b/docs/reference/mapping/types/histogram.asciidoc
@@ -85,6 +85,12 @@ The histogram field is "algorithm agnostic" and does not store data specific to 
 means the field can technically be aggregated with either algorithm, in practice the user should chose one algorithm and
 index data in that manner (e.g. centroids for T-Digest or intervals for HDRHistogram) to ensure best accuracy.
 
+[[histogram-synthetic-source]]
+==== Synthetic source preview:[]
+`histogram` fields support <<synthetic-source,synthetic `_source`>> in their
+default configuration. Synthetic `_source` cannot be used together with
+<<ignore-malformed,`ignore_malformed`>> or <<copy-to,`copy_to`>>.
+
 [[histogram-ex]]
 ==== Examples
 

--- a/test/framework/src/main/java/org/elasticsearch/index/mapper/MapperTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/index/mapper/MapperTestCase.java
@@ -929,6 +929,11 @@ public abstract class MapperTestCase extends MapperServiceTestCase {
             try (DirectoryReader reader = DirectoryReader.open(directory)) {
                 LeafReader leafReader = getOnlyLeafReader(reader);
                 SourceLoader.SyntheticFieldLoader fieldLoader = mapper.mapping().getRoot().getMapper("field").syntheticFieldLoader();
+                /*
+                 * null means "there are no values for this field, don't call me".
+                 * Empty fields are common enough that we need to make sure this
+                 * optimization kicks in.
+                 */
                 assertThat(fieldLoader.docValuesLoader(leafReader, new int[] { 0 }), nullValue());
             }
         }

--- a/test/framework/src/main/java/org/elasticsearch/index/mapper/MapperTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/index/mapper/MapperTestCase.java
@@ -73,7 +73,6 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.matchesPattern;
 import static org.hamcrest.Matchers.nullValue;
-import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 

--- a/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/mapper/HistogramFieldMapper.java
+++ b/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/mapper/HistogramFieldMapper.java
@@ -475,7 +475,7 @@ public class HistogramFieldMapper extends FieldMapper {
 
             @Override
             public DocValuesLoader docValuesLoader(LeafReader leafReader, int[] docIdsInLeaf) throws IOException {
-                BinaryDocValues docValues = DocValues.getBinary(leafReader, fieldType().name());
+                BinaryDocValues docValues = leafReader.getBinaryDocValues(fieldType().name());
                 if (docValues == null) {
                     // No values in this leaf
                     binaryValue = null;

--- a/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/mapper/HistogramFieldMapper.java
+++ b/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/mapper/HistogramFieldMapper.java
@@ -38,7 +38,6 @@ import org.elasticsearch.index.mapper.TextSearchInfo;
 import org.elasticsearch.index.mapper.TimeSeriesParams;
 import org.elasticsearch.index.mapper.ValueFetcher;
 import org.elasticsearch.index.query.SearchExecutionContext;
-import org.elasticsearch.logging.LogManager;
 import org.elasticsearch.script.field.DocValuesScriptFieldFactory;
 import org.elasticsearch.search.DocValueFormat;
 import org.elasticsearch.search.MultiValueMode;
@@ -477,7 +476,6 @@ public class HistogramFieldMapper extends FieldMapper {
             @Override
             public DocValuesLoader docValuesLoader(LeafReader leafReader, int[] docIdsInLeaf) throws IOException {
                 BinaryDocValues docValues = DocValues.getBinary(leafReader, fieldType().name());
-                LogManager.getLogger(HistogramFieldMapper.class).error("DSAFADFDASFSAF {} {}", fieldType().name(), docValues);
                 if (docValues == null) {
                     // No values in this leaf
                     binaryValue = null;
@@ -485,11 +483,9 @@ public class HistogramFieldMapper extends FieldMapper {
                 }
                 return docId -> {
                     if (docValues.advanceExact(docId)) {
-                        LogManager.getLogger(HistogramFieldMapper.class).error("DSAFADFDASFSAF {} true", fieldType().name());
                         binaryValue = docValues.binaryValue();
                         return true;
                     }
-                    LogManager.getLogger(HistogramFieldMapper.class).error("DSAFADFDASFSAF {} false", fieldType().name());
                     binaryValue = null;
                     return false;
                 };
@@ -502,7 +498,6 @@ public class HistogramFieldMapper extends FieldMapper {
 
             @Override
             public void write(XContentBuilder b) throws IOException {
-                LogManager.getLogger(HistogramFieldMapper.class).error("DSAFADFDASFSAF {} true", binaryValue);
                 if (binaryValue == null) {
                     return;
                 }

--- a/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/mapper/HistogramFieldMapper.java
+++ b/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/mapper/HistogramFieldMapper.java
@@ -10,6 +10,7 @@ import org.apache.lucene.document.BinaryDocValuesField;
 import org.apache.lucene.document.Field;
 import org.apache.lucene.index.BinaryDocValues;
 import org.apache.lucene.index.DocValues;
+import org.apache.lucene.index.LeafReader;
 import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.SortField;
@@ -31,17 +32,20 @@ import org.elasticsearch.index.mapper.FieldMapper;
 import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.mapper.MapperBuilderContext;
 import org.elasticsearch.index.mapper.MapperParsingException;
+import org.elasticsearch.index.mapper.SourceLoader;
 import org.elasticsearch.index.mapper.SourceValueFetcher;
 import org.elasticsearch.index.mapper.TextSearchInfo;
 import org.elasticsearch.index.mapper.TimeSeriesParams;
 import org.elasticsearch.index.mapper.ValueFetcher;
 import org.elasticsearch.index.query.SearchExecutionContext;
+import org.elasticsearch.logging.LogManager;
 import org.elasticsearch.script.field.DocValuesScriptFieldFactory;
 import org.elasticsearch.search.DocValueFormat;
 import org.elasticsearch.search.MultiValueMode;
 import org.elasticsearch.search.sort.BucketedSort;
 import org.elasticsearch.search.sort.SortOrder;
 import org.elasticsearch.xcontent.ParseField;
+import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xcontent.XContentParser;
 import org.elasticsearch.xcontent.XContentSubParser;
 import org.elasticsearch.xpack.analytics.aggregations.support.AnalyticsValuesSourceType;
@@ -49,6 +53,7 @@ import org.elasticsearch.xpack.analytics.aggregations.support.AnalyticsValuesSou
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Map;
+import java.util.stream.Stream;
 
 import static org.elasticsearch.common.xcontent.XContentParserUtils.ensureExpectedToken;
 
@@ -446,5 +451,79 @@ public class HistogramFieldMapper extends FieldMapper {
             }
             return count;
         }
+    }
+
+    @Override
+    public SourceLoader.SyntheticFieldLoader syntheticFieldLoader() {
+        if (ignoreMalformed.value()) {
+            throw new IllegalArgumentException(
+                "field [" + name() + "] of type [histogram] doesn't support synthetic source because it ignores malformed histograms"
+            );
+        }
+        if (copyTo.copyToFields().isEmpty() != true) {
+            throw new IllegalArgumentException(
+                "field [" + name() + "] of type [histogram] doesn't support synthetic source because it declares copy_to"
+            );
+        }
+        return new SourceLoader.SyntheticFieldLoader() {
+            private final InternalHistogramValue value = new InternalHistogramValue();
+            private BytesRef binaryValue;
+
+            @Override
+            public Stream<Map.Entry<String, StoredFieldLoader>> storedFieldLoaders() {
+                return Stream.of();
+            }
+
+            @Override
+            public DocValuesLoader docValuesLoader(LeafReader leafReader, int[] docIdsInLeaf) throws IOException {
+                BinaryDocValues docValues = DocValues.getBinary(leafReader, fieldType().name());
+                LogManager.getLogger(HistogramFieldMapper.class).error("DSAFADFDASFSAF {} {}", fieldType().name(), docValues);
+                if (docValues == null) {
+                    // No values in this leaf
+                    binaryValue = null;
+                    return null;
+                }
+                return docId -> {
+                    if (docValues.advanceExact(docId)) {
+                        LogManager.getLogger(HistogramFieldMapper.class).error("DSAFADFDASFSAF {} true", fieldType().name());
+                        binaryValue = docValues.binaryValue();
+                        return true;
+                    }
+                    LogManager.getLogger(HistogramFieldMapper.class).error("DSAFADFDASFSAF {} false", fieldType().name());
+                    binaryValue = null;
+                    return false;
+                };
+            }
+
+            @Override
+            public boolean hasValue() {
+                return binaryValue != null;
+            }
+
+            @Override
+            public void write(XContentBuilder b) throws IOException {
+                LogManager.getLogger(HistogramFieldMapper.class).error("DSAFADFDASFSAF {} true", binaryValue);
+                if (binaryValue == null) {
+                    return;
+                }
+                b.startObject(simpleName());
+
+                value.reset(binaryValue);
+                b.startArray("values");
+                while (value.next()) {
+                    b.value(value.value());
+                }
+                b.endArray();
+
+                value.reset(binaryValue);
+                b.startArray("counts");
+                while (value.next()) {
+                    b.value(value.count());
+                }
+                b.endArray();
+
+                b.endObject();
+            }
+        };
     }
 }

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/analytics/histogram.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/analytics/histogram.yml
@@ -249,3 +249,49 @@ histogram with wrong time series mappings:
                           latency:
                             type: histogram
                             time_series_metric: counter
+
+---
+histogram with synthetic source:
+  - skip:
+      version: " - 8.4.99"
+      reason: introduced in 8.5.0
+
+  - do:
+      indices.create:
+        index: histo_synthetic
+        body:
+          mappings:
+            _source:
+              mode: synthetic
+            properties:
+              latency:
+                type: histogram
+  - do:
+      bulk:
+        index: histo_synthetic
+        refresh: true
+        body:
+          - '{"index": {"_id": 1}}'
+          - '{"latency": {"values" : [0.1, 0.2, 0.3, 0.4, 0.5], "counts" : [3, 7, 23, 12, 6]}}'
+          - '{"index": {"_id": 2}}'
+          - '{"latency": {"values" : [0, 0.1, 0.2, 0.3, 0.4, 0.5], "counts" : [3, 2, 5, 10, 1, 8]}}'
+
+  - do:
+      get:
+        index: histo_synthetic
+        id: 1
+  - match:
+      _source:
+        latency:
+          values: [0.1, 0.2, 0.3, 0.4, 0.5]
+          counts: [3, 7, 23, 12, 6]
+
+  - do:
+      get:
+        index: histo_synthetic
+        id: 2
+  - match:
+      _source:
+        latency:
+          values: [0.0, 0.1, 0.2, 0.3, 0.4, 0.5]
+          counts: [3, 2, 5, 10, 1, 8]


### PR DESCRIPTION
Adds support for the `histogram` field type to synthetic _source.

![image](https://user-images.githubusercontent.com/215970/188691249-9d23d1dc-64ab-49a4-8b24-f60fc966c0ac.png)
