### PR TITLE
Extend systemd startup timeout to 900s

### DIFF
--- a/distribution/packages/src/common/systemd/elasticsearch.service
+++ b/distribution/packages/src/common/systemd/elasticsearch.service
@@ -62,7 +62,7 @@ SendSIGKILL=no
 SuccessExitStatus=143
 
 # Allow a slow startup before the systemd notifier module kicks in to extend the timeout
-TimeoutStartSec=75
+TimeoutStartSec=900
 
 [Install]
 WantedBy=multi-user.target

--- a/docs/changelog/91338.yaml
+++ b/docs/changelog/91338.yaml
@@ -1,0 +1,5 @@
+pr: 91338
+summary: Extend systemd startup timeout to 900s
+area: Infra/Core
+type: enhancement
+issues: []


### PR DESCRIPTION
Extends the default `systemd` startup timeout from 75s to 900s.

Relates #86476