### PR TITLE
More opinionated docs about http.max_content_length

### DIFF
--- a/docs/reference/docs/bulk.asciidoc
+++ b/docs/reference/docs/bulk.asciidoc
@@ -110,10 +110,14 @@ something similar on the client side, and reduce buffering as much as
 possible.
 
 There is no "correct" number of actions to perform in a single bulk request.
-Experiment with different settings to find the optimal size for your particular workload.
-
-When using the HTTP API, make sure that the client does not send HTTP chunks,
-as this will slow things down.
+Experiment with different settings to find the optimal size for your particular
+workload. Note that {es} limits the maximum size of a HTTP request to `100mb`
+by default so clients must ensure that no request exceeds this size. It is not
+possible to index a single document which exceeds the size limit, so you must
+pre-process any such documents into smaller pieces before sending them to {es}.
+For instance, split documents into pages or chapters before indexing them, or
+store raw binary data in a system outside {es} and replacing the raw data with
+a link to the external system in the documents that you send to {es}.
 
 [discrete]
 [[bulk-clients]]

--- a/docs/reference/modules/http.asciidoc
+++ b/docs/reference/modules/http.asciidoc
@@ -43,7 +43,14 @@ Configure this setting only if you need the publish port to be different from
 
 `http.max_content_length`::
 (<<static-cluster-setting,Static>>, <<byte-units,byte value>>)
-Maximum size of an HTTP request body. Defaults to `100mb`.
+Maximum size of an HTTP request body. Defaults to `100mb`. Configuring this
+setting to greater than `100mb` can cause cluster instability and is not
+recommended. If you hit this limit when sending a request to the <<docs-bulk>>
+API, configure your client to send fewer documents in each bulk request. If you
+wish to index individual documents that exceed `100mb`, pre-process them into
+smaller documents before sending them to {es}. For instance, store the raw data
+in a system outside {es} and include a link to the raw data in the documents
+that {es} indexes.
 
 `http.max_initial_line_length`::
 (<<static-cluster-setting,Static>>, <<byte-units,byte value>>)


### PR DESCRIPTION
Adds to the docs a note that the `100mb` default for `http.max_content_length` is the recommended maximum, along with suggestions for what to do when hitting this limit.