### PR TITLE
[7.17] Fix inter project handling of generateDependenciesReport (#91555)

### DIFF
--- a/build-tools-internal/src/integTest/groovy/org/elasticsearch/gradle/internal/BuildPluginFuncTest.groovy
+++ b/build-tools-internal/src/integTest/groovy/org/elasticsearch/gradle/internal/BuildPluginFuncTest.groovy
@@ -45,6 +45,7 @@ class BuildPluginFuncTest extends AbstractGradleFuncTest {
         THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.""".stripIndent()
 
     def setup() {
+        configurationCacheCompatible = false
         buildFile << """
         plugins {
           id 'java'

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/ConcatFilesTask.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/ConcatFilesTask.java
@@ -8,7 +8,7 @@
 package org.elasticsearch.gradle.internal;
 
 import org.gradle.api.DefaultTask;
-import org.gradle.api.file.FileTree;
+import org.gradle.api.file.FileCollection;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.InputFiles;
 import org.gradle.api.tasks.Optional;
@@ -34,7 +34,7 @@ public class ConcatFilesTask extends DefaultTask {
     }
 
     /** List of files to concatenate */
-    private FileTree files;
+    private FileCollection files;
 
     /** line to add at the top of the target file */
     private String headerLine;
@@ -43,12 +43,12 @@ public class ConcatFilesTask extends DefaultTask {
 
     private List<String> additionalLines = new ArrayList<>();
 
-    public void setFiles(FileTree files) {
+    public void setFiles(FileCollection files) {
         this.files = files;
     }
 
     @InputFiles
-    public FileTree getFiles() {
+    public FileCollection getFiles() {
         return files;
     }
 
@@ -83,13 +83,16 @@ public class ConcatFilesTask extends DefaultTask {
     @TaskAction
     public void concatFiles() throws IOException {
         if (getHeaderLine() != null) {
+            getTarget().mkdirs();
             Files.write(getTarget().toPath(), (getHeaderLine() + '\n').getBytes(StandardCharsets.UTF_8));
         }
 
         // To remove duplicate lines
         LinkedHashSet<String> uniqueLines = new LinkedHashSet<>();
         for (File f : getFiles()) {
-            uniqueLines.addAll(Files.readAllLines(f.toPath(), StandardCharsets.UTF_8));
+            if (f.exists()) {
+                uniqueLines.addAll(Files.readAllLines(f.toPath(), StandardCharsets.UTF_8));
+            }
         }
         Files.write(getTarget().toPath(), uniqueLines, StandardCharsets.UTF_8, StandardOpenOption.APPEND);
 

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/DependenciesInfoPlugin.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/DependenciesInfoPlugin.java
@@ -12,6 +12,8 @@ import org.elasticsearch.gradle.dependencies.CompileOnlyResolvePlugin;
 import org.elasticsearch.gradle.internal.precommit.DependencyLicensesTask;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
+import org.gradle.api.artifacts.Configuration;
+import org.gradle.api.attributes.Category;
 import org.gradle.api.plugins.JavaPlugin;
 
 public class DependenciesInfoPlugin implements Plugin<Project> {
@@ -19,6 +21,7 @@ public class DependenciesInfoPlugin implements Plugin<Project> {
     public void apply(final Project project) {
         project.getPlugins().apply(CompileOnlyResolvePlugin.class);
         var depsInfo = project.getTasks().register("dependenciesInfo", DependenciesInfoTask.class);
+
         depsInfo.configure(t -> {
             t.setRuntimeConfiguration(project.getConfigurations().getByName(JavaPlugin.RUNTIME_CLASSPATH_CONFIGURATION_NAME));
             t.setCompileOnlyConfiguration(
@@ -29,6 +32,18 @@ public class DependenciesInfoPlugin implements Plugin<Project> {
                 return depLic.get().getMappings();
             });
         });
+        Configuration dependenciesInfoFilesConfiguration = project.getConfigurations().create("dependenciesInfoFiles");
+        dependenciesInfoFilesConfiguration.setCanBeResolved(false);
+        dependenciesInfoFilesConfiguration.setCanBeConsumed(true);
+        dependenciesInfoFilesConfiguration.attributes(
+            attributes -> attributes.attribute(
+                Category.CATEGORY_ATTRIBUTE,
+                project.getObjects().named(Category.class, Category.DOCUMENTATION)
+            )
+        );
+
+        project.getArtifacts().add("dependenciesInfoFiles", depsInfo);
+
     }
 
 }

--- a/distribution/build.gradle
+++ b/distribution/build.gradle
@@ -11,7 +11,7 @@ import org.apache.tools.ant.filters.FixCrLfFilter
 import org.apache.tools.ant.filters.ReplaceTokens
 import org.elasticsearch.gradle.VersionProperties
 import org.elasticsearch.gradle.internal.ConcatFilesTask
-import org.elasticsearch.gradle.internal.DependenciesInfoTask
+import org.elasticsearch.gradle.internal.DependenciesInfoPlugin
 import org.elasticsearch.gradle.internal.NoticeTask
 import org.elasticsearch.gradle.internal.info.BuildParams
 
@@ -24,6 +24,18 @@ plugins {
 
 configurations {
   log4jConfig
+  dependencyInfos {
+    attributes {
+      attribute(Category.CATEGORY_ATTRIBUTE, project.getObjects().named(Category.class, Category.DOCUMENTATION))
+    }
+  }
+}
+
+def thisProj = project
+rootProject.allprojects { proj ->
+    proj.plugins.withType(DependenciesInfoPlugin) {
+      thisProj.dependencies.add("dependencyInfos", project.dependencies.project(path: proj.path))
+    }
 }
 
 /*****************************************************************************
@@ -32,8 +44,7 @@ configurations {
 
 // Concatenates the dependencies CSV files into a single file
 tasks.register("generateDependenciesReport", ConcatFilesTask) {
-  dependsOn rootProject.allprojects.collect { it.tasks.withType(DependenciesInfoTask) }
-  files = fileTree(dir: project.rootDir, include: '**/dependencies.csv')
+  files = configurations.dependencyInfos
   headerLine = "name,version,url,license,sourceURL"
   target = new File(providers.systemProperty('csv')
                       .orElse("${project.buildDir}/reports/dependencies/es-dependencies.csv")


### PR DESCRIPTION
Backports the following commits to 7.17:
 - Fix inter project handling of generateDependenciesReport (#91555)