### PR TITLE
[7.8] [DOCS] Modifies link that points to .NET client page. (#90229)

### DIFF
--- a/docs/reference/docs/bulk.asciidoc
+++ b/docs/reference/docs/bulk.asciidoc
@@ -110,7 +110,7 @@ JavaScript::
     See {jsclient-current}/client-helpers.html[client.helpers.*]
 
 .NET::
-    See https://www.elastic.co/guide/en/elasticsearch/client/net-api/current/indexing-documents.html[`BulkAllObservable`]
+    See https://www.elastic.co/guide/en/elasticsearch/client/net-api/7.16/indexing-documents.html#bulkall-observable[`BulkAllObservable`]
 
 [discrete]
 [[bulk-curl]]

--- a/docs/reference/docs/bulk.asciidoc
+++ b/docs/reference/docs/bulk.asciidoc
@@ -110,7 +110,7 @@ JavaScript::
     See {jsclient-current}/client-helpers.html[client.helpers.*]
 
 .NET::
-    See https://www.elastic.co/guide/en/elasticsearch/client/net-api/current/indexing-documents.html#bulkall-observable[`BulkAllObservable`]
+    See https://www.elastic.co/guide/en/elasticsearch/client/net-api/current/indexing-documents.html[`BulkAllObservable`]
 
 [discrete]
 [[bulk-curl]]


### PR DESCRIPTION
Backports the following commits to 7.8:
 - [DOCS] Modifies link that points to .NET client page. (#90229)