### PR TITLE
GeoBoundsAggregation reject sub aggregations

### DIFF
--- a/docs/changelog/91073.yaml
+++ b/docs/changelog/91073.yaml
@@ -1,0 +1,6 @@
+pr: 91073
+summary: GeoBoundsAggregations reject sub aggregations
+area: Aggregations
+type: bug
+issues:
+ - 91072

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/GeoBoundsAggregationBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/GeoBoundsAggregationBuilder.java
@@ -16,6 +16,7 @@ import org.elasticsearch.search.aggregations.AggregatorFactories;
 import org.elasticsearch.search.aggregations.AggregatorFactory;
 import org.elasticsearch.search.aggregations.support.AggregationContext;
 import org.elasticsearch.search.aggregations.support.CoreValuesSourceType;
+import org.elasticsearch.search.aggregations.support.ValuesSource;
 import org.elasticsearch.search.aggregations.support.ValuesSourceAggregationBuilder;
 import org.elasticsearch.search.aggregations.support.ValuesSourceConfig;
 import org.elasticsearch.search.aggregations.support.ValuesSourceRegistry;
@@ -27,7 +28,9 @@ import java.io.IOException;
 import java.util.Map;
 import java.util.Objects;
 
-public class GeoBoundsAggregationBuilder extends ValuesSourceAggregationBuilder<GeoBoundsAggregationBuilder> {
+public class GeoBoundsAggregationBuilder extends ValuesSourceAggregationBuilder.LeafOnly<
+    ValuesSource.GeoPoint,
+    GeoBoundsAggregationBuilder> {
     public static final String NAME = "geo_bounds";
     public static final ValuesSourceRegistry.RegistryKey<GeoBoundsAggregatorSupplier> REGISTRY_KEY = new ValuesSourceRegistry.RegistryKey<>(
         NAME,
@@ -103,11 +106,6 @@ public class GeoBoundsAggregationBuilder extends ValuesSourceAggregationBuilder<
      */
     public boolean wrapLongitude() {
         return wrapLongitude;
-    }
-
-    @Override
-    public BucketCardinality bucketCardinality() {
-        return BucketCardinality.NONE;
     }
 
     @Override


### PR DESCRIPTION
In #91072 I submitted an issue about GeoBoundsAggregation not rejecting sub aggregatsions.

In this PR, I let `GeoBoundsAggregationBuilder` extend from `ValuesSourceAggregationBuilder.LeafOnly` which will help `GeoBoundsAggregations` throwing `AggregationInitializationException` when sub aggregations are added.

`ValuesSourceAggregationBuilder.LeafOnly` is the common way for metric aggregations to reject sub aggregations. And `GeoBoundsAggregationBuilder` is the only metric aggregation builder that does not extend from `ValuesSourceAggregationBuilder.LeafOnly` actually.