### PR TITLE
[8.5] [Doc] Release notes for v8.4.3 (#90443)

### DIFF
--- a/docs/reference/release-notes.asciidoc
+++ b/docs/reference/release-notes.asciidoc
@@ -6,6 +6,7 @@
 
 This section summarizes the changes in each release.
 
+* <<release-notes-8.4.3>>
 * <<release-notes-8.5.0>>
 * <<release-notes-8.4.2>>
 * <<release-notes-8.4.1>>
@@ -32,6 +33,7 @@ This section summarizes the changes in each release.
 
 --
 
+include::release-notes/8.4.3.asciidoc[]
 include::release-notes/8.5.0.asciidoc[]
 include::release-notes/8.4.2.asciidoc[]
 include::release-notes/8.4.1.asciidoc[]

--- a/docs/reference/release-notes/8.4.3.asciidoc
+++ b/docs/reference/release-notes/8.4.3.asciidoc
@@ -1,0 +1,25 @@
+[[release-notes-8.4.3]]
+== {es} version 8.4.3
+
+coming[8.4.3]
+
+Also see <<breaking-changes-8.4,Breaking changes in 8.4>>.
+
+[[bug-8.4.3]]
+[float]
+=== Bug fixes
+
+Infra/Core::
+* Fix file permission errors to avoid repeated error save loops on Windows {es-pull}90271[#90271] (issue: {es-issue}90222[#90222])
+
+Ingest Node::
+* Prevent serialization errors in the nodes stats API {es-pull}90319[#90319] (issue: {es-issue}77973[#77973])
+
+[[regression-8.4.3]]
+[float]
+=== Regressions
+
+Ranking::
+* Ensure `cross_fields` always uses valid term statistics {es-pull}90314[#90314]
+
+


### PR DESCRIPTION
# Backport

This will backport the following commits from `8.4` to `8.5`:
 - [[Doc] Release notes for v8.4.3 (#90443)](https://github.com/elastic/elasticsearch/pull/90443)

<!--- Backport version: 8.9.3 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)