### PR TITLE
Add privileges for crawler logs indices in Enterprise Search service account

### DIFF
--- a/docs/changelog/91094.yaml
+++ b/docs/changelog/91094.yaml
@@ -1,0 +1,5 @@
+pr: 91094
+summary: Add privileges for crawler logs indices in Enterprise Search service account
+area: Authorization
+type: enhancement
+issues: []

--- a/x-pack/plugin/security/qa/service-account/src/javaRestTest/java/org/elasticsearch/xpack/security/authc/service/ServiceAccountIT.java
+++ b/x-pack/plugin/security/qa/service-account/src/javaRestTest/java/org/elasticsearch/xpack/security/authc/service/ServiceAccountIT.java
@@ -165,6 +165,7 @@ public class ServiceAccountIT extends ESRestTestCase {
                         "logs-enterprise_search.audit-default",
                         "logs-app_search.search_relevance_suggestions-default",
                         "logs-crawler-default",
+                        "logs-elastic_crawler-default",
                         "logs-workplace_search.analytics-default",
                         "logs-workplace_search.content_events-default",
                         ".elastic-connectors*"

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/service/ElasticServiceAccounts.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/service/ElasticServiceAccounts.java
@@ -42,6 +42,7 @@ final class ElasticServiceAccounts {
                         "logs-enterprise_search.audit-default",
                         "logs-app_search.search_relevance_suggestions-default",
                         "logs-crawler-default",
+                        "logs-elastic_crawler-default",
                         "logs-workplace_search.analytics-default",
                         "logs-workplace_search.content_events-default",
                         ".elastic-connectors*"

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/service/ElasticServiceAccountsTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/service/ElasticServiceAccountsTests.java
@@ -360,7 +360,8 @@ public class ElasticServiceAccountsTests extends ESTestCase {
             "logs-crawler-default",
             "logs-workplace_search.analytics-default",
             "logs-workplace_search.content_events-default",
-            ".elastic-connectors*"
+            ".elastic-connectors*",
+            "logs-elastic_crawler-default"
         ).forEach(index -> {
             final IndexAbstraction enterpriseSearchIndex = mockIndexAbstraction(index);
             assertThat(role.indices().allowedIndicesMatcher(AutoCreateAction.NAME).test(enterpriseSearchIndex), is(true));


### PR DESCRIPTION
Add privileges for Enterprise Search service account to manage `logs-crawler-default` index. This index will be used by the Enterprise Search crawler for logging.

Related: https://github.com/elastic/cloud/pull/108604, https://github.com/elastic/cloud-assets/pull/1091 https://github.com/elastic/elasticsearch/pull/91026