### PR TITLE
GitHub Workflows security hardening

### DIFF
--- a/.github/workflows/docs-preview-links.yml
+++ b/.github/workflows/docs-preview-links.yml
@@ -6,8 +6,13 @@ on:
     paths:
       - '**.asciidoc'
 
+permissions:
+  contents: read
+
 jobs:
   doc-preview:
+    permissions:
+      issues: write
     runs-on: ubuntu-latest
     steps:
       - uses: actions/github-script@v6

--- a/.github/workflows/docs-preview-links.yml
+++ b/.github/workflows/docs-preview-links.yml
@@ -12,7 +12,7 @@ permissions:
 jobs:
   doc-preview:
     permissions:
-      issues: write
+      pull-requests: write
     runs-on: ubuntu-latest
     steps:
       - uses: actions/github-script@v6

--- a/.github/workflows/docs-preview-links.yml
+++ b/.github/workflows/docs-preview-links.yml
@@ -6,9 +6,6 @@ on:
     paths:
       - '**.asciidoc'
 
-permissions:
-  contents: read
-
 jobs:
   doc-preview:
     permissions:

--- a/docs/changelog/90124.yaml
+++ b/docs/changelog/90124.yaml
@@ -1,5 +1,0 @@
-pr: 90142
-summary: Harden GitHub workflow token permissions
-area: Infra/Scripting
-type: feature
-issues: []

--- a/docs/changelog/90124.yaml
+++ b/docs/changelog/90124.yaml
@@ -1,0 +1,5 @@
+pr: 90142
+summary: Harden GitHub workflow token permissions
+area: Infra/Scripting
+type: feature
+issues: []


### PR DESCRIPTION
This PR adds explicit [permissions section](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions) to workflows. This is a security best practice because by default workflows run with [extended set of permissions](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token) (except from `on: pull_request` [from external forks](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)). By specifying any permission explicitly all others are set to none. By using the principle of least privilege the damage a compromised workflow can do (because of an [injection](https://securitylab.github.com/research/github-actions-untrusted-input/) or compromised third party tool or action) is restricted.
It is recommended to have [most strict permissions on the top level](https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions) and grant write permissions on [job level](https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs) case by case.