### PR TITLE
Script: Write Fields API for reindex, update, update by query

### DIFF
--- a/docs/changelog/90145.yaml
+++ b/docs/changelog/90145.yaml
@@ -1,0 +1,5 @@
+pr: 90145
+summary: "Script: Write Fields API for reindex, update, update by query"
+area: Infra/Scripting
+type: enhancement
+issues: []

--- a/modules/lang-painless/src/main/resources/org/elasticsearch/painless/org.elasticsearch.script.reindex.txt
+++ b/modules/lang-painless/src/main/resources/org/elasticsearch/painless/org.elasticsearch.script.reindex.txt
@@ -36,4 +36,37 @@ class org.elasticsearch.script.Metadata {
 
 class org.elasticsearch.script.ReindexScript {
     Metadata metadata()
+    WriteField field(String)
+}
+
+class org.elasticsearch.script.field.WriteField {
+    String getName()
+    boolean exists()
+    WriteField move(def)
+    WriteField overwrite(def)
+    void remove()
+    WriteField set(def)
+    WriteField append(def)
+    boolean isEmpty()
+    int size()
+    Iterator iterator()
+    def get(def)
+    def get(int, def)
+    boolean hasValue(Predicate)
+    WriteField transform(Function)
+    WriteField deduplicate()
+    WriteField removeValuesIf(Predicate)
+    WriteField removeValue(int)
+    NestedDocument doc()
+    NestedDocument doc(int)
+    Iterable docs()
+}
+
+class org.elasticsearch.script.field.NestedDocument {
+    WriteField field(String)
+    Stream fields(String)
+    boolean isEmpty()
+    int size()
+    boolean exists()
+    void remove()
 }

--- a/modules/lang-painless/src/main/resources/org/elasticsearch/painless/org.elasticsearch.script.update.txt
+++ b/modules/lang-painless/src/main/resources/org/elasticsearch/painless/org.elasticsearch.script.update.txt
@@ -31,4 +31,37 @@ class org.elasticsearch.script.Metadata {
 
 class org.elasticsearch.script.UpdateScript {
     Metadata metadata()
+    WriteField field(String)
+}
+
+class org.elasticsearch.script.field.WriteField {
+    String getName()
+    boolean exists()
+    WriteField move(def)
+    WriteField overwrite(def)
+    void remove()
+    WriteField set(def)
+    WriteField append(def)
+    boolean isEmpty()
+    int size()
+    Iterator iterator()
+    def get(def)
+    def get(int, def)
+    boolean hasValue(Predicate)
+    WriteField transform(Function)
+    WriteField deduplicate()
+    WriteField removeValuesIf(Predicate)
+    WriteField removeValue(int)
+    NestedDocument doc()
+    NestedDocument doc(int)
+    Iterable docs()
+}
+
+class org.elasticsearch.script.field.NestedDocument {
+    WriteField field(String)
+    Stream fields(String)
+    boolean isEmpty()
+    int size()
+    boolean exists()
+    void remove()
 }

--- a/modules/lang-painless/src/main/resources/org/elasticsearch/painless/org.elasticsearch.script.update_by_query.txt
+++ b/modules/lang-painless/src/main/resources/org/elasticsearch/painless/org.elasticsearch.script.update_by_query.txt
@@ -30,4 +30,37 @@ class org.elasticsearch.script.Metadata {
 
 class org.elasticsearch.script.UpdateByQueryScript {
     Metadata metadata()
+    WriteField field(String)
+}
+
+class org.elasticsearch.script.field.WriteField {
+    String getName()
+    boolean exists()
+    WriteField move(def)
+    WriteField overwrite(def)
+    void remove()
+    WriteField set(def)
+    WriteField append(def)
+    boolean isEmpty()
+    int size()
+    Iterator iterator()
+    def get(def)
+    def get(int, def)
+    boolean hasValue(Predicate)
+    WriteField transform(Function)
+    WriteField deduplicate()
+    WriteField removeValuesIf(Predicate)
+    WriteField removeValue(int)
+    NestedDocument doc()
+    NestedDocument doc(int)
+    Iterable docs()
+}
+
+class org.elasticsearch.script.field.NestedDocument {
+    WriteField field(String)
+    Stream fields(String)
+    boolean isEmpty()
+    int size()
+    boolean exists()
+    void remove()
 }

--- a/modules/lang-painless/src/yamlRestTest/resources/rest-api-spec/test/painless/15_update.yml
+++ b/modules/lang-painless/src/yamlRestTest/resources/rest-api-spec/test/painless/15_update.yml
@@ -167,3 +167,37 @@
         id: "2"
 
   - match: { found: false }
+
+---
+"Script Write Field":
+  - skip:
+      version: " - 8.4.99"
+      reason: "Write fields api introduced in 8.5.0"
+
+  - do:
+      index:
+        index:  test_1
+        id:     "3"
+        body:
+          foo:    bar
+          count:  1
+
+  - do:
+      update:
+        index:    test_1
+        id:       "3"
+        body:
+          script:
+            source: field('foo').transform(x -> x + '-baz'); field('nest').doc().field('bar').set(200)
+            lang: painless
+          upsert: {}
+          scripted_upsert: true
+
+  - do:
+      get:
+        index: test_1
+        id: "3"
+
+  - match: { _source.foo: bar-baz }
+  - match: { _source.nest.bar: 200 }
+  - match: { found: true }

--- a/modules/lang-painless/src/yamlRestTest/resources/rest-api-spec/test/painless/25_script_upsert.yml
+++ b/modules/lang-painless/src/yamlRestTest/resources/rest-api-spec/test/painless/25_script_upsert.yml
@@ -187,3 +187,29 @@
         id: "2"
 
   - match: { _source.bar: index-extra }
+
+---
+"Script Write Field":
+  - skip:
+      version: " - 8.4.99"
+      reason: "Write fields api introduced in 8.5.0"
+
+  - do:
+      update:
+        index:    test_1
+        id:       "3"
+        body:
+          script:
+            source: field('foo').set('bar').transform(x -> x + '-baz'); field('nest').doc().field('bar').set(200)
+            lang: painless
+          upsert: {}
+          scripted_upsert: true
+
+  - do:
+      get:
+        index: test_1
+        id: "3"
+
+  - match: { _source.foo: bar-baz }
+  - match: { _source.nest.bar: 200 }
+  - match: { found: true }

--- a/modules/reindex/src/yamlRestTest/resources/rest-api-spec/test/reindex/85_scripting.yml
+++ b/modules/reindex/src/yamlRestTest/resources/rest-api-spec/test/reindex/85_scripting.yml
@@ -440,3 +440,43 @@
             lang: painless
             source: syntax errors are fun!
   - match: {error.reason: 'compile error'}
+
+---
+"Script Write Field":
+  - skip:
+      version: " - 8.4.99"
+      reason: "Write fields api introduced in 8.5.0"
+
+  - do:
+      index:
+        index:  testw1
+        id:     "1"
+        body:
+          foo:    bar
+          count:  1
+
+  - do:
+      indices.refresh: {}
+
+  - do:
+      reindex:
+        refresh: true
+        body:
+          source:
+            index: testw1
+          dest:
+            index: testw2
+          script:
+            source: field('foo').transform(x -> x + '-baz'); field('nest').doc().field('bar').set(200)
+            lang: painless
+
+  - match: {created: 1}
+
+  - do:
+      get:
+        index: testw2
+        id: "1"
+
+  - match: { _source.foo: bar-baz }
+  - match: { _source.nest.bar: 200 }
+  - match: { found: true }

--- a/modules/reindex/src/yamlRestTest/resources/rest-api-spec/test/update_by_query/80_scripting.yml
+++ b/modules/reindex/src/yamlRestTest/resources/rest-api-spec/test/update_by_query/80_scripting.yml
@@ -506,3 +506,37 @@
   - match: { hits.total: 1 }
   - match: { hits.hits.0._source.old_version: -1 }
 
+---
+"Script Write Field":
+  - skip:
+      version: " - 8.4.99"
+      reason: "Write fields api introduced in 8.5.0"
+
+  - do:
+      index:
+        index: testw1
+        id: "1"
+        body:
+          foo: bar
+          count: 1
+
+  - do:
+      indices.refresh: {}
+
+  - do:
+      update_by_query:
+        refresh: true
+        index: testw1
+        body:
+          script:
+            source: field('foo').transform(x -> x + '-baz'); field('nest').doc().field('bar').set(200)
+            lang: painless
+
+  - do:
+      get:
+        index: testw1
+        id: "1"
+
+  - match: { _source.foo: bar-baz }
+  - match: { _source.nest.bar: 200 }
+  - match: { found: true }


### PR DESCRIPTION
Whitelists the write fields API to the reindex, update by query and update contexts.