### PR TITLE
[HealthAPI] Rename explain to verbose

### DIFF
--- a/docs/reference/health/health.asciidoc
+++ b/docs/reference/health/health.asciidoc
@@ -46,6 +46,10 @@ A diagnosis contains a cause detailing a root cause analysis, an action containi
 of the steps to take to fix the problem, the list of affected resources (if applicable), and a detailed
 step by step troubleshooting guide to fix the diagnosed problem.
 
+NOTE: The health indicators perform root cause analysis of non-green health statuses. This can
+be computationally expensive when called frequently. When setting up automated polling of the API
+for health status set `verbose` to `false` to disable the more expensive analysis logic.
+
 [[health-api-path-params]]
 ==== {api-path-parms-title}
 
@@ -83,14 +87,10 @@ step by step troubleshooting guide to fix the diagnosed problem.
 [[health-api-query-params]]
 ==== {api-query-parms-title}
 
-`explain`::
+`verbose`::
     (Optional, Boolean) If `true`, the response includes additional details that help explain the status of each non-green indicator.
     These details include additional troubleshooting metrics and sometimes a root cause analysis of a health status.
     Defaults to `true`.
-
-NOTE: Some health indicators perform root cause analysis of non-green health statuses. This can
-be computationally expensive when called frequently. When setting up automated polling of the API
-for health status set `explain` to `false` to disable the more expensive analysis logic.
 
 [role="child_attributes"]
 [[health-api-response-body]]
@@ -152,7 +152,7 @@ for health status set `explain` to `false` to disable the more expensive analysi
     (Optional, object) An object that contains additional information about the cluster that
     has lead to the current health status result. This data is unstructured, and each
     indicator returns <<health-api-response-details, a unique set of details>>. Details will not be calculated if the
-    `explain` property is set to false.
+    `verbose` property is set to false.
 
 `impacts`::
     (Optional, array) If a non-healthy status is returned, indicators may include a list of
@@ -184,7 +184,7 @@ for health status set `explain` to `false` to disable the more expensive analysi
 `diagnosis`::
     (Optional, array) If a non-healthy status is returned, indicators may include a list of
     diagnosis that encapsulate the cause of the health issue and an action to take in order to remediate the problem.
-    The diagnosis will not be calculated if the `explain` property is false.
+    The diagnosis will not be calculated if the `verbose` property is false.
 +
 .Properties of `diagnosis`
 [%collapsible%open]
@@ -395,7 +395,7 @@ The API returns a response for just the shard availability indicator.
 
 [source,console]
 --------------------------------------------------
-GET _internal/_health?explain=false
+GET _internal/_health?verbose=false
 --------------------------------------------------
 
 The API returns a response with all health indicators but will

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/_internal.health.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/_internal.health.json
@@ -36,9 +36,9 @@
         "type":"time",
         "description":"Explicit operation timeout"
       },
-      "explain":{
+      "verbose":{
         "type":"boolean",
-        "description":"Include details on returned indicators",
+        "description":"Opt in for more information about the health of the system",
         "default":true
       }
     }

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/health/30_feature.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/health/30_feature.yml
@@ -1,8 +1,8 @@
 ---
 "cluster health test drilling down into a feature":
   - skip:
-      version: "- 8.3.99"
-      reason: "health drilldown was only added in 8.3.0, and master_is_stable in 8.4.0"
+      version: "- 8.5.99"
+      reason: "the verbose parameter was only added in 8.6"
 
   - do:
       _internal.health:
@@ -17,7 +17,7 @@
   - do:
       _internal.health:
         feature: master_is_stable
-        explain: false
+        verbose: false
 
   - is_true: cluster_name
   - match:   { indicators.master_is_stable.status: "green" }

--- a/server/src/internalClusterTest/java/org/elasticsearch/health/GetHealthActionIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/health/GetHealthActionIT.java
@@ -139,12 +139,12 @@ public class GetHealthActionIT extends ESIntegTestCase {
         }
 
         @Override
