### PR TITLE
Use singleton for empty AliasFilter throughout

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/shards/ClusterSearchShardsResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/shards/ClusterSearchShardsResponse.java
@@ -30,7 +30,7 @@ public class ClusterSearchShardsResponse extends ActionResponse implements ToXCo
         super(in);
         groups = in.readArray(ClusterSearchShardsGroup::new, ClusterSearchShardsGroup[]::new);
         nodes = in.readArray(DiscoveryNode::new, DiscoveryNode[]::new);
-        indicesAndFilters = in.readMap(StreamInput::readString, AliasFilter::new);
+        indicesAndFilters = in.readMap(StreamInput::readString, AliasFilter::readFrom);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/shards/TransportClusterSearchShardsAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/shards/TransportClusterSearchShardsAction.java
@@ -90,7 +90,7 @@ public class TransportClusterSearchShardsAction extends TransportMasterNodeReadA
                 true,
                 indicesAndAliases
             );
-            indicesAndFilters.put(index, new AliasFilter(aliasFilter.getQueryBuilder(), aliases));
+            indicesAndFilters.put(index, AliasFilter.of(aliasFilter.getQueryBuilder(), aliases));
         }
 
         Set<String> nodeIds = new HashSet<>();

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/validate/query/ShardValidateQueryRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/validate/query/ShardValidateQueryRequest.java
@@ -41,7 +41,7 @@ public class ShardValidateQueryRequest extends BroadcastShardRequest {
                 }
             }
         }
-        filteringAliases = new AliasFilter(in);
+        filteringAliases = AliasFilter.readFrom(in);
         explain = in.readBoolean();
         rewrite = in.readBoolean();
         nowInMillis = in.readVLong();

--- a/server/src/main/java/org/elasticsearch/action/explain/ExplainRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/explain/ExplainRequest.java
@@ -41,7 +41,7 @@ public class ExplainRequest extends SingleShardRequest<ExplainRequest> implement
     private String[] storedFields;
     private FetchSourceContext fetchSourceContext;
 
-    private AliasFilter filteringAlias = new AliasFilter(null, Strings.EMPTY_ARRAY);
+    private AliasFilter filteringAlias = AliasFilter.EMPTY;
 
     long nowInMillis;
 
@@ -62,7 +62,7 @@ public class ExplainRequest extends SingleShardRequest<ExplainRequest> implement
         routing = in.readOptionalString();
         preference = in.readOptionalString();
         query = in.readNamedWriteable(QueryBuilder.class);
-        filteringAlias = new AliasFilter(in);
+        filteringAlias = AliasFilter.readFrom(in);
         storedFields = in.readOptionalStringArray();
         fetchSourceContext = in.readOptionalWriteable(FetchSourceContext::readFrom);
         nowInMillis = in.readVLong();

--- a/server/src/main/java/org/elasticsearch/action/search/CanMatchNodeRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/search/CanMatchNodeRequest.java
@@ -88,7 +88,7 @@ public class CanMatchNodeRequest extends TransportRequest implements IndicesRequ
             indices = in.readStringArray();
             shardId = new ShardId(in);
             shardRequestIndex = in.readVInt();
-            aliasFilter = new AliasFilter(in);
+            aliasFilter = AliasFilter.readFrom(in);
             indexBoost = in.readFloat();
             readerId = in.readOptionalWriteable(ShardSearchContextId::new);
             keepAlive = in.readOptionalTimeValue();

