### PR TITLE
Tidyup aggs-matrix-stats module-info.java

### DIFF
--- a/modules/aggs-matrix-stats/src/main/java/module-info.java
+++ b/modules/aggs-matrix-stats/src/main/java/module-info.java
@@ -10,7 +10,6 @@ module org.elasticsearch.aggs.matrix {
     requires org.elasticsearch.base;
     requires org.elasticsearch.server;
     requires org.elasticsearch.xcontent;
-    requires org.apache.logging.log4j;
     requires org.apache.lucene.core;
 
     exports org.elasticsearch.search.aggregations.matrix;


### PR DESCRIPTION
Remove org.apache.logging.log4j as required module, because this module isn't using log4j directly.
Noticed while working on #90294