### PR TITLE
[8.5] Fix #90558 by resolving the backing index name earlier in the process (#90563)

### DIFF
--- a/modules/data-streams/src/internalClusterTest/java/org/elasticsearch/datastreams/DataStreamsSnapshotsIT.java
+++ b/modules/data-streams/src/internalClusterTest/java/org/elasticsearch/datastreams/DataStreamsSnapshotsIT.java
@@ -256,7 +256,8 @@ public class DataStreamsSnapshotsIT extends AbstractSnapshotIntegTestCase {
         RolloverRequest rolloverRequest = new RolloverRequest("ds", null);
         RolloverResponse rolloverResponse = client.admin().indices().rolloverIndex(rolloverRequest).actionGet();
         assertThat(rolloverResponse.isRolledOver(), is(true));
-        assertThat(rolloverResponse.getNewIndex(), equalTo(DataStream.getDefaultBackingIndexName("ds", 2)));
+        String backingIndexAfterSnapshot = DataStream.getDefaultBackingIndexName("ds", 2);
+        assertThat(rolloverResponse.getNewIndex(), equalTo(backingIndexAfterSnapshot));
 
         // Close all backing indices of ds data stream:
         CloseIndexRequest closeIndexRequest = new CloseIndexRequest(".ds-ds-*");
@@ -287,7 +288,7 @@ public class DataStreamsSnapshotsIT extends AbstractSnapshotIntegTestCase {
         assertThat(backingIndices.stream().map(Index::getName).collect(Collectors.toList()), contains(equalTo(dsBackingIndexName)));
 
         // The backing index created as part of rollover should still exist (but just not part of the data stream)
-        assertThat(indexExists(DataStream.getDefaultBackingIndexName("ds", 2)), is(true));
+        assertThat(indexExists(backingIndexAfterSnapshot), is(true));
         // An additional rollover should create a new backing index (3th generation) and leave .ds-ds-...-2 index as is:
         rolloverRequest = new RolloverRequest("ds", null);
         rolloverResponse = client.admin().indices().rolloverIndex(rolloverRequest).actionGet();
@@ -857,6 +858,11 @@ public class DataStreamsSnapshotsIT extends AbstractSnapshotIntegTestCase {
         }
         refresh();
         assertDocCount(dataStream, 100L);
+        // Resolve backing index name after the data stream has been created because it has a date component,
+        // and running around midnight could lead to test failures otherwise
+        GetDataStreamAction.Request getDataStreamRequest = new GetDataStreamAction.Request(new String[] { dataStream });
+        GetDataStreamAction.Response getDataStreamResponse = client.execute(GetDataStreamAction.INSTANCE, getDataStreamRequest).actionGet();
+        String backingIndexName = getDataStreamResponse.getDataStreams().get(0).getDataStream().getIndices().get(0).getName();
 
         logger.info("--> snapshot");
         ActionFuture<CreateSnapshotResponse> future = client1.admin()
@@ -887,7 +893,7 @@ public class DataStreamsSnapshotsIT extends AbstractSnapshotIntegTestCase {
         SnapshotInfo snapshotInfo = createSnapshotResponse.getSnapshotInfo();
         assertThat(snapshotInfo.state(), equalTo((SnapshotState.SUCCESS)));
         assertThat(snapshotInfo.dataStreams(), contains(dataStream));
-        assertThat(snapshotInfo.indices(), contains(DataStream.getDefaultBackingIndexName(dataStream, 1)));
+        assertThat(snapshotInfo.indices(), contains(backingIndexName));
     }
 
     public void testCloneSnapshotThatIncludesDataStream() throws Exception {


### PR DESCRIPTION
Backports the following commits to 8.5:
 - Fix #90558 by resolving the backing index name earlier in the process (#90563)