### PR TITLE
[Transform] Don't fail a transform due to ILM closing an index

### DIFF
--- a/docs/changelog/90396.yaml
+++ b/docs/changelog/90396.yaml
@@ -1,0 +1,6 @@
+pr: 90396
+summary: Don't fail a transform due to ILM closing an index
+area: Transform
+type: bug
+issues:
+ - 89802

--- a/docs/changelog/90396.yaml
+++ b/docs/changelog/90396.yaml
@@ -1,5 +1,5 @@
 pr: 90396
-summary: Don't fail a transform due to ILM closing an index
+summary: Don't fail a transform on a ClusterBlockException, this may be due to ILM closing an index
 area: Transform
 type: bug
 issues:


### PR DESCRIPTION
Transform can fail due to a ClusterBlockException that reports to be non-retryable. This is a special kind of race condition where the initial checks pass, but meanwhile between the check and the action something changes. In the particular case a wildcard index pattern got resolved to concrete index names. One of the indices got closed (ILM) before transform run the search operation. Pragmatically we should handle a cluster block exception as retry-able error.

fixes #89802