### PR TITLE
Remove deprecated Authentication#getAuthenticatedBy

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/saml/SamlAuthenticateResponse.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/saml/SamlAuthenticateResponse.java
@@ -44,7 +44,7 @@ public final class SamlAuthenticateResponse extends ActionResponse {
 
     public SamlAuthenticateResponse(Authentication authentication, String tokenString, String refreshToken, TimeValue expiresIn) {
         this.principal = authentication.getEffectiveSubject().getUser().principal();
-        this.realm = authentication.getAuthenticatingSubject().getRealm().getName();
+        this.realm = authentication.getEffectiveSubject().getRealm().getName();
         this.tokenString = tokenString;
         this.refreshToken = refreshToken;
         this.expiresIn = expiresIn;

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/saml/SamlAuthenticateResponse.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/saml/SamlAuthenticateResponse.java
@@ -44,7 +44,7 @@ public final class SamlAuthenticateResponse extends ActionResponse {
 
     public SamlAuthenticateResponse(Authentication authentication, String tokenString, String refreshToken, TimeValue expiresIn) {
         this.principal = authentication.getEffectiveSubject().getUser().principal();
-        this.realm = authentication.getAuthenticatedBy().getName();
+        this.realm = authentication.getAuthenticatingSubject().getRealm().getName();
         this.tokenString = tokenString;
         this.refreshToken = refreshToken;
         this.expiresIn = expiresIn;

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authc/Authentication.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authc/Authentication.java
@@ -168,14 +168,6 @@ public final class Authentication implements ToXContentObject {
     }
 
     /**
-     * Use {@code getAuthenticatingSubject().getRealm()} instead.
-     */
-    @Deprecated
-    public RealmRef getAuthenticatedBy() {
-        return authenticatingSubject.getRealm();
-    }
-
-    /**
      * The use case for this method is largely trying to tell whether there is a run-as user
      * and can be replaced by {@code isRunAs}
      */
@@ -367,7 +359,7 @@ public final class Authentication implements ToXContentObject {
     }
 
     public boolean isAuthenticatedWithServiceAccount() {
-        return ServiceAccountSettings.REALM_TYPE.equals(getAuthenticatedBy().getType());
+        return ServiceAccountSettings.REALM_TYPE.equals(getAuthenticatingSubject().getRealm().getType());
     }
 
     /**
@@ -568,12 +560,12 @@ public final class Authentication implements ToXContentObject {
         builder.field(User.Fields.METADATA.getPreferredName(), user.metadata());
         builder.field(User.Fields.ENABLED.getPreferredName(), user.enabled());
         builder.startObject(User.Fields.AUTHENTICATION_REALM.getPreferredName());
-        builder.field(User.Fields.REALM_NAME.getPreferredName(), getAuthenticatedBy().getName());
-        builder.field(User.Fields.REALM_TYPE.getPreferredName(), getAuthenticatedBy().getType());
+        builder.field(User.Fields.REALM_NAME.getPreferredName(), getAuthenticatingSubject().getRealm().getName());
+        builder.field(User.Fields.REALM_TYPE.getPreferredName(), getAuthenticatingSubject().getRealm().getType());
         // domain name is generally ambiguous, because it can change during the lifetime of the authentication,
         // but it is good enough for display purposes (including auditing)
-        if (getAuthenticatedBy().getDomain() != null) {
-            builder.field(User.Fields.REALM_DOMAIN.getPreferredName(), getAuthenticatedBy().getDomain().name());
+        if (getAuthenticatingSubject().getRealm().getDomain() != null) {
+            builder.field(User.Fields.REALM_DOMAIN.getPreferredName(), getAuthenticatingSubject().getRealm().getDomain().name());
         }
         builder.endObject();
         builder.startObject(User.Fields.LOOKUP_REALM.getPreferredName());
@@ -584,10 +576,10 @@ public final class Authentication implements ToXContentObject {
                 builder.field(User.Fields.REALM_DOMAIN.getPreferredName(), getLookedUpBy().getDomain().name());
             }
         } else {
-            builder.field(User.Fields.REALM_NAME.getPreferredName(), getAuthenticatedBy().getName());
-            builder.field(User.Fields.REALM_TYPE.getPreferredName(), getAuthenticatedBy().getType());
-            if (getAuthenticatedBy().getDomain() != null) {
-                builder.field(User.Fields.REALM_DOMAIN.getPreferredName(), getAuthenticatedBy().getDomain().name());
+            builder.field(User.Fields.REALM_NAME.getPreferredName(), getAuthenticatingSubject().getRealm().getName());
+            builder.field(User.Fields.REALM_TYPE.getPreferredName(), getAuthenticatingSubject().getRealm().getType());
+            if (getAuthenticatingSubject().getRealm().getDomain() != null) {
+                builder.field(User.Fields.REALM_DOMAIN.getPreferredName(), getAuthenticatingSubject().getRealm().getDomain().name());
             }
         }
         builder.endObject();

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authc/AuthenticationTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authc/AuthenticationTests.java
@@ -224,7 +224,7 @@ public class AuthenticationTests extends ESTestCase {
             authentication = AuthenticationTestHelper.builder().serviceAccount().build();
         } else {
             authentication = randomValueOtherThanMany(
-                authc -> "_service_account".equals(authc.getAuthenticatedBy().getName()),
+                authc -> "_service_account".equals(authc.getAuthenticatingSubject().getRealm().getName()),
                 () -> AuthenticationTestHelper.builder().build()
             );
         }

--- a/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/xpack/security/authc/esnative/NativeRealmIntegTests.java
+++ b/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/xpack/security/authc/esnative/NativeRealmIntegTests.java
@@ -745,8 +745,8 @@ public class NativeRealmIntegTests extends NativeRealmIntegTestCase {
             Collections.singletonMap("Authorization", basicAuthHeaderValue(username, getReservedPassword()))
         ).execute(AuthenticateAction.INSTANCE, AuthenticateRequest.INSTANCE).get();
         assertThat(authenticateResponse.authentication().getEffectiveSubject().getUser().principal(), is(username));
-        assertThat(authenticateResponse.authentication().getAuthenticatedBy().getName(), equalTo("reserved"));
-        assertThat(authenticateResponse.authentication().getAuthenticatedBy().getType(), equalTo("reserved"));
+        assertThat(authenticateResponse.authentication().getAuthenticatingSubject().getRealm().getName(), equalTo("reserved"));
+        assertThat(authenticateResponse.authentication().getAuthenticatingSubject().getRealm().getType(), equalTo("reserved"));
         assertNull(authenticateResponse.authentication().getLookedUpBy());
     }
 

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/oidc/TransportOpenIdConnectLogoutAction.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/oidc/TransportOpenIdConnectLogoutAction.java
@@ -86,7 +86,7 @@ public class TransportOpenIdConnectLogoutAction extends HandledTransportAction<O
 
     private OpenIdConnectLogoutResponse buildResponse(Authentication authentication, Map<String, Object> tokenMetadata) {
         final String idTokenHint = (String) getFromMetadata(tokenMetadata, "id_token_hint");
-        final Realm realm = this.realms.realm(authentication.getAuthenticatedBy().getName());
+        final Realm realm = this.realms.realm(authentication.getAuthenticatingSubject().getRealm().getName());
         final JWT idToken;
         try {
             idToken = JWTParser.parse(idTokenHint);
@@ -108,11 +108,11 @@ public class TransportOpenIdConnectLogoutAction extends HandledTransportAction<O
             throw new ElasticsearchSecurityException("No active user");
         }
 
-        final Authentication.RealmRef ref = authentication.getAuthenticatedBy();
+        final Authentication.RealmRef ref = authentication.getAuthenticatingSubject().getRealm();
         if (ref == null || Strings.isNullOrEmpty(ref.getName())) {
             throw new ElasticsearchSecurityException("Authentication {} has no authenticating realm", authentication);
         }
-        final Realm realm = this.realms.realm(authentication.getAuthenticatedBy().getName());
+        final Realm realm = this.realms.realm(authentication.getAuthenticatingSubject().getRealm().getName());
         if (realm == null) {
             throw new ElasticsearchSecurityException("Authenticating realm {} does not exist", ref.getName());
         }

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/oidc/TransportOpenIdConnectLogoutAction.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/oidc/TransportOpenIdConnectLogoutAction.java
@@ -66,6 +66,7 @@ public class TransportOpenIdConnectLogoutAction extends HandledTransportAction<O
             final String token = request.getToken();
             tokenService.getAuthenticationAndMetadata(token, ActionListener.wrap(tuple -> {
                 final Authentication authentication = tuple.v1();
+                assert false == authentication.isRunAs() : "oidc realm authentication cannot have run-as";
                 final Map<String, Object> tokenMetadata = tuple.v2();
                 validateAuthenticationAndMetadata(authentication, tokenMetadata);
                 tokenService.invalidateAccessToken(token, ActionListener.wrap(result -> {
@@ -86,7 +87,7 @@ public class TransportOpenIdConnectLogoutAction extends HandledTransportAction<O
 
     private OpenIdConnectLogoutResponse buildResponse(Authentication authentication, Map<String, Object> tokenMetadata) {
         final String idTokenHint = (String) getFromMetadata(tokenMetadata, "id_token_hint");
-        final Realm realm = this.realms.realm(authentication.getAuthenticatingSubject().getRealm().getName());
+        final Realm realm = this.realms.realm(authentication.getEffectiveSubject().getRealm().getName());
         final JWT idToken;
         try {
             idToken = JWTParser.parse(idTokenHint);
@@ -108,11 +109,11 @@ public class TransportOpenIdConnectLogoutAction extends HandledTransportAction<O
             throw new ElasticsearchSecurityException("No active user");
         }
 
-        final Authentication.RealmRef ref = authentication.getAuthenticatingSubject().getRealm();
+        final Authentication.RealmRef ref = authentication.getEffectiveSubject().getRealm();
         if (ref == null || Strings.isNullOrEmpty(ref.getName())) {
             throw new ElasticsearchSecurityException("Authentication {} has no authenticating realm", authentication);
         }
-        final Realm realm = this.realms.realm(authentication.getAuthenticatingSubject().getRealm().getName());
+        final Realm realm = this.realms.realm(authentication.getEffectiveSubject().getRealm().getName());
         if (realm == null) {
             throw new ElasticsearchSecurityException("Authenticating realm {} does not exist", ref.getName());
         }

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/saml/TransportSamlAuthenticateAction.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/saml/TransportSamlAuthenticateAction.java
@@ -69,6 +69,7 @@ public final class TransportSamlAuthenticateAction extends HandledTransportActio
                     return;
                 }
                 assert authentication != null : "authentication should never be null at this point";
+                assert false == authentication.isRunAs() : "saml realm authentication cannot have run-as";
                 @SuppressWarnings("unchecked")
                 final Map<String, Object> tokenMeta = (Map<String, Object>) result.getMetadata().get(SamlRealm.CONTEXT_TOKEN_DATA);
                 tokenService.createOAuth2Tokens(

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/saml/TransportSamlLogoutAction.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/saml/TransportSamlLogoutAction.java
@@ -58,6 +58,7 @@ public final class TransportSamlLogoutAction extends HandledTransportAction<Saml
                 final String token = request.getToken();
                 tokenService.getAuthenticationAndMetadata(token, ActionListener.wrap(tuple -> {
                     Authentication authentication = tuple.v1();
+                    assert false == authentication.isRunAs() : "saml realm authentication cannot have run-as";
                     final Map<String, Object> tokenMetadata = tuple.v2();
                     SamlLogoutResponse response = buildResponse(authentication, tokenMetadata);
                     tokenService.invalidateAccessToken(token, ActionListener.wrap(created -> {
@@ -134,9 +135,9 @@ public final class TransportSamlLogoutAction extends HandledTransportAction<Saml
     }
 
     private SamlRealm findRealm(Authentication authentication) {
-        final Authentication.RealmRef ref = authentication.getAuthenticatingSubject().getRealm();
+        final Authentication.RealmRef ref = authentication.getEffectiveSubject().getRealm();
         if (ref == null || Strings.isNullOrEmpty(ref.getName())) {
-            throw SamlUtils.samlException("Authentication {} has no authenticating realm", authentication);
+            throw SamlUtils.samlException("Authentication {} has no effective realm", authentication);
         }
         final Realm realm = realms.realm(ref.getName());
         if (realm == null) {

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/saml/TransportSamlLogoutAction.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/saml/TransportSamlLogoutAction.java
@@ -134,7 +134,7 @@ public final class TransportSamlLogoutAction extends HandledTransportAction<Saml
     }
 
     private SamlRealm findRealm(Authentication authentication) {
-        final Authentication.RealmRef ref = authentication.getAuthenticatedBy();
+        final Authentication.RealmRef ref = authentication.getAuthenticatingSubject().getRealm();
         if (ref == null || Strings.isNullOrEmpty(ref.getName())) {
             throw SamlUtils.samlException("Authentication {} has no authenticating realm", authentication);
         }

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/audit/logfile/LoggingAuditTrail.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/audit/logfile/LoggingAuditTrail.java
@@ -457,7 +457,7 @@ public class LoggingAuditTrail implements AuditTrail, ClusterStateListener {
                     )
                 ) == false) {
             // this is redundant information maintained for bwc purposes
-            final String authnRealm = authentication.getAuthenticatedBy().getName();
+            final String authnRealm = authentication.getAuthenticatingSubject().getRealm().getName();
             new LogEntryBuilder().with(EVENT_TYPE_FIELD_NAME, REST_ORIGIN_FIELD_VALUE)
                 .with(EVENT_ACTION_FIELD_NAME, "authentication_success")
                 .with(REALM_FIELD_NAME, authnRealm)
@@ -1531,10 +1531,10 @@ public class LoggingAuditTrail implements AuditTrail, ClusterStateListener {
 
         LogEntryBuilder withRunAsSubject(Authentication authentication) {
             logEntry.with(PRINCIPAL_FIELD_NAME, authentication.getAuthenticatingSubject().getUser().principal())
-                .with(PRINCIPAL_REALM_FIELD_NAME, authentication.getAuthenticatedBy().getName())
+                .with(PRINCIPAL_REALM_FIELD_NAME, authentication.getAuthenticatingSubject().getRealm().getName())
                 .with(PRINCIPAL_RUN_AS_FIELD_NAME, authentication.getEffectiveSubject().getUser().principal());
-            if (authentication.getAuthenticatedBy().getDomain() != null) {
-                logEntry.with(PRINCIPAL_DOMAIN_FIELD_NAME, authentication.getAuthenticatedBy().getDomain().name());
+            if (authentication.getAuthenticatingSubject().getRealm().getDomain() != null) {
+                logEntry.with(PRINCIPAL_DOMAIN_FIELD_NAME, authentication.getAuthenticatingSubject().getRealm().getDomain().name());
             }
             if (authentication.getLookedUpBy() != null) {
                 logEntry.with(PRINCIPAL_RUN_AS_REALM_FIELD_NAME, authentication.getLookedUpBy().getName());
@@ -1625,7 +1625,7 @@ public class LoggingAuditTrail implements AuditTrail, ClusterStateListener {
                     // No domain information is needed here since API key itself does not work across realms
                 }
             } else {
-                final Authentication.RealmRef authenticatedBy = authentication.getAuthenticatedBy();
+                final Authentication.RealmRef authenticatedBy = authentication.getAuthenticatingSubject().getRealm();
                 if (authentication.isRunAs()) {
                     final Authentication.RealmRef lookedUpBy = authentication.getLookedUpBy();
                     logEntry.with(PRINCIPAL_REALM_FIELD_NAME, lookedUpBy.getName())

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/pki/PkiRealm.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/pki/PkiRealm.java
@@ -214,7 +214,7 @@ public class PkiRealm extends Realm implements CachingRealm {
                 "pki_delegated_by_user",
                 token.getDelegateeAuthentication().getEffectiveSubject().getUser().principal(),
                 "pki_delegated_by_realm",
-                token.getDelegateeAuthentication().getAuthenticatedBy().getName()
+                token.getDelegateeAuthentication().getAuthenticatingSubject().getRealm().getName()
             );
         } else {
             metadata = Map.of("pki_dn", token.dn());

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/pki/PkiRealm.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/pki/PkiRealm.java
@@ -214,6 +214,7 @@ public class PkiRealm extends Realm implements CachingRealm {
                 "pki_delegated_by_user",
                 token.getDelegateeAuthentication().getEffectiveSubject().getUser().principal(),
                 "pki_delegated_by_realm",
+                // TODO: this should be the realm of effective subject
                 token.getDelegateeAuthentication().getAuthenticatingSubject().getRealm().getName()
             );
         } else {

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authz/RBACEngine.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authz/RBACEngine.java
@@ -866,7 +866,7 @@ public class RBACEngine implements AuthorizationEngine {
         if (isRunAs) {
             realmType = authentication.getLookedUpBy().getType();
         } else {
-            realmType = authentication.getAuthenticatedBy().getType();
+            realmType = authentication.getAuthenticatingSubject().getRealm().getType();
         }
 
         assert realmType != null;

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/SecurityContextTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/SecurityContextTests.java
@@ -159,7 +159,7 @@ public class SecurityContextTests extends ESTestCase {
         securityContext.executeAfterRewritingAuthentication(originalCtx -> {
             Authentication authentication = securityContext.getAuthentication();
             assertEquals(original.getEffectiveSubject().getUser(), authentication.getEffectiveSubject().getUser());
-            assertEquals(original.getAuthenticatedBy(), authentication.getAuthenticatedBy());
+            assertEquals(original.getAuthenticatingSubject().getRealm(), authentication.getAuthenticatingSubject().getRealm());
             assertEquals(original.getLookedUpBy(), authentication.getLookedUpBy());
             assertEquals(VersionUtils.getPreviousVersion(), authentication.getEffectiveSubject().getVersion());
             assertEquals(original.getAuthenticationType(), securityContext.getAuthentication().getAuthenticationType());

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/action/user/TransportAuthenticateActionTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/action/user/TransportAuthenticateActionTests.java
@@ -152,7 +152,7 @@ public class TransportAuthenticateActionTests extends ESTestCase {
             if (auth.isRunAs()) {
                 assertThat(auth.getAuthenticatingSubject().getUser(), sameInstance(authentication.getAuthenticatingSubject().getUser()));
             }
-            assertThat(auth.getAuthenticatedBy(), sameInstance(auth.getAuthenticatedBy()));
+            assertThat(auth.getAuthenticatingSubject().getRealm(), sameInstance(auth.getAuthenticatingSubject().getRealm()));
             assertThat(auth.getLookedUpBy(), sameInstance(auth.getLookedUpBy()));
             assertThat(auth.getEffectiveSubject().getVersion(), sameInstance(auth.getEffectiveSubject().getVersion()));
             assertThat(auth.getAuthenticationType(), sameInstance(auth.getAuthenticationType()));
@@ -196,7 +196,7 @@ public class TransportAuthenticateActionTests extends ESTestCase {
             final Authentication auth = responseRef.get().authentication();
             final User authUser = auth.getEffectiveSubject().getUser();
             assertThat(authUser.roles(), emptyArray());
-            assertThat(auth.getAuthenticatedBy(), sameInstance(auth.getAuthenticatedBy()));
+            assertThat(auth.getAuthenticatingSubject().getRealm(), sameInstance(auth.getAuthenticatingSubject().getRealm()));
             assertThat(auth.getLookedUpBy(), sameInstance(auth.getLookedUpBy()));
             assertThat(auth.getEffectiveSubject().getVersion(), sameInstance(auth.getEffectiveSubject().getVersion()));
             assertThat(auth.getAuthenticationType(), sameInstance(auth.getAuthenticationType()));

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/audit/logfile/LoggingAuditTrailTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/audit/logfile/LoggingAuditTrailTests.java
@@ -2454,7 +2454,7 @@ public class LoggingAuditTrailTests extends ESTestCase {
         auditTrail.authenticationSuccess(requestId, authentication, request);
         checkedFields.put(LoggingAuditTrail.EVENT_TYPE_FIELD_NAME, LoggingAuditTrail.REST_ORIGIN_FIELD_VALUE)
             .put(LoggingAuditTrail.EVENT_ACTION_FIELD_NAME, "authentication_success")
-            .put(LoggingAuditTrail.REALM_FIELD_NAME, authentication.getAuthenticatedBy().getName())
+            .put(LoggingAuditTrail.REALM_FIELD_NAME, authentication.getAuthenticatingSubject().getRealm().getName())
             .put(LoggingAuditTrail.ORIGIN_TYPE_FIELD_NAME, LoggingAuditTrail.REST_ORIGIN_FIELD_VALUE)
             .put(LoggingAuditTrail.ORIGIN_ADDRESS_FIELD_NAME, NetworkAddress.format(address))
             .put(LoggingAuditTrail.REQUEST_METHOD_FIELD_NAME, request.method().toString())
@@ -2893,7 +2893,7 @@ public class LoggingAuditTrailTests extends ESTestCase {
                 checkedFields.put(LoggingAuditTrail.PRINCIPAL_REALM_FIELD_NAME, creatorRealmName);
             }
         } else {
-            final RealmRef authenticatedBy = authentication.getAuthenticatedBy();
+            final RealmRef authenticatedBy = authentication.getAuthenticatingSubject().getRealm();
             if (authentication.isRunAs()) {
                 final RealmRef lookedUpBy = authentication.getLookedUpBy();
                 checkedFields.put(LoggingAuditTrail.PRINCIPAL_REALM_FIELD_NAME, lookedUpBy.getName())

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/AuthenticationServiceTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/AuthenticationServiceTests.java
@@ -481,7 +481,7 @@ public class AuthenticationServiceTests extends ESTestCase {
             assertThat(result, notNullValue());
             assertThat(result.getEffectiveSubject().getUser(), is(user));
             assertThat(result.getLookedUpBy(), is(nullValue()));
-            assertThat(result.getAuthenticatedBy(), is(notNullValue())); // TODO implement equals
+            assertThat(result.getAuthenticatingSubject().getRealm(), is(notNullValue())); // TODO implement equals
             assertThat(result.getAuthenticationType(), is(AuthenticationType.REALM));
             assertThreadContextContainsAuthentication(result);
             setCompletedToTrue(completed);
@@ -521,10 +521,10 @@ public class AuthenticationServiceTests extends ESTestCase {
             assertThat(result, notNullValue());
             assertThat(result.getEffectiveSubject().getUser(), is(user));
             assertThat(result.getLookedUpBy(), is(nullValue()));
-            assertThat(result.getAuthenticatedBy(), is(notNullValue())); // TODO implement equals
-            assertThat(result.getAuthenticatedBy().getName(), is(SECOND_REALM_NAME));
-            assertThat(result.getAuthenticatedBy().getType(), is(SECOND_REALM_TYPE));
-            assertThat(result.getAuthenticatedBy().getDomain(), is(secondDomain));
+            assertThat(result.getAuthenticatingSubject().getRealm(), is(notNullValue())); // TODO implement equals
+            assertThat(result.getAuthenticatingSubject().getRealm().getName(), is(SECOND_REALM_NAME));
+            assertThat(result.getAuthenticatingSubject().getRealm().getType(), is(SECOND_REALM_TYPE));
+            assertThat(result.getAuthenticatingSubject().getRealm().getDomain(), is(secondDomain));
             assertThreadContextContainsAuthentication(result);
             verify(auditTrail).authenticationSuccess(reqId.get(), result, "_action", transportRequest);
             setCompletedToTrue(completed);
@@ -542,10 +542,10 @@ public class AuthenticationServiceTests extends ESTestCase {
             assertThat(result, notNullValue());
             assertThat(result.getEffectiveSubject().getUser(), is(user));
             assertThat(result.getLookedUpBy(), is(nullValue()));
-            assertThat(result.getAuthenticatedBy(), is(notNullValue())); // TODO implement equals
-            assertThat(result.getAuthenticatedBy().getName(), is(SECOND_REALM_NAME));
-            assertThat(result.getAuthenticatedBy().getType(), is(SECOND_REALM_TYPE));
-            assertThat(result.getAuthenticatedBy().getDomain(), is(secondDomain));
+            assertThat(result.getAuthenticatingSubject().getRealm(), is(notNullValue())); // TODO implement equals
+            assertThat(result.getAuthenticatingSubject().getRealm().getName(), is(SECOND_REALM_NAME));
+            assertThat(result.getAuthenticatingSubject().getRealm().getType(), is(SECOND_REALM_TYPE));
+            assertThat(result.getAuthenticatingSubject().getRealm().getDomain(), is(secondDomain));
             assertThreadContextContainsAuthentication(result);
             verify(auditTrail, times(2)).authenticationSuccess(reqId.get(), result, "_action", transportRequest);
             setCompletedToTrue(completed);
@@ -576,10 +576,10 @@ public class AuthenticationServiceTests extends ESTestCase {
             assertThat(result, notNullValue());
             assertThat(result.getEffectiveSubject().getUser(), is(user));
             assertThat(result.getLookedUpBy(), is(nullValue()));
-            assertThat(result.getAuthenticatedBy(), is(notNullValue()));
-            assertThat(result.getAuthenticatedBy().getName(), is(FIRST_REALM_NAME));
-            assertThat(result.getAuthenticatedBy().getType(), is(FIRST_REALM_TYPE));
-            assertThat(result.getAuthenticatedBy().getDomain(), is(firstDomain));
+            assertThat(result.getAuthenticatingSubject().getRealm(), is(notNullValue()));
+            assertThat(result.getAuthenticatingSubject().getRealm().getName(), is(FIRST_REALM_NAME));
+            assertThat(result.getAuthenticatingSubject().getRealm().getType(), is(FIRST_REALM_TYPE));
+            assertThat(result.getAuthenticatingSubject().getRealm().getDomain(), is(firstDomain));
             assertThreadContextContainsAuthentication(result);
             verify(auditTrail).authenticationSuccess(reqId.get(), result, "_action", transportRequest);
             setCompletedToTrue(completed);
@@ -664,8 +664,8 @@ public class AuthenticationServiceTests extends ESTestCase {
             assertThat(result, notNullValue());
             assertThat(result.getEffectiveSubject().getUser(), is(user));
             assertThat(result.getLookedUpBy(), is(nullValue()));
-            assertThat(result.getAuthenticatedBy().getName(), is(SECOND_REALM_NAME)); // TODO implement equals
-            assertThat(result.getAuthenticatedBy().getDomain(), is(secondDomain));
+            assertThat(result.getAuthenticatingSubject().getRealm().getName(), is(SECOND_REALM_NAME)); // TODO implement equals
+            assertThat(result.getAuthenticatingSubject().getRealm().getDomain(), is(secondDomain));
             assertThreadContextContainsAuthentication(result);
             verify(auditTrail).authenticationSuccess(reqId.get(), result, "_action", transportRequest);
             setCompletedToTrue(completed);
@@ -680,8 +680,8 @@ public class AuthenticationServiceTests extends ESTestCase {
             assertThat(result, notNullValue());
             assertThat(result.getEffectiveSubject().getUser(), is(user));
             assertThat(result.getLookedUpBy(), is(nullValue()));
-            assertThat(result.getAuthenticatedBy().getName(), is(SECOND_REALM_NAME)); // TODO implement equals
-            assertThat(result.getAuthenticatedBy().getDomain(), is(secondDomain));
+            assertThat(result.getAuthenticatingSubject().getRealm().getName(), is(SECOND_REALM_NAME)); // TODO implement equals
+            assertThat(result.getAuthenticatingSubject().getRealm().getDomain(), is(secondDomain));
             assertThreadContextContainsAuthentication(result);
             verify(auditTrail, times(2)).authenticationSuccess(reqId.get(), result, "_action", transportRequest);
             setCompletedToTrue(completed);
@@ -721,8 +721,8 @@ public class AuthenticationServiceTests extends ESTestCase {
             assertThat(result, notNullValue());
             assertThat(result.getEffectiveSubject().getUser(), is(user));
             assertThat(result.getAuthenticationType(), is(AuthenticationType.REALM));
-            assertThat(result.getAuthenticatedBy().getName(), is(secondRealm.name())); // TODO implement equals
-            assertThat(result.getAuthenticatedBy().getDomain(), is(secondDomain));
+            assertThat(result.getAuthenticatingSubject().getRealm().getName(), is(secondRealm.name())); // TODO implement equals
+            assertThat(result.getAuthenticatingSubject().getRealm().getDomain(), is(secondDomain));
             assertThat(result.getAuthenticationType(), is(AuthenticationType.REALM));
             assertThreadContextContainsAuthentication(result);
             verify(auditTrail).authenticationSuccess(reqId.get(), result, "_action", transportRequest);
@@ -934,8 +934,8 @@ public class AuthenticationServiceTests extends ESTestCase {
             assertThat(result, notNullValue());
             assertThat(result.getEffectiveSubject().getUser(), sameInstance(user));
             assertThat(result.getAuthenticationType(), is(AuthenticationType.REALM));
-            assertThat(result.getAuthenticatedBy().getDomain(), is(firstDomain));
-            assertThat(result.getAuthenticatedBy().getName(), is(firstRealm.name())); // TODO implement equals
+            assertThat(result.getAuthenticatingSubject().getRealm().getDomain(), is(firstDomain));
+            assertThat(result.getAuthenticatingSubject().getRealm().getName(), is(firstRealm.name())); // TODO implement equals
             assertThreadContextContainsAuthentication(result);
             verify(auditTrail).authenticationSuccess(reqId.get(), result, "_action", transportRequest);
             setCompletedToTrue(completed);
@@ -957,8 +957,8 @@ public class AuthenticationServiceTests extends ESTestCase {
             assertThat(authentication, notNullValue());
             assertThat(authentication.getEffectiveSubject().getUser(), sameInstance(user1));
             assertThat(authentication.getAuthenticationType(), is(AuthenticationType.REALM));
-            assertThat(authentication.getAuthenticatedBy().getName(), is(firstRealm.name())); // TODO implement equals
-            assertThat(authentication.getAuthenticatedBy().getDomain(), is(firstDomain)); // TODO implement equals
+            assertThat(authentication.getAuthenticatingSubject().getRealm().getName(), is(firstRealm.name())); // TODO implement equals
+            assertThat(authentication.getAuthenticatingSubject().getRealm().getDomain(), is(firstDomain)); // TODO implement equals
             assertThreadContextContainsAuthentication(authentication);
             String reqId = expectAuditRequestId(threadContext);
             verify(auditTrail).authenticationSuccess(reqId, authentication, restRequest);
@@ -1889,8 +1889,8 @@ public class AuthenticationServiceTests extends ESTestCase {
                 assertThat(result, notNullValue());
                 assertThat(result.getEffectiveSubject().getUser(), is(user));
                 assertThat(result.getLookedUpBy(), is(nullValue()));
-                assertThat(result.getAuthenticatedBy(), is(notNullValue()));
-                assertThat(result.getAuthenticatedBy().getName(), is("realm")); // TODO implement equals
+                assertThat(result.getAuthenticatingSubject().getRealm(), is(notNullValue()));
+                assertThat(result.getAuthenticatingSubject().getRealm().getName(), is("realm")); // TODO implement equals
                 assertThat(result.getAuthenticationType(), is(AuthenticationType.TOKEN));
                 if (requestIdAlreadyPresent) {
                     assertThat(expectAuditRequestId(threadContext), is(reqId.get()));
@@ -1932,7 +1932,7 @@ public class AuthenticationServiceTests extends ESTestCase {
                 assertThat(result, notNullValue());
                 assertThat(result.getEffectiveSubject().getUser(), is(user));
                 assertThat(result.getLookedUpBy(), is(nullValue()));
-                assertThat(result.getAuthenticatedBy(), is(notNullValue()));
+                assertThat(result.getAuthenticatingSubject().getRealm(), is(notNullValue()));
                 assertThreadContextContainsAuthentication(result);
                 assertEquals(expected, result);
                 if (requestIdAlreadyPresent) {

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/RealmsAuthenticatorTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/RealmsAuthenticatorTests.java
@@ -163,7 +163,7 @@ public class RealmsAuthenticatorTests extends ESTestCase {
         final Authentication authentication = result.getValue();
         assertThat(authentication.getEffectiveSubject().getUser(), is(user));
         assertThat(
-            authentication.getAuthenticatedBy(),
+            authentication.getAuthenticatingSubject().getRealm(),
             is(
                 new Authentication.RealmRef(
                     successfulRealm.name(),

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/TokenServiceTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/TokenServiceTests.java
@@ -465,7 +465,7 @@ public class TokenServiceTests extends ESTestCase {
             return new RefreshTokenStatus(
                 invalidated,
                 authentication.getEffectiveSubject().getUser().principal(),
-                authentication.getAuthenticatedBy().getName(),
+                authentication.getAuthenticatingSubject().getRealm().getName(),
                 refreshed,
                 refreshInstant,
                 supersedingTokens,
@@ -1048,7 +1048,7 @@ public class TokenServiceTests extends ESTestCase {
 
     public static void assertAuthentication(Authentication result, Authentication expected) {
         assertEquals(expected.getEffectiveSubject().getUser(), result.getEffectiveSubject().getUser());
-        assertEquals(expected.getAuthenticatedBy(), result.getAuthenticatedBy());
+        assertEquals(expected.getAuthenticatingSubject().getRealm(), result.getAuthenticatingSubject().getRealm());
         assertEquals(expected.getLookedUpBy(), result.getLookedUpBy());
         assertEquals(expected.getAuthenticatingSubject().getMetadata(), result.getAuthenticatingSubject().getMetadata());
     }

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/support/SecondaryAuthenticatorTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/support/SecondaryAuthenticatorTests.java
@@ -247,7 +247,7 @@ public class SecondaryAuthenticatorTests extends ESTestCase {
         assertThat(secondaryAuthentication, Matchers.notNullValue());
         assertThat(secondaryAuthentication.getAuthentication(), Matchers.notNullValue());
         assertThat(secondaryAuthentication.getAuthentication().getEffectiveSubject().getUser().principal(), equalTo(user));
-        assertThat(secondaryAuthentication.getAuthentication().getAuthenticatedBy().getName(), equalTo(realm.name()));
+        assertThat(secondaryAuthentication.getAuthentication().getAuthenticatingSubject().getRealm().getName(), equalTo(realm.name()));
 
         listenerContext.get().restore();
         return secondaryAuthentication;


### PR DESCRIPTION
This PR removes the deprecated Authentication#getAuthenticatedBy method and replaces its usages with #getAuthenticatingSubject#getRealm

Relates: #88494
