### PR TITLE
Added reference to terms_set query in regular terms query documentation

### DIFF
--- a/docs/reference/mapping/params/eager-global-ordinals.asciidoc
+++ b/docs/reference/mapping/params/eager-global-ordinals.asciidoc
@@ -45,8 +45,7 @@ The global ordinal mapping must be built before ordinals can be used during a
 search. By default, the mapping is loaded during search on the first time that
 global ordinals are needed. This is the right approach if you are optimizing
 for indexing speed, but if search performance is a priority, it's recommended
-to eagerly load global ordinals eagerly on fields that will be used in
-aggregations:
+to eagerly load global ordinals on fields that will be used in aggregations:
 
 [source,console]
 ------------

--- a/docs/reference/query-dsl/terms-query.asciidoc
+++ b/docs/reference/query-dsl/terms-query.asciidoc
@@ -7,8 +7,9 @@
 Returns documents that contain one or more *exact* terms in a provided field.
 
 The `terms` query is the same as the <<query-dsl-term-query, `term` query>>,
-except you can search for a match in multiple values. If you need more
-than one matching term at once, you may find <<query-dsl-terms-set-query, `terms_set` query>> useful.
+except you can search for multiple values. A document will match if it contains
+at least one of the terms. To search for documents that contain more than one
+matching term, use the <<query-dsl-terms-set-query, `terms_set` query>>.
 
 [[terms-query-ex-request]]
 ==== Example request

--- a/docs/reference/query-dsl/terms-query.asciidoc
+++ b/docs/reference/query-dsl/terms-query.asciidoc
@@ -7,7 +7,8 @@
 Returns documents that contain one or more *exact* terms in a provided field.
 
 The `terms` query is the same as the <<query-dsl-term-query, `term` query>>,
-except you can search for multiple values.
+except you can search for a match in multiple values. If you need more
+than one matching term at once, you may find <<query-dsl-terms-set-query, `terms_set` query>> useful.
 
 [[terms-query-ex-request]]
 ==== Example request


### PR DESCRIPTION
Just a tiny reference about alternative for `terms_set` query. If that's something against documentation standards - i don't see such cross-references much, may be there's a reason - feel free to just close, no sweat was shed here.

upd. additionally removed small stylistic issue