### PR TITLE
[8.5] Refactor DatabaseNodeService as a cluster state listener. (#91567)

### DIFF
--- a/docs/changelog/91567.yaml
+++ b/docs/changelog/91567.yaml
@@ -1,0 +1,6 @@
+pr: 91567
+summary: Refactor `DatabaseNodeService` as a cluster state listener
+area: Ingest Node
+type: bug
+issues:
+ - 86999

--- a/modules/ingest-geoip/src/internalClusterTest/java/org/elasticsearch/ingest/geoip/ReloadingDatabasesWhilePerformingGeoLookupsIT.java
+++ b/modules/ingest-geoip/src/internalClusterTest/java/org/elasticsearch/ingest/geoip/ReloadingDatabasesWhilePerformingGeoLookupsIT.java
@@ -201,7 +201,7 @@ public class ReloadingDatabasesWhilePerformingGeoLookupsIT extends ESTestCase {
             configDatabases,
             Runnable::run
         );
-        databaseNodeService.initialize("nodeId", mock(ResourceWatcherService.class), mock(IngestService.class));
+        databaseNodeService.initialize("nodeId", mock(ResourceWatcherService.class), mock(IngestService.class), mock(ClusterService.class));
         return databaseNodeService;
     }
 

--- a/modules/ingest-geoip/src/main/java/org/elasticsearch/ingest/geoip/IngestGeoIpPlugin.java
+++ b/modules/ingest-geoip/src/main/java/org/elasticsearch/ingest/geoip/IngestGeoIpPlugin.java
@@ -120,7 +120,7 @@ public class IngestGeoIpPlugin extends Plugin implements IngestPlugin, SystemInd
     ) {
         try {
             String nodeId = nodeEnvironment.nodeId();
-            databaseRegistry.get().initialize(nodeId, resourceWatcherService, ingestService.get());
+            databaseRegistry.get().initialize(nodeId, resourceWatcherService, ingestService.get(), clusterService);
         } catch (IOException e) {
             throw new UncheckedIOException(e);
         }

--- a/modules/ingest-geoip/src/test/java/org/elasticsearch/ingest/geoip/DatabaseNodeServiceTests.java
+++ b/modules/ingest-geoip/src/test/java/org/elasticsearch/ingest/geoip/DatabaseNodeServiceTests.java
@@ -32,6 +32,7 @@ import org.elasticsearch.cluster.routing.RecoverySource;
 import org.elasticsearch.cluster.routing.RoutingTable;
 import org.elasticsearch.cluster.routing.ShardRouting;
 import org.elasticsearch.cluster.routing.UnassignedInfo;
+import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.hash.MessageDigests;
 import org.elasticsearch.common.io.Streams;
@@ -106,6 +107,7 @@ public class DatabaseNodeServiceTests extends ESTestCase {
     private DatabaseNodeService databaseNodeService;
     private ResourceWatcherService resourceWatcherService;
     private IngestService ingestService;
+    private ClusterService clusterService;
 
     @Before
     public void setup() throws IOException {
@@ -121,9 +123,10 @@ public class DatabaseNodeServiceTests extends ESTestCase {
 
         client = mock(Client.class);
         ingestService = mock(IngestService.class);
+        clusterService = mock(ClusterService.class);
         geoIpTmpDir = createTempDir();
         databaseNodeService = new DatabaseNodeService(geoIpTmpDir, client, cache, configDatabases, Runnable::run);
-        databaseNodeService.initialize("nodeId", resourceWatcherService, ingestService);
+        databaseNodeService.initialize("nodeId", resourceWatcherService, ingestService, clusterService);
     }
 
     @After
@@ -295,14 +298,17 @@ public class DatabaseNodeServiceTests extends ESTestCase {
         databaseNodeService.updateDatabase("_name", "_md5", geoIpTmpDir.resolve("some-file"));
 
         // Updating the first time may trigger a reload.
-        verify(ingestService, times(1)).addIngestClusterStateListener(any());
+        verify(clusterService, times(1)).addListener(any());
         verify(ingestService, times(1)).getPipelineWithProcessorType(any(), any());
         verify(ingestService, times(numPipelinesToBeReloaded)).reloadPipeline(anyString());
+        verifyNoMoreInteractions(clusterService);
         verifyNoMoreInteractions(ingestService);
+        reset(clusterService);
         reset(ingestService);
 
         // Subsequent updates shouldn't trigger a reload.
         databaseNodeService.updateDatabase("_name", "_md5", geoIpTmpDir.resolve("some-file"));
+        verifyNoMoreInteractions(clusterService);
         verifyNoMoreInteractions(ingestService);
     }
 

--- a/modules/ingest-geoip/src/test/java/org/elasticsearch/ingest/geoip/GeoIpProcessorFactoryTests.java
+++ b/modules/ingest-geoip/src/test/java/org/elasticsearch/ingest/geoip/GeoIpProcessorFactoryTests.java
@@ -73,7 +73,7 @@ public class GeoIpProcessorFactoryTests extends ESTestCase {
         copyDatabaseFiles(geoIpConfigDir, configDatabases);
         geoipTmpDir = createTempDir();
         databaseNodeService = new DatabaseNodeService(geoipTmpDir, client, cache, configDatabases, Runnable::run);
-        databaseNodeService.initialize("nodeId", mock(ResourceWatcherService.class), mock(IngestService.class));
+        databaseNodeService.initialize("nodeId", mock(ResourceWatcherService.class), mock(IngestService.class), mock(ClusterService.class));
         clusterService = mock(ClusterService.class);
         when(clusterService.state()).thenReturn(ClusterState.EMPTY_STATE);
     }
@@ -361,7 +361,7 @@ public class GeoIpProcessorFactoryTests extends ESTestCase {
         Client client = mock(Client.class);
         GeoIpCache cache = new GeoIpCache(1000);
         DatabaseNodeService databaseNodeService = new DatabaseNodeService(createTempDir(), client, cache, configDatabases, Runnable::run);
-        databaseNodeService.initialize("nodeId", resourceWatcherService, mock(IngestService.class));
+        databaseNodeService.initialize("nodeId", resourceWatcherService, mock(IngestService.class), mock(ClusterService.class));
         GeoIpProcessor.Factory factory = new GeoIpProcessor.Factory(databaseNodeService, clusterService);
         for (DatabaseReaderLazyLoader lazyLoader : configDatabases.getConfigDatabases().values()) {
             assertNull(lazyLoader.databaseReader.get());


### PR DESCRIPTION
Backports the following commits to 8.5:
 - Refactor DatabaseNodeService as a cluster state listener. (#91567)