### PR TITLE
[8.4] Fix debug mode in MaxRetryAllocationDecider (#89973)

### DIFF
--- a/docs/changelog/89973.yaml
+++ b/docs/changelog/89973.yaml
@@ -1,0 +1,5 @@
+pr: 89973
+summary: Fix debug mode in `MaxRetryAllocationDecider`
+area: Allocation
+type: bug
+issues: []

--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/MaxRetryAllocationDecider.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/MaxRetryAllocationDecider.java
@@ -61,7 +61,7 @@ public class MaxRetryAllocationDecider extends AllocationDecider {
     }
 
     private static Decision debugDecision(Decision decision, UnassignedInfo unassignedInfo, int numFailedAllocations, int maxRetry) {
-        if (decision.type() == Decision.Type.YES) {
+        if (decision.type() == Decision.Type.NO) {
             return Decision.single(
                 Decision.Type.NO,
                 NAME,

--- a/server/src/test/java/org/elasticsearch/cluster/routing/allocation/MaxRetryAllocationDeciderTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/allocation/MaxRetryAllocationDeciderTests.java
@@ -183,12 +183,8 @@ public class MaxRetryAllocationDeciderTests extends ESAllocationTestCase {
             assertThat(unassignedPrimary.unassignedInfo().getMessage(), containsString("boom" + i));
             // MaxRetryAllocationDecider#canForceAllocatePrimary should return YES decisions because canAllocate returns YES here
             assertEquals(
-                Decision.YES,
-                new MaxRetryAllocationDecider().canForceAllocatePrimary(
-                    unassignedPrimary,
-                    null,
-                    new RoutingAllocation(null, clusterState, null, null, 0)
-                )
+                Decision.Type.YES,
+                new MaxRetryAllocationDecider().canForceAllocatePrimary(unassignedPrimary, null, newRoutingAllocation(clusterState)).type()
             );
         }
         // now we go and check that we are actually stick to unassigned on the next failure
@@ -207,12 +203,8 @@ public class MaxRetryAllocationDeciderTests extends ESAllocationTestCase {
             assertThat(unassignedPrimary.unassignedInfo().getMessage(), containsString("boom"));
             // MaxRetryAllocationDecider#canForceAllocatePrimary should return a NO decision because canAllocate returns NO here
             assertEquals(
-                Decision.NO,
-                new MaxRetryAllocationDecider().canForceAllocatePrimary(
-                    unassignedPrimary,
-                    null,
-                    new RoutingAllocation(null, clusterState, null, null, 0)
-                )
+                Decision.Type.NO,
+                new MaxRetryAllocationDecider().canForceAllocatePrimary(unassignedPrimary, null, newRoutingAllocation(clusterState)).type()
             );
         }
 
@@ -247,12 +239,12 @@ public class MaxRetryAllocationDeciderTests extends ESAllocationTestCase {
         assertThat(unassignedPrimary.unassignedInfo().getMessage(), containsString("boom"));
         // bumped up the max retry count, so canForceAllocatePrimary should return a YES decision
         assertEquals(
-            Decision.YES,
+            Decision.Type.YES,
             new MaxRetryAllocationDecider().canForceAllocatePrimary(
                 routingTable.index("idx").shard(0).shard(0),
                 null,
-                new RoutingAllocation(null, clusterState, null, null, 0)
-            )
+                newRoutingAllocation(clusterState)
+            ).type()
         );
 
         // now we start the shard
@@ -279,13 +271,17 @@ public class MaxRetryAllocationDeciderTests extends ESAllocationTestCase {
         assertThat(unassignedPrimary.unassignedInfo().getMessage(), containsString("ZOOOMG"));
         // Counter reset, so MaxRetryAllocationDecider#canForceAllocatePrimary should return a YES decision
         assertEquals(
-            Decision.YES,
-            new MaxRetryAllocationDecider().canForceAllocatePrimary(
-                unassignedPrimary,
-                null,
-                new RoutingAllocation(null, clusterState, null, null, 0)
-            )
+            Decision.Type.YES,
+            new MaxRetryAllocationDecider().canForceAllocatePrimary(unassignedPrimary, null, newRoutingAllocation(clusterState)).type()
         );
+    }
+
+    private RoutingAllocation newRoutingAllocation(ClusterState clusterState) {
+        final var routingAllocation = new RoutingAllocation(null, clusterState, null, null, 0);
+        if (randomBoolean()) {
+            routingAllocation.setDebugMode(randomFrom(RoutingAllocation.DebugMode.values()));
+        }
+        return routingAllocation;
     }
 
 }


### PR DESCRIPTION
Backports the following commits to 8.4:
 - Fix debug mode in MaxRetryAllocationDecider (#89973)