### PR TITLE
[TEST] Change to atomic file contents save

### DIFF
--- a/server/src/test/java/org/elasticsearch/reservedstate/service/FileSettingsServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/reservedstate/service/FileSettingsServiceTests.java
@@ -40,6 +40,7 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
 import java.nio.file.WatchKey;
 import java.nio.file.attribute.FileTime;
 import java.time.Instant;
@@ -207,7 +208,7 @@ public class FileSettingsServiceTests extends ESTestCase {
 
         Files.createDirectories(service.operatorSettingsDir());
 
-        Files.write(service.operatorSettingsFile(), "{}".getBytes(StandardCharsets.UTF_8));
+        writeTestFile(service.operatorSettingsFile(), "{}");
 
         // we need to wait a bit, on MacOS it may take up to 10 seconds for the Java watcher service to notice the file,
         // on Linux is instantaneous. Windows is instantaneous too.
@@ -236,7 +237,7 @@ public class FileSettingsServiceTests extends ESTestCase {
         Files.createDirectories(service.operatorSettingsDir());
 
         // contents of the JSON don't matter, we just need a file to exist
-        Files.write(service.operatorSettingsFile(), "{}".getBytes(StandardCharsets.UTF_8));
+        writeTestFile(service.operatorSettingsFile(), "{}");
 
         Exception startupException = expectThrows(IllegalStateException.class, () -> service.start());
         assertThat(
@@ -301,7 +302,7 @@ public class FileSettingsServiceTests extends ESTestCase {
         Files.createDirectories(service.operatorSettingsDir());
 
         // Make some fake settings file to cause the file settings service to process it
-        Files.write(service.operatorSettingsFile(), "{}".getBytes(StandardCharsets.UTF_8));
+        writeTestFile(service.operatorSettingsFile(), "{}");
 
         // we need to wait a bit, on MacOS it may take up to 10 seconds for the Java watcher service to notice the file,
         // on Linux is instantaneous. Windows is instantaneous too.
@@ -347,7 +348,7 @@ public class FileSettingsServiceTests extends ESTestCase {
         Files.createDirectories(service.operatorSettingsDir());
 
         // Make some fake settings file to cause the file settings service to process it
-        Files.write(service.operatorSettingsFile(), "{}".getBytes(StandardCharsets.UTF_8));
+        writeTestFile(service.operatorSettingsFile(), "{}");
 
         // we need to wait a bit, on MacOS it may take up to 10 seconds for the Java watcher service to notice the file,
         // on Linux is instantaneous. Windows is instantaneous too.
@@ -384,7 +385,7 @@ public class FileSettingsServiceTests extends ESTestCase {
 
         Files.createDirectories(service.operatorSettingsDir());
         // Make some fake settings file to cause the file settings service to process it
-        Files.write(service.operatorSettingsFile(), "{}".getBytes(StandardCharsets.UTF_8));
+        writeTestFile(service.operatorSettingsFile(), "{}");
 
         clearInvocations(csAdminClient);
         clearInvocations(spiedController);
@@ -495,5 +496,13 @@ public class FileSettingsServiceTests extends ESTestCase {
         assertTrue(result != prevWatchKey);
 
         verify(service, times(2)).retryDelayMillis(anyInt());
+    }
+
+    // helpers
+    private void writeTestFile(Path path, String contents) throws IOException {
+        Path tempFilePath = createTempFile();
+
+        Files.write(tempFilePath, contents.getBytes(StandardCharsets.UTF_8));
+        Files.move(tempFilePath, path, StandardCopyOption.ATOMIC_MOVE);
     }
 }


### PR DESCRIPTION
The unit tests we have for File settings didn't save the contents atomically, so in theory they can trigger more than one file save operation. This PR changes all file saves to atomic saves.

Closes https://github.com/elastic/elasticsearch/issues/90693