### PR TITLE
Stop automatically rollover for searchable snapshot tests on a hot node

### DIFF
--- a/x-pack/plugin/ilm/qa/multi-node/src/javaRestTest/java/org/elasticsearch/xpack/ilm/actions/SearchableSnapshotActionIT.java
+++ b/x-pack/plugin/ilm/qa/multi-node/src/javaRestTest/java/org/elasticsearch/xpack/ilm/actions/SearchableSnapshotActionIT.java
@@ -620,7 +620,7 @@ public class SearchableSnapshotActionIT extends ESRestTestCase {
                 TimeValue.ZERO,
                 Map.of(
                     RolloverAction.NAME,
-                    new RolloverAction(null, null, null, 1L, null, null, null, null, null, null),
+                    new RolloverAction(null, null, null, 1000L, null, null, null, null, null, null),
                     SearchableSnapshotAction.NAME,
                     new SearchableSnapshotAction(snapshotRepo, randomBoolean())
                 )


### PR DESCRIPTION
We roll over the data stream manually in the test via a `rolloverMaxOneDocCondition(client(), dataStream)` call, so we don't need duplicate the max amount of docs in `RolloverAction`. 

This makes sure we don't accidentally create searchable snapshots while cleaning them.

Fixes https://github.com/elastic/elasticsearch/issues/86890