### PR TITLE
Fix for SearchableSnapshotActionIT::testSearchableSnapshotForceMergesIndexToOneSegment

### DIFF
--- a/x-pack/plugin/ilm/qa/multi-node/src/javaRestTest/java/org/elasticsearch/xpack/TimeSeriesRestDriver.java
+++ b/x-pack/plugin/ilm/qa/multi-node/src/javaRestTest/java/org/elasticsearch/xpack/TimeSeriesRestDriver.java
@@ -362,7 +362,7 @@ public final class TimeSeriesRestDriver {
     }
 
     @SuppressWarnings("unchecked")
-    public static Integer getNumberOfSegments(RestClient client, String index) throws IOException {
+    public static Integer getNumberOfPrimarySegments(RestClient client, String index) throws IOException {
         Response response = client.performRequest(new Request("GET", index + "/_segments"));
         XContentType entityContentType = XContentType.fromMediaType(response.getEntity().getContentType().getValue());
         final Map<String, Object> originalResponseEntity = XContentHelper.convertToMap(

--- a/x-pack/plugin/ilm/qa/multi-node/src/javaRestTest/java/org/elasticsearch/xpack/TimeSeriesRestDriver.java
+++ b/x-pack/plugin/ilm/qa/multi-node/src/javaRestTest/java/org/elasticsearch/xpack/TimeSeriesRestDriver.java
@@ -45,7 +45,9 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
 
 import static java.util.Collections.singletonMap;
 import static org.elasticsearch.cluster.metadata.IndexMetadata.SETTING_NUMBER_OF_SHARDS;
@@ -363,16 +365,34 @@ public final class TimeSeriesRestDriver {
     public static Integer getNumberOfSegments(RestClient client, String index) throws IOException {
         Response response = client.performRequest(new Request("GET", index + "/_segments"));
         XContentType entityContentType = XContentType.fromMediaType(response.getEntity().getContentType().getValue());
-        Map<String, Object> responseEntity = XContentHelper.convertToMap(
+        final Map<String, Object> originalResponseEntity = XContentHelper.convertToMap(
             entityContentType.xContent(),
             response.getEntity().getContent(),
             false
         );
-        responseEntity = (Map<String, Object>) responseEntity.get("indices");
+        if (logger.isTraceEnabled()) {
+            logger.trace(
+                "segments response for {}: {}",
+                index,
+                originalResponseEntity.keySet()
+                    .stream()
+                    .map(key -> key + "=" + originalResponseEntity.get(key))
+                    .collect(Collectors.joining(", ", "{", "}"))
+            );
+        }
+        Map<String, Object> responseEntity = (Map<String, Object>) originalResponseEntity.get("indices");
         responseEntity = (Map<String, Object>) responseEntity.get(index);
         responseEntity = (Map<String, Object>) responseEntity.get("shards");
         List<Map<String, Object>> shards = (List<Map<String, Object>>) responseEntity.get("0");
-        return (Integer) shards.get(0).get("num_search_segments");
+        // We want to mamke sure to get the primary shard because there is a chance the replica doesn't have data yet:
+        Optional<Map<String, Object>> shardOptional = shards.stream()
+            .filter(shard -> ((Map<String, Object>) shard.get("routing")).get("primary").equals(true))
+            .findAny();
+        if (shardOptional.isPresent()) {
+            return (Integer) shardOptional.get().get("num_search_segments");
+        } else {
+            throw new RuntimeException("No primary shard found for index " + index);
+        }
     }
 
     public static void updatePolicy(RestClient client, String indexName, String policy) throws IOException {

--- a/x-pack/plugin/ilm/qa/multi-node/src/javaRestTest/java/org/elasticsearch/xpack/ilm/TimeSeriesLifecycleActionsIT.java
+++ b/x-pack/plugin/ilm/qa/multi-node/src/javaRestTest/java/org/elasticsearch/xpack/ilm/TimeSeriesLifecycleActionsIT.java
@@ -63,7 +63,7 @@ import static org.elasticsearch.xpack.TimeSeriesRestDriver.createIndexWithSettin
 import static org.elasticsearch.xpack.TimeSeriesRestDriver.createNewSingletonPolicy;
 import static org.elasticsearch.xpack.TimeSeriesRestDriver.createSnapshotRepo;
 import static org.elasticsearch.xpack.TimeSeriesRestDriver.explainIndex;
-import static org.elasticsearch.xpack.TimeSeriesRestDriver.getNumberOfSegments;
+import static org.elasticsearch.xpack.TimeSeriesRestDriver.getNumberOfPrimarySegments;
 import static org.elasticsearch.xpack.TimeSeriesRestDriver.getOnlyIndexSettings;
 import static org.elasticsearch.xpack.TimeSeriesRestDriver.getSnapshotState;
 import static org.elasticsearch.xpack.TimeSeriesRestDriver.getStepKeyForIndex;
@@ -487,7 +487,7 @@ public class TimeSeriesLifecycleActionsIT extends ESRestTestCase {
             client().performRequest(request);
         }
 
-        assertThat(getNumberOfSegments(client(), index), greaterThanOrEqualTo(1));
+        assertThat(getNumberOfPrimarySegments(client(), index), greaterThanOrEqualTo(1));
         createNewSingletonPolicy(client(), policy, "warm", new ForceMergeAction(1, codec));
         updatePolicy(client(), index, policy);
 

--- a/x-pack/plugin/ilm/qa/multi-node/src/javaRestTest/java/org/elasticsearch/xpack/ilm/actions/SearchableSnapshotActionIT.java
+++ b/x-pack/plugin/ilm/qa/multi-node/src/javaRestTest/java/org/elasticsearch/xpack/ilm/actions/SearchableSnapshotActionIT.java
@@ -54,7 +54,7 @@ import static org.elasticsearch.xpack.TimeSeriesRestDriver.createNewSingletonPol
 import static org.elasticsearch.xpack.TimeSeriesRestDriver.createPolicy;
 import static org.elasticsearch.xpack.TimeSeriesRestDriver.createSnapshotRepo;
 import static org.elasticsearch.xpack.TimeSeriesRestDriver.explainIndex;
-import static org.elasticsearch.xpack.TimeSeriesRestDriver.getNumberOfSegments;
+import static org.elasticsearch.xpack.TimeSeriesRestDriver.getNumberOfPrimarySegments;
 import static org.elasticsearch.xpack.TimeSeriesRestDriver.getStepKeyForIndex;
 import static org.elasticsearch.xpack.TimeSeriesRestDriver.indexDocument;
 import static org.elasticsearch.xpack.TimeSeriesRestDriver.rolloverMaxOneDocCondition;
@@ -138,7 +138,7 @@ public class SearchableSnapshotActionIT extends ESRestTestCase {
         }
 
         String backingIndexName = DataStream.getDefaultBackingIndexName(dataStream, 1L);
-        Integer preLifecycleBackingIndexSegments = getNumberOfSegments(client(), backingIndexName);
+        Integer preLifecycleBackingIndexSegments = getNumberOfPrimarySegments(client(), backingIndexName);
         assertThat(preLifecycleBackingIndexSegments, greaterThanOrEqualTo(1));
 
         // rolling over the data stream so we can apply the searchable snapshot policy to a backing index that's not the write index
@@ -147,7 +147,7 @@ public class SearchableSnapshotActionIT extends ESRestTestCase {
         updateIndexSettings(dataStream, Settings.builder().put(LifecycleSettings.LIFECYCLE_NAME, policy));
         assertTrue(waitUntil(() -> {
             try {
-                Integer numberOfSegments = getNumberOfSegments(client(), backingIndexName);
+                Integer numberOfSegments = getNumberOfPrimarySegments(client(), backingIndexName);
                 logger.info("index {} has {} segments", backingIndexName, numberOfSegments);
                 // this is a loose assertion here as forcemerge is best effort
                 if (preLifecycleBackingIndexSegments > 1) {


### PR DESCRIPTION
In `SearchableSnapshotActionIT::testSearchableSnapshotForceMergesIndexToOneSegment` we add some documents into the datastream, and then assert that the first shard we find has > 0 segments. This occasionally failed if two things happened:

1. The segments API call happened to order the replica shard before the primary shard in its list of shards
2. The replica shard was not yet allocated at the time indexing occurred and it does not yet have the data

This PR makes sure that we only check the segment count for the primary shard. It also adds trace logging for the segment response in case that is useful for tracking down problems in the future (it was useful for this).
Closes #91460