### PR TITLE
Add curations to the search engine settings

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/metadata/SearchEngine.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/SearchEngine.java
@@ -30,7 +30,8 @@ public class SearchEngine implements SimpleDiffable<SearchEngine>, ToXContentObj
     public static final ParseField INDICES_FIELD = new ParseField("index");
     public static final ParseField HIDDEN_FIELD = new ParseField("hidden");
     public static final ParseField SYSTEM_FIELD = new ParseField("system");
-    public static final ParseField RELEVANCE_SETTINGS_ID_FIELD = new ParseField("relevance_settings_id");
+    public static final ParseField RELEVANCE_SETTINGS_FIELD = new ParseField("relevance_settings");
+    public static final ParseField CURATIONS_FIELD = new ParseField("curations");
     public static final ParseField ANALYTICS_COLLECTION_FIELD = new ParseField("analytics_collection");
 
     @SuppressWarnings("unchecked")
@@ -42,7 +43,8 @@ public class SearchEngine implements SimpleDiffable<SearchEngine>, ToXContentObj
             (boolean) args[2],
             (boolean) args[3],
             (String) args[4],
-            (String) args[5]
+            (String) args[5],
+            (String) args[6]
         )
     );
 
@@ -51,7 +53,9 @@ public class SearchEngine implements SimpleDiffable<SearchEngine>, ToXContentObj
         PARSER.declareObjectArray(ConstructingObjectParser.constructorArg(), (p, c) -> Index.fromXContent(p), INDICES_FIELD);
         PARSER.declareBoolean(ConstructingObjectParser.optionalConstructorArg(), HIDDEN_FIELD);
         PARSER.declareBoolean(ConstructingObjectParser.optionalConstructorArg(), SYSTEM_FIELD);
-        PARSER.declareString(ConstructingObjectParser.optionalConstructorArg(), RELEVANCE_SETTINGS_ID_FIELD);
+
+        PARSER.declareString(ConstructingObjectParser.optionalConstructorArg(), RELEVANCE_SETTINGS_FIELD);
+        PARSER.declareString(ConstructingObjectParser.optionalConstructorArg(), CURATIONS_FIELD);
         PARSER.declareString(ConstructingObjectParser.optionalConstructorArg(), ANALYTICS_COLLECTION_FIELD);
     }
 
@@ -67,7 +71,9 @@ public class SearchEngine implements SimpleDiffable<SearchEngine>, ToXContentObj
     private final List<Index> indices;
     private final boolean isHidden;
     private final boolean isSystem;
-    private final String relevanceSettingsId;
+    private final String relevanceSettings;
+
+    private final String curations;
     private final String analyticsCollection;
 
     public SearchEngine(
@@ -75,14 +81,16 @@ public class SearchEngine implements SimpleDiffable<SearchEngine>, ToXContentObj
         List<Index> indices,
         boolean isHidden,
         boolean isSystem,
-        String relevanceSettingsId,
+        String relevanceSettings,
+        String curations,
         String analyticsCollection
     ) {
         this.name = name;
         this.indices = indices;
         this.isHidden = isHidden;
         this.isSystem = isSystem;
-        this.relevanceSettingsId = relevanceSettingsId;
+        this.relevanceSettings = relevanceSettings;
+        this.curations = curations;
         this.analyticsCollection = analyticsCollection;
     }
 
@@ -92,8 +100,9 @@ public class SearchEngine implements SimpleDiffable<SearchEngine>, ToXContentObj
             in.readList(Index::new),
             in.readBoolean(),
             in.readBoolean(),
-            in.readOptionalString(),
-            in.readOptionalString()
+            in.readString(),
+            in.readString(),
+            in.readString()
         );
     }
 
@@ -113,8 +122,12 @@ public class SearchEngine implements SimpleDiffable<SearchEngine>, ToXContentObj
         return isSystem;
     }
 
-    public String getRelevanceSettingsId() {
-        return relevanceSettingsId;
+    public String getRelevanceSettings() {
+        return relevanceSettings;
+    }
+
+    public String getCurations() {
+        return curations;
     }
 
     public boolean shouldRecordAnalytics() {
@@ -129,11 +142,14 @@ public class SearchEngine implements SimpleDiffable<SearchEngine>, ToXContentObj
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
         builder.startObject();
         builder.field(NAME_FIELD.getPreferredName(), name);
-        builder.xContentList(INDICES_FIELD.getPreferredName(), indices);
-        builder.field(HIDDEN_FIELD.getPreferredName(), isHidden);
-        builder.field(SYSTEM_FIELD.getPreferredName(), isSystem);
-        builder.field(RELEVANCE_SETTINGS_ID_FIELD.getPreferredName(), relevanceSettingsId);
-        builder.field(ANALYTICS_COLLECTION_FIELD.getPreferredName(), analyticsCollection);
+        {
+            builder.xContentList(INDICES_FIELD.getPreferredName(), indices);
+            builder.field(HIDDEN_FIELD.getPreferredName(), isHidden);
+            builder.field(SYSTEM_FIELD.getPreferredName(), isSystem);
+            builder.field(RELEVANCE_SETTINGS_FIELD.getPreferredName(), relevanceSettings);
+            builder.field(CURATIONS_FIELD.getPreferredName(), curations);
+            builder.field(ANALYTICS_COLLECTION_FIELD.getPreferredName(), analyticsCollection);
+        }
         builder.endObject();
         return builder;
     }
@@ -144,8 +160,9 @@ public class SearchEngine implements SimpleDiffable<SearchEngine>, ToXContentObj
         out.writeList(indices);
         out.writeBoolean(isHidden);
         out.writeBoolean(isSystem);
-        out.writeOptionalString(relevanceSettingsId);
-        out.writeOptionalString(analyticsCollection);
+        out.writeString(relevanceSettings);
+        out.writeString(curations);
+        out.writeString(analyticsCollection);
     }
 
     @Override
