### PR TITLE
Fix disk indicator symptoms, impacts and diagnosis

### DIFF
--- a/docs/changelog/90262.yaml
+++ b/docs/changelog/90262.yaml
@@ -1,0 +1,5 @@
+pr: 90262
+summary: Fix disk indicator impacts and diagnosis
+area: Health
+type: bug
+issues: []

--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/ShardsAvailabilityHealthIndicatorService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/ShardsAvailabilityHealthIndicatorService.java
@@ -47,7 +47,6 @@ import org.elasticsearch.snapshots.SnapshotShardSizeInfo;
 
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -72,6 +71,8 @@ import static org.elasticsearch.cluster.routing.allocation.decider.ShardsLimitAl
 import static org.elasticsearch.health.HealthStatus.GREEN;
 import static org.elasticsearch.health.HealthStatus.RED;
 import static org.elasticsearch.health.HealthStatus.YELLOW;
+import static org.elasticsearch.health.node.HealthIndicatorDisplayStringGetter.byPriorityThenByName;
+import static org.elasticsearch.health.node.HealthIndicatorDisplayStringGetter.getTruncatedIndices;
 
 /**
  * This indicator reports health for shards.
@@ -854,7 +855,7 @@ public class ShardsAvailabilityHealthIndicatorService implements HealthIndicator
                     "Cannot add data to %d %s [%s]. Searches might return incomplete results.",
                     primaries.indicesWithUnavailableShards.size(),
                     primaries.indicesWithUnavailableShards.size() == 1 ? "index" : "indices",
-                    getTruncatedIndicesString(primaries.indicesWithUnavailableShards, clusterMetadata)
+                    getTruncatedIndices(primaries.indicesWithUnavailableShards, clusterMetadata)
                 );
                 impacts.add(
                     new HealthIndicatorImpact(
@@ -879,7 +880,7 @@ public class ShardsAvailabilityHealthIndicatorService implements HealthIndicator
                     "Searches might be slower than usual. Fewer redundant copies of the data exist on %d %s [%s].",
                     indicesWithUnavailableReplicasOnly.size(),
                     indicesWithUnavailableReplicasOnly.size() == 1 ? "index" : "indices",
-                    getTruncatedIndicesString(indicesWithUnavailableReplicasOnly, clusterMetadata)
+                    getTruncatedIndices(indicesWithUnavailableReplicasOnly, clusterMetadata)
                 );
                 impacts.add(
                     new HealthIndicatorImpact(NAME, REPLICA_UNASSIGNED_IMPACT_ID, 2, impactDescription, List.of(ImpactArea.SEARCH))
@@ -921,31 +922,5 @@ public class ShardsAvailabilityHealthIndicatorService implements HealthIndicator
                 return Collections.emptyList();
             }
         }
-    }
-
-    private static String getTruncatedIndicesString(Set<String> indices, Metadata clusterMetadata) {
-        final int maxIndices = 10;
-        String truncatedIndicesString = indices.stream()
-            .sorted(byPriorityThenByName(clusterMetadata))
-            .limit(maxIndices)
-            .collect(joining(", "));
-        if (maxIndices < indices.size()) {
-            truncatedIndicesString = truncatedIndicesString + ", ...";
-        }
-        return truncatedIndicesString;
-    }
-
-    /**
-     * Sorts index names by their priority first, then alphabetically by name. If the priority cannot be determined for an index then
-     * a priority of -1 is used to sort it behind other index names.
-     * @param clusterMetadata Used to look up index priority.
-     * @return Comparator instance
-     */
-    private static Comparator<String> byPriorityThenByName(Metadata clusterMetadata) {
-        // We want to show indices with a numerically higher index.priority first (since lower priority ones might get truncated):
-        return Comparator.comparingInt((String indexName) -> {
-            IndexMetadata indexMetadata = clusterMetadata.index(indexName);
-            return indexMetadata == null ? -1 : indexMetadata.priority();
-        }).reversed().thenComparing(Comparator.naturalOrder());
     }
 }

--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/ShardsAvailabilityHealthIndicatorService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/ShardsAvailabilityHealthIndicatorService.java
@@ -71,8 +71,8 @@ import static org.elasticsearch.cluster.routing.allocation.decider.ShardsLimitAl
 import static org.elasticsearch.health.HealthStatus.GREEN;
 import static org.elasticsearch.health.HealthStatus.RED;
 import static org.elasticsearch.health.HealthStatus.YELLOW;
