### PR TITLE
Synthetic _source: ignore_malformed in geo_point

### DIFF
--- a/libs/x-content/src/main/java/org/elasticsearch/xcontent/CopyingXContentParser.java
+++ b/libs/x-content/src/main/java/org/elasticsearch/xcontent/CopyingXContentParser.java
@@ -11,6 +11,10 @@ package org.elasticsearch.xcontent;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 
+/**
+ * Copies its values into a {@code byte[]} while reading them. Use
+ * with {@link XContentSubParser} to read the entire object.
+ */
 public class CopyingXContentParser extends FilterXContentParserWrapper {
     private final ByteArrayOutputStream out;
     private final XContentGenerator generator;

--- a/libs/x-content/src/main/java/org/elasticsearch/xcontent/CopyingXContentParser.java
+++ b/libs/x-content/src/main/java/org/elasticsearch/xcontent/CopyingXContentParser.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.xcontent;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+
+public class CopyingXContentParser extends FilterXContentParserWrapper {
+    private final ByteArrayOutputStream out;
+    private final XContentGenerator generator;
+
+    public CopyingXContentParser(XContentParser delegate) throws IOException {
+        super(delegate);
+        out = new ByteArrayOutputStream();
+        generator = delegate.contentType().xContent().createGenerator(out);
+        switch (delegate.currentToken()) {
+            case START_OBJECT -> generator.writeStartObject();
+            case START_ARRAY -> generator.writeStartArray();
+            default -> throw new IllegalArgumentException(
+                "can only copy parsers pointed to START_OBJECT or START_ARRAY but found: " + delegate.currentToken()
+            );
+        }
+    }
+
+    @Override
+    public Token nextToken() throws IOException {
+        Token next = delegate().nextToken();
+        generator.copyCurrentEvent(delegate());
+        return next;
+    }
+
+    @Override
+    public void skipChildren() throws IOException {
+        super.skipChildren();
+    }
+
+    public byte[] bytes() throws IOException {
+        generator.close();
+        return out.toByteArray();
+    }
+}

--- a/libs/x-content/src/main/java/org/elasticsearch/xcontent/CopyingXContentParser.java
+++ b/libs/x-content/src/main/java/org/elasticsearch/xcontent/CopyingXContentParser.java
@@ -39,11 +39,6 @@ public class CopyingXContentParser extends FilterXContentParserWrapper {
         return next;
     }
 
-    @Override
-    public void skipChildren() throws IOException {
-        super.skipChildren();
-    }
-
     public byte[] bytes() throws IOException {
         generator.close();
         return out.toByteArray();

--- a/modules/legacy-geo/src/main/java/org/elasticsearch/legacygeo/mapper/LegacyGeoShapeFieldMapper.java
+++ b/modules/legacy-geo/src/main/java/org/elasticsearch/legacygeo/mapper/LegacyGeoShapeFieldMapper.java
@@ -18,6 +18,7 @@ import org.apache.lucene.spatial.prefix.tree.QuadPrefixTree;
 import org.apache.lucene.spatial.prefix.tree.SpatialPrefixTree;
 import org.elasticsearch.ElasticsearchParseException;
 import org.elasticsearch.Version;
+import org.elasticsearch.common.CheckedBiConsumer;
 import org.elasticsearch.common.Explicit;
 import org.elasticsearch.common.geo.GeoUtils;
 import org.elasticsearch.common.geo.GeometryFormatterFactory;
@@ -57,7 +58,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
-import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
@@ -393,18 +393,19 @@ public class LegacyGeoShapeFieldMapper extends AbstractShapeGeometryFieldMapper<
         public void parse(
             XContentParser parser,
             CheckedConsumer<ShapeBuilder<?, ?, ?>, IOException> consumer,
-            Consumer<Exception> onMalformed
+            CheckedBiConsumer<XContentParser, Exception, IOException> onMalformed,
+            boolean saveSyntheticSourceForMalformed
         ) throws IOException {
             try {
                 if (parser.currentToken() == XContentParser.Token.START_ARRAY) {
                     while (parser.nextToken() != XContentParser.Token.END_ARRAY) {
-                        parse(parser, consumer, onMalformed);
+                        parse(parser, consumer, onMalformed, saveSyntheticSourceForMalformed);
                     }
                 } else {
                     consumer.accept(ShapeParser.parse(parser));
                 }
             } catch (ElasticsearchParseException e) {
-                onMalformed.accept(e);
+                onMalformed.accept(parser, e);
             }
         }
 

--- a/server/src/main/java/org/elasticsearch/index/mapper/GeoPointFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/GeoPointFieldMapper.java
@@ -152,7 +152,7 @@ public class GeoPointFieldMapper extends AbstractPointGeometryFieldMapper<GeoPoi
         public FieldMapper build(MapperBuilderContext context) {
             Parser<GeoPoint> geoParser = new GeoPointParser(
                 name,
-                (parser) -> GeoUtils.parseGeoPoint(parser, ignoreZValue.get().value()),
+                parser -> GeoUtils.parseGeoPoint(parser, ignoreZValue.get().value()),
                 nullValue.get(),
                 ignoreZValue.get().value(),
                 ignoreMalformed.get().value()
@@ -430,6 +430,13 @@ public class GeoPointFieldMapper extends AbstractPointGeometryFieldMapper<GeoPoi
         }
     }
 
+    @Override
+    protected void onIgnoredMalformedValue(DocumentParserContext context, XContentParser parser) throws IOException {
+        if (context.isSyntheticSource()) {
+            context.doc().add(IgnoreMalformedStoredValues.storedField(name(), parser));
+        }
+    }
+
     /** GeoPoint parser implementation */
     private static class GeoPointParser extends PointParser<GeoPoint> {
 
@@ -485,11 +492,6 @@ public class GeoPointFieldMapper extends AbstractPointGeometryFieldMapper<GeoPoi
         if (fieldType().hasDocValues() == false) {
             throw new IllegalArgumentException(
                 "field [" + name() + "] of type [" + typeName() + "] doesn't support synthetic source because it doesn't have doc values"
-            );
-        }
-        if (ignoreMalformed()) {
-            throw new IllegalArgumentException(
-                "field [" + name() + "] of type [" + typeName() + "] doesn't support synthetic source because it ignores malformed points"
             );
         }
         if (copyTo.copyToFields().isEmpty() != true) {


### PR DESCRIPTION
This adds support for `geo_point` fields configured with `ignore_malformed` for synthetic `_source`. `geo_point` fields are the first that support object or array valued malformed fields. To support *that* we copy complex fields while we read them.
