### PR TITLE
Fixing disk health indicator unit tests

### DIFF
--- a/server/src/test/java/org/elasticsearch/health/node/DiskHealthIndicatorServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/health/node/DiskHealthIndicatorServiceTests.java
@@ -739,7 +739,7 @@ public class DiskHealthIndicatorServiceTests extends ESTestCase {
         Set<String> nonRedNodeIndices = new HashSet<>();
         for (int i = 0; i < numberOfIndices; i++) {
             String indexName = randomAlphaOfLength(20);
-            if (randomBoolean()) {
+            if (nonRedNodeIds.isEmpty() || randomBoolean()) {
                 indexNameToNodeIdsMap.put(indexName, redNodeIds);
                 redNodeIndices.add(indexName);
             } else {
@@ -775,7 +775,7 @@ public class DiskHealthIndicatorServiceTests extends ESTestCase {
         Set<String> nonRedNodeIndices = new HashSet<>();
         for (int i = 0; i < numberOfIndices; i++) {
             String indexName = randomAlphaOfLength(20);
-            if (randomBoolean()) {
+            if (nonRedNodeIds.isEmpty() || randomBoolean()) {
                 indexNameToNodeIdsMap.put(indexName, redNodeIds);
                 redNodeIndices.add(indexName);
             } else {


### PR DESCRIPTION
The disk health indicator unit tests had a couple of edge cases where they could fail if all test nodes had a red status. This protects against that.