### PR TITLE
Revert "[8.5] Validate field names when subobjects are disabled (#90950)"

### DIFF
--- a/docs/changelog/90950.yaml
+++ b/docs/changelog/90950.yaml
@@ -1,5 +1,0 @@
-pr: 90950
-summary: Validate field names when subobjects are disabled
-area: Mapping
-type: bug
-issues: []

--- a/server/src/main/java/org/elasticsearch/index/mapper/DocumentParser.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/DocumentParser.java
@@ -313,9 +313,6 @@ public final class DocumentParser {
                     if (currentFieldName.isBlank()) {
                         throwFieldNameBlank(context, currentFieldName);
                     }
-                    if (currentFieldName.replace(".", "").length() == 0) {
-                        throwFieldNameOnlyDots();
-                    }
                     break;
                 case START_OBJECT:
                     parseObject(context, mapper, currentFieldName);
@@ -340,10 +337,6 @@ public final class DocumentParser {
         throw new MapperParsingException(
             "Field name cannot contain only whitespace: [" + context.path().pathAsText(currentFieldName) + "]"
         );
-    }
-
-    private static void throwFieldNameOnlyDots() {
-        throw new IllegalArgumentException("field name cannot contain only dots");
     }
 
     private static void throwEOF(ObjectMapper mapper, DocumentParserContext context) throws IOException {

--- a/server/src/main/java/org/elasticsearch/index/mapper/DotExpandingXContentParser.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/DotExpandingXContentParser.java
@@ -73,6 +73,9 @@ class DotExpandingXContentParser extends FilterXContentParserWrapper {
             XContentParser delegate = delegate();
             String field = delegate.currentName();
             String[] subpaths = splitAndValidatePath(field);
+            if (subpaths.length == 0) {
+                throw new IllegalArgumentException("field name cannot contain only dots: [" + field + "]");
+            }
             // Corner case: if the input has a single trailing '.', eg 'field.', then we will get a single
             // subpath due to the way String.split() works. We can only return fast here if this is not
             // the case

--- a/server/src/test/java/org/elasticsearch/index/mapper/DocumentParserTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/DocumentParserTests.java
@@ -1847,27 +1847,8 @@ public class DocumentParserTests extends MapperServiceTestCase {
         assertThat(err.getCause().getMessage(), containsString("field name cannot be an empty string"));
     }
 
-    public void testBlankFieldNamesSubobjectsFalse() throws Exception {
-        DocumentMapper mapper = createDocumentMapper(topMapping(b -> b.field("subobjects", false)));
-        {
-            MapperParsingException err = expectThrows(MapperParsingException.class, () -> mapper.parse(source(b -> b.field("", "foo"))));
-            assertThat(err.getMessage(), containsString("Field name cannot contain only whitespace: []"));
-        }
-        {
-            MapperParsingException err = expectThrows(MapperParsingException.class, () -> mapper.parse(source(b -> b.field("  ", "foo"))));
-            assertThat(err.getMessage(), containsString("Field name cannot contain only whitespace: [  ]"));
-        }
-    }
-
     public void testDotsOnlyFieldNames() throws Exception {
-        dotsOnlyFieldNames(createDocumentMapper(mapping(b -> {})));
-    }
-
-    public void testDotsOnlyFieldNamesSubobjectsFalse() throws Exception {
-        dotsOnlyFieldNames(createDocumentMapper(topMapping(b -> b.field("subobjects", false))));
-    }
-
-    private void dotsOnlyFieldNames(DocumentMapper mapper) {
+        DocumentMapper mapper = createDocumentMapper(mapping(b -> {}));
         MapperParsingException err = expectThrows(
             MapperParsingException.class,
             () -> mapper.parse(source(b -> b.field(randomFrom(".", "..", "..."), "bar")))


### PR DESCRIPTION
Reverts elastic/elasticsearch#90951

In hindsight, there is a slight possibility that existing users are relying on Elasticsearch accepting field names that contain only dots when subobjects are disabled. The original change assumed that such fields were not accepted in mappings, but they actually are, as #90950 has surfaced. As a result, we end up rejecting field names that the mappings would happily accept, which is inconsistent.