### PR TITLE
Increase timeout for FrozenExistenceDeciderIT#testZeroToOne

### DIFF
--- a/x-pack/plugin/autoscaling/src/internalClusterTest/java/org/elasticsearch/xpack/autoscaling/existence/FrozenExistenceDeciderIT.java
+++ b/x-pack/plugin/autoscaling/src/internalClusterTest/java/org/elasticsearch/xpack/autoscaling/existence/FrozenExistenceDeciderIT.java
@@ -33,6 +33,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 
 import static java.util.Collections.singletonMap;
 import static org.elasticsearch.cluster.metadata.IndexMetadata.SETTING_NUMBER_OF_REPLICAS;
@@ -73,7 +74,6 @@ public class FrozenExistenceDeciderIT extends AbstractFrozenAutoscalingIntegTest
         return List.of(LocalStateAutoscalingAndSearchableSnapshotsAndIndexLifecycle.class);
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/89082")
     public void testZeroToOne() throws Exception {
         internalCluster().startMasterOnlyNode();
         setupRepoAndPolicy();
@@ -131,7 +131,7 @@ public class FrozenExistenceDeciderIT extends AbstractFrozenAutoscalingIntegTest
             String[] indices = indices();
             assertThat(indices, arrayContaining(PARTIAL_INDEX_NAME));
             assertThat(indices, not(arrayContaining(INDEX_NAME)));
-        });
+        }, 30, TimeUnit.SECONDS);
         ensureGreen();
     }
 


### PR DESCRIPTION
It looks like 10 seconds is always enough on CI to move all the indices to the cold tier.

Fixes https://github.com/elastic/elasticsearch/issues/89082

