### PR TITLE
[8.5] [DOCS] Remove coming tag from 8.4.3 release notes (#90683)

### DIFF
--- a/docs/reference/release-notes/8.4.3.asciidoc
+++ b/docs/reference/release-notes/8.4.3.asciidoc
@@ -1,8 +1,6 @@
 [[release-notes-8.4.3]]
 == {es} version 8.4.3
 
-coming[8.4.3]
-
 Also see <<breaking-changes-8.4,Breaking changes in 8.4>>.
 
 [[bug-8.4.3]]


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.5`:
 - [[DOCS] Remove coming tag from 8.4.3 release notes (#90683)](https://github.com/elastic/elasticsearch/pull/90683)

<!--- Backport version: 8.9.4 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)