### PR TITLE
[8.5] Fork TransportClusterStateAction to MANAGEMENT (#90996)

### DIFF
--- a/docs/changelog/90996.yaml
+++ b/docs/changelog/90996.yaml
@@ -1,0 +1,5 @@
+pr: 90996
+summary: Fork `TransportClusterStateAction` to MANAGEMENT
+area: Distributed
+type: bug
+issues: []

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/state/TransportClusterStateAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/state/TransportClusterStateAction.java
@@ -40,7 +40,7 @@ import java.util.function.Predicate;
 
 public class TransportClusterStateAction extends TransportMasterNodeReadAction<ClusterStateRequest, ClusterStateResponse> {
 
-    private final Logger logger = LogManager.getLogger(getClass());
+    private static final Logger logger = LogManager.getLogger(TransportClusterStateAction.class);
 
     @Inject
     public TransportClusterStateAction(
@@ -60,7 +60,7 @@ public class TransportClusterStateAction extends TransportMasterNodeReadAction<C
             ClusterStateRequest::new,
             indexNameExpressionResolver,
             ClusterStateResponse::new,
-            ThreadPool.Names.SAME
+            ThreadPool.Names.MANAGEMENT
         );
     }
 


### PR DESCRIPTION
Backports the following commits to 8.5:
 - Fork TransportClusterStateAction to MANAGEMENT (#90996)