### PR TITLE
[8.5] EQL: remove version limitations for CCS (#91409)

### DIFF
--- a/docs/changelog/91409.yaml
+++ b/docs/changelog/91409.yaml
@@ -1,0 +1,5 @@
+pr: 91409
+summary: Remove version limitations for CCS
+area: EQL
+type: enhancement
+issues: []

--- a/x-pack/plugin/eql/qa/ccs-rolling-upgrade/build.gradle
+++ b/x-pack/plugin/eql/qa/ccs-rolling-upgrade/build.gradle
@@ -1,0 +1,91 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+
+import org.elasticsearch.gradle.Version
+import org.elasticsearch.gradle.internal.info.BuildParams
+import org.elasticsearch.gradle.testclusters.StandaloneRestIntegTestTask
+
+apply plugin: 'elasticsearch.internal-testclusters'
+apply plugin: 'elasticsearch.standalone-rest-test'
+apply plugin: 'elasticsearch.bwc-test'
+apply plugin: 'elasticsearch.rest-resources'
+
+dependencies {
+  testImplementation project(':client:rest-high-level')
+}
+
+BuildParams.bwcVersions.withWireCompatible { bwcVersion, baseName ->
+
+  /**
+   * We execute tests 3 times.
+   * - The local cluster is unchanged and it consists of two new version nodes.
+   * - Nodes in the remote cluster are upgraded one by one in three steps.
+   * - Only node-0 and node-2 of the remote cluster can accept remote connections.
+   */
+  def localCluster = testClusters.register("${baseName}-local") {
+    testDistribution = 'DEFAULT'
+    numberOfNodes = 2
+    versions = [project.version, project.version]
+    setting 'cluster.remote.node.attr', 'gateway'
+    setting 'xpack.security.enabled', 'false'
+  }
+  def remoteCluster = testClusters.register("${baseName}-remote") {
+    testDistribution = 'DEFAULT'
+    numberOfNodes = 3
+    versions = [bwcVersion.toString(), project.version]
+    firstNode.setting 'node.attr.gateway', 'true'
+    lastNode.setting 'node.attr.gateway', 'true'
+    setting 'xpack.security.enabled', 'false'
+  }
+
+
+  tasks.withType(StandaloneRestIntegTestTask).matching { it.name.startsWith("${baseName}#") }.configureEach {
+    useCluster localCluster
+    useCluster remoteCluster
+    systemProperty 'tests.upgrade_from_version', bwcVersion.toString().replace('-SNAPSHOT', '')
+
+    doFirst {
+      nonInputProperties.systemProperty('tests.rest.cluster', localCluster.map(c -> c.allHttpSocketURI.join(",")))
+      nonInputProperties.systemProperty('tests.rest.remote_cluster', remoteCluster.map(c -> c.allHttpSocketURI.join(",")))
+    }
+  }
+
+  tasks.register("${baseName}#oldClusterTest", StandaloneRestIntegTestTask) {
+    dependsOn "processTestResources"
+    mustRunAfter("precommit")
+    doFirst {
+      localCluster.get().nextNodeToNextVersion()
+    }
+  }
+
+  tasks.register("${baseName}#oneThirdUpgraded", StandaloneRestIntegTestTask) {
+    dependsOn "${baseName}#oldClusterTest"
+    doFirst {
+      remoteCluster.get().nextNodeToNextVersion()
+    }
+  }
+
+  tasks.register("${baseName}#twoThirdUpgraded", StandaloneRestIntegTestTask) {
+    dependsOn "${baseName}#oneThirdUpgraded"
+    doFirst {
+      remoteCluster.get().nextNodeToNextVersion()
+    }
+  }
+
+  tasks.register("${baseName}#fullUpgraded", StandaloneRestIntegTestTask) {
+    dependsOn "${baseName}#twoThirdUpgraded"
+    doFirst {
+      remoteCluster.get().nextNodeToNextVersion()
+    }
+  }
+
+  tasks.register(bwcTaskName(bwcVersion)) {
+    dependsOn tasks.named("${baseName}#fullUpgraded")
+  }
+}

--- a/x-pack/plugin/eql/qa/ccs-rolling-upgrade/src/test/java/org/elasticsearch/xpack/eql/qa/ccs_rolling_upgrade/EqlCcsRollingUpgradeIT.java
+++ b/x-pack/plugin/eql/qa/ccs-rolling-upgrade/src/test/java/org/elasticsearch/xpack/eql/qa/ccs_rolling_upgrade/EqlCcsRollingUpgradeIT.java
@@ -1,0 +1,191 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.eql.qa.ccs_rolling_upgrade;
+
+import org.apache.http.HttpHost;
+import org.apache.http.util.EntityUtils;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.elasticsearch.Version;
+import org.elasticsearch.action.index.IndexRequest;
+import org.elasticsearch.client.Request;
+import org.elasticsearch.client.RequestOptions;
+import org.elasticsearch.client.Response;
+import org.elasticsearch.client.RestClient;
+import org.elasticsearch.client.RestHighLevelClient;
+import org.elasticsearch.cluster.metadata.IndexMetadata;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.test.rest.ESRestTestCase;
+import org.elasticsearch.test.rest.ObjectPath;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.not;
+
+/**
+ * This test ensures that EQL can process CCS requests correctly when the local and remote clusters
+ * have different but compatible versions.
+ */
+@SuppressWarnings("removal")
+public class EqlCcsRollingUpgradeIT extends ESRestTestCase {
+
+    private static final Logger LOGGER = LogManager.getLogger(EqlCcsRollingUpgradeIT.class);
+    private static final String CLUSTER_ALIAS = "remote_cluster";
+
+    record Node(String id, String name, Version version, String transportAddress, String httpAddress, Map<String, Object> attributes) {}
+
+    static List<Node> getNodes(RestClient restClient) throws IOException {
+        Response response = restClient.performRequest(new Request("GET", "_nodes"));
+        ObjectPath objectPath = ObjectPath.createFromResponse(response);
+        final Map<String, Object> nodeMap = objectPath.evaluate("nodes");
+        final List<Node> nodes = new ArrayList<>();
+        for (String id : nodeMap.keySet()) {
+            final String name = objectPath.evaluate("nodes." + id + ".name");
+            final Version version = Version.fromString(objectPath.evaluate("nodes." + id + ".version"));
+            final String transportAddress = objectPath.evaluate("nodes." + id + ".transport.publish_address");
+            final String httpAddress = objectPath.evaluate("nodes." + id + ".http.publish_address");
+            final Map<String, Object> attributes = objectPath.evaluate("nodes." + id + ".attributes");
+            nodes.add(new Node(id, name, version, transportAddress, httpAddress, attributes));
+        }
+        return nodes;
+    }
+
+    static List<HttpHost> parseHosts(String props) {
+        final String address = System.getProperty(props);
+        assertNotNull("[" + props + "] is not configured", address);
+        String[] stringUrls = address.split(",");
+        List<HttpHost> hosts = new ArrayList<>(stringUrls.length);
+        for (String stringUrl : stringUrls) {
+            int portSeparator = stringUrl.lastIndexOf(':');
+            if (portSeparator < 0) {
+                throw new IllegalArgumentException("Illegal cluster url [" + stringUrl + "]");
+            }
+            String host = stringUrl.substring(0, portSeparator);
+            int port = Integer.parseInt(stringUrl.substring(portSeparator + 1));
+            hosts.add(new HttpHost(host, port, "http"));
+        }
+        assertThat("[" + props + "] is empty", hosts, not(empty()));
+        return hosts;
+    }
+
+    public static void configureRemoteClusters(List<Node> remoteNodes) throws Exception {
+        assertThat(remoteNodes, hasSize(3));
+        final String remoteClusterSettingPrefix = "cluster.remote." + CLUSTER_ALIAS + ".";
+        try (RestClient localClient = newLocalClient().getLowLevelClient()) {
+            final Settings remoteConnectionSettings;
+            if (randomBoolean()) {
+                final List<String> seeds = remoteNodes.stream()
+                    .filter(n -> n.attributes.containsKey("gateway"))
+                    .map(n -> n.transportAddress)
+                    .collect(Collectors.toList());
+                assertThat(seeds, hasSize(2));
+                LOGGER.info("--> use sniff mode with seed [{}], remote nodes [{}]", seeds, remoteNodes);
+                remoteConnectionSettings = Settings.builder()
+                    .putNull(remoteClusterSettingPrefix + "proxy_address")
+                    .put(remoteClusterSettingPrefix + "mode", "sniff")
+                    .putList(remoteClusterSettingPrefix + "seeds", seeds)
+                    .build();
+            } else {
+                final Node proxyNode = randomFrom(remoteNodes);
+                LOGGER.info("--> use proxy node [{}], remote nodes [{}]", proxyNode, remoteNodes);
+                remoteConnectionSettings = Settings.builder()
+                    .putNull(remoteClusterSettingPrefix + "seeds")
+                    .put(remoteClusterSettingPrefix + "mode", "proxy")
+                    .put(remoteClusterSettingPrefix + "proxy_address", proxyNode.transportAddress)
+                    .build();
+            }
+            updateClusterSettings(localClient, remoteConnectionSettings);
+            assertBusy(() -> {
+                final Response resp = localClient.performRequest(new Request("GET", "/_remote/info"));
+                assertOK(resp);
+                final ObjectPath objectPath = ObjectPath.createFromResponse(resp);
+                assertNotNull(objectPath.evaluate(CLUSTER_ALIAS));
+                assertTrue(objectPath.evaluate(CLUSTER_ALIAS + ".connected"));
+            }, 60, TimeUnit.SECONDS);
+        }
+    }
+
+    static RestHighLevelClient newLocalClient() {
+        final List<HttpHost> hosts = parseHosts("tests.rest.cluster");
+        final int index = random().nextInt(hosts.size());
+        LOGGER.info("Using client node {}", index);
+        return new RestHighLevelClient(RestClient.builder(hosts.get(index)));
+    }
+
+    static RestHighLevelClient newRemoteClient() {
+        return new RestHighLevelClient(RestClient.builder(randomFrom(parseHosts("tests.rest.remote_cluster"))));
+    }
+
+    static int indexDocs(RestHighLevelClient client, String index, int numDocs) throws IOException {
+        for (int i = 0; i < numDocs; i++) {
+            client.index(new IndexRequest(index).id("id_" + i).source("f", i, "@timestamp", i), RequestOptions.DEFAULT);
+        }
+
+        refresh(client.getLowLevelClient(), index);
+        return numDocs;
+    }
+
+    void verify(String localIndex, int localNumDocs, String remoteIndex, int remoteNumDocs) {
+        try (RestClient localClient = newLocalClient().getLowLevelClient()) {
+
+            Request request = new Request("POST", "/" + randomFrom(remoteIndex, localIndex + "," + remoteIndex) + "/_eql/search");
+            int size = between(1, 100);
+            int id1 = between(0, 5);
+            int id2 = between(6, Math.min(localNumDocs - 1, remoteNumDocs - 1));
+            request.setJsonEntity(
+                "{\"query\": \"sequence [any where f == " + id1 + "] [any where f == " + id2 + "] \", \"size\": " + size + "}"
+            );
+            Response response = localClient.performRequest(request);
+            String responseText = EntityUtils.toString(response.getEntity());
+            assertTrue(responseText.contains("\"sequences\":[{"));
+            assertTrue(responseText.contains("\"_id\":\"id_" + id1 + "\""));
+            assertTrue(responseText.contains("\"_id\":\"id_" + id2 + "\""));
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    public void testSequences() throws Exception {
+        String localIndex = "test_bwc_search_states_index";
+        String remoteIndex = "test_bwc_search_states_remote_index";
+        try (RestHighLevelClient localClient = newLocalClient(); RestHighLevelClient remoteClient = newRemoteClient()) {
+            createIndex(
+                localClient.getLowLevelClient(),
+                localIndex,
+                Settings.builder().put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, between(1, 5)).build(),
+                "{\"properties\": {\"@timestamp\": {\"type\": \"date\"}}}",
+                null
+            );
+            int localNumDocs = indexDocs(localClient, localIndex, between(10, 100));
+            createIndex(
+                remoteClient.getLowLevelClient(),
+                remoteIndex,
+                Settings.builder().put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, between(1, 5)).build(),
+                "{\"properties\": {\"@timestamp\": {\"type\": \"date\"}}}",
+                null
+            );
+            int remoteNumDocs = indexDocs(remoteClient, remoteIndex, between(10, 100));
+
+            configureRemoteClusters(getNodes(remoteClient.getLowLevelClient()));
+            int iterations = between(1, 20);
+            for (int i = 0; i < iterations; i++) {
+                verify(localIndex, localNumDocs, CLUSTER_ALIAS + ":" + remoteIndex, remoteNumDocs);
+            }
+            deleteIndex(localClient.getLowLevelClient(), localIndex);
+            deleteIndex(remoteClient.getLowLevelClient(), remoteIndex);
+        }
+    }
+}

--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/analysis/Analyzer.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/analysis/Analyzer.java
@@ -60,7 +60,7 @@ public class Analyzer extends RuleExecutor<LogicalPlan> {
     }
 
     private LogicalPlan verify(LogicalPlan plan) {
-        Collection<Failure> failures = verifier.verify(plan, configuration.versionIncompatibleClusters());
+        Collection<Failure> failures = verifier.verify(plan);
         if (failures.isEmpty() == false) {
             throw new VerificationException(failures);
         }

--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/plugin/TransportEqlSearchAction.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/plugin/TransportEqlSearchAction.java
@@ -232,8 +232,7 @@ public class TransportEqlSearchAction extends HandledTransportAction<EqlSearchRe
                 request.fetchSize(),
                 clientId,
                 new TaskId(nodeId, task.getId()),
-                task,
-                remoteClusterRegistry::versionIncompatibleClusters
+                task
             );
             executeRequestWithRetryAttempt(
                 clusterService,

--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/session/EqlConfiguration.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/session/EqlConfiguration.java
@@ -17,10 +17,8 @@ import org.elasticsearch.tasks.TaskId;
 import org.elasticsearch.xpack.eql.action.EqlSearchTask;
 
 import java.time.ZoneId;
-import java.util.Collection;
 import java.util.List;
 import java.util.Map;
-import java.util.function.Function;
 
 public class EqlConfiguration extends org.elasticsearch.xpack.ql.session.Configuration {
 
@@ -52,10 +50,9 @@ public class EqlConfiguration extends org.elasticsearch.xpack.ql.session.Configu
         int fetchSize,
         String clientId,
         TaskId taskId,
-        EqlSearchTask task,
-        Function<String, Collection<String>> versionIncompatibleClusters
+        EqlSearchTask task
     ) {
-        super(zi, username, clusterName, versionIncompatibleClusters);
+        super(zi, username, clusterName);
 
         this.indices = indices;
         this.filter = filter;

--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/util/RemoteClusterRegistry.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/util/RemoteClusterRegistry.java
@@ -7,14 +7,11 @@
 
 package org.elasticsearch.xpack.eql.util;
 
-import org.elasticsearch.Version;
 import org.elasticsearch.action.support.IndicesOptions;
-import org.elasticsearch.common.Strings;
 import org.elasticsearch.transport.RemoteClusterAware;
 import org.elasticsearch.transport.RemoteClusterService;
 
 import java.util.Set;
-import java.util.TreeSet;
 
 public class RemoteClusterRegistry {
 
@@ -24,17 +21,6 @@ public class RemoteClusterRegistry {
     public RemoteClusterRegistry(RemoteClusterService remoteClusterService, IndicesOptions indicesOptions) {
         this.remoteClusterService = remoteClusterService;
         this.indicesOptions = indicesOptions;
-    }
-
-    public Set<String> versionIncompatibleClusters(String indexPattern) {
-        Set<String> incompatibleClusters = new TreeSet<>();
-        for (String clusterAlias : clusterAliases(Strings.splitStringByCommaToArray(indexPattern), true)) {
-            Version clusterVersion = remoteClusterService.getConnection(clusterAlias).getVersion();
-            if (clusterVersion.equals(Version.CURRENT) == false) { // TODO: should newer clusters be eventually allowed?
-                incompatibleClusters.add(clusterAlias);
-            }
-        }
-        return incompatibleClusters;
     }
 
     public Set<String> clusterAliases(String[] indices, boolean discardLocal) {

--- a/x-pack/plugin/eql/src/test/java/org/elasticsearch/xpack/eql/EqlTestUtils.java
+++ b/x-pack/plugin/eql/src/test/java/org/elasticsearch/xpack/eql/EqlTestUtils.java
@@ -23,8 +23,6 @@ import org.elasticsearch.xpack.eql.expression.predicate.operator.comparison.Inse
 import org.elasticsearch.xpack.eql.session.EqlConfiguration;
 import org.elasticsearch.xpack.ql.expression.Expression;
 
-import java.util.Collections;
-
 import static java.util.Collections.emptyMap;
 import static org.elasticsearch.test.ESTestCase.randomAlphaOfLength;
 import static org.elasticsearch.test.ESTestCase.randomBoolean;
@@ -53,8 +51,7 @@ public final class EqlTestUtils {
         123,
         "",
         new TaskId("test", 123),
-        null,
-        x -> Collections.emptySet()
+        null
     );
 
     public static EqlConfiguration randomConfiguration() {
@@ -71,8 +68,7 @@ public final class EqlTestUtils {
             randomIntBetween(1, 1000),
             randomAlphaOfLength(16),
             new TaskId(randomAlphaOfLength(10), randomNonNegativeLong()),
-            randomTask(),
-            x -> Collections.emptySet()
+            randomTask()
         );
     }
 

--- a/x-pack/plugin/eql/src/test/java/org/elasticsearch/xpack/eql/analysis/VerifierTests.java
+++ b/x-pack/plugin/eql/src/test/java/org/elasticsearch/xpack/eql/analysis/VerifierTests.java
@@ -6,15 +6,11 @@
  */
 package org.elasticsearch.xpack.eql.analysis;
 
-import org.elasticsearch.Version;
-import org.elasticsearch.core.TimeValue;
-import org.elasticsearch.tasks.TaskId;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.eql.EqlTestUtils;
 import org.elasticsearch.xpack.eql.expression.function.EqlFunctionRegistry;
 import org.elasticsearch.xpack.eql.parser.EqlParser;
 import org.elasticsearch.xpack.eql.parser.ParsingException;
-import org.elasticsearch.xpack.eql.session.EqlConfiguration;
 import org.elasticsearch.xpack.eql.stats.Metrics;
 import org.elasticsearch.xpack.ql.index.EsIndex;
 import org.elasticsearch.xpack.ql.index.IndexResolution;
@@ -22,14 +18,8 @@ import org.elasticsearch.xpack.ql.plan.logical.LogicalPlan;
 import org.elasticsearch.xpack.ql.type.EsField;
 import org.elasticsearch.xpack.ql.type.TypesTests;
 
-import java.util.Collection;
 import java.util.Map;
-import java.util.Set;
-import java.util.TreeSet;
-import java.util.function.Function;
 
-import static java.util.Collections.emptyMap;
-import static java.util.Collections.emptySet;
 import static org.hamcrest.Matchers.startsWith;
 
 public class VerifierTests extends ESTestCase {
@@ -449,61 +439,6 @@ public class VerifierTests extends ESTestCase {
         assertEquals(
             "1:69: Sequence key [opcode] type [long] is incompatible with key [@timestamp] type [date]",
             error(index, "sequence " + "[process where true] by @timestamp " + "[process where true] by opcode")
-        );
-    }
-
-    private LogicalPlan analyzeWithVerifierFunction(Function<String, Collection<String>> versionIncompatibleClusters) {
-        PreAnalyzer preAnalyzer = new PreAnalyzer();
-        EqlConfiguration eqlConfiguration = new EqlConfiguration(
-            new String[] { "none" },
-            org.elasticsearch.xpack.ql.util.DateUtils.UTC,
-            "nobody",
-            "cluster",
-            null,
-            emptyMap(),
-            null,
-            TimeValue.timeValueSeconds(30),
-            null,
-            123,
-            "",
-            new TaskId("test", 123),
-            null,
-            versionIncompatibleClusters
-        );
-        Analyzer analyzer = new Analyzer(eqlConfiguration, new EqlFunctionRegistry(), new Verifier(new Metrics()));
-        IndexResolution resolution = IndexResolution.valid(new EsIndex("irrelevant", loadEqlMapping("mapping-default.json")));
-        return analyzer.analyze(preAnalyzer.preAnalyze(new EqlParser().createStatement("any where true"), resolution));
-    }
-
-    public void testRemoteClusterVersionCheck() {
-        assertNotNull(analyzeWithVerifierFunction(x -> emptySet()));
-
-        Set<String> clusters = new TreeSet<>() {
-            {
-                add("one");
-            }
-        };
-        VerificationException e = expectThrows(VerificationException.class, () -> analyzeWithVerifierFunction(x -> clusters));
-        assertTrue(
-            e.getMessage()
-                .contains(
-                    "the following remote cluster is incompatible, being on a version different than local "
-                        + "cluster's ["
-                        + Version.CURRENT
-                        + "]: [one]"
-                )
-        );
-
-        clusters.add("two");
-        e = expectThrows(VerificationException.class, () -> analyzeWithVerifierFunction(x -> clusters));
-        assertTrue(
-            e.getMessage()
-                .contains(
-                    "the following remote clusters are incompatible, being on a version different than local "
-                        + "cluster's ["
-                        + Version.CURRENT
-                        + "]: [one, two]"
-                )
         );
     }
 }

--- a/x-pack/plugin/eql/src/test/java/org/elasticsearch/xpack/eql/execution/sequence/CircuitBreakerTests.java
+++ b/x-pack/plugin/eql/src/test/java/org/elasticsearch/xpack/eql/execution/sequence/CircuitBreakerTests.java
@@ -301,8 +301,7 @@ public class CircuitBreakerTests extends ESTestCase {
                 emptyMap(),
                 new AsyncExecutionId("", new TaskId(randomAlphaOfLength(10), 1)),
                 TimeValue.timeValueDays(5)
-            ),
-            x -> Collections.emptySet()
+            )
         );
         IndexResolver indexResolver = new IndexResolver(esClient, "cluster", DefaultDataTypeRegistry.INSTANCE, Collections::emptySet);
         EqlSession eqlSession = new EqlSession(

--- a/x-pack/plugin/eql/src/test/java/org/elasticsearch/xpack/eql/execution/sequence/PITFailureTests.java
+++ b/x-pack/plugin/eql/src/test/java/org/elasticsearch/xpack/eql/execution/sequence/PITFailureTests.java
@@ -90,8 +90,7 @@ public class PITFailureTests extends ESTestCase {
                     emptyMap(),
                     new AsyncExecutionId("", new TaskId(randomAlphaOfLength(10), 1)),
                     TimeValue.timeValueDays(5)
-                ),
-                x -> emptySet()
+                )
             );
             IndexResolver indexResolver = new IndexResolver(esClient, "cluster", DefaultDataTypeRegistry.INSTANCE, () -> emptySet());
             CircuitBreaker cb = new NoopCircuitBreaker("testcb");

--- a/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/session/Configuration.java
+++ b/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/session/Configuration.java
@@ -11,8 +11,6 @@ import java.time.Clock;
 import java.time.Duration;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
-import java.util.Collection;
-import java.util.function.Function;
 
 public class Configuration {
 
@@ -20,15 +18,13 @@ public class Configuration {
     private final String username;
     private final ZonedDateTime now;
     private final ZoneId zoneId;
-    private final Function<String, Collection<String>> versionIncompatibleClusters;
 
-    public Configuration(ZoneId zi, String username, String clusterName, Function<String, Collection<String>> versionIncompatibleClusters) {
+    public Configuration(ZoneId zi, String username, String clusterName) {
         this.zoneId = zi.normalized();
         Clock clock = Clock.system(zoneId);
         this.now = ZonedDateTime.now(Clock.tick(clock, Duration.ofNanos(1)));
         this.username = username;
         this.clusterName = clusterName;
-        this.versionIncompatibleClusters = versionIncompatibleClusters;
     }
 
     public ZoneId zoneId() {
@@ -45,9 +41,5 @@ public class Configuration {
 
     public String username() {
         return username;
-    }
-
-    public Function<String, Collection<String>> versionIncompatibleClusters() {
-        return versionIncompatibleClusters;
     }
 }

--- a/x-pack/plugin/ql/test-fixtures/src/main/java/org/elasticsearch/xpack/ql/TestUtils.java
+++ b/x-pack/plugin/ql/test-fixtures/src/main/java/org/elasticsearch/xpack/ql/TestUtils.java
@@ -59,7 +59,6 @@ import java.nio.file.attribute.BasicFileAttributes;
 import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.EnumSet;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -83,7 +82,7 @@ import static org.junit.Assert.assertEquals;
 public final class TestUtils {
 
     public static final ZoneId UTC = ZoneId.of("Z");
-    public static final Configuration TEST_CFG = new Configuration(UTC, null, null, x -> Collections.emptySet());
+    public static final Configuration TEST_CFG = new Configuration(UTC, null, null);
 
     private static final String MATCHER_TYPE_CONTAINS = "CONTAINS";
     private static final String MATCHER_TYPE_REGEX = "REGEX";
@@ -91,11 +90,11 @@ public final class TestUtils {
     private TestUtils() {}
 
     public static Configuration randomConfiguration() {
-        return new Configuration(randomZone(), randomAlphaOfLength(10), randomAlphaOfLength(10), x -> Collections.emptySet());
+        return new Configuration(randomZone(), randomAlphaOfLength(10), randomAlphaOfLength(10));
     }
 
     public static Configuration randomConfiguration(ZoneId zoneId) {
-        return new Configuration(zoneId, randomAlphaOfLength(10), randomAlphaOfLength(10), x -> Collections.emptySet());
+        return new Configuration(zoneId, randomAlphaOfLength(10), randomAlphaOfLength(10));
     }
 
     public static Literal of(Object value) {

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/session/SqlConfiguration.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/session/SqlConfiguration.java
@@ -16,7 +16,6 @@ import org.elasticsearch.xpack.sql.proto.Mode;
 import org.elasticsearch.xpack.sql.proto.SqlVersion;
 
 import java.time.ZoneId;
-import java.util.Collections;
 import java.util.Map;
 
 // Typed object holding properties for a given query
@@ -64,7 +63,7 @@ public class SqlConfiguration extends org.elasticsearch.xpack.ql.session.Configu
         @Nullable SqlQueryTask task,
         boolean allowPartialSearchResults
     ) {
-        super(zi, username, clusterName, x -> Collections.emptySet());
+        super(zi, username, clusterName);
 
         this.catalog = catalog;
         this.pageSize = pageSize;


### PR DESCRIPTION
Backports the following commits to 8.5:
 - EQL: remove version limitations for CCS (#91409)