### PR TITLE
Remove synthetic _source from tech preview

### DIFF
--- a/docs/reference/mapping/fields/synthetic-source.asciidoc
+++ b/docs/reference/mapping/fields/synthetic-source.asciidoc
@@ -1,5 +1,5 @@
 [[synthetic-source]]
-==== Synthetic `_source` preview:[]
+==== Synthetic `_source`
 
 Though very handy to have around, the source field takes up a significant amount
 of space on disk. Instead of storing source documents on disk exactly as you

--- a/docs/reference/mapping/types/aggregate-metric-double.asciidoc
+++ b/docs/reference/mapping/types/aggregate-metric-double.asciidoc
@@ -248,7 +248,7 @@ The search returns the following hit. The value of the `default_metric` field,
 // TESTRESPONSE[s/\.\.\./"took": $body.took,"timed_out": false,"_shards": $body._shards,/]
 
 [[aggregate-metric-double-synthetic-source]]
-==== Synthetic source preview:[]
+==== Synthetic `_source`
 `aggregate_metric-double` fields support <<synthetic-source,synthetic `_source`>> in their default
 configuration. Synthetic `_source` cannot be used together with <<ignore-malformed,`ignore_malformed`>>.
 

--- a/docs/reference/mapping/types/boolean.asciidoc
+++ b/docs/reference/mapping/types/boolean.asciidoc
@@ -216,7 +216,7 @@ The following parameters are accepted by `boolean` fields:
     Metadata about the field.
 
 [[boolean-synthetic-source]]
-==== Synthetic source preview:[]
+==== Synthetic `_source`
 `boolean` fields support <<synthetic-source,synthetic `_source`>> in their
 default configuration. Synthetic `_source` cannot be used together with
 <<copy-to,`copy_to`>> or with <<doc-values,`doc_values`>> disabled.

--- a/docs/reference/mapping/types/date.asciidoc
+++ b/docs/reference/mapping/types/date.asciidoc
@@ -232,7 +232,7 @@ Which will reply with a date like:
 ----
 
 [[date-synthetic-source]]
-==== Synthetic source preview:[]
+==== Synthetic `_source`
 `date` fields support <<synthetic-source,synthetic `_source`>> in their
 default configuration. Synthetic `_source` cannot be used together with
 <<copy-to,`copy_to`>>, <<ignore-malformed,`ignore_malformed`>> set to true

--- a/docs/reference/mapping/types/date_nanos.asciidoc
+++ b/docs/reference/mapping/types/date_nanos.asciidoc
@@ -141,7 +141,7 @@ field. This limitation also affects <<transforms,{transforms}>>.
 ---
 
 [[date-nanos-synthetic-source]]
-==== Synthetic source preview:[]
+==== Synthetic `_source`
 `date_nanos` fields support <<synthetic-source,synthetic `_source`>> in their
 default configuration. Synthetic `_source` cannot be used together with
 <<copy-to,`copy_to`>>, <<ignore-malformed,`ignore_malformed`>> set to true

--- a/docs/reference/mapping/types/dense-vector.asciidoc
+++ b/docs/reference/mapping/types/dense-vector.asciidoc
@@ -180,5 +180,5 @@ neighbors for each new node. Defaults to `100`.
 ====
 
 [[dense-vector-synthetic-source]]
-==== Synthetic source preview:[]
+==== Synthetic `_source`
 `dense_vector` fields support <<synthetic-source,synthetic `_source`>> .

--- a/docs/reference/mapping/types/geo-point.asciidoc
+++ b/docs/reference/mapping/types/geo-point.asciidoc
@@ -205,7 +205,7 @@ def lon      = doc['location'].lon;
 --------------------------------------------------
 
 [[geo-point-synthetic-source]]
-==== Synthetic source preview:[]
+==== Synthetic `_source`
 `geo_point` fields support <<synthetic-source,synthetic `_source`>> in their
 default configuration. Synthetic `_source` cannot be used together with
 <<ignore-malformed,`ignore_malformed`>>, <<copy-to,`copy_to`>>, or with

