### PR TITLE
Update min version for the diagnosis yaml test

### DIFF
--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/health/40_diagnosis.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/health/40_diagnosis.yml
@@ -1,8 +1,8 @@
 ---
 "Diagnosis":
   - skip:
-      version: "- 8.4.99"
-      reason: "diagnosis was redefined in 8.5.0"
+      version: "- 8.5.99"
+      reason: "diagnosis was redefined in 8.6.0"
 
   - do:
       indices.create:


### PR DESCRIPTION
We reverted the diagnosis redesign in 8.5 ( https://github.com/elastic/elasticsearch/pull/90722 ) so this test shouldn't run in 8.5