### PR TITLE
[8.4] Log unsuccessful attempts to get credentials from web identity tokens (#88241)

### DIFF
--- a/docs/changelog/88241.yaml
+++ b/docs/changelog/88241.yaml
@@ -1,0 +1,5 @@
+pr: 88241
+summary: Log unsuccessful attempts to get credentials from web identity tokens
+area: Allocation
+type: enhancement
+issues: []


### PR DESCRIPTION
Backports the following commits to 8.4:
 - Log unsuccessful attempts to get credentials from web identity tokens (#88241)