### PR TITLE
Don't print global build info header in included builds

### DIFF
--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/info/GlobalBuildInfoPlugin.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/info/GlobalBuildInfoPlugin.java
@@ -12,6 +12,7 @@ import org.elasticsearch.gradle.internal.BwcVersions;
 import org.elasticsearch.gradle.internal.conventions.info.GitInfo;
 import org.elasticsearch.gradle.internal.conventions.info.ParallelDetector;
 import org.elasticsearch.gradle.internal.conventions.util.Util;
+import org.elasticsearch.gradle.util.GradleUtils;
 import org.gradle.api.Action;
 import org.gradle.api.GradleException;
 import org.gradle.api.JavaVersion;
@@ -123,7 +124,10 @@ public class GlobalBuildInfoPlugin implements Plugin<Project> {
         assertMinimumCompilerVersion(minimumCompilerVersion);
 
         // Print global build info header just before task execution
-        project.getGradle().getTaskGraph().whenReady(graph -> logGlobalBuildInfo());
+        // Only do this if we are the root build of a composite
+        if (GradleUtils.isIncludedBuild(project) == false) {
+            project.getGradle().getTaskGraph().whenReady(graph -> logGlobalBuildInfo());
+        }
     }
 
     private Provider<MetadataBasedToolChainMatcher> resolveToolchainSpecFromEnv() {

--- a/build-tools/src/main/java/org/elasticsearch/gradle/util/GradleUtils.java
+++ b/build-tools/src/main/java/org/elasticsearch/gradle/util/GradleUtils.java
@@ -219,4 +219,15 @@ public abstract class GradleUtils {
     public static String projectPath(String taskPath) {
         return taskPath.lastIndexOf(':') == 0 ? ":" : taskPath.substring(0, taskPath.lastIndexOf(':'));
     }
+
+    /**
+     * Determine if the given {@link Project} is part of a composite included build. Returns {@code false} for any projects that belong
+     * to the root "outer" build of a composite.
+     *
+     * @param project the current project
+     * @return true if the project is an included build
+     */
+    public static boolean isIncludedBuild(Project project) {
+        return project.getGradle().getParent() == null;
+    }
 }


### PR DESCRIPTION
When including a build which applies the global build info plugin in a composite we don't want to print this header out. It's like that a) it's non-applicable to the outer build, or b) the outer build will also apply this plugin resulting in duplicate output.