### PR TITLE
Replace SourceLookup invocations with Source

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/mapper/NestedValueFetcher.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/NestedValueFetcher.java
@@ -13,7 +13,6 @@ import org.elasticsearch.common.document.DocumentField;
 import org.elasticsearch.common.xcontent.support.XContentMapValues;
 import org.elasticsearch.search.fetch.subphase.FieldFetcher;
 import org.elasticsearch.search.lookup.Source;
-import org.elasticsearch.search.lookup.SourceLookup;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -51,9 +50,10 @@ public class NestedValueFetcher implements ValueFetcher {
         for (Object entry : nestedValues) {
             // add this one entry only to the stub and use this as source lookup
             stub.put(nestedFieldName, entry);
-            SourceLookup nestedSourceLookup = new SourceLookup(new SourceLookup.MapSourceProvider(filteredSource));
-
-            Map<String, DocumentField> fetchResult = nestedFieldFetcher.fetch(nestedSourceLookup, doc);
+            Map<String, DocumentField> fetchResult = nestedFieldFetcher.fetch(
+                Source.fromMap(filteredSource, source.sourceContentType()),
+                doc
+            );
 
             Map<String, Object> nestedEntry = new HashMap<>();
             for (DocumentField field : fetchResult.values()) {

--- a/server/src/main/java/org/elasticsearch/index/termvectors/TermVectorsService.java
+++ b/server/src/main/java/org/elasticsearch/index/termvectors/TermVectorsService.java
@@ -40,7 +40,8 @@ import org.elasticsearch.index.mapper.SourceValueFetcher;
 import org.elasticsearch.index.mapper.StringFieldType;
 import org.elasticsearch.index.mapper.TextSearchInfo;
 import org.elasticsearch.index.shard.IndexShard;
-import org.elasticsearch.search.lookup.SourceLookup;
+import org.elasticsearch.search.lookup.Source;
+import org.elasticsearch.xcontent.XContentType;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -272,12 +273,12 @@ public class TermVectorsService {
         }
         if (source != null) {
             MappingLookup mappingLookup = indexShard.mapperService().mappingLookup();
-            SourceLookup sourceLookup = new SourceLookup(new SourceLookup.MapSourceProvider(source));
+            Source s = Source.fromMap(source, XContentType.JSON);
             for (String field : fields) {
                 if (values.containsKey(field) == false) {
                     SourceValueFetcher valueFetcher = SourceValueFetcher.toString(mappingLookup.sourcePaths(field));
                     List<Object> ignoredValues = new ArrayList<>();
-                    List<Object> v = valueFetcher.fetchValues(sourceLookup, -1, ignoredValues);
+                    List<Object> v = valueFetcher.fetchValues(s, -1, ignoredValues);
                     if (v.isEmpty() == false) {
                         values.put(field, v);
                     }

--- a/server/src/main/java/org/elasticsearch/search/lookup/SourceLookup.java
+++ b/server/src/main/java/org/elasticsearch/search/lookup/SourceLookup.java
@@ -234,7 +234,7 @@ public class SourceLookup implements Source, Map<String, Object> {
     /**
      * Provider for source using a given map and optional content type.
      */
-    public static class MapSourceProvider implements SourceProvider {
+    private static class MapSourceProvider implements SourceProvider {
         private Map<String, Object> source;
         private XContentType sourceContentType;
 

--- a/server/src/main/java/org/elasticsearch/search/lookup/SourceLookup.java
+++ b/server/src/main/java/org/elasticsearch/search/lookup/SourceLookup.java
@@ -235,16 +235,12 @@ public class SourceLookup implements Source, Map<String, Object> {
      * Provider for source using a given map and optional content type.
      */
     private static class MapSourceProvider implements SourceProvider {
-        private Map<String, Object> source;
-        private XContentType sourceContentType;
+        private final Map<String, Object> source;
+        private final XContentType sourceContentType;
 
-        public MapSourceProvider(Map<String, Object> source) {
+        private MapSourceProvider(Map<String, Object> source) {
             this.source = source;
-        }
-
-        public MapSourceProvider(Map<String, Object> source, @Nullable XContentType sourceContentType) {
-            this.source = source;
-            this.sourceContentType = sourceContentType;
+            this.sourceContentType = XContentType.JSON;
         }
 
         @Override

--- a/server/src/main/java/org/elasticsearch/search/lookup/SourceLookup.java
+++ b/server/src/main/java/org/elasticsearch/search/lookup/SourceLookup.java
@@ -17,7 +17,6 @@ import org.elasticsearch.common.lucene.index.SequentialStoredFieldsLeafReader;
 import org.elasticsearch.common.xcontent.XContentHelper;
 import org.elasticsearch.common.xcontent.support.XContentMapValues;
 import org.elasticsearch.core.MemoizedSupplier;
-import org.elasticsearch.core.Nullable;
 import org.elasticsearch.core.Tuple;
 import org.elasticsearch.index.fieldvisitor.FieldsVisitor;
 import org.elasticsearch.xcontent.XContentType;

--- a/server/src/test/java/org/elasticsearch/index/mapper/LookupRuntimeFieldTypeTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/LookupRuntimeFieldTypeTests.java
@@ -15,12 +15,14 @@ import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.index.query.TermQueryBuilder;
 import org.elasticsearch.search.fetch.subphase.FieldAndFormat;
 import org.elasticsearch.search.fetch.subphase.LookupField;
-import org.elasticsearch.search.lookup.SourceLookup;
+import org.elasticsearch.search.lookup.Source;
 import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xcontent.XContentFactory;
+import org.elasticsearch.xcontent.XContentType;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.Map;
 
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsString;
@@ -54,11 +56,10 @@ public class LookupRuntimeFieldTypeTests extends MapperServiceTestCase {
             }
             """;
         var mapperService = createMapperService(mapping);
-        XContentBuilder source = XContentFactory.jsonBuilder().startObject().field("foo", List.of("f1", "f2")).endObject();
-        SourceLookup sourceLookup = new SourceLookup(new SourceLookup.BytesSourceProvider(BytesReference.bytes(source)));
+        Source source = Source.fromMap(Map.of("foo", List.of("f1", "f2")), randomFrom(XContentType.values()));
         MappedFieldType fieldType = mapperService.fieldType("foo_lookup_field");
         ValueFetcher valueFetcher = fieldType.valueFetcher(createSearchExecutionContext(mapperService), null);
-        DocumentField doc = valueFetcher.fetchDocumentField("foo_lookup_field", sourceLookup, -1);
+        DocumentField doc = valueFetcher.fetchDocumentField("foo_lookup_field", source, -1);
         assertNotNull(doc);
         assertThat(doc.getName(), equalTo("foo_lookup_field"));
         assertThat(doc.getValues(), empty());
@@ -110,10 +111,10 @@ public class LookupRuntimeFieldTypeTests extends MapperServiceTestCase {
             source.field("foo", List.of());
         }
         source.endObject();
-        SourceLookup sourceLookup = new SourceLookup(new SourceLookup.BytesSourceProvider(BytesReference.bytes(source)));
+        Source s = Source.fromBytes(BytesReference.bytes(source), XContentType.JSON);
         MappedFieldType fieldType = mapperService.fieldType("foo_lookup_field");
         ValueFetcher valueFetcher = fieldType.valueFetcher(createSearchExecutionContext(mapperService), null);
-        DocumentField doc = valueFetcher.fetchDocumentField("foo_lookup_field", sourceLookup, -1);
+        DocumentField doc = valueFetcher.fetchDocumentField("foo_lookup_field", s, -1);
         assertNull(doc);
     }
 

--- a/test/framework/src/main/java/org/elasticsearch/index/mapper/FieldTypeTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/index/mapper/FieldTypeTestCase.java
@@ -10,8 +10,10 @@ package org.elasticsearch.index.mapper;
 import org.elasticsearch.Version;
 import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.search.lookup.SearchLookup;
+import org.elasticsearch.search.lookup.Source;
 import org.elasticsearch.search.lookup.SourceLookup;
 import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xcontent.XContentType;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -55,8 +57,8 @@ public abstract class FieldTypeTestCase extends ESTestCase {
         when(searchExecutionContext.sourcePath(field)).thenReturn(Set.of(field));
 
         ValueFetcher fetcher = fieldType.valueFetcher(searchExecutionContext, format);
-        SourceLookup lookup = new SourceLookup(new SourceLookup.MapSourceProvider(Collections.singletonMap(field, sourceValue)));
-        return fetcher.fetchValues(lookup, -1, new ArrayList<>());
+        Source source = Source.fromMap(Collections.singletonMap(field, sourceValue), randomFrom(XContentType.values()));
+        return fetcher.fetchValues(source, -1, new ArrayList<>());
     }
 
     public static List<?> fetchSourceValues(MappedFieldType fieldType, Object... values) throws IOException {
@@ -66,7 +68,7 @@ public abstract class FieldTypeTestCase extends ESTestCase {
         when(searchExecutionContext.sourcePath(field)).thenReturn(Set.of(field));
 
         ValueFetcher fetcher = fieldType.valueFetcher(searchExecutionContext, null);
-        SourceLookup lookup = new SourceLookup(new SourceLookup.MapSourceProvider(Collections.singletonMap(field, List.of(values))));
-        return fetcher.fetchValues(lookup, -1, new ArrayList<>());
+        Source source = Source.fromMap(Collections.singletonMap(field, List.of(values)), randomFrom(XContentType.values()));
+        return fetcher.fetchValues(source, -1, new ArrayList<>());
     }
 }

--- a/x-pack/plugin/mapper-constant-keyword/src/test/java/org/elasticsearch/xpack/constantkeyword/mapper/ConstantKeywordFieldTypeTests.java
+++ b/x-pack/plugin/mapper-constant-keyword/src/test/java/org/elasticsearch/xpack/constantkeyword/mapper/ConstantKeywordFieldTypeTests.java
@@ -14,13 +14,15 @@ import org.elasticsearch.common.unit.Fuzziness;
 import org.elasticsearch.index.mapper.FieldTypeTestCase;
 import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.mapper.ValueFetcher;
-import org.elasticsearch.search.lookup.SourceLookup;
+import org.elasticsearch.search.lookup.Source;
+import org.elasticsearch.xcontent.XContentType;
 import org.elasticsearch.xpack.constantkeyword.mapper.ConstantKeywordFieldMapper.ConstantKeywordFieldType;
 
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 
 public class ConstantKeywordFieldTypeTests extends FieldTypeTestCase {
 
@@ -111,17 +113,17 @@ public class ConstantKeywordFieldTypeTests extends FieldTypeTestCase {
         MappedFieldType fieldType = new ConstantKeywordFieldMapper.ConstantKeywordFieldType("field", null);
         ValueFetcher fetcher = fieldType.valueFetcher(null, null);
 
-        SourceLookup missingValueLookup = new SourceLookup(new SourceLookup.ReaderSourceProvider());
-        SourceLookup nullValueLookup = new SourceLookup(new SourceLookup.MapSourceProvider(Collections.singletonMap("field", null)));
+        Source sourceWithNoFieldValue = Source.fromMap(Map.of("unrelated", "random"), randomFrom(XContentType.values()));
+        Source sourceWithNullFieldValue = Source.fromMap(Collections.singletonMap("field", null), randomFrom(XContentType.values()));
 
         List<Object> ignoredValues = new ArrayList<>();
-        assertTrue(fetcher.fetchValues(missingValueLookup, -1, ignoredValues).isEmpty());
-        assertTrue(fetcher.fetchValues(nullValueLookup, -1, ignoredValues).isEmpty());
+        assertTrue(fetcher.fetchValues(sourceWithNoFieldValue, -1, ignoredValues).isEmpty());
+        assertTrue(fetcher.fetchValues(sourceWithNullFieldValue, -1, ignoredValues).isEmpty());
 
         MappedFieldType valued = new ConstantKeywordFieldMapper.ConstantKeywordFieldType("field", "foo");
         fetcher = valued.valueFetcher(null, null);
 
-        assertEquals(List.of("foo"), fetcher.fetchValues(missingValueLookup, -1, ignoredValues));
-        assertEquals(List.of("foo"), fetcher.fetchValues(nullValueLookup, -1, ignoredValues));
+        assertEquals(List.of("foo"), fetcher.fetchValues(sourceWithNoFieldValue, -1, ignoredValues));
+        assertEquals(List.of("foo"), fetcher.fetchValues(sourceWithNullFieldValue, -1, ignoredValues));
     }
 }


### PR DESCRIPTION
Removes a few more uses of SourceLookup in favour of plain 
Source.  This also allows us to make the MapSourceProvider
implementation within SourceLookup private.