### PR TITLE
[7.17] Fix output dir creation in ConcatFileTask (#91568)

### DIFF
--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/ConcatFilesTask.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/ConcatFilesTask.java
@@ -83,7 +83,7 @@ public class ConcatFilesTask extends DefaultTask {
     @TaskAction
     public void concatFiles() throws IOException {
         if (getHeaderLine() != null) {
-            getTarget().mkdirs();
+            getTarget().getParentFile().mkdirs();
             Files.write(getTarget().toPath(), (getHeaderLine() + '\n').getBytes(StandardCharsets.UTF_8));
         }
 


### PR DESCRIPTION
Backports the following commits to 7.17:
 - Fix output dir creation in ConcatFileTask (#91568)