### PR TITLE
[8.1] [DOCS] Adds missing_bucket setting to transform APIs (#90111)

### DIFF
--- a/docs/reference/rest-api/common-parms.asciidoc
+++ b/docs/reference/rest-api/common-parms.asciidoc
@@ -725,6 +725,9 @@ The following groupings are currently supported:
 * <<_histogram,Histogram>>
 * <<_terms,Terms>>
 
+The grouping properties can optionally have a `missing_bucket` property. If 
+it's `true`, documents without a value in the respective `group_by` field are 
+included. Defaults to `false`.
 --
 end::pivot-group-by[]
 

--- a/docs/reference/transform/apis/preview-transform.asciidoc
+++ b/docs/reference/transform/apis/preview-transform.asciidoc
@@ -286,7 +286,8 @@ POST _transform/_preview
     "group_by": {
       "customer_id": {
         "terms": {
-          "field": "customer_id"
+          "field": "customer_id",
+          "missing_bucket": true
         }
       }
     },

--- a/docs/reference/transform/apis/put-transform.asciidoc
+++ b/docs/reference/transform/apis/put-transform.asciidoc
@@ -154,7 +154,6 @@ include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=pivot-aggs]
 `group_by`:::
 (Required, object)
 include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=pivot-group-by]
-
 ====
 //End pivot
 
@@ -295,7 +294,8 @@ PUT _transform/ecommerce_transform1
     "group_by": {
       "customer_id": {
         "terms": {
-          "field": "customer_id"
+          "field": "customer_id",
+          "missing_bucket": true
         }
       }
     },


### PR DESCRIPTION
Backports the following commits to 8.1:
 - [DOCS] Adds missing_bucket setting to transform APIs (#90111)