### PR TITLE
[Enterprise Search][Rex Demo] Introducing Engines as an index abstraction - DELETE api

### DIFF
--- a/server/src/main/java/org/elasticsearch/ElasticsearchException.java
+++ b/server/src/main/java/org/elasticsearch/ElasticsearchException.java
@@ -1585,6 +1585,12 @@ public class ElasticsearchException extends RuntimeException implements ToXConte
             UnsupportedAggregationOnDownsampledIndex::new,
             167,
             Version.V_8_5_0
+        ),
+        ENGINE_NOT_FOUND_EXCEPTION(
+            org.elasticsearch.index.EngineNotFoundException.class,
+            org.elasticsearch.index.EngineNotFoundException::new,
+            168,
+            Version.V_8_6_0
         );
 
         final Class<? extends ElasticsearchException> exceptionClass;

--- a/server/src/main/java/org/elasticsearch/cluster/ClusterModule.java
+++ b/server/src/main/java/org/elasticsearch/cluster/ClusterModule.java
@@ -24,6 +24,7 @@ import org.elasticsearch.cluster.metadata.MetadataIndexTemplateService;
 import org.elasticsearch.cluster.metadata.MetadataMappingService;
 import org.elasticsearch.cluster.metadata.NodesShutdownMetadata;
 import org.elasticsearch.cluster.metadata.RepositoriesMetadata;
+import org.elasticsearch.cluster.metadata.SearchEngineMetadata;
 import org.elasticsearch.cluster.routing.DelayedAllocationService;
 import org.elasticsearch.cluster.routing.allocation.AllocationService;
 import org.elasticsearch.cluster.routing.allocation.ExistingShardsAllocator;
@@ -168,6 +169,7 @@ public class ClusterModule extends AbstractModule {
             ComposableIndexTemplateMetadata::readDiffFrom
         );
         registerMetadataCustom(entries, DataStreamMetadata.TYPE, DataStreamMetadata::new, DataStreamMetadata::readDiffFrom);
+        registerMetadataCustom(entries, SearchEngineMetadata.TYPE, SearchEngineMetadata::new, SearchEngineMetadata::readDiffFrom);
         registerMetadataCustom(entries, NodesShutdownMetadata.TYPE, NodesShutdownMetadata::new, NodesShutdownMetadata::readDiffFrom);
         registerMetadataCustom(entries, FeatureMigrationResults.TYPE, FeatureMigrationResults::new, FeatureMigrationResults::readDiffFrom);
         registerMetadataCustom(entries, DesiredNodesMetadata.TYPE, DesiredNodesMetadata::new, DesiredNodesMetadata::readDiffFrom);
