### PR TITLE
Prevent unnecessary map copying

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/ClusterInfoSimulator.java
+++ b/server/src/main/java/org/elasticsearch/cluster/ClusterInfoSimulator.java
@@ -27,8 +27,8 @@ public class ClusterInfoSimulator {
         this.leastAvailableSpaceUsage = new HashMap<>(clusterInfo.getNodeLeastAvailableDiskUsages());
         this.mostAvailableSpaceUsage = new HashMap<>(clusterInfo.getNodeMostAvailableDiskUsages());
         this.shardSizes = new HashMap<>(clusterInfo.shardSizes);
-        this.shardDataSetSizes = clusterInfo.shardDataSetSizes;
-        this.dataPath = clusterInfo.dataPath;
+        this.shardDataSetSizes = Map.copyOf(clusterInfo.shardDataSetSizes);
+        this.dataPath = Map.copyOf(clusterInfo.dataPath);
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/cluster/ClusterInfoSimulator.java
+++ b/server/src/main/java/org/elasticsearch/cluster/ClusterInfoSimulator.java
@@ -27,8 +27,8 @@ public class ClusterInfoSimulator {
         this.leastAvailableSpaceUsage = new HashMap<>(clusterInfo.getNodeLeastAvailableDiskUsages());
         this.mostAvailableSpaceUsage = new HashMap<>(clusterInfo.getNodeMostAvailableDiskUsages());
         this.shardSizes = new HashMap<>(clusterInfo.shardSizes);
-        this.shardDataSetSizes = new HashMap<>(clusterInfo.shardDataSetSizes);
-        this.dataPath = new HashMap<>(clusterInfo.dataPath);
+        this.shardDataSetSizes = clusterInfo.shardDataSetSizes;
+        this.dataPath = clusterInfo.dataPath;
     }
 
     /**


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/1331856/199751106-ed98e85b-408d-499d-a886-81c817095c61.png)

According to the image above, the majority of time spend in ClusterInfoSimulator is related to copying immutable map and creating a hashmap. This change remove that for 2 maps that are not changing during the calculation.