### PR TITLE
[8.5] Move user profile status to stable and private (#90439)

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/api/security.activate_user_profile.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/security.activate_user_profile.json
@@ -4,7 +4,7 @@
       "url":"https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-activate-user-profile.html",
       "description":"Creates or updates the user profile on behalf of another user."
     },
-    "stability":"experimental",
+    "stability":"stable",
     "visibility":"private",
     "headers":{
       "accept": [ "application/json"],

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/security.disable_user_profile.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/security.disable_user_profile.json
@@ -4,7 +4,7 @@
       "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-disable-user-profile.html",
       "description":"Disables a user profile so it's not visible in user profile searches."
     },
-    "stability":"experimental",
+    "stability":"stable",
     "visibility":"private",
     "headers":{
       "accept": [ "application/json"]

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/security.enable_user_profile.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/security.enable_user_profile.json
@@ -4,7 +4,7 @@
       "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-enable-user-profile.html",
       "description":"Enables a user profile so it's visible in user profile searches."
     },
-    "stability":"experimental",
+    "stability":"stable",
     "visibility":"private",
     "headers":{
       "accept": [ "application/json"]

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/security.get_user_profile.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/security.get_user_profile.json
@@ -4,7 +4,7 @@
       "url":"https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-get-user-profile.html",
       "description":"Retrieves user profiles for the given unique ID(s)."
     },
-    "stability":"experimental",
+    "stability":"stable",
     "visibility":"private",
     "headers":{
       "accept": [ "application/json"]

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/security.has_privileges_user_profile.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/security.has_privileges_user_profile.json
@@ -4,7 +4,7 @@
       "url":"https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-has-privileges-user-profile.html",
       "description":"Determines whether the users associated with the specified profile IDs have all the requested privileges."
     },
-    "stability":"experimental",
+    "stability":"stable",
     "visibility":"private",
     "headers":{
       "accept": [ "application/json"],

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/security.suggest_user_profiles.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/security.suggest_user_profiles.json
@@ -4,7 +4,7 @@
       "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-suggest-user-profile.html",
       "description":"Get suggestions for user profiles that match specified search criteria."
     },
-    "stability":"experimental",
+    "stability":"stable",
     "visibility":"private",
     "headers":{
       "accept": [ "application/json"],

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/security.update_user_profile_data.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/security.update_user_profile_data.json
@@ -4,7 +4,7 @@
       "url":"https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-update-user-profile-data.html",
       "description":"Update application specific data for the user profile of the given unique ID."
     },
