### PR TITLE
[8.5] [ML] Reduce logging from trace to debug for PyTorch inference tests

### DIFF
--- a/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/PyTorchModelIT.java
+++ b/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/PyTorchModelIT.java
@@ -122,9 +122,9 @@ public class PyTorchModelIT extends ESRestTestCase {
         Request loggingSettings = new Request("PUT", "_cluster/settings");
         loggingSettings.setJsonEntity("""
             {"persistent" : {
-                    "logger.org.elasticsearch.xpack.ml.inference.assignment" : "TRACE",
-                    "logger.org.elasticsearch.xpack.ml.inference.deployment" : "TRACE",
-                    "logger.org.elasticsearch.xpack.ml.process.logging" : "TRACE"
+                    "logger.org.elasticsearch.xpack.ml.inference.assignment" : "DEBUG",
+                    "logger.org.elasticsearch.xpack.ml.inference.deployment" : "DEBUG",
+                    "logger.org.elasticsearch.xpack.ml.process.logging" : "DEBUG"
                 }}""");
         client().performRequest(loggingSettings);
     }


### PR DESCRIPTION
Previously logging was set to trace for all tests in the PyTorchModelIT suite.  However, this causes the entire cluster state to be logged many times during the tests, and this can slow down the tests to the extent that they are at risk of timing out.

This change removes the trace logging (which is the level that logs the entire cluster state).

Backport of #90361