### PR TITLE
Cleanup needless instances of ActiveShardsObserver

### DIFF
--- a/modules/data-streams/src/test/java/org/elasticsearch/datastreams/DataStreamGetWriteIndexTests.java
+++ b/modules/data-streams/src/test/java/org/elasticsearch/datastreams/DataStreamGetWriteIndexTests.java
@@ -277,7 +277,7 @@ public class DataStreamGetWriteIndexTests extends ESTestCase {
             );
         }
 
-        createDataStreamService = new MetadataCreateDataStreamService(testThreadPool, clusterService, createIndexService);
+        createDataStreamService = new MetadataCreateDataStreamService(clusterService, createIndexService);
     }
 
     @After

--- a/server/src/main/java/org/elasticsearch/action/support/ActiveShardsObserver.java
+++ b/server/src/main/java/org/elasticsearch/action/support/ActiveShardsObserver.java
@@ -16,79 +16,74 @@ import org.elasticsearch.cluster.ClusterStateObserver;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.node.NodeClosedException;
-import org.elasticsearch.threadpool.ThreadPool;
 
 import java.util.Arrays;
-import java.util.function.Consumer;
-import java.util.function.Predicate;
+
+import static org.elasticsearch.core.Strings.format;
 
 /**
- * This class provides primitives for waiting for a configured number of shards
+ * This utility class provides a primitive for waiting for a configured number of shards
  * to become active before sending a response on an {@link ActionListener}.
  */
-public class ActiveShardsObserver {
-
+public enum ActiveShardsObserver {
+    ;
     private static final Logger logger = LogManager.getLogger(ActiveShardsObserver.class);
 
-    private final ClusterService clusterService;
-    private final ThreadPool threadPool;
-
-    public ActiveShardsObserver(final ClusterService clusterService, final ThreadPool threadPool) {
-        this.clusterService = clusterService;
-        this.threadPool = threadPool;
-    }
-
     /**
-     * Waits on the specified number of active shards to be started before executing the
+     * Waits on the specified number of active shards to be started
      *
+     * @param clusterService cluster service
      * @param indexNames the indices to wait for active shards on
      * @param activeShardCount the number of active shards to wait on before returning
      * @param timeout the timeout value
-     * @param onResult a function that is executed in response to the requisite shards becoming active or a timeout (whichever comes first)
-     * @param onFailure a function that is executed in response to an error occurring during waiting for the active shards
+     * @param listener listener to resolve with {@code true} once the specified number of shards becomes available, resolve with
+     *                 {@code false} on timeout or fail if an exception occurs
      */
-    public void waitForActiveShards(
+    public static void waitForActiveShards(
+        ClusterService clusterService,
         final String[] indexNames,
         final ActiveShardCount activeShardCount,
         final TimeValue timeout,
-        final Consumer<Boolean> onResult,
-        final Consumer<Exception> onFailure
+        final ActionListener<Boolean> listener
     ) {
-
-        // wait for the configured number of active shards to be allocated before executing the result consumer
         if (activeShardCount == ActiveShardCount.NONE) {
             // not waiting, so just run whatever we were to run when the waiting is
-            onResult.accept(true);
+            listener.onResponse(true);
             return;
         }
 
         final ClusterState state = clusterService.state();
-        final ClusterStateObserver observer = new ClusterStateObserver(state, clusterService, null, logger, threadPool.getThreadContext());
         if (activeShardCount.enoughShardsActive(state, indexNames)) {
-            onResult.accept(true);
-        } else {
-            final Predicate<ClusterState> shardsAllocatedPredicate = newState -> activeShardCount.enoughShardsActive(newState, indexNames);
+            listener.onResponse(true);
+            return;
+        }
 
-            final ClusterStateObserver.Listener observerListener = new ClusterStateObserver.Listener() {
+        new ClusterStateObserver(state, clusterService, null, logger, clusterService.threadPool().getThreadContext()).waitForNextChange(
+            new ClusterStateObserver.Listener() {
                 @Override
-                public void onNewClusterState(ClusterState state) {
-                    onResult.accept(true);
+                public void onNewClusterState(ClusterState state1) {
+                    listener.onResponse(true);
                 }
 
                 @Override
                 public void onClusterServiceClose() {
-                    logger.debug("[{}] cluster service closed while waiting for enough shards to be started.", Arrays.toString(indexNames));
-                    onFailure.accept(new NodeClosedException(clusterService.localNode()));
+                    logger.debug(
+                        () -> format(
+                            "[{}] cluster service closed while waiting for enough shards to be started.",
+                            Arrays.toString(indexNames)
+                        )
+                    );
+                    listener.onFailure(new NodeClosedException(clusterService.localNode()));
                 }
 
                 @Override
                 public void onTimeout(TimeValue timeout) {
-                    onResult.accept(false);
+                    listener.onResponse(false);
                 }
-            };
-
-            observer.waitForNextChange(observerListener, shardsAllocatedPredicate, timeout);
-        }
+            },
+            newState -> activeShardCount.enoughShardsActive(newState, indexNames),
+            timeout
+        );
     }
 
 }

--- a/server/src/main/java/org/elasticsearch/node/Node.java
+++ b/server/src/main/java/org/elasticsearch/node/Node.java
@@ -689,7 +689,6 @@ public class Node implements Closeable {
             );
 
             final MetadataCreateDataStreamService metadataCreateDataStreamService = new MetadataCreateDataStreamService(
-                threadPool,
                 clusterService,
                 metadataCreateIndexService
             );


### PR DESCRIPTION
Found these needless complicating a heap dump during an investigation so I figured I'd clean this up ...

`ActiveShardsObserver` was somewhat needless. We can just pass the `ClusteService` to its single method to make it clear that this thing holds no state. Also, we just make it use `ActionListener` for the result so that we don't have to create redundant response and failure listeners.
Lastly, this just makes the code in the method a little shorter and removes a potentially huge string allocation from logging.
