### PR TITLE
Consolidate search request parsing methods

### DIFF
--- a/server/src/main/java/org/elasticsearch/rest/action/search/RestSearchAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/search/RestSearchAction.java
@@ -43,7 +43,6 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Locale;
 import java.util.Set;
-import java.util.function.BiConsumer;
 import java.util.function.IntConsumer;
 
 import static org.elasticsearch.action.ValidateActions.addValidationError;
@@ -128,21 +127,6 @@ public class RestSearchAction extends BaseRestHandler {
         NamedWriteableRegistry namedWriteableRegistry,
         IntConsumer setSize
     ) throws IOException {
-        parseSearchRequest(searchRequest, request, requestContentParser, namedWriteableRegistry, setSize, (r, sr) -> {});
-    }
-
-    /**
-     * Parses the rest request on top of the SearchRequest, preserving values that are not overridden by the rest request. This variation
-     * allows the caller to specify if wait_for_checkpoints functionality is supported.
-     */
-    public static void parseSearchRequest(
-        SearchRequest searchRequest,
-        RestRequest request,
-        XContentParser requestContentParser,
-        NamedWriteableRegistry namedWriteableRegistry,
-        IntConsumer setSize,
-        BiConsumer<RestRequest, SearchRequest> extraParamParser
-    ) throws IOException {
         if (request.getRestApiVersion() == RestApiVersion.V_7 && request.hasParam("type")) {
             request.param("type");
             deprecationLogger.compatibleCritical("search_with_types", TYPES_DEPRECATION_MESSAGE);
@@ -204,8 +188,6 @@ public class RestSearchAction extends BaseRestHandler {
         if (request.paramAsBoolean("force_synthetic_source", false)) {
             searchRequest.setForceSyntheticSource(true);
         }
-
-        extraParamParser.accept(request, searchRequest);
     }
 
     /**

--- a/x-pack/plugin/fleet/src/main/java/org/elasticsearch/xpack/fleet/rest/RestFleetSearchAction.java
+++ b/x-pack/plugin/fleet/src/main/java/org/elasticsearch/xpack/fleet/rest/RestFleetSearchAction.java
@@ -57,36 +57,25 @@ public class RestFleetSearchAction extends BaseRestHandler {
         }
 
         IntConsumer setSize = size -> searchRequest.source().size(size);
-        request.withContentOrSourceParamParserOrNull(
-            parser -> RestSearchAction.parseSearchRequest(
-                searchRequest,
-                request,
-                parser,
-                client.getNamedWriteableRegistry(),
-                setSize,
-                (restRequest, sr) -> {
-                    String[] stringWaitForCheckpoints = request.paramAsStringArray("wait_for_checkpoints", Strings.EMPTY_ARRAY);
-                    final long[] waitForCheckpoints = new long[stringWaitForCheckpoints.length];
-                    for (int i = 0; i < stringWaitForCheckpoints.length; ++i) {
-                        waitForCheckpoints[i] = Long.parseLong(stringWaitForCheckpoints[i]);
-                    }
-                    String[] indices1 = Strings.splitStringByCommaToArray(request.param("index"));
-                    if (indices1.length > 1) {
-                        throw new IllegalArgumentException(
-                            "Fleet search API only supports searching a single index. Found: [" + Arrays.toString(indices1) + "]."
-                        );
-                    }
-                    if (waitForCheckpoints.length != 0) {
-                        sr.setWaitForCheckpoints(Collections.singletonMap(indices1[0], waitForCheckpoints));
-                    }
-                    final TimeValue waitForCheckpointsTimeout = request.paramAsTime(
-                        "wait_for_checkpoints_timeout",
-                        TimeValue.timeValueSeconds(30)
-                    );
-                    sr.setWaitForCheckpointsTimeout(waitForCheckpointsTimeout);
-                }
-            )
-        );
+        request.withContentOrSourceParamParserOrNull(parser -> {
+            RestSearchAction.parseSearchRequest(searchRequest, request, parser, client.getNamedWriteableRegistry(), setSize);
+            String[] stringWaitForCheckpoints = request.paramAsStringArray("wait_for_checkpoints", Strings.EMPTY_ARRAY);
+            final long[] waitForCheckpoints = new long[stringWaitForCheckpoints.length];
+            for (int i = 0; i < stringWaitForCheckpoints.length; ++i) {
+                waitForCheckpoints[i] = Long.parseLong(stringWaitForCheckpoints[i]);
+            }
+            String[] indices1 = Strings.splitStringByCommaToArray(request.param("index"));
+            if (indices1.length > 1) {
+                throw new IllegalArgumentException(
+                    "Fleet search API only supports searching a single index. Found: [" + Arrays.toString(indices1) + "]."
+                );
+            }
+            if (waitForCheckpoints.length != 0) {
+                searchRequest.setWaitForCheckpoints(Collections.singletonMap(indices1[0], waitForCheckpoints));
+            }
+            final TimeValue waitForCheckpointsTimeout = request.paramAsTime("wait_for_checkpoints_timeout", TimeValue.timeValueSeconds(30));
+            searchRequest.setWaitForCheckpointsTimeout(waitForCheckpointsTimeout);
+        });
 
         return channel -> {
             RestCancellableNodeClient cancelClient = new RestCancellableNodeClient(client, request.getHttpChannel());


### PR DESCRIPTION
We have two variants of RestSearchAction#parseSearchRequest. One that is most commonly used, while the other one is used only by the REST fleet search action to parse the additional wait_for_checkpoint parameter. The latter does not need an additional consumer argument to implement the additional parsing, as it can instead reuse the former and do the additional parsing as part of the existing parser callback.

With this change, we have a single method to parse an incoming search request instead of two.
