### PR TITLE
[main] Fix typo in stop-tokenfilter.asciidoc (#91128)

### DIFF
--- a/docs/reference/analysis/tokenfilters/stop-tokenfilter.asciidoc
+++ b/docs/reference/analysis/tokenfilters/stop-tokenfilter.asciidoc
@@ -203,7 +203,7 @@ PUT /my-index-000001
 ----
 
 You can also specify your own list of stop words. For example, the following
-request creates a custom case-sensitive `stop` filter that removes only the stop
+request creates a custom case-insensitive `stop` filter that removes only the stop
 words `and`, `is`, and `the`:
 
 [source,console]


### PR DESCRIPTION
# Backport

This will backport the following commits from `8.4` to `main`:
 - [Fix typo in stop-tokenfilter.asciidoc (#91128)](https://github.com/elastic/elasticsearch/pull/91128)

<!--- Backport version: 8.9.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)