### PR TITLE
[DOCS] Add ml-cpp PR to v8.4.2 release docs

### DIFF
--- a/docs/reference/release-notes/8.4.2.asciidoc
+++ b/docs/reference/release-notes/8.4.2.asciidoc
@@ -34,6 +34,7 @@ Ingest Node::
 
 Machine Learning::
 * Fix memory leak in `TransportDeleteExpiredDataAction` {es-pull}89935[#89935]
+* Do not retain categorization tokens when existing category matches {ml-pull}2398[#2398]
 
 Network::
 * Fix memory leak when double invoking `RestChannel.sendResponse` {es-pull}89873[#89873]


### PR DESCRIPTION
Relates to https://github.com/elastic/elasticsearch/pull/90084

This PR adds the ml-cpp PRs from https://github.com/elastic/ml-cpp/blob/8.4/docs/CHANGELOG.asciidoc into the Elasticsearch release notes for 8.4.2