### PR TITLE
Tidy up CompoundProcessor collections handling

### DIFF
--- a/server/src/main/java/org/elasticsearch/ingest/CompoundProcessor.java
+++ b/server/src/main/java/org/elasticsearch/ingest/CompoundProcessor.java
@@ -14,8 +14,6 @@ import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.core.Tuple;
 
 import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -43,11 +41,11 @@ public class CompoundProcessor implements Processor {
     private final boolean isAsync;
 
     CompoundProcessor(LongSupplier relativeTimeProvider, boolean ignoreFailure, Processor... processor) {
-        this(ignoreFailure, Arrays.asList(processor), Collections.emptyList(), relativeTimeProvider);
+        this(ignoreFailure, List.of(processor), List.of(), relativeTimeProvider);
     }
 
     public CompoundProcessor(Processor... processor) {
-        this(false, Arrays.asList(processor), Collections.emptyList());
+        this(false, List.of(processor), List.of());
     }
 
     public CompoundProcessor(boolean ignoreFailure, List<Processor> processors, List<Processor> onFailureProcessors) {

--- a/server/src/main/java/org/elasticsearch/ingest/CompoundProcessor.java
+++ b/server/src/main/java/org/elasticsearch/ingest/CompoundProcessor.java
@@ -63,9 +63,8 @@ public class CompoundProcessor implements Processor {
         this.processors = processors;
         this.onFailureProcessors = onFailureProcessors;
         this.relativeTimeProvider = relativeTimeProvider;
-        this.processorsWithMetrics = new ArrayList<>(processors.size());
+        this.processorsWithMetrics = processors.stream().map(p -> new Tuple<>(p, new IngestMetric())).toList();
         this.isAsync = flattenProcessors().stream().anyMatch(Processor::isAsync);
-        processors.forEach(p -> processorsWithMetrics.add(new Tuple<>(p, new IngestMetric())));
     }
 
     List<Tuple<Processor, IngestMetric>> getProcessorsWithMetrics() {

--- a/server/src/main/java/org/elasticsearch/ingest/CompoundProcessor.java
+++ b/server/src/main/java/org/elasticsearch/ingest/CompoundProcessor.java
@@ -60,8 +60,8 @@ public class CompoundProcessor implements Processor {
     ) {
         super();
         this.ignoreFailure = ignoreFailure;
-        this.processors = processors;
-        this.onFailureProcessors = onFailureProcessors;
+        this.processors = List.copyOf(processors);
+        this.onFailureProcessors = List.copyOf(onFailureProcessors);
         this.relativeTimeProvider = relativeTimeProvider;
         this.processorsWithMetrics = processors.stream().map(p -> new Tuple<>(p, new IngestMetric())).toList();
         this.isAsync = flattenProcessors().stream().anyMatch(Processor::isAsync);

--- a/server/src/main/java/org/elasticsearch/ingest/CompoundProcessor.java
+++ b/server/src/main/java/org/elasticsearch/ingest/CompoundProcessor.java
@@ -40,12 +40,12 @@ public class CompoundProcessor implements Processor {
     private final LongSupplier relativeTimeProvider;
     private final boolean isAsync;
 
-    CompoundProcessor(LongSupplier relativeTimeProvider, boolean ignoreFailure, Processor... processor) {
-        this(ignoreFailure, List.of(processor), List.of(), relativeTimeProvider);
+    CompoundProcessor(LongSupplier relativeTimeProvider, boolean ignoreFailure, Processor... processors) {
+        this(ignoreFailure, List.of(processors), List.of(), relativeTimeProvider);
     }
 
-    public CompoundProcessor(Processor... processor) {
-        this(false, List.of(processor), List.of());
+    public CompoundProcessor(Processor... processors) {
+        this(false, List.of(processors), List.of());
     }
 
     public CompoundProcessor(boolean ignoreFailure, List<Processor> processors, List<Processor> onFailureProcessors) {

--- a/server/src/main/java/org/elasticsearch/ingest/ConfigurationUtils.java
+++ b/server/src/main/java/org/elasticsearch/ingest/ConfigurationUtils.java
@@ -29,6 +29,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -488,7 +489,7 @@ public final class ConfigurationUtils {
             throw exception;
         }
 
-        return processors;
+        return Collections.unmodifiableList(processors);
     }
 
     public static TemplateScript.Factory readTemplateProperty(

--- a/server/src/main/java/org/elasticsearch/ingest/ConfigurationUtils.java
+++ b/server/src/main/java/org/elasticsearch/ingest/ConfigurationUtils.java
@@ -29,7 +29,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -422,7 +421,7 @@ public final class ConfigurationUtils {
     ) {
         String mediaType = readStringProperty(processorType, processorTag, configuration, propertyName, defaultValue);
 
-        if (Arrays.asList(VALID_MEDIA_TYPES).contains(mediaType) == false) {
+        if (List.of(VALID_MEDIA_TYPES).contains(mediaType) == false) {
             throw newConfigurationException(
                 processorType,
                 processorTag,
@@ -516,7 +515,7 @@ public final class ConfigurationUtils {
             // modified if templating is not available so a script that simply returns an unmodified `propertyValue`
             // is returned.
             if (scriptService.isLangSupported(DEFAULT_TEMPLATE_LANG) && propertyValue.contains("{{")) {
-                Script script = new Script(ScriptType.INLINE, DEFAULT_TEMPLATE_LANG, propertyValue, Collections.emptyMap());
+                Script script = new Script(ScriptType.INLINE, DEFAULT_TEMPLATE_LANG, propertyValue, Map.of());
                 return scriptService.compile(script, TemplateScript.CONTEXT);
             } else {
                 return (params) -> new TemplateScript(params) {
@@ -601,7 +600,7 @@ public final class ConfigurationUtils {
                     );
                 }
                 if (onFailureProcessors.size() > 0 || ignoreFailure) {
-                    processor = new CompoundProcessor(ignoreFailure, Collections.singletonList(processor), onFailureProcessors);
+                    processor = new CompoundProcessor(ignoreFailure, List.of(processor), onFailureProcessors);
                 }
                 if (conditionalScript != null) {
                     processor = new ConditionalProcessor(tag, description, conditionalScript, scriptService, processor);
@@ -634,7 +633,7 @@ public final class ConfigurationUtils {
         if (scriptConfig instanceof Map<?, ?>) {
             return (Map<String, Object>) scriptConfig;
         } else if (scriptConfig instanceof String) {
-            return Collections.singletonMap("source", scriptConfig);
+            return Map.of("source", scriptConfig);
         } else {
             throw newConfigurationException(
                 "conditional",

--- a/server/src/main/java/org/elasticsearch/ingest/Pipeline.java
+++ b/server/src/main/java/org/elasticsearch/ingest/Pipeline.java
@@ -15,7 +15,6 @@ import org.elasticsearch.core.Nullable;
 import org.elasticsearch.script.ScriptService;
 
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -102,11 +101,7 @@ public final class Pipeline {
         if (onFailureProcessorConfigs != null && onFailureProcessors.isEmpty()) {
             throw new ElasticsearchParseException("pipeline [" + id + "] cannot have an empty on_failure option defined");
         }
-        CompoundProcessor compoundProcessor = new CompoundProcessor(
-            false,
-            Collections.unmodifiableList(processors),
-            Collections.unmodifiableList(onFailureProcessors)
-        );
+        CompoundProcessor compoundProcessor = new CompoundProcessor(false, processors, onFailureProcessors);
         return new Pipeline(id, description, version, metadata, compoundProcessor);
     }
 


### PR DESCRIPTION
Really just a clean up PR. The primary thrust is that it internalizes that logic that makes a CompoundProcessor wrap a series of immutable collections, rather than relying on the caller to pass in immutable collections.