### PR TITLE
[TEST] adjust WrapperQueryBuilder#testMaxNestedDepth

### DIFF
--- a/server/src/test/java/org/elasticsearch/index/query/WrapperQueryBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/index/query/WrapperQueryBuilderTests.java
@@ -177,13 +177,8 @@ public class WrapperQueryBuilderTests extends AbstractQueryTestCase<WrapperQuery
     public void testMaxNestedDepth() throws IOException {
         BoolQueryBuilderTests boolQueryBuilderTests = new BoolQueryBuilderTests();
         BoolQueryBuilder boolQuery = boolQueryBuilderTests.createQueryWithInnerQuery(new MatchAllQueryBuilder());
-        int maxDepth;
-        if (frequently()) {
-            maxDepth = randomIntBetween(3, 5);
-            AbstractQueryBuilder.setMaxNestedDepth(maxDepth);
-        } else {
-            maxDepth = INDICES_MAX_NESTED_DEPTH_SETTING.getDefault(Settings.EMPTY);
-        }
+        int maxDepth = randomIntBetween(3, 5);
+        AbstractQueryBuilder.setMaxNestedDepth(maxDepth);
         for (int i = 1; i < maxDepth - 1; i++) {
             boolQuery = boolQueryBuilderTests.createQueryWithInnerQuery(boolQuery);
         }


### PR DESCRIPTION
This commit holds the same change as #90990 but for WrapperQueryBuilderTests, which has special needs and overrides the default impl of the test method

Closes #91342