### PR TITLE
Node ids order

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/allocator/NodeAllocationOrdering.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/allocator/NodeAllocationOrdering.java
@@ -9,6 +9,7 @@
 package org.elasticsearch.cluster.routing.allocation.allocator;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
@@ -26,7 +27,7 @@ public class NodeAllocationOrdering {
         recentAllocations.put(nodeId, order.incrementAndGet());
     }
 
-    public List<String> sort(Set<String> nodeIds) {
+    public List<String> sort(Collection<String> nodeIds) {
         var list = new ArrayList<>(nodeIds);
         list.sort(comparator);
         return list;

--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/allocator/ShardAssignment.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/allocator/ShardAssignment.java
@@ -10,10 +10,11 @@ package org.elasticsearch.cluster.routing.allocation.allocator;
 
 import org.elasticsearch.cluster.routing.ShardRouting;
 
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
 
-import static java.util.stream.Collectors.toUnmodifiableSet;
+import static java.util.stream.Collectors.toCollection;
 
 public record ShardAssignment(Set<String> nodeIds, int total, int unassigned, int ignored) {
 
@@ -27,6 +28,7 @@ public record ShardAssignment(Set<String> nodeIds, int total, int unassigned, in
     }
 
     public static ShardAssignment of(List<ShardRouting> routings) {
-        return new ShardAssignment(routings.stream().map(ShardRouting::currentNodeId).collect(toUnmodifiableSet()), routings.size(), 0, 0);
+        var nodeIds = routings.stream().map(ShardRouting::currentNodeId).collect(toCollection(LinkedHashSet::new));
+        return new ShardAssignment(nodeIds, routings.size(), 0, 0);
     }
 }

--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/allocator/ShardAssignment.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/allocator/ShardAssignment.java
@@ -14,6 +14,7 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
 
+import static java.util.Collections.unmodifiableSet;
 import static java.util.stream.Collectors.toCollection;
 
 public record ShardAssignment(Set<String> nodeIds, int total, int unassigned, int ignored) {
@@ -29,6 +30,6 @@ public record ShardAssignment(Set<String> nodeIds, int total, int unassigned, in
 
     public static ShardAssignment of(List<ShardRouting> routings) {
         var nodeIds = routings.stream().map(ShardRouting::currentNodeId).collect(toCollection(LinkedHashSet::new));
-        return new ShardAssignment(nodeIds, routings.size(), 0, 0);
+        return new ShardAssignment(unmodifiableSet(nodeIds), routings.size(), 0, 0);
     }
 }


### PR DESCRIPTION
Un-modifiable set is backed by SetN implementation that might revert iteration order based on seed generated during JVM start. This makes some tests flaky. Updating the code to use collection with consistent ordering