### PR TITLE
Add wait_if_ongoing for refresh API increasing refresh reliability

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/indices/refresh/RefreshIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/indices/refresh/RefreshIT.java
@@ -109,8 +109,7 @@ public class RefreshIT extends ESIntegTestCase {
         );
         ensureGreen(index);
         AtomicBoolean stopped = new AtomicBoolean();
-        // Thread[] threads = new Thread[between(1, 4)];
-        Thread[] threads = new Thread[2];
+         Thread[] threads = new Thread[between(2, 4)];
         AtomicInteger docID = new AtomicInteger();
         for (int i = 0; i < threads.length; i++) {
             threads[i] = new Thread(() -> {

--- a/server/src/internalClusterTest/java/org/elasticsearch/indices/refresh/RefreshIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/indices/refresh/RefreshIT.java
@@ -1,0 +1,249 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.indices.refresh;
+
+import org.elasticsearch.ElasticsearchException;
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.admin.indices.refresh.RefreshResponse;
+import org.elasticsearch.action.admin.indices.stats.ShardStats;
+import org.elasticsearch.action.index.IndexResponse;
+import org.elasticsearch.action.support.replication.ReplicationRequest;
+import org.elasticsearch.cluster.metadata.IndexMetadata;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.index.IndexService;
+import org.elasticsearch.index.IndexSettings;
+import org.elasticsearch.index.refresh.RefreshStats;
+import org.elasticsearch.indices.IndexingMemoryController;
+import org.elasticsearch.plugins.Plugin;
+import org.elasticsearch.test.ESIntegTestCase;
+import org.elasticsearch.test.InternalSettingsPlugin;
+import org.elasticsearch.test.InternalTestCluster;
+import org.elasticsearch.xcontent.XContentType;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.elasticsearch.action.DocWriteResponse.Result.CREATED;
+import static org.elasticsearch.action.DocWriteResponse.Result.UPDATED;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
+import static org.hamcrest.Matchers.emptyIterable;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.lessThanOrEqualTo;
+import static org.hamcrest.Matchers.oneOf;
+
+@ESIntegTestCase.ClusterScope(scope = ESIntegTestCase.Scope.TEST, numDataNodes = 2)
+public class RefreshIT extends ESIntegTestCase {
+    @Override
+    protected Collection<Class<? extends Plugin>> nodePlugins() {
+        return Collections.singletonList(InternalSettingsPlugin.class);
+    }
+
+    public void testWaitIfOngoing() throws InterruptedException {
+        createIndex("test");
+        ensureGreen("test");
+        final int numIters = scaledRandomIntBetween(10, 30);
+
+        for (int i = 0; i < numIters; i++) {
+            for (int j = 0; j < 10; j++) {
+                client().prepareIndex("test").setSource("{}", XContentType.JSON).get();
+            }
+            final CountDownLatch latch = new CountDownLatch(10);
+            final CopyOnWriteArrayList<Throwable> errors = new CopyOnWriteArrayList<>();
+            for (int j = 0; j < 10; j++) {
+                client().admin().indices().prepareRefresh("test").execute(new ActionListener<RefreshResponse>() {
+                    @Override
+                    public void onResponse(RefreshResponse refreshResponse) {
+                        try {
+                            // don't use assertAllSuccessful it uses a randomized context that belongs to a different thread
+                            assertThat(
+                                "Unexpected ShardFailures: " + Arrays.toString(refreshResponse.getShardFailures()),
+                                refreshResponse.getFailedShards(),
+                                equalTo(0)
+                            );
+                            latch.countDown();
+                        } catch (Exception ex) {
+                            onFailure(ex);
+                        }
+                    }
+
+                    @Override
+                    public void onFailure(Exception e) {
+                        errors.add(e);
+                        latch.countDown();
+                    }
+                });
+            }
+            latch.await();
+            assertThat(errors, emptyIterable());
+        }
+    }
+
+    public void testRefreshWithBlocked() throws Exception {
+        String index = "refresh_block";
+        long shards = 3;
+        long replicas = 1;
+        final long totalDoc = 100;
+        createIndex(
+            index,
+            Settings.builder()
+                .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, shards)
+                .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, replicas)
+                .put(IndexMetadata.SETTING_AUTO_EXPAND_REPLICAS, "false")
+                .build()
+        );
+        ensureGreen(index);
+        AtomicBoolean stopped = new AtomicBoolean();
+        // Thread[] threads = new Thread[between(1, 4)];
+        Thread[] threads = new Thread[2];
+        AtomicInteger docID = new AtomicInteger();
+        for (int i = 0; i < threads.length; i++) {
+            threads[i] = new Thread(() -> {
+                while (stopped.get() == false && docID.get() < totalDoc) {
+                    String id = Integer.toString(docID.incrementAndGet());
+                    try {
+                        IndexResponse response = client().prepareIndex(index)
+                            .setId(id)
+                            .setSource(Map.of("f" + randomIntBetween(1, 10), randomNonNegativeLong()), XContentType.JSON)
+                            .get();
+                        assertThat(response.getResult(), is(oneOf(CREATED, UPDATED)));
+                        logger.info("--> index id={} seq_no={}", response.getId(), response.getSeqNo());
+                        RefreshResponse refreshResponse = client().admin().indices().prepareRefresh(index).setWaitIfOngoing(true).get();
+                        assertEquals(refreshResponse.getShardFailures().length, 0);
+                    } catch (ElasticsearchException ignore) {
+                        logger.info("--> fail to index id={}", id);
+                    }
+                }
+            });
+            threads[i].start();
+        }
+
+        for (Thread thread : threads) {
+            thread.join();
+        }
+
+        ensureGreen(index);
+        assertBusy(() -> assertThat(docID.get(), greaterThanOrEqualTo(1)));
+        RefreshStats refreshStats = client().admin().indices().prepareStats(index).clear().setRefresh(true).get().getTotal().refresh;
+
+        assertThat(refreshStats.getTotal(), greaterThanOrEqualTo(totalDoc * shards * (1 + replicas)));
+
+        assertAcked(client().admin().indices().prepareDelete(index));
+        stopped.set(true);
+        for (Thread thread : threads) {
+            thread.join(ReplicationRequest.DEFAULT_TIMEOUT.millis() / 2);
+            assertFalse(thread.isAlive());
+        }
+
+    }
+
+    public void testRefreshWithNonBlocked() throws Exception {
+        String index = "refresh_nonblock";
+        long shards = 3;
+        long replicas = 1;
+        final long totalDoc = 100;
+        createIndex(
+            index,
+            Settings.builder()
+                .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, shards)
+                .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, replicas)
+                .put(IndexMetadata.SETTING_AUTO_EXPAND_REPLICAS, "false")
+                .build()
+        );
+        ensureGreen(index);
+        AtomicBoolean stopped = new AtomicBoolean();
+        Thread[] threads = new Thread[between(2, 4)];
+        AtomicInteger docID = new AtomicInteger();
+        for (int i = 0; i < threads.length; i++) {
+            threads[i] = new Thread(() -> {
+                while (stopped.get() == false && docID.get() < totalDoc) {
+                    String id = Integer.toString(docID.incrementAndGet());
+                    try {
+                        IndexResponse response = client().prepareIndex(index)
+                            .setId(id)
+                            .setSource(Map.of("f" + randomIntBetween(1, 10), randomNonNegativeLong()), XContentType.JSON)
+                            .get();
+                        assertThat(response.getResult(), is(oneOf(CREATED, UPDATED)));
+                        logger.info("--> index id={} seq_no={}", response.getId(), response.getSeqNo());
+                        RefreshResponse refreshResponse = client().admin().indices().prepareRefresh(index).setWaitIfOngoing(false).get();
+                        assertEquals(refreshResponse.getShardFailures().length, 0);
+                    } catch (ElasticsearchException ignore) {
+                        logger.info("--> fail to index id={}", id);
+                    }
+                }
+            });
+            threads[i].start();
+        }
+
+        for (Thread thread : threads) {
+            thread.join();
+        }
+
+        ensureGreen(index);
+        assertBusy(() -> assertThat(docID.get(), greaterThanOrEqualTo(1)));
+        RefreshStats refreshStats = client().admin().indices().prepareStats(index).clear().setRefresh(true).get().getTotal().refresh;
+        assertThat(refreshStats.getTotal(), lessThanOrEqualTo(totalDoc * shards * (1 + replicas)));
+
+        assertAcked(client().admin().indices().prepareDelete(index));
+        stopped.set(true);
+        for (Thread thread : threads) {
+            thread.join(ReplicationRequest.DEFAULT_TIMEOUT.millis() / 2);
+            assertFalse(thread.isAlive());
+        }
+    }
+
+    public void testRefreshOnInactive() throws Exception {
+        final String indexName = "refresh_on_inactive";
+        List<String> dataNodes = internalCluster().startDataOnlyNodes(
+            2,
+            Settings.builder()
+                .put(IndexingMemoryController.SHARD_INACTIVE_TIME_SETTING.getKey(), randomTimeValue(10, 1000, "ms"))
+                .put(IndexingMemoryController.SHARD_MEMORY_INTERVAL_TIME_SETTING.getKey(), randomTimeValue(10, 1000, "ms"))
+                .build()
+        );
+        assertAcked(
+            client().admin()
+                .indices()
+                .prepareCreate(indexName)
+                .setSettings(
+                    Settings.builder()
+                        .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1)
+                        .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 1)
+                        .put(IndexSettings.INDEX_TRANSLOG_SYNC_INTERVAL_SETTING.getKey(), randomTimeValue(200, 500, "ms"))
+                        .put(IndexService.GLOBAL_CHECKPOINT_SYNC_INTERVAL_SETTING.getKey(), randomTimeValue(50, 200, "ms"))
+                        .put("index.routing.allocation.include._name", String.join(",", dataNodes))
+                        .build()
+                )
+        );
+        ensureGreen(indexName);
+        int numDocs = randomIntBetween(1, 10);
+        for (int i = 0; i < numDocs; i++) {
+            client().prepareIndex(indexName).setSource("f", "v").get();
+        }
+        if (randomBoolean()) {
+            internalCluster().restartNode(randomFrom(dataNodes), new InternalTestCluster.RestartCallback());
+            ensureGreen(indexName);
+        }
+
+        assertBusy(() -> {
+            for (ShardStats shardStats : client().admin().indices().prepareStats(indexName).get().getShards()) {
+                assertThat(shardStats.getStats().getTranslog().getUncommittedOperations(), equalTo(0));
+            }
+        }, 30, TimeUnit.SECONDS);
+    }
+}

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/refresh/RefreshRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/refresh/RefreshRequest.java
@@ -10,6 +10,7 @@ package org.elasticsearch.action.admin.indices.refresh;
 
 import org.elasticsearch.action.support.broadcast.BroadcastRequest;
 import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
 
 import java.io.IOException;
 
