### PR TITLE
[ML] Require correct tier processors when multiple AZs are present

### DIFF
--- a/docs/changelog/90903.yaml
+++ b/docs/changelog/90903.yaml
@@ -1,0 +1,5 @@
+pr: 90903
+summary: Require correct tier processors when multiple AZs are present
+area: Machine Learning
+type: bug
+issues: []

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/autoscaling/MlAutoscalingDeciderService.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/autoscaling/MlAutoscalingDeciderService.java
@@ -68,7 +68,7 @@ public class MlAutoscalingDeciderService implements AutoscalingDeciderService, L
             nodeLoadDetector,
             scaleTimer
         );
-        this.processorDecider = new MlProcessorAutoscalingDecider(scaleTimer, nodeAvailabilityZoneMapper);
+        this.processorDecider = new MlProcessorAutoscalingDecider(scaleTimer);
         clusterService.addLocalNodeMasterListener(this);
     }
 


### PR DESCRIPTION
When we added an autoscaling decider for processors we assumed wrongly that when there are multiple availability zones ML would get the processors it requests for the tier multiplied by the number of AZs.

This assumption was incorrect. This commit fixes this issue which should correct autoscaling behaviour in clusters with multiple AZs.
