### PR TITLE
docs: clarify scope of terms query as exact match

### DIFF
--- a/docs/reference/query-dsl/terms-query.asciidoc
+++ b/docs/reference/query-dsl/terms-query.asciidoc
@@ -12,7 +12,7 @@ except you can search for multiple values.
 [[terms-query-ex-request]]
 ==== Example request
 
-The following search returns documents where the `user.id` field contains `kimchy`
+The following search returns documents where the `user.id` field contains exactly `kimchy`
 or `elkbee`.
 
 [source,console]


### PR DESCRIPTION
in the leading paragraph of the terms query docs, it refers to a field "containing" a given search value. however, it may not be obvious that this is an exact match against a keyword field (or analyzed field with `fielddata` enabled. while the exact match is explained later on the page, doc skimmers may possibly miss this detail.

<!--
Thank you for your interest in and contributing to Elasticsearch! There
are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your
attention.
-->

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/elasticsearch/blob/main/CONTRIBUTING.md)?
- If submitting code, have you built your formula locally prior to submission with `gradle check`?
- If submitting code, is your pull request against main? Unless there is a good reason otherwise, we prefer pull requests against main and will backport as needed.
- If submitting code, have you checked that your submission is for an [OS and architecture that we support](https://www.elastic.co/support/matrix#show_os)?
- If you are submitting this code for a class then read our [policy](https://github.com/elastic/elasticsearch/blob/main/CONTRIBUTING.md#contributing-as-part-of-a-class) for that.
