### PR TITLE
[8.4] Update threadpool.asciidoc (#90098)

### DIFF
--- a/docs/reference/modules/threadpool.asciidoc
+++ b/docs/reference/modules/threadpool.asciidoc
@@ -177,7 +177,10 @@ thread_pool:
 The number of processors is automatically detected, and the thread pool settings
 are automatically set based on it. In some cases it can be useful to override
 the number of detected processors. This can be done by explicitly setting the
-`node.processors` setting.
+`node.processors` setting. This setting is bounded by the number of available
+processors and accepts floating point numbers, which can be useful in environments
+where the {es} nodes are configured to run with CPU limits, such as cpu
+shares or quota under `Cgroups`. 
 
 [source,yaml]
 --------------------------------------------------


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.4`:
 - [Update threadpool.asciidoc (#90098)](https://github.com/elastic/elasticsearch/pull/90098)

<!--- Backport version: 8.9.3 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)