### PR TITLE
Update threadpool.asciidoc

### DIFF
--- a/docs/reference/modules/threadpool.asciidoc
+++ b/docs/reference/modules/threadpool.asciidoc
@@ -177,9 +177,10 @@ thread_pool:
 The number of processors is automatically detected, and the thread pool settings
 are automatically set based on it. In some cases it can be useful to override
 the number of detected processors. This can be done by explicitly setting the
-`node.processors` setting. This setting accepts floating point numbers, this
-can be useful in environments where the Elasticsearch nodes are configured
-to run with CPU limits, such as cpu shares or quota under `Cgroups`.
+`node.processors` setting. This setting is  bounded by the number of available
+processors and accepts floating point numbers, which can be useful in environments
+where the Elasticsearch nodes are configured to run with CPU limits, such as cpu
+shares or quota under `Cgroups`. 
 
 [source,yaml]
 --------------------------------------------------

--- a/docs/reference/modules/threadpool.asciidoc
+++ b/docs/reference/modules/threadpool.asciidoc
@@ -177,9 +177,9 @@ thread_pool:
 The number of processors is automatically detected, and the thread pool settings
 are automatically set based on it. In some cases it can be useful to override
 the number of detected processors. This can be done by explicitly setting the
-`node.processors` setting. This setting is  bounded by the number of available
+`node.processors` setting. This setting is bounded by the number of available
 processors and accepts floating point numbers, which can be useful in environments
-where the Elasticsearch nodes are configured to run with CPU limits, such as cpu
+where the {es} nodes are configured to run with CPU limits, such as cpu
 shares or quota under `Cgroups`. 
 
 [source,yaml]


### PR DESCRIPTION
Starting from 8.0 the value of the `node.processors` setting is  bounded by the number of available processors https://github.com/elastic/elasticsearch/pull/44894