### PR TITLE
Account for using ML snapshot builds in HLRC release tests

### DIFF
--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/PingAndInfoIT.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/PingAndInfoIT.java
@@ -19,6 +19,8 @@ import java.io.IOException;
 import java.util.EnumSet;
 import java.util.Map;
 
+import static org.hamcrest.Matchers.startsWith;
+
 public class PingAndInfoIT extends ESRestHighLevelClientTestCase {
 
     public void testPing() throws IOException {
@@ -71,7 +73,9 @@ public class PingAndInfoIT extends ESRestHighLevelClientTestCase {
         FeatureSet ml = info.getFeatureSetsInfo().getFeatureSets().get("ml");
         assertTrue(ml.available());
         assertTrue(ml.enabled());
-        assertEquals(mainResponse.getVersion().getNumber(), ml.nativeCodeInfo().get("version").toString());
+        // startsWith because since https://github.com/elastic/elasticsearch/pull/89951 the
+        // release-tests CI jobs use ML snapshot builds
+        assertThat(ml.nativeCodeInfo().get("version").toString(), startsWith(mainResponse.getVersion().getNumber()));
     }
 
     public void testXPackInfoEmptyRequest() throws IOException {


### PR DESCRIPTION
Since https://github.com/elastic/elasticsearch/pull/89951 we use ML snapshot builds in all elasticsearch-ci jobs, even the release-tests ones.

The test of the reported ML native code version in the HLRC tests needs to account for this.

This change is 7.17 only, as the HLRC is removed in 8.x.