### PR TITLE
[8.5] Aggs: fix auto_date_histogram > ip_range (#90317)

### DIFF
--- a/docs/changelog/90317.yaml
+++ b/docs/changelog/90317.yaml
@@ -1,0 +1,6 @@
+pr: 90317
+summary: "Aggs: fix `auto_date_histogram` > `ip_range`"
+area: Aggregations
+type: bug
+issues:
+ - 90121

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/range/BinaryRangeAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/range/BinaryRangeAggregator.java
@@ -17,6 +17,7 @@ import org.elasticsearch.search.aggregations.Aggregator;
 import org.elasticsearch.search.aggregations.AggregatorFactories;
 import org.elasticsearch.search.aggregations.CardinalityUpperBound;
 import org.elasticsearch.search.aggregations.InternalAggregation;
+import org.elasticsearch.search.aggregations.InternalAggregations;
 import org.elasticsearch.search.aggregations.LeafBucketCollector;
 import org.elasticsearch.search.aggregations.LeafBucketCollectorBase;
 import org.elasticsearch.search.aggregations.bucket.BucketsAggregator;
@@ -24,12 +25,11 @@ import org.elasticsearch.search.aggregations.support.AggregationContext;
 import org.elasticsearch.search.aggregations.support.ValuesSource;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
-
-import static java.util.Collections.emptyList;
 
 /** A range aggregator for values that are stored in SORTED_SET doc values. */
 public final class BinaryRangeAggregator extends BucketsAggregator {
@@ -330,6 +330,13 @@ public final class BinaryRangeAggregator extends BucketsAggregator {
 
     @Override
     public InternalAggregation buildEmptyAggregation() {
-        return new InternalBinaryRange(name, format, keyed, emptyList(), metadata());
+        // Create empty buckets with 0 count and with empty sub-aggs so we can merge them with non-empty aggs
+        InternalAggregations subAggs = buildEmptySubAggregations();
+        List<InternalBinaryRange.Bucket> buckets = new ArrayList<>(ranges.length);
+        for (Range range : ranges) {
+            InternalBinaryRange.Bucket bucket = new InternalBinaryRange.Bucket(format, keyed, range.key, range.from, range.to, 0, subAggs);
+            buckets.add(bucket);
+        }
+        return new InternalBinaryRange(name, format, keyed, buckets, metadata());
     }
 }


### PR DESCRIPTION
Backports the following commits to 8.5:
 - Aggs: fix auto_date_histogram > ip_range (#90317)