### PR TITLE
[8.5] [DOCS] Add links to clear trained model deployment cache API (#90727)

### DIFF
--- a/docs/reference/ml/trained-models/apis/index.asciidoc
+++ b/docs/reference/ml/trained-models/apis/index.asciidoc
@@ -1,4 +1,6 @@
 include::ml-trained-models-apis.asciidoc[leveloffset=+1]
+//CLEAR
+include::clear-trained-model-deployment-cache.asciidoc[leveloffset=+2]
 //CREATE
 include::put-trained-models-aliases.asciidoc[leveloffset=+2]
 include::put-trained-model-definition-part.asciidoc[leveloffset=+2]
@@ -11,9 +13,7 @@ include::delete-trained-models.asciidoc[leveloffset=+2]
 include::get-trained-models.asciidoc[leveloffset=+2]
 include::get-trained-models-stats.asciidoc[leveloffset=+2]
 //INFER
-include::infer-trained-model.asciidoc[leveloffset=+2][leveloffset=+2]
-//UPDATE
-include::clear-trained-model-deployment-cache.asciidoc[leveloffset=+2]
+include::infer-trained-model.asciidoc[leveloffset=+2]
 //START/STOP
 include::start-trained-model-deployment.asciidoc[leveloffset=+2]
 include::stop-trained-model-deployment.asciidoc[leveloffset=+2]

--- a/docs/reference/ml/trained-models/apis/ml-trained-models-apis.asciidoc
+++ b/docs/reference/ml/trained-models/apis/ml-trained-models-apis.asciidoc
@@ -4,6 +4,7 @@
 
 You can use the following APIs to perform model management operations:
 
+* <<clear-trained-model-deployment-cache>>
 * <<put-trained-models>>
 * <<put-trained-model-definition-part>>
 * <<put-trained-model-vocabulary>>


### PR DESCRIPTION
Backports the following commits to 8.5:
 - [DOCS] Add links to clear trained model deployment cache API (#90727)