@@ -24,11 +25,43 @@ import java.io.IOException;
  */
 public class RefreshRequest extends BroadcastRequest<RefreshRequest> {
 
+    private boolean waitIfOngoing = true;
+
     public RefreshRequest(String... indices) {
         super(indices);
     }
 
     public RefreshRequest(StreamInput in) throws IOException {
         super(in);
+        waitIfOngoing = in.readBoolean();
+    }
+
+    /**
+     * Returns {@code true} iff a flush should block
+     * if a another flush operation is already running. Otherwise {@code false}
+     */
+    public boolean waitIfOngoing() {
+        return this.waitIfOngoing;
+    }
+
+    /**
+     * if set to {@code true} the flush will block
+     * if a another flush operation is already running until the flush can be performed.
+     * The default is <code>true</code>
+     */
+    public RefreshRequest waitIfOngoing(boolean waitIfOngoing) {
+        this.waitIfOngoing = waitIfOngoing;
+        return this;
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        super.writeTo(out);
+        out.writeBoolean(waitIfOngoing);
+    }
+
+    @Override
+    public String toString() {
+        return "RefreshRequest{" + "waitIfOngoing=" + waitIfOngoing + "}";
     }
 }

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/refresh/RefreshRequestBuilder.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/refresh/RefreshRequestBuilder.java
@@ -21,4 +21,9 @@ public class RefreshRequestBuilder extends BroadcastOperationRequestBuilder<Refr
     public RefreshRequestBuilder(ElasticsearchClient client, RefreshAction action) {
         super(client, action, new RefreshRequest());
     }
