### PR TITLE
add an option for new index allocation ignore current node shard counts

### DIFF
--- a/docs/changelog/90118.yaml
+++ b/docs/changelog/90118.yaml
@@ -1,0 +1,5 @@
+pr: 90118
+summary: add an option for new index allocation ignore current node shard counts
+area: Distributed/Allocation
+type: enhancement
+issues: []

--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/allocator/BalancedShardsAllocator.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/allocator/BalancedShardsAllocator.java
@@ -994,7 +994,8 @@ public class BalancedShardsAllocator implements ShardsAllocator {
             List<Tuple<String, Float>> nodeWeights = explain ? new ArrayList<>() : null;
             Collection<ModelNode> nodeList = nodes.values();
             if (newCreateIgnoreNodeShards) {
-                // 随机重排node，保证当shard数小于节点数的情况下，shard能随机分配node
+                // shuffle nodes so that new shards will be randomly allocated to different nodes when the number of shards is less than the
+                // total count of cluster nodes
                 List<ModelNode> tempNodeList = new ArrayList<>(nodeList);
                 Collections.shuffle(tempNodeList);
                 nodeList = tempNodeList;

--- a/server/src/main/java/org/elasticsearch/common/settings/ClusterSettings.java
+++ b/server/src/main/java/org/elasticsearch/common/settings/ClusterSettings.java
@@ -194,6 +194,7 @@ public final class ClusterSettings extends AbstractScopedSettings {
         BalancedShardsAllocator.INDEX_BALANCE_FACTOR_SETTING,
         BalancedShardsAllocator.SHARD_BALANCE_FACTOR_SETTING,
         BalancedShardsAllocator.THRESHOLD_SETTING,
+        BalancedShardsAllocator.NEW_INDEX_IGNORE_NODE_SHARDS,
         BreakerSettings.CIRCUIT_BREAKER_LIMIT_SETTING,
         BreakerSettings.CIRCUIT_BREAKER_OVERHEAD_SETTING,
         BreakerSettings.CIRCUIT_BREAKER_TYPE,

--- a/server/src/test/java/org/elasticsearch/cluster/routing/IndexCreateWhenExpandNodeTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/IndexCreateWhenExpandNodeTests.java
@@ -1,0 +1,196 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.cluster.routing;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.elasticsearch.Version;
+import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.ESAllocationTestCase;
+import org.elasticsearch.cluster.metadata.IndexMetadata;
+import org.elasticsearch.cluster.metadata.Metadata;
+import org.elasticsearch.cluster.node.DiscoveryNodes;
+import org.elasticsearch.cluster.routing.allocation.AllocationService;
+import org.elasticsearch.cluster.routing.allocation.allocator.BalancedShardsAllocator;
+import org.elasticsearch.cluster.routing.allocation.decider.ClusterRebalanceAllocationDecider;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.index.Index;
+
+import static org.elasticsearch.cluster.routing.ShardRoutingState.STARTED;
+import static org.hamcrest.Matchers.equalTo;
+
+public class IndexCreateWhenExpandNodeTests extends ESAllocationTestCase {
+    private final Logger logger = LogManager.getLogger(IndexCreateWhenExpandNodeTests.class);
+
+    public void testCreateIndexIgnoreNodeShardCounts() {
+        AllocationService strategy = createAllocationService(
+            Settings.builder()
+                .put(
+                    ClusterRebalanceAllocationDecider.CLUSTER_ROUTING_ALLOCATION_ALLOW_REBALANCE_SETTING.getKey(),
+                    ClusterRebalanceAllocationDecider.ClusterRebalanceType.ALWAYS.toString()
+                )
+                .put(BalancedShardsAllocator.NEW_INDEX_IGNORE_NODE_SHARDS.getKey(), true)
+                .build()
+        );
+        Metadata metadata = Metadata.builder()
+            .put(IndexMetadata.builder("test1").settings(settings(Version.CURRENT)).numberOfShards(8).numberOfReplicas(0))
+            .put(IndexMetadata.builder("test2").settings(settings(Version.CURRENT)).numberOfShards(8).numberOfReplicas(0))
+            .build();
+        RoutingTable initialRoutingTable = RoutingTable.builder()
+            .addAsNew(metadata.index("test1"))
+            .addAsNew(metadata.index("test2"))
+            .build();
+        ClusterState clusterState = ClusterState.builder(
+            org.elasticsearch.cluster.ClusterName.CLUSTER_NAME_SETTING.getDefault(Settings.EMPTY)
+        ).metadata(metadata).routingTable(initialRoutingTable).build();
+        logger.info("start 4 nodes");
+        clusterState = ClusterState.builder(clusterState)
+            .nodes(DiscoveryNodes.builder().add(newNode("node1")).add(newNode("node2")).add(newNode("node3")).add(newNode("node4")))
+            .build();
+        clusterState = strategy.reroute(clusterState, "reroute");
+        logger.info("start all the primary shards, replicas will start initializing");
+        clusterState = startInitializingShardsAndReroute(strategy, clusterState);
+        RoutingNodes routingNodes = clusterState.getRoutingNodes();
+        assertThat(routingNodes.node("node1").numberOfShardsWithState(STARTED), equalTo(4));
+        assertThat(routingNodes.node("node2").numberOfShardsWithState(STARTED), equalTo(4));
+        assertThat(routingNodes.node("node3").numberOfShardsWithState(STARTED), equalTo(4));
+        assertThat(routingNodes.node("node4").numberOfShardsWithState(STARTED), equalTo(4));
+        metadata = Metadata.builder(clusterState.metadata())
+            .put(IndexMetadata.builder("test3").settings(settings(Version.CURRENT)).numberOfShards(8).numberOfReplicas(0))
+            .build();
+        clusterState = ClusterState.builder(clusterState)
+            .nodes(
+                DiscoveryNodes.builder(clusterState.nodes())
+                    .add(newNode("node5"))
+                    .add(newNode("node6"))
+                    .add(newNode("node7"))
+                    .add(newNode("node8"))
+            )
+            .metadata(metadata)
+            .routingTable(RoutingTable.builder(clusterState.routingTable()).addAsNew(metadata.index("test3")).build())
+            .build();
+        clusterState = startInitializingShardsAndReroute(strategy, clusterState);
+        routingNodes = clusterState.getRoutingNodes();
+        Index index3 = clusterState.metadata().index("test3").getIndex();
+        assertThat(routingNodes.node("node5").numberOfOwningShardsForIndex(index3), equalTo(1));
+        assertThat(routingNodes.node("node6").numberOfOwningShardsForIndex(index3), equalTo(1));
+        assertThat(routingNodes.node("node7").numberOfOwningShardsForIndex(index3), equalTo(1));
+        assertThat(routingNodes.node("node8").numberOfOwningShardsForIndex(index3), equalTo(1));
+        assertThat(routingNodes.node("node1").numberOfOwningShardsForIndex(index3), equalTo(1));
+        assertThat(routingNodes.node("node2").numberOfOwningShardsForIndex(index3), equalTo(1));
+        assertThat(routingNodes.node("node3").numberOfOwningShardsForIndex(index3), equalTo(1));
+        assertThat(routingNodes.node("node4").numberOfOwningShardsForIndex(index3), equalTo(1));
+        clusterState = startInitializingShardsAndReroute(strategy, clusterState);
+        clusterState = startInitializingShardsAndReroute(strategy, clusterState);
+        clusterState = startInitializingShardsAndReroute(strategy, clusterState);
+        clusterState = startInitializingShardsAndReroute(strategy, clusterState);
+        routingNodes = clusterState.getRoutingNodes();
+        assertThat(routingNodes.node("node1").numberOfShardsWithState(STARTED), equalTo(3));
+        assertThat(routingNodes.node("node2").numberOfShardsWithState(STARTED), equalTo(3));
+        assertThat(routingNodes.node("node3").numberOfShardsWithState(STARTED), equalTo(3));
+        assertThat(routingNodes.node("node4").numberOfShardsWithState(STARTED), equalTo(3));
+        assertThat(routingNodes.node("node5").numberOfShardsWithState(STARTED), equalTo(3));
+        assertThat(routingNodes.node("node6").numberOfShardsWithState(STARTED), equalTo(3));
+        assertThat(routingNodes.node("node7").numberOfShardsWithState(STARTED), equalTo(3));
+        assertThat(routingNodes.node("node8").numberOfShardsWithState(STARTED), equalTo(3));
+        assertThat(routingNodes.node("node5").numberOfOwningShardsForIndex(index3), equalTo(1));
+        assertThat(routingNodes.node("node6").numberOfOwningShardsForIndex(index3), equalTo(1));
+        assertThat(routingNodes.node("node7").numberOfOwningShardsForIndex(index3), equalTo(1));
+        assertThat(routingNodes.node("node8").numberOfOwningShardsForIndex(index3), equalTo(1));
+        assertThat(routingNodes.node("node1").numberOfOwningShardsForIndex(index3), equalTo(1));
+        assertThat(routingNodes.node("node2").numberOfOwningShardsForIndex(index3), equalTo(1));
+        assertThat(routingNodes.node("node3").numberOfOwningShardsForIndex(index3), equalTo(1));
+        assertThat(routingNodes.node("node4").numberOfOwningShardsForIndex(index3), equalTo(1));
+    }
+
+    public void testCreateIndexOrigin() {
+        AllocationService strategy = createAllocationService(
+            Settings.builder()
+                .put(
+                    ClusterRebalanceAllocationDecider.CLUSTER_ROUTING_ALLOCATION_ALLOW_REBALANCE_SETTING.getKey(),
+                    ClusterRebalanceAllocationDecider.ClusterRebalanceType.ALWAYS.toString()
+                )
+                .put(BalancedShardsAllocator.NEW_INDEX_IGNORE_NODE_SHARDS.getKey(), false)
+                .build()
+        );
+        Metadata metadata = Metadata.builder()
+            .put(IndexMetadata.builder("test1").settings(settings(Version.CURRENT)).numberOfShards(8).numberOfReplicas(0))
+            .put(IndexMetadata.builder("test2").settings(settings(Version.CURRENT)).numberOfShards(8).numberOfReplicas(0))
+            .build();
+        RoutingTable initialRoutingTable = RoutingTable.builder()
+            .addAsNew(metadata.index("test1"))
+            .addAsNew(metadata.index("test2"))
+            .build();
+        ClusterState clusterState = ClusterState.builder(
+            org.elasticsearch.cluster.ClusterName.CLUSTER_NAME_SETTING.getDefault(Settings.EMPTY)
+        ).metadata(metadata).routingTable(initialRoutingTable).build();
+        logger.info("start 4 nodes");
+        clusterState = ClusterState.builder(clusterState)
+            .nodes(DiscoveryNodes.builder().add(newNode("node1")).add(newNode("node2")).add(newNode("node3")).add(newNode("node4")))
+            .build();
+        clusterState = strategy.reroute(clusterState, "reroute");
+        logger.info("start all the primary shards, replicas will start initializing");
+        clusterState = startInitializingShardsAndReroute(strategy, clusterState);
+        RoutingNodes routingNodes = clusterState.getRoutingNodes();
+        assertThat(routingNodes.node("node1").numberOfShardsWithState(STARTED), equalTo(4));
+        assertThat(routingNodes.node("node2").numberOfShardsWithState(STARTED), equalTo(4));
+        assertThat(routingNodes.node("node3").numberOfShardsWithState(STARTED), equalTo(4));
+        assertThat(routingNodes.node("node4").numberOfShardsWithState(STARTED), equalTo(4));
+        metadata = Metadata.builder(clusterState.metadata())
+            .put(IndexMetadata.builder("test3").settings(settings(Version.CURRENT)).numberOfShards(8).numberOfReplicas(0))
+            .build();
+        clusterState = ClusterState.builder(clusterState)
+            .nodes(
+                DiscoveryNodes.builder(clusterState.nodes())
+                    .add(newNode("node5"))
+                    .add(newNode("node6"))
+                    .add(newNode("node7"))
+                    .add(newNode("node8"))
+            )
+            .metadata(metadata)
+            .routingTable(RoutingTable.builder(clusterState.routingTable()).addAsNew(metadata.index("test3")).build())
+            .build();
+        clusterState = startInitializingShardsAndReroute(strategy, clusterState);
+        routingNodes = clusterState.getRoutingNodes();
+        Index index3 = clusterState.metadata().index("test3").getIndex();
+        assertThat(routingNodes.node("node5").numberOfOwningShardsForIndex(index3), equalTo(2));
+        assertThat(routingNodes.node("node6").numberOfOwningShardsForIndex(index3), equalTo(2));
+        assertThat(routingNodes.node("node7").numberOfOwningShardsForIndex(index3), equalTo(2));
+        assertThat(routingNodes.node("node8").numberOfOwningShardsForIndex(index3), equalTo(2));
+        assertThat(routingNodes.node("node1").numberOfOwningShardsForIndex(index3), equalTo(0));
+        assertThat(routingNodes.node("node2").numberOfOwningShardsForIndex(index3), equalTo(0));
+        assertThat(routingNodes.node("node3").numberOfOwningShardsForIndex(index3), equalTo(0));
+        assertThat(routingNodes.node("node4").numberOfOwningShardsForIndex(index3), equalTo(0));
+        clusterState = startInitializingShardsAndReroute(strategy, clusterState);
+        clusterState = startInitializingShardsAndReroute(strategy, clusterState);
+        clusterState = startInitializingShardsAndReroute(strategy, clusterState);
+        clusterState = startInitializingShardsAndReroute(strategy, clusterState);
+        clusterState = startInitializingShardsAndReroute(strategy, clusterState);
+        clusterState = startInitializingShardsAndReroute(strategy, clusterState);
+        clusterState = startInitializingShardsAndReroute(strategy, clusterState);
+        routingNodes = clusterState.getRoutingNodes();
+        assertThat(routingNodes.node("node1").numberOfShardsWithState(STARTED), equalTo(3));
+        assertThat(routingNodes.node("node2").numberOfShardsWithState(STARTED), equalTo(3));
+        assertThat(routingNodes.node("node3").numberOfShardsWithState(STARTED), equalTo(3));
+        assertThat(routingNodes.node("node4").numberOfShardsWithState(STARTED), equalTo(3));
+        assertThat(routingNodes.node("node5").numberOfShardsWithState(STARTED), equalTo(3));
+        assertThat(routingNodes.node("node6").numberOfShardsWithState(STARTED), equalTo(3));
+        assertThat(routingNodes.node("node7").numberOfShardsWithState(STARTED), equalTo(3));
+        assertThat(routingNodes.node("node8").numberOfShardsWithState(STARTED), equalTo(3));
+        assertThat(routingNodes.node("node5").numberOfOwningShardsForIndex(index3), equalTo(1));
+        assertThat(routingNodes.node("node6").numberOfOwningShardsForIndex(index3), equalTo(1));
+        assertThat(routingNodes.node("node7").numberOfOwningShardsForIndex(index3), equalTo(1));
+        assertThat(routingNodes.node("node8").numberOfOwningShardsForIndex(index3), equalTo(1));
+        assertThat(routingNodes.node("node1").numberOfOwningShardsForIndex(index3), equalTo(1));
+        assertThat(routingNodes.node("node2").numberOfOwningShardsForIndex(index3), equalTo(1));
+        assertThat(routingNodes.node("node3").numberOfOwningShardsForIndex(index3), equalTo(1));
+        assertThat(routingNodes.node("node4").numberOfOwningShardsForIndex(index3), equalTo(1));
+    }
+
+}


### PR DESCRIPTION
Now when new index created, shard allocations will consider current shard distribution among nodes, and choose nodes with less shard count to assign new index shards. This policy may result in all new index shards allocation to newly added nodes to clusters and all the write workload are direct to these new node.

There are others cases may result in current shard distribution unbalanced: 
1. in cold-warm architecture, the shard migration speed may differ.  
2. once a node down, and than failover
in these cases, if new index crated, the new index shards allocation may unbalance. 

This pr adds an option for new index allocation ignore current node shard counts. so that new index shards will all balanced among all nodes.