### PR TITLE
[8.4] Allow for building multi-arch docker images via buildx (#89986)

### DIFF
--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/docker/DockerSupportService.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/docker/DockerSupportService.java
@@ -7,6 +7,7 @@
  */
 package org.elasticsearch.gradle.internal.docker;
 
+import org.elasticsearch.gradle.Architecture;
 import org.elasticsearch.gradle.Version;
 import org.elasticsearch.gradle.internal.info.BuildParams;
 import org.gradle.api.GradleException;
@@ -23,15 +24,20 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import javax.inject.Inject;
+
+import static java.util.function.Predicate.not;
 
 /**
  * Build service for detecting available Docker installation and checking for compatibility with Elasticsearch Docker image build
@@ -39,10 +45,10 @@ import javax.inject.Inject;
  */
 public abstract class DockerSupportService implements BuildService<DockerSupportService.Parameters> {
 
-    private static Logger LOGGER = Logging.getLogger(DockerSupportService.class);
+    private static final Logger LOGGER = Logging.getLogger(DockerSupportService.class);
     // Defines the possible locations of the Docker CLI. These will be searched in order.
-    private static String[] DOCKER_BINARIES = { "/usr/bin/docker", "/usr/local/bin/docker" };
-    private static String[] DOCKER_COMPOSE_BINARIES = { "/usr/local/bin/docker-compose", "/usr/bin/docker-compose" };
+    private static final String[] DOCKER_BINARIES = { "/usr/bin/docker", "/usr/local/bin/docker" };
+    private static final String[] DOCKER_COMPOSE_BINARIES = { "/usr/local/bin/docker-compose", "/usr/bin/docker-compose" };
     private static final Version MINIMUM_DOCKER_VERSION = Version.fromString("17.05.0");
 
     private final ExecOperations execOperations;
@@ -65,6 +71,7 @@ public abstract class DockerSupportService implements BuildService<DockerSupport
             Version version = null;
             boolean isVersionHighEnough = false;
             boolean isComposeAvailable = false;
+            Set<Architecture> supportedArchitectures = new HashSet<>();
 
             // Check if the Docker binary exists
             final Optional<String> dockerBinary = getDockerPath();
@@ -92,6 +99,25 @@ public abstract class DockerSupportService implements BuildService<DockerSupport
                         if (lastResult.isSuccess() && composePath.isPresent()) {
                             isComposeAvailable = runCommand(composePath.get(), "version").isSuccess();
                         }
+
+                        // Now let's check if buildx is available and what supported platforms exist
+                        if (lastResult.isSuccess()) {
+                            Result buildxResult = runCommand(dockerPath, "buildx", "inspect", "--bootstrap");
+                            if (buildxResult.isSuccess()) {
+                                supportedArchitectures = buildxResult.stdout()
+                                    .lines()
+                                    .filter(l -> l.startsWith("Platforms:"))
+                                    .map(l -> l.substring(10))
+                                    .flatMap(l -> Arrays.stream(l.split(",")).filter(not(String::isBlank)))
+                                    .map(String::trim)
+                                    .map(s -> Arrays.stream(Architecture.values()).filter(a -> a.dockerPlatform.equals(s)).findAny())
+                                    .filter(Optional::isPresent)
+                                    .map(Optional::get)
+                                    .collect(Collectors.toSet());
+                            } else {
+                                supportedArchitectures = Set.of(Architecture.current());
+                            }
+                        }
                     }
                 }
             }
@@ -104,7 +130,8 @@ public abstract class DockerSupportService implements BuildService<DockerSupport
                 isVersionHighEnough,
                 dockerPath,
                 version,
-                lastResult
+                lastResult,
+                supportedArchitectures
             );
         }
 
@@ -334,7 +361,10 @@ public abstract class DockerSupportService implements BuildService<DockerSupport
         Version version,
 
         // Information about the last command executes while probing Docker, or null.
