### PR TITLE
Remove `AggregationContext` from `ValuesSourceType.getField()`

### DIFF
--- a/modules/aggregations/src/main/java/org/elasticsearch/aggregations/bucket/histogram/AutoDateHistogramAggregator.java
+++ b/modules/aggregations/src/main/java/org/elasticsearch/aggregations/bucket/histogram/AutoDateHistogramAggregator.java
@@ -99,7 +99,7 @@ abstract class AutoDateHistogramAggregator extends DeferableBucketAggregator {
         this.valuesSource = valuesSourceConfig.hasValues() ? (ValuesSource.Numeric) valuesSourceConfig.getValuesSource() : null;
         this.formatter = valuesSourceConfig.format();
         this.roundingInfos = roundingInfos;
-        this.roundingPreparer = valuesSourceConfig.roundingPreparer();
+        this.roundingPreparer = valuesSourceConfig.roundingPreparer(context);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/DateHistogramAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/DateHistogramAggregator.java
@@ -87,7 +87,7 @@ class DateHistogramAggregator extends BucketsAggregator implements SizedBucketAg
         CardinalityUpperBound cardinality,
         Map<String, Object> metadata
     ) throws IOException {
-        Rounding.Prepared preparedRounding = valuesSourceConfig.roundingPreparer().apply(rounding);
+        Rounding.Prepared preparedRounding = valuesSourceConfig.roundingPreparer(context).apply(rounding);
         Aggregator asRange = adaptIntoRangeOrNull(
             name,
             factories,

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/DateRangeHistogramAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/DateRangeHistogramAggregator.java
@@ -82,7 +82,7 @@ class DateRangeHistogramAggregator extends BucketsAggregator {
 
         super(name, factories, context, parent, CardinalityUpperBound.MANY, metadata);
         this.rounding = rounding;
-        this.preparedRounding = valuesSourceConfig.roundingPreparer().apply(rounding);
+        this.preparedRounding = valuesSourceConfig.roundingPreparer(context).apply(rounding);
         this.order = order;
         order.validate(this);
         this.keyed = keyed;

--- a/server/src/main/java/org/elasticsearch/search/aggregations/support/CoreValuesSourceType.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/support/CoreValuesSourceType.java
@@ -11,7 +11,6 @@ package org.elasticsearch.search.aggregations.support;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.lucene.index.DocValues;
-import org.apache.lucene.index.IndexReader;
 import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.index.PointValues;
 import org.apache.lucene.search.BooleanClause;
@@ -59,7 +58,7 @@ public enum CoreValuesSourceType implements ValuesSourceType {
         }
 
         @Override
-        public ValuesSource getField(FieldContext fieldContext, AggregationScript.LeafFactory script, AggregationContext context) {
+        public ValuesSource getField(FieldContext fieldContext, AggregationScript.LeafFactory script) {
 
             if ((fieldContext.indexFieldData() instanceof IndexNumericFieldData) == false) {
                 throw new IllegalArgumentException(
@@ -119,7 +118,7 @@ public enum CoreValuesSourceType implements ValuesSourceType {
         }
 
         @Override
-        public ValuesSource getField(FieldContext fieldContext, AggregationScript.LeafFactory script, AggregationContext context) {
+        public ValuesSource getField(FieldContext fieldContext, AggregationScript.LeafFactory script) {
             final IndexFieldData<?> indexFieldData = fieldContext.indexFieldData();
             ValuesSource dataSource;
             if (indexFieldData instanceof IndexOrdinalsFieldData) {
@@ -161,7 +160,7 @@ public enum CoreValuesSourceType implements ValuesSourceType {
         }
 
         @Override
-        public ValuesSource getField(FieldContext fieldContext, AggregationScript.LeafFactory script, AggregationContext context) {
+        public ValuesSource getField(FieldContext fieldContext, AggregationScript.LeafFactory script) {
             if (fieldContext.indexFieldData()instanceof IndexGeoPointFieldData pointFieldData) {
                 return new ValuesSource.GeoPoint.Fielddata(pointFieldData);
             }
@@ -199,7 +198,7 @@ public enum CoreValuesSourceType implements ValuesSourceType {
         }
 
         @Override
-        public ValuesSource getField(FieldContext fieldContext, AggregationScript.LeafFactory script, AggregationContext context) {
+        public ValuesSource getField(FieldContext fieldContext, AggregationScript.LeafFactory script) {
             MappedFieldType fieldType = fieldContext.fieldType();
 
             if (fieldType instanceof RangeFieldMapper.RangeFieldType == false) {
@@ -231,8 +230,8 @@ public enum CoreValuesSourceType implements ValuesSourceType {
         }
 
         @Override
-        public ValuesSource getField(FieldContext fieldContext, AggregationScript.LeafFactory script, AggregationContext context) {
-            return KEYWORD.getField(fieldContext, script, context);
+        public ValuesSource getField(FieldContext fieldContext, AggregationScript.LeafFactory script) {
+            return KEYWORD.getField(fieldContext, script);
         }
 
         @Override
@@ -262,8 +261,8 @@ public enum CoreValuesSourceType implements ValuesSourceType {
         }
 
         @Override
-        public ValuesSource getField(FieldContext fieldContext, AggregationScript.LeafFactory script, AggregationContext context) {
-            ValuesSource.Numeric dataSource = fieldData(fieldContext, context);
+        public ValuesSource getField(FieldContext fieldContext, AggregationScript.LeafFactory script) {
+            ValuesSource.Numeric dataSource = fieldData(fieldContext);
             if (script != null) {
                 // Value script case
                 return new ValuesSource.Numeric.WithScript(dataSource, script);
@@ -271,7 +270,7 @@ public enum CoreValuesSourceType implements ValuesSourceType {
             return dataSource;
         }
 
-        private ValuesSource.Numeric fieldData(FieldContext fieldContext, AggregationContext context) {
+        private ValuesSource.Numeric fieldData(FieldContext fieldContext) {
             if ((fieldContext.indexFieldData() instanceof IndexNumericFieldData) == false) {
                 throw new IllegalArgumentException(
                     "Expected numeric type on field [" + fieldContext.field() + "], but got [" + fieldContext.fieldType().typeName() + "]"
@@ -284,13 +283,13 @@ public enum CoreValuesSourceType implements ValuesSourceType {
             return new ValuesSource.Numeric.FieldData((IndexNumericFieldData) fieldContext.indexFieldData()) {
                 /**
                  * Proper dates get a real implementation of
-                 * {@link #roundingPreparer(IndexReader)}. If the field is
+                 * {@link #roundingPreparer(AggregationContext)}. If the field is
                  * configured with a script or a missing value then we'll
                  * wrap this without delegating so those fields will ignore
                  * this implementation. Which is correct.
                  */
                 @Override
-                public Function<Rounding, Rounding.Prepared> roundingPreparer() throws IOException {
+                public Function<Rounding, Rounding.Prepared> roundingPreparer(AggregationContext context) throws IOException {
                     DateFieldType dft = (DateFieldType) fieldContext.fieldType();
                     /*
                      * The range of dates, min first, then max. This is an array so we can
@@ -414,8 +413,8 @@ public enum CoreValuesSourceType implements ValuesSourceType {
         }
 
         @Override
-        public ValuesSource getField(FieldContext fieldContext, AggregationScript.LeafFactory script, AggregationContext context) {
-            return NUMERIC.getField(fieldContext, script, context);
+        public ValuesSource getField(FieldContext fieldContext, AggregationScript.LeafFactory script) {
+            return NUMERIC.getField(fieldContext, script);
         }
 
         @Override

--- a/server/src/main/java/org/elasticsearch/search/aggregations/support/TimeSeriesValuesSourceType.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/support/TimeSeriesValuesSourceType.java
@@ -31,7 +31,7 @@ public enum TimeSeriesValuesSourceType implements ValuesSourceType {
         }
 
         @Override
-        public ValuesSource getField(FieldContext fieldContext, AggregationScript.LeafFactory script, AggregationContext context) {
+        public ValuesSource getField(FieldContext fieldContext, AggregationScript.LeafFactory script) {
             if (script != null) {
                 throw new IllegalArgumentException("Cannot use scripts for time-series counters");
             }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/support/ValuesSource.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/support/ValuesSource.java
@@ -89,7 +89,7 @@ public abstract class ValuesSource {
      * need to call it many times over the course of running the aggregation.
      * Other aggregations should feel free to call it once.
      */
-    protected abstract Function<Rounding, Rounding.Prepared> roundingPreparer() throws IOException;
+    protected abstract Function<Rounding, Rounding.Prepared> roundingPreparer(AggregationContext context) throws IOException;
 
     /**
      * Check if this values source supports using global and segment ordinals.
@@ -116,7 +116,7 @@ public abstract class ValuesSource {
         }
 
         @Override
-        public final Function<Rounding, Rounding.Prepared> roundingPreparer() throws IOException {
+        public final Function<Rounding, Rounding.Prepared> roundingPreparer(AggregationContext context) throws IOException {
             throw new AggregationExecutionException("can't round a [BYTES]");
         }
 
@@ -489,7 +489,7 @@ public abstract class ValuesSource {
         }
 
         @Override
-        public Function<Rounding, Prepared> roundingPreparer() throws IOException {
+        public Function<Rounding, Prepared> roundingPreparer(AggregationContext context) throws IOException {
             return Rounding::prepareForUnknown;
         }
 
@@ -687,7 +687,7 @@ public abstract class ValuesSource {
         }
 
         @Override
-        public Function<Rounding, Prepared> roundingPreparer() throws IOException {
+        public Function<Rounding, Prepared> roundingPreparer(AggregationContext context) throws IOException {
             // TODO lookup the min and max rounding when appropriate
             return Rounding::prepareForUnknown;
         }
@@ -724,7 +724,7 @@ public abstract class ValuesSource {
         }
 
         @Override
-        public final Function<Rounding, Rounding.Prepared> roundingPreparer() throws IOException {
+        public final Function<Rounding, Rounding.Prepared> roundingPreparer(AggregationContext context) throws IOException {
             throw new AggregationExecutionException("can't round a [GEO_POINT]");
         }
 

--- a/server/src/main/java/org/elasticsearch/search/aggregations/support/ValuesSourceConfig.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/support/ValuesSourceConfig.java
@@ -323,7 +323,7 @@ public class ValuesSourceConfig {
                 vs = valueSourceType().getScript(script(), scriptValueType());
             } else {
                 // Field or Value Script case
-                vs = valueSourceType().getField(fieldContext(), script(), context);
+                vs = valueSourceType().getField(fieldContext(), script());
             }
         }
 
@@ -403,8 +403,8 @@ public class ValuesSourceConfig {
      * This returns a {@linkplain Function} because auto date histogram will
      * need to call it many times over the course of running the aggregation.
      */
-    public Function<Rounding, Rounding.Prepared> roundingPreparer() throws IOException {
-        return valuesSource.roundingPreparer();
+    public Function<Rounding, Rounding.Prepared> roundingPreparer(AggregationContext context) throws IOException {
+        return valuesSource.roundingPreparer(context);
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/search/aggregations/support/ValuesSourceType.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/support/ValuesSourceType.java
@@ -55,11 +55,10 @@ public interface ValuesSourceType {
      * Return a {@link ValuesSource} wrapping a field for the given type.  All {@link ValuesSource}s must implement this method.
      *
      * @param fieldContext - The field being wrapped
-     * @param script - Optional script that might be applied over the field
-     * @param context context for the aggregation fetching the field
+     * @param script       - Optional script that might be applied over the field
      * @return - Field specialization of the base {@link ValuesSource}
      */
-    ValuesSource getField(FieldContext fieldContext, AggregationScript.LeafFactory script, AggregationContext context);
+    ValuesSource getField(FieldContext fieldContext, AggregationScript.LeafFactory script);
 
     /**
      * Apply the given missing value to an already-constructed {@link ValuesSource}.  Types which do not support missing values should throw

--- a/server/src/test/java/org/elasticsearch/search/aggregations/support/CoreValuesSourceTypeTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/support/CoreValuesSourceTypeTests.java
@@ -45,7 +45,7 @@ public class CoreValuesSourceTypeTests extends MapperServiceTestCase {
     public void testDatePrepareRoundingWithNothing() throws IOException {
         withAggregationContext(dateMapperService(), List.of(), context -> {
             Rounding rounding = mock(Rounding.class);
-            CoreValuesSourceType.DATE.getField(context.buildFieldContext("field"), null, context).roundingPreparer().apply(rounding);
+            CoreValuesSourceType.DATE.getField(context.buildFieldContext("field"), null).roundingPreparer(context).apply(rounding);
             verify(rounding).prepareForUnknown();
         });
     }
@@ -55,7 +55,7 @@ public class CoreValuesSourceTypeTests extends MapperServiceTestCase {
         long max = randomLongBetween(min + 1, 100000000000L);
         withAggregationContext(dateMapperService(), docsWithDatesBetween(min, max), context -> {
             Rounding rounding = mock(Rounding.class);
-            CoreValuesSourceType.DATE.getField(context.buildFieldContext("field"), null, context).roundingPreparer().apply(rounding);
+            CoreValuesSourceType.DATE.getField(context.buildFieldContext("field"), null).roundingPreparer(context).apply(rounding);
             verify(rounding).prepare(min, max);
         });
     }
@@ -82,7 +82,7 @@ public class CoreValuesSourceTypeTests extends MapperServiceTestCase {
         );
         withAggregationContext(null, mapperService, List.of(), query, context -> {
             Rounding rounding = mock(Rounding.class);
-            CoreValuesSourceType.DATE.getField(context.buildFieldContext("field"), null, context).roundingPreparer().apply(rounding);
+            CoreValuesSourceType.DATE.getField(context.buildFieldContext("field"), null).roundingPreparer(context).apply(rounding);
             verify(rounding).prepare(min, max);
         });
     }
@@ -105,7 +105,7 @@ public class CoreValuesSourceTypeTests extends MapperServiceTestCase {
         );
         withAggregationContext(null, mapperService, List.of(), query, context -> {
             Rounding rounding = mock(Rounding.class);
-            CoreValuesSourceType.DATE.getField(context.buildFieldContext("field"), null, context).roundingPreparer().apply(rounding);
+            CoreValuesSourceType.DATE.getField(context.buildFieldContext("field"), null).roundingPreparer(context).apply(rounding);
             verify(rounding).prepareForUnknown();
         });
     }
@@ -134,7 +134,7 @@ public class CoreValuesSourceTypeTests extends MapperServiceTestCase {
             .rangeQuery(minQuery, maxQuery, true, true, ShapeRelation.CONTAINS, null, null, createSearchExecutionContext(mapperService));
         withAggregationContext(null, mapperService, docsWithDatesBetween(minDocs, maxDocs), query, context -> {
             Rounding rounding = mock(Rounding.class);
-            CoreValuesSourceType.DATE.getField(context.buildFieldContext("field"), null, context).roundingPreparer().apply(rounding);
+            CoreValuesSourceType.DATE.getField(context.buildFieldContext("field"), null).roundingPreparer(context).apply(rounding);
             verify(rounding).prepare(min, max);
         });
     }

--- a/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/aggregations/support/AnalyticsValuesSourceType.java
+++ b/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/aggregations/support/AnalyticsValuesSourceType.java
@@ -33,7 +33,7 @@ public enum AnalyticsValuesSourceType implements ValuesSourceType {
         }
 
         @Override
-        public ValuesSource getField(FieldContext fieldContext, AggregationScript.LeafFactory script, AggregationContext context) {
+        public ValuesSource getField(FieldContext fieldContext, AggregationScript.LeafFactory script) {
             final IndexFieldData<?> indexFieldData = fieldContext.indexFieldData();
 
             if ((indexFieldData instanceof IndexHistogramFieldData) == false) {

--- a/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/aggregations/support/HistogramValuesSource.java
+++ b/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/aggregations/support/HistogramValuesSource.java
@@ -15,6 +15,7 @@ import org.elasticsearch.index.fielddata.HistogramValues;
 import org.elasticsearch.index.fielddata.IndexHistogramFieldData;
 import org.elasticsearch.index.fielddata.SortedBinaryDocValues;
 import org.elasticsearch.search.aggregations.AggregationExecutionException;
+import org.elasticsearch.search.aggregations.support.AggregationContext;
 
 import java.io.IOException;
 import java.util.function.Function;
@@ -25,7 +26,7 @@ public class HistogramValuesSource {
         public abstract HistogramValues getHistogramValues(LeafReaderContext context) throws IOException;
 
         @Override
-        public Function<Rounding, Prepared> roundingPreparer() throws IOException {
+        public Function<Rounding, Prepared> roundingPreparer(AggregationContext context) throws IOException {
             throw new AggregationExecutionException("can't round a [histogram]");
         }
 

--- a/x-pack/plugin/mapper-aggregate-metric/src/main/java/org/elasticsearch/xpack/aggregatemetric/aggregations/support/AggregateMetricsValuesSource.java
+++ b/x-pack/plugin/mapper-aggregate-metric/src/main/java/org/elasticsearch/xpack/aggregatemetric/aggregations/support/AggregateMetricsValuesSource.java
@@ -12,6 +12,7 @@ import org.elasticsearch.index.fielddata.DocValueBits;
 import org.elasticsearch.index.fielddata.SortedBinaryDocValues;
 import org.elasticsearch.index.fielddata.SortedNumericDoubleValues;
 import org.elasticsearch.search.aggregations.AggregationExecutionException;
+import org.elasticsearch.search.aggregations.support.AggregationContext;
 import org.elasticsearch.xpack.aggregatemetric.fielddata.IndexAggregateDoubleMetricFieldData;
 import org.elasticsearch.xpack.aggregatemetric.mapper.AggregateDoubleMetricFieldMapper;
 import org.elasticsearch.xpack.aggregatemetric.mapper.AggregateDoubleMetricFieldMapper.Metric;
@@ -49,7 +50,7 @@ public class AggregateMetricsValuesSource {
             }
 
             @Override
-            protected Function<Rounding, Rounding.Prepared> roundingPreparer() throws IOException {
+            protected Function<Rounding, Rounding.Prepared> roundingPreparer(AggregationContext context) throws IOException {
                 throw new AggregationExecutionException("Can't round an [" + AggregateDoubleMetricFieldMapper.CONTENT_TYPE + "]");
             }
 

--- a/x-pack/plugin/mapper-aggregate-metric/src/main/java/org/elasticsearch/xpack/aggregatemetric/aggregations/support/AggregateMetricsValuesSourceType.java
+++ b/x-pack/plugin/mapper-aggregate-metric/src/main/java/org/elasticsearch/xpack/aggregatemetric/aggregations/support/AggregateMetricsValuesSourceType.java
@@ -40,7 +40,7 @@ public enum AggregateMetricsValuesSourceType implements ValuesSourceType {
         }
 
         @Override
-        public ValuesSource getField(FieldContext fieldContext, AggregationScript.LeafFactory script, AggregationContext context) {
+        public ValuesSource getField(FieldContext fieldContext, AggregationScript.LeafFactory script) {
             final IndexFieldData<?> indexFieldData = fieldContext.indexFieldData();
 
             if ((indexFieldData instanceof IndexAggregateDoubleMetricFieldData) == false) {

--- a/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/search/aggregations/support/CartesianPointValuesSource.java
+++ b/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/search/aggregations/support/CartesianPointValuesSource.java
@@ -17,6 +17,7 @@ import org.elasticsearch.index.fielddata.MultiPointValues;
 import org.elasticsearch.index.fielddata.PointValues;
 import org.elasticsearch.index.fielddata.SortedBinaryDocValues;
 import org.elasticsearch.search.aggregations.AggregationExecutionException;
+import org.elasticsearch.search.aggregations.support.AggregationContext;
 import org.elasticsearch.search.aggregations.support.ValuesSource;
 import org.elasticsearch.xcontent.ToXContentFragment;
 import org.elasticsearch.xcontent.XContentBuilder;
@@ -49,7 +50,7 @@ public abstract class CartesianPointValuesSource extends ValuesSource {
     }
 
     @Override
-    public final Function<Rounding, Rounding.Prepared> roundingPreparer() {
+    public final Function<Rounding, Rounding.Prepared> roundingPreparer(AggregationContext context) {
         throw new AggregationExecutionException("can't round a [POINT]");
     }
 

--- a/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/search/aggregations/support/CartesianPointValuesSourceType.java
+++ b/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/search/aggregations/support/CartesianPointValuesSourceType.java
@@ -47,7 +47,7 @@ public class CartesianPointValuesSourceType implements Writeable, ValuesSourceTy
     }
 
     @Override
-    public ValuesSource getField(FieldContext fieldContext, AggregationScript.LeafFactory script, AggregationContext context) {
+    public ValuesSource getField(FieldContext fieldContext, AggregationScript.LeafFactory script) {
         if (fieldContext.indexFieldData()instanceof IndexCartesianPointFieldData pointFieldData) {
             return new CartesianPointValuesSource.Fielddata(pointFieldData);
         }

--- a/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/search/aggregations/support/CartesianShapeValuesSource.java
+++ b/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/search/aggregations/support/CartesianShapeValuesSource.java
@@ -11,6 +11,7 @@ import org.apache.lucene.index.LeafReaderContext;
 import org.elasticsearch.common.Rounding;
 import org.elasticsearch.index.fielddata.SortedBinaryDocValues;
 import org.elasticsearch.search.aggregations.AggregationExecutionException;
+import org.elasticsearch.search.aggregations.support.AggregationContext;
 import org.elasticsearch.xpack.spatial.index.fielddata.CartesianShapeValues;
 import org.elasticsearch.xpack.spatial.index.fielddata.IndexShapeFieldData;
 
@@ -26,7 +27,7 @@ public abstract class CartesianShapeValuesSource extends ShapeValuesSource<Carte
     };
 
     @Override
-    protected Function<Rounding, Rounding.Prepared> roundingPreparer() {
+    protected Function<Rounding, Rounding.Prepared> roundingPreparer(AggregationContext context) {
         throw new AggregationExecutionException("can't round a [shape]");
     }
 

--- a/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/search/aggregations/support/CartesianShapeValuesSourceType.java
+++ b/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/search/aggregations/support/CartesianShapeValuesSourceType.java
@@ -38,7 +38,7 @@ public class CartesianShapeValuesSourceType extends ShapeValuesSourceType {
     }
 
     @Override
-    public ValuesSource getField(FieldContext fieldContext, AggregationScript.LeafFactory script, AggregationContext context) {
+    public ValuesSource getField(FieldContext fieldContext, AggregationScript.LeafFactory script) {
         boolean isPoint = fieldContext.indexFieldData() instanceof IndexCartesianPointFieldData;
         boolean isShape = fieldContext.indexFieldData() instanceof IndexShapeFieldData;
         if (isPoint == false && isShape == false) {

--- a/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/search/aggregations/support/GeoShapeValuesSource.java
+++ b/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/search/aggregations/support/GeoShapeValuesSource.java
@@ -11,6 +11,7 @@ import org.apache.lucene.index.LeafReaderContext;
 import org.elasticsearch.common.Rounding;
 import org.elasticsearch.index.fielddata.SortedBinaryDocValues;
 import org.elasticsearch.search.aggregations.AggregationExecutionException;
+import org.elasticsearch.search.aggregations.support.AggregationContext;
 import org.elasticsearch.xpack.spatial.index.fielddata.GeoShapeValues;
 import org.elasticsearch.xpack.spatial.index.fielddata.IndexShapeFieldData;
 
@@ -26,7 +27,7 @@ public abstract class GeoShapeValuesSource extends ShapeValuesSource<GeoShapeVal
     };
 
     @Override
-    protected Function<Rounding, Rounding.Prepared> roundingPreparer() {
+    protected Function<Rounding, Rounding.Prepared> roundingPreparer(AggregationContext context) {
         throw new AggregationExecutionException("can't round a [geo_shape]");
     }
 

--- a/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/search/aggregations/support/GeoShapeValuesSourceType.java
+++ b/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/search/aggregations/support/GeoShapeValuesSourceType.java
@@ -38,7 +38,7 @@ public class GeoShapeValuesSourceType extends ShapeValuesSourceType {
     }
 
     @Override
-    public ValuesSource getField(FieldContext fieldContext, AggregationScript.LeafFactory script, AggregationContext context) {
+    public ValuesSource getField(FieldContext fieldContext, AggregationScript.LeafFactory script) {
         boolean isPoint = fieldContext.indexFieldData() instanceof IndexGeoPointFieldData;
         boolean isShape = fieldContext.indexFieldData() instanceof IndexShapeFieldData;
         if (isPoint == false && isShape == false) {

--- a/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/search/aggregations/support/ShapeValuesSourceType.java
+++ b/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/search/aggregations/support/ShapeValuesSourceType.java
@@ -8,7 +8,6 @@
 package org.elasticsearch.xpack.spatial.search.aggregations.support;
 
 import org.elasticsearch.script.AggregationScript;
-import org.elasticsearch.search.aggregations.support.AggregationContext;
 import org.elasticsearch.search.aggregations.support.FieldContext;
 import org.elasticsearch.search.aggregations.support.ValueType;
 import org.elasticsearch.search.aggregations.support.ValuesSource;
@@ -23,5 +22,5 @@ public abstract class ShapeValuesSourceType implements ValuesSourceType {
     }
 
     @Override
-    public abstract ValuesSource getField(FieldContext fieldContext, AggregationScript.LeafFactory script, AggregationContext context);
+    public abstract ValuesSource getField(FieldContext fieldContext, AggregationScript.LeafFactory script);
 }


### PR DESCRIPTION
`AggregationContext` is a heavy object that is required when creating a `ValuesSource` instance using the `ValuesSourceType.getField()` method. 

Looking a bit deeper, it looks like `AggregationContext` is only required for date fields when calling the `roundingPreparer()` method. This PR removes the dependency to `AggregationContext` when creating a `ValuesSource` instance and moves directly in the `roundingPreparer(context)` method