### PR TITLE
Dry up rest response listener for chunked xcontent responses

### DIFF
--- a/server/src/main/java/org/elasticsearch/rest/action/RestChunkedToXContentListener.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/RestChunkedToXContentListener.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.rest.action;
+
+import org.elasticsearch.common.xcontent.ChunkedToXContent;
+import org.elasticsearch.rest.ChunkedRestResponseBody;
+import org.elasticsearch.rest.RestChannel;
+import org.elasticsearch.rest.RestResponse;
+import org.elasticsearch.rest.RestStatus;
+
+import java.io.IOException;
+
+/**
+ * A REST based action listener that requires the response to implement {@link org.elasticsearch.common.xcontent.ChunkedToXContent}
+ * and automatically builds an XContent based response.
+ */
+public final class RestChunkedToXContentListener<Response extends ChunkedToXContent> extends RestActionListener<Response> {
+
+    public RestChunkedToXContentListener(RestChannel channel) {
+        super(channel);
+    }
+
+    @Override
+    protected void processResponse(Response response) throws IOException {
+        channel.sendResponse(new RestResponse(RestStatus.OK, ChunkedRestResponseBody.fromXContent(response, channel.request(), channel)));
+    }
+}

--- a/server/src/main/java/org/elasticsearch/rest/action/RestFieldCapabilitiesAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/RestFieldCapabilitiesAction.java
@@ -9,15 +9,11 @@
 package org.elasticsearch.rest.action;
 
 import org.elasticsearch.action.fieldcaps.FieldCapabilitiesRequest;
-import org.elasticsearch.action.fieldcaps.FieldCapabilitiesResponse;
 import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.client.internal.node.NodeClient;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.rest.BaseRestHandler;
-import org.elasticsearch.rest.ChunkedRestResponseBody;
 import org.elasticsearch.rest.RestRequest;
-import org.elasticsearch.rest.RestResponse;
-import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.xcontent.ObjectParser;
 import org.elasticsearch.xcontent.ParseField;
 
@@ -71,13 +67,7 @@ public class RestFieldCapabilitiesAction extends BaseRestHandler {
             }
             fieldRequest.fields(Strings.splitStringByCommaToArray(request.param("fields")));
         }
-        return channel -> client.fieldCaps(fieldRequest, new RestActionListener<>(channel) {
-            @Override
-            protected void processResponse(FieldCapabilitiesResponse response) throws IOException {
-                ensureOpen();
-                channel.sendResponse(new RestResponse(RestStatus.OK, ChunkedRestResponseBody.fromXContent(response, request, channel)));
-            }
-        });
+        return channel -> client.fieldCaps(fieldRequest, new RestChunkedToXContentListener<>(channel));
     }
 
     private static final ParseField INDEX_FILTER_FIELD = new ParseField("index_filter");

--- a/server/src/main/java/org/elasticsearch/rest/action/admin/cluster/RestGetSnapshotsAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/admin/cluster/RestGetSnapshotsAction.java
@@ -9,16 +9,12 @@
 package org.elasticsearch.rest.action.admin.cluster;
 
 import org.elasticsearch.action.admin.cluster.snapshots.get.GetSnapshotsRequest;
-import org.elasticsearch.action.admin.cluster.snapshots.get.GetSnapshotsResponse;
 import org.elasticsearch.client.internal.node.NodeClient;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.rest.BaseRestHandler;
-import org.elasticsearch.rest.ChunkedRestResponseBody;
 import org.elasticsearch.rest.RestRequest;
-import org.elasticsearch.rest.RestResponse;
-import org.elasticsearch.rest.RestStatus;
-import org.elasticsearch.rest.action.RestActionListener;
 import org.elasticsearch.rest.action.RestCancellableNodeClient;
+import org.elasticsearch.rest.action.RestChunkedToXContentListener;
 import org.elasticsearch.search.sort.SortOrder;
 
 import java.io.IOException;
@@ -84,14 +80,6 @@ public class RestGetSnapshotsAction extends BaseRestHandler {
         getSnapshotsRequest.masterNodeTimeout(request.paramAsTime("master_timeout", getSnapshotsRequest.masterNodeTimeout()));
         return channel -> new RestCancellableNodeClient(client, request.getHttpChannel()).admin()
             .cluster()
-            .getSnapshots(getSnapshotsRequest, new RestActionListener<>(channel) {
-                @Override
-                protected void processResponse(GetSnapshotsResponse getSnapshotsResponse) throws IOException {
-                    ensureOpen();
-                    channel.sendResponse(
-                        new RestResponse(RestStatus.OK, ChunkedRestResponseBody.fromXContent(getSnapshotsResponse, request, channel))
-                    );
-                }
-            });
+            .getSnapshots(getSnapshotsRequest, new RestChunkedToXContentListener<>(channel));
     }
 }

--- a/server/src/test/java/org/elasticsearch/action/admin/indices/mapping/get/GetMappingsResponseTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/indices/mapping/get/GetMappingsResponseTests.java
@@ -79,7 +79,7 @@ public class GetMappingsResponseTests extends AbstractWireSerializingTestCase<Ge
             chunks.next();
             chunkCount++;
         }
-        assertEquals(indexCount, chunkCount);
+        assertEquals(2 + indexCount, chunkCount);
     }
 
     // Not meant to be exhaustive


### PR DESCRIPTION
This is always the same code. We also don't need the `ensureOpen` check, that's already done in the caller.
Lastly, turned the `GetMappingsResponse` into a normal xcontent (as opposed to a fragment) to be able to use the listener there as well.
