### PR TITLE
[8.5] [CI] Fix `DownsampleActionSingleNodeTests#testCannotRollupWhileOtherRollupInProgress` (#90209)

### DIFF
--- a/x-pack/plugin/rollup/src/test/java/org/elasticsearch/xpack/downsample/DownsampleActionSingleNodeTests.java
+++ b/x-pack/plugin/rollup/src/test/java/org/elasticsearch/xpack/downsample/DownsampleActionSingleNodeTests.java
@@ -496,7 +496,6 @@ public class DownsampleActionSingleNodeTests extends ESSingleNodeTestCase {
         assertThat(exception.getMessage(), containsString("no such index [missing-index]"));
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/90197")
     public void testCannotRollupWhileOtherRollupInProgress() throws Exception {
         DownsampleConfig config = new DownsampleConfig(randomInterval());
         SourceSupplier sourceSupplier = () -> XContentFactory.jsonBuilder()
@@ -525,6 +524,13 @@ public class DownsampleActionSingleNodeTests extends ESSingleNodeTestCase {
             }
         };
         client().execute(DownsampleAction.INSTANCE, new DownsampleAction.Request(sourceIndex, rollupIndex, config), rollupListener);
+        assertBusy(() -> {
+            try {
+                assertEquals(client().admin().indices().prepareGetIndex().addIndices(rollupIndex).get().getIndices().length, 1);
+            } catch (IndexNotFoundException e) {
+                fail("rollup index has not been created");
+            }
+        });
         ResourceAlreadyExistsException exception = expectThrows(
             ResourceAlreadyExistsException.class,
             () -> rollup(sourceIndex, rollupIndex, config)


### PR DESCRIPTION
Backports the following commits to 8.5:
 - [CI] Fix `DownsampleActionSingleNodeTests#testCannotRollupWhileOtherRollupInProgress` (#90209)