### PR TITLE
Use chunked encoding for RestGetSettingsAction

### DIFF
--- a/server/src/main/java/org/elasticsearch/rest/action/admin/indices/RestGetSettingsAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/admin/indices/RestGetSettingsAction.java
@@ -14,7 +14,7 @@ import org.elasticsearch.client.internal.node.NodeClient;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.rest.BaseRestHandler;
 import org.elasticsearch.rest.RestRequest;
-import org.elasticsearch.rest.action.RestToXContentListener;
+import org.elasticsearch.rest.action.RestChunkedToXContentListener;
 
 import java.io.IOException;
 import java.util.List;
@@ -52,6 +52,6 @@ public class RestGetSettingsAction extends BaseRestHandler {
             .names(names);
         getSettingsRequest.local(request.paramAsBoolean("local", getSettingsRequest.local()));
         getSettingsRequest.masterNodeTimeout(request.paramAsTime("master_timeout", getSettingsRequest.masterNodeTimeout()));
-        return channel -> client.admin().indices().getSettings(getSettingsRequest, new RestToXContentListener<>(channel));
+        return channel -> client.admin().indices().getSettings(getSettingsRequest, new RestChunkedToXContentListener<>(channel));
     }
 }

--- a/server/src/test/java/org/elasticsearch/action/admin/indices/settings/get/GetSettingsResponseTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/indices/settings/get/GetSettingsResponseTests.java
@@ -74,4 +74,15 @@ public class GetSettingsResponseTests extends AbstractSerializingTestCase<GetSet
         return f -> f.equals("") || f.contains(".settings") || f.contains(".defaults");
     }
 
+    public void testOneChunkPerIndex() {
+        final var instance = createTestInstance();
+        final var iterator = instance.toXContentChunked();
+        int chunks = 0;
+        while (iterator.hasNext()) {
+            chunks++;
+            iterator.next();
+        }
+        assertEquals(2 + instance.getIndexToSettings().size(), chunks);
+    }
+
 }


### PR DESCRIPTION
This one needs chunked encoding as well, the response easily grows to O(10M) for large deployments with many indices. Especially when settings are numerous or have large values like e.g. settings from the Beats templates.

relates #89838  