### PR TITLE
support only the params of index in request body,when use /_cluster/allocation/explain api

### DIFF
--- a/docs/changelog/91191.yaml
+++ b/docs/changelog/91191.yaml
@@ -1,0 +1,5 @@
+pr: 91191
+summary: when using the /_cluster/allocation/explain api, it supports the request body to set only the index parameters
+area: cluster allocation explain api
+type: enhancement
+issues: []

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/allocation/ClusterAllocationExplainRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/allocation/ClusterAllocationExplainRequest.java
@@ -97,11 +97,13 @@ public class ClusterAllocationExplainRequest extends MasterNodeRequest<ClusterAl
             if (this.index == null) {
                 validationException = addValidationError("index must be specified", validationException);
             }
-            if (this.shard == null) {
-                validationException = addValidationError("shard must be specified", validationException);
-            }
-            if (this.primary == null) {
-                validationException = addValidationError("primary must be specified", validationException);
+            if (this.useIndexAnyUnassignedShard() == false) {
+                if (this.shard == null) {
+                    validationException = addValidationError("shard must be specified", validationException);
+                }
+                if (this.primary == null) {
+                    validationException = addValidationError("primary must be specified", validationException);
+                }
             }
         }
         return validationException;
@@ -113,6 +115,14 @@ public class ClusterAllocationExplainRequest extends MasterNodeRequest<ClusterAl
     public boolean useAnyUnassignedShard() {
         return this.index == null && this.shard == null && this.primary == null && this.currentNode == null;
     }
