### PR TITLE
[ML]  PyTorchModelIT: investigate single processor mode failures

### DIFF
--- a/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/PyTorchModelIT.java
+++ b/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/PyTorchModelIT.java
@@ -238,14 +238,13 @@ public class PyTorchModelIT extends PyTorchModelRestTestCase {
 
     @SuppressWarnings("unchecked")
     public void testLiveDeploymentStats() throws IOException {
-        String modelA = "model_a";
-
-        createPassThroughModel(modelA);
-        putVocabulary(List.of("once", "twice"), modelA);
-        putModelDefinition(modelA);
-        startDeployment(modelA, AllocationStatus.State.FULLY_ALLOCATED.toString());
+        String modelId = "live_deployment_stats";
+        createPassThroughModel(modelId);
+        putVocabulary(List.of("once", "twice"), modelId);
+        putModelDefinition(modelId);
+        startDeployment(modelId, AllocationStatus.State.FULLY_ALLOCATED.toString());
         {
-            Response noInferenceCallsStatsResponse = getTrainedModelStats(modelA);
+            Response noInferenceCallsStatsResponse = getTrainedModelStats(modelId);
             List<Map<String, Object>> stats = (List<Map<String, Object>>) entityAsMap(noInferenceCallsStatsResponse).get(
                 "trained_model_stats"
             );
@@ -266,17 +265,17 @@ public class PyTorchModelIT extends PyTorchModelRestTestCase {
             }
         }
 
-        infer("once", modelA);
-        infer("twice", modelA);
+        infer("once", modelId);
+        infer("twice", modelId);
         // By making this request 3 times at least one of the responses must come from the cache because the cluster has 2 ML nodes
-        infer("three times", modelA);
-        infer("three times", modelA);
-        infer("three times", modelA);
+        infer("three times", modelId);
+        infer("three times", modelId);
+        infer("three times", modelId);
         {
-            Response postInferStatsResponse = getTrainedModelStats(modelA);
+            Response postInferStatsResponse = getTrainedModelStats(modelId);
             List<Map<String, Object>> stats = (List<Map<String, Object>>) entityAsMap(postInferStatsResponse).get("trained_model_stats");
             assertThat(stats, hasSize(1));
-            assertThat(XContentMapValues.extractValue("deployment_stats.model_id", stats.get(0)), equalTo(modelA));
+            assertThat(XContentMapValues.extractValue("deployment_stats.model_id", stats.get(0)), equalTo(modelId));
             assertThat(XContentMapValues.extractValue("model_size_stats.model_size_bytes", stats.get(0)), equalTo((int) RAW_MODEL_SIZE));
             List<Map<String, Object>> nodes = (List<Map<String, Object>>) XContentMapValues.extractValue(
                 "deployment_stats.nodes",
@@ -746,12 +745,12 @@ public class PyTorchModelIT extends PyTorchModelRestTestCase {
                 }}""");
         client().performRequest(loggingSettings);
 
-        String modelId1 = "model_1";
+        String modelId1 = "stopping_triggers_rebalance_1";
         createPassThroughModel(modelId1);
         putModelDefinition(modelId1);
         putVocabulary(List.of("these", "are", "my", "words"), modelId1);
 
-        String modelId2 = "model_2";
+        String modelId2 = "stopping_triggers_rebalance_2";
         createPassThroughModel(modelId2);
         putModelDefinition(modelId2);
         putVocabulary(List.of("these", "are", "my", "words"), modelId2);
@@ -824,12 +823,12 @@ public class PyTorchModelIT extends PyTorchModelRestTestCase {
                 }}""");
         client().performRequest(loggingSettings);
 
-        String modelId1 = "model_1";
+        String modelId1 = "start_no_processors_left_lazy_start_1";
         createPassThroughModel(modelId1);
         putModelDefinition(modelId1);
         putVocabulary(List.of("these", "are", "my", "words"), modelId1);
 
-        String modelId2 = "model_2";
+        String modelId2 = "start_no_processors_left_lazy_start_2";
         createPassThroughModel(modelId2);
         putModelDefinition(modelId2);
         putVocabulary(List.of("these", "are", "my", "words"), modelId2);

--- a/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/PyTorchModelRestTestCase.java
+++ b/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/PyTorchModelRestTestCase.java
@@ -58,6 +58,7 @@ public abstract class PyTorchModelRestTestCase extends ESRestTestCase {
             {"persistent" : {
                     "logger.org.elasticsearch.xpack.ml.inference.assignment" : "DEBUG",
                     "logger.org.elasticsearch.xpack.ml.inference.deployment" : "DEBUG",
+                    "logger.org.elasticsearch.xpack.ml.inference.pytorch" : "DEBUG",
                     "logger.org.elasticsearch.xpack.ml.process.logging" : "DEBUG"
                 }}""");
         client().performRequest(loggingSettings);
@@ -72,6 +73,7 @@ public abstract class PyTorchModelRestTestCase extends ESRestTestCase {
             {"persistent" : {
                 "logger.org.elasticsearch.xpack.ml.inference.assignment": null,
                 "logger.org.elasticsearch.xpack.ml.inference.deployment" : null,
+                "logger.org.elasticsearch.xpack.ml.inference.pytorch" : null,
                 "logger.org.elasticsearch.xpack.ml.process.logging" : null,
                 "xpack.ml.max_lazy_ml_nodes": null
             }}""");

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/deployment/DeploymentManager.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/deployment/DeploymentManager.java
@@ -106,7 +106,7 @@ public class DeploymentManager {
                 stats.timingStats().getAverage(),
                 stats.timingStatsExcludingCacheHits().getAverage(),
                 stats.lastUsed(),
-                processContext.executorService.queueSize() + stats.numberOfPendingResults(),
+                processContext.priorityProcessWorker.queueSize() + stats.numberOfPendingResults(),
                 stats.errorCount(),
                 stats.cacheHitCount(),
                 processContext.rejectedExecutionCount.intValue(),
@@ -129,7 +129,7 @@ public class DeploymentManager {
     private void doStartDeployment(TrainedModelDeploymentTask task, ActionListener<TrainedModelDeploymentTask> finalListener) {
         logger.info("[{}] Starting model deployment", task.getModelId());
 
-        ProcessContext processContext = new ProcessContext(task, executorServiceForProcess);
+        ProcessContext processContext = new ProcessContext(task);
         if (addProcessContext(task.getId(), processContext) != null) {
             finalListener.onFailure(
                 ExceptionsHelper.serverError("[{}] Could not create inference process as one already exists", task.getModelId())
@@ -231,7 +231,10 @@ public class DeploymentManager {
     private void startAndLoad(ProcessContext processContext, TrainedModelLocation modelLocation, ActionListener<Boolean> loadedListener) {
         try {
             processContext.startProcess();
-            processContext.loadModel(modelLocation, loadedListener);
+            processContext.loadModel(modelLocation, ActionListener.wrap(success -> {
+                processContext.startPriorityProcessWorker();
+                loadedListener.onResponse(success);
+            }, loadedListener::onFailure));
         } catch (Exception e) {
             loadedListener.onFailure(e);
         }
@@ -331,13 +334,13 @@ public class DeploymentManager {
         executePyTorchAction(processContext, PriorityProcessWorkerExecutorService.RequestPriority.HIGHEST, controlMessageAction);
     }
 
-    public void executePyTorchAction(
+    void executePyTorchAction(
         ProcessContext processContext,
         PriorityProcessWorkerExecutorService.RequestPriority priority,
         AbstractPyTorchAction<?> action
     ) {
         try {
-            processContext.getExecutorService().executeWithPriority(action, priority, action.getRequestId());
+            processContext.getPriorityProcessWorker().executeWithPriority(action, priority, action.getRequestId());
         } catch (EsRejectedExecutionException e) {
             processContext.getRejectedExecutionCount().incrementAndGet();
             action.onFailure(e);
@@ -375,21 +378,21 @@ public class DeploymentManager {
         private final SetOnce<TrainedModelInput> modelInput = new SetOnce<>();
         private final PyTorchResultProcessor resultProcessor;
         private final PyTorchStateStreamer stateStreamer;
-        private final PriorityProcessWorkerExecutorService executorService;
+        private final PriorityProcessWorkerExecutorService priorityProcessWorker;
         private volatile Instant startTime;
         private volatile Integer numThreadsPerAllocation;
         private volatile Integer numAllocations;
         private final AtomicInteger rejectedExecutionCount = new AtomicInteger();
         private final AtomicInteger timeoutCount = new AtomicInteger();
 
-        ProcessContext(TrainedModelDeploymentTask task, ExecutorService executorService) {
+        ProcessContext(TrainedModelDeploymentTask task) {
             this.task = Objects.requireNonNull(task);
             resultProcessor = new PyTorchResultProcessor(task.getModelId(), threadSettings -> {
                 this.numThreadsPerAllocation = threadSettings.numThreadsPerAllocation();
                 this.numAllocations = threadSettings.numAllocations();
             });
-            this.stateStreamer = new PyTorchStateStreamer(client, executorService, xContentRegistry);
-            this.executorService = new PriorityProcessWorkerExecutorService(
+            this.stateStreamer = new PyTorchStateStreamer(client, executorServiceForProcess, xContentRegistry);
+            this.priorityProcessWorker = new PriorityProcessWorkerExecutorService(
                 threadPool.getThreadContext(),
                 "inference process",
                 task.getParams().getQueueCapacity()
@@ -403,12 +406,15 @@ public class DeploymentManager {
         synchronized void startProcess() {
             process.set(pyTorchProcessFactory.createProcess(task, executorServiceForProcess, onProcessCrash()));
             startTime = Instant.now();
-            executorServiceForProcess.submit(executorService::start);
+        }
+
+        void startPriorityProcessWorker() {
+            executorServiceForProcess.submit(priorityProcessWorker::start);
         }
 
         synchronized void stopProcess() {
             resultProcessor.stop();
-            executorService.shutdown();
+            priorityProcessWorker.shutdown();
             try {
                 if (process.get() == null) {
                     return;
@@ -429,7 +435,7 @@ public class DeploymentManager {
             return reason -> {
                 logger.error("[{}] inference process crashed due to reason [{}]", task.getModelId(), reason);
                 resultProcessor.stop();
-                executorService.shutdownWithError(new IllegalStateException(reason));
+                priorityProcessWorker.shutdownWithError(new IllegalStateException(reason));
                 processContextByAllocation.remove(task.getId());
                 if (nlpTaskProcessor.get() != null) {
                     nlpTaskProcessor.get().close();
@@ -454,8 +460,8 @@ public class DeploymentManager {
         }
 
         // accessor used for mocking in tests
-        PriorityProcessWorkerExecutorService getExecutorService() {
-            return executorService;
+        PriorityProcessWorkerExecutorService getPriorityProcessWorker() {
+            return priorityProcessWorker;
         }
 
         // accessor used for mocking in tests

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/deployment/DeploymentManagerTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/deployment/DeploymentManagerTests.java
@@ -78,19 +78,19 @@ public class DeploymentManagerTests extends ESTestCase {
             mock(PyTorchProcessFactory.class)
         );
 
-        PriorityProcessWorkerExecutorService executorService = new PriorityProcessWorkerExecutorService(
+        PriorityProcessWorkerExecutorService priorityExecutorService = new PriorityProcessWorkerExecutorService(
             tp.getThreadContext(),
             "test reject",
             10
         );
-        executorService.shutdown();
+        priorityExecutorService.shutdown();
 
         AtomicInteger rejectedCount = new AtomicInteger();
 
         DeploymentManager.ProcessContext context = mock(DeploymentManager.ProcessContext.class);
         PyTorchResultProcessor resultProcessor = new PyTorchResultProcessor("1", threadSettings -> {});
         when(context.getResultProcessor()).thenReturn(resultProcessor);
-        when(context.getExecutorService()).thenReturn(executorService);
+        when(context.getPriorityProcessWorker()).thenReturn(priorityExecutorService);
         when(context.getRejectedExecutionCount()).thenReturn(rejectedCount);
 
         deploymentManager.addProcessContext(taskId, context);


### PR DESCRIPTION
Forward port of #91547 without the extra debug logging as the refactorings are worth committing here. 

Original description

>  The single processor test failures in https://github.com/elastic/elasticsearch/issues/91422 suggest the native process is started but the model never loaded causing a timeout waiting for the model to start. The assumption is the state loading is starved of threads and never gets going. Only after the deployment is cancelled the various thread consuming utilities stopped do we see the message loading model state cancelled suggesting that freeing the resources enabled the state loading to get going.
> The main change here is in DeploymentManager which now starts the priority process worker after the model has been loaded. Also adds debug logging and some renaming for clarity.


