### PR TITLE
add merge filters before building cluster filters (#55815)

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/node/DiscoveryNodeFilters.java
+++ b/server/src/main/java/org/elasticsearch/cluster/node/DiscoveryNodeFilters.java
@@ -15,10 +15,13 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.transport.TransportAddress;
 import org.elasticsearch.core.Nullable;
 
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 public class DiscoveryNodeFilters {
 
@@ -45,6 +48,11 @@ public class DiscoveryNodeFilters {
                 }
             }
         }
+    }
+
+    public static Map<String, List<String>> mergeFilters(Map<String, List<String>> exist, Map<String, List<String>> toApply) {
+        return Stream.concat(exist.entrySet().stream(), toApply.entrySet().stream())
+            .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue, (existValue, toApplyValue) -> toApplyValue));
     }
 
     public static DiscoveryNodeFilters buildFromKeyValues(OpType opType, Map<String, List<String>> filters) {
@@ -103,6 +111,10 @@ public class DiscoveryNodeFilters {
         final String[] removed = newFilters.remove("_tier_preference");
         assert removed != null;
         return newFilters.isEmpty() ? null : new DiscoveryNodeFilters(original.opType, newFilters);
+    }
+
+    public Map<String, List<String>> getFilters() {
+        return filters.entrySet().stream().collect(Collectors.toMap(Map.Entry::getKey, entry -> Arrays.stream(entry.getValue()).toList()));
     }
 
     public boolean match(DiscoveryNode node) {

--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/FilterAllocationDecider.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/FilterAllocationDecider.java
@@ -218,15 +218,36 @@ public class FilterAllocationDecider extends AllocationDecider {
     }
 
     private void setClusterRequireFilters(Map<String, List<String>> filters) {
-        clusterRequireFilters = DiscoveryNodeFilters.trimTier(DiscoveryNodeFilters.buildFromKeyValues(AND, filters));
+        Map<String, List<String>> newFilters;
+        if (clusterRequireFilters != null) {
+            newFilters = DiscoveryNodeFilters.mergeFilters(clusterRequireFilters.getFilters(), filters);
+        } else {
+            newFilters = filters;
+        }
+
+        clusterRequireFilters = DiscoveryNodeFilters.trimTier(DiscoveryNodeFilters.buildFromKeyValues(AND, newFilters));
     }
 
     private void setClusterIncludeFilters(Map<String, List<String>> filters) {
-        clusterIncludeFilters = DiscoveryNodeFilters.trimTier(DiscoveryNodeFilters.buildFromKeyValues(OR, filters));
+        Map<String, List<String>> newFilters;
+        if (clusterIncludeFilters != null) {
+            newFilters = DiscoveryNodeFilters.mergeFilters(clusterIncludeFilters.getFilters(), filters);
+        } else {
+            newFilters = filters;
+        }
+
+        clusterIncludeFilters = DiscoveryNodeFilters.trimTier(DiscoveryNodeFilters.buildFromKeyValues(OR, newFilters));
     }
 
     private void setClusterExcludeFilters(Map<String, List<String>> filters) {
-        clusterExcludeFilters = DiscoveryNodeFilters.trimTier(DiscoveryNodeFilters.buildFromKeyValues(OR, filters));
+        Map<String, List<String>> newFilters;
+        if (clusterExcludeFilters != null) {
+            newFilters = DiscoveryNodeFilters.mergeFilters(clusterExcludeFilters.getFilters(), filters);
+        } else {
+            newFilters = filters;
+        }
+
+        clusterExcludeFilters = DiscoveryNodeFilters.trimTier(DiscoveryNodeFilters.buildFromKeyValues(OR, newFilters));
     }
 
     @Override

--- a/server/src/test/java/org/elasticsearch/cluster/node/DiscoveryNodeFiltersTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/node/DiscoveryNodeFiltersTests.java
@@ -47,6 +47,55 @@ public class DiscoveryNodeFiltersTests extends ESTestCase {
         localAddress = null;
     }
 
+    public void testMergeFilters() {
+        Map<String, List<String>> exist = new HashMap<>();
+        exist.put("xxx.name", List.of("name1"));
+        Map<String, List<String>> toApply = new HashMap<>();
+        toApply.put("xxx.ip", List.of("ip1"));
+        Map<String, List<String>> merge = DiscoveryNodeFilters.mergeFilters(exist, toApply);
+        assertEquals(merge, new HashMap<String, List<String>>() {
+            {
+                put("xxx.name", List.of("name1"));
+                put("xxx.ip", List.of("ip1"));
+            }
+        });
+
+        exist = new HashMap<>();
+        exist.put("xxx.name", List.of("name1"));
+        toApply = new HashMap<>();
+        merge = DiscoveryNodeFilters.mergeFilters(exist, toApply);
+        assertEquals(merge, new HashMap<String, List<String>>() {
+            {
+                put("xxx.name", List.of("name1"));
+            }
+        });
+
+        exist = new HashMap<>();
+        toApply = new HashMap<>();
+        toApply.put("xxx.ip", List.of("ip1"));
+        merge = DiscoveryNodeFilters.mergeFilters(exist, toApply);
+        assertEquals(merge, new HashMap<String, List<String>>() {
+            {
+                put("xxx.ip", List.of("ip1"));
+            }
+        });
+
+        exist = new HashMap<>();
+        exist.put("xxx.name", List.of("name1"));
+        exist.put("xxx.host", List.of("host1"));
+        toApply = new HashMap<>();
+        toApply.put("xxx.ip", List.of("ip1"));
+        toApply.put("xxx.host", List.of("host2"));
+        merge = DiscoveryNodeFilters.mergeFilters(exist, toApply);
+        assertEquals(merge, new HashMap<String, List<String>>() {
+            {
+                put("xxx.name", List.of("name1"));
+                put("xxx.ip", List.of("ip1"));
+                put("xxx.host", List.of("host2"));
+            }
+        });
+    }
+
     public void testNameMatch() {
         Settings settings = Settings.builder().put("xxx.name", "name1").build();
         DiscoveryNodeFilters filters = buildFromSettings(OR, "xxx.", settings);

--- a/server/src/test/java/org/elasticsearch/cluster/routing/allocation/decider/FilterAllocationDeciderTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/allocation/decider/FilterAllocationDeciderTests.java
@@ -18,6 +18,7 @@ import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
 import org.elasticsearch.cluster.routing.RecoverySource;
+import org.elasticsearch.cluster.routing.RoutingNode;
 import org.elasticsearch.cluster.routing.RoutingTable;
 import org.elasticsearch.cluster.routing.ShardRouting;
 import org.elasticsearch.cluster.routing.UnassignedInfo;
@@ -26,6 +27,7 @@ import org.elasticsearch.cluster.routing.allocation.FailedShard;
 import org.elasticsearch.cluster.routing.allocation.RoutingAllocation;
 import org.elasticsearch.cluster.routing.allocation.allocator.BalancedShardsAllocator;
 import org.elasticsearch.cluster.routing.allocation.decider.Decision.Type;
+import org.elasticsearch.common.collect.ImmutableOpenMap;
 import org.elasticsearch.common.settings.ClusterSettings;
 import org.elasticsearch.common.settings.IndexScopedSettings;
 import org.elasticsearch.common.settings.Settings;
@@ -35,12 +37,15 @@ import org.elasticsearch.test.gateway.TestGatewayAllocator;
 
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
 import static org.elasticsearch.cluster.metadata.IndexMetadata.INDEX_RESIZE_SOURCE_NAME;
 import static org.elasticsearch.cluster.metadata.IndexMetadata.INDEX_RESIZE_SOURCE_UUID;
+import static org.elasticsearch.cluster.routing.RoutingNodesHelper.routingNode;
 import static org.elasticsearch.cluster.routing.ShardRoutingState.INITIALIZING;
 import static org.elasticsearch.cluster.routing.ShardRoutingState.STARTED;
 import static org.elasticsearch.cluster.routing.ShardRoutingState.UNASSIGNED;
@@ -326,5 +331,318 @@ public class FilterAllocationDeciderTests extends ESAllocationTestCase {
             new UnassignedInfo(UnassignedInfo.Reason.INDEX_CREATED, "index created")
         );
         assertThat(decider.getForcedInitialShardAllocationToNodes(newShard, allocation), equalTo(Optional.empty()));
+    }
+
+    public void testClusterRequireFilter() {
+        ClusterSettings clusterSettings = new ClusterSettings(Settings.EMPTY, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS);
+        FilterAllocationDecider filterAllocationDecider = new FilterAllocationDecider(Settings.EMPTY, clusterSettings);
+        AllocationDeciders allocationDeciders = new AllocationDeciders(Collections.singleton(filterAllocationDecider));
+
+        String indexName = "test";
+        IndexMetadata indexMetadata = IndexMetadata.builder(indexName)
+            .settings(settings(Version.CURRENT))
+            .numberOfShards(1)
+            .numberOfReplicas(0)
+            .build();
+        ImmutableOpenMap<String, IndexMetadata> indices = ImmutableOpenMap.<String, IndexMetadata>builder()
+            .fPut(indexName, indexMetadata)
+            .build();
+        RoutingAllocation allocation = new RoutingAllocation(
+            allocationDeciders,
+            null,
+            ClusterState.builder(ClusterState.EMPTY_STATE).metadata(Metadata.builder().indices(indices).build()).build(),
+            null,
+            null,
+            0
+        );
+        ShardRouting shard = ShardRouting.newUnassigned(
+            new ShardId(indexName, "_na_", 0),
+            true,
+            RecoverySource.ExistingStoreRecoverySource.INSTANCE,
+            new UnassignedInfo(UnassignedInfo.Reason.INDEX_CREATED, null)
+        );
+
+        Map<String, String> nodeAttrMap1 = new HashMap<>();
+        nodeAttrMap1.put("attr", "n1");
+        Map<String, String> nodeAttrMap2 = new HashMap<>();
+        nodeAttrMap2.put("attr", "n2");
+
+        RoutingNode node1 = routingNode("1", newNode("node1", "1", nodeAttrMap1));
+        RoutingNode node2 = routingNode("2", newNode("node2", "2", nodeAttrMap2));
+
+        Decision decisionNode1 = filterAllocationDecider.canAllocate(shard, node1, allocation);
+        Decision decisionNode2 = filterAllocationDecider.canAllocate(shard, node2, allocation);
+        assertEquals(Type.YES, decisionNode1.type());
+        assertEquals(Type.YES, decisionNode2.type());
+
+        String prefixKey = "cluster.routing.allocation.require.";
+        // set cluster.routing.allocation.require._name to node1
+        clusterSettings.applySettings(Settings.builder().put(prefixKey + "_name", "node1").build());
+        decisionNode1 = filterAllocationDecider.canAllocate(shard, node1, allocation);
+        decisionNode2 = filterAllocationDecider.canAllocate(shard, node2, allocation);
+        assertEquals(Type.YES, decisionNode1.type());
+        assertEquals(Type.NO, decisionNode2.type());
+
+        // set cluster.routing.allocation.require.attr to n2
+        clusterSettings.applySettings(Settings.builder().put(prefixKey + "_name", "node1").put(prefixKey + "attr", "n2").build());
+        decisionNode1 = filterAllocationDecider.canAllocate(shard, node1, allocation);
+        decisionNode2 = filterAllocationDecider.canAllocate(shard, node2, allocation);
+        assertEquals(Type.NO, decisionNode1.type());
+        assertEquals(Type.NO, decisionNode2.type());
+
+        // set cluster.routing.allocation.require.attr to n1
+        clusterSettings.applySettings(Settings.builder().put(prefixKey + "_name", "node1").put(prefixKey + "attr", "n1").build());
+        decisionNode1 = filterAllocationDecider.canAllocate(shard, node1, allocation);
+        decisionNode2 = filterAllocationDecider.canAllocate(shard, node2, allocation);
+        assertEquals(Type.YES, decisionNode1.type());
+        assertEquals(Type.NO, decisionNode2.type());
+    }
+
+    public void testClusterIncludeFilter() {
+        ClusterSettings clusterSettings = new ClusterSettings(Settings.EMPTY, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS);
+        FilterAllocationDecider filterAllocationDecider = new FilterAllocationDecider(Settings.EMPTY, clusterSettings);
+        AllocationDeciders allocationDeciders = new AllocationDeciders(Collections.singleton(filterAllocationDecider));
+
+        String indexName = "test";
+        IndexMetadata indexMetadata = IndexMetadata.builder(indexName)
+            .settings(settings(Version.CURRENT))
+            .numberOfShards(1)
+            .numberOfReplicas(0)
+            .build();
+        ImmutableOpenMap<String, IndexMetadata> indices = ImmutableOpenMap.<String, IndexMetadata>builder()
+            .fPut(indexName, indexMetadata)
+            .build();
+        RoutingAllocation allocation = new RoutingAllocation(
+            allocationDeciders,
+            null,
+            ClusterState.builder(ClusterState.EMPTY_STATE).metadata(Metadata.builder().indices(indices).build()).build(),
+            null,
+            null,
+            0
+        );
+        ShardRouting shard = ShardRouting.newUnassigned(
+            new ShardId(indexName, "_na_", 0),
+            true,
+            RecoverySource.ExistingStoreRecoverySource.INSTANCE,
+            new UnassignedInfo(UnassignedInfo.Reason.INDEX_CREATED, null)
+        );
+
+        Map<String, String> nodeAttrMap1 = new HashMap<>();
+        nodeAttrMap1.put("attr", "n1");
+        Map<String, String> nodeAttrMap2 = new HashMap<>();
+        nodeAttrMap2.put("attr", "n2");
+        Map<String, String> nodeAttrMap3 = new HashMap<>();
+        nodeAttrMap3.put("attr", "n3");
+
+        RoutingNode node1 = routingNode("1", newNode("node1", "1", nodeAttrMap1));
+        RoutingNode node2 = routingNode("2", newNode("node2", "2", nodeAttrMap2));
+        RoutingNode node3 = routingNode("3", newNode("node3", "3", nodeAttrMap3));
+
+        Decision decisionNode1 = filterAllocationDecider.canAllocate(shard, node1, allocation);
+        Decision decisionNode2 = filterAllocationDecider.canAllocate(shard, node2, allocation);
+        Decision decisionNode3 = filterAllocationDecider.canAllocate(shard, node3, allocation);
+        assertEquals(Type.YES, decisionNode1.type());
+        assertEquals(Type.YES, decisionNode2.type());
+        assertEquals(Type.YES, decisionNode3.type());
+
+        String prefixKey = "cluster.routing.allocation.include.";
+        // set cluster.routing.allocation.include._name to node1
+        clusterSettings.applySettings(Settings.builder().put(prefixKey + "_name", "node1").build());
+        decisionNode1 = filterAllocationDecider.canAllocate(shard, node1, allocation);
+        decisionNode2 = filterAllocationDecider.canAllocate(shard, node2, allocation);
+        decisionNode3 = filterAllocationDecider.canAllocate(shard, node3, allocation);
+        assertEquals(Type.YES, decisionNode1.type());
+        assertEquals(Type.NO, decisionNode2.type());
+        assertEquals(Type.NO, decisionNode3.type());
+
+        // set cluster.routing.allocation.include.attr to n2
+        clusterSettings.applySettings(Settings.builder().put(prefixKey + "_name", "node1").put(prefixKey + "attr", "n2").build());
+        decisionNode1 = filterAllocationDecider.canAllocate(shard, node1, allocation);
+        decisionNode2 = filterAllocationDecider.canAllocate(shard, node2, allocation);
+        decisionNode3 = filterAllocationDecider.canAllocate(shard, node3, allocation);
+        assertEquals(Type.YES, decisionNode1.type());
+        assertEquals(Type.YES, decisionNode2.type());
+        assertEquals(Type.NO, decisionNode3.type());
+
+        // set cluster.routing.allocation.include.attr to n1,n2,n3
+        clusterSettings.applySettings(Settings.builder().put(prefixKey + "attr", "n1,n2,n3").build());
+        decisionNode1 = filterAllocationDecider.canAllocate(shard, node1, allocation);
+        decisionNode2 = filterAllocationDecider.canAllocate(shard, node2, allocation);
+        decisionNode3 = filterAllocationDecider.canAllocate(shard, node3, allocation);
+        assertEquals(Type.YES, decisionNode1.type());
+        assertEquals(Type.YES, decisionNode2.type());
+        assertEquals(Type.YES, decisionNode3.type());
+
+        // set cluster.routing.allocation.include.attr to n2,n3
+        clusterSettings.applySettings(Settings.builder().put(prefixKey + "attr", "n2,n3").build());
+        decisionNode1 = filterAllocationDecider.canAllocate(shard, node1, allocation);
+        decisionNode2 = filterAllocationDecider.canAllocate(shard, node2, allocation);
+        decisionNode3 = filterAllocationDecider.canAllocate(shard, node3, allocation);
+        assertEquals(Type.NO, decisionNode1.type());
+        assertEquals(Type.YES, decisionNode2.type());
+        assertEquals(Type.YES, decisionNode3.type());
+    }
+
+    public void testClusterExcludeFilter() {
+        ClusterSettings clusterSettings = new ClusterSettings(Settings.EMPTY, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS);
+        FilterAllocationDecider filterAllocationDecider = new FilterAllocationDecider(Settings.EMPTY, clusterSettings);
+        AllocationDeciders allocationDeciders = new AllocationDeciders(Collections.singleton(filterAllocationDecider));
+
+        String indexName = "test";
+        IndexMetadata indexMetadata = IndexMetadata.builder(indexName)
+            .settings(settings(Version.CURRENT))
+            .numberOfShards(1)
+            .numberOfReplicas(0)
+            .build();
+        ImmutableOpenMap<String, IndexMetadata> indices = ImmutableOpenMap.<String, IndexMetadata>builder()
+            .fPut(indexName, indexMetadata)
+            .build();
+        RoutingAllocation allocation = new RoutingAllocation(
+            allocationDeciders,
+            null,
+            ClusterState.builder(ClusterState.EMPTY_STATE).metadata(Metadata.builder().indices(indices).build()).build(),
+            null,
+            null,
+            0
+        );
+        ShardRouting shard = ShardRouting.newUnassigned(
+            new ShardId(indexName, "_na_", 0),
+            true,
+            RecoverySource.ExistingStoreRecoverySource.INSTANCE,
+            new UnassignedInfo(UnassignedInfo.Reason.INDEX_CREATED, null)
+        );
+
+        Map<String, String> nodeAttrMap1 = new HashMap<>();
+        nodeAttrMap1.put("attr", "n1");
+        Map<String, String> nodeAttrMap2 = new HashMap<>();
+        nodeAttrMap2.put("attr", "n2");
+        Map<String, String> nodeAttrMap3 = new HashMap<>();
+        nodeAttrMap3.put("attr", "n3");
+
+        RoutingNode node1 = routingNode("1", newNode("node1", "1", nodeAttrMap1));
+        RoutingNode node2 = routingNode("2", newNode("node2", "2", nodeAttrMap2));
+        RoutingNode node3 = routingNode("3", newNode("node3", "3", nodeAttrMap3));
+
+        Decision decisionNode1 = filterAllocationDecider.canAllocate(shard, node1, allocation);
+        Decision decisionNode2 = filterAllocationDecider.canAllocate(shard, node2, allocation);
+        Decision decisionNode3 = filterAllocationDecider.canAllocate(shard, node3, allocation);
+        assertEquals(Type.YES, decisionNode1.type());
+        assertEquals(Type.YES, decisionNode2.type());
+        assertEquals(Type.YES, decisionNode3.type());
+
+        String prefixKey = "cluster.routing.allocation.exclude.";
+        // set cluster.routing.allocation.exclude._name to node1
+        clusterSettings.applySettings(Settings.builder().put(prefixKey + "_name", "node1").build());
+        decisionNode1 = filterAllocationDecider.canAllocate(shard, node1, allocation);
+        decisionNode2 = filterAllocationDecider.canAllocate(shard, node2, allocation);
+        decisionNode3 = filterAllocationDecider.canAllocate(shard, node3, allocation);
+        assertEquals(Type.NO, decisionNode1.type());
+        assertEquals(Type.YES, decisionNode2.type());
+        assertEquals(Type.YES, decisionNode3.type());
+
+        // set cluster.routing.allocation.exclude.attr to n2
+        clusterSettings.applySettings(Settings.builder().put(prefixKey + "_name", "node1").put(prefixKey + "attr", "n2").build());
+        decisionNode1 = filterAllocationDecider.canAllocate(shard, node1, allocation);
+        decisionNode2 = filterAllocationDecider.canAllocate(shard, node2, allocation);
+        decisionNode3 = filterAllocationDecider.canAllocate(shard, node3, allocation);
+        assertEquals(Type.NO, decisionNode1.type());
+        assertEquals(Type.NO, decisionNode2.type());
+        assertEquals(Type.YES, decisionNode3.type());
+
+        // set cluster.routing.allocation.exclude.attr to n1,n2,n3
+        clusterSettings.applySettings(Settings.builder().put(prefixKey + "attr", "n1,n2,n3").build());
+        decisionNode1 = filterAllocationDecider.canAllocate(shard, node1, allocation);
+        decisionNode2 = filterAllocationDecider.canAllocate(shard, node2, allocation);
+        decisionNode3 = filterAllocationDecider.canAllocate(shard, node3, allocation);
+        assertEquals(Type.NO, decisionNode1.type());
+        assertEquals(Type.NO, decisionNode2.type());
+        assertEquals(Type.NO, decisionNode3.type());
+
+        // set cluster.routing.allocation.exclude.attr to n2,n3
+        clusterSettings.applySettings(Settings.builder().put(prefixKey + "attr", "n2,n3").build());
+        decisionNode1 = filterAllocationDecider.canAllocate(shard, node1, allocation);
+        decisionNode2 = filterAllocationDecider.canAllocate(shard, node2, allocation);
+        decisionNode3 = filterAllocationDecider.canAllocate(shard, node3, allocation);
+        assertEquals(Type.YES, decisionNode1.type());
+        assertEquals(Type.NO, decisionNode2.type());
+        assertEquals(Type.NO, decisionNode3.type());
+    }
+
+    public void testClusterMixedFilter() {
+        ClusterSettings clusterSettings = new ClusterSettings(Settings.EMPTY, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS);
+        FilterAllocationDecider filterAllocationDecider = new FilterAllocationDecider(Settings.EMPTY, clusterSettings);
+        AllocationDeciders allocationDeciders = new AllocationDeciders(Collections.singleton(filterAllocationDecider));
+
+        String indexName = "test";
+        IndexMetadata indexMetadata = IndexMetadata.builder(indexName)
+            .settings(settings(Version.CURRENT))
+            .numberOfShards(1)
+            .numberOfReplicas(0)
+            .build();
+        ImmutableOpenMap<String, IndexMetadata> indices = ImmutableOpenMap.<String, IndexMetadata>builder()
+            .fPut(indexName, indexMetadata)
+            .build();
+        RoutingAllocation allocation = new RoutingAllocation(
+            allocationDeciders,
+            null,
+            ClusterState.builder(ClusterState.EMPTY_STATE).metadata(Metadata.builder().indices(indices).build()).build(),
+            null,
+            null,
+            0
+        );
+        ShardRouting shard = ShardRouting.newUnassigned(
+            new ShardId(indexName, "_na_", 0),
+            true,
+            RecoverySource.ExistingStoreRecoverySource.INSTANCE,
+            new UnassignedInfo(UnassignedInfo.Reason.INDEX_CREATED, null)
+        );
+
+        Map<String, String> nodeAttrMap1 = new HashMap<>();
+        nodeAttrMap1.put("attr", "n1");
+        Map<String, String> nodeAttrMap2 = new HashMap<>();
+        nodeAttrMap2.put("attr", "n2");
+
+        RoutingNode node1 = routingNode("1", newNode("node1", "1", nodeAttrMap1));
+        RoutingNode node2 = routingNode("2", newNode("node2", "2", nodeAttrMap2));
+
+        Decision decisionNode1 = filterAllocationDecider.canAllocate(shard, node1, allocation);
+        Decision decisionNode2 = filterAllocationDecider.canAllocate(shard, node2, allocation);
+        assertEquals(Type.YES, decisionNode1.type());
+        assertEquals(Type.YES, decisionNode2.type());
+
+        String requirePrefixKey = "cluster.routing.allocation.require.";
+        String includePrefixKey = "cluster.routing.allocation.include.";
+        String excludePrefixKey = "cluster.routing.allocation.exclude.";
+
+        // set cluster.routing.allocation.require._name to node1
+        // set cluster.routing.allocation.include._name to node1
+
+        clusterSettings.applySettings(
+            Settings.builder().put(requirePrefixKey + "_name", "node1").put(includePrefixKey + "_name", "node1").build()
+        );
+        decisionNode1 = filterAllocationDecider.canAllocate(shard, node1, allocation);
+        decisionNode2 = filterAllocationDecider.canAllocate(shard, node2, allocation);
+        assertEquals(Type.YES, decisionNode1.type());
+        assertEquals(Type.NO, decisionNode2.type());
+
+        // set cluster.routing.allocation.require._name to node1
+        // set cluster.routing.allocation.include._name to node2
+        clusterSettings.applySettings(
+            Settings.builder().put(requirePrefixKey + "_name", "node1").put(includePrefixKey + "_name", "node2").build()
+        );
+        decisionNode1 = filterAllocationDecider.canAllocate(shard, node1, allocation);
+        decisionNode2 = filterAllocationDecider.canAllocate(shard, node2, allocation);
+        assertEquals(Type.NO, decisionNode1.type());
+        assertEquals(Type.NO, decisionNode2.type());
+
+        // set cluster.routing.allocation.require._name to node1
+        // set cluster.routing.allocation.exclude._name to node2
+        clusterSettings.applySettings(
+            Settings.builder().put(requirePrefixKey + "_name", "node1").put(excludePrefixKey + "_name", "node2").build()
+        );
+        decisionNode1 = filterAllocationDecider.canAllocate(shard, node1, allocation);
+        decisionNode2 = filterAllocationDecider.canAllocate(shard, node2, allocation);
+        assertEquals(Type.YES, decisionNode1.type());
+        assertEquals(Type.NO, decisionNode2.type());
     }
 }


### PR DESCRIPTION
Currently allocation filtering works only on delta settings. For example: 
1. we first set `cluster.routing.allocation.exclude.zone` to `us-east-1a` to allocate shards to all nodes not in zone `us-east-1a`. 
2. Then we update `cluster.routing.allocation.exclude.rack` to `rack-id`. At this point, shards will relocate to nodes not in rack `rack-id`, ignoring the zone tag which we first set.

The reason for this bug is, when updating cluster settings for cluster `require/include/exclude` filters, `AffixMapUpdateConsumer` is only passing setting deltas, then `FilterAllocationDecider` rebuilds new filters using the settings deltas.

To fix this, we can merge the incoming `include/exclude/require` delta filters with the existing ones, and use the new merge filters to build `cluster include/exclude/require` filters. In this way, cluster `require/include/exclude` filters will include all cluster settings we have set instead of the delta ones.

ISSUE: #55815 
