### PR TITLE
[8.5] [Docs] Remove feature flag from downsampling page (#91228)

### DIFF
--- a/docs/reference/data-streams/downsampling.asciidoc
+++ b/docs/reference/data-streams/downsampling.asciidoc
@@ -1,4 +1,3 @@
-ifeval::["{release-state}"=="unreleased"]
 [[downsampling]]
 === Downsampling a time series data stream
 
@@ -175,5 +174,3 @@ To take downsampling for a test run, try our example of
 
 Downsampling can easily be added to your ILM policy. To learn how, try our
 <<downsampling-ilm,Run downsampling with ILM>> example.
-
-endif::[]


### PR DESCRIPTION
Backports the following commits to 8.5:
 - [Docs] Remove feature flag from downsampling page (#91228)