### PR TITLE
[7.17] Unmute `RollupIT.testPutStartAndGetRollupJob()` test

### DIFF
--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/RollupIT.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/RollupIT.java
@@ -170,7 +170,6 @@ public class RollupIT extends ESRestHighLevelClientTestCase {
         assertThat(responseException.status().getStatus(), is(404));
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/67749")
     public void testPutStartAndGetRollupJob() throws Exception {
         // TODO expand this to also test with histogram and terms?
         final GroupConfig groups = new GroupConfig(new DateHistogramGroupConfig.CalendarInterval("date", DateHistogramInterval.DAY));


### PR DESCRIPTION
Test had been muted because of issue https://github.com/elastic/elasticsearch/issues/67749

This PR unmutes test `RollupIT.testPutStartAndGetRollupJob()` because most probably it has
been fixed by https://github.com/elastic/elasticsearch/pull/86992

Closes https://github.com/elastic/elasticsearch/issues/67749