### PR TITLE
Use immutable map and list readers instead of wrappers in some obvious spots

### DIFF
--- a/modules/ingest-geoip/src/main/java/org/elasticsearch/ingest/geoip/GeoIpTaskState.java
+++ b/modules/ingest-geoip/src/main/java/org/elasticsearch/ingest/geoip/GeoIpTaskState.java
@@ -67,10 +67,10 @@ class GeoIpTaskState implements PersistentTaskState, VersionedNamedWriteable {
     }
 
     GeoIpTaskState(StreamInput input) throws IOException {
-        databases = Collections.unmodifiableMap(input.readMap(StreamInput::readString, in -> {
+        databases = input.readImmutableMap(StreamInput::readString, in -> {
             long lastUpdate = in.readLong();
             return new Metadata(lastUpdate, in.readVInt(), in.readVInt(), in.readString(), in.readLong());
-        }));
+        });
     }
 
     public GeoIpTaskState put(String name, Metadata metadata) {

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/action/PainlessContextClassBindingInfo.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/action/PainlessContextClassBindingInfo.java
@@ -77,7 +77,7 @@ public class PainlessContextClassBindingInfo implements Writeable, ToXContentObj
         name = in.readString();
         rtn = in.readString();
         readOnly = in.readInt();
-        parameters = Collections.unmodifiableList(in.readStringList());
+        parameters = in.readImmutableList(StreamInput::readString);
     }
 
     @Override

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/action/PainlessContextClassInfo.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/action/PainlessContextClassInfo.java
@@ -124,11 +124,11 @@ public class PainlessContextClassInfo implements Writeable, ToXContentObject {
     public PainlessContextClassInfo(StreamInput in) throws IOException {
         name = in.readString();
         imported = in.readBoolean();
-        constructors = Collections.unmodifiableList(in.readList(PainlessContextConstructorInfo::new));
-        staticMethods = Collections.unmodifiableList(in.readList(PainlessContextMethodInfo::new));
-        methods = Collections.unmodifiableList(in.readList(PainlessContextMethodInfo::new));
-        staticFields = Collections.unmodifiableList(in.readList(PainlessContextFieldInfo::new));
-        fields = Collections.unmodifiableList(in.readList(PainlessContextFieldInfo::new));
+        constructors = in.readImmutableList(PainlessContextConstructorInfo::new);
+        staticMethods = in.readImmutableList(PainlessContextMethodInfo::new);
+        methods = in.readImmutableList(PainlessContextMethodInfo::new);
+        staticFields = in.readImmutableList(PainlessContextFieldInfo::new);
+        fields = in.readImmutableList(PainlessContextFieldInfo::new);
     }
 
     @Override

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/action/PainlessContextConstructorInfo.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/action/PainlessContextConstructorInfo.java
@@ -62,7 +62,7 @@ public class PainlessContextConstructorInfo implements Writeable, ToXContentObje
 
     public PainlessContextConstructorInfo(StreamInput in) throws IOException {
         declaring = in.readString();
-        parameters = Collections.unmodifiableList(in.readStringList());
+        parameters = in.readImmutableList(StreamInput::readString);
     }
 
     @Override

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/action/PainlessContextInfo.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/action/PainlessContextInfo.java
@@ -148,10 +148,10 @@ public class PainlessContextInfo implements Writeable, ToXContentObject {
 
     public PainlessContextInfo(StreamInput in) throws IOException {
         name = in.readString();
-        classes = Collections.unmodifiableList(in.readList(PainlessContextClassInfo::new));
-        importedMethods = Collections.unmodifiableList(in.readList(PainlessContextMethodInfo::new));
-        classBindings = Collections.unmodifiableList(in.readList(PainlessContextClassBindingInfo::new));
-        instanceBindings = Collections.unmodifiableList(in.readList(PainlessContextInstanceBindingInfo::new));
+        classes = in.readImmutableList(PainlessContextClassInfo::new);
+        importedMethods = in.readImmutableList(PainlessContextMethodInfo::new);
+        classBindings = in.readImmutableList(PainlessContextClassBindingInfo::new);
+        instanceBindings = in.readImmutableList(PainlessContextInstanceBindingInfo::new);
     }
 
     @Override

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/action/PainlessContextInstanceBindingInfo.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/action/PainlessContextInstanceBindingInfo.java
@@ -72,7 +72,7 @@ public class PainlessContextInstanceBindingInfo implements Writeable, ToXContent
         declaring = in.readString();
         name = in.readString();
         rtn = in.readString();
-        parameters = Collections.unmodifiableList(in.readStringList());
+        parameters = in.readImmutableList(StreamInput::readString);
     }
 
     @Override

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/action/PainlessContextMethodInfo.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/action/PainlessContextMethodInfo.java
@@ -71,7 +71,7 @@ public class PainlessContextMethodInfo implements Writeable, ToXContentObject {
         declaring = in.readString();
         name = in.readString();
         rtn = in.readString();
-        parameters = Collections.unmodifiableList(in.readStringList());
+        parameters = in.readImmutableList(StreamInput::readString);
     }
 
     @Override

--- a/modules/percolator/src/main/java/org/elasticsearch/percolator/PercolateQueryBuilder.java
+++ b/modules/percolator/src/main/java/org/elasticsearch/percolator/PercolateQueryBuilder.java
@@ -233,7 +233,7 @@ public class PercolateQueryBuilder extends AbstractQueryBuilder<PercolateQueryBu
         } else {
             indexedDocumentVersion = null;
         }
