### PR TITLE
Ensure PKI's delegated_by_realm metadata respect run-as (#91173)

### DIFF
--- a/docs/changelog/91173.yaml
+++ b/docs/changelog/91173.yaml
@@ -1,0 +1,5 @@
+pr: 91173
+summary: Ensure PKI's `delegated_by_realm` metadata respect run-as
+area: Authentication
+type: bug
+issues: []

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/pki/PkiRealm.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/pki/PkiRealm.java
@@ -214,7 +214,7 @@ public class PkiRealm extends Realm implements CachingRealm {
                 "pki_delegated_by_user",
                 token.getDelegateeAuthentication().getUser().principal(),
                 "pki_delegated_by_realm",
-                token.getDelegateeAuthentication().getAuthenticatedBy().getName()
+                token.getDelegateeAuthentication().getEffectiveSubject().getRealm().getName()
             );
         } else {
             metadata = Map.of("pki_dn", token.dn());


### PR DESCRIPTION
When delegated PKI authentication is used, the delegatee's realm name is added as a metadata field. This realm name should be the effective subject's realm instead of that of the authenticating subject. This PR ensures this is the case.

Backport: #91173