### PR TITLE
[ML] Do not count interim buckets towards the bucket count

### DIFF
--- a/docs/changelog/91288.yaml
+++ b/docs/changelog/91288.yaml
@@ -1,5 +1,5 @@
 pr: 91288
-summary: Do not count interim buckets towards the bucket count
+summary: Interim buckets should not count towards the total bucket count
 area: Machine Learning
 type: bug
 issues: []

--- a/docs/changelog/91288.yaml
+++ b/docs/changelog/91288.yaml
@@ -1,0 +1,5 @@
+pr: 91288
+summary: Do not count interim buckets towards the bucket count
+area: Machine Learning
+type: bug
+issues: []

--- a/x-pack/plugin/ml/src/internalClusterTest/java/org/elasticsearch/xpack/ml/integration/AutodetectResultProcessorIT.java
+++ b/x-pack/plugin/ml/src/internalClusterTest/java/org/elasticsearch/xpack/ml/integration/AutodetectResultProcessorIT.java
@@ -314,16 +314,16 @@ public class AutodetectResultProcessorIT extends MlSingleNodeTestCase {
     }
 
     public void testProcessResults_TimingStats() throws Exception {
-        ResultsBuilder resultsBuilder = new ResultsBuilder().addBucket(createBucket(true, 100))
-            .addBucket(createBucket(true, 1000))
-            .addBucket(createBucket(true, 100))
-            .addBucket(createBucket(true, 1000))
-            .addBucket(createBucket(true, 100))
-            .addBucket(createBucket(true, 1000))
-            .addBucket(createBucket(true, 100))
-            .addBucket(createBucket(true, 1000))
-            .addBucket(createBucket(true, 100))
-            .addBucket(createBucket(true, 1000));
+        ResultsBuilder resultsBuilder = new ResultsBuilder().addBucket(createBucket(false, 100))
+            .addBucket(createBucket(false, 1000))
+            .addBucket(createBucket(false, 100))
+            .addBucket(createBucket(false, 1000))
+            .addBucket(createBucket(false, 100))
+            .addBucket(createBucket(false, 1000))
+            .addBucket(createBucket(false, 100))
+            .addBucket(createBucket(false, 1000))
+            .addBucket(createBucket(false, 100))
+            .addBucket(createBucket(false, 1000));
         when(process.readAutodetectResults()).thenReturn(resultsBuilder.build().iterator());
 
         resultProcessor.process();
@@ -336,6 +336,24 @@ public class AutodetectResultProcessorIT extends MlSingleNodeTestCase {
         assertThat(timingStats.getMaxBucketProcessingTimeMs(), equalTo(1000.0));
         assertThat(timingStats.getAvgBucketProcessingTimeMs(), equalTo(550.0));
         assertThat(timingStats.getExponentialAvgBucketProcessingTimeMs(), closeTo(143.244, 1e-3));
+    }
+
+    public void testProcessResults_InterimResultsDoNotChangeTimingStats() throws Exception {
+        ResultsBuilder resultsBuilder = new ResultsBuilder().addBucket(createBucket(true, 100))
+            .addBucket(createBucket(true, 100))
+            .addBucket(createBucket(true, 100))
+            .addBucket(createBucket(false, 10000));
+        when(process.readAutodetectResults()).thenReturn(resultsBuilder.build().iterator());
+
+        resultProcessor.process();
+        resultProcessor.awaitCompletion();
+
+        TimingStats timingStats = resultProcessor.timingStats();
+        assertThat(timingStats.getBucketCount(), equalTo(1L));
+        assertThat(timingStats.getMinBucketProcessingTimeMs(), equalTo(10000.0));
+        assertThat(timingStats.getMaxBucketProcessingTimeMs(), equalTo(10000.0));
+        assertThat(timingStats.getAvgBucketProcessingTimeMs(), equalTo(10000.0));
+        assertThat(timingStats.getExponentialAvgBucketProcessingTimeMs(), closeTo(10000.0, 1e-3));
     }
 
     public void testParseQuantiles_GivenRenormalizationIsEnabled() throws Exception {

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/process/autodetect/output/AutodetectResultProcessor.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/process/autodetect/output/AutodetectResultProcessor.java
@@ -586,6 +586,8 @@ public class AutodetectResultProcessor {
         this.deleteInterimRequired = deleteInterimRequired;
     }
 
+    // For testing only.
+    // Reading currentRunBucketCount is not thread safe
     long getCurrentRunBucketCount() {
         return currentRunBucketCount;
     }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/process/autodetect/output/AutodetectResultProcessor.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/process/autodetect/output/AutodetectResultProcessor.java
@@ -586,7 +586,7 @@ public class AutodetectResultProcessor {
         this.deleteInterimRequired = deleteInterimRequired;
     }
 
-    public long currentRunBucketCount() {
+    long getCurrentRunBucketCount() {
         return currentRunBucketCount;
     }
 }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/process/autodetect/output/AutodetectResultProcessor.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/process/autodetect/output/AutodetectResultProcessor.java
@@ -281,12 +281,14 @@ public class AutodetectResultProcessor {
                 deleteInterimRequired = false;
             }
 
+            if (bucket.isInterim() == false) {
+                timingStatsReporter.reportBucket(bucket);
+                ++currentRunBucketCount;
+            }
             // persist after deleting interim results in case the new
             // results are also interim
-            timingStatsReporter.reportBucket(bucket);
             bulkResultsPersister.persistBucket(bucket).executeRequest();
             bulkAnnotationsPersister.executeRequest();
-            ++currentRunBucketCount;
         }
         List<AnomalyRecord> records = result.getRecords();
         if (records != null && records.isEmpty() == false) {
@@ -582,5 +584,9 @@ public class AutodetectResultProcessor {
 
     void setDeleteInterimRequired(boolean deleteInterimRequired) {
         this.deleteInterimRequired = deleteInterimRequired;
+    }
+
+    public long currentRunBucketCount() {
+        return currentRunBucketCount;
     }
 }

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/process/autodetect/output/AutodetectResultProcessorTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/process/autodetect/output/AutodetectResultProcessorTests.java
@@ -178,7 +178,7 @@ public class AutodetectResultProcessorTests extends ESTestCase {
         when(result.getBucket()).thenReturn(bucket);
 
         processorUnderTest.processResult(result);
-        assertEquals(1L, processorUnderTest.currentRunBucketCount());
+        assertEquals(1L, processorUnderTest.getCurrentRunBucketCount());
         assertFalse(processorUnderTest.isDeleteInterimRequired());
 
         verify(bulkResultsPersister).persistTimingStats(any(TimingStats.class));
@@ -198,7 +198,7 @@ public class AutodetectResultProcessorTests extends ESTestCase {
 
         processorUnderTest.setDeleteInterimRequired(false);
         processorUnderTest.processResult(result);
-        assertEquals(0L, processorUnderTest.currentRunBucketCount());
+        assertEquals(0L, processorUnderTest.getCurrentRunBucketCount());
 
         verify(bulkResultsPersister, never()).persistTimingStats(any(TimingStats.class));
         verify(bulkResultsPersister).persistBucket(bucket);

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/process/autodetect/output/AutodetectResultProcessorTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/process/autodetect/output/AutodetectResultProcessorTests.java
@@ -178,6 +178,7 @@ public class AutodetectResultProcessorTests extends ESTestCase {
         when(result.getBucket()).thenReturn(bucket);
 
         processorUnderTest.processResult(result);
+        assertEquals(1L, processorUnderTest.currentRunBucketCount());
         assertFalse(processorUnderTest.isDeleteInterimRequired());
 
         verify(bulkResultsPersister).persistTimingStats(any(TimingStats.class));
@@ -185,6 +186,24 @@ public class AutodetectResultProcessorTests extends ESTestCase {
         verify(bulkResultsPersister).executeRequest();
         verify(persister).bulkPersisterBuilder(eq(JOB_ID));
         verify(persister).deleteInterimResults(JOB_ID);
+    }
+
+    public void testProcessResult_bucket_isInterim() {
+        when(bulkResultsPersister.persistTimingStats(any(TimingStats.class))).thenReturn(bulkResultsPersister);
+        when(bulkResultsPersister.persistBucket(any(Bucket.class))).thenReturn(bulkResultsPersister);
+        AutodetectResult result = mock(AutodetectResult.class);
+        Bucket bucket = new Bucket(JOB_ID, new Date(), BUCKET_SPAN_MS);
+        bucket.setInterim(true);
+        when(result.getBucket()).thenReturn(bucket);
+
+        processorUnderTest.setDeleteInterimRequired(false);
+        processorUnderTest.processResult(result);
+        assertEquals(0L, processorUnderTest.currentRunBucketCount());
+
+        verify(bulkResultsPersister, never()).persistTimingStats(any(TimingStats.class));
+        verify(bulkResultsPersister).persistBucket(bucket);
+        verify(bulkResultsPersister).executeRequest();
+        verify(persister).bulkPersisterBuilder(eq(JOB_ID));
     }
 
     public void testProcessResult_records() {


### PR DESCRIPTION
The `bucket_count` field in anomaly detector `timing_stats` can be higher than the true count if interim buckets are included. Interim bucket should not contribute to the timing stats, only the final bucket should be counted to ensure it is counted exactly once. 