### PR TITLE
[DOCS] Remove coming tag from 8.4.3 release notes

### DIFF
--- a/docs/reference/release-notes/8.4.3.asciidoc
+++ b/docs/reference/release-notes/8.4.3.asciidoc
@@ -1,8 +1,6 @@
 [[release-notes-8.4.3]]
 == {es} version 8.4.3
 
-coming[8.4.3]
-
 Also see <<breaking-changes-8.4,Breaking changes in 8.4>>.
 
 [[bug-8.4.3]]


### PR DESCRIPTION
This PR removes the callout.
