### PR TITLE
[8.5] EQL: Fix EqlSearchRequest serialization (bwc) (#91402)

### DIFF
--- a/docs/changelog/91402.yaml
+++ b/docs/changelog/91402.yaml
@@ -1,0 +1,5 @@
+pr: 91402
+summary: Fix EQLSearchRequest serialization (bwc)
+area: EQL
+type: bug
+issues: []

--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/action/EqlSearchRequest.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/action/EqlSearchRequest.java
@@ -115,12 +115,10 @@ public class EqlSearchRequest extends ActionRequest implements IndicesRequest.Re
         if (in.getVersion().onOrAfter(Version.V_7_15_0)) {
             this.ccsMinimizeRoundtrips = in.readBoolean();
         }
-        if (in.getVersion().onOrAfter(Version.V_8_0_0)) { // TODO: Remove after backport
-            this.waitForCompletionTimeout = in.readOptionalTimeValue();
-            this.keepAlive = in.readOptionalTimeValue();
-            this.keepOnCompletion = in.readBoolean();
-        }
-        if (in.getVersion().onOrAfter(Version.V_7_10_0)) {
+        this.waitForCompletionTimeout = in.readOptionalTimeValue();
+        this.keepAlive = in.readOptionalTimeValue();
+        this.keepOnCompletion = in.readBoolean();
+        if (in.getVersion().onOrAfter(Version.V_8_0_0)) {
             resultPosition = in.readString();
         }
         if (in.getVersion().onOrAfter(Version.V_7_13_0)) {
@@ -223,10 +221,10 @@ public class EqlSearchRequest extends ActionRequest implements IndicesRequest.Re
         builder.field(KEY_FETCH_SIZE, fetchSize());
         builder.field(KEY_QUERY, query);
         if (waitForCompletionTimeout != null) {
-            builder.field(KEY_WAIT_FOR_COMPLETION_TIMEOUT, waitForCompletionTimeout);
+            builder.field(KEY_WAIT_FOR_COMPLETION_TIMEOUT, waitForCompletionTimeout.getStringRep());
         }
         if (keepAlive != null) {
-            builder.field(KEY_KEEP_ALIVE, keepAlive);
+            builder.field(KEY_KEEP_ALIVE, keepAlive.getStringRep());
         }
         builder.field(KEY_KEEP_ON_COMPLETION, keepOnCompletion);
         builder.field(KEY_RESULT_POSITION, resultPosition);
@@ -435,13 +433,10 @@ public class EqlSearchRequest extends ActionRequest implements IndicesRequest.Re
         if (out.getVersion().onOrAfter(Version.V_7_15_0)) {
             out.writeBoolean(ccsMinimizeRoundtrips);
         }
-        if (out.getVersion().onOrAfter(Version.V_8_0_0)) { // TODO: Remove after backport
-            out.writeOptionalTimeValue(waitForCompletionTimeout);
-            out.writeOptionalTimeValue(keepAlive);
-            out.writeBoolean(keepOnCompletion);
-        }
-
-        if (out.getVersion().onOrAfter(Version.V_7_10_0)) {
+        out.writeOptionalTimeValue(waitForCompletionTimeout);
+        out.writeOptionalTimeValue(keepAlive);
+        out.writeBoolean(keepOnCompletion);
+        if (out.getVersion().onOrAfter(Version.V_8_0_0)) {
             out.writeString(resultPosition);
         }
         if (out.getVersion().onOrAfter(Version.V_7_13_0)) {

--- a/x-pack/plugin/eql/src/test/java/org/elasticsearch/xpack/eql/action/EqlSearchRequestTests.java
+++ b/x-pack/plugin/eql/src/test/java/org/elasticsearch/xpack/eql/action/EqlSearchRequestTests.java
@@ -10,6 +10,7 @@ import org.elasticsearch.Version;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.search.SearchModule;
 import org.elasticsearch.search.fetch.subphase.FieldAndFormat;
@@ -76,12 +77,20 @@ public class EqlSearchRequestTests extends AbstractBWCSerializationTestCase<EqlS
                 .size(randomInt(50))
                 .query(randomAlphaOfLength(10))
                 .ccsMinimizeRoundtrips(ccsMinimizeRoundtrips)
+                .waitForCompletionTimeout(randomTV())
+                .keepAlive(randomTV())
+                .keepOnCompletion(randomBoolean())
                 .fetchFields(randomFetchFields)
-                .runtimeMappings(randomRuntimeMappings());
+                .runtimeMappings(randomRuntimeMappings())
+                .resultPosition(randomFrom("tail", "head"));
         } catch (IOException ex) {
             assertNotNull("unexpected IOException " + ex.getCause().getMessage(), ex);
         }
         return null;
+    }
+
+    private TimeValue randomTV() {
+        return TimeValue.parseTimeValue(randomTimeValue(), null, "test");
     }
 
     protected QueryBuilder parseFilter(String filter) throws IOException {
@@ -123,6 +132,7 @@ public class EqlSearchRequestTests extends AbstractBWCSerializationTestCase<EqlS
         mutatedInstance.keepOnCompletion(instance.keepOnCompletion());
         mutatedInstance.fetchFields(version.onOrAfter(Version.V_7_13_0) ? instance.fetchFields() : null);
         mutatedInstance.runtimeMappings(version.onOrAfter(Version.V_7_13_0) ? instance.runtimeMappings() : emptyMap());
+        mutatedInstance.resultPosition(version.onOrAfter(Version.V_8_0_0) ? instance.resultPosition() : "tail");
 
         return mutatedInstance;
     }


### PR DESCRIPTION
Backports the following commits to 8.5:
 - EQL: Fix EqlSearchRequest serialization (bwc) (#91402)