### PR TITLE
[8.5] [CCR] Data streams: order follower backing indices by original name (#90850)

### DIFF
--- a/docs/changelog/90850.yaml
+++ b/docs/changelog/90850.yaml
@@ -1,0 +1,6 @@
+pr: 90850
+summary: "[CCR] Data streams: order follower backing indices by original name"
+area: "CCR"
+type: bug
+issues:
+ - 90820

--- a/x-pack/plugin/ccr/qa/multi-cluster/src/test/java/org/elasticsearch/xpack/ccr/AutoFollowIT.java
+++ b/x-pack/plugin/ccr/qa/multi-cluster/src/test/java/org/elasticsearch/xpack/ccr/AutoFollowIT.java
@@ -13,6 +13,7 @@ import org.elasticsearch.client.Request;
 import org.elasticsearch.client.Response;
 import org.elasticsearch.client.ResponseException;
 import org.elasticsearch.client.RestClient;
+import org.elasticsearch.cluster.metadata.DataStream;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.settings.SecureString;
 import org.elasticsearch.common.settings.Settings;
@@ -33,6 +34,7 @@ import java.util.concurrent.TimeUnit;
 
 import static org.elasticsearch.core.Strings.format;
 import static org.elasticsearch.xcontent.ObjectPath.eval;
+import static org.elasticsearch.xpack.core.ilm.ShrinkIndexNameSupplier.SHRUNKEN_INDEX_PREFIX;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.emptyOrNullString;
 import static org.hamcrest.Matchers.equalTo;
@@ -510,6 +512,133 @@ public class AutoFollowIT extends ESCCRRestTestCase {
                 List.of()
             );
         }
