### PR TITLE
Introduce singleton for empty IngestStats.Stats

### DIFF
--- a/server/src/main/java/org/elasticsearch/ingest/IngestMetric.java
+++ b/server/src/main/java/org/elasticsearch/ingest/IngestMetric.java
@@ -102,6 +102,6 @@ class IngestMetric {
         long ingestTimeInMillis = TimeUnit.NANOSECONDS.toMillis(ingestTimeInNanos.count());
         // It is possible for the current count to briefly drop below 0, causing serialization problems. See #90319
         long currentCount = Math.max(0, ingestCurrent.get());
-        return new IngestStats.Stats(ingestCount.count(), ingestTimeInMillis, currentCount, ingestFailed.count());
+        return IngestStats.Stats.of(ingestCount.count(), ingestTimeInMillis, currentCount, ingestFailed.count());
     }
 }

--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/node/stats/NodeStatsTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/node/stats/NodeStatsTests.java
@@ -944,7 +944,7 @@ public class NodeStatsTests extends ESTestCase {
             int numPipelines = randomIntBetween(0, 10);
             int numProcessors = randomIntBetween(0, 10);
             long maxStatValue = Long.MAX_VALUE / Math.max(1, numPipelines) / Math.max(1, numProcessors);
-            IngestStats.Stats totalStats = new IngestStats.Stats(
+            IngestStats.Stats totalStats = IngestStats.Stats.of(
                 randomLongBetween(0, maxStatValue),
                 randomLongBetween(0, maxStatValue),
                 randomLongBetween(0, maxStatValue),
@@ -957,7 +957,7 @@ public class NodeStatsTests extends ESTestCase {
                 ingestPipelineStats.add(
                     new IngestStats.PipelineStat(
                         pipelineId,
-                        new IngestStats.Stats(
+                        IngestStats.Stats.of(
                             randomLongBetween(0, maxStatValue),
                             randomLongBetween(0, maxStatValue),
                             randomLongBetween(0, maxStatValue),
@@ -968,7 +968,7 @@ public class NodeStatsTests extends ESTestCase {
 
                 List<IngestStats.ProcessorStat> processorPerPipeline = new ArrayList<>(numProcessors);
                 for (int j = 0; j < numProcessors; j++) {
-                    IngestStats.Stats processorStats = new IngestStats.Stats(
+                    IngestStats.Stats processorStats = IngestStats.Stats.of(
                         randomLongBetween(0, maxStatValue),
                         randomLongBetween(0, maxStatValue),
                         randomLongBetween(0, maxStatValue),

--- a/server/src/test/java/org/elasticsearch/ingest/IngestStatsTests.java
+++ b/server/src/test/java/org/elasticsearch/ingest/IngestStatsTests.java
@@ -23,7 +23,7 @@ import java.util.stream.Stream;
 public class IngestStatsTests extends ESTestCase {
 
     public void testSerialization() throws IOException {
-        IngestStats.Stats totalStats = new IngestStats.Stats(50, 100, 200, 300);
+        IngestStats.Stats totalStats = IngestStats.Stats.of(50, 100, 200, 300);
         List<IngestStats.PipelineStat> pipelineStats = createPipelineStats();
         Map<String, List<IngestStats.ProcessorStat>> processorStats = createProcessorStats(pipelineStats);
         IngestStats ingestStats = new IngestStats(totalStats, pipelineStats, processorStats);
@@ -32,20 +32,20 @@ public class IngestStatsTests extends ESTestCase {
     }
 
     private List<IngestStats.PipelineStat> createPipelineStats() {
-        IngestStats.PipelineStat pipeline1Stats = new IngestStats.PipelineStat("pipeline1", new IngestStats.Stats(3, 3, 3, 3));
-        IngestStats.PipelineStat pipeline2Stats = new IngestStats.PipelineStat("pipeline2", new IngestStats.Stats(47, 97, 197, 297));
-        IngestStats.PipelineStat pipeline3Stats = new IngestStats.PipelineStat("pipeline3", new IngestStats.Stats(0, 0, 0, 0));
+        IngestStats.PipelineStat pipeline1Stats = new IngestStats.PipelineStat("pipeline1", IngestStats.Stats.of(3, 3, 3, 3));
+        IngestStats.PipelineStat pipeline2Stats = new IngestStats.PipelineStat("pipeline2", IngestStats.Stats.of(47, 97, 197, 297));
+        IngestStats.PipelineStat pipeline3Stats = new IngestStats.PipelineStat("pipeline3", IngestStats.Stats.of(0, 0, 0, 0));
         return Stream.of(pipeline1Stats, pipeline2Stats, pipeline3Stats).toList();
     }
 
     private Map<String, List<IngestStats.ProcessorStat>> createProcessorStats(List<IngestStats.PipelineStat> pipelineStats) {
         assert (pipelineStats.size() >= 2);
-        IngestStats.ProcessorStat processor1Stat = new IngestStats.ProcessorStat("processor1", "type", new IngestStats.Stats(1, 1, 1, 1));
-        IngestStats.ProcessorStat processor2Stat = new IngestStats.ProcessorStat("processor2", "type", new IngestStats.Stats(2, 2, 2, 2));
+        IngestStats.ProcessorStat processor1Stat = new IngestStats.ProcessorStat("processor1", "type", IngestStats.Stats.of(1, 1, 1, 1));
+        IngestStats.ProcessorStat processor2Stat = new IngestStats.ProcessorStat("processor2", "type", IngestStats.Stats.of(2, 2, 2, 2));
         IngestStats.ProcessorStat processor3Stat = new IngestStats.ProcessorStat(
             "processor3",
             "type",
-            new IngestStats.Stats(47, 97, 197, 297)
+            IngestStats.Stats.of(47, 97, 197, 297)
         );
         // pipeline1 -> processor1,processor2; pipeline2 -> processor3
         return MapBuilder.<String, List<IngestStats.ProcessorStat>>newMapBuilder()

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/GetTrainedModelsStatsAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/GetTrainedModelsStatsAction.java
@@ -93,7 +93,7 @@ public class GetTrainedModelsStatsAction extends ActionType<GetTrainedModelsStat
             private final int pipelineCount;
 
             private static final IngestStats EMPTY_INGEST_STATS = new IngestStats(
-                new IngestStats.Stats(0, 0, 0, 0),
+                IngestStats.Stats.of(0, 0, 0, 0),
                 Collections.emptyList(),
                 Collections.emptyMap()
             );

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/action/GetTrainedModelsStatsActionResponseTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/action/GetTrainedModelsStatsActionResponseTests.java
@@ -49,14 +49,14 @@ public class GetTrainedModelsStatsActionResponseTests extends AbstractBWCWireSer
     private IngestStats randomIngestStats() {
         List<String> pipelineIds = Stream.generate(() -> randomAlphaOfLength(10)).limit(randomIntBetween(0, 10)).toList();
         return new IngestStats(
-            new IngestStats.Stats(randomNonNegativeLong(), randomNonNegativeLong(), randomNonNegativeLong(), randomNonNegativeLong()),
+            IngestStats.Stats.of(randomNonNegativeLong(), randomNonNegativeLong(), randomNonNegativeLong(), randomNonNegativeLong()),
             pipelineIds.stream().map(id -> new IngestStats.PipelineStat(id, randomStats())).collect(Collectors.toList()),
             pipelineIds.stream().collect(Collectors.toMap(Function.identity(), (v) -> randomProcessorStats()))
         );
     }
 
     private IngestStats.Stats randomStats() {
-        return new IngestStats.Stats(randomNonNegativeLong(), randomNonNegativeLong(), randomNonNegativeLong(), randomNonNegativeLong());
+        return IngestStats.Stats.of(randomNonNegativeLong(), randomNonNegativeLong(), randomNonNegativeLong(), randomNonNegativeLong());
     }
 
     private List<IngestStats.ProcessorStat> randomProcessorStats() {

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportGetTrainedModelsStatsAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportGetTrainedModelsStatsAction.java
@@ -283,7 +283,7 @@ public class TransportGetTrainedModelsStatsAction extends HandledTransportAction
         });
 
         return new IngestStats(
-            new IngestStats.Stats(ingestCount.count(), ingestTimeInMillis.count(), ingestCurrent.count(), ingestFailedCount.count()),
+            IngestStats.Stats.of(ingestCount.count(), ingestTimeInMillis.count(), ingestCurrent.count(), ingestFailedCount.count()),
             filteredPipelineStats,
             filteredProcessorStats
         );
@@ -354,7 +354,7 @@ public class TransportGetTrainedModelsStatsAction extends HandledTransportAction
         }
 
         IngestStats.Stats build() {
-            return new IngestStats.Stats(ingestCount.count(), ingestTimeInMillis.count(), ingestCurrent.count(), ingestFailedCount.count());
+            return IngestStats.Stats.of(ingestCount.count(), ingestTimeInMillis.count(), ingestCurrent.count(), ingestFailedCount.count());
         }
     }
 

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/MachineLearningInfoTransportActionTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/MachineLearningInfoTransportActionTests.java
@@ -282,7 +282,7 @@ public class MachineLearningInfoTransportActionTests extends ESTestCase {
                             trainedModel1.getModelId(),
                             new TrainedModelSizeStats(trainedModel1.getModelSize(), 0L),
                             new IngestStats(
-                                new IngestStats.Stats(0, 0, 0, 0),
+                                IngestStats.Stats.of(0, 0, 0, 0),
                                 List.of(),
                                 Map.of(
                                     "pipeline_1",
@@ -290,15 +290,15 @@ public class MachineLearningInfoTransportActionTests extends ESTestCase {
                                         new IngestStats.ProcessorStat(
                                             InferenceProcessor.TYPE,
                                             InferenceProcessor.TYPE,
-                                            new IngestStats.Stats(10, 1, 1000, 100)
+                                            IngestStats.Stats.of(10, 1, 1000, 100)
                                         ),
                                         new IngestStats.ProcessorStat(
                                             InferenceProcessor.TYPE,
                                             InferenceProcessor.TYPE,
-                                            new IngestStats.Stats(20, 2, 2000, 200)
+                                            IngestStats.Stats.of(20, 2, 2000, 200)
                                         ),
                                         // Adding a non inference processor that should be ignored
-                                        new IngestStats.ProcessorStat("grok", "grok", new IngestStats.Stats(100, 100, 100, 100))
+                                        new IngestStats.ProcessorStat("grok", "grok", IngestStats.Stats.of(100, 100, 100, 100))
                                     )
                                 )
                             ),
@@ -310,7 +310,7 @@ public class MachineLearningInfoTransportActionTests extends ESTestCase {
                             trainedModel2.getModelId(),
                             new TrainedModelSizeStats(trainedModel2.getModelSize(), 0L),
                             new IngestStats(
-                                new IngestStats.Stats(0, 0, 0, 0),
+                                IngestStats.Stats.of(0, 0, 0, 0),
                                 List.of(),
                                 Map.of(
                                     "pipeline_1",
@@ -318,7 +318,7 @@ public class MachineLearningInfoTransportActionTests extends ESTestCase {
                                         new IngestStats.ProcessorStat(
                                             InferenceProcessor.TYPE,
                                             InferenceProcessor.TYPE,
-                                            new IngestStats.Stats(30, 3, 3000, 300)
+                                            IngestStats.Stats.of(30, 3, 3000, 300)
                                         )
                                     )
                                 )
@@ -331,7 +331,7 @@ public class MachineLearningInfoTransportActionTests extends ESTestCase {
                             trainedModel3.getModelId(),
                             new TrainedModelSizeStats(trainedModel3.getModelSize(), 0L),
                             new IngestStats(
-                                new IngestStats.Stats(0, 0, 0, 0),
+                                IngestStats.Stats.of(0, 0, 0, 0),
                                 List.of(),
                                 Map.of(
                                     "pipeline_2",
@@ -339,7 +339,7 @@ public class MachineLearningInfoTransportActionTests extends ESTestCase {
                                         new IngestStats.ProcessorStat(
                                             InferenceProcessor.TYPE,
                                             InferenceProcessor.TYPE,
-                                            new IngestStats.Stats(40, 4, 4000, 400)
+                                            IngestStats.Stats.of(40, 4, 4000, 400)
                                         )
                                     )
                                 )
@@ -354,7 +354,7 @@ public class MachineLearningInfoTransportActionTests extends ESTestCase {
                             trainedModel4.getModelId(),
                             new TrainedModelSizeStats(trainedModel4.getModelSize(), 0L),
                             new IngestStats(
-                                new IngestStats.Stats(0, 0, 0, 0),
+                                IngestStats.Stats.of(0, 0, 0, 0),
                                 List.of(),
                                 Map.of(
                                     "pipeline_3",
@@ -362,7 +362,7 @@ public class MachineLearningInfoTransportActionTests extends ESTestCase {
                                         new IngestStats.ProcessorStat(
                                             InferenceProcessor.TYPE,
                                             InferenceProcessor.TYPE,
-                                            new IngestStats.Stats(50, 5, 5000, 500)
+                                            IngestStats.Stats.of(50, 5, 5000, 500)
                                         )
                                     )
                                 )

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/action/TransportGetTrainedModelsStatsActionTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/action/TransportGetTrainedModelsStatsActionTests.java
@@ -131,47 +131,43 @@ public class TransportGetTrainedModelsStatsActionTests extends ESTestCase {
     public void testInferenceIngestStatsByModelId() {
         List<NodeStats> nodeStatsList = Arrays.asList(
             buildNodeStats(
-                new IngestStats.Stats(2, 2, 3, 4),
+                IngestStats.Stats.of(2, 2, 3, 4),
                 Arrays.asList(
-                    new IngestStats.PipelineStat("pipeline1", new IngestStats.Stats(0, 0, 3, 1)),
-                    new IngestStats.PipelineStat("pipeline2", new IngestStats.Stats(1, 1, 0, 1)),
-                    new IngestStats.PipelineStat("pipeline3", new IngestStats.Stats(2, 1, 1, 1))
+                    new IngestStats.PipelineStat("pipeline1", IngestStats.Stats.of(0, 0, 3, 1)),
+                    new IngestStats.PipelineStat("pipeline2", IngestStats.Stats.of(1, 1, 0, 1)),
+                    new IngestStats.PipelineStat("pipeline3", IngestStats.Stats.of(2, 1, 1, 1))
                 ),
                 Arrays.asList(
                     Arrays.asList(
-                        new IngestStats.ProcessorStat(InferenceProcessor.TYPE, InferenceProcessor.TYPE, new IngestStats.Stats(10, 1, 0, 0)),
-                        new IngestStats.ProcessorStat("grok", "grok", new IngestStats.Stats(10, 1, 0, 0)),
-                        new IngestStats.ProcessorStat(
-                            InferenceProcessor.TYPE,
-                            InferenceProcessor.TYPE,
-                            new IngestStats.Stats(100, 10, 0, 1)
-                        )
+                        new IngestStats.ProcessorStat(InferenceProcessor.TYPE, InferenceProcessor.TYPE, IngestStats.Stats.of(10, 1, 0, 0)),
+                        new IngestStats.ProcessorStat("grok", "grok", IngestStats.Stats.of(10, 1, 0, 0)),
+                        new IngestStats.ProcessorStat(InferenceProcessor.TYPE, InferenceProcessor.TYPE, IngestStats.Stats.of(100, 10, 0, 1))
                     ),
                     Arrays.asList(
-                        new IngestStats.ProcessorStat(InferenceProcessor.TYPE, InferenceProcessor.TYPE, new IngestStats.Stats(5, 1, 0, 0)),
-                        new IngestStats.ProcessorStat("grok", "grok", new IngestStats.Stats(10, 1, 0, 0))
+                        new IngestStats.ProcessorStat(InferenceProcessor.TYPE, InferenceProcessor.TYPE, IngestStats.Stats.of(5, 1, 0, 0)),
+                        new IngestStats.ProcessorStat("grok", "grok", IngestStats.Stats.of(10, 1, 0, 0))
                     ),
-                    Arrays.asList(new IngestStats.ProcessorStat("grok", "grok", new IngestStats.Stats(10, 1, 0, 0)))
+                    Arrays.asList(new IngestStats.ProcessorStat("grok", "grok", IngestStats.Stats.of(10, 1, 0, 0)))
                 )
             ),
             buildNodeStats(
-                new IngestStats.Stats(15, 5, 3, 4),
+                IngestStats.Stats.of(15, 5, 3, 4),
                 Arrays.asList(
-                    new IngestStats.PipelineStat("pipeline1", new IngestStats.Stats(10, 1, 3, 1)),
-                    new IngestStats.PipelineStat("pipeline2", new IngestStats.Stats(1, 1, 0, 1)),
-                    new IngestStats.PipelineStat("pipeline3", new IngestStats.Stats(2, 1, 1, 1))
+                    new IngestStats.PipelineStat("pipeline1", IngestStats.Stats.of(10, 1, 3, 1)),
+                    new IngestStats.PipelineStat("pipeline2", IngestStats.Stats.of(1, 1, 0, 1)),
+                    new IngestStats.PipelineStat("pipeline3", IngestStats.Stats.of(2, 1, 1, 1))
                 ),
                 Arrays.asList(
                     Arrays.asList(
-                        new IngestStats.ProcessorStat(InferenceProcessor.TYPE, InferenceProcessor.TYPE, new IngestStats.Stats(0, 0, 0, 0)),
-                        new IngestStats.ProcessorStat("grok", "grok", new IngestStats.Stats(0, 0, 0, 0)),
-                        new IngestStats.ProcessorStat(InferenceProcessor.TYPE, InferenceProcessor.TYPE, new IngestStats.Stats(10, 1, 0, 0))
+                        new IngestStats.ProcessorStat(InferenceProcessor.TYPE, InferenceProcessor.TYPE, IngestStats.Stats.of(0, 0, 0, 0)),
+                        new IngestStats.ProcessorStat("grok", "grok", IngestStats.Stats.of(0, 0, 0, 0)),
+                        new IngestStats.ProcessorStat(InferenceProcessor.TYPE, InferenceProcessor.TYPE, IngestStats.Stats.of(10, 1, 0, 0))
                     ),
                     Arrays.asList(
-                        new IngestStats.ProcessorStat(InferenceProcessor.TYPE, InferenceProcessor.TYPE, new IngestStats.Stats(5, 1, 0, 0)),
-                        new IngestStats.ProcessorStat("grok", "grok", new IngestStats.Stats(10, 1, 0, 0))
+                        new IngestStats.ProcessorStat(InferenceProcessor.TYPE, InferenceProcessor.TYPE, IngestStats.Stats.of(5, 1, 0, 0)),
+                        new IngestStats.ProcessorStat("grok", "grok", IngestStats.Stats.of(10, 1, 0, 0))
                     ),
-                    Arrays.asList(new IngestStats.ProcessorStat("grok", "grok", new IngestStats.Stats(10, 1, 0, 0)))
+                    Arrays.asList(new IngestStats.ProcessorStat("grok", "grok", IngestStats.Stats.of(10, 1, 0, 0)))
                 )
             )
         );
@@ -193,37 +189,37 @@ public class TransportGetTrainedModelsStatsActionTests extends ESTestCase {
         assertThat(ingestStatsMap.keySet(), equalTo(new HashSet<>(Arrays.asList("trained_model_1", "trained_model_2"))));
 
         IngestStats expectedStatsModel1 = new IngestStats(
-            new IngestStats.Stats(10, 1, 6, 2),
-            Collections.singletonList(new IngestStats.PipelineStat("pipeline1", new IngestStats.Stats(10, 1, 6, 2))),
+            IngestStats.Stats.of(10, 1, 6, 2),
+            Collections.singletonList(new IngestStats.PipelineStat("pipeline1", IngestStats.Stats.of(10, 1, 6, 2))),
             Collections.singletonMap(
                 "pipeline1",
                 Arrays.asList(
-                    new IngestStats.ProcessorStat("inference", "inference", new IngestStats.Stats(120, 12, 0, 1)),
-                    new IngestStats.ProcessorStat("grok", "grok", new IngestStats.Stats(10, 1, 0, 0))
+                    new IngestStats.ProcessorStat("inference", "inference", IngestStats.Stats.of(120, 12, 0, 1)),
+                    new IngestStats.ProcessorStat("grok", "grok", IngestStats.Stats.of(10, 1, 0, 0))
                 )
             )
         );
 
         IngestStats expectedStatsModel2 = new IngestStats(
-            new IngestStats.Stats(12, 3, 6, 4),
+            IngestStats.Stats.of(12, 3, 6, 4),
             Arrays.asList(
-                new IngestStats.PipelineStat("pipeline1", new IngestStats.Stats(10, 1, 6, 2)),
-                new IngestStats.PipelineStat("pipeline2", new IngestStats.Stats(2, 2, 0, 2))
+                new IngestStats.PipelineStat("pipeline1", IngestStats.Stats.of(10, 1, 6, 2)),
+                new IngestStats.PipelineStat("pipeline2", IngestStats.Stats.of(2, 2, 0, 2))
             ),
             new HashMap<>() {
                 {
                     put(
                         "pipeline2",
                         Arrays.asList(
-                            new IngestStats.ProcessorStat("inference", "inference", new IngestStats.Stats(10, 2, 0, 0)),
-                            new IngestStats.ProcessorStat("grok", "grok", new IngestStats.Stats(20, 2, 0, 0))
+                            new IngestStats.ProcessorStat("inference", "inference", IngestStats.Stats.of(10, 2, 0, 0)),
+                            new IngestStats.ProcessorStat("grok", "grok", IngestStats.Stats.of(20, 2, 0, 0))
                         )
                     );
                     put(
                         "pipeline1",
                         Arrays.asList(
-                            new IngestStats.ProcessorStat("inference", "inference", new IngestStats.Stats(120, 12, 0, 1)),
-                            new IngestStats.ProcessorStat("grok", "grok", new IngestStats.Stats(10, 1, 0, 0))
+                            new IngestStats.ProcessorStat("inference", "inference", IngestStats.Stats.of(120, 12, 0, 1)),
+                            new IngestStats.ProcessorStat("grok", "grok", IngestStats.Stats.of(10, 1, 0, 0))
                         )
                     );
                 }


### PR DESCRIPTION
Randomly found this in a user issue's heap dump. If you have a number of unused pipelines/processors and/or a larger number of nodes these empty duplicates can take up tens of MB of space needlessly when fetching stats.
