### PR TITLE
Fixing a failing GeoIpDownloaderIT.testUseGeoIpProcessorWithDownloadedDBs() test

### DIFF
--- a/modules/ingest-geoip/src/internalClusterTest/java/org/elasticsearch/ingest/geoip/GeoIpDownloaderIT.java
+++ b/modules/ingest-geoip/src/internalClusterTest/java/org/elasticsearch/ingest/geoip/GeoIpDownloaderIT.java
@@ -334,7 +334,7 @@ public class GeoIpDownloaderIT extends AbstractGeoIpIT {
                     );
                 }
             }
-        });
+        }, 20, TimeUnit.SECONDS);
 
         verifyUpdatedDatabase();
 

--- a/modules/ingest-geoip/src/main/java/org/elasticsearch/ingest/geoip/DatabaseNodeService.java
+++ b/modules/ingest-geoip/src/main/java/org/elasticsearch/ingest/geoip/DatabaseNodeService.java
@@ -186,22 +186,26 @@ public final class DatabaseNodeService implements Closeable {
     void checkDatabases(ClusterState state) {
         DiscoveryNode localNode = state.nodes().getLocalNode();
         if (localNode.isIngestNode() == false) {
+            LOGGER.trace("Not checking databases because local node is not ingest node");
             return;
         }
 
         PersistentTasksCustomMetadata persistentTasks = state.metadata().custom(PersistentTasksCustomMetadata.TYPE);
         if (persistentTasks == null) {
+            LOGGER.trace("Not checking databases because persistent tasks are null");
             return;
         }
 
         IndexAbstraction databasesAbstraction = state.getMetadata().getIndicesLookup().get(GeoIpDownloader.DATABASES_INDEX);
         if (databasesAbstraction == null) {
+            LOGGER.trace("Not checking databases because geoip databases index does not exist");
             return;
         } else {
             // regardless of whether DATABASES_INDEX is an alias, resolve it to a concrete index
             Index databasesIndex = databasesAbstraction.getWriteIndex();
             IndexRoutingTable databasesIndexRT = state.getRoutingTable().index(databasesIndex);
             if (databasesIndexRT == null || databasesIndexRT.allPrimaryShardsActive() == false) {
+                LOGGER.trace("Not checking databases because geoip databases index does not have all active primary shards");
                 return;
             }
         }
@@ -244,6 +248,7 @@ public final class DatabaseNodeService implements Closeable {
     }
 
     void retrieveAndUpdateDatabase(String databaseName, GeoIpTaskState.Metadata metadata) throws IOException {
+        LOGGER.trace("Retrieving database {}", databaseName);
         final String recordedMd5 = metadata.md5();
 
         // This acts as a lock, if this method for a specific db is executed later and downloaded for this db is still ongoing then


### PR DESCRIPTION
It looks like it is possible that creating the `.geoip_databases` index can occasionally take long enough that `GeoIpDownloaderIT.testUseGeoIpProcessorWithDownloadedDBs()` fails. See https://github.com/elastic/elasticsearch/issues/86339#issuecomment-1314201313 for more discussion. This PR lets the test waiting a little bit longer so that it still passes when that happens. It also adds some trace logging that is useful for understanding why the geoip downloader has not started.
Closes #86339