### PR TITLE
[8.5] Remove incorrect outputs mapping from fleet-agents (#90714)

### DIFF
--- a/x-pack/plugin/core/src/main/resources/fleet-agents.json
+++ b/x-pack/plugin/core/src/main/resources/fleet-agents.json
@@ -29,26 +29,6 @@
             }
           }
         },
-        "outputs": {
-          "properties": {
-            "api_key": {
-              "type": "keyword"
-            },
-            "api_key_id": {
-              "type": "keyword"
-            },
-            "type": {
-              "type": "keyword"
-            },
-            "policy_permissions_hash": {
-              "type": "keyword"
-            },
-            "to_retire_api_key_ids": {
-              "type": "object",
-              "enabled": false
-            }
-          }
-        },
         "default_api_key": {
           "type": "keyword"
         },


### PR DESCRIPTION
Backports the following commits to 8.5:
 - Remove incorrect outputs mapping from fleet-agents (#90714)