### PR TITLE
[DOCS] Add reference for ingest pipelines in Enterprise Search

### DIFF
--- a/docs/reference/ingest.asciidoc
+++ b/docs/reference/ingest.asciidoc
@@ -319,7 +319,7 @@ You can safely specify a pipeline for this integration in one of two ways: an
 
 When you create Elasticsearch indices for {enterprise-search-ref}/index.html[Enterprise Search^] use cases, for example, using the {enterprise-search-ref}/crawler.html[web crawler^] or {enterprise-search-ref}/connectors.html[connectors^], these indices are automatically set up with specific ingest pipelines. 
 These processors help optimize your content for search.
-Refer to the {enterprise-search-ref}/index.html[Enterprise Search documentation^] for more information.
+Refer to the {enterprise-search-ref}/ingest-pipelines.html[Enterprise Search documentation^] for more information.
 
 [[pipeline-custom-logs-index-template]]
 **Option 1: Index template**

--- a/docs/reference/ingest.asciidoc
+++ b/docs/reference/ingest.asciidoc
@@ -313,14 +313,6 @@ You can safely specify a pipeline for this integration in one of two ways: an
 <<pipeline-custom-logs-index-template,index template>> or a
 <<pipeline-custom-logs-configuration,custom configuration>>.
 
-[discrete]
-[[pipelines-in-enterprise-search]]
-=== Pipelines in Enterprise Search
-
-When you create Elasticsearch indices for {enterprise-search-ref}/index.html[Enterprise Search^] use cases, for example, using the {enterprise-search-ref}/crawler.html[web crawler^] or {enterprise-search-ref}/connectors.html[connectors^], these indices are automatically set up with specific ingest pipelines. 
-These processors help optimize your content for search.
-Refer to the {enterprise-search-ref}/ingest-pipelines.html[Enterprise Search documentation^] for more information.
-
 [[pipeline-custom-logs-index-template]]
 **Option 1: Index template**
 
@@ -449,6 +441,14 @@ If you run {agent} standalone, you can apply pipelines using an
 <<index-final-pipeline,`index.final_pipeline`>> index setting. Alternatively,
 you can specify the `pipeline` policy setting in your `elastic-agent.yml`
 configuration. See {fleet-guide}/install-standalone-elastic-agent.html[Install standalone {agent}s].
+
+[discrete]
+[[pipelines-in-enterprise-search]]
+=== Pipelines in Enterprise Search
+
+When you create Elasticsearch indices for {enterprise-search-ref}/index.html[Enterprise Search^] use cases, for example, using the {enterprise-search-ref}/crawler.html[web crawler^] or {enterprise-search-ref}/connectors.html[connectors^], these indices are automatically set up with specific ingest pipelines. 
+These processors help optimize your content for search.
+Refer to the {enterprise-search-ref}/ingest-pipelines.html[Enterprise Search documentation^] for more information.
 
 [discrete]
 [[access-source-fields]]

--- a/docs/reference/ingest.asciidoc
+++ b/docs/reference/ingest.asciidoc
@@ -313,6 +313,14 @@ You can safely specify a pipeline for this integration in one of two ways: an
 <<pipeline-custom-logs-index-template,index template>> or a
 <<pipeline-custom-logs-configuration,custom configuration>>.
 
+[discrete]
+[[pipelines-in-enterprise-search]]
+=== Pipelines in Enterprise Search
+
+When you create Elasticsearch indices for {enterprise-search-ref}/index.html[Enterprise Search^] use cases, for example, using the {enterprise-search-ref}/crawler.html[web crawler^] or {enterprise-search-ref}/connectors.html[connectors^], these indices are automatically set up with specific ingest pipelines. 
+These processors help optimize your content for search.
+Refer to the {enterprise-search-ref}/index.html[Enterprise Search documentation^] for more information.
+
 [[pipeline-custom-logs-index-template]]
 **Option 1: Index template**
 


### PR DESCRIPTION
- Adds reference to ingest pipelines in Enterprise Search to the [platform ingest pipelines doc](https://www.elastic.co/guide/en/elasticsearch/reference/current/ingest.html).

- Issue: https://github.com/elastic/enterprise-search-team/issues/3173