### PR TITLE
Improving logging to troubleshoot pipeline metrics problem

### DIFF
--- a/server/src/main/java/org/elasticsearch/ingest/CompoundProcessor.java
+++ b/server/src/main/java/org/elasticsearch/ingest/CompoundProcessor.java
@@ -210,7 +210,7 @@ public class CompoundProcessor implements Processor {
         try {
             finalProcessor.execute(ingestDocument, (result, e) -> {
                 if (listenerHasBeenCalled.getAndSet(true)) {
-                    logger.warn("A listener was unexpectedly called more than once", new RuntimeException());
+                    logger.warn("A listener was unexpectedly called more than once", new RuntimeException(e));
                     assert false : "A listener was unexpectedly called more than once";
                 } else {
                     long ingestTimeInNanos = relativeTimeProvider.getAsLong() - startTimeInNanos;
@@ -230,7 +230,7 @@ public class CompoundProcessor implements Processor {
         } catch (Exception e) {
             long ingestTimeInNanos = relativeTimeProvider.getAsLong() - startTimeInNanos;
             if (postIngestHasBeenCalled.get()) {
-                logger.warn("Preventing postIngest from being called more than once", new RuntimeException());
+                logger.warn("Preventing postIngest from being called more than once", e);
                 assert false : "Attempt to call postIngest more than once";
             } else {
                 finalMetric.postIngest(ingestTimeInNanos);

--- a/server/src/main/java/org/elasticsearch/ingest/ConditionalProcessor.java
+++ b/server/src/main/java/org/elasticsearch/ingest/ConditionalProcessor.java
@@ -135,7 +135,7 @@ public class ConditionalProcessor extends AbstractProcessor implements WrappingP
             metric.preIngest();
             processor.execute(ingestDocument, (result, e) -> {
                 if (listenerHasBeenCalled.getAndSet(true)) {
-                    logger.warn("A listener was unexpectedly called more than once", new RuntimeException());
+                    logger.warn("A listener was unexpectedly called more than once", new RuntimeException(e));
                     assert false : "A listener was unexpectedly called more than once";
                 } else {
                     long ingestTimeInNanos = relativeTimeProvider.getAsLong() - startTimeInNanos;

--- a/server/src/main/java/org/elasticsearch/ingest/IngestService.java
+++ b/server/src/main/java/org/elasticsearch/ingest/IngestService.java
@@ -913,7 +913,7 @@ public class IngestService implements ClusterStateApplier, ReportingService<Inge
         final AtomicBoolean listenerHasBeenCalled = new AtomicBoolean(false);
         ingestDocument.executePipeline(pipeline, (result, e) -> {
             if (listenerHasBeenCalled.getAndSet(true)) {
-                logger.warn("A listener was unexpectedly called more than once", new RuntimeException());
+                logger.warn("A listener was unexpectedly called more than once", new RuntimeException(e));
                 assert false : "A listener was unexpectedly called more than once";
             } else {
                 long ingestTimeInNanos = System.nanoTime() - startTimeInNanos;

--- a/server/src/main/java/org/elasticsearch/ingest/Pipeline.java
+++ b/server/src/main/java/org/elasticsearch/ingest/Pipeline.java
@@ -123,7 +123,7 @@ public final class Pipeline {
         metrics.preIngest();
         compoundProcessor.execute(ingestDocument, (result, e) -> {
             if (listenerHasBeenCalled.getAndSet(true)) {
-                logger.warn("A listener was unexpectedly called more than once", new RuntimeException());
+                logger.warn("A listener was unexpectedly called more than once", new RuntimeException(e));
                 assert false : "A listener was unexpectedly called more than once";
             } else {
                 long ingestTimeInNanos = relativeTimeProvider.getAsLong() - startTimeInNanos;


### PR DESCRIPTION
We think that we have tracked down the problem of negative metrics (#90319) to be an exception happening in a pipeline. Unfortunately we're not currently getting any information about that exception in order to prevent it. This PR logs the exception when it detects the problem of a listener being called more than once (which is the source of the metrics problem). If the exception can be null, it logs it as a `new RuntimeException(e)` so that we still get information about the stack regardless.