### PR TITLE
[8.5] Validate field names when subobjects are disabled (#90950)

### DIFF
--- a/docs/changelog/90950.yaml
+++ b/docs/changelog/90950.yaml
@@ -1,0 +1,5 @@
+pr: 90950
+summary: Validate field names when subobjects are disabled
+area: Mapping
+type: bug
+issues: []

--- a/server/src/main/java/org/elasticsearch/index/mapper/DocumentParser.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/DocumentParser.java
@@ -313,6 +313,9 @@ public final class DocumentParser {
                     if (currentFieldName.isBlank()) {
                         throwFieldNameBlank(context, currentFieldName);
                     }
+                    if (currentFieldName.replace(".", "").length() == 0) {
+                        throwFieldNameOnlyDots();
+                    }
                     break;
                 case START_OBJECT:
                     parseObject(context, mapper, currentFieldName);
@@ -337,6 +340,10 @@ public final class DocumentParser {
         throw new MapperParsingException(
             "Field name cannot contain only whitespace: [" + context.path().pathAsText(currentFieldName) + "]"
         );
+    }
+
+    private static void throwFieldNameOnlyDots() {
+        throw new IllegalArgumentException("field name cannot contain only dots");
     }
 
     private static void throwEOF(ObjectMapper mapper, DocumentParserContext context) throws IOException {

--- a/server/src/main/java/org/elasticsearch/index/mapper/DotExpandingXContentParser.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/DotExpandingXContentParser.java
@@ -73,9 +73,6 @@ class DotExpandingXContentParser extends FilterXContentParserWrapper {
             XContentParser delegate = delegate();
             String field = delegate.currentName();
             String[] subpaths = splitAndValidatePath(field);
-            if (subpaths.length == 0) {
-                throw new IllegalArgumentException("field name cannot contain only dots: [" + field + "]");
-            }
             // Corner case: if the input has a single trailing '.', eg 'field.', then we will get a single
             // subpath due to the way String.split() works. We can only return fast here if this is not
             // the case

--- a/server/src/test/java/org/elasticsearch/index/mapper/DocumentParserTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/DocumentParserTests.java
@@ -1847,8 +1847,27 @@ public class DocumentParserTests extends MapperServiceTestCase {
         assertThat(err.getCause().getMessage(), containsString("field name cannot be an empty string"));
     }
 
+    public void testBlankFieldNamesSubobjectsFalse() throws Exception {
+        DocumentMapper mapper = createDocumentMapper(topMapping(b -> b.field("subobjects", false)));
+        {
+            MapperParsingException err = expectThrows(MapperParsingException.class, () -> mapper.parse(source(b -> b.field("", "foo"))));
+            assertThat(err.getMessage(), containsString("Field name cannot contain only whitespace: []"));
+        }
+        {
+            MapperParsingException err = expectThrows(MapperParsingException.class, () -> mapper.parse(source(b -> b.field("  ", "foo"))));
+            assertThat(err.getMessage(), containsString("Field name cannot contain only whitespace: [  ]"));
+        }
+    }
+
     public void testDotsOnlyFieldNames() throws Exception {
-        DocumentMapper mapper = createDocumentMapper(mapping(b -> {}));
+        dotsOnlyFieldNames(createDocumentMapper(mapping(b -> {})));
+    }
+
+    public void testDotsOnlyFieldNamesSubobjectsFalse() throws Exception {
+        dotsOnlyFieldNames(createDocumentMapper(topMapping(b -> b.field("subobjects", false))));
+    }
+
+    private void dotsOnlyFieldNames(DocumentMapper mapper) {
         MapperParsingException err = expectThrows(
             MapperParsingException.class,
             () -> mapper.parse(source(b -> b.field(randomFrom(".", "..", "..."), "bar")))


### PR DESCRIPTION
Backports the following commits to 8.5:
 - Validate field names when subobjects are disabled (#90950)