### PR TITLE
Clarify that knn does not use postfiltering

### DIFF
--- a/docs/reference/search/search-your-data/knn-search.asciidoc
+++ b/docs/reference/search/search-your-data/knn-search.asciidoc
@@ -279,6 +279,12 @@ POST image-index/_search
 ----
 // TEST[continued]
 
+NOTE: The filter is applied **during** the approximate kNN search to ensure
+that `k` matching documents are returned. This contrasts with a
+post-filtering approach, where the filter is applied **after** the approximate
+kNN search completes. Post-filtering has the downside that it sometimes
+returns fewer than k results, even when there are enough matching documents.
+
 [discrete]
 ==== Combine approximate kNN with other features
 


### PR DESCRIPTION
This PR expands the approximate kNN docs to clarify the filter is applied
during the kNN search, not after. It explains the downsides of postfiltering.
