### PR TITLE
[Docs] Remove feature flag from downsampling page

### DIFF
--- a/docs/reference/data-streams/downsampling.asciidoc
+++ b/docs/reference/data-streams/downsampling.asciidoc
@@ -1,4 +1,3 @@
-ifeval::["{release-state}"=="unreleased"]
 [[downsampling]]
 === Downsampling a time series data stream
 
@@ -175,5 +174,3 @@ To take downsampling for a test run, try our example of
 
 Downsampling can easily be added to your ILM policy. To learn how, try our
 <<downsampling-ilm,Run downsampling with ILM>> example.
-
-endif::[]


### PR DESCRIPTION
This removes a feature flag from the Downsampling docs page, that is currently causing a docs build failure.