### PR TITLE
[DOCS] Add `ssl.verification_mode` to secure settings

### DIFF
--- a/docs/reference/settings/common-defs.asciidoc
+++ b/docs/reference/settings/common-defs.asciidoc
@@ -11,34 +11,6 @@ List of paths to PEM encoded certificate files that should be trusted.
 This setting and `ssl.truststore.path` cannot be used at the same time.
 end::ssl-certificate-authorities[]
 
-tag::ssl-verification-mode[]
-Defines how to verify the certificates presented by the other party in the TLS 
-connection. This setting accepts the following values for TLS _clients_, but 
-should not be set for TLS _servers_:
-+
-.Valid values
-[%collapsible%open]
-=====
-`full`::
-(Required) Verifies that the certificate has a valid issue date that's 
-within the `not_before` and `not_after` dates, chains to a trusted 
-Certificate Authority (CA), and has a Subject Alternative Name (SAN, or `hostname`) 
-that matches the intended connection address.
-
-`certificate`::
-(Required) Checks the validity and trust chain (CA) of the certificate, but
-doesn't check the SAN (`hostname`).
-
-`none`::
-(Required) Performs no certificate validation.
-+
-IMPORTANT: Setting certificate validation to `none` is very dangerous. When set
-to this value, {es} performs no checks on the validity, trust chain, or `hostname`
-for a certificate. Only set this value if instructed by Elastic Support for
-debugging purposes.
-=====
-end::ssl-verification-mode[]
-
 tag::ssl-cipher-suites-values[]
 Supported cipher suites vary depending on which version of Java you use. For
 example, for version 12 the default value is `TLS_AES_256_GCM_SHA384`,
@@ -177,20 +149,28 @@ Otherwise, it defaults to `jks`.
 end::ssl-truststore-type[]
 
 tag::ssl-verification-mode-values[]
-Controls the verification of certificates.
 +
-Valid values are:
+.Valid values
+[%collapsible%open]
+=====
+`full`::
+Validates that the provided certificate: has an issue date that's
+within the `not_before` and `not_after` dates; chains to a trusted Certificate
+Authority (CA); has a `hostname` or IP address that matches the names within
+the certificate.
 
- * `full`, which verifies that the provided certificate is signed by a trusted
-authority (CA) and also verifies that the server's hostname (or IP address)
-matches the names identified within the certificate.
- * `certificate`, which verifies that the provided certificate is signed by a
-trusted authority (CA), but does not perform any hostname verification.
- * `none`, which performs _no verification_ of the server's certificate. This
-mode disables many of the security benefits of SSL/TLS and should only be used
-after very careful consideration. It is primarily intended as a temporary
-diagnostic mechanism when attempting to resolve TLS errors; its use on
-production clusters is strongly discouraged.
+`certificate`::
+Validates the provided certificate and verifies that it's signed by a 
+trusted authority (CA), but doesn't check the certificate `hostname`.
+
+`none`::
+Performs no certificate validation.
 +
-The default value is `full`.
+IMPORTANT: Setting certificate validation to `none` disables many security
+benefits of SSL/TLS, which is very dangerous. Only set this value if instructed
+by Elastic Support as a temporary diagnostic mechanism when attempting to
+resolve TLS errors.
+=====
++
+Defaults to `full`.
 end::ssl-verification-mode-values[]

--- a/docs/reference/settings/common-defs.asciidoc
+++ b/docs/reference/settings/common-defs.asciidoc
@@ -11,6 +11,34 @@ List of paths to PEM encoded certificate files that should be trusted.
 This setting and `ssl.truststore.path` cannot be used at the same time.
 end::ssl-certificate-authorities[]
 
+tag::ssl-verification-mode[]
+Defines how to verify the certificates presented by the other party in the TLS 
+connection. This setting accepts the following values for TLS _clients_, but 
+should not be set for TLS _servers_:
++
+.Valid values
+[%collapsible%open]
+=====
+`full`::
+(Required) Verifies that the certificate has a valid issue date that's 
+within the `not_before` and `not_after` dates, chains to a trusted 
+Certificate Authority (CA), and has a Subject Alternative Name (SAN, or `hostname`) 
+that matches the intended connection address.
+
+`certificate`::
+(Required) Checks the validity and trust chain (CA) of the certificate, but
+doesn't check the SAN (`hostname`).
+
+`none`::
+(Required) Performs no certificate validation.
++
+IMPORTANT: Setting certificate validation to `none` is very dangerous. When set
+to this value, {es} performs no checks on the validity, trust chain, or `hostname`
+for a certificate. Only set this value if instructed by Elastic Support for
+debugging purposes.
+=====
+end::ssl-verification-mode[]
+
 tag::ssl-cipher-suites-values[]
 Supported cipher suites vary depending on which version of Java you use. For
 example, for version 12 the default value is `TLS_AES_256_GCM_SHA384`,

--- a/docs/reference/settings/security-settings.asciidoc
+++ b/docs/reference/settings/security-settings.asciidoc
@@ -1501,6 +1501,8 @@ This setting cannot be used with `ssl.truststore.password`.
 // tag::saml-ssl-verification-mode-tag[]
 `ssl.verification_mode` {ess-icon}::
 (<<static-cluster-setting,Static>>)
