### PR TITLE
[8.5] [CI] Fix RollupStepTest.testHashcodeAndEquals() (#90958)

### DIFF
--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/RollupStepTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/RollupStepTests.java
@@ -34,11 +34,6 @@ import static org.hamcrest.Matchers.is;
 
 public class RollupStepTests extends AbstractStepTestCase<RollupStep> {
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/90843")
-    public void testHashcodeAndEquals() {
-        super.testHashcodeAndEquals();
-    }
-
     @Override
     public RollupStep createRandomInstance() {
         StepKey stepKey = randomStepKey();
@@ -56,7 +51,7 @@ public class RollupStepTests extends AbstractStepTestCase<RollupStep> {
         switch (between(0, 2)) {
             case 0 -> key = new StepKey(key.getPhase(), key.getAction(), key.getName() + randomAlphaOfLength(5));
             case 1 -> nextKey = new StepKey(nextKey.getPhase(), nextKey.getAction(), nextKey.getName() + randomAlphaOfLength(5));
-            case 2 -> fixedInterval = ConfigTestHelpers.randomInterval();
+            case 2 -> fixedInterval = randomValueOtherThan(instance.getFixedInterval(), ConfigTestHelpers::randomInterval);
             default -> throw new AssertionError("Illegal randomisation branch");
         }
 


### PR DESCRIPTION
Backports #90958 to 8.5

> The test was failing because the random generated value was the same as the previous one, so equals() and hashCode() were the same.
> 
> Fixes #90843
> 