### PR TITLE
Convert pending cluster task to a record

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/service/PendingClusterTask.java
+++ b/server/src/main/java/org/elasticsearch/cluster/service/PendingClusterTask.java
@@ -17,30 +17,17 @@ import org.elasticsearch.core.TimeValue;
 
 import java.io.IOException;
 
-public class PendingClusterTask implements Writeable {
-
-    private long insertOrder;
-    private Priority priority;
-    private Text source;
-    private long timeInQueue;
-    private boolean executing;
+public record PendingClusterTask(long insertOrder, Priority priority, Text source, long timeInQueue, boolean executing)
+    implements
+        Writeable {
 
     public PendingClusterTask(StreamInput in) throws IOException {
-        insertOrder = in.readVLong();
-        priority = Priority.readFrom(in);
-        source = in.readText();
-        timeInQueue = in.readLong();
-        executing = in.readBoolean();
+        this(in.readVLong(), Priority.readFrom(in), in.readText(), in.readLong(), in.readBoolean());
     }
 
-    public PendingClusterTask(long insertOrder, Priority priority, Text source, long timeInQueue, boolean executing) {
+    public PendingClusterTask {
         assert timeInQueue >= 0 : "got a negative timeInQueue [" + timeInQueue + "]";
         assert insertOrder >= 0 : "got a negative insertOrder [" + insertOrder + "]";
-        this.insertOrder = insertOrder;
-        this.priority = priority;
-        this.source = source;
-        this.timeInQueue = timeInQueue;
-        this.executing = executing;
     }
 
     public long getInsertOrder() {


### PR DESCRIPTION
This change makes all fields final as well as adds default equals/hashCode/toString implementation to simplify testing and debugging.
