### PR TITLE
Update get-settings.asciidoc

### DIFF
--- a/docs/reference/cluster/get-settings.asciidoc
+++ b/docs/reference/cluster/get-settings.asciidoc
@@ -37,7 +37,7 @@ defined, but can also include the default settings by calling the
 include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=flat-settings]
 
 `include_defaults`::
-    (Optional, Boolean) If `true`, returns all default cluster settings. 
+    (Optional, Boolean) If `true`, returns default cluster settings from the local node. 
     Defaults to `false`.
 
 include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=timeoutparms]


### PR DESCRIPTION
If `include_defaults` is `true`, the API returns the default settings from the node handling the API request.
