### PR TITLE
[8.5] JoinValidationService: cleanup even on Error (#90597)

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/coordination/JoinValidationService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/JoinValidationService.java
@@ -349,13 +349,13 @@ public class JoinValidationService {
                 newBytes.length()
             );
             final var previousBytes = statesByVersion.put(version, newBytes);
-            success = true;
             assert previousBytes == null;
+            success = true;
             return newBytes;
         } finally {
             if (success == false) {
-                assert false;
                 bytesStream.close();
+                assert false;
             }
         }
     }


### PR DESCRIPTION
Backports the following commits to 8.5:
 - JoinValidationService: cleanup even on Error (#90597)