### PR TITLE
[7.17] Fix hacky ephemeral port config for SAML tests (#91301)

### DIFF
--- a/x-pack/qa/saml-idp-tests/build.gradle
+++ b/x-pack/qa/saml-idp-tests/build.gradle
@@ -1,3 +1,5 @@
+import org.elasticsearch.gradle.LazyPropertyMap
+
 Project idpFixtureProject = xpackProject("test:idp-fixture")
 
 apply plugin: 'elasticsearch.internal-java-rest-test'
@@ -11,36 +13,25 @@ dependencies {
 testFixtures.useFixture ":x-pack:test:idp-fixture"
 
 String outputDir = "${project.buildDir}/generated-resources/${project.name}"
-def copyIdpFiles = tasks.register("copyIdpFiles", Sync) {
+tasks.register("copyIdpFiles", Sync) {
+  dependsOn idpFixtureProject.postProcessFixture
+  // Don't attempt to get ephemeral ports when Docker is not available
+  onlyIf { idpFixtureProject.postProcessFixture.state.skipped == false }
   from idpFixtureProject.files('idp/shibboleth-idp/credentials/idp-browser.pem', 'idp/shibboleth-idp/metadata/idp-metadata.xml',
     'idp/shibboleth-idp/credentials/sp-signing.key', 'idp/shibboleth-idp/credentials/sp-signing.crt');
   into outputDir
-  outputs.upToDateWhen { false } //ensure this copy is always done to prevent stale configuration
-}
-
-def setupPorts = tasks.register("setupPorts") {
-  dependsOn copyIdpFiles, idpFixtureProject.postProcessFixture
-  // Don't attempt to get ephemeral ports when Docker is not available
-  onlyIf { idpFixtureProject.postProcessFixture.state.skipped == false }
-  doLast {
-    String portString = idpFixtureProject.postProcessFixture.ext."test.fixtures.shibboleth-idp.tcp.4443"
-    int ephemeralPort = Integer.valueOf(portString)
-    File idpMetaFile = file("$outputDir/idp-metadata.xml")
-    List<String> lines = idpMetaFile.readLines("UTF-8")
-    StringBuilder content = new StringBuilder()
-    for (String line : lines) {
-      content.append(line.replace("localhost:4443", "localhost:" + ephemeralPort))
-    }
-    idpMetaFile.delete()
-    idpMetaFile.createNewFile()
-    idpMetaFile.write(content.toString(), "UTF-8")
+  def expandProps = new LazyPropertyMap<>("lazy port config")
+  expandProps.put("port", () -> idpFixtureProject.postProcessFixture.ext."test.fixtures.shibboleth-idp.tcp.4443")
+  inputs.properties(expandProps)
+  filesMatching("idp-metadata.xml") {
+    expand(expandProps)
   }
 }
 
 project.sourceSets.javaRestTest.output.dir(outputDir, builtBy: [copyIdpFiles])
 
 tasks.named("javaRestTest").configure {
-  dependsOn setupPorts
+  dependsOn tasks.named("copyIdpFiles")
   onlyIf { idpFixtureProject.postProcessFixture.state.skipped == false }
 }
 

--- a/x-pack/test/idp-fixture/idp/shibboleth-idp/metadata/idp-metadata.xml
+++ b/x-pack/test/idp-fixture/idp/shibboleth-idp/metadata/idp-metadata.xml
@@ -115,7 +115,7 @@ NgQpDdo=
         </KeyDescriptor>
 
         <SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" req-attr:supportsRequestedAttributes="true"
-                             Location="https://localhost:4443/idp/profile/SAML2/Redirect/SSO"/>
+                             Location="https://localhost:${port}/idp/profile/SAML2/Redirect/SSO"/>
 
     </IDPSSODescriptor>
 </EntityDescriptor>


### PR DESCRIPTION
Backports the following commits to 7.17:
 - Fix hacky ephemeral port config for SAML tests (#91301)