### PR TITLE
[8.4] [Doc] Correctly cite setup-passwords CLI for minimal security guide (#90579)

### DIFF
--- a/x-pack/docs/en/security/securing-communications/security-basic-setup-https.asciidoc
+++ b/x-pack/docs/en/security/securing-communications/security-basic-setup-https.asciidoc
@@ -274,17 +274,18 @@ example, `https://<your_kibana_host>.com`.
 
 [[configure-beats-security]]
 ==== Configure {beats} security
-
-The {beats} are open source data shippers that you install as agents on your
+{beats} are open source data shippers that you install as agents on your
 servers to send operational data to {es}. Each Beat is a separately
 installable product. The following steps cover configuring security for
-{metricbeat}. Follow these steps for each https://www.elastic.co/guide/en/elastic-stack-get-started/7.9/get-started-elastic-stack.html#install-beats[additonal Beat] you want to configure security for.
+{metricbeat}. Follow these steps for each 
+{beats-ref}/getting-started.html[additional Beat] you want to configure security
+for.
 
 ===== Prerequisites
 
-https://www.elastic.co/guide/en/beats/metricbeat/7.9/metricbeat-installation-configuration.html[Install {metricbeat}] using your preferred method.
+{metricbeat-ref}/metricbeat-installation-configuration.html[Install {metricbeat}] using your preferred method.
 
-NOTE: You cannot connect to the Elastic Stack or set up assets for {metricbeat}
+IMPORTANT: You cannot connect to the {stack} or configure assets for {metricbeat}
 before completing the following steps.
 
 ===== Create roles for {metricbeat}
@@ -292,8 +293,8 @@ Typically, you need to create the following separate roles:
 
 - **setup** role for setting up index templates and other dependencies
 - **monitoring** role for sending monitoring information
-- **writer** role for publishing events collected by Metricbeat
-- **reader** role for Kibana users who need to view and create visualizations that access Metricbeat data
+- **writer** role for publishing events collected by {metricbeat}
+- **reader** role for Kibana users who need to view and create visualizations that access {metricbeat} data
 
 NOTE: These instructions assume that you are using the default name for
 {metricbeat} indices. If the indicated index names are not listed, or you are
@@ -317,25 +318,25 @@ WARNING: Setting up {metricbeat} is an admin-level task that requires extra
 privileges. As a best practice, grant the setup role to administrators only,
 and use a more restrictive role for event publishing.
 
-1. Create the setup role:
+. Create the setup role:
 
-   a. Enter **metricbeat_setup** as the role name.
+   . Enter **metricbeat_setup** as the role name.
 
-   b. Choose the **monitor** and **manage_ilm** cluster privileges.
+   . Choose the **monitor** and **manage_ilm** cluster privileges.
 
-   c. On the **metricbeat-\*** indices, choose the **manage** and **write**
+   . On the **metricbeat-\*** indices, choose the **manage** and **write**
    privileges.
 +
 If the **metricbeat-\*** indices aren't listed, enter that pattern into the
 list of indices.
 
-2. Create the setup user:
+. Create the setup user:
 
-   a. Enter **metricbeat_setup** as the user name.
+   . Enter **metricbeat_setup** as the user name.
 
-   b. Enter the username, password, and other user details.
+   . Enter the username, password, and other user details.
 
-   c. Assign the following roles to the **metricbeat_setup** user:
+   . Assign the following roles to the **metricbeat_setup** user:
 +
 [cols="1,1"]
 |===
@@ -356,26 +357,46 @@ To send monitoring data securely, create a monitoring user and grant it the
 necessary privileges.
 
 You can use the built-in `beats_system` user, if it’s available in your
-environment. Because the built-in users are not available in Elastic Cloud,
+environment. Because the built-in users are not available in {ecloud},
 these instructions create a user that is explicitly used for monitoring
 {metricbeat}.
 
-1. Create the monitoring role:
+. If you're using the built-in `beats_system` user, on any node in your cluster,
+run the <<reset-password,`elasticsearch-reset-password`>> utility to set the
+password for that user:
++
+This command resets the password for the `beats_system` user to an 
+auto-generated value.
++
+[source,shell]
+----
+./bin/elasticsearch-reset-password -u beats_system
+----
++
+If you want to set the password to a specific value, run the command with the 
+interactive (`-i`) parameter.
++
+[source,shell]
+----
+./bin/elasticsearch-reset-password -i -u beats_system
+----
 
-   a. Enter **metricbeat_monitoring** as the role name.
+. Create the monitoring role:
 
-   b. Choose the **monitor** cluster privilege.
+   . Enter **metricbeat_monitoring** as the role name.
 
-   c. On the **.monitoring-beats-\*** indices, choose the **create_index** and
+   . Choose the **monitor** cluster privilege.
+
+   . On the **.monitoring-beats-\*** indices, choose the **create_index** and
    **create_doc** privileges.
 
-2. Create the monitoring user:
+. Create the monitoring user:
 
-   a. Enter **metricbeat_monitoring** as the user name.
+   . Enter **metricbeat_monitoring** as the user name.
 
-   b. Enter the username, password, and other user details.
+   . Enter the username, password, and other user details.
 
-   c. Assign the following roles to the **metricbeat_monitoring** user:
+   . Assign the following roles to the **metricbeat_monitoring** user:
 +
 [cols="1,1"]
 |===
@@ -395,21 +416,21 @@ these instructions create a user that is explicitly used for monitoring
 Users who publish events to {es} need to create and write to {metricbeat} indices. To minimize the privileges required by the writer role, use the setup role to pre-load dependencies. This section assumes that you’ve
 <<beats-setup-role,created the setup role>>.
 
-1. Create the writer role:
+. Create the writer role:
 
-   a. Enter **metricbeat_writer** as the role name.
+   . Enter **metricbeat_writer** as the role name.
 
-   b. Choose the **monitor** and **read_ilm** cluster privileges.
+   . Choose the **monitor** and **read_ilm** cluster privileges.
 
-   c. On the **metricbeat-\*** indices, choose the **create_doc**, **create_index**, and **view_index_metadata** privileges.
+   . On the **metricbeat-\*** indices, choose the **create_doc**, **create_index**, and **view_index_metadata** privileges.
 
-2. Create the writer user:
+. Create the writer user:
 
-   a. Enter **metricbeat_writer** as the user name.
+   . Enter **metricbeat_writer** as the user name.
 
-   b. Enter the username, password, and other user details.
+   . Enter the username, password, and other user details.
 
-   c. Assign the following roles to the **metricbeat_writer** user:
+   . Assign the following roles to the **metricbeat_writer** user:
 +
 [cols="1,1"]
 |===
@@ -431,25 +452,25 @@ Users who publish events to {es} need to create and write to {metricbeat} indice
 and visualizations. Create the reader role to assign proper privileges to these
 users.
 
-1. Create the reader role:
+. Create the reader role:
 
-   a. Enter **metricbeat_reader** as the role name.
+   . Enter **metricbeat_reader** as the role name.
 
-   b. On the **metricbeat-\*** indices, choose the **read** privilege.
+   . On the **metricbeat-\*** indices, choose the **read** privilege.
 
-   c. Under **Kibana**, click **Add Kibana privilege**.
+   . Under **Kibana**, click **Add Kibana privilege**.
 
    - Under **Spaces**, choose **Default**.
 
    - Choose **Read** or **All** for Discover, Visualize, Dashboard, and Metrics.
 
-2. Create the reader user:
+. Create the reader user:
 
-   a. Enter **metricbeat_reader** as the user name.
+   . Enter **metricbeat_reader** as the user name.
 
-   b. Enter the username, password, and other user details.
+   . Enter the username, password, and other user details.
 
-   c. Assign the following roles to the **metricbeat_reader** user:
+   . Assign the following roles to the **metricbeat_reader** user:
 +
 [cols="1,1"]
 |===
@@ -593,7 +614,7 @@ See {metricbeat-ref}/configuration-ssl.html[Configure SSL for {metricbeat}].
 ./metricbeat setup -e
 ----
 
-. Start {es}, and then start Metricbeat.
+. Start {es}, and then start {metricbeat}.
 +
 [source,shell]
 ----
@@ -603,6 +624,6 @@ See {metricbeat-ref}/configuration-ssl.html[Configure SSL for {metricbeat}].
 `-e` is optional and sends output to standard error instead of the configured
 log output.
 
-. Log in to Kibana, open the main menu, and click **Stack Monitoring**.
+. Log in to {kib}, open the main menu, and click **Stack Monitoring**.
 +
 You’ll see cluster alerts that require your attention and a summary of the available monitoring metrics for {es}. Click any of the header links on the available cards to view additional information.

--- a/x-pack/docs/en/security/securing-communications/security-minimal-setup.asciidoc
+++ b/x-pack/docs/en/security/securing-communications/security-minimal-setup.asciidoc
@@ -4,16 +4,16 @@
 <titleabbrev>Set up minimal security</titleabbrev>
 ++++
 
-IMPORTANT: You only need to complete the following steps if you're running an 
+IMPORTANT: You only need to complete the following steps if you're running an
 existing, unsecured cluster and want to enable the {es} {security-features}.
 
 In {es} 8.0 and later, security is
-<<configuring-stack-security,enabled automatically>> when you start {es} for the 
-first time. 
+<<configuring-stack-security,enabled automatically>> when you start {es} for the
+first time.
 
-If you're running an existing {es} cluster where security is disabled, you can 
-manually enable the {es} {security-features} and then create passwords for 
-built-in users. You can add more users later, but using the built-in users 
+If you're running an existing {es} cluster where security is disabled, you can
+manually enable the {es} {security-features} and then create passwords for
+built-in users. You can add more users later, but using the built-in users
 simplifies the process of enabling security for your cluster.
 
 include::../security-manual-configuration.asciidoc[tag=minimal-security-note]
@@ -51,14 +51,15 @@ discovery.type: single-node
 [[security-create-builtin-users]]
 ==== Set passwords for built-in users
 
-To communicate with the cluster, you must configure a username for the built-in
-users. Unless you enable anonymous access, all requests that don’t include a
-username and password are rejected.
+To communicate with your cluster, you must configure a password for
+the `elastic` and `kibana_system` built-in users. Unless you enable anonymous
+access (not recommended), all requests that don’t include credentials are
+rejected.
 
 NOTE: You only need to set passwords for the `elastic` and `kibana_system` users
 when enabling minimal or basic security.
 
-. On *every* node in your cluster, start {es}. For example, if you installed 
+. On *every* node in your cluster, start {es}. For example, if you installed
 {es} with a `.tar.gz` package, run the following command from the `ES_HOME`
 directory:
 +
@@ -67,33 +68,33 @@ directory:
 ./bin/elasticsearch
 ----
 
-. In another terminal window, set the passwords for the built-in users by
-running the <<reset-password,`elasticsearch-reset-password`>> utility.
-+
-IMPORTANT: You can run the `elasticsearch-reset-password` utility
-against any node in your cluster. However, you should only run this utility *one
-time* for the entire cluster.
-+
-Using the `auto` parameter
-outputs randomly-generated passwords to the console that you can change later
-if necessary:
+. On any node in your cluster, open another terminal window and set the password
+for the `elastic` built-in user by running the
+<<reset-password,`elasticsearch-reset-password`>> utility.
+This command resets the password to an auto-generated value.
 +
 [source,shell]
 ----
-./bin/elasticsearch-reset-password auto
+./bin/elasticsearch-reset-password -u elastic
 ----
 +
-If you want to use your own passwords, run the command with the
-`interactive` parameter instead of the `auto` parameter. Using this mode
-steps you through password configuration for all of the built-in users.
+If you want to set the password to a specific value, run the command with the 
+interactive (`-i`) parameter.
 +
 [source,shell]
 ----
-./bin/elasticsearch-reset-password interactive
+./bin/elasticsearch-reset-password -i -u elastic
 ----
 
-. Save the generated passwords. You'll need them to add the built-in user to
-{kib}.
+. Set the password for the `kibana_system` built-in user.
++
+[source,shell]
+----
+./bin/elasticsearch-reset-password -u kibana_system
+----
+
+. Save the new passwords. In the next step, you'll add the the password for the
+`kibana_system` user to {kib}.
 
 *Next*: <<add-built-in-users,Configure {kib} to connect to {es} with a password>>
 
@@ -108,7 +109,7 @@ you created earlier. {kib} performs some background tasks that require use of th
 `kibana_system` user.
 
 This account is not meant for individual users and does not have permission to log in
-to {kib} from a browser. Instead, you'll log in to {kib} as the `elastic` superuser. 
+to {kib} from a browser. Instead, you'll log in to {kib} as the `elastic` superuser.
 
 . Add the `elasticsearch.username` setting to the `KIB_PATH_CONF/kibana.yml`
 file and set the value to the `kibana_system` user:
@@ -149,7 +150,7 @@ When prompted, enter the password for the `kibana_system` user.
 ./bin/kibana
 ----
 
-. Log in to {kib} as the `elastic` user. Use this superuser account to 
+. Log in to {kib} as the `elastic` user. Use this superuser account to
 {kibana-ref}/tutorial-secure-access-to-kibana.html[manage spaces, create new users, and assign roles]. If you're running {kib} locally, go to `http://localhost:5601` to view the login page.
 
 [[minimal-security-whatsnext]]


### PR DESCRIPTION
Backports the following commits to 8.4:
 - [Doc] Correctly cite setup-passwords CLI for minimal security guide (#90579)