### PR TITLE
Fix usage of `IndexAccessControl` in `CustomAuthorizationEngine`

### DIFF
--- a/build-conventions/src/main/java/org/elasticsearch/gradle/internal/conventions/VersionPropertiesPlugin.java
+++ b/build-conventions/src/main/java/org/elasticsearch/gradle/internal/conventions/VersionPropertiesPlugin.java
@@ -33,9 +33,10 @@ public class VersionPropertiesPlugin implements Plugin<Project> {
 
     private static File locateElasticsearchWorkspace(Gradle project) {
         if (project.getParent() == null) {
-            // See if "elasticsearch" is one of the included builds, if so use that project directory
+            // See if any of these included builds is the Elasticsearch project
             for (IncludedBuild includedBuild : project.getIncludedBuilds()) {
-                if (includedBuild.getName().equals("elasticsearch")) {
+                File versionProperties = new File(includedBuild.getProjectDir(), "build-tools-internal/version.properties");
+                if (versionProperties.exists()) {
                     return includedBuild.getProjectDir();
                 }
             }

--- a/build-conventions/src/main/java/org/elasticsearch/gradle/internal/conventions/VersionPropertiesPlugin.java
+++ b/build-conventions/src/main/java/org/elasticsearch/gradle/internal/conventions/VersionPropertiesPlugin.java
@@ -21,7 +21,9 @@ public class VersionPropertiesPlugin implements Plugin<Project> {
     @Override
     public void apply(Project project) {
         File workspaceDir = locateElasticsearchWorkspace(project.getGradle());
-
+        if (workspaceDir == null) {
+            workspaceDir = project.getRootDir();
+        }
         // Register the service if not done yet
         File infoPath = new File(workspaceDir, "build-tools-internal");
         Provider<VersionPropertiesBuildService> serviceProvider = project.getGradle().getSharedServices()
@@ -41,7 +43,11 @@ public class VersionPropertiesPlugin implements Plugin<Project> {
             }
 
             // Otherwise assume this project is the root elasticsearch workspace
-            return project.getRootProject().getRootDir();
+            if (project.getRootProject().getName().equals("elasticsearch")) {
+                return project.getRootProject().getRootDir();
+            } else {
+                return null;
+            }
         } else {
             // We're an included build, so keep looking
             return locateElasticsearchWorkspace(project.getParent());

--- a/build-conventions/src/main/java/org/elasticsearch/gradle/internal/conventions/VersionPropertiesPlugin.java
+++ b/build-conventions/src/main/java/org/elasticsearch/gradle/internal/conventions/VersionPropertiesPlugin.java
@@ -22,7 +22,7 @@ public class VersionPropertiesPlugin implements Plugin<Project> {
     public void apply(Project project) {
         File workspaceDir = locateElasticsearchWorkspace(project.getGradle());
         if (workspaceDir == null) {
-            workspaceDir = project.getRootDir();
+            workspaceDir = project.getRootDir().getParentFile();
         }
         // Register the service if not done yet
         File infoPath = new File(workspaceDir, "build-tools-internal");

--- a/build-conventions/src/main/java/org/elasticsearch/gradle/internal/conventions/VersionPropertiesPlugin.java
+++ b/build-conventions/src/main/java/org/elasticsearch/gradle/internal/conventions/VersionPropertiesPlugin.java
@@ -21,9 +21,7 @@ public class VersionPropertiesPlugin implements Plugin<Project> {
     @Override
     public void apply(Project project) {
         File workspaceDir = locateElasticsearchWorkspace(project.getGradle());
-        if (workspaceDir == null) {
-            workspaceDir = project.getRootDir().getParentFile();
-        }
+
         // Register the service if not done yet
         File infoPath = new File(workspaceDir, "build-tools-internal");
         Provider<VersionPropertiesBuildService> serviceProvider = project.getGradle().getSharedServices()
@@ -43,11 +41,7 @@ public class VersionPropertiesPlugin implements Plugin<Project> {
             }
 
             // Otherwise assume this project is the root elasticsearch workspace
-            if (project.getRootProject().getName().equals("elasticsearch")) {
-                return project.getRootProject().getRootDir();
-            } else {
-                return null;
-            }
+            return project.getRootProject().getRootDir();
         } else {
             // We're an included build, so keep looking
             return locateElasticsearchWorkspace(project.getParent());

--- a/plugins/examples/security-authorization-engine/src/main/java/org/elasticsearch/example/CustomAuthorizationEngine.java
+++ b/plugins/examples/security-authorization-engine/src/main/java/org/elasticsearch/example/CustomAuthorizationEngine.java
@@ -92,7 +92,7 @@ public class CustomAuthorizationEngine implements AuthorizationEngine {
                     indexAccessControlMap.put(name, new IndexAccessControl(FieldPermissions.DEFAULT, null));
                 }
                 IndicesAccessControl indicesAccessControl =
-                    new IndicesAccessControl(Collections.unmodifiableMap(indexAccessControlMap));
+                    new IndicesAccessControl(true, Collections.unmodifiableMap(indexAccessControlMap));
                 listener.onResponse(new IndexAuthorizationResult(true, indicesAccessControl));
             }, listener::onFailure));
         } else {

--- a/plugins/examples/security-authorization-engine/src/main/java/org/elasticsearch/example/CustomAuthorizationEngine.java
+++ b/plugins/examples/security-authorization-engine/src/main/java/org/elasticsearch/example/CustomAuthorizationEngine.java
@@ -89,10 +89,10 @@ public class CustomAuthorizationEngine implements AuthorizationEngine {
             indicesAsyncSupplier.getAsync(ActionListener.wrap(resolvedIndices -> {
                 Map<String, IndexAccessControl> indexAccessControlMap = new HashMap<>();
                 for (String name : resolvedIndices.getLocal()) {
-                    indexAccessControlMap.put(name, new IndexAccessControl(true, FieldPermissions.DEFAULT, null));
+                    indexAccessControlMap.put(name, new IndexAccessControl(FieldPermissions.DEFAULT, null));
                 }
                 IndicesAccessControl indicesAccessControl =
-                    new IndicesAccessControl(true, Collections.unmodifiableMap(indexAccessControlMap));
+                    new IndicesAccessControl(Collections.unmodifiableMap(indexAccessControlMap));
                 listener.onResponse(new IndexAuthorizationResult(true, indicesAccessControl));
             }, listener::onFailure));
         } else {

--- a/plugins/examples/security-authorization-engine/src/test/java/org/elasticsearch/example/CustomAuthorizationEngineTests.java
+++ b/plugins/examples/security-authorization-engine/src/test/java/org/elasticsearch/example/CustomAuthorizationEngineTests.java
@@ -145,7 +145,6 @@ public class CustomAuthorizationEngineTests extends ESTestCase {
             assertThat(result.isAuditable(), is(true));
             IndicesAccessControl indicesAccessControl = result.getIndicesAccessControl();
             assertNotNull(indicesAccessControl.getIndexPermissions("index"));
-            assertThat(indicesAccessControl.getIndexPermissions("index").isGranted(), is(true));
         }
 
         // unauthorized


### PR DESCRIPTION
`CustomAuthorizationEngine` compilation is failing due to recent changes to `IndexAccessControl` constructor.
Constructor of `IndexAccessControl` has been changed to remove `granted` flag.

This caused compilation errors when running `elasticsearch-ci/example-plugins`:

https://elasticsearch-ci.elastic.co/job/elastic+elasticsearch+main+periodic+example-plugins/388/console