### PR TITLE
[8.4] Fix double sending of response in TransportOpenIdConnectPrepareAuthenticationAction (#89930)

### DIFF
--- a/docs/changelog/89930.yaml
+++ b/docs/changelog/89930.yaml
@@ -1,0 +1,5 @@
+pr: 89930
+summary: Fix double sending of response in `TransportOpenIdConnectPrepareAuthenticationAction`
+area: Authentication
+type: bug
+issues: []


### PR DESCRIPTION
Backports the following commits to 8.4:
 - Fix double sending of response in TransportOpenIdConnectPrepareAuthenticationAction (#89930)