### PR TITLE
[8.5] Set the enrich maintenance cluster lifecycle listener only once (#90486)

### DIFF
--- a/docs/changelog/90486.yaml
+++ b/docs/changelog/90486.yaml
@@ -1,0 +1,5 @@
+pr: 90486
+summary: Set the enrich maintenance cluster lifecycle listener only once
+area: Ingest Node
+type: bug
+issues: []


### PR DESCRIPTION
Backports the following commits to 8.5:
 - Set the enrich maintenance cluster lifecycle listener only once (#90486)