### PR TITLE
[8.5] Node's disk UNKNOWN status doesn't set disk indicator to UNKNOWN (#90654)

### DIFF
--- a/server/src/main/java/org/elasticsearch/health/node/DiskHealthIndicatorService.java
+++ b/server/src/main/java/org/elasticsearch/health/node/DiskHealthIndicatorService.java
@@ -159,12 +159,12 @@ public class DiskHealthIndicatorService implements HealthIndicatorService {
             for (String nodeId : diskHealthByNode.keySet()) {
                 DiscoveryNode node = clusterState.getNodes().get(nodeId);
                 HealthStatus healthStatus = diskHealthByNode.get(nodeId).healthStatus();
-                // TODO #90213 update this only after we check that this health status indicates a problem.
-                if (mostSevereStatusSoFar.value() < healthStatus.value()) {
-                    mostSevereStatusSoFar = healthStatus;
-                }
                 if (node == null || healthStatus.indicatesHealthProblem() == false) {
                     continue;
+                }
+
+                if (mostSevereStatusSoFar.value() < healthStatus.value()) {
+                    mostSevereStatusSoFar = healthStatus;
                 }
                 affectedRoles.addAll(node.getRoles());
                 if (node.canContainData()) {

--- a/server/src/test/java/org/elasticsearch/health/node/DiskHealthIndicatorServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/health/node/DiskHealthIndicatorServiceTests.java
@@ -106,19 +106,6 @@ public class DiskHealthIndicatorServiceTests extends ESTestCase {
             assertThat(result.status(), equalTo(expectedStatus));
         }
         {
-            HealthStatus expectedStatus = HealthStatus.UNKNOWN;
-            HealthInfo healthInfo = createHealthInfoWithOneUnhealthyNode(expectedStatus, discoveryNodes);
-            HealthIndicatorResult result = diskHealthIndicatorService.calculate(true, healthInfo);
-            assertThat(result.status(), equalTo(expectedStatus));
-        }
-        {
-            // TODO #90213 will change the expected status to GREEN.
-            HealthStatus expectedStatus = HealthStatus.UNKNOWN;
-            HealthInfo healthInfo = createHealthInfoWithOneUnhealthyNode(expectedStatus, discoveryNodes);
-            HealthIndicatorResult result = diskHealthIndicatorService.calculate(true, healthInfo);
-            assertThat(result.status(), equalTo(expectedStatus));
-        }
-        {
             HealthStatus expectedStatus = HealthStatus.YELLOW;
             HealthInfo healthInfo = createHealthInfoWithOneUnhealthyNode(expectedStatus, discoveryNodes);
             HealthIndicatorResult result = diskHealthIndicatorService.calculate(true, healthInfo);
@@ -130,6 +117,17 @@ public class DiskHealthIndicatorServiceTests extends ESTestCase {
             HealthIndicatorResult result = diskHealthIndicatorService.calculate(true, healthInfo);
             assertThat(result.status(), equalTo(expectedStatus));
         }
+    }
+
+    public void testIndicatorYieldsGreenWhenNodeHasUnknownStatus() {
+        Set<DiscoveryNode> discoveryNodes = createNodesWithAllRoles();
+        ClusterService clusterService = createClusterService(discoveryNodes, false);
+        DiskHealthIndicatorService diskHealthIndicatorService = new DiskHealthIndicatorService(clusterService);
+
+        HealthStatus expectedStatus = HealthStatus.GREEN;
+        HealthInfo healthInfo = createHealthInfoWithOneUnhealthyNode(HealthStatus.UNKNOWN, discoveryNodes);
+        HealthIndicatorResult result = diskHealthIndicatorService.calculate(true, healthInfo);
+        assertThat(result.status(), equalTo(expectedStatus));
     }
 
     public void testGreen() throws IOException {


### PR DESCRIPTION
Backports the following commits to 8.5:
 - Node's disk UNKNOWN status doesn't set disk indicator to UNKNOWN (#90654)