### PR TITLE
[8.5] Update move-to-step.asciidoc (#91114)

### DIFF
--- a/docs/reference/ilm/apis/move-to-step.asciidoc
+++ b/docs/reference/ilm/apis/move-to-step.asciidoc
@@ -95,11 +95,11 @@ For more information, see <<index-lifecycle-error-handling, {ilm-init} error han
 The name of the phase that contains the action you want to perform or resume.
 
 `action`::
-(Required, string)
+(Optional, string)
 The name action you want to perform or resume. 
 
 `name`::
-(Required, string)
+(Optional, string)
 The name of the step to move to and execute. 
 
 ====


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.5`:
 - [Update move-to-step.asciidoc (#91114)](https://github.com/elastic/elasticsearch/pull/91114)

<!--- Backport version: 8.9.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)