### PR TITLE
[8.4] Removed note saying DLS/FLS disable shard request cache (#90885)

### DIFF
--- a/x-pack/docs/en/security/authorization/field-and-document-access-control.asciidoc
+++ b/x-pack/docs/en/security/authorization/field-and-document-access-control.asciidoc
@@ -25,9 +25,6 @@ grant wider access than intended. Each user has a single set of field level and
 document level permissions per data stream or index. See <<multiple-roles-dls-fls>>.
 =====================================================================
 
-NOTE: Document- and field-level security disables the
-<<shard-request-cache,shard request cache>>.
-
 [[multiple-roles-dls-fls]]
 ==== Multiple roles with document and field level security
 


### PR DESCRIPTION
Backports the following commits to 8.4:
 - Removed note saying DLS/FLS disable shard request cache (#90885)