### PR TITLE
Fix the details calculation of the disk indicator (#90715)

### DIFF
--- a/docs/changelog/90869.yaml
+++ b/docs/changelog/90869.yaml
@@ -1,0 +1,5 @@
+pr: 90869
+summary: Fix the details calculation of the disk indicator
+area: Health
+type: bug
+issues: []

--- a/server/src/main/java/org/elasticsearch/health/node/DiskHealthIndicatorService.java
+++ b/server/src/main/java/org/elasticsearch/health/node/DiskHealthIndicatorService.java
@@ -396,7 +396,8 @@ public class DiskHealthIndicatorService implements HealthIndicatorService {
             });
         }
 
-        private static Map<HealthStatus, Integer> countNodesByHealthStatus(
+        // Visible for testing
+        static Map<HealthStatus, Integer> countNodesByHealthStatus(
             Map<String, DiskHealthInfo> diskHealthInfoMap,
             ClusterState clusterState
         ) {

--- a/server/src/main/java/org/elasticsearch/health/node/DiskHealthIndicatorService.java
+++ b/server/src/main/java/org/elasticsearch/health/node/DiskHealthIndicatorService.java
@@ -150,7 +150,7 @@ public class DiskHealthIndicatorService implements HealthIndicatorService {
         private final Set<DiscoveryNodeRole> affectedRoles = new HashSet<>();
         private final Set<String> indicesAtRisk;
         private final HealthStatus healthStatus;
-        private final HealthIndicatorDetails details;
+        private final Map<HealthStatus, Integer> healthStatusNodeCount;
 
         DiskHealthAnalyzer(Map<String, DiskHealthInfo> diskHealthByNode, ClusterState clusterState) {
             this.clusterState = clusterState;
@@ -190,7 +190,7 @@ public class DiskHealthIndicatorService implements HealthIndicatorService {
             }
             indicesAtRisk = getIndicesForNodes(dataNodes, clusterState);
             healthStatus = mostSevereStatusSoFar;
-            details = createDetails(diskHealthByNode, blockedIndices);
+            healthStatusNodeCount = countNodesByHealthStatus(diskHealthByNode, clusterState);
         }
 
         public HealthStatus getHealthStatus() {
@@ -386,25 +386,31 @@ public class DiskHealthIndicatorService implements HealthIndicatorService {
             if (explain == false) {
                 return HealthIndicatorDetails.EMPTY;
             }
-            return details;
-        }
-
-        private static HealthIndicatorDetails createDetails(Map<String, DiskHealthInfo> diskHealthInfoMap, Set<String> blockedIndices) {
-            Map<HealthStatus, Integer> healthNodesCount = new HashMap<>();
-            for (HealthStatus healthStatus : HealthStatus.values()) {
-                healthNodesCount.put(healthStatus, 0);
-            }
-            for (DiskHealthInfo diskHealthInfo : diskHealthInfoMap.values()) {
-                healthNodesCount.computeIfPresent(diskHealthInfo.healthStatus(), (key, oldCount) -> oldCount + 1);
-            }
             return ((builder, params) -> {
                 builder.startObject();
                 builder.field(INDICES_WITH_READONLY_BLOCK, blockedIndices.size());
                 for (HealthStatus healthStatus : HealthStatus.values()) {
-                    builder.field(getDetailsDisplayKey(healthStatus), healthNodesCount.get(healthStatus));
+                    builder.field(getDetailsDisplayKey(healthStatus), healthStatusNodeCount.get(healthStatus));
                 }
                 return builder.endObject();
             });
+        }
+
+        private static Map<HealthStatus, Integer> countNodesByHealthStatus(
+            Map<String, DiskHealthInfo> diskHealthInfoMap,
+            ClusterState clusterState
+        ) {
+            Map<HealthStatus, Integer> counts = new HashMap<>();
+            for (HealthStatus healthStatus : HealthStatus.values()) {
+                counts.put(healthStatus, 0);
+            }
+            for (DiscoveryNode node : clusterState.getNodes()) {
+                HealthStatus healthStatus = diskHealthInfoMap.containsKey(node.getId())
+                    ? diskHealthInfoMap.get(node.getId()).healthStatus()
+                    : HealthStatus.UNKNOWN;
+                counts.computeIfPresent(healthStatus, (ignored, count) -> count + 1);
+            }
+            return counts;
         }
 
         private static String getDetailsDisplayKey(HealthStatus status) {

--- a/server/src/test/java/org/elasticsearch/health/node/DiskHealthIndicatorServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/health/node/DiskHealthIndicatorServiceTests.java
@@ -756,12 +756,90 @@ public class DiskHealthIndicatorServiceTests extends ESTestCase {
         }
     }
 
+    public void testNodeHealthStatusCounts() {
+        {
+            // A bit of everything
+            int unknownCount = randomIntBetween(1, 10);
+            int greenCount = randomIntBetween(1, 10);
+            int yellowCount = randomIntBetween(1, 10);
+            int redCount = randomIntBetween(1, 10);
+            Set<DiscoveryNode> nodes = createNodes(unknownCount + greenCount + yellowCount + redCount, DiscoveryNodeRole.roles());
+            int i = 0;
+            Map<String, DiskHealthInfo> nodesDiskHealth = new HashMap<>();
+            for (DiscoveryNode node : nodes) {
+                HealthStatus status;
+                if (i < unknownCount) {
+                    status = HealthStatus.UNKNOWN;
+                } else if (i < unknownCount + greenCount) {
+                    status = HealthStatus.GREEN;
+                } else if (i < unknownCount + greenCount + yellowCount) {
+                    status = HealthStatus.YELLOW;
+                } else {
+                    status = HealthStatus.RED;
+                }
+                nodesDiskHealth.put(node.getId(), new DiskHealthInfo(status, randomFrom(DiskHealthInfo.Cause.values())));
+                i++;
+            }
+            ClusterState clusterState = createClusterState(Set.of(), nodes, Map.of());
+            Map<HealthStatus, Integer> counts = DiskHealthIndicatorService.DiskHealthAnalyzer.countNodesByHealthStatus(
+                nodesDiskHealth,
+                clusterState
+            );
+            assertThat(counts.get(HealthStatus.UNKNOWN), equalTo(unknownCount));
+            assertThat(counts.get(HealthStatus.GREEN), equalTo(greenCount));
+            assertThat(counts.get(HealthStatus.YELLOW), equalTo(yellowCount));
+            assertThat(counts.get(HealthStatus.RED), equalTo(redCount));
+        }
+        {
+            // No nodes
+            Map<HealthStatus, Integer> counts = DiskHealthIndicatorService.DiskHealthAnalyzer.countNodesByHealthStatus(
+                Map.of(),
+                ClusterState.EMPTY_STATE
+            );
+            assertThat(counts.get(HealthStatus.UNKNOWN), equalTo(0));
+            assertThat(counts.get(HealthStatus.GREEN), equalTo(0));
+            assertThat(counts.get(HealthStatus.YELLOW), equalTo(0));
+            assertThat(counts.get(HealthStatus.RED), equalTo(0));
+        }
+        {
+            // No disk health info, cluster state with nodes
+            Set<DiscoveryNode> nodes = createNodes(DiscoveryNodeRole.roles());
+            ClusterState clusterState = createClusterState(Set.of(), nodes, Map.of());
+            Map<HealthStatus, Integer> counts = DiskHealthIndicatorService.DiskHealthAnalyzer.countNodesByHealthStatus(
+                Map.of(),
+                clusterState
+            );
+            assertThat(counts.get(HealthStatus.UNKNOWN), equalTo(nodes.size()));
+            assertThat(counts.get(HealthStatus.GREEN), equalTo(0));
+            assertThat(counts.get(HealthStatus.YELLOW), equalTo(0));
+            assertThat(counts.get(HealthStatus.RED), equalTo(0));
+        }
+        {
+            // Disk health info for one node, no nodes in cluster state
+            Map<String, DiskHealthInfo> nodesDiskHealth = Map.of(
+                randomAlphaOfLength(10),
+                new DiskHealthInfo(randomFrom(HealthStatus.values()))
+            );
+            Map<HealthStatus, Integer> counts = DiskHealthIndicatorService.DiskHealthAnalyzer.countNodesByHealthStatus(
+                nodesDiskHealth,
+                ClusterState.EMPTY_STATE
+            );
+            assertThat(counts.get(HealthStatus.UNKNOWN), equalTo(0));
+            assertThat(counts.get(HealthStatus.GREEN), equalTo(0));
+            assertThat(counts.get(HealthStatus.YELLOW), equalTo(0));
+            assertThat(counts.get(HealthStatus.RED), equalTo(0));
+        }
+    }
+
     private Set<DiscoveryNode> createNodesWithAllRoles() {
         return createNodes(DiscoveryNodeRole.roles());
     }
 
     private Set<DiscoveryNode> createNodes(Set<DiscoveryNodeRole> roles) {
-        int numberOfNodes = randomIntBetween(1, 200);
+        return createNodes(randomIntBetween(1, 200), roles);
+    }
+
+    private Set<DiscoveryNode> createNodes(int numberOfNodes, Set<DiscoveryNodeRole> roles) {
         Set<DiscoveryNode> discoveryNodes = new HashSet<>();
         for (int i = 0; i < numberOfNodes; i++) {
             discoveryNodes.add(


### PR DESCRIPTION
As #90715 explains there is a discrepancy in certain cases in which the counts in the details do not match the counts of the nodes in the affected resources. 

These cases are:

- the health API coordinating node hasn't heard yet of the new cluster membership, but the health node received a health status from a new node

- the health API coordinating node has the latest cluster membership but the coordinating node already received the health cache overview using the previous membership configuration

In the following example we have 4 nodes, the health node has detected that 2 nodes are out of space but one of the nodes drops off the cluster. The coordinating node has processed the cluster state update but the health node hasn't 

**Current result:**
```
  "disk": {
      "status": "red",
      "symptom": "1 node with roles: [...] is out of disk or running low on disk space.",
      "details": {
        "blocked_indices": 0,
        "green_nodes": 2,
        "unknown_nodes": 0,
        "yellow_nodes": 0,
        "red_nodes": 2
      }
    },
```

**Fixed**
```
  "disk": {
      "status": "red",
      "symptom": "1 node with roles: [...] is out of disk or running low on disk space.",
      "details": {
        "blocked_indices": 0,
        "green_nodes": 2,
        "unknown_nodes": 0,
        "yellow_nodes": 0,
        "red_nodes": 1
      }
    },
```