### PR TITLE
[8.5] [ML] Do not count interim buckets towards the total bucket count (#91288)

### DIFF
--- a/docs/changelog/91288.yaml
+++ b/docs/changelog/91288.yaml
@@ -1,0 +1,5 @@
+pr: 91288
+summary: Interim buckets should not count towards the total bucket count
+area: Machine Learning
+type: bug
+issues: []

--- a/x-pack/plugin/ml/src/internalClusterTest/java/org/elasticsearch/xpack/ml/integration/AutodetectResultProcessorIT.java
+++ b/x-pack/plugin/ml/src/internalClusterTest/java/org/elasticsearch/xpack/ml/integration/AutodetectResultProcessorIT.java
@@ -314,16 +314,16 @@ public class AutodetectResultProcessorIT extends MlSingleNodeTestCase {
     }
 
     public void testProcessResults_TimingStats() throws Exception {
-        ResultsBuilder resultsBuilder = new ResultsBuilder().addBucket(createBucket(true, 100))
-            .addBucket(createBucket(true, 1000))
-            .addBucket(createBucket(true, 100))
-            .addBucket(createBucket(true, 1000))
-            .addBucket(createBucket(true, 100))
-            .addBucket(createBucket(true, 1000))
-            .addBucket(createBucket(true, 100))
-            .addBucket(createBucket(true, 1000))
-            .addBucket(createBucket(true, 100))
-            .addBucket(createBucket(true, 1000));
+        ResultsBuilder resultsBuilder = new ResultsBuilder().addBucket(createBucket(false, 100))
+            .addBucket(createBucket(false, 1000))
+            .addBucket(createBucket(false, 100))
+            .addBucket(createBucket(false, 1000))
+            .addBucket(createBucket(false, 100))
+            .addBucket(createBucket(false, 1000))
+            .addBucket(createBucket(false, 100))
+            .addBucket(createBucket(false, 1000))
+            .addBucket(createBucket(false, 100))
+            .addBucket(createBucket(false, 1000));
         when(process.readAutodetectResults()).thenReturn(resultsBuilder.build().iterator());
 
         resultProcessor.process();
@@ -336,6 +336,24 @@ public class AutodetectResultProcessorIT extends MlSingleNodeTestCase {
         assertThat(timingStats.getMaxBucketProcessingTimeMs(), equalTo(1000.0));
         assertThat(timingStats.getAvgBucketProcessingTimeMs(), equalTo(550.0));
         assertThat(timingStats.getExponentialAvgBucketProcessingTimeMs(), closeTo(143.244, 1e-3));
+    }
+
+    public void testProcessResults_InterimResultsDoNotChangeTimingStats() throws Exception {
+        ResultsBuilder resultsBuilder = new ResultsBuilder().addBucket(createBucket(true, 100))
+            .addBucket(createBucket(true, 100))
+            .addBucket(createBucket(true, 100))
+            .addBucket(createBucket(false, 10000));
+        when(process.readAutodetectResults()).thenReturn(resultsBuilder.build().iterator());
+
+        resultProcessor.process();
+        resultProcessor.awaitCompletion();
+
+        TimingStats timingStats = resultProcessor.timingStats();
+        assertThat(timingStats.getBucketCount(), equalTo(1L));
+        assertThat(timingStats.getMinBucketProcessingTimeMs(), equalTo(10000.0));
+        assertThat(timingStats.getMaxBucketProcessingTimeMs(), equalTo(10000.0));
+        assertThat(timingStats.getAvgBucketProcessingTimeMs(), equalTo(10000.0));
+        assertThat(timingStats.getExponentialAvgBucketProcessingTimeMs(), closeTo(10000.0, 1e-3));
     }
 
     public void testParseQuantiles_GivenRenormalizationIsEnabled() throws Exception {

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/process/autodetect/output/AutodetectResultProcessor.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/process/autodetect/output/AutodetectResultProcessor.java
@@ -281,12 +281,14 @@ public class AutodetectResultProcessor {
                 deleteInterimRequired = false;
             }
 
+            if (bucket.isInterim() == false) {
+                timingStatsReporter.reportBucket(bucket);
+                ++currentRunBucketCount;
+            }
             // persist after deleting interim results in case the new
             // results are also interim
-            timingStatsReporter.reportBucket(bucket);
             bulkResultsPersister.persistBucket(bucket).executeRequest();
             bulkAnnotationsPersister.executeRequest();
-            ++currentRunBucketCount;
         }
         List<AnomalyRecord> records = result.getRecords();
         if (records != null && records.isEmpty() == false) {
@@ -582,5 +584,11 @@ public class AutodetectResultProcessor {
 
     void setDeleteInterimRequired(boolean deleteInterimRequired) {
         this.deleteInterimRequired = deleteInterimRequired;
+    }
+
+    // For testing only.
+    // Reading currentRunBucketCount is not thread safe
+    long getCurrentRunBucketCount() {
+        return currentRunBucketCount;
     }
 }


### PR DESCRIPTION
Backports the following commits to 8.5:
 - [ML] Do not count interim buckets towards the total bucket count (#91288)