### PR TITLE
Increase tolerance for Cartesian Centroid

### DIFF
--- a/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/search/aggregations/metrics/CartesianShapeCentroidAggregatorTests.java
+++ b/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/search/aggregations/metrics/CartesianShapeCentroidAggregatorTests.java
@@ -128,7 +128,6 @@ public class CartesianShapeCentroidAggregatorTests extends AggregatorTestCase {
     }
 
     @SuppressWarnings("unchecked")
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/90824")
     public void testSingleValuedField() throws Exception {
         int numDocs = scaledRandomIntBetween(64, 256);
         List<Geometry> geometries = new ArrayList<>();
@@ -212,7 +211,7 @@ public class CartesianShapeCentroidAggregatorTests extends AggregatorTestCase {
     }
 
     private double tolerance(double expected, long count) {
-        double tolerance = Math.abs(expected / 1e6);
+        double tolerance = Math.abs(expected / 1e5);
         // Very large numbers have more floating point error, also increasing with count
         return tolerance > 1e25 ? tolerance * count : tolerance;
     }


### PR DESCRIPTION
Very occasionally the collection of geometries generated randomly includes enough diversity to increase the floating point errors on calculating the expected centroid. This is specific to cartesian data which can have extreme values. To avoid this we're simply increasing our tolerance by one order of magnitude. This passed `-Dtests.iters=1000`, but is not certain to solve every conceivable case.

Fixes #90824
