### PR TITLE
Reinstate prerelease upgrade warning

### DIFF
--- a/docs/reference/upgrade.asciidoc
+++ b/docs/reference/upgrade.asciidoc
@@ -3,14 +3,14 @@
 
 ifeval::["{release-state}"!="released"]
 [[upgrade-pre-release]]
-NOTE: This documentation is for {es} version {version}, which is not yet
-released. You may run a pre-release build of {es} for testing, and you may
-upgrade from an earlier released version to a pre-release build of {es}
-{version} if permitted by the usual version compatibility rules, but upgrading
-from a pre-release build to another build (whether released or not) is
-unsupported. Upgrading a pre-release build may result in errors or may appear
-to succeed having silently lost some data. You should discard the contents of a
-cluster running a pre-release build before using a different build.
+IMPORTANT: This documentation is for {es} {version}, which is not yet released.
+You can upgrade from a previously released version to a pre-release build, if
+following a supported upgrade path. Upgrading from a pre-release build to any 
+other build is not supported, and can result in errors or data loss. If you run
+a pre-release build for testing, discard the contents of the cluster before 
+upgrading to the released version of {es}.
+
+
 endif::[]
 
 {es} clusters can usually be upgraded one node at a time so upgrading does not

--- a/docs/reference/upgrade.asciidoc
+++ b/docs/reference/upgrade.asciidoc
@@ -6,9 +6,9 @@ ifeval::["{release-state}"!="released"]
 IMPORTANT: This documentation is for {es} {version}, which is not yet released.
 You can upgrade from a previously released version to a pre-release build, if
 following a supported upgrade path. Upgrading from a pre-release build to any
-other build is not supported, and can result in errors or data loss. If you run
-a pre-release build for testing, discard the contents of the cluster before
-upgrading to the released version of {es}.
+other build is not supported, and can result in errors or silent data loss. If
+you run a pre-release build for testing, discard the contents of the cluster
+before upgrading to another build of {es}.
 endif::[]
 
 {es} clusters can usually be upgraded one node at a time so upgrading does not

--- a/docs/reference/upgrade.asciidoc
+++ b/docs/reference/upgrade.asciidoc
@@ -5,12 +5,10 @@ ifeval::["{release-state}"!="released"]
 [[upgrade-pre-release]]
 IMPORTANT: This documentation is for {es} {version}, which is not yet released.
 You can upgrade from a previously released version to a pre-release build, if
-following a supported upgrade path. Upgrading from a pre-release build to any 
+following a supported upgrade path. Upgrading from a pre-release build to any
 other build is not supported, and can result in errors or data loss. If you run
-a pre-release build for testing, discard the contents of the cluster before 
+a pre-release build for testing, discard the contents of the cluster before
 upgrading to the released version of {es}.
-
-
 endif::[]
 
 {es} clusters can usually be upgraded one node at a time so upgrading does not

--- a/docs/reference/upgrade.asciidoc
+++ b/docs/reference/upgrade.asciidoc
@@ -1,6 +1,18 @@
 [[setup-upgrade]]
 = Upgrade {es}
 
+ifeval::["{release-state}"!="released"]
+[[upgrade-pre-release]]
+NOTE: This documentation is for {es} version {version}, which is not yet
+released. You may run a pre-release build of {es} for testing, and you may
+upgrade from an earlier released version to a pre-release build of {es}
+{version} if permitted by the usual version compatibility rules, but upgrading
+from a pre-release build to another build (whether released or not) is
+unsupported. Upgrading a pre-release build may result in errors or may appear
+to succeed having silently lost some data. You should discard the contents of a
+cluster running a pre-release build before using a different build.
+endif::[]
+
 {es} clusters can usually be upgraded one node at a time so upgrading does not
 interrupt service. For upgrade instructions, refer to
 {stack-ref}/upgrading-elastic-stack.html[Upgrading to Elastic {version}].


### PR DESCRIPTION
This warning was lost in #83489, but it's important we have it in these docs since users keep on trying this kind of invalid upgrade. This commit reinstates the lost warning.