### PR TITLE
Mute AutoscalingDeciderResultsTests.testRequiredCapacity

### DIFF
--- a/x-pack/plugin/autoscaling/src/test/java/org/elasticsearch/xpack/autoscaling/capacity/AutoscalingDeciderResultsTests.java
+++ b/x-pack/plugin/autoscaling/src/test/java/org/elasticsearch/xpack/autoscaling/capacity/AutoscalingDeciderResultsTests.java
@@ -47,6 +47,7 @@ public class AutoscalingDeciderResultsTests extends AutoscalingTestCase {
         assertThat(e.getMessage(), equalTo("results can not be empty"));
     }
 
+    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/89854")
     public void testRequiredCapacity() {
         AutoscalingCapacity single = randomBoolean() ? randomAutoscalingCapacity() : null;
         verifyRequiredCapacity(single, single);


### PR DESCRIPTION
See https://github.com/elastic/elasticsearch/issues/89854