### PR TITLE
[8.4] Update bundled JDK to Java 19.0.1 (#91025)

### DIFF
--- a/build-tools-internal/version.properties
+++ b/build-tools-internal/version.properties
@@ -2,7 +2,7 @@ elasticsearch     = 8.4.4
 lucene            = 9.3.0
 
 bundled_jdk_vendor = openjdk
-bundled_jdk = 18.0.2.1+1@db379da656dc47308e138f21b33976fa
+bundled_jdk = 19.0.1+10@afdd2e245b014143b62ccb916125e3ce
 
 # optional dependencies
 spatial4j         = 0.7

--- a/docs/changelog/91025.yaml
+++ b/docs/changelog/91025.yaml
@@ -1,0 +1,6 @@
+pr: 91025
+summary: Update bundled JDK to Java 19.0.1
+area: Packaging
+type: upgrade
+issues:
+ - 91010


### PR DESCRIPTION
Backports the following commits to 8.4:
 - Update bundled JDK to Java 19.0.1 (#91025)