### PR TITLE
[8.4] [DOCS] Fix links to .NET and PHP clients (#90276)

### DIFF
--- a/x-pack/docs/en/security/ccs-clients-integrations/http.asciidoc
+++ b/x-pack/docs/en/security/ccs-clients-integrations/http.asciidoc
@@ -85,8 +85,8 @@ specific clients, refer to:
 
 * {java-api-client}/_basic_authentication.html[Java]
 * {jsclient-current}/auth-reference.html[JavaScript]
-* https://www.elastic.co/guide/en/elasticsearch/client/net-api/master/configuration-options.html[.NET]
+* {es-dotnet-client}/configuration.html[.NET]
 * https://metacpan.org/pod/Search::Elasticsearch::Cxn::HTTPTiny#CONFIGURATION[Perl]
-* https://www.elastic.co/guide/en/elasticsearch/client/php-api/master/security.html[PHP]
+* {es-php-client}/connecting.html[PHP]
 * https://elasticsearch-py.readthedocs.io/en/master/#ssl-and-authentication[Python]
 * https://github.com/elasticsearch/elasticsearch-ruby/tree/master/elasticsearch-transport#authentication[Ruby]


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.4`:
 - [[DOCS] Fix links to .NET and PHP clients (#90276)](https://github.com/elastic/elasticsearch/pull/90276)

<!--- Backport version: 8.9.4 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)