### PR TITLE
Remove the regex filter from the mock log appender

### DIFF
--- a/docs/changelog/90607.yaml
+++ b/docs/changelog/90607.yaml
@@ -1,5 +1,0 @@
-pr: 90607
-summary: Remove the regex filter from the mock log appender
-area: Infra/Core
-type: bug
-issues: []

--- a/docs/changelog/90607.yaml
+++ b/docs/changelog/90607.yaml
@@ -1,0 +1,5 @@
+pr: 90607
+summary: Remove the regex filter from the mock log appender
+area: Infra/Core
+type: bug
+issues: []

--- a/test/framework/src/main/java/org/elasticsearch/test/MockLogAppender.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/MockLogAppender.java
@@ -10,7 +10,7 @@ package org.elasticsearch.test;
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.core.LogEvent;
 import org.apache.logging.log4j.core.appender.AbstractAppender;
-import org.apache.logging.log4j.core.filter.RegexFilter;
+import org.apache.logging.log4j.core.config.Property;
 import org.elasticsearch.common.regex.Regex;
 
 import java.util.List;
@@ -29,8 +29,8 @@ public class MockLogAppender extends AbstractAppender {
 
     private List<LoggingExpectation> expectations;
 
-    public MockLogAppender() throws IllegalAccessException {
-        super("mock", RegexFilter.createFilter(".*(\n.*)*", new String[0], false, null, null), null, false);
+    public MockLogAppender() {
+        super("mock", null, null, false, Property.EMPTY_ARRAY);
         /*
          * We use a copy-on-write array list since log messages could be appended while we are setting up expectations. When that occurs,
          * we would run into a concurrent modification exception from the iteration over the expectations in #append, concurrent with a

--- a/test/framework/src/main/java/org/elasticsearch/test/MockLogAppender.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/MockLogAppender.java
@@ -27,7 +27,7 @@ public class MockLogAppender extends AbstractAppender {
 
     private static final String COMMON_PREFIX = System.getProperty("es.logger.prefix", "org.elasticsearch.");
 
-    private List<LoggingExpectation> expectations;
+    private final List<LoggingExpectation> expectations;
 
     public MockLogAppender() {
         super("mock", null, null, false, Property.EMPTY_ARRAY);


### PR DESCRIPTION
This is for issue #90596 

The `.*` regex on the mock log appender filters out some characters that can appear in random unicode strings (depending on the random seed), breaking tests that look at log statements for some specific seeds. This filter doesn't seem to do anything in particular, so I've removed it.