### PR TITLE
[DOCS] Add ML CPP PR to release notes

### DIFF
--- a/docs/reference/release-notes/7.17.7.asciidoc
+++ b/docs/reference/release-notes/7.17.7.asciidoc
@@ -25,6 +25,9 @@ Infra/Core::
 Ingest Node::
 * Fix pipeline id not being present in ingest metadata inside `on_failure` block {es-pull}89632[#89632]
 
+Machine Learning::
+* Do not retain categorization tokens when existing category matches {ml-pull}2398[#2398]
+
 Network::
 * Fix memory leak when double invoking `RestChannel.sendResponse` {es-pull}89873[#89873]
 


### PR DESCRIPTION
This PR adds the details from https://github.com/elastic/ml-cpp/blob/7.17/docs/CHANGELOG.asciidoc to the appropriate release notes.

### Preview

https://elasticsearch_90957.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/7.17/release-notes-7.17.7.html