### PR TITLE
Ensure we include previous minor when generate stub docs for new minor

### DIFF
--- a/build-tools-internal/src/test/java/org/elasticsearch/gradle/internal/release/GenerateReleaseNotesTaskTest.java
+++ b/build-tools-internal/src/test/java/org/elasticsearch/gradle/internal/release/GenerateReleaseNotesTaskTest.java
@@ -150,7 +150,7 @@ public class GenerateReleaseNotesTaskTest {
      * Check that when deriving a lit of versions from git tags, the current unreleased version is included.
      */
     @Test
-    public void getVersions_includesCurrentVersion() {
+    public void getVersions_includesCurrentAndPreviousVersion() {
         // given:
         when(gitWrapper.listVersions(anyString())).thenReturn(
             Stream.of("8.0.0-alpha1", "8.0.0-alpha2", "8.0.0-beta1", "8.0.0-beta2", "8.0.0-beta3", "8.0.0-rc1", "8.0.0", "8.0.1", "8.1.0")
@@ -158,7 +158,7 @@ public class GenerateReleaseNotesTaskTest {
         );
 
         // when:
-        Set<QualifiedVersion> versions = GenerateReleaseNotesTask.getVersions(gitWrapper, "8.2.0-SNAPSHOT");
+        Set<QualifiedVersion> versions = GenerateReleaseNotesTask.getVersions(gitWrapper, "8.3.0-SNAPSHOT");
 
         // then:
         assertThat(
@@ -174,7 +174,8 @@ public class GenerateReleaseNotesTaskTest {
                     "8.0.0",
                     "8.0.1",
                     "8.1.0",
-                    "8.2.0-SNAPSHOT"
+                    "8.2.0",
+                    "8.3.0-SNAPSHOT"
                 ).map(QualifiedVersion::of).toArray(QualifiedVersion[]::new)
             )
         );


### PR DESCRIPTION
When generating release notes indexes, we rely on Git tags to determine previous release versions. When generating the stub notes for a new minor version after feature freeze of the next minor release, we end up mistakenly omitting the previous minor, since it hasn't actually been released yet. For example:

If we are feature freezing 8.6, we cut an 8.6 branch from main, then bump main to 8.7. When we generate the stub release notes for 8.7 in main, the current workflow _removes_ links to 8.6, since it doesn't think it's a released version. We need to explicitly add this staged version back, since of course no Git tag will exist for it until it's actually released.