### PR TITLE
Fix typo in stop-tokenfilter.asciidoc

### DIFF
--- a/docs/reference/analysis/tokenfilters/stop-tokenfilter.asciidoc
+++ b/docs/reference/analysis/tokenfilters/stop-tokenfilter.asciidoc
@@ -203,7 +203,7 @@ PUT /my-index-000001
 ----
 
 You can also specify your own list of stop words. For example, the following
-request creates a custom case-sensitive `stop` filter that removes only the stop
+request creates a custom case-insensitive `stop` filter that removes only the stop
 words `and`, `is`, and `the`:
 
 [source,console]


### PR DESCRIPTION
Since `ignore_case` is set to `true` in our custom stop words filter, the matching will be case-insensitive.