### PR TITLE
Ensure desired balance computations run in order

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/allocator/DesiredBalanceShardsAllocator.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/allocator/DesiredBalanceShardsAllocator.java
@@ -99,8 +99,13 @@ public class DesiredBalanceShardsAllocator implements ShardsAllocator {
         this.desiredBalanceComputer = desiredBalanceComputer;
         this.desiredBalanceComputation = new ContinuousComputation<>(threadPool.generic()) {
 
+            private long lastProcessedIndex = -1;
+
             @Override
             protected void processInput(DesiredBalanceInput desiredBalanceInput) {
+
+                assert lastProcessedIndex < desiredBalanceInput.index() : lastProcessedIndex + " vs " + desiredBalanceInput.index();
+                lastProcessedIndex = desiredBalanceInput.index();
 
                 long index = desiredBalanceInput.index();
                 logger.debug("Starting desired balance computation for [{}]", index);


### PR DESCRIPTION
Today we implicitly assume that desired balance computations run in increasing `index()` order. This commit makes that assumption explicit.

Relates #91386