### PR TITLE
Add default index for storing relevance settings

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ClientHelper.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ClientHelper.java
@@ -189,6 +189,7 @@ public final class ClientHelper {
     public static final String SEARCHABLE_SNAPSHOTS_ORIGIN = "searchable_snapshots";
     public static final String LOGSTASH_MANAGEMENT_ORIGIN = "logstash_management";
     public static final String FLEET_ORIGIN = "fleet";
+    public static final String RELEVANCE_SETTINGS_ORIGIN = "relevance_settings";
 
     private ClientHelper() {}
 

--- a/x-pack/plugin/relevance-search/src/main/java/org/elasticsearch/xpack/relevancesearch/RelevanceSearchTaskExecutor.java
+++ b/x-pack/plugin/relevance-search/src/main/java/org/elasticsearch/xpack/relevancesearch/RelevanceSearchTaskExecutor.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.relevancesearch;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.elasticsearch.ResourceAlreadyExistsException;
+import org.elasticsearch.Version;
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.admin.indices.create.CreateIndexRequest;
+import org.elasticsearch.action.admin.indices.create.CreateIndexResponse;
+import org.elasticsearch.action.support.ActiveShardCount;
+import org.elasticsearch.client.internal.Client;
+import org.elasticsearch.cluster.ClusterChangedEvent;
+import org.elasticsearch.cluster.ClusterStateListener;
+import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.gateway.GatewayService;
+import org.elasticsearch.indices.SystemIndexDescriptor;
+import org.elasticsearch.persistent.AllocatedPersistentTask;
+import org.elasticsearch.persistent.PersistentTaskState;
+import org.elasticsearch.persistent.PersistentTasksCustomMetadata;
+import org.elasticsearch.persistent.PersistentTasksExecutor;
+import org.elasticsearch.persistent.PersistentTasksService;
+import org.elasticsearch.tasks.TaskId;
+import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.transport.RemoteTransportException;
+
+import java.util.Map;
+
+import static org.elasticsearch.xpack.core.ClientHelper.executeAsyncWithOrigin;
+
+public class RelevanceSearchTaskExecutor extends PersistentTasksExecutor<RelevanceSearchTaskParams> implements ClusterStateListener {
+    public static final String RELEVANCE_SEARCH = "relevance_search";
+    private static final Logger logger = LogManager.getLogger(RelevanceSearchTaskExecutor.class);
+    private final ClusterService clusterService;
+    private final PersistentTasksService persistentTasksService;
+    private final Client client;
+
+    protected RelevanceSearchTaskExecutor(Client client, ClusterService clusterService, ThreadPool threadPool) {
+        super(RELEVANCE_SEARCH, ThreadPool.Names.GENERIC);
+        clusterService.addListener(this);
+        this.clusterService = clusterService;
+        this.client = client;
+        this.persistentTasksService = new PersistentTasksService(clusterService, threadPool, client);
+    }
+
+    @Override
+    protected AllocatedPersistentTask createTask(
+        long id,
+        String type,
+        String action,
+        TaskId parentTaskId,
+        PersistentTasksCustomMetadata.PersistentTask<RelevanceSearchTaskParams> taskInProgress,
+        Map<String, String> headers
+    ) {
+        return new AllocatedPersistentTask(id, type, action, "", parentTaskId, headers);
+    }
+
+    @Override
+    public void clusterChanged(ClusterChangedEvent event) {
+        if (event.state().blocks().hasGlobalBlock(GatewayService.STATE_NOT_RECOVERED_BLOCK)) {
+            // wait for state recovered
+            return;
+        }
+
+        DiscoveryNode masterNode = event.state().nodes().getMasterNode();
+        if (masterNode == null || masterNode.getVersion().before(Version.V_8_6_0)) {
+            // wait for master to be upgraded
+            return;
+        }
+
+        clusterService.removeListener(this);
+
+        persistentTasksService.sendStartRequest(
+            RELEVANCE_SEARCH,
+            RELEVANCE_SEARCH,
+            new RelevanceSearchTaskParams(),
+            ActionListener.wrap(r -> logger.debug("Started relevance search task"), e -> {
+                Throwable t = e instanceof RemoteTransportException ? e.getCause() : e;
+                if (t instanceof ResourceAlreadyExistsException == false) {
+                    logger.error("failed relevance search task", e);
+                }
+            })
+        );
+    }
+
+    @Override
+    protected void nodeOperation(AllocatedPersistentTask task, RelevanceSearchTaskParams params, PersistentTaskState state) {
+        logger.info("Creating relevance settings system index");
+        createRelevanceSettingsIndex(task);
+    }
+
+    private void createRelevanceSettingsIndex(AllocatedPersistentTask task) {
+        SystemIndexDescriptor descriptor = RelevanceSettingsIndexManager.getSystemIndexDescriptor();
+        CreateIndexRequest request = new CreateIndexRequest(descriptor.getPrimaryIndex()).origin(descriptor.getOrigin())
+            .mapping(descriptor.getMappings())
+            .settings(descriptor.getSettings())
+            .waitForActiveShards(ActiveShardCount.ALL);
+        executeAsyncWithOrigin(
+            client.threadPool().getThreadContext(),
+            descriptor.getOrigin(),
+            request,
+            new ActionListener<CreateIndexResponse>() {
+                @Override
+                public void onResponse(CreateIndexResponse createIndexResponse) {
+                    logger.info("Created .ent-search index");
+                    task.markAsCompleted();
+                }
+
+                @Override
+                public void onFailure(Exception e) {
+                    logger.info("Failed to create .ent-search index " + e.toString());
+                    task.markAsCompleted();
+                }
+            },
+            client.admin().indices()::create
+        );
+    }
+}

--- a/x-pack/plugin/relevance-search/src/main/java/org/elasticsearch/xpack/relevancesearch/RelevanceSearchTaskParams.java
+++ b/x-pack/plugin/relevance-search/src/main/java/org/elasticsearch/xpack/relevancesearch/RelevanceSearchTaskParams.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.relevancesearch;
+
+import org.elasticsearch.Version;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.persistent.PersistentTaskParams;
+import org.elasticsearch.xcontent.XContentBuilder;
+
+import java.io.IOException;
+
+import static org.elasticsearch.xpack.relevancesearch.RelevanceSearchTaskExecutor.RELEVANCE_SEARCH;
+
+public class RelevanceSearchTaskParams implements PersistentTaskParams {
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        builder.startObject();
+        builder.endObject();
+        return builder;
+    }
+
+    @Override
+    public String getWriteableName() {
+        return RELEVANCE_SEARCH;
+    }
+
+    @Override
+    public Version getMinimalSupportedVersion() {
+        return Version.V_8_6_0;
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) {}
+}

