### PR TITLE
Catching exceptions to prevent ingest listeners from being called multiple times

### DIFF
--- a/docs/changelog/91475.yaml
+++ b/docs/changelog/91475.yaml
@@ -1,0 +1,6 @@
+pr: 91475
+summary: Catching exceptions to prevent ingest listeners from being called multiple
+  times
+area: Ingest Node
+type: bug
+issues: []

--- a/server/src/main/java/org/elasticsearch/ingest/IngestService.java
+++ b/server/src/main/java/org/elasticsearch/ingest/IngestService.java
@@ -912,64 +912,71 @@ public class IngestService implements ClusterStateApplier, ReportingService<Inge
          */
         final AtomicBoolean listenerHasBeenCalled = new AtomicBoolean(false);
         ingestDocument.executePipeline(pipeline, (result, e) -> {
-            if (listenerHasBeenCalled.getAndSet(true)) {
-                logger.warn("A listener was unexpectedly called more than once", new RuntimeException());
-                assert false : "A listener was unexpectedly called more than once";
-            } else {
-                long ingestTimeInNanos = System.nanoTime() - startTimeInNanos;
-                totalMetrics.postIngest(ingestTimeInNanos);
-                if (e != null) {
-                    totalMetrics.ingestFailed();
-                    handler.accept(e);
-                } else if (result == null) {
-                    itemDroppedHandler.accept(slot);
-                    handler.accept(null);
+            try {
+                if (listenerHasBeenCalled.getAndSet(true)) {
+                    logger.warn("A listener was unexpectedly called more than once", new RuntimeException());
+                    assert false : "A listener was unexpectedly called more than once";
                 } else {
-                    org.elasticsearch.script.Metadata metadata = ingestDocument.getMetadata();
-
-                    // it's fine to set all metadata fields all the time, as ingest document holds their starting values
-                    // before ingestion, which might also get modified during ingestion.
-                    indexRequest.index(metadata.getIndex());
-                    indexRequest.id(metadata.getId());
-                    indexRequest.routing(metadata.getRouting());
-                    indexRequest.version(metadata.getVersion());
-                    if (metadata.getVersionType() != null) {
-                        indexRequest.versionType(VersionType.fromString(metadata.getVersionType()));
-                    }
-                    Number number;
-                    if ((number = metadata.getIfSeqNo()) != null) {
-                        indexRequest.setIfSeqNo(number.longValue());
-                    }
-                    if ((number = metadata.getIfPrimaryTerm()) != null) {
-                        indexRequest.setIfPrimaryTerm(number.longValue());
-                    }
-                    try {
-                        boolean ensureNoSelfReferences = ingestDocument.doNoSelfReferencesCheck();
-                        indexRequest.source(ingestDocument.getSource(), indexRequest.getContentType(), ensureNoSelfReferences);
-                    } catch (IllegalArgumentException ex) {
-                        // An IllegalArgumentException can be thrown when an ingest
-                        // processor creates a source map that is self-referencing.
-                        // In that case, we catch and wrap the exception so we can
-                        // include which pipeline failed.
+                    long ingestTimeInNanos = System.nanoTime() - startTimeInNanos;
+                    totalMetrics.postIngest(ingestTimeInNanos);
+                    if (e != null) {
                         totalMetrics.ingestFailed();
-                        handler.accept(
-                            new IllegalArgumentException(
-                                "Failed to generate the source document for ingest pipeline [" + pipeline.getId() + "]",
-                                ex
-                            )
-                        );
-                        return;
-                    }
-                    Map<String, String> map;
-                    if ((map = metadata.getDynamicTemplates()) != null) {
-                        Map<String, String> mergedDynamicTemplates = new HashMap<>(indexRequest.getDynamicTemplates());
-                        mergedDynamicTemplates.putAll(map);
-                        indexRequest.setDynamicTemplates(mergedDynamicTemplates);
-                    }
-                    postIngest(ingestDocument, indexRequest);
+                        handler.accept(e);
+                    } else if (result == null) {
+                        itemDroppedHandler.accept(slot);
+                        handler.accept(null);
+                    } else {
+                        org.elasticsearch.script.Metadata metadata = ingestDocument.getMetadata();
 
-                    handler.accept(null);
+                        // it's fine to set all metadata fields all the time, as ingest document holds their starting values
+                        // before ingestion, which might also get modified during ingestion.
+                        indexRequest.index(metadata.getIndex());
+                        indexRequest.id(metadata.getId());
+                        indexRequest.routing(metadata.getRouting());
+                        indexRequest.version(metadata.getVersion());
+                        if (metadata.getVersionType() != null) {
+                            indexRequest.versionType(VersionType.fromString(metadata.getVersionType()));
+                        }
+                        Number number;
+                        if ((number = metadata.getIfSeqNo()) != null) {
+                            indexRequest.setIfSeqNo(number.longValue());
+                        }
+                        if ((number = metadata.getIfPrimaryTerm()) != null) {
+                            indexRequest.setIfPrimaryTerm(number.longValue());
+                        }
+                        try {
+                            boolean ensureNoSelfReferences = ingestDocument.doNoSelfReferencesCheck();
+                            indexRequest.source(ingestDocument.getSource(), indexRequest.getContentType(), ensureNoSelfReferences);
+                        } catch (IllegalArgumentException ex) {
+                            // An IllegalArgumentException can be thrown when an ingest
+                            // processor creates a source map that is self-referencing.
+                            // In that case, we catch and wrap the exception so we can
+                            // include which pipeline failed.
+                            totalMetrics.ingestFailed();
+                            handler.accept(
+                                new IllegalArgumentException(
+                                    "Failed to generate the source document for ingest pipeline [" + pipeline.getId() + "]",
+                                    ex
+                                )
+                            );
+                            return;
+                        }
+                        Map<String, String> map;
+                        if ((map = metadata.getDynamicTemplates()) != null) {
+                            Map<String, String> mergedDynamicTemplates = new HashMap<>(indexRequest.getDynamicTemplates());
+                            mergedDynamicTemplates.putAll(map);
+                            indexRequest.setDynamicTemplates(mergedDynamicTemplates);
+                        }
+                        postIngest(ingestDocument, indexRequest);
+
+                        handler.accept(null);
+                    }
                 }
+            } catch (Exception e2) {
+                if (e != null) {
+                    logger.error("Exception encountered while handling another exception", e);
+                }
+                handler.accept(e2);
             }
         });
     }


### PR DESCRIPTION
If an exception is thrown from inside of the handler given to `IngestDocument::executePipeline` in `IngestService::innerExecute` or inside the handler given to `Pipeline::execute` in `IngestDocument::executePipeline``, then the error listener will be called twice, resulting in log messages like these:
```
[2022-10-11T12:00:54,244][WARN ][o.e.i.CompoundProcessor  ] [XPCS-S1] Preventing postIngest from being called more than once
java.lang.RuntimeException: null
        at org.elasticsearch.ingest.CompoundProcessor.innerExecute(CompoundProcessor.java:231) ~[elasticsearch-8.4.3.jar:?]
        at org.elasticsearch.ingest.CompoundProcessor.lambda$innerExecute$2(CompoundProcessor.java:221) ~[elasticsearch-8.4.3.jar:?]
        at org.elasticsearch.ingest.ConditionalProcessor.execute(ConditionalProcessor.java:152) ~[elasticsearch-8.4.3.jar:?]
        at org.elasticsearch.ingest.CompoundProcessor.innerExecute(CompoundProcessor.java:209) ~[elasticsearch-8.4.3.jar:?] <-------- first different frame
        at org.elasticsearch.ingest.CompoundProcessor.lambda$innerExecute$2(CompoundProcessor.java:221) ~[elasticsearch-8.4.3.jar:?]
        at org.elasticsearch.ingest.ConditionalProcessor.execute(ConditionalProcessor.java:152) ~[elasticsearch-8.4.3.jar:?]
        at org.elasticsearch.ingest.CompoundProcessor.innerExecute(CompoundProcessor.java:209) ~[elasticsearch-8.4.3.jar:?]
        at org.elasticsearch.ingest.CompoundProcessor.execute(CompoundProcessor.java:152) ~[elasticsearch-8.4.3.jar:?]
        at org.elasticsearch.ingest.Pipeline.execute(Pipeline.java:129) ~[elasticsearch-8.4.3.jar:?]
        at org.elasticsearch.ingest.IngestDocument.executePipeline(IngestDocument.java:823) ~[elasticsearch-8.4.3.jar:?]
        at org.elasticsearch.ingest.IngestService.innerExecute(IngestService.java:898) ~[elasticsearch-8.4.3.jar:?]
        at org.elasticsearch.ingest.IngestService.executePipelines(IngestService.java:748) ~[elasticsearch-8.4.3.jar:?]
        at org.elasticsearch.ingest.IngestService$1.doRun(IngestService.java:710) ~[elasticsearch-8.4.3.jar:?]
        at org.elasticsearch.common.util.concurrent.ThreadContext$ContextPreservingAbstractRunnable.doRun(ThreadContext.java:769) ~[elasticsearch-8.4.3.jar:?]
        at org.elasticsearch.common.util.concurrent.AbstractRunnable.run(AbstractRunnable.java:26) ~[elasticsearch-8.4.3.jar:?]
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136) ~[?:?]
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635) ~[?:?]
        at java.lang.Thread.run(Thread.java:833) ~[?:?]
