### PR TITLE
[Stable plugin api] Extensible annotation

### DIFF
--- a/libs/logging/build.gradle
+++ b/libs/logging/build.gradle
@@ -1,7 +1,3 @@
-import org.elasticsearch.gradle.transform.UnzipTransform
-
-import java.util.stream.Collectors
-
 /*
  * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
  * or more contributor license agreements. Licensed under the Elastic License

--- a/libs/plugin-analysis-api/src/main/java/org/elasticsearch/plugin/analysis/api/AnalyzerFactory.java
+++ b/libs/plugin-analysis-api/src/main/java/org/elasticsearch/plugin/analysis/api/AnalyzerFactory.java
@@ -9,11 +9,13 @@
 package org.elasticsearch.plugin.analysis.api;
 
 import org.apache.lucene.analysis.Analyzer;
+import org.elasticsearch.plugin.api.Extensible;
 import org.elasticsearch.plugin.api.Nameable;
 
 /**
  * An analysis component used to create Analyzers.
  */
+@Extensible
 public interface AnalyzerFactory extends Nameable {
     /**
      * Returns a lucene org.apache.lucene.analysis.Analyzer instance.

--- a/libs/plugin-analysis-api/src/main/java/org/elasticsearch/plugin/analysis/api/CharFilterFactory.java
+++ b/libs/plugin-analysis-api/src/main/java/org/elasticsearch/plugin/analysis/api/CharFilterFactory.java
@@ -8,6 +8,7 @@
 
 package org.elasticsearch.plugin.analysis.api;
 
+import org.elasticsearch.plugin.api.Extensible;
 import org.elasticsearch.plugin.api.Nameable;
 
 import java.io.Reader;
@@ -16,6 +17,7 @@ import java.io.Reader;
  * An analysis component used to create char filters.
  *
  */
+@Extensible
 public interface CharFilterFactory extends Nameable {
     /**
      * Wraps the given Reader with a CharFilter.

--- a/libs/plugin-analysis-api/src/main/java/org/elasticsearch/plugin/analysis/api/TokenFilterFactory.java
+++ b/libs/plugin-analysis-api/src/main/java/org/elasticsearch/plugin/analysis/api/TokenFilterFactory.java
@@ -9,11 +9,13 @@
 package org.elasticsearch.plugin.analysis.api;
 
 import org.apache.lucene.analysis.TokenStream;
+import org.elasticsearch.plugin.api.Extensible;
 import org.elasticsearch.plugin.api.Nameable;
 
 /**
  * An analysis component used to create token filters.
  */
+@Extensible
 public interface TokenFilterFactory extends Nameable {
 
     /**

--- a/libs/plugin-analysis-api/src/main/java/org/elasticsearch/plugin/analysis/api/TokenizerFactory.java
+++ b/libs/plugin-analysis-api/src/main/java/org/elasticsearch/plugin/analysis/api/TokenizerFactory.java
@@ -9,11 +9,13 @@
 package org.elasticsearch.plugin.analysis.api;
 
 import org.apache.lucene.analysis.Tokenizer;
+import org.elasticsearch.plugin.api.Extensible;
 import org.elasticsearch.plugin.api.Nameable;
 
 /**
  * An analysis component used to create tokenizers.
  */
+@Extensible
 public interface TokenizerFactory extends Nameable {
 
     /**

--- a/libs/plugin-api/src/main/java/org/elasticsearch/plugin/api/Extensible.java
+++ b/libs/plugin-api/src/main/java/org/elasticsearch/plugin/api/Extensible.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.plugin.api;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.TYPE;
+
+/**
+ * Marker for things that can be loaded by component loader.
+ *
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(value = { TYPE })
+public @interface Extensible {
+}


### PR DESCRIPTION
This commits adds an Extensible annotation aimed to mark things that can be loaded by a component loader.
It also marks Analyzer api components (AnalyzerFactory, CharFilterFactory, TokenFilterFactory and TokenizerFactory) with this annotation.

relates #88980

<!--
Thank you for your interest in and contributing to Elasticsearch! There
are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your
attention.
-->

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/elasticsearch/blob/main/CONTRIBUTING.md)?
- If submitting code, have you built your formula locally prior to submission with `gradle check`?
- If submitting code, is your pull request against main? Unless there is a good reason otherwise, we prefer pull requests against main and will backport as needed.
- If submitting code, have you checked that your submission is for an [OS and architecture that we support](https://www.elastic.co/support/matrix#show_os)?
- If you are submitting this code for a class then read our [policy](https://github.com/elastic/elasticsearch/blob/main/CONTRIBUTING.md#contributing-as-part-of-a-class) for that.
