### PR TITLE
[8.4] Upgrade bundled JDK to Java 19 (#90571)

### DIFF
--- a/build-tools-internal/version.properties
+++ b/build-tools-internal/version.properties
@@ -2,7 +2,7 @@ elasticsearch     = 8.4.4
 lucene            = 9.3.0
 
 bundled_jdk_vendor = openjdk
-bundled_jdk = 18.0.2.1+1@db379da656dc47308e138f21b33976fa
+bundled_jdk = 19+36@877d6127e982470ba2a7faa31cc93d04
 
 # optional dependencies
 spatial4j         = 0.7

--- a/docs/changelog/90571.yaml
+++ b/docs/changelog/90571.yaml
@@ -1,0 +1,5 @@
+pr: 90571
+summary: Upgrade bundled JDK to Java 19
+area: Packaging
+type: upgrade
+issues: []


### PR DESCRIPTION
Backports the following commits to 8.4:
 - Upgrade bundled JDK to Java 19 (#90571)