### PR TITLE
Bad ref to 'node_id' parameter in Task Mgt doc

### DIFF
--- a/docs/reference/cluster/tasks.asciidoc
+++ b/docs/reference/cluster/tasks.asciidoc
@@ -44,7 +44,7 @@ include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=detailed]
 
 include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=group-by]
 
-include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=node-id-query-parm]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=node-id]
 
 include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=parent-task-id]
 

--- a/docs/reference/cluster/tasks.asciidoc
+++ b/docs/reference/cluster/tasks.asciidoc
@@ -44,7 +44,7 @@ include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=detailed]
 
 include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=group-by]
 
-include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=node-id]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=nodes]
 
 include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=parent-task-id]
 

--- a/docs/reference/rest-api/common-parms.asciidoc
+++ b/docs/reference/rest-api/common-parms.asciidoc
@@ -714,6 +714,12 @@ tag::node-id[]
 returned information.
 end::node-id[]
 
+tag::nodes[]
+`nodes`::
+(Optional, string) Comma-separated list of node IDs or names used to limit
+returned information.
+end::nodes[]
+
 tag::offsets[]
 `<offsets>`::
 (Optional, Boolean) If `true`, the response includes term offsets.

--- a/docs/reference/rest-api/common-parms.asciidoc
+++ b/docs/reference/rest-api/common-parms.asciidoc
@@ -714,13 +714,6 @@ tag::node-id[]
 returned information.
 end::node-id[]
 
-tag::node-id-query-parm[]
-`node_id`::
-(Optional, string)
-Comma-separated list of node IDs or names
-used to limit returned information.
-end::node-id-query-parm[]
-
 tag::offsets[]
 `<offsets>`::
 (Optional, Boolean) If `true`, the response includes term offsets.


### PR DESCRIPTION
Here in documentation:
https://www.elastic.co/guide/en/elasticsearch/reference/8.4/tasks.html#tasks-api-query-params

Name of parameter to filter node is `nodes`.
