### PR TITLE
`buildFromRoleDescriptor` uses application privilege look up

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/permission/Role.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/permission/Role.java
@@ -319,7 +319,7 @@ public interface Role {
         final FieldPermissionsCache fieldPermissionsCache,
         final RestrictedIndices restrictedIndices
     ) {
-        return Role.buildFromRoleDescriptor(roleDescriptor, fieldPermissionsCache, restrictedIndices, List.of());
+        return buildFromRoleDescriptor(roleDescriptor, fieldPermissionsCache, restrictedIndices, List.of());
     }
 
     static SimpleRole buildFromRoleDescriptor(

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/permission/Role.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/permission/Role.java
@@ -319,6 +319,15 @@ public interface Role {
         final FieldPermissionsCache fieldPermissionsCache,
         final RestrictedIndices restrictedIndices
     ) {
+        return Role.buildFromRoleDescriptor(roleDescriptor, fieldPermissionsCache, restrictedIndices, List.of());
+    }
+
+    static SimpleRole buildFromRoleDescriptor(
+        final RoleDescriptor roleDescriptor,
+        final FieldPermissionsCache fieldPermissionsCache,
+        final RestrictedIndices restrictedIndices,
+        final Collection<ApplicationPrivilegeDescriptor> storedApplicationPrivilegeDescriptors
+    ) {
         // TODO handle this when we introduce remote index privileges for built-in users and roles. That's the only production code
         // using this builder
         assert false == roleDescriptor.hasRemoteIndicesPrivileges();
@@ -344,14 +353,11 @@ public interface Role {
         }
 
         for (RoleDescriptor.ApplicationResourcePrivileges applicationPrivilege : roleDescriptor.getApplicationPrivileges()) {
-            builder.addApplicationPrivilege(
-                new ApplicationPrivilege(
-                    applicationPrivilege.getApplication(),
-                    Sets.newHashSet(applicationPrivilege.getPrivileges()),
-                    applicationPrivilege.getPrivileges()
-                ),
-                Sets.newHashSet(applicationPrivilege.getResources())
-            );
+            ApplicationPrivilege.get(
+                applicationPrivilege.getApplication(),
+                Sets.newHashSet(applicationPrivilege.getPrivileges()),
+                storedApplicationPrivilegeDescriptors
+            ).forEach(priv -> builder.addApplicationPrivilege(priv, Sets.newHashSet(applicationPrivilege.getResources())));
         }
 
         final String[] rdRunAs = roleDescriptor.getRunAs();

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/permission/SimpleRoleTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/permission/SimpleRoleTests.java
@@ -111,7 +111,8 @@ public class SimpleRoleTests extends ESTestCase {
                 ),
             is(true)
         );
-        // This gives decent but not complete coverage of denial cases; for any non-wildcard field we pick a mismatched value
+        // This gives decent but not complete coverage of denial cases; for any non-wildcard field we pick a mismatched value to force a
+        // denial
         assertThat(
             "expected grant for role with application privilege to be: " + applicationPrivilege,
             role.application()

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/permission/SimpleRoleTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/permission/SimpleRoleTests.java
@@ -68,7 +68,7 @@ public class SimpleRoleTests extends ESTestCase {
         final boolean wildcardResources = randomBoolean();
         final RoleDescriptor.ApplicationResourcePrivileges applicationPrivilege = RoleDescriptor.ApplicationResourcePrivileges.builder()
             .application(wildcardApplication ? "*" : randomAlphaOfLengthBetween(5, 12))
-            // concrete privileges need to be prefixed with lower case letter, so use "app"
+            // concrete privileges need to be prefixed with lower case letters to be considered valid, so use "app"
             .privileges(wildcardPrivileges ? "*" : "app" + randomAlphaOfLengthBetween(5, 12))
             .resources(wildcardResources ? new String[] { "*" } : generateRandomStringArray(6, randomIntBetween(4, 8), false, false))
             .build();

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStoreTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStoreTests.java
@@ -1143,11 +1143,12 @@ public class ReservedRolesStoreTests extends ESTestCase {
         assertThat(roleDescriptor.getMetadata(), hasEntry("_reserved", true));
         assertThat(roleDescriptor.getMetadata(), not(hasEntry("_deprecated", true)));
 
+        final String allowedApplicationActionPattern = "example/custom/action/*";
         Role kibanaAdminRole = Role.buildFromRoleDescriptor(
             roleDescriptor,
             new FieldPermissionsCache(Settings.EMPTY),
             RESTRICTED_INDICES,
-            List.of(new ApplicationPrivilegeDescriptor("kibana-.kibana", "all", Set.of("all"), Map.of()))
+            List.of(new ApplicationPrivilegeDescriptor("kibana-.kibana", "all", Set.of(allowedApplicationActionPattern), Map.of()))
         );
         assertThat(kibanaAdminRole.cluster().check(ClusterHealthAction.NAME, request, authentication), is(false));
         assertThat(kibanaAdminRole.cluster().check(ClusterStateAction.NAME, request, authentication), is(false));
@@ -1172,7 +1173,10 @@ public class ReservedRolesStoreTests extends ESTestCase {
 
         final String application = "kibana-.kibana";
         assertThat(kibanaAdminRole.application().grants(new ApplicationPrivilege(application, "app-foo", "foo"), "*"), is(false));
-        assertThat(kibanaAdminRole.application().grants(new ApplicationPrivilege(application, "app-all", "all"), "*"), is(true));
+        assertThat(
+            kibanaAdminRole.application().grants(new ApplicationPrivilege(application, "app-all", allowedApplicationActionPattern), "*"),
+            is(true)
+        );
 
         final String applicationWithRandomIndex = "kibana-.kibana_" + randomAlphaOfLengthBetween(8, 24);
         assertThat(
@@ -1192,11 +1196,12 @@ public class ReservedRolesStoreTests extends ESTestCase {
         assertThat(roleDescriptor.getMetadata(), hasEntry("_reserved", true));
         assertThat(roleDescriptor.getMetadata(), hasEntry("_deprecated", true));
 
+        final String allowedApplicationActionPattern = "example/custom/action/*";
         Role kibanaUserRole = Role.buildFromRoleDescriptor(
             roleDescriptor,
             new FieldPermissionsCache(Settings.EMPTY),
             RESTRICTED_INDICES,
-            List.of(new ApplicationPrivilegeDescriptor("kibana-.kibana", "all", Set.of("all"), Map.of()))
+            List.of(new ApplicationPrivilegeDescriptor("kibana-.kibana", "all", Set.of(allowedApplicationActionPattern), Map.of()))
         );
         assertThat(kibanaUserRole.cluster().check(ClusterHealthAction.NAME, request, authentication), is(false));
         assertThat(kibanaUserRole.cluster().check(ClusterStateAction.NAME, request, authentication), is(false));
@@ -1217,15 +1222,23 @@ public class ReservedRolesStoreTests extends ESTestCase {
         );
 
         final String randomApplication = "kibana-" + randomAlphaOfLengthBetween(8, 24);
-        assertThat(kibanaUserRole.application().grants(new ApplicationPrivilege(randomApplication, "app-random", "all"), "*"), is(false));
+        assertThat(
+            kibanaUserRole.application()
+                .grants(new ApplicationPrivilege(randomApplication, "app-random", allowedApplicationActionPattern), "*"),
+            is(false)
+        );
 
         final String application = "kibana-.kibana";
         assertThat(kibanaUserRole.application().grants(new ApplicationPrivilege(application, "app-foo", "foo"), "*"), is(false));
-        assertThat(kibanaUserRole.application().grants(new ApplicationPrivilege(application, "app-all", "all"), "*"), is(true));
+        assertThat(
+            kibanaUserRole.application().grants(new ApplicationPrivilege(application, "app-all", allowedApplicationActionPattern), "*"),
+            is(true)
+        );
 
         final String applicationWithRandomIndex = "kibana-.kibana_" + randomAlphaOfLengthBetween(8, 24);
         assertThat(
-            kibanaUserRole.application().grants(new ApplicationPrivilege(applicationWithRandomIndex, "app-random-index", "all"), "*"),
+            kibanaUserRole.application()
+                .grants(new ApplicationPrivilege(applicationWithRandomIndex, "app-random-index", allowedApplicationActionPattern), "*"),
             is(false)
         );
 
@@ -1241,11 +1254,14 @@ public class ReservedRolesStoreTests extends ESTestCase {
         assertNotNull(roleDescriptor);
         assertThat(roleDescriptor.getMetadata(), hasEntry("_reserved", true));
 
+        final String allowedApplicationActionPattern = "example/custom/action/*";
         Role monitoringUserRole = Role.buildFromRoleDescriptor(
             roleDescriptor,
             new FieldPermissionsCache(Settings.EMPTY),
             RESTRICTED_INDICES,
-            List.of(new ApplicationPrivilegeDescriptor("kibana-*", "reserved_monitoring", Set.of("reserved_monitoring"), Map.of()))
+            List.of(
+                new ApplicationPrivilegeDescriptor("kibana-*", "reserved_monitoring", Set.of(allowedApplicationActionPattern), Map.of())
+            )
         );
         assertThat(monitoringUserRole.cluster().check(MainAction.NAME, request, authentication), is(true));
         assertThat(monitoringUserRole.cluster().check(XPackInfoAction.NAME, request, authentication), is(true));
@@ -1314,7 +1330,10 @@ public class ReservedRolesStoreTests extends ESTestCase {
         );
         assertThat(
             monitoringUserRole.application()
-                .grants(new ApplicationPrivilege(kibanaApplicationWithRandomIndex, "app-reserved_monitoring", "reserved_monitoring"), "*"),
+                .grants(
+                    new ApplicationPrivilege(kibanaApplicationWithRandomIndex, "app-reserved_monitoring", allowedApplicationActionPattern),
+                    "*"
+                ),
             is(true)
         );
 
@@ -1322,7 +1341,7 @@ public class ReservedRolesStoreTests extends ESTestCase {
         assertThat(monitoringUserRole.application().grants(new ApplicationPrivilege(otherApplication, "app-foo", "foo"), "*"), is(false));
         assertThat(
             monitoringUserRole.application()
-                .grants(new ApplicationPrivilege(otherApplication, "app-reserved_monitoring", "reserved_monitoring"), "*"),
+                .grants(new ApplicationPrivilege(otherApplication, "app-reserved_monitoring", allowedApplicationActionPattern), "*"),
             is(false)
         );
     }
@@ -2150,11 +2169,14 @@ public class ReservedRolesStoreTests extends ESTestCase {
         assertNotNull(roleDescriptor);
         assertThat(roleDescriptor.getMetadata(), hasEntry("_reserved", true));
 
+        final String allowedApplicationActionPattern = "example/custom/action/*";
         Role role = Role.buildFromRoleDescriptor(
             roleDescriptor,
             new FieldPermissionsCache(Settings.EMPTY),
             RESTRICTED_INDICES,
-            List.of(new ApplicationPrivilegeDescriptor("kibana-*", "reserved_ml_apm_user", Set.of("reserved_ml_apm_user"), Map.of()))
+            List.of(
+                new ApplicationPrivilegeDescriptor("kibana-*", "reserved_ml_apm_user", Set.of(allowedApplicationActionPattern), Map.of())
+            )
         );
 
         assertThat(role.cluster().check(DelegatePkiAuthenticationAction.NAME, request, authentication), is(false));
@@ -2185,7 +2207,7 @@ public class ReservedRolesStoreTests extends ESTestCase {
         assertThat(
             role.application()
                 .grants(
-                    new ApplicationPrivilege(kibanaApplicationWithRandomIndex, "app-reserved_ml_apm_user", "reserved_ml_apm_user"),
+                    new ApplicationPrivilege(kibanaApplicationWithRandomIndex, "app-reserved_ml_apm_user", allowedApplicationActionPattern),
                     "*"
                 ),
             is(true)
@@ -2194,7 +2216,8 @@ public class ReservedRolesStoreTests extends ESTestCase {
         final String otherApplication = "logstash-" + randomAlphaOfLengthBetween(8, 24);
         assertThat(role.application().grants(new ApplicationPrivilege(otherApplication, "app-foo", "foo"), "*"), is(false));
         assertThat(
-            role.application().grants(new ApplicationPrivilege(otherApplication, "app-reserved_ml_apm_user", "reserved_ml_apm_user"), "*"),
+            role.application()
+                .grants(new ApplicationPrivilege(otherApplication, "app-reserved_ml_apm_user", allowedApplicationActionPattern), "*"),
             is(false)
         );
     }
@@ -2207,11 +2230,12 @@ public class ReservedRolesStoreTests extends ESTestCase {
         assertNotNull(roleDescriptor);
         assertThat(roleDescriptor.getMetadata(), hasEntry("_reserved", true));
 
+        final String allowedApplicationActionPattern = "example/custom/action/*";
         Role role = Role.buildFromRoleDescriptor(
             roleDescriptor,
             new FieldPermissionsCache(Settings.EMPTY),
             RESTRICTED_INDICES,
-            List.of(new ApplicationPrivilegeDescriptor("kibana-*", "reserved_ml_admin", Set.of("reserved_ml_admin"), Map.of()))
+            List.of(new ApplicationPrivilegeDescriptor("kibana-*", "reserved_ml_admin", Set.of(allowedApplicationActionPattern), Map.of()))
         );
         assertRoleHasManageMl(role);
         assertThat(role.cluster().check(DelegatePkiAuthenticationAction.NAME, request, authentication), is(false));
@@ -2233,14 +2257,17 @@ public class ReservedRolesStoreTests extends ESTestCase {
         assertThat(role.application().grants(new ApplicationPrivilege(kibanaApplicationWithRandomIndex, "app-foo", "foo"), "*"), is(false));
         assertThat(
             role.application()
-                .grants(new ApplicationPrivilege(kibanaApplicationWithRandomIndex, "app-reserved_ml", "reserved_ml_admin"), "*"),
+                .grants(
+                    new ApplicationPrivilege(kibanaApplicationWithRandomIndex, "app-reserved_ml", allowedApplicationActionPattern),
+                    "*"
+                ),
             is(true)
         );
 
         final String otherApplication = "logstash-" + randomAlphaOfLengthBetween(8, 24);
         assertThat(role.application().grants(new ApplicationPrivilege(otherApplication, "app-foo", "foo"), "*"), is(false));
         assertThat(
-            role.application().grants(new ApplicationPrivilege(otherApplication, "app-reserved_ml", "reserved_ml_admin"), "*"),
+            role.application().grants(new ApplicationPrivilege(otherApplication, "app-reserved_ml", allowedApplicationActionPattern), "*"),
             is(false)
         );
     }
@@ -2322,11 +2349,12 @@ public class ReservedRolesStoreTests extends ESTestCase {
         assertNotNull(roleDescriptor);
         assertThat(roleDescriptor.getMetadata(), hasEntry("_reserved", true));
 
+        final String allowedApplicationActionPattern = "example/custom/action/*";
         Role role = Role.buildFromRoleDescriptor(
             roleDescriptor,
             new FieldPermissionsCache(Settings.EMPTY),
             RESTRICTED_INDICES,
-            List.of(new ApplicationPrivilegeDescriptor("kibana-*", "reserved_ml_user", Set.of("reserved_ml_user"), Map.of()))
+            List.of(new ApplicationPrivilegeDescriptor("kibana-*", "reserved_ml_user", Set.of(allowedApplicationActionPattern), Map.of()))
         );
         assertThat(role.cluster().check(CloseJobAction.NAME, request, authentication), is(false));
         assertThat(role.cluster().check(DeleteCalendarAction.NAME, request, authentication), is(false));
@@ -2401,14 +2429,17 @@ public class ReservedRolesStoreTests extends ESTestCase {
         assertThat(role.application().grants(new ApplicationPrivilege(kibanaApplicationWithRandomIndex, "app-foo", "foo"), "*"), is(false));
         assertThat(
             role.application()
-                .grants(new ApplicationPrivilege(kibanaApplicationWithRandomIndex, "app-reserved_ml", "reserved_ml_user"), "*"),
+                .grants(
+                    new ApplicationPrivilege(kibanaApplicationWithRandomIndex, "app-reserved_ml", allowedApplicationActionPattern),
+                    "*"
+                ),
             is(true)
         );
 
         final String otherApplication = "logstash-" + randomAlphaOfLengthBetween(8, 24);
         assertThat(role.application().grants(new ApplicationPrivilege(otherApplication, "app-foo", "foo"), "*"), is(false));
         assertThat(
-            role.application().grants(new ApplicationPrivilege(otherApplication, "app-reserved_ml", "reserved_ml_user"), "*"),
+            role.application().grants(new ApplicationPrivilege(otherApplication, "app-reserved_ml", allowedApplicationActionPattern), "*"),
             is(false)
         );
     }
@@ -2430,8 +2461,11 @@ public class ReservedRolesStoreTests extends ESTestCase {
                 assertThat(roleDescriptor.getMetadata(), not(hasEntry("_deprecated", true)));
             }
 
+            final String allowedApplicationActionPattern = "example/custom/action/*";
             List<ApplicationPrivilegeDescriptor> lookup = roleDescriptor.getName().equals("data_frame_transforms_admin")
-                ? List.of(new ApplicationPrivilegeDescriptor("kibana-*", "reserved_ml_user", Set.of("reserved_ml_user"), Map.of()))
+                ? List.of(
+                    new ApplicationPrivilegeDescriptor("kibana-*", "reserved_ml_user", Set.of(allowedApplicationActionPattern), Map.of())
+                )
                 : List.of();
             Role role = Role.buildFromRoleDescriptor(roleDescriptor, new FieldPermissionsCache(Settings.EMPTY), RESTRICTED_INDICES, lookup);
             assertThat(role.cluster().check(DeleteTransformAction.NAME, request, authentication), is(true));
@@ -2463,7 +2497,10 @@ public class ReservedRolesStoreTests extends ESTestCase {
             if (roleDescriptor.getName().equals("data_frame_transforms_admin")) {
                 assertThat(
                     role.application()
-                        .grants(new ApplicationPrivilege(kibanaApplicationWithRandomIndex, "app-reserved_ml", "reserved_ml_user"), "*"),
+                        .grants(
+                            new ApplicationPrivilege(kibanaApplicationWithRandomIndex, "app-reserved_ml", allowedApplicationActionPattern),
+                            "*"
+                        ),
                     is(true)
                 );
             }
@@ -2472,7 +2509,8 @@ public class ReservedRolesStoreTests extends ESTestCase {
             assertThat(role.application().grants(new ApplicationPrivilege(otherApplication, "app-foo", "foo"), "*"), is(false));
             if (roleDescriptor.getName().equals("data_frame_transforms_admin")) {
                 assertThat(
-                    role.application().grants(new ApplicationPrivilege(otherApplication, "app-reserved_ml", "reserved_ml_user"), "*"),
+                    role.application()
+                        .grants(new ApplicationPrivilege(otherApplication, "app-reserved_ml", allowedApplicationActionPattern), "*"),
                     is(false)
                 );
             }
@@ -2496,8 +2534,11 @@ public class ReservedRolesStoreTests extends ESTestCase {
                 assertThat(roleDescriptor.getMetadata(), not(hasEntry("_deprecated", true)));
             }
 
+            final String allowedApplicationActionPattern = "example/custom/action/*";
             List<ApplicationPrivilegeDescriptor> lookup = roleDescriptor.getName().equals("data_frame_transforms_user")
-                ? List.of(new ApplicationPrivilegeDescriptor("kibana-*", "reserved_ml_user", Set.of("reserved_ml_user"), Map.of()))
+                ? List.of(
+                    new ApplicationPrivilegeDescriptor("kibana-*", "reserved_ml_user", Set.of(allowedApplicationActionPattern), Map.of())
+                )
                 : List.of();
             Role role = Role.buildFromRoleDescriptor(roleDescriptor, new FieldPermissionsCache(Settings.EMPTY), RESTRICTED_INDICES, lookup);
             assertThat(role.cluster().check(DeleteTransformAction.NAME, request, authentication), is(false));
@@ -2534,7 +2575,10 @@ public class ReservedRolesStoreTests extends ESTestCase {
             if (roleDescriptor.getName().equals("data_frame_transforms_user")) {
                 assertThat(
                     role.application()
-                        .grants(new ApplicationPrivilege(kibanaApplicationWithRandomIndex, "app-reserved_ml", "reserved_ml_user"), "*"),
+                        .grants(
+                            new ApplicationPrivilege(kibanaApplicationWithRandomIndex, "app-reserved_ml", allowedApplicationActionPattern),
+                            "*"
+                        ),
                     is(true)
                 );
             }
@@ -2543,7 +2587,8 @@ public class ReservedRolesStoreTests extends ESTestCase {
             assertThat(role.application().grants(new ApplicationPrivilege(otherApplication, "app-foo", "foo"), "*"), is(false));
             if (roleDescriptor.getName().equals("data_frame_transforms_user")) {
                 assertThat(
-                    role.application().grants(new ApplicationPrivilege(otherApplication, "app-reserved_ml", "reserved_ml_user"), "*"),
+                    role.application()
+                        .grants(new ApplicationPrivilege(otherApplication, "app-reserved_ml", allowedApplicationActionPattern), "*"),
                     is(false)
                 );
             }
@@ -2624,11 +2669,12 @@ public class ReservedRolesStoreTests extends ESTestCase {
         assertNotNull(roleDescriptor);
         assertThat(roleDescriptor.getMetadata(), hasEntry("_reserved", true));
 
+        final String allowedApplicationActionPattern = "example/custom/action/*";
         Role role = Role.buildFromRoleDescriptor(
             roleDescriptor,
             new FieldPermissionsCache(Settings.EMPTY),
             RESTRICTED_INDICES,
-            List.of(new ApplicationPrivilegeDescriptor("kibana-.kibana", "read", Set.of("read"), Map.of()))
+            List.of(new ApplicationPrivilegeDescriptor("kibana-.kibana", "read", Set.of(allowedApplicationActionPattern), Map.of()))
         );
         // No cluster privileges
         assertThat(role.cluster().check(ClusterHealthAction.NAME, request, authentication), is(false));
@@ -2673,7 +2719,10 @@ public class ReservedRolesStoreTests extends ESTestCase {
         assertNoAccessAllowed(role, "." + randomAlphaOfLengthBetween(6, 10));
         assertNoAccessAllowed(role, "ilm-history-" + randomIntBetween(0, 5));
         // Check application privileges
-        assertThat(role.application().grants(new ApplicationPrivilege("kibana-.kibana", "kibana-read", "read"), "*"), is(true));
+        assertThat(
+            role.application().grants(new ApplicationPrivilege("kibana-.kibana", "kibana-read", allowedApplicationActionPattern), "*"),
+            is(true)
+        );
         assertThat(role.application().grants(new ApplicationPrivilege("kibana-.kibana", "kibana-all", "all"), "*"), is(false));
 
         assertThat(role.runAs().check(randomAlphaOfLengthBetween(1, 20)), is(false));
@@ -2687,11 +2736,12 @@ public class ReservedRolesStoreTests extends ESTestCase {
         assertNotNull(roleDescriptor);
         assertThat(roleDescriptor.getMetadata(), hasEntry("_reserved", true));
 
+        final String allowedApplicationActionPattern = "example/custom/action/*";
         Role role = Role.buildFromRoleDescriptor(
             roleDescriptor,
             new FieldPermissionsCache(Settings.EMPTY),
             RESTRICTED_INDICES,
-            List.of(new ApplicationPrivilegeDescriptor("kibana-.kibana", "all", Set.of("all"), Map.of()))
+            List.of(new ApplicationPrivilegeDescriptor("kibana-.kibana", "all", Set.of(allowedApplicationActionPattern), Map.of()))
         );
 
         // No cluster privileges
@@ -2742,7 +2792,10 @@ public class ReservedRolesStoreTests extends ESTestCase {
         assertNoAccessAllowed(role, "ilm-history-" + randomIntBetween(0, 5));
 
         // Check application privileges
-        assertThat(role.application().grants(new ApplicationPrivilege("kibana-.kibana", "kibana-all", "all"), "*"), is(true));
+        assertThat(
+            role.application().grants(new ApplicationPrivilege("kibana-.kibana", "kibana-all", allowedApplicationActionPattern), "*"),
+            is(true)
+        );
 
         assertThat(role.runAs().check(randomAlphaOfLengthBetween(1, 20)), is(false));
     }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStoreTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStoreTests.java
@@ -1255,12 +1255,18 @@ public class ReservedRolesStoreTests extends ESTestCase {
         assertThat(roleDescriptor.getMetadata(), hasEntry("_reserved", true));
 
         final String allowedApplicationActionPattern = "example/custom/action/*";
+        final String kibanaApplicationWithRandomIndex = "kibana-" + randomFrom(randomAlphaOfLengthBetween(8, 24), ".kibana");
         Role monitoringUserRole = Role.buildFromRoleDescriptor(
             roleDescriptor,
             new FieldPermissionsCache(Settings.EMPTY),
             RESTRICTED_INDICES,
             List.of(
-                new ApplicationPrivilegeDescriptor("kibana-*", "reserved_monitoring", Set.of(allowedApplicationActionPattern), Map.of())
+                new ApplicationPrivilegeDescriptor(
+                    kibanaApplicationWithRandomIndex,
+                    "reserved_monitoring",
+                    Set.of(allowedApplicationActionPattern),
+                    Map.of()
+                )
             )
         );
         assertThat(monitoringUserRole.cluster().check(MainAction.NAME, request, authentication), is(true));
@@ -1323,7 +1329,6 @@ public class ReservedRolesStoreTests extends ESTestCase {
         assertNoAccessAllowed(monitoringUserRole, TestRestrictedIndices.SAMPLE_RESTRICTED_NAMES);
         assertNoAccessAllowed(monitoringUserRole, XPackPlugin.ASYNC_RESULTS_INDEX + randomAlphaOfLengthBetween(0, 2));
 
-        final String kibanaApplicationWithRandomIndex = "kibana-" + randomFrom(randomAlphaOfLengthBetween(8, 24), ".kibana");
         assertThat(
             monitoringUserRole.application().grants(new ApplicationPrivilege(kibanaApplicationWithRandomIndex, "app-foo", "foo"), "*"),
             is(false)
@@ -2170,12 +2175,18 @@ public class ReservedRolesStoreTests extends ESTestCase {
         assertThat(roleDescriptor.getMetadata(), hasEntry("_reserved", true));
 
         final String allowedApplicationActionPattern = "example/custom/action/*";
+        final String kibanaApplicationWithRandomIndex = "kibana-" + randomFrom(randomAlphaOfLengthBetween(8, 24), ".kibana");
         Role role = Role.buildFromRoleDescriptor(
             roleDescriptor,
             new FieldPermissionsCache(Settings.EMPTY),
             RESTRICTED_INDICES,
             List.of(
-                new ApplicationPrivilegeDescriptor("kibana-*", "reserved_ml_apm_user", Set.of(allowedApplicationActionPattern), Map.of())
+                new ApplicationPrivilegeDescriptor(
+                    kibanaApplicationWithRandomIndex,
+                    "reserved_ml_apm_user",
+                    Set.of(allowedApplicationActionPattern),
+                    Map.of()
+                )
             )
         );
 
@@ -2202,7 +2213,6 @@ public class ReservedRolesStoreTests extends ESTestCase {
 
         assertOnlyReadAllowed(role, "observability-annotations");
 
-        final String kibanaApplicationWithRandomIndex = "kibana-" + randomFrom(randomAlphaOfLengthBetween(8, 24), ".kibana");
         assertThat(role.application().grants(new ApplicationPrivilege(kibanaApplicationWithRandomIndex, "app-foo", "foo"), "*"), is(false));
         assertThat(
             role.application()
@@ -2231,11 +2241,19 @@ public class ReservedRolesStoreTests extends ESTestCase {
         assertThat(roleDescriptor.getMetadata(), hasEntry("_reserved", true));
 
         final String allowedApplicationActionPattern = "example/custom/action/*";
+        final String kibanaApplicationWithRandomIndex = "kibana-" + randomFrom(randomAlphaOfLengthBetween(8, 24), ".kibana");
         Role role = Role.buildFromRoleDescriptor(
             roleDescriptor,
             new FieldPermissionsCache(Settings.EMPTY),
             RESTRICTED_INDICES,
-            List.of(new ApplicationPrivilegeDescriptor("kibana-*", "reserved_ml_admin", Set.of(allowedApplicationActionPattern), Map.of()))
+            List.of(
+                new ApplicationPrivilegeDescriptor(
+                    kibanaApplicationWithRandomIndex,
+                    "reserved_ml_admin",
+                    Set.of(allowedApplicationActionPattern),
+                    Map.of()
+                )
+            )
         );
         assertRoleHasManageMl(role);
         assertThat(role.cluster().check(DelegatePkiAuthenticationAction.NAME, request, authentication), is(false));
@@ -2253,7 +2271,6 @@ public class ReservedRolesStoreTests extends ESTestCase {
         assertNoAccessAllowed(role, TestRestrictedIndices.SAMPLE_RESTRICTED_NAMES);
         assertNoAccessAllowed(role, XPackPlugin.ASYNC_RESULTS_INDEX + randomAlphaOfLengthBetween(0, 2));
 
-        final String kibanaApplicationWithRandomIndex = "kibana-" + randomFrom(randomAlphaOfLengthBetween(8, 24), ".kibana");
         assertThat(role.application().grants(new ApplicationPrivilege(kibanaApplicationWithRandomIndex, "app-foo", "foo"), "*"), is(false));
         assertThat(
             role.application()
@@ -2350,11 +2367,19 @@ public class ReservedRolesStoreTests extends ESTestCase {
         assertThat(roleDescriptor.getMetadata(), hasEntry("_reserved", true));
 
         final String allowedApplicationActionPattern = "example/custom/action/*";
+        final String kibanaApplicationWithRandomIndex = "kibana-" + randomFrom(randomAlphaOfLengthBetween(8, 24), ".kibana");
         Role role = Role.buildFromRoleDescriptor(
             roleDescriptor,
             new FieldPermissionsCache(Settings.EMPTY),
             RESTRICTED_INDICES,
-            List.of(new ApplicationPrivilegeDescriptor("kibana-*", "reserved_ml_user", Set.of(allowedApplicationActionPattern), Map.of()))
+            List.of(
+                new ApplicationPrivilegeDescriptor(
+                    kibanaApplicationWithRandomIndex,
+                    "reserved_ml_user",
+                    Set.of(allowedApplicationActionPattern),
+                    Map.of()
+                )
+            )
         );
         assertThat(role.cluster().check(CloseJobAction.NAME, request, authentication), is(false));
         assertThat(role.cluster().check(DeleteCalendarAction.NAME, request, authentication), is(false));
@@ -2425,7 +2450,6 @@ public class ReservedRolesStoreTests extends ESTestCase {
         assertNoAccessAllowed(role, TestRestrictedIndices.SAMPLE_RESTRICTED_NAMES);
         assertNoAccessAllowed(role, XPackPlugin.ASYNC_RESULTS_INDEX + randomAlphaOfLengthBetween(0, 2));
 
-        final String kibanaApplicationWithRandomIndex = "kibana-" + randomFrom(randomAlphaOfLengthBetween(8, 24), ".kibana");
         assertThat(role.application().grants(new ApplicationPrivilege(kibanaApplicationWithRandomIndex, "app-foo", "foo"), "*"), is(false));
         assertThat(
             role.application()
@@ -2462,9 +2486,15 @@ public class ReservedRolesStoreTests extends ESTestCase {
             }
 
             final String allowedApplicationActionPattern = "example/custom/action/*";
+            final String kibanaApplicationWithRandomIndex = "kibana-" + randomFrom(randomAlphaOfLengthBetween(8, 24), ".kibana");
             List<ApplicationPrivilegeDescriptor> lookup = roleDescriptor.getName().equals("data_frame_transforms_admin")
                 ? List.of(
-                    new ApplicationPrivilegeDescriptor("kibana-*", "reserved_ml_user", Set.of(allowedApplicationActionPattern), Map.of())
+                    new ApplicationPrivilegeDescriptor(
+                        kibanaApplicationWithRandomIndex,
+                        "reserved_ml_user",
+                        Set.of(allowedApplicationActionPattern),
+                        Map.of()
+                    )
                 )
                 : List.of();
             Role role = Role.buildFromRoleDescriptor(roleDescriptor, new FieldPermissionsCache(Settings.EMPTY), RESTRICTED_INDICES, lookup);
@@ -2488,7 +2518,6 @@ public class ReservedRolesStoreTests extends ESTestCase {
             assertNoAccessAllowed(role, TestRestrictedIndices.SAMPLE_RESTRICTED_NAMES);
             assertNoAccessAllowed(role, XPackPlugin.ASYNC_RESULTS_INDEX + randomAlphaOfLengthBetween(0, 2));
 
-            final String kibanaApplicationWithRandomIndex = "kibana-" + randomFrom(randomAlphaOfLengthBetween(8, 24), ".kibana");
             assertThat(
                 role.application().grants(new ApplicationPrivilege(kibanaApplicationWithRandomIndex, "app-foo", "foo"), "*"),
                 is(false)
@@ -2535,9 +2564,15 @@ public class ReservedRolesStoreTests extends ESTestCase {
             }
 
             final String allowedApplicationActionPattern = "example/custom/action/*";
+            final String kibanaApplicationWithRandomIndex = "kibana-" + randomFrom(randomAlphaOfLengthBetween(8, 24), ".kibana");
             List<ApplicationPrivilegeDescriptor> lookup = roleDescriptor.getName().equals("data_frame_transforms_user")
                 ? List.of(
-                    new ApplicationPrivilegeDescriptor("kibana-*", "reserved_ml_user", Set.of(allowedApplicationActionPattern), Map.of())
+                    new ApplicationPrivilegeDescriptor(
+                        kibanaApplicationWithRandomIndex,
+                        "reserved_ml_user",
+                        Set.of(allowedApplicationActionPattern),
+                        Map.of()
+                    )
                 )
                 : List.of();
             Role role = Role.buildFromRoleDescriptor(roleDescriptor, new FieldPermissionsCache(Settings.EMPTY), RESTRICTED_INDICES, lookup);
@@ -2566,7 +2601,6 @@ public class ReservedRolesStoreTests extends ESTestCase {
             assertNoAccessAllowed(role, TestRestrictedIndices.SAMPLE_RESTRICTED_NAMES);
             assertNoAccessAllowed(role, XPackPlugin.ASYNC_RESULTS_INDEX + randomAlphaOfLengthBetween(0, 2));
 
-            final String kibanaApplicationWithRandomIndex = "kibana-" + randomFrom(randomAlphaOfLengthBetween(8, 24), ".kibana");
             assertThat(
                 role.application().grants(new ApplicationPrivilege(kibanaApplicationWithRandomIndex, "app-foo", "foo"), "*"),
                 is(false)

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/service/ElasticServiceAccountsTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/service/ElasticServiceAccountsTests.java
@@ -150,12 +150,18 @@ public class ElasticServiceAccountsTests extends ESTestCase {
 
     public void testElasticFleetServerPrivileges() {
         final String allowedApplicationActionPattern = "example/custom/action/*";
+        final String kibanaApplication = "kibana-" + randomFrom(randomAlphaOfLengthBetween(8, 24), ".kibana");
         final Role role = Role.buildFromRoleDescriptor(
             ElasticServiceAccounts.ACCOUNTS.get("elastic/fleet-server").roleDescriptor(),
             new FieldPermissionsCache(Settings.EMPTY),
             RESTRICTED_INDICES,
             List.of(
-                new ApplicationPrivilegeDescriptor("kibana-*", "reserved_fleet-setup", Set.of(allowedApplicationActionPattern), Map.of())
+                new ApplicationPrivilegeDescriptor(
+                    kibanaApplication,
+                    "reserved_fleet-setup",
+                    Set.of(allowedApplicationActionPattern),
+                    Map.of()
+                )
             )
         );
         final Authentication authentication = AuthenticationTestHelper.builder().serviceAccount().build();
@@ -242,7 +248,6 @@ public class ElasticServiceAccountsTests extends ESTestCase {
         assertThat(role.indices().allowedIndicesMatcher(DeleteIndexAction.NAME).test(apmSampledTracesIndex), is(false));
         assertThat(role.indices().allowedIndicesMatcher(UpdateSettingsAction.NAME).test(apmSampledTracesIndex), is(false));
 
-        final String kibanaApplication = "kibana-" + randomFrom(randomAlphaOfLengthBetween(8, 24), ".kibana");
         final String privilegeName = randomAlphaOfLengthBetween(3, 16);
         assertThat(
             role.application().grants(new ApplicationPrivilege(kibanaApplication, privilegeName, allowedApplicationActionPattern), "*"),

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/service/ElasticServiceAccountsTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/service/ElasticServiceAccountsTests.java
@@ -111,6 +111,7 @@ import org.elasticsearch.xpack.core.security.authz.RoleDescriptor;
 import org.elasticsearch.xpack.core.security.authz.permission.FieldPermissionsCache;
 import org.elasticsearch.xpack.core.security.authz.permission.Role;
 import org.elasticsearch.xpack.core.security.authz.privilege.ApplicationPrivilege;
+import org.elasticsearch.xpack.core.security.authz.privilege.ApplicationPrivilegeDescriptor;
 import org.elasticsearch.xpack.core.security.authz.store.ReservedRolesStore;
 import org.elasticsearch.xpack.core.security.user.KibanaSystemUser;
 import org.elasticsearch.xpack.core.security.user.User;
@@ -119,6 +120,7 @@ import org.elasticsearch.xpack.security.authc.service.ElasticServiceAccounts.Ela
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import static org.elasticsearch.xpack.core.security.test.TestRestrictedIndices.RESTRICTED_INDICES;
 import static org.hamcrest.Matchers.containsString;
@@ -150,7 +152,8 @@ public class ElasticServiceAccountsTests extends ESTestCase {
         final Role role = Role.buildFromRoleDescriptor(
             ElasticServiceAccounts.ACCOUNTS.get("elastic/fleet-server").roleDescriptor(),
             new FieldPermissionsCache(Settings.EMPTY),
-            RESTRICTED_INDICES
+            RESTRICTED_INDICES,
+            List.of(new ApplicationPrivilegeDescriptor("kibana-*", "reserved_fleet-setup", Set.of("reserved_fleet-setup"), Map.of()))
         );
         final Authentication authentication = AuthenticationTestHelper.builder().serviceAccount().build();
         assertThat(

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/service/ElasticServiceAccountsTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/service/ElasticServiceAccountsTests.java
@@ -149,11 +149,14 @@ public class ElasticServiceAccountsTests extends ESTestCase {
     }
 
     public void testElasticFleetServerPrivileges() {
+        final String allowedApplicationActionPattern = "example/custom/action/*";
         final Role role = Role.buildFromRoleDescriptor(
             ElasticServiceAccounts.ACCOUNTS.get("elastic/fleet-server").roleDescriptor(),
             new FieldPermissionsCache(Settings.EMPTY),
             RESTRICTED_INDICES,
-            List.of(new ApplicationPrivilegeDescriptor("kibana-*", "reserved_fleet-setup", Set.of("reserved_fleet-setup"), Map.of()))
+            List.of(
+                new ApplicationPrivilegeDescriptor("kibana-*", "reserved_fleet-setup", Set.of(allowedApplicationActionPattern), Map.of())
+            )
         );
         final Authentication authentication = AuthenticationTestHelper.builder().serviceAccount().build();
         assertThat(
@@ -242,7 +245,7 @@ public class ElasticServiceAccountsTests extends ESTestCase {
         final String kibanaApplication = "kibana-" + randomFrom(randomAlphaOfLengthBetween(8, 24), ".kibana");
         final String privilegeName = randomAlphaOfLengthBetween(3, 16);
         assertThat(
-            role.application().grants(new ApplicationPrivilege(kibanaApplication, privilegeName, "reserved_fleet-setup"), "*"),
+            role.application().grants(new ApplicationPrivilege(kibanaApplication, privilegeName, allowedApplicationActionPattern), "*"),
             is(true)
         );
 
@@ -250,7 +253,7 @@ public class ElasticServiceAccountsTests extends ESTestCase {
             + "-"
             + randomAlphaOfLengthBetween(8, 24);
         assertThat(
-            role.application().grants(new ApplicationPrivilege(otherApplication, privilegeName, "reserved_fleet-setup"), "*"),
+            role.application().grants(new ApplicationPrivilege(otherApplication, privilegeName, allowedApplicationActionPattern), "*"),
             is(false)
         );
 

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authz/store/CompositeRolesStoreTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authz/store/CompositeRolesStoreTests.java
@@ -491,6 +491,19 @@ public class CompositeRolesStoreTests extends ESTestCase {
         final Role role = future.actionGet();
         assertThat(role.names(), arrayContaining("superuser"));
         assertThat(role.application().getApplicationNames(), containsInAnyOrder("*"));
+        assertThat(
+            role.application()
+                .grants(
+                    new ApplicationPrivilege(
+                        randomAlphaOfLengthBetween(2, 10),
+                        randomAlphaOfLengthBetween(2, 10),
+                        randomAlphaOfLengthBetween(2, 10)
+                    ),
+                    "*"
+                ),
+            is(true)
+        );
+
         assertThat(role.cluster().privileges(), containsInAnyOrder(ClusterPrivilegeResolver.ALL));
         assertThat(role.indices().check(SearchAction.NAME), Matchers.is(true));
         assertThat(role.indices().check(IndexAction.NAME), Matchers.is(true));


### PR DESCRIPTION
Building a role from a single role descriptor previously only worked
correctly for application privileges with wildcard patterns. This PR
adds support for concrete name look up and ports the relevant tests. 

Relates: https://github.com/elastic/elasticsearch/pull/91107#discussion_r1005107825