### PR TITLE
Fix debug mode in MaxRetryAllocationDecider

### DIFF
--- a/docs/changelog/89973.yaml
+++ b/docs/changelog/89973.yaml
@@ -1,0 +1,5 @@
+pr: 89973
+summary: Fix debug mode in `MaxRetryAllocationDecider`
+area: Allocation
+type: bug
+issues: []

--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/MaxRetryAllocationDecider.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/MaxRetryAllocationDecider.java
@@ -61,7 +61,7 @@ public class MaxRetryAllocationDecider extends AllocationDecider {
     }
 
     private static Decision debugDecision(Decision decision, UnassignedInfo unassignedInfo, int numFailedAllocations, int maxRetry) {
-        if (decision.type() == Decision.Type.YES) {
+        if (decision.type() == Decision.Type.NO) {
             return Decision.single(
                 Decision.Type.NO,
                 NAME,

--- a/server/src/test/java/org/elasticsearch/cluster/routing/allocation/MaxRetryAllocationDeciderTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/allocation/MaxRetryAllocationDeciderTests.java
@@ -183,12 +183,12 @@ public class MaxRetryAllocationDeciderTests extends ESAllocationTestCase {
             assertThat(unassignedPrimary.unassignedInfo().getMessage(), containsString("boom" + i));
             // MaxRetryAllocationDecider#canForceAllocatePrimary should return YES decisions because canAllocate returns YES here
             assertEquals(
-                Decision.YES,
+                Decision.Type.YES,
                 new MaxRetryAllocationDecider().canForceAllocatePrimary(
                     unassignedPrimary,
                     null,
-                    new RoutingAllocation(null, clusterState, null, null, 0)
-                )
+                    newRoutingAllocation(clusterState)
+                ).type()
             );
         }
         // now we go and check that we are actually stick to unassigned on the next failure
@@ -207,12 +207,12 @@ public class MaxRetryAllocationDeciderTests extends ESAllocationTestCase {
             assertThat(unassignedPrimary.unassignedInfo().getMessage(), containsString("boom"));
             // MaxRetryAllocationDecider#canForceAllocatePrimary should return a NO decision because canAllocate returns NO here
             assertEquals(
-                Decision.NO,
+                Decision.Type.NO,
                 new MaxRetryAllocationDecider().canForceAllocatePrimary(
                     unassignedPrimary,
                     null,
-                    new RoutingAllocation(null, clusterState, null, null, 0)
-                )
+                    newRoutingAllocation(clusterState)
+                ).type()
             );
         }
 
@@ -247,12 +247,12 @@ public class MaxRetryAllocationDeciderTests extends ESAllocationTestCase {
         assertThat(unassignedPrimary.unassignedInfo().getMessage(), containsString("boom"));
         // bumped up the max retry count, so canForceAllocatePrimary should return a YES decision
         assertEquals(
-            Decision.YES,
+            Decision.Type.YES,
             new MaxRetryAllocationDecider().canForceAllocatePrimary(
                 routingTable.index("idx").shard(0).shard(0),
                 null,
-                new RoutingAllocation(null, clusterState, null, null, 0)
-            )
+                newRoutingAllocation(clusterState)
+            ).type()
         );
 
         // now we start the shard
@@ -279,13 +279,21 @@ public class MaxRetryAllocationDeciderTests extends ESAllocationTestCase {
         assertThat(unassignedPrimary.unassignedInfo().getMessage(), containsString("ZOOOMG"));
         // Counter reset, so MaxRetryAllocationDecider#canForceAllocatePrimary should return a YES decision
         assertEquals(
-            Decision.YES,
+            Decision.Type.YES,
             new MaxRetryAllocationDecider().canForceAllocatePrimary(
                 unassignedPrimary,
                 null,
-                new RoutingAllocation(null, clusterState, null, null, 0)
-            )
+                newRoutingAllocation(clusterState)
+            ).type()
         );
+    }
+
+    private RoutingAllocation newRoutingAllocation(ClusterState clusterState) {
+        final var routingAllocation = new RoutingAllocation(null, clusterState, null, null, 0);
+        if (randomBoolean()) {
+            routingAllocation.setDebugMode(randomFrom(RoutingAllocation.DebugMode.values()));
+        }
+        return routingAllocation;
     }
 
 }

--- a/server/src/test/java/org/elasticsearch/cluster/routing/allocation/MaxRetryAllocationDeciderTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/allocation/MaxRetryAllocationDeciderTests.java
@@ -184,11 +184,7 @@ public class MaxRetryAllocationDeciderTests extends ESAllocationTestCase {
             // MaxRetryAllocationDecider#canForceAllocatePrimary should return YES decisions because canAllocate returns YES here
             assertEquals(
                 Decision.Type.YES,
-                new MaxRetryAllocationDecider().canForceAllocatePrimary(
-                    unassignedPrimary,
-                    null,
-                    newRoutingAllocation(clusterState)
-                ).type()
+                new MaxRetryAllocationDecider().canForceAllocatePrimary(unassignedPrimary, null, newRoutingAllocation(clusterState)).type()
             );
         }
         // now we go and check that we are actually stick to unassigned on the next failure
@@ -208,11 +204,7 @@ public class MaxRetryAllocationDeciderTests extends ESAllocationTestCase {
             // MaxRetryAllocationDecider#canForceAllocatePrimary should return a NO decision because canAllocate returns NO here
             assertEquals(
                 Decision.Type.NO,
-                new MaxRetryAllocationDecider().canForceAllocatePrimary(
-                    unassignedPrimary,
-                    null,
-                    newRoutingAllocation(clusterState)
-                ).type()
+                new MaxRetryAllocationDecider().canForceAllocatePrimary(unassignedPrimary, null, newRoutingAllocation(clusterState)).type()
             );
         }
 
@@ -280,11 +272,7 @@ public class MaxRetryAllocationDeciderTests extends ESAllocationTestCase {
         // Counter reset, so MaxRetryAllocationDecider#canForceAllocatePrimary should return a YES decision
         assertEquals(
             Decision.Type.YES,
-            new MaxRetryAllocationDecider().canForceAllocatePrimary(
-                unassignedPrimary,
-                null,
-                newRoutingAllocation(clusterState)
-            ).type()
+            new MaxRetryAllocationDecider().canForceAllocatePrimary(unassignedPrimary, null, newRoutingAllocation(clusterState)).type()
         );
     }
 


### PR DESCRIPTION
In #62275 we refactored this code a bit and inadvertently reversed the sense of this conditional when running in debug mode. This commit fixes the mistake.