-        Result lastCommand
+        Result lastCommand,
+
+        // Supported build architectures
+        Set<Architecture> supportedArchitectures
     ) {}
 
     /**

--- a/build-tools/src/main/java/org/elasticsearch/gradle/Architecture.java
+++ b/build-tools/src/main/java/org/elasticsearch/gradle/Architecture.java
@@ -10,13 +10,15 @@ package org.elasticsearch.gradle;
 
 public enum Architecture {
 
-    X64("x86_64"),
-    AARCH64("aarch64");
+    X64("x86_64", "linux/amd64"),
+    AARCH64("aarch64", "linux/arm64");
 
     public final String classifier;
+    public final String dockerPlatform;
 
-    Architecture(String classifier) {
+    Architecture(String classifier, String dockerPlatform) {
         this.classifier = classifier;
+        this.dockerPlatform = dockerPlatform;
     }
 
     public static Architecture current() {

--- a/distribution/docker/build.gradle
+++ b/distribution/docker/build.gradle
@@ -4,9 +4,12 @@ import org.elasticsearch.gradle.VersionProperties
 import org.elasticsearch.gradle.internal.DockerBase
 import org.elasticsearch.gradle.internal.distribution.InternalElasticsearchDistributionTypes
 import org.elasticsearch.gradle.internal.docker.DockerBuildTask
+import org.elasticsearch.gradle.internal.docker.DockerSupportPlugin
+import org.elasticsearch.gradle.internal.docker.DockerSupportService
 import org.elasticsearch.gradle.internal.docker.ShellRetry
 import org.elasticsearch.gradle.internal.docker.TransformLog4jConfigFilter
 import org.elasticsearch.gradle.internal.info.BuildParams
+import org.elasticsearch.gradle.util.GradleUtils
 
 import java.nio.file.Path
 import java.time.temporal.ChronoUnit
@@ -271,7 +274,7 @@ void addBuildDockerContextTask(Architecture architecture, DockerBase base) {
         rename ~/((?:file|metric)beat)-.*\.tar\.gz$/, "\$1-${VersionProperties.elasticsearch}.tar.gz"
       }
 
-      onlyIf { Architecture.current() == architecture }
+      onlyIf { isArchitectureSupported(architecture) }
     }
 
   if (base == DockerBase.IRON_BANK) {
@@ -318,12 +321,12 @@ void addTransformDockerContextTask(Architecture architecture, DockerBase base) {
       inputs.property(k, { v.toString() })
     }
 
-    onlyIf { Architecture.current() == architecture }
+    onlyIf { isArchitectureSupported(architecture) }
   }
 }
 
 
-private static List<String> generateTags(DockerBase base) {
+private static List<String> generateTags(DockerBase base, Architecture architecture) {
   final String version = VersionProperties.elasticsearch
 
   String image = "elasticsearch${base.suffix}"
@@ -333,11 +336,13 @@ private static List<String> generateTags(DockerBase base) {
     namespace += '-ci'
   }
 
-  return [
-    "${image}:test",
-    "${image}:${version}",
-    "docker.elastic.co/${namespace}/${image}:${version}"
-  ]
+  def tags = ["${image}:${architecture.classifier}"]
+
+  if (architecture == Architecture.current()) {
+    tags.addAll(["${image}:test", "${image}:${version}", "docker.elastic.co/${namespace}/${image}:${version}"])
+  }
+
+  return tags
 }
 
 void addBuildDockerImageTask(Architecture architecture, DockerBase base) {
@@ -350,7 +355,8 @@ void addBuildDockerImageTask(Architecture architecture, DockerBase base) {
       dockerContext.fileProvider(transformTask.map { Sync task -> task.getDestinationDir() })
 
       noCache = BuildParams.isCi
-      tags = generateTags(base)
+      tags = generateTags(base, architecture)
+      platform = architecture.dockerPlatform
 
       // We don't build the Iron Bank image when we release Elasticsearch, as there's
       // separate process for submitting new releases. However, for testing we do a
@@ -375,7 +381,7 @@ void addBuildDockerImageTask(Architecture architecture, DockerBase base) {
         baseImages = [base.image]
       }
 
-      onlyIf { Architecture.current() == architecture }
+      onlyIf { isArchitectureSupported(architecture) }
     }
 
   if (base != DockerBase.IRON_BANK && base != DockerBase.CLOUD && base != DockerBase.CLOUD_ESS) {
@@ -419,9 +425,10 @@ void addBuildEssDockerImageTask(Architecture architecture) {
 
       noCache = BuildParams.isCi
       baseImages = []
-      tags = generateTags(base)
+      tags = generateTags(base, architecture)
+      platform = architecture.dockerPlatform
 
-      onlyIf { Architecture.current() == architecture }
+      onlyIf { isArchitectureSupported(architecture) }
     }
 
   tasks.named("assemble").configure {
@@ -440,6 +447,11 @@ for (final Architecture architecture : Architecture.values()) {
   }
 
   addBuildEssDockerImageTask(architecture)
+}
+
+boolean isArchitectureSupported(Architecture architecture) {
+  Provider<DockerSupportService> serviceProvider = GradleUtils.getBuildService(project.gradle.sharedServices, DockerSupportPlugin.DOCKER_SUPPORT_SERVICE_NAME)
+  return serviceProvider.get().dockerAvailability.supportedArchitectures().contains(architecture)
 }
 
 /*
@@ -481,10 +493,10 @@ subprojects { Project subProject ->
       args "save",
         "-o",
         tarFile,
-        "elasticsearch${base.suffix}:test"
+        "elasticsearch${base.suffix}:${architecture.classifier}"
 
       dependsOn(parent.path + ":" + buildTaskName)
-      onlyIf { Architecture.current() == architecture }
+      onlyIf { isArchitectureSupported(architecture) }
     }
 
     artifacts.add('default', file(tarFile)) {


### PR DESCRIPTION
Backports the following commits to 8.4:
 - Allow for building multi-arch docker images via buildx (#89986)