### PR TITLE
Consolidate SearchSourceBuilder parsing methods

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/bucket/terms/StringTermsIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/bucket/terms/StringTermsIT.java
@@ -1365,7 +1365,7 @@ public class StringTermsIT extends AbstractTermsTestCase {
         String source = builder.toString();
 
         try (XContentParser parser = createParser(JsonXContent.jsonXContent, source)) {
-            SearchResponse response = client().prepareSearch("idx").setSource(SearchSourceBuilder.fromXContent(parser)).get();
+            SearchResponse response = client().prepareSearch("idx").setSource(SearchSourceBuilder.fromXContent(parser, true)).get();
 
             assertSearchResponse(response);
             LongTerms terms = response.getAggregations().get("terms");
@@ -1379,7 +1379,7 @@ public class StringTermsIT extends AbstractTermsTestCase {
         try (XContentParser parser = createParser(JsonXContent.jsonXContent, invalidValueType)) {
             XContentParseException ex = expectThrows(
                 XContentParseException.class,
-                () -> client().prepareSearch("idx").setSource(SearchSourceBuilder.fromXContent(parser)).get()
+                () -> client().prepareSearch("idx").setSource(SearchSourceBuilder.fromXContent(parser, true)).get()
             );
             assertThat(ex.getCause(), instanceOf(IllegalArgumentException.class));
             assertThat(ex.getCause().getMessage(), containsString("Unknown value type [foobar]"));

--- a/server/src/main/java/org/elasticsearch/search/builder/SearchSourceBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/builder/SearchSourceBuilder.java
@@ -109,10 +109,6 @@ public final class SearchSourceBuilder implements Writeable, ToXContentObject, R
     public static final ParseField POINT_IN_TIME = new ParseField("pit");
     public static final ParseField RUNTIME_MAPPINGS_FIELD = new ParseField("runtime_mappings");
 
-    public static SearchSourceBuilder fromXContent(XContentParser parser) throws IOException {
-        return fromXContent(parser, true);
-    }
-
     public static SearchSourceBuilder fromXContent(XContentParser parser, boolean checkTrailingTokens) throws IOException {
         SearchSourceBuilder builder = new SearchSourceBuilder();
         builder.parseXContent(parser, checkTrailingTokens);

--- a/server/src/main/java/org/elasticsearch/search/builder/SearchSourceBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/builder/SearchSourceBuilder.java
@@ -1138,10 +1138,6 @@ public final class SearchSourceBuilder implements Writeable, ToXContentObject, R
         return rewrittenBuilder;
     }
 
-    public void parseXContent(XContentParser parser) throws IOException {
-        parseXContent(parser, true);
-    }
-
     /**
      * Parse some xContent into this SearchSourceBuilder, overwriting any values specified in the xContent. Use this if you need to set up
      * different defaults than a regular SearchSourceBuilder would have and use {@link #fromXContent(XContentParser, boolean)} if you have

--- a/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/support/search/WatcherSearchTemplateService.java
+++ b/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/support/search/WatcherSearchTemplateService.java
@@ -73,7 +73,7 @@ public class WatcherSearchTemplateService {
                 XContentParser parser = XContentFactory.xContent(XContentHelper.xContentType(source))
                     .createParser(xContentRegistry, LoggingDeprecationHandler.INSTANCE, stream)
             ) {
-                sourceBuilder.parseXContent(parser);
+                sourceBuilder.parseXContent(parser, true);
                 searchRequest.source(sourceBuilder);
             }
         }


### PR DESCRIPTION
There are two variants of SearchSourceBuilder#fromXContent: one that takes the parser argument only, and another one that takes an additional boolean checkTrailingTokens argument. The former is only used in tests. For simplicity, this commit removes the variant that's only used in tests in favour of always providing the additional boolean argument.

There are also two variants of SearchSourceBuilder#parseXContent: one that takes the parser argument only, and another one that takes an additional boolean checkTrailingTokens argument. The former is only used by watcher search template service. For simplicity, this commit removes the variant that's only used in watcher in favour of always providing the additional boolean argument.