### PR TITLE
top_metrics: consistently allow sorting by size>1

### DIFF
--- a/docs/changelog/89974.yaml
+++ b/docs/changelog/89974.yaml
@@ -1,0 +1,6 @@
+pr: 89974
+summary: "Top_metrics: consistently allow sorting by size>1"
+area: Aggregations
+type: bug
+issues:
+ - 86663

--- a/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/topmetrics/TopMetricsAggregator.java
+++ b/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/topmetrics/TopMetricsAggregator.java
@@ -91,9 +91,6 @@ class TopMetricsAggregator extends NumericMetricsAggregator.MultiValue {
 
     @Override
     public boolean hasMetric(String name) {
-        if (size != 1) {
-            throw new IllegalArgumentException("[top_metrics] can only the be target if [size] is [1] but was [" + size + "]");
-        }
         for (MetricValues values : metrics.values) {
             if (values.name.equals(name)) {
                 return true;
@@ -104,14 +101,7 @@ class TopMetricsAggregator extends NumericMetricsAggregator.MultiValue {
 
     @Override
     public double metric(String name, long owningBucketOrd) {
-        assert size == 1;
-        /*
-         * Since size is always 1 we know that the index into the values
-         * array is same same as the bucket ordinal. Also, this will always
-         * be called after we've collected a bucket, so it won't just fetch
-         * garbage.
-         */
-        return metrics.metric(name, owningBucketOrd);
+        return metrics.metric(name, owningBucketOrd * size);
     }
 
     @Override

--- a/x-pack/plugin/analytics/src/test/java/org/elasticsearch/xpack/analytics/topmetrics/TopMetricsAggregatorTests.java
+++ b/x-pack/plugin/analytics/src/test/java/org/elasticsearch/xpack/analytics/topmetrics/TopMetricsAggregatorTests.java
@@ -333,7 +333,7 @@ public class TopMetricsAggregatorTests extends AggregatorTestCase {
         TopMetricsAggregationBuilder builder = simpleBuilder(new FieldSortBuilder("s").order(SortOrder.ASC));
         TermsAggregationBuilder terms = new TermsAggregationBuilder("terms").field("c")
             .subAggregation(builder)
-            .order(BucketOrder.aggregation("test", "m",true));
+            .order(BucketOrder.aggregation("test", "m", true));
         Terms result = (Terms) collect(terms, new MatchAllDocsQuery(), writer -> {
             writer.addDocument(Arrays.asList(doubleField("c", 1.0), doubleField("s", 1.0), doubleField("m", 9.0)));
             writer.addDocument(Arrays.asList(doubleField("c", 1.0), doubleField("s", 2.0), doubleField("m", 3.0)));
@@ -355,7 +355,7 @@ public class TopMetricsAggregatorTests extends AggregatorTestCase {
         TopMetricsAggregationBuilder builder = simpleBuilder(new FieldSortBuilder("s").order(SortOrder.ASC), 2);
         TermsAggregationBuilder terms = new TermsAggregationBuilder("terms").field("c")
             .subAggregation(builder)
-            .order(BucketOrder.aggregation("test", "m",true));
+            .order(BucketOrder.aggregation("test", "m", true));
         Terms result = (Terms) collect(terms, new MatchAllDocsQuery(), writer -> {
             writer.addDocument(Arrays.asList(doubleField("c", 1.0), doubleField("s", 1.0), doubleField("m", 9.0)));
             writer.addDocument(Arrays.asList(doubleField("c", 1.0), doubleField("s", 2.0), doubleField("m", 3.0)));

--- a/x-pack/plugin/analytics/src/test/java/org/elasticsearch/xpack/analytics/topmetrics/TopMetricsAggregatorTests.java
+++ b/x-pack/plugin/analytics/src/test/java/org/elasticsearch/xpack/analytics/topmetrics/TopMetricsAggregatorTests.java
@@ -53,6 +53,7 @@ import org.elasticsearch.search.aggregations.AggregationBuilder;
 import org.elasticsearch.search.aggregations.AggregationExecutionContext;
 import org.elasticsearch.search.aggregations.Aggregator;
 import org.elasticsearch.search.aggregations.AggregatorTestCase;
+import org.elasticsearch.search.aggregations.BucketOrder;
 import org.elasticsearch.search.aggregations.CardinalityUpperBound;
 import org.elasticsearch.search.aggregations.InternalAggregation;
 import org.elasticsearch.search.aggregations.LeafBucketCollector;
@@ -286,7 +287,7 @@ public class TopMetricsAggregatorTests extends AggregatorTestCase {
         }, geoPointAndDoubleField());
     }
 
-    public void testSortByGeoDistancDescending() throws IOException {
+    public void testSortByGeoDistanceDescending() throws IOException {
         TopMetricsAggregationBuilder builder = simpleBuilder(new GeoDistanceSortBuilder("s", 35.7796, 78.6382).order(SortOrder.DESC));
         InternalTopMetrics result = collectFromNewYorkAndLA(builder);
         assertThat(result.getSortOrder(), equalTo(SortOrder.DESC));
@@ -326,6 +327,50 @@ public class TopMetricsAggregatorTests extends AggregatorTestCase {
         InternalTopMetrics top2 = bucket2.getAggregations().get("test");
         assertThat(top2.getSortOrder(), equalTo(SortOrder.ASC));
         assertThat(top2.getTopMetrics(), equalTo(singletonList(top(4.0, 9.0))));
+    }
+
+    public void testTermsSortedBySingle() throws IOException {
+        TopMetricsAggregationBuilder builder = simpleBuilder(new FieldSortBuilder("s").order(SortOrder.ASC));
+        TermsAggregationBuilder terms = new TermsAggregationBuilder("terms").field("c")
+            .subAggregation(builder)
+            .order(BucketOrder.aggregation("test", "m",true));
+        Terms result = (Terms) collect(terms, new MatchAllDocsQuery(), writer -> {
+            writer.addDocument(Arrays.asList(doubleField("c", 1.0), doubleField("s", 1.0), doubleField("m", 9.0)));
+            writer.addDocument(Arrays.asList(doubleField("c", 1.0), doubleField("s", 2.0), doubleField("m", 3.0)));
+            writer.addDocument(Arrays.asList(doubleField("c", 2.0), doubleField("s", 4.0), doubleField("m", 2.0)));
+        }, numberFieldType(NumberType.DOUBLE, "c"), numberFieldType(NumberType.DOUBLE, "s"), numberFieldType(NumberType.DOUBLE, "m"));
+        Terms.Bucket bucket1 = result.getBuckets().get(0);
+        assertThat(bucket1.getKey(), equalTo(2.0));
+        InternalTopMetrics top1 = bucket1.getAggregations().get("test");
+        assertThat(top1.getSortOrder(), equalTo(SortOrder.ASC));
+        assertThat(top1.getTopMetrics(), equalTo(singletonList(top(4.0, 2.0))));
+        Terms.Bucket bucket2 = result.getBuckets().get(1);
+        assertThat(bucket2.getKey(), equalTo(1.0));
+        InternalTopMetrics top2 = bucket2.getAggregations().get("test");
+        assertThat(top2.getSortOrder(), equalTo(SortOrder.ASC));
+        assertThat(top2.getTopMetrics(), equalTo(singletonList(top(1.0, 9.0))));
+    }
+
+    public void testTermsSortedByMulti() throws IOException {
+        TopMetricsAggregationBuilder builder = simpleBuilder(new FieldSortBuilder("s").order(SortOrder.ASC), 2);
+        TermsAggregationBuilder terms = new TermsAggregationBuilder("terms").field("c")
+            .subAggregation(builder)
+            .order(BucketOrder.aggregation("test", "m",true));
+        Terms result = (Terms) collect(terms, new MatchAllDocsQuery(), writer -> {
+            writer.addDocument(Arrays.asList(doubleField("c", 1.0), doubleField("s", 1.0), doubleField("m", 9.0)));
+            writer.addDocument(Arrays.asList(doubleField("c", 1.0), doubleField("s", 2.0), doubleField("m", 3.0)));
+            writer.addDocument(Arrays.asList(doubleField("c", 2.0), doubleField("s", 4.0), doubleField("m", 2.0)));
+        }, numberFieldType(NumberType.DOUBLE, "c"), numberFieldType(NumberType.DOUBLE, "s"), numberFieldType(NumberType.DOUBLE, "m"));
+        Terms.Bucket bucket1 = result.getBuckets().get(0);
+        assertThat(bucket1.getKey(), equalTo(2.0));
+        InternalTopMetrics top1 = bucket1.getAggregations().get("test");
+        assertThat(top1.getSortOrder(), equalTo(SortOrder.ASC));
+        assertThat(top1.getTopMetrics(), equalTo(singletonList(top(4.0, 2.0))));
+        Terms.Bucket bucket2 = result.getBuckets().get(1);
+        assertThat(bucket2.getKey(), equalTo(1.0));
+        InternalTopMetrics top2 = bucket2.getAggregations().get("test");
+        assertThat(top2.getSortOrder(), equalTo(SortOrder.ASC));
+        assertThat(top2.getTopMetrics(), equalTo(List.of(top(1.0, 9.0), top(2.0, 3.0))));
     }
 
     public void testTonsOfBucketsTriggersBreaker() throws IOException {

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/analytics/nested_top_metrics_sort.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/analytics/nested_top_metrics_sort.yml
@@ -969,7 +969,6 @@ teardown:
             search.aggs.rewrite_to_filter_by_filter: false
 
   - do:
-      catch: /Invalid aggregation order path \[field_exists>top_metrics\[score\]\]. \[top_metrics\] can only the be target if \[size\] is \[1\] but was \[2\]/
       search:
         index: test_order_by_top_metrics
         body:
@@ -1001,6 +1000,59 @@ teardown:
                         size: 2
                         sort:
                           order_date: desc
+
+  - match: { hits.total.value: 16 }
+  - match: { hits.total.relation: "eq" }
+  - length: { aggregations.name.buckets: 5 }
+
+  - match: { aggregations.name.buckets.0.key: "sophia" }
+  - match: { aggregations.name.buckets.0.doc_count: 3 }
+  - match: { aggregations.name.buckets.0.field_exists.doc_count: 3 }
+  - length: { aggregations.name.buckets.0.field_exists.top_metrics.top: 2 }
+  - length: { aggregations.name.buckets.0.field_exists.top_metrics.top.0.sort: 1 }
+  - match: { aggregations.name.buckets.0.field_exists.top_metrics.top.0.sort.0: "2021-12-11T12:13:00.000Z" }
+  - match: { aggregations.name.buckets.0.field_exists.top_metrics.top.0.metrics.score: 3 }
+  - length: { aggregations.name.buckets.0.field_exists.top_metrics.top.1.sort: 1 }
+  - match: { aggregations.name.buckets.0.field_exists.top_metrics.top.1.sort.0: "2021-10-24T18:37:00.000Z" }
+  - match: { aggregations.name.buckets.0.field_exists.top_metrics.top.1.metrics.score: 9 }
+
+  - match: { aggregations.name.buckets.1.key: "bruce" }
+  - match: { aggregations.name.buckets.1.doc_count: 1 }
+  - match: { aggregations.name.buckets.1.field_exists.doc_count: 1 }
+  - length: { aggregations.name.buckets.1.field_exists.top_metrics.top: 1 }
+  - length: { aggregations.name.buckets.1.field_exists.top_metrics.top.0.sort: 1 }
+  - match: { aggregations.name.buckets.1.field_exists.top_metrics.top.0.sort.0: "2021-08-29T18:47:00.000Z" }
+  - match: { aggregations.name.buckets.1.field_exists.top_metrics.top.0.metrics.score: 4 }
+
+  - match: { aggregations.name.buckets.2.key: "daniel" }
+  - match: { aggregations.name.buckets.2.doc_count: 3 }
+  - match: { aggregations.name.buckets.2.field_exists.doc_count: 3 }
+  - length: { aggregations.name.buckets.2.field_exists.top_metrics.top: 2 }
+  - length: { aggregations.name.buckets.2.field_exists.top_metrics.top.0.sort: 1 }
+  - match: { aggregations.name.buckets.2.field_exists.top_metrics.top.0.sort.0: "2021-11-09T17:29:00.000Z" }
+  - match: { aggregations.name.buckets.2.field_exists.top_metrics.top.0.metrics.score: 5 }
+  - length: { aggregations.name.buckets.2.field_exists.top_metrics.top.1.sort: 1 }
+  - match: { aggregations.name.buckets.2.field_exists.top_metrics.top.1.sort.0: "2021-08-09T17:22:00.000Z" }
+  - match: { aggregations.name.buckets.2.field_exists.top_metrics.top.1.metrics.score: 3 }
+
+  - match: { aggregations.name.buckets.3.key: "mike" }
+  - match: { aggregations.name.buckets.3.doc_count: 1 }
+  - match: { aggregations.name.buckets.3.field_exists.doc_count: 1 }
+  - length: { aggregations.name.buckets.3.field_exists.top_metrics.top: 1 }
+  - length: { aggregations.name.buckets.3.field_exists.top_metrics.top.0.sort: 1 }
+  - match: { aggregations.name.buckets.3.field_exists.top_metrics.top.0.sort.0: "2021-11-11T15:22:00.000Z" }
+  - match: { aggregations.name.buckets.3.field_exists.top_metrics.top.0.metrics.score: 5 }
+
+  - match: { aggregations.name.buckets.4.key: "charlie" }
+  - match: { aggregations.name.buckets.4.doc_count: 3 }
+  - match: { aggregations.name.buckets.4.field_exists.doc_count: 3 }
+  - length: { aggregations.name.buckets.4.field_exists.top_metrics.top: 2 }
+  - length: { aggregations.name.buckets.4.field_exists.top_metrics.top.0.sort: 1 }
+  - match: { aggregations.name.buckets.4.field_exists.top_metrics.top.0.sort.0: "2021-12-10T19:33:00.000Z" }
+  - match: { aggregations.name.buckets.4.field_exists.top_metrics.top.0.metrics.score: 6 }
+  - length: { aggregations.name.buckets.4.field_exists.top_metrics.top.1.sort: 1 }
+  - match: { aggregations.name.buckets.4.field_exists.top_metrics.top.1.sort.0: "2021-11-22T18:47:00.000Z" }
+  - match: { aggregations.name.buckets.4.field_exists.top_metrics.top.1.metrics.score: 8 }
 
 ---
 "terms order by top metrics missing metric rewrite_to_filter_by_filter false":


### PR DESCRIPTION
This allows aggregations like `terms` to sort by `top_metrics` aggs who's size is `> 1`. In that case we take the metric with the top sort value. This has been supported when rewriting as filter-by-filter for a while, but not in the compatible collection mode.

Closes #86663
