### PR TITLE
Fix ReactiveStorageIT#testScaleWhileShrinking

### DIFF
--- a/test/framework/src/main/java/org/elasticsearch/cluster/DiskUsageIntegTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/cluster/DiskUsageIntegTestCase.java
@@ -27,6 +27,7 @@ import org.junit.Before;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.AccessDeniedException;
 import java.nio.file.DirectoryIteratorException;
 import java.nio.file.DirectoryStream;
 import java.nio.file.FileStore;
@@ -156,8 +157,8 @@ public class DiskUsageIntegTestCase extends ESIntegTestCase {
                 }
                 try {
                     return Files.size(path);
-                } catch (NoSuchFileException | FileNotFoundException e) {
-                    // probably removed
+                } catch (NoSuchFileException | FileNotFoundException | AccessDeniedException e) {
+                    // probably removed (Windows sometimes throws AccessDeniedException after a file has been deleted)
                     return 0L;
                 }
             } else if (path.getFileName().toString().equals("_state") || path.getFileName().toString().equals("translog")) {

--- a/x-pack/plugin/autoscaling/src/internalClusterTest/java/org/elasticsearch/xpack/autoscaling/storage/ReactiveStorageIT.java
+++ b/x-pack/plugin/autoscaling/src/internalClusterTest/java/org/elasticsearch/xpack/autoscaling/storage/ReactiveStorageIT.java
@@ -230,7 +230,6 @@ public class ReactiveStorageIT extends AutoscalingStorageIntegTestCase {
         );
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/88842")
     public void testScaleWhileShrinking() throws Exception {
         internalCluster().startMasterOnlyNode();
         final String dataNode1Name = internalCluster().startDataOnlyNode();


### PR DESCRIPTION
Sometimes Windows throws an AccessDeniedException when some of the attributes for a file that has been deleted are read. This caused issues in this test since it prevented gathering the FS stats from one of the nodes where some of the relocated index files were deleted concurrently.

Closes #88842
