### PR TITLE
[8.5] [DOCS] Fix typo in knn-search.asciidoc (#91206)

### DIFF
--- a/docs/reference/search/knn-search.asciidoc
+++ b/docs/reference/search/knn-search.asciidoc
@@ -4,8 +4,8 @@
 <titleabbrev>kNN search</titleabbrev>
 ++++
 
-deprecated::[8.4.0,"The kNN search API has been replaced by the <<<<search-api-knn, `knn` option>> in the search API."]
-experimental::[]
+deprecated::[8.4.0,"The kNN search API has been replaced by the <<search-api-knn, `knn` option>> in the search API."]
+
 Performs a k-nearest neighbor (kNN) search and returns the matching documents.
 
 ////

--- a/docs/reference/search/knn-search.asciidoc
+++ b/docs/reference/search/knn-search.asciidoc
@@ -5,7 +5,6 @@
 ++++
 
 deprecated::[8.4.0,"The kNN search API has been replaced by the <<search-api-knn,`knn` option>> in the search API."]
-experimental::[]
 
 Performs a k-nearest neighbor (kNN) search and returns the matching documents.
 

--- a/docs/reference/search/knn-search.asciidoc
+++ b/docs/reference/search/knn-search.asciidoc
@@ -4,7 +4,7 @@
 <titleabbrev>kNN search</titleabbrev>
 ++++
 
-deprecated::[8.4.0,"The kNN search API has been replaced by the <<search-api-knn, `knn` option>> in the search API."]
+deprecated::[8.4.0,"The kNN search API has been replaced by the <<search-api-knn,`knn` option>> in the search API."]
 experimental::[]
 Performs a k-nearest neighbor (kNN) search and returns the matching documents.
 

--- a/docs/reference/search/knn-search.asciidoc
+++ b/docs/reference/search/knn-search.asciidoc
@@ -5,7 +5,7 @@
 ++++
 
 deprecated::[8.4.0,"The kNN search API has been replaced by the <<search-api-knn, `knn` option>> in the search API."]
-
+experimental::[]
 Performs a k-nearest neighbor (kNN) search and returns the matching documents.
 
 ////


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.5`:
 - [[DOCS] Fix typo in knn-search.asciidoc (#91206)](https://github.com/elastic/elasticsearch/pull/91206)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)