### PR TITLE
[DOCS] Fix docs build break from 8.6 RN link

### DIFF
--- a/docs/reference/release-notes/highlights.asciidoc
+++ b/docs/reference/release-notes/highlights.asciidoc
@@ -12,7 +12,7 @@ endif::[]
 // Add previous release to the list
 Other versions:
 
-{ref-bare}/8.6/release-highlights.html[8.6]
+//{ref-bare}/8.6/release-highlights.html[8.6]
 | {ref-bare}/8.5/release-highlights.html[8.5]
 | {ref-bare}/8.4/release-highlights.html[8.4]
 | {ref-bare}/8.3/release-highlights.html[8.3]

--- a/docs/reference/release-notes/highlights.asciidoc
+++ b/docs/reference/release-notes/highlights.asciidoc
@@ -13,7 +13,7 @@ endif::[]
 Other versions:
 
 //{ref-bare}/8.6/release-highlights.html[8.6]
-| {ref-bare}/8.5/release-highlights.html[8.5]
+{ref-bare}/8.5/release-highlights.html[8.5]
 | {ref-bare}/8.4/release-highlights.html[8.4]
 | {ref-bare}/8.3/release-highlights.html[8.3]
 | {ref-bare}/8.2/release-highlights.html[8.2]


### PR DESCRIPTION
Fixes 

 ```
09:43:34 INFO:build_docs:Bad cross-document links:
09:43:34 INFO:build_docs:  /tmp/docsbuild/target_repo/html/en/elasticsearch/reference/master/release-highlights.html contains broken links to:
09:43:34 INFO:build_docs:   - en/elasticsearch/reference/8.6/release-highlights.html
```