### PR TITLE
Make some ByteSizeValue instances always use the singleton

### DIFF
--- a/modules/data-streams/src/main/java/org/elasticsearch/datastreams/action/DataStreamsStatsTransportAction.java
+++ b/modules/data-streams/src/main/java/org/elasticsearch/datastreams/action/DataStreamsStatsTransportAction.java
@@ -224,7 +224,7 @@ public class DataStreamsStatsTransportAction extends TransportBroadcastByNodeAct
                 entry -> new DataStreamsStatsAction.DataStreamStats(
                     entry.getKey(),
                     entry.getValue().backingIndices.size(),
-                    new ByteSizeValue(entry.getValue().storageBytes),
+                    ByteSizeValue.ofBytes(entry.getValue().storageBytes),
                     entry.getValue().maxTimestamp
                 )
             )
@@ -237,7 +237,7 @@ public class DataStreamsStatsTransportAction extends TransportBroadcastByNodeAct
             shardFailures,
             aggregatedDataStreamsStats.size(),
             allBackingIndices.size(),
-            new ByteSizeValue(totalStoreSizeBytes),
+            ByteSizeValue.ofBytes(totalStoreSizeBytes),
             dataStreamStats
         );
     }

--- a/modules/data-streams/src/test/java/org/elasticsearch/datastreams/action/DataStreamsStatsResponseTests.java
+++ b/modules/data-streams/src/test/java/org/elasticsearch/datastreams/action/DataStreamsStatsResponseTests.java
@@ -43,7 +43,12 @@ public class DataStreamsStatsResponseTests extends AbstractWireSerializingTestCa
             totalStoreSize += storeSize;
             long maximumTimestamp = randomRecentTimestamp();
             dataStreamStats.add(
-                new DataStreamsStatsAction.DataStreamStats(dataStreamName, backingIndices, new ByteSizeValue(storeSize), maximumTimestamp)
+                new DataStreamsStatsAction.DataStreamStats(
+                    dataStreamName,
+                    backingIndices,
+                    ByteSizeValue.ofBytes(storeSize),
+                    maximumTimestamp
+                )
             );
         }
         int totalShards = randomIntBetween(backingIndicesTotal, backingIndicesTotal * 3);
@@ -66,7 +71,7 @@ public class DataStreamsStatsResponseTests extends AbstractWireSerializingTestCa
             exceptions,
             dataStreamCount,
             backingIndicesTotal,
-            new ByteSizeValue(totalStoreSize),
+            ByteSizeValue.ofBytes(totalStoreSize),
             dataStreamStats.toArray(DataStreamsStatsAction.DataStreamStats[]::new)
         );
     }

--- a/modules/reindex/src/main/java/org/elasticsearch/reindex/AbstractAsyncBulkByScrollAction.java
+++ b/modules/reindex/src/main/java/org/elasticsearch/reindex/AbstractAsyncBulkByScrollAction.java
@@ -430,7 +430,7 @@ public abstract class AbstractAsyncBulkByScrollAction<
                 "[{}]: sending [{}] entry, [{}] bulk request",
                 task.getId(),
                 requestSize,
