### PR TITLE
Remove RestGetSnapshotsIT.testLargeChunkedResponses

### DIFF
--- a/qa/smoke-test-http/src/javaRestTest/java/org/elasticsearch/http/snapshots/RestGetSnapshotsIT.java
+++ b/qa/smoke-test-http/src/javaRestTest/java/org/elasticsearch/http/snapshots/RestGetSnapshotsIT.java
@@ -321,33 +321,6 @@ public class RestGetSnapshotsIT extends AbstractSnapshotRestTestCase {
         assertThat(allBeforeStartTimeDescending(startTime1 - 1), empty());
     }
 
-    public void testLargeChunkedResponses() throws Exception {
-        final String repoName = "test-repo";
-        AbstractSnapshotIntegTestCase.createRepository(logger, repoName, "fs");
-        for (int i = 0; i < 100; i++) {
-            createIndexWithContent("test-index-a-" + i);
-        }
-        final List<String> snapshotNamesWithoutIndex = AbstractSnapshotIntegTestCase.createNSnapshots(
-            logger,
-            repoName,
-            randomIntBetween(200, 300)
-        );
-
-        for (int i = 0; i < 100; i++) {
-            createIndexWithContent("test-index-b-" + i);
-        }
-
-        final List<String> snapshotNamesWithIndex = AbstractSnapshotIntegTestCase.createNSnapshots(
-            logger,
-            repoName,
-            randomIntBetween(200, 300)
-        );
-        final Collection<String> allSnapshotNames = new HashSet<>(snapshotNamesWithIndex);
-        allSnapshotNames.addAll(snapshotNamesWithoutIndex);
-        doTestSortOrder(repoName, allSnapshotNames, SortOrder.ASC);
-        doTestSortOrder(repoName, allSnapshotNames, SortOrder.DESC);
-    }
-
     // create a snapshot that is guaranteed to have a unique start time
     private SnapshotInfo createFullSnapshotWithUniqueStartTime(String repoName, String snapshotName, Set<Long> forbiddenStartTimes) {
         while (true) {


### PR DESCRIPTION
As discussed elsewhere this test is redundant, we test the correct chunking in the unit tests and it's slightly unstable.

closes #90009
