### PR TITLE
Fix index.routing_path index setting generating bugs from dynamic mapping templates

### DIFF
--- a/modules/data-streams/src/main/java/org/elasticsearch/datastreams/DataStreamIndexSettingsProvider.java
+++ b/modules/data-streams/src/main/java/org/elasticsearch/datastreams/DataStreamIndexSettingsProvider.java
@@ -167,11 +167,19 @@ public class DataStreamIndexSettingsProvider implements IndexSettingProvider {
                 extractPath(routingPaths, fieldMapper);
             }
             for (var template : mapperService.getAllDynamicTemplates()) {
+                if (template.pathMatch() == null) {
+                    continue;
+                }
+
                 var templateName = "__dynamic__" + template.name();
                 var mappingSnippet = template.mappingForName(templateName, KeywordFieldMapper.CONTENT_TYPE);
+                String mappingSnippetType = (String) mappingSnippet.get("type");
+                if (mappingSnippetType == null) {
+                    continue;
+                }
 
                 MappingParserContext parserContext = mapperService.parserContext();
-                var mapper = parserContext.typeParser(KeywordFieldMapper.CONTENT_TYPE)
+                var mapper = parserContext.typeParser(mappingSnippetType)
                     .parse(template.pathMatch(), mappingSnippet, parserContext)
                     .build(MapperBuilderContext.ROOT);
                 extractPath(routingPaths, mapper);


### PR DESCRIPTION
This PR fixes two bugs:
* If template contains dynamic mapping templates with no `path_match` then the extraction of index.routing_path index setting from mapping fails with a NPE.
* If template contains dynamic mapping template with a type other than keyword and an attribute that is unsupported by the keyword field mapper then the extraction of index.routing_path index setting from mapping fails with a NPE. This is caused by the fact that each dynamic mapping template was always parsed as keyword field.

These bugs could occur even if no dynamic templates contains the `time_series_dimension` attribute.

Bugs were introduced by #90552

(none issue, this fixes bugs for a non released enhancement)