### PR TITLE
Remove extra SearchService constructor

### DIFF
--- a/server/src/main/java/org/elasticsearch/search/SearchService.java
+++ b/server/src/main/java/org/elasticsearch/search/SearchService.java
@@ -281,31 +281,6 @@ public class SearchService extends AbstractLifecycleComponent implements IndexEv
         FetchPhase fetchPhase,
         ResponseCollectorService responseCollectorService,
         CircuitBreakerService circuitBreakerService,
-        ExecutorSelector executorSelector
-    ) {
-        this(
-            clusterService,
-            indicesService,
-            threadPool,
-            scriptService,
-            bigArrays,
-            fetchPhase,
-            responseCollectorService,
-            circuitBreakerService,
-            executorSelector,
-            Tracer.NOOP
-        );
-    }
-
-    public SearchService(
-        ClusterService clusterService,
-        IndicesService indicesService,
-        ThreadPool threadPool,
-        ScriptService scriptService,
-        BigArrays bigArrays,
-        FetchPhase fetchPhase,
-        ResponseCollectorService responseCollectorService,
-        CircuitBreakerService circuitBreakerService,
         ExecutorSelector executorSelector,
         Tracer tracer
     ) {

--- a/server/src/test/java/org/elasticsearch/snapshots/SnapshotResiliencyTests.java
+++ b/server/src/test/java/org/elasticsearch/snapshots/SnapshotResiliencyTests.java
@@ -176,6 +176,7 @@ import org.elasticsearch.search.fetch.FetchPhase;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.disruption.DisruptableMockTransport;
 import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.tracing.Tracer;
 import org.elasticsearch.transport.BytesRefRecycler;
 import org.elasticsearch.transport.TransportService;
 import org.elasticsearch.xcontent.NamedXContentRegistry;
@@ -1977,7 +1978,8 @@ public class SnapshotResiliencyTests extends ESTestCase {
                     new FetchPhase(Collections.emptyList()),
                     responseCollectorService,
                     new NoneCircuitBreakerService(),
-                    EmptySystemIndices.INSTANCE.getExecutorSelector()
+                    EmptySystemIndices.INSTANCE.getExecutorSelector(),
+                    Tracer.NOOP
                 );
                 SearchPhaseController searchPhaseController = new SearchPhaseController(searchService::aggReduceContextBuilder);
                 actions.put(


### PR DESCRIPTION
It's nice to avoid introducing too many constructors -- if we did this for all
arguments, we could have a lot of "telescoping" going on.

Follow up to #90574.