### PR TITLE
Reduce number of object allocations in H3#geoToH3 and speed up computations

### DIFF
--- a/docs/changelog/91492.yaml
+++ b/docs/changelog/91492.yaml
@@ -1,0 +1,5 @@
+pr: 91492
+summary: Reduce number of object allocations in H3#geoToH3 and speed up computations
+area: Geo
+type: enhancement
+issues: []

--- a/libs/h3/src/main/java/org/elasticsearch/h3/BaseCells.java
+++ b/libs/h3/src/main/java/org/elasticsearch/h3/BaseCells.java
@@ -613,7 +613,7 @@ final class BaseCells {
         return new FaceIJK(cellData.homeFace, new CoordIJK(cellData.homeI, cellData.homeJ, cellData.homeK));
     }
 
-    /** Find base cell given FaceIJK.
+    /** Find base cell given a face and a CoordIJK.
      *
      * Given the face number and a resolution 0 ijk+ coordinate in that face's
      * face-centered ijk coordinate system, return the base cell located at that
@@ -621,11 +621,11 @@ final class BaseCells {
      *
      * Valid ijk+ lookup coordinates are from (0, 0, 0) to (2, 2, 2).
      */
-    public static int getBaseCell(FaceIJK faceIJK) {
-        return faceIjkBaseCells[faceIJK.face][faceIJK.coord.i][faceIJK.coord.j][faceIJK.coord.k].baseCell;
+    public static int getBaseCell(int face, CoordIJK coord) {
+        return faceIjkBaseCells[face][coord.i][coord.j][coord.k].baseCell;
     }
 
-    /** Find base cell given FaceIJK.
+    /** Find base cell given a face and a CoordIJK.
      *
      * Given the face number and a resolution 0 ijk+ coordinate in that face's
      * face-centered ijk coordinate system, return the number of 60' ccw rotations
@@ -633,8 +633,8 @@ final class BaseCells {
      *
      * Valid ijk+ lookup coordinates are from (0, 0, 0) to (2, 2, 2).
      */
-    public static int getBaseCellCCWrot60(FaceIJK faceIJK) {
-        return faceIjkBaseCells[faceIJK.face][faceIJK.coord.i][faceIJK.coord.j][faceIJK.coord.k].ccwRot60;
+    public static int getBaseCellCCWrot60(int face, CoordIJK coord) {
+        return faceIjkBaseCells[face][coord.i][coord.j][coord.k].ccwRot60;
     }
 
     /**  Return whether or not the tested face is a cw offset face.

--- a/libs/h3/src/main/java/org/elasticsearch/h3/CoordIJK.java
+++ b/libs/h3/src/main/java/org/elasticsearch/h3/CoordIJK.java
@@ -90,8 +90,20 @@ final class CoordIJK {
     }
 
     /**
-     * Find the center point in 2D cartesian coordinates of a hex.
+     * Reset the value of the IJK coordinates to the provided ones.
      *
+     * @param i the i coordinate
+     * @param j the j coordinate
+     * @param k the k coordinate
+     */
+    void reset(int i, int j, int k) {
+        this.i = i;
+        this.j = j;
+        this.k = k;
+    }
+
+    /**
+     * Find the center point in 2D cartesian coordinates of a hex.
      */
     public Vec2d ijkToHex2d() {
         int i = this.i - this.k;
@@ -128,41 +140,13 @@ final class CoordIJK {
 
     /**
      * Normalizes ijk coordinates by setting the ijk coordinates
-     * to the smallest possible values.
+     * to the smallest possible positive values.
      */
     public void ijkNormalize() {
-        // remove any negative values
-        if (i < 0) {
-            j -= i;
-            k -= i;
-            i = 0;
-        }
-
-        if (j < 0) {
-            i -= j;
-            k -= j;
-            j = 0;
-        }
-
-        if (k < 0) {
-            i -= k;
-            j -= k;
-            k = 0;
-        }
-
-        // remove the min value if needed
-        int min = i;
-        if (j < min) {
-            min = j;
-        }
-        if (k < min) {
-            min = k;
-        }
-        if (min > 0) {
-            i -= min;
-            j -= min;
-            k -= min;
-        }
+        final int min = Math.min(i, Math.min(j, k));
+        i -= min;
+        j -= min;
+        k -= min;
     }
 
     /**
@@ -321,26 +305,11 @@ final class CoordIJK {
      * INVALID_DIGIT on failure.
      */
     public int unitIjkToDigit() {
-        ijkNormalize();
-        int digit = Direction.INVALID_DIGIT.digit();
-        for (int i = Direction.CENTER_DIGIT.digit(); i < Direction.NUM_DIGITS.digit(); i++) {
-            if (ijkMatches(UNIT_VECS[i])) {
-                digit = i;
-                break;
-            }
+        // should be call on a normalized object
+        if (Math.min(i, Math.min(j, k)) < 0 || Math.max(i, Math.max(j, k)) > 1) {
+            return Direction.INVALID_DIGIT.digit();
         }
-        return digit;
-    }
-
-    /**
-     * Returns whether or not two ijk coordinates contain exactly the same
-     * component values.
-     *
-     * @param c The  set of ijk coordinates.
-     * @return true if the two addresses match, 0 if they do not.
-     */
-    private boolean ijkMatches(int[] c) {
-        return (i == c[0] && j == c[1] && k == c[2]);
+        return i << 2 | j << 1 | k;
     }
 
     /**
@@ -349,22 +318,21 @@ final class CoordIJK {
      * @param digit Indexing digit (between 1 and 6 inclusive)
      */
     public static int rotate60cw(int digit) {
-        switch (digit) {
-            case 1: // K_AXES_DIGIT
-                return Direction.JK_AXES_DIGIT.digit();
-            case 3: // JK_AXES_DIGIT:
-                return Direction.J_AXES_DIGIT.digit();
-            case 2: // J_AXES_DIGIT:
-                return Direction.IJ_AXES_DIGIT.digit();
-            case 6: // IJ_AXES_DIGIT
-                return Direction.I_AXES_DIGIT.digit();
-            case 4: // I_AXES_DIGIT
-                return Direction.IK_AXES_DIGIT.digit();
-            case 5: // IK_AXES_DIGIT
-                return Direction.K_AXES_DIGIT.digit();
-            default:
-                return digit;
-        }
+        return switch (digit) {
+            case 1 -> // K_AXES_DIGIT
+                Direction.JK_AXES_DIGIT.digit();
+            case 3 -> // JK_AXES_DIGIT:
+                Direction.J_AXES_DIGIT.digit();
+            case 2 -> // J_AXES_DIGIT:
+                Direction.IJ_AXES_DIGIT.digit();
+            case 6 -> // IJ_AXES_DIGIT
+                Direction.I_AXES_DIGIT.digit();
+            case 4 -> // I_AXES_DIGIT
+                Direction.IK_AXES_DIGIT.digit();
+            case 5 -> // IK_AXES_DIGIT
+                Direction.K_AXES_DIGIT.digit();
+            default -> digit;
+        };
     }
 
     /**
@@ -373,22 +341,21 @@ final class CoordIJK {
      * @param digit Indexing digit (between 1 and 6 inclusive)
      */
     public static int rotate60ccw(int digit) {
-        switch (digit) {
-            case 1: // K_AXES_DIGIT
-                return Direction.IK_AXES_DIGIT.digit();
-            case 5: // IK_AXES_DIGIT
-                return Direction.I_AXES_DIGIT.digit();
-            case 4: // I_AXES_DIGIT
-                return Direction.IJ_AXES_DIGIT.digit();
-            case 6: // IJ_AXES_DIGIT
-                return Direction.J_AXES_DIGIT.digit();
-            case 2: // J_AXES_DIGIT:
-                return Direction.JK_AXES_DIGIT.digit();
-            case 3: // JK_AXES_DIGIT:
-                return Direction.K_AXES_DIGIT.digit();
-            default:
-                return digit;
-        }
+        return switch (digit) {
+            case 1 -> // K_AXES_DIGIT
+                Direction.IK_AXES_DIGIT.digit();
+            case 5 -> // IK_AXES_DIGIT
+                Direction.I_AXES_DIGIT.digit();
+            case 4 -> // I_AXES_DIGIT
+                Direction.IJ_AXES_DIGIT.digit();
+            case 6 -> // IJ_AXES_DIGIT
+                Direction.J_AXES_DIGIT.digit();
+            case 2 -> // J_AXES_DIGIT:
+                Direction.JK_AXES_DIGIT.digit();
+            case 3 -> // JK_AXES_DIGIT:
+                Direction.K_AXES_DIGIT.digit();
+            default -> digit;
+        };
     }
 
 }

--- a/libs/h3/src/main/java/org/elasticsearch/h3/H3.java
+++ b/libs/h3/src/main/java/org/elasticsearch/h3/H3.java
@@ -189,7 +189,7 @@ public final class H3 {
      */
     public static long geoToH3(double lat, double lng, int res) {
         checkResolution(res);
-        return new LatLng(toRadians(lat), toRadians(lng)).geoToFaceIJK(res).faceIjkToH3(res);
+        return Vec3d.geoToH3(res, toRadians(lat), toRadians(lng));
     }
 
     /**

--- a/libs/h3/src/main/java/org/elasticsearch/h3/H3Index.java
+++ b/libs/h3/src/main/java/org/elasticsearch/h3/H3Index.java
@@ -179,7 +179,7 @@ final class H3Index {
      *         a Class II grid.
      */
     public static boolean isResolutionClassIII(int res) {
-        return res % 2 != 0;
+        return (res & 1) == 1;
     }
 
     /**

--- a/libs/h3/src/main/java/org/elasticsearch/h3/LatLng.java
+++ b/libs/h3/src/main/java/org/elasticsearch/h3/LatLng.java
@@ -55,67 +55,16 @@ public final class LatLng {
     }
 
     /**
-     * Encodes a coordinate on the sphere to the corresponding icosahedral face and
-     * containing 2D hex coordinates relative to that face center.
-     *
-     * @param res The desired H3 resolution for the encoding.
-     */
-    FaceIJK geoToFaceIJK(int res) {
-        Vec3d v3d = new Vec3d(this);
-
-        // determine the icosahedron face
-        int face = 0;
-        double sqd = v3d.pointSquareDist(Vec3d.faceCenterPoint[0]);
-        for (int i = 1; i < Vec3d.faceCenterPoint.length; i++) {
-            double sqdT = v3d.pointSquareDist(Vec3d.faceCenterPoint[i]);
-            if (sqdT < sqd) {
-                face = i;
-                sqd = sqdT;
-            }
-        }
-        // cos(r) = 1 - 2 * sin^2(r/2) = 1 - 2 * (sqd / 4) = 1 - sqd/2
-        double r = Math.acos(1 - sqd / 2);
-
-        if (r < Constants.EPSILON) {
-            return new FaceIJK(face, new Vec2d(0.0, 0.0).hex2dToCoordIJK());
-        }
-
-        // now have face and r, now find CCW theta from CII i-axis
-        double theta = Vec2d.posAngleRads(
-            Vec2d.faceAxesAzRadsCII[face][0] - Vec2d.posAngleRads(Vec2d.faceCenterGeo[face].geoAzimuthRads(this))
-        );
-
-        // adjust theta for Class III (odd resolutions)
-        if (H3Index.isResolutionClassIII(res)) {
-            theta = Vec2d.posAngleRads(theta - Constants.M_AP7_ROT_RADS);
-        }
-
-        // perform gnomonic scaling of r
-        r = Math.tan(r);
-
-        // scale for current resolution length u
-        r /= Constants.RES0_U_GNOMONIC;
-        for (int i = 0; i < res; i++) {
-            r *= Constants.M_SQRT7;
-        }
-
-        // we now have (r, theta) in hex2d with theta ccw from x-axes
-
-        // convert to local x,y
-        Vec2d vec2d = new Vec2d(r * Math.cos(theta), r * Math.sin(theta));
-        return new FaceIJK(face, vec2d.hex2dToCoordIJK());
-    }
-
-    /**
      * Determines the azimuth to the provided LatLng in radians.
      *
-     * @param p The spherical coordinates.
+     * @param lat The latitude in radians.
+     * @param lon The longitude in radians.
      * @return The azimuth in radians.
      */
-    private double geoAzimuthRads(LatLng p) {
+    double geoAzimuthRads(double lat, double lon) {
         return Math.atan2(
-            Math.cos(p.lat) * Math.sin(p.lon - lon),
-            Math.cos(lat) * Math.sin(p.lat) - Math.sin(lat) * Math.cos(p.lat) * Math.cos(p.lon - lon)
+            Math.cos(lat) * Math.sin(lon - this.lon),
+            Math.cos(this.lat) * Math.sin(lat) - Math.sin(this.lat) * Math.cos(lat) * Math.cos(lon - this.lon)
         );
     }
 }

--- a/libs/h3/src/main/java/org/elasticsearch/h3/Vec2d.java
+++ b/libs/h3/src/main/java/org/elasticsearch/h3/Vec2d.java
@@ -88,15 +88,15 @@ final class Vec2d {
     /**
      * pi
      */
-    private static double M_PI = 3.14159265358979323846;
+    private static final double M_PI = 3.14159265358979323846;
     /**
      * pi / 2.0
      */
-    private static double M_PI_2 = 1.5707963267948966;
+    private static final double M_PI_2 = 1.5707963267948966;
     /**
      * 2.0 * PI
      */
-    public static double M_2PI = 6.28318530717958647692528676655900576839433;
+    public static final double M_2PI = 6.28318530717958647692528676655900576839433;
 
     private final double x;  /// < x component
     private final double y;  /// < y component
@@ -160,7 +160,7 @@ final class Vec2d {
      * coordinate vector (from DGGRID).
      *
      */
-    public CoordIJK hex2dToCoordIJK() {
+    static CoordIJK hex2dToCoordIJK(double x, double y) {
         double a1, a2;
         double x1, x2;
         int m1, m2;
@@ -251,7 +251,7 @@ final class Vec2d {
             i = i - (2 * j + 1) / 2;
             j = -1 * j;
         }
-        CoordIJK coordIJK = new CoordIJK(i, j, k);
+        final CoordIJK coordIJK = new CoordIJK(i, j, k);
         coordIJK.ijkNormalize();
         return coordIJK;
     }
@@ -307,9 +307,13 @@ final class Vec2d {
      * @return The normalized radians value.
      */
     static double posAngleRads(double rads) {
-        double tmp = ((rads < 0.0) ? rads + M_2PI : rads);
-        if (rads >= M_2PI) tmp -= M_2PI;
-        return tmp;
+        if (rads < 0.0) {
+            return rads + M_2PI;
+        } else if (rads >= M_2PI) {
+            return rads - M_2PI;
+        } else {
+            return rads;
+        }
     }
 
     /**

--- a/libs/h3/src/main/java/org/elasticsearch/h3/Vec3d.java
+++ b/libs/h3/src/main/java/org/elasticsearch/h3/Vec3d.java
@@ -23,51 +23,106 @@
 
 package org.elasticsearch.h3;
 
+/**
+ *  3D floating-point vector
+ */
 final class Vec3d {
 
     /** icosahedron face centers in x/y/z on the unit sphere */
-    public static final double[][] faceCenterPoint = new double[][] {
-        { 0.2199307791404606, 0.6583691780274996, 0.7198475378926182 },     // face 0
-        { -0.2139234834501421, 0.1478171829550703, 0.9656017935214205 },    // face 1
-        { 0.1092625278784797, -0.4811951572873210, 0.8697775121287253 },    // face 2
-        { 0.7428567301586791, -0.3593941678278028, 0.5648005936517033 },    // face 3
-        { 0.8112534709140969, 0.3448953237639384, 0.4721387736413930 },     // face 4
-        { -0.1055498149613921, 0.9794457296411413, 0.1718874610009365 },    // face 5
-        { -0.8075407579970092, 0.1533552485898818, 0.5695261994882688 },    // face 6
-        { -0.2846148069787907, -0.8644080972654206, 0.4144792552473539 },   // face 7
-        { 0.7405621473854482, -0.6673299564565524, -0.0789837646326737 },   // face 8
-        { 0.8512303986474293, 0.4722343788582681, -0.2289137388687808 },    // face 9
-        { -0.7405621473854481, 0.6673299564565524, 0.0789837646326737 },    // face 10
-        { -0.8512303986474292, -0.4722343788582682, 0.2289137388687808 },   // face 11
-        { 0.1055498149613919, -0.9794457296411413, -0.1718874610009365 },   // face 12
-        { 0.8075407579970092, -0.1533552485898819, -0.5695261994882688 },   // face 13
-        { 0.2846148069787908, 0.8644080972654204, -0.4144792552473539 },    // face 14
-        { -0.7428567301586791, 0.3593941678278027, -0.5648005936517033 },   // face 15
-        { -0.8112534709140971, -0.3448953237639382, -0.4721387736413930 },  // face 16
-        { -0.2199307791404607, -0.6583691780274996, -0.7198475378926182 },  // face 17
-        { 0.2139234834501420, -0.1478171829550704, -0.9656017935214205 },   // face 18
-        { -0.1092625278784796, 0.4811951572873210, -0.8697775121287253 },   // face 19
+    public static final Vec3d[] faceCenterPoint = new Vec3d[] {
+        new Vec3d(0.2199307791404606, 0.6583691780274996, 0.7198475378926182),     // face 0
+        new Vec3d(-0.2139234834501421, 0.1478171829550703, 0.9656017935214205),    // face 1
+        new Vec3d(0.1092625278784797, -0.4811951572873210, 0.8697775121287253),    // face 2
+        new Vec3d(0.7428567301586791, -0.3593941678278028, 0.5648005936517033),    // face 3
+        new Vec3d(0.8112534709140969, 0.3448953237639384, 0.4721387736413930),     // face 4
+        new Vec3d(-0.1055498149613921, 0.9794457296411413, 0.1718874610009365),    // face 5
+        new Vec3d(-0.8075407579970092, 0.1533552485898818, 0.5695261994882688),    // face 6
+        new Vec3d(-0.2846148069787907, -0.8644080972654206, 0.4144792552473539),   // face 7
+        new Vec3d(0.7405621473854482, -0.6673299564565524, -0.0789837646326737),   // face 8
+        new Vec3d(0.8512303986474293, 0.4722343788582681, -0.2289137388687808),    // face 9
+        new Vec3d(-0.7405621473854481, 0.6673299564565524, 0.0789837646326737),    // face 10
+        new Vec3d(-0.8512303986474292, -0.4722343788582682, 0.2289137388687808),   // face 11
+        new Vec3d(0.1055498149613919, -0.9794457296411413, -0.1718874610009365),   // face 12
+        new Vec3d(0.8075407579970092, -0.1533552485898819, -0.5695261994882688),   // face 13
+        new Vec3d(0.2846148069787908, 0.8644080972654204, -0.4144792552473539),   // face 14
+        new Vec3d(-0.7428567301586791, 0.3593941678278027, -0.5648005936517033),   // face 15
+        new Vec3d(-0.8112534709140971, -0.3448953237639382, -0.4721387736413930),  // face 16
+        new Vec3d(-0.2199307791404607, -0.6583691780274996, -0.7198475378926182),  // face 17
+        new Vec3d(0.2139234834501420, -0.1478171829550704, -0.9656017935214205),   // face 18
+        new Vec3d(-0.1092625278784796, 0.4811951572873210, -0.8697775121287253)   // face 19
     };
 
-    private final double x;
-    private final double y;
-    private final double z;
+    private final double x, y, z;
 
-    Vec3d(LatLng latLng) {
-        double r = Math.cos(latLng.getLatRad());
-        this.z = Math.sin(latLng.getLatRad());
-        this.x = Math.cos(latLng.getLonRad()) * r;
-        this.y = Math.sin(latLng.getLonRad()) * r;
+    private Vec3d(double x, double y, double z) {
+        this.x = x;
+        this.y = y;
+        this.z = z;
     }
 
     /**
      * Calculate the square of the distance between two 3D coordinates.
      *
-     * @param v The first 3D coordinate.
+     * @param x The first 3D coordinate.
+     * @param y The second 3D coordinate.
+     * @param z The third 3D coordinate.
      * @return The square of the distance between the given points.
      */
-    public double pointSquareDist(double[] v) {
-        return square(x - v[0]) + square(y - v[1]) + square(z - v[2]);
+    private double pointSquareDist(double x, double y, double z) {
+        return square(x - this.x) + square(y - this.y) + square(z - this.z);
+    }
+
+    /**
+     * Encodes a coordinate on the sphere to the corresponding H3 index.
+     *
+     * @param res The desired H3 resolution for the encoding.
+     * @param lat The coordinate latitude in radians.
+     * @param lon The coordinate longitude in radians.
+     * @return The H3 index.
+     */
+    static long geoToH3(int res, double lat, double lon) {
+        final double cosLat = Math.cos(lat);
+        final double z = Math.sin(lat);
+        final double x = Math.cos(lon) * cosLat;
+        final double y = Math.sin(lon) * cosLat;
+        // determine the icosahedron face
+        int face = 0;
+        double sqd = Vec3d.faceCenterPoint[0].pointSquareDist(x, y, z);
+        for (int i = 1; i < Vec3d.faceCenterPoint.length; i++) {
+            final double sqdT = Vec3d.faceCenterPoint[i].pointSquareDist(x, y, z);
+            if (sqdT < sqd) {
+                face = i;
+                sqd = sqdT;
+            }
+        }
+        // cos(r) = 1 - 2 * sin^2(r/2) = 1 - 2 * (sqd / 4) = 1 - sqd/2
+        double r = Math.acos(1 - sqd / 2);
+
+        if (r < Constants.EPSILON) {
+            return FaceIJK.faceIjkToH3(res, face, new CoordIJK(0, 0, 0));
+        }
+
+        // now have face and r, now find CCW theta from CII i-axis
+        double theta = Vec2d.posAngleRads(
+            Vec2d.faceAxesAzRadsCII[face][0] - Vec2d.posAngleRads(faceCenterPoint[face].geoAzimuthRads(x, y, z))
+        );
+
+        // adjust theta for Class III (odd resolutions)
+        if (H3Index.isResolutionClassIII(res)) {
+            theta = Vec2d.posAngleRads(theta - Constants.M_AP7_ROT_RADS);
+        }
+
+        // perform gnomonic scaling of r
+        r = Math.tan(r);
+
+        // scale for current resolution length u
+        r /= Constants.RES0_U_GNOMONIC;
+        for (int i = 0; i < res; i++) {
+            r *= Constants.M_SQRT7;
+        }
+        // we now have (r, theta) in hex2d with theta ccw from x-axes
+        // convert to face and centered IJK coordinates
+        return FaceIJK.faceIjkToH3(res, face, Vec2d.hex2dToCoordIJK(r * Math.cos(theta), r * Math.sin(theta)));
     }
 
     /**
@@ -76,8 +131,67 @@ final class Vec3d {
      * @param x The input number.
      * @return The square of the input number.
      */
-    private double square(double x) {
+    private static double square(double x) {
         return x * x;
+    }
+
+    /**
+     * Determines the azimuth to the provided 3D coordinate.
+     *
+     * @param x The first 3D coordinate.
+     * @param y The second 3D coordinate.
+     * @param z The third 3D coordinate.
+     * @return The azimuth in radians.
+     */
+    double geoAzimuthRads(double x, double y, double z) {
+        // from https://www.movable-type.co.uk/scripts/latlong-vectors.html
+        // N = {0,0,1}
+        // c1 = a×b
+        // c2 = a×N
+        // sinθ = |c1×c2| · sgn(c1×c2 · a)
+        // cosθ = c1·c2
+        // θ = atan2(sinθ, cosθ)
+        final double c1X = this.y * z - this.z * y;
+        final double c1Y = this.z * x - this.x * z;
+        final double c1Z = this.x * y - this.y * x;
+
+        final double c2X = this.y;
+        final double c2Y = -this.x;
+        final double c2Z = 0d;
+
+        final double c1c2X = c1Y * c2Z - c1Z * c2Y;
+        final double c1c2Y = c1Z * c2X - c1X * c2Z;
+        final double c1c2Z = c1X * c2Y - c1Y * c2X;
+
+        final double sign = Math.signum(dotProduct(this.x, this.y, this.z, c1c2X, c1c2Y, c1c2Z));
+        return Math.atan2(sign * magnitude(c1c2X, c1c2Y, c1c2Z), dotProduct(c1X, c1Y, c1Z, c2X, c2Y, c2Z));
+    }
+
+    /**
+     * Calculate the dot product between two 3D coordinates.
+     *
+     * @param x1 The first 3D coordinate from the first set of coordinates.
+     * @param y1 The second 3D coordinate from the first set of coordinates.
+     * @param z1 The third 3D coordinate from the first set of coordinates.
+     * @param x2 The first 3D coordinate from the second set of coordinates.
+     * @param y2 The second 3D coordinate from the second set of coordinates.
+     * @param z2 The third 3D coordinate from the second set of coordinates.
+     * @return The dot product.
+     */
+    private static double dotProduct(double x1, double y1, double z1, double x2, double y2, double z2) {
+        return x1 * x2 + y1 * y2 + z1 * z2;
+    }
+
+    /**
+     * Calculate the magnitude of 3D coordinates.
+     *
+     * @param x The first 3D coordinate.
+     * @param y The second 3D coordinate.
+     * @param z The third 3D coordinate.
+     * @return The magnitude of the provided coordinates.
+     */
+    private static double magnitude(double x, double y, double z) {
+        return Math.sqrt(square(x) + square(y) + square(z));
     }
 
 }

--- a/libs/h3/src/test/java/org/elasticsearch/h3/AzimuthTests.java
+++ b/libs/h3/src/test/java/org/elasticsearch/h3/AzimuthTests.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.elasticsearch.h3;
+
+import org.apache.lucene.spatial3d.geom.GeoPoint;
+import org.apache.lucene.spatial3d.geom.PlanetModel;
+import org.apache.lucene.tests.geo.GeoTestUtil;
+import org.elasticsearch.test.ESTestCase;
+
+public class AzimuthTests extends ESTestCase {
+
+    public void testLatLonVec3d() {
+        final double lat = Math.toRadians(GeoTestUtil.nextLatitude());
+        final double lon = Math.toRadians(GeoTestUtil.nextLongitude());
+        final GeoPoint point = new GeoPoint(PlanetModel.SPHERE, lat, lon);
+        for (int i = 0; i < Vec3d.faceCenterPoint.length; i++) {
+            final double azVec3d = Vec3d.faceCenterPoint[i].geoAzimuthRads(point.x, point.y, point.z);
+            final double azVec2d = Vec2d.faceCenterGeo[i].geoAzimuthRads(point.getLatitude(), point.getLongitude());
+            assertEquals(azVec2d, azVec3d, 1e-14);
+        }
+    }
+}


### PR DESCRIPTION
With this change, we reduce drastically the number of object allocations that happen when computing the h3 cell for a given point. In addition we speed up the computation, in particular by adding the capability of computing the azimuth between two 3d vector so we don't need to transform them back to lat/lon position and saving some expensive trigonometric computations.

Rally test shows a ~20% speed up:

```
|                                                        Metric |       Task |       Baseline |      Contender |        Diff |   Unit |   Diff % |
|--------------------------------------------------------------:|-----------:|---------------:|---------------:|------------:|-------:|---------:|
|                                       Total Young Gen GC time |            |    0.189       |    0.059       |    -0.13    |      s |  -68.78% |
|                                      Total Young Gen GC count |            |   73           |   12           |   -61       |        |  -83.56% |
|                                                Min Throughput | geohexgrid |    0.132743    |    0.161854    |     0.02911 |  ops/s |  +21.93% |
|                                               Mean Throughput | geohexgrid |    0.134395    |    0.164184    |     0.02979 |  ops/s |  +22.16% |
|                                             Median Throughput | geohexgrid |    0.134757    |    0.164622    |     0.02986 |  ops/s |  +22.16% |
|                                                Max Throughput | geohexgrid |    0.1354      |    0.165032    |     0.02963 |  ops/s |  +21.88% |
|                                       50th percentile latency | geohexgrid | 7247.87        | 5989.9         | -1257.97    |     ms |  -17.36% |
|                                       90th percentile latency | geohexgrid | 7438.09        | 6134.77        | -1303.32    |     ms |  -17.52% |
|                                      100th percentile latency | geohexgrid | 7822.38        | 6253.8         | -1568.58    |     ms |  -20.05% |
|                                  50th percentile service time | geohexgrid | 7247.87        | 5989.9         | -1257.97    |     ms |  -17.36% |
|                                  90th percentile service time | geohexgrid | 7438.09        | 6134.77        | -1303.32    |     ms |  -17.52% |
|                                 100th percentile service time | geohexgrid | 7822.38        | 6253.8         | -1568.58    |     ms |  -20.05% |
|                                                    error rate | geohexgrid |    0           |    0           |     0       |      % |    0.00% |


```