### PR TITLE
[ML] Revert Add stat for non cache hit inference time

### DIFF
--- a/docs/changelog/90464.yaml
+++ b/docs/changelog/90464.yaml
@@ -1,5 +1,0 @@
-pr: 90464
-summary: Add measure of non cache hit inference count
-area: Machine Learning
-type: enhancement
-issues: []

--- a/docs/reference/ml/trained-models/apis/get-trained-models-stats.asciidoc
+++ b/docs/reference/ml/trained-models/apis/get-trained-models-stats.asciidoc
@@ -140,14 +140,6 @@ The deployment stats for each node that currently has the model allocated.
 The average time for each inference call to complete on this node.
 The average is calculated over the lifetime of the deployment.
 
-`average_inference_time_ms_excluding_cache_hits`:::
-(double)
-The average time to perform inference on the trained model excluding
-occasions where the response comes from the cache. Cached inference
-calls return very quickly as the model is not evaluated, by excluding
-cache hits this value is an accurate measure of the average time taken
-to evaluate the model.
-
 `average_inference_time_ms_last_minute`:::
 (double)
 The average time for each inference call to complete on this node

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/assignment/AssignmentStats.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/assignment/AssignmentStats.java
@@ -32,7 +32,6 @@ public class AssignmentStats implements ToXContentObject, Writeable {
         private final DiscoveryNode node;
         private final Long inferenceCount;
         private final Double avgInferenceTime;
-        private final Double avgInferenceTimeExcludingCacheHit;
         private final Instant lastAccess;
         private final Integer pendingCount;
         private final int errorCount;
@@ -52,7 +51,6 @@ public class AssignmentStats implements ToXContentObject, Writeable {
             DiscoveryNode node,
             long inferenceCount,
             Double avgInferenceTime,
-            Double avgInferenceTimeExcludingCacheHit,
             int pendingCount,
             int errorCount,
             long cacheHitCount,
@@ -71,7 +69,6 @@ public class AssignmentStats implements ToXContentObject, Writeable {
                 node,
                 inferenceCount,
                 avgInferenceTime,
-                avgInferenceTimeExcludingCacheHit,
                 lastAccess,
                 pendingCount,
                 errorCount,
@@ -96,7 +93,6 @@ public class AssignmentStats implements ToXContentObject, Writeable {
                 null,
                 null,
                 null,
-                null,
                 0,
                 null,
                 0,
@@ -116,7 +112,6 @@ public class AssignmentStats implements ToXContentObject, Writeable {
             DiscoveryNode node,
             Long inferenceCount,
             Double avgInferenceTime,
-            Double avgInferenceTimeExcludingCacheHit,
             @Nullable Instant lastAccess,
             Integer pendingCount,
             int errorCount,
@@ -135,7 +130,6 @@ public class AssignmentStats implements ToXContentObject, Writeable {
             this.node = node;
             this.inferenceCount = inferenceCount;
             this.avgInferenceTime = avgInferenceTime;
-            this.avgInferenceTimeExcludingCacheHit = avgInferenceTimeExcludingCacheHit;
             this.lastAccess = lastAccess;
             this.pendingCount = pendingCount;
             this.errorCount = errorCount;
@@ -192,12 +186,6 @@ public class AssignmentStats implements ToXContentObject, Writeable {
                 this.cacheHitCount = null;
                 this.cacheHitCountLastPeriod = null;
             }
-            if (in.getVersion().onOrAfter(Version.V_8_5_0)) {
-                this.avgInferenceTimeExcludingCacheHit = in.readOptionalDouble();
-            } else {
-                this.avgInferenceTimeExcludingCacheHit = null;
-            }
-
         }
 
         public DiscoveryNode getNode() {
@@ -214,10 +202,6 @@ public class AssignmentStats implements ToXContentObject, Writeable {
 
         public Optional<Double> getAvgInferenceTime() {
             return Optional.ofNullable(avgInferenceTime);
-        }
-
-        public Optional<Double> getAvgInferenceTimeExcludingCacheHit() {
-            return Optional.ofNullable(avgInferenceTimeExcludingCacheHit);
         }
 
         public Instant getLastAccess() {
@@ -285,13 +269,8 @@ public class AssignmentStats implements ToXContentObject, Writeable {
                 builder.field("inference_count", inferenceCount);
             }
             // avoid reporting the average time as 0 if count < 1
-            if (inferenceCount != null && inferenceCount > 0) {
-                if (avgInferenceTime != null) {
-                    builder.field("average_inference_time_ms", avgInferenceTime);
-                }
-                if (avgInferenceTimeExcludingCacheHit != null) {
-                    builder.field("average_inference_time_ms_excluding_cache_hits", avgInferenceTimeExcludingCacheHit);
-                }
+            if (avgInferenceTime != null && (inferenceCount != null && inferenceCount > 0)) {
+                builder.field("average_inference_time_ms", avgInferenceTime);
             }
             if (cacheHitCount != null) {
                 builder.field("inference_cache_hit_count", cacheHitCount);
@@ -358,9 +337,6 @@ public class AssignmentStats implements ToXContentObject, Writeable {
                 out.writeOptionalVLong(cacheHitCount);
                 out.writeOptionalVLong(cacheHitCountLastPeriod);
             }
-            if (out.getVersion().onOrAfter(Version.V_8_5_0)) {
-                out.writeOptionalDouble(avgInferenceTimeExcludingCacheHit);
-            }
         }
 
         @Override
@@ -370,7 +346,6 @@ public class AssignmentStats implements ToXContentObject, Writeable {
             AssignmentStats.NodeStats that = (AssignmentStats.NodeStats) o;
             return Objects.equals(inferenceCount, that.inferenceCount)
                 && Objects.equals(that.avgInferenceTime, avgInferenceTime)
-                && Objects.equals(that.avgInferenceTimeExcludingCacheHit, avgInferenceTimeExcludingCacheHit)
                 && Objects.equals(node, that.node)
                 && Objects.equals(lastAccess, that.lastAccess)
                 && Objects.equals(pendingCount, that.pendingCount)
@@ -394,7 +369,6 @@ public class AssignmentStats implements ToXContentObject, Writeable {
                 node,
                 inferenceCount,
                 avgInferenceTime,
-                avgInferenceTimeExcludingCacheHit,
                 lastAccess,
                 pendingCount,
                 errorCount,

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/action/GetTrainedModelsStatsActionResponseTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/action/GetTrainedModelsStatsActionResponseTests.java
@@ -28,8 +28,7 @@ public class GetTrainedModelsStatsActionResponseTests extends AbstractBWCWireSer
 
     @Override
     protected Response createTestInstance() {
-        // int listSize = randomInt(10);
-        int listSize = 1;
+        int listSize = randomInt(10);
         List<Response.TrainedModelStats> trainedModelStats = Stream.generate(() -> randomAlphaOfLength(10))
             .limit(listSize)
             .map(
@@ -124,7 +123,6 @@ public class GetTrainedModelsStatsActionResponseTests extends AbstractBWCWireSer
                                                     nodeStats.getNode(),
                                                     nodeStats.getInferenceCount().orElse(null),
                                                     nodeStats.getAvgInferenceTime().orElse(null),
-                                                    null,
                                                     nodeStats.getLastAccess(),
                                                     nodeStats.getPendingCount(),
                                                     0,
@@ -180,7 +178,6 @@ public class GetTrainedModelsStatsActionResponseTests extends AbstractBWCWireSer
                                                     nodeStats.getNode(),
                                                     nodeStats.getInferenceCount().orElse(null),
                                                     nodeStats.getAvgInferenceTime().orElse(null),
-                                                    null,
                                                     nodeStats.getLastAccess(),
                                                     nodeStats.getPendingCount(),
                                                     nodeStats.getErrorCount(),
@@ -236,7 +233,6 @@ public class GetTrainedModelsStatsActionResponseTests extends AbstractBWCWireSer
                                                     nodeStats.getNode(),
                                                     nodeStats.getInferenceCount().orElse(null),
                                                     nodeStats.getAvgInferenceTime().orElse(null),
-                                                    null,
                                                     nodeStats.getLastAccess(),
                                                     nodeStats.getPendingCount(),
                                                     nodeStats.getErrorCount(),
@@ -251,62 +247,6 @@ public class GetTrainedModelsStatsActionResponseTests extends AbstractBWCWireSer
                                                     nodeStats.getThroughputLastPeriod(),
                                                     nodeStats.getAvgInferenceTimeLastPeriod(),
                                                     null
-                                                )
-                                            )
-                                            .toList()
-                                    )
-                            )
-                        )
-                        .toList(),
-                    instance.getResources().count(),
-                    RESULTS_FIELD
-                )
-            );
-        } else if (version.before(Version.V_8_5_0)) {
-            return new Response(
-                new QueryPage<>(
-                    instance.getResources()
-                        .results()
-                        .stream()
-                        .map(
-                            stats -> new Response.TrainedModelStats(
-                                stats.getModelId(),
-                                stats.getModelSizeStats(),
-                                stats.getIngestStats(),
-                                stats.getPipelineCount(),
-                                stats.getInferenceStats(),
-                                stats.getDeploymentStats() == null
-                                    ? null
-                                    : new AssignmentStats(
-                                        stats.getDeploymentStats().getModelId(),
-                                        stats.getDeploymentStats().getThreadsPerAllocation(),
-                                        stats.getDeploymentStats().getNumberOfAllocations(),
-                                        stats.getDeploymentStats().getQueueCapacity(),
-                                        stats.getDeploymentStats().getCacheSize(),
-                                        stats.getDeploymentStats().getStartTime(),
-                                        stats.getDeploymentStats()
-                                            .getNodeStats()
-                                            .stream()
-                                            .map(
-                                                nodeStats -> new AssignmentStats.NodeStats(
-                                                    nodeStats.getNode(),
-                                                    nodeStats.getInferenceCount().orElse(null),
-                                                    nodeStats.getAvgInferenceTime().orElse(null),
-                                                    null,
-                                                    nodeStats.getLastAccess(),
-                                                    nodeStats.getPendingCount(),
-                                                    nodeStats.getErrorCount(),
-                                                    nodeStats.getCacheHitCount().orElse(null),
-                                                    nodeStats.getRejectedExecutionCount(),
-                                                    nodeStats.getTimeoutCount(),
-                                                    nodeStats.getRoutingState(),
-                                                    nodeStats.getStartTime(),
-                                                    nodeStats.getThreadsPerAllocation(),
-                                                    nodeStats.getNumberOfAllocations(),
-                                                    nodeStats.getPeakThroughput(),
-                                                    nodeStats.getThroughputLastPeriod(),
-                                                    nodeStats.getAvgInferenceTimeLastPeriod(),
-                                                    nodeStats.getCacheHitCountLastPeriod().orElse(null)
                                                 )
                                             )
                                             .toList()

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/assignment/AssignmentStatsTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/assignment/AssignmentStatsTests.java
@@ -58,7 +58,6 @@ public class AssignmentStatsTests extends AbstractWireSerializingTestCase<Assign
         var lastAccess = Instant.now();
         var inferenceCount = randomNonNegativeLong();
         Double avgInferenceTime = randomDoubleBetween(0.0, 100.0, true);
-        Double avgInferenceTimeExcludingCacheHit = randomDoubleBetween(0.0, 100.0, true);
         Double avgInferenceTimeLastPeriod = randomDoubleBetween(0.0, 100.0, true);
 
         var noInferenceCallsOnNodeYet = randomBoolean();
@@ -66,14 +65,12 @@ public class AssignmentStatsTests extends AbstractWireSerializingTestCase<Assign
             lastAccess = null;
             inferenceCount = 0;
             avgInferenceTime = null;
-            avgInferenceTimeExcludingCacheHit = null;
             avgInferenceTimeLastPeriod = null;
         }
         return AssignmentStats.NodeStats.forStartedState(
             node,
             inferenceCount,
             avgInferenceTime,
-            avgInferenceTimeExcludingCacheHit,
             randomIntBetween(0, 100),
             randomIntBetween(0, 100),
             randomLongBetween(0, 100),
@@ -105,7 +102,6 @@ public class AssignmentStatsTests extends AbstractWireSerializingTestCase<Assign
                     new DiscoveryNode("node_started_1", buildNewFakeTransportAddress(), Version.CURRENT),
                     10L,
                     randomDoubleBetween(0.0, 100.0, true),
-                    randomDoubleBetween(0.0, 100.0, true),
                     randomIntBetween(1, 10),
                     5,
                     4L,
@@ -123,7 +119,6 @@ public class AssignmentStatsTests extends AbstractWireSerializingTestCase<Assign
                 AssignmentStats.NodeStats.forStartedState(
                     new DiscoveryNode("node_started_2", buildNewFakeTransportAddress(), Version.CURRENT),
                     12L,
-                    randomDoubleBetween(0.0, 100.0, true),
                     randomDoubleBetween(0.0, 100.0, true),
                     randomIntBetween(1, 10),
                     15,

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportGetDeploymentStatsAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportGetDeploymentStatsAction.java
@@ -309,9 +309,8 @@ public class TransportGetDeploymentStatsAction extends TransportTasksAction<
             nodeStats.add(
                 AssignmentStats.NodeStats.forStartedState(
                     clusterService.localNode(),
-                    presentValue.inferenceCount(),
-                    presentValue.averageInferenceTime(),
-                    presentValue.averageInferenceTimeNoCacheHits(),
+                    presentValue.timingStats().getCount(),
+                    presentValue.timingStats().getAverage(),
                     presentValue.pendingCount(),
                     presentValue.errorCount(),
                     presentValue.cacheHitCount(),

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/deployment/DeploymentManager.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/deployment/DeploymentManager.java
@@ -103,9 +103,7 @@ public class DeploymentManager {
             var recentStats = stats.recentStats();
             return new ModelStats(
                 processContext.startTime,
-                stats.timingStats().getCount(),
-                stats.timingStats().getAverage(),
-                stats.timingStatsExcludingCacheHits().getAverage(),
+                stats.timingStats(),
                 stats.lastUsed(),
                 processContext.executorService.queueSize() + stats.numberOfPendingResults(),
                 stats.errorCount(),

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/deployment/ModelStats.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/deployment/ModelStats.java
@@ -8,12 +8,11 @@
 package org.elasticsearch.xpack.ml.inference.deployment;
 
 import java.time.Instant;
+import java.util.LongSummaryStatistics;
 
 public record ModelStats(
     Instant startTime,
-    long inferenceCount,
-    Double averageInferenceTime,
-    Double averageInferenceTimeNoCacheHits,
+    LongSummaryStatistics timingStats,
     Instant lastUsed,
     int pendingCount,
     int errorCount,

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/MachineLearningInfoTransportActionTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/MachineLearningInfoTransportActionTests.java
@@ -381,7 +381,6 @@ public class MachineLearningInfoTransportActionTests extends ESTestCase {
                                         new DiscoveryNode("foo", new TransportAddress(TransportAddress.META_ADDRESS, 2), Version.CURRENT),
                                         5,
                                         42.0,
-                                        42.0,
                                         0,
                                         1,
                                         3L,
@@ -399,7 +398,6 @@ public class MachineLearningInfoTransportActionTests extends ESTestCase {
                                     AssignmentStats.NodeStats.forStartedState(
                                         new DiscoveryNode("bar", new TransportAddress(TransportAddress.META_ADDRESS, 3), Version.CURRENT),
                                         4,
-                                        50.0,
                                         50.0,
                                         0,
                                         1,

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/pytorch/process/PyTorchResultProcessorTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/pytorch/process/PyTorchResultProcessorTests.java
@@ -153,8 +153,8 @@ public class PyTorchResultProcessorTests extends ESTestCase {
         }
     }
 
-    private PyTorchResult wrapInferenceResult(String requestId, boolean isCacheHit, long timeMs) {
-        return new PyTorchResult(requestId, isCacheHit, timeMs, new PyTorchInferenceResult(null), null, null, null);
+    private PyTorchResult wrapInferenceResult(String requestId, boolean isCacheHit, long timeMs, PyTorchInferenceResult result) {
+        return new PyTorchResult(requestId, isCacheHit, timeMs, result, null, null, null);
     }
 
     public void testsStats() {
@@ -168,9 +168,9 @@ public class PyTorchResultProcessorTests extends ESTestCase {
         processor.registerRequest("b", pendingB);
         processor.registerRequest("c", pendingC);
 
-        var a = wrapInferenceResult("a", false, 1000L);
-        var b = wrapInferenceResult("b", false, 900L);
-        var c = wrapInferenceResult("c", true, 200L); // cache hit
+        var a = wrapInferenceResult("a", false, 1000L, new PyTorchInferenceResult(null));
+        var b = wrapInferenceResult("b", false, 900L, new PyTorchInferenceResult(null));
+        var c = wrapInferenceResult("c", true, 200L, new PyTorchInferenceResult(null));
 
         processor.processInferenceResult(a);
         var stats = processor.getResultStats();
@@ -179,8 +179,6 @@ public class PyTorchResultProcessorTests extends ESTestCase {
         assertThat(stats.numberOfPendingResults(), equalTo(2));
         assertThat(stats.timingStats().getCount(), equalTo(1L));
         assertThat(stats.timingStats().getSum(), equalTo(1000L));
-        assertThat(stats.timingStatsExcludingCacheHits().getCount(), equalTo(1L));
-        assertThat(stats.timingStatsExcludingCacheHits().getSum(), equalTo(1000L));
 
         processor.processInferenceResult(b);
         stats = processor.getResultStats();
@@ -189,8 +187,6 @@ public class PyTorchResultProcessorTests extends ESTestCase {
         assertThat(stats.numberOfPendingResults(), equalTo(1));
         assertThat(stats.timingStats().getCount(), equalTo(2L));
         assertThat(stats.timingStats().getSum(), equalTo(1900L));
-        assertThat(stats.timingStatsExcludingCacheHits().getCount(), equalTo(2L));
-        assertThat(stats.timingStatsExcludingCacheHits().getSum(), equalTo(1900L));
 
         processor.processInferenceResult(c);
         stats = processor.getResultStats();
@@ -199,8 +195,6 @@ public class PyTorchResultProcessorTests extends ESTestCase {
         assertThat(stats.numberOfPendingResults(), equalTo(0));
         assertThat(stats.timingStats().getCount(), equalTo(3L));
         assertThat(stats.timingStats().getSum(), equalTo(2100L));
-        assertThat(stats.timingStatsExcludingCacheHits().getCount(), equalTo(2L));
-        assertThat(stats.timingStatsExcludingCacheHits().getSum(), equalTo(1900L));
     }
 
     public void testsTimeDependentStats() {
@@ -240,9 +234,9 @@ public class PyTorchResultProcessorTests extends ESTestCase {
         var processor = new PyTorchResultProcessor("foo", s -> {}, timeSupplier);
 
         // 1st period
-        processor.processInferenceResult(wrapInferenceResult("foo", false, 200L));
-        processor.processInferenceResult(wrapInferenceResult("foo", false, 200L));
-        processor.processInferenceResult(wrapInferenceResult("foo", false, 200L));
+        processor.processInferenceResult(wrapInferenceResult("foo", false, 200L, new PyTorchInferenceResult(null)));
+        processor.processInferenceResult(wrapInferenceResult("foo", false, 200L, new PyTorchInferenceResult(null)));
+        processor.processInferenceResult(wrapInferenceResult("foo", false, 200L, new PyTorchInferenceResult(null)));
         // first call has no results as is in the same period
         var stats = processor.getResultStats();
         assertThat(stats.recentStats().requestsProcessed(), equalTo(0L));
@@ -256,7 +250,7 @@ public class PyTorchResultProcessorTests extends ESTestCase {
         assertThat(stats.peakThroughput(), equalTo(3L));
 
         // 2nd period
-        processor.processInferenceResult(wrapInferenceResult("foo", false, 100L));
+        processor.processInferenceResult(wrapInferenceResult("foo", false, 100L, new PyTorchInferenceResult(null)));
         stats = processor.getResultStats();
         assertNotNull(stats.recentStats());
         assertThat(stats.recentStats().requestsProcessed(), equalTo(1L));
@@ -268,7 +262,7 @@ public class PyTorchResultProcessorTests extends ESTestCase {
         assertThat(stats.recentStats().requestsProcessed(), equalTo(0L));
 
         // 4th period
-        processor.processInferenceResult(wrapInferenceResult("foo", false, 300L));
+        processor.processInferenceResult(wrapInferenceResult("foo", false, 300L, new PyTorchInferenceResult(null)));
         stats = processor.getResultStats();
         assertNotNull(stats.recentStats());
         assertThat(stats.recentStats().requestsProcessed(), equalTo(1L));
@@ -276,8 +270,8 @@ public class PyTorchResultProcessorTests extends ESTestCase {
         assertThat(stats.lastUsed(), equalTo(Instant.ofEpochMilli(resultTimestamps[9])));
 
         // 7th period
-        processor.processInferenceResult(wrapInferenceResult("foo", false, 410L));
-        processor.processInferenceResult(wrapInferenceResult("foo", false, 390L));
+        processor.processInferenceResult(wrapInferenceResult("foo", false, 410L, new PyTorchInferenceResult(null)));
+        processor.processInferenceResult(wrapInferenceResult("foo", false, 390L, new PyTorchInferenceResult(null)));
         stats = processor.getResultStats();
         assertThat(stats.recentStats().requestsProcessed(), equalTo(0L));
         assertThat(stats.recentStats().avgInferenceTime(), nullValue());
@@ -288,9 +282,9 @@ public class PyTorchResultProcessorTests extends ESTestCase {
         assertThat(stats.lastUsed(), equalTo(Instant.ofEpochMilli(resultTimestamps[12])));
 
         // 8th period
-        processor.processInferenceResult(wrapInferenceResult("foo", false, 510L));
-        processor.processInferenceResult(wrapInferenceResult("foo", false, 500L));
-        processor.processInferenceResult(wrapInferenceResult("foo", false, 490L));
+        processor.processInferenceResult(wrapInferenceResult("foo", false, 510L, new PyTorchInferenceResult(null)));
+        processor.processInferenceResult(wrapInferenceResult("foo", false, 500L, new PyTorchInferenceResult(null)));
+        processor.processInferenceResult(wrapInferenceResult("foo", false, 490L, new PyTorchInferenceResult(null)));
         stats = processor.getResultStats();
         assertNotNull(stats.recentStats());
         assertThat(stats.recentStats().requestsProcessed(), equalTo(3L));


### PR DESCRIPTION
Reverting #90464 which has introduced a BWC serialisation error. 