### PR TITLE
Mute IndexRecoveryWithSnapshotsIT testTransientErrorsDuringRecoveryAreRe...

### DIFF
--- a/x-pack/plugin/snapshot-based-recoveries/src/internalClusterTest/java/org/elasticsearch/xpack/snapshotbasedrecoveries/recovery/IndexRecoveryWithSnapshotsIT.java
+++ b/x-pack/plugin/snapshot-based-recoveries/src/internalClusterTest/java/org/elasticsearch/xpack/snapshotbasedrecoveries/recovery/IndexRecoveryWithSnapshotsIT.java
@@ -22,6 +22,7 @@ public class IndexRecoveryWithSnapshotsIT extends AbstractIndexRecoveryIntegTest
         return CollectionUtils.appendToCopy(super.nodePlugins(), ConfigurableMockSnapshotBasedRecoveriesPlugin.class);
     }
 
+    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/91087")
     public void testTransientErrorsDuringRecoveryAreRetried() throws Exception {
         checkTransientErrorsDuringRecoveryAreRetried(PeerRecoveryTargetService.Actions.RESTORE_FILE_FROM_SNAPSHOT);
     }


### PR DESCRIPTION
Mute failing test: `IndexRecoveryWithSnapshotsIT#testTransientErrorsDuringRecoveryAreRetried`.

See https://github.com/elastic/elasticsearch/issues/91087