### PR TITLE
Mute InternalCartesianCentroidTests.testEqualsAndHashcode

### DIFF
--- a/test/framework/src/main/java/org/elasticsearch/test/AbstractWireTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/AbstractWireTestCase.java
@@ -53,7 +53,7 @@ public abstract class AbstractWireTestCase<T> extends ESTestCase {
      * Tests that the equals and hashcode methods are consistent and copied
      * versions of the instance are equal.
      */
-    public final void testEqualsAndHashcode() {
+    public void testEqualsAndHashcode() {
         for (int runs = 0; runs < NUMBER_OF_TEST_RUNS; runs++) {
             EqualsHashCodeTestUtils.checkEqualsAndHashCode(createTestInstance(), this::copyInstance, this::mutateInstance);
         }

--- a/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/search/aggregations/metrics/InternalCartesianCentroidTests.java
+++ b/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/search/aggregations/metrics/InternalCartesianCentroidTests.java
@@ -94,6 +94,13 @@ public class InternalCartesianCentroidTests extends InternalAggregationTestCase<
         assertEquals(sampled.count(), samplingContext.scaleUp(reduced.count()), 0);
     }
 
+    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/90474")
+    @Override
+    public void testEqualsAndHashcode() {
+        // TODO: When this issue is fixed, remove this method and set the parent method back to final
+        super.testEqualsAndHashcode();
+    }
+
     public void testReduceMaxCount() {
         InternalCartesianCentroid maxValueCentroid = new InternalCartesianCentroid(
             "agg",


### PR DESCRIPTION
See https://github.com/elastic/elasticsearch/issues/90474