### PR TITLE
[CI] fix rollup resource leakage problems in tests

### DIFF
--- a/x-pack/plugin/rollup/src/test/java/org/elasticsearch/xpack/rollup/RollupResponseTranslationTests.java
+++ b/x-pack/plugin/rollup/src/test/java/org/elasticsearch/xpack/rollup/RollupResponseTranslationTests.java
@@ -1313,8 +1313,7 @@ public class RollupResponseTranslationTests extends AggregatorTestCase {
         IndexReader indexReader = DirectoryReader.open(directory);
         IndexSearcher indexSearcher = newIndexSearcher(indexReader);
 
-        Aggregator aggregator = createAggregator(aggBuilder, indexSearcher, fieldType);
-        try {
+        try (Aggregator aggregator = createAggregator(aggBuilder, indexSearcher, fieldType)) {
             aggregator.preCollection();
             indexSearcher.search(query, aggregator.asCollector());
             aggregator.postCollection();


### PR DESCRIPTION
ensure aggregator is closed in rollup tests

fixes #90661

Notes:
 - test issue: looks like a problem of the test, not production code
 - I haven't checked whether this should be backported
 - I couldn't find the reason for this regression, the code seems old, so I wonder what causes the many recent failures 
   - likely explanation: big arrays are not always recycled, it depends on the size, for smaller sizes a small heap object is used, for larger ones the big array uses a recycled object. So maybe something has either changed w.r.t. to the size of the test data or the boundary of the heap vs. recycled decider. This fits with the observation that not every test run fails