### PR TITLE
[ML] Add a regex to the output of the categorize_text aggregation

### DIFF
--- a/docs/changelog/90723.yaml
+++ b/docs/changelog/90723.yaml
@@ -1,0 +1,5 @@
+pr: 90723
+summary: Add a regex to the output of the `categorize_text` aggregation
+area: Machine Learning
+type: enhancement
+issues: []

--- a/docs/reference/aggregations/bucket/categorize-text-aggregation.asciidoc
+++ b/docs/reference/aggregations/bucket/categorize-text-aggregation.asciidoc
@@ -142,21 +142,25 @@ Response:
         {
           "doc_count" : 3,
           "key" : "Node shutting down",
+          "regex" : ".*?Node.+?shutting.+?down.*?",
           "max_matching_length" : 49
         },
         {
           "doc_count" : 1,
           "key" : "Node starting up",
+          "regex" : ".*?Node.+?starting.+?up.*?",
           "max_matching_length" : 47
         },
         {
           "doc_count" : 1,
           "key" : "User foo_325 logging on",
+          "regex" : ".*?User.+?foo_325.+?logging.+?on.*?",
           "max_matching_length" : 52
         },
         {
           "doc_count" : 1,
           "key" : "User foo_864 logged off",
+          "regex" : ".*?User.+?foo_864.+?logged.+?off.*?",
           "max_matching_length" : 52
         }
       ]
@@ -198,21 +202,25 @@ category results
         {
           "doc_count" : 3,
           "key" : "Node shutting down",
+          "regex" : ".*?Node.+?shutting.+?down.*?",
           "max_matching_length" : 49
         },
         {
           "doc_count" : 1,
           "key" : "Node starting up",
+          "regex" : ".*?Node.+?starting.+?up.*?",
           "max_matching_length" : 47
         },
         {
           "doc_count" : 1,
           "key" : "User logged off",
+          "regex" : ".*?User.+?logged.+?off.*?",
           "max_matching_length" : 52
         },
         {
           "doc_count" : 1,
           "key" : "User logging on",
+          "regex" : ".*?User.+?logging.+?on.*?",
           "max_matching_length" : 52
         }
       ]
@@ -266,11 +274,13 @@ The resulting categories are now very broad, merging the log groups.
         {
           "doc_count" : 4,
           "key" : "Node",
+          "regex" : ".*?Node.*?",
           "max_matching_length" : 49
         },
         {
           "doc_count" : 2,
           "key" : "User",
+          "regex" : ".*?User.*?",
           "max_matching_length" : 52
         }
       ]
