### PR TITLE
Mute reference/cluster/nodes-stats/line_2751

### DIFF
--- a/docs/reference/cluster/nodes-stats.asciidoc
+++ b/docs/reference/cluster/nodes-stats.asciidoc
@@ -2751,3 +2751,4 @@ For example, the following request only returns ingest pipeline statistics.
 --------------------------------------------------
 GET /_nodes/stats?metric=ingest&filter_path=nodes.*.ingest.pipelines
 --------------------------------------------------
+// TESTRESPONSE[skip:"AwaitsFix https://github.com/elastic/elasticsearch/issues/91081"]


### PR DESCRIPTION
Mute `reference/cluster/nodes-stats/line_2751` because of multiple failures #91081 .