### PR TITLE
Fix InternalEngineTests.testMergeThreadLogging

### DIFF
--- a/server/src/test/java/org/elasticsearch/index/engine/InternalEngineTests.java
+++ b/server/src/test/java/org/elasticsearch/index/engine/InternalEngineTests.java
@@ -15,6 +15,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.core.LogEvent;
 import org.apache.logging.log4j.core.appender.AbstractAppender;
+import org.apache.logging.log4j.core.config.Property;
 import org.apache.logging.log4j.core.filter.RegexFilter;
 import org.apache.lucene.document.Field;
 import org.apache.lucene.document.FieldType;
@@ -2548,7 +2549,7 @@ public class InternalEngineTests extends EngineTestCase {
         }
 
         MockMTAppender(final String name) throws IllegalAccessException {
-            super(name, RegexFilter.createFilter(".*(\n.*)*", new String[0], false, null, null), null);
+            super(name, RegexFilter.createFilter(".*(\n.*)*", new String[0], false, null, null), null, false, Property.EMPTY_ARRAY);
         }
 
         @Override
@@ -2560,39 +2561,50 @@ public class InternalEngineTests extends EngineTestCase {
         }
     }
 
-    public void testMergeThreadLogging() throws IllegalAccessException, IOException {
-        MockMTAppender mockAppender = new MockMTAppender("testMergeThreadLogging");
+    public void testMergeThreadLogging() throws Exception {
+        final MockMTAppender mockAppender = new MockMTAppender("testMergeThreadLogging");
         mockAppender.start();
 
         Logger rootLogger = LogManager.getRootLogger();
         Level savedLevel = rootLogger.getLevel();
         Loggers.addAppender(rootLogger, mockAppender);
         Loggers.setLevel(rootLogger, Level.TRACE);
+        try {
+            LogMergePolicy lmp = newLogMergePolicy();
+            lmp.setMergeFactor(2);
 
-        LogMergePolicy lmp = newLogMergePolicy();
-        lmp.setMergeFactor(2);
-        try (Store store = createStore()) {
-            InternalEngine engine = createEngine(defaultSettings, store, createTempDir(), lmp); // fmp
-            engine.index(indexForDoc(testParsedDocument("1", null, testDocument(), B_1, null)));
-            engine.index(indexForDoc(testParsedDocument("2", null, testDocument(), B_1, null)));
-            engine.index(indexForDoc(testParsedDocument("3", null, testDocument(), B_1, null)));
-            engine.index(indexForDoc(testParsedDocument("4", null, testDocument(), B_1, null)));
-            engine.forceMerge(true, 1, false, UUIDs.randomBase64UUID());
-            engine.flushAndClose();
+            try (Store store = createStore()) {
+                InternalEngine engine = createEngine(defaultSettings, store, createTempDir(), lmp);
+                engine.index(indexForDoc(testParsedDocument("1", null, testDocument(), B_1, null)));
+                engine.index(indexForDoc(testParsedDocument("2", null, testDocument(), B_1, null)));
+                engine.flush();
+                engine.index(indexForDoc(testParsedDocument("3", null, testDocument(), B_1, null)));
+                engine.index(indexForDoc(testParsedDocument("4", null, testDocument(), B_1, null)));
+                engine.forceMerge(true, 1, false, UUIDs.randomBase64UUID());
+                engine.flushAndClose();
 
-            long merges = engine.getMergeStats().getTotal();
-            if (merges > 0) {
+                assertBusy(() -> {
+                    assertThat(engine.getMergeStats().getTotal(), greaterThan(0L));
+                    assertThat(engine.getMergeStats().getCurrent(), equalTo(0L));
+                });
+            }
+
+            assertBusy(() -> {
                 List<String> threadMsgs = mockAppender.messages().stream().filter(line -> line.startsWith("merge thread")).toList();
-                assertThat("messages:" + threadMsgs + ", merges=" + merges, threadMsgs.size(), greaterThanOrEqualTo(2));
+                assertThat("messages:" + threadMsgs, threadMsgs.size(), greaterThanOrEqualTo(3));
                 assertThat(
                     threadMsgs,
-                    containsInRelativeOrder(matchesRegex("^merge thread .* start$"), matchesRegex("^merge thread .* merge segment.*$"))
+                    containsInRelativeOrder(
+                        matchesRegex("^merge thread .* start$"),
+                        matchesRegex("^merge thread .* merge segment.*$"),
+                        matchesRegex("^merge thread .* end$")
+                    )
                 );
-            }
+            });
         } finally {
+            Loggers.setLevel(rootLogger, savedLevel);
             Loggers.removeAppender(rootLogger, mockAppender);
             mockAppender.stop();
-            Loggers.setLevel(rootLogger, savedLevel);
         }
     }
 


### PR DESCRIPTION
This test failed 3 times last year while tearing down the test and checking the Log4j status logger (the logger that Log4j uses to log its own errors). The test uses a custom appender to check Lucene merges and this appender received log events after being stopped. 

This is likely due to a congestion in log events that are processed out of order by the loggers, some of them being processed after the test stopped the appender, like in this case:

```
[2022-08-19T11:05:54,101][DEBUG][o.e.i.e.Engine           ] [testMergeThreadLogging] [index][0] engine closed [api]
[2022-08-19T11:05:54,104][TRACE][o.e.i.e.I.EngineMergeScheduler] [[index] [index][0] merge thread elasticsearch[[index][0]: Lucene Merge Thread #0] end
[2022-08-19T11:05:54,108][DEBUG][o.e.i.s.Store            ] [testMergeThreadLogging] [index][0] store reference count on close: 0
[2022-08-19T11:05:54,106][TRACE][o.e.i.e.E.MS             ] [[index] [index][0] elasticsearch[[index][0]: Lucene Merge Thread #0] MS: merge thread elasticsearch[[index][0]: Lucene Merge Thread #0] end
```

The test waits for the engine to be closed (which is done at `05:54,108`) and then stops the appender but the latest log event produced by the Lucene merge thread is processed after but was originated at `11:05:54,106`.

This change revisits the test so that it asserts-busy that the expected messages have been processed before resetting the level, removing and stopping the appender. It now also asserts that the ending message has been logged. It also adds a `flush` to ensure some merging happens (today the test does nothing 1 time on 2). Finally the `MockMTAppender` appender used in the test also had the default behavior of ignoring exceptions instead of throwing an exception which would have make the failure more obvious: this is changed in this pull request too.

Closes #90071