### PR TITLE
Rename NamedComponent name parameter to value

### DIFF
--- a/build-tools/src/integTest/groovy/org/elasticsearch/gradle/plugin/StablePluginBuildPluginFuncTest.groovy
+++ b/build-tools/src/integTest/groovy/org/elasticsearch/gradle/plugin/StablePluginBuildPluginFuncTest.groovy
@@ -90,7 +90,7 @@ class StablePluginBuildPluginFuncTest extends AbstractGradleFuncTest {
             import org.elasticsearch.plugin.api.NamedComponent;
             import org.elasticsearch.plugin.scanner.test_classes.ExtensibleClass;
 
-            @NamedComponent(name = "componentA")
+            @NamedComponent( "componentA")
             public class A extends ExtensibleClass {
             }
         """

--- a/build-tools/src/main/java/org/elasticsearch/gradle/plugin/scanner/NamedComponentScanner.java
+++ b/build-tools/src/main/java/org/elasticsearch/gradle/plugin/scanner/NamedComponentScanner.java
@@ -31,8 +31,8 @@ public class NamedComponentScanner {
             "Lorg/elasticsearch/plugin/api/NamedComponent;"/*NamedComponent.class*/,
             (classname, map) -> new AnnotationVisitor(Opcodes.ASM9) {
                 @Override
-                public void visit(String name, Object value) {
-                    assert name.equals("name");
+                public void visit(String key, Object value) {
+                    assert key.equals("value");
                     assert value instanceof String;
                     map.put(value.toString(), classname);
                 }

--- a/build-tools/src/test/groovy/org/elasticsearch/gradle/plugin/scanner/NamedComponentScannerSpec.groovy
+++ b/build-tools/src/test/groovy/org/elasticsearch/gradle/plugin/scanner/NamedComponentScannerSpec.groovy
@@ -76,7 +76,7 @@ class NamedComponentScannerSpec extends Specification {
             package p;
             import org.elasticsearch.plugin.api.*;
             import org.elasticsearch.plugin.scanner.test_classes.*;
-            @NamedComponent(name = "a_component")
+            @NamedComponent( "a_component")
             public class A extends ExtensibleClass {}
             """
         ), "p/B.class", InMemoryJavaCompiler.compile(
@@ -84,7 +84,7 @@ class NamedComponentScannerSpec extends Specification {
             package p;
             import org.elasticsearch.plugin.api.*;
             import org.elasticsearch.plugin.scanner.test_classes.*;
-            @NamedComponent(name = "b_component")
+            @NamedComponent( "b_component")
             public class B implements ExtensibleInterface{}
             """
         )
@@ -136,7 +136,7 @@ class NamedComponentScannerSpec extends Specification {
                 package p;
                 import org.elasticsearch.plugin.api.*;
                 import org.elasticsearch.plugin.scanner.test_classes.*;
-                @NamedComponent(name = "a_component")
+                @NamedComponent( "a_component")
                 public class A extends CustomExtensibleClass {}
                 """,
             "p.B",
@@ -144,7 +144,7 @@ class NamedComponentScannerSpec extends Specification {
                 package p;
                 import org.elasticsearch.plugin.api.*;
                 import org.elasticsearch.plugin.scanner.test_classes.*;
-                @NamedComponent(name = "b_component")
+                @NamedComponent( "b_component")
                 public class B implements CustomExtensibleInterface{}
                 """
         );

--- a/build-tools/src/test/groovy/org/elasticsearch/gradle/plugin/scanner/NamedComponentScannerSpec.groovy
+++ b/build-tools/src/test/groovy/org/elasticsearch/gradle/plugin/scanner/NamedComponentScannerSpec.groovy
@@ -76,7 +76,7 @@ class NamedComponentScannerSpec extends Specification {
             package p;
             import org.elasticsearch.plugin.api.*;
             import org.elasticsearch.plugin.scanner.test_classes.*;
-            @NamedComponent( "a_component")
+            @NamedComponent("a_component")
             public class A extends ExtensibleClass {}
             """
         ), "p/B.class", InMemoryJavaCompiler.compile(
@@ -84,7 +84,7 @@ class NamedComponentScannerSpec extends Specification {
             package p;
             import org.elasticsearch.plugin.api.*;
             import org.elasticsearch.plugin.scanner.test_classes.*;
-            @NamedComponent( "b_component")
+            @NamedComponent("b_component")
             public class B implements ExtensibleInterface{}
             """
         )
@@ -136,7 +136,7 @@ class NamedComponentScannerSpec extends Specification {
                 package p;
                 import org.elasticsearch.plugin.api.*;
                 import org.elasticsearch.plugin.scanner.test_classes.*;
-                @NamedComponent( "a_component")
+                @NamedComponent("a_component")
                 public class A extends CustomExtensibleClass {}
                 """,
             "p.B",
@@ -144,7 +144,7 @@ class NamedComponentScannerSpec extends Specification {
                 package p;
                 import org.elasticsearch.plugin.api.*;
                 import org.elasticsearch.plugin.scanner.test_classes.*;
-                @NamedComponent( "b_component")
+                @NamedComponent("b_component")
                 public class B implements CustomExtensibleInterface{}
                 """
         );

--- a/build-tools/src/testFixtures/java/org/elasticsearch/plugin/api/NamedComponent.java
+++ b/build-tools/src/testFixtures/java/org/elasticsearch/plugin/api/NamedComponent.java
@@ -20,5 +20,5 @@ public @interface NamedComponent {
      * The name used for registration and lookup
      * @return a name
      */
-    String name();
+    String value();
 }

--- a/build-tools/src/testFixtures/java/org/elasticsearch/plugin/scanner/test_classes/TestNamedComponent.java
+++ b/build-tools/src/testFixtures/java/org/elasticsearch/plugin/scanner/test_classes/TestNamedComponent.java
@@ -8,7 +8,7 @@
 
 package org.elasticsearch.plugin.scanner.test_classes;
 
-@org.elasticsearch.plugin.api.NamedComponent(name = "test_named_component")
+@org.elasticsearch.plugin.api.NamedComponent("test_named_component")
 public class TestNamedComponent implements ExtensibleInterface {
 
 }

--- a/docs/changelog/91306.yaml
+++ b/docs/changelog/91306.yaml
@@ -1,0 +1,5 @@
+pr: 91306
+summary: Rename `NamedComponent` name parameter to value
+area: Infra/Plugins
+type: enhancement
+issues: []

--- a/libs/plugin-api/src/main/java/org/elasticsearch/plugin/api/Nameable.java
+++ b/libs/plugin-api/src/main/java/org/elasticsearch/plugin/api/Nameable.java
@@ -22,7 +22,7 @@ public interface Nameable {
     default String name() {
         NamedComponent[] annotationsByType = this.getClass().getAnnotationsByType(NamedComponent.class);
         if (annotationsByType.length == 1) {
-            return annotationsByType[0].name();
+            return annotationsByType[0].value();
         }
         return null;
     }

--- a/libs/plugin-api/src/main/java/org/elasticsearch/plugin/api/NamedComponent.java
+++ b/libs/plugin-api/src/main/java/org/elasticsearch/plugin/api/NamedComponent.java
@@ -23,5 +23,5 @@ public @interface NamedComponent {
      * The name used for registration and lookup
      * @return a name
      */
-    String name();
+    String value();
 }

--- a/plugins/examples/stable-analysis/src/main/java/org/elasticsearch/example/analysis/ExampleAnalyzerFactory.java
+++ b/plugins/examples/stable-analysis/src/main/java/org/elasticsearch/example/analysis/ExampleAnalyzerFactory.java
@@ -14,7 +14,7 @@ import org.elasticsearch.example.analysis.lucene.Skip1TokenFilter;
 import org.elasticsearch.example.analysis.lucene.UnderscoreTokenizer;
 import org.elasticsearch.plugin.api.NamedComponent;
 
-@NamedComponent(name = "example_analyzer_factory")
+@NamedComponent( "example_analyzer_factory")
 public class ExampleAnalyzerFactory implements org.elasticsearch.plugin.analysis.api.AnalyzerFactory {
 
     @Override

--- a/plugins/examples/stable-analysis/src/main/java/org/elasticsearch/example/analysis/ExampleCharFilterFactory.java
+++ b/plugins/examples/stable-analysis/src/main/java/org/elasticsearch/example/analysis/ExampleCharFilterFactory.java
@@ -15,7 +15,7 @@ import org.elasticsearch.plugin.api.NamedComponent;
 
 import java.io.Reader;
 
-@NamedComponent(name = "example_char_filter")
+@NamedComponent( "example_char_filter")
 public class ExampleCharFilterFactory implements CharFilterFactory {
     @Override
     public Reader create(Reader reader) {

--- a/plugins/examples/stable-analysis/src/main/java/org/elasticsearch/example/analysis/ExampleTokenFilterFactory.java
+++ b/plugins/examples/stable-analysis/src/main/java/org/elasticsearch/example/analysis/ExampleTokenFilterFactory.java
@@ -14,7 +14,7 @@ import org.elasticsearch.example.analysis.lucene.Skip1TokenFilter;
 import org.elasticsearch.plugin.analysis.api.AnalysisMode;
 import org.elasticsearch.plugin.api.NamedComponent;
 
-@NamedComponent(name = "example_token_filter_factory")
+@NamedComponent( "example_token_filter_factory")
 public class ExampleTokenFilterFactory implements org.elasticsearch.plugin.analysis.api.TokenFilterFactory {
     @Override
     public TokenStream create(TokenStream tokenStream) {

--- a/plugins/examples/stable-analysis/src/main/java/org/elasticsearch/example/analysis/ExampleTokenizerFactory.java
+++ b/plugins/examples/stable-analysis/src/main/java/org/elasticsearch/example/analysis/ExampleTokenizerFactory.java
@@ -13,7 +13,7 @@ import org.elasticsearch.example.analysis.lucene.UnderscoreTokenizer;
 import org.elasticsearch.plugin.analysis.api.TokenizerFactory;
 import org.elasticsearch.plugin.api.NamedComponent;
 
-@NamedComponent(name = "example_tokenizer_factory")
+@NamedComponent( "example_tokenizer_factory")
 public class ExampleTokenizerFactory implements TokenizerFactory {
     @Override
     public Tokenizer create() {

--- a/server/src/test/java/org/elasticsearch/indices/analysis/AnalysisModuleTests.java
+++ b/server/src/test/java/org/elasticsearch/indices/analysis/AnalysisModuleTests.java
@@ -476,7 +476,7 @@ public class AnalysisModuleTests extends ESTestCase {
         assertSame(dictionary, module.getHunspellService().getDictionary("foo"));
     }
 
-    @NamedComponent(name = "stableCharFilterFactory")
+    @NamedComponent("stableCharFilterFactory")
     public static class TestCharFilterFactory implements org.elasticsearch.plugin.analysis.api.CharFilterFactory {
         @SuppressForbidden(reason = "need a public constructor")
         public TestCharFilterFactory() {}
@@ -506,7 +506,7 @@ public class AnalysisModuleTests extends ESTestCase {
         }
     }
 
-    @NamedComponent(name = "stableTokenFilterFactory")
+    @NamedComponent("stableTokenFilterFactory")
     public static class TestTokenFilterFactory implements org.elasticsearch.plugin.analysis.api.TokenFilterFactory {
 
         @SuppressForbidden(reason = "need a public constructor")
@@ -544,7 +544,7 @@ public class AnalysisModuleTests extends ESTestCase {
         }
     }
 
-    @NamedComponent(name = "stableTokenizerFactory")
+    @NamedComponent("stableTokenizerFactory")
     public static class TestTokenizerFactory implements org.elasticsearch.plugin.analysis.api.TokenizerFactory {
         @SuppressForbidden(reason = "need a public constructor")
         public TestTokenizerFactory() {}
@@ -564,7 +564,7 @@ public class AnalysisModuleTests extends ESTestCase {
         }
     }
 
-    @NamedComponent(name = "stableAnalyzerFactory")
+    @NamedComponent("stableAnalyzerFactory")
     public static class TestAnalyzerFactory implements org.elasticsearch.plugin.analysis.api.AnalyzerFactory {
 
         @Override

--- a/server/src/test/java/org/elasticsearch/indices/analysis/wrappers/StableApiWrappersTests.java
+++ b/server/src/test/java/org/elasticsearch/indices/analysis/wrappers/StableApiWrappersTests.java
@@ -197,7 +197,7 @@ public class StableApiWrappersTests extends ESTestCase {
         assertThat(charFilterFactory.name(), equalTo("TestCharFilterFactory"));
     }
 
-    @NamedComponent(name = "DefaultConstrAnalyzerFactory")
+    @NamedComponent("DefaultConstrAnalyzerFactory")
     public static class DefaultConstrAnalyzerFactory implements org.elasticsearch.plugin.analysis.api.AnalyzerFactory {
 
         public DefaultConstrAnalyzerFactory(int x) {}
@@ -209,7 +209,7 @@ public class StableApiWrappersTests extends ESTestCase {
 
     }
 
-    @NamedComponent(name = "TestAnalyzerFactory")
+    @NamedComponent("TestAnalyzerFactory")
     public static class TestAnalyzerFactory implements org.elasticsearch.plugin.analysis.api.AnalyzerFactory {
 
         @Override
@@ -219,7 +219,7 @@ public class StableApiWrappersTests extends ESTestCase {
 
     }
 
-    @NamedComponent(name = "TestTokenizerFactory")
+    @NamedComponent("TestTokenizerFactory")
     public static class TestTokenizerFactory implements org.elasticsearch.plugin.analysis.api.TokenizerFactory {
 
         @Override
@@ -228,7 +228,7 @@ public class StableApiWrappersTests extends ESTestCase {
         }
     }
 
-    @NamedComponent(name = "TestTokenFilterFactory")
+    @NamedComponent("TestTokenFilterFactory")
     public static class TestTokenFilterFactory implements org.elasticsearch.plugin.analysis.api.TokenFilterFactory {
 
         @Override
@@ -253,7 +253,7 @@ public class StableApiWrappersTests extends ESTestCase {
         }
     }
 
-    @NamedComponent(name = "TestCharFilterFactory")
+    @NamedComponent("TestCharFilterFactory")
     public static class TestCharFilterFactory implements org.elasticsearch.plugin.analysis.api.CharFilterFactory {
 
         @Override

--- a/server/src/test/java/org/elasticsearch/plugins/PluginsServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/plugins/PluginsServiceTests.java
@@ -795,7 +795,7 @@ public class PluginsServiceTests extends ESTestCase {
             import org.elasticsearch.plugin.analysis.api.CharFilterFactory;
             import org.elasticsearch.plugin.api.NamedComponent;
             import java.io.Reader;
-            @NamedComponent(name = "a_name")
+            @NamedComponent( "a_name")
             public class A  implements CharFilterFactory {
                  @Override
                 public Reader create(Reader reader) {


### PR DESCRIPTION
to allow @NamedComponent("name") syntax java annotation should have single value annotation

relates #88980

<!--
Thank you for your interest in and contributing to Elasticsearch! There
are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your
attention.
-->

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/elasticsearch/blob/main/CONTRIBUTING.md)?
- If submitting code, have you built your formula locally prior to submission with `gradle check`?
- If submitting code, is your pull request against main? Unless there is a good reason otherwise, we prefer pull requests against main and will backport as needed.
- If submitting code, have you checked that your submission is for an [OS and architecture that we support](https://www.elastic.co/support/matrix#show_os)?
- If you are submitting this code for a class then read our [policy](https://github.com/elastic/elasticsearch/blob/main/CONTRIBUTING.md#contributing-as-part-of-a-class) for that.
