### PR TITLE
Fix performance regressions in Strings utility

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/Strings.java
+++ b/server/src/main/java/org/elasticsearch/common/Strings.java
@@ -137,7 +137,13 @@ public class Strings {
         if (hasLength(str) == false) {
             return false;
         }
-        return str.chars().anyMatch(c -> Character.isWhitespace(c) == false);
+        int strLen = str.length();
+        for (int i = 0; i < strLen; i++) {
+            if (Character.isWhitespace(str.charAt(i)) == false) {
+                return true;
+            }
+        }
+        return false;
     }
 
     /**
@@ -151,7 +157,7 @@ public class Strings {
      * @see #hasText(CharSequence)
      */
     public static boolean hasText(String str) {
-        return hasText((CharSequence) str);
+        return isNullOrBlank(str) == false;
     }
 
     /**
@@ -286,11 +292,22 @@ public class Strings {
         .collect(Collectors.joining(",", "[", "]"));
 
     public static boolean validFileName(String fileName) {
-        return fileName.chars().noneMatch(c -> isInvalidFileNameCharacter((char) c));
+        for (int i = 0; i < fileName.length(); i++) {
+            if (isInvalidFileNameCharacter(fileName.charAt(i))) {
+                return false;
+            }
+        }
+        return true;
     }
 
     public static boolean validFileNameExcludingAstrix(String fileName) {
-        return fileName.chars().noneMatch(c -> c != '*' && isInvalidFileNameCharacter((char) c));
+        for (int i = 0; i < fileName.length(); i++) {
+            char c = fileName.charAt(i);
+            if (c != '*' && isInvalidFileNameCharacter(c)) {
+                return false;
+            }
+        }
+        return true;
     }
 
     private static boolean isInvalidFileNameCharacter(char c) {


### PR DESCRIPTION
Some of the changes in
https://github.com/elastic/elasticsearch/pull/90672 introduced considerable performance hits for many shards benchmarks because the changed methods are used in hot loops here and there. This reverts some of the changes to the previous code and delegates to the fast `isNullOrBlank` to fix `hasText` performance for strings.

E.g. `hasText` which hardly registered in profiling before the above PR went to 2%+ of total CPU usage during snapshotting:
<img width="596" alt="image" src="https://user-images.githubusercontent.com/6490959/200846141-af2ed913-c646-4283-8799-df4df7bcbcfa.png">

