### PR TITLE
Dry up TransportResponseHandler use via ActionListenerResponseHandler

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/ActionListenerResponseHandler.java
+++ b/server/src/main/java/org/elasticsearch/action/ActionListenerResponseHandler.java
@@ -24,7 +24,7 @@ import java.util.Objects;
  */
 public class ActionListenerResponseHandler<Response extends TransportResponse> implements TransportResponseHandler<Response> {
 
-    private final ActionListener<? super Response> listener;
+    protected final ActionListener<? super Response> listener;
     private final Writeable.Reader<Response> reader;
     private final String executor;
 

--- a/server/src/main/java/org/elasticsearch/action/resync/TransportResyncReplicationAction.java
+++ b/server/src/main/java/org/elasticsearch/action/resync/TransportResyncReplicationAction.java
@@ -8,6 +8,7 @@
 package org.elasticsearch.action.resync;
 
 import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.ActionListenerResponseHandler;
 import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.replication.ReplicationOperation;
 import org.elasticsearch.action.support.replication.ReplicationResponse;
@@ -31,8 +32,6 @@ import org.elasticsearch.indices.IndicesService;
 import org.elasticsearch.indices.SystemIndices;
 import org.elasticsearch.tasks.Task;
 import org.elasticsearch.threadpool.ThreadPool;
-import org.elasticsearch.transport.TransportException;
-import org.elasticsearch.transport.TransportResponseHandler;
 import org.elasticsearch.transport.TransportService;
 
 import java.io.IOException;
@@ -191,11 +190,7 @@ public class TransportResyncReplicationAction extends TransportWriteAction<
             new ConcreteShardRequest<>(request, primaryAllocationId, primaryTerm),
             parentTask,
             transportOptions,
-            new TransportResponseHandler<ResyncReplicationResponse>() {
-                @Override
-                public ResyncReplicationResponse read(StreamInput in) throws IOException {
-                    return newResponseInstance(in);
-                }
+            new ActionListenerResponseHandler<>(listener, TransportResyncReplicationAction.this::newResponseInstance) {
 
                 @Override
                 public void handleResponse(ResyncReplicationResponse response) {
@@ -209,11 +204,6 @@ public class TransportResyncReplicationAction extends TransportWriteAction<
                         );
                     }
                     listener.onResponse(response);
-                }
-
-                @Override
-                public void handleException(TransportException exp) {
-                    listener.onFailure(exp);
                 }
             }
         );

--- a/server/src/main/java/org/elasticsearch/action/support/single/instance/TransportInstanceSingleOperationAction.java
+++ b/server/src/main/java/org/elasticsearch/action/support/single/instance/TransportInstanceSingleOperationAction.java
@@ -9,6 +9,7 @@
 package org.elasticsearch.action.support.single.instance;
 
 import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.ActionListenerResponseHandler;
 import org.elasticsearch.action.ActionResponse;
 import org.elasticsearch.action.UnavailableShardsException;
 import org.elasticsearch.action.support.ActionFilters;
@@ -38,7 +39,6 @@ import org.elasticsearch.transport.TransportChannel;
 import org.elasticsearch.transport.TransportException;
 import org.elasticsearch.transport.TransportRequestHandler;
 import org.elasticsearch.transport.TransportRequestOptions;
-import org.elasticsearch.transport.TransportResponseHandler;
 import org.elasticsearch.transport.TransportService;
 
 import java.io.IOException;
@@ -184,29 +184,24 @@ public abstract class TransportInstanceSingleOperationAction<
 
             request.shardId = shardIt.shardId();
             DiscoveryNode node = clusterState.nodes().get(shard.currentNodeId());
-            transportService.sendRequest(node, shardActionName, request, transportOptions(), new TransportResponseHandler<Response>() {
-
-                @Override
-                public Response read(StreamInput in) throws IOException {
-                    return newResponse(in);
-                }
-
-                @Override
-                public void handleResponse(Response response) {
-                    listener.onResponse(response);
-                }
-
-                @Override
-                public void handleException(TransportException exp) {
-                    final Throwable cause = exp.unwrapCause();
-                    // if we got disconnected from the node, or the node / shard is not in the right state (being closed)
-                    if (cause instanceof ConnectTransportException || cause instanceof NodeClosedException || retryOnFailure(exp)) {
-                        retry((Exception) cause);
-                    } else {
-                        listener.onFailure(exp);
+            transportService.sendRequest(
+                node,
+                shardActionName,
+                request,
+                transportOptions(),
+                new ActionListenerResponseHandler<>(listener, TransportInstanceSingleOperationAction.this::newResponse) {
+                    @Override
+                    public void handleException(TransportException exp) {
+                        final Throwable cause = exp.unwrapCause();
+                        // if we got disconnected from the node, or the node / shard is not in the right state (being closed)
+                        if (cause instanceof ConnectTransportException || cause instanceof NodeClosedException || retryOnFailure(exp)) {
+                            retry((Exception) cause);
+                        } else {
+                            listener.onFailure(exp);
+                        }
                     }
                 }
-            });
+            );
         }
 
         void retry(@Nullable final Exception failure) {

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/TransportGetCheckpointAction.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/TransportGetCheckpointAction.java
@@ -10,6 +10,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.ActionListenerResponseHandler;
 import org.elasticsearch.action.NoShardAvailableActionException;
 import org.elasticsearch.action.OriginalIndices;
 import org.elasticsearch.action.UnavailableShardsException;
@@ -24,21 +25,17 @@ import org.elasticsearch.cluster.routing.ShardRouting;
 import org.elasticsearch.cluster.routing.ShardsIterator;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.inject.Inject;
-import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.indices.IndicesService;
 import org.elasticsearch.tasks.Task;
 import org.elasticsearch.transport.ActionNotFoundTransportException;
-import org.elasticsearch.transport.TransportException;
 import org.elasticsearch.transport.TransportRequestOptions;
-import org.elasticsearch.transport.TransportResponseHandler;
 import org.elasticsearch.transport.TransportService;
 import org.elasticsearch.xpack.core.transform.action.GetCheckpointAction;
 import org.elasticsearch.xpack.core.transform.action.GetCheckpointAction.Request;
 import org.elasticsearch.xpack.core.transform.action.GetCheckpointAction.Response;
 import org.elasticsearch.xpack.core.transform.action.GetCheckpointNodeAction;
 
-import java.io.IOException;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -200,24 +197,7 @@ public class TransportGetCheckpointAction extends HandledTransportAction<Request
                     nodeCheckpointsRequest,
                     task,
                     TransportRequestOptions.EMPTY,
-                    new TransportResponseHandler<GetCheckpointNodeAction.Response>() {
-
-                        @Override
-                        public GetCheckpointNodeAction.Response read(StreamInput in) throws IOException {
-                            return new GetCheckpointNodeAction.Response(in);
-                        }
-
-                        @Override
-                        public void handleResponse(GetCheckpointNodeAction.Response response) {
-                            groupedListener.onResponse(response);
-                        }
-
-                        @Override
-                        public void handleException(TransportException exp) {
-                            groupedListener.onFailure(exp);
-                        }
-
-                    }
+                    new ActionListenerResponseHandler<>(groupedListener, GetCheckpointNodeAction.Response::new)
                 );
             }
         }


### PR DESCRIPTION
Use the action listener response handler in a couple additional spots to get proper `toString` that make slow logging easier to interpret if needed and to save some LoC and duplication.
