### PR TITLE
Run enrich maintenance tasks using current cluster state

### DIFF
--- a/docs/changelog/90487.yaml
+++ b/docs/changelog/90487.yaml
@@ -1,0 +1,5 @@
+pr: 90487
+summary: Run enrich maintenance tasks using current cluster state
+area: Ingest Node
+type: enhancement
+issues: []


### PR DESCRIPTION
The enrich maintenance task looks at all enrich system indices and cleans up any that are misconfigured, malformed, or not linked to the enrich alias. A policy execution creates and populates a new enrich index, a process that can take a substantial amount of time. To keep the maintenance task from deleting a new enrich index while it is being prepared, the maintenance task must acquire a write lock before it is allowed to continue. 

One problem here is that the write lock is not held for the entire maintenance operation because there are multiple asynchronous steps (getting the indices and deleting them). To get around that, the state of the policy locks is checked in between async calls, but even this state gathering can be non-thread safe due to the usage of the concurrent map's size method.

The maintenance task is now simplified to only run one async operation - the index delete. Indices are now collected directly from the local cluster state instead of the get index action. This allows the maintenance task to hold the write lock for the entire critical section instead of checking for state changes.