### PR TITLE
Tidy ContinuousComputation rejection handling

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/allocator/DesiredBalanceShardsAllocator.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/allocator/DesiredBalanceShardsAllocator.java
@@ -97,7 +97,7 @@ public class DesiredBalanceShardsAllocator implements ShardsAllocator {
         this.clusterService = clusterService;
         this.reconciler = reconciler;
         this.desiredBalanceComputer = desiredBalanceComputer;
-        this.desiredBalanceComputation = new ContinuousComputation<>(threadPool.generic()) {
+        this.desiredBalanceComputation = new ContinuousComputation<>(threadPool) {
 
             @Override
             protected void processInput(DesiredBalanceInput desiredBalanceInput) {

--- a/server/src/test/java/org/elasticsearch/cluster/routing/allocation/allocator/ContinuousComputationTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/allocation/allocator/ContinuousComputationTests.java
@@ -46,7 +46,7 @@ public class ContinuousComputationTests extends ESTestCase {
     public void testConcurrency() throws Exception {
 
         final var result = new AtomicReference<Integer>();
-        final var computation = new ContinuousComputation<Integer>(threadPool.generic()) {
+        final var computation = new ContinuousComputation<Integer>(threadPool) {
 
             public final Semaphore executePermit = new Semaphore(1);
 
@@ -104,7 +104,7 @@ public class ContinuousComputationTests extends ESTestCase {
         final var finalInput = new Object();
 
         final var result = new AtomicReference<Object>();
-        final var computation = new ContinuousComputation<Object>(threadPool.generic()) {
+        final var computation = new ContinuousComputation<Object>(threadPool) {
             @Override
             protected void processInput(Object input) {
                 assertNotEquals(input, skippedInput);


### PR DESCRIPTION
Today we implicitly assume the executor used by the `ContinuousComputation` has an unbounded queue. This commit makes that explicit.

Relates #91386