### PR TITLE
[7.17] Use DRA artifacts for beats and ML dependencies (#89951)

### DIFF
--- a/x-pack/plugin/ml/build.gradle
+++ b/x-pack/plugin/ml/build.gradle
@@ -1,3 +1,5 @@
+import org.elasticsearch.gradle.VersionProperties
+
 apply plugin: 'elasticsearch.internal-es-plugin'
 apply plugin: 'elasticsearch.internal-cluster-test'
 apply plugin: 'elasticsearch.internal-test-artifact'
@@ -10,24 +12,38 @@ esplugin {
   extendedPlugins = ['x-pack-autoscaling', 'lang-painless']
 }
 
+def localRepo = providers.systemProperty('build.ml_cpp.repo').orNull
 
 repositories {
   exclusiveContent {
+    filter {
+      includeGroup 'org.elasticsearch.ml'
+    }
     forRepository {
       ivy {
         name "ml-cpp"
-        url providers.systemProperty('build.ml_cpp.repo').orElse('https://prelert-artifacts.s3.amazonaws.com').get()
         metadataSources {
           // no repository metadata, look directly for the artifact
           artifact()
         }
-        patternLayout {
-          artifact "maven/org/elasticsearch/ml/ml-cpp/[revision]/ml-cpp-[revision].[ext]"
+        if (localRepo) {
+          url localRepo
+          patternLayout {
+            artifact "maven/[orgPath]/[module]/[revision]/[module]-[revision](-[classifier]).[ext]"
+          }
+        } else {
+          url "https://artifacts-snapshot.elastic.co/"
+          patternLayout {
+            if (VersionProperties.isElasticsearchSnapshot()) {
+              artifact '/ml-cpp/[revision]/downloads/ml-cpp/[module]-[revision](-[classifier]).[ext]'
+            } else {
+              // When building locally we always use snapshot artifacts even if passing `-Dbuild.snapshot=false`.
+              // Release builds are always done with a local repo.
+              artifact '/ml-cpp/[revision]-SNAPSHOT/downloads/ml-cpp/[module]-[revision]-SNAPSHOT(-[classifier]).[ext]'
+            }
+          }
         }
       }
-    }
-    filter {
-      includeGroup 'org.elasticsearch.ml'
     }
   }
 }


### PR DESCRIPTION
Backports the following commits to 7.17:
 - Use DRA artifacts for beats and ML dependencies (#89951)