### PR TITLE
[8.5] [DOCS] Clarify description of geo_results (#91237)

### DIFF
--- a/docs/reference/ml/anomaly-detection/apis/get-record.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/get-record.asciidoc
@@ -76,6 +76,7 @@ default, the records are sorted by the `record_score` value.
 (Optional, string) Returns records with timestamps after this time. Defaults to
 `-1`, which means it is unset and results are not limited to specific timestamps.
 
+[role="child_attributes"]
 [[ml-get-record-request-body]]
 == {api-request-body-title}
 
@@ -96,6 +97,7 @@ You can also specify the query parameters in the request body; the exception are
 to `100`.
 ====
 
+[role="child_attributes"]
 [[ml-get-record-results]]
 == {api-response-body-title}
 
@@ -173,6 +175,12 @@ include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=is-interim]
 (string)
 include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=job-id-anomaly-detection]
 
+`multi_bucket_impact`::
+(number) An indication of how strongly an anomaly is multi bucket or single
+bucket. The value is on a scale of `-5.0` to `+5.0` where `-5.0` means the
+anomaly is purely single bucket and `+5.0` means the anomaly is purely multi
+bucket.
+
 `over_field_name`::
 (string)
 include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=over-field-name]
@@ -192,12 +200,6 @@ include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=partition-field-name]
 0 to 1. For example, 0.0000772031. This value can be held to a high precision
 of over 300 decimal places, so the `record_score` is provided as a
 human-readable and friendly interpretation of this.
-
-`multi_bucket_impact`::
-(number) An indication of how strongly an anomaly is multi bucket or single
-bucket. The value is on a scale of `-5.0` to `+5.0` where `-5.0` means the
-anomaly is purely single bucket and `+5.0` means the anomaly is purely multi
-bucket.
 
 `record_score`::
 (number) A normalized score between 0-100, which is based on the probability of

--- a/docs/reference/ml/anomaly-detection/apis/get-record.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/get-record.asciidoc
@@ -142,15 +142,19 @@ configuration. For example, `max`.
 (string) The description of the function in which the anomaly occurs, as
 specified in the detector configuration.
 
-`geo_results.actual_point`::
-(string) The actual value for the bucket formatted as a `geo_point`. If the
-detector function is `lat_long`, this is a comma delimited string of the
-latitude and longitude.
+`geo_results`::
+(optional, object) If the detector function is `lat_long`, this object contains
+comma delimited strings for the latitude and longitude of the actual and typical values.  
++
+.Properties of `geo_results`
+[%collapsible%open]
+====
+`actual_point`::
+(string) The actual value for the bucket formatted as a `geo_point`.
 
-`geo_results.typical_point`::
-(string) The typical value for the bucket formatted as a `geo_point`. If the
-detector function is `lat_long`, this is a comma delimited string of the
-latitude and longitude.
+`typical_point`::
+(string) The typical value for the bucket formatted as a `geo_point`.
+====
 
 `influencers`::
 (array) If `influencers` was specified in the detector configuration, this array


### PR DESCRIPTION
Backports the following commits to 8.5:
 - [DOCS] Clarify description of geo_results (#91237)

It also includes some formatting fixes that were implemented in `main` via https://github.com/elastic/elasticsearch/pull/91177