### PR TITLE
Remove ImmutableOpenMap from various metadata-related classes

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/metadata/Metadata.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/Metadata.java
@@ -1901,7 +1901,7 @@ public class Metadata extends AbstractCollection<IndexMetadata> implements Diffa
             final List<String> visibleOpenIndices = new ArrayList<>();
             final List<String> allClosedIndices = new ArrayList<>();
             final List<String> visibleClosedIndices = new ArrayList<>();
-            final Map<String, IndexMetadata> indicesMap = indices;
+            final Map<String, IndexMetadata> indicesMap = new HashMap<>(indices);
 
             int oldestIndexVersionId = Version.CURRENT.id;
             int totalNumberOfShards = 0;

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataDeleteIndexService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataDeleteIndexService.java
@@ -22,7 +22,6 @@ import org.elasticsearch.cluster.routing.RoutingTable;
 import org.elasticsearch.cluster.routing.allocation.AllocationService;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.Priority;
-import org.elasticsearch.common.collect.ImmutableOpenMap;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.set.Sets;
@@ -149,9 +148,9 @@ public class MetadataDeleteIndexService {
         final RestoreInProgress restoreInProgress = currentState.custom(RestoreInProgress.TYPE, RestoreInProgress.EMPTY);
         RestoreInProgress updatedRestoreInProgress = RestoreService.updateRestoreStateWithDeletedIndices(restoreInProgress, indices);
         if (updatedRestoreInProgress != restoreInProgress) {
-            ImmutableOpenMap.Builder<String, ClusterState.Custom> builder = ImmutableOpenMap.builder(customs);
+            Map<String, ClusterState.Custom> builder = new HashMap<>(customs);
             builder.put(RestoreInProgress.TYPE, updatedRestoreInProgress);
-            customs = builder.build();
+            customs = builder;
         }
 
         return allocationService.reroute(

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/DataStreamMetadataTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/DataStreamMetadataTests.java
@@ -8,7 +8,6 @@
 
 package org.elasticsearch.cluster.metadata;
 
-import org.elasticsearch.common.collect.ImmutableOpenMap;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.test.AbstractNamedWriteableTestCase;
 import org.elasticsearch.xcontent.ToXContent;
@@ -33,17 +32,20 @@ public class DataStreamMetadataTests extends AbstractNamedWriteableTestCase<Data
     @Override
     protected DataStreamMetadata createTestInstance() {
         if (randomBoolean()) {
-            return new DataStreamMetadata(ImmutableOpenMap.of(), ImmutableOpenMap.of());
+            return new DataStreamMetadata(Map.of(), Map.of());
         }
+
         Map<String, DataStream> dataStreams = IntStream.range(0, randomIntBetween(1, 5))
             .boxed()
-            .collect(Collectors.toUnmodifiableMap(i -> randomAlphaOfLength(5), i -> DataStreamTestHelper.randomInstance()));
+            .collect(Collectors.toMap(i -> randomAlphaOfLength(5), i -> DataStreamTestHelper.randomInstance()));
 
-        Map<String, DataStreamAlias> dataStreamsAliases = IntStream.range(0, randomIntBetween(1, 5))
-            .mapToObj(i -> DataStreamTestHelper.randomAliasInstance())
-            .collect(Collectors.toUnmodifiableMap(DataStreamAlias::getName, Function.identity()));
-
-        return new DataStreamMetadata(ImmutableOpenMap.builder(dataStreams).build(), ImmutableOpenMap.builder(dataStreamsAliases).build());
+        Map<String, DataStreamAlias> dataStreamsAliases = Map.of();
+        if (randomBoolean()) {
+            dataStreamsAliases = IntStream.range(0, randomIntBetween(1, 5))
+                .mapToObj(i -> DataStreamTestHelper.randomAliasInstance())
+                .collect(Collectors.toMap(DataStreamAlias::getName, Function.identity()));
+        }
+        return new DataStreamMetadata(dataStreams, dataStreamsAliases);
     }
 
     @Override

--- a/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/watch/WatchStoreUtilsTests.java
+++ b/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/watch/WatchStoreUtilsTests.java
@@ -10,12 +10,10 @@ package org.elasticsearch.xpack.watcher.watch;
 import org.elasticsearch.Version;
 import org.elasticsearch.cluster.metadata.AliasMetadata;
 import org.elasticsearch.cluster.metadata.DataStream;
-import org.elasticsearch.cluster.metadata.DataStreamAlias;
 import org.elasticsearch.cluster.metadata.DataStreamMetadata;
 import org.elasticsearch.cluster.metadata.DataStreamTestHelper;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.metadata.Metadata;
-import org.elasticsearch.common.collect.ImmutableOpenMap;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.index.Index;
 import org.elasticsearch.test.ESTestCase;
@@ -48,11 +46,7 @@ public class WatchStoreUtilsTests extends ESTestCase {
                 indexNames.stream().map(indexName -> new Index(indexName, IndexMetadata.INDEX_UUID_NA_VALUE)).collect(Collectors.toList())
             )
         );
-        ImmutableOpenMap<String, DataStreamAlias> dataStreamAliases = ImmutableOpenMap.of();
-        DataStreamMetadata dataStreamMetadata = new DataStreamMetadata(
-            ImmutableOpenMap.<String, DataStream>builder().putAllFromMap(dataStreams).build(),
-            dataStreamAliases
-        );
+        DataStreamMetadata dataStreamMetadata = new DataStreamMetadata(dataStreams, Map.of());
         customsBuilder.put(DataStreamMetadata.TYPE, dataStreamMetadata);
         metadataBuilder.customs(customsBuilder);
         IndexMetadata concreteIndex = WatchStoreUtils.getConcreteIndex(dataStreamName, metadataBuilder.build());


### PR DESCRIPTION
Remove `ImmutableOpenMap` from classes in `org.elasticsearch.cluster.metadata`