### PR TITLE
[Transform] Support `aggregate_metric_double` field type in transform aggregations

### DIFF
--- a/docs/changelog/91045.yaml
+++ b/docs/changelog/91045.yaml
@@ -1,0 +1,5 @@
+pr: 91045
+summary: Support `aggregate_metric_double` field type in transform aggregations
+area: Transform
+type: enhancement
+issues: []

--- a/x-pack/plugin/transform/qa/single-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/TransformRestTestCase.java
+++ b/x-pack/plugin/transform/qa/single-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/TransformRestTestCase.java
@@ -107,6 +107,18 @@ public abstract class TransformRestTestCase extends ESRestTestCase {
             if ((user == userWithMissingBuckets && missingBucketField.equals("stars")) == false) {
                 bulk.append("\"stars\":").append(stars).append(",");
             }
+            if ((user == userWithMissingBuckets && missingBucketField.equals("stars_stats")) == false) {
+                bulk.append("\"stars_stats\": { ")
+                    .append("\"min\": ")
+                    .append(stars - 1)
+                    .append(",")
+                    .append("\"max\": ")
+                    .append(stars + 1)
+                    .append(",")
+                    .append("\"sum\": ")
+                    .append(10 * stars)
+                    .append("},");
+            }
             if ((user == userWithMissingBuckets && missingBucketField.equals("location")) == false) {
                 bulk.append("\"location\":\"").append(location).append("\",");
             }
@@ -176,6 +188,11 @@ public abstract class TransformRestTestCase extends ESRestTestCase {
                     .endObject()
                     .startObject("stars")
                     .field("type", randomFrom("integer", "long")) // gh#64347 unsigned_long disabled
+                    .endObject()
+                    .startObject("stars_stats")
+                    .field("type", "aggregate_metric_double")
+                    .field("metrics", List.of("min", "max", "sum"))
+                    .field("default_metric", "max")
                     .endObject()
                     .startObject("location")
                     .field("type", "geo_point")

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/pivot/TransformAggregations.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/pivot/TransformAggregations.java
@@ -38,6 +38,7 @@ public final class TransformAggregations {
     public static final String FLATTENED = "flattened";
     public static final String SCALED_FLOAT = "scaled_float";
     public static final String DOUBLE = "double";
+    public static final String AGGREGATE_METRIC_DOUBLE = "aggregate_metric_double";
     public static final String LONG = "long";
     public static final String GEO_SHAPE = "geo_shape";
     public static final String GEO_POINT = "geo_point";
@@ -173,6 +174,11 @@ public final class TransformAggregations {
             // scaled float requires an additional parameter "scaling_factor", which we do not know, therefore we fallback to float
             if (sourceType.equals(SCALED_FLOAT)) {
                 return FLOAT;
+            }
+
+            // min/max/sum aggregations over aggregate_metric_double return double
+            if (sourceType.equals(AGGREGATE_METRIC_DOUBLE)) {
+                return DOUBLE;
             }
 
             return sourceType;

--- a/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/pivot/TransformAggregationsTests.java
+++ b/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/pivot/TransformAggregationsTests.java
@@ -54,17 +54,20 @@ public class TransformAggregationsTests extends ESTestCase {
         // max
         assertEquals("int", TransformAggregations.resolveTargetMapping("max", "int"));
         assertEquals("double", TransformAggregations.resolveTargetMapping("max", "double"));
+        assertEquals("double", TransformAggregations.resolveTargetMapping("max", "aggregate_metric_double"));
         assertEquals("half_float", TransformAggregations.resolveTargetMapping("max", "half_float"));
         assertEquals("float", TransformAggregations.resolveTargetMapping("max", "scaled_float"));
 
         // min
         assertEquals("int", TransformAggregations.resolveTargetMapping("min", "int"));
         assertEquals("double", TransformAggregations.resolveTargetMapping("min", "double"));
+        assertEquals("double", TransformAggregations.resolveTargetMapping("min", "aggregate_metric_double"));
         assertEquals("half_float", TransformAggregations.resolveTargetMapping("min", "half_float"));
         assertEquals("float", TransformAggregations.resolveTargetMapping("min", "scaled_float"));
 
         // sum
         assertEquals("double", TransformAggregations.resolveTargetMapping("sum", "double"));
+        assertEquals("double", TransformAggregations.resolveTargetMapping("sum", "aggregate_metric_double"));
         assertEquals("double", TransformAggregations.resolveTargetMapping("sum", "half_float"));
         assertEquals("double", TransformAggregations.resolveTargetMapping("sum", null));
 


### PR DESCRIPTION
This PR adds support for the `aggregate_metric_double` field type so that such fields work correctly with mappings deduction.
Also, unit and integration tests for the `aggregate_metric_double` field type are added.

Relates https://github.com/elastic/elasticsearch/issues/90588