### PR TITLE
Fix path to compatible x-pack tests

### DIFF
--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/rest/compat/YamlRestCompatTestPlugin.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/rest/compat/YamlRestCompatTestPlugin.java
@@ -58,7 +58,7 @@ public class YamlRestCompatTestPlugin implements Plugin<Project> {
     private static final Path RELATIVE_API_PATH = Path.of("rest-api-spec/api");
     private static final Path RELATIVE_TEST_PATH = Path.of("rest-api-spec/test");
     private static final Path RELATIVE_REST_API_RESOURCES = Path.of("rest-api-spec/src/main/resources");
-    private static final Path RELATIVE_REST_XPACK_RESOURCES = Path.of("x-pack/plugin/src/test/resources");
+    private static final Path RELATIVE_REST_XPACK = Path.of("x-pack/plugin");
     private static final Path RELATIVE_REST_PROJECT_RESOURCES = Path.of("src/yamlRestTest/resources");
     private static final int COMPATIBLE_VERSION = Version.fromString(VersionProperties.getVersions().get("elasticsearch")).getMajor() - 1;
     private static final String SOURCE_SET_NAME = "yamlRestTestV" + COMPATIBLE_VERSION + "Compat";
@@ -147,7 +147,11 @@ public class YamlRestCompatTestPlugin implements Plugin<Project> {
                 );
                 task.setXpackConfigToFileTree(
                     config -> fileOperations.fileTree(
-                        config.getSingleFile().toPath().resolve(RELATIVE_REST_XPACK_RESOURCES).resolve(RELATIVE_TEST_PATH)
+                        config.getSingleFile()
+                            .toPath()
+                            .resolve(RELATIVE_REST_XPACK)
+                            .resolve(RELATIVE_REST_PROJECT_RESOURCES)
+                            .resolve(RELATIVE_TEST_PATH)
                     )
                 );
                 task.setAdditionalConfigToFileTree(


### PR DESCRIPTION
Compatible REST tests (like normal REST tests) allow copying the tests from either `rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test` (includeCore) or `x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test`  (includeXpack). Both are currently broken.  https://github.com/elastic/elasticsearch/pull/90851 fixes the former , and this commit fixes the later. The fix here is to ensure the correct path to the x-pack rest tests when pulling from the elder branch for compatible testing. This only impacts modules that have the compatibility plugin enabled and are configured to pull from the main x-pack  set of tests. Currently, this should only impact `:x-pack:plugin:enrich:qa:rest` but will fix it for future projects with that configuration. 
