### PR TITLE
[ML] Hybrid retrieval for Semantic search.

### DIFF
--- a/docs/changelog/91348.yaml
+++ b/docs/changelog/91348.yaml
@@ -1,5 +1,0 @@
-pr: 91348
-summary: Hybrid retrieval for Semantic search
-area: Machine Learning
-type: enhancement
-issues: []

--- a/docs/changelog/91348.yaml
+++ b/docs/changelog/91348.yaml
@@ -1,0 +1,5 @@
+pr: 91348
+summary: Hybrid retrieval for Semantic search
+area: Machine Learning
+type: enhancement
+issues: []

--- a/docs/reference/search/semantic-search.asciidoc
+++ b/docs/reference/search/semantic-search.asciidoc
@@ -10,25 +10,6 @@ The resulting dense vector is then used in a <<knn-search,k-nearest neighbor (kn
 created with the same text embedding model. The search results are semantically similar as learned
 by the model.
 
-////
-[source,console]
-----
-PUT my-index
-{
-  "mappings": {
-    "properties": {
-      "text_embedding": {
-        "type": "dense_vector",
-        "dims": 512,
-        "index": true,
-        "similarity": "cosine"
-      }
-    }
-  }
-}
-----
-////
-
 [source,console]
 ----
 GET my-index/_semantic_search
@@ -110,15 +91,69 @@ value must be less than `num_candidates`.
 shard. Cannot exceed 10,000. {es} collects `num_candidates` results from each
 shard, then merges them to find the top `k` results. Increasing
 `num_candidates` tends to improve the accuracy of the final `k` results.
-====
 
 `filter`::
 (Optional, <<query-dsl,Query DSL object>>) Query to filter the documents that
 can match. The kNN search will return the top `k` documents that also match
 this filter. The value can be a single query or a list of queries. If `filter`
 is not provided, all documents are allowed to match.
+====
 
+`query`::
+(Optional, <<query-dsl,query object>>) Defines the search definition using the
+<<query-dsl,Query DSL>>.
 
+`text_embedding_config`::
+(Object, optional) Override certain setting of the text embedding model's configuration
+.Properties of text_embedding inference
+[%collapsible%open]
+=====
+`results_field`::::
+(Optional, string)
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=inference-config-results-field]
+
+`tokenization`::::
+(Optional, object)
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=inference-config-nlp-tokenization]
++
+.Properties of tokenization
+[%collapsible%open]
+======
+`bert`::::
+(Optional, object)
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=inference-config-nlp-tokenization-bert]
++
+.Properties of bert
+[%collapsible%open]
+=======
+`truncate`::::
+(Optional, string)
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=inference-config-nlp-tokenization-truncate]
+=======
+`roberta`::::
+(Optional, object)
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=inference-config-nlp-tokenization-roberta]
++
+.Properties of roberta
+[%collapsible%open]
+=======
+`truncate`::::
+(Optional, string)
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=inference-config-nlp-tokenization-truncate]
+=======
+`mpnet`::::
+(Optional, object)
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=inference-config-nlp-tokenization-mpnet]
++
+.Properties of mpnet
+[%collapsible%open]
+=======
+`truncate`::::
+(Optional, string)
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=inference-config-nlp-tokenization-truncate]
+=======
+======
+=====
 
 include::{es-repo-dir}/search/search.asciidoc[tag=docvalue-fields-def]
 include::{es-repo-dir}/search/search.asciidoc[tag=fields-param-def]
@@ -129,5 +164,5 @@ include::{es-repo-dir}/search/search.asciidoc[tag=stored-fields-def]
 [[semantic-search-api-response-body]]
 ==== {api-response-body-title}
 
