### PR TITLE
Fix memory leak when double invoking RestChannel.sendResponse (#89873)

### DIFF
--- a/docs/changelog/89873.yaml
+++ b/docs/changelog/89873.yaml
@@ -1,0 +1,5 @@
+pr: 89873
+summary: Fix memory leak when double invoking `RestChannel.sendResponse`
+area: Network
+type: bug
+issues: []

--- a/server/src/main/java/org/elasticsearch/rest/AbstractRestChannel.java
+++ b/server/src/main/java/org/elasticsearch/rest/AbstractRestChannel.java
@@ -149,11 +149,8 @@ public abstract class AbstractRestChannel implements RestChannel {
         return bytesOut;
     }
 
-    /**
-     * Releases the current output buffer for this channel. Must be called after the buffer derived from {@link #bytesOutput} is no longer
-     * needed.
-     */
-    protected final void releaseOutputBuffer() {
+    @Override
+    public final void releaseOutputBuffer() {
         if (bytesOut != null) {
             bytesOut.close();
             bytesOut = null;

--- a/server/src/main/java/org/elasticsearch/rest/RestChannel.java
+++ b/server/src/main/java/org/elasticsearch/rest/RestChannel.java
@@ -31,6 +31,12 @@ public interface RestChannel {
 
     BytesStreamOutput bytesOutput();
 
+    /**
+     * Releases the current output buffer for this channel. Must be called after the buffer derived from {@link #bytesOutput} is no longer
+     * needed.
+     */
+    void releaseOutputBuffer();
+
     RestRequest request();
 
     /**

--- a/server/src/main/java/org/elasticsearch/rest/RestController.java
+++ b/server/src/main/java/org/elasticsearch/rest/RestController.java
@@ -573,6 +573,11 @@ public class RestController implements HttpServerTransport.Dispatcher {
         }
 
         @Override
+        public void releaseOutputBuffer() {
+            delegate.releaseOutputBuffer();
+        }
+
+        @Override
         public RestRequest request() {
             return delegate.request();
         }
@@ -584,8 +589,16 @@ public class RestController implements HttpServerTransport.Dispatcher {
 
         @Override
         public void sendResponse(RestResponse response) {
-            close();
-            delegate.sendResponse(response);
+            boolean success = false;
+            try {
+                close();
+                delegate.sendResponse(response);
+                success = true;
+            } finally {
+                if (success == false) {
+                    releaseOutputBuffer();
+                }
+            }
         }
 
         private void close() {


### PR DESCRIPTION
When using the resource handling channel we must make sure that if we (by what is IMO a bug) try to double invoke it after having already sent a response (or tried to do so) we at least release the memory in the channel's outbound buffer. Otherwise we will leak any memory from it that was used to create the now failing to send `RestResponse`.

backport of #89873 