### PR TITLE
Fix NPE in auditing authenticationSuccess for non-existing run-as user

### DIFF
--- a/docs/changelog/91171.yaml
+++ b/docs/changelog/91171.yaml
@@ -1,0 +1,5 @@
+pr: 91171
+summary: Fix NPE in auditing `authenticationSuccess` for non-existing run-as user
+area: Audit
+type: bug
+issues: []

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/audit/logfile/LoggingAuditTrail.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/audit/logfile/LoggingAuditTrail.java
@@ -1629,14 +1629,16 @@ public class LoggingAuditTrail implements AuditTrail, ClusterStateListener {
                 final Authentication.RealmRef authenticatedBy = authentication.getAuthenticatingSubject().getRealm();
                 if (authentication.isRunAs()) {
                     final Authentication.RealmRef lookedUpBy = authentication.getEffectiveSubject().getRealm();
-                    logEntry.with(PRINCIPAL_REALM_FIELD_NAME, lookedUpBy.getName())
-                        .with(PRINCIPAL_RUN_BY_FIELD_NAME, authentication.getAuthenticatingSubject().getUser().principal())
+                    if (lookedUpBy != null) {
+                        logEntry.with(PRINCIPAL_REALM_FIELD_NAME, lookedUpBy.getName());
+                        if (lookedUpBy.getDomain() != null) {
+                            logEntry.with(PRINCIPAL_DOMAIN_FIELD_NAME, lookedUpBy.getDomain().name());
+                        }
+                    }
+                    logEntry.with(PRINCIPAL_RUN_BY_FIELD_NAME, authentication.getAuthenticatingSubject().getUser().principal())
                         // API key can run-as, when that happens, the following field will be _es_api_key,
                         // not the API key owner user's realm.
                         .with(PRINCIPAL_RUN_BY_REALM_FIELD_NAME, authenticatedBy.getName());
-                    if (lookedUpBy.getDomain() != null) {
-                        logEntry.with(PRINCIPAL_DOMAIN_FIELD_NAME, lookedUpBy.getDomain().name());
-                    }
                     if (authenticatedBy.getDomain() != null) {
                         logEntry.with(PRINCIPAL_RUN_BY_DOMAIN_FIELD_NAME, authenticatedBy.getDomain().name());
                     }


### PR DESCRIPTION
When run-as fails because the target user does not exist, the authentication is created with a null lookup realm. It is then rejected at authorization time. But for authentication, it is treated as success. This can lead to NPE when auditing the authenticationSuccess event.

This PR fixes the NPE by checking whether lookup realm is null before using it.

Relates: https://github.com/elastic/elasticsearch/pull/91126#discussion_r1005472501
