### PR TITLE
[8.4] Generate server resources on IDE import (#90420)

### DIFF
--- a/build-tools-internal/src/main/groovy/elasticsearch.ide.gradle
+++ b/build-tools-internal/src/main/groovy/elasticsearch.ide.gradle
@@ -110,7 +110,9 @@ if (providers.systemProperty('idea.active').getOrNull() == 'true') {
     description = 'Builds artifacts needed as dependency for IDE modules'
     dependsOn ':client:rest-high-level:shadowJar',
       ':plugins:repository-hdfs:hadoop-client-api:shadowJar',
-      ':libs:elasticsearch-x-content:generateProviderImpl'
+      ':libs:elasticsearch-x-content:generateProviderImpl',
+      ':server:generateModulesList',
+      ':server:generatePluginsList'
   }
 
   idea {


### PR DESCRIPTION
Backports the following commits to 8.4:
 - Generate server resources on IDE import (#90420)