### PR TITLE
EQL: Refine bwc version checks on EqlSearchRequest

### DIFF
--- a/docs/changelog/91510.yaml
+++ b/docs/changelog/91510.yaml
@@ -1,0 +1,5 @@
+pr: 91510
+summary: Refine bwc version checks on `EqlSearchRequest`
+area: EQL
+type: bug
+issues: []

--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/action/EqlSearchRequest.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/action/EqlSearchRequest.java
@@ -118,7 +118,7 @@ public class EqlSearchRequest extends ActionRequest implements IndicesRequest.Re
         this.waitForCompletionTimeout = in.readOptionalTimeValue();
         this.keepAlive = in.readOptionalTimeValue();
         this.keepOnCompletion = in.readBoolean();
-        if (in.getVersion().onOrAfter(Version.V_8_0_0)) {
+        if (in.getVersion().onOrAfter(Version.V_7_17_8)) {
             resultPosition = in.readString();
         }
         if (in.getVersion().onOrAfter(Version.V_7_13_0)) {
@@ -436,7 +436,7 @@ public class EqlSearchRequest extends ActionRequest implements IndicesRequest.Re
         out.writeOptionalTimeValue(waitForCompletionTimeout);
         out.writeOptionalTimeValue(keepAlive);
         out.writeBoolean(keepOnCompletion);
-        if (out.getVersion().onOrAfter(Version.V_8_0_0)) {
+        if (out.getVersion().onOrAfter(Version.V_7_17_8)) {
             out.writeString(resultPosition);
         }
         if (out.getVersion().onOrAfter(Version.V_7_13_0)) {

--- a/x-pack/plugin/eql/src/test/java/org/elasticsearch/xpack/eql/action/EqlSearchRequestTests.java
+++ b/x-pack/plugin/eql/src/test/java/org/elasticsearch/xpack/eql/action/EqlSearchRequestTests.java
@@ -132,7 +132,7 @@ public class EqlSearchRequestTests extends AbstractBWCSerializationTestCase<EqlS
         mutatedInstance.keepOnCompletion(instance.keepOnCompletion());
         mutatedInstance.fetchFields(version.onOrAfter(Version.V_7_13_0) ? instance.fetchFields() : null);
         mutatedInstance.runtimeMappings(version.onOrAfter(Version.V_7_13_0) ? instance.runtimeMappings() : emptyMap());
-        mutatedInstance.resultPosition(version.onOrAfter(Version.V_8_0_0) ? instance.resultPosition() : "tail");
+        mutatedInstance.resultPosition(version.onOrAfter(Version.V_7_17_8) ? instance.resultPosition() : "tail");
 
         return mutatedInstance;
     }


### PR DESCRIPTION
Evolution of https://github.com/elastic/elasticsearch/pull/91402 
taking into consideration that https://github.com/elastic/elasticsearch/pull/91497 will allow v `7.17.8` to properly handle 'resultPosition'