### PR TITLE
Check for unassigned shards on node shutdown

### DIFF
--- a/docs/changelog/91297.yaml
+++ b/docs/changelog/91297.yaml
@@ -1,0 +1,6 @@
+pr: 91297
+summary: Check for unassigned shards on node shutdown
+area: Infra/Core
+type: enhancement
+issues:
+ - 88635

--- a/test/framework/src/main/java/org/elasticsearch/test/gateway/TestGatewayAllocator.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/gateway/TestGatewayAllocator.java
@@ -8,9 +8,12 @@
 
 package org.elasticsearch.test.gateway;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
 import org.elasticsearch.cluster.routing.ShardRouting;
+import org.elasticsearch.cluster.routing.allocation.AllocateUnassignedDecision;
 import org.elasticsearch.cluster.routing.allocation.FailedShard;
 import org.elasticsearch.cluster.routing.allocation.RoutingAllocation;
 import org.elasticsearch.gateway.AsyncShardFetch;
@@ -44,6 +47,8 @@ import java.util.stream.Collectors;
  * not have all the infrastructure required to use it.
  */
 public class TestGatewayAllocator extends GatewayAllocator {
+
+    private static final Logger LOGGER = LogManager.getLogger(TestGatewayAllocator.class);
 
     Map<String /* node id */, Map<ShardId, ShardRouting>> knownAllocations = new HashMap<>();
     DiscoveryNodes currentNodes = DiscoveryNodes.EMPTY_NODES;
@@ -126,6 +131,18 @@ public class TestGatewayAllocator extends GatewayAllocator {
         innerAllocatedUnassigned(allocation, primaryShardAllocator, replicaShardAllocator, shardRouting, unassignedAllocationHandler);
     }
 
+    @Override
+    public AllocateUnassignedDecision explainUnassignedShardAllocation(ShardRouting unassignedShard, RoutingAllocation routingAllocation) {
+        assert unassignedShard.unassigned();
+        assert routingAllocation.debugDecision();
+        if (unassignedShard.primary()) {
+            assert primaryShardAllocator != null;
+            return primaryShardAllocator.makeAllocationDecision(unassignedShard, routingAllocation, LOGGER);
+        } else {
+            assert replicaShardAllocator != null;
+            return replicaShardAllocator.makeAllocationDecision(unassignedShard, routingAllocation, LOGGER);
+        }
+    }
     /**
      * manually add a specific shard to the allocations the gateway keeps track of
      */

--- a/test/framework/src/main/java/org/elasticsearch/test/gateway/TestGatewayAllocator.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/gateway/TestGatewayAllocator.java
@@ -143,6 +143,7 @@ public class TestGatewayAllocator extends GatewayAllocator {
             return replicaShardAllocator.makeAllocationDecision(unassignedShard, routingAllocation, LOGGER);
         }
     }
+
     /**
      * manually add a specific shard to the allocations the gateway keeps track of
      */

--- a/x-pack/plugin/shutdown/src/internalClusterTest/java/org/elasticsearch/xpack/shutdown/NodeShutdownShardsIT.java
+++ b/x-pack/plugin/shutdown/src/internalClusterTest/java/org/elasticsearch/xpack/shutdown/NodeShutdownShardsIT.java
@@ -14,9 +14,7 @@ import org.elasticsearch.action.admin.cluster.node.info.NodesInfoResponse;
 import org.elasticsearch.action.admin.cluster.settings.ClusterUpdateSettingsRequest;
 import org.elasticsearch.action.admin.indices.settings.get.GetSettingsRequest;
 import org.elasticsearch.action.index.IndexRequestBuilder;
-import org.elasticsearch.action.index.IndexResponse;
 import org.elasticsearch.cluster.ClusterState;
-import org.elasticsearch.cluster.metadata.DataStream;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.metadata.SingleNodeShutdownMetadata;
 import org.elasticsearch.cluster.node.DiscoveryNode;
