### PR TITLE
Fix Lucene94HnswVectorsFormat validation bug

### DIFF
--- a/server/src/main/java/module-info.java
+++ b/server/src/main/java/module-info.java
@@ -356,6 +356,8 @@ module org.elasticsearch.server {
 
     opens org.elasticsearch.common.logging to org.apache.logging.log4j.core;
 
+    exports org.elasticsearch.index.codec.vectors;
+
     provides java.util.spi.CalendarDataProvider with org.elasticsearch.common.time.IsoCalendarDataProvider;
     provides org.elasticsearch.xcontent.ErrorOnUnknown with org.elasticsearch.common.xcontent.SuggestingErrorOnUnknown;
     provides org.elasticsearch.xcontent.XContentBuilderExtension with org.elasticsearch.common.xcontent.XContentElasticsearchExtension;
@@ -367,4 +369,7 @@ module org.elasticsearch.server {
     uses org.elasticsearch.reservedstate.ReservedClusterStateHandlerProvider;
 
     provides org.apache.lucene.codecs.PostingsFormat with org.elasticsearch.index.codec.bloomfilter.ES85BloomFilterPostingsFormat;
+    provides org.apache.lucene.codecs.KnnVectorsFormat with org.elasticsearch.index.codec.vectors.XLucene94HnswVectorsFormat;
+    provides org.apache.lucene.codecs.Codec with org.elasticsearch.index.codec.XLucene94Codec;
+
 }

--- a/server/src/main/java/org/elasticsearch/index/codec/CodecService.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/CodecService.java
@@ -9,7 +9,6 @@
 package org.elasticsearch.index.codec;
 
 import org.apache.lucene.codecs.Codec;
-import org.apache.lucene.codecs.lucene94.Lucene94Codec;
 import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.index.mapper.MapperService;
@@ -35,11 +34,11 @@ public class CodecService {
     public CodecService(@Nullable MapperService mapperService, BigArrays bigArrays) {
         final var codecs = new HashMap<String, Codec>();
         if (mapperService == null) {
-            codecs.put(DEFAULT_CODEC, new Lucene94Codec());
-            codecs.put(BEST_COMPRESSION_CODEC, new Lucene94Codec(Lucene94Codec.Mode.BEST_COMPRESSION));
+            codecs.put(DEFAULT_CODEC, new XLucene94Codec());
+            codecs.put(BEST_COMPRESSION_CODEC, new XLucene94Codec(XLucene94Codec.Mode.BEST_COMPRESSION));
         } else {
-            codecs.put(DEFAULT_CODEC, new PerFieldMapperCodec(Lucene94Codec.Mode.BEST_SPEED, mapperService, bigArrays));
-            codecs.put(BEST_COMPRESSION_CODEC, new PerFieldMapperCodec(Lucene94Codec.Mode.BEST_COMPRESSION, mapperService, bigArrays));
+            codecs.put(DEFAULT_CODEC, new PerFieldMapperCodec(XLucene94Codec.Mode.BEST_SPEED, mapperService, bigArrays));
+            codecs.put(BEST_COMPRESSION_CODEC, new PerFieldMapperCodec(XLucene94Codec.Mode.BEST_COMPRESSION, mapperService, bigArrays));
         }
         codecs.put(LUCENE_DEFAULT_CODEC, Codec.getDefault());
         for (String codec : Codec.availableCodecs()) {

--- a/server/src/main/java/org/elasticsearch/index/codec/PerFieldMapperCodec.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/PerFieldMapperCodec.java
@@ -13,7 +13,6 @@ import org.apache.lucene.codecs.DocValuesFormat;
 import org.apache.lucene.codecs.KnnVectorsFormat;
 import org.apache.lucene.codecs.PostingsFormat;
 import org.apache.lucene.codecs.lucene90.Lucene90DocValuesFormat;
-import org.apache.lucene.codecs.lucene94.Lucene94Codec;
 import org.elasticsearch.common.lucene.Lucene;
 import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.index.IndexSettings;
@@ -31,7 +30,7 @@ import org.elasticsearch.index.mapper.vectors.DenseVectorFieldMapper;
  * per index in real time via the mapping API. If no specific postings format or vector format is
  * configured for a specific field the default postings or vector format is used.
  */
-public class PerFieldMapperCodec extends Lucene94Codec {
+public class PerFieldMapperCodec extends XLucene94Codec {
     private final MapperService mapperService;
 
     private final DocValuesFormat docValuesFormat = new Lucene90DocValuesFormat();

--- a/server/src/main/java/org/elasticsearch/index/codec/XLucene94Codec.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/XLucene94Codec.java
@@ -1,0 +1,208 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.index.codec;
+
+import org.apache.lucene.codecs.Codec;
+import org.apache.lucene.codecs.CompoundFormat;
+import org.apache.lucene.codecs.DocValuesFormat;
+import org.apache.lucene.codecs.FieldInfosFormat;
+import org.apache.lucene.codecs.KnnVectorsFormat;
+import org.apache.lucene.codecs.LiveDocsFormat;
+import org.apache.lucene.codecs.NormsFormat;
+import org.apache.lucene.codecs.PointsFormat;
+import org.apache.lucene.codecs.PostingsFormat;
+import org.apache.lucene.codecs.SegmentInfoFormat;
+import org.apache.lucene.codecs.StoredFieldsFormat;
+import org.apache.lucene.codecs.TermVectorsFormat;
+import org.apache.lucene.codecs.lucene90.Lucene90CompoundFormat;
+import org.apache.lucene.codecs.lucene90.Lucene90DocValuesFormat;
+import org.apache.lucene.codecs.lucene90.Lucene90LiveDocsFormat;
+import org.apache.lucene.codecs.lucene90.Lucene90NormsFormat;
+import org.apache.lucene.codecs.lucene90.Lucene90PointsFormat;
+import org.apache.lucene.codecs.lucene90.Lucene90PostingsFormat;
+import org.apache.lucene.codecs.lucene90.Lucene90SegmentInfoFormat;
+import org.apache.lucene.codecs.lucene90.Lucene90StoredFieldsFormat;
+import org.apache.lucene.codecs.lucene90.Lucene90TermVectorsFormat;
+import org.apache.lucene.codecs.lucene94.Lucene94FieldInfosFormat;
+import org.apache.lucene.codecs.perfield.PerFieldDocValuesFormat;
+import org.apache.lucene.codecs.perfield.PerFieldKnnVectorsFormat;
+import org.apache.lucene.codecs.perfield.PerFieldPostingsFormat;
+import org.elasticsearch.index.codec.vectors.XLucene94HnswVectorsFormat;
+
+import java.util.Objects;
+
+/**
+ * Implements the Lucene 9.4 index format
+ *
+ * <p>If you want to reuse functionality of this codec in another codec, extend {@link org.apache.lucene.codecs.FilterCodec}.
+ *
+ * @see org.apache.lucene.codecs.lucene94 package documentation for file format details.
+ *
+ * NOTE: this class was temporarily copied from Lucene to fix a bug in Lucene94HnswVectorsReader.
+ * It contains no modifications to the Lucene version except that it returns {@link XLucene94HnswVectorsFormat}.
+ */
+public class XLucene94Codec extends Codec {
+
+    /** Configuration option for the codec. */
+    public enum Mode {
+        /** Trade compression ratio for retrieval speed. */
+        BEST_SPEED(Lucene90StoredFieldsFormat.Mode.BEST_SPEED),
+        /** Trade retrieval speed for compression ratio. */
+        BEST_COMPRESSION(Lucene90StoredFieldsFormat.Mode.BEST_COMPRESSION);
+
+        final Lucene90StoredFieldsFormat.Mode storedMode;
+
+        Mode(Lucene90StoredFieldsFormat.Mode storedMode) {
+            this.storedMode = Objects.requireNonNull(storedMode);
+        }
+    }
+
+    private final TermVectorsFormat vectorsFormat = new Lucene90TermVectorsFormat();
+    private final FieldInfosFormat fieldInfosFormat = new Lucene94FieldInfosFormat();
+    private final SegmentInfoFormat segmentInfosFormat = new Lucene90SegmentInfoFormat();
+    private final LiveDocsFormat liveDocsFormat = new Lucene90LiveDocsFormat();
+    private final CompoundFormat compoundFormat = new Lucene90CompoundFormat();
+    private final NormsFormat normsFormat = new Lucene90NormsFormat();
+
+    private final PostingsFormat defaultPostingsFormat;
+    private final PostingsFormat postingsFormat = new PerFieldPostingsFormat() {
+        @Override
+        public PostingsFormat getPostingsFormatForField(String field) {
+            return XLucene94Codec.this.getPostingsFormatForField(field);
+        }
+    };
+
+    private final DocValuesFormat defaultDVFormat;
+    private final DocValuesFormat docValuesFormat = new PerFieldDocValuesFormat() {
+        @Override
+        public DocValuesFormat getDocValuesFormatForField(String field) {
+            return XLucene94Codec.this.getDocValuesFormatForField(field);
+        }
+    };
+
+    private final KnnVectorsFormat defaultKnnVectorsFormat;
+    private final KnnVectorsFormat knnVectorsFormat = new PerFieldKnnVectorsFormat() {
+        @Override
+        public KnnVectorsFormat getKnnVectorsFormatForField(String field) {
+            return XLucene94Codec.this.getKnnVectorsFormatForField(field);
+        }
+    };
+
+    private final StoredFieldsFormat storedFieldsFormat;
+
+    /** Instantiates a new codec. */
+    public XLucene94Codec() {
+        this(XLucene94Codec.Mode.BEST_SPEED);
+    }
+
+    /**
+     * Instantiates a new codec, specifying the stored fields compression mode to use.
+     *
+     * @param mode stored fields compression mode to use for newly flushed/merged segments.
+     */
+    public XLucene94Codec(XLucene94Codec.Mode mode) {
+        super("Lucene94");
+        this.storedFieldsFormat = new Lucene90StoredFieldsFormat(Objects.requireNonNull(mode).storedMode);
+        this.defaultPostingsFormat = new Lucene90PostingsFormat();
+        this.defaultDVFormat = new Lucene90DocValuesFormat();
+        this.defaultKnnVectorsFormat = new XLucene94HnswVectorsFormat();
+    }
+
+    @Override
+    public final StoredFieldsFormat storedFieldsFormat() {
+        return storedFieldsFormat;
+    }
+
+    @Override
+    public final TermVectorsFormat termVectorsFormat() {
+        return vectorsFormat;
+    }
+
+    @Override
+    public final PostingsFormat postingsFormat() {
+        return postingsFormat;
+    }
+
+    @Override
+    public final FieldInfosFormat fieldInfosFormat() {
+        return fieldInfosFormat;
+    }
+
+    @Override
+    public final SegmentInfoFormat segmentInfoFormat() {
+        return segmentInfosFormat;
+    }
+
+    @Override
+    public final LiveDocsFormat liveDocsFormat() {
+        return liveDocsFormat;
+    }
+
+    @Override
+    public final CompoundFormat compoundFormat() {
+        return compoundFormat;
+    }
+
+    @Override
+    public final PointsFormat pointsFormat() {
+        return new Lucene90PointsFormat();
+    }
+
+    @Override
+    public final KnnVectorsFormat knnVectorsFormat() {
+        return knnVectorsFormat;
+    }
+
+    /**
+     * Returns the postings format that should be used for writing new segments of <code>field</code>.
+     *
+     * <p>The default implementation always returns "Lucene90".
+     *
+     * <p><b>WARNING:</b> if you subclass, you are responsible for index backwards compatibility:
+     * future version of Lucene are only guaranteed to be able to read the default implementation,
+     */
+    public PostingsFormat getPostingsFormatForField(String field) {
+        return defaultPostingsFormat;
+    }
+
+    /**
+     * Returns the docvalues format that should be used for writing new segments of <code>field</code>
+     * .
+     *
+     * <p>The default implementation always returns "Lucene90".
+     *
+     * <p><b>WARNING:</b> if you subclass, you are responsible for index backwards compatibility:
+     * future version of Lucene are only guaranteed to be able to read the default implementation.
+     */
+    public DocValuesFormat getDocValuesFormatForField(String field) {
+        return defaultDVFormat;
+    }
+
+    /**
+     * Returns the vectors format that should be used for writing new segments of <code>field</code>
+     *
+     * <p>The default implementation always returns "lucene94".
+     *
+     * <p><b>WARNING:</b> if you subclass, you are responsible for index backwards compatibility:
+     * future version of Lucene are only guaranteed to be able to read the default implementation.
+     */
+    public KnnVectorsFormat getKnnVectorsFormatForField(String field) {
+        return defaultKnnVectorsFormat;
+    }
+
+    @Override
+    public final DocValuesFormat docValuesFormat() {
+        return docValuesFormat;
+    }
+
+    @Override
+    public final NormsFormat normsFormat() {
+        return normsFormat;
+    }
+}

--- a/server/src/main/java/org/elasticsearch/index/codec/vectors/XExpandingVectorValues.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/vectors/XExpandingVectorValues.java
@@ -1,0 +1,52 @@
+/*
+ * @notice
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.elasticsearch.index.codec.vectors;
+
+import org.apache.lucene.index.FilterVectorValues;
+import org.apache.lucene.index.VectorValues;
+import org.apache.lucene.util.BytesRef;
+
+import java.io.IOException;
+
+/**
+ * reads from byte-encoded data
+ *
+ * NOTE: this class was temporarily copied from Lucene to fix a bug in Lucene94HnswVectorsReader.
+ * It contains no modifications to the Lucene version.
+ */
+public class XExpandingVectorValues extends FilterVectorValues {
+
+    private final float[] value;
+
+    /** @param in the wrapped values */
+    protected XExpandingVectorValues(VectorValues in) {
+        super(in);
+        value = new float[in.dimension()];
+    }
+
+    @Override
+    public float[] vectorValue() throws IOException {
+        BytesRef binaryValue = binaryValue();
+        byte[] bytes = binaryValue.bytes;
+        for (int i = 0, j = binaryValue.offset; i < value.length; i++, j++) {
+            value[i] = bytes[j];
+        }
+        return value;
+    }
+}

--- a/server/src/main/java/org/elasticsearch/index/codec/vectors/XLucene94HnswVectorsFormat.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/vectors/XLucene94HnswVectorsFormat.java
@@ -1,0 +1,164 @@
+/*
+ * @notice
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.elasticsearch.index.codec.vectors;
+
+import org.apache.lucene.codecs.KnnVectorsFormat;
+import org.apache.lucene.codecs.KnnVectorsReader;
+import org.apache.lucene.codecs.KnnVectorsWriter;
+import org.apache.lucene.index.SegmentReadState;
+import org.apache.lucene.index.SegmentWriteState;
+import org.apache.lucene.util.hnsw.HnswGraph;
+
+import java.io.IOException;
+
+/**
+ * Lucene 9.4 vector format, which encodes numeric vector values and an optional associated graph
+ * connecting the documents having values. The graph is used to power HNSW search. The format
+ * consists of three files:
+ *
+ * <h2>.vec (vector data) file</h2>
+ *
+ * <p>For each field:
+ *
+ * <ul>
+ *   <li>Vector data ordered by field, document ordinal, and vector dimension. When the
+ *       vectorEncoding is BYTE, each sample is stored as a single byte. When it is FLOAT32, each
+ *       sample is stored as an IEEE float in little-endian byte order.
+ *   <li>DocIds encoded by {@code IndexedDISI#writeBitSet(DocIdSetIterator, IndexOutput, byte)},
+ *       note that only in sparse case
+ *   <li>OrdToDoc was encoded by {@link org.apache.lucene.util.packed.DirectMonotonicWriter}, note
+ *       that only in sparse case
+ * </ul>
+ *
+ * <h2>.vex (vector index)</h2>
+ *
+ * <p>Stores graphs connecting the documents for each field organized as a list of nodes' neighbours
+ * as following:
+ *
+ * <ul>
+ *   <li>For each level:
+ *       <ul>
+ *         <li>For each node:
+ *             <ul>
+ *               <li><b>[int32]</b> the number of neighbor nodes
+ *               <li><b>array[int32]</b> the neighbor ordinals
+ *               <li><b>array[int32]</b> padding if the number of the node's neighbors is less than
+ *                   the maximum number of connections allowed on this level. Padding is equal to
+ *                   ((maxConnOnLevel – the number of neighbours) * 4) bytes.
+ *             </ul>
+ *       </ul>
+ * </ul>
+ *
+ * <h2>.vem (vector metadata) file</h2>
+ *
+ * <p>For each field:
+ *
+ * <ul>
+ *   <li><b>[int32]</b> field number
+ *   <li><b>[int32]</b> vector similarity function ordinal
+ *   <li><b>[vlong]</b> offset to this field's vectors in the .vec file
+ *   <li><b>[vlong]</b> length of this field's vectors, in bytes
+ *   <li><b>[vlong]</b> offset to this field's index in the .vex file
+ *   <li><b>[vlong]</b> length of this field's index data, in bytes
+ *   <li><b>[int]</b> dimension of this field's vectors
+ *   <li><b>[int]</b> the number of documents having values for this field
+ *   <li><b>[int8]</b> if equals to -1, dense – all documents have values for a field. If equals to
+ *       0, sparse – some documents missing values.
+ *   <li>DocIds were encoded by {@code IndexedDISI#writeBitSet(DocIdSetIterator, IndexOutput, byte)}
+ *   <li>OrdToDoc was encoded by {@link org.apache.lucene.util.packed.DirectMonotonicWriter}, note
+ *       that only in sparse case
+ *   <li><b>[int]</b> the maximum number of connections (neigbours) that each node can have
+ *   <li><b>[int]</b> number of levels in the graph
+ *   <li>Graph nodes by level. For each level
+ *       <ul>
+ *         <li><b>[int]</b> the number of nodes on this level
+ *         <li><b>array[int]</b> for levels greater than 0 list of nodes on this level, stored as
+ *             the level 0th nodes' ordinals.
+ *       </ul>
+ * </ul>
+ *
+ * NOTE: this class was temporarily copied from Lucene to fix a bug in Lucene94HnswVectorsReader.
+ * It contains no modifications to the Lucene version.
+ */
+public final class XLucene94HnswVectorsFormat extends KnnVectorsFormat {
+
+    static final String META_CODEC_NAME = "lucene94HnswVectorsFormatMeta";
+    static final String VECTOR_DATA_CODEC_NAME = "lucene94HnswVectorsFormatData";
+    static final String VECTOR_INDEX_CODEC_NAME = "lucene94HnswVectorsFormatIndex";
+    static final String META_EXTENSION = "vem";
+    static final String VECTOR_DATA_EXTENSION = "vec";
+    static final String VECTOR_INDEX_EXTENSION = "vex";
+
+    public static final int VERSION_START = 0;
+    public static final int VERSION_CURRENT = 1;
+
+    /** Default number of maximum connections per node */
+    public static final int DEFAULT_MAX_CONN = 16;
+    /**
+     * Default number of the size of the queue maintained while searching during a graph construction.
+     */
+    public static final int DEFAULT_BEAM_WIDTH = 100;
+
+    static final int DIRECT_MONOTONIC_BLOCK_SHIFT = 16;
+
+    /**
+     * Controls how many of the nearest neighbor candidates are connected to the new node. Defaults to
+     * {@link XLucene94HnswVectorsFormat#DEFAULT_MAX_CONN}. See {@link HnswGraph} for more details.
+     */
+    private final int maxConn;
+
+    /**
+     * The number of candidate neighbors to track while searching the graph for each newly inserted
+     * node. Defaults to to {@link XLucene94HnswVectorsFormat#DEFAULT_BEAM_WIDTH}. See {@link
+     * HnswGraph} for details.
+     */
+    private final int beamWidth;
+
+    /** Constructs a format using default graph construction parameters */
+    public XLucene94HnswVectorsFormat() {
+        this(DEFAULT_MAX_CONN, DEFAULT_BEAM_WIDTH);
+    }
+
+    /**
+     * Constructs a format using the given graph construction parameters.
+     *
+     * @param maxConn the maximum number of connections to a node in the HNSW graph
+     * @param beamWidth the size of the queue maintained during graph construction.
+     */
+    public XLucene94HnswVectorsFormat(int maxConn, int beamWidth) {
+        super("Lucene94HnswVectorsFormat");
+        this.maxConn = maxConn;
+        this.beamWidth = beamWidth;
+    }
+
+    @Override
+    public KnnVectorsWriter fieldsWriter(SegmentWriteState state) throws IOException {
+        return new XLucene94HnswVectorsWriter(state, maxConn, beamWidth);
+    }
+
+    @Override
+    public KnnVectorsReader fieldsReader(SegmentReadState state) throws IOException {
+        return new XLucene94HnswVectorsReader(state);
+    }
+
+    @Override
+    public String toString() {
+        return "Lucene94HnswVectorsFormat(name=Lucene94HnswVectorsFormat, maxConn=" + maxConn + ", beamWidth=" + beamWidth + ")";
+    }
+}

--- a/server/src/main/java/org/elasticsearch/index/codec/vectors/XLucene94HnswVectorsReader.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/vectors/XLucene94HnswVectorsReader.java
@@ -1,0 +1,477 @@
+/*
+ * @notice
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.elasticsearch.index.codec.vectors;
+
+import org.apache.lucene.codecs.CodecUtil;
+import org.apache.lucene.codecs.KnnVectorsReader;
+import org.apache.lucene.index.CorruptIndexException;
+import org.apache.lucene.index.FieldInfo;
+import org.apache.lucene.index.FieldInfos;
+import org.apache.lucene.index.IndexFileNames;
+import org.apache.lucene.index.SegmentReadState;
+import org.apache.lucene.index.VectorEncoding;
+import org.apache.lucene.index.VectorSimilarityFunction;
+import org.apache.lucene.index.VectorValues;
+import org.apache.lucene.search.ScoreDoc;
+import org.apache.lucene.search.TopDocs;
+import org.apache.lucene.search.TotalHits;
+import org.apache.lucene.store.ChecksumIndexInput;
+import org.apache.lucene.store.DataInput;
+import org.apache.lucene.store.IndexInput;
+import org.apache.lucene.util.Bits;
+import org.apache.lucene.util.IOUtils;
+import org.apache.lucene.util.RamUsageEstimator;
+import org.apache.lucene.util.hnsw.HnswGraph;
+import org.apache.lucene.util.hnsw.HnswGraphSearcher;
+import org.apache.lucene.util.hnsw.NeighborQueue;
+import org.apache.lucene.util.packed.DirectMonotonicReader;
+import org.elasticsearch.core.SuppressForbidden;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.apache.lucene.search.DocIdSetIterator.NO_MORE_DOCS;
+
+/**
+ * Reads vectors from the index segments along with index data structures supporting KNN search.
+ *
+ * NOTE: this class was temporarily copied from Lucene to fix a bug in Lucene94HnswVectorsReader.
+ * Its only modification is to use a long instead of integer in the {@code validateFieldEntry} method.
+ */
+@SuppressForbidden(reason = "class is copied from Lucene")
+public final class XLucene94HnswVectorsReader extends KnnVectorsReader {
+
+    private final FieldInfos fieldInfos;
+    private final Map<String, FieldEntry> fields = new HashMap<>();
+    private final IndexInput vectorData;
+    private final IndexInput vectorIndex;
+
+    XLucene94HnswVectorsReader(SegmentReadState state) throws IOException {
+        this.fieldInfos = state.fieldInfos;
+        int versionMeta = readMetadata(state);
+        boolean success = false;
+        try {
+            vectorData = openDataInput(
+                state,
+                versionMeta,
+                XLucene94HnswVectorsFormat.VECTOR_DATA_EXTENSION,
+                XLucene94HnswVectorsFormat.VECTOR_DATA_CODEC_NAME
+            );
+            vectorIndex = openDataInput(
+                state,
+                versionMeta,
+                XLucene94HnswVectorsFormat.VECTOR_INDEX_EXTENSION,
+                XLucene94HnswVectorsFormat.VECTOR_INDEX_CODEC_NAME
+            );
+            success = true;
+        } finally {
+            if (success == false) {
+                IOUtils.closeWhileHandlingException(this);
+            }
+        }
+    }
+
+    private int readMetadata(SegmentReadState state) throws IOException {
+        String metaFileName = IndexFileNames.segmentFileName(
+            state.segmentInfo.name,
+            state.segmentSuffix,
+            XLucene94HnswVectorsFormat.META_EXTENSION
+        );
+        int versionMeta = -1;
+        try (ChecksumIndexInput meta = state.directory.openChecksumInput(metaFileName, state.context)) {
+            Throwable priorE = null;
+            try {
+                versionMeta = CodecUtil.checkIndexHeader(
+                    meta,
+                    XLucene94HnswVectorsFormat.META_CODEC_NAME,
+                    XLucene94HnswVectorsFormat.VERSION_START,
+                    XLucene94HnswVectorsFormat.VERSION_CURRENT,
+                    state.segmentInfo.getId(),
+                    state.segmentSuffix
+                );
+                readFields(meta, state.fieldInfos);
+            } catch (Throwable exception) {
+                priorE = exception;
+            } finally {
+                CodecUtil.checkFooter(meta, priorE);
+            }
+        }
+        return versionMeta;
+    }
+
+    private static IndexInput openDataInput(SegmentReadState state, int versionMeta, String fileExtension, String codecName)
+        throws IOException {
+        String fileName = IndexFileNames.segmentFileName(state.segmentInfo.name, state.segmentSuffix, fileExtension);
+        IndexInput in = state.directory.openInput(fileName, state.context);
+        boolean success = false;
+        try {
+            int versionVectorData = CodecUtil.checkIndexHeader(
+                in,
+                codecName,
+                XLucene94HnswVectorsFormat.VERSION_START,
+                XLucene94HnswVectorsFormat.VERSION_CURRENT,
+                state.segmentInfo.getId(),
+                state.segmentSuffix
+            );
+            if (versionMeta != versionVectorData) {
+                throw new CorruptIndexException(
+                    "Format versions mismatch: meta=" + versionMeta + ", " + codecName + "=" + versionVectorData,
+                    in
+                );
+            }
+            CodecUtil.retrieveChecksum(in);
+            success = true;
+            return in;
+        } finally {
+            if (success == false) {
+                IOUtils.closeWhileHandlingException(in);
+            }
+        }
+    }
+
+    private void readFields(ChecksumIndexInput meta, FieldInfos infos) throws IOException {
+        for (int fieldNumber = meta.readInt(); fieldNumber != -1; fieldNumber = meta.readInt()) {
+            FieldInfo info = infos.fieldInfo(fieldNumber);
+            if (info == null) {
+                throw new CorruptIndexException("Invalid field number: " + fieldNumber, meta);
+            }
+            FieldEntry fieldEntry = readField(meta);
+            validateFieldEntry(info, fieldEntry);
+            fields.put(info.name, fieldEntry);
+        }
+    }
+
+    private void validateFieldEntry(FieldInfo info, FieldEntry fieldEntry) {
+        int dimension = info.getVectorDimension();
+        if (dimension != fieldEntry.dimension) {
+            throw new IllegalStateException(
+                "Inconsistent vector dimension for field=\"" + info.name + "\"; " + dimension + " != " + fieldEntry.dimension
+            );
+        }
+
+        int byteSize;
+        switch (info.getVectorEncoding()) {
+            case BYTE:
+                byteSize = Byte.BYTES;
+                break;
+            default:
+            case FLOAT32:
+                byteSize = Float.BYTES;
+                break;
+        }
+        long numBytes = (long) fieldEntry.size * dimension * byteSize;
+        if (numBytes != fieldEntry.vectorDataLength) {
+            throw new IllegalStateException(
+                "Vector data length "
+                    + fieldEntry.vectorDataLength
+                    + " not matching size="
+                    + fieldEntry.size
+                    + " * dim="
+                    + dimension
+                    + " * byteSize="
+                    + byteSize
+                    + " = "
+                    + numBytes
+            );
+        }
+    }
+
+    private VectorSimilarityFunction readSimilarityFunction(DataInput input) throws IOException {
+        int similarityFunctionId = input.readInt();
+        if (similarityFunctionId < 0 || similarityFunctionId >= VectorSimilarityFunction.values().length) {
+            throw new CorruptIndexException("Invalid similarity function id: " + similarityFunctionId, input);
+        }
+        return VectorSimilarityFunction.values()[similarityFunctionId];
+    }
+
+    private VectorEncoding readVectorEncoding(DataInput input) throws IOException {
+        int encodingId = input.readInt();
+        if (encodingId < 0 || encodingId >= VectorEncoding.values().length) {
+            throw new CorruptIndexException("Invalid vector encoding id: " + encodingId, input);
+        }
+        return VectorEncoding.values()[encodingId];
+    }
+
+    private FieldEntry readField(IndexInput input) throws IOException {
+        VectorEncoding vectorEncoding = readVectorEncoding(input);
+        VectorSimilarityFunction similarityFunction = readSimilarityFunction(input);
+        return new FieldEntry(input, vectorEncoding, similarityFunction);
+    }
+
+    @Override
+    public long ramBytesUsed() {
+        long totalBytes = RamUsageEstimator.shallowSizeOfInstance(XLucene94HnswVectorsFormat.class);
+        totalBytes += RamUsageEstimator.sizeOfMap(fields, RamUsageEstimator.shallowSizeOfInstance(FieldEntry.class));
+        return totalBytes;
+    }
+
+    @Override
+    public void checkIntegrity() throws IOException {
+        CodecUtil.checksumEntireFile(vectorData);
+        CodecUtil.checksumEntireFile(vectorIndex);
+    }
+
+    @Override
+    public VectorValues getVectorValues(String field) throws IOException {
+        FieldEntry fieldEntry = fields.get(field);
+        VectorValues values = XOffHeapVectorValues.load(fieldEntry, vectorData);
+        if (fieldEntry.vectorEncoding == VectorEncoding.BYTE) {
+            return new XExpandingVectorValues(values);
+        } else {
+            return values;
+        }
+    }
+
+    @Override
+    public TopDocs search(String field, float[] target, int k, Bits acceptDocs, int visitedLimit) throws IOException {
+        FieldEntry fieldEntry = fields.get(field);
+
+        if (fieldEntry.size() == 0) {
+            return new TopDocs(new TotalHits(0, TotalHits.Relation.EQUAL_TO), new ScoreDoc[0]);
+        }
+
+        // bound k by total number of vectors to prevent oversizing data structures
+        k = Math.min(k, fieldEntry.size());
+        XOffHeapVectorValues vectorValues = XOffHeapVectorValues.load(fieldEntry, vectorData);
+
+        NeighborQueue results = HnswGraphSearcher.search(
+            target,
+            k,
+            vectorValues,
+            fieldEntry.vectorEncoding,
+            fieldEntry.similarityFunction,
+            getGraph(fieldEntry),
+            vectorValues.getAcceptOrds(acceptDocs),
+            visitedLimit
+        );
+
+        int i = 0;
+        ScoreDoc[] scoreDocs = new ScoreDoc[Math.min(results.size(), k)];
+        while (results.size() > 0) {
+            int node = results.topNode();
+            float score = results.topScore();
+            results.pop();
+            scoreDocs[scoreDocs.length - ++i] = new ScoreDoc(vectorValues.ordToDoc(node), score);
+        }
+
+        TotalHits.Relation relation = results.incomplete() ? TotalHits.Relation.GREATER_THAN_OR_EQUAL_TO : TotalHits.Relation.EQUAL_TO;
+        return new TopDocs(new TotalHits(results.visitedCount(), relation), scoreDocs);
+    }
+
+    /** Get knn graph values; used for testing */
+    public HnswGraph getGraph(String field) throws IOException {
+        FieldInfo info = fieldInfos.fieldInfo(field);
+        if (info == null) {
+            throw new IllegalArgumentException("No such field '" + field + "'");
+        }
+        FieldEntry entry = fields.get(field);
+        if (entry != null && entry.vectorIndexLength > 0) {
+            return getGraph(entry);
+        } else {
+            return HnswGraph.EMPTY;
+        }
+    }
+
+    private HnswGraph getGraph(FieldEntry entry) throws IOException {
+        IndexInput bytesSlice = vectorIndex.slice("graph-data", entry.vectorIndexOffset, entry.vectorIndexLength);
+        return new OffHeapHnswGraph(entry, bytesSlice);
+    }
+
+    @Override
+    public void close() throws IOException {
+        IOUtils.close(vectorData, vectorIndex);
+    }
+
+    static class FieldEntry {
+
+        final VectorSimilarityFunction similarityFunction;
+        final VectorEncoding vectorEncoding;
+        final long vectorDataOffset;
+        final long vectorDataLength;
+        final long vectorIndexOffset;
+        final long vectorIndexLength;
+        final int M;
+        final int numLevels;
+        final int dimension;
+        final int size;
+        final int[][] nodesByLevel;
+        // for each level the start offsets in vectorIndex file from where to read neighbours
+        final long[] graphOffsetsByLevel;
+
+        // the following four variables used to read docIds encoded by IndexDISI
+        // special values of docsWithFieldOffset are -1 and -2
+        // -1 : dense
+        // -2 : empty
+        // other: sparse
+        final long docsWithFieldOffset;
+        final long docsWithFieldLength;
+        final short jumpTableEntryCount;
+        final byte denseRankPower;
+
+        // the following four variables used to read ordToDoc encoded by DirectMonotonicWriter
+        // note that only spare case needs to store ordToDoc
+        final long addressesOffset;
+        final int blockShift;
+        final DirectMonotonicReader.Meta meta;
+        final long addressesLength;
+
+        FieldEntry(IndexInput input, VectorEncoding vectorEncoding, VectorSimilarityFunction similarityFunction) throws IOException {
+            this.similarityFunction = similarityFunction;
+            this.vectorEncoding = vectorEncoding;
+            vectorDataOffset = input.readVLong();
+            vectorDataLength = input.readVLong();
+            vectorIndexOffset = input.readVLong();
+            vectorIndexLength = input.readVLong();
+            dimension = input.readInt();
+            size = input.readInt();
+
+            docsWithFieldOffset = input.readLong();
+            docsWithFieldLength = input.readLong();
+            jumpTableEntryCount = input.readShort();
+            denseRankPower = input.readByte();
+
+            // dense or empty
+            if (docsWithFieldOffset == -1 || docsWithFieldOffset == -2) {
+                addressesOffset = 0;
+                blockShift = 0;
+                meta = null;
+                addressesLength = 0;
+            } else {
+                // sparse
+                addressesOffset = input.readLong();
+                blockShift = input.readVInt();
+                meta = DirectMonotonicReader.loadMeta(input, size, blockShift);
+                addressesLength = input.readLong();
+            }
+
+            // read nodes by level
+            M = input.readInt();
+            numLevels = input.readInt();
+            nodesByLevel = new int[numLevels][];
+            for (int level = 0; level < numLevels; level++) {
+                int numNodesOnLevel = input.readInt();
+                if (level == 0) {
+                    // we don't store nodes for level 0th, as this level contains all nodes
+                    assert numNodesOnLevel == size;
+                    nodesByLevel[0] = null;
+                } else {
+                    nodesByLevel[level] = new int[numNodesOnLevel];
+                    for (int i = 0; i < numNodesOnLevel; i++) {
+                        nodesByLevel[level][i] = input.readInt();
+                    }
+                }
+            }
+
+            // calculate for each level the start offsets in vectorIndex file from where to read
+            // neighbours
+            graphOffsetsByLevel = new long[numLevels];
+            for (int level = 0; level < numLevels; level++) {
+                if (level == 0) {
+                    graphOffsetsByLevel[level] = 0;
+                } else if (level == 1) {
+                    int numNodesOnLevel0 = size;
+                    graphOffsetsByLevel[level] = (1 + (M * 2)) * Integer.BYTES * numNodesOnLevel0;
+                } else {
+                    int numNodesOnPrevLevel = nodesByLevel[level - 1].length;
+                    graphOffsetsByLevel[level] = graphOffsetsByLevel[level - 1] + (1 + M) * Integer.BYTES * numNodesOnPrevLevel;
+                }
+            }
+        }
+
+        int size() {
+            return size;
+        }
+    }
+
+    /** Read the nearest-neighbors graph from the index input */
+    private static final class OffHeapHnswGraph extends HnswGraph {
+
+        final IndexInput dataIn;
+        final int[][] nodesByLevel;
+        final long[] graphOffsetsByLevel;
+        final int numLevels;
+        final int entryNode;
+        final int size;
+        final long bytesForConns;
+        final long bytesForConns0;
+
+        int arcCount;
+        int arcUpTo;
+        int arc;
+
+        OffHeapHnswGraph(FieldEntry entry, IndexInput dataIn) {
+            this.dataIn = dataIn;
+            this.nodesByLevel = entry.nodesByLevel;
+            this.numLevels = entry.numLevels;
+            this.entryNode = numLevels > 1 ? nodesByLevel[numLevels - 1][0] : 0;
+            this.size = entry.size();
+            this.graphOffsetsByLevel = entry.graphOffsetsByLevel;
+            this.bytesForConns = ((long) entry.M + 1) * Integer.BYTES;
+            this.bytesForConns0 = ((long) (entry.M * 2) + 1) * Integer.BYTES;
+        }
+
+        @Override
+        public void seek(int level, int targetOrd) throws IOException {
+            int targetIndex = level == 0 ? targetOrd : Arrays.binarySearch(nodesByLevel[level], 0, nodesByLevel[level].length, targetOrd);
+            assert targetIndex >= 0;
+            long graphDataOffset = graphOffsetsByLevel[level] + targetIndex * (level == 0 ? bytesForConns0 : bytesForConns);
+            // unsafe; no bounds checking
+            dataIn.seek(graphDataOffset);
+            arcCount = dataIn.readInt();
+            arc = -1;
+            arcUpTo = 0;
+        }
+
+        @Override
+        public int size() {
+            return size;
+        }
+
+        @Override
+        public int nextNeighbor() throws IOException {
+            if (arcUpTo >= arcCount) {
+                return NO_MORE_DOCS;
+            }
+            ++arcUpTo;
+            arc = dataIn.readInt();
+            return arc;
+        }
+
+        @Override
+        public int numLevels() throws IOException {
+            return numLevels;
+        }
+
+        @Override
+        public int entryNode() throws IOException {
+            return entryNode;
+        }
+
+        @Override
+        public NodesIterator getNodesOnLevel(int level) {
+            if (level == 0) {
+                return new NodesIterator(size());
+            } else {
+                return new NodesIterator(nodesByLevel[level], nodesByLevel[level].length);
+            }
+        }
+    }
+}

--- a/server/src/main/java/org/elasticsearch/index/codec/vectors/XLucene94HnswVectorsReader.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/vectors/XLucene94HnswVectorsReader.java
@@ -177,7 +177,8 @@ public final class XLucene94HnswVectorsReader extends KnnVectorsReader {
                 byteSize = Float.BYTES;
                 break;
         }
-        long numBytes = (long) fieldEntry.size * dimension * byteSize;
+        long vectorBytes = Math.multiplyExact((long) dimension, byteSize);
+        long numBytes = Math.multiplyExact(vectorBytes, fieldEntry.size);
         if (numBytes != fieldEntry.vectorDataLength) {
             throw new IllegalStateException(
                 "Vector data length "

--- a/server/src/main/java/org/elasticsearch/index/codec/vectors/XLucene94HnswVectorsWriter.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/vectors/XLucene94HnswVectorsWriter.java
@@ -1,0 +1,715 @@
+/*
+ * @notice
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.elasticsearch.index.codec.vectors;
+
+import org.apache.lucene.codecs.CodecUtil;
+import org.apache.lucene.codecs.KnnFieldVectorsWriter;
+import org.apache.lucene.codecs.KnnVectorsWriter;
+import org.apache.lucene.codecs.lucene90.IndexedDISI;
+import org.apache.lucene.index.DocsWithFieldSet;
+import org.apache.lucene.index.FieldInfo;
+import org.apache.lucene.index.IndexFileNames;
+import org.apache.lucene.index.MergeState;
+import org.apache.lucene.index.RandomAccessVectorValues;
+import org.apache.lucene.index.SegmentWriteState;
+import org.apache.lucene.index.Sorter;
+import org.apache.lucene.index.VectorValues;
+import org.apache.lucene.search.DocIdSetIterator;
+import org.apache.lucene.store.IndexInput;
+import org.apache.lucene.store.IndexOutput;
+import org.apache.lucene.util.ArrayUtil;
+import org.apache.lucene.util.BytesRef;
+import org.apache.lucene.util.IOUtils;
+import org.apache.lucene.util.InfoStream;
+import org.apache.lucene.util.RamUsageEstimator;
+import org.apache.lucene.util.hnsw.HnswGraph;
+import org.apache.lucene.util.hnsw.HnswGraph.NodesIterator;
+import org.apache.lucene.util.hnsw.HnswGraphBuilder;
+import org.apache.lucene.util.hnsw.NeighborArray;
+import org.apache.lucene.util.hnsw.OnHeapHnswGraph;
+import org.apache.lucene.util.packed.DirectMonotonicWriter;
+import org.elasticsearch.core.SuppressForbidden;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.apache.lucene.search.DocIdSetIterator.NO_MORE_DOCS;
+import static org.elasticsearch.index.codec.vectors.XLucene94HnswVectorsFormat.DIRECT_MONOTONIC_BLOCK_SHIFT;
+
+/**
+ * Writes vector values and knn graphs to index segments.
+ *
+ * NOTE: this class was temporarily copied from Lucene to fix a bug in Lucene94HnswVectorsReader.
+ * It contains no modifications to the Lucene version.
+ */
+@SuppressForbidden(reason = "class is copied from Lucene")
+public final class XLucene94HnswVectorsWriter extends KnnVectorsWriter {
+
+    private final SegmentWriteState segmentWriteState;
+    private final IndexOutput meta, vectorData, vectorIndex;
+    private final int M;
+    private final int beamWidth;
+
+    private final List<FieldWriter<?>> fields = new ArrayList<>();
+    private boolean finished;
+
+    XLucene94HnswVectorsWriter(SegmentWriteState state, int M, int beamWidth) throws IOException {
+        this.M = M;
+        this.beamWidth = beamWidth;
+        segmentWriteState = state;
+        String metaFileName = IndexFileNames.segmentFileName(
+            state.segmentInfo.name,
+            state.segmentSuffix,
+            XLucene94HnswVectorsFormat.META_EXTENSION
+        );
+
+        String vectorDataFileName = IndexFileNames.segmentFileName(
+            state.segmentInfo.name,
+            state.segmentSuffix,
+            XLucene94HnswVectorsFormat.VECTOR_DATA_EXTENSION
+        );
+
+        String indexDataFileName = IndexFileNames.segmentFileName(
+            state.segmentInfo.name,
+            state.segmentSuffix,
+            XLucene94HnswVectorsFormat.VECTOR_INDEX_EXTENSION
+        );
+
+        boolean success = false;
+        try {
+            meta = state.directory.createOutput(metaFileName, state.context);
+            vectorData = state.directory.createOutput(vectorDataFileName, state.context);
+            vectorIndex = state.directory.createOutput(indexDataFileName, state.context);
+
+            CodecUtil.writeIndexHeader(
+                meta,
+                XLucene94HnswVectorsFormat.META_CODEC_NAME,
+                XLucene94HnswVectorsFormat.VERSION_CURRENT,
+                state.segmentInfo.getId(),
+                state.segmentSuffix
+            );
+            CodecUtil.writeIndexHeader(
+                vectorData,
+                XLucene94HnswVectorsFormat.VECTOR_DATA_CODEC_NAME,
+                XLucene94HnswVectorsFormat.VERSION_CURRENT,
+                state.segmentInfo.getId(),
+                state.segmentSuffix
+            );
+            CodecUtil.writeIndexHeader(
+                vectorIndex,
+                XLucene94HnswVectorsFormat.VECTOR_INDEX_CODEC_NAME,
+                XLucene94HnswVectorsFormat.VERSION_CURRENT,
+                state.segmentInfo.getId(),
+                state.segmentSuffix
+            );
+            success = true;
+        } finally {
+            if (success == false) {
+                IOUtils.closeWhileHandlingException(this);
+            }
+        }
+    }
+
+    @Override
+    public KnnFieldVectorsWriter<?> addField(FieldInfo fieldInfo) throws IOException {
+        FieldWriter<?> newField = FieldWriter.create(fieldInfo, M, beamWidth, segmentWriteState.infoStream);
+        fields.add(newField);
+        return newField;
+    }
+
+    @Override
+    public void flush(int maxDoc, Sorter.DocMap sortMap) throws IOException {
+        for (FieldWriter<?> field : fields) {
+            if (sortMap == null) {
+                writeField(field, maxDoc);
+            } else {
+                writeSortingField(field, maxDoc, sortMap);
+            }
+        }
+    }
+
+    @Override
+    public void finish() throws IOException {
+        if (finished) {
+            throw new IllegalStateException("already finished");
+        }
+        finished = true;
+
+        if (meta != null) {
+            // write end of fields marker
+            meta.writeInt(-1);
+            CodecUtil.writeFooter(meta);
+        }
+        if (vectorData != null) {
+            CodecUtil.writeFooter(vectorData);
+            CodecUtil.writeFooter(vectorIndex);
+        }
+    }
+
+    @Override
+    public long ramBytesUsed() {
+        long total = 0;
+        for (FieldWriter<?> field : fields) {
+            total += field.ramBytesUsed();
+        }
+        return total;
+    }
+
+    private void writeField(FieldWriter<?> fieldData, int maxDoc) throws IOException {
+        // write vector values
+        long vectorDataOffset = vectorData.alignFilePointer(Float.BYTES);
+        switch (fieldData.fieldInfo.getVectorEncoding()) {
+            case BYTE:
+                writeByteVectors(fieldData);
+                break;
+            default:
+            case FLOAT32:
+                writeFloat32Vectors(fieldData);
+        }
+        long vectorDataLength = vectorData.getFilePointer() - vectorDataOffset;
+
+        // write graph
+        long vectorIndexOffset = vectorIndex.getFilePointer();
+        OnHeapHnswGraph graph = fieldData.getGraph();
+        writeGraph(graph);
+        long vectorIndexLength = vectorIndex.getFilePointer() - vectorIndexOffset;
+
+        writeMeta(
+            fieldData.fieldInfo,
+            maxDoc,
+            vectorDataOffset,
+            vectorDataLength,
+            vectorIndexOffset,
+            vectorIndexLength,
+            fieldData.docsWithField,
+            graph
+        );
+    }
+
+    private void writeFloat32Vectors(FieldWriter<?> fieldData) throws IOException {
+        final ByteBuffer buffer = ByteBuffer.allocate(fieldData.dim * Float.BYTES).order(ByteOrder.LITTLE_ENDIAN);
+        final BytesRef binaryValue = new BytesRef(buffer.array());
+        for (Object v : fieldData.vectors) {
+            buffer.asFloatBuffer().put((float[]) v);
+            vectorData.writeBytes(binaryValue.bytes, binaryValue.offset, binaryValue.length);
+        }
+    }
+
+    private void writeByteVectors(FieldWriter<?> fieldData) throws IOException {
+        for (Object v : fieldData.vectors) {
+            BytesRef vector = (BytesRef) v;
+            vectorData.writeBytes(vector.bytes, vector.offset, vector.length);
+        }
+    }
+
+    private void writeSortingField(FieldWriter<?> fieldData, int maxDoc, Sorter.DocMap sortMap) throws IOException {
+        final int[] docIdOffsets = new int[sortMap.size()];
+        int offset = 1; // 0 means no vector for this (field, document)
+        DocIdSetIterator iterator = fieldData.docsWithField.iterator();
+        for (int docID = iterator.nextDoc(); docID != DocIdSetIterator.NO_MORE_DOCS; docID = iterator.nextDoc()) {
+            int newDocID = sortMap.oldToNew(docID);
+            docIdOffsets[newDocID] = offset++;
+        }
+        DocsWithFieldSet newDocsWithField = new DocsWithFieldSet();
+        final int[] ordMap = new int[offset - 1]; // new ord to old ord
+        final int[] oldOrdMap = new int[offset - 1]; // old ord to new ord
+        int ord = 0;
+        int doc = 0;
+        for (int docIdOffset : docIdOffsets) {
+            if (docIdOffset != 0) {
+                ordMap[ord] = docIdOffset - 1;
+                oldOrdMap[docIdOffset - 1] = ord;
+                newDocsWithField.add(doc);
+                ord++;
+            }
+            doc++;
+        }
+
+        // write vector values
+        long vectorDataOffset;
+        switch (fieldData.fieldInfo.getVectorEncoding()) {
+            case BYTE:
+                vectorDataOffset = writeSortedByteVectors(fieldData, ordMap);
+                break;
+            default:
+            case FLOAT32:
+                vectorDataOffset = writeSortedFloat32Vectors(fieldData, ordMap);
+                break;
+        }
+        ;
+        long vectorDataLength = vectorData.getFilePointer() - vectorDataOffset;
+
+        // write graph
+        long vectorIndexOffset = vectorIndex.getFilePointer();
+        OnHeapHnswGraph graph = fieldData.getGraph();
+        HnswGraph mockGraph = reconstructAndWriteGraph(graph, ordMap, oldOrdMap);
+        long vectorIndexLength = vectorIndex.getFilePointer() - vectorIndexOffset;
+
+        writeMeta(
+            fieldData.fieldInfo,
+            maxDoc,
+            vectorDataOffset,
+            vectorDataLength,
+            vectorIndexOffset,
+            vectorIndexLength,
+            newDocsWithField,
+            mockGraph
+        );
+    }
+
+    private long writeSortedFloat32Vectors(FieldWriter<?> fieldData, int[] ordMap) throws IOException {
+        long vectorDataOffset = vectorData.alignFilePointer(Float.BYTES);
+        final ByteBuffer buffer = ByteBuffer.allocate(fieldData.dim * Float.BYTES).order(ByteOrder.LITTLE_ENDIAN);
+        final BytesRef binaryValue = new BytesRef(buffer.array());
+        for (int ordinal : ordMap) {
+            float[] vector = (float[]) fieldData.vectors.get(ordinal);
+            buffer.asFloatBuffer().put(vector);
+            vectorData.writeBytes(binaryValue.bytes, binaryValue.offset, binaryValue.length);
+        }
+        return vectorDataOffset;
+    }
+
+    private long writeSortedByteVectors(FieldWriter<?> fieldData, int[] ordMap) throws IOException {
+        long vectorDataOffset = vectorData.alignFilePointer(Float.BYTES);
+        for (int ordinal : ordMap) {
+            BytesRef vector = (BytesRef) fieldData.vectors.get(ordinal);
+            vectorData.writeBytes(vector.bytes, vector.offset, vector.length);
+        }
+        return vectorDataOffset;
+    }
+
+    // reconstruct graph substituting old ordinals with new ordinals
+    private HnswGraph reconstructAndWriteGraph(OnHeapHnswGraph graph, int[] newToOldMap, int[] oldToNewMap) throws IOException {
+        if (graph == null) return null;
+
+        List<int[]> nodesByLevel = new ArrayList<>(graph.numLevels());
+        nodesByLevel.add(null);
+
+        int maxOrd = graph.size();
+        int maxConnOnLevel = M * 2;
+        NodesIterator nodesOnLevel0 = graph.getNodesOnLevel(0);
+        while (nodesOnLevel0.hasNext()) {
+            int node = nodesOnLevel0.nextInt();
+            NeighborArray neighbors = graph.getNeighbors(0, newToOldMap[node]);
+            reconstructAndWriteNeigbours(neighbors, oldToNewMap, maxConnOnLevel, maxOrd);
+        }
+
+        maxConnOnLevel = M;
+        for (int level = 1; level < graph.numLevels(); level++) {
+            NodesIterator nodesOnLevel = graph.getNodesOnLevel(level);
+            int[] newNodes = new int[nodesOnLevel.size()];
+            int n = 0;
+            while (nodesOnLevel.hasNext()) {
+                newNodes[n++] = oldToNewMap[nodesOnLevel.nextInt()];
+            }
+            Arrays.sort(newNodes);
+            nodesByLevel.add(newNodes);
+            for (int node : newNodes) {
+                NeighborArray neighbors = graph.getNeighbors(level, newToOldMap[node]);
+                reconstructAndWriteNeigbours(neighbors, oldToNewMap, maxConnOnLevel, maxOrd);
+            }
+        }
+        return new HnswGraph() {
+            @Override
+            public int nextNeighbor() {
+                throw new UnsupportedOperationException("Not supported on a mock graph");
+            }
+
+            @Override
+            public void seek(int level, int target) {
+                throw new UnsupportedOperationException("Not supported on a mock graph");
+            }
+
+            @Override
+            public int size() {
+                return graph.size();
+            }
+
+            @Override
+            public int numLevels() {
+                return graph.numLevels();
+            }
+
+            @Override
+            public int entryNode() {
+                throw new UnsupportedOperationException("Not supported on a mock graph");
+            }
+
+            @Override
+            public NodesIterator getNodesOnLevel(int level) {
+                if (level == 0) {
+                    return graph.getNodesOnLevel(0);
+                } else {
+                    return new NodesIterator(nodesByLevel.get(level), nodesByLevel.get(level).length);
+                }
+            }
+        };
+    }
+
+    private void reconstructAndWriteNeigbours(NeighborArray neighbors, int[] oldToNewMap, int maxConnOnLevel, int maxOrd)
+        throws IOException {
+        int size = neighbors.size();
+        vectorIndex.writeInt(size);
+
+        // Destructively modify; it's ok we are discarding it after this
+        int[] nnodes = neighbors.node();
+        for (int i = 0; i < size; i++) {
+            nnodes[i] = oldToNewMap[nnodes[i]];
+        }
+        Arrays.sort(nnodes, 0, size);
+        for (int i = 0; i < size; i++) {
+            int nnode = nnodes[i];
+            assert nnode < maxOrd : "node too large: " + nnode + ">=" + maxOrd;
+            vectorIndex.writeInt(nnode);
+        }
+        // if number of connections < maxConn,
+        // add bogus values up to maxConn to have predictable offsets
+        for (int i = size; i < maxConnOnLevel; i++) {
+            vectorIndex.writeInt(0);
+        }
+    }
+
+    @Override
+    public void mergeOneField(FieldInfo fieldInfo, MergeState mergeState) throws IOException {
+        long vectorDataOffset = vectorData.alignFilePointer(Float.BYTES);
+        VectorValues vectors = MergedVectorValues.mergeVectorValues(fieldInfo, mergeState);
+
+        IndexOutput tempVectorData = segmentWriteState.directory.createTempOutput(vectorData.getName(), "temp", segmentWriteState.context);
+        IndexInput vectorDataInput = null;
+        boolean success = false;
+        try {
+            // write the vector data to a temporary file
+            DocsWithFieldSet docsWithField = writeVectorData(tempVectorData, vectors, fieldInfo.getVectorEncoding().byteSize);
+            CodecUtil.writeFooter(tempVectorData);
+            IOUtils.close(tempVectorData);
+
+            // copy the temporary file vectors to the actual data file
+            vectorDataInput = segmentWriteState.directory.openInput(tempVectorData.getName(), segmentWriteState.context);
+            vectorData.copyBytes(vectorDataInput, vectorDataInput.length() - CodecUtil.footerLength());
+            CodecUtil.retrieveChecksum(vectorDataInput);
+            long vectorDataLength = vectorData.getFilePointer() - vectorDataOffset;
+            long vectorIndexOffset = vectorIndex.getFilePointer();
+            // build the graph using the temporary vector data
+            // we use Lucene94HnswVectorsReader.DenseOffHeapVectorValues for the graph construction
+            // doesn't need to know docIds
+            // TODO: separate random access vector values from DocIdSetIterator?
+            int byteSize = vectors.dimension() * fieldInfo.getVectorEncoding().byteSize;
+            XOffHeapVectorValues offHeapVectors = new XOffHeapVectorValues.DenseOffHeapVectorValues(
+                vectors.dimension(),
+                docsWithField.cardinality(),
+                vectorDataInput,
+                byteSize
+            );
+            OnHeapHnswGraph graph = null;
+            if (offHeapVectors.size() != 0) {
+                // build graph
+                HnswGraphBuilder<?> hnswGraphBuilder = HnswGraphBuilder.create(
+                    offHeapVectors,
+                    fieldInfo.getVectorEncoding(),
+                    fieldInfo.getVectorSimilarityFunction(),
+                    M,
+                    beamWidth,
+                    HnswGraphBuilder.randSeed
+                );
+                hnswGraphBuilder.setInfoStream(segmentWriteState.infoStream);
+                graph = hnswGraphBuilder.build(offHeapVectors.copy());
+                writeGraph(graph);
+            }
+            long vectorIndexLength = vectorIndex.getFilePointer() - vectorIndexOffset;
+            writeMeta(
+                fieldInfo,
+                segmentWriteState.segmentInfo.maxDoc(),
+                vectorDataOffset,
+                vectorDataLength,
+                vectorIndexOffset,
+                vectorIndexLength,
+                docsWithField,
+                graph
+            );
+            success = true;
+        } finally {
+            IOUtils.close(vectorDataInput);
+            if (success) {
+                segmentWriteState.directory.deleteFile(tempVectorData.getName());
+            } else {
+                IOUtils.closeWhileHandlingException(tempVectorData);
+                IOUtils.deleteFilesIgnoringExceptions(segmentWriteState.directory, tempVectorData.getName());
+            }
+        }
+    }
+
+    private void writeGraph(OnHeapHnswGraph graph) throws IOException {
+        if (graph == null) return;
+        // write vectors' neighbours on each level into the vectorIndex file
+        int countOnLevel0 = graph.size();
+        for (int level = 0; level < graph.numLevels(); level++) {
+            int maxConnOnLevel = level == 0 ? (M * 2) : M;
+            NodesIterator nodesOnLevel = graph.getNodesOnLevel(level);
+            while (nodesOnLevel.hasNext()) {
+                int node = nodesOnLevel.nextInt();
+                NeighborArray neighbors = graph.getNeighbors(level, node);
+                int size = neighbors.size();
+                vectorIndex.writeInt(size);
+                // Destructively modify; it's ok we are discarding it after this
+                int[] nnodes = neighbors.node();
+                Arrays.sort(nnodes, 0, size);
+                for (int i = 0; i < size; i++) {
+                    int nnode = nnodes[i];
+                    assert nnode < countOnLevel0 : "node too large: " + nnode + ">=" + countOnLevel0;
+                    vectorIndex.writeInt(nnode);
+                }
+                // if number of connections < maxConn, add bogus values up to maxConn to have predictable
+                // offsets
+                for (int i = size; i < maxConnOnLevel; i++) {
+                    vectorIndex.writeInt(0);
+                }
+            }
+        }
+    }
+
+    private void writeMeta(
+        FieldInfo field,
+        int maxDoc,
+        long vectorDataOffset,
+        long vectorDataLength,
+        long vectorIndexOffset,
+        long vectorIndexLength,
+        DocsWithFieldSet docsWithField,
+        HnswGraph graph
+    ) throws IOException {
+        meta.writeInt(field.number);
+        meta.writeInt(field.getVectorEncoding().ordinal());
+        meta.writeInt(field.getVectorSimilarityFunction().ordinal());
+        meta.writeVLong(vectorDataOffset);
+        meta.writeVLong(vectorDataLength);
+        meta.writeVLong(vectorIndexOffset);
+        meta.writeVLong(vectorIndexLength);
+        meta.writeInt(field.getVectorDimension());
+
+        // write docIDs
+        int count = docsWithField.cardinality();
+        meta.writeInt(count);
+        if (count == 0) {
+            meta.writeLong(-2); // docsWithFieldOffset
+            meta.writeLong(0L); // docsWithFieldLength
+            meta.writeShort((short) -1); // jumpTableEntryCount
+            meta.writeByte((byte) -1); // denseRankPower
+        } else if (count == maxDoc) {
+            meta.writeLong(-1); // docsWithFieldOffset
+            meta.writeLong(0L); // docsWithFieldLength
+            meta.writeShort((short) -1); // jumpTableEntryCount
+            meta.writeByte((byte) -1); // denseRankPower
+        } else {
+            long offset = vectorData.getFilePointer();
+            meta.writeLong(offset); // docsWithFieldOffset
+            final short jumpTableEntryCount = IndexedDISI.writeBitSet(
+                docsWithField.iterator(),
+                vectorData,
+                IndexedDISI.DEFAULT_DENSE_RANK_POWER
+            );
+            meta.writeLong(vectorData.getFilePointer() - offset); // docsWithFieldLength
+            meta.writeShort(jumpTableEntryCount);
+            meta.writeByte(IndexedDISI.DEFAULT_DENSE_RANK_POWER);
+
+            // write ordToDoc mapping
+            long start = vectorData.getFilePointer();
+            meta.writeLong(start);
+            meta.writeVInt(DIRECT_MONOTONIC_BLOCK_SHIFT);
+            // dense case and empty case do not need to store ordToMap mapping
+            final DirectMonotonicWriter ordToDocWriter = DirectMonotonicWriter.getInstance(
+                meta,
+                vectorData,
+                count,
+                DIRECT_MONOTONIC_BLOCK_SHIFT
+            );
+            DocIdSetIterator iterator = docsWithField.iterator();
+            for (int doc = iterator.nextDoc(); doc != DocIdSetIterator.NO_MORE_DOCS; doc = iterator.nextDoc()) {
+                ordToDocWriter.add(doc);
+            }
+            ordToDocWriter.finish();
+            meta.writeLong(vectorData.getFilePointer() - start);
+        }
+
+        meta.writeInt(M);
+        // write graph nodes on each level
+        if (graph == null) {
+            meta.writeInt(0);
+        } else {
+            meta.writeInt(graph.numLevels());
+            for (int level = 0; level < graph.numLevels(); level++) {
+                NodesIterator nodesOnLevel = graph.getNodesOnLevel(level);
+                meta.writeInt(nodesOnLevel.size()); // number of nodes on a level
+                if (level > 0) {
+                    while (nodesOnLevel.hasNext()) {
+                        int node = nodesOnLevel.nextInt();
+                        meta.writeInt(node); // list of nodes on a level
+                    }
+                }
+            }
+        }
+    }
+
+    /**
+     * Writes the vector values to the output and returns a set of documents that contains vectors.
+     */
+    private static DocsWithFieldSet writeVectorData(IndexOutput output, VectorValues vectors, int scalarSize) throws IOException {
+        DocsWithFieldSet docsWithField = new DocsWithFieldSet();
+        for (int docV = vectors.nextDoc(); docV != NO_MORE_DOCS; docV = vectors.nextDoc()) {
+            // write vector
+            BytesRef binaryValue = vectors.binaryValue();
+            assert binaryValue.length == vectors.dimension() * scalarSize;
+            output.writeBytes(binaryValue.bytes, binaryValue.offset, binaryValue.length);
+            docsWithField.add(docV);
+        }
+        return docsWithField;
+    }
+
+    @Override
+    public void close() throws IOException {
+        IOUtils.close(meta, vectorData, vectorIndex);
+    }
+
+    private abstract static class FieldWriter<T> extends KnnFieldVectorsWriter<T> {
+        private final FieldInfo fieldInfo;
+        private final int dim;
+        private final DocsWithFieldSet docsWithField;
+        private final List<T> vectors;
+        private final RAVectorValues<T> raVectorValues;
+        private final HnswGraphBuilder<T> hnswGraphBuilder;
+
+        private int lastDocID = -1;
+        private int node = 0;
+
+        static FieldWriter<?> create(FieldInfo fieldInfo, int M, int beamWidth, InfoStream infoStream) throws IOException {
+            int dim = fieldInfo.getVectorDimension();
+            switch (fieldInfo.getVectorEncoding()) {
+                case BYTE:
+                    return new FieldWriter<BytesRef>(fieldInfo, M, beamWidth, infoStream) {
+                        @Override
+                        public BytesRef copyValue(BytesRef value) {
+                            return new BytesRef(ArrayUtil.copyOfSubArray(value.bytes, value.offset, value.offset + dim));
+                        }
+                    };
+                default:
+                case FLOAT32:
+                    return new FieldWriter<float[]>(fieldInfo, M, beamWidth, infoStream) {
+                        @Override
+                        public float[] copyValue(float[] value) {
+                            return ArrayUtil.copyOfSubArray(value, 0, dim);
+                        }
+                    };
+            }
+        }
+
+        @SuppressWarnings("unchecked")
+        FieldWriter(FieldInfo fieldInfo, int M, int beamWidth, InfoStream infoStream) throws IOException {
+            this.fieldInfo = fieldInfo;
+            this.dim = fieldInfo.getVectorDimension();
+            this.docsWithField = new DocsWithFieldSet();
+            vectors = new ArrayList<>();
+            raVectorValues = new RAVectorValues<>(vectors, dim);
+            hnswGraphBuilder = (HnswGraphBuilder<T>) HnswGraphBuilder.create(
+                raVectorValues,
+                fieldInfo.getVectorEncoding(),
+                fieldInfo.getVectorSimilarityFunction(),
+                M,
+                beamWidth,
+                HnswGraphBuilder.randSeed
+            );
+            hnswGraphBuilder.setInfoStream(infoStream);
+        }
+
+        @Override
+        @SuppressWarnings("unchecked")
+        public void addValue(int docID, Object value) throws IOException {
+            if (docID == lastDocID) {
+                throw new IllegalArgumentException(
+                    "VectorValuesField \""
+                        + fieldInfo.name
+                        + "\" appears more than once in this document (only one value is allowed per field)"
+                );
+            }
+            T vectorValue = (T) value;
+            assert docID > lastDocID;
+            docsWithField.add(docID);
+            vectors.add(copyValue(vectorValue));
+            if (node > 0) {
+                // start at node 1! node 0 is added implicitly, in the constructor
+                hnswGraphBuilder.addGraphNode(node, vectorValue);
+            }
+            node++;
+            lastDocID = docID;
+        }
+
+        OnHeapHnswGraph getGraph() {
+            if (vectors.size() > 0) {
+                return hnswGraphBuilder.getGraph();
+            } else {
+                return null;
+            }
+        }
+
+        @Override
+        public long ramBytesUsed() {
+            if (vectors.size() == 0) return 0;
+            return docsWithField.ramBytesUsed() + vectors.size() * (RamUsageEstimator.NUM_BYTES_OBJECT_REF
+                + RamUsageEstimator.NUM_BYTES_ARRAY_HEADER) + vectors.size() * fieldInfo.getVectorDimension() * fieldInfo
+                    .getVectorEncoding().byteSize + hnswGraphBuilder.getGraph().ramBytesUsed();
+        }
+    }
+
+    private static class RAVectorValues<T> implements RandomAccessVectorValues {
+        private final List<T> vectors;
+        private final int dim;
+
+        RAVectorValues(List<T> vectors, int dim) {
+            this.vectors = vectors;
+            this.dim = dim;
+        }
+
+        @Override
+        public int size() {
+            return vectors.size();
+        }
+
+        @Override
+        public int dimension() {
+            return dim;
+        }
+
+        @Override
+        public float[] vectorValue(int targetOrd) throws IOException {
+            return (float[]) vectors.get(targetOrd);
+        }
+
+        @Override
+        public BytesRef binaryValue(int targetOrd) throws IOException {
+            return (BytesRef) vectors.get(targetOrd);
+        }
+
+        @Override
+        public RandomAccessVectorValues copy() throws IOException {
+            return this;
+        }
+    }
+}

--- a/server/src/main/java/org/elasticsearch/index/codec/vectors/XOffHeapVectorValues.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/vectors/XOffHeapVectorValues.java
@@ -1,0 +1,324 @@
+/*
+ * @notice
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.elasticsearch.index.codec.vectors;
+
+import org.apache.lucene.codecs.lucene90.IndexedDISI;
+import org.apache.lucene.index.RandomAccessVectorValues;
+import org.apache.lucene.index.VectorValues;
+import org.apache.lucene.store.IndexInput;
+import org.apache.lucene.store.RandomAccessInput;
+import org.apache.lucene.util.Bits;
+import org.apache.lucene.util.BytesRef;
+import org.apache.lucene.util.packed.DirectMonotonicReader;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+
+/**
+ * Read the vector values from the index input. This supports both iterated and random access.
+ *
+ *
+ * NOTE: this class was temporarily copied from Lucene to fix a bug in Lucene94HnswVectorsReader.
+ * It contains no modifications to the Lucene version.
+ */
+abstract class XOffHeapVectorValues extends VectorValues implements RandomAccessVectorValues {
+
+    protected final int dimension;
+    protected final int size;
+    protected final IndexInput slice;
+    protected final BytesRef binaryValue;
+    protected final ByteBuffer byteBuffer;
+    protected final int byteSize;
+    protected final float[] value;
+
+    XOffHeapVectorValues(int dimension, int size, IndexInput slice, int byteSize) {
+        this.dimension = dimension;
+        this.size = size;
+        this.slice = slice;
+        this.byteSize = byteSize;
+        byteBuffer = ByteBuffer.allocate(byteSize);
+        value = new float[dimension];
+        binaryValue = new BytesRef(byteBuffer.array(), byteBuffer.arrayOffset(), byteSize);
+    }
+
+    @Override
+    public int dimension() {
+        return dimension;
+    }
+
+    @Override
+    public int size() {
+        return size;
+    }
+
+    @Override
+    public long cost() {
+        return size;
+    }
+
+    @Override
+    public float[] vectorValue(int targetOrd) throws IOException {
+        slice.seek((long) targetOrd * byteSize);
+        slice.readFloats(value, 0, value.length);
+        return value;
+    }
+
+    @Override
+    public BytesRef binaryValue(int targetOrd) throws IOException {
+        readValue(targetOrd);
+        return binaryValue;
+    }
+
+    private void readValue(int targetOrd) throws IOException {
+        slice.seek((long) targetOrd * byteSize);
+        slice.readBytes(byteBuffer.array(), byteBuffer.arrayOffset(), byteSize);
+    }
+
+    public abstract int ordToDoc(int ord);
+
+    static XOffHeapVectorValues load(XLucene94HnswVectorsReader.FieldEntry fieldEntry, IndexInput vectorData) throws IOException {
+        if (fieldEntry.docsWithFieldOffset == -2) {
+            return new EmptyOffHeapVectorValues(fieldEntry.dimension);
+        }
+        IndexInput bytesSlice = vectorData.slice("vector-data", fieldEntry.vectorDataOffset, fieldEntry.vectorDataLength);
+        int byteSize = fieldEntry.dimension * fieldEntry.vectorEncoding.byteSize;
+        if (fieldEntry.docsWithFieldOffset == -1) {
+            return new DenseOffHeapVectorValues(fieldEntry.dimension, fieldEntry.size, bytesSlice, byteSize);
+        } else {
+            return new SparseOffHeapVectorValues(fieldEntry, vectorData, bytesSlice, byteSize);
+        }
+    }
+
+    abstract Bits getAcceptOrds(Bits acceptDocs);
+
+    static class DenseOffHeapVectorValues extends XOffHeapVectorValues {
+
+        private int doc = -1;
+
+        DenseOffHeapVectorValues(int dimension, int size, IndexInput slice, int byteSize) {
+            super(dimension, size, slice, byteSize);
+        }
+
+        @Override
+        public float[] vectorValue() throws IOException {
+            slice.seek((long) doc * byteSize);
+            slice.readFloats(value, 0, value.length);
+            return value;
+        }
+
+        @Override
+        public BytesRef binaryValue() throws IOException {
+            slice.seek((long) doc * byteSize);
+            slice.readBytes(byteBuffer.array(), byteBuffer.arrayOffset(), byteSize, false);
+            return binaryValue;
+        }
+
+        @Override
+        public int docID() {
+            return doc;
+        }
+
+        @Override
+        public int nextDoc() throws IOException {
+            return advance(doc + 1);
+        }
+
+        @Override
+        public int advance(int target) throws IOException {
+            assert docID() < target;
+            if (target >= size) {
+                return doc = NO_MORE_DOCS;
+            }
+            return doc = target;
+        }
+
+        @Override
+        public RandomAccessVectorValues copy() throws IOException {
+            return new DenseOffHeapVectorValues(dimension, size, slice.clone(), byteSize);
+        }
+
+        @Override
+        public int ordToDoc(int ord) {
+            return ord;
+        }
+
+        @Override
+        Bits getAcceptOrds(Bits acceptDocs) {
+            return acceptDocs;
+        }
+    }
+
+    private static class SparseOffHeapVectorValues extends XOffHeapVectorValues {
+        private final DirectMonotonicReader ordToDoc;
+        private final IndexedDISI disi;
+        // dataIn was used to init a new IndexedDIS for #randomAccess()
+        private final IndexInput dataIn;
+        private final XLucene94HnswVectorsReader.FieldEntry fieldEntry;
+
+        SparseOffHeapVectorValues(XLucene94HnswVectorsReader.FieldEntry fieldEntry, IndexInput dataIn, IndexInput slice, int byteSize)
+            throws IOException {
+
+            super(fieldEntry.dimension, fieldEntry.size, slice, byteSize);
+            this.fieldEntry = fieldEntry;
+            final RandomAccessInput addressesData = dataIn.randomAccessSlice(fieldEntry.addressesOffset, fieldEntry.addressesLength);
+            this.dataIn = dataIn;
+            this.ordToDoc = DirectMonotonicReader.getInstance(fieldEntry.meta, addressesData);
+            this.disi = new IndexedDISI(
+                dataIn,
+                fieldEntry.docsWithFieldOffset,
+                fieldEntry.docsWithFieldLength,
+                fieldEntry.jumpTableEntryCount,
+                fieldEntry.denseRankPower,
+                fieldEntry.size
+            );
+        }
+
+        @Override
+        public float[] vectorValue() throws IOException {
+            slice.seek((long) (disi.index()) * byteSize);
+            slice.readFloats(value, 0, value.length);
+            return value;
+        }
+
+        @Override
+        public BytesRef binaryValue() throws IOException {
+            slice.seek((long) (disi.index()) * byteSize);
+            slice.readBytes(byteBuffer.array(), byteBuffer.arrayOffset(), byteSize, false);
+            return binaryValue;
+        }
+
+        @Override
+        public int docID() {
+            return disi.docID();
+        }
+
+        @Override
+        public int nextDoc() throws IOException {
+            return disi.nextDoc();
+        }
+
+        @Override
+        public int advance(int target) throws IOException {
+            assert docID() < target;
+            return disi.advance(target);
+        }
+
+        @Override
+        public RandomAccessVectorValues copy() throws IOException {
+            return new SparseOffHeapVectorValues(fieldEntry, dataIn, slice.clone(), byteSize);
+        }
+
+        @Override
+        public int ordToDoc(int ord) {
+            return (int) ordToDoc.get(ord);
+        }
+
+        @Override
+        Bits getAcceptOrds(Bits acceptDocs) {
+            if (acceptDocs == null) {
+                return null;
+            }
+            return new Bits() {
+                @Override
+                public boolean get(int index) {
+                    return acceptDocs.get(ordToDoc(index));
+                }
+
+                @Override
+                public int length() {
+                    return size;
+                }
+            };
+        }
+    }
+
+    private static class EmptyOffHeapVectorValues extends XOffHeapVectorValues {
+
+        EmptyOffHeapVectorValues(int dimension) {
+            super(dimension, 0, null, 0);
+        }
+
+        private int doc = -1;
+
+        @Override
+        public int dimension() {
+            return super.dimension();
+        }
+
+        @Override
+        public int size() {
+            return 0;
+        }
+
+        @Override
+        public float[] vectorValue() throws IOException {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public BytesRef binaryValue() throws IOException {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public int docID() {
+            return doc;
+        }
+
+        @Override
+        public int nextDoc() throws IOException {
+            return advance(doc + 1);
+        }
+
+        @Override
+        public int advance(int target) throws IOException {
+            return doc = NO_MORE_DOCS;
+        }
+
+        @Override
+        public long cost() {
+            return 0;
+        }
+
+        @Override
+        public RandomAccessVectorValues copy() throws IOException {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public float[] vectorValue(int targetOrd) throws IOException {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public BytesRef binaryValue(int targetOrd) throws IOException {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public int ordToDoc(int ord) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        Bits getAcceptOrds(Bits acceptDocs) {
+            return null;
+        }
+    }
+}

--- a/server/src/main/java/org/elasticsearch/index/mapper/vectors/DenseVectorFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/vectors/DenseVectorFieldMapper.java
@@ -9,7 +9,6 @@
 package org.elasticsearch.index.mapper.vectors;
 
 import org.apache.lucene.codecs.KnnVectorsFormat;
-import org.apache.lucene.codecs.lucene94.Lucene94HnswVectorsFormat;
 import org.apache.lucene.document.BinaryDocValuesField;
 import org.apache.lucene.document.Field;
 import org.apache.lucene.document.KnnVectorField;
@@ -23,6 +22,7 @@ import org.apache.lucene.search.Query;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.Version;
 import org.elasticsearch.common.xcontent.support.XContentMapValues;
+import org.elasticsearch.index.codec.vectors.XLucene94HnswVectorsFormat;
 import org.elasticsearch.index.fielddata.FieldDataContext;
 import org.elasticsearch.index.fielddata.IndexFieldData;
 import org.elasticsearch.index.mapper.ArraySourceValueFetcher;
@@ -520,14 +520,14 @@ public class DenseVectorFieldMapper extends FieldMapper {
 
     /**
      * @return the custom kNN vectors format that is configured for this field or
-     * {@code null} if the default format should be used.
+     * null if the default format should be used
      */
     public KnnVectorsFormat getKnnVectorsFormatForField() {
         if (indexOptions == null) {
             return null; // use default format
         } else {
             HnswIndexOptions hnswIndexOptions = (HnswIndexOptions) indexOptions;
-            return new Lucene94HnswVectorsFormat(hnswIndexOptions.m, hnswIndexOptions.efConstruction);
+            return new XLucene94HnswVectorsFormat(hnswIndexOptions.m, hnswIndexOptions.efConstruction);
         }
     }
 

--- a/server/src/main/resources/META-INF/services/org.apache.lucene.codecs.Codec
+++ b/server/src/main/resources/META-INF/services/org.apache.lucene.codecs.Codec
@@ -1,0 +1,24 @@
+#
+# Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+# or more contributor license agreements. Licensed under the Elastic License
+# 2.0 and the Server Side Public License, v 1; you may not use this file except
+# in compliance with, at your election, the Elastic License 2.0 or the Server
+# Side Public License, v 1.
+#
+
+#  Licensed to the Apache Software Foundation (ASF) under one or more
+#  contributor license agreements.  See the NOTICE file distributed with
+#  this work for additional information regarding copyright ownership.
+#  The ASF licenses this file to You under the Apache License, Version 2.0
+#  (the "License"); you may not use this file except in compliance with
+#  the License.  You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+org.elasticsearch.index.codec.XLucene94Codec

--- a/server/src/main/resources/META-INF/services/org.apache.lucene.codecs.KnnVectorsFormat
+++ b/server/src/main/resources/META-INF/services/org.apache.lucene.codecs.KnnVectorsFormat
@@ -1,0 +1,24 @@
+#
+# Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+# or more contributor license agreements. Licensed under the Elastic License
+# 2.0 and the Server Side Public License, v 1; you may not use this file except
+# in compliance with, at your election, the Elastic License 2.0 or the Server
+# Side Public License, v 1.
+#
+
+#  Licensed to the Apache Software Foundation (ASF) under one or more
+#  contributor license agreements.  See the NOTICE file distributed with
+#  this work for additional information regarding copyright ownership.
+#  The ASF licenses this file to You under the Apache License, Version 2.0
+#  (the "License"); you may not use this file except in compliance with
+#  the License.  You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+org.elasticsearch.index.codec.vectors.XLucene94HnswVectorsFormat

--- a/server/src/test/java/org/elasticsearch/index/codec/CodecTests.java
+++ b/server/src/test/java/org/elasticsearch/index/codec/CodecTests.java
@@ -42,7 +42,7 @@ public class CodecTests extends ESTestCase {
     public void testResolveDefaultCodecs() throws Exception {
         CodecService codecService = createCodecService();
         assertThat(codecService.codec("default"), instanceOf(PerFieldMapperCodec.class));
-        assertThat(codecService.codec("default"), instanceOf(Lucene94Codec.class));
+        assertThat(codecService.codec("default"), instanceOf(XLucene94Codec.class));
     }
 
     public void testDefault() throws Exception {


### PR DESCRIPTION
If a single segment has a large amount of vector data, then the codec
validation can fail. This is because the validation code uses an int instead of
a long to hold the size, and the value can overflow.

This PR proposes to temporarily fix the problem within Elasticsearch by copying
over the Lucene codec classes and applying the tiny fix. The same codec name
`Lucene94` is used, so we don't have to maintain a separate codec and can
switch onto Lucene's version when the fix is available.