### PR TITLE
fix typo PUT _cluster/settings

### DIFF
--- a/docs/reference/data-management/migrate-index-allocation-filters.asciidoc
+++ b/docs/reference/data-management/migrate-index-allocation-filters.asciidoc
@@ -154,7 +154,7 @@ specifies `null` for the setting.
 
 [source,console]
 ----
-PUT _cluster/_settings
+PUT _cluster/settings
 {
   "persistent": {
     "cluster.routing.allocation.enforce_default_tier_preference": true


### PR DESCRIPTION
We had `PUT _cluster/_settings` which should be `PUT _cluster/settings` (affecting 7.16 and 7.17 doc) from https://github.com/elastic/elasticsearch/pull/81401
