### PR TITLE
Add docs about TimeoutStartSec in systemd

### DIFF
--- a/docs/reference/setup/install/systemd.asciidoc
+++ b/docs/reference/setup/install/systemd.asciidoc
@@ -90,7 +90,11 @@ However the `systemd` logs will report that the startup timed out:
 
 [source,text]
 -------------
+Jan 31 01:22:30 debian systemd[1]: Starting Elasticsearch...
 Jan 31 01:23:45 debian systemd[1]: elasticsearch.service: Start operation timed out. Terminating.
+Jan 31 01:23:45 debian systemd[1]: elasticsearch.service: Main process exited, code=killed, status=15/TERM
+Jan 31 01:23:45 debian systemd[1]: elasticsearch.service: Failed with result 'timeout'.
+Jan 31 01:23:45 debian systemd[1]: Failed to start Elasticsearch.
 -------------
 
 To avoid this, upgrade your `systemd` to at least version 238. You can also

--- a/docs/reference/setup/install/systemd.asciidoc
+++ b/docs/reference/setup/install/systemd.asciidoc
@@ -64,3 +64,36 @@ sudo journalctl --unit elasticsearch --since  "2016-10-30 18:17:16"
 
 Check `man journalctl` or https://www.freedesktop.org/software/systemd/man/journalctl.html for
 more command line options.
+
+[[systemd-startup-timeout]]
+[TIP]
+.Startup timeouts with older `systemd` versions
+====
+By default {es} sets the `TimeoutStartSec` parameter to `systemd` to `75s`. If
+you are running at least version 238 of `systemd` then {es} can automatically
+extend the startup timeout, and will do so repeatedly until startup is complete
+even if it takes longer than 75s.
+
+Versions of `systemd` prior to 238 do not support the timeout extension
+mechanism and will terminate the {es} process if it has not fully started up
+within the configured timeout. If this happens, {es} will report in its logs
+that it was shut down normally a short time after it started:
+
+[source,text]
+-------------
+[2022-01-31T01:22:31,077][INFO ][o.e.n.Node               ] [instance-0000000123] starting ...
+...
+[2022-01-31T01:23:45,077][INFO ][o.e.n.Node               ] [instance-0000000123] stopping ...
+-------------
+
+However the `systemd` logs will report that the startup timed out:
+
+[source,text]
+-------------
+Jan 31 01:23:45 debian systemd[1]: elasticsearch.service: Start operation timed out. Terminating.
+-------------
+
+To avoid this, upgrade your `systemd` to at least version 238. You can also
+temporarily work around the problem by extending the `TimeoutStartSec`
+parameter.
+====

--- a/docs/reference/setup/install/systemd.asciidoc
+++ b/docs/reference/setup/install/systemd.asciidoc
@@ -65,7 +65,6 @@ sudo journalctl --unit elasticsearch --since  "2016-10-30 18:17:16"
 Check `man journalctl` or https://www.freedesktop.org/software/systemd/man/journalctl.html for
 more command line options.
 
-[[systemd-startup-timeout]]
 [TIP]
 .Startup timeouts with older `systemd` versions
 ====


### PR DESCRIPTION
Adds a short note about the effects of `TimeoutStartSec` in older `systemd` versions.

Relates https://github.com/elastic/elasticsearch/issues/86476