### PR TITLE
Add YAML setting `transport.min_accepted_version`

### DIFF
--- a/docs/changelog/90782.yaml
+++ b/docs/changelog/90782.yaml
@@ -1,0 +1,5 @@
+pr: 90782
+summary: Add YAML setting `transport.min_accepted_version`
+area: Cluster Coordination
+type: enhancement
+issues: []

--- a/docs/reference/modules/transport.asciidoc
+++ b/docs/reference/modules/transport.asciidoc
@@ -122,6 +122,15 @@ to `-1` meaning that application-level pings are not sent. You should use TCP
 keepalives (see `transport.tcp.keep_alive`) instead of application-level pings
 wherever possible.
 
+`transport.min_accepted_version`::
+(<<static-cluster-setting,Static>>, integer)
+Configures the minimum version id to accept during handshake.
+(e.g. 8_05_00_99, 8000000)
+If set, this overrides the minimum compatibility version.
+If not set, it defaults to the minimum compatibility version.
+Only values between the minimum compatibility version
+and current version, inclusive, can be set.
+
 [[transport-profiles]]
 ===== Transport profiles
 

--- a/server/src/main/java/org/elasticsearch/common/settings/Setting.java
+++ b/server/src/main/java/org/elasticsearch/common/settings/Setting.java
@@ -1249,6 +1249,15 @@ public class Setting<T> implements ToXContentObject {
 
     public static Setting<Version> versionSetting(
         final String key,
+        Version defaultValue,
+        Validator<Version> validator,
+        Property... properties
+    ) {
+        return new Setting<>(key, Integer.toString(defaultValue.id), s -> Version.fromId(Integer.parseInt(s)), validator, properties);
+    }
+
+    public static Setting<Version> versionSetting(
+        final String key,
         Setting<Version> fallbackSetting,
         Validator<Version> validator,
         Property... properties

--- a/server/src/main/java/org/elasticsearch/common/settings/Setting.java
+++ b/server/src/main/java/org/elasticsearch/common/settings/Setting.java
@@ -1244,7 +1244,7 @@ public class Setting<T> implements ToXContentObject {
     }
 
     public static Setting<Version> versionSetting(final String key, final Version defaultValue, Property... properties) {
-        return new Setting<>(key, Integer.toString(defaultValue.id), s -> Version.fromId(Integer.parseInt(s)), properties);
+        return versionSetting(key, defaultValue, v -> {}, properties);
     }
 
     public static Setting<Version> versionSetting(
@@ -1253,7 +1253,17 @@ public class Setting<T> implements ToXContentObject {
         Validator<Version> validator,
         Property... properties
     ) {
-        return new Setting<>(key, Integer.toString(defaultValue.id), s -> Version.fromId(Integer.parseInt(s)), validator, properties);
+        return versionSetting(key, defaultValue, s -> Version.fromId(Integer.parseInt(s)), validator, properties);
+    }
+
+    public static Setting<Version> versionSetting(
+        final String key,
+        Version defaultValue,
+        Function<String, Version> parser,
+        Validator<Version> validator,
+        Property... properties
+    ) {
+        return new Setting<>(key, Integer.toString(defaultValue.id), parser, validator, properties);
     }
 
     public static Setting<Version> versionSetting(

--- a/server/src/main/java/org/elasticsearch/transport/TcpTransport.java
+++ b/server/src/main/java/org/elasticsearch/transport/TcpTransport.java
@@ -186,6 +186,7 @@ public abstract class TcpTransport extends AbstractLifecycleComponent implements
 
         this.handshaker = new TransportHandshaker(
             version,
+            TransportSettings.MIN_ACCEPTED_VERSION.get(settings),
             threadPool,
             (node, channel, requestId, v) -> outboundHandler.sendRequest(
                 node,

--- a/server/src/main/java/org/elasticsearch/transport/TransportHandshaker.java
+++ b/server/src/main/java/org/elasticsearch/transport/TransportHandshaker.java
@@ -87,10 +87,9 @@ final class TransportHandshaker {
     }
 
     void handleHandshake(TransportChannel channel, long requestId, StreamInput stream) throws IOException {
-        final HandshakeRequest request;
         try {
             // Must read the handshake request to exhaust the stream
-            request = new HandshakeRequest(stream);
+            new HandshakeRequest(stream);
         } catch (Exception e) {
             assert ignoreDeserializationErrors : e;
             throw e;
@@ -109,19 +108,7 @@ final class TransportHandshaker {
             assert ignoreDeserializationErrors : exception;
             throw exception;
         }
-        if ((request.version != null) && (request.version.compareTo(this.minAcceptedVersion) < 0)) {
-            channel.sendResponse(
-                new IllegalStateException(
-                    "remote node request version ["
-                        + request.version
-                        + "] is not allowed with local node minimum accepted version ["
-                        + this.minAcceptedVersion
-                        + "]"
-                )
-            );
-        } else {
-            channel.sendResponse(new HandshakeResponse(this.version));
-        }
+        channel.sendResponse(new HandshakeResponse(this.version));
     }
 
     TransportResponseHandler<HandshakeResponse> removeHandlerForHandshake(long requestId) {

--- a/server/src/main/java/org/elasticsearch/transport/TransportHandshaker.java
+++ b/server/src/main/java/org/elasticsearch/transport/TransportHandshaker.java
@@ -109,10 +109,7 @@ final class TransportHandshaker {
             assert ignoreDeserializationErrors : exception;
             throw exception;
         }
-        if ((request.version != null)
-            && (this.minAcceptedVersion != null)
-            && (Version.V_EMPTY.equals(this.minAcceptedVersion) == false)
-            && (request.version.compareTo(this.minAcceptedVersion) < 0)) {
+        if ((request.version != null) && (request.version.compareTo(this.minAcceptedVersion) < 0)) {
             channel.sendResponse(
                 new IllegalStateException(
                     "remote node request version ["

--- a/server/src/main/java/org/elasticsearch/transport/TransportService.java
+++ b/server/src/main/java/org/elasticsearch/transport/TransportService.java
@@ -558,22 +558,21 @@ public class TransportService extends AbstractLifecycleComponent
                                 + "]"
                         )
                     );
-                } else if ((Version.V_EMPTY.equals(this.minAcceptedVersion) == false)
-                    && (response.version.compareTo(this.minAcceptedVersion) < 0)) {
-                        l.onFailure(
-                            new IllegalStateException(
-                                "handshake with ["
-                                    + node
-                                    + "] failed: remote node response version ["
-                                    + response.version
-                                    + "] is not accepted due to local node minimum accepted version ["
-                                    + this.minAcceptedVersion
-                                    + "]"
-                            )
-                        );
-                    } else {
-                        l.onResponse(response);
-                    }
+                } else if (response.version.compareTo(this.minAcceptedVersion) < 0) {
+                    l.onFailure(
+                        new IllegalStateException(
+                            "handshake with ["
+                                + node
+                                + "] failed: remote node response version ["
+                                + response.version
+                                + "] is not accepted due to local node minimum accepted version ["
+                                + this.minAcceptedVersion
+                                + "]"
+                        )
+                    );
+                } else {
+                    l.onResponse(response);
+                }
             }), HandshakeResponse::new, ThreadPool.Names.GENERIC)
         );
     }

--- a/server/src/main/java/org/elasticsearch/transport/TransportService.java
+++ b/server/src/main/java/org/elasticsearch/transport/TransportService.java
@@ -288,9 +288,7 @@ public class TransportService extends AbstractLifecycleComponent
                         )
                     );
                 } else {
-                    channel.sendResponse(
-                        new HandshakeResponse(localNode.getVersion(), Build.CURRENT.hash(), localNode, clusterName)
-                    );
+                    channel.sendResponse(new HandshakeResponse(localNode.getVersion(), Build.CURRENT.hash(), localNode, clusterName));
                 }
             }
         );
