### PR TITLE
Remove deprecated Authentication#getLookedUpBy

### DIFF
--- a/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/xpack/security/authc/esnative/NativeRealmIntegTests.java
+++ b/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/xpack/security/authc/esnative/NativeRealmIntegTests.java
@@ -747,7 +747,7 @@ public class NativeRealmIntegTests extends NativeRealmIntegTestCase {
         assertThat(authenticateResponse.authentication().getEffectiveSubject().getUser().principal(), is(username));
         assertThat(authenticateResponse.authentication().getAuthenticatingSubject().getRealm().getName(), equalTo("reserved"));
         assertThat(authenticateResponse.authentication().getAuthenticatingSubject().getRealm().getType(), equalTo("reserved"));
-        assertNull(authenticateResponse.authentication().getLookedUpBy());
+        assertFalse(authenticateResponse.authentication().isRunAs());
     }
 
     public void testOperationsOnReservedRoles() throws Exception {

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/audit/logfile/LoggingAuditTrail.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/audit/logfile/LoggingAuditTrail.java
@@ -1536,10 +1536,11 @@ public class LoggingAuditTrail implements AuditTrail, ClusterStateListener {
             if (authentication.getAuthenticatingSubject().getRealm().getDomain() != null) {
                 logEntry.with(PRINCIPAL_DOMAIN_FIELD_NAME, authentication.getAuthenticatingSubject().getRealm().getDomain().name());
             }
-            if (authentication.getLookedUpBy() != null) {
-                logEntry.with(PRINCIPAL_RUN_AS_REALM_FIELD_NAME, authentication.getLookedUpBy().getName());
-                if (authentication.getLookedUpBy().getDomain() != null) {
-                    logEntry.with(PRINCIPAL_RUN_AS_DOMAIN_FIELD_NAME, authentication.getLookedUpBy().getDomain().name());
+            final Authentication.RealmRef lookedUpBy = authentication.isRunAs() ? authentication.getEffectiveSubject().getRealm() : null;
+            if (lookedUpBy != null) {
+                logEntry.with(PRINCIPAL_RUN_AS_REALM_FIELD_NAME, lookedUpBy.getName());
+                if (lookedUpBy.getDomain() != null) {
+                    logEntry.with(PRINCIPAL_RUN_AS_DOMAIN_FIELD_NAME, lookedUpBy.getDomain().name());
                 }
             }
             return this;
@@ -1627,7 +1628,7 @@ public class LoggingAuditTrail implements AuditTrail, ClusterStateListener {
             } else {
                 final Authentication.RealmRef authenticatedBy = authentication.getAuthenticatingSubject().getRealm();
                 if (authentication.isRunAs()) {
-                    final Authentication.RealmRef lookedUpBy = authentication.getLookedUpBy();
+                    final Authentication.RealmRef lookedUpBy = authentication.getEffectiveSubject().getRealm();
                     logEntry.with(PRINCIPAL_REALM_FIELD_NAME, lookedUpBy.getName())
                         .with(PRINCIPAL_RUN_BY_FIELD_NAME, authentication.getAuthenticatingSubject().getUser().principal())
                         // API key can run-as, when that happens, the following field will be _es_api_key,

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/RealmsAuthenticator.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/RealmsAuthenticator.java
@@ -276,7 +276,7 @@ class RealmsAuthenticator implements Authenticator {
      * names of users that exist using a timing attack
      */
     public void lookupRunAsUser(Context context, Authentication authentication, ActionListener<Tuple<User, Realm>> listener) {
-        assert authentication.getLookedUpBy() == null : "authentication already has a lookup realm";
+        assert false == authentication.isRunAs() : "authentication already has run-as";
         final String runAsUsername = context.getThreadContext().getHeader(AuthenticationServiceField.RUN_AS_USER_HEADER);
         if (runAsUsername != null && runAsUsername.isEmpty() == false) {
             logger.trace(

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authz/AuthorizationService.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authz/AuthorizationService.java
@@ -664,7 +664,7 @@ public class AuthorizationService {
         final ActionListener<AuthorizationResult> listener
     ) {
         final Authentication authentication = requestInfo.getAuthentication();
-        assert authentication.isRunAs() : "authentication does not have a run-as";
+        assert authentication.isRunAs() : "authentication must have run-as for run-as to be authorized";
         if (authentication.getEffectiveSubject().getRealm() == null) {
             // this user did not really exist
             // TODO(jaymode) find a better way to indicate lookup failed for a user and we need to fail authz

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authz/AuthorizationService.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authz/AuthorizationService.java
@@ -664,7 +664,8 @@ public class AuthorizationService {
         final ActionListener<AuthorizationResult> listener
     ) {
         final Authentication authentication = requestInfo.getAuthentication();
-        if (authentication.getLookedUpBy() == null) {
+        assert authentication.isRunAs() : "authentication does not have a run-as";
+        if (authentication.getEffectiveSubject().getRealm() == null) {
             // this user did not really exist
             // TODO(jaymode) find a better way to indicate lookup failed for a user and we need to fail authz
             listener.onResponse(AuthorizationResult.deny());

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authz/RBACEngine.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authz/RBACEngine.java
@@ -864,7 +864,7 @@ public class RBACEngine implements AuthorizationEngine {
         final boolean isRunAs = authentication.isRunAs();
         final String realmType;
         if (isRunAs) {
-            realmType = authentication.getLookedUpBy().getType();
+            realmType = authentication.getEffectiveSubject().getRealm().getType();
         } else {
             realmType = authentication.getAuthenticatingSubject().getRealm().getType();
         }

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/SecurityContextTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/SecurityContextTests.java
@@ -160,7 +160,8 @@ public class SecurityContextTests extends ESTestCase {
             Authentication authentication = securityContext.getAuthentication();
             assertEquals(original.getEffectiveSubject().getUser(), authentication.getEffectiveSubject().getUser());
             assertEquals(original.getAuthenticatingSubject().getRealm(), authentication.getAuthenticatingSubject().getRealm());
-            assertEquals(original.getLookedUpBy(), authentication.getLookedUpBy());
+            assertEquals(original.isRunAs(), authentication.isRunAs());
+            assertEquals(original.getEffectiveSubject().getRealm(), authentication.getEffectiveSubject().getRealm());
             assertEquals(VersionUtils.getPreviousVersion(), authentication.getEffectiveSubject().getVersion());
             assertEquals(original.getAuthenticationType(), securityContext.getAuthentication().getAuthenticationType());
             contextAtomicReference.set(originalCtx);

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/audit/logfile/LoggingAuditTrailTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/audit/logfile/LoggingAuditTrailTests.java
@@ -2895,7 +2895,7 @@ public class LoggingAuditTrailTests extends ESTestCase {
         } else {
             final RealmRef authenticatedBy = authentication.getAuthenticatingSubject().getRealm();
             if (authentication.isRunAs()) {
-                final RealmRef lookedUpBy = authentication.getLookedUpBy();
+                final RealmRef lookedUpBy = authentication.getEffectiveSubject().getRealm();
                 checkedFields.put(LoggingAuditTrail.PRINCIPAL_REALM_FIELD_NAME, lookedUpBy.getName())
                     .put(LoggingAuditTrail.PRINCIPAL_RUN_BY_FIELD_NAME, authentication.getAuthenticatingSubject().getUser().principal())
                     .put(LoggingAuditTrail.PRINCIPAL_RUN_BY_REALM_FIELD_NAME, authenticatedBy.getName());

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/AuthenticationServiceTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/AuthenticationServiceTests.java
@@ -480,7 +480,7 @@ public class AuthenticationServiceTests extends ESTestCase {
             }
             assertThat(result, notNullValue());
             assertThat(result.getEffectiveSubject().getUser(), is(user));
-            assertThat(result.getLookedUpBy(), is(nullValue()));
+            assertThat(result.isRunAs(), is(false));
             assertThat(result.getAuthenticatingSubject().getRealm(), is(notNullValue())); // TODO implement equals
             assertThat(result.getAuthenticationType(), is(AuthenticationType.REALM));
             assertThreadContextContainsAuthentication(result);
@@ -520,7 +520,7 @@ public class AuthenticationServiceTests extends ESTestCase {
             }
             assertThat(result, notNullValue());
             assertThat(result.getEffectiveSubject().getUser(), is(user));
-            assertThat(result.getLookedUpBy(), is(nullValue()));
+            assertThat(result.isRunAs(), is(false));
             assertThat(result.getAuthenticatingSubject().getRealm(), is(notNullValue())); // TODO implement equals
             assertThat(result.getAuthenticatingSubject().getRealm().getName(), is(SECOND_REALM_NAME));
             assertThat(result.getAuthenticatingSubject().getRealm().getType(), is(SECOND_REALM_TYPE));
@@ -541,7 +541,7 @@ public class AuthenticationServiceTests extends ESTestCase {
             assertThat(expectAuditRequestId(threadContext), is(reqId.get()));
             assertThat(result, notNullValue());
             assertThat(result.getEffectiveSubject().getUser(), is(user));
-            assertThat(result.getLookedUpBy(), is(nullValue()));
+            assertThat(result.isRunAs(), is(false));
             assertThat(result.getAuthenticatingSubject().getRealm(), is(notNullValue())); // TODO implement equals
             assertThat(result.getAuthenticatingSubject().getRealm().getName(), is(SECOND_REALM_NAME));
             assertThat(result.getAuthenticatingSubject().getRealm().getType(), is(SECOND_REALM_TYPE));
@@ -575,7 +575,7 @@ public class AuthenticationServiceTests extends ESTestCase {
             assertThat(expectAuditRequestId(threadContext), is(reqId.get()));
             assertThat(result, notNullValue());
             assertThat(result.getEffectiveSubject().getUser(), is(user));
-            assertThat(result.getLookedUpBy(), is(nullValue()));
+            assertThat(result.isRunAs(), is(false));
             assertThat(result.getAuthenticatingSubject().getRealm(), is(notNullValue()));
             assertThat(result.getAuthenticatingSubject().getRealm().getName(), is(FIRST_REALM_NAME));
             assertThat(result.getAuthenticatingSubject().getRealm().getType(), is(FIRST_REALM_TYPE));
@@ -663,7 +663,7 @@ public class AuthenticationServiceTests extends ESTestCase {
             }
             assertThat(result, notNullValue());
             assertThat(result.getEffectiveSubject().getUser(), is(user));
-            assertThat(result.getLookedUpBy(), is(nullValue()));
+            assertThat(result.isRunAs(), is(false));
             assertThat(result.getAuthenticatingSubject().getRealm().getName(), is(SECOND_REALM_NAME)); // TODO implement equals
             assertThat(result.getAuthenticatingSubject().getRealm().getDomain(), is(secondDomain));
             assertThreadContextContainsAuthentication(result);
@@ -679,7 +679,7 @@ public class AuthenticationServiceTests extends ESTestCase {
             assertThat(expectAuditRequestId(threadContext), is(reqId.get()));
             assertThat(result, notNullValue());
             assertThat(result.getEffectiveSubject().getUser(), is(user));
-            assertThat(result.getLookedUpBy(), is(nullValue()));
+            assertThat(result.isRunAs(), is(false));
             assertThat(result.getAuthenticatingSubject().getRealm().getName(), is(SECOND_REALM_NAME)); // TODO implement equals
             assertThat(result.getAuthenticatingSubject().getRealm().getDomain(), is(secondDomain));
             assertThreadContextContainsAuthentication(result);
@@ -1888,7 +1888,7 @@ public class AuthenticationServiceTests extends ESTestCase {
             service.authenticate("_action", transportRequest, true, ActionListener.wrap(result -> {
                 assertThat(result, notNullValue());
                 assertThat(result.getEffectiveSubject().getUser(), is(user));
-                assertThat(result.getLookedUpBy(), is(nullValue()));
+                assertThat(result.isRunAs(), is(false));
                 assertThat(result.getAuthenticatingSubject().getRealm(), is(notNullValue()));
                 assertThat(result.getAuthenticatingSubject().getRealm().getName(), is("realm")); // TODO implement equals
                 assertThat(result.getAuthenticationType(), is(AuthenticationType.TOKEN));
@@ -1931,7 +1931,7 @@ public class AuthenticationServiceTests extends ESTestCase {
             service.authenticate("_action", transportRequest, true, ActionListener.wrap(result -> {
                 assertThat(result, notNullValue());
                 assertThat(result.getEffectiveSubject().getUser(), is(user));
-                assertThat(result.getLookedUpBy(), is(nullValue()));
+                assertThat(result.isRunAs(), is(false));
                 assertThat(result.getAuthenticatingSubject().getRealm(), is(notNullValue()));
                 assertThreadContextContainsAuthentication(result);
                 assertEquals(expected, result);

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/TokenServiceTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/TokenServiceTests.java
@@ -1049,7 +1049,8 @@ public class TokenServiceTests extends ESTestCase {
     public static void assertAuthentication(Authentication result, Authentication expected) {
         assertEquals(expected.getEffectiveSubject().getUser(), result.getEffectiveSubject().getUser());
         assertEquals(expected.getAuthenticatingSubject().getRealm(), result.getAuthenticatingSubject().getRealm());
-        assertEquals(expected.getLookedUpBy(), result.getLookedUpBy());
+        assertEquals(expected.isRunAs(), result.isRunAs());
+        assertEquals(expected.getEffectiveSubject().getRealm(), result.getEffectiveSubject().getRealm());
         assertEquals(expected.getAuthenticatingSubject().getMetadata(), result.getAuthenticatingSubject().getMetadata());
     }
 

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/ingest/SetSecurityUserProcessorTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/ingest/SetSecurityUserProcessorTests.java
@@ -420,7 +420,7 @@ public class SetSecurityUserProcessorTests extends ESTestCase {
 
         Map<String, Object> result = ingestDocument.getFieldValue("_field", Map.class);
         assertThat(result, aMapWithSize(3));
-        final Authentication.RealmRef lookedUpRealmRef = auth.getLookedUpBy();
+        final Authentication.RealmRef lookedUpRealmRef = auth.getEffectiveSubject().getRealm();
         assertThat(((Map<String, String>) result.get("realm")).get("name"), equalTo(lookedUpRealmRef.getName()));
         assertThat(((Map<String, String>) result.get("realm")).get("type"), equalTo(lookedUpRealmRef.getType()));
     }


### PR DESCRIPTION
This PR removes the deprecated Authentication#getLookedUpBy method. Its usages are replaced by either isRunAs or
getEffectiveSubject#getRealm or their combinations depending on the actual context.

Relates: #88494
