### PR TITLE
Remove incorrect outputs mapping from fleet-agents

### DIFF
--- a/x-pack/plugin/core/src/main/resources/fleet-agents.json
+++ b/x-pack/plugin/core/src/main/resources/fleet-agents.json
@@ -29,26 +29,6 @@
             }
           }
         },
-        "outputs": {
-          "properties": {
-            "api_key": {
-              "type": "keyword"
-            },
-            "api_key_id": {
-              "type": "keyword"
-            },
-            "type": {
-              "type": "keyword"
-            },
-            "policy_permissions_hash": {
-              "type": "keyword"
-            },
-            "to_retire_api_key_ids": {
-              "type": "object",
-              "enabled": false
-            }
-          }
-        },
         "default_api_key": {
           "type": "keyword"
         },


### PR DESCRIPTION
As discussed in https://github.com/elastic/fleet-server/issues/1958, these mappings are incorrect. We do not actually need them right now so we're going to remove them for the 8.5.0 release to reduce confusion and reintroduce them again later.