### PR TITLE
[DOCS] Add links to clear trained model deployment cache API

### DIFF
--- a/docs/reference/ml/trained-models/apis/index.asciidoc
+++ b/docs/reference/ml/trained-models/apis/index.asciidoc
@@ -13,8 +13,7 @@ include::delete-trained-models.asciidoc[leveloffset=+2]
 include::get-trained-models.asciidoc[leveloffset=+2]
 include::get-trained-models-stats.asciidoc[leveloffset=+2]
 //INFER
-include::infer-trained-model.asciidoc[leveloffset=+2][leveloffset=+2]
-//UPDATE
+include::infer-trained-model.asciidoc[leveloffset=+2]
 //START/STOP
 include::start-trained-model-deployment.asciidoc[leveloffset=+2]
 include::stop-trained-model-deployment.asciidoc[leveloffset=+2]

--- a/docs/reference/ml/trained-models/apis/index.asciidoc
+++ b/docs/reference/ml/trained-models/apis/index.asciidoc
@@ -1,4 +1,6 @@
 include::ml-trained-models-apis.asciidoc[leveloffset=+1]
+//CLEAR
+include::clear-trained-model-deployment-cache.asciidoc[leveloffset=+2]
 //CREATE
 include::put-trained-models-aliases.asciidoc[leveloffset=+2]
 include::put-trained-model-definition-part.asciidoc[leveloffset=+2]
@@ -13,7 +15,6 @@ include::get-trained-models-stats.asciidoc[leveloffset=+2]
 //INFER
 include::infer-trained-model.asciidoc[leveloffset=+2][leveloffset=+2]
 //UPDATE
-include::clear-trained-model-deployment-cache.asciidoc[leveloffset=+2]
 //START/STOP
 include::start-trained-model-deployment.asciidoc[leveloffset=+2]
 include::stop-trained-model-deployment.asciidoc[leveloffset=+2]

--- a/docs/reference/ml/trained-models/apis/ml-trained-models-apis.asciidoc
+++ b/docs/reference/ml/trained-models/apis/ml-trained-models-apis.asciidoc
@@ -4,6 +4,7 @@
 
 You can use the following APIs to perform model management operations:
 
+* <<clear-trained-model-deployment-cache>>
 * <<put-trained-models>>
 * <<put-trained-model-definition-part>>
 * <<put-trained-model-vocabulary>>


### PR DESCRIPTION
Relates to https://github.com/elastic/elasticsearch/pull/89074

This PR adds the new API to https://www.elastic.co/guide/en/elasticsearch/reference/8.5/ml-df-trained-models-apis.html and sorts it alphabetically in the navigation tree.