### PR TITLE
Add assertion about not double-calling RestChannel#sendResponse

### DIFF
--- a/server/src/main/java/org/elasticsearch/rest/RestController.java
+++ b/server/src/main/java/org/elasticsearch/rest/RestController.java
@@ -757,7 +757,9 @@ public class RestController implements HttpServerTransport.Dispatcher {
         private void close() {
             // attempt to close once atomically
             if (closed.compareAndSet(false, true) == false) {
-                throw new IllegalStateException("Channel is already closed");
+                final IllegalStateException e = new IllegalStateException("Channel is already closed");
+                assert false : e; // this is always a bug, we tried to send two responses to the same channel
+                throw e;
             }
             inFlightRequestsBreaker(circuitBreakerService).addWithoutBreaking(-contentLength);
         }

--- a/server/src/test/java/org/elasticsearch/rest/RestControllerTests.java
+++ b/server/src/test/java/org/elasticsearch/rest/RestControllerTests.java
@@ -64,6 +64,7 @@ import static org.elasticsearch.rest.RestRequest.Method.OPTIONS;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
 import static org.mockito.ArgumentMatchers.any;
@@ -384,7 +385,11 @@ public class RestControllerTests extends ESTestCase {
             }
         };
 
-        restController.dispatchRequest(request, channel, client.threadPool().getThreadContext());
+        try {
+            restController.dispatchRequest(request, channel, client.threadPool().getThreadContext());
+        } catch (AssertionError e) {
+            assertThat(e.getCause(), instanceOf(IllegalStateException.class));
+        }
 
         assertEquals(0, inFlightRequestsBreaker.getTrippedCount());
         assertEquals(0, inFlightRequestsBreaker.getUsed());


### PR DESCRIPTION
Adds the assertion requested in #89902 now that all the double sending bugs should be fixed.

closes #89902
