### PR TITLE
Graph tests - more data on failure

### DIFF
--- a/x-pack/plugin/graph/src/internalClusterTest/java/org/elasticsearch/xpack/graph/test/GraphTests.java
+++ b/x-pack/plugin/graph/src/internalClusterTest/java/org/elasticsearch/xpack/graph/test/GraphTests.java
@@ -11,6 +11,7 @@ import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.admin.indices.forcemerge.ForceMergeResponse;
 import org.elasticsearch.action.admin.indices.segments.IndexShardSegments;
 import org.elasticsearch.action.admin.indices.segments.ShardSegments;
+import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.settings.Settings.Builder;
 import org.elasticsearch.core.TimeValue;
@@ -236,7 +237,7 @@ public class GraphTests extends ESSingleNodeTestCase {
         grb.createNextHop(QueryBuilders.termQuery("decade", "00s")).addVertexRequest("people").size(100).minDocCount(1);
 
         GraphExploreResponse response = grb.get();
-        assertTrue(response.isTimedOut());
+        assertTrue(Strings.toString(response), response.isTimedOut());
 
         checkVertexDepth(response, 0, "john", "paul", "george", "ringo");
 


### PR DESCRIPTION
Get more data when the graph timeout test fails. Relates to #90286.
