### PR TITLE
Fix wrong test assertion which was introduced after refactoring

### DIFF
--- a/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/xpack/security/authc/TokenAuthIntegTests.java
+++ b/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/xpack/security/authc/TokenAuthIntegTests.java
@@ -186,7 +186,7 @@ public class TokenAuthIntegTests extends SecurityIntegTestCase {
                 }
                 """);
             Response searchResponse = getRestClient().performRequest(searchRequest);
-            assertThat(ObjectPath.createFromResponse(searchResponse).evaluate("hits.total.value"), equalTo(1));
+            assertThat(ObjectPath.createFromResponse(searchResponse).evaluate("hits.total.value"), equalTo(0));
         }, 30, TimeUnit.SECONDS);
 
         // Weird testing behaviour ahead...


### PR DESCRIPTION
Fixes a mistake which was introduced in https://github.com/elastic/elasticsearch/pull/91088

Original test code was expecting 0 results:

```
assertThat(searchResponse.getHits().getTotalHits().value, equalTo(0L));
```

Closes https://github.com/elastic/elasticsearch/issues/91225