+
+    /**
+     * Returns {@code true} iff the index unassigned shard is to be used
+     */
+    public boolean useIndexAnyUnassignedShard() {
+        return this.index != null && this.shard == null && this.primary == null && this.currentNode == null;
+    }
+
 
     /**
      * Sets the index name of the shard to explain.
@@ -219,10 +229,12 @@ public class ClusterAllocationExplainRequest extends MasterNodeRequest<ClusterAl
             sb.append("useAnyUnassignedShard=true");
         } else {
             sb.append("index=").append(index);
-            sb.append(",shard=").append(shard);
-            sb.append(",primary?=").append(primary);
-            if (currentNode != null) {
-                sb.append(",currentNode=").append(currentNode);
+            if(this.useIndexAnyUnassignedShard()) {
+                sb.append(",shard=").append(shard);
+                sb.append(",primary?=").append(primary);
+                if (currentNode != null) {
+                    sb.append(",currentNode=").append(currentNode);
+                }
             }
         }
         sb.append(",includeYesDecisions?=").append(includeYesDecisions);

--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/allocation/ClusterAllocationExplainActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/allocation/ClusterAllocationExplainActionTests.java
@@ -196,6 +196,73 @@ public class ClusterAllocationExplainActionTests extends ESTestCase {
         );
     }
 
+    public void testFindIndexAnyUnassignedShardToExplain() {
+        // find unassigned primary
+        ClusterState clusterState = ClusterStateCreationUtils.state("idx", randomBoolean(), ShardRoutingState.UNASSIGNED);
+        ClusterAllocationExplainRequest request = new ClusterAllocationExplainRequest();
+        request.setIndex("idx");
+        ShardRouting shard = findShardToExplain(request, routingAllocation(clusterState));
+        assertEquals(clusterState.getRoutingTable().index("idx").shard(0).primaryShard(), shard);
+
+        // find unassigned replica
+        clusterState = ClusterStateCreationUtils.state("idx", randomBoolean(), ShardRoutingState.STARTED, ShardRoutingState.UNASSIGNED);
+        request = new ClusterAllocationExplainRequest();
+        request.setIndex("idx");
+        shard = findShardToExplain(request, routingAllocation(clusterState));
+        assertEquals(clusterState.getRoutingTable().index("idx").shard(0).replicaShards().get(0), shard);
+
+        // prefer unassigned primary to replica
+        clusterState = ClusterStateCreationUtils.stateWithAssignedPrimariesAndReplicas(new String[] { "idx1", "idx2" }, 1, 1);
+        final String redIndex = randomBoolean() ? "idx1" : "idx2";
+        final RoutingTable.Builder routingTableBuilder = RoutingTable.builder(clusterState.routingTable());
+        for (final IndexRoutingTable indexRoutingTable : clusterState.routingTable()) {
+            final IndexRoutingTable.Builder indexBuilder = new IndexRoutingTable.Builder(indexRoutingTable.getIndex());
+            for (int shardId = 0; shardId < indexRoutingTable.size(); shardId++) {
+                IndexShardRoutingTable indexShardRoutingTable = indexRoutingTable.shard(shardId);
+                final IndexShardRoutingTable.Builder shardBuilder = new IndexShardRoutingTable.Builder(indexShardRoutingTable.shardId());
+                for (int copy = 0; copy < indexShardRoutingTable.size(); copy++) {
+                    ShardRouting shardRouting = indexShardRoutingTable.shard(copy);
+                    if (shardRouting.primary() == false || indexRoutingTable.getIndex().getName().equals(redIndex)) {
+                        // move all replicas and one primary to unassigned
+                        shardBuilder.addShard(
+                            shardRouting.moveToUnassigned(new UnassignedInfo(UnassignedInfo.Reason.ALLOCATION_FAILED, "test"))
+                        );
+                    } else {
+                        shardBuilder.addShard(shardRouting);
+                    }
+                }
+                indexBuilder.addIndexShard(shardBuilder);
+            }
+            routingTableBuilder.add(indexBuilder);
+        }
+        clusterState = ClusterState.builder(clusterState).routingTable(routingTableBuilder.build()).build();
+        request = new ClusterAllocationExplainRequest();
+        request.setIndex(redIndex);
+        shard = findShardToExplain(request, routingAllocation(clusterState));
+        assertEquals(clusterState.getRoutingTable().index(redIndex).shard(0).primaryShard(), shard);
+
+        // no unassigned shard to explain
+        final ClusterState allStartedClusterState = ClusterStateCreationUtils.state(
+            "idx",
+            randomBoolean(),
+            ShardRoutingState.STARTED,
+            ShardRoutingState.STARTED
+        );
+        final ClusterAllocationExplainRequest anyUnassignedShardsRequest = new ClusterAllocationExplainRequest();
+        anyUnassignedShardsRequest.setIndex("idx");
+        assertThat(
+            expectThrows(
+                IllegalArgumentException.class,
+                () -> findShardToExplain(anyUnassignedShardsRequest, routingAllocation(allStartedClusterState))
+            ).getMessage(),
+            allOf(
+                // no point in asserting the precise wording of the message into this test, but we care that it contains these bits:
+                containsString("No shard was specified in the request"),
+                containsString("but there are no unassigned shards in index")
+            )
+        );
+    }
+
     public void testFindPrimaryShardToExplain() {
         ClusterState clusterState = ClusterStateCreationUtils.state("idx", randomBoolean(), randomFrom(ShardRoutingState.values()));
         ClusterAllocationExplainRequest request = new ClusterAllocationExplainRequest("idx", 0, true, null);


### PR DESCRIPTION
ignore the pr [91190](https://github.com/elastic/elasticsearch/pull/91190).  

https://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-allocation-explain.html
The index, shard and primary parameters need to be set together
```
GET _cluster/allocation/explain
{
  "index": "my-index-000001"
}
```
response       
```
{
  "error" : {
    "root_cause" : [
      {
        "type" : "action_request_validation_exception",
        "reason" : "Validation Failed: 1: shard must be specified;"
      }
    ],
    "type" : "action_request_validation_exception",
    "reason" : "Validation Failed: 1: shard must be specified;"
  },
  "status" : 400
}
```
reason.   

org.elasticsearch.action.admin.cluster.allocation.ClusterAllocationExplainRequest#validate
```
    @Override
    public ActionRequestValidationException validate() {
        ActionRequestValidationException validationException = null;
        if (this.useAnyUnassignedShard() == false) {
            if (this.index == null) {
                validationException = addValidationError("index must be specified", validationException);
            }
            if (this.shard == null) {
                validationException = addValidationError("shard must be specified", validationException);
            }
           if (this.primary == null) {
                 validationException = addValidationError("primary must be specified", validationException);
           }
        }
        return validationException;
    }
```
If we only want to view any shard of a specific index; What should we do?