-                new ByteSizeValue(request.estimatedSizeInBytes())
+                ByteSizeValue.ofBytes(request.estimatedSizeInBytes())
             );
         }
         if (task.isCancelled()) {

--- a/modules/repository-azure/src/main/java/org/elasticsearch/repositories/azure/AzureStorageService.java
+++ b/modules/repository-azure/src/main/java/org/elasticsearch/repositories/azure/AzureStorageService.java
@@ -30,7 +30,7 @@ import java.util.function.BiConsumer;
 import static java.util.Collections.emptyMap;
 
 public class AzureStorageService {
-    public static final ByteSizeValue MIN_CHUNK_SIZE = new ByteSizeValue(1, ByteSizeUnit.BYTES);
+    public static final ByteSizeValue MIN_CHUNK_SIZE = ByteSizeValue.ofBytes(1);
 
     /**
      * The maximum size of a BlockBlob block.
@@ -48,12 +48,11 @@ public class AzureStorageService {
      * Default block size for multi-block uploads. The Azure repository will use the Put block and Put block list APIs to split the
      * stream into several part, each of block_size length, and will upload each part in its own request.
      */
-    private static final ByteSizeValue DEFAULT_BLOCK_SIZE = new ByteSizeValue(
+    private static final ByteSizeValue DEFAULT_BLOCK_SIZE = ByteSizeValue.ofBytes(
         Math.max(
             ByteSizeUnit.MB.toBytes(5), // minimum value
             Math.min(MAX_BLOCK_SIZE.getBytes(), JvmInfo.jvmInfo().getMem().getHeapMax().getBytes() / 20)
-        ),
-        ByteSizeUnit.BYTES
+        )
     );
 
     /**
@@ -65,7 +64,7 @@ public class AzureStorageService {
     /**
      * Maximum allowed blob size in Azure blob store.
      */
-    public static final ByteSizeValue MAX_CHUNK_SIZE = new ByteSizeValue(MAX_BLOB_SIZE, ByteSizeUnit.BYTES);
+    public static final ByteSizeValue MAX_CHUNK_SIZE = ByteSizeValue.ofBytes(MAX_BLOB_SIZE);
 
     private static final long DEFAULT_UPLOAD_BLOCK_SIZE = DEFAULT_BLOCK_SIZE.getBytes();
 

--- a/modules/repository-gcs/src/main/java/org/elasticsearch/repositories/gcs/GoogleCloudStorageRepository.java
+++ b/modules/repository-gcs/src/main/java/org/elasticsearch/repositories/gcs/GoogleCloudStorageRepository.java
@@ -34,7 +34,7 @@ class GoogleCloudStorageRepository extends MeteredBlobStoreRepository {
     private static final Logger logger = LogManager.getLogger(GoogleCloudStorageRepository.class);
 
     // package private for testing
-    static final ByteSizeValue MIN_CHUNK_SIZE = new ByteSizeValue(1, ByteSizeUnit.BYTES);
+    static final ByteSizeValue MIN_CHUNK_SIZE = ByteSizeValue.ONE;
 
     /**
      * Maximum allowed object size in GCS.

--- a/modules/repository-s3/src/main/java/org/elasticsearch/repositories/s3/S3Repository.java
+++ b/modules/repository-s3/src/main/java/org/elasticsearch/repositories/s3/S3Repository.java
@@ -76,12 +76,11 @@ class S3Repository extends MeteredBlobStoreRepository {
      * Default is to use 100MB (S3 defaults) for heaps above 2GB and 5% of
      * the available memory for smaller heaps.
      */
-    private static final ByteSizeValue DEFAULT_BUFFER_SIZE = new ByteSizeValue(
+    private static final ByteSizeValue DEFAULT_BUFFER_SIZE = ByteSizeValue.ofBytes(
         Math.max(
             ByteSizeUnit.MB.toBytes(5), // minimum value
             Math.min(ByteSizeUnit.MB.toBytes(100), JvmInfo.jvmInfo().getMem().getHeapMax().getBytes() / 20)
-        ),
-        ByteSizeUnit.BYTES
+        )
     );
 
     static final Setting<String> BUCKET_SETTING = Setting.simpleString("bucket");

--- a/modules/repository-s3/src/test/java/org/elasticsearch/repositories/s3/S3BlobContainerRetriesTests.java
+++ b/modules/repository-s3/src/test/java/org/elasticsearch/repositories/s3/S3BlobContainerRetriesTests.java
@@ -453,7 +453,7 @@ public class S3BlobContainerRetriesTests extends AbstractBlobContainerRetriesTes
             0,
             randomFrom(1000, Math.toIntExact(S3Repository.BUFFER_SIZE_SETTING.get(Settings.EMPTY).getBytes()))
         );
-        final BlobContainer blobContainer = createBlobContainer(maxRetries, null, true, new ByteSizeValue(bufferSizeBytes));
+        final BlobContainer blobContainer = createBlobContainer(maxRetries, null, true, ByteSizeValue.ofBytes(bufferSizeBytes));
         final int meaningfulProgressBytes = Math.max(1, bufferSizeBytes / 100);
 
         final byte[] bytes = randomBlobContent();

--- a/modules/transport-netty4/src/main/java/org/elasticsearch/http/netty4/Netty4HttpServerTransport.java
+++ b/modules/transport-netty4/src/main/java/org/elasticsearch/http/netty4/Netty4HttpServerTransport.java
@@ -84,7 +84,7 @@ public class Netty4HttpServerTransport extends AbstractHttpServerTransport {
      *
      * By default we assume the Ethernet MTU (1500 bytes) but users can override it with a system property.
      */
-    private static final ByteSizeValue MTU = new ByteSizeValue(Long.parseLong(System.getProperty("es.net.mtu", "1500")));
+    private static final ByteSizeValue MTU = ByteSizeValue.ofBytes(Long.parseLong(System.getProperty("es.net.mtu", "1500")));
 
     private static final String SETTING_KEY_HTTP_NETTY_MAX_COMPOSITE_BUFFER_COMPONENTS = "http.netty.max_composite_buffer_components";
 

--- a/modules/transport-netty4/src/main/java/org/elasticsearch/transport/netty4/NettyAllocator.java
+++ b/modules/transport-netty4/src/main/java/org/elasticsearch/transport/netty4/NettyAllocator.java
@@ -47,15 +47,15 @@ public class NettyAllocator {
             ALLOCATOR = ByteBufAllocator.DEFAULT;
             SUGGESTED_MAX_ALLOCATION_SIZE = 1024 * 1024;
             DESCRIPTION = "[name=netty_default, suggested_max_allocation_size="
-                + new ByteSizeValue(SUGGESTED_MAX_ALLOCATION_SIZE)
+                + ByteSizeValue.ofBytes(SUGGESTED_MAX_ALLOCATION_SIZE)
                 + ", factors={es.unsafe.use_netty_default_allocator=true}]";
         } else {
             final long heapSizeInBytes = JvmInfo.jvmInfo().getMem().getHeapMax().getBytes();
             final boolean g1gcEnabled = Boolean.parseBoolean(JvmInfo.jvmInfo().useG1GC());
             final long g1gcRegionSizeInBytes = JvmInfo.jvmInfo().getG1RegionSize();
             final boolean g1gcRegionSizeIsKnown = g1gcRegionSizeInBytes != -1;
-            ByteSizeValue heapSize = new ByteSizeValue(heapSizeInBytes);
-            ByteSizeValue g1gcRegionSize = new ByteSizeValue(g1gcRegionSizeInBytes);
+            ByteSizeValue heapSize = ByteSizeValue.ofBytes(heapSizeInBytes);
+            ByteSizeValue g1gcRegionSize = ByteSizeValue.ofBytes(g1gcRegionSizeInBytes);
 
             ByteBufAllocator delegate;
             if (useUnpooled(heapSizeInBytes, g1gcEnabled, g1gcRegionSizeIsKnown, g1gcRegionSizeInBytes)) {
@@ -68,7 +68,7 @@ public class NettyAllocator {
                     SUGGESTED_MAX_ALLOCATION_SIZE = 1024 * 1024;
                 }
                 DESCRIPTION = "[name=unpooled, suggested_max_allocation_size="
-                    + new ByteSizeValue(SUGGESTED_MAX_ALLOCATION_SIZE)
+                    + ByteSizeValue.ofBytes(SUGGESTED_MAX_ALLOCATION_SIZE)
                     + ", factors={es.unsafe.use_unpooled_allocator="
                     + System.getProperty(USE_UNPOOLED)
                     + ", g1gc_enabled="
@@ -114,12 +114,12 @@ public class NettyAllocator {
                     useCacheForAllThreads
                 );
                 int chunkSizeInBytes = pageSize << maxOrder;
-                ByteSizeValue chunkSize = new ByteSizeValue(chunkSizeInBytes);
+                ByteSizeValue chunkSize = ByteSizeValue.ofBytes(chunkSizeInBytes);
                 SUGGESTED_MAX_ALLOCATION_SIZE = chunkSizeInBytes;
                 DESCRIPTION = "[name=elasticsearch_configured, chunk_size="
                     + chunkSize
                     + ", suggested_max_allocation_size="
-                    + new ByteSizeValue(SUGGESTED_MAX_ALLOCATION_SIZE)
+                    + ByteSizeValue.ofBytes(SUGGESTED_MAX_ALLOCATION_SIZE)
                     + ", factors={es.unsafe.use_netty_default_chunk_and_page_size="
                     + useDefaultChunkAndPageSize()
                     + ", g1gc_enabled="

--- a/server/src/internalClusterTest/java/org/elasticsearch/health/HealthMetadataServiceIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/health/HealthMetadataServiceIT.java
@@ -41,7 +41,7 @@ public class HealthMetadataServiceIT extends ESIntegTestCase {
             Map<String, String> watermarkByNode = new HashMap<>();
             Map<String, ByteSizeValue> maxHeadroomByNode = new HashMap<>();
             for (int i = 0; i < numberOfNodes; i++) {
-                ByteSizeValue randomBytes = new ByteSizeValue(randomLongBetween(6, 19));
+                ByteSizeValue randomBytes = ByteSizeValue.ofBytes(randomLongBetween(6, 19));
                 String customWatermark = percentageMode ? randomIntBetween(86, 94) + "%" : randomBytes.toString();
                 ByteSizeValue customMaxHeadroom = percentageMode ? randomBytes : ByteSizeValue.MINUS_ONE;
                 String nodeName = startNode(internalCluster, customWatermark, customMaxHeadroom.toString());
@@ -74,20 +74,20 @@ public class HealthMetadataServiceIT extends ESIntegTestCase {
     public void testWatermarkSettingUpdate() throws Exception {
         try (InternalTestCluster internalCluster = internalCluster()) {
             int numberOfNodes = 3;
-            ByteSizeValue randomBytes = new ByteSizeValue(randomLongBetween(6, 19));
+            ByteSizeValue randomBytes = ByteSizeValue.ofBytes(randomLongBetween(6, 19));
             String initialWatermark = percentageMode ? randomIntBetween(86, 94) + "%" : randomBytes.toString();
             ByteSizeValue initialMaxHeadroom = percentageMode ? randomBytes : ByteSizeValue.MINUS_ONE;
             for (int i = 0; i < numberOfNodes; i++) {
                 startNode(internalCluster, initialWatermark, initialMaxHeadroom.toString());
             }
 
-            randomBytes = new ByteSizeValue(randomLongBetween(101, 200));
+            randomBytes = ByteSizeValue.ofBytes(randomLongBetween(101, 200));
             String updatedLowWatermark = percentageMode ? randomIntBetween(40, 59) + "%" : randomBytes.toString();
             ByteSizeValue updatedLowMaxHeadroom = percentageMode ? randomBytes : ByteSizeValue.MINUS_ONE;
-            randomBytes = new ByteSizeValue(randomLongBetween(50, 100));
+            randomBytes = ByteSizeValue.ofBytes(randomLongBetween(50, 100));
             String updatedHighWatermark = percentageMode ? randomIntBetween(60, 90) + "%" : randomBytes.toString();
             ByteSizeValue updatedHighMaxHeadroom = percentageMode ? randomBytes : ByteSizeValue.MINUS_ONE;
-            randomBytes = new ByteSizeValue(randomLongBetween(5, 10));
+            randomBytes = ByteSizeValue.ofBytes(randomLongBetween(5, 10));
             String updatedFloodStageWatermark = percentageMode ? randomIntBetween(91, 95) + "%" : randomBytes.toString();
             ByteSizeValue updatedFloodStageMaxHeadroom = percentageMode ? randomBytes : ByteSizeValue.MINUS_ONE;
 

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/node/info/NodeInfo.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/node/info/NodeInfo.java
@@ -57,7 +57,7 @@ public class NodeInfo extends BaseNodeResponse {
         version = Version.readVersion(in);
         build = Build.readBuild(in);
         if (in.readBoolean()) {
-            totalIndexingBuffer = new ByteSizeValue(in.readLong());
+            totalIndexingBuffer = ByteSizeValue.ofBytes(in.readLong());
         } else {
             totalIndexingBuffer = null;
         }

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/status/SnapshotStats.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/status/SnapshotStats.java
@@ -164,7 +164,7 @@ public class SnapshotStats implements Writeable, ToXContentObject {
             builder.startObject(Fields.INCREMENTAL);
             {
                 builder.field(Fields.FILE_COUNT, getIncrementalFileCount());
-                builder.humanReadableField(Fields.SIZE_IN_BYTES, Fields.SIZE, new ByteSizeValue(getIncrementalSize()));
+                builder.humanReadableField(Fields.SIZE_IN_BYTES, Fields.SIZE, ByteSizeValue.ofBytes(getIncrementalSize()));
             }
             builder.endObject();
 
@@ -172,7 +172,7 @@ public class SnapshotStats implements Writeable, ToXContentObject {
                 builder.startObject(Fields.PROCESSED);
                 {
                     builder.field(Fields.FILE_COUNT, getProcessedFileCount());
-                    builder.humanReadableField(Fields.SIZE_IN_BYTES, Fields.SIZE, new ByteSizeValue(getProcessedSize()));
+                    builder.humanReadableField(Fields.SIZE_IN_BYTES, Fields.SIZE, ByteSizeValue.ofBytes(getProcessedSize()));
                 }
                 builder.endObject();
             }
@@ -180,7 +180,7 @@ public class SnapshotStats implements Writeable, ToXContentObject {
             builder.startObject(Fields.TOTAL);
             {
                 builder.field(Fields.FILE_COUNT, getTotalFileCount());
-                builder.humanReadableField(Fields.SIZE_IN_BYTES, Fields.SIZE, new ByteSizeValue(getTotalSize()));
+                builder.humanReadableField(Fields.SIZE_IN_BYTES, Fields.SIZE, ByteSizeValue.ofBytes(getTotalSize()));
             }
             builder.endObject();
 

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/stats/ClusterStatsNodes.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/stats/ClusterStatsNodes.java
@@ -515,14 +515,14 @@ public class ClusterStatsNodes implements ToXContentFragment {
          * Total heap used in the cluster
          */
         public ByteSizeValue getHeapUsed() {
-            return new ByteSizeValue(heapUsed);
+            return ByteSizeValue.ofBytes(heapUsed);
         }
 
         /**
          * Maximum total heap available to the cluster
          */
         public ByteSizeValue getHeapMax() {
-            return new ByteSizeValue(heapMax);
+            return ByteSizeValue.ofBytes(heapMax);
         }
 
         static final class Fields {

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/stats/VersionStats.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/stats/VersionStats.java
@@ -189,7 +189,7 @@ public final class VersionStats implements ToXContentFragment, Writeable {
             builder.field("version", version.toString());
             builder.field("index_count", indexCount);
             builder.field("primary_shard_count", primaryShardCount);
-            builder.humanReadableField("total_primary_bytes", "total_primary_size", new ByteSizeValue(totalPrimaryByteCount));
+            builder.humanReadableField("total_primary_bytes", "total_primary_size", ByteSizeValue.ofBytes(totalPrimaryByteCount));
             builder.endObject();
             return builder;
         }

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/diskusage/IndexDiskUsageStats.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/diskusage/IndexDiskUsageStats.java
@@ -136,7 +136,7 @@ public final class IndexDiskUsageStats implements ToXContentFragment, Writeable 
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
         final PerFieldDiskUsage total = total();
-        builder.field(STORE_SIZE, new ByteSizeValue(indexSizeInBytes));
+        builder.field(STORE_SIZE, ByteSizeValue.ofBytes(indexSizeInBytes));
         builder.field(STORE_SIZE_IN_BYTES, indexSizeInBytes);
 
         // all fields
@@ -252,30 +252,30 @@ public final class IndexDiskUsageStats implements ToXContentFragment, Writeable 
         @Override
         public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
             final long totalBytes = totalBytes();
-            builder.field(TOTAL, new ByteSizeValue(totalBytes));
+            builder.field(TOTAL, ByteSizeValue.ofBytes(totalBytes));
             builder.field(TOTAL_IN_BYTES, totalBytes);
 
             builder.startObject(INVERTED_INDEX);
-            builder.field(TOTAL, new ByteSizeValue(invertedIndexBytes));
+            builder.field(TOTAL, ByteSizeValue.ofBytes(invertedIndexBytes));
             builder.field(TOTAL_IN_BYTES, invertedIndexBytes);
             builder.endObject();
 
-            builder.field(STORED_FIELDS, new ByteSizeValue(storedFieldBytes));
+            builder.field(STORED_FIELDS, ByteSizeValue.ofBytes(storedFieldBytes));
             builder.field(STORED_FIELDS_IN_BYTES, storedFieldBytes);
 
-            builder.field(DOC_VALUES, new ByteSizeValue(docValuesBytes));
+            builder.field(DOC_VALUES, ByteSizeValue.ofBytes(docValuesBytes));
             builder.field(DOC_VALUES_IN_BYTES, docValuesBytes);
 
-            builder.field(POINTS, new ByteSizeValue(pointsBytes));
+            builder.field(POINTS, ByteSizeValue.ofBytes(pointsBytes));
             builder.field(POINTS_IN_BYTES, pointsBytes);
 
-            builder.field(NORMS, new ByteSizeValue(normsBytes));
+            builder.field(NORMS, ByteSizeValue.ofBytes(normsBytes));
             builder.field(NORMS_IN_BYTES, normsBytes);
 
-            builder.field(TERM_VECTORS, new ByteSizeValue(termVectorsBytes));
+            builder.field(TERM_VECTORS, ByteSizeValue.ofBytes(termVectorsBytes));
             builder.field(TERM_VECTORS_IN_BYTES, termVectorsBytes);
 
-            builder.field(KNN_VECTORS, new ByteSizeValue(knnVectorsBytes));
+            builder.field(KNN_VECTORS, ByteSizeValue.ofBytes(knnVectorsBytes));
             builder.field(KNN_VECTORS_IN_BYTES, knnVectorsBytes);
             return builder;
         }

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/rollover/MaxPrimaryShardSizeCondition.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/rollover/MaxPrimaryShardSizeCondition.java
@@ -10,7 +10,6 @@ package org.elasticsearch.action.admin.indices.rollover;
 
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
-import org.elasticsearch.common.unit.ByteSizeUnit;
 import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xcontent.XContentParser;
@@ -31,7 +30,7 @@ public class MaxPrimaryShardSizeCondition extends Condition<ByteSizeValue> {
 
     public MaxPrimaryShardSizeCondition(StreamInput in) throws IOException {
         super(NAME, Type.MAX);
-        this.value = new ByteSizeValue(in.readVLong(), ByteSizeUnit.BYTES);
+        this.value = ByteSizeValue.ofBytes(in.readVLong());
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/rollover/MaxSizeCondition.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/rollover/MaxSizeCondition.java
@@ -10,7 +10,6 @@ package org.elasticsearch.action.admin.indices.rollover;
 
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
-import org.elasticsearch.common.unit.ByteSizeUnit;
 import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xcontent.XContentParser;
@@ -31,7 +30,7 @@ public class MaxSizeCondition extends Condition<ByteSizeValue> {
 
     public MaxSizeCondition(StreamInput in) throws IOException {
         super(NAME, Type.MAX);
-        this.value = new ByteSizeValue(in.readVLong(), ByteSizeUnit.BYTES);
+        this.value = ByteSizeValue.ofBytes(in.readVLong());
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/rollover/MinPrimaryShardSizeCondition.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/rollover/MinPrimaryShardSizeCondition.java
@@ -31,7 +31,7 @@ public class MinPrimaryShardSizeCondition extends Condition<ByteSizeValue> {
 
     public MinPrimaryShardSizeCondition(StreamInput in) throws IOException {
         super(NAME, Type.MIN);
-        this.value = new ByteSizeValue(in);
+        this.value = ByteSizeValue.readFrom(in);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/rollover/MinSizeCondition.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/rollover/MinSizeCondition.java
@@ -31,7 +31,7 @@ public class MinSizeCondition extends Condition<ByteSizeValue> {
 
     public MinSizeCondition(StreamInput in) throws IOException {
         super(NAME, Type.MIN);
-        this.value = new ByteSizeValue(in);
+        this.value = ByteSizeValue.readFrom(in);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/rollover/TransportRolloverAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/rollover/TransportRolloverAction.java
@@ -228,8 +228,8 @@ public class TransportRolloverAction extends TransportMasterNodeAction<RolloverR
             return new Condition.Stats(
                 docsStats == null ? 0 : docsStats.getCount(),
                 metadata.getCreationDate(),
-                new ByteSizeValue(docsStats == null ? 0 : docsStats.getTotalSizeInBytes()),
-                new ByteSizeValue(maxPrimaryShardSize),
+                ByteSizeValue.ofBytes(docsStats == null ? 0 : docsStats.getTotalSizeInBytes()),
+                ByteSizeValue.ofBytes(maxPrimaryShardSize),
                 maxPrimaryShardDocs
             );
         }

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/segments/IndicesSegmentResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/segments/IndicesSegmentResponse.java
@@ -113,7 +113,7 @@ public class IndicesSegmentResponse extends BaseBroadcastResponse implements Chu
                         builder.field(Fields.DELETED_DOCS, segment.getDeletedDocs());
                         builder.humanReadableField(Fields.SIZE_IN_BYTES, Fields.SIZE, segment.getSize());
                         if (builder.getRestApiVersion() == RestApiVersion.V_7) {
-                            builder.humanReadableField(Fields.MEMORY_IN_BYTES, Fields.MEMORY, new ByteSizeValue(0));
+                            builder.humanReadableField(Fields.MEMORY_IN_BYTES, Fields.MEMORY, ByteSizeValue.ZERO);
                         }
                         builder.field(Fields.COMMITTED, segment.isCommitted());
                         builder.field(Fields.SEARCH, segment.isSearch());

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/shrink/ResizeRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/shrink/ResizeRequest.java
@@ -68,7 +68,7 @@ public class ResizeRequest extends AcknowledgedRequest<ResizeRequest> implements
         type = in.readEnum(ResizeType.class);
         copySettings = in.readOptionalBoolean();
         if (in.readBoolean()) {
-            maxPrimaryShardSize = new ByteSizeValue(in);
+            maxPrimaryShardSize = ByteSizeValue.readFrom(in);
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/stats/CommonStats.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/stats/CommonStats.java
@@ -554,7 +554,7 @@ public class CommonStats implements Writeable, ToXContentFragment {
             size += this.getSegments().getIndexWriterMemoryInBytes() + this.getSegments().getVersionMapMemoryInBytes();
         }
 
-        return new ByteSizeValue(size);
+        return ByteSizeValue.ofBytes(size);
     }
 
     // note, requires a wrapping object

--- a/server/src/main/java/org/elasticsearch/action/datastreams/DataStreamsStatsAction.java
+++ b/server/src/main/java/org/elasticsearch/action/datastreams/DataStreamsStatsAction.java
@@ -74,7 +74,7 @@ public class DataStreamsStatsAction extends ActionType<DataStreamsStatsAction.Re
             super(in);
             this.dataStreamCount = in.readVInt();
             this.backingIndices = in.readVInt();
-            this.totalStoreSize = new ByteSizeValue(in);
+            this.totalStoreSize = ByteSizeValue.readFrom(in);
             this.dataStreams = in.readArray(DataStreamStats::new, DataStreamStats[]::new);
         }
 
@@ -164,7 +164,7 @@ public class DataStreamsStatsAction extends ActionType<DataStreamsStatsAction.Re
         public DataStreamStats(StreamInput in) throws IOException {
             this.dataStream = in.readString();
             this.backingIndices = in.readVInt();
-            this.storeSize = new ByteSizeValue(in);
+            this.storeSize = ByteSizeValue.readFrom(in);
             this.maximumTimestamp = in.readVLong();
         }
 

--- a/server/src/main/java/org/elasticsearch/action/index/IndexRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/index/IndexRequest.java
@@ -717,9 +717,9 @@ public class IndexRequest extends ReplicatedWriteRequest<IndexRequest> implement
         try {
             if (source.length() > MAX_SOURCE_LENGTH_IN_TOSTRING) {
                 sSource = "n/a, actual length: ["
-                    + new ByteSizeValue(source.length()).toString()
+                    + ByteSizeValue.ofBytes(source.length()).toString()
                     + "], max length: "
-                    + new ByteSizeValue(MAX_SOURCE_LENGTH_IN_TOSTRING).toString();
+                    + ByteSizeValue.ofBytes(MAX_SOURCE_LENGTH_IN_TOSTRING).toString();
             } else {
                 sSource = XContentHelper.convertToJson(source, false);
             }

--- a/server/src/main/java/org/elasticsearch/cluster/ClusterInfo.java
+++ b/server/src/main/java/org/elasticsearch/cluster/ClusterInfo.java
@@ -165,14 +165,14 @@ public class ClusterInfo implements ToXContentFragment, Writeable {
         builder.startObject("shard_sizes");
         {
             for (Map.Entry<String, Long> c : this.shardSizes.entrySet()) {
-                builder.humanReadableField(c.getKey() + "_bytes", c.getKey(), new ByteSizeValue(c.getValue()));
+                builder.humanReadableField(c.getKey() + "_bytes", c.getKey(), ByteSizeValue.ofBytes(c.getValue()));
             }
         }
         builder.endObject(); // end "shard_sizes"
         builder.startObject("shard_data_set_sizes");
         {
             for (Map.Entry<ShardId, Long> c : this.shardDataSetSizes.entrySet()) {
-                builder.humanReadableField(c.getKey() + "_bytes", c.getKey().toString(), new ByteSizeValue(c.getValue()));
+                builder.humanReadableField(c.getKey() + "_bytes", c.getKey().toString(), ByteSizeValue.ofBytes(c.getValue()));
             }
         }
         builder.endObject(); // end "shard_data_set_sizes"

--- a/server/src/main/java/org/elasticsearch/cluster/DiskUsage.java
+++ b/server/src/main/java/org/elasticsearch/cluster/DiskUsage.java
@@ -52,9 +52,9 @@ public record DiskUsage(String nodeId, String nodeName, String path, long totalB
 
     XContentBuilder toShortXContent(XContentBuilder builder) throws IOException {
         builder.field("path", this.path);
-        builder.humanReadableField("total_bytes", "total", new ByteSizeValue(this.totalBytes));
-        builder.humanReadableField("used_bytes", "used", new ByteSizeValue(this.getUsedBytes()));
-        builder.humanReadableField("free_bytes", "free", new ByteSizeValue(this.freeBytes));
+        builder.humanReadableField("total_bytes", "total", ByteSizeValue.ofBytes(this.totalBytes));
+        builder.humanReadableField("used_bytes", "used", ByteSizeValue.ofBytes(this.getUsedBytes()));
+        builder.humanReadableField("free_bytes", "free", ByteSizeValue.ofBytes(this.freeBytes));
         builder.field("free_disk_percent", truncatePercent(this.getFreeDiskAsPercentage()));
         builder.field("used_disk_percent", truncatePercent(this.getUsedDiskAsPercentage()));
         return builder;
@@ -113,7 +113,7 @@ public record DiskUsage(String nodeId, String nodeName, String path, long totalB
             + "]["
             + path
             + "] free: "
-            + new ByteSizeValue(getFreeBytes())
+            + ByteSizeValue.ofBytes(getFreeBytes())
             + "["
             + Strings.format1Decimals(getFreeDiskAsPercentage(), "%")
             + "]";

--- a/server/src/main/java/org/elasticsearch/cluster/coordination/ClusterStateSerializationStats.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/ClusterStateSerializationStats.java
@@ -82,13 +82,17 @@ public class ClusterStateSerializationStats implements Writeable, ToXContentObje
         builder.startObject();
         builder.startObject("full_states");
         builder.field("count", fullStateCount);
-        builder.humanReadableField("uncompressed_size_in_bytes", "uncompressed_size", new ByteSizeValue(totalUncompressedFullStateBytes));
-        builder.humanReadableField("compressed_size_in_bytes", "compressed_size", new ByteSizeValue(totalCompressedFullStateBytes));
+        builder.humanReadableField(
+            "uncompressed_size_in_bytes",
+            "uncompressed_size",
+            ByteSizeValue.ofBytes(totalUncompressedFullStateBytes)
+        );
+        builder.humanReadableField("compressed_size_in_bytes", "compressed_size", ByteSizeValue.ofBytes(totalCompressedFullStateBytes));
         builder.endObject();
         builder.startObject("diffs");
         builder.field("count", diffCount);
-        builder.humanReadableField("uncompressed_size_in_bytes", "uncompressed_size", new ByteSizeValue(totalUncompressedDiffBytes));
-        builder.humanReadableField("compressed_size_in_bytes", "compressed_size", new ByteSizeValue(totalCompressedDiffBytes));
+        builder.humanReadableField("uncompressed_size_in_bytes", "uncompressed_size", ByteSizeValue.ofBytes(totalUncompressedDiffBytes));
+        builder.humanReadableField("compressed_size_in_bytes", "compressed_size", ByteSizeValue.ofBytes(totalCompressedDiffBytes));
         builder.endObject();
         builder.endObject();
         return builder;

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/DesiredNode.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/DesiredNode.java
@@ -180,8 +180,8 @@ public final class DesiredNode implements Writeable, ToXContentObject, Comparabl
             processors = Processors.readFrom(in);
             processorsRange = null;
         }
-        final var memory = new ByteSizeValue(in);
-        final var storage = new ByteSizeValue(in);
+        final var memory = ByteSizeValue.readFrom(in);
+        final var storage = ByteSizeValue.readFrom(in);
         final var version = Version.readVersion(in);
         return new DesiredNode(settings, processors, processorsRange, memory, storage, version);
     }

--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/NodeAllocationResult.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/NodeAllocationResult.java
@@ -265,7 +265,7 @@ public class NodeAllocationResult implements ToXContentObject, Writeable, Compar
                     if (hasMatchingSyncId()) {
                         builder.field("matching_sync_id", true);
                     } else {
-                        builder.humanReadableField("matching_size_in_bytes", "matching_size", new ByteSizeValue(matchingBytes));
+                        builder.humanReadableField("matching_size_in_bytes", "matching_size", ByteSizeValue.ofBytes(matchingBytes));
                     }
                 }
                 if (storeException != null) {

--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/DiskThresholdDecider.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/DiskThresholdDecider.java
@@ -229,7 +229,7 @@ public class DiskThresholdDecider extends AllocationDecider {
             );
         }
 
-        ByteSizeValue freeBytesValue = new ByteSizeValue(freeBytes);
+        ByteSizeValue freeBytesValue = ByteSizeValue.ofBytes(freeBytes);
         if (logger.isTraceEnabled()) {
             logger.trace("node [{}] has {}% used disk", node.nodeId(), usedDiskPercentage);
         }
@@ -319,7 +319,7 @@ public class DiskThresholdDecider extends AllocationDecider {
                 diskThresholdSettings.getFreeBytesThresholdHighStage(total),
                 freeBytesValue,
                 Strings.format1Decimals(usedDiskPercentage, "%"),
-                new ByteSizeValue(shardSize)
+                ByteSizeValue.ofBytes(shardSize)
             );
             return allocation.decision(
                 Decision.NO,
@@ -331,7 +331,7 @@ public class DiskThresholdDecider extends AllocationDecider {
                 diskThresholdSettings.getFreeBytesThresholdHighStage(total),
                 freeBytesValue,
                 Strings.format1Decimals(usedDiskPercentage, "%"),
-                new ByteSizeValue(shardSize)
+                ByteSizeValue.ofBytes(shardSize)
             );
         }
 
@@ -342,8 +342,8 @@ public class DiskThresholdDecider extends AllocationDecider {
             "enough disk for shard on node, free: [%s], used: [%s], shard size: [%s], free after allocating shard: [%s]",
             freeBytesValue,
             Strings.format1Decimals(usedDiskPercentage, "%"),
-            new ByteSizeValue(shardSize),
-            new ByteSizeValue(freeBytesAfterShard)
+            ByteSizeValue.ofBytes(shardSize),
+            ByteSizeValue.ofBytes(freeBytesAfterShard)
         );
     }
 
@@ -466,7 +466,7 @@ public class DiskThresholdDecider extends AllocationDecider {
                     + "and there is less than the required [%s] free space on node, actual free: [%s], actual used: [%s]",
                 diskThresholdSettings.describeHighThreshold(total, true),
                 diskThresholdSettings.getFreeBytesThresholdHighStage(total),
-                new ByteSizeValue(freeBytes),
+                ByteSizeValue.ofBytes(freeBytes),
                 Strings.format1Decimals(usedDiskPercentage, "%")
             );
         }
@@ -475,7 +475,7 @@ public class DiskThresholdDecider extends AllocationDecider {
             Decision.YES,
             NAME,
             "there is enough disk on this node for the shard to remain, free: [%s]",
-            new ByteSizeValue(freeBytes)
+            ByteSizeValue.ofBytes(freeBytes)
         );
     }
 

--- a/server/src/main/java/org/elasticsearch/common/FieldMemoryStats.java
+++ b/server/src/main/java/org/elasticsearch/common/FieldMemoryStats.java
@@ -67,7 +67,7 @@ public final class FieldMemoryStats implements Writeable, Iterable<Map.Entry<Str
         builder.startObject(key);
         for (var entry : stats.entrySet()) {
             builder.startObject(entry.getKey());
-            builder.humanReadableField(rawKey, readableKey, new ByteSizeValue(entry.getValue()));
+            builder.humanReadableField(rawKey, readableKey, ByteSizeValue.ofBytes(entry.getValue()));
             builder.endObject();
         }
         builder.endObject();

--- a/server/src/main/java/org/elasticsearch/common/breaker/ChildMemoryCircuitBreaker.java
+++ b/server/src/main/java/org/elasticsearch/common/breaker/ChildMemoryCircuitBreaker.java
@@ -66,12 +66,12 @@ public class ChildMemoryCircuitBreaker implements CircuitBreaker {
             + " would be ["
             + bytesNeeded
             + "/"
-            + new ByteSizeValue(bytesNeeded)
+            + ByteSizeValue.ofBytes(bytesNeeded)
             + "]"
             + ", which is larger than the limit of ["
             + memoryBytesLimit
             + "/"
-            + new ByteSizeValue(memoryBytesLimit)
+            + ByteSizeValue.ofBytes(memoryBytesLimit)
             + "]";
         logger.debug(() -> format("%s", message));
         throw new CircuitBreakingException(message, bytesNeeded, memoryBytesLimit, durability);
@@ -124,9 +124,9 @@ public class ChildMemoryCircuitBreaker implements CircuitBreaker {
             () -> format(
                 "[%s] Adding [%s][%s] to used bytes [new used: [%s], limit: [-1b]]",
                 this.name,
-                new ByteSizeValue(bytes),
+                ByteSizeValue.ofBytes(bytes),
                 label,
-                new ByteSizeValue(newUsed)
+                ByteSizeValue.ofBytes(newUsed)
             )
         );
         return newUsed;
@@ -145,13 +145,13 @@ public class ChildMemoryCircuitBreaker implements CircuitBreaker {
                 logger.trace(
                     "[{}] Adding [{}][{}] to used bytes [new used: [{}], limit: {} [{}], estimate: {} [{}]]",
                     this.name,
-                    new ByteSizeValue(bytes),
+                    ByteSizeValue.ofBytes(bytes),
                     label,
-                    new ByteSizeValue(newUsed),
+                    ByteSizeValue.ofBytes(newUsed),
                     memoryBytesLimit,
-                    new ByteSizeValue(memoryBytesLimit),
+                    ByteSizeValue.ofBytes(memoryBytesLimit),
                     newUsedWithOverhead,
-                    new ByteSizeValue(newUsedWithOverhead)
+                    ByteSizeValue.ofBytes(newUsedWithOverhead)
                 );
             }
             if (memoryBytesLimit > 0 && newUsedWithOverhead > memoryBytesLimit) {
@@ -159,10 +159,10 @@ public class ChildMemoryCircuitBreaker implements CircuitBreaker {
                     "[{}] New used memory {} [{}] for data of [{}] would be larger than configured breaker: {} [{}], breaking",
                     this.name,
                     newUsedWithOverhead,
-                    new ByteSizeValue(newUsedWithOverhead),
+                    ByteSizeValue.ofBytes(newUsedWithOverhead),
                     label,
                     memoryBytesLimit,
-                    new ByteSizeValue(memoryBytesLimit)
+                    ByteSizeValue.ofBytes(memoryBytesLimit)
                 );
                 circuitBreak(label, newUsedWithOverhead);
             }

--- a/server/src/main/java/org/elasticsearch/common/network/NetworkService.java
+++ b/server/src/main/java/org/elasticsearch/common/network/NetworkService.java
@@ -64,12 +64,12 @@ public final class NetworkService {
     );
     public static final Setting<ByteSizeValue> TCP_SEND_BUFFER_SIZE = Setting.byteSizeSetting(
         "network.tcp.send_buffer_size",
-        new ByteSizeValue(-1),
+        ByteSizeValue.MINUS_ONE,
         Property.NodeScope
     );
     public static final Setting<ByteSizeValue> TCP_RECEIVE_BUFFER_SIZE = Setting.byteSizeSetting(
         "network.tcp.receive_buffer_size",
-        new ByteSizeValue(-1),
+        ByteSizeValue.MINUS_ONE,
         Property.NodeScope
     );
 

--- a/server/src/main/java/org/elasticsearch/common/unit/MemorySizeValue.java
+++ b/server/src/main/java/org/elasticsearch/common/unit/MemorySizeValue.java
@@ -31,7 +31,7 @@ public enum MemorySizeValue {
                 if (percent < 0 || percent > 100) {
                     throw new ElasticsearchParseException("percentage should be in [0-100], got [{}]", percentAsString);
                 }
-                return new ByteSizeValue((long) ((percent / 100) * JvmInfo.jvmInfo().getMem().getHeapMax().getBytes()), ByteSizeUnit.BYTES);
+                return ByteSizeValue.ofBytes((long) ((percent / 100) * JvmInfo.jvmInfo().getMem().getHeapMax().getBytes()));
             } catch (NumberFormatException e) {
                 throw new ElasticsearchParseException("failed to parse [{}] as a double", e, percentAsString);
             }

--- a/server/src/main/java/org/elasticsearch/gateway/ReplicaShardAllocator.java
+++ b/server/src/main/java/org/elasticsearch/gateway/ReplicaShardAllocator.java
@@ -431,7 +431,7 @@ public abstract class ReplicaShardAllocator extends BaseGatewayShardAllocator {
                         "{}: node [{}] has [{}/{}] bytes of re-usable data",
                         shard,
                         discoNode.getName(),
-                        new ByteSizeValue(matchingNode.matchingBytes),
+                        ByteSizeValue.ofBytes(matchingNode.matchingBytes),
                         matchingNode.matchingBytes
                     );
                 }

--- a/server/src/main/java/org/elasticsearch/health/metadata/HealthMetadata.java
+++ b/server/src/main/java/org/elasticsearch/health/metadata/HealthMetadata.java
@@ -132,12 +132,12 @@ public final class HealthMetadata extends AbstractNamedDiffable<ClusterState.Cus
                 in.readString(),
                 FROZEN_FLOOD_STAGE_WATERMARK_FIELD.getPreferredName()
             );
-            ByteSizeValue frozenFloodStageMaxHeadroom = new ByteSizeValue(in);
+            ByteSizeValue frozenFloodStageMaxHeadroom = ByteSizeValue.readFrom(in);
             ByteSizeValue highMaxHeadroom = in.getVersion().onOrAfter(VERSION_SUPPORTING_HEADROOM_FIELDS)
-                ? new ByteSizeValue(in)
+                ? ByteSizeValue.readFrom(in)
                 : ByteSizeValue.MINUS_ONE;
             ByteSizeValue floodStageMaxHeadroom = in.getVersion().onOrAfter(VERSION_SUPPORTING_HEADROOM_FIELDS)
-                ? new ByteSizeValue(in)
+                ? ByteSizeValue.readFrom(in)
                 : ByteSizeValue.MINUS_ONE;
             return new Disk(
                 highWatermark,

--- a/server/src/main/java/org/elasticsearch/http/HttpInfo.java
+++ b/server/src/main/java/org/elasticsearch/http/HttpInfo.java
@@ -58,7 +58,7 @@ public class HttpInfo implements ReportingService.Info {
             publishAddressString = hostString + '/' + publishAddress;
         }
         builder.field(Fields.PUBLISH_ADDRESS, publishAddressString);
-        builder.humanReadableField(Fields.MAX_CONTENT_LENGTH_IN_BYTES, Fields.MAX_CONTENT_LENGTH, new ByteSizeValue(maxContentLength));
+        builder.humanReadableField(Fields.MAX_CONTENT_LENGTH_IN_BYTES, Fields.MAX_CONTENT_LENGTH, ByteSizeValue.ofBytes(maxContentLength));
         builder.endObject();
         return builder;
     }

--- a/server/src/main/java/org/elasticsearch/http/HttpTransportSettings.java
+++ b/server/src/main/java/org/elasticsearch/http/HttpTransportSettings.java
@@ -95,8 +95,8 @@ public final class HttpTransportSettings {
     public static final Setting<ByteSizeValue> SETTING_HTTP_MAX_CONTENT_LENGTH = Setting.byteSizeSetting(
         "http.max_content_length",
         new ByteSizeValue(100, ByteSizeUnit.MB),
-        new ByteSizeValue(0, ByteSizeUnit.BYTES),
-        new ByteSizeValue(Integer.MAX_VALUE, ByteSizeUnit.BYTES),
+        ByteSizeValue.ZERO,
+        ByteSizeValue.ofBytes(Integer.MAX_VALUE),
         Property.NodeScope
     );
     public static final Setting<ByteSizeValue> SETTING_HTTP_MAX_CHUNK_SIZE = Setting.byteSizeSetting(
@@ -117,7 +117,7 @@ public final class HttpTransportSettings {
     );
     public static final Setting<ByteSizeValue> SETTING_HTTP_MAX_WARNING_HEADER_SIZE = Setting.byteSizeSetting(
         "http.max_warning_header_size",
-        new ByteSizeValue(-1),
+        ByteSizeValue.MINUS_ONE,
         Property.NodeScope
     );
     public static final Setting<ByteSizeValue> SETTING_HTTP_MAX_INITIAL_LINE_LENGTH = Setting.byteSizeSetting(

--- a/server/src/main/java/org/elasticsearch/index/IndexSettings.java
+++ b/server/src/main/java/org/elasticsearch/index/IndexSettings.java
@@ -266,8 +266,8 @@ public final class IndexSettings {
          * can get stuck in an infinite loop as the shouldPeriodicallyFlush can still be true after flushing.
          * However, small thresholds are useful for testing so we do not add a large lower bound here.
          */
-        new ByteSizeValue(Translog.DEFAULT_HEADER_SIZE_IN_BYTES + 1, ByteSizeUnit.BYTES),
-        new ByteSizeValue(Long.MAX_VALUE, ByteSizeUnit.BYTES),
+        ByteSizeValue.ofBytes(Translog.DEFAULT_HEADER_SIZE_IN_BYTES + 1),
+        ByteSizeValue.ofBytes(Long.MAX_VALUE),
         Property.Dynamic,
         Property.IndexScope
     );
@@ -278,8 +278,8 @@ public final class IndexSettings {
     public static final Setting<ByteSizeValue> INDEX_FLUSH_AFTER_MERGE_THRESHOLD_SIZE_SETTING = Setting.byteSizeSetting(
         "index.flush_after_merge",
         new ByteSizeValue(512, ByteSizeUnit.MB),
-        new ByteSizeValue(0, ByteSizeUnit.BYTES), // always flush after merge
-        new ByteSizeValue(Long.MAX_VALUE, ByteSizeUnit.BYTES), // never flush after merge
+        ByteSizeValue.ZERO, // always flush after merge
+        ByteSizeValue.ofBytes(Long.MAX_VALUE), // never flush after merge
         Property.Dynamic,
         Property.IndexScope
     );
@@ -297,8 +297,8 @@ public final class IndexSettings {
          * generation threshold. However, small thresholds are useful for testing so we
          * do not add a large lower bound here.
          */
-        new ByteSizeValue(Translog.DEFAULT_HEADER_SIZE_IN_BYTES + 1, ByteSizeUnit.BYTES),
-        new ByteSizeValue(Long.MAX_VALUE, ByteSizeUnit.BYTES),
+        ByteSizeValue.ofBytes(Translog.DEFAULT_HEADER_SIZE_IN_BYTES + 1),
+        ByteSizeValue.ofBytes(Long.MAX_VALUE),
         Property.Dynamic,
         Property.IndexScope
     );

--- a/server/src/main/java/org/elasticsearch/index/cache/query/QueryCacheStats.java
+++ b/server/src/main/java/org/elasticsearch/index/cache/query/QueryCacheStats.java
@@ -62,7 +62,7 @@ public class QueryCacheStats implements Writeable, ToXContentFragment {
     }
 
     public ByteSizeValue getMemorySize() {
-        return new ByteSizeValue(ramBytesUsed);
+        return ByteSizeValue.ofBytes(ramBytesUsed);
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/index/cache/request/RequestCacheStats.java
+++ b/server/src/main/java/org/elasticsearch/index/cache/request/RequestCacheStats.java
@@ -56,7 +56,7 @@ public class RequestCacheStats implements Writeable, ToXContentFragment {
     }
 
     public ByteSizeValue getMemorySize() {
-        return new ByteSizeValue(memorySize);
+        return ByteSizeValue.ofBytes(memorySize);
     }
 
     public long getEvictions() {

--- a/server/src/main/java/org/elasticsearch/index/engine/ElasticsearchConcurrentMergeScheduler.java
+++ b/server/src/main/java/org/elasticsearch/index/engine/ElasticsearchConcurrentMergeScheduler.java
@@ -109,8 +109,8 @@ class ElasticsearchConcurrentMergeScheduler extends ConcurrentMergeScheduler {
                 getSegmentName(merge),
                 merge.segments.size(),
                 totalNumDocs,
-                new ByteSizeValue(totalSizeInBytes),
-                new ByteSizeValue(merge.estimatedMergeBytes)
+                ByteSizeValue.ofBytes(totalSizeInBytes),
+                ByteSizeValue.ofBytes(merge.estimatedMergeBytes)
             );
         }
         try {

--- a/server/src/main/java/org/elasticsearch/index/engine/Segment.java
+++ b/server/src/main/java/org/elasticsearch/index/engine/Segment.java
@@ -96,7 +96,7 @@ public class Segment implements Writeable {
     }
 
     public ByteSizeValue getSize() {
-        return new ByteSizeValue(sizeInBytes);
+        return ByteSizeValue.ofBytes(sizeInBytes);
     }
 
     public org.apache.lucene.util.Version getVersion() {

--- a/server/src/main/java/org/elasticsearch/index/engine/SegmentsStats.java
+++ b/server/src/main/java/org/elasticsearch/index/engine/SegmentsStats.java
@@ -106,7 +106,7 @@ public class SegmentsStats implements Writeable, ToXContentFragment {
     }
 
     public ByteSizeValue getIndexWriterMemory() {
-        return new ByteSizeValue(indexWriterMemoryInBytes);
+        return ByteSizeValue.ofBytes(indexWriterMemoryInBytes);
     }
 
     /**
@@ -117,7 +117,7 @@ public class SegmentsStats implements Writeable, ToXContentFragment {
     }
 
     public ByteSizeValue getVersionMapMemory() {
-        return new ByteSizeValue(versionMapMemoryInBytes);
+        return ByteSizeValue.ofBytes(versionMapMemoryInBytes);
     }
 
     /**
@@ -128,7 +128,7 @@ public class SegmentsStats implements Writeable, ToXContentFragment {
     }
 
     public ByteSizeValue getBitsetMemory() {
-        return new ByteSizeValue(bitsetMemoryInBytes);
+        return ByteSizeValue.ofBytes(bitsetMemoryInBytes);
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/index/fielddata/FieldDataStats.java
+++ b/server/src/main/java/org/elasticsearch/index/fielddata/FieldDataStats.java
@@ -68,7 +68,7 @@ public class FieldDataStats implements Writeable, ToXContentFragment {
     }
 
     public ByteSizeValue getMemorySize() {
-        return new ByteSizeValue(memorySize);
+        return ByteSizeValue.ofBytes(memorySize);
     }
 
     public long getEvictions() {

--- a/server/src/main/java/org/elasticsearch/index/mapper/NodeMappingStats.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/NodeMappingStats.java
@@ -60,7 +60,7 @@ public class NodeMappingStats implements Writeable, ToXContentFragment {
     }
 
     public ByteSizeValue getTotalEstimatedOverhead() {
-        return new ByteSizeValue(totalEstimatedOverhead);
+        return ByteSizeValue.ofBytes(totalEstimatedOverhead);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/index/merge/MergeStats.java
+++ b/server/src/main/java/org/elasticsearch/index/merge/MergeStats.java
@@ -203,7 +203,7 @@ public class MergeStats implements Writeable, ToXContentFragment {
     }
 
     public ByteSizeValue getTotalSize() {
-        return new ByteSizeValue(totalSizeInBytes);
+        return ByteSizeValue.ofBytes(totalSizeInBytes);
     }
 
     public long getTotalBytesPerSecAutoThrottle() {
@@ -226,7 +226,7 @@ public class MergeStats implements Writeable, ToXContentFragment {
     }
 
     public ByteSizeValue getCurrentSize() {
-        return new ByteSizeValue(currentSizeInBytes);
+        return ByteSizeValue.ofBytes(currentSizeInBytes);
     }
 
     @Override
@@ -242,7 +242,7 @@ public class MergeStats implements Writeable, ToXContentFragment {
         builder.humanReadableField(Fields.TOTAL_STOPPED_TIME_IN_MILLIS, Fields.TOTAL_STOPPED_TIME, getTotalStoppedTime());
         builder.humanReadableField(Fields.TOTAL_THROTTLED_TIME_IN_MILLIS, Fields.TOTAL_THROTTLED_TIME, getTotalThrottledTime());
         if (builder.humanReadable() && totalBytesPerSecAutoThrottle != -1) {
-            builder.field(Fields.TOTAL_THROTTLE_BYTES_PER_SEC).value(new ByteSizeValue(totalBytesPerSecAutoThrottle).toString());
+            builder.field(Fields.TOTAL_THROTTLE_BYTES_PER_SEC).value(ByteSizeValue.ofBytes(totalBytesPerSecAutoThrottle).toString());
         }
         builder.field(Fields.TOTAL_THROTTLE_BYTES_PER_SEC_IN_BYTES, totalBytesPerSecAutoThrottle);
         builder.endObject();

--- a/server/src/main/java/org/elasticsearch/index/shard/PrimaryReplicaSyncer.java
+++ b/server/src/main/java/org/elasticsearch/index/shard/PrimaryReplicaSyncer.java
@@ -357,7 +357,7 @@ public class PrimaryReplicaSyncer {
                     "{} sending batch of [{}][{}] (total sent: [{}], skipped: [{}])",
                     shardId,
                     operations.size(),
-                    new ByteSizeValue(size),
+                    ByteSizeValue.ofBytes(size),
                     totalSentOps.get(),
                     totalSkippedOps.get()
                 );

--- a/server/src/main/java/org/elasticsearch/index/shard/StoreRecovery.java
+++ b/server/src/main/java/org/elasticsearch/index/shard/StoreRecovery.java
@@ -328,19 +328,19 @@ public final class StoreRecovery {
                     sb.append("    index    : files           [")
                         .append(index.totalFileCount())
                         .append("] with total_size [")
-                        .append(new ByteSizeValue(index.totalBytes()))
+                        .append(ByteSizeValue.ofBytes(index.totalBytes()))
                         .append("], took[")
                         .append(TimeValue.timeValueMillis(index.time()))
                         .append("]\n");
                     sb.append("             : recovered_files [")
                         .append(index.recoveredFileCount())
                         .append("] with total_size [")
-                        .append(new ByteSizeValue(index.recoveredBytes()))
+                        .append(ByteSizeValue.ofBytes(index.recoveredBytes()))
                         .append("]\n");
                     sb.append("             : reusing_files   [")
                         .append(index.reusedFileCount())
                         .append("] with total_size [")
-                        .append(new ByteSizeValue(index.reusedBytes()))
+                        .append(ByteSizeValue.ofBytes(index.reusedBytes()))
                         .append("]\n");
                     sb.append("    verify_index    : took [")
                         .append(TimeValue.timeValueMillis(recoveryState.getVerifyIndex().time()))

--- a/server/src/main/java/org/elasticsearch/index/snapshots/blobstore/BlobStoreIndexShardSnapshot.java
+++ b/server/src/main/java/org/elasticsearch/index/snapshots/blobstore/BlobStoreIndexShardSnapshot.java
@@ -80,7 +80,7 @@ public class BlobStoreIndexShardSnapshot implements ToXContentFragment {
         }
 
         public FileInfo(StreamInput in) throws IOException {
-            this(in.readString(), new StoreFileMetadata(in), in.readOptionalWriteable(ByteSizeValue::new));
+            this(in.readString(), new StoreFileMetadata(in), in.readOptionalWriteable(ByteSizeValue::readFrom));
         }
 
         @Override
@@ -309,7 +309,7 @@ public class BlobStoreIndexShardSnapshot implements ToXContentFragment {
                     case PHYSICAL_NAME -> physicalName = parser.text();
                     case LENGTH -> length = parser.longValue();
                     case CHECKSUM -> checksum = parser.text();
-                    case PART_SIZE -> partSize = new ByteSizeValue(parser.longValue());
+                    case PART_SIZE -> partSize = ByteSizeValue.ofBytes(parser.longValue());
                     case WRITTEN_BY -> writtenBy = parser.text();
                     case META_HASH -> {
                         metaHash.bytes = parser.binaryValue();

--- a/server/src/main/java/org/elasticsearch/index/stats/IndexingPressureStats.java
+++ b/server/src/main/java/org/elasticsearch/index/stats/IndexingPressureStats.java
@@ -227,23 +227,27 @@ public class IndexingPressureStats implements Writeable, ToXContentFragment {
         builder.startObject("indexing_pressure");
         builder.startObject("memory");
         builder.startObject("current");
-        builder.humanReadableField(COMBINED_IN_BYTES, COMBINED, new ByteSizeValue(currentCombinedCoordinatingAndPrimaryBytes));
-        builder.humanReadableField(COORDINATING_IN_BYTES, COORDINATING, new ByteSizeValue(currentCoordinatingBytes));
-        builder.humanReadableField(PRIMARY_IN_BYTES, PRIMARY, new ByteSizeValue(currentPrimaryBytes));
-        builder.humanReadableField(REPLICA_IN_BYTES, REPLICA, new ByteSizeValue(currentReplicaBytes));
-        builder.humanReadableField(ALL_IN_BYTES, ALL, new ByteSizeValue(currentReplicaBytes + currentCombinedCoordinatingAndPrimaryBytes));
+        builder.humanReadableField(COMBINED_IN_BYTES, COMBINED, ByteSizeValue.ofBytes(currentCombinedCoordinatingAndPrimaryBytes));
+        builder.humanReadableField(COORDINATING_IN_BYTES, COORDINATING, ByteSizeValue.ofBytes(currentCoordinatingBytes));
+        builder.humanReadableField(PRIMARY_IN_BYTES, PRIMARY, ByteSizeValue.ofBytes(currentPrimaryBytes));
+        builder.humanReadableField(REPLICA_IN_BYTES, REPLICA, ByteSizeValue.ofBytes(currentReplicaBytes));
+        builder.humanReadableField(
+            ALL_IN_BYTES,
+            ALL,
+            ByteSizeValue.ofBytes(currentReplicaBytes + currentCombinedCoordinatingAndPrimaryBytes)
+        );
         builder.endObject();
         builder.startObject("total");
-        builder.humanReadableField(COMBINED_IN_BYTES, COMBINED, new ByteSizeValue(totalCombinedCoordinatingAndPrimaryBytes));
-        builder.humanReadableField(COORDINATING_IN_BYTES, COORDINATING, new ByteSizeValue(totalCoordinatingBytes));
-        builder.humanReadableField(PRIMARY_IN_BYTES, PRIMARY, new ByteSizeValue(totalPrimaryBytes));
-        builder.humanReadableField(REPLICA_IN_BYTES, REPLICA, new ByteSizeValue(totalReplicaBytes));
-        builder.humanReadableField(ALL_IN_BYTES, ALL, new ByteSizeValue(totalReplicaBytes + totalCombinedCoordinatingAndPrimaryBytes));
+        builder.humanReadableField(COMBINED_IN_BYTES, COMBINED, ByteSizeValue.ofBytes(totalCombinedCoordinatingAndPrimaryBytes));
+        builder.humanReadableField(COORDINATING_IN_BYTES, COORDINATING, ByteSizeValue.ofBytes(totalCoordinatingBytes));
+        builder.humanReadableField(PRIMARY_IN_BYTES, PRIMARY, ByteSizeValue.ofBytes(totalPrimaryBytes));
+        builder.humanReadableField(REPLICA_IN_BYTES, REPLICA, ByteSizeValue.ofBytes(totalReplicaBytes));
+        builder.humanReadableField(ALL_IN_BYTES, ALL, ByteSizeValue.ofBytes(totalReplicaBytes + totalCombinedCoordinatingAndPrimaryBytes));
         builder.field(COORDINATING_REJECTIONS, coordinatingRejections);
         builder.field(PRIMARY_REJECTIONS, primaryRejections);
         builder.field(REPLICA_REJECTIONS, replicaRejections);
         builder.endObject();
-        builder.humanReadableField(LIMIT_IN_BYTES, LIMIT, new ByteSizeValue(memoryLimit));
+        builder.humanReadableField(LIMIT_IN_BYTES, LIMIT, ByteSizeValue.ofBytes(memoryLimit));
         builder.endObject();
         return builder.endObject();
     }

--- a/server/src/main/java/org/elasticsearch/index/store/StoreStats.java
+++ b/server/src/main/java/org/elasticsearch/index/store/StoreStats.java
@@ -87,7 +87,7 @@ public class StoreStats implements Writeable, ToXContentFragment {
     }
 
     public ByteSizeValue size() {
-        return new ByteSizeValue(sizeInBytes);
+        return ByteSizeValue.ofBytes(sizeInBytes);
     }
 
     public ByteSizeValue getSize() {
@@ -95,7 +95,7 @@ public class StoreStats implements Writeable, ToXContentFragment {
     }
 
     public ByteSizeValue totalDataSetSize() {
-        return new ByteSizeValue(totalDataSetSizeInBytes);
+        return ByteSizeValue.ofBytes(totalDataSetSizeInBytes);
     }
 
     public ByteSizeValue getTotalDataSetSize() {
@@ -112,7 +112,7 @@ public class StoreStats implements Writeable, ToXContentFragment {
      * the reserved size is unknown.
      */
     public ByteSizeValue getReservedSize() {
-        return new ByteSizeValue(reservedSize);
+        return ByteSizeValue.ofBytes(reservedSize);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/index/translog/TranslogConfig.java
+++ b/server/src/main/java/org/elasticsearch/index/translog/TranslogConfig.java
@@ -25,7 +25,7 @@ import java.nio.file.Path;
 public final class TranslogConfig {
 
     public static final ByteSizeValue DEFAULT_BUFFER_SIZE = new ByteSizeValue(1, ByteSizeUnit.MB);
-    public static final ByteSizeValue EMPTY_TRANSLOG_BUFFER_SIZE = new ByteSizeValue(10, ByteSizeUnit.BYTES);
+    public static final ByteSizeValue EMPTY_TRANSLOG_BUFFER_SIZE = ByteSizeValue.ofBytes(10);
     private final BigArrays bigArrays;
     private final DiskIoBufferPool diskIoBufferPool;
     private final IndexSettings indexSettings;

--- a/server/src/main/java/org/elasticsearch/index/translog/TranslogStats.java
+++ b/server/src/main/java/org/elasticsearch/index/translog/TranslogStats.java
@@ -107,9 +107,9 @@ public class TranslogStats implements Writeable, ToXContentFragment {
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
         builder.startObject("translog");
         builder.field("operations", numberOfOperations);
-        builder.humanReadableField("size_in_bytes", "size", new ByteSizeValue(translogSizeInBytes));
+        builder.humanReadableField("size_in_bytes", "size", ByteSizeValue.ofBytes(translogSizeInBytes));
         builder.field("uncommitted_operations", uncommittedOperations);
-        builder.humanReadableField("uncommitted_size_in_bytes", "uncommitted_size", new ByteSizeValue(uncommittedSizeInBytes));
+        builder.humanReadableField("uncommitted_size_in_bytes", "uncommitted_size", ByteSizeValue.ofBytes(uncommittedSizeInBytes));
         builder.field("earliest_last_modified_age", earliestLastModifiedAge);
         builder.endObject();
         return builder;

--- a/server/src/main/java/org/elasticsearch/indices/IndexingMemoryController.java
+++ b/server/src/main/java/org/elasticsearch/indices/IndexingMemoryController.java
@@ -53,8 +53,8 @@ public class IndexingMemoryController implements IndexingOperationListener, Clos
     public static final Setting<ByteSizeValue> MIN_INDEX_BUFFER_SIZE_SETTING = Setting.byteSizeSetting(
         "indices.memory.min_index_buffer_size",
         new ByteSizeValue(48, ByteSizeUnit.MB),
-        new ByteSizeValue(0, ByteSizeUnit.BYTES),
-        new ByteSizeValue(Long.MAX_VALUE, ByteSizeUnit.BYTES),
+        ByteSizeValue.ZERO,
+        ByteSizeValue.ofBytes(Long.MAX_VALUE),
         Property.NodeScope
     );
 
@@ -62,9 +62,9 @@ public class IndexingMemoryController implements IndexingOperationListener, Clos
      * to set a ceiling on the actual size in bytes (default: not set). */
     public static final Setting<ByteSizeValue> MAX_INDEX_BUFFER_SIZE_SETTING = Setting.byteSizeSetting(
         "indices.memory.max_index_buffer_size",
-        new ByteSizeValue(-1),
-        new ByteSizeValue(-1),
-        new ByteSizeValue(Long.MAX_VALUE, ByteSizeUnit.BYTES),
+        ByteSizeValue.MINUS_ONE,
+        ByteSizeValue.MINUS_ONE,
+        ByteSizeValue.ofBytes(Long.MAX_VALUE),
         Property.NodeScope
     );
 
@@ -328,10 +328,10 @@ public class IndexingMemoryController implements IndexingOperationListener, Clos
             if (logger.isTraceEnabled()) {
                 logger.trace(
                     "total indexing heap bytes used [{}] vs {} [{}], currently writing bytes [{}]",
-                    new ByteSizeValue(totalBytesUsed),
+                    ByteSizeValue.ofBytes(totalBytesUsed),
                     INDEX_BUFFER_SIZE_SETTING.getKey(),
                     indexingBuffer,
-                    new ByteSizeValue(totalBytesWriting)
+                    ByteSizeValue.ofBytes(totalBytesWriting)
                 );
             }
 
@@ -379,10 +379,10 @@ public class IndexingMemoryController implements IndexingOperationListener, Clos
                 logger.debug(
                     "now write some indexing buffers: total indexing heap bytes used [{}] vs {} [{}], "
                         + "currently writing bytes [{}], [{}] shards with non-zero indexing buffer",
-                    new ByteSizeValue(totalBytesUsed),
+                    ByteSizeValue.ofBytes(totalBytesUsed),
                     INDEX_BUFFER_SIZE_SETTING.getKey(),
                     indexingBuffer,
-                    new ByteSizeValue(totalBytesWriting),
+                    ByteSizeValue.ofBytes(totalBytesWriting),
                     queue.size()
                 );
 
@@ -391,7 +391,7 @@ public class IndexingMemoryController implements IndexingOperationListener, Clos
                     logger.debug(
                         "write indexing buffer to disk for shard [{}] to free up its [{}] indexing buffer",
                         largest.shard.shardId(),
-                        new ByteSizeValue(largest.bytesUsed)
+                        ByteSizeValue.ofBytes(largest.bytesUsed)
                     );
                     writeIndexingBufferAsync(largest.shard);
                     totalBytesUsed -= largest.bytesUsed;

--- a/server/src/main/java/org/elasticsearch/indices/breaker/BreakerSettings.java
+++ b/server/src/main/java/org/elasticsearch/indices/breaker/BreakerSettings.java
@@ -69,7 +69,7 @@ public final class BreakerSettings {
             breakerName,
             getOrDefault(
                 CIRCUIT_BREAKER_LIMIT_SETTING.getConcreteSetting(breakerLimitSettingKey(breakerName)),
-                new ByteSizeValue(defaultSettings.limitBytes),
+                ByteSizeValue.ofBytes(defaultSettings.limitBytes),
                 currentSettings
             ).getBytes(),
             getOrDefault(
@@ -133,7 +133,7 @@ public final class BreakerSettings {
             + ",limit="
             + this.limitBytes
             + "/"
-            + new ByteSizeValue(this.limitBytes)
+            + ByteSizeValue.ofBytes(this.limitBytes)
             + ",overhead="
             + this.overhead
             + "]";

--- a/server/src/main/java/org/elasticsearch/indices/breaker/CircuitBreakerStats.java
+++ b/server/src/main/java/org/elasticsearch/indices/breaker/CircuitBreakerStats.java
@@ -88,7 +88,7 @@ public class CircuitBreakerStats implements Writeable, ToXContentObject {
     private void addBytesFieldsSafe(XContentBuilder builder, long bytes, String rawFieldName, String humanFieldName) throws IOException {
         builder.field(rawFieldName, bytes);
         if (-1L <= bytes) {
-            builder.field(humanFieldName, new ByteSizeValue(bytes));
+            builder.field(humanFieldName, ByteSizeValue.ofBytes(bytes));
         } else {
             // Something's definitely wrong, maybe a breaker was freed twice? Still, we're just writing out stats here, so we should keep
             // going if we're running in production.

--- a/server/src/main/java/org/elasticsearch/indices/breaker/HierarchyCircuitBreakerService.java
+++ b/server/src/main/java/org/elasticsearch/indices/breaker/HierarchyCircuitBreakerService.java
@@ -463,7 +463,7 @@ public class HierarchyCircuitBreakerService extends CircuitBreakerService {
         stringBuilder.append(bytes);
         if (-1L <= bytes) {
             stringBuilder.append("/");
-            stringBuilder.append(new ByteSizeValue(bytes));
+            stringBuilder.append(ByteSizeValue.ofBytes(bytes));
         } else {
             // Something's definitely wrong, maybe a breaker was freed twice? Still, we're just creating an exception message here, so we
             // should keep going if we're running in production.

--- a/server/src/main/java/org/elasticsearch/indices/fielddata/cache/IndicesFieldDataCache.java
+++ b/server/src/main/java/org/elasticsearch/indices/fielddata/cache/IndicesFieldDataCache.java
@@ -44,7 +44,7 @@ public class IndicesFieldDataCache implements RemovalListener<IndicesFieldDataCa
 
     public static final Setting<ByteSizeValue> INDICES_FIELDDATA_CACHE_SIZE_KEY = Setting.memorySizeSetting(
         "indices.fielddata.cache.size",
-        new ByteSizeValue(-1),
+        ByteSizeValue.MINUS_ONE,
         Property.NodeScope
     );
     private final IndexFieldDataCache.Listener indicesFieldDataCacheListener;

--- a/server/src/main/java/org/elasticsearch/indices/recovery/PeerRecoveryTargetService.java
+++ b/server/src/main/java/org/elasticsearch/indices/recovery/PeerRecoveryTargetService.java
@@ -713,7 +713,7 @@ public class PeerRecoveryTargetService implements IndexEventListener {
                     .append(recoveryResponse.phase1FileNames.size())
                     .append("]")
                     .append(" with total_size of [")
-                    .append(new ByteSizeValue(recoveryResponse.phase1TotalSize))
+                    .append(ByteSizeValue.ofBytes(recoveryResponse.phase1TotalSize))
                     .append("]")
                     .append(", took [")
                     .append(timeValueMillis(recoveryResponse.phase1Time))
@@ -724,7 +724,7 @@ public class PeerRecoveryTargetService implements IndexEventListener {
                 sb.append("         : reusing_files   [")
                     .append(recoveryResponse.phase1ExistingFileNames.size())
                     .append("] with total_size of [")
-                    .append(new ByteSizeValue(recoveryResponse.phase1ExistingTotalSize))
+                    .append(ByteSizeValue.ofBytes(recoveryResponse.phase1ExistingTotalSize))
                     .append("]\n");
                 sb.append("   phase2: start took [").append(timeValueMillis(recoveryResponse.startTime)).append("]\n");
                 sb.append("         : recovered [")

--- a/server/src/main/java/org/elasticsearch/indices/recovery/RecoverFilesRecoveryException.java
+++ b/server/src/main/java/org/elasticsearch/indices/recovery/RecoverFilesRecoveryException.java
@@ -43,7 +43,7 @@ public class RecoverFilesRecoveryException extends ElasticsearchException implem
     public RecoverFilesRecoveryException(StreamInput in) throws IOException {
         super(in);
         numberOfFiles = in.readInt();
-        totalFilesSize = new ByteSizeValue(in);
+        totalFilesSize = ByteSizeValue.readFrom(in);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/indices/recovery/RecoverySettings.java
+++ b/server/src/main/java/org/elasticsearch/indices/recovery/RecoverySettings.java
@@ -54,7 +54,7 @@ public class RecoverySettings {
     // package private for tests
     static final Setting<ByteSizeValue> TOTAL_PHYSICAL_MEMORY_OVERRIDING_TEST_SETTING = Setting.byteSizeSetting(
         "recovery_settings.total_physical_memory_override",
-        settings -> new ByteSizeValue(OsProbe.getInstance().getTotalPhysicalMemorySize()).getStringRep(),
+        settings -> ByteSizeValue.ofBytes(OsProbe.getInstance().getTotalPhysicalMemorySize()).getStringRep(),
         Property.NodeScope
     );
 
@@ -151,7 +151,7 @@ public class RecoverySettings {
                         + "] for bandwidth setting ["
                         + key
                         + "], must be < ["
-                        + new ByteSizeValue(Long.MAX_VALUE, ByteSizeUnit.BYTES).getStringRep()
+                        + ByteSizeValue.ofBytes(Long.MAX_VALUE).getStringRep()
                         + ']'
                 );
             }

--- a/server/src/main/java/org/elasticsearch/indices/recovery/RecoverySourceHandler.java
+++ b/server/src/main/java/org/elasticsearch/indices/recovery/RecoverySourceHandler.java
@@ -600,7 +600,7 @@ public class RecoverySourceHandler {
 
             }
         } catch (Exception e) {
-            throw new RecoverFilesRecoveryException(request.shardId(), 0, new ByteSizeValue(0L), e);
+            throw new RecoverFilesRecoveryException(request.shardId(), 0, ByteSizeValue.ZERO, e);
         }
     }
 
@@ -665,9 +665,9 @@ public class RecoverySourceHandler {
             logger.trace(
                 "recovery [phase1]: recovering_files [{}] with total_size [{}], reusing_files [{}] with total_size [{}]",
                 filesToRecoverNames.size(),
-                new ByteSizeValue(totalSize),
+                ByteSizeValue.ofBytes(totalSize),
                 phase1ExistingFileNames.size(),
-                new ByteSizeValue(existingTotalSize)
+                ByteSizeValue.ofBytes(existingTotalSize)
             );
         }
 

--- a/server/src/main/java/org/elasticsearch/indices/recovery/RecoveryState.java
+++ b/server/src/main/java/org/elasticsearch/indices/recovery/RecoveryState.java
@@ -708,13 +708,13 @@ public class RecoveryState implements ToXContentFragment, Writeable {
         public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
             builder.startObject();
             builder.field(Fields.NAME, name);
-            builder.humanReadableField(Fields.LENGTH_IN_BYTES, Fields.LENGTH, new ByteSizeValue(length));
+            builder.humanReadableField(Fields.LENGTH_IN_BYTES, Fields.LENGTH, ByteSizeValue.ofBytes(length));
             builder.field(Fields.REUSED, reused);
-            builder.humanReadableField(Fields.RECOVERED_IN_BYTES, Fields.RECOVERED, new ByteSizeValue(recovered));
+            builder.humanReadableField(Fields.RECOVERED_IN_BYTES, Fields.RECOVERED, ByteSizeValue.ofBytes(recovered));
             builder.humanReadableField(
                 Fields.RECOVERED_FROM_SNAPSHOT_IN_BYTES,
                 Fields.RECOVERED_FROM_SNAPSHOT,
-                new ByteSizeValue(recoveredFromSnapshot)
+                ByteSizeValue.ofBytes(recoveredFromSnapshot)
             );
             builder.endObject();
             return builder;
@@ -1102,13 +1102,13 @@ public class RecoveryState implements ToXContentFragment, Writeable {
         public synchronized XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
             // stream size first, as it matters more and the files section can be long
             builder.startObject(Fields.SIZE);
-            builder.humanReadableField(Fields.TOTAL_IN_BYTES, Fields.TOTAL, new ByteSizeValue(totalBytes()));
-            builder.humanReadableField(Fields.REUSED_IN_BYTES, Fields.REUSED, new ByteSizeValue(reusedBytes()));
-            builder.humanReadableField(Fields.RECOVERED_IN_BYTES, Fields.RECOVERED, new ByteSizeValue(recoveredBytes()));
+            builder.humanReadableField(Fields.TOTAL_IN_BYTES, Fields.TOTAL, ByteSizeValue.ofBytes(totalBytes()));
+            builder.humanReadableField(Fields.REUSED_IN_BYTES, Fields.REUSED, ByteSizeValue.ofBytes(reusedBytes()));
+            builder.humanReadableField(Fields.RECOVERED_IN_BYTES, Fields.RECOVERED, ByteSizeValue.ofBytes(recoveredBytes()));
             builder.humanReadableField(
                 Fields.RECOVERED_FROM_SNAPSHOT_IN_BYTES,
                 Fields.RECOVERED_FROM_SNAPSHOT,
-                new ByteSizeValue(recoveredFromSnapshotBytes())
+                ByteSizeValue.ofBytes(recoveredFromSnapshotBytes())
             );
             builder.field(Fields.PERCENT, String.format(Locale.ROOT, "%1.1f%%", recoveredBytesPercent()));
             builder.endObject();

--- a/server/src/main/java/org/elasticsearch/monitor/fs/FsInfo.java
+++ b/server/src/main/java/org/elasticsearch/monitor/fs/FsInfo.java
@@ -82,15 +82,15 @@ public class FsInfo implements Iterable<FsInfo.Path>, Writeable, ToXContentFragm
         }
 
         public ByteSizeValue getTotal() {
-            return new ByteSizeValue(total);
+            return ByteSizeValue.ofBytes(total);
         }
 
         public ByteSizeValue getFree() {
-            return new ByteSizeValue(free);
+            return ByteSizeValue.ofBytes(free);
         }
 
         public ByteSizeValue getAvailable() {
-            return new ByteSizeValue(available);
+            return ByteSizeValue.ofBytes(available);
         }
 
         private static long addLong(long current, long other) {

--- a/server/src/main/java/org/elasticsearch/monitor/jvm/HotThreads.java
+++ b/server/src/main/java/org/elasticsearch/monitor/jvm/HotThreads.java
@@ -307,7 +307,7 @@ public class HotThreads {
                     String.format(
                         Locale.ROOT,
                         "%n%s memory allocated by thread '%s'%n",
-                        new ByteSizeValue(topThread.getAllocatedBytes()),
+                        ByteSizeValue.ofBytes(topThread.getAllocatedBytes()),
                         threadName
                     )
                 );

--- a/server/src/main/java/org/elasticsearch/monitor/jvm/JvmInfo.java
+++ b/server/src/main/java/org/elasticsearch/monitor/jvm/JvmInfo.java
@@ -422,11 +422,11 @@ public class JvmInfo implements ReportingService.Info {
         builder.timeField(Fields.START_TIME_IN_MILLIS, Fields.START_TIME, startTime);
 
         builder.startObject(Fields.MEM);
-        builder.humanReadableField(Fields.HEAP_INIT_IN_BYTES, Fields.HEAP_INIT, new ByteSizeValue(mem.heapInit));
-        builder.humanReadableField(Fields.HEAP_MAX_IN_BYTES, Fields.HEAP_MAX, new ByteSizeValue(mem.heapMax));
-        builder.humanReadableField(Fields.NON_HEAP_INIT_IN_BYTES, Fields.NON_HEAP_INIT, new ByteSizeValue(mem.nonHeapInit));
-        builder.humanReadableField(Fields.NON_HEAP_MAX_IN_BYTES, Fields.NON_HEAP_MAX, new ByteSizeValue(mem.nonHeapMax));
-        builder.humanReadableField(Fields.DIRECT_MAX_IN_BYTES, Fields.DIRECT_MAX, new ByteSizeValue(mem.directMemoryMax));
+        builder.humanReadableField(Fields.HEAP_INIT_IN_BYTES, Fields.HEAP_INIT, ByteSizeValue.ofBytes(mem.heapInit));
+        builder.humanReadableField(Fields.HEAP_MAX_IN_BYTES, Fields.HEAP_MAX, ByteSizeValue.ofBytes(mem.heapMax));
+        builder.humanReadableField(Fields.NON_HEAP_INIT_IN_BYTES, Fields.NON_HEAP_INIT, ByteSizeValue.ofBytes(mem.nonHeapInit));
+        builder.humanReadableField(Fields.NON_HEAP_MAX_IN_BYTES, Fields.NON_HEAP_MAX, ByteSizeValue.ofBytes(mem.nonHeapMax));
+        builder.humanReadableField(Fields.DIRECT_MAX_IN_BYTES, Fields.DIRECT_MAX, ByteSizeValue.ofBytes(mem.directMemoryMax));
         builder.endObject();
 
         builder.array(Fields.GC_COLLECTORS, gcCollectors);
@@ -502,11 +502,11 @@ public class JvmInfo implements ReportingService.Info {
         }
 
         public ByteSizeValue getHeapInit() {
-            return new ByteSizeValue(heapInit);
+            return ByteSizeValue.ofBytes(heapInit);
         }
 
         public ByteSizeValue getHeapMax() {
-            return new ByteSizeValue(heapMax);
+            return ByteSizeValue.ofBytes(heapMax);
         }
 
     }

--- a/server/src/main/java/org/elasticsearch/monitor/jvm/JvmStats.java
+++ b/server/src/main/java/org/elasticsearch/monitor/jvm/JvmStats.java
@@ -205,23 +205,27 @@ public class JvmStats implements Writeable, ToXContentFragment {
 
         builder.startObject(Fields.MEM);
 
-        builder.humanReadableField(Fields.HEAP_USED_IN_BYTES, Fields.HEAP_USED, new ByteSizeValue(mem.heapUsed));
+        builder.humanReadableField(Fields.HEAP_USED_IN_BYTES, Fields.HEAP_USED, ByteSizeValue.ofBytes(mem.heapUsed));
         if (mem.getHeapUsedPercent() >= 0) {
             builder.field(Fields.HEAP_USED_PERCENT, mem.getHeapUsedPercent());
         }
-        builder.humanReadableField(Fields.HEAP_COMMITTED_IN_BYTES, Fields.HEAP_COMMITTED, new ByteSizeValue(mem.heapCommitted));
-        builder.humanReadableField(Fields.HEAP_MAX_IN_BYTES, Fields.HEAP_MAX, new ByteSizeValue(mem.heapMax));
-        builder.humanReadableField(Fields.NON_HEAP_USED_IN_BYTES, Fields.NON_HEAP_USED, new ByteSizeValue(mem.nonHeapUsed));
-        builder.humanReadableField(Fields.NON_HEAP_COMMITTED_IN_BYTES, Fields.NON_HEAP_COMMITTED, new ByteSizeValue(mem.nonHeapCommitted));
+        builder.humanReadableField(Fields.HEAP_COMMITTED_IN_BYTES, Fields.HEAP_COMMITTED, ByteSizeValue.ofBytes(mem.heapCommitted));
+        builder.humanReadableField(Fields.HEAP_MAX_IN_BYTES, Fields.HEAP_MAX, ByteSizeValue.ofBytes(mem.heapMax));
+        builder.humanReadableField(Fields.NON_HEAP_USED_IN_BYTES, Fields.NON_HEAP_USED, ByteSizeValue.ofBytes(mem.nonHeapUsed));
+        builder.humanReadableField(
+            Fields.NON_HEAP_COMMITTED_IN_BYTES,
+            Fields.NON_HEAP_COMMITTED,
+            ByteSizeValue.ofBytes(mem.nonHeapCommitted)
+        );
 
         builder.startObject(Fields.POOLS);
         for (MemoryPool pool : mem) {
             builder.startObject(pool.getName());
-            builder.humanReadableField(Fields.USED_IN_BYTES, Fields.USED, new ByteSizeValue(pool.used));
-            builder.humanReadableField(Fields.MAX_IN_BYTES, Fields.MAX, new ByteSizeValue(pool.max));
+            builder.humanReadableField(Fields.USED_IN_BYTES, Fields.USED, ByteSizeValue.ofBytes(pool.used));
+            builder.humanReadableField(Fields.MAX_IN_BYTES, Fields.MAX, ByteSizeValue.ofBytes(pool.max));
 
-            builder.humanReadableField(Fields.PEAK_USED_IN_BYTES, Fields.PEAK_USED, new ByteSizeValue(pool.peakUsed));
-            builder.humanReadableField(Fields.PEAK_MAX_IN_BYTES, Fields.PEAK_MAX, new ByteSizeValue(pool.peakMax));
+            builder.humanReadableField(Fields.PEAK_USED_IN_BYTES, Fields.PEAK_USED, ByteSizeValue.ofBytes(pool.peakUsed));
+            builder.humanReadableField(Fields.PEAK_MAX_IN_BYTES, Fields.PEAK_MAX, ByteSizeValue.ofBytes(pool.peakMax));
 
             builder.endObject();
         }
@@ -252,11 +256,11 @@ public class JvmStats implements Writeable, ToXContentFragment {
             for (BufferPool bufferPool : bufferPools) {
                 builder.startObject(bufferPool.getName());
                 builder.field(Fields.COUNT, bufferPool.getCount());
-                builder.humanReadableField(Fields.USED_IN_BYTES, Fields.USED, new ByteSizeValue(bufferPool.used));
+                builder.humanReadableField(Fields.USED_IN_BYTES, Fields.USED, ByteSizeValue.ofBytes(bufferPool.used));
                 builder.humanReadableField(
                     Fields.TOTAL_CAPACITY_IN_BYTES,
                     Fields.TOTAL_CAPACITY,
-                    new ByteSizeValue(bufferPool.totalCapacity)
+                    ByteSizeValue.ofBytes(bufferPool.totalCapacity)
                 );
                 builder.endObject();
             }
@@ -456,11 +460,11 @@ public class JvmStats implements Writeable, ToXContentFragment {
         }
 
         public ByteSizeValue getUsed() {
-            return new ByteSizeValue(used);
+            return ByteSizeValue.ofBytes(used);
         }
 
         public ByteSizeValue getMax() {
-            return new ByteSizeValue(max);
+            return ByteSizeValue.ofBytes(max);
         }
 
     }
@@ -508,18 +512,18 @@ public class JvmStats implements Writeable, ToXContentFragment {
         }
 
         public ByteSizeValue getHeapCommitted() {
-            return new ByteSizeValue(heapCommitted);
+            return ByteSizeValue.ofBytes(heapCommitted);
         }
 
         public ByteSizeValue getHeapUsed() {
-            return new ByteSizeValue(heapUsed);
+            return ByteSizeValue.ofBytes(heapUsed);
         }
 
         /**
          * returns the maximum heap size. 0 bytes signals unknown.
          */
         public ByteSizeValue getHeapMax() {
-            return new ByteSizeValue(heapMax);
+            return ByteSizeValue.ofBytes(heapMax);
         }
 
         /**
@@ -533,11 +537,11 @@ public class JvmStats implements Writeable, ToXContentFragment {
         }
 
         public ByteSizeValue getNonHeapCommitted() {
-            return new ByteSizeValue(nonHeapCommitted);
+            return ByteSizeValue.ofBytes(nonHeapCommitted);
         }
 
         public ByteSizeValue getNonHeapUsed() {
-            return new ByteSizeValue(nonHeapUsed);
+            return ByteSizeValue.ofBytes(nonHeapUsed);
         }
     }
 
@@ -579,11 +583,11 @@ public class JvmStats implements Writeable, ToXContentFragment {
         }
 
         public ByteSizeValue getTotalCapacity() {
-            return new ByteSizeValue(totalCapacity);
+            return ByteSizeValue.ofBytes(totalCapacity);
         }
 
         public ByteSizeValue getUsed() {
-            return new ByteSizeValue(used);
+            return ByteSizeValue.ofBytes(used);
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/monitor/os/OsStats.java
+++ b/server/src/main/java/org/elasticsearch/monitor/os/OsStats.java
@@ -202,7 +202,7 @@ public class OsStats implements Writeable, ToXContentFragment {
         }
 
         public ByteSizeValue getFree() {
-            return new ByteSizeValue(free);
+            return ByteSizeValue.ofBytes(free);
         }
 
         public ByteSizeValue getUsed() {
@@ -217,13 +217,13 @@ public class OsStats implements Writeable, ToXContentFragment {
                 if (free > 0) {
                     logger.debug("cannot compute used swap when total swap is 0 and free swap is " + free);
                 }
-                return new ByteSizeValue(0);
+                return ByteSizeValue.ZERO;
             }
-            return new ByteSizeValue(total - free);
+            return ByteSizeValue.ofBytes(total - free);
         }
 
         public ByteSizeValue getTotal() {
-            return new ByteSizeValue(total);
+            return ByteSizeValue.ofBytes(total);
         }
 
         @Override
@@ -306,11 +306,11 @@ public class OsStats implements Writeable, ToXContentFragment {
         }
 
         public ByteSizeValue getTotal() {
-            return new ByteSizeValue(total);
+            return ByteSizeValue.ofBytes(total);
         }
 
         public ByteSizeValue getAdjustedTotal() {
-            return new ByteSizeValue(adjustedTotal);
+            return ByteSizeValue.ofBytes(adjustedTotal);
         }
 
         public ByteSizeValue getUsed() {
@@ -324,9 +324,9 @@ public class OsStats implements Writeable, ToXContentFragment {
                 if (free > 0) {
                     logger.debug("cannot compute used memory when total memory is 0 and free memory is " + free);
                 }
-                return new ByteSizeValue(0);
+                return ByteSizeValue.ZERO;
             }
-            return new ByteSizeValue(total - free);
+            return ByteSizeValue.ofBytes(total - free);
         }
 
         public short getUsedPercent() {
@@ -334,7 +334,7 @@ public class OsStats implements Writeable, ToXContentFragment {
         }
 
         public ByteSizeValue getFree() {
-            return new ByteSizeValue(free);
+            return ByteSizeValue.ofBytes(free);
         }
 
         public short getFreePercent() {

--- a/server/src/main/java/org/elasticsearch/monitor/process/ProcessStats.java
+++ b/server/src/main/java/org/elasticsearch/monitor/process/ProcessStats.java
@@ -101,7 +101,7 @@ public class ProcessStats implements Writeable, ToXContentFragment {
         }
         if (mem != null) {
             builder.startObject(Fields.MEM);
-            builder.humanReadableField(Fields.TOTAL_VIRTUAL_IN_BYTES, Fields.TOTAL_VIRTUAL, new ByteSizeValue(mem.totalVirtual));
+            builder.humanReadableField(Fields.TOTAL_VIRTUAL_IN_BYTES, Fields.TOTAL_VIRTUAL, ByteSizeValue.ofBytes(mem.totalVirtual));
             builder.endObject();
         }
         builder.endObject();
@@ -126,7 +126,7 @@ public class ProcessStats implements Writeable, ToXContentFragment {
         }
 
         public ByteSizeValue getTotalVirtual() {
-            return new ByteSizeValue(totalVirtual);
+            return ByteSizeValue.ofBytes(totalVirtual);
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/repositories/ShardSnapshotResult.java
+++ b/server/src/main/java/org/elasticsearch/repositories/ShardSnapshotResult.java
@@ -42,7 +42,7 @@ public class ShardSnapshotResult implements Writeable {
 
     public ShardSnapshotResult(StreamInput in) throws IOException {
         generation = new ShardGeneration(in);
-        size = new ByteSizeValue(in);
+        size = ByteSizeValue.readFrom(in);
         segmentCount = in.readVInt();
     }
 

--- a/server/src/main/java/org/elasticsearch/repositories/fs/FsRepository.java
+++ b/server/src/main/java/org/elasticsearch/repositories/fs/FsRepository.java
@@ -54,16 +54,16 @@ public class FsRepository extends BlobStoreRepository {
     );
     public static final Setting<ByteSizeValue> CHUNK_SIZE_SETTING = Setting.byteSizeSetting(
         "chunk_size",
-        new ByteSizeValue(Long.MAX_VALUE),
-        new ByteSizeValue(5),
-        new ByteSizeValue(Long.MAX_VALUE),
+        ByteSizeValue.ofBytes(Long.MAX_VALUE),
+        ByteSizeValue.ofBytes(5),
+        ByteSizeValue.ofBytes(Long.MAX_VALUE),
         Property.NodeScope
     );
     public static final Setting<ByteSizeValue> REPOSITORIES_CHUNK_SIZE_SETTING = Setting.byteSizeSetting(
         "repositories.fs.chunk_size",
-        new ByteSizeValue(Long.MAX_VALUE),
-        new ByteSizeValue(5),
-        new ByteSizeValue(Long.MAX_VALUE),
+        ByteSizeValue.ofBytes(Long.MAX_VALUE),
+        ByteSizeValue.ofBytes(5),
+        ByteSizeValue.ofBytes(Long.MAX_VALUE),
         Property.NodeScope
     );
     private final Environment environment;

--- a/server/src/main/java/org/elasticsearch/rest/action/cat/RestAllocationAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/cat/RestAllocationAction.java
@@ -128,7 +128,7 @@ public class RestAllocationAction extends AbstractCatAction {
             table.startRow();
             table.addCell(shardCount);
             table.addCell(nodeStats.getIndices().getStore().getSize());
-            table.addCell(used < 0 ? null : new ByteSizeValue(used));
+            table.addCell(used < 0 ? null : ByteSizeValue.ofBytes(used));
             table.addCell(avail.getBytes() < 0 ? null : avail);
             table.addCell(total.getBytes() < 0 ? null : total);
             table.addCell(diskPercent < 0 ? null : diskPercent);

--- a/server/src/main/java/org/elasticsearch/rest/action/cat/RestCatRecoveryAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/cat/RestCatRecoveryAction.java
@@ -158,10 +158,10 @@ public class RestCatRecoveryAction extends AbstractCatAction {
                 t.addCell(state.getIndex().recoveredFileCount());
                 t.addCell(String.format(Locale.ROOT, "%1.1f%%", state.getIndex().recoveredFilesPercent()));
                 t.addCell(state.getIndex().totalFileCount());
-                t.addCell(new ByteSizeValue(state.getIndex().totalRecoverBytes()));
-                t.addCell(new ByteSizeValue(state.getIndex().recoveredBytes()));
+                t.addCell(ByteSizeValue.ofBytes(state.getIndex().totalRecoverBytes()));
+                t.addCell(ByteSizeValue.ofBytes(state.getIndex().recoveredBytes()));
                 t.addCell(String.format(Locale.ROOT, "%1.1f%%", state.getIndex().recoveredBytesPercent()));
-                t.addCell(new ByteSizeValue(state.getIndex().totalBytes()));
+                t.addCell(ByteSizeValue.ofBytes(state.getIndex().totalBytes()));
                 t.addCell(state.getTranslog().totalOperations());
                 t.addCell(state.getTranslog().recoveredOperations());
                 t.addCell(String.format(Locale.ROOT, "%1.1f%%", state.getTranslog().recoveredPercent()));

--- a/server/src/main/java/org/elasticsearch/rest/action/cat/RestFielddataAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/cat/RestFielddataAction.java
@@ -85,7 +85,7 @@ public class RestFielddataAction extends AbstractCatAction {
                     table.addCell(nodeStats.getNode().getHostAddress());
                     table.addCell(nodeStats.getNode().getName());
                     table.addCell(field.getKey());
-                    table.addCell(new ByteSizeValue(field.getValue()));
+                    table.addCell(ByteSizeValue.ofBytes(field.getValue()));
                     table.endRow();
                 }
             }

--- a/server/src/main/java/org/elasticsearch/rest/action/cat/RestIndicesAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/cat/RestIndicesAction.java
@@ -826,8 +826,8 @@ public class RestIndicesAction extends AbstractCatAction {
             table.addCell(totalStats.getSegments() == null ? null : totalStats.getSegments().getCount());
             table.addCell(primaryStats.getSegments() == null ? null : primaryStats.getSegments().getCount());
 
-            table.addCell(totalStats.getSegments() == null ? null : new ByteSizeValue(0));
-            table.addCell(primaryStats.getSegments() == null ? null : new ByteSizeValue(0));
+            table.addCell(totalStats.getSegments() == null ? null : ByteSizeValue.ZERO);
+            table.addCell(primaryStats.getSegments() == null ? null : ByteSizeValue.ZERO);
 
             table.addCell(totalStats.getSegments() == null ? null : totalStats.getSegments().getIndexWriterMemory());
             table.addCell(primaryStats.getSegments() == null ? null : primaryStats.getSegments().getIndexWriterMemory());

--- a/server/src/main/java/org/elasticsearch/rest/action/cat/RestNodesAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/cat/RestNodesAction.java
@@ -369,7 +369,7 @@ public class RestNodesAction extends AbstractCatAction {
             if (fsInfo != null) {
                 diskTotal = fsInfo.getTotal().getTotal();
                 diskAvailable = fsInfo.getTotal().getAvailable();
-                diskUsed = new ByteSizeValue(diskTotal.getBytes() - diskAvailable.getBytes());
+                diskUsed = ByteSizeValue.ofBytes(diskTotal.getBytes() - diskAvailable.getBytes());
 
                 double diskUsedRatio = diskTotal.getBytes() == 0 ? 1.0 : (double) diskUsed.getBytes() / diskTotal.getBytes();
                 diskUsedPercent = String.format(Locale.ROOT, "%.2f", 100.0 * diskUsedRatio);
@@ -498,7 +498,7 @@ public class RestNodesAction extends AbstractCatAction {
 
             SegmentsStats segmentsStats = indicesStats == null ? null : indicesStats.getSegments();
             table.addCell(segmentsStats == null ? null : segmentsStats.getCount());
-            table.addCell(segmentsStats == null ? null : new ByteSizeValue(0));
+            table.addCell(segmentsStats == null ? null : ByteSizeValue.ZERO);
             table.addCell(segmentsStats == null ? null : segmentsStats.getIndexWriterMemory());
             table.addCell(segmentsStats == null ? null : segmentsStats.getVersionMapMemory());
             table.addCell(segmentsStats == null ? null : segmentsStats.getBitsetMemory());

--- a/server/src/main/java/org/elasticsearch/rest/action/cat/RestShardsAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/cat/RestShardsAction.java
@@ -379,7 +379,7 @@ public class RestShardsAction extends AbstractCatAction {
             table.addCell(getOrNull(commonStats, CommonStats::getSearch, i -> i.getTotal().getScrollCount()));
 
             table.addCell(getOrNull(commonStats, CommonStats::getSegments, SegmentsStats::getCount));
-            table.addCell(getOrNull(commonStats, CommonStats::getSegments, ss -> new ByteSizeValue(0)));
+            table.addCell(getOrNull(commonStats, CommonStats::getSegments, ss -> ByteSizeValue.ZERO));
             table.addCell(getOrNull(commonStats, CommonStats::getSegments, SegmentsStats::getIndexWriterMemory));
             table.addCell(getOrNull(commonStats, CommonStats::getSegments, SegmentsStats::getVersionMapMemory));
             table.addCell(getOrNull(commonStats, CommonStats::getSegments, SegmentsStats::getBitsetMemory));

--- a/server/src/main/java/org/elasticsearch/search/suggest/completion/CompletionStats.java
+++ b/server/src/main/java/org/elasticsearch/search/suggest/completion/CompletionStats.java
@@ -47,7 +47,7 @@ public class CompletionStats implements Writeable, ToXContentFragment {
     }
 
     public ByteSizeValue getSize() {
-        return new ByteSizeValue(sizeInBytes);
+        return ByteSizeValue.ofBytes(sizeInBytes);
     }
 
     public FieldMemoryStats getFields() {

--- a/server/src/main/java/org/elasticsearch/snapshots/SnapshotInfo.java
+++ b/server/src/main/java/org/elasticsearch/snapshots/SnapshotInfo.java
@@ -1136,7 +1136,7 @@ public final class SnapshotInfo implements Comparable<SnapshotInfo>, ToXContentF
 
         public IndexSnapshotDetails(StreamInput in) throws IOException {
             shardCount = in.readVInt();
-            size = new ByteSizeValue(in);
+            size = ByteSizeValue.readFrom(in);
             maxSegmentsPerShard = in.readVInt();
         }
 

--- a/server/src/main/java/org/elasticsearch/snapshots/SnapshotsService.java
+++ b/server/src/main/java/org/elasticsearch/snapshots/SnapshotsService.java
@@ -1557,7 +1557,7 @@ public class SnapshotsService extends AbstractLifecycleComponent implements Clus
                         } else {
                             return new SnapshotInfo.IndexSnapshotDetails(
                                 current.getShardCount() + 1,
-                                new ByteSizeValue(current.getSize().getBytes() + result.getSize().getBytes()),
+                                ByteSizeValue.ofBytes(current.getSize().getBytes() + result.getSize().getBytes()),
                                 Math.max(current.getMaxSegmentsPerShard(), result.getSegmentCount())
                             );
                         }

--- a/server/src/main/java/org/elasticsearch/transport/TcpTransport.java
+++ b/server/src/main/java/org/elasticsearch/transport/TcpTransport.java
@@ -873,9 +873,9 @@ public abstract class TcpTransport extends AbstractLifecycleComponent implements
         if (messageLength > THIRTY_PER_HEAP_SIZE) {
             throw new IllegalArgumentException(
                 "illegal transport message of size ["
-                    + new ByteSizeValue(messageLength)
+                    + ByteSizeValue.ofBytes(messageLength)
                     + "] which exceeds 30% of this node's heap size ["
-                    + new ByteSizeValue(THIRTY_PER_HEAP_SIZE)
+                    + ByteSizeValue.ofBytes(THIRTY_PER_HEAP_SIZE)
                     + "], closing connection"
             );
         }

--- a/server/src/main/java/org/elasticsearch/transport/TransportStats.java
+++ b/server/src/main/java/org/elasticsearch/transport/TransportStats.java
@@ -120,7 +120,7 @@ public class TransportStats implements Writeable, ToXContentFragment {
     }
 
     public ByteSizeValue rxSize() {
-        return new ByteSizeValue(rxSize);
+        return ByteSizeValue.ofBytes(rxSize);
     }
 
     public ByteSizeValue getRxSize() {
@@ -136,7 +136,7 @@ public class TransportStats implements Writeable, ToXContentFragment {
     }
 
     public ByteSizeValue txSize() {
-        return new ByteSizeValue(txSize);
+        return ByteSizeValue.ofBytes(txSize);
     }
 
     public ByteSizeValue getTxSize() {
@@ -168,9 +168,9 @@ public class TransportStats implements Writeable, ToXContentFragment {
         builder.field(Fields.SERVER_OPEN, serverOpen);
         builder.field(Fields.TOTAL_OUTBOUND_CONNECTIONS, totalOutboundConnections);
         builder.field(Fields.RX_COUNT, rxCount);
-        builder.humanReadableField(Fields.RX_SIZE_IN_BYTES, Fields.RX_SIZE, new ByteSizeValue(rxSize));
+        builder.humanReadableField(Fields.RX_SIZE_IN_BYTES, Fields.RX_SIZE, ByteSizeValue.ofBytes(rxSize));
         builder.field(Fields.TX_COUNT, txCount);
-        builder.humanReadableField(Fields.TX_SIZE_IN_BYTES, Fields.TX_SIZE, new ByteSizeValue(txSize));
+        builder.humanReadableField(Fields.TX_SIZE_IN_BYTES, Fields.TX_SIZE, ByteSizeValue.ofBytes(txSize));
         if (inboundHandlingTimeBucketFrequencies.length > 0) {
             histogramToXContent(builder, inboundHandlingTimeBucketFrequencies, Fields.INBOUND_HANDLING_TIME_HISTOGRAM);
             histogramToXContent(builder, outboundHandlingTimeBucketFrequencies, Fields.OUTBOUND_HANDLING_TIME_HISTOGRAM);

--- a/server/src/test/java/org/elasticsearch/ExceptionSerializationTests.java
+++ b/server/src/test/java/org/elasticsearch/ExceptionSerializationTests.java
@@ -317,7 +317,7 @@ public class ExceptionSerializationTests extends ESTestCase {
 
     public void testRecoverFilesRecoveryException() throws IOException {
         ShardId id = new ShardId("foo", "_na_", 1);
-        ByteSizeValue bytes = new ByteSizeValue(randomIntBetween(0, 10000));
+        ByteSizeValue bytes = ByteSizeValue.ofBytes(randomIntBetween(0, 10000));
         RecoverFilesRecoveryException ex = serialize(new RecoverFilesRecoveryException(id, 10, bytes, null));
         assertEquals(ex.getShardId(), id);
         assertEquals(ex.numberOfFiles(), 10);

--- a/server/src/test/java/org/elasticsearch/action/admin/indices/rollover/ConditionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/indices/rollover/ConditionTests.java
@@ -350,6 +350,6 @@ public class ConditionTests extends ESTestCase {
     }
 
     private static ByteSizeValue randomByteSize() {
-        return new ByteSizeValue(randomNonNegativeLong());
+        return ByteSizeValue.ofBytes(randomNonNegativeLong());
     }
 }

--- a/server/src/test/java/org/elasticsearch/action/admin/indices/rollover/RolloverRequestTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/indices/rollover/RolloverRequestTests.java
@@ -161,13 +161,13 @@ public class RolloverRequestTests extends ESTestCase {
         RolloverRequest originalRequest = new RolloverRequest("alias-index", "new-index-name");
         originalRequest.addMaxIndexDocsCondition(randomNonNegativeLong());
         originalRequest.addMaxIndexAgeCondition(TimeValue.timeValueNanos(randomNonNegativeLong()));
-        originalRequest.addMaxIndexSizeCondition(new ByteSizeValue(randomNonNegativeLong()));
-        originalRequest.addMaxPrimaryShardSizeCondition(new ByteSizeValue(randomNonNegativeLong()));
+        originalRequest.addMaxIndexSizeCondition(ByteSizeValue.ofBytes(randomNonNegativeLong()));
+        originalRequest.addMaxPrimaryShardSizeCondition(ByteSizeValue.ofBytes(randomNonNegativeLong()));
         originalRequest.addMaxPrimaryShardDocsCondition(randomNonNegativeLong());
         originalRequest.addMinIndexDocsCondition(randomNonNegativeLong());
         originalRequest.addMinIndexAgeCondition(TimeValue.timeValueNanos(randomNonNegativeLong()));
-        originalRequest.addMinIndexSizeCondition(new ByteSizeValue(randomNonNegativeLong()));
-        originalRequest.addMinPrimaryShardSizeCondition(new ByteSizeValue(randomNonNegativeLong()));
+        originalRequest.addMinIndexSizeCondition(ByteSizeValue.ofBytes(randomNonNegativeLong()));
+        originalRequest.addMinPrimaryShardSizeCondition(ByteSizeValue.ofBytes(randomNonNegativeLong()));
         originalRequest.addMinPrimaryShardDocsCondition(randomNonNegativeLong());
         try (BytesStreamOutput out = new BytesStreamOutput()) {
             originalRequest.writeTo(out);
@@ -347,14 +347,14 @@ public class RolloverRequestTests extends ESTestCase {
 
     private static final List<Consumer<RolloverRequest>> conditionsGenerator = Arrays.asList(
         (request) -> request.addMaxIndexDocsCondition(randomNonNegativeLong()),
-        (request) -> request.addMaxIndexSizeCondition(new ByteSizeValue(randomNonNegativeLong())),
+        (request) -> request.addMaxIndexSizeCondition(ByteSizeValue.ofBytes(randomNonNegativeLong())),
         (request) -> request.addMaxIndexAgeCondition(new TimeValue(randomNonNegativeLong())),
-        (request) -> request.addMaxPrimaryShardSizeCondition(new ByteSizeValue(randomNonNegativeLong())),
+        (request) -> request.addMaxPrimaryShardSizeCondition(ByteSizeValue.ofBytes(randomNonNegativeLong())),
         (request) -> request.addMaxPrimaryShardDocsCondition(randomNonNegativeLong()),
         (request) -> request.addMinIndexDocsCondition(randomNonNegativeLong()),
-        (request) -> request.addMinIndexSizeCondition(new ByteSizeValue(randomNonNegativeLong())),
+        (request) -> request.addMinIndexSizeCondition(ByteSizeValue.ofBytes(randomNonNegativeLong())),
         (request) -> request.addMinIndexAgeCondition(new TimeValue(randomNonNegativeLong())),
-        (request) -> request.addMinPrimaryShardSizeCondition(new ByteSizeValue(randomNonNegativeLong())),
+        (request) -> request.addMinPrimaryShardSizeCondition(ByteSizeValue.ofBytes(randomNonNegativeLong())),
         (request) -> request.addMinPrimaryShardDocsCondition(randomNonNegativeLong())
     );
 }

--- a/server/src/test/java/org/elasticsearch/action/admin/indices/rollover/RolloverResponseTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/indices/rollover/RolloverResponseTests.java
@@ -52,13 +52,13 @@ public class RolloverResponseTests extends AbstractWireSerializingTestCase<Rollo
     static {
         conditionSuppliers.add(() -> new MaxAgeCondition(new TimeValue(randomNonNegativeLong())));
         conditionSuppliers.add(() -> new MaxDocsCondition(randomNonNegativeLong()));
-        conditionSuppliers.add(() -> new MaxSizeCondition(new ByteSizeValue(randomNonNegativeLong())));
-        conditionSuppliers.add(() -> new MaxPrimaryShardSizeCondition(new ByteSizeValue(randomNonNegativeLong())));
+        conditionSuppliers.add(() -> new MaxSizeCondition(ByteSizeValue.ofBytes(randomNonNegativeLong())));
+        conditionSuppliers.add(() -> new MaxPrimaryShardSizeCondition(ByteSizeValue.ofBytes(randomNonNegativeLong())));
         conditionSuppliers.add(() -> new MaxPrimaryShardDocsCondition(randomNonNegativeLong()));
         conditionSuppliers.add(() -> new MinAgeCondition(new TimeValue(randomNonNegativeLong())));
         conditionSuppliers.add(() -> new MinDocsCondition(randomNonNegativeLong()));
-        conditionSuppliers.add(() -> new MinSizeCondition(new ByteSizeValue(randomNonNegativeLong())));
-        conditionSuppliers.add(() -> new MinPrimaryShardSizeCondition(new ByteSizeValue(randomNonNegativeLong())));
+        conditionSuppliers.add(() -> new MinSizeCondition(ByteSizeValue.ofBytes(randomNonNegativeLong())));
+        conditionSuppliers.add(() -> new MinPrimaryShardSizeCondition(ByteSizeValue.ofBytes(randomNonNegativeLong())));
         conditionSuppliers.add(() -> new MinPrimaryShardDocsCondition(randomNonNegativeLong()));
     }
 

--- a/server/src/test/java/org/elasticsearch/action/admin/indices/rollover/TransportRolloverActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/indices/rollover/TransportRolloverActionTests.java
@@ -190,16 +190,16 @@ public class TransportRolloverActionTests extends ESTestCase {
     public void testEvaluateWithoutStats() {
         MaxAgeCondition maxAgeCondition = new MaxAgeCondition(TimeValue.timeValueHours(randomIntBetween(1, 3)));
         MaxDocsCondition maxDocsCondition = new MaxDocsCondition(randomNonNegativeLong());
-        MaxSizeCondition maxSizeCondition = new MaxSizeCondition(new ByteSizeValue(randomNonNegativeLong()));
+        MaxSizeCondition maxSizeCondition = new MaxSizeCondition(ByteSizeValue.ofBytes(randomNonNegativeLong()));
         MaxPrimaryShardSizeCondition maxPrimaryShardSizeCondition = new MaxPrimaryShardSizeCondition(
-            new ByteSizeValue(randomNonNegativeLong())
+            ByteSizeValue.ofBytes(randomNonNegativeLong())
         );
         MaxPrimaryShardDocsCondition maxPrimaryShardDocsCondition = new MaxPrimaryShardDocsCondition(randomNonNegativeLong());
         MinAgeCondition minAgeCondition = new MinAgeCondition(TimeValue.timeValueHours(randomIntBetween(1, 3)));
         MinDocsCondition minDocsCondition = new MinDocsCondition(randomNonNegativeLong());
-        MinSizeCondition minSizeCondition = new MinSizeCondition(new ByteSizeValue(randomNonNegativeLong()));
+        MinSizeCondition minSizeCondition = new MinSizeCondition(ByteSizeValue.ofBytes(randomNonNegativeLong()));
         MinPrimaryShardSizeCondition minPrimaryShardSizeCondition = new MinPrimaryShardSizeCondition(
-            new ByteSizeValue(randomNonNegativeLong())
+            ByteSizeValue.ofBytes(randomNonNegativeLong())
         );
         MinPrimaryShardDocsCondition minPrimaryShardDocsCondition = new MinPrimaryShardDocsCondition(randomNonNegativeLong());
         final Set<Condition<?>> conditions = Set.of(

--- a/server/src/test/java/org/elasticsearch/action/admin/indices/shrink/ResizeRequestTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/indices/shrink/ResizeRequestTests.java
@@ -167,7 +167,7 @@ public class ResizeRequestTests extends AbstractWireSerializingTestCase<ResizeRe
             resizeRequest.setTargetIndex(RandomCreateIndexGenerator.randomCreateIndexRequest());
         }
         if (randomBoolean()) {
-            resizeRequest.setMaxPrimaryShardSize(new ByteSizeValue(randomIntBetween(1, 100)));
+            resizeRequest.setMaxPrimaryShardSize(ByteSizeValue.ofBytes(randomIntBetween(1, 100)));
         }
         return resizeRequest;
     }

--- a/server/src/test/java/org/elasticsearch/action/admin/indices/shrink/TransportResizeActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/indices/shrink/TransportResizeActionTests.java
@@ -290,7 +290,7 @@ public class TransportResizeActionTests extends ESTestCase {
             Settings.builder().put("index.blocks.write", true).build()
         ).metadata().index("source");
         ResizeRequest resizeRequest = new ResizeRequest("target", "source");
-        resizeRequest.setMaxPrimaryShardSize(new ByteSizeValue(10));
+        resizeRequest.setMaxPrimaryShardSize(ByteSizeValue.ofBytes(10));
         resizeRequest.getTargetIndexRequest().settings(Settings.builder().put("index.number_of_shards", 2).build());
         assertTrue(
             expectThrows(
@@ -329,7 +329,7 @@ public class TransportResizeActionTests extends ESTestCase {
 
         // each shard's storage will not be greater than the `max_primary_shard_size`
         ResizeRequest target1 = new ResizeRequest("target", "source");
-        target1.setMaxPrimaryShardSize(new ByteSizeValue(2));
+        target1.setMaxPrimaryShardSize(ByteSizeValue.ofBytes(2));
         StoreStats storeStats = new StoreStats(10, between(0, 100), between(1, 100));
         final int targetIndexShardsNum1 = 5;
         final ActiveShardCount activeShardCount1 = ActiveShardCount.from(targetIndexShardsNum1);
@@ -350,7 +350,7 @@ public class TransportResizeActionTests extends ESTestCase {
         // if `max_primary_shard_size` is less than the single shard size of the source index,
         // the shards number of the target index will be equal to the source index's shards number
         ResizeRequest target2 = new ResizeRequest("target2", "source");
-        target2.setMaxPrimaryShardSize(new ByteSizeValue(1));
+        target2.setMaxPrimaryShardSize(ByteSizeValue.ofBytes(1));
         StoreStats storeStats2 = new StoreStats(100, between(0, 100), between(1, 100));
         final int targetIndexShardsNum2 = 10;
         final ActiveShardCount activeShardCount2 = ActiveShardCount.from(targetIndexShardsNum2);

--- a/server/src/test/java/org/elasticsearch/action/bulk/BulkProcessorTests.java
+++ b/server/src/test/java/org/elasticsearch/action/bulk/BulkProcessorTests.java
@@ -222,7 +222,7 @@ public class BulkProcessorTests extends ESTestCase {
                 countingListener(requestCount, successCount, failureCount, docCount, exceptionRef),
                 concurrentBulkRequests,
                 maxBatchSize,
-                new ByteSizeValue(Integer.MAX_VALUE),
+                ByteSizeValue.ofBytes(Integer.MAX_VALUE),
                 null,
                 (command, delay, executor) -> null,
                 () -> called.set(true),
@@ -341,7 +341,7 @@ public class BulkProcessorTests extends ESTestCase {
                 countingListener(requestCount, successCount, failureCount, docCount, exceptionRef),
                 concurrentBulkRequests,
                 maxBatchSize,
-                new ByteSizeValue(Integer.MAX_VALUE),
+                ByteSizeValue.ofBytes(Integer.MAX_VALUE),
                 TimeValue.timeValueMillis(simulateWorkTimeInMillis * 2),
                 (command, delay, executor) -> Scheduler.wrapAsScheduledCancellable(
                     flushExecutor.schedule(command, delay.millis(), TimeUnit.MILLISECONDS)
@@ -444,7 +444,7 @@ public class BulkProcessorTests extends ESTestCase {
             emptyListener(),
             0,
             10,
-            new ByteSizeValue(1000),
+            ByteSizeValue.ofBytes(1000),
             null,
             (command, delay, executor) -> null,
             () -> called.set(true),

--- a/server/src/test/java/org/elasticsearch/action/index/IndexRequestTests.java
+++ b/server/src/test/java/org/elasticsearch/action/index/IndexRequestTests.java
@@ -264,9 +264,9 @@ public class IndexRequestTests extends ESTestCase {
         int actualBytes = source.getBytes(StandardCharsets.UTF_8).length;
         assertEquals(
             "index {[index][null], source[n/a, actual length: ["
-                + new ByteSizeValue(actualBytes).toString()
+                + ByteSizeValue.ofBytes(actualBytes).toString()
                 + "], max length: "
-                + new ByteSizeValue(IndexRequest.MAX_SOURCE_LENGTH_IN_TOSTRING).toString()
+                + ByteSizeValue.ofBytes(IndexRequest.MAX_SOURCE_LENGTH_IN_TOSTRING).toString()
                 + "]}",
             request.toString()
         );

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/IndexMetadataTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/IndexMetadataTests.java
@@ -91,8 +91,8 @@ public class IndexMetadataTests extends ESTestCase {
                     List.of(
                         new MaxAgeCondition(TimeValue.timeValueMillis(randomNonNegativeLong())),
                         new MaxDocsCondition(randomNonNegativeLong()),
-                        new MaxSizeCondition(new ByteSizeValue(randomNonNegativeLong())),
-                        new MaxPrimaryShardSizeCondition(new ByteSizeValue(randomNonNegativeLong())),
+                        new MaxSizeCondition(ByteSizeValue.ofBytes(randomNonNegativeLong())),
+                        new MaxPrimaryShardSizeCondition(ByteSizeValue.ofBytes(randomNonNegativeLong())),
                         new MaxPrimaryShardDocsCondition(randomNonNegativeLong())
                     ),
                     randomNonNegativeLong()

--- a/server/src/test/java/org/elasticsearch/common/UUIDTests.java
+++ b/server/src/test/java/org/elasticsearch/common/UUIDTests.java
@@ -167,7 +167,7 @@ public class UUIDTests extends ESTestCase {
                 + " docs indexed at "
                 + numDocsPerSecond
                 + " docs/s required "
-                + new ByteSizeValue(size)
+                + ByteSizeValue.ofBytes(size)
                 + " bytes of disk space, or "
                 + bytesPerDoc
                 + " bytes per document. Took: "

--- a/server/src/test/java/org/elasticsearch/common/settings/MemorySizeSettingsTests.java
+++ b/server/src/test/java/org/elasticsearch/common/settings/MemorySizeSettingsTests.java
@@ -30,7 +30,7 @@ public class MemorySizeSettingsTests extends ESTestCase {
         assertMemorySizeSetting(
             PageCacheRecycler.LIMIT_HEAP_SETTING,
             "cache.recycler.page.limit.heap",
-            new ByteSizeValue((long) (JvmInfo.jvmInfo().getMem().getHeapMax().getBytes() * 0.1))
+            ByteSizeValue.ofBytes((long) (JvmInfo.jvmInfo().getMem().getHeapMax().getBytes() * 0.1))
         );
     }
 
@@ -38,7 +38,7 @@ public class MemorySizeSettingsTests extends ESTestCase {
         assertMemorySizeSetting(
             IndexingMemoryController.INDEX_BUFFER_SIZE_SETTING,
             "indices.memory.index_buffer_size",
-            new ByteSizeValue((long) (JvmInfo.jvmInfo().getMem().getHeapMax().getBytes() * 0.1))
+            ByteSizeValue.ofBytes((long) (JvmInfo.jvmInfo().getMem().getHeapMax().getBytes() * 0.1))
         );
     }
 
@@ -46,7 +46,7 @@ public class MemorySizeSettingsTests extends ESTestCase {
         assertMemorySizeSetting(
             IndicesQueryCache.INDICES_CACHE_QUERY_SIZE_SETTING,
             "indices.queries.cache.size",
-            new ByteSizeValue((long) (JvmInfo.jvmInfo().getMem().getHeapMax().getBytes() * 0.1))
+            ByteSizeValue.ofBytes((long) (JvmInfo.jvmInfo().getMem().getHeapMax().getBytes() * 0.1))
         );
     }
 
@@ -54,7 +54,7 @@ public class MemorySizeSettingsTests extends ESTestCase {
         assertMemorySizeSetting(
             IndicesRequestCache.INDICES_CACHE_QUERY_SIZE,
             "indices.requests.cache.size",
-            new ByteSizeValue((long) (JvmInfo.jvmInfo().getMem().getHeapMax().getBytes() * 0.01))
+            ByteSizeValue.ofBytes((long) (JvmInfo.jvmInfo().getMem().getHeapMax().getBytes() * 0.01))
         );
     }
 
@@ -69,22 +69,22 @@ public class MemorySizeSettingsTests extends ESTestCase {
         assertMemorySizeSetting(
             HierarchyCircuitBreakerService.TOTAL_CIRCUIT_BREAKER_LIMIT_SETTING,
             "indices.breaker.total.limit",
-            new ByteSizeValue((long) (JvmInfo.jvmInfo().getMem().getHeapMax().getBytes() * defaultTotalPercentage))
+            ByteSizeValue.ofBytes((long) (JvmInfo.jvmInfo().getMem().getHeapMax().getBytes() * defaultTotalPercentage))
         );
         assertMemorySizeSetting(
             HierarchyCircuitBreakerService.FIELDDATA_CIRCUIT_BREAKER_LIMIT_SETTING,
             "indices.breaker.fielddata.limit",
-            new ByteSizeValue((long) (JvmInfo.jvmInfo().getMem().getHeapMax().getBytes() * 0.4))
+            ByteSizeValue.ofBytes((long) (JvmInfo.jvmInfo().getMem().getHeapMax().getBytes() * 0.4))
         );
         assertMemorySizeSetting(
             HierarchyCircuitBreakerService.REQUEST_CIRCUIT_BREAKER_LIMIT_SETTING,
             "indices.breaker.request.limit",
-            new ByteSizeValue((long) (JvmInfo.jvmInfo().getMem().getHeapMax().getBytes() * 0.6))
+            ByteSizeValue.ofBytes((long) (JvmInfo.jvmInfo().getMem().getHeapMax().getBytes() * 0.6))
         );
         assertMemorySizeSetting(
             HierarchyCircuitBreakerService.IN_FLIGHT_REQUESTS_CIRCUIT_BREAKER_LIMIT_SETTING,
             "network.breaker.inflight_requests.limit",
-            new ByteSizeValue((JvmInfo.jvmInfo().getMem().getHeapMax().getBytes()))
+            ByteSizeValue.ofBytes((JvmInfo.jvmInfo().getMem().getHeapMax().getBytes()))
         );
     }
 
@@ -92,7 +92,7 @@ public class MemorySizeSettingsTests extends ESTestCase {
         assertMemorySizeSetting(
             IndicesFieldDataCache.INDICES_FIELDDATA_CACHE_SIZE_KEY,
             "indices.fielddata.cache.size",
-            new ByteSizeValue(-1)
+            ByteSizeValue.ofBytes(-1)
         );
     }
 
@@ -104,10 +104,10 @@ public class MemorySizeSettingsTests extends ESTestCase {
         Settings settingWithPercentage = Settings.builder().put(settingKey, "25%").build();
         assertThat(
             setting.get(settingWithPercentage),
-            equalTo(new ByteSizeValue((long) (JvmInfo.jvmInfo().getMem().getHeapMax().getBytes() * 0.25)))
+            equalTo(ByteSizeValue.ofBytes((long) (JvmInfo.jvmInfo().getMem().getHeapMax().getBytes() * 0.25)))
         );
         Settings settingWithBytesValue = Settings.builder().put(settingKey, "1024b").build();
-        assertThat(setting.get(settingWithBytesValue), equalTo(new ByteSizeValue(1024)));
+        assertThat(setting.get(settingWithBytesValue), equalTo(ByteSizeValue.ofBytes(1024)));
     }
 
 }

--- a/server/src/test/java/org/elasticsearch/common/settings/SettingTests.java
+++ b/server/src/test/java/org/elasticsearch/common/settings/SettingTests.java
@@ -59,7 +59,7 @@ public class SettingTests extends ESTestCase {
     public void testByteSizeSetting() {
         final Setting<ByteSizeValue> byteSizeValueSetting = Setting.byteSizeSetting(
             "a.byte.size",
-            new ByteSizeValue(1024),
+            ByteSizeValue.ofBytes(1024),
             Property.Dynamic,
             Property.NodeScope
         );
@@ -73,7 +73,7 @@ public class SettingTests extends ESTestCase {
             "a.byte.size",
             new ByteSizeValue(100, ByteSizeUnit.MB),
             new ByteSizeValue(20_000_000, ByteSizeUnit.BYTES),
-            new ByteSizeValue(Integer.MAX_VALUE, ByteSizeUnit.BYTES)
+            ByteSizeValue.ofBytes(Integer.MAX_VALUE)
         );
         final long value = 20_000_000 - randomIntBetween(1, 1024);
         final Settings settings = Settings.builder().put("a.byte.size", value + "b").build();
@@ -87,7 +87,7 @@ public class SettingTests extends ESTestCase {
             "a.byte.size",
             new ByteSizeValue(100, ByteSizeUnit.MB),
             new ByteSizeValue(16, ByteSizeUnit.MB),
-            new ByteSizeValue(Integer.MAX_VALUE, ByteSizeUnit.BYTES)
+            ByteSizeValue.ofBytes(Integer.MAX_VALUE)
         );
         final long value = (1L << 31) - 1 + randomIntBetween(1, 1024);
         final Settings settings = Settings.builder().put("a.byte.size", value + "b").build();
@@ -119,13 +119,13 @@ public class SettingTests extends ESTestCase {
         final String expected = "failed to parse setting [a.byte.size] with value [12] as a size in bytes: unit is missing or unrecognized";
         assertThat(cause, hasToString(containsString(expected)));
         assertTrue(settingUpdater.apply(Settings.builder().put("a.byte.size", "12b").build(), Settings.EMPTY));
-        assertThat(value.get(), equalTo(new ByteSizeValue(12)));
+        assertThat(value.get(), equalTo(ByteSizeValue.ofBytes(12)));
     }
 
     public void testMemorySize() {
         Setting<ByteSizeValue> memorySizeValueSetting = Setting.memorySizeSetting(
             "a.byte.size",
-            new ByteSizeValue(1024),
+            ByteSizeValue.ofBytes(1024),
             Property.Dynamic,
             Property.NodeScope
         );
@@ -163,10 +163,10 @@ public class SettingTests extends ESTestCase {
         }
 
         assertTrue(settingUpdater.apply(Settings.builder().put("a.byte.size", "12b").build(), Settings.EMPTY));
-        assertEquals(new ByteSizeValue(12), value.get());
+        assertEquals(ByteSizeValue.ofBytes(12), value.get());
 
         assertTrue(settingUpdater.apply(Settings.builder().put("a.byte.size", "20%").build(), Settings.EMPTY));
-        assertEquals(new ByteSizeValue((long) (JvmInfo.jvmInfo().getMem().getHeapMax().getBytes() * 0.2)), value.get());
+        assertEquals(ByteSizeValue.ofBytes((long) (JvmInfo.jvmInfo().getMem().getHeapMax().getBytes() * 0.2)), value.get());
     }
 
     public void testSimpleUpdate() {

--- a/server/src/test/java/org/elasticsearch/common/unit/ByteSizeUnitTests.java
+++ b/server/src/test/java/org/elasticsearch/common/unit/ByteSizeUnitTests.java
@@ -72,12 +72,12 @@ public class ByteSizeUnitTests extends ESTestCase {
 
     public void testToString() {
         int v = randomIntBetween(1, 1023);
-        assertThat(new ByteSizeValue(PB.toBytes(v)).toString(), equalTo(v + "pb"));
-        assertThat(new ByteSizeValue(TB.toBytes(v)).toString(), equalTo(v + "tb"));
-        assertThat(new ByteSizeValue(GB.toBytes(v)).toString(), equalTo(v + "gb"));
-        assertThat(new ByteSizeValue(MB.toBytes(v)).toString(), equalTo(v + "mb"));
-        assertThat(new ByteSizeValue(KB.toBytes(v)).toString(), equalTo(v + "kb"));
-        assertThat(new ByteSizeValue(BYTES.toBytes(v)).toString(), equalTo(v + "b"));
+        assertThat(ByteSizeValue.ofBytes(PB.toBytes(v)).toString(), equalTo(v + "pb"));
+        assertThat(ByteSizeValue.ofBytes(TB.toBytes(v)).toString(), equalTo(v + "tb"));
+        assertThat(ByteSizeValue.ofBytes(GB.toBytes(v)).toString(), equalTo(v + "gb"));
+        assertThat(ByteSizeValue.ofBytes(MB.toBytes(v)).toString(), equalTo(v + "mb"));
+        assertThat(ByteSizeValue.ofBytes(KB.toBytes(v)).toString(), equalTo(v + "kb"));
+        assertThat(ByteSizeValue.ofBytes(BYTES.toBytes(v)).toString(), equalTo(v + "b"));
     }
 
     public void testSerialization() throws IOException {

--- a/server/src/test/java/org/elasticsearch/common/unit/ByteSizeValueTests.java
+++ b/server/src/test/java/org/elasticsearch/common/unit/ByteSizeValueTests.java
@@ -217,13 +217,13 @@ public class ByteSizeValueTests extends AbstractWireSerializingTestCase<ByteSize
             }
             return new ByteSizeValue(size, unit);
         } else {
-            return new ByteSizeValue(randomNonNegativeLong());
+            return ByteSizeValue.ofBytes(randomNonNegativeLong());
         }
     }
 
     @Override
     protected Reader<ByteSizeValue> instanceReader() {
-        return ByteSizeValue::new;
+        return ByteSizeValue::readFrom;
     }
 
     @Override
@@ -288,11 +288,11 @@ public class ByteSizeValueTests extends AbstractWireSerializingTestCase<ByteSize
     }
 
     public void testParseSpecialValues() throws IOException {
-        ByteSizeValue instance = new ByteSizeValue(-1);
+        ByteSizeValue instance = ByteSizeValue.ofBytes(-1);
         assertEquals(instance, ByteSizeValue.parseBytesSizeValue(instance.getStringRep(), null, "test"));
         assertSerialization(instance);
 
-        instance = new ByteSizeValue(0);
+        instance = ByteSizeValue.ofBytes(0);
         assertEquals(instance, ByteSizeValue.parseBytesSizeValue(instance.getStringRep(), null, "test"));
         assertSerialization(instance);
     }
@@ -524,5 +524,11 @@ public class ByteSizeValueTests extends AbstractWireSerializingTestCase<ByteSize
 
         e = expectThrows(IllegalArgumentException.class, () -> ByteSizeValue.min(ByteSizeValue.MINUS_ONE, ByteSizeValue.MINUS_ONE));
         assertThat(e.getMessage(), containsString(exceptionMessage));
+    }
+
+    @Override
+    protected void assertEqualInstances(ByteSizeValue expectedInstance, ByteSizeValue newInstance) {
+        assertThat(newInstance, equalTo(expectedInstance));
+        assertThat(newInstance.hashCode(), equalTo(expectedInstance.hashCode()));
     }
 }

--- a/server/src/test/java/org/elasticsearch/common/util/BitArrayTests.java
+++ b/server/src/test/java/org/elasticsearch/common/util/BitArrayTests.java
@@ -81,7 +81,7 @@ public class BitArrayTests extends ESTestCase {
     }
 
     public void testAllocation() {
-        MockBigArrays.assertFitsIn(new ByteSizeValue(100), bigArrays -> new BitArray(1, bigArrays));
+        MockBigArrays.assertFitsIn(ByteSizeValue.ofBytes(100), bigArrays -> new BitArray(1, bigArrays));
     }
 
     public void testOr() {

--- a/server/src/test/java/org/elasticsearch/common/util/BytesRefHashTests.java
+++ b/server/src/test/java/org/elasticsearch/common/util/BytesRefHashTests.java
@@ -338,7 +338,7 @@ public class BytesRefHashTests extends ESTestCase {
     // END - tests borrowed from LUCENE
 
     public void testAllocation() {
-        MockBigArrays.assertFitsIn(new ByteSizeValue(512), bigArrays -> new BytesRefHash(1, bigArrays));
+        MockBigArrays.assertFitsIn(ByteSizeValue.ofBytes(512), bigArrays -> new BytesRefHash(1, bigArrays));
     }
 
     private void assertEquality(BytesRefHash original, BytesRefHash copy) {

--- a/server/src/test/java/org/elasticsearch/common/util/LongHashTests.java
+++ b/server/src/test/java/org/elasticsearch/common/util/LongHashTests.java
@@ -181,7 +181,7 @@ public class LongHashTests extends ESTestCase {
     }
 
     public void testAllocation() {
-        MockBigArrays.assertFitsIn(new ByteSizeValue(160), bigArrays -> new LongHash(1, bigArrays));
+        MockBigArrays.assertFitsIn(ByteSizeValue.ofBytes(160), bigArrays -> new LongHash(1, bigArrays));
     }
 
     private static void assertAllIn(Set<Long> longs, LongHash hash) {

--- a/server/src/test/java/org/elasticsearch/common/util/LongLongHashTests.java
+++ b/server/src/test/java/org/elasticsearch/common/util/LongLongHashTests.java
@@ -91,7 +91,7 @@ public class LongLongHashTests extends ESTestCase {
     }
 
     public void testAllocation() {
-        MockBigArrays.assertFitsIn(new ByteSizeValue(256), bigArrays -> new LongLongHash(1, bigArrays));
+        MockBigArrays.assertFitsIn(ByteSizeValue.ofBytes(256), bigArrays -> new LongLongHash(1, bigArrays));
     }
 
     class Key {

--- a/server/src/test/java/org/elasticsearch/common/util/LongObjectPagedHashMapTests.java
+++ b/server/src/test/java/org/elasticsearch/common/util/LongObjectPagedHashMapTests.java
@@ -57,7 +57,7 @@ public class LongObjectPagedHashMapTests extends ESTestCase {
     }
 
     public void testAllocation() {
-        MockBigArrays.assertFitsIn(new ByteSizeValue(256), bigArrays -> new LongObjectPagedHashMap<Object>(1, bigArrays));
+        MockBigArrays.assertFitsIn(ByteSizeValue.ofBytes(256), bigArrays -> new LongObjectPagedHashMap<Object>(1, bigArrays));
     }
 
 }

--- a/server/src/test/java/org/elasticsearch/index/IndexSettingsTests.java
+++ b/server/src/test/java/org/elasticsearch/index/IndexSettingsTests.java
@@ -512,7 +512,7 @@ public class IndexSettingsTests extends ESTestCase {
     }
 
     public void testTranslogFlushSizeThreshold() {
-        ByteSizeValue translogFlushThresholdSize = new ByteSizeValue(Math.abs(randomInt()));
+        ByteSizeValue translogFlushThresholdSize = ByteSizeValue.ofBytes(Math.abs(randomInt()));
         ByteSizeValue actualValue = ByteSizeValue.parseBytesSizeValue(
             translogFlushThresholdSize.getBytes() + "B",
             IndexSettings.INDEX_TRANSLOG_FLUSH_THRESHOLD_SIZE_SETTING.getKey()
@@ -526,7 +526,7 @@ public class IndexSettingsTests extends ESTestCase {
         );
         IndexSettings settings = new IndexSettings(metadata, Settings.EMPTY);
         assertEquals(actualValue, settings.getFlushThresholdSize());
-        ByteSizeValue newTranslogFlushThresholdSize = new ByteSizeValue(Math.abs(randomInt()));
+        ByteSizeValue newTranslogFlushThresholdSize = ByteSizeValue.ofBytes(Math.abs(randomInt()));
         ByteSizeValue actualNewTranslogFlushThresholdSize = ByteSizeValue.parseBytesSizeValue(
             newTranslogFlushThresholdSize.getBytes() + "B",
             IndexSettings.INDEX_TRANSLOG_FLUSH_THRESHOLD_SIZE_SETTING.getKey()
@@ -543,7 +543,7 @@ public class IndexSettingsTests extends ESTestCase {
     }
 
     public void testTranslogGenerationSizeThreshold() {
-        final ByteSizeValue size = new ByteSizeValue(Math.abs(randomInt()));
+        final ByteSizeValue size = ByteSizeValue.ofBytes(Math.abs(randomInt()));
         final String key = IndexSettings.INDEX_TRANSLOG_GENERATION_THRESHOLD_SIZE_SETTING.getKey();
         final ByteSizeValue actualValue = ByteSizeValue.parseBytesSizeValue(size.getBytes() + "B", key);
         final IndexMetadata metadata = newIndexMeta(
@@ -552,7 +552,7 @@ public class IndexSettingsTests extends ESTestCase {
         );
         final IndexSettings settings = new IndexSettings(metadata, Settings.EMPTY);
         assertEquals(actualValue, settings.getGenerationThresholdSize());
-        final ByteSizeValue newSize = new ByteSizeValue(Math.abs(randomInt()));
+        final ByteSizeValue newSize = ByteSizeValue.ofBytes(Math.abs(randomInt()));
         final ByteSizeValue actual = ByteSizeValue.parseBytesSizeValue(newSize.getBytes() + "B", key);
         settings.updateIndexMetadata(newIndexMeta("index", Settings.builder().put(key, newSize.getBytes() + "B").build()));
         assertEquals(actual, settings.getGenerationThresholdSize());

--- a/server/src/test/java/org/elasticsearch/index/MergePolicySettingsTests.java
+++ b/server/src/test/java/org/elasticsearch/index/MergePolicySettingsTests.java
@@ -140,14 +140,14 @@ public class MergePolicySettingsTests extends ESTestCase {
                 Settings.builder()
                     .put(
                         MergePolicyConfig.INDEX_MERGE_POLICY_MAX_MERGED_SEGMENT_SETTING.getKey(),
-                        new ByteSizeValue(MergePolicyConfig.DEFAULT_MAX_MERGED_SEGMENT.getBytes() + 1)
+                        ByteSizeValue.ofBytes(MergePolicyConfig.DEFAULT_MAX_MERGED_SEGMENT.getBytes() + 1)
                     )
                     .build()
             )
         );
         assertEquals(
             ((TieredMergePolicy) indexSettings.getMergePolicy()).getMaxMergedSegmentMB(),
-            new ByteSizeValue(MergePolicyConfig.DEFAULT_MAX_MERGED_SEGMENT.getBytes() + 1).getMbFrac(),
+            ByteSizeValue.ofBytes(MergePolicyConfig.DEFAULT_MAX_MERGED_SEGMENT.getBytes() + 1).getMbFrac(),
             0.0001
         );
 
@@ -211,7 +211,7 @@ public class MergePolicySettingsTests extends ESTestCase {
         assertEquals(((TieredMergePolicy) indexSettings.getMergePolicy()).getMaxMergeAtOnce(), MergePolicyConfig.DEFAULT_MAX_MERGE_AT_ONCE);
         assertEquals(
             ((TieredMergePolicy) indexSettings.getMergePolicy()).getMaxMergedSegmentMB(),
-            new ByteSizeValue(MergePolicyConfig.DEFAULT_MAX_MERGED_SEGMENT.getBytes() + 1).getMbFrac(),
+            ByteSizeValue.ofBytes(MergePolicyConfig.DEFAULT_MAX_MERGED_SEGMENT.getBytes() + 1).getMbFrac(),
             0.0001
         );
         assertEquals(

--- a/server/src/test/java/org/elasticsearch/index/shard/PrimaryReplicaSyncerTests.java
+++ b/server/src/test/java/org/elasticsearch/index/shard/PrimaryReplicaSyncerTests.java
@@ -71,7 +71,7 @@ public class PrimaryReplicaSyncerTests extends IndexShardTestCase {
             listener.onResponse(new ResyncReplicationResponse());
         };
         PrimaryReplicaSyncer syncer = new PrimaryReplicaSyncer(transportService, syncAction);
-        syncer.setChunkSize(new ByteSizeValue(randomIntBetween(1, 10)));
+        syncer.setChunkSize(ByteSizeValue.ofBytes(randomIntBetween(1, 10)));
 
         int numDocs = randomInt(10);
         for (int i = 0; i < numDocs; i++) {
@@ -161,7 +161,7 @@ public class PrimaryReplicaSyncerTests extends IndexShardTestCase {
             emptySet()
         );
         PrimaryReplicaSyncer syncer = new PrimaryReplicaSyncer(transportService, syncAction);
-        syncer.setChunkSize(new ByteSizeValue(1)); // every document is sent off separately
+        syncer.setChunkSize(ByteSizeValue.ofBytes(1)); // every document is sent off separately
 
         int numDocs = 10;
         for (int i = 0; i < numDocs; i++) {

--- a/server/src/test/java/org/elasticsearch/index/shard/RemoveCorruptedShardDataCommandTests.java
+++ b/server/src/test/java/org/elasticsearch/index/shard/RemoveCorruptedShardDataCommandTests.java
@@ -137,8 +137,8 @@ public class RemoveCorruptedShardDataCommandTests extends IndexShardTestCase {
         Condition<?> rolloverCondition = randomFrom(
             new MaxAgeCondition(new TimeValue(randomNonNegativeLong())),
             new MaxDocsCondition(randomNonNegativeLong()),
-            new MaxPrimaryShardSizeCondition(new ByteSizeValue(randomNonNegativeLong())),
-            new MaxSizeCondition(new ByteSizeValue(randomNonNegativeLong())),
+            new MaxPrimaryShardSizeCondition(ByteSizeValue.ofBytes(randomNonNegativeLong())),
+            new MaxSizeCondition(ByteSizeValue.ofBytes(randomNonNegativeLong())),
             new MaxPrimaryShardDocsCondition(randomNonNegativeLong())
         );
 

--- a/server/src/test/java/org/elasticsearch/index/snapshots/blobstore/FileInfoTests.java
+++ b/server/src/test/java/org/elasticsearch/index/snapshots/blobstore/FileInfoTests.java
@@ -51,7 +51,7 @@ public class FileInfoTests extends ESTestCase {
                 hash,
                 writerUuid
             );
-            ByteSizeValue size = new ByteSizeValue(Math.abs(randomLong()));
+            ByteSizeValue size = ByteSizeValue.ofBytes(Math.abs(randomLong()));
             BlobStoreIndexShardSnapshot.FileInfo info = new BlobStoreIndexShardSnapshot.FileInfo("_foobar", meta, size);
             XContentBuilder builder = XContentFactory.contentBuilder(XContentType.JSON).prettyPrint();
             boolean serializeWriterUUID = randomBoolean();
@@ -164,7 +164,7 @@ public class FileInfoTests extends ESTestCase {
         BlobStoreIndexShardSnapshot.FileInfo info = new BlobStoreIndexShardSnapshot.FileInfo(
             "foo",
             new StoreFileMetadata("foo", 36, "666", MIN_SUPPORTED_LUCENE_VERSION.toString()),
-            new ByteSizeValue(6)
+            ByteSizeValue.ofBytes(6)
         );
         int numBytes = 0;
         for (int i = 0; i < info.numberOfParts(); i++) {
@@ -175,7 +175,7 @@ public class FileInfoTests extends ESTestCase {
         info = new BlobStoreIndexShardSnapshot.FileInfo(
             "foo",
             new StoreFileMetadata("foo", 35, "666", MIN_SUPPORTED_LUCENE_VERSION.toString()),
-            new ByteSizeValue(6)
+            ByteSizeValue.ofBytes(6)
         );
         numBytes = 0;
         for (int i = 0; i < info.numberOfParts(); i++) {
@@ -190,7 +190,7 @@ public class FileInfoTests extends ESTestCase {
                 "666",
                 MIN_SUPPORTED_LUCENE_VERSION.toString()
             );
-            info = new BlobStoreIndexShardSnapshot.FileInfo("foo", metadata, new ByteSizeValue(randomIntBetween(1, 1000)));
+            info = new BlobStoreIndexShardSnapshot.FileInfo("foo", metadata, ByteSizeValue.ofBytes(randomIntBetween(1, 1000)));
             numBytes = 0;
             for (int i = 0; i < info.numberOfParts(); i++) {
                 numBytes += info.partBytes(i);

--- a/server/src/test/java/org/elasticsearch/indices/breaker/HierarchyCircuitBreakerServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/indices/breaker/HierarchyCircuitBreakerServiceTests.java
@@ -299,7 +299,7 @@ public class HierarchyCircuitBreakerServiceTests extends ESTestCase {
                 "real usage: [181/181b], new bytes reserved: ["
                     + (reservationInBytes * 2)
                     + "/"
-                    + new ByteSizeValue(reservationInBytes * 2)
+                    + ByteSizeValue.ofBytes(reservationInBytes * 2)
                     + "]"
             )
         );
@@ -308,7 +308,7 @@ public class HierarchyCircuitBreakerServiceTests extends ESTestCase {
         assertThat(exception.getMessage(), containsString("fielddata=0/0b"));
         assertThat(
             exception.getMessage(),
-            containsString("request=" + requestCircuitBreakerUsed + "/" + new ByteSizeValue(requestCircuitBreakerUsed))
+            containsString("request=" + requestCircuitBreakerUsed + "/" + ByteSizeValue.ofBytes(requestCircuitBreakerUsed))
         );
         assertThat(exception.getMessage(), containsString("inflight_requests=0/0b"));
         assertThat(exception.getDurability(), equalTo(CircuitBreaker.Durability.TRANSIENT));

--- a/server/src/test/java/org/elasticsearch/indices/recovery/RecoverySettingsTests.java
+++ b/server/src/test/java/org/elasticsearch/indices/recovery/RecoverySettingsTests.java
@@ -413,11 +413,11 @@ public class RecoverySettingsTests extends ESTestCase {
     }
 
     private static ByteSizeValue randomByteSizeValue() {
-        return new ByteSizeValue(randomLongBetween(0L, Long.MAX_VALUE >> 16));
+        return ByteSizeValue.ofBytes(randomLongBetween(0L, Long.MAX_VALUE >> 16));
     }
 
     private static ByteSizeValue randomNonZeroByteSizeValue() {
-        return new ByteSizeValue(randomLongBetween(1L, Long.MAX_VALUE >> 16));
+        return ByteSizeValue.ofBytes(randomLongBetween(1L, Long.MAX_VALUE >> 16));
     }
 
     private static Set<String> randomDataNodeRoles() {

--- a/server/src/test/java/org/elasticsearch/monitor/jvm/JvmGcMonitorServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/monitor/jvm/JvmGcMonitorServiceTests.java
@@ -34,14 +34,14 @@ public class JvmGcMonitorServiceTests extends ESTestCase {
         final TimeValue totalCollectionTime = TimeValue.timeValueMillis(randomIntBetween(1, elapsedValue));
         final TimeValue currentCollectionTime = TimeValue.timeValueMillis(randomIntBetween(1, elapsedValue));
 
-        final ByteSizeValue lastHeapUsed = new ByteSizeValue(randomIntBetween(1, 1 << 10));
+        final ByteSizeValue lastHeapUsed = ByteSizeValue.ofBytes(randomIntBetween(1, 1 << 10));
         JvmStats lastJvmStats = mock(JvmStats.class);
         JvmStats.Mem lastMem = mock(JvmStats.Mem.class);
         when(lastMem.getHeapUsed()).thenReturn(lastHeapUsed);
         when(lastJvmStats.getMem()).thenReturn(lastMem);
         when(lastJvmStats.toString()).thenReturn("last");
 
-        final ByteSizeValue currentHeapUsed = new ByteSizeValue(randomIntBetween(1, 1 << 10));
+        final ByteSizeValue currentHeapUsed = ByteSizeValue.ofBytes(randomIntBetween(1, 1 << 10));
         JvmStats currentJvmStats = mock(JvmStats.class);
         JvmStats.Mem currentMem = mock(JvmStats.Mem.class);
         when(currentMem.getHeapUsed()).thenReturn(currentHeapUsed);
@@ -53,7 +53,7 @@ public class JvmGcMonitorServiceTests extends ESTestCase {
         when(gc.getCollectionCount()).thenReturn(totalCollectionCount);
         when(gc.getCollectionTime()).thenReturn(totalCollectionTime);
 
-        final ByteSizeValue maxHeapUsed = new ByteSizeValue(Math.max(lastHeapUsed.getBytes(), currentHeapUsed.getBytes()) + 1 << 10);
+        final ByteSizeValue maxHeapUsed = ByteSizeValue.ofBytes(Math.max(lastHeapUsed.getBytes(), currentHeapUsed.getBytes()) + 1 << 10);
 
         JvmGcMonitorService.JvmMonitor.SlowGcEvent slowGcEvent = new JvmGcMonitorService.JvmMonitor.SlowGcEvent(
             gc,

--- a/server/src/test/java/org/elasticsearch/nodesinfo/NodeInfoStreamingTests.java
+++ b/server/src/test/java/org/elasticsearch/nodesinfo/NodeInfoStreamingTests.java
@@ -222,7 +222,7 @@ public class NodeInfoStreamingTests extends ESTestCase {
         ByteSizeValue indexingBuffer = null;
         if (randomBoolean()) {
             // pick a random long that sometimes exceeds an int:
-            indexingBuffer = new ByteSizeValue(random().nextLong() & ((1L << 40) - 1));
+            indexingBuffer = ByteSizeValue.ofBytes(random().nextLong() & ((1L << 40) - 1));
         }
         return new NodeInfo(
             VersionUtils.randomVersion(random()),

--- a/server/src/test/java/org/elasticsearch/rest/RestControllerTests.java
+++ b/server/src/test/java/org/elasticsearch/rest/RestControllerTests.java
@@ -78,7 +78,7 @@ import static org.mockito.Mockito.when;
 
 public class RestControllerTests extends ESTestCase {
 
-    private static final ByteSizeValue BREAKER_LIMIT = new ByteSizeValue(20);
+    private static final ByteSizeValue BREAKER_LIMIT = ByteSizeValue.ofBytes(20);
     private CircuitBreaker inFlightRequestsBreaker;
     private RestController restController;
     private HierarchyCircuitBreakerService circuitBreakerService;

--- a/server/src/test/java/org/elasticsearch/rest/action/cat/RestCatRecoveryActionTests.java
+++ b/server/src/test/java/org/elasticsearch/rest/action/cat/RestCatRecoveryActionTests.java
@@ -175,10 +175,10 @@ public class RestCatRecoveryActionTests extends ESTestCase {
                 state.getIndex().recoveredFileCount(),
                 percent(state.getIndex().recoveredFilesPercent()),
                 state.getIndex().totalFileCount(),
-                new ByteSizeValue(state.getIndex().totalRecoverBytes()),
-                new ByteSizeValue(state.getIndex().recoveredBytes()),
+                ByteSizeValue.ofBytes(state.getIndex().totalRecoverBytes()),
+                ByteSizeValue.ofBytes(state.getIndex().recoveredBytes()),
                 percent(state.getIndex().recoveredBytesPercent()),
-                new ByteSizeValue(state.getIndex().totalBytes()),
+                ByteSizeValue.ofBytes(state.getIndex().totalBytes()),
                 state.getTranslog().totalOperations(),
                 state.getTranslog().recoveredOperations(),
                 percent(state.getTranslog().recoveredPercent())

--- a/server/src/test/java/org/elasticsearch/snapshots/ShardSnapshotResultWireSerializationTests.java
+++ b/server/src/test/java/org/elasticsearch/snapshots/ShardSnapshotResultWireSerializationTests.java
@@ -49,7 +49,7 @@ public class ShardSnapshotResultWireSerializationTests extends AbstractWireSeria
     }
 
     static ShardSnapshotResult randomShardSnapshotResult() {
-        return new ShardSnapshotResult(ShardGeneration.newGeneration(), new ByteSizeValue(randomNonNegativeLong()), between(0, 1000));
+        return new ShardSnapshotResult(ShardGeneration.newGeneration(), ByteSizeValue.ofBytes(randomNonNegativeLong()), between(0, 1000));
     }
 
     static ShardSnapshotResult mutateShardSnapshotResult(ShardSnapshotResult instance) {
@@ -63,7 +63,7 @@ public class ShardSnapshotResultWireSerializationTests extends AbstractWireSeria
             case 2:
                 return new ShardSnapshotResult(
                     instance.getGeneration(),
-                    randomValueOtherThan(instance.getSize(), () -> new ByteSizeValue(randomNonNegativeLong())),
+                    randomValueOtherThan(instance.getSize(), () -> ByteSizeValue.ofBytes(randomNonNegativeLong())),
                     instance.getSegmentCount()
                 );
 

--- a/server/src/test/java/org/elasticsearch/snapshots/SnapshotInfoTestUtils.java
+++ b/server/src/test/java/org/elasticsearch/snapshots/SnapshotInfoTestUtils.java
@@ -78,7 +78,7 @@ public class SnapshotInfoTestUtils {
         while (result.size() < size) {
             result.put(
                 randomAlphaOfLengthBetween(5, 10),
-                new SnapshotInfo.IndexSnapshotDetails(between(1, 10), new ByteSizeValue(between(0, Integer.MAX_VALUE)), between(1, 100))
+                new SnapshotInfo.IndexSnapshotDetails(between(1, 10), ByteSizeValue.ofBytes(between(0, Integer.MAX_VALUE)), between(1, 100))
             );
         }
         return result;

--- a/server/src/test/java/org/elasticsearch/snapshots/SnapshotsInProgressSerializationTests.java
+++ b/server/src/test/java/org/elasticsearch/snapshots/SnapshotsInProgressSerializationTests.java
@@ -102,7 +102,7 @@ public class SnapshotsInProgressSerializationTests extends SimpleDiffableWireSer
         if (shardState == ShardState.QUEUED) {
             return SnapshotsInProgress.ShardSnapshotStatus.UNASSIGNED_QUEUED;
         } else if (shardState == ShardState.SUCCESS) {
-            final ShardSnapshotResult shardSnapshotResult = new ShardSnapshotResult(new ShardGeneration(1L), new ByteSizeValue(1L), 1);
+            final ShardSnapshotResult shardSnapshotResult = new ShardSnapshotResult(new ShardGeneration(1L), ByteSizeValue.ofBytes(1L), 1);
             return SnapshotsInProgress.ShardSnapshotStatus.success(nodeId, shardSnapshotResult);
         } else {
             final String reason = shardState.failed() ? randomAlphaOfLength(10) : null;
@@ -402,7 +402,7 @@ public class SnapshotsInProgressSerializationTests extends SimpleDiffableWireSer
                     new ShardId("index", "uuid", 0),
                     SnapshotsInProgress.ShardSnapshotStatus.success(
                         "nodeId",
-                        new ShardSnapshotResult(new ShardGeneration("shardgen"), new ByteSizeValue(1L), 1)
+                        new ShardSnapshotResult(new ShardGeneration("shardgen"), ByteSizeValue.ofBytes(1L), 1)
                     ),
                     new ShardId("index", "uuid", 1),
                     new SnapshotsInProgress.ShardSnapshotStatus(

--- a/server/src/test/java/org/elasticsearch/snapshots/SnapshotsServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/snapshots/SnapshotsServiceTests.java
@@ -539,7 +539,7 @@ public class SnapshotsServiceTests extends ESTestCase {
     private static SnapshotsInProgress.ShardSnapshotStatus successfulShardStatus(String nodeId) {
         return SnapshotsInProgress.ShardSnapshotStatus.success(
             nodeId,
-            new ShardSnapshotResult(ShardGeneration.newGeneration(random()), new ByteSizeValue(1L), 1)
+            new ShardSnapshotResult(ShardGeneration.newGeneration(random()), ByteSizeValue.ofBytes(1L), 1)
         );
     }
 

--- a/test/framework/src/main/java/org/elasticsearch/test/InternalTestCluster.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/InternalTestCluster.java
@@ -597,7 +597,7 @@ public final class InternalTestCluster extends TestCluster {
         if (random.nextInt(10) == 0) {
             builder.put(
                 PersistedClusterStateService.DOCUMENT_PAGE_SIZE.getKey(),
-                new ByteSizeValue(
+                ByteSizeValue.ofBytes(
                     RandomNumbers.randomIntBetween(random, rarely(random) ? 10 : 100, randomFrom(random, 1000, 10000, 100000, 1000000))
                 )
             );

--- a/x-pack/plugin/autoscaling/src/main/java/org/elasticsearch/xpack/autoscaling/capacity/AutoscalingCalculateCapacityService.java
+++ b/x-pack/plugin/autoscaling/src/main/java/org/elasticsearch/xpack/autoscaling/capacity/AutoscalingCalculateCapacityService.java
@@ -330,8 +330,8 @@ public class AutoscalingCalculateCapacityService implements PolicyValidator {
 
             Optional<AutoscalingNodeInfo> memoryAndProcessors = autoscalingNodesInfo.get(node);
             return new AutoscalingCapacity.AutoscalingResources(
-                storage == -1 ? ByteSizeValue.ZERO : new ByteSizeValue(storage),
-                memoryAndProcessors.map(AutoscalingNodeInfo::memory).map(ByteSizeValue::new).orElse(ByteSizeValue.ZERO),
+                storage == -1 ? ByteSizeValue.ZERO : ByteSizeValue.ofBytes(storage),
+                memoryAndProcessors.map(AutoscalingNodeInfo::memory).map(ByteSizeValue::ofBytes).orElse(ByteSizeValue.ZERO),
                 memoryAndProcessors.map(AutoscalingNodeInfo::processors).orElse(null)
             );
         }

--- a/x-pack/plugin/autoscaling/src/main/java/org/elasticsearch/xpack/autoscaling/capacity/AutoscalingCapacity.java
+++ b/x-pack/plugin/autoscaling/src/main/java/org/elasticsearch/xpack/autoscaling/capacity/AutoscalingCapacity.java
@@ -44,8 +44,8 @@ public class AutoscalingCapacity implements ToXContent, Writeable {
         }
 
         public AutoscalingResources(StreamInput in) throws IOException {
-            this.storage = in.readOptionalWriteable(ByteSizeValue::new);
-            this.memory = in.readOptionalWriteable(ByteSizeValue::new);
+            this.storage = in.readOptionalWriteable(ByteSizeValue::readFrom);
+            this.memory = in.readOptionalWriteable(ByteSizeValue::readFrom);
             if (in.getVersion().onOrAfter(Version.V_8_4_0)) {
                 this.processors = in.readOptionalWriteable(Processors::readFrom);
             } else {
@@ -147,7 +147,7 @@ public class AutoscalingCapacity implements ToXContent, Writeable {
                 return v1;
             }
 
-            return new ByteSizeValue(v1.getBytes() + v2.getBytes());
+            return ByteSizeValue.ofBytes(v1.getBytes() + v2.getBytes());
         }
 
         private static Processors max(Processors v1, Processors v2) {
@@ -315,7 +315,7 @@ public class AutoscalingCapacity implements ToXContent, Writeable {
         }
 
         private ByteSizeValue byteSizeValue(Long memory) {
-            return memory == null ? null : new ByteSizeValue(memory);
+            return memory == null ? null : ByteSizeValue.ofBytes(memory);
         }
     }
 }

--- a/x-pack/plugin/autoscaling/src/main/java/org/elasticsearch/xpack/autoscaling/capacity/FixedAutoscalingDeciderService.java
+++ b/x-pack/plugin/autoscaling/src/main/java/org/elasticsearch/xpack/autoscaling/capacity/FixedAutoscalingDeciderService.java
@@ -67,7 +67,7 @@ public class FixedAutoscalingDeciderService implements AutoscalingDeciderService
 
     private static ByteSizeValue totalCapacity(ByteSizeValue nodeCapacity, int nodes) {
         if (nodeCapacity != null) {
-            return new ByteSizeValue(nodeCapacity.getBytes() * nodes);
+            return ByteSizeValue.ofBytes(nodeCapacity.getBytes() * nodes);
         } else {
             return null;
         }
@@ -116,8 +116,8 @@ public class FixedAutoscalingDeciderService implements AutoscalingDeciderService
         }
 
         public FixedReason(StreamInput in) throws IOException {
-            this.storage = in.readOptionalWriteable(ByteSizeValue::new);
-            this.memory = in.readOptionalWriteable(ByteSizeValue::new);
+            this.storage = in.readOptionalWriteable(ByteSizeValue::readFrom);
+            this.memory = in.readOptionalWriteable(ByteSizeValue::readFrom);
             this.nodes = in.readInt();
             if (in.getVersion().onOrAfter(Version.V_8_4_0)) {
                 this.processors = in.readOptionalWriteable(Processors::readFrom);

--- a/x-pack/plugin/autoscaling/src/main/java/org/elasticsearch/xpack/autoscaling/storage/ReactiveStorageDeciderService.java
+++ b/x-pack/plugin/autoscaling/src/main/java/org/elasticsearch/xpack/autoscaling/storage/ReactiveStorageDeciderService.java
@@ -173,7 +173,7 @@ public class ReactiveStorageDeciderService implements AutoscalingDeciderService 
 
     static String message(long unassignedBytes, long assignedBytes) {
         return unassignedBytes > 0 || assignedBytes > 0
-            ? "not enough storage available, needs " + new ByteSizeValue(unassignedBytes + assignedBytes)
+            ? "not enough storage available, needs " + ByteSizeValue.ofBytes(unassignedBytes + assignedBytes)
             : "storage ok";
     }
 

--- a/x-pack/plugin/autoscaling/src/test/java/org/elasticsearch/xpack/autoscaling/AutoscalingTestCase.java
+++ b/x-pack/plugin/autoscaling/src/test/java/org/elasticsearch/xpack/autoscaling/AutoscalingTestCase.java
@@ -120,7 +120,7 @@ public abstract class AutoscalingTestCase extends ESTestCase {
 
     public static ByteSizeValue randomByteSizeValue() {
         // do not want to test any overflow.
-        return new ByteSizeValue(randomLongBetween(0, Long.MAX_VALUE >> 16));
+        return ByteSizeValue.ofBytes(randomLongBetween(0, Long.MAX_VALUE >> 16));
     }
 
     public static ByteSizeValue randomNullableByteSizeValue() {

--- a/x-pack/plugin/autoscaling/src/test/java/org/elasticsearch/xpack/autoscaling/capacity/AutoscalingCalculateCapacityServiceTests.java
+++ b/x-pack/plugin/autoscaling/src/test/java/org/elasticsearch/xpack/autoscaling/capacity/AutoscalingCalculateCapacityServiceTests.java
@@ -161,8 +161,8 @@ public class AutoscalingCalculateCapacityServiceTests extends AutoscalingTestCas
         ByteSizeValue memory = configuration.getAsBytesSize(FixedAutoscalingDeciderService.MEMORY.getKey(), null);
         Double processors = configuration.getAsDouble(FixedAutoscalingDeciderService.PROCESSORS.getKey(), null);
         int nodes = FixedAutoscalingDeciderService.NODES.get(configuration);
-        ByteSizeValue totalStorage = storage != null ? new ByteSizeValue(storage.getBytes() * nodes) : null;
-        ByteSizeValue totalMemory = memory != null ? new ByteSizeValue(memory.getBytes() * nodes) : null;
+        ByteSizeValue totalStorage = storage != null ? ByteSizeValue.ofBytes(storage.getBytes() * nodes) : null;
+        ByteSizeValue totalMemory = memory != null ? ByteSizeValue.ofBytes(memory.getBytes() * nodes) : null;
         Double totalProcessors = processors != null ? processors * nodes : null;
 
         if (totalStorage == null && totalMemory == null && totalProcessors == null) {
@@ -223,8 +223,8 @@ public class AutoscalingCalculateCapacityServiceTests extends AutoscalingTestCas
         if (hasDataRole) {
             assertNull(context.currentCapacity());
         } else {
-            assertThat(context.currentCapacity().node().memory(), equalTo(new ByteSizeValue(memory)));
-            assertThat(context.currentCapacity().total().memory(), equalTo(new ByteSizeValue(memory)));
+            assertThat(context.currentCapacity().node().memory(), equalTo(ByteSizeValue.ofBytes(memory)));
+            assertThat(context.currentCapacity().total().memory(), equalTo(ByteSizeValue.ofBytes(memory)));
             assertThat(context.currentCapacity().node().storage(), equalTo(ByteSizeValue.ZERO));
             assertThat(context.currentCapacity().total().storage(), equalTo(ByteSizeValue.ZERO));
         }
@@ -278,14 +278,17 @@ public class AutoscalingCalculateCapacityServiceTests extends AutoscalingTestCas
 
         assertThat(context.nodes(), equalTo(expectedNodes));
         if (hasDataRole) {
-            assertThat(context.currentCapacity().node().storage(), equalTo(new ByteSizeValue(maxTotal)));
-            assertThat(context.currentCapacity().total().storage(), equalTo(new ByteSizeValue(sumTotal)));
+            assertThat(context.currentCapacity().node().storage(), equalTo(ByteSizeValue.ofBytes(maxTotal)));
+            assertThat(context.currentCapacity().total().storage(), equalTo(ByteSizeValue.ofBytes(sumTotal)));
         } else {
             assertThat(context.currentCapacity().node().storage(), equalTo(ByteSizeValue.ZERO));
             assertThat(context.currentCapacity().total().storage(), equalTo(ByteSizeValue.ZERO));
         }
-        assertThat(context.currentCapacity().node().memory(), equalTo(new ByteSizeValue(memory * Integer.signum(expectedNodes.size()))));
-        assertThat(context.currentCapacity().total().memory(), equalTo(new ByteSizeValue(memory * expectedNodes.size())));
+        assertThat(
+            context.currentCapacity().node().memory(),
+            equalTo(ByteSizeValue.ofBytes(memory * Integer.signum(expectedNodes.size())))
+        );
+        assertThat(context.currentCapacity().total().memory(), equalTo(ByteSizeValue.ofBytes(memory * expectedNodes.size())));
 
         if (expectedNodes.isEmpty() == false) {
             context = new AutoscalingCalculateCapacityService.DefaultAutoscalingDeciderContext(
@@ -325,8 +328,8 @@ public class AutoscalingCalculateCapacityServiceTests extends AutoscalingTestCas
             if (hasDataRole) {
                 assertThat(context.currentCapacity(), is(nullValue()));
             } else {
-                assertThat(context.currentCapacity().node().memory(), equalTo(new ByteSizeValue(memory)));
-                assertThat(context.currentCapacity().total().memory(), equalTo(new ByteSizeValue(memory * expectedNodes.size())));
+                assertThat(context.currentCapacity().node().memory(), equalTo(ByteSizeValue.ofBytes(memory)));
+                assertThat(context.currentCapacity().total().memory(), equalTo(ByteSizeValue.ofBytes(memory * expectedNodes.size())));
                 assertThat(context.currentCapacity().node().storage(), equalTo(ByteSizeValue.ZERO));
                 assertThat(context.currentCapacity().total().storage(), equalTo(ByteSizeValue.ZERO));
             }

--- a/x-pack/plugin/autoscaling/src/test/java/org/elasticsearch/xpack/autoscaling/capacity/FixedAutoscalingDeciderServiceTests.java
+++ b/x-pack/plugin/autoscaling/src/test/java/org/elasticsearch/xpack/autoscaling/capacity/FixedAutoscalingDeciderServiceTests.java
@@ -61,7 +61,7 @@ public class FixedAutoscalingDeciderServiceTests extends AutoscalingTestCase {
     }
 
     private ByteSizeValue multiply(ByteSizeValue bytes, int nodes) {
-        return bytes == null ? null : new ByteSizeValue(bytes.getBytes() * nodes);
+        return bytes == null ? null : ByteSizeValue.ofBytes(bytes.getBytes() * nodes);
     }
 
     private Processors multiply(Processors processors, int nodes) {

--- a/x-pack/plugin/ccr/src/internalClusterTest/java/org/elasticsearch/xpack/ccr/AutoFollowIT.java
+++ b/x-pack/plugin/ccr/src/internalClusterTest/java/org/elasticsearch/xpack/ccr/AutoFollowIT.java
@@ -25,7 +25,6 @@ import org.elasticsearch.cluster.metadata.Template;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.regex.Regex;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.common.unit.ByteSizeUnit;
 import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.core.CheckedRunnable;
 import org.elasticsearch.core.TimeValue;
@@ -291,7 +290,7 @@ public class AutoFollowIT extends CcrIntegTestCase {
             request.getParameters().setMaxReadRequestOperationCount(randomIntBetween(0, Integer.MAX_VALUE));
         }
         if (randomBoolean()) {
-            request.getParameters().setMaxReadRequestSize(new ByteSizeValue(randomNonNegativeLong(), ByteSizeUnit.BYTES));
+            request.getParameters().setMaxReadRequestSize(ByteSizeValue.ofBytes(randomNonNegativeLong()));
         }
         if (randomBoolean()) {
             request.getParameters().setMaxRetryDelay(TimeValue.timeValueMillis(500));
@@ -303,10 +302,10 @@ public class AutoFollowIT extends CcrIntegTestCase {
             request.getParameters().setMaxWriteRequestOperationCount(randomIntBetween(0, Integer.MAX_VALUE));
         }
         if (randomBoolean()) {
-            request.getParameters().setMaxWriteBufferSize(new ByteSizeValue(randomNonNegativeLong(), ByteSizeUnit.BYTES));
+            request.getParameters().setMaxWriteBufferSize(ByteSizeValue.ofBytes(randomNonNegativeLong()));
         }
         if (randomBoolean()) {
-            request.getParameters().setMaxWriteRequestSize(new ByteSizeValue(randomNonNegativeLong()));
+            request.getParameters().setMaxWriteRequestSize(ByteSizeValue.ofBytes(randomNonNegativeLong()));
         }
 
         request.setName("my-pattern");

--- a/x-pack/plugin/ccr/src/internalClusterTest/java/org/elasticsearch/xpack/ccr/CloseFollowerIndexIT.java
+++ b/x-pack/plugin/ccr/src/internalClusterTest/java/org/elasticsearch/xpack/ccr/CloseFollowerIndexIT.java
@@ -76,7 +76,7 @@ public class CloseFollowerIndexIT extends CcrIntegTestCase {
         followRequest.setFollowerIndex("index2");
         followRequest.getParameters().setMaxRetryDelay(TimeValue.timeValueMillis(10));
         followRequest.getParameters().setReadPollTimeout(TimeValue.timeValueMillis(10));
-        followRequest.getParameters().setMaxReadRequestSize(new ByteSizeValue(1));
+        followRequest.getParameters().setMaxReadRequestSize(ByteSizeValue.ofBytes(1));
         followRequest.getParameters().setMaxOutstandingReadRequests(128);
         followRequest.waitForActiveShards(ActiveShardCount.DEFAULT);
 

--- a/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/action/ShardChangesAction.java
+++ b/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/action/ShardChangesAction.java
@@ -91,7 +91,7 @@ public class ShardChangesAction extends ActionType<ShardChangesAction.Response> 
             shardId = new ShardId(in);
             expectedHistoryUUID = in.readString();
             pollTimeout = in.readTimeValue();
-            maxBatchSize = new ByteSizeValue(in);
+            maxBatchSize = ByteSizeValue.readFrom(in);
 
             // Starting the clock in order to know how much time is spent on fetching operations:
             relativeStartNanos = System.nanoTime();

--- a/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/action/TransportResumeFollowAction.java
+++ b/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/action/TransportResumeFollowAction.java
@@ -64,7 +64,7 @@ import java.util.Set;
 public class TransportResumeFollowAction extends AcknowledgedTransportMasterNodeAction<ResumeFollowAction.Request> {
 
     static final ByteSizeValue DEFAULT_MAX_READ_REQUEST_SIZE = new ByteSizeValue(32, ByteSizeUnit.MB);
-    static final ByteSizeValue DEFAULT_MAX_WRITE_REQUEST_SIZE = new ByteSizeValue(Long.MAX_VALUE, ByteSizeUnit.BYTES);
+    static final ByteSizeValue DEFAULT_MAX_WRITE_REQUEST_SIZE = ByteSizeValue.ofBytes(Long.MAX_VALUE);
     private static final TimeValue DEFAULT_MAX_RETRY_DELAY = new TimeValue(500);
     private static final int DEFAULT_MAX_OUTSTANDING_WRITE_REQUESTS = 9;
     private static final int DEFAULT_MAX_WRITE_BUFFER_COUNT = Integer.MAX_VALUE;

--- a/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/repository/CcrRepository.java
+++ b/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/repository/CcrRepository.java
@@ -625,7 +625,7 @@ public class CcrRepository extends AbstractLifecycleComponent implements Reposit
         void restoreFiles(Store store, ActionListener<Void> listener) {
             ArrayList<FileInfo> fileInfos = new ArrayList<>();
             for (StoreFileMetadata fileMetadata : sourceMetadata) {
-                ByteSizeValue fileSize = new ByteSizeValue(fileMetadata.length());
+                ByteSizeValue fileSize = ByteSizeValue.ofBytes(fileMetadata.length());
                 fileInfos.add(new FileInfo(fileMetadata.name(), fileMetadata, fileSize));
             }
             SnapshotFiles snapshotFiles = new SnapshotFiles(LATEST, fileInfos, null);

--- a/x-pack/plugin/ccr/src/test/java/org/elasticsearch/xpack/CcrIntegTestCase.java
+++ b/x-pack/plugin/ccr/src/test/java/org/elasticsearch/xpack/CcrIntegTestCase.java
@@ -606,7 +606,7 @@ public abstract class CcrIntegTestCase extends ESTestCase {
         request.setFollowerIndex(followerIndex);
         request.getParameters().setMaxRetryDelay(TimeValue.timeValueMillis(10));
         request.getParameters().setReadPollTimeout(TimeValue.timeValueMillis(10));
-        request.getParameters().setMaxReadRequestSize(new ByteSizeValue(between(1, 32 * 1024 * 1024)));
+        request.getParameters().setMaxReadRequestSize(ByteSizeValue.ofBytes(between(1, 32 * 1024 * 1024)));
         request.getParameters().setMaxReadRequestOperationCount(between(1, 10000));
         request.waitForActiveShards(waitForActiveShards);
         return request;

--- a/x-pack/plugin/ccr/src/test/java/org/elasticsearch/xpack/ccr/AutoFollowMetadataTests.java
+++ b/x-pack/plugin/ccr/src/test/java/org/elasticsearch/xpack/ccr/AutoFollowMetadataTests.java
@@ -9,7 +9,6 @@ package org.elasticsearch.xpack.ccr;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.common.unit.ByteSizeUnit;
 import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.core.TimeValue;
@@ -56,10 +55,10 @@ public class AutoFollowMetadataTests extends AbstractXContentSerializingTestCase
                 randomIntBetween(0, Integer.MAX_VALUE),
                 randomIntBetween(0, Integer.MAX_VALUE),
                 randomIntBetween(0, Integer.MAX_VALUE),
-                new ByteSizeValue(randomNonNegativeLong(), ByteSizeUnit.BYTES),
-                new ByteSizeValue(randomNonNegativeLong(), ByteSizeUnit.BYTES),
+                ByteSizeValue.ofBytes(randomNonNegativeLong()),
+                ByteSizeValue.ofBytes(randomNonNegativeLong()),
                 randomIntBetween(0, Integer.MAX_VALUE),
-                new ByteSizeValue(randomNonNegativeLong()),
+                ByteSizeValue.ofBytes(randomNonNegativeLong()),
                 TimeValue.timeValueMillis(500),
                 TimeValue.timeValueMillis(500)
             );

--- a/x-pack/plugin/ccr/src/test/java/org/elasticsearch/xpack/ccr/action/FollowParametersTests.java
+++ b/x-pack/plugin/ccr/src/test/java/org/elasticsearch/xpack/ccr/action/FollowParametersTests.java
@@ -49,10 +49,10 @@ public class FollowParametersTests extends AbstractXContentSerializingTestCase<F
         followParameters.setMaxOutstandingWriteRequests(randomIntBetween(0, Integer.MAX_VALUE));
         followParameters.setMaxReadRequestOperationCount(randomIntBetween(0, Integer.MAX_VALUE));
         followParameters.setMaxWriteRequestOperationCount(randomIntBetween(0, Integer.MAX_VALUE));
-        followParameters.setMaxReadRequestSize(new ByteSizeValue(randomNonNegativeLong()));
-        followParameters.setMaxWriteRequestSize(new ByteSizeValue(randomNonNegativeLong()));
+        followParameters.setMaxReadRequestSize(ByteSizeValue.ofBytes(randomNonNegativeLong()));
+        followParameters.setMaxWriteRequestSize(ByteSizeValue.ofBytes(randomNonNegativeLong()));
         followParameters.setMaxWriteBufferCount(randomIntBetween(0, Integer.MAX_VALUE));
-        followParameters.setMaxWriteBufferSize(new ByteSizeValue(randomNonNegativeLong()));
+        followParameters.setMaxWriteBufferSize(ByteSizeValue.ofBytes(randomNonNegativeLong()));
         followParameters.setMaxRetryDelay(new TimeValue(randomNonNegativeLong()));
         followParameters.setReadPollTimeout(new TimeValue(randomNonNegativeLong()));
         return followParameters;

--- a/x-pack/plugin/ccr/src/test/java/org/elasticsearch/xpack/ccr/action/GetAutoFollowPatternResponseTests.java
+++ b/x-pack/plugin/ccr/src/test/java/org/elasticsearch/xpack/ccr/action/GetAutoFollowPatternResponseTests.java
@@ -9,7 +9,6 @@ package org.elasticsearch.xpack.ccr.action;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.common.unit.ByteSizeUnit;
 import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.core.TimeValue;
@@ -43,10 +42,10 @@ public class GetAutoFollowPatternResponseTests extends AbstractWireSerializingTe
                 randomIntBetween(0, Integer.MAX_VALUE),
                 randomIntBetween(0, Integer.MAX_VALUE),
                 randomIntBetween(0, Integer.MAX_VALUE),
-                new ByteSizeValue(randomNonNegativeLong(), ByteSizeUnit.BYTES),
-                new ByteSizeValue(randomNonNegativeLong(), ByteSizeUnit.BYTES),
+                ByteSizeValue.ofBytes(randomNonNegativeLong()),
+                ByteSizeValue.ofBytes(randomNonNegativeLong()),
                 randomIntBetween(0, Integer.MAX_VALUE),
-                new ByteSizeValue(randomNonNegativeLong()),
+                ByteSizeValue.ofBytes(randomNonNegativeLong()),
                 TimeValue.timeValueMillis(500),
                 TimeValue.timeValueMillis(500)
             );

--- a/x-pack/plugin/ccr/src/test/java/org/elasticsearch/xpack/ccr/action/ResumeFollowActionRequestTests.java
+++ b/x-pack/plugin/ccr/src/test/java/org/elasticsearch/xpack/ccr/action/ResumeFollowActionRequestTests.java
@@ -78,10 +78,10 @@ public class ResumeFollowActionRequestTests extends AbstractXContentSerializingT
             followParameters.setMaxWriteRequestOperationCount(randomIntBetween(1, Integer.MAX_VALUE));
         }
         if (randomBoolean()) {
-            followParameters.setMaxWriteRequestSize(new ByteSizeValue(randomNonNegativeLong()));
+            followParameters.setMaxWriteRequestSize(ByteSizeValue.ofBytes(randomNonNegativeLong()));
         }
         if (randomBoolean()) {
-            followParameters.setMaxWriteBufferSize(new ByteSizeValue(randomNonNegativeLong(), ByteSizeUnit.BYTES));
+            followParameters.setMaxWriteBufferSize(ByteSizeValue.ofBytes(randomNonNegativeLong()));
         }
         if (randomBoolean()) {
             followParameters.setMaxRetryDelay(TimeValue.timeValueMillis(500));

--- a/x-pack/plugin/ccr/src/test/java/org/elasticsearch/xpack/ccr/action/ShardFollowNodeTaskTests.java
+++ b/x-pack/plugin/ccr/src/test/java/org/elasticsearch/xpack/ccr/action/ShardFollowNodeTaskTests.java
@@ -1042,7 +1042,7 @@ public class ShardFollowNodeTaskTests extends ESTestCase {
         ShardFollowTaskParams params = new ShardFollowTaskParams();
         params.maxReadRequestOperationCount = 64;
         params.maxOutstandingReadRequests = 1;
-        params.maxWriteRequestSize = new ByteSizeValue(1, ByteSizeUnit.BYTES);
+        params.maxWriteRequestSize = ByteSizeValue.ofBytes(1);
         params.maxOutstandingWriteRequests = 128;
 
         ShardFollowNodeTask task = createShardFollowTask(params);
@@ -1139,10 +1139,10 @@ public class ShardFollowNodeTaskTests extends ESTestCase {
             Integer.MAX_VALUE,
             Integer.MAX_VALUE,
             Integer.MAX_VALUE,
-            new ByteSizeValue(Long.MAX_VALUE),
-            new ByteSizeValue(Long.MAX_VALUE),
+            ByteSizeValue.ofBytes(Long.MAX_VALUE),
+            ByteSizeValue.ofBytes(Long.MAX_VALUE),
             Integer.MAX_VALUE,
-            new ByteSizeValue(Long.MAX_VALUE),
+            ByteSizeValue.ofBytes(Long.MAX_VALUE),
             TimeValue.ZERO,
             TimeValue.ZERO,
             Collections.emptyMap()
@@ -1261,13 +1261,13 @@ public class ShardFollowNodeTaskTests extends ESTestCase {
         private ShardId followShardId = new ShardId("follow_index", "", 0);
         private ShardId leaderShardId = new ShardId("leader_index", "", 0);
         private int maxReadRequestOperationCount = Integer.MAX_VALUE;
-        private ByteSizeValue maxReadRequestSize = new ByteSizeValue(Long.MAX_VALUE, ByteSizeUnit.BYTES);
+        private ByteSizeValue maxReadRequestSize = ByteSizeValue.ofBytes(Long.MAX_VALUE);
         private int maxOutstandingReadRequests = Integer.MAX_VALUE;
         private int maxWriteRequestOperationCount = Integer.MAX_VALUE;
-        private ByteSizeValue maxWriteRequestSize = new ByteSizeValue(Long.MAX_VALUE, ByteSizeUnit.BYTES);
+        private ByteSizeValue maxWriteRequestSize = ByteSizeValue.ofBytes(Long.MAX_VALUE);
         private int maxOutstandingWriteRequests = Integer.MAX_VALUE;
         private int maxWriteBufferCount = Integer.MAX_VALUE;
-        private ByteSizeValue maxWriteBufferSize = new ByteSizeValue(Long.MAX_VALUE, ByteSizeUnit.BYTES);
+        private ByteSizeValue maxWriteBufferSize = ByteSizeValue.ofBytes(Long.MAX_VALUE);
         private TimeValue maxRetryDelay = TimeValue.ZERO;
         private TimeValue readPollTimeout = TimeValue.ZERO;
         private Map<String, String> headers = Collections.emptyMap();

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/DataTiersFeatureSetUsage.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/DataTiersFeatureSetUsage.java
@@ -159,19 +159,23 @@ public class DataTiersFeatureSetUsage extends XPackFeatureSet.Usage {
             builder.field("total_shard_count", totalShardCount);
             builder.field("primary_shard_count", primaryShardCount);
             builder.field("doc_count", docCount);
-            builder.humanReadableField("total_size_bytes", "total_size", new ByteSizeValue(totalByteCount));
-            builder.humanReadableField("primary_size_bytes", "primary_size", new ByteSizeValue(primaryByteCount));
+            builder.humanReadableField("total_size_bytes", "total_size", ByteSizeValue.ofBytes(totalByteCount));
+            builder.humanReadableField("primary_size_bytes", "primary_size", ByteSizeValue.ofBytes(primaryByteCount));
             builder.humanReadableField(
                 "primary_shard_size_avg_bytes",
                 "primary_shard_size_avg",
-                new ByteSizeValue(primaryShardCount == 0 ? 0 : (primaryByteCount / primaryShardCount))
+                ByteSizeValue.ofBytes(primaryShardCount == 0 ? 0 : (primaryByteCount / primaryShardCount))
             );
             builder.humanReadableField(
                 "primary_shard_size_median_bytes",
                 "primary_shard_size_median",
-                new ByteSizeValue(primaryByteCountMedian)
+                ByteSizeValue.ofBytes(primaryByteCountMedian)
             );
-            builder.humanReadableField("primary_shard_size_mad_bytes", "primary_shard_size_mad", new ByteSizeValue(primaryShardBytesMAD));
+            builder.humanReadableField(
+                "primary_shard_size_mad_bytes",
+                "primary_shard_size_mad",
+                ByteSizeValue.ofBytes(primaryShardBytesMAD)
+            );
             builder.endObject();
             return builder;
         }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ccr/ShardFollowNodeTaskStatus.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ccr/ShardFollowNodeTaskStatus.java
@@ -12,7 +12,6 @@ import org.elasticsearch.Version;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
-import org.elasticsearch.common.unit.ByteSizeUnit;
 import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.core.TimeValue;
@@ -505,7 +504,7 @@ public class ShardFollowNodeTaskStatus implements Task.Status {
         builder.humanReadableField(
             WRITE_BUFFER_SIZE_IN_BYTES_FIELD.getPreferredName(),
             "write_buffer_size",
-            new ByteSizeValue(writeBufferSizeInBytes)
+            ByteSizeValue.ofBytes(writeBufferSizeInBytes)
         );
         builder.field(FOLLOWER_MAPPING_VERSION_FIELD.getPreferredName(), followerMappingVersion);
         builder.field(FOLLOWER_SETTINGS_VERSION_FIELD.getPreferredName(), followerSettingsVersion);
@@ -523,7 +522,7 @@ public class ShardFollowNodeTaskStatus implements Task.Status {
         builder.field(SUCCESSFUL_READ_REQUESTS_FIELD.getPreferredName(), successfulReadRequests);
         builder.field(FAILED_READ_REQUESTS_FIELD.getPreferredName(), failedReadRequests);
         builder.field(OPERATIONS_READ_FIELD.getPreferredName(), operationsReads);
-        builder.humanReadableField(BYTES_READ.getPreferredName(), "total_read", new ByteSizeValue(bytesRead, ByteSizeUnit.BYTES));
+        builder.humanReadableField(BYTES_READ.getPreferredName(), "total_read", ByteSizeValue.ofBytes(bytesRead));
         builder.humanReadableField(
             TOTAL_WRITE_TIME_MILLIS_FIELD.getPreferredName(),
             "total_write_time",

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ccr/action/FollowParameters.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ccr/action/FollowParameters.java
@@ -210,12 +210,12 @@ public class FollowParameters implements Writeable, ToXContentObject {
     void fromStreamInput(StreamInput in) throws IOException {
         maxReadRequestOperationCount = in.readOptionalVInt();
         maxOutstandingReadRequests = in.readOptionalVInt();
-        maxReadRequestSize = in.readOptionalWriteable(ByteSizeValue::new);
+        maxReadRequestSize = in.readOptionalWriteable(ByteSizeValue::readFrom);
         maxWriteRequestOperationCount = in.readOptionalVInt();
-        maxWriteRequestSize = in.readOptionalWriteable(ByteSizeValue::new);
+        maxWriteRequestSize = in.readOptionalWriteable(ByteSizeValue::readFrom);
         maxOutstandingWriteRequests = in.readOptionalVInt();
         maxWriteBufferCount = in.readOptionalVInt();
-        maxWriteBufferSize = in.readOptionalWriteable(ByteSizeValue::new);
+        maxWriteBufferSize = in.readOptionalWriteable(ByteSizeValue::readFrom);
         maxRetryDelay = in.readOptionalTimeValue();
         readPollTimeout = in.readOptionalTimeValue();
     }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ccr/action/ImmutableFollowParameters.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ccr/action/ImmutableFollowParameters.java
@@ -97,13 +97,13 @@ public class ImmutableFollowParameters implements Writeable {
 
     public ImmutableFollowParameters(StreamInput in) throws IOException {
         maxReadRequestOperationCount = in.readOptionalVInt();
-        maxReadRequestSize = in.readOptionalWriteable(ByteSizeValue::new);
+        maxReadRequestSize = in.readOptionalWriteable(ByteSizeValue::readFrom);
         maxOutstandingReadRequests = in.readOptionalVInt();
         maxWriteRequestOperationCount = in.readOptionalVInt();
-        maxWriteRequestSize = in.readOptionalWriteable(ByteSizeValue::new);
+        maxWriteRequestSize = in.readOptionalWriteable(ByteSizeValue::readFrom);
         maxOutstandingWriteRequests = in.readOptionalVInt();
         maxWriteBufferCount = in.readOptionalVInt();
-        maxWriteBufferSize = in.readOptionalWriteable(ByteSizeValue::new);
+        maxWriteBufferSize = in.readOptionalWriteable(ByteSizeValue::readFrom);
         maxRetryDelay = in.readOptionalTimeValue();
         readPollTimeout = in.readOptionalTimeValue();
     }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/IndexLifecycleFeatureSetUsage.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/IndexLifecycleFeatureSetUsage.java
@@ -420,10 +420,10 @@ public class IndexLifecycleFeatureSetUsage extends XPackFeatureSet.Usage {
             this.forceMergeMaxNumberOfSegments = in.readOptionalVInt();
             this.rolloverMaxAge = in.readOptionalTimeValue();
             this.rolloverMaxDocs = in.readOptionalVLong();
-            this.rolloverMaxPrimaryShardSize = in.readOptionalWriteable(ByteSizeValue::new);
-            this.rolloverMaxSize = in.readOptionalWriteable(ByteSizeValue::new);
+            this.rolloverMaxPrimaryShardSize = in.readOptionalWriteable(ByteSizeValue::readFrom);
+            this.rolloverMaxSize = in.readOptionalWriteable(ByteSizeValue::readFrom);
             this.setPriorityPriority = in.readOptionalVInt();
-            this.shrinkMaxPrimaryShardSize = in.readOptionalWriteable(ByteSizeValue::new);
+            this.shrinkMaxPrimaryShardSize = in.readOptionalWriteable(ByteSizeValue::readFrom);
             this.shrinkNumberOfShards = in.readOptionalVInt();
             if (in.getVersion().onOrAfter(Version.V_8_2_0)) {
                 this.rolloverMaxPrimaryShardDocs = in.readOptionalVLong();
@@ -433,8 +433,8 @@ public class IndexLifecycleFeatureSetUsage extends XPackFeatureSet.Usage {
             if (in.getVersion().onOrAfter(Version.V_8_4_0)) {
                 this.rolloverMinAge = in.readOptionalTimeValue();
                 this.rolloverMinDocs = in.readOptionalVLong();
-                this.rolloverMinPrimaryShardSize = in.readOptionalWriteable(ByteSizeValue::new);
-                this.rolloverMinSize = in.readOptionalWriteable(ByteSizeValue::new);
+                this.rolloverMinPrimaryShardSize = in.readOptionalWriteable(ByteSizeValue::readFrom);
+                this.rolloverMinSize = in.readOptionalWriteable(ByteSizeValue::readFrom);
                 this.rolloverMinPrimaryShardDocs = in.readOptionalVLong();
             } else {
                 this.rolloverMinAge = null;

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/RolloverAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/RolloverAction.java
@@ -157,8 +157,8 @@ public class RolloverAction implements LifecycleAction {
     }
 
     public RolloverAction(StreamInput in) throws IOException {
-        maxSize = in.readOptionalWriteable(ByteSizeValue::new);
-        maxPrimaryShardSize = in.readOptionalWriteable(ByteSizeValue::new);
+        maxSize = in.readOptionalWriteable(ByteSizeValue::readFrom);
+        maxPrimaryShardSize = in.readOptionalWriteable(ByteSizeValue::readFrom);
         maxAge = in.readOptionalTimeValue();
         maxDocs = in.readOptionalVLong();
         if (in.getVersion().onOrAfter(Version.V_8_2_0)) {
@@ -167,8 +167,8 @@ public class RolloverAction implements LifecycleAction {
             maxPrimaryShardDocs = null;
         }
         if (in.getVersion().onOrAfter(Version.V_8_4_0)) {
-            minSize = in.readOptionalWriteable(ByteSizeValue::new);
-            minPrimaryShardSize = in.readOptionalWriteable(ByteSizeValue::new);
+            minSize = in.readOptionalWriteable(ByteSizeValue::readFrom);
+            minPrimaryShardSize = in.readOptionalWriteable(ByteSizeValue::readFrom);
             minAge = in.readOptionalTimeValue();
             minDocs = in.readOptionalVLong();
             minPrimaryShardDocs = in.readOptionalVLong();

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/ShrinkAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/ShrinkAction.java
@@ -91,7 +91,7 @@ public class ShrinkAction implements LifecycleAction {
             this.maxPrimaryShardSize = null;
         } else {
             this.numberOfShards = null;
-            this.maxPrimaryShardSize = new ByteSizeValue(in);
+            this.maxPrimaryShardSize = ByteSizeValue.readFrom(in);
         }
     }
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/EstimateModelMemoryAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/EstimateModelMemoryAction.java
@@ -151,7 +151,7 @@ public class EstimateModelMemoryAction extends ActionType<EstimateModelMemoryAct
         }
 
         public Response(StreamInput in) throws IOException {
-            modelMemoryEstimate = new ByteSizeValue(in);
+            modelMemoryEstimate = ByteSizeValue.readFrom(in);
         }
 
         @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/MlMemoryAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/MlMemoryAction.java
@@ -153,16 +153,16 @@ public class MlMemoryAction extends ActionType<MlMemoryAction.Response> {
 
             public MlMemoryStats(StreamInput in) throws IOException {
                 super(in);
-                memTotal = new ByteSizeValue(in);
-                memAdjustedTotal = new ByteSizeValue(in);
-                mlMax = new ByteSizeValue(in);
-                mlNativeCodeOverhead = new ByteSizeValue(in);
-                mlAnomalyDetectors = new ByteSizeValue(in);
-                mlDataFrameAnalytics = new ByteSizeValue(in);
-                mlNativeInference = new ByteSizeValue(in);
-                jvmHeapMax = new ByteSizeValue(in);
-                jvmInferenceMax = new ByteSizeValue(in);
-                jvmInference = new ByteSizeValue(in);
+                memTotal = ByteSizeValue.readFrom(in);
+                memAdjustedTotal = ByteSizeValue.readFrom(in);
+                mlMax = ByteSizeValue.readFrom(in);
+                mlNativeCodeOverhead = ByteSizeValue.readFrom(in);
+                mlAnomalyDetectors = ByteSizeValue.readFrom(in);
+                mlDataFrameAnalytics = ByteSizeValue.readFrom(in);
+                mlNativeInference = ByteSizeValue.readFrom(in);
+                jvmHeapMax = ByteSizeValue.readFrom(in);
+                jvmInferenceMax = ByteSizeValue.readFrom(in);
+                jvmInference = ByteSizeValue.readFrom(in);
             }
 
             public ByteSizeValue getMemTotal() {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/StartTrainedModelDeploymentAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/StartTrainedModelDeploymentAction.java
@@ -136,7 +136,7 @@ public class StartTrainedModelDeploymentAction extends ActionType<CreateTrainedM
             threadsPerAllocation = in.readVInt();
             queueCapacity = in.readVInt();
             if (in.getVersion().onOrAfter(Version.V_8_4_0)) {
-                this.cacheSize = in.readOptionalWriteable(ByteSizeValue::new);
+                this.cacheSize = in.readOptionalWriteable(ByteSizeValue::readFrom);
             }
         }
 
@@ -401,7 +401,7 @@ public class StartTrainedModelDeploymentAction extends ActionType<CreateTrainedM
             this.numberOfAllocations = in.readVInt();
             this.queueCapacity = in.readVInt();
             if (in.getVersion().onOrAfter(Version.V_8_4_0)) {
-                this.cacheSize = in.readOptionalWriteable(ByteSizeValue::new);
+                this.cacheSize = in.readOptionalWriteable(ByteSizeValue::readFrom);
             } else {
                 this.cacheSize = null;
             }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/TrainedModelCacheInfoAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/TrainedModelCacheInfoAction.java
@@ -87,8 +87,8 @@ public class TrainedModelCacheInfoAction extends ActionType<TrainedModelCacheInf
 
             public CacheInfo(StreamInput in) throws IOException {
                 super(in);
-                jvmInferenceMax = new ByteSizeValue(in);
-                jvmInference = new ByteSizeValue(in);
+                jvmInferenceMax = ByteSizeValue.readFrom(in);
+                jvmInference = ByteSizeValue.readFrom(in);
             }
 
             public ByteSizeValue getJvmInferenceMax() {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/DataFrameAnalyticsConfig.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/DataFrameAnalyticsConfig.java
@@ -179,7 +179,7 @@ public class DataFrameAnalyticsConfig implements ToXContentObject, Writeable {
         this.dest = new DataFrameAnalyticsDest(in);
         this.analysis = in.readNamedWriteable(DataFrameAnalysis.class);
         this.analyzedFields = in.readOptionalWriteable(FetchSourceContext::readFrom);
-        this.modelMemoryLimit = in.readOptionalWriteable(ByteSizeValue::new);
+        this.modelMemoryLimit = in.readOptionalWriteable(ByteSizeValue::readFrom);
         this.headers = in.readImmutableMap(StreamInput::readString, StreamInput::readString);
         this.createTime = in.readOptionalInstant();
         this.version = in.readBoolean() ? Version.readVersion(in) : null;

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/DataFrameAnalyticsConfigUpdate.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/DataFrameAnalyticsConfigUpdate.java
@@ -73,7 +73,7 @@ public class DataFrameAnalyticsConfigUpdate implements Writeable, ToXContentObje
     public DataFrameAnalyticsConfigUpdate(StreamInput in) throws IOException {
         this.id = in.readString();
         this.description = in.readOptionalString();
-        this.modelMemoryLimit = in.readOptionalWriteable(ByteSizeValue::new);
+        this.modelMemoryLimit = in.readOptionalWriteable(ByteSizeValue::readFrom);
         this.allowLazyStart = in.readOptionalBoolean();
         this.maxNumThreads = in.readOptionalVInt();
     }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/explain/MemoryEstimation.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/explain/MemoryEstimation.java
@@ -56,8 +56,8 @@ public class MemoryEstimation implements ToXContentObject, Writeable {
     }
 
     public MemoryEstimation(StreamInput in) throws IOException {
-        this.expectedMemoryWithoutDisk = in.readOptionalWriteable(ByteSizeValue::new);
-        this.expectedMemoryWithDisk = in.readOptionalWriteable(ByteSizeValue::new);
+        this.expectedMemoryWithoutDisk = in.readOptionalWriteable(ByteSizeValue::readFrom);
+        this.expectedMemoryWithDisk = in.readOptionalWriteable(ByteSizeValue::readFrom);
     }
 
     public ByteSizeValue getExpectedMemoryWithoutDisk() {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/assignment/AssignmentStats.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/assignment/AssignmentStats.java
@@ -459,7 +459,7 @@ public class AssignmentStats implements ToXContentObject, Writeable {
         reason = in.readOptionalString();
         allocationStatus = in.readOptionalWriteable(AllocationStatus::new);
         if (in.getVersion().onOrAfter(Version.V_8_4_0)) {
-            cacheSize = in.readOptionalWriteable(ByteSizeValue::new);
+            cacheSize = in.readOptionalWriteable(ByteSizeValue::readFrom);
         } else {
             cacheSize = null;
         }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/searchablesnapshots/SearchableSnapshotShardStats.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/searchablesnapshots/SearchableSnapshotShardStats.java
@@ -209,13 +209,13 @@ public class SearchableSnapshotShardStats implements Writeable, ToXContentObject
             this.fileExt = in.readString();
             this.numFiles = in.readVLong();
             if (in.getVersion().before(Version.V_7_13_0)) {
-                this.totalSize = new ByteSizeValue(in.readVLong());
+                this.totalSize = ByteSizeValue.ofBytes(in.readVLong());
                 this.minSize = ByteSizeValue.ZERO;
                 this.maxSize = ByteSizeValue.ZERO;
             } else {
-                this.totalSize = new ByteSizeValue(in);
-                this.minSize = new ByteSizeValue(in);
-                this.maxSize = new ByteSizeValue(in);
+                this.totalSize = ByteSizeValue.readFrom(in);
+                this.minSize = ByteSizeValue.readFrom(in);
+                this.maxSize = ByteSizeValue.readFrom(in);
             }
             this.openCount = in.readVLong();
             this.closeCount = in.readVLong();
@@ -249,9 +249,9 @@ public class SearchableSnapshotShardStats implements Writeable, ToXContentObject
             return new CacheIndexInputStats(
                 cis1.fileExt,
                 cis1.numFiles + cis2.numFiles,
-                new ByteSizeValue(Math.addExact(cis1.totalSize.getBytes(), cis2.totalSize.getBytes())),
-                new ByteSizeValue(Math.min(cis1.minSize.getBytes(), cis2.minSize.getBytes())),
-                new ByteSizeValue(Math.max(cis1.maxSize.getBytes(), cis2.maxSize.getBytes())),
+                ByteSizeValue.ofBytes(Math.addExact(cis1.totalSize.getBytes(), cis2.totalSize.getBytes())),
+                ByteSizeValue.ofBytes(Math.min(cis1.minSize.getBytes(), cis2.minSize.getBytes())),
+                ByteSizeValue.ofBytes(Math.max(cis1.maxSize.getBytes(), cis2.maxSize.getBytes())),
                 cis1.openCount + cis2.openCount,
                 cis1.closeCount + cis2.closeCount,
                 cis1.forwardSmallSeeks.add(cis2.forwardSmallSeeks),
@@ -331,7 +331,7 @@ public class SearchableSnapshotShardStats implements Writeable, ToXContentObject
 
         public ByteSizeValue getAverageSize() {
             final double average = (double) totalSize.getBytes() / (double) numFiles;
-            return new ByteSizeValue(Math.round(average));
+            return ByteSizeValue.ofBytes(Math.round(average));
         }
 
         public long getOpenCount() {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/accesscontrol/DocumentSubsetBitsetCache.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/accesscontrol/DocumentSubsetBitsetCache.java
@@ -30,7 +30,6 @@ import org.elasticsearch.common.cache.RemovalNotification;
 import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Setting.Property;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.common.unit.ByteSizeUnit;
 import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.common.util.concurrent.ReleasableLock;
 import org.elasticsearch.common.util.set.Sets;
@@ -319,7 +318,7 @@ public final class DocumentSubsetBitsetCache implements IndexReader.ClosedListen
     }
 
     public Map<String, Object> usageStats() {
-        final ByteSizeValue ram = new ByteSizeValue(ramBytesUsed(), ByteSizeUnit.BYTES);
+        final ByteSizeValue ram = ByteSizeValue.ofBytes(ramBytesUsed());
         return Map.of("count", entryCount(), "memory", ram.toString(), "memory_in_bytes", ram.getBytes());
     }
 

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ccr/action/ShardFollowTaskTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ccr/action/ShardFollowTaskTests.java
@@ -7,7 +7,6 @@
 package org.elasticsearch.xpack.core.ccr.action;
 
 import org.elasticsearch.common.io.stream.Writeable;
-import org.elasticsearch.common.unit.ByteSizeUnit;
 import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.index.shard.ShardId;
@@ -34,10 +33,10 @@ public class ShardFollowTaskTests extends AbstractXContentSerializingTestCase<Sh
             randomIntBetween(1, Integer.MAX_VALUE),
             randomIntBetween(1, Integer.MAX_VALUE),
             randomIntBetween(1, Integer.MAX_VALUE),
-            new ByteSizeValue(randomNonNegativeLong(), ByteSizeUnit.BYTES),
-            new ByteSizeValue(randomNonNegativeLong(), ByteSizeUnit.BYTES),
+            ByteSizeValue.ofBytes(randomNonNegativeLong()),
+            ByteSizeValue.ofBytes(randomNonNegativeLong()),
             randomIntBetween(1, Integer.MAX_VALUE),
-            new ByteSizeValue(randomNonNegativeLong(), ByteSizeUnit.BYTES),
+            ByteSizeValue.ofBytes(randomNonNegativeLong()),
             TimeValue.parseTimeValue(randomTimeValue(), ""),
             TimeValue.parseTimeValue(randomTimeValue(), ""),
             randomBoolean() ? null : Collections.singletonMap("key", "value")

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/RolloverStepTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/RolloverStepTests.java
@@ -183,7 +183,7 @@ public class RolloverStepTests extends AbstractStepTestCase<RolloverStep> {
             .putRolloverInfo(
                 new RolloverInfo(
                     rolloverAlias,
-                    Collections.singletonList(new MaxSizeCondition(new ByteSizeValue(2L))),
+                    Collections.singletonList(new MaxSizeCondition(ByteSizeValue.ofBytes(2L))),
                     System.currentTimeMillis()
                 )
             )

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/ShrinkActionTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/ShrinkActionTests.java
@@ -68,7 +68,7 @@ public class ShrinkActionTests extends AbstractActionTestCase<ShrinkAction> {
         if (randomBoolean()) {
             return new ShrinkAction(randomIntBetween(1, 100), null);
         } else {
-            return new ShrinkAction(null, new ByteSizeValue(randomIntBetween(1, 100)));
+            return new ShrinkAction(null, ByteSizeValue.ofBytes(randomIntBetween(1, 100)));
         }
     }
 
@@ -77,7 +77,7 @@ public class ShrinkActionTests extends AbstractActionTestCase<ShrinkAction> {
         if (action.getNumberOfShards() != null) {
             return new ShrinkAction(action.getNumberOfShards() + randomIntBetween(1, 2), null);
         } else {
-            return new ShrinkAction(null, new ByteSizeValue(action.getMaxPrimaryShardSize().getBytes() + 1));
+            return new ShrinkAction(null, ByteSizeValue.ofBytes(action.getMaxPrimaryShardSize().getBytes() + 1));
         }
     }
 
@@ -92,11 +92,11 @@ public class ShrinkActionTests extends AbstractActionTestCase<ShrinkAction> {
     }
 
     public void testMaxPrimaryShardSize() {
-        ByteSizeValue maxPrimaryShardSize1 = new ByteSizeValue(10);
+        ByteSizeValue maxPrimaryShardSize1 = ByteSizeValue.ofBytes(10);
         Exception e1 = expectThrows(Exception.class, () -> new ShrinkAction(randomIntBetween(1, 100), maxPrimaryShardSize1));
         assertThat(e1.getMessage(), equalTo("Cannot set both [number_of_shards] and [max_primary_shard_size]"));
 
-        ByteSizeValue maxPrimaryShardSize2 = new ByteSizeValue(0);
+        ByteSizeValue maxPrimaryShardSize2 = ByteSizeValue.ZERO;
         Exception e2 = expectThrows(Exception.class, () -> new ShrinkAction(null, maxPrimaryShardSize2));
         assertThat(e2.getMessage(), equalTo("[max_primary_shard_size] must be greater than 0"));
     }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/ShrinkStepTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/ShrinkStepTests.java
@@ -40,7 +40,7 @@ public class ShrinkStepTests extends AbstractStepTestCase<ShrinkStep> {
         if (randomBoolean()) {
             numberOfShards = randomIntBetween(1, 20);
         } else {
-            maxPrimaryShardSize = new ByteSizeValue(between(1, 100));
+            maxPrimaryShardSize = ByteSizeValue.ofBytes(between(1, 100));
         }
         return new ShrinkStep(stepKey, nextStepKey, client, numberOfShards, maxPrimaryShardSize);
     }
@@ -60,7 +60,7 @@ public class ShrinkStepTests extends AbstractStepTestCase<ShrinkStep> {
                     numberOfShards = numberOfShards + 1;
                 }
                 if (maxPrimaryShardSize != null) {
-                    maxPrimaryShardSize = new ByteSizeValue(maxPrimaryShardSize.getBytes() + 1);
+                    maxPrimaryShardSize = ByteSizeValue.ofBytes(maxPrimaryShardSize.getBytes() + 1);
                 }
             }
             default -> throw new AssertionError("Illegal randomisation branch");

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/TimeseriesLifecycleTypeTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/TimeseriesLifecycleTypeTests.java
@@ -63,7 +63,7 @@ public class TimeseriesLifecycleTypeTests extends ESTestCase {
     private static final WaitForSnapshotAction TEST_WAIT_FOR_SNAPSHOT_ACTION = new WaitForSnapshotAction("policy");
     private static final ForceMergeAction TEST_FORCE_MERGE_ACTION = new ForceMergeAction(1, null);
     private static final RolloverAction TEST_ROLLOVER_ACTION = new RolloverAction(
-        new ByteSizeValue(1),
+        ByteSizeValue.ofBytes(1),
         null,
         null,
         null,

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/WaitForRolloverReadyStepTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/WaitForRolloverReadyStepTests.java
@@ -366,7 +366,7 @@ public class WaitForRolloverReadyStepTests extends AbstractStepTestCase<WaitForR
             .putRolloverInfo(
                 new RolloverInfo(
                     rolloverAlias,
-                    Collections.singletonList(new MaxSizeCondition(new ByteSizeValue(2L))),
+                    Collections.singletonList(new MaxSizeCondition(ByteSizeValue.ofBytes(2L))),
                     System.currentTimeMillis()
                 )
             )
@@ -400,7 +400,7 @@ public class WaitForRolloverReadyStepTests extends AbstractStepTestCase<WaitForR
             .putRolloverInfo(
                 new RolloverInfo(
                     randomAlphaOfLength(5),
-                    Collections.singletonList(new MaxSizeCondition(new ByteSizeValue(2L))),
+                    Collections.singletonList(new MaxSizeCondition(ByteSizeValue.ofBytes(2L))),
                     System.currentTimeMillis()
                 )
             )

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/dataframe/DataFrameAnalyticsConfigUpdateTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/dataframe/DataFrameAnalyticsConfigUpdateTests.java
@@ -46,7 +46,7 @@ public class DataFrameAnalyticsConfigUpdateTests extends AbstractXContentSeriali
             builder.setDescription(randomAlphaOfLength(20));
         }
         if (randomBoolean()) {
-            builder.setModelMemoryLimit(new ByteSizeValue(randomNonNegativeLong()));
+            builder.setModelMemoryLimit(ByteSizeValue.ofBytes(randomNonNegativeLong()));
         }
         if (randomBoolean()) {
             builder.setAllowLazyStart(randomBoolean());
@@ -70,13 +70,14 @@ public class DataFrameAnalyticsConfigUpdateTests extends AbstractXContentSeriali
     public void testMergeWithConfig_UpdatedModelMemoryLimit() {
         String id = randomValidId();
         DataFrameAnalyticsConfig config = DataFrameAnalyticsConfigTests.createRandomBuilder(id)
-            .setModelMemoryLimit(new ByteSizeValue(1024))
+            .setModelMemoryLimit(ByteSizeValue.ofBytes(1024))
             .build();
-        DataFrameAnalyticsConfigUpdate update = new DataFrameAnalyticsConfigUpdate.Builder(id).setModelMemoryLimit(new ByteSizeValue(2048))
-            .build();
+        DataFrameAnalyticsConfigUpdate update = new DataFrameAnalyticsConfigUpdate.Builder(id).setModelMemoryLimit(
+            ByteSizeValue.ofBytes(2048)
+        ).build();
         assertThat(
             update.mergeWithConfig(config).build(),
-            is(equalTo(new DataFrameAnalyticsConfig.Builder(config).setModelMemoryLimit(new ByteSizeValue(2048)).build()))
+            is(equalTo(new DataFrameAnalyticsConfig.Builder(config).setModelMemoryLimit(ByteSizeValue.ofBytes(2048)).build()))
         );
     }
 
@@ -104,12 +105,12 @@ public class DataFrameAnalyticsConfigUpdateTests extends AbstractXContentSeriali
         String id = randomValidId();
         DataFrameAnalyticsConfig config = DataFrameAnalyticsConfigTests.createRandomBuilder(id)
             .setDescription("old description")
-            .setModelMemoryLimit(new ByteSizeValue(1024))
+            .setModelMemoryLimit(ByteSizeValue.ofBytes(1024))
             .setAllowLazyStart(false)
             .setMaxNumThreads(1)
             .build();
         DataFrameAnalyticsConfigUpdate update = new DataFrameAnalyticsConfigUpdate.Builder(id).setDescription("new description")
-            .setModelMemoryLimit(new ByteSizeValue(2048))
+            .setModelMemoryLimit(ByteSizeValue.ofBytes(2048))
             .setAllowLazyStart(true)
             .setMaxNumThreads(4)
             .build();
@@ -118,7 +119,7 @@ public class DataFrameAnalyticsConfigUpdateTests extends AbstractXContentSeriali
             is(
                 equalTo(
                     new DataFrameAnalyticsConfig.Builder(config).setDescription("new description")
-                        .setModelMemoryLimit(new ByteSizeValue(2048))
+                        .setModelMemoryLimit(ByteSizeValue.ofBytes(2048))
                         .setAllowLazyStart(true)
                         .setMaxNumThreads(4)
                         .build()
@@ -168,10 +169,11 @@ public class DataFrameAnalyticsConfigUpdateTests extends AbstractXContentSeriali
     public void testRequiresRestart_ModelMemoryLimitUpdateRequiresRestart() {
         String id = randomValidId();
         DataFrameAnalyticsConfig config = DataFrameAnalyticsConfigTests.createRandomBuilder(id)
-            .setModelMemoryLimit(new ByteSizeValue(1024))
+            .setModelMemoryLimit(ByteSizeValue.ofBytes(1024))
             .build();
-        DataFrameAnalyticsConfigUpdate update = new DataFrameAnalyticsConfigUpdate.Builder(id).setModelMemoryLimit(new ByteSizeValue(2048))
-            .build();
+        DataFrameAnalyticsConfigUpdate update = new DataFrameAnalyticsConfigUpdate.Builder(id).setModelMemoryLimit(
+            ByteSizeValue.ofBytes(2048)
+        ).build();
 
         assertThat(update.requiresRestart(config), is(true));
     }
@@ -206,7 +208,7 @@ public class DataFrameAnalyticsConfigUpdateTests extends AbstractXContentSeriali
 
     public void testGetUpdatedFields_GivenAll() {
         DataFrameAnalyticsConfigUpdate update = new DataFrameAnalyticsConfigUpdate.Builder("test_job").setDescription("new description")
-            .setModelMemoryLimit(new ByteSizeValue(1024))
+            .setModelMemoryLimit(ByteSizeValue.ofBytes(1024))
             .setAllowLazyStart(true)
             .setMaxNumThreads(8)
             .build();
@@ -235,7 +237,7 @@ public class DataFrameAnalyticsConfigUpdateTests extends AbstractXContentSeriali
 
     public void testGetUpdatedFields_GivenModelMemoryLimit() {
         DataFrameAnalyticsConfigUpdate update = new DataFrameAnalyticsConfigUpdate.Builder("test_job").setModelMemoryLimit(
-            new ByteSizeValue(1024)
+            ByteSizeValue.ofBytes(1024)
         ).build();
 
         assertThat(update.getUpdatedFields(), contains("model_memory_limit"));

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/dataframe/explain/MemoryEstimationTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/dataframe/explain/MemoryEstimationTests.java
@@ -21,8 +21,8 @@ public class MemoryEstimationTests extends AbstractXContentSerializingTestCase<M
 
     public static MemoryEstimation createRandom() {
         return new MemoryEstimation(
-            randomBoolean() ? new ByteSizeValue(randomNonNegativeLong()) : null,
-            randomBoolean() ? new ByteSizeValue(randomNonNegativeLong()) : null
+            randomBoolean() ? ByteSizeValue.ofBytes(randomNonNegativeLong()) : null,
+            randomBoolean() ? ByteSizeValue.ofBytes(randomNonNegativeLong()) : null
         );
     }
 

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/job/config/JobTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/job/config/JobTests.java
@@ -152,7 +152,7 @@ public class JobTests extends AbstractXContentSerializingTestCase<Job> {
     public void testEnsureModelMemoryLimitSet() {
         Job.Builder builder = buildJobBuilder("foo");
         builder.setAnalysisLimits(new AnalysisLimits(null, null));
-        builder.validateAnalysisLimitsAndSetDefaults(new ByteSizeValue(0L));
+        builder.validateAnalysisLimitsAndSetDefaults(ByteSizeValue.ZERO);
         Job job = builder.build();
         assertEquals("foo", job.getId());
         assertNotNull(job.getAnalysisLimits());

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/job/config/JobUpdateTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/job/config/JobUpdateTests.java
@@ -305,7 +305,7 @@ public class JobUpdateTests extends AbstractXContentSerializingTestCase<JobUpdat
         jobBuilder.setCreateTime(new Date());
         Job job = jobBuilder.build();
 
-        Job updatedJob = update.mergeWithJob(job, new ByteSizeValue(0L));
+        Job updatedJob = update.mergeWithJob(job, ByteSizeValue.ZERO);
 
         assertEquals(update.getGroups(), updatedJob.getGroups());
         assertEquals(update.getDescription(), updatedJob.getDescription());
@@ -342,7 +342,7 @@ public class JobUpdateTests extends AbstractXContentSerializingTestCase<JobUpdat
                 update = createRandom(job.getId(), job);
             } while (update.isNoop(job));
 
-            Job updatedJob = update.mergeWithJob(job, new ByteSizeValue(0L));
+            Job updatedJob = update.mergeWithJob(job, ByteSizeValue.ZERO);
             assertThat(job, not(equalTo(updatedJob)));
         }
     }
@@ -395,7 +395,7 @@ public class JobUpdateTests extends AbstractXContentSerializingTestCase<JobUpdat
         jobBuilder.validateAnalysisLimitsAndSetDefaults(null);
 
         JobUpdate update = new JobUpdate.Builder("foo").setAnalysisLimits(new AnalysisLimits(2048L, 5L)).build();
-        Job updated = update.mergeWithJob(jobBuilder.build(), new ByteSizeValue(0L));
+        Job updated = update.mergeWithJob(jobBuilder.build(), ByteSizeValue.ZERO);
         assertThat(updated.getAnalysisLimits().getModelMemoryLimit(), equalTo(2048L));
         assertThat(updated.getAnalysisLimits().getCategorizationExamplesLimit(), equalTo(5L));
 

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/searchablesnapshots/SearchableSnapshotShardStatsTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/searchablesnapshots/SearchableSnapshotShardStatsTests.java
@@ -51,9 +51,9 @@ public class SearchableSnapshotShardStatsTests extends AbstractWireSerializingTe
         return new CacheIndexInputStats(
             randomAlphaOfLength(10),
             randomNonNegativeLong(),
-            new ByteSizeValue(randomNonNegativeLong()),
-            new ByteSizeValue(randomNonNegativeLong()),
-            new ByteSizeValue(randomNonNegativeLong()),
+            ByteSizeValue.ofBytes(randomNonNegativeLong()),
+            ByteSizeValue.ofBytes(randomNonNegativeLong()),
+            ByteSizeValue.ofBytes(randomNonNegativeLong()),
             randomNonNegativeLong(),
             randomNonNegativeLong(),
             randomCounter(),

--- a/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/logging/DeprecationIndexingComponent.java
+++ b/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/logging/DeprecationIndexingComponent.java
@@ -29,7 +29,6 @@ import org.elasticsearch.common.logging.ECSJsonLayout;
 import org.elasticsearch.common.logging.Loggers;
 import org.elasticsearch.common.logging.RateLimitingFilter;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.common.unit.ByteSizeUnit;
 import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.common.util.concurrent.EsExecutors;
 import org.elasticsearch.core.TimeValue;
@@ -181,7 +180,7 @@ public class DeprecationIndexingComponent extends AbstractLifecycleComponent imp
             .setBackoffPolicy(BackoffPolicy.exponentialBackoff(TimeValue.timeValueMillis(1000), 3))
             .setConcurrentRequests(Math.max(2, EsExecutors.allocatedProcessors(settings)))
             .setBulkActions(-1)
-            .setBulkSize(new ByteSizeValue(-1, ByteSizeUnit.BYTES))
+            .setBulkSize(ByteSizeValue.MINUS_ONE)
             .setFlushInterval(TimeValue.timeValueSeconds(5))
             .setFlushCondition(() -> flushEnabled.get())
             .build();

--- a/x-pack/plugin/searchable-snapshots/preallocate/src/main/java/org/elasticsearch/xpack/searchablesnapshots/preallocate/Preallocate.java
+++ b/x-pack/plugin/searchable-snapshots/preallocate/src/main/java/org/elasticsearch/xpack/searchablesnapshots/preallocate/Preallocate.java
@@ -44,7 +44,7 @@ public class Preallocate {
                 try (FileOutputStream fileChannel = new FileOutputStream(cacheFile.toFile())) {
                     long currentSize = fileChannel.getChannel().size();
                     if (currentSize < fileSize) {
-                        logger.info("pre-allocating cache file [{}] ({}) using native methods", cacheFile, new ByteSizeValue(fileSize));
+                        logger.info("pre-allocating cache file [{}] ({}) using native methods", cacheFile, ByteSizeValue.ofBytes(fileSize));
                         final Field field = AccessController.doPrivileged(new FileDescriptorFieldAction(fileChannel));
                         final int errno = prealloactor.preallocate(
                             (int) field.get(fileChannel.getFD()),
@@ -70,7 +70,7 @@ public class Preallocate {
             // even if allocation was successful above, verify again here
             try (RandomAccessFile raf = new RandomAccessFile(cacheFile.toFile(), "rw")) {
                 if (raf.length() != fileSize) {
-                    logger.info("pre-allocating cache file [{}] ({}) using setLength method", cacheFile, new ByteSizeValue(fileSize));
+                    logger.info("pre-allocating cache file [{}] ({}) using setLength method", cacheFile, ByteSizeValue.ofBytes(fileSize));
                     raf.setLength(fileSize);
                     logger.debug("pre-allocated cache file [{}] using setLength method", cacheFile);
                 }

--- a/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/FrozenSearchableSnapshotsIntegTests.java
+++ b/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/FrozenSearchableSnapshotsIntegTests.java
@@ -166,7 +166,7 @@ public class FrozenSearchableSnapshotsIntegTests extends BaseFrozenSearchableSna
         if (randomBoolean()) {
             indexSettingsBuilder.put(
                 SearchableSnapshots.SNAPSHOT_UNCACHED_CHUNK_SIZE_SETTING.getKey(),
-                new ByteSizeValue(randomLongBetween(10, 100_000))
+                ByteSizeValue.ofBytes(randomLongBetween(10, 100_000))
             );
         }
         final int expectedReplicas;

--- a/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/SearchableSnapshotsIntegTests.java
+++ b/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/SearchableSnapshotsIntegTests.java
@@ -184,7 +184,7 @@ public class SearchableSnapshotsIntegTests extends BaseSearchableSnapshotsIntegT
         if (randomBoolean()) {
             indexSettingsBuilder.put(
                 SearchableSnapshots.SNAPSHOT_UNCACHED_CHUNK_SIZE_SETTING.getKey(),
-                new ByteSizeValue(randomLongBetween(10, 100_000))
+                ByteSizeValue.ofBytes(randomLongBetween(10, 100_000))
             );
         }
         final int expectedReplicas;
@@ -471,7 +471,7 @@ public class SearchableSnapshotsIntegTests extends BaseSearchableSnapshotsIntegT
             // trigger the rate limiter in all nodes. We could just use the min shard size
             // but that would make this test too slow.
             long rateLimitInBytes = getMaxShardSizeByNodeInBytes(indexName).values().stream().min(Long::compareTo).get();
-            repositorySettings.put("max_restore_bytes_per_sec", new ByteSizeValue(rateLimitInBytes, ByteSizeUnit.BYTES));
+            repositorySettings.put("max_restore_bytes_per_sec", ByteSizeValue.ofBytes(rateLimitInBytes));
         } else {
             repositorySettings.put("max_restore_bytes_per_sec", ByteSizeValue.ZERO);
         }

--- a/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/cache/shared/PartiallyCachedShardAllocationIntegTests.java
+++ b/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/cache/shared/PartiallyCachedShardAllocationIntegTests.java
@@ -136,7 +136,7 @@ public class PartiallyCachedShardAllocationIntegTests extends BaseFrozenSearchab
         final List<String> newNodeNames = internalCluster().startDataOnlyNodes(
             between(1, 3),
             Settings.builder()
-                .put(SHARED_CACHE_SIZE_SETTING.getKey(), new ByteSizeValue(randomLongBetween(1, ByteSizeValue.ofMb(10).getBytes())))
+                .put(SHARED_CACHE_SIZE_SETTING.getKey(), ByteSizeValue.ofBytes(randomLongBetween(1, ByteSizeValue.ofMb(10).getBytes())))
                 .build()
         );
 
@@ -158,7 +158,7 @@ public class PartiallyCachedShardAllocationIntegTests extends BaseFrozenSearchab
         final List<String> newNodeNames = internalCluster().startNodes(
             between(1, 3),
             Settings.builder()
-                .put(SHARED_CACHE_SIZE_SETTING.getKey(), new ByteSizeValue(randomLongBetween(1, ByteSizeValue.ofMb(10).getBytes())))
+                .put(SHARED_CACHE_SIZE_SETTING.getKey(), ByteSizeValue.ofBytes(randomLongBetween(1, ByteSizeValue.ofMb(10).getBytes())))
                 .put(onlyRole(DiscoveryNodeRole.DATA_FROZEN_NODE_ROLE))
                 .build()
         );
@@ -244,7 +244,7 @@ public class PartiallyCachedShardAllocationIntegTests extends BaseFrozenSearchab
         final List<String> newNodes = internalCluster().startDataOnlyNodes(
             2,
             Settings.builder()
-                .put(SHARED_CACHE_SIZE_SETTING.getKey(), new ByteSizeValue(randomLongBetween(1, ByteSizeValue.ofMb(10).getBytes())))
+                .put(SHARED_CACHE_SIZE_SETTING.getKey(), ByteSizeValue.ofBytes(randomLongBetween(1, ByteSizeValue.ofMb(10).getBytes())))
                 .build()
         );
         final ActionFuture<RestoreSnapshotResponse> responseFuture = client().execute(MountSearchableSnapshotAction.INSTANCE, req);

--- a/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/SearchableSnapshots.java
+++ b/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/SearchableSnapshots.java
@@ -197,7 +197,7 @@ public class SearchableSnapshots extends Plugin implements IndexStorePlugin, Eng
     );
     public static final Setting<ByteSizeValue> SNAPSHOT_UNCACHED_CHUNK_SIZE_SETTING = Setting.byteSizeSetting(
         "index.store.snapshot.uncached_chunk_size",
-        new ByteSizeValue(-1, ByteSizeUnit.BYTES),
+        ByteSizeValue.MINUS_ONE,
         Setting.Property.IndexScope,
         Setting.Property.NodeScope,
         Setting.Property.NotCopyableOnResize
@@ -212,7 +212,7 @@ public class SearchableSnapshots extends Plugin implements IndexStorePlugin, Eng
         s -> Setting.parseByteSize(
             s,
             new ByteSizeValue(1L, ByteSizeUnit.KB),
-            new ByteSizeValue(Long.MAX_VALUE),
+            ByteSizeValue.ofBytes(Long.MAX_VALUE),
             SNAPSHOT_BLOB_CACHE_METADATA_FILES_MAX_LENGTH
         ),
         value -> {

--- a/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/action/TransportSearchableSnapshotsStatsAction.java
+++ b/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/action/TransportSearchableSnapshotsStatsAction.java
@@ -101,9 +101,9 @@ public class TransportSearchableSnapshotsStatsAction extends AbstractTransportSe
         return new CacheIndexInputStats(
             fileExt,
             inputStats.getNumFiles(),
-            new ByteSizeValue(inputStats.getTotalSize()),
-            new ByteSizeValue(inputStats.getMinSize()),
-            new ByteSizeValue(inputStats.getMaxSize()),
+            ByteSizeValue.ofBytes(inputStats.getTotalSize()),
+            ByteSizeValue.ofBytes(inputStats.getMinSize()),
+            ByteSizeValue.ofBytes(inputStats.getMaxSize()),
             inputStats.getOpened().sum(),
             inputStats.getClosed().sum(),
             toCounter(inputStats.getForwardSmallSeeks()),

--- a/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/allocation/SearchableSnapshotAllocator.java
+++ b/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/allocation/SearchableSnapshotAllocator.java
@@ -519,7 +519,7 @@ public class SearchableSnapshotAllocator implements ExistingShardsAllocator {
                     "{}: node [{}] has [{}/{}] bytes of re-usable cache data",
                     shard,
                     discoNode.getName(),
-                    new ByteSizeValue(matchingBytes),
+                    ByteSizeValue.ofBytes(matchingBytes),
                     matchingBytes
                 );
             }

--- a/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/cache/full/CacheService.java
+++ b/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/cache/full/CacheService.java
@@ -70,7 +70,7 @@ public class CacheService extends AbstractLifecycleComponent {
     private static final String SETTINGS_PREFIX = "xpack.searchable.snapshot.cache.";
 
     public static final ByteSizeValue MIN_SNAPSHOT_CACHE_RANGE_SIZE = new ByteSizeValue(4, ByteSizeUnit.KB);
-    public static final ByteSizeValue MAX_SNAPSHOT_CACHE_RANGE_SIZE = new ByteSizeValue(Integer.MAX_VALUE, ByteSizeUnit.BYTES);
+    public static final ByteSizeValue MAX_SNAPSHOT_CACHE_RANGE_SIZE = ByteSizeValue.ofBytes(Integer.MAX_VALUE);
 
     /**
      * If a search needs data from the repository then we expand it to a larger contiguous range whose size is determined by this setting,

--- a/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/xpack/searchablesnapshots/AbstractSearchableSnapshotsTestCase.java
+++ b/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/xpack/searchablesnapshots/AbstractSearchableSnapshotsTestCase.java
@@ -197,7 +197,7 @@ public abstract class AbstractSearchableSnapshotsTestCase extends ESIndexInputTe
     }
 
     protected static ByteSizeValue randomFrozenCacheSize() {
-        return new ByteSizeValue(randomLongBetween(0, 10_000_000));
+        return ByteSizeValue.ofBytes(randomLongBetween(0, 10_000_000));
     }
 
     /**
@@ -208,14 +208,14 @@ public abstract class AbstractSearchableSnapshotsTestCase extends ESIndexInputTe
     }
 
     protected static ByteSizeValue randomFrozenCacheRangeSize() {
-        return pageAlignedBetween(new ByteSizeValue(4, ByteSizeUnit.KB), new ByteSizeValue(Integer.MAX_VALUE, ByteSizeUnit.BYTES));
+        return pageAlignedBetween(new ByteSizeValue(4, ByteSizeUnit.KB), ByteSizeValue.ofBytes(Integer.MAX_VALUE));
     }
 
     private static ByteSizeValue pageAlignedBetween(ByteSizeValue min, ByteSizeValue max) {
-        ByteSizeValue aligned = pageAligned(new ByteSizeValue(randomLongBetween(min.getBytes(), max.getBytes())));
+        ByteSizeValue aligned = pageAligned(ByteSizeValue.ofBytes(randomLongBetween(min.getBytes(), max.getBytes())));
         if (aligned.compareTo(max) > 0) {
             // minus one page in case page alignment moved us past the max setting value
-            return new ByteSizeValue(aligned.getBytes() - PAGE_SIZE);
+            return ByteSizeValue.ofBytes(aligned.getBytes() - PAGE_SIZE);
         }
         return aligned;
     }

--- a/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/xpack/searchablesnapshots/action/SearchableSnapshotsStatsResponseTests.java
+++ b/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/xpack/searchablesnapshots/action/SearchableSnapshotsStatsResponseTests.java
@@ -100,9 +100,9 @@ public class SearchableSnapshotsStatsResponseTests extends ESTestCase {
         return new SearchableSnapshotShardStats.CacheIndexInputStats(
             randomAlphaOfLength(10),
             randomNonNegativeLong(),
-            new ByteSizeValue(randomNonNegativeLong()),
-            new ByteSizeValue(randomNonNegativeLong()),
-            new ByteSizeValue(randomNonNegativeLong()),
+            ByteSizeValue.ofBytes(randomNonNegativeLong()),
+            ByteSizeValue.ofBytes(randomNonNegativeLong()),
+            ByteSizeValue.ofBytes(randomNonNegativeLong()),
             randomNonNegativeLong(),
             randomNonNegativeLong(),
             randomCounter(),

--- a/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/xpack/searchablesnapshots/cache/shared/FrozenCacheServiceTests.java
+++ b/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/xpack/searchablesnapshots/cache/shared/FrozenCacheServiceTests.java
@@ -49,8 +49,8 @@ public class FrozenCacheServiceTests extends ESTestCase {
     public void testBasicEviction() throws IOException {
         Settings settings = Settings.builder()
             .put(NODE_NAME_SETTING.getKey(), "node")
-            .put(FrozenCacheService.SHARED_CACHE_SIZE_SETTING.getKey(), new ByteSizeValue(size(500)).getStringRep())
-            .put(FrozenCacheService.SHARED_CACHE_REGION_SIZE_SETTING.getKey(), new ByteSizeValue(size(100)).getStringRep())
+            .put(FrozenCacheService.SHARED_CACHE_SIZE_SETTING.getKey(), ByteSizeValue.ofBytes(size(500)).getStringRep())
+            .put(FrozenCacheService.SHARED_CACHE_REGION_SIZE_SETTING.getKey(), ByteSizeValue.ofBytes(size(100)).getStringRep())
             .put("path.home", createTempDir())
             .build();
         final DeterministicTaskQueue taskQueue = new DeterministicTaskQueue();
@@ -94,8 +94,8 @@ public class FrozenCacheServiceTests extends ESTestCase {
     public void testAutoEviction() throws IOException {
         Settings settings = Settings.builder()
             .put(NODE_NAME_SETTING.getKey(), "node")
-            .put(FrozenCacheService.SHARED_CACHE_SIZE_SETTING.getKey(), new ByteSizeValue(size(200)).getStringRep())
-            .put(FrozenCacheService.SHARED_CACHE_REGION_SIZE_SETTING.getKey(), new ByteSizeValue(size(100)).getStringRep())
+            .put(FrozenCacheService.SHARED_CACHE_SIZE_SETTING.getKey(), ByteSizeValue.ofBytes(size(200)).getStringRep())
+            .put(FrozenCacheService.SHARED_CACHE_REGION_SIZE_SETTING.getKey(), ByteSizeValue.ofBytes(size(100)).getStringRep())
             .put("path.home", createTempDir())
             .build();
         final DeterministicTaskQueue taskQueue = new DeterministicTaskQueue();
@@ -130,8 +130,8 @@ public class FrozenCacheServiceTests extends ESTestCase {
     public void testForceEviction() throws IOException {
         Settings settings = Settings.builder()
             .put(NODE_NAME_SETTING.getKey(), "node")
-            .put(FrozenCacheService.SHARED_CACHE_SIZE_SETTING.getKey(), new ByteSizeValue(size(500)).getStringRep())
-            .put(FrozenCacheService.SHARED_CACHE_REGION_SIZE_SETTING.getKey(), new ByteSizeValue(size(100)).getStringRep())
+            .put(FrozenCacheService.SHARED_CACHE_SIZE_SETTING.getKey(), ByteSizeValue.ofBytes(size(500)).getStringRep())
+            .put(FrozenCacheService.SHARED_CACHE_REGION_SIZE_SETTING.getKey(), ByteSizeValue.ofBytes(size(100)).getStringRep())
             .put("path.home", createTempDir())
             .build();
         final DeterministicTaskQueue taskQueue = new DeterministicTaskQueue();
@@ -158,8 +158,8 @@ public class FrozenCacheServiceTests extends ESTestCase {
     public void testDecay() throws IOException {
         Settings settings = Settings.builder()
             .put(NODE_NAME_SETTING.getKey(), "node")
-            .put(FrozenCacheService.SHARED_CACHE_SIZE_SETTING.getKey(), new ByteSizeValue(size(500)).getStringRep())
-            .put(FrozenCacheService.SHARED_CACHE_REGION_SIZE_SETTING.getKey(), new ByteSizeValue(size(100)).getStringRep())
+            .put(FrozenCacheService.SHARED_CACHE_SIZE_SETTING.getKey(), ByteSizeValue.ofBytes(size(500)).getStringRep())
+            .put(FrozenCacheService.SHARED_CACHE_REGION_SIZE_SETTING.getKey(), ByteSizeValue.ofBytes(size(100)).getStringRep())
             .put("path.home", createTempDir())
             .build();
         final DeterministicTaskQueue taskQueue = new DeterministicTaskQueue();
@@ -211,11 +211,11 @@ public class FrozenCacheServiceTests extends ESTestCase {
 
     public void testCacheSizeRejectedOnNonFrozenNodes() {
         String cacheSize = randomBoolean()
-            ? new ByteSizeValue(size(500)).getStringRep()
+            ? ByteSizeValue.ofBytes(size(500)).getStringRep()
             : (new RatioValue(between(1, 100))).formatNoTrailingZerosPercent();
         final Settings settings = Settings.builder()
             .put(FrozenCacheService.SHARED_CACHE_SIZE_SETTING.getKey(), cacheSize)
-            .put(FrozenCacheService.SHARED_CACHE_REGION_SIZE_SETTING.getKey(), new ByteSizeValue(size(100)).getStringRep())
+            .put(FrozenCacheService.SHARED_CACHE_REGION_SIZE_SETTING.getKey(), ByteSizeValue.ofBytes(size(100)).getStringRep())
             .putList(NodeRoleSettings.NODE_ROLES_SETTING.getKey(), DiscoveryNodeRole.DATA_HOT_NODE_ROLE.roleName())
             .build();
         final IllegalArgumentException e = expectThrows(
@@ -238,7 +238,7 @@ public class FrozenCacheServiceTests extends ESTestCase {
 
     public void testMultipleDataPathsRejectedOnFrozenNodes() {
         final Settings settings = Settings.builder()
-            .put(FrozenCacheService.SHARED_CACHE_SIZE_SETTING.getKey(), new ByteSizeValue(size(500)).getStringRep())
+            .put(FrozenCacheService.SHARED_CACHE_SIZE_SETTING.getKey(), ByteSizeValue.ofBytes(size(500)).getStringRep())
             .putList(NodeRoleSettings.NODE_ROLES_SETTING.getKey(), DiscoveryNodeRole.DATA_FROZEN_NODE_ROLE.roleName())
             .putList(Environment.PATH_DATA_SETTING.getKey(), List.of("a", "b"))
             .build();
@@ -254,7 +254,7 @@ public class FrozenCacheServiceTests extends ESTestCase {
                 "setting ["
                     + FrozenCacheService.SHARED_CACHE_SIZE_SETTING.getKey()
                     + "="
-                    + new ByteSizeValue(size(500)).getStringRep()
+                    + ByteSizeValue.ofBytes(size(500)).getStringRep()
                     + "] is not permitted on nodes with multiple data paths [a,b]"
             )
         );
@@ -305,10 +305,10 @@ public class FrozenCacheServiceTests extends ESTestCase {
     }
 
     public void testMaxHeadroomRejectedForAbsoluteCacheSize() {
-        String cacheSize = new ByteSizeValue(size(500)).getStringRep();
+        String cacheSize = ByteSizeValue.ofBytes(size(500)).getStringRep();
         final Settings settings = Settings.builder()
             .put(FrozenCacheService.SHARED_CACHE_SIZE_SETTING.getKey(), cacheSize)
-            .put(FrozenCacheService.SHARED_CACHE_SIZE_MAX_HEADROOM_SETTING.getKey(), new ByteSizeValue(size(100)).getStringRep())
+            .put(FrozenCacheService.SHARED_CACHE_SIZE_MAX_HEADROOM_SETTING.getKey(), ByteSizeValue.ofBytes(size(100)).getStringRep())
             .putList(NodeRoleSettings.NODE_ROLES_SETTING.getKey(), DiscoveryNodeRole.DATA_FROZEN_NODE_ROLE.roleName())
             .build();
         final IllegalArgumentException e = expectThrows(
@@ -356,7 +356,7 @@ public class FrozenCacheServiceTests extends ESTestCase {
         Settings settings = Settings.builder()
             .put(NODE_NAME_SETTING.getKey(), "node")
             .put(FrozenCacheService.SHARED_CACHE_SIZE_SETTING.getKey(), val1.getStringRep())
-            .put(FrozenCacheService.SHARED_CACHE_REGION_SIZE_SETTING.getKey(), new ByteSizeValue(size(100)).getStringRep())
+            .put(FrozenCacheService.SHARED_CACHE_REGION_SIZE_SETTING.getKey(), ByteSizeValue.ofBytes(size(100)).getStringRep())
             .put("path.home", createTempDir())
             .build();
         final DeterministicTaskQueue taskQueue = new DeterministicTaskQueue();
@@ -380,7 +380,7 @@ public class FrozenCacheServiceTests extends ESTestCase {
     private void assertThatNonPositiveRecoveryRangeSizeRejected(Setting<ByteSizeValue> setting) {
         final String value = randomFrom(ByteSizeValue.MINUS_ONE, ByteSizeValue.ZERO).getStringRep();
         final Settings settings = Settings.builder()
-            .put(FrozenCacheService.SHARED_CACHE_SIZE_SETTING.getKey(), new ByteSizeValue(size(100)).getStringRep())
+            .put(FrozenCacheService.SHARED_CACHE_SIZE_SETTING.getKey(), ByteSizeValue.ofBytes(size(100)).getStringRep())
             .putList(NodeRoleSettings.NODE_ROLES_SETTING.getKey(), DiscoveryNodeRole.DATA_FROZEN_NODE_ROLE.roleName())
             .put(setting.getKey(), value)
             .build();

--- a/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/xpack/searchablesnapshots/store/SearchableSnapshotDirectoryStatsTests.java
+++ b/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/xpack/searchablesnapshots/store/SearchableSnapshotDirectoryStatsTests.java
@@ -113,7 +113,7 @@ public class SearchableSnapshotDirectoryStatsTests extends AbstractSearchableSna
 
     public void testCachedBytesReadsAndWrites() throws Exception {
         // a cache service with a low range size but enough space to not evict the cache file
-        final ByteSizeValue rangeSize = new ByteSizeValue(SharedBytes.PAGE_SIZE * randomLongBetween(3, 6), ByteSizeUnit.BYTES);
+        final ByteSizeValue rangeSize = ByteSizeValue.ofBytes(SharedBytes.PAGE_SIZE * randomLongBetween(3, 6));
         final ByteSizeValue cacheSize = new ByteSizeValue(10, ByteSizeUnit.MB);
 
         executeTestCaseWithCache(cacheSize, rangeSize, (fileName, fileContent, directory) -> {
@@ -167,7 +167,7 @@ public class SearchableSnapshotDirectoryStatsTests extends AbstractSearchableSna
     }
 
     public void testCachedBytesReadsAndWritesNoCache() throws Exception {
-        final ByteSizeValue uncachedChunkSize = new ByteSizeValue(randomIntBetween(512, MAX_FILE_LENGTH), ByteSizeUnit.BYTES);
+        final ByteSizeValue uncachedChunkSize = ByteSizeValue.ofBytes(randomIntBetween(512, MAX_FILE_LENGTH));
         executeTestCaseWithoutCache(uncachedChunkSize, (fileName, fileContent, directory) -> {
             try (IndexInput input = directory.openInput(fileName, randomIOContext())) {
                 final long length = input.length();
@@ -578,10 +578,7 @@ public class SearchableSnapshotDirectoryStatsTests extends AbstractSearchableSna
     private void executeTestCaseWithDefaultCache(final TriConsumer<String, byte[], SearchableSnapshotDirectory> test) throws Exception {
         executeTestCase(
             defaultCacheService(),
-            createFrozenCacheService(
-                ByteSizeValue.ofMb(10),
-                new ByteSizeValue(SharedBytes.PAGE_SIZE * randomLongBetween(3, 6), ByteSizeUnit.BYTES)
-            ),
+            createFrozenCacheService(ByteSizeValue.ofMb(10), ByteSizeValue.ofBytes(SharedBytes.PAGE_SIZE * randomLongBetween(3, 6))),
             Settings.builder()
                 .put(SNAPSHOT_CACHE_ENABLED_SETTING.getKey(), true)
                 .put(SNAPSHOT_CACHE_PREWARM_ENABLED_SETTING.getKey(), false) // disable prewarming as it impacts the stats
@@ -644,7 +641,7 @@ public class SearchableSnapshotDirectoryStatsTests extends AbstractSearchableSna
             fileChecksum,
             Version.CURRENT.luceneVersion.toString()
         );
-        final List<FileInfo> files = List.of(new FileInfo(blobName, metadata, new ByteSizeValue(fileContent.length)));
+        final List<FileInfo> files = List.of(new FileInfo(blobName, metadata, ByteSizeValue.ofBytes(fileContent.length)));
         final BlobStoreIndexShardSnapshot snapshot = new BlobStoreIndexShardSnapshot(snapshotId.getName(), 0L, files, 0L, 0L, 0, 0L);
         final Path shardDir = randomShardPath(shardId);
         final ShardPath shardPath = new ShardPath(false, shardDir, shardDir, shardId);

--- a/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/xpack/searchablesnapshots/store/SearchableSnapshotDirectoryTests.java
+++ b/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/xpack/searchablesnapshots/store/SearchableSnapshotDirectoryTests.java
@@ -735,7 +735,7 @@ public class SearchableSnapshotDirectoryTests extends AbstractSearchableSnapshot
                     new BlobStoreIndexShardSnapshot.FileInfo(
                         blobName,
                         new StoreFileMetadata(fileName, input.length, checksum, Version.CURRENT.luceneVersion.toString()),
-                        new ByteSizeValue(input.length)
+                        ByteSizeValue.ofBytes(input.length)
                     )
                 );
             }

--- a/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/xpack/searchablesnapshots/store/input/CachedBlobContainerIndexInputTests.java
+++ b/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/xpack/searchablesnapshots/store/input/CachedBlobContainerIndexInputTests.java
@@ -82,7 +82,7 @@ public class CachedBlobContainerIndexInputTests extends AbstractSearchableSnapsh
                 final BlobStoreIndexShardSnapshot snapshot = new BlobStoreIndexShardSnapshot(
                     snapshotId.getName(),
                     0L,
-                    List.of(new BlobStoreIndexShardSnapshot.FileInfo(blobName, metadata, new ByteSizeValue(partSize))),
+                    List.of(new BlobStoreIndexShardSnapshot.FileInfo(blobName, metadata, ByteSizeValue.ofBytes(partSize))),
                     0L,
                     0L,
                     0,
@@ -200,7 +200,7 @@ public class CachedBlobContainerIndexInputTests extends AbstractSearchableSnapsh
             final BlobStoreIndexShardSnapshot snapshot = new BlobStoreIndexShardSnapshot(
                 snapshotId.getName(),
                 0L,
-                List.of(new BlobStoreIndexShardSnapshot.FileInfo(blobName, metadata, new ByteSizeValue(input.length + 1))),
+                List.of(new BlobStoreIndexShardSnapshot.FileInfo(blobName, metadata, ByteSizeValue.ofBytes(input.length + 1))),
                 0L,
                 0L,
                 0,

--- a/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/xpack/searchablesnapshots/store/input/FrozenIndexInputTests.java
+++ b/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/xpack/searchablesnapshots/store/input/FrozenIndexInputTests.java
@@ -55,30 +55,30 @@ public class FrozenIndexInputTests extends AbstractSearchableSnapshotsTestCase {
         final FileInfo fileInfo = new FileInfo(
             randomAlphaOfLength(10),
             new StoreFileMetadata(fileName, fileData.length, checksum, Version.CURRENT.luceneVersion.toString()),
-            new ByteSizeValue(fileData.length)
+            ByteSizeValue.ofBytes(fileData.length)
         );
 
         final ByteSizeValue rangeSize;
         if (rarely()) {
             rangeSize = FrozenCacheService.SHARED_CACHE_RANGE_SIZE_SETTING.get(Settings.EMPTY);
         } else if (randomBoolean()) {
-            rangeSize = new ByteSizeValue(randomIntBetween(1, 16) * SharedBytes.PAGE_SIZE);
+            rangeSize = ByteSizeValue.ofBytes(randomIntBetween(1, 16) * SharedBytes.PAGE_SIZE);
         } else {
-            rangeSize = new ByteSizeValue(randomIntBetween(1, 16000) * SharedBytes.PAGE_SIZE);
+            rangeSize = ByteSizeValue.ofBytes(randomIntBetween(1, 16000) * SharedBytes.PAGE_SIZE);
         }
 
         final ByteSizeValue regionSize;
         if (rarely()) {
             regionSize = FrozenCacheService.SHARED_CACHE_REGION_SIZE_SETTING.get(Settings.EMPTY);
         } else {
-            regionSize = new ByteSizeValue(randomIntBetween(1, 16) * SharedBytes.PAGE_SIZE);
+            regionSize = ByteSizeValue.ofBytes(randomIntBetween(1, 16) * SharedBytes.PAGE_SIZE);
         }
 
         final ByteSizeValue cacheSize;
         if (rarely()) {
             cacheSize = regionSize;
         } else {
-            cacheSize = new ByteSizeValue(randomLongBetween(1L, 10L) * regionSize.getBytes() + randomIntBetween(0, 100));
+            cacheSize = ByteSizeValue.ofBytes(randomLongBetween(1L, 10L) * regionSize.getBytes() + randomIntBetween(0, 100));
         }
 
         final Settings settings = Settings.builder()

--- a/x-pack/plugin/snapshot-based-recoveries/src/test/java/org/elasticsearch/xpack/snapshotbasedrecoveries/recovery/plan/SnapshotsRecoveryPlannerServiceTests.java
+++ b/x-pack/plugin/snapshot-based-recoveries/src/test/java/org/elasticsearch/xpack/snapshotbasedrecoveries/recovery/plan/SnapshotsRecoveryPlannerServiceTests.java
@@ -72,7 +72,7 @@ public class SnapshotsRecoveryPlannerServiceTests extends ESTestCase {
         "index",
         Settings.builder().put(IndexMetadata.SETTING_VERSION_CREATED, org.elasticsearch.Version.CURRENT).build()
     );
-    private static final ByteSizeValue PART_SIZE = new ByteSizeValue(Long.MAX_VALUE);
+    private static final ByteSizeValue PART_SIZE = ByteSizeValue.ofBytes(Long.MAX_VALUE);
     private static final ShardId shardId = new ShardId(INDEX_SETTINGS.getIndex(), 1);
 
     private String shardHistoryUUID;

--- a/x-pack/plugin/snapshot-repo-test-kit/src/internalClusterTest/java/org/elasticsearch/repositories/blobstore/testkit/RepositoryAnalysisFailureIT.java
+++ b/x-pack/plugin/snapshot-repo-test-kit/src/internalClusterTest/java/org/elasticsearch/repositories/blobstore/testkit/RepositoryAnalysisFailureIT.java
@@ -93,7 +93,7 @@ public class RepositoryAnalysisFailureIT extends AbstractSnapshotIntegTestCase {
     public void testSuccess() {
         final RepositoryAnalyzeAction.Request request = new RepositoryAnalyzeAction.Request("test-repo");
         request.blobCount(1);
-        request.maxBlobSize(new ByteSizeValue(10L));
+        request.maxBlobSize(ByteSizeValue.ofBytes(10L));
 
         final RepositoryAnalyzeAction.Response response = analyseRepository(request);
         assertThat(response.status(), equalTo(RestStatus.OK));
@@ -101,7 +101,7 @@ public class RepositoryAnalysisFailureIT extends AbstractSnapshotIntegTestCase {
 
     public void testFailsOnReadError() {
         final RepositoryAnalyzeAction.Request request = new RepositoryAnalyzeAction.Request("test-repo");
-        request.maxBlobSize(new ByteSizeValue(10L));
+        request.maxBlobSize(ByteSizeValue.ofBytes(10L));
         request.abortWritePermitted(false);
 
         final CountDown countDown = new CountDown(between(1, request.getBlobCount()));
@@ -123,7 +123,7 @@ public class RepositoryAnalysisFailureIT extends AbstractSnapshotIntegTestCase {
 
     public void testFailsOnNotFoundAfterWrite() {
         final RepositoryAnalyzeAction.Request request = new RepositoryAnalyzeAction.Request("test-repo");
-        request.maxBlobSize(new ByteSizeValue(10L));
+        request.maxBlobSize(ByteSizeValue.ofBytes(10L));
         request.abortWritePermitted(false);
         request.rareActionProbability(0.0); // not found on an early read or an overwrite is ok
 
@@ -144,7 +144,7 @@ public class RepositoryAnalysisFailureIT extends AbstractSnapshotIntegTestCase {
 
     public void testFailsOnChecksumMismatch() {
         final RepositoryAnalyzeAction.Request request = new RepositoryAnalyzeAction.Request("test-repo");
-        request.maxBlobSize(new ByteSizeValue(10L));
+        request.maxBlobSize(ByteSizeValue.ofBytes(10L));
         request.abortWritePermitted(false);
 
         final CountDown countDown = new CountDown(between(1, request.getBlobCount()));
@@ -166,7 +166,7 @@ public class RepositoryAnalysisFailureIT extends AbstractSnapshotIntegTestCase {
 
     public void testFailsOnWriteException() {
         final RepositoryAnalyzeAction.Request request = new RepositoryAnalyzeAction.Request("test-repo");
-        request.maxBlobSize(new ByteSizeValue(10L));
+        request.maxBlobSize(ByteSizeValue.ofBytes(10L));
         request.abortWritePermitted(false);
 
         final CountDown countDown = new CountDown(between(1, request.getBlobCount()));
@@ -190,7 +190,7 @@ public class RepositoryAnalysisFailureIT extends AbstractSnapshotIntegTestCase {
 
     public void testFailsOnIncompleteListing() {
         final RepositoryAnalyzeAction.Request request = new RepositoryAnalyzeAction.Request("test-repo");
-        request.maxBlobSize(new ByteSizeValue(10L));
+        request.maxBlobSize(ByteSizeValue.ofBytes(10L));
         request.abortWritePermitted(false);
 
         blobStore.setDisruption(new Disruption() {
@@ -209,7 +209,7 @@ public class RepositoryAnalysisFailureIT extends AbstractSnapshotIntegTestCase {
 
     public void testFailsOnListingException() {
         final RepositoryAnalyzeAction.Request request = new RepositoryAnalyzeAction.Request("test-repo");
-        request.maxBlobSize(new ByteSizeValue(10L));
+        request.maxBlobSize(ByteSizeValue.ofBytes(10L));
         request.abortWritePermitted(false);
 
         final CountDown countDown = new CountDown(1);
@@ -229,7 +229,7 @@ public class RepositoryAnalysisFailureIT extends AbstractSnapshotIntegTestCase {
 
     public void testFailsOnDeleteException() {
         final RepositoryAnalyzeAction.Request request = new RepositoryAnalyzeAction.Request("test-repo");
-        request.maxBlobSize(new ByteSizeValue(10L));
+        request.maxBlobSize(ByteSizeValue.ofBytes(10L));
         request.abortWritePermitted(false);
 
         blobStore.setDisruption(new Disruption() {
@@ -244,7 +244,7 @@ public class RepositoryAnalysisFailureIT extends AbstractSnapshotIntegTestCase {
 
     public void testFailsOnIncompleteDelete() {
         final RepositoryAnalyzeAction.Request request = new RepositoryAnalyzeAction.Request("test-repo");
-        request.maxBlobSize(new ByteSizeValue(10L));
+        request.maxBlobSize(ByteSizeValue.ofBytes(10L));
         request.abortWritePermitted(false);
 
         blobStore.setDisruption(new Disruption() {
@@ -272,7 +272,7 @@ public class RepositoryAnalysisFailureIT extends AbstractSnapshotIntegTestCase {
 
     public void testFailsIfBlobCreatedOnAbort() {
         final RepositoryAnalyzeAction.Request request = new RepositoryAnalyzeAction.Request("test-repo");
-        request.maxBlobSize(new ByteSizeValue(10L));
+        request.maxBlobSize(ByteSizeValue.ofBytes(10L));
         request.rareActionProbability(0.7); // abort writes quite often
 
         final AtomicBoolean writeWasAborted = new AtomicBoolean();

--- a/x-pack/plugin/snapshot-repo-test-kit/src/internalClusterTest/java/org/elasticsearch/repositories/blobstore/testkit/RepositoryAnalysisSuccessIT.java
+++ b/x-pack/plugin/snapshot-repo-test-kit/src/internalClusterTest/java/org/elasticsearch/repositories/blobstore/testkit/RepositoryAnalysisSuccessIT.java
@@ -107,13 +107,13 @@ public class RepositoryAnalysisSuccessIT extends AbstractSnapshotIntegTestCase {
 
         if (request.getBlobCount() > 3 || randomBoolean()) {
             // only use the default blob size of 10MB if writing a small number of blobs, since this is all in-memory
-            request.maxBlobSize(new ByteSizeValue(between(1, 2048)));
+            request.maxBlobSize(ByteSizeValue.ofBytes(between(1, 2048)));
             blobStore.setMaxBlobSize(request.getMaxBlobSize().getBytes());
         }
 
         if (usually()) {
             request.maxTotalDataSize(
-                new ByteSizeValue(request.getMaxBlobSize().getBytes() + request.getBlobCount() - 1 + between(0, 1 << 20))
+                ByteSizeValue.ofBytes(request.getMaxBlobSize().getBytes() + request.getBlobCount() - 1 + between(0, 1 << 20))
             );
             blobStore.setMaxTotalBlobSize(request.getMaxTotalDataSize().getBytes());
         }

--- a/x-pack/plugin/snapshot-repo-test-kit/src/main/java/org/elasticsearch/repositories/blobstore/testkit/BlobAnalyzeAction.java
+++ b/x-pack/plugin/snapshot-repo-test-kit/src/main/java/org/elasticsearch/repositories/blobstore/testkit/BlobAnalyzeAction.java
@@ -848,7 +848,7 @@ public class BlobAnalyzeAction extends ActionType<BlobAnalyzeAction.Response> {
 
             builder.startObject("blob");
             builder.field("name", blobName);
-            builder.humanReadableField("size_bytes", "size", new ByteSizeValue(blobLength));
+            builder.humanReadableField("size_bytes", "size", ByteSizeValue.ofBytes(blobLength));
             builder.field("read_start", checksumStart);
             builder.field("read_end", checksumEnd);
             builder.field("read_early", readEarly);

--- a/x-pack/plugin/snapshot-repo-test-kit/src/main/java/org/elasticsearch/repositories/blobstore/testkit/RepositoryAnalyzeAction.java
+++ b/x-pack/plugin/snapshot-repo-test-kit/src/main/java/org/elasticsearch/repositories/blobstore/testkit/RepositoryAnalyzeAction.java
@@ -697,8 +697,8 @@ public class RepositoryAnalyzeAction extends ActionType<RepositoryAnalyzeAction.
             readNodeCount = in.readVInt();
             earlyReadNodeCount = in.readVInt();
             timeout = in.readTimeValue();
-            maxBlobSize = new ByteSizeValue(in);
-            maxTotalDataSize = new ByteSizeValue(in);
+            maxBlobSize = ByteSizeValue.readFrom(in);
+            maxTotalDataSize = ByteSizeValue.readFrom(in);
             detailed = in.readBoolean();
             reroutedFrom = in.readOptionalWriteable(DiscoveryNode::new);
             if (in.getVersion().onOrAfter(Version.V_7_14_0)) {
@@ -973,8 +973,8 @@ public class RepositoryAnalyzeAction extends ActionType<RepositoryAnalyzeAction.
             concurrency = in.readVInt();
             readNodeCount = in.readVInt();
             earlyReadNodeCount = in.readVInt();
-            maxBlobSize = new ByteSizeValue(in);
-            maxTotalDataSize = new ByteSizeValue(in);
+            maxBlobSize = ByteSizeValue.readFrom(in);
+            maxTotalDataSize = ByteSizeValue.readFrom(in);
             seed = in.readLong();
             rareActionProbability = in.readDouble();
             blobPath = in.readString();

--- a/x-pack/plugin/snapshot-repo-test-kit/src/main/java/org/elasticsearch/repositories/blobstore/testkit/RepositoryPerformanceSummary.java
+++ b/x-pack/plugin/snapshot-repo-test-kit/src/main/java/org/elasticsearch/repositories/blobstore/testkit/RepositoryPerformanceSummary.java
@@ -90,14 +90,14 @@ public class RepositoryPerformanceSummary implements Writeable, ToXContentFragme
 
         builder.startObject("write");
         builder.field("count", writeCount);
-        builder.humanReadableField("total_size_bytes", "total_size", new ByteSizeValue(writeBytes));
+        builder.humanReadableField("total_size_bytes", "total_size", ByteSizeValue.ofBytes(writeBytes));
         humanReadableNanos(builder, "total_throttled_nanos", "total_throttled", writeThrottledNanos);
         humanReadableNanos(builder, "total_elapsed_nanos", "total_elapsed", writeElapsedNanos);
         builder.endObject();
 
         builder.startObject("read");
         builder.field("count", readCount);
-        builder.humanReadableField("total_size_bytes", "total_size", new ByteSizeValue(readBytes));
+        builder.humanReadableField("total_size_bytes", "total_size", ByteSizeValue.ofBytes(readBytes));
         humanReadableNanos(builder, "total_wait_nanos", "total_wait", readWaitNanos);
         humanReadableNanos(builder, "max_wait_nanos", "max_wait", maxReadWaitNanos);
         humanReadableNanos(builder, "total_throttled_nanos", "total_throttled", readThrottledNanos);

--- a/x-pack/plugin/snapshot-repo-test-kit/src/test/java/org/elasticsearch/repositories/blobstore/testkit/RepositoryAnalyzeActionTests.java
+++ b/x-pack/plugin/snapshot-repo-test-kit/src/test/java/org/elasticsearch/repositories/blobstore/testkit/RepositoryAnalyzeActionTests.java
@@ -102,8 +102,8 @@ public class RepositoryAnalyzeActionTests extends ESTestCase {
 
     private static List<Long> getBlobSizes(long maxBlobSize, long maxTotalDataSize, int blobCount) {
         final RepositoryAnalyzeAction.Request request = new RepositoryAnalyzeAction.Request("repo");
-        request.maxBlobSize(new ByteSizeValue(maxBlobSize));
-        request.maxTotalDataSize(new ByteSizeValue(maxTotalDataSize));
+        request.maxBlobSize(ByteSizeValue.ofBytes(maxBlobSize));
+        request.maxTotalDataSize(ByteSizeValue.ofBytes(maxTotalDataSize));
         request.blobCount(blobCount);
         return RepositoryAnalyzeAction.getBlobSizes(request);
     }

--- a/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/common/http/HttpSettings.java
+++ b/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/common/http/HttpSettings.java
@@ -62,7 +62,7 @@ public class HttpSettings {
     static final Setting<ByteSizeValue> MAX_HTTP_RESPONSE_SIZE = Setting.byteSizeSetting(
         "xpack.http.max_response_size",
         new ByteSizeValue(10, ByteSizeUnit.MB),   // default
-        new ByteSizeValue(1, ByteSizeUnit.BYTES), // min
+        ByteSizeValue.ONE, // min
         new ByteSizeValue(50, ByteSizeUnit.MB),   // max
         Property.NodeScope
     );

--- a/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/test/bench/WatcherScheduleEngineBenchmark.java
+++ b/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/test/bench/WatcherScheduleEngineBenchmark.java
@@ -344,7 +344,7 @@ public class WatcherScheduleEngineBenchmark {
                 Locale.ENGLISH,
                 "%10s | %13s | %12d | %13d \n",
                 name,
-                new ByteSizeValue(avgHeapUsed),
+                ByteSizeValue.ofBytes(avgHeapUsed),
                 watcherThreadPoolStats.getRejected(),
                 watcherThreadPoolStats.getCompleted()
             );


### PR DESCRIPTION
This comes out of a user heap dump investigation. In some snapshot corner cases we ran into about 100M of duplicate 0b instances.

-> even though it's a little heavy handed, lets make it so the common constants that we already have are used whenever possible.

