### PR TITLE
[7.17] Removed note saying DLS/FLS disable shard request cache (#90885)

### DIFF
--- a/x-pack/docs/en/security/authorization/field-and-document-access-control.asciidoc
+++ b/x-pack/docs/en/security/authorization/field-and-document-access-control.asciidoc
@@ -25,9 +25,6 @@ grant wider access than intended. Each user has a single set of field level and
 document level permissions per data stream or index. See <<multiple-roles-dls-fls>>.
 =====================================================================
 
-NOTE: Document- and field-level security disables the
-{ref}/shard-request-cache.html[shard request cache].
-
 [[multiple-roles-dls-fls]]
 ==== Multiple roles with document and field level security
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `7.17`:
 - [Removed note saying DLS/FLS disable shard request cache (#90885)](https://github.com/elastic/elasticsearch/pull/90885)

<!--- Backport version: 8.9.3 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)