### PR TITLE
Fix double sending of response in TransportOpenIdConnectPrepareAuthenticationAction

### DIFF
--- a/docs/changelog/89930.yaml
+++ b/docs/changelog/89930.yaml
@@ -1,0 +1,5 @@
+pr: 89930
+summary: Fix double sending of response in `TransportOpenIdConnectPrepareAuthenticationAction`
+area: Authentication
+type: bug
+issues: []


### PR DESCRIPTION
This fixes an obvious bug where the listener was resolved twice if any of the first two failure conditions in the changed method were met. Prior to #89873 this would lead to a memory leak.

This is actually observable in the real world looking at cloud failure logs.