### PR TITLE
[test] Stop ILM to prevent accident rollover for a searchable snapshot tests

### DIFF
--- a/x-pack/plugin/ilm/qa/multi-node/src/javaRestTest/java/org/elasticsearch/xpack/ilm/actions/SearchableSnapshotActionIT.java
+++ b/x-pack/plugin/ilm/qa/multi-node/src/javaRestTest/java/org/elasticsearch/xpack/ilm/actions/SearchableSnapshotActionIT.java
@@ -665,7 +665,13 @@ public class SearchableSnapshotActionIT extends ESRestTestCase {
         // searchable snapshots mounted in the hot phase should be pinned to hot nodes
         assertThat(hotIndexSettings.get(DataTier.TIER_PREFERENCE), is("data_hot"));
 
+        // Need to stop ILM to prevent a race between rollovers and deletion of searchable snapshots
         assertOK(client().performRequest(new Request("POST", "_ilm/stop")));
+        try {
+            cleanUpCluster();
+        } finally {
+            assertOK(client().performRequest(new Request("POST", "_ilm/start")));
+        }
     }
 
     // See: https://github.com/elastic/elasticsearch/issues/77269

--- a/x-pack/plugin/ilm/qa/multi-node/src/javaRestTest/java/org/elasticsearch/xpack/ilm/actions/SearchableSnapshotActionIT.java
+++ b/x-pack/plugin/ilm/qa/multi-node/src/javaRestTest/java/org/elasticsearch/xpack/ilm/actions/SearchableSnapshotActionIT.java
@@ -664,6 +664,8 @@ public class SearchableSnapshotActionIT extends ESRestTestCase {
         Map<String, Object> hotIndexSettings = getIndexSettingsAsMap(restoredIndex);
         // searchable snapshots mounted in the hot phase should be pinned to hot nodes
         assertThat(hotIndexSettings.get(DataTier.TIER_PREFERENCE), is("data_hot"));
+
+        assertOK(client().performRequest(new Request("POST", "_ilm/stop")));
     }
 
     // See: https://github.com/elastic/elasticsearch/issues/77269


### PR DESCRIPTION

Disable ILM to make sure we don't accidentally create searchable snapshots while cleaning them.

Fixes #86890
