### PR TITLE
Suppress third party audit warnings from the use of preview APIs in lucene-core

### DIFF
--- a/libs/plugin-analysis-api/build.gradle
+++ b/libs/plugin-analysis-api/build.gradle
@@ -26,3 +26,17 @@ tasks.named('forbiddenApisMain').configure {
 tasks.named("dependencyLicenses").configure {
   mapping from: /lucene-.*/, to: 'lucene'
 }
+
+tasks.named("thirdPartyAudit").configure {
+  ignoreMissingClasses(
+    // from lucene-core versions/19/org/apache/lucene/store/MemorySegmentIndexInput
+    'java.lang.foreign.MemorySegment',
+    'java.lang.foreign.MemorySession',
+    'java.lang.foreign.ValueLayout',
+    'java.lang.foreign.ValueLayout$OfByte',
+    'java.lang.foreign.ValueLayout$OfFloat',
+    'java.lang.foreign.ValueLayout$OfInt',
+    'java.lang.foreign.ValueLayout$OfLong',
+    'java.lang.foreign.ValueLayout$OfShort'
+  )
+}

--- a/server/build.gradle
+++ b/server/build.gradle
@@ -138,6 +138,16 @@ if (BuildParams.isSnapshotBuild() == false) {
 
 tasks.named("thirdPartyAudit").configure {
     ignoreMissingClasses(
+            // from lucene-core versions/19/org/apache/lucene/store/MemorySegmentIndexInput
+            'java.lang.foreign.MemorySegment',
+            'java.lang.foreign.MemorySession',
+            'java.lang.foreign.ValueLayout',
+            'java.lang.foreign.ValueLayout$OfByte',
+            'java.lang.foreign.ValueLayout$OfFloat',
+            'java.lang.foreign.ValueLayout$OfInt',
+            'java.lang.foreign.ValueLayout$OfLong',
+            'java.lang.foreign.ValueLayout$OfShort',
+
             // from com.fasterxml.jackson.dataformat.yaml.YAMLMapper (jackson-dataformat-yaml)
             'com.fasterxml.jackson.databind.ObjectMapper',
 


### PR DESCRIPTION
Suppress third party audit warnings from the use of preview APIs in lucene-core.

closes #91264