### PR TITLE
Downsampling: replace map with array and avoid calling map contains

### DIFF
--- a/x-pack/plugin/rollup/src/main/java/org/elasticsearch/xpack/downsample/FieldValueFetcher.java
+++ b/x-pack/plugin/rollup/src/main/java/org/elasticsearch/xpack/downsample/FieldValueFetcher.java
@@ -16,21 +16,22 @@ import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.search.DocValueFormat;
 import org.elasticsearch.xpack.aggregatemetric.mapper.AggregateDoubleMetricFieldMapper;
 
-import java.util.Collections;
-import java.util.LinkedHashMap;
-import java.util.Map;
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * Utility class used for fetching field values by reading field data
  */
 class FieldValueFetcher {
     private final String name;
+    private final ValueType valueType;
     private final MappedFieldType fieldType;
     private final DocValueFormat format;
     private final IndexFieldData<?> fieldData;
 
-    protected FieldValueFetcher(String name, MappedFieldType fieldType, IndexFieldData<?> fieldData) {
+    protected FieldValueFetcher(String name, ValueType valueType, MappedFieldType fieldType, IndexFieldData<?> fieldData) {
         this.name = name;
+        this.valueType = valueType;
         this.fieldType = fieldType;
         this.format = fieldType.docValueFormat(null, null);
         this.fieldData = fieldData;
@@ -38,6 +39,10 @@ class FieldValueFetcher {
 
     public String name() {
         return name;
+    }
+
+    public ValueType valueType() {
+        return valueType;
     }
 
     public MappedFieldType fieldType() {
@@ -59,9 +64,9 @@ class FieldValueFetcher {
     /**
      * Retrieve field value fetchers for a list of fields.
      */
-    static Map<String, FieldValueFetcher> create(SearchExecutionContext context, String[] fields) {
-        Map<String, FieldValueFetcher> fetchers = new LinkedHashMap<>();
-        for (String field : fields) {
+    static FieldValueFetcher[] create(SearchExecutionContext context, String[] metricFields, String[] labelFields) {
+        List<FieldValueFetcher> fetchers = new ArrayList<>();
+        for (String field : metricFields) {
             MappedFieldType fieldType = context.getFieldType(field);
             assert fieldType != null : "Unknown field type for field: [" + field + "]";
 
@@ -71,24 +76,41 @@ class FieldValueFetcher {
                 for (NumberFieldMapper.NumberFieldType metricSubField : aggMetricFieldType.getMetricFields().values()) {
                     if (context.fieldExistsInIndex(metricSubField.name())) {
                         IndexFieldData<?> fieldData = context.getForField(metricSubField, MappedFieldType.FielddataOperation.SEARCH);
-                        fetchers.put(metricSubField.name(), new FieldValueFetcher(metricSubField.name(), fieldType, fieldData));
+                        fetchers.add(new FieldValueFetcher(metricSubField.name(), ValueType.METRIC, fieldType, fieldData));
                     }
                 }
             } else {
                 if (context.fieldExistsInIndex(field)) {
                     IndexFieldData<?> fieldData = context.getForField(fieldType, MappedFieldType.FielddataOperation.SEARCH);
-                    fetchers.put(field, new FieldValueFetcher(field, fieldType, fieldData));
+                    fetchers.add(new FieldValueFetcher(field, ValueType.METRIC, fieldType, fieldData));
                 }
             }
         }
-        return Collections.unmodifiableMap(fetchers);
+        for (String field : labelFields) {
+            MappedFieldType fieldType = context.getFieldType(field);
+            assert fieldType != null : "Unknown field type for field: [" + field + "]";
+            if (context.fieldExistsInIndex(field)) {
+                IndexFieldData<?> fieldData = context.getForField(fieldType, MappedFieldType.FielddataOperation.SEARCH);
+                fetchers.add(new FieldValueFetcher(field, ValueType.LABEL, fieldType, fieldData));
+            }
+        }
+        return fetchers.toArray(new FieldValueFetcher[0]);
     }
 
-    static Map<String, FormattedDocValues> docValuesFetchers(LeafReaderContext ctx, Map<String, FieldValueFetcher> fieldValueFetchers) {
-        final Map<String, FormattedDocValues> docValuesFetchers = new LinkedHashMap<>(fieldValueFetchers.size());
-        for (FieldValueFetcher fetcher : fieldValueFetchers.values()) {
-            docValuesFetchers.put(fetcher.name(), fetcher.getLeaf(ctx));
+    static DocValueFetcher[] docValuesFetchers(LeafReaderContext ctx, FieldValueFetcher[] fetchers) {
+        DocValueFetcher[] docValueFetchers = new DocValueFetcher[fetchers.length];
+        for (int i = 0; i < fetchers.length; i++) {
+            FieldValueFetcher fetcher = fetchers[i];
+            docValueFetchers[i] = new DocValueFetcher(fetcher.name(), fetcher.valueType(), fetcher.getLeaf(ctx));
         }
-        return Collections.unmodifiableMap(docValuesFetchers);
+        return docValueFetchers;
+    }
+
+    enum ValueType {
+        METRIC, LABEL
+    }
+
+    record DocValueFetcher(String name, ValueType valueType,
+                           FormattedDocValues formattedDocValues) {
     }
 }


### PR DESCRIPTION
In the collect method, it will iterate all fields for every doc, and for each field, it will call the map containsKey method.
I use an array to replace map, and add a ValueType in the FieldValueFetcher to avoid calling containsKey method.
In my benchmark,  when interval is large, the performance can improve 30%+.
Here is the Flame Graph:
![20220922-165735](https://user-images.githubusercontent.com/5070449/191877181-53a22923-2886-4755-9466-87df8b8e14fb.svg)
