### PR TITLE
Fix testNoRebalanceOnRollingRestart

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/recovery/FullRollingRestartIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/recovery/FullRollingRestartIT.java
@@ -199,7 +199,7 @@ public class FullRollingRestartIT extends ESIntegTestCase {
         ClusterState state = client().admin().cluster().prepareState().get().getState();
         RecoveryResponse recoveryResponse = client().admin().indices().prepareRecoveries("test").get();
         for (RecoveryState recoveryState : recoveryResponse.shardRecoveryStates().get("test")) {
-            assertTrue(
+            assertNotEquals(
                 "relocated "
                     + recoveryState.getShardId()
                     + " from: "
@@ -208,16 +208,17 @@ public class FullRollingRestartIT extends ESIntegTestCase {
                     + recoveryState.getTargetNode()
                     + "\n"
                     + state,
-                recoveryState.getRecoverySource().getType() != RecoverySource.Type.PEER || recoveryState.getPrimary() == false
+                recoveryState.getRecoverySource().getType(),
+                RecoverySource.Type.PEER
             );
         }
         internalCluster().restartRandomDataNode();
         ensureGreen();
-        client().admin().cluster().prepareState().get().getState();
+        client().admin().cluster().prepareState().get();
 
         recoveryResponse = client().admin().indices().prepareRecoveries("test").get();
         for (RecoveryState recoveryState : recoveryResponse.shardRecoveryStates().get("test")) {
-            assertTrue(
+            assertNotEquals(
                 "relocated "
                     + recoveryState.getShardId()
                     + " from: "
@@ -226,7 +227,8 @@ public class FullRollingRestartIT extends ESIntegTestCase {
                     + recoveryState.getTargetNode()
                     + "-- \nbefore: \n"
                     + state,
-                recoveryState.getRecoverySource().getType() != RecoverySource.Type.PEER || recoveryState.getPrimary() == false
+                recoveryState.getRecoverySource().getType(),
+                RecoverySource.Type.PEER
             );
         }
     }

--- a/server/src/internalClusterTest/java/org/elasticsearch/recovery/FullRollingRestartIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/recovery/FullRollingRestartIT.java
@@ -171,13 +171,12 @@ public class FullRollingRestartIT extends ESIntegTestCase {
         }
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/91441")
     public void testNoRebalanceOnRollingRestart() throws Exception {
         // see https://github.com/elastic/elasticsearch/issues/14387
         internalCluster().startMasterOnlyNode(Settings.EMPTY);
         internalCluster().startDataOnlyNodes(3);
         /**
-         * We start 3 nodes and a dedicated master. Restart on of the data-nodes and ensure that we got no relocations.
+         * We start 3 nodes and a dedicated master. Restart one of the data-nodes and ensure that we got no relocations.
          * Yet we have 6 shards 0 replica so that means if the restarting node comes back both other nodes are subject
          * to relocating to the restarting node since all had 2 shards and now one node has nothing allocated.
          * We have a fix for this to wait until we have allocated unallocated shards now so this shouldn't happen.
@@ -201,7 +200,14 @@ public class FullRollingRestartIT extends ESIntegTestCase {
         RecoveryResponse recoveryResponse = client().admin().indices().prepareRecoveries("test").get();
         for (RecoveryState recoveryState : recoveryResponse.shardRecoveryStates().get("test")) {
             assertTrue(
-                "relocated from: " + recoveryState.getSourceNode() + " to: " + recoveryState.getTargetNode() + "\n" + state,
+                "relocated "
+                    + recoveryState.getShardId()
+                    + " from: "
+                    + recoveryState.getSourceNode()
+                    + " to: "
+                    + recoveryState.getTargetNode()
+                    + "\n"
+                    + state,
                 recoveryState.getRecoverySource().getType() != RecoverySource.Type.PEER || recoveryState.getPrimary() == false
             );
         }
@@ -212,7 +218,14 @@ public class FullRollingRestartIT extends ESIntegTestCase {
         recoveryResponse = client().admin().indices().prepareRecoveries("test").get();
         for (RecoveryState recoveryState : recoveryResponse.shardRecoveryStates().get("test")) {
             assertTrue(
-                "relocated from: " + recoveryState.getSourceNode() + " to: " + recoveryState.getTargetNode() + "-- \nbefore: \n" + state,
+                "relocated "
+                    + recoveryState.getShardId()
+                    + " from: "
+                    + recoveryState.getSourceNode()
+                    + " to: "
+                    + recoveryState.getTargetNode()
+                    + "-- \nbefore: \n"
+                    + state,
                 recoveryState.getRecoverySource().getType() != RecoverySource.Type.PEER || recoveryState.getPrimary() == false
             );
         }

--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/allocator/DesiredBalanceComputer.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/allocator/DesiredBalanceComputer.java
@@ -32,7 +32,6 @@ import java.util.Set;
 import java.util.TreeMap;
 import java.util.TreeSet;
 import java.util.function.Predicate;
-import java.util.stream.Stream;
 
 import static java.util.stream.Collectors.toSet;
 import static java.util.stream.Collectors.toUnmodifiableSet;
@@ -321,9 +320,7 @@ public class DesiredBalanceComputer {
     }
 
     private static Set<ShardRouting> getIgnoredShardsWithDiscardedAllocationStatus(List<ShardRouting> ignoredShards) {
-        return ignoredShards.stream()
-            .flatMap(shardRouting -> Stream.of(shardRouting, discardAllocationStatus(shardRouting)))
-            .collect(toUnmodifiableSet());
+        return ignoredShards.stream().map(DesiredBalanceComputer::discardAllocationStatus).collect(toUnmodifiableSet());
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/allocator/DesiredBalanceInput.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/allocator/DesiredBalanceInput.java
@@ -9,13 +9,9 @@
 package org.elasticsearch.cluster.routing.allocation.allocator;
 
 import org.elasticsearch.cluster.routing.ShardRouting;
-import org.elasticsearch.cluster.routing.UnassignedInfo;
 import org.elasticsearch.cluster.routing.allocation.RoutingAllocation;
 
-import java.util.Set;
-import java.util.stream.Stream;
-
-import static java.util.stream.Collectors.toUnmodifiableSet;
+import java.util.List;
 
 /**
  * The input to the desired balance computation.
@@ -26,45 +22,13 @@ import static java.util.stream.Collectors.toUnmodifiableSet;
  * @param routingAllocation a copy of (the immutable parts of) the context for the allocation decision process
  * @param ignoredShards     a list of the shards for which earlier allocators have claimed responsibility
  */
-public record DesiredBalanceInput(long index, RoutingAllocation routingAllocation, Set<ShardRouting> ignoredShards) {
+public record DesiredBalanceInput(long index, RoutingAllocation routingAllocation, List<ShardRouting> ignoredShards) {
 
     public static DesiredBalanceInput create(long index, RoutingAllocation routingAllocation) {
         return new DesiredBalanceInput(
             index,
             routingAllocation.immutableClone(),
-            getIgnoredShardsWithDiscardedAllocationStatus(routingAllocation)
-        );
-    }
-
-    private static Set<ShardRouting> getIgnoredShardsWithDiscardedAllocationStatus(RoutingAllocation routingAllocation) {
-        return routingAllocation.routingNodes()
-            .unassigned()
-            .ignored()
-            .stream()
-            .flatMap(
-                shardRouting -> Stream.of(
-                    shardRouting,
-                    shardRouting.updateUnassigned(discardAllocationStatus(shardRouting.unassignedInfo()), shardRouting.recoverySource())
-                )
-            )
-            .collect(toUnmodifiableSet());
-    }
-
-    /**
-     * AllocationStatus is discarded as it might come from GatewayAllocator and not be present in corresponding routing table
-     */
-    private static UnassignedInfo discardAllocationStatus(UnassignedInfo info) {
-        return new UnassignedInfo(
-            info.getReason(),
-            info.getMessage(),
-            info.getFailure(),
-            info.getNumFailedAllocations(),
-            info.getUnassignedTimeInNanos(),
-            info.getUnassignedTimeInMillis(),
-            info.isDelayed(),
-            UnassignedInfo.AllocationStatus.NO_ATTEMPT,
-            info.getFailedNodeIds(),
-            info.getLastAllocatedNodeId()
+            List.copyOf(routingAllocation.routingNodes().unassigned().ignored())
         );
     }
 }


### PR DESCRIPTION
This test would sometimes fail to keep the shards on their original nodes because the ignored `ShardRouting` objects had a different `allocationStatus` from the ones in the routing table. With this commit we fix the status at `NO_ATTEMPT` to avoid the problem.

Closes #91441