### PR TITLE
Allow plugins to wrap Lucene directories created by the IndexModule

### DIFF
--- a/docs/changelog/91556.yaml
+++ b/docs/changelog/91556.yaml
@@ -1,0 +1,5 @@
+pr: 91556
+summary: Allow plugins to wrap Lucene directories created by the `IndexModule`
+area: Store
+type: enhancement
+issues: []

--- a/server/src/test/java/org/elasticsearch/index/IndexModuleTests.java
+++ b/server/src/test/java/org/elasticsearch/index/IndexModuleTests.java
@@ -19,6 +19,7 @@ import org.apache.lucene.search.Weight;
 import org.apache.lucene.search.similarities.BM25Similarity;
 import org.apache.lucene.search.similarities.Similarity;
 import org.apache.lucene.store.Directory;
+import org.apache.lucene.store.FilterDirectory;
 import org.apache.lucene.tests.index.AssertingDirectoryReader;
 import org.apache.lucene.util.SetOnce.AlreadySetException;
 import org.elasticsearch.Version;
@@ -100,6 +101,7 @@ import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.hasToString;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
 import static org.mockito.Mockito.mock;
 
 public class IndexModuleTests extends ESTestCase {
@@ -242,6 +244,39 @@ public class IndexModuleTests extends ESTestCase {
         assertThat(indexService.getDirectoryFactory(), instanceOf(FooFunction.class));
 
         indexService.close("simon says", false);
+    }
+
+    public void testDirectoryWrapper() throws IOException {
+        final Path homeDir = createTempDir();
+        final Settings settings = Settings.builder()
+            .put(IndexMetadata.SETTING_VERSION_CREATED, Version.CURRENT)
+            .put(Environment.PATH_HOME_SETTING.getKey(), homeDir.toString())
+            .build();
+        final IndexSettings indexSettings = IndexSettingsModule.newIndexSettings(index, settings);
+        final IndexModule module = new IndexModule(
+            indexSettings,
+            emptyAnalysisRegistry,
+            new InternalEngineFactory(),
+            Map.of(),
+            () -> true,
+            indexNameExpressionResolver,
+            Collections.emptyMap()
+        );
+
+        module.setDirectoryWrapper(new DirectoryWrapper());
+
+        final IndexService indexService = newIndexService(module);
+        assertSame(indexService.getEngineFactory(), module.getEngineFactory());
+        final IndexStorePlugin.DirectoryFactory directoryFactory = indexService.getDirectoryFactory();
+        assertThat(directoryFactory, notNullValue());
+
+        final ShardId shardId = new ShardId(indexSettings.getIndex(), randomIntBetween(0, 5));
+        final Path dataPath = new NodeEnvironment.DataPath(homeDir).resolve(shardId);
+        final Directory directory = directoryFactory.newDirectory(indexSettings, new ShardPath(false, dataPath, dataPath, shardId));
+        assertThat(directory, instanceOf(WrappedDirectory.class));
+        assertThat(directory, instanceOf(FilterDirectory.class));
+
+        indexService.close("test done", false);
     }
 
     public void testOtherServiceBound() throws IOException {
@@ -657,6 +692,20 @@ public class IndexModuleTests extends ESTestCase {
         @Override
         public DirectoryReader apply(DirectoryReader reader) {
             return null;
+        }
+    }
+
+    private static final class DirectoryWrapper implements CheckedFunction<Directory, Directory, IOException> {
+        @Override
+        public Directory apply(Directory directory) {
+            return new WrappedDirectory(directory);
+        }
+    }
+
+    private static final class WrappedDirectory extends FilterDirectory {
+
+        protected WrappedDirectory(Directory in) {
+            super(in);
         }
     }
 }

--- a/server/src/test/java/org/elasticsearch/index/IndexModuleTests.java
+++ b/server/src/test/java/org/elasticsearch/index/IndexModuleTests.java
@@ -414,6 +414,7 @@ public class IndexModuleTests extends ESTestCase {
         assertEquals(msg, expectThrows(IllegalStateException.class, () -> module.addSimilarity(null, null)).getMessage());
         assertEquals(msg, expectThrows(IllegalStateException.class, () -> module.setReaderWrapper(null)).getMessage());
         assertEquals(msg, expectThrows(IllegalStateException.class, () -> module.forceQueryCacheProvider(null)).getMessage());
+        assertEquals(msg, expectThrows(IllegalStateException.class, () -> module.setDirectoryWrapper(null)).getMessage());
     }
 
     public void testSetupUnknownSimilarity() {

--- a/server/src/test/java/org/elasticsearch/index/IndexModuleTests.java
+++ b/server/src/test/java/org/elasticsearch/index/IndexModuleTests.java
@@ -263,7 +263,7 @@ public class IndexModuleTests extends ESTestCase {
             Collections.emptyMap()
         );
 
-        module.setDirectoryWrapper(new DirectoryWrapper());
+        module.setDirectoryWrapper(new TestDirectoryWrapper());
 
         final IndexService indexService = newIndexService(module);
         assertSame(indexService.getEngineFactory(), module.getEngineFactory());
@@ -695,7 +695,7 @@ public class IndexModuleTests extends ESTestCase {
         }
     }
 
-    private static final class DirectoryWrapper implements CheckedFunction<Directory, Directory, IOException> {
+    private static final class TestDirectoryWrapper implements IndexModule.DirectoryWrapper {
         @Override
         public Directory apply(Directory directory) {
             return new WrappedDirectory(directory);


### PR DESCRIPTION
Today plugins can provide custom Directory factories but they cannot wrap directory instances created by default/other plugins. 

This change introduces a `IndexModule#setDirectoryWrapper(CheckedFunction<Directory, Directory, IOException>)` method that allows to set one (and only one) wrapping method that will be invoked after the Lucene directory is created. This will be useful for plugins to wrap the default directory instance created by Elasticsearch in a `FilterDirectory` that can track which and when Lucene files are accessed.

The mechanic here is similar to how plugins can wrap `DirectoryReader` instances by setting `IndexModule#setReaderWrapper()`.