### PR TITLE
Remove the deprecated Authentication#getVersion method

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ClientHelper.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ClientHelper.java
@@ -158,7 +158,7 @@ public final class ClientHelper {
     ) {
         try {
             final Authentication authentication = authenticationReader.apply(authenticationHeaderKey);
-            if (authentication != null && authentication.getVersion().after(minNodeVersion)) {
+            if (authentication != null && authentication.getEffectiveSubject().getVersion().after(minNodeVersion)) {
                 return authentication.maybeRewriteForOlderVersion(minNodeVersion).encode();
             }
         } catch (IOException e) {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authc/Subject.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authc/Subject.java
@@ -87,7 +87,7 @@ public class Subject {
         return metadata;
     }
 
-    Version getVersion() {
+    public Version getVersion() {
         return version;
     }
 

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ClientHelperTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ClientHelperTests.java
@@ -454,14 +454,14 @@ public class ClientHelperTests extends ESTestCase {
             final Authentication rewrittenAuth = AuthenticationContextSerializer.decode(
                 headers2.get(AuthenticationField.AUTHENTICATION_KEY)
             );
-            assertThat(rewrittenAuth.getVersion(), equalTo(previousVersion));
+            assertThat(rewrittenAuth.getEffectiveSubject().getVersion(), equalTo(previousVersion));
             assertThat(rewrittenAuth.getUser(), equalTo(authentication.getUser()));
         }
         if (hasSecondaryAuthHeader) {
             final Authentication rewrittenSecondaryAuth = AuthenticationContextSerializer.decode(
                 headers2.get(SecondaryAuthentication.THREAD_CTX_KEY)
             );
-            assertThat(rewrittenSecondaryAuth.getVersion(), equalTo(previousVersion));
+            assertThat(rewrittenSecondaryAuth.getEffectiveSubject().getVersion(), equalTo(previousVersion));
             assertThat(rewrittenSecondaryAuth.getUser(), equalTo(authentication.getUser()));
         }
     }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authc/AuthenticationTestHelper.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authc/AuthenticationTestHelper.java
@@ -244,7 +244,7 @@ public class AuthenticationTestHelper {
         private AuthenticationTestBuilder(Authentication authentication) {
             assert false == authentication.isRunAs() : "authenticating authentication cannot itself be run-as";
             this.authenticatingAuthentication = authentication;
-            this.version = authentication.getVersion();
+            this.version = authentication.getEffectiveSubject().getVersion();
         }
 
         public AuthenticationTestBuilder realm() {
@@ -502,7 +502,7 @@ public class AuthenticationTestHelper {
                 if (version == null) {
                     version = Version.CURRENT;
                 }
-                if (version.before(authentication.getVersion())) {
+                if (version.before(authentication.getEffectiveSubject().getVersion())) {
                     return authentication.maybeRewriteForOlderVersion(version);
                 } else {
                     return authentication;

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/TokenService.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/TokenService.java
@@ -2542,7 +2542,7 @@ public final class TokenService {
             String iv,
             String salt
         ) {
-            assert associatedAuthentication.getVersion().onOrAfter(VERSION_CLIENT_AUTH_FOR_REFRESH);
+            assert associatedAuthentication.getEffectiveSubject().getVersion().onOrAfter(VERSION_CLIENT_AUTH_FOR_REFRESH);
             this.invalidated = invalidated;
             // not used, filled-in for consistency's sake
             this.associatedUser = associatedAuthentication.getUser().principal();

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/transport/SecurityServerTransportInterceptor.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/transport/SecurityServerTransportInterceptor.java
@@ -117,7 +117,7 @@ public class SecurityServerTransportInterceptor implements TransportInterceptor 
                         )
                     );
                 } else if (securityContext.getAuthentication() != null
-                    && securityContext.getAuthentication().getVersion().equals(minVersion) == false) {
+                    && securityContext.getAuthentication().getEffectiveSubject().getVersion().equals(minVersion) == false) {
                         // re-write the authentication since we want the authentication version to match the version of the connection
                         securityContext.executeAfterRewritingAuthentication(
                             original -> sendWithUser(

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/SecurityContextTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/SecurityContextTests.java
@@ -161,7 +161,7 @@ public class SecurityContextTests extends ESTestCase {
             assertEquals(original.getUser(), authentication.getUser());
             assertEquals(original.getAuthenticatedBy(), authentication.getAuthenticatedBy());
             assertEquals(original.getLookedUpBy(), authentication.getLookedUpBy());
-            assertEquals(VersionUtils.getPreviousVersion(), authentication.getVersion());
+            assertEquals(VersionUtils.getPreviousVersion(), authentication.getEffectiveSubject().getVersion());
             assertEquals(original.getAuthenticationType(), securityContext.getAuthentication().getAuthenticationType());
             contextAtomicReference.set(originalCtx);
             // Other request headers should be preserved

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/action/user/TransportAuthenticateActionTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/action/user/TransportAuthenticateActionTests.java
@@ -154,7 +154,7 @@ public class TransportAuthenticateActionTests extends ESTestCase {
             }
             assertThat(auth.getAuthenticatedBy(), sameInstance(auth.getAuthenticatedBy()));
             assertThat(auth.getLookedUpBy(), sameInstance(auth.getLookedUpBy()));
-            assertThat(auth.getVersion(), sameInstance(auth.getVersion()));
+            assertThat(auth.getEffectiveSubject().getVersion(), sameInstance(auth.getEffectiveSubject().getVersion()));
             assertThat(auth.getAuthenticationType(), sameInstance(auth.getAuthenticationType()));
             assertThat(auth.getMetadata(), sameInstance(auth.getMetadata()));
         } else {
@@ -198,7 +198,7 @@ public class TransportAuthenticateActionTests extends ESTestCase {
             assertThat(authUser.roles(), emptyArray());
             assertThat(auth.getAuthenticatedBy(), sameInstance(auth.getAuthenticatedBy()));
             assertThat(auth.getLookedUpBy(), sameInstance(auth.getLookedUpBy()));
-            assertThat(auth.getVersion(), sameInstance(auth.getVersion()));
+            assertThat(auth.getEffectiveSubject().getVersion(), sameInstance(auth.getEffectiveSubject().getVersion()));
             assertThat(auth.getAuthenticationType(), sameInstance(auth.getAuthenticationType()));
             assertThat(auth.getMetadata(), sameInstance(auth.getMetadata()));
         } else {

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/TokenServiceTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/TokenServiceTests.java
@@ -459,7 +459,7 @@ public class TokenServiceTests extends ESTestCase {
         String iv,
         String salt
     ) {
-        if (authentication.getVersion().onOrAfter(VERSION_CLIENT_AUTH_FOR_REFRESH)) {
+        if (authentication.getEffectiveSubject().getVersion().onOrAfter(VERSION_CLIENT_AUTH_FOR_REFRESH)) {
             return new RefreshTokenStatus(invalidated, authentication, refreshed, refreshInstant, supersedingTokens, iv, salt);
         } else {
             return new RefreshTokenStatus(

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authz/AuthorizationUtilsTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authz/AuthorizationUtilsTests.java
@@ -151,7 +151,7 @@ public class AuthorizationUtilsTests extends ESTestCase {
             assertNull(threadContext.getHeader(headerName));
             final Authentication authentication = securityContext.getAuthentication();
             assertEquals(user, authentication.getUser());
-            assertEquals(version, authentication.getVersion());
+            assertEquals(version, authentication.getEffectiveSubject().getVersion());
             latch.countDown();
         }, e -> fail(e.getMessage()));
 
@@ -160,7 +160,7 @@ public class AuthorizationUtilsTests extends ESTestCase {
             assertNull(threadContext.getHeader(headerName));
             final Authentication authentication = securityContext.getAuthentication();
             assertEquals(user, authentication.getUser());
-            assertEquals(version, authentication.getVersion());
+            assertEquals(version, authentication.getEffectiveSubject().getVersion());
             latch.countDown();
             listener.onResponse(null);
         };

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/transport/SecurityServerTransportInterceptorTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/transport/SecurityServerTransportInterceptorTests.java
@@ -295,8 +295,8 @@ public class SecurityServerTransportInterceptorTests extends ESTestCase {
         assertTrue(calledWrappedSender.get());
         assertEquals(authentication.getUser(), sendingUser.get());
         assertEquals(authentication.getUser(), securityContext.getUser());
-        assertEquals(Version.CURRENT, authRef.get().getVersion());
-        assertEquals(Version.CURRENT, authentication.getVersion());
+        assertEquals(Version.CURRENT, authRef.get().getEffectiveSubject().getVersion());
+        assertEquals(Version.CURRENT, authentication.getEffectiveSubject().getVersion());
     }
 
     public void testSendToOlderVersionSetsCorrectVersion() throws Exception {
@@ -361,8 +361,8 @@ public class SecurityServerTransportInterceptorTests extends ESTestCase {
         assertTrue(calledWrappedSender.get());
         assertEquals(authentication.getUser(), sendingUser.get());
         assertEquals(authentication.getUser(), securityContext.getUser());
-        assertEquals(connectionVersion, authRef.get().getVersion());
-        assertEquals(Version.CURRENT, authentication.getVersion());
+        assertEquals(connectionVersion, authRef.get().getEffectiveSubject().getVersion());
+        assertEquals(Version.CURRENT, authentication.getEffectiveSubject().getVersion());
     }
 
     public void testSetUserBasedOnActionOrigin() {
@@ -421,7 +421,7 @@ public class SecurityServerTransportInterceptorTests extends ESTestCase {
         final Authentication authentication = authenticationRef.get();
         assertThat(authentication, notNullValue());
         assertThat(authentication.getUser(), equalTo(originToUserMap.get(origin)));
-        assertThat(authentication.getVersion(), equalTo(connectionVersion));
+        assertThat(authentication.getEffectiveSubject().getVersion(), equalTo(connectionVersion));
     }
 
     public void testContextRestoreResponseHandler() throws Exception {


### PR DESCRIPTION
This PR removes the deprecated Authentication#getVersion method and replaces its usages by #getEffectiveSubject#getVersion.

Relates: #88494