### PR TITLE
Adding node name to cluster_formation section of stable master health API results

### DIFF
--- a/docs/reference/health/health.asciidoc
+++ b/docs/reference/health/health.asciidoc
@@ -274,7 +274,7 @@ details have contents and a structure that is unique to each indicator.
     (string) The node id of a master-eligible node
 
 `name`::
-(string) The node name of a master-eligible node
+(Optional, string) The node name of a master-eligible node
 
 `cluster_formation_message`::
     (string) A detailed description explaining what went wrong with cluster formation, or why this node was

--- a/docs/reference/health/health.asciidoc
+++ b/docs/reference/health/health.asciidoc
@@ -273,6 +273,9 @@ details have contents and a structure that is unique to each indicator.
 `node_id`::
     (string) The node id of a master-eligible node
 
+`name`::
+(string) The node name of a master-eligible node
+
 `cluster_formation_message`::
     (string) A detailed description explaining what went wrong with cluster formation, or why this node was
     unable to join the cluster if it has formed.

--- a/server/src/main/java/org/elasticsearch/cluster/coordination/StableMasterHealthIndicatorService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/StableMasterHealthIndicatorService.java
@@ -9,6 +9,7 @@
 package org.elasticsearch.cluster.coordination;
 
 import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.health.Diagnosis;
 import org.elasticsearch.health.HealthIndicatorDetails;
 import org.elasticsearch.health.HealthIndicatorImpact;
