### PR TITLE
Fleet: Added upgrade_status field to fleet-agents

### DIFF
--- a/docs/changelog/89845.yaml
+++ b/docs/changelog/89845.yaml
@@ -1,0 +1,5 @@
+pr: 89845
+summary: "Fleet: Add `upgrade_status` attributes to agents"
+area: Infra/Core
+type: enhancement
+issues: []

--- a/x-pack/plugin/core/src/main/resources/fleet-agents.json
+++ b/x-pack/plugin/core/src/main/resources/fleet-agents.json
@@ -241,6 +241,9 @@
         "upgraded_at": {
           "type": "date"
         },
+        "upgrade_status": {
+          "type": "keyword"
+        },
         "user_provided_metadata": {
           "type": "object",
           "enabled": false


### PR DESCRIPTION
### What does this PR Do?

Add new `upgrade_status` attribute to `.fleet-agents` index mapping.

### Related Issues

- https://github.com/elastic/kibana/issues/139704
