### PR TITLE
Disk indicator change details

### DIFF
--- a/docs/changelog/90189.yaml
+++ b/docs/changelog/90189.yaml
@@ -1,0 +1,5 @@
+pr: 90189
+summary: Disk indicator change details
+area: Health
+type: bug
+issues: []

--- a/docs/reference/health/health.asciidoc
+++ b/docs/reference/health/health.asciidoc
@@ -312,30 +312,25 @@ details have contents and a structure that is unique to each indicator.
     (int) The number of replica shards that are relocating because of a node shutdown operation.
 
 `started_replicas`::
-    (int) The number of replica shards that are active and available on the sysetm.
+    (int) The number of replica shards that are active and available on the system.
 
 [[health-api-response-details-disk]]
 ===== disk
 
-`nodes`::
-    (Optional, array) A list of nodes that have reported disk usage information. This field
-    is present if any node has reported disk usage.
-+
-.Properties of `nodes`
-[%collapsible%open]
-====
-`node_id`::
-    (string) The node id of the node reporting disk usage.
+`blocked_indices`::
+(int) The number of indices that are blocked by the system because the cluster is running out of space.
 
-`name`::
-    (Optional, string) The node name of the node reporting disk usage.
+`green_nodes`::
+(int) The number of nodes that have enough available disk space to function.
 
-`status`::
-    (string) The status of the disk indicator on the node.
+`yellow_nodes`::
+(int) The number of nodes that are running low on disk and it is likely that they will run out.
 
-`cause`::
-    (Optional, string) The cause for the status not being GREEN, if known.
-====
+`red_nodes`::
+(int) The number of nodes that have run out of disk.
+
+`unknown_nodes`::
+(int) The number of nodes for which it was not possible to determine their disk health.
 
 [[health-api-response-details-repository-integrity]]
 ===== repository_integrity

--- a/docs/reference/health/health.asciidoc
+++ b/docs/reference/health/health.asciidoc
@@ -324,7 +324,7 @@ details have contents and a structure that is unique to each indicator.
 (int) The number of nodes that have enough available disk space to function.
 
 `yellow_nodes`::
-(int) The number of nodes that are running low on disk and it is likely that they will run out.
+(int) The number of nodes that are running low on disk and it is likely that they will run out of space.
 
 `red_nodes`::
 (int) The number of nodes that have run out of disk.


### PR DESCRIPTION
Change the details of the disk indicator to provide an overview of the impact of the disk space health instead of a comprehensive list. For example:
```
"details": {
  "blocked_indices": 1,
  "red_nodes": 1,
  "yellow_nodes": 2,
  "unknown_nodes": 0,
  "green_nodes": 3
}
```