### PR TITLE
[DOCS] Add 8.5 release notes and fix links

### DIFF
--- a/docs/reference/migration/index.asciidoc
+++ b/docs/reference/migration/index.asciidoc
@@ -1,6 +1,7 @@
 include::migration_intro.asciidoc[]
 
 * <<migrating-8.6,Migrating to 8.6>>
+* <<migrating-8.5,Migrating to 8.5>>
 * <<migrating-8.4,Migrating to 8.4>>
 * <<migrating-8.3,Migrating to 8.3>>
 * <<migrating-8.2,Migrating to 8.2>>
@@ -8,6 +9,7 @@ include::migration_intro.asciidoc[]
 * <<migrating-8.0,Migrating to 8.0>>
 
 include::migrate_8_6.asciidoc[]
+include::migrate_8_5.asciidoc[]
 include::migrate_8_4.asciidoc[]
 include::migrate_8_3.asciidoc[]
 include::migrate_8_2.asciidoc[]

--- a/docs/reference/release-notes.asciidoc
+++ b/docs/reference/release-notes.asciidoc
@@ -7,6 +7,7 @@
 This section summarizes the changes in each release.
 
 * <<release-notes-8.6.0>>
+* <<release-notes-8.5.0>>
 * <<release-notes-8.4.2>>
 * <<release-notes-8.4.1>>
 * <<release-notes-8.4.0>>
@@ -33,6 +34,7 @@ This section summarizes the changes in each release.
 --
 
 include::release-notes/8.6.0.asciidoc[]
+include::release-notes/8.5.0.asciidoc[]
 include::release-notes/8.4.2.asciidoc[]
 include::release-notes/8.4.1.asciidoc[]
 include::release-notes/8.4.0.asciidoc[]

--- a/docs/reference/release-notes/8.5.0.asciidoc
+++ b/docs/reference/release-notes/8.5.0.asciidoc
@@ -1,0 +1,6 @@
+[[release-notes-8.5.0]]
+== {es} version 8.5.0
+
+coming[8.5.0]
+
+Also see <<breaking-changes-8.5,Breaking changes in 8.5>>.

--- a/docs/reference/release-notes/highlights.asciidoc
+++ b/docs/reference/release-notes/highlights.asciidoc
@@ -12,8 +12,7 @@ endif::[]
 // Add previous release to the list
 Other versions:
 
-{ref-bare}/8.5/release-highlights.html[8.5]
-| {ref-bare}/8.4/release-highlights.html[8.4]
+{ref-bare}/8.4/release-highlights.html[8.4]
 | {ref-bare}/8.3/release-highlights.html[8.3]
 | {ref-bare}/8.2/release-highlights.html[8.2]
 | {ref-bare}/8.1/release-highlights.html[8.1]


### PR DESCRIPTION
Adds missing 8.5 release notes file, plus appropriate links to all files.