### PR TITLE
Use new base testcase for chunked xcontenttypes in examples

### DIFF
--- a/plugins/examples/custom-significance-heuristic/src/test/java/org/elasticsearch/example/customsigheuristic/SimpleHeuristicWireTests.java
+++ b/plugins/examples/custom-significance-heuristic/src/test/java/org/elasticsearch/example/customsigheuristic/SimpleHeuristicWireTests.java
@@ -11,13 +11,13 @@ package org.elasticsearch.example.customsigheuristic;
 import org.elasticsearch.common.io.stream.Writeable.Reader;
 import org.elasticsearch.xcontent.XContentParser;
 import org.elasticsearch.xcontent.XContentParser.Token;
-import org.elasticsearch.test.AbstractSerializingTestCase;
+import org.elasticsearch.test.AbstractXContentSerializingTestCase;
 
 import java.io.IOException;
 
 import static org.hamcrest.Matchers.equalTo;
 
-public class SimpleHeuristicWireTests extends AbstractSerializingTestCase<SimpleHeuristic> {
+public class SimpleHeuristicWireTests extends AbstractXContentSerializingTestCase<SimpleHeuristic> {
     @Override
     protected SimpleHeuristic doParseInstance(XContentParser parser) throws IOException {
         /* Because Heuristics are XContent "fragments" we need to throw away


### PR DESCRIPTION
in #90707 a org.elasticsearch.test.AbstractSerializingTestCase was refactored and AbstractXContentSerializingTestCase should be used instead.

<!--
Thank you for your interest in and contributing to Elasticsearch! There
are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your
attention.
-->

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/elasticsearch/blob/main/CONTRIBUTING.md)?
- If submitting code, have you built your formula locally prior to submission with `gradle check`?
- If submitting code, is your pull request against main? Unless there is a good reason otherwise, we prefer pull requests against main and will backport as needed.
- If submitting code, have you checked that your submission is for an [OS and architecture that we support](https://www.elastic.co/support/matrix#show_os)?
- If you are submitting this code for a class then read our [policy](https://github.com/elastic/elasticsearch/blob/main/CONTRIBUTING.md#contributing-as-part-of-a-class) for that.
