### PR TITLE
Ensure PKI's delegated_by_realm metadata respect run-as

### DIFF
--- a/docs/changelog/91173.yaml
+++ b/docs/changelog/91173.yaml
@@ -1,0 +1,5 @@
+pr: 91173
+summary: Ensure PKI's `delegated_by_realm` metadata respect run-as
+area: Authentication
+type: bug
+issues: []

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/pki/PkiRealm.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/pki/PkiRealm.java
@@ -214,8 +214,7 @@ public class PkiRealm extends Realm implements CachingRealm {
                 "pki_delegated_by_user",
                 token.getDelegateeAuthentication().getEffectiveSubject().getUser().principal(),
                 "pki_delegated_by_realm",
-                // TODO: this should be the realm of effective subject
-                token.getDelegateeAuthentication().getAuthenticatingSubject().getRealm().getName()
+                token.getDelegateeAuthentication().getEffectiveSubject().getRealm().getName()
             );
         } else {
             metadata = Map.of("pki_dn", token.dn());


### PR DESCRIPTION
When delegated PKI authentication is used, the delegatee's realm name is added as a metadata field. This realm name should be the effective subject's realm instead of that of the authenticating subject. This PR ensures this is the case.

Relates: https://github.com/elastic/elasticsearch/pull/91104#discussion_r1004154801
