### PR TITLE
[Synthetics] Add synthetics-* read to fleet-server (#91391)

### DIFF
--- a/x-pack/docs/en/rest-api/security/get-service-accounts.asciidoc
+++ b/x-pack/docs/en/rest-api/security/get-service-accounts.asciidoc
@@ -73,7 +73,6 @@ GET /_security/service/elastic/fleet-server
             "logs-*",
             "metrics-*",
             "traces-*",
-            "synthetics-*",
             ".logs-endpoint.diagnostic.collection-*",
             ".logs-endpoint.action.responses-*"
           ],
@@ -108,6 +107,18 @@ GET /_security/service/elastic/fleet-server
             "maintenance"
           ],
           "allow_restricted_indices": true
+        },
+        {
+          "names": [
+            "synthetics-*"
+          ],
+          "privileges": [
+            "read",
+            "write",
+            "create_index",
+            "auto_configure"
+          ],
+          "allow_restricted_indices": false
         }
       ],
       "applications": [

--- a/x-pack/plugin/security/qa/service-account/src/javaRestTest/java/org/elasticsearch/xpack/security/authc/service/ServiceAccountIT.java
+++ b/x-pack/plugin/security/qa/service-account/src/javaRestTest/java/org/elasticsearch/xpack/security/authc/service/ServiceAccountIT.java
@@ -90,7 +90,6 @@ public class ServiceAccountIT extends ESRestTestCase {
                     "logs-*",
                     "metrics-*",
                     "traces-*",
-                    "synthetics-*",
                     ".logs-endpoint.diagnostic.collection-*",
                     ".logs-endpoint.action.responses-*"
                   ],
@@ -125,6 +124,18 @@ public class ServiceAccountIT extends ESRestTestCase {
                     "maintenance"
                   ],
                   "allow_restricted_indices": true
+                },
+                {
+                  "names": [
+                    "synthetics-*"
+                  ],
+                  "privileges": [
+                    "read",
+                    "write",
+                    "create_index",
+                    "auto_configure"
+                  ],
+                  "allow_restricted_indices": false
                 }
               ],
               "applications": [        {

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/service/ElasticServiceAccounts.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/service/ElasticServiceAccounts.java
@@ -68,7 +68,6 @@ final class ElasticServiceAccounts {
                         "logs-*",
                         "metrics-*",
                         "traces-*",
-                        "synthetics-*",
                         ".logs-endpoint.diagnostic.collection-*",
                         ".logs-endpoint.action.responses-*"
                     )
@@ -88,6 +87,12 @@ final class ElasticServiceAccounts {
                     // Fleet Server needs "maintenance" privilege to be able to perform operations with "refresh"
                     .privileges("read", "write", "monitor", "create_index", "auto_configure", "maintenance")
                     .allowRestrictedIndices(true)
+                    .build(),
+                RoleDescriptor.IndicesPrivileges.builder()
+                    .indices("synthetics-*")
+                    // Fleet Server needs "read" privilege to be able to retrieve multi-agent docs
+                    .privileges("read", "write", "create_index", "auto_configure")
+                    .allowRestrictedIndices(false)
                     .build() },
             new RoleDescriptor.ApplicationResourcePrivileges[] {
                 RoleDescriptor.ApplicationResourcePrivileges.builder()

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/service/ElasticServiceAccountsTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/service/ElasticServiceAccountsTests.java
@@ -177,7 +177,6 @@ public class ElasticServiceAccountsTests extends ESTestCase {
             "logs-" + randomAlphaOfLengthBetween(1, 20),
             "metrics-" + randomAlphaOfLengthBetween(1, 20),
             "traces-" + randomAlphaOfLengthBetween(1, 20),
-            "synthetics-" + randomAlphaOfLengthBetween(1, 20),
             ".logs-endpoint.diagnostic.collection-" + randomAlphaOfLengthBetween(1, 20),
             ".logs-endpoint.action.responses-" + randomAlphaOfLengthBetween(1, 20)
         ).stream().map(this::mockIndexAbstraction).forEach(index -> {
@@ -192,6 +191,21 @@ public class ElasticServiceAccountsTests extends ESTestCase {
             assertThat(role.indices().allowedIndicesMatcher(MultiGetAction.NAME).test(index), is(false));
             assertThat(role.indices().allowedIndicesMatcher(SearchAction.NAME).test(index), is(false));
             assertThat(role.indices().allowedIndicesMatcher(MultiSearchAction.NAME).test(index), is(false));
+            assertThat(role.indices().allowedIndicesMatcher(UpdateSettingsAction.NAME).test(index), is(false));
+        });
+
+        List.of("synthetics-" + randomAlphaOfLengthBetween(1, 20)).stream().map(this::mockIndexAbstraction).forEach(index -> {
+            assertThat(role.indices().allowedIndicesMatcher(AutoPutMappingAction.NAME).test(index), is(true));
+            assertThat(role.indices().allowedIndicesMatcher(AutoCreateAction.NAME).test(index), is(true));
+            assertThat(role.indices().allowedIndicesMatcher(DeleteAction.NAME).test(index), is(true));
+            assertThat(role.indices().allowedIndicesMatcher(CreateIndexAction.NAME).test(index), is(true));
+            assertThat(role.indices().allowedIndicesMatcher(IndexAction.NAME).test(index), is(true));
+            assertThat(role.indices().allowedIndicesMatcher(BulkAction.NAME).test(index), is(true));
+            assertThat(role.indices().allowedIndicesMatcher(DeleteIndexAction.NAME).test(index), is(false));
+            assertThat(role.indices().allowedIndicesMatcher(GetAction.NAME).test(index), is(true));
+            assertThat(role.indices().allowedIndicesMatcher(MultiGetAction.NAME).test(index), is(true));
+            assertThat(role.indices().allowedIndicesMatcher(SearchAction.NAME).test(index), is(true));
+            assertThat(role.indices().allowedIndicesMatcher(MultiSearchAction.NAME).test(index), is(true));
             assertThat(role.indices().allowedIndicesMatcher(UpdateSettingsAction.NAME).test(index), is(false));
         });
 


### PR DESCRIPTION
Add read synthetics-* privilege for elastic/fleet-server service account.

related: https://github.com/elastic/beats/issues/33299

Backport: #91391