### PR TITLE
Update network threading documentation

### DIFF
--- a/docs/reference/modules/network/threading.asciidoc
+++ b/docs/reference/modules/network/threading.asciidoc
@@ -13,9 +13,10 @@ thread is chosen when the channel is opened and remains the same for the
 lifetime of the channel.
 
 Each `transport_worker` thread has sole responsibility for sending and
-receiving data over the channels it owns. One of the `transport_worker` threads
-is also responsible for accepting new incoming transport connections, and one
-is responsible for accepting new HTTP connections.
+receiving data over the channels it owns. Additionally, each http and transport
+server socket is assigned to one of the `transport_worker` threads. That worker
+has the responsibility of accepting new incoming connections to the server
+socket it owns.
 
 If a thread in {es} wants to send data over a particular channel, it passes the
 data to the owning `transport_worker` thread for the actual transmission.


### PR DESCRIPTION
Currently the documentation on network threading suggests that we still use a model where we have individual workers dedicated to server sockets. That is no longer true and server sockets are assigned to normal workers. This commit updates the documentation.