-        documents = in.readList(StreamInput::readBytesReference);
+        documents = in.readImmutableList(StreamInput::readBytesReference);
         if (documents.isEmpty() == false) {
             documentXContentType = in.readEnum(XContentType.class);
         } else {

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/migration/GetFeatureUpgradeStatusResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/migration/GetFeatureUpgradeStatusResponse.java
@@ -48,7 +48,7 @@ public class GetFeatureUpgradeStatusResponse extends ActionResponse implements T
      */
     public GetFeatureUpgradeStatusResponse(StreamInput in) throws IOException {
         super(in);
-        this.featureUpgradeStatuses = in.readList(FeatureUpgradeStatus::new);
+        this.featureUpgradeStatuses = in.readImmutableList(FeatureUpgradeStatus::new);
         this.upgradeStatus = in.readEnum(UpgradeStatus.class);
     }
 
@@ -154,7 +154,7 @@ public class GetFeatureUpgradeStatusResponse extends ActionResponse implements T
             this.featureName = in.readString();
             this.minimumIndexVersion = Version.readVersion(in);
             this.upgradeStatus = in.readEnum(UpgradeStatus.class);
-            this.indexInfos = in.readList(IndexInfo::new);
+            this.indexInfos = in.readImmutableList(IndexInfo::new);
         }
 
         public String getFeatureName() {

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/migration/PostFeatureUpgradeResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/migration/PostFeatureUpgradeResponse.java
@@ -59,7 +59,7 @@ public class PostFeatureUpgradeResponse extends ActionResponse implements ToXCon
     public PostFeatureUpgradeResponse(StreamInput in) throws IOException {
         super(in);
         this.accepted = in.readBoolean();
-        this.features = in.readList(Feature::new);
+        this.features = in.readImmutableList(Feature::new);
         this.reason = in.readOptionalString();
         this.elasticsearchException = in.readOptionalWriteable(ElasticsearchException::new);
     }

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/node/info/PluginsAndModules.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/node/info/PluginsAndModules.java
@@ -36,7 +36,7 @@ public class PluginsAndModules implements ReportingService.Info {
 
     public PluginsAndModules(StreamInput in) throws IOException {
         this.plugins = in.readImmutableList(PluginRuntimeInfo::new);
-        this.modules = Collections.unmodifiableList(in.readList(PluginDescriptor::new));
+        this.modules = in.readImmutableList(PluginDescriptor::new);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/node/tasks/list/ListTasksResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/node/tasks/list/ListTasksResponse.java
@@ -54,12 +54,12 @@ public class ListTasksResponse extends BaseTasksResponse implements ToXContentOb
         List<? extends ElasticsearchException> nodeFailures
     ) {
         super(taskFailures, nodeFailures);
-        this.tasks = tasks == null ? Collections.emptyList() : List.copyOf(tasks);
+        this.tasks = tasks == null ? List.of() : List.copyOf(tasks);
     }
 
     public ListTasksResponse(StreamInput in) throws IOException {
         super(in);
-        tasks = Collections.unmodifiableList(in.readList(TaskInfo::from));
+        tasks = in.readImmutableList(TaskInfo::from);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/remote/RemoteInfoResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/remote/RemoteInfoResponse.java
@@ -21,11 +21,11 @@ import java.util.List;
 
 public final class RemoteInfoResponse extends ActionResponse implements ToXContentObject {
 
-    private List<RemoteConnectionInfo> infos;
+    private final List<RemoteConnectionInfo> infos;
 
     RemoteInfoResponse(StreamInput in) throws IOException {
         super(in);
-        infos = in.readList(RemoteConnectionInfo::new);
+        infos = in.readImmutableList(RemoteConnectionInfo::new);
     }
 
     public RemoteInfoResponse(Collection<RemoteConnectionInfo> infos) {

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/features/GetSnapshottableFeaturesResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/features/GetSnapshottableFeaturesResponse.java
@@ -16,7 +16,6 @@ import org.elasticsearch.xcontent.ToXContentObject;
 import org.elasticsearch.xcontent.XContentBuilder;
 
 import java.io.IOException;
-import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 
@@ -25,12 +24,12 @@ public class GetSnapshottableFeaturesResponse extends ActionResponse implements 
     private final List<SnapshottableFeature> snapshottableFeatures;
 
     public GetSnapshottableFeaturesResponse(List<SnapshottableFeature> features) {
-        this.snapshottableFeatures = Collections.unmodifiableList(features);
+        this.snapshottableFeatures = List.copyOf(features);
     }
 
     public GetSnapshottableFeaturesResponse(StreamInput in) throws IOException {
         super(in);
-        snapshottableFeatures = in.readList(SnapshottableFeature::new);
+        snapshottableFeatures = in.readImmutableList(SnapshottableFeature::new);
     }
 
     public List<SnapshottableFeature> getSnapshottableFeatures() {

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/get/GetSnapshotsResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/get/GetSnapshotsResponse.java
@@ -92,7 +92,7 @@ public class GetSnapshotsResponse extends ActionResponse implements ChunkedToXCo
     }
 
     public GetSnapshotsResponse(StreamInput in) throws IOException {
-        this.snapshots = in.readList(SnapshotInfo::readFrom);
+        this.snapshots = in.readImmutableList(SnapshotInfo::readFrom);
         if (in.getVersion().onOrAfter(GetSnapshotsRequest.MULTIPLE_REPOSITORIES_SUPPORT_ADDED)) {
             final Map<String, ElasticsearchException> failedResponses = in.readMap(StreamInput::readString, StreamInput::readException);
             this.failures = Collections.unmodifiableMap(failedResponses);

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/status/SnapshotStatus.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/status/SnapshotStatus.java
@@ -27,7 +27,6 @@ import org.elasticsearch.xcontent.XContentParser;
 
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -64,7 +63,7 @@ public class SnapshotStatus implements ToXContentObject, Writeable {
     SnapshotStatus(StreamInput in) throws IOException {
         snapshot = new Snapshot(in);
         state = State.fromValue(in.readByte());
-        shards = Collections.unmodifiableList(in.readList(SnapshotIndexShardStatus::new));
+        shards = in.readImmutableList(SnapshotIndexShardStatus::new);
         includeGlobalState = in.readOptionalBoolean();
         final long startTime = in.readLong();
         final long time = in.readLong();

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/status/SnapshotsStatusResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/status/SnapshotsStatusResponse.java
@@ -18,7 +18,6 @@ import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xcontent.XContentParser;
 
 import java.io.IOException;
-import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 
@@ -33,7 +32,7 @@ public class SnapshotsStatusResponse extends ActionResponse implements ToXConten
 
     public SnapshotsStatusResponse(StreamInput in) throws IOException {
         super(in);
-        snapshots = Collections.unmodifiableList(in.readList(SnapshotStatus::new));
+        snapshots = in.readImmutableList(SnapshotStatus::new);
     }
 
     SnapshotsStatusResponse(List<SnapshotStatus> snapshots) {

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/status/TransportNodesSnapshotsStatus.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/status/TransportNodesSnapshotsStatus.java
@@ -195,9 +195,7 @@ public class TransportNodesSnapshotsStatus extends TransportNodesAction<
 
         public NodeSnapshotStatus(StreamInput in) throws IOException {
             super(in);
-            status = unmodifiableMap(
-                in.readMap(Snapshot::new, input -> unmodifiableMap(input.readMap(ShardId::new, SnapshotIndexShardStatus::new)))
-            );
+            status = in.readImmutableMap(Snapshot::new, input -> input.readImmutableOpenMap(ShardId::new, SnapshotIndexShardStatus::new));
         }
 
         public NodeSnapshotStatus(DiscoveryNode node, Map<Snapshot, Map<ShardId, SnapshotIndexShardStatus>> status) {

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/stats/MappingStats.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/stats/MappingStats.java
@@ -217,7 +217,7 @@ public final class MappingStats implements ToXContentFragment, Writeable {
             totalMappingSizeBytes = null;
         }
         fieldTypeStats = in.readImmutableList(FieldStats::new);
-        runtimeFieldStats = in.readList(RuntimeFieldStats::new);
+        runtimeFieldStats = in.readImmutableList(RuntimeFieldStats::new);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/stats/MappingStats.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/stats/MappingStats.java
@@ -216,8 +216,8 @@ public final class MappingStats implements ToXContentFragment, Writeable {
             totalDeduplicatedFieldCount = null;
             totalMappingSizeBytes = null;
         }
-        fieldTypeStats = Collections.unmodifiableList(in.readList(FieldStats::new));
-        runtimeFieldStats = Collections.unmodifiableList(in.readList(RuntimeFieldStats::new));
+        fieldTypeStats = in.readImmutableList(FieldStats::new);
+        runtimeFieldStats = in.readList(RuntimeFieldStats::new);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/close/CloseIndexResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/close/CloseIndexResponse.java
@@ -32,7 +32,7 @@ public class CloseIndexResponse extends ShardsAcknowledgedResponse {
 
     CloseIndexResponse(StreamInput in) throws IOException {
         super(in, true);
-        indices = List.copyOf(in.readList(IndexResult::new));
+        indices = in.readImmutableList(IndexResult::new);
     }
 
     public CloseIndexResponse(final boolean acknowledged, final boolean shardsAcknowledged, final List<IndexResult> indices) {

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/mapping/get/GetFieldMappingsResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/mapping/get/GetFieldMappingsResponse.java
@@ -31,7 +31,6 @@ import java.util.Collections;
 import java.util.Map;
 import java.util.Objects;
 
-import static java.util.Collections.unmodifiableMap;
 import static org.elasticsearch.rest.BaseRestHandler.DEFAULT_INCLUDE_TYPE_NAME_POLICY;
 
 /**
@@ -52,7 +51,7 @@ public class GetFieldMappingsResponse extends ActionResponse implements ToXConte
 
     GetFieldMappingsResponse(StreamInput in) throws IOException {
         super(in);
-        mappings = unmodifiableMap(in.readMap(StreamInput::readString, mapIn -> {
+        mappings = in.readImmutableMap(StreamInput::readString, mapIn -> {
             if (mapIn.getVersion().before(Version.V_8_0_0)) {
                 int typesSize = mapIn.readVInt();
                 assert typesSize == 1 || typesSize == 0 : "Expected 0 or 1 types but got " + typesSize;
@@ -61,10 +60,11 @@ public class GetFieldMappingsResponse extends ActionResponse implements ToXConte
                 }
                 mapIn.readString(); // type
             }
-            return unmodifiableMap(
-                mapIn.readMap(StreamInput::readString, inpt -> new FieldMappingMetadata(inpt.readString(), inpt.readBytesReference()))
+            return mapIn.readImmutableMap(
+                StreamInput::readString,
+                inpt -> new FieldMappingMetadata(inpt.readString(), inpt.readBytesReference())
             );
-        }));
+        });
     }
 
     /** returns the retrieved field mapping. The return map keys are index, field (as specified in the request). */

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/readonly/AddIndexBlockResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/readonly/AddIndexBlockResponse.java
@@ -33,7 +33,7 @@ public class AddIndexBlockResponse extends ShardsAcknowledgedResponse {
 
     AddIndexBlockResponse(StreamInput in) throws IOException {
         super(in, true);
-        indices = List.copyOf(in.readList(AddBlockResult::new));
+        indices = in.readImmutableList(AddBlockResult::new);
     }
 
     public AddIndexBlockResponse(final boolean acknowledged, final boolean shardsAcknowledged, final List<AddBlockResult> indices) {

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/shards/IndicesShardStoresResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/shards/IndicesShardStoresResponse.java
@@ -248,7 +248,7 @@ public class IndicesShardStoresResponse extends ActionResponse implements ToXCon
             StreamInput::readString,
             i -> i.readImmutableMap(StreamInput::readInt, j -> j.readImmutableList(StoreStatus::new))
         );
-        failures = Collections.unmodifiableList(in.readList(Failure::readFailure));
+        failures = in.readImmutableList(Failure::readFailure);
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/cluster/SnapshotDeletionsInProgress.java
+++ b/server/src/main/java/org/elasticsearch/cluster/SnapshotDeletionsInProgress.java
@@ -54,7 +54,7 @@ public class SnapshotDeletionsInProgress extends AbstractNamedDiffable<Custom> i
     }
 
     public SnapshotDeletionsInProgress(StreamInput in) throws IOException {
-        this(in.readList(Entry::new));
+        this(in.readImmutableList(Entry::new));
     }
 
     private static boolean assertNoConcurrentDeletionsForSameRepository(List<Entry> entries) {
@@ -220,7 +220,7 @@ public class SnapshotDeletionsInProgress extends AbstractNamedDiffable<Custom> i
 
         public Entry(StreamInput in) throws IOException {
             this.repoName = in.readString();
-            this.snapshots = in.readList(SnapshotId::new);
+            this.snapshots = in.readImmutableList(SnapshotId::new);
             this.startTime = in.readVLong();
             this.repositoryStateId = in.readLong();
             this.state = State.readFrom(in);

--- a/server/src/main/java/org/elasticsearch/cluster/SnapshotsInProgress.java
+++ b/server/src/main/java/org/elasticsearch/cluster/SnapshotsInProgress.java
@@ -1610,7 +1610,7 @@ public class SnapshotsInProgress extends AbstractNamedDiffable<Custom> implement
             this.mapDiff = DiffableUtils.readJdkMapDiff(
                 in,
                 DiffableUtils.getStringKeySerializer(),
-                i -> new ByRepo(i.readList(Entry::readFrom)),
+                i -> new ByRepo(i.readImmutableList(Entry::readFrom)),
                 i -> new ByRepo.ByRepoDiff(
                     DiffableUtils.readJdkMapDiff(i, DiffableUtils.getStringKeySerializer(), Entry::readFrom, EntryDiff::new),
                     DiffableUtils.readJdkMapDiff(i, DiffableUtils.getStringKeySerializer(), ByRepo.INT_DIFF_VALUE_SERIALIZER)

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/DataStream.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/DataStream.java
@@ -533,7 +533,7 @@ public final class DataStream implements SimpleDiffable<DataStream>, ToXContentO
 
     static List<Index> readIndices(StreamInput in) throws IOException {
         in.readString(); // timestamp field, which is always @timestamp
-        return in.readList(Index::new);
+        return in.readImmutableList(Index::new);
     }
 
     public static Diff<DataStream> readDiffFrom(StreamInput in) throws IOException {

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/IndexGraveyard.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/IndexGraveyard.java
@@ -75,7 +75,7 @@ public final class IndexGraveyard implements Metadata.Custom {
     }
 
     public IndexGraveyard(final StreamInput in) throws IOException {
-        this.tombstones = Collections.unmodifiableList(in.readList(Tombstone::new));
+        this.tombstones = in.readImmutableList(Tombstone::new);
     }
 
     @Override
@@ -256,7 +256,7 @@ public final class IndexGraveyard implements Metadata.Custom {
         private final int removedCount;
 
         IndexGraveyardDiff(final StreamInput in) throws IOException {
-            added = Collections.unmodifiableList(in.readList((streamInput) -> new Tombstone(streamInput)));
+            added = in.readImmutableList(Tombstone::new);
             removedCount = in.readVInt();
         }
 

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/RepositoriesMetadata.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/RepositoriesMetadata.java
@@ -171,7 +171,7 @@ public class RepositoriesMetadata extends AbstractNamedDiffable<Custom> implemen
     }
 
     public RepositoriesMetadata(StreamInput in) throws IOException {
-        this.repositories = in.readList(RepositoryMetadata::new);
+        this.repositories = in.readImmutableList(RepositoryMetadata::new);
     }
 
     public static NamedDiff<Custom> readDiffFrom(StreamInput in) throws IOException {

--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/AbstractAllocationDecision.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/AbstractAllocationDecision.java
@@ -18,7 +18,6 @@ import org.elasticsearch.xcontent.ToXContentFragment;
 import org.elasticsearch.xcontent.XContentBuilder;
 
 import java.io.IOException;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -40,7 +39,7 @@ public abstract class AbstractAllocationDecision implements ToXContentFragment, 
 
     protected AbstractAllocationDecision(StreamInput in) throws IOException {
         targetNode = in.readOptionalWriteable(DiscoveryNode::new);
-        nodeDecisions = in.readBoolean() ? Collections.unmodifiableList(in.readList(NodeAllocationResult::new)) : null;
+        nodeDecisions = in.readBoolean() ? in.readImmutableList(NodeAllocationResult::new) : null;
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/index/query/MoreLikeThisQueryBuilder.java
+++ b/server/src/main/java/org/elasticsearch/index/query/MoreLikeThisQueryBuilder.java
@@ -502,9 +502,9 @@ public class MoreLikeThisQueryBuilder extends AbstractQueryBuilder<MoreLikeThisQ
         super(in);
         fields = in.readOptionalStringArray();
         likeTexts = in.readStringArray();
-        likeItems = in.readList(Item::new).toArray(new Item[0]);
+        likeItems = in.readArray(Item::new, Item[]::new);
         unlikeTexts = in.readStringArray();
-        unlikeItems = in.readList(Item::new).toArray(new Item[0]);
+        unlikeItems = in.readArray(Item::new, Item[]::new);
         maxQueryTerms = in.readVInt();
         minTermFreq = in.readVInt();
         minDocFreq = in.readVInt();

--- a/server/src/main/java/org/elasticsearch/index/query/functionscore/FunctionScoreQueryBuilder.java
+++ b/server/src/main/java/org/elasticsearch/index/query/functionscore/FunctionScoreQueryBuilder.java
@@ -138,7 +138,7 @@ public class FunctionScoreQueryBuilder extends AbstractQueryBuilder<FunctionScor
     public FunctionScoreQueryBuilder(StreamInput in) throws IOException {
         super(in);
         query = in.readNamedWriteable(QueryBuilder.class);
-        filterFunctionBuilders = in.readList(FilterFunctionBuilder::new).toArray(new FilterFunctionBuilder[0]);
+        filterFunctionBuilders = in.readArray(FilterFunctionBuilder::new, FilterFunctionBuilder[]::new);
         maxBoost = in.readFloat();
         minScore = in.readOptionalFloat();
         boostMode = in.readOptionalWriteable(CombineFunction::readFromStream);

--- a/server/src/main/java/org/elasticsearch/indices/store/TransportNodesListShardStoreMetadata.java
+++ b/server/src/main/java/org/elasticsearch/indices/store/TransportNodesListShardStoreMetadata.java
@@ -204,7 +204,7 @@ public class TransportNodesListShardStoreMetadata extends TransportNodesAction<
                 new ShardId(in);
             }
             final var metadataSnapshot = Store.MetadataSnapshot.readFrom(in);
-            final var peerRecoveryRetentionLeases = in.readList(RetentionLease::new);
+            final var peerRecoveryRetentionLeases = in.readImmutableList(RetentionLease::new);
             if (metadataSnapshot == Store.MetadataSnapshot.EMPTY && peerRecoveryRetentionLeases.isEmpty()) {
                 return EMPTY;
             } else {

--- a/server/src/main/java/org/elasticsearch/snapshots/RestoreInfo.java
+++ b/server/src/main/java/org/elasticsearch/snapshots/RestoreInfo.java
@@ -18,7 +18,6 @@ import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xcontent.XContentParser;
 
 import java.io.IOException;
-import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 
@@ -48,7 +47,7 @@ public class RestoreInfo implements ToXContentObject, Writeable {
 
     public RestoreInfo(StreamInput in) throws IOException {
         name = in.readString();
-        indices = Collections.unmodifiableList(in.readStringList());
+        indices = in.readImmutableList(StreamInput::readString);
         totalShards = in.readVInt();
         successfulShards = in.readVInt();
     }

--- a/server/src/main/java/org/elasticsearch/snapshots/SnapshotFeatureInfo.java
+++ b/server/src/main/java/org/elasticsearch/snapshots/SnapshotFeatureInfo.java
@@ -48,7 +48,7 @@ public class SnapshotFeatureInfo implements Writeable, ToXContentObject {
     }
 
     public SnapshotFeatureInfo(final StreamInput in) throws IOException {
-        this(in.readString(), in.readStringList());
+        this(in.readString(), in.readImmutableList(StreamInput::readString));
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/threadpool/ThreadPoolInfo.java
+++ b/server/src/main/java/org/elasticsearch/threadpool/ThreadPoolInfo.java
@@ -14,7 +14,6 @@ import org.elasticsearch.node.ReportingService;
 import org.elasticsearch.xcontent.XContentBuilder;
 
 import java.io.IOException;
-import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 
@@ -23,11 +22,11 @@ public class ThreadPoolInfo implements ReportingService.Info, Iterable<ThreadPoo
     private final List<ThreadPool.Info> infos;
 
     public ThreadPoolInfo(List<ThreadPool.Info> infos) {
-        this.infos = Collections.unmodifiableList(infos);
+        this.infos = List.copyOf(infos);
     }
 
     public ThreadPoolInfo(StreamInput in) throws IOException {
-        this.infos = Collections.unmodifiableList(in.readList(ThreadPool.Info::new));
+        this.infos = in.readImmutableList(ThreadPool.Info::new);
     }
 
     @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ccr/action/ShardFollowTask.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ccr/action/ShardFollowTask.java
@@ -122,7 +122,7 @@ public class ShardFollowTask extends ImmutableFollowParameters implements Persis
         this.remoteCluster = remoteCluster;
         this.followShardId = followShardId;
         this.leaderShardId = leaderShardId;
-        this.headers = Collections.unmodifiableMap(in.readMap(StreamInput::readString, StreamInput::readString));
+        this.headers = in.readImmutableMap(StreamInput::readString, StreamInput::readString);
     }
 
     public String getRemoteCluster() {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/LifecyclePolicy.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/LifecyclePolicy.java
@@ -104,7 +104,7 @@ public class LifecyclePolicy implements SimpleDiffable<LifecyclePolicy>, ToXCont
     public LifecyclePolicy(StreamInput in) throws IOException {
         type = in.readNamedWriteable(LifecycleType.class);
         name = in.readString();
-        phases = Collections.unmodifiableMap(in.readMap(StreamInput::readString, Phase::new));
+        phases = in.readImmutableMap(StreamInput::readString, Phase::new);
         this.metadata = in.readMap();
     }
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/InferModelAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/InferModelAction.java
@@ -122,7 +122,7 @@ public class InferModelAction extends ActionType<InferModelAction.Response> {
         public Request(StreamInput in) throws IOException {
             super(in);
             this.modelId = in.readString();
-            this.objectsToInfer = Collections.unmodifiableList(in.readList(StreamInput::readMap));
+            this.objectsToInfer = in.readImmutableList(StreamInput::readMap);
             this.update = in.readNamedWriteable(InferenceConfigUpdate.class);
             this.previouslyLicensed = in.readBoolean();
             if (in.getVersion().onOrAfter(Version.V_8_3_0)) {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/InferTrainedModelDeploymentAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/InferTrainedModelDeploymentAction.java
@@ -103,7 +103,7 @@ public class InferTrainedModelDeploymentAction extends ActionType<InferTrainedMo
         public Request(StreamInput in) throws IOException {
             super(in);
             deploymentId = in.readString();
-            docs = Collections.unmodifiableList(in.readList(StreamInput::readMap));
+            docs = in.readImmutableList(StreamInput::readMap);
             update = in.readOptionalNamedWriteable(InferenceConfigUpdate.class);
             inferenceTimeout = in.readOptionalTimeValue();
             if (in.getVersion().onOrAfter(Version.V_8_3_0)) {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/datafeed/DatafeedConfig.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/datafeed/DatafeedConfig.java
@@ -279,7 +279,7 @@ public class DatafeedConfig implements SimpleDiffable<DatafeedConfig>, ToXConten
         this.queryDelay = in.readOptionalTimeValue();
         this.frequency = in.readOptionalTimeValue();
         if (in.readBoolean()) {
-            this.indices = Collections.unmodifiableList(in.readStringList());
+            this.indices = in.readImmutableList(StreamInput::readString);
         } else {
             this.indices = null;
         }
@@ -289,13 +289,13 @@ public class DatafeedConfig implements SimpleDiffable<DatafeedConfig>, ToXConten
         this.aggProvider = in.readOptionalWriteable(AggProvider::fromStream);
 
         if (in.readBoolean()) {
-            this.scriptFields = Collections.unmodifiableList(in.readList(SearchSourceBuilder.ScriptField::new));
+            this.scriptFields = in.readImmutableList(SearchSourceBuilder.ScriptField::new);
         } else {
             this.scriptFields = null;
         }
         this.scrollSize = in.readOptionalVInt();
         this.chunkingConfig = in.readOptionalWriteable(ChunkingConfig::new);
-        this.headers = Collections.unmodifiableMap(in.readMap(StreamInput::readString, StreamInput::readString));
+        this.headers = in.readImmutableMap(StreamInput::readString, StreamInput::readString);
         delayedDataCheckConfig = in.readOptionalWriteable(DelayedDataCheckConfig::new);
         maxEmptySearches = in.readOptionalVInt();
         indicesOptions = IndicesOptions.readIndicesOptions(in);
@@ -792,7 +792,7 @@ public class DatafeedConfig implements SimpleDiffable<DatafeedConfig>, ToXConten
             this.queryDelay = in.readOptionalTimeValue();
             this.frequency = in.readOptionalTimeValue();
             if (in.readBoolean()) {
-                this.indices = Collections.unmodifiableList(in.readStringList());
+                this.indices = in.readImmutableList(StreamInput::readString);
             } else {
                 this.indices = null;
             }
@@ -802,13 +802,13 @@ public class DatafeedConfig implements SimpleDiffable<DatafeedConfig>, ToXConten
             this.aggProvider = in.readOptionalWriteable(AggProvider::fromStream);
 
             if (in.readBoolean()) {
-                this.scriptFields = Collections.unmodifiableList(in.readList(SearchSourceBuilder.ScriptField::new));
+                this.scriptFields = in.readImmutableList(SearchSourceBuilder.ScriptField::new);
             } else {
                 this.scriptFields = null;
             }
             this.scrollSize = in.readOptionalVInt();
             this.chunkingConfig = in.readOptionalWriteable(ChunkingConfig::new);
-            this.headers = Collections.unmodifiableMap(in.readMap(StreamInput::readString, StreamInput::readString));
+            this.headers = in.readImmutableMap(StreamInput::readString, StreamInput::readString);
             delayedDataCheckConfig = in.readOptionalWriteable(DelayedDataCheckConfig::new);
             maxEmptySearches = in.readOptionalVInt();
             if (in.readBoolean()) {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/DataFrameAnalyticsConfig.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/DataFrameAnalyticsConfig.java
@@ -180,7 +180,7 @@ public class DataFrameAnalyticsConfig implements ToXContentObject, Writeable {
         this.analysis = in.readNamedWriteable(DataFrameAnalysis.class);
         this.analyzedFields = in.readOptionalWriteable(FetchSourceContext::readFrom);
         this.modelMemoryLimit = in.readOptionalWriteable(ByteSizeValue::new);
-        this.headers = Collections.unmodifiableMap(in.readMap(StreamInput::readString, StreamInput::readString));
+        this.headers = in.readImmutableMap(StreamInput::readString, StreamInput::readString);
         this.createTime = in.readOptionalInstant();
         this.version = in.readBoolean() ? Version.readVersion(in) : null;
         this.allowLazyStart = in.readBoolean();

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/evaluation/classification/Accuracy.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/evaluation/classification/Accuracy.java
@@ -239,7 +239,7 @@ public class Accuracy implements EvaluationMetric {
         }
 
         public Result(StreamInput in) throws IOException {
-            this.classes = Collections.unmodifiableList(in.readList(PerClassSingleValue::new));
+            this.classes = in.readImmutableList(PerClassSingleValue::new);
             this.overallAccuracy = in.readDouble();
         }
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/evaluation/classification/MulticlassConfusionMatrix.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/evaluation/classification/MulticlassConfusionMatrix.java
@@ -286,7 +286,7 @@ public class MulticlassConfusionMatrix implements EvaluationMetric {
         }
 
         public Result(StreamInput in) throws IOException {
-            this.actualClasses = Collections.unmodifiableList(in.readList(ActualClass::new));
+            this.actualClasses = in.readImmutableList(ActualClass::new);
             this.otherActualClassCount = in.readVLong();
         }
 
@@ -382,7 +382,7 @@ public class MulticlassConfusionMatrix implements EvaluationMetric {
         public ActualClass(StreamInput in) throws IOException {
             this.actualClass = in.readString();
             this.actualClassDocCount = in.readVLong();
-            this.predictedClasses = Collections.unmodifiableList(in.readList(PredictedClass::new));
+            this.predictedClasses = in.readImmutableList(PredictedClass::new);
             this.otherPredictedClassDocCount = in.readVLong();
         }
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/evaluation/classification/Precision.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/evaluation/classification/Precision.java
@@ -232,7 +232,7 @@ public class Precision implements EvaluationMetric {
         }
 
         public Result(StreamInput in) throws IOException {
-            this.classes = Collections.unmodifiableList(in.readList(PerClassSingleValue::new));
+            this.classes = in.readImmutableList(PerClassSingleValue::new);
             this.avgPrecision = in.readDouble();
         }
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/evaluation/classification/Recall.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/evaluation/classification/Recall.java
@@ -202,7 +202,7 @@ public class Recall implements EvaluationMetric {
         }
 
         public Result(StreamInput in) throws IOException {
-            this.classes = Collections.unmodifiableList(in.readList(PerClassSingleValue::new));
+            this.classes = in.readImmutableList(PerClassSingleValue::new);
             this.avgRecall = in.readDouble();
         }
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/TrainedModelConfig.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/TrainedModelConfig.java
@@ -237,15 +237,13 @@ public class TrainedModelConfig implements ToXContentObject, Writeable {
         description = in.readOptionalString();
         createTime = in.readInstant();
         definition = in.readOptionalWriteable(LazyModelDefinition::fromStreamInput);
-        tags = Collections.unmodifiableList(in.readList(StreamInput::readString));
+        tags = in.readImmutableList(StreamInput::readString);
         metadata = in.readMap();
         input = new TrainedModelInput(in);
         modelSize = in.readVLong();
         estimatedOperations = in.readVLong();
         licenseLevel = License.OperationMode.parse(in.readString());
-        this.defaultFieldMap = in.readBoolean()
-            ? Collections.unmodifiableMap(in.readMap(StreamInput::readString, StreamInput::readString))
-            : null;
+        this.defaultFieldMap = in.readBoolean() ? in.readImmutableMap(StreamInput::readString, StreamInput::readString) : null;
 
         this.inferenceConfig = in.readOptionalNamedWriteable(InferenceConfig.class);
         if (in.getVersion().onOrAfter(VERSION_3RD_PARTY_CONFIG_ADDED)) {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/TrainedModelInput.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/TrainedModelInput.java
@@ -35,7 +35,7 @@ public class TrainedModelInput implements ToXContentObject, Writeable {
     }
 
     public TrainedModelInput(StreamInput in) throws IOException {
-        this.fieldNames = Collections.unmodifiableList(in.readStringList());
+        this.fieldNames = in.readImmutableList(StreamInput::readString);
     }
 
     @SuppressWarnings("unchecked")

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/preprocessing/FrequencyEncoding.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/preprocessing/FrequencyEncoding.java
@@ -86,7 +86,7 @@ public class FrequencyEncoding implements LenientlyParsedPreProcessor, StrictlyP
     public FrequencyEncoding(StreamInput in) throws IOException {
         this.field = in.readString();
         this.featureName = in.readString();
-        this.frequencyMap = Collections.unmodifiableMap(in.readMap(StreamInput::readString, StreamInput::readDouble));
+        this.frequencyMap = in.readImmutableMap(StreamInput::readString, StreamInput::readDouble);
         this.custom = in.readBoolean();
     }
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/preprocessing/TargetMeanEncoding.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/preprocessing/TargetMeanEncoding.java
@@ -90,7 +90,7 @@ public class TargetMeanEncoding implements LenientlyParsedPreProcessor, Strictly
     public TargetMeanEncoding(StreamInput in) throws IOException {
         this.field = in.readString();
         this.featureName = in.readString();
-        this.meanMap = Collections.unmodifiableMap(in.readMap(StreamInput::readString, StreamInput::readDouble));
+        this.meanMap = in.readImmutableMap(StreamInput::readString, StreamInput::readDouble);
         this.defaultValue = in.readDouble();
         this.custom = in.readBoolean();
     }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/results/ClassificationInferenceResults.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/results/ClassificationInferenceResults.java
@@ -120,7 +120,7 @@ public class ClassificationInferenceResults extends SingleValueInferenceResults 
         super(in);
         this.featureImportance = in.readList(ClassificationFeatureImportance::new);
         this.classificationLabel = in.readOptionalString();
-        this.topClasses = Collections.unmodifiableList(in.readList(TopClassEntry::new));
+        this.topClasses = in.readImmutableList(TopClassEntry::new);
         this.topNumClassesField = in.readString();
         this.resultsField = in.readString();
         this.predictionFieldType = in.readEnum(PredictionFieldType.class);

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/results/NlpClassificationInferenceResults.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/results/NlpClassificationInferenceResults.java
@@ -45,7 +45,7 @@ public class NlpClassificationInferenceResults extends NlpInferenceResults {
     public NlpClassificationInferenceResults(StreamInput in) throws IOException {
         super(in);
         this.classificationLabel = in.readString();
-        this.topClasses = Collections.unmodifiableList(in.readList(TopClassEntry::new));
+        this.topClasses = in.readImmutableList(TopClassEntry::new);
         this.resultsField = in.readString();
         this.predictionProbability = in.readOptionalDouble();
     }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/results/QuestionAnsweringInferenceResults.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/results/QuestionAnsweringInferenceResults.java
@@ -62,7 +62,7 @@ public class QuestionAnsweringInferenceResults extends NlpInferenceResults {
         this.answer = in.readString();
         this.startOffset = in.readVInt();
         this.endOffset = in.readVInt();
-        this.topClasses = Collections.unmodifiableList(in.readList(TopAnswerEntry::fromStream));
+        this.topClasses = in.readImmutableList(TopAnswerEntry::fromStream);
         this.resultsField = in.readString();
         this.score = in.readDouble();
     }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/ensemble/Ensemble.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/ensemble/Ensemble.java
@@ -109,7 +109,7 @@ public class Ensemble implements LenientlyParsedTrainedModel, StrictlyParsedTrai
     }
 
     public Ensemble(StreamInput in) throws IOException {
-        this.featureNames = Collections.unmodifiableList(in.readStringList());
+        this.featureNames = in.readImmutableList(StreamInput::readString);
         this.models = Collections.unmodifiableList(in.readNamedWriteableList(TrainedModel.class));
         this.outputAggregator = in.readNamedWriteable(OutputAggregator.class);
         this.targetType = TargetType.fromStream(in);

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/tree/Tree.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/tree/Tree.java
@@ -81,11 +81,11 @@ public class Tree implements LenientlyParsedTrainedModel, StrictlyParsedTrainedM
     }
 
     public Tree(StreamInput in) throws IOException {
-        this.featureNames = Collections.unmodifiableList(in.readStringList());
-        this.nodes = Collections.unmodifiableList(in.readList(TreeNode::new));
+        this.featureNames = in.readImmutableList(StreamInput::readString);
+        this.nodes = in.readImmutableList(TreeNode::new);
         this.targetType = TargetType.fromStream(in);
         if (in.readBoolean()) {
-            this.classificationLabels = Collections.unmodifiableList(in.readStringList());
+            this.classificationLabels = in.readImmutableList(StreamInput::readString);
         } else {
             this.classificationLabels = null;
         }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/config/AnalysisConfig.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/config/AnalysisConfig.java
@@ -174,13 +174,13 @@ public class AnalysisConfig implements ToXContentObject, Writeable {
     public AnalysisConfig(StreamInput in) throws IOException {
         bucketSpan = in.readTimeValue();
         categorizationFieldName = in.readOptionalString();
-        categorizationFilters = in.readBoolean() ? Collections.unmodifiableList(in.readStringList()) : null;
+        categorizationFilters = in.readBoolean() ? in.readImmutableList(StreamInput::readString) : null;
         categorizationAnalyzerConfig = in.readOptionalWriteable(CategorizationAnalyzerConfig::new);
         perPartitionCategorizationConfig = new PerPartitionCategorizationConfig(in);
         latency = in.readOptionalTimeValue();
         summaryCountFieldName = in.readOptionalString();
-        detectors = Collections.unmodifiableList(in.readList(Detector::new));
-        influencers = Collections.unmodifiableList(in.readStringList());
+        detectors = in.readImmutableList(Detector::new);
+        influencers = in.readImmutableList(StreamInput::readString);
 
         multivariateByFields = in.readOptionalBoolean();
         modelPruneWindow = in.readOptionalTimeValue();

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/config/Detector.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/config/Detector.java
@@ -225,7 +225,7 @@ public class Detector implements ToXContentObject, Writeable {
         partitionFieldName = in.readOptionalString();
         useNull = in.readBoolean();
         excludeFrequent = in.readBoolean() ? ExcludeFrequent.readFromStream(in) : null;
-        rules = Collections.unmodifiableList(in.readList(DetectionRule::new));
+        rules = in.readImmutableList(DetectionRule::new);
         detectorIndex = in.readInt();
     }
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/config/Job.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/config/Job.java
@@ -278,7 +278,7 @@ public class Job implements SimpleDiffable<Job>, Writeable, ToXContentObject {
         jobId = in.readString();
         jobType = in.readString();
         jobVersion = in.readBoolean() ? Version.readVersion(in) : null;
-        groups = Collections.unmodifiableList(in.readStringList());
+        groups = in.readImmutableList(StreamInput::readString);
         description = in.readOptionalString();
         createTime = new Date(in.readVLong());
         finishedTime = in.readBoolean() ? new Date(in.readVLong()) : null;

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/rollup/action/GetRollupCapsAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/rollup/action/GetRollupCapsAction.java
@@ -116,7 +116,7 @@ public class GetRollupCapsAction extends ActionType<GetRollupCapsAction.Response
         }
 
         Response(StreamInput in) throws IOException {
-            jobs = Collections.unmodifiableMap(in.readMap(StreamInput::readString, RollableIndexCaps::new));
+            jobs = in.readImmutableMap(StreamInput::readString, RollableIndexCaps::new);
         }
 
         public Map<String, RollableIndexCaps> getJobs() {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/DelegatePkiAuthenticationRequest.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/DelegatePkiAuthenticationRequest.java
@@ -64,7 +64,7 @@ public final class DelegatePkiAuthenticationRequest extends ActionRequest implem
         return PARSER.apply(parser, null);
     }
 
-    private List<X509Certificate> certificateChain;
+    private final List<X509Certificate> certificateChain;
 
     public DelegatePkiAuthenticationRequest(List<X509Certificate> certificateChain) {
         this.certificateChain = List.copyOf(certificateChain);
@@ -74,13 +74,13 @@ public final class DelegatePkiAuthenticationRequest extends ActionRequest implem
         super(input);
         try {
             final CertificateFactory certificateFactory = CertificateFactory.getInstance("X.509");
-            certificateChain = List.copyOf(input.readList(in -> {
+            certificateChain = input.readImmutableList(in -> {
                 try (ByteArrayInputStream bis = new ByteArrayInputStream(in.readByteArray())) {
                     return (X509Certificate) certificateFactory.generateCertificate(bis);
                 } catch (CertificateException e) {
                     throw new IOException(e);
                 }
-            }));
+            });
         } catch (CertificateException e) {
             throw new IOException(e);
         }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/apikey/CreateApiKeyRequest.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/apikey/CreateApiKeyRequest.java
@@ -85,7 +85,7 @@ public final class CreateApiKeyRequest extends ActionRequest {
             this.name = in.readString();
         }
         this.expiration = in.readOptionalTimeValue();
-        this.roleDescriptors = List.copyOf(in.readList(RoleDescriptor::new));
+        this.roleDescriptors = in.readImmutableList(RoleDescriptor::new);
         this.refreshPolicy = WriteRequest.RefreshPolicy.readFrom(in);
         if (in.getVersion().onOrAfter(Version.V_8_0_0)) {
             this.metadata = in.readMap();

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/privilege/PutPrivilegesRequest.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/privilege/PutPrivilegesRequest.java
@@ -34,7 +34,7 @@ public final class PutPrivilegesRequest extends ActionRequest implements Applica
 
     public PutPrivilegesRequest(StreamInput in) throws IOException {
         super(in);
-        privileges = Collections.unmodifiableList(in.readList(ApplicationPrivilegeDescriptor::new));
+        privileges = in.readImmutableList(ApplicationPrivilegeDescriptor::new);
         refreshPolicy = RefreshPolicy.readFrom(in);
     }
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/privilege/PutPrivilegesResponse.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/privilege/PutPrivilegesResponse.java
@@ -23,11 +23,11 @@ import java.util.Map;
  */
 public final class PutPrivilegesResponse extends ActionResponse implements ToXContentObject {
 
-    private Map<String, List<String>> created;
+    private final Map<String, List<String>> created;
 
     public PutPrivilegesResponse(StreamInput in) throws IOException {
         super(in);
-        this.created = Collections.unmodifiableMap(in.readMap(StreamInput::readString, StreamInput::readStringList));
+        this.created = in.readImmutableMap(StreamInput::readString, StreamInput::readStringList);
     }
 
     public PutPrivilegesResponse(Map<String, List<String>> created) {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authc/TokenMetadata.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authc/TokenMetadata.java
@@ -16,7 +16,6 @@ import org.elasticsearch.xcontent.XContentBuilder;
 
 import java.io.IOException;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 
 public final class TokenMetadata extends AbstractNamedDiffable<ClusterState.Custom> implements ClusterState.Custom {
@@ -45,7 +44,7 @@ public final class TokenMetadata extends AbstractNamedDiffable<ClusterState.Cust
 
     public TokenMetadata(StreamInput input) throws IOException {
         currentKeyHash = input.readByteArray();
-        keys = Collections.unmodifiableList(input.readList(KeyAndTimestamp::new));
+        keys = input.readImmutableList(KeyAndTimestamp::new);
     }
 
     @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/RoleDescriptorsIntersection.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/RoleDescriptorsIntersection.java
@@ -24,7 +24,7 @@ import java.util.Set;
 public record RoleDescriptorsIntersection(Collection<Set<RoleDescriptor>> roleDescriptorsList) implements ToXContentObject, Writeable {
 
     public RoleDescriptorsIntersection(StreamInput in) throws IOException {
-        this(List.copyOf(in.readList(inner -> inner.readSet(RoleDescriptor::new))));
+        this(in.readImmutableList(inner -> inner.readSet(RoleDescriptor::new)));
     }
 
     @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/textstructure/structurefinder/TextStructure.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/textstructure/structurefinder/TextStructure.java
@@ -218,7 +218,7 @@ public class TextStructure implements ToXContentObject, Writeable {
         format = in.readEnum(Format.class);
         multilineStartPattern = in.readOptionalString();
         excludeLinesPattern = in.readOptionalString();
-        columnNames = in.readBoolean() ? Collections.unmodifiableList(in.readStringList()) : null;
+        columnNames = in.readBoolean() ? in.readImmutableList(StreamInput::readString) : null;
         hasHeaderRow = in.readOptionalBoolean();
         delimiter = in.readBoolean() ? (char) in.readVInt() : null;
         quote = in.readBoolean() ? (char) in.readVInt() : null;
@@ -229,14 +229,14 @@ public class TextStructure implements ToXContentObject, Writeable {
         } else {
             ecsCompatibility = getNonNullEcsCompatibilityString(null);
         }
-        jodaTimestampFormats = in.readBoolean() ? Collections.unmodifiableList(in.readStringList()) : null;
-        javaTimestampFormats = in.readBoolean() ? Collections.unmodifiableList(in.readStringList()) : null;
+        jodaTimestampFormats = in.readBoolean() ? in.readImmutableList(StreamInput::readString) : null;
+        javaTimestampFormats = in.readBoolean() ? in.readImmutableList(StreamInput::readString) : null;
         timestampField = in.readOptionalString();
         needClientTimezone = in.readBoolean();
         mappings = Collections.unmodifiableSortedMap(new TreeMap<>(in.readMap()));
         ingestPipeline = in.readBoolean() ? Collections.unmodifiableMap(in.readMap()) : null;
         fieldStats = Collections.unmodifiableSortedMap(new TreeMap<>(in.readMap(StreamInput::readString, FieldStats::new)));
-        explanation = Collections.unmodifiableList(in.readStringList());
+        explanation = in.readImmutableList(StreamInput::readString);
     }
 
     @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/action/GetTransformStatsAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/action/GetTransformStatsAction.java
@@ -63,7 +63,7 @@ public class GetTransformStatsAction extends ActionType<GetTransformStatsAction.
         public Request(StreamInput in) throws IOException {
             super(in);
             id = in.readString();
-            expandedIds = Collections.unmodifiableList(in.readStringList());
+            expandedIds = in.readImmutableList(StreamInput::readString);
             pageParams = new PageParams(in);
             allowNoMatch = in.readBoolean();
         }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/transforms/NodeAttributes.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/transforms/NodeAttributes.java
@@ -83,7 +83,7 @@ public class NodeAttributes implements ToXContentObject, Writeable {
         this.name = in.readString();
         this.ephemeralId = in.readString();
         this.transportAddress = in.readString();
-        this.attributes = Collections.unmodifiableMap(in.readMap(StreamInput::readString, StreamInput::readString));
+        this.attributes = in.readImmutableMap(StreamInput::readString, StreamInput::readString);
     }
 
     /**

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/ModelAliasMetadata.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/ModelAliasMetadata.java
@@ -80,7 +80,7 @@ public class ModelAliasMetadata implements Metadata.Custom {
     }
 
     public ModelAliasMetadata(StreamInput in) throws IOException {
-        this.modelAliases = Collections.unmodifiableMap(in.readMap(StreamInput::readString, ModelAliasEntry::new));
+        this.modelAliases = in.readImmutableMap(StreamInput::readString, ModelAliasEntry::new);
     }
 
     public Map<String, ModelAliasEntry> modelAliases() {


### PR DESCRIPTION
Fixed a couple of issues around duplicate empty + unmodifiable collection wrappers polluting heaps lately so this tries to bulk fix all obvious spots where we can just more efficiently read the immutable collection directly.
