### PR TITLE
Make extendedPlugins, HasNativeController and moduleName optional in plugin descriptor

### DIFF
--- a/build-tools/src/integTest/groovy/org/elasticsearch/gradle/plugin/PluginBuildPluginFuncTest.groovy
+++ b/build-tools/src/integTest/groovy/org/elasticsearch/gradle/plugin/PluginBuildPluginFuncTest.groovy
@@ -119,12 +119,13 @@ class PluginBuildPluginFuncTest extends AbstractGradleFuncTest {
         props.get("version") == "1.2.3"
         props.get("description") == "test plugin"
         props.get("classname") == "com.acme.plugin.TestPlugin"
-        props.get("modulename") == ""
         props.get("java.version") == Integer.toString(Runtime.version().feature())
         props.get("elasticsearch.version") == VersionProperties.elasticsearchVersion.toString()
-        props.get("extended.plugins") == ""
-        props.get("has.native.controller") == "false"
-        props.size() == 9
+
+        props.get("has.native.controller") == null
+        props.get("extended.plugins") == null
+        props.get("modulename") == null
+        props.size() == 6
     }
 
     def "module name is inferred by plugin properties"() {

--- a/build-tools/src/integTest/groovy/org/elasticsearch/gradle/plugin/StableBuildPluginPluginFuncTest.groovy
+++ b/build-tools/src/integTest/groovy/org/elasticsearch/gradle/plugin/StableBuildPluginPluginFuncTest.groovy
@@ -46,17 +46,18 @@ class StableBuildPluginPluginFuncTest extends AbstractGradleFuncTest {
 
         then:
         result.task(":pluginProperties").outcome == TaskOutcome.SUCCESS
-        props.get("classname") == null
 
         props.get("name") == "myplugin"
         props.get("version") == "1.2.3"
         props.get("description") == "test plugin"
-        props.get("modulename") == ""
         props.get("java.version") == Integer.toString(Runtime.version().feature())
         props.get("elasticsearch.version") == VersionProperties.elasticsearchVersion.toString()
-        props.get("extended.plugins") == ""
-        props.get("has.native.controller") == "false"
-        props.size() == 8
+
+        props.get("classname") == null
+        props.get("modulename") == null
+        props.get("extended.plugins") == null
+        props.get("has.native.controller") == null
+        props.size() == 5
 
     }
 

--- a/build-tools/src/main/resources/plugin-descriptor.properties
+++ b/build-tools/src/main/resources/plugin-descriptor.properties
@@ -24,18 +24,6 @@ version=${version}
 #
 # 'name': the plugin name
 name=${name}
-
-<% if (classname) { %>
-#
-# 'classname': the name of the class to load, fully-qualified. Only applies to
-# "isolated" plugins
-classname=${classname}
-<% } %>
-#
-# 'modulename': the name of the module to load classname from. Only applies to
-# "isolated" plugins. This is optional. Specifying it causes the plugin
-# to be loaded as a module.
-modulename=${modulename}
 #
 # 'java.version': version of java the code is built against
 # use the system property java.specification.version
@@ -46,12 +34,29 @@ java.version=${javaVersion}
 # 'elasticsearch.version': version of elasticsearch compiled against
 elasticsearch.version=${elasticsearchVersion}
 ### optional elements for plugins:
+<% if (classname) { %>
+#
+# 'classname': the name of the class to load, fully-qualified. Only applies to
+# "isolated" plugins
+classname=${classname}
+<% } %>
+<% if (modulename) { %>
+#
+# 'modulename': the name of the module to load classname from. Only applies to
+# "isolated" plugins. This is optional. Specifying it causes the plugin
+# to be loaded as a module.
+modulename=${modulename}
+<% } %>
+<% if (extendedPlugins) { %>
 #
 #  'extended.plugins': other plugins this plugin extends through SPI
 extended.plugins=${extendedPlugins}
+<% } %>
+<% if (hasNativeController) { %>
 #
 # 'has.native.controller': whether or not the plugin has a native controller
 has.native.controller=${hasNativeController}
+<% } %>
 <% if (licensed) { %>
 # This plugin requires that a license agreement be accepted before installation
 licensed=${licensed}

--- a/docs/changelog/90835.yaml
+++ b/docs/changelog/90835.yaml
@@ -1,0 +1,6 @@
+pr: 90835
+summary: "Make `extendedPlugins,` `HasNativeController` and `moduleName` optional\
+  \ in plugin descriptor"
+area: Infra/Plugins
+type: enhancement
+issues: []


### PR DESCRIPTION
Stable plugins do not use className, extendedPlugins and hasNativeController properties. They also don't necessarily have moduleName.
These properties should not be present in stable-plugin-descriptor, even if they are empty because the parsing will fail complaining about unused properties.

Old plugins can use these properties, but they use defaults when the property is not present These defaults are:
has.native.controller = false
extended.plugins = emptyList
moduleName = null
classname is required and will throw exception when old plugin is not configuring this property

relates #88980

<!--
Thank you for your interest in and contributing to Elasticsearch! There
are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your
attention.
-->

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/elasticsearch/blob/main/CONTRIBUTING.md)?
- If submitting code, have you built your formula locally prior to submission with `gradle check`?
- If submitting code, is your pull request against main? Unless there is a good reason otherwise, we prefer pull requests against main and will backport as needed.
- If submitting code, have you checked that your submission is for an [OS and architecture that we support](https://www.elastic.co/support/matrix#show_os)?
- If you are submitting this code for a class then read our [policy](https://github.com/elastic/elasticsearch/blob/main/CONTRIBUTING.md#contributing-as-part-of-a-class) for that.
