### PR TITLE
Fixing BulkProcessor deadlock

### DIFF
--- a/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/history/ILMHistoryStore.java
+++ b/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/history/ILMHistoryStore.java
@@ -64,6 +64,10 @@ public class ILMHistoryStore implements Closeable {
     private final ThreadPool threadPool;
 
     public ILMHistoryStore(Client client, ClusterService clusterService, ThreadPool threadPool) {
+        this(client, clusterService, threadPool, TimeValue.timeValueSeconds(5));
+    }
+
+    ILMHistoryStore(Client client, ClusterService clusterService, ThreadPool threadPool, TimeValue flushInterval) {
         this.setIlmHistoryEnabled(LIFECYCLE_HISTORY_INDEX_ENABLED_SETTING.get(clusterService.getSettings()));
         clusterService.getClusterSettings().addSettingsUpdateConsumer(LIFECYCLE_HISTORY_INDEX_ENABLED_SETTING, this::setIlmHistoryEnabled);
 
@@ -133,7 +137,7 @@ public class ILMHistoryStore implements Closeable {
         }, "ilm-history-store")
             .setBulkActions(-1)
             .setBulkSize(ByteSizeValue.ofBytes(ILM_HISTORY_BULK_SIZE))
-            .setFlushInterval(TimeValue.timeValueSeconds(5))
+            .setFlushInterval(flushInterval)
             .setConcurrentRequests(1)
             .setBackoffPolicy(BackoffPolicy.exponentialBackoff(TimeValue.timeValueMillis(1000), 3))
             .build();

--- a/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/ilm/history/ILMHistoryStoreTests.java
+++ b/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/ilm/history/ILMHistoryStoreTests.java
@@ -53,6 +53,7 @@ import java.util.stream.IntStream;
 import static org.elasticsearch.xpack.core.ilm.LifecycleSettings.LIFECYCLE_HISTORY_INDEX_ENABLED_SETTING;
 import static org.elasticsearch.xpack.ilm.history.ILMHistoryStore.ILM_HISTORY_DATA_STREAM;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -277,7 +278,7 @@ public class ILMHistoryStoreTests extends ESTestCase {
             });
 
             historyStore.putAsync(record);
-            assertBusy(() -> assertThat(calledTimes.get(), equalTo(1)));
+            assertBusy(() -> assertThat(calledTimes.get(), greaterThanOrEqualTo(1)));
         }
     }
 
@@ -307,6 +308,8 @@ public class ILMHistoryStoreTests extends ESTestCase {
                 listener.onResponse((Response) verifier.apply(action, request, listener));
             } catch (Exception e) {
                 listener.onFailure(e);
+            } catch (AssertionError e) {
+                // Expected
             }
         }
 

--- a/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/ilm/history/ILMHistoryStoreTests.java
+++ b/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/ilm/history/ILMHistoryStoreTests.java
@@ -212,7 +212,6 @@ public class ILMHistoryStoreTests extends ESTestCase {
         }
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/68468")
     @TestLogging(
         value = "org.elasticsearch.action.bulk:trace",
         reason = "Logging information about locks useful for tracking down deadlock"

--- a/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/ilm/history/ILMHistoryStoreTests.java
+++ b/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/ilm/history/ILMHistoryStoreTests.java
@@ -35,6 +35,7 @@ import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.test.ClusterServiceUtils;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.client.NoOpClient;
+import org.elasticsearch.test.junit.annotations.TestLogging;
 import org.elasticsearch.threadpool.TestThreadPool;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.xcontent.NamedXContentRegistry;
@@ -211,6 +212,10 @@ public class ILMHistoryStoreTests extends ESTestCase {
     }
 
     @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/68468")
+    @TestLogging(
+        value = "org.elasticsearch.action.bulk:trace",
+        reason = "Logging information about locks useful for tracking down deadlock"
+    )
     public void testDeadlock() throws Exception {
         String policyId = randomAlphaOfLength(5);
         final long timestamp = randomNonNegativeLong();


### PR DESCRIPTION
FOR DISCUSSION PURPOSES ONLY. DO NOT MERGE

This draft PR does 4 things:

- It adds a good bit of trace logging around the acquisition and release of the BulkProcessor lock and the BulkRequestHandler semaphore
- It adds a new unit test (`ILMHistoryStoreTests::testDeadlock`) that reproduces a deadlock problem in BulkProcessor.
- It fixes the `testDeadlock` test by acquiring the BulkRequestHandler semaphore inside of the consumer (so that it is never held when we try to acquire the BulkProcessor lock).
- It change `Retry` so that the queue of things to be retried is bounded, and when that bound is reached an EsRejectedException is thrown.