### PR TITLE
Add master_timeout to the delete snapshot API docs

### DIFF
--- a/docs/reference/snapshot-restore/apis/delete-snapshot-api.asciidoc
+++ b/docs/reference/snapshot-restore/apis/delete-snapshot-api.asciidoc
@@ -53,6 +53,11 @@ Name of the repository to delete a snapshot from.
 (Required, string)
 Comma-separated list of snapshot names to delete. Also accepts wildcards (`*`).
 
+[[delete-snapshot-api-query-params]]
+==== {api-query-parms-title}
+
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=master-timeout]
+
 [[delete-snapshot-api-example]]
 ==== {api-example-title}
 


### PR DESCRIPTION
The snapshot delete code supports passing in a `master_timeout`:

https://github.com/elastic/elasticsearch/blob/main/server/src/main/java/org/elasticsearch/rest/action/admin/cluster/RestDeleteSnapshotAction.java#L45

It's been that way *forever*:

```
joegallo@galactic:~/Code/elastic/elasticsearch $ git blame server/src/main/java/org/elasticsearch/rest/action/admin/cluster/RestDeleteSnapshotAction.java | grep paramAsTime
510397aecdb9 src/main/java/org/elasticsearch/rest/action/admin/cluster/snapshots/delete/RestDeleteSnapshotAction.java      (Igor Motov             2013-11-08 19:20:43 -0500 45)         deleteSnapshotRequest.masterNodeTimeout(request.paramAsTime("master_timeout", deleteSnapshotRequest.masterNodeTimeout()));
joegallo@galactic:~/Code/elastic/elasticsearch $ git tag --contains=510397aecdb9 | head -n10
v1.0.0
v1.0.0.Beta2
v1.0.0.RC1
v1.0.0.RC2
v1.0.1
v1.0.2
v1.0.3
v1.1.0
v1.1.1
v1.1.2
```