### PR TITLE
[ML] Unmute "Test existing but corrupt snapshot" test

### DIFF
--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/ml/upgrade_job_snapshot.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/ml/upgrade_job_snapshot.yml
@@ -95,11 +95,7 @@ setup:
         snapshot_id: "9999999999"
 
 ---
-
 "Test existing but corrupt snapshot":
-  - skip:
-      version: "all"
-      reason: "AwaitsFix https://github.com/elastic/elasticsearch/issues/89564"
   - do:
       ml.upgrade_job_snapshot:
         job_id: "upgrade-model-snapshot"


### PR DESCRIPTION
Following https://github.com/elastic/elasticsearch/pull/90193 this should no longer fail.