@@ -421,10 +419,6 @@ public class NodeShutdownShardsIT extends ESIntegTestCase {
             "index",
             Settings.builder().put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1).put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 1).build()
         );
-
-        final IndexResponse indexResponse = client().prepareIndex("index")
-            .setSource(DataStream.TimestampField.FIXED_TIMESTAMP_FIELD, "2010-01-06T02:03:04.567Z")
-            .get();
 
         ensureYellow("index");
 

--- a/x-pack/plugin/shutdown/src/internalClusterTest/java/org/elasticsearch/xpack/shutdown/NodeShutdownShardsIT.java
+++ b/x-pack/plugin/shutdown/src/internalClusterTest/java/org/elasticsearch/xpack/shutdown/NodeShutdownShardsIT.java
@@ -11,9 +11,12 @@ import org.elasticsearch.Build;
 import org.elasticsearch.action.admin.cluster.allocation.ClusterAllocationExplainResponse;
 import org.elasticsearch.action.admin.cluster.node.info.NodeInfo;
 import org.elasticsearch.action.admin.cluster.node.info.NodesInfoResponse;
+import org.elasticsearch.action.admin.cluster.settings.ClusterUpdateSettingsRequest;
 import org.elasticsearch.action.admin.indices.settings.get.GetSettingsRequest;
 import org.elasticsearch.action.index.IndexRequestBuilder;
+import org.elasticsearch.action.index.IndexResponse;
 import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.metadata.DataStream;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.metadata.SingleNodeShutdownMetadata;
 import org.elasticsearch.cluster.node.DiscoveryNode;
@@ -408,6 +411,45 @@ public class NodeShutdownShardsIT extends ESIntegTestCase {
         });
 
         ensureGreen("myindex");
+    }
+
+    public void testNodeShutdownWithUnassignedShards() throws Exception {
+        final String nodeA = internalCluster().startNode();
+        final String nodeAId = getNodeId(nodeA);
+
+        createIndex(
+            "index",
+            Settings.builder().put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1).put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 1).build()
+        );
+
+        final IndexResponse indexResponse = client().prepareIndex("index")
+            .setSource(DataStream.TimestampField.FIXED_TIMESTAMP_FIELD, "2010-01-06T02:03:04.567Z")
+            .get();
+
+        ensureYellow("index");
+
+        // Start a second node, so the replica will be on nodeB
+        final String nodeB = internalCluster().startNode();
+        final String nodeBId = getNodeId(nodeB);
+        ensureGreen("index");
+
+        client().admin()
+            .cluster()
+            .updateSettings(
+                new ClusterUpdateSettingsRequest().persistentSettings(Settings.builder().put("cluster.routing.allocation.enable", "none"))
+            );
+
+        assertThat(client().admin().indices().prepareFlush("index").get().getSuccessfulShards(), equalTo(2));
+        assertThat(client().admin().indices().prepareRefresh("index").get().getSuccessfulShards(), equalTo(2));
+
+        internalCluster().restartNode(nodeA);
+        internalCluster().restartNode(nodeB);
+
+        assertThat(client().admin().cluster().prepareHealth("index").get().getUnassignedShards(), equalTo(1));
+
+        putNodeShutdown(nodeAId, SingleNodeShutdownMetadata.Type.REMOVE, null);
+
+        assertBusy(() -> assertNodeShutdownStatus(nodeAId, STALLED));
     }
 
     private void indexRandomData(String index) throws Exception {

--- a/x-pack/plugin/shutdown/src/main/java/org/elasticsearch/xpack/shutdown/TransportGetShutdownStatusAction.java
+++ b/x-pack/plugin/shutdown/src/main/java/org/elasticsearch/xpack/shutdown/TransportGetShutdownStatusAction.java
@@ -217,8 +217,8 @@ public class TransportGetShutdownStatusAction extends TransportMasterNodeAction<
             UnaryOperator.identity()
         )
             .map(Iterator::next)
