### PR TITLE
[8.5] Mute reference/cluster/nodes-stats/line_2751 (#91174)

### DIFF
--- a/docs/reference/cluster/nodes-stats.asciidoc
+++ b/docs/reference/cluster/nodes-stats.asciidoc
@@ -2747,3 +2747,4 @@ For example, the following request only returns ingest pipeline statistics.
 --------------------------------------------------
 GET /_nodes/stats?metric=ingest&filter_path=nodes.*.ingest.pipelines
 --------------------------------------------------
+// TESTRESPONSE[skip:"AwaitsFix https://github.com/elastic/elasticsearch/issues/91081"]


### PR DESCRIPTION
Backports the following commits to 8.5:
 - Mute reference/cluster/nodes-stats/line_2751 (#91174)