### PR TITLE
[8.3] Add master_timeout to the snapshot delete docs (#90032)

### DIFF
--- a/docs/reference/snapshot-restore/apis/delete-snapshot-api.asciidoc
+++ b/docs/reference/snapshot-restore/apis/delete-snapshot-api.asciidoc
@@ -53,6 +53,11 @@ Name of the repository to delete a snapshot from.
 (Required, string)
 Comma-separated list of snapshot names to delete. Also accepts wildcards (`*`).
 
+[[delete-snapshot-api-query-params]]
+==== {api-query-parms-title}
+
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=master-timeout]
+
 [[delete-snapshot-api-example]]
 ==== {api-example-title}
 


### PR DESCRIPTION
Backports the following commits to 8.3:
 - Add master_timeout to the snapshot delete docs (#90032)