### PR TITLE
Remove deadcode in request interceptors

### DIFF
--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authz/interceptor/SearchRequestInterceptor.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authz/interceptor/SearchRequestInterceptor.java
@@ -7,7 +7,6 @@
 package org.elasticsearch.xpack.security.authz.interceptor;
 
 import org.elasticsearch.ElasticsearchSecurityException;
-import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.IndicesRequest;
 import org.elasticsearch.action.search.SearchRequest;
@@ -25,7 +24,6 @@ import static org.elasticsearch.transport.RemoteClusterAware.REMOTE_CLUSTER_INDE
 
 public class SearchRequestInterceptor extends FieldAndDocumentLevelSecurityRequestInterceptor {
 
-    public static final Version VERSION_SHARD_SEARCH_INTERCEPTOR = Version.V_7_11_2;
     private final ClusterService clusterService;
 
     public SearchRequestInterceptor(ThreadPool threadPool, XPackLicenseState licenseState, ClusterService clusterService) {
@@ -40,10 +38,7 @@ public class SearchRequestInterceptor extends FieldAndDocumentLevelSecurityReque
         ActionListener<Void> listener
     ) {
         final SearchRequest request = (SearchRequest) indicesRequest;
-        // The 7.11.2 version check is needed because request caching has a bug related to DLS/FLS
-        // versions before 7.11.2. It is fixed by #69505. See also ESA-2021-08.
-        // TODO: The version check can be removed in 8.0 because 7.last will have support for request caching with DLS/FLS
-        if (clusterService.state().nodes().getMinNodeVersion().before(VERSION_SHARD_SEARCH_INTERCEPTOR) || hasRemoteIndices(request)) {
+        if (hasRemoteIndices(request)) {
             request.requestCache(false);
         }
 

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authz/interceptor/ShardSearchRequestInterceptor.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authz/interceptor/ShardSearchRequestInterceptor.java
@@ -21,8 +21,6 @@ import org.elasticsearch.xpack.core.security.authz.permission.DocumentPermission
 import java.io.IOException;
 import java.util.Map;
 
-import static org.elasticsearch.xpack.security.authz.interceptor.SearchRequestInterceptor.VERSION_SHARD_SEARCH_INTERCEPTOR;
-
 public class ShardSearchRequestInterceptor extends FieldAndDocumentLevelSecurityRequestInterceptor {
 
     private static final Logger logger = LogManager.getLogger(ShardSearchRequestInterceptor.class);
@@ -41,12 +39,7 @@ public class ShardSearchRequestInterceptor extends FieldAndDocumentLevelSecurity
         ActionListener<Void> listener
     ) {
         final ShardSearchRequest request = (ShardSearchRequest) indicesRequest;
-        // The 7.11.2 version check is needed because request caching has a bug related to DLS/FLS
-        // versions before 7.11.2. It is fixed by #69505. See also ESA-2021-08.
-        // TODO: The version check can be removed in 8.0 because 7.last will have support for request caching with DLS/FLS
-        if (clusterService.state().nodes().getMinNodeVersion().before(VERSION_SHARD_SEARCH_INTERCEPTOR)) {
-            request.requestCache(false);
-        } else if (dlsUsesStoredScripts(request, indexAccessControlByIndex)) {
+        if (dlsUsesStoredScripts(request, indexAccessControlByIndex)) {
             logger.debug("Disable shard search request cache because DLS queries use stored scripts");
             request.requestCache(false);
         }

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authz/interceptor/SearchRequestInterceptorTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authz/interceptor/SearchRequestInterceptorTests.java
@@ -66,19 +66,8 @@ public class SearchRequestInterceptorTests extends ESTestCase {
         when(discoveryNodes.getMinNodeVersion()).thenReturn(version);
     }
 
-    public void testRequestCacheWillBeDisabledWhenMinNodeVersionIsBeforeShardSearchInterceptor() {
-        configureMinMondeVersion(VersionUtils.randomVersionBetween(random(), Version.V_7_0_0, Version.V_7_11_1));
-        final SearchRequest searchRequest = mock(SearchRequest.class);
-        when(searchRequest.indices()).thenReturn(randomArray(0, 3, String[]::new, () -> randomAlphaOfLengthBetween(3, 8)));
-        when(searchRequest.source()).thenReturn(SearchSourceBuilder.searchSource());
-        final PlainActionFuture<Void> future = new PlainActionFuture<>();
-        interceptor.disableFeatures(searchRequest, Map.of(), future);
-        future.actionGet();
-        verify(searchRequest).requestCache(false);
-    }
-
     public void testRequestCacheWillBeDisabledWhenSearchRemoteIndices() {
-        configureMinMondeVersion(VersionUtils.randomVersionBetween(random(), Version.V_7_11_2, Version.CURRENT));
+        configureMinMondeVersion(VersionUtils.randomVersion(random()));
         final SearchRequest searchRequest = mock(SearchRequest.class);
         when(searchRequest.source()).thenReturn(SearchSourceBuilder.searchSource());
         final String[] localIndices = randomArray(0, 3, String[]::new, () -> randomAlphaOfLengthBetween(3, 8));


### PR DESCRIPTION
Nothing to see here!
This just removes deadcode that is been guarded by version checks which
don't apply anymore.

This is just a simple PR to get me started on further changing the request
interceptors to not examine the access control map so often.
