### PR TITLE
[8.5][DOCS] Adds snapshot-related highlights to 8.5

### DIFF
--- a/docs/changelog/89619.yaml
+++ b/docs/changelog/89619.yaml
@@ -1,9 +1,9 @@
 pr: 89619
-summary: Make `SnapshotsInProgress` Diffable
-area: Snapshot/Restore
+summary: "Make `SnapshotsInProgress` Diffable"
+area: "Snapshot/Restore"
 type: enhancement
 issues:
- - 88732, 88209
+ - 88732
 highlight: 
   title: Make `SnapshotsInProgress` Diffable
   body: |-

--- a/docs/changelog/89619.yaml
+++ b/docs/changelog/89619.yaml
@@ -4,3 +4,9 @@ area: Snapshot/Restore
 type: enhancement
 issues:
  - 88732
+highlight: 
+  title: Make `SnapshotsInProgress` Diffable
+  body: |-
+    The overhead of the snapshot operation has been reduced significantly. 
+Snapshots now execute in a more efficient order and require much less network
+traffic than before.

--- a/docs/changelog/89619.yaml
+++ b/docs/changelog/89619.yaml
@@ -3,7 +3,7 @@ summary: Make `SnapshotsInProgress` Diffable
 area: Snapshot/Restore
 type: enhancement
 issues:
- - 88732
+ - 88732, 88209
 highlight: 
   title: Make `SnapshotsInProgress` Diffable
   body: |-

--- a/docs/changelog/89619.yaml
+++ b/docs/changelog/89619.yaml
@@ -8,5 +8,5 @@ highlight:
   title: Make `SnapshotsInProgress` Diffable
   body: |-
     The overhead of the snapshot operation has been reduced significantly. 
-Snapshots now execute in a more efficient order and require much less network
-traffic than before.
+    Snapshots now execute in a more efficient order and require much less network
+    traffic than before.

--- a/docs/changelog/89619.yaml
+++ b/docs/changelog/89619.yaml
@@ -8,5 +8,5 @@ highlight:
   title: Make `SnapshotsInProgress` Diffable
   body: |-
     The overhead of the snapshot operation has been reduced significantly. 
-    Snapshots now execute in a more efficient order and require much less network
+    Snapshots now executes in a more efficient order and requires much less network
     traffic than before.


### PR DESCRIPTION
Add snapshot-in-progress diffable work to the release highlight doc.
Should https://github.com/elastic/elasticsearch/pull/88209 be included as well?

