### PR TITLE
Changing health indicator diagnosis resources from strings to objects

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/ShardsAvailabilityHealthIndicatorService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/ShardsAvailabilityHealthIndicatorService.java
@@ -882,7 +882,11 @@ public class ShardsAvailabilityHealthIndicatorService implements HealthIndicator
                         .map(
                             e -> new Diagnosis(
                                 e.getKey(),
-                                e.getValue().stream().sorted(byPriorityThenByName(clusterMetadata)).collect(Collectors.toList())
+                                e.getValue()
+                                    .stream()
+                                    .sorted(byPriorityThenByName(clusterMetadata))
+                                    .map(indexName -> new Diagnosis.Resource(Diagnosis.Resource.Type.INDEX, indexName))
+                                    .collect(Collectors.toList())
                             )
                         )
                         .collect(Collectors.toList());

--- a/server/src/main/java/org/elasticsearch/snapshots/RepositoryIntegrityHealthIndicatorService.java
+++ b/server/src/main/java/org/elasticsearch/snapshots/RepositoryIntegrityHealthIndicatorService.java
@@ -110,6 +110,11 @@ public class RepositoryIntegrityHealthIndicatorService implements HealthIndicato
                 List.of(ImpactArea.BACKUP)
             )
         );
+        List<Diagnosis.Resource> corruptedResources = snapshotMetadata.repositories()
+            .stream()
+            .filter(repository -> repository.generation() == RepositoryData.CORRUPTED_REPO_GEN)
+            .map(repository -> new Diagnosis.Resource(Diagnosis.Resource.Type.REPOSITORY, repository.uuid(), repository.name()))
+            .toList();
         return createIndicator(
             RED,
             createCorruptedRepositorySummary(corrupted),
@@ -126,7 +131,7 @@ public class RepositoryIntegrityHealthIndicatorService implements HealthIndicato
                 )
                 : HealthIndicatorDetails.EMPTY,
             impacts,
-            List.of(new Diagnosis(CORRUPTED_REPOSITORY, corrupted))
+            List.of(new Diagnosis(CORRUPTED_REPOSITORY, corruptedResources))
         );
     }
 

--- a/server/src/test/java/org/elasticsearch/cluster/routing/allocation/ShardsAvailabilityHealthIndicatorServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/allocation/ShardsAvailabilityHealthIndicatorServiceTests.java
@@ -159,7 +159,12 @@ public class ShardsAvailabilityHealthIndicatorServiceTests extends ESTestCase {
                             List.of(ImpactArea.SEARCH)
                         )
                     ),
-                    List.of(new Diagnosis(ACTION_CHECK_ALLOCATION_EXPLAIN_API, List.of("yellow-index")))
+                    List.of(
+                        new Diagnosis(
+                            ACTION_CHECK_ALLOCATION_EXPLAIN_API,
+                            List.of(new Diagnosis.Resource(Diagnosis.Resource.Type.INDEX, "yellow-index"))
+                        )
+                    )
                 )
             )
         );
@@ -186,7 +191,12 @@ public class ShardsAvailabilityHealthIndicatorServiceTests extends ESTestCase {
                             List.of(ImpactArea.INGEST, ImpactArea.SEARCH)
                         )
                     ),
-                    List.of(new Diagnosis(ACTION_CHECK_ALLOCATION_EXPLAIN_API, List.of("red-index")))
+                    List.of(
+                        new Diagnosis(
+                            ACTION_CHECK_ALLOCATION_EXPLAIN_API,
+                            List.of(new Diagnosis.Resource(Diagnosis.Resource.Type.INDEX, "red-index"))
+                        )
+                    )
                 )
             )
         );
@@ -210,7 +220,12 @@ public class ShardsAvailabilityHealthIndicatorServiceTests extends ESTestCase {
                             List.of(ImpactArea.INGEST, ImpactArea.SEARCH)
                         )
                     ),
-                    List.of(new Diagnosis(ACTION_CHECK_ALLOCATION_EXPLAIN_API, List.of("red-index")))
+                    List.of(
+                        new Diagnosis(
+                            ACTION_CHECK_ALLOCATION_EXPLAIN_API,
+                            List.of(new Diagnosis.Resource(Diagnosis.Resource.Type.INDEX, "red-index"))
+                        )
+                    )
                 )
             )
         );
@@ -388,7 +403,12 @@ public class ShardsAvailabilityHealthIndicatorServiceTests extends ESTestCase {
                             List.of(ImpactArea.SEARCH)
                         )
                     ),
-                    List.of(new Diagnosis(DIAGNOSIS_WAIT_FOR_OR_FIX_DELAYED_SHARDS, List.of("restarting-index")))
+                    List.of(
+                        new Diagnosis(
+                            DIAGNOSIS_WAIT_FOR_OR_FIX_DELAYED_SHARDS,
+                            List.of(new Diagnosis.Resource(Diagnosis.Resource.Type.INDEX, "restarting-index"))
+                        )
+                    )
                 )
             )
         );
@@ -462,7 +482,12 @@ public class ShardsAvailabilityHealthIndicatorServiceTests extends ESTestCase {
                             List.of(ImpactArea.INGEST, ImpactArea.SEARCH)
                         )
                     ),
-                    List.of(new Diagnosis(DIAGNOSIS_WAIT_FOR_OR_FIX_DELAYED_SHARDS, List.of("restarting-index")))
+                    List.of(
+                        new Diagnosis(
+                            DIAGNOSIS_WAIT_FOR_OR_FIX_DELAYED_SHARDS,
+                            List.of(new Diagnosis.Resource(Diagnosis.Resource.Type.INDEX, "restarting-index"))
+                        )
+                    )
                 )
             )
         );

