### PR TITLE
[8.4] Mention internal user `_security_profile` in docs (#89100)

### DIFF
--- a/x-pack/docs/en/security/authentication/internal-users.asciidoc
+++ b/x-pack/docs/en/security/authentication/internal-users.asciidoc
@@ -2,8 +2,10 @@
 [[internal-users]]
 === Internal users
 
-The {stack-security-features} use four _internal_ users (`_system`, `_xpack`,
-`_xpack_security`, and `_async_search`), which are responsible for the operations
+NOTE: These users are designed for internal use by {es} only. Authenticating with these users is not supported.
+
+The {stack-security-features} use five _internal_ users (`_system`, `_xpack`,
+`_xpack_security`, `_async_search`, and `_security_profile`), which are responsible for the operations
 that take place inside an {es} cluster.
 
 These users are only used by requests that originate from within the cluster.


### PR DESCRIPTION
Backports the following commits to 8.4:
 - Mention internal user `_security_profile` in docs (#89100)