### PR TITLE
Fix serialization of resultPosition in EqlSearchRequest

### DIFF
--- a/docs/changelog/91497.yaml
+++ b/docs/changelog/91497.yaml
@@ -1,0 +1,5 @@
+pr: 91497
+summary: Fix serialization of `resultPosition` in `EqlSearchRequest`
+area: EQL
+type: bug
+issues: []

--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/action/EqlSearchRequest.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/action/EqlSearchRequest.java
@@ -123,7 +123,7 @@ public class EqlSearchRequest extends ActionRequest implements IndicesRequest.Re
         if (in.getVersion().before(Version.V_7_10_0)) {
             in.readBoolean();
         }
-        if (versionHasResultPosition(in.getVersion())) {
+        if (in.getVersion().onOrAfter(Version.V_7_17_8)) {
             resultPosition = in.readString();
         }
         if (in.getVersion().onOrAfter(Version.V_7_13_0)) {
@@ -134,16 +134,6 @@ public class EqlSearchRequest extends ActionRequest implements IndicesRequest.Re
         } else {
             runtimeMappings = emptyMap();
         }
-    }
-
-    private boolean versionHasResultPosition(Version version) {
-        if (version.before(Version.V_7_17_8)) {
-            return false;
-        }
-        if (version.onOrAfter(Version.fromString("8.0.0")) && version.before(Version.fromString("8.5.2"))) {
-            return false;
-        }
-        return true;
     }
 
     @Override
@@ -456,7 +446,7 @@ public class EqlSearchRequest extends ActionRequest implements IndicesRequest.Re
         if (out.getVersion().before(Version.V_7_10_0)) {
             out.writeBoolean(true);
         }
-        if (versionHasResultPosition(out.getVersion())) {
+        if (out.getVersion().onOrAfter(Version.V_7_17_8)) {
             out.writeString(resultPosition);
         }
         if (out.getVersion().onOrAfter(Version.V_7_13_0)) {

--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/action/EqlSearchRequest.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/action/EqlSearchRequest.java
@@ -123,6 +123,9 @@ public class EqlSearchRequest extends ActionRequest implements IndicesRequest.Re
         if (in.getVersion().before(Version.V_7_10_0)) {
             in.readBoolean();
         }
+        if (versionHasResultPosition(in.getVersion())) {
+            resultPosition = in.readString();
+        }
         if (in.getVersion().onOrAfter(Version.V_7_13_0)) {
             if (in.readBoolean()) {
                 fetchFields = in.readList(FieldAndFormat::new);
@@ -131,6 +134,16 @@ public class EqlSearchRequest extends ActionRequest implements IndicesRequest.Re
         } else {
             runtimeMappings = emptyMap();
         }
+    }
+
+    private boolean versionHasResultPosition(Version version) {
+        if (version.before(Version.V_7_17_8)) {
+            return false;
+        }
+        if (version.onOrAfter(Version.fromString("8.0.0")) && version.before(Version.fromString("8.5.2"))) {
+            return false;
+        }
+        return true;
     }
 
     @Override
@@ -442,6 +455,9 @@ public class EqlSearchRequest extends ActionRequest implements IndicesRequest.Re
         }
         if (out.getVersion().before(Version.V_7_10_0)) {
             out.writeBoolean(true);
+        }
+        if (versionHasResultPosition(out.getVersion())) {
+            out.writeString(resultPosition);
         }
         if (out.getVersion().onOrAfter(Version.V_7_13_0)) {
             out.writeBoolean(fetchFields != null);

--- a/x-pack/plugin/eql/src/test/java/org/elasticsearch/xpack/eql/action/EqlSearchRequestTests.java
+++ b/x-pack/plugin/eql/src/test/java/org/elasticsearch/xpack/eql/action/EqlSearchRequestTests.java
@@ -73,7 +73,8 @@ public class EqlSearchRequestTests extends AbstractBWCSerializationTestCase<EqlS
                 .query(randomAlphaOfLength(10))
                 .ccsMinimizeRoundtrips(ccsMinimizeRoundtrips)
                 .fetchFields(randomFetchFields)
-                .runtimeMappings(randomRuntimeMappings());
+                .runtimeMappings(randomRuntimeMappings())
+                .resultPosition(randomFrom("tail", "head"));
         } catch (IOException ex) {
             assertNotNull("unexpected IOException " + ex.getCause().getMessage(), ex);
         }
@@ -119,7 +120,7 @@ public class EqlSearchRequestTests extends AbstractBWCSerializationTestCase<EqlS
         mutatedInstance.keepOnCompletion(instance.keepOnCompletion());
         mutatedInstance.fetchFields(version.onOrAfter(Version.V_7_13_0) ? instance.fetchFields() : null);
         mutatedInstance.runtimeMappings(version.onOrAfter(Version.V_7_13_0) ? instance.runtimeMappings() : emptyMap());
-
+        mutatedInstance.resultPosition(version.onOrAfter(Version.V_7_17_8) ? instance.resultPosition() : "tail");
         return mutatedInstance;
     }
 }


### PR DESCRIPTION
EqlSearchRequest did not send `resultPosition`.
This PR fixes this situation, with particular attention to backward and forward compatibility (see comments below)