### PR TITLE
[7.17] Don't start docker fixtures when resolving test runtime classpath (#91476)

### DIFF
--- a/x-pack/qa/saml-idp-tests/build.gradle
+++ b/x-pack/qa/saml-idp-tests/build.gradle
@@ -6,7 +6,7 @@ apply plugin: 'elasticsearch.internal-java-rest-test'
 apply plugin: 'elasticsearch.test.fixtures'
 
 dependencies {
-  javaRestTestImplementation(testArtifact(project(xpackModule('core'))))
+  javaRestTestImplementation testArtifact(project(xpackModule('core')))
   javaRestTestImplementation "com.google.jimfs:jimfs:${versions.jimfs}"
 }
 
@@ -28,10 +28,8 @@ tasks.register("copyIdpFiles", Sync) {
   }
 }
 
-project.sourceSets.javaRestTest.output.dir(outputDir, builtBy: [copyIdpFiles])
-
 tasks.named("javaRestTest").configure {
-  dependsOn tasks.named("copyIdpFiles")
+  classpath += files(tasks.named("copyIdpFiles"))
   onlyIf { idpFixtureProject.postProcessFixture.state.skipped == false }
 }
 


### PR DESCRIPTION
Backports the following commits to 7.17:
 - Don't start docker fixtures when resolving test runtime classpath (#91476)