### PR TITLE
Add extra details in SSL config reload log message

### DIFF
--- a/libs/ssl-config/src/main/java/org/elasticsearch/common/ssl/SslConfiguration.java
+++ b/libs/ssl-config/src/main/java/org/elasticsearch/common/ssl/SslConfiguration.java
@@ -33,6 +33,7 @@ import javax.net.ssl.X509ExtendedTrustManager;
  * from files (see {@link #getDependentFiles()}, and the content of those files may change.
  */
 public record SslConfiguration(
+    String settingPrefix,
     boolean explicitlyConfigured,
     SslTrustConfig trustConfig,
     SslKeyConfig keyConfig,
@@ -68,6 +69,7 @@ public record SslConfiguration(
     }
 
     public SslConfiguration(
+        String settingPrefix,
         boolean explicitlyConfigured,
         SslTrustConfig trustConfig,
         SslKeyConfig keyConfig,
@@ -76,6 +78,7 @@ public record SslConfiguration(
         List<String> ciphers,
         List<String> supportedProtocols
     ) {
+        this.settingPrefix = settingPrefix;
         this.explicitlyConfigured = explicitlyConfigured;
         if (ciphers == null || ciphers.isEmpty()) {
             throw new SslConfigException("cannot configure SSL/TLS without any supported cipher suites");
@@ -160,7 +163,8 @@ public record SslConfiguration(
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         final SslConfiguration that = (SslConfiguration) o;
-        return Objects.equals(this.trustConfig, that.trustConfig)
+        return Objects.equals(this.settingPrefix, that.settingPrefix)
+            && Objects.equals(this.trustConfig, that.trustConfig)
             && Objects.equals(this.keyConfig, that.keyConfig)
             && this.verificationMode == that.verificationMode
             && this.clientAuth == that.clientAuth
@@ -170,7 +174,6 @@ public record SslConfiguration(
 
     @Override
     public int hashCode() {
-        return Objects.hash(trustConfig, keyConfig, verificationMode, clientAuth, ciphers, supportedProtocols);
+        return Objects.hash(settingPrefix, trustConfig, keyConfig, verificationMode, clientAuth, ciphers, supportedProtocols);
     }
-
 }

--- a/libs/ssl-config/src/main/java/org/elasticsearch/common/ssl/SslConfigurationLoader.java
+++ b/libs/ssl-config/src/main/java/org/elasticsearch/common/ssl/SslConfigurationLoader.java
@@ -266,7 +266,16 @@ public abstract class SslConfigurationLoader {
             throw new SslConfigException("no cipher suites configured in [" + settingPrefix + CIPHERS + "]");
         }
         final boolean isExplicitlyConfigured = hasSettings(settingPrefix);
-        return new SslConfiguration(isExplicitlyConfigured, trustConfig, keyConfig, verificationMode, clientAuth, ciphers, protocols);
+        return new SslConfiguration(
+            settingPrefix,
+            isExplicitlyConfigured,
+            trustConfig,
+            keyConfig,
+            verificationMode,
+            clientAuth,
+            ciphers,
+            protocols
+        );
     }
 
     protected SslTrustConfig buildTrustConfig(Path basePath, SslVerificationMode verificationMode, SslKeyConfig keyConfig) {

--- a/libs/ssl-config/src/test/java/org/elasticsearch/common/ssl/SslConfigurationTests.java
+++ b/libs/ssl-config/src/test/java/org/elasticsearch/common/ssl/SslConfigurationTests.java
@@ -39,6 +39,7 @@ public class SslConfigurationTests extends ESTestCase {
         final List<String> ciphers = randomSubsetOf(randomIntBetween(1, DEFAULT_CIPHERS.size()), DEFAULT_CIPHERS);
         final List<String> protocols = randomSubsetOf(randomIntBetween(1, 4), VALID_PROTOCOLS);
         final SslConfiguration configuration = new SslConfiguration(
+            "test.ssl",
             true,
             trustConfig,
             keyConfig,
@@ -71,6 +72,7 @@ public class SslConfigurationTests extends ESTestCase {
         final List<String> ciphers = randomSubsetOf(randomIntBetween(1, DEFAULT_CIPHERS.size() - 1), DEFAULT_CIPHERS);
         final List<String> protocols = randomSubsetOf(randomIntBetween(1, VALID_PROTOCOLS.length - 1), VALID_PROTOCOLS);
         final SslConfiguration configuration = new SslConfiguration(
+            "test.ssl",
             true,
             trustConfig,
             keyConfig,
@@ -83,6 +85,7 @@ public class SslConfigurationTests extends ESTestCase {
         EqualsHashCodeTestUtils.checkEqualsAndHashCode(
             configuration,
             orig -> new SslConfiguration(
+                "test.ssl",
                 true,
                 orig.trustConfig(),
                 orig.keyConfig(),
@@ -98,6 +101,7 @@ public class SslConfigurationTests extends ESTestCase {
     private SslConfiguration mutateSslConfiguration(SslConfiguration orig) {
         return switch (randomIntBetween(1, 4)) {
             case 1 -> new SslConfiguration(
+                "test.ssl",
                 true,
                 orig.trustConfig(),
                 orig.keyConfig(),
@@ -107,6 +111,7 @@ public class SslConfigurationTests extends ESTestCase {
                 orig.supportedProtocols()
             );
             case 2 -> new SslConfiguration(
+                "test.ssl",
                 true,
                 orig.trustConfig(),
                 orig.keyConfig(),
@@ -116,6 +121,7 @@ public class SslConfigurationTests extends ESTestCase {
                 orig.supportedProtocols()
             );
             case 3 -> new SslConfiguration(
+                "test.ssl",
                 true,
                 orig.trustConfig(),
                 orig.keyConfig(),
@@ -125,6 +131,7 @@ public class SslConfigurationTests extends ESTestCase {
                 orig.supportedProtocols()
             );
             default -> new SslConfiguration(
+                "test.ssl",
                 true,
                 orig.trustConfig(),
                 orig.keyConfig(),
@@ -140,6 +147,7 @@ public class SslConfigurationTests extends ESTestCase {
         final SslTrustConfig trustConfig = Mockito.mock(SslTrustConfig.class);
         final SslKeyConfig keyConfig = Mockito.mock(SslKeyConfig.class);
         final SslConfiguration configuration = new SslConfiguration(
+            "test.ssl",
             true,
             trustConfig,
             keyConfig,
@@ -166,6 +174,7 @@ public class SslConfigurationTests extends ESTestCase {
         final SslKeyConfig keyConfig = Mockito.mock(SslKeyConfig.class);
         final String protocol = randomFrom(SslConfigurationLoader.DEFAULT_PROTOCOLS);
         final SslConfiguration configuration = new SslConfiguration(
+            "test.ssl",
             true,
             trustConfig,
             keyConfig,


### PR DESCRIPTION
Instead of just logging the reloaded file, add extra useful information:
- list of setting prefixes that reloaded the file
- list of the setting prefixes
- taken in msec to process all of the SSL contexts for that one reloaded file

The initial idea came from #91147. I started with just an update to 1 file, but adding the setting prefixes required touching 3 other files. At that point, it made sense to split this into a separate PR.