### PR TITLE
[Stack Monitoring] Update ES module mappings

### DIFF
--- a/docs/changelog/90649.yaml
+++ b/docs/changelog/90649.yaml
@@ -1,0 +1,5 @@
+pr: 90649
+summary: "[Stack Monitoring] Update ES module mappings"
+area: Monitoring
+type: bug
+issues: []

--- a/x-pack/plugin/core/src/main/resources/monitoring-es-mb.json
+++ b/x-pack/plugin/core/src/main/resources/monitoring-es-mb.json
@@ -154,13 +154,6 @@
                         "data": {
                           "type": "long"
                         },
-                        "stats": {
-                          "properties": {
-                            "data": {
-                              "type": "long"
-                            }
-                          }
-                        },
                         "count": {
                           "type": "long"
                         },


### PR DESCRIPTION
## Summary

Updates mappings due to changes in https://github.com/elastic/beats/pull/33214. Specifically addresses https://github.com/elastic/beats/pull/33214#discussion_r985360811.

