### PR TITLE
Mention full location of document _source

### DIFF
--- a/docs/painless/painless-guide/painless-runtime-fields.asciidoc
+++ b/docs/painless/painless-guide/painless-runtime-fields.asciidoc
@@ -6,7 +6,7 @@ filtering, and sorting.
 
 When defining a runtime field, you can include a Painless script that is
 evaluated at query time. This script has access to the entire context of a
-document, including the original `_source` and any mapped fields plus their
+document, including the original document at `params._source` and any mapped fields plus their
 values. At query time, the script runs and generates values for each scripted
 field that is included in the query.
 

--- a/docs/painless/painless-guide/painless-runtime-fields.asciidoc
+++ b/docs/painless/painless-guide/painless-runtime-fields.asciidoc
@@ -6,9 +6,9 @@ filtering, and sorting.
 
 When defining a runtime field, you can include a Painless script that is
 evaluated at query time. This script has access to the entire context of a
-document, including the original document <<modules-scripting-source, `_source` field>> and any mapped fields plus their
-values. At query time, the script runs and generates values for each scripted
-field that is included in the query.
+document, including the original document {ref}/modules-scripting-fields.html[`_source` field]
+and any mapped fields plus their values. At query time, the script runs and
+generates values for each scripted field that is included in the query.
 
 You can map a runtime field in the `runtime` section under the mapping
 definition, or define runtime fields that exist only as part of a search

--- a/docs/painless/painless-guide/painless-runtime-fields.asciidoc
+++ b/docs/painless/painless-guide/painless-runtime-fields.asciidoc
@@ -6,7 +6,7 @@ filtering, and sorting.
 
 When defining a runtime field, you can include a Painless script that is
 evaluated at query time. This script has access to the entire context of a
-document, including the original document at `params._source` and any mapped fields plus their
+document, including the original document <<modules-scripting-source, `_source` field>> and any mapped fields plus their
 values. At query time, the script runs and generates values for each scripted
 field that is included in the query.
 


### PR DESCRIPTION
This is mentioned at https://www.elastic.co/guide/en/elasticsearch/reference/current/runtime-mapping-fields.html and should also be mentioned here.

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/elasticsearch/blob/main/CONTRIBUTING.md)?
- If submitting code, have you built your formula locally prior to submission with `gradle check`?
- If submitting code, is your pull request against main? Unless there is a good reason otherwise, we prefer pull requests against main and will backport as needed.
- If submitting code, have you checked that your submission is for an [OS and architecture that we support](https://www.elastic.co/support/matrix#show_os)?
- If you are submitting this code for a class then read our [policy](https://github.com/elastic/elasticsearch/blob/main/CONTRIBUTING.md#contributing-as-part-of-a-class) for that.
