### PR TITLE
TrackFailedAllocationNodesTests needs local master node

### DIFF
--- a/server/src/test/java/org/elasticsearch/cluster/routing/allocation/TrackFailedAllocationNodesTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/allocation/TrackFailedAllocationNodesTests.java
@@ -34,12 +34,13 @@ public class TrackFailedAllocationNodesTests extends ESAllocationTestCase {
         int maxRetries = MaxRetryAllocationDecider.SETTING_ALLOCATION_MAX_RETRY.get(Settings.EMPTY);
         AllocationService allocationService = createAllocationService();
         Metadata metadata = Metadata.builder()
-            .put(IndexMetadata.builder("idx").settings(settings(Version.CURRENT)).numberOfShards(1).numberOfReplicas(0))
+            .put(IndexMetadata.builder("idx").settings(settings(Version.CURRENT)).numberOfShards(1).numberOfReplicas(1))
             .build();
         DiscoveryNodes.Builder discoNodes = DiscoveryNodes.builder();
         for (int i = 0; i < 5; i++) {
             discoNodes.add(newNode("node-" + i));
         }
+        discoNodes.masterNodeId("node-0").localNodeId("node-0");
         ClusterState clusterState = ClusterState.builder(ClusterName.CLUSTER_NAME_SETTING.getDefault(Settings.EMPTY))
             .nodes(discoNodes)
             .metadata(metadata)


### PR DESCRIPTION
It doesn't make sense to reroute on a node other than the elected master, so this commit sets up the cluster state appropriately.

It also runs the test with a replica which makes no difference to the `BalancedShardsAllocator` but fixes compatibility with the desired balance feature branch.