### PR TITLE
Only add ReadTimeoutHandler to Netty4 http pipeline if not a noop

### DIFF
--- a/modules/transport-netty4/src/main/java/org/elasticsearch/http/netty4/Netty4HttpServerTransport.java
+++ b/modules/transport-netty4/src/main/java/org/elasticsearch/http/netty4/Netty4HttpServerTransport.java
@@ -307,21 +307,25 @@ public class Netty4HttpServerTransport extends AbstractHttpServerTransport {
         protected void initChannel(Channel ch) throws Exception {
             Netty4HttpChannel nettyHttpChannel = new Netty4HttpChannel(ch);
             ch.attr(HTTP_CHANNEL_KEY).set(nettyHttpChannel);
-            ch.pipeline().addLast("chunked_writer", new Netty4WriteThrottlingHandler(transport.getThreadPool().getThreadContext()));
-            ch.pipeline().addLast("byte_buf_sizer", NettyByteBufSizer.INSTANCE);
-            ch.pipeline().addLast("read_timeout", new ReadTimeoutHandler(transport.readTimeoutMillis, TimeUnit.MILLISECONDS));
+            ch.pipeline()
+                .addLast("chunked_writer", new Netty4WriteThrottlingHandler(transport.getThreadPool().getThreadContext()))
+                .addLast("byte_buf_sizer", NettyByteBufSizer.INSTANCE);
+            if (transport.readTimeoutMillis > 0) {
+                ch.pipeline().addLast("read_timeout", new ReadTimeoutHandler(transport.readTimeoutMillis, TimeUnit.MILLISECONDS));
+            }
             final HttpRequestDecoder decoder = new HttpRequestDecoder(
                 handlingSettings.maxInitialLineLength(),
                 handlingSettings.maxHeaderSize(),
                 handlingSettings.maxChunkSize()
             );
             decoder.setCumulator(ByteToMessageDecoder.COMPOSITE_CUMULATOR);
-            ch.pipeline().addLast("decoder", decoder);
-            ch.pipeline().addLast("decoder_compress", new HttpContentDecompressor());
-            ch.pipeline().addLast("encoder", new HttpResponseEncoder());
             final HttpObjectAggregator aggregator = new HttpObjectAggregator(handlingSettings.maxContentLength());
             aggregator.setMaxCumulationBufferComponents(transport.maxCompositeBufferComponents);
-            ch.pipeline().addLast("aggregator", aggregator);
+            ch.pipeline()
+                .addLast("decoder", decoder)
+                .addLast("decoder_compress", new HttpContentDecompressor())
+                .addLast("encoder", new HttpResponseEncoder())
+                .addLast("aggregator", aggregator);
             if (handlingSettings.compression()) {
                 ch.pipeline().addLast("encoder_compress", new HttpContentCompressor(handlingSettings.compressionLevel()));
             }


### PR DESCRIPTION
No need to add this for the (default) case of no http read timeout, it just adds needless overhead and makes profiling harder to read (which with the complicated chunked encoding in the pipeline is kind of neat to have as simple as can be otherwise).
Also, removed a little clutter from the code that sets up the pipeline by chaining where possible, just to make the order of handlers a little easier to extract at first sight.
