### PR TITLE
Fork TransportClusterStateAction to MANAGEMENT

### DIFF
--- a/docs/changelog/90996.yaml
+++ b/docs/changelog/90996.yaml
@@ -1,0 +1,5 @@
+pr: 90996
+summary: Fork `TransportClusterStateAction` to MANAGEMENT
+area: Distributed
+type: bug
+issues: []

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/state/TransportClusterStateAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/state/TransportClusterStateAction.java
@@ -40,7 +40,7 @@ import java.util.function.Predicate;
 
 public class TransportClusterStateAction extends TransportMasterNodeReadAction<ClusterStateRequest, ClusterStateResponse> {
 
-    private final Logger logger = LogManager.getLogger(getClass());
+    private static final Logger logger = LogManager.getLogger(TransportClusterStateAction.class);
 
     @Inject
     public TransportClusterStateAction(
@@ -60,7 +60,7 @@ public class TransportClusterStateAction extends TransportMasterNodeReadAction<C
             ClusterStateRequest::new,
             indexNameExpressionResolver,
             ClusterStateResponse::new,
-            ThreadPool.Names.SAME
+            ThreadPool.Names.MANAGEMENT
         );
     }
 


### PR DESCRIPTION
For large cluster states the serialization of the response can take a longer time than is acceptable on a transport thread. Also, moving this to management creates a bit of a natural bottleneck via the management pool's size in case a master node is hit by a large number of concurrent requests which might also be helpful in limiting the considerable memory consumption of this transport action.
