### PR TITLE
[8.4]Backport 90117

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/reservedstate/service/SnaphotsAndFileSettingsIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/reservedstate/service/SnaphotsAndFileSettingsIT.java
@@ -94,7 +94,7 @@ public class SnaphotsAndFileSettingsIT extends AbstractSnapshotIntegTestCase {
             @Override
             public void clusterChanged(ClusterChangedEvent event) {
                 ReservedStateMetadata reservedState = event.state().metadata().reservedStateMetadata().get(FileSettingsService.NAMESPACE);
-                if (reservedState != null) {
+                if (reservedState != null && reservedState.version() != 0L) {
                     ReservedStateHandlerMetadata handlerMetadata = reservedState.handlers().get(ReservedClusterSettingsAction.NAME);
                     if (handlerMetadata == null) {
                         fail("Should've found cluster settings in this metadata");


### PR DESCRIPTION
This backports the test fix for SnapshotsAndFileSettingsIT in 8.4 https://github.com/elastic/elasticsearch/pull/90117