### PR TITLE
Improve robustness of formatting plugin in composite builds

### DIFF
--- a/build-conventions/src/main/java/org/elasticsearch/gradle/internal/conventions/VersionPropertiesPlugin.java
+++ b/build-conventions/src/main/java/org/elasticsearch/gradle/internal/conventions/VersionPropertiesPlugin.java
@@ -8,10 +8,9 @@
 
 package org.elasticsearch.gradle.internal.conventions;
 
+import org.elasticsearch.gradle.internal.conventions.util.Util;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
-import org.gradle.api.initialization.IncludedBuild;
-import org.gradle.api.invocation.Gradle;
 import org.gradle.api.provider.Provider;
 
 import java.io.File;
@@ -20,7 +19,7 @@ public class VersionPropertiesPlugin implements Plugin<Project> {
 
     @Override
     public void apply(Project project) {
-        File workspaceDir = locateElasticsearchWorkspace(project.getGradle());
+        File workspaceDir = Util.locateElasticsearchWorkspace(project.getGradle());
 
         // Register the service if not done yet
         File infoPath = new File(workspaceDir, "build-tools-internal");
@@ -29,23 +28,5 @@ public class VersionPropertiesPlugin implements Plugin<Project> {
             spec.getParameters().getInfoPath().set(infoPath);
         });
         project.getExtensions().add("versions", serviceProvider.get().getProperties());
-    }
-
-    private static File locateElasticsearchWorkspace(Gradle project) {
-        if (project.getParent() == null) {
-            // See if any of these included builds is the Elasticsearch project
-            for (IncludedBuild includedBuild : project.getIncludedBuilds()) {
-                File versionProperties = new File(includedBuild.getProjectDir(), "build-tools-internal/version.properties");
-                if (versionProperties.exists()) {
-                    return includedBuild.getProjectDir();
-                }
-            }
-
-            // Otherwise assume this project is the root elasticsearch workspace
-            return project.getRootProject().getRootDir();
-        } else {
-            // We're an included build, so keep looking
-            return locateElasticsearchWorkspace(project.getParent());
-        }
     }
 }

--- a/build-conventions/src/main/java/org/elasticsearch/gradle/internal/conventions/precommit/FormattingPrecommitPlugin.java
+++ b/build-conventions/src/main/java/org/elasticsearch/gradle/internal/conventions/precommit/FormattingPrecommitPlugin.java
@@ -11,8 +11,11 @@ package org.elasticsearch.gradle.internal.conventions.precommit;
 import com.diffplug.gradle.spotless.SpotlessExtension;
 import com.diffplug.gradle.spotless.SpotlessPlugin;
 
+import org.elasticsearch.gradle.internal.conventions.util.Util;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
+
+import java.io.File;
 
 /**
  * This plugin configures formatting for Java source using Spotless
@@ -49,23 +52,18 @@ public class FormattingPrecommitPlugin implements Plugin<Project> {
             project.getRepositories().mavenCentral();
 
             project.getExtensions().getByType(SpotlessExtension.class).java(java -> {
+                File elasticsearchWorkspace = Util.locateElasticsearchWorkspace(project.getGradle());
                 String importOrderPath = "build-conventions/elastic.importorder";
                 String formatterConfigPath = "build-conventions/formatterConfig.xml";
-
-                // When applied to e.g. `:build-tools`, we need to modify the path to our config files
-                if (project.getRootProject().file(importOrderPath).exists() == false) {
-                    importOrderPath = "../" + importOrderPath;
-                    formatterConfigPath = "../" + formatterConfigPath;
-                }
 
                 java.target("src/**/*.java");
                 java.removeUnusedImports();
 
                 // We enforce a standard order for imports
-                java.importOrderFile(project.getRootProject().file(importOrderPath));
+                java.importOrderFile(new File(elasticsearchWorkspace, importOrderPath));
 
                 // Most formatting is done through the Eclipse formatter
-                java.eclipse().configFile(project.getRootProject().file(formatterConfigPath));
+                java.eclipse().configFile(new File(elasticsearchWorkspace, formatterConfigPath));
 
                 // Ensure blank lines are actually empty. Since formatters are applied in
                 // order, apply this one last, otherwise non-empty blank lines can creep


### PR DESCRIPTION
Allow the spotless formatting plugin to be used across builds in a Gradle composite.