### PR TITLE
[8.5] [ML] Detect ML nodes by AZ from consistent state during rebalance (#90770)

### DIFF
--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/autoscaling/NodeAvailabilityZoneMapper.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/autoscaling/NodeAvailabilityZoneMapper.java
@@ -10,6 +10,7 @@ package org.elasticsearch.xpack.ml.autoscaling;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.elasticsearch.cluster.ClusterChangedEvent;
+import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.ClusterStateListener;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.DiscoveryNodeRole;
@@ -47,7 +48,7 @@ public class NodeAvailabilityZoneMapper implements ClusterStateListener {
     public NodeAvailabilityZoneMapper(Settings settings, ClusterSettings clusterSettings, DiscoveryNodes discoveryNodes) {
         awarenessAttributes = AwarenessAllocationDecider.CLUSTER_ROUTING_ALLOCATION_AWARENESS_ATTRIBUTE_SETTING.get(settings);
         lastDiscoveryNodes = discoveryNodes;
-        buildNodesByAvailabilityZone();
+        updateNodesByAvailabilityZone();
         clusterSettings.addSettingsUpdateConsumer(
             AwarenessAllocationDecider.CLUSTER_ROUTING_ALLOCATION_AWARENESS_ATTRIBUTE_SETTING,
             this::setAwarenessAttributes
@@ -56,7 +57,7 @@ public class NodeAvailabilityZoneMapper implements ClusterStateListener {
 
     private synchronized void setAwarenessAttributes(List<String> awarenessAttributes) {
         this.awarenessAttributes = List.copyOf(awarenessAttributes);
-        buildNodesByAvailabilityZone();
+        updateNodesByAvailabilityZone();
     }
 
     public List<String> getAwarenessAttributes() {
@@ -107,30 +108,33 @@ public class NodeAvailabilityZoneMapper implements ClusterStateListener {
     public synchronized void clusterChanged(ClusterChangedEvent event) {
         if (lastDiscoveryNodes == null || event.nodesChanged()) {
             lastDiscoveryNodes = event.state().nodes();
-            buildNodesByAvailabilityZone();
+            updateNodesByAvailabilityZone();
         }
     }
 
-    private synchronized void buildNodesByAvailabilityZone() {
+    private synchronized void updateNodesByAvailabilityZone() {
         if (lastDiscoveryNodes == null) {
             allNodesByAvailabilityZone = Map.of();
             mlNodesByAvailabilityZone = allNodesByAvailabilityZone;
             return;
         }
+        NodesByAvailabilityZone nodesByAvailabilityZone = buildNodesByAvailabilityZone(lastDiscoveryNodes, awarenessAttributes);
+        this.allNodesByAvailabilityZone = nodesByAvailabilityZone.allNodes;
+        this.mlNodesByAvailabilityZone = nodesByAvailabilityZone.mlNodes;
+    }
 
-        Collection<DiscoveryNode> nodes = lastDiscoveryNodes.getNodes().values();
+    private static NodesByAvailabilityZone buildNodesByAvailabilityZone(DiscoveryNodes discoveryNodes, List<String> awarenessAttributes) {
+        Collection<DiscoveryNode> nodes = discoveryNodes.getNodes().values();
 
         if (awarenessAttributes.isEmpty()) {
-            allNodesByAvailabilityZone = Map.of(List.of(), nodes);
-            mlNodesByAvailabilityZone = Map.of(
-                List.of(),
-                nodes.stream().filter(n -> n.getRoles().contains(DiscoveryNodeRole.ML_ROLE)).toList()
+            return new NodesByAvailabilityZone(
+                Map.of(List.of(), nodes),
+                Map.of(List.of(), nodes.stream().filter(n -> n.getRoles().contains(DiscoveryNodeRole.ML_ROLE)).toList())
             );
-            return;
         }
 
-        Map<List<String>, Collection<DiscoveryNode>> updatedNodesByAvailabilityZone = new HashMap<>();
-        Map<List<String>, Collection<DiscoveryNode>> updatedMlNodesByAvailabilityZone = new HashMap<>();
+        Map<List<String>, Collection<DiscoveryNode>> allNodesByAvailabilityZone = new HashMap<>();
+        Map<List<String>, Collection<DiscoveryNode>> mlNodesByAvailabilityZone = new HashMap<>();
         for (DiscoveryNode node : nodes) {
             List<String> orderedNodeAttributeValues = awarenessAttributes.stream()
                 .map(a -> node.getAttributes().get(a))
@@ -145,9 +149,9 @@ public class NodeAvailabilityZoneMapper implements ClusterStateListener {
                 );
                 continue;
             }
-            updatedNodesByAvailabilityZone.computeIfAbsent(orderedNodeAttributeValues, k -> new ArrayList<>()).add(node);
+            allNodesByAvailabilityZone.computeIfAbsent(orderedNodeAttributeValues, k -> new ArrayList<>()).add(node);
             if (node.getRoles().contains(DiscoveryNodeRole.ML_ROLE)) {
-                updatedMlNodesByAvailabilityZone.compute(orderedNodeAttributeValues, (k, v) -> {
+                mlNodesByAvailabilityZone.compute(orderedNodeAttributeValues, (k, v) -> {
                     if (v == null) {
                         v = new ArrayList<>();
                     }
@@ -156,7 +160,27 @@ public class NodeAvailabilityZoneMapper implements ClusterStateListener {
                 });
             }
         }
-        allNodesByAvailabilityZone = Map.copyOf(updatedNodesByAvailabilityZone);
-        mlNodesByAvailabilityZone = Map.copyOf(updatedMlNodesByAvailabilityZone);
+        return new NodesByAvailabilityZone(Map.copyOf(allNodesByAvailabilityZone), Map.copyOf(mlNodesByAvailabilityZone));
     }
+
+    /**
+     * This is different to {@link #getMlNodesByAvailabilityZone()} in that the latter returns the ML nodes by availability zone
+     * of the latest cluster state, while this method does the same for a specific cluster state.
+     *
+     * @param clusterState The cluster state whose nodes will be used to detect ML nodes by availability zone.
+     * @return A map whose keys are lists of awareness attribute values in the same order as the configured awareness attribute
+     *         names, and whose values are collections of nodes that have that combination of attributes. If availability zones
+     *         are not configured then the map will contain one entry mapping an empty list to a collection of all nodes. If
+     *         it is too early in the lifecycle of the node to know the answer then an empty map will be returned. An empty
+     *         map will also be returned if there are no ML nodes in the cluster. (These two empty map return scenarios can be
+     *         distinguished by calling one of the other methods.)
+     */
+    public Map<List<String>, Collection<DiscoveryNode>> buildMlNodesByAvailabilityZone(ClusterState clusterState) {
+        return buildNodesByAvailabilityZone(clusterState.nodes(), awarenessAttributes).mlNodes;
+    }
+
+    private record NodesByAvailabilityZone(
+        Map<List<String>, Collection<DiscoveryNode>> allNodes,
+        Map<List<String>, Collection<DiscoveryNode>> mlNodes
+    ) {};
 }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/assignment/TrainedModelAssignmentClusterService.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/assignment/TrainedModelAssignmentClusterService.java
@@ -466,7 +466,7 @@ public class TrainedModelAssignmentClusterService implements ClusterStateListene
         TrainedModelAssignmentRebalancer rebalancer = new TrainedModelAssignmentRebalancer(
             TrainedModelAssignmentMetadata.fromState(currentState),
             nodeLoads,
-            nodeAvailabilityZoneMapper,
+            nodeAvailabilityZoneMapper.buildMlNodesByAvailabilityZone(currentState),
             modelToAdd
         );
         return rebalancer.rebalance();

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/assignment/TrainedModelAssignmentRebalancer.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/assignment/TrainedModelAssignmentRebalancer.java
@@ -19,7 +19,6 @@ import org.elasticsearch.xpack.core.ml.inference.assignment.RoutingInfo;
 import org.elasticsearch.xpack.core.ml.inference.assignment.RoutingState;
 import org.elasticsearch.xpack.core.ml.inference.assignment.TrainedModelAssignment;
 import org.elasticsearch.xpack.ml.MachineLearning;
-import org.elasticsearch.xpack.ml.autoscaling.NodeAvailabilityZoneMapper;
 import org.elasticsearch.xpack.ml.inference.assignment.planning.AssignmentPlan;
 import org.elasticsearch.xpack.ml.inference.assignment.planning.ZoneAwareAssignmentPlanner;
 import org.elasticsearch.xpack.ml.job.NodeLoad;
@@ -43,18 +42,18 @@ class TrainedModelAssignmentRebalancer {
 
     private final TrainedModelAssignmentMetadata currentMetadata;
     private final Map<DiscoveryNode, NodeLoad> nodeLoads;
-    private final NodeAvailabilityZoneMapper nodeAvailabilityZoneMapper;
+    private final Map<List<String>, Collection<DiscoveryNode>> mlNodesByZone;
     private final Optional<StartTrainedModelDeploymentAction.TaskParams> modelToAdd;
 
     TrainedModelAssignmentRebalancer(
         TrainedModelAssignmentMetadata currentMetadata,
         Map<DiscoveryNode, NodeLoad> nodeLoads,
-        NodeAvailabilityZoneMapper nodeAvailabilityZoneMapper,
+        Map<List<String>, Collection<DiscoveryNode>> mlNodesByZone,
         Optional<StartTrainedModelDeploymentAction.TaskParams> modelToAdd
     ) {
         this.currentMetadata = Objects.requireNonNull(currentMetadata);
         this.nodeLoads = Objects.requireNonNull(nodeLoads);
-        this.nodeAvailabilityZoneMapper = Objects.requireNonNull(nodeAvailabilityZoneMapper);
+        this.mlNodesByZone = Objects.requireNonNull(mlNodesByZone);
         this.modelToAdd = Objects.requireNonNull(modelToAdd);
     }
 
@@ -128,7 +127,6 @@ class TrainedModelAssignmentRebalancer {
     }
 
     private Map<List<String>, List<AssignmentPlan.Node>> createNodesByZoneMap() {
-        Map<List<String>, Collection<DiscoveryNode>> mlNodesByZone = nodeAvailabilityZoneMapper.getMlNodesByAvailabilityZone();
         return mlNodesByZone.entrySet().stream().collect(Collectors.toMap(e -> e.getKey(), e -> {
             Collection<DiscoveryNode> discoveryNodes = e.getValue();
             List<AssignmentPlan.Node> nodes = new ArrayList<>();


### PR DESCRIPTION
Backports the following commits to 8.5:
 - [ML] Detect ML nodes by AZ from consistent state during rebalance (#90770)