### PR TITLE
Do not deserialize back BytesTransportRequest to clone a request in MockTransportService

### DIFF
--- a/test/framework/src/main/java/org/elasticsearch/test/transport/MockTransportService.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/transport/MockTransportService.java
@@ -517,6 +517,7 @@ public final class MockTransportService extends TransportService {
                     RequestHandlerRegistry<?> reg = MockTransportService.this.getRequestHandler(action);
                     clonedRequest = reg.newRequest(bStream.bytes().streamInput());
                 }
+                assert clonedRequest.getClass().equals(request.getClass()) : clonedRequest + " vs " + request;
 
                 final RunOnce runnable = new RunOnce(new AbstractRunnable() {
                     @Override

--- a/test/framework/src/main/java/org/elasticsearch/test/transport/MockTransportService.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/transport/MockTransportService.java
@@ -510,6 +510,8 @@ public final class MockTransportService extends TransportService {
                     // Some request handlers read back a BytesTransportRequest
                     // into a different class that cannot be re-serialized (i.e. JOIN_VALIDATE_ACTION_NAME),
                     // in those cases we just copy the raw bytes back to a BytesTransportRequest.
+                    // This is only needed for the BwC for JOIN_VALIDATE_ACTION_NAME and can be removed in the next major
+                    assert Version.CURRENT.major == Version.V_7_17_0.major + 1;
                     clonedRequest = new BytesTransportRequest(bStream.bytes().streamInput());
                 } else {
                     RequestHandlerRegistry<?> reg = MockTransportService.this.getRequestHandler(action);

--- a/test/framework/src/main/java/org/elasticsearch/test/transport/MockTransportService.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/transport/MockTransportService.java
@@ -37,6 +37,7 @@ import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.tasks.MockTaskManager;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.tracing.Tracer;
+import org.elasticsearch.transport.BytesTransportRequest;
 import org.elasticsearch.transport.ClusterConnectionManager;
 import org.elasticsearch.transport.ConnectTransportException;
 import org.elasticsearch.transport.ConnectionProfile;
@@ -502,10 +503,18 @@ public final class MockTransportService extends TransportService {
                 }
 
                 // poor mans request cloning...
-                RequestHandlerRegistry<?> reg = MockTransportService.this.getRequestHandler(action);
                 BytesStreamOutput bStream = new BytesStreamOutput();
                 request.writeTo(bStream);
-                final TransportRequest clonedRequest = reg.newRequest(bStream.bytes().streamInput());
+                final TransportRequest clonedRequest;
+                if (request instanceof BytesTransportRequest) {
+                    // Some request handlers read back a BytesTransportRequest
+                    // into a different class that cannot be re-serialized (i.e. JOIN_VALIDATE_ACTION_NAME),
+                    // in those cases we just copy the raw bytes back to a BytesTransportRequest.
+                    clonedRequest = new BytesTransportRequest(bStream.bytes().streamInput());
+                } else {
+                    RequestHandlerRegistry<?> reg = MockTransportService.this.getRequestHandler(action);
+                    clonedRequest = reg.newRequest(bStream.bytes().streamInput());
+                }
 
                 final RunOnce runnable = new RunOnce(new AbstractRunnable() {
                     @Override


### PR DESCRIPTION
Some handlers, such as JOIN_VALIDATE_ACTION_NAME, deserialize a BytesTransportRequest into a different class that cannot be serialized. This commit changes that behaviour and directly clones the BytesTransportRequest instead of relying on the transport handler.

Closes #88120
