### PR TITLE
More actionable error for ancient indices

### DIFF
--- a/docs/changelog/91243.yaml
+++ b/docs/changelog/91243.yaml
@@ -1,0 +1,5 @@
+pr: 91243
+summary: More actionable error for ancient indices
+area: Infra/Core
+type: enhancement
+issues: []

--- a/server/src/main/java/org/elasticsearch/env/NodeEnvironment.java
+++ b/server/src/main/java/org/elasticsearch/env/NodeEnvironment.java
@@ -519,7 +519,7 @@ public final class NodeEnvironment implements Closeable {
             throw new IllegalStateException(
                 "Cannot start this node because it holds metadata for indices created with version ["
                     + metadata.oldestIndexVersion()
-                    + "] with which a node of version ["
+                    + "] with which this node of version ["
                     + Version.CURRENT
                     + "] is incompatible. Revert this node to version ["
                     + Version.max(Version.CURRENT.minimumCompatibilityVersion(), metadata.previousNodeVersion())

--- a/server/src/main/java/org/elasticsearch/env/NodeEnvironment.java
+++ b/server/src/main/java/org/elasticsearch/env/NodeEnvironment.java
@@ -519,7 +519,7 @@ public final class NodeEnvironment implements Closeable {
             throw new IllegalStateException(
                 "Cannot start this node because it holds metadata for indices created with version ["
                     + metadata.oldestIndexVersion()
-                    + "] which which a node of version ["
+                    + "] with which a node of version ["
                     + Version.CURRENT
                     + "] is incompatible. Revert this node to version ["
                     + Version.max(Version.CURRENT.minimumCompatibilityVersion(), metadata.previousNodeVersion())

--- a/server/src/main/java/org/elasticsearch/env/NodeEnvironment.java
+++ b/server/src/main/java/org/elasticsearch/env/NodeEnvironment.java
@@ -495,9 +495,6 @@ public final class NodeEnvironment implements Closeable {
     /**
      * Checks to see if we can upgrade to this version based on the existing index state. Upgrading
      * from older versions can cause irreversible changes if allowed.
-     * @param logger
-     * @param dataPaths
-     * @throws IOException
      */
     static void checkForIndexCompatibility(Logger logger, DataPath... dataPaths) throws IOException {
         final Path[] paths = Arrays.stream(dataPaths).map(np -> np.path).toArray(Path[]::new);
@@ -520,14 +517,19 @@ public final class NodeEnvironment implements Closeable {
 
         if (metadata.oldestIndexVersion().isLegacyIndexVersion()) {
             throw new IllegalStateException(
-                "cannot upgrade node because incompatible indices created with version ["
+                "Cannot start this node because it holds metadata for indices created with version ["
                     + metadata.oldestIndexVersion()
-                    + "] exist, while the minimum compatible index version is ["
+                    + "] which which a node of version ["
+                    + Version.CURRENT
+                    + "] is incompatible. Revert this node to version ["
+                    + Version.max(Version.CURRENT.minimumCompatibilityVersion(), metadata.previousNodeVersion())
+                    + "] and delete any indices created in versions earlier than ["
                     + Version.CURRENT.minimumIndexCompatibilityVersion()
-                    + "]. "
-                    + "Upgrade your older indices by reindexing them in version ["
-                    + Version.CURRENT.minimumCompatibilityVersion()
-                    + "] first."
+                    + "] before upgrading to version ["
+                    + Version.CURRENT
+                    + "]. If all such indices have already been deleted, revert this node to version ["
+                    + Version.max(Version.CURRENT.minimumCompatibilityVersion(), metadata.previousNodeVersion())
+                    + "] and wait for it to join the cluster to clean up any older indices from its metadata."
             );
         }
     }


### PR DESCRIPTION
We've had a few reports of failed upgrades caused by deleting the last ancient index just before stopping the first node, which may not have allowed enough time for the deletion to complete. Today the resulting error message doesn't say how to address this, which leaves users struggling mid-upgrade. This commit makes the error message more actionable.