@@ -157,12 +174,13 @@ public class SearchEngine implements SimpleDiffable<SearchEngine>, ToXContentObj
             && indices.equals(that.indices)
             && Objects.equals(isHidden, that.isHidden)
             && Objects.equals(isSystem, that.isSystem)
-            && relevanceSettingsId.equals(that.relevanceSettingsId)
+            && relevanceSettings.equals(that.relevanceSettings)
+            && curations.equals(that.curations)
             && analyticsCollection.equals(that.analyticsCollection);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(name, indices, isHidden, isSystem, relevanceSettingsId, analyticsCollection);
+        return Objects.hash(name, indices, isHidden, isSystem, relevanceSettings, curations, analyticsCollection);
     }
 }

--- a/x-pack/plugin/relevance-search/src/main/java/org/elasticsearch/xpack/relevancesearch/query/CurationQueryRewriter.java
+++ b/x-pack/plugin/relevance-search/src/main/java/org/elasticsearch/xpack/relevancesearch/query/CurationQueryRewriter.java
@@ -27,8 +27,7 @@ class CurationQueryRewriter extends AbstractQueryRewriter<CurationsGroup> {
 
     @Override
     protected String getSettingsId(SearchEngine searchEngine) {
-        // TODO: add curation to engine.
-        return null;
+        return searchEngine.getCurations();
     }
 
     @Override

--- a/x-pack/plugin/relevance-search/src/main/java/org/elasticsearch/xpack/relevancesearch/query/OrganicQueryRewriter.java
+++ b/x-pack/plugin/relevance-search/src/main/java/org/elasticsearch/xpack/relevancesearch/query/OrganicQueryRewriter.java
@@ -50,7 +50,7 @@ class OrganicQueryRewriter extends AbstractQueryRewriter<RelevanceSettings> {
 
     @Override
     protected String getSettingsId(SearchEngine searchEngine) {
-        return searchEngine.getRelevanceSettingsId();
+        return searchEngine.getRelevanceSettings();
     }
 
     @Override

--- a/x-pack/plugin/search-engines/src/main/java/org/elasticsearch/searchengines/SearchEngineMetadataService.java
+++ b/x-pack/plugin/search-engines/src/main/java/org/elasticsearch/searchengines/SearchEngineMetadataService.java
@@ -141,7 +141,8 @@ public class SearchEngineMetadataService {
                 indices,
                 false,
                 false,
-                request.getRelevanceSettingsId(),
+                request.getRelevanceSettings(),
+                request.getCurations(),
                 request.getAnalyticsCollection()
             );
             searchEngines.put(request.getName(), searchEngine);

--- a/x-pack/plugin/search-engines/src/main/java/org/elasticsearch/searchengines/action/GetSearchEngineAction.java
+++ b/x-pack/plugin/search-engines/src/main/java/org/elasticsearch/searchengines/action/GetSearchEngineAction.java
@@ -113,8 +113,10 @@ public class GetSearchEngineAction extends ActionType<GetSearchEngineAction.Resp
 
         public static final ParseField NAME_FIELD = new ParseField("name");
         public static final ParseField INDICES_FIELD = new ParseField("indices");
-        public static final ParseField RELEVANCE_SETTINGS_ID_FIELD = new ParseField("relevance_settings");
+        public static final ParseField RELEVANCE_SETTINGS_FIELD = new ParseField("relevance_settings");
+
         public static final ParseField ANALYTICS_COLLECTION_FIELD = new ParseField("analytics_collection");
+        public static final ParseField CURATIONS_FIELD = new ParseField("relevance_settings");
 
         private final List<SearchEngine> searchEngines;
 
@@ -166,9 +168,14 @@ public class GetSearchEngineAction extends ActionType<GetSearchEngineAction.Resp
                 builder.endArray();
                 builder.endObject();
 
-                if (searchEngine.getRelevanceSettingsId() != null) {
-                    builder.field(RELEVANCE_SETTINGS_ID_FIELD.getPreferredName(), searchEngine.getRelevanceSettingsId());
+                if (searchEngine.getRelevanceSettings() != null) {
+                    builder.field(RELEVANCE_SETTINGS_FIELD.getPreferredName(), searchEngine.getRelevanceSettings());
                 }
+
+                if (searchEngine.getCurations() != null) {
+                    builder.field(CURATIONS_FIELD.getPreferredName(), searchEngine.getCurations());
+                }
+
                 if (searchEngine.shouldRecordAnalytics()) {
                     builder.field(ANALYTICS_COLLECTION_FIELD.getPreferredName(), searchEngine.getAnalyticsCollection());
                 }

--- a/x-pack/plugin/search-engines/src/main/java/org/elasticsearch/searchengines/action/PutSearchEngineAction.java
+++ b/x-pack/plugin/search-engines/src/main/java/org/elasticsearch/searchengines/action/PutSearchEngineAction.java
@@ -47,7 +47,9 @@ public class PutSearchEngineAction extends ActionType<AcknowledgedResponse> {
 
         private String[] indices;
 
-        private String relevanceSettingsId;
+        private String relevanceSettings;
+
+        private String curations;
 
         private String analyticsCollection;
 
@@ -63,31 +65,42 @@ public class PutSearchEngineAction extends ActionType<AcknowledgedResponse> {
                 }
                 return indices;
             }, new ParseField("indices"), ObjectParser.ValueType.OBJECT_ARRAY);
-            PARSER.declareString(Request::setRelevanceSettingsId, new ParseField("relevance_settings"));
+            PARSER.declareString(Request::setRelevanceSettings, new ParseField("relevance_settings"));
             PARSER.declareString(Request::setAnalyticsCollection, new ParseField("analytics_collection"));
+            PARSER.declareString(Request::setCurations, new ParseField("curations"));
+
         }
 
         public Request(String name) {
-            this(name, new String[0], null, null);
+            this(name, new String[0], null, null, null);
         }
 
-        public Request(String name, String[] indices, String relevanceSettingsId, String analyticsCollection) {
+        public Request(String name, String[] indices, String relevanceSettings, String curations, String analyticsCollection) {
             this.name = name;
             this.indices = indices;
-            this.relevanceSettingsId = relevanceSettingsId;
             this.analyticsCollection = analyticsCollection;
+            this.relevanceSettings = relevanceSettings;
+            this.curations = curations;
         }
 
         public String getName() {
             return name;
         }
 
-        public String getRelevanceSettingsId() {
-            return relevanceSettingsId;
+        public String getRelevanceSettings() {
+            return relevanceSettings;
         }
 
-        public void setRelevanceSettingsId(String relevanceSettingsId) {
-            this.relevanceSettingsId = relevanceSettingsId;
+        public void setRelevanceSettings(String relevanceSettings) {
+            this.relevanceSettings = relevanceSettings;
+        }
+
+        public String getCurations() {
+            return curations;
+        }
+
+        public void setCurations(String curations) {
+            this.curations = curations;
         }
 
         public String getAnalyticsCollection() {
@@ -127,8 +140,9 @@ public class PutSearchEngineAction extends ActionType<AcknowledgedResponse> {
             super(in);
             this.name = in.readString();
             this.indices = in.readStringArray();
-            this.relevanceSettingsId = in.readString();
-            this.analyticsCollection = in.readOptionalString();
+            this.relevanceSettings = in.readString();
+            this.curations = in.readString();
+            this.analyticsCollection = in.readString();
         }
 
         @Override
@@ -136,7 +150,8 @@ public class PutSearchEngineAction extends ActionType<AcknowledgedResponse> {
             super.writeTo(out);
             out.writeString(name);
             out.writeStringArray(indices);
-            out.writeString(relevanceSettingsId);
+            out.writeString(relevanceSettings);
+            out.writeString(curations);
             out.writeOptionalString(analyticsCollection);
         }
 
@@ -147,12 +162,14 @@ public class PutSearchEngineAction extends ActionType<AcknowledgedResponse> {
             Request request = (Request) o;
             return name.equals(request.name)
                 && Arrays.equals(indices, request.indices)
+                && relevanceSettings.equals(request.relevanceSettings)
+                && curations.equals(request.curations)
                 && analyticsCollection.equals(request.getAnalyticsCollection());
         }
 
         @Override
         public int hashCode() {
-            return Objects.hash(name, indices);
+            return Objects.hash(name, indices, relevanceSettings, curations, analyticsCollection);
         }
 
         @Override


### PR DESCRIPTION
Added an optional `curations` parameter that can be used when creating / updating a search engine:

```
PUT _search_engine/foo-engine
{
  "indices": ["foo-index", "bar-index"],
  "relevance_settings": "foo-relevance-settings",
  "curations": "foo-curations",
  "analytics_collection": "my_collection"
}
```