### PR TITLE
Create placeholder plugin when loading stable plugins

### DIFF
--- a/docs/changelog/90870.yaml
+++ b/docs/changelog/90870.yaml
@@ -1,0 +1,5 @@
+pr: 90870
+summary: Create placeholder plugin when loading stable plugins
+area: Infra/Plugins
+type: enhancement
+issues: []

--- a/server/src/main/java/org/elasticsearch/indices/analysis/wrappers/StableApiWrappers.java
+++ b/server/src/main/java/org/elasticsearch/indices/analysis/wrappers/StableApiWrappers.java
@@ -82,9 +82,9 @@ public class StableApiWrappers {
             charFilterFactoryClass.getCanonicalName()
         );
 
-        Map<String, AnalysisModule.AnalysisProvider<T>> oldCharFilters = pluginInfosForExtensible.stream()
+        Map<String, AnalysisModule.AnalysisProvider<T>> oldApiComponents = pluginInfosForExtensible.stream()
             .collect(Collectors.toMap(PluginInfo::name, p -> analysisProviderWrapper(p, wrapper)));
-        return oldCharFilters;
+        return oldApiComponents;
     }
 
     @SuppressWarnings("unchecked")

--- a/server/src/main/java/org/elasticsearch/plugins/PluginsService.java
+++ b/server/src/main/java/org/elasticsearch/plugins/PluginsService.java
@@ -466,7 +466,7 @@ public class PluginsService implements ReportingService<PluginsAndModules> {
             Plugin plugin;
             if (bundle.pluginDescriptor().isStable()) {
                 stablePluginsRegistry.scanBundleForStablePlugins(bundle, pluginClassLoader);
-             /*
+                /*
                 Contrary to old plugins we don't need an instance of the plugin here.
                 Stable plugin register components (like CharFilterFactory) in stable plugin registry, which is then used in AnalysisModule
                 when registering char filter factories and other analysis components.
@@ -490,7 +490,7 @@ public class PluginsService implements ReportingService<PluginsAndModules> {
                             + "])"
                     );
                 }
-                 plugin = loadPlugin(pluginClass, settings, configPath);
+                plugin = loadPlugin(pluginClass, settings, configPath);
             }
             loaded.put(name, new LoadedPlugin(bundle.plugin, plugin, spiLayerAndLoader.loader(), spiLayerAndLoader.layer()));
         } finally {

--- a/server/src/main/java/org/elasticsearch/plugins/PluginsService.java
+++ b/server/src/main/java/org/elasticsearch/plugins/PluginsService.java
@@ -415,7 +415,7 @@ public class PluginsService implements ReportingService<PluginsAndModules> {
         return "constructor for extension [" + extensionClass.getName() + "] of type [" + extensionPointType.getName() + "]";
     }
 
-    private Plugin loadBundle(PluginBundle bundle, Map<String, LoadedPlugin> loaded) {
+    private void loadBundle(PluginBundle bundle, Map<String, LoadedPlugin> loaded) {
         String name = bundle.plugin.getName();
         logger.debug(() -> "Loading bundle: " + name);
 
@@ -463,25 +463,36 @@ public class PluginsService implements ReportingService<PluginsAndModules> {
             // that have dependencies with their own SPI endpoints have a chance to load
             // and initialize them appropriately.
             privilegedSetContextClassLoader(pluginClassLoader);
+            Plugin plugin;
             if (bundle.pluginDescriptor().isStable()) {
                 stablePluginsRegistry.scanBundleForStablePlugins(bundle, pluginClassLoader);
-            }
+             /*
+                Contrary to old plugins we don't need an instance of the plugin here.
+                Stable plugin register components (like CharFilterFactory) in stable plugin registry, which is then used in AnalysisModule
+                when registering char filter factories and other analysis components.
+                We don't have to support for settings, additional components and other methods
+                that are in org.elasticsearch.plugins.Plugin
+                We need to pass a name though so that we can show that a plugin was loaded (via cluster state api)
+                This might need to be revisited once support for settings is added
+                 */
+                plugin = new StablePluginPlaceHolder(bundle.plugin.getName());
+            } else {
 
-            Class<? extends Plugin> pluginClass = loadPluginClass(bundle.plugin.getClassname(), pluginClassLoader);
-            if (pluginClassLoader != pluginClass.getClassLoader()) {
-                throw new IllegalStateException(
-                    "Plugin ["
-                        + name
-                        + "] must reference a class loader local Plugin class ["
-                        + bundle.plugin.getClassname()
-                        + "] (class loader ["
-                        + pluginClass.getClassLoader()
-                        + "])"
-                );
+                Class<? extends Plugin> pluginClass = loadPluginClass(bundle.plugin.getClassname(), pluginClassLoader);
+                if (pluginClassLoader != pluginClass.getClassLoader()) {
+                    throw new IllegalStateException(
+                        "Plugin ["
+                            + name
+                            + "] must reference a class loader local Plugin class ["
+                            + bundle.plugin.getClassname()
+                            + "] (class loader ["
+                            + pluginClass.getClassLoader()
+                            + "])"
+                    );
+                }
+                 plugin = loadPlugin(pluginClass, settings, configPath);
             }
-            Plugin plugin = loadPlugin(pluginClass, settings, configPath);
             loaded.put(name, new LoadedPlugin(bundle.plugin, plugin, spiLayerAndLoader.loader(), spiLayerAndLoader.layer()));
-            return plugin;
         } finally {
             privilegedSetContextClassLoader(cl);
         }

--- a/server/src/main/java/org/elasticsearch/plugins/StablePluginPlaceHolder.java
+++ b/server/src/main/java/org/elasticsearch/plugins/StablePluginPlaceHolder.java
@@ -1,0 +1,17 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.plugins;
+
+class StablePluginPlaceHolder extends Plugin {
+    private final String name;
+
+    StablePluginPlaceHolder(String name) {
+        this.name = name;
+    }
+}

--- a/server/src/test/java/org/elasticsearch/plugins/PluginsServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/plugins/PluginsServiceTests.java
@@ -11,6 +11,7 @@ package org.elasticsearch.plugins;
 import org.apache.lucene.tests.util.LuceneTestCase;
 import org.apache.lucene.util.Constants;
 import org.elasticsearch.Version;
+import org.elasticsearch.action.admin.cluster.node.info.PluginsAndModules;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.core.Strings;
 import org.elasticsearch.env.Environment;
@@ -43,13 +44,16 @@ import java.util.Map;
 import java.util.Set;
 
 import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.everyItem;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.hasToString;
 import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.sameInstance;
 
@@ -760,6 +764,67 @@ public class PluginsServiceTests extends ESTestCase {
                 "Plugin class p.DeprecatedPlugin from plugin deprecated-plugin implements deprecated method "
                     + "getElectionStrategies from plugin interface DiscoveryPlugin. This method will be removed in a future release."
             );
+        } finally {
+            closePluginLoaders(pluginService);
+        }
+    }
+
+    public void testStablePluginLoading() throws Exception {
+        final Path home = createTempDir();
+        final Settings settings = Settings.builder().put(Environment.PATH_HOME_SETTING.getKey(), home).build();
+        final Path plugins = home.resolve("plugins");
+        final Path plugin = plugins.resolve("stable-plugin");
+        Files.createDirectories(plugin);
+        PluginTestUtil.writeStablePluginProperties(
+            plugin,
+            "description",
+            "description",
+            "name",
+            "stable-plugin",
+            "version",
+            "1.0.0",
+            "elasticsearch.version",
+            Version.CURRENT.toString(),
+            "java.version",
+            System.getProperty("java.specification.version")
+        );
+
+        Path jar = plugin.resolve("impl.jar");
+        JarUtils.createJarWithEntries(jar, Map.of("p/A.class", InMemoryJavaCompiler.compile("p.A", """
+            package p;
+            import java.util.Map;
+            import org.elasticsearch.plugin.analysis.api.CharFilterFactory;
+            import org.elasticsearch.plugin.api.NamedComponent;
+            import java.io.Reader;
+            @NamedComponent(name = "a_name")
+            public class A  implements CharFilterFactory {
+                 @Override
+                public Reader create(Reader reader) {
+                    return reader;
+                }
+            }
+            """)));
+        Path namedComponentFile = plugin.resolve("named_components.json");
+        Files.writeString(namedComponentFile, """
+            {
+              "org.elasticsearch.plugin.analysis.api.CharFilterFactory": {
+                "a_name": "p.A"
+              }
+            }
+            """);
+
+        var pluginService = newPluginsService(settings);
+        try {
+            Map<String, Plugin> stringPluginMap = pluginService.pluginMap();
+            assertThat(stringPluginMap.get("stable-plugin"), instanceOf(StablePluginPlaceHolder.class));
+
+            PluginsAndModules info = pluginService.info();
+            List<PluginRuntimeInfo> pluginInfos = info.getPluginInfos();
+            assertEquals(pluginInfos.size(), 1);
+            assertThat(pluginInfos.get(0).descriptor().getName(), equalTo("stable-plugin"));
+            assertThat(pluginInfos.get(0).descriptor().isStable(), is(true));
+
+            //TODO should we add something to pluginInfos.get(0).pluginApiInfo() ?
         } finally {
             closePluginLoaders(pluginService);
         }

--- a/server/src/test/java/org/elasticsearch/plugins/PluginsServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/plugins/PluginsServiceTests.java
@@ -44,7 +44,6 @@ import java.util.Map;
 import java.util.Set;
 
 import static org.hamcrest.Matchers.allOf;
-import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.empty;
@@ -824,7 +823,7 @@ public class PluginsServiceTests extends ESTestCase {
             assertThat(pluginInfos.get(0).descriptor().getName(), equalTo("stable-plugin"));
             assertThat(pluginInfos.get(0).descriptor().isStable(), is(true));
 
-            //TODO should we add something to pluginInfos.get(0).pluginApiInfo() ?
+            // TODO should we add something to pluginInfos.get(0).pluginApiInfo() ?
         } finally {
             closePluginLoaders(pluginService);
         }

--- a/test/framework/src/main/java/org/elasticsearch/plugins/PluginTestUtil.java
+++ b/test/framework/src/main/java/org/elasticsearch/plugins/PluginTestUtil.java
@@ -18,6 +18,7 @@ import java.util.Properties;
 
 /** Utility methods for testing plugins */
 public class PluginTestUtil {
+
     public static void writePluginProperties(Path pluginDir, String... stringProps) throws IOException {
         writeProperties(pluginDir.resolve(PluginDescriptor.INTERNAL_DESCRIPTOR_FILENAME), stringProps);
     }

--- a/test/framework/src/main/java/org/elasticsearch/plugins/PluginTestUtil.java
+++ b/test/framework/src/main/java/org/elasticsearch/plugins/PluginTestUtil.java
@@ -18,7 +18,6 @@ import java.util.Properties;
 
 /** Utility methods for testing plugins */
 public class PluginTestUtil {
-
     public static void writePluginProperties(Path pluginDir, String... stringProps) throws IOException {
         writeProperties(pluginDir.resolve(PluginDescriptor.INTERNAL_DESCRIPTOR_FILENAME), stringProps);
     }


### PR DESCRIPTION
Stable plugins do not extend Plugin class and are not instantiated in PluginService. Therefore a simple StablePluginPlaceHolder has to be used in order to make pluginService aware of the plugin and its descriptor. It is needed to return information about loaded stable plugins in cluster state.

relates #88980

<!--
Thank you for your interest in and contributing to Elasticsearch! There
are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your
attention.
-->

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/elasticsearch/blob/main/CONTRIBUTING.md)?
- If submitting code, have you built your formula locally prior to submission with `gradle check`?
- If submitting code, is your pull request against main? Unless there is a good reason otherwise, we prefer pull requests against main and will backport as needed.
- If submitting code, have you checked that your submission is for an [OS and architecture that we support](https://www.elastic.co/support/matrix#show_os)?
- If you are submitting this code for a class then read our [policy](https://github.com/elastic/elasticsearch/blob/main/CONTRIBUTING.md#contributing-as-part-of-a-class) for that.
