### PR TITLE
Fix corrupted Metadata from index and alias having the same name (#91456)

### DIFF
--- a/docs/changelog/91456.yaml
+++ b/docs/changelog/91456.yaml
@@ -1,0 +1,5 @@
+pr: 91456
+summary: Fix corrupted Metadata from index and alias having the same name
+area: Cluster Coordination
+type: bug
+issues: []

--- a/server/src/internalClusterTest/java/org/elasticsearch/aliases/IndexAliasesIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/aliases/IndexAliasesIT.java
@@ -1376,6 +1376,15 @@ public class IndexAliasesIT extends ESIntegTestCase {
         assertThat(searchResponse.getHits().getHits(), emptyArray());
     }
 
+    public void testCreateIndexAndAliasWithSameNameFails() {
+        final String indexName = "index-name";
+        final IllegalArgumentException iae = expectThrows(
+            IllegalArgumentException.class,
+            () -> client().admin().indices().prepareCreate(indexName).addAlias(new Alias(indexName)).execute().actionGet()
+        );
+        assertEquals("alias name [" + indexName + "] self-conflicts with index name", iae.getMessage());
+    }
+
     public void testGetAliasAndAliasExistsForHiddenAliases() {
         final String writeIndex = randomAlphaOfLength(5).toLowerCase(Locale.ROOT);
         final String nonWriteIndex = randomAlphaOfLength(6).toLowerCase(Locale.ROOT);

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/IndexMetadata.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/IndexMetadata.java
@@ -2017,6 +2017,13 @@ public class IndexMetadata implements Diffable<IndexMetadata>, ToXContentFragmen
                 lifecycleExecutionState = LifecycleExecutionState.EMPTY_STATE;
             }
 
+            var aliasesMap = aliases.build();
+            for (AliasMetadata alias : aliasesMap.values()) {
+                if (alias.alias().equals(index)) {
+                    throw new IllegalArgumentException("alias name [" + index + "] self-conflicts with index name");
+                }
+            }
+
             final boolean isSearchableSnapshot = SearchableSnapshotsSettings.isSearchableSnapshotStore(settings);
             final String indexMode = settings.get(IndexSettings.MODE.getKey());
             final boolean isTsdb = indexMode != null && IndexMode.TIME_SERIES.getName().equals(indexMode.toLowerCase(Locale.ROOT));
@@ -2032,7 +2039,7 @@ public class IndexMetadata implements Diffable<IndexMetadata>, ToXContentFragmen
                 numberOfReplicas,
                 settings,
                 mapping,
-                aliases.build(),
+                aliasesMap,
                 newCustomMetadata,
                 Map.ofEntries(denseInSyncAllocationIds),
                 requireFilters,

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/IndexMetadataTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/IndexMetadataTests.java
@@ -482,6 +482,19 @@ public class IndexMetadataTests extends ESTestCase {
         assertThat(idxMeta2.getLifecyclePolicyName(), equalTo("some_policy"));
     }
 
+    public void testIndexAndAliasWithSameName() {
+        final IllegalArgumentException iae = expectThrows(
+            IllegalArgumentException.class,
+            () -> IndexMetadata.builder("index")
+                .settings(Settings.builder().put(IndexMetadata.SETTING_VERSION_CREATED, Version.CURRENT))
+                .numberOfShards(1)
+                .numberOfReplicas(0)
+                .putAlias(AliasMetadata.builder("index").build())
+                .build()
+        );
+        assertEquals("alias name [index] self-conflicts with index name", iae.getMessage());
+    }
+
     private static Settings indexSettingsWithDataTier(String dataTier) {
         return Settings.builder()
             .put(IndexMetadata.SETTING_VERSION_CREATED, Version.CURRENT)


### PR DESCRIPTION
This fixes a bug introduced in https://github.com/elastic/elasticsearch/pull/87863 which added a Metadata copy constructor with separate name collision checks that assumed index name and alias names were already validated in `IndexMetada`. => fixed corrupted states by actually adding the validation to `IndexMetadata` to make it impossible to instantiate a broken `IndexMetadata` in the first place.

back port of #91456 