### PR TITLE
Handle APM global labels as affix setting

### DIFF
--- a/distribution/tools/server-cli/src/test/java/org/elasticsearch/server/cli/APMJvmOptionsTests.java
+++ b/distribution/tools/server-cli/src/test/java/org/elasticsearch/server/cli/APMJvmOptionsTests.java
@@ -19,8 +19,10 @@ import org.junit.Before;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Arrays;
 
 import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.hasEntry;
 import static org.hamcrest.Matchers.hasKey;
@@ -89,9 +91,12 @@ public class APMJvmOptionsTests extends ESTestCase {
                 not(hasKey("global_labels.organization_id")) // tests that we strip out the top level label keys
             )
         );
+
+        String[] labels = extracted.get("global_labels").split(",");
+
         assertThat(
-            extracted.get("global_labels"),
-            allOf(containsString("deployment_name=APM Tracing"), containsString("organization_id=456"), containsString("deployment_id=123"))
+            Arrays.stream(labels).toList(),
+            containsInAnyOrder("deployment_name=APM Tracing", "organization_id=456", "deployment_id=123")
         );
 
         settings = Settings.builder()

--- a/distribution/tools/server-cli/src/test/java/org/elasticsearch/server/cli/APMJvmOptionsTests.java
+++ b/distribution/tools/server-cli/src/test/java/org/elasticsearch/server/cli/APMJvmOptionsTests.java
@@ -92,10 +92,11 @@ public class APMJvmOptionsTests extends ESTestCase {
             )
         );
 
-        String[] labels = extracted.get("global_labels").split(",");
+        List<String> labels = Arrays.stream(extracted.get("global_labels").split(",")).toList();
 
+        assertThat(labels, hasSize(3));
         assertThat(
-            Arrays.stream(labels).toList(),
+            labels,
             containsInAnyOrder("deployment_name=APM Tracing", "organization_id=456", "deployment_id=123")
         );
 

--- a/docs/changelog/91438.yaml
+++ b/docs/changelog/91438.yaml
@@ -1,0 +1,6 @@
+pr: 91438
+summary: Handle APM global labels as affix setting
+area: Infra/Core
+type: enhancement
+issues:
+ - 91278


### PR DESCRIPTION
Make it easier for operator and automation to supply APM global labels by using an affix setting. Instead of expecting the operator to supply a comma concatenated list of key=value pairs, we let them specify it now as individual settings which are then collapsed by Elasticsearch in the correct format for the agent.

Closes https://github.com/elastic/elasticsearch/issues/91278