### PR TITLE
Run aggs tests in aggs module

### DIFF
--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/rest/compat/YamlRestCompatTestPlugin.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/rest/compat/YamlRestCompatTestPlugin.java
@@ -58,6 +58,7 @@ public class YamlRestCompatTestPlugin implements Plugin<Project> {
     private static final Path RELATIVE_API_PATH = Path.of("rest-api-spec/api");
     private static final Path RELATIVE_TEST_PATH = Path.of("rest-api-spec/test");
     private static final Path RELATIVE_REST_API_RESOURCES = Path.of("rest-api-spec/src/main/resources");
+    private static final Path RELATIVE_REST_CORE = Path.of("rest-api-spec");
     private static final Path RELATIVE_REST_XPACK_RESOURCES = Path.of("x-pack/plugin/src/test/resources");
     private static final Path RELATIVE_REST_PROJECT_RESOURCES = Path.of("src/yamlRestTest/resources");
     private static final int COMPATIBLE_VERSION = Version.fromString(VersionProperties.getVersions().get("elasticsearch")).getMajor() - 1;
@@ -142,7 +143,11 @@ public class YamlRestCompatTestPlugin implements Plugin<Project> {
                 task.getOutputResourceDir().set(projectLayout.getBuildDirectory().dir(compatTestsDir.resolve("original").toString()));
                 task.setCoreConfigToFileTree(
                     config -> fileOperations.fileTree(
-                        config.getSingleFile().toPath().resolve(RELATIVE_REST_API_RESOURCES).resolve(RELATIVE_TEST_PATH)
+                        config.getSingleFile()
+                            .toPath()
+                            .resolve(RELATIVE_REST_CORE)
+                            .resolve(RELATIVE_REST_PROJECT_RESOURCES)
+                            .resolve(RELATIVE_TEST_PATH)
                     )
                 );
                 task.setXpackConfigToFileTree(

--- a/modules/aggregations/build.gradle
+++ b/modules/aggregations/build.gradle
@@ -18,4 +18,23 @@ restResources {
   restApi {
     include '_common', 'indices', 'cluster', 'index', 'search', 'nodes', 'bulk'
   }
+  restTests {
+    // Pulls in all aggregation tests from core AND the forwards v7's core for forwards compatibility
+    includeCore 'search.aggregation'
+  }
+}
+
+artifacts {
+  restTests(new File(projectDir, "src/yamlRestTest/resources/rest-api-spec/test"))
+}
+
+tasks.named("yamlRestTestV7CompatTransform").configure { task ->
+  task.skipTest("search.aggregation/20_terms/string profiler via global ordinals filters implementation", "The profiler results aren't backwards compatible.")
+  task.skipTest("search.aggregation/20_terms/string profiler via global ordinals native implementation", "The profiler results aren't backwards compatible.")
+  task.skipTest("search.aggregation/20_terms/string profiler via map", "The profiler results aren't backwards compatible.")
+  task.skipTest("search.aggregation/20_terms/numeric profiler", "The profiler results aren't backwards compatible.")
+  task.skipTest("search.aggregation/210_top_hits_nested_metric/top_hits aggregation with sequence numbers", "#42809 the use nested path and filter sort throws an exception")
+  task.skipTest("search.aggregation/370_doc_count_field/Test filters agg with doc_count", "Uses profiler for assertions which is not backwards compatible")
+
+  task.addAllowedWarningRegex("\\[types removal\\].*")
 }

--- a/modules/aggregations/build.gradle
+++ b/modules/aggregations/build.gradle
@@ -24,10 +24,6 @@ restResources {
   }
 }
 
-artifacts {
-  restTests(new File(projectDir, "src/yamlRestTest/resources/rest-api-spec/test"))
-}
-
 tasks.named("yamlRestTestV7CompatTransform").configure { task ->
   task.skipTest("search.aggregation/20_terms/string profiler via global ordinals filters implementation", "The profiler results aren't backwards compatible.")
   task.skipTest("search.aggregation/20_terms/string profiler via global ordinals native implementation", "The profiler results aren't backwards compatible.")
@@ -37,4 +33,8 @@ tasks.named("yamlRestTestV7CompatTransform").configure { task ->
   task.skipTest("search.aggregation/370_doc_count_field/Test filters agg with doc_count", "Uses profiler for assertions which is not backwards compatible")
 
   task.addAllowedWarningRegex("\\[types removal\\].*")
+}
+
+artifacts {
+  restTests(new File(projectDir, "src/yamlRestTest/resources/rest-api-spec/test"))
 }

--- a/rest-api-spec/build.gradle
+++ b/rest-api-spec/build.gradle
@@ -35,9 +35,6 @@ artifacts {
 
 testClusters.configureEach {
   module ':modules:mapper-extras'
-  // This dependency can be removed when aggregations and
-  // respective yaml test have been moved to aggregations module.
-  // See for the progress: https://github.com/elastic/elasticsearch/issues/90283
   requiresFeature 'es.index_mode_feature_flag_registered', Version.fromString("8.0.0")
 }
 

--- a/rest-api-spec/build.gradle
+++ b/rest-api-spec/build.gradle
@@ -38,7 +38,6 @@ testClusters.configureEach {
   // This dependency can be removed when aggregations and
   // respective yaml test have been moved to aggregations module.
   // See for the progress: https://github.com/elastic/elasticsearch/issues/90283
-  module ':modules:aggregations'
   requiresFeature 'es.index_mode_feature_flag_registered', Version.fromString("8.0.0")
 }
 
@@ -47,6 +46,7 @@ tasks.named("yamlRestTestV7CompatTransform").configure { task ->
   task.skipTestsByFilePattern("**/cat*/*.yml", "Cat API are meant to be consumed by humans, so will not be supported by Compatible REST API")
   task.skipTestsByFilePattern("**/indices.upgrade/*.yml", "upgrade api will only get a dummy endpoint returning an exception suggesting to use _reindex")
   task.skipTestsByFilePattern("**/indices.stats/60_field_usage/*/*.yml", "field usage results will be different between lucene versions")
+  task.skipTestsByFilePattern("**/search.aggregation/*.yml", "run by the aggregation module")
 
   task.skipTest("bulk/11_dynamic_templates/Dynamic templates", "Error message has changed")
   task.skipTest("indices.create/20_mix_typeless_typeful/Implicitly create a typed index while there is a typeless template", "Type information about the type is removed and not passed down. The logic to check for this is also removed.")
@@ -70,18 +70,12 @@ tasks.named("yamlRestTestV7CompatTransform").configure { task ->
   task.skipTest("indices.stats/20_translog/Translog retention settings are deprecated", "translog settings removal is not supported under compatible api")
   task.skipTest("indices.stats/20_translog/Translog retention without soft_deletes", "translog settings removal is not supported under compatible api")
   task.skipTest("indices.stats/20_translog/Translog stats on closed indices without soft-deletes", "translog settings removal is not supported under compatible api")
-  task.skipTest("search.aggregation/370_doc_count_field/Test filters agg with doc_count", "Uses profiler for assertions which is not backwards compatible")
   task.skipTest("indices.create/10_basic/Create index without soft deletes", "Make soft-deletes mandatory in 8.0 #51122 - settings changes are note supported in Rest Api compatibility")
   task.skipTest("field_caps/30_filter/Field caps with index filter", "behaviour change after #63692 4digits dates are parsed as epoch and in quotes as year")
   task.skipTest("indices.forcemerge/10_basic/Check deprecation warning when incompatible only_expunge_deletes and max_num_segments values are both set", "#44761 bug fix")
   task.skipTest("search/340_type_query/type query", "#47207 type query throws exception in compatible mode")
-  task.skipTest("search.aggregation/210_top_hits_nested_metric/top_hits aggregation with sequence numbers", "#42809 the use nested path and filter sort throws an exception")
   task.skipTest("search/310_match_bool_prefix/multi_match multiple fields with cutoff_frequency throws exception", "#42654 cutoff_frequency, common terms are not supported. Throwing an exception")
   task.skipTest("search_shards/10_basic/Search shards aliases with and without filters", "Filter representation no longer outputs default boosts")
-  task.skipTest("search.aggregation/20_terms/string profiler via global ordinals filters implementation", "The profiler results aren't backwards compatible.")
-  task.skipTest("search.aggregation/20_terms/string profiler via global ordinals native implementation", "The profiler results aren't backwards compatible.")
-  task.skipTest("search.aggregation/20_terms/string profiler via map", "The profiler results aren't backwards compatible.")
-  task.skipTest("search.aggregation/20_terms/numeric profiler", "The profiler results aren't backwards compatible.")
   task.skipTest("migration/10_get_feature_upgrade_status/Get feature upgrade status", "Awaits backport")
   task.skipTest("search/330_fetch_fields/Test disable source", "Error no longer thrown")
   task.skipTest("search/240_date_nanos/doc value fields are working as expected across date and date_nanos fields", "Fetching docvalues field multiple times is no longer allowed")

--- a/x-pack/rest-resources-zip/build.gradle
+++ b/x-pack/rest-resources-zip/build.gradle
@@ -19,6 +19,7 @@ configurations {
 dependencies {
   apis project(path: ':rest-api-spec', configuration: 'restSpecs')
   freeTests project(path: ':rest-api-spec', configuration: 'restTests')
+  freeTests project(path: ':modules:aggregations', configuration: 'restTests')
   compatApis project(path: ':rest-api-spec', configuration: 'restCompatSpecs')
   compatApis project(path: ':x-pack:plugin', configuration: 'restCompatSpecs')
   freeCompatTests project(path: ':rest-api-spec', configuration: 'restCompatTests')


### PR DESCRIPTION
Run the aggregations tests v7 compat tests against the aggregations module and *not* the `rest-api-spec` module. This allows us to drop `rest-api-spec`'s dependency on the aggregations module and keep it "just the server" which is nice.

There are a few side effects here that are ok:
1. We run all aggregations REST tests in the aggregations module. Even the ones in `rest-api-spec`. This means we run them twice. We plan to move all of the aggregations REST tests into the aggregations module anyway.
2. We now bundle the REST tests in the aggregations module into the tests that the clients run for their verification step. This should keep our clients from losing coverage.

Relates to https://github.com/elastic/elasticsearch/issues/90283
