### PR TITLE
Fix EqlSearchResponseTests

### DIFF
--- a/x-pack/plugin/eql/src/test/java/org/elasticsearch/xpack/eql/action/EqlSearchResponseTests.java
+++ b/x-pack/plugin/eql/src/test/java/org/elasticsearch/xpack/eql/action/EqlSearchResponseTests.java
@@ -139,9 +139,9 @@ public class EqlSearchResponseTests extends AbstractBWCWireSerializingTestCase<E
                     () -> Map.of(
                         randomAlphaOfLength(5),
                         randomInt(),
-                        randomAlphaOfLength(5),
+                        randomAlphaOfLength(6),
                         randomBoolean(),
-                        randomAlphaOfLength(5),
+                        randomAlphaOfLength(7),
                         randomAlphaOfLength(10)
                     )
                 );


### PR DESCRIPTION
Randomized map entry keys could lead to duplicate keys

Fixes: #91245