### PR TITLE
Reenable muted test

### DIFF
--- a/modules/aggregations/src/yamlRestTest/resources/rest-api-spec/test/aggregations/max_metric.yml
+++ b/modules/aggregations/src/yamlRestTest/resources/rest-api-spec/test/aggregations/max_metric.yml
@@ -206,10 +206,6 @@ setup:
 
 ---
 "Merging results with unmapped fields":
-  - skip:
-      version: "all"
-      reason: "https://github.com/elastic/elasticsearch/issues/89994"
-
   - do:
      search:
        index: [date_test_1, date_test_2]


### PR DESCRIPTION
I can't reproduce the failure. The failure looks like we it isn't including the "_as_string" value:
```
{
  "stash" : {
    "body" : {
      "took" : 4,
      "timed_out" : false,
      "_shards" : {
        "total" : 2,
        "successful" : 2,
        "skipped" : 0,
        "failed" : 0
      },
      "hits" : {
        "total" : {
          "value" : 1,
          "relation" : "eq"
        },
        "max_score" : 1.0,
        "hits" : [
          {
            "_index" : "date_test_2",
            "_id" : "5",
            "_score" : 1.0,
            "_source" : {
              "date_field" : "2021-05-01T00:00:00.000Z"
            }
          }
        ]
      },
      "aggregations" : {
        "date_field_max" : {
          "value" : 1.6198272E12
        }
      }
    }
  }
}
```
Which could be because the "unmapped" max was the "lead" aggregation. It shouldn't and we've tried to make sure it doesn't, but maybe that's what happened?

Either way I can't reproduce and don't see similar failures.