--- a/docs/reference/mapping/types/histogram.asciidoc
+++ b/docs/reference/mapping/types/histogram.asciidoc
@@ -69,7 +69,7 @@ means the field can technically be aggregated with either algorithm, in practice
 index data in that manner (e.g. centroids for T-Digest or intervals for HDRHistogram) to ensure best accuracy.
 
 [[histogram-synthetic-source]]
-==== Synthetic source preview:[]
+==== Synthetic source
 `histogram` fields support <<synthetic-source,synthetic `_source`>> in their
 default configuration. Synthetic `_source` cannot be used together with
 <<ignore-malformed,`ignore_malformed`>> or <<copy-to,`copy_to`>>.

--- a/docs/reference/mapping/types/ip.asciidoc
+++ b/docs/reference/mapping/types/ip.asciidoc
@@ -152,7 +152,7 @@ GET my-index-000001/_search
 --------------------------------------------------
 
 [[ip-synthetic-source]]
-==== Synthetic source preview:[]
+==== Synthetic source
 `ip` fields support <<synthetic-source,synthetic `_source`>> in their default
 configuration. Synthetic `_source` cannot be used together with
 <<ignore-malformed,`ignore_malformed`>>, <<copy-to,`copy_to`>>, or with

--- a/docs/reference/mapping/types/keyword.asciidoc
+++ b/docs/reference/mapping/types/keyword.asciidoc
@@ -170,7 +170,7 @@ Dimension fields have the following constraints:
 --
 
 [[keyword-synthetic-source]]
-==== Synthetic source preview:[]
+==== Synthetic `_source`
 `keyword` fields support <<synthetic-source,synthetic `_source`>> in their
 default configuration. Synthetic `_source` cannot be used together with
 a <<normalizer,`normalizer`>> or <<copy-to,`copy_to`>>.

--- a/docs/reference/mapping/types/numeric.asciidoc
+++ b/docs/reference/mapping/types/numeric.asciidoc
@@ -228,7 +228,7 @@ numeric field can't be both a time series dimension and a time series metric.
     This parameter is required.
 
 [[numeric-synthetic-source]]
-==== Synthetic source preview:[]
+==== Synthetic `_source`
 All numeric fields except `unsigned_long` support <<synthetic-source,synthetic
 `_source`>> in their default configuration. Synthetic `_source` cannot be used
 together with <<ignore-malformed,`ignore_malformed`>>, <<copy-to,`copy_to`>>, or

--- a/docs/reference/mapping/types/text.asciidoc
+++ b/docs/reference/mapping/types/text.asciidoc
@@ -160,7 +160,7 @@ The following parameters are accepted by `text` fields:
     Metadata about the field.
 
 [[text-synthetic-source]]
-==== Synthetic source preview:[]
+==== Synthetic `_source`
 `text` fields support <<synthetic-source,synthetic `_source`>> if they have
 a <<keyword-synthetic-source, `keyword`>> sub-field that supports synthetic
 `_source` or if the `text` field sets `store` to `true`. Either way, it may

--- a/docs/reference/mapping/types/version.asciidoc
+++ b/docs/reference/mapping/types/version.asciidoc
@@ -69,7 +69,7 @@ you strongly rely on these kind of queries.
 
 
 [[version-synthetic-source]]
-==== Synthetic source preview:[]
+==== Synthetic `_source`
 `version` fields support <<synthetic-source,synthetic `_source`>> so long as they don't
 declare <<copy-to,`copy_to`>>.
 


### PR DESCRIPTION
I've been hacking on synthetic source for a while now and not seen any need to break backwards compatibility or any major bugs. I think it's time to remove the `preview` marker from it so folks can use it without fear.

![image](https://user-images.githubusercontent.com/215970/189995701-ef0645ee-e128-4c05-bab9-a65015375185.png)