@@ -609,7 +607,9 @@ public class TransportService extends AbstractLifecycleComponent
             this.version = in.getVersion();
         }
 
-        private HandshakeRequest() {this.version = Version.CURRENT;}
+        private HandshakeRequest() {
+            this.version = Version.CURRENT;
+        }
 
     }
 

--- a/server/src/main/java/org/elasticsearch/transport/TransportSettings.java
+++ b/server/src/main/java/org/elasticsearch/transport/TransportSettings.java
@@ -7,6 +7,7 @@
  */
 package org.elasticsearch.transport;
 
+import org.elasticsearch.Version;
 import org.elasticsearch.common.network.NetworkService;
 import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Settings;
@@ -248,6 +249,14 @@ public final class TransportSettings {
     );
     // only used in tests: RST connections when closing to avoid actively closing sockets to end up in time_wait in tests
     public static final Setting<Boolean> RST_ON_CLOSE = boolSetting("transport.rst_on_close", false, Setting.Property.NodeScope);
+
+    // Minimum accepted version during handshake.
+    // Example: Even though 8.6.0 is compatible with 7.17.0 and 8.7.0, either side of handshake may only want to accept 8.5.0 or higher.
+    public static final Setting<Version> MIN_ACCEPTED_VERSION = Setting.versionSetting(
+        "transport.min_accepted_version",
+        Version.V_EMPTY,
+        Setting.Property.NodeScope
+    );
 
     private TransportSettings() {}
 }