+
+    public RefreshRequestBuilder setWaitIfOngoing(boolean waitIfOngoing) {
+        request.waitIfOngoing(waitIfOngoing);
+        return this;
+    }
 }

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/refresh/ShardRefreshRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/refresh/ShardRefreshRequest.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.action.admin.indices.refresh;
+
+import org.elasticsearch.action.support.ActiveShardCount;
+import org.elasticsearch.action.support.replication.ReplicationRequest;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.index.shard.ShardId;
+
+import java.io.IOException;
+
+public class ShardRefreshRequest extends ReplicationRequest<ShardRefreshRequest> {
+
+    private final RefreshRequest request;
+
+    public ShardRefreshRequest(RefreshRequest request, ShardId shardId) {
+        super(shardId);
+        this.request = request;
+        this.waitForActiveShards = ActiveShardCount.NONE; // don't wait for any active shards before proceeding, by default
+    }
+
+    public ShardRefreshRequest(StreamInput in) throws IOException {
+        super(in);
+        request = new RefreshRequest(in);
+    }
+
+    RefreshRequest getRequest() {
+        return request;
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        super.writeTo(out);
+        request.writeTo(out);
+    }
+
+    @Override
+    public String toString() {
+        return "refresh {" + shardId + "}";
+    }
+}

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/refresh/TransportRefreshAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/refresh/TransportRefreshAction.java
@@ -9,9 +9,7 @@
 package org.elasticsearch.action.admin.indices.refresh;
 
 import org.elasticsearch.action.support.ActionFilters;
