### PR TITLE
[CI] Mute test `CoordinatorTests#testUnhealthyLeaderIsReplaced`

### DIFF
--- a/server/src/test/java/org/elasticsearch/cluster/coordination/CoordinatorTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/coordination/CoordinatorTests.java
@@ -605,6 +605,7 @@ public class CoordinatorTests extends AbstractCoordinatorTestCase {
         }
     }
 
+    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/90158")
     public void testUnhealthyLeaderIsReplaced() {
         final AtomicReference<StatusInfo> nodeHealthServiceStatus = new AtomicReference<>(new StatusInfo(HEALTHY, "healthy-info"));
         final int initialClusterSize = between(1, 3);


### PR DESCRIPTION
Mute flaky test `CoordinatorTests#testUnhealthyLeaderIsReplaced`

Relates to https://github.com/elastic/elasticsearch/issues/90158