### PR TITLE
[ML] Fix trained model deployment stats after allocations change

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/StartTrainedModelDeploymentAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/StartTrainedModelDeploymentAction.java
@@ -371,8 +371,8 @@ public class StartTrainedModelDeploymentAction extends ActionType<CreateTrainedM
             this(
                 modelId,
                 modelBytes,
-                threadsPerAllocation == null ? legacyInferenceThreads : threadsPerAllocation,
                 numberOfAllocations == null ? legacyModelThreads : numberOfAllocations,
+                threadsPerAllocation == null ? legacyInferenceThreads : threadsPerAllocation,
                 queueCapacity,
                 cacheSizeValue
             );
@@ -381,8 +381,8 @@ public class StartTrainedModelDeploymentAction extends ActionType<CreateTrainedM
         public TaskParams(
             String modelId,
             long modelBytes,
-            int threadsPerAllocation,
             int numberOfAllocations,
+            int threadsPerAllocation,
             int queueCapacity,
             @Nullable ByteSizeValue cacheSize
         ) {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/assignment/TrainedModelAssignment.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/assignment/TrainedModelAssignment.java
@@ -434,8 +434,8 @@ public class TrainedModelAssignment implements SimpleDiffable<TrainedModelAssign
             this.taskParams = new StartTrainedModelDeploymentAction.TaskParams(
                 taskParams.getModelId(),
                 taskParams.getModelBytes(),
-                taskParams.getThreadsPerAllocation(),
                 numberOfAllocations,
+                taskParams.getThreadsPerAllocation(),
                 taskParams.getQueueCapacity(),
                 taskParams.getCacheSize().orElse(null)
             );

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/assignment/TrainedModelAssignmentTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/assignment/TrainedModelAssignmentTests.java
@@ -286,8 +286,8 @@ public class TrainedModelAssignmentTests extends AbstractXContentSerializingTest
         return new StartTrainedModelDeploymentAction.TaskParams(
             randomAlphaOfLength(10),
             modelSize,
-            randomIntBetween(1, 8),
             numberOfAllocations,
+            randomIntBetween(1, 8),
             randomIntBetween(1, 10000),
             randomBoolean() ? null : ByteSizeValue.ofBytes(randomLongBetween(0, modelSize + 1))
         );

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportStartTrainedModelDeploymentAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportStartTrainedModelDeploymentAction.java
@@ -209,8 +209,8 @@ public class TransportStartTrainedModelDeploymentAction extends TransportMasterN
                     TaskParams taskParams = new TaskParams(
                         trainedModelConfig.getModelId(),
                         modelBytes,
-                        request.getThreadsPerAllocation(),
                         request.getNumberOfAllocations(),
+                        request.getThreadsPerAllocation(),
                         request.getQueueCapacity(),
                         Optional.ofNullable(request.getCacheSize()).orElse(ByteSizeValue.ofBytes(modelBytes))
                     );

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/assignment/TrainedModelAssignmentNodeService.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/assignment/TrainedModelAssignmentNodeService.java
@@ -360,8 +360,8 @@ public class TrainedModelAssignmentNodeService implements ClusterStateListener {
                             new StartTrainedModelDeploymentAction.TaskParams(
                                 trainedModelAssignment.getModelId(),
                                 trainedModelAssignment.getTaskParams().getModelBytes(),
-                                trainedModelAssignment.getTaskParams().getThreadsPerAllocation(),
                                 routingInfo.getCurrentAllocations(),
+                                trainedModelAssignment.getTaskParams().getThreadsPerAllocation(),
                                 trainedModelAssignment.getTaskParams().getQueueCapacity(),
                                 trainedModelAssignment.getTaskParams().getCacheSize().orElse(null)
                             )

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/deployment/TrainedModelDeploymentTask.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/deployment/TrainedModelDeploymentTask.java
@@ -77,8 +77,8 @@ public class TrainedModelDeploymentTask extends CancellableTask implements Start
         params = new TaskParams(
             params.getModelId(),
             params.getModelBytes(),
-            params.getThreadsPerAllocation(),
             numberOfAllocations,
+            params.getThreadsPerAllocation(),
             params.getQueueCapacity(),
             params.getCacheSize().orElse(null)
         );

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/deployment/TrainedModelDeploymentTask.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/deployment/TrainedModelDeploymentTask.java
@@ -77,10 +77,10 @@ public class TrainedModelDeploymentTask extends CancellableTask implements Start
         params = new TaskParams(
             params.getModelId(),
             params.getModelBytes(),
-            numberOfAllocations,
             params.getThreadsPerAllocation(),
+            numberOfAllocations,
             params.getQueueCapacity(),
-            null
+            params.getCacheSize().orElse(null)
         );
     }
 

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/autoscaling/MlMemoryAutoscalingDeciderTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/autoscaling/MlMemoryAutoscalingDeciderTests.java
@@ -1053,7 +1053,7 @@ public class MlMemoryAutoscalingDeciderTests extends ESTestCase {
             MlMemoryAutoscalingDecider.modelAssignmentsRequireMoreThanHalfCpu(
                 List.of(
                     TrainedModelAssignment.Builder.empty(
-                        new StartTrainedModelDeploymentAction.TaskParams("model1", TEST_JOB_SIZE, 3, 2, 100, null)
+                        new StartTrainedModelDeploymentAction.TaskParams("model1", TEST_JOB_SIZE, 2, 3, 100, null)
                     ).build(),
                     TrainedModelAssignment.Builder.empty(
                         new StartTrainedModelDeploymentAction.TaskParams("model1", TEST_JOB_SIZE, 1, 1, 100, null)
@@ -1066,7 +1066,7 @@ public class MlMemoryAutoscalingDeciderTests extends ESTestCase {
             MlMemoryAutoscalingDecider.modelAssignmentsRequireMoreThanHalfCpu(
                 List.of(
                     TrainedModelAssignment.Builder.empty(
-                        new StartTrainedModelDeploymentAction.TaskParams("model1", TEST_JOB_SIZE, 3, 1, 100, null)
+                        new StartTrainedModelDeploymentAction.TaskParams("model1", TEST_JOB_SIZE, 1, 3, 100, null)
                     ).build(),
                     TrainedModelAssignment.Builder.empty(
                         new StartTrainedModelDeploymentAction.TaskParams("model1", TEST_JOB_SIZE, 1, 1, 100, null)
@@ -1079,7 +1079,7 @@ public class MlMemoryAutoscalingDeciderTests extends ESTestCase {
             MlMemoryAutoscalingDecider.modelAssignmentsRequireMoreThanHalfCpu(
                 List.of(
                     TrainedModelAssignment.Builder.empty(
-                        new StartTrainedModelDeploymentAction.TaskParams("model1", TEST_JOB_SIZE, 3, 1, 100, null)
+                        new StartTrainedModelDeploymentAction.TaskParams("model1", TEST_JOB_SIZE, 1, 3, 100, null)
                     ).build(),
                     TrainedModelAssignment.Builder.empty(
                         new StartTrainedModelDeploymentAction.TaskParams("model1", TEST_JOB_SIZE, 1, 1, 100, null)

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/autoscaling/MlProcessorAutoscalingDeciderTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/autoscaling/MlProcessorAutoscalingDeciderTests.java
@@ -67,13 +67,13 @@ public class MlProcessorAutoscalingDeciderTests extends ESTestCase {
                             .addNewAssignment(
                                 modelId1,
                                 TrainedModelAssignment.Builder.empty(
-                                    new StartTrainedModelDeploymentAction.TaskParams(modelId1, 42L, 3, 2, 1024, ByteSizeValue.ONE)
+                                    new StartTrainedModelDeploymentAction.TaskParams(modelId1, 42L, 2, 3, 1024, ByteSizeValue.ONE)
                                 ).addRoutingEntry(mlNodeId1, new RoutingInfo(2, 2, RoutingState.STARTED, ""))
                             )
                             .addNewAssignment(
                                 modelId2,
                                 TrainedModelAssignment.Builder.empty(
-                                    new StartTrainedModelDeploymentAction.TaskParams(modelId2, 42L, 1, 10, 1024, ByteSizeValue.ONE)
+                                    new StartTrainedModelDeploymentAction.TaskParams(modelId2, 42L, 10, 1, 1024, ByteSizeValue.ONE)
                                 )
                                     .addRoutingEntry(mlNodeId1, new RoutingInfo(2, 2, RoutingState.STARTED, ""))
                                     .addRoutingEntry(mlNodeId2, new RoutingInfo(8, 8, RoutingState.STARTED, ""))
@@ -118,13 +118,13 @@ public class MlProcessorAutoscalingDeciderTests extends ESTestCase {
                             .addNewAssignment(
                                 modelId1,
                                 TrainedModelAssignment.Builder.empty(
-                                    new StartTrainedModelDeploymentAction.TaskParams(modelId1, 42L, 8, 1, 1024, ByteSizeValue.ONE)
+                                    new StartTrainedModelDeploymentAction.TaskParams(modelId1, 42L, 1, 8, 1024, ByteSizeValue.ONE)
                                 )
                             )
                             .addNewAssignment(
                                 modelId2,
                                 TrainedModelAssignment.Builder.empty(
-                                    new StartTrainedModelDeploymentAction.TaskParams(modelId2, 42L, 4, 3, 1024, ByteSizeValue.ONE)
+                                    new StartTrainedModelDeploymentAction.TaskParams(modelId2, 42L, 3, 4, 1024, ByteSizeValue.ONE)
                                 )
                                     .addRoutingEntry(mlNodeId1, new RoutingInfo(1, 1, RoutingState.STARTED, ""))
                                     .addRoutingEntry(mlNodeId2, new RoutingInfo(1, 1, RoutingState.STARTED, ""))

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/assignment/TrainedModelAssignmentClusterServiceTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/assignment/TrainedModelAssignmentClusterServiceTests.java
@@ -1502,8 +1502,8 @@ public class TrainedModelAssignmentClusterServiceTests extends ESTestCase {
         return new StartTrainedModelDeploymentAction.TaskParams(
             modelId,
             modelSize,
-            threadsPerAllocation,
             numberOfAllocations,
+            threadsPerAllocation,
             1024,
             ByteSizeValue.ofBytes(modelSize)
         );

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/assignment/TrainedModelAssignmentRebalancerTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/assignment/TrainedModelAssignmentRebalancerTests.java
@@ -593,8 +593,8 @@ public class TrainedModelAssignmentRebalancerTests extends ESTestCase {
         return new StartTrainedModelDeploymentAction.TaskParams(
             modelId,
             modelSize,
-            threadsPerAllocation,
             numberOfAllocations,
+            threadsPerAllocation,
             1024,
             ByteSizeValue.ofBytes(modelSize)
         );

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/assignment/planning/AllocationReducerTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/assignment/planning/AllocationReducerTests.java
@@ -172,8 +172,8 @@ public class AllocationReducerTests extends ESTestCase {
             new StartTrainedModelDeploymentAction.TaskParams(
                 modelId,
                 randomNonNegativeLong(),
-                randomIntBetween(1, 16),
                 numberOfAllocations,
+                randomIntBetween(1, 16),
                 1024,
                 null
             )


### PR DESCRIPTION
When the number of allocations of a particular assignment gets changed as the result of a rebalance, we update the params stored in the local task via `TrainedModelDeploymentTask.updateNumberOfAllocations`.

These are then used to report stats for the deployment.

This commit fixes a bug where we wrongly report:

- no `cache_size`
- `threads_per_allocation` as equal to local `number_of_allocations`

for a deployment after there was a change to the number of allocations of an assignment.
