### PR TITLE
Fix incorrect variable placeholder for Strings.format calls

### DIFF
--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/precommit/JavaModulePrecommitTask.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/precommit/JavaModulePrecommitTask.java
@@ -137,7 +137,7 @@ public class JavaModulePrecommitTask extends PrecommitTask {
                             throw new GradleException(
                                 String.format(
                                     Locale.ROOT,
-                                    "Expected provides {} in module %s with provides {}.",
+                                    "Expected provides %s in module %s with provides %s.",
                                     service,
                                     mref.descriptor().name(),
                                     mref.descriptor().provides()

--- a/server/src/main/java/org/elasticsearch/action/support/ActiveShardsObserver.java
+++ b/server/src/main/java/org/elasticsearch/action/support/ActiveShardsObserver.java
@@ -69,7 +69,7 @@ public enum ActiveShardsObserver {
                 public void onClusterServiceClose() {
                     logger.debug(
                         () -> format(
-                            "[{}] cluster service closed while waiting for enough shards to be started.",
+                            "[%s] cluster service closed while waiting for enough shards to be started.",
                             Arrays.toString(indexNames)
                         )
                     );

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataIndexStateService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataIndexStateService.java
@@ -249,7 +249,7 @@ public class MetadataIndexStateService {
                                     if (shardsAcknowledged == false) {
                                         logger.debug(
                                             () -> format(
-                                                "[{}] indices closed, but the operation timed out while "
+                                                "[%s] indices closed, but the operation timed out while "
                                                     + "waiting for enough shards to be started.",
                                                 Arrays.toString(waitForIndices)
                                             )
@@ -916,7 +916,7 @@ public class MetadataIndexStateService {
                         if (shardsAcknowledged == false) {
                             logger.debug(
                                 () -> format(
-                                    "[{}] indices opened, but the operation timed out while waiting for enough shards to be started.",
+                                    "[%s] indices opened, but the operation timed out while waiting for enough shards to be started.",
                                     Arrays.toString(indexNames)
                                 )
                             );

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportStartTrainedModelDeploymentAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportStartTrainedModelDeploymentAction.java
@@ -290,7 +290,7 @@ public class TransportStartTrainedModelDeploymentAction extends TransportMasterN
         Exception exception,
         ActionListener<CreateTrainedModelAssignmentAction.Response> listener
     ) {
-        logger.trace(() -> format("[{}] Deleting failed deployment", modelId), exception);
+        logger.trace(() -> format("[%s] Deleting failed deployment", modelId), exception);
         trainedModelAssignmentService.deleteModelAssignment(modelId, ActionListener.wrap(pTask -> listener.onFailure(exception), e -> {
             logger.error(
                 () -> format(

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/assignment/TrainedModelAssignmentClusterService.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/assignment/TrainedModelAssignmentClusterService.java
@@ -228,7 +228,7 @@ public class TrainedModelAssignmentClusterService implements ClusterStateListene
             if (routedNodeIdsToRemove.isEmpty() == false) {
                 logger.debug(
                     () -> format(
-                        "[%s] removing routing entries to nodes {} because they have been removed or are shutting down",
+                        "[%s] removing routing entries to nodes %s because they have been removed or are shutting down",
                         assignment.getModelId(),
                         routedNodeIdsToRemove
                     )

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/ApiKeyService.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/ApiKeyService.java
@@ -534,7 +534,7 @@ public class ApiKeyService {
 
         final List<RoleDescriptor> keyRoles = request.getRoleDescriptors();
         if (keyRoles != null) {
-            logger.trace(() -> format("Building API key doc with updated role descriptors [{}]", keyRoles));
+            logger.trace(() -> format("Building API key doc with updated role descriptors [%s]", keyRoles));
             addRoleDescriptors(builder, keyRoles);
         } else {
             assert currentApiKeyDoc.roleDescriptorsBytes != null;
@@ -551,7 +551,7 @@ public class ApiKeyService {
             ) == false : "API key doc to be updated contains reserved metadata";
         final Map<String, Object> metadata = request.getMetadata();
         if (metadata != null) {
-            logger.trace(() -> format("Building API key doc with updated metadata [{}]", metadata));
+            logger.trace(() -> format("Building API key doc with updated metadata [%s]", metadata));
             builder.field("metadata_flattened", metadata);
         } else {
             builder.rawField(
@@ -1507,7 +1507,7 @@ public class ApiKeyService {
 
             @Override
             public void onFailure(Exception e) {
-                logger.error(() -> format("unable to clear API key cache [{}]", clearApiKeyCacheRequest.cacheName()), e);
+                logger.error(() -> format("unable to clear API key cache [%s]", clearApiKeyCacheRequest.cacheName()), e);
                 listener.onFailure(new ElasticsearchException("clearing the API key cache failed; please clear the caches manually", e));
             }
         });

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authz/RBACEngine.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authz/RBACEngine.java
@@ -513,7 +513,7 @@ public class RBACEngine implements AuthorizationEngine {
         final Role userRole = ((RBACAuthorizationInfo) authorizationInfo).getRole();
         logger.trace(
             () -> format(
-                "Check whether role [{}] has privileges [{}]",
+                "Check whether role [%s] has privileges [%s]",
                 Strings.arrayToCommaDelimitedString(userRole.names()),
                 privilegesToCheck
             )
@@ -586,7 +586,7 @@ public class RBACEngine implements AuthorizationEngine {
             .map(RoleDescriptor.ApplicationResourcePrivileges::getApplication)
             .collect(Collectors.toSet());
         for (String applicationName : applicationNames) {
-            logger.debug(() -> format("Checking privileges for application [{}]", applicationName));
+            logger.debug(() -> format("Checking privileges for application [%s]", applicationName));
             final ResourcePrivilegesMap.Builder resourcePrivilegesMapBuilder = privilegesToCheck.runDetailedCheck()
                 ? ResourcePrivilegesMap.builder()
                 : null;


### PR DESCRIPTION
The curly bracket placeholder works for LoggerMessageFormat.format and ParameterizedMessage.format, but Not for Strings.format which requires Java's string format syntax. This PR fixes the incorrect usages.

Relates: #86549, #87924

PS: I labelled this `>non-issue` because the changes are all for debug/trace level loggings.