### PR TITLE
[8.4] [DOCS] Document security limitation for terms enum API (#89731)

### DIFF
--- a/x-pack/docs/en/security/limitations.asciidoc
+++ b/x-pack/docs/en/security/limitations.asciidoc
@@ -79,6 +79,8 @@ including the following queries:
 ** `percolate` query
 * If suggesters are specified and document level security is enabled, the specified suggesters are ignored.
 * A search request cannot be profiled if document level security is enabled.
+* The <<search-terms-enum,terms enum API>> does not return terms if document 
+level security is enabled.
 
 [discrete]
 [[alias-limitations]]


### PR DESCRIPTION
Backports the following commits to 8.4:
 - [DOCS] Document security limitation for terms enum API (#89731)