### PR TITLE
Fix repeated error save loops in File Settings Service

### DIFF
--- a/docs/changelog/90271.yaml
+++ b/docs/changelog/90271.yaml
@@ -1,0 +1,6 @@
+pr: 90271
+summary: Fix repeated error save loops in File Settings Service
+area: Infra/Core
+type: bug
+issues:
+ - 90222

--- a/server/src/main/java/org/elasticsearch/bootstrap/Security.java
+++ b/server/src/main/java/org/elasticsearch/bootstrap/Security.java
@@ -16,7 +16,6 @@ import org.elasticsearch.env.Environment;
 import org.elasticsearch.http.HttpTransportSettings;
 import org.elasticsearch.jdk.JarHell;
 import org.elasticsearch.plugins.PluginsUtils;
-import org.elasticsearch.reservedstate.service.FileSettingsService;
 import org.elasticsearch.secure_sm.SecureSM;
 import org.elasticsearch.transport.TcpTransport;
 
@@ -257,11 +256,7 @@ final class Security {
             addSingleFilePath(policy, pidFile, "delete");
         }
         // we need to touch the operator/settings.json file when restoring from snapshots, on some OSs it needs file write permission
-        addSingleFilePath(
-            policy,
-            environment.configFile().resolve(OPERATOR_DIRECTORY).resolve(SETTINGS_FILE_NAME),
-            "read,readlink,write"
-        );
+        addSingleFilePath(policy, environment.configFile().resolve(OPERATOR_DIRECTORY).resolve(SETTINGS_FILE_NAME), "read,readlink,write");
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/bootstrap/Security.java
+++ b/server/src/main/java/org/elasticsearch/bootstrap/Security.java
@@ -16,6 +16,7 @@ import org.elasticsearch.env.Environment;
 import org.elasticsearch.http.HttpTransportSettings;
 import org.elasticsearch.jdk.JarHell;
 import org.elasticsearch.plugins.PluginsUtils;
+import org.elasticsearch.reservedstate.service.FileSettingsService;
 import org.elasticsearch.secure_sm.SecureSM;
 import org.elasticsearch.transport.TcpTransport;
 
@@ -46,6 +47,8 @@ import java.util.function.Consumer;
 import static java.lang.invoke.MethodType.methodType;
 import static org.elasticsearch.bootstrap.FilePermissionUtils.addDirectoryPath;
 import static org.elasticsearch.bootstrap.FilePermissionUtils.addSingleFilePath;
+import static org.elasticsearch.reservedstate.service.FileSettingsService.OPERATOR_DIRECTORY;
+import static org.elasticsearch.reservedstate.service.FileSettingsService.SETTINGS_FILE_NAME;
 
 /**
  * Initializes SecurityManager with necessary permissions.
@@ -253,6 +256,12 @@ final class Security {
             // we just need permission to remove the file if its elsewhere.
             addSingleFilePath(policy, pidFile, "delete");
         }
+        // we need to touch the operator/settings.json file when restoring from snapshots, on some OSs it needs file write permission
+        addSingleFilePath(
+            policy,
+            environment.configFile().resolve(OPERATOR_DIRECTORY).resolve(SETTINGS_FILE_NAME),
+            "read,readlink,write"
+        );
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/ReservedStateMetadata.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/ReservedStateMetadata.java
@@ -209,7 +209,7 @@ public record ReservedStateMetadata(
          */
         public Builder(String namespace) {
             this.namespace = namespace;
-            this.version = 0L;
+            this.version = -1L;
             this.handlers = new HashMap<>();
             this.errorMetadata = null;
         }

--- a/server/src/main/java/org/elasticsearch/reservedstate/service/FileSettingsService.java
+++ b/server/src/main/java/org/elasticsearch/reservedstate/service/FileSettingsService.java
@@ -50,7 +50,7 @@ import static org.elasticsearch.xcontent.XContentType.JSON;
 public class FileSettingsService extends AbstractLifecycleComponent implements ClusterStateListener {
     private static final Logger logger = LogManager.getLogger(FileSettingsService.class);
 
-    private static final String SETTINGS_FILE_NAME = "settings.json";
+    public static final String SETTINGS_FILE_NAME = "settings.json";
     public static final String NAMESPACE = "file_settings";
 
     private final ClusterService clusterService;

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/ReservedStateMetadataTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/ReservedStateMetadataTests.java
@@ -75,6 +75,11 @@ public class ReservedStateMetadataTests extends ESTestCase {
         xContentTest(false, false);
     }
 
+    public void testReservedStateVersionWithError() {
+        final ReservedStateMetadata meta = createRandom(false, true);
+        assertEquals(-1L, meta.version().longValue());
+    }
+
     private static ReservedStateMetadata createRandom(boolean addHandlers, boolean addErrors) {
         List<ReservedStateHandlerMetadata> handlers = randomList(
             0,

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/ToAndFromJsonMetadataTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/ToAndFromJsonMetadataTests.java
@@ -782,7 +782,7 @@ public class ToAndFromJsonMetadataTests extends ESTestCase {
                 },
                 "reserved_state" : {
                   "namespace_one" : {
-                    "version" : 0,
+                    "version" : -1,
                     "handlers" : {
                       "one" : {
                         "keys" : [
@@ -807,7 +807,7 @@ public class ToAndFromJsonMetadataTests extends ESTestCase {
                     }
                   },
                   "namespace_two" : {
-                    "version" : 0,
+                    "version" : -1,
                     "handlers" : {
                       "three" : {
                         "keys" : [


### PR DESCRIPTION
There were two bugs that were exposed by a recent Windows failures on File Settings:

- When we process an initial settings file which had errors, the reserved metadata version that was saved was 0, which is wrong because we use 0 to mean we need to touch and reset the file from a snapshot restore. The correct default value should be -1, meaning no successful file settings were ever written. Because we used 0, the code that monitors for 0 version was constantly resetting the modified timestamp on the settings file, which caused a flurry of save activity, eventually leading to very rare failure when we time out waiting on the error state to be saved.
- Windows apparently needs write file permission to be able to touch the settings.json file in the operator directory. This means that this functionality never worked correctly in production on Windows. 

Closes https://github.com/elastic/elasticsearch/issues/90222