### PR TITLE
Off-by-one innerExecute current processor count

### DIFF
--- a/docs/changelog/90995.yaml
+++ b/docs/changelog/90995.yaml
@@ -1,0 +1,5 @@
+pr: 90995
+summary: Off-by-one `innerExecute` current processor count
+area: Ingest Node
+type: bug
+issues: []

--- a/server/src/main/java/org/elasticsearch/ingest/CompoundProcessor.java
+++ b/server/src/main/java/org/elasticsearch/ingest/CompoundProcessor.java
@@ -152,7 +152,8 @@ public class CompoundProcessor implements Processor {
         innerExecute(0, ingestDocument, handler);
     }
 
-    void innerExecute(int currentProcessor, IngestDocument ingestDocument, BiConsumer<IngestDocument, Exception> handler) {
+    void innerExecute(int currentProcessor, IngestDocument ingestDocument, final BiConsumer<IngestDocument, Exception> handler) {
+        assert currentProcessor <= processorsWithMetrics.size();
         if (currentProcessor == processorsWithMetrics.size()) {
             handler.accept(ingestDocument, null);
             return;
@@ -187,10 +188,11 @@ public class CompoundProcessor implements Processor {
             currentProcessor++;
         }
 
-        if (currentProcessor >= processorsWithMetrics.size()) {
+        assert currentProcessor <= processorsWithMetrics.size();
+        if (currentProcessor == processorsWithMetrics.size()) {
             handler.accept(ingestDocument, null);
         } else {
-            final int finalCurrentProcessor = currentProcessor + 1;
+            final int finalCurrentProcessor = currentProcessor;
             final int nextProcessor = currentProcessor + 1;
             final long finalStartTimeInNanos = startTimeInNanos;
             final IngestMetric finalMetric = processorsWithMetrics.get(currentProcessor).v2();
@@ -233,7 +235,7 @@ public class CompoundProcessor implements Processor {
                 } else {
                     finalMetric.postIngest(ingestTimeInNanos);
                 }
-                executeOnFailureOuter(currentProcessor, finalIngestDocument, handler, finalProcessor, finalMetric, e);
+                executeOnFailureOuter(finalCurrentProcessor, finalIngestDocument, handler, finalProcessor, finalMetric, e);
             }
         }
     }

--- a/server/src/main/java/org/elasticsearch/ingest/CompoundProcessor.java
+++ b/server/src/main/java/org/elasticsearch/ingest/CompoundProcessor.java
@@ -191,52 +191,53 @@ public class CompoundProcessor implements Processor {
         assert currentProcessor <= processorsWithMetrics.size();
         if (currentProcessor == processorsWithMetrics.size()) {
             handler.accept(ingestDocument, null);
-        } else {
-            final int finalCurrentProcessor = currentProcessor;
-            final int nextProcessor = currentProcessor + 1;
-            final long finalStartTimeInNanos = startTimeInNanos;
-            final IngestMetric finalMetric = processorsWithMetrics.get(currentProcessor).v2();
-            final Processor finalProcessor = processorsWithMetrics.get(currentProcessor).v1();
-            final IngestDocument finalIngestDocument = ingestDocument;
-            /*
-             * Our assumption is that the listener passed to the processor is only ever called once. However, there is no way to enforce
-             * that in all processors and all the code that they call. If the listener is called more than once it causes problems
-             * such as the metrics being wrong. The listenerHasBeenCalled variable is used to make sure that the code in the listener
-             * is only executed once.
-             */
-            final AtomicBoolean listenerHasBeenCalled = new AtomicBoolean(false);
-            finalMetric.preIngest();
-            final AtomicBoolean postIngestHasBeenCalled = new AtomicBoolean(false);
-            try {
-                finalProcessor.execute(ingestDocument, (result, e) -> {
-                    if (listenerHasBeenCalled.getAndSet(true)) {
-                        logger.warn("A listener was unexpectedly called more than once", new RuntimeException());
-                        assert false : "A listener was unexpectedly called more than once";
+            return;
+        }
+
+        final int finalCurrentProcessor = currentProcessor;
+        final int nextProcessor = currentProcessor + 1;
+        final long finalStartTimeInNanos = startTimeInNanos;
+        final IngestMetric finalMetric = processorsWithMetrics.get(currentProcessor).v2();
+        final Processor finalProcessor = processorsWithMetrics.get(currentProcessor).v1();
+        final IngestDocument finalIngestDocument = ingestDocument;
+        /*
+         * Our assumption is that the listener passed to the processor is only ever called once. However, there is no way to enforce
+         * that in all processors and all the code that they call. If the listener is called more than once it causes problems
+         * such as the metrics being wrong. The listenerHasBeenCalled variable is used to make sure that the code in the listener
+         * is only executed once.
+         */
+        final AtomicBoolean listenerHasBeenCalled = new AtomicBoolean(false);
+        finalMetric.preIngest();
+        final AtomicBoolean postIngestHasBeenCalled = new AtomicBoolean(false);
+        try {
+            finalProcessor.execute(ingestDocument, (result, e) -> {
+                if (listenerHasBeenCalled.getAndSet(true)) {
+                    logger.warn("A listener was unexpectedly called more than once", new RuntimeException());
+                    assert false : "A listener was unexpectedly called more than once";
+                } else {
+                    long ingestTimeInNanos = relativeTimeProvider.getAsLong() - finalStartTimeInNanos;
+                    finalMetric.postIngest(ingestTimeInNanos);
+                    postIngestHasBeenCalled.set(true);
+                    if (e != null) {
+                        executeOnFailureOuter(finalCurrentProcessor, finalIngestDocument, handler, finalProcessor, finalMetric, e);
                     } else {
-                        long ingestTimeInNanos = relativeTimeProvider.getAsLong() - finalStartTimeInNanos;
-                        finalMetric.postIngest(ingestTimeInNanos);
-                        postIngestHasBeenCalled.set(true);
-                        if (e != null) {
-                            executeOnFailureOuter(finalCurrentProcessor, finalIngestDocument, handler, finalProcessor, finalMetric, e);
+                        if (result != null) {
+                            innerExecute(nextProcessor, result, handler);
                         } else {
-                            if (result != null) {
-                                innerExecute(nextProcessor, result, handler);
-                            } else {
-                                handler.accept(null, null);
-                            }
+                            handler.accept(null, null);
                         }
                     }
-                });
-            } catch (Exception e) {
-                long ingestTimeInNanos = relativeTimeProvider.getAsLong() - startTimeInNanos;
-                if (postIngestHasBeenCalled.get()) {
-                    logger.warn("Preventing postIngest from being called more than once", new RuntimeException());
-                    assert false : "Attempt to call postIngest more than once";
-                } else {
-                    finalMetric.postIngest(ingestTimeInNanos);
                 }
-                executeOnFailureOuter(finalCurrentProcessor, finalIngestDocument, handler, finalProcessor, finalMetric, e);
+            });
+        } catch (Exception e) {
+            long ingestTimeInNanos = relativeTimeProvider.getAsLong() - startTimeInNanos;
+            if (postIngestHasBeenCalled.get()) {
+                logger.warn("Preventing postIngest from being called more than once", new RuntimeException());
+                assert false : "Attempt to call postIngest more than once";
+            } else {
+                finalMetric.postIngest(ingestTimeInNanos);
             }
+            executeOnFailureOuter(finalCurrentProcessor, finalIngestDocument, handler, finalProcessor, finalMetric, e);
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/ingest/CompoundProcessor.java
+++ b/server/src/main/java/org/elasticsearch/ingest/CompoundProcessor.java
@@ -198,7 +198,7 @@ public class CompoundProcessor implements Processor {
             final IngestDocument finalIngestDocument = ingestDocument;
             /*
              * Our assumption is that the listener passed to the processor is only ever called once. However, there is no way to enforce
-             * that in all processors and all of the code that they call. If the listener is called more than once it causes problems
+             * that in all processors and all the code that they call. If the listener is called more than once it causes problems
              * such as the metrics being wrong. The listenerHasBeenCalled variable is used to make sure that the code in the listener
              * is only executed once.
              */

--- a/server/src/main/java/org/elasticsearch/ingest/IngestDocument.java
+++ b/server/src/main/java/org/elasticsearch/ingest/IngestDocument.java
@@ -145,7 +145,7 @@ public final class IngestDocument {
      * Returns the value contained in the document with the provided templated path
      * @param pathTemplate The path within the document in dot-notation
      * @param clazz The expected class fo the field value
-     * @return the value fro the provided path if existing, null otherwise
+     * @return the value for the provided path if existing, null otherwise
      * @throws IllegalArgumentException if the pathTemplate is null, empty, invalid, if the field doesn't exist,
      * or if the field that is found at the provided path is not of the expected type.
      */

--- a/server/src/test/java/org/elasticsearch/ingest/CompoundProcessorTests.java
+++ b/server/src/test/java/org/elasticsearch/ingest/CompoundProcessorTests.java
@@ -86,7 +86,7 @@ public class CompoundProcessorTests extends ESTestCase {
     }
 
     public void testIgnoreFailure() throws Exception {
-        TestProcessor processor1 = new TestProcessor(new RuntimeException("error"));
+        TestProcessor processor1 = getTestProcessor(null, randomBoolean(), true);
         TestProcessor processor2 = new TestProcessor(ingestDocument -> { ingestDocument.setFieldValue("field", "value"); });
         LongSupplier relativeTimeProvider = mock(LongSupplier.class);
         when(relativeTimeProvider.getAsLong()).thenReturn(0L);

--- a/server/src/test/java/org/elasticsearch/ingest/CompoundProcessorTests.java
+++ b/server/src/test/java/org/elasticsearch/ingest/CompoundProcessorTests.java
@@ -12,8 +12,6 @@ import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.test.ESTestCase;
 import org.junit.Before;
 
-import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
@@ -88,12 +86,7 @@ public class CompoundProcessorTests extends ESTestCase {
         TestProcessor processor2 = new TestProcessor(ingestDocument -> { ingestDocument.setFieldValue("field", "value"); });
         LongSupplier relativeTimeProvider = mock(LongSupplier.class);
         when(relativeTimeProvider.getAsLong()).thenReturn(0L);
-        CompoundProcessor compoundProcessor = new CompoundProcessor(
-            true,
-            Arrays.asList(processor1, processor2),
-            Collections.emptyList(),
-            relativeTimeProvider
-        );
+        CompoundProcessor compoundProcessor = new CompoundProcessor(true, List.of(processor1, processor2), List.of(), relativeTimeProvider);
         executeCompound(compoundProcessor, ingestDocument, (result, e) -> {});
         assertThat(processor1.getInvokedCounter(), equalTo(1));
         assertStats(0, compoundProcessor, 0, 1, 1, 0);
@@ -114,12 +107,7 @@ public class CompoundProcessorTests extends ESTestCase {
 
         LongSupplier relativeTimeProvider = mock(LongSupplier.class);
         when(relativeTimeProvider.getAsLong()).thenReturn(0L, TimeUnit.MILLISECONDS.toNanos(1));
-        CompoundProcessor compoundProcessor = new CompoundProcessor(
-            false,
-            Collections.singletonList(processor1),
-            Collections.singletonList(processor2),
-            relativeTimeProvider
-        );
+        CompoundProcessor compoundProcessor = new CompoundProcessor(false, List.of(processor1), List.of(processor2), relativeTimeProvider);
         executeCompound(compoundProcessor, ingestDocument, (result, e) -> {});
         verify(relativeTimeProvider, times(2)).getAsLong();
 
@@ -155,12 +143,7 @@ public class CompoundProcessorTests extends ESTestCase {
 
         LongSupplier relativeTimeProvider = mock(LongSupplier.class);
         when(relativeTimeProvider.getAsLong()).thenReturn(0L);
-        CompoundProcessor compoundProcessor = new CompoundProcessor(
-            false,
-            Collections.singletonList(processor1),
-            Collections.singletonList(processor2),
-            relativeTimeProvider
-        );
+        CompoundProcessor compoundProcessor = new CompoundProcessor(false, List.of(processor1), List.of(processor2), relativeTimeProvider);
         IngestDocument[] result = new IngestDocument[1];
         executeCompound(compoundProcessor, ingestDocument, (r, e) -> result[0] = r);
         assertThat(result[0], nullValue());
@@ -189,14 +172,14 @@ public class CompoundProcessorTests extends ESTestCase {
         when(relativeTimeProvider.getAsLong()).thenReturn(0L);
         CompoundProcessor compoundOnFailProcessor = new CompoundProcessor(
             false,
-            Collections.singletonList(processorToFail),
-            Collections.singletonList(lastProcessor),
+            List.of(processorToFail),
+            List.of(lastProcessor),
             relativeTimeProvider
         );
         CompoundProcessor compoundProcessor = new CompoundProcessor(
             false,
-            Collections.singletonList(processor),
-            Collections.singletonList(compoundOnFailProcessor),
+            List.of(processor),
+            List.of(compoundOnFailProcessor),
             relativeTimeProvider
         );
         executeCompound(compoundProcessor, ingestDocument, (result, e) -> {});
@@ -227,8 +210,8 @@ public class CompoundProcessorTests extends ESTestCase {
         CompoundProcessor compoundOnFailProcessor = new CompoundProcessor(false, List.of(onFailure1, of2), List.of(), relativeTimeProvider);
         CompoundProcessor compoundProcessor = new CompoundProcessor(
             false,
-            Collections.singletonList(firstFailingProcessor),
-            Collections.singletonList(compoundOnFailProcessor),
+            List.of(firstFailingProcessor),
+            List.of(compoundOnFailProcessor),
             relativeTimeProvider
         );
         IngestDocument[] docHolder = new IngestDocument[1];
@@ -264,8 +247,8 @@ public class CompoundProcessorTests extends ESTestCase {
 
         CompoundProcessor compoundProcessor = new CompoundProcessor(
             false,
-            Collections.singletonList(failCompoundProcessor),
-            Collections.singletonList(secondProcessor),
+            List.of(failCompoundProcessor),
+            List.of(secondProcessor),
             relativeTimeProvider
         );
         executeCompound(compoundProcessor, ingestDocument, (result, e) -> {});
@@ -290,15 +273,15 @@ public class CompoundProcessorTests extends ESTestCase {
         when(relativeTimeProvider.getAsLong()).thenReturn(0L);
         CompoundProcessor failCompoundProcessor = new CompoundProcessor(
             false,
-            Collections.singletonList(firstProcessor),
-            Collections.singletonList(failProcessor),
+            List.of(firstProcessor),
+            List.of(failProcessor),
             relativeTimeProvider
         );
 
         CompoundProcessor compoundProcessor = new CompoundProcessor(
             false,
-            Collections.singletonList(failCompoundProcessor),
-            Collections.singletonList(secondProcessor),
+            List.of(failCompoundProcessor),
+            List.of(secondProcessor),
             relativeTimeProvider
         );
         executeCompound(compoundProcessor, ingestDocument, (result, e) -> {});
@@ -323,14 +306,14 @@ public class CompoundProcessorTests extends ESTestCase {
         when(relativeTimeProvider.getAsLong()).thenReturn(0L);
         CompoundProcessor failCompoundProcessor = new CompoundProcessor(
             false,
-            Collections.singletonList(firstProcessor),
-            Collections.singletonList(new CompoundProcessor(relativeTimeProvider, false, failProcessor))
+            List.of(firstProcessor),
+            List.of(new CompoundProcessor(relativeTimeProvider, false, failProcessor))
         );
 
         CompoundProcessor compoundProcessor = new CompoundProcessor(
             false,
-            Collections.singletonList(failCompoundProcessor),
-            Collections.singletonList(secondProcessor),
+            List.of(failCompoundProcessor),
+            List.of(secondProcessor),
             relativeTimeProvider
         );
         executeCompound(compoundProcessor, ingestDocument, (result, e) -> {});
@@ -348,8 +331,8 @@ public class CompoundProcessorTests extends ESTestCase {
         when(relativeTimeProvider.getAsLong()).thenReturn(0L);
         CompoundProcessor pipeline = new CompoundProcessor(
             false,
-            Arrays.asList(firstProcessor, secondProcessor),
-            Collections.singletonList(onFailureProcessor),
+            List.of(firstProcessor, secondProcessor),
+            List.of(onFailureProcessor),
             relativeTimeProvider
         );
         executeCompound(pipeline, ingestDocument, (result, e) -> {});

--- a/server/src/test/java/org/elasticsearch/ingest/CompoundProcessorTests.java
+++ b/server/src/test/java/org/elasticsearch/ingest/CompoundProcessorTests.java
@@ -66,7 +66,6 @@ public class CompoundProcessorTests extends ESTestCase {
         verify(relativeTimeProvider, times(2)).getAsLong();
         assertThat(processor.getInvokedCounter(), equalTo(1));
         assertStats(compoundProcessor, 1, 0, 1);
-
     }
 
     public void testSingleProcessorWithException() throws Exception {
@@ -82,7 +81,6 @@ public class CompoundProcessorTests extends ESTestCase {
         assertThat(((ElasticsearchException) holder[0]).getRootCause().getMessage(), equalTo("error"));
         assertThat(processor.getInvokedCounter(), equalTo(1));
         assertStats(compoundProcessor, 1, 1, 0);
-
     }
 
     public void testIgnoreFailure() throws Exception {

--- a/test/framework/src/main/java/org/elasticsearch/ingest/TestProcessor.java
+++ b/test/framework/src/main/java/org/elasticsearch/ingest/TestProcessor.java
@@ -55,7 +55,18 @@ public class TestProcessor implements Processor {
     @Override
     public void execute(IngestDocument ingestDocument, BiConsumer<IngestDocument, Exception> handler) {
         invokedCounter.incrementAndGet();
-        ingestDocumentMapper.apply(ingestDocument);
+
+        try {
+            ingestDocumentMapper.apply(ingestDocument);
+        } catch (Exception e) {
+            if (this.isAsync()) {
+                handler.accept(null, e);
+                return;
+            } else {
+                throw e;
+            }
+        }
+
         handler.accept(ingestDocument, null);
     }
 


### PR DESCRIPTION
In `CompoundProcessor`'s `innerExecute`, the call to `executeOnFailureOuter` has an off by one error, because `finalCurrentProcessor` is initialized incorrectly.

The effect of that is that if you were to create a `CompoundProcessor` around multiple processors (at least one of which is async) and that has `ignoreFailures` set to `true`, then a processor directly after a failing async processor would be skipped. See my first commit which creates exactly this scenario as a failing test (we already tested this scenario, except only ever with *non*-async processors).

As far as I can tell this ends up being harmless because of other code elsewhere -- it seems like there's no user-facing path that results in a `CompoundProcessor` that wraps *multiple* processors **and** has `ignoreFailures` set to `true`. However, it does make some of the other logic a little sloppy even if everything does work out correctly in the end.

Most of the diff here is due to the last commit, and that commit is mostly a whitespace diff (I bumped an `else` out of the code so a big block got reindented).