### PR TITLE
[7.17] Allowing xpack.notification.email.account.domain_allowlist to be set dynamically (#90426)

### DIFF
--- a/docs/changelog/90426.yaml
+++ b/docs/changelog/90426.yaml
@@ -1,0 +1,6 @@
+pr: 90426
+summary: Allowing `xpack.notification.email.account.domain_allowlist` to be set dynamically
+area: Watcher
+type: bug
+issues:
+ - 89913

--- a/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/notification/email/EmailService.java
+++ b/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/notification/email/EmailService.java
@@ -193,7 +193,7 @@ public class EmailService extends NotificationService<Account> {
         clusterSettings.addAffixUpdateConsumer(SETTING_SMTP_SEND_PARTIAL, (s, o) -> {}, (s, o) -> {});
         clusterSettings.addAffixUpdateConsumer(SETTING_SMTP_WAIT_ON_QUIT, (s, o) -> {}, (s, o) -> {});
         this.allowedDomains = new HashSet<>(SETTING_DOMAIN_ALLOWLIST.get(settings));
-        clusterSettings.addSettingsUpdateConsumer(SETTING_DOMAIN_ALLOWLIST, (s) -> {});
+        clusterSettings.addSettingsUpdateConsumer(SETTING_DOMAIN_ALLOWLIST, this::updateAllowedDomains);
         // do an initial load
         reload(settings);
     }

--- a/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/notification/email/EmailServiceTests.java
+++ b/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/notification/email/EmailServiceTests.java
@@ -21,6 +21,8 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Properties;
 
+import javax.mail.MessagingException;
+
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.hasEntry;
@@ -262,6 +264,55 @@ public class EmailServiceTests extends ESTestCase {
                     + "[xpack.notification.email.account.domain_allowlist]."
             )
         );
+    }
+
+    public void testChangeDomainAllowListSetting() throws UnsupportedEncodingException, MessagingException {
+        Settings settings = Settings.builder()
+            .put("xpack.notification.email.account.account1.foo", "bar")
+            .put("xpack.notification.email.account.account1.smtp.host", "localhost")
+            .putList("xpack.notification.email.account.domain_allowlist", "bar.com")
+            .build();
+        ClusterSettings clusterSettings = new ClusterSettings(Settings.EMPTY, new HashSet<>(EmailService.getSettings()));
+        EmailService emailService = new EmailService(settings, null, mock(SSLService.class), clusterSettings);
+        Email email = new Email(
+            "id",
+            new Email.Address("foo@bar.com", "Mr. Foo Man"),
+            createAddressList("foo@bar.com", "baz@potato.com"),
+            randomFrom(Email.Priority.values()),
+            ZonedDateTime.now(),
+            createAddressList("foo@bar.com", "non-whitelisted@invalid.com"),
+            null,
+            null,
+            "subject",
+            "body",
+            "htmlbody",
+            Collections.emptyMap()
+        );
+        when(account.name()).thenReturn("account1");
+        Authentication auth = new Authentication("user", new Secret("passwd".toCharArray()));
+        Profile profile = randomFrom(Profile.values());
+
+        // This send will fail because one of the recipients ("non-whitelisted@invalid.com") is in a domain that is not in the allowed list
+        IllegalArgumentException e = expectThrows(
+            IllegalArgumentException.class,
+            () -> emailService.send(email, auth, profile, "account1")
+        );
+        assertThat(
+            e.getMessage(),
+            containsString(
+                "failed to send email with subject [subject] and recipient domains "
+                    + "[bar.com, invalid.com], one or more recipients is not specified in the domain allow list setting "
+                    + "[xpack.notification.email.account.domain_allowlist]."
+            )
+        );
+
+        // Now dynamically add "invalid.com" to the list of allowed domains:
+        Settings newSettings = Settings.builder()
+            .putList("xpack.notification.email.account.domain_allowlist", "bar.com", "invalid.com")
+            .build();
+        clusterSettings.applySettings(newSettings);
+        // Still expect an exception because we're not actually sending the email, but it's no longer because the domain isn't allowed:
+        expectThrows(MessagingException.class, () -> emailService.send(email, auth, profile, "account1"));
     }
 
     private static Email.AddressList createAddressList(String... emails) throws UnsupportedEncodingException {


### PR DESCRIPTION
Backports the following commits to 7.17:
 - Allowing xpack.notification.email.account.domain_allowlist to be set dynamically (#90426)