### PR TITLE
[8.5] Fork building snapshot status response off of transport thread (#90651)

### DIFF
--- a/docs/changelog/90651.yaml
+++ b/docs/changelog/90651.yaml
@@ -1,0 +1,5 @@
+pr: 90651
+summary: Fork building snapshot status response off of transport thread
+area: Snapshot/Restore
+type: bug
+issues: []


### PR DESCRIPTION
Backports the following commits to 8.5:
 - Fork building snapshot status response off of transport thread (#90651)