### PR TITLE
[8.4] [DOCS] Fixed footnote. Closes #89403 (#90541)

### DIFF
--- a/docs/reference/snapshot-restore/cluster-index-compat.asciidoc
+++ b/docs/reference/snapshot-restore/cluster-index-compat.asciidoc
@@ -1,12 +1,13 @@
-
 [cols="^,^,^,^,^,^"]
 |====
 | 5+^h| Cluster version
 h| Index creation version   | 6.8        | 7.0–7.1    | 7.2–{prev-major-last} | 8.0–8.2    | 8.3-{minor-version}
-| 5.0–5.6                   | {yes-icon} | {no-icon}  | {no-icon}             | {no-icon}  | {yes-icon}footnote:archive[Using <<archive-indices,archive>> functionality]
-| 6.0–6.7                   | {yes-icon} | {yes-icon} | {yes-icon}            | {no-icon}  | {yes-icon}footnote:archive[]
-| 6.8                       | {yes-icon} | {no-icon}  | {yes-icon}            | {no-icon}  | {yes-icon}footnote:archive[]
+| 5.0–5.6                   | {yes-icon} | {no-icon}  | {no-icon}             | {no-icon}  | {yes-icon}<<fn-archive,^[1]^>>
+| 6.0–6.7                   | {yes-icon} | {yes-icon} | {yes-icon}            | {no-icon}  | {yes-icon}<<fn-archive,^[1]^>>
+| 6.8                       | {yes-icon} | {no-icon}  | {yes-icon}            | {no-icon}  | {yes-icon}<<fn-archive,^[1]^>>
 | 7.0–7.1                   | {no-icon}  | {yes-icon} | {yes-icon}            | {yes-icon} | {yes-icon}
 | 7.2–{prev-major-last}     | {no-icon}  | {no-icon}  | {yes-icon}            | {yes-icon} | {yes-icon}
 | 8.0–{minor-version}       | {no-icon}  | {no-icon}  | {no-icon}             | {yes-icon} | {yes-icon}
 |====
+[[fn-archive]]
+[small]#1. Supported with <<archive-indices,archive indices>>.#


### PR DESCRIPTION
Backports the following commits to 8.4:
 - [DOCS] Fixed footnote. Closes #89403 (#90541)