-        public HealthIndicatorResult calculate(boolean explain, HealthInfo healthInfo) {
+        public HealthIndicatorResult calculate(boolean verbose, HealthInfo healthInfo) {
             var status = clusterService.getClusterSettings().get(statusSetting);
             return createIndicator(
                 status,
                 "Health is set to [" + status + "] by test plugin",
-                new SimpleHealthIndicatorDetails(Map.of("explain", explain)),
+                new SimpleHealthIndicatorDetails(Map.of("verbose", verbose)),
                 Collections.emptyList(),
                 Collections.emptyList()
             );
@@ -219,9 +219,9 @@ public class GetHealthActionIT extends ESIntegTestCase {
         HealthStatus ilmIndicatorStatus,
         HealthStatus slmIndicatorStatus,
         HealthStatus clusterCoordinationIndicatorStatus,
-        boolean explain
+        boolean verbose
     ) throws Exception {
-        var response = client.execute(GetHealthAction.INSTANCE, new GetHealthAction.Request(explain)).get();
+        var response = client.execute(GetHealthAction.INSTANCE, new GetHealthAction.Request(verbose)).get();
 
         assertThat(
             response.getStatus(),
@@ -235,7 +235,7 @@ public class GetHealthActionIT extends ESIntegTestCase {
                     ILM_INDICATOR_NAME,
                     ilmIndicatorStatus,
                     "Health is set to [" + ilmIndicatorStatus + "] by test plugin",
-                    new SimpleHealthIndicatorDetails(Map.of("explain", explain)),
+                    new SimpleHealthIndicatorDetails(Map.of("verbose", verbose)),
                     Collections.emptyList(),
                     Collections.emptyList()
                 )
@@ -248,7 +248,7 @@ public class GetHealthActionIT extends ESIntegTestCase {
                     INSTANCE_HAS_MASTER_INDICATOR_NAME,
                     clusterCoordinationIndicatorStatus,
                     "Health is set to [" + clusterCoordinationIndicatorStatus + "] by test plugin",
-                    new SimpleHealthIndicatorDetails(Map.of("explain", explain)),
+                    new SimpleHealthIndicatorDetails(Map.of("verbose", verbose)),
                     Collections.emptyList(),
                     Collections.emptyList()
                 )
@@ -256,8 +256,8 @@ public class GetHealthActionIT extends ESIntegTestCase {
         );
     }
 
-    private void testIndicator(Client client, HealthStatus ilmIndicatorStatus, boolean explain) throws Exception {
-        var response = client.execute(GetHealthAction.INSTANCE, new GetHealthAction.Request(ILM_INDICATOR_NAME, explain)).get();
+    private void testIndicator(Client client, HealthStatus ilmIndicatorStatus, boolean verbose) throws Exception {
+        var response = client.execute(GetHealthAction.INSTANCE, new GetHealthAction.Request(ILM_INDICATOR_NAME, verbose)).get();
         assertNull(response.getStatus());
         assertThat(response.getClusterName(), equalTo(new ClusterName(cluster().getClusterName())));
         assertThat(
@@ -267,7 +267,7 @@ public class GetHealthActionIT extends ESIntegTestCase {
                     ILM_INDICATOR_NAME,
                     ilmIndicatorStatus,
                     "Health is set to [" + ilmIndicatorStatus + "] by test plugin",
-                    new SimpleHealthIndicatorDetails(Map.of("explain", explain)),
+                    new SimpleHealthIndicatorDetails(Map.of("verbose", verbose)),
                     Collections.emptyList(),
                     Collections.emptyList()
                 )

--- a/server/src/internalClusterTest/java/org/elasticsearch/health/HealthServiceIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/health/HealthServiceIT.java
@@ -158,7 +158,7 @@ public class HealthServiceIT extends ESIntegTestCase {
         }
 
         @Override
-        public HealthIndicatorResult calculate(boolean explain, HealthInfo healthInfo) {
+        public HealthIndicatorResult calculate(boolean verbose, HealthInfo healthInfo) {
             assertThat(healthInfo.diskInfoByNode().size(), equalTo(internalCluster().getNodeNames().length));
             for (DiskHealthInfo diskHealthInfo : healthInfo.diskInfoByNode().values()) {
                 assertThat(diskHealthInfo.healthStatus(), equalTo(HealthStatus.GREEN));

--- a/server/src/main/java/org/elasticsearch/cluster/coordination/CoordinationDiagnosticsService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/CoordinationDiagnosticsService.java
@@ -203,25 +203,25 @@ public class CoordinationDiagnosticsService implements ClusterStateListener {
 
     /**
      * This method calculates the master stability as seen from this node.
-     * @param explain If true, the result will contain a non-empty CoordinationDiagnosticsDetails if the resulting status is non-GREEN
+     * @param verbose If true, the result will contain a non-empty CoordinationDiagnosticsDetails if the resulting status is non-GREEN
      * @return Information about the current stability of the master node, as seen from this node
      */
-    public CoordinationDiagnosticsResult diagnoseMasterStability(boolean explain) {
+    public CoordinationDiagnosticsResult diagnoseMasterStability(boolean verbose) {
         MasterHistory localMasterHistory = masterHistoryService.getLocalMasterHistory();
         if (hasSeenMasterInHasMasterLookupTimeframe()) {
-            return diagnoseOnHaveSeenMasterRecently(localMasterHistory, explain);
+            return diagnoseOnHaveSeenMasterRecently(localMasterHistory, verbose);
         } else {
-            return diagnoseOnHaveNotSeenMasterRecently(localMasterHistory, explain);
+            return diagnoseOnHaveNotSeenMasterRecently(localMasterHistory, verbose);
         }
     }
 
     /**
      * Returns the health result for the case when we have seen a master recently (at some point in the last 30 seconds).
      * @param localMasterHistory The master history as seen from the local machine
-     * @param explain Whether to calculate and include the details and user actions in the result
+     * @param verbose Whether to calculate and include the details and user actions in the result
      * @return The CoordinationDiagnosticsResult for the given localMasterHistory
      */
-    private CoordinationDiagnosticsResult diagnoseOnHaveSeenMasterRecently(MasterHistory localMasterHistory, boolean explain) {
+    private CoordinationDiagnosticsResult diagnoseOnHaveSeenMasterRecently(MasterHistory localMasterHistory, boolean verbose) {
         int masterChanges = MasterHistory.getNumberOfMasterIdentityChanges(localMasterHistory.getNodes());
         logger.trace(
             "Have seen a master in the last {}): {}",
@@ -230,11 +230,11 @@ public class CoordinationDiagnosticsService implements ClusterStateListener {
         );
         final CoordinationDiagnosticsResult result;
         if (masterChanges >= unacceptableIdentityChanges) {
-            result = diagnoseOnMasterHasChangedIdentity(localMasterHistory, masterChanges, explain);
+            result = diagnoseOnMasterHasChangedIdentity(localMasterHistory, masterChanges, verbose);
         } else if (localMasterHistory.hasMasterGoneNullAtLeastNTimes(unacceptableNullTransitions)) {
-            result = diagnoseOnMasterHasFlappedNull(localMasterHistory, explain);
+            result = diagnoseOnMasterHasFlappedNull(localMasterHistory, verbose);
         } else {
-            result = getMasterIsStableResult(explain, localMasterHistory);
+            result = getMasterIsStableResult(verbose, localMasterHistory);
         }
         return result;
     }
@@ -244,13 +244,13 @@ public class CoordinationDiagnosticsService implements ClusterStateListener {
      * times in the last 30 minutes)
      * @param localMasterHistory The master history as seen from the local machine
      * @param masterChanges The number of times that the local machine has seen the master identity change in the last 30 minutes
-     * @param explain Whether to calculate and include the details in the result
+     * @param verbose Whether to calculate and include the details in the result
      * @return The CoordinationDiagnosticsResult for the given localMasterHistory
      */
     private CoordinationDiagnosticsResult diagnoseOnMasterHasChangedIdentity(
         MasterHistory localMasterHistory,
         int masterChanges,
-        boolean explain
+        boolean verbose
     ) {
         logger.trace("Have seen {} master changes in the last {}", masterChanges, localMasterHistory.getMaxHistoryAge());
         CoordinationDiagnosticsStatus coordinationDiagnosticsStatus = CoordinationDiagnosticsStatus.YELLOW;
@@ -260,29 +260,29 @@ public class CoordinationDiagnosticsService implements ClusterStateListener {
             masterChanges,
             localMasterHistory.getMaxHistoryAge()
         );
-        CoordinationDiagnosticsDetails details = getDetails(explain, localMasterHistory, null, null);
+        CoordinationDiagnosticsDetails details = getDetails(verbose, localMasterHistory, null, null);
         return new CoordinationDiagnosticsResult(coordinationDiagnosticsStatus, summary, details);
     }
 
     /**
-     * This returns CoordinationDiagnosticsDetails.EMPTY if explain is false, otherwise a CoordinationDiagnosticsDetails object
+     * This returns CoordinationDiagnosticsDetails.EMPTY if verbose is false, otherwise a CoordinationDiagnosticsDetails object
      * containing only a "current_master" object and a "recent_masters" array. The "current_master" object will have "node_id" and "name"
      * fields for the master node. Both will be null if the last-seen master was null. The "recent_masters" array will contain
      * "recent_master" objects. Each "recent_master" object will have "node_id" and "name" fields for the master node. These fields will
      * never be null because null masters are not written to this array.
-     * @param explain If true, the CoordinationDiagnosticsDetails will contain "current_master" and "recent_masters". Otherwise it will
+     * @param verbose If true, the CoordinationDiagnosticsDetails will contain "current_master" and "recent_masters". Otherwise it will
      *                be empty.
      * @param localMasterHistory The MasterHistory object to pull current and recent master info from
-     * @return An empty CoordinationDiagnosticsDetails if explain is false, otherwise a CoordinationDiagnosticsDetails containing only
+     * @return An empty CoordinationDiagnosticsDetails if verbose is false, otherwise a CoordinationDiagnosticsDetails containing only
      * "current_master" and "recent_masters"
      */
     private static CoordinationDiagnosticsDetails getDetails(
-        boolean explain,
+        boolean verbose,
         MasterHistory localMasterHistory,
         @Nullable Exception remoteException,
         @Nullable Map<String, String> clusterFormationMessages
     ) {
-        if (explain == false) {
+        if (verbose == false) {
             return CoordinationDiagnosticsDetails.EMPTY;
         }
         DiscoveryNode masterNode = localMasterHistory.getMostRecentMaster();
@@ -298,10 +298,10 @@ public class CoordinationDiagnosticsService implements ClusterStateListener {
      * and a GREEN status is returned (the problems with this node will be covered in a separate health indicator). If there had been
      * problems fetching the remote master history, the exception seen will be included in the details of the result.
      * @param localMasterHistory The master history as seen from the local machine
-     * @param explain Whether to calculate and include the details in the result
+     * @param verbose Whether to calculate and include the details in the result
      * @return The CoordinationDiagnosticsResult for the given localMasterHistory
      */
-    private CoordinationDiagnosticsResult diagnoseOnMasterHasFlappedNull(MasterHistory localMasterHistory, boolean explain) {
+    private CoordinationDiagnosticsResult diagnoseOnMasterHasFlappedNull(MasterHistory localMasterHistory, boolean verbose) {
         DiscoveryNode master = localMasterHistory.getMostRecentNonNullMaster();
         boolean localNodeIsMaster = clusterService.localNode().equals(master);
         List<DiscoveryNode> remoteHistory;
@@ -338,11 +338,11 @@ public class CoordinationDiagnosticsService implements ClusterStateListener {
                 localMasterHistory.getNodes().stream().filter(Objects::nonNull).collect(Collectors.toSet()),
                 localMasterHistory.getMaxHistoryAge()
             );
-            final CoordinationDiagnosticsDetails details = getDetails(explain, localMasterHistory, remoteHistoryException, null);
+            final CoordinationDiagnosticsDetails details = getDetails(verbose, localMasterHistory, remoteHistoryException, null);
             return new CoordinationDiagnosticsResult(CoordinationDiagnosticsStatus.YELLOW, summary, details);
         } else {
             logger.trace("This node thinks the master is unstable, but the master node {} thinks it is stable", master);
-            return getMasterIsStableResult(explain, localMasterHistory);
+            return getMasterIsStableResult(verbose, localMasterHistory);
         }
     }
 
@@ -350,37 +350,37 @@ public class CoordinationDiagnosticsService implements ClusterStateListener {
      * Returns a CoordinationDiagnosticsResult for the case when the master is seen as stable
      * @return A CoordinationDiagnosticsResult for the case when the master is seen as stable (GREEN status, no impacts or details)
      */
-    private CoordinationDiagnosticsResult getMasterIsStableResult(boolean explain, MasterHistory localMasterHistory) {
+    private CoordinationDiagnosticsResult getMasterIsStableResult(boolean verbose, MasterHistory localMasterHistory) {
         String summary = "The cluster has a stable master node";
         logger.trace("The cluster has a stable master node");
-        CoordinationDiagnosticsDetails details = getDetails(explain, localMasterHistory, null, null);
+        CoordinationDiagnosticsDetails details = getDetails(verbose, localMasterHistory, null, null);
         return new CoordinationDiagnosticsResult(CoordinationDiagnosticsStatus.GREEN, summary, details);
     }
 
     /**
      * Returns the health result for the case when we have NOT seen a master recently (at some point in the last 30 seconds).
      * @param localMasterHistory The master history as seen from the local machine
-     * @param explain Whether to calculate and include the details in the result
+     * @param verbose Whether to calculate and include the details in the result
      * @return The CoordinationDiagnosticsResult for the given localMasterHistory
      */
-    private CoordinationDiagnosticsResult diagnoseOnHaveNotSeenMasterRecently(MasterHistory localMasterHistory, boolean explain) {
+    private CoordinationDiagnosticsResult diagnoseOnHaveNotSeenMasterRecently(MasterHistory localMasterHistory, boolean verbose) {
         Collection<DiscoveryNode> masterEligibleNodes = getMasterEligibleNodes();
         final CoordinationDiagnosticsResult result;
         boolean clusterHasLeader = coordinator.getPeerFinder().getLeader().isPresent();
         boolean noLeaderAndNoMasters = clusterHasLeader == false && masterEligibleNodes.isEmpty();
         boolean isLocalNodeMasterEligible = clusterService.localNode().isMasterNode();
         if (noLeaderAndNoMasters) {
-            result = getResultOnNoMasterEligibleNodes(localMasterHistory, explain);
+            result = getResultOnNoMasterEligibleNodes(localMasterHistory, verbose);
         } else if (clusterHasLeader) {
             DiscoveryNode currentMaster = coordinator.getPeerFinder().getLeader().get();
-            result = getResultOnCannotJoinLeader(localMasterHistory, currentMaster, explain);
+            result = getResultOnCannotJoinLeader(localMasterHistory, currentMaster, verbose);
         } else if (isLocalNodeMasterEligible == false) { // none is elected master and we aren't master eligible
             result = diagnoseOnHaveNotSeenMasterRecentlyAndWeAreNotMasterEligible(
                 localMasterHistory,
                 coordinator,
                 nodeHasMasterLookupTimeframe,
                 remoteCoordinationDiagnosisResult,
-                explain
+                verbose
             );
         } else { // none is elected master and we are master eligible
             result = diagnoseOnHaveNotSeenMasterRecentlyAndWeAreMasterEligible(
@@ -389,7 +389,7 @@ public class CoordinationDiagnosticsService implements ClusterStateListener {
                 coordinator,
                 clusterFormationResponses,
                 nodeHasMasterLookupTimeframe,
-                explain
+                verbose
             );
         }
         return result;
@@ -402,7 +402,7 @@ public class CoordinationDiagnosticsService implements ClusterStateListener {
      * @param coordinator The Coordinator for this node
      * @param nodeHasMasterLookupTimeframe The value of health.master_history.has_master_lookup_timeframe
      * @param remoteCoordinationDiagnosisResult A reference to the result of polling a master-eligible node for diagnostic information
-     * @param explain If true, details are returned
+     * @param verbose If true, details are returned
      * @return A CoordinationDiagnosticsResult that will be determined by the CoordinationDiagnosticsResult returned by the remote
      * master-eligible node
      */
@@ -411,7 +411,7 @@ public class CoordinationDiagnosticsService implements ClusterStateListener {
         Coordinator coordinator,
         TimeValue nodeHasMasterLookupTimeframe,
         AtomicReference<RemoteMasterHealthResult> remoteCoordinationDiagnosisResult,
-        boolean explain
+        boolean verbose
     ) {
         RemoteMasterHealthResult remoteResultOrException = remoteCoordinationDiagnosisResult == null
             ? null
@@ -427,7 +427,7 @@ public class CoordinationDiagnosticsService implements ClusterStateListener {
                     + " for more information",
                 nodeHasMasterLookupTimeframe
             );
-            if (explain) {
+            if (verbose) {
                 details = getDetails(
                     true,
                     localMasterHistory,
@@ -456,7 +456,7 @@ public class CoordinationDiagnosticsService implements ClusterStateListener {
                         coordinator.getLocalNode().getName()
                     );
                 }
-                if (explain) {
+                if (verbose) {
                     details = remoteResult.details();
                 } else {
                     details = CoordinationDiagnosticsDetails.EMPTY;
@@ -470,7 +470,7 @@ public class CoordinationDiagnosticsService implements ClusterStateListener {
                     nodeHasMasterLookupTimeframe,
                     remoteNode.getName()
                 );
-                if (explain) {
+                if (verbose) {
                     details = getDetails(true, localMasterHistory, exception, null);
                 } else {
                     details = CoordinationDiagnosticsDetails.EMPTY;
@@ -490,7 +490,7 @@ public class CoordinationDiagnosticsService implements ClusterStateListener {
      * @param clusterFormationResponses A map that contains the cluster formation information (or exception encountered while requesting
      *                                  it) from each master eligible node in the cluster
      * @param nodeHasMasterLookupTimeframe The value of health.master_history.has_master_lookup_timeframe
-     * @param explain If true, details are returned
+     * @param verbose If true, details are returned
      * @return A CoordinationDiagnosticsResult with a RED status
      */
     static CoordinationDiagnosticsResult diagnoseOnHaveNotSeenMasterRecentlyAndWeAreMasterEligible(
@@ -499,7 +499,7 @@ public class CoordinationDiagnosticsService implements ClusterStateListener {
         Coordinator coordinator,
         ConcurrentMap<DiscoveryNode, ClusterFormationStateOrException> clusterFormationResponses,
         TimeValue nodeHasMasterLookupTimeframe,
-        boolean explain
+        boolean verbose
 
     ) {
         final CoordinationDiagnosticsResult result;
@@ -522,7 +522,7 @@ public class CoordinationDiagnosticsService implements ClusterStateListener {
                         entry.getKey().getName()
                     ),
                     getDetails(
-                        explain,
+                        verbose,
                         localMasterHistory,
                         remoteException,
                         Map.of(coordinator.getLocalNode().getId(), coordinator.getClusterFormationState().getDescription())
@@ -553,7 +553,7 @@ public class CoordinationDiagnosticsService implements ClusterStateListener {
                         + "eligible nodes",
                     nodeHasMasterLookupTimeframe
                 ),
-                getDetails(explain, localMasterHistory, null, nodeIdToClusterFormationDescription)
+                getDetails(verbose, localMasterHistory, null, nodeIdToClusterFormationDescription)
             );
         } else {
             if (anyNodeInClusterReportsQuorumProblems(nodeClusterFormationStateMap)) {
@@ -564,7 +564,7 @@ public class CoordinationDiagnosticsService implements ClusterStateListener {
                         "No master node observed in the last %s, and the master eligible nodes are unable to form a quorum",
                         nodeHasMasterLookupTimeframe
                     ),
-                    getDetails(explain, localMasterHistory, null, nodeIdToClusterFormationDescription)
+                    getDetails(verbose, localMasterHistory, null, nodeIdToClusterFormationDescription)
                 );
             } else {
                 result = new CoordinationDiagnosticsResult(
@@ -574,7 +574,7 @@ public class CoordinationDiagnosticsService implements ClusterStateListener {
                         "No master node observed in the last %s, and the cause has not been determined.",
                         nodeHasMasterLookupTimeframe
                     ),
-                    getDetails(explain, localMasterHistory, null, nodeIdToClusterFormationDescription)
+                    getDetails(verbose, localMasterHistory, null, nodeIdToClusterFormationDescription)
                 );
             }
         }
@@ -662,16 +662,16 @@ public class CoordinationDiagnosticsService implements ClusterStateListener {
 
     /**
      * Creates a CoordinationDiagnosticsResult in the case that there has been no master in the last few seconds, there is no elected
-     * master known, and there are no master eligible nodes. The status will be RED, and the details (if explain is true) will contain
+     * master known, and there are no master eligible nodes. The status will be RED, and the details (if verbose is true) will contain
      * the list of any masters seen previously and a description of known problems from this node's Coordinator.
-     * @param localMasterHistory Used to pull recent master nodes for the details if explain is true
-     * @param explain If true, details are returned
+     * @param localMasterHistory Used to pull recent master nodes for the details if verbose is true
+     * @param verbose If true, details are returned
      * @return A CoordinationDiagnosticsResult with a RED status
      */
-    private CoordinationDiagnosticsResult getResultOnNoMasterEligibleNodes(MasterHistory localMasterHistory, boolean explain) {
+    private CoordinationDiagnosticsResult getResultOnNoMasterEligibleNodes(MasterHistory localMasterHistory, boolean verbose) {
         String summary = "No master eligible nodes found in the cluster";
         CoordinationDiagnosticsDetails details = getDetails(
-            explain,
+            verbose,
             localMasterHistory,
             null,
             Map.of(coordinator.getLocalNode().getId(), coordinator.getClusterFormationState().getDescription())
@@ -682,17 +682,17 @@ public class CoordinationDiagnosticsService implements ClusterStateListener {
     /**
      * Creates a CoordinationDiagnosticsResult in the case that there has been no master in the last few seconds in this node's cluster
      * state, but PeerFinder reports that there is an elected master. The assumption is that this node is having a problem joining the
-     * elected master. The status will be RED, and the details (if explain is true) will contain the list of any masters seen previously
+     * elected master. The status will be RED, and the details (if verbose is true) will contain the list of any masters seen previously
      * and a description of known problems from this node's Coordinator.
-     * @param localMasterHistory Used to pull recent master nodes for the details if explain is true
+     * @param localMasterHistory Used to pull recent master nodes for the details if verbose is true
      * @param currentMaster The node that PeerFinder reports as the elected master
-     * @param explain If true, details are returned
+     * @param verbose If true, details are returned
      * @return A CoordinationDiagnosticsResult with a RED status
      */
     private CoordinationDiagnosticsResult getResultOnCannotJoinLeader(
         MasterHistory localMasterHistory,
         DiscoveryNode currentMaster,
-        boolean explain
+        boolean verbose
     ) {
         String summary = String.format(
             Locale.ROOT,
@@ -701,7 +701,7 @@ public class CoordinationDiagnosticsService implements ClusterStateListener {
             clusterService.localNode()
         );
         CoordinationDiagnosticsDetails details = getDetails(
-            explain,
+            verbose,
             localMasterHistory,
             null,
             Map.of(coordinator.getLocalNode().getId(), coordinator.getClusterFormationState().getDescription())

--- a/server/src/main/java/org/elasticsearch/cluster/coordination/StableMasterHealthIndicatorService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/StableMasterHealthIndicatorService.java
@@ -104,10 +104,10 @@ public class StableMasterHealthIndicatorService implements HealthIndicatorServic
     }
 
     @Override
-    public HealthIndicatorResult calculate(boolean explain, HealthInfo healthInfo) {
+    public HealthIndicatorResult calculate(boolean verbose, HealthInfo healthInfo) {
         CoordinationDiagnosticsService.CoordinationDiagnosticsResult coordinationDiagnosticsResult = coordinationDiagnosticsService
-            .diagnoseMasterStability(explain);
-        return getHealthIndicatorResult(coordinationDiagnosticsResult, explain);
+            .diagnoseMasterStability(verbose);
+        return getHealthIndicatorResult(coordinationDiagnosticsResult, verbose);
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/health/GetHealthAction.java
+++ b/server/src/main/java/org/elasticsearch/health/GetHealthAction.java
@@ -122,17 +122,17 @@ public class GetHealthAction extends ActionType<GetHealthAction.Response> {
 
     public static class Request extends ActionRequest {
         private final String indicatorName;
-        private final boolean explain;
+        private final boolean verbose;
 
-        public Request(boolean explain) {
+        public Request(boolean verbose) {
             // We never compute details if no indicator name is given because of the runtime cost:
             this.indicatorName = null;
-            this.explain = explain;
+            this.verbose = verbose;
         }
 
-        public Request(String indicatorName, boolean explain) {
+        public Request(String indicatorName, boolean verbose) {
             this.indicatorName = indicatorName;
-            this.explain = explain;
+            this.verbose = verbose;
         }
 
         @Override
@@ -166,7 +166,7 @@ public class GetHealthAction extends ActionType<GetHealthAction.Response> {
             healthService.getHealth(
                 client,
                 request.indicatorName,
-                request.explain,
+                request.verbose,
                 responseListener.map(
                     healthIndicatorResults -> new Response(
                         clusterService.getClusterName(),

--- a/server/src/main/java/org/elasticsearch/health/HealthIndicatorService.java
+++ b/server/src/main/java/org/elasticsearch/health/HealthIndicatorService.java
@@ -22,7 +22,7 @@ public interface HealthIndicatorService {
 
     String name();
 
-    HealthIndicatorResult calculate(boolean explain, HealthInfo healthInfo);
+    HealthIndicatorResult calculate(boolean verbose, HealthInfo healthInfo);
 
     /**
      * This method creates a HealthIndicatorResult with the given information. Note that it sorts the impacts by severity (the lower the

--- a/server/src/main/java/org/elasticsearch/health/RestGetHealthAction.java
+++ b/server/src/main/java/org/elasticsearch/health/RestGetHealthAction.java
@@ -20,7 +20,7 @@ import static org.elasticsearch.rest.RestRequest.Method.GET;
 
 public class RestGetHealthAction extends BaseRestHandler {
 
-    private static final String EXPLAIN_PARAM = "explain";
+    private static final String VERBOSE_PARAM = "verbose";
 
     @Override
     public String getName() {
@@ -36,8 +36,8 @@ public class RestGetHealthAction extends BaseRestHandler {
     @Override
     protected RestChannelConsumer prepareRequest(RestRequest request, NodeClient client) throws IOException {
         String indicatorName = request.param("indicator");
-        boolean explain = request.paramAsBoolean(EXPLAIN_PARAM, true);
-        GetHealthAction.Request getHealthRequest = new GetHealthAction.Request(indicatorName, explain);
+        boolean verbose = request.paramAsBoolean(VERBOSE_PARAM, true);
+        GetHealthAction.Request getHealthRequest = new GetHealthAction.Request(indicatorName, verbose);
         return channel -> client.execute(GetHealthAction.INSTANCE, getHealthRequest, new RestToXContentListener<>(channel));
     }
 }

--- a/server/src/main/java/org/elasticsearch/health/node/DiskHealthIndicatorService.java
+++ b/server/src/main/java/org/elasticsearch/health/node/DiskHealthIndicatorService.java
@@ -82,7 +82,7 @@ public class DiskHealthIndicatorService implements HealthIndicatorService {
     }
 
     @Override
-    public HealthIndicatorResult calculate(boolean explain, HealthInfo healthInfo) {
+    public HealthIndicatorResult calculate(boolean verbose, HealthInfo healthInfo) {
         Map<String, DiskHealthInfo> diskHealthInfoMap = healthInfo.diskInfoByNode();
         if (diskHealthInfoMap == null || diskHealthInfoMap.isEmpty()) {
             /*
@@ -105,7 +105,7 @@ public class DiskHealthIndicatorService implements HealthIndicatorService {
         return createIndicator(
             diskHealthAnalyzer.getHealthStatus(),
             diskHealthAnalyzer.getSymptom(),
-            diskHealthAnalyzer.getDetails(explain),
+            diskHealthAnalyzer.getDetails(verbose),
             diskHealthAnalyzer.getImpacts(),
             diskHealthAnalyzer.getDiagnoses()
         );
@@ -419,8 +419,8 @@ public class DiskHealthIndicatorService implements HealthIndicatorService {
             return diagnosisList;
         }
 
-        HealthIndicatorDetails getDetails(boolean explain) {
-            if (explain == false) {
+        HealthIndicatorDetails getDetails(boolean verbose) {
+            if (verbose == false) {
                 return HealthIndicatorDetails.EMPTY;
             }
             return ((builder, params) -> {

--- a/server/src/main/java/org/elasticsearch/snapshots/RepositoryIntegrityHealthIndicatorService.java
+++ b/server/src/main/java/org/elasticsearch/snapshots/RepositoryIntegrityHealthIndicatorService.java
@@ -72,7 +72,7 @@ public class RepositoryIntegrityHealthIndicatorService implements HealthIndicato
     }
 
     @Override
-    public HealthIndicatorResult calculate(boolean explain, HealthInfo healthInfo) {
+    public HealthIndicatorResult calculate(boolean verbose, HealthInfo healthInfo) {
         var snapshotMetadata = clusterService.state().metadata().custom(RepositoriesMetadata.TYPE, RepositoriesMetadata.EMPTY);
 
         if (snapshotMetadata.repositories().isEmpty()) {
@@ -98,7 +98,7 @@ public class RepositoryIntegrityHealthIndicatorService implements HealthIndicato
             return createIndicator(
                 GREEN,
                 "No corrupted snapshot repositories.",
-                explain ? new SimpleHealthIndicatorDetails(Map.of("total_repositories", totalRepositories)) : HealthIndicatorDetails.EMPTY,
+                verbose ? new SimpleHealthIndicatorDetails(Map.of("total_repositories", totalRepositories)) : HealthIndicatorDetails.EMPTY,
                 Collections.emptyList(),
                 Collections.emptyList()
             );
@@ -120,7 +120,7 @@ public class RepositoryIntegrityHealthIndicatorService implements HealthIndicato
         return createIndicator(
             RED,
             createCorruptedRepositorySummary(corrupted),
-            explain
+            verbose
                 ? new SimpleHealthIndicatorDetails(
                     Map.of(
                         "total_repositories",

--- a/server/src/test/java/org/elasticsearch/cluster/coordination/StableMasterHealthIndicatorServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/coordination/StableMasterHealthIndicatorServiceTests.java
@@ -94,7 +94,7 @@ public class StableMasterHealthIndicatorServiceTests extends AbstractCoordinator
     }
 
     @SuppressWarnings("unchecked")
-    public void testGetHealthIndicatorResultNotGreenExplainTrue() throws Exception {
+    public void testGetHealthIndicatorResultNotGreenVerboseTrue() throws Exception {
         MasterHistoryService masterHistoryService = createMasterHistoryService();
         StableMasterHealthIndicatorService service = createStableMasterHealthIndicatorService(nullMasterClusterState, masterHistoryService);
         List<DiscoveryNode> recentMasters = List.of(node2, node1);
@@ -154,7 +154,7 @@ public class StableMasterHealthIndicatorServiceTests extends AbstractCoordinator
     }
 
     @SuppressWarnings("unchecked")
-    public void testGetHealthIndicatorResultNotGreenExplainFalse() throws Exception {
+    public void testGetHealthIndicatorResultNotGreenVerboseFalse() throws Exception {
         MasterHistoryService masterHistoryService = createMasterHistoryService();
         StableMasterHealthIndicatorService service = createStableMasterHealthIndicatorService(nullMasterClusterState, masterHistoryService);
         List<DiscoveryNode> recentMasters = List.of(node2, node1);

--- a/server/src/test/java/org/elasticsearch/health/HealthIndicatorServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/health/HealthIndicatorServiceTests.java
@@ -90,7 +90,7 @@ public class HealthIndicatorServiceTests extends ESTestCase {
             }
 
             @Override
-            public HealthIndicatorResult calculate(boolean explain, HealthInfo healthInfo) {
+            public HealthIndicatorResult calculate(boolean verbose, HealthInfo healthInfo) {
                 return null;
             }
         };

--- a/server/src/test/java/org/elasticsearch/health/HealthServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/health/HealthServiceTests.java
@@ -368,7 +368,7 @@ public class HealthServiceTests extends ESTestCase {
             }
 
             @Override
-            public HealthIndicatorResult calculate(boolean explain, HealthInfo healthInfo) {
+            public HealthIndicatorResult calculate(boolean verbose, HealthInfo healthInfo) {
                 if (expectedHealthInfo != null) {
                     assertThat(healthInfo, equalTo(expectedHealthInfo));
                 }

--- a/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/IlmHealthIndicatorService.java
+++ b/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/IlmHealthIndicatorService.java
@@ -64,13 +64,13 @@ public class IlmHealthIndicatorService implements HealthIndicatorService {
     }
 
     @Override
-    public HealthIndicatorResult calculate(boolean explain, HealthInfo healthInfo) {
+    public HealthIndicatorResult calculate(boolean verbose, HealthInfo healthInfo) {
         var ilmMetadata = clusterService.state().metadata().custom(IndexLifecycleMetadata.TYPE, IndexLifecycleMetadata.EMPTY);
         if (ilmMetadata.getPolicyMetadatas().isEmpty()) {
             return createIndicator(
                 GREEN,
                 "No Index Lifecycle Management policies configured",
-                createDetails(explain, ilmMetadata),
+                createDetails(verbose, ilmMetadata),
                 Collections.emptyList(),
                 Collections.emptyList()
             );
@@ -88,7 +88,7 @@ public class IlmHealthIndicatorService implements HealthIndicatorService {
             return createIndicator(
                 YELLOW,
                 "Index Lifecycle Management is not running",
-                createDetails(explain, ilmMetadata),
+                createDetails(verbose, ilmMetadata),
                 impacts,
                 List.of(ILM_NOT_RUNNING)
             );
@@ -96,15 +96,15 @@ public class IlmHealthIndicatorService implements HealthIndicatorService {
             return createIndicator(
                 GREEN,
                 "Index Lifecycle Management is running",
-                createDetails(explain, ilmMetadata),
+                createDetails(verbose, ilmMetadata),
                 Collections.emptyList(),
                 Collections.emptyList()
             );
         }
     }
 
-    private static HealthIndicatorDetails createDetails(boolean explain, IndexLifecycleMetadata metadata) {
-        if (explain) {
+    private static HealthIndicatorDetails createDetails(boolean verbose, IndexLifecycleMetadata metadata) {
+        if (verbose) {
             return new SimpleHealthIndicatorDetails(
                 Map.of("ilm_status", metadata.getOperationMode(), "policies", metadata.getPolicies().size())
             );

--- a/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/slm/SlmHealthIndicatorService.java
+++ b/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/slm/SlmHealthIndicatorService.java
@@ -97,13 +97,13 @@ public class SlmHealthIndicatorService implements HealthIndicatorService {
     }
 
     @Override
-    public HealthIndicatorResult calculate(boolean explain, HealthInfo healthInfo) {
+    public HealthIndicatorResult calculate(boolean verbose, HealthInfo healthInfo) {
         var slmMetadata = clusterService.state().metadata().custom(SnapshotLifecycleMetadata.TYPE, SnapshotLifecycleMetadata.EMPTY);
         if (slmMetadata.getSnapshotConfigurations().isEmpty()) {
             return createIndicator(
                 GREEN,
                 "No Snapshot Lifecycle Management policies configured",
-                createDetails(explain, Collections.emptyList(), slmMetadata),
+                createDetails(verbose, Collections.emptyList(), slmMetadata),
                 Collections.emptyList(),
                 Collections.emptyList()
             );
@@ -120,7 +120,7 @@ public class SlmHealthIndicatorService implements HealthIndicatorService {
             return createIndicator(
                 YELLOW,
                 "Snapshot Lifecycle Management is not running",
-                createDetails(explain, Collections.emptyList(), slmMetadata),
+                createDetails(verbose, Collections.emptyList(), slmMetadata),
                 impacts,
                 List.of(SLM_NOT_RUNNING)
             );
@@ -169,7 +169,7 @@ public class SlmHealthIndicatorService implements HealthIndicatorService {
                 return createIndicator(
                     YELLOW,
                     "Encountered [" + unhealthyPolicies.size() + "] unhealthy snapshot lifecycle management policies.",
-                    createDetails(explain, unhealthyPolicies, slmMetadata),
+                    createDetails(verbose, unhealthyPolicies, slmMetadata),
                     impacts,
                     List.of(
                         new Diagnosis(
@@ -188,7 +188,7 @@ public class SlmHealthIndicatorService implements HealthIndicatorService {
             return createIndicator(
                 GREEN,
                 "Snapshot Lifecycle Management is running",
-                createDetails(explain, Collections.emptyList(), slmMetadata),
+                createDetails(verbose, Collections.emptyList(), slmMetadata),
                 Collections.emptyList(),
                 Collections.emptyList()
             );
@@ -213,11 +213,11 @@ public class SlmHealthIndicatorService implements HealthIndicatorService {
     }
 
     private static HealthIndicatorDetails createDetails(
-        boolean explain,
+        boolean verbose,
         Collection<SnapshotLifecyclePolicyMetadata> unhealthyPolicies,
         SnapshotLifecycleMetadata metadata
     ) {
-        if (explain) {
+        if (verbose) {
             Map<String, Object> details = new LinkedHashMap<>();
             details.put("slm_status", metadata.getOperationMode());
             details.put("policies", metadata.getSnapshotConfigurations().size());


### PR DESCRIPTION
This renames the `explain` Health API parameter to `verbose`.

We decided to rename `explain` because `verbose` is a more established 
term in the industry for "opt-in to get more information" and allows for more 
flexibility to control what exactly that extra information is (`explain` is already 
pushing the limits of what it semantically represents as it's controlling both 
the `diagnosis` insights and the raw `details` information)

Note that the Health API is `_internal` and `experimental` so this is not a 
breaking change.