### PR TITLE
[Testing] Enable bwc and fix sorting for 500_date_range

### DIFF
--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search/500_date_range.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search/500_date_range.yml
@@ -1,4 +1,7 @@
 setup:
+  - skip:
+      version: " - 8.5.0"
+      reason: fixed in 8.5.1
   - do:
       indices.create:
         index: dates_year_only

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search/500_date_range.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search/500_date_range.yml
@@ -1,7 +1,4 @@
 setup:
-  - skip:
-      version: " - 8.5.99"
-      reason: awaits backports
   - do:
       indices.create:
         index: dates_year_only
@@ -16,14 +13,14 @@ setup:
       bulk:
         refresh: true
         body:
-          - '{ "index" : { "_index" : "dates_year_only", "_id" : "first" } }'
+          - '{ "index" : { "_index" : "dates_year_only", "_id" : "1" } }'
           - '{"date" : "1900", "field" : 1 }'
-          - '{ "index" : { "_index" : "dates_year_only", "_id" : "second" } }'
-          - '{"date" : "2022", "field" : 1 }'
-          - '{ "index" : { "_index" : "dates_year_only", "_id" : "third" } }'
+          - '{ "index" : { "_index" : "dates_year_only", "_id" : "2" } }'
           - '{"date" : "2022", "field" : 2 }'
-          - '{ "index" : { "_index" : "dates_year_only", "_id" : "fourth" } }'
-          - '{"date" : "1500", "field" : 2 }'
+          - '{ "index" : { "_index" : "dates_year_only", "_id" : "3" } }'
+          - '{"date" : "2022", "field" : 3 }'
+          - '{ "index" : { "_index" : "dates_year_only", "_id" : "4" } }'
+          - '{"date" : "1500", "field" : 4 }'
 
   - do:
       indices.create:
@@ -38,16 +35,16 @@ setup:
       bulk:
         refresh: true
         body:
-          - '{ "index" : { "_index" : "dates", "_id" : "first" } }'
+          - '{ "index" : { "_index" : "dates", "_id" : "1" } }'
           - '{"date" : "1900-01-01T12:12:12.123456789Z", "field" : 1 }'
-          - '{ "index" : { "_index" : "dates", "_id" : "second" } }'
-          - '{"date" : "2022-01-01T12:12:12.123456789Z", "field" : 1 }'
-          - '{ "index" : { "_index" : "dates", "_id" : "third" } }'
-          - '{"date" : "2022-01-03T12:12:12.123456789Z", "field" : 2 }'
-          - '{ "index" : { "_index" : "dates", "_id" : "fourth" } }'
-          - '{"date" : "1500-01-01T12:12:12.123456789Z", "field" : 2 }'
-          - '{ "index" : { "_index" : "dates", "_id" : "fifth" } }'
-          - '{"date" : "1500-01-05T12:12:12.123456789Z", "field" : 2 }'
+          - '{ "index" : { "_index" : "dates", "_id" : "2" } }'
+          - '{"date" : "2022-01-01T12:12:12.123456789Z", "field" : 2 }'
+          - '{ "index" : { "_index" : "dates", "_id" : "3" } }'
+          - '{"date" : "2022-01-03T12:12:12.123456789Z", "field" : 3 }'
+          - '{ "index" : { "_index" : "dates", "_id" : "4" } }'
+          - '{"date" : "1500-01-01T12:12:12.123456789Z", "field" : 4 }'
+          - '{ "index" : { "_index" : "dates", "_id" : "5" } }'
+          - '{"date" : "1500-01-05T12:12:12.123456789Z", "field" : 5 }'
 
 ---
 "test range query for all docs with year uuuu":
@@ -56,6 +53,7 @@ setup:
         rest_total_hits_as_int: true
         index: dates
         body:
+          sort: field
           query:
             range:
               date:
@@ -73,6 +71,7 @@ setup:
         rest_total_hits_as_int: true
         index: dates
         body:
+          sort: field
           query:
             range:
               date:
@@ -82,7 +81,7 @@ setup:
 
   - match: { hits.total: 1 }
   - length: { hits.hits: 1 }
-  - match: { hits.hits.0._id: "fourth" }
+  - match: { hits.hits.0._id: "4" }
 
 ---
 "test match query gte and lte with year uuuu":
@@ -91,6 +90,7 @@ setup:
         rest_total_hits_as_int: true
         index: dates
         body:
+          sort: field
           query:
             range:
               date:
@@ -100,9 +100,9 @@ setup:
 
   - match: { hits.total: 3 }
   - length: { hits.hits: 3 }
-  - match: { hits.hits.0._id: "first" }
-  - match: { hits.hits.1._id: "fourth" }
-  - match: { hits.hits.2._id: "fifth" }
+  - match: { hits.hits.0._id: "1" }
+  - match: { hits.hits.1._id: "4" }
+  - match: { hits.hits.2._id: "5" }
 
 ---
 "test match query with year uuuu":
@@ -111,6 +111,7 @@ setup:
         rest_total_hits_as_int: true
         index: dates_year_only
         body:
+          sort: field
           query:
             match:
               date:
@@ -118,4 +119,4 @@ setup:
 
   - match: { hits.total: 1 }
   - length: { hits.hits: 1 }
-  - match: { hits.hits.0._id: "fourth" }
+  - match: { hits.hits.0._id: "4" }


### PR DESCRIPTION
the #90458 has been backported to all branches so the bwc testing can be enable for this tests were incorrectly relying on sort order. Added sort to make it deterministic

closes #90668

<!--
Thank you for your interest in and contributing to Elasticsearch! There
are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your
attention.
-->

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/elasticsearch/blob/main/CONTRIBUTING.md)?
- If submitting code, have you built your formula locally prior to submission with `gradle check`?
- If submitting code, is your pull request against main? Unless there is a good reason otherwise, we prefer pull requests against main and will backport as needed.
- If submitting code, have you checked that your submission is for an [OS and architecture that we support](https://www.elastic.co/support/matrix#show_os)?
- If you are submitting this code for a class then read our [policy](https://github.com/elastic/elasticsearch/blob/main/CONTRIBUTING.md#contributing-as-part-of-a-class) for that.
