### PR TITLE
Fix duplicate entries in AutoFollowCoordinator.recentAutoFollowErrors

### DIFF
--- a/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/action/AutoFollowCoordinator.java
+++ b/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/action/AutoFollowCoordinator.java
@@ -110,10 +110,7 @@ public class AutoFollowCoordinator extends AbstractLifecycleComponent implements
     private long numberOfFailedRemoteClusterStateRequests = 0;
     private final LinkedHashMap<AutoFollowErrorKey, Tuple<Long, ElasticsearchException>> recentAutoFollowErrors;
 
-    private static final class AutoFollowErrorKey {
-        private final String pattern;
-        private final String index;
-
+    private record AutoFollowErrorKey(String pattern, String index) {
         private AutoFollowErrorKey(String pattern, String index) {
             this.pattern = Objects.requireNonNull(pattern);
             this.index = index;


### PR DESCRIPTION
Make this a record to get a proper equals + hash code. The current version would needlessly track multiple entries for the same pattern+index combination, but then only use the last one anyway when building the stats in `getStats`.
