### PR TITLE
[TEST] Expand tests for special field names in docs and mappings

### DIFF
--- a/server/src/test/java/org/elasticsearch/index/mapper/DynamicMappingTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/DynamicMappingTests.java
@@ -904,12 +904,9 @@ public class DynamicMappingTests extends MapperServiceTestCase {
     }
 
     public void testSubobjectsFalseRootDynamicUpdate() throws Exception {
-        MapperService mapperService = createMapperService(topMapping(b -> {
-            b.field("subobjects", false);
-            b.startObject("properties");
-            b.startObject("host.name").field("type", "keyword").endObject();
-            b.endObject();
-        }));
+        MapperService mapperService = createMapperService(
+            mappingNoSubobjects(b -> b.startObject("host.name").field("type", "keyword").endObject())
+        );
         ParsedDocument doc = mapperService.documentMapper().parse(source("""
             {
               "time" : 10,

--- a/server/src/test/java/org/elasticsearch/index/mapper/MappingParserTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/MappingParserTests.java
@@ -206,4 +206,135 @@ public class MappingParserTests extends MapperServiceTestCase {
         assertEquals("location", geoPointFieldMapper.simpleName());
         assertEquals("obj.source.geo.location", geoPointFieldMapper.mappedFieldType.name());
     }
+
+    public void testFieldStartingWithDot() throws Exception {
+        XContentBuilder builder = mapping(b -> b.startObject(".foo").field("type", "keyword").endObject());
+        IllegalArgumentException iae = expectThrows(
+            IllegalArgumentException.class,
+            () -> createMappingParser(Settings.EMPTY).parse("_doc", new CompressedXContent(BytesReference.bytes(builder)))
+        );
+        // TODO isn't this error misleading?
+        assertEquals("name cannot be empty string", iae.getMessage());
+    }
+
+    public void testFieldEndingWithDot() throws Exception {
+        XContentBuilder builder = mapping(b -> b.startObject("foo.").field("type", "keyword").endObject());
+        Mapping mapping = createMappingParser(Settings.EMPTY).parse("_doc", new CompressedXContent(BytesReference.bytes(builder)));
+        // TODO this needs fixing as part of addressing https://github.com/elastic/elasticsearch/issues/28948
+        assertNotNull(mapping.getRoot().mappers.get("foo"));
+        assertNull(mapping.getRoot().mappers.get("foo."));
+    }
+
+    public void testFieldTrailingDots() throws Exception {
+        XContentBuilder builder = mapping(b -> b.startObject("top..foo").field("type", "keyword").endObject());
+        IllegalArgumentException iae = expectThrows(
+            IllegalArgumentException.class,
+            () -> createMappingParser(Settings.EMPTY).parse("_doc", new CompressedXContent(BytesReference.bytes(builder)))
+        );
+        // TODO isn't this error misleading?
+        assertEquals("name cannot be empty string", iae.getMessage());
+    }
+
+    public void testDottedFieldEndingWithDot() throws Exception {
+        XContentBuilder builder = mapping(b -> b.startObject("foo.bar.").field("type", "keyword").endObject());
+        Mapping mapping = createMappingParser(Settings.EMPTY).parse("_doc", new CompressedXContent(BytesReference.bytes(builder)));
+        // TODO this needs fixing as part of addressing https://github.com/elastic/elasticsearch/issues/28948
+        assertNotNull(((ObjectMapper) mapping.getRoot().mappers.get("foo")).mappers.get("bar"));
+        assertNull(((ObjectMapper) mapping.getRoot().mappers.get("foo")).mappers.get("bar."));
+    }
+
+    public void testFieldStartingAndEndingWithDot() throws Exception {
+        XContentBuilder builder = mapping(b -> b.startObject("foo..bar.").field("type", "keyword").endObject());
+        IllegalArgumentException iae = expectThrows(
+            IllegalArgumentException.class,
+            () -> createMappingParser(Settings.EMPTY).parse("_doc", new CompressedXContent(BytesReference.bytes(builder)))
+        );
+        // TODO isn't this error misleading?
+        assertEquals("name cannot be empty string", iae.getMessage());
+    }
+
+    public void testDottedFieldWithTrailingWhitespace() throws Exception {
+        XContentBuilder builder = mapping(b -> b.startObject("top. .foo").field("type", "keyword").endObject());
+        Mapping mapping = createMappingParser(Settings.EMPTY).parse("_doc", new CompressedXContent(BytesReference.bytes(builder)));
+        ObjectMapper top = (ObjectMapper) mapping.getRoot().mappers.get("top");
+        // TODO this needs fixing? This field name is not allowed in documents when subobjects are enabled.
+        ObjectMapper mapper = (ObjectMapper) top.getMapper(" ");
+        assertNotNull(mapper.getMapper("foo"));
+    }
+
+    public void testEmptyFieldName() throws Exception {
+        {
+            XContentBuilder builder = mapping(b -> b.startObject("").field("type", "keyword").endObject());
+            IllegalArgumentException iae = expectThrows(
+                IllegalArgumentException.class,
+                () -> createMappingParser(Settings.EMPTY).parse("_doc", new CompressedXContent(BytesReference.bytes(builder)))
+            );
+            assertEquals("name cannot be empty string", iae.getMessage());
+        }
+        {
+            XContentBuilder builder = mappingNoSubobjects(b -> b.startObject("").field("type", "keyword").endObject());
+            IllegalArgumentException iae = expectThrows(
+                IllegalArgumentException.class,
+                () -> createMappingParser(Settings.EMPTY).parse("_doc", new CompressedXContent(BytesReference.bytes(builder)))
+            );
+            assertEquals("name cannot be empty string", iae.getMessage());
+        }
+    }
+
+    public void testBlankFieldName() throws Exception {
+        // TODO this needs fixing? This field name is never allowed in documents hence such a field can never be indexed?
+        {
+            XContentBuilder builder = mapping(b -> b.startObject(" ").field("type", "keyword").endObject());
+            Mapping mapping = createMappingParser(Settings.EMPTY).parse("_doc", new CompressedXContent(BytesReference.bytes(builder)));
+            assertNotNull(mapping.getRoot().getMapper(" "));
+        }
+        {
+            XContentBuilder builder = mappingNoSubobjects(b -> b.startObject(" ").field("type", "keyword").endObject());
+            Mapping mapping = createMappingParser(Settings.EMPTY).parse("_doc", new CompressedXContent(BytesReference.bytes(builder)));
+            assertNotNull(mapping.getRoot().getMapper(" "));
+        }
+    }
+
+    public void testFieldNameDotsOnly() throws Exception {
+        String[] fieldNames = { ".", "..", "..." };
+        for (String fieldName : fieldNames) {
+            XContentBuilder builder = mapping(b -> b.startObject(fieldName).field("type", "keyword").endObject());
+            // TODO this should really throw a better error, relates to https://github.com/elastic/elasticsearch/issues/21862
+            expectThrows(
+                ArrayIndexOutOfBoundsException.class,
+                () -> createMappingParser(Settings.EMPTY).parse("_doc", new CompressedXContent(BytesReference.bytes(builder)))
+            );
+        }
+    }
+
+    public void testFieldNameDotsOnlySubobjectsFalse() throws Exception {
+        String[] fieldNames = { ".", "..", "..." };
+        for (String fieldName : fieldNames) {
+            XContentBuilder builder = mappingNoSubobjects(b -> b.startObject(fieldName).field("type", "keyword").endObject());
+
+            createMappingParser(Settings.EMPTY).parse("_doc", new CompressedXContent(BytesReference.bytes(builder)));
+        }
+    }
+
+    public void testDynamicFieldEdgeCaseNamesSubobjectsFalse() throws Exception {
+        // these combinations are not accepted by default, but they are when subobjects are disabled
+        String[] fieldNames = new String[] { ".foo", "foo.", "top..foo", "top.foo.", "top..foo.", "top. .foo" };
+        MappingParser mappingParser = createMappingParser(Settings.EMPTY);
+        for (String fieldName : fieldNames) {
+            XContentBuilder builder = mappingNoSubobjects(b -> b.startObject(fieldName).field("type", "keyword").endObject());
+            // TODO this is not accepted in documents, shall we revert https://github.com/elastic/elasticsearch/pull/90950 ?
+            assertNotNull(mappingParser.parse("_doc", new CompressedXContent(BytesReference.bytes(builder))));
+        }
+    }
+
+    public void testDynamicFieldEdgeCaseNamesRuntimeSection() throws Exception {
+        // TODO these combinations are not accepted by default, but they are in the runtime section, though they are not accepted when
+        // parsing documents with subobjects enabled
+        String[] fieldNames = new String[] { ".foo", "foo.", "top..foo", "top.foo.", "top..foo.", "top. .foo" };
+        MappingParser mappingParser = createMappingParser(Settings.EMPTY);
+        for (String fieldName : fieldNames) {
+            XContentBuilder builder = runtimeMapping(b -> b.startObject(fieldName).field("type", "keyword").endObject());
+            mappingParser.parse("_doc", new CompressedXContent(BytesReference.bytes(builder)));
+        }
+    }
 }

--- a/server/src/test/java/org/elasticsearch/index/mapper/ObjectMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/ObjectMapperTests.java
@@ -424,17 +424,12 @@ public class ObjectMapperTests extends MapperServiceTestCase {
     }
 
     public void testSubobjectsFalseRoot() throws Exception {
-        MapperService mapperService = createMapperService(topMapping(b -> {
-            b.field("subobjects", false);
-            b.startObject("properties");
-            {
-                b.startObject("metrics.service.time");
-                b.field("type", "long");
-                b.endObject();
-                b.startObject("metrics.service.time.max");
-                b.field("type", "long");
-                b.endObject();
-            }
+        MapperService mapperService = createMapperService(mappingNoSubobjects(b -> {
+            b.startObject("metrics.service.time");
+            b.field("type", "long");
+            b.endObject();
+            b.startObject("metrics.service.time.max");
+            b.field("type", "long");
             b.endObject();
         }));
         assertNotNull(mapperService.fieldType("metrics.service.time"));
@@ -447,18 +442,13 @@ public class ObjectMapperTests extends MapperServiceTestCase {
     }
 
     public void testSubobjectsFalseRootWithInnerObject() {
-        MapperParsingException exception = expectThrows(MapperParsingException.class, () -> createMapperService(topMapping(b -> {
-            b.field("subobjects", false);
-            b.startObject("properties");
+        MapperParsingException exception = expectThrows(MapperParsingException.class, () -> createMapperService(mappingNoSubobjects(b -> {
+            b.startObject("metrics.service.time");
             {
-                b.startObject("metrics.service.time");
+                b.startObject("properties");
                 {
-                    b.startObject("properties");
-                    {
-                        b.startObject("max");
-                        b.field("type", "long");
-                        b.endObject();
-                    }
+                    b.startObject("max");
+                    b.field("type", "long");
                     b.endObject();
                 }
                 b.endObject();
@@ -472,14 +462,9 @@ public class ObjectMapperTests extends MapperServiceTestCase {
     }
 
     public void testSubobjectsFalseRootWithInnerNested() {
-        MapperParsingException exception = expectThrows(MapperParsingException.class, () -> createMapperService(topMapping(b -> {
-            b.field("subobjects", false);
-            b.startObject("properties");
-            {
-                b.startObject("metrics.service");
-                b.field("type", "nested");
-                b.endObject();
-            }
+        MapperParsingException exception = expectThrows(MapperParsingException.class, () -> createMapperService(mappingNoSubobjects(b -> {
+            b.startObject("metrics.service");
+            b.field("type", "nested");
             b.endObject();
         })));
         assertEquals(

--- a/test/framework/src/main/java/org/elasticsearch/index/mapper/MapperServiceTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/index/mapper/MapperServiceTestCase.java
@@ -314,6 +314,15 @@ public abstract class MapperServiceTestCase extends ESTestCase {
         return builder.endObject().endObject();
     }
 
+    protected final XContentBuilder mappingNoSubobjects(CheckedConsumer<XContentBuilder, IOException> buildFields) throws IOException {
+        return topMapping(xContentBuilder -> {
+            xContentBuilder.field("subobjects", false);
+            xContentBuilder.startObject("properties");
+            buildFields.accept(xContentBuilder);
+            xContentBuilder.endObject();
+        });
+    }
+
     protected final XContentBuilder mapping(CheckedConsumer<XContentBuilder, IOException> buildFields) throws IOException {
         XContentBuilder builder = XContentFactory.jsonBuilder().startObject().startObject("_doc").startObject("properties");
         buildFields.accept(builder);


### PR DESCRIPTION
We have some existing tests that verify that we throw errors when parsing certain special field names in documents. This commit expands them to test more edge cases, as well as to test the same scearios with subobjects:false as well as dynamic:runtime. Furthermore, additional tests and checks are added to verify that the behaviour is aligned between document parsing and mapping parsing, which is not the case in many scenarios.

This commit does not aim at fixing the anomalies found, but only to surface them and have tests that can later be adapted once the different scenarios are fixed.
