### PR TITLE
[8.4] Fix typos in audit event types (#89886)

### DIFF
--- a/x-pack/docs/en/security/auditing/event-types.asciidoc
+++ b/x-pack/docs/en/security/auditing/event-types.asciidoc
@@ -761,8 +761,8 @@ the <<mapping-roles, API request for mapping roles>>.
 +
 [source,js]
 ----
-`{"id": <string>, "name": <string>, "expiration": <string>, "role_descriptors" [<object>],
-"metadata" [<object>]}`
+`{"id": <string>, "name": <string>, "expiration": <string>, "role_descriptors": [<object>],
+"metadata": [<object>]}`
 ----
 // NOTCONSOLE
 +


### PR DESCRIPTION
Backports the following commits to 8.4:
 - Fix typos in audit event types (#89886)