### PR TITLE
Disable packaging tests for arm ironbank docker image

### DIFF
--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/test/DistroTestPlugin.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/test/DistroTestPlugin.java
@@ -393,6 +393,10 @@ public class DistroTestPlugin implements Plugin<Project> {
                             continue;
                         }
                     }
+                    if (type == DOCKER_IRONBANK && architecture == Architecture.AARCH64) {
+                        // We don't produce an ARM IronBank Image
+                        continue;
+                    }
                     currentDistros.add(
                         createDistro(distributions, architecture, type, null, bundledJdk, VersionProperties.getElasticsearch())
                     );


### PR DESCRIPTION
We've removed the ARM IronBank docker project (since we don't produce such an image). This pull request also ensures we don't attempt to run packaging tests against this missing distribution.

Closes https://github.com/elastic/elasticsearch/issues/90449