### PR TITLE
Provide compressed docker image exports for DRA process

### DIFF
--- a/.ci/jobs.t/elastic+elasticsearch+periodic+dra-snapshots.yml
+++ b/.ci/jobs.t/elastic+elasticsearch+periodic+dra-snapshots.yml
@@ -29,7 +29,7 @@
                 -Ddra.artifacts.dependency.ml-cpp=${ML_CPP_BUILD_ID} \
                 -Dcsv=$WORKSPACE/build/distributions/dependencies-${ES_VERSION}-SNAPSHOT.csv \
                 buildReleaseArtifacts \
-                exportDockerImages \
+                exportCompressedDockerImages \
                 :distribution:generateDependenciesReport
 
             unset VAULT_TOKEN

--- a/distribution/docker/build.gradle
+++ b/distribution/docker/build.gradle
@@ -473,6 +473,7 @@ boolean isArchitectureSupported(Architecture architecture) {
 }
 
 def exportDockerImages = tasks.register("exportDockerImages")
+def exportCompressedDockerImages = tasks.register("exportCompressedDockerImages")
 
 /*
  * The export subprojects write out the generated Docker images to disk, so
@@ -514,13 +515,27 @@ subprojects { Project subProject ->
         "-o",
         tarFile,
         "elasticsearch${base.suffix}:${architecture.classifier}"
-
       dependsOn(parent.path + ":" + buildTaskName)
       onlyIf { isArchitectureSupported(architecture) }
     }
 
     exportDockerImages.configure {
       dependsOn exportTask
+    }
+
+    def compressExportTask = tasks.register(taskName("compress", architecture, base, 'DockerImageExport'), Tar) {
+      it.from(project.tarTree(tarFile))
+      archiveExtension = 'tar.gz'
+      it.setCompression(Compression.GZIP)
+      it.getArchiveBaseName().set("elasticsearch${base.suffix}-${VersionProperties.elasticsearch}-docker-image")
+      it.getArchiveVersion().set("")
+      it.getArchiveClassifier().set(arch)
+      it.getDestinationDirectory().set(new File(project.parent.buildDir, 'distributions'))
+      it.dependsOn(exportTask)
+    }
+
+    exportCompressedDockerImages.configure {
+      dependsOn compressExportTask
     }
 
     artifacts.add('default', file(tarFile)) {

--- a/distribution/docker/build.gradle
+++ b/distribution/docker/build.gradle
@@ -529,7 +529,7 @@ subprojects { Project subProject ->
       it.setCompression(Compression.GZIP)
       it.getArchiveBaseName().set("elasticsearch${base.suffix}-${VersionProperties.elasticsearch}-docker-image")
       it.getArchiveVersion().set("")
-      it.getArchiveClassifier().set(arch)
+      it.getArchiveClassifier().set(architecture == Architecture.AARCH64 ? 'aarch64' : '')
       it.getDestinationDirectory().set(new File(project.parent.buildDir, 'distributions'))
       it.dependsOn(exportTask)
     }


### PR DESCRIPTION
Initial fix for providing the expected Docker files for our DRA process
- Can be tweaked to be more efficient, but kept simple for now