### PR TITLE
unmute tests fixed in #91129

### DIFF
--- a/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/TransformHealthCheckerTests.java
+++ b/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/TransformHealthCheckerTests.java
@@ -34,7 +34,6 @@ public class TransformHealthCheckerTests extends ESTestCase {
         assertThat(TransformHealthChecker.checkTransform(task), equalTo(TransformHealth.GREEN));
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/91110")
     public void testPersistenceFailure() {
         TransformTask task = mock(TransformTask.class);
         TransformContext context = createTestContext();


### PR DESCRIPTION
unmute test fixed in #91129

fixes #91110

Note: I missed that 1 test got muted meanwhile and that  #91110 is a dup of #91129