### PR TITLE
[8.2] [DOCS] Replace dependencies list with a link.  Closes #84863 (#90694)

### DIFF
--- a/docs/reference/dependencies-versions.asciidoc
+++ b/docs/reference/dependencies-versions.asciidoc
@@ -1,7 +1,10 @@
 ["appendix",id="dependencies-versions"]
 = Dependencies and versions
 
-[source, text]
-----
-include::{dependencies-dir}/version.properties[]
-----
+ifeval::["{release-state}"=="unreleased"]
+See https://artifacts.elastic.co/reports/dependencies/dependencies-current.html[Elastic Stack Third-party Dependencices] for the complete list of dependencies for {es}.
+endif::[]
+
+ifeval::["{release-state}"=="released"]
+See https://artifacts.elastic.co/reports/dependencies/dependencies-{elasticsearch_version}.html[Elastic Stack Third-party Dependencices] for the complete list of dependencies for {es} {elasticsearch_version}.
+endif::[]


### PR DESCRIPTION
Backports the following commits to 8.2:
 - [DOCS] Replace dependencies list with a link.  Closes #84863 (#90694)