### PR TITLE
Ingest CompoundProcessor asynchronous time stats can be incorrect

### DIFF
--- a/docs/changelog/91033.yaml
+++ b/docs/changelog/91033.yaml
@@ -1,0 +1,5 @@
+pr: 91033
+summary: Ingest `CompoundProcessor` asynchronous time stats can be incorrect
+area: Ingest Node
+type: bug
+issues: []

--- a/server/src/main/java/org/elasticsearch/ingest/CompoundProcessor.java
+++ b/server/src/main/java/org/elasticsearch/ingest/CompoundProcessor.java
@@ -162,15 +162,14 @@ public class CompoundProcessor implements Processor {
         Tuple<Processor, IngestMetric> processorWithMetric;
         Processor processor;
         IngestMetric metric;
-        long startTimeInNanos = 0;
         // iteratively execute any sync processors
         while (currentProcessor < processorsWithMetrics.size() && processorsWithMetrics.get(currentProcessor).v1().isAsync() == false) {
             processorWithMetric = processorsWithMetrics.get(currentProcessor);
             processor = processorWithMetric.v1();
             metric = processorWithMetric.v2();
-            startTimeInNanos = relativeTimeProvider.getAsLong();
             metric.preIngest();
 
+            final long startTimeInNanos = relativeTimeProvider.getAsLong();
             try {
                 ingestDocument = processor.execute(ingestDocument);
                 long ingestTimeInNanos = relativeTimeProvider.getAsLong() - startTimeInNanos;

--- a/server/src/main/java/org/elasticsearch/ingest/CompoundProcessor.java
+++ b/server/src/main/java/org/elasticsearch/ingest/CompoundProcessor.java
@@ -197,7 +197,7 @@ public class CompoundProcessor implements Processor {
 
         final int finalCurrentProcessor = currentProcessor;
         final int nextProcessor = currentProcessor + 1;
-        final long finalStartTimeInNanos = startTimeInNanos;
+        final long finalStartTimeInNanos = relativeTimeProvider.getAsLong();
         final IngestMetric finalMetric = processorsWithMetrics.get(currentProcessor).v2();
         final Processor finalProcessor = processorsWithMetrics.get(currentProcessor).v1();
         final IngestDocument finalIngestDocument = ingestDocument;
@@ -231,7 +231,7 @@ public class CompoundProcessor implements Processor {
                 }
             });
         } catch (Exception e) {
-            long ingestTimeInNanos = relativeTimeProvider.getAsLong() - startTimeInNanos;
+            long ingestTimeInNanos = relativeTimeProvider.getAsLong() - finalStartTimeInNanos;
             if (postIngestHasBeenCalled.get()) {
                 logger.warn("Preventing postIngest from being called more than once", new RuntimeException());
                 assert false : "Attempt to call postIngest more than once";

--- a/server/src/main/java/org/elasticsearch/ingest/CompoundProcessor.java
+++ b/server/src/main/java/org/elasticsearch/ingest/CompoundProcessor.java
@@ -194,6 +194,7 @@ public class CompoundProcessor implements Processor {
             return;
         }
 
+        // n.b. read 'final' on these variable names as hungarian notation -- we need final variables because of the lambda
         final int finalCurrentProcessor = currentProcessor;
         final int nextProcessor = currentProcessor + 1;
         final long startTimeInNanos = relativeTimeProvider.getAsLong();

--- a/server/src/main/java/org/elasticsearch/ingest/CompoundProcessor.java
+++ b/server/src/main/java/org/elasticsearch/ingest/CompoundProcessor.java
@@ -180,7 +180,8 @@ public class CompoundProcessor implements Processor {
                     return;
                 }
             } catch (Exception e) {
-                metric.postIngest(relativeTimeProvider.getAsLong() - startTimeInNanos);
+                long ingestTimeInNanos = relativeTimeProvider.getAsLong() - startTimeInNanos;
+                metric.postIngest(ingestTimeInNanos);
                 executeOnFailureOuter(currentProcessor, ingestDocument, handler, processor, metric, e);
                 return;
             }

--- a/server/src/main/java/org/elasticsearch/ingest/CompoundProcessor.java
+++ b/server/src/main/java/org/elasticsearch/ingest/CompoundProcessor.java
@@ -196,7 +196,7 @@ public class CompoundProcessor implements Processor {
 
         final int finalCurrentProcessor = currentProcessor;
         final int nextProcessor = currentProcessor + 1;
-        final long finalStartTimeInNanos = relativeTimeProvider.getAsLong();
+        final long startTimeInNanos = relativeTimeProvider.getAsLong();
         final IngestMetric finalMetric = processorsWithMetrics.get(currentProcessor).v2();
         final Processor finalProcessor = processorsWithMetrics.get(currentProcessor).v1();
         final IngestDocument finalIngestDocument = ingestDocument;
@@ -215,7 +215,7 @@ public class CompoundProcessor implements Processor {
                     logger.warn("A listener was unexpectedly called more than once", new RuntimeException());
                     assert false : "A listener was unexpectedly called more than once";
                 } else {
-                    long ingestTimeInNanos = relativeTimeProvider.getAsLong() - finalStartTimeInNanos;
+                    long ingestTimeInNanos = relativeTimeProvider.getAsLong() - startTimeInNanos;
                     finalMetric.postIngest(ingestTimeInNanos);
                     postIngestHasBeenCalled.set(true);
                     if (e != null) {
@@ -230,7 +230,7 @@ public class CompoundProcessor implements Processor {
                 }
             });
         } catch (Exception e) {
-            long ingestTimeInNanos = relativeTimeProvider.getAsLong() - finalStartTimeInNanos;
+            long ingestTimeInNanos = relativeTimeProvider.getAsLong() - startTimeInNanos;
             if (postIngestHasBeenCalled.get()) {
                 logger.warn("Preventing postIngest from being called more than once", new RuntimeException());
                 assert false : "Attempt to call postIngest more than once";

--- a/server/src/test/java/org/elasticsearch/ingest/CompoundProcessorTests.java
+++ b/server/src/test/java/org/elasticsearch/ingest/CompoundProcessorTests.java
@@ -49,11 +49,17 @@ public class CompoundProcessorTests extends ESTestCase {
     }
 
     public void testSingleProcessor() throws Exception {
+        boolean isAsync = randomBoolean();
         LongSupplier relativeTimeProvider = mock(LongSupplier.class);
         when(relativeTimeProvider.getAsLong()).thenReturn(0L, TimeUnit.MILLISECONDS.toNanos(1));
         TestProcessor processor = new TestProcessor(
             ingestDocument -> { assertStats(0, ingestDocument.getFieldValue("compoundProcessor", CompoundProcessor.class), 1, 0, 0, 0); }
-        );
+        ) {
+            @Override
+            public boolean isAsync() {
+                return isAsync;
+            }
+        };
         CompoundProcessor compoundProcessor = new CompoundProcessor(relativeTimeProvider, false, processor);
         ingestDocument.setFieldValue("compoundProcessor", compoundProcessor); // ugly hack to assert current count = 1
         assertThat(compoundProcessor.getProcessors().size(), equalTo(1));


### PR DESCRIPTION
#84250 introduced a bug in the timing metrics for asynchronous processors. If an asynchronous processor is the only processor in a compound processor, or if an asynchronous processor follows another asynchronous processor, then the timing metrics for the ingest stats for that processor will be nonsense.

Here's a good local reproduction:

```
PUT _ingest/pipeline/my-scripting-pipeline-id
{
  "processors": [
    {
      "script": {
        "lang": "painless",
        "source": "ctx['boom'] = 2"
      }
    }
  ]
}

PUT _ingest/pipeline/my-pipeline-id
{
  "processors" : [
    {
      "pipeline": {
        "name": "my-scripting-pipeline-id"
      }
    }
  ]
}

PUT index-1

POST _bulk?pipeline=my-pipeline-id
{ "index" : { "_index" : "index-1" } }
{ "doc_id" : 0 }

GET _nodes/stats?metric=ingest&human=true
```

And that final request has a response that'll contain something like this:

```
[...]
        "pipelines" : {
          "my-pipeline-id" : {
            "count" : 1,
            "time" : "1ms",
            "time_in_millis" : 1,
            "current" : 0,
            "failed" : 0,
            "processors" : [
              {
                "pipeline:my-scripting-pipeline-id" : {
                  "type" : "pipeline",
                  "stats" : {
                    "count" : 1,
                    "time" : "19.7h",
                    "time_in_millis" : 71029922,
                    "current" : 0,
                    "failed" : 0
                  }
                }
              }
            ]
          },
[...]
```

Hat tip to @jbaiera for seeing the `= 0` initialization bug.