### PR TITLE
[ML] Audit rebalance message after deployment allocations are increased

### DIFF
--- a/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/PyTorchModelIT.java
+++ b/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/PyTorchModelIT.java
@@ -895,6 +895,7 @@ public class PyTorchModelIT extends ESRestTestCase {
         updateDeployment(modelId, 2);
 
         assertBusy(() -> assertAllocationCount(modelId, 2));
+        assertSystemNotificationsContain("Rebalanced trained model allocations because [model deployment updated]");
     }
 
     public void testUpdateDeployment_GivenAllocationsAreIncreasedOverResources_AndScalingIsPossible() throws Exception {


### PR DESCRIPTION
This commit adds an audit message that a rebalance was performed after a deployment is updated to have more allocations than before.
