### PR TITLE
[8.5] Update min version for health node reporting to 8.5 (#90365)

### DIFF
--- a/docs/changelog/90365.yaml
+++ b/docs/changelog/90365.yaml
@@ -1,0 +1,6 @@
+pr: 90365
+summary: Update min version for health node reporting to 8.5
+area: Health
+type: bug
+issues:
+ - 90359

--- a/server/src/main/java/org/elasticsearch/health/metadata/HealthMetadataService.java
+++ b/server/src/main/java/org/elasticsearch/health/metadata/HealthMetadataService.java
@@ -142,7 +142,7 @@ public class HealthMetadataService {
         // We do not use the cluster state to check if this is the master node because the cluster state might not have been initialized
         if (isMaster && enabled) {
             ClusterState clusterState = clusterService.state();
-            if (clusterState.nodesIfRecovered().getMinNodeVersion().onOrAfter(Version.V_8_4_0)) {
+            if (clusterState.nodesIfRecovered().getMinNodeVersion().onOrAfter(Version.V_8_5_0)) {
                 var task = new UpdateHealthMetadata(setting, value);
                 var config = ClusterStateTaskConfig.build(Priority.NORMAL);
                 clusterService.submitStateUpdateTask("health-metadata-update", task, config, executor);

--- a/server/src/main/java/org/elasticsearch/health/node/selection/HealthNodeTaskExecutor.java
+++ b/server/src/main/java/org/elasticsearch/health/node/selection/HealthNodeTaskExecutor.java
@@ -142,8 +142,8 @@ public final class HealthNodeTaskExecutor extends PersistentTasksExecutor<Health
 
     // visible for testing
     void startTask(ClusterChangedEvent event) {
-        // Wait until every node in the cluster is upgraded to 8.4.0 or later
-        if (event.state().nodesIfRecovered().getMinNodeVersion().onOrAfter(Version.V_8_4_0)) {
+        // Wait until every node in the cluster is upgraded to 8.5.0 or later
+        if (event.state().nodesIfRecovered().getMinNodeVersion().onOrAfter(Version.V_8_5_0)) {
             boolean healthNodeTaskExists = HealthNode.findTask(event.state()) != null;
             boolean isElectedMaster = event.localNodeMaster();
             if (isElectedMaster || healthNodeTaskExists) {


### PR DESCRIPTION
Backports the following commits to 8.5:
 - Update min version for health node reporting to 8.5 (#90365)