--- a/server/src/test/java/org/elasticsearch/VersionTests.java
+++ b/server/src/test/java/org/elasticsearch/VersionTests.java
@@ -354,23 +354,27 @@ public class VersionTests extends ESTestCase {
 
     public void testMinAcceptedVersionSetting() {
         // default (if not set)
-        assertThat(TransportSettings.MIN_ACCEPTED_VERSION.getDefault(Settings.EMPTY),
-            is(equalTo(Version.CURRENT.minimumCompatibilityVersion())));
+        assertThat(
+            TransportSettings.MIN_ACCEPTED_VERSION.getDefault(Settings.EMPTY),
+            is(equalTo(Version.CURRENT.minimumCompatibilityVersion()))
+        );
 
         // too old
         final Version tooOld = Version.fromId(Version.CURRENT.minimumCompatibilityVersion().id - 1);
-        IllegalArgumentException tooOldException = expectThrows(IllegalArgumentException.class, () -> {
-            TransportSettings.MIN_ACCEPTED_VERSION.get(Settings.builder().put("transport.min_accepted_version", tooOld.id).build());
-        });
-        assertThat(
-            tooOldException.getMessage(),
-            equalTo("Invalid version [" + tooOld + "] too low for [transport.min_accepted_version].")
+        IllegalArgumentException tooOldException = expectThrows(
+            IllegalArgumentException.class,
+            () -> {
+                TransportSettings.MIN_ACCEPTED_VERSION.get(Settings.builder().put("transport.min_accepted_version", tooOld.id).build());
+            }
         );
+        assertThat(tooOldException.getMessage(), equalTo("Invalid version [" + tooOld + "] too low for [transport.min_accepted_version]."));
 
         // oldest accepted
         final Version oldestAccepted = Version.CURRENT.minimumCompatibilityVersion();
-        assertThat(TransportSettings.MIN_ACCEPTED_VERSION.get(Settings.builder().put("transport.min_accepted_version",
-            oldestAccepted.id).build()), is(equalTo(oldestAccepted)));
+        assertThat(
+            TransportSettings.MIN_ACCEPTED_VERSION.get(Settings.builder().put("transport.min_accepted_version", oldestAccepted.id).build()),
+            is(equalTo(oldestAccepted))
+        );
 
         // random accepted
         final Version randomAccepted = VersionUtils.randomVersionBetween(
@@ -378,19 +382,26 @@ public class VersionTests extends ESTestCase {
             Version.CURRENT.minimumCompatibilityVersion(),
             Version.CURRENT
         );
-        assertThat(TransportSettings.MIN_ACCEPTED_VERSION.get(Settings.builder().put("transport.min_accepted_version",
-            randomAccepted.id).build()), is(equalTo(randomAccepted)));
+        assertThat(
+            TransportSettings.MIN_ACCEPTED_VERSION.get(Settings.builder().put("transport.min_accepted_version", randomAccepted.id).build()),
+            is(equalTo(randomAccepted))
+        );
 
         // newest accepted
         final Version newestAccepted = Version.CURRENT;
-        assertThat(TransportSettings.MIN_ACCEPTED_VERSION.get(Settings.builder().put("transport.min_accepted_version",
-            newestAccepted.id).build()), is(equalTo(newestAccepted)));
+        assertThat(
+            TransportSettings.MIN_ACCEPTED_VERSION.get(Settings.builder().put("transport.min_accepted_version", newestAccepted.id).build()),
+            is(equalTo(newestAccepted))
+        );
 
         // too new
         final Version tooNew = Version.fromId(Version.CURRENT.id + 1);
-        IllegalArgumentException tooNewException = expectThrows(IllegalArgumentException.class, () -> {
-            TransportSettings.MIN_ACCEPTED_VERSION.get(Settings.builder().put("transport.min_accepted_version", tooNew.id).build());
-        });
+        IllegalArgumentException tooNewException = expectThrows(
+            IllegalArgumentException.class,
+            () -> {
+                TransportSettings.MIN_ACCEPTED_VERSION.get(Settings.builder().put("transport.min_accepted_version", tooNew.id).build());
+            }
+        );
         assertThat(
             tooNewException.getMessage(),
             equalTo("Invalid version [" + tooNew + "] too high for [transport.min_accepted_version].")

--- a/server/src/test/java/org/elasticsearch/VersionTests.java
+++ b/server/src/test/java/org/elasticsearch/VersionTests.java
@@ -359,15 +359,12 @@ public class VersionTests extends ESTestCase {
             is(equalTo(Version.CURRENT.minimumCompatibilityVersion()))
         );
 
-        // too old
+        // too old (rounded up to minCompatibilityVersion)
         final Version tooOld = Version.fromId(Version.CURRENT.minimumCompatibilityVersion().id - 1);
-        IllegalArgumentException tooOldException = expectThrows(
-            IllegalArgumentException.class,
-            () -> {
-                TransportSettings.MIN_ACCEPTED_VERSION.get(Settings.builder().put("transport.min_accepted_version", tooOld.id).build());
-            }
+        assertThat(
+            TransportSettings.MIN_ACCEPTED_VERSION.get(Settings.builder().put("transport.min_accepted_version", tooOld.id).build()),
+            is(equalTo(Version.CURRENT.minimumCompatibilityVersion()))
         );
-        assertThat(tooOldException.getMessage(), equalTo("Invalid version [" + tooOld + "] too low for [transport.min_accepted_version]."));
 
         // oldest accepted
         final Version oldestAccepted = Version.CURRENT.minimumCompatibilityVersion();

--- a/server/src/test/java/org/elasticsearch/transport/InboundHandlerTests.java
+++ b/server/src/test/java/org/elasticsearch/transport/InboundHandlerTests.java
@@ -67,7 +67,7 @@ public class InboundHandlerTests extends ESTestCase {
         final boolean ignoreDeserializationErrors = true; // suppress assertions to test production error-handling
         TransportHandshaker handshaker = new TransportHandshaker(
             version,
-            Version.V_EMPTY,
+            TransportSettings.MIN_ACCEPTED_VERSION.getDefault(Settings.EMPTY),
             threadPool,
             (n, c, r, v) -> {},
             ignoreDeserializationErrors

--- a/server/src/test/java/org/elasticsearch/transport/InboundHandlerTests.java
+++ b/server/src/test/java/org/elasticsearch/transport/InboundHandlerTests.java
@@ -65,7 +65,13 @@ public class InboundHandlerTests extends ESTestCase {
         channel = new FakeTcpChannel(randomBoolean(), buildNewFakeTransportAddress().address(), buildNewFakeTransportAddress().address());
         NamedWriteableRegistry namedWriteableRegistry = new NamedWriteableRegistry(Collections.emptyList());
         final boolean ignoreDeserializationErrors = true; // suppress assertions to test production error-handling
-        TransportHandshaker handshaker = new TransportHandshaker(version, threadPool, (n, c, r, v) -> {}, ignoreDeserializationErrors);
+        TransportHandshaker handshaker = new TransportHandshaker(
+            version,
+            Version.V_EMPTY,
+            threadPool,
+            (n, c, r, v) -> {},
+            ignoreDeserializationErrors
+        );
         TransportKeepAlive keepAlive = new TransportKeepAlive(threadPool, TcpChannel::sendMessage);
         OutboundHandler outboundHandler = new OutboundHandler(
             "node",

--- a/server/src/test/java/org/elasticsearch/transport/TransportHandshakerTests.java
+++ b/server/src/test/java/org/elasticsearch/transport/TransportHandshakerTests.java
@@ -52,7 +52,7 @@ public class TransportHandshakerTests extends ESTestCase {
             Version.CURRENT
         );
         threadPool = new TestThreadPool("thread-poll");
-        handshaker = new TransportHandshaker(Version.CURRENT, threadPool, requestSender, false);
+        handshaker = new TransportHandshaker(Version.CURRENT, Version.V_EMPTY, threadPool, requestSender, false);
     }
 
     @Override

--- a/server/src/test/java/org/elasticsearch/transport/TransportHandshakerTests.java
+++ b/server/src/test/java/org/elasticsearch/transport/TransportHandshakerTests.java
@@ -12,6 +12,7 @@ import org.elasticsearch.action.support.PlainActionFuture;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.tasks.TaskId;
 import org.elasticsearch.test.ESTestCase;
@@ -52,7 +53,13 @@ public class TransportHandshakerTests extends ESTestCase {
             Version.CURRENT
         );
         threadPool = new TestThreadPool("thread-poll");
-        handshaker = new TransportHandshaker(Version.CURRENT, Version.V_EMPTY, threadPool, requestSender, false);
+        handshaker = new TransportHandshaker(
+            Version.CURRENT,
+            TransportSettings.MIN_ACCEPTED_VERSION.getDefault(Settings.EMPTY),
+            threadPool,
+            requestSender,
+            false
+        );
     }
 
     @Override

--- a/server/src/test/java/org/elasticsearch/transport/TransportServiceHandshakeTests.java
+++ b/server/src/test/java/org/elasticsearch/transport/TransportServiceHandshakeTests.java
@@ -209,7 +209,7 @@ public class TransportServiceHandshakeTests extends ESTestCase {
         Settings settingsB = Settings.builder().put("cluster.name", "test").build();
         NetworkHandle handleA = startServices("TS_A", settingsA, versionA);
         NetworkHandle handleB = startServices("TS_B", settingsB, versionB);
-        DiscoveryNode discoveryNodeB = new DiscoveryNode("", handleB.discoveryNode.getAddress(), emptyMap(), emptySet(), versionA);
+        DiscoveryNode discoveryNodeB = new DiscoveryNode("", handleB.discoveryNode.getAddress(), emptyMap(), emptySet(), versionB);
         IllegalStateException exception = expectThrows(IllegalStateException.class, () -> {
             try (
                 Transport.Connection connectionA = AbstractSimpleTransportTestCase.openConnection(
@@ -244,7 +244,7 @@ public class TransportServiceHandshakeTests extends ESTestCase {
         Settings settingsB = Settings.builder().put("cluster.name", "test").put("transport.min_accepted_version", versionB).build();
         NetworkHandle handleA = startServices("TS_A", settingsA, versionA);
         NetworkHandle handleB = startServices("TS_B", settingsB, versionB);
-        DiscoveryNode discoveryNodeB = new DiscoveryNode("", handleB.discoveryNode.getAddress(), emptyMap(), emptySet(), versionA);
+        DiscoveryNode discoveryNodeB = new DiscoveryNode("", handleB.discoveryNode.getAddress(), emptyMap(), emptySet(), versionB);
 
         IllegalStateException illegalStateException = expectThrows(IllegalStateException.class, () -> {
             try (


### PR DESCRIPTION
The goal of this PR is to add an optional YAML setting `transport.min_accepted_version`. Even if two cluster versions are compatible, there may be desirable features that are only available in higher versions.

Example 1 (cluster1 v8.6.0 is **backwards compatible** with cluster2 v7.17.0):
- When cluster1 sends a handshake request to cluster2, cluster1 can check the response version against its optional `transport.min_accepted_version` setting to only accept v8.4.0 responses or higher.

Example 2 (cluster1 v7.17.0 is **forwards compatible** with cluster2 v8.6.0):
- When cluster1 sends a handshake request to cluster2, cluster2 can check the request version against its optional `transport.min_accepted_version` setting to only accept v8.4.0 requestes or higher.

In both examples, 7.17.0 is compatible, but the other cluster admin only wants to accept handshakes with higher versions, possibly to make use of enhancements or bug fixes available only in those higher versions.

Note: This PR replaces #89938.