### PR TITLE
[ML] Fix MlAutoscalingContext.hasWaitingTasks

### DIFF
--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/autoscaling/MlAutoscalingContext.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/autoscaling/MlAutoscalingContext.java
@@ -139,7 +139,7 @@ class MlAutoscalingContext {
     public boolean hasWaitingTasks() {
         return waitingAnomalyJobs.isEmpty() == false
             || waitingSnapshotUpgrades.isEmpty() == false
-            || waitingAnalyticsJobs.isEmpty()
+            || waitingAnalyticsJobs.isEmpty() == false
             || waitingAllocatedModels.isEmpty() == false;
     }
 

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/autoscaling/MlMemoryAutoscalingDeciderTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/autoscaling/MlMemoryAutoscalingDeciderTests.java
@@ -24,7 +24,6 @@ import org.elasticsearch.core.Tuple;
 import org.elasticsearch.persistent.PersistentTasksCustomMetadata;
 import org.elasticsearch.snapshots.SnapshotShardSizeInfo;
 import org.elasticsearch.test.ESTestCase;
-import org.elasticsearch.xpack.autoscaling.Autoscaling;
 import org.elasticsearch.xpack.autoscaling.capacity.AutoscalingCapacity;
 import org.elasticsearch.xpack.autoscaling.capacity.AutoscalingDeciderContext;
 import org.elasticsearch.xpack.core.ml.MlTasks;


### PR DESCRIPTION
This fixes the method `hasWaitingTasks` in `MlAutoscalingContext` to correctly account for analytics jobs. This bug was introduced in the refactoring done in #89167.
