### PR TITLE
Fork TransportListTasksAction to generic pool if we need to wait completion

### DIFF
--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/node/tasks/TaskManagerTestCase.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/node/tasks/TaskManagerTestCase.java
@@ -208,7 +208,7 @@ public abstract class TaskManagerTestCase extends ESTestCase {
             clusterService = createClusterService(threadPool, discoveryNode.get());
             clusterService.addStateApplier(transportService.getTaskManager());
             ActionFilters actionFilters = new ActionFilters(emptySet());
-            transportListTasksAction = new TransportListTasksAction(clusterService, transportService, actionFilters);
+            transportListTasksAction = new TransportListTasksAction(clusterService, transportService, actionFilters, threadPool);
             transportCancelTasksAction = new TransportCancelTasksAction(clusterService, transportService, actionFilters);
             transportService.acceptIncomingRequests();
         }


### PR DESCRIPTION
In case we need to wait for the all the matched tasks by the "lists tasks" command to complete, we need to fork `processActions` to the generic pool in order not to block the management pool which is can be as small as 1 thread. 

See #89564