### PR TITLE
Fix computation stats

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/allocator/DesiredBalanceComputer.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/allocator/DesiredBalanceComputer.java
@@ -242,6 +242,7 @@ public class DesiredBalanceComputer {
             // TODO what if we never converge?
             // TODO maybe expose interim desired balances computed here
 
+            i++;
             if (hasChanges == false) {
                 logger.debug("Desired balance computation converged after {} iterations", i);
                 break;
@@ -252,11 +253,10 @@ public class DesiredBalanceComputer {
                 logger.debug("Newer cluster state received, publishing incomplete desired balance and restarting computation");
                 break;
             }
-            if (i > 0 && i % 100 == 0) {
+            if (i % 100 == 0) {
                 // TODO this warning should be time based, iteration count should be proportional to the number of shards
                 logger.debug("Desired balance computation is still not converged after {} iterations", i);
             }
-            i++;
         }
         iterations.inc(i);
 


### PR DESCRIPTION
I executed a simulation and received following stats:
```
[2022-10-17T15:12:01,122][INFO ][o.e.c.r.a.a.ClusterRebalanceRoutingTests] [testCreateManyIndicesAndAddNewNode] Desired balance allocator stats [DesiredBalanceStats[
lastConvergedIndex=12692,
computationActive=true,
computationSubmitted=12694,
computationExecuted=11069,
computationConverged=7864,
computationIterations=3515, <----
cumulativeComputationTime=534099,
cumulativeReconciliationTime=51423
]]
```

It was completely unexpected that `computationIterations` << `computationSubmitted` as every time we execute at least 1 iteration. It turned out that code exits computation loop before incrementing iteration count if input is outdated or computation is converged. Moving the increment before computation exit.