### PR TITLE
Optimize unchanged metadata handling in PersistedClusterStateService

### DIFF
--- a/server/src/main/java/org/elasticsearch/gateway/PersistedClusterStateService.java
+++ b/server/src/main/java/org/elasticsearch/gateway/PersistedClusterStateService.java
@@ -944,6 +944,10 @@ public class PersistedClusterStateService {
             assert previouslyWrittenMetadata.coordinationMetadata().term() == metadata.coordinationMetadata().term();
             logger.trace("currentTerm [{}] matches previous currentTerm, writing changes only", metadata.coordinationMetadata().term());
 
+            if (previouslyWrittenMetadata == metadata) {
+                // breakout early if nothing changed
+                return new WriterStats(false, false, metadata.getMappingsByHash().size(), 0, 0, metadata.size(), 0, 0, 0);
+            }
             final boolean updateGlobalMeta = Metadata.isGlobalStateEquals(previouslyWrittenMetadata, metadata) == false;
             if (updateGlobalMeta) {
                 for (MetadataIndexWriter metadataIndexWriter : metadataIndexWriters) {


### PR DESCRIPTION
With #90101 both follower and leader nodes will get instance equality on the metadata on non-metadata changes here reliably. We can leverage that and skip the expensive loop over all indices in this method on instance equality.

relates #77466 