### PR TITLE
[Transform] don't timeout when transform has a failure during stop

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/indexing/AsyncTwoPhaseIndexer.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/indexing/AsyncTwoPhaseIndexer.java
@@ -418,20 +418,17 @@ public abstract class AsyncTwoPhaseIndexer<JobPosition, JobStats extends Indexer
 
     private void finishWithSearchFailure(Exception exc) {
         stats.incrementSearchFailures();
-        onFailure(exc);
-        doSaveState(finishAndSetState(), position.get(), this::afterFinishOrFailure);
+        finishWithFailure(exc);
     }
 
     private void finishWithIndexingFailure(Exception exc) {
         stats.incrementIndexingFailures();
-        onFailure(exc);
-        doSaveState(finishAndSetState(), position.get(), this::afterFinishOrFailure);
+        finishWithFailure(exc);
     }
 
     private void finishWithFailure(Exception exc) {
         onFailure(exc);
-        finishAndSetState();
-        afterFinishOrFailure();
+        doSaveState(finishAndSetState(), position.get(), this::afterFinishOrFailure);
     }
 
     private IndexerState finishAndSetState() {

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/indexing/AsyncTwoPhaseIndexerTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/indexing/AsyncTwoPhaseIndexerTests.java
@@ -357,7 +357,6 @@ public class AsyncTwoPhaseIndexerTests extends ESTestCase {
 
         @Override
         protected void doSaveState(IndexerState state, Integer position, Runnable next) {
-            fail("should not be called");
         }
 
         @Override

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/indexing/AsyncTwoPhaseIndexerTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/indexing/AsyncTwoPhaseIndexerTests.java
@@ -356,8 +356,7 @@ public class AsyncTwoPhaseIndexerTests extends ESTestCase {
         }
 
         @Override
-        protected void doSaveState(IndexerState state, Integer position, Runnable next) {
-        }
+        protected void doSaveState(IndexerState state, Integer position, Runnable next) {}
 
         @Override
         protected void onFailure(Exception exc) {


### PR DESCRIPTION
fixes a race condition when a transform is stopped and has a failure at the same time. By always saving state after a failure, the transform specialization can shutdown the persistent task.

fixes #90054

Note: This isn't a bug in existing/released versions as this can only happen for _unattended_ transforms, which haven't been released yet. Therefore flagging this as `>test` as this also fixes an integration test