### PR TITLE
[DOCS] Add note about passwords in .env Docker file

### DIFF
--- a/docs/reference/setup/install/docker.asciidoc
+++ b/docs/reference/setup/install/docker.asciidoc
@@ -263,6 +263,10 @@ password for the `elastic` and `kibana_system` users with the
 `ELASTIC_PASSWORD` and `KIBANA_PASSWORD` variables. These variable are
 referenced by the `docker-compose.yml` file.
 
+IMPORTANT: Your passwords must be alphanumeric, and cannot contain special
+characters such as `!` or `@`. The `bash` script included in the 
+`docker-compose.yml` file only operates on alphanumeric characters.
+
 ["source","txt",subs="attributes"]
 ----
 include::docker/.env[]


### PR DESCRIPTION
Adds a note to the Elasticsearch installation instructions [on Docker](https://www.elastic.co/guide/en/elasticsearch/reference/current/docker.html#docker-env-file) to indicate that passwords in the `.env` file must be alphanumeric and cannot contain special characters.

Closes https://github.com/elastic/kibana/issues/139977