### PR TITLE
Settings services refactor

### DIFF
--- a/x-pack/plugin/relevance-search/src/main/java/org/elasticsearch/xpack/relevancesearch/RelevanceSearchPlugin.java
+++ b/x-pack/plugin/relevance-search/src/main/java/org/elasticsearch/xpack/relevancesearch/RelevanceSearchPlugin.java
@@ -38,8 +38,9 @@ import org.elasticsearch.xcontent.NamedXContentRegistry;
 import org.elasticsearch.xpack.relevancesearch.query.QueryFieldsResolver;
 import org.elasticsearch.xpack.relevancesearch.query.RelevanceMatchQueryBuilder;
 import org.elasticsearch.xpack.relevancesearch.query.RelevanceMatchQueryRewriter;
-import org.elasticsearch.xpack.relevancesearch.relevance.curations.CurationsService;
-import org.elasticsearch.xpack.relevancesearch.relevance.settings.RelevanceSettingsService;
+import org.elasticsearch.xpack.relevancesearch.settings.curations.CurationsService;
+import org.elasticsearch.xpack.relevancesearch.settings.index.IndexCreationService;
+import org.elasticsearch.xpack.relevancesearch.settings.relevance.RelevanceSettingsService;
 
 import java.util.Collection;
 import java.util.Collections;
@@ -55,6 +56,7 @@ public class RelevanceSearchPlugin extends Plugin implements ActionPlugin, Searc
     }
 
     private final SetOnce<RelevanceMatchQueryRewriter> relevanceMatchQueryRewriter = new SetOnce<>();
+    private final SetOnce<IndexCreationService> indexCreationService = new SetOnce<>();
 
     @Override
     public List<RestHandler> getRestHandlers(
@@ -105,12 +107,13 @@ public class RelevanceSearchPlugin extends Plugin implements ActionPlugin, Searc
         AllocationDeciders allocationDeciders
     ) {
 
-        RelevanceSettingsService relevanceSettingsService = new RelevanceSettingsService(client, clusterService);
+        indexCreationService.set(new IndexCreationService(client, clusterService));
+        RelevanceSettingsService relevanceSettingsService = new RelevanceSettingsService(client);
         CurationsService curationsService = new CurationsService(client);
         QueryFieldsResolver queryFieldsResolver = new QueryFieldsResolver();
 
         relevanceMatchQueryRewriter.set(new RelevanceMatchQueryRewriter(relevanceSettingsService, curationsService, queryFieldsResolver));
 
-        return List.of(relevanceMatchQueryRewriter.get());
+        return List.of(relevanceMatchQueryRewriter.get(), indexCreationService.get());
     }
 }

--- a/x-pack/plugin/relevance-search/src/main/java/org/elasticsearch/xpack/relevancesearch/query/RelevanceMatchQueryRewriter.java
+++ b/x-pack/plugin/relevance-search/src/main/java/org/elasticsearch/xpack/relevancesearch/query/RelevanceMatchQueryRewriter.java
@@ -95,10 +95,8 @@ public class RelevanceMatchQueryRewriter {
                 RelevanceSettings relevanceSettings = relevanceSettingsService.getSettings(relevanceSettingsId);
                 QueryConfiguration queryConfiguration = relevanceSettings.getQueryConfiguration();
                 fieldsAndBoosts = queryConfiguration.getFieldsAndBoosts();
-            } catch (RelevanceSettingsService.SettingsNotFoundException e) {
-                throw new IllegalArgumentException("[relevance_match] query can't find search settings: " + relevanceSettingsId);
-            } catch (RelevanceSettingsService.InvalidSettingsException e) {
-                throw new IllegalArgumentException("[relevance_match] invalid relevance search settings for: " + relevanceSettingsId);
+            } catch (AbstractSettingsService.SettingsServiceException e) {
+                throw new IllegalArgumentException("[relevance_match] " + e.getMessage());
             }
         } else {
             Collection<String> fields = queryFieldsResolver.getQueryFields(context);
@@ -121,10 +119,8 @@ public class RelevanceMatchQueryRewriter {
                     queryBuilder = applyExcludedDocs(queryBuilder, curationSettings);
                 }
 
-            } catch (CurationsService.SettingsNotFoundException e) {
-                throw new IllegalArgumentException("[relevance_match] query cannot find curation settings: " + curationsSettingsId);
-            } catch (AbstractSettingsService.InvalidSettingsException e) {
-                throw new IllegalArgumentException("[relevance_match] invalid curation settings for: " + curationsSettingsId);
+            } catch (AbstractSettingsService.SettingsServiceException e) {
+                throw new IllegalArgumentException("[relevance_match] " + e.getMessage());
             }
         }
 

