### PR TITLE
[8.5] Fork TransportClusterHealthAction to MANAGEMENT (#90621)

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/health/TransportClusterHealthAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/health/TransportClusterHealthAction.java
@@ -67,7 +67,7 @@ public class TransportClusterHealthAction extends TransportMasterNodeReadAction<
             ClusterHealthRequest::new,
             indexNameExpressionResolver,
             ClusterHealthResponse::new,
-            ThreadPool.Names.SAME
+            ThreadPool.Names.MANAGEMENT // fork to management since the health computation can become expensive for large cluster states
         );
         this.allocationService = allocationService;
     }


### PR DESCRIPTION
Backports the following commits to 8.5:
 - Fork TransportClusterHealthAction to MANAGEMENT (#90621)