### PR TITLE
[Doc] Release notes for v8.4.3

### DIFF
--- a/docs/reference/release-notes.asciidoc
+++ b/docs/reference/release-notes.asciidoc
@@ -6,6 +6,7 @@
 
 This section summarizes the changes in each release.
 
+* <<release-notes-8.4.3>>
 * <<release-notes-8.4.2>>
 * <<release-notes-8.4.1>>
 * <<release-notes-8.4.0>>
@@ -31,6 +32,7 @@ This section summarizes the changes in each release.
 
 --
 
+include::release-notes/8.4.3.asciidoc[]
 include::release-notes/8.4.2.asciidoc[]
 include::release-notes/8.4.1.asciidoc[]
 include::release-notes/8.4.0.asciidoc[]

--- a/docs/reference/release-notes/8.4.3.asciidoc
+++ b/docs/reference/release-notes/8.4.3.asciidoc
@@ -11,7 +11,7 @@ Also see <<breaking-changes-8.4,Breaking changes in 8.4>>.
 
 Infra/Core::
 * Fix another potential race in the file settings watcher {es-pull}90302[#90302] (issue: {es-issue}89500[#89500])
-* Fix repeated error save loops in File Settings Service {es-pull}90271[#90271] (issue: {es-issue}90222[#90222])
+* Fix file permission errors to avoid repeated error save loops on Windows {es-pull}90271[#90271] (issue: {es-issue}90222[#90222])
 
 [[regression-8.4.3]]
 [float]

--- a/docs/reference/release-notes/8.4.3.asciidoc
+++ b/docs/reference/release-notes/8.4.3.asciidoc
@@ -10,7 +10,7 @@ Also see <<breaking-changes-8.4,Breaking changes in 8.4>>.
 === Bug fixes
 
 Infra/Core::
-* Fix another potential race in the file settings watcher {es-pull}90302[#90302] (issue: {es-issue}89500[#89500])
+* Fix potential race condition in the file settings watcher on Windows {es-pull}90302[#90302] (issue: {es-issue}89500[#89500])
 * Fix file permission errors to avoid repeated error save loops on Windows {es-pull}90271[#90271] (issue: {es-issue}90222[#90222])
 
 [[regression-8.4.3]]

--- a/docs/reference/release-notes/8.4.3.asciidoc
+++ b/docs/reference/release-notes/8.4.3.asciidoc
@@ -13,7 +13,7 @@ Infra/Core::
 * Fix file permission errors to avoid repeated error save loops on Windows {es-pull}90271[#90271] (issue: {es-issue}90222[#90222])
 
 Ingest Node::
-* Preventing serialization errors in the nodes stats API {es-pull}90319[#90319] (issue: {es-issue}77973[#77973])
+* Prevent serialization errors in the nodes stats API {es-pull}90319[#90319] (issue: {es-issue}77973[#77973])
 
 [[regression-8.4.3]]
 [float]

--- a/docs/reference/release-notes/8.4.3.asciidoc
+++ b/docs/reference/release-notes/8.4.3.asciidoc
@@ -13,6 +13,9 @@ Infra/Core::
 * Fix potential race condition in the file settings watcher on Windows {es-pull}90302[#90302] (issue: {es-issue}89500[#89500])
 * Fix file permission errors to avoid repeated error save loops on Windows {es-pull}90271[#90271] (issue: {es-issue}90222[#90222])
 
+Ingest Node::
+* Preventing serialization errors in the nodes stats API {es-pull}90319[#90319] (issue: {es-issue}77973[#77973])
+
 [[regression-8.4.3]]
 [float]
 === Regressions

--- a/docs/reference/release-notes/8.4.3.asciidoc
+++ b/docs/reference/release-notes/8.4.3.asciidoc
@@ -10,7 +10,6 @@ Also see <<breaking-changes-8.4,Breaking changes in 8.4>>.
 === Bug fixes
 
 Infra/Core::
-* Fix potential race condition in the file settings watcher on Windows {es-pull}90302[#90302] (issue: {es-issue}89500[#89500])
 * Fix file permission errors to avoid repeated error save loops on Windows {es-pull}90271[#90271] (issue: {es-issue}90222[#90222])
 
 Ingest Node::

--- a/docs/reference/release-notes/8.4.3.asciidoc
+++ b/docs/reference/release-notes/8.4.3.asciidoc
@@ -1,0 +1,23 @@
+[[release-notes-8.4.3]]
+== {es} version 8.4.3
+
+coming[8.4.3]
+
+Also see <<breaking-changes-8.4,Breaking changes in 8.4>>.
+
+[[bug-8.4.3]]
+[float]
+=== Bug fixes
+
+Infra/Core::
+* Fix another potential race in the file settings watcher {es-pull}90302[#90302] (issue: {es-issue}89500[#89500])
+* Fix repeated error save loops in File Settings Service {es-pull}90271[#90271] (issue: {es-issue}90222[#90222])
+
+[[regression-8.4.3]]
+[float]
+=== Regressions
+
+Ranking::
+* Ensure `cross_fields` always uses valid term statistics {es-pull}90314[#90314]
+
+

--- a/docs/reference/release-notes/highlights.asciidoc
+++ b/docs/reference/release-notes/highlights.asciidoc
@@ -125,6 +125,16 @@ the original documents, it's good enough for features like reindexing data.
 
 {es-pull}85649[#85649]
 
+[discrete]
+[[errors_with_cross_fields_query_type]]
+=== Errors with the `cross_fields` query type
+The 8.4.2 release introduced a bug that may fail queries that use the
+`cross_fields` type at search time with an error message containing
+`totalTermFreq must be at least docFreq`. Users of the `cross_fields` type
+are recommended to upgrade to 8.4.3 to avoid hitting this bug.
+
+{es-pull}90314[#90314]
+
 // end::notable-highlights[]
 
 

--- a/docs/reference/release-notes/highlights.asciidoc
+++ b/docs/reference/release-notes/highlights.asciidoc
@@ -128,10 +128,11 @@ the original documents, it's good enough for features like reindexing data.
 [discrete]
 [[errors_with_cross_fields_query_type]]
 === Errors with the `cross_fields` query type
-The 8.4.2 release introduced a bug that may fail queries that use the
+The {es} 8.4.2 release introduced a bug that may fail queries using the
 `cross_fields` type at search time with an error message containing
-`totalTermFreq must be at least docFreq`. Users of the `cross_fields` type
-are recommended to upgrade to 8.4.3 to avoid hitting this bug.
+`totalTermFreq must be at least docFreq`. If you run queries that use
+ the <<type-cross-fields,`cross_fields` type>>, we strongly recommend
+ upgrading to 8.4.3 to avoid hitting this bug.
 
 {es-pull}90314[#90314]
 

--- a/docs/reference/release-notes/highlights.asciidoc
+++ b/docs/reference/release-notes/highlights.asciidoc
@@ -33,7 +33,7 @@ from 250ms to 30ms.
 === Minimum conditions for the rollover API and ILM actions
 The rollover API and ILM actions now support minimum conditions for rollover.
 
-Minimum conditions prevent rollover from occuring until they are met. That is, an index
+Minimum conditions prevent rollover from occurring until they are met. That is, an index
 will rollover once one or more max conditions are satisfied and all min conditions are satisfied.
 
 As an example, the following ILM policy would roll an index over if it is at least 7 days old or
@@ -131,8 +131,9 @@ the original documents, it's good enough for features like reindexing data.
 The {es} 8.4.2 release introduced a bug that may fail queries using the
 `cross_fields` type at search time with an error message containing
 `totalTermFreq must be at least docFreq`. If you run queries that use
- the <<type-cross-fields,`cross_fields` type>>, we strongly recommend
- upgrading to 8.4.3 to avoid hitting this bug.
+the
+{ref}/query-dsl-multi-match-query.html#type-cross-fields[`cross_fields` type],
+we strongly recommend upgrading to 8.4.3 to avoid hitting this bug.
 
 {es-pull}90314[#90314]
 


### PR DESCRIPTION
Generated release notes and added highlights for 8.4.3 release.


Note: Command `./gradlew generateReleaseNotes` did not generate highlights (https://github.com/elastic/elasticsearch/pull/90398) for this patch release, so I had to manually add them.