### PR TITLE
Date histogram extended_bounds and offset

### DIFF
--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.aggregation/10_histogram.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.aggregation/10_histogram.yml
@@ -879,6 +879,49 @@ setup:
   - match: { aggregations.foo.histo.buckets.3.key_as_string: "2016-01-04T01:00:00.000Z" }
   - match: { aggregations.foo.histo.buckets.3.doc_count: 0 }
 
+
+---
+"date_histogram with extended_bounds and offset":
+  - skip:
+      version: " - 7.17.6"
+      reason: fixed in 7.17.7
+
+  - do:
+      indices.create:
+        index: test_date_offset
+        body:
+          mappings:
+            properties:
+              date:
+                type: date
+
+  - do:
+      bulk:
+        index: test_date_offset
+        refresh: true
+        body:
+          - '{"index": {}}'
+          - '{"date": 1639447293418}'
+
+  - do:
+      search:
+        index: test_*
+        body:
+          size: 0
+          aggs:
+            by_date:
+              date_histogram:
+                field: date
+                calendar_interval: day
+                offset: "18000000ms"
+                extended_bounds:
+                  max: 1639457999999
+  - match: { hits.total.value: 1 }
+  - length: { aggregations.by_date.buckets: 1 }
+  - match: { aggregations.by_date.buckets.0.key_as_string: "2021-12-13T05:00:00.000Z" }
+  - match: { aggregations.by_date.buckets.0.key: 1639371600000 }
+  - match: { aggregations.by_date.buckets.0.doc_count: 1 }
+
 ---
 "Tiny tiny tiny range":
   - skip:

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/InternalDateHistogram.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/InternalDateHistogram.java
@@ -469,12 +469,14 @@ public final class InternalDateHistogram extends InternalMultiBucketAggregation<
         }
 
         // finally, adding the empty buckets *after* the actual data (based on the extended_bounds.max requested by the user)
-        if (bounds != null && lastBucket != null && bounds.getMax() != null && bounds.getMax() + offset - 1 > lastBucket.key) {
+        if (bounds != null && lastBucket != null && bounds.getMax() != null) {
             long key = nextKey(lastBucket.key).longValue();
-            long max = bounds.getMax() + offset;
-            while (key <= max) {
-                onBucket.accept(key);
-                key = nextKey(key).longValue();
+            if (key <= bounds.getMax() + offset) {
+                long max = bounds.getMax() + offset;
+                while (key <= max) {
+                    onBucket.accept(key);
+                    key = nextKey(key).longValue();
+                }
             }
         }
     }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/InternalDateHistogram.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/InternalDateHistogram.java
@@ -469,7 +469,7 @@ public final class InternalDateHistogram extends InternalMultiBucketAggregation<
         }
 
         // finally, adding the empty buckets *after* the actual data (based on the extended_bounds.max requested by the user)
-        if (bounds != null && lastBucket != null && bounds.getMax() != null && bounds.getMax() + offset > lastBucket.key) {
+        if (bounds != null && lastBucket != null && bounds.getMax() != null && bounds.getMax() + offset - 1 > lastBucket.key) {
             long key = nextKey(lastBucket.key).longValue();
             long max = bounds.getMax() + offset;
             while (key <= max) {

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/histogram/DateHistogramAggregatorTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/histogram/DateHistogramAggregatorTests.java
@@ -821,6 +821,27 @@ public class DateHistogramAggregatorTests extends DateHistogramAggregatorTestCas
         );
     }
 
+    public void testExtendedBoundsWithOffsetPartTwo() throws IOException {
+        DateFieldMapper.DateFieldType dateFieldType = aggregableDateFieldType(false, true);
+        testCase(
+            new DateHistogramAggregationBuilder("test").field(AGGREGABLE_DATE)
+                .calendarInterval(DateHistogramInterval.DAY)
+                .offset("18000000ms")
+                .extendedBounds(new LongBounds(null, 1639457999999L - (5 * 60 * 60 * 1000))),
+            new MatchAllDocsQuery(),
+            iw -> {
+                Document d = new Document();
+                d.add(new SortedNumericDocValuesField(AGGREGABLE_DATE, 1639447293418L));
+                iw.addDocument(d);
+            },
+            result -> {
+                InternalDateHistogram dateHisto = (InternalDateHistogram) result;
+                assertEquals(1, dateHisto.getBuckets().size());
+            },
+            dateFieldType
+        );
+    }
+
     public void testExtendedBoundsWithOffset() throws IOException {
         DateFieldMapper.DateFieldType dateFieldType = aggregableDateFieldType(false, true);
         testCase(

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/histogram/DateHistogramAggregatorTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/histogram/DateHistogramAggregatorTests.java
@@ -821,6 +821,19 @@ public class DateHistogramAggregatorTests extends DateHistogramAggregatorTestCas
         );
     }
 
+    public void testExtendedBoundsWithOffset() throws IOException {
+        aggregationImplementationChoiceTestCase(
+            aggregableDateFieldType(false, true),
+            List.of("1639447293418"),
+            List.of("2021-12-13T05:00:00.000Z"),
+            new DateHistogramAggregationBuilder("test").field(AGGREGABLE_DATE)
+                .calendarInterval(DateHistogramInterval.DAY)
+                .offset("18000000ms")
+                .extendedBounds(new LongBounds(null, 1639457999999L)),
+            false
+        );
+    }
+
     public void testHardBoundsUsesFromRange() throws IOException {
         aggregationImplementationChoiceTestCase(
             aggregableDateFieldType(false, true, DateFormatter.forPattern("yyyy")),

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/histogram/DateHistogramAggregatorTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/histogram/DateHistogramAggregatorTests.java
@@ -822,15 +822,23 @@ public class DateHistogramAggregatorTests extends DateHistogramAggregatorTestCas
     }
 
     public void testExtendedBoundsWithOffset() throws IOException {
-        aggregationImplementationChoiceTestCase(
-            aggregableDateFieldType(false, true),
-            List.of("1639447293418"),
-            List.of("2021-12-13T05:00:00.000Z"),
+        DateFieldMapper.DateFieldType dateFieldType = aggregableDateFieldType(false, true);
+        testCase(
             new DateHistogramAggregationBuilder("test").field(AGGREGABLE_DATE)
                 .calendarInterval(DateHistogramInterval.DAY)
                 .offset("18000000ms")
                 .extendedBounds(new LongBounds(null, 1639457999999L)),
-            false
+            new MatchAllDocsQuery(),
+            iw -> {
+                Document d = new Document();
+                d.add(new SortedNumericDocValuesField(AGGREGABLE_DATE, 1639447293418L));
+                iw.addDocument(d);
+            },
+            result -> {
+                InternalDateHistogram dateHisto = (InternalDateHistogram) result;
+                assertEquals(1, dateHisto.getBuckets().size());
+            },
+            dateFieldType
         );
     }
 


### PR DESCRIPTION
Some tests and code fixes related to an issue regarding extended bonds and offsets in the calculation of date histograms.

See https://github.com/elastic/elasticsearch/issues/81701
