### PR TITLE
Change "zscore" to "z-score" in documentation

### DIFF
--- a/docs/reference/aggregations/pipeline/normalize-aggregation.asciidoc
+++ b/docs/reference/aggregations/pipeline/normalize-aggregation.asciidoc
@@ -72,7 +72,7 @@ _mean_::
 
                 [4.63, 4.63, 9.63, 49.63, 9.63, 9.63, 19.63]
 
-_zscore_::
+_z-score_::
                 This method normalizes such that each value represents how far it is from the mean relative to the standard deviation
 
                 x' = (x - mean_x) / stdev_x


### PR DESCRIPTION
The string "zscore" is an invalid method name for the normalisation aggregation.  The documentation should be updated with correct name that is "z-score".

The string is defined here:
https://github.com/elastic/elasticsearch/blob/e0f07130bd15328af1c15f37ddd30a82936eb37e/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/normalize/NormalizePipelineMethods.java#L70