-            .filter(s -> s.unassignedInfo().getLastAllocatedNodeId() != null && s.unassignedInfo().getLastAllocatedNodeId().equals(nodeId))
-            .collect(Collectors.toList());
+            .filter(s -> Objects.equals(s.unassignedInfo().getLastAllocatedNodeId(), nodeId))
+            .toList();
 
         if (unassignedShards.isEmpty() == false) {
             var shardRouting = unassignedShards.get(0);

--- a/x-pack/plugin/shutdown/src/main/java/org/elasticsearch/xpack/shutdown/TransportGetShutdownStatusAction.java
+++ b/x-pack/plugin/shutdown/src/main/java/org/elasticsearch/xpack/shutdown/TransportGetShutdownStatusAction.java
@@ -215,28 +215,26 @@ public class TransportGetShutdownStatusAction extends TransportMasterNodeAction<
             currentState.getRoutingNodes().unassigned().iterator(),
             Iterator::hasNext,
             UnaryOperator.identity()
-        )
-            .map(Iterator::next)
-            .filter(s -> Objects.equals(s.unassignedInfo().getLastAllocatedNodeId(), nodeId))
-            .toList();
+        ).map(Iterator::next).filter(s -> Objects.equals(s.unassignedInfo().getLastAllocatedNodeId(), nodeId)).toList();
 
         if (unassignedShards.isEmpty() == false) {
-            var shardRouting = unassignedShards.get(0);
-            if (shardRouting.primary() || hasShardCopyOnAnotherNode(currentState, shardRouting, shuttingDownNodes) == false) {
-                ShardAllocationDecision decision = allocationService.explainShardAllocation(shardRouting, allocation);
+            for (var shardRouting : unassignedShards) {
+                if (shardRouting.primary() || hasShardCopyOnAnotherNode(currentState, shardRouting, shuttingDownNodes) == false) {
+                    ShardAllocationDecision decision = allocationService.explainShardAllocation(shardRouting, allocation);
 
-                return new ShutdownShardMigrationStatus(
-                    SingleNodeShutdownMetadata.Status.STALLED,
-                    unassignedShards.size(),
-                    format(
-                        "shard [%s] [%s] of index [%s] is unassigned, see [%s] for details or use the cluster allocation explain API",
-                        shardRouting.shardId().getId(),
-                        shardRouting.primary() ? "primary" : "replica",
-                        shardRouting.index().getName(),
-                        NODE_ALLOCATION_DECISION_KEY
-                    ),
-                    decision
-                );
+                    return new ShutdownShardMigrationStatus(
+                        SingleNodeShutdownMetadata.Status.STALLED,
+                        unassignedShards.size(),
+                        format(
+                            "shard [%s] [%s] of index [%s] is unassigned, see [%s] for details or use the cluster allocation explain API",
+                            shardRouting.shardId().getId(),
+                            shardRouting.primary() ? "primary" : "replica",
+                            shardRouting.index().getName(),
+                            NODE_ALLOCATION_DECISION_KEY
+                        ),
+                        decision
+                    );
+                }
             }
         }
 

--- a/x-pack/plugin/shutdown/src/main/java/org/elasticsearch/xpack/shutdown/TransportGetShutdownStatusAction.java
+++ b/x-pack/plugin/shutdown/src/main/java/org/elasticsearch/xpack/shutdown/TransportGetShutdownStatusAction.java
@@ -215,27 +215,28 @@ public class TransportGetShutdownStatusAction extends TransportMasterNodeAction<
             currentState.getRoutingNodes().unassigned().iterator(),
             Iterator::hasNext,
             UnaryOperator.identity()
-        ).map(Iterator::next).filter(s -> Objects.equals(s.unassignedInfo().getLastAllocatedNodeId(), nodeId)).toList();
+        )
+            .map(Iterator::next)
+            .filter(s -> Objects.equals(s.unassignedInfo().getLastAllocatedNodeId(), nodeId))
+            .filter(s -> s.primary() || hasShardCopyOnAnotherNode(currentState, s, shuttingDownNodes) == false)
+            .toList();
 
         if (unassignedShards.isEmpty() == false) {
-            for (var shardRouting : unassignedShards) {
-                if (shardRouting.primary() || hasShardCopyOnAnotherNode(currentState, shardRouting, shuttingDownNodes) == false) {
-                    ShardAllocationDecision decision = allocationService.explainShardAllocation(shardRouting, allocation);
+            var shardRouting = unassignedShards.get(0);
+            ShardAllocationDecision decision = allocationService.explainShardAllocation(shardRouting, allocation);
 
-                    return new ShutdownShardMigrationStatus(
-                        SingleNodeShutdownMetadata.Status.STALLED,
-                        unassignedShards.size(),
-                        format(
-                            "shard [%s] [%s] of index [%s] is unassigned, see [%s] for details or use the cluster allocation explain API",
-                            shardRouting.shardId().getId(),
-                            shardRouting.primary() ? "primary" : "replica",
-                            shardRouting.index().getName(),
-                            NODE_ALLOCATION_DECISION_KEY
-                        ),
-                        decision
-                    );
-                }
-            }
+            return new ShutdownShardMigrationStatus(
+                SingleNodeShutdownMetadata.Status.STALLED,
+                unassignedShards.size(),
+                format(
+                    "shard [%s] [%s] of index [%s] is unassigned, see [%s] for details or use the cluster allocation explain API",
+                    shardRouting.shardId().getId(),
+                    shardRouting.primary() ? "primary" : "replica",
+                    shardRouting.index().getName(),
+                    NODE_ALLOCATION_DECISION_KEY
+                ),
+                decision
+            );
         }
 
         // Check if there are any shards currently on this node, and if there are any relocating shards

