### PR TITLE
Enable search/500_date_range test for bwc testing

### DIFF
--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search/500_date_range.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search/500_date_range.yml
@@ -1,7 +1,4 @@
 setup:
-  - skip:
-      version: " - 8.5.99"
-      reason: awaits backports
   - do:
       indices.create:
         index: dates_year_only


### PR DESCRIPTION
the #90458 has been backported to all branches so the bwc testing can be enable for this

<!--
Thank you for your interest in and contributing to Elasticsearch! There
are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your
attention.
-->

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/elasticsearch/blob/main/CONTRIBUTING.md)?
- If submitting code, have you built your formula locally prior to submission with `gradle check`?
- If submitting code, is your pull request against main? Unless there is a good reason otherwise, we prefer pull requests against main and will backport as needed.
- If submitting code, have you checked that your submission is for an [OS and architecture that we support](https://www.elastic.co/support/matrix#show_os)?
- If you are submitting this code for a class then read our [policy](https://github.com/elastic/elasticsearch/blob/main/CONTRIBUTING.md#contributing-as-part-of-a-class) for that.
