### PR TITLE
[8.5] [ML] Update `number_of_allocations` description in REST spec (#90413)

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/api/ml.start_trained_model_deployment.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/ml.start_trained_model_deployment.json
@@ -35,7 +35,7 @@
       },
       "number_of_allocations":{
         "type":"int",
-        "description": "The number of model allocations on each node where the model is deployed.",
+        "description": "The total number of allocations this model is assigned across machine learning nodes.",
         "required": false,
         "default": 1
       },


### PR DESCRIPTION
Backports the following commits to 8.5:
 - [ML] Update `number_of_allocations` description in REST spec (#90413)