### PR TITLE
Change permissions for Enterprise Search Behavioural Analytics indexes

### DIFF
--- a/x-pack/plugin/security/qa/service-account/src/javaRestTest/java/org/elasticsearch/xpack/security/authc/service/ServiceAccountIT.java
+++ b/x-pack/plugin/security/qa/service-account/src/javaRestTest/java/org/elasticsearch/xpack/security/authc/service/ServiceAccountIT.java
@@ -160,7 +160,7 @@ public class ServiceAccountIT extends ESRestTestCase {
                         "metricbeat-ent-search-*",
                         "enterprise-search-*",
                         "logs-app_search.analytics-default",
-                        "logs-elastic_analytics.events-*-*",
+                        "logs-elastic_analytics.events-*",
                         "logs-enterprise_search.api-default",
                         "logs-enterprise_search.audit-default",
                         "logs-app_search.search_relevance_suggestions-default",

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/service/ElasticServiceAccounts.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/service/ElasticServiceAccounts.java
@@ -37,7 +37,7 @@ final class ElasticServiceAccounts {
                         "metricbeat-ent-search-*",
                         "enterprise-search-*",
                         "logs-app_search.analytics-default",
-                        "logs-elastic_analytics.events-*-*",
+                        "logs-elastic_analytics.events-*",
                         "logs-enterprise_search.api-default",
                         "logs-enterprise_search.audit-default",
                         "logs-app_search.search_relevance_suggestions-default",

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/service/ElasticServiceAccountsTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/service/ElasticServiceAccountsTests.java
@@ -353,7 +353,7 @@ public class ElasticServiceAccountsTests extends ESTestCase {
             "metricbeat-ent-search-" + randomAlphaOfLengthBetween(1, 20),
             "enterprise-search-" + randomAlphaOfLengthBetween(1, 20),
             "logs-app_search.analytics-default",
-            "logs-elastic_analytics.events-" + randomAlphaOfLengthBetween(1, 20) + "-" + randomAlphaOfLengthBetween(1, 20),
+            "logs-elastic_analytics.events-" + randomAlphaOfLengthBetween(1, 20),
             "logs-enterprise_search.api-default",
             "logs-enterprise_search.audit-default",
             "logs-app_search.search_relevance_suggestions-default",


### PR DESCRIPTION
### Description
During the testing, it was discovered that two wildcards simply do not work for `elastic_analytics.events` indexes.

This PR is dedicated to changing two wildcards to one wildcard

Relates: #89869