### PR TITLE
Fail when rebuilding scorer in breadth_first mode and query context has changed

### DIFF
--- a/docs/changelog/89993.yaml
+++ b/docs/changelog/89993.yaml
@@ -1,0 +1,7 @@
+pr: 89993
+summary: Fail when rebuilding scorer in `breadth_first` mode and query context has
+  changed
+area: Aggregations
+type: bug
+issues:
+ - 37650

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/BestBucketsDeferringCollector.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/BestBucketsDeferringCollector.java
@@ -214,7 +214,8 @@ public class BestBucketsDeferringCollector extends DeferringBucketCollector {
      * The likely cause is that a children aggregation has a terms aggregator with collection mode breadth_first and this
      * terms aggregator has a sub aggregation that requires score. See #37650
      * Sub aggregators of children aggregation can't access scores, because that information isn't kept track of by the children aggregator
-     * when collect mode is breath first. Keeping track of this scores in breath first mode would require a non-trivial amount of heap memory.
+     * when collect mode is breath first. Keeping track of this scores in breath first mode would require a non-trivial amount of heap
+     * memory.
      */
     private static void failInCaseOfBadScorer(String message) {
         String likelyExplanation =

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/BestBucketsDeferringCollector.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/BestBucketsDeferringCollector.java
@@ -172,6 +172,9 @@ public class BestBucketsDeferringCollector extends DeferringBucketCollector {
                 DocIdSetIterator scoreIt = null;
                 if (needsScores) {
                     Scorer scorer = weight.scorer(entry.aggCtx.getLeafReaderContext());
+                    if (scorer == null) {
+                        failInCaseOfBadScorer("no scores are available");
+                    }
                     // We don't need to check if the scorer is null
                     // since we are sure that there are documents to replay (entry.docDeltas it not empty).
                     scoreIt = scorer.iterator();
@@ -190,7 +193,9 @@ public class BestBucketsDeferringCollector extends DeferringBucketCollector {
                                 scoreIt.advance(doc);
                             }
                             // aggregations should only be replayed on matching documents
-                            assert scoreIt.docID() == doc;
+                            if (scoreIt.docID() != doc) {
+                                failInCaseOfBadScorer("score for different docid");
+                            }
                         }
                         leafCollector.collect(doc, rebasedBucket);
                     }
@@ -201,6 +206,20 @@ public class BestBucketsDeferringCollector extends DeferringBucketCollector {
             }
         }
         collector.postCollection();
+    }
+
+    /*
+     * Fail with when no scores are available or a scorer for incorrect doc ids are used when replaying
+     *
+     * The likely cause is that a children aggregation has a terms aggregator with collection mode breadth_first and this
+     * terms aggregator has a sub aggregation that requires score. See #37650
+     * Sub aggregators of children aggregation can't access scores, because that information isn't kept track of by the children aggregator
+     * when collect mode is breath first. Keeping track of this scores in breath first mode would require a non-trivial amount of heap memory.
+     */
+    private static void failInCaseOfBadScorer(String message) {
+        String likelyExplanation =
+            "nesting an aggregation under a children aggregation and terms aggregation with collect mode breadth_first isn't possible";
+        throw new RuntimeException(message + ", " + likelyExplanation);
     }
 
     /**


### PR DESCRIPTION
The children agg changes the query context, when BestBucketsDeferringCollector is rebuilding scores for the breath first  collect mode then this leads to erroneous situations:
* A null scorer could be returned, because a segment had no matches.
* Scores for incorrect docids could be reported.

This commit adds checks for both cases and throws runtime errors with a more actionable error message.

These erroneous situations that could occur when top_hits is nested under children agg and terms agg with breath_first execution mode. Possible there are other cases too were this NPE would occur.

Note that this NPE would actually only occur if parent and child docs are in separate segments, otherwise the scorer would report scores for different documents. This would trigger an assertion error in tests.

Closes #37650