### PR TITLE
Fix `GetUserPrivilegesResponse` in `CustomAuthorizationEngine` 

### DIFF
--- a/plugins/examples/security-authorization-engine/src/main/java/org/elasticsearch/example/CustomAuthorizationEngine.java
+++ b/plugins/examples/security-authorization-engine/src/main/java/org/elasticsearch/example/CustomAuthorizationEngine.java
@@ -201,7 +201,7 @@ public class CustomAuthorizationEngine implements AuthorizationEngine {
                 RoleDescriptor.ApplicationResourcePrivileges.builder().application("*").privileges("*").resources("*").build()) :
             Collections.emptySet();
         final Set<String> runAs = isSuperuser ? Collections.singleton("*") : Collections.emptySet();
-        return new GetUserPrivilegesResponse(cluster, conditionalCluster, indices, application, runAs);
+        return new GetUserPrivilegesResponse(cluster, conditionalCluster, indices, application, runAs, Set.of());
     }
 
     public static class CustomAuthorizationInfo implements AuthorizationInfo {


### PR DESCRIPTION
This PR brings the constructor call for `GetUserPrivilegesResponse` up-to-date with `main`, to fix plugin compilation.

Passing an empty set for `remoteIndices` since the relevant functionality for remote privilege still sits behind a feature flag. Will update the code accordingly with real remote indices permissions in the future (will track in a Jira issue).

Fixes: https://github.com/elastic/elasticsearch/issues/91415