### PR TITLE
client can use  lz4 to compress request

### DIFF
--- a/client/rest/build.gradle
+++ b/client/rest/build.gradle
@@ -41,6 +41,7 @@ dependencies {
   api "org.apache.httpcomponents:httpcore-nio:${versions.httpcore}"
   api "commons-codec:commons-codec:${versions.commonscodec}"
   api "commons-logging:commons-logging:${versions.commonslogging}"
+  api 'org.lz4:lz4-java:1.8.0'
 
   testImplementation project(":client:test")
   testImplementation "com.carrotsearch.randomizedtesting:randomizedtesting-runner:${versions.randomizedrunner}"

--- a/client/rest/src/main/java/org/elasticsearch/client/RestClientBuilder.java
+++ b/client/rest/src/main/java/org/elasticsearch/client/RestClientBuilder.java
@@ -67,6 +67,7 @@ public final class RestClientBuilder {
     private NodeSelector nodeSelector = NodeSelector.ANY;
     private boolean strictDeprecationMode = false;
     private boolean compressionEnabled = false;
+    private CompressionScheme compressionScheme = CompressionScheme.gzip;
     private boolean metaHeaderEnabled = true;
 
     static {
@@ -262,6 +263,11 @@ public final class RestClientBuilder {
         return this;
     }
 
+    public RestClientBuilder setCompressionScheme(CompressionScheme compressionScheme) {
+        this.compressionScheme = compressionScheme;
+        return this;
+    }
+
     /**
      * Whether to send a {@code X-Elastic-Client-Meta} header that describes the runtime environment. It contains
      * information that is similar to what could be found in {@code User-Agent}. Using a separate header allows
@@ -292,6 +298,7 @@ public final class RestClientBuilder {
             nodeSelector,
             strictDeprecationMode,
             compressionEnabled,
+            compressionScheme,
             metaHeaderEnabled
         );
         httpClient.start();
@@ -325,6 +332,11 @@ public final class RestClientBuilder {
         } catch (NoSuchAlgorithmException e) {
             throw new IllegalStateException("could not create the default ssl context", e);
         }
+    }
+
+    public enum CompressionScheme {
+        lz4,
+        gzip
     }
 
     /**

--- a/client/rest/src/main/java/org/elasticsearch/client/ReuseBuffersLZ4BlockOutputStream.java
+++ b/client/rest/src/main/java/org/elasticsearch/client/ReuseBuffersLZ4BlockOutputStream.java
@@ -1,0 +1,275 @@
+/*
+ * Copyright 2020 Adrien Grand and the lz4-java contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.elasticsearch.client;
+
+import net.jpountz.lz4.LZ4BlockInputStream;
+import net.jpountz.lz4.LZ4Compressor;
+import net.jpountz.lz4.LZ4Factory;
+import net.jpountz.lz4.LZ4FrameOutputStream;
+import net.jpountz.util.SafeUtils;
+
+import java.io.FilterOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+
+/**
+ * This file is forked from https://github.com/lz4/lz4-java. In particular it forks the following file
+ * net.jpountz.lz4.LZ4BlockOutputStream.
+ *
+ * It modifies the original lz4-java code to allow the reuse of local thread local byte arrays. This prevents
+ * the need to allocate two new byte arrays everytime a new stream is created. For the Elasticsearch use case,
+ * a single thread should fully compress the stream in one go to avoid memory corruption.
+ *
+ * Additionally, it does not checksum (or write a check) for the data compressed. We do not read the checksum
+ * when decompressing in Elasticsearch.
+ *
+ * Streaming LZ4 (not compatible with the LZ4 Frame format).
+ * This class compresses data into fixed-size blocks of compressed data.
+ * This class uses its own format and is not compatible with the LZ4 Frame format.
+ * For interoperability with other LZ4 tools, use {@link LZ4FrameOutputStream},
+ * which is compatible with the LZ4 Frame format. This class remains for backward compatibility.
+ * @see LZ4BlockInputStream
+ * @see LZ4FrameOutputStream
+ */
+public class ReuseBuffersLZ4BlockOutputStream extends FilterOutputStream {
+    public static final byte[] EMPTY_BYTES = new byte[0];
+
+    private static class ArrayBox {
+        private byte[] uncompressed = EMPTY_BYTES;
+        private byte[] compressed = EMPTY_BYTES;
+        private boolean owned = false;
+
+        private void markOwnership(int uncompressedBlockSize, int compressedMaxSize) {
+            assert owned == false;
+            owned = true;
+            if (uncompressedBlockSize > uncompressed.length) {
+                uncompressed = new byte[uncompressedBlockSize];
+            }
+            if (compressedMaxSize > compressed.length) {
+                compressed = new byte[compressedMaxSize];
+            }
+        }
+
+        private void release() {
+            owned = false;
+        }
+    }
+
+    private static final ThreadLocal<ArrayBox> ARRAY_BOX = ThreadLocal.withInitial(ArrayBox::new);
+
+    static final byte[] MAGIC = new byte[] { 'L', 'Z', '4', 'B', 'l', 'o', 'c', 'k' };
+    static final int MAGIC_LENGTH = MAGIC.length;
+
+    static final int HEADER_LENGTH = MAGIC_LENGTH // magic bytes
+        + 1          // token
+        + 4          // compressed length
+        + 4          // decompressed length
+        + 4;         // checksum
+
+    static final int COMPRESSION_LEVEL_BASE = 10;
+    static final int MIN_BLOCK_SIZE = 64;
+    static final int MAX_BLOCK_SIZE = 1 << (COMPRESSION_LEVEL_BASE + 0x0F);
+
+    static final int COMPRESSION_METHOD_RAW = 0x10;
+    static final int COMPRESSION_METHOD_LZ4 = 0x20;
+
+    static final int DEFAULT_SEED = 0x9747b28c;
+
+    private static int compressionLevel(int blockSize) {
+        if (blockSize < MIN_BLOCK_SIZE) {
+            throw new IllegalArgumentException("blockSize must be >= " + MIN_BLOCK_SIZE + ", got " + blockSize);
+        } else if (blockSize > MAX_BLOCK_SIZE) {
+            throw new IllegalArgumentException("blockSize must be <= " + MAX_BLOCK_SIZE + ", got " + blockSize);
+        }
+        int compressionLevel = 32 - Integer.numberOfLeadingZeros(blockSize - 1); // ceil of log2
+        assert (1 << compressionLevel) >= blockSize;
+        assert blockSize * 2 > (1 << compressionLevel);
+        compressionLevel = Math.max(0, compressionLevel - COMPRESSION_LEVEL_BASE);
+        assert compressionLevel >= 0 && compressionLevel <= 0x0F;
+        return compressionLevel;
+    }
+
+    private final int blockSize;
+    private final int compressionLevel;
+    private final LZ4Compressor compressor;
+    private final ArrayBox arrayBox;
+    private final byte[] buffer;
+    private final byte[] compressedBuffer;
+    private final boolean syncFlush;
+    private boolean finished;
+    private int o;
+
+    /**
+     * Creates a new {@link OutputStream} with configurable block size. Large
+     * blocks require more memory at compression and decompression time but
+     * should improve the compression ratio.
+     *
+     * @param out         the {@link OutputStream} to feed
+     * @param blockSize   the maximum number of bytes to try to compress at once,
+     *                    must be &gt;= 64 and &lt;= 32 M
+     */
+    public ReuseBuffersLZ4BlockOutputStream(OutputStream out, int blockSize) {
+        super(out);
+        this.blockSize = blockSize;
+        this.compressor = LZ4Factory.safeInstance().fastCompressor();
+        ;
+        this.compressionLevel = compressionLevel(blockSize);
+        final int compressedBlockSize = HEADER_LENGTH + compressor.maxCompressedLength(blockSize);
+        this.arrayBox = ARRAY_BOX.get();
+        arrayBox.markOwnership(blockSize, compressedBlockSize);
+        this.buffer = arrayBox.uncompressed;
+        this.compressedBuffer = arrayBox.compressed;
+        this.syncFlush = false;
+        o = 0;
+        finished = false;
+        System.arraycopy(MAGIC, 0, compressedBuffer, 0, MAGIC_LENGTH);
+    }
+
+    private void ensureNotFinished() {
+        if (finished) {
+            throw new IllegalStateException("This stream is already closed");
+        }
+    }
+
+    @Override
+    public void write(int b) throws IOException {
+        ensureNotFinished();
+        if (o == blockSize) {
+            flushBufferedData();
+        }
+        buffer[o++] = (byte) b;
+    }
+
+    @Override
+    public void write(byte[] b, int off, int len) throws IOException {
+        SafeUtils.checkRange(b, off, len);
+        ensureNotFinished();
+
+        while (o + len > blockSize) {
+            final int l = blockSize - o;
+            System.arraycopy(b, off, buffer, o, blockSize - o);
+            o = blockSize;
+            flushBufferedData();
+            off += l;
+            len -= l;
+        }
+        System.arraycopy(b, off, buffer, o, len);
+        o += len;
+    }
+
+    @Override
+    public void write(byte[] b) throws IOException {
+        ensureNotFinished();
+        write(b, 0, b.length);
+    }
+
+    @Override
+    public void close() throws IOException {
+        try {
+            if (finished == false) {
+                finish();
+            }
+            if (out != null) {
+                out.close();
+                out = null;
+            }
+        } finally {
+            arrayBox.release();
+        }
+    }
+
+    private void flushBufferedData() throws IOException {
+        if (o == 0) {
+            return;
+        }
+        int compressedLength = compressor.compress(buffer, 0, o, compressedBuffer, HEADER_LENGTH);
+        final int compressMethod;
+        if (compressedLength >= o) {
+            compressMethod = COMPRESSION_METHOD_RAW;
+            compressedLength = o;
+            System.arraycopy(buffer, 0, compressedBuffer, HEADER_LENGTH, o);
+        } else {
+            compressMethod = COMPRESSION_METHOD_LZ4;
+        }
+
+        compressedBuffer[MAGIC_LENGTH] = (byte) (compressMethod | compressionLevel);
+        writeIntLE(compressedLength, compressedBuffer, MAGIC_LENGTH + 1);
+        writeIntLE(o, compressedBuffer, MAGIC_LENGTH + 5);
+        // Write 0 for checksum. We do not read it on decompress.
+        writeIntLE(0, compressedBuffer, MAGIC_LENGTH + 9);
+        assert MAGIC_LENGTH + 13 == HEADER_LENGTH;
+        out.write(compressedBuffer, 0, HEADER_LENGTH + compressedLength);
+        o = 0;
+    }
+
+    /**
+     * Flushes this compressed {@link OutputStream}.
+     *
+     * If the stream has been created with <code>syncFlush=true</code>, pending
+     * data will be compressed and appended to the underlying {@link OutputStream}
+     * before calling {@link OutputStream#flush()} on the underlying stream.
+     * Otherwise, this method just flushes the underlying stream, so pending
+     * data might not be available for reading until {@link #finish()} or
+     * {@link #close()} is called.
+     */
+    @Override
+    public void flush() throws IOException {
+        if (out != null) {
+            if (syncFlush) {
+                flushBufferedData();
+            }
+            out.flush();
+        }
+    }
+
+    /**
+     * Same as {@link #close()} except that it doesn't close the underlying stream.
+     * This can be useful if you want to keep on using the underlying stream.
+     *
+     * @throws IOException if an I/O error occurs.
+     */
+    public void finish() throws IOException {
+        ensureNotFinished();
+        flushBufferedData();
+        compressedBuffer[MAGIC_LENGTH] = (byte) (COMPRESSION_METHOD_RAW | compressionLevel);
+        writeIntLE(0, compressedBuffer, MAGIC_LENGTH + 1);
+        writeIntLE(0, compressedBuffer, MAGIC_LENGTH + 5);
+        writeIntLE(0, compressedBuffer, MAGIC_LENGTH + 9);
+        assert MAGIC_LENGTH + 13 == HEADER_LENGTH;
+        out.write(compressedBuffer, 0, HEADER_LENGTH);
+        finished = true;
+        out.flush();
+    }
+
+    private static void writeIntLE(int i, byte[] buf, int off) {
+        buf[off++] = (byte) i;
+        buf[off++] = (byte) (i >>> 8);
+        buf[off++] = (byte) (i >>> 16);
+        buf[off++] = (byte) (i >>> 24);
+    }
+
+    @Override
+    public String toString() {
+        return getClass().getSimpleName() + "(out=" + out + ", blockSize=" + blockSize + ", compressor=" + compressor + ")";
+    }
+
+    public static int COMPRESS_BLOCK_SIZE = 128 * 1024;
+
+    public static OutputStream compressedOutputStream(OutputStream outputStream) {
+        return new ReuseBuffersLZ4BlockOutputStream(outputStream, COMPRESS_BLOCK_SIZE);
+    }
+}

--- a/client/rest/src/test/java/org/elasticsearch/client/ReuseBuffersLZ4BlockOutputStreamTests.java
+++ b/client/rest/src/test/java/org/elasticsearch/client/ReuseBuffersLZ4BlockOutputStreamTests.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.client;
+
+import org.elasticsearch.client.RestClient.ByteArrayInputOutputStream;
+import org.elasticsearch.client.util.LZ4Decompress;
+
+import java.io.OutputStream;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * @author xiaoping
+ * @date 2022/9/6
+ */
+public class ReuseBuffersLZ4BlockOutputStreamTests extends RestClientTestCase {
+    public void testLz4Compression() throws Exception {
+        try (ByteArrayInputOutputStream compress = new ByteArrayInputOutputStream(1024)) {
+            byte[] origin = randomBytes();
+            try (OutputStream outputStream = ReuseBuffersLZ4BlockOutputStream.compressedOutputStream(compress)) {
+                outputStream.write(origin);
+            }
+            byte[] bytes = compress.toByteArray();
+            LZ4Decompress customDecompress = new LZ4Decompress();
+            ByteArrayInputOutputStream decompress = new ByteArrayInputOutputStream(1024);
+            customDecompress.decode(bytes, decompress);
+            byte[] decompressBytes = decompress.toByteArray();
+            assertEquals(origin.length, decompressBytes.length);
+            for (int i = 0; i < origin.length; i++) {
+                assertEquals(origin[i], decompressBytes[i]);
+            }
+            decompress.close();
+        }
+    }
+
+    public byte[] randomBytes() {
+        StringBuilder stringBuilder = new StringBuilder();
+        for (int i = 0; i < randomIntBetween(1000, 2000); i++) {
+            int value = randomInt();
+            for (int j = 0; j < randomIntBetween(50, 100); j++) {
+                stringBuilder.append(value);
+            }
+        }
+        return stringBuilder.toString().getBytes();
+    }
+}

--- a/client/rest/src/test/java/org/elasticsearch/client/util/LZ4Decompress.java
+++ b/client/rest/src/test/java/org/elasticsearch/client/util/LZ4Decompress.java
@@ -1,0 +1,224 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.client.util;
+
+import net.jpountz.lz4.LZ4Exception;
+import net.jpountz.lz4.LZ4Factory;
+import net.jpountz.lz4.LZ4FastDecompressor;
+
+import java.io.OutputStream;
+import java.util.Locale;
+
+public class LZ4Decompress {
+
+    /**
+     * Magic number of LZ4 block.
+     */
+    static final long MAGIC_NUMBER = (long) 'L' << 56 | (long) 'Z' << 48 | (long) '4' << 40 | (long) 'B' << 32 | 'l' << 24 | 'o' << 16 | 'c'
+        << 8 | 'k';
+
+    static final int HEADER_LENGTH = 8 +  // magic number
+        1 +  // token
+        4 +  // compressed length
+        4 +  // decompressed length
+        4;   // checksum
+
+    /**
+     * Base value for compression level.
+     */
+    static final int COMPRESSION_LEVEL_BASE = 10;
+
+    static final int MAX_BLOCK_SIZE = 1 << COMPRESSION_LEVEL_BASE + 0x0F;   // 32 M
+
+    static final int BLOCK_TYPE_NON_COMPRESSED = 0x10;
+    static final int BLOCK_TYPE_COMPRESSED = 0x20;
+
+    private enum State {
+        INIT_BLOCK,
+        DECOMPRESS_DATA,
+        FINISHED,
+        CORRUPTED
+    }
+
+    private State currentState = State.INIT_BLOCK;
+
+    /**
+     * Underlying decompressor in use.
+     */
+    private LZ4FastDecompressor decompressor;
+
+    /**
+     * Type of current block.
+     */
+    private int blockType;
+
+    /**
+     * Compressed length of current incoming block.
+     */
+    private int compressedLength;
+
+    /**
+     * Decompressed length of current incoming block.
+     */
+    private int decompressedLength;
+
+    public LZ4Decompress() {
+        this.decompressor = LZ4Factory.safeInstance().fastDecompressor();
+    }
+
+    public static long readLong(byte[] bytes, int index) {
+        return (((long) readInt(bytes, index)) << 32) | (readInt(bytes, index + Integer.BYTES) & 0xFFFFFFFFL);
+    }
+
+    public static short readShort(byte[] bytes, int index) {
+        return (short) (((bytes[index] & 0xFF) << 8) | (bytes[index + 1] & 0xFF));
+    }
+
+    public static int readInt(byte[] bytes, int index) {
+        return ((bytes[index] & 0xFF) << 24) | ((bytes[index + 1] & 0xFF) << 16) | ((bytes[index + 2] & 0xFF) << 8) | (bytes[index + 3]
+            & 0xFF);
+    }
+
+    public void decode(byte[] in, OutputStream outputStream) throws Exception {
+        int currentIndex = 0;
+        while (true) {
+            try {
+                switch (currentState) {
+                    case INIT_BLOCK:
+                        if (in.length - currentIndex < HEADER_LENGTH) {
+                            return;
+                        }
+
+                    {
+                        final long magic = readLong(in, currentIndex);
+                        currentIndex += Long.BYTES;
+                        if (magic != MAGIC_NUMBER) {
+                            throw new IllegalStateException("unexpected block identifier");
+                        }
+
+                        final int token = in[currentIndex];
+                        currentIndex++;
+
+                        final int compressionLevel = (token & 0x0F) + COMPRESSION_LEVEL_BASE;
+                        int blockType = token & 0xF0;
+
+                        int compressedLength = Integer.reverseBytes(readInt(in, currentIndex));
+                        currentIndex += Integer.BYTES;
+                        if (compressedLength < 0 || compressedLength > MAX_BLOCK_SIZE) {
+                            throw new IllegalStateException(
+                                String.format(
+                                    Locale.ROOT,
+                                    "invalid compressedLength: %d (expected: 0-%d)",
+                                    compressedLength,
+                                    MAX_BLOCK_SIZE
+                                )
+                            );
+                        }
+
+                        int decompressedLength = Integer.reverseBytes(readInt(in, currentIndex));
+                        currentIndex += Integer.BYTES;
+                        final int maxDecompressedLength = 1 << compressionLevel;
+                        if (decompressedLength < 0 || decompressedLength > maxDecompressedLength) {
+                            throw new IllegalStateException(
+                                String.format(
+                                    Locale.ROOT,
+                                    "invalid decompressedLength: %d (expected: 0-%d)",
+                                    decompressedLength,
+                                    maxDecompressedLength
+                                )
+                            );
+                        }
+                        if (decompressedLength == 0 && compressedLength != 0
+                            || decompressedLength != 0 && compressedLength == 0
+                            || blockType == BLOCK_TYPE_NON_COMPRESSED && decompressedLength != compressedLength) {
+                            throw new IllegalStateException(
+                                String.format(
+                                    Locale.ROOT,
+                                    "stream corrupted: compressedLength(%d) and decompressedLength(%d) mismatch",
+                                    compressedLength,
+                                    decompressedLength
+                                )
+                            );
+                        }
+
+                        // Read int where checksum would normally be written
+                        readInt(in, currentIndex);
+                        currentIndex += Integer.BYTES;
+
+                        if (decompressedLength == 0) {
+                            currentState = State.FINISHED;
+                            decompressor = null;
+                            return;
+                        }
+
+                        this.blockType = blockType;
+                        this.compressedLength = compressedLength;
+                        this.decompressedLength = decompressedLength;
+                    }
+
+                        currentState = State.DECOMPRESS_DATA;
+                        break;
+                    case DECOMPRESS_DATA:
+                        if (in.length - currentIndex < HEADER_LENGTH) {
+                            return;
+                        }
+                        byte[] decompressed = new byte[decompressedLength];
+                        try {
+                            switch (blockType) {
+                                case BLOCK_TYPE_NON_COMPRESSED:
+                                    System.arraycopy(in, currentIndex, decompressed, 0, decompressedLength);
+                                    currentIndex += decompressedLength;
+                                    break;
+                                case BLOCK_TYPE_COMPRESSED:
+                                    decompressor.decompress(in, currentIndex, decompressed, 0, decompressedLength);
+                                    currentIndex += compressedLength;
+                                    break;
+                                default:
+                                    throw new IllegalStateException(
+                                        String.format(
+                                            Locale.ROOT,
+                                            "unexpected blockType: %d (expected: %d or %d)",
+                                            blockType,
+                                            BLOCK_TYPE_NON_COMPRESSED,
+                                            BLOCK_TYPE_COMPRESSED
+                                        )
+                                    );
+                            }
+                            outputStream.write(decompressed);
+                            currentState = State.INIT_BLOCK;
+                        } catch (LZ4Exception e) {
+                            throw new IllegalStateException(e);
+                        }
+                        break;
+                    case FINISHED:
+                        break;
+                    case CORRUPTED:
+                        throw new IllegalStateException("LZ4 stream corrupted.");
+                    default:
+                        throw new IllegalStateException();
+                }
+            } catch (Exception e) {
+                currentState = State.CORRUPTED;
+                throw e;
+            }
+        }
+    }
+
+}

--- a/docs/changelog/89988.yaml
+++ b/docs/changelog/89988.yaml
@@ -1,0 +1,5 @@
+pr: 89988
+summary: Client can use lz4 to compress request
+area: Client
+type: feature
+issues: []

--- a/modules/transport-netty4/src/main/java/module-info.java
+++ b/modules/transport-netty4/src/main/java/module-info.java
@@ -19,6 +19,7 @@ module org.elasticsearch.transport.netty4 {
     requires io.netty.handler;
     requires io.netty.transport;
     requires io.netty.codec.http;
+    requires org.lz4.java;
 
     exports org.elasticsearch.http.netty4;
     exports org.elasticsearch.transport.netty4;

--- a/modules/transport-netty4/src/main/java/org/elasticsearch/http/netty4/LZ4Decoder.java
+++ b/modules/transport-netty4/src/main/java/org/elasticsearch/http/netty4/LZ4Decoder.java
@@ -1,0 +1,231 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.http.netty4;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.handler.codec.ByteToMessageDecoder;
+import net.jpountz.lz4.LZ4Exception;
+import net.jpountz.lz4.LZ4FastDecompressor;
+
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.transport.Compression;
+
+import java.util.List;
+import java.util.Locale;
+
+public class LZ4Decoder extends ByteToMessageDecoder {
+    private static final ThreadLocal<byte[]> COMPRESSED = ThreadLocal.withInitial(() -> BytesRef.EMPTY_BYTES);
+
+    /**
+     * Magic number of LZ4 block.
+     */
+    static final long MAGIC_NUMBER = (long) 'L' << 56 | (long) 'Z' << 48 | (long) '4' << 40 | (long) 'B' << 32 | 'l' << 24 | 'o' << 16 | 'c'
+        << 8 | 'k';
+
+    static final int HEADER_LENGTH = 8 +  // magic number
+        1 +  // token
+        4 +  // compressed length
+        4 +  // decompressed length
+        4;   // checksum
+
+    /**
+     * Base value for compression level.
+     */
+    static final int COMPRESSION_LEVEL_BASE = 10;
+
+    static final int MAX_BLOCK_SIZE = 1 << COMPRESSION_LEVEL_BASE + 0x0F;   // 32 M
+
+    static final int BLOCK_TYPE_NON_COMPRESSED = 0x10;
+    static final int BLOCK_TYPE_COMPRESSED = 0x20;
+
+    private enum State {
+        INIT_BLOCK,
+        DECOMPRESS_DATA,
+        FINISHED,
+        CORRUPTED
+    }
+
+    private State currentState = State.INIT_BLOCK;
+
+    /**
+     * Underlying decompressor in use.
+     */
+    private LZ4FastDecompressor decompressor;
+
+    /**
+     * Type of current block.
+     */
+    private int blockType;
+
+    /**
+     * Compressed length of current incoming block.
+     */
+    private int compressedLength;
+
+    /**
+     * Decompressed length of current incoming block.
+     */
+    private int decompressedLength;
+
+    public LZ4Decoder() {
+        this.decompressor = Compression.Scheme.lz4Decompressor();
+    }
+
+    @Override
+    public void decode(ChannelHandlerContext ctx, ByteBuf in, List<Object> out) throws Exception {
+        try {
+            switch (currentState) {
+                case INIT_BLOCK:
+                    if (in.readableBytes() < HEADER_LENGTH) {
+                        return;
+                    }
+
+                {
+                    final long magic = in.readLong();
+                    if (magic != MAGIC_NUMBER) {
+                        throw new IllegalStateException("unexpected block identifier");
+                    }
+
+                    final int token = in.readByte();
+                    final int compressionLevel = (token & 0x0F) + COMPRESSION_LEVEL_BASE;
+                    int blockType = token & 0xF0;
+
+                    int compressedLength = Integer.reverseBytes(in.readInt());
+                    if (compressedLength < 0 || compressedLength > MAX_BLOCK_SIZE) {
+                        throw new IllegalStateException(
+                            String.format(Locale.ROOT, "invalid compressedLength: %d (expected: 0-%d)", compressedLength, MAX_BLOCK_SIZE)
+                        );
+                    }
+
+                    int decompressedLength = Integer.reverseBytes(in.readInt());
+                    final int maxDecompressedLength = 1 << compressionLevel;
+                    if (decompressedLength < 0 || decompressedLength > maxDecompressedLength) {
+                        throw new IllegalStateException(
+                            String.format(
+                                Locale.ROOT,
+                                "invalid decompressedLength: %d (expected: 0-%d)",
+                                decompressedLength,
+                                maxDecompressedLength
+                            )
+                        );
+                    }
+                    if (decompressedLength == 0 && compressedLength != 0
+                        || decompressedLength != 0 && compressedLength == 0
+                        || blockType == BLOCK_TYPE_NON_COMPRESSED && decompressedLength != compressedLength) {
+                        throw new IllegalStateException(
+                            String.format(
+                                Locale.ROOT,
+                                "stream corrupted: compressedLength(%d) and decompressedLength(%d) mismatch",
+                                compressedLength,
+                                decompressedLength
+                            )
+                        );
+                    }
+
+                    // Read int where checksum would normally be written
+                    in.readInt();
+
+                    if (decompressedLength == 0) {
+                        currentState = State.FINISHED;
+                        decompressor = null;
+                        break;
+                    }
+
+                    this.blockType = blockType;
+                    this.compressedLength = compressedLength;
+                    this.decompressedLength = decompressedLength;
+                }
+
+                    currentState = State.DECOMPRESS_DATA;
+                    break;
+                case DECOMPRESS_DATA:
+                    if (in.readableBytes() < this.compressedLength) {
+                        break;
+                    }
+                    ByteBuf decompressed = ctx.alloc().heapBuffer(decompressedLength);
+                    try {
+                        switch (blockType) {
+                            case BLOCK_TYPE_NON_COMPRESSED:
+                                in.readBytes(decompressed, decompressedLength);
+                                break;
+                            case BLOCK_TYPE_COMPRESSED:
+                                final byte[] compressed;
+                                final int compressedOffset;
+                                if (in.hasArray()) {
+                                    compressed = in.array();
+                                    compressedOffset = in.arrayOffset() + in.readerIndex();
+                                    in.skipBytes(this.compressedLength);
+                                } else {
+                                    compressed = getThreadLocalBuffer(COMPRESSED, this.compressedLength);
+                                    compressedOffset = 0;
+                                    in.readBytes(compressed, 0, this.compressedLength);
+                                }
+                                byte[] decompressedArray = decompressed.array();
+                                int writerIndex = decompressed.writerIndex();
+                                int outIndex = decompressed.arrayOffset() + writerIndex;
+                                decompressor.decompress(compressed, compressedOffset, decompressedArray, outIndex, decompressedLength);
+                                decompressed.writerIndex(writerIndex + decompressedLength);
+                                break;
+                            default:
+                                throw new IllegalStateException(
+                                    String.format(
+                                        Locale.ROOT,
+                                        "unexpected blockType: %d (expected: %d or %d)",
+                                        blockType,
+                                        BLOCK_TYPE_NON_COMPRESSED,
+                                        BLOCK_TYPE_COMPRESSED
+                                    )
+                                );
+                        }
+                        currentState = State.INIT_BLOCK;
+                    } catch (LZ4Exception e) {
+                        throw new IllegalStateException(e);
+                    } finally {
+                        if (decompressed.isReadable()) {
+                            out.add(decompressed);
+                        } else {
+                            decompressed.release();
+                        }
+                    }
+                    break;
+                case FINISHED:
+                    break;
+                case CORRUPTED:
+                    throw new IllegalStateException("LZ4 stream corrupted.");
+                default:
+                    throw new IllegalStateException();
+            }
+        } catch (Exception e) {
+            currentState = State.CORRUPTED;
+            throw e;
+        }
+    }
+
+    private byte[] getThreadLocalBuffer(ThreadLocal<byte[]> threadLocal, int requiredSize) {
+        byte[] buffer = threadLocal.get();
+        if (requiredSize > buffer.length) {
+            buffer = new byte[requiredSize];
+            threadLocal.set(buffer);
+        }
+        return buffer;
+    }
+
+}

--- a/modules/transport-netty4/src/test/java/org/elasticsearch/http/netty4/Lz4DecoderTests.java
+++ b/modules/transport-netty4/src/test/java/org/elasticsearch/http/netty4/Lz4DecoderTests.java
@@ -1,0 +1,84 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.http.netty4;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+
+import org.elasticsearch.http.netty4.util.CompressOutputStream;
+import org.elasticsearch.http.netty4.util.MockChannelHandlerContext;
+import org.elasticsearch.test.ESTestCase;
+
+import java.io.ByteArrayOutputStream;
+import java.io.OutputStream;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * @author xiaoping
+ * @date 2022/9/6
+ */
+public class Lz4DecoderTests extends ESTestCase {
+
+    public void testLz4Decode() throws Exception {
+
+        try (ByteArrayOutputStream compress = new ByteArrayOutputStream(1024)) {
+            byte[] origin = randomBytes();
+            try (OutputStream outputStream = CompressOutputStream.compressedOutputStream(compress)) {
+                outputStream.write(origin);
+            }
+            byte[] bytes = compress.toByteArray();
+            LZ4Decoder customDecompress = new LZ4Decoder();
+            ByteArrayOutputStream decompress = new ByteArrayOutputStream(1024);
+            ByteBuf in = Unpooled.wrappedBuffer(bytes);
+
+            while (true) {
+                List<Object> result = new ArrayList<>();
+
+                customDecompress.decode(new MockChannelHandlerContext(), in, result);
+                if (in.readableBytes() == 0) {
+                    break;
+                } else {
+                    for (Object object : result) {
+                        ByteBuf byteBuf = (ByteBuf) object;
+                        byteBuf.readBytes(decompress, byteBuf.readableBytes());
+                    }
+                }
+            }
+            byte[] decompressBytes = decompress.toByteArray();
+            assertEquals(origin.length, decompressBytes.length);
+            for (int i = 0; i < origin.length; i++) {
+                assertEquals(origin[i], decompressBytes[i]);
+            }
+            decompress.close();
+        }
+    }
+
+    public byte[] randomBytes() {
+        StringBuilder stringBuilder = new StringBuilder();
+        for (int i = 0; i < randomIntBetween(1000, 2000); i++) {
+            int value = randomInt();
+            for (int j = 0; j < randomIntBetween(50, 100); j++) {
+                stringBuilder.append(value);
+            }
+        }
+        return stringBuilder.toString().getBytes();
+    }
+}

--- a/modules/transport-netty4/src/test/java/org/elasticsearch/http/netty4/util/CompressOutputStream.java
+++ b/modules/transport-netty4/src/test/java/org/elasticsearch/http/netty4/util/CompressOutputStream.java
@@ -1,0 +1,257 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.http.netty4.util;
+
+import net.jpountz.lz4.LZ4Compressor;
+import net.jpountz.lz4.LZ4Factory;
+import net.jpountz.util.SafeUtils;
+
+import java.io.FilterOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+
+public class CompressOutputStream extends FilterOutputStream {
+    public static final byte[] EMPTY_BYTES = new byte[0];
+
+    private static class ArrayBox {
+        private byte[] uncompressed = EMPTY_BYTES;
+        private byte[] compressed = EMPTY_BYTES;
+        private boolean owned = false;
+
+        private void markOwnership(int uncompressedBlockSize, int compressedMaxSize) {
+            assert owned == false;
+            owned = true;
+            if (uncompressedBlockSize > uncompressed.length) {
+                uncompressed = new byte[uncompressedBlockSize];
+            }
+            if (compressedMaxSize > compressed.length) {
+                compressed = new byte[compressedMaxSize];
+            }
+        }
+
+        private void release() {
+            owned = false;
+        }
+    }
+
+    private static final ThreadLocal<ArrayBox> ARRAY_BOX = ThreadLocal.withInitial(ArrayBox::new);
+
+    static final byte[] MAGIC = new byte[] { 'L', 'Z', '4', 'B', 'l', 'o', 'c', 'k' };
+    static final int MAGIC_LENGTH = MAGIC.length;
+
+    static final int HEADER_LENGTH = MAGIC_LENGTH // magic bytes
+        + 1          // token
+        + 4          // compressed length
+        + 4          // decompressed length
+        + 4;         // checksum
+
+    static final int COMPRESSION_LEVEL_BASE = 10;
+    static final int MIN_BLOCK_SIZE = 64;
+    static final int MAX_BLOCK_SIZE = 1 << (COMPRESSION_LEVEL_BASE + 0x0F);
+
+    static final int COMPRESSION_METHOD_RAW = 0x10;
+    static final int COMPRESSION_METHOD_LZ4 = 0x20;
+
+    static final int DEFAULT_SEED = 0x9747b28c;
+
+    private static int compressionLevel(int blockSize) {
+        if (blockSize < MIN_BLOCK_SIZE) {
+            throw new IllegalArgumentException("blockSize must be >= " + MIN_BLOCK_SIZE + ", got " + blockSize);
+        } else if (blockSize > MAX_BLOCK_SIZE) {
+            throw new IllegalArgumentException("blockSize must be <= " + MAX_BLOCK_SIZE + ", got " + blockSize);
+        }
+        int compressionLevel = 32 - Integer.numberOfLeadingZeros(blockSize - 1); // ceil of log2
+        assert (1 << compressionLevel) >= blockSize;
+        assert blockSize * 2 > (1 << compressionLevel);
+        compressionLevel = Math.max(0, compressionLevel - COMPRESSION_LEVEL_BASE);
+        assert compressionLevel >= 0 && compressionLevel <= 0x0F;
+        return compressionLevel;
+    }
+
+    private final int blockSize;
+    private final int compressionLevel;
+    private LZ4Compressor compressor;
+    private final ArrayBox arrayBox;
+    private final byte[] buffer;
+    private final byte[] compressedBuffer;
+    private final boolean syncFlush;
+    private boolean finished;
+    private int o;
+
+    /**
+     * Creates a new {@link OutputStream} with configurable block size. Large
+     * blocks require more memory at compression and decompression time but
+     * should improve the compression ratio.
+     *
+     * @param out         the {@link OutputStream} to feed
+     * @param blockSize   the maximum number of bytes to try to compress at once,
+     *                    must be &gt;= 64 and &lt;= 32 M
+     */
+    public CompressOutputStream(OutputStream out, int blockSize) {
+        super(out);
+        this.blockSize = blockSize;
+        this.compressionLevel = compressionLevel(blockSize);
+        int maxCompressedBlockSize = 0;
+        this.compressor = LZ4Factory.safeInstance().fastCompressor();
+        maxCompressedBlockSize = HEADER_LENGTH + compressor.maxCompressedLength(blockSize);
+        this.arrayBox = ARRAY_BOX.get();
+        arrayBox.markOwnership(blockSize, maxCompressedBlockSize);
+        this.buffer = arrayBox.uncompressed;
+        this.compressedBuffer = arrayBox.compressed;
+        this.syncFlush = false;
+        o = 0;
+        finished = false;
+        System.arraycopy(MAGIC, 0, compressedBuffer, 0, MAGIC_LENGTH);
+    }
+
+    private void ensureNotFinished() {
+        if (finished) {
+            throw new IllegalStateException("This stream is already closed");
+        }
+    }
+
+    @Override
+    public void write(int b) throws IOException {
+        ensureNotFinished();
+        if (o == blockSize) {
+            flushBufferedData();
+        }
+        buffer[o++] = (byte) b;
+    }
+
+    @Override
+    public void write(byte[] b, int off, int len) throws IOException {
+        SafeUtils.checkRange(b, off, len);
+        ensureNotFinished();
+
+        while (o + len > blockSize) {
+            final int l = blockSize - o;
+            System.arraycopy(b, off, buffer, o, blockSize - o);
+            o = blockSize;
+            flushBufferedData();
+            off += l;
+            len -= l;
+        }
+        System.arraycopy(b, off, buffer, o, len);
+        o += len;
+    }
+
+    @Override
+    public void write(byte[] b) throws IOException {
+        ensureNotFinished();
+        write(b, 0, b.length);
+    }
+
+    @Override
+    public void close() throws IOException {
+        try {
+            if (finished == false) {
+                finish();
+            }
+            if (out != null) {
+                out.close();
+                out = null;
+            }
+        } finally {
+            arrayBox.release();
+        }
+    }
+
+    private void flushBufferedData() throws IOException {
+        if (o == 0) {
+            return;
+        }
+        int compressedLength = compressor.compress(buffer, 0, o, compressedBuffer, HEADER_LENGTH);
+        final int compressMethod;
+        if (compressedLength >= o) {
+            compressMethod = COMPRESSION_METHOD_RAW;
+            compressedLength = o;
+            System.arraycopy(buffer, 0, compressedBuffer, HEADER_LENGTH, o);
+        } else {
+            compressMethod = COMPRESSION_METHOD_LZ4;
+        }
+
+        compressedBuffer[MAGIC_LENGTH] = (byte) (compressMethod | compressionLevel);
+        writeIntLE(compressedLength, compressedBuffer, MAGIC_LENGTH + 1);
+        writeIntLE(o, compressedBuffer, MAGIC_LENGTH + 5);
+        // Write 0 for checksum. We do not read it on decompress.
+        writeIntLE(0, compressedBuffer, MAGIC_LENGTH + 9);
+        assert MAGIC_LENGTH + 13 == HEADER_LENGTH;
+        out.write(compressedBuffer, 0, HEADER_LENGTH + compressedLength);
+        o = 0;
+    }
+
+    /**
+     * Flushes this compressed {@link OutputStream}.
+     *
+     * If the stream has been created with <code>syncFlush=true</code>, pending
+     * data will be compressed and appended to the underlying {@link OutputStream}
+     * before calling {@link OutputStream#flush()} on the underlying stream.
+     * Otherwise, this method just flushes the underlying stream, so pending
+     * data might not be available for reading until {@link #finish()} or
+     * {@link #close()} is called.
+     */
+    @Override
+    public void flush() throws IOException {
+        if (out != null) {
+            if (syncFlush) {
+                flushBufferedData();
+            }
+            out.flush();
+        }
+    }
+
+    /**
+     * Same as {@link #close()} except that it doesn't close the underlying stream.
+     * This can be useful if you want to keep on using the underlying stream.
+     *
+     * @throws IOException if an I/O error occurs.
+     */
+    public void finish() throws IOException {
+        ensureNotFinished();
+        flushBufferedData();
+        compressedBuffer[MAGIC_LENGTH] = (byte) (COMPRESSION_METHOD_RAW | compressionLevel);
+        writeIntLE(0, compressedBuffer, MAGIC_LENGTH + 1);
+        writeIntLE(0, compressedBuffer, MAGIC_LENGTH + 5);
+        writeIntLE(0, compressedBuffer, MAGIC_LENGTH + 9);
+        assert MAGIC_LENGTH + 13 == HEADER_LENGTH;
+        out.write(compressedBuffer, 0, HEADER_LENGTH);
+        finished = true;
+        out.flush();
+    }
+
+    private static void writeIntLE(int i, byte[] buf, int off) {
+        buf[off++] = (byte) i;
+        buf[off++] = (byte) (i >>> 8);
+        buf[off++] = (byte) (i >>> 16);
+        buf[off++] = (byte) (i >>> 24);
+    }
+
+    @Override
+    public String toString() {
+        return getClass().getSimpleName() + "(out=" + out + ", blockSize=" + blockSize + ", compressor=" + compressor + ")";
+    }
+
+    public static int COMPRESS_BLOCK_SIZE = 128 * 1024;
+
+    public static OutputStream compressedOutputStream(OutputStream outputStream) {
+        return new CompressOutputStream(outputStream, COMPRESS_BLOCK_SIZE);
+    }
+}

--- a/modules/transport-netty4/src/test/java/org/elasticsearch/http/netty4/util/MockChannelHandlerContext.java
+++ b/modules/transport-netty4/src/test/java/org/elasticsearch/http/netty4/util/MockChannelHandlerContext.java
@@ -1,0 +1,352 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.http.netty4.util;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufAllocator;
+import io.netty.buffer.CompositeByteBuf;
+import io.netty.buffer.Unpooled;
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelFuture;
+import io.netty.channel.ChannelHandler;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelPipeline;
+import io.netty.channel.ChannelProgressivePromise;
+import io.netty.channel.ChannelPromise;
+import io.netty.util.Attribute;
+import io.netty.util.AttributeKey;
+import io.netty.util.concurrent.EventExecutor;
+
+import java.net.SocketAddress;
+
+/**
+ * @author xiaoping
+ * @date 2022/9/6
+ */
+public class MockChannelHandlerContext implements ChannelHandlerContext {
+    @Override
+    public Channel channel() {
+        return null;
+    }
+
+    @Override
+    public EventExecutor executor() {
+        return null;
+    }
+
+    @Override
+    public String name() {
+        return null;
+    }
+
+    @Override
+    public ChannelHandler handler() {
+        return null;
+    }
+
+    @Override
+    public boolean isRemoved() {
+        return false;
+    }
+
+    @Override
+    public ChannelHandlerContext fireChannelRegistered() {
+        return null;
+    }
+
+    @Override
+    public ChannelHandlerContext fireChannelUnregistered() {
+        return null;
+    }
+
+    @Override
+    public ChannelHandlerContext fireChannelActive() {
+        return null;
+    }
+
+    @Override
+    public ChannelHandlerContext fireChannelInactive() {
+        return null;
+    }
+
+    @Override
+    public ChannelHandlerContext fireExceptionCaught(Throwable cause) {
+        return null;
+    }
+
+    @Override
+    public ChannelHandlerContext fireUserEventTriggered(Object evt) {
+        return null;
+    }
+
+    @Override
+    public ChannelHandlerContext fireChannelRead(Object msg) {
+        return null;
+    }
+
+    @Override
+    public ChannelHandlerContext fireChannelReadComplete() {
+        return null;
+    }
+
+    @Override
+    public ChannelHandlerContext fireChannelWritabilityChanged() {
+        return null;
+    }
+
+    @Override
+    public ChannelFuture bind(SocketAddress localAddress) {
+        return null;
+    }
+
+    @Override
+    public ChannelFuture connect(SocketAddress remoteAddress) {
+        return null;
+    }
+
+    @Override
+    public ChannelFuture connect(SocketAddress remoteAddress, SocketAddress localAddress) {
+        return null;
+    }
+
+    @Override
+    public ChannelFuture disconnect() {
+        return null;
+    }
+
+    @Override
+    public ChannelFuture close() {
+        return null;
+    }
+
+    @Override
+    public ChannelFuture deregister() {
+        return null;
+    }
+
+    @Override
+    public ChannelFuture bind(SocketAddress localAddress, ChannelPromise promise) {
+        return null;
+    }
+
+    @Override
+    public ChannelFuture connect(SocketAddress remoteAddress, ChannelPromise promise) {
+        return null;
+    }
+
+    @Override
+    public ChannelFuture connect(SocketAddress remoteAddress, SocketAddress localAddress, ChannelPromise promise) {
+        return null;
+    }
+
+    @Override
+    public ChannelFuture disconnect(ChannelPromise promise) {
+        return null;
+    }
+
+    @Override
+    public ChannelFuture close(ChannelPromise promise) {
+        return null;
+    }
+
+    @Override
+    public ChannelFuture deregister(ChannelPromise promise) {
+        return null;
+    }
+
+    @Override
+    public ChannelHandlerContext read() {
+        return null;
+    }
+
+    @Override
+    public ChannelFuture write(Object msg) {
+        return null;
+    }
+
+    @Override
+    public ChannelFuture write(Object msg, ChannelPromise promise) {
+        return null;
+    }
+
+    @Override
+    public ChannelHandlerContext flush() {
+        return null;
+    }
+
+    @Override
+    public ChannelFuture writeAndFlush(Object msg, ChannelPromise promise) {
+        return null;
+    }
+
+    @Override
+    public ChannelFuture writeAndFlush(Object msg) {
+        return null;
+    }
+
+    @Override
+    public ChannelPromise newPromise() {
+        return null;
+    }
+
+    @Override
+    public ChannelProgressivePromise newProgressivePromise() {
+        return null;
+    }
+
+    @Override
+    public ChannelFuture newSucceededFuture() {
+        return null;
+    }
+
+    @Override
+    public ChannelFuture newFailedFuture(Throwable cause) {
+        return null;
+    }
+
+    @Override
+    public ChannelPromise voidPromise() {
+        return null;
+    }
+
+    @Override
+    public ChannelPipeline pipeline() {
+        return null;
+    }
+
+    @Override
+    public ByteBufAllocator alloc() {
+        return new ByteBufAllocator() {
+            @Override
+            public ByteBuf buffer() {
+                return null;
+            }
+
+            @Override
+            public ByteBuf buffer(int initialCapacity) {
+                return null;
+            }
+
+            @Override
+            public ByteBuf buffer(int initialCapacity, int maxCapacity) {
+                return null;
+            }
+
+            @Override
+            public ByteBuf ioBuffer() {
+                return null;
+            }
+
+            @Override
+            public ByteBuf ioBuffer(int initialCapacity) {
+                return null;
+            }
+
+            @Override
+            public ByteBuf ioBuffer(int initialCapacity, int maxCapacity) {
+                return null;
+            }
+
+            @Override
+            public ByteBuf heapBuffer() {
+                return null;
+            }
+
+            @Override
+            public ByteBuf heapBuffer(int initialCapacity) {
+                ByteBuf buf = Unpooled.wrappedBuffer(new byte[initialCapacity]);
+                buf.writerIndex(0);
+                buf.readerIndex(0);
+
+                return buf;
+            }
+
+            @Override
+            public ByteBuf heapBuffer(int initialCapacity, int maxCapacity) {
+                return null;
+            }
+
+            @Override
+            public ByteBuf directBuffer() {
+                return null;
+            }
+
+            @Override
+            public ByteBuf directBuffer(int initialCapacity) {
+                return null;
+            }
+
+            @Override
+            public ByteBuf directBuffer(int initialCapacity, int maxCapacity) {
+                return null;
+            }
+
+            @Override
+            public CompositeByteBuf compositeBuffer() {
+                return null;
+            }
+
+            @Override
+            public CompositeByteBuf compositeBuffer(int maxNumComponents) {
+                return null;
+            }
+
+            @Override
+            public CompositeByteBuf compositeHeapBuffer() {
+                return null;
+            }
+
+            @Override
+            public CompositeByteBuf compositeHeapBuffer(int maxNumComponents) {
+                return null;
+            }
+
+            @Override
+            public CompositeByteBuf compositeDirectBuffer() {
+                return null;
+            }
+
+            @Override
+            public CompositeByteBuf compositeDirectBuffer(int maxNumComponents) {
+                return null;
+            }
+
+            @Override
+            public boolean isDirectBufferPooled() {
+                return false;
+            }
+
+            @Override
+            public int calculateNewCapacity(int minNewCapacity, int maxCapacity) {
+                return 0;
+            }
+        };
+    }
+
+    @Override
+    public <T> Attribute<T> attr(AttributeKey<T> key) {
+        return null;
+    }
+
+    @Override
+    public <T> boolean hasAttr(AttributeKey<T> key) {
+        return false;
+    }
+}


### PR DESCRIPTION
now client can use gzip to compress request, but gzip is more cpu consuming, this pr add another choice to use lz4 to compress request.

In my test data, lz4 can compress data size to one fifth with 4% cpu overhead in client, while gzip can compress data size to one eighth with 17% cpu overhead. So LZ4 is more lightweight.


