### PR TITLE
[POC] resolve cluster alias in security interceptor

### DIFF
--- a/server/src/main/java/org/elasticsearch/client/internal/Client.java
+++ b/server/src/main/java/org/elasticsearch/client/internal/Client.java
@@ -56,6 +56,7 @@ import org.elasticsearch.common.settings.Setting.Property;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.core.Releasable;
+import org.elasticsearch.transport.Transport;
 
 import java.util.Map;
 
@@ -425,6 +426,10 @@ public interface Client extends ElasticsearchClient, Releasable {
      * @throws UnsupportedOperationException if this functionality is not available on this client.
      */
     default Client getRemoteClusterClient(String clusterAlias) {
+        throw new UnsupportedOperationException("this client doesn't support remote cluster connections");
+    }
+
+    default String getRemoteClusterAliasForConnection(Transport.Connection connection) {
         throw new UnsupportedOperationException("this client doesn't support remote cluster connections");
     }
 }

--- a/server/src/main/java/org/elasticsearch/client/internal/node/NodeClient.java
+++ b/server/src/main/java/org/elasticsearch/client/internal/node/NodeClient.java
@@ -148,6 +148,11 @@ public class NodeClient extends AbstractClient {
         return remoteClusterService.getRemoteClusterClient(threadPool(), clusterAlias, true);
     }
 
+    @Override
+    public String getRemoteClusterAliasForConnection(Transport.Connection connection) {
+        return remoteClusterService.getRemoteClusterAliasForConnection(connection);
+    }
+
     public NamedWriteableRegistry getNamedWriteableRegistry() {
         return namedWriteableRegistry;
     }

--- a/server/src/main/java/org/elasticsearch/transport/RemoteClusterAwareClient.java
+++ b/server/src/main/java/org/elasticsearch/transport/RemoteClusterAwareClient.java
@@ -88,4 +88,9 @@ final class RemoteClusterAwareClient extends AbstractClient {
     public Client getRemoteClusterClient(String remoteClusterAlias) {
         return remoteClusterService.getRemoteClusterClient(threadPool(), remoteClusterAlias);
     }
+
+    @Override
+    public String getRemoteClusterAliasForConnection(Transport.Connection connection) {
+        return remoteClusterService.getRemoteClusterAliasForConnection(connection);
+    }
 }

--- a/server/src/main/java/org/elasticsearch/transport/RemoteClusterService.java
+++ b/server/src/main/java/org/elasticsearch/transport/RemoteClusterService.java
@@ -368,6 +368,14 @@ public final class RemoteClusterService extends RemoteClusterAware implements Cl
         return remoteClusters.values().stream().map(RemoteClusterConnection::getConnectionInfo);
     }
 
+    public String getRemoteClusterAliasForConnection(Transport.Connection connection) {
+        return getConnections().stream()
+            .filter(rcc -> rcc.getConnection(connection.getNode()) == connection)
+            .map(rcc -> rcc.getConnectionInfo().getClusterAlias())
+            .findFirst()
+            .orElse(null);
+    }
+
     /**
      * Collects all nodes of the given clusters and returns / passes a (clusterAlias, nodeId) to {@link DiscoveryNode}
      * function on success.

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/Security.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/Security.java
@@ -906,7 +906,8 @@ public class Security extends Plugin
                 authzService,
                 getSslService(),
                 securityContext.get(),
-                destructiveOperations
+                destructiveOperations,
+                client
             )
         );
 


### PR DESCRIPTION
This PR shows how we can use `NodeClient` to resolve a cluster alias for a given transport connection, inside `SecurityServerTransportInterceptor`. This is just a proof of concept, and I'm no intending to merge it. Thank you @ywangd for the idea.