@@ -330,6 +340,7 @@ POST log-messages/_search?filter_path=aggregations
               {
                 "doc_count" : 2,
                 "key" : "Node shutting down",
+                "regex" : ".*?Node.+?shutting.+?down.*?",
                 "max_matching_length" : 49,
                 "hit" : {
                   "hits" : {
@@ -357,6 +368,7 @@ POST log-messages/_search?filter_path=aggregations
               {
                 "doc_count" : 1,
                 "key" : "Node starting up",
+                "regex" : ".*?Node.+?starting.+?up.*?",
                 "max_matching_length" : 47,
                 "hit" : {
                   "hits" : {
@@ -393,6 +405,7 @@ POST log-messages/_search?filter_path=aggregations
               {
                 "doc_count" : 1,
                 "key" : "Node shutting down",
+                "regex" : ".*?Node.+?shutting.+?down.*?",
                 "max_matching_length" : 49,
                 "hit" : {
                   "hits" : {
@@ -420,6 +433,7 @@ POST log-messages/_search?filter_path=aggregations
               {
                 "doc_count" : 1,
                 "key" : "User logged off",
+                "regex" : ".*?User.+?logged.+?off.*?",
                 "max_matching_length" : 52,
                 "hit" : {
                   "hits" : {
@@ -447,6 +461,7 @@ POST log-messages/_search?filter_path=aggregations
               {
                 "doc_count" : 1,
                 "key" : "User logging on",
+                "regex" : ".*?User.+?logging.+?on.*?",
                 "max_matching_length" : 52,
                 "hit" : {
                   "hits" : {

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/aggs/categorization/InternalCategorizationAggregation.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/aggs/categorization/InternalCategorizationAggregation.java
@@ -145,6 +145,7 @@ public class InternalCategorizationAggregation extends InternalMultiBucketAggreg
             builder.field(CommonFields.DOC_COUNT.getPreferredName(), serializableCategory.getNumMatches());
             builder.field(CommonFields.KEY.getPreferredName());
             key.toXContent(builder, params);
+            builder.field(CategoryDefinition.REGEX.getPreferredName(), serializableCategory.getRegex());
             builder.field(CategoryDefinition.MAX_MATCHING_LENGTH.getPreferredName(), serializableCategory.maxMatchingStringLen());
             aggregations.toXContentInternal(builder, params);
             builder.endObject();

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/aggs/categorization/SerializableTokenListCategory.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/aggs/categorization/SerializableTokenListCategory.java
@@ -37,6 +37,8 @@ public class SerializableTokenListCategory implements Writeable {
      */
     public static final int KEY_BUDGET = 10000;
 
+    private static final String REGEX_NEEDS_ESCAPE_PATTERN = "([\\\\|()\\[\\]{}^$.+*?])";
+
     final BytesRef[] baseTokens;
     final int[] baseTokenWeights;
     final int baseUnfilteredLength;
@@ -158,6 +160,16 @@ public class SerializableTokenListCategory implements Writeable {
 
     public BytesRef[] getKeyTokens() {
         return Arrays.stream(keyTokenIndexes).mapToObj(index -> baseTokens[index]).toArray(BytesRef[]::new);
+    }
+
+    public String getRegex() {
+        if (keyTokenIndexes.length == 0 || orderedCommonTokenBeginIndex == orderedCommonTokenEndIndex) {
+            return ".*";
+        }
+        return Arrays.stream(keyTokenIndexes)
+            .filter(index -> index >= orderedCommonTokenBeginIndex && index < orderedCommonTokenEndIndex)
+            .mapToObj(index -> baseTokens[index].utf8ToString().replaceAll(REGEX_NEEDS_ESCAPE_PATTERN, "\\\\$1"))
+            .collect(Collectors.joining(".+?", ".*?", ".*?"));
     }
 
     @Override

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/aggs/categorization/CategorizeTextAggregatorTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/aggs/categorization/CategorizeTextAggregatorTests.java
@@ -69,10 +69,17 @@ public class CategorizeTextAggregatorTests extends AggregatorTestCase {
                 assertThat(result.getBuckets(), hasSize(2));
                 assertThat(result.getBuckets().get(0).getDocCount(), equalTo(6L));
                 assertThat(result.getBuckets().get(0).getKeyAsString(), equalTo("Node started"));
+                assertThat(result.getBuckets().get(0).getSerializableCategory().maxMatchingStringLen(), equalTo(15));
+                assertThat(result.getBuckets().get(0).getSerializableCategory().getRegex(), equalTo(".*?Node.+?started.*?"));
                 assertThat(result.getBuckets().get(1).getDocCount(), equalTo(2L));
                 assertThat(
                     result.getBuckets().get(1).getKeyAsString(),
                     equalTo("Failed to shutdown error org.aaaa.bbbb.Cccc line caused by foo exception")
+                );
+                assertThat(result.getBuckets().get(1).getSerializableCategory().maxMatchingStringLen(), equalTo(84));
+                assertThat(
+                    result.getBuckets().get(1).getSerializableCategory().getRegex(),
+                    equalTo(".*?Failed.+?to.+?shutdown.+?error.+?org\\.aaaa\\.bbbb\\.Cccc.+?line.+?caused.+?by.+?foo.+?exception.*?")
                 );
             },
             new TextFieldMapper.TextFieldType(TEXT_FIELD_NAME),
@@ -94,6 +101,8 @@ public class CategorizeTextAggregatorTests extends AggregatorTestCase {
                 assertThat(result.getBuckets(), hasSize(2));
                 assertThat(result.getBuckets().get(0).getDocCount(), equalTo(6L));
                 assertThat(result.getBuckets().get(0).getKeyAsString(), equalTo("Node started"));
+                assertThat(result.getBuckets().get(0).getSerializableCategory().maxMatchingStringLen(), equalTo(15));
+                assertThat(result.getBuckets().get(0).getSerializableCategory().getRegex(), equalTo(".*?Node.+?started.*?"));
                 assertThat(((Max) result.getBuckets().get(0).getAggregations().get("max")).value(), equalTo(5.0));
                 assertThat(((Min) result.getBuckets().get(0).getAggregations().get("min")).value(), equalTo(0.0));
                 assertThat(((Avg) result.getBuckets().get(0).getAggregations().get("avg")).getValue(), equalTo(2.5));
@@ -102,6 +111,11 @@ public class CategorizeTextAggregatorTests extends AggregatorTestCase {
                 assertThat(
                     result.getBuckets().get(1).getKeyAsString(),
                     equalTo("Failed to shutdown error org.aaaa.bbbb.Cccc line caused by foo exception")
+                );
+                assertThat(result.getBuckets().get(1).getSerializableCategory().maxMatchingStringLen(), equalTo(84));
+                assertThat(
+                    result.getBuckets().get(1).getSerializableCategory().getRegex(),
+                    equalTo(".*?Failed.+?to.+?shutdown.+?error.+?org\\.aaaa\\.bbbb\\.Cccc.+?line.+?caused.+?by.+?foo.+?exception.*?")
                 );
                 assertThat(((Max) result.getBuckets().get(1).getAggregations().get("max")).value(), equalTo(4.0));
                 assertThat(((Min) result.getBuckets().get(1).getAggregations().get("min")).value(), equalTo(0.0));
@@ -128,6 +142,8 @@ public class CategorizeTextAggregatorTests extends AggregatorTestCase {
                 assertThat(result.getBuckets(), hasSize(2));
                 assertThat(result.getBuckets().get(0).getDocCount(), equalTo(6L));
                 assertThat(result.getBuckets().get(0).getKeyAsString(), equalTo("Node started"));
+                assertThat(result.getBuckets().get(0).getSerializableCategory().maxMatchingStringLen(), equalTo(15));
+                assertThat(result.getBuckets().get(0).getSerializableCategory().getRegex(), equalTo(".*?Node.+?started.*?"));
                 Histogram histo = result.getBuckets().get(0).getAggregations().get("histo");
                 assertThat(histo.getBuckets(), hasSize(3));
                 for (Histogram.Bucket bucket : histo.getBuckets()) {
@@ -147,6 +163,11 @@ public class CategorizeTextAggregatorTests extends AggregatorTestCase {
                 assertThat(
                     result.getBuckets().get(1).getKeyAsString(),
                     equalTo("Failed to shutdown error org.aaaa.bbbb.Cccc line caused by foo exception")
+                );
+                assertThat(result.getBuckets().get(1).getSerializableCategory().maxMatchingStringLen(), equalTo(84));
+                assertThat(
+                    result.getBuckets().get(1).getSerializableCategory().getRegex(),
+                    equalTo(".*?Failed.+?to.+?shutdown.+?error.+?org\\.aaaa\\.bbbb\\.Cccc.+?line.+?caused.+?by.+?foo.+?exception.*?")
                 );
                 histo = result.getBuckets().get(1).getAggregations().get("histo");
                 assertThat(histo.getBuckets(), hasSize(3));
@@ -180,6 +201,8 @@ public class CategorizeTextAggregatorTests extends AggregatorTestCase {
             assertThat(categorizationAggregation.getBuckets(), hasSize(2));
             assertThat(categorizationAggregation.getBuckets().get(0).getDocCount(), equalTo(2L));
             assertThat(categorizationAggregation.getBuckets().get(0).getKeyAsString(), equalTo("Node started"));
+            assertThat(categorizationAggregation.getBuckets().get(0).getSerializableCategory().maxMatchingStringLen(), equalTo(15));
+            assertThat(categorizationAggregation.getBuckets().get(0).getSerializableCategory().getRegex(), equalTo(".*?Node.+?started.*?"));
             assertThat(((Max) categorizationAggregation.getBuckets().get(0).getAggregations().get("max")).value(), equalTo(1.0));
             assertThat(((Min) categorizationAggregation.getBuckets().get(0).getAggregations().get("min")).value(), equalTo(0.0));
             assertThat(((Avg) categorizationAggregation.getBuckets().get(0).getAggregations().get("avg")).getValue(), equalTo(0.5));
@@ -188,6 +211,11 @@ public class CategorizeTextAggregatorTests extends AggregatorTestCase {
             assertThat(
                 categorizationAggregation.getBuckets().get(1).getKeyAsString(),
                 equalTo("Failed to shutdown error org.aaaa.bbbb.Cccc line caused by foo exception")
+            );
+            assertThat(categorizationAggregation.getBuckets().get(1).getSerializableCategory().maxMatchingStringLen(), equalTo(84));
+            assertThat(
+                categorizationAggregation.getBuckets().get(1).getSerializableCategory().getRegex(),
+                equalTo(".*?Failed.+?to.+?shutdown.+?error.+?org\\.aaaa\\.bbbb\\.Cccc.+?line.+?caused.+?by.+?foo.+?exception.*?")
             );
             assertThat(((Max) categorizationAggregation.getBuckets().get(1).getAggregations().get("max")).value(), equalTo(0.0));
             assertThat(((Min) categorizationAggregation.getBuckets().get(1).getAggregations().get("min")).value(), equalTo(0.0));
@@ -199,6 +227,8 @@ public class CategorizeTextAggregatorTests extends AggregatorTestCase {
             assertThat(categorizationAggregation.getBuckets(), hasSize(1));
             assertThat(categorizationAggregation.getBuckets().get(0).getDocCount(), equalTo(2L));
             assertThat(categorizationAggregation.getBuckets().get(0).getKeyAsString(), equalTo("Node started"));
+            assertThat(categorizationAggregation.getBuckets().get(0).getSerializableCategory().maxMatchingStringLen(), equalTo(15));
+            assertThat(categorizationAggregation.getBuckets().get(0).getSerializableCategory().getRegex(), equalTo(".*?Node.+?started.*?"));
             assertThat(((Max) categorizationAggregation.getBuckets().get(0).getAggregations().get("max")).value(), equalTo(3.0));
             assertThat(((Min) categorizationAggregation.getBuckets().get(0).getAggregations().get("min")).value(), equalTo(2.0));
             assertThat(((Avg) categorizationAggregation.getBuckets().get(0).getAggregations().get("avg")).getValue(), equalTo(2.5));
@@ -209,6 +239,8 @@ public class CategorizeTextAggregatorTests extends AggregatorTestCase {
             assertThat(categorizationAggregation.getBuckets(), hasSize(2));
             assertThat(categorizationAggregation.getBuckets().get(0).getDocCount(), equalTo(2L));
             assertThat(categorizationAggregation.getBuckets().get(0).getKeyAsString(), equalTo("Node started"));
+            assertThat(categorizationAggregation.getBuckets().get(0).getSerializableCategory().maxMatchingStringLen(), equalTo(15));
+            assertThat(categorizationAggregation.getBuckets().get(0).getSerializableCategory().getRegex(), equalTo(".*?Node.+?started.*?"));
             assertThat(((Max) categorizationAggregation.getBuckets().get(0).getAggregations().get("max")).value(), equalTo(5.0));
             assertThat(((Min) categorizationAggregation.getBuckets().get(0).getAggregations().get("min")).value(), equalTo(4.0));
             assertThat(((Avg) categorizationAggregation.getBuckets().get(0).getAggregations().get("avg")).getValue(), equalTo(4.5));
@@ -217,6 +249,11 @@ public class CategorizeTextAggregatorTests extends AggregatorTestCase {
             assertThat(
                 categorizationAggregation.getBuckets().get(1).getKeyAsString(),
                 equalTo("Failed to shutdown error org.aaaa.bbbb.Cccc line caused by foo exception")
+            );
+            assertThat(categorizationAggregation.getBuckets().get(1).getSerializableCategory().maxMatchingStringLen(), equalTo(84));
+            assertThat(
+                categorizationAggregation.getBuckets().get(1).getSerializableCategory().getRegex(),
+                equalTo(".*?Failed.+?to.+?shutdown.+?error.+?org\\.aaaa\\.bbbb\\.Cccc.+?line.+?caused.+?by.+?foo.+?exception.*?")
             );
             assertThat(((Max) categorizationAggregation.getBuckets().get(1).getAggregations().get("max")).value(), equalTo(4.0));
             assertThat(((Min) categorizationAggregation.getBuckets().get(1).getAggregations().get("min")).value(), equalTo(4.0));
@@ -240,6 +277,8 @@ public class CategorizeTextAggregatorTests extends AggregatorTestCase {
                 assertThat(result.getBuckets(), hasSize(2));
                 assertThat(result.getBuckets().get(0).getDocCount(), equalTo(30000L));
                 assertThat(result.getBuckets().get(0).getKeyAsString(), equalTo("Node started"));
+                assertThat(result.getBuckets().get(0).getSerializableCategory().maxMatchingStringLen(), equalTo(15));
+                assertThat(result.getBuckets().get(0).getSerializableCategory().getRegex(), equalTo(".*?Node.+?started.*?"));
                 Histogram histo = result.getBuckets().get(0).getAggregations().get("histo");
                 assertThat(histo.getBuckets(), hasSize(3));
                 for (Histogram.Bucket bucket : histo.getBuckets()) {
@@ -259,6 +298,11 @@ public class CategorizeTextAggregatorTests extends AggregatorTestCase {
                 assertThat(
                     result.getBuckets().get(1).getKeyAsString(),
                     equalTo("Failed to shutdown error org.aaaa.bbbb.Cccc line caused by foo exception")
+                );
+                assertThat(result.getBuckets().get(1).getSerializableCategory().maxMatchingStringLen(), equalTo(84));
+                assertThat(
+                    result.getBuckets().get(1).getSerializableCategory().getRegex(),
+                    equalTo(".*?Failed.+?to.+?shutdown.+?error.+?org\\.aaaa\\.bbbb\\.Cccc.+?line.+?caused.+?by.+?foo.+?exception.*?")
                 );
                 histo = result.getBuckets().get(1).getAggregations().get("histo");
                 assertThat(histo.getBuckets(), hasSize(3));

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/aggs/categorization/ParsedCategorization.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/aggs/categorization/ParsedCategorization.java
@@ -57,6 +57,7 @@ class ParsedCategorization extends ParsedMultiBucketAggregation<ParsedCategoriza
     public static class ParsedBucket extends ParsedMultiBucketAggregation.ParsedBucket implements MultiBucketsAggregation.Bucket {
 
         private InternalCategorizationAggregation.BucketKey key;
+        private String regex;
         private int maxMatchingLength;
 
         protected void setKeyAsString(String keyAsString) {
@@ -74,6 +75,10 @@ class ParsedCategorization extends ParsedMultiBucketAggregation<ParsedCategoriza
                     ? new BytesRef[] { new BytesRef(keyAsString) }
                     : Arrays.stream(split).map(BytesRef::new).toArray(BytesRef[]::new)
             );
+        }
+
+        private void setRegex(String regex) {
+            this.regex = regex;
         }
 
         private void setMaxMatchingLength(int maxMatchingLength) {
@@ -99,6 +104,7 @@ class ParsedCategorization extends ParsedMultiBucketAggregation<ParsedCategoriza
         public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
             builder.startObject();
             keyToXContent(builder);
+            builder.field(CategoryDefinition.REGEX.getPreferredName(), regex);
             builder.field(CategoryDefinition.MAX_MATCHING_LENGTH.getPreferredName(), maxMatchingLength);
             builder.field(CommonFields.DOC_COUNT.getPreferredName(), getDocCount());
             getAggregations().toXContentInternal(builder, params);
@@ -142,6 +148,8 @@ class ParsedCategorization extends ParsedMultiBucketAggregation<ParsedCategoriza
                         keyConsumer.accept(parser, bucket);
                     } else if (CommonFields.DOC_COUNT.getPreferredName().equals(currentFieldName)) {
                         bucket.setDocCount(parser.longValue());
+                    } else if (CategoryDefinition.REGEX.getPreferredName().equals(currentFieldName)) {
+                        bucket.setRegex(parser.text());
                     } else if (CategoryDefinition.MAX_MATCHING_LENGTH.getPreferredName().equals(currentFieldName)) {
                         bucket.setMaxMatchingLength(parser.intValue());
                     }

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/aggs/categorization/SerializableTokenListCategoryTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/aggs/categorization/SerializableTokenListCategoryTests.java
@@ -7,12 +7,20 @@
 
 package org.elasticsearch.xpack.ml.aggs.categorization;
 
+import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.common.util.BytesRefHash;
 import org.elasticsearch.test.AbstractWireSerializingTestCase;
 import org.junit.After;
 import org.junit.Before;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.TreeMap;
+import java.util.stream.Collectors;
+
+import static org.hamcrest.Matchers.equalTo;
 
 public class SerializableTokenListCategoryTests extends AbstractWireSerializingTestCase<SerializableTokenListCategory> {
 
@@ -26,6 +34,45 @@ public class SerializableTokenListCategoryTests extends AbstractWireSerializingT
     @After
     public void destroyHash() {
         bytesRefHash.close();
+    }
+
+    public void testGetRegex() {
+        StringBuilder expectedResult = new StringBuilder();
+
+        int unfilteredStringLength = 0;
+        int numBaseTokens = randomIntBetween(3, 15);
+        List<TokenListCategory.TokenAndWeight> baseWeightedTokenIds = new ArrayList<>();
+        for (int i = 0; i < numBaseTokens; ++i) {
+            int stringLen = randomIntBetween(3, 20);
+            unfilteredStringLength += stringLen;
+            String string = randomAlphaOfLength(stringLen);
+            BytesRef token = new BytesRef(string);
+            baseWeightedTokenIds.add(new TokenListCategory.TokenAndWeight(bytesRefHash.put(token), randomIntBetween(1, 5)));
+            expectedResult.append(i == 0 ? ".*?" : ".+?").append(string);
+        }
+        expectedResult.append(".*?");
+        unfilteredStringLength += randomIntBetween(numBaseTokens, numBaseTokens + 100);
+        List<TokenListCategory.TokenAndWeight> uniqueWeightedTokenIds = baseWeightedTokenIds.stream()
+            .collect(
+                Collectors.groupingBy(
+                    TokenListCategory.TokenAndWeight::getTokenId,
+                    TreeMap::new,
+                    Collectors.summingInt(TokenListCategory.TokenAndWeight::getWeight)
+                )
+            )
+            .entrySet()
+            .stream()
+            .map(entry -> new TokenListCategory.TokenAndWeight(entry.getKey(), entry.getValue()))
+            .toList();
+        TokenListCategory category = new TokenListCategory(
+            1,
+            unfilteredStringLength,
+            baseWeightedTokenIds,
+            uniqueWeightedTokenIds,
+            randomLongBetween(1, 10)
+        );
+
+        assertThat(new SerializableTokenListCategory(category, bytesRefHash).getRegex(), equalTo(expectedResult.toString()));
     }
 
     @Override

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/ml/categorization_agg.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/ml/categorization_agg.yml
@@ -81,11 +81,11 @@ setup:
   - match: { aggregations.categories.buckets.0.doc_count: 4 }
   - match: { aggregations.categories.buckets.0.key: "Node" }
   - match: { aggregations.categories.buckets.0.regex: ".*?Node.*?" }
-  - match: { aggregations.categories.buckets.0.max_matching_len: 15 }
+  - match: { aggregations.categories.buckets.0.max_matching_length: 16 }
   - match: { aggregations.categories.buckets.1.doc_count: 3 }
   - match: { aggregations.categories.buckets.1.key: "User Foo logging" }
   - match: { aggregations.categories.buckets.1.regex: ".*?User.+?Foo.+?logging.*?" }
-  - match: { aggregations.categories.buckets.1.max_matching_len: 20 }
+  - match: { aggregations.categories.buckets.1.max_matching_length: 22 }
 
 ---
 "Test categorization aggregation against unsupported field":

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/ml/categorization_agg.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/ml/categorization_agg.yml
@@ -80,8 +80,13 @@ setup:
   - length: { aggregations.categories.buckets: 2 }
   - match: { aggregations.categories.buckets.0.doc_count: 4 }
   - match: { aggregations.categories.buckets.0.key: "Node" }
+  - match: { aggregations.categories.buckets.0.regex: ".*?Node.*?" }
+  - match: { aggregations.categories.buckets.0.max_matching_len: 15 }
   - match: { aggregations.categories.buckets.1.doc_count: 3 }
   - match: { aggregations.categories.buckets.1.key: "User Foo logging" }
+  - match: { aggregations.categories.buckets.1.regex: ".*?User.+?Foo.+?logging.*?" }
+  - match: { aggregations.categories.buckets.1.max_matching_len: 20 }
+
 ---
 "Test categorization aggregation against unsupported field":
   - do:


### PR DESCRIPTION
The new `regex` field in `categorize_text` output is created in the same way as the `regex` field that appears in the category definitions created by anomaly detection jobs that do categorization.

It consists of the terms that occur in the same order for every message that matches the category, separated with a `.+?` wildcard. It therefore matches the category messages and enforces the order of the terms that occurred in the same order for all messages used to create the category.

It is not recommended to use the regex as the primary mechanism for searching for the original documents that were categorized. Search using a regular expression is very slow. Instead the terms of the category should be used to search for matching documents, as a terms search can use the inverted index and hence be much faster. However, there may be situations where it is useful to use the `regex` field to test whether a small set of messages that have not been indexed match the category.