### PR TITLE
Avoid potential unsupported operation exception in doc bitset cache (#91490)

### DIFF
--- a/docs/changelog/91490.yaml
+++ b/docs/changelog/91490.yaml
@@ -1,0 +1,5 @@
+pr: 91490
+summary: Avoid potential unsupported operation exception in doc bitset cache
+area: Authorization
+type: bug
+issues: []

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/accesscontrol/DocumentSubsetBitsetCache.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/accesscontrol/DocumentSubsetBitsetCache.java
@@ -43,6 +43,7 @@ import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutionException;
@@ -179,7 +180,7 @@ public final class DocumentSubsetBitsetCache implements IndexReader.ClosedListen
                 // it's possible for the key to be back in the cache if it was immediately repopulated after it was evicted, so check
                 if (bitsetCache.get(bitsetKey) == null) {
                     // key is no longer in the cache, make sure it is no longer in the lookup map either.
-                    keysByIndex.getOrDefault(indexKey, Set.of()).remove(bitsetKey);
+                    Optional.ofNullable(keysByIndex.get(indexKey)).ifPresent(set -> set.remove(bitsetKey));
                 }
             }
         });


### PR DESCRIPTION
This PR replaces Set.of() with explicit null handling so that remove does not get called against an immutableSet.

Backport: #91490