### PR TITLE
[8.4] Fix typo in get-snapshot-status-api doc (#89865)

### DIFF
--- a/docs/reference/snapshot-restore/apis/get-snapshot-status-api.asciidoc
+++ b/docs/reference/snapshot-restore/apis/get-snapshot-status-api.asciidoc
@@ -200,7 +200,7 @@ Number of shards that are still initializing.
 
 `started`::
 (integer)
-Number of shards that have started but not are not finalized.
+Number of shards that have started but are not finalized.
 
 `finalizing`::
 (integer)


### PR DESCRIPTION
Backports the following commits to 8.4:
 - Fix typo in get-snapshot-status-api doc (#89865)