--- a/x-pack/plugin/relevance-search/src/main/java/org/elasticsearch/xpack/relevancesearch/settings/AbstractSettingsService.java
+++ b/x-pack/plugin/relevance-search/src/main/java/org/elasticsearch/xpack/relevancesearch/settings/AbstractSettingsService.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.relevancesearch.settings;
+
+import org.elasticsearch.client.internal.Client;
+import org.elasticsearch.index.IndexNotFoundException;
+import org.elasticsearch.xpack.relevancesearch.settings.index.IndexCreationService;
+
+import java.util.Map;
+
+public abstract class AbstractSettingsService<S extends Settings> {
+    public static final String ENT_SEARCH_INDEX = ".ent-search";
+
+    protected final Client client;
+
+    public AbstractSettingsService(final Client client) {
+        this.client = client;
+    }
+
+    protected abstract String getName();
+
+    public S getSettings(String settingsId) throws SettingsNotFoundException, InvalidSettingsException {
+        // TODO cache relevance settings, including cache invalidation
+        Map<String, Object> settingsContent = null;
+        try {
+            settingsContent = client.prepareGet(ENT_SEARCH_INDEX, getSettingsPrefix() + settingsId).get().getSource();
+        } catch (IndexNotFoundException e) {
+            IndexCreationService.ensureInternalIndex(client);
+        }
+
+        if (settingsContent == null) {
+            throw new SettingsNotFoundException(getName() + " settings " + settingsId + " not found");
+        }
+
+        return parseSettings(settingsContent);
+    }
+
+    protected abstract S parseSettings(Map<String, Object> source) throws InvalidSettingsException;
+
+    protected abstract String getSettingsPrefix();
+
+    public static class SettingsNotFoundException extends Exception {
+        public SettingsNotFoundException(String message) {
+            super(message);
+        }
+    }
+
+    public static class InvalidSettingsException extends Exception {
+        public InvalidSettingsException(String message) {
+            super(message);
+        }
+    }
+}

