### PR TITLE
Add fields to fix logstash cgroup graphs

### DIFF
--- a/docs/changelog/90493.yaml
+++ b/docs/changelog/90493.yaml
@@ -1,0 +1,5 @@
+pr: 90493
+summary: Add fields to fix logstash cgroup graphs
+area: Monitoring
+type: bug
+issues: []

--- a/x-pack/plugin/core/src/main/resources/monitoring-logstash-mb.json
+++ b/x-pack/plugin/core/src/main/resources/monitoring-logstash-mb.json
@@ -192,6 +192,9 @@
                                       "type": "long"
                                     }
                                   }
+                                },
+                                "cfs_quota_micros": {
+                                  "type": "long"
                                 }
                               }
                             },
@@ -393,22 +396,6 @@
               "properties": {
                 "cpu": {
                   "properties": {
-                    "stat": {
-                      "properties": {
-                        "number_of_elapsed_periods": {
-                          "path": "logstash.node.stats.os.cgroup.cpu.stat.number_of_elapsed_periods",
-                          "type": "alias"
-                        },
-                        "number_of_times_throttled": {
-                          "path": "logstash.node.stats.os.cgroup.cpu.stat.number_of_times_throttled",
-                          "type": "alias"
-                        },
-                        "time_throttled_nanos": {
-                          "path": "logstash.node.stats.os.cgroup.cpu.stat.time_throttled_nanos",
-                          "type": "alias"
-                        }
-                      }
-                    },
                     "load_average": {
                       "properties": {
                         "5m": {
@@ -433,6 +420,30 @@
                       "properties": {
                         "usage_nanos": {
                           "path": "logstash.node.stats.os.cgroup.cpuacct.usage_nanos",
+                          "type": "alias"
+                        }
+                      }
+                    },
+                    "cpu": {
+                      "properties": {
+                        "stat": {
+                          "properties": {
+                            "number_of_elapsed_periods": {
+                              "path": "logstash.node.stats.os.cgroup.cpu.stat.number_of_elapsed_periods",
+                              "type": "alias"
+                            },
+                            "number_of_times_throttled": {
+                              "path": "logstash.node.stats.os.cgroup.cpu.stat.number_of_times_throttled",
+                              "type": "alias"
+                            },
+                            "time_throttled_nanos": {
+                              "path": "logstash.node.stats.os.cgroup.cpu.stat.time_throttled_nanos",
+                              "type": "alias"
+                            }
+                          }
+                        },
+                        "cfs_quota_micros": {
+                          "path": "logstash.node.stats.os.cgroup.cpu.cfs_quota_micros",
                           "type": "alias"
                         }
                       }

--- a/x-pack/plugin/core/src/main/resources/monitoring-logstash.json
+++ b/x-pack/plugin/core/src/main/resources/monitoring-logstash.json
@@ -204,6 +204,9 @@
                               "type": "long"
                             }
                           }
+                        },
+                        "cfs_quota_micros": {
+                          "type": "long"
                         }
                       }
                     }


### PR DESCRIPTION
Fixes https://github.com/elastic/kibana/issues/142179

- Add cfs_quota_micros
- Fixes incorrectly-located cgroup stat aliases

## Testing

See https://github.com/elastic/kibana/issues/142179 for details, requires beats main to test end-to-end.