### PR TITLE
[8.5] [DOCS] Add reference for ingest pipelines in Enterprise Search (#91357)

### DIFF
--- a/docs/reference/ingest.asciidoc
+++ b/docs/reference/ingest.asciidoc
@@ -447,6 +447,14 @@ you can specify the `pipeline` policy setting in your `elastic-agent.yml`
 configuration. See {fleet-guide}/install-standalone-elastic-agent.html[Install standalone {agent}s].
 
 [discrete]
+[[pipelines-in-enterprise-search]]
+=== Pipelines in Enterprise Search
+
+When you create Elasticsearch indices for {enterprise-search-ref}/index.html[Enterprise Search^] use cases, for example, using the {enterprise-search-ref}/crawler.html[web crawler^] or {enterprise-search-ref}/connectors.html[connectors^], these indices are automatically set up with specific ingest pipelines. 
+These processors help optimize your content for search.
+Refer to the {enterprise-search-ref}/ingest-pipelines.html[Enterprise Search documentation^] for more information.
+
+[discrete]
 [[access-source-fields]]
 === Access source fields in a processor
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.5`:
 - [[DOCS] Add reference for ingest pipelines in Enterprise Search (#91357)](https://github.com/elastic/elasticsearch/pull/91357)

<!--- Backport version: 7.4.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)