### PR TITLE
[7.17] Fix double sending of response in TransportOpenIdConnectPrepareAuthenticationAction (#89930)

### DIFF
--- a/docs/changelog/89930.yaml
+++ b/docs/changelog/89930.yaml
@@ -1,0 +1,5 @@
+pr: 89930
+summary: Fix double sending of response in `TransportOpenIdConnectPrepareAuthenticationAction`
+area: Authentication
+type: bug
+issues: []

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/oidc/TransportOpenIdConnectPrepareAuthenticationAction.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/oidc/TransportOpenIdConnectPrepareAuthenticationAction.java
@@ -23,6 +23,7 @@ import org.elasticsearch.xpack.security.authc.Realms;
 import org.elasticsearch.xpack.security.authc.oidc.OpenIdConnectRealm;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 public class TransportOpenIdConnectPrepareAuthenticationAction extends HandledTransportAction<
     OpenIdConnectPrepareAuthenticationRequest,
@@ -56,7 +57,7 @@ public class TransportOpenIdConnectPrepareAuthenticationAction extends HandledTr
             List<OpenIdConnectRealm> matchingRealms = this.realms.stream()
                 .filter(r -> r instanceof OpenIdConnectRealm && ((OpenIdConnectRealm) r).isIssuerValid(request.getIssuer()))
                 .map(r -> (OpenIdConnectRealm) r)
-                .toList();
+                .collect(Collectors.toList());
             if (matchingRealms.isEmpty()) {
                 listener.onFailure(
                     new ElasticsearchSecurityException("Cannot find OpenID Connect realm with issuer [{}]", request.getIssuer())


### PR DESCRIPTION
Backports the following commits to 7.17:
 - Fix double sending of response in TransportOpenIdConnectPrepareAuthenticationAction (#89930)