### PR TITLE
Fix integer overflow in AsyncTaskIndexService

### DIFF
--- a/docs/changelog/91044.yaml
+++ b/docs/changelog/91044.yaml
@@ -1,0 +1,5 @@
+pr: 91044
+summary: Fix integer overflow in `AsyncTaskIndexService`
+area: Search
+type: bug
+issues: []

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/async/AsyncTaskIndexService.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/async/AsyncTaskIndexService.java
@@ -428,8 +428,8 @@ public final class AsyncTaskIndexService<R extends AsyncResponse<R>> {
             try {
                 final BytesReference source = getResponse.getSourceInternal();
                 // reserve twice memory of the source length: one for the internal XContent parser and one for the response
-                final int reservedBytes = source.length() * 2;
-                circuitBreaker.addEstimateBytesAndMaybeBreak(source.length() * 2L, "decode async response");
+                final long reservedBytes = source.length() * 2L;
+                circuitBreaker.addEstimateBytesAndMaybeBreak(reservedBytes, "decode async response");
                 listener = ActionListener.runAfter(listener, () -> circuitBreaker.addWithoutBreaking(-reservedBytes));
                 resp = parseResponseFromIndex(asyncExecutionId, source, restoreResponseHeaders, checkAuthentication);
             } catch (Exception e) {


### PR DESCRIPTION
If source is larger than `int_max/2` we overflow on the multiplication. Since we didn't use the same variable we will increment the breaker once and then increment it again with the broken overflown int on release.
