### PR TITLE
Add privileges for connectors index creation

### DIFF
--- a/docs/changelog/91026.yaml
+++ b/docs/changelog/91026.yaml
@@ -1,0 +1,5 @@
+pr: 91026
+summary: Add privileges for connectors index creation
+area: Authorization
+type: enhancement
+issues: []

--- a/x-pack/plugin/security/qa/service-account/src/javaRestTest/java/org/elasticsearch/xpack/security/authc/service/ServiceAccountIT.java
+++ b/x-pack/plugin/security/qa/service-account/src/javaRestTest/java/org/elasticsearch/xpack/security/authc/service/ServiceAccountIT.java
@@ -166,7 +166,8 @@ public class ServiceAccountIT extends ESRestTestCase {
                         "logs-app_search.search_relevance_suggestions-default",
                         "logs-crawler-default",
                         "logs-workplace_search.analytics-default",
-                        "logs-workplace_search.content_events-default"
+                        "logs-workplace_search.content_events-default",
+                        ".elastic-connectors*"
                     ],
                     "privileges": [
                         "manage",

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/service/ElasticServiceAccounts.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/service/ElasticServiceAccounts.java
@@ -43,7 +43,8 @@ final class ElasticServiceAccounts {
                         "logs-app_search.search_relevance_suggestions-default",
                         "logs-crawler-default",
                         "logs-workplace_search.analytics-default",
-                        "logs-workplace_search.content_events-default"
+                        "logs-workplace_search.content_events-default",
+                        ".elastic-connectors*"
                     )
                     .privileges("manage", "read", "write")
                     .build() },

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/service/ElasticServiceAccountsTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/service/ElasticServiceAccountsTests.java
@@ -359,7 +359,8 @@ public class ElasticServiceAccountsTests extends ESTestCase {
             "logs-app_search.search_relevance_suggestions-default",
             "logs-crawler-default",
             "logs-workplace_search.analytics-default",
-            "logs-workplace_search.content_events-default"
+            "logs-workplace_search.content_events-default",
+            ".elastic-connectors*"
         ).forEach(index -> {
             final IndexAbstraction enterpriseSearchIndex = mockIndexAbstraction(index);
             assertThat(role.indices().allowedIndicesMatcher(AutoCreateAction.NAME).test(enterpriseSearchIndex), is(true));


### PR DESCRIPTION
Add privileges for Enterprise Search service account to manage `.elastic-connectors*` indices. These indices will be used by Enterprise Search connectors to maintain state.

Related: https://github.com/elastic/cloud/pull/108604, https://github.com/elastic/cloud-assets/pull/1091