### PR TITLE
[8.5] Fix testRedNodesWithoutAnyBlockedIndices (#90917)

### DIFF
--- a/server/src/test/java/org/elasticsearch/health/node/DiskHealthIndicatorServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/health/node/DiskHealthIndicatorServiceTests.java
@@ -450,9 +450,11 @@ public class DiskHealthIndicatorServiceTests extends ESTestCase {
         assertThat(
             result.symptom(),
             equalTo(
-                (numberOfRedNodes == 1 ? "1 node is" : numberOfRedNodes + " nodes ")
+                (numberOfRedNodes == 1 ? "1 node " : numberOfRedNodes + " nodes ")
                     + "with roles: [data, data_cold, data_content, data_frozen, data_hot, data_warm, ingest, master, ml, "
-                    + "remote_cluster_client, transform, voting_only] are out of disk or running low on disk space."
+                    + "remote_cluster_client, transform, voting_only] "
+                    + (numberOfRedNodes == 1 ? "is" : "are")
+                    + " out of disk or running low on disk space."
             )
         );
         assertThat(


### PR DESCRIPTION
Backports the following commits to 8.5:
 - Fix testRedNodesWithoutAnyBlockedIndices (#90917)