### PR TITLE
[8.5] Fix date rounding for date math parsing (#90458)

### DIFF
--- a/docs/changelog/90458.yaml
+++ b/docs/changelog/90458.yaml
@@ -1,0 +1,6 @@
+pr: 90458
+summary: Fix date rounding for date math parsing
+area: Infra/Core
+type: bug
+issues:
+ - 90187

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search/500_date_range.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search/500_date_range.yml
@@ -1,0 +1,121 @@
+setup:
+  - skip:
+      version: " - 8.5.99"
+      reason: awaits backports
+  - do:
+      indices.create:
+        index: dates_year_only
+        body:
+          mappings:
+            properties:
+              date:
+                type: date
+                format: uuuu
+
+  - do:
+      bulk:
+        refresh: true
+        body:
+          - '{ "index" : { "_index" : "dates_year_only", "_id" : "first" } }'
+          - '{"date" : "1900", "field" : 1 }'
+          - '{ "index" : { "_index" : "dates_year_only", "_id" : "second" } }'
+          - '{"date" : "2022", "field" : 1 }'
+          - '{ "index" : { "_index" : "dates_year_only", "_id" : "third" } }'
+          - '{"date" : "2022", "field" : 2 }'
+          - '{ "index" : { "_index" : "dates_year_only", "_id" : "fourth" } }'
+          - '{"date" : "1500", "field" : 2 }'
+
+  - do:
+      indices.create:
+        index: dates
+        body:
+          mappings:
+            properties:
+              date:
+                type: date
+
+  - do:
+      bulk:
+        refresh: true
+        body:
+          - '{ "index" : { "_index" : "dates", "_id" : "first" } }'
+          - '{"date" : "1900-01-01T12:12:12.123456789Z", "field" : 1 }'
+          - '{ "index" : { "_index" : "dates", "_id" : "second" } }'
+          - '{"date" : "2022-01-01T12:12:12.123456789Z", "field" : 1 }'
+          - '{ "index" : { "_index" : "dates", "_id" : "third" } }'
+          - '{"date" : "2022-01-03T12:12:12.123456789Z", "field" : 2 }'
+          - '{ "index" : { "_index" : "dates", "_id" : "fourth" } }'
+          - '{"date" : "1500-01-01T12:12:12.123456789Z", "field" : 2 }'
+          - '{ "index" : { "_index" : "dates", "_id" : "fifth" } }'
+          - '{"date" : "1500-01-05T12:12:12.123456789Z", "field" : 2 }'
+
+---
+"test range query for all docs with year uuuu":
+  - do:
+      search:
+        rest_total_hits_as_int: true
+        index: dates
+        body:
+          query:
+            range:
+              date:
+                gte: 1000
+                lte: 2023
+                format: uuuu
+
+  - match: { hits.total: 5 }
+  - length: { hits.hits: 5 }
+
+---
+"test match query gte and lt for single result with year uuuu":
+  - do:
+      search:
+        rest_total_hits_as_int: true
+        index: dates
+        body:
+          query:
+            range:
+              date:
+                gte: 1500 #1500-01-01T00:00:00
+                lte: 1500 #1500-01-01T23:59:59
+                format: uuuu
+
+  - match: { hits.total: 1 }
+  - length: { hits.hits: 1 }
+  - match: { hits.hits.0._id: "fourth" }
+
+---
+"test match query gte and lte with year uuuu":
+  - do:
+      search:
+        rest_total_hits_as_int: true
+        index: dates
+        body:
+          query:
+            range:
+              date:
+                gte: 1500
+                lte: 2000
+                format: uuuu
+
+  - match: { hits.total: 3 }
+  - length: { hits.hits: 3 }
+  - match: { hits.hits.0._id: "first" }
+  - match: { hits.hits.1._id: "fourth" }
+  - match: { hits.hits.2._id: "fifth" }
+
+---
+"test match query with year uuuu":
+  - do:
+      search:
+        rest_total_hits_as_int: true
+        index: dates_year_only
+        body:
+          query:
+            match:
+              date:
+                query: "1500"
+
+  - match: { hits.total: 1 }
+  - length: { hits.hits: 1 }
+  - match: { hits.hits.0._id: "fourth" }

--- a/server/src/main/java/org/elasticsearch/common/time/JavaDateFormatter.java
+++ b/server/src/main/java/org/elasticsearch/common/time/JavaDateFormatter.java
@@ -16,6 +16,7 @@ import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeFormatterBuilder;
 import java.time.format.DateTimeParseException;
 import java.time.temporal.ChronoField;
+import java.time.temporal.IsoFields;
 import java.time.temporal.TemporalAccessor;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -41,12 +42,17 @@ class JavaDateFormatter implements DateFormatter {
     */
     private static final BiConsumer<DateTimeFormatterBuilder, DateTimeFormatter> DEFAULT_ROUND_UP = (builder, parser) -> {
         String parserAsString = parser.toString();
-        if (parserAsString.contains(ChronoField.MONTH_OF_YEAR.toString())) {
+        if (parserAsString.contains(ChronoField.DAY_OF_YEAR.toString())) {
+            builder.parseDefaulting(ChronoField.DAY_OF_YEAR, 1L);
+            // TODO ideally we should make defaulting for weekbased year here too,
+            // but this will not work when locale is changed
+            // weekbased rounding relies on DateFormatters#localDateFromWeekBasedDate
+            // Applying month of year or dayOfMonth when weekbased fields are used will result in a conflict
+        } else if (parserAsString.contains(IsoFields.WEEK_BASED_YEAR.toString()) == false) {
             builder.parseDefaulting(ChronoField.MONTH_OF_YEAR, 1L);
-        }
-        if (parserAsString.contains(ChronoField.DAY_OF_MONTH.toString())) {
             builder.parseDefaulting(ChronoField.DAY_OF_MONTH, 1L);
         }
+
         if (parserAsString.contains(ChronoField.CLOCK_HOUR_OF_AMPM.toString())) {
             builder.parseDefaulting(ChronoField.CLOCK_HOUR_OF_AMPM, 11L);
             builder.parseDefaulting(ChronoField.AMPM_OF_DAY, 1L);


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.5`:
 - [Fix date rounding for date math parsing (#90458)](https://github.com/elastic/elasticsearch/pull/90458)

<!--- Backport version: 8.4.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)