### PR TITLE
[DOCS] Replace dependencies list with a link.  Closes #84863

### DIFF
--- a/docs/reference/dependencies-versions.asciidoc
+++ b/docs/reference/dependencies-versions.asciidoc
@@ -5,6 +5,6 @@ ifeval::["{release-state}"=="unreleased"]
 See https://artifacts.elastic.co/reports/dependencies/dependencies-current.html[Elastic Stack Third-party Dependencices] for the complete list of dependencies for {es}.
 endif::[]
 
-ifeval::["{release-state}"!="unreleased"]
-See https://artifacts.elastic.co/reports/dependencies/dependencies-{elasticsearch_version}.html[Elastic Stack Third-party Dependencices] for the complete list of dependencies for {es} {elasticsearch_version}.
 ifeval::["{release-state}"=="released"]
+See https://artifacts.elastic.co/reports/dependencies/dependencies-{elasticsearch_version}.html[Elastic Stack Third-party Dependencices] for the complete list of dependencies for {es} {elasticsearch_version}.
+endif::[]

--- a/docs/reference/dependencies-versions.asciidoc
+++ b/docs/reference/dependencies-versions.asciidoc
@@ -1,4 +1,10 @@
 ["appendix",id="dependencies-versions"]
 = Dependencies and versions
 
+ifeval::["{release-state}"=="unreleased"]
+See https://artifacts.elastic.co/reports/dependencies/dependencies-current.html[Elastic Stack Third-party Dependencices] for the complete list of dependencies for {es}.
+endif::[]
+
+ifeval::["{release-state}"!="unreleased"]
 See https://artifacts.elastic.co/reports/dependencies/dependencies-{elasticsearch_version}.html[Elastic Stack Third-party Dependencices] for the complete list of dependencies for {es} {elasticsearch_version}.
+ifeval::["{release-state}"=="released"]

--- a/docs/reference/dependencies-versions.asciidoc
+++ b/docs/reference/dependencies-versions.asciidoc
@@ -1,7 +1,4 @@
 ["appendix",id="dependencies-versions"]
 = Dependencies and versions
 
-[source, text]
-----
-include::{dependencies-dir}/version.properties[]
-----
+See https://artifacts.elastic.co/reports/dependencies/dependencies-{elasticsearch_version}.html[Elastic Stack Third-party Dependencices] for the complete list of dependencies for {es} {elasticsearch_version}.


### PR DESCRIPTION
This gets folks to accurate information for the latest patch release, which is consistent with how we update the docs in-place for each patch release. 

There's no simple way to generate a list of links to the dependencies for all patch releases of the minor version, it would have to be manually updated each release. 

Agree that being able to see easily see that a dependency has changed would be helpful. It's a similar problem to having to dig through release notes/breaking changes over multiple releases to figure out what has changed. 