### PR TITLE
Generate server resources on IDE import

### DIFF
--- a/build-tools-internal/src/main/groovy/elasticsearch.ide.gradle
+++ b/build-tools-internal/src/main/groovy/elasticsearch.ide.gradle
@@ -110,7 +110,9 @@ if (providers.systemProperty('idea.active').getOrNull() == 'true') {
     description = 'Builds artifacts needed as dependency for IDE modules'
     dependsOn ':client:rest-high-level:shadowJar',
       ':plugins:repository-hdfs:hadoop-client-api:shadowJar',
-      ':libs:elasticsearch-x-content:generateProviderImpl'
+      ':libs:elasticsearch-x-content:generateProviderImpl',
+      ':server:generateModulesList',
+      ':server:generatePluginsList'
   }
 
   idea {


### PR DESCRIPTION
The `:server` project generates some resource files with plugin/module information that is needed for some tests. To make it easier to run these in the IDE with the intellij platform runner we need these files generated on import.

Closes https://github.com/elastic/elasticsearch/issues/90390