-import static org.elasticsearch.health.node.HealthIndicatorDisplayStringGetter.byPriorityThenByName;
-import static org.elasticsearch.health.node.HealthIndicatorDisplayStringGetter.getTruncatedIndices;
+import static org.elasticsearch.health.node.HealthIndicatorDisplayValues.getTruncatedIndices;
+import static org.elasticsearch.health.node.HealthIndicatorDisplayValues.indicesComparatorByPriorityAndName;
 
 /**
  * This indicator reports health for shards.
@@ -913,7 +913,10 @@ public class ShardsAvailabilityHealthIndicatorService implements HealthIndicator
                         .map(
                             e -> new Diagnosis(
                                 e.getKey(),
-                                e.getValue().stream().sorted(byPriorityThenByName(clusterMetadata)).collect(Collectors.toList())
+                                e.getValue()
+                                    .stream()
+                                    .sorted(indicesComparatorByPriorityAndName(clusterMetadata))
+                                    .collect(Collectors.toList())
                             )
                         )
                         .collect(Collectors.toList());

--- a/server/src/main/java/org/elasticsearch/health/node/DiskHealthIndicatorService.java
+++ b/server/src/main/java/org/elasticsearch/health/node/DiskHealthIndicatorService.java
@@ -179,7 +179,7 @@ public class DiskHealthIndicatorService implements HealthIndicatorService {
             if (unhealthyDataNodes.isEmpty()) {
                 // In this case the disk issue has been resolved but the index block has not been removed yet or the
                 // cluster is still moving shards away from data nodes that are over the high watermark.
-                symptom += ("the cluster was running out of disk space. The cluster is recovering and you should be able to update them "
+                symptom += ("the cluster was running out of disk space. The cluster is recovering and ingest capabilities should be restored "
                     + "within a few minutes.");
             } else {
                 symptom += String.format(

--- a/server/src/main/java/org/elasticsearch/health/node/HealthIndicatorDisplayStringGetter.java
+++ b/server/src/main/java/org/elasticsearch/health/node/HealthIndicatorDisplayStringGetter.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.health.node;
+
+import org.elasticsearch.cluster.metadata.IndexMetadata;
+import org.elasticsearch.cluster.metadata.Metadata;
+import org.elasticsearch.cluster.node.DiscoveryNode;
+
+import java.util.Comparator;
+import java.util.Locale;
+import java.util.Set;
+
+import static java.util.stream.Collectors.joining;
+
+public class HealthIndicatorDisplayStringGetter {
+
+    public static String getNodeName(DiscoveryNode node) {
+        if (node.getName() != null) {
+            return String.format(Locale.ROOT, "[%s][%s]", node.getId(), node.getName());
+        }
+        return String.format(Locale.ROOT, "[%s]", node.getId());
+    }
+
+    public static String getTruncatedIndices(Set<String> indices, Metadata clusterMetadata) {
+        final int maxIndices = 10;
+        String truncatedIndicesString = indices.stream()
+            .sorted(byPriorityThenByName(clusterMetadata))
+            .limit(maxIndices)
+            .collect(joining(", "));
+        if (maxIndices < indices.size()) {
+            truncatedIndicesString = truncatedIndicesString + ", ...";
+        }
+        return truncatedIndicesString;
+    }
+
+    /**
+     * Sorts index names by their priority first, then alphabetically by name. If the priority cannot be determined for an index then
+     * a priority of -1 is used to sort it behind other index names.
+     * @param clusterMetadata Used to look up index priority.
+     * @return Comparator instance
+     */
+    public static Comparator<String> byPriorityThenByName(Metadata clusterMetadata) {
+        // We want to show indices with a numerically higher index.priority first (since lower priority ones might get truncated):
+        return Comparator.comparingInt((String indexName) -> {
+            IndexMetadata indexMetadata = clusterMetadata.index(indexName);
+            return indexMetadata == null ? -1 : indexMetadata.priority();
+        }).reversed().thenComparing(Comparator.naturalOrder());
+    }
+}

--- a/server/src/main/java/org/elasticsearch/health/node/HealthIndicatorDisplayValues.java
+++ b/server/src/main/java/org/elasticsearch/health/node/HealthIndicatorDisplayValues.java
@@ -18,7 +18,7 @@ import java.util.Set;
 
 import static java.util.stream.Collectors.joining;
 
