### PR TITLE
Restrict nodes for testClusterPrimariesActive2

### DIFF
--- a/server/src/test/java/org/elasticsearch/cluster/routing/allocation/ClusterRebalanceRoutingTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/allocation/ClusterRebalanceRoutingTests.java
@@ -229,7 +229,18 @@ public class ClusterRebalanceRoutingTests extends ESAllocationTestCase {
 
         Metadata metadata = Metadata.builder()
             .put(IndexMetadata.builder("test1").settings(settings(Version.CURRENT)).numberOfShards(1).numberOfReplicas(1))
-            .put(IndexMetadata.builder("test2").settings(settings(Version.CURRENT)).numberOfShards(1).numberOfReplicas(1))
+            .put(
+                IndexMetadata.builder("test2")
+                    .settings(
+                        settings(Version.CURRENT).put(
+                            IndexMetadata.INDEX_ROUTING_INCLUDE_GROUP_SETTING.getConcreteSettingForNamespace("_id").getKey(),
+                            "node1,node2"
+                        )
+                    )
+                    .numberOfShards(1)
+                    .numberOfReplicas(1)
+            )
+
             .build();
 
         RoutingTable initialRoutingTable = RoutingTable.builder()


### PR DESCRIPTION
This test sets up one `green` and one `yellow` index and requires that the `green` index is the one that gets rebalanced. This may not be true in future, but we can make it true by restricting the nodes that can hold shards of the `yellow` index.