### PR TITLE
Echo test fixture docker logs for info/debug log levels

### DIFF
--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/testfixtures/TestFixturesPlugin.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/testfixtures/TestFixturesPlugin.java
@@ -25,6 +25,7 @@ import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.api.Task;
 import org.gradle.api.file.FileSystemOperations;
+import org.gradle.api.logging.LogLevel;
 import org.gradle.api.logging.Logger;
 import org.gradle.api.logging.Logging;
 import org.gradle.api.plugins.BasePlugin;
@@ -40,6 +41,7 @@ import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.nio.file.Files;
 import java.util.Collections;
+import java.util.EnumSet;
 import java.util.function.BiConsumer;
 
 import javax.inject.Inject;
@@ -117,6 +119,8 @@ public class TestFixturesPlugin implements Plugin<Project> {
             ComposeExtension composeExtension = project.getExtensions().getByType(ComposeExtension.class);
             composeExtension.getUseComposeFiles().addAll(Collections.singletonList(DOCKER_COMPOSE_YML));
             composeExtension.getRemoveContainers().set(true);
+            composeExtension.getCaptureContainersOutput()
+                .set(EnumSet.of(LogLevel.INFO, LogLevel.DEBUG).contains(project.getGradle().getStartParameter().getLogLevel()));
             composeExtension.getExecutable().set(this.providerFactory.provider(() -> {
                 String composePath = dockerSupport.get().getDockerAvailability().dockerComposePath();
                 LOGGER.debug("Docker Compose path: {}", composePath);

--- a/x-pack/test/idp-fixture/build.gradle
+++ b/x-pack/test/idp-fixture/build.gradle
@@ -5,10 +5,6 @@ import static org.elasticsearch.gradle.internal.distribution.InternalElasticsear
 apply plugin: 'elasticsearch.test.fixtures'
 apply plugin: 'elasticsearch.internal-distribution-download'
 
-dockerCompose {
-  captureContainersOutput = EnumSet.of(LogLevel.INFO, LogLevel.DEBUG).contains(gradle.startParameter.logLevel)
-}
-
 tasks.register("copyKeystore", Sync) {
   from project(':x-pack:plugin:core')
     .file('src/test/resources/org/elasticsearch/xpack/security/transport/ssl/certs/simple/testnode.jks')

--- a/x-pack/test/idp-fixture/build.gradle
+++ b/x-pack/test/idp-fixture/build.gradle
@@ -5,6 +5,10 @@ import static org.elasticsearch.gradle.internal.distribution.InternalElasticsear
 apply plugin: 'elasticsearch.test.fixtures'
 apply plugin: 'elasticsearch.internal-distribution-download'
 
+dockerCompose {
+  captureContainersOutput = EnumSet.of(LogLevel.INFO, LogLevel.DEBUG).contains(gradle.startParameter.logLevel)
+}
+
 tasks.register("copyKeystore", Sync) {
   from project(':x-pack:plugin:core')
     .file('src/test/resources/org/elasticsearch/xpack/security/transport/ssl/certs/simple/testnode.jks')


### PR DESCRIPTION
This is to help with troubleshooting. Alternatively I can enable this only for the test fixture project I care about. 

relevant doc: https://github.com/avast/gradle-docker-compose-plugin 