### PR TITLE
Fork building snapshot status response off of transport thread

### DIFF
--- a/docs/changelog/90651.yaml
+++ b/docs/changelog/90651.yaml
@@ -1,0 +1,5 @@
+pr: 90651
+summary: Fork building snapshot status response off of transport thread
+area: Snapshot/Restore
+type: bug
+issues: []


### PR DESCRIPTION
This can take O(10s) for tens of thousands of shards, we have to fork it.
Currently, this one is the most common slow long on cloud ... (which isn't so great in a few dimensions :), on it)

relates #77466 