### PR TITLE
Improving logging to troubelshoot pipeline metrics problem (#91439)

### DIFF
--- a/server/src/main/java/org/elasticsearch/ingest/CompoundProcessor.java
+++ b/server/src/main/java/org/elasticsearch/ingest/CompoundProcessor.java
@@ -213,7 +213,7 @@ public class CompoundProcessor implements Processor {
         try {
             finalProcessor.execute(ingestDocument, (result, e) -> {
                 if (listenerHasBeenCalled.getAndSet(true)) {
-                    logger.warn("A listener was unexpectedly called more than once", new RuntimeException());
+                    logger.warn("A listener was unexpectedly called more than once", new RuntimeException(e));
                     assert false : "A listener was unexpectedly called more than once";
                 } else {
                     long ingestTimeInNanos = relativeTimeProvider.getAsLong() - startTimeInNanos;
@@ -233,7 +233,7 @@ public class CompoundProcessor implements Processor {
         } catch (Exception e) {
             long ingestTimeInNanos = relativeTimeProvider.getAsLong() - startTimeInNanos;
             if (postIngestHasBeenCalled.get()) {
-                logger.warn("Preventing postIngest from being called more than once", new RuntimeException());
+                logger.warn("Preventing postIngest from being called more than once", e);
                 assert false : "Attempt to call postIngest more than once";
             } else {
                 finalMetric.postIngest(ingestTimeInNanos);

--- a/server/src/main/java/org/elasticsearch/ingest/ConditionalProcessor.java
+++ b/server/src/main/java/org/elasticsearch/ingest/ConditionalProcessor.java
@@ -135,7 +135,7 @@ public class ConditionalProcessor extends AbstractProcessor implements WrappingP
             metric.preIngest();
             processor.execute(ingestDocument, (result, e) -> {
                 if (listenerHasBeenCalled.getAndSet(true)) {
-                    logger.warn("A listener was unexpectedly called more than once", new RuntimeException());
+                    logger.warn("A listener was unexpectedly called more than once", new RuntimeException(e));
                     assert false : "A listener was unexpectedly called more than once";
                 } else {
                     long ingestTimeInNanos = relativeTimeProvider.getAsLong() - startTimeInNanos;

--- a/server/src/main/java/org/elasticsearch/ingest/IngestService.java
+++ b/server/src/main/java/org/elasticsearch/ingest/IngestService.java
@@ -894,7 +894,7 @@ public class IngestService implements ClusterStateApplier, ReportingService<Inge
         final AtomicBoolean listenerHasBeenCalled = new AtomicBoolean(false);
         ingestDocument.executePipeline(pipeline, (result, e) -> {
             if (listenerHasBeenCalled.getAndSet(true)) {
-                logger.warn("A listener was unexpectedly called more than once", new RuntimeException());
+                logger.warn("A listener was unexpectedly called more than once", new RuntimeException(e));
                 assert false : "A listener was unexpectedly called more than once";
             } else {
                 long ingestTimeInNanos = System.nanoTime() - startTimeInNanos;

--- a/server/src/main/java/org/elasticsearch/ingest/Pipeline.java
+++ b/server/src/main/java/org/elasticsearch/ingest/Pipeline.java
@@ -128,7 +128,7 @@ public final class Pipeline {
         metrics.preIngest();
         compoundProcessor.execute(ingestDocument, (result, e) -> {
             if (listenerHasBeenCalled.getAndSet(true)) {
-                logger.warn("A listener was unexpectedly called more than once", new RuntimeException());
+                logger.warn("A listener was unexpectedly called more than once", new RuntimeException(e));
                 assert false : "A listener was unexpectedly called more than once";
             } else {
                 long ingestTimeInNanos = relativeTimeProvider.getAsLong() - startTimeInNanos;


### PR DESCRIPTION
We think that we have tracked down the problem of negative metrics (https://github.com/elastic/elasticsearch/pull/90319) to be an exception happening in a pipeline. Unfortunately we're not currently getting any information about that exception in order to prevent it. This PR logs the exception when it detects the problem of a listener being called more than once (which is the source of the metrics problem). If the exception can be null, it logs it as a new RuntimeException(e) so that we still get information about the stack regardless.
Backport of #91439