-import org.elasticsearch.action.support.ActiveShardCount;
 import org.elasticsearch.action.support.DefaultShardOperationFailedException;
-import org.elasticsearch.action.support.replication.BasicReplicationRequest;
 import org.elasticsearch.action.support.replication.ReplicationResponse;
 import org.elasticsearch.action.support.replication.TransportBroadcastReplicationAction;
 import org.elasticsearch.client.internal.node.NodeClient;
@@ -29,7 +27,7 @@ import java.util.List;
 public class TransportRefreshAction extends TransportBroadcastReplicationAction<
     RefreshRequest,
     RefreshResponse,
-    BasicReplicationRequest,
+    ShardRefreshRequest,
     ReplicationResponse> {
 
     @Inject
@@ -58,10 +56,8 @@ public class TransportRefreshAction extends TransportBroadcastReplicationAction<
     }
 
     @Override
-    protected BasicReplicationRequest newShardRequest(RefreshRequest request, ShardId shardId) {
-        BasicReplicationRequest replicationRequest = new BasicReplicationRequest(shardId);
-        replicationRequest.waitForActiveShards(ActiveShardCount.NONE);
-        return replicationRequest;
+    protected ShardRefreshRequest newShardRequest(RefreshRequest request, ShardId shardId) {
+        return new ShardRefreshRequest(request, shardId);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/index/shard/IndexShard.java
+++ b/server/src/main/java/org/elasticsearch/index/shard/IndexShard.java
@@ -33,6 +33,7 @@ import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.ActionRunnable;
 import org.elasticsearch.action.admin.indices.flush.FlushRequest;
 import org.elasticsearch.action.admin.indices.forcemerge.ForceMergeRequest;
+import org.elasticsearch.action.admin.indices.refresh.RefreshRequest;
 import org.elasticsearch.action.support.replication.PendingReplicationActions;
 import org.elasticsearch.action.support.replication.ReplicationResponse;
 import org.elasticsearch.cluster.metadata.DataStream;
@@ -1212,6 +1213,25 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
     }
 
     /**
+     * Executes the given refresh request
+     *
+     * @param request
+     * @return <code>false</code> if <code>waitIfOngoing==false</code> and an ongoing request is detected, else <code>true</code>
+     *         If <code>false</code> is returned, there is in-flight refreshing.
+     */
+    public boolean refresh(RefreshRequest request, String source) {
+        final boolean waitIfOngoing = request.waitIfOngoing();
+        boolean refreshed = true;
+        logger.trace("refresh with {}", request);
+        if (waitIfOngoing) {
+            refresh(source);
+        } else {
+            refreshed = maybeRefresh(source);
+        }
+        return refreshed;
+    }
+
+    /**
      * Writes all indexing changes to disk and opens a new searcher reflecting all changes.  This can throw {@link AlreadyClosedException}.
      */
     public void refresh(String source) {
@@ -1220,6 +1240,14 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
             logger.trace("refresh with source [{}]", source);
         }
         getEngine().refresh(source);
+    }
+
+    public boolean maybeRefresh(String source) {
+        verifyNotClosed();
+        if (logger.isTraceEnabled()) {
+            logger.trace("maybeRefresh with source [{}]", source);
+        }
+        return getEngine().maybeRefresh(source);
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/rest/action/admin/indices/RestRefreshAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/admin/indices/RestRefreshAction.java
@@ -45,7 +45,8 @@ public class RestRefreshAction extends BaseRestHandler {
     public RestChannelConsumer prepareRequest(final RestRequest request, final NodeClient client) throws IOException {
         RefreshRequest refreshRequest = new RefreshRequest(Strings.splitStringByCommaToArray(request.param("index")));
         refreshRequest.indicesOptions(IndicesOptions.fromRequest(request, refreshRequest.indicesOptions()));
-        return channel -> client.admin().indices().refresh(refreshRequest, new RestToXContentListener<RefreshResponse>(channel) {
+        refreshRequest.waitIfOngoing(request.paramAsBoolean("wait_if_ongoing", refreshRequest.waitIfOngoing()));
+        return channel -> client.admin().indices().refresh(refreshRequest, new RestToXContentListener<>(channel) {
             @Override
             protected RestStatus getStatus(RefreshResponse response) {
                 return response.getStatus();

--- a/test/framework/src/main/java/org/elasticsearch/test/rest/ESRestTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/rest/ESRestTestCase.java
@@ -1131,6 +1131,7 @@ public abstract class ESRestTestCase extends ESTestCase {
         boolean includeHidden = minimumNodeVersion().onOrAfter(Version.V_7_7_0);
         Request refreshRequest = new Request("POST", "/_refresh");
         refreshRequest.addParameter("expand_wildcards", "open" + (includeHidden ? ",hidden" : ""));
+        refreshRequest.addParameter("wait_if_ongoing", "true");
         // Allow system index deprecation warnings
         refreshRequest.setOptions(RequestOptions.DEFAULT.toBuilder().setWarningsHandler(warnings -> {
             if (warnings.isEmpty()) {


### PR DESCRIPTION
### Problem Statement
ISSUE: #91579

When we have many frequently update and refresh request for many indices (i know refresh is a resource-intensive api as [docs](https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-refresh.html) says: ). 

it shows that refresh queue would blocked `hundreds of thousands of queued requests` even in 3 nodes with 16G heap, 10 primary shards, 20 replications shards, and 400G storage, ES Version 8.4.3,  96 Core CPU
![image](https://user-images.githubusercontent.com/12760367/201847938-1a4e80a8-db9d-45e8-9143-559c78d44d52.png)

I think this because 
1. `REFRESH` thread pool type is `ThreadPoolType.SCALING`
2. `TransportShardRefreshAction` is extends of `TransportReplicationAction` which `forceExecution` is default true in replication(like [TransportReplicationAction.java#L200](https://github.com/elastic/elasticsearch/blob/main/server/src/main/java/org/elasticsearch/action/support/replication/TransportReplicationAction.java#L200) )
3. `REFRESH` API would call InternalEngine refresh with `block = true` (like [InternalEngine.java#L1795](https://github.com/elastic/elasticsearch/blob/main/server/src/main/java/org/elasticsearch/index/engine/InternalEngine.java#L1795) )  and in hot threads shows __block in acquire lock__
![9c94f741-3406-4949-a6af-c51c6ac204b3](https://user-images.githubusercontent.com/12760367/201852208-d1b6deaf-497f-4e9c-8b2a-edca630d8cf2.jpeg)

So a refresh request would expands to `indices * shards * replications` (in our test case is 30), with blocked executions

### Proposal 

May be we can add a `wait_if_ongoing` parameter in refresh api like [`flush` api](https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-flush.html#flush-api-query-params). which can make refresh requests with `nonblocking`. just calling `InternalEngine#maybeRefresh`. when it can not acquire a lock, it must be a in-flight refresh task is running