@@ -226,6 +228,13 @@ public class ClusterModule extends AbstractModule {
                 Metadata.Custom.class,
                 new ParseField(DataStreamMetadata.TYPE),
                 DataStreamMetadata::fromXContent
+            )
+        );
+        entries.add(
+            new NamedXContentRegistry.Entry(
+                Metadata.Custom.class,
+                new ParseField(SearchEngineMetadata.TYPE),
+                SearchEngineMetadata::fromXContent
             )
         );
         entries.add(

--- a/server/src/main/java/org/elasticsearch/cluster/coordination/ElasticsearchNodeCommand.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/ElasticsearchNodeCommand.java
@@ -27,6 +27,7 @@ import org.elasticsearch.cluster.metadata.ComponentTemplateMetadata;
 import org.elasticsearch.cluster.metadata.ComposableIndexTemplateMetadata;
 import org.elasticsearch.cluster.metadata.DataStreamMetadata;
 import org.elasticsearch.cluster.metadata.Metadata;
+import org.elasticsearch.cluster.metadata.SearchEngineMetadata;
 import org.elasticsearch.common.cli.EnvironmentAwareCommand;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.settings.ClusterSettings;
@@ -67,6 +68,7 @@ public abstract class ElasticsearchNodeCommand extends EnvironmentAwareCommand {
             // Currently, two unknown top-level objects are present
             if (Metadata.Custom.class.isAssignableFrom(categoryClass)) {
                 if (DataStreamMetadata.TYPE.equals(name)
+                    || SearchEngineMetadata.TYPE.equals(name)
                     || ComposableIndexTemplateMetadata.TYPE.equals(name)
                     || ComponentTemplateMetadata.TYPE.equals(name)) {
                     // DataStreamMetadata is used inside Metadata class for validation purposes and building the indicesLookup,

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/IndexAbstraction.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/IndexAbstraction.java
@@ -120,7 +120,14 @@ public interface IndexAbstraction {
          * A data stream typically has multiple backing indices, the latest of which
          * is the target for index requests.
          */
-        DATA_STREAM("data_stream");
+        DATA_STREAM("data_stream"),
+
+        /**
+         * An index abstraction that referes to an engine.
+         * An engine is used to search one or many concrete indices using a predefined
+         * search relevance configuration.
+         */
+        SEARCH_ENGINE("search_engine");
 
         private final String displayName;
 
@@ -471,6 +478,70 @@ public interface IndexAbstraction {
         @Override
         public int hashCode() {
             return Objects.hash(dataStream);
+        }
+    }
+
+    class SearchEngine implements IndexAbstraction {
+
+        private final org.elasticsearch.cluster.metadata.SearchEngine searchEngine;
+
+        public SearchEngine(org.elasticsearch.cluster.metadata.SearchEngine searchEngine) {
+            this.searchEngine = searchEngine;
+        }
+
+        @Override
+        public Type getType() {
+            return Type.SEARCH_ENGINE;
+        }
+
+        @Override
+        public String getName() {
+            return searchEngine.getName();
+        }
+
+        @Override
+        public List<Index> getIndices() {
+            return searchEngine.getIndices();
+        }
+
+        @Override
+        public Index getWriteIndex() {
+            // Search engines are read-only and does not have a write-index.
+            // Documents are written directly to backing indices.
+            return null;
+        }
+
+        @Override
+        public DataStream getParentDataStream() {
+            // Search engines can't be part of a data stream.
+            return null;
+        }
+
+        @Override
+        public boolean isHidden() {
+            return searchEngine.isHidden();
+        }
+
+        @Override
+        public boolean isSystem() {
+            return searchEngine.isSystem();
+        }
+
+        public org.elasticsearch.cluster.metadata.SearchEngine getSearchEngine() {
+            return searchEngine;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            SearchEngine that = (SearchEngine) o;
+            return searchEngine.equals(that.searchEngine);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(searchEngine);
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/IndexNameExpressionResolver.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/IndexNameExpressionResolver.java
@@ -1185,7 +1185,10 @@ public class IndexNameExpressionResolver {
                     .getIndicesLookup()
                     .values()
                     .stream()
-                    .filter(indexAbstraction -> indexAbstraction.getType() == Type.DATA_STREAM)
+                    .filter(
+                        indexAbstraction -> indexAbstraction.getType() == Type.DATA_STREAM
+                            || indexAbstraction.getType() == Type.SEARCH_ENGINE
+                    )
                     .filter(
                         indexAbstraction -> indexAbstraction.isSystem() == false
                             || context.systemIndexAccessPredicate.test(indexAbstraction.getName())
@@ -1415,7 +1418,8 @@ public class IndexNameExpressionResolver {
             return resources.flatMap(indexAbstraction -> {
                 if (context.isPreserveAliases() && indexAbstraction.getType() == Type.ALIAS) {
                     return Stream.of(indexAbstraction.getName());
-                } else if (context.isPreserveDataStreams() && indexAbstraction.getType() == Type.DATA_STREAM) {
+                } else if (context.isPreserveDataStreams() && indexAbstraction.getType() == Type.DATA_STREAM
+                    || indexAbstraction.getType() == Type.SEARCH_ENGINE) {
                     return Stream.of(indexAbstraction.getName());
                 } else {
                     Stream<IndexMetadata> indicesStateStream = indexAbstraction.getIndices().stream().map(context.state.metadata()::index);

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/IndexNameExpressionResolver.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/IndexNameExpressionResolver.java
@@ -1420,14 +1420,16 @@ public class IndexNameExpressionResolver {
                     return Stream.of(indexAbstraction.getName());
                 } else if (context.isPreserveDataStreams() && indexAbstraction.getType() == Type.DATA_STREAM
                     || indexAbstraction.getType() == Type.SEARCH_ENGINE) {
-                    return Stream.of(indexAbstraction.getName());
-                } else {
-                    Stream<IndexMetadata> indicesStateStream = indexAbstraction.getIndices().stream().map(context.state.metadata()::index);
-                    if (excludeState != null) {
-                        indicesStateStream = indicesStateStream.filter(indexMeta -> indexMeta.getState() != excludeState);
+                        return Stream.of(indexAbstraction.getName());
+                    } else {
+                        Stream<IndexMetadata> indicesStateStream = indexAbstraction.getIndices()
+                            .stream()
+                            .map(context.state.metadata()::index);
+                        if (excludeState != null) {
+                            indicesStateStream = indicesStateStream.filter(indexMeta -> indexMeta.getState() != excludeState);
+                        }
+                        return indicesStateStream.map(indexMeta -> indexMeta.getIndex().getName());
                     }
-                    return indicesStateStream.map(indexMeta -> indexMeta.getIndex().getName());
-                }
             });
         }
 

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/IndexNameExpressionResolver.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/IndexNameExpressionResolver.java
@@ -198,6 +198,32 @@ public class IndexNameExpressionResolver {
             .toList();
     }
 
+    public List<String> searchEngineNames(ClusterState state, IndicesOptions options, String... indexExpressions) {
+        Context context = new Context(
+            state,
+            options,
+            false,
+            false,
+            true,
+            true,
+            getSystemIndexAccessLevel(),
+            getSystemIndexAccessPredicate(),
+            getNetNewSystemIndexPredicate()
+        );
+        if (indexExpressions == null || indexExpressions.length == 0) {
+            indexExpressions = new String[] { "*" };
+        }
+
+        final Collection<String> expressions = resolveExpressions(Arrays.asList(indexExpressions), context);
+        return expressions.stream()
+            .map(x -> state.metadata().getIndicesLookup().get(x))
+            .filter(Objects::nonNull)
+            .filter(ia -> ia.getType() == Type.SEARCH_ENGINE)
+            .map(IndexAbstraction::getName)
+            .toList();
+    }
+
+
     /**
      * Returns {@link IndexAbstraction} instance for the provided write request. This instance isn't fully resolved,
      * meaning that {@link IndexAbstraction#getWriteIndex()} should be invoked in order to get concrete write index.

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/IndexNameExpressionResolver.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/IndexNameExpressionResolver.java
@@ -223,7 +223,6 @@ public class IndexNameExpressionResolver {
             .toList();
     }
 
-
     /**
      * Returns {@link IndexAbstraction} instance for the provided write request. This instance isn't fully resolved,
      * meaning that {@link IndexAbstraction#getWriteIndex()} should be invoked in order to get concrete write index.

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/Metadata.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/Metadata.java
@@ -2368,7 +2368,7 @@ public class Metadata extends AbstractCollection<IndexMetadata> implements Diffa
                     assert searchEngine.getIndices().isEmpty() == false;
                     final IndexAbstraction.SearchEngine engineAbstraction = new IndexAbstraction.SearchEngine(searchEngine);
                     IndexAbstraction existing = indicesLookup.put(searchEngine.getName(), engineAbstraction);
-                    assert existing == null : "duplicate data stream for " + searchEngine.getName();
+                    assert existing == null : "duplicate engine for " + searchEngine.getName();
                 }
             }
 

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/Metadata.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/Metadata.java
@@ -2359,7 +2359,7 @@ public class Metadata extends AbstractCollection<IndexMetadata> implements Diffa
                     }
                 }
 
-                for (SearchEngine searchEngine: searchEngineMetadata.searchEngines().values()) {
+                for (SearchEngine searchEngine : searchEngineMetadata.searchEngines().values()) {
                     assert searchEngine.getIndices().isEmpty() == false;
                     final IndexAbstraction.SearchEngine engineAbstraction = new IndexAbstraction.SearchEngine(searchEngine);
                     IndexAbstraction existing = indicesLookup.put(searchEngine.getName(), engineAbstraction);

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/Metadata.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/Metadata.java
@@ -1662,6 +1662,11 @@ public class Metadata extends AbstractCollection<IndexMetadata> implements Diffa
             return this;
         }
 
+        public Builder put(SearchEngineMetadata searchEngineMetadata) {
+            previousIndicesLookup = null;
+            return putCustom(SearchEngineMetadata.TYPE, searchEngineMetadata);
+        }
+
         private void maybeSetMappingPurgeFlag(@Nullable IndexMetadata previous, IndexMetadata updated) {
             if (checkForUnusedMappings) {
                 return;

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/Metadata.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/Metadata.java
@@ -700,7 +700,9 @@ public class Metadata extends AbstractCollection<IndexMetadata> implements Diffa
         if (i != null) {
             return i;
         }
-        i = Builder.buildIndicesLookup(custom(DataStreamMetadata.TYPE, DataStreamMetadata.EMPTY), indices);
+        DataStreamMetadata dataStreamMetadata = custom(DataStreamMetadata.TYPE, DataStreamMetadata.EMPTY);
+        SearchEngineMetadata searchEngineMetadata = custom(SearchEngineMetadata.TYPE, SearchEngineMetadata.EMPTY);
+        i = Builder.buildIndicesLookup(dataStreamMetadata, searchEngineMetadata, indices);
         indicesLookup = i;
         return i;
     }
@@ -1195,6 +1197,10 @@ public class Metadata extends AbstractCollection<IndexMetadata> implements Diffa
 
     public Map<String, DataStreamAlias> dataStreamAliases() {
         return this.custom(DataStreamMetadata.TYPE, DataStreamMetadata.EMPTY).getDataStreamAliases();
+    }
+
+    public Map<String, SearchEngine> searchEngines() {
+        return this.custom(SearchEngineMetadata.TYPE, SearchEngineMetadata.EMPTY).searchEngines();
     }
 
     public Map<String, SingleNodeShutdownMetadata> nodeShutdowns() {
@@ -1917,6 +1923,10 @@ public class Metadata extends AbstractCollection<IndexMetadata> implements Diffa
             return (DataStreamMetadata) this.customs.getOrDefault(DataStreamMetadata.TYPE, DataStreamMetadata.EMPTY);
         }
 
+        public SearchEngineMetadata searchEngineMetadata() {
+            return (SearchEngineMetadata) this.customs.getOrDefault(SearchEngineMetadata.TYPE, SearchEngineMetadata.EMPTY);
+        }
+
         public boolean put(String aliasName, String dataStream, Boolean isWriteDataStream, String filter) {
             previousIndicesLookup = null;
             final DataStreamMetadata existing = dataStreamMetadata();
@@ -2168,7 +2178,7 @@ public class Metadata extends AbstractCollection<IndexMetadata> implements Diffa
             SortedMap<String, IndexAbstraction> indicesLookup = null;
             if (previousIndicesLookup != null) {
                 // no changes to the names of indices, datastreams, and their aliases so we can reuse the previous lookup
-                assert previousIndicesLookup.equals(buildIndicesLookup(dataStreamMetadata(), indicesMap));
+                assert previousIndicesLookup.equals(buildIndicesLookup(dataStreamMetadata(), searchEngineMetadata(), indicesMap));
                 indicesLookup = previousIndicesLookup;
             } else if (skipNameCollisionChecks == false) {
                 // we have changes to the the entity names so we ensure we have no naming collisions
@@ -2312,6 +2322,7 @@ public class Metadata extends AbstractCollection<IndexMetadata> implements Diffa
 
         static SortedMap<String, IndexAbstraction> buildIndicesLookup(
             DataStreamMetadata dataStreamMetadata,
+            SearchEngineMetadata searchEngineMetadata,
             ImmutableOpenMap<String, IndexMetadata> indices
         ) {
             SortedMap<String, IndexAbstraction> indicesLookup = new TreeMap<>();
@@ -2346,6 +2357,13 @@ public class Metadata extends AbstractCollection<IndexMetadata> implements Diffa
                     for (Index i : dataStream.getIndices()) {
                         indexToDataStreamLookup.put(i.getName(), dsAbstraction);
                     }
+                }
+
+                for (SearchEngine searchEngine: searchEngineMetadata.searchEngines().values()) {
+                    assert searchEngine.getIndices().isEmpty() == false;
+                    final IndexAbstraction.SearchEngine engineAbstraction = new IndexAbstraction.SearchEngine(searchEngine);
+                    IndexAbstraction existing = indicesLookup.put(searchEngine.getName(), engineAbstraction);
+                    assert existing == null : "duplicate data stream for " + searchEngine.getName();
                 }
             }
 

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/SearchEngine.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/SearchEngine.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.cluster.metadata;
+
+import org.elasticsearch.index.Index;
+
+import java.util.Collections;
+import java.util.List;
+
+public class SearchEngine {
+
+    public String getName() {
+        // TODO: implement.
+        return null;
+    }
+
+    public List<Index> getIndices() {
+        // TODO: implement.
+        return Collections.emptyList();
+    }
+
+    public boolean isHidden() {
+        // TODO: implement.
+        return false;
+    }
+
+    public boolean isSystem() {
+        // TODO: implement.
+        return false;
+    }
+}

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/SearchEngine.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/SearchEngine.java
@@ -8,30 +8,123 @@
 
 package org.elasticsearch.cluster.metadata;
 
+import org.elasticsearch.cluster.Diff;
+import org.elasticsearch.cluster.SimpleDiffable;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.index.Index;
+import org.elasticsearch.xcontent.ConstructingObjectParser;
+import org.elasticsearch.xcontent.ParseField;
+import org.elasticsearch.xcontent.ToXContentObject;
+import org.elasticsearch.xcontent.XContentBuilder;
+import org.elasticsearch.xcontent.XContentParser;
 
-import java.util.Collections;
+import java.io.IOException;
 import java.util.List;
+import java.util.Objects;
 
-public class SearchEngine {
+public class SearchEngine implements SimpleDiffable<SearchEngine>, ToXContentObject {
+
+    public static final ParseField NAME_FIELD = new ParseField("name");
+    public static final ParseField INDICES_FIELD = new ParseField("index");
+    public static final ParseField HIDDEN_FIELD = new ParseField("hidden");
+    public static final ParseField SYSTEM_FIELD = new ParseField("system");
+
+    @SuppressWarnings("unchecked")
+    private static final ConstructingObjectParser<SearchEngine, Void> PARSER = new ConstructingObjectParser<>(
+        "search_engine",
+        args -> new SearchEngine(
+            (String) args[0],
+            (List<Index>) args[1],
+            (boolean) args[2],
+            (boolean) args[3]
+        )
+    );
+
+    static {
+        PARSER.declareString(ConstructingObjectParser.constructorArg(), NAME_FIELD);
+        PARSER.declareObjectArray(ConstructingObjectParser.constructorArg(), (p, c) -> Index.fromXContent(p), INDICES_FIELD);
+        PARSER.declareBoolean(ConstructingObjectParser.optionalConstructorArg(), HIDDEN_FIELD);
+        PARSER.declareBoolean(ConstructingObjectParser.optionalConstructorArg(), SYSTEM_FIELD);
+    }
+
+    public static SearchEngine fromXContent(XContentParser parser) throws IOException {
+        return PARSER.parse(parser, null);
+    }
+
+    public static Diff<SearchEngine> readDiffFrom(StreamInput in) throws IOException {
+        return SimpleDiffable.readDiffFrom(SearchEngine::new, in);
+    }
+
+    private final String name;
+    private final List<Index> indices;
+    private final boolean isHidden;
+    private final boolean isSystem;
+
+    public SearchEngine(String name, List<Index> indices, boolean isHidden, boolean isSystem) {
+        this.name = name;
+        this.indices = indices;
+        this.isHidden = isHidden;
+        this.isSystem = isSystem;
+    }
+
+    public SearchEngine(StreamInput in) throws IOException {
+        this(
+            in.readString(),
+            in.readList(Index::new),
+            in.readBoolean(),
+            in.readBoolean()
+        );
+    }
 
     public String getName() {
-        // TODO: implement.
-        return null;
+        return name;
     }
 
     public List<Index> getIndices() {
-        // TODO: implement.
-        return Collections.emptyList();
+        return indices;
     }
 
     public boolean isHidden() {
-        // TODO: implement.
-        return false;
+        return isHidden;
     }
 
     public boolean isSystem() {
-        // TODO: implement.
-        return false;
+        return isSystem;
+    }
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        builder.startObject();
+        builder.field(NAME_FIELD.getPreferredName(), name);
+        builder.xContentList(INDICES_FIELD.getPreferredName(), indices);
+        builder.field(HIDDEN_FIELD.getPreferredName(), isHidden);
+        builder.field(SYSTEM_FIELD.getPreferredName(), isSystem);
+        builder.endObject();
+        return builder;
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        out.writeString(name);
+        out.writeList(indices);
+        out.writeBoolean(isHidden);
+        out.writeBoolean(isSystem);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        SearchEngine that = (SearchEngine) o;
+        return name.equals(that.name)
+            && indices.equals(that.indices)
+            && Objects.equals(isHidden, that.isHidden)
+            && Objects.equals(isSystem, that.isSystem);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(name, indices, isHidden, isSystem);
     }
 }

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/SearchEngine.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/SearchEngine.java
@@ -33,12 +33,7 @@ public class SearchEngine implements SimpleDiffable<SearchEngine>, ToXContentObj
     @SuppressWarnings("unchecked")
     private static final ConstructingObjectParser<SearchEngine, Void> PARSER = new ConstructingObjectParser<>(
         "search_engine",
-        args -> new SearchEngine(
-            (String) args[0],
-            (List<Index>) args[1],
-            (boolean) args[2],
-            (boolean) args[3]
-        )
+        args -> new SearchEngine((String) args[0], (List<Index>) args[1], (boolean) args[2], (boolean) args[3])
     );
 
     static {
@@ -69,12 +64,7 @@ public class SearchEngine implements SimpleDiffable<SearchEngine>, ToXContentObj
     }
 
     public SearchEngine(StreamInput in) throws IOException {
-        this(
-            in.readString(),
-            in.readList(Index::new),
-            in.readBoolean(),
-            in.readBoolean()
-        );
+        this(in.readString(), in.readList(Index::new), in.readBoolean(), in.readBoolean());
     }
 
     public String getName() {

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/SearchEngineMetadata.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/SearchEngineMetadata.java
@@ -1,0 +1,170 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.cluster.metadata;
+
+import org.elasticsearch.Version;
+import org.elasticsearch.cluster.Diff;
+import org.elasticsearch.cluster.DiffableUtils;
+import org.elasticsearch.cluster.NamedDiff;
+import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.xcontent.ConstructingObjectParser;
+import org.elasticsearch.xcontent.ParseField;
+import org.elasticsearch.xcontent.XContentBuilder;
+import org.elasticsearch.xcontent.XContentParser;
+
+import java.io.IOException;
+import java.util.EnumSet;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+
+public class SearchEngineMetadata implements Metadata.Custom {
+
+    public static final String TYPE = "content_indices";
+    public static final ParseField CONTENT_INDICES = new ParseField("content_indices");
+
+    @SuppressWarnings("unchecked")
+    private static final ConstructingObjectParser<SearchEngineMetadata, Void> PARSER = new ConstructingObjectParser<>(TYPE, false, args -> {
+        Map<String, SearchEngine> searchEngines = (Map<String, SearchEngine>) args[0];
+        return new SearchEngineMetadata(searchEngines);
+    });
+
+    static {
+        PARSER.declareObject(ConstructingObjectParser.constructorArg(), (p, c) -> {
+            Map<String, SearchEngine> contentIndices = new HashMap<>();
+            while (p.nextToken() != XContentParser.Token.END_OBJECT) {
+                String name = p.currentName();
+                contentIndices.put(name, SearchEngine.fromXContent(p));
+            }
+            return contentIndices;
+        }, CONTENT_INDICES);
+    }
+
+    private final Map<String, SearchEngine> searchEngines;
+
+    public SearchEngineMetadata(Map<String, SearchEngine> searchEngines) {
+        this.searchEngines = searchEngines;
+    }
+
+    public SearchEngineMetadata(StreamInput in) throws IOException {
+        this(in.readMap(StreamInput::readString, SearchEngine::new));
+    }
+
+    public Map<String, SearchEngine> searchEngines() {
+        return searchEngines;
+    }
+
+    @Override
+    public Diff<Metadata.Custom> diff(Metadata.Custom before) {
+        return new SearchEngineMetadata.SearchEngineMetadataDiff((SearchEngineMetadata) before, this);
+    }
+
+    public static NamedDiff<Metadata.Custom> readDiffFrom(StreamInput in) throws IOException {
+        return new SearchEngineMetadataDiff(in);
+    }
+
+    @Override
+    public EnumSet<Metadata.XContentContext> context() {
+        return Metadata.ALL_CONTEXTS;
+    }
+
+    @Override
+    public String getWriteableName() {
+        return TYPE;
+    }
+
+    @Override
+    public Version getMinimalSupportedVersion() {
+        return Version.V_8_3_0;
+    }
+
+    public static SearchEngineMetadata fromXContent(XContentParser parser) throws IOException {
+        return PARSER.parse(parser, null);
+    }
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        builder.xContentValuesMap(CONTENT_INDICES.getPreferredName(), searchEngines);
+        return builder;
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        out.writeMap(this.searchEngines, StreamOutput::writeString, (stream, val) -> val.writeTo(stream));
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(this.searchEngines);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == null) {
+            return false;
+        }
+        if (obj.getClass() != getClass()) {
+            return false;
+        }
+        SearchEngineMetadata other = (SearchEngineMetadata) obj;
+
+        return Objects.equals(this.searchEngines, other.searchEngines);
+    }
+
+    @Override
+    public String toString() {
+        return Strings.toString(this);
+    }
+
+    static class SearchEngineMetadataDiff implements NamedDiff<Metadata.Custom> {
+
+        final Diff<Map<String, SearchEngine>> searchEnginesDiff;
+
+        SearchEngineMetadataDiff(SearchEngineMetadata before, SearchEngineMetadata after) {
+            this.searchEnginesDiff = DiffableUtils.diff(
+                before.searchEngines,
+                after.searchEngines,
+                DiffableUtils.getStringKeySerializer()
+            );
+        }
+
+        SearchEngineMetadataDiff(StreamInput in) throws IOException {
+            this.searchEnginesDiff = DiffableUtils.readJdkMapDiff(
+                in,
+                DiffableUtils.getStringKeySerializer(),
+                SearchEngine::new,
+                SearchEngine::readDiffFrom
+            );
+        }
+
+        @Override
+        public Metadata.Custom apply(Metadata.Custom part) {
+            return new SearchEngineMetadata(
+                searchEnginesDiff.apply(((SearchEngineMetadata) part).searchEngines)
+            );
+        }
+
+        @Override
+        public void writeTo(StreamOutput out) throws IOException {
+            searchEnginesDiff.writeTo(out);
+        }
+
+        @Override
+        public String getWriteableName() {
+            return TYPE;
+        }
+
+        @Override
+        public Version getMinimalSupportedVersion() {
+            return Version.V_8_6_0;
+        }
+    }
+}

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/SearchEngineMetadata.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/SearchEngineMetadata.java
@@ -13,6 +13,7 @@ import org.elasticsearch.cluster.Diff;
 import org.elasticsearch.cluster.DiffableUtils;
 import org.elasticsearch.cluster.NamedDiff;
 import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.collect.ImmutableOpenMap;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.xcontent.ConstructingObjectParser;
@@ -29,6 +30,8 @@ import java.util.Objects;
 public class SearchEngineMetadata implements Metadata.Custom {
 
     public static final String TYPE = "content_indices";
+
+    public static final SearchEngineMetadata EMPTY = new SearchEngineMetadata(ImmutableOpenMap.of());
     public static final ParseField CONTENT_INDICES = new ParseField("content_indices");
 
     @SuppressWarnings("unchecked")

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/SearchEngineMetadata.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/SearchEngineMetadata.java
@@ -129,11 +129,7 @@ public class SearchEngineMetadata implements Metadata.Custom {
         final Diff<Map<String, SearchEngine>> searchEnginesDiff;
 
         SearchEngineMetadataDiff(SearchEngineMetadata before, SearchEngineMetadata after) {
-            this.searchEnginesDiff = DiffableUtils.diff(
-                before.searchEngines,
-                after.searchEngines,
-                DiffableUtils.getStringKeySerializer()
-            );
+            this.searchEnginesDiff = DiffableUtils.diff(before.searchEngines, after.searchEngines, DiffableUtils.getStringKeySerializer());
         }
 
         SearchEngineMetadataDiff(StreamInput in) throws IOException {
@@ -147,9 +143,7 @@ public class SearchEngineMetadata implements Metadata.Custom {
 
         @Override
         public Metadata.Custom apply(Metadata.Custom part) {
-            return new SearchEngineMetadata(
-                searchEnginesDiff.apply(((SearchEngineMetadata) part).searchEngines)
-            );
+            return new SearchEngineMetadata(searchEnginesDiff.apply(((SearchEngineMetadata) part).searchEngines));
         }
 
         @Override

--- a/server/src/main/java/org/elasticsearch/index/EngineNotFoundException.java
+++ b/server/src/main/java/org/elasticsearch/index/EngineNotFoundException.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+package org.elasticsearch.index;
+
+import org.elasticsearch.ResourceNotFoundException;
+
+public final class EngineNotFoundException extends ResourceNotFoundException {
+    public EngineNotFoundException(String engine) {
+        this(engine, (Throwable) null);
+    }
+
+    public EngineNotFoundException(String engine, Throwable cause) {
+        super("no such engine [" + engine + "]", cause);
+    }
+}

--- a/server/src/main/java/org/elasticsearch/index/EngineNotFoundException.java
+++ b/server/src/main/java/org/elasticsearch/index/EngineNotFoundException.java
@@ -8,6 +8,9 @@
 package org.elasticsearch.index;
 
 import org.elasticsearch.ResourceNotFoundException;
+import org.elasticsearch.common.io.stream.StreamInput;
+
+import java.io.IOException;
 
 public final class EngineNotFoundException extends ResourceNotFoundException {
     public EngineNotFoundException(String engine) {
@@ -16,5 +19,9 @@ public final class EngineNotFoundException extends ResourceNotFoundException {
 
     public EngineNotFoundException(String engine, Throwable cause) {
         super("no such engine [" + engine + "]", cause);
+    }
+
+    public EngineNotFoundException(StreamInput in) throws IOException {
+        super(in);
     }
 }

--- a/server/src/main/java/org/elasticsearch/indices/InvalidEngineNameException.java
+++ b/server/src/main/java/org/elasticsearch/indices/InvalidEngineNameException.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.indices;
+
+import org.elasticsearch.ElasticsearchException;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.rest.RestStatus;
+
+import java.io.IOException;
+
+public class InvalidEngineNameException extends ElasticsearchException {
+    public InvalidEngineNameException(String name, String desc) {
+        super("Invalid engine name [" + name + "], " + desc);
+    }
+
+    public InvalidEngineNameException(StreamInput in) throws IOException {
+        super(in);
+    }
+
+    @Override
+    public RestStatus status() {
+        return RestStatus.BAD_REQUEST;
+    }
+}

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/IndexNameExpressionResolverTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/IndexNameExpressionResolverTests.java
@@ -46,6 +46,7 @@ import java.time.ZoneOffset;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.EnumSet;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -2781,6 +2782,51 @@ public class IndexNameExpressionResolverTests extends ESTestCase {
         assertThat(names, containsInAnyOrder(dataStream2));
 
         names = indexNameExpressionResolver.dataStreamNames(state, IndicesOptions.lenientExpand(), "*", "-*");
+        assertThat(names, empty());
+    }
+
+    public void testSearchEngineNames() {
+        final String engineName1 = "my-engine";
+        final String engineName2 = "other-engine";
+
+        IndexMetadata index1 = IndexMetadata.builder("my-index")
+            .settings(ESTestCase.settings(Version.CURRENT))
+            .numberOfShards(1)
+            .numberOfReplicas(1)
+            .build();
+
+        IndexMetadata index2 = IndexMetadata.builder("other-index")
+            .settings(ESTestCase.settings(Version.CURRENT))
+            .numberOfShards(1)
+            .numberOfReplicas(1)
+            .build();
+
+        HashMap<String, SearchEngine> searchEngines = new HashMap<>();
+        searchEngines.put(engineName1, new SearchEngine(engineName1, Collections.singletonList(index1.getIndex()), false, false));
+        searchEngines.put(engineName2, new SearchEngine(engineName2, Collections.singletonList(index2.getIndex()), false, false));
+
+        SearchEngineMetadata engineMeta = new SearchEngineMetadata(searchEngines);
+
+        ClusterState state = ClusterState.builder(new ClusterName("_name"))
+            .metadata(Metadata.builder().put(index1, false).put(index2, false).put(engineMeta))
+            .build();
+
+        List<String> names = indexNameExpressionResolver.searchEngineNames(state, IndicesOptions.lenientExpand(), "*");
+        assertThat(names, containsInAnyOrder(engineName1, engineName2));
+
+        names = indexNameExpressionResolver.searchEngineNames(state, IndicesOptions.lenientExpand(), engineName1);
+        assertEquals(Collections.singletonList(engineName1), names);
+
+        names = indexNameExpressionResolver.searchEngineNames(state, IndicesOptions.lenientExpand(), engineName2);
+        assertEquals(Collections.singletonList(engineName2), names);
+
+        names = indexNameExpressionResolver.searchEngineNames(state, IndicesOptions.lenientExpand(), "my*");
+        assertEquals(Collections.singletonList(engineName1), names);
+
+        names = indexNameExpressionResolver.searchEngineNames(state, IndicesOptions.lenientExpand(), "other*");
+        assertEquals(Collections.singletonList(engineName2), names);
+
+        names = indexNameExpressionResolver.searchEngineNames(state, IndicesOptions.lenientExpand(), "*", "-*");
         assertThat(names, empty());
     }
 

--- a/x-pack/plugin/search-engines/build.gradle
+++ b/x-pack/plugin/search-engines/build.gradle
@@ -1,0 +1,16 @@
+import org.elasticsearch.gradle.internal.info.BuildParams
+
+apply plugin: 'elasticsearch.internal-es-plugin'
+apply plugin: 'elasticsearch.internal-cluster-test'
+
+esplugin {
+  description 'Search Engines API Plugin'
+  classname 'org.elasticsearch.searchengines.SearchEnginesPlugin'
+}
+
+if (BuildParams.inFipsJvm){
+  // These fail in CI but only when run as part of checkPart2 and not individually.
+  // Tracked in :
+  tasks.named("javaRestTest").configure{enabled = false }
+  tasks.named("yamlRestTest").configure{enabled = false }
+}

--- a/x-pack/plugin/search-engines/src/main/java/module-info.java
+++ b/x-pack/plugin/search-engines/src/main/java/module-info.java
@@ -1,9 +1,8 @@
 /*
  * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
  * or more contributor license agreements. Licensed under the Elastic License
- * 2.0 and the Server Side Public License, v 1; you may not use this file except
- * in compliance with, at your election, the Elastic License 2.0 or the Server
- * Side Public License, v 1.
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
  */
 
 module org.elasticsearch.searchengines {

--- a/x-pack/plugin/search-engines/src/main/java/module-info.java
+++ b/x-pack/plugin/search-engines/src/main/java/module-info.java
@@ -1,0 +1,17 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+module org.elasticsearch.searchengines {
+    requires org.elasticsearch.base;
+    requires org.elasticsearch.server;
+    requires org.elasticsearch.xcontent;
+    requires org.apache.logging.log4j;
+    requires org.apache.lucene.core;
+
+    exports org.elasticsearch.searchengines.action to org.elasticsearch.server;
+}

--- a/x-pack/plugin/search-engines/src/main/java/org/elasticsearch/searchengines/SearchEngineMetadataService.java
+++ b/x-pack/plugin/search-engines/src/main/java/org/elasticsearch/searchengines/SearchEngineMetadataService.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.searchengines;
+
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.support.master.AcknowledgedResponse;
+import org.elasticsearch.cluster.ClusterStateTaskConfig;
+import org.elasticsearch.cluster.ClusterStateTaskExecutor;
+import org.elasticsearch.cluster.ClusterStateTaskListener;
+import org.elasticsearch.cluster.metadata.SearchEngine;
+import org.elasticsearch.cluster.metadata.SearchEngineMetadata;
+import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.Priority;
+import org.elasticsearch.searchengines.action.CreateSearchEngineAction;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+public class SearchEngineMetadataService {
+
+    private final ClusterService clusterService;
+
+    /**
+     * Cluster state task executor for ingest pipeline operations
+     */
+    static final ClusterStateTaskExecutor<SearchEngineMetadataService.ClusterStateUpdateTask> TASK_EXECUTOR = batchExecutionContext -> {
+        final SearchEngineMetadata initialMetadata = batchExecutionContext.initialState().metadata().custom(SearchEngineMetadata.TYPE, SearchEngineMetadata.EMPTY);
+        var currentMetadata = initialMetadata;
+        for (final var taskContext : batchExecutionContext.taskContexts()) {
+            try {
+                final var task = taskContext.getTask();
+                try (var ignored = taskContext.captureResponseHeaders()) {
+                    currentMetadata = task.execute(currentMetadata);
+                }
+                taskContext.success(() -> task.listener.onResponse(AcknowledgedResponse.TRUE));
+            } catch (Exception e) {
+                taskContext.onFailure(e);
+            }
+        }
+        final var finalMetadata = currentMetadata;
+        return finalMetadata == initialMetadata
+            ? batchExecutionContext.initialState()
+            : batchExecutionContext.initialState().copyAndUpdateMetadata(b -> b.putCustom(SearchEngineMetadata.TYPE, finalMetadata));
+    };
+
+    /**
+     * Specialized cluster state update task specifically for ingest pipeline operations.
+     * These operations all receive an AcknowledgedResponse.
+     */
+    abstract static class ClusterStateUpdateTask implements ClusterStateTaskListener {
+        final ActionListener<AcknowledgedResponse> listener;
+
+        ClusterStateUpdateTask(ActionListener<AcknowledgedResponse> listener) {
+            this.listener = listener;
+        }
+
+        public abstract SearchEngineMetadata execute(SearchEngineMetadata currentMetadata);
+
+        @Override
+        public void onFailure(Exception e) {
+            listener.onFailure(e);
+        }
+    }
+
+
+    public SearchEngineMetadataService(ClusterService clusterService) {
+        this.clusterService = clusterService;
+    }
+
+    public void createSearchEngine(CreateSearchEngineAction.Request request, ActionListener<AcknowledgedResponse> listener) {
+        clusterService.submitStateUpdateTask(
+            "create-search-engine-" + request.getName(),
+            new CreateSearchEngineClusterStateUpdateTask(listener, request),
+            ClusterStateTaskConfig.build(Priority.NORMAL, request.masterNodeTimeout()),
+            TASK_EXECUTOR
+        );
+    }
+
+    static class CreateSearchEngineClusterStateUpdateTask extends ClusterStateUpdateTask {
+        private final CreateSearchEngineAction.Request request;
+
+        CreateSearchEngineClusterStateUpdateTask(ActionListener<AcknowledgedResponse> listener, CreateSearchEngineAction.Request request) {
+            super(listener);
+            this.request = request;
+        }
+
+        @Override
+        public SearchEngineMetadata execute(SearchEngineMetadata currentMetadata) {
+            Map<String, SearchEngine> searchEngines = new HashMap<>(currentMetadata.searchEngines());
+
+            // TODO:
+            // - validate the engine name
+            // - handle indices list
+            SearchEngine searchEngine = new SearchEngine(
+                request.getName(),
+                Collections.emptyList(),
+                false,
+                false
+            );
+            searchEngines.put(request.getName(), searchEngine);
+
+            return new SearchEngineMetadata(searchEngines);
+        }
+    }
+}

--- a/x-pack/plugin/search-engines/src/main/java/org/elasticsearch/searchengines/SearchEngineMetadataService.java
+++ b/x-pack/plugin/search-engines/src/main/java/org/elasticsearch/searchengines/SearchEngineMetadataService.java
@@ -53,7 +53,7 @@ public class SearchEngineMetadataService {
         final var finalMetadata = currentMetadata;
         return finalMetadata == initialMetadata
             ? batchExecutionContext.initialState()
-            : batchExecutionContext.initialState().copyAndUpdateMetadata(b -> b.putCustom(SearchEngineMetadata.TYPE, finalMetadata));
+            : batchExecutionContext.initialState().copyAndUpdateMetadata(b -> { b.put(finalMetadata); });
     };
 
     /**

--- a/x-pack/plugin/search-engines/src/main/java/org/elasticsearch/searchengines/SearchEngineMetadataService.java
+++ b/x-pack/plugin/search-engines/src/main/java/org/elasticsearch/searchengines/SearchEngineMetadataService.java
@@ -30,7 +30,9 @@ public class SearchEngineMetadataService {
      * Cluster state task executor for ingest pipeline operations
      */
     static final ClusterStateTaskExecutor<SearchEngineMetadataService.ClusterStateUpdateTask> TASK_EXECUTOR = batchExecutionContext -> {
-        final SearchEngineMetadata initialMetadata = batchExecutionContext.initialState().metadata().custom(SearchEngineMetadata.TYPE, SearchEngineMetadata.EMPTY);
+        final SearchEngineMetadata initialMetadata = batchExecutionContext.initialState()
+            .metadata()
+            .custom(SearchEngineMetadata.TYPE, SearchEngineMetadata.EMPTY);
         var currentMetadata = initialMetadata;
         for (final var taskContext : batchExecutionContext.taskContexts()) {
             try {
@@ -68,7 +70,6 @@ public class SearchEngineMetadataService {
         }
     }
 
-
     public SearchEngineMetadataService(ClusterService clusterService) {
         this.clusterService = clusterService;
     }
@@ -97,12 +98,7 @@ public class SearchEngineMetadataService {
             // TODO:
             // - validate the engine name
             // - handle indices list
-            SearchEngine searchEngine = new SearchEngine(
-                request.getName(),
-                Collections.emptyList(),
-                false,
-                false
-            );
+            SearchEngine searchEngine = new SearchEngine(request.getName(), Collections.emptyList(), false, false);
             searchEngines.put(request.getName(), searchEngine);
 
             return new SearchEngineMetadata(searchEngines);

--- a/x-pack/plugin/search-engines/src/main/java/org/elasticsearch/searchengines/SearchEngineMetadataService.java
+++ b/x-pack/plugin/search-engines/src/main/java/org/elasticsearch/searchengines/SearchEngineMetadataService.java
@@ -79,7 +79,6 @@ public class SearchEngineMetadataService {
         this.clusterService = clusterService;
     }
 
-
     public void createSearchEngine(CreateSearchEngineAction.Request request, ActionListener<AcknowledgedResponse> listener) {
         clusterService.submitStateUpdateTask(
             "create-search-engine-" + request.getName(),
@@ -100,7 +99,7 @@ public class SearchEngineMetadataService {
         private void validate(CreateSearchEngineAction.Request request, ClusterState state) {
             // - validate index names, make sure they exist
             List<String> missingIndices = new ArrayList<>();
-            for (String index: request.indices()) {
+            for (String index : request.indices()) {
                 if ((state.routingTable().hasIndex(index)
                     || state.metadata().hasIndex(index)
                     || state.metadata().hasAlias(index)) == false) {
@@ -120,7 +119,7 @@ public class SearchEngineMetadataService {
 
             // TODO: is this right?
             List<Index> indices = new ArrayList<>();
-            for (String indexName: request.indices()) {
+            for (String indexName : request.indices()) {
                 indices.add(state.getMetadata().index(indexName).getIndex());
             }
 

--- a/x-pack/plugin/search-engines/src/main/java/org/elasticsearch/searchengines/SearchEngineMetadataService.java
+++ b/x-pack/plugin/search-engines/src/main/java/org/elasticsearch/searchengines/SearchEngineMetadataService.java
@@ -1,9 +1,8 @@
 /*
  * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
  * or more contributor license agreements. Licensed under the Elastic License
- * 2.0 and the Server Side Public License, v 1; you may not use this file except
- * in compliance with, at your election, the Elastic License 2.0 or the Server
- * Side Public License, v 1.
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
  */
 
 package org.elasticsearch.searchengines;

--- a/x-pack/plugin/search-engines/src/main/java/org/elasticsearch/searchengines/SearchEngineMetadataService.java
+++ b/x-pack/plugin/search-engines/src/main/java/org/elasticsearch/searchengines/SearchEngineMetadataService.java
@@ -7,6 +7,7 @@
 
 package org.elasticsearch.searchengines;
 
+import org.apache.logging.log4j.util.Strings;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.master.AcknowledgedResponse;
 import org.elasticsearch.cluster.ClusterState;
@@ -21,10 +22,10 @@ import org.elasticsearch.index.Index;
 import org.elasticsearch.index.IndexNotFoundException;
 import org.elasticsearch.searchengines.action.CreateSearchEngineAction;
 
-import java.util.List;
 import java.util.ArrayList;
-import java.util.Map;
 import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 public class SearchEngineMetadataService {
 
@@ -98,10 +99,16 @@ public class SearchEngineMetadataService {
 
         private void validate(CreateSearchEngineAction.Request request, ClusterState state) {
             // - validate index names, make sure they exist
+            List<String> missingIndices = new ArrayList<>();
             for (String index: request.indices()) {
-                if ((state.routingTable().hasIndex(index) || state.metadata().hasIndex(index) || state.metadata().hasAlias(index)) == false) {
-                    throw new IndexNotFoundException(index);
+                if ((state.routingTable().hasIndex(index)
+                    || state.metadata().hasIndex(index)
+                    || state.metadata().hasAlias(index)) == false) {
+                    missingIndices.add(index);
                 }
+            }
+            if (missingIndices.size() > 0) {
+                throw new IndexNotFoundException(Strings.join(missingIndices, ','));
             }
         }
 

--- a/x-pack/plugin/search-engines/src/main/java/org/elasticsearch/searchengines/SearchEnginesPlugin.java
+++ b/x-pack/plugin/search-engines/src/main/java/org/elasticsearch/searchengines/SearchEnginesPlugin.java
@@ -1,10 +1,10 @@
 /*
  * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
  * or more contributor license agreements. Licensed under the Elastic License
- * 2.0 and the Server Side Public License, v 1; you may not use this file except
- * in compliance with, at your election, the Elastic License 2.0 or the Server
- * Side Public License, v 1.
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
  */
+
 package org.elasticsearch.searchengines;
 
 import org.elasticsearch.action.ActionRequest;

--- a/x-pack/plugin/search-engines/src/main/java/org/elasticsearch/searchengines/SearchEnginesPlugin.java
+++ b/x-pack/plugin/search-engines/src/main/java/org/elasticsearch/searchengines/SearchEnginesPlugin.java
@@ -29,9 +29,12 @@ import org.elasticsearch.rest.RestHandler;
 import org.elasticsearch.script.ScriptService;
 import org.elasticsearch.searchengines.action.CreateSearchEngineAction;
 import org.elasticsearch.searchengines.action.CreateSearchEngineTransportAction;
+import org.elasticsearch.searchengines.action.DeleteSearchEngineAction;
+import org.elasticsearch.searchengines.action.DeleteSearchEngineTransportAction;
 import org.elasticsearch.searchengines.action.GetSearchEngineAction;
 import org.elasticsearch.searchengines.action.GetSearchEngineTransportAction;
 import org.elasticsearch.searchengines.rest.RestCreateSearchEngineAction;
+import org.elasticsearch.searchengines.rest.RestDeleteSearchEngineAction;
 import org.elasticsearch.searchengines.rest.RestGetSearchEngineAction;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.tracing.Tracer;
@@ -70,7 +73,8 @@ public class SearchEnginesPlugin extends Plugin implements ActionPlugin {
     public List<ActionPlugin.ActionHandler<? extends ActionRequest, ? extends ActionResponse>> getActions() {
         return List.of(
             new ActionPlugin.ActionHandler<>(CreateSearchEngineAction.INSTANCE, CreateSearchEngineTransportAction.class),
-            new ActionPlugin.ActionHandler<>(GetSearchEngineAction.INSTANCE, GetSearchEngineTransportAction.class)
+            new ActionPlugin.ActionHandler<>(GetSearchEngineAction.INSTANCE, GetSearchEngineTransportAction.class),
+            new ActionPlugin.ActionHandler<>(DeleteSearchEngineAction.INSTANCE, DeleteSearchEngineTransportAction.class)
         );
     }
 
@@ -84,6 +88,6 @@ public class SearchEnginesPlugin extends Plugin implements ActionPlugin {
         IndexNameExpressionResolver indexNameExpressionResolver,
         Supplier<DiscoveryNodes> nodesInCluster
     ) {
-        return List.of(new RestCreateSearchEngineAction(), new RestGetSearchEngineAction());
+        return List.of(new RestCreateSearchEngineAction(), new RestGetSearchEngineAction(), new RestDeleteSearchEngineAction());
     }
 }

--- a/x-pack/plugin/search-engines/src/main/java/org/elasticsearch/searchengines/SearchEnginesPlugin.java
+++ b/x-pack/plugin/search-engines/src/main/java/org/elasticsearch/searchengines/SearchEnginesPlugin.java
@@ -84,9 +84,6 @@ public class SearchEnginesPlugin extends Plugin implements ActionPlugin {
         IndexNameExpressionResolver indexNameExpressionResolver,
         Supplier<DiscoveryNodes> nodesInCluster
     ) {
-        return List.of(
-            new RestCreateSearchEngineAction(),
-            new RestGetSearchEngineAction()
-        );
+        return List.of(new RestCreateSearchEngineAction(), new RestGetSearchEngineAction());
     }
 }

--- a/x-pack/plugin/search-engines/src/main/java/org/elasticsearch/searchengines/SearchEnginesPlugin.java
+++ b/x-pack/plugin/search-engines/src/main/java/org/elasticsearch/searchengines/SearchEnginesPlugin.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+package org.elasticsearch.searchengines;
+
+import org.elasticsearch.action.ActionRequest;
+import org.elasticsearch.action.ActionResponse;
+import org.elasticsearch.client.internal.Client;
+import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
+import org.elasticsearch.cluster.node.DiscoveryNodes;
+import org.elasticsearch.cluster.routing.allocation.decider.AllocationDeciders;
+import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
+import org.elasticsearch.common.settings.ClusterSettings;
+import org.elasticsearch.common.settings.IndexScopedSettings;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.settings.SettingsFilter;
+import org.elasticsearch.env.Environment;
+import org.elasticsearch.env.NodeEnvironment;
+import org.elasticsearch.plugins.ActionPlugin;
+import org.elasticsearch.plugins.Plugin;
+import org.elasticsearch.repositories.RepositoriesService;
+import org.elasticsearch.rest.RestController;
+import org.elasticsearch.rest.RestHandler;
+import org.elasticsearch.script.ScriptService;
+import org.elasticsearch.searchengines.action.CreateSearchEngineAction;
+import org.elasticsearch.searchengines.action.CreateSearchEngineTransportAction;
+import org.elasticsearch.searchengines.action.GetSearchEngineAction;
+import org.elasticsearch.searchengines.action.GetSearchEngineTransportAction;
+import org.elasticsearch.searchengines.rest.RestCreateSearchEngineAction;
+import org.elasticsearch.searchengines.rest.RestGetSearchEngineAction;
+import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.tracing.Tracer;
+import org.elasticsearch.watcher.ResourceWatcherService;
+import org.elasticsearch.xcontent.NamedXContentRegistry;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.function.Supplier;
+
+public class SearchEnginesPlugin extends Plugin implements ActionPlugin {
+
+    public static final String REST_BASE_PATH = "/_search_engine";
+
+    @Override
+    public Collection<Object> createComponents(
+        Client client,
+        ClusterService clusterService,
+        ThreadPool threadPool,
+        ResourceWatcherService resourceWatcherService,
+        ScriptService scriptService,
+        NamedXContentRegistry xContentRegistry,
+        Environment environment,
+        NodeEnvironment nodeEnvironment,
+        NamedWriteableRegistry namedWriteableRegistry,
+        IndexNameExpressionResolver indexNameExpressionResolver,
+        Supplier<RepositoriesService> repositoriesServiceSupplier,
+        Tracer tracer,
+        AllocationDeciders allocationDeciders
+    ) {
+        var searchEngineMetadataService = new SearchEngineMetadataService(clusterService);
+        return List.of(searchEngineMetadataService);
+    }
+
+    @Override
+    public List<ActionPlugin.ActionHandler<? extends ActionRequest, ? extends ActionResponse>> getActions() {
+        return List.of(
+            new ActionPlugin.ActionHandler<>(CreateSearchEngineAction.INSTANCE, CreateSearchEngineTransportAction.class),
+            new ActionPlugin.ActionHandler<>(GetSearchEngineAction.INSTANCE, GetSearchEngineTransportAction.class)
+        );
+    }
+
+    @Override
+    public List<RestHandler> getRestHandlers(
+        Settings settings,
+        RestController restController,
+        ClusterSettings clusterSettings,
+        IndexScopedSettings indexScopedSettings,
+        SettingsFilter settingsFilter,
+        IndexNameExpressionResolver indexNameExpressionResolver,
+        Supplier<DiscoveryNodes> nodesInCluster
+    ) {
+        return List.of(
+            new RestCreateSearchEngineAction(),
+            new RestGetSearchEngineAction()
+        );
+    }
+}

--- a/x-pack/plugin/search-engines/src/main/java/org/elasticsearch/searchengines/action/CreateSearchEngineAction.java
+++ b/x-pack/plugin/search-engines/src/main/java/org/elasticsearch/searchengines/action/CreateSearchEngineAction.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.searchengines.action;
+
+import org.elasticsearch.action.ActionRequestValidationException;
+import org.elasticsearch.action.ActionType;
+import org.elasticsearch.action.IndicesRequest;
+import org.elasticsearch.action.ValidateActions;
+import org.elasticsearch.action.support.IndicesOptions;
+import org.elasticsearch.action.support.master.AcknowledgedRequest;
+import org.elasticsearch.action.support.master.AcknowledgedResponse;
+import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+
+import java.io.IOException;
+import java.util.Objects;
+
+public class CreateSearchEngineAction extends ActionType<AcknowledgedResponse> {
+
+    public static final CreateSearchEngineAction INSTANCE = new CreateSearchEngineAction();
+    public static final String NAME = "indices:admin/search_engine/create";
+
+    private CreateSearchEngineAction() {
+        super(NAME, AcknowledgedResponse::readFrom);
+    }
+
+    public static class Request extends AcknowledgedRequest<Request> implements IndicesRequest {
+
+        private final String name;
+        private final long startTime;
+
+        public Request(String name) {
+            this(name, System.currentTimeMillis());
+        }
+
+        public Request(String name, long startTime) {
+            this.name = name;
+            this.startTime = startTime;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public long getStartTime() {
+            return startTime;
+        }
+
+        @Override
+        public ActionRequestValidationException validate() {
+            ActionRequestValidationException validationException = null;
+
+            if (Strings.hasText(name) == false) {
+                validationException = ValidateActions.addValidationError("name is missing", validationException);
+            }
+
+            return validationException;
+        }
+
+        public Request(StreamInput in) throws IOException {
+            super(in);
+            this.name = in.readString();
+            this.startTime = in.readVLong();
+        }
+
+        @Override
+        public void writeTo(StreamOutput out) throws IOException {
+            super.writeTo(out);
+            out.writeString(name);
+            out.writeVLong(startTime);
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            Request request = (Request) o;
+            return name.equals(request.name) && startTime == request.startTime;
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(name, startTime);
+        }
+
+        @Override
+        public String[] indices() {
+            return new String[] { name };
+        }
+
+        @Override
+        public IndicesOptions indicesOptions() {
+            return IndicesOptions.strictSingleIndexNoExpandForbidClosed();
+        }
+    }
+}

--- a/x-pack/plugin/search-engines/src/main/java/org/elasticsearch/searchengines/action/CreateSearchEngineAction.java
+++ b/x-pack/plugin/search-engines/src/main/java/org/elasticsearch/searchengines/action/CreateSearchEngineAction.java
@@ -88,8 +88,7 @@ public class CreateSearchEngineAction extends ActionType<AcknowledgedResponse> {
             // validate engine name using the same rules as index name
             try {
                 MetadataCreateIndexService.validateIndexOrAliasName(name, InvalidEngineNameException::new);
-            }
-            catch (InvalidEngineNameException x) {
+            } catch (InvalidEngineNameException x) {
                 validationException = ValidateActions.addValidationError(x.getMessage(), validationException);
             }
             if (CollectionUtils.isEmpty(indices)) {

--- a/x-pack/plugin/search-engines/src/main/java/org/elasticsearch/searchengines/action/CreateSearchEngineAction.java
+++ b/x-pack/plugin/search-engines/src/main/java/org/elasticsearch/searchengines/action/CreateSearchEngineAction.java
@@ -1,9 +1,8 @@
 /*
  * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
  * or more contributor license agreements. Licensed under the Elastic License
- * 2.0 and the Server Side Public License, v 1; you may not use this file except
- * in compliance with, at your election, the Elastic License 2.0 or the Server
- * Side Public License, v 1.
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
  */
 
 package org.elasticsearch.searchengines.action;

--- a/x-pack/plugin/search-engines/src/main/java/org/elasticsearch/searchengines/action/CreateSearchEngineTransportAction.java
+++ b/x-pack/plugin/search-engines/src/main/java/org/elasticsearch/searchengines/action/CreateSearchEngineTransportAction.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.searchengines.action;
+
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.support.ActionFilters;
+import org.elasticsearch.action.support.master.AcknowledgedResponse;
+import org.elasticsearch.action.support.master.AcknowledgedTransportMasterNodeAction;
+import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.block.ClusterBlockException;
+import org.elasticsearch.cluster.block.ClusterBlockLevel;
+import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
+import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.searchengines.SearchEngineMetadataService;
+import org.elasticsearch.tasks.Task;
+import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.transport.TransportService;
+
+public class CreateSearchEngineTransportAction extends AcknowledgedTransportMasterNodeAction<CreateSearchEngineAction.Request> {
+
+    private final SearchEngineMetadataService searchEngineMetadataService;
+
+    @Inject
+    public CreateSearchEngineTransportAction(
+        TransportService transportService,
+        ClusterService clusterService,
+        ThreadPool threadPool,
+        ActionFilters actionFilters,
+        IndexNameExpressionResolver indexNameExpressionResolver,
+        SearchEngineMetadataService searchEngineMetadataService
+    ) {
+        super(
+            CreateSearchEngineAction.NAME,
+            transportService,
+            clusterService,
+            threadPool,
+            actionFilters,
+            CreateSearchEngineAction.Request::new,
+            indexNameExpressionResolver,
+            ThreadPool.Names.SAME
+        );
+
+        this.searchEngineMetadataService = searchEngineMetadataService;
+    }
+
+    @Override
+    protected void masterOperation(Task task, CreateSearchEngineAction.Request request, ClusterState state, ActionListener<AcknowledgedResponse> listener) throws Exception {
+        searchEngineMetadataService.createSearchEngine(request, listener);
+    }
+
+    @Override
+    protected ClusterBlockException checkBlock(CreateSearchEngineAction.Request request, ClusterState state) {
+        return state.blocks().globalBlockedException(ClusterBlockLevel.METADATA_WRITE);
+    }
+}

--- a/x-pack/plugin/search-engines/src/main/java/org/elasticsearch/searchengines/action/CreateSearchEngineTransportAction.java
+++ b/x-pack/plugin/search-engines/src/main/java/org/elasticsearch/searchengines/action/CreateSearchEngineTransportAction.java
@@ -50,7 +50,12 @@ public class CreateSearchEngineTransportAction extends AcknowledgedTransportMast
     }
 
     @Override
-    protected void masterOperation(Task task, CreateSearchEngineAction.Request request, ClusterState state, ActionListener<AcknowledgedResponse> listener) throws Exception {
+    protected void masterOperation(
+        Task task,
+        CreateSearchEngineAction.Request request,
+        ClusterState state,
+        ActionListener<AcknowledgedResponse> listener
+    ) throws Exception {
         searchEngineMetadataService.createSearchEngine(request, listener);
     }
 

--- a/x-pack/plugin/search-engines/src/main/java/org/elasticsearch/searchengines/action/CreateSearchEngineTransportAction.java
+++ b/x-pack/plugin/search-engines/src/main/java/org/elasticsearch/searchengines/action/CreateSearchEngineTransportAction.java
@@ -1,9 +1,8 @@
 /*
  * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
  * or more contributor license agreements. Licensed under the Elastic License
- * 2.0 and the Server Side Public License, v 1; you may not use this file except
- * in compliance with, at your election, the Elastic License 2.0 or the Server
- * Side Public License, v 1.
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
  */
 
 package org.elasticsearch.searchengines.action;

--- a/x-pack/plugin/search-engines/src/main/java/org/elasticsearch/searchengines/action/DeleteSearchEngineAction.java
+++ b/x-pack/plugin/search-engines/src/main/java/org/elasticsearch/searchengines/action/DeleteSearchEngineAction.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.searchengines.action;
+
+import org.elasticsearch.action.ActionRequestValidationException;
+import org.elasticsearch.action.ActionType;
+import org.elasticsearch.action.IndicesRequest;
+import org.elasticsearch.action.ValidateActions;
+import org.elasticsearch.action.support.IndicesOptions;
+import org.elasticsearch.action.support.master.AcknowledgedRequest;
+import org.elasticsearch.action.support.master.AcknowledgedResponse;
+import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+
+public class DeleteSearchEngineAction extends ActionType<AcknowledgedResponse> {
+
+    public static final DeleteSearchEngineAction INSTANCE = new DeleteSearchEngineAction();
+    public static final String NAME = "indices:admin/search_engine/delete";
+
+    private DeleteSearchEngineAction() {
+        super(NAME, AcknowledgedResponse::readFrom);
+    }
+
+    public static class Request extends AcknowledgedRequest<Request> implements IndicesRequest {
+
+        private final String[] names;
+
+        private List<String> resolved = null;
+
+        public Request(String[] names) {
+            this.names = names;
+        }
+
+        public String[] getNames() {
+            return names;
+        }
+
+        public void setResolved(List<String> names) {
+            this.resolved = names;
+        }
+
+        public List<String> getResolved() {
+            return resolved;
+        }
+
+        @Override
+        public ActionRequestValidationException validate() {
+            ActionRequestValidationException validationException = null;
+            for (String name : names) {
+                if (Strings.hasText(name) == false) {
+                    validationException = ValidateActions.addValidationError("engine name can't be empty", validationException);
+                }
+            }
+            return validationException;
+        }
+
+        public Request(StreamInput in) throws IOException {
+            super(in);
+            this.names = in.readOptionalStringArray();
+        }
+
+        @Override
+        public void writeTo(StreamOutput out) throws IOException {
+            super.writeTo(out);
+            out.writeOptionalStringArray(names);
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            Request request = (Request) o;
+            return Arrays.equals(names, request.names);
+        }
+
+        @Override
+        public int hashCode() {
+            return Arrays.hashCode(names);
+        }
+
+        @Override
+        public String[] indices() {
+            return names;
+        }
+
+        @Override
+        public IndicesOptions indicesOptions() {
+            return IndicesOptions.strictSingleIndexNoExpandForbidClosed();
+        }
+    }
+}

--- a/x-pack/plugin/search-engines/src/main/java/org/elasticsearch/searchengines/action/DeleteSearchEngineTransportAction.java
+++ b/x-pack/plugin/search-engines/src/main/java/org/elasticsearch/searchengines/action/DeleteSearchEngineTransportAction.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.searchengines.action;
+
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.support.ActionFilters;
+import org.elasticsearch.action.support.IndicesOptions;
+import org.elasticsearch.action.support.master.AcknowledgedResponse;
+import org.elasticsearch.action.support.master.AcknowledgedTransportMasterNodeAction;
+import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.block.ClusterBlockException;
+import org.elasticsearch.cluster.block.ClusterBlockLevel;
+import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
+import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.searchengines.SearchEngineMetadataService;
+import org.elasticsearch.tasks.Task;
+import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.transport.TransportService;
+
+import java.util.EnumSet;
+import java.util.List;
+
+public class DeleteSearchEngineTransportAction extends AcknowledgedTransportMasterNodeAction<DeleteSearchEngineAction.Request> {
+
+    private final SearchEngineMetadataService searchEngineMetadataService;
+
+    @Inject
+    public DeleteSearchEngineTransportAction(
+        TransportService transportService,
+        ClusterService clusterService,
+        ThreadPool threadPool,
+        ActionFilters actionFilters,
+        IndexNameExpressionResolver indexNameExpressionResolver,
+        SearchEngineMetadataService searchEngineMetadataService
+    ) {
+        super(
+            DeleteSearchEngineAction.NAME,
+            transportService,
+            clusterService,
+            threadPool,
+            actionFilters,
+            DeleteSearchEngineAction.Request::new,
+            indexNameExpressionResolver,
+            ThreadPool.Names.SAME
+        );
+
+        this.searchEngineMetadataService = searchEngineMetadataService;
+    }
+
+    @Override
+    protected void masterOperation(
+        Task task,
+        DeleteSearchEngineAction.Request request,
+        ClusterState state,
+        ActionListener<AcknowledgedResponse> listener
+    ) throws Exception {
+        List<String> engineNames = getSearchEnginesNames(indexNameExpressionResolver, state, request.getNames(), request.indicesOptions());
+        request.setResolved(engineNames);
+        searchEngineMetadataService.deleteSearchEngine(request, listener);
+    }
+
+    @Override
+    protected ClusterBlockException checkBlock(DeleteSearchEngineAction.Request request, ClusterState state) {
+        return state.blocks().globalBlockedException(ClusterBlockLevel.METADATA_WRITE);
+    }
+
+    private static List<String> getSearchEnginesNames(
+        IndexNameExpressionResolver indexNameExpressionResolver,
+        ClusterState currentState,
+        String[] names,
+        IndicesOptions indicesOptions
+    ) {
+        indicesOptions = updateIndicesOptions(indicesOptions);
+        return indexNameExpressionResolver.searchEngineNames(currentState, indicesOptions, names);
+    }
+
+    private static IndicesOptions updateIndicesOptions(IndicesOptions indicesOptions) {
+        EnumSet<IndicesOptions.WildcardStates> expandWildcards = indicesOptions.expandWildcards();
+        expandWildcards.add(IndicesOptions.WildcardStates.OPEN);
+        indicesOptions = new IndicesOptions(indicesOptions.options(), expandWildcards);
+
+        return indicesOptions;
+    }
+}

--- a/x-pack/plugin/search-engines/src/main/java/org/elasticsearch/searchengines/action/GetSearchEngineAction.java
+++ b/x-pack/plugin/search-engines/src/main/java/org/elasticsearch/searchengines/action/GetSearchEngineAction.java
@@ -1,0 +1,172 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.searchengines.action;
+
+import org.elasticsearch.action.ActionRequestValidationException;
+import org.elasticsearch.action.ActionResponse;
+import org.elasticsearch.action.ActionType;
+import org.elasticsearch.action.IndicesRequest;
+import org.elasticsearch.action.support.IndicesOptions;
+import org.elasticsearch.action.support.master.MasterNodeReadRequest;
+import org.elasticsearch.cluster.metadata.SearchEngine;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.index.Index;
+import org.elasticsearch.xcontent.ParseField;
+import org.elasticsearch.xcontent.ToXContent;
+import org.elasticsearch.xcontent.ToXContentObject;
+import org.elasticsearch.xcontent.XContentBuilder;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+
+public class GetSearchEngineAction extends ActionType<GetSearchEngineAction.Response> {
+
+    public static final GetSearchEngineAction INSTANCE = new GetSearchEngineAction();
+    public static final String NAME = "indices:admin/search_engine/get";
+
+    private GetSearchEngineAction() {
+        super(NAME, Response::new);
+    }
+
+    public static class Request extends MasterNodeReadRequest<GetSearchEngineAction.Request> implements IndicesRequest.Replaceable {
+
+        private String[] names;
+        private IndicesOptions indicesOptions = IndicesOptions.fromOptions(false, true, true, true, false, false, true, false);
+
+        public Request(String[] names) {
+            this.names = names;
+        }
+
+        public Request(StreamInput in) throws IOException {
+            super(in);
+            this.names = in.readOptionalStringArray();
+            this.indicesOptions = IndicesOptions.readIndicesOptions(in);
+        }
+
+        @Override
+        public ActionRequestValidationException validate() {
+            return null;
+        }
+
+        @Override
+        public void writeTo(StreamOutput out) throws IOException {
+            super.writeTo(out);
+            out.writeOptionalStringArray(names);
+            indicesOptions.writeIndicesOptions(out);
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            GetSearchEngineAction.Request request = (GetSearchEngineAction.Request) o;
+            return Arrays.equals(names, request.names) && indicesOptions.equals(request.indicesOptions);
+        }
+
+        @Override
+        public int hashCode() {
+            int result = Objects.hash(indicesOptions);
+            result = 31 * result + Arrays.hashCode(names);
+            return result;
+        }
+
+        @Override
+        public String[] indices() {
+            return names;
+        }
+
+        public String[] getNames() {
+            return names;
+        }
+
+        @Override
+        public IndicesOptions indicesOptions() {
+            return indicesOptions;
+        }
+
+        public Request indicesOptions(IndicesOptions indicesOptions) {
+            this.indicesOptions = indicesOptions;
+            return this;
+        }
+
+        @Override
+        public boolean includeDataStreams() {
+            return false;
+        }
+
+        @Override
+        public IndicesRequest indices(String... indices) {
+            this.names = indices;
+            return this;
+        }
+    }
+
+    public static class Response extends ActionResponse implements ToXContentObject {
+
+        public static final ParseField NAME_FIELD = new ParseField("name");
+        public static final ParseField INDICES_FIELD = new ParseField("indices");
+
+        private final List<SearchEngine> searchEngines;
+
+        public Response(List<SearchEngine> searchEngines) {
+            this.searchEngines = searchEngines;
+        }
+
+        public Response(StreamInput in) throws IOException {
+            this(in.readList(SearchEngine::new));
+        }
+
+
+        public List<SearchEngine> getSearchEngines() {
+            return searchEngines;
+        }
+
+        @Override
+        public void writeTo(StreamOutput out) throws IOException {
+            out.writeList(searchEngines);
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            GetSearchEngineAction.Response response = (GetSearchEngineAction.Response) o;
+            return searchEngines.equals(response.searchEngines);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(searchEngines);
+        }
+
+        @Override
+        public XContentBuilder toXContent(XContentBuilder builder, ToXContent.Params params) throws IOException {
+            builder.startObject();
+
+            for (SearchEngine searchEngine: searchEngines) {
+                builder.field(searchEngine.getName());
+                builder.startObject();
+
+                builder.field(NAME_FIELD.getPreferredName(), searchEngine.getName());
+
+                builder.startArray(INDICES_FIELD.getPreferredName());
+                for (Index index: searchEngine.getIndices()) {
+                    builder.value(index.getName());
+                }
+
+                builder.endObject();
+            }
+            builder.endObject();
+            return builder;
+        }
+    }
+}

--- a/x-pack/plugin/search-engines/src/main/java/org/elasticsearch/searchengines/action/GetSearchEngineAction.java
+++ b/x-pack/plugin/search-engines/src/main/java/org/elasticsearch/searchengines/action/GetSearchEngineAction.java
@@ -124,7 +124,6 @@ public class GetSearchEngineAction extends ActionType<GetSearchEngineAction.Resp
             this(in.readList(SearchEngine::new));
         }
 
-
         public List<SearchEngine> getSearchEngines() {
             return searchEngines;
         }
@@ -151,14 +150,14 @@ public class GetSearchEngineAction extends ActionType<GetSearchEngineAction.Resp
         public XContentBuilder toXContent(XContentBuilder builder, ToXContent.Params params) throws IOException {
             builder.startObject();
 
-            for (SearchEngine searchEngine: searchEngines) {
+            for (SearchEngine searchEngine : searchEngines) {
                 builder.field(searchEngine.getName());
                 builder.startObject();
 
                 builder.field(NAME_FIELD.getPreferredName(), searchEngine.getName());
 
                 builder.startArray(INDICES_FIELD.getPreferredName());
-                for (Index index: searchEngine.getIndices()) {
+                for (Index index : searchEngine.getIndices()) {
                     builder.value(index.getName());
                 }
 

--- a/x-pack/plugin/search-engines/src/main/java/org/elasticsearch/searchengines/action/GetSearchEngineAction.java
+++ b/x-pack/plugin/search-engines/src/main/java/org/elasticsearch/searchengines/action/GetSearchEngineAction.java
@@ -160,7 +160,7 @@ public class GetSearchEngineAction extends ActionType<GetSearchEngineAction.Resp
                 for (Index index : searchEngine.getIndices()) {
                     builder.value(index.getName());
                 }
-
+                builder.endArray();
                 builder.endObject();
             }
             builder.endObject();

--- a/x-pack/plugin/search-engines/src/main/java/org/elasticsearch/searchengines/action/GetSearchEngineAction.java
+++ b/x-pack/plugin/search-engines/src/main/java/org/elasticsearch/searchengines/action/GetSearchEngineAction.java
@@ -1,9 +1,8 @@
 /*
  * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
  * or more contributor license agreements. Licensed under the Elastic License
- * 2.0 and the Server Side Public License, v 1; you may not use this file except
- * in compliance with, at your election, the Elastic License 2.0 or the Server
- * Side Public License, v 1.
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
  */
 
 package org.elasticsearch.searchengines.action;

--- a/x-pack/plugin/search-engines/src/main/java/org/elasticsearch/searchengines/action/GetSearchEngineTransportAction.java
+++ b/x-pack/plugin/search-engines/src/main/java/org/elasticsearch/searchengines/action/GetSearchEngineTransportAction.java
@@ -61,7 +61,8 @@ public class GetSearchEngineTransportAction extends TransportMasterNodeReadActio
         Task task,
         GetSearchEngineAction.Request request,
         ClusterState state,
-        ActionListener<GetSearchEngineAction.Response> listener) {
+        ActionListener<GetSearchEngineAction.Response> listener
+    ) {
         List<SearchEngine> searchEngines = getSearchEngines(request, state);
         listener.onResponse(new GetSearchEngineAction.Response(searchEngines));
     }

--- a/x-pack/plugin/search-engines/src/main/java/org/elasticsearch/searchengines/action/GetSearchEngineTransportAction.java
+++ b/x-pack/plugin/search-engines/src/main/java/org/elasticsearch/searchengines/action/GetSearchEngineTransportAction.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.searchengines.action;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.support.ActionFilters;
+import org.elasticsearch.action.support.IndicesOptions;
+import org.elasticsearch.action.support.master.TransportMasterNodeReadAction;
+import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.block.ClusterBlockException;
+import org.elasticsearch.cluster.block.ClusterBlockLevel;
+import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
+import org.elasticsearch.cluster.metadata.SearchEngine;
+import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.tasks.Task;
+import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.transport.TransportService;
+
+import java.util.Comparator;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Map;
+
+public class GetSearchEngineTransportAction extends TransportMasterNodeReadAction<
+    GetSearchEngineAction.Request,
+    GetSearchEngineAction.Response> {
+
+    private static final Logger LOGGER = LogManager.getLogger(GetSearchEngineTransportAction.class);
+
+    @Inject
+    public GetSearchEngineTransportAction(
+        TransportService transportService,
+        ClusterService clusterService,
+        ThreadPool threadPool,
+        ActionFilters actionFilters,
+        IndexNameExpressionResolver indexNameExpressionResolver
+    ) {
+        super(
+            GetSearchEngineAction.NAME,
+            transportService,
+            clusterService,
+            threadPool,
+            actionFilters,
+            GetSearchEngineAction.Request::new,
+            indexNameExpressionResolver,
+            GetSearchEngineAction.Response::new,
+            ThreadPool.Names.SAME
+        );
+    }
+
+    @Override
+    protected void masterOperation(
+        Task task,
+        GetSearchEngineAction.Request request,
+        ClusterState state,
+        ActionListener<GetSearchEngineAction.Response> listener) {
+        List<SearchEngine> searchEngines = getSearchEngines(request, state);
+        listener.onResponse(new GetSearchEngineAction.Response(searchEngines));
+    }
+
+    private List<SearchEngine> getSearchEngines(GetSearchEngineAction.Request request, ClusterState clusterState) {
+        List<String> results = getSearchEnginesNames(
+            indexNameExpressionResolver,
+            clusterState,
+            request.getNames(),
+            request.indicesOptions()
+        );
+        Map<String, SearchEngine> contentIndices = clusterState.metadata().searchEngines();
+
+        return results.stream().map(contentIndices::get).sorted(Comparator.comparing(SearchEngine::getName)).toList();
+    }
+
+    @Override
+    protected ClusterBlockException checkBlock(GetSearchEngineAction.Request request, ClusterState state) {
+        return state.blocks().globalBlockedException(ClusterBlockLevel.METADATA_WRITE);
+    }
+
+    private static List<String> getSearchEnginesNames(
+        IndexNameExpressionResolver indexNameExpressionResolver,
+        ClusterState currentState,
+        String[] names,
+        IndicesOptions indicesOptions
+    ) {
+        indicesOptions = updateIndicesOptions(indicesOptions);
+        return indexNameExpressionResolver.searchEngineNames(currentState, indicesOptions, names);
+    }
+
+    private static IndicesOptions updateIndicesOptions(IndicesOptions indicesOptions) {
+        EnumSet<IndicesOptions.WildcardStates> expandWildcards = indicesOptions.expandWildcards();
+        expandWildcards.add(IndicesOptions.WildcardStates.OPEN);
+        indicesOptions = new IndicesOptions(indicesOptions.options(), expandWildcards);
+
+        return indicesOptions;
+    }
+}

--- a/x-pack/plugin/search-engines/src/main/java/org/elasticsearch/searchengines/action/GetSearchEngineTransportAction.java
+++ b/x-pack/plugin/search-engines/src/main/java/org/elasticsearch/searchengines/action/GetSearchEngineTransportAction.java
@@ -1,9 +1,8 @@
 /*
  * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
  * or more contributor license agreements. Licensed under the Elastic License
- * 2.0 and the Server Side Public License, v 1; you may not use this file except
- * in compliance with, at your election, the Elastic License 2.0 or the Server
- * Side Public License, v 1.
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
  */
 
 package org.elasticsearch.searchengines.action;

--- a/x-pack/plugin/search-engines/src/main/java/org/elasticsearch/searchengines/rest/RestCreateSearchEngineAction.java
+++ b/x-pack/plugin/search-engines/src/main/java/org/elasticsearch/searchengines/rest/RestCreateSearchEngineAction.java
@@ -1,9 +1,8 @@
 /*
  * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
  * or more contributor license agreements. Licensed under the Elastic License
- * 2.0 and the Server Side Public License, v 1; you may not use this file except
- * in compliance with, at your election, the Elastic License 2.0 or the Server
- * Side Public License, v 1.
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
  */
 
 package org.elasticsearch.searchengines.rest;

--- a/x-pack/plugin/search-engines/src/main/java/org/elasticsearch/searchengines/rest/RestCreateSearchEngineAction.java
+++ b/x-pack/plugin/search-engines/src/main/java/org/elasticsearch/searchengines/rest/RestCreateSearchEngineAction.java
@@ -15,6 +15,7 @@ import org.elasticsearch.rest.action.RestToXContentListener;
 import org.elasticsearch.searchengines.SearchEnginesPlugin;
 import org.elasticsearch.searchengines.action.CreateSearchEngineAction;
 
+import java.io.IOException;
 import java.util.List;
 
 import static org.elasticsearch.rest.RestRequest.Method.PUT;
@@ -32,9 +33,8 @@ public class RestCreateSearchEngineAction extends BaseRestHandler {
     }
 
     @Override
-    protected BaseRestHandler.RestChannelConsumer prepareRequest(RestRequest request, NodeClient client) {
-        CreateSearchEngineAction.Request createEngineRequest = new CreateSearchEngineAction.Request(request.param("name"));
+    protected BaseRestHandler.RestChannelConsumer prepareRequest(RestRequest request, NodeClient client) throws IOException {
+        CreateSearchEngineAction.Request createEngineRequest = CreateSearchEngineAction.Request.parseRestRequest(request);
         return channel -> client.execute(CreateSearchEngineAction.INSTANCE, createEngineRequest, new RestToXContentListener<>(channel));
     }
-
 }

--- a/x-pack/plugin/search-engines/src/main/java/org/elasticsearch/searchengines/rest/RestCreateSearchEngineAction.java
+++ b/x-pack/plugin/search-engines/src/main/java/org/elasticsearch/searchengines/rest/RestCreateSearchEngineAction.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.searchengines.rest;
+
+import org.elasticsearch.client.internal.node.NodeClient;
+import org.elasticsearch.searchengines.SearchEnginesPlugin;
+import org.elasticsearch.searchengines.action.CreateSearchEngineAction;
+import org.elasticsearch.rest.BaseRestHandler;
+import org.elasticsearch.rest.RestHandler;
+import org.elasticsearch.rest.RestRequest;
+import org.elasticsearch.rest.action.RestToXContentListener;
+
+import java.util.List;
+
+import static org.elasticsearch.rest.RestRequest.Method.PUT;
+
+public class RestCreateSearchEngineAction  extends BaseRestHandler {
+
+    @Override
+    public String getName() {
+        return "create_search_engine_action";
+    }
+
+    @Override
+    public List<Route> routes() {
+        return List.of(new RestHandler.Route(PUT, SearchEnginesPlugin.REST_BASE_PATH + "/{name}"));
+    }
+
+    @Override
+    protected BaseRestHandler.RestChannelConsumer prepareRequest(RestRequest request, NodeClient client) {
+        CreateSearchEngineAction.Request createEngineRequest = new CreateSearchEngineAction.Request(request.param("name"));
+        return channel -> client.execute(CreateSearchEngineAction.INSTANCE, createEngineRequest, new RestToXContentListener<>(channel));
+    }
+
+}

--- a/x-pack/plugin/search-engines/src/main/java/org/elasticsearch/searchengines/rest/RestCreateSearchEngineAction.java
+++ b/x-pack/plugin/search-engines/src/main/java/org/elasticsearch/searchengines/rest/RestCreateSearchEngineAction.java
@@ -8,18 +8,18 @@
 package org.elasticsearch.searchengines.rest;
 
 import org.elasticsearch.client.internal.node.NodeClient;
-import org.elasticsearch.searchengines.SearchEnginesPlugin;
-import org.elasticsearch.searchengines.action.CreateSearchEngineAction;
 import org.elasticsearch.rest.BaseRestHandler;
 import org.elasticsearch.rest.RestHandler;
 import org.elasticsearch.rest.RestRequest;
 import org.elasticsearch.rest.action.RestToXContentListener;
+import org.elasticsearch.searchengines.SearchEnginesPlugin;
+import org.elasticsearch.searchengines.action.CreateSearchEngineAction;
 
 import java.util.List;
 
 import static org.elasticsearch.rest.RestRequest.Method.PUT;
 
-public class RestCreateSearchEngineAction  extends BaseRestHandler {
+public class RestCreateSearchEngineAction extends BaseRestHandler {
 
     @Override
     public String getName() {

--- a/x-pack/plugin/search-engines/src/main/java/org/elasticsearch/searchengines/rest/RestDeleteSearchEngineAction.java
+++ b/x-pack/plugin/search-engines/src/main/java/org/elasticsearch/searchengines/rest/RestDeleteSearchEngineAction.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.searchengines.rest;
+
+import org.elasticsearch.client.internal.node.NodeClient;
+import org.elasticsearch.common.Strings;
+import org.elasticsearch.rest.BaseRestHandler;
+import org.elasticsearch.rest.RestRequest;
+import org.elasticsearch.rest.action.RestToXContentListener;
+import org.elasticsearch.searchengines.SearchEnginesPlugin;
+import org.elasticsearch.searchengines.action.DeleteSearchEngineAction;
+
+import java.io.IOException;
+import java.util.List;
+
+import static org.elasticsearch.rest.RestRequest.Method.DELETE;
+
+public class RestDeleteSearchEngineAction extends BaseRestHandler {
+
+    @Override
+    public String getName() {
+        return "delete_search_engine_action";
+    }
+
+    @Override
+    public List<Route> routes() {
+        return List.of(new Route(DELETE, SearchEnginesPlugin.REST_BASE_PATH + "/{name}"));
+    }
+
+    @Override
+    protected RestChannelConsumer prepareRequest(RestRequest request, NodeClient client) throws IOException {
+        DeleteSearchEngineAction.Request deleteRequest = new DeleteSearchEngineAction.Request(
+            Strings.splitStringByCommaToArray(request.param("name"))
+        );
+        return channel -> client.execute(DeleteSearchEngineAction.INSTANCE, deleteRequest, new RestToXContentListener<>(channel));
+    }
+}

--- a/x-pack/plugin/search-engines/src/main/java/org/elasticsearch/searchengines/rest/RestGetSearchEngineAction.java
+++ b/x-pack/plugin/search-engines/src/main/java/org/elasticsearch/searchengines/rest/RestGetSearchEngineAction.java
@@ -1,9 +1,8 @@
 /*
  * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
  * or more contributor license agreements. Licensed under the Elastic License
- * 2.0 and the Server Side Public License, v 1; you may not use this file except
- * in compliance with, at your election, the Elastic License 2.0 or the Server
- * Side Public License, v 1.
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
  */
 
 package org.elasticsearch.searchengines.rest;

--- a/x-pack/plugin/search-engines/src/main/java/org/elasticsearch/searchengines/rest/RestGetSearchEngineAction.java
+++ b/x-pack/plugin/search-engines/src/main/java/org/elasticsearch/searchengines/rest/RestGetSearchEngineAction.java
@@ -19,7 +19,7 @@ import org.elasticsearch.searchengines.action.GetSearchEngineAction;
 
 import java.util.List;
 
-import static org.elasticsearch.rest.RestRequest.Method.GET;;
+import static org.elasticsearch.rest.RestRequest.Method.GET;
 
 public class RestGetSearchEngineAction extends BaseRestHandler {
     @Override
@@ -29,9 +29,7 @@ public class RestGetSearchEngineAction extends BaseRestHandler {
 
     @Override
     public List<Route> routes() {
-        return List.of(
-            new RestHandler.Route(GET, SearchEnginesPlugin.REST_BASE_PATH + "/{name}")
-        );
+        return List.of(new RestHandler.Route(GET, SearchEnginesPlugin.REST_BASE_PATH + "/{name}"));
     }
 
     @Override

--- a/x-pack/plugin/search-engines/src/main/java/org/elasticsearch/searchengines/rest/RestGetSearchEngineAction.java
+++ b/x-pack/plugin/search-engines/src/main/java/org/elasticsearch/searchengines/rest/RestGetSearchEngineAction.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.searchengines.rest;
+
+import org.elasticsearch.action.support.IndicesOptions;
+import org.elasticsearch.client.internal.node.NodeClient;
+import org.elasticsearch.common.Strings;
+import org.elasticsearch.rest.BaseRestHandler;
+import org.elasticsearch.rest.RestHandler;
+import org.elasticsearch.rest.RestRequest;
+import org.elasticsearch.rest.action.RestToXContentListener;
+import org.elasticsearch.searchengines.SearchEnginesPlugin;
+import org.elasticsearch.searchengines.action.GetSearchEngineAction;
+
+import java.util.List;
+
+import static org.elasticsearch.rest.RestRequest.Method.GET;;
+
+public class RestGetSearchEngineAction extends BaseRestHandler {
+    @Override
+    public String getName() {
+        return "get_search_engine_action";
+    }
+
+    @Override
+    public List<Route> routes() {
+        return List.of(
+            new RestHandler.Route(GET, SearchEnginesPlugin.REST_BASE_PATH + "/{name}")
+        );
+    }
+
+    @Override
+    protected RestChannelConsumer prepareRequest(RestRequest request, NodeClient client) {
+        GetSearchEngineAction.Request getContentIndexRequest = new GetSearchEngineAction.Request(
+            Strings.splitStringByCommaToArray(request.param("name"))
+        );
+        getContentIndexRequest.indicesOptions(IndicesOptions.fromRequest(request, getContentIndexRequest.indicesOptions()));
+        return channel -> client.execute(GetSearchEngineAction.INSTANCE, getContentIndexRequest, new RestToXContentListener<>(channel));
+    }
+
+    @Override
+    public boolean allowSystemIndexAccessByDefault() {
+        return false;
+    }
+}

--- a/x-pack/plugin/security/qa/operator-privileges-tests/src/javaRestTest/java/org/elasticsearch/xpack/security/operator/Constants.java
+++ b/x-pack/plugin/security/qa/operator-privileges-tests/src/javaRestTest/java/org/elasticsearch/xpack/security/operator/Constants.java
@@ -408,6 +408,8 @@ public class Constants {
         "indices:admin/seq_no/global_checkpoint_sync",
         "indices:admin/seq_no/remove_retention_lease",
         "indices:admin/seq_no/renew_retention_lease",
+        "indices:admin/search_engine/create",
+        "indices:admin/search_engine/get",
         "indices:admin/settings/update",
         "indices:admin/shards/search_shards",
         "indices:admin/template/delete",


### PR DESCRIPTION
Part of REX Paris demo. Based on branch `afoucret:afoucret/rex-engine-poc`.

Implements Delete API for https://github.com/elastic/elasticsearch/pull/90512.

- [ ] Additional APIs:
  - [x] Delete a Search Engine
  - [ ] Add / Remove an index from a Search engine