### PR TITLE
[7.17] update c2id/c2id-server-demo docker image to support ARM (#91144)

### DIFF
--- a/x-pack/qa/oidc-op-tests/build.gradle
+++ b/x-pack/qa/oidc-op-tests/build.gradle
@@ -1,5 +1,3 @@
-import org.elasticsearch.gradle.Architecture
-
 apply plugin: 'elasticsearch.internal-java-rest-test'
 apply plugin: 'elasticsearch.test.fixtures'
 
@@ -16,9 +14,4 @@ tasks.named("processJavaRestTestResources").configure {
           .files(
                   'src/test/resources/org/elasticsearch/xpack/security/transport/ssl/certs/simple/testnode_ec.crt'
           )
-}
-
-tasks.named("javaRestTest").configure {
-  // OpenID Connect fixture does not support aarm64
-  onlyIf { Architecture.current() == Architecture.X64 }
 }

--- a/x-pack/test/idp-fixture/docker-compose.yml
+++ b/x-pack/test/idp-fixture/docker-compose.yml
@@ -155,7 +155,9 @@ services:
       - ./idp/shib-jetty-base/start.d/ssl.ini:/opt/shib-jetty-base/start.d/ssl.ini
 
   oidc-provider:
-    image: "c2id/c2id-server-demo:12.16.1"
+    build:
+      context: .
+      dockerfile: ./oidc/Dockerfile
     depends_on:
       - http-proxy
     ports:

--- a/x-pack/test/idp-fixture/oidc/Dockerfile
+++ b/x-pack/test/idp-fixture/oidc/Dockerfile
@@ -1,0 +1,9 @@
+FROM c2id/c2id-server-demo:12.18 AS c2id
+FROM openjdk:11.0.16-jre
+
+COPY --from=c2id /c2id-server /c2id-server
+COPY --from=c2id /etc/c2id /etc/c2id
+
+ENV CATALINA_OPTS="-DsystemPropertiesURL=file:///etc/c2id/override.properties"
+EXPOSE 8080
+CMD ["/bin/bash", "/c2id-server/tomcat/bin/catalina.sh", "run"]


### PR DESCRIPTION
Backports the following commits to 7.17:
 - update c2id/c2id-server-demo docker image to support ARM (#91144)