### PR TITLE
Don't schedule a new snapshot for an SLM policy if one is already running

### DIFF
--- a/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/slm/SnapshotLifecycleTask.java
+++ b/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/slm/SnapshotLifecycleTask.java
@@ -65,7 +65,7 @@ public class SnapshotLifecycleTask implements SchedulerEngine.Listener {
                 event.getJobName(),
                 name
             ),
-            () -> logger.warn("snapshot lifecycle policy for job [{}] no longer exists, snapshot not created", event.getJobName())
+            () -> logger.warn("snapshot lifecycle policy job [{}] did not issue new snapshot creation", event.getJobName())
         );
     }
 

--- a/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/slm/SnapshotLifecycleTask.java
+++ b/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/slm/SnapshotLifecycleTask.java
@@ -107,12 +107,13 @@ public class SnapshotLifecycleTask implements SchedulerEngine.Listener {
                     // Check that there are no failed shards, since the request may not entirely
                     // fail, but may still have failures (such as in the case of an aborted snapshot)
                     if (snapInfo.failedShards() == 0) {
-                        long snapshotStartTime = snapInfo.startTime();
                         final long timestamp = Instant.now().toEpochMilli();
+                        long startTime = snapInfo.startTime();
+                        long endTime = snapInfo.endTime();
                         submitUnbatchedTask(
                             clusterService,
                             "slm-record-success-" + policyMetadata.getPolicy().getId(),
-                            WriteJobStatus.success(policyMetadata.getPolicy().getId(), request.snapshot(), snapshotStartTime, timestamp)
+                            WriteJobStatus.success(policyMetadata.getPolicy().getId(), request.snapshot(), startTime, endTime)
                         );
                         historyStore.putAsync(
                             SnapshotHistoryItem.creationSuccessRecord(timestamp, policyMetadata.getPolicy(), request.snapshot())

--- a/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/slm/SnapshotLifecycleTask.java
+++ b/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/slm/SnapshotLifecycleTask.java
@@ -59,21 +59,14 @@ public class SnapshotLifecycleTask implements SchedulerEngine.Listener {
     @Override
     public void triggered(SchedulerEngine.Event event) {
         logger.debug("snapshot lifecycle policy task triggered from job [{}]", event.getJobName());
-
-        final Optional<String> snapshotName = maybeTakeSnapshot(event.getJobName(), client, clusterService, historyStore);
-
-        // Would be cleaner if we could use Optional#ifPresentOrElse
-        snapshotName.ifPresent(
+        maybeTakeSnapshot(event.getJobName(), client, clusterService, historyStore).ifPresentOrElse(
             name -> logger.info(
                 "snapshot lifecycle policy job [{}] issued new snapshot creation for [{}] successfully",
                 event.getJobName(),
                 name
-            )
+            ),
+            () -> logger.warn("snapshot lifecycle policy for job [{}] no longer exists, snapshot not created", event.getJobName())
         );
-
-        if (snapshotName.isPresent() == false) {
-            logger.warn("snapshot lifecycle policy for job [{}] no longer exists, snapshot not created", event.getJobName());
-        }
     }
 
     /**

--- a/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/slm/SnapshotLifecycleTask.java
+++ b/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/slm/SnapshotLifecycleTask.java
@@ -55,7 +55,7 @@ public class SnapshotLifecycleTask implements SchedulerEngine.Listener {
     private final SnapshotHistoryStore historyStore;
 
     /**
-     * Set of all currently running  {@link SnapshotLifecyclePolicy} ids, used to prevent starting multiple snapshots for the same policy.
+     * Set of all currently running {@link SnapshotLifecyclePolicy} ids, used to prevent starting multiple snapshots for the same policy.
      */
     private final Set<String> runningPolicies = Collections.synchronizedSet(new HashSet<>());
 

--- a/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/slm/package-info.java
+++ b/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/slm/package-info.java
@@ -27,10 +27,8 @@
  * is triggered for execution. It constructs a snapshot request and runs it as the user who originally set up the policy. The bulk of this
  * logic is contained in the
  * {@link org.elasticsearch.xpack.slm.SnapshotLifecycleTask#maybeTakeSnapshot(String, Client, ClusterService,
- * SnapshotHistoryStore)} method. After a snapshot request has been submitted, it persists the result (success or failure) in a history
- * store (an index), caching the latest success and failure information in the cluster state. It is important to note that this task
- * fires the snapshot request off and forgets it; It does not wait until the entire snapshot completes. Any success or failure that this
- * task sees will be from the initial submission of the snapshot request only.
+ * SnapshotHistoryStore)} method. After a snapshot request has been completed, it persists the result (success or failure) in a history
+ * store (an index), caching the latest success and failure information in the cluster state.
  */
 package org.elasticsearch.xpack.slm;
 


### PR DESCRIPTION
Closes https://github.com/elastic/elasticsearch/issues/65318

