### PR TITLE
[7.x] Fix TransportResponse reference counting in DirectResponseChannel (#91289)

### DIFF
--- a/server/src/main/java/org/elasticsearch/transport/TransportService.java
+++ b/server/src/main/java/org/elasticsearch/transport/TransportService.java
@@ -1520,26 +1520,43 @@ public class TransportService extends AbstractLifecycleComponent
 
         @Override
         public void sendResponse(TransportResponse response) throws IOException {
-            service.onResponseSent(requestId, action, response);
-            final TransportResponseHandler<?> handler = service.responseHandlers.onResponseReceived(requestId, service);
-            // ignore if its null, the service logs it
-            if (handler != null) {
-                final String executor = handler.executor();
-                if (ThreadPool.Names.SAME.equals(executor)) {
-                    processResponse(handler, response);
-                } else {
-                    threadPool.executor(executor).execute(new Runnable() {
-                        @Override
-                        public void run() {
-                            processResponse(handler, response);
-                        }
+            try {
+                service.onResponseSent(requestId, action, response);
+                final TransportResponseHandler<?> handler = service.responseHandlers.onResponseReceived(requestId, service);
+                // ignore if its null, the service logs it
+                if (handler != null) {
+                    final String executor = handler.executor();
+                    if (ThreadPool.Names.SAME.equals(executor)) {
+                        processResponse(handler, response);
+                    } else {
+                        boolean success = false;
+                        response.incRef();
+                        try {
+                            threadPool.executor(executor).execute(new Runnable() {
+                                @Override
+                                public void run() {
+                                    try {
+                                        processResponse(handler, response);
+                                    } finally {
+                                        response.decRef();
+                                    }
+                                }
 
-                        @Override
-                        public String toString() {
-                            return "delivery of response to [" + requestId + "][" + action + "]: " + response;
+                                @Override
+                                public String toString() {
+                                    return "delivery of response to [" + requestId + "][" + action + "]: " + response;
+                                }
+                            });
+                            success = true;
+                        } finally {
+                            if (success == false) {
+                                response.decRef();
+                            }
                         }
-                    });
+                    }
                 }
+            } finally {
+                response.decRef();
             }
         }
 

--- a/server/src/test/java/org/elasticsearch/cluster/coordination/PublicationTransportHandlerTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/coordination/PublicationTransportHandlerTests.java
@@ -180,7 +180,10 @@ public class PublicationTransportHandlerTests extends ESTestCase {
                 new MockBigArrays(PageCacheRecycler.NON_RECYCLING_INSTANCE, new NoneCircuitBreakerService()),
                 transportService,
                 writableRegistry(),
-                pu -> null,
+                pu -> new PublishWithJoinResponse(
+                    new PublishResponse(randomNonNegativeLong(), randomNonNegativeLong()),
+                    Optional.empty()
+                ),
                 (pu, l) -> {}
             );
             transportService.start();

--- a/server/src/test/java/org/elasticsearch/cluster/coordination/PublicationTransportHandlerTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/coordination/PublicationTransportHandlerTests.java
@@ -180,10 +180,7 @@ public class PublicationTransportHandlerTests extends ESTestCase {
                 new MockBigArrays(PageCacheRecycler.NON_RECYCLING_INSTANCE, new NoneCircuitBreakerService()),
                 transportService,
                 writableRegistry(),
-                pu -> new PublishWithJoinResponse(
-                    new PublishResponse(randomNonNegativeLong(), randomNonNegativeLong()),
-                    Optional.empty()
-                ),
+                pu -> new PublishWithJoinResponse(new PublishResponse(randomNonNegativeLong(), randomNonNegativeLong()), Optional.empty()),
                 (pu, l) -> {}
             );
             transportService.start();

--- a/server/src/test/java/org/elasticsearch/transport/TransportActionProxyTests.java
+++ b/server/src/test/java/org/elasticsearch/transport/TransportActionProxyTests.java
@@ -14,6 +14,8 @@ import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.core.AbstractRefCounted;
+import org.elasticsearch.core.RefCounted;
 import org.elasticsearch.core.internal.io.IOUtils;
 import org.elasticsearch.tasks.CancellableTask;
 import org.elasticsearch.tasks.Task;
@@ -27,8 +29,10 @@ import org.junit.Before;
 import java.io.IOException;
 import java.util.Map;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicReference;
 
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.notNullValue;
 
 public class TransportActionProxyTests extends ESTestCase {
     protected ThreadPool threadPool;
@@ -76,8 +80,9 @@ public class TransportActionProxyTests extends ESTestCase {
     public void testSendMessage() throws InterruptedException {
         serviceA.registerRequestHandler("internal:test", ThreadPool.Names.SAME, SimpleTestRequest::new, (request, channel, task) -> {
             assertEquals(request.sourceNode, "TS_A");
-            SimpleTestResponse response = new SimpleTestResponse("TS_A");
+            final SimpleTestResponse response = new SimpleTestResponse("TS_A");
             channel.sendResponse(response);
+            assertThat(response.hasReferences(), equalTo(false));
         });
         final boolean cancellable = randomBoolean();
         TransportActionProxy.registerProxyAction(serviceA, "internal:test", cancellable, SimpleTestResponse::new);
@@ -86,21 +91,24 @@ public class TransportActionProxyTests extends ESTestCase {
         serviceB.registerRequestHandler("internal:test", ThreadPool.Names.SAME, SimpleTestRequest::new, (request, channel, task) -> {
             assertThat(task instanceof CancellableTask, equalTo(cancellable));
             assertEquals(request.sourceNode, "TS_A");
-            SimpleTestResponse response = new SimpleTestResponse("TS_B");
+            final SimpleTestResponse response = new SimpleTestResponse("TS_B");
             channel.sendResponse(response);
+            assertThat(response.hasReferences(), equalTo(false));
         });
         TransportActionProxy.registerProxyAction(serviceB, "internal:test", cancellable, SimpleTestResponse::new);
         serviceB.connectToNode(nodeC);
         serviceC.registerRequestHandler("internal:test", ThreadPool.Names.SAME, SimpleTestRequest::new, (request, channel, task) -> {
             assertThat(task instanceof CancellableTask, equalTo(cancellable));
             assertEquals(request.sourceNode, "TS_A");
-            SimpleTestResponse response = new SimpleTestResponse("TS_C");
+            final SimpleTestResponse response = new SimpleTestResponse("TS_C");
             channel.sendResponse(response);
+            assertThat(response.hasReferences(), equalTo(false));
         });
 
         TransportActionProxy.registerProxyAction(serviceC, "internal:test", cancellable, SimpleTestResponse::new);
 
-        CountDownLatch latch = new CountDownLatch(1);
+        final CountDownLatch latch = new CountDownLatch(1);
+        // Node A -> Node B -> Node C
         serviceA.sendRequest(
             nodeB,
             TransportActionProxy.getProxyAction("internal:test"),
@@ -131,6 +139,61 @@ public class TransportActionProxyTests extends ESTestCase {
             }
         );
         latch.await();
+    }
+
+    public void testSendLocalRequest() throws InterruptedException {
+        final AtomicReference<SimpleTestResponse> response = new AtomicReference<>();
+        final boolean cancellable = randomBoolean();
+        serviceB.registerRequestHandler(
+            "internal:test",
+            randomFrom(ThreadPool.Names.SAME, ThreadPool.Names.GENERIC),
+            SimpleTestRequest::new,
+            (request, channel, task) -> {
+                assertThat(task instanceof CancellableTask, equalTo(cancellable));
+                assertEquals(request.sourceNode, "TS_A");
+                final SimpleTestResponse responseB = new SimpleTestResponse("TS_B");
+                channel.sendResponse(responseB);
+                response.set(responseB);
+            }
+        );
+        TransportActionProxy.registerProxyAction(serviceB, "internal:test", cancellable, SimpleTestResponse::new);
+        serviceA.connectToNode(nodeB);
+
+        final CountDownLatch latch = new CountDownLatch(1);
+        // Node A -> Proxy Node B (Local execution)
+        serviceA.sendRequest(
+            nodeB,
+            TransportActionProxy.getProxyAction("internal:test"),
+            TransportActionProxy.wrapRequest(nodeB, new SimpleTestRequest("TS_A", cancellable)), // Request
+            new TransportResponseHandler<SimpleTestResponse>() {
+                @Override
+                public SimpleTestResponse read(StreamInput in) throws IOException {
+                    return new SimpleTestResponse(in);
+                }
+
+                @Override
+                public void handleResponse(SimpleTestResponse response) {
+                    try {
+                        assertEquals("TS_B", response.targetNode);
+                    } finally {
+                        latch.countDown();
+                    }
+                }
+
+                @Override
+                public void handleException(TransportException exp) {
+                    try {
+                        throw new AssertionError(exp);
+                    } finally {
+                        latch.countDown();
+                    }
+                }
+            }
+        );
+        latch.await();
+
+        assertThat(response.get(), notNullValue());
+        assertThat(response.get().hasReferences(), equalTo(false));
     }
 
     public void testException() throws InterruptedException {
@@ -230,7 +293,12 @@ public class TransportActionProxyTests extends ESTestCase {
     }
 
     public static class SimpleTestResponse extends TransportResponse {
+
         final String targetNode;
+        final RefCounted refCounted = new AbstractRefCounted() {
+            @Override
+            protected void closeInternal() {}
+        };
 
         SimpleTestResponse(String targetNode) {
             this.targetNode = targetNode;
@@ -244,6 +312,26 @@ public class TransportActionProxyTests extends ESTestCase {
         @Override
         public void writeTo(StreamOutput out) throws IOException {
             out.writeString(targetNode);
+        }
+
+        @Override
+        public void incRef() {
+            refCounted.incRef();
+        }
+
+        @Override
+        public boolean tryIncRef() {
+            return refCounted.tryIncRef();
+        }
+
+        @Override
+        public boolean decRef() {
+            return refCounted.decRef();
+        }
+
+        @Override
+        public boolean hasReferences() {
+            return refCounted.hasReferences();
         }
     }
 

--- a/server/src/test/java/org/elasticsearch/transport/TransportActionProxyTests.java
+++ b/server/src/test/java/org/elasticsearch/transport/TransportActionProxyTests.java
@@ -141,25 +141,30 @@ public class TransportActionProxyTests extends ESTestCase {
         latch.await();
     }
 
-    public void testSendLocalRequest() throws InterruptedException {
+    public void testSendLocalRequest() throws Exception {
         final AtomicReference<SimpleTestResponse> response = new AtomicReference<>();
+        final CountDownLatch latch = new CountDownLatch(2);
+
         final boolean cancellable = randomBoolean();
         serviceB.registerRequestHandler(
             "internal:test",
             randomFrom(ThreadPool.Names.SAME, ThreadPool.Names.GENERIC),
             SimpleTestRequest::new,
             (request, channel, task) -> {
-                assertThat(task instanceof CancellableTask, equalTo(cancellable));
-                assertEquals(request.sourceNode, "TS_A");
-                final SimpleTestResponse responseB = new SimpleTestResponse("TS_B");
-                channel.sendResponse(responseB);
-                response.set(responseB);
+                try {
+                    assertThat(task instanceof CancellableTask, equalTo(cancellable));
+                    assertEquals(request.sourceNode, "TS_A");
+                    final SimpleTestResponse responseB = new SimpleTestResponse("TS_B");
+                    channel.sendResponse(responseB);
+                    response.set(responseB);
+                } finally {
+                    latch.countDown();
+                }
             }
         );
         TransportActionProxy.registerProxyAction(serviceB, "internal:test", cancellable, SimpleTestResponse::new);
         serviceA.connectToNode(nodeB);
 
-        final CountDownLatch latch = new CountDownLatch(1);
         // Node A -> Proxy Node B (Local execution)
         serviceA.sendRequest(
             nodeB,
@@ -193,7 +198,7 @@ public class TransportActionProxyTests extends ESTestCase {
         latch.await();
 
         assertThat(response.get(), notNullValue());
-        assertThat(response.get().hasReferences(), equalTo(false));
+        assertBusy(() -> assertThat(response.get().hasReferences(), equalTo(false)));
     }
 
     public void testException() throws InterruptedException {


### PR DESCRIPTION
Backport of #91289 with some adjustments.