### PR TITLE
[8.0] [DOCS] Update FIPS verbiage for the bundled JVM (#89949)

### DIFF
--- a/x-pack/docs/en/security/fips-140-compliance.asciidoc
+++ b/x-pack/docs/en/security/fips-140-compliance.asciidoc
@@ -8,14 +8,16 @@ government computer security standard used to approve cryptographic modules.
 {es} offers a FIPS 140-2 compliant mode and as such can run in a FIPS 140-2
 configured JVM.
 
-IMPORTANT: The JVM bundled with {es} is not configured for FIPS 140-2. You must
-either configure the bundled JVM to run with a FIPS 140-2 certified Java
-Security Provider or use an external JVM configured for FIPS 140-2.
+IMPORTANT: The JVM bundled with {es} is not configured for FIPS 140-2. You must 
+configure an external JDK with a FIPS 140-2 certified Java Security Provider.
+Refer to the {es}
+https://www.elastic.co/support/matrix#matrix_jvm[JVM support matrix] for
+supported JVM configurations.
 
 After configuring your JVM for FIPS 140-2, you can run {es} in FIPS 140-2 mode by
 setting the `xpack.security.fips_mode.enabled` to `true` in `elasticsearch.yml`.
 
-For {es}, adherence to FIPS 140-2 is ensured by
+For {es}, adherence to FIPS 140-2 is ensured by:
 
 - Using FIPS approved / NIST recommended cryptographic algorithms.
 - Delegating the implementation of these cryptographic algorithms to a NIST

--- a/x-pack/docs/en/security/fips-java17.asciidoc
+++ b/x-pack/docs/en/security/fips-java17.asciidoc
@@ -5,5 +5,6 @@ If you run in FIPS 140-2 mode, you will either need to request
 an exception from your security organization to upgrade to {es} {version}, 
 or remain on {es} 7.x until Java 17 is certified. 
 ifeval::["{release-state}"=="released"]
-Alternatively, consider using {ess} in the FedRAMP-certified GovCloud region.
+Alternatively, consider using {ess} in the
+https://www.elastic.co/industries/public-sector/fedramp[FedRAMP-certified GovCloud region].
 endif::[]


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.0`:
 - [[DOCS] Update FIPS verbiage for the bundled JVM (#89949)](https://github.com/elastic/elasticsearch/pull/89949)

<!--- Backport version: 8.4.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)