### PR TITLE
Add SimpleBatchedAckListenerTaskExecutor

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/SimpleBatchedAckListenerTaskExecutor.java
+++ b/server/src/main/java/org/elasticsearch/cluster/SimpleBatchedAckListenerTaskExecutor.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.cluster;
+
+/**
+ * A basic batch executor implementation for tasks that implement {@link ClusterStateAckListener}, where the tasks in the
+ * batch are executed iteratively, producing a cluster state after each task. This allows executing the tasks in the batch
+ * as a series of executions, each taking an input cluster state and producing a new cluster state that serves as the
+ * input of the next task in the batch.
+ */
+public abstract class SimpleBatchedAckListenerTaskExecutor<Task extends ClusterStateAckListener & ClusterStateTaskListener>
+    implements
+        ClusterStateTaskExecutor<Task> {
+
+    /**
+     * Executes the provided task from the batch.
+     *
+     * @param task The task to be executed.
+     * @param clusterState    The cluster state on which the task should be executed.
+     * @return The resulting cluster state after executing this task.
+     */
+    public abstract ClusterState executeTask(Task task, ClusterState clusterState) throws Exception;
+
+    /**
+     * Called once all tasks in the batch have finished execution. It should return a cluster state that reflects
+     * the execution of all the tasks.
+     *
+     * @param clusterState The cluster state resulting from the execution of all the tasks.
+     * @param clusterStateChanged Whether {@code clusterState} is different from the cluster state before executing the tasks in the batch.
+     * @return The resulting cluster state after executing all the tasks.
+     */
+    public ClusterState afterBatchExecution(ClusterState clusterState, boolean clusterStateChanged) {
+        return clusterState;
+    }
+
+    @Override
+    public final void clusterStatePublished(ClusterState newClusterState) {
+        clusterStatePublished();
+    }
+
+    /**
+     * Called after the new cluster state is published. Note that this method is not invoked if the cluster state was not updated.
+     */
+    public void clusterStatePublished() {}
+
+    @Override
+    public final ClusterState execute(BatchExecutionContext<Task> batchExecutionContext) throws Exception {
+        var initState = batchExecutionContext.initialState();
+        var clusterState = initState;
+        for (final var taskContext : batchExecutionContext.taskContexts()) {
+            try (var ignored = taskContext.captureResponseHeaders()) {
+                var task = taskContext.getTask();
+                clusterState = executeTask(task, clusterState);
+                taskContext.success(task);
+            } catch (Exception e) {
+                taskContext.onFailure(e);
+            }
+        }
+        try (var ignored = batchExecutionContext.dropHeadersContext()) {
+            return afterBatchExecution(clusterState, clusterState != initState);
+        }
+    }
+}

--- a/server/src/main/java/org/elasticsearch/cluster/SimpleBatchedAckListenerTaskExecutor.java
+++ b/server/src/main/java/org/elasticsearch/cluster/SimpleBatchedAckListenerTaskExecutor.java
@@ -11,9 +11,9 @@ package org.elasticsearch.cluster;
 import org.elasticsearch.core.Tuple;
 
 /**
- * A basic batch executor implementation for tasks that implement {@link ClusterStateAckListener}, where the tasks in the
- * batch are executed iteratively, producing a cluster state after each task. This allows executing the tasks in the batch
- * as a series of executions, each taking an input cluster state and producing a new cluster state that serves as the
+ * A basic batch executor implementation for tasks that can listen for acks themselves by providing a {@link ClusterStateAckListener}.
+ * The tasks in the batch are executed iteratively, producing a cluster state after each task. This allows executing the tasks
+ * in the batch as a series of executions, each taking an input cluster state and producing a new cluster state that serves as the
  * input of the next task in the batch.
  */
 public abstract class SimpleBatchedAckListenerTaskExecutor<Task extends ClusterStateTaskListener>

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataDeleteIndexService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataDeleteIndexService.java
@@ -12,6 +12,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.elasticsearch.action.admin.indices.delete.DeleteIndexClusterStateUpdateRequest;
 import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.ClusterStateAckListener;
 import org.elasticsearch.cluster.ClusterStateTaskConfig;
 import org.elasticsearch.cluster.ClusterStateTaskExecutor;
 import org.elasticsearch.cluster.RestoreInProgress;
@@ -25,6 +26,7 @@ import org.elasticsearch.common.collect.ImmutableOpenMap;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.set.Sets;
+import org.elasticsearch.core.Tuple;
 import org.elasticsearch.index.Index;
 import org.elasticsearch.snapshots.RestoreService;
 import org.elasticsearch.snapshots.SnapshotInProgressException;