--- a/server/src/main/java/org/elasticsearch/action/search/SearchContextId.java
+++ b/server/src/main/java/org/elasticsearch/action/search/SearchContextId.java
@@ -89,7 +89,7 @@ public final class SearchContextId {
             final Version version = Version.readVersion(in);
             in.setVersion(version);
             final Map<ShardId, SearchContextIdForNode> shards = in.readMap(ShardId::new, SearchContextIdForNode::new);
-            final Map<String, AliasFilter> aliasFilters = in.readMap(StreamInput::readString, AliasFilter::new);
+            final Map<String, AliasFilter> aliasFilters = in.readMap(StreamInput::readString, AliasFilter::readFrom);
             if (in.available() > 0) {
                 throw new IllegalArgumentException("Not all bytes were read");
             }

--- a/server/src/main/java/org/elasticsearch/indices/IndicesService.java
+++ b/server/src/main/java/org/elasticsearch/indices/IndicesService.java
@@ -1657,21 +1657,21 @@ public class IndicesService extends AbstractLifecycleComponent
                 }
             }).toList();
             if (filters.isEmpty()) {
-                return new AliasFilter(null, aliases);
+                return AliasFilter.of(null, aliases);
             } else {
                 if (filters.size() == 1) {
-                    return new AliasFilter(filters.get(0), aliases);
+                    return AliasFilter.of(filters.get(0), aliases);
                 } else {
                     BoolQueryBuilder bool = new BoolQueryBuilder();
                     for (QueryBuilder filter : filters) {
                         bool.should(filter);
                     }
-                    return new AliasFilter(bool, aliases);
+                    return AliasFilter.of(bool, aliases);
                 }
             }
         } else {
             IndexMetadata indexMetadata = metadata.index(index);
-            return new AliasFilter(ShardSearchRequest.parseAliasFilter(filterParser, indexMetadata, aliases), aliases);
+            return AliasFilter.of(ShardSearchRequest.parseAliasFilter(filterParser, indexMetadata, aliases), aliases);
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/search/internal/AliasFilter.java
+++ b/server/src/main/java/org/elasticsearch/search/internal/AliasFilter.java
@@ -30,14 +30,22 @@ public final class AliasFilter implements Writeable, Rewriteable<AliasFilter> {
 
     public static final AliasFilter EMPTY = new AliasFilter(null, Strings.EMPTY_ARRAY);
 
-    public AliasFilter(QueryBuilder filter, String... aliases) {
+    private AliasFilter(QueryBuilder filter, String... aliases) {
         this.aliases = aliases == null ? Strings.EMPTY_ARRAY : aliases;
         this.filter = filter;
     }
 
-    public AliasFilter(StreamInput input) throws IOException {
-        aliases = input.readStringArray();
-        filter = input.readOptionalNamedWriteable(QueryBuilder.class);
+    public static AliasFilter of(QueryBuilder filter, String... aliases) {
+        if (filter == null && (aliases == null || aliases.length == 0)) {
+            return EMPTY;
+        }
+        return new AliasFilter(filter, aliases);
+    }
+
+    public static AliasFilter readFrom(StreamInput in) throws IOException {
+        final String[] aliases = in.readStringArray();
+        final QueryBuilder filter = in.readOptionalNamedWriteable(QueryBuilder.class);
+        return of(filter, aliases);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/search/internal/ShardSearchRequest.java
+++ b/server/src/main/java/org/elasticsearch/search/internal/ShardSearchRequest.java
@@ -283,7 +283,7 @@ public class ShardSearchRequest extends TransportRequest implements IndicesReque
                 );
             }
         }
-        aliasFilter = new AliasFilter(in);
+        aliasFilter = AliasFilter.readFrom(in);
         indexBoost = in.readFloat();
         nowInMillis = in.readVLong();
         requestCache = in.readOptionalBoolean();

--- a/server/src/test/java/org/elasticsearch/action/ShardValidateQueryRequestTests.java
+++ b/server/src/test/java/org/elasticsearch/action/ShardValidateQueryRequestTests.java
@@ -46,7 +46,7 @@ public class ShardValidateQueryRequestTests extends ESTestCase {
             validateQueryRequest.explain(false);
             ShardValidateQueryRequest request = new ShardValidateQueryRequest(
                 new ShardId("index", "foobar", 1),
-                new AliasFilter(QueryBuilders.termQuery("filter_field", "value"), "alias0", "alias1"),
+                AliasFilter.of(QueryBuilders.termQuery("filter_field", "value"), "alias0", "alias1"),
                 validateQueryRequest
             );
             request.writeTo(output);

--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/shards/ClusterSearchShardsResponseTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/shards/ClusterSearchShardsResponseTests.java
@@ -13,7 +13,6 @@ import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.routing.ShardRouting;
 import org.elasticsearch.cluster.routing.ShardRoutingState;
 import org.elasticsearch.cluster.routing.TestShardRouting;
-import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.elasticsearch.common.io.stream.NamedWriteableAwareStreamInput;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
@@ -56,9 +55,9 @@ public class ClusterSearchShardsResponseTests extends ESTestCase {
             nodes.add(node);
             AliasFilter aliasFilter;
             if (randomBoolean()) {
-                aliasFilter = new AliasFilter(RandomQueryBuilder.createQuery(random()), "alias-" + index);
+                aliasFilter = AliasFilter.of(RandomQueryBuilder.createQuery(random()), "alias-" + index);
             } else {
-                aliasFilter = new AliasFilter(null, Strings.EMPTY_ARRAY);
+                aliasFilter = AliasFilter.EMPTY;
             }
             indicesAndFilters.put(index, aliasFilter);
         }

--- a/server/src/test/java/org/elasticsearch/action/explain/ExplainRequestTests.java
+++ b/server/src/test/java/org/elasticsearch/action/explain/ExplainRequestTests.java
@@ -45,7 +45,7 @@ public class ExplainRequestTests extends ESTestCase {
         try (BytesStreamOutput output = new BytesStreamOutput()) {
             ExplainRequest request = new ExplainRequest("index", "id");
             request.fetchSourceContext(FetchSourceContext.of(true, new String[] { "field1.*" }, new String[] { "field2.*" }));
-            request.filteringAlias(new AliasFilter(QueryBuilders.termQuery("filter_field", "value"), "alias0", "alias1"));
+            request.filteringAlias(AliasFilter.of(QueryBuilders.termQuery("filter_field", "value"), "alias0", "alias1"));
             request.preference("the_preference");
             request.query(QueryBuilders.termQuery("field", "value"));
             request.storedFields(new String[] { "field1", "field2" });

--- a/server/src/test/java/org/elasticsearch/action/search/AbstractSearchAsyncActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/search/AbstractSearchAsyncActionTests.java
@@ -77,7 +77,7 @@ public class AbstractSearchAsyncActionTests extends ESTestCase {
             logger,
             null,
             nodeIdToConnection,
-            Collections.singletonMap("foo", new AliasFilter(new MatchAllQueryBuilder())),
+            Collections.singletonMap("foo", AliasFilter.of(new MatchAllQueryBuilder())),
             Collections.singletonMap("foo", 2.0f),
             null,
             request,

--- a/server/src/test/java/org/elasticsearch/action/search/CanMatchPreFilterSearchPhaseTests.java
+++ b/server/src/test/java/org/elasticsearch/action/search/CanMatchPreFilterSearchPhaseTests.java
@@ -142,7 +142,7 @@ public class CanMatchPreFilterSearchPhaseTests extends ESTestCase {
             logger,
             searchTransportService,
             (clusterAlias, node) -> lookup.get(node),
-            Collections.singletonMap("_na_", new AliasFilter(null, Strings.EMPTY_ARRAY)),
+            Collections.singletonMap("_na_", AliasFilter.EMPTY),
             Collections.emptyMap(),
             threadPool.executor(ThreadPool.Names.SEARCH_COORDINATION),
             searchRequest,
@@ -244,7 +244,7 @@ public class CanMatchPreFilterSearchPhaseTests extends ESTestCase {
             logger,
             searchTransportService,
             (clusterAlias, node) -> lookup.get(node),
-            Collections.singletonMap("_na_", new AliasFilter(null, Strings.EMPTY_ARRAY)),
+            Collections.singletonMap("_na_", AliasFilter.EMPTY),
             Collections.emptyMap(),
             threadPool.executor(ThreadPool.Names.SEARCH_COORDINATION),
             searchRequest,
@@ -341,7 +341,7 @@ public class CanMatchPreFilterSearchPhaseTests extends ESTestCase {
                 logger,
                 searchTransportService,
                 (clusterAlias, node) -> lookup.get(node),
-                Collections.singletonMap("_na_", new AliasFilter(null, Strings.EMPTY_ARRAY)),
+                Collections.singletonMap("_na_", AliasFilter.EMPTY),
                 Collections.emptyMap(),
                 threadPool.executor(ThreadPool.Names.SEARCH_COORDINATION),
                 searchRequest,
@@ -447,7 +447,7 @@ public class CanMatchPreFilterSearchPhaseTests extends ESTestCase {
                 logger,
                 searchTransportService,
                 (clusterAlias, node) -> lookup.get(node),
-                Collections.singletonMap("_na_", new AliasFilter(null, Strings.EMPTY_ARRAY)),
+                Collections.singletonMap("_na_", AliasFilter.EMPTY),
                 Collections.emptyMap(),
                 threadPool.executor(ThreadPool.Names.SEARCH_COORDINATION),
                 searchRequest,
@@ -775,10 +775,10 @@ public class CanMatchPreFilterSearchPhaseTests extends ESTestCase {
             searchRequest.source(searchSourceBuilder);
 
             // Sometimes apply the same query in the alias filter too
-            aliasFilter = new AliasFilter(randomBoolean() ? query : null, Strings.EMPTY_ARRAY);
+            aliasFilter = AliasFilter.of(randomBoolean() ? query : null, Strings.EMPTY_ARRAY);
         } else {
             // Apply the query as an alias filter
-            aliasFilter = new AliasFilter(query, Strings.EMPTY_ARRAY);
+            aliasFilter = AliasFilter.of(query, Strings.EMPTY_ARRAY);
         }
 
         Map<String, AliasFilter> aliasFilters = new HashMap<>();

--- a/server/src/test/java/org/elasticsearch/action/search/SearchAsyncActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/search/SearchAsyncActionTests.java
@@ -16,7 +16,6 @@ import org.elasticsearch.cluster.routing.GroupShardsIterator;
 import org.elasticsearch.cluster.routing.RecoverySource;
 import org.elasticsearch.cluster.routing.ShardRouting;
 import org.elasticsearch.cluster.routing.UnassignedInfo;
-import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.UUIDs;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.index.Index;
@@ -94,7 +93,7 @@ public class SearchAsyncActionTests extends ESTestCase {
         Map<ShardId, Boolean> seenShard = new ConcurrentHashMap<>();
         lookup.put(primaryNode.getId(), new MockConnection(primaryNode));
         lookup.put(replicaNode.getId(), new MockConnection(replicaNode));
-        Map<String, AliasFilter> aliasFilters = Collections.singletonMap("_na_", new AliasFilter(null, Strings.EMPTY_ARRAY));
+        Map<String, AliasFilter> aliasFilters = Collections.singletonMap("_na_", AliasFilter.EMPTY);
         AtomicInteger numRequests = new AtomicInteger(0);
         AbstractSearchAsyncAction<TestSearchPhaseResult> asyncAction = new AbstractSearchAsyncAction<TestSearchPhaseResult>(
             "test",
@@ -203,7 +202,7 @@ public class SearchAsyncActionTests extends ESTestCase {
         Map<ShardId, Boolean> seenShard = new ConcurrentHashMap<>();
         lookup.put(primaryNode.getId(), new MockConnection(primaryNode));
         lookup.put(replicaNode.getId(), new MockConnection(replicaNode));
-        Map<String, AliasFilter> aliasFilters = Collections.singletonMap("_na_", new AliasFilter(null, Strings.EMPTY_ARRAY));
+        Map<String, AliasFilter> aliasFilters = Collections.singletonMap("_na_", AliasFilter.EMPTY);
         CountDownLatch awaitInitialRequests = new CountDownLatch(1);
         AtomicInteger numRequests = new AtomicInteger(0);
         AbstractSearchAsyncAction<TestSearchPhaseResult> asyncAction = new AbstractSearchAsyncAction<TestSearchPhaseResult>(
@@ -312,7 +311,7 @@ public class SearchAsyncActionTests extends ESTestCase {
         Map<String, Transport.Connection> lookup = new HashMap<>();
         lookup.put(primaryNode.getId(), new MockConnection(primaryNode));
         lookup.put(replicaNode.getId(), new MockConnection(replicaNode));
-        Map<String, AliasFilter> aliasFilters = Collections.singletonMap("_na_", new AliasFilter(null, Strings.EMPTY_ARRAY));
+        Map<String, AliasFilter> aliasFilters = Collections.singletonMap("_na_", AliasFilter.EMPTY);
         ExecutorService executor = Executors.newFixedThreadPool(randomIntBetween(1, Runtime.getRuntime().availableProcessors()));
         final CountDownLatch latch = new CountDownLatch(1);
         final AtomicBoolean latchTriggered = new AtomicBoolean();
@@ -434,7 +433,7 @@ public class SearchAsyncActionTests extends ESTestCase {
         Map<String, Transport.Connection> lookup = new HashMap<>();
         lookup.put(primaryNode.getId(), new MockConnection(primaryNode));
         lookup.put(replicaNode.getId(), new MockConnection(replicaNode));
-        Map<String, AliasFilter> aliasFilters = Collections.singletonMap("_na_", new AliasFilter(null, Strings.EMPTY_ARRAY));
+        Map<String, AliasFilter> aliasFilters = Collections.singletonMap("_na_", AliasFilter.EMPTY);
         ExecutorService executor = Executors.newFixedThreadPool(randomIntBetween(1, Runtime.getRuntime().availableProcessors()));
         AbstractSearchAsyncAction<TestSearchPhaseResult> asyncAction = new AbstractSearchAsyncAction<TestSearchPhaseResult>(
             "test",
@@ -542,7 +541,7 @@ public class SearchAsyncActionTests extends ESTestCase {
         Map<ShardId, Boolean> seenShard = new ConcurrentHashMap<>();
         lookup.put(primaryNode.getId(), new MockConnection(primaryNode));
         lookup.put(replicaNode.getId(), new MockConnection(replicaNode));
-        Map<String, AliasFilter> aliasFilters = Collections.singletonMap("_na_", new AliasFilter(null, Strings.EMPTY_ARRAY));
+        Map<String, AliasFilter> aliasFilters = Collections.singletonMap("_na_", AliasFilter.EMPTY);
         AtomicInteger numRequests = new AtomicInteger(0);
         AtomicInteger numFailReplicas = new AtomicInteger(0);
         AbstractSearchAsyncAction<TestSearchPhaseResult> asyncAction = new AbstractSearchAsyncAction<>(
@@ -649,7 +648,7 @@ public class SearchAsyncActionTests extends ESTestCase {
                 assert cluster == null : "cluster was not null: " + cluster;
                 return lookup.get(node);
             },
-            Map.of("_na_", new AliasFilter(null, Strings.EMPTY_ARRAY)),
+            Map.of("_na_", AliasFilter.EMPTY),
             Collections.emptyMap(),
             null,
             request,

--- a/server/src/test/java/org/elasticsearch/action/search/SearchContextIdTests.java
+++ b/server/src/test/java/org/elasticsearch/action/search/SearchContextIdTests.java
@@ -54,9 +54,9 @@ public class SearchContextIdTests extends ESTestCase {
         for (SearchPhaseResult result : queryResults.asList()) {
             final AliasFilter aliasFilter;
             if (randomBoolean()) {
-                aliasFilter = new AliasFilter(randomQueryBuilder());
+                aliasFilter = AliasFilter.of(randomQueryBuilder());
             } else if (randomBoolean()) {
-                aliasFilter = new AliasFilter(randomQueryBuilder(), "alias-" + between(1, 10));
+                aliasFilter = AliasFilter.of(randomQueryBuilder(), "alias-" + between(1, 10));
             } else {
                 aliasFilter = AliasFilter.EMPTY;
             }

--- a/server/src/test/java/org/elasticsearch/action/search/SearchQueryThenFetchAsyncActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/search/SearchQueryThenFetchAsyncActionTests.java
@@ -20,7 +20,6 @@ import org.elasticsearch.cluster.routing.GroupShardsIterator;
 import org.elasticsearch.cluster.routing.RecoverySource;
 import org.elasticsearch.cluster.routing.ShardRouting;
 import org.elasticsearch.cluster.routing.UnassignedInfo;
-import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.breaker.CircuitBreaker;
 import org.elasticsearch.common.breaker.NoopCircuitBreaker;
 import org.elasticsearch.common.lucene.search.TopDocsAndMaxScore;
@@ -183,7 +182,7 @@ public class SearchQueryThenFetchAsyncActionTests extends ESTestCase {
             logger,
             searchTransportService,
             (clusterAlias, node) -> lookup.get(node),
-            Collections.singletonMap("_na_", new AliasFilter(null, Strings.EMPTY_ARRAY)),
+            Collections.singletonMap("_na_", AliasFilter.EMPTY),
             Collections.emptyMap(),
             EsExecutors.DIRECT_EXECUTOR_SERVICE,
             resultConsumer,
@@ -312,7 +311,7 @@ public class SearchQueryThenFetchAsyncActionTests extends ESTestCase {
             logger,
             searchTransportService,
             (clusterAlias, node) -> lookup.get(node),
-            Collections.singletonMap("_na_", new AliasFilter(null, Strings.EMPTY_ARRAY)),
+            Collections.singletonMap("_na_", AliasFilter.EMPTY),
             Collections.emptyMap(),
             EsExecutors.DIRECT_EXECUTOR_SERVICE,
             resultConsumer,
@@ -453,7 +452,7 @@ public class SearchQueryThenFetchAsyncActionTests extends ESTestCase {
             logger,
             searchTransportService,
             (clusterAlias, node) -> lookup.get(node),
-            Collections.singletonMap("_na_", new AliasFilter(null, Strings.EMPTY_ARRAY)),
+            Collections.singletonMap("_na_", AliasFilter.EMPTY),
             Collections.emptyMap(),
             EsExecutors.DIRECT_EXECUTOR_SERVICE,
             resultConsumer,
@@ -595,7 +594,7 @@ public class SearchQueryThenFetchAsyncActionTests extends ESTestCase {
             logger,
             searchTransportService,
             (clusterAlias, node) -> lookup.get(node),
-            Collections.singletonMap("_na_", new AliasFilter(null, Strings.EMPTY_ARRAY)),
+            Collections.singletonMap("_na_", AliasFilter.EMPTY),
             Collections.emptyMap(),
             EsExecutors.DIRECT_EXECUTOR_SERVICE,
             resultConsumer,

--- a/server/src/test/java/org/elasticsearch/action/search/TransportSearchActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/search/TransportSearchActionTests.java
@@ -251,11 +251,8 @@ public class TransportSearchActionTests extends ESTestCase {
                 new DiscoveryNode("node1", buildNewFakeTransportAddress(), Version.CURRENT),
                 new DiscoveryNode("node2", buildNewFakeTransportAddress(), Version.CURRENT) };
             Map<String, AliasFilter> indicesAndAliases = new HashMap<>();
-            indicesAndAliases.put(
-                "foo",
-                new AliasFilter(new TermsQueryBuilder("foo", "bar"), "some_alias_for_foo", "some_other_foo_alias")
-            );
-            indicesAndAliases.put("bar", new AliasFilter(new MatchAllQueryBuilder(), Strings.EMPTY_ARRAY));
+            indicesAndAliases.put("foo", AliasFilter.of(new TermsQueryBuilder("foo", "bar"), "some_alias_for_foo", "some_other_foo_alias"));
+            indicesAndAliases.put("bar", AliasFilter.of(new MatchAllQueryBuilder(), Strings.EMPTY_ARRAY));
             ClusterSearchShardsGroup[] groups = new ClusterSearchShardsGroup[] {
                 new ClusterSearchShardsGroup(
                     new ShardId("foo", "foo_id", 0),
@@ -283,7 +280,7 @@ public class TransportSearchActionTests extends ESTestCase {
                     new ShardRouting[] { TestShardRouting.newShardRouting("xyz", 0, "node3", true, ShardRoutingState.STARTED) }
                 ) };
             Map<String, AliasFilter> filter = new HashMap<>();
-            filter.put("xyz", new AliasFilter(null, "some_alias_for_xyz"));
+            filter.put("xyz", AliasFilter.of(null, "some_alias_for_xyz"));
             searchShardsResponseMap.put("test_cluster_2", new ClusterSearchShardsResponse(groups2, nodes2, filter));
 
             Map<String, OriginalIndices> remoteIndicesByCluster = new HashMap<>();

--- a/server/src/test/java/org/elasticsearch/search/SearchServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/search/SearchServiceTests.java
@@ -36,7 +36,6 @@ import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.routing.ShardRouting;
 import org.elasticsearch.cluster.routing.ShardRoutingState;
 import org.elasticsearch.cluster.routing.TestShardRouting;
-import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.UUIDs;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.settings.Settings;
@@ -349,7 +348,7 @@ public class SearchServiceTests extends ESSingleNodeTestCase {
                                 indexShard.shardId(),
                                 0,
                                 1,
-                                new AliasFilter(null, Strings.EMPTY_ARRAY),
+                                AliasFilter.EMPTY,
                                 1.0f,
                                 -1,
                                 null
@@ -424,7 +423,7 @@ public class SearchServiceTests extends ESSingleNodeTestCase {
                 new ShardId(resolveIndex("index"), 0),
                 0,
                 1,
-                new AliasFilter(null, Strings.EMPTY_ARRAY),
+                AliasFilter.EMPTY,
                 1.0f,
                 -1,
                 null
@@ -495,7 +494,7 @@ public class SearchServiceTests extends ESSingleNodeTestCase {
             indexShard.shardId(),
             0,
             1,
-            new AliasFilter(null, Strings.EMPTY_ARRAY),
+            AliasFilter.EMPTY,
             1.0f,
             -1,
             null
@@ -522,7 +521,7 @@ public class SearchServiceTests extends ESSingleNodeTestCase {
             indexShard.shardId(),
             0,
             1,
-            new AliasFilter(null, Strings.EMPTY_ARRAY),
+            AliasFilter.EMPTY,
             1.0f,
             -1,
             null
@@ -560,7 +559,7 @@ public class SearchServiceTests extends ESSingleNodeTestCase {
             indexShard.shardId(),
             0,
             1,
-            new AliasFilter(null, Strings.EMPTY_ARRAY),
+            AliasFilter.EMPTY,
             1.0f,
             -1,
             null
@@ -623,7 +622,7 @@ public class SearchServiceTests extends ESSingleNodeTestCase {
                 indexShard.shardId(),
                 0,
                 1,
-                new AliasFilter(null, Strings.EMPTY_ARRAY),
+                AliasFilter.EMPTY,
                 1.0f,
                 -1,
                 null
@@ -662,7 +661,7 @@ public class SearchServiceTests extends ESSingleNodeTestCase {
             indexShard.shardId(),
             0,
             1,
-            new AliasFilter(null, Strings.EMPTY_ARRAY),
+            AliasFilter.EMPTY,
             1.0f,
             -1,
             null
@@ -712,7 +711,7 @@ public class SearchServiceTests extends ESSingleNodeTestCase {
             indexShard.shardId(),
             0,
             1,
-            new AliasFilter(null, Strings.EMPTY_ARRAY),
+            AliasFilter.EMPTY,
             1.0f,
             -1,
             null
@@ -870,7 +869,7 @@ public class SearchServiceTests extends ESSingleNodeTestCase {
                 shardId,
                 0,
                 1,
-                new AliasFilter(null, Strings.EMPTY_ARRAY),
+                AliasFilter.EMPTY,
                 1f,
                 -1,
                 null
@@ -893,51 +892,21 @@ public class SearchServiceTests extends ESSingleNodeTestCase {
         SearchRequest searchRequest = new SearchRequest().allowPartialSearchResults(true);
         assertTrue(
             service.canMatch(
-                new ShardSearchRequest(
-                    OriginalIndices.NONE,
-                    searchRequest,
-                    indexShard.shardId(),
-                    0,
-                    1,
-                    new AliasFilter(null, Strings.EMPTY_ARRAY),
-                    1f,
-                    -1,
-                    null
-                )
+                new ShardSearchRequest(OriginalIndices.NONE, searchRequest, indexShard.shardId(), 0, 1, AliasFilter.EMPTY, 1f, -1, null)
             ).canMatch()
         );
 
         searchRequest.source(new SearchSourceBuilder());
         assertTrue(
             service.canMatch(
-                new ShardSearchRequest(
-                    OriginalIndices.NONE,
-                    searchRequest,
-                    indexShard.shardId(),
-                    0,
-                    1,
-                    new AliasFilter(null, Strings.EMPTY_ARRAY),
-                    1f,
-                    -1,
-                    null
-                )
+                new ShardSearchRequest(OriginalIndices.NONE, searchRequest, indexShard.shardId(), 0, 1, AliasFilter.EMPTY, 1f, -1, null)
             ).canMatch()
         );
 
         searchRequest.source(new SearchSourceBuilder().query(new MatchAllQueryBuilder()));
         assertTrue(
             service.canMatch(
-                new ShardSearchRequest(
-                    OriginalIndices.NONE,
-                    searchRequest,
-                    indexShard.shardId(),
-                    0,
-                    1,
-                    new AliasFilter(null, Strings.EMPTY_ARRAY),
-                    1f,
-                    -1,
-                    null
-                )
+                new ShardSearchRequest(OriginalIndices.NONE, searchRequest, indexShard.shardId(), 0, 1, AliasFilter.EMPTY, 1f, -1, null)
             ).canMatch()
         );
 
@@ -947,17 +916,7 @@ public class SearchServiceTests extends ESSingleNodeTestCase {
         );
         assertTrue(
             service.canMatch(
-                new ShardSearchRequest(
-                    OriginalIndices.NONE,
-                    searchRequest,
-                    indexShard.shardId(),
-                    0,
-                    1,
-                    new AliasFilter(null, Strings.EMPTY_ARRAY),
-                    1f,
-                    -1,
-                    null
-                )
+                new ShardSearchRequest(OriginalIndices.NONE, searchRequest, indexShard.shardId(), 0, 1, AliasFilter.EMPTY, 1f, -1, null)
             ).canMatch()
         );
         searchRequest.source(
@@ -965,34 +924,14 @@ public class SearchServiceTests extends ESSingleNodeTestCase {
         );
         assertTrue(
             service.canMatch(
-                new ShardSearchRequest(
-                    OriginalIndices.NONE,
-                    searchRequest,
-                    indexShard.shardId(),
-                    0,
-                    1,
-                    new AliasFilter(null, Strings.EMPTY_ARRAY),
-                    1f,
-                    -1,
-                    null
-                )
+                new ShardSearchRequest(OriginalIndices.NONE, searchRequest, indexShard.shardId(), 0, 1, AliasFilter.EMPTY, 1f, -1, null)
             ).canMatch()
         );
 
         searchRequest.source(new SearchSourceBuilder().query(new MatchNoneQueryBuilder()));
         assertFalse(
             service.canMatch(
-                new ShardSearchRequest(
-                    OriginalIndices.NONE,
-                    searchRequest,
-                    indexShard.shardId(),
-                    0,
-                    1,
-                    new AliasFilter(null, Strings.EMPTY_ARRAY),
-                    1f,
-                    -1,
-                    null
-                )
+                new ShardSearchRequest(OriginalIndices.NONE, searchRequest, indexShard.shardId(), 0, 1, AliasFilter.EMPTY, 1f, -1, null)
             ).canMatch()
         );
         assertEquals(6, numWrapInvocations.get());
@@ -1003,7 +942,7 @@ public class SearchServiceTests extends ESSingleNodeTestCase {
             indexShard.shardId(),
             0,
             1,
-            new AliasFilter(null, Strings.EMPTY_ARRAY),
+            AliasFilter.EMPTY,
             1.0f,
             -1,
             null
@@ -1022,7 +961,7 @@ public class SearchServiceTests extends ESSingleNodeTestCase {
                     indexShard.shardId(),
                     0,
                     1,
-                    new AliasFilter(new TermQueryBuilder("foo", "bar"), "alias"),
+                    AliasFilter.of(new TermQueryBuilder("foo", "bar"), "alias"),
                     1f,
                     -1,
                     null
@@ -1041,7 +980,7 @@ public class SearchServiceTests extends ESSingleNodeTestCase {
                     indexShard.shardId(),
                     0,
                     1,
-                    new AliasFilter(new TermQueryBuilder("foo", "bar"), "alias"),
+                    AliasFilter.of(new TermQueryBuilder("foo", "bar"), "alias"),
                     1f,
                     -1,
                     null
@@ -1156,7 +1095,7 @@ public class SearchServiceTests extends ESSingleNodeTestCase {
             new ShardId(index, 0),
             0,
             1,
-            new AliasFilter(null, Strings.EMPTY_ARRAY),
+            AliasFilter.EMPTY,
             1f,
             -1,
             null
@@ -1488,7 +1427,7 @@ public class SearchServiceTests extends ESSingleNodeTestCase {
                         indexShard.shardId(),
                         0,
                         1,
-                        new AliasFilter(null, Strings.EMPTY_ARRAY),
+                        AliasFilter.EMPTY,
                         1.0f,
                         -1,
                         null
@@ -1550,7 +1489,7 @@ public class SearchServiceTests extends ESSingleNodeTestCase {
             indexShard.shardId(),
             0,
             1,
-            new AliasFilter(null, Strings.EMPTY_ARRAY),
+            AliasFilter.EMPTY,
             1.0f,
             -1,
             null
@@ -1723,7 +1662,7 @@ public class SearchServiceTests extends ESSingleNodeTestCase {
             indexShard.shardId(),
             0,
             1,
-            new AliasFilter(null, Strings.EMPTY_ARRAY),
+            AliasFilter.EMPTY,
             1.0f,
             -1,
             null,
@@ -1756,7 +1695,7 @@ public class SearchServiceTests extends ESSingleNodeTestCase {
             indexShard.shardId(),
             0,
             1,
-            new AliasFilter(null, Strings.EMPTY_ARRAY),
+            AliasFilter.EMPTY,
             1.0f,
             -1,
             null,
@@ -1792,7 +1731,7 @@ public class SearchServiceTests extends ESSingleNodeTestCase {
             indexShard.shardId(),
             0,
             1,
-            new AliasFilter(null, Strings.EMPTY_ARRAY),
+            AliasFilter.EMPTY,
             1.0f,
             -1,
             null,
@@ -1829,7 +1768,7 @@ public class SearchServiceTests extends ESSingleNodeTestCase {
             indexShard.shardId(),
             0,
             1,
-            new AliasFilter(null, Strings.EMPTY_ARRAY),
+            AliasFilter.EMPTY,
             1.0f,
             -1,
             null,

--- a/server/src/test/java/org/elasticsearch/search/internal/AliasFilterTests.java
+++ b/server/src/test/java/org/elasticsearch/search/internal/AliasFilterTests.java
@@ -25,14 +25,14 @@ public class AliasFilterTests extends ESTestCase {
     public void testEqualsAndHashCode() {
         final QueryBuilder filter = QueryBuilders.termQuery("field", "value");
         final String[] aliases = new String[] { "alias_0", "alias_1" };
-        final AliasFilter aliasFilter = new AliasFilter(filter, aliases);
+        final AliasFilter aliasFilter = AliasFilter.of(filter, aliases);
         final EqualsHashCodeTestUtils.CopyFunction<AliasFilter> aliasFilterCopyFunction = x -> {
             assertThat(x.getQueryBuilder(), instanceOf(TermQueryBuilder.class));
             final BytesStreamOutput out = new BytesStreamOutput();
             x.getQueryBuilder().writeTo(out);
             final QueryBuilder otherFilter = new TermQueryBuilder(out.bytes().streamInput());
             final String[] otherAliases = Arrays.copyOf(x.getAliases(), x.getAliases().length);
-            return new AliasFilter(otherFilter, otherAliases);
+            return AliasFilter.of(otherFilter, otherAliases);
         };
 
         final EqualsHashCodeTestUtils.MutateFunction<AliasFilter> aliasFilterMutationFunction = x -> {
@@ -42,7 +42,7 @@ public class AliasFilterTests extends ESTestCase {
             final QueryBuilder otherFilter = new TermQueryBuilder(out.bytes().streamInput());
             assertThat(x.getAliases().length, greaterThan(0));
             final String[] otherAliases = Arrays.copyOf(x.getAliases(), x.getAliases().length - 1);
-            return new AliasFilter(otherFilter, otherAliases);
+            return AliasFilter.of(otherFilter, otherAliases);
         };
 
         EqualsHashCodeTestUtils.checkEqualsAndHashCode(aliasFilter, aliasFilterCopyFunction, aliasFilterMutationFunction);

--- a/server/src/test/java/org/elasticsearch/search/internal/ShardSearchRequestTests.java
+++ b/server/src/test/java/org/elasticsearch/search/internal/ShardSearchRequestTests.java
@@ -82,9 +82,9 @@ public class ShardSearchRequestTests extends AbstractSearchTestCase {
         final AliasFilter filteringAliases;
         if (randomBoolean()) {
             String[] strings = generateRandomStringArray(10, 10, false, false);
-            filteringAliases = new AliasFilter(RandomQueryBuilder.createQuery(random()), strings);
+            filteringAliases = AliasFilter.of(RandomQueryBuilder.createQuery(random()), strings);
         } else {
-            filteringAliases = new AliasFilter(null, Strings.EMPTY_ARRAY);
+            filteringAliases = AliasFilter.EMPTY;
         }
         ShardSearchContextId shardSearchContextId = null;
         TimeValue keepAlive = null;

--- a/server/src/test/java/org/elasticsearch/search/query/QuerySearchResultTests.java
+++ b/server/src/test/java/org/elasticsearch/search/query/QuerySearchResultTests.java
@@ -14,7 +14,6 @@ import org.apache.lucene.search.TotalHits;
 import org.elasticsearch.Version;
 import org.elasticsearch.action.OriginalIndicesTests;
 import org.elasticsearch.action.search.SearchRequest;
-import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.UUIDs;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.lucene.search.TopDocsAndMaxScore;
@@ -53,7 +52,7 @@ public class QuerySearchResultTests extends ESTestCase {
             shardId,
             0,
             1,
-            new AliasFilter(null, Strings.EMPTY_ARRAY),
+            AliasFilter.EMPTY,
             1.0f,
             randomNonNegativeLong(),
             null

--- a/x-pack/plugin/frozen-indices/src/internalClusterTest/java/org/elasticsearch/index/engine/frozen/FrozenIndexTests.java
+++ b/x-pack/plugin/frozen-indices/src/internalClusterTest/java/org/elasticsearch/index/engine/frozen/FrozenIndexTests.java
@@ -27,7 +27,6 @@ import org.elasticsearch.cluster.block.ClusterBlockException;
 import org.elasticsearch.cluster.metadata.DataStream;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.routing.RecoverySource;
-import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.index.Index;
@@ -341,17 +340,7 @@ public class FrozenIndexTests extends ESSingleNodeTestCase {
             SearchRequest searchRequest = new SearchRequest().allowPartialSearchResults(true);
             assertTrue(
                 searchService.canMatch(
-                    new ShardSearchRequest(
-                        OriginalIndices.NONE,
-                        searchRequest,
-                        shard.shardId(),
-                        0,
-                        1,
-                        new AliasFilter(null, Strings.EMPTY_ARRAY),
-                        1f,
-                        -1,
-                        null
-                    )
+                    new ShardSearchRequest(OriginalIndices.NONE, searchRequest, shard.shardId(), 0, 1, AliasFilter.EMPTY, 1f, -1, null)
                 ).canMatch()
             );
 
@@ -360,34 +349,14 @@ public class FrozenIndexTests extends ESSingleNodeTestCase {
             sourceBuilder.query(QueryBuilders.rangeQuery("field").gte("2010-01-03||+2d").lte("2010-01-04||+2d/d"));
             assertTrue(
                 searchService.canMatch(
-                    new ShardSearchRequest(
-                        OriginalIndices.NONE,
-                        searchRequest,
-                        shard.shardId(),
-                        0,
-                        1,
-                        new AliasFilter(null, Strings.EMPTY_ARRAY),
-                        1f,
-                        -1,
-                        null
-                    )
+                    new ShardSearchRequest(OriginalIndices.NONE, searchRequest, shard.shardId(), 0, 1, AliasFilter.EMPTY, 1f, -1, null)
                 ).canMatch()
             );
 
             sourceBuilder.query(QueryBuilders.rangeQuery("field").gt("2010-01-06T02:00").lt("2010-01-07T02:00"));
             assertFalse(
                 searchService.canMatch(
-                    new ShardSearchRequest(
-                        OriginalIndices.NONE,
-                        searchRequest,
-                        shard.shardId(),
-                        0,
-                        1,
-                        new AliasFilter(null, Strings.EMPTY_ARRAY),
-                        1f,
-                        -1,
-                        null
-                    )
+                    new ShardSearchRequest(OriginalIndices.NONE, searchRequest, shard.shardId(), 0, 1, AliasFilter.EMPTY, 1f, -1, null)
                 ).canMatch()
             );
         }
@@ -404,17 +373,7 @@ public class FrozenIndexTests extends ESSingleNodeTestCase {
             SearchRequest searchRequest = new SearchRequest().allowPartialSearchResults(true);
             assertTrue(
                 searchService.canMatch(
-                    new ShardSearchRequest(
-                        OriginalIndices.NONE,
-                        searchRequest,
-                        shard.shardId(),
-                        0,
-                        1,
-                        new AliasFilter(null, Strings.EMPTY_ARRAY),
-                        1f,
-                        -1,
-                        null
-                    )
+                    new ShardSearchRequest(OriginalIndices.NONE, searchRequest, shard.shardId(), 0, 1, AliasFilter.EMPTY, 1f, -1, null)
                 ).canMatch()
             );
 
@@ -423,34 +382,14 @@ public class FrozenIndexTests extends ESSingleNodeTestCase {
             searchRequest.source(sourceBuilder);
             assertTrue(
                 searchService.canMatch(
-                    new ShardSearchRequest(
-                        OriginalIndices.NONE,
-                        searchRequest,
-                        shard.shardId(),
-                        0,
-                        1,
-                        new AliasFilter(null, Strings.EMPTY_ARRAY),
-                        1f,
-                        -1,
-                        null
-                    )
+                    new ShardSearchRequest(OriginalIndices.NONE, searchRequest, shard.shardId(), 0, 1, AliasFilter.EMPTY, 1f, -1, null)
                 ).canMatch()
             );
 
             sourceBuilder.query(QueryBuilders.rangeQuery("field").gt("2010-01-06T02:00").lt("2010-01-07T02:00"));
             assertFalse(
                 searchService.canMatch(
-                    new ShardSearchRequest(
-                        OriginalIndices.NONE,
-                        searchRequest,
-                        shard.shardId(),
-                        0,
-                        1,
-                        new AliasFilter(null, Strings.EMPTY_ARRAY),
-                        1f,
-                        -1,
-                        null
-                    )
+                    new ShardSearchRequest(OriginalIndices.NONE, searchRequest, shard.shardId(), 0, 1, AliasFilter.EMPTY, 1f, -1, null)
                 ).canMatch()
             );
 
@@ -471,7 +410,7 @@ public class FrozenIndexTests extends ESSingleNodeTestCase {
                         shard.shardId(),
                         0,
                         1,
-                        new AliasFilter(null, Strings.EMPTY_ARRAY),
+                        AliasFilter.EMPTY,
                         1f,
                         -1,
                         null,
@@ -491,7 +430,7 @@ public class FrozenIndexTests extends ESSingleNodeTestCase {
                         shard.shardId(),
                         0,
                         1,
-                        new AliasFilter(null, Strings.EMPTY_ARRAY),
+                        AliasFilter.EMPTY,
                         1f,
                         -1,
                         null,
@@ -512,7 +451,7 @@ public class FrozenIndexTests extends ESSingleNodeTestCase {
                             shard.shardId(),
                             0,
                             1,
-                            new AliasFilter(null, Strings.EMPTY_ARRAY),
+                            AliasFilter.EMPTY,
                             1f,
                             -1,
                             null,


### PR DESCRIPTION
Saw a couple MB of heap used by duplicate empty instances in a user heap dump -> let's save those and use the singleton throughout.

