### PR TITLE
Geo cartesian code deduplication

### DIFF
--- a/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/index/fielddata/CartesianShapeValues.java
+++ b/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/index/fielddata/CartesianShapeValues.java
@@ -23,13 +23,13 @@ import java.io.IOException;
 public interface CartesianShapeValues extends ShapeValues<CartesianShapeValues.CartesianShapeValue> {
 
     CartesianShapeValuesSourceType DEFAULT_VALUES_SOURCE_TYPE = CartesianShapeValuesSourceType.instance();
-    CartesianShapeValues EMPTY = new CartesianShapeValues.Empty();
     ShapeValuesConfig<CartesianShapeValues.CartesianShapeValue> DEFAULT_CONFIG = new ShapeValuesConfig<>(
         CoordinateEncoder.CARTESIAN,
         CartesianShapeValue::new,
         new CartesianShapeIndexer("missing"),
         DEFAULT_VALUES_SOURCE_TYPE
     );
+    CartesianShapeValues EMPTY = new CartesianShapeValues.Empty();
 
     /**
      * Produce empty ShapeValues for cartesian data

--- a/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/index/fielddata/CartesianShapeValues.java
+++ b/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/index/fielddata/CartesianShapeValues.java
@@ -24,13 +24,19 @@ public interface CartesianShapeValues extends ShapeValues<CartesianShapeValues.C
 
     CartesianShapeValuesSourceType DEFAULT_VALUES_SOURCE_TYPE = CartesianShapeValuesSourceType.instance();
     CartesianShapeValues EMPTY = new CartesianShapeValues.Empty();
+    ShapeValuesConfig<CartesianShapeValues.CartesianShapeValue> DEFAULT_CONFIG = new ShapeValuesConfig<>(
+        CoordinateEncoder.CARTESIAN,
+        CartesianShapeValue::new,
+        new CartesianShapeIndexer("missing"),
+        DEFAULT_VALUES_SOURCE_TYPE
+    );
 
     /**
      * Produce empty ShapeValues for cartesian data
      */
     class Empty extends ShapeValues.Empty<CartesianShapeValues.CartesianShapeValue> implements CartesianShapeValues {
         Empty() {
-            super(CoordinateEncoder.CARTESIAN, CartesianShapeValue::new, new CartesianShapeIndexer("missing"), DEFAULT_VALUES_SOURCE_TYPE);
+            super(DEFAULT_CONFIG);
         }
     }
 
@@ -39,14 +45,7 @@ public interface CartesianShapeValues extends ShapeValues<CartesianShapeValues.C
      */
     class Wrapped extends ShapeValues.Wrapped<CartesianShapeValue> implements CartesianShapeValues {
         public Wrapped(ShapeValues<CartesianShapeValue> values, CartesianShapeValue missing) {
-            super(
-                CoordinateEncoder.CARTESIAN,
-                CartesianShapeValue::new,
-                new CartesianShapeIndexer("missing"),
-                DEFAULT_VALUES_SOURCE_TYPE,
-                values,
-                missing
-            );
+            super(DEFAULT_CONFIG, values, missing);
         }
     }
 
@@ -55,14 +54,7 @@ public interface CartesianShapeValues extends ShapeValues<CartesianShapeValues.C
      */
     class BinaryDocData extends ShapeValues.BinaryDocData<CartesianShapeValue> implements CartesianShapeValues {
         public BinaryDocData(BinaryDocValues binaryValues) {
-            super(
-                CoordinateEncoder.CARTESIAN,
-                CartesianShapeValue::new,
-                new CartesianShapeIndexer("missing"),
-                DEFAULT_VALUES_SOURCE_TYPE,
-                binaryValues,
-                new CartesianShapeValue()
-            );
+            super(DEFAULT_CONFIG, binaryValues, new CartesianShapeValue());
         }
     }
 

--- a/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/index/fielddata/GeoShapeValues.java
+++ b/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/index/fielddata/GeoShapeValues.java
@@ -10,10 +10,10 @@ package org.elasticsearch.xpack.spatial.index.fielddata;
 import org.apache.lucene.geo.Component2D;
 import org.apache.lucene.geo.LatLonGeometry;
 import org.apache.lucene.geo.Point;
+import org.apache.lucene.index.BinaryDocValues;
 import org.elasticsearch.common.geo.GeoPoint;
 import org.elasticsearch.common.geo.Orientation;
 import org.elasticsearch.index.mapper.GeoShapeIndexer;
-import org.elasticsearch.search.aggregations.support.ValuesSourceType;
 import org.elasticsearch.xpack.spatial.search.aggregations.support.GeoShapeValuesSourceType;
 
 import java.io.IOException;
@@ -21,38 +21,56 @@ import java.io.IOException;
 /**
  * A stateful lightweight per document geo values.
  */
-public abstract class GeoShapeValues extends ShapeValues<GeoShapeValues.GeoShapeValue> {
+public interface GeoShapeValues extends ShapeValues<GeoShapeValues.GeoShapeValue> {
 
-    public static GeoShapeValues EMPTY = new GeoShapeValues() {
-        private final GeoShapeValuesSourceType DEFAULT_VALUES_SOURCE_TYPE = GeoShapeValuesSourceType.instance();
-
-        @Override
-        public boolean advanceExact(int doc) {
-            return false;
-        }
-
-        @Override
-        public ValuesSourceType valuesSourceType() {
-            return DEFAULT_VALUES_SOURCE_TYPE;
-        }
-
-        @Override
-        public GeoShapeValue value() {
-            throw new UnsupportedOperationException();
-        }
-    };
+    GeoShapeValuesSourceType DEFAULT_VALUES_SOURCE_TYPE = GeoShapeValuesSourceType.instance();
+    GeoShapeValues EMPTY = new Empty();
 
     /**
-     * Creates a new {@link GeoShapeValues} instance
+     * Produce empty ShapeValues for geo data
      */
-    protected GeoShapeValues() {
-        super(CoordinateEncoder.GEO, GeoShapeValues.GeoShapeValue::new, new GeoShapeIndexer(Orientation.CCW, "missing"));
+    class Empty extends ShapeValues.Empty<GeoShapeValue> implements GeoShapeValues {
+        Empty() {
+            super(CoordinateEncoder.GEO, GeoShapeValue::new, new GeoShapeIndexer(Orientation.CCW, "missing"), DEFAULT_VALUES_SOURCE_TYPE);
+        }
+    }
+
+    /**
+     * Produce ShapeValues for geo data that wrap existing ShapeValues but replace missing fields with the specified value
+     */
+    class Wrapped extends ShapeValues.Wrapped<GeoShapeValue> implements GeoShapeValues {
+        public Wrapped(ShapeValues<GeoShapeValue> values, GeoShapeValue missing) {
+            super(
+                CoordinateEncoder.GEO,
+                GeoShapeValue::new,
+                new GeoShapeIndexer(Orientation.CCW, "missing"),
+                DEFAULT_VALUES_SOURCE_TYPE,
+                values,
+                missing
+            );
+        }
+    }
+
+    /**
+    * Produce ShapeValues for geo data that generate each ShapeValue from the specified BinaryDocValues
+    */
+    class BinaryDocData extends ShapeValues.BinaryDocData<GeoShapeValue> implements GeoShapeValues {
+        public BinaryDocData(BinaryDocValues binaryValues) {
+            super(
+                CoordinateEncoder.GEO,
+                GeoShapeValue::new,
+                new GeoShapeIndexer(Orientation.CCW, "missing"),
+                DEFAULT_VALUES_SOURCE_TYPE,
+                binaryValues,
+                new GeoShapeValue()
+            );
+        }
     }
 
     /**
      * thin wrapper around a {@link GeometryDocValueReader} which encodes / decodes values using the Geo decoder
      */
-    public static class GeoShapeValue extends ShapeValues.ShapeValue {
+    class GeoShapeValue extends ShapeValues.ShapeValue {
         private final Tile2DVisitor tile2DVisitor;  // This does not work for cartesian, so we currently only support this in geo
 
         public GeoShapeValue() {

--- a/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/index/fielddata/GeoShapeValues.java
+++ b/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/index/fielddata/GeoShapeValues.java
@@ -24,13 +24,13 @@ import java.io.IOException;
 public interface GeoShapeValues extends ShapeValues<GeoShapeValues.GeoShapeValue> {
 
     GeoShapeValuesSourceType DEFAULT_VALUES_SOURCE_TYPE = GeoShapeValuesSourceType.instance();
-    GeoShapeValues EMPTY = new Empty();
     ShapeValuesConfig<GeoShapeValues.GeoShapeValue> DEFAULT_CONFIG = new ShapeValuesConfig<>(
         CoordinateEncoder.GEO,
         GeoShapeValue::new,
         new GeoShapeIndexer(Orientation.CCW, "missing"),
         DEFAULT_VALUES_SOURCE_TYPE
     );
+    GeoShapeValues EMPTY = new Empty();
 
     /**
      * Produce empty ShapeValues for geo data

--- a/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/index/fielddata/GeoShapeValues.java
+++ b/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/index/fielddata/GeoShapeValues.java
@@ -25,13 +25,19 @@ public interface GeoShapeValues extends ShapeValues<GeoShapeValues.GeoShapeValue
 
     GeoShapeValuesSourceType DEFAULT_VALUES_SOURCE_TYPE = GeoShapeValuesSourceType.instance();
     GeoShapeValues EMPTY = new Empty();
+    ShapeValuesConfig<GeoShapeValues.GeoShapeValue> DEFAULT_CONFIG = new ShapeValuesConfig<>(
+        CoordinateEncoder.GEO,
+        GeoShapeValue::new,
+        new GeoShapeIndexer(Orientation.CCW, "missing"),
+        DEFAULT_VALUES_SOURCE_TYPE
+    );
 
     /**
      * Produce empty ShapeValues for geo data
      */
     class Empty extends ShapeValues.Empty<GeoShapeValue> implements GeoShapeValues {
         Empty() {
-            super(CoordinateEncoder.GEO, GeoShapeValue::new, new GeoShapeIndexer(Orientation.CCW, "missing"), DEFAULT_VALUES_SOURCE_TYPE);
+            super(DEFAULT_CONFIG);
         }
     }
 
@@ -40,14 +46,7 @@ public interface GeoShapeValues extends ShapeValues<GeoShapeValues.GeoShapeValue
      */
     class Wrapped extends ShapeValues.Wrapped<GeoShapeValue> implements GeoShapeValues {
         public Wrapped(ShapeValues<GeoShapeValue> values, GeoShapeValue missing) {
-            super(
-                CoordinateEncoder.GEO,
-                GeoShapeValue::new,
-                new GeoShapeIndexer(Orientation.CCW, "missing"),
-                DEFAULT_VALUES_SOURCE_TYPE,
-                values,
-                missing
-            );
+            super(DEFAULT_CONFIG, values, missing);
         }
     }
 
@@ -56,14 +55,7 @@ public interface GeoShapeValues extends ShapeValues<GeoShapeValues.GeoShapeValue
     */
     class BinaryDocData extends ShapeValues.BinaryDocData<GeoShapeValue> implements GeoShapeValues {
         public BinaryDocData(BinaryDocValues binaryValues) {
-            super(
-                CoordinateEncoder.GEO,
-                GeoShapeValue::new,
-                new GeoShapeIndexer(Orientation.CCW, "missing"),
-                DEFAULT_VALUES_SOURCE_TYPE,
-                binaryValues,
-                new GeoShapeValue()
-            );
+            super(DEFAULT_CONFIG, binaryValues, new GeoShapeValue());
         }
     }
 

--- a/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/index/fielddata/ShapeValues.java
+++ b/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/index/fielddata/ShapeValues.java
@@ -9,6 +9,7 @@ package org.elasticsearch.xpack.spatial.index.fielddata;
 
 import org.apache.lucene.document.ShapeField;
 import org.apache.lucene.geo.Component2D;
+import org.apache.lucene.index.BinaryDocValues;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.geo.SpatialPoint;
 import org.elasticsearch.geometry.Geometry;
@@ -19,6 +20,7 @@ import org.elasticsearch.search.aggregations.support.ValuesSourceType;
 import org.elasticsearch.xcontent.ToXContentFragment;
 import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xpack.spatial.index.mapper.BinaryShapeDocValuesField;
+import org.elasticsearch.xpack.spatial.search.aggregations.support.ShapeValuesSourceType;
 
 import java.io.IOException;
 import java.text.ParseException;
@@ -40,47 +42,158 @@ import java.util.function.Supplier;
  *
  * There is just one value for one document.
  */
-public abstract class ShapeValues<T extends ShapeValues.ShapeValue> {
-    protected final CoordinateEncoder encoder;
-    protected final Supplier<T> supplier;
-    protected final ShapeIndexer missingShapeIndexer;
-
-    /**
-     * Creates a new {@link ShapeValues} instance
-     */
-    protected ShapeValues(CoordinateEncoder encoder, Supplier<T> supplier, ShapeIndexer missingShapeIndexer) {
-        this.encoder = encoder;
-        this.supplier = supplier;
-        this.missingShapeIndexer = missingShapeIndexer;
-    }
+public interface ShapeValues<T extends ShapeValues.ShapeValue> {
 
     /**
      * Advance this instance to the given document id
+     *
      * @return true if there is a value for this document
      */
-    public abstract boolean advanceExact(int doc) throws IOException;
-
-    public abstract ValuesSourceType valuesSourceType();
+    boolean advanceExact(int doc) throws IOException;
 
     /**
      * Return the value associated with the current document.
-     *
+     * <p>
      * Note: the returned {@link ShapeValue} might be shared across invocations.
      *
      * @return the value for the current docID set to {@link #advanceExact(int)}.
      */
-    public abstract T value() throws IOException;
+    T value() throws IOException;
 
-    public T missing(String missing) {
-        try {
-            final Geometry geometry = WellKnownText.fromWKT(GeographyValidator.instance(true), true, missing);
-            final BinaryShapeDocValuesField field = new BinaryShapeDocValuesField("missing", encoder);
-            field.add(missingShapeIndexer.indexShape(geometry), geometry);
-            final T value = supplier.get();
-            value.reset(field.binaryValue());
-            return value;
-        } catch (IOException | ParseException e) {
-            throw new IllegalArgumentException("Can't apply missing value [" + missing + "]", e);
+    ValuesSourceType valuesSourceType();
+
+    T missing(String missing);
+
+    abstract class ShapeValuesImpl<T extends ShapeValues.ShapeValue> implements ShapeValues<T> {
+        protected final CoordinateEncoder encoder;
+        protected final Supplier<T> supplier;
+        protected final ShapeIndexer missingShapeIndexer;
+        protected final ShapeValuesSourceType valuesSourceType;
+
+        protected ShapeValuesImpl(
+            CoordinateEncoder encoder,
+            Supplier<T> supplier,
+            ShapeIndexer missingShapeIndexer,
+            ShapeValuesSourceType valuesSourceType
+        ) {
+            this.encoder = encoder;
+            this.supplier = supplier;
+            this.missingShapeIndexer = missingShapeIndexer;
+            this.valuesSourceType = valuesSourceType;
+        }
+
+        @Override
+        public ValuesSourceType valuesSourceType() {
+            return valuesSourceType;
+        }
+
+        @Override
+        public T missing(String missing) {
+            try {
+                final Geometry geometry = WellKnownText.fromWKT(GeographyValidator.instance(true), true, missing);
+                final BinaryShapeDocValuesField field = new BinaryShapeDocValuesField("missing", encoder);
+                field.add(missingShapeIndexer.indexShape(geometry), geometry);
+                final T value = supplier.get();
+                value.reset(field.binaryValue());
+                return value;
+            } catch (IOException | ParseException e) {
+                throw new IllegalArgumentException("Can't apply missing value [" + missing + "]", e);
+            }
+        }
+    }
+
+    /**
+     * An empty collection of ShapeValue
+     */
+    class Empty<T extends ShapeValues.ShapeValue> extends ShapeValuesImpl<T> {
+        protected Empty(CoordinateEncoder encoder, Supplier<T> supplier, ShapeIndexer indexer, ShapeValuesSourceType sourceType) {
+            super(encoder, supplier, indexer, sourceType);
+        }
+
+        @Override
+        public boolean advanceExact(int doc) {
+            return false;
+        }
+
+        @Override
+        public T value() {
+            throw new UnsupportedOperationException();
+        }
+    }
+
+    /**
+     * ShapeValues that produces a stream of ShapeValue from a BinaryDocValues instance
+     */
+    class BinaryDocData<T extends ShapeValues.ShapeValue> extends ShapeValuesImpl<T> {
+        private final BinaryDocValues binaryValues;
+        private final T shapeValue;
+
+        protected BinaryDocData(
+            CoordinateEncoder encoder,
+            Supplier<T> supplier,
+            ShapeIndexer indexer,
+            ShapeValuesSourceType sourceType,
+            BinaryDocValues binaryValues,
+            T shapeValue
+        ) {
+            super(encoder, supplier, indexer, sourceType);
+            this.binaryValues = binaryValues;
+            this.shapeValue = shapeValue;
+        }
+
+        @Override
+        public boolean advanceExact(int doc) throws IOException {
+            return binaryValues.advanceExact(doc);
+        }
+
+        @Override
+        public T value() throws IOException {
+            shapeValue.reset(binaryValues.binaryValue());
+            return shapeValue;
+        }
+    }
+
+    /**
+     * ShapeValues that wraps another ShapeValues, but replaces missing values with the specified missing value
+     */
+    class Wrapped<T extends ShapeValues.ShapeValue> extends ShapeValuesImpl<T> {
+        private final ShapeValues<T> values;
+        private final T missing;
+        private boolean exists;
+
+        protected Wrapped(
+            CoordinateEncoder encoder,
+            Supplier<T> supplier,
+            ShapeIndexer indexer,
+            ShapeValuesSourceType sourceType,
+            ShapeValues<T> values,
+            T missing
+        ) {
+            super(encoder, supplier, indexer, sourceType);
+            this.values = values;
+            this.missing = missing;
+        }
+
+        @Override
+        public boolean advanceExact(int doc) throws IOException {
+            exists = values.advanceExact(doc);
+            // always return true because we want to return a value even if the document does not have a value
+            return true;
+        }
+
+        @Override
+        public ValuesSourceType valuesSourceType() {
+            return values.valuesSourceType();
+        }
+
+        @Override
+        public T value() throws IOException {
+            return exists ? values.value() : missing;
+        }
+
+        @Override
+        public String toString() {
+            return "anon ShapeValues of [" + super.toString() + "]";
         }
     }
 
@@ -88,7 +201,7 @@ public abstract class ShapeValues<T extends ShapeValues.ShapeValue> {
      * thin wrapper around a {@link GeometryDocValueReader} which encodes / decodes values using
      * the provided decoder (could be geo or cartesian)
      */
-    protected abstract static class ShapeValue implements ToXContentFragment {
+    abstract class ShapeValue implements ToXContentFragment {
         protected final GeometryDocValueReader reader;
         private final BoundingBox boundingBox;
         protected final CoordinateEncoder encoder;
@@ -180,7 +293,7 @@ public abstract class ShapeValues<T extends ShapeValues.ShapeValue> {
         }
     }
 
-    public static class BoundingBox {
+    class BoundingBox {
         public double top;
         public double bottom;
         public double negLeft;

--- a/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/index/fielddata/plain/CartesianShapeDVAtomicShapeFieldData.java
+++ b/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/index/fielddata/plain/CartesianShapeDVAtomicShapeFieldData.java
@@ -7,15 +7,12 @@
 
 package org.elasticsearch.xpack.spatial.index.fielddata.plain;
 
-import org.apache.lucene.index.BinaryDocValues;
 import org.apache.lucene.index.DocValues;
 import org.apache.lucene.index.LeafReader;
 import org.apache.lucene.util.Accountable;
 import org.elasticsearch.script.field.ToScriptFieldFactory;
-import org.elasticsearch.search.aggregations.support.ValuesSourceType;
 import org.elasticsearch.xpack.spatial.index.fielddata.CartesianShapeValues;
 import org.elasticsearch.xpack.spatial.index.fielddata.LeafShapeFieldData;
-import org.elasticsearch.xpack.spatial.search.aggregations.support.CartesianShapeValuesSourceType;
 
 import java.io.IOException;
 import java.util.Collection;
@@ -53,26 +50,7 @@ final class CartesianShapeDVAtomicShapeFieldData extends LeafShapeFieldData<Cart
     @Override
     public CartesianShapeValues getShapeValues() {
         try {
-            final BinaryDocValues binaryValues = DocValues.getBinary(reader, fieldName);
-            final CartesianShapeValues.CartesianShapeValue geoShapeValue = new CartesianShapeValues.CartesianShapeValue();
-            return new CartesianShapeValues() {
-
-                @Override
-                public boolean advanceExact(int doc) throws IOException {
-                    return binaryValues.advanceExact(doc);
-                }
-
-                @Override
-                public ValuesSourceType valuesSourceType() {
-                    return CartesianShapeValuesSourceType.instance();
-                }
-
-                @Override
-                public CartesianShapeValue value() throws IOException {
-                    geoShapeValue.reset(binaryValues.binaryValue());
-                    return geoShapeValue;
-                }
-            };
+            return new CartesianShapeValues.BinaryDocData(DocValues.getBinary(reader, fieldName));
         } catch (IOException e) {
             throw new IllegalStateException("Cannot load doc values", e);
         }

--- a/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/index/fielddata/plain/LatLonShapeDVAtomicShapeFieldData.java
+++ b/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/index/fielddata/plain/LatLonShapeDVAtomicShapeFieldData.java
@@ -7,15 +7,12 @@
 
 package org.elasticsearch.xpack.spatial.index.fielddata.plain;
 
-import org.apache.lucene.index.BinaryDocValues;
 import org.apache.lucene.index.DocValues;
 import org.apache.lucene.index.LeafReader;
 import org.apache.lucene.util.Accountable;
 import org.elasticsearch.script.field.ToScriptFieldFactory;
-import org.elasticsearch.search.aggregations.support.ValuesSourceType;
 import org.elasticsearch.xpack.spatial.index.fielddata.GeoShapeValues;
 import org.elasticsearch.xpack.spatial.index.fielddata.LeafShapeFieldData;
-import org.elasticsearch.xpack.spatial.search.aggregations.support.GeoShapeValuesSourceType;
 
 import java.io.IOException;
 import java.util.Collection;
@@ -49,26 +46,7 @@ final class LatLonShapeDVAtomicShapeFieldData extends LeafShapeFieldData<GeoShap
     @Override
     public GeoShapeValues getShapeValues() {
         try {
-            final BinaryDocValues binaryValues = DocValues.getBinary(reader, fieldName);
-            final GeoShapeValues.GeoShapeValue geoShapeValue = new GeoShapeValues.GeoShapeValue();
-            return new GeoShapeValues() {
-
-                @Override
-                public boolean advanceExact(int doc) throws IOException {
-                    return binaryValues.advanceExact(doc);
-                }
-
-                @Override
-                public ValuesSourceType valuesSourceType() {
-                    return GeoShapeValuesSourceType.instance();
-                }
-
-                @Override
-                public GeoShapeValue value() throws IOException {
-                    geoShapeValue.reset(binaryValues.binaryValue());
-                    return geoShapeValue;
-                }
-            };
+            return new GeoShapeValues.BinaryDocData(DocValues.getBinary(reader, fieldName));
         } catch (IOException e) {
             throw new IllegalStateException("Cannot load doc values", e);
         }

--- a/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/search/aggregations/support/CartesianShapeValuesSourceType.java
+++ b/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/search/aggregations/support/CartesianShapeValuesSourceType.java
@@ -16,7 +16,6 @@ import org.elasticsearch.search.aggregations.support.AggregationContext;
 import org.elasticsearch.search.aggregations.support.FieldContext;
 import org.elasticsearch.search.aggregations.support.MissingValues;
 import org.elasticsearch.search.aggregations.support.ValuesSource;
-import org.elasticsearch.search.aggregations.support.ValuesSourceType;
 import org.elasticsearch.xpack.spatial.index.fielddata.CartesianShapeValues;
 import org.elasticsearch.xpack.spatial.index.fielddata.IndexCartesianPointFieldData;
 import org.elasticsearch.xpack.spatial.index.fielddata.IndexShapeFieldData;
@@ -68,34 +67,7 @@ public class CartesianShapeValuesSourceType extends ShapeValuesSourceType {
         return new CartesianShapeValuesSource() {
             @Override
             public CartesianShapeValues shapeValues(LeafReaderContext context) {
-                CartesianShapeValues values = shapeValuesSource.shapeValues(context);
-                return new CartesianShapeValues() {
-
-                    private boolean exists;
-
-                    @Override
-                    public boolean advanceExact(int doc) throws IOException {
-                        exists = values.advanceExact(doc);
-                        // always return true because we want to return a value even if
-                        // the document does not have a value
-                        return true;
-                    }
-
-                    @Override
-                    public ValuesSourceType valuesSourceType() {
-                        return values.valuesSourceType();
-                    }
-
-                    @Override
-                    public CartesianShapeValue value() throws IOException {
-                        return exists ? values.value() : missing;
-                    }
-
-                    @Override
-                    public String toString() {
-                        return "anon MultiShapeValues of [" + super.toString() + "]";
-                    }
-                };
+                return new CartesianShapeValues.Wrapped(shapeValuesSource.shapeValues(context), missing);
             }
 
             @Override

--- a/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/search/aggregations/support/GeoShapeValuesSourceType.java
+++ b/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/search/aggregations/support/GeoShapeValuesSourceType.java
@@ -17,7 +17,6 @@ import org.elasticsearch.search.aggregations.support.AggregationContext;
 import org.elasticsearch.search.aggregations.support.FieldContext;
 import org.elasticsearch.search.aggregations.support.MissingValues;
 import org.elasticsearch.search.aggregations.support.ValuesSource;
-import org.elasticsearch.search.aggregations.support.ValuesSourceType;
 import org.elasticsearch.xpack.spatial.index.fielddata.GeoShapeValues;
 import org.elasticsearch.xpack.spatial.index.fielddata.IndexShapeFieldData;
 import org.elasticsearch.xpack.spatial.index.fielddata.plain.LatLonShapeIndexFieldData;
@@ -68,34 +67,7 @@ public class GeoShapeValuesSourceType extends ShapeValuesSourceType {
         return new GeoShapeValuesSource() {
             @Override
             public GeoShapeValues shapeValues(LeafReaderContext context) {
-                GeoShapeValues values = shapeValuesSource.shapeValues(context);
-                return new GeoShapeValues() {
-
-                    private boolean exists;
-
-                    @Override
-                    public boolean advanceExact(int doc) throws IOException {
-                        exists = values.advanceExact(doc);
-                        // always return true because we want to return a value even if
-                        // the document does not have a value
-                        return true;
-                    }
-
-                    @Override
-                    public ValuesSourceType valuesSourceType() {
-                        return values.valuesSourceType();
-                    }
-
-                    @Override
-                    public GeoShapeValue value() throws IOException {
-                        return exists ? values.value() : missing;
-                    }
-
-                    @Override
-                    public String toString() {
-                        return "anon MultiShapeValues of [" + super.toString() + "]";
-                    }
-                };
+                return new GeoShapeValues.Wrapped(shapeValuesSource.shapeValues(context), missing);
             }
 
             @Override

--- a/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/search/aggregations/bucket/geogrid/GeoGridTilerTestCase.java
+++ b/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/search/aggregations/bucket/geogrid/GeoGridTilerTestCase.java
@@ -28,9 +28,10 @@ import org.elasticsearch.index.mapper.GeoShapeIndexer;
 import org.elasticsearch.indices.breaker.BreakerSettings;
 import org.elasticsearch.indices.breaker.CircuitBreakerService;
 import org.elasticsearch.indices.breaker.HierarchyCircuitBreakerService;
-import org.elasticsearch.search.aggregations.support.ValuesSourceType;
 import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xpack.spatial.index.fielddata.CoordinateEncoder;
 import org.elasticsearch.xpack.spatial.index.fielddata.GeoShapeValues;
+import org.elasticsearch.xpack.spatial.index.fielddata.ShapeValues;
 import org.elasticsearch.xpack.spatial.search.aggregations.support.GeoShapeValuesSourceType;
 import org.hamcrest.Matchers;
 
@@ -253,29 +254,39 @@ public abstract class GeoGridTilerTestCase extends ESTestCase {
     }
 
     protected GeoShapeValues makeGeoShapeValues(GeoShapeValues.GeoShapeValue... values) {
-        return new GeoShapeValues() {
-            int index = 0;
+        return new TestGeoShapeValues(values);
+    }
 
-            @Override
-            public boolean advanceExact(int doc) {
-                assertThat(index, Matchers.greaterThanOrEqualTo(doc));
-                if (doc < values.length) {
-                    index = doc;
-                    return true;
-                }
-                return false;
-            }
+    private static final class TestGeoShapeValues extends ShapeValues.ShapeValuesImpl<GeoShapeValues.GeoShapeValue>
+        implements
+            GeoShapeValues {
+        private final GeoShapeValue[] values;
+        int index = 0;
 
-            @Override
-            public ValuesSourceType valuesSourceType() {
-                return GeoShapeValuesSourceType.instance();
-            }
+        private TestGeoShapeValues(GeoShapeValues.GeoShapeValue[] values) {
+            super(
+                CoordinateEncoder.GEO,
+                GeoShapeValues.GeoShapeValue::new,
+                new GeoShapeIndexer(Orientation.CCW, "missing"),
+                GeoShapeValuesSourceType.instance()
+            );
+            this.values = values;
+        }
 
-            @Override
-            public GeoShapeValue value() {
-                return values[index];
+        @Override
+        public boolean advanceExact(int doc) {
+            assertThat(index, Matchers.greaterThanOrEqualTo(doc));
+            if (doc < values.length) {
+                index = doc;
+                return true;
             }
-        };
+            return false;
+        }
+
+        @Override
+        public GeoShapeValues.GeoShapeValue value() {
+            return values[index];
+        }
     }
 
     private static Geometry boxToGeo(GeoBoundingBox geoBox) {

--- a/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/search/aggregations/bucket/geogrid/GeoGridTilerTestCase.java
+++ b/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/search/aggregations/bucket/geogrid/GeoGridTilerTestCase.java
@@ -29,10 +29,8 @@ import org.elasticsearch.indices.breaker.BreakerSettings;
 import org.elasticsearch.indices.breaker.CircuitBreakerService;
 import org.elasticsearch.indices.breaker.HierarchyCircuitBreakerService;
 import org.elasticsearch.test.ESTestCase;
-import org.elasticsearch.xpack.spatial.index.fielddata.CoordinateEncoder;
 import org.elasticsearch.xpack.spatial.index.fielddata.GeoShapeValues;
 import org.elasticsearch.xpack.spatial.index.fielddata.ShapeValues;
-import org.elasticsearch.xpack.spatial.search.aggregations.support.GeoShapeValuesSourceType;
 import org.hamcrest.Matchers;
 
 import java.io.IOException;
@@ -264,12 +262,7 @@ public abstract class GeoGridTilerTestCase extends ESTestCase {
         int index = 0;
 
         private TestGeoShapeValues(GeoShapeValues.GeoShapeValue[] values) {
-            super(
-                CoordinateEncoder.GEO,
-                GeoShapeValues.GeoShapeValue::new,
-                new GeoShapeIndexer(Orientation.CCW, "missing"),
-                GeoShapeValuesSourceType.instance()
-            );
+            super(GeoShapeValues.DEFAULT_CONFIG);
             this.values = values;
         }
 


### PR DESCRIPTION
The PR at https://github.com/elastic/elasticsearch/pull/89216 included some work to de-duplicate code between Geo and Cartesian ShapeValues, to minimize risk of these two case bases drifting apart. However, we decided to pull that into a separate PR to simplify code review of the centroid aggregation work.

Since this PR is built on top of the work done in the other PR it initially contains all those commits. Once the centroid aggregation PR is merged, this PR should contain only the code de-duplication work.

Earlier work generalized GeoShapeValues so that all geo-specific code could
be injected, and there was no need for objects of type GeoShapeValues.
However, this advantage was not taken, and instances of GeoShapeValues, and
now also CartesianShapeValues, were being created with different behaviors
leading to a lot of duplicate code. This unnecessary duplication is now entirely
removed for the three common cases:

* Empty ShapeValues
* ShapeValues using BinaryDocValues (in ShapeValueSourceType classes)
* ShapeValues wrapping other ShapeValues and replacing missing values
