### PR TITLE
[DOCS] Clarify multi-field addition requires update by query for existing documents

### DIFF
--- a/docs/reference/indices/put-mapping.asciidoc
+++ b/docs/reference/indices/put-mapping.asciidoc
@@ -198,9 +198,10 @@ PUT /my-index-000001/_mapping
 You can use the update mapping API to update the `fields` mapping parameter and
 enable multi-fields for an existing field.
 
-WARNING: If an index (or data stream) contains documents when you add a multi-field,
-those documents will not receive the mapping update. You can apply mapping changes
-with the <<docs-update-by-query,update by query API>>.
+WARNING: If an index (or data stream) contains documents when you add a
+multi-field, those documents will not have values for the new multi-field. You
+can populate the new multi-field with the <<picking-up-a-new-property,update by
+query API>>.
 
 To see how this works, try the following example.
 

--- a/docs/reference/indices/put-mapping.asciidoc
+++ b/docs/reference/indices/put-mapping.asciidoc
@@ -198,6 +198,10 @@ PUT /my-index-000001/_mapping
 You can use the update mapping API to update the `fields` mapping parameter and
 enable multi-fields for an existing field.
 
+WARNING: If an index (or data stream) contains documents when you add a multi-field,
+those documents will not receive the mapping update. You can apply mapping changes
+with the <<docs-update-by-query,update by query API>>.
+
 To see how this works, try the following example.
 
 Use the <<indices-create-index,create index>> API to create an index with the

--- a/docs/reference/mapping/params/multi-fields.asciidoc
+++ b/docs/reference/mapping/params/multi-fields.asciidoc
@@ -61,6 +61,10 @@ GET my-index-000001/_search
 You can add multi-fields to an existing field using the
 <<indices-put-mapping,update mapping API>>.
 
+WARNING: If an index (or data stream) contains documents when you add a multi-field,
+those documents will not receive the mapping update. You can apply mapping changes
+with the <<docs-update-by-query,update by query API>>.
+
 A multi-field mapping is completely separate from the parent field's mapping. A
 multi-field doesn't inherit any mapping options from its parent field.
 Multi-fields don't change the original `_source` field.

--- a/docs/reference/mapping/params/multi-fields.asciidoc
+++ b/docs/reference/mapping/params/multi-fields.asciidoc
@@ -61,9 +61,10 @@ GET my-index-000001/_search
 You can add multi-fields to an existing field using the
 <<indices-put-mapping,update mapping API>>.
 
-WARNING: If an index (or data stream) contains documents when you add a multi-field,
-those documents will not receive the mapping update. You can apply mapping changes
-with the <<docs-update-by-query,update by query API>>.
+WARNING: If an index (or data stream) contains documents when you add a
+multi-field, those documents will not have values for the new multi-field. You
+can populate the new multi-field with the <<picking-up-a-new-property,update by
+query API>>.
 
 A multi-field mapping is completely separate from the parent field's mapping. A
 multi-field doesn't inherit any mapping options from its parent field.


### PR DESCRIPTION
Addressing [87339](https://github.com/elastic/elasticsearch/issues/87339)

**Notes:**

**1.** I added a banner to both pages (let me know if this could be handled better). The link (in the banner) has the command to pick up the mapping changes.
**2.** I was going to update the multi-field [example](https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-put-mapping.html#add-multi-fields-existing-field-ex) with a sort request to show the issue. However, I thought this might make the example clunky, so I didn't add it. There's also an [example](https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-update-by-query.html#picking-up-a-new-property) here. 
