### PR TITLE
Add parameter object to Aggregator Test Case

### DIFF
--- a/modules/aggs-matrix-stats/src/test/java/org/elasticsearch/search/aggregations/matrix/stats/MatrixStatsAggregatorTests.java
+++ b/modules/aggs-matrix-stats/src/test/java/org/elasticsearch/search/aggregations/matrix/stats/MatrixStatsAggregatorTests.java
@@ -40,7 +40,7 @@ public class MatrixStatsAggregatorTests extends AggregatorTestCase {
                 MatrixStatsAggregationBuilder aggBuilder = new MatrixStatsAggregationBuilder("my_agg").fields(
                     Collections.singletonList("field")
                 );
-                InternalMatrixStats stats = searchAndReduce(new AggTestConfig(searcher, aggBuilder, ft));
+                InternalMatrixStats stats = searchAndReduce(new AggTestConfig<>(searcher, aggBuilder, ft));
                 assertNull(stats.getStats());
                 assertEquals(0L, stats.getDocCount());
             }
@@ -59,7 +59,7 @@ public class MatrixStatsAggregatorTests extends AggregatorTestCase {
                 MatrixStatsAggregationBuilder aggBuilder = new MatrixStatsAggregationBuilder("my_agg").fields(
                     Collections.singletonList("bogus")
                 );
-                InternalMatrixStats stats = searchAndReduce(new AggTestConfig(searcher, aggBuilder, ft));
+                InternalMatrixStats stats = searchAndReduce(new AggTestConfig<>(searcher, aggBuilder, ft));
                 assertNull(stats.getStats());
                 assertEquals(0L, stats.getDocCount());
             }
@@ -94,7 +94,7 @@ public class MatrixStatsAggregatorTests extends AggregatorTestCase {
                 MatrixStatsAggregationBuilder aggBuilder = new MatrixStatsAggregationBuilder("my_agg").fields(
                     Arrays.asList(fieldA, fieldB)
                 );
-                InternalMatrixStats stats = searchAndReduce(new AggTestConfig(searcher, aggBuilder, ftA, ftB));
+                InternalMatrixStats stats = searchAndReduce(new AggTestConfig<>(searcher, aggBuilder, ftA, ftB));
                 multiPassStats.assertNearlyEqual(stats);
                 assertTrue(MatrixAggregationInspectionHelper.hasValue(stats));
             }

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/DocCountProviderTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/DocCountProviderTests.java
@@ -84,6 +84,10 @@ public class DocCountProviderTests extends AggregatorTestCase {
         AggregationBuilder builder = new FilterAggregationBuilder("f", new MatchAllQueryBuilder());
         MappedFieldType fieldType = new NumberFieldMapper.NumberFieldType(NUMBER_FIELD, NumberFieldMapper.NumberType.LONG);
         MappedFieldType docCountFieldType = new DocCountFieldMapper.DocCountFieldType();
-        testCase(builder, query, indexer, verify, fieldType, docCountFieldType);
+        testCase(
+            new AggTestConfig<InternalFilter>(builder, indexer, verify, new MappedFieldType[] { fieldType, docCountFieldType }).withQuery(
+                query
+            )
+        );
     }
 }

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/DocCountProviderTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/DocCountProviderTests.java
@@ -84,6 +84,6 @@ public class DocCountProviderTests extends AggregatorTestCase {
         AggregationBuilder builder = new FilterAggregationBuilder("f", new MatchAllQueryBuilder());
         MappedFieldType fieldType = new NumberFieldMapper.NumberFieldType(NUMBER_FIELD, NumberFieldMapper.NumberType.LONG);
         MappedFieldType docCountFieldType = new DocCountFieldMapper.DocCountFieldType();
-        testCase(new AggTestConfig<>(builder, indexer, verify, fieldType, docCountFieldType).withQuery(query));
+        testCase(new AggTestConfig<>(builder, verify, fieldType, docCountFieldType).withQuery(query).withIndexBuilder(indexer));
     }
 }

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/DocCountProviderTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/DocCountProviderTests.java
@@ -84,10 +84,6 @@ public class DocCountProviderTests extends AggregatorTestCase {
         AggregationBuilder builder = new FilterAggregationBuilder("f", new MatchAllQueryBuilder());
         MappedFieldType fieldType = new NumberFieldMapper.NumberFieldType(NUMBER_FIELD, NumberFieldMapper.NumberType.LONG);
         MappedFieldType docCountFieldType = new DocCountFieldMapper.DocCountFieldType();
-        testCase(
-            new AggTestConfig<InternalFilter>(builder, indexer, verify, new MappedFieldType[] { fieldType, docCountFieldType }).withQuery(
-                query
-            )
-        );
+        testCase(new AggTestConfig<>(builder, indexer, verify, fieldType, docCountFieldType).withQuery(query));
     }
 }

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/GlobalAggregatorTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/GlobalAggregatorTests.java
@@ -65,9 +65,9 @@ public class GlobalAggregatorTests extends AggregatorTestCase {
         aggregationBuilder.subAggregation(new MinAggregationBuilder("in_global").field("number"));
         MappedFieldType fieldType = new NumberFieldMapper.NumberFieldType("number", NumberFieldMapper.NumberType.LONG);
 
-        testCase(new AggTestConfig<InternalGlobal>(aggregationBuilder, buildIndex, (InternalGlobal result) -> {
+        testCase(new AggTestConfig<InternalGlobal>(aggregationBuilder, buildIndex, result -> {
             Min min = result.getAggregations().get("in_global");
             verify.accept(result, min);
-        }, new MappedFieldType[] { fieldType }).withQuery(topLevelQuery));
+        }, fieldType).withQuery(topLevelQuery));
     }
 }

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/GlobalAggregatorTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/GlobalAggregatorTests.java
@@ -65,9 +65,9 @@ public class GlobalAggregatorTests extends AggregatorTestCase {
         aggregationBuilder.subAggregation(new MinAggregationBuilder("in_global").field("number"));
         MappedFieldType fieldType = new NumberFieldMapper.NumberFieldType("number", NumberFieldMapper.NumberType.LONG);
 
-        testCase(aggregationBuilder, topLevelQuery, buildIndex, (InternalGlobal result) -> {
+        testCase(new AggTestConfig<InternalGlobal>(aggregationBuilder, buildIndex, (InternalGlobal result) -> {
             Min min = result.getAggregations().get("in_global");
             verify.accept(result, min);
-        }, fieldType);
+        }, new MappedFieldType[] { fieldType }).withQuery(topLevelQuery));
     }
 }

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/GlobalAggregatorTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/GlobalAggregatorTests.java
@@ -65,9 +65,9 @@ public class GlobalAggregatorTests extends AggregatorTestCase {
         aggregationBuilder.subAggregation(new MinAggregationBuilder("in_global").field("number"));
         MappedFieldType fieldType = new NumberFieldMapper.NumberFieldType("number", NumberFieldMapper.NumberType.LONG);
 
-        testCase(new AggTestConfig<InternalGlobal>(aggregationBuilder, buildIndex, result -> {
+        testCase(new AggTestConfig<InternalGlobal>(aggregationBuilder, result -> {
             Min min = result.getAggregations().get("in_global");
             verify.accept(result, min);
-        }, fieldType).withQuery(topLevelQuery));
+        }, fieldType).withQuery(topLevelQuery).withIndexBuilder(buildIndex));
     }
 }

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/adjacency/AdjacencyMatrixAggregatorTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/adjacency/AdjacencyMatrixAggregatorTests.java
@@ -34,7 +34,7 @@ public class AdjacencyMatrixAggregatorTests extends AggregatorTestCase {
         AdjacencyMatrixAggregationBuilder tooBig = new AdjacencyMatrixAggregationBuilder("dummy", filters);
         IllegalArgumentException ex = expectThrows(
             IllegalArgumentException.class,
-            () -> testCase(new AggTestConfig<>(tooBig, iw -> {}, r -> {}))
+            () -> testCase(new AggTestConfig<>(tooBig,  r -> {}).withEmptyIndex())
         );
         assertThat(
             ex.getMessage(),
@@ -49,9 +49,8 @@ public class AdjacencyMatrixAggregatorTests extends AggregatorTestCase {
         testCase(
             new AggTestConfig<InternalAdjacencyMatrix>(
                 aggregationBuilder,
-                iw -> iw.addDocument(List.of()),
                 result -> assertThat(result.getBuckets(), equalTo(List.of()))
-            )
+            ).withIndexBuilder(iw -> iw.addDocument(List.of()))
         );
     }
 
@@ -60,7 +59,7 @@ public class AdjacencyMatrixAggregatorTests extends AggregatorTestCase {
             "dummy",
             Map.of("a", new MatchAllQueryBuilder(), "b", new MatchAllQueryBuilder())
         );
-        testCase(new AggTestConfig<InternalAdjacencyMatrix>(aggregationBuilder, iw -> iw.addDocument(List.of()), result -> {
+        testCase(new AggTestConfig<InternalAdjacencyMatrix>(aggregationBuilder, result -> {
             assertThat(result.getBuckets(), hasSize(3));
             InternalAdjacencyMatrix.InternalBucket a = result.getBucketByKey("a");
             InternalAdjacencyMatrix.InternalBucket b = result.getBucketByKey("b");
@@ -68,6 +67,6 @@ public class AdjacencyMatrixAggregatorTests extends AggregatorTestCase {
             assertThat(a.getDocCount(), equalTo(1L));
             assertThat(b.getDocCount(), equalTo(1L));
             assertThat(ab.getDocCount(), equalTo(1L));
-        }));
+        }).withIndexBuilder(iw -> iw.addDocument(List.of())));
     }
 }

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/composite/CompositeAggregatorTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/composite/CompositeAggregatorTests.java
@@ -762,8 +762,6 @@ public class CompositeAggregatorTests extends AggregatorTestCase {
         NestedAggregationBuilder builder = new NestedAggregationBuilder("nestedAggName", nestedPath);
         builder.subAggregation(new CompositeAggregationBuilder("compositeAggName", Collections.singletonList(terms)));
         // Without after
-        // Sub-Docs
-        // Root docs
         testCase(new AggTestConfig<InternalSingleBucketAggregation>(builder, iw -> {
             // Sub-Docs
             List<Iterable<IndexableField>> documents = new ArrayList<>();
@@ -818,8 +816,6 @@ public class CompositeAggregatorTests extends AggregatorTestCase {
                 createAfterKey("keyword", "Pens and Stuff")
             )
         );
-        // Sub-Docs
-        // Root docs
         testCase(new AggTestConfig<InternalSingleBucketAggregation>(builder, iw -> {
             // Sub-Docs
             List<Iterable<IndexableField>> documents = new ArrayList<>();

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/composite/CompositeAggregatorTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/composite/CompositeAggregatorTests.java
@@ -3335,7 +3335,7 @@ public class CompositeAggregatorTests extends AggregatorTestCase {
             try (IndexReader indexReader = DirectoryReader.open(directory)) {
                 IndexSearcher indexSearcher = new IndexSearcher(indexReader);
                 for (int i = 0; i < create.size(); i++) {
-                    verify.get(i).accept(searchAndReduce(new AggTestConfig(indexSearcher, query, create.get(i).get(), FIELD_TYPES)));
+                    verify.get(i).accept(searchAndReduce(new AggTestConfig<>(indexSearcher, query, create.get(i).get(), FIELD_TYPES)));
                 }
             }
         }

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/composite/CompositeAggregatorTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/composite/CompositeAggregatorTests.java
@@ -737,7 +737,7 @@ public class CompositeAggregatorTests extends AggregatorTestCase {
                 iw.addDocument(document);
                 id++;
             }
-        }, (InternalComposite result) -> {
+        }, result -> {
             assertEquals(3, result.getBuckets().size());
             assertEquals("{keyword=d}", result.afterKey().toString());
             assertEquals("{keyword=a}", result.getBuckets().get(0).getKeyAsString());
@@ -746,7 +746,7 @@ public class CompositeAggregatorTests extends AggregatorTestCase {
             assertEquals(2L, result.getBuckets().get(1).getDocCount());
             assertEquals("{keyword=d}", result.getBuckets().get(2).getKeyAsString());
             assertEquals(1L, result.getBuckets().get(2).getDocCount());
-        }, FIELD_TYPES).withQuery(new MatchAllDocsQuery()));
+        }, FIELD_TYPES));
     }
 
     /**
@@ -785,7 +785,7 @@ public class CompositeAggregatorTests extends AggregatorTestCase {
             sequenceIDFields.addFields(root);
             documents.add(root);
             iw.addDocuments(documents);
-        }, (InternalSingleBucketAggregation parent) -> {
+        }, parent -> {
             assertEquals(1, parent.getAggregations().asList().size());
             InternalComposite result = (InternalComposite) parent.getProperty("compositeAggName");
             assertEquals(3, result.getBuckets().size());
@@ -797,10 +797,9 @@ public class CompositeAggregatorTests extends AggregatorTestCase {
             assertEquals("{keyword=Stationary}", result.getBuckets().get(2).getKeyAsString());
             assertEquals(1L, result.getBuckets().get(2).getDocCount());
         },
-            new MappedFieldType[] {
-                new KeywordFieldMapper.KeywordFieldType(nestedPath + "." + leafNameField),
-                new NumberFieldMapper.NumberFieldType("price", NumberFieldMapper.NumberType.LONG) }
-        ).withQuery(new MatchAllDocsQuery()));
+            new KeywordFieldMapper.KeywordFieldType(nestedPath + "." + leafNameField),
+            new NumberFieldMapper.NumberFieldType("price", NumberFieldMapper.NumberType.LONG)
+        ));
     }
 
     /**
@@ -842,7 +841,7 @@ public class CompositeAggregatorTests extends AggregatorTestCase {
             sequenceIDFields.addFields(root);
             documents.add(root);
             iw.addDocuments(documents);
-        }, (InternalSingleBucketAggregation parent) -> {
+        }, parent -> {
             assertEquals(1, parent.getAggregations().asList().size());
             InternalComposite result = (InternalComposite) parent.getProperty("compositeAggName");
             assertEquals(1, result.getBuckets().size());
@@ -850,10 +849,9 @@ public class CompositeAggregatorTests extends AggregatorTestCase {
             assertEquals("{keyword=Stationary}", result.getBuckets().get(0).getKeyAsString());
             assertEquals(1L, result.getBuckets().get(0).getDocCount());
         },
-            new MappedFieldType[] {
-                new KeywordFieldMapper.KeywordFieldType(nestedPath + "." + leafNameField),
-                new NumberFieldMapper.NumberFieldType("price", NumberFieldMapper.NumberType.LONG) }
-        ).withQuery(new MatchAllDocsQuery()));
+            new KeywordFieldMapper.KeywordFieldType(nestedPath + "." + leafNameField),
+            new NumberFieldMapper.NumberFieldType("price", NumberFieldMapper.NumberType.LONG)
+        ));
     }
 
     public void testWithKeywordAndMissingBucket() throws Exception {

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/filter/FilterAggregatorTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/filter/FilterAggregatorTests.java
@@ -51,7 +51,7 @@ public class FilterAggregatorTests extends AggregatorTestCase {
         IndexSearcher indexSearcher = newSearcher(indexReader, true, true);
         QueryBuilder filter = QueryBuilders.termQuery("field", randomAlphaOfLength(5));
         FilterAggregationBuilder builder = new FilterAggregationBuilder("test", filter);
-        InternalFilter response = searchAndReduce(new AggTestConfig(indexSearcher, builder, fieldType));
+        InternalFilter response = searchAndReduce(new AggTestConfig<>(indexSearcher, builder, fieldType));
         assertEquals(response.getDocCount(), 0);
         assertFalse(AggregationInspectionHelper.hasValue(response));
         indexReader.close();
@@ -86,7 +86,7 @@ public class FilterAggregatorTests extends AggregatorTestCase {
             QueryBuilder filter = QueryBuilders.termQuery("field", Integer.toString(value));
             FilterAggregationBuilder builder = new FilterAggregationBuilder("test", filter);
 
-            final InternalFilter response = searchAndReduce(new AggTestConfig(indexSearcher, builder, fieldType));
+            final InternalFilter response = searchAndReduce(new AggTestConfig<>(indexSearcher, builder, fieldType));
             assertEquals(response.getDocCount(), (long) expectedBucketCount[value]);
             if (expectedBucketCount[value] > 0) {
                 assertTrue(AggregationInspectionHelper.hasValue(response));

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/filter/FiltersAggregatorTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/filter/FiltersAggregatorTests.java
@@ -120,7 +120,7 @@ public class FiltersAggregatorTests extends AggregatorTestCase {
         FiltersAggregationBuilder builder = new FiltersAggregationBuilder("test", filters);
         builder.otherBucketKey("other");
         InternalFilters response = searchAndReduce(
-            new AggTestConfig(indexSearcher, new MatchAllDocsQuery(), builder, new KeywordFieldType("field"))
+            new AggTestConfig<>(indexSearcher, new MatchAllDocsQuery(), builder, new KeywordFieldType("field"))
         );
         assertEquals(response.getBuckets().size(), numFilters);
         for (InternalFilters.InternalBucket filter : response.getBuckets()) {
@@ -218,7 +218,7 @@ public class FiltersAggregatorTests extends AggregatorTestCase {
         builder.otherBucket(true);
         builder.otherBucketKey("other");
         final InternalFilters filters = searchAndReduce(
-            new AggTestConfig(indexSearcher, new MatchAllDocsQuery(), builder, new KeywordFieldType("field"))
+            new AggTestConfig<>(indexSearcher, new MatchAllDocsQuery(), builder, new KeywordFieldType("field"))
         );
         assertEquals(filters.getBuckets().size(), 7);
         assertEquals(filters.getBucketByKey("foobar").getDocCount(), 2);
@@ -275,7 +275,7 @@ public class FiltersAggregatorTests extends AggregatorTestCase {
             builder.otherBucketKey("other");
 
             final InternalFilters response = searchAndReduce(
-                new AggTestConfig(indexSearcher, new MatchAllDocsQuery(), builder, new KeywordFieldType("field"))
+                new AggTestConfig<>(indexSearcher, new MatchAllDocsQuery(), builder, new KeywordFieldType("field"))
             );
             List<InternalFilters.InternalBucket> buckets = response.getBuckets();
             assertEquals(buckets.size(), filters.length + 1);

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/histogram/AutoDateHistogramAggregatorTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/histogram/AutoDateHistogramAggregatorTests.java
@@ -409,19 +409,25 @@ public class AutoDateHistogramAggregatorTests extends DateHistogramAggregatorTes
 
         final DateFieldMapper.DateFieldType fieldType = new DateFieldMapper.DateFieldType("date_field");
 
-        testCase(new AggTestConfig<InternalAutoDateHistogram>(aggregation, iw -> {}, histogram -> {
+        testCase(new AggTestConfig<InternalAutoDateHistogram>(aggregation, histogram -> {
             assertEquals(0, histogram.getBuckets().size());
             assertFalse(AggregationInspectionHelper.hasValue(histogram));
-        }, fieldType));
+        }, fieldType).withEmptyIndex());
     }
 
     public void testBooleanFieldDeprecated() throws IOException {
         final String fieldName = "bogusBoolean";
-        testCase(new AggTestConfig<>(new AutoDateHistogramAggregationBuilder("name").field(fieldName), iw -> {
-            Document d = new Document();
-            d.add(new SortedNumericDocValuesField(fieldName, 0));
-            iw.addDocument(d);
-        }, a -> {}, new BooleanFieldMapper.BooleanFieldType(fieldName)));
+        testCase(
+            new AggTestConfig<>(
+                new AutoDateHistogramAggregationBuilder("name").field(fieldName),
+                a -> {},
+                new BooleanFieldMapper.BooleanFieldType(fieldName)
+            ).withIndexBuilder(iw -> {
+                Document d = new Document();
+                d.add(new SortedNumericDocValuesField(fieldName, 0));
+                iw.addDocument(d);
+            })
+        );
         assertWarnings("Running AutoIntervalDateHistogram aggregations on [boolean] fields is deprecated");
     }
 

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/histogram/AutoDateHistogramAggregatorTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/histogram/AutoDateHistogramAggregatorTests.java
@@ -942,7 +942,7 @@ public class AutoDateHistogramAggregatorTests extends DateHistogramAggregatorTes
                 MappedFieldType numericFieldType = new NumberFieldMapper.NumberFieldType(NUMERIC_FIELD, NumberFieldMapper.NumberType.LONG);
 
                 final InternalAutoDateHistogram histogram = searchAndReduce(
-                    new AggTestConfig(indexSearcher, query, aggregationBuilder, fieldType, instantFieldType, numericFieldType)
+                    new AggTestConfig<>(indexSearcher, query, aggregationBuilder, fieldType, instantFieldType, numericFieldType)
                 );
                 verify.accept(histogram);
             }

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/histogram/AutoDateHistogramAggregatorTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/histogram/AutoDateHistogramAggregatorTests.java
@@ -37,7 +37,6 @@ import org.elasticsearch.index.mapper.NumberFieldMapper;
 import org.elasticsearch.search.aggregations.Aggregation;
 import org.elasticsearch.search.aggregations.AggregationBuilder;
 import org.elasticsearch.search.aggregations.AggregationBuilders;
-import org.elasticsearch.search.aggregations.InternalAggregation;
 import org.elasticsearch.search.aggregations.MultiBucketConsumerService;
 import org.elasticsearch.search.aggregations.bucket.terms.StringTerms;
 import org.elasticsearch.search.aggregations.bucket.terms.TermsAggregationBuilder;
@@ -410,19 +409,19 @@ public class AutoDateHistogramAggregatorTests extends DateHistogramAggregatorTes
 
         final DateFieldMapper.DateFieldType fieldType = new DateFieldMapper.DateFieldType("date_field");
 
-        testCase(new AggTestConfig<InternalAutoDateHistogram>(aggregation, iw -> {}, (Consumer<InternalAutoDateHistogram>) histogram -> {
+        testCase(new AggTestConfig<InternalAutoDateHistogram>(aggregation, iw -> {}, histogram -> {
             assertEquals(0, histogram.getBuckets().size());
             assertFalse(AggregationInspectionHelper.hasValue(histogram));
-        }, new MappedFieldType[] { fieldType }).withQuery(DEFAULT_QUERY));
+        }, fieldType));
     }
 
     public void testBooleanFieldDeprecated() throws IOException {
         final String fieldName = "bogusBoolean";
-        testCase(new AggTestConfig<InternalAggregation>(new AutoDateHistogramAggregationBuilder("name").field(fieldName), iw -> {
+        testCase(new AggTestConfig<>(new AutoDateHistogramAggregationBuilder("name").field(fieldName), iw -> {
             Document d = new Document();
             d.add(new SortedNumericDocValuesField(fieldName, 0));
             iw.addDocument(d);
-        }, a -> {}, new BooleanFieldMapper.BooleanFieldType(fieldName)).withQuery(new MatchAllDocsQuery()));
+        }, a -> {}, new BooleanFieldMapper.BooleanFieldType(fieldName)));
         assertWarnings("Running AutoIntervalDateHistogram aggregations on [boolean] fields is deprecated");
     }
 
@@ -433,7 +432,7 @@ public class AutoDateHistogramAggregatorTests extends DateHistogramAggregatorTes
 
         final DateFieldMapper.DateFieldType fieldType = new DateFieldMapper.DateFieldType("date_field");
 
-        testCase(new AggTestConfig<InternalAutoDateHistogram>(aggregation, iw -> {}, (Consumer<InternalAutoDateHistogram>) histogram -> {
+        testCase(new AggTestConfig<InternalAutoDateHistogram>(aggregation, iw -> {}, histogram -> {
             assertEquals(0, histogram.getBuckets().size());
             assertFalse(AggregationInspectionHelper.hasValue(histogram));
         }, new MappedFieldType[] { fieldType }).withQuery(DEFAULT_QUERY));

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/histogram/AutoDateHistogramAggregatorTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/histogram/AutoDateHistogramAggregatorTests.java
@@ -435,7 +435,7 @@ public class AutoDateHistogramAggregatorTests extends DateHistogramAggregatorTes
         testCase(new AggTestConfig<InternalAutoDateHistogram>(aggregation, iw -> {}, histogram -> {
             assertEquals(0, histogram.getBuckets().size());
             assertFalse(AggregationInspectionHelper.hasValue(histogram));
-        }, new MappedFieldType[] { fieldType }).withQuery(DEFAULT_QUERY));
+        }, fieldType));
     }
 
     public void testIntervalYear() throws IOException {

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/histogram/AutoDateHistogramAggregatorTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/histogram/AutoDateHistogramAggregatorTests.java
@@ -37,6 +37,7 @@ import org.elasticsearch.index.mapper.NumberFieldMapper;
 import org.elasticsearch.search.aggregations.Aggregation;
 import org.elasticsearch.search.aggregations.AggregationBuilder;
 import org.elasticsearch.search.aggregations.AggregationBuilders;
+import org.elasticsearch.search.aggregations.InternalAggregation;
 import org.elasticsearch.search.aggregations.MultiBucketConsumerService;
 import org.elasticsearch.search.aggregations.bucket.terms.StringTerms;
 import org.elasticsearch.search.aggregations.bucket.terms.TermsAggregationBuilder;
@@ -409,19 +410,19 @@ public class AutoDateHistogramAggregatorTests extends DateHistogramAggregatorTes
 
         final DateFieldMapper.DateFieldType fieldType = new DateFieldMapper.DateFieldType("date_field");
 
-        testCase(aggregation, DEFAULT_QUERY, iw -> {}, (Consumer<InternalAutoDateHistogram>) histogram -> {
+        testCase(new AggTestConfig<InternalAutoDateHistogram>(aggregation, iw -> {}, (Consumer<InternalAutoDateHistogram>) histogram -> {
             assertEquals(0, histogram.getBuckets().size());
             assertFalse(AggregationInspectionHelper.hasValue(histogram));
-        }, fieldType);
+        }, new MappedFieldType[] { fieldType }).withQuery(DEFAULT_QUERY));
     }
 
     public void testBooleanFieldDeprecated() throws IOException {
         final String fieldName = "bogusBoolean";
-        testCase(new AutoDateHistogramAggregationBuilder("name").field(fieldName), new MatchAllDocsQuery(), iw -> {
+        testCase(new AggTestConfig<InternalAggregation>(new AutoDateHistogramAggregationBuilder("name").field(fieldName), iw -> {
             Document d = new Document();
             d.add(new SortedNumericDocValuesField(fieldName, 0));
             iw.addDocument(d);
-        }, a -> {}, new BooleanFieldMapper.BooleanFieldType(fieldName));
+        }, a -> {}, new BooleanFieldMapper.BooleanFieldType(fieldName)).withQuery(new MatchAllDocsQuery()));
         assertWarnings("Running AutoIntervalDateHistogram aggregations on [boolean] fields is deprecated");
     }
 
@@ -432,10 +433,10 @@ public class AutoDateHistogramAggregatorTests extends DateHistogramAggregatorTes
 
         final DateFieldMapper.DateFieldType fieldType = new DateFieldMapper.DateFieldType("date_field");
 
-        testCase(aggregation, DEFAULT_QUERY, iw -> {}, (Consumer<InternalAutoDateHistogram>) histogram -> {
+        testCase(new AggTestConfig<InternalAutoDateHistogram>(aggregation, iw -> {}, (Consumer<InternalAutoDateHistogram>) histogram -> {
             assertEquals(0, histogram.getBuckets().size());
             assertFalse(AggregationInspectionHelper.hasValue(histogram));
-        }, fieldType);
+        }, new MappedFieldType[] { fieldType }).withQuery(DEFAULT_QUERY));
     }
 
     public void testIntervalYear() throws IOException {

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/histogram/DateHistogramAggregatorTestCase.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/histogram/DateHistogramAggregatorTestCase.java
@@ -18,6 +18,7 @@ import org.elasticsearch.common.CheckedBiConsumer;
 import org.elasticsearch.common.time.DateFormatter;
 import org.elasticsearch.index.mapper.DateFieldMapper;
 import org.elasticsearch.index.mapper.KeywordFieldMapper;
+import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.mapper.NumberFieldMapper;
 import org.elasticsearch.index.mapper.NumberFieldMapper.NumberType;
 import org.elasticsearch.search.aggregations.AggregationBuilder;
@@ -104,7 +105,10 @@ public abstract class DateHistogramAggregatorTestCase extends AggregatorTestCase
         KeywordFieldMapper.KeywordFieldType k2ft = new KeywordFieldMapper.KeywordFieldType("k2");
         NumberFieldMapper.NumberFieldType nft = new NumberFieldMapper.NumberFieldType("n", NumberType.LONG);
         DateFieldMapper.DateFieldType dft = aggregableDateFieldType(false, randomBoolean());
-        testCase(builder, new MatchAllDocsQuery(), iw -> buildIndex.accept(iw, dft), verify, k1ft, k2ft, nft, dft);
+        testCase(
+            new AggTestConfig<R>(builder, iw -> buildIndex.accept(iw, dft), verify, new MappedFieldType[] { k1ft, k2ft, nft, dft })
+                .withQuery(new MatchAllDocsQuery())
+        );
     }
 
     protected final DateFieldMapper.DateFieldType aggregableDateFieldType(boolean useNanosecondResolution, boolean isSearchable) {

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/histogram/DateHistogramAggregatorTestCase.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/histogram/DateHistogramAggregatorTestCase.java
@@ -11,14 +11,12 @@ package org.elasticsearch.search.aggregations.bucket.histogram;
 import org.apache.lucene.document.Field;
 import org.apache.lucene.document.SortedNumericDocValuesField;
 import org.apache.lucene.document.SortedSetDocValuesField;
-import org.apache.lucene.search.MatchAllDocsQuery;
 import org.apache.lucene.tests.index.RandomIndexWriter;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.CheckedBiConsumer;
 import org.elasticsearch.common.time.DateFormatter;
 import org.elasticsearch.index.mapper.DateFieldMapper;
 import org.elasticsearch.index.mapper.KeywordFieldMapper;
-import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.mapper.NumberFieldMapper;
 import org.elasticsearch.index.mapper.NumberFieldMapper.NumberType;
 import org.elasticsearch.search.aggregations.AggregationBuilder;
@@ -105,10 +103,7 @@ public abstract class DateHistogramAggregatorTestCase extends AggregatorTestCase
         KeywordFieldMapper.KeywordFieldType k2ft = new KeywordFieldMapper.KeywordFieldType("k2");
         NumberFieldMapper.NumberFieldType nft = new NumberFieldMapper.NumberFieldType("n", NumberType.LONG);
         DateFieldMapper.DateFieldType dft = aggregableDateFieldType(false, randomBoolean());
-        testCase(
-            new AggTestConfig<R>(builder, iw -> buildIndex.accept(iw, dft), verify, new MappedFieldType[] { k1ft, k2ft, nft, dft })
-                .withQuery(new MatchAllDocsQuery())
-        );
+        testCase(new AggTestConfig<R>(builder, iw -> buildIndex.accept(iw, dft), verify, k1ft, k2ft, nft, dft));
     }
 
     protected final DateFieldMapper.DateFieldType aggregableDateFieldType(boolean useNanosecondResolution, boolean isSearchable) {

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/histogram/DateHistogramAggregatorTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/histogram/DateHistogramAggregatorTests.java
@@ -33,7 +33,6 @@ import org.elasticsearch.search.aggregations.AggregationBuilder;
 import org.elasticsearch.search.aggregations.AggregationReduceContext;
 import org.elasticsearch.search.aggregations.Aggregator;
 import org.elasticsearch.search.aggregations.BucketOrder;
-import org.elasticsearch.search.aggregations.InternalAggregation;
 import org.elasticsearch.search.aggregations.bucket.range.RangeAggregator;
 import org.elasticsearch.search.aggregations.bucket.terms.StringTerms;
 import org.elasticsearch.search.aggregations.bucket.terms.TermsAggregationBuilder;
@@ -83,7 +82,7 @@ public class DateHistogramAggregatorTests extends DateHistogramAggregatorTestCas
     public void testBooleanFieldDeprecated() throws IOException {
         final String fieldName = "bogusBoolean";
         testCase(
-            new AggTestConfig<InternalAggregation>(
+            new AggTestConfig<>(
                 new DateHistogramAggregationBuilder("name").calendarInterval(DateHistogramInterval.HOUR).field(fieldName),
                 iw -> {
                     Document d = new Document();

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/histogram/DateHistogramAggregatorTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/histogram/DateHistogramAggregatorTests.java
@@ -1135,27 +1135,14 @@ public class DateHistogramAggregatorTests extends DateHistogramAggregatorTestCas
         Consumer<InternalDateHistogram> verify,
         boolean useNanosecondResolution
     ) throws IOException {
-        testSearchCase(query, dataset, configure, verify, 10000, useNanosecondResolution);
-    }
-
-    private void testSearchCase(
-        Query query,
-        List<String> dataset,
-        Consumer<DateHistogramAggregationBuilder> configure,
-        Consumer<InternalDateHistogram> verify,
-        int maxBucket,
-        boolean useNanosecondResolution
-    ) throws IOException {
         boolean aggregableDateIsSearchable = randomBoolean();
         DateFieldMapper.DateFieldType fieldType = aggregableDateFieldType(useNanosecondResolution, aggregableDateIsSearchable);
         DateHistogramAggregationBuilder aggregationBuilder = new DateHistogramAggregationBuilder("_name");
         if (configure != null) {
             configure.accept(aggregationBuilder);
         }
-
         testCase(
             new AggTestConfig<>(aggregationBuilder, iw -> indexDates(iw, dataset, aggregableDateIsSearchable, fieldType), verify, fieldType)
-                .withMaxBuckets(maxBucket)
                 .withQuery(query)
         );
     }

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/histogram/DateHistogramAggregatorTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/histogram/DateHistogramAggregatorTests.java
@@ -33,6 +33,7 @@ import org.elasticsearch.search.aggregations.AggregationBuilder;
 import org.elasticsearch.search.aggregations.AggregationReduceContext;
 import org.elasticsearch.search.aggregations.Aggregator;
 import org.elasticsearch.search.aggregations.BucketOrder;
+import org.elasticsearch.search.aggregations.InternalAggregation;
 import org.elasticsearch.search.aggregations.bucket.range.RangeAggregator;
 import org.elasticsearch.search.aggregations.bucket.terms.StringTerms;
 import org.elasticsearch.search.aggregations.bucket.terms.TermsAggregationBuilder;
@@ -82,15 +83,16 @@ public class DateHistogramAggregatorTests extends DateHistogramAggregatorTestCas
     public void testBooleanFieldDeprecated() throws IOException {
         final String fieldName = "bogusBoolean";
         testCase(
-            new DateHistogramAggregationBuilder("name").calendarInterval(DateHistogramInterval.HOUR).field(fieldName),
-            new MatchAllDocsQuery(),
-            iw -> {
-                Document d = new Document();
-                d.add(new SortedNumericDocValuesField(fieldName, 0));
-                iw.addDocument(d);
-            },
-            a -> {},
-            new BooleanFieldMapper.BooleanFieldType(fieldName)
+            new AggTestConfig<InternalAggregation>(
+                new DateHistogramAggregationBuilder("name").calendarInterval(DateHistogramInterval.HOUR).field(fieldName),
+                iw -> {
+                    Document d = new Document();
+                    d.add(new SortedNumericDocValuesField(fieldName, 0));
+                    iw.addDocument(d);
+                },
+                a -> {},
+                new BooleanFieldMapper.BooleanFieldType(fieldName)
+            ).withQuery(new MatchAllDocsQuery())
         );
         assertWarnings("Running DateHistogram aggregations on [boolean] fields is deprecated");
     }

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/histogram/DateHistogramAggregatorTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/histogram/DateHistogramAggregatorTests.java
@@ -91,7 +91,7 @@ public class DateHistogramAggregatorTests extends DateHistogramAggregatorTestCas
                 },
                 a -> {},
                 new BooleanFieldMapper.BooleanFieldType(fieldName)
-            ).withQuery(new MatchAllDocsQuery())
+            )
         );
         assertWarnings("Running DateHistogram aggregations on [boolean] fields is deprecated");
     }

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/histogram/DateRangeHistogramAggregatorTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/histogram/DateRangeHistogramAggregatorTests.java
@@ -1084,7 +1084,7 @@ public class DateRangeHistogramAggregatorTests extends AggregatorTestCase {
             try (IndexReader indexReader = DirectoryReader.open(directory)) {
                 IndexSearcher indexSearcher = newSearcher(indexReader, true, true);
 
-                InternalDateHistogram histogram = searchAndReduce(new AggTestConfig(indexSearcher, query, aggregationBuilder, fieldType));
+                InternalDateHistogram histogram = searchAndReduce(new AggTestConfig<>(indexSearcher, query, aggregationBuilder, fieldType));
                 verify.accept(histogram);
             }
         }

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/histogram/NumericHistogramAggregatorTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/histogram/NumericHistogramAggregatorTests.java
@@ -441,6 +441,13 @@ public class NumericHistogramAggregatorTests extends AggregatorTestCase {
                 }
             }
         };
-        testCase(request, new MatchAllDocsQuery(), buildIndex, verify, longField("outer"), longField("inner"), longField("n"));
+        testCase(
+            new AggTestConfig<InternalHistogram>(
+                request,
+                buildIndex,
+                verify,
+                new MappedFieldType[] { longField("outer"), longField("inner"), longField("n") }
+            ).withQuery(new MatchAllDocsQuery())
+        );
     }
 }

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/histogram/NumericHistogramAggregatorTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/histogram/NumericHistogramAggregatorTests.java
@@ -52,7 +52,7 @@ public class NumericHistogramAggregatorTests extends AggregatorTestCase {
             HistogramAggregationBuilder aggBuilder = new HistogramAggregationBuilder("my_agg").field("field").interval(5);
             try (IndexReader reader = w.getReader()) {
                 IndexSearcher searcher = new IndexSearcher(reader);
-                InternalHistogram histogram = searchAndReduce(new AggTestConfig(searcher, aggBuilder, longField("field")));
+                InternalHistogram histogram = searchAndReduce(new AggTestConfig<>(searcher, aggBuilder, longField("field")));
                 assertEquals(6, histogram.getBuckets().size());
                 assertEquals(-10d, histogram.getBuckets().get(0).getKey());
                 assertEquals(2, histogram.getBuckets().get(0).getDocCount());
@@ -82,7 +82,7 @@ public class NumericHistogramAggregatorTests extends AggregatorTestCase {
             HistogramAggregationBuilder aggBuilder = new HistogramAggregationBuilder("my_agg").field("field").interval(5);
             try (IndexReader reader = w.getReader()) {
                 IndexSearcher searcher = new IndexSearcher(reader);
-                InternalHistogram histogram = searchAndReduce(new AggTestConfig(searcher, aggBuilder, doubleField("field")));
+                InternalHistogram histogram = searchAndReduce(new AggTestConfig<>(searcher, aggBuilder, doubleField("field")));
                 assertEquals(6, histogram.getBuckets().size());
                 assertEquals(6, histogram.getBuckets().size());
                 assertEquals(-10d, histogram.getBuckets().get(0).getKey());
@@ -132,7 +132,7 @@ public class NumericHistogramAggregatorTests extends AggregatorTestCase {
                 .interval(1000 * 60 * 60 * 24);
             try (IndexReader reader = indexWriter.getReader()) {
                 IndexSearcher searcher = new IndexSearcher(reader);
-                InternalHistogram histogram = searchAndReduce(new AggTestConfig(searcher, aggBuilder, fieldType));
+                InternalHistogram histogram = searchAndReduce(new AggTestConfig<>(searcher, aggBuilder, fieldType));
                 assertTrue(AggregationInspectionHelper.hasValue(histogram));
             }
         }
@@ -149,7 +149,7 @@ public class NumericHistogramAggregatorTests extends AggregatorTestCase {
             HistogramAggregationBuilder aggBuilder = new HistogramAggregationBuilder("my_agg").field("field").interval(Math.PI);
             try (IndexReader reader = w.getReader()) {
                 IndexSearcher searcher = new IndexSearcher(reader);
-                InternalHistogram histogram = searchAndReduce(new AggTestConfig(searcher, aggBuilder, longField("field")));
+                InternalHistogram histogram = searchAndReduce(new AggTestConfig<>(searcher, aggBuilder, longField("field")));
                 assertEquals(6, histogram.getBuckets().size());
                 assertEquals(-4 * Math.PI, histogram.getBuckets().get(0).getKey());
                 assertEquals(1, histogram.getBuckets().get(0).getDocCount());
@@ -179,7 +179,7 @@ public class NumericHistogramAggregatorTests extends AggregatorTestCase {
             HistogramAggregationBuilder aggBuilder = new HistogramAggregationBuilder("my_agg").field("field").interval(10).minDocCount(2);
             try (IndexReader reader = w.getReader()) {
                 IndexSearcher searcher = new IndexSearcher(reader);
-                InternalHistogram histogram = searchAndReduce(new AggTestConfig(searcher, aggBuilder, longField("field")));
+                InternalHistogram histogram = searchAndReduce(new AggTestConfig<>(searcher, aggBuilder, longField("field")));
                 assertEquals(2, histogram.getBuckets().size());
                 assertEquals(-10d, histogram.getBuckets().get(0).getKey());
                 assertEquals(2, histogram.getBuckets().get(0).getDocCount());
@@ -202,7 +202,7 @@ public class NumericHistogramAggregatorTests extends AggregatorTestCase {
             HistogramAggregationBuilder aggBuilder = new HistogramAggregationBuilder("my_agg").field("field").interval(5).missing(2d);
             try (IndexReader reader = w.getReader()) {
                 IndexSearcher searcher = new IndexSearcher(reader);
-                InternalHistogram histogram = searchAndReduce(new AggTestConfig(searcher, aggBuilder, longField("field")));
+                InternalHistogram histogram = searchAndReduce(new AggTestConfig<>(searcher, aggBuilder, longField("field")));
                 assertEquals(6, histogram.getBuckets().size());
                 assertEquals(-10d, histogram.getBuckets().get(0).getKey());
                 assertEquals(2, histogram.getBuckets().get(0).getDocCount());
@@ -231,7 +231,7 @@ public class NumericHistogramAggregatorTests extends AggregatorTestCase {
             HistogramAggregationBuilder aggBuilder = new HistogramAggregationBuilder("my_agg").field("field").interval(5).missing(2d);
             try (IndexReader reader = w.getReader()) {
                 IndexSearcher searcher = new IndexSearcher(reader);
-                InternalHistogram histogram = searchAndReduce(new AggTestConfig(searcher, aggBuilder));
+                InternalHistogram histogram = searchAndReduce(new AggTestConfig<>(searcher, aggBuilder));
 
                 assertEquals(1, histogram.getBuckets().size());
 
@@ -257,7 +257,7 @@ public class NumericHistogramAggregatorTests extends AggregatorTestCase {
                 IndexSearcher searcher = new IndexSearcher(reader);
                 Throwable t = expectThrows(
                     IllegalArgumentException.class,
-                    () -> { searchAndReduce(new AggTestConfig(searcher, aggBuilder)); }
+                    () -> { searchAndReduce(new AggTestConfig<>(searcher, aggBuilder)); }
                 );
                 // This throws a number format exception (which is a subclass of IllegalArgumentException) and might be ok?
                 assertThat(t.getMessage(), containsString(missingValue));
@@ -279,7 +279,7 @@ public class NumericHistogramAggregatorTests extends AggregatorTestCase {
 
                 expectThrows(
                     IllegalArgumentException.class,
-                    () -> { searchAndReduce(new AggTestConfig(searcher, aggBuilder, keywordField("field"))); }
+                    () -> { searchAndReduce(new AggTestConfig<>(searcher, aggBuilder, keywordField("field"))); }
                 );
             }
         }
@@ -297,7 +297,7 @@ public class NumericHistogramAggregatorTests extends AggregatorTestCase {
             HistogramAggregationBuilder aggBuilder = new HistogramAggregationBuilder("my_agg").field("field").interval(5).offset(Math.PI);
             try (IndexReader reader = w.getReader()) {
                 IndexSearcher searcher = new IndexSearcher(reader);
-                InternalHistogram histogram = searchAndReduce(new AggTestConfig(searcher, aggBuilder, doubleField("field")));
+                InternalHistogram histogram = searchAndReduce(new AggTestConfig<>(searcher, aggBuilder, doubleField("field")));
                 assertEquals(4, histogram.getBuckets().size());
                 assertEquals(-10 + Math.PI, histogram.getBuckets().get(0).getKey());
                 assertEquals(2, histogram.getBuckets().get(0).getDocCount());
@@ -329,7 +329,7 @@ public class NumericHistogramAggregatorTests extends AggregatorTestCase {
                 .offset(offset);
             try (IndexReader reader = w.getReader()) {
                 IndexSearcher searcher = new IndexSearcher(reader);
-                InternalHistogram histogram = searchAndReduce(new AggTestConfig(searcher, aggBuilder, doubleField("field")));
+                InternalHistogram histogram = searchAndReduce(new AggTestConfig<>(searcher, aggBuilder, doubleField("field")));
                 assertEquals(4, histogram.getBuckets().size());
 
                 assertEquals(-10 + expectedOffset, histogram.getBuckets().get(0).getKey());
@@ -363,7 +363,7 @@ public class NumericHistogramAggregatorTests extends AggregatorTestCase {
             MappedFieldType fieldType = new NumberFieldMapper.NumberFieldType("field", NumberFieldMapper.NumberType.DOUBLE);
             try (IndexReader reader = w.getReader()) {
                 IndexSearcher searcher = new IndexSearcher(reader);
-                InternalHistogram histogram = searchAndReduce(new AggTestConfig(searcher, aggBuilder, doubleField("field")));
+                InternalHistogram histogram = searchAndReduce(new AggTestConfig<>(searcher, aggBuilder, doubleField("field")));
                 assertEquals(6, histogram.getBuckets().size());
                 assertEquals(-15d, histogram.getBuckets().get(0).getKey());
                 assertEquals(0, histogram.getBuckets().get(0).getDocCount());
@@ -396,7 +396,7 @@ public class NumericHistogramAggregatorTests extends AggregatorTestCase {
             MappedFieldType fieldType = new NumberFieldMapper.NumberFieldType("field", NumberFieldMapper.NumberType.DOUBLE);
             try (IndexReader reader = w.getReader()) {
                 IndexSearcher searcher = new IndexSearcher(reader);
-                InternalHistogram histogram = searchAndReduce(new AggTestConfig(searcher, aggBuilder, fieldType));
+                InternalHistogram histogram = searchAndReduce(new AggTestConfig<>(searcher, aggBuilder, fieldType));
                 assertEquals(1, histogram.getBuckets().size());
                 assertEquals(0d, histogram.getBuckets().get(0).getKey());
                 assertEquals(2, histogram.getBuckets().get(0).getDocCount());

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/histogram/NumericHistogramAggregatorTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/histogram/NumericHistogramAggregatorTests.java
@@ -14,7 +14,6 @@ import org.apache.lucene.document.SortedSetDocValuesField;
 import org.apache.lucene.index.IndexReader;
 import org.apache.lucene.index.IndexableField;
 import org.apache.lucene.search.IndexSearcher;
-import org.apache.lucene.search.MatchAllDocsQuery;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.tests.index.RandomIndexWriter;
 import org.apache.lucene.util.BytesRef;
@@ -441,13 +440,6 @@ public class NumericHistogramAggregatorTests extends AggregatorTestCase {
                 }
             }
         };
-        testCase(
-            new AggTestConfig<InternalHistogram>(
-                request,
-                buildIndex,
-                verify,
-                new MappedFieldType[] { longField("outer"), longField("inner"), longField("n") }
-            ).withQuery(new MatchAllDocsQuery())
-        );
+        testCase(new AggTestConfig<>(request, buildIndex, verify, longField("outer"), longField("inner"), longField("n")));
     }
 }

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/histogram/RangeHistogramAggregatorTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/histogram/RangeHistogramAggregatorTests.java
@@ -20,6 +20,7 @@ import org.apache.lucene.tests.index.RandomIndexWriter;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.network.InetAddresses;
 import org.elasticsearch.core.CheckedConsumer;
+import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.mapper.RangeFieldMapper;
 import org.elasticsearch.index.mapper.RangeType;
 import org.elasticsearch.search.aggregations.AggregationBuilder;
@@ -465,13 +466,12 @@ public class RangeHistogramAggregatorTests extends AggregatorTestCase {
             }
         };
         testCase(
-            request,
-            new MatchAllDocsQuery(),
-            buildIndex,
-            verify,
-            rangeField("outer", RangeType.LONG),
-            rangeField("inner", RangeType.LONG),
-            longField("n")
+            new AggTestConfig<InternalHistogram>(
+                request,
+                buildIndex,
+                verify,
+                new MappedFieldType[] { rangeField("outer", RangeType.LONG), rangeField("inner", RangeType.LONG), longField("n") }
+            ).withQuery(new MatchAllDocsQuery())
         );
     }
 }

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/histogram/RangeHistogramAggregatorTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/histogram/RangeHistogramAggregatorTests.java
@@ -57,7 +57,7 @@ public class RangeHistogramAggregatorTests extends AggregatorTestCase {
 
             try (IndexReader reader = w.getReader()) {
                 IndexSearcher searcher = new IndexSearcher(reader);
-                InternalHistogram histogram = searchAndReduce(new AggTestConfig(searcher, aggBuilder, rangeField("field", rangeType)));
+                InternalHistogram histogram = searchAndReduce(new AggTestConfig<>(searcher, aggBuilder, rangeField("field", rangeType)));
                 assertEquals(7, histogram.getBuckets().size());
 
                 assertEquals(-5d, histogram.getBuckets().get(0).getKey());
@@ -103,7 +103,7 @@ public class RangeHistogramAggregatorTests extends AggregatorTestCase {
 
             try (IndexReader reader = w.getReader()) {
                 IndexSearcher searcher = new IndexSearcher(reader);
-                InternalHistogram histogram = searchAndReduce(new AggTestConfig(searcher, aggBuilder, rangeField("field", rangeType)));
+                InternalHistogram histogram = searchAndReduce(new AggTestConfig<>(searcher, aggBuilder, rangeField("field", rangeType)));
                 assertEquals(7, histogram.getBuckets().size());
 
                 assertEquals(-5d, histogram.getBuckets().get(0).getKey());
@@ -149,7 +149,7 @@ public class RangeHistogramAggregatorTests extends AggregatorTestCase {
 
             try (IndexReader reader = w.getReader()) {
                 IndexSearcher searcher = new IndexSearcher(reader);
-                InternalHistogram histogram = searchAndReduce(new AggTestConfig(searcher, aggBuilder, rangeField("field", rangeType)));
+                InternalHistogram histogram = searchAndReduce(new AggTestConfig<>(searcher, aggBuilder, rangeField("field", rangeType)));
                 assertEquals(7, histogram.getBuckets().size());
 
                 assertEquals(-5d, histogram.getBuckets().get(0).getKey());
@@ -196,7 +196,7 @@ public class RangeHistogramAggregatorTests extends AggregatorTestCase {
 
             try (IndexReader reader = w.getReader()) {
                 IndexSearcher searcher = new IndexSearcher(reader);
-                InternalHistogram histogram = searchAndReduce(new AggTestConfig(searcher, aggBuilder, rangeField("field", rangeType)));
+                InternalHistogram histogram = searchAndReduce(new AggTestConfig<>(searcher, aggBuilder, rangeField("field", rangeType)));
                 assertEquals(3, histogram.getBuckets().size());
 
                 assertEquals(0d, histogram.getBuckets().get(0).getKey());
@@ -230,7 +230,7 @@ public class RangeHistogramAggregatorTests extends AggregatorTestCase {
 
             try (IndexReader reader = w.getReader()) {
                 IndexSearcher searcher = new IndexSearcher(reader);
-                InternalHistogram histogram = searchAndReduce(new AggTestConfig(searcher, aggBuilder, rangeField("field", rangeType)));
+                InternalHistogram histogram = searchAndReduce(new AggTestConfig<>(searcher, aggBuilder, rangeField("field", rangeType)));
                 assertEquals(6, histogram.getBuckets().size());
 
                 assertEquals(-1 * Math.PI, histogram.getBuckets().get(0).getKey());
@@ -273,7 +273,7 @@ public class RangeHistogramAggregatorTests extends AggregatorTestCase {
 
             try (IndexReader reader = w.getReader()) {
                 IndexSearcher searcher = new IndexSearcher(reader);
-                InternalHistogram histogram = searchAndReduce(new AggTestConfig(searcher, aggBuilder, rangeField("field", rangeType)));
+                InternalHistogram histogram = searchAndReduce(new AggTestConfig<>(searcher, aggBuilder, rangeField("field", rangeType)));
                 assertEquals(2, histogram.getBuckets().size());
 
                 assertEquals(5d, histogram.getBuckets().get(0).getKey());
@@ -304,7 +304,7 @@ public class RangeHistogramAggregatorTests extends AggregatorTestCase {
 
             try (IndexReader reader = w.getReader()) {
                 IndexSearcher searcher = new IndexSearcher(reader);
-                InternalHistogram histogram = searchAndReduce(new AggTestConfig(searcher, aggBuilder, rangeField("field", rangeType)));
+                InternalHistogram histogram = searchAndReduce(new AggTestConfig<>(searcher, aggBuilder, rangeField("field", rangeType)));
                 assertEquals(8, histogram.getBuckets().size());
 
                 assertEquals(-6d, histogram.getBuckets().get(0).getKey());
@@ -361,7 +361,7 @@ public class RangeHistogramAggregatorTests extends AggregatorTestCase {
 
             try (IndexReader reader = w.getReader()) {
                 IndexSearcher searcher = new IndexSearcher(reader);
-                InternalHistogram histogram = searchAndReduce(new AggTestConfig(searcher, aggBuilder, rangeField("field", rangeType)));
+                InternalHistogram histogram = searchAndReduce(new AggTestConfig<>(searcher, aggBuilder, rangeField("field", rangeType)));
                 assertEquals(7, histogram.getBuckets().size());
 
                 assertEquals(-5d + expectedOffset, histogram.getBuckets().get(0).getKey());
@@ -412,7 +412,7 @@ public class RangeHistogramAggregatorTests extends AggregatorTestCase {
                 IndexSearcher searcher = new IndexSearcher(reader);
                 Exception e = expectThrows(
                     IllegalArgumentException.class,
-                    () -> searchAndReduce(new AggTestConfig(searcher, aggBuilder, rangeField("field", rangeType)))
+                    () -> searchAndReduce(new AggTestConfig<>(searcher, aggBuilder, rangeField("field", rangeType)))
                 );
                 assertThat(e.getMessage(), equalTo("Expected numeric range type but found non-numeric range [ip_range]"));
             }

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/histogram/RangeHistogramAggregatorTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/histogram/RangeHistogramAggregatorTests.java
@@ -14,13 +14,11 @@ import org.apache.lucene.document.SortedNumericDocValuesField;
 import org.apache.lucene.index.IndexReader;
 import org.apache.lucene.index.IndexableField;
 import org.apache.lucene.search.IndexSearcher;
-import org.apache.lucene.search.MatchAllDocsQuery;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.tests.index.RandomIndexWriter;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.network.InetAddresses;
 import org.elasticsearch.core.CheckedConsumer;
-import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.mapper.RangeFieldMapper;
 import org.elasticsearch.index.mapper.RangeType;
 import org.elasticsearch.search.aggregations.AggregationBuilder;
@@ -466,12 +464,14 @@ public class RangeHistogramAggregatorTests extends AggregatorTestCase {
             }
         };
         testCase(
-            new AggTestConfig<InternalHistogram>(
+            new AggTestConfig<>(
                 request,
                 buildIndex,
                 verify,
-                new MappedFieldType[] { rangeField("outer", RangeType.LONG), rangeField("inner", RangeType.LONG), longField("n") }
-            ).withQuery(new MatchAllDocsQuery())
+                rangeField("outer", RangeType.LONG),
+                rangeField("inner", RangeType.LONG),
+                longField("n")
+            )
         );
     }
 }

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/histogram/VariableWidthHistogramAggregatorTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/histogram/VariableWidthHistogramAggregatorTests.java
@@ -498,7 +498,10 @@ public class VariableWidthHistogramAggregatorTests extends AggregatorTestCase {
         };
         Exception e = expectThrows(
             IllegalArgumentException.class,
-            () -> testCase(builder, DEFAULT_QUERY, buildIndex, verify, longField("t"), longField("v"))
+            () -> testCase(
+                new AggTestConfig<LongTerms>(builder, buildIndex, verify, new MappedFieldType[] { longField("t"), longField("v") })
+                    .withQuery(DEFAULT_QUERY)
+            )
         );
         assertThat(e.getMessage(), containsString("cannot be nested"));
     }

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/histogram/VariableWidthHistogramAggregatorTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/histogram/VariableWidthHistogramAggregatorTests.java
@@ -625,7 +625,7 @@ public class VariableWidthHistogramAggregatorTests extends AggregatorTestCase {
                 }
 
                 final InternalVariableWidthHistogram histogram = searchAndReduce(
-                    new AggTestConfig(indexSearcher, query, aggregationBuilder, fieldType)
+                    new AggTestConfig<>(indexSearcher, query, aggregationBuilder, fieldType)
                 );
                 verify.accept(histogram);
             }

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/histogram/VariableWidthHistogramAggregatorTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/histogram/VariableWidthHistogramAggregatorTests.java
@@ -498,10 +498,7 @@ public class VariableWidthHistogramAggregatorTests extends AggregatorTestCase {
         };
         Exception e = expectThrows(
             IllegalArgumentException.class,
-            () -> testCase(
-                new AggTestConfig<LongTerms>(builder, buildIndex, verify, new MappedFieldType[] { longField("t"), longField("v") })
-                    .withQuery(DEFAULT_QUERY)
-            )
+            () -> testCase(new AggTestConfig<LongTerms>(builder, buildIndex, verify, longField("t"), longField("v")))
         );
         assertThat(e.getMessage(), containsString("cannot be nested"));
     }

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/missing/MissingAggregatorTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/missing/MissingAggregatorTests.java
@@ -324,7 +324,7 @@ public class MissingAggregatorTests extends AggregatorTestCase {
             try (IndexReader indexReader = DirectoryReader.open(directory)) {
                 final IndexSearcher indexSearcher = newSearcher(indexReader, true, true);
                 final MappedFieldType[] fieldTypesArray = fieldTypes.toArray(new MappedFieldType[0]);
-                final InternalMissing missing = searchAndReduce(new AggTestConfig(indexSearcher, query, builder, fieldTypesArray));
+                final InternalMissing missing = searchAndReduce(new AggTestConfig<>(indexSearcher, query, builder, fieldTypesArray));
                 verify.accept(missing);
             }
         }

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/nested/NestedAggregatorTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/nested/NestedAggregatorTests.java
@@ -148,7 +148,9 @@ public class NestedAggregatorTests extends AggregatorTestCase {
                 nestedBuilder.subAggregation(maxAgg);
                 MappedFieldType fieldType = new NumberFieldMapper.NumberFieldType(VALUE_FIELD_NAME, NumberFieldMapper.NumberType.LONG);
 
-                InternalNested nested = searchAndReduce(new AggTestConfig(newSearcher(indexReader, false, true), nestedBuilder, fieldType));
+                InternalNested nested = searchAndReduce(
+                    new AggTestConfig<>(newSearcher(indexReader, false, true), nestedBuilder, fieldType)
+                );
 
                 assertEquals(NESTED_AGG, nested.getName());
                 assertEquals(0, nested.getDocCount());
@@ -193,7 +195,9 @@ public class NestedAggregatorTests extends AggregatorTestCase {
                 nestedBuilder.subAggregation(maxAgg);
                 MappedFieldType fieldType = new NumberFieldMapper.NumberFieldType(VALUE_FIELD_NAME, NumberFieldMapper.NumberType.LONG);
 
-                InternalNested nested = searchAndReduce(new AggTestConfig(newSearcher(indexReader, false, true), nestedBuilder, fieldType));
+                InternalNested nested = searchAndReduce(
+                    new AggTestConfig<>(newSearcher(indexReader, false, true), nestedBuilder, fieldType)
+                );
                 assertEquals(expectedNestedDocs, nested.getDocCount());
 
                 assertEquals(NESTED_AGG, nested.getName());
@@ -245,7 +249,9 @@ public class NestedAggregatorTests extends AggregatorTestCase {
 
                 MappedFieldType fieldType = new NumberFieldMapper.NumberFieldType(VALUE_FIELD_NAME, NumberFieldMapper.NumberType.LONG);
 
-                InternalNested nested = searchAndReduce(new AggTestConfig(newSearcher(indexReader, false, true), nestedBuilder, fieldType));
+                InternalNested nested = searchAndReduce(
+                    new AggTestConfig<>(newSearcher(indexReader, false, true), nestedBuilder, fieldType)
+                );
                 assertEquals(expectedNestedDocs, nested.getDocCount());
 
                 assertEquals(NESTED_AGG, nested.getName());
@@ -298,7 +304,9 @@ public class NestedAggregatorTests extends AggregatorTestCase {
                 nestedBuilder.subAggregation(sumAgg);
                 MappedFieldType fieldType = new NumberFieldMapper.NumberFieldType(VALUE_FIELD_NAME, NumberFieldMapper.NumberType.LONG);
 
-                InternalNested nested = searchAndReduce(new AggTestConfig(newSearcher(indexReader, false, true), nestedBuilder, fieldType));
+                InternalNested nested = searchAndReduce(
+                    new AggTestConfig<>(newSearcher(indexReader, false, true), nestedBuilder, fieldType)
+                );
                 assertEquals(expectedNestedDocs, nested.getDocCount());
 
                 assertEquals(NESTED_AGG, nested.getName());
@@ -379,7 +387,7 @@ public class NestedAggregatorTests extends AggregatorTestCase {
                 bq.add(new TermQuery(new Term(IdFieldMapper.NAME, Uid.encodeId("2"))), BooleanClause.Occur.MUST_NOT);
 
                 InternalNested nested = searchAndReduce(
-                    new AggTestConfig(newSearcher(indexReader, false, true), new ConstantScoreQuery(bq.build()), nestedBuilder, fieldType)
+                    new AggTestConfig<>(newSearcher(indexReader, false, true), new ConstantScoreQuery(bq.build()), nestedBuilder, fieldType)
                 );
 
                 assertEquals(NESTED_AGG, nested.getName());
@@ -418,7 +426,7 @@ public class NestedAggregatorTests extends AggregatorTestCase {
                 termsBuilder.subAggregation(nestedBuilder);
 
                 Terms terms = searchAndReduce(
-                    new AggTestConfig(newSearcher(indexReader, false, true), termsBuilder, fieldType1, fieldType2)
+                    new AggTestConfig<>(newSearcher(indexReader, false, true), termsBuilder, fieldType1, fieldType2)
                 );
 
                 assertEquals(7, terms.getBuckets().size());
@@ -468,7 +476,7 @@ public class NestedAggregatorTests extends AggregatorTestCase {
                 nestedBuilder.subAggregation(maxAgg);
                 termsBuilder.subAggregation(nestedBuilder);
 
-                terms = searchAndReduce(new AggTestConfig(newSearcher(indexReader, false, true), termsBuilder, fieldType1, fieldType2));
+                terms = searchAndReduce(new AggTestConfig<>(newSearcher(indexReader, false, true), termsBuilder, fieldType1, fieldType2));
 
                 assertEquals(7, terms.getBuckets().size());
                 assertEquals("authors", terms.getName());
@@ -555,7 +563,7 @@ public class NestedAggregatorTests extends AggregatorTestCase {
                 termsBuilder.subAggregation(nestedBuilder);
 
                 Terms terms = searchAndReduce(
-                    new AggTestConfig(newSearcher(indexReader, false, true), termsBuilder, fieldType1, fieldType2)
+                    new AggTestConfig<>(newSearcher(indexReader, false, true), termsBuilder, fieldType1, fieldType2)
                 );
 
                 assertEquals(books.size(), terms.getBuckets().size());
@@ -652,7 +660,7 @@ public class NestedAggregatorTests extends AggregatorTestCase {
                 MappedFieldType fieldType2 = new KeywordFieldMapper.KeywordFieldType("value");
 
                 Filter filter = searchAndReduce(
-                    new AggTestConfig(
+                    new AggTestConfig<>(
                         newSearcher(indexReader, false, true),
                         Queries.newNonNestedFilter(),
                         filterAggregationBuilder,
@@ -720,8 +728,8 @@ public class NestedAggregatorTests extends AggregatorTestCase {
                     max(MAX_AGG_NAME).field(VALUE_FIELD_NAME + "-alias")
                 );
 
-                InternalNested nested = searchAndReduce(new AggTestConfig(newSearcher(indexReader, false, true), agg, fieldType));
-                Nested aliasNested = searchAndReduce(new AggTestConfig(newSearcher(indexReader, false, true), aliasAgg, fieldType));
+                InternalNested nested = searchAndReduce(new AggTestConfig<>(newSearcher(indexReader, false, true), agg, fieldType));
+                Nested aliasNested = searchAndReduce(new AggTestConfig<>(newSearcher(indexReader, false, true), aliasAgg, fieldType));
 
                 assertEquals(nested, aliasNested);
                 assertEquals(expectedNestedDocs, nested.getDocCount());
@@ -771,7 +779,9 @@ public class NestedAggregatorTests extends AggregatorTestCase {
 
                 MappedFieldType fieldType = new NumberFieldMapper.NumberFieldType(VALUE_FIELD_NAME, NumberFieldMapper.NumberType.LONG);
 
-                InternalNested nested = searchAndReduce(new AggTestConfig(newSearcher(indexReader, false, true), nestedBuilder, fieldType));
+                InternalNested nested = searchAndReduce(
+                    new AggTestConfig<>(newSearcher(indexReader, false, true), nestedBuilder, fieldType)
+                );
 
                 assertEquals(expectedNestedDocs, nested.getDocCount());
                 assertEquals(NESTED_AGG, nested.getName());

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/nested/NestedAggregatorTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/nested/NestedAggregatorTests.java
@@ -815,7 +815,7 @@ public class NestedAggregatorTests extends AggregatorTestCase {
                     new TermsAggregationBuilder("resellers").field("reseller_id").size(numResellers)
                 )
             );
-        testCase(b, new MatchAllDocsQuery(), buildResellerData(numProducts, numResellers), result -> {
+        testCase(new AggTestConfig<InternalAggregation>(b, buildResellerData(numProducts, numResellers), result -> {
             LongTerms products = (LongTerms) result;
             assertThat(
                 products.getBuckets().stream().map(LongTerms.Bucket::getKeyAsNumber).collect(toList()),
@@ -832,7 +832,7 @@ public class NestedAggregatorTests extends AggregatorTestCase {
                     equalTo(LongStream.range(0, numResellers).mapToObj(Long::valueOf).collect(toList()))
                 );
             }
-        }, resellersMappedFields());
+        }, resellersMappedFields()).withQuery(new MatchAllDocsQuery()));
     }
 
     public static CheckedConsumer<RandomIndexWriter, IOException> buildResellerData(int numProducts, int numResellers) {

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/nested/NestedAggregatorTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/nested/NestedAggregatorTests.java
@@ -22,7 +22,6 @@ import org.apache.lucene.index.Term;
 import org.apache.lucene.search.BooleanClause;
 import org.apache.lucene.search.BooleanQuery;
 import org.apache.lucene.search.ConstantScoreQuery;
-import org.apache.lucene.search.MatchAllDocsQuery;
 import org.apache.lucene.search.TermQuery;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.tests.index.RandomIndexWriter;
@@ -815,8 +814,7 @@ public class NestedAggregatorTests extends AggregatorTestCase {
                     new TermsAggregationBuilder("resellers").field("reseller_id").size(numResellers)
                 )
             );
-        testCase(new AggTestConfig<InternalAggregation>(b, buildResellerData(numProducts, numResellers), result -> {
-            LongTerms products = (LongTerms) result;
+        testCase(new AggTestConfig<LongTerms>(b, buildResellerData(numProducts, numResellers), products -> {
             assertThat(
                 products.getBuckets().stream().map(LongTerms.Bucket::getKeyAsNumber).collect(toList()),
                 equalTo(LongStream.range(0, numProducts).mapToObj(Long::valueOf).collect(toList()))
@@ -832,7 +830,7 @@ public class NestedAggregatorTests extends AggregatorTestCase {
                     equalTo(LongStream.range(0, numResellers).mapToObj(Long::valueOf).collect(toList()))
                 );
             }
-        }, resellersMappedFields()).withQuery(new MatchAllDocsQuery()));
+        }, resellersMappedFields()));
     }
 
     public static CheckedConsumer<RandomIndexWriter, IOException> buildResellerData(int numProducts, int numResellers) {

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/nested/ReverseNestedAggregatorTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/nested/ReverseNestedAggregatorTests.java
@@ -226,7 +226,7 @@ public class ReverseNestedAggregatorTests extends AggregatorTestCase {
                     )
                 )
         );
-        testCase(b, new MatchAllDocsQuery(), NestedAggregatorTests.buildResellerData(numProducts, numResellers), result -> {
+        testCase(new AggTestConfig<InternalAggregation>(b, NestedAggregatorTests.buildResellerData(numProducts, numResellers), result -> {
             InternalNested nested = (InternalNested) result;
             assertThat(nested.getDocCount(), equalTo((long) numProducts * numResellers));
             LongTerms resellers = nested.getAggregations().get("resellers");
@@ -245,7 +245,7 @@ public class ReverseNestedAggregatorTests extends AggregatorTestCase {
                     equalTo(LongStream.range(0, numProducts).mapToObj(Long::valueOf).collect(toList()))
                 );
             }
-        }, NestedAggregatorTests.resellersMappedFields());
+        }, NestedAggregatorTests.resellersMappedFields()).withQuery(new MatchAllDocsQuery()));
     }
 
     @Override

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/nested/ReverseNestedAggregatorTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/nested/ReverseNestedAggregatorTests.java
@@ -14,7 +14,6 @@ import org.apache.lucene.document.SortedNumericDocValuesField;
 import org.apache.lucene.index.DirectoryReader;
 import org.apache.lucene.index.IndexReader;
 import org.apache.lucene.index.IndexableField;
-import org.apache.lucene.search.MatchAllDocsQuery;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.tests.index.RandomIndexWriter;
 import org.elasticsearch.index.mapper.IdFieldMapper;
@@ -226,8 +225,7 @@ public class ReverseNestedAggregatorTests extends AggregatorTestCase {
                     )
                 )
         );
-        testCase(new AggTestConfig<InternalAggregation>(b, NestedAggregatorTests.buildResellerData(numProducts, numResellers), result -> {
-            InternalNested nested = (InternalNested) result;
+        testCase(new AggTestConfig<InternalNested>(b, NestedAggregatorTests.buildResellerData(numProducts, numResellers), nested -> {
             assertThat(nested.getDocCount(), equalTo((long) numProducts * numResellers));
             LongTerms resellers = nested.getAggregations().get("resellers");
             assertThat(
@@ -245,7 +243,7 @@ public class ReverseNestedAggregatorTests extends AggregatorTestCase {
                     equalTo(LongStream.range(0, numProducts).mapToObj(Long::valueOf).collect(toList()))
                 );
             }
-        }, NestedAggregatorTests.resellersMappedFields()).withQuery(new MatchAllDocsQuery()));
+        }, NestedAggregatorTests.resellersMappedFields()));
     }
 
     @Override

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/nested/ReverseNestedAggregatorTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/nested/ReverseNestedAggregatorTests.java
@@ -74,7 +74,7 @@ public class ReverseNestedAggregatorTests extends AggregatorTestCase {
                 reverseNestedBuilder.subAggregation(maxAgg);
                 MappedFieldType fieldType = new NumberFieldMapper.NumberFieldType(VALUE_FIELD_NAME, NumberFieldMapper.NumberType.LONG);
 
-                Nested nested = searchAndReduce(new AggTestConfig(newSearcher(indexReader, false, true), nestedBuilder, fieldType));
+                Nested nested = searchAndReduce(new AggTestConfig<>(newSearcher(indexReader, false, true), nestedBuilder, fieldType));
                 ReverseNested reverseNested = (ReverseNested) ((InternalAggregation) nested).getProperty(REVERSE_AGG_NAME);
                 assertEquals(REVERSE_AGG_NAME, reverseNested.getName());
                 assertEquals(0, reverseNested.getDocCount());
@@ -134,7 +134,7 @@ public class ReverseNestedAggregatorTests extends AggregatorTestCase {
                 reverseNestedBuilder.subAggregation(maxAgg);
                 MappedFieldType fieldType = new NumberFieldMapper.NumberFieldType(VALUE_FIELD_NAME, NumberFieldMapper.NumberType.LONG);
 
-                Nested nested = searchAndReduce(new AggTestConfig(newSearcher(indexReader, false, true), nestedBuilder, fieldType));
+                Nested nested = searchAndReduce(new AggTestConfig<>(newSearcher(indexReader, false, true), nestedBuilder, fieldType));
                 assertEquals(expectedNestedDocs, nested.getDocCount());
 
                 ReverseNested reverseNested = (ReverseNested) ((InternalAggregation) nested).getProperty(REVERSE_AGG_NAME);
@@ -201,8 +201,8 @@ public class ReverseNestedAggregatorTests extends AggregatorTestCase {
                     reverseNested(REVERSE_AGG_NAME).subAggregation(aliasMaxAgg)
                 );
 
-                Nested nested = searchAndReduce(new AggTestConfig(newSearcher(indexReader, false, true), agg, fieldType));
-                Nested aliasNested = searchAndReduce(new AggTestConfig(newSearcher(indexReader, false, true), aliasAgg, fieldType));
+                Nested nested = searchAndReduce(new AggTestConfig<>(newSearcher(indexReader, false, true), agg, fieldType));
+                Nested aliasNested = searchAndReduce(new AggTestConfig<>(newSearcher(indexReader, false, true), aliasAgg, fieldType));
 
                 ReverseNested reverseNested = nested.getAggregations().get(REVERSE_AGG_NAME);
                 ReverseNested aliasReverseNested = aliasNested.getAggregations().get(REVERSE_AGG_NAME);

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/prefix/IpPrefixAggregatorTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/prefix/IpPrefixAggregatorTests.java
@@ -22,6 +22,7 @@ import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.mapper.NumberFieldMapper;
 import org.elasticsearch.search.aggregations.AggregationBuilder;
 import org.elasticsearch.search.aggregations.AggregatorTestCase;
+import org.elasticsearch.search.aggregations.InternalAggregation;
 import org.elasticsearch.search.aggregations.bucket.histogram.DateHistogramAggregationBuilder;
 import org.elasticsearch.search.aggregations.bucket.histogram.DateHistogramInterval;
 import org.elasticsearch.search.aggregations.bucket.histogram.InternalDateHistogram;
@@ -143,7 +144,8 @@ public class IpPrefixAggregatorTests extends AggregatorTestCase {
         final List<TestIpDataHolder> ipAddresses = Collections.emptyList();
 
         // WHEN
-        testCase(aggregationBuilder, new MatchAllDocsQuery(), iw -> {
+        // THEN
+        testCase(new AggTestConfig<InternalAggregation>(aggregationBuilder, iw -> {
 
         }, agg -> {
             final InternalIpPrefix ipPrefix = (InternalIpPrefix) agg;
@@ -166,7 +168,7 @@ public class IpPrefixAggregatorTests extends AggregatorTestCase {
             assertEquals(expectedSubnets.size(), ipPrefix.getBuckets().size());
             assertTrue(ipAddressesAsString.containsAll(expectedSubnets));
             assertTrue(expectedSubnets.containsAll(ipAddressesAsString));
-        }, fieldType);
+        }, fieldType).withQuery(new MatchAllDocsQuery()));
     }
 
     public void testIpv4Addresses() throws IOException {
@@ -191,7 +193,8 @@ public class IpPrefixAggregatorTests extends AggregatorTestCase {
         );
 
         // WHEN
-        testCase(aggregationBuilder, new MatchAllDocsQuery(), iw -> {
+        // THEN
+        testCase(new AggTestConfig<InternalAggregation>(aggregationBuilder, iw -> {
             for (TestIpDataHolder ipDataHolder : ipAddresses) {
                 iw.addDocument(
                     singleton(new SortedDocValuesField(field, new BytesRef(InetAddressPoint.encode(ipDataHolder.getIpAddress()))))
@@ -222,7 +225,7 @@ public class IpPrefixAggregatorTests extends AggregatorTestCase {
                 ipPrefix.getBuckets().stream().sorted(IP_ADDRESS_KEY_COMPARATOR).map(InternalIpPrefix.Bucket::getDocCount).toList(),
                 List.of(1L, 1L, 4L, 1L)
             );
-        }, fieldType);
+        }, fieldType).withQuery(new MatchAllDocsQuery()));
     }
 
     public void testIpv6Addresses() throws IOException {
@@ -245,7 +248,8 @@ public class IpPrefixAggregatorTests extends AggregatorTestCase {
         );
 
         // WHEN
-        testCase(aggregationBuilder, new MatchAllDocsQuery(), iw -> {
+        // THEN
+        testCase(new AggTestConfig<InternalAggregation>(aggregationBuilder, iw -> {
             for (TestIpDataHolder ipDataHolder : ipAddresses) {
                 iw.addDocument(
                     singleton(new SortedDocValuesField(field, new BytesRef(InetAddressPoint.encode(ipDataHolder.getIpAddress()))))
@@ -275,7 +279,7 @@ public class IpPrefixAggregatorTests extends AggregatorTestCase {
                 ipPrefix.getBuckets().stream().sorted(IP_ADDRESS_KEY_COMPARATOR).map(InternalIpPrefix.Bucket::getDocCount).toList(),
                 List.of(2L, 1L, 2L)
             );
-        }, fieldType);
+        }, fieldType).withQuery(new MatchAllDocsQuery()));
     }
 
     public void testZeroPrefixLength() throws IOException {
@@ -300,7 +304,8 @@ public class IpPrefixAggregatorTests extends AggregatorTestCase {
         );
 
         // WHEN
-        testCase(aggregationBuilder, new MatchAllDocsQuery(), iw -> {
+        // THEN
+        testCase(new AggTestConfig<InternalAggregation>(aggregationBuilder, iw -> {
             for (TestIpDataHolder ipDataHolder : ipAddresses) {
                 iw.addDocument(
                     singleton(new SortedDocValuesField(field, new BytesRef(InetAddressPoint.encode(ipDataHolder.getIpAddress()))))
@@ -331,7 +336,7 @@ public class IpPrefixAggregatorTests extends AggregatorTestCase {
                 ipPrefix.getBuckets().stream().sorted(IP_ADDRESS_KEY_COMPARATOR).map(InternalIpPrefix.Bucket::getDocCount).toList(),
                 List.of((long) ipAddresses.size())
             );
-        }, fieldType);
+        }, fieldType).withQuery(new MatchAllDocsQuery()));
     }
 
     public void testIpv4MaxPrefixLength() throws IOException {
@@ -356,7 +361,8 @@ public class IpPrefixAggregatorTests extends AggregatorTestCase {
         );
 
         // WHEN
-        testCase(aggregationBuilder, new MatchAllDocsQuery(), iw -> {
+        // THEN
+        testCase(new AggTestConfig<InternalAggregation>(aggregationBuilder, iw -> {
             for (TestIpDataHolder ipDataHolder : ipAddresses) {
                 iw.addDocument(
                     singleton(new SortedDocValuesField(field, new BytesRef(InetAddressPoint.encode(ipDataHolder.getIpAddress()))))
@@ -387,7 +393,7 @@ public class IpPrefixAggregatorTests extends AggregatorTestCase {
                 ipPrefix.getBuckets().stream().sorted(IP_ADDRESS_KEY_COMPARATOR).map(InternalIpPrefix.Bucket::getDocCount).toList(),
                 List.of(1L, 1L, 1L, 2L, 1L, 1L)
             );
-        }, fieldType);
+        }, fieldType).withQuery(new MatchAllDocsQuery()));
     }
 
     public void testIpv6MaxPrefixLength() throws IOException {
@@ -410,7 +416,8 @@ public class IpPrefixAggregatorTests extends AggregatorTestCase {
         );
 
         // WHEN
-        testCase(aggregationBuilder, new MatchAllDocsQuery(), iw -> {
+        // THEN
+        testCase(new AggTestConfig<InternalAggregation>(aggregationBuilder, iw -> {
             for (TestIpDataHolder ipDataHolder : ipAddresses) {
                 iw.addDocument(
                     singleton(new SortedDocValuesField(field, new BytesRef(InetAddressPoint.encode(ipDataHolder.getIpAddress()))))
@@ -440,7 +447,7 @@ public class IpPrefixAggregatorTests extends AggregatorTestCase {
                 ipPrefix.getBuckets().stream().sorted(IP_ADDRESS_KEY_COMPARATOR).map(InternalIpPrefix.Bucket::getDocCount).toList(),
                 List.of(1L, 1L, 1L, 1L, 1L)
             );
-        }, fieldType);
+        }, fieldType).withQuery(new MatchAllDocsQuery()));
     }
 
     public void testAggregateOnIpv4Field() throws IOException {
@@ -467,7 +474,8 @@ public class IpPrefixAggregatorTests extends AggregatorTestCase {
         final String ipv6Value = "2001:db8:a4f8:112a:6001:0:12:7f2a";
 
         // WHEN
-        testCase(aggregationBuilder, new MatchAllDocsQuery(), iw -> {
+        // THEN
+        testCase(new AggTestConfig<InternalAggregation>(aggregationBuilder, iw -> {
             for (TestIpDataHolder ipDataHolder : ipAddresses) {
                 iw.addDocument(
                     List.of(
@@ -501,7 +509,7 @@ public class IpPrefixAggregatorTests extends AggregatorTestCase {
                 ipPrefix.getBuckets().stream().sorted(IP_ADDRESS_KEY_COMPARATOR).map(InternalIpPrefix.Bucket::getDocCount).toList(),
                 List.of(1L, 1L, 4L, 1L)
             );
-        }, fieldTypes);
+        }, fieldTypes).withQuery(new MatchAllDocsQuery()));
     }
 
     public void testAggregateOnIpv6Field() throws IOException {
@@ -526,7 +534,8 @@ public class IpPrefixAggregatorTests extends AggregatorTestCase {
         final String ipv4Value = "192.168.10.20";
 
         // WHEN
-        testCase(aggregationBuilder, new MatchAllDocsQuery(), iw -> {
+        // THEN
+        testCase(new AggTestConfig<InternalAggregation>(aggregationBuilder, iw -> {
             for (TestIpDataHolder ipDataHolder : ipAddresses) {
                 iw.addDocument(
                     List.of(
@@ -559,7 +568,7 @@ public class IpPrefixAggregatorTests extends AggregatorTestCase {
                 ipPrefix.getBuckets().stream().sorted(IP_ADDRESS_KEY_COMPARATOR).map(InternalIpPrefix.Bucket::getDocCount).toList(),
                 List.of(2L, 1L, 2L)
             );
-        }, fieldTypes);
+        }, fieldTypes).withQuery(new MatchAllDocsQuery()));
     }
 
     public void testIpv4AggregationAsSubAggregation() throws IOException {
@@ -608,7 +617,7 @@ public class IpPrefixAggregatorTests extends AggregatorTestCase {
             .collect(Collectors.toUnmodifiableSet());
 
         // WHEN
-        testCase(aggregationBuilder, new MatchAllDocsQuery(), iw -> {
+        testCase(new AggTestConfig<InternalAggregation>(aggregationBuilder, iw -> {
             for (final TestIpDataHolder ipDataHolder : ipAddresses) {
                 iw.addDocument(
                     List.of(
@@ -649,7 +658,7 @@ public class IpPrefixAggregatorTests extends AggregatorTestCase {
             assertTrue(bucket2Subnets.containsAll(expectedBucket2Subnets));
             assertTrue(expectedBucket1Subnets.containsAll(bucket1Subnets));
             assertTrue(expectedBucket2Subnets.containsAll(bucket2Subnets));
-        }, fieldTypes);
+        }, fieldTypes).withQuery(new MatchAllDocsQuery()));
     }
 
     public void testIpv6AggregationAsSubAggregation() throws IOException {
@@ -695,7 +704,7 @@ public class IpPrefixAggregatorTests extends AggregatorTestCase {
             .collect(Collectors.toUnmodifiableSet());
 
         // WHEN
-        testCase(aggregationBuilder, new MatchAllDocsQuery(), iw -> {
+        testCase(new AggTestConfig<InternalAggregation>(aggregationBuilder, iw -> {
             for (final TestIpDataHolder ipDataHolder : ipAddresses) {
                 iw.addDocument(
                     List.of(
@@ -736,7 +745,7 @@ public class IpPrefixAggregatorTests extends AggregatorTestCase {
             assertTrue(bucket2Subnets.containsAll(expectedBucket2Subnets));
             assertTrue(expectedBucket1Subnets.containsAll(bucket1Subnets));
             assertTrue(expectedBucket2Subnets.containsAll(bucket2Subnets));
-        }, fieldTypes);
+        }, fieldTypes).withQuery(new MatchAllDocsQuery()));
     }
 
     public void testIpPrefixSubAggregations() throws IOException {
@@ -777,7 +786,7 @@ public class IpPrefixAggregatorTests extends AggregatorTestCase {
         );
 
         // WHEN
-        testCase(aggregationBuilder, new MatchAllDocsQuery(), iw -> {
+        testCase(new AggTestConfig<InternalAggregation>(aggregationBuilder, iw -> {
             for (final TestIpDataHolder ipDataHolder : ipAddresses) {
                 iw.addDocument(
                     List.of(new SortedDocValuesField(ipv4FieldName, new BytesRef(InetAddressPoint.encode(ipDataHolder.getIpAddress()))))
@@ -820,7 +829,7 @@ public class IpPrefixAggregatorTests extends AggregatorTestCase {
             assertTrue(secondSubnetNestedSubnets.containsAll(expectedSecondSubnetNestedSUbnets));
             assertTrue(expectedSecondSubnetNestedSUbnets.containsAll(secondSubnetNestedSubnets));
 
-        }, fieldTypes);
+        }, fieldTypes).withQuery(new MatchAllDocsQuery()));
     }
 
     public void testIpv4AppendPrefixLength() throws IOException {
@@ -845,7 +854,8 @@ public class IpPrefixAggregatorTests extends AggregatorTestCase {
         );
 
         // WHEN
-        testCase(aggregationBuilder, new MatchAllDocsQuery(), iw -> {
+        // THEN
+        testCase(new AggTestConfig<InternalAggregation>(aggregationBuilder, iw -> {
             for (TestIpDataHolder ipDataHolder : ipAddresses) {
                 iw.addDocument(
                     singleton(new SortedDocValuesField(field, new BytesRef(InetAddressPoint.encode(ipDataHolder.getIpAddress()))))
@@ -874,7 +884,7 @@ public class IpPrefixAggregatorTests extends AggregatorTestCase {
             assertEquals(expectedSubnets.size(), ipPrefix.getBuckets().size());
             assertTrue(ipAddressesAsString.containsAll(expectedSubnets));
             assertTrue(expectedSubnets.containsAll(ipAddressesAsString));
-        }, fieldType);
+        }, fieldType).withQuery(new MatchAllDocsQuery()));
     }
 
     public void testIpv6AppendPrefixLength() throws IOException {
@@ -897,7 +907,8 @@ public class IpPrefixAggregatorTests extends AggregatorTestCase {
         );
 
         // WHEN
-        testCase(aggregationBuilder, new MatchAllDocsQuery(), iw -> {
+        // THEN
+        testCase(new AggTestConfig<InternalAggregation>(aggregationBuilder, iw -> {
             for (TestIpDataHolder ipDataHolder : ipAddresses) {
                 iw.addDocument(
                     singleton(new SortedDocValuesField(field, new BytesRef(InetAddressPoint.encode(ipDataHolder.getIpAddress()))))
@@ -925,7 +936,7 @@ public class IpPrefixAggregatorTests extends AggregatorTestCase {
             assertEquals(expectedSubnets.size(), ipPrefix.getBuckets().size());
             assertTrue(ipAddressesAsString.containsAll(expectedSubnets));
             assertTrue(expectedSubnets.containsAll(ipAddressesAsString));
-        }, fieldType);
+        }, fieldType).withQuery(new MatchAllDocsQuery()));
     }
 
     public void testMinDocCount() throws IOException {
@@ -949,7 +960,7 @@ public class IpPrefixAggregatorTests extends AggregatorTestCase {
             new TestIpDataHolder("10.122.2.67", "10.122.0.0", prefixLength, defaultTime())
         );
 
-        testCase(aggregationBuilder, new MatchAllDocsQuery(), iw -> {
+        testCase(new AggTestConfig<InternalIpPrefix>(aggregationBuilder, iw -> {
             for (TestIpDataHolder ipDataHolder : ipAddresses) {
                 iw.addDocument(
                     singleton(new SortedDocValuesField(field, new BytesRef(InetAddressPoint.encode(ipDataHolder.getIpAddress()))))
@@ -979,7 +990,7 @@ public class IpPrefixAggregatorTests extends AggregatorTestCase {
                 ipPrefix.getBuckets().stream().sorted(IP_ADDRESS_KEY_COMPARATOR).map(InternalIpPrefix.Bucket::getDocCount).toList(),
                 equalTo(List.of(4L))
             );
-        }, fieldType);
+        }, new MappedFieldType[] { fieldType }).withQuery(new MatchAllDocsQuery()));
     }
 
     public void testAggregationWithQueryFilter() throws IOException {
@@ -1009,7 +1020,8 @@ public class IpPrefixAggregatorTests extends AggregatorTestCase {
         );
 
         // WHEN
-        testCase(aggregationBuilder, query, iw -> {
+        // THEN
+        testCase(new AggTestConfig<InternalAggregation>(aggregationBuilder, iw -> {
             for (TestIpDataHolder ipDataHolder : ipAddresses) {
                 iw.addDocument(
                     List.of(
@@ -1044,7 +1056,7 @@ public class IpPrefixAggregatorTests extends AggregatorTestCase {
                 ipPrefix.getBuckets().stream().sorted(IP_ADDRESS_KEY_COMPARATOR).map(InternalIpPrefix.Bucket::getDocCount).toList(),
                 List.of(4L)
             );
-        }, fieldType);
+        }, fieldType).withQuery(query));
     }
 
     public void testMetricAggregation() throws IOException {
@@ -1073,7 +1085,8 @@ public class IpPrefixAggregatorTests extends AggregatorTestCase {
         );
 
         // WHEN
-        testCase(aggregationBuilder, new MatchAllDocsQuery(), iw -> {
+        // THEN
+        testCase(new AggTestConfig<InternalAggregation>(aggregationBuilder, iw -> {
             for (TestIpDataHolder ipDataHolder : ipAddresses) {
                 iw.addDocument(
                     List.of(
@@ -1106,7 +1119,7 @@ public class IpPrefixAggregatorTests extends AggregatorTestCase {
             assertEquals(210, ((Sum) ipPrefix.getBuckets().get(0).getAggregations().get(subAggregationName)).value(), 0);
             assertEquals(200, ((Sum) ipPrefix.getBuckets().get(1).getAggregations().get(subAggregationName)).value(), 0);
             assertEquals(300, ((Sum) ipPrefix.getBuckets().get(2).getAggregations().get(subAggregationName)).value(), 0);
-        }, fieldTypes);
+        }, fieldTypes).withQuery(new MatchAllDocsQuery()));
     }
 
     private Function<String, String> appendPrefixLength(int prefixLength) {

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/range/DateRangeAggregatorTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/range/DateRangeAggregatorTests.java
@@ -529,7 +529,7 @@ public class DateRangeAggregatorTests extends AggregatorTestCase {
                 IndexSearcher indexSearcher = newSearcher(indexReader, true, true);
 
                 InternalRange<? extends InternalRange.Bucket, ? extends InternalRange<?, ?>> agg = searchAndReduce(
-                    new AggTestConfig(indexSearcher, query, aggregationBuilder, fieldType)
+                    new AggTestConfig<>(indexSearcher, query, aggregationBuilder, fieldType)
                 );
                 verify.accept(agg);
 

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/range/IpRangeAggregatorTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/range/IpRangeAggregatorTests.java
@@ -99,7 +99,7 @@ public class IpRangeAggregatorTests extends AggregatorTestCase {
             MappedFieldType fieldType = new IpFieldMapper.IpFieldType("field");
             try (IndexReader reader = w.getReader()) {
                 IndexSearcher searcher = new IndexSearcher(reader);
-                InternalBinaryRange range = searchAndReduce(new AggTestConfig(searcher, builder, fieldType));
+                InternalBinaryRange range = searchAndReduce(new AggTestConfig<>(searcher, builder, fieldType));
                 assertEquals(numRanges, range.getBuckets().size());
                 for (int i = 0; i < range.getBuckets().size(); i++) {
                     Tuple<BytesRef, BytesRef> expected = requestedRanges[i];
@@ -132,7 +132,7 @@ public class IpRangeAggregatorTests extends AggregatorTestCase {
                 .missing("192.168.100.42"); // Apparently we expect a string here
             try (IndexReader reader = w.getReader()) {
                 IndexSearcher searcher = new IndexSearcher(reader);
-                InternalBinaryRange range = searchAndReduce(new AggTestConfig(searcher, builder));
+                InternalBinaryRange range = searchAndReduce(new AggTestConfig<>(searcher, builder));
                 assertEquals(1, range.getBuckets().size());
             }
         }
@@ -150,7 +150,7 @@ public class IpRangeAggregatorTests extends AggregatorTestCase {
                 .missing(1234);
             try (IndexReader reader = w.getReader()) {
                 IndexSearcher searcher = new IndexSearcher(reader);
-                expectThrows(IllegalArgumentException.class, () -> searchAndReduce(new AggTestConfig(searcher, builder)));
+                expectThrows(IllegalArgumentException.class, () -> searchAndReduce(new AggTestConfig<>(searcher, builder)));
             }
         }
     }

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/range/RangeAggregatorTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/range/RangeAggregatorTests.java
@@ -33,7 +33,6 @@ import org.elasticsearch.script.StringFieldScript;
 import org.elasticsearch.search.aggregations.Aggregator;
 import org.elasticsearch.search.aggregations.AggregatorTestCase;
 import org.elasticsearch.search.aggregations.CardinalityUpperBound;
-import org.elasticsearch.search.aggregations.InternalAggregation;
 import org.elasticsearch.search.aggregations.support.AggregationInspectionHelper;
 import org.elasticsearch.search.lookup.SearchLookup;
 import org.elasticsearch.search.lookup.SourceLookup;
@@ -111,18 +110,17 @@ public class RangeAggregatorTests extends AggregatorTestCase {
         final String fieldName = "double";
         MappedFieldType field = new NumberFieldMapper.NumberFieldType(fieldName, NumberType.DOUBLE);
         testCase(
-            new AggTestConfig<InternalAggregation>(
+            new AggTestConfig<InternalRange<?, ?>>(
                 new RangeAggregationBuilder("range").field(fieldName).addRange("r1", 0, 0.04D).addRange("r2", 0.04D, 1.0D),
                 iw -> { iw.addDocument(List.of(new SortedNumericDocValuesField(fieldName, NumericUtils.doubleToSortableLong(0.04D)))); },
-                result -> {
-                    InternalRange<?, ?> range = (InternalRange<?, ?>) result;
+                range -> {
                     List<? extends InternalRange.Bucket> ranges = range.getBuckets();
                     assertEquals(2, ranges.size());
                     assertEquals(0, ranges.get(0).getDocCount());
                     assertEquals(1, ranges.get(1).getDocCount());
                 },
                 field
-            ).withQuery(new MatchAllDocsQuery())
+            )
         );
     }
 
@@ -132,18 +130,17 @@ public class RangeAggregatorTests extends AggregatorTestCase {
         double from = Long.valueOf(Long.MIN_VALUE).doubleValue();
         double to = Long.valueOf(Long.MAX_VALUE).doubleValue();
         testCase(
-            new AggTestConfig<InternalAggregation>(
+            new AggTestConfig<InternalRange<?, ?>>(
                 new RangeAggregationBuilder("0").field(fieldName).addRange(Long.MIN_VALUE, Long.MAX_VALUE),
                 iw -> { iw.addDocument(singleton(new NumericDocValuesField(fieldName, randomLong()))); },
-                result -> {
-                    InternalRange<?, ?> range = (InternalRange<?, ?>) result;
+                range -> {
                     List<? extends InternalRange.Bucket> ranges = range.getBuckets();
                     assertEquals(1, ranges.size());
                     assertEquals(from + "-" + to, ranges.get(0).getKeyAsString());
                     assertEquals(1, ranges.get(0).getDocCount());
                 },
                 field
-            ).withQuery(new MatchAllDocsQuery())
+            )
         );
     }
 
@@ -151,15 +148,14 @@ public class RangeAggregatorTests extends AggregatorTestCase {
         final String fieldName = "test";
         MappedFieldType field = new NumberFieldMapper.NumberFieldType(fieldName, NumberType.FLOAT);
         testCase(
-            new AggTestConfig<InternalAggregation>(
+            new AggTestConfig<InternalRange<?, ?>>(
                 new RangeAggregationBuilder("0").field(fieldName).addRange(5, 6).addRange(6, 10.6).keyed(true),
                 iw -> {
                     iw.addDocument(singleton(new SortedNumericDocValuesField(fieldName, NumericUtils.floatToSortableInt(10))));
                     iw.addDocument(singleton(new SortedNumericDocValuesField(fieldName, NumericUtils.floatToSortableInt(5.5F))));
                     iw.addDocument(singleton(new SortedNumericDocValuesField(fieldName, NumericUtils.floatToSortableInt(6.7F))));
                 },
-                result -> {
-                    InternalRange<?, ?> range = (InternalRange<?, ?>) result;
+                range -> {
                     List<? extends InternalRange.Bucket> ranges = range.getBuckets();
                     assertEquals(2, ranges.size());
                     assertEquals("5.0-6.0", ranges.get(0).getKeyAsString());
@@ -176,7 +172,7 @@ public class RangeAggregatorTests extends AggregatorTestCase {
                     assertEquals(2, ranges.get(1).getDocCount());
                 },
                 field
-            ).withQuery(new MatchAllDocsQuery())
+            )
         );
     }
 
@@ -184,15 +180,14 @@ public class RangeAggregatorTests extends AggregatorTestCase {
         final String fieldName = "test";
         MappedFieldType field = new NumberFieldMapper.NumberFieldType(fieldName, NumberType.DOUBLE);
         testCase(
-            new AggTestConfig<InternalAggregation>(
+            new AggTestConfig<InternalRange<?, ?>>(
                 new RangeAggregationBuilder("0").field(fieldName).addRange(5, 6).addRange(6, 10.6).keyed(true),
                 iw -> {
                     iw.addDocument(singleton(new SortedNumericDocValuesField(fieldName, NumericUtils.doubleToSortableLong(10))));
                     iw.addDocument(singleton(new SortedNumericDocValuesField(fieldName, NumericUtils.doubleToSortableLong(5.5D))));
                     iw.addDocument(singleton(new SortedNumericDocValuesField(fieldName, NumericUtils.doubleToSortableLong(6.7D))));
                 },
-                result -> {
-                    InternalRange<?, ?> range = (InternalRange<?, ?>) result;
+                range -> {
                     List<? extends InternalRange.Bucket> ranges = range.getBuckets();
                     assertEquals(2, ranges.size());
                     assertEquals("5.0-6.0", ranges.get(0).getKeyAsString());
@@ -209,7 +204,7 @@ public class RangeAggregatorTests extends AggregatorTestCase {
                     assertEquals(2, ranges.get(1).getDocCount());
                 },
                 field
-            ).withQuery(new MatchAllDocsQuery())
+            )
         );
     }
 
@@ -217,7 +212,7 @@ public class RangeAggregatorTests extends AggregatorTestCase {
         final String fieldName = "long_field";
         MappedFieldType field = new NumberFieldMapper.NumberFieldType(fieldName, NumberType.LONG);
         testCase(
-            new AggTestConfig<InternalAggregation>(
+            new AggTestConfig<InternalRange<?, ?>>(
                 new RangeAggregationBuilder("0").field(fieldName).addRange(990.0, 999.9).addUnboundedFrom(999.9),
                 iw -> {
                     iw.addDocument(singleton(new NumericDocValuesField(fieldName, 998)));
@@ -225,15 +220,14 @@ public class RangeAggregatorTests extends AggregatorTestCase {
                     iw.addDocument(singleton(new NumericDocValuesField(fieldName, 1000)));
                     iw.addDocument(singleton(new NumericDocValuesField(fieldName, 1001)));
                 },
-                result -> {
-                    InternalRange<?, ?> range = (InternalRange<?, ?>) result;
+                range -> {
                     List<? extends InternalRange.Bucket> ranges = range.getBuckets();
                     assertEquals(2, ranges.size());
                     assertEquals(2, ranges.get(0).getDocCount());
                     assertEquals(2, ranges.get(1).getDocCount());
                 },
                 field
-            ).withQuery(new MatchAllDocsQuery())
+            )
         );
     }
 
@@ -241,7 +235,7 @@ public class RangeAggregatorTests extends AggregatorTestCase {
         final String fieldName = "integer_field";
         MappedFieldType field = new NumberFieldMapper.NumberFieldType(fieldName, NumberType.INTEGER);
         testCase(
-            new AggTestConfig<InternalAggregation>(
+            new AggTestConfig<InternalRange<?, ?>>(
                 new RangeAggregationBuilder("0").field(fieldName).addRange(990.0, 999.9).addUnboundedFrom(999.9),
                 iw -> {
                     iw.addDocument(singleton(new NumericDocValuesField(fieldName, 998)));
@@ -249,15 +243,14 @@ public class RangeAggregatorTests extends AggregatorTestCase {
                     iw.addDocument(singleton(new NumericDocValuesField(fieldName, 1000)));
                     iw.addDocument(singleton(new NumericDocValuesField(fieldName, 1001)));
                 },
-                result -> {
-                    InternalRange<?, ?> range = (InternalRange<?, ?>) result;
+                range -> {
                     List<? extends InternalRange.Bucket> ranges = range.getBuckets();
                     assertEquals(2, ranges.size());
                     assertEquals(2, ranges.get(0).getDocCount());
                     assertEquals(2, ranges.get(1).getDocCount());
                 },
                 field
-            ).withQuery(new MatchAllDocsQuery())
+            )
         );
     }
 
@@ -268,22 +261,21 @@ public class RangeAggregatorTests extends AggregatorTestCase {
         final String fieldName = "float";
         MappedFieldType field = new NumberFieldMapper.NumberFieldType(fieldName, NumberType.FLOAT);
         testCase(
-            new AggTestConfig<InternalAggregation>(
+            new AggTestConfig<InternalRange<?, ?>>(
                 new RangeAggregationBuilder("range").field(fieldName).addRange("r1", 0, 0.04D).addRange("r2", 0.04D, 1.0D),
                 iw -> {
                     LuceneDocument doc = new LuceneDocument();
                     NumberType.FLOAT.addFields(doc, fieldName, 0.04F, false, true, false);
                     iw.addDocument(doc);
                 },
-                result -> {
-                    InternalRange<?, ?> range = (InternalRange<?, ?>) result;
+                range -> {
                     List<? extends InternalRange.Bucket> ranges = range.getBuckets();
                     assertEquals(2, ranges.size());
                     assertEquals(0, ranges.get(0).getDocCount());
                     assertEquals(1, ranges.get(1).getDocCount());
                 },
                 field
-            ).withQuery(new MatchAllDocsQuery())
+            )
         );
     }
 
@@ -294,28 +286,27 @@ public class RangeAggregatorTests extends AggregatorTestCase {
         final String fieldName = "halfFloat";
         MappedFieldType field = new NumberFieldMapper.NumberFieldType(fieldName, NumberType.HALF_FLOAT);
         testCase(
-            new AggTestConfig<InternalAggregation>(
+            new AggTestConfig<InternalRange<?, ?>>(
                 new RangeAggregationBuilder("range").field(fieldName).addRange("r1", 0, 0.0152D).addRange("r2", 0.0152D, 1.0D),
                 iw -> {
                     LuceneDocument doc = new LuceneDocument();
                     NumberType.HALF_FLOAT.addFields(doc, fieldName, 0.0152F, false, true, false);
                     iw.addDocument(doc);
                 },
-                result -> {
-                    InternalRange<?, ?> range = (InternalRange<?, ?>) result;
+                range -> {
                     List<? extends InternalRange.Bucket> ranges = range.getBuckets();
                     assertEquals(2, ranges.size());
                     assertEquals(0, ranges.get(0).getDocCount());
                     assertEquals(1, ranges.get(1).getDocCount());
                 },
                 field
-            ).withQuery(new MatchAllDocsQuery())
+            )
         );
     }
 
     public void testUnboundedRanges() throws IOException {
         testCase(
-            new AggTestConfig<InternalAggregation>(
+            new AggTestConfig<InternalRange<?, ?>>(
                 new RangeAggregationBuilder("name").field(NUMBER_FIELD_NAME).addUnboundedTo(5).addUnboundedFrom(5),
                 iw -> {
                     iw.addDocument(
@@ -334,8 +325,7 @@ public class RangeAggregatorTests extends AggregatorTestCase {
                         )
                     );
                 },
-                result -> {
-                    InternalRange<?, ?> range = (InternalRange<?, ?>) result;
+                range -> {
                     List<? extends InternalRange.Bucket> ranges = range.getBuckets();
                     assertThat(ranges, hasSize(2));
                     assertThat(ranges.get(0).getFrom(), equalTo(Double.NEGATIVE_INFINITY));
@@ -359,7 +349,7 @@ public class RangeAggregatorTests extends AggregatorTestCase {
                     false,
                     null
                 )
-            ).withQuery(new MatchAllDocsQuery())
+            )
         );
     }
 
@@ -385,12 +375,12 @@ public class RangeAggregatorTests extends AggregatorTestCase {
         testCase(new AggTestConfig<InternalRange<?, ?>>(aggregationBuilder, iw -> {
             iw.addDocument(List.of(new SortedNumericDocValuesField(DATE_FIELD_NAME, milli1), new LongPoint(DATE_FIELD_NAME, milli1)));
             iw.addDocument(List.of(new SortedNumericDocValuesField(DATE_FIELD_NAME, milli2), new LongPoint(DATE_FIELD_NAME, milli2)));
-        }, (Consumer<InternalRange<?, ?>>) range -> {
+        }, range -> {
             List<? extends InternalRange.Bucket> ranges = range.getBuckets();
             assertEquals(1, ranges.size());
             assertEquals(1, ranges.get(0).getDocCount());
             assertTrue(AggregationInspectionHelper.hasValue(range));
-        }, new MappedFieldType[] { fieldType }).withQuery(new MatchAllDocsQuery()));
+        }, fieldType));
     }
 
     public void testDateFieldNanosecondResolution() throws IOException {
@@ -416,12 +406,12 @@ public class RangeAggregatorTests extends AggregatorTestCase {
         testCase(new AggTestConfig<InternalRange<?, ?>>(aggregationBuilder, iw -> {
             iw.addDocument(singleton(new SortedNumericDocValuesField(DATE_FIELD_NAME, TimeUnit.MILLISECONDS.toNanos(milli1))));
             iw.addDocument(singleton(new SortedNumericDocValuesField(DATE_FIELD_NAME, TimeUnit.MILLISECONDS.toNanos(milli2))));
-        }, (Consumer<InternalRange<?, ?>>) range -> {
+        }, range -> {
             List<? extends InternalRange.Bucket> ranges = range.getBuckets();
             assertEquals(1, ranges.size());
             assertEquals(1, ranges.get(0).getDocCount());
             assertTrue(AggregationInspectionHelper.hasValue(range));
-        }, new MappedFieldType[] { fieldType }).withQuery(new MatchAllDocsQuery()));
+        }, fieldType));
     }
 
     public void testMissingDateWithDateNanosField() throws IOException {
@@ -451,12 +441,12 @@ public class RangeAggregatorTests extends AggregatorTestCase {
             iw.addDocument(singleton(new SortedNumericDocValuesField(DATE_FIELD_NAME, TimeUnit.MILLISECONDS.toNanos(milli2))));
             // Missing will apply to this document
             iw.addDocument(singleton(new SortedNumericDocValuesField(NUMBER_FIELD_NAME, 7)));
-        }, (Consumer<InternalRange<?, ?>>) range -> {
+        }, range -> {
             List<? extends InternalRange.Bucket> ranges = range.getBuckets();
             assertEquals(1, ranges.size());
             assertEquals(2, ranges.get(0).getDocCount());
             assertTrue(AggregationInspectionHelper.hasValue(range));
-        }, new MappedFieldType[] { fieldType }).withQuery(new MatchAllDocsQuery()));
+        }, fieldType));
     }
 
     public void testNotFitIntoDouble() throws IOException {
@@ -486,13 +476,13 @@ public class RangeAggregatorTests extends AggregatorTestCase {
             for (long l = start; l < start + 150; l++) {
                 iw.addDocument(List.of(new SortedNumericDocValuesField(NUMBER_FIELD_NAME, l), new LongPoint(NUMBER_FIELD_NAME, l)));
             }
-        }, (Consumer<InternalRange<?, ?>>) range -> {
+        }, range -> {
             List<? extends InternalRange.Bucket> ranges = range.getBuckets();
             assertThat(ranges, hasSize(3));
             // If we had a native `double` range aggregator we'd get 50, 50, 50
             assertThat(ranges.stream().mapToLong(InternalRange.Bucket::getDocCount).toArray(), equalTo(new long[] { 44, 48, 58 }));
             assertTrue(AggregationInspectionHelper.hasValue(range));
-        }, new MappedFieldType[] { fieldType }).withQuery(new MatchAllDocsQuery()));
+        }, fieldType));
     }
 
     public void testMissingDateWithNumberField() throws IOException {
@@ -502,10 +492,10 @@ public class RangeAggregatorTests extends AggregatorTestCase {
 
         MappedFieldType fieldType = new NumberFieldMapper.NumberFieldType(NUMBER_FIELD_NAME, NumberFieldMapper.NumberType.INTEGER);
 
-        expectThrows(NumberFormatException.class, () -> testCase(new AggTestConfig<InternalAggregation>(aggregationBuilder, iw -> {
+        expectThrows(NumberFormatException.class, () -> testCase(new AggTestConfig<>(aggregationBuilder, iw -> {
             iw.addDocument(singleton(new NumericDocValuesField(NUMBER_FIELD_NAME, 7)));
             iw.addDocument(singleton(new NumericDocValuesField(NUMBER_FIELD_NAME, 1)));
-        }, range -> fail("Should have thrown exception"), fieldType).withQuery(new MatchAllDocsQuery())));
+        }, range -> fail("Should have thrown exception"), fieldType)));
     }
 
     public void testUnmappedWithMissingNumber() throws IOException {
@@ -518,12 +508,12 @@ public class RangeAggregatorTests extends AggregatorTestCase {
         testCase(new AggTestConfig<InternalRange<?, ?>>(aggregationBuilder, iw -> {
             iw.addDocument(singleton(new NumericDocValuesField(NUMBER_FIELD_NAME, 7)));
             iw.addDocument(singleton(new NumericDocValuesField(NUMBER_FIELD_NAME, 1)));
-        }, (Consumer<InternalRange<?, ?>>) range -> {
+        }, range -> {
             List<? extends InternalRange.Bucket> ranges = range.getBuckets();
             assertEquals(1, ranges.size());
             assertEquals(2, ranges.get(0).getDocCount());
             assertTrue(AggregationInspectionHelper.hasValue(range));
-        }, new MappedFieldType[] { fieldType }).withQuery(new MatchAllDocsQuery()));
+        }, fieldType));
     }
 
     public void testUnmappedWithMissingDate() throws IOException {
@@ -533,10 +523,10 @@ public class RangeAggregatorTests extends AggregatorTestCase {
 
         MappedFieldType fieldType = new NumberFieldMapper.NumberFieldType(NUMBER_FIELD_NAME, NumberFieldMapper.NumberType.INTEGER);
 
-        expectThrows(NumberFormatException.class, () -> testCase(new AggTestConfig<InternalAggregation>(aggregationBuilder, iw -> {
+        expectThrows(NumberFormatException.class, () -> testCase(new AggTestConfig<>(aggregationBuilder, iw -> {
             iw.addDocument(singleton(new NumericDocValuesField(NUMBER_FIELD_NAME, 7)));
             iw.addDocument(singleton(new NumericDocValuesField(NUMBER_FIELD_NAME, 1)));
-        }, range -> fail("Should have thrown exception"), fieldType).withQuery(new MatchAllDocsQuery())));
+        }, range -> fail("Should have thrown exception"), fieldType)));
     }
 
     public void testUnsupportedType() {
@@ -547,12 +537,12 @@ public class RangeAggregatorTests extends AggregatorTestCase {
         IllegalArgumentException e = expectThrows(
             IllegalArgumentException.class,
             () -> testCase(
-                new AggTestConfig<InternalAggregation>(
+                new AggTestConfig<>(
                     aggregationBuilder,
-                    iw -> { iw.addDocument(singleton(new SortedSetDocValuesField("string", new BytesRef("foo")))); },
+                    iw -> iw.addDocument(singleton(new SortedSetDocValuesField("string", new BytesRef("foo")))),
                     range -> fail("Should have thrown exception"),
                     fieldType
-                ).withQuery(new MatchAllDocsQuery())
+                )
             )
         );
         assertEquals("Field [not_a_number] of type [keyword] is not supported for aggregation [range]", e.getMessage());
@@ -565,10 +555,10 @@ public class RangeAggregatorTests extends AggregatorTestCase {
 
         MappedFieldType fieldType = new NumberFieldMapper.NumberFieldType(NUMBER_FIELD_NAME, NumberFieldMapper.NumberType.INTEGER);
 
-        expectThrows(NumberFormatException.class, () -> testCase(new AggTestConfig<InternalAggregation>(aggregationBuilder, iw -> {
+        expectThrows(NumberFormatException.class, () -> testCase(new AggTestConfig<>(aggregationBuilder, iw -> {
             iw.addDocument(singleton(new NumericDocValuesField(NUMBER_FIELD_NAME, 7)));
             iw.addDocument(singleton(new NumericDocValuesField(NUMBER_FIELD_NAME, 1)));
-        }, range -> fail("Should have thrown exception"), fieldType).withQuery(new MatchAllDocsQuery())));
+        }, range -> fail("Should have thrown exception"), fieldType)));
     }
 
     public void testUnmappedWithBadMissingField() {
@@ -578,10 +568,10 @@ public class RangeAggregatorTests extends AggregatorTestCase {
 
         MappedFieldType fieldType = new NumberFieldMapper.NumberFieldType(NUMBER_FIELD_NAME, NumberFieldMapper.NumberType.INTEGER);
 
-        expectThrows(NumberFormatException.class, () -> testCase(new AggTestConfig<InternalAggregation>(aggregationBuilder, iw -> {
+        expectThrows(NumberFormatException.class, () -> testCase(new AggTestConfig<>(aggregationBuilder, iw -> {
             iw.addDocument(singleton(new NumericDocValuesField(NUMBER_FIELD_NAME, 7)));
             iw.addDocument(singleton(new NumericDocValuesField(NUMBER_FIELD_NAME, 1)));
-        }, range -> fail("Should have thrown exception"), fieldType).withQuery(new MatchAllDocsQuery())));
+        }, range -> fail("Should have thrown exception"), fieldType)));
     }
 
     public void testSubAggCollectsFromSingleBucketIfOneRange() throws IOException {
@@ -618,13 +608,12 @@ public class RangeAggregatorTests extends AggregatorTestCase {
         aggregationBuilder.addRange(10d, 20d);
         aggregationBuilder.addRange(0d, 20d);
         aggregationBuilder.missing(100);            // Set a missing value to force the "normal" range collection instead of filter-based
-        testCase(new AggTestConfig<InternalAggregation>(aggregationBuilder, iw -> {
+        testCase(new AggTestConfig<InternalRange<?, ?>>(aggregationBuilder, iw -> {
             iw.addDocument(singleton(new NumericDocValuesField(NUMBER_FIELD_NAME, 11)));
             iw.addDocument(singleton(new NumericDocValuesField(NUMBER_FIELD_NAME, 7)));
             iw.addDocument(singleton(new NumericDocValuesField(NUMBER_FIELD_NAME, 2)));
             iw.addDocument(singleton(new NumericDocValuesField(NUMBER_FIELD_NAME, 3)));
-        }, result -> {
-            InternalRange<?, ?> range = (InternalRange<?, ?>) result;
+        }, range -> {
             List<? extends InternalRange.Bucket> ranges = range.getBuckets();
             assertThat(ranges, hasSize(3));
             assertThat(ranges.get(0).getFrom(), equalTo(0d));
@@ -637,7 +626,7 @@ public class RangeAggregatorTests extends AggregatorTestCase {
             assertThat(ranges.get(2).getTo(), equalTo(20d));
             assertThat(ranges.get(2).getDocCount(), equalTo(1L));
             assertTrue(AggregationInspectionHelper.hasValue(range));
-        }, new NumberFieldMapper.NumberFieldType(NUMBER_FIELD_NAME, NumberType.INTEGER)).withQuery(new MatchAllDocsQuery()));
+        }, new NumberFieldMapper.NumberFieldType(NUMBER_FIELD_NAME, NumberType.INTEGER)));
     }
 
     /**
@@ -759,14 +748,7 @@ public class RangeAggregatorTests extends AggregatorTestCase {
         aggregationBuilder.field(NUMBER_FIELD_NAME);
         aggregationBuilder.addRange(0d, 5d);
         aggregationBuilder.addRange(10d, 20d);
-        testCase(
-            new AggTestConfig<InternalRange<? extends InternalRange.Bucket, ? extends InternalRange<?, ?>>>(
-                aggregationBuilder,
-                buildIndex,
-                verify,
-                new MappedFieldType[] { fieldType }
-            ).withQuery(query)
-        );
+        testCase(new AggTestConfig<>(aggregationBuilder, buildIndex, verify, fieldType).withQuery(query));
     }
 
     private void simpleTestCase(
@@ -776,10 +758,10 @@ public class RangeAggregatorTests extends AggregatorTestCase {
     ) throws IOException {
         MappedFieldType fieldType = new NumberFieldMapper.NumberFieldType(NUMBER_FIELD_NAME, NumberFieldMapper.NumberType.INTEGER);
 
-        testCase(new AggTestConfig<InternalRange<? extends InternalRange.Bucket, ? extends InternalRange<?, ?>>>(aggregationBuilder, iw -> {
+        testCase(new AggTestConfig<>(aggregationBuilder, iw -> {
             iw.addDocument(singleton(new SortedNumericDocValuesField(NUMBER_FIELD_NAME, 7)));
             iw.addDocument(singleton(new SortedNumericDocValuesField(NUMBER_FIELD_NAME, 2)));
             iw.addDocument(singleton(new SortedNumericDocValuesField(NUMBER_FIELD_NAME, 3)));
-        }, verify, new MappedFieldType[] { fieldType }).withQuery(new MatchAllDocsQuery()));
+        }, verify, fieldType));
     }
 }

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/sampler/DiversifiedSamplerTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/sampler/DiversifiedSamplerTests.java
@@ -181,7 +181,7 @@ public class DiversifiedSamplerTests extends AggregatorTestCase {
             .shardSize(shardSize)
             .subAggregation(new TermsAggregationBuilder("terms").field("id"));
 
-        InternalSampler result = searchAndReduce(new AggTestConfig(indexSearcher, query, builder, genreFieldType, idFieldType));
+        InternalSampler result = searchAndReduce(new AggTestConfig<>(indexSearcher, query, builder, genreFieldType, idFieldType));
         verify.accept(result);
     }
 
@@ -199,7 +199,7 @@ public class DiversifiedSamplerTests extends AggregatorTestCase {
         DiversifiedAggregationBuilder builder = new DiversifiedAggregationBuilder("_name").field(genreFieldType.name())
             .subAggregation(new TermsAggregationBuilder("terms").field("id"));
 
-        InternalSampler result = searchAndReduce(new AggTestConfig(indexSearcher, builder, genreFieldType, idFieldType));
+        InternalSampler result = searchAndReduce(new AggTestConfig<>(indexSearcher, builder, genreFieldType, idFieldType));
         Terms terms = result.getAggregations().get("terms");
         assertEquals(0, terms.getBuckets().size());
         indexReader.close();

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/sampler/SamplerAggregatorTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/sampler/SamplerAggregatorTests.java
@@ -65,7 +65,7 @@ public class SamplerAggregatorTests extends AggregatorTestCase {
                 assertEquals("test expects a single segment", 1, reader.leaves().size());
                 IndexSearcher searcher = new IndexSearcher(reader);
                 InternalSampler sampler = searchAndReduce(
-                    new AggTestConfig(searcher, new TermQuery(new Term("text", "good")), aggBuilder, textFieldType, numericFieldType)
+                    new AggTestConfig<>(searcher, new TermQuery(new Term("text", "good")), aggBuilder, textFieldType, numericFieldType)
                 );
                 Min min = sampler.getAggregations().get("min");
                 assertEquals(5.0, min.value(), 0);
@@ -100,7 +100,7 @@ public class SamplerAggregatorTests extends AggregatorTestCase {
                 assertEquals("test expects a single segment", 1, reader.leaves().size());
                 IndexSearcher searcher = new IndexSearcher(reader);
                 InternalSampler sampler = searchAndReduce(
-                    new AggTestConfig(searcher, new TermQuery(new Term("text", "good")), aggBuilder, textFieldType, numericFieldType)
+                    new AggTestConfig<>(searcher, new TermQuery(new Term("text", "good")), aggBuilder, textFieldType, numericFieldType)
                 );
                 Min min = sampler.getAggregations().get("min");
                 assertEquals(3.0, min.value(), 0);
@@ -127,7 +127,7 @@ public class SamplerAggregatorTests extends AggregatorTestCase {
                 SamplerAggregationBuilder sampler = new SamplerAggregationBuilder("sampler").subAggregation(samplerChild);
                 samplerParent.subAggregation(sampler);
 
-                InternalFilters response = searchAndReduce(new AggTestConfig(searcher, samplerParent));
+                InternalFilters response = searchAndReduce(new AggTestConfig<>(searcher, samplerParent));
                 assertEquals(response.getBuckets().size(), 2);
                 assertEquals(response.getBuckets().get(0).getDocCount(), 1);
                 assertEquals(response.getBuckets().get(1).getDocCount(), 0);

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/sampler/random/RandomSamplerAggregatorTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/sampler/random/RandomSamplerAggregatorTests.java
@@ -16,6 +16,7 @@ import org.apache.lucene.tests.index.RandomIndexWriter;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.index.mapper.KeywordFieldMapper;
+import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.query.QueryBuilders;
 import org.elasticsearch.search.aggregations.AggregationBuilders;
 import org.elasticsearch.search.aggregations.AggregatorTestCase;
@@ -57,19 +58,20 @@ public class RandomSamplerAggregatorTests extends AggregatorTestCase {
         AtomicInteger integer = new AtomicInteger();
         do {
             testCase(
-                new RandomSamplerAggregationBuilder("my_agg").subAggregation(AggregationBuilders.avg("avg").field(NUMERIC_FIELD_NAME))
-                    .setProbability(0.25),
-                new MatchAllDocsQuery(),
-                RandomSamplerAggregatorTests::writeTestDocs,
-                (InternalRandomSampler result) -> {
-                    counts[integer.get()] = result.getDocCount();
-                    if (result.getDocCount() > 0) {
-                        Avg agg = result.getAggregations().get("avg");
-                        assertThat(Strings.toString(result), agg.getValue(), allOf(not(notANumber()), IsFinite.isFinite()));
-                        avgs[integer.get()] = agg.getValue();
-                    }
-                },
-                longField(NUMERIC_FIELD_NAME)
+                new AggTestConfig<InternalRandomSampler>(
+                    new RandomSamplerAggregationBuilder("my_agg").subAggregation(AggregationBuilders.avg("avg").field(NUMERIC_FIELD_NAME))
+                        .setProbability(0.25),
+                    RandomSamplerAggregatorTests::writeTestDocs,
+                    (InternalRandomSampler result) -> {
+                        counts[integer.get()] = result.getDocCount();
+                        if (result.getDocCount() > 0) {
+                            Avg agg = result.getAggregations().get("avg");
+                            assertThat(Strings.toString(result), agg.getValue(), allOf(not(notANumber()), IsFinite.isFinite()));
+                            avgs[integer.get()] = agg.getValue();
+                        }
+                    },
+                    new MappedFieldType[] { longField(NUMERIC_FIELD_NAME) }
+                ).withQuery(new MatchAllDocsQuery())
             );
         } while (integer.incrementAndGet() < 5);
         long avgCount = LongStream.of(counts).sum() / integer.get();
@@ -79,53 +81,58 @@ public class RandomSamplerAggregatorTests extends AggregatorTestCase {
     }
 
     public void testAggregationSamplingNestedAggsScaled() throws IOException {
+        // in case 0 docs get sampled, which can rarely happen
+        // in case the test index has many segments.
+        // subaggs should be scaled along with upper level aggs
+        // sampled doc count is NOT scaled, and thus should be lower
         testCase(
-            new RandomSamplerAggregationBuilder("my_agg").subAggregation(
-                AggregationBuilders.filter("filter_outer", QueryBuilders.termsQuery(KEYWORD_FIELD_NAME, KEYWORD_FIELD_VALUE))
-                    .subAggregation(
-                        AggregationBuilders.filter("filter_inner", QueryBuilders.termsQuery(KEYWORD_FIELD_NAME, KEYWORD_FIELD_VALUE))
-                    )
-            ).setProbability(0.25),
-            new MatchAllDocsQuery(),
-            RandomSamplerAggregatorTests::writeTestDocs,
-            (InternalRandomSampler result) -> {
-                long sampledDocCount = result.getDocCount();
-                Filter agg = result.getAggregations().get("filter_outer");
-                long outerFilterDocCount = agg.getDocCount();
-                Filter innerAgg = agg.getAggregations().get("filter_inner");
-                long innerFilterDocCount = innerAgg.getDocCount();
-                if (sampledDocCount == 0) {
-                    // in case 0 docs get sampled, which can rarely happen
-                    // in case the test index has many segments.
-                    assertThat(sampledDocCount, equalTo(0L));
-                    assertThat(innerFilterDocCount, equalTo(0L));
-                    assertThat(outerFilterDocCount, equalTo(0L));
-                } else {
-                    // subaggs should be scaled along with upper level aggs
-                    assertThat(outerFilterDocCount, equalTo(innerFilterDocCount));
-                    // sampled doc count is NOT scaled, and thus should be lower
-                    assertThat(outerFilterDocCount, greaterThan(sampledDocCount));
-                }
-            },
-            longField(NUMERIC_FIELD_NAME),
-            keywordField(KEYWORD_FIELD_NAME)
+            new AggTestConfig<InternalRandomSampler>(
+                new RandomSamplerAggregationBuilder("my_agg").subAggregation(
+                    AggregationBuilders.filter("filter_outer", QueryBuilders.termsQuery(KEYWORD_FIELD_NAME, KEYWORD_FIELD_VALUE))
+                        .subAggregation(
+                            AggregationBuilders.filter("filter_inner", QueryBuilders.termsQuery(KEYWORD_FIELD_NAME, KEYWORD_FIELD_VALUE))
+                        )
+                ).setProbability(0.25),
+                RandomSamplerAggregatorTests::writeTestDocs,
+                (InternalRandomSampler result) -> {
+                    long sampledDocCount = result.getDocCount();
+                    Filter agg = result.getAggregations().get("filter_outer");
+                    long outerFilterDocCount = agg.getDocCount();
+                    Filter innerAgg = agg.getAggregations().get("filter_inner");
+                    long innerFilterDocCount = innerAgg.getDocCount();
+                    if (sampledDocCount == 0) {
+                        // in case 0 docs get sampled, which can rarely happen
+                        // in case the test index has many segments.
+                        assertThat(sampledDocCount, equalTo(0L));
+                        assertThat(innerFilterDocCount, equalTo(0L));
+                        assertThat(outerFilterDocCount, equalTo(0L));
+                    } else {
+                        // subaggs should be scaled along with upper level aggs
+                        assertThat(outerFilterDocCount, equalTo(innerFilterDocCount));
+                        // sampled doc count is NOT scaled, and thus should be lower
+                        assertThat(outerFilterDocCount, greaterThan(sampledDocCount));
+                    }
+                },
+                new MappedFieldType[] { longField(NUMERIC_FIELD_NAME), keywordField(KEYWORD_FIELD_NAME) }
+            ).withQuery(new MatchAllDocsQuery())
         );
     }
 
     public void testAggregationSamplingOptimizedMinAndMax() throws IOException {
         testCase(
-            new RandomSamplerAggregationBuilder("my_agg").subAggregation(AggregationBuilders.max("max").field(RANDOM_NUMERIC_FIELD_NAME))
-                .subAggregation(AggregationBuilders.min("min").field(RANDOM_NUMERIC_FIELD_NAME))
-                .setProbability(0.25),
-            new MatchAllDocsQuery(),
-            RandomSamplerAggregatorTests::writeTestDocsWithTrueMinMax,
-            (InternalRandomSampler result) -> {
-                Min min = result.getAggregations().get("min");
-                Max max = result.getAggregations().get("max");
-                assertThat(min.value(), equalTo((double) TRUE_MIN));
-                assertThat(max.value(), equalTo((double) TRUE_MAX));
-            },
-            longField(RANDOM_NUMERIC_FIELD_NAME)
+            new AggTestConfig<InternalRandomSampler>(
+                new RandomSamplerAggregationBuilder("my_agg").subAggregation(
+                    AggregationBuilders.max("max").field(RANDOM_NUMERIC_FIELD_NAME)
+                ).subAggregation(AggregationBuilders.min("min").field(RANDOM_NUMERIC_FIELD_NAME)).setProbability(0.25),
+                RandomSamplerAggregatorTests::writeTestDocsWithTrueMinMax,
+                (InternalRandomSampler result) -> {
+                    Min min = result.getAggregations().get("min");
+                    Max max = result.getAggregations().get("max");
+                    assertThat(min.value(), equalTo((double) TRUE_MIN));
+                    assertThat(max.value(), equalTo((double) TRUE_MAX));
+                },
+                new MappedFieldType[] { longField(RANDOM_NUMERIC_FIELD_NAME) }
+            ).withQuery(new MatchAllDocsQuery())
         );
     }
 

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/sampler/random/RandomSamplerAggregatorTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/sampler/random/RandomSamplerAggregatorTests.java
@@ -11,12 +11,10 @@ package org.elasticsearch.search.aggregations.bucket.sampler.random;
 import org.apache.lucene.document.LongPoint;
 import org.apache.lucene.document.SortedNumericDocValuesField;
 import org.apache.lucene.document.SortedSetDocValuesField;
-import org.apache.lucene.search.MatchAllDocsQuery;
 import org.apache.lucene.tests.index.RandomIndexWriter;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.index.mapper.KeywordFieldMapper;
-import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.query.QueryBuilders;
 import org.elasticsearch.search.aggregations.AggregationBuilders;
 import org.elasticsearch.search.aggregations.AggregatorTestCase;
@@ -62,7 +60,7 @@ public class RandomSamplerAggregatorTests extends AggregatorTestCase {
                     new RandomSamplerAggregationBuilder("my_agg").subAggregation(AggregationBuilders.avg("avg").field(NUMERIC_FIELD_NAME))
                         .setProbability(0.25),
                     RandomSamplerAggregatorTests::writeTestDocs,
-                    (InternalRandomSampler result) -> {
+                    result -> {
                         counts[integer.get()] = result.getDocCount();
                         if (result.getDocCount() > 0) {
                             Avg agg = result.getAggregations().get("avg");
@@ -70,8 +68,8 @@ public class RandomSamplerAggregatorTests extends AggregatorTestCase {
                             avgs[integer.get()] = agg.getValue();
                         }
                     },
-                    new MappedFieldType[] { longField(NUMERIC_FIELD_NAME) }
-                ).withQuery(new MatchAllDocsQuery())
+                    longField(NUMERIC_FIELD_NAME)
+                )
             );
         } while (integer.incrementAndGet() < 5);
         long avgCount = LongStream.of(counts).sum() / integer.get();
@@ -94,7 +92,7 @@ public class RandomSamplerAggregatorTests extends AggregatorTestCase {
                         )
                 ).setProbability(0.25),
                 RandomSamplerAggregatorTests::writeTestDocs,
-                (InternalRandomSampler result) -> {
+                result -> {
                     long sampledDocCount = result.getDocCount();
                     Filter agg = result.getAggregations().get("filter_outer");
                     long outerFilterDocCount = agg.getDocCount();
@@ -113,8 +111,9 @@ public class RandomSamplerAggregatorTests extends AggregatorTestCase {
                         assertThat(outerFilterDocCount, greaterThan(sampledDocCount));
                     }
                 },
-                new MappedFieldType[] { longField(NUMERIC_FIELD_NAME), keywordField(KEYWORD_FIELD_NAME) }
-            ).withQuery(new MatchAllDocsQuery())
+                longField(NUMERIC_FIELD_NAME),
+                keywordField(KEYWORD_FIELD_NAME)
+            )
         );
     }
 
@@ -125,14 +124,14 @@ public class RandomSamplerAggregatorTests extends AggregatorTestCase {
                     AggregationBuilders.max("max").field(RANDOM_NUMERIC_FIELD_NAME)
                 ).subAggregation(AggregationBuilders.min("min").field(RANDOM_NUMERIC_FIELD_NAME)).setProbability(0.25),
                 RandomSamplerAggregatorTests::writeTestDocsWithTrueMinMax,
-                (InternalRandomSampler result) -> {
+                result -> {
                     Min min = result.getAggregations().get("min");
                     Max max = result.getAggregations().get("max");
                     assertThat(min.value(), equalTo((double) TRUE_MIN));
                     assertThat(max.value(), equalTo((double) TRUE_MAX));
                 },
-                new MappedFieldType[] { longField(RANDOM_NUMERIC_FIELD_NAME) }
-            ).withQuery(new MatchAllDocsQuery())
+                longField(RANDOM_NUMERIC_FIELD_NAME)
+            )
         );
     }
 

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/terms/BinaryTermsAggregatorTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/terms/BinaryTermsAggregatorTests.java
@@ -157,7 +157,7 @@ public class BinaryTermsAggregatorTests extends AggregatorTestCase {
                 MappedFieldType binaryFieldType = new BinaryFieldMapper.BinaryFieldType(BINARY_FIELD);
 
                 InternalMappedTerms<?, ?> rareTerms = searchAndReduce(
-                    new AggTestConfig(indexSearcher, query, aggregationBuilder, binaryFieldType)
+                    new AggTestConfig<>(indexSearcher, query, aggregationBuilder, binaryFieldType)
                 );
                 verify.accept(rareTerms);
             }

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/terms/KeywordTermsAggregatorTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/terms/KeywordTermsAggregatorTests.java
@@ -128,7 +128,7 @@ public class KeywordTermsAggregatorTests extends AggregatorTestCase {
                 }
 
                 InternalMappedTerms<?, ?> rareTerms = searchAndReduce(
-                    new AggTestConfig(indexSearcher, query, aggregationBuilder, keywordFieldType)
+                    new AggTestConfig<>(indexSearcher, query, aggregationBuilder, keywordFieldType)
                 );
                 verify.accept(rareTerms);
             }

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/terms/NumericTermsAggregatorTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/terms/NumericTermsAggregatorTests.java
@@ -167,7 +167,7 @@ public class NumericTermsAggregatorTests extends AggregatorTestCase {
                 MappedFieldType longFieldType = new NumberFieldMapper.NumberFieldType(LONG_FIELD, NumberFieldMapper.NumberType.LONG);
 
                 InternalMappedTerms<?, ?> rareTerms = searchAndReduce(
-                    new AggTestConfig(indexSearcher, query, aggregationBuilder, longFieldType)
+                    new AggTestConfig<>(indexSearcher, query, aggregationBuilder, longFieldType)
                 );
                 verify.accept(rareTerms);
             }

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/terms/RareTermsAggregatorTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/terms/RareTermsAggregatorTests.java
@@ -365,7 +365,7 @@ public class RareTermsAggregatorTests extends AggregatorTestCase {
 
                     MappedFieldType fieldType = new KeywordFieldMapper.KeywordFieldType("keyword");
 
-                    InternalGlobal result = searchAndReduce(new AggTestConfig(indexSearcher, globalBuilder, fieldType));
+                    InternalGlobal result = searchAndReduce(new AggTestConfig<>(indexSearcher, globalBuilder, fieldType));
                     InternalMultiBucketAggregation<?, ?> terms = result.getAggregations().get("terms");
                     assertThat(terms.getBuckets().size(), equalTo(3));
                     for (MultiBucketsAggregation.Bucket bucket : terms.getBuckets()) {
@@ -402,7 +402,7 @@ public class RareTermsAggregatorTests extends AggregatorTestCase {
                 try (IndexReader indexReader = wrapInMockESDirectoryReader(DirectoryReader.open(directory))) {
                     InternalNested result = searchAndReduce(
                         // match root document only
-                        new AggTestConfig(newIndexSearcher(indexReader), new FieldExistsQuery(PRIMARY_TERM_NAME), nested, fieldType)
+                        new AggTestConfig<>(newIndexSearcher(indexReader), new FieldExistsQuery(PRIMARY_TERM_NAME), nested, fieldType)
                     );
                     InternalMultiBucketAggregation<?, ?> terms = result.getAggregations().get("terms");
                     assertThat(terms.getBuckets().size(), equalTo(1));
@@ -443,7 +443,7 @@ public class RareTermsAggregatorTests extends AggregatorTestCase {
                                 IllegalStateException.class,
                                 () -> searchAndReduce(
                                     // match root document only
-                                    new AggTestConfig(
+                                    new AggTestConfig<>(
                                         newIndexSearcher(indexReader),
                                         new FieldExistsQuery(PRIMARY_TERM_NAME),
                                         nested,
@@ -462,7 +462,12 @@ public class RareTermsAggregatorTests extends AggregatorTestCase {
                         } else {
                             InternalNested result = searchAndReduce(
                                 // match root document only
-                                new AggTestConfig(newIndexSearcher(indexReader), new FieldExistsQuery(PRIMARY_TERM_NAME), nested, fieldType)
+                                new AggTestConfig<>(
+                                    newIndexSearcher(indexReader),
+                                    new FieldExistsQuery(PRIMARY_TERM_NAME),
+                                    nested,
+                                    fieldType
+                                )
                             );
                             InternalMultiBucketAggregation<?, ?> terms = result.getAggregations().get("terms");
                             assertThat(terms.getBuckets().size(), equalTo(2));
@@ -561,7 +566,7 @@ public class RareTermsAggregatorTests extends AggregatorTestCase {
                     keywordField(KEYWORD_FIELD),
                     longField(LONG_FIELD),
                     keywordField("even_odd") };
-                return searchAndReduce(new AggTestConfig(indexSearcher, query, aggregationBuilder, types));
+                return searchAndReduce(new AggTestConfig<>(indexSearcher, query, aggregationBuilder, types));
             }
         }
     }

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/terms/SignificantTermsAggregatorTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/terms/SignificantTermsAggregatorTests.java
@@ -129,7 +129,7 @@ public class SignificantTermsAggregatorTests extends AggregatorTestCase {
 
                 // Search "odd"
                 SignificantStringTerms terms = searchAndReduce(
-                    new AggTestConfig(searcher, new TermQuery(new Term("text", "odd")), sigAgg, textFieldType)
+                    new AggTestConfig<>(searcher, new TermQuery(new Term("text", "odd")), sigAgg, textFieldType)
                 );
 
                 assertThat(terms.getSubsetSize(), equalTo(5L));
@@ -139,7 +139,7 @@ public class SignificantTermsAggregatorTests extends AggregatorTestCase {
                 assertNotNull(terms.getBucketByKey("odd"));
 
                 // Search even
-                terms = searchAndReduce(new AggTestConfig(searcher, new TermQuery(new Term("text", "even")), sigAgg, textFieldType));
+                terms = searchAndReduce(new AggTestConfig<>(searcher, new TermQuery(new Term("text", "even")), sigAgg, textFieldType));
 
                 assertThat(terms.getSubsetSize(), equalTo(5L));
                 assertEquals(1, terms.getBuckets().size());
@@ -149,7 +149,7 @@ public class SignificantTermsAggregatorTests extends AggregatorTestCase {
 
                 // Search odd with regex includeexcludes
                 sigAgg.includeExclude(new IncludeExclude("o.d", null, null, null));
-                terms = searchAndReduce(new AggTestConfig(searcher, new TermQuery(new Term("text", "odd")), sigAgg, textFieldType));
+                terms = searchAndReduce(new AggTestConfig<>(searcher, new TermQuery(new Term("text", "odd")), sigAgg, textFieldType));
                 assertThat(terms.getSubsetSize(), equalTo(5L));
                 assertEquals(1, terms.getBuckets().size());
                 assertNotNull(terms.getBucketByKey("odd"));
@@ -162,7 +162,7 @@ public class SignificantTermsAggregatorTests extends AggregatorTestCase {
 
                 sigAgg.includeExclude(new IncludeExclude(null, null, oddStrings, evenStrings));
                 sigAgg.significanceHeuristic(heuristic);
-                terms = searchAndReduce(new AggTestConfig(searcher, new TermQuery(new Term("text", "odd")), sigAgg, textFieldType));
+                terms = searchAndReduce(new AggTestConfig<>(searcher, new TermQuery(new Term("text", "odd")), sigAgg, textFieldType));
                 assertThat(terms.getSubsetSize(), equalTo(5L));
                 assertEquals(1, terms.getBuckets().size());
                 assertNotNull(terms.getBucketByKey("odd"));
@@ -172,7 +172,7 @@ public class SignificantTermsAggregatorTests extends AggregatorTestCase {
                 assertNull(terms.getBucketByKey("regular"));
 
                 sigAgg.includeExclude(new IncludeExclude(null, null, evenStrings, oddStrings));
-                terms = searchAndReduce(new AggTestConfig(searcher, new TermQuery(new Term("text", "odd")), sigAgg, textFieldType));
+                terms = searchAndReduce(new AggTestConfig<>(searcher, new TermQuery(new Term("text", "odd")), sigAgg, textFieldType));
                 assertThat(terms.getSubsetSize(), equalTo(5L));
                 assertEquals(0, terms.getBuckets().size());
                 assertNull(terms.getBucketByKey("odd"));
@@ -226,7 +226,7 @@ public class SignificantTermsAggregatorTests extends AggregatorTestCase {
                 // Match all so background and foreground should be the same size
                 InternalRandomSampler randomSampler = searchAndReduce(
                     // randomly select the query, but both should hit the same docs, which is all of them.
-                    new AggTestConfig(
+                    new AggTestConfig<>(
                         searcher,
                         randomBoolean() ? new MatchAllDocsQuery() : new TermQuery(new Term("text", "common")),
                         randomSamplerAggregationBuilder,
@@ -277,7 +277,7 @@ public class SignificantTermsAggregatorTests extends AggregatorTestCase {
 
                 // Search "odd"
                 SignificantLongTerms terms = searchAndReduce(
-                    new AggTestConfig(searcher, new TermQuery(new Term("text", "odd")), sigNumAgg, longFieldType)
+                    new AggTestConfig<>(searcher, new TermQuery(new Term("text", "odd")), sigNumAgg, longFieldType)
                 );
                 assertEquals(1, terms.getBuckets().size());
                 assertThat(terms.getSubsetSize(), equalTo(5L));
@@ -286,7 +286,7 @@ public class SignificantTermsAggregatorTests extends AggregatorTestCase {
                 assertNull(terms.getBucketByKey(Long.toString(COMMON_VALUE)));
                 assertNotNull(terms.getBucketByKey(Long.toString(ODD_VALUE)));
 
-                terms = searchAndReduce(new AggTestConfig(searcher, new TermQuery(new Term("text", "even")), sigNumAgg, longFieldType));
+                terms = searchAndReduce(new AggTestConfig<>(searcher, new TermQuery(new Term("text", "even")), sigNumAgg, longFieldType));
                 assertEquals(1, terms.getBuckets().size());
                 assertThat(terms.getSubsetSize(), equalTo(5L));
 
@@ -321,7 +321,7 @@ public class SignificantTermsAggregatorTests extends AggregatorTestCase {
 
                 // Search "odd"
                 SignificantTerms terms = searchAndReduce(
-                    new AggTestConfig(searcher, new TermQuery(new Term("text", "odd")), sigAgg, textFieldType)
+                    new AggTestConfig<>(searcher, new TermQuery(new Term("text", "odd")), sigAgg, textFieldType)
                 );
                 assertEquals(0, terms.getBuckets().size());
 
@@ -397,20 +397,20 @@ public class SignificantTermsAggregatorTests extends AggregatorTestCase {
                 IndexSearcher searcher = new IndexSearcher(reader);
 
                 SignificantTerms evenTerms = searchAndReduce(
-                    new AggTestConfig(searcher, new TermQuery(new Term("text", "even")), agg, textFieldType)
+                    new AggTestConfig<>(searcher, new TermQuery(new Term("text", "even")), agg, textFieldType)
                 );
                 SignificantTerms aliasEvenTerms = searchAndReduce(
-                    new AggTestConfig(searcher, new TermQuery(new Term("text", "even")), aliasAgg, textFieldType)
+                    new AggTestConfig<>(searcher, new TermQuery(new Term("text", "even")), aliasAgg, textFieldType)
                 );
 
                 assertFalse(evenTerms.getBuckets().isEmpty());
                 assertEquals(evenTerms, aliasEvenTerms);
 
                 SignificantTerms oddTerms = searchAndReduce(
-                    new AggTestConfig(searcher, new TermQuery(new Term("text", "odd")), agg, textFieldType)
+                    new AggTestConfig<>(searcher, new TermQuery(new Term("text", "odd")), agg, textFieldType)
                 );
                 SignificantTerms aliasOddTerms = searchAndReduce(
-                    new AggTestConfig(searcher, new TermQuery(new Term("text", "odd")), aliasAgg, textFieldType)
+                    new AggTestConfig<>(searcher, new TermQuery(new Term("text", "odd")), aliasAgg, textFieldType)
                 );
 
                 assertFalse(oddTerms.getBuckets().isEmpty());
@@ -445,10 +445,10 @@ public class SignificantTermsAggregatorTests extends AggregatorTestCase {
                 IndexSearcher searcher = new IndexSearcher(reader);
 
                 SignificantTerms evenTerms = searchAndReduce(
-                    new AggTestConfig(searcher, new TermQuery(new Term("text", "even")), agg, textFieldType)
+                    new AggTestConfig<>(searcher, new TermQuery(new Term("text", "even")), agg, textFieldType)
                 );
                 SignificantTerms backgroundEvenTerms = searchAndReduce(
-                    new AggTestConfig(searcher, new TermQuery(new Term("text", "even")), backgroundAgg, textFieldType)
+                    new AggTestConfig<>(searcher, new TermQuery(new Term("text", "even")), backgroundAgg, textFieldType)
                 );
 
                 assertFalse(evenTerms.getBuckets().isEmpty());
@@ -483,7 +483,7 @@ public class SignificantTermsAggregatorTests extends AggregatorTestCase {
                     IndexSearcher searcher = newIndexSearcher(reader);
                     SignificantTermsAggregationBuilder request = new SignificantTermsAggregationBuilder("f").field("f")
                         .executionHint(executionHint);
-                    SignificantStringTerms result = searchAndReduce(new AggTestConfig(searcher, request, keywordField("f")));
+                    SignificantStringTerms result = searchAndReduce(new AggTestConfig<>(searcher, request, keywordField("f")));
                     assertThat(result.getSubsetSize(), equalTo(1L));
                 }
             }
@@ -503,7 +503,7 @@ public class SignificantTermsAggregatorTests extends AggregatorTestCase {
                 try (IndexReader reader = maybeWrapReaderEs(writer.getReader())) {
                     IndexSearcher searcher = newIndexSearcher(reader);
                     SignificantTermsAggregationBuilder request = new SignificantTermsAggregationBuilder("f").field("f");
-                    SignificantLongTerms result = searchAndReduce(new AggTestConfig(searcher, request, longField("f")));
+                    SignificantLongTerms result = searchAndReduce(new AggTestConfig<>(searcher, request, longField("f")));
                     assertThat(result.getSubsetSize(), equalTo(1L));
                 }
             }
@@ -535,7 +535,7 @@ public class SignificantTermsAggregatorTests extends AggregatorTestCase {
                     IndexSearcher searcher = newIndexSearcher(reader);
                     SignificantTermsAggregationBuilder request = new SignificantTermsAggregationBuilder("f").field("f")
                         .executionHint(executionHint);
-                    SignificantStringTerms result = searchAndReduce(new AggTestConfig(searcher, request, keywordField("f")));
+                    SignificantStringTerms result = searchAndReduce(new AggTestConfig<>(searcher, request, keywordField("f")));
                     assertThat(result.getSubsetSize(), equalTo(2L));
                 }
             }
@@ -557,7 +557,7 @@ public class SignificantTermsAggregatorTests extends AggregatorTestCase {
                 try (IndexReader reader = maybeWrapReaderEs(writer.getReader())) {
                     IndexSearcher searcher = newIndexSearcher(reader);
                     SignificantTermsAggregationBuilder request = new SignificantTermsAggregationBuilder("f").field("f");
-                    SignificantLongTerms result = searchAndReduce(new AggTestConfig(searcher, request, longField("f")));
+                    SignificantLongTerms result = searchAndReduce(new AggTestConfig<>(searcher, request, longField("f")));
                     assertThat(result.getSubsetSize(), equalTo(2L));
                 }
             }
@@ -600,7 +600,7 @@ public class SignificantTermsAggregatorTests extends AggregatorTestCase {
                         .executionHint(executionHint)
                         .subAggregation(jRequest);
                     SignificantStringTerms result = searchAndReduce(
-                        new AggTestConfig(searcher, request, keywordField("i"), keywordField("j"), keywordField("k"))
+                        new AggTestConfig<>(searcher, request, keywordField("i"), keywordField("j"), keywordField("k"))
                     );
                     assertThat(result.getSubsetSize(), equalTo(1000L));
                     for (int i = 0; i < 10; i++) {
@@ -649,7 +649,7 @@ public class SignificantTermsAggregatorTests extends AggregatorTestCase {
                                 .subAggregation(new SignificantTermsAggregationBuilder("k").field("k").minDocCount(0))
                         );
                     SignificantLongTerms result = searchAndReduce(
-                        new AggTestConfig(searcher, request, longField("i"), longField("j"), longField("k"))
+                        new AggTestConfig<>(searcher, request, longField("i"), longField("j"), longField("k"))
                     );
                     assertThat(result.getSubsetSize(), equalTo(1000L));
                     for (int i = 0; i < 10; i++) {

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/terms/SignificantTextAggregatorTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/terms/SignificantTextAggregatorTests.java
@@ -91,7 +91,7 @@ public class SignificantTextAggregatorTests extends AggregatorTestCase {
 
                 // Search "odd" which should have no duplication
                 InternalSampler sampler = searchAndReduce(
-                    new AggTestConfig(searcher, new TermQuery(new Term("text", "odd")), aggBuilder, textFieldType)
+                    new AggTestConfig<>(searcher, new TermQuery(new Term("text", "odd")), aggBuilder, textFieldType)
                 );
                 SignificantTerms terms = sampler.getAggregations().get("sig_text");
 
@@ -101,7 +101,9 @@ public class SignificantTextAggregatorTests extends AggregatorTestCase {
                 assertNotNull(terms.getBucketByKey("odd"));
 
                 // Search "even" which will have duplication
-                sampler = searchAndReduce(new AggTestConfig(searcher, new TermQuery(new Term("text", "even")), aggBuilder, textFieldType));
+                sampler = searchAndReduce(
+                    new AggTestConfig<>(searcher, new TermQuery(new Term("text", "even")), aggBuilder, textFieldType)
+                );
                 terms = sampler.getAggregations().get("sig_text");
 
                 assertNull(terms.getBucketByKey("odd"));
@@ -147,7 +149,7 @@ public class SignificantTextAggregatorTests extends AggregatorTestCase {
                     }
                     // Search "even" which should have duplication
                     InternalSampler sampler = searchAndReduce(
-                        new AggTestConfig(searcher, new TermQuery(new Term("text", "even")), aggBuilder, textFieldType)
+                        new AggTestConfig<>(searcher, new TermQuery(new Term("text", "even")), aggBuilder, textFieldType)
                     );
                     SignificantTerms terms = sampler.getAggregations().get("sig_text");
 
@@ -167,7 +169,7 @@ public class SignificantTextAggregatorTests extends AggregatorTestCase {
                     }
                     // Search "even" which should have duplication
                     InternalSampler sampler = searchAndReduce(
-                        new AggTestConfig(searcher, new TermQuery(new Term("text", "even")), aggBuilder, textFieldType)
+                        new AggTestConfig<>(searcher, new TermQuery(new Term("text", "even")), aggBuilder, textFieldType)
                     );
                     SignificantTerms terms = sampler.getAggregations().get("sig_text");
 
@@ -199,7 +201,7 @@ public class SignificantTextAggregatorTests extends AggregatorTestCase {
             try (IndexReader reader = DirectoryReader.open(w)) {
                 IndexSearcher searcher = new IndexSearcher(reader);
                 InternalSampler sampler = searchAndReduce(
-                    new AggTestConfig(searcher, new TermQuery(new Term("text", "odd")), aggBuilder, textFieldType)
+                    new AggTestConfig<>(searcher, new TermQuery(new Term("text", "odd")), aggBuilder, textFieldType)
                 );
                 SignificantTerms terms = sampler.getAggregations().get("sig_text");
                 assertTrue(terms.getBuckets().isEmpty());
@@ -233,10 +235,10 @@ public class SignificantTextAggregatorTests extends AggregatorTestCase {
                 SamplerAggregationBuilder aliasSamplerAgg = sampler("sampler").subAggregation(aliasAgg);
 
                 InternalSampler sampler = searchAndReduce(
-                    new AggTestConfig(searcher, new TermQuery(new Term("text", "odd")), samplerAgg, textFieldType)
+                    new AggTestConfig<>(searcher, new TermQuery(new Term("text", "odd")), samplerAgg, textFieldType)
                 );
                 InternalSampler aliasSampler = searchAndReduce(
-                    new AggTestConfig(searcher, new TermQuery(new Term("text", "odd")), aliasSamplerAgg, textFieldType)
+                    new AggTestConfig<>(searcher, new TermQuery(new Term("text", "odd")), aliasSamplerAgg, textFieldType)
                 );
 
                 SignificantTerms terms = sampler.getAggregations().get("sig_text");
@@ -244,9 +246,11 @@ public class SignificantTextAggregatorTests extends AggregatorTestCase {
                 assertFalse(terms.getBuckets().isEmpty());
                 assertEquals(terms, aliasTerms);
 
-                sampler = searchAndReduce(new AggTestConfig(searcher, new TermQuery(new Term("text", "even")), samplerAgg, textFieldType));
+                sampler = searchAndReduce(
+                    new AggTestConfig<>(searcher, new TermQuery(new Term("text", "even")), samplerAgg, textFieldType)
+                );
                 aliasSampler = searchAndReduce(
-                    new AggTestConfig(searcher, new TermQuery(new Term("text", "even")), aliasSamplerAgg, textFieldType)
+                    new AggTestConfig<>(searcher, new TermQuery(new Term("text", "even")), aliasSamplerAgg, textFieldType)
                 );
 
                 terms = sampler.getAggregations().get("sig_text");
@@ -276,7 +280,7 @@ public class SignificantTextAggregatorTests extends AggregatorTestCase {
                 assertEquals("test expects a single segment", 1, reader.leaves().size());
                 IndexSearcher searcher = new IndexSearcher(reader);
 
-                StringTerms terms = searchAndReduce(new AggTestConfig(searcher, aggBuilder, textFieldType, keywordField("kwd")));
+                StringTerms terms = searchAndReduce(new AggTestConfig<>(searcher, aggBuilder, textFieldType, keywordField("kwd")));
                 SignificantTerms sigOdd = terms.getBucketByKey("odd").getAggregations().get("sig_text");
                 assertNull(sigOdd.getBucketByKey("even"));
                 assertNull(sigOdd.getBucketByKey("duplicate"));
@@ -338,7 +342,7 @@ public class SignificantTextAggregatorTests extends AggregatorTestCase {
             try (IndexReader reader = DirectoryReader.open(w)) {
                 assertEquals("test expects a single segment", 1, reader.leaves().size());
                 IndexSearcher searcher = new IndexSearcher(reader);
-                searchAndReduce(new AggTestConfig(searcher, new TermQuery(new Term("text", "foo")), sigAgg, textFieldType));
+                searchAndReduce(new AggTestConfig<>(searcher, new TermQuery(new Term("text", "foo")), sigAgg, textFieldType));
                 // No significant results to be found in this test - only checking we don't end up
                 // with the internal exception discovered in issue https://github.com/elastic/elasticsearch/issues/25029
             }

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/terms/TermsAggregatorTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/terms/TermsAggregatorTests.java
@@ -400,7 +400,9 @@ public class TermsAggregatorTests extends AggregatorTestCase {
              * lets us create a fairly small test index.
              */
             int maxBuckets = 200;
-            StringTerms result = searchAndReduce(new AggTestConfig(searcher, aggregationBuilder, s1ft, s2ft).withMaxBuckets(maxBuckets));
+            StringTerms result = (StringTerms) searchAndReduce(
+                new AggTestConfig<>(searcher, aggregationBuilder, s1ft, s2ft).withMaxBuckets(maxBuckets)
+            );
             assertThat(
                 result.getBuckets().stream().map(StringTerms.Bucket::getKey).collect(toList()),
                 equalTo(List.of("b007", "b107", "b207", "b307", "b407", "b507", "b607", "b707", "b807", "b907", "b000"))
@@ -1371,7 +1373,7 @@ public class TermsAggregatorTests extends AggregatorTestCase {
 
                     MappedFieldType fieldType = new KeywordFieldMapper.KeywordFieldType("keyword");
 
-                    InternalGlobal result = searchAndReduce(new AggTestConfig(indexSearcher, globalBuilder, fieldType));
+                    InternalGlobal result = searchAndReduce(new AggTestConfig<>(indexSearcher, globalBuilder, fieldType));
                     InternalMultiBucketAggregation<?, ?> terms = result.getAggregations().get("terms");
                     assertThat(terms.getBuckets().size(), equalTo(3));
                     for (MultiBucketsAggregation.Bucket bucket : terms.getBuckets()) {
@@ -1422,7 +1424,7 @@ public class TermsAggregatorTests extends AggregatorTestCase {
                             {
                                 InternalNested result = searchAndReduce(
                                     // match root document only
-                                    new AggTestConfig(
+                                    new AggTestConfig<>(
                                         newSearcher(indexReader, false, true),
                                         new FieldExistsQuery(PRIMARY_TERM_NAME),
                                         nested,
@@ -1438,7 +1440,7 @@ public class TermsAggregatorTests extends AggregatorTestCase {
                                     .subAggregation(nested);
                                 InternalFilter result = searchAndReduce(
                                     // match root document only
-                                    new AggTestConfig(
+                                    new AggTestConfig<>(
                                         newSearcher(indexReader, false, true),
                                         new FieldExistsQuery(PRIMARY_TERM_NAME),
                                         filter,
@@ -1477,7 +1479,7 @@ public class TermsAggregatorTests extends AggregatorTestCase {
                 try (IndexReader indexReader = wrapInMockESDirectoryReader(DirectoryReader.open(directory))) {
                     StringTerms result = searchAndReduce(
                         // match root document only
-                        new AggTestConfig(
+                        new AggTestConfig<>(
                             newSearcher(indexReader, false, true),
                             Queries.newNonNestedFilter(),
                             terms,
@@ -1521,7 +1523,7 @@ public class TermsAggregatorTests extends AggregatorTestCase {
                 try (IndexReader indexReader = wrapInMockESDirectoryReader(DirectoryReader.open(directory))) {
                     LongTerms result = searchAndReduce(
                         // match root document only
-                        new AggTestConfig(
+                        new AggTestConfig<>(
                             newSearcher(indexReader, false, true),
                             new FieldExistsQuery(PRIMARY_TERM_NAME),
                             terms,
@@ -1705,7 +1707,7 @@ public class TermsAggregatorTests extends AggregatorTestCase {
                                 .executionHint(executionHint)
                                 .subAggregation(new TermsAggregationBuilder("k").field("k").executionHint(executionHint))
                         );
-                    StringTerms result = searchAndReduce(new AggTestConfig(searcher, request, ift, jft, kft));
+                    StringTerms result = searchAndReduce(new AggTestConfig<>(searcher, request, ift, jft, kft));
                     for (int i = 0; i < 10; i++) {
                         StringTerms.Bucket iBucket = result.getBucketByKey(Integer.toString(i));
                         assertThat(iBucket.getDocCount(), equalTo(100L));
@@ -1746,7 +1748,7 @@ public class TermsAggregatorTests extends AggregatorTestCase {
                             new TermsAggregationBuilder("j").field("j").subAggregation(new TermsAggregationBuilder("k").field("k"))
                         );
                     LongTerms result = searchAndReduce(
-                        new AggTestConfig(searcher, request, longField("i"), longField("j"), longField("k"))
+                        new AggTestConfig<>(searcher, request, longField("i"), longField("j"), longField("k"))
                     );
                     for (int i = 0; i < 10; i++) {
                         LongTerms.Bucket iBucket = result.getBucketByKey(Integer.toString(i));
@@ -1883,14 +1885,12 @@ public class TermsAggregatorTests extends AggregatorTestCase {
             try (DirectoryReader unwrapped = DirectoryReader.open(directory); IndexReader indexReader = wrapDirectoryReader(unwrapped)) {
                 IndexSearcher indexSearcher = newIndexSearcher(indexReader);
 
-                LongTerms terms = searchAndReduce(
-                    new AggTestConfig(
+                LongTerms terms = (LongTerms) searchAndReduce(
+                    new AggTestConfig<>(
                         indexSearcher,
                         aggregationBuilder,
-                        new NumberFieldMapper.NumberFieldType("a", NumberFieldMapper.NumberType.INTEGER),
-                        bIsString
-                            ? new KeywordFieldMapper.KeywordFieldType("b")
-                            : new NumberFieldMapper.NumberFieldType("b", NumberFieldMapper.NumberType.INTEGER)
+                        new NumberFieldType("a", NumberType.INTEGER),
+                        bIsString ? new KeywordFieldType("b") : new NumberFieldType("b", NumberType.INTEGER)
                     ).withSplitLeavesIntoSeperateAggregators(false).withMaxBuckets(Integer.MAX_VALUE)
                 );
                 assertThat(

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/terms/TermsAggregatorTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/terms/TermsAggregatorTests.java
@@ -264,7 +264,7 @@ public class TermsAggregatorTests extends AggregatorTestCase {
         TermsAggregationBuilder aggregationBuilder = new TermsAggregationBuilder("_name").executionHint(
             randomFrom(TermsAggregatorFactory.ExecutionMode.values()).toString()
         ).field("string").order(BucketOrder.key(true));
-        testCase(aggregationBuilder, new MatchAllDocsQuery(), iw -> {
+        testCase(new AggTestConfig<InternalTerms<?, ?>>(aggregationBuilder, iw -> {
             iw.addDocument(doc(fieldType, "a", "b"));
             iw.addDocument(doc(fieldType, "", "c", "a"));
             iw.addDocument(doc(fieldType, "b", "d"));
@@ -282,7 +282,7 @@ public class TermsAggregatorTests extends AggregatorTestCase {
             assertEquals("d", result.getBuckets().get(4).getKeyAsString());
             assertEquals(1L, result.getBuckets().get(4).getDocCount());
             assertTrue(AggregationInspectionHelper.hasValue(result));
-        }, fieldType);
+        }, new MappedFieldType[] { fieldType }).withQuery(new MatchAllDocsQuery()));
     }
 
     public void testStringShardMinDocCount() throws IOException {
@@ -294,7 +294,8 @@ public class TermsAggregatorTests extends AggregatorTestCase {
                 .minDocCount(2)
                 .shardMinDocCount(2)
                 .order(BucketOrder.key(true));
-            testCase(aggregationBuilder, new MatchAllDocsQuery(), iw -> {
+            // force single shard/segment
+            testCase(new AggTestConfig<InternalTerms<?, ?>>(aggregationBuilder, iw -> {
                 // force single shard/segment
                 iw.addDocuments(
                     Arrays.asList(doc(fieldType, "a", "b"), doc(fieldType, "", "c", "d"), doc(fieldType, "b", "d"), doc(fieldType, "b"))
@@ -305,14 +306,20 @@ public class TermsAggregatorTests extends AggregatorTestCase {
                 assertEquals(3L, result.getBuckets().get(0).getDocCount());
                 assertEquals("d", result.getBuckets().get(1).getKeyAsString());
                 assertEquals(2L, result.getBuckets().get(1).getDocCount());
-            }, fieldType);
+            }, new MappedFieldType[] { fieldType }).withQuery(new MatchAllDocsQuery()));
         }
     }
 
     public void testManyTerms() throws Exception {
         MappedFieldType fieldType = new KeywordFieldMapper.KeywordFieldType("string", randomBoolean(), true, Collections.emptyMap());
         TermsAggregationBuilder aggregationBuilder = new TermsAggregationBuilder("_name").executionHint(randomHint()).field("string");
-        testCase(aggregationBuilder, new MatchAllDocsQuery(), iw -> {
+        /*
+         * index all of the fields into a single segment so our
+         * test gets accurate counts. We *could* set the shard size
+         * very very high but we want to test the branch of the
+         * aggregation building code that picks the top sorted aggs.
+         */
+        testCase(new AggTestConfig<StringTerms>(aggregationBuilder, iw -> {
             /*
              * index all of the fields into a single segment so our
              * test gets accurate counts. We *could* set the shard size
@@ -333,7 +340,7 @@ public class TermsAggregatorTests extends AggregatorTestCase {
                 result.getBuckets().stream().map(StringTerms.Bucket::getKey).collect(toList()),
                 equalTo(List.of("b007", "b107", "b207", "b307", "b407", "b507", "b607", "b707", "b000", "b001"))
             );
-        }, fieldType);
+        }, new MappedFieldType[] { fieldType }).withQuery(new MatchAllDocsQuery()));
     }
 
     public void testManyTermsOrderBySubAgg() throws Exception {
@@ -344,7 +351,11 @@ public class TermsAggregatorTests extends AggregatorTestCase {
             .order(BucketOrder.aggregation("max", false))
             .field("string")
             .subAggregation(new MaxAggregationBuilder("max").field("long"));
-        testCase(aggregationBuilder, new MatchAllDocsQuery(), iw -> {
+        /*
+         * index all of the fields into a single segment so the
+         * collector picks up all the docs.
+         */
+        testCase(new AggTestConfig<StringTerms>(aggregationBuilder, iw -> {
             /*
              * index all of the fields into a single segment so the
              * collector picks up all the docs.
@@ -364,7 +375,7 @@ public class TermsAggregatorTests extends AggregatorTestCase {
             ).mapToObj(l -> String.format(Locale.ROOT, "b%03d", l)).collect(toList());
             Collections.reverse(expected);
             assertThat(result.getBuckets().stream().map(StringTerms.Bucket::getKey).collect(toList()), equalTo(expected));
-        }, kft, lft);
+        }, new MappedFieldType[] { kft, lft }).withQuery(new MatchAllDocsQuery()));
     }
 
     /**
@@ -440,119 +451,119 @@ public class TermsAggregatorTests extends AggregatorTestCase {
             .field("mv_field")
             .size(12)
             .order(BucketOrder.key(true));
-        testCase(builder, new MatchAllDocsQuery(), buildIndex, (StringTerms result) -> {
-            assertEquals(10, result.getBuckets().size());
-            assertEquals("val000", result.getBuckets().get(0).getKeyAsString());
-            assertEquals(1L, result.getBuckets().get(0).getDocCount());
-            assertEquals("val001", result.getBuckets().get(1).getKeyAsString());
-            assertEquals(1L, result.getBuckets().get(1).getDocCount());
-            assertEquals("val002", result.getBuckets().get(2).getKeyAsString());
-            assertEquals(1L, result.getBuckets().get(2).getDocCount());
-            assertEquals("val003", result.getBuckets().get(3).getKeyAsString());
-            assertEquals(1L, result.getBuckets().get(3).getDocCount());
-            assertEquals("val004", result.getBuckets().get(4).getKeyAsString());
-            assertEquals(1L, result.getBuckets().get(4).getDocCount());
-            assertEquals("val005", result.getBuckets().get(5).getKeyAsString());
-            assertEquals(1L, result.getBuckets().get(5).getDocCount());
-            assertEquals("val006", result.getBuckets().get(6).getKeyAsString());
-            assertEquals(1L, result.getBuckets().get(6).getDocCount());
-            assertEquals("val007", result.getBuckets().get(7).getKeyAsString());
-            assertEquals(1L, result.getBuckets().get(7).getDocCount());
-            assertEquals("val008", result.getBuckets().get(8).getKeyAsString());
-            assertEquals(1L, result.getBuckets().get(8).getDocCount());
-            assertEquals("val009", result.getBuckets().get(9).getKeyAsString());
-            assertEquals(1L, result.getBuckets().get(9).getDocCount());
-            assertTrue(AggregationInspectionHelper.hasValue(result));
-        }, ft1, ft2);
+        testCase(new AggTestConfig<StringTerms>(builder, buildIndex, (StringTerms result8) -> {
+            assertEquals(10, result8.getBuckets().size());
+            assertEquals("val000", result8.getBuckets().get(0).getKeyAsString());
+            assertEquals(1L, result8.getBuckets().get(0).getDocCount());
+            assertEquals("val001", result8.getBuckets().get(1).getKeyAsString());
+            assertEquals(1L, result8.getBuckets().get(1).getDocCount());
+            assertEquals("val002", result8.getBuckets().get(2).getKeyAsString());
+            assertEquals(1L, result8.getBuckets().get(2).getDocCount());
+            assertEquals("val003", result8.getBuckets().get(3).getKeyAsString());
+            assertEquals(1L, result8.getBuckets().get(3).getDocCount());
+            assertEquals("val004", result8.getBuckets().get(4).getKeyAsString());
+            assertEquals(1L, result8.getBuckets().get(4).getDocCount());
+            assertEquals("val005", result8.getBuckets().get(5).getKeyAsString());
+            assertEquals(1L, result8.getBuckets().get(5).getDocCount());
+            assertEquals("val006", result8.getBuckets().get(6).getKeyAsString());
+            assertEquals(1L, result8.getBuckets().get(6).getDocCount());
+            assertEquals("val007", result8.getBuckets().get(7).getKeyAsString());
+            assertEquals(1L, result8.getBuckets().get(7).getDocCount());
+            assertEquals("val008", result8.getBuckets().get(8).getKeyAsString());
+            assertEquals(1L, result8.getBuckets().get(8).getDocCount());
+            assertEquals("val009", result8.getBuckets().get(9).getKeyAsString());
+            assertEquals(1L, result8.getBuckets().get(9).getDocCount());
+            assertTrue(AggregationInspectionHelper.hasValue(result8));
+        }, new MappedFieldType[] { ft1, ft2 }).withQuery(new MatchAllDocsQuery()));
 
         builder = new TermsAggregationBuilder("_name").executionHint(executionHint)
             .includeExclude(new IncludeExclude("val00.+", null, null, null))
             .field("sv_field")
             .order(BucketOrder.key(true));
-        testCase(builder, new MatchAllDocsQuery(), buildIndex, (StringTerms result) -> {
-            assertEquals(5, result.getBuckets().size());
-            assertEquals("val001", result.getBuckets().get(0).getKeyAsString());
-            assertEquals(1L, result.getBuckets().get(0).getDocCount());
-            assertEquals("val003", result.getBuckets().get(1).getKeyAsString());
-            assertEquals(1L, result.getBuckets().get(1).getDocCount());
-            assertEquals("val005", result.getBuckets().get(2).getKeyAsString());
-            assertEquals(1L, result.getBuckets().get(2).getDocCount());
-            assertEquals("val007", result.getBuckets().get(3).getKeyAsString());
-            assertEquals(1L, result.getBuckets().get(3).getDocCount());
-            assertEquals("val009", result.getBuckets().get(4).getKeyAsString());
-            assertEquals(1L, result.getBuckets().get(4).getDocCount());
-            assertTrue(AggregationInspectionHelper.hasValue(result));
-        }, ft1, ft2);
+        testCase(new AggTestConfig<StringTerms>(builder, buildIndex, (StringTerms result7) -> {
+            assertEquals(5, result7.getBuckets().size());
+            assertEquals("val001", result7.getBuckets().get(0).getKeyAsString());
+            assertEquals(1L, result7.getBuckets().get(0).getDocCount());
+            assertEquals("val003", result7.getBuckets().get(1).getKeyAsString());
+            assertEquals(1L, result7.getBuckets().get(1).getDocCount());
+            assertEquals("val005", result7.getBuckets().get(2).getKeyAsString());
+            assertEquals(1L, result7.getBuckets().get(2).getDocCount());
+            assertEquals("val007", result7.getBuckets().get(3).getKeyAsString());
+            assertEquals(1L, result7.getBuckets().get(3).getDocCount());
+            assertEquals("val009", result7.getBuckets().get(4).getKeyAsString());
+            assertEquals(1L, result7.getBuckets().get(4).getDocCount());
+            assertTrue(AggregationInspectionHelper.hasValue(result7));
+        }, new MappedFieldType[] { ft1, ft2 }).withQuery(new MatchAllDocsQuery()));
 
         builder = new TermsAggregationBuilder("_name").executionHint(executionHint)
             .includeExclude(new IncludeExclude("val00.+", null, null, null))
             .field("sv_field")
             .order(BucketOrder.key(true));
-        testCase(builder, new MatchAllDocsQuery(), buildIndex, (StringTerms result) -> {
-            assertEquals(5, result.getBuckets().size());
-            assertEquals("val001", result.getBuckets().get(0).getKeyAsString());
-            assertEquals(1L, result.getBuckets().get(0).getDocCount());
-            assertEquals("val003", result.getBuckets().get(1).getKeyAsString());
-            assertEquals(1L, result.getBuckets().get(1).getDocCount());
-            assertEquals("val005", result.getBuckets().get(2).getKeyAsString());
-            assertEquals(1L, result.getBuckets().get(2).getDocCount());
-            assertEquals("val007", result.getBuckets().get(3).getKeyAsString());
-            assertEquals(1L, result.getBuckets().get(3).getDocCount());
-            assertEquals("val009", result.getBuckets().get(4).getKeyAsString());
-            assertEquals(1L, result.getBuckets().get(4).getDocCount());
-            assertTrue(AggregationInspectionHelper.hasValue(result));
-        }, ft1, ft2);
+        testCase(new AggTestConfig<StringTerms>(builder, buildIndex, (StringTerms result6) -> {
+            assertEquals(5, result6.getBuckets().size());
+            assertEquals("val001", result6.getBuckets().get(0).getKeyAsString());
+            assertEquals(1L, result6.getBuckets().get(0).getDocCount());
+            assertEquals("val003", result6.getBuckets().get(1).getKeyAsString());
+            assertEquals(1L, result6.getBuckets().get(1).getDocCount());
+            assertEquals("val005", result6.getBuckets().get(2).getKeyAsString());
+            assertEquals(1L, result6.getBuckets().get(2).getDocCount());
+            assertEquals("val007", result6.getBuckets().get(3).getKeyAsString());
+            assertEquals(1L, result6.getBuckets().get(3).getDocCount());
+            assertEquals("val009", result6.getBuckets().get(4).getKeyAsString());
+            assertEquals(1L, result6.getBuckets().get(4).getDocCount());
+            assertTrue(AggregationInspectionHelper.hasValue(result6));
+        }, new MappedFieldType[] { ft1, ft2 }).withQuery(new MatchAllDocsQuery()));
 
         builder = new TermsAggregationBuilder("_name").executionHint(executionHint)
             .includeExclude(new IncludeExclude("val00.+", "(val000|val001)", null, null))
             .field("mv_field")
             .order(BucketOrder.key(true));
-        testCase(builder, new MatchAllDocsQuery(), buildIndex, (StringTerms result) -> {
-            assertEquals(8, result.getBuckets().size());
-            assertEquals("val002", result.getBuckets().get(0).getKeyAsString());
-            assertEquals(1L, result.getBuckets().get(0).getDocCount());
-            assertEquals("val003", result.getBuckets().get(1).getKeyAsString());
-            assertEquals(1L, result.getBuckets().get(1).getDocCount());
-            assertEquals("val004", result.getBuckets().get(2).getKeyAsString());
-            assertEquals(1L, result.getBuckets().get(2).getDocCount());
-            assertEquals("val005", result.getBuckets().get(3).getKeyAsString());
-            assertEquals(1L, result.getBuckets().get(3).getDocCount());
-            assertEquals("val006", result.getBuckets().get(4).getKeyAsString());
-            assertEquals(1L, result.getBuckets().get(4).getDocCount());
-            assertEquals("val007", result.getBuckets().get(5).getKeyAsString());
-            assertEquals(1L, result.getBuckets().get(5).getDocCount());
-            assertEquals("val008", result.getBuckets().get(6).getKeyAsString());
-            assertEquals(1L, result.getBuckets().get(6).getDocCount());
-            assertEquals("val009", result.getBuckets().get(7).getKeyAsString());
-            assertEquals(1L, result.getBuckets().get(7).getDocCount());
-            assertTrue(AggregationInspectionHelper.hasValue(result));
-        }, ft1, ft2);
+        testCase(new AggTestConfig<StringTerms>(builder, buildIndex, (StringTerms result5) -> {
+            assertEquals(8, result5.getBuckets().size());
+            assertEquals("val002", result5.getBuckets().get(0).getKeyAsString());
+            assertEquals(1L, result5.getBuckets().get(0).getDocCount());
+            assertEquals("val003", result5.getBuckets().get(1).getKeyAsString());
+            assertEquals(1L, result5.getBuckets().get(1).getDocCount());
+            assertEquals("val004", result5.getBuckets().get(2).getKeyAsString());
+            assertEquals(1L, result5.getBuckets().get(2).getDocCount());
+            assertEquals("val005", result5.getBuckets().get(3).getKeyAsString());
+            assertEquals(1L, result5.getBuckets().get(3).getDocCount());
+            assertEquals("val006", result5.getBuckets().get(4).getKeyAsString());
+            assertEquals(1L, result5.getBuckets().get(4).getDocCount());
+            assertEquals("val007", result5.getBuckets().get(5).getKeyAsString());
+            assertEquals(1L, result5.getBuckets().get(5).getDocCount());
+            assertEquals("val008", result5.getBuckets().get(6).getKeyAsString());
+            assertEquals(1L, result5.getBuckets().get(6).getDocCount());
+            assertEquals("val009", result5.getBuckets().get(7).getKeyAsString());
+            assertEquals(1L, result5.getBuckets().get(7).getDocCount());
+            assertTrue(AggregationInspectionHelper.hasValue(result5));
+        }, new MappedFieldType[] { ft1, ft2 }).withQuery(new MatchAllDocsQuery()));
 
         builder = new TermsAggregationBuilder("_name").executionHint(executionHint)
             .includeExclude(new IncludeExclude(null, "val00.+", null, null))
             .field("mv_field")
             .order(BucketOrder.key(true));
-        testCase(builder, new MatchAllDocsQuery(), buildIndex, (StringTerms result) -> {
-            assertEquals(2, result.getBuckets().size());
-            assertEquals("val010", result.getBuckets().get(0).getKeyAsString());
-            assertEquals(1L, result.getBuckets().get(0).getDocCount());
-            assertEquals("val011", result.getBuckets().get(1).getKeyAsString());
-            assertEquals(1L, result.getBuckets().get(1).getDocCount());
-            assertTrue(AggregationInspectionHelper.hasValue(result));
-        }, ft1, ft2);
+        testCase(new AggTestConfig<StringTerms>(builder, buildIndex, (StringTerms result4) -> {
+            assertEquals(2, result4.getBuckets().size());
+            assertEquals("val010", result4.getBuckets().get(0).getKeyAsString());
+            assertEquals(1L, result4.getBuckets().get(0).getDocCount());
+            assertEquals("val011", result4.getBuckets().get(1).getKeyAsString());
+            assertEquals(1L, result4.getBuckets().get(1).getDocCount());
+            assertTrue(AggregationInspectionHelper.hasValue(result4));
+        }, new MappedFieldType[] { ft1, ft2 }).withQuery(new MatchAllDocsQuery()));
 
         builder = new TermsAggregationBuilder("_name").executionHint(executionHint)
             .includeExclude(new IncludeExclude(null, null, new TreeSet<>(Set.of(new BytesRef("val000"), new BytesRef("val010"))), null))
             .field("mv_field")
             .order(BucketOrder.key(true));
-        testCase(builder, new MatchAllDocsQuery(), buildIndex, (StringTerms result) -> {
-            assertEquals(2, result.getBuckets().size());
-            assertEquals("val000", result.getBuckets().get(0).getKeyAsString());
-            assertEquals(1L, result.getBuckets().get(0).getDocCount());
-            assertEquals("val010", result.getBuckets().get(1).getKeyAsString());
-            assertEquals(1L, result.getBuckets().get(1).getDocCount());
-            assertTrue(AggregationInspectionHelper.hasValue(result));
-        }, ft1, ft2);
+        testCase(new AggTestConfig<StringTerms>(builder, buildIndex, (StringTerms result3) -> {
+            assertEquals(2, result3.getBuckets().size());
+            assertEquals("val000", result3.getBuckets().get(0).getKeyAsString());
+            assertEquals(1L, result3.getBuckets().get(0).getDocCount());
+            assertEquals("val010", result3.getBuckets().get(1).getKeyAsString());
+            assertEquals(1L, result3.getBuckets().get(1).getDocCount());
+            assertTrue(AggregationInspectionHelper.hasValue(result3));
+        }, new MappedFieldType[] { ft1, ft2 }).withQuery(new MatchAllDocsQuery()));
 
         builder = new TermsAggregationBuilder("_name").executionHint(executionHint)
             .includeExclude(
@@ -578,14 +589,14 @@ public class TermsAggregatorTests extends AggregatorTestCase {
             )
             .field("mv_field")
             .order(BucketOrder.key(true));
-        testCase(builder, new MatchAllDocsQuery(), buildIndex, (StringTerms result) -> {
-            assertEquals(2, result.getBuckets().size());
-            assertEquals("val000", result.getBuckets().get(0).getKeyAsString());
-            assertEquals(1L, result.getBuckets().get(0).getDocCount());
-            assertEquals("val010", result.getBuckets().get(1).getKeyAsString());
-            assertEquals(1L, result.getBuckets().get(1).getDocCount());
-            assertTrue(AggregationInspectionHelper.hasValue(result));
-        }, ft1, ft2);
+        testCase(new AggTestConfig<StringTerms>(builder, buildIndex, (StringTerms result2) -> {
+            assertEquals(2, result2.getBuckets().size());
+            assertEquals("val000", result2.getBuckets().get(0).getKeyAsString());
+            assertEquals(1L, result2.getBuckets().get(0).getDocCount());
+            assertEquals("val010", result2.getBuckets().get(1).getKeyAsString());
+            assertEquals(1L, result2.getBuckets().get(1).getDocCount());
+            assertTrue(AggregationInspectionHelper.hasValue(result2));
+        }, new MappedFieldType[] { ft1, ft2 }).withQuery(new MatchAllDocsQuery()));
 
         builder = new TermsAggregationBuilder("_name").executionHint(executionHint)
             .includeExclude(
@@ -609,14 +620,14 @@ public class TermsAggregatorTests extends AggregatorTestCase {
             )
             .field("mv_field")
             .order(BucketOrder.key(true));
-        testCase(builder, new MatchAllDocsQuery(), buildIndex, (StringTerms result) -> {
-            assertEquals(2, result.getBuckets().size());
-            assertEquals("val000", result.getBuckets().get(0).getKeyAsString());
-            assertEquals(1L, result.getBuckets().get(0).getDocCount());
-            assertEquals("val009", result.getBuckets().get(1).getKeyAsString());
-            assertEquals(1L, result.getBuckets().get(1).getDocCount());
-            assertTrue(AggregationInspectionHelper.hasValue(result));
-        }, ft1, ft2);
+        testCase(new AggTestConfig<StringTerms>(builder, buildIndex, (StringTerms result1) -> {
+            assertEquals(2, result1.getBuckets().size());
+            assertEquals("val000", result1.getBuckets().get(0).getKeyAsString());
+            assertEquals(1L, result1.getBuckets().get(0).getDocCount());
+            assertEquals("val009", result1.getBuckets().get(1).getKeyAsString());
+            assertEquals(1L, result1.getBuckets().get(1).getDocCount());
+            assertTrue(AggregationInspectionHelper.hasValue(result1));
+        }, new MappedFieldType[] { ft1, ft2 }).withQuery(new MatchAllDocsQuery()));
 
         builder = new TermsAggregationBuilder("_name").executionHint(executionHint)
             .includeExclude(
@@ -629,14 +640,14 @@ public class TermsAggregatorTests extends AggregatorTestCase {
             )
             .field("mv_field")
             .order(BucketOrder.key(true));
-        testCase(builder, new MatchAllDocsQuery(), buildIndex, (StringTerms result) -> {
+        testCase(new AggTestConfig<StringTerms>(builder, buildIndex, (StringTerms result) -> {
             assertEquals(2, result.getBuckets().size());
             assertEquals("val001", result.getBuckets().get(0).getKeyAsString());
             assertEquals(1L, result.getBuckets().get(0).getDocCount());
             assertEquals("val002", result.getBuckets().get(1).getKeyAsString());
             assertEquals(1L, result.getBuckets().get(1).getDocCount());
             assertTrue(AggregationInspectionHelper.hasValue(result));
-        }, ft1, ft2);
+        }, new MappedFieldType[] { ft1, ft2 }).withQuery(new MatchAllDocsQuery()));
     }
 
     private List<IndexableField> doc(MappedFieldType ft1, MappedFieldType ft2, String f1v1, String f1v2, String f2v) {
@@ -1211,7 +1222,7 @@ public class TermsAggregatorTests extends AggregatorTestCase {
             Collections.emptyMap(),
             false
         );
-        testCase(new TermsAggregationBuilder("_name").field("field"), new MatchAllDocsQuery(), iw -> {
+        testCase(new AggTestConfig<StringTerms>(new TermsAggregationBuilder("_name").field("field"), iw -> {
             Document document = new Document();
             InetAddress point = InetAddresses.forString("192.168.100.42");
             document.add(new SortedSetDocValuesField("field", new BytesRef(InetAddressPoint.encode(point))));
@@ -1224,7 +1235,7 @@ public class TermsAggregatorTests extends AggregatorTestCase {
             assertEquals(1, result.getBuckets().size());
             assertEquals("192.168.100.42", result.getBuckets().get(0).getKey());
             assertEquals(1, result.getBuckets().get(0).getDocCount());
-        }, fieldType);
+        }, new MappedFieldType[] { fieldType }).withQuery(new MatchAllDocsQuery()));
     }
 
     public void testNestedTermsAgg() throws Exception {
@@ -1664,12 +1675,15 @@ public class TermsAggregatorTests extends AggregatorTestCase {
             .field("number")
             .script(new Script(ScriptType.INLINE, MockScriptEngine.NAME, STRING_SCRIPT_NAME, Collections.emptyMap()));
 
-        testCase(aggregationBuilder, new MatchAllDocsQuery(), iw -> {
+        testCase(new AggTestConfig<InternalTerms<?, ?>>(aggregationBuilder, iw -> {
             final int numDocs = 10;
             for (int i = 0; i < numDocs; i++) {
                 iw.addDocument(singleton(new NumericDocValuesField("number", i + 1)));
             }
-        }, (Consumer<InternalTerms<?, ?>>) terms -> { assertTrue(AggregationInspectionHelper.hasValue(terms)); }, fieldType);
+        },
+            (Consumer<InternalTerms<?, ?>>) terms -> { assertTrue(AggregationInspectionHelper.hasValue(terms)); },
+            new MappedFieldType[] { fieldType }
+        ).withQuery(new MatchAllDocsQuery()));
     }
 
     public void testThreeLayerStringViaGlobalOrds() throws IOException {
@@ -1820,13 +1834,16 @@ public class TermsAggregatorTests extends AggregatorTestCase {
             .format("$###.00")
             .missing(randomFrom(42, "$42", 42.0));
 
-        testCase(aggregationBuilder, new MatchAllDocsQuery(), iw -> {
+        testCase(new AggTestConfig<InternalTerms<?, ?>>(aggregationBuilder, iw -> {
             final int numDocs = 10;
             iw.addDocument(singleton(new NumericDocValuesField("not_number", 0)));
             for (int i = 1; i < numDocs; i++) {
                 iw.addDocument(singleton(new NumericDocValuesField("number", i + 1)));
             }
-        }, (Consumer<InternalTerms<?, ?>>) terms -> assertTrue(AggregationInspectionHelper.hasValue(terms)), fieldType);
+        },
+            (Consumer<InternalTerms<?, ?>>) terms -> assertTrue(AggregationInspectionHelper.hasValue(terms)),
+            new MappedFieldType[] { fieldType }
+        ).withQuery(new MatchAllDocsQuery()));
     }
 
     public void testFormatCannotParseMissing() throws IOException {
@@ -1834,13 +1851,18 @@ public class TermsAggregatorTests extends AggregatorTestCase {
 
         TermsAggregationBuilder aggregationBuilder = new TermsAggregationBuilder("name").field("number").format("$###.00").missing("42");
 
-        RuntimeException ex = expectThrows(RuntimeException.class, () -> testCase(aggregationBuilder, new MatchAllDocsQuery(), iw -> {
-            final int numDocs = 10;
-            iw.addDocument(singleton(new NumericDocValuesField("not_number", 0)));
-            for (int i = 1; i < numDocs; i++) {
-                iw.addDocument(singleton(new NumericDocValuesField("number", i + 1)));
-            }
-        }, (Consumer<InternalTerms<?, ?>>) terms -> fail("Should have thrown"), fieldType));
+        RuntimeException ex = expectThrows(
+            RuntimeException.class,
+            () -> testCase(new AggTestConfig<InternalTerms<?, ?>>(aggregationBuilder, iw -> {
+                final int numDocs = 10;
+                iw.addDocument(singleton(new NumericDocValuesField("not_number", 0)));
+                for (int i = 1; i < numDocs; i++) {
+                    iw.addDocument(singleton(new NumericDocValuesField("number", i + 1)));
+                }
+            }, (Consumer<InternalTerms<?, ?>>) terms -> fail("Should have thrown"), new MappedFieldType[] { fieldType }).withQuery(
+                new MatchAllDocsQuery()
+            ))
+        );
 
         assertThat(ex.getMessage(), equalTo("Cannot parse the value [42] using the pattern [$###.00]"));
     }
@@ -1948,16 +1970,16 @@ public class TermsAggregatorTests extends AggregatorTestCase {
                 )
             );
         };
-        testCase(builder, new MatchAllDocsQuery(), buildIndex, (InternalDateHistogram dh) -> {
+        testCase(new AggTestConfig<InternalDateHistogram>(builder, buildIndex, (InternalDateHistogram dh) -> {
             assertThat(
                 dh.getBuckets().stream().map(InternalDateHistogram.Bucket::getKeyAsString).collect(toList()),
                 equalTo(List.of("2020-01-01T00:00:00.000Z", "2021-01-01T00:00:00.000Z"))
             );
-            StringTerms terms = dh.getBuckets().get(0).getAggregations().get("k");
-            assertThat(terms.getBuckets().stream().map(StringTerms.Bucket::getKey).collect(toList()), equalTo(List.of("a", "b")));
-            terms = dh.getBuckets().get(1).getAggregations().get("k");
-            assertThat(terms.getBuckets().stream().map(StringTerms.Bucket::getKey).collect(toList()), equalTo(List.of("a")));
-        }, dft, kft);
+            StringTerms terms1 = dh.getBuckets().get(0).getAggregations().get("k");
+            assertThat(terms1.getBuckets().stream().map(StringTerms.Bucket::getKey).collect(toList()), equalTo(List.of("a", "b")));
+            terms1 = dh.getBuckets().get(1).getAggregations().get("k");
+            assertThat(terms1.getBuckets().stream().map(StringTerms.Bucket::getKey).collect(toList()), equalTo(List.of("a")));
+        }, new MappedFieldType[] { dft, kft }).withQuery(new MatchAllDocsQuery()));
         withAggregator(builder, new MatchAllDocsQuery(), buildIndex, (searcher, aggregator) -> {
             TermsAggregator terms = (TermsAggregator) aggregator.subAggregator("k");
             Map<String, Object> info = new HashMap<>();

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/terms/TermsAggregatorTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/terms/TermsAggregatorTests.java
@@ -132,7 +132,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.TreeSet;
 import java.util.function.BiFunction;
-import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.stream.LongStream;
 
@@ -269,7 +268,7 @@ public class TermsAggregatorTests extends AggregatorTestCase {
             iw.addDocument(doc(fieldType, "", "c", "a"));
             iw.addDocument(doc(fieldType, "b", "d"));
             iw.addDocument(doc(fieldType, ""));
-        }, (InternalTerms<?, ?> result) -> {
+        }, result -> {
             assertEquals(5, result.getBuckets().size());
             assertEquals("", result.getBuckets().get(0).getKeyAsString());
             assertEquals(2L, result.getBuckets().get(0).getDocCount());
@@ -282,7 +281,7 @@ public class TermsAggregatorTests extends AggregatorTestCase {
             assertEquals("d", result.getBuckets().get(4).getKeyAsString());
             assertEquals(1L, result.getBuckets().get(4).getDocCount());
             assertTrue(AggregationInspectionHelper.hasValue(result));
-        }, new MappedFieldType[] { fieldType }).withQuery(new MatchAllDocsQuery()));
+        }, fieldType));
     }
 
     public void testStringShardMinDocCount() throws IOException {
@@ -300,13 +299,13 @@ public class TermsAggregatorTests extends AggregatorTestCase {
                 iw.addDocuments(
                     Arrays.asList(doc(fieldType, "a", "b"), doc(fieldType, "", "c", "d"), doc(fieldType, "b", "d"), doc(fieldType, "b"))
                 );
-            }, (InternalTerms<?, ?> result) -> {
+            }, result -> {
                 assertEquals(2, result.getBuckets().size());
                 assertEquals("b", result.getBuckets().get(0).getKeyAsString());
                 assertEquals(3L, result.getBuckets().get(0).getDocCount());
                 assertEquals("d", result.getBuckets().get(1).getKeyAsString());
                 assertEquals(2L, result.getBuckets().get(1).getDocCount());
-            }, new MappedFieldType[] { fieldType }).withQuery(new MatchAllDocsQuery()));
+            }, fieldType));
         }
     }
 
@@ -335,12 +334,12 @@ public class TermsAggregatorTests extends AggregatorTestCase {
                 }
             }
             iw.addDocuments(docs);
-        }, (StringTerms result) -> {
+        }, result -> {
             assertThat(
                 result.getBuckets().stream().map(StringTerms.Bucket::getKey).collect(toList()),
                 equalTo(List.of("b007", "b107", "b207", "b307", "b407", "b507", "b607", "b707", "b000", "b001"))
             );
-        }, new MappedFieldType[] { fieldType }).withQuery(new MatchAllDocsQuery()));
+        }, fieldType));
     }
 
     public void testManyTermsOrderBySubAgg() throws Exception {
@@ -368,14 +367,14 @@ public class TermsAggregatorTests extends AggregatorTestCase {
                 docs.add(doc);
             }
             iw.addDocuments(docs);
-        }, (StringTerms result) -> {
+        }, result -> {
             List<String> expected = LongStream.range(
                 TermsAggregatorFactory.MAX_ORDS_TO_TRY_FILTERS - 210,
                 TermsAggregatorFactory.MAX_ORDS_TO_TRY_FILTERS - 200
             ).mapToObj(l -> String.format(Locale.ROOT, "b%03d", l)).collect(toList());
             Collections.reverse(expected);
             assertThat(result.getBuckets().stream().map(StringTerms.Bucket::getKey).collect(toList()), equalTo(expected));
-        }, new MappedFieldType[] { kft, lft }).withQuery(new MatchAllDocsQuery()));
+        }, kft, lft));
     }
 
     /**
@@ -451,119 +450,119 @@ public class TermsAggregatorTests extends AggregatorTestCase {
             .field("mv_field")
             .size(12)
             .order(BucketOrder.key(true));
-        testCase(new AggTestConfig<StringTerms>(builder, buildIndex, (StringTerms result8) -> {
-            assertEquals(10, result8.getBuckets().size());
-            assertEquals("val000", result8.getBuckets().get(0).getKeyAsString());
-            assertEquals(1L, result8.getBuckets().get(0).getDocCount());
-            assertEquals("val001", result8.getBuckets().get(1).getKeyAsString());
-            assertEquals(1L, result8.getBuckets().get(1).getDocCount());
-            assertEquals("val002", result8.getBuckets().get(2).getKeyAsString());
-            assertEquals(1L, result8.getBuckets().get(2).getDocCount());
-            assertEquals("val003", result8.getBuckets().get(3).getKeyAsString());
-            assertEquals(1L, result8.getBuckets().get(3).getDocCount());
-            assertEquals("val004", result8.getBuckets().get(4).getKeyAsString());
-            assertEquals(1L, result8.getBuckets().get(4).getDocCount());
-            assertEquals("val005", result8.getBuckets().get(5).getKeyAsString());
-            assertEquals(1L, result8.getBuckets().get(5).getDocCount());
-            assertEquals("val006", result8.getBuckets().get(6).getKeyAsString());
-            assertEquals(1L, result8.getBuckets().get(6).getDocCount());
-            assertEquals("val007", result8.getBuckets().get(7).getKeyAsString());
-            assertEquals(1L, result8.getBuckets().get(7).getDocCount());
-            assertEquals("val008", result8.getBuckets().get(8).getKeyAsString());
-            assertEquals(1L, result8.getBuckets().get(8).getDocCount());
-            assertEquals("val009", result8.getBuckets().get(9).getKeyAsString());
-            assertEquals(1L, result8.getBuckets().get(9).getDocCount());
-            assertTrue(AggregationInspectionHelper.hasValue(result8));
-        }, new MappedFieldType[] { ft1, ft2 }).withQuery(new MatchAllDocsQuery()));
+        testCase(new AggTestConfig<StringTerms>(builder, buildIndex, result -> {
+            assertEquals(10, result.getBuckets().size());
+            assertEquals("val000", result.getBuckets().get(0).getKeyAsString());
+            assertEquals(1L, result.getBuckets().get(0).getDocCount());
+            assertEquals("val001", result.getBuckets().get(1).getKeyAsString());
+            assertEquals(1L, result.getBuckets().get(1).getDocCount());
+            assertEquals("val002", result.getBuckets().get(2).getKeyAsString());
+            assertEquals(1L, result.getBuckets().get(2).getDocCount());
+            assertEquals("val003", result.getBuckets().get(3).getKeyAsString());
+            assertEquals(1L, result.getBuckets().get(3).getDocCount());
+            assertEquals("val004", result.getBuckets().get(4).getKeyAsString());
+            assertEquals(1L, result.getBuckets().get(4).getDocCount());
+            assertEquals("val005", result.getBuckets().get(5).getKeyAsString());
+            assertEquals(1L, result.getBuckets().get(5).getDocCount());
+            assertEquals("val006", result.getBuckets().get(6).getKeyAsString());
+            assertEquals(1L, result.getBuckets().get(6).getDocCount());
+            assertEquals("val007", result.getBuckets().get(7).getKeyAsString());
+            assertEquals(1L, result.getBuckets().get(7).getDocCount());
+            assertEquals("val008", result.getBuckets().get(8).getKeyAsString());
+            assertEquals(1L, result.getBuckets().get(8).getDocCount());
+            assertEquals("val009", result.getBuckets().get(9).getKeyAsString());
+            assertEquals(1L, result.getBuckets().get(9).getDocCount());
+            assertTrue(AggregationInspectionHelper.hasValue(result));
+        }, ft1, ft2));
 
         builder = new TermsAggregationBuilder("_name").executionHint(executionHint)
             .includeExclude(new IncludeExclude("val00.+", null, null, null))
             .field("sv_field")
             .order(BucketOrder.key(true));
-        testCase(new AggTestConfig<StringTerms>(builder, buildIndex, (StringTerms result7) -> {
-            assertEquals(5, result7.getBuckets().size());
-            assertEquals("val001", result7.getBuckets().get(0).getKeyAsString());
-            assertEquals(1L, result7.getBuckets().get(0).getDocCount());
-            assertEquals("val003", result7.getBuckets().get(1).getKeyAsString());
-            assertEquals(1L, result7.getBuckets().get(1).getDocCount());
-            assertEquals("val005", result7.getBuckets().get(2).getKeyAsString());
-            assertEquals(1L, result7.getBuckets().get(2).getDocCount());
-            assertEquals("val007", result7.getBuckets().get(3).getKeyAsString());
-            assertEquals(1L, result7.getBuckets().get(3).getDocCount());
-            assertEquals("val009", result7.getBuckets().get(4).getKeyAsString());
-            assertEquals(1L, result7.getBuckets().get(4).getDocCount());
-            assertTrue(AggregationInspectionHelper.hasValue(result7));
-        }, new MappedFieldType[] { ft1, ft2 }).withQuery(new MatchAllDocsQuery()));
+        testCase(new AggTestConfig<StringTerms>(builder, buildIndex, result -> {
+            assertEquals(5, result.getBuckets().size());
+            assertEquals("val001", result.getBuckets().get(0).getKeyAsString());
+            assertEquals(1L, result.getBuckets().get(0).getDocCount());
+            assertEquals("val003", result.getBuckets().get(1).getKeyAsString());
+            assertEquals(1L, result.getBuckets().get(1).getDocCount());
+            assertEquals("val005", result.getBuckets().get(2).getKeyAsString());
+            assertEquals(1L, result.getBuckets().get(2).getDocCount());
+            assertEquals("val007", result.getBuckets().get(3).getKeyAsString());
+            assertEquals(1L, result.getBuckets().get(3).getDocCount());
+            assertEquals("val009", result.getBuckets().get(4).getKeyAsString());
+            assertEquals(1L, result.getBuckets().get(4).getDocCount());
+            assertTrue(AggregationInspectionHelper.hasValue(result));
+        }, ft1, ft2));
 
         builder = new TermsAggregationBuilder("_name").executionHint(executionHint)
             .includeExclude(new IncludeExclude("val00.+", null, null, null))
             .field("sv_field")
             .order(BucketOrder.key(true));
-        testCase(new AggTestConfig<StringTerms>(builder, buildIndex, (StringTerms result6) -> {
-            assertEquals(5, result6.getBuckets().size());
-            assertEquals("val001", result6.getBuckets().get(0).getKeyAsString());
-            assertEquals(1L, result6.getBuckets().get(0).getDocCount());
-            assertEquals("val003", result6.getBuckets().get(1).getKeyAsString());
-            assertEquals(1L, result6.getBuckets().get(1).getDocCount());
-            assertEquals("val005", result6.getBuckets().get(2).getKeyAsString());
-            assertEquals(1L, result6.getBuckets().get(2).getDocCount());
-            assertEquals("val007", result6.getBuckets().get(3).getKeyAsString());
-            assertEquals(1L, result6.getBuckets().get(3).getDocCount());
-            assertEquals("val009", result6.getBuckets().get(4).getKeyAsString());
-            assertEquals(1L, result6.getBuckets().get(4).getDocCount());
-            assertTrue(AggregationInspectionHelper.hasValue(result6));
-        }, new MappedFieldType[] { ft1, ft2 }).withQuery(new MatchAllDocsQuery()));
+        testCase(new AggTestConfig<StringTerms>(builder, buildIndex, result -> {
+            assertEquals(5, result.getBuckets().size());
+            assertEquals("val001", result.getBuckets().get(0).getKeyAsString());
+            assertEquals(1L, result.getBuckets().get(0).getDocCount());
+            assertEquals("val003", result.getBuckets().get(1).getKeyAsString());
+            assertEquals(1L, result.getBuckets().get(1).getDocCount());
+            assertEquals("val005", result.getBuckets().get(2).getKeyAsString());
+            assertEquals(1L, result.getBuckets().get(2).getDocCount());
+            assertEquals("val007", result.getBuckets().get(3).getKeyAsString());
+            assertEquals(1L, result.getBuckets().get(3).getDocCount());
+            assertEquals("val009", result.getBuckets().get(4).getKeyAsString());
+            assertEquals(1L, result.getBuckets().get(4).getDocCount());
+            assertTrue(AggregationInspectionHelper.hasValue(result));
+        }, ft1, ft2));
 
         builder = new TermsAggregationBuilder("_name").executionHint(executionHint)
             .includeExclude(new IncludeExclude("val00.+", "(val000|val001)", null, null))
             .field("mv_field")
             .order(BucketOrder.key(true));
-        testCase(new AggTestConfig<StringTerms>(builder, buildIndex, (StringTerms result5) -> {
-            assertEquals(8, result5.getBuckets().size());
-            assertEquals("val002", result5.getBuckets().get(0).getKeyAsString());
-            assertEquals(1L, result5.getBuckets().get(0).getDocCount());
-            assertEquals("val003", result5.getBuckets().get(1).getKeyAsString());
-            assertEquals(1L, result5.getBuckets().get(1).getDocCount());
-            assertEquals("val004", result5.getBuckets().get(2).getKeyAsString());
-            assertEquals(1L, result5.getBuckets().get(2).getDocCount());
-            assertEquals("val005", result5.getBuckets().get(3).getKeyAsString());
-            assertEquals(1L, result5.getBuckets().get(3).getDocCount());
-            assertEquals("val006", result5.getBuckets().get(4).getKeyAsString());
-            assertEquals(1L, result5.getBuckets().get(4).getDocCount());
-            assertEquals("val007", result5.getBuckets().get(5).getKeyAsString());
-            assertEquals(1L, result5.getBuckets().get(5).getDocCount());
-            assertEquals("val008", result5.getBuckets().get(6).getKeyAsString());
-            assertEquals(1L, result5.getBuckets().get(6).getDocCount());
-            assertEquals("val009", result5.getBuckets().get(7).getKeyAsString());
-            assertEquals(1L, result5.getBuckets().get(7).getDocCount());
-            assertTrue(AggregationInspectionHelper.hasValue(result5));
-        }, new MappedFieldType[] { ft1, ft2 }).withQuery(new MatchAllDocsQuery()));
+        testCase(new AggTestConfig<StringTerms>(builder, buildIndex, result -> {
+            assertEquals(8, result.getBuckets().size());
+            assertEquals("val002", result.getBuckets().get(0).getKeyAsString());
+            assertEquals(1L, result.getBuckets().get(0).getDocCount());
+            assertEquals("val003", result.getBuckets().get(1).getKeyAsString());
+            assertEquals(1L, result.getBuckets().get(1).getDocCount());
+            assertEquals("val004", result.getBuckets().get(2).getKeyAsString());
+            assertEquals(1L, result.getBuckets().get(2).getDocCount());
+            assertEquals("val005", result.getBuckets().get(3).getKeyAsString());
+            assertEquals(1L, result.getBuckets().get(3).getDocCount());
+            assertEquals("val006", result.getBuckets().get(4).getKeyAsString());
+            assertEquals(1L, result.getBuckets().get(4).getDocCount());
+            assertEquals("val007", result.getBuckets().get(5).getKeyAsString());
+            assertEquals(1L, result.getBuckets().get(5).getDocCount());
+            assertEquals("val008", result.getBuckets().get(6).getKeyAsString());
+            assertEquals(1L, result.getBuckets().get(6).getDocCount());
+            assertEquals("val009", result.getBuckets().get(7).getKeyAsString());
+            assertEquals(1L, result.getBuckets().get(7).getDocCount());
+            assertTrue(AggregationInspectionHelper.hasValue(result));
+        }, ft1, ft2));
 
         builder = new TermsAggregationBuilder("_name").executionHint(executionHint)
             .includeExclude(new IncludeExclude(null, "val00.+", null, null))
             .field("mv_field")
             .order(BucketOrder.key(true));
-        testCase(new AggTestConfig<StringTerms>(builder, buildIndex, (StringTerms result4) -> {
-            assertEquals(2, result4.getBuckets().size());
-            assertEquals("val010", result4.getBuckets().get(0).getKeyAsString());
-            assertEquals(1L, result4.getBuckets().get(0).getDocCount());
-            assertEquals("val011", result4.getBuckets().get(1).getKeyAsString());
-            assertEquals(1L, result4.getBuckets().get(1).getDocCount());
-            assertTrue(AggregationInspectionHelper.hasValue(result4));
-        }, new MappedFieldType[] { ft1, ft2 }).withQuery(new MatchAllDocsQuery()));
+        testCase(new AggTestConfig<StringTerms>(builder, buildIndex, result -> {
+            assertEquals(2, result.getBuckets().size());
+            assertEquals("val010", result.getBuckets().get(0).getKeyAsString());
+            assertEquals(1L, result.getBuckets().get(0).getDocCount());
+            assertEquals("val011", result.getBuckets().get(1).getKeyAsString());
+            assertEquals(1L, result.getBuckets().get(1).getDocCount());
+            assertTrue(AggregationInspectionHelper.hasValue(result));
+        }, ft1, ft2));
 
         builder = new TermsAggregationBuilder("_name").executionHint(executionHint)
             .includeExclude(new IncludeExclude(null, null, new TreeSet<>(Set.of(new BytesRef("val000"), new BytesRef("val010"))), null))
             .field("mv_field")
             .order(BucketOrder.key(true));
-        testCase(new AggTestConfig<StringTerms>(builder, buildIndex, (StringTerms result3) -> {
-            assertEquals(2, result3.getBuckets().size());
-            assertEquals("val000", result3.getBuckets().get(0).getKeyAsString());
-            assertEquals(1L, result3.getBuckets().get(0).getDocCount());
-            assertEquals("val010", result3.getBuckets().get(1).getKeyAsString());
-            assertEquals(1L, result3.getBuckets().get(1).getDocCount());
-            assertTrue(AggregationInspectionHelper.hasValue(result3));
-        }, new MappedFieldType[] { ft1, ft2 }).withQuery(new MatchAllDocsQuery()));
+        testCase(new AggTestConfig<StringTerms>(builder, buildIndex, result -> {
+            assertEquals(2, result.getBuckets().size());
+            assertEquals("val000", result.getBuckets().get(0).getKeyAsString());
+            assertEquals(1L, result.getBuckets().get(0).getDocCount());
+            assertEquals("val010", result.getBuckets().get(1).getKeyAsString());
+            assertEquals(1L, result.getBuckets().get(1).getDocCount());
+            assertTrue(AggregationInspectionHelper.hasValue(result));
+        }, ft1, ft2));
 
         builder = new TermsAggregationBuilder("_name").executionHint(executionHint)
             .includeExclude(
@@ -589,14 +588,14 @@ public class TermsAggregatorTests extends AggregatorTestCase {
             )
             .field("mv_field")
             .order(BucketOrder.key(true));
-        testCase(new AggTestConfig<StringTerms>(builder, buildIndex, (StringTerms result2) -> {
-            assertEquals(2, result2.getBuckets().size());
-            assertEquals("val000", result2.getBuckets().get(0).getKeyAsString());
-            assertEquals(1L, result2.getBuckets().get(0).getDocCount());
-            assertEquals("val010", result2.getBuckets().get(1).getKeyAsString());
-            assertEquals(1L, result2.getBuckets().get(1).getDocCount());
-            assertTrue(AggregationInspectionHelper.hasValue(result2));
-        }, new MappedFieldType[] { ft1, ft2 }).withQuery(new MatchAllDocsQuery()));
+        testCase(new AggTestConfig<StringTerms>(builder, buildIndex, result -> {
+            assertEquals(2, result.getBuckets().size());
+            assertEquals("val000", result.getBuckets().get(0).getKeyAsString());
+            assertEquals(1L, result.getBuckets().get(0).getDocCount());
+            assertEquals("val010", result.getBuckets().get(1).getKeyAsString());
+            assertEquals(1L, result.getBuckets().get(1).getDocCount());
+            assertTrue(AggregationInspectionHelper.hasValue(result));
+        }, ft1, ft2));
 
         builder = new TermsAggregationBuilder("_name").executionHint(executionHint)
             .includeExclude(
@@ -620,14 +619,14 @@ public class TermsAggregatorTests extends AggregatorTestCase {
             )
             .field("mv_field")
             .order(BucketOrder.key(true));
-        testCase(new AggTestConfig<StringTerms>(builder, buildIndex, (StringTerms result1) -> {
-            assertEquals(2, result1.getBuckets().size());
-            assertEquals("val000", result1.getBuckets().get(0).getKeyAsString());
-            assertEquals(1L, result1.getBuckets().get(0).getDocCount());
-            assertEquals("val009", result1.getBuckets().get(1).getKeyAsString());
-            assertEquals(1L, result1.getBuckets().get(1).getDocCount());
-            assertTrue(AggregationInspectionHelper.hasValue(result1));
-        }, new MappedFieldType[] { ft1, ft2 }).withQuery(new MatchAllDocsQuery()));
+        testCase(new AggTestConfig<StringTerms>(builder, buildIndex, result -> {
+            assertEquals(2, result.getBuckets().size());
+            assertEquals("val000", result.getBuckets().get(0).getKeyAsString());
+            assertEquals(1L, result.getBuckets().get(0).getDocCount());
+            assertEquals("val009", result.getBuckets().get(1).getKeyAsString());
+            assertEquals(1L, result.getBuckets().get(1).getDocCount());
+            assertTrue(AggregationInspectionHelper.hasValue(result));
+        }, ft1, ft2));
 
         builder = new TermsAggregationBuilder("_name").executionHint(executionHint)
             .includeExclude(
@@ -640,14 +639,14 @@ public class TermsAggregatorTests extends AggregatorTestCase {
             )
             .field("mv_field")
             .order(BucketOrder.key(true));
-        testCase(new AggTestConfig<StringTerms>(builder, buildIndex, (StringTerms result) -> {
+        testCase(new AggTestConfig<StringTerms>(builder, buildIndex, result -> {
             assertEquals(2, result.getBuckets().size());
             assertEquals("val001", result.getBuckets().get(0).getKeyAsString());
             assertEquals(1L, result.getBuckets().get(0).getDocCount());
             assertEquals("val002", result.getBuckets().get(1).getKeyAsString());
             assertEquals(1L, result.getBuckets().get(1).getDocCount());
             assertTrue(AggregationInspectionHelper.hasValue(result));
-        }, new MappedFieldType[] { ft1, ft2 }).withQuery(new MatchAllDocsQuery()));
+        }, ft1, ft2));
     }
 
     private List<IndexableField> doc(MappedFieldType ft1, MappedFieldType ft2, String f1v1, String f1v2, String f2v) {
@@ -1230,12 +1229,12 @@ public class TermsAggregatorTests extends AggregatorTestCase {
                 document.add(new InetAddressPoint("field", point));
             }
             iw.addDocument(document);
-        }, (StringTerms result) -> {
+        }, result -> {
             assertEquals("_name", result.getName());
             assertEquals(1, result.getBuckets().size());
             assertEquals("192.168.100.42", result.getBuckets().get(0).getKey());
             assertEquals(1, result.getBuckets().get(0).getDocCount());
-        }, new MappedFieldType[] { fieldType }).withQuery(new MatchAllDocsQuery()));
+        }, fieldType));
     }
 
     public void testNestedTermsAgg() throws Exception {
@@ -1680,10 +1679,7 @@ public class TermsAggregatorTests extends AggregatorTestCase {
             for (int i = 0; i < numDocs; i++) {
                 iw.addDocument(singleton(new NumericDocValuesField("number", i + 1)));
             }
-        },
-            (Consumer<InternalTerms<?, ?>>) terms -> { assertTrue(AggregationInspectionHelper.hasValue(terms)); },
-            new MappedFieldType[] { fieldType }
-        ).withQuery(new MatchAllDocsQuery()));
+        }, terms -> { assertTrue(AggregationInspectionHelper.hasValue(terms)); }, fieldType));
     }
 
     public void testThreeLayerStringViaGlobalOrds() throws IOException {
@@ -1840,10 +1836,7 @@ public class TermsAggregatorTests extends AggregatorTestCase {
             for (int i = 1; i < numDocs; i++) {
                 iw.addDocument(singleton(new NumericDocValuesField("number", i + 1)));
             }
-        },
-            (Consumer<InternalTerms<?, ?>>) terms -> assertTrue(AggregationInspectionHelper.hasValue(terms)),
-            new MappedFieldType[] { fieldType }
-        ).withQuery(new MatchAllDocsQuery()));
+        }, terms -> assertTrue(AggregationInspectionHelper.hasValue(terms)), fieldType));
     }
 
     public void testFormatCannotParseMissing() throws IOException {
@@ -1859,9 +1852,7 @@ public class TermsAggregatorTests extends AggregatorTestCase {
                 for (int i = 1; i < numDocs; i++) {
                     iw.addDocument(singleton(new NumericDocValuesField("number", i + 1)));
                 }
-            }, (Consumer<InternalTerms<?, ?>>) terms -> fail("Should have thrown"), new MappedFieldType[] { fieldType }).withQuery(
-                new MatchAllDocsQuery()
-            ))
+            }, terms -> fail("Should have thrown"), fieldType))
         );
 
         assertThat(ex.getMessage(), equalTo("Cannot parse the value [42] using the pattern [$###.00]"));
@@ -1970,7 +1961,7 @@ public class TermsAggregatorTests extends AggregatorTestCase {
                 )
             );
         };
-        testCase(new AggTestConfig<InternalDateHistogram>(builder, buildIndex, (InternalDateHistogram dh) -> {
+        testCase(new AggTestConfig<InternalDateHistogram>(builder, buildIndex, dh -> {
             assertThat(
                 dh.getBuckets().stream().map(InternalDateHistogram.Bucket::getKeyAsString).collect(toList()),
                 equalTo(List.of("2020-01-01T00:00:00.000Z", "2021-01-01T00:00:00.000Z"))
@@ -1979,7 +1970,7 @@ public class TermsAggregatorTests extends AggregatorTestCase {
             assertThat(terms1.getBuckets().stream().map(StringTerms.Bucket::getKey).collect(toList()), equalTo(List.of("a", "b")));
             terms1 = dh.getBuckets().get(1).getAggregations().get("k");
             assertThat(terms1.getBuckets().stream().map(StringTerms.Bucket::getKey).collect(toList()), equalTo(List.of("a")));
-        }, new MappedFieldType[] { dft, kft }).withQuery(new MatchAllDocsQuery()));
+        }, dft, kft));
         withAggregator(builder, new MatchAllDocsQuery(), buildIndex, (searcher, aggregator) -> {
             TermsAggregator terms = (TermsAggregator) aggregator.subAggregator("k");
             Map<String, Object> info = new HashMap<>();

--- a/server/src/test/java/org/elasticsearch/search/aggregations/metrics/AvgAggregatorTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/metrics/AvgAggregatorTests.java
@@ -586,7 +586,7 @@ public class AvgAggregatorTests extends AggregatorTestCase {
         Consumer<InternalAvg> verify,
         MappedFieldType... fieldTypes
     ) throws IOException {
-        testCase(aggregationBuilder, query, buildIndex, verify, fieldTypes);
+        testCase(new AggTestConfig<InternalAvg>(aggregationBuilder, buildIndex, verify, fieldTypes).withQuery(query));
     }
 
     /**

--- a/server/src/test/java/org/elasticsearch/search/aggregations/metrics/AvgAggregatorTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/metrics/AvgAggregatorTests.java
@@ -586,7 +586,7 @@ public class AvgAggregatorTests extends AggregatorTestCase {
         Consumer<InternalAvg> verify,
         MappedFieldType... fieldTypes
     ) throws IOException {
-        testCase(new AggTestConfig<InternalAvg>(aggregationBuilder, buildIndex, verify, fieldTypes).withQuery(query));
+        testCase(new AggTestConfig<>(aggregationBuilder, buildIndex, verify, fieldTypes).withQuery(query));
     }
 
     /**

--- a/server/src/test/java/org/elasticsearch/search/aggregations/metrics/CardinalityAggregatorTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/metrics/CardinalityAggregatorTests.java
@@ -534,7 +534,7 @@ public class CardinalityAggregatorTests extends AggregatorTestCase {
             assertEquals(cardinality, ((InternalAggregation) global).getProperty("cardinality"));
             assertEquals(numDocs, (double) ((InternalAggregation) global).getProperty("cardinality.value"), 0);
             assertEquals(numDocs, (double) ((InternalAggregation) cardinality).getProperty("value"), 0);
-        }, fieldType).withQuery(new MatchAllDocsQuery()));
+        }, fieldType));
     }
 
     public void testUnmappedMissingGeoPoint() throws IOException {
@@ -561,7 +561,7 @@ public class CardinalityAggregatorTests extends AggregatorTestCase {
             .subAggregation(AggregationBuilders.cardinality("cardinality").field("number"));
 
         // ("even", "odd")
-        testCase(new AggTestConfig<InternalAggregation>(aggregationBuilder, iw -> {
+        testCase(new AggTestConfig<StringTerms>(aggregationBuilder, iw -> {
             final int numDocs = 10;
             for (int i = 0; i < numDocs; i++) {
                 iw.addDocument(
@@ -571,9 +571,8 @@ public class CardinalityAggregatorTests extends AggregatorTestCase {
                     )
                 );
             }
-        }, topLevelAgg -> {
+        }, terms -> {
             int expectedTermBucketsCount = 2; // ("even", "odd")
-            final Terms terms = (StringTerms) topLevelAgg;
             assertNotNull(terms);
             List<? extends Terms.Bucket> buckets = terms.getBuckets();
             assertNotNull(buckets);
@@ -590,7 +589,7 @@ public class CardinalityAggregatorTests extends AggregatorTestCase {
                 assertEquals("cardinality", cardinality.getName());
                 assertEquals(5, cardinality.getValue());
             }
-        }, mappedFieldTypes).withQuery(new MatchAllDocsQuery()));
+        }, mappedFieldTypes));
     }
 
     private void testAggregation(
@@ -610,10 +609,10 @@ public class CardinalityAggregatorTests extends AggregatorTestCase {
         Consumer<InternalCardinality> verify,
         MappedFieldType... fieldTypes
     ) throws IOException {
-        testCase(new AggTestConfig<InternalCardinality>(aggregationBuilder, buildIndex, verify, fieldTypes).withQuery(query));
+        testCase(new AggTestConfig<>(aggregationBuilder, buildIndex, verify, fieldTypes).withQuery(query));
         for (CardinalityAggregatorFactory.ExecutionMode mode : CardinalityAggregatorFactory.ExecutionMode.values()) {
             aggregationBuilder.executionHint(mode.toString().toLowerCase(Locale.ROOT));
-            testCase(new AggTestConfig<InternalCardinality>(aggregationBuilder, buildIndex, verify, fieldTypes).withQuery(query));
+            testCase(new AggTestConfig<>(aggregationBuilder, buildIndex, verify, fieldTypes).withQuery(query));
         }
     }
 }

--- a/server/src/test/java/org/elasticsearch/search/aggregations/metrics/CardinalityAggregatorTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/metrics/CardinalityAggregatorTests.java
@@ -514,7 +514,7 @@ public class CardinalityAggregatorTests extends AggregatorTestCase {
             .subAggregation(AggregationBuilders.cardinality("cardinality").field("number"));
 
         final int numDocs = 10;
-        testCase(aggregationBuilder, new MatchAllDocsQuery(), iw -> {
+        testCase(new AggTestConfig<InternalAggregation>(aggregationBuilder, iw -> {
             for (int i = 0; i < numDocs; i++) {
                 iw.addDocument(singleton(new NumericDocValuesField("number", (i + 1))));
                 iw.addDocument(singleton(new NumericDocValuesField("number", (i + 1))));
@@ -534,7 +534,7 @@ public class CardinalityAggregatorTests extends AggregatorTestCase {
             assertEquals(cardinality, ((InternalAggregation) global).getProperty("cardinality"));
             assertEquals(numDocs, (double) ((InternalAggregation) global).getProperty("cardinality.value"), 0);
             assertEquals(numDocs, (double) ((InternalAggregation) cardinality).getProperty("value"), 0);
-        }, fieldType);
+        }, fieldType).withQuery(new MatchAllDocsQuery()));
     }
 
     public void testUnmappedMissingGeoPoint() throws IOException {
@@ -560,7 +560,8 @@ public class CardinalityAggregatorTests extends AggregatorTestCase {
             .missing("unknown")
             .subAggregation(AggregationBuilders.cardinality("cardinality").field("number"));
 
-        testCase(aggregationBuilder, new MatchAllDocsQuery(), iw -> {
+        // ("even", "odd")
+        testCase(new AggTestConfig<InternalAggregation>(aggregationBuilder, iw -> {
             final int numDocs = 10;
             for (int i = 0; i < numDocs; i++) {
                 iw.addDocument(
@@ -578,10 +579,10 @@ public class CardinalityAggregatorTests extends AggregatorTestCase {
             assertNotNull(buckets);
             assertEquals(expectedTermBucketsCount, buckets.size());
 
-            for (int i = 0; i < expectedTermBucketsCount; i++) {
-                final Terms.Bucket bucket = buckets.get(i);
+            for (int i1 = 0; i1 < expectedTermBucketsCount; i1++) {
+                final Terms.Bucket bucket = buckets.get(i1);
                 assertNotNull(bucket);
-                assertEquals(((i + 1) % 2 == 0) ? "odd" : "even", bucket.getKey());
+                assertEquals(((i1 + 1) % 2 == 0) ? "odd" : "even", bucket.getKey());
                 assertEquals(5L, bucket.getDocCount());
 
                 final InternalCardinality cardinality = bucket.getAggregations().get("cardinality");
@@ -589,7 +590,7 @@ public class CardinalityAggregatorTests extends AggregatorTestCase {
                 assertEquals("cardinality", cardinality.getName());
                 assertEquals(5, cardinality.getValue());
             }
-        }, mappedFieldTypes);
+        }, mappedFieldTypes).withQuery(new MatchAllDocsQuery()));
     }
 
     private void testAggregation(
@@ -609,10 +610,10 @@ public class CardinalityAggregatorTests extends AggregatorTestCase {
         Consumer<InternalCardinality> verify,
         MappedFieldType... fieldTypes
     ) throws IOException {
-        testCase(aggregationBuilder, query, buildIndex, verify, fieldTypes);
+        testCase(new AggTestConfig<InternalCardinality>(aggregationBuilder, buildIndex, verify, fieldTypes).withQuery(query));
         for (CardinalityAggregatorFactory.ExecutionMode mode : CardinalityAggregatorFactory.ExecutionMode.values()) {
             aggregationBuilder.executionHint(mode.toString().toLowerCase(Locale.ROOT));
-            testCase(aggregationBuilder, query, buildIndex, verify, fieldTypes);
+            testCase(new AggTestConfig<InternalCardinality>(aggregationBuilder, buildIndex, verify, fieldTypes).withQuery(query));
         }
     }
 }

--- a/server/src/test/java/org/elasticsearch/search/aggregations/metrics/ExtendedStatsAggregatorTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/metrics/ExtendedStatsAggregatorTests.java
@@ -11,7 +11,6 @@ package org.elasticsearch.search.aggregations.metrics;
 import org.apache.lucene.document.Document;
 import org.apache.lucene.document.NumericDocValuesField;
 import org.apache.lucene.document.SortedNumericDocValuesField;
-import org.apache.lucene.search.MatchAllDocsQuery;
 import org.apache.lucene.tests.index.RandomIndexWriter;
 import org.apache.lucene.util.NumericUtils;
 import org.elasticsearch.core.CheckedConsumer;
@@ -266,11 +265,7 @@ public class ExtendedStatsAggregatorTests extends AggregatorTestCase {
         ExtendedStatsAggregationBuilder aggBuilder = new ExtendedStatsAggregationBuilder("my_agg").field("field")
             .sigma(randomDoubleBetween(0, 10, true));
 
-        testCase(
-            new AggTestConfig<InternalExtendedStats>(aggBuilder, buildIndex, verify, new MappedFieldType[] { ft }).withQuery(
-                new MatchAllDocsQuery()
-            )
-        );
+        testCase(new AggTestConfig<>(aggBuilder, buildIndex, verify, ft));
     }
 
     static class ExtendedSimpleStatsAggregator extends StatsAggregatorTests.SimpleStatsAggregator {

--- a/server/src/test/java/org/elasticsearch/search/aggregations/metrics/ExtendedStatsAggregatorTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/metrics/ExtendedStatsAggregatorTests.java
@@ -266,7 +266,11 @@ public class ExtendedStatsAggregatorTests extends AggregatorTestCase {
         ExtendedStatsAggregationBuilder aggBuilder = new ExtendedStatsAggregationBuilder("my_agg").field("field")
             .sigma(randomDoubleBetween(0, 10, true));
 
-        testCase(aggBuilder, new MatchAllDocsQuery(), buildIndex, verify, ft);
+        testCase(
+            new AggTestConfig<InternalExtendedStats>(aggBuilder, buildIndex, verify, new MappedFieldType[] { ft }).withQuery(
+                new MatchAllDocsQuery()
+            )
+        );
     }
 
     static class ExtendedSimpleStatsAggregator extends StatsAggregatorTests.SimpleStatsAggregator {

--- a/server/src/test/java/org/elasticsearch/search/aggregations/metrics/GeoBoundsAggregatorTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/metrics/GeoBoundsAggregatorTests.java
@@ -44,7 +44,7 @@ public class GeoBoundsAggregatorTests extends AggregatorTestCase {
             MappedFieldType fieldType = new GeoPointFieldMapper.GeoPointFieldType("field");
             try (IndexReader reader = w.getReader()) {
                 IndexSearcher searcher = new IndexSearcher(reader);
-                InternalGeoBounds bounds = searchAndReduce(new AggTestConfig(searcher, aggBuilder, fieldType));
+                InternalGeoBounds bounds = searchAndReduce(new AggTestConfig<>(searcher, aggBuilder, fieldType));
                 assertTrue(Double.isInfinite(bounds.top));
                 assertTrue(Double.isInfinite(bounds.bottom));
                 assertTrue(Double.isInfinite(bounds.posLeft));
@@ -69,7 +69,7 @@ public class GeoBoundsAggregatorTests extends AggregatorTestCase {
             MappedFieldType fieldType = new GeoPointFieldMapper.GeoPointFieldType("field");
             try (IndexReader reader = w.getReader()) {
                 IndexSearcher searcher = new IndexSearcher(reader);
-                InternalGeoBounds bounds = searchAndReduce(new AggTestConfig(searcher, aggBuilder, fieldType));
+                InternalGeoBounds bounds = searchAndReduce(new AggTestConfig<>(searcher, aggBuilder, fieldType));
                 assertTrue(Double.isInfinite(bounds.top));
                 assertTrue(Double.isInfinite(bounds.bottom));
                 assertTrue(Double.isInfinite(bounds.posLeft));
@@ -101,7 +101,7 @@ public class GeoBoundsAggregatorTests extends AggregatorTestCase {
 
                 try (IndexReader reader = w.getReader()) {
                     IndexSearcher searcher = new IndexSearcher(reader);
-                    InternalGeoBounds bounds = searchAndReduce(new AggTestConfig(searcher, aggBuilder, fieldType));
+                    InternalGeoBounds bounds = searchAndReduce(new AggTestConfig<>(searcher, aggBuilder, fieldType));
                     assertThat(bounds.top, equalTo(lat));
                     assertThat(bounds.bottom, equalTo(lat));
                     assertThat(bounds.posLeft, equalTo(lon >= 0 ? lon : Double.POSITIVE_INFINITY));
@@ -128,7 +128,7 @@ public class GeoBoundsAggregatorTests extends AggregatorTestCase {
                 IndexSearcher searcher = new IndexSearcher(reader);
                 ElasticsearchParseException exception = expectThrows(
                     ElasticsearchParseException.class,
-                    () -> searchAndReduce(new AggTestConfig(searcher, aggBuilder, fieldType))
+                    () -> searchAndReduce(new AggTestConfig<>(searcher, aggBuilder, fieldType))
                 );
                 assertThat(exception.getMessage(), startsWith("unsupported symbol"));
             }
@@ -176,7 +176,7 @@ public class GeoBoundsAggregatorTests extends AggregatorTestCase {
             MappedFieldType fieldType = new GeoPointFieldMapper.GeoPointFieldType("field");
             try (IndexReader reader = w.getReader()) {
                 IndexSearcher searcher = new IndexSearcher(reader);
-                InternalGeoBounds bounds = searchAndReduce(new AggTestConfig(searcher, aggBuilder, fieldType));
+                InternalGeoBounds bounds = searchAndReduce(new AggTestConfig<>(searcher, aggBuilder, fieldType));
                 assertThat(bounds.top, closeTo(top, GEOHASH_TOLERANCE));
                 assertThat(bounds.bottom, closeTo(bottom, GEOHASH_TOLERANCE));
                 assertThat(bounds.posLeft, closeTo(posLeft, GEOHASH_TOLERANCE));

--- a/server/src/test/java/org/elasticsearch/search/aggregations/metrics/GeoCentroidAggregatorTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/metrics/GeoCentroidAggregatorTests.java
@@ -39,7 +39,7 @@ public class GeoCentroidAggregatorTests extends AggregatorTestCase {
             MappedFieldType fieldType = new GeoPointFieldMapper.GeoPointFieldType("field");
             try (IndexReader reader = w.getReader()) {
                 IndexSearcher searcher = new IndexSearcher(reader);
-                InternalGeoCentroid result = searchAndReduce(new AggTestConfig(searcher, aggBuilder, fieldType));
+                InternalGeoCentroid result = searchAndReduce(new AggTestConfig<>(searcher, aggBuilder, fieldType));
                 assertNull(result.centroid());
                 assertFalse(AggregationInspectionHelper.hasValue(result));
             }
@@ -57,11 +57,11 @@ public class GeoCentroidAggregatorTests extends AggregatorTestCase {
                 IndexSearcher searcher = new IndexSearcher(reader);
 
                 MappedFieldType fieldType = new GeoPointFieldMapper.GeoPointFieldType("another_field");
-                InternalGeoCentroid result = searchAndReduce(new AggTestConfig(searcher, aggBuilder, fieldType));
+                InternalGeoCentroid result = searchAndReduce(new AggTestConfig<>(searcher, aggBuilder, fieldType));
                 assertNull(result.centroid());
 
                 fieldType = new GeoPointFieldMapper.GeoPointFieldType("another_field");
-                result = searchAndReduce(new AggTestConfig(searcher, aggBuilder, fieldType));
+                result = searchAndReduce(new AggTestConfig<>(searcher, aggBuilder, fieldType));
                 assertNull(result.centroid());
                 assertFalse(AggregationInspectionHelper.hasValue(result));
             }
@@ -84,7 +84,7 @@ public class GeoCentroidAggregatorTests extends AggregatorTestCase {
                 IndexSearcher searcher = new IndexSearcher(reader);
 
                 MappedFieldType fieldType = new GeoPointFieldMapper.GeoPointFieldType("another_field");
-                InternalGeoCentroid result = searchAndReduce(new AggTestConfig(searcher, aggBuilder, fieldType));
+                InternalGeoCentroid result = searchAndReduce(new AggTestConfig<>(searcher, aggBuilder, fieldType));
                 assertEquals(result.centroid(), expectedCentroid);
                 assertTrue(AggregationInspectionHelper.hasValue(result));
             }
@@ -149,7 +149,7 @@ public class GeoCentroidAggregatorTests extends AggregatorTestCase {
         GeoCentroidAggregationBuilder aggBuilder = new GeoCentroidAggregationBuilder("my_agg").field("field");
         try (IndexReader reader = w.getReader()) {
             IndexSearcher searcher = new IndexSearcher(reader);
-            InternalGeoCentroid result = searchAndReduce(new AggTestConfig(searcher, aggBuilder, fieldType));
+            InternalGeoCentroid result = searchAndReduce(new AggTestConfig<>(searcher, aggBuilder, fieldType));
 
             assertEquals("my_agg", result.getName());
             SpatialPoint centroid = result.centroid();

--- a/server/src/test/java/org/elasticsearch/search/aggregations/metrics/HDRPercentileRanksAggregatorTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/metrics/HDRPercentileRanksAggregatorTests.java
@@ -48,7 +48,7 @@ public class HDRPercentileRanksAggregatorTests extends AggregatorTestCase {
         MappedFieldType fieldType = new NumberFieldMapper.NumberFieldType("field", NumberFieldMapper.NumberType.DOUBLE);
         try (IndexReader reader = new MultiReader()) {
             IndexSearcher searcher = new IndexSearcher(reader);
-            PercentileRanks ranks = searchAndReduce(new AggTestConfig(searcher, aggBuilder, fieldType));
+            PercentileRanks ranks = searchAndReduce(new AggTestConfig<>(searcher, aggBuilder, fieldType));
             Percentile rank = ranks.iterator().next();
             assertEquals(Double.NaN, rank.getPercent(), 0d);
             assertEquals(0.5, rank.getValue(), 0d);
@@ -70,7 +70,7 @@ public class HDRPercentileRanksAggregatorTests extends AggregatorTestCase {
             MappedFieldType fieldType = new NumberFieldMapper.NumberFieldType("field", NumberFieldMapper.NumberType.DOUBLE);
             try (IndexReader reader = w.getReader()) {
                 IndexSearcher searcher = new IndexSearcher(reader);
-                PercentileRanks ranks = searchAndReduce(new AggTestConfig(searcher, aggBuilder, fieldType));
+                PercentileRanks ranks = searchAndReduce(new AggTestConfig<>(searcher, aggBuilder, fieldType));
                 Iterator<Percentile> rankIterator = ranks.iterator();
                 Percentile rank = rankIterator.next();
                 assertEquals(0.1, rank.getValue(), 0d);

--- a/server/src/test/java/org/elasticsearch/search/aggregations/metrics/MaxAggregatorTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/metrics/MaxAggregatorTests.java
@@ -286,7 +286,7 @@ public class MaxAggregatorTests extends AggregatorTestCase {
         Consumer<Max> verify,
         MappedFieldType... fieldTypes
     ) throws IOException {
-        testCase(new AggTestConfig<Max>(aggregationBuilder, buildIndex, verify, fieldTypes).withQuery(query));
+        testCase(new AggTestConfig<>(aggregationBuilder, buildIndex, verify, fieldTypes).withQuery(query));
     }
 
     public void testMaxShortcutRandom() throws Exception {

--- a/server/src/test/java/org/elasticsearch/search/aggregations/metrics/MaxAggregatorTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/metrics/MaxAggregatorTests.java
@@ -286,7 +286,7 @@ public class MaxAggregatorTests extends AggregatorTestCase {
         Consumer<Max> verify,
         MappedFieldType... fieldTypes
     ) throws IOException {
-        testCase(aggregationBuilder, query, buildIndex, verify, fieldTypes);
+        testCase(new AggTestConfig<Max>(aggregationBuilder, buildIndex, verify, fieldTypes).withQuery(query));
     }
 
     public void testMaxShortcutRandom() throws Exception {

--- a/server/src/test/java/org/elasticsearch/search/aggregations/metrics/MedianAbsoluteDeviationAggregatorTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/metrics/MedianAbsoluteDeviationAggregatorTests.java
@@ -228,7 +228,7 @@ public class MedianAbsoluteDeviationAggregatorTests extends AggregatorTestCase {
         Consumer<InternalMedianAbsoluteDeviation> verify,
         MappedFieldType... fieldTypes
     ) throws IOException {
-        testCase(aggregationBuilder, query, indexer, verify, fieldTypes);
+        testCase(new AggTestConfig<InternalMedianAbsoluteDeviation>(aggregationBuilder, indexer, verify, fieldTypes).withQuery(query));
     }
 
     public static class IsCloseToRelative extends TypeSafeMatcher<Double> {

--- a/server/src/test/java/org/elasticsearch/search/aggregations/metrics/MedianAbsoluteDeviationAggregatorTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/metrics/MedianAbsoluteDeviationAggregatorTests.java
@@ -228,7 +228,7 @@ public class MedianAbsoluteDeviationAggregatorTests extends AggregatorTestCase {
         Consumer<InternalMedianAbsoluteDeviation> verify,
         MappedFieldType... fieldTypes
     ) throws IOException {
-        testCase(new AggTestConfig<InternalMedianAbsoluteDeviation>(aggregationBuilder, indexer, verify, fieldTypes).withQuery(query));
+        testCase(new AggTestConfig<>(aggregationBuilder, indexer, verify, fieldTypes).withQuery(query));
     }
 
     public static class IsCloseToRelative extends TypeSafeMatcher<Double> {

--- a/server/src/test/java/org/elasticsearch/search/aggregations/metrics/MinAggregatorTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/metrics/MinAggregatorTests.java
@@ -385,7 +385,7 @@ public class MinAggregatorTests extends AggregatorTestCase {
                 MultiReader multiReader = new MultiReader(indexReader, unamappedIndexReader);
                 IndexSearcher indexSearcher = newSearcher(multiReader, true, true);
 
-                Min min = searchAndReduce(new AggTestConfig(indexSearcher, aggregationBuilder, fieldType));
+                Min min = searchAndReduce(new AggTestConfig<>(indexSearcher, aggregationBuilder, fieldType));
                 assertEquals(2.0, min.value(), 0);
                 assertTrue(AggregationInspectionHelper.hasValue(min));
             }
@@ -416,7 +416,7 @@ public class MinAggregatorTests extends AggregatorTestCase {
                 MultiReader multiReader = new MultiReader(indexReader, unamappedIndexReader);
                 IndexSearcher indexSearcher = newSearcher(multiReader, true, true);
 
-                Min min = searchAndReduce(new AggTestConfig(indexSearcher, aggregationBuilder, fieldType));
+                Min min = searchAndReduce(new AggTestConfig<>(indexSearcher, aggregationBuilder, fieldType));
                 assertEquals(-19.0, min.value(), 0);
                 assertTrue(AggregationInspectionHelper.hasValue(min));
             }

--- a/server/src/test/java/org/elasticsearch/search/aggregations/metrics/MinAggregatorTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/metrics/MinAggregatorTests.java
@@ -50,6 +50,7 @@ import org.elasticsearch.script.ScriptType;
 import org.elasticsearch.search.aggregations.AggregationBuilder;
 import org.elasticsearch.search.aggregations.AggregatorTestCase;
 import org.elasticsearch.search.aggregations.BucketOrder;
+import org.elasticsearch.search.aggregations.InternalAggregation;
 import org.elasticsearch.search.aggregations.bucket.filter.Filter;
 import org.elasticsearch.search.aggregations.bucket.filter.FilterAggregationBuilder;
 import org.elasticsearch.search.aggregations.bucket.global.GlobalAggregationBuilder;
@@ -232,10 +233,10 @@ public class MinAggregatorTests extends AggregatorTestCase {
 
         MappedFieldType fieldType = new IpFieldMapper.IpFieldType(fieldName);
         boolean v4 = randomBoolean();
-        expectThrows(IllegalArgumentException.class, () -> testCase(aggregationBuilder, new MatchAllDocsQuery(), iw -> {
+        expectThrows(IllegalArgumentException.class, () -> testCase(new AggTestConfig<InternalAggregation>(aggregationBuilder, iw -> {
             iw.addDocument(singleton(new SortedSetDocValuesField(fieldName, new BytesRef(InetAddressPoint.encode(randomIp(v4))))));
             iw.addDocument(singleton(new SortedSetDocValuesField(fieldName, new BytesRef(InetAddressPoint.encode(randomIp(v4))))));
-        }, min -> fail("expected an exception"), fieldType));
+        }, min -> fail("expected an exception"), fieldType).withQuery(new MatchAllDocsQuery())));
     }
 
     public void testUnmappedWithMissingField() throws IOException {
@@ -243,13 +244,13 @@ public class MinAggregatorTests extends AggregatorTestCase {
 
         MappedFieldType fieldType = new NumberFieldMapper.NumberFieldType("number", NumberFieldMapper.NumberType.INTEGER);
 
-        testCase(aggregationBuilder, new MatchAllDocsQuery(), iw -> {
+        testCase(new AggTestConfig<Min>(aggregationBuilder, iw -> {
             iw.addDocument(singleton(new NumericDocValuesField("number", 7)));
             iw.addDocument(singleton(new NumericDocValuesField("number", 1)));
         }, (Consumer<Min>) min -> {
             assertEquals(0.0, min.value(), 0);
             assertTrue(AggregationInspectionHelper.hasValue(min));
-        }, fieldType);
+        }, new MappedFieldType[] { fieldType }).withQuery(new MatchAllDocsQuery()));
     }
 
     public void testUnsupportedType() {
@@ -260,11 +261,12 @@ public class MinAggregatorTests extends AggregatorTestCase {
         IllegalArgumentException e = expectThrows(
             IllegalArgumentException.class,
             () -> testCase(
-                aggregationBuilder,
-                new MatchAllDocsQuery(),
-                iw -> { iw.addDocument(singleton(new SortedSetDocValuesField("string", new BytesRef("foo")))); },
-                (Consumer<Min>) min -> { fail("Should have thrown exception"); },
-                fieldType
+                new AggTestConfig<Min>(
+                    aggregationBuilder,
+                    iw -> { iw.addDocument(singleton(new SortedSetDocValuesField("string", new BytesRef("foo")))); },
+                    (Consumer<Min>) min -> { fail("Should have thrown exception"); },
+                    new MappedFieldType[] { fieldType }
+                ).withQuery(new MatchAllDocsQuery())
             )
         );
         assertEquals("Field [not_a_number] of type [keyword] is not supported for aggregation [min]", e.getMessage());
@@ -275,10 +277,12 @@ public class MinAggregatorTests extends AggregatorTestCase {
 
         MappedFieldType fieldType = new NumberFieldMapper.NumberFieldType("number", NumberFieldMapper.NumberType.INTEGER);
 
-        expectThrows(NumberFormatException.class, () -> testCase(aggregationBuilder, new MatchAllDocsQuery(), iw -> {
+        expectThrows(NumberFormatException.class, () -> testCase(new AggTestConfig<Min>(aggregationBuilder, iw -> {
             iw.addDocument(singleton(new NumericDocValuesField("number", 7)));
             iw.addDocument(singleton(new NumericDocValuesField("number", 1)));
-        }, (Consumer<Min>) min -> { fail("Should have thrown exception"); }, fieldType));
+        }, (Consumer<Min>) min -> { fail("Should have thrown exception"); }, new MappedFieldType[] { fieldType }).withQuery(
+            new MatchAllDocsQuery()
+        )));
     }
 
     public void testUnmappedWithBadMissingField() {
@@ -286,10 +290,12 @@ public class MinAggregatorTests extends AggregatorTestCase {
 
         MappedFieldType fieldType = new NumberFieldMapper.NumberFieldType("number", NumberFieldMapper.NumberType.INTEGER);
 
-        expectThrows(NumberFormatException.class, () -> testCase(aggregationBuilder, new MatchAllDocsQuery(), iw -> {
+        expectThrows(NumberFormatException.class, () -> testCase(new AggTestConfig<Min>(aggregationBuilder, iw -> {
             iw.addDocument(singleton(new NumericDocValuesField("number", 7)));
             iw.addDocument(singleton(new NumericDocValuesField("number", 1)));
-        }, (Consumer<Min>) min -> { fail("Should have thrown exception"); }, fieldType));
+        }, (Consumer<Min>) min -> { fail("Should have thrown exception"); }, new MappedFieldType[] { fieldType }).withQuery(
+            new MatchAllDocsQuery()
+        )));
     }
 
     public void testEmptyBucket() throws IOException {
@@ -300,7 +306,7 @@ public class MinAggregatorTests extends AggregatorTestCase {
 
         MappedFieldType fieldType = new NumberFieldMapper.NumberFieldType("number", NumberFieldMapper.NumberType.INTEGER);
 
-        testCase(histogram, new MatchAllDocsQuery(), iw -> {
+        testCase(new AggTestConfig<InternalHistogram>(histogram, iw -> {
             iw.addDocument(singleton(new NumericDocValuesField("number", 1)));
             iw.addDocument(singleton(new NumericDocValuesField("number", 3)));
         }, (Consumer<InternalHistogram>) histo -> {
@@ -321,7 +327,7 @@ public class MinAggregatorTests extends AggregatorTestCase {
             assertEquals(3.0, min.value(), 0);
             assertTrue(AggregationInspectionHelper.hasValue(min));
 
-        }, fieldType);
+        }, new MappedFieldType[] { fieldType }).withQuery(new MatchAllDocsQuery()));
     }
 
     public void testFormatter() throws IOException {
@@ -329,14 +335,14 @@ public class MinAggregatorTests extends AggregatorTestCase {
 
         MappedFieldType fieldType = new NumberFieldMapper.NumberFieldType("number", NumberFieldMapper.NumberType.INTEGER);
 
-        testCase(aggregationBuilder, new MatchAllDocsQuery(), iw -> {
+        testCase(new AggTestConfig<Min>(aggregationBuilder, iw -> {
             iw.addDocument(singleton(new NumericDocValuesField("number", 7)));
             iw.addDocument(singleton(new NumericDocValuesField("number", 1)));
         }, (Consumer<Min>) min -> {
             assertEquals(1.0, min.value(), 0);
             assertTrue(AggregationInspectionHelper.hasValue(min));
             assertEquals("0001.0", min.getValueAsString());
-        }, fieldType);
+        }, new MappedFieldType[] { fieldType }).withQuery(new MatchAllDocsQuery()));
     }
 
     public void testGetProperty() throws IOException {
@@ -346,7 +352,7 @@ public class MinAggregatorTests extends AggregatorTestCase {
 
         MappedFieldType fieldType = new NumberFieldMapper.NumberFieldType("number", NumberFieldMapper.NumberType.INTEGER);
 
-        testCase(globalBuilder, new MatchAllDocsQuery(), iw -> {
+        testCase(new AggTestConfig<InternalGlobal>(globalBuilder, iw -> {
             iw.addDocument(singleton(new NumericDocValuesField("number", 7)));
             iw.addDocument(singleton(new NumericDocValuesField("number", 1)));
         }, (Consumer<InternalGlobal>) global -> {
@@ -359,7 +365,7 @@ public class MinAggregatorTests extends AggregatorTestCase {
             assertThat(global.getProperty("min"), equalTo(min));
             assertThat(global.getProperty("min.value"), equalTo(1.0));
             assertThat(min.getProperty("value"), equalTo(1.0));
-        }, fieldType);
+        }, new MappedFieldType[] { fieldType }).withQuery(new MatchAllDocsQuery()));
     }
 
     public void testSingleValuedFieldPartiallyUnmapped() throws IOException {
@@ -429,7 +435,7 @@ public class MinAggregatorTests extends AggregatorTestCase {
         MinAggregationBuilder aggregationBuilder = new MinAggregationBuilder("min").field("number")
             .script(new Script(ScriptType.INLINE, MockScriptEngine.NAME, INVERT_SCRIPT, Collections.emptyMap()));
 
-        testCase(aggregationBuilder, new MatchAllDocsQuery(), iw -> {
+        testCase(new AggTestConfig<Min>(aggregationBuilder, iw -> {
             final int numDocs = 10;
             for (int i = 0; i < numDocs; i++) {
                 iw.addDocument(singleton(new NumericDocValuesField("number", i + 1)));
@@ -437,7 +443,7 @@ public class MinAggregatorTests extends AggregatorTestCase {
         }, (Consumer<Min>) min -> {
             assertEquals(-10.0, min.value(), 0);
             assertTrue(AggregationInspectionHelper.hasValue(min));
-        }, fieldType);
+        }, new MappedFieldType[] { fieldType }).withQuery(new MatchAllDocsQuery()));
     }
 
     public void testSingleValuedFieldWithValueScriptAndMissing() throws IOException {
@@ -447,7 +453,8 @@ public class MinAggregatorTests extends AggregatorTestCase {
             .missing(-100L)
             .script(new Script(ScriptType.INLINE, MockScriptEngine.NAME, INVERT_SCRIPT, Collections.emptyMap()));
 
-        testCase(aggregationBuilder, new MatchAllDocsQuery(), iw -> {
+        // Note: this comes straight from missing, and is not inverted from script
+        testCase(new AggTestConfig<Min>(aggregationBuilder, iw -> {
             final int numDocs = 10;
             for (int i = 0; i < numDocs; i++) {
                 iw.addDocument(singleton(new NumericDocValuesField("number", i + 1)));
@@ -456,7 +463,7 @@ public class MinAggregatorTests extends AggregatorTestCase {
         }, (Consumer<Min>) min -> {
             assertEquals(-100.0, min.value(), 0); // Note: this comes straight from missing, and is not inverted from script
             assertTrue(AggregationInspectionHelper.hasValue(min));
-        }, fieldType);
+        }, new MappedFieldType[] { fieldType }).withQuery(new MatchAllDocsQuery()));
     }
 
     public void testSingleValuedFieldWithValueScriptAndParams() throws IOException {
@@ -465,7 +472,7 @@ public class MinAggregatorTests extends AggregatorTestCase {
         MinAggregationBuilder aggregationBuilder = new MinAggregationBuilder("min").field("number")
             .script(new Script(ScriptType.INLINE, MockScriptEngine.NAME, VALUE_SCRIPT, Collections.singletonMap("inc", 5)));
 
-        testCase(aggregationBuilder, new MatchAllDocsQuery(), iw -> {
+        testCase(new AggTestConfig<Min>(aggregationBuilder, iw -> {
             final int numDocs = 10;
             for (int i = 0; i < numDocs; i++) {
                 iw.addDocument(singleton(new NumericDocValuesField("number", i + 1)));
@@ -473,7 +480,7 @@ public class MinAggregatorTests extends AggregatorTestCase {
         }, (Consumer<Min>) min -> {
             assertEquals(6.0, min.value(), 0);
             assertTrue(AggregationInspectionHelper.hasValue(min));
-        }, fieldType);
+        }, new MappedFieldType[] { fieldType }).withQuery(new MatchAllDocsQuery()));
     }
 
     public void testScript() throws IOException {
@@ -483,7 +490,7 @@ public class MinAggregatorTests extends AggregatorTestCase {
             new Script(ScriptType.INLINE, MockScriptEngine.NAME, SCRIPT_NAME, Collections.emptyMap())
         );
 
-        testCase(aggregationBuilder, new MatchAllDocsQuery(), iw -> {
+        testCase(new AggTestConfig<Min>(aggregationBuilder, iw -> {
             final int numDocs = 10;
             for (int i = 0; i < numDocs; i++) {
                 iw.addDocument(singleton(new NumericDocValuesField("number", i + 1)));
@@ -491,7 +498,7 @@ public class MinAggregatorTests extends AggregatorTestCase {
         }, (Consumer<Min>) min -> {
             assertEquals(19.0, min.value(), 0);
             assertTrue(AggregationInspectionHelper.hasValue(min));
-        }, fieldType);
+        }, new MappedFieldType[] { fieldType }).withQuery(new MatchAllDocsQuery()));
     }
 
     public void testMultiValuedField() throws IOException {
@@ -499,7 +506,7 @@ public class MinAggregatorTests extends AggregatorTestCase {
 
         MappedFieldType fieldType = new NumberFieldMapper.NumberFieldType("number", NumberFieldMapper.NumberType.INTEGER);
 
-        testCase(aggregationBuilder, new MatchAllDocsQuery(), iw -> {
+        testCase(new AggTestConfig<Min>(aggregationBuilder, iw -> {
             final int numDocs = 10;
             for (int i = 0; i < numDocs; i++) {
                 Document document = new Document();
@@ -510,7 +517,7 @@ public class MinAggregatorTests extends AggregatorTestCase {
         }, (Consumer<Min>) min -> {
             assertEquals(2.0, min.value(), 0);
             assertTrue(AggregationInspectionHelper.hasValue(min));
-        }, fieldType);
+        }, new MappedFieldType[] { fieldType }).withQuery(new MatchAllDocsQuery()));
     }
 
     public void testMultiValuedFieldWithScript() throws IOException {
@@ -519,7 +526,7 @@ public class MinAggregatorTests extends AggregatorTestCase {
 
         MappedFieldType fieldType = new NumberFieldMapper.NumberFieldType("number", NumberFieldMapper.NumberType.INTEGER);
 
-        testCase(aggregationBuilder, new MatchAllDocsQuery(), iw -> {
+        testCase(new AggTestConfig<Min>(aggregationBuilder, iw -> {
             final int numDocs = 10;
             for (int i = 0; i < numDocs; i++) {
                 Document document = new Document();
@@ -530,7 +537,7 @@ public class MinAggregatorTests extends AggregatorTestCase {
         }, (Consumer<Min>) min -> {
             assertEquals(-12.0, min.value(), 0);
             assertTrue(AggregationInspectionHelper.hasValue(min));
-        }, fieldType);
+        }, new MappedFieldType[] { fieldType }).withQuery(new MatchAllDocsQuery()));
     }
 
     public void testMultiValuedFieldWithScriptParams() throws IOException {
@@ -539,7 +546,7 @@ public class MinAggregatorTests extends AggregatorTestCase {
 
         MappedFieldType fieldType = new NumberFieldMapper.NumberFieldType("number", NumberFieldMapper.NumberType.INTEGER);
 
-        testCase(aggregationBuilder, new MatchAllDocsQuery(), iw -> {
+        testCase(new AggTestConfig<Min>(aggregationBuilder, iw -> {
             final int numDocs = 10;
             for (int i = 0; i < numDocs; i++) {
                 Document document = new Document();
@@ -550,7 +557,7 @@ public class MinAggregatorTests extends AggregatorTestCase {
         }, (Consumer<Min>) min -> {
             assertEquals(7.0, min.value(), 0);
             assertTrue(AggregationInspectionHelper.hasValue(min));
-        }, fieldType);
+        }, new MappedFieldType[] { fieldType }).withQuery(new MatchAllDocsQuery()));
     }
 
     public void testOrderByEmptyAggregation() throws IOException {
@@ -565,16 +572,16 @@ public class MinAggregatorTests extends AggregatorTestCase {
         MappedFieldType fieldType = new NumberFieldMapper.NumberFieldType("number", NumberFieldMapper.NumberType.INTEGER);
 
         int numDocs = 10;
-        testCase(termsBuilder, new MatchAllDocsQuery(), iw -> {
+        testCase(new AggTestConfig<InternalTerms<?, LongTerms.Bucket>>(termsBuilder, iw -> {
             for (int i = 0; i < numDocs; i++) {
                 iw.addDocument(singleton(new NumericDocValuesField("number", i + 1)));
             }
         }, (Consumer<InternalTerms<?, LongTerms.Bucket>>) terms -> {
-            for (int i = 0; i < numDocs; i++) {
+            for (int i1 = 0; i1 < numDocs; i1++) {
                 List<LongTerms.Bucket> buckets = terms.getBuckets();
-                Terms.Bucket bucket = buckets.get(i);
+                Terms.Bucket bucket = buckets.get(i1);
                 assertNotNull(bucket);
-                assertEquals((long) i + 1, bucket.getKeyAsNumber());
+                assertEquals((long) i1 + 1, bucket.getKeyAsNumber());
                 assertEquals(1L, bucket.getDocCount());
 
                 Filter filter = bucket.getAggregations().get("filter");
@@ -586,7 +593,7 @@ public class MinAggregatorTests extends AggregatorTestCase {
                 assertEquals(Double.POSITIVE_INFINITY, min.value(), 0);
                 assertFalse(AggregationInspectionHelper.hasValue(min));
             }
-        }, fieldType);
+        }, new MappedFieldType[] { fieldType }).withQuery(new MatchAllDocsQuery()));
     }
 
     public void testCaching() throws IOException {
@@ -718,6 +725,6 @@ public class MinAggregatorTests extends AggregatorTestCase {
         throws IOException {
         MappedFieldType fieldType = new NumberFieldMapper.NumberFieldType("number", NumberFieldMapper.NumberType.INTEGER);
         MinAggregationBuilder aggregationBuilder = new MinAggregationBuilder("min").field("number");
-        testCase(aggregationBuilder, query, buildIndex, verify, fieldType);
+        testCase(new AggTestConfig<Min>(aggregationBuilder, buildIndex, verify, new MappedFieldType[] { fieldType }).withQuery(query));
     }
 }

--- a/server/src/test/java/org/elasticsearch/search/aggregations/metrics/ScriptedMetricAggregatorTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/metrics/ScriptedMetricAggregatorTests.java
@@ -289,7 +289,7 @@ public class ScriptedMetricAggregatorTests extends AggregatorTestCase {
                 ScriptedMetricAggregationBuilder aggregationBuilder = new ScriptedMetricAggregationBuilder(AGG_NAME);
                 aggregationBuilder.mapScript(MAP_SCRIPT).combineScript(COMBINE_SCRIPT_NOOP).reduceScript(REDUCE_SCRIPT);
                 ScriptedMetric scriptedMetric = searchAndReduce(
-                    new AggTestConfig(newSearcher(indexReader, true, true), aggregationBuilder)
+                    new AggTestConfig<>(newSearcher(indexReader, true, true), aggregationBuilder)
                 );
                 assertEquals(AGG_NAME, scriptedMetric.getName());
                 assertNotNull(scriptedMetric.aggregation());
@@ -311,7 +311,7 @@ public class ScriptedMetricAggregatorTests extends AggregatorTestCase {
                 aggregationBuilder.initScript(INIT_SCRIPT).mapScript(MAP_SCRIPT).reduceScript(REDUCE_SCRIPT);
                 IllegalArgumentException exception = expectThrows(
                     IllegalArgumentException.class,
-                    () -> searchAndReduce(new AggTestConfig(newSearcher(indexReader, true, true), aggregationBuilder))
+                    () -> searchAndReduce(new AggTestConfig<>(newSearcher(indexReader, true, true), aggregationBuilder))
                 );
                 assertEquals(exception.getMessage(), "[combineScript] must not be null: [scriptedMetric]");
             }
@@ -331,7 +331,7 @@ public class ScriptedMetricAggregatorTests extends AggregatorTestCase {
                 aggregationBuilder.initScript(INIT_SCRIPT).mapScript(MAP_SCRIPT).combineScript(COMBINE_SCRIPT);
                 IllegalArgumentException exception = expectThrows(
                     IllegalArgumentException.class,
-                    () -> searchAndReduce(new AggTestConfig(newSearcher(indexReader, true, true), aggregationBuilder))
+                    () -> searchAndReduce(new AggTestConfig<>(newSearcher(indexReader, true, true), aggregationBuilder))
                 );
                 assertEquals(exception.getMessage(), "[reduceScript] must not be null: [scriptedMetric]");
             }
@@ -353,7 +353,7 @@ public class ScriptedMetricAggregatorTests extends AggregatorTestCase {
                 ScriptedMetricAggregationBuilder aggregationBuilder = new ScriptedMetricAggregationBuilder(AGG_NAME);
                 aggregationBuilder.initScript(INIT_SCRIPT).mapScript(MAP_SCRIPT).combineScript(COMBINE_SCRIPT).reduceScript(REDUCE_SCRIPT);
                 ScriptedMetric scriptedMetric = searchAndReduce(
-                    new AggTestConfig(newSearcher(indexReader, true, true), aggregationBuilder)
+                    new AggTestConfig<>(newSearcher(indexReader, true, true), aggregationBuilder)
                 );
                 assertEquals(AGG_NAME, scriptedMetric.getName());
                 assertNotNull(scriptedMetric.aggregation());
@@ -380,7 +380,7 @@ public class ScriptedMetricAggregatorTests extends AggregatorTestCase {
                     .combineScript(COMBINE_SCRIPT_SCORE)
                     .reduceScript(REDUCE_SCRIPT);
                 ScriptedMetric scriptedMetric = searchAndReduce(
-                    new AggTestConfig(newSearcher(indexReader, true, true), aggregationBuilder)
+                    new AggTestConfig<>(newSearcher(indexReader, true, true), aggregationBuilder)
                 );
                 assertEquals(AGG_NAME, scriptedMetric.getName());
                 assertNotNull(scriptedMetric.aggregation());
@@ -407,7 +407,7 @@ public class ScriptedMetricAggregatorTests extends AggregatorTestCase {
                     .combineScript(COMBINE_SCRIPT_PARAMS)
                     .reduceScript(REDUCE_SCRIPT);
                 ScriptedMetric scriptedMetric = searchAndReduce(
-                    new AggTestConfig(newSearcher(indexReader, true, true), aggregationBuilder)
+                    new AggTestConfig<>(newSearcher(indexReader, true, true), aggregationBuilder)
                 );
 
                 // The result value depends on the script params.
@@ -435,8 +435,8 @@ public class ScriptedMetricAggregatorTests extends AggregatorTestCase {
                     .mapScript(MAP_SCRIPT_PARAMS)
                     .combineScript(COMBINE_SCRIPT_PARAMS)
                     .reduceScript(REDUCE_SCRIPT_PARAMS);
-                ScriptedMetric scriptedMetric = searchAndReduce(
-                    new AggTestConfig(newSearcher(indexReader, true, true), aggregationBuilder).withMaxBuckets(0)
+                ScriptedMetric scriptedMetric = (ScriptedMetric) searchAndReduce(
+                    new AggTestConfig<>(newSearcher(indexReader, true, true), aggregationBuilder).withMaxBuckets(0)
                 );
 
                 // The result value depends on the script params.
@@ -464,7 +464,7 @@ public class ScriptedMetricAggregatorTests extends AggregatorTestCase {
 
                 IllegalArgumentException ex = expectThrows(
                     IllegalArgumentException.class,
-                    () -> searchAndReduce(new AggTestConfig(newSearcher(indexReader, true, true), aggregationBuilder))
+                    () -> searchAndReduce(new AggTestConfig<>(newSearcher(indexReader, true, true), aggregationBuilder))
                 );
                 assertEquals(
                     "Parameter name \"" + CONFLICTING_PARAM_NAME + "\" used in both aggregation and script parameters",
@@ -488,7 +488,7 @@ public class ScriptedMetricAggregatorTests extends AggregatorTestCase {
 
                 IllegalArgumentException ex = expectThrows(
                     IllegalArgumentException.class,
-                    () -> searchAndReduce(new AggTestConfig(newSearcher(indexReader, true, true), aggregationBuilder))
+                    () -> searchAndReduce(new AggTestConfig<>(newSearcher(indexReader, true, true), aggregationBuilder))
                 );
                 assertEquals("Iterable object is self-referencing itself (Scripted metric aggs init script)", ex.getMessage());
             }
@@ -512,7 +512,7 @@ public class ScriptedMetricAggregatorTests extends AggregatorTestCase {
 
                 IllegalArgumentException ex = expectThrows(
                     IllegalArgumentException.class,
-                    () -> searchAndReduce(new AggTestConfig(newSearcher(indexReader, true, true), aggregationBuilder))
+                    () -> searchAndReduce(new AggTestConfig<>(newSearcher(indexReader, true, true), aggregationBuilder))
                 );
                 assertEquals("Iterable object is self-referencing itself (Scripted metric aggs map script)", ex.getMessage());
             }
@@ -533,7 +533,7 @@ public class ScriptedMetricAggregatorTests extends AggregatorTestCase {
 
                 IllegalArgumentException ex = expectThrows(
                     IllegalArgumentException.class,
-                    () -> searchAndReduce(new AggTestConfig(newSearcher(indexReader, true, true), aggregationBuilder))
+                    () -> searchAndReduce(new AggTestConfig<>(newSearcher(indexReader, true, true), aggregationBuilder))
                 );
                 assertEquals("Iterable object is self-referencing itself (Scripted metric aggs combine script)", ex.getMessage());
             }

--- a/server/src/test/java/org/elasticsearch/search/aggregations/metrics/ScriptedMetricAggregatorTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/metrics/ScriptedMetricAggregatorTests.java
@@ -13,7 +13,6 @@ import org.apache.lucene.document.SortedNumericDocValuesField;
 import org.apache.lucene.document.SortedSetDocValuesField;
 import org.apache.lucene.index.DirectoryReader;
 import org.apache.lucene.index.IndexReader;
-import org.apache.lucene.search.MatchAllDocsQuery;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.tests.index.RandomIndexWriter;
 import org.apache.lucene.util.BytesRef;
@@ -22,7 +21,6 @@ import org.elasticsearch.common.breaker.CircuitBreakingException;
 import org.elasticsearch.common.breaker.NoopCircuitBreaker;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.core.CheckedConsumer;
-import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.indices.breaker.CircuitBreakerService;
 import org.elasticsearch.script.MockScriptEngine;
 import org.elasticsearch.script.Script;
@@ -550,10 +548,9 @@ public class ScriptedMetricAggregatorTests extends AggregatorTestCase {
         testCase(
             new AggTestConfig<InternalScriptedMetric>(
                 aggregationBuilder,
-                iw -> { iw.addDocument(new Document()); },
-                (InternalScriptedMetric r) -> { assertEquals(1, r.aggregation()); },
-                new MappedFieldType[] {}
-            ).withQuery(new MatchAllDocsQuery())
+                iw -> iw.addDocument(new Document()),
+                r -> assertEquals(1, r.aggregation())
+            )
         );
     }
 
@@ -581,13 +578,6 @@ public class ScriptedMetricAggregatorTests extends AggregatorTestCase {
             ScriptedMetric oddMetric = odd.getAggregations().get("scripted");
             assertThat(oddMetric.aggregation(), equalTo(49));
         };
-        testCase(
-            new AggTestConfig<StringTerms>(
-                aggregationBuilder,
-                buildIndex,
-                verify,
-                new MappedFieldType[] { keywordField("t"), longField("number") }
-            ).withQuery(new MatchAllDocsQuery())
-        );
+        testCase(new AggTestConfig<>(aggregationBuilder, buildIndex, verify, keywordField("t"), longField("number")));
     }
 }

--- a/server/src/test/java/org/elasticsearch/search/aggregations/metrics/StatsAggregatorTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/metrics/StatsAggregatorTests.java
@@ -394,7 +394,7 @@ public class StatsAggregatorTests extends AggregatorTestCase {
         Consumer<InternalStats> verify,
         MappedFieldType... fieldTypes
     ) throws IOException {
-        testCase(new AggTestConfig<InternalStats>(builder, buildIndex, verify, fieldTypes).withQuery(new MatchAllDocsQuery()));
+        testCase(new AggTestConfig<>(builder, buildIndex, verify, fieldTypes).withQuery(new MatchAllDocsQuery()));
     }
 
     static class SimpleStatsAggregator {

--- a/server/src/test/java/org/elasticsearch/search/aggregations/metrics/StatsAggregatorTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/metrics/StatsAggregatorTests.java
@@ -223,7 +223,7 @@ public class StatsAggregatorTests extends AggregatorTestCase {
             ) {
 
                 final IndexSearcher searcher = new IndexSearcher(multiReader);
-                final InternalStats stats = searchAndReduce(new AggTestConfig(searcher, builder, ft));
+                final InternalStats stats = searchAndReduce(new AggTestConfig<>(searcher, builder, ft));
 
                 assertEquals(expected.count, stats.getCount(), 0);
                 assertEquals(expected.sum, stats.getSum(), TOLERANCE);

--- a/server/src/test/java/org/elasticsearch/search/aggregations/metrics/StatsAggregatorTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/metrics/StatsAggregatorTests.java
@@ -394,7 +394,7 @@ public class StatsAggregatorTests extends AggregatorTestCase {
         Consumer<InternalStats> verify,
         MappedFieldType... fieldTypes
     ) throws IOException {
-        testCase(builder, new MatchAllDocsQuery(), buildIndex, verify, fieldTypes);
+        testCase(new AggTestConfig<InternalStats>(builder, buildIndex, verify, fieldTypes).withQuery(new MatchAllDocsQuery()));
     }
 
     static class SimpleStatsAggregator {

--- a/server/src/test/java/org/elasticsearch/search/aggregations/metrics/SumAggregatorTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/metrics/SumAggregatorTests.java
@@ -379,7 +379,7 @@ public class SumAggregatorTests extends AggregatorTestCase {
         Consumer<Sum> verify,
         MappedFieldType... fieldTypes
     ) throws IOException {
-        testCase(aggregationBuilder, query, indexer, verify, fieldTypes);
+        testCase(new AggTestConfig<Sum>(aggregationBuilder, indexer, verify, fieldTypes).withQuery(query));
     }
 
     @Override

--- a/server/src/test/java/org/elasticsearch/search/aggregations/metrics/SumAggregatorTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/metrics/SumAggregatorTests.java
@@ -379,7 +379,7 @@ public class SumAggregatorTests extends AggregatorTestCase {
         Consumer<Sum> verify,
         MappedFieldType... fieldTypes
     ) throws IOException {
-        testCase(new AggTestConfig<Sum>(aggregationBuilder, indexer, verify, fieldTypes).withQuery(query));
+        testCase(new AggTestConfig<>(aggregationBuilder, indexer, verify, fieldTypes).withQuery(query));
     }
 
     @Override

--- a/server/src/test/java/org/elasticsearch/search/aggregations/metrics/SumAggregatorTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/metrics/SumAggregatorTests.java
@@ -241,7 +241,7 @@ public class SumAggregatorTests extends AggregatorTestCase {
 
                 final IndexSearcher searcher = newSearcher(multiReader, true, true);
 
-                final Sum internalSum = searchAndReduce(new AggTestConfig(searcher, builder, fieldType));
+                final Sum internalSum = searchAndReduce(new AggTestConfig<>(searcher, builder, fieldType));
                 assertEquals(sum, internalSum.value(), 0d);
                 assertTrue(AggregationInspectionHelper.hasValue(internalSum));
             }

--- a/server/src/test/java/org/elasticsearch/search/aggregations/metrics/TDigestPercentileRanksAggregatorTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/metrics/TDigestPercentileRanksAggregatorTests.java
@@ -48,7 +48,7 @@ public class TDigestPercentileRanksAggregatorTests extends AggregatorTestCase {
         MappedFieldType fieldType = new NumberFieldMapper.NumberFieldType("field", NumberFieldMapper.NumberType.DOUBLE);
         try (IndexReader reader = new MultiReader()) {
             IndexSearcher searcher = new IndexSearcher(reader);
-            PercentileRanks ranks = searchAndReduce(new AggTestConfig(searcher, aggBuilder, fieldType));
+            PercentileRanks ranks = searchAndReduce(new AggTestConfig<>(searcher, aggBuilder, fieldType));
             Percentile rank = ranks.iterator().next();
             assertEquals(Double.NaN, rank.getPercent(), 0d);
             assertEquals(0.5, rank.getValue(), 0d);
@@ -70,7 +70,7 @@ public class TDigestPercentileRanksAggregatorTests extends AggregatorTestCase {
             MappedFieldType fieldType = new NumberFieldMapper.NumberFieldType("field", NumberFieldMapper.NumberType.DOUBLE);
             try (IndexReader reader = w.getReader()) {
                 IndexSearcher searcher = new IndexSearcher(reader);
-                PercentileRanks ranks = searchAndReduce(new AggTestConfig(searcher, aggBuilder, fieldType));
+                PercentileRanks ranks = searchAndReduce(new AggTestConfig<>(searcher, aggBuilder, fieldType));
                 Iterator<Percentile> rankIterator = ranks.iterator();
                 Percentile rank = rankIterator.next();
                 assertEquals(0.1, rank.getValue(), 0d);

--- a/server/src/test/java/org/elasticsearch/search/aggregations/metrics/TopHitsAggregatorTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/metrics/TopHitsAggregatorTests.java
@@ -130,7 +130,7 @@ public class TopHitsAggregatorTests extends AggregatorTestCase {
         // We do not use LuceneTestCase.newSearcher because we need a DirectoryReader for "testInsideTerms"
         IndexSearcher indexSearcher = new IndexSearcher(indexReader);
 
-        Aggregation result = searchAndReduce(new AggTestConfig(indexSearcher, query, builder, STRING_FIELD_TYPE));
+        Aggregation result = searchAndReduce(new AggTestConfig<>(indexSearcher, query, builder, STRING_FIELD_TYPE));
         indexReader.close();
         directory.close();
         return result;
@@ -185,7 +185,7 @@ public class TopHitsAggregatorTests extends AggregatorTestCase {
             .add(new TermQuery(new Term("string", "baz")), Occur.SHOULD)
             .build();
         AggregationBuilder agg = AggregationBuilders.topHits("top_hits");
-        TopHits result = searchAndReduce(new AggTestConfig(searcher, query, agg, STRING_FIELD_TYPE));
+        TopHits result = searchAndReduce(new AggTestConfig<>(searcher, query, agg, STRING_FIELD_TYPE));
         assertEquals(3, result.getHits().getTotalHits().value);
         reader.close();
         directory.close();

--- a/server/src/test/java/org/elasticsearch/search/aggregations/metrics/ValueCountAggregatorTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/metrics/ValueCountAggregatorTests.java
@@ -382,7 +382,7 @@ public class ValueCountAggregatorTests extends AggregatorTestCase {
         Consumer<InternalValueCount> verify,
         MappedFieldType... fieldTypes
     ) throws IOException {
-        testCase(aggregationBuilder, query, buildIndex, verify, fieldTypes);
+        testCase(new AggTestConfig<InternalValueCount>(aggregationBuilder, buildIndex, verify, fieldTypes).withQuery(query));
     }
 
     private static MappedFieldType createMappedFieldType(String name, ValueType valueType) {

--- a/server/src/test/java/org/elasticsearch/search/aggregations/metrics/ValueCountAggregatorTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/metrics/ValueCountAggregatorTests.java
@@ -382,7 +382,7 @@ public class ValueCountAggregatorTests extends AggregatorTestCase {
         Consumer<InternalValueCount> verify,
         MappedFieldType... fieldTypes
     ) throws IOException {
-        testCase(new AggTestConfig<InternalValueCount>(aggregationBuilder, buildIndex, verify, fieldTypes).withQuery(query));
+        testCase(new AggTestConfig<>(aggregationBuilder, buildIndex, verify, fieldTypes).withQuery(query));
     }
 
     private static MappedFieldType createMappedFieldType(String name, ValueType valueType) {

--- a/server/src/test/java/org/elasticsearch/search/aggregations/metrics/ValueCountAggregatorTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/metrics/ValueCountAggregatorTests.java
@@ -198,41 +198,41 @@ public class ValueCountAggregatorTests extends AggregatorTestCase {
     public void testUnmappedMissingString() throws IOException {
         ValueCountAggregationBuilder aggregationBuilder = new ValueCountAggregationBuilder("name").field("number").missing("🍌🍌🍌");
 
-        testAggregation(aggregationBuilder, new MatchAllDocsQuery(), iw -> {
+        testCase(new AggTestConfig<InternalValueCount>(aggregationBuilder, iw -> {
             iw.addDocument(singleton(new NumericDocValuesField("unrelatedField", 7)));
             iw.addDocument(singleton(new NumericDocValuesField("unrelatedField", 8)));
             iw.addDocument(singleton(new NumericDocValuesField("unrelatedField", 9)));
         }, valueCount -> {
             assertEquals(3, valueCount.getValue(), 0);
             assertTrue(AggregationInspectionHelper.hasValue(valueCount));
-        });
+        }));
     }
 
     public void testUnmappedMissingNumber() throws IOException {
         ValueCountAggregationBuilder aggregationBuilder = new ValueCountAggregationBuilder("name").field("number").missing(1234);
 
-        testAggregation(aggregationBuilder, new MatchAllDocsQuery(), iw -> {
+        testCase(new AggTestConfig<InternalValueCount>(aggregationBuilder, iw -> {
             iw.addDocument(singleton(new NumericDocValuesField("unrelatedField", 7)));
             iw.addDocument(singleton(new NumericDocValuesField("unrelatedField", 8)));
             iw.addDocument(singleton(new NumericDocValuesField("unrelatedField", 9)));
         }, valueCount -> {
             assertEquals(3, valueCount.getValue(), 0);
             assertTrue(AggregationInspectionHelper.hasValue(valueCount));
-        });
+        }));
     }
 
     public void testUnmappedMissingGeoPoint() throws IOException {
         ValueCountAggregationBuilder aggregationBuilder = new ValueCountAggregationBuilder("name").field("number")
             .missing(new GeoPoint(42.39561, -71.13051));
 
-        testAggregation(aggregationBuilder, new MatchAllDocsQuery(), iw -> {
+        testCase(new AggTestConfig<InternalValueCount>(aggregationBuilder, iw -> {
             iw.addDocument(singleton(new NumericDocValuesField("unrelatedField", 7)));
             iw.addDocument(singleton(new NumericDocValuesField("unrelatedField", 8)));
             iw.addDocument(singleton(new NumericDocValuesField("unrelatedField", 9)));
         }, valueCount -> {
             assertEquals(3, valueCount.getValue(), 0);
             assertTrue(AggregationInspectionHelper.hasValue(valueCount));
-        });
+        }));
     }
 
     public void testRangeFieldValues() throws IOException {
@@ -242,7 +242,7 @@ public class ValueCountAggregatorTests extends AggregatorTestCase {
         final String fieldName = "rangeField";
         MappedFieldType fieldType = new RangeFieldMapper.RangeFieldType(fieldName, rangeType);
         final ValueCountAggregationBuilder aggregationBuilder = new ValueCountAggregationBuilder("_name").field(fieldName);
-        testAggregation(aggregationBuilder, new MatchAllDocsQuery(), iw -> {
+        testCase(new AggTestConfig<InternalValueCount>(aggregationBuilder, iw -> {
             iw.addDocument(singleton(new BinaryDocValuesField(fieldName, rangeType.encodeRanges(singleton(range1)))));
             iw.addDocument(singleton(new BinaryDocValuesField(fieldName, rangeType.encodeRanges(singleton(range1)))));
             iw.addDocument(singleton(new BinaryDocValuesField(fieldName, rangeType.encodeRanges(singleton(range2)))));
@@ -250,7 +250,7 @@ public class ValueCountAggregatorTests extends AggregatorTestCase {
         }, count -> {
             assertEquals(4.0, count.getValue(), 0);
             assertTrue(AggregationInspectionHelper.hasValue(count));
-        }, fieldType);
+        }, fieldType));
     }
 
     public void testValueScriptNumber() throws IOException {
@@ -259,14 +259,14 @@ public class ValueCountAggregatorTests extends AggregatorTestCase {
 
         MappedFieldType fieldType = createMappedFieldType(FIELD_NAME, ValueType.NUMERIC);
 
-        testAggregation(aggregationBuilder, new MatchAllDocsQuery(), iw -> {
+        testCase(new AggTestConfig<InternalValueCount>(aggregationBuilder, iw -> {
             iw.addDocument(singleton(new NumericDocValuesField(FIELD_NAME, 7)));
             iw.addDocument(singleton(new NumericDocValuesField(FIELD_NAME, 8)));
             iw.addDocument(singleton(new NumericDocValuesField(FIELD_NAME, 9)));
         }, valueCount -> {
             assertEquals(3, valueCount.getValue(), 0);
             assertTrue(AggregationInspectionHelper.hasValue(valueCount));
-        }, fieldType);
+        }, fieldType));
     }
 
     public void testSingleScriptNumber() throws IOException {
@@ -276,7 +276,9 @@ public class ValueCountAggregatorTests extends AggregatorTestCase {
 
         MappedFieldType fieldType = createMappedFieldType(FIELD_NAME, ValueType.NUMERIC);
 
-        testAggregation(aggregationBuilder, new MatchAllDocsQuery(), iw -> {
+        // Note: The field values won't be taken into account. The script will only be called
+        // once per document, and only expect a count of 3
+        testCase(new AggTestConfig<InternalValueCount>(aggregationBuilder, iw -> {
             Document doc = new Document();
             doc.add(new SortedNumericDocValuesField(FIELD_NAME, 7));
             doc.add(new SortedNumericDocValuesField(FIELD_NAME, 7));
@@ -296,7 +298,7 @@ public class ValueCountAggregatorTests extends AggregatorTestCase {
             // once per document, and only expect a count of 3
             assertEquals(3, valueCount.getValue(), 0);
             assertTrue(AggregationInspectionHelper.hasValue(valueCount));
-        }, fieldType);
+        }, fieldType));
     }
 
     public void testValueScriptString() throws IOException {
@@ -305,14 +307,14 @@ public class ValueCountAggregatorTests extends AggregatorTestCase {
 
         MappedFieldType fieldType = createMappedFieldType(FIELD_NAME, ValueType.STRING);
 
-        testAggregation(aggregationBuilder, new MatchAllDocsQuery(), iw -> {
+        testCase(new AggTestConfig<InternalValueCount>(aggregationBuilder, iw -> {
             iw.addDocument(singleton(new SortedDocValuesField(FIELD_NAME, new BytesRef("1"))));
             iw.addDocument(singleton(new SortedDocValuesField(FIELD_NAME, new BytesRef("2"))));
             iw.addDocument(singleton(new SortedDocValuesField(FIELD_NAME, new BytesRef("3"))));
         }, valueCount -> {
             assertEquals(3, valueCount.getValue(), 0);
             assertTrue(AggregationInspectionHelper.hasValue(valueCount));
-        }, fieldType);
+        }, fieldType));
     }
 
     public void testSingleScriptString() throws IOException {
@@ -322,7 +324,7 @@ public class ValueCountAggregatorTests extends AggregatorTestCase {
 
         MappedFieldType fieldType = createMappedFieldType(FIELD_NAME, ValueType.STRING);
 
-        testAggregation(aggregationBuilder, new MatchAllDocsQuery(), iw -> {
+        testCase(new AggTestConfig<InternalValueCount>(aggregationBuilder, iw -> {
             Document doc = new Document();
             // Note: unlike numerics, lucene de-dupes strings so we increment here
             doc.add(new SortedSetDocValuesField(FIELD_NAME, new BytesRef("1")));
@@ -343,7 +345,7 @@ public class ValueCountAggregatorTests extends AggregatorTestCase {
             // once per document, and only expect a count of 3
             assertEquals(3, valueCount.getValue(), 0);
             assertTrue(AggregationInspectionHelper.hasValue(valueCount));
-        }, fieldType);
+        }, fieldType));
     }
 
     private void testAggregation(
@@ -372,17 +374,7 @@ public class ValueCountAggregatorTests extends AggregatorTestCase {
         }
         aggregationBuilder.field(FIELD_NAME);
 
-        testAggregation(aggregationBuilder, query, indexer, verify, fieldType);
-    }
-
-    private void testAggregation(
-        AggregationBuilder aggregationBuilder,
-        Query query,
-        CheckedConsumer<RandomIndexWriter, IOException> buildIndex,
-        Consumer<InternalValueCount> verify,
-        MappedFieldType... fieldTypes
-    ) throws IOException {
-        testCase(new AggTestConfig<>(aggregationBuilder, buildIndex, verify, fieldTypes).withQuery(query));
+        testCase(new AggTestConfig<InternalValueCount>(aggregationBuilder, indexer, verify, fieldType).withQuery(query));
     }
 
     private static MappedFieldType createMappedFieldType(String name, ValueType valueType) {

--- a/server/src/test/java/org/elasticsearch/search/aggregations/pipeline/AvgBucketAggregatorTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/pipeline/AvgBucketAggregatorTests.java
@@ -111,11 +111,11 @@ public class AvgBucketAggregatorTests extends AggregatorTestCase {
 
                 MappedFieldType valueFieldType = new NumberFieldMapper.NumberFieldType(VALUE_FIELD, NumberFieldMapper.NumberType.LONG);
 
-                avgResult = searchAndReduce(
-                    new AggTestConfig(indexSearcher, query, avgBuilder, fieldType, valueFieldType).withMaxBuckets(10000)
+                avgResult = (InternalAvg) searchAndReduce(
+                    new AggTestConfig<>(indexSearcher, query, avgBuilder, fieldType, valueFieldType).withMaxBuckets(10000)
                 );
-                histogramResult = searchAndReduce(
-                    new AggTestConfig(indexSearcher, query, histo, fieldType, valueFieldType).withMaxBuckets(10000)
+                histogramResult = (InternalDateHistogram) searchAndReduce(
+                    new AggTestConfig<>(indexSearcher, query, histo, fieldType, valueFieldType).withMaxBuckets(10000)
                 );
             }
 
@@ -171,7 +171,7 @@ public class AvgBucketAggregatorTests extends AggregatorTestCase {
                 MappedFieldType keywordField = keywordField(textField);
 
                 filterResult = searchAndReduce(
-                    new AggTestConfig(
+                    new AggTestConfig<>(
                         indexSearcher,
                         query,
                         filterAggregationBuilder,

--- a/server/src/test/java/org/elasticsearch/search/aggregations/pipeline/BucketScriptAggregatorTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/pipeline/BucketScriptAggregatorTests.java
@@ -113,7 +113,7 @@ public class BucketScriptAggregatorTests extends AggregatorTestCase {
                 IndexSearcher indexSearcher = newIndexSearcher(indexReader);
 
                 InternalFilters filters;
-                filters = searchAndReduce(new AggTestConfig(indexSearcher, query, aggregationBuilder, fieldType));
+                filters = searchAndReduce(new AggTestConfig<>(indexSearcher, query, aggregationBuilder, fieldType));
                 verify.accept(filters);
             }
         }

--- a/server/src/test/java/org/elasticsearch/search/aggregations/pipeline/CumulativeSumAggregatorTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/pipeline/CumulativeSumAggregatorTests.java
@@ -313,7 +313,7 @@ public class CumulativeSumAggregatorTests extends AggregatorTestCase {
 
                 InternalAggregation histogram;
                 histogram = searchAndReduce(
-                    new AggTestConfig(indexSearcher, query, aggBuilder, new MappedFieldType[] { fieldType, valueFieldType })
+                    new AggTestConfig<>(indexSearcher, query, aggBuilder, new MappedFieldType[] { fieldType, valueFieldType })
                 );
                 verify.accept(histogram);
             }

--- a/server/src/test/java/org/elasticsearch/search/aggregations/pipeline/DerivativeAggregatorTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/pipeline/DerivativeAggregatorTests.java
@@ -660,7 +660,7 @@ public class DerivativeAggregatorTests extends AggregatorTestCase {
 
             try (IndexReader indexReader = DirectoryReader.open(directory)) {
                 IndexSearcher indexSearcher = newSearcher(indexReader, true, true);
-                searchAndReduce(new AggTestConfig(indexSearcher, query, aggBuilder));
+                searchAndReduce(new AggTestConfig<>(indexSearcher, query, aggBuilder));
             }
         }
     }
@@ -716,7 +716,7 @@ public class DerivativeAggregatorTests extends AggregatorTestCase {
                 MappedFieldType valueFieldType = new NumberFieldMapper.NumberFieldType("value_field", NumberFieldMapper.NumberType.LONG);
 
                 InternalAggregation histogram = searchAndReduce(
-                    new AggTestConfig(indexSearcher, query, aggBuilder, fieldType, valueFieldType)
+                    new AggTestConfig<>(indexSearcher, query, aggBuilder, fieldType, valueFieldType)
                 );
 
                 verify.accept(histogram);

--- a/server/src/test/java/org/elasticsearch/search/aggregations/pipeline/MovFnAggrgatorTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/pipeline/MovFnAggrgatorTests.java
@@ -137,8 +137,8 @@ public class MovFnAggrgatorTests extends AggregatorTestCase {
                 MappedFieldType valueFieldType = new NumberFieldMapper.NumberFieldType("value_field", NumberFieldMapper.NumberType.LONG);
 
                 InternalDateHistogram histogram;
-                histogram = searchAndReduce(
-                    new AggTestConfig(indexSearcher, query, aggBuilder, fieldType, valueFieldType).withMaxBuckets(1000)
+                histogram = (InternalDateHistogram) searchAndReduce(
+                    new AggTestConfig<>(indexSearcher, query, aggBuilder, fieldType, valueFieldType).withMaxBuckets(1000)
                 );
                 verify.accept(histogram);
             }

--- a/server/src/test/java/org/elasticsearch/search/aggregations/timeseries/TimeSeriesAggregatorTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/timeseries/TimeSeriesAggregatorTests.java
@@ -111,7 +111,7 @@ public class TimeSeriesAggregatorTests extends AggregatorTestCase {
         newFieldTypes[1] = new DateFieldMapper.DateFieldType("@timestamp");
         System.arraycopy(fieldTypes, 0, newFieldTypes, 2, fieldTypes.length);
 
-        testCase(new AggTestConfig<InternalTimeSeries>(builder, buildIndex, verify, newFieldTypes).withQuery(query));
+        testCase(new AggTestConfig<>(builder, buildIndex, verify, newFieldTypes).withQuery(query));
     }
 
 }

--- a/server/src/test/java/org/elasticsearch/search/aggregations/timeseries/TimeSeriesAggregatorTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/timeseries/TimeSeriesAggregatorTests.java
@@ -111,7 +111,7 @@ public class TimeSeriesAggregatorTests extends AggregatorTestCase {
         newFieldTypes[1] = new DateFieldMapper.DateFieldType("@timestamp");
         System.arraycopy(fieldTypes, 0, newFieldTypes, 2, fieldTypes.length);
 
-        testCase(builder, query, buildIndex, verify, newFieldTypes);
+        testCase(new AggTestConfig<InternalTimeSeries>(builder, buildIndex, verify, newFieldTypes).withQuery(query));
     }
 
 }

--- a/test/framework/src/main/java/org/elasticsearch/search/aggregations/AggregatorTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/search/aggregations/AggregatorTestCase.java
@@ -608,16 +608,6 @@ public abstract class AggregatorTestCase extends ESTestCase {
         InternalAggregationTestCase.assertMultiBucketConsumer(agg, bucketConsumer);
     }
 
-    protected <T extends AggregationBuilder, V extends InternalAggregation> void testCase(
-        T builder,
-        Query query,
-        CheckedConsumer<RandomIndexWriter, IOException> buildIndex,
-        Consumer<V> verify,
-        MappedFieldType... fieldTypes
-    ) throws IOException {
-        testCase(new AggTestConfig<V>(builder, buildIndex, verify, fieldTypes).withQuery(query));
-    }
-
     protected <T extends AggregationBuilder, V extends InternalAggregation> void testCase(AggTestConfig<V> aggTestConfig)
         throws IOException {
         boolean timeSeries = aggTestConfig.builder().isInSortOrderExecutionRequired();

--- a/test/framework/src/main/java/org/elasticsearch/search/aggregations/bucket/geogrid/GeoGridAggregatorTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/search/aggregations/bucket/geogrid/GeoGridAggregatorTestCase.java
@@ -32,6 +32,7 @@ import org.elasticsearch.search.aggregations.Aggregation;
 import org.elasticsearch.search.aggregations.AggregationBuilder;
 import org.elasticsearch.search.aggregations.Aggregator;
 import org.elasticsearch.search.aggregations.AggregatorTestCase;
+import org.elasticsearch.search.aggregations.InternalAggregation;
 import org.elasticsearch.search.aggregations.MultiBucketConsumerService;
 import org.elasticsearch.search.aggregations.bucket.terms.StringTerms;
 import org.elasticsearch.search.aggregations.bucket.terms.TermsAggregationBuilder;
@@ -214,7 +215,7 @@ public abstract class GeoGridAggregatorTestCase<T extends InternalGeoGridBucket>
             gridBuilder.setGeoBoundingBox(bbox);
         }
         aggregationBuilder.subAggregation(gridBuilder);
-        testCase(aggregationBuilder, new MatchAllDocsQuery(), iw -> {
+        testCase(new AggTestConfig<InternalAggregation>(aggregationBuilder, iw -> {
             List<IndexableField> fields = new ArrayList<>();
             Set<String> distinctHashesPerDoc = new HashSet<>();
             String t = randomAlphaOfLength(1);
@@ -254,7 +255,7 @@ public abstract class GeoGridAggregatorTestCase<T extends InternalGeoGridBucket>
                 actual.put(tb.getKeyAsString(), sub);
             }
             assertThat(actual, equalTo(expectedCountPerTPerGeoHash));
-        }, keywordField("t"), geoPointField(FIELD_NAME));
+        }, keywordField("t"), geoPointField(FIELD_NAME)).withQuery(new MatchAllDocsQuery()));
     }
 
     private double[] randomLatLng() {

--- a/x-pack/plugin/analytics/src/test/java/org/elasticsearch/xpack/analytics/aggregations/metrics/HistoBackedAvgAggregatorTests.java
+++ b/x-pack/plugin/analytics/src/test/java/org/elasticsearch/xpack/analytics/aggregations/metrics/HistoBackedAvgAggregatorTests.java
@@ -111,10 +111,7 @@ public class HistoBackedAvgAggregatorTests extends AggregatorTestCase {
 
     private void testCase(Query query, CheckedConsumer<RandomIndexWriter, IOException> indexer, Consumer<InternalAvg> verify)
         throws IOException {
-        testCase(
-            new AggTestConfig<InternalAvg>(avg("_name").field(FIELD_NAME), indexer, verify, new MappedFieldType[] { defaultFieldType() })
-                .withQuery(query)
-        );
+        testCase(new AggTestConfig<>(avg("_name").field(FIELD_NAME), indexer, verify, defaultFieldType()).withQuery(query));
     }
 
     @Override

--- a/x-pack/plugin/analytics/src/test/java/org/elasticsearch/xpack/analytics/aggregations/metrics/HistoBackedAvgAggregatorTests.java
+++ b/x-pack/plugin/analytics/src/test/java/org/elasticsearch/xpack/analytics/aggregations/metrics/HistoBackedAvgAggregatorTests.java
@@ -9,11 +9,7 @@ package org.elasticsearch.xpack.analytics.aggregations.metrics;
 import org.apache.lucene.document.Field;
 import org.apache.lucene.document.StringField;
 import org.apache.lucene.index.Term;
-import org.apache.lucene.search.MatchAllDocsQuery;
-import org.apache.lucene.search.Query;
 import org.apache.lucene.search.TermQuery;
-import org.apache.lucene.tests.index.RandomIndexWriter;
-import org.elasticsearch.core.CheckedConsumer;
 import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.plugins.SearchPlugin;
 import org.elasticsearch.search.aggregations.AggregationBuilder;
@@ -31,7 +27,6 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
-import java.util.function.Consumer;
 
 import static java.util.Collections.singleton;
 import static org.elasticsearch.search.aggregations.AggregationBuilders.avg;
@@ -42,37 +37,37 @@ public class HistoBackedAvgAggregatorTests extends AggregatorTestCase {
     private static final String FIELD_NAME = "field";
 
     public void testNoDocs() throws IOException {
-        testCase(new MatchAllDocsQuery(), iw -> {
+        testCase(new AggTestConfig<InternalAvg>(avg("_name").field(FIELD_NAME), iw -> {
             // Intentionally not writing any docs
         }, avg -> {
             assertEquals(Double.NaN, avg.getValue(), 0d);
             assertFalse(AggregationInspectionHelper.hasValue(avg));
-        });
+        }, defaultFieldType()));
     }
 
     public void testNoMatchingField() throws IOException {
-        testCase(new MatchAllDocsQuery(), iw -> {
+        testCase(new AggTestConfig<InternalAvg>(avg("_name").field(FIELD_NAME), iw -> {
             iw.addDocument(singleton(histogramFieldDocValues("wrong_field", new double[] { 3, 1.2, 10 })));
             iw.addDocument(singleton(histogramFieldDocValues("wrong_field", new double[] { 5.3, 6, 20 })));
         }, avg -> {
             assertEquals(Double.NaN, avg.getValue(), 0d);
             assertFalse(AggregationInspectionHelper.hasValue(avg));
-        });
+        }, defaultFieldType()));
     }
 
     public void testSimpleHistogram() throws IOException {
-        testCase(new MatchAllDocsQuery(), iw -> {
+        testCase(new AggTestConfig<InternalAvg>(avg("_name").field(FIELD_NAME), iw -> {
             iw.addDocument(singleton(histogramFieldDocValues(FIELD_NAME, new double[] { 3, 1.2, 10 })));
             iw.addDocument(singleton(histogramFieldDocValues(FIELD_NAME, new double[] { 5.3, 6, 6, 20 })));
             iw.addDocument(singleton(histogramFieldDocValues(FIELD_NAME, new double[] { -10, 0.01, 1, 90 })));
         }, avg -> {
             assertEquals(12.0463d, avg.getValue(), 0.01d);
             assertTrue(AggregationInspectionHelper.hasValue(avg));
-        });
+        }, defaultFieldType()));
     }
 
     public void testQueryFiltering() throws IOException {
-        testCase(new TermQuery(new Term("match", "yes")), iw -> {
+        testCase(new AggTestConfig<InternalAvg>(avg("_name").field(FIELD_NAME), iw -> {
             iw.addDocument(
                 Arrays.asList(
                     new StringField("match", "yes", Field.Store.NO),
@@ -106,12 +101,7 @@ public class HistoBackedAvgAggregatorTests extends AggregatorTestCase {
         }, avg -> {
             assertEquals(12.651d, avg.getValue(), 0.01d);
             assertTrue(AggregationInspectionHelper.hasValue(avg));
-        });
-    }
-
-    private void testCase(Query query, CheckedConsumer<RandomIndexWriter, IOException> indexer, Consumer<InternalAvg> verify)
-        throws IOException {
-        testCase(new AggTestConfig<>(avg("_name").field(FIELD_NAME), indexer, verify, defaultFieldType()).withQuery(query));
+        }, defaultFieldType()).withQuery(new TermQuery(new Term("match", "yes"))));
     }
 
     @Override

--- a/x-pack/plugin/analytics/src/test/java/org/elasticsearch/xpack/analytics/aggregations/metrics/HistoBackedAvgAggregatorTests.java
+++ b/x-pack/plugin/analytics/src/test/java/org/elasticsearch/xpack/analytics/aggregations/metrics/HistoBackedAvgAggregatorTests.java
@@ -111,7 +111,10 @@ public class HistoBackedAvgAggregatorTests extends AggregatorTestCase {
 
     private void testCase(Query query, CheckedConsumer<RandomIndexWriter, IOException> indexer, Consumer<InternalAvg> verify)
         throws IOException {
-        testCase(avg("_name").field(FIELD_NAME), query, indexer, verify, defaultFieldType());
+        testCase(
+            new AggTestConfig<InternalAvg>(avg("_name").field(FIELD_NAME), indexer, verify, new MappedFieldType[] { defaultFieldType() })
+                .withQuery(query)
+        );
     }
 
     @Override

--- a/x-pack/plugin/analytics/src/test/java/org/elasticsearch/xpack/analytics/aggregations/metrics/HistoBackedMaxAggregatorTests.java
+++ b/x-pack/plugin/analytics/src/test/java/org/elasticsearch/xpack/analytics/aggregations/metrics/HistoBackedMaxAggregatorTests.java
@@ -110,11 +110,7 @@ public class HistoBackedMaxAggregatorTests extends AggregatorTestCase {
     }
 
     private void testCase(Query query, CheckedConsumer<RandomIndexWriter, IOException> indexer, Consumer<Max> verify) throws IOException {
-        testCase(
-            new AggTestConfig<Max>(max("_name").field(FIELD_NAME), indexer, verify, new MappedFieldType[] { defaultFieldType() }).withQuery(
-                query
-            )
-        );
+        testCase(new AggTestConfig<>(max("_name").field(FIELD_NAME), indexer, verify, defaultFieldType()).withQuery(query));
     }
 
     @Override

--- a/x-pack/plugin/analytics/src/test/java/org/elasticsearch/xpack/analytics/aggregations/metrics/HistoBackedMaxAggregatorTests.java
+++ b/x-pack/plugin/analytics/src/test/java/org/elasticsearch/xpack/analytics/aggregations/metrics/HistoBackedMaxAggregatorTests.java
@@ -110,7 +110,11 @@ public class HistoBackedMaxAggregatorTests extends AggregatorTestCase {
     }
 
     private void testCase(Query query, CheckedConsumer<RandomIndexWriter, IOException> indexer, Consumer<Max> verify) throws IOException {
-        testCase(max("_name").field(FIELD_NAME), query, indexer, verify, defaultFieldType());
+        testCase(
+            new AggTestConfig<Max>(max("_name").field(FIELD_NAME), indexer, verify, new MappedFieldType[] { defaultFieldType() }).withQuery(
+                query
+            )
+        );
     }
 
     @Override

--- a/x-pack/plugin/analytics/src/test/java/org/elasticsearch/xpack/analytics/aggregations/metrics/HistoBackedMaxAggregatorTests.java
+++ b/x-pack/plugin/analytics/src/test/java/org/elasticsearch/xpack/analytics/aggregations/metrics/HistoBackedMaxAggregatorTests.java
@@ -9,11 +9,7 @@ package org.elasticsearch.xpack.analytics.aggregations.metrics;
 import org.apache.lucene.document.Field;
 import org.apache.lucene.document.StringField;
 import org.apache.lucene.index.Term;
-import org.apache.lucene.search.MatchAllDocsQuery;
-import org.apache.lucene.search.Query;
 import org.apache.lucene.search.TermQuery;
-import org.apache.lucene.tests.index.RandomIndexWriter;
-import org.elasticsearch.core.CheckedConsumer;
 import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.plugins.SearchPlugin;
 import org.elasticsearch.search.aggregations.AggregationBuilder;
@@ -31,7 +27,6 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
-import java.util.function.Consumer;
 
 import static java.util.Collections.singleton;
 import static org.elasticsearch.search.aggregations.AggregationBuilders.max;
@@ -42,37 +37,38 @@ public class HistoBackedMaxAggregatorTests extends AggregatorTestCase {
     private static final String FIELD_NAME = "field";
 
     public void testNoDocs() throws IOException {
-        testCase(new MatchAllDocsQuery(), iw -> {
+        // Intentionally not writing any docs
+        testCase(new AggTestConfig<Max>(max("_name").field(FIELD_NAME), iw -> {
             // Intentionally not writing any docs
         }, max -> {
             assertEquals(Double.NEGATIVE_INFINITY, max.value(), 0d);
             assertFalse(AggregationInspectionHelper.hasValue(max));
-        });
+        }, defaultFieldType()));
     }
 
     public void testNoMatchingField() throws IOException {
-        testCase(new MatchAllDocsQuery(), iw -> {
+        testCase(new AggTestConfig<Max>(max("_name").field(FIELD_NAME), iw -> {
             iw.addDocument(singleton(histogramFieldDocValues("wrong_field", new double[] { 3, 1.2, 10 })));
             iw.addDocument(singleton(histogramFieldDocValues("wrong_field", new double[] { 5.3, 6, 20 })));
         }, max -> {
             assertEquals(Double.NEGATIVE_INFINITY, max.value(), 0d);
             assertFalse(AggregationInspectionHelper.hasValue(max));
-        });
+        }, defaultFieldType()));
     }
 
     public void testSimpleHistogram() throws IOException {
-        testCase(new MatchAllDocsQuery(), iw -> {
+        testCase(new AggTestConfig<Max>(max("_name").field(FIELD_NAME), iw -> {
             iw.addDocument(singleton(histogramFieldDocValues(FIELD_NAME, new double[] { 3, 1.2, 10 })));
             iw.addDocument(singleton(histogramFieldDocValues(FIELD_NAME, new double[] { 5.3, 6, 6, 20 })));
             iw.addDocument(singleton(histogramFieldDocValues(FIELD_NAME, new double[] { -10, 0.01, 1, 90 })));
         }, max -> {
             assertEquals(90d, max.value(), 0.01d);
             assertTrue(AggregationInspectionHelper.hasValue(max));
-        });
+        }, defaultFieldType()));
     }
 
     public void testQueryFiltering() throws IOException {
-        testCase(new TermQuery(new Term("match", "yes")), iw -> {
+        testCase(new AggTestConfig<Max>(max("_name").field(FIELD_NAME), iw -> {
             iw.addDocument(
                 Arrays.asList(
                     new StringField("match", "yes", Field.Store.NO),
@@ -106,11 +102,7 @@ public class HistoBackedMaxAggregatorTests extends AggregatorTestCase {
         }, min -> {
             assertEquals(90d, min.value(), 0.01d);
             assertTrue(AggregationInspectionHelper.hasValue(min));
-        });
-    }
-
-    private void testCase(Query query, CheckedConsumer<RandomIndexWriter, IOException> indexer, Consumer<Max> verify) throws IOException {
-        testCase(new AggTestConfig<>(max("_name").field(FIELD_NAME), indexer, verify, defaultFieldType()).withQuery(query));
+        }, defaultFieldType()).withQuery(new TermQuery(new Term("match", "yes"))));
     }
 
     @Override

--- a/x-pack/plugin/analytics/src/test/java/org/elasticsearch/xpack/analytics/aggregations/metrics/HistoBackedMinAggregatorTests.java
+++ b/x-pack/plugin/analytics/src/test/java/org/elasticsearch/xpack/analytics/aggregations/metrics/HistoBackedMinAggregatorTests.java
@@ -110,11 +110,7 @@ public class HistoBackedMinAggregatorTests extends AggregatorTestCase {
     }
 
     private void testCase(Query query, CheckedConsumer<RandomIndexWriter, IOException> indexer, Consumer<Min> verify) throws IOException {
-        testCase(
-            new AggTestConfig<Min>(min("_name").field(FIELD_NAME), indexer, verify, new MappedFieldType[] { defaultFieldType() }).withQuery(
-                query
-            )
-        );
+        testCase(new AggTestConfig<>(min("_name").field(FIELD_NAME), indexer, verify, defaultFieldType()).withQuery(query));
     }
 
     @Override

--- a/x-pack/plugin/analytics/src/test/java/org/elasticsearch/xpack/analytics/aggregations/metrics/HistoBackedMinAggregatorTests.java
+++ b/x-pack/plugin/analytics/src/test/java/org/elasticsearch/xpack/analytics/aggregations/metrics/HistoBackedMinAggregatorTests.java
@@ -110,7 +110,11 @@ public class HistoBackedMinAggregatorTests extends AggregatorTestCase {
     }
 
     private void testCase(Query query, CheckedConsumer<RandomIndexWriter, IOException> indexer, Consumer<Min> verify) throws IOException {
-        testCase(min("_name").field(FIELD_NAME), query, indexer, verify, defaultFieldType());
+        testCase(
+            new AggTestConfig<Min>(min("_name").field(FIELD_NAME), indexer, verify, new MappedFieldType[] { defaultFieldType() }).withQuery(
+                query
+            )
+        );
     }
 
     @Override

--- a/x-pack/plugin/analytics/src/test/java/org/elasticsearch/xpack/analytics/aggregations/metrics/HistoBackedMinAggregatorTests.java
+++ b/x-pack/plugin/analytics/src/test/java/org/elasticsearch/xpack/analytics/aggregations/metrics/HistoBackedMinAggregatorTests.java
@@ -9,11 +9,7 @@ package org.elasticsearch.xpack.analytics.aggregations.metrics;
 import org.apache.lucene.document.Field;
 import org.apache.lucene.document.StringField;
 import org.apache.lucene.index.Term;
-import org.apache.lucene.search.MatchAllDocsQuery;
-import org.apache.lucene.search.Query;
 import org.apache.lucene.search.TermQuery;
-import org.apache.lucene.tests.index.RandomIndexWriter;
-import org.elasticsearch.core.CheckedConsumer;
 import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.plugins.SearchPlugin;
 import org.elasticsearch.search.aggregations.AggregationBuilder;
@@ -31,7 +27,6 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
-import java.util.function.Consumer;
 
 import static java.util.Collections.singleton;
 import static org.elasticsearch.search.aggregations.AggregationBuilders.min;
@@ -42,37 +37,37 @@ public class HistoBackedMinAggregatorTests extends AggregatorTestCase {
     private static final String FIELD_NAME = "field";
 
     public void testNoDocs() throws IOException {
-        testCase(new MatchAllDocsQuery(), iw -> {
+        testCase(new AggTestConfig<Min>(min("_name").field(FIELD_NAME), iw -> {
             // Intentionally not writing any docs
         }, min -> {
             assertEquals(Double.POSITIVE_INFINITY, min.value(), 0d);
             assertFalse(AggregationInspectionHelper.hasValue(min));
-        });
+        }, defaultFieldType()));
     }
 
     public void testNoMatchingField() throws IOException {
-        testCase(new MatchAllDocsQuery(), iw -> {
+        testCase(new AggTestConfig<Min>(min("_name").field(FIELD_NAME), iw -> {
             iw.addDocument(singleton(histogramFieldDocValues("wrong_field", new double[] { 3, 1.2, 10 })));
             iw.addDocument(singleton(histogramFieldDocValues("wrong_field", new double[] { 5.3, 6, 20 })));
         }, min -> {
             assertEquals(Double.POSITIVE_INFINITY, min.value(), 0d);
             assertFalse(AggregationInspectionHelper.hasValue(min));
-        });
+        }, defaultFieldType()));
     }
 
     public void testSimpleHistogram() throws IOException {
-        testCase(new MatchAllDocsQuery(), iw -> {
+        testCase(new AggTestConfig<Min>(min("_name").field(FIELD_NAME), iw -> {
             iw.addDocument(singleton(histogramFieldDocValues(FIELD_NAME, new double[] { 3, 1.2, 10 })));
             iw.addDocument(singleton(histogramFieldDocValues(FIELD_NAME, new double[] { 5.3, 6, 6, 20 })));
             iw.addDocument(singleton(histogramFieldDocValues(FIELD_NAME, new double[] { -10, 0.01, 1, 90 })));
         }, min -> {
             assertEquals(-10d, min.value(), 0.01d);
             assertTrue(AggregationInspectionHelper.hasValue(min));
-        });
+        }, defaultFieldType()));
     }
 
     public void testQueryFiltering() throws IOException {
-        testCase(new TermQuery(new Term("match", "yes")), iw -> {
+        testCase(new AggTestConfig<Min>(min("_name").field(FIELD_NAME), iw -> {
             iw.addDocument(
                 Arrays.asList(
                     new StringField("match", "yes", Field.Store.NO),
@@ -106,11 +101,7 @@ public class HistoBackedMinAggregatorTests extends AggregatorTestCase {
         }, min -> {
             assertEquals(-10d, min.value(), 0.01d);
             assertTrue(AggregationInspectionHelper.hasValue(min));
-        });
-    }
-
-    private void testCase(Query query, CheckedConsumer<RandomIndexWriter, IOException> indexer, Consumer<Min> verify) throws IOException {
-        testCase(new AggTestConfig<>(min("_name").field(FIELD_NAME), indexer, verify, defaultFieldType()).withQuery(query));
+        }, defaultFieldType()).withQuery(new TermQuery(new Term("match", "yes"))));
     }
 
     @Override

--- a/x-pack/plugin/analytics/src/test/java/org/elasticsearch/xpack/analytics/aggregations/metrics/HistoBackedSumAggregatorTests.java
+++ b/x-pack/plugin/analytics/src/test/java/org/elasticsearch/xpack/analytics/aggregations/metrics/HistoBackedSumAggregatorTests.java
@@ -9,11 +9,7 @@ package org.elasticsearch.xpack.analytics.aggregations.metrics;
 import org.apache.lucene.document.Field;
 import org.apache.lucene.document.StringField;
 import org.apache.lucene.index.Term;
-import org.apache.lucene.search.MatchAllDocsQuery;
-import org.apache.lucene.search.Query;
 import org.apache.lucene.search.TermQuery;
-import org.apache.lucene.tests.index.RandomIndexWriter;
-import org.elasticsearch.core.CheckedConsumer;
 import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.plugins.SearchPlugin;
 import org.elasticsearch.search.aggregations.AggregationBuilder;
@@ -31,7 +27,6 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
-import java.util.function.Consumer;
 
 import static java.util.Collections.singleton;
 import static org.elasticsearch.search.aggregations.AggregationBuilders.sum;
@@ -42,37 +37,37 @@ public class HistoBackedSumAggregatorTests extends AggregatorTestCase {
     private static final String FIELD_NAME = "field";
 
     public void testNoDocs() throws IOException {
-        testCase(new MatchAllDocsQuery(), iw -> {
+        testCase(new AggTestConfig<Sum>(sum("_name").field(FIELD_NAME), iw -> {
             // Intentionally not writing any docs
         }, sum -> {
             assertEquals(0L, sum.value(), 0d);
             assertFalse(AggregationInspectionHelper.hasValue(sum));
-        });
+        }, defaultFieldType()));
     }
 
     public void testNoMatchingField() throws IOException {
-        testCase(new MatchAllDocsQuery(), iw -> {
+        testCase(new AggTestConfig<Sum>(sum("_name").field(FIELD_NAME), iw -> {
             iw.addDocument(singleton(histogramFieldDocValues("wrong_field", new double[] { 3, 1.2, 10 })));
             iw.addDocument(singleton(histogramFieldDocValues("wrong_field", new double[] { 5.3, 6, 20 })));
         }, sum -> {
             assertEquals(0L, sum.value(), 0d);
             assertFalse(AggregationInspectionHelper.hasValue(sum));
-        });
+        }, defaultFieldType()));
     }
 
     public void testSimpleHistogram() throws IOException {
-        testCase(new MatchAllDocsQuery(), iw -> {
+        testCase(new AggTestConfig<Sum>(sum("_name").field(FIELD_NAME), iw -> {
             iw.addDocument(singleton(histogramFieldDocValues(FIELD_NAME, new double[] { 3, 1.2, 10 })));
             iw.addDocument(singleton(histogramFieldDocValues(FIELD_NAME, new double[] { 5.3, 6, 6, 20 })));
             iw.addDocument(singleton(histogramFieldDocValues(FIELD_NAME, new double[] { -10, 0.01, 1, 90 })));
         }, sum -> {
             assertEquals(132.51d, sum.value(), 0.01d);
             assertTrue(AggregationInspectionHelper.hasValue(sum));
-        });
+        }, defaultFieldType()));
     }
 
     public void testQueryFiltering() throws IOException {
-        testCase(new TermQuery(new Term("match", "yes")), iw -> {
+        testCase(new AggTestConfig<Sum>(sum("_name").field(FIELD_NAME), iw -> {
             iw.addDocument(
                 Arrays.asList(
                     new StringField("match", "yes", Field.Store.NO),
@@ -106,11 +101,7 @@ public class HistoBackedSumAggregatorTests extends AggregatorTestCase {
         }, sum -> {
             assertEquals(126.51d, sum.value(), 0.01d);
             assertTrue(AggregationInspectionHelper.hasValue(sum));
-        });
-    }
-
-    private void testCase(Query query, CheckedConsumer<RandomIndexWriter, IOException> indexer, Consumer<Sum> verify) throws IOException {
-        testCase(new AggTestConfig<>(sum("_name").field(FIELD_NAME), indexer, verify, defaultFieldType()).withQuery(query));
+        }, defaultFieldType()).withQuery(new TermQuery(new Term("match", "yes"))));
     }
 
     @Override

--- a/x-pack/plugin/analytics/src/test/java/org/elasticsearch/xpack/analytics/aggregations/metrics/HistoBackedSumAggregatorTests.java
+++ b/x-pack/plugin/analytics/src/test/java/org/elasticsearch/xpack/analytics/aggregations/metrics/HistoBackedSumAggregatorTests.java
@@ -110,11 +110,7 @@ public class HistoBackedSumAggregatorTests extends AggregatorTestCase {
     }
 
     private void testCase(Query query, CheckedConsumer<RandomIndexWriter, IOException> indexer, Consumer<Sum> verify) throws IOException {
-        testCase(
-            new AggTestConfig<Sum>(sum("_name").field(FIELD_NAME), indexer, verify, new MappedFieldType[] { defaultFieldType() }).withQuery(
-                query
-            )
-        );
+        testCase(new AggTestConfig<>(sum("_name").field(FIELD_NAME), indexer, verify, defaultFieldType()).withQuery(query));
     }
 
     @Override

--- a/x-pack/plugin/analytics/src/test/java/org/elasticsearch/xpack/analytics/aggregations/metrics/HistoBackedSumAggregatorTests.java
+++ b/x-pack/plugin/analytics/src/test/java/org/elasticsearch/xpack/analytics/aggregations/metrics/HistoBackedSumAggregatorTests.java
@@ -110,7 +110,11 @@ public class HistoBackedSumAggregatorTests extends AggregatorTestCase {
     }
 
     private void testCase(Query query, CheckedConsumer<RandomIndexWriter, IOException> indexer, Consumer<Sum> verify) throws IOException {
-        testCase(sum("_name").field(FIELD_NAME), query, indexer, verify, defaultFieldType());
+        testCase(
+            new AggTestConfig<Sum>(sum("_name").field(FIELD_NAME), indexer, verify, new MappedFieldType[] { defaultFieldType() }).withQuery(
+                query
+            )
+        );
     }
 
     @Override

--- a/x-pack/plugin/analytics/src/test/java/org/elasticsearch/xpack/analytics/aggregations/metrics/HistoBackedValueCountAggregatorTests.java
+++ b/x-pack/plugin/analytics/src/test/java/org/elasticsearch/xpack/analytics/aggregations/metrics/HistoBackedValueCountAggregatorTests.java
@@ -111,14 +111,7 @@ public class HistoBackedValueCountAggregatorTests extends AggregatorTestCase {
 
     private void testCase(Query query, CheckedConsumer<RandomIndexWriter, IOException> indexer, Consumer<InternalValueCount> verify)
         throws IOException {
-        testCase(
-            new AggTestConfig<InternalValueCount>(
-                count("_name").field(FIELD_NAME),
-                indexer,
-                verify,
-                new MappedFieldType[] { defaultFieldType() }
-            ).withQuery(query)
-        );
+        testCase(new AggTestConfig<>(count("_name").field(FIELD_NAME), indexer, verify, defaultFieldType()).withQuery(query));
     }
 
     @Override

--- a/x-pack/plugin/analytics/src/test/java/org/elasticsearch/xpack/analytics/aggregations/metrics/HistoBackedValueCountAggregatorTests.java
+++ b/x-pack/plugin/analytics/src/test/java/org/elasticsearch/xpack/analytics/aggregations/metrics/HistoBackedValueCountAggregatorTests.java
@@ -111,7 +111,14 @@ public class HistoBackedValueCountAggregatorTests extends AggregatorTestCase {
 
     private void testCase(Query query, CheckedConsumer<RandomIndexWriter, IOException> indexer, Consumer<InternalValueCount> verify)
         throws IOException {
-        testCase(count("_name").field(FIELD_NAME), query, indexer, verify, defaultFieldType());
+        testCase(
+            new AggTestConfig<InternalValueCount>(
+                count("_name").field(FIELD_NAME),
+                indexer,
+                verify,
+                new MappedFieldType[] { defaultFieldType() }
+            ).withQuery(query)
+        );
     }
 
     @Override

--- a/x-pack/plugin/analytics/src/test/java/org/elasticsearch/xpack/analytics/aggregations/metrics/HistoBackedValueCountAggregatorTests.java
+++ b/x-pack/plugin/analytics/src/test/java/org/elasticsearch/xpack/analytics/aggregations/metrics/HistoBackedValueCountAggregatorTests.java
@@ -9,11 +9,7 @@ package org.elasticsearch.xpack.analytics.aggregations.metrics;
 import org.apache.lucene.document.Field;
 import org.apache.lucene.document.StringField;
 import org.apache.lucene.index.Term;
-import org.apache.lucene.search.MatchAllDocsQuery;
-import org.apache.lucene.search.Query;
 import org.apache.lucene.search.TermQuery;
-import org.apache.lucene.tests.index.RandomIndexWriter;
-import org.elasticsearch.core.CheckedConsumer;
 import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.plugins.SearchPlugin;
 import org.elasticsearch.search.aggregations.AggregationBuilder;
@@ -31,7 +27,6 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
-import java.util.function.Consumer;
 
 import static java.util.Collections.singleton;
 import static org.elasticsearch.search.aggregations.AggregationBuilders.count;
@@ -42,37 +37,37 @@ public class HistoBackedValueCountAggregatorTests extends AggregatorTestCase {
     private static final String FIELD_NAME = "field";
 
     public void testNoDocs() throws IOException {
-        testCase(new MatchAllDocsQuery(), iw -> {
+        testCase(new AggTestConfig<InternalValueCount>(count("_name").field(FIELD_NAME), iw -> {
             // Intentionally not writing any docs
         }, count -> {
             assertEquals(0L, count.getValue(), 0d);
             assertFalse(AggregationInspectionHelper.hasValue(count));
-        });
+        }, defaultFieldType()));
     }
 
     public void testNoMatchingField() throws IOException {
-        testCase(new MatchAllDocsQuery(), iw -> {
+        testCase(new AggTestConfig<InternalValueCount>(count("_name").field(FIELD_NAME), iw -> {
             iw.addDocument(singleton(histogramFieldDocValues("wrong_field", new double[] { 3, 1.2, 10 })));
             iw.addDocument(singleton(histogramFieldDocValues("wrong_field", new double[] { 5.3, 6, 20 })));
         }, count -> {
             assertEquals(0L, count.getValue());
             assertFalse(AggregationInspectionHelper.hasValue(count));
-        });
+        }, defaultFieldType()));
     }
 
     public void testSimpleHistogram() throws IOException {
-        testCase(new MatchAllDocsQuery(), iw -> {
+        testCase(new AggTestConfig<InternalValueCount>(count("_name").field(FIELD_NAME), iw -> {
             iw.addDocument(singleton(histogramFieldDocValues(FIELD_NAME, new double[] { 3, 1.2, 10 })));
             iw.addDocument(singleton(histogramFieldDocValues(FIELD_NAME, new double[] { 5.3, 6, 6, 20 })));
             iw.addDocument(singleton(histogramFieldDocValues(FIELD_NAME, new double[] { -10, 0.01, 1, 90 })));
         }, count -> {
             assertEquals(11, count.getValue());
             assertTrue(AggregationInspectionHelper.hasValue(count));
-        });
+        }, defaultFieldType()));
     }
 
     public void testQueryFiltering() throws IOException {
-        testCase(new TermQuery(new Term("match", "yes")), iw -> {
+        testCase(new AggTestConfig<InternalValueCount>(count("_name").field(FIELD_NAME), iw -> {
             iw.addDocument(
                 Arrays.asList(
                     new StringField("match", "yes", Field.Store.NO),
@@ -106,12 +101,7 @@ public class HistoBackedValueCountAggregatorTests extends AggregatorTestCase {
         }, count -> {
             assertEquals(10, count.getValue());
             assertTrue(AggregationInspectionHelper.hasValue(count));
-        });
-    }
-
-    private void testCase(Query query, CheckedConsumer<RandomIndexWriter, IOException> indexer, Consumer<InternalValueCount> verify)
-        throws IOException {
-        testCase(new AggTestConfig<>(count("_name").field(FIELD_NAME), indexer, verify, defaultFieldType()).withQuery(query));
+        }, defaultFieldType()).withQuery(new TermQuery(new Term("match", "yes"))));
     }
 
     @Override

--- a/x-pack/plugin/analytics/src/test/java/org/elasticsearch/xpack/analytics/boxplot/BoxplotAggregatorTests.java
+++ b/x-pack/plugin/analytics/src/test/java/org/elasticsearch/xpack/analytics/boxplot/BoxplotAggregatorTests.java
@@ -177,13 +177,13 @@ public class BoxplotAggregatorTests extends AggregatorTestCase {
             iw.addDocument(singleton(new NumericDocValuesField("other", 4)));
             iw.addDocument(singleton(new NumericDocValuesField("other", 5)));
             iw.addDocument(singleton(new NumericDocValuesField("number", 0)));
-        }, (Consumer<InternalBoxplot>) boxplot -> {
+        }, boxplot -> {
             assertEquals(0, boxplot.getMin(), 0);
             assertEquals(10, boxplot.getMax(), 0);
             assertEquals(10, boxplot.getQ1(), 0);
             assertEquals(10, boxplot.getQ2(), 0);
             assertEquals(10, boxplot.getQ3(), 0);
-        }, new MappedFieldType[] { fieldType }).withQuery(new MatchAllDocsQuery()));
+        }, fieldType));
     }
 
     public void testUnmappedWithMissingField() throws IOException {
@@ -194,13 +194,13 @@ public class BoxplotAggregatorTests extends AggregatorTestCase {
         testCase(new AggTestConfig<InternalBoxplot>(aggregationBuilder, iw -> {
             iw.addDocument(singleton(new NumericDocValuesField("number", 7)));
             iw.addDocument(singleton(new NumericDocValuesField("number", 1)));
-        }, (Consumer<InternalBoxplot>) boxplot -> {
+        }, boxplot -> {
             assertEquals(0, boxplot.getMin(), 0);
             assertEquals(0, boxplot.getMax(), 0);
             assertEquals(0, boxplot.getQ1(), 0);
             assertEquals(0, boxplot.getQ2(), 0);
             assertEquals(0, boxplot.getQ3(), 0);
-        }, new MappedFieldType[] { fieldType }).withQuery(new MatchAllDocsQuery()));
+        }, fieldType));
     }
 
     public void testUnsupportedType() {
@@ -214,9 +214,9 @@ public class BoxplotAggregatorTests extends AggregatorTestCase {
                 new AggTestConfig<InternalBoxplot>(
                     aggregationBuilder,
                     iw -> { iw.addDocument(singleton(new SortedSetDocValuesField("string", new BytesRef("foo")))); },
-                    (Consumer<InternalBoxplot>) boxplot -> { fail("Should have thrown exception"); },
-                    new MappedFieldType[] { fieldType }
-                ).withQuery(new MatchAllDocsQuery())
+                    boxplot -> { fail("Should have thrown exception"); },
+                    fieldType
+                )
             )
         );
         assertEquals(e.getMessage(), "Field [not_a_number] of type [keyword] " + "is not supported for aggregation [boxplot]");
@@ -234,9 +234,7 @@ public class BoxplotAggregatorTests extends AggregatorTestCase {
             iw.addDocument(singleton(new NumericDocValuesField("number", 4)));
             iw.addDocument(singleton(new NumericDocValuesField("number", 5)));
             iw.addDocument(singleton(new NumericDocValuesField("number", 10)));
-        }, (Consumer<InternalBoxplot>) boxplot -> { fail("Should have thrown exception"); }, new MappedFieldType[] { fieldType }).withQuery(
-            new MatchAllDocsQuery()
-        )));
+        }, boxplot -> fail("Should have thrown exception"), fieldType)));
     }
 
     public void testUnmappedWithBadMissingField() {
@@ -252,9 +250,7 @@ public class BoxplotAggregatorTests extends AggregatorTestCase {
             iw.addDocument(singleton(new NumericDocValuesField("number", 4)));
             iw.addDocument(singleton(new NumericDocValuesField("number", 5)));
             iw.addDocument(singleton(new NumericDocValuesField("number", 10)));
-        }, (Consumer<InternalBoxplot>) boxplot -> { fail("Should have thrown exception"); }, new MappedFieldType[] { fieldType }).withQuery(
-            new MatchAllDocsQuery()
-        )));
+        }, boxplot -> fail("Should have thrown exception"), fieldType)));
     }
 
     public void testEmptyBucket() throws IOException {
@@ -270,7 +266,7 @@ public class BoxplotAggregatorTests extends AggregatorTestCase {
             iw.addDocument(singleton(new NumericDocValuesField("number", 3)));
             iw.addDocument(singleton(new NumericDocValuesField("number", 21)));
             iw.addDocument(singleton(new NumericDocValuesField("number", 23)));
-        }, (Consumer<InternalHistogram>) histo -> {
+        }, histo -> {
             assertThat(histo.getBuckets().size(), equalTo(3));
 
             assertNotNull(histo.getBuckets().get(0).getAggregations().asMap().get("boxplot"));
@@ -296,7 +292,7 @@ public class BoxplotAggregatorTests extends AggregatorTestCase {
             assertEquals(21, boxplot.getQ1(), 0);
             assertEquals(22, boxplot.getQ2(), 0);
             assertEquals(23, boxplot.getQ3(), 0);
-        }, new MappedFieldType[] { fieldType }).withQuery(new MatchAllDocsQuery()));
+        }, fieldType));
     }
 
     public void testFormatter() throws IOException {
@@ -310,7 +306,7 @@ public class BoxplotAggregatorTests extends AggregatorTestCase {
             iw.addDocument(singleton(new NumericDocValuesField("number", 3)));
             iw.addDocument(singleton(new NumericDocValuesField("number", 4)));
             iw.addDocument(singleton(new NumericDocValuesField("number", 5)));
-        }, (Consumer<InternalBoxplot>) boxplot -> {
+        }, boxplot -> {
             assertEquals(1, boxplot.getMin(), 0);
             assertEquals(5, boxplot.getMax(), 0);
             assertEquals(1.75, boxplot.getQ1(), 0);
@@ -321,7 +317,7 @@ public class BoxplotAggregatorTests extends AggregatorTestCase {
             assertEquals("0001.8", boxplot.getQ1AsString());
             assertEquals("0003.0", boxplot.getQ2AsString());
             assertEquals("0004.2", boxplot.getQ3AsString());
-        }, new MappedFieldType[] { fieldType }).withQuery(new MatchAllDocsQuery()));
+        }, fieldType));
     }
 
     public void testGetProperty() throws IOException {
@@ -337,7 +333,7 @@ public class BoxplotAggregatorTests extends AggregatorTestCase {
             iw.addDocument(singleton(new NumericDocValuesField("number", 3)));
             iw.addDocument(singleton(new NumericDocValuesField("number", 4)));
             iw.addDocument(singleton(new NumericDocValuesField("number", 5)));
-        }, (Consumer<InternalGlobal>) global -> {
+        }, global -> {
             assertEquals(5, global.getDocCount());
             assertTrue(AggregationInspectionHelper.hasValue(global));
             assertNotNull(global.getAggregations().asMap().get("boxplot"));
@@ -347,7 +343,7 @@ public class BoxplotAggregatorTests extends AggregatorTestCase {
             assertThat(global.getProperty("boxplot.max"), equalTo(5.0));
             assertThat(boxplot.getProperty("min"), equalTo(1.0));
             assertThat(boxplot.getProperty("max"), equalTo(5.0));
-        }, new MappedFieldType[] { fieldType }).withQuery(new MatchAllDocsQuery()));
+        }, fieldType));
     }
 
     public void testValueScript() throws IOException {
@@ -359,13 +355,13 @@ public class BoxplotAggregatorTests extends AggregatorTestCase {
         testCase(new AggTestConfig<InternalBoxplot>(aggregationBuilder, iw -> {
             iw.addDocument(singleton(new NumericDocValuesField("number", 7)));
             iw.addDocument(singleton(new NumericDocValuesField("number", 1)));
-        }, (Consumer<InternalBoxplot>) boxplot -> {
+        }, boxplot -> {
             assertEquals(2, boxplot.getMin(), 0);
             assertEquals(8, boxplot.getMax(), 0);
             assertEquals(2, boxplot.getQ1(), 0);
             assertEquals(5, boxplot.getQ2(), 0);
             assertEquals(8, boxplot.getQ3(), 0);
-        }, new MappedFieldType[] { fieldType }).withQuery(new MatchAllDocsQuery()));
+        }, fieldType));
     }
 
     public void testValueScriptUnmapped() throws IOException {
@@ -377,13 +373,13 @@ public class BoxplotAggregatorTests extends AggregatorTestCase {
         testCase(new AggTestConfig<InternalBoxplot>(aggregationBuilder, iw -> {
             iw.addDocument(singleton(new NumericDocValuesField("number", 7)));
             iw.addDocument(singleton(new NumericDocValuesField("number", 1)));
-        }, (Consumer<InternalBoxplot>) boxplot -> {
+        }, boxplot -> {
             assertEquals(Double.POSITIVE_INFINITY, boxplot.getMin(), 0);
             assertEquals(Double.NEGATIVE_INFINITY, boxplot.getMax(), 0);
             assertEquals(Double.NaN, boxplot.getQ1(), 0);
             assertEquals(Double.NaN, boxplot.getQ2(), 0);
             assertEquals(Double.NaN, boxplot.getQ3(), 0);
-        }, new MappedFieldType[] { fieldType }).withQuery(new MatchAllDocsQuery()));
+        }, fieldType));
     }
 
     public void testValueScriptUnmappedMissing() throws IOException {
@@ -397,23 +393,21 @@ public class BoxplotAggregatorTests extends AggregatorTestCase {
         testCase(new AggTestConfig<InternalBoxplot>(aggregationBuilder, iw -> {
             iw.addDocument(singleton(new NumericDocValuesField("number", 7)));
             iw.addDocument(singleton(new NumericDocValuesField("number", 1)));
-        }, (Consumer<InternalBoxplot>) boxplot -> {
+        }, boxplot -> {
             // Note: the way scripts, missing and unmapped interact, these will be the missing value and the script is not invoked
             assertEquals(1.0, boxplot.getMin(), 0);
             assertEquals(1.0, boxplot.getMax(), 0);
             assertEquals(1.0, boxplot.getQ1(), 0);
             assertEquals(1.0, boxplot.getQ2(), 0);
             assertEquals(1.0, boxplot.getQ3(), 0);
-        }, new MappedFieldType[] { fieldType }).withQuery(new MatchAllDocsQuery()));
+        }, fieldType));
     }
 
     private void testCase(Query query, CheckedConsumer<RandomIndexWriter, IOException> buildIndex, Consumer<InternalBoxplot> verify)
         throws IOException {
         MappedFieldType fieldType = new NumberFieldMapper.NumberFieldType("number", NumberFieldMapper.NumberType.INTEGER);
         BoxplotAggregationBuilder aggregationBuilder = new BoxplotAggregationBuilder("boxplot").field("number");
-        testCase(
-            new AggTestConfig<InternalBoxplot>(aggregationBuilder, buildIndex, verify, new MappedFieldType[] { fieldType }).withQuery(query)
-        );
+        testCase(new AggTestConfig<>(aggregationBuilder, buildIndex, verify, new MappedFieldType[] { fieldType }).withQuery(query));
     }
 
 }

--- a/x-pack/plugin/analytics/src/test/java/org/elasticsearch/xpack/analytics/boxplot/BoxplotAggregatorTests.java
+++ b/x-pack/plugin/analytics/src/test/java/org/elasticsearch/xpack/analytics/boxplot/BoxplotAggregatorTests.java
@@ -170,7 +170,7 @@ public class BoxplotAggregatorTests extends AggregatorTestCase {
 
         MappedFieldType fieldType = new NumberFieldMapper.NumberFieldType("number", NumberFieldMapper.NumberType.INTEGER);
 
-        testCase(aggregationBuilder, new MatchAllDocsQuery(), iw -> {
+        testCase(new AggTestConfig<InternalBoxplot>(aggregationBuilder, iw -> {
             iw.addDocument(singleton(new NumericDocValuesField("other", 2)));
             iw.addDocument(singleton(new NumericDocValuesField("other", 2)));
             iw.addDocument(singleton(new NumericDocValuesField("other", 3)));
@@ -183,7 +183,7 @@ public class BoxplotAggregatorTests extends AggregatorTestCase {
             assertEquals(10, boxplot.getQ1(), 0);
             assertEquals(10, boxplot.getQ2(), 0);
             assertEquals(10, boxplot.getQ3(), 0);
-        }, fieldType);
+        }, new MappedFieldType[] { fieldType }).withQuery(new MatchAllDocsQuery()));
     }
 
     public void testUnmappedWithMissingField() throws IOException {
@@ -191,7 +191,7 @@ public class BoxplotAggregatorTests extends AggregatorTestCase {
 
         MappedFieldType fieldType = new NumberFieldMapper.NumberFieldType("number", NumberFieldMapper.NumberType.INTEGER);
 
-        testCase(aggregationBuilder, new MatchAllDocsQuery(), iw -> {
+        testCase(new AggTestConfig<InternalBoxplot>(aggregationBuilder, iw -> {
             iw.addDocument(singleton(new NumericDocValuesField("number", 7)));
             iw.addDocument(singleton(new NumericDocValuesField("number", 1)));
         }, (Consumer<InternalBoxplot>) boxplot -> {
@@ -200,7 +200,7 @@ public class BoxplotAggregatorTests extends AggregatorTestCase {
             assertEquals(0, boxplot.getQ1(), 0);
             assertEquals(0, boxplot.getQ2(), 0);
             assertEquals(0, boxplot.getQ3(), 0);
-        }, fieldType);
+        }, new MappedFieldType[] { fieldType }).withQuery(new MatchAllDocsQuery()));
     }
 
     public void testUnsupportedType() {
@@ -211,11 +211,12 @@ public class BoxplotAggregatorTests extends AggregatorTestCase {
         IllegalArgumentException e = expectThrows(
             IllegalArgumentException.class,
             () -> testCase(
-                aggregationBuilder,
-                new MatchAllDocsQuery(),
-                iw -> { iw.addDocument(singleton(new SortedSetDocValuesField("string", new BytesRef("foo")))); },
-                (Consumer<InternalBoxplot>) boxplot -> { fail("Should have thrown exception"); },
-                fieldType
+                new AggTestConfig<InternalBoxplot>(
+                    aggregationBuilder,
+                    iw -> { iw.addDocument(singleton(new SortedSetDocValuesField("string", new BytesRef("foo")))); },
+                    (Consumer<InternalBoxplot>) boxplot -> { fail("Should have thrown exception"); },
+                    new MappedFieldType[] { fieldType }
+                ).withQuery(new MatchAllDocsQuery())
             )
         );
         assertEquals(e.getMessage(), "Field [not_a_number] of type [keyword] " + "is not supported for aggregation [boxplot]");
@@ -226,14 +227,16 @@ public class BoxplotAggregatorTests extends AggregatorTestCase {
 
         MappedFieldType fieldType = new NumberFieldMapper.NumberFieldType("number", NumberFieldMapper.NumberType.INTEGER);
 
-        expectThrows(NumberFormatException.class, () -> testCase(aggregationBuilder, new MatchAllDocsQuery(), iw -> {
+        expectThrows(NumberFormatException.class, () -> testCase(new AggTestConfig<InternalBoxplot>(aggregationBuilder, iw -> {
             iw.addDocument(singleton(new NumericDocValuesField("number", 2)));
             iw.addDocument(singleton(new NumericDocValuesField("number", 2)));
             iw.addDocument(singleton(new NumericDocValuesField("number", 3)));
             iw.addDocument(singleton(new NumericDocValuesField("number", 4)));
             iw.addDocument(singleton(new NumericDocValuesField("number", 5)));
             iw.addDocument(singleton(new NumericDocValuesField("number", 10)));
-        }, (Consumer<InternalBoxplot>) boxplot -> { fail("Should have thrown exception"); }, fieldType));
+        }, (Consumer<InternalBoxplot>) boxplot -> { fail("Should have thrown exception"); }, new MappedFieldType[] { fieldType }).withQuery(
+            new MatchAllDocsQuery()
+        )));
     }
 
     public void testUnmappedWithBadMissingField() {
@@ -242,14 +245,16 @@ public class BoxplotAggregatorTests extends AggregatorTestCase {
 
         MappedFieldType fieldType = new NumberFieldMapper.NumberFieldType("number", NumberFieldMapper.NumberType.INTEGER);
 
-        expectThrows(NumberFormatException.class, () -> testCase(aggregationBuilder, new MatchAllDocsQuery(), iw -> {
+        expectThrows(NumberFormatException.class, () -> testCase(new AggTestConfig<InternalBoxplot>(aggregationBuilder, iw -> {
             iw.addDocument(singleton(new NumericDocValuesField("number", 2)));
             iw.addDocument(singleton(new NumericDocValuesField("number", 2)));
             iw.addDocument(singleton(new NumericDocValuesField("number", 3)));
             iw.addDocument(singleton(new NumericDocValuesField("number", 4)));
             iw.addDocument(singleton(new NumericDocValuesField("number", 5)));
             iw.addDocument(singleton(new NumericDocValuesField("number", 10)));
-        }, (Consumer<InternalBoxplot>) boxplot -> { fail("Should have thrown exception"); }, fieldType));
+        }, (Consumer<InternalBoxplot>) boxplot -> { fail("Should have thrown exception"); }, new MappedFieldType[] { fieldType }).withQuery(
+            new MatchAllDocsQuery()
+        )));
     }
 
     public void testEmptyBucket() throws IOException {
@@ -260,7 +265,7 @@ public class BoxplotAggregatorTests extends AggregatorTestCase {
 
         MappedFieldType fieldType = new NumberFieldMapper.NumberFieldType("number", NumberFieldMapper.NumberType.INTEGER);
 
-        testCase(histogram, new MatchAllDocsQuery(), iw -> {
+        testCase(new AggTestConfig<InternalHistogram>(histogram, iw -> {
             iw.addDocument(singleton(new NumericDocValuesField("number", 1)));
             iw.addDocument(singleton(new NumericDocValuesField("number", 3)));
             iw.addDocument(singleton(new NumericDocValuesField("number", 21)));
@@ -291,7 +296,7 @@ public class BoxplotAggregatorTests extends AggregatorTestCase {
             assertEquals(21, boxplot.getQ1(), 0);
             assertEquals(22, boxplot.getQ2(), 0);
             assertEquals(23, boxplot.getQ3(), 0);
-        }, fieldType);
+        }, new MappedFieldType[] { fieldType }).withQuery(new MatchAllDocsQuery()));
     }
 
     public void testFormatter() throws IOException {
@@ -299,7 +304,7 @@ public class BoxplotAggregatorTests extends AggregatorTestCase {
 
         MappedFieldType fieldType = new NumberFieldMapper.NumberFieldType("number", NumberFieldMapper.NumberType.INTEGER);
 
-        testCase(aggregationBuilder, new MatchAllDocsQuery(), iw -> {
+        testCase(new AggTestConfig<InternalBoxplot>(aggregationBuilder, iw -> {
             iw.addDocument(singleton(new NumericDocValuesField("number", 1)));
             iw.addDocument(singleton(new NumericDocValuesField("number", 2)));
             iw.addDocument(singleton(new NumericDocValuesField("number", 3)));
@@ -316,7 +321,7 @@ public class BoxplotAggregatorTests extends AggregatorTestCase {
             assertEquals("0001.8", boxplot.getQ1AsString());
             assertEquals("0003.0", boxplot.getQ2AsString());
             assertEquals("0004.2", boxplot.getQ3AsString());
-        }, fieldType);
+        }, new MappedFieldType[] { fieldType }).withQuery(new MatchAllDocsQuery()));
     }
 
     public void testGetProperty() throws IOException {
@@ -326,7 +331,7 @@ public class BoxplotAggregatorTests extends AggregatorTestCase {
 
         MappedFieldType fieldType = new NumberFieldMapper.NumberFieldType("number", NumberFieldMapper.NumberType.INTEGER);
 
-        testCase(globalBuilder, new MatchAllDocsQuery(), iw -> {
+        testCase(new AggTestConfig<InternalGlobal>(globalBuilder, iw -> {
             iw.addDocument(singleton(new NumericDocValuesField("number", 1)));
             iw.addDocument(singleton(new NumericDocValuesField("number", 2)));
             iw.addDocument(singleton(new NumericDocValuesField("number", 3)));
@@ -342,7 +347,7 @@ public class BoxplotAggregatorTests extends AggregatorTestCase {
             assertThat(global.getProperty("boxplot.max"), equalTo(5.0));
             assertThat(boxplot.getProperty("min"), equalTo(1.0));
             assertThat(boxplot.getProperty("max"), equalTo(5.0));
-        }, fieldType);
+        }, new MappedFieldType[] { fieldType }).withQuery(new MatchAllDocsQuery()));
     }
 
     public void testValueScript() throws IOException {
@@ -351,7 +356,7 @@ public class BoxplotAggregatorTests extends AggregatorTestCase {
 
         MappedFieldType fieldType = new NumberFieldMapper.NumberFieldType("number", NumberFieldMapper.NumberType.INTEGER);
 
-        testCase(aggregationBuilder, new MatchAllDocsQuery(), iw -> {
+        testCase(new AggTestConfig<InternalBoxplot>(aggregationBuilder, iw -> {
             iw.addDocument(singleton(new NumericDocValuesField("number", 7)));
             iw.addDocument(singleton(new NumericDocValuesField("number", 1)));
         }, (Consumer<InternalBoxplot>) boxplot -> {
@@ -360,7 +365,7 @@ public class BoxplotAggregatorTests extends AggregatorTestCase {
             assertEquals(2, boxplot.getQ1(), 0);
             assertEquals(5, boxplot.getQ2(), 0);
             assertEquals(8, boxplot.getQ3(), 0);
-        }, fieldType);
+        }, new MappedFieldType[] { fieldType }).withQuery(new MatchAllDocsQuery()));
     }
 
     public void testValueScriptUnmapped() throws IOException {
@@ -369,7 +374,7 @@ public class BoxplotAggregatorTests extends AggregatorTestCase {
 
         MappedFieldType fieldType = new NumberFieldMapper.NumberFieldType("number", NumberFieldMapper.NumberType.INTEGER);
 
-        testCase(aggregationBuilder, new MatchAllDocsQuery(), iw -> {
+        testCase(new AggTestConfig<InternalBoxplot>(aggregationBuilder, iw -> {
             iw.addDocument(singleton(new NumericDocValuesField("number", 7)));
             iw.addDocument(singleton(new NumericDocValuesField("number", 1)));
         }, (Consumer<InternalBoxplot>) boxplot -> {
@@ -378,7 +383,7 @@ public class BoxplotAggregatorTests extends AggregatorTestCase {
             assertEquals(Double.NaN, boxplot.getQ1(), 0);
             assertEquals(Double.NaN, boxplot.getQ2(), 0);
             assertEquals(Double.NaN, boxplot.getQ3(), 0);
-        }, fieldType);
+        }, new MappedFieldType[] { fieldType }).withQuery(new MatchAllDocsQuery()));
     }
 
     public void testValueScriptUnmappedMissing() throws IOException {
@@ -388,7 +393,8 @@ public class BoxplotAggregatorTests extends AggregatorTestCase {
 
         MappedFieldType fieldType = new NumberFieldMapper.NumberFieldType("number", NumberFieldMapper.NumberType.INTEGER);
 
-        testCase(aggregationBuilder, new MatchAllDocsQuery(), iw -> {
+        // Note: the way scripts, missing and unmapped interact, these will be the missing value and the script is not invoked
+        testCase(new AggTestConfig<InternalBoxplot>(aggregationBuilder, iw -> {
             iw.addDocument(singleton(new NumericDocValuesField("number", 7)));
             iw.addDocument(singleton(new NumericDocValuesField("number", 1)));
         }, (Consumer<InternalBoxplot>) boxplot -> {
@@ -398,14 +404,16 @@ public class BoxplotAggregatorTests extends AggregatorTestCase {
             assertEquals(1.0, boxplot.getQ1(), 0);
             assertEquals(1.0, boxplot.getQ2(), 0);
             assertEquals(1.0, boxplot.getQ3(), 0);
-        }, fieldType);
+        }, new MappedFieldType[] { fieldType }).withQuery(new MatchAllDocsQuery()));
     }
 
     private void testCase(Query query, CheckedConsumer<RandomIndexWriter, IOException> buildIndex, Consumer<InternalBoxplot> verify)
         throws IOException {
         MappedFieldType fieldType = new NumberFieldMapper.NumberFieldType("number", NumberFieldMapper.NumberType.INTEGER);
         BoxplotAggregationBuilder aggregationBuilder = new BoxplotAggregationBuilder("boxplot").field("number");
-        testCase(aggregationBuilder, query, buildIndex, verify, fieldType);
+        testCase(
+            new AggTestConfig<InternalBoxplot>(aggregationBuilder, buildIndex, verify, new MappedFieldType[] { fieldType }).withQuery(query)
+        );
     }
 
 }

--- a/x-pack/plugin/analytics/src/test/java/org/elasticsearch/xpack/analytics/multiterms/MultiTermsAggregatorTests.java
+++ b/x-pack/plugin/analytics/src/test/java/org/elasticsearch/xpack/analytics/multiterms/MultiTermsAggregatorTests.java
@@ -634,14 +634,7 @@ public class MultiTermsAggregatorTests extends AggregatorTestCase {
                 builder.size(randomIntBetween(10, 200));
             }
         }
-        testCase(
-            new AggTestConfig<InternalMultiTerms>(
-                builder,
-                buildIndex,
-                verify,
-                new MappedFieldType[] { dateType, intType, floatType, keywordType }
-            ).withQuery(query)
-        );
+        testCase(new AggTestConfig<>(builder, buildIndex, verify, dateType, intType, floatType, keywordType).withQuery(query));
     }
 
     @Override

--- a/x-pack/plugin/analytics/src/test/java/org/elasticsearch/xpack/analytics/multiterms/MultiTermsAggregatorTests.java
+++ b/x-pack/plugin/analytics/src/test/java/org/elasticsearch/xpack/analytics/multiterms/MultiTermsAggregatorTests.java
@@ -634,7 +634,14 @@ public class MultiTermsAggregatorTests extends AggregatorTestCase {
                 builder.size(randomIntBetween(10, 200));
             }
         }
-        testCase(builder, query, buildIndex, verify, dateType, intType, floatType, keywordType);
+        testCase(
+            new AggTestConfig<InternalMultiTerms>(
+                builder,
+                buildIndex,
+                verify,
+                new MappedFieldType[] { dateType, intType, floatType, keywordType }
+            ).withQuery(query)
+        );
     }
 
     @Override

--- a/x-pack/plugin/analytics/src/test/java/org/elasticsearch/xpack/analytics/stringstats/StringStatsAggregatorTests.java
+++ b/x-pack/plugin/analytics/src/test/java/org/elasticsearch/xpack/analytics/stringstats/StringStatsAggregatorTests.java
@@ -391,7 +391,7 @@ public class StringStatsAggregatorTests extends AggregatorTestCase {
         Consumer<InternalStringStats> verify,
         MappedFieldType... fieldTypes
     ) throws IOException {
-        testCase(aggregationBuilder, query, buildIndex, verify, fieldTypes);
+        testCase(new AggTestConfig<InternalStringStats>(aggregationBuilder, buildIndex, verify, fieldTypes).withQuery(query));
     }
 
     @Override

--- a/x-pack/plugin/analytics/src/test/java/org/elasticsearch/xpack/analytics/stringstats/StringStatsAggregatorTests.java
+++ b/x-pack/plugin/analytics/src/test/java/org/elasticsearch/xpack/analytics/stringstats/StringStatsAggregatorTests.java
@@ -81,7 +81,7 @@ public class StringStatsAggregatorTests extends AggregatorTestCase {
 
     public void testUnmappedField() throws IOException {
         StringStatsAggregationBuilder aggregationBuilder = new StringStatsAggregationBuilder("_name").field("text");
-        testAggregation(aggregationBuilder, new MatchAllDocsQuery(), iw -> {
+        testCase(new AggTestConfig<InternalStringStats>(aggregationBuilder, iw -> {
             for (int i = 0; i < 10; i++) {
                 iw.addDocument(singleton(new TextField("text", "test" + i, Field.Store.NO)));
             }
@@ -93,12 +93,12 @@ public class StringStatsAggregatorTests extends AggregatorTestCase {
             assertTrue(stats.getDistribution().isEmpty());
             assertEquals(0.0, stats.getEntropy(), 0);
 
-        });
+        }));
     }
 
     public void testUnmappedWithMissingField() throws IOException {
         StringStatsAggregationBuilder aggregationBuilder = new StringStatsAggregationBuilder("_name").field("text").missing("abca");
-        testAggregation(aggregationBuilder, new MatchAllDocsQuery(), iw -> {
+        testCase(new AggTestConfig<InternalStringStats>(aggregationBuilder, iw -> {
             for (int i = 0; i < 10; i++) {
                 iw.addDocument(singleton(new TextField("text", "test" + i, Field.Store.NO)));
             }
@@ -112,7 +112,7 @@ public class StringStatsAggregatorTests extends AggregatorTestCase {
             assertEquals(0.25, stats.getDistribution().get("b"), 0);
             assertEquals(0.25, stats.getDistribution().get("c"), 0);
             assertEquals(1.5, stats.getEntropy(), 0);
-        });
+        }));
     }
 
     public void testMissing() throws IOException {
@@ -122,7 +122,7 @@ public class StringStatsAggregatorTests extends AggregatorTestCase {
         final StringStatsAggregationBuilder aggregationBuilder = new StringStatsAggregationBuilder("_name").field(fieldType.name())
             .missing("b");
 
-        testAggregation(aggregationBuilder, new MatchAllDocsQuery(), iw -> {
+        testCase(new AggTestConfig<InternalStringStats>(aggregationBuilder, iw -> {
             iw.addDocument(singleton(new TextField(fieldType.name(), "a", Field.Store.NO)));
             iw.addDocument(emptySet());
             iw.addDocument(singleton(new TextField(fieldType.name(), "a", Field.Store.NO)));
@@ -136,7 +136,7 @@ public class StringStatsAggregatorTests extends AggregatorTestCase {
             assertEquals(0.5, stats.getDistribution().get("a"), 0);
             assertEquals(0.5, stats.getDistribution().get("b"), 0);
             assertEquals(1.0, stats.getEntropy(), 0);
-        }, fieldType);
+        }, fieldType));
     }
 
     public void testSingleValuedField() throws IOException {
@@ -199,7 +199,7 @@ public class StringStatsAggregatorTests extends AggregatorTestCase {
             .format("0000.00")
             .showDistribution(true);
 
-        testAggregation(aggregationBuilder, new MatchAllDocsQuery(), iw -> {
+        testCase(new AggTestConfig<InternalStringStats>(aggregationBuilder, iw -> {
             for (int i = 0; i < 10; i++) {
                 iw.addDocument(singleton(new TextField("text", "test" + i, Field.Store.NO)));
             }
@@ -209,7 +209,7 @@ public class StringStatsAggregatorTests extends AggregatorTestCase {
             assertEquals("0005.00", stats.getMinLengthAsString());
             assertEquals("0005.00", stats.getAvgLengthAsString());
             assertEquals("0002.58", stats.getEntropyAsString());
-        }, fieldType);
+        }, fieldType));
     }
 
     /**
@@ -279,7 +279,7 @@ public class StringStatsAggregatorTests extends AggregatorTestCase {
         final StringStatsAggregationBuilder aggregationBuilder = new StringStatsAggregationBuilder("_name").field(fieldType.name())
             .script(new Script(ScriptType.INLINE, MockScriptEngine.NAME, VALUE_SCRIPT_NAME, emptyMap()));
 
-        testAggregation(aggregationBuilder, new MatchAllDocsQuery(), iw -> {
+        testCase(new AggTestConfig<InternalStringStats>(aggregationBuilder, iw -> {
             iw.addDocument(singleton(new TextField(fieldType.name(), "b", Field.Store.NO)));
             iw.addDocument(singleton(new TextField(fieldType.name(), "b", Field.Store.NO)));
         }, stats -> {
@@ -291,7 +291,7 @@ public class StringStatsAggregatorTests extends AggregatorTestCase {
             assertEquals(0.5, stats.getDistribution().get("a"), 0);
             assertEquals(0.5, stats.getDistribution().get("b"), 0);
             assertEquals(1.0, stats.getEntropy(), 0);
-        }, fieldType);
+        }, fieldType));
     }
 
     public void testValueScriptMultiValuedField() throws IOException {
@@ -301,7 +301,7 @@ public class StringStatsAggregatorTests extends AggregatorTestCase {
         final StringStatsAggregationBuilder aggregationBuilder = new StringStatsAggregationBuilder("_name").field(fieldType.name())
             .script(new Script(ScriptType.INLINE, MockScriptEngine.NAME, VALUE_SCRIPT_NAME, emptyMap()));
 
-        testAggregation(aggregationBuilder, new MatchAllDocsQuery(), iw -> {
+        testCase(new AggTestConfig<InternalStringStats>(aggregationBuilder, iw -> {
             iw.addDocument(
                 Set.of(new TextField(fieldType.name(), "b", Field.Store.NO), new TextField(fieldType.name(), "c", Field.Store.NO))
             );
@@ -318,7 +318,7 @@ public class StringStatsAggregatorTests extends AggregatorTestCase {
             assertEquals(0.25, stats.getDistribution().get("b"), 0);
             assertEquals(0.25, stats.getDistribution().get("c"), 0);
             assertEquals(1.5, stats.getEntropy(), 0);
-        }, fieldType);
+        }, fieldType));
     }
 
     public void testFieldScriptSingleValuedField() throws IOException {
@@ -329,7 +329,7 @@ public class StringStatsAggregatorTests extends AggregatorTestCase {
             new Script(ScriptType.INLINE, MockScriptEngine.NAME, FIELD_SCRIPT_NAME, singletonMap("field", fieldType.name()))
         );
 
-        testAggregation(aggregationBuilder, new MatchAllDocsQuery(), iw -> {
+        testCase(new AggTestConfig<InternalStringStats>(aggregationBuilder, iw -> {
             iw.addDocument(singleton(new TextField(fieldType.name(), "b", Field.Store.NO)));
             iw.addDocument(singleton(new TextField(fieldType.name(), "b", Field.Store.NO)));
         }, stats -> {
@@ -341,7 +341,7 @@ public class StringStatsAggregatorTests extends AggregatorTestCase {
             assertEquals(0.5, stats.getDistribution().get("a"), 0);
             assertEquals(0.5, stats.getDistribution().get("b"), 0);
             assertEquals(1.0, stats.getEntropy(), 0);
-        }, fieldType);
+        }, fieldType));
     }
 
     public void testFieldScriptMultiValuedField() throws IOException {
@@ -352,7 +352,7 @@ public class StringStatsAggregatorTests extends AggregatorTestCase {
             new Script(ScriptType.INLINE, MockScriptEngine.NAME, FIELD_SCRIPT_NAME, singletonMap("field", fieldType.name()))
         );
 
-        testAggregation(aggregationBuilder, new MatchAllDocsQuery(), iw -> {
+        testCase(new AggTestConfig<InternalStringStats>(aggregationBuilder, iw -> {
             iw.addDocument(
                 Set.of(new TextField(fieldType.name(), "b", Field.Store.NO), new TextField(fieldType.name(), "c", Field.Store.NO))
             );
@@ -369,7 +369,7 @@ public class StringStatsAggregatorTests extends AggregatorTestCase {
             assertEquals(0.25, stats.getDistribution().get("b"), 0);
             assertEquals(0.25, stats.getDistribution().get("c"), 0);
             assertEquals(1.5, stats.getEntropy(), 0);
-        }, fieldType);
+        }, fieldType));
     }
 
     private void testAggregation(
@@ -381,17 +381,7 @@ public class StringStatsAggregatorTests extends AggregatorTestCase {
         fieldType.setFielddata(true);
 
         AggregationBuilder aggregationBuilder = new StringStatsAggregationBuilder("_name").field("text");
-        testAggregation(aggregationBuilder, query, buildIndex, verify, fieldType);
-    }
-
-    private void testAggregation(
-        AggregationBuilder aggregationBuilder,
-        Query query,
-        CheckedConsumer<RandomIndexWriter, IOException> buildIndex,
-        Consumer<InternalStringStats> verify,
-        MappedFieldType... fieldTypes
-    ) throws IOException {
-        testCase(new AggTestConfig<>(aggregationBuilder, buildIndex, verify, fieldTypes).withQuery(query));
+        testCase(new AggTestConfig<InternalStringStats>(aggregationBuilder, buildIndex, verify, fieldType).withQuery(query));
     }
 
     @Override

--- a/x-pack/plugin/analytics/src/test/java/org/elasticsearch/xpack/analytics/stringstats/StringStatsAggregatorTests.java
+++ b/x-pack/plugin/analytics/src/test/java/org/elasticsearch/xpack/analytics/stringstats/StringStatsAggregatorTests.java
@@ -391,7 +391,7 @@ public class StringStatsAggregatorTests extends AggregatorTestCase {
         Consumer<InternalStringStats> verify,
         MappedFieldType... fieldTypes
     ) throws IOException {
-        testCase(new AggTestConfig<InternalStringStats>(aggregationBuilder, buildIndex, verify, fieldTypes).withQuery(query));
+        testCase(new AggTestConfig<>(aggregationBuilder, buildIndex, verify, fieldTypes).withQuery(query));
     }
 
     @Override

--- a/x-pack/plugin/analytics/src/test/java/org/elasticsearch/xpack/analytics/topmetrics/TopMetricsAggregatorTests.java
+++ b/x-pack/plugin/analytics/src/test/java/org/elasticsearch/xpack/analytics/topmetrics/TopMetricsAggregatorTests.java
@@ -595,7 +595,7 @@ public class TopMetricsAggregatorTests extends AggregatorTestCase {
             try (IndexReader indexReader = DirectoryReader.open(directory)) {
                 IndexSearcher indexSearcher = newSearcher(indexReader, true, true);
                 InternalAggregation agg = searchAndReduce(
-                    new AggTestConfig(indexSearcher, query, builder, fields).withShouldBeCached(shouldBeCached)
+                    new AggTestConfig<>(indexSearcher, query, builder, fields).withShouldBeCached(shouldBeCached)
                 );
                 verifyOutputFieldNames(builder, agg);
                 return agg;

--- a/x-pack/plugin/analytics/src/test/java/org/elasticsearch/xpack/analytics/ttest/TTestAggregatorTests.java
+++ b/x-pack/plugin/analytics/src/test/java/org/elasticsearch/xpack/analytics/ttest/TTestAggregatorTests.java
@@ -33,6 +33,7 @@ import org.elasticsearch.script.ScriptType;
 import org.elasticsearch.search.aggregations.AggregationBuilder;
 import org.elasticsearch.search.aggregations.AggregationExecutionException;
 import org.elasticsearch.search.aggregations.AggregatorTestCase;
+import org.elasticsearch.search.aggregations.InternalAggregation;
 import org.elasticsearch.search.aggregations.bucket.global.GlobalAggregationBuilder;
 import org.elasticsearch.search.aggregations.bucket.global.InternalGlobal;
 import org.elasticsearch.search.aggregations.bucket.histogram.HistogramAggregationBuilder;
@@ -208,10 +209,10 @@ public class TTestAggregatorTests extends AggregatorTestCase {
 
         IllegalArgumentException ex = expectThrows(
             IllegalArgumentException.class,
-            () -> testCase(aggregationBuilder, new MatchAllDocsQuery(), iw -> {
+            () -> testCase(new AggTestConfig<InternalAggregation>(aggregationBuilder, iw -> {
                 iw.addDocument(singleton(new SortedNumericDocValuesField("field", 102)));
                 iw.addDocument(singleton(new SortedNumericDocValuesField("field", 99)));
-            }, tTest -> fail("Should have thrown exception"), fieldType)
+            }, tTest -> fail("Should have thrown exception"), fieldType).withQuery(new MatchAllDocsQuery()))
         );
         assertEquals("The same field [field] is used for both population but no filters are specified.", ex.getMessage());
     }
@@ -272,7 +273,7 @@ public class TTestAggregatorTests extends AggregatorTestCase {
         TTestAggregationBuilder aggregationBuilder = new TTestAggregationBuilder("t_test").a(
             new MultiValuesSourceFieldConfig.Builder().setFieldName("a").setMissing(100).build()
         ).b(new MultiValuesSourceFieldConfig.Builder().setFieldName("b").setMissing(100).build()).testType(tTestType);
-        testCase(aggregationBuilder, new MatchAllDocsQuery(), iw -> {
+        testCase(new AggTestConfig<InternalTTest>(aggregationBuilder, iw -> {
             iw.addDocument(asList(new NumericDocValuesField("a", 102), new NumericDocValuesField("b", 89)));
             iw.addDocument(asList(new NumericDocValuesField("a", 99), new NumericDocValuesField("b", 93)));
         }, (Consumer<InternalTTest>) tTest -> {
@@ -295,7 +296,7 @@ public class TTestAggregatorTests extends AggregatorTestCase {
                     }
                 }
             }
-        }, fieldType1, fieldType2);
+        }, new MappedFieldType[] { fieldType1, fieldType2 }).withQuery(new MatchAllDocsQuery()));
     }
 
     public void testUnsupportedType() {
@@ -320,7 +321,7 @@ public class TTestAggregatorTests extends AggregatorTestCase {
 
         IllegalArgumentException ex = expectThrows(
             IllegalArgumentException.class,
-            () -> testCase(aggregationBuilder, new MatchAllDocsQuery(), iw -> {
+            () -> testCase(new AggTestConfig<InternalAggregation>(aggregationBuilder, iw -> {
                 iw.addDocument(
                     asList(
                         new SortedNumericDocValuesField("a", 102),
@@ -329,7 +330,7 @@ public class TTestAggregatorTests extends AggregatorTestCase {
                     )
                 );
                 iw.addDocument(asList(new SortedNumericDocValuesField("a", 99), new SortedNumericDocValuesField("b", 93)));
-            }, tTest -> fail("Should have thrown exception"), fieldType1, fieldType2)
+            }, tTest -> fail("Should have thrown exception"), fieldType1, fieldType2).withQuery(new MatchAllDocsQuery()))
         );
         assertEquals("Expected numeric type on field [" + (wrongA ? "a" : "b") + "], but got [keyword]", ex.getMessage());
     }
@@ -352,10 +353,10 @@ public class TTestAggregatorTests extends AggregatorTestCase {
 
         NumberFormatException ex = expectThrows(
             NumberFormatException.class,
-            () -> testCase(aggregationBuilder, new MatchAllDocsQuery(), iw -> {
+            () -> testCase(new AggTestConfig<InternalAggregation>(aggregationBuilder, iw -> {
                 iw.addDocument(asList(new SortedNumericDocValuesField("a", 102), new SortedNumericDocValuesField("b", 89)));
                 iw.addDocument(asList(new SortedNumericDocValuesField("a", 99), new SortedNumericDocValuesField("b", 93)));
-            }, tTest -> fail("Should have thrown exception"), fieldType1, fieldType2)
+            }, tTest -> fail("Should have thrown exception"), fieldType1, fieldType2).withQuery(new MatchAllDocsQuery()))
         );
         assertEquals("For input string: \"bad_number\"", ex.getMessage());
     }
@@ -383,10 +384,10 @@ public class TTestAggregatorTests extends AggregatorTestCase {
 
         NumberFormatException ex = expectThrows(
             NumberFormatException.class,
-            () -> testCase(aggregationBuilder, new MatchAllDocsQuery(), iw -> {
+            () -> testCase(new AggTestConfig<InternalAggregation>(aggregationBuilder, iw -> {
                 iw.addDocument(asList(new SortedNumericDocValuesField("a", 102), new SortedNumericDocValuesField("b", 89)));
                 iw.addDocument(asList(new SortedNumericDocValuesField("a", 99), new SortedNumericDocValuesField("b", 93)));
-            }, tTest -> fail("Should have thrown exception"), fieldType1, fieldType2)
+            }, tTest -> fail("Should have thrown exception"), fieldType1, fieldType2).withQuery(new MatchAllDocsQuery()))
         );
         assertEquals("For input string: \"bad_number\"", ex.getMessage());
     }
@@ -405,7 +406,7 @@ public class TTestAggregatorTests extends AggregatorTestCase {
                     .testType(tTestType)
             );
 
-        testCase(histogram, new MatchAllDocsQuery(), iw -> {
+        testCase(new AggTestConfig<InternalHistogram>(histogram, iw -> {
             iw.addDocument(
                 asList(new NumericDocValuesField("a", 102), new NumericDocValuesField("b", 89), new NumericDocValuesField("part", 1))
             );
@@ -446,7 +447,7 @@ public class TTestAggregatorTests extends AggregatorTestCase {
                 0.000001
             );
 
-        }, fieldType1, fieldType2, fieldTypePart);
+        }, new MappedFieldType[] { fieldType1, fieldType2, fieldTypePart }).withQuery(new MatchAllDocsQuery()));
     }
 
     @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/54365")
@@ -458,7 +459,7 @@ public class TTestAggregatorTests extends AggregatorTestCase {
             new MultiValuesSourceFieldConfig.Builder().setFieldName("a").build()
         ).b(new MultiValuesSourceFieldConfig.Builder().setFieldName("b").build()).testType(tTestType).format("0.00%");
 
-        testCase(aggregationBuilder, new MatchAllDocsQuery(), iw -> {
+        testCase(new AggTestConfig<InternalTTest>(aggregationBuilder, iw -> {
             iw.addDocument(asList(new NumericDocValuesField("a", 102), new NumericDocValuesField("b", 89)));
             iw.addDocument(asList(new NumericDocValuesField("a", 99), new NumericDocValuesField("b", 93)));
             iw.addDocument(asList(new NumericDocValuesField("a", 111), new NumericDocValuesField("b", 72)));
@@ -472,7 +473,7 @@ public class TTestAggregatorTests extends AggregatorTestCase {
                 tTestType == TTestType.PAIRED ? "19.40%" : tTestType == TTestType.HOMOSCEDASTIC ? "5.88%" : "7.53%",
                 tTest.getValueAsString()
             );
-        }, fieldType1, fieldType2);
+        }, new MappedFieldType[] { fieldType1, fieldType2 }).withQuery(new MatchAllDocsQuery()));
     }
 
     public void testGetProperty() throws IOException {
@@ -484,7 +485,7 @@ public class TTestAggregatorTests extends AggregatorTestCase {
                 .testType(TTestType.PAIRED)
         );
 
-        testCase(globalBuilder, new MatchAllDocsQuery(), iw -> {
+        testCase(new AggTestConfig<InternalGlobal>(globalBuilder, iw -> {
             iw.addDocument(asList(new NumericDocValuesField("a", 102), new NumericDocValuesField("b", 89)));
             iw.addDocument(asList(new NumericDocValuesField("a", 99), new NumericDocValuesField("b", 93)));
             iw.addDocument(asList(new NumericDocValuesField("a", 111), new NumericDocValuesField("b", 72)));
@@ -495,7 +496,7 @@ public class TTestAggregatorTests extends AggregatorTestCase {
             InternalTTest tTest = (InternalTTest) global.getAggregations().asMap().get("t_test");
             assertEquals(tTest, global.getProperty("t_test"));
             assertEquals(0.1939778614, (Double) global.getProperty("t_test.value"), 0.000001);
-        }, fieldType1, fieldType2);
+        }, new MappedFieldType[] { fieldType1, fieldType2 }).withQuery(new MatchAllDocsQuery()));
     }
 
     public void testScript() throws IOException {
@@ -512,7 +513,7 @@ public class TTestAggregatorTests extends AggregatorTestCase {
             .b(fieldInA ? b : a)
             .testType(tTestType);
 
-        testCase(aggregationBuilder, new MatchAllDocsQuery(), iw -> {
+        testCase(new AggTestConfig<InternalTTest>(aggregationBuilder, iw -> {
             iw.addDocument(singleton(new NumericDocValuesField("field", 1)));
             iw.addDocument(singleton(new NumericDocValuesField("field", 2)));
             iw.addDocument(singleton(new NumericDocValuesField("field", 3)));
@@ -520,8 +521,8 @@ public class TTestAggregatorTests extends AggregatorTestCase {
             (Consumer<InternalTTest>) tTest -> {
                 assertEquals(tTestType == TTestType.PAIRED ? 0 : 0.5733922538, tTest.getValue(), 0.000001);
             },
-            fieldType
-        );
+            new MappedFieldType[] { fieldType }
+        ).withQuery(new MatchAllDocsQuery()));
     }
 
     public void testPaired() throws IOException {
@@ -534,14 +535,17 @@ public class TTestAggregatorTests extends AggregatorTestCase {
         if (tails == 1 || randomBoolean()) {
             aggregationBuilder.tails(tails);
         }
-        testCase(aggregationBuilder, new MatchAllDocsQuery(), iw -> {
+        testCase(new AggTestConfig<InternalTTest>(aggregationBuilder, iw -> {
             iw.addDocument(asList(new NumericDocValuesField("a", 102), new NumericDocValuesField("b", 89)));
             iw.addDocument(asList(new NumericDocValuesField("a", 99), new NumericDocValuesField("b", 93)));
             iw.addDocument(asList(new NumericDocValuesField("a", 111), new NumericDocValuesField("b", 72)));
             iw.addDocument(asList(new NumericDocValuesField("a", 97), new NumericDocValuesField("b", 98)));
             iw.addDocument(asList(new NumericDocValuesField("a", 101), new NumericDocValuesField("b", 102)));
             iw.addDocument(asList(new NumericDocValuesField("a", 99), new NumericDocValuesField("b", 98)));
-        }, (Consumer<InternalTTest>) ttest -> { assertEquals(0.09571844217 * tails, ttest.getValue(), 0.00001); }, fieldType1, fieldType2);
+        },
+            (Consumer<InternalTTest>) ttest -> { assertEquals(0.09571844217 * tails, ttest.getValue(), 0.00001); },
+            new MappedFieldType[] { fieldType1, fieldType2 }
+        ).withQuery(new MatchAllDocsQuery()));
     }
 
     public void testHomoscedastic() throws IOException {
@@ -554,14 +558,17 @@ public class TTestAggregatorTests extends AggregatorTestCase {
         if (tails == 1 || randomBoolean()) {
             aggregationBuilder.tails(tails);
         }
-        testCase(aggregationBuilder, new MatchAllDocsQuery(), iw -> {
+        testCase(new AggTestConfig<InternalTTest>(aggregationBuilder, iw -> {
             iw.addDocument(asList(new NumericDocValuesField("a", 102), new NumericDocValuesField("b", 89)));
             iw.addDocument(asList(new NumericDocValuesField("a", 99), new NumericDocValuesField("b", 93)));
             iw.addDocument(asList(new NumericDocValuesField("a", 111), new NumericDocValuesField("b", 72)));
             iw.addDocument(asList(new NumericDocValuesField("a", 97), new NumericDocValuesField("b", 98)));
             iw.addDocument(asList(new NumericDocValuesField("a", 101), new NumericDocValuesField("b", 102)));
             iw.addDocument(asList(new NumericDocValuesField("a", 99), new NumericDocValuesField("b", 98)));
-        }, (Consumer<InternalTTest>) ttest -> { assertEquals(0.03928288693 * tails, ttest.getValue(), 0.00001); }, fieldType1, fieldType2);
+        },
+            (Consumer<InternalTTest>) ttest -> { assertEquals(0.03928288693 * tails, ttest.getValue(), 0.00001); },
+            new MappedFieldType[] { fieldType1, fieldType2 }
+        ).withQuery(new MatchAllDocsQuery()));
     }
 
     public void testHeteroscedastic() throws IOException {
@@ -577,14 +584,17 @@ public class TTestAggregatorTests extends AggregatorTestCase {
         if (tails == 1 || randomBoolean()) {
             aggregationBuilder.tails(tails);
         }
-        testCase(aggregationBuilder, new MatchAllDocsQuery(), iw -> {
+        testCase(new AggTestConfig<InternalTTest>(aggregationBuilder, iw -> {
             iw.addDocument(asList(new NumericDocValuesField("a", 102), new NumericDocValuesField("b", 89)));
             iw.addDocument(asList(new NumericDocValuesField("a", 99), new NumericDocValuesField("b", 93)));
             iw.addDocument(asList(new NumericDocValuesField("a", 111), new NumericDocValuesField("b", 72)));
             iw.addDocument(asList(new NumericDocValuesField("a", 97), new NumericDocValuesField("b", 98)));
             iw.addDocument(asList(new NumericDocValuesField("a", 101), new NumericDocValuesField("b", 102)));
             iw.addDocument(asList(new NumericDocValuesField("a", 99), new NumericDocValuesField("b", 98)));
-        }, (Consumer<InternalTTest>) ttest -> { assertEquals(0.04538666214 * tails, ttest.getValue(), 0.00001); }, fieldType1, fieldType2);
+        },
+            (Consumer<InternalTTest>) ttest -> { assertEquals(0.04538666214 * tails, ttest.getValue(), 0.00001); },
+            new MappedFieldType[] { fieldType1, fieldType2 }
+        ).withQuery(new MatchAllDocsQuery()));
     }
 
     public void testFiltered() throws IOException {
@@ -626,23 +636,24 @@ public class TTestAggregatorTests extends AggregatorTestCase {
             IllegalArgumentException ex = expectThrows(
                 IllegalArgumentException.class,
                 () -> testCase(
-                    aggregationBuilder,
-                    new MatchAllDocsQuery(),
-                    buildIndex,
-                    tTest -> fail("Should have thrown exception"),
-                    fieldType1,
-                    fieldType2
+                    new AggTestConfig<InternalAggregation>(
+                        aggregationBuilder,
+                        buildIndex,
+                        tTest -> fail("Should have thrown exception"),
+                        fieldType1,
+                        fieldType2
+                    ).withQuery(new MatchAllDocsQuery())
                 )
             );
             assertEquals("Paired t-test doesn't support filters", ex.getMessage());
         } else {
-            testCase(aggregationBuilder, new MatchAllDocsQuery(), buildIndex, (Consumer<InternalTTest>) ttest -> {
+            testCase(new AggTestConfig<InternalTTest>(aggregationBuilder, buildIndex, (Consumer<InternalTTest>) ttest -> {
                 if (tTestType == TTestType.HOMOSCEDASTIC) {
                     assertEquals(0.03928288693 * tails, ttest.getValue(), 0.00001);
                 } else {
                     assertEquals(0.04538666214 * tails, ttest.getValue(), 0.00001);
                 }
-            }, fieldType1, fieldType2);
+            }, new MappedFieldType[] { fieldType1, fieldType2 }).withQuery(new MatchAllDocsQuery()));
         }
     }
 
@@ -665,7 +676,7 @@ public class TTestAggregatorTests extends AggregatorTestCase {
             .b(fieldInA ? b.build() : a.build())
             .testType(tTestType);
 
-        testCase(aggregationBuilder, new MatchAllDocsQuery(), iw -> {
+        testCase(new AggTestConfig<InternalTTest>(aggregationBuilder, iw -> {
             iw.addDocument(asList(new NumericDocValuesField("field", 1), new IntPoint("term", 1), new NumericDocValuesField("term", 1)));
             iw.addDocument(asList(new NumericDocValuesField("field", 2), new IntPoint("term", 1), new NumericDocValuesField("term", 1)));
             iw.addDocument(asList(new NumericDocValuesField("field", 3), new IntPoint("term", 1), new NumericDocValuesField("term", 1)));
@@ -673,7 +684,10 @@ public class TTestAggregatorTests extends AggregatorTestCase {
             iw.addDocument(asList(new NumericDocValuesField("field", 4), new IntPoint("term", 2), new NumericDocValuesField("term", 2)));
             iw.addDocument(asList(new NumericDocValuesField("field", 5), new IntPoint("term", 2), new NumericDocValuesField("term", 2)));
             iw.addDocument(asList(new NumericDocValuesField("field", 6), new IntPoint("term", 2), new NumericDocValuesField("term", 2)));
-        }, (Consumer<InternalTTest>) tTest -> { assertEquals(0.02131164113, tTest.getValue(), 0.000001); }, fieldType1, fieldType2);
+        },
+            (Consumer<InternalTTest>) tTest -> { assertEquals(0.02131164113, tTest.getValue(), 0.000001); },
+            new MappedFieldType[] { fieldType1, fieldType2 }
+        ).withQuery(new MatchAllDocsQuery()));
     }
 
     private void testCase(
@@ -691,7 +705,10 @@ public class TTestAggregatorTests extends AggregatorTestCase {
         if (type != TTestType.HETEROSCEDASTIC || randomBoolean()) {
             aggregationBuilder.testType(type);
         }
-        testCase(aggregationBuilder, query, buildIndex, verify, fieldType1, fieldType2);
+        testCase(
+            new AggTestConfig<InternalTTest>(aggregationBuilder, buildIndex, verify, new MappedFieldType[] { fieldType1, fieldType2 })
+                .withQuery(query)
+        );
     }
 
     @Override

--- a/x-pack/plugin/mapper-aggregate-metric/src/test/java/org/elasticsearch/xpack/aggregatemetric/aggregations/metrics/AggregateMetricBackedAvgAggregatorTests.java
+++ b/x-pack/plugin/mapper-aggregate-metric/src/test/java/org/elasticsearch/xpack/aggregatemetric/aggregations/metrics/AggregateMetricBackedAvgAggregatorTests.java
@@ -135,7 +135,9 @@ public class AggregateMetricBackedAvgAggregatorTests extends AggregatorTestCase 
         throws IOException {
         MappedFieldType fieldType = createDefaultFieldType(FIELD_NAME);
         AggregationBuilder aggregationBuilder = createAggBuilderForTypeTest(fieldType, FIELD_NAME);
-        testCase(aggregationBuilder, query, buildIndex, verify, fieldType);
+        testCase(
+            new AggTestConfig<InternalAvg>(aggregationBuilder, buildIndex, verify, new MappedFieldType[] { fieldType }).withQuery(query)
+        );
     }
 
     @Override

--- a/x-pack/plugin/mapper-aggregate-metric/src/test/java/org/elasticsearch/xpack/aggregatemetric/aggregations/metrics/AggregateMetricBackedAvgAggregatorTests.java
+++ b/x-pack/plugin/mapper-aggregate-metric/src/test/java/org/elasticsearch/xpack/aggregatemetric/aggregations/metrics/AggregateMetricBackedAvgAggregatorTests.java
@@ -135,9 +135,7 @@ public class AggregateMetricBackedAvgAggregatorTests extends AggregatorTestCase 
         throws IOException {
         MappedFieldType fieldType = createDefaultFieldType(FIELD_NAME);
         AggregationBuilder aggregationBuilder = createAggBuilderForTypeTest(fieldType, FIELD_NAME);
-        testCase(
-            new AggTestConfig<InternalAvg>(aggregationBuilder, buildIndex, verify, new MappedFieldType[] { fieldType }).withQuery(query)
-        );
+        testCase(new AggTestConfig<>(aggregationBuilder, buildIndex, verify, fieldType).withQuery(query));
     }
 
     @Override

--- a/x-pack/plugin/mapper-aggregate-metric/src/test/java/org/elasticsearch/xpack/aggregatemetric/aggregations/metrics/AggregateMetricBackedMaxAggregatorTests.java
+++ b/x-pack/plugin/mapper-aggregate-metric/src/test/java/org/elasticsearch/xpack/aggregatemetric/aggregations/metrics/AggregateMetricBackedMaxAggregatorTests.java
@@ -135,7 +135,7 @@ public class AggregateMetricBackedMaxAggregatorTests extends AggregatorTestCase 
         throws IOException {
         MappedFieldType fieldType = createDefaultFieldType(FIELD_NAME);
         AggregationBuilder aggregationBuilder = createAggBuilderForTypeTest(fieldType, FIELD_NAME);
-        testCase(new AggTestConfig<Max>(aggregationBuilder, buildIndex, verify, new MappedFieldType[] { fieldType }).withQuery(query));
+        testCase(new AggTestConfig<>(aggregationBuilder, buildIndex, verify, fieldType).withQuery(query));
     }
 
     @Override

--- a/x-pack/plugin/mapper-aggregate-metric/src/test/java/org/elasticsearch/xpack/aggregatemetric/aggregations/metrics/AggregateMetricBackedMaxAggregatorTests.java
+++ b/x-pack/plugin/mapper-aggregate-metric/src/test/java/org/elasticsearch/xpack/aggregatemetric/aggregations/metrics/AggregateMetricBackedMaxAggregatorTests.java
@@ -135,7 +135,7 @@ public class AggregateMetricBackedMaxAggregatorTests extends AggregatorTestCase 
         throws IOException {
         MappedFieldType fieldType = createDefaultFieldType(FIELD_NAME);
         AggregationBuilder aggregationBuilder = createAggBuilderForTypeTest(fieldType, FIELD_NAME);
-        testCase(aggregationBuilder, query, buildIndex, verify, fieldType);
+        testCase(new AggTestConfig<Max>(aggregationBuilder, buildIndex, verify, new MappedFieldType[] { fieldType }).withQuery(query));
     }
 
     @Override

--- a/x-pack/plugin/mapper-aggregate-metric/src/test/java/org/elasticsearch/xpack/aggregatemetric/aggregations/metrics/AggregateMetricBackedMinAggregatorTests.java
+++ b/x-pack/plugin/mapper-aggregate-metric/src/test/java/org/elasticsearch/xpack/aggregatemetric/aggregations/metrics/AggregateMetricBackedMinAggregatorTests.java
@@ -135,7 +135,7 @@ public class AggregateMetricBackedMinAggregatorTests extends AggregatorTestCase 
         throws IOException {
         MappedFieldType fieldType = createDefaultFieldType(FIELD_NAME);
         AggregationBuilder aggregationBuilder = createAggBuilderForTypeTest(fieldType, FIELD_NAME);
-        testCase(new AggTestConfig<Min>(aggregationBuilder, buildIndex, verify, new MappedFieldType[] { fieldType }).withQuery(query));
+        testCase(new AggTestConfig<>(aggregationBuilder, buildIndex, verify, fieldType).withQuery(query));
     }
 
     @Override

--- a/x-pack/plugin/mapper-aggregate-metric/src/test/java/org/elasticsearch/xpack/aggregatemetric/aggregations/metrics/AggregateMetricBackedMinAggregatorTests.java
+++ b/x-pack/plugin/mapper-aggregate-metric/src/test/java/org/elasticsearch/xpack/aggregatemetric/aggregations/metrics/AggregateMetricBackedMinAggregatorTests.java
@@ -135,7 +135,7 @@ public class AggregateMetricBackedMinAggregatorTests extends AggregatorTestCase 
         throws IOException {
         MappedFieldType fieldType = createDefaultFieldType(FIELD_NAME);
         AggregationBuilder aggregationBuilder = createAggBuilderForTypeTest(fieldType, FIELD_NAME);
-        testCase(aggregationBuilder, query, buildIndex, verify, fieldType);
+        testCase(new AggTestConfig<Min>(aggregationBuilder, buildIndex, verify, new MappedFieldType[] { fieldType }).withQuery(query));
     }
 
     @Override

--- a/x-pack/plugin/mapper-aggregate-metric/src/test/java/org/elasticsearch/xpack/aggregatemetric/aggregations/metrics/AggregateMetricBackedSumAggregatorTests.java
+++ b/x-pack/plugin/mapper-aggregate-metric/src/test/java/org/elasticsearch/xpack/aggregatemetric/aggregations/metrics/AggregateMetricBackedSumAggregatorTests.java
@@ -135,7 +135,7 @@ public class AggregateMetricBackedSumAggregatorTests extends AggregatorTestCase 
         throws IOException {
         MappedFieldType fieldType = createDefaultFieldType(FIELD_NAME);
         AggregationBuilder aggregationBuilder = createAggBuilderForTypeTest(fieldType, FIELD_NAME);
-        testCase(new AggTestConfig<Sum>(aggregationBuilder, buildIndex, verify, new MappedFieldType[] { fieldType }).withQuery(query));
+        testCase(new AggTestConfig<>(aggregationBuilder, buildIndex, verify, fieldType).withQuery(query));
     }
 
     @Override

--- a/x-pack/plugin/mapper-aggregate-metric/src/test/java/org/elasticsearch/xpack/aggregatemetric/aggregations/metrics/AggregateMetricBackedSumAggregatorTests.java
+++ b/x-pack/plugin/mapper-aggregate-metric/src/test/java/org/elasticsearch/xpack/aggregatemetric/aggregations/metrics/AggregateMetricBackedSumAggregatorTests.java
@@ -135,7 +135,7 @@ public class AggregateMetricBackedSumAggregatorTests extends AggregatorTestCase 
         throws IOException {
         MappedFieldType fieldType = createDefaultFieldType(FIELD_NAME);
         AggregationBuilder aggregationBuilder = createAggBuilderForTypeTest(fieldType, FIELD_NAME);
-        testCase(aggregationBuilder, query, buildIndex, verify, fieldType);
+        testCase(new AggTestConfig<Sum>(aggregationBuilder, buildIndex, verify, new MappedFieldType[] { fieldType }).withQuery(query));
     }
 
     @Override

--- a/x-pack/plugin/mapper-aggregate-metric/src/test/java/org/elasticsearch/xpack/aggregatemetric/aggregations/metrics/AggregateMetricBackedValueCountAggregatorTests.java
+++ b/x-pack/plugin/mapper-aggregate-metric/src/test/java/org/elasticsearch/xpack/aggregatemetric/aggregations/metrics/AggregateMetricBackedValueCountAggregatorTests.java
@@ -134,11 +134,7 @@ public class AggregateMetricBackedValueCountAggregatorTests extends AggregatorTe
         throws IOException {
         MappedFieldType fieldType = createDefaultFieldType(FIELD_NAME);
         AggregationBuilder aggregationBuilder = createAggBuilderForTypeTest(fieldType, FIELD_NAME);
-        testCase(
-            new AggTestConfig<InternalValueCount>(aggregationBuilder, buildIndex, verify, new MappedFieldType[] { fieldType }).withQuery(
-                query
-            )
-        );
+        testCase(new AggTestConfig<>(aggregationBuilder, buildIndex, verify, fieldType).withQuery(query));
     }
 
     @Override

--- a/x-pack/plugin/mapper-aggregate-metric/src/test/java/org/elasticsearch/xpack/aggregatemetric/aggregations/metrics/AggregateMetricBackedValueCountAggregatorTests.java
+++ b/x-pack/plugin/mapper-aggregate-metric/src/test/java/org/elasticsearch/xpack/aggregatemetric/aggregations/metrics/AggregateMetricBackedValueCountAggregatorTests.java
@@ -134,7 +134,11 @@ public class AggregateMetricBackedValueCountAggregatorTests extends AggregatorTe
         throws IOException {
         MappedFieldType fieldType = createDefaultFieldType(FIELD_NAME);
         AggregationBuilder aggregationBuilder = createAggBuilderForTypeTest(fieldType, FIELD_NAME);
-        testCase(aggregationBuilder, query, buildIndex, verify, fieldType);
+        testCase(
+            new AggTestConfig<InternalValueCount>(aggregationBuilder, buildIndex, verify, new MappedFieldType[] { fieldType }).withQuery(
+                query
+            )
+        );
     }
 
     @Override

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/aggs/categorization/CategorizeTextAggregatorTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/aggs/categorization/CategorizeTextAggregatorTests.java
@@ -16,6 +16,7 @@ import org.elasticsearch.analysis.common.CommonAnalysisPlugin;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.env.Environment;
 import org.elasticsearch.env.TestEnvironment;
+import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.mapper.TextFieldMapper;
 import org.elasticsearch.indices.analysis.AnalysisModule;
 import org.elasticsearch.plugins.SearchPlugin;
@@ -62,21 +63,21 @@ public class CategorizeTextAggregatorTests extends AggregatorTestCase {
 
     public void testCategorizationWithoutSubAggs() throws Exception {
         testCase(
-            new CategorizeTextAggregationBuilder("my_agg", TEXT_FIELD_NAME),
-            new MatchAllDocsQuery(),
-            CategorizeTextAggregatorTests::writeTestDocs,
-            (InternalCategorizationAggregation result) -> {
-                assertThat(result.getBuckets(), hasSize(2));
-                assertThat(result.getBuckets().get(0).getDocCount(), equalTo(6L));
-                assertThat(result.getBuckets().get(0).getKeyAsString(), equalTo("Node started"));
-                assertThat(result.getBuckets().get(1).getDocCount(), equalTo(2L));
-                assertThat(
-                    result.getBuckets().get(1).getKeyAsString(),
-                    equalTo("Failed to shutdown error org.aaaa.bbbb.Cccc line caused by foo exception")
-                );
-            },
-            new TextFieldMapper.TextFieldType(TEXT_FIELD_NAME),
-            longField(NUMERIC_FIELD_NAME)
+            new AggTestConfig<InternalCategorizationAggregation>(
+                new CategorizeTextAggregationBuilder("my_agg", TEXT_FIELD_NAME),
+                CategorizeTextAggregatorTests::writeTestDocs,
+                (InternalCategorizationAggregation result) -> {
+                    assertThat(result.getBuckets(), hasSize(2));
+                    assertThat(result.getBuckets().get(0).getDocCount(), equalTo(6L));
+                    assertThat(result.getBuckets().get(0).getKeyAsString(), equalTo("Node started"));
+                    assertThat(result.getBuckets().get(1).getDocCount(), equalTo(2L));
+                    assertThat(
+                        result.getBuckets().get(1).getKeyAsString(),
+                        equalTo("Failed to shutdown error org.aaaa.bbbb.Cccc line caused by foo exception")
+                    );
+                },
+                new MappedFieldType[] { new TextFieldMapper.TextFieldType(TEXT_FIELD_NAME), longField(NUMERIC_FIELD_NAME) }
+            ).withQuery(new MatchAllDocsQuery())
         );
     }
 
@@ -87,28 +88,28 @@ public class CategorizeTextAggregatorTests extends AggregatorTestCase {
             .subAggregation(new AvgAggregationBuilder("avg").field(NUMERIC_FIELD_NAME))
             .subAggregation(new MinAggregationBuilder("min").field(NUMERIC_FIELD_NAME));
         testCase(
-            aggBuilder,
-            new MatchAllDocsQuery(),
-            CategorizeTextAggregatorTests::writeTestDocs,
-            (InternalCategorizationAggregation result) -> {
-                assertThat(result.getBuckets(), hasSize(2));
-                assertThat(result.getBuckets().get(0).getDocCount(), equalTo(6L));
-                assertThat(result.getBuckets().get(0).getKeyAsString(), equalTo("Node started"));
-                assertThat(((Max) result.getBuckets().get(0).getAggregations().get("max")).value(), equalTo(5.0));
-                assertThat(((Min) result.getBuckets().get(0).getAggregations().get("min")).value(), equalTo(0.0));
-                assertThat(((Avg) result.getBuckets().get(0).getAggregations().get("avg")).getValue(), equalTo(2.5));
+            new AggTestConfig<InternalCategorizationAggregation>(
+                aggBuilder,
+                CategorizeTextAggregatorTests::writeTestDocs,
+                (InternalCategorizationAggregation result) -> {
+                    assertThat(result.getBuckets(), hasSize(2));
+                    assertThat(result.getBuckets().get(0).getDocCount(), equalTo(6L));
+                    assertThat(result.getBuckets().get(0).getKeyAsString(), equalTo("Node started"));
+                    assertThat(((Max) result.getBuckets().get(0).getAggregations().get("max")).value(), equalTo(5.0));
+                    assertThat(((Min) result.getBuckets().get(0).getAggregations().get("min")).value(), equalTo(0.0));
+                    assertThat(((Avg) result.getBuckets().get(0).getAggregations().get("avg")).getValue(), equalTo(2.5));
 
-                assertThat(result.getBuckets().get(1).getDocCount(), equalTo(2L));
-                assertThat(
-                    result.getBuckets().get(1).getKeyAsString(),
-                    equalTo("Failed to shutdown error org.aaaa.bbbb.Cccc line caused by foo exception")
-                );
-                assertThat(((Max) result.getBuckets().get(1).getAggregations().get("max")).value(), equalTo(4.0));
-                assertThat(((Min) result.getBuckets().get(1).getAggregations().get("min")).value(), equalTo(0.0));
-                assertThat(((Avg) result.getBuckets().get(1).getAggregations().get("avg")).getValue(), equalTo(2.0));
-            },
-            new TextFieldMapper.TextFieldType(TEXT_FIELD_NAME),
-            longField(NUMERIC_FIELD_NAME)
+                    assertThat(result.getBuckets().get(1).getDocCount(), equalTo(2L));
+                    assertThat(
+                        result.getBuckets().get(1).getKeyAsString(),
+                        equalTo("Failed to shutdown error org.aaaa.bbbb.Cccc line caused by foo exception")
+                    );
+                    assertThat(((Max) result.getBuckets().get(1).getAggregations().get("max")).value(), equalTo(4.0));
+                    assertThat(((Min) result.getBuckets().get(1).getAggregations().get("min")).value(), equalTo(0.0));
+                    assertThat(((Avg) result.getBuckets().get(1).getAggregations().get("avg")).getValue(), equalTo(2.0));
+                },
+                new MappedFieldType[] { new TextFieldMapper.TextFieldType(TEXT_FIELD_NAME), longField(NUMERIC_FIELD_NAME) }
+            ).withQuery(new MatchAllDocsQuery())
         );
     }
 
@@ -121,43 +122,43 @@ public class CategorizeTextAggregatorTests extends AggregatorTestCase {
                 .subAggregation(new MinAggregationBuilder("min").field(NUMERIC_FIELD_NAME))
         );
         testCase(
-            aggBuilder,
-            new MatchAllDocsQuery(),
-            CategorizeTextAggregatorTests::writeTestDocs,
-            (InternalCategorizationAggregation result) -> {
-                assertThat(result.getBuckets(), hasSize(2));
-                assertThat(result.getBuckets().get(0).getDocCount(), equalTo(6L));
-                assertThat(result.getBuckets().get(0).getKeyAsString(), equalTo("Node started"));
-                Histogram histo = result.getBuckets().get(0).getAggregations().get("histo");
-                assertThat(histo.getBuckets(), hasSize(3));
-                for (Histogram.Bucket bucket : histo.getBuckets()) {
-                    assertThat(bucket.getDocCount(), equalTo(2L));
-                }
-                assertThat(((Max) histo.getBuckets().get(0).getAggregations().get("max")).value(), equalTo(1.0));
-                assertThat(((Min) histo.getBuckets().get(0).getAggregations().get("min")).value(), equalTo(0.0));
-                assertThat(((Avg) histo.getBuckets().get(0).getAggregations().get("avg")).getValue(), equalTo(0.5));
-                assertThat(((Max) histo.getBuckets().get(1).getAggregations().get("max")).value(), equalTo(3.0));
-                assertThat(((Min) histo.getBuckets().get(1).getAggregations().get("min")).value(), equalTo(2.0));
-                assertThat(((Avg) histo.getBuckets().get(1).getAggregations().get("avg")).getValue(), equalTo(2.5));
-                assertThat(((Max) histo.getBuckets().get(2).getAggregations().get("max")).value(), equalTo(5.0));
-                assertThat(((Min) histo.getBuckets().get(2).getAggregations().get("min")).value(), equalTo(4.0));
-                assertThat(((Avg) histo.getBuckets().get(2).getAggregations().get("avg")).getValue(), equalTo(4.5));
+            new AggTestConfig<InternalCategorizationAggregation>(
+                aggBuilder,
+                CategorizeTextAggregatorTests::writeTestDocs,
+                (InternalCategorizationAggregation result) -> {
+                    assertThat(result.getBuckets(), hasSize(2));
+                    assertThat(result.getBuckets().get(0).getDocCount(), equalTo(6L));
+                    assertThat(result.getBuckets().get(0).getKeyAsString(), equalTo("Node started"));
+                    Histogram histo = result.getBuckets().get(0).getAggregations().get("histo");
+                    assertThat(histo.getBuckets(), hasSize(3));
+                    for (Histogram.Bucket bucket : histo.getBuckets()) {
+                        assertThat(bucket.getDocCount(), equalTo(2L));
+                    }
+                    assertThat(((Max) histo.getBuckets().get(0).getAggregations().get("max")).value(), equalTo(1.0));
+                    assertThat(((Min) histo.getBuckets().get(0).getAggregations().get("min")).value(), equalTo(0.0));
+                    assertThat(((Avg) histo.getBuckets().get(0).getAggregations().get("avg")).getValue(), equalTo(0.5));
+                    assertThat(((Max) histo.getBuckets().get(1).getAggregations().get("max")).value(), equalTo(3.0));
+                    assertThat(((Min) histo.getBuckets().get(1).getAggregations().get("min")).value(), equalTo(2.0));
+                    assertThat(((Avg) histo.getBuckets().get(1).getAggregations().get("avg")).getValue(), equalTo(2.5));
+                    assertThat(((Max) histo.getBuckets().get(2).getAggregations().get("max")).value(), equalTo(5.0));
+                    assertThat(((Min) histo.getBuckets().get(2).getAggregations().get("min")).value(), equalTo(4.0));
+                    assertThat(((Avg) histo.getBuckets().get(2).getAggregations().get("avg")).getValue(), equalTo(4.5));
 
-                assertThat(result.getBuckets().get(1).getDocCount(), equalTo(2L));
-                assertThat(
-                    result.getBuckets().get(1).getKeyAsString(),
-                    equalTo("Failed to shutdown error org.aaaa.bbbb.Cccc line caused by foo exception")
-                );
-                histo = result.getBuckets().get(1).getAggregations().get("histo");
-                assertThat(histo.getBuckets(), hasSize(3));
-                assertThat(histo.getBuckets().get(0).getDocCount(), equalTo(1L));
-                assertThat(histo.getBuckets().get(1).getDocCount(), equalTo(0L));
-                assertThat(histo.getBuckets().get(2).getDocCount(), equalTo(1L));
-                assertThat(((Avg) histo.getBuckets().get(0).getAggregations().get("avg")).getValue(), equalTo(0.0));
-                assertThat(((Avg) histo.getBuckets().get(2).getAggregations().get("avg")).getValue(), equalTo(4.0));
-            },
-            new TextFieldMapper.TextFieldType(TEXT_FIELD_NAME),
-            longField(NUMERIC_FIELD_NAME)
+                    assertThat(result.getBuckets().get(1).getDocCount(), equalTo(2L));
+                    assertThat(
+                        result.getBuckets().get(1).getKeyAsString(),
+                        equalTo("Failed to shutdown error org.aaaa.bbbb.Cccc line caused by foo exception")
+                    );
+                    histo = result.getBuckets().get(1).getAggregations().get("histo");
+                    assertThat(histo.getBuckets(), hasSize(3));
+                    assertThat(histo.getBuckets().get(0).getDocCount(), equalTo(1L));
+                    assertThat(histo.getBuckets().get(1).getDocCount(), equalTo(0L));
+                    assertThat(histo.getBuckets().get(2).getDocCount(), equalTo(1L));
+                    assertThat(((Avg) histo.getBuckets().get(0).getAggregations().get("avg")).getValue(), equalTo(0.0));
+                    assertThat(((Avg) histo.getBuckets().get(2).getAggregations().get("avg")).getValue(), equalTo(4.0));
+                },
+                new MappedFieldType[] { new TextFieldMapper.TextFieldType(TEXT_FIELD_NAME), longField(NUMERIC_FIELD_NAME) }
+            ).withQuery(new MatchAllDocsQuery())
         );
     }
 
@@ -171,57 +172,64 @@ public class CategorizeTextAggregatorTests extends AggregatorTestCase {
                     .subAggregation(new AvgAggregationBuilder("avg").field(NUMERIC_FIELD_NAME))
                     .subAggregation(new MinAggregationBuilder("min").field(NUMERIC_FIELD_NAME))
             );
-        testCase(aggBuilder, new MatchAllDocsQuery(), CategorizeTextAggregatorTests::writeTestDocs, (InternalHistogram result) -> {
-            assertThat(result.getBuckets(), hasSize(3));
+        // First histo bucket
+        // Second histo bucket
+        // Third histo bucket
+        testCase(
+            new AggTestConfig<InternalHistogram>(aggBuilder, CategorizeTextAggregatorTests::writeTestDocs, (InternalHistogram result) -> {
+                assertThat(result.getBuckets(), hasSize(3));
 
-            // First histo bucket
-            assertThat(result.getBuckets().get(0).getDocCount(), equalTo(3L));
-            InternalCategorizationAggregation categorizationAggregation = result.getBuckets().get(0).getAggregations().get("my_agg");
-            assertThat(categorizationAggregation.getBuckets(), hasSize(2));
-            assertThat(categorizationAggregation.getBuckets().get(0).getDocCount(), equalTo(2L));
-            assertThat(categorizationAggregation.getBuckets().get(0).getKeyAsString(), equalTo("Node started"));
-            assertThat(((Max) categorizationAggregation.getBuckets().get(0).getAggregations().get("max")).value(), equalTo(1.0));
-            assertThat(((Min) categorizationAggregation.getBuckets().get(0).getAggregations().get("min")).value(), equalTo(0.0));
-            assertThat(((Avg) categorizationAggregation.getBuckets().get(0).getAggregations().get("avg")).getValue(), equalTo(0.5));
+                // First histo bucket
+                assertThat(result.getBuckets().get(0).getDocCount(), equalTo(3L));
+                InternalCategorizationAggregation categorizationAggregation = result.getBuckets().get(0).getAggregations().get("my_agg");
+                assertThat(categorizationAggregation.getBuckets(), hasSize(2));
+                assertThat(categorizationAggregation.getBuckets().get(0).getDocCount(), equalTo(2L));
+                assertThat(categorizationAggregation.getBuckets().get(0).getKeyAsString(), equalTo("Node started"));
+                assertThat(((Max) categorizationAggregation.getBuckets().get(0).getAggregations().get("max")).value(), equalTo(1.0));
+                assertThat(((Min) categorizationAggregation.getBuckets().get(0).getAggregations().get("min")).value(), equalTo(0.0));
+                assertThat(((Avg) categorizationAggregation.getBuckets().get(0).getAggregations().get("avg")).getValue(), equalTo(0.5));
 
-            assertThat(categorizationAggregation.getBuckets().get(1).getDocCount(), equalTo(1L));
-            assertThat(
-                categorizationAggregation.getBuckets().get(1).getKeyAsString(),
-                equalTo("Failed to shutdown error org.aaaa.bbbb.Cccc line caused by foo exception")
-            );
-            assertThat(((Max) categorizationAggregation.getBuckets().get(1).getAggregations().get("max")).value(), equalTo(0.0));
-            assertThat(((Min) categorizationAggregation.getBuckets().get(1).getAggregations().get("min")).value(), equalTo(0.0));
-            assertThat(((Avg) categorizationAggregation.getBuckets().get(1).getAggregations().get("avg")).getValue(), equalTo(0.0));
+                assertThat(categorizationAggregation.getBuckets().get(1).getDocCount(), equalTo(1L));
+                assertThat(
+                    categorizationAggregation.getBuckets().get(1).getKeyAsString(),
+                    equalTo("Failed to shutdown error org.aaaa.bbbb.Cccc line caused by foo exception")
+                );
+                assertThat(((Max) categorizationAggregation.getBuckets().get(1).getAggregations().get("max")).value(), equalTo(0.0));
+                assertThat(((Min) categorizationAggregation.getBuckets().get(1).getAggregations().get("min")).value(), equalTo(0.0));
+                assertThat(((Avg) categorizationAggregation.getBuckets().get(1).getAggregations().get("avg")).getValue(), equalTo(0.0));
 
-            // Second histo bucket
-            assertThat(result.getBuckets().get(1).getDocCount(), equalTo(2L));
-            categorizationAggregation = result.getBuckets().get(1).getAggregations().get("my_agg");
-            assertThat(categorizationAggregation.getBuckets(), hasSize(1));
-            assertThat(categorizationAggregation.getBuckets().get(0).getDocCount(), equalTo(2L));
-            assertThat(categorizationAggregation.getBuckets().get(0).getKeyAsString(), equalTo("Node started"));
-            assertThat(((Max) categorizationAggregation.getBuckets().get(0).getAggregations().get("max")).value(), equalTo(3.0));
-            assertThat(((Min) categorizationAggregation.getBuckets().get(0).getAggregations().get("min")).value(), equalTo(2.0));
-            assertThat(((Avg) categorizationAggregation.getBuckets().get(0).getAggregations().get("avg")).getValue(), equalTo(2.5));
+                // Second histo bucket
+                assertThat(result.getBuckets().get(1).getDocCount(), equalTo(2L));
+                categorizationAggregation = result.getBuckets().get(1).getAggregations().get("my_agg");
+                assertThat(categorizationAggregation.getBuckets(), hasSize(1));
+                assertThat(categorizationAggregation.getBuckets().get(0).getDocCount(), equalTo(2L));
+                assertThat(categorizationAggregation.getBuckets().get(0).getKeyAsString(), equalTo("Node started"));
+                assertThat(((Max) categorizationAggregation.getBuckets().get(0).getAggregations().get("max")).value(), equalTo(3.0));
+                assertThat(((Min) categorizationAggregation.getBuckets().get(0).getAggregations().get("min")).value(), equalTo(2.0));
+                assertThat(((Avg) categorizationAggregation.getBuckets().get(0).getAggregations().get("avg")).getValue(), equalTo(2.5));
 
-            // Third histo bucket
-            assertThat(result.getBuckets().get(2).getDocCount(), equalTo(3L));
-            categorizationAggregation = result.getBuckets().get(2).getAggregations().get("my_agg");
-            assertThat(categorizationAggregation.getBuckets(), hasSize(2));
-            assertThat(categorizationAggregation.getBuckets().get(0).getDocCount(), equalTo(2L));
-            assertThat(categorizationAggregation.getBuckets().get(0).getKeyAsString(), equalTo("Node started"));
-            assertThat(((Max) categorizationAggregation.getBuckets().get(0).getAggregations().get("max")).value(), equalTo(5.0));
-            assertThat(((Min) categorizationAggregation.getBuckets().get(0).getAggregations().get("min")).value(), equalTo(4.0));
-            assertThat(((Avg) categorizationAggregation.getBuckets().get(0).getAggregations().get("avg")).getValue(), equalTo(4.5));
+                // Third histo bucket
+                assertThat(result.getBuckets().get(2).getDocCount(), equalTo(3L));
+                categorizationAggregation = result.getBuckets().get(2).getAggregations().get("my_agg");
+                assertThat(categorizationAggregation.getBuckets(), hasSize(2));
+                assertThat(categorizationAggregation.getBuckets().get(0).getDocCount(), equalTo(2L));
+                assertThat(categorizationAggregation.getBuckets().get(0).getKeyAsString(), equalTo("Node started"));
+                assertThat(((Max) categorizationAggregation.getBuckets().get(0).getAggregations().get("max")).value(), equalTo(5.0));
+                assertThat(((Min) categorizationAggregation.getBuckets().get(0).getAggregations().get("min")).value(), equalTo(4.0));
+                assertThat(((Avg) categorizationAggregation.getBuckets().get(0).getAggregations().get("avg")).getValue(), equalTo(4.5));
 
-            assertThat(categorizationAggregation.getBuckets().get(1).getDocCount(), equalTo(1L));
-            assertThat(
-                categorizationAggregation.getBuckets().get(1).getKeyAsString(),
-                equalTo("Failed to shutdown error org.aaaa.bbbb.Cccc line caused by foo exception")
-            );
-            assertThat(((Max) categorizationAggregation.getBuckets().get(1).getAggregations().get("max")).value(), equalTo(4.0));
-            assertThat(((Min) categorizationAggregation.getBuckets().get(1).getAggregations().get("min")).value(), equalTo(4.0));
-            assertThat(((Avg) categorizationAggregation.getBuckets().get(1).getAggregations().get("avg")).getValue(), equalTo(4.0));
-        }, new TextFieldMapper.TextFieldType(TEXT_FIELD_NAME), longField(NUMERIC_FIELD_NAME));
+                assertThat(categorizationAggregation.getBuckets().get(1).getDocCount(), equalTo(1L));
+                assertThat(
+                    categorizationAggregation.getBuckets().get(1).getKeyAsString(),
+                    equalTo("Failed to shutdown error org.aaaa.bbbb.Cccc line caused by foo exception")
+                );
+                assertThat(((Max) categorizationAggregation.getBuckets().get(1).getAggregations().get("max")).value(), equalTo(4.0));
+                assertThat(((Min) categorizationAggregation.getBuckets().get(1).getAggregations().get("min")).value(), equalTo(4.0));
+                assertThat(((Avg) categorizationAggregation.getBuckets().get(1).getAggregations().get("avg")).getValue(), equalTo(4.0));
+            }, new MappedFieldType[] { new TextFieldMapper.TextFieldType(TEXT_FIELD_NAME), longField(NUMERIC_FIELD_NAME) }).withQuery(
+                new MatchAllDocsQuery()
+            )
+        );
     }
 
     public void testCategorizationWithSubAggsManyDocs() throws Exception {
@@ -233,43 +241,43 @@ public class CategorizeTextAggregatorTests extends AggregatorTestCase {
                 .subAggregation(new MinAggregationBuilder("min").field(NUMERIC_FIELD_NAME))
         );
         testCase(
-            aggBuilder,
-            new MatchAllDocsQuery(),
-            CategorizeTextAggregatorTests::writeManyTestDocs,
-            (InternalCategorizationAggregation result) -> {
-                assertThat(result.getBuckets(), hasSize(2));
-                assertThat(result.getBuckets().get(0).getDocCount(), equalTo(30000L));
-                assertThat(result.getBuckets().get(0).getKeyAsString(), equalTo("Node started"));
-                Histogram histo = result.getBuckets().get(0).getAggregations().get("histo");
-                assertThat(histo.getBuckets(), hasSize(3));
-                for (Histogram.Bucket bucket : histo.getBuckets()) {
-                    assertThat(bucket.getDocCount(), equalTo(10000L));
-                }
-                assertThat(((Max) histo.getBuckets().get(0).getAggregations().get("max")).value(), equalTo(1.0));
-                assertThat(((Min) histo.getBuckets().get(0).getAggregations().get("min")).value(), equalTo(0.0));
-                assertThat(((Avg) histo.getBuckets().get(0).getAggregations().get("avg")).getValue(), equalTo(0.5));
-                assertThat(((Max) histo.getBuckets().get(1).getAggregations().get("max")).value(), equalTo(3.0));
-                assertThat(((Min) histo.getBuckets().get(1).getAggregations().get("min")).value(), equalTo(2.0));
-                assertThat(((Avg) histo.getBuckets().get(1).getAggregations().get("avg")).getValue(), equalTo(2.5));
-                assertThat(((Max) histo.getBuckets().get(2).getAggregations().get("max")).value(), equalTo(5.0));
-                assertThat(((Min) histo.getBuckets().get(2).getAggregations().get("min")).value(), equalTo(4.0));
-                assertThat(((Avg) histo.getBuckets().get(2).getAggregations().get("avg")).getValue(), equalTo(4.5));
+            new AggTestConfig<InternalCategorizationAggregation>(
+                aggBuilder,
+                CategorizeTextAggregatorTests::writeManyTestDocs,
+                (InternalCategorizationAggregation result) -> {
+                    assertThat(result.getBuckets(), hasSize(2));
+                    assertThat(result.getBuckets().get(0).getDocCount(), equalTo(30000L));
+                    assertThat(result.getBuckets().get(0).getKeyAsString(), equalTo("Node started"));
+                    Histogram histo = result.getBuckets().get(0).getAggregations().get("histo");
+                    assertThat(histo.getBuckets(), hasSize(3));
+                    for (Histogram.Bucket bucket : histo.getBuckets()) {
+                        assertThat(bucket.getDocCount(), equalTo(10000L));
+                    }
+                    assertThat(((Max) histo.getBuckets().get(0).getAggregations().get("max")).value(), equalTo(1.0));
+                    assertThat(((Min) histo.getBuckets().get(0).getAggregations().get("min")).value(), equalTo(0.0));
+                    assertThat(((Avg) histo.getBuckets().get(0).getAggregations().get("avg")).getValue(), equalTo(0.5));
+                    assertThat(((Max) histo.getBuckets().get(1).getAggregations().get("max")).value(), equalTo(3.0));
+                    assertThat(((Min) histo.getBuckets().get(1).getAggregations().get("min")).value(), equalTo(2.0));
+                    assertThat(((Avg) histo.getBuckets().get(1).getAggregations().get("avg")).getValue(), equalTo(2.5));
+                    assertThat(((Max) histo.getBuckets().get(2).getAggregations().get("max")).value(), equalTo(5.0));
+                    assertThat(((Min) histo.getBuckets().get(2).getAggregations().get("min")).value(), equalTo(4.0));
+                    assertThat(((Avg) histo.getBuckets().get(2).getAggregations().get("avg")).getValue(), equalTo(4.5));
 
-                assertThat(result.getBuckets().get(1).getDocCount(), equalTo(10000L));
-                assertThat(
-                    result.getBuckets().get(1).getKeyAsString(),
-                    equalTo("Failed to shutdown error org.aaaa.bbbb.Cccc line caused by foo exception")
-                );
-                histo = result.getBuckets().get(1).getAggregations().get("histo");
-                assertThat(histo.getBuckets(), hasSize(3));
-                assertThat(histo.getBuckets().get(0).getDocCount(), equalTo(5000L));
-                assertThat(histo.getBuckets().get(1).getDocCount(), equalTo(0L));
-                assertThat(histo.getBuckets().get(2).getDocCount(), equalTo(5000L));
-                assertThat(((Avg) histo.getBuckets().get(0).getAggregations().get("avg")).getValue(), equalTo(0.0));
-                assertThat(((Avg) histo.getBuckets().get(2).getAggregations().get("avg")).getValue(), equalTo(4.0));
-            },
-            new TextFieldMapper.TextFieldType(TEXT_FIELD_NAME),
-            longField(NUMERIC_FIELD_NAME)
+                    assertThat(result.getBuckets().get(1).getDocCount(), equalTo(10000L));
+                    assertThat(
+                        result.getBuckets().get(1).getKeyAsString(),
+                        equalTo("Failed to shutdown error org.aaaa.bbbb.Cccc line caused by foo exception")
+                    );
+                    histo = result.getBuckets().get(1).getAggregations().get("histo");
+                    assertThat(histo.getBuckets(), hasSize(3));
+                    assertThat(histo.getBuckets().get(0).getDocCount(), equalTo(5000L));
+                    assertThat(histo.getBuckets().get(1).getDocCount(), equalTo(0L));
+                    assertThat(histo.getBuckets().get(2).getDocCount(), equalTo(5000L));
+                    assertThat(((Avg) histo.getBuckets().get(0).getAggregations().get("avg")).getValue(), equalTo(0.0));
+                    assertThat(((Avg) histo.getBuckets().get(2).getAggregations().get("avg")).getValue(), equalTo(4.0));
+                },
+                new MappedFieldType[] { new TextFieldMapper.TextFieldType(TEXT_FIELD_NAME), longField(NUMERIC_FIELD_NAME) }
+            ).withQuery(new MatchAllDocsQuery())
         );
     }
 

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/aggs/changepoint/ChangePointAggregatorTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/aggs/changepoint/ChangePointAggregatorTests.java
@@ -16,6 +16,7 @@ import org.apache.lucene.tests.index.RandomIndexWriter;
 import org.apache.lucene.util.NumericUtils;
 import org.elasticsearch.common.Randomness;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.query.MatchAllQueryBuilder;
 import org.elasticsearch.plugins.SearchPlugin;
 import org.elasticsearch.search.aggregations.AggregationBuilders;
@@ -208,10 +209,10 @@ public class ChangePointAggregatorTests extends AggregatorTestCase {
                     .subAggregation(AggregationBuilders.max("max").field(NUMERIC_FIELD_NAME))
             )
             .subAggregation(new ChangePointAggregationBuilder("changes", "time>max"));
-        testCase(dummy, new MatchAllDocsQuery(), w -> writeTestDocs(w, bucketValues), (InternalFilter result) -> {
+        testCase(new AggTestConfig<InternalFilter>(dummy, w -> writeTestDocs(w, bucketValues), (InternalFilter result) -> {
             InternalChangePointAggregation agg = result.getAggregations().get("changes");
             changeTypeAssertions.accept(agg.getChangeType());
-        }, longField(TIME_FIELD_NAME), doubleField(NUMERIC_FIELD_NAME));
+        }, new MappedFieldType[] { longField(TIME_FIELD_NAME), doubleField(NUMERIC_FIELD_NAME) }).withQuery(new MatchAllDocsQuery()));
     }
 
     private static void writeTestDocs(RandomIndexWriter w, double[] bucketValues) throws IOException {

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/aggs/changepoint/ChangePointAggregatorTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/aggs/changepoint/ChangePointAggregatorTests.java
@@ -11,12 +11,10 @@ import org.apache.commons.math3.distribution.NormalDistribution;
 import org.apache.commons.math3.random.RandomGeneratorFactory;
 import org.apache.lucene.document.NumericDocValuesField;
 import org.apache.lucene.document.SortedNumericDocValuesField;
-import org.apache.lucene.search.MatchAllDocsQuery;
 import org.apache.lucene.tests.index.RandomIndexWriter;
 import org.apache.lucene.util.NumericUtils;
 import org.elasticsearch.common.Randomness;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.query.MatchAllQueryBuilder;
 import org.elasticsearch.plugins.SearchPlugin;
 import org.elasticsearch.search.aggregations.AggregationBuilders;
@@ -209,10 +207,10 @@ public class ChangePointAggregatorTests extends AggregatorTestCase {
                     .subAggregation(AggregationBuilders.max("max").field(NUMERIC_FIELD_NAME))
             )
             .subAggregation(new ChangePointAggregationBuilder("changes", "time>max"));
-        testCase(new AggTestConfig<InternalFilter>(dummy, w -> writeTestDocs(w, bucketValues), (InternalFilter result) -> {
+        testCase(new AggTestConfig<InternalFilter>(dummy, w -> writeTestDocs(w, bucketValues), result -> {
             InternalChangePointAggregation agg = result.getAggregations().get("changes");
             changeTypeAssertions.accept(agg.getChangeType());
-        }, new MappedFieldType[] { longField(TIME_FIELD_NAME), doubleField(NUMERIC_FIELD_NAME) }).withQuery(new MatchAllDocsQuery()));
+        }, longField(TIME_FIELD_NAME), doubleField(NUMERIC_FIELD_NAME)));
     }
 
     private static void writeTestDocs(RandomIndexWriter w, double[] bucketValues) throws IOException {

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/aggs/frequentitemsets/FrequentItemSetsAggregatorTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/aggs/frequentitemsets/FrequentItemSetsAggregatorTests.java
@@ -201,10 +201,10 @@ public class FrequentItemSetsAggregatorTests extends AggregatorTestCase {
                     new SortedSetDocValuesField(KEYWORD_FIELD1, new BytesRef("item-7"))
                 )
             );
-        }, (InternalItemSetMapReduceAggregation<?, ?, ?, EclatResult> results) -> {
+        }, results -> {
             assertNotNull(results);
             assertResults(expectedResults, results.getMapReduceResult().getFrequentItemSets(), minimumSupport, minimumSetSize, size);
-        }, new MappedFieldType[] { keywordType }).withQuery(query));
+        }, keywordType).withQuery(query));
     }
 
     public void testMixedSingleValues() throws IOException {
@@ -377,10 +377,10 @@ public class FrequentItemSetsAggregatorTests extends AggregatorTestCase {
                     new SortedSetDocValuesField(KEYWORD_FIELD3, new BytesRef("type-2"))
                 )
             );
-        }, (InternalItemSetMapReduceAggregation<?, ?, ?, EclatResult> results) -> {
+        }, results -> {
             assertNotNull(results);
             assertResults(expectedResults, results.getMapReduceResult().getFrequentItemSets(), minimumSupport, minimumSetSize, size);
-        }, new MappedFieldType[] { keywordType1, keywordType2, keywordType3, intType, floatType, ipType }).withQuery(query));
+        }, keywordType1, keywordType2, keywordType3, intType, floatType, ipType).withQuery(query));
 
     }
 
@@ -565,10 +565,10 @@ public class FrequentItemSetsAggregatorTests extends AggregatorTestCase {
                     new SortedNumericDocValuesField(DATE_FIELD, dateFieldType(DATE_FIELD).parse("2022-06-02"))
                 )
             );
-        }, (InternalItemSetMapReduceAggregation<?, ?, ?, EclatResult> results) -> {
+        }, results -> {
             assertNotNull(results);
             assertResults(expectedResults, results.getMapReduceResult().getFrequentItemSets(), minimumSupport, minimumSetSize, size);
-        }, new MappedFieldType[] { keywordType1, keywordType2, keywordType3, dateType, ipType }).withQuery(query));
+        }, keywordType1, keywordType2, keywordType3, dateType, ipType).withQuery(query));
 
     }
 

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/aggs/frequentitemsets/FrequentItemSetsAggregatorTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/aggs/frequentitemsets/FrequentItemSetsAggregatorTests.java
@@ -121,7 +121,7 @@ public class FrequentItemSetsAggregatorTests extends AggregatorTestCase {
             size
         );
 
-        testCase(builder, query, iw -> {
+        testCase(new AggTestConfig<InternalItemSetMapReduceAggregation<?, ?, ?, EclatResult>>(builder, iw -> {
             iw.addDocument(
                 List.of(
                     new SortedSetDocValuesField(KEYWORD_FIELD1, new BytesRef("item-1")),
@@ -204,7 +204,7 @@ public class FrequentItemSetsAggregatorTests extends AggregatorTestCase {
         }, (InternalItemSetMapReduceAggregation<?, ?, ?, EclatResult> results) -> {
             assertNotNull(results);
             assertResults(expectedResults, results.getMapReduceResult().getFrequentItemSets(), minimumSupport, minimumSetSize, size);
-        }, keywordType);
+        }, new MappedFieldType[] { keywordType }).withQuery(query));
     }
 
     public void testMixedSingleValues() throws IOException {
@@ -276,7 +276,7 @@ public class FrequentItemSetsAggregatorTests extends AggregatorTestCase {
             size
         );
 
-        testCase(builder, query, iw -> {
+        testCase(new AggTestConfig<InternalItemSetMapReduceAggregation<?, ?, ?, EclatResult>>(builder, iw -> {
             iw.addDocument(
                 List.of(
                     new SortedSetDocValuesField(KEYWORD_FIELD1, new BytesRef("host-1")),
@@ -380,7 +380,7 @@ public class FrequentItemSetsAggregatorTests extends AggregatorTestCase {
         }, (InternalItemSetMapReduceAggregation<?, ?, ?, EclatResult> results) -> {
             assertNotNull(results);
             assertResults(expectedResults, results.getMapReduceResult().getFrequentItemSets(), minimumSupport, minimumSetSize, size);
-        }, keywordType1, keywordType2, keywordType3, intType, floatType, ipType);
+        }, new MappedFieldType[] { keywordType1, keywordType2, keywordType3, intType, floatType, ipType }).withQuery(query));
 
     }
 
@@ -474,7 +474,7 @@ public class FrequentItemSetsAggregatorTests extends AggregatorTestCase {
             size
         );
 
-        testCase(builder, query, iw -> {
+        testCase(new AggTestConfig<InternalItemSetMapReduceAggregation<?, ?, ?, EclatResult>>(builder, iw -> {
             iw.addDocument(
                 List.of(
                     new SortedSetDocValuesField(KEYWORD_FIELD1, new BytesRef("host-1")),
@@ -568,7 +568,7 @@ public class FrequentItemSetsAggregatorTests extends AggregatorTestCase {
         }, (InternalItemSetMapReduceAggregation<?, ?, ?, EclatResult> results) -> {
             assertNotNull(results);
             assertResults(expectedResults, results.getMapReduceResult().getFrequentItemSets(), minimumSupport, minimumSetSize, size);
-        }, keywordType1, keywordType2, keywordType3, dateType, ipType);
+        }, new MappedFieldType[] { keywordType1, keywordType2, keywordType3, dateType, ipType }).withQuery(query));
 
     }
 

--- a/x-pack/plugin/wildcard/src/test/java/org/elasticsearch/xpack/wildcard/mapper/WildcardFieldAggregationTests.java
+++ b/x-pack/plugin/wildcard/src/test/java/org/elasticsearch/xpack/wildcard/mapper/WildcardFieldAggregationTests.java
@@ -13,6 +13,7 @@ import org.apache.lucene.search.MatchAllDocsQuery;
 import org.apache.lucene.tests.index.RandomIndexWriter;
 import org.elasticsearch.Version;
 import org.elasticsearch.index.mapper.LuceneDocument;
+import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.mapper.MapperBuilderContext;
 import org.elasticsearch.search.aggregations.AggregatorTestCase;
 import org.elasticsearch.search.aggregations.BucketOrder;
@@ -75,7 +76,7 @@ public class WildcardFieldAggregationTests extends AggregatorTestCase {
         TermsAggregationBuilder aggregationBuilder = new TermsAggregationBuilder("_name").field(WILDCARD_FIELD_NAME)
             .order(BucketOrder.key(true));
 
-        testCase(aggregationBuilder, new MatchAllDocsQuery(), iw -> {
+        testCase(new AggTestConfig<StringTerms>(aggregationBuilder, iw -> {
             indexStrings(iw, "a");
             indexStrings(iw, "a");
             indexStrings(iw, "b");
@@ -92,7 +93,7 @@ public class WildcardFieldAggregationTests extends AggregatorTestCase {
             assertEquals(3L, result.getBuckets().get(1).getDocCount());
             assertEquals("c", result.getBuckets().get(2).getKeyAsString());
             assertEquals(1L, result.getBuckets().get(2).getDocCount());
-        }, wildcardFieldType);
+        }, new MappedFieldType[] { wildcardFieldType }).withQuery(new MatchAllDocsQuery()));
     }
 
     public void testCompositeTermsAggregation() throws IOException {
@@ -101,7 +102,7 @@ public class WildcardFieldAggregationTests extends AggregatorTestCase {
             List.of(new TermsValuesSourceBuilder("terms_key").field(WILDCARD_FIELD_NAME))
         );
 
-        testCase(aggregationBuilder, new MatchAllDocsQuery(), iw -> {
+        testCase(new AggTestConfig<InternalComposite>(aggregationBuilder, iw -> {
             indexStrings(iw, "a");
             indexStrings(iw, "c");
             indexStrings(iw, "a");
@@ -118,7 +119,7 @@ public class WildcardFieldAggregationTests extends AggregatorTestCase {
             assertEquals(2L, result.getBuckets().get(1).getDocCount());
             assertEquals("{terms_key=d}", result.getBuckets().get(2).getKeyAsString());
             assertEquals(1L, result.getBuckets().get(2).getDocCount());
-        }, wildcardFieldType);
+        }, new MappedFieldType[] { wildcardFieldType }).withQuery(new MatchAllDocsQuery()));
     }
 
     public void testCompositeTermsSearchAfter() throws IOException {
@@ -127,7 +128,7 @@ public class WildcardFieldAggregationTests extends AggregatorTestCase {
         CompositeAggregationBuilder aggregationBuilder = new CompositeAggregationBuilder("name", Collections.singletonList(terms))
             .aggregateAfter(Collections.singletonMap("terms_key", "a"));
 
-        testCase(aggregationBuilder, new MatchAllDocsQuery(), iw -> {
+        testCase(new AggTestConfig<InternalComposite>(aggregationBuilder, iw -> {
             indexStrings(iw, "a");
             indexStrings(iw, "c");
             indexStrings(iw, "a");
@@ -140,6 +141,6 @@ public class WildcardFieldAggregationTests extends AggregatorTestCase {
             assertEquals(2L, result.getBuckets().get(0).getDocCount());
             assertEquals("{terms_key=d}", result.getBuckets().get(1).getKeyAsString());
             assertEquals(1L, result.getBuckets().get(1).getDocCount());
-        }, wildcardFieldType);
+        }, new MappedFieldType[] { wildcardFieldType }).withQuery(new MatchAllDocsQuery()));
     }
 }

--- a/x-pack/plugin/wildcard/src/test/java/org/elasticsearch/xpack/wildcard/mapper/WildcardFieldAggregationTests.java
+++ b/x-pack/plugin/wildcard/src/test/java/org/elasticsearch/xpack/wildcard/mapper/WildcardFieldAggregationTests.java
@@ -9,11 +9,9 @@ package org.elasticsearch.xpack.wildcard.mapper;
 
 import org.apache.lucene.document.Document;
 import org.apache.lucene.index.IndexableField;
-import org.apache.lucene.search.MatchAllDocsQuery;
 import org.apache.lucene.tests.index.RandomIndexWriter;
 import org.elasticsearch.Version;
 import org.elasticsearch.index.mapper.LuceneDocument;
-import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.mapper.MapperBuilderContext;
 import org.elasticsearch.search.aggregations.AggregatorTestCase;
 import org.elasticsearch.search.aggregations.BucketOrder;
@@ -83,7 +81,7 @@ public class WildcardFieldAggregationTests extends AggregatorTestCase {
             indexStrings(iw, "b");
             indexStrings(iw, "b");
             indexStrings(iw, "c");
-        }, (StringTerms result) -> {
+        }, result -> {
             assertTrue(AggregationInspectionHelper.hasValue(result));
 
             assertEquals(3, result.getBuckets().size());
@@ -93,7 +91,7 @@ public class WildcardFieldAggregationTests extends AggregatorTestCase {
             assertEquals(3L, result.getBuckets().get(1).getDocCount());
             assertEquals("c", result.getBuckets().get(2).getKeyAsString());
             assertEquals(1L, result.getBuckets().get(2).getDocCount());
-        }, new MappedFieldType[] { wildcardFieldType }).withQuery(new MatchAllDocsQuery()));
+        }, wildcardFieldType));
     }
 
     public void testCompositeTermsAggregation() throws IOException {
@@ -108,7 +106,7 @@ public class WildcardFieldAggregationTests extends AggregatorTestCase {
             indexStrings(iw, "a");
             indexStrings(iw, "d");
             indexStrings(iw, "c");
-        }, (InternalComposite result) -> {
+        }, result -> {
             assertTrue(AggregationInspectionHelper.hasValue(result));
 
             assertEquals(3, result.getBuckets().size());
@@ -119,7 +117,7 @@ public class WildcardFieldAggregationTests extends AggregatorTestCase {
             assertEquals(2L, result.getBuckets().get(1).getDocCount());
             assertEquals("{terms_key=d}", result.getBuckets().get(2).getKeyAsString());
             assertEquals(1L, result.getBuckets().get(2).getDocCount());
-        }, new MappedFieldType[] { wildcardFieldType }).withQuery(new MatchAllDocsQuery()));
+        }, wildcardFieldType));
     }
 
     public void testCompositeTermsSearchAfter() throws IOException {
@@ -134,13 +132,13 @@ public class WildcardFieldAggregationTests extends AggregatorTestCase {
             indexStrings(iw, "a");
             indexStrings(iw, "d");
             indexStrings(iw, "c");
-        }, (InternalComposite result) -> {
+        }, result -> {
             assertEquals(2, result.getBuckets().size());
             assertEquals("{terms_key=d}", result.afterKey().toString());
             assertEquals("{terms_key=c}", result.getBuckets().get(0).getKeyAsString());
             assertEquals(2L, result.getBuckets().get(0).getDocCount());
             assertEquals("{terms_key=d}", result.getBuckets().get(1).getKeyAsString());
             assertEquals(1L, result.getBuckets().get(1).getDocCount());
-        }, new MappedFieldType[] { wildcardFieldType }).withQuery(new MatchAllDocsQuery()));
+        }, wildcardFieldType));
     }
 }


### PR DESCRIPTION
I apologize for the huge, largely automated, refactoring PR.  This extends the refactoring from #90149 by applying the same parameter object to `AggregatorTestCase#testCase`, and extending it to include that method's parameters, which allows removing some useless wrapper functions.  By being a bit more explicit about type parameters, I was also able to remove some useless casting.  This should make it easier to write tests and extend the testing framework going forward.