### PR TITLE
Make RepositoryShardId a record

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/SnapshotsInProgress.java
+++ b/server/src/main/java/org/elasticsearch/cluster/SnapshotsInProgress.java
@@ -848,7 +848,7 @@ public class SnapshotsInProgress extends AbstractNamedDiffable<Custom> implement
             final List<String> dataStreams = in.readStringList();
             final SnapshotId source = in.readOptionalWriteable(SnapshotId::new);
             final Map<RepositoryShardId, ShardSnapshotStatus> clones = in.readImmutableMap(
-                RepositoryShardId::new,
+                RepositoryShardId::readFrom,
                 ShardSnapshotStatus::readFrom
             );
             final List<SnapshotFeatureInfo> featureStates = in.readImmutableList(SnapshotFeatureInfo::new);
@@ -1414,7 +1414,7 @@ public class SnapshotsInProgress extends AbstractNamedDiffable<Custom> implement
 
                 @Override
                 public RepositoryShardId readKey(StreamInput in) throws IOException {
-                    return new RepositoryShardId(in);
+                    return RepositoryShardId.readFrom(in);
                 }
             };
 

--- a/server/src/main/java/org/elasticsearch/repositories/RepositoryShardId.java
+++ b/server/src/main/java/org/elasticsearch/repositories/RepositoryShardId.java
@@ -13,64 +13,23 @@ import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
 
 import java.io.IOException;
-import java.util.Objects;
 
 /**
  * Represents a shard snapshot in a repository.
  */
-public final class RepositoryShardId implements Writeable {
+public record RepositoryShardId(IndexId index, int shardId) implements Writeable {
 
-    private final IndexId index;
-
-    private final int shard;
-
-    public RepositoryShardId(IndexId index, int shard) {
-        assert index != null;
-        this.index = Objects.requireNonNull(index);
-        this.shard = shard;
-    }
-
-    public RepositoryShardId(StreamInput in) throws IOException {
-        this(new IndexId(in), in.readVInt());
-    }
-
-    public IndexId index() {
-        return index;
+    public static RepositoryShardId readFrom(StreamInput in) throws IOException {
+        return new RepositoryShardId(new IndexId(in), in.readVInt());
     }
 
     public String indexName() {
         return index.getName();
     }
 
-    public int shardId() {
-        return shard;
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(index, shard);
-    }
-
-    @Override
-    public boolean equals(Object obj) {
-        if (this == obj) {
-            return true;
-        }
-        if (obj instanceof RepositoryShardId == false) {
-            return false;
-        }
-        final RepositoryShardId that = (RepositoryShardId) obj;
-        return that.index.equals(index) && that.shard == shard;
-    }
-
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         index.writeTo(out);
-        out.writeVInt(shard);
-    }
-
-    @Override
-    public String toString() {
-        return "RepositoryShardId{" + index + "}{" + shard + "}";
+        out.writeVInt(shardId);
     }
 }


### PR DESCRIPTION
Same reasoning as in #90755, the hash code method in this thing is super hot and accounts for 10%+ of all allocations on master in the many shards snapshot benchmark -> lets use a record here instead to save some code and get a fast version out of the box.

relates #77466 