--- a/server/src/test/java/org/elasticsearch/health/HealthIndicatorResultTests.java
+++ b/server/src/test/java/org/elasticsearch/health/HealthIndicatorResultTests.java
@@ -44,7 +44,7 @@ public class HealthIndicatorResultTests extends ESTestCase {
             new ArrayList<>()
         );
         for (int i = 0; i < randomInt(10); i++) {
-            action1.affectedResources().add(randomAlphaOfLength(10));
+            action1.affectedResources().add(new Diagnosis.Resource(Diagnosis.Resource.Type.INDEX, randomAlphaOfLength(10)));
         }
         actions.add(action1);
         Diagnosis action2 = new Diagnosis(
@@ -52,7 +52,7 @@ public class HealthIndicatorResultTests extends ESTestCase {
             new ArrayList<>()
         );
         for (int i = 0; i < randomInt(10); i++) {
-            action2.affectedResources().add(randomAlphaOfLength(10));
+            action2.affectedResources().add(new Diagnosis.Resource(Diagnosis.Resource.Type.INDEX, randomAlphaOfLength(10)));
         }
         actions.add(action2);
         HealthIndicatorResult result = new HealthIndicatorResult(name, status, symptom, details, impacts, actions);

--- a/server/src/test/java/org/elasticsearch/snapshots/RepositoryIntegrityHealthIndicatorServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/snapshots/RepositoryIntegrityHealthIndicatorServiceTests.java
@@ -87,7 +87,12 @@ public class RepositoryIntegrityHealthIndicatorServiceTests extends ESTestCase {
                             List.of(ImpactArea.BACKUP)
                         )
                     ),
-                    List.of(new Diagnosis(CORRUPTED_REPOSITORY, corruptedRepos))
+                    List.of(
+                        new Diagnosis(
+                            CORRUPTED_REPOSITORY,
+                            corruptedRepos.stream().map(repo -> new Diagnosis.Resource(Diagnosis.Resource.Type.REPOSITORY, repo)).toList()
+                        )
+                    )
                 )
             )
         );

--- a/x-pack/plugin/core/src/internalClusterTest/java/org/elasticsearch/xpack/cluster/routing/allocation/DataTierShardAvailabilityHealthIndicatorIT.java
+++ b/x-pack/plugin/core/src/internalClusterTest/java/org/elasticsearch/xpack/cluster/routing/allocation/DataTierShardAvailabilityHealthIndicatorIT.java
@@ -79,7 +79,7 @@ public class DataTierShardAvailabilityHealthIndicatorIT extends ESIntegTestCase 
             hasItem(
                 new Diagnosis(
                     ShardsAvailabilityHealthIndicatorService.ACTION_INCREASE_TIER_CAPACITY_LOOKUP.get(DataTier.DATA_HOT),
-                    List.of("test")
+                    List.of(new Diagnosis.Resource(Diagnosis.Resource.Type.INDEX, "test"))
                 )
             )
         );
@@ -125,7 +125,7 @@ public class DataTierShardAvailabilityHealthIndicatorIT extends ESIntegTestCase 
             hasItem(
                 new Diagnosis(
                     ShardsAvailabilityHealthIndicatorService.ACTION_INCREASE_TIER_CAPACITY_LOOKUP.get(DataTier.DATA_HOT),
-                    List.of("test")
+                    List.of(new Diagnosis.Resource(Diagnosis.Resource.Type.INDEX, "test"))
                 )
             )
         );
@@ -159,7 +159,12 @@ public class DataTierShardAvailabilityHealthIndicatorIT extends ESIntegTestCase 
         assertThat(indicatorResult.diagnosisList().size(), equalTo(1));
         assertThat(
             indicatorResult.diagnosisList(),
-            hasItem(new Diagnosis(ShardsAvailabilityHealthIndicatorService.DIAGNOSIS_WAIT_FOR_OR_FIX_DELAYED_SHARDS, List.of("test")))
+            hasItem(
+                new Diagnosis(
+                    ShardsAvailabilityHealthIndicatorService.DIAGNOSIS_WAIT_FOR_OR_FIX_DELAYED_SHARDS,
+                    List.of(new Diagnosis.Resource(Diagnosis.Resource.Type.INDEX, "test"))
+                )
+            )
         );
     }
 

--- a/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/slm/SlmHealthIndicatorService.java
+++ b/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/slm/SlmHealthIndicatorService.java
@@ -165,7 +165,10 @@ public class SlmHealthIndicatorService implements HealthIndicatorService {
                     List.of(
                         new Diagnosis(
                             checkRecentlyFailedSnapshots(cause, action),
-                            unhealthyPolicies.stream().map(SnapshotLifecyclePolicyMetadata::getName).toList()
+                            unhealthyPolicies.stream()
+                                .map(SnapshotLifecyclePolicyMetadata::getName)
+                                .map(policy -> new Diagnosis.Resource(Diagnosis.Resource.Type.POLICY, policy))
+                                .toList()
                         )
                     )
                 );

--- a/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/slm/SlmHealthIndicatorServiceTests.java
+++ b/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/slm/SlmHealthIndicatorServiceTests.java
@@ -220,7 +220,7 @@ public class SlmHealthIndicatorServiceTests extends ESTestCase {
                                     + "]",
                                 "Check the snapshot lifecycle policy for detailed failure info:\n- /_slm/policy/test-policy?human"
                             ),
-                            List.of("test-policy")
+                            List.of(new Diagnosis.Resource(Diagnosis.Resource.Type.POLICY, "test-policy"))
                         )
                     )
                 )


### PR DESCRIPTION
This changes the health indicator diagnosis resources from strings to objects so that we can capture type (useful when the list has mixed types) and other information.
Note: This is just a draft to use as a talking point. We're not even sure if we want to do this.