### PR TITLE
Fix SnapshotStatusApisIT.testGetSnapshotsWithSnapshotInProgress

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/snapshots/SnapshotStatusApisIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/snapshots/SnapshotStatusApisIT.java
@@ -63,6 +63,8 @@ public class SnapshotStatusApisIT extends AbstractSnapshotIntegTestCase {
         return Settings.builder()
             .put(super.nodeSettings(nodeOrdinal, otherSettings))
             .put(ThreadPool.ESTIMATED_TIME_INTERVAL_SETTING.getKey(), 0) // We have tests that check by-timestamp order
+            .put(LARGE_SNAPSHOT_POOL_SETTINGS) // we have #testGetSnapshotsWithSnapshotInProgress which needs many threads to ensure
+            // its snapshot pool does not become fully blocked on data nodes when blocking on data files
             .build();
     }
 


### PR DESCRIPTION
Same issue as fixed in #89908, we need our pool to be large enough so all the not-blocked snapshot metadata work can complete while we block data file work.

closes #89922
