### PR TITLE
Create default .ent-search index if it does not exist

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/metadata/Metadata.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/Metadata.java
@@ -2365,7 +2365,8 @@ public class Metadata extends AbstractCollection<IndexMetadata> implements Diffa
                 }
 
                 for (SearchEngine searchEngine : searchEngineMetadata.searchEngines().values()) {
-                    assert searchEngine.getIndices().isEmpty() == false : "search engine " + searchEngine.getName() + " needs at least one index";
+                    assert searchEngine.getIndices().isEmpty() == false
+                        : "search engine " + searchEngine.getName() + " needs at least one index";
                     final IndexAbstraction.SearchEngine engineAbstraction = new IndexAbstraction.SearchEngine(searchEngine);
                     IndexAbstraction existing = indicesLookup.put(searchEngine.getName(), engineAbstraction);
                     assert existing == null : "duplicate engine for " + searchEngine.getName();

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ClientHelper.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ClientHelper.java
@@ -189,6 +189,7 @@ public final class ClientHelper {
     public static final String SEARCHABLE_SNAPSHOTS_ORIGIN = "searchable_snapshots";
     public static final String LOGSTASH_MANAGEMENT_ORIGIN = "logstash_management";
     public static final String FLEET_ORIGIN = "fleet";
+    public static final String RELEVANCE_SETTINGS_ORIGIN = "relevance_settings";
 
     private ClientHelper() {}
 

--- a/x-pack/plugin/relevance-search/src/main/java/org/elasticsearch/xpack/relevancesearch/RelevanceSearchPlugin.java
+++ b/x-pack/plugin/relevance-search/src/main/java/org/elasticsearch/xpack/relevancesearch/RelevanceSearchPlugin.java
@@ -101,7 +101,7 @@ public class RelevanceSearchPlugin extends Plugin implements ActionPlugin, Searc
         Tracer tracer,
         AllocationDeciders allocationDeciders
     ) {
-        relevanceSettingsService.set(new RelevanceSettingsService(client));
+        relevanceSettingsService.set(new RelevanceSettingsService(client, clusterService));
 
         return Collections.singletonList(relevanceSettingsService.get());
     }

--- a/x-pack/plugin/relevance-search/src/main/java/org/elasticsearch/xpack/relevancesearch/query/RelevanceMatchQueryBuilder.java
+++ b/x-pack/plugin/relevance-search/src/main/java/org/elasticsearch/xpack/relevancesearch/query/RelevanceMatchQueryBuilder.java
@@ -112,6 +112,8 @@ public class RelevanceMatchQueryBuilder extends AbstractQueryBuilder<RelevanceMa
     protected Query doToQuery(final SearchExecutionContext context) throws IOException {
 
         Map<String, Float> fieldsAndBoosts;
+        RelevanceSettingsService.ensureInternalIndex(context.getClient());
+
         if (relevanceSettingsId != null) {
             try {
                 RelevanceSettings relevanceSettings = relevanceSettingsService.getRelevanceSettings(relevanceSettingsId);

--- a/x-pack/plugin/relevance-search/src/main/java/org/elasticsearch/xpack/relevancesearch/query/RelevanceMatchQueryBuilder.java
+++ b/x-pack/plugin/relevance-search/src/main/java/org/elasticsearch/xpack/relevancesearch/query/RelevanceMatchQueryBuilder.java
@@ -112,7 +112,6 @@ public class RelevanceMatchQueryBuilder extends AbstractQueryBuilder<RelevanceMa
     protected Query doToQuery(final SearchExecutionContext context) throws IOException {
 
         Map<String, Float> fieldsAndBoosts;
-        RelevanceSettingsService.ensureInternalIndex(context.getClient());
 
         if (relevanceSettingsId != null) {
             try {

--- a/x-pack/plugin/relevance-search/src/main/java/org/elasticsearch/xpack/relevancesearch/query/RelevanceMatchQueryBuilder.java
+++ b/x-pack/plugin/relevance-search/src/main/java/org/elasticsearch/xpack/relevancesearch/query/RelevanceMatchQueryBuilder.java
@@ -112,7 +112,6 @@ public class RelevanceMatchQueryBuilder extends AbstractQueryBuilder<RelevanceMa
     protected Query doToQuery(final SearchExecutionContext context) throws IOException {
 
         Map<String, Float> fieldsAndBoosts;
-
         if (relevanceSettingsId != null) {
             try {
                 RelevanceSettings relevanceSettings = relevanceSettingsService.getRelevanceSettings(relevanceSettingsId);

--- a/x-pack/plugin/relevance-search/src/main/java/org/elasticsearch/xpack/relevancesearch/relevance/RelevanceSettingsService.java
+++ b/x-pack/plugin/relevance-search/src/main/java/org/elasticsearch/xpack/relevancesearch/relevance/RelevanceSettingsService.java
@@ -123,6 +123,7 @@ public class RelevanceSettingsService {
             .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1)
             .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 0)
             .put(IndexMetadata.SETTING_AUTO_EXPAND_REPLICAS, "0-1")
+            .put(IndexMetadata.SETTING_INDEX_HIDDEN, true)
             .build();
     }
 

--- a/x-pack/plugin/relevance-search/src/main/java/org/elasticsearch/xpack/relevancesearch/relevance/RelevanceSettingsService.java
+++ b/x-pack/plugin/relevance-search/src/main/java/org/elasticsearch/xpack/relevancesearch/relevance/RelevanceSettingsService.java
@@ -7,10 +7,29 @@
 
 package org.elasticsearch.xpack.relevancesearch.relevance;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.elasticsearch.ExceptionsHelper;
+import org.elasticsearch.ResourceAlreadyExistsException;
+import org.elasticsearch.Version;
+import org.elasticsearch.action.ActionFuture;
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.admin.indices.create.CreateIndexAction;
+import org.elasticsearch.action.admin.indices.create.CreateIndexRequest;
+import org.elasticsearch.action.admin.indices.create.CreateIndexResponse;
 import org.elasticsearch.client.internal.Client;
+import org.elasticsearch.cluster.metadata.IndexMetadata;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.index.IndexNotFoundException;
+import org.elasticsearch.xcontent.XContentBuilder;
 
+import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.util.List;
 import java.util.Map;
+
+import static org.elasticsearch.index.mapper.MapperService.SINGLE_MAPPING_NAME;
+import static org.elasticsearch.xcontent.XContentFactory.jsonBuilder;
 
 /**
  * Manage relevance settings, retrieving and updating the corresponding documents in .ent-search index
@@ -21,6 +40,8 @@ public class RelevanceSettingsService {
     public static final String RELEVANCE_SETTINGS_PREFIX = "relevance_settings-";
     private final Client client;
 
+    private static final Logger logger = LogManager.getLogger(RelevanceSettingsService.class);
+
     public RelevanceSettingsService(final Client client) {
         this.client = client;
     }
@@ -28,9 +49,12 @@ public class RelevanceSettingsService {
     public RelevanceSettings getRelevanceSettings(String settingsId) throws RelevanceSettingsNotFoundException,
         RelevanceSettingsInvalidException {
         // TODO cache relevance settings, including cache invalidation
-        final Map<String, Object> settingsContent = client.prepareGet(ENT_SEARCH_INDEX, RELEVANCE_SETTINGS_PREFIX + settingsId)
-            .get()
-            .getSource();
+        Map<String, Object> settingsContent = null;
+        try {
+            settingsContent = client.prepareGet(ENT_SEARCH_INDEX, RELEVANCE_SETTINGS_PREFIX + settingsId).get().getSource();
+        } catch (IndexNotFoundException e) {
+            ensureInternalIndex(client);
+        }
 
         if (settingsContent == null) {
             throw new RelevanceSettingsNotFoundException("Relevance settings " + settingsId + " not found");
@@ -72,6 +96,66 @@ public class RelevanceSettingsService {
     public static class RelevanceSettingsInvalidException extends Exception {
         public RelevanceSettingsInvalidException(String message) {
             super(message);
+        }
+    }
+
+    private static void ensureInternalIndex(Client client) {
+        CreateIndexRequest request = new CreateIndexRequest(ENT_SEARCH_INDEX).mapping(getInternalIndexMapping())
+            .settings(getInternalIndexSettings());
+        ActionFuture<CreateIndexResponse> response = client.execute(CreateIndexAction.INSTANCE, request);
+
+        client.execute(CreateIndexAction.INSTANCE, request, new ActionListener<>() {
+            public void onResponse(CreateIndexResponse createIndexResponse) {
+                logger.info("Created " + ENT_SEARCH_INDEX + " index.");
+            }
+
+            public void onFailure(Exception e) {
+                final Throwable cause = ExceptionsHelper.unwrapCause(e);
+                if (!(cause instanceof ResourceAlreadyExistsException)) {
+                    logger.info("Failed to create " + ENT_SEARCH_INDEX + " index " + e.toString());
+                }
+            }
+        });
+    }
+
+    private static Settings getInternalIndexSettings() {
+        return Settings.builder()
+            .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1)
+            .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 0)
+            .put(IndexMetadata.SETTING_AUTO_EXPAND_REPLICAS, "0-1")
+            .build();
+    }
+
+    private static XContentBuilder getInternalIndexMapping() {
+        try {
+            return jsonBuilder().startObject()
+                .startObject(SINGLE_MAPPING_NAME)
+                .startObject("_meta")
+                .field("version", Version.CURRENT)
+                .endObject()
+                .field("dynamic", "strict")
+                .startObject("properties")
+                .startObject("name")
+                .field("type", "keyword")
+                .endObject()
+                .startObject("type")
+                .field("type", "keyword")
+                .endObject()
+                .startObject("query_type")
+                .field("type", "keyword")
+                .endObject()
+                .startObject("query_configuration")
+                .startObject("properties")
+                .startObject("fields")
+                .field("type", "keyword")
+                .endObject()
+                .endObject()
+                .endObject()
+                .endObject()
+                .endObject()
+                .endObject();
+        } catch (IOException e) {
+            throw new UncheckedIOException("Failed to build mappings", e);
         }
     }
 }

--- a/x-pack/plugin/relevance-search/src/main/java/org/elasticsearch/xpack/relevancesearch/relevance/RelevanceSettingsService.java
+++ b/x-pack/plugin/relevance-search/src/main/java/org/elasticsearch/xpack/relevancesearch/relevance/RelevanceSettingsService.java
@@ -99,7 +99,7 @@ public class RelevanceSettingsService {
         }
     }
 
-    private static void ensureInternalIndex(Client client) {
+    public static void ensureInternalIndex(Client client) {
         CreateIndexRequest request = new CreateIndexRequest(ENT_SEARCH_INDEX).mapping(getInternalIndexMapping())
             .settings(getInternalIndexSettings());
         ActionFuture<CreateIndexResponse> response = client.execute(CreateIndexAction.INSTANCE, request);

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authz/AuthorizationUtils.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authz/AuthorizationUtils.java
@@ -34,6 +34,7 @@ import static org.elasticsearch.xpack.core.ClientHelper.INDEX_LIFECYCLE_ORIGIN;
 import static org.elasticsearch.xpack.core.ClientHelper.LOGSTASH_MANAGEMENT_ORIGIN;
 import static org.elasticsearch.xpack.core.ClientHelper.ML_ORIGIN;
 import static org.elasticsearch.xpack.core.ClientHelper.MONITORING_ORIGIN;
+import static org.elasticsearch.xpack.core.ClientHelper.RELEVANCE_SETTINGS_ORIGIN;
 import static org.elasticsearch.xpack.core.ClientHelper.ROLLUP_ORIGIN;
 import static org.elasticsearch.xpack.core.ClientHelper.SEARCHABLE_SNAPSHOTS_ORIGIN;
 import static org.elasticsearch.xpack.core.ClientHelper.SECURITY_ORIGIN;
@@ -138,6 +139,7 @@ public final class AuthorizationUtils {
             case SEARCHABLE_SNAPSHOTS_ORIGIN:
             case LOGSTASH_MANAGEMENT_ORIGIN:
             case FLEET_ORIGIN:
+            case RELEVANCE_SETTINGS_ORIGIN:
             case TASKS_ORIGIN:   // TODO use a more limited user for tasks
                 securityContext.executeAsInternalUser(XPackUser.INSTANCE, version, consumer);
                 break;


### PR DESCRIPTION
This creates the default .ent-search index that stores relevance settings if the index does not already exist.
Alternative for https://github.com/elastic/elasticsearch/pull/90513/

This is done by having `RelevanceSettingsService` implement `ClusterStateListener` and by creating the index when the cluster is ready.
