### PR TITLE
Make SearchExecutionContext search engine aware.

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/search/CanMatchNodeRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/search/CanMatchNodeRequest.java
@@ -206,6 +206,7 @@ public class CanMatchNodeRequest extends TransportRequest implements IndicesRequ
             r.shardRequestIndex,
             numberOfShards,
             searchType,
+            null, // TODO: check if this works really.
             source,
             requestCache,
             r.aliasFilter,

--- a/server/src/main/java/org/elasticsearch/action/search/TransportSearchAction.java
+++ b/server/src/main/java/org/elasticsearch/action/search/TransportSearchAction.java
@@ -1239,19 +1239,23 @@ public class TransportSearchAction extends HandledTransportAction<SearchRequest,
             return;
         }
 
-        List<String> searchEnginesName = resolver.searchEngineNames(clusterState, searchRequest.indicesOptions(), searchRequest.indices());
+        try {
+            List<String> searchEnginesName = resolver.searchEngineNames(clusterState, searchRequest.indicesOptions(), searchRequest.indices());
 
-        if (searchEnginesName.size() > 0) {
-            if (searchEnginesName.size() > 1) {
-                throw new IllegalArgumentException("Can't search several search engines together");
+            if (searchEnginesName.size() > 0) {
+                if (searchEnginesName.size() > 1) {
+                    throw new IllegalArgumentException("Can't search several search engines together");
+                }
+
+                if (searchRequest.indices().length > 1) {
+                    // TODO: need a smarter version too handle wildcards. Enough for a POC.
+                    throw new IllegalArgumentException("Can't search several search engines together");
+                }
+
+                searchRequest.searchEngineName(searchEnginesName.get(0));
             }
-
-            if (searchRequest.indices().length > 1) {
-                // TODO: need a smarter version too handle wildcards. Enough for a POC.
-                throw new IllegalArgumentException("Can't search several search engines together");
-            }
-
-            searchRequest.searchEngineName(searchEnginesName.get(0));
+        } catch (IndexNotFoundException e) {
+            return;
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/action/search/TransportSearchAction.java
+++ b/server/src/main/java/org/elasticsearch/action/search/TransportSearchAction.java
@@ -958,6 +958,8 @@ public class TransportSearchAction extends HandledTransportAction<SearchRequest,
                 searchRequest.allowPartialSearchResults()
             );
         } else {
+            resolveSearchEngine(clusterState, indexNameExpressionResolver, searchRequest);
+
             final Index[] indices = resolveLocalIndices(localIndices, clusterState, timeProvider);
             Map<String, Set<String>> routingMap = indexNameExpressionResolver.resolveSearchRouting(
                 clusterState,
@@ -1229,6 +1231,27 @@ public class TransportSearchAction extends HandledTransportAction<SearchRequest,
                 );
             };
             return searchAsyncAction;
+        }
+    }
+
+    private static void resolveSearchEngine(ClusterState clusterState, IndexNameExpressionResolver resolver, SearchRequest searchRequest) {
+        if (searchRequest.searchEngineName() != null) {
+            return;
+        }
+
+        List<String> searchEnginesName = resolver.searchEngineNames(clusterState, searchRequest.indicesOptions(), searchRequest.indices());
+
+        if (searchEnginesName.size() > 0) {
+            if (searchEnginesName.size() > 1) {
+                throw new IllegalArgumentException("Can't search several search engines together");
+            }
+
+            if (searchRequest.indices().length > 1) {
+                // TODO: need a smarter version too handle wildcards. Enough for a POC.
+                throw new IllegalArgumentException("Can't search several search engines together");
+            }
+
+            searchRequest.searchEngineName(searchEnginesName.get(0));
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/action/search/TransportSearchAction.java
+++ b/server/src/main/java/org/elasticsearch/action/search/TransportSearchAction.java
@@ -1240,7 +1240,11 @@ public class TransportSearchAction extends HandledTransportAction<SearchRequest,
         }
 
         try {
-            List<String> searchEnginesName = resolver.searchEngineNames(clusterState, searchRequest.indicesOptions(), searchRequest.indices());
+            List<String> searchEnginesName = resolver.searchEngineNames(
+                clusterState,
+                searchRequest.indicesOptions(),
+                searchRequest.indices()
+            );
 
             if (searchEnginesName.size() > 0) {
                 if (searchEnginesName.size() > 1) {

--- a/server/src/main/java/org/elasticsearch/index/IndexService.java
+++ b/server/src/main/java/org/elasticsearch/index/IndexService.java
@@ -196,7 +196,7 @@ public class IndexService extends AbstractIndexComponent implements IndicesClust
                 similarityService,
                 mapperRegistry,
                 // we parse all percolator queries as they would be parsed on shard 0
-                () -> newSearchExecutionContext(0, 0, null, System::currentTimeMillis, null, emptyMap()),
+                () -> newSearchExecutionContext(0, 0, null, null, System::currentTimeMillis, null, emptyMap()),
                 idFieldMapper,
                 scriptService
             );
@@ -616,6 +616,7 @@ public class IndexService extends AbstractIndexComponent implements IndicesClust
     public SearchExecutionContext newSearchExecutionContext(
         int shardId,
         int shardRequestIndex,
+        String searchEngineName,
         IndexSearcher searcher,
         LongSupplier nowInMillis,
         String clusterAlias,
@@ -630,6 +631,7 @@ public class IndexService extends AbstractIndexComponent implements IndicesClust
         return new SearchExecutionContext(
             shardId,
             shardRequestIndex,
+            searchEngineName,
             indexSettings,
             indexCache.bitsetFilterCache(),
             indexFieldData::getForField,
@@ -648,6 +650,17 @@ public class IndexService extends AbstractIndexComponent implements IndicesClust
             valuesSourceRegistry,
             runtimeMappings
         );
+    }
+
+    public SearchExecutionContext newSearchExecutionContext(
+        int shardId,
+        int shardRequestIndex,
+        IndexSearcher searcher,
+        LongSupplier nowInMillis,
+        String clusterAlias,
+        Map<String, Object> runtimeMappings
+    ) {
+        return newSearchExecutionContext(shardId, shardRequestIndex, null, searcher, nowInMillis, clusterAlias, runtimeMappings);
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/index/query/SearchExecutionContext.java
+++ b/server/src/main/java/org/elasticsearch/index/query/SearchExecutionContext.java
@@ -115,12 +115,15 @@ public class SearchExecutionContext extends QueryRewriteContext {
     private final Map<String, MappedFieldType> runtimeMappings;
     private Predicate<String> allowedFields;
 
+    private final String searchEngineName;
+
     /**
      * Build a {@linkplain SearchExecutionContext}.
      */
     public SearchExecutionContext(
         int shardId,
         int shardRequestIndex,
+        String searchEngineName,
         IndexSettings indexSettings,
         BitsetFilterCache bitsetFilterCache,
         BiFunction<MappedFieldType, FieldDataContext, IndexFieldData<?>> indexFieldDataLookup,
@@ -142,6 +145,7 @@ public class SearchExecutionContext extends QueryRewriteContext {
         this(
             shardId,
             shardRequestIndex,
+            searchEngineName,
             indexSettings,
             bitsetFilterCache,
             indexFieldDataLookup,
@@ -170,6 +174,7 @@ public class SearchExecutionContext extends QueryRewriteContext {
         this(
             source.shardId,
             source.shardRequestIndex,
+            source.searchEngineName,
             source.indexSettings,
             source.bitsetFilterCache,
             source.indexFieldDataLookup,
@@ -194,6 +199,7 @@ public class SearchExecutionContext extends QueryRewriteContext {
     private SearchExecutionContext(
         int shardId,
         int shardRequestIndex,
+        String searchEngineName,
         IndexSettings indexSettings,
         BitsetFilterCache bitsetFilterCache,
         BiFunction<MappedFieldType, FieldDataContext, IndexFieldData<?>> indexFieldDataLookup,
@@ -216,6 +222,7 @@ public class SearchExecutionContext extends QueryRewriteContext {
         super(parserConfig, namedWriteableRegistry, client, nowInMillis);
         this.shardId = shardId;
         this.shardRequestIndex = shardRequestIndex;
+        this.searchEngineName = searchEngineName;
         this.similarityService = similarityService;
         this.mapperService = mapperService;
         this.mappingLookup = mappingLookup;
@@ -624,6 +631,13 @@ public class SearchExecutionContext extends QueryRewriteContext {
      */
     public int getShardId() {
         return shardId;
+    }
+
+    /**
+     * Returns the search engine name this context was created for.
+     */
+    public String getSearchEngineName() {
+        return searchEngineName;
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/index/query/SearchExecutionContext.java
+++ b/server/src/main/java/org/elasticsearch/index/query/SearchExecutionContext.java
@@ -117,6 +117,51 @@ public class SearchExecutionContext extends QueryRewriteContext {
 
     private final String searchEngineName;
 
+    public SearchExecutionContext(
+        int shardId,
+        int shardRequestIndex,
+        IndexSettings indexSettings,
+        BitsetFilterCache bitsetFilterCache,
+        BiFunction<MappedFieldType, FieldDataContext, IndexFieldData<?>> indexFieldDataLookup,
+        MapperService mapperService,
+        MappingLookup mappingLookup,
+        SimilarityService similarityService,
+        ScriptService scriptService,
+        XContentParserConfiguration parserConfiguration,
+        NamedWriteableRegistry namedWriteableRegistry,
+        Client client,
+        IndexSearcher searcher,
+        LongSupplier nowInMillis,
+        String clusterAlias,
+        Predicate<String> indexNameMatcher,
+        BooleanSupplier allowExpensiveQueries,
+        ValuesSourceRegistry valuesSourceRegistry,
+        Map<String, Object> runtimeMappings
+    ) {
+        this(
+            shardId,
+            shardRequestIndex,
+            null,
+            indexSettings,
+            bitsetFilterCache,
+            indexFieldDataLookup,
+            mapperService,
+            mappingLookup,
+            similarityService,
+            scriptService,
+            parserConfiguration,
+            namedWriteableRegistry,
+            client,
+            searcher,
+            nowInMillis,
+            clusterAlias,
+            indexNameMatcher,
+            allowExpensiveQueries,
+            valuesSourceRegistry,
+            runtimeMappings
+        );
+    }
+
     /**
      * Build a {@linkplain SearchExecutionContext}.
      */

--- a/server/src/main/java/org/elasticsearch/search/DefaultSearchContext.java
+++ b/server/src/main/java/org/elasticsearch/search/DefaultSearchContext.java
@@ -164,6 +164,7 @@ final class DefaultSearchContext extends SearchContext {
         searchExecutionContext = indexService.newSearchExecutionContext(
             request.shardId().id(),
             request.shardRequestIndex(),
+            request.getSearchEngineName(),
             searcher,
             request::nowInMillis,
             shardTarget.getClusterAlias(),

--- a/server/src/main/java/org/elasticsearch/search/SearchService.java
+++ b/server/src/main/java/org/elasticsearch/search/SearchService.java
@@ -1518,6 +1518,7 @@ public class SearchService extends AbstractLifecycleComponent implements IndexEv
                 SearchExecutionContext context = indexService.newSearchExecutionContext(
                     request.shardId().id(),
                     0,
+                    request.getSearchEngineName(),
                     canMatchSearcher,
                     request::nowInMillis,
                     request.getClusterAlias(),

--- a/server/src/main/java/org/elasticsearch/search/internal/ShardSearchRequest.java
+++ b/server/src/main/java/org/elasticsearch/search/internal/ShardSearchRequest.java
@@ -90,6 +90,9 @@ public class ShardSearchRequest extends TransportRequest implements IndicesReque
 
     private final Version channelVersion;
 
+    @Nullable
+    private final String searchEngineName;
+
     /**
      * Should this request force {@link SourceLoader.Synthetic synthetic source}?
      * Use this to test if the mapping supports synthetic _source and to get a sense
@@ -143,6 +146,7 @@ public class ShardSearchRequest extends TransportRequest implements IndicesReque
             shardRequestIndex,
             numberOfShards,
             searchRequest.searchType(),
+            searchRequest.searchEngineName(),
             searchRequest.source(),
             searchRequest.requestCache(),
             aliasFilter,
@@ -186,6 +190,7 @@ public class ShardSearchRequest extends TransportRequest implements IndicesReque
             SearchType.QUERY_THEN_FETCH,
             null,
             null,
+            null,
             aliasFilter,
             1.0f,
             true,
@@ -206,6 +211,7 @@ public class ShardSearchRequest extends TransportRequest implements IndicesReque
         int shardRequestIndex,
         int numberOfShards,
         SearchType searchType,
+        String searchEngineName,
         SearchSourceBuilder source,
         Boolean requestCache,
         AliasFilter aliasFilter,
@@ -240,6 +246,7 @@ public class ShardSearchRequest extends TransportRequest implements IndicesReque
         this.waitForCheckpoint = waitForCheckpoint;
         this.waitForCheckpointsTimeout = waitForCheckpointsTimeout;
         this.forceSyntheticSource = forceSyntheticSource;
+        this.searchEngineName = searchEngineName;
     }
 
     public ShardSearchRequest(ShardSearchRequest clone) {
@@ -264,6 +271,7 @@ public class ShardSearchRequest extends TransportRequest implements IndicesReque
         this.waitForCheckpoint = clone.waitForCheckpoint;
         this.waitForCheckpointsTimeout = clone.waitForCheckpointsTimeout;
         this.forceSyntheticSource = clone.forceSyntheticSource;
+        this.searchEngineName = clone.searchEngineName;
     }
 
     public ShardSearchRequest(StreamInput in) throws IOException {
@@ -324,6 +332,12 @@ public class ShardSearchRequest extends TransportRequest implements IndicesReque
             forceSyntheticSource = false;
         }
         originalIndices = OriginalIndices.readOriginalIndices(in);
+
+        if (in.getVersion().onOrAfter(Version.V_8_6_0)) {
+            searchEngineName = in.readOptionalString();
+        } else {
+            searchEngineName = null;
+        }
     }
 
     @Override
@@ -388,6 +402,10 @@ public class ShardSearchRequest extends TransportRequest implements IndicesReque
                 throw new IllegalArgumentException("force_synthetic_source is not supported before 8.4.0");
             }
         }
+
+        if (out.getVersion().onOrAfter(Version.V_8_6_0)) {
+            out.writeOptionalString(searchEngineName);
+        }
     }
 
     @Override
@@ -412,6 +430,10 @@ public class ShardSearchRequest extends TransportRequest implements IndicesReque
 
     public SearchSourceBuilder source() {
         return source;
+    }
+
+    public String getSearchEngineName() {
+        return searchEngineName;
     }
 
     public AliasFilter getAliasFilter() {

--- a/server/src/main/java/org/elasticsearch/search/internal/ShardSearchRequest.java
+++ b/server/src/main/java/org/elasticsearch/search/internal/ShardSearchRequest.java
@@ -331,13 +331,14 @@ public class ShardSearchRequest extends TransportRequest implements IndicesReque
              */
             forceSyntheticSource = false;
         }
-        originalIndices = OriginalIndices.readOriginalIndices(in);
 
         if (in.getVersion().onOrAfter(Version.V_8_6_0)) {
             searchEngineName = in.readOptionalString();
         } else {
             searchEngineName = null;
         }
+
+        originalIndices = OriginalIndices.readOriginalIndices(in);
     }
 
     @Override

--- a/server/src/test/java/org/elasticsearch/search/DefaultSearchContextTests.java
+++ b/server/src/test/java/org/elasticsearch/search/DefaultSearchContextTests.java
@@ -96,7 +96,7 @@ public class DefaultSearchContextTests extends ESTestCase {
         when(indexCache.query()).thenReturn(queryCache);
         when(indexService.cache()).thenReturn(indexCache);
         SearchExecutionContext searchExecutionContext = mock(SearchExecutionContext.class);
-        when(indexService.newSearchExecutionContext(eq(shardId.id()), eq(shardId.id()), any(), any(), nullable(String.class), any()))
+        when(indexService.newSearchExecutionContext(eq(shardId.id()), eq(shardId.id()), any(), any(), any(), nullable(String.class), any()))
             .thenReturn(searchExecutionContext);
         MapperService mapperService = mock(MapperService.class);
         when(mapperService.hasNested()).thenReturn(randomBoolean());


### PR DESCRIPTION
Implementing the `relevance_match` query requires that we know what search engine is searched when building the query (so we can load search relevance settings configured for the engine).

Currently, the `SearchExecutionContext` execution context contains only information about the searched indices. 
The following PR makes add the `searchEngineName` method to the `SearchExecutionContext` so it can be used by the query builder.

```java
protected Query doToQuery(final SearchExecutionContext context) throws IOException {
...
}
```

The `searchEngineName` method returns null if the search has not been issued against an engine (using a concrete index, an alias or a data stream).

This PR also prevent the user to search several engines at the same time.
