### PR TITLE
Fix TransportResponse reference counting in DirectResponseChannel

### DIFF
--- a/docs/changelog/91289.yaml
+++ b/docs/changelog/91289.yaml
@@ -1,0 +1,5 @@
+pr: 91289
+summary: Fix `TransportActionProxy` for local execution
+area: Network
+type: bug
+issues: []

--- a/server/src/main/java/org/elasticsearch/transport/TransportService.java
+++ b/server/src/main/java/org/elasticsearch/transport/TransportService.java
@@ -1447,6 +1447,8 @@ public class TransportService extends AbstractLifecycleComponent
                 handler.handleResponse(response);
             } catch (Exception e) {
                 processException(handler, wrapInRemote(new ResponseHandlerFailureTransportException(e)));
+            } finally {
+                response.decRef();
             }
         }
 

--- a/server/src/main/java/org/elasticsearch/transport/TransportService.java
+++ b/server/src/main/java/org/elasticsearch/transport/TransportService.java
@@ -1411,33 +1411,43 @@ public class TransportService extends AbstractLifecycleComponent
 
         @Override
         public void sendResponse(TransportResponse response) throws IOException {
-            service.onResponseSent(requestId, action, response);
-            try (var shutdownBlock = service.pendingDirectHandlers.withRef()) {
-                if (shutdownBlock == null) {
-                    // already shutting down, the handler will be completed by sendRequestInternal or doStop
-                    return;
-                }
-                final TransportResponseHandler<?> handler = service.responseHandlers.onResponseReceived(requestId, service);
-                if (handler == null) {
-                    // handler already completed, likely by a timeout which is logged elsewhere
-                    return;
-                }
-                final String executor = handler.executor();
-                if (ThreadPool.Names.SAME.equals(executor)) {
-                    processResponse(handler, response);
-                } else {
-                    threadPool.executor(executor).execute(new ForkingResponseHandlerRunnable(handler, null) {
-                        @Override
-                        protected void doRun() {
-                            processResponse(handler, response);
-                        }
+            try {
+                service.onResponseSent(requestId, action, response);
+                try (var shutdownBlock = service.pendingDirectHandlers.withRef()) {
+                    if (shutdownBlock == null) {
+                        // already shutting down, the handler will be completed by sendRequestInternal or doStop
+                        return;
+                    }
+                    final TransportResponseHandler<?> handler = service.responseHandlers.onResponseReceived(requestId, service);
+                    if (handler == null) {
+                        // handler already completed, likely by a timeout which is logged elsewhere
+                        return;
+                    }
+                    final String executor = handler.executor();
+                    if (ThreadPool.Names.SAME.equals(executor)) {
+                        processResponse(handler, response);
+                    } else {
+                        response.incRef();
+                        threadPool.executor(executor).execute(new ForkingResponseHandlerRunnable(handler, null) {
+                            @Override
+                            protected void doRun() {
+                                processResponse(handler, response);
+                            }
 
-                        @Override
-                        public String toString() {
-                            return "delivery of response to [" + requestId + "][" + action + "]: " + response;
-                        }
-                    });
+                            @Override
+                            public void onAfter() {
+                                response.decRef();
+                            }
+
+                            @Override
+                            public String toString() {
+                                return "delivery of response to [" + requestId + "][" + action + "]: " + response;
+                            }
+                        });
+                    }
                 }
+            } finally {
+                response.decRef();
             }
         }
 
@@ -1447,8 +1457,6 @@ public class TransportService extends AbstractLifecycleComponent
                 handler.handleResponse(response);
             } catch (Exception e) {
                 processException(handler, wrapInRemote(new ResponseHandlerFailureTransportException(e)));
-            } finally {
-                response.decRef();
             }
         }
 

--- a/server/src/test/java/org/elasticsearch/transport/TransportActionProxyTests.java
+++ b/server/src/test/java/org/elasticsearch/transport/TransportActionProxyTests.java
@@ -14,7 +14,9 @@ import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.core.AbstractRefCounted;
 import org.elasticsearch.core.IOUtils;
+import org.elasticsearch.core.RefCounted;
 import org.elasticsearch.tasks.CancellableTask;
 import org.elasticsearch.tasks.Task;
 import org.elasticsearch.tasks.TaskId;
