### PR TITLE
Fix skip version for merging unmapped max

### DIFF
--- a/modules/aggregations/src/yamlRestTest/resources/rest-api-spec/test/aggregations/max_metric.yml
+++ b/modules/aggregations/src/yamlRestTest/resources/rest-api-spec/test/aggregations/max_metric.yml
@@ -207,8 +207,8 @@ setup:
 ---
 "Merging results with unmapped fields":
   - skip:
-      version: "all"
-      reason: "https://github.com/elastic/elasticsearch/issues/89994"
+      version: " - 8.4.99"
+      reason: Fixed in 8.5.0
 
   - do:
      search:

--- a/modules/aggregations/src/yamlRestTest/resources/rest-api-spec/test/aggregations/max_metric.yml
+++ b/modules/aggregations/src/yamlRestTest/resources/rest-api-spec/test/aggregations/max_metric.yml
@@ -206,6 +206,10 @@ setup:
 
 ---
 "Merging results with unmapped fields":
+  - skip:
+      version: "all"
+      reason: "https://github.com/elastic/elasticsearch/issues/89994"
+
   - do:
      search:
        index: [date_test_1, date_test_2]


### PR DESCRIPTION
The version was off by a minor commit and was causing random build
failures.

Closes https://github.com/elastic/elasticsearch/issues/89994