### PR TITLE
[8.5] Avoid capturing per-task RolloverResult (#90626)

### DIFF
--- a/docs/changelog/90626.yaml
+++ b/docs/changelog/90626.yaml
@@ -1,0 +1,6 @@
+pr: 90626
+summary: Avoid capturing per-task `RolloverResult`
+area: Indices APIs
+type: bug
+issues:
+ - 90620


### PR DESCRIPTION
Backports the following commits to 8.5:
 - Avoid capturing per-task RolloverResult (#90626)