### PR TITLE
Don't start docker fixtures when resolving test runtime classpath

### DIFF
--- a/x-pack/qa/saml-idp-tests/build.gradle
+++ b/x-pack/qa/saml-idp-tests/build.gradle
@@ -29,10 +29,8 @@ tasks.register("copyIdpFiles", Sync) {
   }
 }
 
-project.sourceSets.javaRestTest.runtimeClasspath += files(outputDir)
-
 tasks.named("javaRestTest").configure {
-  dependsOn tasks.named("copyIdpFiles")
+  classpath += files(tasks.named("copyIdpFiles"))
   onlyIf { idpFixtureProject.postProcessFixture.state.skipped == false }
 }
 

--- a/x-pack/qa/saml-idp-tests/build.gradle
+++ b/x-pack/qa/saml-idp-tests/build.gradle
@@ -6,7 +6,7 @@ apply plugin: 'elasticsearch.internal-java-rest-test'
 apply plugin: 'elasticsearch.test.fixtures'
 
 dependencies {
-  javaRestTestImplementation(testArtifact(project(xpackModule('core'))))
+  javaRestTestImplementation testArtifact(project(xpackModule('core')))
   javaRestTestImplementation "com.google.jimfs:jimfs:${versions.jimfs}"
   javaRestTestImplementation "com.google.guava:guava:${versions.jimfs_guava}"
 }
@@ -29,7 +29,7 @@ tasks.register("copyIdpFiles", Sync) {
   }
 }
 
-project.sourceSets.javaRestTest.output.dir(outputDir, builtBy: [copyIdpFiles])
+project.sourceSets.javaRestTest.runtimeClasspath += files(outputDir)
 
 tasks.named("javaRestTest").configure {
   dependsOn tasks.named("copyIdpFiles")


### PR DESCRIPTION
We have some test runtime resources that are generated by our Docker based test fixtures. These resources are then placed on the runtime test classpath to be used by the test classes themselves. The problem here is that any build that attempts to resolve the test runtime classpath will then trigger the starting of these Docker fixtures, which is quite expensive. Some of our precommit checks, like forbidden apis and third-party audit tasks do this.

This commit decouples this a bit and removes the implicit dependency replacing it with an explicit one on the test task itself. It's slightly less idiomatic Gradle, but it's a worthwhile optimization.