### PR TITLE
[8.5] [ML] Require correct tier processors when multiple AZs are present (#90903)

### DIFF
--- a/docs/changelog/90903.yaml
+++ b/docs/changelog/90903.yaml
@@ -1,0 +1,5 @@
+pr: 90903
+summary: Require correct tier processors when multiple AZs are present
+area: Machine Learning
+type: bug
+issues: []

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/autoscaling/MlAutoscalingDeciderService.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/autoscaling/MlAutoscalingDeciderService.java
@@ -68,7 +68,7 @@ public class MlAutoscalingDeciderService implements AutoscalingDeciderService, L
             nodeLoadDetector,
             scaleTimer
         );
-        this.processorDecider = new MlProcessorAutoscalingDecider(scaleTimer, nodeAvailabilityZoneMapper);
+        this.processorDecider = new MlProcessorAutoscalingDecider(scaleTimer);
         clusterService.addLocalNodeMasterListener(this);
     }
 


### PR DESCRIPTION
Backports the following commits to 8.5:
 - [ML] Require correct tier processors when multiple AZs are present (#90903)