-A sementic search response has the same structure as a kNN search response.
+The semantic search response has the same structure as a kNN search response.
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/SemanticSearchAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/SemanticSearchAction.java
@@ -57,6 +57,7 @@ public class SemanticSearchAction extends ActionType<SemanticSearchAction.Respon
     public static class Request extends ActionRequest implements IndicesRequest.Replaceable {
 
         public static final ParseField QUERY_STRING = new ParseField("query_string"); // TODO a better name and update docs when changed
+        public static final ParseField TEXT_EMBEDDING_CONFIG = new ParseField("text_embedding_config");
 
         static final ObjectParser<Request.Builder, Void> PARSER = new ObjectParser<>(NAME);
 
@@ -67,7 +68,7 @@ public class SemanticSearchAction extends ActionType<SemanticSearchAction.Respon
             PARSER.declareObject(
                 Request.Builder::setUpdate,
                 (p, c) -> TextEmbeddingConfigUpdate.fromXContentStrict(p),
-                InferTrainedModelDeploymentAction.Request.INFERENCE_CONFIG
+                TEXT_EMBEDDING_CONFIG
             );
             PARSER.declareObject(
                 Request.Builder::setQueryBuilder,

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/action/SemanticSearchActionKnnQueryOptionsTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/action/SemanticSearchActionKnnQueryOptionsTests.java
@@ -19,6 +19,8 @@ import org.junit.Before;
 import java.util.List;
 
 import static java.util.Collections.emptyList;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.sameInstance;
 
 public class SemanticSearchActionKnnQueryOptionsTests extends AbstractWireSerializingTestCase<SemanticSearchAction.KnnQueryOptions> {
 
@@ -64,5 +66,20 @@ public class SemanticSearchActionKnnQueryOptionsTests extends AbstractWireSerial
     @Override
     protected SemanticSearchAction.KnnQueryOptions createTestInstance() {
         return randomInstance();
+    }
+
+    public void testToKnnSearchBuilder() {
+        var knnOptions = new SemanticSearchAction.KnnQueryOptions("foo", 5, 100);
+        knnOptions.boost(20.0f);
+        var termsQuery = QueryBuilders.termQuery("foo", "bar");
+        knnOptions.addFilterQueries(List.of(termsQuery));
+
+        var knnSearch = knnOptions.toKnnSearchBuilder(new float[] { 0.1f, 0.2f });
+        assertEquals(5, knnSearch.k());
+        var knnQuery = knnSearch.toQueryBuilder();
+        assertEquals(100, knnQuery.numCands());
+        assertEquals("foo", knnQuery.getFieldName());
+        assertThat(knnQuery.filterQueries(), contains(sameInstance(termsQuery)));
+        assertEquals(20.0f, knnQuery.boost(), 0.001);
     }
 }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/action/SemanticSearchActionRequestTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/action/SemanticSearchActionRequestTests.java
@@ -71,7 +71,6 @@ public class SemanticSearchActionRequestTests extends AbstractWireSerializingTes
             SemanticSearchActionKnnQueryOptionsTests.randomInstance(),
             TextEmbeddingConfigUpdateTests.randomUpdate(),
             randomBoolean() ? null : TimeValue.timeValueSeconds(randomIntBetween(1, 10)),
-            randomBoolean() ? null : List.of(new TermsQueryBuilder("foo", "bar", "cat")),
             randomBoolean() ? null : FetchSourceContext.of(randomBoolean()),
             randomBoolean() ? null : List.of(new FieldAndFormat("foo", null)),
             randomBoolean() ? null : List.of(new FieldAndFormat("foo", null)),
@@ -86,7 +85,6 @@ public class SemanticSearchActionRequestTests extends AbstractWireSerializingTes
 
         var action = new SemanticSearchAction.Request(
             new String[] { "foo" },
-            null,
             null,
             null,
             null,

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/action/SemanticSearchActionRequestTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/action/SemanticSearchActionRequestTests.java
@@ -67,6 +67,7 @@ public class SemanticSearchActionRequestTests extends AbstractWireSerializingTes
             randomBoolean() ? null : randomAlphaOfLength(5),
             randomAlphaOfLength(5),
             randomAlphaOfLength(5),
+            randomBoolean() ? null : new TermsQueryBuilder("foo", "bar"),
             SemanticSearchActionKnnQueryOptionsTests.randomInstance(),
             TextEmbeddingConfigUpdateTests.randomUpdate(),
             randomBoolean() ? null : TimeValue.timeValueSeconds(randomIntBetween(1, 10)),
@@ -74,7 +75,8 @@ public class SemanticSearchActionRequestTests extends AbstractWireSerializingTes
             randomBoolean() ? null : FetchSourceContext.of(randomBoolean()),
             randomBoolean() ? null : List.of(new FieldAndFormat("foo", null)),
             randomBoolean() ? null : List.of(new FieldAndFormat("foo", null)),
-            randomBoolean() ? null : StoredFieldsContext.fromList(List.of("A", "B"))
+            randomBoolean() ? null : StoredFieldsContext.fromList(List.of("A", "B")),
+            randomBoolean() ? -1 : randomIntBetween(1, 10)
         );
     }
 
@@ -94,7 +96,9 @@ public class SemanticSearchActionRequestTests extends AbstractWireSerializingTes
             null,
             null,
             null,
-            null
+            null,
+            null,
+            -1
         );
         var validation = action.validate();
         assertNotNull(validation);

--- a/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/PyTorchModelRestTestCase.java
+++ b/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/PyTorchModelRestTestCase.java
@@ -262,7 +262,7 @@ public abstract class PyTorchModelRestTestCase extends ESRestTestCase {
         return client().performRequest(request);
     }
 
