### PR TITLE
Use String.equals(obj) when the LHS or RHS of == is known to be String

### DIFF
--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/WriterConstants.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/WriterConstants.java
@@ -46,6 +46,8 @@ public final class WriterConstants {
 
     public static final Type OBJECT_TYPE = Type.getType(Object.class);
 
+    public static final Method OBJECT_EQUALS = getAsmMethod(boolean.class, "equals", Object.class);
+
     public static final MethodType NEEDS_PARAMETER_METHOD_TYPE = MethodType.methodType(boolean.class);
 
     public static final Type ITERATOR_TYPE = Type.getType(Iterator.class);

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/phase/DefaultIRTreeToASMBytesPhase.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/phase/DefaultIRTreeToASMBytesPhase.java
@@ -1031,13 +1031,11 @@ public class DefaultIRTreeToASMBytesPhase implements IRTreeVisitor<WriteScope> {
                         // if one of the types is a String, can use String.equals here
                         if (irLeftNode.getDecorationValue(IRDExpressionType.class) == String.class) {
                             methodWriter.invokeVirtual(STRING_TYPE, OBJECT_EQUALS);
-                        }
-                        else if (irRightNode.getDecorationValue(IRDExpressionType.class) == String.class) {
+                        } else if (irRightNode.getDecorationValue(IRDExpressionType.class) == String.class) {
                             // swap the args to call equals on right object
                             methodWriter.swap();
                             methodWriter.invokeVirtual(STRING_TYPE, OBJECT_EQUALS);
-                        }
-                        else {
+                        } else {
                             methodWriter.invokeDefCall("eq", descriptor, DefBootstrap.BINARY_OPERATOR, DefBootstrap.OPERATOR_ALLOWS_NULL);
                         }
                         writejump = false;
@@ -1051,13 +1049,11 @@ public class DefaultIRTreeToASMBytesPhase implements IRTreeVisitor<WriteScope> {
                         // if one of the types is a String, can use String.equals here
                         if (irLeftNode.getDecorationValue(IRDExpressionType.class) == String.class) {
                             methodWriter.invokeVirtual(STRING_TYPE, OBJECT_EQUALS);
-                        }
-                        else if (irRightNode.getDecorationValue(IRDExpressionType.class) == String.class) {
+                        } else if (irRightNode.getDecorationValue(IRDExpressionType.class) == String.class) {
                             // swap the args to call equals on right object
                             methodWriter.swap();
                             methodWriter.invokeVirtual(STRING_TYPE, OBJECT_EQUALS);
-                        }
-                        else {
+                        } else {
                             methodWriter.invokeDefCall("eq", descriptor, DefBootstrap.BINARY_OPERATOR, DefBootstrap.OPERATOR_ALLOWS_NULL);
                         }
                         methodWriter.ifZCmp(MethodWriter.EQ, jump);

--- a/modules/lang-painless/src/test/java/org/elasticsearch/painless/ComparisonTests.java
+++ b/modules/lang-painless/src/test/java/org/elasticsearch/painless/ComparisonTests.java
@@ -63,6 +63,7 @@ public class ComparisonTests extends ScriptTestCase {
         assertEquals(true, exec("boolean x = true; def y = true; return x == y"));
         assertEquals(true, exec("boolean x = false; def y = false; return x == y"));
 
+        assertEquals(true, exec("String x = \"foo\"; def y = \"foo\"; return x == y"));
         assertEquals(true, exec("Map x = new HashMap(); def y = new HashMap(); return x == y"));
         assertEquals(false, exec("Map x = new HashMap(); x.put(3, 3); def y = new HashMap(); return x == y"));
         assertEquals(true, exec("Map x = new HashMap(); x.put(3, 3); def y = new HashMap(); y.put(3, 3); return x == y"));
@@ -92,6 +93,7 @@ public class ComparisonTests extends ScriptTestCase {
         assertEquals(true, exec("def x = true; boolean y = true; return x == y"));
         assertEquals(true, exec("def x = false; boolean y = false; return x == y"));
 
+        assertEquals(true, exec("def x = \"foo\"; String y = \"foo\"; return x == y"));
         assertEquals(true, exec("def x = new HashMap(); Map y = new HashMap(); return x == y"));
         assertEquals(false, exec("def x = new HashMap(); x.put(3, 3); Map y = new HashMap(); return x == y"));
         assertEquals(true, exec("def x = new HashMap(); x.put(3, 3); Map y = new HashMap(); y.put(3, 3); return x == y"));
@@ -159,6 +161,7 @@ public class ComparisonTests extends ScriptTestCase {
         assertEquals(true, exec("float x = (float)6; def y = (double)2; return x != y"));
         assertEquals(true, exec("double x = (double)7; def y = (double)1; return x != y"));
 
+        assertEquals(false, exec("String x = \"foo\"; def y = \"foo\"; return x != y"));
         assertEquals(false, exec("Map x = new HashMap(); def y = new HashMap(); return x != y"));
         assertEquals(true, exec("Map x = new HashMap(); x.put(3, 3); def y = new HashMap(); return x != y"));
         assertEquals(false, exec("Map x = new HashMap(); x.put(3, 3); def y = new HashMap(); y.put(3, 3); return x != y"));
@@ -187,6 +190,7 @@ public class ComparisonTests extends ScriptTestCase {
         assertEquals(true, exec("def x = (float)6; double y = (double)2; return x != y"));
         assertEquals(true, exec("def x = (double)7; double y = (double)1; return x != y"));
 
+        assertEquals(false, exec("def x = \"foo\"; String y = \"foo\"; return x != y"));
         assertEquals(false, exec("def x = new HashMap(); Map y = new HashMap(); return x != y"));
         assertEquals(true, exec("def x = new HashMap(); x.put(3, 3); Map y = new HashMap(); return x != y"));
         assertEquals(false, exec("def x = new HashMap(); x.put(3, 3); Map y = new HashMap(); y.put(3, 3); return x != y"));

--- a/modules/lang-painless/src/test/java/org/elasticsearch/painless/ComparisonTests.java
+++ b/modules/lang-painless/src/test/java/org/elasticsearch/painless/ComparisonTests.java
@@ -64,10 +64,12 @@ public class ComparisonTests extends ScriptTestCase {
         assertEquals(true, exec("boolean x = false; def y = false; return x == y"));
 
         assertEquals(true, exec("String x = \"foo\"; def y = \"foo\"; return x == y"));
+        assertEquals(false, exec("def x = null; return x == 'foo'"));
         assertEquals(true, exec("Map x = new HashMap(); def y = new HashMap(); return x == y"));
         assertEquals(false, exec("Map x = new HashMap(); x.put(3, 3); def y = new HashMap(); return x == y"));
         assertEquals(true, exec("Map x = new HashMap(); x.put(3, 3); def y = new HashMap(); y.put(3, 3); return x == y"));
         assertEquals(true, exec("Map x = new HashMap(); def y = x; x.put(3, 3); y.put(3, 3); return x == y"));
+
     }
 
     public void testDefEqTypedRHS() {
@@ -162,6 +164,7 @@ public class ComparisonTests extends ScriptTestCase {
         assertEquals(true, exec("double x = (double)7; def y = (double)1; return x != y"));
 
         assertEquals(false, exec("String x = \"foo\"; def y = \"foo\"; return x != y"));
+        assertEquals(true, exec("def x = null; return x != 'foo'"));
         assertEquals(false, exec("Map x = new HashMap(); def y = new HashMap(); return x != y"));
         assertEquals(true, exec("Map x = new HashMap(); x.put(3, 3); def y = new HashMap(); return x != y"));
         assertEquals(false, exec("Map x = new HashMap(); x.put(3, 3); def y = new HashMap(); y.put(3, 3); return x != y"));


### PR DESCRIPTION
PR for issue #91235