+    }
+
+    @SuppressWarnings("unchecked")
+    public void testDataStreamsBackingIndicesOrdering() throws Exception {
+        if ("follow".equals(targetCluster) == false) {
+            return;
+        }
+
+        final int initialNumDocs = 16;
+        int initialNumberOfSuccessfulFollowedIndices = getNumberOfSuccessfulFollowedIndices();
+        final String dataStreamName = getTestName().toLowerCase(Locale.ROOT) + "-logs-syslog-prod";
+        Request putComposableIndexTemplateRequest = new Request("POST", "/_index_template/" + getTestName().toLowerCase(Locale.ROOT));
+        putComposableIndexTemplateRequest.setJsonEntity("{\"index_patterns\":[\"" + dataStreamName + "*\"],\"data_stream\":{}}");
+        assertOK(client().performRequest(putComposableIndexTemplateRequest));
+
+        final String autoFollowPatternName = getTestName().toLowerCase(Locale.ROOT);
+        // Initialize data stream prior to auto following
+        try (RestClient leaderClient = buildLeaderClient()) {
+            assertOK(leaderClient.performRequest(putComposableIndexTemplateRequest));
+
+            for (int i = 0; i < initialNumDocs; i++) {
+                Request indexRequest = new Request("POST", "/" + dataStreamName + "/_doc");
+                indexRequest.addParameter("refresh", "true");
+                indexRequest.setJsonEntity("{\"@timestamp\": \"" + DATE_FORMAT.format(new Date()) + "\",\"message\":\"abc\"}");
+                assertOK(leaderClient.performRequest(indexRequest));
+            }
+            verifyDataStream(leaderClient, dataStreamName, backingIndexName(dataStreamName, 1));
+            verifyDocuments(leaderClient, dataStreamName, initialNumDocs);
+        }
+
+        // Create auto follow pattern
+        createAutoFollowPattern(client(), autoFollowPatternName, dataStreamName + "*", "leader_cluster", null);
+
+        // Rollover and ensure only second backing index is replicated:
+        try (RestClient leaderClient = buildLeaderClient()) {
+            Request rolloverRequest = new Request("POST", "/" + dataStreamName + "/_rollover");
+            assertOK(leaderClient.performRequest(rolloverRequest));
+            verifyDataStream(leaderClient, dataStreamName, backingIndexName(dataStreamName, 1), backingIndexName(dataStreamName, 2));
+
+            Request indexRequest = new Request("POST", "/" + dataStreamName + "/_doc");
+            indexRequest.addParameter("refresh", "true");
+            indexRequest.setJsonEntity("{\"@timestamp\": \"" + DATE_FORMAT.format(new Date()) + "\",\"message\":\"abc\"}");
+            assertOK(leaderClient.performRequest(indexRequest));
+            verifyDocuments(leaderClient, dataStreamName, initialNumDocs + 1);
+
+            assertOK(leaderClient.performRequest(rolloverRequest));
+            assertOK(leaderClient.performRequest(indexRequest));
+            verifyDataStream(
+                leaderClient,
+                dataStreamName,
+                backingIndexName(dataStreamName, 1),
+                backingIndexName(dataStreamName, 2),
+                backingIndexName(dataStreamName, 3)
+            );
+
+        }
+
+        assertBusy(() -> assertThat(indexExists(backingIndexName(dataStreamName, 2)), is(true)));
+        assertBusy(() -> assertThat(indexExists(backingIndexName(dataStreamName, 3)), is(true)));
+
+        // Replace a backing index in the follower data stream with one that has a prefix (simulating a shrink)
+
+        String shrunkIndexName = SHRUNKEN_INDEX_PREFIX + DataStream.getDefaultBackingIndexName(dataStreamName, 2);
+        Request indexRequest = new Request("POST", "/" + shrunkIndexName + "/_doc");
+        indexRequest.addParameter("refresh", "true");
+        indexRequest.setJsonEntity("{\"@timestamp\": \"" + DATE_FORMAT.format(new Date()) + "\",\"message\":\"abc\"}");
+        client().performRequest(indexRequest);
+
+        Request modifyDataStream = new Request("POST", "_data_stream/_modify");
+        modifyDataStream.setJsonEntity(
+            "{\n"
+                + "  \"actions\": [\n"
+                + "    {\n"
+                + "      \"remove_backing_index\": {\n"
+                + "        \"data_stream\": \""
+                + dataStreamName
+                + "\",\n"
+                + "        \"index\": \""
+                + DataStream.getDefaultBackingIndexName(dataStreamName, 2)
+                + "\"\n"
+                + "      }\n"
+                + "    },\n"
+                + "    {\n"
+                + "      \"add_backing_index\": {\n"
+                + "        \"data_stream\": \""
+                + dataStreamName
+                + "\",\n"
+                + "        \"index\": \""
+                + shrunkIndexName
+                + "\"\n"
+                + "      }\n"
+                + "    }\n"
+                + "  ]\n"
+                + "}"
+        );
+        client().performRequest(modifyDataStream);
+
+        // Rollover the leader data stream so we replicate a new index to the following data stream (the 4th generation)
+        try (RestClient leaderClient = buildLeaderClient()) {
+            Request rolloverRequest = new Request("POST", "/" + dataStreamName + "/_rollover");
+            assertOK(leaderClient.performRequest(rolloverRequest));
+            verifyDataStream(
+                leaderClient,
+                dataStreamName,
+                backingIndexName(dataStreamName, 1),
+                backingIndexName(dataStreamName, 2),
+                backingIndexName(dataStreamName, 3),
+                backingIndexName(dataStreamName, 4)
+            );
+
+            indexRequest = new Request("POST", "/" + dataStreamName + "/_doc");
+            indexRequest.addParameter("refresh", "true");
+            indexRequest.setJsonEntity("{\"@timestamp\": \"" + DATE_FORMAT.format(new Date()) + "\",\"message\":\"abc\"}");
+            assertOK(leaderClient.performRequest(indexRequest));
+        }
+
+        assertBusy(() -> {
+            Request request = new Request("GET", "/_data_stream/" + dataStreamName);
+            Map<String, ?> response = toMap(client().performRequest(request));
+            List<?> retrievedDataStreams = (List<?>) response.get("data_streams");
+            List<?> actualBackingIndexItems = (List<?>) ((Map<?, ?>) retrievedDataStreams.get(0)).get("indices");
+            assertThat(actualBackingIndexItems.size(), is(3));
+            Map<String, String> writeIndexMap = (Map<String, String>) actualBackingIndexItems.get(2);
+            assertThat(writeIndexMap.get("index_name"), not(shrunkIndexName));
+            assertThat(writeIndexMap.get("index_name"), is(backingIndexName(dataStreamName, 4)));
+            assertThat(getNumberOfSuccessfulFollowedIndices(), equalTo(initialNumberOfSuccessfulFollowedIndices + 3));
+        });
     }
 
     public void testRolloverDataStreamInFollowClusterForbidden() throws Exception {

--- a/x-pack/plugin/ccr/src/test/java/org/elasticsearch/xpack/ccr/action/TransportPutFollowActionTests.java
+++ b/x-pack/plugin/ccr/src/test/java/org/elasticsearch/xpack/ccr/action/TransportPutFollowActionTests.java
@@ -11,13 +11,16 @@ import org.elasticsearch.cluster.metadata.DataStream;
 import org.elasticsearch.index.Index;
 import org.elasticsearch.test.ESTestCase;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.core.Is.is;
 
 public class TransportPutFollowActionTests extends ESTestCase {
 
@@ -90,6 +93,77 @@ public class TransportPutFollowActionTests extends ESTestCase {
         assertThat(result.getIndices().get(0).getName(), equalTo(DataStream.getDefaultBackingIndexName("logs-foobar", 1)));
         assertThat(result.getIndices().get(1).getName(), equalTo(DataStream.getDefaultBackingIndexName("logs-foobar", 4)));
         assertThat(result.getIndices().get(2).getName(), equalTo(DataStream.getDefaultBackingIndexName("logs-foobar", 5)));
+    }
+
+    public void testLocalDataStreamBackingIndicesOrder() {
+        DataStream remoteDataStream = generateDataSteam("logs-foobar", 8, false);
+
+        List<Index> initialLocalBackingIndices = new ArrayList<>();
+        initialLocalBackingIndices.add(new Index("random-name", UUID.randomUUID().toString()));
+        String dsFirstGeneration = DataStream.getDefaultBackingIndexName("logs-foobar", 1);
+        initialLocalBackingIndices.add(new Index(dsFirstGeneration, UUID.randomUUID().toString()));
+        String shrunkDsSecondGeneration = "shrink-" + DataStream.getDefaultBackingIndexName("logs-foobar", 2);
+        initialLocalBackingIndices.add(new Index(shrunkDsSecondGeneration, UUID.randomUUID().toString()));
+        String partialThirdGeneration = "partial-" + DataStream.getDefaultBackingIndexName("logs-foobar", 3);
+        initialLocalBackingIndices.add(new Index(partialThirdGeneration, UUID.randomUUID().toString()));
+        String forthGeneration = DataStream.getDefaultBackingIndexName("logs-foobar", 4);
+        initialLocalBackingIndices.add(new Index(forthGeneration, UUID.randomUUID().toString()));
+        String sixthGeneration = DataStream.getDefaultBackingIndexName("logs-foobar", 6);
+        initialLocalBackingIndices.add(new Index(sixthGeneration, UUID.randomUUID().toString()));
+        initialLocalBackingIndices.add(new Index("absolute-name", UUID.randomUUID().toString()));
+        initialLocalBackingIndices.add(new Index("persistent-name", UUID.randomUUID().toString()));
+        String restoredFifthGeneration = "restored-" + DataStream.getDefaultBackingIndexName("logs-foobar", 5);
+        initialLocalBackingIndices.add(new Index(restoredFifthGeneration, UUID.randomUUID().toString()));
+        String differentDSBackingIndex = DataStream.getDefaultBackingIndexName("different-datastream", 2);
+        initialLocalBackingIndices.add(new Index(differentDSBackingIndex, UUID.randomUUID().toString()));
+
+        DataStream localDataStream = new DataStream(
+            "logs-foobar",
+            initialLocalBackingIndices,
+            initialLocalBackingIndices.size(),
+            Map.of(),
+            false,
+            true,
+            false,
+            false,
+            null
+        );
+
+        // follow backing index 7
+        Index backingIndexToFollow = remoteDataStream.getIndices().get(6);
+        DataStream result = TransportPutFollowAction.updateLocalDataStream(
+            backingIndexToFollow,
+            localDataStream,
+            remoteDataStream.getName(),
+            remoteDataStream
+        );
+
+        assertThat(result.getName(), equalTo(remoteDataStream.getName()));
+        assertThat(result.getTimeStampField(), equalTo(remoteDataStream.getTimeStampField()));
+        assertThat(result.getGeneration(), equalTo(remoteDataStream.getGeneration()));
+        assertThat(result.getIndices().size(), equalTo(initialLocalBackingIndices.size() + 1));
+        // the later generation we just followed became the local data stream write index
+        assertThat(result.getWriteIndex().getName(), is(remoteDataStream.getIndices().get(6).getName()));
+
+        List<String> localIndicesNames = result.getIndices().stream().map(Index::getName).collect(Collectors.toList());
+        assertThat(
+            localIndicesNames,
+            is(
+                List.of(
+                    differentDSBackingIndex,
+                    "absolute-name",
+                    "persistent-name",
+                    "random-name",
+                    dsFirstGeneration,
+                    shrunkDsSecondGeneration,
+                    partialThirdGeneration,
+                    forthGeneration,
+                    restoredFifthGeneration,
+                    sixthGeneration,
+                    DataStream.getDefaultBackingIndexName("logs-foobar", 7)
+                )
+            )
+        );
     }
 
     static DataStream generateDataSteam(String name, int numBackingIndices, boolean replicate) {


### PR DESCRIPTION
Backports the following commits to 8.5:
 - [CCR] Data streams: order follower backing indices by original name (#90850)