### PR TITLE
Document synthetic source for text and keyword

### DIFF
--- a/docs/reference/mapping/types/keyword.asciidoc
+++ b/docs/reference/mapping/types/keyword.asciidoc
@@ -173,12 +173,11 @@ Dimension fields have the following constraints:
 ==== Synthetic source preview:[]
 `keyword` fields support <<synthetic-source,synthetic `_source`>> in their
 default configuration. Synthetic `_source` cannot be used together with
-<<ignore-above,`ignore_above`>>, a <<normalizer,`normalizer`>>,
-<<copy-to,`copy_to`>>, or with <<doc-values,`doc_values`>> disabled.
+a <<normalizer,`normalizer`>> or <<copy-to,`copy_to`>>.
 
-Synthetic source always sorts `keyword` fields and removes duplicates. For
-example:
-[source,console,id=synthetic-source-keyword-example]
+By default synthetic source sorts `keyword` fields and removes duplicates.
+For example:
+[source,console,id=synthetic-source-keyword-example-default]
 ----
 PUT idx
 {
@@ -205,6 +204,67 @@ Will become:
 }
 ----
 // TEST[s/^/{"_source":/ s/\n$/}/]
+
+If a `keyword` field sets `store` to `true` then order and duplicates
+are preserved. For example:
+[source,console,id=synthetic-source-keyword-example-stored]
+----
+PUT idx
+{
+  "mappings": {
+    "_source": { "mode": "synthetic" },
+    "properties": {
+      "kwd": { "type": "keyword", "store": true }
+    }
+  }
+}
+PUT idx/_doc/1
+{
+  "kwd": ["foo", "foo", "bar", "baz"]
+}
+----
+// TEST[s/$/\nGET idx\/_doc\/1?filter_path=_source\n/]
+
+Will become:
+
+[source,console-result]
+----
+{
+  "kwd": ["foo", "foo", "bar", "baz"]
+}
+----
+// TEST[s/^/{"_source":/ s/\n$/}/]
+
+Values longer than `ignore_above` are preserved but sorted to the end.
+For example:
+[source,console,id=synthetic-source-keyword-example-ignore-above]
+----
+PUT idx
+{
+  "mappings": {
+    "_source": { "mode": "synthetic" },
+    "properties": {
+      "kwd": { "type": "keyword", "ignore_above": 3 }
+    }
+  }
+}
+PUT idx/_doc/1
+{
+  "kwd": ["foo", "foo", "bang", "bar", "baz"]
+}
+----
+// TEST[s/$/\nGET idx\/_doc\/1?filter_path=_source\n/]
+
+Will become:
+
+[source,console-result]
+----
+{
+  "kwd": ["bar", "baz", "foo", "bang"]
+}
+----
+// TEST[s/^/{"_source":/ s/\n$/}/]
+
 
 include::constant-keyword.asciidoc[]
 

--- a/docs/reference/mapping/types/keyword.asciidoc
+++ b/docs/reference/mapping/types/keyword.asciidoc
@@ -175,7 +175,7 @@ Dimension fields have the following constraints:
 default configuration. Synthetic `_source` cannot be used together with
 a <<normalizer,`normalizer`>> or <<copy-to,`copy_to`>>.
 
-By default synthetic source sorts `keyword` fields and removes duplicates.
+By default, synthetic source sorts `keyword` fields and removes duplicates.
 For example:
 [source,console,id=synthetic-source-keyword-example-default]
 ----

--- a/docs/reference/mapping/types/text.asciidoc
+++ b/docs/reference/mapping/types/text.asciidoc
@@ -166,8 +166,8 @@ a <<keyword-synthetic-source, `keyword`>> sub-field that supports synthetic
 `_source` or if the `text` field sets `store` to `true`. Either way, it may
 not have <<copy-to,`copy_to`>>.
 
-If using a sub-`keyword` field then the values are sorted in the same was as
-a `keyword` field's values are sorted. By default that means sorted with
+If using a sub-`keyword` field then the values are sorted in the same way as
+a `keyword` field's values are sorted. By default, that means sorted with
 duplicates removed. So:
 [source,console,id=synthetic-source-text-example-default]
 ----

--- a/docs/reference/mapping/types/text.asciidoc
+++ b/docs/reference/mapping/types/text.asciidoc
@@ -162,12 +162,14 @@ The following parameters are accepted by `text` fields:
 [[text-synthetic-source]]
 ==== Synthetic source preview:[]
 `text` fields support <<synthetic-source,synthetic `_source`>> if they have
-a `keyword` sub-field that supports synthetic `_source` and *do not* have
-<<copy-to,`copy_to`>>.
+a <<keyword-synthetic-source, `keyword`>> sub-field that supports synthetic
+`_source` or if the `text` field sets `store` to `true`. Either way, it may
+not have <<copy-to,`copy_to`>>.
 
-Synthetic source always sorts `keyword` fields and removes duplicates, so
-`text` fields are sorted based on the sub-`keyword` field. For example:
-[source,console,id=synthetic-source-text-example]
+If using a sub-`keyword` field then the values are sorted in the same was as
+a `keyword` field's values are sorted. By default that means sorted with
+duplicates removed. So:
+[source,console,id=synthetic-source-text-example-default]
 ----
 PUT idx
 {
@@ -213,6 +215,43 @@ NOTE: Reordering text fields can have an effect on <<query-dsl-match-query-phras
       <<position-increment-gap,`position_increment_gap`>> for more detail. You
       can avoid this by making sure the `slop` parameter on the phrase queries
       is lower than the `position_increment_gap`. This is the default.
+
+If the `text` field sets `store` to true then order and duplicates
+are preserved.
+[source,console,id=synthetic-source-text-example-stored]
+----
+PUT idx
+{
+  "mappings": {
+    "_source": { "mode": "synthetic" },
+    "properties": {
+      "text": { "type": "text", "store": true }
+    }
+  }
+}
+PUT idx/_doc/1
+{
+  "text": [
+    "the quick brown fox",
+    "the quick brown fox",
+    "jumped over the lazy dog"
+  ]
+}
+----
+// TEST[s/$/\nGET idx\/_doc\/1?filter_path=_source\n/]
+
+Will become:
+[source,console-result]
+----
+{
+  "text": [
+    "the quick brown fox",
+    "the quick brown fox",
+    "jumped over the lazy dog"
+  ]
+}
+----
+// TEST[s/^/{"_source":/ s/\n$/}/]
 
 [[fielddata-mapping-param]]
 ==== `fielddata` mapping parameter


### PR DESCRIPTION
`text` and `keyword` fields support synthetic _source in a few more configurations now. This documents those configurations.
