### PR TITLE
[DOCS] Fix typo in knn-search.asciidoc

### DIFF
--- a/docs/reference/search/knn-search.asciidoc
+++ b/docs/reference/search/knn-search.asciidoc
@@ -4,7 +4,7 @@
 <titleabbrev>kNN search</titleabbrev>
 ++++
 
-deprecated::[8.4.0,"The kNN search API has been replaced by the <<<<search-api-knn, `knn` option>> in the search API."]
+deprecated::[8.4.0,"The kNN search API has been replaced by the <<search-api-knn, `knn` option>> in the search API."]
 
 Performs a k-nearest neighbor (kNN) search and returns the matching documents.
 


### PR DESCRIPTION
This PR removes extra "<<" from https://www.elastic.co/guide/en/elasticsearch/reference/master/knn-search-api.html
