### PR TITLE
[8.4] Fix carriage return removal when reading a long line from terminal (#91131)

### DIFF
--- a/docs/changelog/91131.yaml
+++ b/docs/changelog/91131.yaml
@@ -1,0 +1,6 @@
+pr: 91131
+summary: Fix carriage return removal when reading a long line from terminal
+area: Infra/CLI
+type: bug
+issues:
+ - 89227

--- a/libs/cli/src/main/java/org/elasticsearch/cli/Terminal.java
+++ b/libs/cli/src/main/java/org/elasticsearch/cli/Terminal.java
@@ -243,7 +243,7 @@ public abstract class Terminal {
                 return null;
             }
 
-            if (len > 0 && len < buf.length && buf[len - 1] == '\r') {
+            if (len > 0 && len <= buf.length && buf[len - 1] == '\r') {
                 len--;
             }
 

--- a/server/src/test/java/org/elasticsearch/cli/TerminalTests.java
+++ b/server/src/test/java/org/elasticsearch/cli/TerminalTests.java
@@ -138,6 +138,16 @@ public class TerminalTests extends ESTestCase {
         assertRead(passphrase + "\r\n", passphrase);
     }
 
+    /**
+     * Tests an edge case when read buffer gets completely filled (up to 128 chars) with the last character being carriage return
+     * and asserts that this last CR character is properly removed.
+     */
+    public void testReadLineToCharArrayBufferWithCarriageReturnRemoval() throws Exception {
+        String passphrase = randomAlphaOfLength(127);
+        assertRead(passphrase + "\n", passphrase);
+        assertRead(passphrase + "\r\n", passphrase);
+    }
+
     private void assertRead(String source, String expected) {
         try (StringReader reader = new StringReader(source)) {
             char[] result = readLineToCharArray(reader);


### PR DESCRIPTION
Backports the following commits to 8.4:
 - Fix carriage return removal when reading a long line from terminal (#91131)