### PR TITLE
Use a delta value when comparing double values

### DIFF
--- a/server/src/test/java/org/elasticsearch/search/aggregations/metrics/TDigestStateTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/metrics/TDigestStateTests.java
@@ -9,6 +9,7 @@
 package org.elasticsearch.search.aggregations.metrics;
 
 import org.elasticsearch.test.ESTestCase;
+import org.hamcrest.Matchers;
 
 import java.util.Arrays;
 
@@ -33,7 +34,7 @@ public class TDigestStateTests extends ESTestCase {
         for (double q : quantiles) {
             final double v = digest.quantile(q);
             logger.trace("q=" + q + ", v=" + v);
-            assertTrue(v >= prev);
+            assertThat(v, Matchers.either(Matchers.closeTo(prev, 0.0000001D)).or(Matchers.greaterThan(prev)));
             assertTrue("Unexpectedly low value: " + v, v >= 0.0);
             assertTrue("Unexpectedly high value: " + v, v <= 1.0);
             prev = v;


### PR DESCRIPTION
When comparing double values for greater than or equal we
need to handle equality of double values carefully. It might
happen that the ordering required by the assertion (v >= prev)
is affected by double precision artifacts. This means we can have
two consecutive values for which the assertion does not hold
just because the value of v is slightly less than the previous value
because of a double precision issue. For this reason we check
equality using a delta value.

Resolves #88435 