+Indicates the type of verification when using `saml` to protect against man
+in the middle attacks and certificate forgery.
 include::{es-repo-dir}/settings/common-defs.asciidoc[tag=ssl-verification-mode-values]
 // end::saml-ssl-verification-mode-tag[]
 
@@ -1986,7 +1988,8 @@ You cannot use this setting and `ssl.truststore.password` at the same time.
 // tag::oidc-ssl-verification-mode-tag[]
 `ssl.verification_mode` {ess-icon}::
 (<<static-cluster-setting,Static>>)
-Controls the verification of certificates.
+Indicates the type of verification when using `oidc` to protect against man
+in the middle attacks and certificate forgery.
 include::{es-repo-dir}/settings/common-defs.asciidoc[tag=ssl-verification-mode-values]
 // end::oidc-ssl-verification-mode-tag[]
 
@@ -2348,7 +2351,8 @@ You cannot use this setting and `ssl.truststore.password` at the same time.
 // tag::jwt-ssl-verification-mode-tag[]
 `ssl.verification_mode` {ess-icon}::
 (<<static-cluster-setting,Static>>)
-Controls the verification of certificates.
+Indicates the type of verification when using `jwt` to protect against man
+in the middle attacks and certificate forgery.
 include::{es-repo-dir}/settings/common-defs.asciidoc[tag=ssl-verification-mode-values]
 // end::jwt-ssl-verification-mode-tag[]
 

--- a/docs/reference/settings/security-settings.asciidoc
+++ b/docs/reference/settings/security-settings.asciidoc
@@ -1501,8 +1501,7 @@ This setting cannot be used with `ssl.truststore.password`.
 // tag::saml-ssl-verification-mode-tag[]
 `ssl.verification_mode` {ess-icon}::
 (<<static-cluster-setting,Static>>)
-Indicates the type of verification when using `saml` to protect against man
-in the middle attacks and certificate forgery.
+Controls the verification of certificates.
 include::{es-repo-dir}/settings/common-defs.asciidoc[tag=ssl-verification-mode-values]
 // end::saml-ssl-verification-mode-tag[]
 
@@ -1988,8 +1987,7 @@ You cannot use this setting and `ssl.truststore.password` at the same time.
 // tag::oidc-ssl-verification-mode-tag[]
 `ssl.verification_mode` {ess-icon}::
 (<<static-cluster-setting,Static>>)
-Indicates the type of verification when using `oidc` to protect against man
-in the middle attacks and certificate forgery.
+Controls the verification of certificates.
 include::{es-repo-dir}/settings/common-defs.asciidoc[tag=ssl-verification-mode-values]
 // end::oidc-ssl-verification-mode-tag[]
 
@@ -2351,8 +2349,7 @@ You cannot use this setting and `ssl.truststore.password` at the same time.
 // tag::jwt-ssl-verification-mode-tag[]
 `ssl.verification_mode` {ess-icon}::
 (<<static-cluster-setting,Static>>)
-Indicates the type of verification when using `jwt` to protect against man
-in the middle attacks and certificate forgery.
+Controls the verification of certificates.
 include::{es-repo-dir}/settings/common-defs.asciidoc[tag=ssl-verification-mode-values]
 // end::jwt-ssl-verification-mode-tag[]
 

--- a/docs/reference/settings/ssl-settings.asciidoc
+++ b/docs/reference/settings/ssl-settings.asciidoc
@@ -74,6 +74,10 @@ include::{es-repo-dir}/settings/common-defs.asciidoc[tag=ssl-certificate]
 (<<static-cluster-setting,Static>>)
 include::{es-repo-dir}/settings/common-defs.asciidoc[tag=ssl-certificate-authorities]
 
++{ssl-prefix}.ssl.verification_mode+::
+(<<static-cluster-setting,Static>>)
+include::{es-repo-dir}/settings/common-defs.asciidoc[tag=ssl-verification-mode]
+
 ===== Java keystore files
 
 When using Java keystore files (JKS), which contain the private key, certificate

--- a/docs/reference/settings/ssl-settings.asciidoc
+++ b/docs/reference/settings/ssl-settings.asciidoc
@@ -26,12 +26,14 @@ Defaults to +{client-auth-default}+.
 endif::client-auth-default[]
 endif::server[]
 
-ifdef::verifies[]
+ifdef::server[]
 +{ssl-prefix}.ssl.verification_mode+::
 (<<static-cluster-setting,Static>>)
-Controls the verification of certificates.
+Defines how to verify the certificates presented by another party in the TLS 
+connection. This setting accepts the following values for TLS _clients_, but 
+should not be set for TLS _servers_:
 include::{es-repo-dir}/settings/common-defs.asciidoc[tag=ssl-verification-mode-values]
-endif::verifies[]
+endif::server[]
 
 +{ssl-prefix}.ssl.cipher_suites+::
 (<<static-cluster-setting,Static>>)
