### PR TITLE
[7.17] Set the enrich maintenance cluster lifecycle listener only once (#90486)

### DIFF
--- a/docs/changelog/90486.yaml
+++ b/docs/changelog/90486.yaml
@@ -1,0 +1,5 @@
+pr: 90486
+summary: Set the enrich maintenance cluster lifecycle listener only once
+area: Ingest Node
+type: bug
+issues: []

--- a/x-pack/plugin/enrich/src/main/java/org/elasticsearch/xpack/enrich/EnrichPolicyMaintenanceService.java
+++ b/x-pack/plugin/enrich/src/main/java/org/elasticsearch/xpack/enrich/EnrichPolicyMaintenanceService.java
@@ -8,6 +8,7 @@ package org.elasticsearch.xpack.enrich;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.apache.lucene.util.SetOnce;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.admin.indices.delete.DeleteIndexRequest;
 import org.elasticsearch.action.admin.indices.get.GetIndexRequest;
@@ -55,6 +56,8 @@ public class EnrichPolicyMaintenanceService implements LocalNodeMasterListener {
     private volatile Scheduler.Cancellable cancellable;
     private final Semaphore maintenanceLock = new Semaphore(1);
 
+    private final SetOnce<LifecycleListener> beforeStopListener = new SetOnce<>();
+
     EnrichPolicyMaintenanceService(
         Settings settings,
         Client client,
@@ -78,12 +81,10 @@ public class EnrichPolicyMaintenanceService implements LocalNodeMasterListener {
         if (cancellable == null || cancellable.isCancelled()) {
             isMaster = true;
             scheduleNext();
-            clusterService.addLifecycleListener(new LifecycleListener() {
-                @Override
-                public void beforeStop() {
-                    offMaster();
-                }
-            });
+            // Only set the lifecycle listener if it hasn't already been set.
+            if (beforeStopListener.trySet(new StopMaintenanceOnLifecycleStop())) {
+                clusterService.addLifecycleListener(beforeStopListener.get());
+            }
         }
     }
 
@@ -95,7 +96,18 @@ public class EnrichPolicyMaintenanceService implements LocalNodeMasterListener {
         }
     }
 
-    private void scheduleNext() {
+    /**
+     * Lifecycle listener that halts the maintenance service when node is shutting down.
+     */
+    private class StopMaintenanceOnLifecycleStop extends LifecycleListener {
+        @Override
+        public void beforeStop() {
+            offMaster();
+        }
+    }
+
+    // Visible for testing
+    protected void scheduleNext() {
         if (isMaster) {
             try {
                 TimeValue waitTime = EnrichPlugin.ENRICH_CLEANUP_PERIOD.get(settings);

--- a/x-pack/plugin/enrich/src/test/java/org/elasticsearch/xpack/enrich/EnrichPolicyMaintenanceServiceTests.java
+++ b/x-pack/plugin/enrich/src/test/java/org/elasticsearch/xpack/enrich/EnrichPolicyMaintenanceServiceTests.java
@@ -42,6 +42,10 @@ import static org.elasticsearch.xpack.core.enrich.EnrichPolicy.MATCH_TYPE;
 import static org.elasticsearch.xpack.enrich.AbstractEnrichTestCase.createSourceIndices;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
 public class EnrichPolicyMaintenanceServiceTests extends ESSingleNodeTestCase {
 
@@ -105,6 +109,32 @@ public class EnrichPolicyMaintenanceServiceTests extends ESSingleNodeTestCase {
         maintenanceService.cleanUpEnrichIndices();
         expectedIndices.remove(policy1Index2);
         assertEnrichIndicesExist(expectedIndices);
+    }
+
+    public void testOnlyOneLifecycleListenerAdded() {
+        ClusterService clusterService = mock(ClusterService.class);
+        ThreadPool threadPool = mock(ThreadPool.class);
+        // Extend the maintenance service to do no work on the schedule call.
+        EnrichPolicyMaintenanceService service = new EnrichPolicyMaintenanceService(
+            Settings.EMPTY,
+            client(),
+            clusterService,
+            threadPool,
+            new EnrichPolicyLocks()
+        ) {
+            @Override
+            protected void scheduleNext() {
+                // Do nothing
+            }
+        };
+
+        // Execute the onMaster operation which should "schedule" the runnable and set the lifecycle listener.
+        service.onMaster();
+        // Since it doesn't actually schedule the runnable, we can just run it again to check if it sets the listener twice.
+        service.onMaster();
+
+        // Only set the listener once, despite multiple master swaps.
+        verify(clusterService, times(1)).addLifecycleListener(any());
     }
 
     private void assertEnrichIndicesExist(Set<String> activeIndices) {


### PR DESCRIPTION
Backports the following commits to 7.17:
 - Set the enrich maintenance cluster lifecycle listener only once (#90486)