### PR TITLE
[DOCS] Semantic search endpoint

### DIFF
--- a/docs/reference/search.asciidoc
+++ b/docs/reference/search.asciidoc
@@ -19,6 +19,7 @@ exception of the <<search-explain,explain API>>.
 * <<search-terms-enum>>
 * <<scroll-api>>
 * <<clear-scroll-api>>
+* <<semantic-search-api>>
 
 [discrete]
 [[search-testing-apis]]
@@ -51,6 +52,8 @@ include::search/async-search.asciidoc[]
 include::search/point-in-time-api.asciidoc[]
 
 include::search/knn-search.asciidoc[]
+
+include::search/semantic-search.asciidoc[]
 
 include::search/scroll-api.asciidoc[]
 

--- a/docs/reference/search/search.asciidoc
+++ b/docs/reference/search/search.asciidoc
@@ -246,7 +246,7 @@ By default, you cannot page through more than 10,000 hits using the `from` and
 (Optional)
 Indicates which <<mapping-source-field,source fields>> are returned for matching
 documents. These fields are returned in the `hits._source` property of
-the search response. Defaults to `true`. See <<source-filtering>>.
+the search response. Defaults to `true`. See <<source-filtering,source filtering>>.
 +
 .Valid values for `_source`
 [%collapsible%open]
@@ -641,7 +641,7 @@ By default, you cannot page through more than 10,000 hits using the `from` and
 (Optional)
 Indicates which <<mapping-source-field,source fields>> are returned for matching
 documents. These fields are returned in the `hits._source` property of
-the search response. Defaults to `true`. See <<source-filtering>>.
+the search response. Defaults to `true`. See <<source-filtering,source filtering>>.
 +
 .Valid values for `_source`
 [%collapsible%open]

--- a/docs/reference/search/search.asciidoc
+++ b/docs/reference/search/search.asciidoc
@@ -383,7 +383,7 @@ Array of field patterns. The request returns values for field names matching
 these patterns in the `hits.fields` property of the response.
 +
 You can specify items in the array as a string or object. See
-<<search-fields-param>>.
+<<search-fields-param,the `fields` option>>.
 +
 .Properties of `fields` objects
 [%collapsible%open]

--- a/docs/reference/search/semantic-search.asciidoc
+++ b/docs/reference/search/semantic-search.asciidoc
@@ -1,4 +1,4 @@
-[[knn-search-api]]
+[[semantic-search-api]]
 === Semantic search API
 ++++
 <titleabbrev>Semantic search</titleabbrev>

--- a/docs/reference/search/semantic-search.asciidoc
+++ b/docs/reference/search/semantic-search.asciidoc
@@ -59,14 +59,14 @@ GET my-index/_semantic_search
 <<privileges-list-indices,index privilege>> for the target data stream, index,
 or alias.
 
-[[Semantic-search-api-desc]]
+[[semantic-search-api-desc]]
 ==== {api-description-title}
 
-The Semantic search API uses a text embedding model to create a dense vector
+The semantic search API uses a text embedding model to create a dense vector
 representation of the query string.
 
 
-[[Semantic-search-api-path-params]]
+[[semantic-search-api-path-params]]
 ==== {api-path-parms-title}
 
 `<target>`::
@@ -75,7 +75,7 @@ to search. Supports wildcards (`*`). To search all data streams and indices,
 use `*` or `_all`.
 
 [role="child_attributes"]
-[[Semantic-search-api-query-params]]
+[[semantic-search-api-query-params]]
 ==== {api-query-parms-title}
 
 include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=routing]
@@ -89,7 +89,7 @@ include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=routing]
 include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=model-id]
 
 `query_string`::
-(Required, string) The input text to embed
+(Required, string) The input text to embed.
 
 `knn`::
 (Required, object) Defines the kNN query to run.

--- a/docs/reference/search/semantic-search.asciidoc
+++ b/docs/reference/search/semantic-search.asciidoc
@@ -6,7 +6,7 @@
 
 experimental::[]
 Semantic search uses a text embedding NLP model to generate a dense vector from the input query string.
-The resulting dense vector is then used in a <Knn Search> against an index containing dense vectors
+The resulting dense vector is then used in a <<knn-search,k-nearest neighbor (knn) search>> against an index containing dense vectors
 created with the same text embedding model. The search results are semantically similar as learned
 by the model.
 


### PR DESCRIPTION
A semantic-search.asciidoc file was created in https://github.com/elastic/elasticsearch/pull/90450, however it was not included in the navigation and so was not yet published.

This PR addresses that omission and fixes some minor typos.

### Preview

https://elasticsearch_91210.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/semantic-search-api.html