### PR TITLE
Adjust processors lower bound in autoscaling fixed decider tests

### DIFF
--- a/x-pack/plugin/autoscaling/src/test/java/org/elasticsearch/xpack/autoscaling/capacity/AutoscalingCalculateCapacityServiceTests.java
+++ b/x-pack/plugin/autoscaling/src/test/java/org/elasticsearch/xpack/autoscaling/capacity/AutoscalingCalculateCapacityServiceTests.java
@@ -50,7 +50,6 @@ import static org.hamcrest.Matchers.sameInstance;
 
 public class AutoscalingCalculateCapacityServiceTests extends AutoscalingTestCase {
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/89852")
     public void testMultiplePoliciesFixedCapacity() {
         AutoscalingCalculateCapacityService service = new AutoscalingCalculateCapacityService(Set.of(new FixedAutoscalingDeciderService()));
         Set<String> policyNames = IntStream.range(0, randomIntBetween(1, 10))
@@ -151,7 +150,7 @@ public class AutoscalingCalculateCapacityServiceTests extends AutoscalingTestCas
             settings.put(FixedAutoscalingDeciderService.MEMORY.getKey(), randomByteSizeValue());
         }
         if (randomBoolean()) {
-            settings.put(FixedAutoscalingDeciderService.PROCESSORS.getKey(), randomInt(64));
+            settings.put(FixedAutoscalingDeciderService.PROCESSORS.getKey(), randomIntBetween(1, 64));
         }
         settings.put(FixedAutoscalingDeciderService.NODES.getKey(), randomIntBetween(1, 10));
         return new TreeMap<>(Map.of(FixedAutoscalingDeciderService.NAME, settings.build()));

--- a/x-pack/plugin/autoscaling/src/test/java/org/elasticsearch/xpack/autoscaling/capacity/AutoscalingDeciderResultsTests.java
+++ b/x-pack/plugin/autoscaling/src/test/java/org/elasticsearch/xpack/autoscaling/capacity/AutoscalingDeciderResultsTests.java
@@ -47,7 +47,6 @@ public class AutoscalingDeciderResultsTests extends AutoscalingTestCase {
         assertThat(e.getMessage(), equalTo("results can not be empty"));
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/89854")
     public void testRequiredCapacity() {
         AutoscalingCapacity single = randomBoolean() ? randomAutoscalingCapacity() : null;
         verifyRequiredCapacity(single, single);
@@ -63,7 +62,7 @@ public class AutoscalingDeciderResultsTests extends AutoscalingTestCase {
 
         List<AutoscalingCapacity> autoscalingCapacities = new ArrayList<>();
         autoscalingCapacities.add(large);
-        IntStream.range(0, 10).mapToObj(i -> randomCapacity(node, storage, memory, processor, 0, 1000)).forEach(autoscalingCapacities::add);
+        IntStream.range(0, 10).mapToObj(i -> randomCapacity(node, storage, memory, processor, 1, 1000)).forEach(autoscalingCapacities::add);
 
         Randomness.shuffle(autoscalingCapacities);
         verifyRequiredCapacity(large, autoscalingCapacities.toArray(AutoscalingCapacity[]::new));

--- a/x-pack/plugin/autoscaling/src/test/java/org/elasticsearch/xpack/autoscaling/capacity/FixedAutoscalingDeciderServiceTests.java
+++ b/x-pack/plugin/autoscaling/src/test/java/org/elasticsearch/xpack/autoscaling/capacity/FixedAutoscalingDeciderServiceTests.java
@@ -26,7 +26,9 @@ public class FixedAutoscalingDeciderServiceTests extends AutoscalingTestCase {
 
         ByteSizeValue storage = randomNullableByteSizeValue();
         ByteSizeValue memory = randomNullableByteSizeValue();
-        Processors processors = (memory != null || storage != null) && randomBoolean() ? null : Processors.of((double) randomInt(64));
+        Processors processors = (memory != null || storage != null) && randomBoolean()
+            ? null
+            : Processors.of((double) randomIntBetween(1, 64));
         if (storage != null) {
             configurationBuilder.put(FixedAutoscalingDeciderService.STORAGE.getKey(), storage);
         }


### PR DESCRIPTION
Closes #89852
Closes #89854