@@ -76,8 +78,9 @@ public class TransportActionProxyTests extends ESTestCase {
     public void testSendMessage() throws InterruptedException {
         serviceA.registerRequestHandler("internal:test", ThreadPool.Names.SAME, SimpleTestRequest::new, (request, channel, task) -> {
             assertEquals(request.sourceNode, "TS_A");
-            SimpleTestResponse response = new SimpleTestResponse("TS_A");
+            final SimpleTestResponse response = new SimpleTestResponse("TS_A");
             channel.sendResponse(response);
+            assertThat(response.hasReferences(), equalTo(false));
         });
         final boolean cancellable = randomBoolean();
         TransportActionProxy.registerProxyAction(serviceA, "internal:test", cancellable, SimpleTestResponse::new);
@@ -86,21 +89,24 @@ public class TransportActionProxyTests extends ESTestCase {
         serviceB.registerRequestHandler("internal:test", ThreadPool.Names.SAME, SimpleTestRequest::new, (request, channel, task) -> {
             assertThat(task instanceof CancellableTask, equalTo(cancellable));
             assertEquals(request.sourceNode, "TS_A");
-            SimpleTestResponse response = new SimpleTestResponse("TS_B");
+            final SimpleTestResponse response = new SimpleTestResponse("TS_B");
             channel.sendResponse(response);
+            assertThat(response.hasReferences(), equalTo(false));
         });
         TransportActionProxy.registerProxyAction(serviceB, "internal:test", cancellable, SimpleTestResponse::new);
         AbstractSimpleTransportTestCase.connectToNode(serviceB, nodeC);
         serviceC.registerRequestHandler("internal:test", ThreadPool.Names.SAME, SimpleTestRequest::new, (request, channel, task) -> {
             assertThat(task instanceof CancellableTask, equalTo(cancellable));
             assertEquals(request.sourceNode, "TS_A");
-            SimpleTestResponse response = new SimpleTestResponse("TS_C");
+            final SimpleTestResponse response = new SimpleTestResponse("TS_C");
             channel.sendResponse(response);
+            assertThat(response.hasReferences(), equalTo(false));
         });
 
         TransportActionProxy.registerProxyAction(serviceC, "internal:test", cancellable, SimpleTestResponse::new);
 
-        CountDownLatch latch = new CountDownLatch(1);
+        final CountDownLatch latch = new CountDownLatch(1);
+        // Node A -> Node B -> Node C
         serviceA.sendRequest(
             nodeB,
             TransportActionProxy.getProxyAction("internal:test"),
@@ -115,6 +121,60 @@ public class TransportActionProxyTests extends ESTestCase {
                 public void handleResponse(SimpleTestResponse response) {
                     try {
                         assertEquals("TS_C", response.targetNode);
+                    } finally {
+                        latch.countDown();
+                    }
+                }
+
+                @Override
+                public void handleException(TransportException exp) {
+                    try {
+                        throw new AssertionError(exp);
+                    } finally {
+                        latch.countDown();
+                    }
+                }
+            }
+        );
+        latch.await();
+    }
+
+    public void testSendMessageToLocalNode() throws InterruptedException {
+        serviceA.registerRequestHandler("internal:test", ThreadPool.Names.SAME, SimpleTestRequest::new, (request, channel, task) -> {
+            assertEquals(request.sourceNode, "TS_A");
+            final SimpleTestResponse response = new SimpleTestResponse("TS_A");
+            channel.sendResponse(response);
+            assertThat(response.hasReferences(), equalTo(false));
+        });
+        final boolean cancellable = randomBoolean();
+        TransportActionProxy.registerProxyAction(serviceA, "internal:test", cancellable, SimpleTestResponse::new);
+        AbstractSimpleTransportTestCase.connectToNode(serviceA, nodeB);
+
+        serviceB.registerRequestHandler("internal:test", ThreadPool.Names.SAME, SimpleTestRequest::new, (request, channel, task) -> {
+            assertThat(task instanceof CancellableTask, equalTo(cancellable));
+            assertEquals(request.sourceNode, "TS_A");
+            final SimpleTestResponse response = new SimpleTestResponse("TS_B");
+            channel.sendResponse(response);
+            assertThat(response.hasReferences(), equalTo(false));
+        });
+        TransportActionProxy.registerProxyAction(serviceB, "internal:test", cancellable, SimpleTestResponse::new);
+
+        final CountDownLatch latch = new CountDownLatch(1);
+        // Node A -> Node B (Local execution)
+        serviceA.sendRequest(
+            nodeB,
+            TransportActionProxy.getProxyAction("internal:test"),
+            TransportActionProxy.wrapRequest(nodeB, new SimpleTestRequest("TS_A", cancellable)), // Request
+            new TransportResponseHandler<SimpleTestResponse>() {
+                @Override
+                public SimpleTestResponse read(StreamInput in) throws IOException {
+                    return new SimpleTestResponse(in);
+                }
+
+                @Override
+                public void handleResponse(SimpleTestResponse response) {
+                    try {
+                        assertEquals("TS_B", response.targetNode);
                     } finally {
                         latch.countDown();
                     }
@@ -230,7 +290,12 @@ public class TransportActionProxyTests extends ESTestCase {
     }
 
     public static class SimpleTestResponse extends TransportResponse {
+
         final String targetNode;
+        final RefCounted refCounted = new AbstractRefCounted() {
+            @Override
+            protected void closeInternal() {}
+        };
 
         SimpleTestResponse(String targetNode) {
             this.targetNode = targetNode;
@@ -244,6 +309,26 @@ public class TransportActionProxyTests extends ESTestCase {
         @Override
         public void writeTo(StreamOutput out) throws IOException {
             out.writeString(targetNode);
+        }
+
+        @Override
+        public void incRef() {
+            refCounted.incRef();
+        }
+
+        @Override
+        public boolean tryIncRef() {
+            return refCounted.tryIncRef();
+        }
+
+        @Override
+        public boolean decRef() {
+            return refCounted.decRef();
+        }
+
+        @Override
+        public boolean hasReferences() {
+            return refCounted.hasReferences();
         }
     }
 


### PR DESCRIPTION
In #76474 we fixed a circuit breaker leak in `TransportActionProxy` by incrementing a reference on the `TransportResponse` that  is later decremented by the `OutboundHandler`. 

This works well for all cases except when the request targets the node which is also the proxy node. In that case the reference is incremented but will never be decremented as the local execution (using `TransportService#localNodeConnection` and `DirectResponseChannel`) bypasses the `OutboundHandler`.

This change fixes the ref counting by also decrementing the `TransportResponse` in `DirectResponseChannel`.

This will also have the consequence to correctly decrement used bytes of the `request` circuit breaker when `GetCcrRestoreFileChunkResponse` are executed on a node that is also a proxy node.