### PR TITLE
Add support for predefined char class regexp on wildcard fields

### DIFF
--- a/docs/changelog/90064.yaml
+++ b/docs/changelog/90064.yaml
@@ -1,0 +1,5 @@
+pr: 90064
+summary: Add support for predefined char class regexp on wildcard fields
+area: Search
+type: bug
+issues: []

--- a/x-pack/plugin/wildcard/src/main/java/org/elasticsearch/xpack/wildcard/mapper/WildcardFieldMapper.java
+++ b/x-pack/plugin/wildcard/src/main/java/org/elasticsearch/xpack/wildcard/mapper/WildcardFieldMapper.java
@@ -443,6 +443,7 @@ public class WildcardFieldMapper extends FieldMapper {
                 case REGEXP_INTERVAL:
                 case REGEXP_EMPTY:
                 case REGEXP_AUTOMATON:
+                case REGEXP_PRE_CLASS:
                     result = new MatchAllDocsQuery();
                     break;
             }

--- a/x-pack/plugin/wildcard/src/test/java/org/elasticsearch/xpack/wildcard/mapper/WildcardFieldMapperTests.java
+++ b/x-pack/plugin/wildcard/src/test/java/org/elasticsearch/xpack/wildcard/mapper/WildcardFieldMapperTests.java
@@ -586,7 +586,13 @@ public class WildcardFieldMapperTests extends MapperTestCase {
             "@&~(abc.+)",
             "aaa.+&.+bbb",
             "a*",
-            "...*.." };
+            "...*..",
+            "\\w",
+            "\\W",
+            "\\s",
+            "\\S",
+            "\\d",
+            "\\D" };
         for (String regex : matchAllButVerifyTests) {
             Query wildcardFieldQuery = wildcardFieldType.fieldType().regexpQuery(regex, RegExp.ALL, 0, 20000, null, MOCK_CONTEXT);
             BinaryDvConfirmedAutomatonQuery q = (BinaryDvConfirmedAutomatonQuery) wildcardFieldQuery;

--- a/x-pack/plugin/wildcard/src/yamlRestTest/resources/rest-api-spec/test/20_regexp.yml
+++ b/x-pack/plugin/wildcard/src/yamlRestTest/resources/rest-api-spec/test/20_regexp.yml
@@ -1,0 +1,125 @@
+setup:
+  - do:
+      indices.create:
+        index:  test
+        body:
+          settings:
+            number_of_shards: 1
+          mappings:
+            properties:
+              test_prop:
+                type: wildcard
+
+  - do:
+      bulk:
+        index: test
+        refresh: true
+        body: |
+          { "index": {"_id" : "1"} }
+          { "test_prop": "foo.bar" }
+          { "index": {"_id" : "2"} }
+          { "test_prop": "foobar" }
+          { "index": {"_id" : "3"} }
+          { "test_prop": "this.that" }
+          { "index": {"_id" : "4"} }
+          { "test_prop": "this that" }
+          { "index": {"_id" : "5"} }
+          { "test_prop": "number42" }
+          { "index": {"_id" : "6"} }
+          { "test_prop": "numberfourtytwo" }
+
+
+---
+"Pre Class Regexp w":
+  - do:
+      search:
+        index: test
+        body:
+          query:
+            regexp:
+              test_prop:
+                value: "foo\\w+"
+          docvalue_fields: [test_prop]
+
+  - match: { hits.total.value: 1 }
+  - match: { hits.hits.0.fields.test_prop.0: "foobar" }
+
+
+---
+"Pre Class Regexp W":
+  - do:
+      search:
+        index: test
+        body:
+          query:
+            regexp:
+              test_prop:
+                value: "foo\\W+bar"
+          docvalue_fields: [test_prop]
+
+  - match: { hits.total.value: 1 }
+  - match: { hits.hits.0.fields.test_prop.0: "foo.bar" }
+
+
+---
+"Pre Class Regexp s":
+  - do:
+      search:
+        index: test
+        body:
+          query:
+            regexp:
+              test_prop:
+                value: "this\\sthat"
+          docvalue_fields: [test_prop]
+
+  - match: { hits.total.value: 1 }
+  - match: { hits.hits.0.fields.test_prop.0: "this that" }
+
+
+---
+"Pre Class Regexp S":
+  - do:
+      search:
+        index: test
+        body:
+          query:
+            regexp:
+              test_prop:
+                value: "this\\Sthat"
+          docvalue_fields: [test_prop]
+
+  - match: { hits.total.value: 1 }
+  - match: { hits.hits.0.fields.test_prop.0: "this.that" }
+
+
+---
+"Pre Class Regexp d":
+  - do:
+      search:
+        index: test
+        body:
+          query:
+            regexp:
+              test_prop:
+                value: "number\\d+"
+          docvalue_fields: [test_prop]
+
+  - match: { hits.total.value: 1 }
+  - match: { hits.hits.0.fields.test_prop.0: "number42" }
+
+
+---
+"Pre Class Regexp D":
+  - do:
+      search:
+        index: test
+        body:
+          query:
+            regexp:
+              test_prop:
+                value: "number\\D+"
+          docvalue_fields: [test_prop]
+
+  - match: { hits.total.value: 1 }
+  - match: { hits.hits.0.fields.test_prop.0: "numberfourtytwo" }


### PR DESCRIPTION
Add support for predefined character classes (`\d`, `\D`, `\s`, `\S`, `\w`, `\W`), as defined by Java Pattern specification, for regexp queries on wildcard fields.

Eg.

```
{
    "query": {
        "regexp": {
            "my_field_name": {
                "value": "\\w+"
            }
        }
    }
}
```

Related to https://github.com/elastic/detection-rules/issues/2260