### PR TITLE
Fix RandomSamplerAggregatorTests testAggregationSamplingNestedAggsScaled test failure

### DIFF
--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/sampler/random/RandomSamplerAggregatorTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/sampler/random/RandomSamplerAggregatorTests.java
@@ -94,10 +94,18 @@ public class RandomSamplerAggregatorTests extends AggregatorTestCase {
                 long outerFilterDocCount = agg.getDocCount();
                 Filter innerAgg = agg.getAggregations().get("filter_inner");
                 long innerFilterDocCount = innerAgg.getDocCount();
-                // subaggs should be scaled along with upper level aggs
-                assertThat(outerFilterDocCount, equalTo(innerFilterDocCount));
-                // sampled doc count is NOT scaled, and thus should be lower
-                assertThat(outerFilterDocCount, greaterThan(sampledDocCount));
+                if (sampledDocCount == 0) {
+                    // in case 0 docs get sampled, which can rarely happen
+                    // in case the test index has many segments.
+                    assertThat(sampledDocCount, equalTo(0L));
+                    assertThat(innerFilterDocCount, equalTo(0L));
+                    assertThat(outerFilterDocCount, equalTo(0L));
+                } else {
+                    // subaggs should be scaled along with upper level aggs
+                    assertThat(outerFilterDocCount, equalTo(innerFilterDocCount));
+                    // sampled doc count is NOT scaled, and thus should be lower
+                    assertThat(outerFilterDocCount, greaterThan(sampledDocCount));
+                }
             },
             longField(NUMERIC_FIELD_NAME),
             keywordField(KEYWORD_FIELD_NAME)


### PR DESCRIPTION
This test indexes 150 documents. In case the test index has a high number of segments, it can happen that no documents get sampled. I think this is expected behaviour in this case.

A more detailed explanation of how this failure can happen: https://github.com/elastic/elasticsearch/issues/89818#issuecomment-1241696550

This commit adds a special case for this situation, by expecting other counts to be 0 if sampled doc count is 0 as well.

Closes #89818