### PR TITLE
Use runtime java home for third party audit task

### DIFF
--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/precommit/ThirdPartyAuditPrecommitPlugin.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/precommit/ThirdPartyAuditPrecommitPlugin.java
@@ -16,7 +16,6 @@ import org.gradle.api.Project;
 import org.gradle.api.Task;
 import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.tasks.TaskProvider;
-import org.gradle.internal.jvm.Jvm;
 
 import java.nio.file.Path;
 

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/precommit/ThirdPartyAuditPrecommitPlugin.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/precommit/ThirdPartyAuditPrecommitPlugin.java
@@ -61,7 +61,9 @@ public class ThirdPartyAuditPrecommitPlugin extends PrecommitPlugin {
                 return dep.getGroup() != null && dep.getGroup().startsWith("org.elasticsearch") == false;
             }));
             t.dependsOn(resourcesTask);
-            t.setJavaHome(Jvm.current().getJavaHome().getPath());
+            if (BuildParams.getIsRuntimeJavaHomeSet()) {
+                t.setJavaHome(BuildParams.getRuntimeJavaHome().getPath());
+            }
             t.getTargetCompatibility().set(project.provider(BuildParams::getRuntimeJavaVersion));
             t.setSignatureFile(resourcesDir.resolve("forbidden/third-party-audit.txt").toFile());
             t.getJdkJarHellClasspath().from(jdkJarHellConfig);


### PR DESCRIPTION
We actually do indeed need to use the runtime Java for this task because depending on the target version, we may be loading classes for a later Java version. For example, if we use dependencies that are MR jars, then we in fact do load different classes depending on the runtime Java version. To test this properly then we need to use the target Java version to actually execute the task so it can both load the newer classes, and any classes from any newer APIs present in the later Java version.

Closes #91264
