### PR TITLE
Test fix: make DataStreamIT not sensitive to midnight (#90595)

### DIFF
--- a/modules/data-streams/src/internalClusterTest/java/org/elasticsearch/datastreams/DataStreamIT.java
+++ b/modules/data-streams/src/internalClusterTest/java/org/elasticsearch/datastreams/DataStreamIT.java
@@ -301,7 +301,7 @@ public class DataStreamIT extends ESIntegTestCase {
             GetDataStreamAction.Response getDataStreamResponse = client().execute(GetDataStreamAction.INSTANCE, getDataStreamRequest)
                 .actionGet();
             assertThat(getDataStreamResponse.getDataStreams().size(), equalTo(1));
-            assertThat(getDataStreamResponse.getDataStreams().get(0).getDataStream().getName(), equalTo(dataStreamName));
+            assertThat(getDataStreamResponse.getDataStreams().get(0).getDataStream().getName(), equalTo(dataStreamName + "-baz"));
             assertThat(getDataStreamResponse.getDataStreams().get(0).getDataStream().getIndices().size(), equalTo(1));
             String backingIndex = getDataStreamResponse.getDataStreams().get(0).getDataStream().getIndices().get(0).getName();
             assertThat(backingIndex, backingIndexEqualTo(dataStreamName + "-baz", 1));

--- a/modules/data-streams/src/internalClusterTest/java/org/elasticsearch/datastreams/DataStreamIT.java
+++ b/modules/data-streams/src/internalClusterTest/java/org/elasticsearch/datastreams/DataStreamIT.java
@@ -1174,7 +1174,7 @@ public class DataStreamIT extends ESIntegTestCase {
             .opType(DocWriteRequest.OpType.CREATE)
             .routing("custom");
         IndexResponse indexResponse = client().index(indexRequest).actionGet();
-        assertThat(indexResponse.getIndex(), equalTo(DataStream.getDefaultBackingIndexName(dataStream, 1)));
+        assertThat(indexResponse.getIndex(), backingIndexEqualTo(dataStream, 1));
         // Index doc with custom routing that targets the data stream
         IndexRequest indexRequestWithRouting = new IndexRequest(dataStream).source("@timestamp", System.currentTimeMillis())
             .opType(DocWriteRequest.OpType.CREATE)

--- a/modules/data-streams/src/internalClusterTest/java/org/elasticsearch/datastreams/DataStreamIT.java
+++ b/modules/data-streams/src/internalClusterTest/java/org/elasticsearch/datastreams/DataStreamIT.java
@@ -1023,11 +1023,17 @@ public class DataStreamIT extends ESIntegTestCase {
         CreateDataStreamAction.Request createDataStreamRequest = new CreateDataStreamAction.Request("logs-foobar");
         client().execute(CreateDataStreamAction.INSTANCE, createDataStreamRequest).actionGet();
 
-        String backingIndex1 = DataStream.getDefaultBackingIndexName("logs-foobar", 1);
-        String backingIndex2 = DataStream.getDefaultBackingIndexName("logs-foobar", 2);
+        GetDataStreamAction.Request getDataStreamRequest = new GetDataStreamAction.Request(new String[] { "*" });
+        GetDataStreamAction.Response getDataStreamResponse = client().execute(GetDataStreamAction.INSTANCE, getDataStreamRequest)
+            .actionGet();
+        assertThat(getDataStreamResponse.getDataStreams().size(), equalTo(1));
+        assertThat(getDataStreamResponse.getDataStreams().get(0).getDataStream().getIndices().size(), equalTo(1));
+        String backingIndex1 = getDataStreamResponse.getDataStreams().get(0).getDataStream().getIndices().get(0).getName();
+        assertThat(backingIndex1, backingIndexEqualTo("logs-foobar", 1));
 
         RolloverResponse rolloverResponse = client().admin().indices().rolloverIndex(new RolloverRequest("logs-foobar", null)).get();
-        assertThat(rolloverResponse.getNewIndex(), equalTo(backingIndex2));
+        String backingIndex2 = rolloverResponse.getNewIndex();
+        assertThat(backingIndex2, backingIndexEqualTo("logs-foobar", 2));
         assertTrue(rolloverResponse.isRolledOver());
 
         Map<?, ?> expectedMapping = Map.of(

--- a/modules/data-streams/src/internalClusterTest/java/org/elasticsearch/datastreams/DataStreamIT.java
+++ b/modules/data-streams/src/internalClusterTest/java/org/elasticsearch/datastreams/DataStreamIT.java
@@ -1203,9 +1203,10 @@ public class DataStreamIT extends ESIntegTestCase {
             .opType(DocWriteRequest.OpType.CREATE);
         IndexResponse indexResponse = client().index(indexRequest).actionGet();
         assertThat(indexResponse.getIndex(), backingIndexEqualTo("logs-foobar", 1));
+        String backingIndex = indexResponse.getIndex();
 
         // Index doc with custom routing that targets the backing index
-        IndexRequest indexRequestWithRouting = new IndexRequest(DataStream.getDefaultBackingIndexName("logs-foobar", 1L)).source(
+        IndexRequest indexRequestWithRouting = new IndexRequest(backingIndex).source(
             "@timestamp",
             System.currentTimeMillis()
         )
@@ -1215,7 +1216,7 @@ public class DataStreamIT extends ESIntegTestCase {
             .setIfPrimaryTerm(indexResponse.getPrimaryTerm())
             .setIfSeqNo(indexResponse.getSeqNo());
         IndexResponse response = client().index(indexRequestWithRouting).actionGet();
-        assertThat(response.getIndex(), equalTo(DataStream.getDefaultBackingIndexName("logs-foobar", 1)));
+        assertThat(response.getIndex(), equalTo(backingIndex));
     }
 
     public void testSearchAllResolvesDataStreams() throws Exception {


### PR DESCRIPTION
The tests in `DataStreamIT` were using `DataStream::getDefaultBackingIndexName` to determine the name of the backing index of a data stream. Since `DataStream::getDefaultBackingIndexName` is time sensitive (it uses the day in the index name), if the tests are executed around midnight there is a chance that the tests will fail. 

To fix that,  we took the following steps:
- Retrieve the backing index name directly using the APIs either via getting the data stream or rolling over.
- Use the matcher `backingIndexEqualTo` to verify if the name of the index is the expected one by checking the data stream name and the generation but not the day.

Closes: #90595