### PR TITLE
[TSDB] Improve downsampling performance by using tsid ordinals

### DIFF
--- a/x-pack/plugin/rollup/src/test/java/org/elasticsearch/xpack/downsample/DownsampleActionSingleNodeTests.java
+++ b/x-pack/plugin/rollup/src/test/java/org/elasticsearch/xpack/downsample/DownsampleActionSingleNodeTests.java
@@ -477,7 +477,6 @@ public class DownsampleActionSingleNodeTests extends ESSingleNodeTestCase {
         assertBusy(() -> assertTrue("In progress rollup did not complete", rollupListener.success), 60, TimeUnit.SECONDS);
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/88800")
     public void testRollupDatastream() throws Exception {
         DownsampleConfig config = new DownsampleConfig(randomInterval());
         String dataStreamName = createDataStream();


### PR DESCRIPTION
This PR modifies downsampling operation so that it uses global ordinal to track tsid changes

PR depends on the work done in #90035

Relates to #74660