### PR TITLE
Fix testDeleteAny when there's duplicate chars in the generated string

### DIFF
--- a/server/src/test/java/org/elasticsearch/common/StringsTests.java
+++ b/server/src/test/java/org/elasticsearch/common/StringsTests.java
@@ -180,7 +180,6 @@ public class StringsTests extends ESTestCase {
         );
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/91075")
     public void testDeleteAny() {
         assertNull(deleteAny((CharSequence) null, "abc"));
         assertNull(deleteAny((String) null, "abc"));

--- a/server/src/test/java/org/elasticsearch/common/StringsTests.java
+++ b/server/src/test/java/org/elasticsearch/common/StringsTests.java
@@ -191,10 +191,12 @@ public class StringsTests extends ESTestCase {
 
         String testStr = randomUnicodeOfLength(10);
         String delete = testStr.substring(testStr.length() - 1) + testStr.substring(0, 1);
-        assertThat(deleteAny(testStr, delete), equalTo(testStr.substring(1, testStr.length() - 1)));
-        assertThat(deleteAny(new StringBuilder(testStr), delete), hasToString(testStr.substring(1, testStr.length() - 1)));
-
-        // this method doesn't really work with surrogates
+        String expected = testStr.chars()
+            .mapToObj(Character::toString)
+            .filter(c -> delete.contains(c) == false)
+            .collect(Collectors.joining());
+        assertThat(deleteAny(testStr, delete), equalTo(expected));
+        assertThat(deleteAny(new StringBuilder(testStr), delete), hasToString(expected));
     }
 
     public void testSplitStringToSet() {


### PR DESCRIPTION
This fixes #91075 