### PR TITLE
[7.17] Changing EmailServiceTests to use an impossible SMTP server to avoid accidentally sending email (#90469)

### DIFF
--- a/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/notification/email/EmailServiceTests.java
+++ b/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/notification/email/EmailServiceTests.java
@@ -269,7 +269,9 @@ public class EmailServiceTests extends ESTestCase {
     public void testChangeDomainAllowListSetting() throws UnsupportedEncodingException, MessagingException {
         Settings settings = Settings.builder()
             .put("xpack.notification.email.account.account1.foo", "bar")
-            .put("xpack.notification.email.account.account1.smtp.host", "localhost")
+            // Setting a random SMTP server name and an invalid port so that sending emails is guaranteed to fail:
+            .put("xpack.notification.email.account.account1.smtp.host", randomAlphaOfLength(10))
+            .put("xpack.notification.email.account.account1.smtp.port", -100)
             .putList("xpack.notification.email.account.domain_allowlist", "bar.com")
             .build();
         ClusterSettings clusterSettings = new ClusterSettings(Settings.EMPTY, new HashSet<>(EmailService.getSettings()));
@@ -293,12 +295,12 @@ public class EmailServiceTests extends ESTestCase {
         Profile profile = randomFrom(Profile.values());
 
         // This send will fail because one of the recipients ("non-whitelisted@invalid.com") is in a domain that is not in the allowed list
-        IllegalArgumentException e = expectThrows(
+        IllegalArgumentException e1 = expectThrows(
             IllegalArgumentException.class,
             () -> emailService.send(email, auth, profile, "account1")
         );
         assertThat(
-            e.getMessage(),
+            e1.getMessage(),
             containsString(
                 "failed to send email with subject [subject] and recipient domains "
                     + "[bar.com, invalid.com], one or more recipients is not specified in the domain allow list setting "
@@ -312,7 +314,11 @@ public class EmailServiceTests extends ESTestCase {
             .build();
         clusterSettings.applySettings(newSettings);
         // Still expect an exception because we're not actually sending the email, but it's no longer because the domain isn't allowed:
-        expectThrows(MessagingException.class, () -> emailService.send(email, auth, profile, "account1"));
+        IllegalArgumentException e2 = expectThrows(
+            IllegalArgumentException.class,
+            () -> emailService.send(email, auth, profile, "account1")
+        );
+        assertThat(e2.getMessage(), containsString("port out of range"));
     }
 
     private static Email.AddressList createAddressList(String... emails) throws UnsupportedEncodingException {


### PR DESCRIPTION
Backports the following commits to 7.17:
 - Changing EmailServiceTests to use an impossible SMTP server to avoid accidentally sending email (#90469)