### PR TITLE
[8.5] Add privileges for connectors index creation (#91026)

### DIFF
--- a/docs/changelog/91026.yaml
+++ b/docs/changelog/91026.yaml
@@ -1,0 +1,5 @@
+pr: 91026
+summary: Add privileges for connectors index creation
+area: Authorization
+type: enhancement
+issues: []

--- a/x-pack/plugin/security/qa/service-account/src/javaRestTest/java/org/elasticsearch/xpack/security/authc/service/ServiceAccountIT.java
+++ b/x-pack/plugin/security/qa/service-account/src/javaRestTest/java/org/elasticsearch/xpack/security/authc/service/ServiceAccountIT.java
@@ -167,7 +167,8 @@ public class ServiceAccountIT extends ESRestTestCase {
                         "logs-crawler-default",
                         "logs-elastic_crawler-default",
                         "logs-workplace_search.analytics-default",
-                        "logs-workplace_search.content_events-default"
+                        "logs-workplace_search.content_events-default",
+                        ".elastic-connectors*"
                     ],
                     "privileges": [
                         "manage",

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/service/ElasticServiceAccounts.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/service/ElasticServiceAccounts.java
@@ -44,7 +44,8 @@ final class ElasticServiceAccounts {
                         "logs-crawler-default",
                         "logs-elastic_crawler-default",
                         "logs-workplace_search.analytics-default",
-                        "logs-workplace_search.content_events-default"
+                        "logs-workplace_search.content_events-default",
+                        ".elastic-connectors*"
                     )
                     .privileges("manage", "read", "write")
                     .build() },

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/service/ElasticServiceAccountsTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/service/ElasticServiceAccountsTests.java
@@ -360,7 +360,8 @@ public class ElasticServiceAccountsTests extends ESTestCase {
             "logs-crawler-default",
             "logs-workplace_search.analytics-default",
             "logs-workplace_search.content_events-default",
-            "logs-elastic_crawler-default"
+            "logs-elastic_crawler-default",
+            ".elastic-connectors*"
         ).forEach(index -> {
             final IndexAbstraction enterpriseSearchIndex = mockIndexAbstraction(index);
             assertThat(role.indices().allowedIndicesMatcher(AutoCreateAction.NAME).test(enterpriseSearchIndex), is(true));


### PR DESCRIPTION
Backports the following commits to 8.5:
 - Add privileges for connectors index creation (#91026)