### PR TITLE
[ML] Consistently use model_id over deployment_id

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/ClearDeploymentCacheAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/ClearDeploymentCacheAction.java
@@ -31,30 +31,30 @@ public class ClearDeploymentCacheAction extends ActionType<ClearDeploymentCacheA
     }
 
     public static class Request extends BaseTasksRequest<Request> {
-        private final String deploymentId;
+        private final String modelId;
 
-        public Request(String deploymentId) {
-            this.deploymentId = ExceptionsHelper.requireNonNull(deploymentId, "deployment_id");
+        public Request(String modelId) {
+            this.modelId = ExceptionsHelper.requireNonNull(modelId, InferModelAction.Request.MODEL_ID);
         }
 
         public Request(StreamInput in) throws IOException {
             super(in);
-            this.deploymentId = in.readString();
+            this.modelId = in.readString();
         }
 
         @Override
         public void writeTo(StreamOutput out) throws IOException {
             super.writeTo(out);
-            out.writeString(deploymentId);
+            out.writeString(modelId);
         }
 
-        public String getDeploymentId() {
-            return deploymentId;
+        public String getModelId() {
+            return modelId;
         }
 
         @Override
         public boolean match(Task task) {
-            return StartTrainedModelDeploymentAction.TaskMatcher.match(task, deploymentId);
+            return StartTrainedModelDeploymentAction.TaskMatcher.match(task, modelId);
         }
 
         @Override
@@ -62,12 +62,12 @@ public class ClearDeploymentCacheAction extends ActionType<ClearDeploymentCacheA
             if (this == o) return true;
             if (o == null || getClass() != o.getClass()) return false;
             Request request = (Request) o;
-            return Objects.equals(deploymentId, request.deploymentId);
+            return Objects.equals(modelId, request.modelId);
         }
 
         @Override
         public int hashCode() {
-            return Objects.hash(deploymentId);
+            return Objects.hash(modelId);
         }
     }
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/GetDeploymentStatsAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/GetDeploymentStatsAction.java
@@ -38,30 +38,30 @@ public class GetDeploymentStatsAction extends ActionType<GetDeploymentStatsActio
 
     public static class Request extends BaseTasksRequest<GetDeploymentStatsAction.Request> {
 
-        private final String deploymentId;
+        private final String modelId;
         // used internally this should not be set by the REST request
         private List<String> expandedIds;
 
-        public Request(String deploymentId) {
-            this.deploymentId = ExceptionsHelper.requireNonNull(deploymentId, "deployment_id");
-            this.expandedIds = Collections.singletonList(deploymentId);
+        public Request(String modelId) {
+            this.modelId = ExceptionsHelper.requireNonNull(modelId, InferModelAction.Request.MODEL_ID);
+            this.expandedIds = Collections.singletonList(modelId);
         }
 
         public Request(StreamInput in) throws IOException {
             super(in);
-            this.deploymentId = in.readString();
+            this.modelId = in.readString();
             this.expandedIds = in.readStringList();
         }
 
         @Override
         public void writeTo(StreamOutput out) throws IOException {
             super.writeTo(out);
-            out.writeString(deploymentId);
+            out.writeString(modelId);
             out.writeStringCollection(expandedIds);
         }
 
-        public String getDeploymentId() {
-            return deploymentId;
+        public String getModelId() {
+            return modelId;
         }
 
         public void setExpandedIds(List<String> expandedIds) {
@@ -78,12 +78,12 @@ public class GetDeploymentStatsAction extends ActionType<GetDeploymentStatsActio
             if (this == o) return true;
             if (o == null || getClass() != o.getClass()) return false;
             Request request = (Request) o;
-            return Objects.equals(deploymentId, request.deploymentId) && Objects.equals(expandedIds, request.expandedIds);
+            return Objects.equals(modelId, request.modelId) && Objects.equals(expandedIds, request.expandedIds);
         }
 
         @Override
         public int hashCode() {
-            return Objects.hash(deploymentId, expandedIds);
+            return Objects.hash(modelId, expandedIds);
         }
     }
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/InferModelAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/InferModelAction.java
@@ -66,10 +66,10 @@ public class InferModelAction extends ActionType<InferModelAction.Response> {
             );
         }
 
-        public static Builder parseRequest(String deploymentId, XContentParser parser) {
+        public static Builder parseRequest(String modelId, XContentParser parser) {
             Builder builder = PARSER.apply(parser, null);
-            if (deploymentId != null) {
-                builder.setModelId(deploymentId);
+            if (modelId != null) {
+                builder.setModelId(modelId);
             }
             return builder;
         }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/utils/ExceptionsHelper.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/utils/ExceptionsHelper.java
@@ -49,10 +49,6 @@ public class ExceptionsHelper {
         return new ResourceNotFoundException("No known trained model with model_id [{}]", modelId);
     }
 
-    public static ResourceNotFoundException missingDeployment(String deploymentId) {
-        return new ResourceNotFoundException("No known trained model with deployment with id [{}]", deploymentId);
-    }
-
     public static ResourceNotFoundException missingTrainedModel(String modelId, Exception cause) {
         return new ResourceNotFoundException("No known trained model with model_id [{}]", cause, modelId);
     }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportClearDeploymentCacheAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportClearDeploymentCacheAction.java
@@ -70,9 +70,9 @@ public class TransportClearDeploymentCacheAction extends TransportTasksAction<Tr
     protected void doExecute(Task task, Request request, ActionListener<Response> listener) {
         final ClusterState clusterState = clusterService.state();
         final TrainedModelAssignmentMetadata assignment = TrainedModelAssignmentMetadata.fromState(clusterState);
-        TrainedModelAssignment trainedModelAssignment = assignment.getModelAssignment(request.getDeploymentId());
+        TrainedModelAssignment trainedModelAssignment = assignment.getModelAssignment(request.getModelId());
         if (trainedModelAssignment == null) {
-            listener.onFailure(new ResourceNotFoundException("assignment for model with id [{}] not found", request.getDeploymentId()));
+            listener.onFailure(new ResourceNotFoundException("assignment for model with id [{}] not found", request.getModelId()));
             return;
         }
         String[] nodes = trainedModelAssignment.getNodeRoutingTable()

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/pytorch/process/PyTorchResultProcessor.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/pytorch/process/PyTorchResultProcessor.java
@@ -48,7 +48,7 @@ public class PyTorchResultProcessor {
     static long REPORTING_PERIOD_MS = TimeValue.timeValueMinutes(1).millis();
 
     private final ConcurrentMap<String, PendingResult> pendingResults = new ConcurrentHashMap<>();
-    private final String deploymentId;
+    private final String modelId;
     private final Consumer<ThreadSettings> threadSettingsConsumer;
     private volatile boolean isStopping;
     private final LongSummaryStatistics timingStats;
@@ -65,13 +65,13 @@ public class PyTorchResultProcessor {
     private final long startTime;
     private final LongSupplier currentTimeMsSupplier;
 
-    public PyTorchResultProcessor(String deploymentId, Consumer<ThreadSettings> threadSettingsConsumer) {
-        this(deploymentId, threadSettingsConsumer, System::currentTimeMillis);
+    public PyTorchResultProcessor(String modelId, Consumer<ThreadSettings> threadSettingsConsumer) {
+        this(modelId, threadSettingsConsumer, System::currentTimeMillis);
     }
 
     // for testing
-    PyTorchResultProcessor(String deploymentId, Consumer<ThreadSettings> threadSettingsConsumer, LongSupplier currentTimeSupplier) {
-        this.deploymentId = Objects.requireNonNull(deploymentId);
+    PyTorchResultProcessor(String modelId, Consumer<ThreadSettings> threadSettingsConsumer, LongSupplier currentTimeSupplier) {
+        this.modelId = Objects.requireNonNull(modelId);
         this.timingStats = new LongSummaryStatistics();
         this.timingStatsExcludingCacheHits = new LongSummaryStatistics();
         this.lastPeriodSummaryStats = new LongSummaryStatistics();
@@ -119,7 +119,7 @@ public class PyTorchResultProcessor {
         } catch (Exception e) {
             // No need to report error as we're stopping
             if (isStopping == false) {
-                logger.error(() -> "[" + deploymentId + "] Error processing results", e);
+                logger.error(() -> "[" + modelId + "] Error processing results", e);
             }
             pendingResults.forEach(
                 (id, pendingResult) -> pendingResult.listener.onResponse(
@@ -147,7 +147,7 @@ public class PyTorchResultProcessor {
             );
             pendingResults.clear();
         }
-        logger.debug(() -> "[" + deploymentId + "] Results processing finished");
+        logger.debug(() -> "[" + modelId + "] Results processing finished");
     }
 
     void processInferenceResult(PyTorchResult result) {
@@ -159,11 +159,11 @@ public class PyTorchResultProcessor {
             timeMs = 0L;
         }
 
-        logger.trace(() -> format("[%s] Parsed inference result with id [%s]", deploymentId, result.requestId()));
+        logger.trace(() -> format("[%s] Parsed inference result with id [%s]", modelId, result.requestId()));
         updateStats(timeMs, Boolean.TRUE.equals(result.isCacheHit()));
         PendingResult pendingResult = pendingResults.remove(result.requestId());
         if (pendingResult == null) {
-            logger.debug(() -> format("[%s] no pending result for inference [%s]", deploymentId, result.requestId()));
+            logger.debug(() -> format("[%s] no pending result for inference [%s]", modelId, result.requestId()));
         } else {
             pendingResult.listener.onResponse(result);
         }
@@ -173,10 +173,10 @@ public class PyTorchResultProcessor {
         ThreadSettings threadSettings = result.threadSettings();
         assert threadSettings != null;
 
-        logger.trace(() -> format("[%s] Parsed thread settings result with id [%s]", deploymentId, result.requestId()));
+        logger.trace(() -> format("[%s] Parsed thread settings result with id [%s]", modelId, result.requestId()));
         PendingResult pendingResult = pendingResults.remove(result.requestId());
         if (pendingResult == null) {
-            logger.debug(() -> format("[%s] no pending result for thread settings [%s]", deploymentId, result.requestId()));
+            logger.debug(() -> format("[%s] no pending result for thread settings [%s]", modelId, result.requestId()));
         } else {
             pendingResult.listener.onResponse(result);
         }
@@ -186,10 +186,10 @@ public class PyTorchResultProcessor {
         AckResult ack = result.ackResult();
         assert ack != null;
 
-        logger.trace(() -> format("[%s] Parsed ack result with id [%s]", deploymentId, result.requestId()));
+        logger.trace(() -> format("[%s] Parsed ack result with id [%s]", modelId, result.requestId()));
         PendingResult pendingResult = pendingResults.remove(result.requestId());
         if (pendingResult == null) {
-            logger.debug(() -> format("[%s] no pending result for ack [%s]", deploymentId, result.requestId()));
+            logger.debug(() -> format("[%s] no pending result for ack [%s]", modelId, result.requestId()));
         } else {
             pendingResult.listener.onResponse(result);
         }
@@ -204,10 +204,10 @@ public class PyTorchResultProcessor {
             errorCount++;
         }
 
-        logger.trace(() -> format("[%s] Parsed error with id [%s]", deploymentId, result.requestId()));
+        logger.trace(() -> format("[%s] Parsed error with id [%s]", modelId, result.requestId()));
         PendingResult pendingResult = pendingResults.remove(result.requestId());
         if (pendingResult == null) {
-            logger.debug(() -> format("[%s] no pending result for error [%s]", deploymentId, result.requestId()));
+            logger.debug(() -> format("[%s] no pending result for error [%s]", modelId, result.requestId()));
         } else {
             pendingResult.listener.onResponse(result);
         }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/rest/inference/RestInferTrainedModelDeploymentAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/rest/inference/RestInferTrainedModelDeploymentAction.java
@@ -56,12 +56,12 @@ public class RestInferTrainedModelDeploymentAction extends BaseRestHandler {
 
     @Override
     protected RestChannelConsumer prepareRequest(RestRequest restRequest, NodeClient client) throws IOException {
-        String deploymentId = restRequest.param(TrainedModelConfig.MODEL_ID.getPreferredName());
+        String modelId = restRequest.param(TrainedModelConfig.MODEL_ID.getPreferredName());
         if (restRequest.hasContent() == false) {
             throw ExceptionsHelper.badRequestException("requires body");
         }
         InferTrainedModelDeploymentAction.Request.Builder request = InferTrainedModelDeploymentAction.Request.parseRequest(
-            deploymentId,
+            modelId,
             restRequest.contentParser()
         );
 


### PR DESCRIPTION
The docs and REST endpoints use `model_id` to name the parameter in the trained model APIs (start/stop deployment, infer, etc) and the error messages in code also use the term `model_id`. This is a simple rename of the variables used in internal code from deployment Id to model Id. 

The concept of a deployment remains, a deployment is reference by the model Id in a one-to-one mapping. This change makes that usage uniform.

