### PR TITLE
Fixed: aggregate_metric_double multi values exception

### DIFF
--- a/docs/changelog/90290.yaml
+++ b/docs/changelog/90290.yaml
@@ -1,0 +1,5 @@
+pr: 90290
+summary: "Fixed: aggregate_metric_double multi values exception"
+area: Aggregations
+type: bug
+issues: []

--- a/x-pack/plugin/mapper-aggregate-metric/src/main/java/org/elasticsearch/xpack/aggregatemetric/mapper/AggregateDoubleMetricFieldMapper.java
+++ b/x-pack/plugin/mapper-aggregate-metric/src/main/java/org/elasticsearch/xpack/aggregatemetric/mapper/AggregateDoubleMetricFieldMapper.java
@@ -231,7 +231,7 @@ public class AggregateDoubleMetricFieldMapper extends FieldMapper {
                         false,
                         true,
                         indexCreatedVersion
-                    );
+                    ).allowMultipleValues(false);
                 }
                 NumberFieldMapper fieldMapper = builder.build(context);
                 metricMappers.put(m, fieldMapper);


### PR DESCRIPTION
I only add the allowMultipleValues call in the value_count metric, This will cause the multi values exception when there is no value_count metric.

I improve the tests to find this exception.