--- a/x-pack/plugin/relevance-search/src/main/java/org/elasticsearch/xpack/relevancesearch/RelevanceSettingsIndexManager.java
+++ b/x-pack/plugin/relevance-search/src/main/java/org/elasticsearch/xpack/relevancesearch/RelevanceSettingsIndexManager.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.relevancesearch;
+
+import org.elasticsearch.Version;
+import org.elasticsearch.cluster.metadata.IndexMetadata;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.indices.SystemIndexDescriptor;
+import org.elasticsearch.xcontent.XContentBuilder;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+
+import static org.elasticsearch.index.mapper.MapperService.SINGLE_MAPPING_NAME;
+import static org.elasticsearch.xcontent.XContentFactory.jsonBuilder;
+import static org.elasticsearch.xpack.core.ClientHelper.RELEVANCE_SETTINGS_ORIGIN;
+
+public class RelevanceSettingsIndexManager {
+    public static SystemIndexDescriptor getSystemIndexDescriptor() {
+        return SystemIndexDescriptor.builder()
+            .setIndexPattern(".ent-search*")
+            .setDescription("Relevance Settings Index")
+            .setMappings(mappings())
+            .setSettings(
+                Settings.builder()
+                    .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1)
+                    .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 0)
+                    .put(IndexMetadata.SETTING_AUTO_EXPAND_REPLICAS, "0-1")
+                    .build()
+            )
+            .setOrigin(RELEVANCE_SETTINGS_ORIGIN)
+            .setVersionMetaKey("version")
+            .setPrimaryIndex(".ent-search")
+            .setNetNew()
+            .setType(SystemIndexDescriptor.Type.INTERNAL_MANAGED)
+            .build();
+    }
+
+    private static XContentBuilder mappings() {
+        try {
+            return jsonBuilder().startObject()
+                .startObject(SINGLE_MAPPING_NAME)
+                .startObject("_meta")
+                .field("version", Version.CURRENT)
+                .endObject()
+                .field("dynamic", "strict")
+                .startObject("properties")
+                .startObject("name")
+                .field("type", "keyword")
+                .endObject()
+                .startObject("type")
+                .field("type", "keyword")
+                .endObject()
+                .startObject("query_type")
+                .field("type", "keyword")
+                .endObject()
+                .startObject("query_configuration")
+                .startObject("properties")
+                .startObject("fields")
+                .field("type", "keyword")
+                .endObject()
+                .endObject()
+                .endObject()
+                .endObject()
+                .endObject()
+                .endObject();
+        } catch (IOException e) {
+            throw new UncheckedIOException("Failed to build mappings", e);
+        }
+    }
+}

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authz/AuthorizationUtils.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authz/AuthorizationUtils.java
@@ -34,6 +34,7 @@ import static org.elasticsearch.xpack.core.ClientHelper.INDEX_LIFECYCLE_ORIGIN;
 import static org.elasticsearch.xpack.core.ClientHelper.LOGSTASH_MANAGEMENT_ORIGIN;
 import static org.elasticsearch.xpack.core.ClientHelper.ML_ORIGIN;
 import static org.elasticsearch.xpack.core.ClientHelper.MONITORING_ORIGIN;
+import static org.elasticsearch.xpack.core.ClientHelper.RELEVANCE_SETTINGS_ORIGIN;
 import static org.elasticsearch.xpack.core.ClientHelper.ROLLUP_ORIGIN;
 import static org.elasticsearch.xpack.core.ClientHelper.SEARCHABLE_SNAPSHOTS_ORIGIN;
 import static org.elasticsearch.xpack.core.ClientHelper.SECURITY_ORIGIN;
@@ -138,6 +139,7 @@ public final class AuthorizationUtils {
             case SEARCHABLE_SNAPSHOTS_ORIGIN:
             case LOGSTASH_MANAGEMENT_ORIGIN:
             case FLEET_ORIGIN:
+            case RELEVANCE_SETTINGS_ORIGIN:
             case TASKS_ORIGIN:   // TODO use a more limited user for tasks
                 securityContext.executeAsInternalUser(XPackUser.INSTANCE, version, consumer);
                 break;


### PR DESCRIPTION
Add default index for storing relevance settings for the initial `relevance_match` query.