### PR TITLE
ClusterStateHealth need not be iterable

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/health/ClusterIndexHealth.java
+++ b/server/src/main/java/org/elasticsearch/cluster/health/ClusterIndexHealth.java
@@ -24,7 +24,6 @@ import org.elasticsearch.xcontent.XContentParser;
 
 import java.io.IOException;
 import java.util.HashMap;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -35,7 +34,7 @@ import static org.elasticsearch.common.xcontent.XContentParserUtils.ensureExpect
 import static org.elasticsearch.xcontent.ConstructingObjectParser.constructorArg;
 import static org.elasticsearch.xcontent.ConstructingObjectParser.optionalConstructorArg;
 
-public final class ClusterIndexHealth implements Iterable<ClusterShardHealth>, Writeable, ToXContentFragment {
+public final class ClusterIndexHealth implements Writeable, ToXContentFragment {
     private static final String STATUS = "status";
     private static final String NUMBER_OF_SHARDS = "number_of_shards";
     private static final String NUMBER_OF_REPLICAS = "number_of_replicas";
@@ -240,11 +239,6 @@ public final class ClusterIndexHealth implements Iterable<ClusterShardHealth>, W
 
     public Map<Integer, ClusterShardHealth> getShards() {
         return this.shards;
-    }
-
-    @Override
-    public Iterator<ClusterShardHealth> iterator() {
-        return shards.values().iterator();
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/cluster/health/ClusterStateHealth.java
+++ b/server/src/main/java/org/elasticsearch/cluster/health/ClusterStateHealth.java
@@ -18,11 +18,10 @@ import org.elasticsearch.rest.RestStatus;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.Iterator;
 import java.util.Map;
 import java.util.Objects;
 
-public final class ClusterStateHealth implements Iterable<ClusterIndexHealth>, Writeable {
+public final class ClusterStateHealth implements Writeable {
 
     private final int numberOfNodes;
     private final int numberOfDataNodes;
@@ -182,11 +181,6 @@ public final class ClusterStateHealth implements Iterable<ClusterIndexHealth>, W
 
     public double getActiveShardsPercent() {
         return activeShardsPercent;
-    }
-
-    @Override
-    public Iterator<ClusterIndexHealth> iterator() {
-        return indices.values().iterator();
     }
 
     @Override


### PR DESCRIPTION
We never iterate over this structure, so there's no need for it to implement `Iterable<ClusterIndexHealth>`.