### PR TITLE
Specify primary shard in TrackFailedAllocationNodesTests

### DIFF
--- a/server/src/test/java/org/elasticsearch/cluster/routing/allocation/TrackFailedAllocationNodesTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/allocation/TrackFailedAllocationNodesTests.java
@@ -70,12 +70,12 @@ public class TrackFailedAllocationNodesTests extends ESAllocationTestCase {
 
         // do not track the failed nodes while shard is started
         clusterState = startInitializingShardsAndReroute(allocationService, clusterState);
-        assertThat(clusterState.routingTable().index("idx").shard(0).shard(0).state(), equalTo(ShardRoutingState.STARTED));
+        assertThat(clusterState.routingTable().index("idx").shard(0).primaryShard().state(), equalTo(ShardRoutingState.STARTED));
         clusterState = allocationService.applyFailedShards(
             clusterState,
-            List.of(new FailedShard(clusterState.routingTable().index("idx").shard(0).shard(0), null, null, false)),
+            List.of(new FailedShard(clusterState.routingTable().index("idx").shard(0).primaryShard(), null, null, false)),
             List.of()
         );
-        assertThat(clusterState.routingTable().index("idx").shard(0).shard(0).unassignedInfo().getFailedNodeIds(), empty());
+        assertThat(clusterState.routingTable().index("idx").shard(0).primaryShard().unassignedInfo().getFailedNodeIds(), empty());
     }
 }


### PR DESCRIPTION
Followup to #89975 which added a replica shard to this test: the desired balance allocator might consider `shard(0)` to be the replica. This commit fixes that by being more specific and using `primaryShard()` instead.