### PR TITLE
Fix logstash loadavg (xpack cases)

### DIFF
--- a/docs/changelog/90494.yaml
+++ b/docs/changelog/90494.yaml
@@ -1,0 +1,5 @@
+pr: 90494
+summary: Fix logstash loadavg (xpack cases)
+area: Monitoring
+type: bug
+issues: []

--- a/docs/changelog/90494.yaml
+++ b/docs/changelog/90494.yaml
@@ -10,6 +10,7 @@ highlight:
 
     The type has been corrected to `half_float`. You can force a rollover to see the change immediately or wait for the next ILM rollover.
 
-    ```
+    [source,console]
+    ----
     POST .monitoring-logstash-8-mb/_rollover
-    ```
+    ----

--- a/docs/changelog/90494.yaml
+++ b/docs/changelog/90494.yaml
@@ -3,3 +3,13 @@ summary: Fix logstash loadavg (xpack cases)
 area: Monitoring
 type: bug
 issues: []
+highlight:
+  title: "Stack Monitoring: Logstash load average type fixed for metricbeat collection"
+  body: |-
+    Previously, the templates for ingesting logstash load average using metricbeat were set to `long`. This provides only an integer graph.
+
+    The type has been corrected to `half_float`. You can force a rollover to see the change immediately or wait for the next ILM rollover.
+
+    ```
+    POST .monitoring-logstash-8-mb/_rollover
+    ```

--- a/x-pack/plugin/core/src/main/resources/monitoring-logstash-mb.json
+++ b/x-pack/plugin/core/src/main/resources/monitoring-logstash-mb.json
@@ -164,13 +164,13 @@
                             "load_average": {
                               "properties": {
                                 "5m": {
-                                  "type": "long"
+                                  "type": "half_float"
                                 },
                                 "15m": {
-                                  "type": "long"
+                                  "type": "half_float"
                                 },
                                 "1m": {
-                                  "type": "long"
+                                  "type": "half_float"
                                 }
                               }
                             }

--- a/x-pack/plugin/core/src/main/resources/monitoring-logstash-mb.json
+++ b/x-pack/plugin/core/src/main/resources/monitoring-logstash-mb.json
@@ -146,10 +146,10 @@
                               "type": "nested",
                               "properties": {
                                 "name": {
-                                    "type": "keyword"
+                                  "type": "keyword"
                                 },
                                 "value": {
-                                    "type": "long"
+                                  "type": "long"
                                 }
                               }
                             }

--- a/x-pack/plugin/core/src/main/resources/monitoring-logstash.json
+++ b/x-pack/plugin/core/src/main/resources/monitoring-logstash.json
@@ -271,7 +271,7 @@
                     "out": {
                       "type": "long"
                     },
-                    "duration_in_millis":{
+                    "duration_in_millis": {
                       "type": "long"
                     },
                     "queue_push_duration_in_millis": {
@@ -301,11 +301,21 @@
                     "id": {
                       "type": "keyword"
                     },
-                    "pipeline_ephemeral_id": { "type": "keyword" },
-                    "events_in": { "type": "long" },
-                    "events_out": { "type": "long" },
-                    "duration_in_millis": { "type": "long" },
-                    "queue_push_duration_in_millis": { "type": "long" },
+                    "pipeline_ephemeral_id": {
+                      "type": "keyword"
+                    },
+                    "events_in": {
+                      "type": "long"
+                    },
+                    "events_out": {
+                      "type": "long"
+                    },
+                    "duration_in_millis": {
+                      "type": "long"
+                    },
+                    "queue_push_duration_in_millis": {
+                      "type": "long"
+                    },
                     "long_counters": {
                       "type": "nested",
                       "properties": {


### PR DESCRIPTION
Fixes https://github.com/elastic/kibana/issues/142181

Discovered while working on https://github.com/elastic/kibana/issues/142179

The initial -mb indices had these types listed as long which caused load average graphs to only show integer values.

This change allows expected system load values to carry through.

![Screen Shot 2022-09-29 at 15 15 29](https://user-images.githubusercontent.com/690/192953430-2dc460ed-5820-4780-9640-88f61cc524cb.png)

Beats ingests the data as `interface{}` so no code-level changes are required for beats for this to work, but I'll open a related PR to fix the fields.yml to match for non-xpack cases.

## Testing

1. Follow https://github.com/elastic/kibana/blob/main/x-pack/plugins/monitoring/dev_docs/how_to/running_components_from_source.md to launch ES from source and a standalone logstash container monitored with metricbeat
2. Check the load average graphs for logstash nodes
3. Generate a bit of load on the host OS for the logstash instance

Optionally, do the same without this change to see the integer-only graphs

