### PR TITLE
Update feature flag for remote cluster security

### DIFF
--- a/server/src/main/java/org/elasticsearch/transport/TcpTransport.java
+++ b/server/src/main/java/org/elasticsearch/transport/TcpTransport.java
@@ -110,10 +110,16 @@ public abstract class TcpTransport extends AbstractLifecycleComponent implements
     static {
         final String property = System.getProperty("es.untrusted_remote_cluster_feature_flag_registered");
         if (Build.CURRENT.isSnapshot() && property != null) {
-            throw new IllegalArgumentException("es.untrusted_remote_cluster_feature_flag_registered " +
-                "is only supported in non-snapshot builds");
+            throw new IllegalArgumentException(
+                "es.untrusted_remote_cluster_feature_flag_registered " + "is only supported in non-snapshot builds"
+            );
         }
         UNTRUSTED_REMOTE_CLUSTER_FEATURE_FLAG_REGISTERED = Booleans.parseBoolean(property, null);
+    }
+
+    public static boolean isUntrustedRemoteClusterEnabled() {
+        return Build.CURRENT.isSnapshot()
+            || (UNTRUSTED_REMOTE_CLUSTER_FEATURE_FLAG_REGISTERED != null && UNTRUSTED_REMOTE_CLUSTER_FEATURE_FLAG_REGISTERED);
     }
 
     private final boolean ignoreDeserializationErrors;

--- a/server/src/main/java/org/elasticsearch/transport/TcpTransport.java
+++ b/server/src/main/java/org/elasticsearch/transport/TcpTransport.java
@@ -11,6 +11,7 @@ import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.Build;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionListener;
@@ -41,6 +42,7 @@ import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.common.util.PageCacheRecycler;
 import org.elasticsearch.common.util.concurrent.ConcurrentCollections;
 import org.elasticsearch.common.util.concurrent.CountDown;
+import org.elasticsearch.core.Booleans;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.indices.breaker.CircuitBreakerService;
 import org.elasticsearch.monitor.jvm.JvmInfo;
@@ -102,6 +104,17 @@ public abstract class TcpTransport extends AbstractLifecycleComponent implements
         false,
         Setting.Property.NodeScope
     );
+
+    private static final Boolean UNTRUSTED_REMOTE_CLUSTER_FEATURE_FLAG_REGISTERED;
+
+    static {
+        final String property = System.getProperty("es.untrusted_remote_cluster_feature_flag_registered");
+        if (Build.CURRENT.isSnapshot() && property != null) {
+            throw new IllegalArgumentException("es.untrusted_remote_cluster_feature_flag_registered " +
+                "is only supported in non-snapshot builds");
+        }
+        UNTRUSTED_REMOTE_CLUSTER_FEATURE_FLAG_REGISTERED = Booleans.parseBoolean(property, null);
+    }
 
     private final boolean ignoreDeserializationErrors;
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/XPackSettings.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/XPackSettings.java
@@ -8,7 +8,6 @@
 package org.elasticsearch.xpack.core;
 
 import org.apache.logging.log4j.LogManager;
-import org.elasticsearch.Build;
 import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Setting.Property;
 import org.elasticsearch.common.settings.Settings;
@@ -54,9 +53,6 @@ public class XPackSettings {
      * Setting for controlling whether or not CCR is enabled.
      */
     public static final Setting<Boolean> CCR_ENABLED_SETTING = Setting.boolSetting("xpack.ccr.enabled", true, Property.NodeScope);
-
-    public static final boolean CROSS_CLUSTER_2_FEATURE_FLAG_ENABLED = Build.CURRENT.isSnapshot()
-        || "true".equals(System.getProperty("es.cross_cluster_2_feature_flag_enabled"));
 
     /** Setting for enabling or disabling security. Defaults to true. */
     public static final Setting<Boolean> SECURITY_ENABLED = Setting.boolSetting("xpack.security.enabled", true, Setting.Property.NodeScope);


### PR DESCRIPTION
 This commit reverts https://github.com/elastic/elasticsearch/pull/88451 in favor of a feature flag that:
* is located in core to allow usage from core
* uses conventions from https://github.com/elastic/elasticsearch/pull/83876
* remove CCS from name (likely will reuse with CCR) 