### PR TITLE
Log cause when warning about moving to error step

### DIFF
--- a/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/ExecuteStepsUpdateTask.java
+++ b/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/ExecuteStepsUpdateTask.java
@@ -275,10 +275,13 @@ public class ExecuteStepsUpdateTask extends IndexLifecycleClusterStateUpdateTask
     private ClusterState moveToErrorStep(final ClusterState state, Step.StepKey currentStepKey, Exception cause) {
         this.failure = cause;
         logger.warn(
-            "policy [{}] for index [{}] failed on cluster state step [{}]. Moving to ERROR step",
-            policy,
-            index.getName(),
-            currentStepKey
+            () -> format(
+                "policy [%s] for index [%s] failed on cluster state step [%s]. Moving to ERROR step",
+                policy,
+                index.getName(),
+                currentStepKey
+            ),
+            cause
         );
         return IndexLifecycleTransition.moveClusterStateToErrorStep(index, state, cause, nowSupplier, policyStepsRegistry::getStep);
     }


### PR DESCRIPTION
Log cause when moving an index to the error step. The underlying exception isn't always logged somewhere else and it's impossible to debug these indices without the full exception logged anywhere.