[2022-10-11T12:00:54,244][WARN ][o.e.i.Pipeline           ] [XPCS-S1] A listener was unexpectedly called more than once
java.lang.RuntimeException: null
        at org.elasticsearch.ingest.Pipeline.lambda$execute$0(Pipeline.java:131) ~[elasticsearch-8.4.3.jar:?]
        at org.elasticsearch.ingest.CompoundProcessor.executeOnFailure(CompoundProcessor.java:274) ~[elasticsearch-8.4.3.jar:?]
        at org.elasticsearch.ingest.CompoundProcessor.executeOnFailure(CompoundProcessor.java:308) ~[elasticsearch-8.4.3.jar:?]
        at org.elasticsearch.ingest.CompoundProcessor.executeOnFailureOuter(CompoundProcessor.java:257) ~[elasticsearch-8.4.3.jar:?]
        at org.elasticsearch.ingest.CompoundProcessor.innerExecute(CompoundProcessor.java:236) ~[elasticsearch-8.4.3.jar:?] <-------- first different frame
        at org.elasticsearch.ingest.CompoundProcessor.lambda$innerExecute$2(CompoundProcessor.java:221) ~[elasticsearch-8.4.3.jar:?]
        at org.elasticsearch.ingest.ConditionalProcessor.execute(ConditionalProcessor.java:152) ~[elasticsearch-8.4.3.jar:?]
        at org.elasticsearch.ingest.CompoundProcessor.innerExecute(CompoundProcessor.java:209) ~[elasticsearch-8.4.3.jar:?]
        at org.elasticsearch.ingest.CompoundProcessor.lambda$innerExecute$2(CompoundProcessor.java:221) ~[elasticsearch-8.4.3.jar:?]
        at org.elasticsearch.ingest.ConditionalProcessor.execute(ConditionalProcessor.java:152) ~[elasticsearch-8.4.3.jar:?]
        at org.elasticsearch.ingest.CompoundProcessor.innerExecute(CompoundProcessor.java:209) ~[elasticsearch-8.4.3.jar:?]
        at org.elasticsearch.ingest.CompoundProcessor.execute(CompoundProcessor.java:152) ~[elasticsearch-8.4.3.jar:?]
        at org.elasticsearch.ingest.Pipeline.execute(Pipeline.java:129) ~[elasticsearch-8.4.3.jar:?]
        at org.elasticsearch.ingest.IngestDocument.executePipeline(IngestDocument.java:823) ~[elasticsearch-8.4.3.jar:?]
        at org.elasticsearch.ingest.IngestService.innerExecute(IngestService.java:898) ~[elasticsearch-8.4.3.jar:?]
        at org.elasticsearch.ingest.IngestService.executePipelines(IngestService.java:748) ~[elasticsearch-8.4.3.jar:?]
        at org.elasticsearch.ingest.IngestService$1.doRun(IngestService.java:710) ~[elasticsearch-8.4.3.jar:?]
        at org.elasticsearch.common.util.concurrent.ThreadContext$ContextPreservingAbstractRunnable.doRun(ThreadContext.java:769) ~[elasticsearch-8.4.3.jar:?]
        at org.elasticsearch.common.util.concurrent.AbstractRunnable.run(AbstractRunnable.java:26) ~[elasticsearch-8.4.3.jar:?]
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136) ~[?:?]
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635) ~[?:?]
        at java.lang.Thread.run(Thread.java:833) ~[?:?]
```
Those log messages aren't harmful in themselves (and they are part of #90319 which prevents counters from going negative, causing serialization exceptions like #77973). But they do show that we're getting an unexpected exception while processing an exception, and we're not handling it correctly. This change catches that unexpected exception and deals with it.