### PR TITLE
Speed up equals method on ImmutableOpenMap

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/collect/ImmutableOpenMap.java
+++ b/server/src/main/java/org/elasticsearch/common/collect/ImmutableOpenMap.java
@@ -129,6 +129,22 @@ public final class ImmutableOpenMap<KType, VType> extends AbstractMap<KType, VTy
         return (es = entrySet) == null ? (entrySet = new EntrySet<>(map)) : es;
     }
 
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o instanceof ImmutableOpenMap<?, ?> immutableOpenMap) {
+            return map.equals(immutableOpenMap.map);
+        }
+        return super.equals(o);
+    }
+
+    @Override
+    public int hashCode() {
+        return map.hashCode();
+    }
+
     private static final class ConversionIterator<KType, VType> implements Iterator<Map.Entry<KType, VType>> {
 
         private final Iterator<ObjectObjectCursor<KType, VType>> original;

--- a/server/src/main/java/org/elasticsearch/common/collect/ImmutableOpenMap.java
+++ b/server/src/main/java/org/elasticsearch/common/collect/ImmutableOpenMap.java
@@ -142,7 +142,8 @@ public final class ImmutableOpenMap<KType, VType> extends AbstractMap<KType, VTy
 
     @Override
     public int hashCode() {
-        return map.hashCode();
+        // noop override to make checkstyle happy since we override equals
+        return super.hashCode();
     }
 
     private static final class ConversionIterator<KType, VType> implements Iterator<Map.Entry<KType, VType>> {


### PR DESCRIPTION
This method is somewhat hot during CS diffing at times, we can speed it up a little by taking the pointless indirection of the conversion iterator out of things and saving the allocations from it.

relates #77466 