### PR TITLE
[ML] add ability to filter and sort buckets by change_point numeric values

### DIFF
--- a/docs/changelog/91299.yaml
+++ b/docs/changelog/91299.yaml
@@ -1,0 +1,5 @@
+pr: 91299
+summary: Add ability to filter and sort buckets by `change_point` numeric values
+area: Machine Learning
+type: enhancement
+issues: []

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/aggs/changepoint/InternalChangePointAggregation.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/aggs/changepoint/InternalChangePointAggregation.java
@@ -75,6 +75,20 @@ public class InternalChangePointAggregation extends InternalAggregation {
 
     @Override
     public Object getProperty(List<String> path) {
+        if (path.size() == 1) {
+            String property = path.get(0);
+            if (property.equals("p_value")) {
+                return changeType.pValue();
+            }
+            if (property.equals("type")) {
+                return changeType.getName();
+            }
+            if (property.equals("change_point")) {
+                return changeType.changePoint();
+            }
+        } else if (path.size() > 1 && path.get(0).equals("bucket") && bucket != null) {
+            return bucket.getProperty(name, path.subList(1, path.size()));
+        }
         return null;
     }
 

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/ml/change_point_agg.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/ml/change_point_agg.yml
@@ -13,6 +13,8 @@ setup:
                 type: integer
               time:
                 type: date
+              kind:
+                type: keyword
 
   - do:
       headers:
@@ -36,53 +38,101 @@ setup:
         refresh: true
         body: |
           {"index":{}}
-          {"cost":200,"time":1587501233000}
+          {"cost":200,"time":1587501233000,"kind":"changed"}
           {"index":{}}
-          {"cost":200,"time":1587501243000}
+          {"cost":200,"time":1587501243000,"kind":"changed"}
           {"index":{}}
-          {"cost":200,"time":1587501253000}
+          {"cost":200,"time":1587501253000,"kind":"changed"}
           {"index":{}}
-          {"cost":250,"time":1587501263000}
+          {"cost":250,"time":1587501263000,"kind":"changed"}
           {"index":{}}
-          {"cost":250,"time":1587501273000}
+          {"cost":250,"time":1587501273000,"kind":"changed"}
           {"index":{}}
-          {"cost":580,"time":1587501283000}
+          {"cost":580,"time":1587501283000,"kind":"changed"}
           {"index":{}}
-          {"cost":600,"time":1587501293000}
+          {"cost":600,"time":1587501293000,"kind":"changed"}
           {"index":{}}
-          {"cost":600,"time":1587501303000}
+          {"cost":600,"time":1587501303000,"kind":"changed"}
           {"index":{}}
-          {"cost":600,"time":1587501313000}
+          {"cost":600,"time":1587501313000,"kind":"changed"}
           {"index":{}}
-          {"cost":600,"time":1587501313000}
+          {"cost":600,"time":1587501313000,"kind":"changed"}
           {"index":{}}
-          {"cost":600,"time":1587501323000}
+          {"cost":600,"time":1587501323000,"kind":"changed"}
           {"index":{}}
-          {"cost":600,"time":1587501333000}
+          {"cost":600,"time":1587501333000,"kind":"changed"}
           {"index":{}}
-          {"cost":600,"time":1587501343000}
+          {"cost":600,"time":1587501343000,"kind":"changed"}
           {"index":{}}
-          {"cost":600,"time":1587501353000}
+          {"cost":600,"time":1587501353000,"kind":"changed"}
           {"index":{}}
-          {"cost":600,"time":1587501363000}
+          {"cost":600,"time":1587501363000,"kind":"changed"}
           {"index":{}}
-          {"cost":600,"time":1587501373000}
+          {"cost":600,"time":1587501373000,"kind":"changed"}
           {"index":{}}
-          {"cost":600,"time":1587501383000}
+          {"cost":600,"time":1587501383000,"kind":"changed"}
           {"index":{}}
-          {"cost":600,"time":1587501393000}
+          {"cost":600,"time":1587501393000,"kind":"changed"}
           {"index":{}}
-          {"cost":600,"time":1587501403000}
+          {"cost":600,"time":1587501403000,"kind":"changed"}
           {"index":{}}
-          {"cost":600,"time":1587501413000}
+          {"cost":600,"time":1587501413000,"kind":"changed"}
           {"index":{}}
-          {"cost":600,"time":1587501423000}
+          {"cost":600,"time":1587501423000,"kind":"changed"}
           {"index":{}}
-          {"cost":600,"time":1587501433000}
+          {"cost":600,"time":1587501433000,"kind":"changed"}
           {"index":{}}
-          {"cost":600,"time":1587501443000}
+          {"cost":600,"time":1587501443000,"kind":"changed"}
           {"index":{}}
-          {"cost":600,"time":1587501453000}
+          {"cost":600,"time":1587501453000,"kind":"changed"}
+          {"index":{}}
+          {"cost":600,"time":1587501233000,"kind":"unchanged"}
+          {"index":{}}
+          {"cost":600,"time":1587501243000,"kind":"unchanged"}
+          {"index":{}}
+          {"cost":600,"time":1587501253000,"kind":"unchanged"}
+          {"index":{}}
+          {"cost":600,"time":1587501263000,"kind":"unchanged"}
+          {"index":{}}
+          {"cost":600,"time":1587501273000,"kind":"unchanged"}
+          {"index":{}}
+          {"cost":600,"time":1587501283000,"kind":"unchanged"}
+          {"index":{}}
+          {"cost":600,"time":1587501293000,"kind":"unchanged"}
+          {"index":{}}
+          {"cost":600,"time":1587501303000,"kind":"unchanged"}
+          {"index":{}}
+          {"cost":600,"time":1587501313000,"kind":"unchanged"}
+          {"index":{}}
+          {"cost":600,"time":1587501313000,"kind":"unchanged"}
+          {"index":{}}
+          {"cost":600,"time":1587501323000,"kind":"unchanged"}
+          {"index":{}}
+          {"cost":600,"time":1587501333000,"kind":"unchanged"}
+          {"index":{}}
+          {"cost":600,"time":1587501343000,"kind":"unchanged"}
+          {"index":{}}
+          {"cost":600,"time":1587501353000,"kind":"unchanged"}
+          {"index":{}}
+          {"cost":600,"time":1587501363000,"kind":"unchanged"}
+          {"index":{}}
+          {"cost":600,"time":1587501373000,"kind":"unchanged"}
+          {"index":{}}
+          {"cost":600,"time":1587501383000,"kind":"unchanged"}
+          {"index":{}}
+          {"cost":600,"time":1587501393000,"kind":"unchanged"}
+          {"index":{}}
+          {"cost":600,"time":1587501403000,"kind":"unchanged"}
+          {"index":{}}
+          {"cost":600,"time":1587501413000,"kind":"unchanged"}
+          {"index":{}}
+          {"cost":600,"time":1587501423000,"kind":"unchanged"}
+          {"index":{}}
+          {"cost":600,"time":1587501433000,"kind":"unchanged"}
+          {"index":{}}
+          {"cost":600,"time":1587501443000,"kind":"unchanged"}
+          {"index":{}}
+          {"cost":600,"time":1587501453000,"kind":"unchanged"}
 
 ---
 "Test change_point agg simple":
@@ -100,8 +150,8 @@ setup:
                   "fixed_interval": "1s"
                 },
                 "aggs": {
-                  "avg": {
-                    "avg": {
+                  "min": {
+                    "min": {
                       "field": "cost"
                     }
                   }
@@ -109,7 +159,7 @@ setup:
               },
               "change_point": {
                 "change_point": {
-                  "buckets_path": "date>avg"
+                  "buckets_path": "date>min"
                 }
               }
             }
@@ -196,8 +246,8 @@ setup:
                   "fixed_interval": "1s"
                 },
                 "aggs": {
-                  "avg": {
-                    "avg": {
+                  "min": {
+                    "min": {
                       "field": "cost"
                     }
                   }
@@ -211,3 +261,137 @@ setup:
             }
           }
   - is_true: aggregations.change_point.type.indeterminable
+---
+"Test change_point with terms":
+  - do:
+      search:
+        index: store
+        size: 0
+        body: >
+          {
+            "aggs": {
+              "terms": {
+                 "terms": {
+                   "field": "kind"
+                 },
+                 "aggs": {
+                    "date": {
+                      "date_histogram": {
+                        "field": "time",
+                        "fixed_interval": "1s"
+                      },
+                      "aggs": {
+                        "min": {
+                          "min": {
+                            "field": "cost"
+                          }
+                        }
+                      }
+                    },
+                    "change_point": {
+                      "change_point": {
+                        "buckets_path": "date>min"
+                      }
+                    }
+                 }
+              }
+            }
+          }
+  - is_true: aggregations.terms.buckets.0.change_point.type.trend_change
+  - is_true: aggregations.terms.buckets.0.change_point.type.trend_change.p_value
+  - is_true: aggregations.terms.buckets.0.change_point.type.trend_change.r_value
+  - is_false: aggregations.terms.buckets.1.change_point.type.trend_change
+  - is_false: aggregations.terms.buckets.1.change_point.type.trend_change.p_value
+  - is_false: aggregations.terms.buckets.1.change_point.type.trend_change.r_value
+
+  - do:
+      search:
+        index: store
+        size: 0
+        body: >
+          {
+            "aggs": {
+              "terms": {
+                 "terms": {
+                   "field": "kind"
+                 },
+                 "aggs": {
+                    "date": {
+                      "date_histogram": {
+                        "field": "time",
+                        "fixed_interval": "1s"
+                      },
+                      "aggs": {
+                        "min": {
+                          "min": {
+                            "field": "cost"
+                          }
+                        }
+                      }
+                    },
+                    "change_point": {
+                      "change_point": {
+                        "buckets_path": "date>min"
+                      }
+                    },
+                    "select": {
+                      "bucket_selector": {
+                        "buckets_path": {"p_value": "change_point.p_value"},
+                        "script": "params.p_value < 0.5"
+                      }
+                    }
+                 }
+              }
+            }
+          }
+  - length: {aggregations.terms.buckets: 1}
+  - is_true: aggregations.terms.buckets.0.change_point.type.trend_change
+  - is_true: aggregations.terms.buckets.0.change_point.type.trend_change.p_value
+  - is_true: aggregations.terms.buckets.0.change_point.type.trend_change.r_value
+
+  - do:
+      search:
+        index: store
+        size: 0
+        body: >
+          {
+            "aggs": {
+              "terms": {
+                 "terms": {
+                   "field": "kind"
+                 },
+                 "aggs": {
+                    "date": {
+                      "date_histogram": {
+                        "field": "time",
+                        "fixed_interval": "1s"
+                      },
+                      "aggs": {
+                        "min": {
+                          "min": {
+                            "field": "cost"
+                          }
+                        }
+                      }
+                    },
+                    "change_point": {
+                      "change_point": {
+                        "buckets_path": "date>min"
+                      }
+                    },
+                    "sort": {
+                      "bucket_sort": {
+                        "sort": [{"change_point.p_value": {"order": "desc"}}]
+                      }
+                    }
+                 }
+              }
+            }
+          }
+  - length: {aggregations.terms.buckets: 2}
+  - is_false: aggregations.terms.buckets.0.change_point.type.trend_change
+  - is_false: aggregations.terms.buckets.0.change_point.type.trend_change.p_value
+  - is_false: aggregations.terms.buckets.0.change_point.type.trend_change.r_value
+  - is_true: aggregations.terms.buckets.1.change_point.type.trend_change
+  - is_true: aggregations.terms.buckets.1.change_point.type.trend_change.p_value
+  - is_true: aggregations.terms.buckets.1.change_point.type.trend_change.r_value


### PR DESCRIPTION
The `change_point` aggregation automatically detects the most statistically impactful changepoint in a series of buckets. There is occasion to detect change points over many different timeseries facets. Some of those facets may have no changes at all, so, it would be prudent to filter those from the response.

This commit allows the `p_value`, `type`, and internal bucket values to be used by other pipeline aggregations. Two specific and useful cases are: bucket_selector and bucket_sort. Allowing facets to be sorted by which had the largest changes and simply filtering out those with no changes at all.

closes: https://github.com/elastic/elasticsearch/issues/91281