### PR TITLE
[TEST] Adjust test for single wildcard when wildcards are not expanded

### DIFF
--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/indices.get_mapping/50_wildcard_expansion.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/indices.get_mapping/50_wildcard_expansion.yml
@@ -114,6 +114,7 @@ setup:
     indices.get_mapping:
         index: test-x*
         expand_wildcards: none
+        ignore_unavailable: true
 
  - match: { '':  {} }
 ---


### PR DESCRIPTION
In https://github.com/elastic/elasticsearch/pull/91231#discussion_r1012148829 we concluded that a request that
contains a single wildcard but that also sets `expand_wildcards`
to `none` should throw a "not found" exception if
`ignore_unavailable` is `false`.

This PR adjusts the 7.x test in order to account for that,
in order to pass the rest-compatibility tests in 8.*.

Related: https://github.com/elastic/elasticsearch/pull/91231