### PR TITLE
Fix flaky testCannotAllocateDueToLackOfDiskResourcesWithMaxHeadroom

### DIFF
--- a/server/src/test/java/org/elasticsearch/cluster/routing/allocation/decider/DiskThresholdDeciderUnitTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/allocation/decider/DiskThresholdDeciderUnitTests.java
@@ -223,7 +223,7 @@ public class DiskThresholdDeciderUnitTests extends ESAllocationTestCase {
         Decision decision = decider.canAllocate(test_0, RoutingNodesHelper.routingNode("node_0", node_0), allocation);
         assertEquals(Decision.Type.NO, decision.type());
 
-        double usedPercentage = 100.0 * (totalBytes - freeBytes) / totalBytes;
+        double usedPercentage = 100.0 - (100.0 * freeBytes / totalBytes);
 
         assertThat(
             decision.getExplanation(),


### PR DESCRIPTION
We calculate the actual and expected % differently (with seed `-Dtests.seed=E9C9B530C422D841`):

* expected: [100.0 * (totalBytes - freeBytes) / totalBytes](https://github.com/elastic/elasticsearch/blob/7dc8806dda46cb5eb5f140eda988b6e32cee446f/server/src/test/java/org/elasticsearch/cluster/routing/allocation/decider/DiskThresholdDeciderUnitTests.java#L226) that results in `10.3`
* actual [100.0 - (100.0 * getFreeBytes() / getTotalBytes()](https://github.com/elastic/elasticsearch/blob/862a86c0081553dd40af269c58a8f2195a6912c2/server/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/DiskThresholdDecider.java#L609-L618) that results in `10.299999999999997`

The results are then formatted using [Strings.format1Decimals](https://github.com/elastic/elasticsearch/blob/faae31cca6d38cf1c66117808f62c25c52a4525f/server/src/main/java/org/elasticsearch/common/Strings.java#L706-L724) that returns `10.2%` for the later value.

This change aligns the expected calculation with actual, however I wonder if we should change `Strings.format1Decimals` to properly round instead? It has not changed since the initial commit.

Closes: #90374