### PR TITLE
Update configuration.asciidoc

### DIFF
--- a/docs/java-rest/low-level/configuration.asciidoc
+++ b/docs/java-rest/low-level/configuration.asciidoc
@@ -14,7 +14,7 @@ additional configuration for the low-level Java REST Client.
 Configuring requests timeouts can be done by providing an instance of
 `RequestConfigCallback` while building the `RestClient` through its builder.
 The interface has one method that receives an instance of
-https://hc.apache.org/httpcomponents-client-ga/httpclient/apidocs/org/apache/http/client/config/RequestConfig.Builder.html[`org.apache.http.client.config.RequestConfig.Builder`]
+https://hc.apache.org/httpcomponents-client-5.1.x/current/httpclient5/apidocs/org/apache/hc/client5/http/config/RequestConfig.Builder.html[`org.apache.http.client.config.RequestConfig.Builder`]
  as an argument and has the same return type. The request config builder can
 be modified and then returned. In the following example we increase the
 connect timeout (defaults to 1 second) and the socket timeout (defaults to 30


### PR DESCRIPTION
Documentation points to a [page](https://hc.apache.org/httpcomponents-client-5.1.x/httpclient/apidocs/org/apache/http/client/config/RequestConfig.Builder.html) that doesn't exist anymore.