@@ -20,6 +21,7 @@ import org.elasticsearch.health.ImpactArea;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 /**
  * This indicator reports the health of master stability.
@@ -48,6 +50,7 @@ public class StableMasterHealthIndicatorService implements HealthIndicatorServic
     );
 
     private final CoordinationDiagnosticsService coordinationDiagnosticsService;
+    private final ClusterService clusterService;
 
     // Keys for the details map:
     private static final String DETAILS_CURRENT_MASTER = "current_master";
@@ -73,8 +76,12 @@ public class StableMasterHealthIndicatorService implements HealthIndicatorServic
         new HealthIndicatorImpact(3, UNSTABLE_MASTER_BACKUP_IMPACT, List.of(ImpactArea.BACKUP))
     );
 
-    public StableMasterHealthIndicatorService(CoordinationDiagnosticsService coordinationDiagnosticsService) {
+    public StableMasterHealthIndicatorService(
+        CoordinationDiagnosticsService coordinationDiagnosticsService,
+        ClusterService clusterService
+    ) {
         this.coordinationDiagnosticsService = coordinationDiagnosticsService;
+        this.clusterService = clusterService;
     }
 
     @Override
@@ -162,12 +169,38 @@ public class StableMasterHealthIndicatorService implements HealthIndicatorServic
                     coordinationDiagnosticsDetails.nodeToClusterFormationDescriptionMap()
                         .entrySet()
                         .stream()
-                        .map(entry -> Map.of("node_id", entry.getKey(), CLUSTER_FORMATION_MESSAGE, entry.getValue()))
+                        .map(
+                            entry -> Map.of(
+                                "node_id",
+                                entry.getKey(),
+                                "name",
+                                getNameForNodeId(entry.getKey()),
+                                CLUSTER_FORMATION_MESSAGE,
+                                entry.getValue()
+                            )
+                        )
                         .toList()
                 );
             }
             return builder.endObject();
         };
+    }
+
+    /**
+     * Returns the name of the node with the given nodeId, as seen in the cluster state at this moment. The name of a node is optional,
+     * so if the node does not have a name (or the node with the given nodeId is no longer in the cluster state), an empty string is
+     * returned.
+     * @param nodeId The id of the node whose name is to be returned
+     * @return The current name of the node, or empty string if the node is not in the cluster state or does not have a name
+     */
+    private String getNameForNodeId(String nodeId) {
+        DiscoveryNode node = clusterService.state().nodes().get(nodeId);
+        if (node == null) {
+            return "";
+        } else {
+            String nodeName = node.getName();
+            return Objects.requireNonNullElse(nodeName, "");
+        }
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/cluster/coordination/StableMasterHealthIndicatorService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/StableMasterHealthIndicatorService.java
@@ -10,6 +10,7 @@ package org.elasticsearch.cluster.coordination;
 
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.core.Nullable;
 import org.elasticsearch.health.Diagnosis;
 import org.elasticsearch.health.HealthIndicatorDetails;
 import org.elasticsearch.health.HealthIndicatorImpact;
@@ -166,20 +167,14 @@ public class StableMasterHealthIndicatorService implements HealthIndicatorServic
             if (coordinationDiagnosticsDetails.nodeToClusterFormationDescriptionMap() != null) {
                 builder.field(
                     CLUSTER_FORMATION,
-                    coordinationDiagnosticsDetails.nodeToClusterFormationDescriptionMap()
-                        .entrySet()
-                        .stream()
-                        .map(
-                            entry -> Map.of(
-                                "node_id",
-                                entry.getKey(),
-                                "name",
-                                getNameForNodeId(entry.getKey()),
-                                CLUSTER_FORMATION_MESSAGE,
-                                entry.getValue()
-                            )
-                        )
-                        .toList()
+                    coordinationDiagnosticsDetails.nodeToClusterFormationDescriptionMap().entrySet().stream().map(entry -> {
+                        String nodeName = getNameForNodeId(entry.getKey());
+                        if (nodeName == null) {
+                            return Map.of("node_id", entry.getKey(), CLUSTER_FORMATION_MESSAGE, entry.getValue());
+                        } else {
+                            return Map.of("node_id", entry.getKey(), "name", nodeName, CLUSTER_FORMATION_MESSAGE, entry.getValue());
+                        }
+                    }).toList()
                 );
             }
             return builder.endObject();
@@ -188,18 +183,18 @@ public class StableMasterHealthIndicatorService implements HealthIndicatorServic
 
     /**
      * Returns the name of the node with the given nodeId, as seen in the cluster state at this moment. The name of a node is optional,
-     * so if the node does not have a name (or the node with the given nodeId is no longer in the cluster state), an empty string is
-     * returned.
+     * so if the node does not have a name (or the node with the given nodeId is no longer in the cluster state), null is returned.
      * @param nodeId The id of the node whose name is to be returned
-     * @return The current name of the node, or empty string if the node is not in the cluster state or does not have a name
+     * @return The current name of the node, or null if the node is not in the cluster state or does not have a name
      */
+    @Nullable
     private String getNameForNodeId(String nodeId) {
         DiscoveryNode node = clusterService.state().nodes().get(nodeId);
         if (node == null) {
-            return "";
+            return null;
         } else {
             String nodeName = node.getName();
-            return Objects.requireNonNullElse(nodeName, "");
+            return Objects.requireNonNullElse(nodeName, null);
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/node/Node.java
+++ b/server/src/main/java/org/elasticsearch/node/Node.java
@@ -1159,7 +1159,7 @@ public class Node implements Closeable {
         CoordinationDiagnosticsService coordinationDiagnosticsService
     ) {
         List<HealthIndicatorService> preflightHealthIndicatorServices = Collections.singletonList(
-            new StableMasterHealthIndicatorService(coordinationDiagnosticsService)
+            new StableMasterHealthIndicatorService(coordinationDiagnosticsService, clusterService)
         );
         var serverHealthIndicatorServices = List.of(
             new RepositoryIntegrityHealthIndicatorService(clusterService),

--- a/test/framework/src/main/java/org/elasticsearch/cluster/coordination/AbstractCoordinatorTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/cluster/coordination/AbstractCoordinatorTestCase.java
@@ -1281,7 +1281,7 @@ public class AbstractCoordinatorTestCase extends ESTestCase {
                     null,
                     getNamedWriteableRegistry()
                 );
-                stableMasterHealthIndicatorService = new StableMasterHealthIndicatorService(coordinationDiagnosticsService);
+                stableMasterHealthIndicatorService = new StableMasterHealthIndicatorService(coordinationDiagnosticsService, clusterService);
                 masterService.setClusterStatePublisher(coordinator);
                 final GatewayService gatewayService = new GatewayService(
                     settings,


### PR DESCRIPTION
This adds `name` to the `cluster_formation` results of the `details` section of the `master_is_stable` health indicator. The `cluster_formation` section already had `node_id`, but the `node_id` is a randomly-generated string and not very user-friendly. Node name is optional, but is usually set (and always in cloud), and is much more user-friendly. So for example the results will now look like this:

```
"details": {
                "current_master": {
                    "node_id": null,
                    "name": null
                },
                "recent_masters": [
                    {
                        "node_id": "31WBm9iTTRuMyWnBhWNUGA",
                        "name": "master-node-3"
                    }
                ],
                "cluster_formation": [
                    {
                        "node_id": "31WBm9iTTRuMyWnBhWNUGA",
                        "name": "master-node-3",
                        "cluster_formation_message": "master not discovered or elected yet, an election requires at least 2 nodes with ids from [nADkAeGsT-q12gw89Ga1FA, 31WBm9iTTRuMyWnBhWNUGA, w8v48JvuRsuDCjwBn8KbRw], have only discovered non-quorum [{master-node-3}{31WBm9iTTRuMyWnBhWNUGA}{lJmGYiTPS_W7AJU7csG_gQ}{master-node-3}{127.0.0.1}{127.0.0.1:9301}{dm}]; discovery will continue using [127.0.0.1:9300, 127.0.0.1:9302, 127.0.0.1:9303, 127.0.0.1:9304, 127.0.0.1:9305, [::1]:9300, [::1]:9302, [::1]:9303, [::1]:9304, [::1]:9305] from hosts providers and [{master-node-2}{nADkAeGsT-q12gw89Ga1FA}{logzEHuuTpqwJp-RWssBPw}{master-node-2}{127.0.0.1}{127.0.0.1:9300}{dm}, {master-node-3}{31WBm9iTTRuMyWnBhWNUGA}{lJmGYiTPS_W7AJU7csG_gQ}{master-node-3}{127.0.0.1}{127.0.0.1:9301}{dm}] from last-known cluster state; node term 39, last-accepted version 461 in term 39"
                    }
                ]
}
```
Relates to #89664 and #89842