--- a/x-pack/plugin/shutdown/src/main/java/org/elasticsearch/xpack/shutdown/TransportGetShutdownStatusAction.java
+++ b/x-pack/plugin/shutdown/src/main/java/org/elasticsearch/xpack/shutdown/TransportGetShutdownStatusAction.java
@@ -222,17 +222,16 @@ public class TransportGetShutdownStatusAction extends TransportMasterNodeAction<
 
         if (unassignedShards.isEmpty() == false) {
             var shardRouting = unassignedShards.get(0);
-            var unassignedInfo = shardRouting.unassignedInfo();
-            if (unassignedInfo.getLastAllocatedNodeId().equals(nodeId)
-                && hasShardCopyOnAnotherNode(currentState, shardRouting, shuttingDownNodes) == false) {
+            if (shardRouting.primary() || hasShardCopyOnAnotherNode(currentState, shardRouting, shuttingDownNodes) == false) {
                 ShardAllocationDecision decision = allocationService.explainShardAllocation(shardRouting, allocation);
 
                 return new ShutdownShardMigrationStatus(
                     SingleNodeShutdownMetadata.Status.STALLED,
                     unassignedShards.size(),
                     format(
-                        "shard [%s] [primary] of index [%s] is unassigned, see [%s] for details or use the cluster allocation explain API",
+                        "shard [%s] [%s] of index [%s] is unassigned, see [%s] for details or use the cluster allocation explain API",
                         shardRouting.shardId().getId(),
+                        shardRouting.primary() ? "primary" : "replica",
                         shardRouting.index().getName(),
                         NODE_ALLOCATION_DECISION_KEY
                     ),

--- a/x-pack/plugin/shutdown/src/test/java/org/elasticsearch/xpack/shutdown/TransportGetShutdownStatusActionTests.java
+++ b/x-pack/plugin/shutdown/src/test/java/org/elasticsearch/xpack/shutdown/TransportGetShutdownStatusActionTests.java
@@ -401,6 +401,14 @@ public class TransportGetShutdownStatusActionTests extends ESTestCase {
             2,
             allOf(containsString(index.getName()), containsString("[2] [primary]"))
         );
+
+        // check if we correctly walk all of the unassigned shards, shard 2 replica, shard 3 primary
+        assertShardMigration(
+            getUnassignedShutdownStatus(index, imd, shard0, shard1, shard2, unassignedReplica, unassigned3),
+            SingleNodeShutdownMetadata.Status.STALLED,
+            2,
+            allOf(containsString(index.getName()), containsString("[3] [primary]"))
+        );
     }
 
     public void testNotStalledIfAllShardsHaveACopyOnAnotherNode() {

--- a/x-pack/plugin/shutdown/src/test/java/org/elasticsearch/xpack/shutdown/TransportGetShutdownStatusActionTests.java
+++ b/x-pack/plugin/shutdown/src/test/java/org/elasticsearch/xpack/shutdown/TransportGetShutdownStatusActionTests.java
@@ -406,7 +406,7 @@ public class TransportGetShutdownStatusActionTests extends ESTestCase {
         assertShardMigration(
             getUnassignedShutdownStatus(index, imd, shard0, shard1, shard2, unassignedReplica, unassigned3),
             SingleNodeShutdownMetadata.Status.STALLED,
-            2,
+            1,
             allOf(containsString(index.getName()), containsString("[3] [primary]"))
         );
     }

--- a/x-pack/plugin/shutdown/src/test/java/org/elasticsearch/xpack/shutdown/TransportGetShutdownStatusActionTests.java
+++ b/x-pack/plugin/shutdown/src/test/java/org/elasticsearch/xpack/shutdown/TransportGetShutdownStatusActionTests.java
@@ -35,12 +35,14 @@ import org.elasticsearch.cluster.routing.allocation.decider.NodeReplacementAlloc
 import org.elasticsearch.cluster.routing.allocation.decider.NodeShutdownAllocationDecider;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.transport.TransportAddress;
+import org.elasticsearch.gateway.GatewayAllocator;
 import org.elasticsearch.index.Index;
 import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.node.Node;
 import org.elasticsearch.snapshots.SnapshotShardSizeInfo;
 import org.elasticsearch.snapshots.SnapshotsInfoService;
 import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.test.gateway.TestGatewayAllocator;
 import org.hamcrest.Matcher;
 import org.junit.Before;
 
@@ -123,6 +125,7 @@ public class TransportGetShutdownStatusActionTests extends ESTestCase {
             clusterInfoService,
             snapshotsInfoService
         );
+        allocationService.setExistingShardsAllocators(Map.of(GatewayAllocator.ALLOCATOR_NAME, new TestGatewayAllocator()));
     }
 
     /**

--- a/x-pack/plugin/shutdown/src/test/java/org/elasticsearch/xpack/shutdown/TransportGetShutdownStatusActionTests.java
+++ b/x-pack/plugin/shutdown/src/test/java/org/elasticsearch/xpack/shutdown/TransportGetShutdownStatusActionTests.java
@@ -358,8 +358,8 @@ public class TransportGetShutdownStatusActionTests extends ESTestCase {
     }
 
     /**
-     * Ensure we can detect stalled migrations, defined as the inability to move remaining shards off a shutting-down node due to allocation
-     * deciders.
+     * Ensure we can detect stalled migrations when we have unassigned shards that had the shutting down node as their last known
+     * node id
      */
     public void testStalledUnassigned() {
         Index index = new Index(randomAlphaOfLength(5), randomAlphaOfLengthBetween(1, 20));


### PR DESCRIPTION
`TransportGetShutdownStatusAction` has few checks that prevents a node from being shut down if there are shards without a copy which can't be moved. 

With this PR we also check if the node has unassigned primary shards and if it does, we return the STALLED status and prevent the node from being shut down. To ensure that the node was the last one to hold a copy of the unassigned shard, we check the `org.elasticsearch.cluster.routing.UnassignedInfo#lastAllocatedNodeId`.

- [x] Figure out what kind of integration tests I need to add

Closes #88635