### PR TITLE
Fix another potential race in the file settings watcher

### DIFF
--- a/docs/changelog/90302.yaml
+++ b/docs/changelog/90302.yaml
@@ -1,0 +1,5 @@
+pr: 90302
+summary: Fix another potential race in the file settings watcher
+area: Infra/Core
+type: bug
+issues: []

--- a/docs/changelog/90302.yaml
+++ b/docs/changelog/90302.yaml
@@ -2,4 +2,4 @@ pr: 90302
 summary: Fix another potential race in the file settings watcher
 area: Infra/Core
 type: bug
-issues: []
+issues: [89500]

--- a/server/src/main/java/org/elasticsearch/reservedstate/service/FileSettingsService.java
+++ b/server/src/main/java/org/elasticsearch/reservedstate/service/FileSettingsService.java
@@ -341,6 +341,7 @@ public class FileSettingsService extends AbstractLifecycleComponent implements C
         logger.debug("stopping watcher ...");
         if (watching()) {
             try {
+                // make sure the watcher thread hits the processing latch correctly
                 cleanupWatchKeys();
                 fileUpdateState = null;
                 watchService.close();
@@ -350,6 +351,8 @@ public class FileSettingsService extends AbstractLifecycleComponent implements C
                 if (watcherThreadLatch != null) {
                     watcherThreadLatch.await();
                 }
+                // the watcher thread might have snuck in behind us and re-created the settings watch again
+                cleanupWatchKeys();
             } catch (IOException e) {
                 logger.warn("encountered exception while closing watch service", e);
             } catch (InterruptedException interruptedException) {


### PR DESCRIPTION
Fix race in the shutdown code of FileSettingsWatcher

Potential fix for https://github.com/elastic/elasticsearch/issues/89500