### PR TITLE
Check object depth limit at parse time

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/mapper/DocumentParserContext.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/DocumentParserContext.java
@@ -228,7 +228,7 @@ public abstract class DocumentParserContext {
     public final void addDynamicMapper(Mapper mapper) {
         // eagerly check object depth limit here to avoid stack overflow errors
         if (mapper instanceof ObjectMapper) {
-            mappingLookup.checkObjectDepthLimit(indexSettings().getMappingDepthLimit(), mapper.name());
+            MappingLookup.checkObjectDepthLimit(indexSettings().getMappingDepthLimit(), mapper.name());
         }
         // eagerly check field name limit here to avoid OOM errors
         // only check fields that are not already mapped or tracked in order to avoid hitting field limit too early via double-counting

--- a/server/src/main/java/org/elasticsearch/index/mapper/DocumentParserContext.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/DocumentParserContext.java
@@ -226,6 +226,8 @@ public abstract class DocumentParserContext {
      * Add a new mapper dynamically created while parsing.
      */
     public final void addDynamicMapper(Mapper mapper) {
+        // eagerly check object depth limit here to avoid stack overflow errors
+        mappingLookup.checkObjectDepthLimit(indexSettings().getMappingDepthLimit(), mapper.name());
         // eagerly check field name limit here to avoid OOM errors
         // only check fields that are not already mapped or tracked in order to avoid hitting field limit too early via double-counting
         // note that existing fields can also receive dynamic mapping updates (e.g. constant_keyword to fix the value)

--- a/server/src/main/java/org/elasticsearch/index/mapper/DocumentParserContext.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/DocumentParserContext.java
@@ -227,7 +227,9 @@ public abstract class DocumentParserContext {
      */
     public final void addDynamicMapper(Mapper mapper) {
         // eagerly check object depth limit here to avoid stack overflow errors
-        mappingLookup.checkObjectDepthLimit(indexSettings().getMappingDepthLimit(), mapper.name());
+        if (mapper instanceof ObjectMapper) {
+            mappingLookup.checkObjectDepthLimit(indexSettings().getMappingDepthLimit(), mapper.name());
+        }
         // eagerly check field name limit here to avoid OOM errors
         // only check fields that are not already mapped or tracked in order to avoid hitting field limit too early via double-counting
         // note that existing fields can also receive dynamic mapping updates (e.g. constant_keyword to fix the value)

--- a/server/src/main/java/org/elasticsearch/index/mapper/MappingLookup.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/MappingLookup.java
@@ -294,18 +294,22 @@ public final class MappingLookup {
 
     private void checkObjectDepthLimit(long limit) {
         for (String objectPath : objectMappers.keySet()) {
-            int numDots = 0;
-            for (int i = 0; i < objectPath.length(); ++i) {
-                if (objectPath.charAt(i) == '.') {
-                    numDots += 1;
-                }
+            checkObjectDepthLimit(limit, objectPath);
+        }
+    }
+
+    void checkObjectDepthLimit(long limit, String objectPath) {
+        int numDots = 0;
+        for (int i = 0; i < objectPath.length(); ++i) {
+            if (objectPath.charAt(i) == '.') {
+                numDots += 1;
             }
-            final int depth = numDots + 2;
-            if (depth > limit) {
-                throw new IllegalArgumentException(
-                    "Limit of mapping depth [" + limit + "] has been exceeded due to object field [" + objectPath + "]"
-                );
-            }
+        }
+        final int depth = numDots + 2;
+        if (depth > limit) {
+            throw new IllegalArgumentException(
+                "Limit of mapping depth [" + limit + "] has been exceeded due to object field [" + objectPath + "]"
+            );
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/index/mapper/MappingLookup.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/MappingLookup.java
@@ -298,7 +298,7 @@ public final class MappingLookup {
         }
     }
 
-    void checkObjectDepthLimit(long limit, String objectPath) {
+    static void checkObjectDepthLimit(long limit, String objectPath) {
         int numDots = 0;
         for (int i = 0; i < objectPath.length(); ++i) {
             if (objectPath.charAt(i) == '.') {

--- a/server/src/test/java/org/elasticsearch/index/mapper/DocumentParserTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/DocumentParserTests.java
@@ -2423,6 +2423,16 @@ public class DocumentParserTests extends MapperServiceTestCase {
             }
         })));
         assertThat(mpe.getCause().getMessage(), containsString("Limit of mapping depth [20] has been exceeded due to object field"));
+
+        // check that multiple-dotted field name underneath an object mapper with subobjects=false does not trigger this
+        DocumentMapper docMapper2 = createMapperService(topMapping(b -> { b.field("subobjects", false); })).documentMapper();
+
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < depth; i++) {
+            sb.append("obj.");
+        }
+        sb.append("foo");
+        docMapper2.parse(source(b -> { b.field(sb.toString(), 10); }));
     }
 
     /**

--- a/server/src/test/java/org/elasticsearch/index/mapper/DocumentParserTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/DocumentParserTests.java
@@ -2407,6 +2407,24 @@ public class DocumentParserTests extends MapperServiceTestCase {
         assertArrayEquals(new long[] { 10, 10 }, longs2);
     }
 
+    public void testDeeplyNestedDocument() throws Exception {
+        int depth = 10000;
+
+        DocumentMapper docMapper = createMapperService(Settings.builder().put(getIndexSettings()).build(), mapping(b -> {}))
+            .documentMapper();
+        // hits the mapping object depth limit (defaults to 20)
+        MapperParsingException mpe = expectThrows(MapperParsingException.class, () -> docMapper.parse(source(b -> {
+            for (int i = 0; i < depth; i++) {
+                b.startObject("obj");
+            }
+            b.field("foo", 10);
+            for (int i = 0; i < depth; i++) {
+                b.endObject();
+            }
+        })));
+        assertThat(mpe.getCause().getMessage(), containsString("Limit of mapping depth [20] has been exceeded due to object field"));
+    }
+
     /**
      * Mapper plugin providing a mock metadata field mapper implementation that supports setting its value
      */


### PR DESCRIPTION
Helps avoiding stack overflow errors when the total field limit is set too high.

Relates #87926