### PR TITLE
[7.17] Fix integer overflow in AsyncTaskIndexService (#91044)

### DIFF
--- a/docs/changelog/91044.yaml
+++ b/docs/changelog/91044.yaml
@@ -1,0 +1,5 @@
+pr: 91044
+summary: Fix integer overflow in `AsyncTaskIndexService`
+area: Search
+type: bug
+issues: []

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/async/AsyncTaskIndexService.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/async/AsyncTaskIndexService.java
@@ -445,8 +445,8 @@ public final class AsyncTaskIndexService<R extends AsyncResponse<R>> {
             try {
                 final BytesReference source = getResponse.getSourceInternal();
                 // reserve twice memory of the source length: one for the internal XContent parser and one for the response
-                final int reservedBytes = source.length() * 2;
-                circuitBreaker.addEstimateBytesAndMaybeBreak(source.length() * 2L, "decode async response");
+                final long reservedBytes = source.length() * 2L;
+                circuitBreaker.addEstimateBytesAndMaybeBreak(reservedBytes, "decode async response");
                 listener = ActionListener.runAfter(listener, () -> circuitBreaker.addWithoutBreaking(-reservedBytes));
                 resp = parseResponseFromIndex(asyncExecutionId, source, restoreResponseHeaders, checkAuthentication);
             } catch (Exception e) {


### PR DESCRIPTION
Backports the following commits to 7.17:
 - Fix integer overflow in AsyncTaskIndexService (#91044)