### PR TITLE
Increase cluster health timeout in SnapshotStressTestsIT

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/snapshots/SnapshotStressTestsIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/snapshots/SnapshotStressTestsIT.java
@@ -15,6 +15,7 @@ import org.elasticsearch.ExceptionsHelper;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.ShardOperationFailedException;
 import org.elasticsearch.action.StepListener;
+import org.elasticsearch.action.admin.cluster.health.ClusterHealthRequestBuilder;
 import org.elasticsearch.action.admin.cluster.health.ClusterHealthResponse;
 import org.elasticsearch.action.admin.cluster.node.hotthreads.NodeHotThreads;
 import org.elasticsearch.action.admin.cluster.snapshots.create.CreateSnapshotRequestBuilder;
@@ -577,13 +578,8 @@ public class SnapshotStressTestsIT extends AbstractSnapshotIntegTestCase {
                             snapshotInfo.snapshotId().getName()
                         );
 
-                        client().admin()
-                            .cluster()
-                            .prepareHealth(indicesToRestore)
-                            .setWaitForEvents(Priority.LANGUID)
-                            .setWaitForGreenStatus()
+                        prepareClusterHealthRequest(indicesToRestore).setWaitForGreenStatus()
                             .setWaitForNoInitializingShards(true)
-                            .setWaitForNodes(Integer.toString(internalCluster().getNodeNames().length))
                             .execute(mustSucceed(clusterHealthResponse -> {
 
                                 logger.info(
@@ -877,12 +873,7 @@ public class SnapshotStressTestsIT extends AbstractSnapshotIntegTestCase {
                         snapshotName
                     );
 
-                    client().admin()
-                        .cluster()
-                        .prepareHealth(targetIndexNames.toArray(new String[0]))
-                        .setWaitForEvents(Priority.LANGUID)
-                        .setWaitForYellowStatus()
-                        .setWaitForNodes(Integer.toString(internalCluster().getNodeNames().length))
+                    prepareClusterHealthRequest(targetIndexNames.toArray(Strings.EMPTY_ARRAY)).setWaitForYellowStatus()
                         .execute(ensureYellowStep);
 
                     ensureYellowStep.addListener(mustSucceed(clusterHealthResponse -> {
@@ -1344,13 +1335,7 @@ public class SnapshotStressTestsIT extends AbstractSnapshotIntegTestCase {
 
                             logger.info("--> waiting for yellow health of [{}] prior to indexing [{}] docs", indexName, docCount);
 
-                            client().admin()
-                                .cluster()
-                                .prepareHealth(indexName)
-                                .setWaitForEvents(Priority.LANGUID)
-                                .setWaitForYellowStatus()
-                                .setWaitForNodes(Integer.toString(internalCluster().getNodeNames().length))
-                                .execute(ensureYellowStep);
+                            prepareClusterHealthRequest(indexName).setWaitForYellowStatus().execute(ensureYellowStep);
 
                             final StepListener<BulkResponse> bulkStep = new StepListener<>();
 
@@ -1415,6 +1400,17 @@ public class SnapshotStressTestsIT extends AbstractSnapshotIntegTestCase {
 
         }
 
+    }
+
+    // Prepares a health request with twice the default (30s) timeout that waits for all cluster tasks to finish as well as all cluster
+    // nodes before returning
+    private static ClusterHealthRequestBuilder prepareClusterHealthRequest(String... targetIndexNames) {
+        return client().admin()
+            .cluster()
+            .prepareHealth(targetIndexNames)
+            .setTimeout(TimeValue.timeValueSeconds(60))
+            .setWaitForNodes(Integer.toString(internalCluster().getNodeNames().length))
+            .setWaitForEvents(Priority.LANGUID);
     }
 
     private static String stringFromSnapshotInfo(SnapshotInfo snapshotInfo) {


### PR DESCRIPTION
Just like we did in `main`, backporting the increased the health request timeout to 7.17 here.

closes #89689
