### PR TITLE
[DOCS] Fixes asciidoc syntax in semantic search API docs

### DIFF
--- a/docs/reference/search/semantic-search.asciidoc
+++ b/docs/reference/search/semantic-search.asciidoc
@@ -101,7 +101,9 @@ include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=knn-num-candidates]
 <<query-dsl,Query DSL>>.
 
 `text_embedding_config`::
-(Object, optional) Override certain setting of the text embedding model's configuration
+(Object, optional) Override certain setting of the text embedding model's 
+configuration.
++
 .Properties of text_embedding inference
 [%collapsible%open]
 =====


### PR DESCRIPTION
## Overview

As title states.

### Preview

[Semantic search API docs](https://elasticsearch_91588.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/semantic-search-api.html#semantic-search-api-request-body)