### PR TITLE
Add slow start search routing

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/routing/IndexShardRoutingTable.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/IndexShardRoutingTable.java
@@ -18,6 +18,7 @@ import org.elasticsearch.common.util.CollectionUtils;
 import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.common.util.set.Sets;
 import org.elasticsearch.core.Nullable;
+import org.elasticsearch.core.Tuple;
 import org.elasticsearch.index.Index;
 import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.node.ResponseCollectorService;
@@ -165,19 +166,23 @@ public class IndexShardRoutingTable {
      * its random within the active shards, and initializing shards are the last to iterate through.
      */
     public ShardIterator activeInitializingShardsRandomIt() {
-        return activeInitializingShardsIt(shuffler.nextSeed());
+        return activeInitializingShardsIt(shuffler.nextSeed(), null);
+    }
+
+    public ShardIterator activeInitializingShardsRandomIt(@Nullable Map<String, ShardSlowStart> shardSlowStartByAllocationId) {
+        return activeInitializingShardsIt(shuffler.nextSeed(), shardSlowStartByAllocationId);
     }
 
     /**
      * Returns an iterator over active and initializing shards. Making sure though that
      * its random within the active shards, and initializing shards are the last to iterate through.
      */
-    public ShardIterator activeInitializingShardsIt(int seed) {
-        if (allInitializingShards.isEmpty()) {
-            return new PlainShardIterator(shardId, shuffler.shuffle(activeShards, seed));
-        }
+    public ShardIterator activeInitializingShardsIt(int seed, @Nullable Map<String, ShardSlowStart> shardSlowStartByAllocationId) {
+        List<ShardRouting> shuffled = shuffler.shuffle(activeShards, seed);
+        Tuple<List<ShardRouting>, List<ShardRouting>> tuple = applySlowStart(shuffled, shardSlowStartByAllocationId);
         ArrayList<ShardRouting> ordered = new ArrayList<>(activeShards.size() + allInitializingShards.size());
-        ordered.addAll(shuffler.shuffle(activeShards, seed));
+        ordered.addAll(tuple.v1());
+        ordered.addAll(tuple.v2());
         ordered.addAll(allInitializingShards);
         return new PlainShardIterator(shardId, ordered);
     }
@@ -189,19 +194,25 @@ public class IndexShardRoutingTable {
      */
     public ShardIterator activeInitializingShardsRankedIt(
         @Nullable ResponseCollectorService collector,
-        @Nullable Map<String, Long> nodeSearchCounts
+        @Nullable Map<String, Long> nodeSearchCounts,
+        @Nullable Map<String, ShardSlowStart> shardSlowStartByAllocationId
     ) {
         final int seed = shuffler.nextSeed();
+        List<ShardRouting> shuffled = shuffler.shuffle(activeShards, seed);
+        Tuple<List<ShardRouting>, List<ShardRouting>> tuple = applySlowStart(shuffled, shardSlowStartByAllocationId);
+        List<ShardRouting> rankedActiveShards = rankShardsAndUpdateStats(tuple.v1(), collector, nodeSearchCounts);
+        ArrayList<ShardRouting> ordered = new ArrayList<>(activeShards.size() + allInitializingShards.size());
+        ordered.addAll(rankedActiveShards);
+        if (tuple.v2().isEmpty() == false) {
+            ordered.addAll(tuple.v2());
+            adjustStatsForSlowedShards(tuple.v2(), collector, ordered.get(0).currentNodeId());
+        }
         if (allInitializingShards.isEmpty()) {
             return new PlainShardIterator(
                 shardId,
-                rankShardsAndUpdateStats(shuffler.shuffle(activeShards, seed), collector, nodeSearchCounts)
+                ordered
             );
         }
-
-        ArrayList<ShardRouting> ordered = new ArrayList<>(activeShards.size() + allInitializingShards.size());
-        List<ShardRouting> rankedActiveShards = rankShardsAndUpdateStats(shuffler.shuffle(activeShards, seed), collector, nodeSearchCounts);
-        ordered.addAll(rankedActiveShards);
         List<ShardRouting> rankedInitializingShards = rankShardsAndUpdateStats(allInitializingShards, collector, nodeSearchCounts);
         ordered.addAll(rankedInitializingShards);
         return new PlainShardIterator(shardId, ordered);
@@ -281,6 +292,21 @@ public class IndexShardRoutingTable {
         }
     }
 
+    private static void adjustStatsForSlowedShards(
+        final List<ShardRouting> shards,
+        final ResponseCollectorService collector,
+        final String minNodeId
+        ) {
+        if (collector == null) {
+            return;
+        }
+        final Set<String> nodeIds = getAllNodeIds(shards);
+        nodeIds.add(minNodeId);
+        final Map<String, Optional<ResponseCollectorService.ComputedNodeStats>> nodeStats = getNodeStats(nodeIds, collector);
+        Optional<ResponseCollectorService.ComputedNodeStats> maybeMinStats = nodeStats.get(minNodeId);
+        maybeMinStats.ifPresent(minStats -> adjustStats(collector, nodeStats, minNodeId, minStats));
+    }
+
     private static List<ShardRouting> rankShardsAndUpdateStats(
         List<ShardRouting> shards,
         final ResponseCollectorService collector,
@@ -355,6 +381,28 @@ public class IndexShardRoutingTable {
                 }
             }
         }
+    }
+
+    private Tuple<List<ShardRouting>, List<ShardRouting>> applySlowStart(
+        List<ShardRouting> activeShards,
+        @Nullable Map<String, ShardSlowStart> shardSlowStartByAllocationId
+    ) {
+        if (shardSlowStartByAllocationId == null || shardSlowStartByAllocationId.isEmpty()) {
+            return Tuple.tuple(activeShards, List.of());
+        }
+        long currentNanoTime = System.nanoTime();
+        ArrayList<ShardRouting> shards = new ArrayList<>();
+        ArrayList<ShardRouting> slowedShards = new ArrayList<>();
+        for (ShardRouting shard : activeShards) {
+            ShardSlowStart shardSlowStart = shardSlowStartByAllocationId.getOrDefault(
+                Tuple.tuple(shard.shardId(), shard.allocationId().getId()), null);
+            if (shardSlowStart != null && shardSlowStart.slowed(currentNanoTime)) {
+                slowedShards.add(shard);
+            } else {
+                shards.add(shard);
+            }
+        }
+        return Tuple.tuple(shards, slowedShards);
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/cluster/routing/OperationRouting.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/OperationRouting.java
@@ -8,7 +8,9 @@
 
 package org.elasticsearch.cluster.routing;
 
+import org.elasticsearch.cluster.ClusterChangedEvent;
 import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.ClusterStateApplier;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
 import org.elasticsearch.common.Strings;
@@ -17,6 +19,7 @@ import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.set.Sets;
 import org.elasticsearch.core.Nullable;
+import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.index.IndexNotFoundException;
 import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.node.ResponseCollectorService;
@@ -24,12 +27,14 @@ import org.elasticsearch.node.ResponseCollectorService;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 
-public class OperationRouting {
+public class OperationRouting implements ClusterStateApplier {
 
     public static final Setting<Boolean> USE_ADAPTIVE_REPLICA_SELECTION_SETTING = Setting.boolSetting(
         "cluster.routing.use_adaptive_replica_selection",
@@ -40,9 +45,28 @@ public class OperationRouting {
 
     private boolean useAdaptiveReplicaSelection;
 
+    public static final Setting<TimeValue> SHARD_SLOW_START_DURATION_SETTING = Setting.positiveTimeSetting(
+        "index.routing.slow_start.duration",
+        TimeValue.timeValueMillis(0),
+        Setting.Property.Dynamic,
+        Setting.Property.IndexScope
+    );
+
+    public static final Setting<Double> SHARD_SLOW_START_AGGRESSION_SETTING = Setting.doubleSetting(
+        "index.routing.slow_start.aggression",
+        1.0,
+        0.1,
+        Setting.Property.Dynamic,
+        Setting.Property.IndexScope
+    );
+
+    private final AtomicReference<Map<String, ShardSlowStart>> shardSlowStartByAllocationId;
+
     public OperationRouting(Settings settings, ClusterSettings clusterSettings) {
         this.useAdaptiveReplicaSelection = USE_ADAPTIVE_REPLICA_SELECTION_SETTING.get(settings);
         clusterSettings.addSettingsUpdateConsumer(USE_ADAPTIVE_REPLICA_SELECTION_SETTING, this::setUseAdaptiveReplicaSelection);
+        this.shardSlowStartByAllocationId = new AtomicReference<>();
+        this.shardSlowStartByAllocationId.set(new HashMap<>());
     }
 
     void setUseAdaptiveReplicaSelection(boolean useAdaptiveReplicaSelection) {
@@ -153,7 +177,7 @@ public class OperationRouting {
         @Nullable Map<String, Long> nodeCounts
     ) {
         if (preference == null || preference.isEmpty()) {
-            return shardRoutings(indexShard, nodes, collectorService, nodeCounts);
+            return shardRoutings(indexShard, collectorService, nodeCounts);
         }
         if (preference.charAt(0) == '_') {
             Preference preferenceType = Preference.parse(preference);
@@ -180,7 +204,7 @@ public class OperationRouting {
                 }
                 // no more preference
                 if (index == -1 || index == preference.length() - 1) {
-                    return shardRoutings(indexShard, nodes, collectorService, nodeCounts);
+                    return shardRoutings(indexShard, collectorService, nodeCounts);
                 } else {
                     // update the preference and continue
                     preference = preference.substring(index + 1);
@@ -208,19 +232,18 @@ public class OperationRouting {
         }
         // if not, then use it as the index
         int routingHash = 31 * Murmur3HashFunction.hash(preference) + indexShard.shardId.hashCode();
-        return indexShard.activeInitializingShardsIt(routingHash);
+        return indexShard.activeInitializingShardsIt(routingHash, shardSlowStartByAllocationId.get());
     }
 
     private ShardIterator shardRoutings(
         IndexShardRoutingTable indexShard,
-        DiscoveryNodes nodes,
         @Nullable ResponseCollectorService collectorService,
         @Nullable Map<String, Long> nodeCounts
     ) {
         if (useAdaptiveReplicaSelection) {
-            return indexShard.activeInitializingShardsRankedIt(collectorService, nodeCounts);
+            return indexShard.activeInitializingShardsRankedIt(collectorService, nodeCounts, shardSlowStartByAllocationId.get());
         } else {
-            return indexShard.activeInitializingShardsRandomIt();
+            return indexShard.activeInitializingShardsRandomIt(shardSlowStartByAllocationId.get());
         }
     }
 
@@ -243,5 +266,45 @@ public class OperationRouting {
     public ShardId shardId(ClusterState clusterState, String index, String id, @Nullable String routing) {
         IndexMetadata indexMetadata = indexMetadata(clusterState, index);
         return new ShardId(indexMetadata.getIndex(), IndexRouting.fromIndexMetadata(indexMetadata).getShard(id, routing));
+    }
+
+    @Override
+    public void applyClusterState(ClusterChangedEvent event) {
+        if (event.routingTableChanged()) {
+            Map<String, ShardSlowStart> previous = shardSlowStartByAllocationId.get();
+            Map<String, ShardSlowStart> current = new HashMap<>();
+            long currentNanoTime = System.nanoTime();
+            for (Map.Entry<String, ShardSlowStart> entry : previous.entrySet()) {
+                if (entry.getValue().finished(currentNanoTime) == false) {
+                    current.put(entry.getKey(), entry.getValue());
+                }
+            }
+            for (IndexRoutingTable indexRoutingTable : event.state().getRoutingTable().indicesRouting().values()) {
+                for (int i = 0; i < indexRoutingTable.size(); i++) {
+                    IndexShardRoutingTable indexShard = indexRoutingTable.shard(i);
+                    for (int j=0; j < indexShard.size(); j++) {
+                        ShardRouting shard = indexShard.shard(j);
+                        if (shard.started()) {
+                            ShardRouting prev = event.previousState().getRoutingTable()
+                                .getByAllocationId(shard.shardId(), shard.allocationId().getId());
+                            if (prev == null || prev.initializing()) {
+                                IndexMetadata metadata = indexMetadata(event.state(), shard.index().getName());
+                                if (SHARD_SLOW_START_DURATION_SETTING.get(metadata.getSettings()).nanos() > 0) {
+                                    current.put(
+                                        shard.allocationId().getId(),
+                                        new ShardSlowStart(
+                                            System.nanoTime(),
+                                            SHARD_SLOW_START_DURATION_SETTING.get(metadata.getSettings()).nanos(),
+                                            SHARD_SLOW_START_AGGRESSION_SETTING.get(metadata.getSettings())
+                                        )
+                                    );
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+            shardSlowStartByAllocationId.set(current);
+        }
     }
 }

--- a/server/src/main/java/org/elasticsearch/cluster/routing/ShardSlowStart.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/ShardSlowStart.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.cluster.routing;
+
+import org.elasticsearch.common.Randomness;
+
+public class ShardSlowStart {
+
+    private final long movedToStartedNanoTime;
+    private final long durationNanos;
+    private final double invertedAggression;
+
+    public ShardSlowStart(long movedToStartedNanoTime, long durationNanos, double aggression) {
+        this.movedToStartedNanoTime = movedToStartedNanoTime;
+        this.durationNanos = durationNanos;
+        this.invertedAggression = 1.0 / aggression;
+    }
+
+    public boolean finished(long currentNanoTime) {
+        return currentNanoTime < movedToStartedNanoTime + durationNanos;
+    }
+
+    public boolean slowed(long currentNanoTime) {
+        long remaining = durationNanos - (currentNanoTime - movedToStartedNanoTime);
+        return remaining > 0 && Randomness.get().nextDouble() <
+            Math.pow((double) remaining / durationNanos, invertedAggression);
+    }
+}

--- a/server/src/main/java/org/elasticsearch/cluster/service/ClusterService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/service/ClusterService.java
@@ -104,6 +104,7 @@ public class ClusterService extends AbstractLifecycleComponent {
     protected synchronized void doStart() {
         clusterApplierService.start();
         masterService.start();
+        addHighPriorityApplier(operationRouting);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/common/settings/IndexScopedSettings.java
+++ b/server/src/main/java/org/elasticsearch/common/settings/IndexScopedSettings.java
@@ -9,6 +9,7 @@ package org.elasticsearch.common.settings;
 
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.metadata.MetadataIndexStateService;
+import org.elasticsearch.cluster.routing.OperationRouting;
 import org.elasticsearch.cluster.routing.UnassignedInfo;
 import org.elasticsearch.cluster.routing.allocation.DataTier;
 import org.elasticsearch.cluster.routing.allocation.ExistingShardsAllocator;
@@ -162,6 +163,8 @@ public final class IndexScopedSettings extends AbstractScopedSettings {
         ShardLimitValidator.INDEX_SETTING_SHARD_LIMIT_GROUP,
         DataTier.TIER_PREFERENCE_SETTING,
         IndexSettings.BLOOM_FILTER_ID_FIELD_ENABLED_SETTING,
+        OperationRouting.SHARD_SLOW_START_DURATION_SETTING,
+        OperationRouting.SHARD_SLOW_START_AGGRESSION_SETTING,
 
         // validate that built-in similarities don't get redefined
         Setting.groupSetting("index.similarity.", (s) -> {

--- a/server/src/test/java/org/elasticsearch/cluster/routing/OperationRoutingTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/OperationRoutingTests.java
@@ -196,7 +196,7 @@ public class OperationRoutingTests extends ESTestCase {
         final IndexShardRoutingTable indexShard = clusterState.getRoutingTable().shardRoutingTable(shardId.getIndexName(), shardId.getId());
         int routingHash = Murmur3HashFunction.hash(sessionId);
         routingHash = 31 * routingHash + indexShard.shardId.hashCode();
-        return indexShard.activeInitializingShardsIt(routingHash);
+        return indexShard.activeInitializingShardsIt(routingHash, null);
     }
 
     public void testThatOnlyNodesSupportNodeIds() throws InterruptedException, IOException {


### PR DESCRIPTION
I observed a latency spike just after adding new shards under high QPS search workload. This might be occurred by class loading, JIT compile, or so. To avoid this, this feature routes traffic to newly added shards gradually. This reduced a lot of timeout errors in my environment.
This feature is inspired by Envoy proxy. This is the graph what aggression parameter means.
https://github.com/envoyproxy/envoy/blob/main/docs/root/_static/slow_start_aggression.svg

<!--
Thank you for your interest in and contributing to Elasticsearch! There
are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your
attention.

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/elasticsearch/blob/main/CONTRIBUTING.md)?
- If submitting code, have you built your formula locally prior to submission with `gradle check`?
- If submitting code, is your pull request against main? Unless there is a good reason otherwise, we prefer pull requests against main and will backport as needed.
- If submitting code, have you checked that your submission is for an [OS and architecture that we support](https://www.elastic.co/support/matrix#show_os)?
- If you are submitting this code for a class then read our [policy](https://github.com/elastic/elasticsearch/blob/main/CONTRIBUTING.md#contributing-as-part-of-a-class) for that.
-->