### PR TITLE
Avoid capturing per-task RolloverResult

### DIFF
--- a/docs/changelog/90626.yaml
+++ b/docs/changelog/90626.yaml
@@ -1,0 +1,6 @@
+pr: 90626
+summary: Avoid capturing per-task `RolloverResult`
+area: Indices APIs
+type: bug
+issues:
+ - 90620


### PR DESCRIPTION
Today `TransportRolloverAction$RolloverExecutor` captures a `RolloverResult` for each task for use in the publication success callback. These things contain a cluster state which can be huge, and isn't necessary for the callback. With this commit we extract the fields we need instead, avoiding capturing the complete cluster state.

Closes #90620