### PR TITLE
[Transform] fix rounding issue in transform health test

### DIFF
--- a/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/TransformHealthCheckerTests.java
+++ b/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/TransformHealthCheckerTests.java
@@ -16,6 +16,7 @@ import org.elasticsearch.xpack.core.transform.transforms.TransformState;
 import org.elasticsearch.xpack.core.transform.transforms.TransformTaskState;
 
 import java.time.Instant;
+import java.time.temporal.ChronoUnit;
 
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
@@ -37,7 +38,7 @@ public class TransformHealthCheckerTests extends ESTestCase {
     public void testPersistenceFailure() {
         TransformTask task = mock(TransformTask.class);
         TransformContext context = createTestContext();
-        Instant now = Instant.now();
+        Instant now = getNow();
 
         withIdStateAndContext(task, randomAlphaOfLength(10), context);
         assertThat(TransformHealthChecker.checkTransform(task), equalTo(TransformHealth.GREEN));
@@ -58,7 +59,7 @@ public class TransformHealthCheckerTests extends ESTestCase {
     public void testStatusSwitchingAndMultipleFailures() {
         TransformTask task = mock(TransformTask.class);
         TransformContext context = createTestContext();
-        Instant now = Instant.now();
+        Instant now = getNow();
 
         withIdStateAndContext(task, randomAlphaOfLength(10), context);
         assertThat(TransformHealthChecker.checkTransform(task), equalTo(TransformHealth.GREEN));
@@ -103,6 +104,10 @@ public class TransformHealthCheckerTests extends ESTestCase {
 
     private TransformContext createTestContext() {
         return new TransformContext(TransformTaskState.STARTED, "", 0, mock(TransformContext.Listener.class));
+    }
+
+    private static Instant getNow() {
+        return Instant.now().truncatedTo(ChronoUnit.MILLIS);
     }
 
     private static void withIdStateAndContext(TransformTask task, String transformId, TransformContext context) {


### PR DESCRIPTION
transform health rounds down to milliseconds, this decision hasn't been reflected in the unit tests

fixes #91129

Notes: 
 - rounding happens here: https://github.com/elastic/elasticsearch/blob/82a71f6ef62766bb718452f098a4cf1b41b17b37/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/transforms/TransformHealthIssue.java#L42