### PR TITLE
Enable debug log to debug test failure

### DIFF
--- a/x-pack/plugin/autoscaling/src/internalClusterTest/java/org/elasticsearch/xpack/autoscaling/storage/ReactiveStorageIT.java
+++ b/x-pack/plugin/autoscaling/src/internalClusterTest/java/org/elasticsearch/xpack/autoscaling/storage/ReactiveStorageIT.java
@@ -23,6 +23,7 @@ import org.elasticsearch.core.Tuple;
 import org.elasticsearch.node.Node;
 import org.elasticsearch.test.ESIntegTestCase;
 import org.elasticsearch.test.NodeRoles;
+import org.elasticsearch.test.junit.annotations.TestLogging;
 import org.elasticsearch.transport.TransportService;
 import org.elasticsearch.xpack.autoscaling.action.GetAutoscalingCapacityAction;
 import org.elasticsearch.xpack.autoscaling.action.PutAutoscalingPolicyAction;
@@ -230,7 +231,7 @@ public class ReactiveStorageIT extends AutoscalingStorageIntegTestCase {
         );
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/91083")
+    @TestLogging(value = "org.elasticsearch.monitor.fs.FsService:DEBUG", reason = "https://github.com/elastic/elasticsearch/issues/91083")
     public void testScaleWhileShrinking() throws Exception {
         internalCluster().startMasterOnlyNode();
         final String dataNode1Name = internalCluster().startDataOnlyNode();


### PR DESCRIPTION
According to the test logs we have:
```
[2022-10-24T10:15:26,448][WARN ][o.e.c.DiskUsage] [node_t0] node [node_t2/3myYimW4StelbhrqXJHMBA] did not return any filesystem stats |  
[2022-10-24T10:15:26,448][WARN ][o.e.c.DiskUsage] [node_t0] node [node_t2/3myYimW4StelbhrqXJHMBA] did not return any filesystem stats
```

Similarly to https://github.com/elastic/elasticsearch/pull/90865 I suspect that it could be caused by unexpected IOException that is converted to null at 
https://github.com/elastic/elasticsearch/blob/12ad399c488f0cc60e19b5e1b29c6d569cb4351a/server/src/main/java/org/elasticsearch/monitor/fs/FsService.java#L70-L77

This change enables the logs so that we could see the cause(s) for the failure and address them. 

Related: #91083