### PR TITLE
[8.5] Fix ScalingThreadPoolTests for the management thread pool (#90214)

### DIFF
--- a/server/src/test/java/org/elasticsearch/threadpool/ScalingThreadPoolTests.java
+++ b/server/src/test/java/org/elasticsearch/threadpool/ScalingThreadPoolTests.java
@@ -49,7 +49,12 @@ public class ScalingThreadPoolTests extends ESThreadPoolTestCase {
             core = randomIntBetween(0, 8);
             builder.put("thread_pool." + threadPoolName + ".core", core);
         } else {
-            core = "generic".equals(threadPoolName) ? 4 : 1; // the defaults
+            // the defaults
+            core = switch (threadPoolName) {
+                case "generic" -> 4;
+                case "management" -> 2;
+                default -> 1;
+            };
         }
 
         final int availableProcessors = Runtime.getRuntime().availableProcessors();
@@ -151,7 +156,11 @@ public class ScalingThreadPoolTests extends ESThreadPoolTestCase {
     @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/90210")
     public void testScalingThreadPoolThreadsAreTerminatedAfterKeepAlive() throws InterruptedException {
         final String threadPoolName = randomThreadPool(ThreadPool.ThreadPoolType.SCALING);
-        final int min = "generic".equals(threadPoolName) ? 4 : 1;
+        final int min = switch (threadPoolName) {
+            case "generic" -> 4;
+            case "management" -> 2;
+            default -> 1;
+        };
         final Settings settings = Settings.builder()
             .put("thread_pool." + threadPoolName + ".max", 128)
             .put("thread_pool." + threadPoolName + ".keep_alive", "1ms")

--- a/server/src/test/java/org/elasticsearch/threadpool/ScalingThreadPoolTests.java
+++ b/server/src/test/java/org/elasticsearch/threadpool/ScalingThreadPoolTests.java
@@ -39,7 +39,6 @@ import static org.hamcrest.Matchers.lessThanOrEqualTo;
 
 public class ScalingThreadPoolTests extends ESThreadPoolTestCase {
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/90210")
     public void testScalingThreadPoolConfiguration() throws InterruptedException {
         final String threadPoolName = randomThreadPool(ThreadPool.ThreadPoolType.SCALING);
         final Settings.Builder builder = Settings.builder();
@@ -153,7 +152,6 @@ public class ScalingThreadPoolTests extends ESThreadPoolTestCase {
         });
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/90210")
     public void testScalingThreadPoolThreadsAreTerminatedAfterKeepAlive() throws InterruptedException {
         final String threadPoolName = randomThreadPool(ThreadPool.ThreadPoolType.SCALING);
         final int min = switch (threadPoolName) {

--- a/server/src/test/java/org/elasticsearch/threadpool/UpdateThreadPoolSettingsTests.java
+++ b/server/src/test/java/org/elasticsearch/threadpool/UpdateThreadPoolSettingsTests.java
@@ -112,7 +112,6 @@ public class UpdateThreadPoolSettingsTests extends ESThreadPoolTestCase {
         }
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/90210")
     public void testScalingExecutorType() throws InterruptedException {
         String threadPoolName = randomThreadPool(ThreadPool.ThreadPoolType.SCALING);
         ThreadPool threadPool = null;

--- a/server/src/test/java/org/elasticsearch/threadpool/UpdateThreadPoolSettingsTests.java
+++ b/server/src/test/java/org/elasticsearch/threadpool/UpdateThreadPoolSettingsTests.java
@@ -122,7 +122,11 @@ public class UpdateThreadPoolSettingsTests extends ESThreadPoolTestCase {
                 .put("node.name", "testScalingExecutorType")
                 .build();
             threadPool = new ThreadPool(nodeSettings);
-            final int expectedMinimum = "generic".equals(threadPoolName) ? 4 : 1;
+            final int expectedMinimum = switch (threadPoolName) {
+                case "generic" -> 4;
+                case "management" -> 2;
+                default -> 1;
+            };
             assertThat(info(threadPool, threadPoolName).getMin(), equalTo(expectedMinimum));
             assertThat(info(threadPool, threadPoolName).getMax(), equalTo(10));
             final long expectedKeepAlive = "generic".equals(threadPoolName) || Names.SNAPSHOT_META.equals(threadPoolName) ? 30 : 300;


### PR DESCRIPTION
Backports the following commits to 8.5:
 - Fix ScalingThreadPoolTests for the management thread pool (#90214)