### PR TITLE
Update error states from inside the main state executor

### DIFF
--- a/docs/changelog/90346.yaml
+++ b/docs/changelog/90346.yaml
@@ -1,0 +1,6 @@
+pr: 90346
+summary: Update error states from inside the main state executor
+area: Infra/Core
+type: bug
+issues:
+ - 90337

--- a/server/src/main/java/org/elasticsearch/reservedstate/service/ReservedClusterStateService.java
+++ b/server/src/main/java/org/elasticsearch/reservedstate/service/ReservedClusterStateService.java
@@ -110,7 +110,7 @@ public class ReservedClusterStateService {
             stateChunk = stateChunkParser.apply(parser, null);
         } catch (Exception e) {
             ErrorState errorState = new ErrorState(namespace, -1L, e, ReservedStateErrorMetadata.ErrorKind.PARSING);
-            saveErrorState(clusterService.state(), errorState);
+            updateErrorState(errorState);
             logger.debug("error processing state change request for [{}] with the following errors [{}]", namespace, errorState);
 
             errorListener.accept(
@@ -145,7 +145,7 @@ public class ReservedClusterStateService {
                 ReservedStateErrorMetadata.ErrorKind.PARSING
             );
 
-            saveErrorState(clusterService.state(), errorState);
+            updateErrorState(errorState);
             logger.debug("error processing state change request for [{}] with the following errors [{}]", namespace, errorState);
 
             errorListener.accept(
@@ -167,7 +167,8 @@ public class ReservedClusterStateService {
         // We trial run all handler validations to ensure that we can process all of the cluster state error free. During
         // the trial run we collect 'consumers' (functions) for any non cluster state transforms that need to run.
         var trialRunResult = trialRun(namespace, state, reservedStateChunk, orderedHandlers);
-        var error = checkAndReportError(namespace, trialRunResult.errors, state, reservedStateVersion);
+        // this is not using the modified trial state above, but that doesn't matter, we're just setting errors here
+        var error = checkAndReportError(namespace, trialRunResult.errors, reservedStateVersion);
 
         if (error != null) {
             errorListener.accept(error);
@@ -192,7 +193,7 @@ public class ReservedClusterStateService {
                         nonStateTransformResults,
                         handlers,
                         orderedHandlers,
-                        (clusterState, errorState) -> saveErrorState(clusterState, errorState),
+                        ReservedClusterStateService.this::updateErrorState,
                         new ActionListener<>() {
                             @Override
                             public void onResponse(ActionResponse.Empty empty) {
@@ -220,7 +221,7 @@ public class ReservedClusterStateService {
             @Override
             public void onFailure(Exception e) {
                 // If we encounter an error while runnin the non-state transforms, we avoid saving any cluster state.
-                errorListener.accept(checkAndReportError(namespace, List.of(e.getMessage()), state, reservedStateVersion));
+                errorListener.accept(checkAndReportError(namespace, List.of(e.getMessage()), reservedStateVersion));
             }
         });
     }
@@ -229,7 +230,6 @@ public class ReservedClusterStateService {
     Exception checkAndReportError(
         String namespace,
         List<String> errors,
-        ClusterState currentState,
         ReservedStateVersion reservedStateVersion
     ) {
         // Any errors should be discovered through validation performed in the transform calls
@@ -243,7 +243,7 @@ public class ReservedClusterStateService {
                 ReservedStateErrorMetadata.ErrorKind.VALIDATION
             );
 
-            saveErrorState(currentState, errorState);
+            updateErrorState(errorState);
 
             return new IllegalStateException("Error processing state change request for " + namespace + ", errors: " + errorState);
         }
@@ -260,21 +260,7 @@ public class ReservedClusterStateService {
     }
 
     // package private for testing
-    void saveErrorState(ClusterState clusterState, ErrorState errorState) {
-        ReservedStateMetadata existingMetadata = clusterState.metadata().reservedStateMetadata().get(errorState.namespace());
-
-        if (isNewError(existingMetadata, errorState.version()) == false) {
-            logger.info(
-                () -> format(
-                    "Not updating error state because version [%s] is less or equal to the last state error version [%s]",
-                    errorState.version(),
-                    existingMetadata.errorMetadata().version()
-                )
-            );
-
-            return;
-        }
-
+    void updateErrorState(ErrorState errorState) {
         submitErrorUpdateTask(errorState);
     }
 

--- a/server/src/main/java/org/elasticsearch/reservedstate/service/ReservedClusterStateService.java
+++ b/server/src/main/java/org/elasticsearch/reservedstate/service/ReservedClusterStateService.java
@@ -227,11 +227,7 @@ public class ReservedClusterStateService {
     }
 
     // package private for testing
-    Exception checkAndReportError(
-        String namespace,
-        List<String> errors,
-        ReservedStateVersion reservedStateVersion
-    ) {
+    Exception checkAndReportError(String namespace, List<String> errors, ReservedStateVersion reservedStateVersion) {
         // Any errors should be discovered through validation performed in the transform calls
         if (errors.isEmpty() == false) {
             logger.debug("Error processing state change request for [{}] with the following errors [{}]", namespace, errors);

--- a/server/src/main/java/org/elasticsearch/reservedstate/service/ReservedStateUpdateTask.java
+++ b/server/src/main/java/org/elasticsearch/reservedstate/service/ReservedStateUpdateTask.java
@@ -138,8 +138,6 @@ public class ReservedStateUpdateTask implements ClusterStateTaskListener {
              * It doesn't matter this reporter needs to re-access the base state,
              * any updates set by this task will just be discarded when the below exception is thrown,
              * and we just need to set the error state once
-             *
-             * TODO - does this need to use a 'force' option on the underlying ReservedErrorStateTask?
              */
             errorReporter.accept(errorState);
 

--- a/server/src/main/java/org/elasticsearch/reservedstate/service/ReservedStateUpdateTask.java
+++ b/server/src/main/java/org/elasticsearch/reservedstate/service/ReservedStateUpdateTask.java
@@ -29,7 +29,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.function.BiConsumer;
+import java.util.function.Consumer;
 
 import static org.elasticsearch.ExceptionsHelper.stackTrace;
 import static org.elasticsearch.core.Strings.format;
@@ -48,7 +48,7 @@ public class ReservedStateUpdateTask implements ClusterStateTaskListener {
     private final ReservedStateChunk stateChunk;
     private final Map<String, ReservedClusterStateHandler<?>> handlers;
     private final Collection<String> orderedHandlers;
-    private final BiConsumer<ClusterState, ErrorState> errorReporter;
+    private final Consumer<ErrorState> errorReporter;
     private final ActionListener<ActionResponse.Empty> listener;
     private final Collection<NonStateTransformResult> nonStateTransformResults;
 
@@ -58,7 +58,7 @@ public class ReservedStateUpdateTask implements ClusterStateTaskListener {
         Collection<NonStateTransformResult> nonStateTransformResults,
         Map<String, ReservedClusterStateHandler<?>> handlers,
         Collection<String> orderedHandlers,
-        BiConsumer<ClusterState, ErrorState> errorReporter,
+        Consumer<ErrorState> errorReporter,
         ActionListener<ActionResponse.Empty> listener
     ) {
         this.namespace = namespace;
@@ -105,7 +105,7 @@ public class ReservedStateUpdateTask implements ClusterStateTaskListener {
             }
         }
 
-        checkAndThrowOnError(errors, currentState, reservedStateVersion);
+        checkAndThrowOnError(errors, reservedStateVersion);
 
         // Once we have set all of the handler state from the cluster state update tasks, we add the reserved keys
         // from the non cluster state transforms.
@@ -122,7 +122,7 @@ public class ReservedStateUpdateTask implements ClusterStateTaskListener {
         return stateBuilder.metadata(metadataBuilder).build();
     }
 
-    private void checkAndThrowOnError(List<String> errors, ClusterState currentState, ReservedStateVersion reservedStateVersion) {
+    private void checkAndThrowOnError(List<String> errors, ReservedStateVersion reservedStateVersion) {
         // Any errors should be discovered through validation performed in the transform calls
         if (errors.isEmpty() == false) {
             logger.debug("Error processing state change request for [{}] with the following errors [{}]", namespace, errors);
@@ -134,7 +134,14 @@ public class ReservedStateUpdateTask implements ClusterStateTaskListener {
                 ReservedStateErrorMetadata.ErrorKind.VALIDATION
             );
 
-            errorReporter.accept(currentState, errorState);
+            /*
+             * It doesn't matter this reporter needs to re-access the base state,
+             * any updates set by this task will just be discarded when the below exception is thrown,
+             * and we just need to set the error state once
+             *
+             * TODO - does this need to use a 'force' option on the underlying ReservedErrorStateTask?
+             */
+            errorReporter.accept(errorState);
 
             throw new IllegalStateException("Error processing state change request for " + namespace + ", errors: " + errorState);
         }

--- a/server/src/test/java/org/elasticsearch/reservedstate/service/ReservedClusterStateServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/reservedstate/service/ReservedClusterStateServiceTests.java
@@ -326,10 +326,10 @@ public class ReservedClusterStateServiceTests extends ESTestCase {
         Metadata metadata = Metadata.builder().put(operatorMetadata).build();
         ClusterState state = ClusterState.builder(new ClusterName("test")).metadata(metadata).build();
 
-        assertFalse(ReservedClusterStateService.isNewError(operatorMetadata, 2L));
-        assertFalse(ReservedClusterStateService.isNewError(operatorMetadata, 1L));
-        assertTrue(ReservedClusterStateService.isNewError(operatorMetadata, 3L));
-        assertTrue(ReservedClusterStateService.isNewError(null, 1L));
+        assertFalse(ReservedStateErrorTask.isNewError(operatorMetadata, 2L));
+        assertFalse(ReservedStateErrorTask.isNewError(operatorMetadata, 1L));
+        assertTrue(ReservedStateErrorTask.isNewError(operatorMetadata, 3L));
+        assertTrue(ReservedStateErrorTask.isNewError(null, 1L));
 
         var chunk = new ReservedStateChunk(Map.of("one", "two", "maker", "three"), new ReservedStateVersion(2L, Version.CURRENT));
         var orderedHandlers = List.of(exceptionThrower.name(), newStateMaker.name());
@@ -343,7 +343,7 @@ public class ReservedClusterStateServiceTests extends ESTestCase {
             List.of(),
             Map.of(exceptionThrower.name(), exceptionThrower, newStateMaker.name(), newStateMaker),
             orderedHandlers,
-            errorState -> assertFalse(ReservedClusterStateService.isNewError(operatorMetadata, errorState.version())),
+            errorState -> assertFalse(ReservedStateErrorTask.isNewError(operatorMetadata, errorState.version())),
             new ActionListener<>() {
                 @Override
                 public void onResponse(ActionResponse.Empty empty) {}
@@ -484,6 +484,9 @@ public class ReservedClusterStateServiceTests extends ESTestCase {
 
     public void testCheckAndReportError() {
         ClusterService clusterService = mock(ClusterService.class);
+        var state = ClusterState.builder(new ClusterName("elasticsearch")).build();
+        when(clusterService.state()).thenReturn(state);
+
         final var controller = spy(new ReservedClusterStateService(clusterService, List.of()));
 
         assertNull(controller.checkAndReportError("test", List.of(), null));


### PR DESCRIPTION
Only check if we should update error states when we're running inside the main single-thread master cluster state service.

This fixes #90337