### PR TITLE
Fixing a typo in the health info API master stability code

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/coordination/CoordinationDiagnosticsService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/CoordinationDiagnosticsService.java
@@ -1116,7 +1116,7 @@ public class CoordinationDiagnosticsService implements ClusterStateListener {
                 );
             }
         }, e -> {
-            logger.warn("Exception connecting to master " + masterEligibleNode", e);
+            logger.warn("Exception connecting to master " + masterEligibleNode, e);
             responseConsumer.accept(responseTransformationFunction.apply(null, e));
         });
 

--- a/server/src/main/java/org/elasticsearch/cluster/coordination/CoordinationDiagnosticsService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/CoordinationDiagnosticsService.java
@@ -1116,7 +1116,7 @@ public class CoordinationDiagnosticsService implements ClusterStateListener {
                 );
             }
         }, e -> {
-            logger.warn("Exception connecting to master masterEligibleNode", e);
+            logger.warn("Exception connecting to master " + masterEligibleNode", e);
             responseConsumer.accept(responseTransformationFunction.apply(null, e));
         });
 


### PR DESCRIPTION
The log message now prints the node name.