### PR TITLE
[8.5] TaskManager traceRequest on/off for CancellableTask (#90972)

### DIFF
--- a/docs/changelog/90972.yaml
+++ b/docs/changelog/90972.yaml
@@ -1,0 +1,6 @@
+pr: 90972
+summary: 'Fix disabling APM tracing for `CancellableTask` in `TrainedModelAssignmentNodeService`'
+area: Infra/Core
+type: bug
+issues:
+ - 89850


### PR DESCRIPTION
Backports the following commits to 8.5:
 - TaskManager traceRequest on/off for CancellableTask (#90972)