### PR TITLE
TaskManager traceRequest on/off for CancellableTask

### DIFF
--- a/docs/changelog/90972.yaml
+++ b/docs/changelog/90972.yaml
@@ -1,0 +1,6 @@
+pr: 90972
+summary: '`TaskManager` `traceRequest` on/off for `CancellableTask`'
+area: Infra/Core
+type: bug
+issues:
+ - 89850

--- a/docs/changelog/90972.yaml
+++ b/docs/changelog/90972.yaml
@@ -1,5 +1,5 @@
 pr: 90972
-summary: '`TaskManager` `traceRequest` on/off for `CancellableTask`'
+summary: 'Fix disabling APM tracing for `CancellableTask` in `TrainedModelAssignmentNodeService`'
 area: Infra/Core
 type: bug
 issues:


### PR DESCRIPTION
In certain situations, like ML model loading jobs we don't want to enable the APM tracer as per the original design. For that purpose, the `register` method of `TaskManager` contains the `traceRequest` flag, which is enabled by default unless explicitly disabled.

We disable tracing for ML model loading, but we didn't do it correctly when the Task was of CancellableTask type.

This PR fixes that control flow bug and adds tests for both control flow paths.

Fixes https://github.com/elastic/elasticsearch/issues/89850