### PR TITLE
[8.4] Update openjdk to 18.0.2.1 (#89535)

### DIFF
--- a/build-tools-internal/version.properties
+++ b/build-tools-internal/version.properties
@@ -2,7 +2,7 @@ elasticsearch     = 8.4.2
 lucene            = 9.3.0
 
 bundled_jdk_vendor = openjdk
-bundled_jdk = 18.0.2+9@f6ad4b4450fd4d298113270ec84f30ee
+bundled_jdk = 18.0.2.1+1@db379da656dc47308e138f21b33976fa
 
 # optional dependencies
 spatial4j         = 0.7

--- a/docs/changelog/89535.yaml
+++ b/docs/changelog/89535.yaml
@@ -1,0 +1,6 @@
+pr: 89535
+summary: Update openjdk to 18.0.2.1
+area: Packaging
+type: upgrade
+issues:
+ - 89531


### PR DESCRIPTION
Backports the following commits to 8.4:
 - Update openjdk to 18.0.2.1 (#89535)