### PR TITLE
Use explicit CLI option for enabling transport layer TLS

### DIFF
--- a/build-tools-internal/src/main/groovy/elasticsearch.run-ccs.gradle
+++ b/build-tools-internal/src/main/groovy/elasticsearch.run-ccs.gradle
@@ -13,6 +13,7 @@ boolean proxyMode = Boolean.valueOf(providers.systemProperty('proxyMode').getOrE
 def fulfillingCluster = testClusters.register('fulfilling-cluster') {
   testDistribution = providers.systemProperty('run.distribution').orElse('default').get()
 
+  setting 'xpack.security.enabled', 'true'
   setting 'xpack.watcher.enabled', 'false'
   setting 'xpack.ml.enabled', 'false'
   setting 'xpack.license.self_generated.type', 'trial'
@@ -23,6 +24,7 @@ def fulfillingCluster = testClusters.register('fulfilling-cluster') {
 def queryingCluster = testClusters.register('querying-cluster') {
   testDistribution = providers.systemProperty('run.distribution').orElse('default').get()
 
+  setting 'xpack.security.enabled', 'true'
   setting 'xpack.watcher.enabled', 'false'
   setting 'xpack.ml.enabled', 'false'
   setting 'xpack.license.self_generated.type', 'trial'

--- a/build-tools/src/main/java/org/elasticsearch/gradle/testclusters/RunTask.java
+++ b/build-tools/src/main/java/org/elasticsearch/gradle/testclusters/RunTask.java
@@ -49,7 +49,7 @@ public class RunTask extends DefaultTestClustersTask {
 
     private Boolean useHttps = false;
 
-    private Boolean useTransportHttps = false;
+    private Boolean useTransportTls = false;
 
     private final Path tlsBasePath = Path.of(
         new File(getProject().getRootDir(), "build-tools-internal/src/main/resources/run.ssl").toURI()
@@ -111,15 +111,15 @@ public class RunTask extends DefaultTestClustersTask {
         return useHttps;
     }
 
-    @Option(option = "transport-https", description = "Helper option to enable HTTPS on transport port")
-    public void setUseTransportHttps(boolean useTransportHttps) {
-        this.useTransportHttps = useTransportHttps;
+    @Option(option = "transport-tls", description = "Helper option to enable TLS on transport port")
+    public void setUseTransportTls(boolean useTransportTls) {
+        this.useTransportTls = useTransportTls;
     }
 
     @Input
     @Optional
-    public Boolean getUseTransportHttps() {
-        return useTransportHttps;
+    public Boolean getUseTransportTls() {
+        return useTransportTls;
     }
 
     @Override
@@ -164,7 +164,7 @@ public class RunTask extends DefaultTestClustersTask {
                     node.setting("xpack.security.http.ssl.keystore.path", "https.keystore");
                     node.setting("xpack.security.http.ssl.certificate_authorities", "https.ca");
                 }
-                if (useTransportHttps) {
+                if (useTransportTls) {
                     node.setting("xpack.security.transport.ssl.enabled", "true");
                     node.setting("xpack.security.transport.ssl.client_authentication", "required");
                     node.extraConfigFile("transport.keystore", tlsBasePath.resolve(transportCertificate).toFile());

--- a/build-tools/src/main/java/org/elasticsearch/gradle/testclusters/RunTask.java
+++ b/build-tools/src/main/java/org/elasticsearch/gradle/testclusters/RunTask.java
@@ -49,8 +49,10 @@ public class RunTask extends DefaultTestClustersTask {
 
     private Boolean useHttps = false;
 
+    private Boolean useTransportHttps = false;
+
     private final Path tlsBasePath = Path.of(
-        new File(getProject().getProjectDir(), "build-tools-internal/src/main/resources/run.ssl").toURI()
+        new File(getProject().getRootDir(), "build-tools-internal/src/main/resources/run.ssl").toURI()
     );
 
     @Option(option = "debug-jvm", description = "Enable debugging configuration, to allow attaching a debugger to elasticsearch.")
@@ -109,6 +111,17 @@ public class RunTask extends DefaultTestClustersTask {
         return useHttps;
     }
 
+    @Option(option = "transport-https", description = "Helper option to enable HTTPS on transport port")
+    public void setUseTransportHttps(boolean useTransportHttps) {
+        this.useTransportHttps = useTransportHttps;
+    }
+
+    @Input
+    @Optional
+    public Boolean getUseTransportHttps() {
+        return useTransportHttps;
+    }
+
     @Override
     public void beforeStart() {
         int httpPort = 9200;
@@ -151,7 +164,7 @@ public class RunTask extends DefaultTestClustersTask {
                     node.setting("xpack.security.http.ssl.keystore.path", "https.keystore");
                     node.setting("xpack.security.http.ssl.certificate_authorities", "https.ca");
                 }
-                if (findConfiguredSettingsByPrefix("xpack.security.transport.ssl", node).isEmpty()) {
+                if (useTransportHttps) {
                     node.setting("xpack.security.transport.ssl.enabled", "true");
                     node.setting("xpack.security.transport.ssl.client_authentication", "required");
                     node.extraConfigFile("transport.keystore", tlsBasePath.resolve(transportCertificate).toFile());


### PR DESCRIPTION
Enabling transport layer TLS by default can disrupt certain `RunTask` usage scenarios because the certificate files are not available. While we address that, we'll put this behind an explicit flag.