### PR TITLE
Fix APM log_file option on Windows

### DIFF
--- a/distribution/tools/server-cli/src/main/java/org/elasticsearch/server/cli/APMJvmOptions.java
+++ b/distribution/tools/server-cli/src/main/java/org/elasticsearch/server/cli/APMJvmOptions.java
@@ -21,6 +21,7 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -48,7 +49,7 @@ class APMJvmOptions {
         // by the agent. Don't disable writing to a log file, as the agent will then
         // require extra Security Manager permissions when it tries to do something
         // else, and it's just painful.
-        "log_file", "_AGENT_HOME_/../../logs/apm.log",
+        "log_file", Paths.get("_AGENT_HOME_", "..", "..", "logs", "apm.log").toString(),
 
         // ES does not use auto-instrumentation.
         "instrument", "false"


### PR DESCRIPTION
Changed the log_file option to be Windows friendly, in continue to [APM log_file option is not Windows friendly](https://github.com/elastic/elasticsearch/issues/91280).