### PR TITLE
[7.17] Update running snapshot state value to `STARTED`

### DIFF
--- a/docs/reference/snapshot-restore/apis/get-snapshot-status-api.asciidoc
+++ b/docs/reference/snapshot-restore/apis/get-snapshot-status-api.asciidoc
@@ -169,7 +169,7 @@ Indicates the current snapshot state.
 `FAILED`::
   The snapshot finished with an error and failed to store any data.
 
-`IN_PROGRESS`::
+`STARTED`::
   The snapshot is currently running.
 
 `PARTIAL`::


### PR DESCRIPTION
For whatever reason, the backport of https://github.com/elastic/elasticsearch/pull/89675 didn't work. Probably because of [this](https://github.com/elastic/elasticsearch/pull/89675#issuecomment-1228955382)?