### PR TITLE
[ML] Wait for allocation count assertion in decrease allocations test

### DIFF
--- a/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/PyTorchModelIT.java
+++ b/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/PyTorchModelIT.java
@@ -946,7 +946,7 @@ public class PyTorchModelIT extends ESRestTestCase {
         putVocabulary(List.of("these", "are", "my", "words"), modelId);
         startDeployment(modelId, "started", 2, 1);
 
-        assertAllocationCount(modelId, 2);
+        assertBusy(() -> assertAllocationCount(modelId, 2));
 
         updateDeployment(modelId, 1);
 

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/assignment/planning/AllocationReducer.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/assignment/planning/AllocationReducer.java
@@ -20,6 +20,8 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import static org.elasticsearch.core.Strings.format;
+
 /**
  * Reduces the number of allocations of a {@link TrainedModelAssignment}.
  */
@@ -101,10 +103,26 @@ public class AllocationReducer {
                 largestZoneAllocations,
                 allocationsToRemove
             )) {
+                logger.debug(
+                    () -> format(
+                        "[%s] removing assignment with [%s] allocations on node [%s]",
+                        assignment.getModelId(),
+                        smallestAssignmentInLargestZone.getValue(),
+                        smallestAssignmentInLargestZone.getKey()
+                    )
+                );
                 allocationsByNode.remove(smallestAssignmentInLargestZone.getKey());
                 allocationsByZone.computeIfPresent(largestZone, (k, v) -> v - smallestAssignmentInLargestZone.getValue());
                 totalRemainingAllocations -= smallestAssignmentInLargestZone.getValue();
             } else {
+                logger.debug(
+                    () -> format(
+                        "[%s] removing 1 allocation from assignment with [%s] allocations on node [%s]",
+                        assignment.getModelId(),
+                        smallestAssignmentInLargestZone.getValue(),
+                        smallestAssignmentInLargestZone.getKey()
+                    )
+                );
                 allocationsByNode.computeIfPresent(smallestAssignmentInLargestZone.getKey(), (k, v) -> v - 1);
                 allocationsByZone.computeIfPresent(largestZone, (k, v) -> v - 1);
                 totalRemainingAllocations -= 1;


### PR DESCRIPTION
This fixes `PyTorchModelIT.testUpdateDeployment_GivenAllocationsAreDecreased` which fails when run in nodes with a single processor. The reason it fails is that right after we start the 2-allocation deployment, we assert the allocation count is `2`. But we do so without `assertBusy`. As the deployment needs to be assigned on both ML nodes, we need to give it some time to be fully allocated.

Fixes #90841 