@@ -73,10 +75,6 @@ include::{es-repo-dir}/settings/common-defs.asciidoc[tag=ssl-certificate]
 +{ssl-prefix}.ssl.certificate_authorities+::
 (<<static-cluster-setting,Static>>)
 include::{es-repo-dir}/settings/common-defs.asciidoc[tag=ssl-certificate-authorities]
-
-+{ssl-prefix}.ssl.verification_mode+::
-(<<static-cluster-setting,Static>>)
-include::{es-repo-dir}/settings/common-defs.asciidoc[tag=ssl-verification-mode]
 
 ===== Java keystore files
 

--- a/docs/reference/settings/ssl-settings.asciidoc
+++ b/docs/reference/settings/ssl-settings.asciidoc
@@ -26,14 +26,12 @@ Defaults to +{client-auth-default}+.
 endif::client-auth-default[]
 endif::server[]
 
-ifdef::server[]
 +{ssl-prefix}.ssl.verification_mode+::
 (<<static-cluster-setting,Static>>)
 Defines how to verify the certificates presented by another party in the TLS 
 connection. This setting accepts the following values for TLS _clients_, but 
 should not be set for TLS _servers_:
 include::{es-repo-dir}/settings/common-defs.asciidoc[tag=ssl-verification-mode-values]
-endif::server[]
 
 +{ssl-prefix}.ssl.cipher_suites+::
 (<<static-cluster-setting,Static>>)

--- a/docs/reference/settings/ssl-settings.asciidoc
+++ b/docs/reference/settings/ssl-settings.asciidoc
@@ -29,7 +29,9 @@ endif::server[]
 +{ssl-prefix}.ssl.verification_mode+::
 (<<static-cluster-setting,Static>>)
 ifndef::verifies[]
-The SSL settings in `{ssl-prefix}.ssl` control a _server context_ for TLS. The use of `verification_mode` in a TLS _server_ is discouraged. 
+The SSL settings in `pass:a[{ssl-prefix}.ssl]` control a _server context_ for TLS, which
+defines the settings for the TLS connection. The use of `verification_mode` in
+a TLS _server_ is discouraged. 
 endif::verifies[]
 Defines how to verify the certificates presented by another party in the TLS 
 connection:

--- a/docs/reference/settings/ssl-settings.asciidoc
+++ b/docs/reference/settings/ssl-settings.asciidoc
@@ -28,9 +28,11 @@ endif::server[]
 
 +{ssl-prefix}.ssl.verification_mode+::
 (<<static-cluster-setting,Static>>)
+ifndef::verifies[]
+The SSL settings in `{ssl-prefix}.ssl` control a _server context_ for TLS. The use of `verification_mode` in a TLS _server_ is discouraged. 
+endif::verifies[]
 Defines how to verify the certificates presented by another party in the TLS 
-connection. This setting accepts the following values for TLS _clients_, but 
-should not be set for TLS _servers_:
+connection:
 include::{es-repo-dir}/settings/common-defs.asciidoc[tag=ssl-verification-mode-values]
 
 +{ssl-prefix}.ssl.cipher_suites+::

--- a/docs/reference/setup/install/docker/docker-compose.yml
+++ b/docs/reference/setup/install/docker/docker-compose.yml
@@ -84,7 +84,6 @@ services:
       - xpack.security.http.ssl.key=certs/es01/es01.key
       - xpack.security.http.ssl.certificate=certs/es01/es01.crt
       - xpack.security.http.ssl.certificate_authorities=certs/ca/ca.crt
-      - xpack.security.http.ssl.verification_mode=certificate
       - xpack.security.transport.ssl.enabled=true
       - xpack.security.transport.ssl.key=certs/es01/es01.key
       - xpack.security.transport.ssl.certificate=certs/es01/es01.crt
@@ -124,7 +123,6 @@ services:
       - xpack.security.http.ssl.key=certs/es02/es02.key
       - xpack.security.http.ssl.certificate=certs/es02/es02.crt
       - xpack.security.http.ssl.certificate_authorities=certs/ca/ca.crt
-      - xpack.security.http.ssl.verification_mode=certificate
       - xpack.security.transport.ssl.enabled=true
       - xpack.security.transport.ssl.key=certs/es02/es02.key
       - xpack.security.transport.ssl.certificate=certs/es02/es02.crt
@@ -164,7 +162,6 @@ services:
       - xpack.security.http.ssl.key=certs/es03/es03.key
       - xpack.security.http.ssl.certificate=certs/es03/es03.crt
       - xpack.security.http.ssl.certificate_authorities=certs/ca/ca.crt
-      - xpack.security.http.ssl.verification_mode=certificate
       - xpack.security.transport.ssl.enabled=true
       - xpack.security.transport.ssl.key=certs/es03/es03.key
       - xpack.security.transport.ssl.certificate=certs/es03/es03.crt


### PR DESCRIPTION
Adds documentation for the `xpack.security.http.ssl.verification_mode` setting in the secure settings page, and removes this setting from the `docker-compose.yml` file in the Docker installation guide.

Closes #85375