### PR TITLE
Increment clientCalledCount before onResponse

### DIFF
--- a/server/src/test/java/org/elasticsearch/health/node/LocalHealthMonitorTests.java
+++ b/server/src/test/java/org/elasticsearch/health/node/LocalHealthMonitorTests.java
@@ -210,8 +210,8 @@ public class LocalHealthMonitorTests extends ESTestCase {
         AtomicInteger clientCalledCount = new AtomicInteger();
         doAnswer(invocation -> {
             ActionListener<AcknowledgedResponse> listener = (ActionListener<AcknowledgedResponse>) invocation.getArguments()[2];
-            listener.onResponse(null);
             clientCalledCount.incrementAndGet();
+            listener.onResponse(null);
             return null;
         }).when(client).execute(any(), any(), any());
         simulateHealthDiskSpace();


### PR DESCRIPTION
Closes #89817.

Explanation:
There was a race in test, the test asserts that if the disk health info has been updated then the client should have been called:
```
        assertThat(localHealthMonitor.getLastReportedDiskHealthInfo(), nullValue());
        assertThat(clientCalledCount.get(), equalTo(0));
```
However, in the mocked client call, we first responded to the listener and then we incremented the counter. Since we do not use `assertBusy` in the `clientCalledCount` assertion, there would be cases when the assertion would happen before the counter was incremented.