### PR TITLE
[8.5] Fix true/false accumulation bug in boolean source fallback (#90895)

### DIFF
--- a/docs/changelog/90895.yaml
+++ b/docs/changelog/90895.yaml
@@ -1,0 +1,5 @@
+pr: 90895
+summary: Fix true/false accumulation bug in boolean source fallback
+area: Infra/Scripting
+type: bug
+issues: []

--- a/server/src/main/java/org/elasticsearch/index/fielddata/SourceValueFetcherSortedBooleanIndexFieldData.java
+++ b/server/src/main/java/org/elasticsearch/index/fielddata/SourceValueFetcherSortedBooleanIndexFieldData.java
@@ -81,7 +81,7 @@ public class SourceValueFetcherSortedBooleanIndexFieldData extends SourceValueFe
         }
     }
 
-    private static class SourceValueFetcherSortedBooleanDocValues extends SortedNumericDocValues implements ValueFetcherDocValues {
+    static class SourceValueFetcherSortedBooleanDocValues extends SortedNumericDocValues implements ValueFetcherDocValues {
 
         private final LeafReaderContext leafReaderContext;
 
@@ -92,7 +92,7 @@ public class SourceValueFetcherSortedBooleanIndexFieldData extends SourceValueFe
         private int falseCount;
         private int iteratorIndex;
 
-        private SourceValueFetcherSortedBooleanDocValues(
+        SourceValueFetcherSortedBooleanDocValues(
             LeafReaderContext leafReaderContext,
             ValueFetcher valueFetcher,
             SourceLookup sourceLookup
@@ -105,6 +105,9 @@ public class SourceValueFetcherSortedBooleanIndexFieldData extends SourceValueFe
         @Override
         public boolean advanceExact(int doc) throws IOException {
             sourceLookup.setSegmentAndDocument(leafReaderContext, doc);
+
+            trueCount = 0;
+            falseCount = 0;
 
             for (Object value : valueFetcher.fetchValues(sourceLookup, Collections.emptyList())) {
                 assert value instanceof Boolean;

--- a/server/src/test/java/org/elasticsearch/index/fielddata/SourceValueFetcherIndexFieldDataTests.java
+++ b/server/src/test/java/org/elasticsearch/index/fielddata/SourceValueFetcherIndexFieldDataTests.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.index.fielddata;
+
+import org.apache.lucene.index.LeafReaderContext;
+import org.elasticsearch.index.fielddata.SourceValueFetcherSortedBooleanIndexFieldData.SourceValueFetcherSortedBooleanDocValues;
+import org.elasticsearch.search.lookup.SourceLookup;
+import org.elasticsearch.test.ESTestCase;
+
+import java.io.IOException;
+import java.util.List;
+
+public class SourceValueFetcherIndexFieldDataTests extends ESTestCase {
+
+    public void testSourceValueFetcherSortedBooleanDocValues() throws IOException {
+        List<List<Object>> docs = List.of(
+            List.of(randomBoolean()),
+            List.of(randomBoolean(), randomBoolean()),
+            List.of(randomBoolean(), randomBoolean(), randomBoolean(), randomBoolean()),
+            List.of(randomBoolean(), randomBoolean(), randomBoolean(), randomBoolean(), randomBoolean(), randomBoolean())
+        );
+
+        int[] doc = new int[1];
+
+        SourceValueFetcherSortedBooleanDocValues values = new SourceValueFetcherSortedBooleanDocValues(
+            null,
+            (source, ignoredValues) -> docs.get(doc[0]++),
+            new SourceLookup(null) {
+                @Override
+                public void setSegmentAndDocument(LeafReaderContext context, int docId) {
+                    // do nothing
+                }
+            }
+        );
+
+        for (int i = 0; i < docs.size(); ++i) {
+            values.advanceExact(i);
+
+            int docTrues = 0;
+            int docFalses = 0;
+
+            for (Object object : docs.get(i)) {
+                if ((boolean) object) {
+                    ++docTrues;
+                } else {
+                    ++docFalses;
+                }
+            }
+
+            assertEquals(docs.get(i).size(), values.docValueCount());
+
+            int valueTrues = 0;
+            int valueFalses = 0;
+
+            for (int j = 0; j < values.docValueCount(); ++j) {
+                long value = values.nextValue();
+
+                if (value == 1L) {
+                    ++valueTrues;
+                } else if (value == 0L) {
+                    ++valueFalses;
+                } else {
+                    throw new IllegalStateException("expected 0L or 1L for boolean value, found [" + value + "]");
+                }
+            }
+
+            assertEquals(docTrues, valueTrues);
+            assertEquals(docFalses, valueFalses);
+        }
+    }
+}


### PR DESCRIPTION
Backports the following commits to 8.5:

*  Fix true/false accumulation bug in boolean source fallback (#90895)