### PR TITLE
Make Step.StepKey a record

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/AllocationRoutedStep.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/AllocationRoutedStep.java
@@ -49,13 +49,13 @@ public class AllocationRoutedStep extends ClusterStateWaitStep {
         IndexMetadata idxMeta = clusterState.metadata().index(index);
         if (idxMeta == null) {
             // Index must have been since deleted, ignore it
-            logger.debug("[{}] lifecycle action for index [{}] executed but index no longer exists", getKey().getAction(), index.getName());
+            logger.debug("[{}] lifecycle action for index [{}] executed but index no longer exists", getKey().action(), index.getName());
             return new Result(false, null);
         }
         if (ActiveShardCount.ALL.enoughShardsActive(clusterState, index.getName()) == false) {
             logger.debug(
                 "[{}] lifecycle action for index [{}] cannot make progress because not all shards are active",
-                getKey().getAction(),
+                getKey().action(),
                 index.getName()
             );
             return new Result(false, waitingForActiveShardsAllocationInfo(idxMeta.getNumberOfReplicas()));
@@ -75,12 +75,12 @@ public class AllocationRoutedStep extends ClusterStateWaitStep {
             logger.debug(
                 "{} lifecycle action [{}] waiting for [{}] shards to be allocated to nodes matching the given filters",
                 index,
-                getKey().getAction(),
+                getKey().action(),
                 allocationPendingAllShards
             );
             return new Result(false, allShardsActiveAllocationInfo(idxMeta.getNumberOfReplicas(), allocationPendingAllShards));
         } else {
-            logger.debug("{} lifecycle action for [{}] complete", index, getKey().getAction());
+            logger.debug("{} lifecycle action for [{}] complete", index, getKey().action());
             return new Result(true, null);
         }
     }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/BranchingStep.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/BranchingStep.java
@@ -60,7 +60,7 @@ public class BranchingStep extends ClusterStateActionStep {
         IndexMetadata indexMetadata = clusterState.metadata().index(index);
         if (indexMetadata == null) {
             // Index must have been since deleted, ignore it
-            logger.debug("[{}] lifecycle action for index [{}] executed but index no longer exists", getKey().getAction(), index.getName());
+            logger.debug("[{}] lifecycle action for index [{}] executed but index no longer exists", getKey().action(), index.getName());
             return clusterState;
         }
         predicateValue.set(predicate.test(index, clusterState));

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/CheckNotDataStreamWriteIndexStep.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/CheckNotDataStreamWriteIndexStep.java
@@ -48,7 +48,7 @@ public class CheckNotDataStreamWriteIndexStep extends ClusterStateWaitStep {
             String errorMessage = String.format(
                 Locale.ROOT,
                 "[%s] lifecycle action for index [%s] executed but index no longer exists",
-                getKey().getAction(),
+                getKey().action(),
                 indexName
             );
             // Index must have been since deleted

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/CheckShrinkReadyStep.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/CheckShrinkReadyStep.java
@@ -59,7 +59,7 @@ public class CheckShrinkReadyStep extends ClusterStateWaitStep {
 
         if (idxMeta == null) {
             // Index must have been since deleted, ignore it
-            logger.debug("[{}] lifecycle action for index [{}] executed but index no longer exists", getKey().getAction(), index.getName());
+            logger.debug("[{}] lifecycle action for index [{}] executed but index no longer exists", getKey().action(), index.getName());
             return new Result(false, null);
         }
 
@@ -104,7 +104,7 @@ public class CheckShrinkReadyStep extends ClusterStateWaitStep {
                 index,
                 expectedShardCount,
                 idShardsShouldBeOn,
-                getKey().getAction()
+                getKey().action()
             );
             return new Result(true, null);
         } else {
@@ -122,7 +122,7 @@ public class CheckShrinkReadyStep extends ClusterStateWaitStep {
                 expectedShardCount,
                 foundShards,
                 idShardsShouldBeOn,
-                getKey().getAction()
+                getKey().action()
             );
             return new Result(
                 false,

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/CheckTargetShardsCountStep.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/CheckTargetShardsCountStep.java
@@ -45,7 +45,7 @@ public class CheckTargetShardsCountStep extends ClusterStateWaitStep {
         IndexMetadata indexMetadata = clusterState.metadata().index(index);
         if (indexMetadata == null) {
             // Index must have been since deleted, ignore it
-            logger.debug("[{}] lifecycle action for index [{}] executed but index no longer exists", getKey().getAction(), index.getName());
+            logger.debug("[{}] lifecycle action for index [{}] executed but index no longer exists", getKey().action(), index.getName());
             return new Result(false, null);
         }
         String indexName = indexMetadata.getIndex().getName();

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/ClusterStateWaitUntilThresholdStep.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/ClusterStateWaitUntilThresholdStep.java
@@ -57,7 +57,7 @@ public class ClusterStateWaitUntilThresholdStep extends ClusterStateWaitStep {
         IndexMetadata idxMeta = clusterState.metadata().index(index);
         if (idxMeta == null) {
             // Index must have been since deleted, ignore it
-            logger.debug("[{}] lifecycle action for index [{}] executed but index no longer exists", getKey().getAction(), index.getName());
+            logger.debug("[{}] lifecycle action for index [{}] executed but index no longer exists", getKey().action(), index.getName());
             return new Result(false, null);
         }
 
@@ -76,8 +76,8 @@ public class ClusterStateWaitUntilThresholdStep extends ClusterStateWaitStep {
                     Locale.ROOT,
                     "[%s] lifecycle step, as part of [%s] action, for index [%s] Is not "
                         + "completable, reason: [%s]. Abandoning execution and moving to the next fallback step [%s]",
-                    getKey().getName(),
-                    getKey().getAction(),
+                    getKey().name(),
+                    getKey().action(),
                     idxMeta.getIndex().getName(),
                     Strings.toString(stepResult.getInfomationContext()),
                     nextKeyOnThresholdBreach
@@ -94,8 +94,8 @@ public class ClusterStateWaitUntilThresholdStep extends ClusterStateWaitStep {
                     Locale.ROOT,
                     "[%s] lifecycle step, as part of [%s] action, for index [%s] executed for"
                         + " more than [%s]. Abandoning execution and moving to the next fallback step [%s]",
-                    getKey().getName(),
-                    getKey().getAction(),
+                    getKey().name(),
+                    getKey().action(),
                     idxMeta.getIndex().getName(),
                     retryThreshold,
                     nextKeyOnThresholdBreach

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/CopyExecutionStateStep.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/CopyExecutionStateStep.java
@@ -70,7 +70,7 @@ public class CopyExecutionStateStep extends ClusterStateActionStep {
         IndexMetadata indexMetadata = clusterState.metadata().index(index);
         if (indexMetadata == null) {
             // Index must have been since deleted, ignore it
-            logger.debug("[{}] lifecycle action for index [{}] executed but index no longer exists", getKey().getAction(), index.getName());
+            logger.debug("[{}] lifecycle action for index [{}] executed but index no longer exists", getKey().action(), index.getName());
             return clusterState;
         }
         // get target index
@@ -82,7 +82,7 @@ public class CopyExecutionStateStep extends ClusterStateActionStep {
         if (targetIndexMetadata == null) {
             logger.warn(
                 "[{}] index [{}] unable to copy execution state to target index [{}] as target index does not exist",
-                getKey().getAction(),
+                getKey().action(),
                 index.getName(),
                 targetIndexName
             );
@@ -91,9 +91,9 @@ public class CopyExecutionStateStep extends ClusterStateActionStep {
             );
         }
 
-        String phase = targetNextStepKey.getPhase();
-        String action = targetNextStepKey.getAction();
-        String step = targetNextStepKey.getName();
+        String phase = targetNextStepKey.phase();
+        String action = targetNextStepKey.action();
+        String step = targetNextStepKey.name();
 
         LifecycleExecutionState.Builder newLifecycleState = LifecycleExecutionState.builder(lifecycleState);
         // Override the phase, action, and step for the target next StepKey

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/CopySettingsStep.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/CopySettingsStep.java
@@ -66,7 +66,7 @@ public class CopySettingsStep extends ClusterStateActionStep {
         IndexMetadata sourceIndexMetadata = clusterState.metadata().index(sourceIndexName);
         if (sourceIndexMetadata == null) {
             // Index must have been since deleted, ignore it
-            logger.debug("[{}] lifecycle action for index [{}] executed but index no longer exists", getKey().getAction(), sourceIndexName);
+            logger.debug("[{}] lifecycle action for index [{}] executed but index no longer exists", getKey().action(), sourceIndexName);
             return clusterState;
         }
 
@@ -81,8 +81,8 @@ public class CopySettingsStep extends ClusterStateActionStep {
                 Locale.ROOT,
                 "index [%s] is being referenced by ILM action [%s] on step [%s] but " + "it doesn't exist",
                 targetIndexName,
-                getKey().getAction(),
-                getKey().getName()
+                getKey().action(),
+                getKey().name()
             );
             logger.debug(errorMessage);
             throw new IllegalStateException(errorMessage);

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/DataTierMigrationRoutedStep.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/DataTierMigrationRoutedStep.java
@@ -49,7 +49,7 @@ public class DataTierMigrationRoutedStep extends ClusterStateWaitStep {
         IndexMetadata idxMeta = clusterState.metadata().index(index);
         if (idxMeta == null) {
             // Index must have been since deleted, ignore it
-            logger.debug("[{}] lifecycle action for index [{}] executed but index no longer exists", getKey().getAction(), index.getName());
+            logger.debug("[{}] lifecycle action for index [{}] executed but index no longer exists", getKey().action(), index.getName());
             return new Result(false, null);
         }
         List<String> preferredTierConfiguration = idxMeta.getTierPreference();
@@ -63,14 +63,14 @@ public class DataTierMigrationRoutedStep extends ClusterStateWaitStep {
             if (preferredTierConfiguration.isEmpty()) {
                 logger.debug(
                     "[{}] lifecycle action for index [{}] cannot make progress because not all shards are active",
-                    getKey().getAction(),
+                    getKey().action(),
                     index.getName()
                 );
             } else {
                 if (availableDestinationTier.isPresent()) {
                     logger.debug(
                         "[{}] migration of index [{}] to the {} tier preference cannot progress, as not all shards are active",
-                        getKey().getAction(),
+                        getKey().action(),
                         index.getName(),
                         preferredTierConfiguration
                     );
@@ -78,7 +78,7 @@ public class DataTierMigrationRoutedStep extends ClusterStateWaitStep {
                     logger.debug(
                         "[{}] migration of index [{}] to the next tier cannot progress as there is no available tier for the "
                             + "configured preferred tiers {} and not all shards are active",
-                        getKey().getAction(),
+                        getKey().action(),
                         index.getName(),
                         preferredTierConfiguration
                     );
@@ -92,7 +92,7 @@ public class DataTierMigrationRoutedStep extends ClusterStateWaitStep {
                 "index [{}] has no data tier routing preference setting configured and all its shards are active. considering "
                     + "the [{}] step condition met and continuing to the next step",
                 index.getName(),
-                getKey().getName()
+                getKey().name()
             );
             // the user removed the tier routing setting and all the shards are active so we'll cary on
             return new Result(true, null);
@@ -107,7 +107,7 @@ public class DataTierMigrationRoutedStep extends ClusterStateWaitStep {
                     "[%s] lifecycle action [%s] waiting for [%s] shards to be moved to the [%s] tier (tier "
                         + "migration preference configuration is %s)",
                     index.getName(),
-                    getKey().getAction(),
+                    getKey().action(),
                     allocationPendingAllShards,
                     s,
                     preferredTierConfiguration
@@ -126,7 +126,7 @@ public class DataTierMigrationRoutedStep extends ClusterStateWaitStep {
         } else {
             logger.debug(
                 "[{}] migration of index [{}] to tier [{}] (preference [{}]) complete",
-                getKey().getAction(),
+                getKey().action(),
                 index,
                 availableDestinationTier.orElse(""),
                 preferredTierConfiguration

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/ErrorStep.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/ErrorStep.java
@@ -14,7 +14,7 @@ public class ErrorStep extends Step {
 
     public ErrorStep(StepKey key) {
         super(key, key);
-        if (NAME.equals(key.getName()) == false) {
+        if (NAME.equals(key.name()) == false) {
             throw new IllegalArgumentException("An error step must have a step key whose step name is " + NAME);
         }
     }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/GenerateSnapshotNameStep.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/GenerateSnapshotNameStep.java
@@ -50,7 +50,7 @@ public class GenerateSnapshotNameStep extends ClusterStateActionStep {
         IndexMetadata indexMetadata = clusterState.metadata().index(index);
         if (indexMetadata == null) {
             // Index must have been since deleted, ignore it
-            logger.debug("[{}] lifecycle action for index [{}] executed but index no longer exists", getKey().getAction(), index.getName());
+            logger.debug("[{}] lifecycle action for index [{}] executed but index no longer exists", getKey().action(), index.getName());
             return clusterState;
         }
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/GenerateUniqueIndexNameStep.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/GenerateUniqueIndexNameStep.java
@@ -70,7 +70,7 @@ public class GenerateUniqueIndexNameStep extends ClusterStateActionStep {
         IndexMetadata indexMetadata = clusterState.metadata().index(index);
         if (indexMetadata == null) {
             // Index must have been since deleted, ignore it
-            logger.debug("[{}] lifecycle action for index [{}] executed but index no longer exists", getKey().getAction(), index.getName());
+            logger.debug("[{}] lifecycle action for index [{}] executed but index no longer exists", getKey().action(), index.getName());
             return clusterState;
         }
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/InitializePolicyContextStep.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/InitializePolicyContextStep.java
@@ -35,7 +35,7 @@ public final class InitializePolicyContextStep extends ClusterStateActionStep {
     public ClusterState performAction(Index index, ClusterState clusterState) {
         IndexMetadata indexMetadata = clusterState.getMetadata().index(index);
         if (indexMetadata == null) {
-            logger.debug("[{}] lifecycle action for index [{}] executed but index no longer exists", getKey().getAction(), index.getName());
+            logger.debug("[{}] lifecycle action for index [{}] executed but index no longer exists", getKey().action(), index.getName());
             // Index must have been since deleted, ignore it
             return clusterState;
         }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/LifecyclePolicy.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/LifecyclePolicy.java
@@ -265,21 +265,21 @@ public class LifecyclePolicy implements SimpleDiffable<LifecyclePolicy>, ToXCont
     }
 
     public boolean isActionSafe(StepKey stepKey) {
-        if ("new".equals(stepKey.getPhase())) {
+        if ("new".equals(stepKey.phase())) {
             return true;
         }
-        Phase phase = phases.get(stepKey.getPhase());
+        Phase phase = phases.get(stepKey.phase());
         if (phase != null) {
-            LifecycleAction action = phase.getActions().get(stepKey.getAction());
+            LifecycleAction action = phase.getActions().get(stepKey.action());
             if (action != null) {
                 return action.isSafeAction();
             } else {
                 throw new IllegalArgumentException(
-                    "Action [" + stepKey.getAction() + "] in phase [" + stepKey.getPhase() + "]  does not exist in policy [" + name + "]"
+                    "Action [" + stepKey.action() + "] in phase [" + stepKey.phase() + "]  does not exist in policy [" + name + "]"
                 );
             }
         } else {
-            throw new IllegalArgumentException("Phase [" + stepKey.getPhase() + "]  does not exist in policy [" + name + "]");
+            throw new IllegalArgumentException("Phase [" + stepKey.phase() + "]  does not exist in policy [" + name + "]");
         }
     }
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/MountSnapshotStep.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/MountSnapshotStep.java
@@ -126,7 +126,7 @@ public class MountSnapshotStep extends AsyncRetryDuringSnapshotActionStep {
 
         final Settings.Builder settingsBuilder = Settings.builder();
 
-        overrideTierPreference(this.getKey().getPhase()).ifPresent(override -> settingsBuilder.put(DataTier.TIER_PREFERENCE, override));
+        overrideTierPreference(this.getKey().phase()).ifPresent(override -> settingsBuilder.put(DataTier.TIER_PREFERENCE, override));
 
         final MountSearchableSnapshotRequest mountSearchableSnapshotRequest = new MountSearchableSnapshotRequest(
             mountedIndexName,

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/PhaseCacheManagement.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/PhaseCacheManagement.java
@@ -102,11 +102,11 @@ public final class PhaseCacheManagement {
         }
 
         Step.StepKey currentStepKey = Step.getCurrentStepKey(executionState);
-        if (currentStepKey == null || currentStepKey.getPhase() == null) {
+        if (currentStepKey == null || currentStepKey.phase() == null) {
             return false;
         }
 
-        return ErrorStep.NAME.equals(currentStepKey.getName()) == false;
+        return ErrorStep.NAME.equals(currentStepKey.name()) == false;
     }
 
     /**
@@ -190,7 +190,7 @@ public final class PhaseCacheManagement {
 
         final LifecycleExecutionState executionState = metadata.getLifecycleExecutionState();
         final Step.StepKey currentStepKey = Step.getCurrentStepKey(executionState);
-        final String currentPhase = currentStepKey.getPhase();
+        final String currentPhase = currentStepKey.phase();
 
         final Set<Step.StepKey> newStepKeys = newPolicy.toSteps(client, licenseState)
             .stream()
@@ -221,7 +221,7 @@ public final class PhaseCacheManagement {
         }
 
         final Set<Step.StepKey> oldPhaseStepKeys = oldStepKeys.stream()
-            .filter(sk -> currentPhase.equals(sk.getPhase()))
+            .filter(sk -> currentPhase.equals(sk.phase()))
             .collect(Collectors.toCollection(LinkedHashSet::new));
 
         final PhaseExecutionInfo phaseExecutionInfo = new PhaseExecutionInfo(policyId, newPolicy.getPhases().get(currentPhase), 1L, 1L);

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/SearchableSnapshotAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/SearchableSnapshotAction.java
@@ -345,7 +345,7 @@ public class SearchableSnapshotAction implements LifecycleAction {
      * Resolves the prefix to be used for the mounted index depending on the provided key
      */
     static String getRestoredIndexPrefix(StepKey currentKey) {
-        if (currentKey.getPhase().equals(TimeseriesLifecycleType.FROZEN_PHASE)) {
+        if (currentKey.phase().equals(TimeseriesLifecycleType.FROZEN_PHASE)) {
             return PARTIAL_RESTORED_INDEX_PREFIX;
         } else {
             return FULL_RESTORED_INDEX_PREFIX;
@@ -354,7 +354,7 @@ public class SearchableSnapshotAction implements LifecycleAction {
 
     // Resolves the storage type depending on which phase the index is in
     static MountSearchableSnapshotRequest.Storage getConcreteStorageType(StepKey currentKey) {
-        if (currentKey.getPhase().equals(TimeseriesLifecycleType.FROZEN_PHASE)) {
+        if (currentKey.phase().equals(TimeseriesLifecycleType.FROZEN_PHASE)) {
             return MountSearchableSnapshotRequest.Storage.SHARED_CACHE;
         } else {
             return MountSearchableSnapshotRequest.Storage.FULL_COPY;

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/ShrunkShardsAllocatedStep.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/ShrunkShardsAllocatedStep.java
@@ -46,7 +46,7 @@ public class ShrunkShardsAllocatedStep extends ClusterStateWaitStep {
         IndexMetadata indexMetadata = clusterState.metadata().index(index);
         if (indexMetadata == null) {
             // Index must have been since deleted, ignore it
-            logger.debug("[{}] lifecycle action for index [{}] executed but index no longer exists", getKey().getAction(), index.getName());
+            logger.debug("[{}] lifecycle action for index [{}] executed but index no longer exists", getKey().action(), index.getName());
             return new Result(false, null);
         }
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/ShrunkenIndexCheckStep.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/ShrunkenIndexCheckStep.java
@@ -44,7 +44,7 @@ public class ShrunkenIndexCheckStep extends ClusterStateWaitStep {
     public Result isConditionMet(Index index, ClusterState clusterState) {
         IndexMetadata idxMeta = clusterState.getMetadata().index(index);
         if (idxMeta == null) {
-            logger.debug("[{}] lifecycle action for index [{}] executed but index no longer exists", getKey().getAction(), index.getName());
+            logger.debug("[{}] lifecycle action for index [{}] executed but index no longer exists", getKey().action(), index.getName());
             // Index must have been since deleted, ignore it
             return new Result(false, null);
         }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/Step.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/Step.java
@@ -94,10 +94,7 @@ public abstract class Step {
         return key + " => " + nextStepKey;
     }
 
-    public static final class StepKey implements Writeable, ToXContentObject {
-        private final String phase;
-        private final String action;
-        private final String name;
+    public record StepKey(String phase, String action, String name) implements Writeable, ToXContentObject {
 
         public static final ParseField PHASE_FIELD = new ParseField("phase");
         public static final ParseField ACTION_FIELD = new ParseField("action");
@@ -112,16 +109,8 @@ public abstract class Step {
             PARSER.declareString(ConstructingObjectParser.constructorArg(), NAME_FIELD);
         }
 
-        public StepKey(String phase, String action, String name) {
-            this.phase = phase;
-            this.action = action;
-            this.name = name;
-        }
-
-        public StepKey(StreamInput in) throws IOException {
-            this.phase = in.readString();
-            this.action = in.readString();
-            this.name = in.readString();
+        public static StepKey readFrom(StreamInput in) throws IOException {
+            return new StepKey(in.readString(), in.readString(), in.readString());
         }
 
         public static StepKey parse(XContentParser parser) {
@@ -133,40 +122,6 @@ public abstract class Step {
             out.writeString(phase);
             out.writeString(action);
             out.writeString(name);
-        }
-
-        public String getPhase() {
-            return phase;
-        }
-
-        public String getAction() {
-            return action;
-        }
-
-        public String getName() {
-            return name;
-        }
-
-        @Override
-        public int hashCode() {
-            return Objects.hash(phase, action, name);
-        }
-
-        @Override
-        public boolean equals(Object obj) {
-            if (obj == null) {
-                return false;
-            }
-            if (getClass() != obj.getClass()) {
-                return false;
-            }
-            StepKey other = (StepKey) obj;
-            return Objects.equals(phase, other.phase) && Objects.equals(action, other.action) && Objects.equals(name, other.name);
-        }
-
-        @Override
-        public String toString() {
-            return "{\"phase\":\"" + phase + "\",\"action\":\"" + action + "\",\"name\":\"" + name + "\"}";
         }
 
         @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/Step.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/Step.java
@@ -125,6 +125,11 @@ public abstract class Step {
         }
 
         @Override
+        public String toString() {
+            return "{\"phase\":\"" + phase + "\",\"action\":\"" + action + "\",\"name\":\"" + name + "\"}";
+        }
+
+        @Override
         public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
             builder.startObject();
             builder.field(PHASE_FIELD.getPreferredName(), phase);

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/WaitForActiveShardsStep.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/WaitForActiveShardsStep.java
@@ -57,7 +57,7 @@ public class WaitForActiveShardsStep extends ClusterStateWaitStep {
             String errorMessage = String.format(
                 Locale.ROOT,
                 "[%s] lifecycle action for index [%s] executed but index no longer exists",
-                getKey().getAction(),
+                getKey().action(),
                 index.getName()
             );
             // Index must have been since deleted
@@ -145,7 +145,7 @@ public class WaitForActiveShardsStep extends ClusterStateWaitStep {
             Locale.ROOT,
             "unable to find the index that was rolled over from [%s] as part of lifecycle action [%s]",
             originalIndex.getName(),
-            key.getAction()
+            key.action()
         );
 
         // Index must have been since deleted

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/WaitForIndexColorStep.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/WaitForIndexColorStep.java
@@ -92,7 +92,7 @@ class WaitForIndexColorStep extends ClusterStateWaitStep {
             String errorMessage = String.format(
                 Locale.ROOT,
                 "[%s] lifecycle action for index [%s] executed but the target index [%s] " + "does not exist",
-                getKey().getAction(),
+                getKey().action(),
                 index.getName(),
                 indexName
             );

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/WaitForIndexingCompleteStep.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/WaitForIndexingCompleteStep.java
@@ -40,7 +40,7 @@ final class WaitForIndexingCompleteStep extends ClusterStateWaitStep {
         IndexMetadata followerIndex = clusterState.metadata().index(index);
         if (followerIndex == null) {
             // Index must have been since deleted, ignore it
-            logger.debug("[{}] lifecycle action for index [{}] executed but index no longer exists", getKey().getAction(), index.getName());
+            logger.debug("[{}] lifecycle action for index [{}] executed but index no longer exists", getKey().action(), index.getName());
             return new Result(false, null);
         }
         Map<String, String> customIndexMetadata = followerIndex.getCustomData(CCR_METADATA_KEY);

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/action/MoveToStepAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/action/MoveToStepAction.java
@@ -67,7 +67,7 @@ public class MoveToStepAction extends ActionType<AcknowledgedResponse> {
         public Request(StreamInput in) throws IOException {
             super(in);
             this.index = in.readString();
-            this.currentStepKey = new StepKey(in);
+            this.currentStepKey = StepKey.readFrom(in);
             this.nextStepKey = new PartialStepKey(in);
         }
 

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/AbstractStepTestCase.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/AbstractStepTestCase.java
@@ -63,8 +63,8 @@ public abstract class AbstractStepTestCase<T extends Step> extends ESTestCase {
     public void testStepNameNotError() {
         T instance = createRandomInstance();
         StepKey stepKey = instance.getKey();
-        assertFalse(ErrorStep.NAME.equals(stepKey.getName()));
+        assertFalse(ErrorStep.NAME.equals(stepKey.name()));
         StepKey nextStepKey = instance.getKey();
-        assertFalse(ErrorStep.NAME.equals(nextStepKey.getName()));
+        assertFalse(ErrorStep.NAME.equals(nextStepKey.name()));
     }
 }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/AbstractUnfollowIndexStepTestCase.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/AbstractUnfollowIndexStepTestCase.java
@@ -26,9 +26,9 @@ public abstract class AbstractUnfollowIndexStepTestCase<T extends AbstractUnfoll
         Step.StepKey nextKey = instance.getNextStepKey();
 
         if (randomBoolean()) {
-            key = new Step.StepKey(key.getPhase(), key.getAction(), key.getName() + randomAlphaOfLength(5));
+            key = new Step.StepKey(key.phase(), key.action(), key.name() + randomAlphaOfLength(5));
         } else {
-            nextKey = new Step.StepKey(nextKey.getPhase(), nextKey.getAction(), nextKey.getName() + randomAlphaOfLength(5));
+            nextKey = new Step.StepKey(nextKey.phase(), nextKey.action(), nextKey.name() + randomAlphaOfLength(5));
         }
 
         return newInstance(key, nextKey);

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/AllocationRoutedStepTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/AllocationRoutedStepTests.java
@@ -49,8 +49,8 @@ public class AllocationRoutedStepTests extends AbstractStepTestCase<AllocationRo
         StepKey nextKey = instance.getNextStepKey();
 
         switch (between(0, 1)) {
-            case 0 -> key = new StepKey(key.getPhase(), key.getAction(), key.getName() + randomAlphaOfLength(5));
-            case 1 -> nextKey = new StepKey(nextKey.getPhase(), nextKey.getAction(), nextKey.getName() + randomAlphaOfLength(5));
+            case 0 -> key = new StepKey(key.phase(), key.action(), key.name() + randomAlphaOfLength(5));
+            case 1 -> nextKey = new StepKey(nextKey.phase(), nextKey.action(), nextKey.name() + randomAlphaOfLength(5));
             default -> throw new AssertionError("Illegal randomisation branch");
         }
 

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/AsyncBranchingStepTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/AsyncBranchingStepTests.java
@@ -67,16 +67,12 @@ public class AsyncBranchingStepTests extends AbstractStepTestCase<AsyncBranching
         TriConsumer<IndexMetadata, ClusterState, ActionListener<Boolean>> asyncPredicate = instance.getAsyncPredicate();
 
         switch (between(0, 2)) {
-            case 0 -> key = new StepKey(key.getPhase(), key.getAction(), key.getName() + randomAlphaOfLength(5));
-            case 1 -> nextStepKey = new StepKey(
-                nextStepKey.getPhase(),
-                nextStepKey.getAction(),
-                nextStepKey.getName() + randomAlphaOfLength(5)
-            );
+            case 0 -> key = new StepKey(key.phase(), key.action(), key.name() + randomAlphaOfLength(5));
+            case 1 -> nextStepKey = new StepKey(nextStepKey.phase(), nextStepKey.action(), nextStepKey.name() + randomAlphaOfLength(5));
             case 2 -> nextSkipStepKey = new StepKey(
-                nextSkipStepKey.getPhase(),
-                nextSkipStepKey.getAction(),
-                nextSkipStepKey.getName() + randomAlphaOfLength(5)
+                nextSkipStepKey.phase(),
+                nextSkipStepKey.action(),
+                nextSkipStepKey.name() + randomAlphaOfLength(5)
             );
             default -> throw new AssertionError("Illegal randomisation branch");
         }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/BranchingStepTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/BranchingStepTests.java
@@ -64,16 +64,12 @@ public class BranchingStepTests extends AbstractStepTestCase<BranchingStep> {
         BiPredicate<Index, ClusterState> predicate = instance.getPredicate();
 
         switch (between(0, 2)) {
-            case 0 -> key = new StepKey(key.getPhase(), key.getAction(), key.getName() + randomAlphaOfLength(5));
-            case 1 -> nextStepKey = new StepKey(
-                nextStepKey.getPhase(),
-                nextStepKey.getAction(),
-                nextStepKey.getName() + randomAlphaOfLength(5)
-            );
+            case 0 -> key = new StepKey(key.phase(), key.action(), key.name() + randomAlphaOfLength(5));
+            case 1 -> nextStepKey = new StepKey(nextStepKey.phase(), nextStepKey.action(), nextStepKey.name() + randomAlphaOfLength(5));
             case 2 -> nextSkipStepKey = new StepKey(
-                nextSkipStepKey.getPhase(),
-                nextSkipStepKey.getAction(),
-                nextSkipStepKey.getName() + randomAlphaOfLength(5)
+                nextSkipStepKey.phase(),
+                nextSkipStepKey.action(),
+                nextSkipStepKey.name() + randomAlphaOfLength(5)
             );
             default -> throw new AssertionError("Illegal randomisation branch");
         }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/CheckNoDataStreamWriteIndexStepTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/CheckNoDataStreamWriteIndexStepTests.java
@@ -33,8 +33,8 @@ public class CheckNoDataStreamWriteIndexStepTests extends AbstractStepTestCase<C
         Step.StepKey nextKey = instance.getNextStepKey();
 
         switch (between(0, 1)) {
-            case 0 -> key = new Step.StepKey(key.getPhase(), key.getAction(), key.getName() + randomAlphaOfLength(5));
-            case 1 -> nextKey = new Step.StepKey(nextKey.getPhase(), nextKey.getAction(), nextKey.getName() + randomAlphaOfLength(5));
+            case 0 -> key = new Step.StepKey(key.phase(), key.action(), key.name() + randomAlphaOfLength(5));
+            case 1 -> nextKey = new Step.StepKey(nextKey.phase(), nextKey.action(), nextKey.name() + randomAlphaOfLength(5));
             default -> throw new AssertionError("Illegal randomisation branch");
         }
         return new CheckNotDataStreamWriteIndexStep(key, nextKey);

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/CheckShrinkReadyStepTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/CheckShrinkReadyStepTests.java
@@ -49,8 +49,8 @@ public class CheckShrinkReadyStepTests extends AbstractStepTestCase<CheckShrinkR
         Step.StepKey nextKey = instance.getNextStepKey();
 
         switch (between(0, 1)) {
-            case 0 -> key = new Step.StepKey(key.getPhase(), key.getAction(), key.getName() + randomAlphaOfLength(5));
-            case 1 -> nextKey = new Step.StepKey(nextKey.getPhase(), nextKey.getAction(), nextKey.getName() + randomAlphaOfLength(5));
+            case 0 -> key = new Step.StepKey(key.phase(), key.action(), key.name() + randomAlphaOfLength(5));
+            case 1 -> nextKey = new Step.StepKey(nextKey.phase(), nextKey.action(), nextKey.name() + randomAlphaOfLength(5));
             default -> throw new AssertionError("Illegal randomisation branch");
         }
 

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/CheckTargetShardsCountStepTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/CheckTargetShardsCountStepTests.java
@@ -28,8 +28,8 @@ public class CheckTargetShardsCountStepTests extends AbstractStepTestCase<CheckT
         StepKey nextKey = instance.getNextStepKey();
 
         switch (between(0, 1)) {
-            case 0 -> key = new StepKey(key.getPhase(), key.getAction(), key.getName() + randomAlphaOfLength(5));
-            case 1 -> nextKey = new StepKey(nextKey.getPhase(), nextKey.getAction(), nextKey.getName() + randomAlphaOfLength(5));
+            case 0 -> key = new StepKey(key.phase(), key.action(), key.name() + randomAlphaOfLength(5));
+            case 1 -> nextKey = new StepKey(nextKey.phase(), nextKey.action(), nextKey.name() + randomAlphaOfLength(5));
             default -> throw new AssertionError("Illegal randomisation branch");
         }
 

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/CleanupShrinkIndexStepTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/CleanupShrinkIndexStepTests.java
@@ -45,8 +45,8 @@ public class CleanupShrinkIndexStepTests extends AbstractStepTestCase<CleanupShr
         StepKey key = instance.getKey();
         StepKey nextKey = instance.getNextStepKey();
         switch (between(0, 1)) {
-            case 0 -> key = new StepKey(key.getPhase(), key.getAction(), key.getName() + randomAlphaOfLength(5));
-            case 1 -> nextKey = new StepKey(nextKey.getPhase(), nextKey.getAction(), nextKey.getName() + randomAlphaOfLength(5));
+            case 0 -> key = new StepKey(key.phase(), key.action(), key.name() + randomAlphaOfLength(5));
+            case 1 -> nextKey = new StepKey(nextKey.phase(), nextKey.action(), nextKey.name() + randomAlphaOfLength(5));
             default -> throw new AssertionError("Illegal randomisation branch");
         }
         return new CleanupShrinkIndexStep(key, nextKey, instance.getClient());

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/CleanupSnapshotStepTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/CleanupSnapshotStepTests.java
@@ -45,8 +45,8 @@ public class CleanupSnapshotStepTests extends AbstractStepTestCase<CleanupSnapsh
         StepKey key = instance.getKey();
         StepKey nextKey = instance.getNextStepKey();
         switch (between(0, 1)) {
-            case 0 -> key = new StepKey(key.getPhase(), key.getAction(), key.getName() + randomAlphaOfLength(5));
-            case 1 -> nextKey = new StepKey(nextKey.getPhase(), nextKey.getAction(), nextKey.getName() + randomAlphaOfLength(5));
+            case 0 -> key = new StepKey(key.phase(), key.action(), key.name() + randomAlphaOfLength(5));
+            case 1 -> nextKey = new StepKey(nextKey.phase(), nextKey.action(), nextKey.name() + randomAlphaOfLength(5));
             default -> throw new AssertionError("Illegal randomisation branch");
         }
         return new CleanupSnapshotStep(key, nextKey, instance.getClient());

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/CleanupTargetIndexStepTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/CleanupTargetIndexStepTests.java
@@ -62,8 +62,8 @@ public class CleanupTargetIndexStepTests extends AbstractStepTestCase<CleanupTar
         Function<IndexMetadata, String> targetIndexNameSupplier = instance.getTargetIndexNameSupplier();
 
         switch (between(0, 3)) {
-            case 0 -> key = new StepKey(key.getPhase(), key.getAction(), key.getName() + randomAlphaOfLength(5));
-            case 1 -> nextKey = new StepKey(nextKey.getPhase(), nextKey.getAction(), nextKey.getName() + randomAlphaOfLength(5));
+            case 0 -> key = new StepKey(key.phase(), key.action(), key.name() + randomAlphaOfLength(5));
+            case 1 -> nextKey = new StepKey(nextKey.phase(), nextKey.action(), nextKey.name() + randomAlphaOfLength(5));
             case 2 -> sourceIndexNameSupplier = (indexMetadata) -> randomAlphaOfLengthBetween(11, 15) + indexMetadata.getIndex().getName();
             case 3 -> targetIndexNameSupplier = (indexMetadata) -> randomAlphaOfLengthBetween(11, 15) + indexMetadata.getIndex().getName();
             default -> throw new AssertionError("Illegal randomisation branch");

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/CloseFollowerIndexStepTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/CloseFollowerIndexStepTests.java
@@ -118,9 +118,9 @@ public class CloseFollowerIndexStepTests extends AbstractStepTestCase<CloseFollo
         Step.StepKey nextKey = instance.getNextStepKey();
 
         if (randomBoolean()) {
-            key = new Step.StepKey(key.getPhase(), key.getAction(), key.getName() + randomAlphaOfLength(5));
+            key = new Step.StepKey(key.phase(), key.action(), key.name() + randomAlphaOfLength(5));
         } else {
-            nextKey = new Step.StepKey(nextKey.getPhase(), nextKey.getAction(), nextKey.getName() + randomAlphaOfLength(5));
+            nextKey = new Step.StepKey(nextKey.phase(), nextKey.action(), nextKey.name() + randomAlphaOfLength(5));
         }
 
         return new CloseFollowerIndexStep(key, nextKey, instance.getClient());

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/CloseIndexStepTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/CloseIndexStepTests.java
@@ -45,8 +45,8 @@ public class CloseIndexStepTests extends AbstractStepTestCase<CloseIndexStep> {
         Step.StepKey nextKey = instance.getNextStepKey();
 
         switch (between(0, 1)) {
-            case 0 -> key = new Step.StepKey(key.getPhase(), key.getAction(), key.getName() + randomAlphaOfLength(5));
-            case 1 -> nextKey = new Step.StepKey(nextKey.getPhase(), nextKey.getAction(), nextKey.getName() + randomAlphaOfLength(5));
+            case 0 -> key = new Step.StepKey(key.phase(), key.action(), key.name() + randomAlphaOfLength(5));
+            case 1 -> nextKey = new Step.StepKey(nextKey.phase(), nextKey.action(), nextKey.name() + randomAlphaOfLength(5));
             default -> throw new AssertionError("Illegal randomisation branch");
         }
 

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/ClusterStateWaitUntilThresholdStepTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/ClusterStateWaitUntilThresholdStepTests.java
@@ -191,9 +191,9 @@ public class ClusterStateWaitUntilThresholdStepTests extends AbstractStepTestCas
                 info.getMessage(),
                 equalTo(
                     "["
-                        + currentStepKey.getName()
+                        + currentStepKey.name()
                         + "] lifecycle step, as part of ["
-                        + currentStepKey.getAction()
+                        + currentStepKey.action()
                         + "] "
                         + "action, for index [follower-index] executed for more than [1h]. Abandoning execution and moving to the next "
                         + "fallback step ["
@@ -274,7 +274,7 @@ public class ClusterStateWaitUntilThresholdStepTests extends AbstractStepTestCas
 
         assertFalse(step.isConditionMet(indexMetadata.getIndex(), clusterState).isComplete());
 
-        assertThat(step.getNextStepKey().getName(), equalTo("next-key"));
+        assertThat(step.getNextStepKey().name(), equalTo("next-key"));
 
         step = new ClusterStateWaitUntilThresholdStep(
             new ClusterStateWaitStep(new StepKey("phase", "action", "key"), new StepKey("phase", "action", "next-key")) {
@@ -296,6 +296,6 @@ public class ClusterStateWaitUntilThresholdStepTests extends AbstractStepTestCas
             new StepKey("phase", "action", "breached")
         );
         assertTrue(step.isConditionMet(indexMetadata.getIndex(), clusterState).isComplete());
-        assertThat(step.getNextStepKey().getName(), equalTo("breached"));
+        assertThat(step.getNextStepKey().name(), equalTo("breached"));
     }
 }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/CopyExecutionStateStepTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/CopyExecutionStateStepTests.java
@@ -41,13 +41,13 @@ public class CopyExecutionStateStepTests extends AbstractStepTestCase<CopyExecut
         StepKey targetNextStepKey = instance.getTargetNextStepKey();
 
         switch (between(0, 3)) {
-            case 0 -> key = new StepKey(key.getPhase(), key.getAction(), key.getName() + randomAlphaOfLength(5));
-            case 1 -> nextKey = new StepKey(nextKey.getPhase(), nextKey.getAction(), nextKey.getName() + randomAlphaOfLength(5));
+            case 0 -> key = new StepKey(key.phase(), key.action(), key.name() + randomAlphaOfLength(5));
+            case 1 -> nextKey = new StepKey(nextKey.phase(), nextKey.action(), nextKey.name() + randomAlphaOfLength(5));
             case 2 -> indexNameSupplier = (index, state) -> randomAlphaOfLengthBetween(11, 15) + index;
             case 3 -> targetNextStepKey = new StepKey(
-                targetNextStepKey.getPhase(),
-                targetNextStepKey.getAction(),
-                targetNextStepKey.getName() + randomAlphaOfLength(5)
+                targetNextStepKey.phase(),
+                targetNextStepKey.action(),
+                targetNextStepKey.name() + randomAlphaOfLength(5)
             );
             default -> throw new AssertionError("Illegal randomisation branch");
         }
@@ -92,9 +92,9 @@ public class CopyExecutionStateStepTests extends AbstractStepTestCase<CopyExecut
 
         StepKey targetNextStepKey = step.getTargetNextStepKey();
         assertEquals(newIndexData.lifecycleDate(), oldIndexData.lifecycleDate());
-        assertEquals(newIndexData.phase(), targetNextStepKey.getPhase());
-        assertEquals(newIndexData.action(), targetNextStepKey.getAction());
-        assertEquals(newIndexData.step(), targetNextStepKey.getName());
+        assertEquals(newIndexData.phase(), targetNextStepKey.phase());
+        assertEquals(newIndexData.action(), targetNextStepKey.action());
+        assertEquals(newIndexData.step(), targetNextStepKey.name());
         assertEquals(newIndexData.snapshotRepository(), oldIndexData.snapshotRepository());
         assertEquals(newIndexData.snapshotName(), oldIndexData.snapshotName());
     }
@@ -126,9 +126,9 @@ public class CopyExecutionStateStepTests extends AbstractStepTestCase<CopyExecut
 
         Map<String, String> beforeMap = new HashMap<>(oldIndexData.asMap());
         // The target step key's StepKey is used in the new metadata, so update the "before" map with the new info so it can be compared
-        beforeMap.put("phase", step.getTargetNextStepKey().getPhase());
-        beforeMap.put("action", step.getTargetNextStepKey().getAction());
-        beforeMap.put("step", step.getTargetNextStepKey().getName());
+        beforeMap.put("phase", step.getTargetNextStepKey().phase());
+        beforeMap.put("action", step.getTargetNextStepKey().action());
+        beforeMap.put("step", step.getTargetNextStepKey().name());
         Map<String, String> newMap = newIndexData.asMap();
         assertThat(beforeMap, equalTo(newMap));
     }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/CopySettingsStepTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/CopySettingsStepTests.java
@@ -36,8 +36,8 @@ public class CopySettingsStepTests extends AbstractStepTestCase<CopySettingsStep
         String[] settingsKeys = instance.getSettingsKeys();
 
         switch (between(0, 3)) {
-            case 0 -> key = new Step.StepKey(key.getPhase(), key.getAction(), key.getName() + randomAlphaOfLength(5));
-            case 1 -> nextKey = new Step.StepKey(nextKey.getPhase(), nextKey.getAction(), nextKey.getName() + randomAlphaOfLength(5));
+            case 0 -> key = new Step.StepKey(key.phase(), key.action(), key.name() + randomAlphaOfLength(5));
+            case 1 -> nextKey = new Step.StepKey(nextKey.phase(), nextKey.action(), nextKey.name() + randomAlphaOfLength(5));
             case 2 -> settingsKeys = new String[] { randomAlphaOfLengthBetween(1, 10) };
             case 3 -> targetIndexNameSupplier = (index, state) -> randomAlphaOfLengthBetween(11, 15) + index;
             default -> throw new AssertionError("Illegal randomisation branch");

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/CreateSnapshotStepTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/CreateSnapshotStepTests.java
@@ -53,7 +53,7 @@ public class CreateSnapshotStepTests extends AbstractStepTestCase<CreateSnapshot
         StepKey nextKeyOnCompleteResponse = instance.getNextKeyOnComplete();
         StepKey nextKeyOnIncompleteResponse = instance.getNextKeyOnIncomplete();
         switch (between(0, 2)) {
-            case 0 -> key = new StepKey(key.getPhase(), key.getAction(), key.getName() + randomAlphaOfLength(5));
+            case 0 -> key = new StepKey(key.phase(), key.action(), key.name() + randomAlphaOfLength(5));
             case 1 -> nextKeyOnCompleteResponse = randomStepKey();
             case 2 -> nextKeyOnIncompleteResponse = randomStepKey();
             default -> throw new AssertionError("Illegal randomisation branch");

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/DataTierMigrationRoutedStepTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/DataTierMigrationRoutedStepTests.java
@@ -50,8 +50,8 @@ public class DataTierMigrationRoutedStepTests extends AbstractStepTestCase<DataT
         StepKey nextKey = instance.getNextStepKey();
 
         switch (between(0, 1)) {
-            case 0 -> key = new StepKey(key.getPhase(), key.getAction(), key.getName() + randomAlphaOfLength(5));
-            case 1 -> nextKey = new StepKey(nextKey.getPhase(), nextKey.getAction(), nextKey.getName() + randomAlphaOfLength(5));
+            case 0 -> key = new StepKey(key.phase(), key.action(), key.name() + randomAlphaOfLength(5));
+            case 1 -> nextKey = new StepKey(nextKey.phase(), nextKey.action(), nextKey.name() + randomAlphaOfLength(5));
             default -> throw new AssertionError("Illegal randomisation branch");
         }
 
@@ -125,7 +125,7 @@ public class DataTierMigrationRoutedStepTests extends AbstractStepTestCase<DataT
                 "["
                     + index.getName()
                     + "] lifecycle action ["
-                    + step.getKey().getAction()
+                    + step.getKey().action()
                     + "] waiting for "
                     + "[1] shards to be moved to the [data_warm] tier (tier migration preference configuration is [data_warm])"
             )

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/DeleteStepTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/DeleteStepTests.java
@@ -39,8 +39,8 @@ public class DeleteStepTests extends AbstractStepTestCase<DeleteStep> {
         StepKey nextKey = instance.getNextStepKey();
 
         switch (between(0, 1)) {
-            case 0 -> key = new StepKey(key.getPhase(), key.getAction(), key.getName() + randomAlphaOfLength(5));
-            case 1 -> nextKey = new StepKey(nextKey.getPhase(), nextKey.getAction(), nextKey.getName() + randomAlphaOfLength(5));
+            case 0 -> key = new StepKey(key.phase(), key.action(), key.name() + randomAlphaOfLength(5));
+            case 1 -> nextKey = new StepKey(nextKey.phase(), nextKey.action(), nextKey.name() + randomAlphaOfLength(5));
             default -> throw new AssertionError("Illegal randomisation branch");
         }
 

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/DownsampleActionTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/DownsampleActionTests.java
@@ -59,53 +59,53 @@ public class DownsampleActionTests extends AbstractActionTestCase<DownsampleActi
         assertEquals(12, steps.size());
 
         assertTrue(steps.get(0) instanceof CheckNotDataStreamWriteIndexStep);
-        assertThat(steps.get(0).getKey().getName(), equalTo(CheckNotDataStreamWriteIndexStep.NAME));
-        assertThat(steps.get(0).getNextStepKey().getName(), equalTo(WaitForNoFollowersStep.NAME));
+        assertThat(steps.get(0).getKey().name(), equalTo(CheckNotDataStreamWriteIndexStep.NAME));
+        assertThat(steps.get(0).getNextStepKey().name(), equalTo(WaitForNoFollowersStep.NAME));
 
         assertTrue(steps.get(1) instanceof WaitForNoFollowersStep);
-        assertThat(steps.get(1).getKey().getName(), equalTo(WaitForNoFollowersStep.NAME));
-        assertThat(steps.get(1).getNextStepKey().getName(), equalTo(CleanupTargetIndexStep.NAME));
+        assertThat(steps.get(1).getKey().name(), equalTo(WaitForNoFollowersStep.NAME));
+        assertThat(steps.get(1).getNextStepKey().name(), equalTo(CleanupTargetIndexStep.NAME));
 
         assertTrue(steps.get(2) instanceof CleanupTargetIndexStep);
-        assertThat(steps.get(2).getKey().getName(), equalTo(CleanupTargetIndexStep.NAME));
-        assertThat(steps.get(2).getNextStepKey().getName(), equalTo(ReadOnlyStep.NAME));
+        assertThat(steps.get(2).getKey().name(), equalTo(CleanupTargetIndexStep.NAME));
+        assertThat(steps.get(2).getNextStepKey().name(), equalTo(ReadOnlyStep.NAME));
 
         assertTrue(steps.get(3) instanceof ReadOnlyStep);
-        assertThat(steps.get(3).getKey().getName(), equalTo(ReadOnlyStep.NAME));
-        assertThat(steps.get(3).getNextStepKey().getName(), equalTo(GENERATE_DOWNSAMPLE_STEP_NAME));
+        assertThat(steps.get(3).getKey().name(), equalTo(ReadOnlyStep.NAME));
+        assertThat(steps.get(3).getNextStepKey().name(), equalTo(GENERATE_DOWNSAMPLE_STEP_NAME));
 
         assertTrue(steps.get(4) instanceof GenerateUniqueIndexNameStep);
-        assertThat(steps.get(4).getKey().getName(), equalTo(GENERATE_DOWNSAMPLE_STEP_NAME));
-        assertThat(steps.get(4).getNextStepKey().getName(), equalTo(RollupStep.NAME));
+        assertThat(steps.get(4).getKey().name(), equalTo(GENERATE_DOWNSAMPLE_STEP_NAME));
+        assertThat(steps.get(4).getNextStepKey().name(), equalTo(RollupStep.NAME));
 
         assertTrue(steps.get(5) instanceof RollupStep);
-        assertThat(steps.get(5).getKey().getName(), equalTo(RollupStep.NAME));
-        assertThat(steps.get(5).getNextStepKey().getName(), equalTo(WaitForIndexColorStep.NAME));
+        assertThat(steps.get(5).getKey().name(), equalTo(RollupStep.NAME));
+        assertThat(steps.get(5).getNextStepKey().name(), equalTo(WaitForIndexColorStep.NAME));
 
         assertTrue(steps.get(6) instanceof ClusterStateWaitUntilThresholdStep);
-        assertThat(steps.get(6).getKey().getName(), equalTo(WaitForIndexColorStep.NAME));
-        assertThat(steps.get(6).getNextStepKey().getName(), equalTo(CopyExecutionStateStep.NAME));
+        assertThat(steps.get(6).getKey().name(), equalTo(WaitForIndexColorStep.NAME));
+        assertThat(steps.get(6).getNextStepKey().name(), equalTo(CopyExecutionStateStep.NAME));
 
         assertTrue(steps.get(7) instanceof CopyExecutionStateStep);
-        assertThat(steps.get(7).getKey().getName(), equalTo(CopyExecutionStateStep.NAME));
-        assertThat(steps.get(7).getNextStepKey().getName(), equalTo(CONDITIONAL_DATASTREAM_CHECK_KEY));
+        assertThat(steps.get(7).getKey().name(), equalTo(CopyExecutionStateStep.NAME));
+        assertThat(steps.get(7).getNextStepKey().name(), equalTo(CONDITIONAL_DATASTREAM_CHECK_KEY));
 
         assertTrue(steps.get(8) instanceof BranchingStep);
-        assertThat(steps.get(8).getKey().getName(), equalTo(CONDITIONAL_DATASTREAM_CHECK_KEY));
+        assertThat(steps.get(8).getKey().name(), equalTo(CONDITIONAL_DATASTREAM_CHECK_KEY));
         expectThrows(IllegalStateException.class, () -> steps.get(8).getNextStepKey());
-        assertThat(((BranchingStep) steps.get(8)).getNextStepKeyOnFalse().getName(), equalTo(SwapAliasesAndDeleteSourceIndexStep.NAME));
-        assertThat(((BranchingStep) steps.get(8)).getNextStepKeyOnTrue().getName(), equalTo(ReplaceDataStreamBackingIndexStep.NAME));
+        assertThat(((BranchingStep) steps.get(8)).getNextStepKeyOnFalse().name(), equalTo(SwapAliasesAndDeleteSourceIndexStep.NAME));
+        assertThat(((BranchingStep) steps.get(8)).getNextStepKeyOnTrue().name(), equalTo(ReplaceDataStreamBackingIndexStep.NAME));
 
         assertTrue(steps.get(9) instanceof ReplaceDataStreamBackingIndexStep);
-        assertThat(steps.get(9).getKey().getName(), equalTo(ReplaceDataStreamBackingIndexStep.NAME));
-        assertThat(steps.get(9).getNextStepKey().getName(), equalTo(DeleteStep.NAME));
+        assertThat(steps.get(9).getKey().name(), equalTo(ReplaceDataStreamBackingIndexStep.NAME));
+        assertThat(steps.get(9).getNextStepKey().name(), equalTo(DeleteStep.NAME));
 
         assertTrue(steps.get(10) instanceof DeleteStep);
-        assertThat(steps.get(10).getKey().getName(), equalTo(DeleteStep.NAME));
+        assertThat(steps.get(10).getKey().name(), equalTo(DeleteStep.NAME));
         assertThat(steps.get(10).getNextStepKey(), equalTo(nextStepKey));
 
         assertTrue(steps.get(11) instanceof SwapAliasesAndDeleteSourceIndexStep);
-        assertThat(steps.get(11).getKey().getName(), equalTo(SwapAliasesAndDeleteSourceIndexStep.NAME));
+        assertThat(steps.get(11).getKey().name(), equalTo(SwapAliasesAndDeleteSourceIndexStep.NAME));
         assertThat(steps.get(11).getNextStepKey(), equalTo(nextStepKey));
     }
 

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/ErrorStepTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/ErrorStepTests.java
@@ -21,7 +21,7 @@ public class ErrorStepTests extends AbstractStepTestCase<ErrorStep> {
         StepKey key = instance.getKey();
         assertSame(instance.getNextStepKey(), instance.getKey());
 
-        key = new StepKey(key.getPhase(), key.getAction() + randomAlphaOfLength(5), key.getName());
+        key = new StepKey(key.phase(), key.action() + randomAlphaOfLength(5), key.name());
 
         return new ErrorStep(key);
     }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/ForceMergeStepTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/ForceMergeStepTests.java
@@ -46,8 +46,8 @@ public class ForceMergeStepTests extends AbstractStepTestCase<ForceMergeStep> {
         int maxNumSegments = instance.getMaxNumSegments();
 
         switch (between(0, 2)) {
-            case 0 -> key = new StepKey(key.getPhase(), key.getAction(), key.getName() + randomAlphaOfLength(5));
-            case 1 -> nextKey = new StepKey(nextKey.getPhase(), nextKey.getAction(), nextKey.getName() + randomAlphaOfLength(5));
+            case 0 -> key = new StepKey(key.phase(), key.action(), key.name() + randomAlphaOfLength(5));
+            case 1 -> nextKey = new StepKey(nextKey.phase(), nextKey.action(), nextKey.name() + randomAlphaOfLength(5));
             case 2 -> maxNumSegments += 1;
             default -> throw new AssertionError("Illegal randomisation branch");
         }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/FreezeStepTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/FreezeStepTests.java
@@ -26,8 +26,8 @@ public class FreezeStepTests extends AbstractStepTestCase<FreezeStep> {
         StepKey nextKey = instance.getNextStepKey();
 
         switch (between(0, 1)) {
-            case 0 -> key = new StepKey(key.getPhase(), key.getAction(), key.getName() + randomAlphaOfLength(5));
-            case 1 -> nextKey = new StepKey(nextKey.getPhase(), nextKey.getAction(), nextKey.getName() + randomAlphaOfLength(5));
+            case 0 -> key = new StepKey(key.phase(), key.action(), key.name() + randomAlphaOfLength(5));
+            case 1 -> nextKey = new StepKey(nextKey.phase(), nextKey.action(), nextKey.name() + randomAlphaOfLength(5));
             default -> throw new AssertionError("Illegal randomisation branch");
         }
 

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/GenerateSnapshotNameStepTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/GenerateSnapshotNameStepTests.java
@@ -46,8 +46,8 @@ public class GenerateSnapshotNameStepTests extends AbstractStepTestCase<Generate
         String snapshotRepository = instance.getSnapshotRepository();
 
         switch (between(0, 2)) {
-            case 0 -> key = new Step.StepKey(key.getPhase(), key.getAction(), key.getName() + randomAlphaOfLength(5));
-            case 1 -> nextKey = new Step.StepKey(nextKey.getPhase(), nextKey.getAction(), nextKey.getName() + randomAlphaOfLength(5));
+            case 0 -> key = new Step.StepKey(key.phase(), key.action(), key.name() + randomAlphaOfLength(5));
+            case 1 -> nextKey = new Step.StepKey(nextKey.phase(), nextKey.action(), nextKey.name() + randomAlphaOfLength(5));
             case 2 -> snapshotRepository = randomValueOtherThan(snapshotRepository, () -> randomAlphaOfLengthBetween(5, 10));
             default -> throw new AssertionError("Illegal randomisation branch");
         }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/GenerateUniqueIndexNameStepTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/GenerateUniqueIndexNameStepTests.java
@@ -54,8 +54,8 @@ public class GenerateUniqueIndexNameStepTests extends AbstractStepTestCase<Gener
         String prefix = instance.prefix();
 
         switch (between(0, 2)) {
-            case 0 -> key = new Step.StepKey(key.getPhase(), key.getAction(), key.getName() + randomAlphaOfLength(5));
-            case 1 -> nextKey = new Step.StepKey(nextKey.getPhase(), nextKey.getAction(), nextKey.getName() + randomAlphaOfLength(5));
+            case 0 -> key = new Step.StepKey(key.phase(), key.action(), key.name() + randomAlphaOfLength(5));
+            case 1 -> nextKey = new Step.StepKey(nextKey.phase(), nextKey.action(), nextKey.name() + randomAlphaOfLength(5));
             case 2 -> prefix = randomValueOtherThan(prefix, () -> randomAlphaOfLengthBetween(5, 10));
             default -> throw new AssertionError("Illegal randomisation branch");
         }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/InitializePolicyContextStepTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/InitializePolicyContextStepTests.java
@@ -34,8 +34,8 @@ public class InitializePolicyContextStepTests extends AbstractStepTestCase<Initi
         StepKey nextKey = instance.getNextStepKey();
 
         switch (between(0, 1)) {
-            case 0 -> key = new StepKey(key.getPhase(), key.getAction(), key.getName() + randomAlphaOfLength(5));
-            case 1 -> nextKey = new StepKey(nextKey.getPhase(), nextKey.getAction(), nextKey.getName() + randomAlphaOfLength(5));
+            case 0 -> key = new StepKey(key.phase(), key.action(), key.name() + randomAlphaOfLength(5));
+            case 1 -> nextKey = new StepKey(nextKey.phase(), nextKey.action(), nextKey.name() + randomAlphaOfLength(5));
             default -> throw new AssertionError("Illegal randomisation branch");
         }
 

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/LifecycleExecutionStateTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/LifecycleExecutionStateTests.java
@@ -88,9 +88,9 @@ public class LifecycleExecutionStateTests extends ESTestCase {
         lifecycleState2.setStep(step);
         stepKey = Step.getCurrentStepKey(lifecycleState2.build());
         assertNotNull(stepKey);
-        assertEquals(phase, stepKey.getPhase());
-        assertEquals(action, stepKey.getAction());
-        assertEquals(step, stepKey.getName());
+        assertEquals(phase, stepKey.phase());
+        assertEquals(action, stepKey.action());
+        assertEquals(step, stepKey.name());
 
         phase = randomAlphaOfLength(20);
         action = randomAlphaOfLength(20);

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/MockStep.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/MockStep.java
@@ -41,15 +41,15 @@ public class MockStep extends Step implements Writeable {
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
-        out.writeString(getKey().getPhase());
-        out.writeString(getKey().getAction());
-        out.writeString(getKey().getName());
+        out.writeString(getKey().phase());
+        out.writeString(getKey().action());
+        out.writeString(getKey().name());
         boolean hasNextStep = getNextStepKey() != null;
         out.writeBoolean(hasNextStep);
         if (hasNextStep) {
-            out.writeString(getNextStepKey().getPhase());
-            out.writeString(getNextStepKey().getAction());
-            out.writeString(getNextStepKey().getName());
+            out.writeString(getNextStepKey().phase());
+            out.writeString(getNextStepKey().action());
+            out.writeString(getNextStepKey().name());
         }
     }
 }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/MountSnapshotStepTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/MountSnapshotStepTests.java
@@ -71,10 +71,10 @@ public class MountSnapshotStepTests extends AbstractStepTestCase<MountSnapshotSt
         MountSearchableSnapshotRequest.Storage storage = instance.getStorage();
         switch (between(0, 3)) {
             case 0:
-                key = new StepKey(key.getPhase(), key.getAction(), key.getName() + randomAlphaOfLength(5));
+                key = new StepKey(key.phase(), key.action(), key.name() + randomAlphaOfLength(5));
                 break;
             case 1:
-                nextKey = new StepKey(nextKey.getPhase(), nextKey.getAction(), nextKey.getName() + randomAlphaOfLength(5));
+                nextKey = new StepKey(nextKey.phase(), nextKey.action(), nextKey.name() + randomAlphaOfLength(5));
                 break;
             case 2:
                 restoredIndexPrefix = randomValueOtherThan(restoredIndexPrefix, () -> randomAlphaOfLengthBetween(1, 10));

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/OpenIndexStepTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/OpenIndexStepTests.java
@@ -42,8 +42,8 @@ public class OpenIndexStepTests extends AbstractStepTestCase<OpenIndexStep> {
         Step.StepKey nextKey = instance.getNextStepKey();
 
         switch (between(0, 1)) {
-            case 0 -> key = new Step.StepKey(key.getPhase(), key.getAction(), key.getName() + randomAlphaOfLength(5));
-            case 1 -> nextKey = new Step.StepKey(nextKey.getPhase(), nextKey.getAction(), nextKey.getName() + randomAlphaOfLength(5));
+            case 0 -> key = new Step.StepKey(key.phase(), key.action(), key.name() + randomAlphaOfLength(5));
+            case 1 -> nextKey = new Step.StepKey(nextKey.phase(), nextKey.action(), nextKey.name() + randomAlphaOfLength(5));
             default -> throw new AssertionError("Illegal randomisation branch");
         }
 

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/PhaseCompleteStepTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/PhaseCompleteStepTests.java
@@ -23,9 +23,9 @@ public class PhaseCompleteStepTests extends AbstractStepTestCase<PhaseCompleteSt
         StepKey nextKey = instance.getNextStepKey();
 
         if (randomBoolean()) {
-            key = new StepKey(key.getPhase(), key.getAction(), key.getName() + randomAlphaOfLength(5));
+            key = new StepKey(key.phase(), key.action(), key.name() + randomAlphaOfLength(5));
         } else {
-            nextKey = new StepKey(nextKey.getPhase(), nextKey.getAction(), nextKey.getName() + randomAlphaOfLength(5));
+            nextKey = new StepKey(nextKey.phase(), nextKey.action(), nextKey.name() + randomAlphaOfLength(5));
         }
 
         return new PhaseCompleteStep(key, nextKey);

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/ReplaceDataStreamBackingIndexStepTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/ReplaceDataStreamBackingIndexStepTests.java
@@ -37,8 +37,8 @@ public class ReplaceDataStreamBackingIndexStepTests extends AbstractStepTestCase
         BiFunction<String, LifecycleExecutionState, String> indexNameSupplier = instance.getTargetIndexNameSupplier();
 
         switch (between(0, 2)) {
-            case 0 -> key = new Step.StepKey(key.getPhase(), key.getAction(), key.getName() + randomAlphaOfLength(5));
-            case 1 -> nextKey = new Step.StepKey(nextKey.getPhase(), nextKey.getAction(), nextKey.getName() + randomAlphaOfLength(5));
+            case 0 -> key = new Step.StepKey(key.phase(), key.action(), key.name() + randomAlphaOfLength(5));
+            case 1 -> nextKey = new Step.StepKey(nextKey.phase(), nextKey.action(), nextKey.name() + randomAlphaOfLength(5));
             case 2 -> indexNameSupplier = (index, state) -> randomAlphaOfLengthBetween(11, 15) + index;
             default -> throw new AssertionError("Illegal randomisation branch");
         }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/RolloverStepTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/RolloverStepTests.java
@@ -47,8 +47,8 @@ public class RolloverStepTests extends AbstractStepTestCase<RolloverStep> {
         StepKey nextKey = instance.getNextStepKey();
 
         switch (between(0, 1)) {
-            case 0 -> key = new StepKey(key.getPhase(), key.getAction(), key.getName() + randomAlphaOfLength(5));
-            case 1 -> nextKey = new StepKey(nextKey.getPhase(), nextKey.getAction(), nextKey.getName() + randomAlphaOfLength(5));
+            case 0 -> key = new StepKey(key.phase(), key.action(), key.name() + randomAlphaOfLength(5));
+            case 1 -> nextKey = new StepKey(nextKey.phase(), nextKey.action(), nextKey.name() + randomAlphaOfLength(5));
             default -> throw new AssertionError("Illegal randomisation branch");
         }
 

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/RollupStepTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/RollupStepTests.java
@@ -49,8 +49,8 @@ public class RollupStepTests extends AbstractStepTestCase<RollupStep> {
         DateHistogramInterval fixedInterval = instance.getFixedInterval();
 
         switch (between(0, 2)) {
-            case 0 -> key = new StepKey(key.getPhase(), key.getAction(), key.getName() + randomAlphaOfLength(5));
-            case 1 -> nextKey = new StepKey(nextKey.getPhase(), nextKey.getAction(), nextKey.getName() + randomAlphaOfLength(5));
+            case 0 -> key = new StepKey(key.phase(), key.action(), key.name() + randomAlphaOfLength(5));
+            case 1 -> nextKey = new StepKey(nextKey.phase(), nextKey.action(), nextKey.name() + randomAlphaOfLength(5));
             case 2 -> fixedInterval = ConfigTestHelpers.randomInterval();
             default -> throw new AssertionError("Illegal randomisation branch");
         }
@@ -65,9 +65,9 @@ public class RollupStepTests extends AbstractStepTestCase<RollupStep> {
 
     private IndexMetadata getIndexMetadata(String index, String lifecycleName, RollupStep step) {
         LifecycleExecutionState.Builder lifecycleState = LifecycleExecutionState.builder();
-        lifecycleState.setPhase(step.getKey().getPhase());
-        lifecycleState.setAction(step.getKey().getAction());
-        lifecycleState.setStep(step.getKey().getName());
+        lifecycleState.setPhase(step.getKey().phase());
+        lifecycleState.setAction(step.getKey().action());
+        lifecycleState.setStep(step.getKey().name());
         lifecycleState.setIndexCreationDate(randomNonNegativeLong());
         lifecycleState.setRollupIndexName("rollup-index");
 
@@ -102,9 +102,9 @@ public class RollupStepTests extends AbstractStepTestCase<RollupStep> {
         RollupStep step = createRandomInstance();
 
         LifecycleExecutionState.Builder lifecycleState = LifecycleExecutionState.builder();
-        lifecycleState.setPhase(step.getKey().getPhase());
-        lifecycleState.setAction(step.getKey().getAction());
-        lifecycleState.setStep(step.getKey().getName());
+        lifecycleState.setPhase(step.getKey().phase());
+        lifecycleState.setAction(step.getKey().action());
+        lifecycleState.setStep(step.getKey().name());
         lifecycleState.setIndexCreationDate(randomNonNegativeLong());
 
         IndexMetadata indexMetadata = IndexMetadata.builder(randomAlphaOfLength(10))
@@ -157,9 +157,9 @@ public class RollupStepTests extends AbstractStepTestCase<RollupStep> {
         RollupStep step = createRandomInstance();
 
         LifecycleExecutionState.Builder lifecycleState = LifecycleExecutionState.builder();
-        lifecycleState.setPhase(step.getKey().getPhase());
-        lifecycleState.setAction(step.getKey().getAction());
-        lifecycleState.setStep(step.getKey().getName());
+        lifecycleState.setPhase(step.getKey().phase());
+        lifecycleState.setAction(step.getKey().action());
+        lifecycleState.setStep(step.getKey().name());
         lifecycleState.setIndexCreationDate(randomNonNegativeLong());
 
         String rollupIndex = GenerateUniqueIndexNameStep.generateValidIndexName(DOWNSAMPLED_INDEX_PREFIX, sourceIndexName);
@@ -207,9 +207,9 @@ public class RollupStepTests extends AbstractStepTestCase<RollupStep> {
         RollupStep step = createRandomInstance();
 
         LifecycleExecutionState.Builder lifecycleState = LifecycleExecutionState.builder();
-        lifecycleState.setPhase(step.getKey().getPhase());
-        lifecycleState.setAction(step.getKey().getAction());
-        lifecycleState.setStep(step.getKey().getName());
+        lifecycleState.setPhase(step.getKey().phase());
+        lifecycleState.setAction(step.getKey().action());
+        lifecycleState.setStep(step.getKey().name());
         lifecycleState.setIndexCreationDate(randomNonNegativeLong());
 
         String rollupIndex = GenerateUniqueIndexNameStep.generateValidIndexName(DOWNSAMPLED_INDEX_PREFIX, sourceIndexName);

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/SegmentCountStepTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/SegmentCountStepTests.java
@@ -63,8 +63,8 @@ public class SegmentCountStepTests extends AbstractStepTestCase<SegmentCountStep
         int maxNumSegments = instance.getMaxNumSegments();
 
         switch (between(0, 2)) {
-            case 0 -> key = new StepKey(key.getPhase(), key.getAction(), key.getName() + randomAlphaOfLength(5));
-            case 1 -> nextKey = new StepKey(nextKey.getPhase(), nextKey.getAction(), nextKey.getName() + randomAlphaOfLength(5));
+            case 0 -> key = new StepKey(key.phase(), key.action(), key.name() + randomAlphaOfLength(5));
+            case 1 -> nextKey = new StepKey(nextKey.phase(), nextKey.action(), nextKey.name() + randomAlphaOfLength(5));
             case 2 -> maxNumSegments += 1;
             default -> throw new AssertionError("Illegal randomisation branch");
         }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/SetSingleNodeAllocateStepTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/SetSingleNodeAllocateStepTests.java
@@ -59,8 +59,8 @@ public class SetSingleNodeAllocateStepTests extends AbstractStepTestCase<SetSing
         StepKey nextKey = instance.getNextStepKey();
 
         switch (between(0, 1)) {
-            case 0 -> key = new StepKey(key.getPhase(), key.getAction(), key.getName() + randomAlphaOfLength(5));
-            case 1 -> nextKey = new StepKey(nextKey.getPhase(), nextKey.getAction(), nextKey.getName() + randomAlphaOfLength(5));
+            case 0 -> key = new StepKey(key.phase(), key.action(), key.name() + randomAlphaOfLength(5));
+            case 1 -> nextKey = new StepKey(nextKey.phase(), nextKey.action(), nextKey.name() + randomAlphaOfLength(5));
             default -> throw new AssertionError("Illegal randomisation branch");
         }
 

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/ShrinkActionTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/ShrinkActionTests.java
@@ -211,11 +211,11 @@ public class ShrinkActionTests extends AbstractActionTestCase<ShrinkAction> {
                         indexMetadataBuilder.putCustom(
                             LifecycleExecutionState.ILM_CUSTOM_METADATA_KEY,
                             LifecycleExecutionState.builder()
-                                .setPhase(step.getKey().getPhase())
+                                .setPhase(step.getKey().phase())
                                 .setPhaseTime(0L)
-                                .setAction(step.getKey().getAction())
+                                .setAction(step.getKey().action())
                                 .setActionTime(0L)
-                                .setStep(step.getKey().getName())
+                                .setStep(step.getKey().name())
                                 .setStepTime(0L)
                                 .build()
                                 .asMap()

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/ShrinkSetAliasStepTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/ShrinkSetAliasStepTests.java
@@ -38,8 +38,8 @@ public class ShrinkSetAliasStepTests extends AbstractStepTestCase<ShrinkSetAlias
         StepKey key = instance.getKey();
         StepKey nextKey = instance.getNextStepKey();
         switch (between(0, 1)) {
-            case 0 -> key = new StepKey(key.getPhase(), key.getAction(), key.getName() + randomAlphaOfLength(5));
-            case 1 -> nextKey = new StepKey(nextKey.getPhase(), nextKey.getAction(), nextKey.getName() + randomAlphaOfLength(5));
+            case 0 -> key = new StepKey(key.phase(), key.action(), key.name() + randomAlphaOfLength(5));
+            case 1 -> nextKey = new StepKey(nextKey.phase(), nextKey.action(), nextKey.name() + randomAlphaOfLength(5));
             default -> throw new AssertionError("Illegal randomisation branch");
         }
         return new ShrinkSetAliasStep(key, nextKey, instance.getClient());

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/ShrinkStepTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/ShrinkStepTests.java
@@ -53,8 +53,8 @@ public class ShrinkStepTests extends AbstractStepTestCase<ShrinkStep> {
         ByteSizeValue maxPrimaryShardSize = instance.getMaxPrimaryShardSize();
 
         switch (between(0, 2)) {
-            case 0 -> key = new StepKey(key.getPhase(), key.getAction(), key.getName() + randomAlphaOfLength(5));
-            case 1 -> nextKey = new StepKey(nextKey.getPhase(), nextKey.getAction(), nextKey.getName() + randomAlphaOfLength(5));
+            case 0 -> key = new StepKey(key.phase(), key.action(), key.name() + randomAlphaOfLength(5));
+            case 1 -> nextKey = new StepKey(nextKey.phase(), nextKey.action(), nextKey.name() + randomAlphaOfLength(5));
             case 2 -> {
                 if (numberOfShards != null) {
                     numberOfShards = numberOfShards + 1;
@@ -84,9 +84,9 @@ public class ShrinkStepTests extends AbstractStepTestCase<ShrinkStep> {
         String lifecycleName = randomAlphaOfLength(5);
         ShrinkStep step = createRandomInstance();
         LifecycleExecutionState.Builder lifecycleState = LifecycleExecutionState.builder();
-        lifecycleState.setPhase(step.getKey().getPhase());
-        lifecycleState.setAction(step.getKey().getAction());
-        lifecycleState.setStep(step.getKey().getName());
+        lifecycleState.setPhase(step.getKey().phase());
+        lifecycleState.setAction(step.getKey().action());
+        lifecycleState.setStep(step.getKey().name());
         lifecycleState.setIndexCreationDate(randomNonNegativeLong());
         IndexMetadata sourceIndexMetadata = IndexMetadata.builder(randomAlphaOfLength(10))
             .settings(settings(Version.CURRENT).put(LifecycleSettings.LIFECYCLE_NAME, lifecycleName))
@@ -134,9 +134,9 @@ public class ShrinkStepTests extends AbstractStepTestCase<ShrinkStep> {
         String lifecycleName = randomAlphaOfLength(5);
         ShrinkStep step = createRandomInstance();
         LifecycleExecutionState.Builder lifecycleState = LifecycleExecutionState.builder();
-        lifecycleState.setPhase(step.getKey().getPhase());
-        lifecycleState.setAction(step.getKey().getAction());
-        lifecycleState.setStep(step.getKey().getName());
+        lifecycleState.setPhase(step.getKey().phase());
+        lifecycleState.setAction(step.getKey().action());
+        lifecycleState.setStep(step.getKey().name());
         lifecycleState.setIndexCreationDate(randomNonNegativeLong());
         String generatedShrunkenIndexName = GenerateUniqueIndexNameStep.generateValidIndexName(SHRUNKEN_INDEX_PREFIX, sourceIndexName);
         lifecycleState.setShrinkIndexName(generatedShrunkenIndexName);

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/ShrunkShardsAllocatedStepTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/ShrunkShardsAllocatedStepTests.java
@@ -41,8 +41,8 @@ public class ShrunkShardsAllocatedStepTests extends AbstractStepTestCase<ShrunkS
         StepKey nextKey = instance.getNextStepKey();
 
         switch (between(0, 1)) {
-            case 0 -> key = new StepKey(key.getPhase(), key.getAction(), key.getName() + randomAlphaOfLength(5));
-            case 1 -> nextKey = new StepKey(nextKey.getPhase(), nextKey.getAction(), nextKey.getName() + randomAlphaOfLength(5));
+            case 0 -> key = new StepKey(key.phase(), key.action(), key.name() + randomAlphaOfLength(5));
+            case 1 -> nextKey = new StepKey(nextKey.phase(), nextKey.action(), nextKey.name() + randomAlphaOfLength(5));
             default -> throw new AssertionError("Illegal randomisation branch");
         }
 

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/ShrunkenIndexCheckStepTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/ShrunkenIndexCheckStepTests.java
@@ -32,8 +32,8 @@ public class ShrunkenIndexCheckStepTests extends AbstractStepTestCase<ShrunkenIn
         StepKey key = instance.getKey();
         StepKey nextKey = instance.getNextStepKey();
         switch (between(0, 1)) {
-            case 0 -> key = new StepKey(key.getPhase(), key.getAction(), key.getName() + randomAlphaOfLength(5));
-            case 1 -> nextKey = new StepKey(nextKey.getPhase(), nextKey.getAction(), nextKey.getName() + randomAlphaOfLength(5));
+            case 0 -> key = new StepKey(key.phase(), key.action(), key.name() + randomAlphaOfLength(5));
+            case 1 -> nextKey = new StepKey(nextKey.phase(), nextKey.action(), nextKey.name() + randomAlphaOfLength(5));
             default -> throw new AssertionError("Illegal randomisation branch");
         }
         return new ShrunkenIndexCheckStep(key, nextKey);

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/StepKeyTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/StepKeyTests.java
@@ -28,7 +28,7 @@ public class StepKeyTests extends AbstractXContentSerializingTestCase<StepKey> {
 
     @Override
     protected Writeable.Reader<StepKey> instanceReader() {
-        return StepKey::new;
+        return StepKey::readFrom;
     }
 
     @Override
@@ -38,9 +38,9 @@ public class StepKeyTests extends AbstractXContentSerializingTestCase<StepKey> {
 
     @Override
     public StepKey mutateInstance(StepKey instance) {
-        String phase = instance.getPhase();
-        String action = instance.getAction();
-        String step = instance.getName();
+        String phase = instance.phase();
+        String action = instance.action();
+        String step = instance.name();
 
         switch (between(0, 2)) {
             case 0 -> phase += randomAlphaOfLength(5);

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/SwapAliasesAndDeleteSourceIndexStepTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/SwapAliasesAndDeleteSourceIndexStepTests.java
@@ -57,8 +57,8 @@ public class SwapAliasesAndDeleteSourceIndexStepTests extends AbstractStepTestCa
         BiFunction<String, LifecycleExecutionState, String> indexNameSupplier = instance.getTargetIndexNameSupplier();
         boolean createSourceIndexAlias = instance.getCreateSourceIndexAlias();
         switch (between(0, 3)) {
-            case 0 -> key = new StepKey(key.getPhase(), key.getAction(), key.getName() + randomAlphaOfLength(5));
-            case 1 -> nextKey = new StepKey(nextKey.getPhase(), nextKey.getAction(), nextKey.getName() + randomAlphaOfLength(5));
+            case 0 -> key = new StepKey(key.phase(), key.action(), key.name() + randomAlphaOfLength(5));
+            case 1 -> nextKey = new StepKey(nextKey.phase(), nextKey.action(), nextKey.name() + randomAlphaOfLength(5));
             case 2 -> indexNameSupplier = (index, state) -> index + randomAlphaOfLength(5);
             case 3 -> createSourceIndexAlias = createSourceIndexAlias == false;
             default -> throw new AssertionError("Illegal randomisation branch");

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/TerminalPolicyStepTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/TerminalPolicyStepTests.java
@@ -23,9 +23,9 @@ public class TerminalPolicyStepTests extends AbstractStepTestCase<TerminalPolicy
         StepKey nextKey = instance.getNextStepKey();
 
         if (randomBoolean()) {
-            key = new StepKey(key.getPhase(), key.getAction(), key.getName() + randomAlphaOfLength(5));
+            key = new StepKey(key.phase(), key.action(), key.name() + randomAlphaOfLength(5));
         } else {
-            nextKey = new StepKey(nextKey.getPhase(), nextKey.getAction(), nextKey.getName() + randomAlphaOfLength(5));
+            nextKey = new StepKey(nextKey.phase(), nextKey.action(), nextKey.name() + randomAlphaOfLength(5));
         }
 
         return new TerminalPolicyStep(key, nextKey);

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/UpdateRolloverLifecycleDateStepTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/UpdateRolloverLifecycleDateStepTests.java
@@ -42,9 +42,9 @@ public class UpdateRolloverLifecycleDateStepTests extends AbstractStepTestCase<U
         StepKey nextKey = instance.getNextStepKey();
 
         if (randomBoolean()) {
-            key = new StepKey(key.getPhase(), key.getAction(), key.getName() + randomAlphaOfLength(5));
+            key = new StepKey(key.phase(), key.action(), key.name() + randomAlphaOfLength(5));
         } else {
-            nextKey = new StepKey(nextKey.getPhase(), nextKey.getAction(), nextKey.getName() + randomAlphaOfLength(5));
+            nextKey = new StepKey(nextKey.phase(), nextKey.action(), nextKey.name() + randomAlphaOfLength(5));
         }
 
         return new UpdateRolloverLifecycleDateStep(key, nextKey, null);

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/UpdateRollupIndexPolicyStepTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/UpdateRollupIndexPolicyStepTests.java
@@ -44,8 +44,8 @@ public class UpdateRollupIndexPolicyStepTests extends AbstractStepTestCase<Updat
         String rollupPolicy = instance.getRollupPolicy();
 
         switch (between(0, 2)) {
-            case 0 -> key = new StepKey(key.getPhase(), key.getAction(), key.getName() + randomAlphaOfLength(5));
-            case 1 -> nextKey = new StepKey(nextKey.getPhase(), nextKey.getAction(), nextKey.getName() + randomAlphaOfLength(5));
+            case 0 -> key = new StepKey(key.phase(), key.action(), key.name() + randomAlphaOfLength(5));
+            case 1 -> nextKey = new StepKey(nextKey.phase(), nextKey.action(), nextKey.name() + randomAlphaOfLength(5));
             case 2 -> rollupPolicy = randomAlphaOfLength(5);
             default -> throw new AssertionError("Illegal randomisation branch");
         }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/UpdateSettingsStepTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/UpdateSettingsStepTests.java
@@ -36,8 +36,8 @@ public class UpdateSettingsStepTests extends AbstractStepTestCase<UpdateSettings
         Settings settings = instance.getSettings();
 
         switch (between(0, 2)) {
-            case 0 -> key = new StepKey(key.getPhase(), key.getAction(), key.getName() + randomAlphaOfLength(5));
-            case 1 -> nextKey = new StepKey(nextKey.getPhase(), nextKey.getAction(), nextKey.getName() + randomAlphaOfLength(5));
+            case 0 -> key = new StepKey(key.phase(), key.action(), key.name() + randomAlphaOfLength(5));
+            case 1 -> nextKey = new StepKey(nextKey.phase(), nextKey.action(), nextKey.name() + randomAlphaOfLength(5));
             case 2 -> settings = Settings.builder().put(settings).put(randomAlphaOfLength(10), randomInt()).build();
             default -> throw new AssertionError("Illegal randomisation branch");
         }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/WaitForActiveShardsTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/WaitForActiveShardsTests.java
@@ -48,8 +48,8 @@ public class WaitForActiveShardsTests extends AbstractStepTestCase<WaitForActive
         StepKey nextKey = instance.getNextStepKey();
 
         switch (between(0, 1)) {
-            case 0 -> key = new StepKey(key.getPhase(), key.getAction(), key.getName() + randomAlphaOfLength(5));
-            case 1 -> nextKey = new StepKey(nextKey.getPhase(), nextKey.getAction(), nextKey.getName() + randomAlphaOfLength(5));
+            case 0 -> key = new StepKey(key.phase(), key.action(), key.name() + randomAlphaOfLength(5));
+            case 1 -> nextKey = new StepKey(nextKey.phase(), nextKey.action(), nextKey.name() + randomAlphaOfLength(5));
             default -> throw new AssertionError("Illegal randomisation branch");
         }
 
@@ -271,7 +271,7 @@ public class WaitForActiveShardsTests extends AbstractStepTestCase<WaitForActive
         assertThat(
             actualResultAsString,
             containsString(
-                "[" + step.getKey().getAction() + "] lifecycle action for index [index-000000] executed but " + "index no longer exists"
+                "[" + step.getKey().action() + "] lifecycle action for index [index-000000] executed but " + "index no longer exists"
             )
         );
     }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/WaitForFollowShardTasksStepTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/WaitForFollowShardTasksStepTests.java
@@ -41,9 +41,9 @@ public class WaitForFollowShardTasksStepTests extends AbstractStepTestCase<WaitF
         StepKey nextKey = instance.getNextStepKey();
 
         if (randomBoolean()) {
-            key = new StepKey(key.getPhase(), key.getAction(), key.getName() + randomAlphaOfLength(5));
+            key = new StepKey(key.phase(), key.action(), key.name() + randomAlphaOfLength(5));
         } else {
-            nextKey = new StepKey(nextKey.getPhase(), nextKey.getAction(), nextKey.getName() + randomAlphaOfLength(5));
+            nextKey = new StepKey(nextKey.phase(), nextKey.action(), nextKey.name() + randomAlphaOfLength(5));
         }
 
         return new WaitForFollowShardTasksStep(key, nextKey, instance.getClient());

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/WaitForIndexColorStepTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/WaitForIndexColorStepTests.java
@@ -53,8 +53,8 @@ public class WaitForIndexColorStepTests extends AbstractStepTestCase<WaitForInde
         BiFunction<String, LifecycleExecutionState, String> indexNameSupplier = instance.getIndexNameSupplier();
 
         switch (between(0, 2)) {
-            case 0 -> key = new StepKey(key.getPhase(), key.getAction(), key.getName() + randomAlphaOfLength(5));
-            case 1 -> nextKey = new StepKey(nextKey.getPhase(), nextKey.getAction(), nextKey.getName() + randomAlphaOfLength(5));
+            case 0 -> key = new StepKey(key.phase(), key.action(), key.name() + randomAlphaOfLength(5));
+            case 1 -> nextKey = new StepKey(nextKey.phase(), nextKey.action(), nextKey.name() + randomAlphaOfLength(5));
             case 2 -> color = randomValueOtherThan(color, WaitForIndexColorStepTests::randomColor);
         }
 
@@ -250,7 +250,7 @@ public class WaitForIndexColorStepTests extends AbstractStepTestCase<WaitForInde
             info.getMessage(),
             is(
                 "["
-                    + step.getKey().getAction()
+                    + step.getKey().action()
                     + "] lifecycle action for index ["
                     + originalIndex.getIndex().getName()
                     + "] executed but the target index ["

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/WaitForIndexingCompleteStepTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/WaitForIndexingCompleteStepTests.java
@@ -38,9 +38,9 @@ public class WaitForIndexingCompleteStepTests extends AbstractStepTestCase<WaitF
         StepKey nextKey = instance.getNextStepKey();
 
         if (randomBoolean()) {
-            key = new StepKey(key.getPhase(), key.getAction(), key.getName() + randomAlphaOfLength(5));
+            key = new StepKey(key.phase(), key.action(), key.name() + randomAlphaOfLength(5));
         } else {
-            nextKey = new StepKey(nextKey.getPhase(), nextKey.getAction(), nextKey.getName() + randomAlphaOfLength(5));
+            nextKey = new StepKey(nextKey.phase(), nextKey.action(), nextKey.name() + randomAlphaOfLength(5));
         }
 
         return new WaitForIndexingCompleteStep(key, nextKey);

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/WaitForNoFollowersStepTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/WaitForNoFollowersStepTests.java
@@ -51,9 +51,9 @@ public class WaitForNoFollowersStepTests extends AbstractStepTestCase<WaitForNoF
         Step.StepKey nextKey = instance.getNextStepKey();
 
         if (randomBoolean()) {
-            key = new Step.StepKey(key.getPhase(), key.getAction(), key.getName() + randomAlphaOfLength(5));
+            key = new Step.StepKey(key.phase(), key.action(), key.name() + randomAlphaOfLength(5));
         } else {
-            nextKey = new Step.StepKey(nextKey.getPhase(), nextKey.getAction(), nextKey.getName() + randomAlphaOfLength(5));
+            nextKey = new Step.StepKey(nextKey.phase(), nextKey.action(), nextKey.name() + randomAlphaOfLength(5));
         }
 
         return new WaitForNoFollowersStep(key, nextKey, instance.getClient());

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/WaitForRolloverReadyStepTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/WaitForRolloverReadyStepTests.java
@@ -111,8 +111,8 @@ public class WaitForRolloverReadyStepTests extends AbstractStepTestCase<WaitForR
         Long minPrimaryShardDocs = instance.getMinPrimaryShardDocs();
 
         switch (between(0, 11)) {
-            case 0 -> key = new Step.StepKey(key.getPhase(), key.getAction(), key.getName() + randomAlphaOfLength(5));
-            case 1 -> nextKey = new Step.StepKey(nextKey.getPhase(), nextKey.getAction(), nextKey.getName() + randomAlphaOfLength(5));
+            case 0 -> key = new Step.StepKey(key.phase(), key.action(), key.name() + randomAlphaOfLength(5));
+            case 1 -> nextKey = new Step.StepKey(nextKey.phase(), nextKey.action(), nextKey.name() + randomAlphaOfLength(5));
             case 2 -> maxSize = randomValueOtherThan(maxSize, () -> {
                 ByteSizeUnit maxSizeUnit = randomFrom(ByteSizeUnit.values());
                 return new ByteSizeValue(randomNonNegativeLong() / maxSizeUnit.toBytes(1), maxSizeUnit);

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/WaitForSnapshotActionTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/WaitForSnapshotActionTests.java
@@ -25,9 +25,9 @@ public class WaitForSnapshotActionTests extends AbstractActionTestCase<WaitForSn
         assertEquals(nextStep, step.getNextStepKey());
 
         Step.StepKey key = step.getKey();
-        assertEquals("delete", key.getPhase());
-        assertEquals(WaitForSnapshotAction.NAME, key.getAction());
-        assertEquals(WaitForSnapshotStep.NAME, key.getName());
+        assertEquals("delete", key.phase());
+        assertEquals(WaitForSnapshotAction.NAME, key.action());
+        assertEquals(WaitForSnapshotStep.NAME, key.name());
     }
 
     @Override

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/WaitForSnapshotStepTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/WaitForSnapshotStepTests.java
@@ -35,8 +35,8 @@ public class WaitForSnapshotStepTests extends AbstractStepTestCase<WaitForSnapsh
         String policy = instance.getPolicy();
 
         switch (between(0, 2)) {
-            case 0 -> key = new Step.StepKey(key.getPhase(), key.getAction(), key.getName() + randomAlphaOfLength(5));
-            case 1 -> nextKey = new Step.StepKey(nextKey.getPhase(), nextKey.getAction(), nextKey.getName() + randomAlphaOfLength(5));
+            case 0 -> key = new Step.StepKey(key.phase(), key.action(), key.name() + randomAlphaOfLength(5));
+            case 1 -> nextKey = new Step.StepKey(nextKey.phase(), nextKey.action(), nextKey.name() + randomAlphaOfLength(5));
             case 2 -> policy = randomValueOtherThan(policy, () -> randomAlphaOfLengthBetween(1, 10));
             default -> throw new AssertionError("Illegal randomisation branch");
         }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/action/MoveToStepRequestTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/action/MoveToStepRequestTests.java
@@ -64,7 +64,7 @@ public class MoveToStepRequestTests extends AbstractXContentSerializingTestCase<
     private static Request.PartialStepKey randomStepSpecification() {
         if (randomBoolean()) {
             StepKey key = stepKeyTests.createTestInstance();
-            return new Request.PartialStepKey(key.getPhase(), key.getAction(), key.getName());
+            return new Request.PartialStepKey(key.phase(), key.action(), key.name());
         } else {
             String phase = randomAlphaOfLength(10);
             String action = randomBoolean() ? null : randomAlphaOfLength(6);

--- a/x-pack/plugin/ilm/qa/multi-node/src/javaRestTest/java/org/elasticsearch/xpack/MigrateToDataTiersIT.java
+++ b/x-pack/plugin/ilm/qa/multi-node/src/javaRestTest/java/org/elasticsearch/xpack/MigrateToDataTiersIT.java
@@ -130,13 +130,9 @@ public class MigrateToDataTiersIT extends ESRestTestCase {
         );
 
         // wait for the index to advance to the warm phase
-        assertBusy(() -> assertThat(getStepKeyForIndex(client(), index).getPhase(), equalTo("warm")), 30, TimeUnit.SECONDS);
+        assertBusy(() -> assertThat(getStepKeyForIndex(client(), index).phase(), equalTo("warm")), 30, TimeUnit.SECONDS);
         // let's wait for this index to have received the `require.data` configuration from the warm phase/allocate action
-        assertBusy(
-            () -> assertThat(getStepKeyForIndex(client(), index).getName(), equalTo(AllocationRoutedStep.NAME)),
-            30,
-            TimeUnit.SECONDS
-        );
+        assertBusy(() -> assertThat(getStepKeyForIndex(client(), index).name(), equalTo(AllocationRoutedStep.NAME)), 30, TimeUnit.SECONDS);
 
         // let's also have a policy that doesn't need migrating
         String rolloverOnlyPolicyName = "rollover-policy";
@@ -410,13 +406,9 @@ public class MigrateToDataTiersIT extends ESRestTestCase {
         );
 
         // wait for the index to advance to the warm phase
-        assertBusy(() -> assertThat(getStepKeyForIndex(client(), index).getPhase(), equalTo("warm")), 30, TimeUnit.SECONDS);
+        assertBusy(() -> assertThat(getStepKeyForIndex(client(), index).phase(), equalTo("warm")), 30, TimeUnit.SECONDS);
         // let's wait for this index to have received the `require.data` configuration from the warm phase/allocate action
-        assertBusy(
-            () -> assertThat(getStepKeyForIndex(client(), index).getName(), equalTo(AllocationRoutedStep.NAME)),
-            30,
-            TimeUnit.SECONDS
-        );
+        assertBusy(() -> assertThat(getStepKeyForIndex(client(), index).name(), equalTo(AllocationRoutedStep.NAME)), 30, TimeUnit.SECONDS);
 
         String indexWithDataWarmRouting = "indexwithdatawarmrouting";
         Settings.Builder settings = Settings.builder()

--- a/x-pack/plugin/ilm/qa/multi-node/src/javaRestTest/java/org/elasticsearch/xpack/ilm/ChangePolicyForIndexIT.java
+++ b/x-pack/plugin/ilm/qa/multi-node/src/javaRestTest/java/org/elasticsearch/xpack/ilm/ChangePolicyForIndexIT.java
@@ -224,8 +224,8 @@ public class ChangePolicyForIndexIT extends ESRestTestCase {
         Map<String, Object> indexExplainResponse = (Map<String, Object>) ((Map<String, Object>) explainResponseMap.get("indices")).get(
             indexName
         );
-        assertEquals(expectedStep.getPhase(), indexExplainResponse.get("phase"));
-        assertEquals(expectedStep.getAction(), indexExplainResponse.get("action"));
-        assertEquals(expectedStep.getName(), indexExplainResponse.get("step"));
+        assertEquals(expectedStep.phase(), indexExplainResponse.get("phase"));
+        assertEquals(expectedStep.action(), indexExplainResponse.get("action"));
+        assertEquals(expectedStep.name(), indexExplainResponse.get("step"));
     }
 }

--- a/x-pack/plugin/ilm/qa/multi-node/src/javaRestTest/java/org/elasticsearch/xpack/ilm/TimeSeriesDataStreamsIT.java
+++ b/x-pack/plugin/ilm/qa/multi-node/src/javaRestTest/java/org/elasticsearch/xpack/ilm/TimeSeriesDataStreamsIT.java
@@ -99,7 +99,7 @@ public class TimeSeriesDataStreamsIT extends ESRestTestCase {
 
         String firstGenerationIndex = DataStream.getDefaultBackingIndexName(dataStream, 1);
         assertBusy(
-            () -> assertThat(getStepKeyForIndex(client(), firstGenerationIndex).getName(), equalTo(WaitForRolloverReadyStep.NAME)),
+            () -> assertThat(getStepKeyForIndex(client(), firstGenerationIndex).name(), equalTo(WaitForRolloverReadyStep.NAME)),
             30,
             TimeUnit.SECONDS
         );

--- a/x-pack/plugin/ilm/qa/multi-node/src/javaRestTest/java/org/elasticsearch/xpack/ilm/TimeSeriesLifecycleActionsIT.java
+++ b/x-pack/plugin/ilm/qa/multi-node/src/javaRestTest/java/org/elasticsearch/xpack/ilm/TimeSeriesLifecycleActionsIT.java
@@ -288,7 +288,7 @@ public class TimeSeriesLifecycleActionsIT extends ESRestTestCase {
         assertBusy(() -> {
             Step.StepKey stepKey = getStepKeyForIndex(client(), index);
             logger.info("step key for index {} is {}", index, stepKey);
-            assertThat(stepKey.getAction(), equalTo("complete"));
+            assertThat(stepKey.action(), equalTo("complete"));
         }, slmPolicy);
     }
 
@@ -318,7 +318,7 @@ public class TimeSeriesLifecycleActionsIT extends ESRestTestCase {
         assertBusy(() -> {
             Step.StepKey stepKey = getStepKeyForIndex(client(), index);
             logger.info("step key for index {} is {}", index, stepKey);
-            assertThat(stepKey.getAction(), equalTo("complete"));
+            assertThat(stepKey.action(), equalTo("complete"));
         }, slmPolicy);
     }
 
@@ -374,9 +374,9 @@ public class TimeSeriesLifecycleActionsIT extends ESRestTestCase {
         assertBusy(() -> {
             Step.StepKey stepKey = getStepKeyForIndex(client(), index);
             logger.info("stepKey for index {} is {}", index, stepKey);
-            assertThat(stepKey.getAction(), equalTo("complete"));
+            assertThat(stepKey.action(), equalTo("complete"));
         }, slmPolicy);
-        assertBusy(() -> assertThat(getStepKeyForIndex(client(), index).getAction(), equalTo("complete")), slmPolicy);
+        assertBusy(() -> assertThat(getStepKeyForIndex(client(), index).action(), equalTo("complete")), slmPolicy);
     }
 
     /*
@@ -423,7 +423,7 @@ public class TimeSeriesLifecycleActionsIT extends ESRestTestCase {
         createNewSingletonPolicy(client(), policy, "delete", DeleteAction.WITH_SNAPSHOT_DELETE, TimeValue.timeValueHours(1));
         updatePolicy(client(), index, policy);
         assertBusy(() -> {
-            assertThat(getStepKeyForIndex(client(), index).getAction(), equalTo("complete"));
+            assertThat(getStepKeyForIndex(client(), index).action(), equalTo("complete"));
             Map<String, Object> settings = getOnlyIndexSettings(client(), index);
             assertThat(settings.get(IndexMetadata.INDEX_BLOCKS_WRITE_SETTING.getKey()), not("true"));
         });
@@ -795,7 +795,7 @@ public class TimeSeriesLifecycleActionsIT extends ESRestTestCase {
         index(client(), originalIndex, "_id", "foo", "bar");
         assertBusy(() -> assertTrue(indexExists(secondIndex)));
 
-        assertBusy(() -> assertThat(getStepKeyForIndex(client(), originalIndex).getName(), equalTo(WaitForActiveShardsStep.NAME)));
+        assertBusy(() -> assertThat(getStepKeyForIndex(client(), originalIndex).name(), equalTo(WaitForActiveShardsStep.NAME)));
 
         // reset the number of replicas to 0 so that the second index wait for active shard condition can be met
         updateIndexSettings(secondIndex, Settings.builder().put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 0));
@@ -940,14 +940,14 @@ public class TimeSeriesLifecycleActionsIT extends ESRestTestCase {
         index(client(), index + "-1", "1", "foo", "bar");
 
         // Wait for the index to enter the check-rollover-ready step
-        assertBusy(() -> assertThat(getStepKeyForIndex(client(), index + "-1").getName(), equalTo(WaitForRolloverReadyStep.NAME)));
+        assertBusy(() -> assertThat(getStepKeyForIndex(client(), index + "-1").name(), equalTo(WaitForRolloverReadyStep.NAME)));
 
         // Update the policy to allow rollover at 1 document instead of 100
         createNewSingletonPolicy(client(), policy, "hot", new RolloverAction(null, null, null, 1L, null, null, null, null, null, null));
 
         // Index should now have been able to roll over, creating the new index and proceeding to the "complete" step
         assertBusy(() -> assertThat(indexExists(index + "-000002"), is(true)));
-        assertBusy(() -> assertThat(getStepKeyForIndex(client(), index + "-1").getName(), equalTo(PhaseCompleteStep.NAME)));
+        assertBusy(() -> assertThat(getStepKeyForIndex(client(), index + "-1").name(), equalTo(PhaseCompleteStep.NAME)));
     }
 
     public void testHaltAtEndOfPhase() throws Exception {
@@ -1223,9 +1223,9 @@ public class TimeSeriesLifecycleActionsIT extends ESRestTestCase {
 
         // Finally, check that the history index is in a good state
         Step.StepKey stepKey = getStepKeyForIndex(client(), DataStream.getDefaultBackingIndexName("ilm-history-5", 1));
-        assertEquals("hot", stepKey.getPhase());
-        assertEquals(RolloverAction.NAME, stepKey.getAction());
-        assertEquals(WaitForRolloverReadyStep.NAME, stepKey.getName());
+        assertEquals("hot", stepKey.phase());
+        assertEquals(RolloverAction.NAME, stepKey.action());
+        assertEquals(WaitForRolloverReadyStep.NAME, stepKey.name());
     }
 
     private void createSlmPolicy(String smlPolicy, String repo) throws IOException {

--- a/x-pack/plugin/ilm/qa/multi-node/src/javaRestTest/java/org/elasticsearch/xpack/ilm/actions/RolloverActionIT.java
+++ b/x-pack/plugin/ilm/qa/multi-node/src/javaRestTest/java/org/elasticsearch/xpack/ilm/actions/RolloverActionIT.java
@@ -232,7 +232,7 @@ public class RolloverActionIT extends ESRestTestCase {
 
         // because the index is empty, it doesn't roll over
         assertBusy(() -> {
-            assertThat(getStepKeyForIndex(client(), originalIndex).getName(), is(WaitForRolloverReadyStep.NAME));
+            assertThat(getStepKeyForIndex(client(), originalIndex).name(), is(WaitForRolloverReadyStep.NAME));
             assertFalse(indexExists(secondIndex));
             assertTrue(indexExists(originalIndex));
         }, 30, TimeUnit.SECONDS);
@@ -504,7 +504,7 @@ public class RolloverActionIT extends ESRestTestCase {
             true
         );
 
-        assertBusy(() -> assertThat(getStepKeyForIndex(client(), index).getName(), is(WaitForRolloverReadyStep.NAME)));
+        assertBusy(() -> assertThat(getStepKeyForIndex(client(), index).name(), is(WaitForRolloverReadyStep.NAME)));
 
         // moving ILM to the "update-rollover-lifecycle-date" without having gone through the actual rollover step
         // the "update-rollover-lifecycle-date" step will fail as the index has no rollover information

--- a/x-pack/plugin/ilm/qa/multi-node/src/javaRestTest/java/org/elasticsearch/xpack/ilm/actions/SearchableSnapshotActionIT.java
+++ b/x-pack/plugin/ilm/qa/multi-node/src/javaRestTest/java/org/elasticsearch/xpack/ilm/actions/SearchableSnapshotActionIT.java
@@ -322,8 +322,8 @@ public class SearchableSnapshotActionIT extends ESRestTestCase {
 
         assertBusy(() -> {
             Step.StepKey stepKeyForIndex = getStepKeyForIndex(client(), restoredIndexName);
-            assertThat(stepKeyForIndex.getPhase(), is("hot"));
-            assertThat(stepKeyForIndex.getName(), is(PhaseCompleteStep.NAME));
+            assertThat(stepKeyForIndex.phase(), is("hot"));
+            assertThat(stepKeyForIndex.name(), is(PhaseCompleteStep.NAME));
         }, 30, TimeUnit.SECONDS);
 
         createPolicy(
@@ -344,8 +344,8 @@ public class SearchableSnapshotActionIT extends ESRestTestCase {
         // skip and ILM should not be blocked (not should the managed index move into the ERROR step)
         assertBusy(() -> {
             Step.StepKey stepKeyForIndex = getStepKeyForIndex(client(), restoredIndexName);
-            assertThat(stepKeyForIndex.getPhase(), is("cold"));
-            assertThat(stepKeyForIndex.getName(), is(PhaseCompleteStep.NAME));
+            assertThat(stepKeyForIndex.phase(), is("cold"));
+            assertThat(stepKeyForIndex.name(), is(PhaseCompleteStep.NAME));
         }, 30, TimeUnit.SECONDS);
     }
 
@@ -400,8 +400,8 @@ public class SearchableSnapshotActionIT extends ESRestTestCase {
 
         assertBusy(() -> {
             Step.StepKey stepKeyForIndex = getStepKeyForIndex(client(), searchableSnapMountedIndexName);
-            assertThat(stepKeyForIndex.getPhase(), is("hot"));
-            assertThat(stepKeyForIndex.getName(), is(PhaseCompleteStep.NAME));
+            assertThat(stepKeyForIndex.phase(), is("hot"));
+            assertThat(stepKeyForIndex.name(), is(PhaseCompleteStep.NAME));
         }, 30, TimeUnit.SECONDS);
 
         // snapshot the data stream
@@ -442,8 +442,8 @@ public class SearchableSnapshotActionIT extends ESRestTestCase {
         // the restored index is now managed by the now updated ILM policy and needs to go through the warm and cold phase
         assertBusy(() -> {
             Step.StepKey stepKeyForIndex = getStepKeyForIndex(client(), searchableSnapMountedIndexName);
-            assertThat(stepKeyForIndex.getPhase(), is("cold"));
-            assertThat(stepKeyForIndex.getName(), is(PhaseCompleteStep.NAME));
+            assertThat(stepKeyForIndex.phase(), is("cold"));
+            assertThat(stepKeyForIndex.name(), is(PhaseCompleteStep.NAME));
         }, 30, TimeUnit.SECONDS);
     }
 
@@ -490,8 +490,8 @@ public class SearchableSnapshotActionIT extends ESRestTestCase {
 
         assertBusy(() -> {
             Step.StepKey stepKeyForIndex = getStepKeyForIndex(client(), searchableSnapMountedIndexName);
-            assertThat(stepKeyForIndex.getPhase(), is("cold"));
-            assertThat(stepKeyForIndex.getName(), is(PhaseCompleteStep.NAME));
+            assertThat(stepKeyForIndex.phase(), is("cold"));
+            assertThat(stepKeyForIndex.name(), is(PhaseCompleteStep.NAME));
         }, 30, TimeUnit.SECONDS);
 
         Request getSnaps = new Request("GET", "/_snapshot/" + snapshotRepo + "/_all");
@@ -551,8 +551,8 @@ public class SearchableSnapshotActionIT extends ESRestTestCase {
 
         assertBusy(() -> {
             Step.StepKey stepKeyForIndex = getStepKeyForIndex(client(), searchableSnapMountedIndexName);
-            assertThat(stepKeyForIndex.getPhase(), is("frozen"));
-            assertThat(stepKeyForIndex.getName(), is(PhaseCompleteStep.NAME));
+            assertThat(stepKeyForIndex.phase(), is("frozen"));
+            assertThat(stepKeyForIndex.name(), is(PhaseCompleteStep.NAME));
         }, 30, TimeUnit.SECONDS);
 
         Request getSnaps = new Request("GET", "/_snapshot/" + snapshotRepo + "/_all");

--- a/x-pack/plugin/ilm/qa/multi-node/src/javaRestTest/java/org/elasticsearch/xpack/slm/SnapshotLifecycleRestIT.java
+++ b/x-pack/plugin/ilm/qa/multi-node/src/javaRestTest/java/org/elasticsearch/xpack/slm/SnapshotLifecycleRestIT.java
@@ -726,9 +726,9 @@ public class SnapshotLifecycleRestIT extends ESRestTestCase {
         assertEquals(1, indices.size());
 
         Step.StepKey stepKey = getStepKeyForIndex(client(), indices.get(0).get("index_name"));
-        assertEquals("hot", stepKey.getPhase());
-        assertEquals(RolloverAction.NAME, stepKey.getAction());
-        assertEquals(WaitForRolloverReadyStep.NAME, stepKey.getName());
+        assertEquals("hot", stepKey.phase());
+        assertEquals(RolloverAction.NAME, stepKey.action());
+        assertEquals(WaitForRolloverReadyStep.NAME, stepKey.name());
     }
 
     private void createSnapshotPolicy(

--- a/x-pack/plugin/ilm/src/internalClusterTest/java/org/elasticsearch/xpack/ilm/IndexLifecycleInitialisationTests.java
+++ b/x-pack/plugin/ilm/src/internalClusterTest/java/org/elasticsearch/xpack/ilm/IndexLifecycleInitialisationTests.java
@@ -595,15 +595,15 @@ public class IndexLifecycleInitialisationTests extends ESIntegTestCase {
 
         @Override
         public void writeTo(StreamOutput out) throws IOException {
-            out.writeString(getKey().getPhase());
-            out.writeString(getKey().getAction());
-            out.writeString(getKey().getName());
+            out.writeString(getKey().phase());
+            out.writeString(getKey().action());
+            out.writeString(getKey().name());
             boolean hasNextStep = getNextStepKey() != null;
             out.writeBoolean(hasNextStep);
             if (hasNextStep) {
-                out.writeString(getNextStepKey().getPhase());
-                out.writeString(getNextStepKey().getAction());
-                out.writeString(getNextStepKey().getName());
+                out.writeString(getNextStepKey().phase());
+                out.writeString(getNextStepKey().action());
+                out.writeString(getNextStepKey().name());
             }
         }
 

--- a/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/cluster/metadata/MetadataMigrateToDataTiersRoutingService.java
+++ b/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/cluster/metadata/MetadataMigrateToDataTiersRoutingService.java
@@ -354,9 +354,9 @@ public final class MetadataMigrateToDataTiersRoutingService {
 
             if (currentExState != null) {
                 Step.StepKey currentStepKey = Step.getCurrentStepKey(currentExState);
-                if (currentStepKey != null && phasesWithoutAllocateAction.contains(currentStepKey.getPhase())) {
+                if (currentStepKey != null && phasesWithoutAllocateAction.contains(currentStepKey.phase())) {
                     // the index is in a phase that doesn't contain the allocate action anymore
-                    if (currentStepKey.getAction().equals(AllocateAction.NAME)) {
+                    if (currentStepKey.action().equals(AllocateAction.NAME)) {
                         // this index is in the middle of executing the allocate action - which doesn't exist in the updated policy
                         // anymore so let's try to move the index to the next action
 
@@ -381,7 +381,7 @@ public final class MetadataMigrateToDataTiersRoutingService {
                         LifecycleExecutionState.Builder updatedState = LifecycleExecutionState.builder(currentExState);
                         PhaseExecutionInfo phaseExecutionInfo = new PhaseExecutionInfo(
                             newPolicyMetadata.getPolicy().getName(),
-                            newPolicyMetadata.getPolicy().getPhases().get(currentStepKey.getPhase()),
+                            newPolicyMetadata.getPolicy().getPhases().get(currentStepKey.phase()),
                             newPolicyMetadata.getVersion(),
                             newPolicyMetadata.getModifiedDate()
                         );

--- a/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/ExecuteStepsUpdateTask.java
+++ b/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/ExecuteStepsUpdateTask.java
@@ -206,7 +206,7 @@ public class ExecuteStepsUpdateTask extends IndexLifecycleClusterStateUpdateTask
                 // transition happens, so even if we would continue in the while
                 // loop, if we are about to go into a new phase, return so that
                 // other processing can occur
-                if (currentStep.getKey().getPhase().equals(currentStep.getNextStepKey().getPhase()) == false) {
+                if (currentStep.getKey().phase().equals(currentStep.getNextStepKey().phase()) == false) {
                     return state;
                 }
                 currentStep = policyStepsRegistry.getStep(indexMetadata, currentStep.getNextStepKey());

--- a/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/IndexLifecycleRunner.java
+++ b/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/IndexLifecycleRunner.java
@@ -220,12 +220,12 @@ class IndexLifecycleRunner {
                 logger.debug(
                     "[{}] stopping in the current phase ({}) as there are no more steps in the policy",
                     index,
-                    currentStep.getKey().getPhase()
+                    currentStep.getKey().phase()
                 );
                 return;
             }
             // Only proceed to the next step if enough time has elapsed to go into the next phase
-            if (isReadyToTransitionToThisPhase(policy, indexMetadata, currentStep.getNextStepKey().getPhase())) {
+            if (isReadyToTransitionToThisPhase(policy, indexMetadata, currentStep.getNextStepKey().phase())) {
                 moveToStep(indexMetadata.getIndex(), policy, currentStep.getKey(), currentStep.getNextStepKey());
             }
         } else if (currentStep instanceof AsyncWaitStep) {
@@ -431,12 +431,12 @@ class IndexLifecycleRunner {
                 logger.debug(
                     "[{}] stopping in the current phase ({}) as there are no more steps in the policy",
                     index,
-                    currentStep.getKey().getPhase()
+                    currentStep.getKey().phase()
                 );
                 return;
             }
             // Only proceed to the next step if enough time has elapsed to go into the next phase
-            if (isReadyToTransitionToThisPhase(policy, indexMetadata, currentStep.getNextStepKey().getPhase())) {
+            if (isReadyToTransitionToThisPhase(policy, indexMetadata, currentStep.getNextStepKey().phase())) {
                 moveToStep(indexMetadata.getIndex(), policy, currentStep.getKey(), currentStep.getNextStepKey());
             }
         } else if (currentStep instanceof ClusterStateActionStep || currentStep instanceof ClusterStateWaitStep) {
@@ -690,7 +690,7 @@ class IndexLifecycleRunner {
 
         @Override
         protected void handleFailure(Exception e) {
-            logger.error(() -> format("retry execution of step [%s] for index [%s] failed", failedStep.getKey().getName(), index), e);
+            logger.error(() -> format("retry execution of step [%s] for index [%s] failed", failedStep.getKey().name(), index), e);
         }
 
         @Override

--- a/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/IndexLifecycleService.java
+++ b/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/IndexLifecycleService.java
@@ -184,12 +184,12 @@ public class IndexLifecycleService
 
                     try {
                         if (OperationMode.STOPPING == currentMode) {
-                            if (stepKey != null && IGNORE_STEPS_MAINTENANCE_REQUESTED.contains(stepKey.getName())) {
+                            if (stepKey != null && IGNORE_STEPS_MAINTENANCE_REQUESTED.contains(stepKey.name())) {
                                 logger.info(
                                     "waiting to stop ILM because index [{}] with policy [{}] is currently in step [{}]",
                                     idxMeta.getIndex().getName(),
                                     policyName,
-                                    stepKey.getName()
+                                    stepKey.name()
                                 );
                                 lifecycleRunner.maybeRunAsyncAction(clusterState, idxMeta, policyName, stepKey);
                                 // ILM is trying to stop, but this index is in a Shrink step (or other dangerous step) so we can't stop
@@ -197,7 +197,7 @@ public class IndexLifecycleService
                             } else {
                                 logger.info(
                                     "skipping policy execution of step [{}] for index [{}] with policy [{}]" + " because ILM is stopping",
-                                    stepKey == null ? "n/a" : stepKey.getName(),
+                                    stepKey == null ? "n/a" : stepKey.name(),
                                     idxMeta.getIndex().getName(),
                                     policyName
                                 );
@@ -393,12 +393,12 @@ public class IndexLifecycleService
 
                 try {
                     if (OperationMode.STOPPING == currentMode) {
-                        if (stepKey != null && IGNORE_STEPS_MAINTENANCE_REQUESTED.contains(stepKey.getName())) {
+                        if (stepKey != null && IGNORE_STEPS_MAINTENANCE_REQUESTED.contains(stepKey.name())) {
                             logger.info(
                                 "waiting to stop ILM because index [{}] with policy [{}] is currently in step [{}]",
                                 idxMeta.getIndex().getName(),
                                 policyName,
-                                stepKey.getName()
+                                stepKey.name()
                             );
                             if (fromClusterStateChange) {
                                 lifecycleRunner.runPolicyAfterStateChange(policyName, idxMeta);
@@ -410,7 +410,7 @@ public class IndexLifecycleService
                         } else {
                             logger.info(
                                 "skipping policy execution of step [{}] for index [{}] with policy [{}] because ILM is stopping",
-                                stepKey == null ? "n/a" : stepKey.getName(),
+                                stepKey == null ? "n/a" : stepKey.name(),
                                 idxMeta.getIndex().getName(),
                                 policyName
                             );

--- a/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/IndexLifecycleTransition.java
+++ b/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/IndexLifecycleTransition.java
@@ -169,13 +169,13 @@ public final class IndexLifecycleTransition {
         LifecycleExecutionState nextStepState = updateExecutionStateToStep(
             policyMetadata,
             currentState,
-            new Step.StepKey(currentStep.getPhase(), currentStep.getAction(), ErrorStep.NAME),
+            new Step.StepKey(currentStep.phase(), currentStep.action(), ErrorStep.NAME),
             nowSupplier,
             false
         );
 
         LifecycleExecutionState.Builder failedState = LifecycleExecutionState.builder(nextStepState);
-        failedState.setFailedStep(currentStep.getName());
+        failedState.setFailedStep(currentStep.name());
         failedState.setStepInfo(Strings.toString(((builder, params) -> {
             ElasticsearchException.generateThrowableXContent(builder, EMPTY_PARAMS, cause);
             return builder;
@@ -191,7 +191,7 @@ public final class IndexLifecycleTransition {
         } else {
             logger.warn(
                 "failed step [{}] for index [{}] is not part of policy [{}] anymore, or it is invalid",
-                currentStep.getName(),
+                currentStep.name(),
                 index,
                 policyMetadata.getName()
             );
@@ -219,8 +219,8 @@ public final class IndexLifecycleTransition {
         LifecycleExecutionState lifecycleState = indexMetadata.getLifecycleExecutionState();
         Step.StepKey currentStepKey = Step.getCurrentStepKey(lifecycleState);
         String failedStep = lifecycleState.failedStep();
-        if (currentStepKey != null && ErrorStep.NAME.equals(currentStepKey.getName()) && Strings.isNullOrEmpty(failedStep) == false) {
-            Step.StepKey nextStepKey = new Step.StepKey(currentStepKey.getPhase(), currentStepKey.getAction(), failedStep);
+        if (currentStepKey != null && ErrorStep.NAME.equals(currentStepKey.name()) && Strings.isNullOrEmpty(failedStep) == false) {
+            Step.StepKey nextStepKey = new Step.StepKey(currentStepKey.phase(), currentStepKey.action(), failedStep);
             validateTransition(indexMetadata, currentStepKey, nextStepKey, stepRegistry);
             IndexLifecycleMetadata ilmMeta = currentState.metadata().custom(IndexLifecycleMetadata.TYPE);
 
@@ -231,8 +231,8 @@ public final class IndexLifecycleTransition {
             // we only refresh the cached phase if the failed step's action is still present in the underlying policy
             // as otherwise ILM would block due to not recognizing the next step as part of the policy.
             // if the policy was updated to not contain the action or even phase, we honour the cached phase as it is and do not refresh it
-            boolean forcePhaseDefinitionRefresh = policyPhases.get(nextStepKey.getPhase()) != null
-                && policyPhases.get(nextStepKey.getPhase()).getActions().get(nextStepKey.getAction()) != null;
+            boolean forcePhaseDefinitionRefresh = policyPhases.get(nextStepKey.phase()) != null
+                && policyPhases.get(nextStepKey.phase()).getActions().get(nextStepKey.action()) != null;
 
             final LifecycleExecutionState nextStepState = IndexLifecycleTransition.updateExecutionStateToStep(
                 policyMetadata,
@@ -278,9 +278,9 @@ public final class IndexLifecycleTransition {
         Step.StepKey currentStep = Step.getCurrentStepKey(existingState);
         long nowAsMillis = nowSupplier.getAsLong();
         LifecycleExecutionState.Builder updatedState = LifecycleExecutionState.builder(existingState);
-        updatedState.setPhase(newStep.getPhase());
-        updatedState.setAction(newStep.getAction());
-        updatedState.setStep(newStep.getName());
+        updatedState.setPhase(newStep.phase());
+        updatedState.setAction(newStep.action());
+        updatedState.setStep(newStep.name());
         updatedState.setStepTime(nowAsMillis);
 
         // clear any step info or error-related settings from the current step
@@ -289,13 +289,13 @@ public final class IndexLifecycleTransition {
         updatedState.setIsAutoRetryableError(null);
         updatedState.setFailedStepRetryCount(null);
 
-        if (currentStep == null || currentStep.getPhase().equals(newStep.getPhase()) == false || forcePhaseDefinitionRefresh) {
+        if (currentStep == null || currentStep.phase().equals(newStep.phase()) == false || forcePhaseDefinitionRefresh) {
             final String newPhaseDefinition;
             final Phase nextPhase;
-            if ("new".equals(newStep.getPhase()) || TerminalPolicyStep.KEY.equals(newStep)) {
+            if ("new".equals(newStep.phase()) || TerminalPolicyStep.KEY.equals(newStep)) {
                 nextPhase = null;
             } else {
-                nextPhase = policyMetadata.getPolicy().getPhases().get(newStep.getPhase());
+                nextPhase = policyMetadata.getPolicy().getPhases().get(newStep.phase());
             }
             PhaseExecutionInfo phaseExecutionInfo = new PhaseExecutionInfo(
                 policyMetadata.getName(),
@@ -306,7 +306,7 @@ public final class IndexLifecycleTransition {
             newPhaseDefinition = Strings.toString(phaseExecutionInfo, false, false);
             updatedState.setPhaseDefinition(newPhaseDefinition);
             updatedState.setPhaseTime(nowAsMillis);
-        } else if (currentStep.getPhase().equals(InitializePolicyContextStep.INITIALIZATION_PHASE)) {
+        } else if (currentStep.phase().equals(InitializePolicyContextStep.INITIALIZATION_PHASE)) {
             // The "new" phase is the initialization phase, usually the phase
             // time would be set on phase transition, but since there is no
             // transition into the "new" phase, we set it any time in the "new"
@@ -314,7 +314,7 @@ public final class IndexLifecycleTransition {
             updatedState.setPhaseTime(nowAsMillis);
         }
 
-        if (currentStep == null || currentStep.getAction().equals(newStep.getAction()) == false) {
+        if (currentStep == null || currentStep.action().equals(newStep.action()) == false) {
             updatedState.setActionTime(nowAsMillis);
         }
         return updatedState.build();
@@ -370,7 +370,7 @@ public final class IndexLifecycleTransition {
 
         Optional<Step> nextStepInActionAfterCurrent = policySteps.stream()
             .skip(indexOfCurrentStep)
-            .filter(step -> step.getKey().getAction().equals(currentStepKey.getAction()) == false)
+            .filter(step -> step.getKey().action().equals(currentStepKey.action()) == false)
             .findFirst();
 
         assert nextStepInActionAfterCurrent.isPresent() : "there should always be a complete step at the end of every phase";
@@ -379,10 +379,10 @@ public final class IndexLifecycleTransition {
 
         long nowAsMillis = nowSupplier.getAsLong();
         LifecycleExecutionState.Builder updatedState = LifecycleExecutionState.builder(existingState);
-        updatedState.setPhase(nextStep.getPhase());
-        updatedState.setAction(nextStep.getAction());
+        updatedState.setPhase(nextStep.phase());
+        updatedState.setAction(nextStep.action());
         updatedState.setActionTime(nowAsMillis);
-        updatedState.setStep(nextStep.getName());
+        updatedState.setStep(nextStep.name());
         updatedState.setStepTime(nowAsMillis);
         updatedState.setFailedStep(null);
         updatedState.setStepInfo(null);
@@ -391,7 +391,7 @@ public final class IndexLifecycleTransition {
 
         PhaseExecutionInfo phaseExecutionInfo = new PhaseExecutionInfo(
             newPolicyMetadata.getPolicy().getName(),
-            newPolicyMetadata.getPolicy().getPhases().get(currentStepKey.getPhase()),
+            newPolicyMetadata.getPolicy().getPhases().get(currentStepKey.phase()),
             newPolicyMetadata.getVersion(),
             newPolicyMetadata.getModifiedDate()
         );

--- a/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/PolicyStepsRegistry.java
+++ b/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/PolicyStepsRegistry.java
@@ -149,7 +149,7 @@ public class PolicyStepsRegistry {
                     firstStepMap.put(policyMetadata.getName(), policyAsSteps.get(0));
                     final Map<Step.StepKey, Step> stepMapForPolicy = new LinkedHashMap<>();
                     for (Step step : policyAsSteps) {
-                        assert ErrorStep.NAME.equals(step.getKey().getName()) == false : "unexpected error step in policy";
+                        assert ErrorStep.NAME.equals(step.getKey().name()) == false : "unexpected error step in policy";
                         stepMapForPolicy.put(step.getKey(), step);
                     }
                     logger.trace(
@@ -224,7 +224,7 @@ public class PolicyStepsRegistry {
     public Step.StepKey getFirstStepForPhase(ClusterState state, Index index, String phase) {
         return getAllStepsForIndex(state, index).stream()
             .map(Step::getKey)
-            .filter(stepKey -> phase.equals(stepKey.getPhase()))
+            .filter(stepKey -> phase.equals(stepKey.phase()))
             .findFirst()
             .orElse(null);
     }
@@ -237,8 +237,8 @@ public class PolicyStepsRegistry {
     public Step.StepKey getFirstStepForPhaseAndAction(ClusterState state, Index index, String phase, String action) {
         return getAllStepsForIndex(state, index).stream()
             .map(Step::getKey)
-            .filter(stepKey -> phase.equals(stepKey.getPhase()))
-            .filter(stepKey -> action.equals(stepKey.getAction()))
+            .filter(stepKey -> phase.equals(stepKey.phase()))
+            .filter(stepKey -> action.equals(stepKey.action()))
             .findFirst()
             .orElse(null);
     }
@@ -290,7 +290,7 @@ public class PolicyStepsRegistry {
         if (steps == null) {
             phaseSteps = List.of();
         } else {
-            phaseSteps = steps.stream().filter(e -> e.getKey().getPhase().equals(currentPhase)).toList();
+            phaseSteps = steps.stream().filter(e -> e.getKey().phase().equals(currentPhase)).toList();
         }
         logger.trace(
             "parsed steps for policy [{}] in phase [{}], definition: [{}], steps: [{}]",
@@ -328,11 +328,11 @@ public class PolicyStepsRegistry {
             return cachedStep;
         }
 
-        if (ErrorStep.NAME.equals(stepKey.getName())) {
-            return new ErrorStep(new Step.StepKey(stepKey.getPhase(), stepKey.getAction(), ErrorStep.NAME));
+        if (ErrorStep.NAME.equals(stepKey.name())) {
+            return new ErrorStep(new Step.StepKey(stepKey.phase(), stepKey.action(), ErrorStep.NAME));
         }
 
-        final String phase = stepKey.getPhase();
+        final String phase = stepKey.phase();
         final String policyName = indexMetadata.getLifecyclePolicyName();
         final Index index = indexMetadata.getIndex();
 
@@ -357,7 +357,7 @@ public class PolicyStepsRegistry {
             );
         }
 
-        assert phaseSteps.stream().allMatch(step -> step.getKey().getPhase().equals(phase))
+        assert phaseSteps.stream().allMatch(step -> step.getKey().phase().equals(phase))
             : "expected phase steps loaded from phase definition for ["
                 + index.getName()
                 + "] to be in phase ["

--- a/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/ilm/ExecuteStepsUpdateTaskTests.java
+++ b/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/ilm/ExecuteStepsUpdateTaskTests.java
@@ -296,7 +296,7 @@ public class ExecuteStepsUpdateTaskTests extends ESTestCase {
         ClusterState newState = task.execute(clusterState);
         LifecycleExecutionState lifecycleState = newState.getMetadata().index(index).getLifecycleExecutionState();
         StepKey currentStepKey = Step.getCurrentStepKey(lifecycleState);
-        assertThat(currentStepKey, equalTo(new StepKey(firstStepKey.getPhase(), firstStepKey.getAction(), ErrorStep.NAME)));
+        assertThat(currentStepKey, equalTo(new StepKey(firstStepKey.phase(), firstStepKey.action(), ErrorStep.NAME)));
         assertThat(firstStep.getExecuteCount(), equalTo(1L));
         assertThat(secondStep.getExecuteCount(), equalTo(0L));
         assertNull(task.getNextStepKey());
@@ -316,7 +316,7 @@ public class ExecuteStepsUpdateTaskTests extends ESTestCase {
         ClusterState newState = task.execute(clusterState);
         LifecycleExecutionState lifecycleState = newState.getMetadata().index(index).getLifecycleExecutionState();
         StepKey currentStepKey = Step.getCurrentStepKey(lifecycleState);
-        assertThat(currentStepKey, equalTo(new StepKey(firstStepKey.getPhase(), firstStepKey.getAction(), ErrorStep.NAME)));
+        assertThat(currentStepKey, equalTo(new StepKey(firstStepKey.phase(), firstStepKey.action(), ErrorStep.NAME)));
         assertThat(firstStep.getExecuteCount(), equalTo(1L));
         assertThat(secondStep.getExecuteCount(), equalTo(1L));
         assertThat(lifecycleState.phaseTime(), nullValue());
@@ -329,9 +329,9 @@ public class ExecuteStepsUpdateTaskTests extends ESTestCase {
         LifecycleExecutionState.Builder lifecycleState = LifecycleExecutionState.builder(
             clusterState.getMetadata().index(index).getLifecycleExecutionState()
         );
-        lifecycleState.setPhase(stepKey.getPhase());
-        lifecycleState.setAction(stepKey.getAction());
-        lifecycleState.setStep(stepKey.getName());
+        lifecycleState.setPhase(stepKey.phase());
+        lifecycleState.setAction(stepKey.action());
+        lifecycleState.setStep(stepKey.name());
         clusterState = ClusterState.builder(clusterState)
             .metadata(
                 Metadata.builder(clusterState.getMetadata())

--- a/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/ilm/IndexLifecycleRunnerTests.java
+++ b/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/ilm/IndexLifecycleRunnerTests.java
@@ -201,10 +201,10 @@ public class IndexLifecycleRunnerTests extends ESTestCase {
         ClusterService clusterService = mock(ClusterService.class);
         IndexLifecycleRunner runner = new IndexLifecycleRunner(stepRegistry, historyStore, clusterService, threadPool, () -> 0L);
         LifecycleExecutionState.Builder newState = LifecycleExecutionState.builder();
-        newState.setFailedStep(stepKey.getName());
+        newState.setFailedStep(stepKey.name());
         newState.setIsAutoRetryableError(false);
-        newState.setPhase(stepKey.getPhase());
-        newState.setAction(stepKey.getAction());
+        newState.setPhase(stepKey.phase());
+        newState.setAction(stepKey.action());
         newState.setStep(ErrorStep.NAME);
         newState.setPhaseDefinition(phaseJson);
         IndexMetadata indexMetadata = IndexMetadata.builder("test")
@@ -232,7 +232,7 @@ public class IndexLifecycleRunnerTests extends ESTestCase {
         NoOpClient client = new NoOpClient(threadPool);
         List<Step> waitForRolloverStepList = action.toSteps(client, phaseName, null)
             .stream()
-            .filter(s -> s.getKey().getName().equals(WaitForRolloverReadyStep.NAME))
+            .filter(s -> s.getKey().name().equals(WaitForRolloverReadyStep.NAME))
             .collect(toList());
         assertThat(waitForRolloverStepList.size(), is(1));
         Step waitForRolloverStep = waitForRolloverStepList.get(0);
@@ -243,10 +243,10 @@ public class IndexLifecycleRunnerTests extends ESTestCase {
         when(clusterService.state()).thenReturn(ClusterState.EMPTY_STATE);
         IndexLifecycleRunner runner = new IndexLifecycleRunner(stepRegistry, historyStore, clusterService, threadPool, () -> 0L);
         LifecycleExecutionState.Builder newState = LifecycleExecutionState.builder();
-        newState.setFailedStep(stepKey.getName());
+        newState.setFailedStep(stepKey.name());
         newState.setIsAutoRetryableError(true);
-        newState.setPhase(stepKey.getPhase());
-        newState.setAction(stepKey.getAction());
+        newState.setPhase(stepKey.phase());
+        newState.setAction(stepKey.action());
         newState.setStep(ErrorStep.NAME);
         newState.setPhaseDefinition(phaseJson);
         IndexMetadata indexMetadata = IndexMetadata.builder("test")
@@ -806,9 +806,9 @@ public class IndexLifecycleRunnerTests extends ESTestCase {
             .build();
         LifecycleExecutionState.Builder lifecycleState = LifecycleExecutionState.builder();
         lifecycleState.setPhaseDefinition(phaseJson);
-        lifecycleState.setPhase(step.getKey().getPhase());
-        lifecycleState.setAction(step.getKey().getAction());
-        lifecycleState.setStep(step.getKey().getName());
+        lifecycleState.setPhase(step.getKey().phase());
+        lifecycleState.setAction(step.getKey().action());
+        lifecycleState.setStep(step.getKey().name());
         IndexMetadata indexMetadata = IndexMetadata.builder(index.getName())
             .settings(indexSettings)
             .putCustom(ILM_CUSTOM_METADATA_KEY, lifecycleState.build().asMap())
@@ -904,23 +904,23 @@ public class IndexLifecycleRunnerTests extends ESTestCase {
     private static LifecyclePolicy createPolicy(String policyName, StepKey safeStep, StepKey unsafeStep) {
         Map<String, Phase> phases = new HashMap<>();
         if (safeStep != null) {
-            assert MockAction.NAME.equals(safeStep.getAction()) : "The safe action needs to be MockAction.NAME";
-            assert unsafeStep == null || safeStep.getPhase().equals(unsafeStep.getPhase()) == false
+            assert MockAction.NAME.equals(safeStep.action()) : "The safe action needs to be MockAction.NAME";
+            assert unsafeStep == null || safeStep.phase().equals(unsafeStep.phase()) == false
                 : "safe and unsafe actions must be in different phases";
             Map<String, LifecycleAction> actions = new HashMap<>();
             List<Step> steps = Collections.singletonList(new MockStep(safeStep, null));
             MockAction safeAction = new MockAction(steps, true);
             actions.put(safeAction.getWriteableName(), safeAction);
-            Phase phase = new Phase(safeStep.getPhase(), TimeValue.timeValueMillis(0), actions);
+            Phase phase = new Phase(safeStep.phase(), TimeValue.timeValueMillis(0), actions);
             phases.put(phase.getName(), phase);
         }
         if (unsafeStep != null) {
-            assert MockAction.NAME.equals(unsafeStep.getAction()) : "The unsafe action needs to be MockAction.NAME";
+            assert MockAction.NAME.equals(unsafeStep.action()) : "The unsafe action needs to be MockAction.NAME";
             Map<String, LifecycleAction> actions = new HashMap<>();
             List<Step> steps = Collections.singletonList(new MockStep(unsafeStep, null));
             MockAction unsafeAction = new MockAction(steps, false);
             actions.put(unsafeAction.getWriteableName(), unsafeAction);
-            Phase phase = new Phase(unsafeStep.getPhase(), TimeValue.timeValueMillis(0), actions);
+            Phase phase = new Phase(unsafeStep.phase(), TimeValue.timeValueMillis(0), actions);
             phases.put(phase.getName(), phase);
         }
         return newTestLifecyclePolicy(policyName, phases);
@@ -942,15 +942,15 @@ public class IndexLifecycleRunnerTests extends ESTestCase {
         LifecycleExecutionState newLifecycleState = newClusterState.metadata().index(index).getLifecycleExecutionState();
         LifecycleExecutionState oldLifecycleState = oldClusterState.metadata().index(index).getLifecycleExecutionState();
         assertNotSame(oldLifecycleState, newLifecycleState);
-        assertEquals(nextStep.getPhase(), newLifecycleState.phase());
-        assertEquals(nextStep.getAction(), newLifecycleState.action());
-        assertEquals(nextStep.getName(), newLifecycleState.step());
-        if (currentStep.getPhase().equals(nextStep.getPhase())) {
+        assertEquals(nextStep.phase(), newLifecycleState.phase());
+        assertEquals(nextStep.action(), newLifecycleState.action());
+        assertEquals(nextStep.name(), newLifecycleState.step());
+        if (currentStep.phase().equals(nextStep.phase())) {
             assertEquals(oldLifecycleState.phaseTime(), newLifecycleState.phaseTime());
         } else {
             assertEquals(now, newLifecycleState.phaseTime().longValue());
         }
-        if (currentStep.getAction().equals(nextStep.getAction())) {
+        if (currentStep.action().equals(nextStep.action())) {
             assertEquals(oldLifecycleState.actionTime(), newLifecycleState.actionTime());
         } else {
             assertEquals(now, newLifecycleState.actionTime().longValue());

--- a/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/ilm/IndexLifecycleServiceTests.java
+++ b/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/ilm/IndexLifecycleServiceTests.java
@@ -195,9 +195,9 @@ public class IndexLifecycleServiceTests extends ESTestCase {
         );
         Index index = new Index(randomAlphaOfLengthBetween(1, 20), randomAlphaOfLengthBetween(1, 20));
         LifecycleExecutionState.Builder lifecycleState = LifecycleExecutionState.builder();
-        lifecycleState.setPhase(mockShrinkStep.getPhase());
-        lifecycleState.setAction(mockShrinkStep.getAction());
-        lifecycleState.setStep(mockShrinkStep.getName());
+        lifecycleState.setPhase(mockShrinkStep.phase());
+        lifecycleState.setAction(mockShrinkStep.action());
+        lifecycleState.setStep(mockShrinkStep.name());
         IndexMetadata indexMetadata = IndexMetadata.builder(index.getName())
             .settings(settings(Version.CURRENT).put(LifecycleSettings.LIFECYCLE_NAME, policyName))
             .putCustom(ILM_CUSTOM_METADATA_KEY, lifecycleState.build().asMap())
@@ -231,7 +231,7 @@ public class IndexLifecycleServiceTests extends ESTestCase {
         ShrinkAction action = new ShrinkAction(1, null);
         action.toSteps(mock(Client.class), "warm", randomStepKey())
             .stream()
-            .map(sk -> sk.getKey().getName())
+            .map(sk -> sk.getKey().name())
             .filter(name -> name.equals(ShrinkStep.NAME) == false)
             .forEach(this::verifyCanStopWithStep);
     }
@@ -254,9 +254,9 @@ public class IndexLifecycleServiceTests extends ESTestCase {
         );
         Index index = new Index(randomAlphaOfLengthBetween(1, 20), randomAlphaOfLengthBetween(1, 20));
         LifecycleExecutionState.Builder lifecycleState = LifecycleExecutionState.builder();
-        lifecycleState.setPhase(mockShrinkStep.getPhase());
-        lifecycleState.setAction(mockShrinkStep.getAction());
-        lifecycleState.setStep(mockShrinkStep.getName());
+        lifecycleState.setPhase(mockShrinkStep.phase());
+        lifecycleState.setAction(mockShrinkStep.action());
+        lifecycleState.setStep(mockShrinkStep.name());
         IndexMetadata indexMetadata = IndexMetadata.builder(index.getName())
             .settings(settings(Version.CURRENT).put(LifecycleSettings.LIFECYCLE_NAME, policyName))
             .putCustom(ILM_CUSTOM_METADATA_KEY, lifecycleState.build().asMap())
@@ -306,9 +306,9 @@ public class IndexLifecycleServiceTests extends ESTestCase {
         );
         Index index = new Index(randomAlphaOfLengthBetween(1, 20), randomAlphaOfLengthBetween(1, 20));
         LifecycleExecutionState.Builder lifecycleState = LifecycleExecutionState.builder();
-        lifecycleState.setPhase(currentStepKey.getPhase());
-        lifecycleState.setAction(currentStepKey.getAction());
-        lifecycleState.setStep(currentStepKey.getName());
+        lifecycleState.setPhase(currentStepKey.phase());
+        lifecycleState.setAction(currentStepKey.action());
+        lifecycleState.setStep(currentStepKey.name());
         IndexMetadata indexMetadata = IndexMetadata.builder(index.getName())
             .settings(settings(Version.CURRENT).put(LifecycleSettings.LIFECYCLE_NAME, policyName))
             .putCustom(ILM_CUSTOM_METADATA_KEY, lifecycleState.build().asMap())
@@ -372,9 +372,9 @@ public class IndexLifecycleServiceTests extends ESTestCase {
         LifecyclePolicy i1policy = newTestLifecyclePolicy(policy1, Collections.singletonMap(i1phase.getName(), i1phase));
         Index index1 = new Index(randomAlphaOfLengthBetween(1, 20), randomAlphaOfLengthBetween(1, 20));
         LifecycleExecutionState.Builder i1lifecycleState = LifecycleExecutionState.builder();
-        i1lifecycleState.setPhase(i1currentStepKey.getPhase());
-        i1lifecycleState.setAction(i1currentStepKey.getAction());
-        i1lifecycleState.setStep(i1currentStepKey.getName());
+        i1lifecycleState.setPhase(i1currentStepKey.phase());
+        i1lifecycleState.setAction(i1currentStepKey.action());
+        i1lifecycleState.setStep(i1currentStepKey.name());
 
         String policy2 = randomValueOtherThan(policy1, () -> randomAlphaOfLengthBetween(1, 20));
         Step.StepKey i2currentStepKey = randomStepKey();
@@ -389,9 +389,9 @@ public class IndexLifecycleServiceTests extends ESTestCase {
         LifecyclePolicy i2policy = newTestLifecyclePolicy(policy1, Collections.singletonMap(i2phase.getName(), i1phase));
         Index index2 = new Index(randomAlphaOfLengthBetween(1, 20), randomAlphaOfLengthBetween(1, 20));
         LifecycleExecutionState.Builder i2lifecycleState = LifecycleExecutionState.builder();
-        i2lifecycleState.setPhase(i2currentStepKey.getPhase());
-        i2lifecycleState.setAction(i2currentStepKey.getAction());
-        i2lifecycleState.setStep(i2currentStepKey.getName());
+        i2lifecycleState.setPhase(i2currentStepKey.phase());
+        i2lifecycleState.setAction(i2currentStepKey.action());
+        i2lifecycleState.setStep(i2currentStepKey.name());
 
         CountDownLatch stepLatch = new CountDownLatch(2);
         boolean failStep1 = randomBoolean();

--- a/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/ilm/IndexLifecycleTransitionTests.java
+++ b/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/ilm/IndexLifecycleTransitionTests.java
@@ -106,9 +106,9 @@ public class IndexLifecycleTransitionTests extends ESTestCase {
         assertClusterStateOnNextStep(clusterState, index, currentStep, nextStep, newClusterState, now);
 
         LifecycleExecutionState.Builder lifecycleState = LifecycleExecutionState.builder();
-        lifecycleState.setPhase(currentStep.getPhase());
-        lifecycleState.setAction(currentStep.getAction());
-        lifecycleState.setStep(currentStep.getName());
+        lifecycleState.setPhase(currentStep.phase());
+        lifecycleState.setAction(currentStep.action());
+        lifecycleState.setStep(currentStep.name());
         // test going from set currentStep settings to nextStep
         Settings.Builder indexSettingsBuilder = Settings.builder().put(LifecycleSettings.LIFECYCLE_NAME, policy.getName());
         if (randomBoolean()) {
@@ -138,9 +138,9 @@ public class IndexLifecycleTransitionTests extends ESTestCase {
             indexName,
             Settings.builder().put(LifecycleSettings.LIFECYCLE_NAME, policy.getName()),
             LifecycleExecutionState.builder()
-                .setPhase(currentStep.getPhase())
-                .setAction(currentStep.getAction())
-                .setStep(currentStep.getName())
+                .setPhase(currentStep.phase())
+                .setAction(currentStep.action())
+                .setStep(currentStep.name())
                 .build(),
             policyMetadatas
         );
@@ -157,9 +157,9 @@ public class IndexLifecycleTransitionTests extends ESTestCase {
         assertClusterStateOnNextStep(clusterState, index, currentStep, nextStep, newClusterState, now);
 
         LifecycleExecutionState.Builder lifecycleState = LifecycleExecutionState.builder();
-        lifecycleState.setPhase(currentStep.getPhase());
-        lifecycleState.setAction(currentStep.getAction());
-        lifecycleState.setStep(currentStep.getName());
+        lifecycleState.setPhase(currentStep.phase());
+        lifecycleState.setAction(currentStep.action());
+        lifecycleState.setStep(currentStep.name());
         if (randomBoolean()) {
             lifecycleState.setStepInfo(randomAlphaOfLength(20));
         }
@@ -189,9 +189,9 @@ public class IndexLifecycleTransitionTests extends ESTestCase {
             indexName,
             Settings.builder().put(LifecycleSettings.LIFECYCLE_NAME, policy.getName()),
             LifecycleExecutionState.builder()
-                .setPhase(currentStep.getPhase())
-                .setAction(currentStep.getAction())
-                .setStep(currentStep.getName())
+                .setPhase(currentStep.phase())
+                .setAction(currentStep.action())
+                .setStep(currentStep.name())
                 .build(),
             policyMetadatas
         );
@@ -208,9 +208,9 @@ public class IndexLifecycleTransitionTests extends ESTestCase {
         assertClusterStateOnNextStep(clusterState, index, currentStep, nextStep, newClusterState, now);
 
         LifecycleExecutionState.Builder lifecycleState = LifecycleExecutionState.builder();
-        lifecycleState.setPhase(currentStep.getPhase());
-        lifecycleState.setAction(currentStep.getAction());
-        lifecycleState.setStep(currentStep.getName());
+        lifecycleState.setPhase(currentStep.phase());
+        lifecycleState.setAction(currentStep.action());
+        lifecycleState.setStep(currentStep.name());
         if (randomBoolean()) {
             lifecycleState.setStepInfo(randomAlphaOfLength(20));
         }
@@ -245,9 +245,9 @@ public class IndexLifecycleTransitionTests extends ESTestCase {
         PolicyStepsRegistry stepRegistry = createOneStepPolicyStepRegistry(policyName, step);
 
         LifecycleExecutionState.Builder lifecycleState = LifecycleExecutionState.builder();
-        lifecycleState.setPhase(currentStepKey.getPhase());
-        lifecycleState.setAction(currentStepKey.getAction());
-        lifecycleState.setStep(currentStepKey.getName());
+        lifecycleState.setPhase(currentStepKey.phase());
+        lifecycleState.setAction(currentStepKey.action());
+        lifecycleState.setStep(currentStepKey.name());
 
         Settings.Builder indexSettingsBuilder = Settings.builder().put(LifecycleSettings.LIFECYCLE_NAME, policyName);
         ClusterState clusterState = buildClusterState(indexName, indexSettingsBuilder, lifecycleState.build(), policyMetadatas);
@@ -274,9 +274,9 @@ public class IndexLifecycleTransitionTests extends ESTestCase {
 
         Settings.Builder indexSettingsBuilder = Settings.builder().put(LifecycleSettings.LIFECYCLE_NAME, randomBoolean() ? "" : null);
         LifecycleExecutionState.Builder lifecycleState = LifecycleExecutionState.builder();
-        lifecycleState.setPhase(currentStepKey.getPhase());
-        lifecycleState.setAction(currentStepKey.getAction());
-        lifecycleState.setStep(currentStepKey.getName());
+        lifecycleState.setPhase(currentStepKey.phase());
+        lifecycleState.setAction(currentStepKey.action());
+        lifecycleState.setStep(currentStepKey.name());
 
         ClusterState clusterState = buildClusterState(indexName, indexSettingsBuilder, lifecycleState.build(), Collections.emptyList());
         Index index = clusterState.metadata().index(indexName).getIndex();
@@ -298,9 +298,9 @@ public class IndexLifecycleTransitionTests extends ESTestCase {
 
         Settings.Builder indexSettingsBuilder = Settings.builder().put(LifecycleSettings.LIFECYCLE_NAME, policyName);
         LifecycleExecutionState.Builder lifecycleState = LifecycleExecutionState.builder();
-        lifecycleState.setPhase(currentStepKey.getPhase());
-        lifecycleState.setAction(currentStepKey.getAction());
-        lifecycleState.setStep(currentStepKey.getName());
+        lifecycleState.setPhase(currentStepKey.phase());
+        lifecycleState.setAction(currentStepKey.action());
+        lifecycleState.setStep(currentStepKey.name());
 
         ClusterState clusterState = buildClusterState(indexName, indexSettingsBuilder, lifecycleState.build(), Collections.emptyList());
         Index index = clusterState.metadata().index(indexName).getIndex();
@@ -321,9 +321,9 @@ public class IndexLifecycleTransitionTests extends ESTestCase {
         Exception cause = new ElasticsearchException("THIS IS AN EXPECTED CAUSE");
 
         LifecycleExecutionState.Builder lifecycleState = LifecycleExecutionState.builder();
-        lifecycleState.setPhase(currentStep.getPhase());
-        lifecycleState.setAction(currentStep.getAction());
-        lifecycleState.setStep(currentStep.getName());
+        lifecycleState.setPhase(currentStep.phase());
+        lifecycleState.setAction(currentStep.action());
+        lifecycleState.setStep(currentStep.name());
         ClusterState clusterState = buildClusterState(indexName, Settings.builder(), lifecycleState.build(), Collections.emptyList());
         Index index = clusterState.metadata().index(indexName).getIndex();
 
@@ -355,9 +355,9 @@ public class IndexLifecycleTransitionTests extends ESTestCase {
         RandomStepInfo stepInfo = new RandomStepInfo(() -> randomAlphaOfLength(10));
 
         LifecycleExecutionState.Builder lifecycleState = LifecycleExecutionState.builder();
-        lifecycleState.setPhase(currentStep.getPhase());
-        lifecycleState.setAction(currentStep.getAction());
-        lifecycleState.setStep(currentStep.getName());
+        lifecycleState.setPhase(currentStep.phase());
+        lifecycleState.setAction(currentStep.action());
+        lifecycleState.setStep(currentStep.name());
         ClusterState clusterState = buildClusterState(indexName, Settings.builder(), lifecycleState.build(), Collections.emptyList());
         Index index = clusterState.metadata().index(indexName).getIndex();
         ClusterState newClusterState = IndexLifecycleTransition.addStepInfoToClusterState(index, clusterState, stepInfo);
@@ -373,9 +373,9 @@ public class IndexLifecycleTransitionTests extends ESTestCase {
         LifecyclePolicy oldPolicy = createPolicy(oldPolicyName, currentStep, null);
         Settings.Builder indexSettingsBuilder = Settings.builder().put(LifecycleSettings.LIFECYCLE_NAME, oldPolicyName);
         LifecycleExecutionState.Builder lifecycleState = LifecycleExecutionState.builder();
-        lifecycleState.setPhase(currentStep.getPhase());
-        lifecycleState.setAction(currentStep.getAction());
-        lifecycleState.setStep(currentStep.getName());
+        lifecycleState.setPhase(currentStep.phase());
+        lifecycleState.setAction(currentStep.action());
+        lifecycleState.setStep(currentStep.name());
         List<LifecyclePolicyMetadata> policyMetadatas = new ArrayList<>();
         policyMetadatas.add(
             new LifecyclePolicyMetadata(oldPolicy, Collections.emptyMap(), randomNonNegativeLong(), randomNonNegativeLong())
@@ -417,9 +417,9 @@ public class IndexLifecycleTransitionTests extends ESTestCase {
         Step.StepKey currentStep = AbstractStepTestCase.randomStepKey();
         Settings.Builder indexSettingsBuilder = Settings.builder().put(LifecycleSettings.LIFECYCLE_NAME, oldPolicyName);
         LifecycleExecutionState.Builder lifecycleState = LifecycleExecutionState.builder();
-        lifecycleState.setPhase(currentStep.getPhase());
-        lifecycleState.setAction(currentStep.getAction());
-        lifecycleState.setStep(currentStep.getName());
+        lifecycleState.setPhase(currentStep.phase());
+        lifecycleState.setAction(currentStep.action());
+        lifecycleState.setStep(currentStep.name());
         List<LifecyclePolicyMetadata> policyMetadatas = new ArrayList<>();
         policyMetadatas.add(
             new LifecyclePolicyMetadata(oldPolicy, Collections.emptyMap(), randomNonNegativeLong(), randomNonNegativeLong())
@@ -443,9 +443,9 @@ public class IndexLifecycleTransitionTests extends ESTestCase {
         LifecyclePolicy oldPolicy = createPolicy(oldPolicyName, null, currentStep);
         Settings.Builder indexSettingsBuilder = Settings.builder().put(LifecycleSettings.LIFECYCLE_NAME, oldPolicyName);
         LifecycleExecutionState.Builder lifecycleState = LifecycleExecutionState.builder();
-        lifecycleState.setPhase(currentStep.getPhase());
-        lifecycleState.setAction(currentStep.getAction());
-        lifecycleState.setStep(currentStep.getName());
+        lifecycleState.setPhase(currentStep.phase());
+        lifecycleState.setAction(currentStep.action());
+        lifecycleState.setStep(currentStep.name());
         List<LifecyclePolicyMetadata> policyMetadatas = new ArrayList<>();
         policyMetadatas.add(
             new LifecyclePolicyMetadata(oldPolicy, Collections.emptyMap(), randomNonNegativeLong(), randomNonNegativeLong())
@@ -470,9 +470,9 @@ public class IndexLifecycleTransitionTests extends ESTestCase {
             .put(LifecycleSettings.LIFECYCLE_NAME, oldPolicyName)
             .put(LifecycleSettings.LIFECYCLE_INDEXING_COMPLETE, true);
         LifecycleExecutionState.Builder lifecycleState = LifecycleExecutionState.builder();
-        lifecycleState.setPhase(currentStep.getPhase());
-        lifecycleState.setAction(currentStep.getAction());
-        lifecycleState.setStep(currentStep.getName());
+        lifecycleState.setPhase(currentStep.phase());
+        lifecycleState.setAction(currentStep.action());
+        lifecycleState.setStep(currentStep.name());
         List<LifecyclePolicyMetadata> policyMetadatas = new ArrayList<>();
         policyMetadatas.add(
             new LifecyclePolicyMetadata(oldPolicy, Collections.emptyMap(), randomNonNegativeLong(), randomNonNegativeLong())
@@ -637,7 +637,7 @@ public class IndexLifecycleTransitionTests extends ESTestCase {
         String policyName = "my_policy";
         long now = randomNonNegativeLong();
         Step.StepKey failedStepKey = new Step.StepKey("current_phase", MockAction.NAME, "current_step");
-        Step.StepKey errorStepKey = new Step.StepKey(failedStepKey.getPhase(), failedStepKey.getAction(), ErrorStep.NAME);
+        Step.StepKey errorStepKey = new Step.StepKey(failedStepKey.phase(), failedStepKey.action(), ErrorStep.NAME);
         Step step = new MockStep(failedStepKey, null);
         LifecyclePolicy policy = createPolicy(policyName, failedStepKey, null);
         LifecyclePolicyMetadata policyMetadata = new LifecyclePolicyMetadata(
@@ -650,13 +650,13 @@ public class IndexLifecycleTransitionTests extends ESTestCase {
         PolicyStepsRegistry policyRegistry = createOneStepPolicyStepRegistry(policyName, step);
         Settings.Builder indexSettingsBuilder = Settings.builder().put(LifecycleSettings.LIFECYCLE_NAME, policyName);
         LifecycleExecutionState.Builder lifecycleState = LifecycleExecutionState.builder();
-        lifecycleState.setPhase(errorStepKey.getPhase());
+        lifecycleState.setPhase(errorStepKey.phase());
         lifecycleState.setPhaseTime(now);
-        lifecycleState.setAction(errorStepKey.getAction());
+        lifecycleState.setAction(errorStepKey.action());
         lifecycleState.setActionTime(now);
-        lifecycleState.setStep(errorStepKey.getName());
+        lifecycleState.setStep(errorStepKey.name());
         lifecycleState.setStepTime(now);
-        lifecycleState.setFailedStep(failedStepKey.getName());
+        lifecycleState.setFailedStep(failedStepKey.name());
         ClusterState clusterState = buildClusterState(
             indexName,
             indexSettingsBuilder,
@@ -681,9 +681,9 @@ public class IndexLifecycleTransitionTests extends ESTestCase {
         String policyName = "my_policy";
         long now = randomNonNegativeLong();
         Step.StepKey failedStepKey = new Step.StepKey("current_phase", MockAction.NAME, "current_step");
-        Step.StepKey errorStepKey = new Step.StepKey(failedStepKey.getPhase(), failedStepKey.getAction(), ErrorStep.NAME);
+        Step.StepKey errorStepKey = new Step.StepKey(failedStepKey.phase(), failedStepKey.action(), ErrorStep.NAME);
 
-        Step.StepKey registeredStepKey = new Step.StepKey(randomFrom(failedStepKey.getPhase(), "other"), MockAction.NAME, "different_step");
+        Step.StepKey registeredStepKey = new Step.StepKey(randomFrom(failedStepKey.phase(), "other"), MockAction.NAME, "different_step");
         Step step = new MockStep(registeredStepKey, null);
         LifecyclePolicy policy = createPolicy(policyName, failedStepKey, null);
         LifecyclePolicyMetadata policyMetadata = new LifecyclePolicyMetadata(
@@ -696,13 +696,13 @@ public class IndexLifecycleTransitionTests extends ESTestCase {
         PolicyStepsRegistry policyRegistry = createOneStepPolicyStepRegistry(policyName, step);
         Settings.Builder indexSettingsBuilder = Settings.builder().put(LifecycleSettings.LIFECYCLE_NAME, policyName);
         LifecycleExecutionState.Builder lifecycleState = LifecycleExecutionState.builder();
-        lifecycleState.setPhase(errorStepKey.getPhase());
+        lifecycleState.setPhase(errorStepKey.phase());
         lifecycleState.setPhaseTime(now);
-        lifecycleState.setAction(errorStepKey.getAction());
+        lifecycleState.setAction(errorStepKey.action());
         lifecycleState.setActionTime(now);
-        lifecycleState.setStep(errorStepKey.getName());
+        lifecycleState.setStep(errorStepKey.name());
         lifecycleState.setStepTime(now);
-        lifecycleState.setFailedStep(failedStepKey.getName());
+        lifecycleState.setFailedStep(failedStepKey.name());
         ClusterState clusterState = buildClusterState(
             indexName,
             indexSettingsBuilder,
@@ -740,15 +740,15 @@ public class IndexLifecycleTransitionTests extends ESTestCase {
         String policyName = "my_policy";
         long now = randomNonNegativeLong();
         Step.StepKey failedStepKey = new Step.StepKey("current_phase", "current_action", "current_step");
-        Step.StepKey errorStepKey = new Step.StepKey(failedStepKey.getPhase(), failedStepKey.getAction(), ErrorStep.NAME);
+        Step.StepKey errorStepKey = new Step.StepKey(failedStepKey.phase(), failedStepKey.action(), ErrorStep.NAME);
         Step step = new MockStep(failedStepKey, null);
         PolicyStepsRegistry policyRegistry = createOneStepPolicyStepRegistry(policyName, step);
         Settings.Builder indexSettingsBuilder = Settings.builder().put(LifecycleSettings.LIFECYCLE_NAME, (String) null);
         LifecycleExecutionState.Builder lifecycleState = LifecycleExecutionState.builder();
-        lifecycleState.setPhase(errorStepKey.getPhase());
-        lifecycleState.setAction(errorStepKey.getAction());
-        lifecycleState.setStep(errorStepKey.getName());
-        lifecycleState.setFailedStep(failedStepKey.getName());
+        lifecycleState.setPhase(errorStepKey.phase());
+        lifecycleState.setAction(errorStepKey.action());
+        lifecycleState.setStep(errorStepKey.name());
+        lifecycleState.setFailedStep(failedStepKey.name());
         ClusterState clusterState = buildClusterState(indexName, indexSettingsBuilder, lifecycleState.build(), Collections.emptyList());
         IllegalArgumentException exception = expectThrows(
             IllegalArgumentException.class,
@@ -766,9 +766,9 @@ public class IndexLifecycleTransitionTests extends ESTestCase {
         PolicyStepsRegistry policyRegistry = createOneStepPolicyStepRegistry(policyName, step);
         Settings.Builder indexSettingsBuilder = Settings.builder().put(LifecycleSettings.LIFECYCLE_NAME, (String) null);
         LifecycleExecutionState.Builder lifecycleState = LifecycleExecutionState.builder();
-        lifecycleState.setPhase(failedStepKey.getPhase());
-        lifecycleState.setAction(failedStepKey.getAction());
-        lifecycleState.setStep(failedStepKey.getName());
+        lifecycleState.setPhase(failedStepKey.phase());
+        lifecycleState.setAction(failedStepKey.action());
+        lifecycleState.setStep(failedStepKey.name());
         ClusterState clusterState = buildClusterState(indexName, indexSettingsBuilder, lifecycleState.build(), Collections.emptyList());
         IllegalArgumentException exception = expectThrows(
             IllegalArgumentException.class,
@@ -787,7 +787,7 @@ public class IndexLifecycleTransitionTests extends ESTestCase {
         String policyName = "my_policy";
         long now = randomNonNegativeLong();
         Step.StepKey failedStepKey = new Step.StepKey("current_phase", MockAction.NAME, "current_step");
-        Step.StepKey errorStepKey = new Step.StepKey(failedStepKey.getPhase(), failedStepKey.getAction(), ErrorStep.NAME);
+        Step.StepKey errorStepKey = new Step.StepKey(failedStepKey.phase(), failedStepKey.action(), ErrorStep.NAME);
         Step retryableStep = new IndexLifecycleRunnerTests.RetryableMockStep(failedStepKey, null);
         LifecyclePolicy policy = createPolicy(policyName, failedStepKey, null);
         LifecyclePolicyMetadata policyMetadata = new LifecyclePolicyMetadata(
@@ -800,13 +800,13 @@ public class IndexLifecycleTransitionTests extends ESTestCase {
         PolicyStepsRegistry policyRegistry = createOneStepPolicyStepRegistry(policyName, retryableStep);
         Settings.Builder indexSettingsBuilder = Settings.builder().put(LifecycleSettings.LIFECYCLE_NAME, policyName);
         LifecycleExecutionState.Builder lifecycleState = LifecycleExecutionState.builder();
-        lifecycleState.setPhase(errorStepKey.getPhase());
+        lifecycleState.setPhase(errorStepKey.phase());
         lifecycleState.setPhaseTime(now);
-        lifecycleState.setAction(errorStepKey.getAction());
+        lifecycleState.setAction(errorStepKey.action());
         lifecycleState.setActionTime(now);
-        lifecycleState.setStep(errorStepKey.getName());
+        lifecycleState.setStep(errorStepKey.name());
         lifecycleState.setStepTime(now);
-        lifecycleState.setFailedStep(failedStepKey.getName());
+        lifecycleState.setFailedStep(failedStepKey.name());
         ClusterState clusterState = buildClusterState(
             indexName,
             indexSettingsBuilder,
@@ -1104,8 +1104,8 @@ public class IndexLifecycleTransitionTests extends ESTestCase {
                 );
 
                 Step.StepKey hotPhaseCompleteStepKey = PhaseCompleteStep.finalStep("hot").getKey();
-                assertThat(newState.action(), is(hotPhaseCompleteStepKey.getAction()));
-                assertThat(newState.step(), is(hotPhaseCompleteStepKey.getName()));
+                assertThat(newState.action(), is(hotPhaseCompleteStepKey.action()));
+                assertThat(newState.step(), is(hotPhaseCompleteStepKey.name()));
                 assertThat(
                     "the cached phase should not contain rollover anymore",
                     newState.phaseDefinition(),
@@ -1143,8 +1143,8 @@ public class IndexLifecycleTransitionTests extends ESTestCase {
                 Step.StepKey hotPhaseCompleteStepKey = PhaseCompleteStep.finalStep("hot").getKey();
                 // the state was still moved into the next action, even if the updated policy still contained the action the index was
                 // currently executing
-                assertThat(newState.action(), is(hotPhaseCompleteStepKey.getAction()));
-                assertThat(newState.step(), is(hotPhaseCompleteStepKey.getName()));
+                assertThat(newState.action(), is(hotPhaseCompleteStepKey.action()));
+                assertThat(newState.step(), is(hotPhaseCompleteStepKey.name()));
                 assertThat(newState.phaseDefinition(), containsString(RolloverAction.NAME));
                 assertThat(
                     "the cached phase should not contain set_priority anymore",
@@ -1158,23 +1158,23 @@ public class IndexLifecycleTransitionTests extends ESTestCase {
     private static LifecyclePolicy createPolicy(String policyName, Step.StepKey safeStep, Step.StepKey unsafeStep) {
         Map<String, Phase> phases = new HashMap<>();
         if (safeStep != null) {
-            assert MockAction.NAME.equals(safeStep.getAction()) : "The safe action needs to be MockAction.NAME";
-            assert unsafeStep == null || safeStep.getPhase().equals(unsafeStep.getPhase()) == false
+            assert MockAction.NAME.equals(safeStep.action()) : "The safe action needs to be MockAction.NAME";
+            assert unsafeStep == null || safeStep.phase().equals(unsafeStep.phase()) == false
                 : "safe and unsafe actions must be in different phases";
             Map<String, LifecycleAction> actions = new HashMap<>();
             List<Step> steps = Collections.singletonList(new MockStep(safeStep, null));
             MockAction safeAction = new MockAction(steps, true);
             actions.put(safeAction.getWriteableName(), safeAction);
-            Phase phase = new Phase(safeStep.getPhase(), TimeValue.timeValueMillis(0), actions);
+            Phase phase = new Phase(safeStep.phase(), TimeValue.timeValueMillis(0), actions);
             phases.put(phase.getName(), phase);
         }
         if (unsafeStep != null) {
-            assert MockAction.NAME.equals(unsafeStep.getAction()) : "The unsafe action needs to be MockAction.NAME";
+            assert MockAction.NAME.equals(unsafeStep.action()) : "The unsafe action needs to be MockAction.NAME";
             Map<String, LifecycleAction> actions = new HashMap<>();
             List<Step> steps = Collections.singletonList(new MockStep(unsafeStep, null));
             MockAction unsafeAction = new MockAction(steps, false);
             actions.put(unsafeAction.getWriteableName(), unsafeAction);
-            Phase phase = new Phase(unsafeStep.getPhase(), TimeValue.timeValueMillis(0), actions);
+            Phase phase = new Phase(unsafeStep.phase(), TimeValue.timeValueMillis(0), actions);
             phases.put(phase.getName(), phase);
         }
         return newTestLifecyclePolicy(policyName, phases);
@@ -1238,10 +1238,10 @@ public class IndexLifecycleTransitionTests extends ESTestCase {
         LifecycleExecutionState newLifecycleState = newClusterState.metadata().index(index).getLifecycleExecutionState();
         LifecycleExecutionState oldLifecycleState = oldClusterState.metadata().index(index).getLifecycleExecutionState();
         assertNotSame(oldLifecycleState, newLifecycleState);
-        assertEquals(nextStep.getPhase(), newLifecycleState.phase());
-        assertEquals(nextStep.getAction(), newLifecycleState.action());
-        assertEquals(nextStep.getName(), newLifecycleState.step());
-        if (currentStep.getPhase().equals(nextStep.getPhase())) {
+        assertEquals(nextStep.phase(), newLifecycleState.phase());
+        assertEquals(nextStep.action(), newLifecycleState.action());
+        assertEquals(nextStep.name(), newLifecycleState.step());
+        if (currentStep.phase().equals(nextStep.phase())) {
             assertEquals(
                 "expected phase times to be the same but they were different",
                 oldLifecycleState.phaseTime(),
@@ -1250,7 +1250,7 @@ public class IndexLifecycleTransitionTests extends ESTestCase {
         } else {
             assertEquals(now, newLifecycleState.phaseTime().longValue());
         }
-        if (currentStep.getAction().equals(nextStep.getAction())) {
+        if (currentStep.action().equals(nextStep.action())) {
             assertEquals(
                 "expected action times to be the same but they were different",
                 oldLifecycleState.actionTime(),
@@ -1289,10 +1289,10 @@ public class IndexLifecycleTransitionTests extends ESTestCase {
         LifecycleExecutionState newLifecycleState = newClusterState.metadata().index(index).getLifecycleExecutionState();
         LifecycleExecutionState oldLifecycleState = oldClusterState.metadata().index(index).getLifecycleExecutionState();
         assertNotSame(oldLifecycleState, newLifecycleState);
-        assertEquals(currentStep.getPhase(), newLifecycleState.phase());
-        assertEquals(currentStep.getAction(), newLifecycleState.action());
+        assertEquals(currentStep.phase(), newLifecycleState.phase());
+        assertEquals(currentStep.action(), newLifecycleState.action());
         assertEquals(ErrorStep.NAME, newLifecycleState.step());
-        assertEquals(currentStep.getName(), newLifecycleState.failedStep());
+        assertEquals(currentStep.name(), newLifecycleState.failedStep());
         assertThat(newLifecycleState.stepInfo(), containsString(expectedCauseValue));
         assertEquals(oldLifecycleState.phaseTime(), newLifecycleState.phaseTime());
         assertEquals(oldLifecycleState.actionTime(), newLifecycleState.actionTime());
@@ -1317,9 +1317,9 @@ public class IndexLifecycleTransitionTests extends ESTestCase {
         LifecycleExecutionState newLifecycleState = newClusterState.metadata().index(index).getLifecycleExecutionState();
         LifecycleExecutionState oldLifecycleState = oldClusterState.metadata().index(index).getLifecycleExecutionState();
         assertNotSame(oldLifecycleState, newLifecycleState);
-        assertEquals(currentStep.getPhase(), newLifecycleState.phase());
-        assertEquals(currentStep.getAction(), newLifecycleState.action());
-        assertEquals(currentStep.getName(), newLifecycleState.step());
+        assertEquals(currentStep.phase(), newLifecycleState.phase());
+        assertEquals(currentStep.action(), newLifecycleState.action());
+        assertEquals(currentStep.name(), newLifecycleState.step());
         assertEquals(expectedstepInfoValue, newLifecycleState.stepInfo());
         assertEquals(oldLifecycleState.phaseTime(), newLifecycleState.phaseTime());
         assertEquals(oldLifecycleState.actionTime(), newLifecycleState.actionTime());

--- a/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/ilm/MoveToErrorStepUpdateTaskTests.java
+++ b/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/ilm/MoveToErrorStepUpdateTaskTests.java
@@ -87,8 +87,8 @@ public class MoveToErrorStepUpdateTaskTests extends ESTestCase {
         ClusterState newState = task.execute(clusterState);
         LifecycleExecutionState lifecycleState = newState.getMetadata().index(index).getLifecycleExecutionState();
         StepKey actualKey = Step.getCurrentStepKey(lifecycleState);
-        assertThat(actualKey, equalTo(new StepKey(currentStepKey.getPhase(), currentStepKey.getAction(), ErrorStep.NAME)));
-        assertThat(lifecycleState.failedStep(), equalTo(currentStepKey.getName()));
+        assertThat(actualKey, equalTo(new StepKey(currentStepKey.phase(), currentStepKey.action(), ErrorStep.NAME)));
+        assertThat(lifecycleState.failedStep(), equalTo(currentStepKey.name()));
         assertThat(lifecycleState.phaseTime(), nullValue());
         assertThat(lifecycleState.actionTime(), nullValue());
         assertThat(lifecycleState.stepTime(), equalTo(now));
@@ -148,9 +148,9 @@ public class MoveToErrorStepUpdateTaskTests extends ESTestCase {
         LifecycleExecutionState.Builder lifecycleState = LifecycleExecutionState.builder(
             clusterState.metadata().index(index).getLifecycleExecutionState()
         );
-        lifecycleState.setPhase(stepKey.getPhase());
-        lifecycleState.setAction(stepKey.getAction());
-        lifecycleState.setStep(stepKey.getName());
+        lifecycleState.setPhase(stepKey.phase());
+        lifecycleState.setAction(stepKey.action());
+        lifecycleState.setStep(stepKey.name());
 
         clusterState = ClusterState.builder(clusterState)
             .metadata(

--- a/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/ilm/MoveToNextStepUpdateTaskTests.java
+++ b/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/ilm/MoveToNextStepUpdateTaskTests.java
@@ -209,11 +209,11 @@ public class MoveToNextStepUpdateTaskTests extends ESTestCase {
         LifecycleExecutionState.Builder lifecycleState = LifecycleExecutionState.builder(
             clusterState.metadata().index(index).getLifecycleExecutionState()
         );
-        lifecycleState.setPhase(stepKey.getPhase());
+        lifecycleState.setPhase(stepKey.phase());
         lifecycleState.setPhaseTime(now);
-        lifecycleState.setAction(stepKey.getAction());
+        lifecycleState.setAction(stepKey.action());
         lifecycleState.setActionTime(now);
-        lifecycleState.setStep(stepKey.getName());
+        lifecycleState.setStep(stepKey.name());
         lifecycleState.setStepTime(now);
         lifecycleState.setPhaseDefinition("{\"actions\":{\"TEST_ACTION\":{}}}");
         clusterState = ClusterState.builder(clusterState)

--- a/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/ilm/PolicyStepsRegistryTests.java
+++ b/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/ilm/PolicyStepsRegistryTests.java
@@ -193,7 +193,7 @@ public class PolicyStepsRegistryTests extends ESTestCase {
         SortedMap<String, LifecyclePolicyMetadata> metas = new TreeMap<>();
         metas.put("policy", policyMetadata);
         PolicyStepsRegistry registry = new PolicyStepsRegistry(metas, null, null, REGISTRY, client, null);
-        Step.StepKey badStepKey = new Step.StepKey(step.getKey().getPhase(), step.getKey().getAction(), step.getKey().getName() + "-bad");
+        Step.StepKey badStepKey = new Step.StepKey(step.getKey().phase(), step.getKey().action(), step.getKey().name() + "-bad");
         assertNull(registry.getStep(indexMetadata, badStepKey));
         // repeat the test to make sure that nulls don't poison the registry's cache
         assertNull(registry.getStep(indexMetadata, badStepKey));
@@ -268,7 +268,7 @@ public class PolicyStepsRegistryTests extends ESTestCase {
         assertThat(registeredStepsForPolicy.size(), equalTo(policySteps.size()));
         for (Step step : policySteps) {
             LifecycleExecutionState.Builder newIndexState = LifecycleExecutionState.builder();
-            newIndexState.setPhase(step.getKey().getPhase());
+            newIndexState.setPhase(step.getKey().phase());
             currentState = ClusterState.builder(currentState)
                 .metadata(
                     Metadata.builder(currentState.metadata())
@@ -430,7 +430,7 @@ public class PolicyStepsRegistryTests extends ESTestCase {
         Map<Step.StepKey, Step> registeredStepsForPolicy = registry.getStepMap().get(newPolicy.getName());
         Step shrinkStep = registeredStepsForPolicy.entrySet()
             .stream()
-            .filter(e -> e.getKey().getPhase().equals("warm") && e.getKey().getName().equals("shrink"))
+            .filter(e -> e.getKey().phase().equals("warm") && e.getKey().name().equals("shrink"))
             .findFirst()
             .get()
             .getValue();
@@ -459,7 +459,7 @@ public class PolicyStepsRegistryTests extends ESTestCase {
         registeredStepsForPolicy = registry.getStepMap().get(newPolicy.getName());
         shrinkStep = registeredStepsForPolicy.entrySet()
             .stream()
-            .filter(e -> e.getKey().getPhase().equals("warm") && e.getKey().getName().equals("shrink"))
+            .filter(e -> e.getKey().phase().equals("warm") && e.getKey().name().equals("shrink"))
             .findFirst()
             .get()
             .getValue();

--- a/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/ilm/SetStepInfoUpdateTaskTests.java
+++ b/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/ilm/SetStepInfoUpdateTaskTests.java
@@ -155,9 +155,9 @@ public class SetStepInfoUpdateTaskTests extends ESTestCase {
         LifecycleExecutionState.Builder lifecycleState = LifecycleExecutionState.builder(
             clusterState.metadata().index(index).getLifecycleExecutionState()
         );
-        lifecycleState.setPhase(stepKey.getPhase());
-        lifecycleState.setAction(stepKey.getAction());
-        lifecycleState.setStep(stepKey.getName());
+        lifecycleState.setPhase(stepKey.phase());
+        lifecycleState.setAction(stepKey.action());
+        lifecycleState.setStep(stepKey.name());
 
         clusterState = ClusterState.builder(clusterState)
             .metadata(


### PR DESCRIPTION
A bit of a random refactoring, but I found that master under heavy load gets surprisingly hot on the hashcode calculation in `StepKey` because that seems to not inline and actually sets up an `Object[]` array on every call when this thing is used for checking if there's work for an index.
Instead of fixing the hashCode to run faster, lets just use a record to do this out of the box and save the code for equals as well.

relates #77466 