### PR TITLE
[8.5] [Doc] Document DLS limitation for aggregation (#90701)

### DIFF
--- a/x-pack/docs/en/security/limitations.asciidoc
+++ b/x-pack/docs/en/security/limitations.asciidoc
@@ -79,8 +79,14 @@ including the following queries:
 ** `percolate` query
 * If suggesters are specified and document level security is enabled, the specified suggesters are ignored.
 * A search request cannot be profiled if document level security is enabled.
-* The <<search-terms-enum,terms enum API>> does not return terms if document 
+* The <<search-terms-enum,terms enum API>> does not return terms if document
 level security is enabled.
+
+NOTE: While document-level security prevents users from viewing restricted documents,
+it's still possible to write search requests that return aggregate information about the
+entire index. A user whose access is restricted to specific documents in an index could
+still learn about field names and terms that only exist in inaccessible
+documents, and count how many inaccessible documents contain a given term. 
 
 [discrete]
 [[alias-limitations]]


### PR DESCRIPTION
Backports the following commits to 8.5:
 - [Doc] Document DLS limitation for aggregation (#90701)