### PR TITLE
2 snapshot threads for large blob test

### DIFF
--- a/x-pack/plugin/snapshot-repo-test-kit/qa/rest/build.gradle
+++ b/x-pack/plugin/snapshot-repo-test-kit/qa/rest/build.gradle
@@ -16,6 +16,7 @@ testClusters.matching { it.name == "yamlRestTest" }.configureEach {
   testDistribution = 'DEFAULT'
   setting 'path.repo', repoDir.absolutePath
   setting 'xpack.security.enabled', 'false'
+  setting 'thread_pool.snapshot.max', '2'
 }
 
 tasks.named('yamlRestTestTestingConventions').configure {


### PR DESCRIPTION
In 8.5, the default snapshot thread pool has 1 thread when the "Timeout with large blobs" runs with the
-Dtests.configure_test_clusters_with_one_processor=true pipeline. This makes the 1sec timeout response to never be sent out (because the 1 thread is busy with the slow blob), while with 2 threads it can be sent out.

Fixes #90353 
