### PR TITLE
Replace ClusterInfo#dataPath key

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/ClusterInfo.java
+++ b/server/src/main/java/org/elasticsearch/cluster/ClusterInfo.java
@@ -36,13 +36,15 @@ import java.util.Set;
 public class ClusterInfo implements ToXContentFragment, Writeable {
 
     public static final ClusterInfo EMPTY = new ClusterInfo();
+
     public static final Version DATA_SET_SIZE_SIZE_VERSION = Version.V_7_13_0;
+    public static final Version DATA_PATH_NEW_KEY_VERSION = Version.V_8_6_0;
 
     private final Map<String, DiskUsage> leastAvailableSpaceUsage;
     private final Map<String, DiskUsage> mostAvailableSpaceUsage;
     final Map<String, Long> shardSizes;
     final Map<ShardId, Long> shardDataSetSizes;
-    final Map<ShardRouting, String> routingToDataPath;
+    final Map<NodeAndShard, String> dataPath;
     final Map<NodeAndPath, ReservedSpace> reservedSpace;
 
     protected ClusterInfo() {
@@ -56,7 +58,7 @@ public class ClusterInfo implements ToXContentFragment, Writeable {
      * @param mostAvailableSpaceUsage  a node id to disk usage mapping for the path that has the most available space on the node.
      * @param shardSizes a shardkey to size in bytes mapping per shard.
      * @param shardDataSetSizes a shard id to data set size in bytes mapping per shard
-     * @param routingToDataPath the shard routing to datapath mapping
+     * @param dataPath the shard routing to datapath mapping
      * @param reservedSpace reserved space per shard broken down by node and data path
      * @see #shardIdentifierFromRouting
      */
@@ -65,14 +67,14 @@ public class ClusterInfo implements ToXContentFragment, Writeable {
         Map<String, DiskUsage> mostAvailableSpaceUsage,
         Map<String, Long> shardSizes,
         Map<ShardId, Long> shardDataSetSizes,
-        Map<ShardRouting, String> routingToDataPath,
+        Map<NodeAndShard, String> dataPath,
         Map<NodeAndPath, ReservedSpace> reservedSpace
     ) {
         this.leastAvailableSpaceUsage = Map.copyOf(leastAvailableSpaceUsage);
         this.shardSizes = Map.copyOf(shardSizes);
         this.shardDataSetSizes = Map.copyOf(shardDataSetSizes);
         this.mostAvailableSpaceUsage = Map.copyOf(mostAvailableSpaceUsage);
-        this.routingToDataPath = Map.copyOf(routingToDataPath);
+        this.dataPath = Map.copyOf(dataPath);
         this.reservedSpace = Map.copyOf(reservedSpace);
     }
 
@@ -85,7 +87,8 @@ public class ClusterInfo implements ToXContentFragment, Writeable {
         } else {
             this.shardDataSetSizes = Map.of();
         }
-        this.routingToDataPath = in.readImmutableMap(ShardRouting::new, StreamInput::readString);
+        // TODO conditional read
+        this.dataPath = null;// in.readImmutableMap(ShardRouting::new, StreamInput::readString);
         if (in.getVersion().onOrAfter(StoreStats.RESERVED_BYTES_VERSION)) {
             this.reservedSpace = in.readImmutableMap(NodeAndPath::new, ReservedSpace::new);
         } else {
@@ -101,7 +104,8 @@ public class ClusterInfo implements ToXContentFragment, Writeable {
         if (out.getVersion().onOrAfter(DATA_SET_SIZE_SIZE_VERSION)) {
             out.writeMap(this.shardDataSetSizes, (o, s) -> s.writeTo(o), StreamOutput::writeLong);
         }
-        out.writeMap(this.routingToDataPath, (o, k) -> k.writeTo(o), StreamOutput::writeString);
+        // TODO conditional write
+        out.writeMap(this.dataPath, (o, k) -> k.writeTo(o), StreamOutput::writeString);
         if (out.getVersion().onOrAfter(StoreStats.RESERVED_BYTES_VERSION)) {
             out.writeMap(this.reservedSpace);
         }
@@ -148,7 +152,7 @@ public class ClusterInfo implements ToXContentFragment, Writeable {
         builder.endObject(); // end "shard_data_set_sizes"
         builder.startObject("shard_paths");
         {
-            for (Map.Entry<ShardRouting, String> c : this.routingToDataPath.entrySet()) {
+            for (Map.Entry<NodeAndShard, String> c : this.dataPath.entrySet()) {
                 builder.field(c.getKey().toString(), c.getValue());
             }
         }
@@ -211,7 +215,11 @@ public class ClusterInfo implements ToXContentFragment, Writeable {
      * Returns the nodes absolute data-path the given shard is allocated on or <code>null</code> if the information is not available.
      */
     public String getDataPath(ShardRouting shardRouting) {
-        return routingToDataPath.get(shardRouting);
+        return dataPath.get(NodeAndShard.from(shardRouting));
+    }
+
+    public String getDataPath(NodeAndShard nodeAndShard) {
+        return dataPath.get(nodeAndShard);
     }
 
     public Optional<Long> getShardDataSetSize(ShardId shardId) {
@@ -247,25 +255,40 @@ public class ClusterInfo implements ToXContentFragment, Writeable {
             && mostAvailableSpaceUsage.equals(that.mostAvailableSpaceUsage)
             && shardSizes.equals(that.shardSizes)
             && shardDataSetSizes.equals(that.shardDataSetSizes)
-            && routingToDataPath.equals(that.routingToDataPath)
+            && dataPath.equals(that.dataPath)
             && reservedSpace.equals(that.reservedSpace);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(
-            leastAvailableSpaceUsage,
-            mostAvailableSpaceUsage,
-            shardSizes,
-            shardDataSetSizes,
-            routingToDataPath,
-            reservedSpace
-        );
+        return Objects.hash(leastAvailableSpaceUsage, mostAvailableSpaceUsage, shardSizes, shardDataSetSizes, dataPath, reservedSpace);
     }
 
     @Override
     public String toString() {
         return Strings.toString(this, true, false);
+    }
+
+    public record NodeAndShard(String nodeId, ShardId shardId) implements Writeable {
+
+        public NodeAndShard {
+            Objects.requireNonNull(nodeId);
+            Objects.requireNonNull(shardId);
+        }
+
+        public NodeAndShard(StreamInput in) throws IOException {
+            this(in.readString(), new ShardId(in));
+        }
+
+        @Override
+        public void writeTo(StreamOutput out) throws IOException {
+            out.writeString(nodeId);
+            shardId.writeTo(out);
+        }
+
+        public static NodeAndShard from(ShardRouting shardRouting) {
+            return new NodeAndShard(shardRouting.currentNodeId(), shardRouting.shardId());
+        }
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/cluster/routing/ShardRouting.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/ShardRouting.java
@@ -488,24 +488,6 @@ public final class ShardRouting implements Writeable, ToXContentObject {
         );
     }
 
-    public ShardRouting asBeforeRelocation() {
-        assert state == ShardRoutingState.RELOCATING : this;
-        assert assignedToNode() : this;
-        assert relocatingNodeId != null : this;
-        return new ShardRouting(
-            shardId,
-            currentNodeId,
-            null,
-            primary,
-            ShardRoutingState.STARTED,
-            recoverySource,
-            null,
-            RelocationFailureInfo.NO_FAILURES,
-            AllocationId.cancelRelocation(allocationId),
-            UNAVAILABLE_EXPECTED_SHARD_SIZE
-        );
-    }
-
     /**
      * Removes relocation source of a non-primary shard. The shard state must be <code>INITIALIZING</code>.
      * This allows the non-primary shard to continue recovery from the primary even though its non-primary

--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/DiskThresholdDecider.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/DiskThresholdDecider.java
@@ -161,14 +161,7 @@ public class DiskThresholdDecider extends AllocationDecider {
 
         if (subtractShardsMovingAway) {
             for (ShardRouting routing : node.relocating()) {
-                String actualPath = clusterInfo.getDataPath(routing);
-                // This branch is needed as the map key contains some information that might have changed (eg shard status)
-                // It could be removed once https://github.com/elastic/elasticsearch/issues/90109 is fixed
-                if (actualPath == null) {
-                    // we might know the path of this shard from before when it was relocating
-                    actualPath = clusterInfo.getDataPath(routing.asBeforeRelocation());
-                }
-                if (dataPath.equals(actualPath)) {
+                if (dataPath.equals(clusterInfo.getDataPath(routing))) {
                     totalSize -= getExpectedShardSize(routing, 0L, clusterInfo, null, metadata, routingTable);
                 }
             }

--- a/server/src/test/java/org/elasticsearch/cluster/ClusterInfoTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/ClusterInfoTests.java
@@ -7,9 +7,6 @@
  */
 package org.elasticsearch.cluster;
 
-import org.elasticsearch.cluster.routing.ShardRouting;
-import org.elasticsearch.cluster.routing.ShardRoutingState;
-import org.elasticsearch.cluster.routing.TestShardRouting;
 import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.test.AbstractWireSerializingTestCase;
@@ -81,13 +78,12 @@ public class ClusterInfoTests extends AbstractWireSerializingTestCase<ClusterInf
         return builder;
     }
 
-    private static Map<ShardRouting, String> randomRoutingToDataPath() {
+    private static Map<ClusterInfo.NodeAndShard, String> randomRoutingToDataPath() {
         int numEntries = randomIntBetween(0, 128);
-        Map<ShardRouting, String> builder = new HashMap<>(numEntries);
+        Map<ClusterInfo.NodeAndShard, String> builder = new HashMap<>(numEntries);
         for (int i = 0; i < numEntries; i++) {
             ShardId shardId = new ShardId(randomAlphaOfLength(32), randomAlphaOfLength(32), randomIntBetween(0, Integer.MAX_VALUE));
-            ShardRouting shardRouting = TestShardRouting.newShardRouting(shardId, null, randomBoolean(), ShardRoutingState.UNASSIGNED);
-            builder.put(shardRouting, randomAlphaOfLength(32));
+            builder.put(new ClusterInfo.NodeAndShard(randomAlphaOfLength(10), shardId), randomAlphaOfLength(32));
         }
         return builder;
     }
@@ -96,13 +92,12 @@ public class ClusterInfoTests extends AbstractWireSerializingTestCase<ClusterInf
         int numEntries = randomIntBetween(0, 128);
         Map<ClusterInfo.NodeAndPath, ClusterInfo.ReservedSpace> builder = new HashMap<>(numEntries);
         for (int i = 0; i < numEntries; i++) {
-            final ClusterInfo.NodeAndPath key = new ClusterInfo.NodeAndPath(randomAlphaOfLength(10), randomAlphaOfLength(10));
             final ClusterInfo.ReservedSpace.Builder valueBuilder = new ClusterInfo.ReservedSpace.Builder();
             for (int j = between(0, 10); j > 0; j--) {
                 ShardId shardId = new ShardId(randomAlphaOfLength(32), randomAlphaOfLength(32), randomIntBetween(0, Integer.MAX_VALUE));
                 valueBuilder.add(shardId, between(0, Integer.MAX_VALUE));
             }
-            builder.put(key, valueBuilder.build());
+            builder.put(new ClusterInfo.NodeAndPath(randomAlphaOfLength(10), randomAlphaOfLength(10)), valueBuilder.build());
         }
         return builder;
     }

--- a/server/src/test/java/org/elasticsearch/cluster/routing/allocation/decider/DiskThresholdDeciderUnitTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/allocation/decider/DiskThresholdDeciderUnitTests.java
@@ -264,7 +264,7 @@ public class DiskThresholdDeciderUnitTests extends ESAllocationTestCase {
     private void doTestCanRemainUsesLeastAvailableSpace(boolean testMaxHeadroom) {
         ClusterSettings nss = new ClusterSettings(Settings.EMPTY, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS);
         DiskThresholdDecider decider = new DiskThresholdDecider(Settings.EMPTY, nss);
-        Map<ShardRouting, String> shardRoutingMap = new HashMap<>();
+        Map<ClusterInfo.NodeAndShard, String> shardRoutingMap = new HashMap<>();
 
         DiscoveryNode node_0 = new DiscoveryNode(
             "node_0",
@@ -294,7 +294,7 @@ public class DiskThresholdDeciderUnitTests extends ESAllocationTestCase {
         );
         test_0 = ShardRoutingHelper.initialize(test_0, node_0.getId());
         test_0 = ShardRoutingHelper.moveToStarted(test_0);
-        shardRoutingMap.put(test_0, "/node0/least");
+        shardRoutingMap.put(ClusterInfo.NodeAndShard.from(test_0), "/node0/least");
 
         ShardRouting test_1 = ShardRouting.newUnassigned(
             new ShardId(indexMetadata.getIndex(), 1),
@@ -304,7 +304,7 @@ public class DiskThresholdDeciderUnitTests extends ESAllocationTestCase {
         );
         test_1 = ShardRoutingHelper.initialize(test_1, node_1.getId());
         test_1 = ShardRoutingHelper.moveToStarted(test_1);
-        shardRoutingMap.put(test_1, "/node1/least");
+        shardRoutingMap.put(ClusterInfo.NodeAndShard.from(test_1), "/node1/least");
 
         ShardRouting test_2 = ShardRouting.newUnassigned(
             new ShardId(indexMetadata.getIndex(), 2),
@@ -314,7 +314,7 @@ public class DiskThresholdDeciderUnitTests extends ESAllocationTestCase {
         );
         test_2 = ShardRoutingHelper.initialize(test_2, node_1.getId());
         test_2 = ShardRoutingHelper.moveToStarted(test_2);
-        shardRoutingMap.put(test_2, "/node1/most");
+        shardRoutingMap.put(ClusterInfo.NodeAndShard.from(test_2), "/node1/most");
 
         ShardRouting test_3 = ShardRouting.newUnassigned(
             new ShardId(indexMetadata.getIndex(), 3),


### PR DESCRIPTION
Replace ClusterInfo#dataPath ShardRouting key with a smaller one that only have a necessary information. Previously dataPath could not be found in case if any shard info changes before ClusterInfo is refreshed

Closes: #90109