### PR TITLE
Correct docs for multi_match scoring

### DIFF
--- a/docs/reference/query-dsl/multi-match-query.asciidoc
+++ b/docs/reference/query-dsl/multi-match-query.asciidoc
@@ -244,8 +244,7 @@ GET /_search
 }
 --------------------------------------------------
 
-The score from each `match` clause is added together, then divided by the
-number of `match` clauses.
+The score from each `match` clause is added together, just like a `bool` query.
 
 Also, accepts `analyzer`, `boost`, `operator`, `minimum_should_match`,
 `fuzziness`, `lenient`, `prefix_length`, `max_expansions`, `fuzzy_rewrite`, and `zero_terms_query`.


### PR DESCRIPTION
The documentation claimed that for the most_fields type, the score is equal to
the sum of all matches divided by the number of matches. This is not correct,
we actually don't divide by the number of matches.

This line in the documentation was added several years ago as part of a large
PR, and was likely a mistake.
