### PR TITLE
Set the enrich maintenance cluster lifecycle listener only once

### DIFF
--- a/docs/changelog/90486.yaml
+++ b/docs/changelog/90486.yaml
@@ -1,0 +1,5 @@
+pr: 90486
+summary: Set the enrich maintenance cluster lifecycle listener only once
+area: Ingest Node
+type: bug
+issues: []


### PR DESCRIPTION
The enrich maintenance task listens for updates to the master node, activating and deactivating itself as needed. Every time the maintenance task is activated on the elected master, it sets a lifecycle listener. This can leak multiple listeners if a node is elected master multiple times. 

This PR updates the code to only set the enrich maintenance task's lifecycle listener one time when it is first activated.