### PR TITLE
[8.5] Fix flaky testCannotAllocateDueToLackOfDiskResourcesWithMaxHeadroom (#90386)

### DIFF
--- a/server/src/test/java/org/elasticsearch/cluster/routing/allocation/decider/DiskThresholdDeciderUnitTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/allocation/decider/DiskThresholdDeciderUnitTests.java
@@ -223,7 +223,7 @@ public class DiskThresholdDeciderUnitTests extends ESAllocationTestCase {
         Decision decision = decider.canAllocate(test_0, RoutingNodesHelper.routingNode("node_0", node_0), allocation);
         assertEquals(Decision.Type.NO, decision.type());
 
-        double usedPercentage = 100.0 * (totalBytes - freeBytes) / totalBytes;
+        double usedPercentage = 100.0 - (100.0 * freeBytes / totalBytes);
 
         assertThat(
             decision.getExplanation(),


### PR DESCRIPTION
Backports the following commits to 8.5:
 - Fix flaky testCannotAllocateDueToLackOfDiskResourcesWithMaxHeadroom (#90386)