### PR TITLE
Fix typos in audit event type model 

### DIFF
--- a/x-pack/docs/en/security/auditing/event-types.asciidoc
+++ b/x-pack/docs/en/security/auditing/event-types.asciidoc
@@ -788,8 +788,8 @@ the <<mapping-roles, API request for mapping roles>>.
 +
 [source,js]
 ----
-`{"id": <string>, "name": <string>, "expiration": <string>, "role_descriptors" [<object>],
-"metadata" [<object>]}`
+`{"id": <string>, "name": <string>, "expiration": <string>, "role_descriptors": [<object>],
+"metadata": [<object>]}`
 ----
 // NOTCONSOLE
 +


### PR DESCRIPTION
Nit typo fix in audit event model for `apikey`. 