-    "stability":"experimental",
+    "stability":"stable",
     "visibility":"private",
     "headers":{
       "accept": [ "application/json"],

--- a/x-pack/docs/en/rest-api/security/activate-user-profile.asciidoc
+++ b/x-pack/docs/en/rest-api/security/activate-user-profile.asciidoc
@@ -5,7 +5,10 @@
 <titleabbrev>Activate user profile</titleabbrev>
 ++++
 
-beta::[]
+NOTE: The user profile feature is designed only for use by {kib} and
+Elastic’s {observability}, {ents}, and {elastic-sec} solutions. Individual
+users and external applications should not call this API directly. Elastic reserves
+the right to change or remove this feature in future releases without prior notice.
 
 Creates or updates a user profile on behalf of another user.
 

--- a/x-pack/docs/en/rest-api/security/disable-user-profile.asciidoc
+++ b/x-pack/docs/en/rest-api/security/disable-user-profile.asciidoc
@@ -5,7 +5,10 @@
 <titleabbrev>Disable user profile</titleabbrev>
 ++++
 
-beta::[]
+NOTE: The user profile feature is designed only for use by {kib} and
+Elastic’s {observability}, {ents}, and {elastic-sec} solutions. Individual
+users and external applications should not call this API directly. Elastic reserves
+the right to change or remove this feature in future releases without prior notice.
 
 Disables a user profile so it's not visible in
 <<security-api-suggest-user-profile,user profile searches>>.

--- a/x-pack/docs/en/rest-api/security/enable-user-profile.asciidoc
+++ b/x-pack/docs/en/rest-api/security/enable-user-profile.asciidoc
@@ -5,7 +5,10 @@
 <titleabbrev>Enable user profile</titleabbrev>
 ++++
 
-beta::[]
+NOTE: The user profile feature is designed only for use by {kib} and
+Elastic’s {observability}, {ents}, and {elastic-sec} solutions. Individual
+users and external applications should not call this API directly. Elastic reserves
+the right to change or remove this feature in future releases without prior notice.
 
 Enables a user profile so it's visible in
 <<security-api-suggest-user-profile,user profile searches>>.

--- a/x-pack/docs/en/rest-api/security/get-user-profile.asciidoc
+++ b/x-pack/docs/en/rest-api/security/get-user-profile.asciidoc
@@ -5,7 +5,10 @@
 <titleabbrev>Get user profiles</titleabbrev>
 ++++
 
-beta::[]
+NOTE: The user profile feature is designed only for use by {kib} and
+Elastic’s {observability}, {ents}, and {elastic-sec} solutions. Individual
+users and external applications should not call this API directly. Elastic reserves
+the right to change or remove this feature in future releases without prior notice.
 
 Retrieves user profiles using a list of unique profile ID.
 

--- a/x-pack/docs/en/rest-api/security/has-privileges-user-profile.asciidoc
+++ b/x-pack/docs/en/rest-api/security/has-privileges-user-profile.asciidoc
@@ -4,9 +4,11 @@
 ++++
 <titleabbrev>Has privileges user profile</titleabbrev>
 ++++
-[[security-api-has-privileges-user-profile]]
 
-beta::[]
+NOTE: The user profile feature is designed only for use by {kib} and
+Elastic’s {observability}, {ents}, and {elastic-sec} solutions. Individual
+users and external applications should not call this API directly. Elastic reserves
+the right to change or remove this feature in future releases without prior notice.
 
 Determines whether the users associated with the specified <<user-profile, user profile>> IDs
 have all the requested privileges.

--- a/x-pack/docs/en/rest-api/security/suggest-user-profile.asciidoc
+++ b/x-pack/docs/en/rest-api/security/suggest-user-profile.asciidoc
@@ -5,7 +5,10 @@
 <titleabbrev>Suggest user profile</titleabbrev>
 ++++
 
-beta::[]
+NOTE: The user profile feature is designed only for use by {kib} and
+Elastic’s {observability}, {ents}, and {elastic-sec} solutions. Individual
+users and external applications should not call this API directly. Elastic reserves
+the right to change or remove this feature in future releases without prior notice.
 
 Get suggestions for user profiles that match specified search criteria.
 

--- a/x-pack/docs/en/rest-api/security/update-user-profile-data.asciidoc
+++ b/x-pack/docs/en/rest-api/security/update-user-profile-data.asciidoc
@@ -5,7 +5,10 @@
 <titleabbrev>Update user profile data</titleabbrev>
 ++++
 
-beta::[]
+NOTE: The user profile feature is designed only for use by {kib} and
+Elastic’s {observability}, {ents}, and {elastic-sec} solutions. Individual
+users and external applications should not call this API directly. Elastic reserves
+the right to change or remove this feature in future releases without prior notice.
 
 Updates specific data for the user profile that's associated with the specified
 unique ID.

--- a/x-pack/docs/en/security/authentication/security-domain.asciidoc
+++ b/x-pack/docs/en/security/authentication/security-domain.asciidoc
@@ -2,8 +2,6 @@
 [[security-domain]]
 === Security domains
 
-beta::[]
-
 Security domains are a method of grouping multiple <<realms,realms>> under the
 same domain so that the {stack} can recognize when a single user authenticates
 with these realms. Users can authenticate with any of the realms in the domain

--- a/x-pack/docs/en/security/authentication/user-profile.asciidoc
+++ b/x-pack/docs/en/security/authentication/user-profile.asciidoc
@@ -2,7 +2,10 @@
 [[user-profile]]
 === User profiles
 
-beta::[]
+NOTE: The user profile feature is designed only for use by {kib} and
+Elastic’s {observability}, {ents}, and {elastic-sec} solutions. Individual
+users and external applications should not call this API directly. Elastic reserves
+the right to change or remove this feature in future releases without prior notice.
 
 Because the {stack} supports externally-managed users (such as users who
 authenticate via SAML, or users stored in an LDAP directory), there's a


### PR DESCRIPTION
Backports the following commits to 8.5:
 - Move user profile status to stable and private (#90439)