### PR TITLE
[8.5] Don't shortcut the total hit count for text fields  (#90341)

### DIFF
--- a/docs/changelog/90341.yaml
+++ b/docs/changelog/90341.yaml
@@ -1,0 +1,6 @@
+pr: 90341
+summary: Don't shortcut the total hit count for text fields
+area: Search
+type: bug
+issues:
+ - 89760

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search/160_exists_query.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search/160_exists_query.yml
@@ -1238,3 +1238,31 @@ setup:
                 field: text
 
   - match: {hits.total: 3}
+
+---
+"Test exists query on text field with empty values":
+  - skip:
+      version: '8.4.0 - 8.5.0'
+      reason:  Regression introduced in 8.4.0, fixed in 8.5.1
+
+  - do:
+      index:
+          index:  "empty_text"
+          id:     "999"
+          body:
+            text: ""
+
+  - do:
+      indices.refresh:
+          index: [empty_text]
+
+  - do:
+      search:
+          rest_total_hits_as_int: true
+          index: empty_text
+          body:
+            query:
+              exists:
+                field: text
+
+  - match: {hits.total: 1}

--- a/server/src/main/java/org/elasticsearch/search/query/TopDocsCollectorContext.java
+++ b/server/src/main/java/org/elasticsearch/search/query/TopDocsCollectorContext.java
@@ -8,6 +8,7 @@
 
 package org.elasticsearch.search.query;
 
+import org.apache.lucene.index.DocValuesType;
 import org.apache.lucene.index.FieldInfo;
 import org.apache.lucene.index.FieldInfos;
 import org.apache.lucene.index.IndexOptions;
@@ -408,6 +409,10 @@ abstract class TopDocsCollectorContext extends QueryCollectorContext {
                 FieldInfos fieldInfos = context.reader().getFieldInfos();
                 FieldInfo fieldInfo = fieldInfos.fieldInfo(field);
                 if (fieldInfo != null) {
+                    if (fieldInfo.getDocValuesType() == DocValuesType.NONE) {
+                        // no shortcut possible: it's a text field, empty values are counted as no value.
+                        return -1;
+                    }
                     if (fieldInfo.getPointIndexDimensionCount() > 0) {
                         PointValues points = context.reader().getPointValues(field);
                         if (points != null) {

--- a/server/src/test/java/org/elasticsearch/search/query/TopDocsCollectorContextTests.java
+++ b/server/src/test/java/org/elasticsearch/search/query/TopDocsCollectorContextTests.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.search.query;
+
+import org.apache.lucene.document.Document;
+import org.apache.lucene.document.Field;
+import org.apache.lucene.document.IntPoint;
+import org.apache.lucene.document.NumericDocValuesField;
+import org.apache.lucene.document.SortedDocValuesField;
+import org.apache.lucene.document.StringField;
+import org.apache.lucene.document.TextField;
+import org.apache.lucene.index.IndexReader;
+import org.apache.lucene.search.FieldExistsQuery;
+import org.apache.lucene.search.Query;
+import org.apache.lucene.store.Directory;
+import org.apache.lucene.tests.index.RandomIndexWriter;
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.test.ESTestCase;
+
+import java.io.IOException;
+
+public class TopDocsCollectorContextTests extends ESTestCase {
+
+    public void testShortcutTotalHitCountTextField() throws IOException {
+        try (Directory dir = newDirectory(); RandomIndexWriter iw = new RandomIndexWriter(random(), dir)) {
+            Document doc = new Document();
+            doc.add(new TextField("text", "value", Field.Store.NO));
+            iw.addDocument(doc);
+            doc = new Document();
+            doc.add(new TextField("text", "", Field.Store.NO));
+            iw.addDocument(doc);
+            iw.addDocument(new Document());
+            iw.commit();
+            try (IndexReader reader = iw.getReader()) {
+                final Query testQuery = new FieldExistsQuery("text");
+                int hitCount = TopDocsCollectorContext.shortcutTotalHitCount(reader, testQuery);
+                assertEquals(-1, hitCount);
+            }
+        }
+    }
+
+    public void testShortcutTotalHitCountStringField() throws IOException {
+        try (Directory dir = newDirectory(); RandomIndexWriter iw = new RandomIndexWriter(random(), dir)) {
+            Document doc = new Document();
+            doc.add(new StringField("string", "value", Field.Store.NO));
+            doc.add(new SortedDocValuesField("string", new BytesRef("value")));
+            iw.addDocument(doc);
+            doc = new Document();
+            doc.add(new StringField("string", "", Field.Store.NO));
+            doc.add(new SortedDocValuesField("string", new BytesRef("")));
+            iw.addDocument(doc);
+            iw.addDocument(new Document());
+            iw.commit();
+            try (IndexReader reader = iw.getReader()) {
+                final Query testQuery = new FieldExistsQuery("string");
+                int hitCount = TopDocsCollectorContext.shortcutTotalHitCount(reader, testQuery);
+                assertEquals(2, hitCount);
+            }
+        }
+    }
+
+    public void testShortcutTotalHitCountNumericField() throws IOException {
+        try (Directory dir = newDirectory(); RandomIndexWriter iw = new RandomIndexWriter(random(), dir)) {
+            Document doc = new Document();
+            doc.add(new IntPoint("int", 10));
+            doc.add(new NumericDocValuesField("int", 10));
+            iw.addDocument(doc);
+            iw.addDocument(new Document());
+            iw.commit();
+            try (IndexReader reader = iw.getReader()) {
+                final Query testQuery = new FieldExistsQuery("int");
+                int hitCount = TopDocsCollectorContext.shortcutTotalHitCount(reader, testQuery);
+                assertEquals(1, hitCount);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Backports the following commits to 8.5:
 - Don't shortcut the total hit count for text fields  (#90341)