### PR TITLE
Update language around eliminating replicate shards

### DIFF
--- a/docs/reference/searchable-snapshots/index.asciidoc
+++ b/docs/reference/searchable-snapshots/index.asciidoc
@@ -7,7 +7,7 @@ infrequently accessed and read-only data in a very cost-effective fashion. The
 reduce your storage and operating costs.
 
 {search-snaps-cap} eliminate the need for <<scalability,replica shards>>
-after rollover from hot, potentially halving the local storage needed to search 
+after rolling over from the hot tier, potentially halving the local storage needed to search 
 your data. {search-snaps-cap} rely on the same snapshot mechanism you already
 use for backups and have minimal impact on your snapshot repository storage
 costs.

--- a/docs/reference/searchable-snapshots/index.asciidoc
+++ b/docs/reference/searchable-snapshots/index.asciidoc
@@ -6,10 +6,11 @@ infrequently accessed and read-only data in a very cost-effective fashion. The
 <<cold-tier,cold>> and <<frozen-tier,frozen>> data tiers use {search-snaps} to
 reduce your storage and operating costs.
 
-{search-snaps-cap} eliminate the need for <<scalability,replica shards>>,
-potentially halving the local storage needed to search your data.
-{search-snaps-cap} rely on the same snapshot mechanism you already use for
-backups and have minimal impact on your snapshot repository storage costs.
+{search-snaps-cap} eliminate the need for <<scalability,replica shards>>
+after rollover from hot, potentially halving the local storage needed to search 
+your data. {search-snaps-cap} rely on the same snapshot mechanism you already
+use for backups and have minimal impact on your snapshot repository storage
+costs.
 
 [discrete]
 [[using-searchable-snapshots]]


### PR DESCRIPTION
I didn't notice that #90369 targets `8.4` rather than `main`, so this essentially is a manual forward fit of that PR into `main` that I will also backport into `8.5`.