### PR TITLE
Remove redundant response types from SLM

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/slm/action/DeleteSnapshotLifecycleAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/slm/action/DeleteSnapshotLifecycleAction.java
@@ -13,17 +13,16 @@ import org.elasticsearch.action.support.master.AcknowledgedRequest;
 import org.elasticsearch.action.support.master.AcknowledgedResponse;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
-import org.elasticsearch.xcontent.ToXContentObject;
 
 import java.io.IOException;
 import java.util.Objects;
 
-public class DeleteSnapshotLifecycleAction extends ActionType<DeleteSnapshotLifecycleAction.Response> {
+public class DeleteSnapshotLifecycleAction extends ActionType<AcknowledgedResponse> {
     public static final DeleteSnapshotLifecycleAction INSTANCE = new DeleteSnapshotLifecycleAction();
     public static final String NAME = "cluster:admin/slm/delete";
 
     protected DeleteSnapshotLifecycleAction() {
-        super(NAME, DeleteSnapshotLifecycleAction.Response::new);
+        super(NAME, AcknowledgedResponse::readFrom);
     }
 
     public static class Request extends AcknowledgedRequest<Request> {
@@ -71,17 +70,6 @@ public class DeleteSnapshotLifecycleAction extends ActionType<DeleteSnapshotLife
             }
             Request other = (Request) obj;
             return Objects.equals(lifecycleId, other.lifecycleId);
-        }
-    }
-
-    public static class Response extends AcknowledgedResponse implements ToXContentObject {
-
-        public Response(boolean acknowledged) {
-            super(acknowledged);
-        }
-
-        public Response(StreamInput streamInput) throws IOException {
-            this(streamInput.readBoolean());
         }
     }
 }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/slm/action/PutSnapshotLifecycleAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/slm/action/PutSnapshotLifecycleAction.java
@@ -22,12 +22,12 @@ import org.elasticsearch.xpack.core.slm.SnapshotLifecyclePolicy;
 import java.io.IOException;
 import java.util.Objects;
 
