### PR TITLE
[DOCS] Remove extra ports in Docker command

### DIFF
--- a/docs/reference/setup/install/docker.asciidoc
+++ b/docs/reference/setup/install/docker.asciidoc
@@ -96,7 +96,7 @@ endif::[]
 ifeval::["{release-state}"!="unreleased"]
 [source,sh,subs="attributes"]
 ----
-docker run --name es01 --net elastic -p 9200:9200 -p 9300:9300 -it {docker-image}
+docker run --name es01 --net elastic -p 9200:9200 -it {docker-image}
 ----
 
 endif::[]


### PR DESCRIPTION
The current command to start the first Elasticsearch node includes `-p 9200:9200` and `-p 9300:9300`. This PR removes the extra ports so that they're not open unnecessarily.