### PR TITLE
[8.4] Add advice on restoring ILM indices into unmanaged state (#89140)

### DIFF
--- a/docs/reference/settings/ilm-settings.asciidoc
+++ b/docs/reference/settings/ilm-settings.asciidoc
@@ -23,7 +23,7 @@ indices. Defaults to `true`.
 
 [[indices-lifecycle-poll-interval]]
 `indices.lifecycle.poll_interval`::
-(<<dynamic-cluster-setting,Dynamic>>, <<time-units, time unit value>>) 
+(<<dynamic-cluster-setting,Dynamic>>, <<time-units, time unit value>>)
 How often {ilm} checks for indices that meet policy criteria. Defaults to `10m`.
 
 ==== Index level settings
@@ -31,34 +31,38 @@ These index-level {ilm-init} settings are typically configured through index
 templates. For more information, see <<ilm-gs-create-policy>>.
 
 `index.lifecycle.indexing_complete`::
-(<<indices-update-settings,Dynamic>>, Boolean) 
-Indicates whether or not the index has been rolled over. 
+(<<indices-update-settings,Dynamic>>, Boolean)
+Indicates whether or not the index has been rolled over.
 Automatically set to `true` when {ilm-init} completes the rollover action.
 You can explicitly set it to <<skipping-rollover, skip rollover>>.
 Defaults to `false`.
 
+[[index-lifecycle-name]]
 `index.lifecycle.name`::
 (<<indices-update-settings, Dynamic>>, string)
 The name of the policy to use to manage the index. For information about how
 {es} applies policy changes, see <<update-lifecycle-policy>>.
+If you are restoring an index from snapshot that was previously managed by {ilm},
+you can override this setting to null during the restore operation to disable
+further management of the index. See also <<index-lifecycle-rollover-alias>>.
 
 [[index-lifecycle-origination-date]]
 `index.lifecycle.origination_date`::
-(<<indices-update-settings,Dynamic>>, long) 
-If specified, this is the timestamp used to calculate the index age for its phase transitions. 
-Use this setting if you create a new index that contains old data and 
-want to use the original creation date to calculate the index age. 
+(<<indices-update-settings,Dynamic>>, long)
+If specified, this is the timestamp used to calculate the index age for its phase transitions.
+Use this setting if you create a new index that contains old data and
+want to use the original creation date to calculate the index age.
 Specified as a Unix epoch value in milliseconds.
 
 [[index-lifecycle-parse-origination-date]]
 `index.lifecycle.parse_origination_date`::
-(<<indices-update-settings,Dynamic>>, Boolean) 
-Set to `true` to parse the origination date from the index name. 
-This origination date is used to calculate the index age for its phase transitions. 
-The index name must match the pattern `^.*-{date_format}-\\d+`, 
+(<<indices-update-settings,Dynamic>>, Boolean)
+Set to `true` to parse the origination date from the index name.
+This origination date is used to calculate the index age for its phase transitions.
+The index name must match the pattern `^.*-{date_format}-\\d+`,
 where the `date_format` is `yyyy.MM.dd` and the trailing digits are optional.
-An index that was rolled over would normally match the full format, 
-for example `logs-2016.10.31-000002`). 
+An index that was rolled over would normally match the full format,
+for example `logs-2016.10.31-000002`).
 If the index name doesn't match the pattern, index creation fails.
 
 [[index-lifecycle-step-wait-time-threshold]]
@@ -68,9 +72,13 @@ Time to wait for the cluster to resolve allocation issues during an {ilm-init}
 <<ilm-shrink,`shrink`>> action. Must be greater than `1h` (1 hour). Defaults to
 `12h` (12 hours). See <<ilm-shrink-shard-allocation>>.
 
+[[index-lifecycle-rollover-alias]]
 `index.lifecycle.rollover_alias`::
-(<<indices-update-settings,Dynamic>>, string) 
+(<<indices-update-settings,Dynamic>>, string)
 The index alias to update when the index rolls over. Specify when using a
 policy that contains a rollover action. When the index rolls over, the alias is
 updated to reflect that the index is no longer the write index. For more
 information about rolling indices, see <<index-rollover, Rollover>>.
+If you are restoring an index from snapshot that was previously managed by {ilm},
+you can override this setting to null during the restore operation to disable
+further management of future indices. See also <<index-lifecycle-name>>.


### PR DESCRIPTION
Backports the following commits to 8.4:
 - Add advice on restoring ILM indices into unmanaged state (#89140)