### PR TITLE
Add usage stats report for user profiles

### DIFF
--- a/docs/changelog/90123.yaml
+++ b/docs/changelog/90123.yaml
@@ -1,0 +1,5 @@
+pr: 90123
+summary: Add usage stats report for user profiles
+area: Security
+type: enhancement
+issues: []

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/SecurityFeatureSetUsage.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/SecurityFeatureSetUsage.java
@@ -31,6 +31,7 @@ public class SecurityFeatureSetUsage extends XPackFeatureSet.Usage {
     private static final String FIPS_140_XFIELD = "fips_140";
     private static final String OPERATOR_PRIVILEGES_XFIELD = XPackField.OPERATOR_PRIVILEGES;
     private static final String DOMAINS_XFIELD = "domains";
+    private static final String USER_PROFILE_XFIELD = "user_profile";
 
     private Map<String, Object> realmsUsage;
     private Map<String, Object> rolesStoreUsage;
@@ -44,6 +45,7 @@ public class SecurityFeatureSetUsage extends XPackFeatureSet.Usage {
     private Map<String, Object> fips140Usage;
     private Map<String, Object> operatorPrivilegesUsage;
     private Map<String, Object> domainsUsage;
+    private Map<String, Object> userProfileUsage;
 
     public SecurityFeatureSetUsage(StreamInput in) throws IOException {
         super(in);
@@ -67,6 +69,9 @@ public class SecurityFeatureSetUsage extends XPackFeatureSet.Usage {
         if (in.getVersion().onOrAfter(Version.V_8_2_0)) {
             domainsUsage = in.readMap();
         }
+        if (in.getVersion().onOrAfter(Version.V_8_5_0)) {
+            userProfileUsage = in.readMap();
+        }
     }
 
     public SecurityFeatureSetUsage(
@@ -82,7 +87,8 @@ public class SecurityFeatureSetUsage extends XPackFeatureSet.Usage {
         Map<String, Object> apiKeyServiceUsage,
         Map<String, Object> fips140Usage,
         Map<String, Object> operatorPrivilegesUsage,
-        Map<String, Object> domainsUsage
+        Map<String, Object> domainsUsage,
+        Map<String, Object> userProfileUsage
     ) {
         super(XPackField.SECURITY, true, enabled);
         this.realmsUsage = realmsUsage;
@@ -97,6 +103,7 @@ public class SecurityFeatureSetUsage extends XPackFeatureSet.Usage {
         this.fips140Usage = fips140Usage;
         this.operatorPrivilegesUsage = operatorPrivilegesUsage;
         this.domainsUsage = domainsUsage;
+        this.userProfileUsage = userProfileUsage;
     }
 
     @Override
@@ -127,6 +134,9 @@ public class SecurityFeatureSetUsage extends XPackFeatureSet.Usage {
         if (out.getVersion().onOrAfter(Version.V_8_2_0)) {
             out.writeGenericMap(domainsUsage);
         }
+        if (out.getVersion().onOrAfter(Version.V_8_5_0)) {
+            out.writeGenericMap(userProfileUsage);
+        }
     }
 
     @Override
@@ -146,6 +156,9 @@ public class SecurityFeatureSetUsage extends XPackFeatureSet.Usage {
             builder.field(OPERATOR_PRIVILEGES_XFIELD, operatorPrivilegesUsage);
             if (domainsUsage != null && false == domainsUsage.isEmpty()) {
                 builder.field(DOMAINS_XFIELD, domainsUsage);
+            }
+            if (userProfileUsage != null && false == userProfileUsage.isEmpty()) {
+                builder.field(USER_PROFILE_XFIELD, userProfileUsage);
             }
         } else if (sslUsage.isEmpty() == false) {
             // A trial (or basic) license can have SSL without security.

--- a/x-pack/plugin/security/qa/profile/build.gradle
+++ b/x-pack/plugin/security/qa/profile/build.gradle
@@ -40,6 +40,6 @@ testClusters.matching { it.name == 'javaRestTest' }.configureEach {
   // Ensure new cache setting is recognised
   setting 'xpack.security.authz.store.roles.has_privileges.cache.max_size', '100'
 
-  user username: "test_admin", password: 'x-pack-test-password'
+  user username: "test-admin", password: 'x-pack-test-password'
   user username: "rac-user", password: 'x-pack-test-password', role: "rac_user_role"
 }

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/Security.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/Security.java
@@ -588,7 +588,7 @@ public class Security extends Plugin
     ) throws Exception {
         logger.info("Security is {}", enabled ? "enabled" : "disabled");
         if (enabled == false) {
-            return Collections.singletonList(new SecurityUsageServices(null, null, null, null));
+            return Collections.singletonList(new SecurityUsageServices(null, null, null, null, null));
         }
 
         systemIndices.init(client, clusterService);
@@ -917,7 +917,7 @@ public class Security extends Plugin
             )
         );
 
-        components.add(new SecurityUsageServices(realms, allRolesStore, nativeRoleMappingStore, ipFilter.get()));
+        components.add(new SecurityUsageServices(realms, allRolesStore, nativeRoleMappingStore, ipFilter.get(), profileService));
 
         cacheInvalidatorRegistry.validate();
 

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/SecurityUsageServices.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/SecurityUsageServices.java
@@ -9,6 +9,7 @@ package org.elasticsearch.xpack.security;
 import org.elasticsearch.xpack.security.authc.Realms;
 import org.elasticsearch.xpack.security.authc.support.mapper.NativeRoleMappingStore;
 import org.elasticsearch.xpack.security.authz.store.CompositeRolesStore;
+import org.elasticsearch.xpack.security.profile.ProfileService;
 import org.elasticsearch.xpack.security.transport.filter.IPFilter;
 
 /**
@@ -21,11 +22,13 @@ class SecurityUsageServices {
     final CompositeRolesStore rolesStore;
     final NativeRoleMappingStore roleMappingStore;
     final IPFilter ipFilter;
+    final ProfileService profileService;
 
-    SecurityUsageServices(Realms realms, CompositeRolesStore rolesStore, NativeRoleMappingStore roleMappingStore, IPFilter ipFilter) {
+    SecurityUsageServices(Realms realms, CompositeRolesStore rolesStore, NativeRoleMappingStore roleMappingStore, IPFilter ipFilter, ProfileService profileService) {
         this.realms = realms;
         this.rolesStore = rolesStore;
         this.roleMappingStore = roleMappingStore;
         this.ipFilter = ipFilter;
+        this.profileService = profileService;
     }
 }

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/SecurityUsageServices.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/SecurityUsageServices.java
@@ -24,7 +24,13 @@ class SecurityUsageServices {
     final IPFilter ipFilter;
     final ProfileService profileService;
 
-    SecurityUsageServices(Realms realms, CompositeRolesStore rolesStore, NativeRoleMappingStore roleMappingStore, IPFilter ipFilter, ProfileService profileService) {
+    SecurityUsageServices(
+        Realms realms,
+        CompositeRolesStore rolesStore,
+        NativeRoleMappingStore roleMappingStore,
+        IPFilter ipFilter,
+        ProfileService profileService
+    ) {
         this.realms = realms;
         this.rolesStore = rolesStore;
         this.roleMappingStore = roleMappingStore;

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/profile/ProfileService.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/profile/ProfileService.java
@@ -332,7 +332,7 @@ public class ProfileService {
     public void usageStats(ActionListener<Map<String, Object>> listener) {
         tryFreezeAndCheckIndex(listener.map(response -> { // index does not exist
             assert response == null : "only null response can reach here";
-            return Map.of("total", 0, "enabled", 0, "recent", 0);
+            return Map.of("total", 0L, "enabled", 0L, "recent", 0L);
         })).ifPresent(frozenProfileIndex -> {
             final MultiSearchRequest multiSearchRequest = client.prepareMultiSearch()
                 .add(
@@ -378,19 +378,19 @@ public class ProfileService {
                         final Map<String, Object> usage = new HashMap<>();
                         if (items[0].isFailure()) {
                             logger.debug("error on counting total profiles", items[0].getFailure());
-                            usage.put("total", 0);
+                            usage.put("total", 0L);
                         } else {
                             usage.put("total", items[0].getResponse().getHits().getTotalHits().value);
                         }
                         if (items[1].isFailure()) {
                             logger.debug("error on counting enabled profiles", items[0].getFailure());
-                            usage.put("enabled", 0);
+                            usage.put("enabled", 0L);
                         } else {
                             usage.put("enabled", items[1].getResponse().getHits().getTotalHits().value);
                         }
                         if (items[2].isFailure()) {
                             logger.debug("error on counting recent profiles", items[0].getFailure());
-                            usage.put("recent", 0);
+                            usage.put("recent", 0L);
                         } else {
                             usage.put("recent", items[2].getResponse().getHits().getTotalHits().value);
                         }

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/profile/ProfileService.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/profile/ProfileService.java
@@ -75,6 +75,7 @@ import org.elasticsearch.xpack.security.support.SecurityIndexManager;
 import java.io.IOException;
 import java.time.Clock;
 import java.time.Instant;
+import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -326,6 +327,78 @@ public class ProfileService {
                 }
             }).toList(), resultsAndErrors.errors()));
         }, listener::onFailure));
+    }
+
+    public void usageStats(ActionListener<Map<String, Object>> listener) {
+        tryFreezeAndCheckIndex(listener.map(response -> { // index does not exist
+            assert response == null : "only null response can reach here";
+            return Map.of("total", 0, "enabled", 0, "recent", 0);
+        })).ifPresent(frozenProfileIndex -> {
+            final MultiSearchRequest multiSearchRequest = client.prepareMultiSearch()
+                .add(
+                    client.prepareSearch(SECURITY_PROFILE_ALIAS)
+                        .setQuery(QueryBuilders.boolQuery().filter(QueryBuilders.existsQuery("user_profile.uid")))
+                        .setSize(0)
+                        .setTrackTotalHits(true)
+                        .request()
+                )
+                .add(
+                    client.prepareSearch(SECURITY_PROFILE_ALIAS)
+                        .setQuery(QueryBuilders.boolQuery().filter(QueryBuilders.termQuery("user_profile.enabled", true)))
+                        .setSize(0)
+                        .setTrackTotalHits(true)
+                        .request()
+                )
+                .add(
+                    client.prepareSearch(SECURITY_PROFILE_ALIAS)
+                        .setQuery(
+                            QueryBuilders.boolQuery()
+                                .filter(QueryBuilders.termQuery("user_profile.enabled", true))
+                                .filter(
+                                    QueryBuilders.rangeQuery("user_profile.last_synchronized")
+                                        .gt(Instant.now().minus(30, ChronoUnit.DAYS).toEpochMilli())
+                                )
+                        )
+                        .setSize(0)
+                        .setTrackTotalHits(true)
+                        .request()
+                )
+                .request();
+
+            frozenProfileIndex.checkIndexVersionThenExecute(
+                listener::onFailure,
+                () -> executeAsyncWithOrigin(
+                    client,
+                    getActionOrigin(),
+                    MultiSearchAction.INSTANCE,
+                    multiSearchRequest,
+                    ActionListener.wrap(multiSearchResponse -> {
+                        final MultiSearchResponse.Item[] items = multiSearchResponse.getResponses();
+                        assert items.length == 3;
+                        final Map<String, Object> usage = new HashMap<>();
+                        if (items[0].isFailure()) {
+                            logger.debug("error on counting total profiles", items[0].getFailure());
+                            usage.put("total", 0);
+                        } else {
+                            usage.put("total", items[0].getResponse().getHits().getTotalHits().value);
+                        }
+                        if (items[1].isFailure()) {
+                            logger.debug("error on counting enabled profiles", items[0].getFailure());
+                            usage.put("enabled", 0);
+                        } else {
+                            usage.put("enabled", items[1].getResponse().getHits().getTotalHits().value);
+                        }
+                        if (items[2].isFailure()) {
+                            logger.debug("error on counting recent profiles", items[0].getFailure());
+                            usage.put("recent", 0);
+                        } else {
+                            usage.put("recent", items[2].getResponse().getHits().getTotalHits().value);
+                        }
+                        listener.onResponse(usage);
+                    }, listener::onFailure)
+                )
+            );
+        });
     }
 
     // package private for testing

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/SecurityInfoTransportActionTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/SecurityInfoTransportActionTests.java
@@ -29,7 +29,9 @@ import org.elasticsearch.xpack.security.audit.logfile.LoggingAuditTrail;
 import org.elasticsearch.xpack.security.authc.Realms;
 import org.elasticsearch.xpack.security.authc.support.mapper.NativeRoleMappingStore;
 import org.elasticsearch.xpack.security.authz.store.CompositeRolesStore;
+import org.elasticsearch.xpack.security.profile.ProfileService;
 import org.elasticsearch.xpack.security.transport.filter.IPFilter;
+import org.hamcrest.Matchers;
 import org.junit.Before;
 
 import java.io.IOException;
@@ -39,6 +41,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import static org.elasticsearch.test.ActionListenerUtils.anyActionListener;
+import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.emptyIterable;
@@ -56,6 +59,7 @@ public class SecurityInfoTransportActionTests extends ESTestCase {
     private IPFilter ipFilter;
     private CompositeRolesStore rolesStore;
     private NativeRoleMappingStore roleMappingStore;
+    private ProfileService profileService;
     private SecurityUsageServices securityServices;
 
     @Before
@@ -66,7 +70,8 @@ public class SecurityInfoTransportActionTests extends ESTestCase {
         ipFilter = mock(IPFilter.class);
         rolesStore = mock(CompositeRolesStore.class);
         roleMappingStore = mock(NativeRoleMappingStore.class);
-        securityServices = new SecurityUsageServices(realms, rolesStore, roleMappingStore, ipFilter);
+        profileService = mock(ProfileService.class);
+        securityServices = new SecurityUsageServices(realms, rolesStore, roleMappingStore, ipFilter, profileService);
     }
 
     public void testAvailable() {
@@ -166,6 +171,15 @@ public class SecurityInfoTransportActionTests extends ESTestCase {
             settings.put("xpack.security.operator_privileges.enabled", true);
         }
 
+        final Map<String, Object> userProfileUsage =
+            Map.of("total", randomIntBetween(100, 200), "enabled", randomIntBetween(50, 99), "recent", randomIntBetween(1, 42));
+        doAnswer(invocation -> {
+            @SuppressWarnings("unchecked")
+            final var listener = (ActionListener<Map<String, Object>>) invocation.getArguments()[0];
+            listener.onResponse(userProfileUsage);
+            return null;
+        }).when(profileService).usageStats(anyActionListener());
+
         var usageAction = newUsageAction(settings.build());
         PlainActionFuture<XPackUsageFeatureResponse> future = new PlainActionFuture<>();
         usageAction.masterOperation(null, null, null, future);
@@ -234,6 +248,11 @@ public class SecurityInfoTransportActionTests extends ESTestCase {
                 // operator privileges
                 assertThat(source.getValue("operator_privileges.available"), is(operatorPrivilegesAvailable));
                 assertThat(source.getValue("operator_privileges.enabled"), is(operatorPrivilegesEnabled));
+
+                // user profile
+                assertThat(source.getValue("user_profile.total"), equalTo(userProfileUsage.get("total")));
+                assertThat(source.getValue("user_profile.enabled"), equalTo(userProfileUsage.get("enabled")));
+                assertThat(source.getValue("user_profile.recent"), equalTo(userProfileUsage.get("recent")));
             } else {
                 if (explicitlyDisabled) {
                     assertThat(source.getValue("ssl"), is(nullValue()));
@@ -249,6 +268,7 @@ public class SecurityInfoTransportActionTests extends ESTestCase {
                 assertThat(source.getValue("ipfilter"), is(nullValue()));
                 assertThat(source.getValue("roles"), is(nullValue()));
                 assertThat(source.getValue("operator_privileges"), is(nullValue()));
+                assertThat(source.getValue("user_profile"), is(Matchers.nullValue()));
             }
         }
     }

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/SecurityInfoTransportActionTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/SecurityInfoTransportActionTests.java
@@ -171,8 +171,14 @@ public class SecurityInfoTransportActionTests extends ESTestCase {
             settings.put("xpack.security.operator_privileges.enabled", true);
         }
 
-        final Map<String, Object> userProfileUsage =
-            Map.of("total", randomIntBetween(100, 200), "enabled", randomIntBetween(50, 99), "recent", randomIntBetween(1, 42));
+        final Map<String, Object> userProfileUsage = Map.of(
+            "total",
+            randomIntBetween(100, 200),
+            "enabled",
+            randomIntBetween(50, 99),
+            "recent",
+            randomIntBetween(1, 42)
+        );
         doAnswer(invocation -> {
             @SuppressWarnings("unchecked")
             final var listener = (ActionListener<Map<String, Object>>) invocation.getArguments()[0];

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/profile/ProfileServiceTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/profile/ProfileServiceTests.java
@@ -7,6 +7,7 @@
 
 package org.elasticsearch.xpack.security.profile;
 
+import org.apache.lucene.search.TotalHits;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.ResourceNotFoundException;
 import org.elasticsearch.Version;
@@ -24,6 +25,7 @@ import org.elasticsearch.action.index.IndexAction;
 import org.elasticsearch.action.index.IndexRequestBuilder;
 import org.elasticsearch.action.search.MultiSearchAction;
 import org.elasticsearch.action.search.MultiSearchRequest;
+import org.elasticsearch.action.search.MultiSearchRequestBuilder;
 import org.elasticsearch.action.search.MultiSearchResponse;
 import org.elasticsearch.action.search.SearchAction;
 import org.elasticsearch.action.search.SearchRequest;
@@ -53,6 +55,8 @@ import org.elasticsearch.index.query.MultiMatchQueryBuilder;
 import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.index.query.QueryBuilders;
 import org.elasticsearch.index.shard.ShardId;
+import org.elasticsearch.search.SearchHit;
+import org.elasticsearch.search.SearchHits;
 import org.elasticsearch.search.builder.SearchSourceBuilder;
 import org.elasticsearch.search.sort.FieldSortBuilder;
 import org.elasticsearch.search.sort.ScoreSortBuilder;
@@ -99,6 +103,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
 import java.util.function.Consumer;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import static java.util.Collections.emptyMap;
@@ -1012,6 +1017,53 @@ public class ProfileServiceTests extends ESTestCase {
         assertThat(getException.getSuppressed(), arrayContaining(versionConflictEngineException));
         verify(service, times(1)).shouldSkipUpdateForActivate(any(), any());
         verify(service).doUpdate(any(), anyActionListener());
+    }
+
+    public void testUsageStats() {
+        final List<String> metricNames = List.of("total", "enabled", "recent");
+
+        final String erroredMetric;
+        if (randomBoolean()) {
+            erroredMetric = randomFrom(metricNames);
+        } else {
+            erroredMetric = null;
+        }
+
+        final Map<String, Long> metrics = metricNames.stream()
+            .collect(Collectors.toUnmodifiableMap(Function.identity(), n -> n.equals(erroredMetric) ? 0L : randomNonNegativeLong()));
+
+        final MultiSearchResponse.Item[] items = metricNames.stream().map(name -> {
+            if (name.equals(erroredMetric)) {
+                return new MultiSearchResponse.Item(null, new RuntimeException());
+            } else {
+                final var searchResponse = mock(SearchResponse.class);
+                when(searchResponse.getHits()).thenReturn(
+                    new SearchHits(new SearchHit[0], new TotalHits(metrics.get(name), TotalHits.Relation.EQUAL_TO), 1)
+                );
+                return new MultiSearchResponse.Item(searchResponse, null);
+            }
+        }).toArray(MultiSearchResponse.Item[]::new);
+
+        final MultiSearchResponse multiSearchResponse = new MultiSearchResponse(items, randomNonNegativeLong());
+
+        doAnswer(invocation -> {
+            @SuppressWarnings("unchecked")
+            final var listener = (ActionListener<MultiSearchResponse>) invocation.getArgument(2);
+            listener.onResponse(multiSearchResponse);
+            return null;
+        }).when(client).execute(eq(MultiSearchAction.INSTANCE), any(MultiSearchRequest.class), anyActionListener());
+
+        when(client.prepareMultiSearch()).thenReturn(new MultiSearchRequestBuilder(client, MultiSearchAction.INSTANCE));
+        final PlainActionFuture<Map<String, Object>> future = new PlainActionFuture<>();
+        profileService.usageStats(future);
+        assertThat(future.actionGet(), equalTo(metrics));
+    }
+
+    public void testUsageStatsWhenNoIndex() {
+        when(profileIndex.indexExists()).thenReturn(false);
+        final PlainActionFuture<Map<String, Object>> future = new PlainActionFuture<>();
+        profileService.usageStats(future);
+        assertThat(future.actionGet(), equalTo(Map.of("total", 0, "enabled", 0, "recent", 0)));
     }
 
     record SampleDocumentParameter(String uid, String username, List<String> roles, long lastSynchronized) {}

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/profile/ProfileServiceTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/profile/ProfileServiceTests.java
@@ -1063,7 +1063,7 @@ public class ProfileServiceTests extends ESTestCase {
         when(profileIndex.indexExists()).thenReturn(false);
         final PlainActionFuture<Map<String, Object>> future = new PlainActionFuture<>();
         profileService.usageStats(future);
-        assertThat(future.actionGet(), equalTo(Map.of("total", 0, "enabled", 0, "recent", 0)));
+        assertThat(future.actionGet(), equalTo(Map.of("total", 0L, "enabled", 0L, "recent", 0L)));
     }
 
     record SampleDocumentParameter(String uid, String username, List<String> roles, long lastSynchronized) {}


### PR DESCRIPTION
This PR augments the existing xpack usage API to report total, enabled and recent (last 30 days) usage stats of user profiles.

Resolves: #89525
