### PR TITLE
[TSDB] Release time-series functionality

### DIFF
--- a/docs/changelog/90116.yaml
+++ b/docs/changelog/90116.yaml
@@ -1,5 +1,5 @@
 pr: 90116
-summary: "[TSDB] Remove time-series feature flag"
-area: "TSDB, Rollup"
+summary: "Release time-series (TSDB) functionality"
+area: "TSDB"
 type: feature
 issues: []

--- a/docs/changelog/90116.yaml
+++ b/docs/changelog/90116.yaml
@@ -1,0 +1,5 @@
+pr: 90116
+summary: "[TSDB] Remove time-series feature flag"
+area: "TSDB, Rollup"
+type: feature
+issues: []

--- a/modules/data-streams/build.gradle
+++ b/modules/data-streams/build.gradle
@@ -1,4 +1,3 @@
-import org.elasticsearch.gradle.Version
 import org.elasticsearch.gradle.internal.info.BuildParams
 
 apply plugin: 'elasticsearch.test-with-dependencies'
@@ -27,7 +26,6 @@ testClusters.configureEach {
   setting 'xpack.security.enabled', 'true'
   keystore 'bootstrap.password', 'x-pack-test-password'
   user username: "x_pack_rest_user", password: "x-pack-test-password"
-  requiresFeature 'es.index_mode_feature_flag_registered', Version.fromString("8.0.0")
 }
 
 testClusters.matching { it.name == "javaRestTest" }.configureEach {
@@ -35,7 +33,6 @@ testClusters.matching { it.name == "javaRestTest" }.configureEach {
   setting 'xpack.security.enabled', 'false'
   // disable ILM history, since it disturbs tests using _all
   setting 'indices.lifecycle.history_index_enabled', 'false'
-  requiresFeature 'es.index_mode_feature_flag_registered', Version.fromString("8.0.0")
 }
 
 if (BuildParams.inFipsJvm){
@@ -43,13 +40,4 @@ if (BuildParams.inFipsJvm){
   // Tracked in :
   tasks.named("javaRestTest").configure{enabled = false }
   tasks.named("yamlRestTest").configure{enabled = false }
-}
-
-if (BuildParams.isSnapshotBuild() == false) {
-  tasks.named("internalClusterTest").configure {
-    systemProperty 'es.index_mode_feature_flag_registered', 'true'
-  }
-  tasks.named("test").configure {
-    systemProperty 'es.index_mode_feature_flag_registered', 'true'
-  }
 }

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/IndexMetadata.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/IndexMetadata.java
@@ -1995,9 +1995,7 @@ public class IndexMetadata implements Diffable<IndexMetadata>, ToXContentFragmen
 
             final boolean isSearchableSnapshot = SearchableSnapshotsSettings.isSearchableSnapshotStore(settings);
             final String indexMode = settings.get(IndexSettings.MODE.getKey());
-            final boolean isTsdb = IndexSettings.isTimeSeriesModeEnabled()
-                && indexMode != null
-                && IndexMode.TIME_SERIES.getName().equals(indexMode.toLowerCase(Locale.ROOT));
+            final boolean isTsdb = indexMode != null && IndexMode.TIME_SERIES.getName().equals(indexMode.toLowerCase(Locale.ROOT));
             return new IndexMetadata(
                 new Index(index, uuid),
                 version,

--- a/server/src/main/java/org/elasticsearch/common/settings/IndexScopedSettings.java
+++ b/server/src/main/java/org/elasticsearch/common/settings/IndexScopedSettings.java
@@ -37,7 +37,6 @@ import org.elasticsearch.indices.IndicesRequestCache;
 import org.elasticsearch.indices.ShardLimitValidator;
 
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
@@ -47,7 +46,7 @@ import java.util.Set;
  */
 public final class IndexScopedSettings extends AbstractScopedSettings {
 
-    private static final Set<Setting<?>> ALWAYS_ENABLED_BUILT_IN_INDEX_SETTINGS = Set.of(
+    public static final Set<Setting<?>> BUILT_IN_INDEX_SETTINGS = Set.of(
         MaxRetryAllocationDecider.SETTING_ALLOCATION_MAX_RETRY,
         MergeSchedulerConfig.AUTO_THROTTLE_SETTING,
         MergeSchedulerConfig.MAX_MERGE_COUNT_SETTING,
@@ -175,22 +174,14 @@ public final class IndexScopedSettings extends AbstractScopedSettings {
                 }
             }
         }, Property.IndexScope), // this allows similarity settings to be passed
-        Setting.groupSetting("index.analysis.", Property.IndexScope)
-    ); // this allows analysis settings to be passed
+        Setting.groupSetting("index.analysis.", Property.IndexScope), // this allows analysis settings to be passed
 
-    public static final Set<Setting<?>> BUILT_IN_INDEX_SETTINGS = builtInIndexSettings();
-
-    private static Set<Setting<?>> builtInIndexSettings() {
-        if (false == IndexSettings.isTimeSeriesModeEnabled()) {
-            return ALWAYS_ENABLED_BUILT_IN_INDEX_SETTINGS;
-        }
-        Set<Setting<?>> result = new HashSet<>(ALWAYS_ENABLED_BUILT_IN_INDEX_SETTINGS);
-        result.add(IndexSettings.MODE);
-        result.add(IndexMetadata.INDEX_ROUTING_PATH);
-        result.add(IndexSettings.TIME_SERIES_START_TIME);
-        result.add(IndexSettings.TIME_SERIES_END_TIME);
-        return Set.copyOf(result);
-    }
+        // TSDB index settings
+        IndexSettings.MODE,
+        IndexMetadata.INDEX_ROUTING_PATH,
+        IndexSettings.TIME_SERIES_START_TIME,
+        IndexSettings.TIME_SERIES_END_TIME
+    );
 
     public static final IndexScopedSettings DEFAULT_SCOPED_SETTINGS = new IndexScopedSettings(Settings.EMPTY, BUILT_IN_INDEX_SETTINGS);
 

--- a/server/src/main/java/org/elasticsearch/index/IndexSettings.java
+++ b/server/src/main/java/org/elasticsearch/index/IndexSettings.java
@@ -708,7 +708,7 @@ public final class IndexSettings {
         nodeName = Node.NODE_NAME_SETTING.get(settings);
         this.indexMetadata = indexMetadata;
         numberOfShards = settings.getAsInt(IndexMetadata.SETTING_NUMBER_OF_SHARDS, null);
-        mode = isTimeSeriesModeEnabled() ? scopedSettings.get(MODE) : IndexMode.STANDARD;
+        mode = scopedSettings.get(MODE);
         this.timestampBounds = mode.getTimestampBound(indexMetadata);
         if (timestampBounds != null) {
             scopedSettings.addSettingsUpdateConsumer(

--- a/server/src/main/java/org/elasticsearch/rest/action/document/RestGetAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/document/RestGetAction.java
@@ -13,7 +13,6 @@ import org.elasticsearch.action.get.GetResponse;
 import org.elasticsearch.client.internal.node.NodeClient;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.core.RestApiVersion;
-import org.elasticsearch.index.IndexSettings;
 import org.elasticsearch.index.VersionType;
 import org.elasticsearch.rest.BaseRestHandler;
 import org.elasticsearch.rest.RestRequest;
@@ -79,7 +78,7 @@ public class RestGetAction extends BaseRestHandler {
         getRequest.versionType(VersionType.fromString(request.param("version_type"), getRequest.versionType()));
 
         getRequest.fetchSourceContext(FetchSourceContext.parseFromRestRequest(request));
-        if (IndexSettings.isTimeSeriesModeEnabled() && request.paramAsBoolean("force_synthetic_source", false)) {
+        if (request.paramAsBoolean("force_synthetic_source", false)) {
             getRequest.setForceSyntheticSource(true);
         }
 

--- a/server/src/main/java/org/elasticsearch/rest/action/document/RestMultiGetAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/document/RestMultiGetAction.java
@@ -13,7 +13,6 @@ import org.elasticsearch.client.internal.node.NodeClient;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.core.RestApiVersion;
-import org.elasticsearch.index.IndexSettings;
 import org.elasticsearch.rest.BaseRestHandler;
 import org.elasticsearch.rest.RestRequest;
 import org.elasticsearch.rest.action.RestToXContentListener;
@@ -61,7 +60,7 @@ public class RestMultiGetAction extends BaseRestHandler {
         multiGetRequest.refresh(request.paramAsBoolean("refresh", multiGetRequest.refresh()));
         multiGetRequest.preference(request.param("preference"));
         multiGetRequest.realtime(request.paramAsBoolean("realtime", multiGetRequest.realtime()));
-        if (IndexSettings.isTimeSeriesModeEnabled() && request.paramAsBoolean("force_synthetic_source", false)) {
+        if (request.paramAsBoolean("force_synthetic_source", false)) {
             multiGetRequest.setForceSyntheticSource(true);
         }
 

--- a/server/src/main/java/org/elasticsearch/rest/action/search/RestSearchAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/search/RestSearchAction.java
@@ -21,7 +21,6 @@ import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.logging.DeprecationLogger;
 import org.elasticsearch.core.Booleans;
 import org.elasticsearch.core.RestApiVersion;
-import org.elasticsearch.index.IndexSettings;
 import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.rest.BaseRestHandler;
 import org.elasticsearch.rest.RestRequest;
@@ -209,7 +208,7 @@ public class RestSearchAction extends BaseRestHandler {
                 request.paramAsBoolean("ccs_minimize_roundtrips", searchRequest.isCcsMinimizeRoundtrips())
             );
         }
-        if (IndexSettings.isTimeSeriesModeEnabled() && request.paramAsBoolean("force_synthetic_source", false)) {
+        if (request.paramAsBoolean("force_synthetic_source", false)) {
             searchRequest.setForceSyntheticSource(true);
         }
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/XPackClientPlugin.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/XPackClientPlugin.java
@@ -13,7 +13,6 @@ import org.elasticsearch.cluster.NamedDiff;
 import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.settings.Setting;
-import org.elasticsearch.index.IndexSettings;
 import org.elasticsearch.license.DeleteLicenseAction;
 import org.elasticsearch.license.GetBasicStatusAction;
 import org.elasticsearch.license.GetLicenseAction;
@@ -257,326 +256,296 @@ public class XPackClientPlugin extends Plugin implements ActionPlugin, NetworkPl
 
     @Override
     public List<ActionType<? extends ActionResponse>> getClientActions() {
-        List<ActionType<? extends ActionResponse>> actions = new ArrayList<>(
-            Arrays.asList(
-                // graph
-                GraphExploreAction.INSTANCE,
-                // ML
-                GetJobsAction.INSTANCE,
-                GetJobsStatsAction.INSTANCE,
-                MlInfoAction.INSTANCE,
-                PutJobAction.INSTANCE,
-                UpdateJobAction.INSTANCE,
-                DeleteJobAction.INSTANCE,
-                OpenJobAction.INSTANCE,
-                GetFiltersAction.INSTANCE,
-                PutFilterAction.INSTANCE,
-                UpdateFilterAction.INSTANCE,
-                DeleteFilterAction.INSTANCE,
-                KillProcessAction.INSTANCE,
-                GetBucketsAction.INSTANCE,
-                GetInfluencersAction.INSTANCE,
-                GetOverallBucketsAction.INSTANCE,
-                GetRecordsAction.INSTANCE,
-                PostDataAction.INSTANCE,
-                CloseJobAction.INSTANCE,
-                FinalizeJobExecutionAction.INSTANCE,
-                FlushJobAction.INSTANCE,
-                ValidateDetectorAction.INSTANCE,
-                ValidateJobConfigAction.INSTANCE,
-                GetCategoriesAction.INSTANCE,
-                GetModelSnapshotsAction.INSTANCE,
-                RevertModelSnapshotAction.INSTANCE,
-                UpdateModelSnapshotAction.INSTANCE,
-                GetDatafeedsAction.INSTANCE,
-                GetDatafeedsStatsAction.INSTANCE,
-                PutDatafeedAction.INSTANCE,
-                UpdateDatafeedAction.INSTANCE,
-                DeleteDatafeedAction.INSTANCE,
-                PreviewDatafeedAction.INSTANCE,
-                StartDatafeedAction.INSTANCE,
-                StopDatafeedAction.INSTANCE,
-                IsolateDatafeedAction.INSTANCE,
-                DeleteModelSnapshotAction.INSTANCE,
-                UpdateProcessAction.INSTANCE,
-                DeleteExpiredDataAction.INSTANCE,
-                ForecastJobAction.INSTANCE,
-                DeleteForecastAction.INSTANCE,
-                GetCalendarsAction.INSTANCE,
-                PutCalendarAction.INSTANCE,
-                DeleteCalendarAction.INSTANCE,
-                DeleteCalendarEventAction.INSTANCE,
-                UpdateCalendarJobAction.INSTANCE,
-                GetCalendarEventsAction.INSTANCE,
-                PostCalendarEventsAction.INSTANCE,
-                PersistJobAction.INSTANCE,
-                SetUpgradeModeAction.INSTANCE,
-                PutDataFrameAnalyticsAction.INSTANCE,
-                GetDataFrameAnalyticsAction.INSTANCE,
-                GetDataFrameAnalyticsStatsAction.INSTANCE,
-                UpdateDataFrameAnalyticsAction.INSTANCE,
-                DeleteDataFrameAnalyticsAction.INSTANCE,
-                StartDataFrameAnalyticsAction.INSTANCE,
-                EvaluateDataFrameAction.INSTANCE,
-                ExplainDataFrameAnalyticsAction.INSTANCE,
-                InferModelAction.INSTANCE,
-                InferModelAction.EXTERNAL_INSTANCE,
-                GetTrainedModelsAction.INSTANCE,
-                DeleteTrainedModelAction.INSTANCE,
-                GetTrainedModelsStatsAction.INSTANCE,
-                PutTrainedModelAction.INSTANCE,
-                // security
-                ClearRealmCacheAction.INSTANCE,
-                ClearRolesCacheAction.INSTANCE,
-                GetUsersAction.INSTANCE,
-                PutUserAction.INSTANCE,
-                DeleteUserAction.INSTANCE,
-                GetRolesAction.INSTANCE,
-                PutRoleAction.INSTANCE,
-                DeleteRoleAction.INSTANCE,
-                ChangePasswordAction.INSTANCE,
-                AuthenticateAction.INSTANCE,
-                SetEnabledAction.INSTANCE,
-                HasPrivilegesAction.INSTANCE,
-                GetRoleMappingsAction.INSTANCE,
-                PutRoleMappingAction.INSTANCE,
-                DeleteRoleMappingAction.INSTANCE,
-                CreateTokenAction.INSTANCE,
-                InvalidateTokenAction.INSTANCE,
-                GetCertificateInfoAction.INSTANCE,
-                RefreshTokenAction.INSTANCE,
-                CreateApiKeyAction.INSTANCE,
-                InvalidateApiKeyAction.INSTANCE,
-                GetApiKeyAction.INSTANCE,
-                // watcher
-                PutWatchAction.INSTANCE,
-                DeleteWatchAction.INSTANCE,
-                GetWatchAction.INSTANCE,
-                WatcherStatsAction.INSTANCE,
-                AckWatchAction.INSTANCE,
-                ActivateWatchAction.INSTANCE,
-                WatcherServiceAction.INSTANCE,
-                ExecuteWatchAction.INSTANCE,
-                // license
-                PutLicenseAction.INSTANCE,
-                GetLicenseAction.INSTANCE,
-                DeleteLicenseAction.INSTANCE,
-                PostStartTrialAction.INSTANCE,
-                GetTrialStatusAction.INSTANCE,
-                PostStartBasicAction.INSTANCE,
-                GetBasicStatusAction.INSTANCE,
-                // x-pack
-                XPackInfoAction.INSTANCE,
-                XPackUsageAction.INSTANCE,
-                // rollup
-                RollupSearchAction.INSTANCE,
-                PutRollupJobAction.INSTANCE,
-                StartRollupJobAction.INSTANCE,
-                StopRollupJobAction.INSTANCE,
-                DeleteRollupJobAction.INSTANCE,
-                GetRollupJobsAction.INSTANCE,
-                GetRollupCapsAction.INSTANCE,
-                // ILM
-                DeleteLifecycleAction.INSTANCE,
-                GetLifecycleAction.INSTANCE,
-                PutLifecycleAction.INSTANCE,
-                ExplainLifecycleAction.INSTANCE,
-                RemoveIndexLifecyclePolicyAction.INSTANCE,
-                MoveToStepAction.INSTANCE,
-                RetryAction.INSTANCE,
-                PutSnapshotLifecycleAction.INSTANCE,
-                GetSnapshotLifecycleAction.INSTANCE,
-                DeleteSnapshotLifecycleAction.INSTANCE,
-                ExecuteSnapshotLifecycleAction.INSTANCE,
-                GetSnapshotLifecycleStatsAction.INSTANCE,
-                MigrateToDataTiersAction.INSTANCE,
+        return Arrays.asList(
+            // graph
+            GraphExploreAction.INSTANCE,
+            // ML
+            GetJobsAction.INSTANCE,
+            GetJobsStatsAction.INSTANCE,
+            MlInfoAction.INSTANCE,
+            PutJobAction.INSTANCE,
+            UpdateJobAction.INSTANCE,
+            DeleteJobAction.INSTANCE,
+            OpenJobAction.INSTANCE,
+            GetFiltersAction.INSTANCE,
+            PutFilterAction.INSTANCE,
+            UpdateFilterAction.INSTANCE,
+            DeleteFilterAction.INSTANCE,
+            KillProcessAction.INSTANCE,
+            GetBucketsAction.INSTANCE,
+            GetInfluencersAction.INSTANCE,
+            GetOverallBucketsAction.INSTANCE,
+            GetRecordsAction.INSTANCE,
+            PostDataAction.INSTANCE,
+            CloseJobAction.INSTANCE,
+            FinalizeJobExecutionAction.INSTANCE,
+            FlushJobAction.INSTANCE,
+            ValidateDetectorAction.INSTANCE,
+            ValidateJobConfigAction.INSTANCE,
+            GetCategoriesAction.INSTANCE,
+            GetModelSnapshotsAction.INSTANCE,
+            RevertModelSnapshotAction.INSTANCE,
+            UpdateModelSnapshotAction.INSTANCE,
+            GetDatafeedsAction.INSTANCE,
+            GetDatafeedsStatsAction.INSTANCE,
+            PutDatafeedAction.INSTANCE,
+            UpdateDatafeedAction.INSTANCE,
+            DeleteDatafeedAction.INSTANCE,
+            PreviewDatafeedAction.INSTANCE,
+            StartDatafeedAction.INSTANCE,
+            StopDatafeedAction.INSTANCE,
+            IsolateDatafeedAction.INSTANCE,
+            DeleteModelSnapshotAction.INSTANCE,
+            UpdateProcessAction.INSTANCE,
+            DeleteExpiredDataAction.INSTANCE,
+            ForecastJobAction.INSTANCE,
+            DeleteForecastAction.INSTANCE,
+            GetCalendarsAction.INSTANCE,
+            PutCalendarAction.INSTANCE,
+            DeleteCalendarAction.INSTANCE,
+            DeleteCalendarEventAction.INSTANCE,
+            UpdateCalendarJobAction.INSTANCE,
+            GetCalendarEventsAction.INSTANCE,
+            PostCalendarEventsAction.INSTANCE,
+            PersistJobAction.INSTANCE,
+            SetUpgradeModeAction.INSTANCE,
+            PutDataFrameAnalyticsAction.INSTANCE,
+            GetDataFrameAnalyticsAction.INSTANCE,
+            GetDataFrameAnalyticsStatsAction.INSTANCE,
+            UpdateDataFrameAnalyticsAction.INSTANCE,
+            DeleteDataFrameAnalyticsAction.INSTANCE,
+            StartDataFrameAnalyticsAction.INSTANCE,
+            EvaluateDataFrameAction.INSTANCE,
+            ExplainDataFrameAnalyticsAction.INSTANCE,
+            InferModelAction.INSTANCE,
+            InferModelAction.EXTERNAL_INSTANCE,
+            GetTrainedModelsAction.INSTANCE,
+            DeleteTrainedModelAction.INSTANCE,
+            GetTrainedModelsStatsAction.INSTANCE,
+            PutTrainedModelAction.INSTANCE,
+            // security
+            ClearRealmCacheAction.INSTANCE,
+            ClearRolesCacheAction.INSTANCE,
+            GetUsersAction.INSTANCE,
+            PutUserAction.INSTANCE,
+            DeleteUserAction.INSTANCE,
+            GetRolesAction.INSTANCE,
+            PutRoleAction.INSTANCE,
+            DeleteRoleAction.INSTANCE,
+            ChangePasswordAction.INSTANCE,
+            AuthenticateAction.INSTANCE,
+            SetEnabledAction.INSTANCE,
+            HasPrivilegesAction.INSTANCE,
+            GetRoleMappingsAction.INSTANCE,
+            PutRoleMappingAction.INSTANCE,
+            DeleteRoleMappingAction.INSTANCE,
+            CreateTokenAction.INSTANCE,
+            InvalidateTokenAction.INSTANCE,
+            GetCertificateInfoAction.INSTANCE,
+            RefreshTokenAction.INSTANCE,
+            CreateApiKeyAction.INSTANCE,
+            InvalidateApiKeyAction.INSTANCE,
+            GetApiKeyAction.INSTANCE,
+            // watcher
+            PutWatchAction.INSTANCE,
+            DeleteWatchAction.INSTANCE,
+            GetWatchAction.INSTANCE,
+            WatcherStatsAction.INSTANCE,
+            AckWatchAction.INSTANCE,
+            ActivateWatchAction.INSTANCE,
+            WatcherServiceAction.INSTANCE,
+            ExecuteWatchAction.INSTANCE,
+            // license
+            PutLicenseAction.INSTANCE,
+            GetLicenseAction.INSTANCE,
+            DeleteLicenseAction.INSTANCE,
+            PostStartTrialAction.INSTANCE,
+            GetTrialStatusAction.INSTANCE,
+            PostStartBasicAction.INSTANCE,
+            GetBasicStatusAction.INSTANCE,
+            // x-pack
+            XPackInfoAction.INSTANCE,
+            XPackUsageAction.INSTANCE,
+            // rollup
+            RollupSearchAction.INSTANCE,
+            PutRollupJobAction.INSTANCE,
+            StartRollupJobAction.INSTANCE,
+            StopRollupJobAction.INSTANCE,
+            DeleteRollupJobAction.INSTANCE,
+            GetRollupJobsAction.INSTANCE,
+            GetRollupCapsAction.INSTANCE,
+            // ILM
+            DeleteLifecycleAction.INSTANCE,
+            GetLifecycleAction.INSTANCE,
+            PutLifecycleAction.INSTANCE,
+            ExplainLifecycleAction.INSTANCE,
+            RemoveIndexLifecyclePolicyAction.INSTANCE,
+            MoveToStepAction.INSTANCE,
+            RetryAction.INSTANCE,
+            PutSnapshotLifecycleAction.INSTANCE,
+            GetSnapshotLifecycleAction.INSTANCE,
+            DeleteSnapshotLifecycleAction.INSTANCE,
+            ExecuteSnapshotLifecycleAction.INSTANCE,
+            GetSnapshotLifecycleStatsAction.INSTANCE,
+            MigrateToDataTiersAction.INSTANCE,
 
-                // Freeze
-                FreezeIndexAction.INSTANCE,
-                // Data Frame
-                PutTransformAction.INSTANCE,
-                StartTransformAction.INSTANCE,
-                StopTransformAction.INSTANCE,
-                DeleteTransformAction.INSTANCE,
-                GetTransformAction.INSTANCE,
-                GetTransformStatsAction.INSTANCE,
-                PreviewTransformAction.INSTANCE,
-                // Async Search
-                SubmitAsyncSearchAction.INSTANCE,
-                GetAsyncSearchAction.INSTANCE,
-                DeleteAsyncResultAction.INSTANCE,
-                // Text Structure
-                FindStructureAction.INSTANCE,
-                // Terms enum API
-                TermsEnumAction.INSTANCE
-            )
+            // Freeze
+            FreezeIndexAction.INSTANCE,
+            // Data Frame
+            PutTransformAction.INSTANCE,
+            StartTransformAction.INSTANCE,
+            StopTransformAction.INSTANCE,
+            DeleteTransformAction.INSTANCE,
+            GetTransformAction.INSTANCE,
+            GetTransformStatsAction.INSTANCE,
+            PreviewTransformAction.INSTANCE,
+            // Async Search
+            SubmitAsyncSearchAction.INSTANCE,
+            GetAsyncSearchAction.INSTANCE,
+            DeleteAsyncResultAction.INSTANCE,
+            // Text Structure
+            FindStructureAction.INSTANCE,
+            // Terms enum API
+            TermsEnumAction.INSTANCE,
+            // TSDB Downsampling
+            RollupIndexerAction.INSTANCE,
+            org.elasticsearch.xpack.core.downsample.DownsampleAction.INSTANCE
         );
-
-        // TSDB Downsampling / Rollup
-        if (IndexSettings.isTimeSeriesModeEnabled()) {
-            actions.add(RollupIndexerAction.INSTANCE);
-            actions.add(org.elasticsearch.xpack.core.downsample.DownsampleAction.INSTANCE);
-        }
-
-        return actions;
     }
 
     @Override
     public List<NamedWriteableRegistry.Entry> getNamedWriteables() {
-        List<NamedWriteableRegistry.Entry> namedWriteables = new ArrayList<>(
-            Arrays.asList(
-                // graph
-                new NamedWriteableRegistry.Entry(XPackFeatureSet.Usage.class, XPackField.GRAPH, GraphFeatureSetUsage::new),
-                // logstash
-                new NamedWriteableRegistry.Entry(XPackFeatureSet.Usage.class, XPackField.LOGSTASH, LogstashFeatureSetUsage::new),
-                // ML
-                new NamedWriteableRegistry.Entry(
-                    XPackFeatureSet.Usage.class,
-                    XPackField.MACHINE_LEARNING,
-                    MachineLearningFeatureSetUsage::new
-                ),
-                // monitoring
-                new NamedWriteableRegistry.Entry(XPackFeatureSet.Usage.class, XPackField.MONITORING, MonitoringFeatureSetUsage::new),
-                // security
-                new NamedWriteableRegistry.Entry(ClusterState.Custom.class, TokenMetadata.TYPE, TokenMetadata::new),
-                new NamedWriteableRegistry.Entry(NamedDiff.class, TokenMetadata.TYPE, TokenMetadata::readDiffFrom),
-                new NamedWriteableRegistry.Entry(XPackFeatureSet.Usage.class, XPackField.SECURITY, SecurityFeatureSetUsage::new),
-                // security : conditional privileges
-                new NamedWriteableRegistry.Entry(
-                    ConfigurableClusterPrivilege.class,
-                    ConfigurableClusterPrivileges.ManageApplicationPrivileges.WRITEABLE_NAME,
-                    ConfigurableClusterPrivileges.ManageApplicationPrivileges::createFrom
-                ),
-                new NamedWriteableRegistry.Entry(
-                    ConfigurableClusterPrivilege.class,
-                    ConfigurableClusterPrivileges.WriteProfileDataPrivileges.WRITEABLE_NAME,
-                    ConfigurableClusterPrivileges.WriteProfileDataPrivileges::createFrom
-                ),
-                // security : role-mappings
-                new NamedWriteableRegistry.Entry(RoleMapperExpression.class, AllExpression.NAME, AllExpression::new),
-                new NamedWriteableRegistry.Entry(RoleMapperExpression.class, AnyExpression.NAME, AnyExpression::new),
-                new NamedWriteableRegistry.Entry(RoleMapperExpression.class, FieldExpression.NAME, FieldExpression::new),
-                new NamedWriteableRegistry.Entry(RoleMapperExpression.class, ExceptExpression.NAME, ExceptExpression::new),
-                // eql
-                new NamedWriteableRegistry.Entry(XPackFeatureSet.Usage.class, XPackField.EQL, EqlFeatureSetUsage::new),
-                // sql
-                new NamedWriteableRegistry.Entry(XPackFeatureSet.Usage.class, XPackField.SQL, SqlFeatureSetUsage::new),
-                // watcher
-                new NamedWriteableRegistry.Entry(Metadata.Custom.class, WatcherMetadata.TYPE, WatcherMetadata::new),
-                new NamedWriteableRegistry.Entry(NamedDiff.class, WatcherMetadata.TYPE, WatcherMetadata::readDiffFrom),
-                new NamedWriteableRegistry.Entry(XPackFeatureSet.Usage.class, XPackField.WATCHER, WatcherFeatureSetUsage::new),
-                // licensing
-                new NamedWriteableRegistry.Entry(Metadata.Custom.class, LicensesMetadata.TYPE, LicensesMetadata::new),
-                new NamedWriteableRegistry.Entry(NamedDiff.class, LicensesMetadata.TYPE, LicensesMetadata::readDiffFrom),
-                // rollup
-                new NamedWriteableRegistry.Entry(XPackFeatureSet.Usage.class, XPackField.ROLLUP, RollupFeatureSetUsage::new),
-                new NamedWriteableRegistry.Entry(PersistentTaskParams.class, RollupJob.NAME, RollupJob::new),
-                new NamedWriteableRegistry.Entry(Task.Status.class, RollupJobStatus.NAME, RollupJobStatus::new),
-                new NamedWriteableRegistry.Entry(PersistentTaskState.class, RollupJobStatus.NAME, RollupJobStatus::new),
-                // ccr
-                new NamedWriteableRegistry.Entry(AutoFollowMetadata.class, AutoFollowMetadata.TYPE, AutoFollowMetadata::new),
-                new NamedWriteableRegistry.Entry(Metadata.Custom.class, AutoFollowMetadata.TYPE, AutoFollowMetadata::new),
-                new NamedWriteableRegistry.Entry(
-                    NamedDiff.class,
-                    AutoFollowMetadata.TYPE,
-                    in -> AutoFollowMetadata.readDiffFrom(Metadata.Custom.class, AutoFollowMetadata.TYPE, in)
-                ),
-                // ILM
-                new NamedWriteableRegistry.Entry(
-                    XPackFeatureSet.Usage.class,
-                    XPackField.INDEX_LIFECYCLE,
-                    IndexLifecycleFeatureSetUsage::new
-                ),
-                // SLM
-                new NamedWriteableRegistry.Entry(XPackFeatureSet.Usage.class, XPackField.SNAPSHOT_LIFECYCLE, SLMFeatureSetUsage::new),
-                // ILM - Custom Metadata
-                new NamedWriteableRegistry.Entry(Metadata.Custom.class, IndexLifecycleMetadata.TYPE, IndexLifecycleMetadata::new),
-                new NamedWriteableRegistry.Entry(
-                    NamedDiff.class,
-                    IndexLifecycleMetadata.TYPE,
-                    IndexLifecycleMetadata.IndexLifecycleMetadataDiff::new
-                ),
-                new NamedWriteableRegistry.Entry(Metadata.Custom.class, SnapshotLifecycleMetadata.TYPE, SnapshotLifecycleMetadata::new),
-                new NamedWriteableRegistry.Entry(
-                    NamedDiff.class,
-                    SnapshotLifecycleMetadata.TYPE,
-                    SnapshotLifecycleMetadata.SnapshotLifecycleMetadataDiff::new
-                ),
-                // ILM - LifecycleTypes
-                new NamedWriteableRegistry.Entry(
-                    LifecycleType.class,
-                    TimeseriesLifecycleType.TYPE,
-                    (in) -> TimeseriesLifecycleType.INSTANCE
-                ),
-                // ILM - Lifecycle Actions
-                new NamedWriteableRegistry.Entry(LifecycleAction.class, AllocateAction.NAME, AllocateAction::new),
-                new NamedWriteableRegistry.Entry(LifecycleAction.class, ForceMergeAction.NAME, ForceMergeAction::new),
-                new NamedWriteableRegistry.Entry(LifecycleAction.class, ReadOnlyAction.NAME, ReadOnlyAction::new),
-                new NamedWriteableRegistry.Entry(LifecycleAction.class, RolloverAction.NAME, RolloverAction::new),
-                new NamedWriteableRegistry.Entry(LifecycleAction.class, ShrinkAction.NAME, ShrinkAction::new),
-                new NamedWriteableRegistry.Entry(LifecycleAction.class, DeleteAction.NAME, DeleteAction::readFrom),
-                new NamedWriteableRegistry.Entry(LifecycleAction.class, FreezeAction.NAME, in -> FreezeAction.INSTANCE),
-                new NamedWriteableRegistry.Entry(LifecycleAction.class, SetPriorityAction.NAME, SetPriorityAction::new),
-                new NamedWriteableRegistry.Entry(LifecycleAction.class, UnfollowAction.NAME, in -> UnfollowAction.INSTANCE),
-                new NamedWriteableRegistry.Entry(LifecycleAction.class, WaitForSnapshotAction.NAME, WaitForSnapshotAction::new),
-                new NamedWriteableRegistry.Entry(LifecycleAction.class, SearchableSnapshotAction.NAME, SearchableSnapshotAction::new),
-                new NamedWriteableRegistry.Entry(LifecycleAction.class, MigrateAction.NAME, MigrateAction::readFrom),
-                // Transforms
-                new NamedWriteableRegistry.Entry(Metadata.Custom.class, TransformMetadata.TYPE, TransformMetadata::new),
-                new NamedWriteableRegistry.Entry(NamedDiff.class, TransformMetadata.TYPE, TransformMetadata.TransformMetadataDiff::new),
-                new NamedWriteableRegistry.Entry(XPackFeatureSet.Usage.class, XPackField.TRANSFORM, TransformFeatureSetUsage::new),
-                new NamedWriteableRegistry.Entry(PersistentTaskParams.class, TransformField.TASK_NAME, TransformTaskParams::new),
-                new NamedWriteableRegistry.Entry(Task.Status.class, TransformField.TASK_NAME, TransformState::new),
-                new NamedWriteableRegistry.Entry(PersistentTaskState.class, TransformField.TASK_NAME, TransformState::new),
-                new NamedWriteableRegistry.Entry(SyncConfig.class, TransformField.TIME.getPreferredName(), TimeSyncConfig::new),
-                new NamedWriteableRegistry.Entry(
-                    RetentionPolicyConfig.class,
-                    TransformField.TIME.getPreferredName(),
-                    TimeRetentionPolicyConfig::new
-                ),
-                new NamedWriteableRegistry.Entry(
-                    RetentionPolicyConfig.class,
-                    NullRetentionPolicyConfig.NAME.getPreferredName(),
-                    i -> NullRetentionPolicyConfig.INSTANCE
-                ),
-                // Voting Only Node
-                new NamedWriteableRegistry.Entry(XPackFeatureSet.Usage.class, XPackField.VOTING_ONLY, VotingOnlyNodeFeatureSetUsage::new),
-                // Frozen indices
-                new NamedWriteableRegistry.Entry(XPackFeatureSet.Usage.class, XPackField.FROZEN_INDICES, FrozenIndicesFeatureSetUsage::new),
-                // Spatial
-                new NamedWriteableRegistry.Entry(XPackFeatureSet.Usage.class, XPackField.SPATIAL, SpatialFeatureSetUsage::new),
-                // Analytics
-                new NamedWriteableRegistry.Entry(XPackFeatureSet.Usage.class, XPackField.ANALYTICS, AnalyticsFeatureSetUsage::new),
-                // Aggregate metric field type
-                new NamedWriteableRegistry.Entry(
-                    XPackFeatureSet.Usage.class,
-                    XPackField.AGGREGATE_METRIC,
-                    AggregateMetricFeatureSetUsage::new
-                ),
-                // Enrich
-                new NamedWriteableRegistry.Entry(XPackFeatureSet.Usage.class, XPackField.ENRICH, EnrichFeatureSetUsage::new),
-                new NamedWriteableRegistry.Entry(Task.Status.class, ExecuteEnrichPolicyStatus.NAME, ExecuteEnrichPolicyStatus::new),
-                // Searchable snapshots
-                new NamedWriteableRegistry.Entry(
-                    XPackFeatureSet.Usage.class,
-                    XPackField.SEARCHABLE_SNAPSHOTS,
-                    SearchableSnapshotFeatureSetUsage::new
-                ),
-                // Data Streams
-                new NamedWriteableRegistry.Entry(XPackFeatureSet.Usage.class, XPackField.DATA_STREAMS, DataStreamFeatureSetUsage::new),
-                // Data Tiers
-                new NamedWriteableRegistry.Entry(XPackFeatureSet.Usage.class, XPackField.DATA_TIERS, DataTiersFeatureSetUsage::new),
-                // Archive
-                new NamedWriteableRegistry.Entry(XPackFeatureSet.Usage.class, XPackField.ARCHIVE, ArchiveFeatureSetUsage::new)
-            )
+        return Arrays.asList(
+            // graph
+            new NamedWriteableRegistry.Entry(XPackFeatureSet.Usage.class, XPackField.GRAPH, GraphFeatureSetUsage::new),
+            // logstash
+            new NamedWriteableRegistry.Entry(XPackFeatureSet.Usage.class, XPackField.LOGSTASH, LogstashFeatureSetUsage::new),
+            // ML
+            new NamedWriteableRegistry.Entry(XPackFeatureSet.Usage.class, XPackField.MACHINE_LEARNING, MachineLearningFeatureSetUsage::new),
+            // monitoring
+            new NamedWriteableRegistry.Entry(XPackFeatureSet.Usage.class, XPackField.MONITORING, MonitoringFeatureSetUsage::new),
+            // security
+            new NamedWriteableRegistry.Entry(ClusterState.Custom.class, TokenMetadata.TYPE, TokenMetadata::new),
+            new NamedWriteableRegistry.Entry(NamedDiff.class, TokenMetadata.TYPE, TokenMetadata::readDiffFrom),
+            new NamedWriteableRegistry.Entry(XPackFeatureSet.Usage.class, XPackField.SECURITY, SecurityFeatureSetUsage::new),
+            // security : conditional privileges
+            new NamedWriteableRegistry.Entry(
+                ConfigurableClusterPrivilege.class,
+                ConfigurableClusterPrivileges.ManageApplicationPrivileges.WRITEABLE_NAME,
+                ConfigurableClusterPrivileges.ManageApplicationPrivileges::createFrom
+            ),
+            new NamedWriteableRegistry.Entry(
+                ConfigurableClusterPrivilege.class,
+                ConfigurableClusterPrivileges.WriteProfileDataPrivileges.WRITEABLE_NAME,
+                ConfigurableClusterPrivileges.WriteProfileDataPrivileges::createFrom
+            ),
+            // security : role-mappings
+            new NamedWriteableRegistry.Entry(RoleMapperExpression.class, AllExpression.NAME, AllExpression::new),
+            new NamedWriteableRegistry.Entry(RoleMapperExpression.class, AnyExpression.NAME, AnyExpression::new),
+            new NamedWriteableRegistry.Entry(RoleMapperExpression.class, FieldExpression.NAME, FieldExpression::new),
+            new NamedWriteableRegistry.Entry(RoleMapperExpression.class, ExceptExpression.NAME, ExceptExpression::new),
+            // eql
+            new NamedWriteableRegistry.Entry(XPackFeatureSet.Usage.class, XPackField.EQL, EqlFeatureSetUsage::new),
+            // sql
+            new NamedWriteableRegistry.Entry(XPackFeatureSet.Usage.class, XPackField.SQL, SqlFeatureSetUsage::new),
+            // watcher
+            new NamedWriteableRegistry.Entry(Metadata.Custom.class, WatcherMetadata.TYPE, WatcherMetadata::new),
+            new NamedWriteableRegistry.Entry(NamedDiff.class, WatcherMetadata.TYPE, WatcherMetadata::readDiffFrom),
+            new NamedWriteableRegistry.Entry(XPackFeatureSet.Usage.class, XPackField.WATCHER, WatcherFeatureSetUsage::new),
+            // licensing
+            new NamedWriteableRegistry.Entry(Metadata.Custom.class, LicensesMetadata.TYPE, LicensesMetadata::new),
+            new NamedWriteableRegistry.Entry(NamedDiff.class, LicensesMetadata.TYPE, LicensesMetadata::readDiffFrom),
+            // rollup
+            new NamedWriteableRegistry.Entry(XPackFeatureSet.Usage.class, XPackField.ROLLUP, RollupFeatureSetUsage::new),
+            new NamedWriteableRegistry.Entry(PersistentTaskParams.class, RollupJob.NAME, RollupJob::new),
+            new NamedWriteableRegistry.Entry(Task.Status.class, RollupJobStatus.NAME, RollupJobStatus::new),
+            new NamedWriteableRegistry.Entry(PersistentTaskState.class, RollupJobStatus.NAME, RollupJobStatus::new),
+            // ccr
+            new NamedWriteableRegistry.Entry(AutoFollowMetadata.class, AutoFollowMetadata.TYPE, AutoFollowMetadata::new),
+            new NamedWriteableRegistry.Entry(Metadata.Custom.class, AutoFollowMetadata.TYPE, AutoFollowMetadata::new),
+            new NamedWriteableRegistry.Entry(
+                NamedDiff.class,
+                AutoFollowMetadata.TYPE,
+                in -> AutoFollowMetadata.readDiffFrom(Metadata.Custom.class, AutoFollowMetadata.TYPE, in)
+            ),
+            // ILM
+            new NamedWriteableRegistry.Entry(XPackFeatureSet.Usage.class, XPackField.INDEX_LIFECYCLE, IndexLifecycleFeatureSetUsage::new),
+            // SLM
+            new NamedWriteableRegistry.Entry(XPackFeatureSet.Usage.class, XPackField.SNAPSHOT_LIFECYCLE, SLMFeatureSetUsage::new),
+            // ILM - Custom Metadata
+            new NamedWriteableRegistry.Entry(Metadata.Custom.class, IndexLifecycleMetadata.TYPE, IndexLifecycleMetadata::new),
+            new NamedWriteableRegistry.Entry(
+                NamedDiff.class,
+                IndexLifecycleMetadata.TYPE,
+                IndexLifecycleMetadata.IndexLifecycleMetadataDiff::new
+            ),
+            new NamedWriteableRegistry.Entry(Metadata.Custom.class, SnapshotLifecycleMetadata.TYPE, SnapshotLifecycleMetadata::new),
+            new NamedWriteableRegistry.Entry(
+                NamedDiff.class,
+                SnapshotLifecycleMetadata.TYPE,
+                SnapshotLifecycleMetadata.SnapshotLifecycleMetadataDiff::new
+            ),
+            // ILM - LifecycleTypes
+            new NamedWriteableRegistry.Entry(LifecycleType.class, TimeseriesLifecycleType.TYPE, (in) -> TimeseriesLifecycleType.INSTANCE),
+            // ILM - Lifecycle Actions
+            new NamedWriteableRegistry.Entry(LifecycleAction.class, AllocateAction.NAME, AllocateAction::new),
+            new NamedWriteableRegistry.Entry(LifecycleAction.class, ForceMergeAction.NAME, ForceMergeAction::new),
+            new NamedWriteableRegistry.Entry(LifecycleAction.class, ReadOnlyAction.NAME, ReadOnlyAction::new),
+            new NamedWriteableRegistry.Entry(LifecycleAction.class, RolloverAction.NAME, RolloverAction::new),
+            new NamedWriteableRegistry.Entry(LifecycleAction.class, ShrinkAction.NAME, ShrinkAction::new),
+            new NamedWriteableRegistry.Entry(LifecycleAction.class, DeleteAction.NAME, DeleteAction::readFrom),
+            new NamedWriteableRegistry.Entry(LifecycleAction.class, FreezeAction.NAME, in -> FreezeAction.INSTANCE),
+            new NamedWriteableRegistry.Entry(LifecycleAction.class, SetPriorityAction.NAME, SetPriorityAction::new),
+            new NamedWriteableRegistry.Entry(LifecycleAction.class, UnfollowAction.NAME, in -> UnfollowAction.INSTANCE),
+            new NamedWriteableRegistry.Entry(LifecycleAction.class, WaitForSnapshotAction.NAME, WaitForSnapshotAction::new),
+            new NamedWriteableRegistry.Entry(LifecycleAction.class, SearchableSnapshotAction.NAME, SearchableSnapshotAction::new),
+            new NamedWriteableRegistry.Entry(LifecycleAction.class, MigrateAction.NAME, MigrateAction::readFrom),
+            // Transforms
+            new NamedWriteableRegistry.Entry(Metadata.Custom.class, TransformMetadata.TYPE, TransformMetadata::new),
+            new NamedWriteableRegistry.Entry(NamedDiff.class, TransformMetadata.TYPE, TransformMetadata.TransformMetadataDiff::new),
+            new NamedWriteableRegistry.Entry(XPackFeatureSet.Usage.class, XPackField.TRANSFORM, TransformFeatureSetUsage::new),
+            new NamedWriteableRegistry.Entry(PersistentTaskParams.class, TransformField.TASK_NAME, TransformTaskParams::new),
+            new NamedWriteableRegistry.Entry(Task.Status.class, TransformField.TASK_NAME, TransformState::new),
+            new NamedWriteableRegistry.Entry(PersistentTaskState.class, TransformField.TASK_NAME, TransformState::new),
+            new NamedWriteableRegistry.Entry(SyncConfig.class, TransformField.TIME.getPreferredName(), TimeSyncConfig::new),
+            new NamedWriteableRegistry.Entry(
+                RetentionPolicyConfig.class,
+                TransformField.TIME.getPreferredName(),
+                TimeRetentionPolicyConfig::new
+            ),
+            new NamedWriteableRegistry.Entry(
+                RetentionPolicyConfig.class,
+                NullRetentionPolicyConfig.NAME.getPreferredName(),
+                i -> NullRetentionPolicyConfig.INSTANCE
+            ),
+            // Voting Only Node
+            new NamedWriteableRegistry.Entry(XPackFeatureSet.Usage.class, XPackField.VOTING_ONLY, VotingOnlyNodeFeatureSetUsage::new),
+            // Frozen indices
+            new NamedWriteableRegistry.Entry(XPackFeatureSet.Usage.class, XPackField.FROZEN_INDICES, FrozenIndicesFeatureSetUsage::new),
+            // Spatial
+            new NamedWriteableRegistry.Entry(XPackFeatureSet.Usage.class, XPackField.SPATIAL, SpatialFeatureSetUsage::new),
+            // Analytics
+            new NamedWriteableRegistry.Entry(XPackFeatureSet.Usage.class, XPackField.ANALYTICS, AnalyticsFeatureSetUsage::new),
+            // Aggregate metric field type
+            new NamedWriteableRegistry.Entry(XPackFeatureSet.Usage.class, XPackField.AGGREGATE_METRIC, AggregateMetricFeatureSetUsage::new),
+            // Enrich
+            new NamedWriteableRegistry.Entry(XPackFeatureSet.Usage.class, XPackField.ENRICH, EnrichFeatureSetUsage::new),
+            new NamedWriteableRegistry.Entry(Task.Status.class, ExecuteEnrichPolicyStatus.NAME, ExecuteEnrichPolicyStatus::new),
+            // Searchable snapshots
+            new NamedWriteableRegistry.Entry(
+                XPackFeatureSet.Usage.class,
+                XPackField.SEARCHABLE_SNAPSHOTS,
+                SearchableSnapshotFeatureSetUsage::new
+            ),
+            // Data Streams
+            new NamedWriteableRegistry.Entry(XPackFeatureSet.Usage.class, XPackField.DATA_STREAMS, DataStreamFeatureSetUsage::new),
+            // Data Tiers
+            new NamedWriteableRegistry.Entry(XPackFeatureSet.Usage.class, XPackField.DATA_TIERS, DataTiersFeatureSetUsage::new),
+            // Archive
+            new NamedWriteableRegistry.Entry(XPackFeatureSet.Usage.class, XPackField.ARCHIVE, ArchiveFeatureSetUsage::new),
+            // TSDB Downsampling
+            new NamedWriteableRegistry.Entry(LifecycleAction.class, DownsampleAction.NAME, DownsampleAction::new)
         );
-
-        // TSDB Downsampling / Rollup
-        if (IndexSettings.isTimeSeriesModeEnabled()) {
-            namedWriteables.add(new NamedWriteableRegistry.Entry(LifecycleAction.class, DownsampleAction.NAME, DownsampleAction::new));
-        }
-
-        return namedWriteables;
     }
 
     @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/TimeseriesLifecycleType.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/TimeseriesLifecycleType.java
@@ -10,7 +10,6 @@ import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.util.set.Sets;
 import org.elasticsearch.core.TimeValue;
-import org.elasticsearch.index.IndexSettings;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -56,7 +55,7 @@ public class TimeseriesLifecycleType implements LifecycleType {
         UnfollowAction.NAME,
         RolloverAction.NAME,
         ReadOnlyAction.NAME,
-        IndexSettings.isTimeSeriesModeEnabled() ? DownsampleAction.NAME : null,
+        DownsampleAction.NAME,
         ShrinkAction.NAME,
         ForceMergeAction.NAME,
         SearchableSnapshotAction.NAME
@@ -65,7 +64,7 @@ public class TimeseriesLifecycleType implements LifecycleType {
         SetPriorityAction.NAME,
         UnfollowAction.NAME,
         ReadOnlyAction.NAME,
-        IndexSettings.isTimeSeriesModeEnabled() ? DownsampleAction.NAME : null,
+        DownsampleAction.NAME,
         AllocateAction.NAME,
         MigrateAction.NAME,
         ShrinkAction.NAME,
@@ -75,7 +74,7 @@ public class TimeseriesLifecycleType implements LifecycleType {
         SetPriorityAction.NAME,
         UnfollowAction.NAME,
         ReadOnlyAction.NAME,
-        IndexSettings.isTimeSeriesModeEnabled() ? DownsampleAction.NAME : null,
+        DownsampleAction.NAME,
         SearchableSnapshotAction.NAME,
         AllocateAction.NAME,
         MigrateAction.NAME,

--- a/x-pack/plugin/ilm/build.gradle
+++ b/x-pack/plugin/ilm/build.gradle
@@ -20,9 +20,3 @@ dependencies {
 }
 
 addQaCheckDependencies(project)
-
-tasks.named("test").configure {
-  if (BuildParams.isSnapshotBuild() == false) {
-    systemProperty 'es.index_mode_feature_flag_registered', 'true'
-  }
-}

--- a/x-pack/plugin/ilm/qa/multi-node/build.gradle
+++ b/x-pack/plugin/ilm/qa/multi-node/build.gradle
@@ -1,5 +1,3 @@
-import org.elasticsearch.gradle.Version
-import org.elasticsearch.gradle.util.GradleUtils
 import org.elasticsearch.gradle.internal.info.BuildParams
 
 apply plugin: 'elasticsearch.internal-java-rest-test'
@@ -15,9 +13,6 @@ File repoDir = file("$buildDir/testclusters/repo")
 tasks.named("javaRestTest").configure {
   /* To support taking index snapshots, we have to set path.repo setting */
   systemProperty 'tests.path.repo', repoDir
-  if (BuildParams.isSnapshotBuild() == false) {
-    systemProperty 'es.index_mode_feature_flag_registered', 'true'
-  }
 }
 
 testClusters.configureEach {
@@ -42,7 +37,6 @@ testClusters.configureEach {
    * cached time. So the policy's action date is always after the snapshot's start.
    */
   setting 'thread_pool.estimated_time_interval', '0'
-  requiresFeature 'es.index_mode_feature_flag_registered', Version.fromString("8.3.0")
 }
 
 if (BuildParams.inFipsJvm){

--- a/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/IndexLifecycle.java
+++ b/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/IndexLifecycle.java
@@ -29,7 +29,6 @@ import org.elasticsearch.env.Environment;
 import org.elasticsearch.env.NodeEnvironment;
 import org.elasticsearch.health.HealthIndicatorService;
 import org.elasticsearch.index.IndexModule;
-import org.elasticsearch.index.IndexSettings;
 import org.elasticsearch.license.XPackLicenseState;
 import org.elasticsearch.plugins.ActionPlugin;
 import org.elasticsearch.plugins.HealthPlugin;
@@ -291,56 +290,48 @@ public class IndexLifecycle extends Plugin implements ActionPlugin, HealthPlugin
     }
 
     private static List<NamedXContentRegistry.Entry> xContentEntries() {
-        List<NamedXContentRegistry.Entry> entries = new ArrayList<>(
-            Arrays.asList(
-                // Custom Metadata
-                new NamedXContentRegistry.Entry(
-                    Metadata.Custom.class,
-                    new ParseField(IndexLifecycleMetadata.TYPE),
-                    parser -> IndexLifecycleMetadata.PARSER.parse(parser, null)
-                ),
-                new NamedXContentRegistry.Entry(
-                    Metadata.Custom.class,
-                    new ParseField(SnapshotLifecycleMetadata.TYPE),
-                    parser -> SnapshotLifecycleMetadata.PARSER.parse(parser, null)
-                ),
-                // Lifecycle Types
-                new NamedXContentRegistry.Entry(
-                    LifecycleType.class,
-                    new ParseField(TimeseriesLifecycleType.TYPE),
-                    (p, c) -> TimeseriesLifecycleType.INSTANCE
-                ),
-                // Lifecycle Actions
-                new NamedXContentRegistry.Entry(LifecycleAction.class, new ParseField(AllocateAction.NAME), AllocateAction::parse),
-                new NamedXContentRegistry.Entry(LifecycleAction.class, new ParseField(ForceMergeAction.NAME), ForceMergeAction::parse),
-                new NamedXContentRegistry.Entry(LifecycleAction.class, new ParseField(ReadOnlyAction.NAME), ReadOnlyAction::parse),
-                new NamedXContentRegistry.Entry(LifecycleAction.class, new ParseField(RolloverAction.NAME), RolloverAction::parse),
-                new NamedXContentRegistry.Entry(LifecycleAction.class, new ParseField(ShrinkAction.NAME), ShrinkAction::parse),
-                new NamedXContentRegistry.Entry(LifecycleAction.class, new ParseField(DeleteAction.NAME), DeleteAction::parse),
-                new NamedXContentRegistry.Entry(LifecycleAction.class, new ParseField(FreezeAction.NAME), FreezeAction::parse),
-                new NamedXContentRegistry.Entry(LifecycleAction.class, new ParseField(SetPriorityAction.NAME), SetPriorityAction::parse),
-                new NamedXContentRegistry.Entry(LifecycleAction.class, new ParseField(UnfollowAction.NAME), UnfollowAction::parse),
-                new NamedXContentRegistry.Entry(
-                    LifecycleAction.class,
-                    new ParseField(WaitForSnapshotAction.NAME),
-                    WaitForSnapshotAction::parse
-                ),
-                new NamedXContentRegistry.Entry(
-                    LifecycleAction.class,
-                    new ParseField(SearchableSnapshotAction.NAME),
-                    SearchableSnapshotAction::parse
-                ),
-                new NamedXContentRegistry.Entry(LifecycleAction.class, new ParseField(MigrateAction.NAME), MigrateAction::parse)
-            )
+        return Arrays.asList(
+            // Custom Metadata
+            new NamedXContentRegistry.Entry(
+                Metadata.Custom.class,
+                new ParseField(IndexLifecycleMetadata.TYPE),
+                parser -> IndexLifecycleMetadata.PARSER.parse(parser, null)
+            ),
+            new NamedXContentRegistry.Entry(
+                Metadata.Custom.class,
+                new ParseField(SnapshotLifecycleMetadata.TYPE),
+                parser -> SnapshotLifecycleMetadata.PARSER.parse(parser, null)
+            ),
+            // Lifecycle Types
+            new NamedXContentRegistry.Entry(
+                LifecycleType.class,
+                new ParseField(TimeseriesLifecycleType.TYPE),
+                (p, c) -> TimeseriesLifecycleType.INSTANCE
+            ),
+            // Lifecycle Actions
+            new NamedXContentRegistry.Entry(LifecycleAction.class, new ParseField(AllocateAction.NAME), AllocateAction::parse),
+            new NamedXContentRegistry.Entry(LifecycleAction.class, new ParseField(ForceMergeAction.NAME), ForceMergeAction::parse),
+            new NamedXContentRegistry.Entry(LifecycleAction.class, new ParseField(ReadOnlyAction.NAME), ReadOnlyAction::parse),
+            new NamedXContentRegistry.Entry(LifecycleAction.class, new ParseField(RolloverAction.NAME), RolloverAction::parse),
+            new NamedXContentRegistry.Entry(LifecycleAction.class, new ParseField(ShrinkAction.NAME), ShrinkAction::parse),
+            new NamedXContentRegistry.Entry(LifecycleAction.class, new ParseField(DeleteAction.NAME), DeleteAction::parse),
+            new NamedXContentRegistry.Entry(LifecycleAction.class, new ParseField(FreezeAction.NAME), FreezeAction::parse),
+            new NamedXContentRegistry.Entry(LifecycleAction.class, new ParseField(SetPriorityAction.NAME), SetPriorityAction::parse),
+            new NamedXContentRegistry.Entry(LifecycleAction.class, new ParseField(UnfollowAction.NAME), UnfollowAction::parse),
+            new NamedXContentRegistry.Entry(
+                LifecycleAction.class,
+                new ParseField(WaitForSnapshotAction.NAME),
+                WaitForSnapshotAction::parse
+            ),
+            new NamedXContentRegistry.Entry(
+                LifecycleAction.class,
+                new ParseField(SearchableSnapshotAction.NAME),
+                SearchableSnapshotAction::parse
+            ),
+            new NamedXContentRegistry.Entry(LifecycleAction.class, new ParseField(MigrateAction.NAME), MigrateAction::parse),
+            // TSDB Downsampling
+            new NamedXContentRegistry.Entry(LifecycleAction.class, new ParseField(DownsampleAction.NAME), DownsampleAction::parse)
         );
-
-        // TSDB Downsampling / Rollup
-        if (IndexSettings.isTimeSeriesModeEnabled()) {
-            entries.add(
-                new NamedXContentRegistry.Entry(LifecycleAction.class, new ParseField(DownsampleAction.NAME), DownsampleAction::parse)
-            );
-        }
-        return List.copyOf(entries);
     }
 
     @Override

--- a/x-pack/plugin/mapper-aggregate-metric/build.gradle
+++ b/x-pack/plugin/mapper-aggregate-metric/build.gradle
@@ -26,8 +26,3 @@ dependencies {
   testImplementation(testArtifact(project(xpackModule('core'))))
 }
 
-if (BuildParams.isSnapshotBuild() == false) {
-  tasks.named("test").configure {
-    systemProperty 'es.index_mode_feature_flag_registered', 'true'
-  }
-}

--- a/x-pack/plugin/rollup/build.gradle
+++ b/x-pack/plugin/rollup/build.gradle
@@ -21,9 +21,3 @@ dependencies {
 }
 
 addQaCheckDependencies(project)
-
-tasks.named("test").configure {
-  if (BuildParams.isSnapshotBuild() == false) {
-    systemProperty 'es.index_mode_feature_flag_registered', 'true'
-  }
-}

--- a/x-pack/plugin/rollup/qa/rest/build.gradle
+++ b/x-pack/plugin/rollup/qa/rest/build.gradle
@@ -25,7 +25,6 @@ testClusters.configureEach {
   testDistribution = 'DEFAULT'
   setting 'xpack.license.self_generated.type', 'basic'
   setting 'xpack.security.enabled', 'false'
-  requiresFeature 'es.index_mode_feature_flag_registered', Version.fromString("8.3.0")
 }
 
 if (BuildParams.inFipsJvm){

--- a/x-pack/plugin/rollup/src/main/java/org/elasticsearch/xpack/rollup/Rollup.java
+++ b/x-pack/plugin/rollup/src/main/java/org/elasticsearch/xpack/rollup/Rollup.java
@@ -22,7 +22,6 @@ import org.elasticsearch.common.settings.SettingsFilter;
 import org.elasticsearch.common.settings.SettingsModule;
 import org.elasticsearch.env.Environment;
 import org.elasticsearch.env.NodeEnvironment;
-import org.elasticsearch.index.IndexSettings;
 import org.elasticsearch.persistent.PersistentTasksExecutor;
 import org.elasticsearch.plugins.ActionPlugin;
 import org.elasticsearch.plugins.PersistentTaskPlugin;
@@ -73,7 +72,6 @@ import org.elasticsearch.xpack.rollup.rest.RestStartRollupJobAction;
 import org.elasticsearch.xpack.rollup.rest.RestStopRollupJobAction;
 
 import java.time.Clock;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
@@ -131,50 +129,35 @@ public class Rollup extends Plugin implements ActionPlugin, PersistentTaskPlugin
         IndexNameExpressionResolver indexNameExpressionResolver,
         Supplier<DiscoveryNodes> nodesInCluster
     ) {
-        List<RestHandler> handlers = new ArrayList<>(
-            Arrays.asList(
-                new RestRollupSearchAction(),
-                new RestPutRollupJobAction(),
-                new RestStartRollupJobAction(),
-                new RestStopRollupJobAction(),
-                new RestDeleteRollupJobAction(),
-                new RestGetRollupJobsAction(),
-                new RestGetRollupCapsAction(),
-                new RestGetRollupIndexCapsAction()
-            )
+        return Arrays.asList(
+            new RestRollupSearchAction(),
+            new RestPutRollupJobAction(),
+            new RestStartRollupJobAction(),
+            new RestStopRollupJobAction(),
+            new RestDeleteRollupJobAction(),
+            new RestGetRollupJobsAction(),
+            new RestGetRollupCapsAction(),
+            new RestGetRollupIndexCapsAction(),
+            new RestDownsampleAction() // TSDB Downsampling
         );
-
-        // TSDB Downsampling / Rollup
-        if (IndexSettings.isTimeSeriesModeEnabled()) {
-            handlers.add(new RestDownsampleAction());
-        }
-
-        return handlers;
     }
 
     @Override
     public List<ActionHandler<? extends ActionRequest, ? extends ActionResponse>> getActions() {
-        List<ActionHandler<?, ?>> actions = new ArrayList<>(
-            Arrays.asList(
-                new ActionHandler<>(RollupSearchAction.INSTANCE, TransportRollupSearchAction.class),
-                new ActionHandler<>(PutRollupJobAction.INSTANCE, TransportPutRollupJobAction.class),
-                new ActionHandler<>(StartRollupJobAction.INSTANCE, TransportStartRollupAction.class),
-                new ActionHandler<>(StopRollupJobAction.INSTANCE, TransportStopRollupAction.class),
-                new ActionHandler<>(DeleteRollupJobAction.INSTANCE, TransportDeleteRollupJobAction.class),
-                new ActionHandler<>(GetRollupJobsAction.INSTANCE, TransportGetRollupJobAction.class),
-                new ActionHandler<>(GetRollupCapsAction.INSTANCE, TransportGetRollupCapsAction.class),
-                new ActionHandler<>(GetRollupIndexCapsAction.INSTANCE, TransportGetRollupIndexCapsAction.class),
-                new ActionHandler<>(XPackUsageFeatureAction.ROLLUP, RollupUsageTransportAction.class),
-                new ActionHandler<>(XPackInfoFeatureAction.ROLLUP, RollupInfoTransportAction.class)
-            )
+        return Arrays.asList(
+            new ActionHandler<>(RollupSearchAction.INSTANCE, TransportRollupSearchAction.class),
+            new ActionHandler<>(PutRollupJobAction.INSTANCE, TransportPutRollupJobAction.class),
+            new ActionHandler<>(StartRollupJobAction.INSTANCE, TransportStartRollupAction.class),
+            new ActionHandler<>(StopRollupJobAction.INSTANCE, TransportStopRollupAction.class),
+            new ActionHandler<>(DeleteRollupJobAction.INSTANCE, TransportDeleteRollupJobAction.class),
+            new ActionHandler<>(GetRollupJobsAction.INSTANCE, TransportGetRollupJobAction.class),
+            new ActionHandler<>(GetRollupCapsAction.INSTANCE, TransportGetRollupCapsAction.class),
+            new ActionHandler<>(GetRollupIndexCapsAction.INSTANCE, TransportGetRollupIndexCapsAction.class),
+            new ActionHandler<>(XPackUsageFeatureAction.ROLLUP, RollupUsageTransportAction.class),
+            new ActionHandler<>(XPackInfoFeatureAction.ROLLUP, RollupInfoTransportAction.class),
+            new ActionHandler<>(RollupIndexerAction.INSTANCE, TransportRollupIndexerAction.class),
+            new ActionHandler<>(DownsampleAction.INSTANCE, TransportRollupAction.class)
         );
-
-        if (IndexSettings.isTimeSeriesModeEnabled()) {
-            actions.add(new ActionHandler<>(RollupIndexerAction.INSTANCE, TransportRollupIndexerAction.class));
-            actions.add(new ActionHandler<>(DownsampleAction.INSTANCE, TransportRollupAction.class));
-        }
-
-        return actions;
     }
 
     @Override


### PR DESCRIPTION
This PR removes the feature flag for the time-series data ingestion and downsampling functionality, 
making time-series indices and downsampling available

For more information about the released functionality, see https://github.com/elastic/elasticsearch/issues/74660

Aggregation `time_series` still remains behind the feature flag