-public class PutSnapshotLifecycleAction extends ActionType<PutSnapshotLifecycleAction.Response> {
+public class PutSnapshotLifecycleAction extends ActionType<AcknowledgedResponse> {
     public static final PutSnapshotLifecycleAction INSTANCE = new PutSnapshotLifecycleAction();
     public static final String NAME = "cluster:admin/slm/put";
 
     protected PutSnapshotLifecycleAction() {
-        super(NAME, PutSnapshotLifecycleAction.Response::new);
+        super(NAME, AcknowledgedResponse::readFrom);
     }
 
     public static class Request extends AcknowledgedRequest<Request> implements ToXContentObject {
@@ -100,17 +100,6 @@ public class PutSnapshotLifecycleAction extends ActionType<PutSnapshotLifecycleA
         @Override
         public String toString() {
             return Strings.toString(this);
-        }
-    }
-
-    public static class Response extends AcknowledgedResponse implements ToXContentObject {
-
-        public Response(boolean acknowledged) {
-            super(acknowledged);
-        }
-
-        public Response(StreamInput streamInput) throws IOException {
-            this(streamInput.readBoolean());
         }
     }
 }

--- a/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/slm/action/TransportDeleteSnapshotLifecycleAction.java
+++ b/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/slm/action/TransportDeleteSnapshotLifecycleAction.java
@@ -10,6 +10,7 @@ package org.elasticsearch.xpack.slm.action;
 import org.elasticsearch.ResourceNotFoundException;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.ActionFilters;
+import org.elasticsearch.action.support.master.AcknowledgedResponse;
 import org.elasticsearch.action.support.master.TransportMasterNodeAction;
 import org.elasticsearch.cluster.AckedClusterStateUpdateTask;
 import org.elasticsearch.cluster.ClusterState;
@@ -36,7 +37,7 @@ import java.util.stream.Collectors;
 
 public class TransportDeleteSnapshotLifecycleAction extends TransportMasterNodeAction<
     DeleteSnapshotLifecycleAction.Request,
-    DeleteSnapshotLifecycleAction.Response> {
+    AcknowledgedResponse> {
 
     @Inject
     public TransportDeleteSnapshotLifecycleAction(
@@ -54,7 +55,7 @@ public class TransportDeleteSnapshotLifecycleAction extends TransportMasterNodeA
             actionFilters,
             DeleteSnapshotLifecycleAction.Request::new,
             indexNameExpressionResolver,
-            DeleteSnapshotLifecycleAction.Response::new,
+            AcknowledgedResponse::readFrom,
             ThreadPool.Names.SAME
         );
     }
@@ -64,12 +65,12 @@ public class TransportDeleteSnapshotLifecycleAction extends TransportMasterNodeA
         Task task,
         DeleteSnapshotLifecycleAction.Request request,
         ClusterState state,
-        ActionListener<DeleteSnapshotLifecycleAction.Response> listener
+        ActionListener<AcknowledgedResponse> listener
     ) throws Exception {
         submitUnbatchedTask("delete-snapshot-lifecycle-" + request.getLifecycleId(), new DeleteSnapshotPolicyTask(request, listener) {
             @Override
-            protected DeleteSnapshotLifecycleAction.Response newResponse(boolean acknowledged) {
-                return new DeleteSnapshotLifecycleAction.Response(acknowledged);
+            protected AcknowledgedResponse newResponse(boolean acknowledged) {
+                return AcknowledgedResponse.of(acknowledged);
             }
         });
     }
@@ -81,10 +82,7 @@ public class TransportDeleteSnapshotLifecycleAction extends TransportMasterNodeA
     public static class DeleteSnapshotPolicyTask extends AckedClusterStateUpdateTask {
         private final DeleteSnapshotLifecycleAction.Request request;
 
-        DeleteSnapshotPolicyTask(
-            DeleteSnapshotLifecycleAction.Request request,
-            ActionListener<DeleteSnapshotLifecycleAction.Response> listener
-        ) {
+        DeleteSnapshotPolicyTask(DeleteSnapshotLifecycleAction.Request request, ActionListener<AcknowledgedResponse> listener) {
             super(request, listener);
             this.request = request;
         }

--- a/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/slm/action/TransportPutSnapshotLifecycleAction.java
+++ b/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/slm/action/TransportPutSnapshotLifecycleAction.java
@@ -11,6 +11,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.ActionFilters;
+import org.elasticsearch.action.support.master.AcknowledgedResponse;
 import org.elasticsearch.action.support.master.TransportMasterNodeAction;
 import org.elasticsearch.cluster.AckedClusterStateUpdateTask;
 import org.elasticsearch.cluster.ClusterState;
@@ -44,7 +45,7 @@ import java.util.Set;
 
 public class TransportPutSnapshotLifecycleAction extends TransportMasterNodeAction<
     PutSnapshotLifecycleAction.Request,
-    PutSnapshotLifecycleAction.Response> {
+    AcknowledgedResponse> {
 
     private static final Logger logger = LogManager.getLogger(TransportPutSnapshotLifecycleAction.class);
 
@@ -64,7 +65,7 @@ public class TransportPutSnapshotLifecycleAction extends TransportMasterNodeActi
             actionFilters,
             PutSnapshotLifecycleAction.Request::new,
             indexNameExpressionResolver,
-            PutSnapshotLifecycleAction.Response::new,
+            AcknowledgedResponse::readFrom,
             ThreadPool.Names.SAME
         );
     }
@@ -74,7 +75,7 @@ public class TransportPutSnapshotLifecycleAction extends TransportMasterNodeActi
         final Task task,
         final PutSnapshotLifecycleAction.Request request,
         final ClusterState state,
-        final ActionListener<PutSnapshotLifecycleAction.Response> listener
+        final ActionListener<AcknowledgedResponse> listener
     ) {
         SnapshotLifecycleService.validateRepositoryExists(request.getLifecycle().getRepository(), state);
 
@@ -90,8 +91,8 @@ public class TransportPutSnapshotLifecycleAction extends TransportMasterNodeActi
             "put-snapshot-lifecycle-" + request.getLifecycleId(),
             new UpdateSnapshotPolicyTask(request, listener, filteredHeaders) {
                 @Override
-                protected PutSnapshotLifecycleAction.Response newResponse(boolean acknowledged) {
-                    return new PutSnapshotLifecycleAction.Response(acknowledged);
+                protected AcknowledgedResponse newResponse(boolean acknowledged) {
+                    return AcknowledgedResponse.of(acknowledged);
                 }
             }
         );
@@ -107,7 +108,7 @@ public class TransportPutSnapshotLifecycleAction extends TransportMasterNodeActi
 
         UpdateSnapshotPolicyTask(
             PutSnapshotLifecycleAction.Request request,
-            ActionListener<PutSnapshotLifecycleAction.Response> listener,
+            ActionListener<AcknowledgedResponse> listener,
             Map<String, String> filteredHeaders
         ) {
             super(request, listener);


### PR DESCRIPTION
random find when researching things ... No need to extend the acknowledged response in both cases when we are not actually adding any functionality.
