### PR TITLE
[DOCS] Remove coming tag from release notes

### DIFF
--- a/docs/reference/release-notes/8.5.0.asciidoc
+++ b/docs/reference/release-notes/8.5.0.asciidoc
@@ -1,8 +1,6 @@
 [[release-notes-8.5.0]]
 == {es} version 8.5.0
 
-coming[8.5.0]
-
 Also see <<breaking-changes-8.5,Breaking changes in 8.5>>.
 
 [[breaking-8.5.0]]


### PR DESCRIPTION
This PR removes the "Coming in 8.5.0" text from the 8.5.0 release notes.
