### PR TITLE
Fix BytesRefArray on append empty BytesRef

### DIFF
--- a/docs/changelog/91364.yaml
+++ b/docs/changelog/91364.yaml
@@ -1,0 +1,5 @@
+pr: 91364
+summary: Fix `BytesRefArray` on append empty `BytesRef`
+area: Infra/Core
+type: bug
+issues: []

--- a/server/src/main/java/org/elasticsearch/common/util/BytesRefArray.java
+++ b/server/src/main/java/org/elasticsearch/common/util/BytesRefArray.java
@@ -87,11 +87,13 @@ public class BytesRefArray implements Accountable, Releasable, Writeable {
     public void append(BytesRef key) {
         assert startOffsets != null : "using BytesRefArray after ownership taken";
         final long startOffset = startOffsets.get(size);
-        bytes = bigArrays.grow(bytes, startOffset + key.length);
-        bytes.set(startOffset, key.bytes, key.offset, Math.max(key.length, 1));
         startOffsets = bigArrays.grow(startOffsets, size + 2);
         startOffsets.set(size + 1, startOffset + key.length);
         ++size;
+        if (key.length > 0) {
+            bytes = bigArrays.grow(bytes, startOffset + key.length);
+            bytes.set(startOffset, key.bytes, key.offset, key.length);
+        }
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/common/util/BytesRefArray.java
+++ b/server/src/main/java/org/elasticsearch/common/util/BytesRefArray.java
@@ -88,7 +88,7 @@ public class BytesRefArray implements Accountable, Releasable, Writeable {
         assert startOffsets != null : "using BytesRefArray after ownership taken";
         final long startOffset = startOffsets.get(size);
         bytes = bigArrays.grow(bytes, startOffset + key.length);
-        bytes.set(startOffset, key.bytes, key.offset, key.length);
+        bytes.set(startOffset, key.bytes, key.offset, Math.max(key.length, 1));
         startOffsets = bigArrays.grow(startOffsets, size + 2);
         startOffsets.set(size + 1, startOffset + key.length);
         ++size;


### PR DESCRIPTION
Appending an empty BytesRef to BytesRefArray can fail with NPE or IOE when the current page is fully used. This PR skips writing the empty input to the backing bytes array.