-public class HealthIndicatorDisplayStringGetter {
+public class HealthIndicatorDisplayValues {
 
     public static String getNodeName(DiscoveryNode node) {
         if (node.getName() != null) {
@@ -30,7 +30,7 @@ public class HealthIndicatorDisplayStringGetter {
     public static String getTruncatedIndices(Set<String> indices, Metadata clusterMetadata) {
         final int maxIndices = 10;
         String truncatedIndicesString = indices.stream()
-            .sorted(byPriorityThenByName(clusterMetadata))
+            .sorted(indicesComparatorByPriorityAndName(clusterMetadata))
             .limit(maxIndices)
             .collect(joining(", "));
         if (maxIndices < indices.size()) {
@@ -45,7 +45,7 @@ public class HealthIndicatorDisplayStringGetter {
      * @param clusterMetadata Used to look up index priority.
      * @return Comparator instance
      */
-    public static Comparator<String> byPriorityThenByName(Metadata clusterMetadata) {
+    public static Comparator<String> indicesComparatorByPriorityAndName(Metadata clusterMetadata) {
         // We want to show indices with a numerically higher index.priority first (since lower priority ones might get truncated):
         return Comparator.comparingInt((String indexName) -> {
             IndexMetadata indexMetadata = clusterMetadata.index(indexName);

--- a/server/src/test/java/org/elasticsearch/health/node/DiskHealthIndicatorServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/health/node/DiskHealthIndicatorServiceTests.java
@@ -264,7 +264,7 @@ public class DiskHealthIndicatorServiceTests extends ESTestCase {
                 result.symptom(),
                 equalTo(
                     "1 index is not allowed to be updated because the cluster was running out of "
-                        + "disk space. The cluster is recovering and you should be able to update them within a few minutes."
+                        + "disk space. The cluster is recovering and ingest capabilities should be restored within a few minutes."
                 )
             );
         }


### PR DESCRIPTION
This PR fixes the following:

**Non-data, non-master calculation**
_Bug_: A non-data, non-master node is a node that has at least one role that is not master or data node.
_Fix_: A non-data, non-master node is a node that does not contains data and it is not a master.

**Dedicated master calculation**
_Bug_: A dedicated master node in the context of the disk health indicator is a node that has at least the master role.
_Fix_: A dedicated master node in the context of the disk health indicator is a node that has the master role and cannot contain data.

**Impact implementation**
_Bug_: We list at most 3 impacts, one that is based on blocked indices or indices on unhealthy data nods, one for master and one for the rest. The current implementation wasn't covering this in all cases, for example, if there was a data node and no dedicated master node it wouldn't display the master node impact.
_Fix_: Base the calculation of master and other role impacts, on the roles of the affected nodes.

**Diagnosis implementation**
_Bug_: The code was correct but the tests needed adjusting because they expected 1 extra diagnosis since a master node was identified as both a dedicated master node and a dedicated non-master, non-data node. 
_Fix_: Fixed the test to respect the hierarchy, data node > dedicated master node > other. 

**Symptom implementation**
_Bug_: There were two messages produced as symptoms, one for the case where we have blocked indices but all the other nodes are healthy, and for all the other cases one that would list the roles that were running out of space.
_Fix_: We change them to a messages that might have two parts:
- Always mention if there are indices blocked and explain why, which can be one of the following two cases, (i) cluster is recovering **(this includes the case of all nodes appearing healthy because the cluster is moving shards away from the out of space nodes),** (ii) there are unhealthy data nodes that cannot recover without user intervention.
- Always mention all the affected roles as symptom.
_Examples_
> 3 indices are not allowed to be updated because the cluster was running out of disk space. The cluster is recovering and you should be able to update them within a few minutes. Furthermore 3 more nodes with roles: [master, ingest] are out of disk or running low on disk space.

> 3 indices are not allowed to be updated because 2 nodes are out of disk or running low on disk space. Furthermore 3 nodes with roles: [master, ingest] are out of disk or running low on disk space.

> 5 nodes with roles: [data, master, ingest] are out of disk or running low on disk space.


**Bonus**
- We enrich the impact about "other" nodes with the roles.
- We enrich the affected indices with listing indicative 10 indices like we do with the shards availability indicator.