@@ -55,8 +57,11 @@ public class MetadataDeleteIndexService {
         this.clusterService = clusterService;
         executor = new SimpleBatchedAckListenerTaskExecutor<>() {
             @Override
-            public ClusterState executeTask(DeleteIndexClusterStateUpdateRequest task, ClusterState clusterState) {
-                return deleteIndices(clusterState, Sets.newHashSet(task.indices()));
+            public Tuple<ClusterState, ClusterStateAckListener> executeTask(
+                DeleteIndexClusterStateUpdateRequest task,
+                ClusterState clusterState
+            ) {
+                return Tuple.tuple(deleteIndices(clusterState, Sets.newHashSet(task.indices())), task);
             }
 
             @Override

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataUpdateSettingsService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataUpdateSettingsService.java
@@ -19,6 +19,7 @@ import org.elasticsearch.cluster.ClusterStateAckListener;
 import org.elasticsearch.cluster.ClusterStateTaskConfig;
 import org.elasticsearch.cluster.ClusterStateTaskExecutor;
 import org.elasticsearch.cluster.ClusterStateTaskListener;
+import org.elasticsearch.cluster.SimpleBatchedAckListenerTaskExecutor;
 import org.elasticsearch.cluster.block.ClusterBlock;
 import org.elasticsearch.cluster.block.ClusterBlocks;
 import org.elasticsearch.cluster.node.DiscoveryNode;
@@ -31,6 +32,7 @@ import org.elasticsearch.common.settings.IndexScopedSettings;
 import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.core.TimeValue;
+import org.elasticsearch.core.Tuple;
 import org.elasticsearch.index.Index;
 import org.elasticsearch.index.IndexSettings;
 import org.elasticsearch.indices.IndicesService;
@@ -70,26 +72,21 @@ public class MetadataUpdateSettingsService {
         this.indexScopedSettings = indexScopedSettings;
         this.indicesService = indicesService;
         this.shardLimitValidator = shardLimitValidator;
-        this.executor = batchExecutionContext -> {
-            ClusterState state = batchExecutionContext.initialState();
-            for (final var taskContext : batchExecutionContext.taskContexts()) {
-                try {
-                    final var task = taskContext.getTask();
-                    try (var ignored = taskContext.captureResponseHeaders()) {
-                        state = task.execute(state);
-                    }
-                    taskContext.success(task.getAckListener());
-                } catch (Exception e) {
-                    taskContext.onFailure(e);
-                }
+        this.executor = new SimpleBatchedAckListenerTaskExecutor<>() {
+            @Override
+            public Tuple<ClusterState, ClusterStateAckListener> executeTask(UpdateSettingsTask task, ClusterState clusterState)
+                throws Exception {
+                return Tuple.tuple(task.execute(clusterState), task.getAckListener());
             }
-            if (state != batchExecutionContext.initialState()) {
-                // reroute in case things change that require it (like number of replicas)
-                try (var ignored = batchExecutionContext.dropHeadersContext()) {
-                    state = allocationService.reroute(state, "settings update");
+
+            @Override
+            public ClusterState afterBatchExecution(ClusterState clusterState, boolean clusterStateChanged) {
+                if (clusterStateChanged) {
+                    // reroute in case things change that require it (like number of replicas)
+                    return allocationService.reroute(clusterState, "settings update");
                 }
+                return clusterState;
             }
-            return state;
         };
     }
 

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataUpdateSettingsService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataUpdateSettingsService.java
@@ -74,8 +74,7 @@ public class MetadataUpdateSettingsService {
         this.shardLimitValidator = shardLimitValidator;
         this.executor = new SimpleBatchedAckListenerTaskExecutor<>() {
             @Override
-            public Tuple<ClusterState, ClusterStateAckListener> executeTask(UpdateSettingsTask task, ClusterState clusterState)
-                throws Exception {
+            public Tuple<ClusterState, ClusterStateAckListener> executeTask(UpdateSettingsTask task, ClusterState clusterState) {
                 return Tuple.tuple(task.execute(clusterState), task.getAckListener());
             }
 


### PR DESCRIPTION
A followup to https://github.com/elastic/elasticsearch/pull/90343 for cluster state update tasks that implement `ClusterStateAckListener` (see https://github.com/elastic/elasticsearch/pull/90343#issuecomment-1260638634).
