### PR TITLE
[8.4] Use DRA artifacts for beats and ML dependencies (#89951)

### DIFF
--- a/distribution/docker/build.gradle
+++ b/distribution/docker/build.gradle
@@ -35,15 +35,22 @@ repositories {
 
   // Cloud builds bundle some beats
   ivy {
+    name = 'beats'
     if (useLocalArtifacts) {
       url "file://${buildDir}/artifacts/"
       patternLayout {
-        artifact '/[organisation]/[module]-[revision]-linux-[classifier].[ext]'
+        artifact '/[organisation]/[module]-[revision]-[classifier].[ext]'
       }
     } else {
-      url "https://${VersionProperties.isElasticsearchSnapshot() ? 'snapshots' : 'artifacts'}-no-kpi.elastic.co/"
+      url "https://artifacts-snapshot.elastic.co/"
       patternLayout {
-        artifact '/downloads/[organization]/[module]/[module]-[revision]-linux-[classifier].[ext]'
+        if (VersionProperties.isElasticsearchSnapshot()) {
+          artifact '/[organization]/[revision]/downloads/[organization]/[module]/[module]-[revision]-[classifier].[ext]'
+        } else {
+          // When building locally we always use snapshot artifacts even if passing `-Dbuild.snapshot=false`.
+          // Release builds are always done with a local repo.
+          artifact '/[organization]/[revision]-SNAPSHOT/downloads/[organization]/[module]/[module]-[revision]-SNAPSHOT-[classifier].[ext]'
+        }
       }
     }
     metadataSources { artifact() }
@@ -72,8 +79,8 @@ dependencies {
   log4jConfig project(path: ":distribution", configuration: 'log4jConfig')
   tini "krallin:tini:0.19.0:${tiniArch}"
   allPlugins project(path: ':plugins', configuration: 'allPlugins')
-  filebeat "beats:filebeat:${VersionProperties.elasticsearch}:${beatsArch}@tar.gz"
-  metricbeat "beats:metricbeat:${VersionProperties.elasticsearch}:${beatsArch}@tar.gz"
+  filebeat "beats:filebeat:${VersionProperties.elasticsearch}:linux-${beatsArch}@tar.gz"
+  metricbeat "beats:metricbeat:${VersionProperties.elasticsearch}:linux-${beatsArch}@tar.gz"
 }
 
 ext.expansions = { Architecture architecture, DockerBase base ->

--- a/x-pack/plugin/ml/build.gradle
+++ b/x-pack/plugin/ml/build.gradle
@@ -1,3 +1,5 @@
+import org.elasticsearch.gradle.VersionProperties
+
 apply plugin: 'elasticsearch.internal-es-plugin'
 apply plugin: 'elasticsearch.internal-cluster-test'
 apply plugin: 'elasticsearch.internal-test-artifact'
@@ -10,24 +12,38 @@ esplugin {
   extendedPlugins = ['x-pack-autoscaling', 'lang-painless']
 }
 
+def localRepo = providers.systemProperty('build.ml_cpp.repo').orNull
 
 repositories {
   exclusiveContent {
+    filter {
+      includeGroup 'org.elasticsearch.ml'
+    }
     forRepository {
       ivy {
         name "ml-cpp"
-        url providers.systemProperty('build.ml_cpp.repo').orElse('https://prelert-artifacts.s3.amazonaws.com').get()
         metadataSources {
           // no repository metadata, look directly for the artifact
           artifact()
         }
-        patternLayout {
-          artifact "maven/org/elasticsearch/ml/ml-cpp/[revision]/[module]-[revision](-[classifier]).[ext]"
+        if (localRepo) {
+          url localRepo
+          patternLayout {
+            artifact "maven/[orgPath]/[module]/[revision]/[module]-[revision](-[classifier]).[ext]"
+          }
+        } else {
+          url "https://artifacts-snapshot.elastic.co/"
+          patternLayout {
+            if (VersionProperties.isElasticsearchSnapshot()) {
+              artifact '/ml-cpp/[revision]/downloads/ml-cpp/[module]-[revision]-[classifier].[ext]'
+            } else {
+              // When building locally we always use snapshot artifacts even if passing `-Dbuild.snapshot=false`.
+              // Release builds are always done with a local repo.
+              artifact '/ml-cpp/[revision]-SNAPSHOT/downloads/ml-cpp/[module]-[revision]-SNAPSHOT-[classifier].[ext]'
+            }
+          }
         }
       }
-    }
-    filter {
-      includeGroup 'org.elasticsearch.ml'
     }
   }
 }


### PR DESCRIPTION
Backports the following commits to 8.4:
 - Use DRA artifacts for beats and ML dependencies (#89951)