### PR TITLE
Fix deadlock bug exposed by a test

### DIFF
--- a/docs/changelog/89934.yaml
+++ b/docs/changelog/89934.yaml
@@ -1,0 +1,5 @@
+pr: 89934
+summary: Fix deadlock bug exposed by the test
+area: Infra/Core
+type: bug
+issues: []

--- a/server/src/main/java/org/elasticsearch/reservedstate/service/FileSettingsService.java
+++ b/server/src/main/java/org/elasticsearch/reservedstate/service/FileSettingsService.java
@@ -59,7 +59,7 @@ public class FileSettingsService extends AbstractLifecycleComponent implements C
 
     private WatchService watchService; // null;
     private CountDownLatch watcherThreadLatch;
-    private CountDownLatch processingLatch;
+    private volatile CountDownLatch processingLatch;
 
     private volatile FileUpdateState fileUpdateState = null;
     private volatile WatchKey settingsDirWatchKey = null;
@@ -316,7 +316,11 @@ public class FileSettingsService extends AbstractLifecycleComponent implements C
                                     path,
                                     (e) -> logger.error("Error processing operator settings json file", e)
                                 );
-                                processingLatch.await();
+                                // After we get and set the processing latch, we need to check if stop wasn't
+                                // invoked in the meantime. Stop will invalidate all watch keys.
+                                if (configDirWatchKey != null) {
+                                    processingLatch.await();
+                                }
                             }
                         } catch (IOException e) {
                             logger.warn("encountered I/O error while watching file settings", e);


### PR DESCRIPTION
A new test exposed a very rare bug where the file settings service was in the middle of processing the file when the node closed. This terminated the cluster state update task, but nobody unlocked the latch await. The fix allows the stop operation to properly terminate the watcher thread.

Essentially, the cluster state tasks we run while processing the settings.json file, can terminate when the node is being shutdown, without calling the task success or failure methods. This means that if we are waiting for all async tasks to finish inside the file watcher processing loop, we'll be waiting forever. This problem was exposed while writing a new integration test for the repository settings. 

https://github.com/elastic/elasticsearch/pull/89601

Unit tests added that expose the bug consistently.