### PR TITLE
[DOCS] Adds KNN object sub-properties individually to common params

### DIFF
--- a/docs/reference/rest-api/common-parms.asciidoc
+++ b/docs/reference/rest-api/common-parms.asciidoc
@@ -550,35 +550,36 @@ end::index-template[]
 
 tag::knn[]
 Defines the <<approximate-knn,kNN>> query to run.
-+
-.Properties of `knn` object
-[%collapsible%open]
-====
-`field`::
-(Required, string) The name of the vector field to search against. Must be a
-<<index-vectors-knn-search, `dense_vector` field with indexing enabled>>.
-
-`query_vector`::
-(Required, array of floats) Query vector. Must have the same number of
-dimensions as the vector field you are searching against.
-
-`k`::
-(Required, integer) Number of nearest neighbors to return as top hits. This
-value must be less than `num_candidates`.
-
-`num_candidates`::
-(Required, integer) The number of nearest neighbor candidates to consider per
-shard. Cannot exceed 10,000. {es} collects `num_candidates` results from each
-shard, then merges them to find the top `k` results. Increasing
-`num_candidates` tends to improve the accuracy of the final `k` results.
-
-`filter`::
-(Optional, <<query-dsl,Query DSL object>>) Query to filter the documents that
-can match. The kNN search will return the top `k` documents that also match
-this filter. The value can be a single query or a list of queries. If `filter`
-is not provided, all documents are allowed to match.
-====
 end::knn[]
+
+tag::knn-field[]
+The name of the vector field to search against. Must be a
+<<index-vectors-knn-search, `dense_vector` field with indexing enabled>>.
+end::knn-field[]
+
+tag::knn-filter[]
+Query to filter the documents that can match. The kNN search will return the top 
+`k` documents that also match this filter. The value can be a single query or a 
+list of queries. If `filter` is not provided, all documents are allowed to 
+match.
+end::knn-filter[]
+
+tag::knn-k[]
+Number of nearest neighbors to return as top hits. This value must be less than 
+`num_candidates`.
+end::knn-k[]
+
+tag::knn-num-candidates[]
+The number of nearest neighbor candidates to consider per shard. Cannot exceed 
+10,000. {es} collects `num_candidates` results from each shard, then merges them 
+to find the top `k` results. Increasing `num_candidates` tends to improve the 
+accuracy of the final `k` results.
+end::knn-num-candidates[]
+
+tag::knn-query-vector[]
+Query vector. Must have the same number of dimensions as the vector field you 
+are searching against.
+end::knn-query-vector[]
 
 tag::lenient[]
 `lenient`::

--- a/docs/reference/search/knn-search.asciidoc
+++ b/docs/reference/search/knn-search.asciidoc
@@ -97,6 +97,10 @@ include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=routing]
 [[knn-search-api-request-body]]
 ==== {api-request-body-title}
 
+`filter`::
+(Optional, <<query-dsl,Query DSL object>>)
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=knn-filter]
+
 `knn`::
 (Required, object) 
 include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=knn]
@@ -107,10 +111,6 @@ include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=knn]
 `field`::
 (Required, string) 
 include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=knn-field]
-
-`filter`::
-(Optional, <<query-dsl,Query DSL object>>)
-include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=knn-filter]
 
 `k`::
 (Required, integer) 
@@ -124,7 +124,6 @@ include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=knn-num-candidates]
 (Required, array of floats)
 include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=knn-query-vector]
 ====
-
 
 include::{es-repo-dir}/search/search.asciidoc[tag=docvalue-fields-def]
 include::{es-repo-dir}/search/search.asciidoc[tag=fields-param-def]

--- a/docs/reference/search/knn-search.asciidoc
+++ b/docs/reference/search/knn-search.asciidoc
@@ -100,6 +100,30 @@ include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=routing]
 `knn`::
 (Required, object) 
 include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=knn]
++
+.Properties of `knn` object
+[%collapsible%open]
+====
+`field`::
+(Required, string) 
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=knn-field]
+
+`filter`::
+(Optional, <<query-dsl,Query DSL object>>)
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=knn-filter]
+
+`k`::
+(Required, integer) 
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=knn-k]
+
+`num_candidates`::
+(Required, integer) 
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=knn-num-candidates]
+
+`query_vector`::
+(Required, array of floats)
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=knn-query-vector]
+====
 
 
 include::{es-repo-dir}/search/search.asciidoc[tag=docvalue-fields-def]

--- a/docs/reference/search/search.asciidoc
+++ b/docs/reference/search/search.asciidoc
@@ -485,6 +485,30 @@ experimental::[]
 `knn`::
 (Optional, object) 
 include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=knn]
++
+.Properties of `knn` object
+[%collapsible%open]
+====
+`field`::
+(Required, string) 
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=knn-field]
+
+`filter`::
+(Optional, <<query-dsl,Query DSL object>>)
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=knn-filter]
+
+`k`::
+(Required, integer) 
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=knn-k]
+
+`num_candidates`::
+(Required, integer) 
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=knn-num-candidates]
+
+`query_vector`::
+(Required, array of floats)
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=knn-query-vector]
+====
 
 [[search-api-min-score]]
 `min_score`::

--- a/docs/reference/search/semantic-search.asciidoc
+++ b/docs/reference/search/semantic-search.asciidoc
@@ -75,6 +75,26 @@ include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=model-id]
 `knn`::
 (Required, object)
 include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=knn]
++
+.Properties of `knn` object
+[%collapsible%open]
+====
+`field`::
+(Required, string) 
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=knn-field]
+
+`filter`::
+(Optional, <<query-dsl,Query DSL object>>)
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=knn-filter]
+
+`k`::
+(Required, integer) 
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=knn-k]
+
+`num_candidates`::
+(Required, integer) 
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=knn-num-candidates]
+====
 
 `query`::
 (Optional, <<query-dsl,query object>>) Defines the search definition using the


### PR DESCRIPTION
## Overview

This PR:
* adds the sub-properties of the kNN object individually to the common parameters so that they can be referenced separately,
* removes `query_vector` kNN sub-property from the semantic search API docs.

### Preview

* [Semantic search](https://elasticsearch_91503.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/semantic-search-api.html)
* [kNN search](https://elasticsearch_91503.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/knn-search-api.html)
* [Search](https://elasticsearch_91503.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/search-search.html)