### PR TITLE
Remove full cluster state from error logging in MasterService

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/service/MasterService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/service/MasterService.java
@@ -961,7 +961,7 @@ public class MasterService extends AbstractLifecycleComponent {
                     onPublicationSuccess.run();
                 }
             } catch (Exception e) {
-                logger.error(() -> format("exception thrown by listener while notifying of new cluster state:\n%s", newClusterState), e);
+                logger.error("exception thrown by listener while notifying of new cluster state", e);
             }
         }
 
@@ -978,7 +978,7 @@ public class MasterService extends AbstractLifecycleComponent {
                     onPublicationSuccess.run();
                 }
             } catch (Exception e) {
-                logger.error(() -> format("exception thrown by listener while notifying of unchanged cluster state:\n%s", clusterState), e);
+                logger.error("exception thrown by listener while notifying of unchanged cluster state", e);
             }
         }
 


### PR DESCRIPTION
I found a couple of these error logs in Cloud but was unable to interpret them because the cluster state string was so long that the logs would get truncated. For large deployments the string could be absolutely unmanageable in size even if it wasn't truncated. I think the error is vastly more valuable that the cluster state itself -> lets just log the error.
