### PR TITLE
Fix quadratic complexity in SnapshotStatus serialization

### DIFF
--- a/docs/changelog/90795.yaml
+++ b/docs/changelog/90795.yaml
@@ -1,0 +1,5 @@
+pr: 90795
+summary: Fix quadratic complexity in `SnapshotStatus` serialization
+area: Snapshot/Restore
+type: bug
+issues: []

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/status/SnapshotStatus.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/status/SnapshotStatus.java
@@ -28,11 +28,9 @@ import org.elasticsearch.xcontent.XContentParser;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Set;
 
 import static java.util.Collections.emptyList;
 import static java.util.Collections.emptyMap;
@@ -142,29 +140,22 @@ public class SnapshotStatus implements ToXContentObject, Writeable {
      * Returns list of snapshot indices
      */
     public Map<String, SnapshotIndexStatus> getIndices() {
-        if (this.indicesStatus != null) {
-            return this.indicesStatus;
+        var res = this.indicesStatus;
+        if (res != null) {
+            return res;
         }
 
-        Map<String, SnapshotIndexStatus> indicesStatus = new HashMap<>();
-
-        Set<String> indices = new HashSet<>();
+        Map<String, List<SnapshotIndexShardStatus>> indices = new HashMap<>();
         for (SnapshotIndexShardStatus shard : shards) {
-            indices.add(shard.getIndex());
+            indices.computeIfAbsent(shard.getIndex(), k -> new ArrayList<>()).add(shard);
         }
-
-        for (String index : indices) {
-            List<SnapshotIndexShardStatus> shards = new ArrayList<>();
-            for (SnapshotIndexShardStatus shard : this.shards) {
-                if (shard.getIndex().equals(index)) {
-                    shards.add(shard);
-                }
-            }
-            indicesStatus.put(index, new SnapshotIndexStatus(index, shards));
+        Map<String, SnapshotIndexStatus> indicesStatus = Maps.newMapWithExpectedSize(indices.size());
+        for (Map.Entry<String, List<SnapshotIndexShardStatus>> entry : indices.entrySet()) {
+            indicesStatus.put(entry.getKey(), new SnapshotIndexStatus(entry.getKey(), entry.getValue()));
         }
-        this.indicesStatus = unmodifiableMap(indicesStatus);
-        return this.indicesStatus;
-
+        res = unmodifiableMap(indicesStatus);
+        this.indicesStatus = res;
+        return res;
     }
 
     @Override


### PR DESCRIPTION
The loop here is obviously O(N^2) and it shows as taking multiple seconds to build the by-index map in x-content serialization for a 25k shards snapshot.
This makes the logic O(N) and fixes some potential issues with consistency around concurrent access by using a more appropriate access pattern to the field caching the by-index map.

Still not great but good enough with this change.

relates #77466 
