### PR TITLE
SLM uneahlthy policies diagnosis recommends correct URL in action

### DIFF
--- a/docs/changelog/91506.yaml
+++ b/docs/changelog/91506.yaml
@@ -1,0 +1,5 @@
+pr: 91506
+summary: SLM uneahlthy policies diagnosis recommends correct URL in action
+area: Health
+type: bug
+issues: []

--- a/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/slm/SlmHealthIndicatorService.java
+++ b/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/slm/SlmHealthIndicatorService.java
@@ -159,7 +159,7 @@ public class SlmHealthIndicatorService implements HealthIndicatorService {
                     : "An automated snapshot policy is unhealthy:\n") + unhealthyPolicyCauses;
 
                 String unhealthyPolicyActions = unhealthyPolicies.stream()
-                    .map(policy -> "- /_slm/policy/" + policy.getName() + "?human")
+                    .map(policy -> "- /_slm/policy/" + policy.getPolicy().getId() + "?human")
                     .collect(Collectors.joining("\n"));
                 String action = "Check the snapshot lifecycle "
                     + (unhealthyPolicies.size() > 1 ? "policies" : "policy")

--- a/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/slm/SlmHealthIndicatorServiceTests.java
+++ b/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/slm/SlmHealthIndicatorServiceTests.java
@@ -223,7 +223,7 @@ public class SlmHealthIndicatorServiceTests extends ESTestCase {
                                     + "] repeated failures without successful execution since ["
                                     + FORMATTER.formatMillis(execTime)
                                     + "]",
-                                "Check the snapshot lifecycle policy for detailed failure info:\n- /_slm/policy/test-policy?human"
+                                "Check the snapshot lifecycle policy for detailed failure info:\n- /_slm/policy/policy-id?human"
                             ),
                             List.of(new Diagnosis.Resource(Type.SLM_POLICY, List.of("test-policy")))
                         )
@@ -303,7 +303,7 @@ public class SlmHealthIndicatorServiceTests extends ESTestCase {
         return Map.of(
             "test-policy",
             SnapshotLifecyclePolicyMetadata.builder()
-                .setPolicy(new SnapshotLifecyclePolicy("id", "test-policy", "", "test-repository", null, null))
+                .setPolicy(new SnapshotLifecyclePolicy("policy-id", "test-policy", "", "test-repository", null, null))
                 .setVersion(1L)
                 .setModifiedDate(System.currentTimeMillis())
                 .setLastSuccess(lastSuccess)


### PR DESCRIPTION
The SLM indicator advises checking the unhealthy SLM policy to get more details about the health condition.
The current message is something along the lines of
```
Check the snapshot lifecycle policy for detailed failure info:
- /_slm/policy/<cloud-snapshot-{now/d}>?human
```
This message uses the policy name (ie. `<cloud-snapshot-{now/d}>`) as opposed to the policy id (ie. `/_slm/policy/cloud-snapshot-policy?human`).

This changes the diagnosis to advise the correct URL using the policy id.