### PR TITLE
Revert change that would return type name in the field caps API

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/fieldcaps/FieldCapabilitiesFetcher.java
+++ b/server/src/main/java/org/elasticsearch/action/fieldcaps/FieldCapabilitiesFetcher.java
@@ -117,11 +117,7 @@ class FieldCapabilitiesFetcher {
             if (filter.test(ft)) {
                 IndexFieldCapabilities fieldCap = new IndexFieldCapabilities(
                     field,
-                    // This is a nasty hack so that we expose aggregate_metric_double field,
-                    // when the index is a time series index and the field is marked as metric.
-                    // This code should be reverted once PR https://github.com/elastic/elasticsearch/pull/87849
-                    // is merged.
-                    isTimeSeriesIndex && ft.getMetricType() != null ? ft.typeName() : ft.familyTypeName(),
+                    ft.familyTypeName(),
                     context.isMetadataField(field),
                     ft.isSearchable(),
                     ft.isAggregatable(),


### PR DESCRIPTION
Since  `aggregate_metric_field` was presented as a `double` in the field caps API, 
we had a committed a temporary change that would treat `aggregate_metric_double` 
fields as a special case.

After merging PR #87849 that exposes `aggregate_metric_field` with its own field type
in all cases, we can revert this change.