### PR TITLE
Remove unnecessary field from RoutingAllocation

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/allocator/BalancedShardsAllocator.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/allocator/BalancedShardsAllocator.java
@@ -732,7 +732,7 @@ public class BalancedShardsAllocator implements ShardsAllocator {
              */
             MoveDecision moveDecision = decideMove(shardRouting, sourceNode, canRemain, this::decideCanAllocate);
             if (moveDecision.canRemain() == false && moveDecision.forceMove() == false) {
-                final SingleNodeShutdownMetadata shutdown = allocation.nodeShutdowns().get(shardRouting.currentNodeId());
+                final SingleNodeShutdownMetadata shutdown = allocation.metadata().nodeShutdowns().get(shardRouting.currentNodeId());
                 final boolean shardsOnReplacedNode = shutdown != null && shutdown.getType().equals(SingleNodeShutdownMetadata.Type.REPLACE);
                 if (shardsOnReplacedNode) {
                     return decideMove(shardRouting, sourceNode, canRemain, this::decideCanForceAllocateForVacate);

--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/NodeReplacementAllocationDecider.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/NodeReplacementAllocationDecider.java
@@ -170,7 +170,7 @@ public class NodeReplacementAllocationDecider extends AllocationDecider {
         if (sourceNodeId == null || targetNodeName == null) {
             return false;
         }
-        final SingleNodeShutdownMetadata shutdown = allocation.nodeShutdowns().get(sourceNodeId);
+        final SingleNodeShutdownMetadata shutdown = allocation.metadata().nodeShutdowns().get(sourceNodeId);
         return shutdown != null
             && shutdown.getType().equals(SingleNodeShutdownMetadata.Type.REPLACE)
             && shutdown.getNodeId().equals(sourceNodeId)
@@ -184,7 +184,7 @@ public class NodeReplacementAllocationDecider extends AllocationDecider {
         if (nodeId == null || replacementOngoing(allocation) == false) {
             return false;
         }
-        final SingleNodeShutdownMetadata shutdown = allocation.nodeShutdowns().get(nodeId);
+        final SingleNodeShutdownMetadata shutdown = allocation.metadata().nodeShutdowns().get(nodeId);
         return shutdown != null && shutdown.getType().equals(SingleNodeShutdownMetadata.Type.REPLACE);
     }
 
@@ -202,7 +202,7 @@ public class NodeReplacementAllocationDecider extends AllocationDecider {
         if (nodeIdBeingReplaced == null || replacementOngoing(allocation) == false) {
             return null;
         }
-        return Optional.ofNullable(allocation.nodeShutdowns().get(nodeIdBeingReplaced))
+        return Optional.ofNullable(allocation.metadata().nodeShutdowns().get(nodeIdBeingReplaced))
             .filter(shutdown -> shutdown.getType().equals(SingleNodeShutdownMetadata.Type.REPLACE))
             .map(SingleNodeShutdownMetadata::getTargetNodeName)
             .orElse(null);

--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/NodeShutdownAllocationDecider.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/NodeShutdownAllocationDecider.java
@@ -57,7 +57,7 @@ public class NodeShutdownAllocationDecider extends AllocationDecider {
     }
 
     private static Decision getDecision(RoutingAllocation allocation, String nodeId) {
-        final var nodeShutdowns = allocation.nodeShutdowns();
+        final var nodeShutdowns = allocation.metadata().nodeShutdowns();
         if (nodeShutdowns.isEmpty()) {
             return YES_EMPTY_SHUTDOWN_METADATA;
         }

--- a/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/allocation/SearchableSnapshotAllocator.java
+++ b/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/allocation/SearchableSnapshotAllocator.java
@@ -354,7 +354,7 @@ public class SearchableSnapshotAllocator implements ExistingShardsAllocator {
         if (shardRouting.unassignedInfo().isDelayed()) {
             String lastAllocatedNodeId = shardRouting.unassignedInfo().getLastAllocatedNodeId();
             if (lastAllocatedNodeId != null) {
-                SingleNodeShutdownMetadata nodeShutdownMetadata = allocation.nodeShutdowns().get(lastAllocatedNodeId);
+                SingleNodeShutdownMetadata nodeShutdownMetadata = allocation.metadata().nodeShutdowns().get(lastAllocatedNodeId);
                 return nodeShutdownMetadata != null && nodeShutdownMetadata.getType() == SingleNodeShutdownMetadata.Type.RESTART;
             }
         }


### PR DESCRIPTION
This removes RoutingAllocation#nodeShutdowns field and replaces it with a delegate to metadata().