### PR TITLE
Run TransportListTasksAction in the generic pool

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/node/tasks/list/TransportListTasksAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/node/tasks/list/TransportListTasksAction.java
@@ -46,7 +46,7 @@ public class TransportListTasksAction extends TransportTasksAction<Task, ListTas
             ListTasksRequest::new,
             ListTasksResponse::new,
             TaskInfo::from,
-            ThreadPool.Names.MANAGEMENT
+            ThreadPool.Names.GENERIC
         );
     }
 


### PR DESCRIPTION
It can block if we the command needs to wait for completion of all tasks and thus block the management pool
