### PR TITLE
[8.5] docs: update fleet/agent pipeline docs (#90659)

### DIFF
--- a/docs/reference/ingest.asciidoc
+++ b/docs/reference/ingest.asciidoc
@@ -300,18 +300,20 @@ output.elasticsearch:
 [[pipelines-for-fleet-elastic-agent]]
 === Pipelines for {fleet} and {agent}
 
-{fleet-guide}/index.html[{fleet}] automatically adds ingest pipelines for its
-integrations. {fleet} applies these pipelines using <<index-templates,index
+{agent} integrations ship with default ingest pipelines that preprocess and enrich data before indexing.
+{fleet-guide}/index.html[{fleet}] applies these pipelines using <<index-templates,index
 templates>> that include <<set-default-pipeline,pipeline index settings>>. {es}
 matches these templates to your {fleet} data streams based on the
 {fleet-guide}/data-streams.html#data-streams-naming-scheme[stream's naming
 scheme].
 
-WARNING: Do not change {fleet}'s ingest pipelines or use custom pipelines for
-your {fleet} integrations. Doing so can break your {fleet} data streams.
+Each default integration pipeline calls a nonexistent, unversioned `@custom` ingest pipeline.
+If unaltered, this pipeline call has no effect on your data. However, you can modify this call to
+create custom pipelines for integrations that persist across upgrades.
+Refer to {fleet-guide}/data-streams-pipeline-tutorial.html[Tutorial: Transform data with custom ingest pipelines] to learn more.
 
-{fleet} doesn't provide an ingest pipeline for the **Custom logs** integration.
-You can safely specify a pipeline for this integration in one of two ways: an
+{fleet} doesn't provide a default ingest pipeline for the **Custom logs** integration,
+but you can specify a pipeline for this integration using an 
 <<pipeline-custom-logs-index-template,index template>> or a
 <<pipeline-custom-logs-configuration,custom configuration>>.
 


### PR DESCRIPTION
Backports the following commits to 8.5:
 - docs: update fleet/agent pipeline docs (#90659)