### PR TITLE
[8.5] Fix overcounting recovered bytes after network disconnect  (#90477)

### DIFF
--- a/docs/changelog/90477.yaml
+++ b/docs/changelog/90477.yaml
@@ -1,0 +1,6 @@
+pr: 90477
+summary: Fix overcounting recovered bytes after network disconnect
+area: Recovery
+type: bug
+issues:
+ - 90441

--- a/server/src/main/java/org/elasticsearch/index/shard/IndexShard.java
+++ b/server/src/main/java/org/elasticsearch/index/shard/IndexShard.java
@@ -2001,7 +2001,9 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
         if (state != IndexShardState.RECOVERING) {
             throw new IndexShardNotRecoveringException(shardId, state);
         }
-        recoveryState().setStage(RecoveryState.Stage.INIT);
+        synchronized (mutex) {
+            this.recoveryState = recoveryState().reset();
+        }
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/indices/recovery/MultiFileWriter.java
+++ b/server/src/main/java/org/elasticsearch/indices/recovery/MultiFileWriter.java
@@ -117,18 +117,6 @@ public class MultiFileWriter extends AbstractRefCounted implements Releasable {
         }
     }
 
-    public void deleteTempFiles() {
-        incRef();
-        try {
-            for (String tempFileName : tempFileNames.keySet()) {
-                store.deleteQuiet(tempFileName);
-            }
-            tempFileNames.clear();
-        } finally {
-            decRef();
-        }
-    }
-
     /** Get a temporary name for the provided file name. */
     String getTempNameForFile(String origFile) {
         return tempFilePrefix + origFile;

--- a/server/src/main/java/org/elasticsearch/indices/recovery/RecoveryState.java
+++ b/server/src/main/java/org/elasticsearch/indices/recovery/RecoveryState.java
@@ -109,12 +109,27 @@ public class RecoveryState implements ToXContentFragment, Writeable {
     }
 
     public RecoveryState(ShardRouting shardRouting, DiscoveryNode targetNode, @Nullable DiscoveryNode sourceNode, Index index) {
+        this(shardRouting.shardId(), shardRouting.primary(), shardRouting.recoverySource(), sourceNode, targetNode, index, new Timer());
         assert shardRouting.initializing() : "only allow initializing shard routing to be recovered: " + shardRouting;
-        RecoverySource recoverySource = shardRouting.recoverySource();
-        assert (recoverySource.getType() == RecoverySource.Type.PEER) == (sourceNode != null)
-            : "peer recovery requires source node, recovery type: " + recoverySource.getType() + " source node: " + sourceNode;
-        this.shardId = shardRouting.shardId();
-        this.primary = shardRouting.primary();
+        assert (shardRouting.recoverySource().getType() == RecoverySource.Type.PEER) == (sourceNode != null)
+            : "peer recovery requires source node, recovery type: "
+                + shardRouting.recoverySource().getType()
+                + " source node: "
+                + sourceNode;
+        timer.start();
+    }
+
+    private RecoveryState(
+        ShardId shardId,
+        boolean primary,
+        RecoverySource recoverySource,
+        DiscoveryNode sourceNode,
+        DiscoveryNode targetNode,
+        Index index,
+        Timer timer
+    ) {
+        this.shardId = shardId;
+        this.primary = primary;
         this.recoverySource = recoverySource;
         this.sourceNode = sourceNode;
         this.targetNode = targetNode;
@@ -122,8 +137,7 @@ public class RecoveryState implements ToXContentFragment, Writeable {
         this.index = index;
         translog = new Translog();
         verifyIndex = new VerifyIndex();
-        timer = new Timer();
-        timer.start();
+        this.timer = timer;
     }
 
     public RecoveryState(StreamInput in) throws IOException {
@@ -214,6 +228,14 @@ public class RecoveryState implements ToXContentFragment, Writeable {
             default -> throw new IllegalArgumentException("unknown RecoveryState.Stage [" + stage + "]");
         }
         return this;
+    }
+
+    /**
+     * Resets the stage to the initial state and clears all index, verify index and translog information keeping the original timing
+     * information
+     */
+    public RecoveryState reset() {
+        return new RecoveryState(shardId, primary, recoverySource, sourceNode, targetNode, new Index(), timer);
     }
 
     public synchronized RecoveryState setLocalTranslogStage() {

--- a/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/recovery/SearchableSnapshotRecoveryState.java
+++ b/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/recovery/SearchableSnapshotRecoveryState.java
@@ -52,6 +52,13 @@ public final class SearchableSnapshotRecoveryState extends RecoveryState {
     }
 
     @Override
+    public synchronized RecoveryState reset() {
+        // In searchable snapshots we won't run into #90441, therefore we don't need to create a new copy
+        setStage(Stage.INIT);
+        return this;
+    }
+
+    @Override
     public synchronized void validateCurrentStage(Stage expected) {
         if (remoteTranslogSet == false) {
             super.validateCurrentStage(expected);


### PR DESCRIPTION
Backports the following commits to 8.5:
 - Fix overcounting recovered bytes after network disconnect  (#90477)