### PR TITLE
Fixed : [CI] DownsampleActionSingleNodeTests » testCannotRollupWhileOtherRollupInProgress

### DIFF
--- a/x-pack/plugin/rollup/src/test/java/org/elasticsearch/xpack/downsample/DownsampleActionSingleNodeTests.java
+++ b/x-pack/plugin/rollup/src/test/java/org/elasticsearch/xpack/downsample/DownsampleActionSingleNodeTests.java
@@ -496,7 +496,6 @@ public class DownsampleActionSingleNodeTests extends ESSingleNodeTestCase {
         assertThat(exception.getMessage(), containsString("no such index [missing-index]"));
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/90197")
     public void testCannotRollupWhileOtherRollupInProgress() throws Exception {
         DownsampleConfig config = new DownsampleConfig(randomInterval());
         SourceSupplier sourceSupplier = () -> XContentFactory.jsonBuilder()
@@ -525,6 +524,13 @@ public class DownsampleActionSingleNodeTests extends ESSingleNodeTestCase {
             }
         };
         client().execute(DownsampleAction.INSTANCE, new DownsampleAction.Request(sourceIndex, rollupIndex, config), rollupListener);
+        assertBusy(() -> {
+            try {
+                assertEquals(client().admin().indices().prepareGetIndex().addIndices(rollupIndex).get().getIndices().length, 1);
+            } catch (IndexNotFoundException e) {
+                fail("rollup index has not created");
+            }
+        });
         ResourceAlreadyExistsException exception = expectThrows(
             ResourceAlreadyExistsException.class,
             () -> rollup(sourceIndex, rollupIndex, config)

--- a/x-pack/plugin/rollup/src/test/java/org/elasticsearch/xpack/downsample/DownsampleActionSingleNodeTests.java
+++ b/x-pack/plugin/rollup/src/test/java/org/elasticsearch/xpack/downsample/DownsampleActionSingleNodeTests.java
@@ -528,7 +528,7 @@ public class DownsampleActionSingleNodeTests extends ESSingleNodeTestCase {
             try {
                 assertEquals(client().admin().indices().prepareGetIndex().addIndices(rollupIndex).get().getIndices().length, 1);
             } catch (IndexNotFoundException e) {
-                fail("rollup index has not created");
+                fail("rollup index has not been created");
             }
         });
         ResourceAlreadyExistsException exception = expectThrows(


### PR DESCRIPTION
The reason why this test some times failed is that, the next rollup call is so close to the first rollup call, it may case the first rollup failed.
I add a check, that the first rollup has already created the rollup index, then call the next rollup.