### PR TITLE
[ML] Delete 90903 change log entry

### DIFF
--- a/docs/changelog/90903.yaml
+++ b/docs/changelog/90903.yaml
@@ -1,5 +1,0 @@
-pr: 90903
-summary: Require correct tier processors when multiple AZs are present
-area: Machine Learning
-type: bug
-issues: []


### PR DESCRIPTION
As #90903 made the cut for `8.5.0`, the issue
is no longer a bug. After udpating the PR to `non-issue`, this commit also deletes the release note from the changelog.
