### PR TITLE
[8.5] [Test mute] DocumentSubsetBitsetCacheTests.testCacheUnderConcurrentAccess (#91486)

### DIFF
--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/accesscontrol/DocumentSubsetBitsetCacheTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/accesscontrol/DocumentSubsetBitsetCacheTests.java
@@ -359,6 +359,7 @@ public class DocumentSubsetBitsetCacheTests extends ESTestCase {
         });
     }
 
+    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/91471")
     public void testCacheUnderConcurrentAccess() throws Exception {
         // This value is based on the internal implementation details of lucene's FixedBitSet
         // If the implementation changes, this can be safely updated to match the new ram usage for a single bitset


### PR DESCRIPTION
Backports the following commits to 8.5:
 - [Test mute] DocumentSubsetBitsetCacheTests.testCacheUnderConcurrentAccess (#91486)