### PR TITLE
[DOC]: Removed note saying DLS/FLS disable shard request cache

### DIFF
--- a/x-pack/docs/en/security/authorization/field-and-document-access-control.asciidoc
+++ b/x-pack/docs/en/security/authorization/field-and-document-access-control.asciidoc
@@ -25,9 +25,6 @@ grant wider access than intended. Each user has a single set of field level and
 document level permissions per data stream or index. See <<multiple-roles-dls-fls>>.
 =====================================================================
 
-NOTE: Document- and field-level security disables the
-<<shard-request-cache,shard request cache>>.
-
 [[multiple-roles-dls-fls]]
 ==== Multiple roles with document and field level security
 


### PR DESCRIPTION
Removed below note from field and document access control doc

NOTE: Document- and field-level security disables the [shard request cache](https://www.elastic.co/guide/en/elasticsearch/reference/8.1/shard-request-cache.html).

This feature limitation was resolved in https://github.com/elastic/elasticsearch/pull/70191

Refer to #84741 
