### PR TITLE
Fork TransportClusterHealthAction to MANAGEMENT

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/health/TransportClusterHealthAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/health/TransportClusterHealthAction.java
@@ -67,7 +67,7 @@ public class TransportClusterHealthAction extends TransportMasterNodeReadAction<
             ClusterHealthRequest::new,
             indexNameExpressionResolver,
             ClusterHealthResponse::new,
-            ThreadPool.Names.SAME
+            ThreadPool.Names.MANAGEMENT // fork to management since the health computation can become expensive for large cluster states
         );
         this.allocationService = allocationService;
     }


### PR DESCRIPTION
This action can become fairly expensive for large states. Plus it is called at high rates on e.g. Cloud which is blocking transport threads needlessly in large deployments. Lets fork it to MANAGEMENT like we do for similar CPU bound actions.

relates #77466 