### PR TITLE
Fix integration test on Windows

### DIFF
--- a/build-tools-internal/src/integTest/groovy/org/elasticsearch/gradle/internal/ElasticsearchJavaModulePathPluginFuncTest.groovy
+++ b/build-tools-internal/src/integTest/groovy/org/elasticsearch/gradle/internal/ElasticsearchJavaModulePathPluginFuncTest.groovy
@@ -204,7 +204,7 @@ class ElasticsearchJavaModulePathPluginFuncTest extends AbstractJavaGradleFuncTe
     def "included build with module dependencies"() {
         given:
         file(rootBuild.root, 'settings.gradle') << """
-        includeBuild '$projectDir'
+        includeBuild '${projectDir.path.replace('\\', '\\\\')}'
         """
 
         file(rootBuild.root, 'build.gradle') << """

--- a/build-tools-internal/src/integTest/groovy/org/elasticsearch/gradle/internal/ElasticsearchJavaModulePathPluginFuncTest.groovy
+++ b/build-tools-internal/src/integTest/groovy/org/elasticsearch/gradle/internal/ElasticsearchJavaModulePathPluginFuncTest.groovy
@@ -172,7 +172,7 @@ class ElasticsearchJavaModulePathPluginFuncTest extends AbstractJavaGradleFuncTe
     def "included build with non module dependencies"() {
         given:
         file(rootBuild.root, 'settings.gradle') << """
-        includeBuild '$projectDir'
+        includeBuild '${projectDir.path.replace('\\', '\\\\')}'
         """
 
         file(rootBuild.root, 'build.gradle') << """


### PR DESCRIPTION
Fix some string escaping related file paths on windows.

Resolves https://github.com/elastic/elasticsearch/issues/89856#issuecomment-1239154458