### PR TITLE
Remove ShapeValues from Geo specific classes in favour of GeoShapeValues

### DIFF
--- a/x-pack/plugin/spatial/src/internalClusterTest/java/org/elasticsearch/xpack/spatial/search/GeoShapeScriptDocValuesIT.java
+++ b/x-pack/plugin/spatial/src/internalClusterTest/java/org/elasticsearch/xpack/spatial/search/GeoShapeScriptDocValuesIT.java
@@ -81,7 +81,7 @@ public class GeoShapeScriptDocValuesIT extends ESSingleNodeTestCase {
 
         private double scriptHeight(Map<String, Object> vars) {
             Map<?, ?> doc = (Map<?, ?>) vars.get("doc");
-            LeafShapeFieldData.ShapeScriptValues<GeoPoint> geometry = assertGeometry(doc);
+            LeafShapeFieldData.ShapeScriptValues<GeoPoint, GeoShapeValues.GeoShapeValue> geometry = assertGeometry(doc);
             if (geometry.size() == 0) {
                 return Double.NaN;
             } else {
@@ -92,7 +92,7 @@ public class GeoShapeScriptDocValuesIT extends ESSingleNodeTestCase {
 
         private double scriptWidth(Map<String, Object> vars) {
             Map<?, ?> doc = (Map<?, ?>) vars.get("doc");
-            LeafShapeFieldData.ShapeScriptValues<GeoPoint> geometry = assertGeometry(doc);
+            LeafShapeFieldData.ShapeScriptValues<GeoPoint, GeoShapeValues.GeoShapeValue> geometry = assertGeometry(doc);
             if (geometry.size() == 0) {
                 return Double.NaN;
             } else {
@@ -103,29 +103,29 @@ public class GeoShapeScriptDocValuesIT extends ESSingleNodeTestCase {
 
         private double scriptLat(Map<String, Object> vars) {
             Map<?, ?> doc = (Map<?, ?>) vars.get("doc");
-            LeafShapeFieldData.ShapeScriptValues<GeoPoint> geometry = assertGeometry(doc);
+            LeafShapeFieldData.ShapeScriptValues<GeoPoint, GeoShapeValues.GeoShapeValue> geometry = assertGeometry(doc);
             return geometry.size() == 0 ? Double.NaN : geometry.getCentroid().lat();
         }
 
         private double scriptLon(Map<String, Object> vars) {
             Map<?, ?> doc = (Map<?, ?>) vars.get("doc");
-            LeafShapeFieldData.ShapeScriptValues<GeoPoint> geometry = assertGeometry(doc);
+            LeafShapeFieldData.ShapeScriptValues<GeoPoint, GeoShapeValues.GeoShapeValue> geometry = assertGeometry(doc);
             return geometry.size() == 0 ? Double.NaN : geometry.getCentroid().lon();
         }
 
         private double scriptLabelLat(Map<String, Object> vars) {
             Map<?, ?> doc = (Map<?, ?>) vars.get("doc");
-            LeafShapeFieldData.ShapeScriptValues<GeoPoint> geometry = assertGeometry(doc);
+            LeafShapeFieldData.ShapeScriptValues<GeoPoint, GeoShapeValues.GeoShapeValue> geometry = assertGeometry(doc);
             return geometry.size() == 0 ? Double.NaN : geometry.getLabelPosition().lat();
         }
 
         private double scriptLabelLon(Map<String, Object> vars) {
             Map<?, ?> doc = (Map<?, ?>) vars.get("doc");
-            LeafShapeFieldData.ShapeScriptValues<GeoPoint> geometry = assertGeometry(doc);
+            LeafShapeFieldData.ShapeScriptValues<GeoPoint, GeoShapeValues.GeoShapeValue> geometry = assertGeometry(doc);
             return geometry.size() == 0 ? Double.NaN : geometry.getLabelPosition().lon();
         }
 
-        private LeafShapeFieldData.ShapeScriptValues<GeoPoint> assertGeometry(Map<?, ?> doc) {
+        private LeafShapeFieldData.ShapeScriptValues<GeoPoint, GeoShapeValues.GeoShapeValue> assertGeometry(Map<?, ?> doc) {
             AbstractAtomicGeoShapeShapeFieldData.GeoShapeScriptValues geometry =
                 (AbstractAtomicGeoShapeShapeFieldData.GeoShapeScriptValues) doc.get("location");
             if (geometry.size() == 0) {

--- a/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/index/fielddata/GeoShapeValues.java
+++ b/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/index/fielddata/GeoShapeValues.java
@@ -33,7 +33,7 @@ import java.io.IOException;
  *
  * There is just one value for one document.
  */
-public abstract class GeoShapeValues extends ShapeValues {
+public abstract class GeoShapeValues extends ShapeValues<GeoShapeValues.GeoShapeValue> {
 
     public static GeoShapeValues EMPTY = new GeoShapeValues() {
         private final GeoShapeValuesSourceType DEFAULT_VALUES_SOURCE_TYPE = GeoShapeValuesSourceType.instance();

--- a/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/index/fielddata/IndexShapeFieldData.java
+++ b/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/index/fielddata/IndexShapeFieldData.java
@@ -12,4 +12,4 @@ import org.elasticsearch.index.fielddata.IndexFieldData;
 /**
  * Specialization of {@link IndexFieldData} for geo shapes and shapes.
  */
-public interface IndexShapeFieldData extends IndexFieldData<LeafShapeFieldData> {}
+public interface IndexShapeFieldData<T extends ShapeValues<?>> extends IndexFieldData<LeafShapeFieldData<T>> {}

--- a/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/index/fielddata/ShapeValues.java
+++ b/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/index/fielddata/ShapeValues.java
@@ -41,15 +41,15 @@ import java.util.function.Supplier;
  *
  * There is just one value for one document.
  */
-public abstract class ShapeValues {
+public abstract class ShapeValues<T extends ShapeValues.ShapeValue> {
     protected final CoordinateEncoder encoder;
-    protected final Supplier<ShapeValue> supplier;
+    protected final Supplier<T> supplier;
     protected final ShapeIndexer missingShapeIndexer;
 
     /**
      * Creates a new {@link ShapeValues} instance
      */
-    protected ShapeValues(CoordinateEncoder encoder, Supplier<ShapeValue> supplier, ShapeIndexer missingShapeIndexer) {
+    protected ShapeValues(CoordinateEncoder encoder, Supplier<T> supplier, ShapeIndexer missingShapeIndexer) {
         this.encoder = encoder;
         this.supplier = supplier;
         this.missingShapeIndexer = missingShapeIndexer;
@@ -70,14 +70,14 @@ public abstract class ShapeValues {
      *
      * @return the value for the current docID set to {@link #advanceExact(int)}.
      */
-    public abstract ShapeValue value() throws IOException;
+    public abstract T value() throws IOException;
 
-    public ShapeValue missing(String missing) {
+    public T missing(String missing) {
         try {
             final Geometry geometry = WellKnownText.fromWKT(GeographyValidator.instance(true), true, missing);
             final BinaryShapeDocValuesField field = new BinaryShapeDocValuesField("missing", encoder);
             field.add(missingShapeIndexer.indexShape(geometry), geometry);
-            final ShapeValue value = supplier.get();
+            final T value = supplier.get();
             value.reset(field.binaryValue());
             return value;
         } catch (IOException | ParseException e) {
@@ -87,7 +87,7 @@ public abstract class ShapeValues {
 
     /** thin wrapper around a {@link GeometryDocValueReader} which encodes / decodes values using
      * the Geo decoder */
-    public abstract static class ShapeValue implements ToXContentFragment {
+    protected abstract static class ShapeValue implements ToXContentFragment {
         protected final GeometryDocValueReader reader;
         private final BoundingBox boundingBox;
         private final Tile2DVisitor tile2DVisitor;

--- a/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/index/fielddata/plain/AbstractAtomicGeoShapeShapeFieldData.java
+++ b/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/index/fielddata/plain/AbstractAtomicGeoShapeShapeFieldData.java
@@ -7,43 +7,63 @@
 
 package org.elasticsearch.xpack.spatial.index.fielddata.plain;
 
+import org.apache.lucene.util.Accountable;
 import org.elasticsearch.common.geo.GeoBoundingBox;
 import org.elasticsearch.common.geo.GeoPoint;
 import org.elasticsearch.index.fielddata.ScriptDocValues;
 import org.elasticsearch.script.field.ToScriptFieldFactory;
 import org.elasticsearch.xpack.spatial.index.fielddata.GeoShapeValues;
 import org.elasticsearch.xpack.spatial.index.fielddata.LeafShapeFieldData;
-import org.elasticsearch.xpack.spatial.index.fielddata.ShapeValues;
+
+import java.util.Collection;
+import java.util.Collections;
 
 import static org.elasticsearch.common.geo.SphericalMercatorUtils.latToSphericalMercator;
 import static org.elasticsearch.common.geo.SphericalMercatorUtils.lonToSphericalMercator;
 
-public abstract class AbstractAtomicGeoShapeShapeFieldData extends LeafShapeFieldData {
+public abstract class AbstractAtomicGeoShapeShapeFieldData extends LeafShapeFieldData<GeoShapeValues> {
 
-    public AbstractAtomicGeoShapeShapeFieldData(ToScriptFieldFactory<ShapeValues> toScriptFieldFactory) {
+    private static class Empty extends AbstractAtomicGeoShapeShapeFieldData {
+        private final GeoShapeValues emptyValues;
+
+        Empty(ToScriptFieldFactory<GeoShapeValues> toScriptFieldFactory, GeoShapeValues emptyValues) {
+            super(toScriptFieldFactory);
+            this.emptyValues = emptyValues;
+        }
+
+        @Override
+        public long ramBytesUsed() {
+            return 0;
+        }
+
+        @Override
+        public Collection<Accountable> getChildResources() {
+            return Collections.emptyList();
+        }
+
+        @Override
+        public void close() {}
+
+        @Override
+        public GeoShapeValues getShapeValues() {
+            return emptyValues;
+        }
+    }
+
+    public AbstractAtomicGeoShapeShapeFieldData(ToScriptFieldFactory<GeoShapeValues> toScriptFieldFactory) {
         super(toScriptFieldFactory);
     }
 
-    public static LeafShapeFieldData empty(final int maxDoc, ToScriptFieldFactory<ShapeValues> toScriptFieldFactory) {
-        return new LeafShapeFieldData.Empty<>(toScriptFieldFactory, GeoShapeValues.EMPTY);
+    public static AbstractAtomicGeoShapeShapeFieldData empty(final int maxDoc, ToScriptFieldFactory<GeoShapeValues> toScriptFieldFactory) {
+        return new Empty(toScriptFieldFactory, GeoShapeValues.EMPTY);
     }
 
-    public static final class GeoShapeScriptValues extends LeafShapeFieldData.ShapeScriptValues<GeoPoint>
+    public static final class GeoShapeScriptValues extends LeafShapeFieldData.ShapeScriptValues<GeoPoint, GeoShapeValues.GeoShapeValue>
         implements
             ScriptDocValues.Geometry {
 
-        public GeoShapeScriptValues(GeometrySupplier<GeoPoint, ShapeValues.ShapeValue> supplier) {
+        public GeoShapeScriptValues(GeometrySupplier<GeoPoint, GeoShapeValues.GeoShapeValue> supplier) {
             super(supplier);
-        }
-
-        @Override
-        public GeoShapeValues.GeoShapeValue get(int index) {
-            return (GeoShapeValues.GeoShapeValue) super.get(index);
-        }
-
-        @Override
-        public GeoShapeValues.GeoShapeValue getValue() {
-            return (GeoShapeValues.GeoShapeValue) super.getValue();
         }
 
         @Override

--- a/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/index/fielddata/plain/AbstractAtomicGeoShapeShapeFieldData.java
+++ b/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/index/fielddata/plain/AbstractAtomicGeoShapeShapeFieldData.java
@@ -67,6 +67,16 @@ public abstract class AbstractAtomicGeoShapeShapeFieldData extends LeafShapeFiel
         }
 
         @Override
+        public GeoShapeValues.GeoShapeValue get(int index) {
+            return super.get(index);
+        }
+
+        @Override
+        public GeoShapeValues.GeoShapeValue getValue() {
+            return super.getValue();
+        }
+
+        @Override
         public GeoBoundingBox getBoundingBox() {
             return (GeoBoundingBox) super.getBoundingBox();
         }

--- a/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/index/fielddata/plain/AbstractShapeIndexFieldData.java
+++ b/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/index/fielddata/plain/AbstractShapeIndexFieldData.java
@@ -29,16 +29,12 @@ import org.elasticsearch.xpack.spatial.index.fielddata.ShapeValues;
  * `ValueSourceType` that this is constructed with. For example, the `LatLonShapeIndexFieldData.load(context)` method will
  * create an instance of `LatLonShapeDVAtomicShapeFieldData`.
  */
-public abstract class AbstractShapeIndexFieldData implements IndexShapeFieldData {
+public abstract class AbstractShapeIndexFieldData<T extends ShapeValues<?>> implements IndexShapeFieldData<T> {
     protected final String fieldName;
     protected final ValuesSourceType valuesSourceType;
-    protected final ToScriptFieldFactory<ShapeValues> toScriptFieldFactory;
+    protected final ToScriptFieldFactory<T> toScriptFieldFactory;
 
-    AbstractShapeIndexFieldData(
-        String fieldName,
-        ValuesSourceType valuesSourceType,
-        ToScriptFieldFactory<ShapeValues> toScriptFieldFactory
-    ) {
+    AbstractShapeIndexFieldData(String fieldName, ValuesSourceType valuesSourceType, ToScriptFieldFactory<T> toScriptFieldFactory) {
         this.fieldName = fieldName;
         this.valuesSourceType = valuesSourceType;
         this.toScriptFieldFactory = toScriptFieldFactory;
@@ -55,7 +51,7 @@ public abstract class AbstractShapeIndexFieldData implements IndexShapeFieldData
     }
 
     @Override
-    public LeafShapeFieldData loadDirect(LeafReaderContext context) {
+    public LeafShapeFieldData<T> loadDirect(LeafReaderContext context) {
         return load(context);
     }
 

--- a/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/index/fielddata/plain/LatLonShapeDVAtomicShapeFieldData.java
+++ b/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/index/fielddata/plain/LatLonShapeDVAtomicShapeFieldData.java
@@ -15,18 +15,17 @@ import org.elasticsearch.script.field.ToScriptFieldFactory;
 import org.elasticsearch.search.aggregations.support.ValuesSourceType;
 import org.elasticsearch.xpack.spatial.index.fielddata.GeoShapeValues;
 import org.elasticsearch.xpack.spatial.index.fielddata.LeafShapeFieldData;
-import org.elasticsearch.xpack.spatial.index.fielddata.ShapeValues;
 import org.elasticsearch.xpack.spatial.search.aggregations.support.GeoShapeValuesSourceType;
 
 import java.io.IOException;
 import java.util.Collection;
 import java.util.Collections;
 
-final class LatLonShapeDVAtomicShapeFieldData extends LeafShapeFieldData {
+final class LatLonShapeDVAtomicShapeFieldData extends LeafShapeFieldData<GeoShapeValues> {
     private final LeafReader reader;
     private final String fieldName;
 
-    LatLonShapeDVAtomicShapeFieldData(LeafReader reader, String fieldName, ToScriptFieldFactory<ShapeValues> toScriptFieldFactory) {
+    LatLonShapeDVAtomicShapeFieldData(LeafReader reader, String fieldName, ToScriptFieldFactory<GeoShapeValues> toScriptFieldFactory) {
         super(toScriptFieldFactory);
         this.reader = reader;
         this.fieldName = fieldName;
@@ -48,7 +47,7 @@ final class LatLonShapeDVAtomicShapeFieldData extends LeafShapeFieldData {
     }
 
     @Override
-    public ShapeValues getShapeValues() {
+    public GeoShapeValues getShapeValues() {
         try {
             final BinaryDocValues binaryValues = DocValues.getBinary(reader, fieldName);
             final GeoShapeValues.GeoShapeValue geoShapeValue = new GeoShapeValues.GeoShapeValue();

--- a/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/index/fielddata/plain/LatLonShapeIndexFieldData.java
+++ b/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/index/fielddata/plain/LatLonShapeIndexFieldData.java
@@ -12,20 +12,20 @@ import org.apache.lucene.index.LeafReader;
 import org.apache.lucene.index.LeafReaderContext;
 import org.elasticsearch.script.field.ToScriptFieldFactory;
 import org.elasticsearch.search.aggregations.support.ValuesSourceType;
+import org.elasticsearch.xpack.spatial.index.fielddata.GeoShapeValues;
 import org.elasticsearch.xpack.spatial.index.fielddata.LeafShapeFieldData;
-import org.elasticsearch.xpack.spatial.index.fielddata.ShapeValues;
 
-public class LatLonShapeIndexFieldData extends AbstractShapeIndexFieldData {
+public class LatLonShapeIndexFieldData extends AbstractShapeIndexFieldData<GeoShapeValues> {
     public LatLonShapeIndexFieldData(
         String fieldName,
         ValuesSourceType valuesSourceType,
-        ToScriptFieldFactory<ShapeValues> toScriptFieldFactory
+        ToScriptFieldFactory<GeoShapeValues> toScriptFieldFactory
     ) {
         super(fieldName, valuesSourceType, toScriptFieldFactory);
     }
 
     @Override
-    public LeafShapeFieldData load(LeafReaderContext context) {
+    public LeafShapeFieldData<GeoShapeValues> load(LeafReaderContext context) {
         LeafReader reader = context.reader();
         FieldInfo info = reader.getFieldInfos().fieldInfo(fieldName);
         if (info != null) {

--- a/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/index/mapper/GeoShapeWithDocValuesFieldMapper.java
+++ b/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/index/mapper/GeoShapeWithDocValuesFieldMapper.java
@@ -46,8 +46,6 @@ import org.elasticsearch.script.field.DocValuesScriptFieldFactory;
 import org.elasticsearch.script.field.Field;
 import org.elasticsearch.xpack.spatial.index.fielddata.CoordinateEncoder;
 import org.elasticsearch.xpack.spatial.index.fielddata.GeoShapeValues;
-import org.elasticsearch.xpack.spatial.index.fielddata.LeafShapeFieldData;
-import org.elasticsearch.xpack.spatial.index.fielddata.ShapeValues;
 import org.elasticsearch.xpack.spatial.index.fielddata.plain.AbstractAtomicGeoShapeShapeFieldData;
 import org.elasticsearch.xpack.spatial.index.fielddata.plain.LatLonShapeIndexFieldData;
 import org.elasticsearch.xpack.spatial.search.aggregations.support.GeoShapeValuesSourceType;
@@ -346,13 +344,13 @@ public class GeoShapeWithDocValuesFieldMapper extends AbstractShapeGeometryField
         super.checkIncomingMergeType(mergeWith);
     }
 
-    public static class GeoShapeDocValuesField extends AbstractScriptFieldFactory<ShapeValues.ShapeValue>
+    public static class GeoShapeDocValuesField extends AbstractScriptFieldFactory<GeoShapeValues.GeoShapeValue>
         implements
-            Field<ShapeValues.ShapeValue>,
+            Field<GeoShapeValues.GeoShapeValue>,
             DocValuesScriptFieldFactory,
-            ScriptDocValues.GeometrySupplier<GeoPoint, ShapeValues.ShapeValue> {
+            ScriptDocValues.GeometrySupplier<GeoPoint, GeoShapeValues.GeoShapeValue> {
 
-        private final ShapeValues in;
+        private final GeoShapeValues in;
         protected final String name;
 
         private GeoShapeValues.GeoShapeValue value;
@@ -360,9 +358,9 @@ public class GeoShapeWithDocValuesFieldMapper extends AbstractShapeGeometryField
         // maintain bwc by making bounding box and centroid available to GeoShapeValues (ScriptDocValues)
         private final GeoPoint centroid = new GeoPoint();
         private final GeoBoundingBox boundingBox = new GeoBoundingBox(new GeoPoint(), new GeoPoint());
-        private LeafShapeFieldData.ShapeScriptValues<GeoPoint> geoShapeScriptValues;
+        private AbstractAtomicGeoShapeShapeFieldData.GeoShapeScriptValues geoShapeScriptValues;
 
-        public GeoShapeDocValuesField(ShapeValues in, String name) {
+        public GeoShapeDocValuesField(GeoShapeValues in, String name) {
             this.in = in;
             this.name = name;
         }
@@ -370,7 +368,7 @@ public class GeoShapeWithDocValuesFieldMapper extends AbstractShapeGeometryField
         @Override
         public void setNextDocId(int docId) throws IOException {
             if (in.advanceExact(docId)) {
-                value = (GeoShapeValues.GeoShapeValue) in.value();
+                value = in.value();
                 centroid.reset(value.getY(), value.getX());
                 boundingBox.topLeft().reset(value.boundingBox().maxY(), value.boundingBox().minX());
                 boundingBox.bottomRight().reset(value.boundingBox().minY(), value.boundingBox().maxX());
@@ -380,7 +378,7 @@ public class GeoShapeWithDocValuesFieldMapper extends AbstractShapeGeometryField
         }
 
         @Override
-        public ScriptDocValues<ShapeValues.ShapeValue> toScriptDocValues() {
+        public ScriptDocValues<GeoShapeValues.GeoShapeValue> toScriptDocValues() {
             if (geoShapeScriptValues == null) {
                 geoShapeScriptValues = new AbstractAtomicGeoShapeShapeFieldData.GeoShapeScriptValues(this);
             }
@@ -389,7 +387,7 @@ public class GeoShapeWithDocValuesFieldMapper extends AbstractShapeGeometryField
         }
 
         @Override
-        public ShapeValues.ShapeValue getInternal(int index) {
+        public GeoShapeValues.GeoShapeValue getInternal(int index) {
             if (index != 0) {
                 throw new UnsupportedOperationException();
             }
@@ -446,7 +444,7 @@ public class GeoShapeWithDocValuesFieldMapper extends AbstractShapeGeometryField
         }
 
         @Override
-        public Iterator<ShapeValues.ShapeValue> iterator() {
+        public Iterator<GeoShapeValues.GeoShapeValue> iterator() {
             return new Iterator<>() {
                 private int index = 0;
 
@@ -456,7 +454,7 @@ public class GeoShapeWithDocValuesFieldMapper extends AbstractShapeGeometryField
                 }
 
                 @Override
-                public ShapeValues.ShapeValue next() {
+                public GeoShapeValues.GeoShapeValue next() {
                     if (hasNext() == false) {
                         throw new NoSuchElementException();
                     }

--- a/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/search/aggregations/bucket/geogrid/AbstractGeoHashGridTiler.java
+++ b/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/search/aggregations/bucket/geogrid/AbstractGeoHashGridTiler.java
@@ -12,7 +12,6 @@ import org.elasticsearch.geometry.Rectangle;
 import org.elasticsearch.geometry.utils.Geohash;
 import org.elasticsearch.xpack.spatial.index.fielddata.GeoRelation;
 import org.elasticsearch.xpack.spatial.index.fielddata.GeoShapeValues;
-import org.elasticsearch.xpack.spatial.index.fielddata.ShapeValues;
 
 import java.io.IOException;
 
@@ -34,7 +33,7 @@ abstract class AbstractGeoHashGridTiler extends GeoGridTiler {
     }
 
     @Override
-    public int setValues(GeoShapeCellValues values, ShapeValues.ShapeValue geoValue) throws IOException {
+    public int setValues(GeoShapeCellValues values, GeoShapeValues.GeoShapeValue geoValue) throws IOException {
 
         if (precision == 0) {
             return 1;
@@ -52,8 +51,11 @@ abstract class AbstractGeoHashGridTiler extends GeoGridTiler {
         return setValuesByRasterization("", values, 0, geoValue);
     }
 
-    protected int setValuesByBruteForceScan(GeoShapeCellValues values, ShapeValues.ShapeValue geoValue, GeoShapeValues.BoundingBox bounds)
-        throws IOException {
+    protected int setValuesByBruteForceScan(
+        GeoShapeCellValues values,
+        GeoShapeValues.GeoShapeValue geoValue,
+        GeoShapeValues.BoundingBox bounds
+    ) throws IOException {
         // TODO: This way to discover cells inside of a bounding box seems not to work as expected. I can
         // see that eventually we will be visiting twice the same cell which should not happen.
         int idx = 0;
@@ -78,9 +80,9 @@ abstract class AbstractGeoHashGridTiler extends GeoGridTiler {
     }
 
     /**
-     * Sets a singular doc-value for the {@link ShapeValues.ShapeValue}.
+     * Sets a singular doc-value for the {@link GeoShapeValues.GeoShapeValue}.
      */
-    protected int setValue(GeoShapeCellValues docValues, ShapeValues.ShapeValue geoValue, GeoShapeValues.BoundingBox bounds)
+    protected int setValue(GeoShapeCellValues docValues, GeoShapeValues.GeoShapeValue geoValue, GeoShapeValues.BoundingBox bounds)
         throws IOException {
         String hash = Geohash.stringEncode(bounds.minX(), bounds.minY(), precision);
         if (relateTile(geoValue, hash) != GeoRelation.QUERY_DISJOINT) {
@@ -91,7 +93,7 @@ abstract class AbstractGeoHashGridTiler extends GeoGridTiler {
         return 0;
     }
 
-    private GeoRelation relateTile(ShapeValues.ShapeValue geoValue, String hash) throws IOException {
+    private GeoRelation relateTile(GeoShapeValues.GeoShapeValue geoValue, String hash) throws IOException {
         if (validHash(hash)) {
             final Rectangle rectangle = Geohash.toBoundingBox(hash);
             int minX = GeoEncodingUtils.encodeLongitude(rectangle.getMinLon());
@@ -103,7 +105,7 @@ abstract class AbstractGeoHashGridTiler extends GeoGridTiler {
         return GeoRelation.QUERY_DISJOINT;
     }
 
-    protected int setValuesByRasterization(String hash, GeoShapeCellValues values, int valuesIndex, ShapeValues.ShapeValue geoValue)
+    protected int setValuesByRasterization(String hash, GeoShapeCellValues values, int valuesIndex, GeoShapeValues.GeoShapeValue geoValue)
         throws IOException {
         String[] hashes = Geohash.getSubGeohashes(hash);
         for (String s : hashes) {

--- a/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/search/aggregations/bucket/geogrid/AbstractGeoTileGridTiler.java
+++ b/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/search/aggregations/bucket/geogrid/AbstractGeoTileGridTiler.java
@@ -11,7 +11,6 @@ import org.apache.lucene.geo.GeoEncodingUtils;
 import org.elasticsearch.search.aggregations.bucket.geogrid.GeoTileUtils;
 import org.elasticsearch.xpack.spatial.index.fielddata.GeoRelation;
 import org.elasticsearch.xpack.spatial.index.fielddata.GeoShapeValues;
-import org.elasticsearch.xpack.spatial.index.fielddata.ShapeValues;
 
 import java.io.IOException;
 
@@ -48,7 +47,7 @@ abstract class AbstractGeoTileGridTiler extends GeoGridTiler {
      * @return the number of tiles set by the shape
      */
     @Override
-    public int setValues(GeoShapeCellValues values, ShapeValues.ShapeValue geoValue) throws IOException {
+    public int setValues(GeoShapeCellValues values, GeoShapeValues.GeoShapeValue geoValue) throws IOException {
         GeoShapeValues.BoundingBox bounds = geoValue.boundingBox();
         assert bounds.minX() <= bounds.maxX();
 
@@ -76,7 +75,7 @@ abstract class AbstractGeoTileGridTiler extends GeoGridTiler {
         }
     }
 
-    private GeoRelation relateTile(ShapeValues.ShapeValue geoValue, int xTile, int yTile, int precision) throws IOException {
+    private GeoRelation relateTile(GeoShapeValues.GeoShapeValue geoValue, int xTile, int yTile, int precision) throws IOException {
         if (validTile(xTile, yTile, precision)) {
             final double tiles = 1 << precision;
             final int minX = GeoEncodingUtils.encodeLongitude(GeoTileUtils.tileToLon(xTile, tiles));
@@ -113,7 +112,7 @@ abstract class AbstractGeoTileGridTiler extends GeoGridTiler {
      */
     protected int setValuesByBruteForceScan(
         GeoShapeCellValues values,
-        ShapeValues.ShapeValue geoValue,
+        GeoShapeValues.GeoShapeValue geoValue,
         int minXTile,
         int minYTile,
         int maxXTile,
@@ -138,7 +137,7 @@ abstract class AbstractGeoTileGridTiler extends GeoGridTiler {
         int zTile,
         GeoShapeCellValues values,
         int valuesIndex,
-        ShapeValues.ShapeValue geoValue
+        GeoShapeValues.GeoShapeValue geoValue
     ) throws IOException {
         zTile++;
         for (int i = 0; i < 2; i++) {

--- a/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/search/aggregations/bucket/geogrid/GeoGridTiler.java
+++ b/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/search/aggregations/bucket/geogrid/GeoGridTiler.java
@@ -7,7 +7,7 @@
 
 package org.elasticsearch.xpack.spatial.search.aggregations.bucket.geogrid;
 
-import org.elasticsearch.xpack.spatial.index.fielddata.ShapeValues;
+import org.elasticsearch.xpack.spatial.index.fielddata.GeoShapeValues;
 
 import java.io.IOException;
 
@@ -44,7 +44,7 @@ public abstract class GeoGridTiler {
      *
      * @return the number of cells the geoValue intersects
      */
-    public abstract int setValues(GeoShapeCellValues docValues, ShapeValues.ShapeValue geoValue) throws IOException;
+    public abstract int setValues(GeoShapeCellValues docValues, GeoShapeValues.GeoShapeValue geoValue) throws IOException;
 
     /** Maximum number of cells that can be created by this tiler */
     protected abstract long getMaxCells();

--- a/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/search/aggregations/bucket/geogrid/GeoShapeCellIdSource.java
+++ b/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/search/aggregations/bucket/geogrid/GeoShapeCellIdSource.java
@@ -13,7 +13,7 @@ import org.elasticsearch.index.fielddata.SortedBinaryDocValues;
 import org.elasticsearch.index.fielddata.SortedNumericDoubleValues;
 import org.elasticsearch.search.aggregations.support.ValuesSource;
 import org.elasticsearch.search.aggregations.support.ValuesSourceType;
-import org.elasticsearch.xpack.spatial.index.fielddata.ShapeValues;
+import org.elasticsearch.xpack.spatial.index.fielddata.GeoShapeValues;
 import org.elasticsearch.xpack.spatial.search.aggregations.support.GeoShapeValuesSource;
 import org.elasticsearch.xpack.spatial.search.aggregations.support.GeoShapeValuesSourceType;
 
@@ -46,7 +46,7 @@ public class GeoShapeCellIdSource extends ValuesSource.Numeric {
 
     @Override
     public SortedNumericDocValues longValues(LeafReaderContext ctx) {
-        ShapeValues geoValues = valuesSource.shapeValues(ctx);
+        GeoShapeValues geoValues = valuesSource.shapeValues(ctx);
         ValuesSourceType vs = geoValues.valuesSourceType();
         if (GeoShapeValuesSourceType.instance() == vs) {
             // docValues are geo shapes

--- a/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/search/aggregations/bucket/geogrid/GeoShapeCellValues.java
+++ b/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/search/aggregations/bucket/geogrid/GeoShapeCellValues.java
@@ -7,17 +7,17 @@
 
 package org.elasticsearch.xpack.spatial.search.aggregations.bucket.geogrid;
 
-import org.elasticsearch.xpack.spatial.index.fielddata.ShapeValues;
+import org.elasticsearch.xpack.spatial.index.fielddata.GeoShapeValues;
 
 import java.io.IOException;
 import java.util.function.LongConsumer;
 
 /** Sorted numeric doc values for geo shapes */
 class GeoShapeCellValues extends ByteTrackingSortingNumericDocValues {
-    private final ShapeValues geoShapeValues;
+    private final GeoShapeValues geoShapeValues;
     protected final GeoGridTiler tiler;
 
-    protected GeoShapeCellValues(ShapeValues geoShapeValues, GeoGridTiler tiler, LongConsumer circuitBreakerConsumer) {
+    protected GeoShapeCellValues(GeoShapeValues geoShapeValues, GeoGridTiler tiler, LongConsumer circuitBreakerConsumer) {
         super(circuitBreakerConsumer);
         this.geoShapeValues = geoShapeValues;
         this.tiler = tiler;

--- a/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/search/aggregations/metrics/GeoShapeBoundsAggregator.java
+++ b/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/search/aggregations/metrics/GeoShapeBoundsAggregator.java
@@ -19,7 +19,6 @@ import org.elasticsearch.search.aggregations.metrics.MetricsAggregator;
 import org.elasticsearch.search.aggregations.support.AggregationContext;
 import org.elasticsearch.search.aggregations.support.ValuesSourceConfig;
 import org.elasticsearch.xpack.spatial.index.fielddata.GeoShapeValues;
-import org.elasticsearch.xpack.spatial.index.fielddata.ShapeValues;
 import org.elasticsearch.xpack.spatial.search.aggregations.support.GeoShapeValuesSource;
 
 import java.io.IOException;
@@ -67,13 +66,13 @@ public final class GeoShapeBoundsAggregator extends MetricsAggregator {
         if (valuesSource == null) {
             return LeafBucketCollector.NO_OP_COLLECTOR;
         }
-        final ShapeValues values = valuesSource.shapeValues(aggCtx.getLeafReaderContext());
+        final GeoShapeValues values = valuesSource.shapeValues(aggCtx.getLeafReaderContext());
         return new LeafBucketCollectorBase(sub, values) {
             @Override
             public void collect(int doc, long bucket) throws IOException {
                 if (values.advanceExact(doc)) {
                     maybeResize(bucket);
-                    final GeoShapeValues.ShapeValue value = values.value();
+                    final GeoShapeValues.GeoShapeValue value = values.value();
                     final GeoShapeValues.BoundingBox bounds = value.boundingBox();
                     tops.set(bucket, Math.max(tops.get(bucket), bounds.top));
                     bottoms.set(bucket, Math.min(bottoms.get(bucket), bounds.bottom));

--- a/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/search/aggregations/metrics/GeoShapeCentroidAggregator.java
+++ b/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/search/aggregations/metrics/GeoShapeCentroidAggregator.java
@@ -23,7 +23,7 @@ import org.elasticsearch.search.aggregations.metrics.MetricsAggregator;
 import org.elasticsearch.search.aggregations.support.AggregationContext;
 import org.elasticsearch.search.aggregations.support.ValuesSourceConfig;
 import org.elasticsearch.xpack.spatial.index.fielddata.DimensionalShapeType;
-import org.elasticsearch.xpack.spatial.index.fielddata.ShapeValues;
+import org.elasticsearch.xpack.spatial.index.fielddata.GeoShapeValues;
 import org.elasticsearch.xpack.spatial.search.aggregations.support.GeoShapeValuesSource;
 
 import java.io.IOException;
@@ -65,7 +65,7 @@ public final class GeoShapeCentroidAggregator extends MetricsAggregator {
         if (valuesSource == null) {
             return LeafBucketCollector.NO_OP_COLLECTOR;
         }
-        final ShapeValues values = valuesSource.shapeValues(aggCtx.getLeafReaderContext());
+        final GeoShapeValues values = valuesSource.shapeValues(aggCtx.getLeafReaderContext());
         final CompensatedSum compensatedSumLat = new CompensatedSum(0, 0);
         final CompensatedSum compensatedSumLon = new CompensatedSum(0, 0);
         final CompensatedSum compensatedSumWeight = new CompensatedSum(0, 0);
@@ -80,7 +80,7 @@ public final class GeoShapeCentroidAggregator extends MetricsAggregator {
                     // Compute the sum of double values with Kahan summation algorithm which is more
                     // accurate than naive summation.
                     final DimensionalShapeType shapeType = DimensionalShapeType.fromOrdinalByte(dimensionalShapeTypes.get(bucket));
-                    final ShapeValues.ShapeValue value = values.value();
+                    final GeoShapeValues.GeoShapeValue value = values.value();
                     final int compares = shapeType.compareTo(value.dimensionalShapeType());
                     // update the sum
                     if (compares < 0) {

--- a/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/search/aggregations/support/GeoShapeValuesSource.java
+++ b/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/search/aggregations/support/GeoShapeValuesSource.java
@@ -13,12 +13,11 @@ import org.elasticsearch.index.fielddata.SortedBinaryDocValues;
 import org.elasticsearch.search.aggregations.AggregationExecutionException;
 import org.elasticsearch.xpack.spatial.index.fielddata.GeoShapeValues;
 import org.elasticsearch.xpack.spatial.index.fielddata.IndexShapeFieldData;
-import org.elasticsearch.xpack.spatial.index.fielddata.ShapeValues;
 
 import java.io.IOException;
 import java.util.function.Function;
 
-public abstract class GeoShapeValuesSource extends ShapeValuesSource {
+public abstract class GeoShapeValuesSource extends ShapeValuesSource<GeoShapeValues> {
     public static final GeoShapeValuesSource EMPTY = new GeoShapeValuesSource() {
 
         @Override
@@ -34,9 +33,9 @@ public abstract class GeoShapeValuesSource extends ShapeValuesSource {
 
     public static class Fielddata extends GeoShapeValuesSource {
 
-        protected final IndexShapeFieldData indexFieldData;
+        protected final IndexShapeFieldData<GeoShapeValues> indexFieldData;
 
-        public Fielddata(IndexShapeFieldData indexFieldData) {
+        public Fielddata(IndexShapeFieldData<GeoShapeValues> indexFieldData) {
             this.indexFieldData = indexFieldData;
         }
 
@@ -45,7 +44,7 @@ public abstract class GeoShapeValuesSource extends ShapeValuesSource {
             return indexFieldData.load(context).getBytesValues();
         }
 
-        public ShapeValues shapeValues(LeafReaderContext context) {
+        public GeoShapeValues shapeValues(LeafReaderContext context) {
             return indexFieldData.load(context).getShapeValues();
         }
     }

--- a/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/search/aggregations/support/GeoShapeValuesSourceType.java
+++ b/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/search/aggregations/support/GeoShapeValuesSourceType.java
@@ -20,7 +20,6 @@ import org.elasticsearch.search.aggregations.support.ValuesSource;
 import org.elasticsearch.search.aggregations.support.ValuesSourceType;
 import org.elasticsearch.xpack.spatial.index.fielddata.GeoShapeValues;
 import org.elasticsearch.xpack.spatial.index.fielddata.IndexShapeFieldData;
-import org.elasticsearch.xpack.spatial.index.fielddata.ShapeValues;
 import org.elasticsearch.xpack.spatial.index.fielddata.plain.LatLonShapeIndexFieldData;
 
 import java.io.IOException;
@@ -65,11 +64,11 @@ public class GeoShapeValuesSourceType extends ShapeValuesSourceType {
         AggregationContext context
     ) {
         GeoShapeValuesSource shapeValuesSource = (GeoShapeValuesSource) valuesSource;
-        final ShapeValues.ShapeValue missing = GeoShapeValues.EMPTY.missing(rawMissing.toString());
+        final GeoShapeValues.GeoShapeValue missing = GeoShapeValues.EMPTY.missing(rawMissing.toString());
         return new GeoShapeValuesSource() {
             @Override
             public GeoShapeValues shapeValues(LeafReaderContext context) {
-                ShapeValues values = shapeValuesSource.shapeValues(context);
+                GeoShapeValues values = shapeValuesSource.shapeValues(context);
                 return new GeoShapeValues() {
 
                     private boolean exists;
@@ -88,7 +87,7 @@ public class GeoShapeValuesSourceType extends ShapeValuesSourceType {
                     }
 
                     @Override
-                    public ShapeValue value() throws IOException {
+                    public GeoShapeValue value() throws IOException {
                         return exists ? values.value() : missing;
                     }
 

--- a/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/search/aggregations/support/ShapeValuesSource.java
+++ b/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/search/aggregations/support/ShapeValuesSource.java
@@ -16,8 +16,8 @@ import org.elasticsearch.xpack.spatial.index.fielddata.ShapeValues;
 
 import java.io.IOException;
 
-public abstract class ShapeValuesSource extends ValuesSource {
-    public abstract ShapeValues shapeValues(LeafReaderContext context);
+public abstract class ShapeValuesSource<T extends ShapeValues<?>> extends ValuesSource {
+    public abstract T shapeValues(LeafReaderContext context);
 
     @Override
     public SortedBinaryDocValues bytesValues(LeafReaderContext context) throws IOException {
@@ -26,7 +26,7 @@ public abstract class ShapeValuesSource extends ValuesSource {
 
     @Override
     public DocValueBits docsWithValue(LeafReaderContext context) {
-        ShapeValues values = shapeValues(context);
+        T values = shapeValues(context);
         return new DocValueBits() {
             @Override
             public boolean advanceExact(int doc) throws IOException {


### PR DESCRIPTION
In #89388 we refactor the doc values plumbing for aggregation that resulted in adding the shapeValues and ShapeValue abstractions into many geo classes.  This classes are meant to be used for sharing code between different implementation but not to leak into those classes. More over, this change is probably introducing a backwards compatibility issue with painless.

Here is my proposal on how to handle it. 