### PR TITLE
[TEST] Wait for non-zero settings version

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/reservedstate/service/SnaphotsAndFileSettingsIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/reservedstate/service/SnaphotsAndFileSettingsIT.java
@@ -94,7 +94,7 @@ public class SnaphotsAndFileSettingsIT extends AbstractSnapshotIntegTestCase {
             @Override
             public void clusterChanged(ClusterChangedEvent event) {
                 ReservedStateMetadata reservedState = event.state().metadata().reservedStateMetadata().get(FileSettingsService.NAMESPACE);
-                if (reservedState != null) {
+                if (reservedState != null && reservedState.version() != 0L) {
                     ReservedStateHandlerMetadata handlerMetadata = reservedState.handlers().get(ReservedClusterSettingsAction.NAME);
                     if (handlerMetadata == null) {
                         fail("Should've found cluster settings in this metadata");


### PR DESCRIPTION
When we do snapshot restore and we have file settings, we don't know if the restored
version makes sense, therefore we simply reset the file settings version to 0 and let
the file settings service re-process the file.

We have a test that ensures that the file is reprocessed, but the listener for the restored state
had a bug,  it wasn't waiting for the file settings version to be > 0. This caused a rare timing situation
where the counter of the state would be one less than before, causing the clean-up to fail 
to remove the reserved cluster state.

Closes #90113