--- a/x-pack/plugin/relevance-search/src/main/java/org/elasticsearch/xpack/relevancesearch/settings/AbstractSettingsService.java
+++ b/x-pack/plugin/relevance-search/src/main/java/org/elasticsearch/xpack/relevancesearch/settings/AbstractSettingsService.java
@@ -44,13 +44,19 @@ public abstract class AbstractSettingsService<S extends Settings> {
 
     protected abstract String getSettingsPrefix();
 
-    public static class SettingsNotFoundException extends Exception {
+    public static class SettingsServiceException extends Exception {
+        public SettingsServiceException(String message) {
+            super(message);
+        }
+    }
+
+    public static class SettingsNotFoundException extends SettingsServiceException {
         public SettingsNotFoundException(String message) {
             super(message);
         }
     }
 
-    public static class InvalidSettingsException extends Exception {
+    public static class InvalidSettingsException extends SettingsServiceException {
         public InvalidSettingsException(String message) {
             super(message);
         }

--- a/x-pack/plugin/relevance-search/src/main/java/org/elasticsearch/xpack/relevancesearch/settings/Settings.java
+++ b/x-pack/plugin/relevance-search/src/main/java/org/elasticsearch/xpack/relevancesearch/settings/Settings.java
@@ -1,0 +1,10 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.relevancesearch.settings;
+
+public interface Settings {}

--- a/x-pack/plugin/relevance-search/src/main/java/org/elasticsearch/xpack/relevancesearch/settings/curations/Condition.java
+++ b/x-pack/plugin/relevance-search/src/main/java/org/elasticsearch/xpack/relevancesearch/settings/curations/Condition.java
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-package org.elasticsearch.xpack.relevancesearch.relevance.curations;
+package org.elasticsearch.xpack.relevancesearch.settings.curations;
 
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.xpack.relevancesearch.query.RelevanceMatchQueryBuilder;

--- a/x-pack/plugin/relevance-search/src/main/java/org/elasticsearch/xpack/relevancesearch/settings/curations/CurationSettings.java
+++ b/x-pack/plugin/relevance-search/src/main/java/org/elasticsearch/xpack/relevancesearch/settings/curations/CurationSettings.java
@@ -5,16 +5,19 @@
  * 2.0.
  */
 
-package org.elasticsearch.xpack.relevancesearch.relevance.curations;
+package org.elasticsearch.xpack.relevancesearch.settings.curations;
 
 import org.elasticsearch.common.Strings;
+import org.elasticsearch.xpack.relevancesearch.settings.Settings;
 
 import java.util.List;
 
 /**
  * Holds curation settings, including the conditions needed to execute the curation, the pinned documents and the excluded documents.
  */
-public record CurationSettings(List<DocumentReference> pinnedDocs, List<DocumentReference> excludedDocs, List<Condition> conditions) {
+public record CurationSettings(List<DocumentReference> pinnedDocs, List<DocumentReference> excludedDocs, List<Condition> conditions)
+    implements
+        Settings {
 
     public record DocumentReference(String id, String index) {
         public DocumentReference(String id, String index) {

--- a/x-pack/plugin/relevance-search/src/main/java/org/elasticsearch/xpack/relevancesearch/settings/curations/CurationsService.java
+++ b/x-pack/plugin/relevance-search/src/main/java/org/elasticsearch/xpack/relevancesearch/settings/curations/CurationsService.java
@@ -32,7 +32,6 @@ public class CurationsService extends AbstractSettingsService<CurationSettings> 
         super(client);
     }
 
-
     protected CurationSettings parseSettings(Map<String, Object> source) throws IllegalArgumentException {
         // TODO Probably worth to take a look into document mappers in case they can be used for parsing
         // see org/elasticsearch/index/mapper/DocumentParser.java

--- a/x-pack/plugin/relevance-search/src/main/java/org/elasticsearch/xpack/relevancesearch/settings/curations/CurationsService.java
+++ b/x-pack/plugin/relevance-search/src/main/java/org/elasticsearch/xpack/relevancesearch/settings/curations/CurationsService.java
@@ -5,9 +5,10 @@
  * 2.0.
  */
 
-package org.elasticsearch.xpack.relevancesearch.relevance.curations;
+package org.elasticsearch.xpack.relevancesearch.settings.curations;
 
 import org.elasticsearch.client.internal.Client;
+import org.elasticsearch.xpack.relevancesearch.settings.AbstractSettingsService;
 
 import java.util.Collections;
 import java.util.List;
@@ -16,9 +17,8 @@ import java.util.Map;
 /**
  * Manage relevance settings, retrieving and updating the corresponding documents in .ent-search index
  */
-public class CurationsService {
+public class CurationsService extends AbstractSettingsService<CurationSettings> {
 
-    public static final String ENT_SEARCH_INDEX = ".ent-search";
     public static final String CURATIONS_SETTINGS_PREFIX = "curations-";
     private static final String CONDITIONS_FIELD = "conditions";
     private static final String PINNED_DOCS_FIELD = "pinned_document_ids";
@@ -28,26 +28,12 @@ public class CurationsService {
     private static final String ID_ATTR = "_id";
     private static final String INDEX_ATTR = "_index";
 
-    private final Client client;
-
     public CurationsService(final Client client) {
-        this.client = client;
+        super(client);
     }
 
-    public CurationSettings getCurationsSettings(String curationId) throws CurationsSettingsNotFoundException {
-        // TODO cache relevance settings, including cache invalidation
-        final Map<String, Object> settingsContent = client.prepareGet(ENT_SEARCH_INDEX, CURATIONS_SETTINGS_PREFIX + curationId)
-            .get()
-            .getSource();
 
-        if (settingsContent == null) {
-            throw new CurationsSettingsNotFoundException("Curation settings " + curationId + " not found");
-        }
-
-        return parseCurationSettings(settingsContent);
-    }
-
-    private CurationSettings parseCurationSettings(Map<String, Object> source) throws IllegalArgumentException {
+    protected CurationSettings parseSettings(Map<String, Object> source) throws IllegalArgumentException {
         // TODO Probably worth to take a look into document mappers in case they can be used for parsing
         // see org/elasticsearch/index/mapper/DocumentParser.java
 
@@ -83,9 +69,13 @@ public class CurationsService {
         return Condition.buildCondition((String) sourceCondition.get(CONTEXT_ATTR), (String) sourceCondition.get(VALUE_ATTR));
     }
 
-    public static class CurationsSettingsNotFoundException extends Exception {
-        public CurationsSettingsNotFoundException(String message) {
-            super(message);
-        }
+    @Override
+    protected String getName() {
+        return "Curation";
+    }
+
+    @Override
+    protected String getSettingsPrefix() {
+        return CURATIONS_SETTINGS_PREFIX;
     }
 }

--- a/x-pack/plugin/relevance-search/src/main/java/org/elasticsearch/xpack/relevancesearch/settings/index/IndexCreationService.java
+++ b/x-pack/plugin/relevance-search/src/main/java/org/elasticsearch/xpack/relevancesearch/settings/index/IndexCreationService.java
@@ -48,7 +48,6 @@ public class IndexCreationService implements ClusterStateListener {
         clusterService.addListener(this);
     }
 
-
     @Override
     public void clusterChanged(ClusterChangedEvent event) {
         if (event.state().blocks().hasGlobalBlock(GatewayService.STATE_NOT_RECOVERED_BLOCK)) {

--- a/x-pack/plugin/relevance-search/src/main/java/org/elasticsearch/xpack/relevancesearch/settings/index/IndexCreationService.java
+++ b/x-pack/plugin/relevance-search/src/main/java/org/elasticsearch/xpack/relevancesearch/settings/index/IndexCreationService.java
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-package org.elasticsearch.xpack.relevancesearch.relevance.settings;
+package org.elasticsearch.xpack.relevancesearch.settings.index;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -22,78 +22,32 @@ import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.gateway.GatewayService;
-import org.elasticsearch.index.IndexNotFoundException;
 import org.elasticsearch.xcontent.XContentBuilder;
-import org.elasticsearch.xpack.relevancesearch.relevance.QueryConfiguration;
+import org.elasticsearch.xpack.relevancesearch.settings.AbstractSettingsService;
+import org.elasticsearch.xpack.relevancesearch.settings.relevance.RelevanceSettingsService;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
-import java.util.List;
-import java.util.Map;
 
 import static org.elasticsearch.index.mapper.MapperService.SINGLE_MAPPING_NAME;
 import static org.elasticsearch.xcontent.XContentFactory.jsonBuilder;
 import static org.elasticsearch.xpack.core.ClientHelper.RELEVANCE_SETTINGS_ORIGIN;
 import static org.elasticsearch.xpack.core.ClientHelper.executeAsyncWithOrigin;
 
-/**
- * Manage relevance settings, retrieving and updating the corresponding documents in .ent-search index
- */
-public class RelevanceSettingsService implements ClusterStateListener {
-
-    public static final String ENT_SEARCH_INDEX = ".ent-search";
-    public static final String RELEVANCE_SETTINGS_PREFIX = "relevance_settings-";
-    private final Client client;
-    private final ClusterService clusterService;
+public class IndexCreationService implements ClusterStateListener {
 
     private static final Logger logger = LogManager.getLogger(RelevanceSettingsService.class);
 
-    public RelevanceSettingsService(final Client client, final ClusterService clusterService) {
+    private final ClusterService clusterService;
+
+    private final Client client;
+
+    public IndexCreationService(final Client client, final ClusterService clusterService) {
         this.client = client;
         this.clusterService = clusterService;
         clusterService.addListener(this);
     }
 
-    public RelevanceSettings getRelevanceSettings(String settingsId) throws RelevanceSettingsNotFoundException,
-        RelevanceSettingsInvalidException {
-        // TODO cache relevance settings, including cache invalidation
-        Map<String, Object> settingsContent = null;
-        try {
-            settingsContent = client.prepareGet(ENT_SEARCH_INDEX, RELEVANCE_SETTINGS_PREFIX + settingsId).get().getSource();
-        } catch (IndexNotFoundException e) {
-            ensureInternalIndex(client);
-        }
-
-        if (settingsContent == null) {
-            throw new RelevanceSettingsNotFoundException("Relevance settings " + settingsId + " not found");
-        }
-
-        return parseRelevanceSettings(settingsContent);
-    }
-
-    private RelevanceSettings parseRelevanceSettings(Map<String, Object> source) throws RelevanceSettingsInvalidException {
-
-        RelevanceSettings relevanceSettings = new RelevanceSettings();
-        QueryConfiguration relevanceSettingsQueryConfiguration = new QueryConfiguration();
-
-        @SuppressWarnings("unchecked")
-        final Map<String, Object> queryConfiguration = (Map<String, Object>) source.get("query_configuration");
-        if (queryConfiguration == null) {
-            throw new RelevanceSettingsInvalidException(
-                "[relevance_match] query configuration not specified in relevance settings. Source: " + source
-            );
-        }
-        @SuppressWarnings("unchecked")
-        final List<String> fields = (List<String>) queryConfiguration.get("fields");
-        if (fields == null || fields.isEmpty()) {
-            throw new RelevanceSettingsInvalidException("[relevance_match] fields not specified in relevance settings. Source: " + source);
-        }
-        relevanceSettingsQueryConfiguration.parseFieldsAndBoosts(fields);
-
-        relevanceSettings.setQueryConfiguration(relevanceSettingsQueryConfiguration);
-
-        return relevanceSettings;
-    }
 
     @Override
     public void clusterChanged(ClusterChangedEvent event) {
@@ -106,20 +60,8 @@ public class RelevanceSettingsService implements ClusterStateListener {
         this.clusterService.removeListener(this);
     }
 
-    public static class RelevanceSettingsNotFoundException extends Exception {
-        public RelevanceSettingsNotFoundException(String message) {
-            super(message);
-        }
-    }
-
-    public static class RelevanceSettingsInvalidException extends Exception {
-        public RelevanceSettingsInvalidException(String message) {
-            super(message);
-        }
-    }
-
-    private static void ensureInternalIndex(Client client) {
-        CreateIndexRequest request = new CreateIndexRequest(ENT_SEARCH_INDEX).mapping(getInternalIndexMapping())
+    public static void ensureInternalIndex(Client client) {
+        CreateIndexRequest request = new CreateIndexRequest(AbstractSettingsService.ENT_SEARCH_INDEX).mapping(getInternalIndexMapping())
             .settings(getInternalIndexSettings())
             .origin(RELEVANCE_SETTINGS_ORIGIN);
         executeAsyncWithOrigin(
@@ -128,15 +70,15 @@ public class RelevanceSettingsService implements ClusterStateListener {
             request,
             new ActionListener<CreateIndexResponse>() {
                 public void onResponse(CreateIndexResponse createIndexResponse) {
-                    logger.info("Created " + ENT_SEARCH_INDEX + " index.");
+                    logger.info("Created " + AbstractSettingsService.ENT_SEARCH_INDEX + " index.");
                 }
 
                 public void onFailure(Exception e) {
                     final Throwable cause = ExceptionsHelper.unwrapCause(e);
                     if (cause instanceof ResourceAlreadyExistsException) {
-                        logger.info("Index " + ENT_SEARCH_INDEX + " already exists.");
+                        logger.info("Index " + AbstractSettingsService.ENT_SEARCH_INDEX + " already exists.");
                     } else {
-                        logger.info("Failed to create " + ENT_SEARCH_INDEX + " index " + e.toString());
+                        logger.info("Failed to create " + AbstractSettingsService.ENT_SEARCH_INDEX + " index " + e.toString());
                     }
                 }
             },
@@ -215,7 +157,7 @@ public class RelevanceSettingsService implements ClusterStateListener {
                 .endObject()
                 .endObject();
         } catch (IOException e) {
-            throw new UncheckedIOException("Failed to build mappings for " + ENT_SEARCH_INDEX, e);
+            throw new UncheckedIOException("Failed to build mappings for " + AbstractSettingsService.ENT_SEARCH_INDEX, e);
         }
     }
 }

--- a/x-pack/plugin/relevance-search/src/main/java/org/elasticsearch/xpack/relevancesearch/settings/relevance/QueryConfiguration.java
+++ b/x-pack/plugin/relevance-search/src/main/java/org/elasticsearch/xpack/relevancesearch/settings/relevance/QueryConfiguration.java
@@ -36,9 +36,7 @@ public class QueryConfiguration {
                     )
                 );
         } catch (NumberFormatException e) {
-            throw new RelevanceSettingsService.InvalidSettingsException(
-                "Invalid boost detected in relevance settings, must be numeric"
-            );
+            throw new RelevanceSettingsService.InvalidSettingsException("Invalid boost detected in relevance settings, must be numeric");
         }
     }
 }

--- a/x-pack/plugin/relevance-search/src/main/java/org/elasticsearch/xpack/relevancesearch/settings/relevance/QueryConfiguration.java
+++ b/x-pack/plugin/relevance-search/src/main/java/org/elasticsearch/xpack/relevancesearch/settings/relevance/QueryConfiguration.java
@@ -5,10 +5,9 @@
  * 2.0.
  */
 
-package org.elasticsearch.xpack.relevancesearch.relevance;
+package org.elasticsearch.xpack.relevancesearch.settings.relevance;
 
 import org.elasticsearch.index.query.AbstractQueryBuilder;
-import org.elasticsearch.xpack.relevancesearch.relevance.settings.RelevanceSettingsService;
 
 import java.util.List;
 import java.util.Map;
@@ -26,7 +25,7 @@ public class QueryConfiguration {
         this.fieldsAndBoosts = fieldsAndBoosts;
     }
 
-    public void parseFieldsAndBoosts(List<String> inputFields) throws RelevanceSettingsService.RelevanceSettingsInvalidException {
+    public void parseFieldsAndBoosts(List<String> inputFields) throws RelevanceSettingsService.InvalidSettingsException {
         try {
             this.fieldsAndBoosts = inputFields.stream()
                 .map(s -> s.split("\\^"))
@@ -37,7 +36,7 @@ public class QueryConfiguration {
                     )
                 );
         } catch (NumberFormatException e) {
-            throw new RelevanceSettingsService.RelevanceSettingsInvalidException(
+            throw new RelevanceSettingsService.InvalidSettingsException(
                 "Invalid boost detected in relevance settings, must be numeric"
             );
         }

--- a/x-pack/plugin/relevance-search/src/main/java/org/elasticsearch/xpack/relevancesearch/settings/relevance/RelevanceSettings.java
+++ b/x-pack/plugin/relevance-search/src/main/java/org/elasticsearch/xpack/relevancesearch/settings/relevance/RelevanceSettings.java
@@ -5,11 +5,11 @@
  * 2.0.
  */
 
-package org.elasticsearch.xpack.relevancesearch.relevance.settings;
+package org.elasticsearch.xpack.relevancesearch.settings.relevance;
 
-import org.elasticsearch.xpack.relevancesearch.relevance.QueryConfiguration;
+import org.elasticsearch.xpack.relevancesearch.settings.Settings;
 
-public class RelevanceSettings {
+public class RelevanceSettings implements Settings {
 
     private QueryConfiguration queryConfiguration;
 

--- a/x-pack/plugin/relevance-search/src/main/java/org/elasticsearch/xpack/relevancesearch/settings/relevance/RelevanceSettingsService.java
+++ b/x-pack/plugin/relevance-search/src/main/java/org/elasticsearch/xpack/relevancesearch/settings/relevance/RelevanceSettingsService.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.relevancesearch.settings.relevance;
+
+import org.elasticsearch.client.internal.Client;
+import org.elasticsearch.xpack.relevancesearch.settings.AbstractSettingsService;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Manage relevance settings, retrieving and updating the corresponding documents in .ent-search index
+ */
+public class RelevanceSettingsService extends AbstractSettingsService<RelevanceSettings> {
+
+    public static final String RELEVANCE_SETTINGS_PREFIX = "relevance_settings-";
+
+    public RelevanceSettingsService(final Client client) {
+        super(client);
+    }
+
+    protected RelevanceSettings parseSettings(Map<String, Object> source) throws InvalidSettingsException {
+
+        RelevanceSettings relevanceSettings = new RelevanceSettings();
+        QueryConfiguration relevanceSettingsQueryConfiguration = new QueryConfiguration();
+
+        @SuppressWarnings("unchecked")
+        final Map<String, Object> queryConfiguration = (Map<String, Object>) source.get("query_configuration");
+        if (queryConfiguration == null) {
+            throw new InvalidSettingsException(
+                "[relevance_match] query configuration not specified in relevance settings. Source: " + source
+            );
+        }
+        @SuppressWarnings("unchecked")
+        final List<String> fields = (List<String>) queryConfiguration.get("fields");
+        if (fields == null || fields.isEmpty()) {
+            throw new InvalidSettingsException("[relevance_match] fields not specified in relevance settings. Source: " + source);
+        }
+        relevanceSettingsQueryConfiguration.parseFieldsAndBoosts(fields);
+
+        relevanceSettings.setQueryConfiguration(relevanceSettingsQueryConfiguration);
+
+        return relevanceSettings;
+    }
+
+    @Override
+    protected String getName() {
+        return "Relevance";
+    }
+
+    @Override
+    protected String getSettingsPrefix() {
+        return RELEVANCE_SETTINGS_PREFIX;
+    }
+}

--- a/x-pack/plugin/relevance-search/src/test/java/org/elasticsearch/xpack/relevancesearch/query/RelevanceMatchQueryIntTests.java
+++ b/x-pack/plugin/relevance-search/src/test/java/org/elasticsearch/xpack/relevancesearch/query/RelevanceMatchQueryIntTests.java
@@ -14,8 +14,8 @@ import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.test.ESSingleNodeTestCase;
 import org.elasticsearch.xpack.relevancesearch.RelevanceSearchPlugin;
-import org.elasticsearch.xpack.relevancesearch.relevance.curations.CurationsService;
-import org.elasticsearch.xpack.relevancesearch.relevance.settings.RelevanceSettingsService;
+import org.elasticsearch.xpack.relevancesearch.settings.curations.CurationsService;
+import org.elasticsearch.xpack.relevancesearch.settings.relevance.RelevanceSettingsService;
 
 import java.util.Collection;
 import java.util.List;

--- a/x-pack/plugin/relevance-search/src/test/java/org/elasticsearch/xpack/relevancesearch/query/RelevanceMatchQueryIntTests.java
+++ b/x-pack/plugin/relevance-search/src/test/java/org/elasticsearch/xpack/relevancesearch/query/RelevanceMatchQueryIntTests.java
@@ -225,7 +225,7 @@ public class RelevanceMatchQueryIntTests extends ESSingleNodeTestCase {
 
         final SearchRequestBuilder searchRequestBuilder = client().prepareSearch(DOCUMENTS_INDEX).setQuery(relevanceMatchQueryBuilder);
 
-        final String expectedMsg = "[relevance_match] query can't find search settings: " + relevanceSettingsId;
+        final String expectedMsg = "[relevance_match] Relevance settings non-existing-settings not found";
         assertFailures(searchRequestBuilder, RestStatus.BAD_REQUEST, containsString(expectedMsg));
     }
 

--- a/x-pack/plugin/relevance-search/src/test/java/org/elasticsearch/xpack/relevancesearch/query/RelevanceMatchQueryRewriterTests.java
+++ b/x-pack/plugin/relevance-search/src/test/java/org/elasticsearch/xpack/relevancesearch/query/RelevanceMatchQueryRewriterTests.java
@@ -14,12 +14,13 @@ import org.elasticsearch.index.query.QueryBuilders;
 import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.index.query.TermsQueryBuilder;
 import org.elasticsearch.test.AbstractBuilderTestCase;
-import org.elasticsearch.xpack.relevancesearch.relevance.QueryConfiguration;
-import org.elasticsearch.xpack.relevancesearch.relevance.curations.Condition;
-import org.elasticsearch.xpack.relevancesearch.relevance.curations.CurationSettings;
-import org.elasticsearch.xpack.relevancesearch.relevance.curations.CurationsService;
-import org.elasticsearch.xpack.relevancesearch.relevance.settings.RelevanceSettings;
-import org.elasticsearch.xpack.relevancesearch.relevance.settings.RelevanceSettingsService;
+import org.elasticsearch.xpack.relevancesearch.settings.AbstractSettingsService;
+import org.elasticsearch.xpack.relevancesearch.settings.curations.Condition;
+import org.elasticsearch.xpack.relevancesearch.settings.curations.CurationSettings;
+import org.elasticsearch.xpack.relevancesearch.settings.curations.CurationsService;
+import org.elasticsearch.xpack.relevancesearch.settings.relevance.QueryConfiguration;
+import org.elasticsearch.xpack.relevancesearch.settings.relevance.RelevanceSettings;
+import org.elasticsearch.xpack.relevancesearch.settings.relevance.RelevanceSettingsService;
 import org.elasticsearch.xpack.searchbusinessrules.PinnedQueryBuilder;
 
 import java.io.IOException;
@@ -97,7 +98,8 @@ public class RelevanceMatchQueryRewriterTests extends AbstractBuilderTestCase {
         assertEquals(expectedQuery, obtainedQuery);
     }
 
-    public void testQueryWithCurationsPinnedAndHiddenDocs() throws IOException, CurationsService.CurationsSettingsNotFoundException {
+    public void testQueryWithCurationsPinnedAndHiddenDocs() throws IOException, AbstractSettingsService.SettingsNotFoundException,
+        AbstractSettingsService.InvalidSettingsException {
 
         final String queryText = "matching";
         queryBuilder.setQuery(queryText);
@@ -130,7 +132,8 @@ public class RelevanceMatchQueryRewriterTests extends AbstractBuilderTestCase {
         assertEquals(expectedQuery, obtainedQuery);
     }
 
-    public void testQueryWithCurationsNoHiddenDocs() throws IOException, CurationsService.CurationsSettingsNotFoundException {
+    public void testQueryWithCurationsNoHiddenDocs() throws IOException, AbstractSettingsService.SettingsNotFoundException,
+        AbstractSettingsService.InvalidSettingsException {
 
         final String queryText = "matching";
         queryBuilder.setQuery(queryText);
@@ -150,7 +153,8 @@ public class RelevanceMatchQueryRewriterTests extends AbstractBuilderTestCase {
         assertEquals(expectedQuery, obtainedQuery);
     }
 
-    public void testQueryWithCurationsNoPinnedDocs() throws IOException, CurationsService.CurationsSettingsNotFoundException {
+    public void testQueryWithCurationsNoPinnedDocs() throws IOException, AbstractSettingsService.SettingsNotFoundException,
+        AbstractSettingsService.InvalidSettingsException {
 
         final String queryText = "matching";
         queryBuilder.setQuery(queryText);
@@ -177,7 +181,8 @@ public class RelevanceMatchQueryRewriterTests extends AbstractBuilderTestCase {
         assertEquals(expectedQuery, obtainedQuery);
     }
 
-    public void testQueryWithCurationDoesNotMatchQuery() throws IOException, CurationsService.CurationsSettingsNotFoundException {
+    public void testQueryWithCurationDoesNotMatchQuery() throws IOException, AbstractSettingsService.SettingsNotFoundException,
+        AbstractSettingsService.InvalidSettingsException {
 
         final String queryText = "matching";
         queryBuilder.setQuery(queryText);
@@ -202,15 +207,14 @@ public class RelevanceMatchQueryRewriterTests extends AbstractBuilderTestCase {
         relevanceSettings.setQueryConfiguration(queryConfiguration);
 
         try {
-            when(relevanceSettingsService.getRelevanceSettings(RELEVANCE_SETTINGS_ID)).thenReturn(relevanceSettings);
-        } catch (RelevanceSettingsService.RelevanceSettingsNotFoundException
-            | RelevanceSettingsService.RelevanceSettingsInvalidException e) {
+            when(relevanceSettingsService.getSettings(RELEVANCE_SETTINGS_ID)).thenReturn(relevanceSettings);
+        } catch (RelevanceSettingsService.SettingsNotFoundException | RelevanceSettingsService.InvalidSettingsException e) {
             // Can't happen at mock definition
         }
     }
 
     private void setCurationsSettings(boolean withPinnedDocs, boolean withHiddenDocs, String queryToMatch)
-        throws CurationsService.CurationsSettingsNotFoundException {
+        throws CurationsService.SettingsNotFoundException, AbstractSettingsService.InvalidSettingsException {
 
         queryBuilder.setCurationsSettingsId(CURATION_SETTINGS_ID);
 
@@ -237,7 +241,7 @@ public class RelevanceMatchQueryRewriterTests extends AbstractBuilderTestCase {
 
         CurationSettings curationSettings = new CurationSettings(pinnedDocs, hiddenDocs, conditions);
 
-        when(curationsService.getCurationsSettings(CURATION_SETTINGS_ID)).thenReturn(curationSettings);
+        when(curationsService.getSettings(CURATION_SETTINGS_ID)).thenReturn(curationSettings);
     }
 
 }

--- a/x-pack/plugin/relevance-search/src/test/java/org/elasticsearch/xpack/relevancesearch/settings/relevance/QueryConfigurationTests.java
+++ b/x-pack/plugin/relevance-search/src/test/java/org/elasticsearch/xpack/relevancesearch/settings/relevance/QueryConfigurationTests.java
@@ -28,10 +28,7 @@ public class QueryConfigurationTests extends ESTestCase {
     public void testParsingFieldsAndBoostsWithInvalidBoost() {
         List<String> fields = List.of("foo^bar");
         QueryConfiguration queryConfiguration = new QueryConfiguration();
-        expectThrows(
-            RelevanceSettingsService.InvalidSettingsException.class,
-            () -> queryConfiguration.parseFieldsAndBoosts(fields)
-        );
+        expectThrows(RelevanceSettingsService.InvalidSettingsException.class, () -> queryConfiguration.parseFieldsAndBoosts(fields));
     }
 
 }

--- a/x-pack/plugin/relevance-search/src/test/java/org/elasticsearch/xpack/relevancesearch/settings/relevance/QueryConfigurationTests.java
+++ b/x-pack/plugin/relevance-search/src/test/java/org/elasticsearch/xpack/relevancesearch/settings/relevance/QueryConfigurationTests.java
@@ -5,18 +5,17 @@
  * 2.0.
  */
 
-package org.elasticsearch.xpack.relevancesearch.relevance;
+package org.elasticsearch.xpack.relevancesearch.settings.relevance;
 
 import org.elasticsearch.index.query.AbstractQueryBuilder;
 import org.elasticsearch.test.ESTestCase;
-import org.elasticsearch.xpack.relevancesearch.relevance.settings.RelevanceSettingsService;
 
 import java.util.List;
 import java.util.Map;
 
 public class QueryConfigurationTests extends ESTestCase {
 
-    public void testParsingFieldsAndBoosts() throws RelevanceSettingsService.RelevanceSettingsInvalidException {
+    public void testParsingFieldsAndBoosts() throws RelevanceSettingsService.InvalidSettingsException {
         List<String> fields = List.of("foo^2.5", "bar^5", "foobar");
         QueryConfiguration queryConfiguration = new QueryConfiguration();
         queryConfiguration.parseFieldsAndBoosts(fields);
@@ -30,7 +29,7 @@ public class QueryConfigurationTests extends ESTestCase {
         List<String> fields = List.of("foo^bar");
         QueryConfiguration queryConfiguration = new QueryConfiguration();
         expectThrows(
-            RelevanceSettingsService.RelevanceSettingsInvalidException.class,
+            RelevanceSettingsService.InvalidSettingsException.class,
             () -> queryConfiguration.parseFieldsAndBoosts(fields)
         );
     }


### PR DESCRIPTION
I started doing some refactor that eventually led to this...

Basically, it groups together code from the CurationsService and RelevanceSettingsService into an abstract class that returns a Settings object.

I've also separated the code for creating the index into its own service, being invoked by the other.

LMK if this is too much refactoring for our demo 😉 