### PR TITLE
Disable data tiers allocation deciders

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/XPackPlugin.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/XPackPlugin.java
@@ -447,11 +447,17 @@ public class XPackPlugin extends XPackClientPlugin
 
     @Override
     public Collection<AllocationDecider> createAllocationDeciders(Settings settings, ClusterSettings clusterSettings) {
+        if (DiscoveryNode.isStateless(settings)) {
+            return List.of();
+        }
         return Collections.singleton(DataTierAllocationDecider.INSTANCE);
     }
 
     @Override
     public Collection<IndexSettingProvider> getAdditionalIndexSettingProviders(IndexSettingProvider.Parameters parameters) {
+        if (DiscoveryNode.isStateless(settings)) {
+            return List.of();
+        }
         return Collections.singleton(new DataTier.DefaultHotAllocationSettingProvider());
     }
 


### PR DESCRIPTION
When specific settings are set, we don't want existing data tiers allocation deciders to be enabled (otherwise we can't allocate shards to nodes with `index` or `search` roles when x-pack core module is present).