-    protected Response semanticSearch(String index, String query, String modelId, String denseVectorFieldName) throws IOException {
+    protected Response semanticSearch(String index, String queryText, String modelId, String denseVectorFieldName) throws IOException {
         Request request = new Request("GET", index + "/_semantic_search?error_trace=true");
 
         request.setJsonEntity(String.format(Locale.ROOT, """
@@ -274,12 +274,17 @@ public abstract class PyTorchModelRestTestCase extends ESRestTestCase {
                   "k": 5,
                   "num_candidates": 10
               }
-            }""", modelId, query, denseVectorFieldName));
+            }""", modelId, queryText, denseVectorFieldName));
         return client().performRequest(request);
     }
 
-    protected Response semanticSearch(String index, String query, String filter, String modelId, String denseVectorFieldName)
-        throws IOException {
+    protected Response semanticSearchWithTermsFilter(
+        String index,
+        String queryText,
+        String filter,
+        String modelId,
+        String denseVectorFieldName
+    ) throws IOException {
         Request request = new Request("GET", index + "/_semantic_search?error_trace=true");
 
         String termsFilter = String.format(Locale.ROOT, """
@@ -296,7 +301,25 @@ public abstract class PyTorchModelRestTestCase extends ESRestTestCase {
                   "num_candidates": 10,
                   "filter": %s
               }
-            }""", modelId, query, denseVectorFieldName, termsFilter));
+            }""", modelId, queryText, denseVectorFieldName, termsFilter));
+        return client().performRequest(request);
+    }
+
+    protected Response semanticSearchWithQuery(String index, String queryText, String query, String modelId, String denseVectorFieldName)
+        throws IOException {
+        Request request = new Request("GET", index + "/_semantic_search?error_trace=true");
+
+        request.setJsonEntity(String.format(Locale.ROOT, """
+            {
+              "model_id": "%s",
+              "query_string": "%s",
+              "knn": {
+                  "field": "%s",
+                  "k": 5,
+                  "num_candidates": 10
+              },
+              "query": %s
+            }""", modelId, queryText, denseVectorFieldName, query));
         return client().performRequest(request);
     }
 

--- a/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/PyTorchModelRestTestCase.java
+++ b/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/PyTorchModelRestTestCase.java
@@ -262,7 +262,7 @@ public abstract class PyTorchModelRestTestCase extends ESRestTestCase {
         return client().performRequest(request);
     }
 
-    protected Response semanticSearch(String index, String query, String deploymentId, String denseVectorFieldName) throws IOException {
+    protected Response semanticSearch(String index, String query, String modelId, String denseVectorFieldName) throws IOException {
         Request request = new Request("GET", index + "/_semantic_search?error_trace=true");
 
         request.setJsonEntity(String.format(Locale.ROOT, """
@@ -274,7 +274,29 @@ public abstract class PyTorchModelRestTestCase extends ESRestTestCase {
                   "k": 5,
                   "num_candidates": 10
               }
-            }""", deploymentId, query, denseVectorFieldName));
+            }""", modelId, query, denseVectorFieldName));
+        return client().performRequest(request);
+    }
+
+    protected Response semanticSearch(String index, String query, String filter, String modelId, String denseVectorFieldName)
+        throws IOException {
+        Request request = new Request("GET", index + "/_semantic_search?error_trace=true");
+
+        String termsFilter = String.format(Locale.ROOT, """
+            {"term": {"filter_field": "%s"}}
+            """, filter);
+
+        request.setJsonEntity(String.format(Locale.ROOT, """
+            {
+              "model_id": "%s",
+              "query_string": "%s",
+              "knn": {
+                  "field": "%s",
+                  "k": 5,
+                  "num_candidates": 10,
+                  "filter": %s
+              }
+            }""", modelId, query, denseVectorFieldName, termsFilter));
         return client().performRequest(request);
     }
 

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportSemanticSearchAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportSemanticSearchAction.java
@@ -99,8 +99,12 @@ public class TransportSemanticSearchAction extends HandledTransportAction<Semant
         SearchSourceBuilder sourceBuilder = new SearchSourceBuilder();
         sourceBuilder.trackTotalHitsUpTo(SearchContext.TRACK_TOTAL_HITS_ACCURATE);
         sourceBuilder.knnSearch(knnSearchBuilder);
-        sourceBuilder.size(knnSearchBuilder.k());
-
+        if (request.getSize() != -1) {
+            sourceBuilder.size(request.getSize());
+        }
+        if (request.getQuery() != null) {
+            sourceBuilder.query(request.getQuery());
+        }
         if (request.getFetchSource() != null) {
             sourceBuilder.fetchSource(request.getFetchSource());
         }

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/ml/semantic_search.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/ml/semantic_search.yml
@@ -145,6 +145,25 @@ setup:
     # See comment at the top of the file for the reason why
     # the test cannot match on the text field
 
+  - do:
+      semantic_search:
+        index: embedded_text
+        body:
+          model_id: text_embedding_model
+          query_string: "the octopus comforter smells"
+          text_embedding_config:
+            tokenization:
+              bert:
+                truncate: none
+          knn:
+            field: embedding
+            k: 3
+            num_candidates: 10
+  - gte: { inference_took: 0 }
+  - match: { hits.total.value: 3 }
+    # See comment at the top of the file for the reason why
+    # the test cannot match on the text field
+
 ---
 "Knn field is not a vector":
   - do:


### PR DESCRIPTION
Adds the `query` option to the `_semantic_search` endpoint for hybrid retrieval. Scoring is controlled by the `boost` fields of the `knn` search and the `query`.

```
GET {INDEX}/_semantic_search
{
        "model_id": "my-text-embedding-model",
        "query_string": "a dark forest",
        "knn": {
            "field": "embedding",
            "k": 5,
            "num_candidates": 100,
            "boost": 2.0
        },
        "query": {"match": {"source_text": {"query": "the deep dark wood", "boost": 0.5}}}
}
```


Follow up to #90450 