### PR TITLE
Log created shards sizes

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/cluster/routing/allocation/decider/DiskThresholdDeciderIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/cluster/routing/allocation/decider/DiskThresholdDeciderIT.java
@@ -249,7 +249,8 @@ public class DiskThresholdDeciderIT extends DiskUsageIntegTestCase {
 
                 logger.info(
                     "Created shards with sizes {}",
-                    Arrays.stream(shardStates).collect(toMap(it -> it.getShardRouting().shardId(), it -> it.getStats().getStore().sizeInBytes()))
+                    Arrays.stream(shardStates)
+                        .collect(toMap(it -> it.getShardRouting().shardId(), it -> it.getStats().getStore().sizeInBytes()))
                 );
 
                 return new SmallestShards(smallestShardSize, smallestShardIds);

--- a/server/src/internalClusterTest/java/org/elasticsearch/cluster/routing/allocation/decider/DiskThresholdDeciderIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/cluster/routing/allocation/decider/DiskThresholdDeciderIT.java
@@ -45,6 +45,7 @@ import java.util.Locale;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
+import static java.util.stream.Collectors.toMap;
 import static java.util.stream.Collectors.toSet;
 import static org.elasticsearch.index.store.Store.INDEX_STORE_STATS_REFRESH_INTERVAL_SETTING;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
@@ -245,6 +246,11 @@ public class DiskThresholdDeciderIT extends DiskUsageIntegTestCase {
                     .filter(it -> it.getStats().getStore().sizeInBytes() == smallestShardSize)
                     .map(it -> removeIndexUUID(it.getShardRouting().shardId()))
                     .collect(toSet());
+
+                logger.info(
+                    "Created shards with sizes {}",
+                    Arrays.stream(shardStates).collect(toMap(it -> it.getShardRouting().shardId(), it -> it.getStats().getStore().sizeInBytes()))
+                );
 
                 return new SmallestShards(smallestShardSize, smallestShardIds);
             }


### PR DESCRIPTION
This change adds a logging for an actual shard sizes. This might be a helpful debug information in case of since re-running the test with a reproduction line does not yield the same shards.