### PR TITLE
Ensure RUNTIME_JAVA_HOME is used for pre-7.0 package upgrade tests

### DIFF
--- a/.idea/checkstyle-idea.xml
+++ b/.idea/checkstyle-idea.xml
@@ -1,20 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
-    <component name="CheckStyle-IDEA" serialisationVersion="2">
-        <checkstyleVersion>10.3.1</checkstyleVersion>
-        <scanScope>JavaOnlyWithTests</scanScope>
-        <option name="thirdPartyClasspath">
-            <option value="$PROJECT_DIR$/build-conventions/build/libs/build-conventions.jar" />
-        </option>
-        <option name="activeLocationIds">
-            <option value="dfb90780-ced3-4152-a4df-3cc9be08e3d8" />
-        </option>
-        <option name="locations">
-            <list>
-                <ConfigurationLocation id="bundled-sun-checks" type="BUNDLED" scope="All" description="Sun Checks">(bundled)</ConfigurationLocation>
-                <ConfigurationLocation id="bundled-google-checks" type="BUNDLED" scope="All" description="Google Checks">(bundled)</ConfigurationLocation>
-                <ConfigurationLocation id="dfb90780-ced3-4152-a4df-3cc9be08e3d8" type="PROJECT_RELATIVE" scope="All" description="Elasticsearch">$PROJECT_DIR$/checkstyle_ide.xml</ConfigurationLocation>
-            </list>
-        </option>
-    </component>
+  <component name="CheckStyle-IDEA" serialisationVersion="2">
+    <checkstyleVersion>10.3.1</checkstyleVersion>
+    <scanScope>JavaOnlyWithTests</scanScope>
+    <option name="thirdPartyClasspath">
+      <option value="$PROJECT_DIR$/build-conventions/build/libs/build-conventions.jar" />
+    </option>
+    <option name="activeLocationIds">
+      <option value="dfb90780-ced3-4152-a4df-3cc9be08e3d8" />
+    </option>
+    <option name="locations">
+      <list>
+        <ConfigurationLocation id="bundled-sun-checks" type="BUNDLED" scope="All" description="Sun Checks">(bundled)</ConfigurationLocation>
+        <ConfigurationLocation id="bundled-google-checks" type="BUNDLED" scope="All" description="Google Checks">(bundled)</ConfigurationLocation>
+        <ConfigurationLocation id="dfb90780-ced3-4152-a4df-3cc9be08e3d8" type="PROJECT_RELATIVE" scope="All" description="Elasticsearch">$PROJECT_DIR$/checkstyle_ide.xml</ConfigurationLocation>
+      </list>
+    </option>
+  </component>
 </project>

--- a/qa/os/src/test/java/org/elasticsearch/packaging/util/Distribution.java
+++ b/qa/os/src/test/java/org/elasticsearch/packaging/util/Distribution.java
@@ -47,7 +47,7 @@ public class Distribution {
             tmpVersion = tmpVersion.replace(".rpm", "");
         }
         this.baseVersion = tmpVersion;
-        this.hasJdk = filename.contains("no-jdk") == false && Version.fromString(baseVersion).onOrAfter(Version.V_7_0_0);
+        this.hasJdk = isDocker() || (filename.contains("no-jdk") == false && Version.fromString(baseVersion).onOrAfter(Version.V_7_0_0));
         this.version = filename.contains("-SNAPSHOT") ? this.baseVersion + "-SNAPSHOT" : this.baseVersion;
     }
 

--- a/qa/os/src/test/java/org/elasticsearch/packaging/util/Distribution.java
+++ b/qa/os/src/test/java/org/elasticsearch/packaging/util/Distribution.java
@@ -8,6 +8,8 @@
 
 package org.elasticsearch.packaging.util;
 
+import org.elasticsearch.Version;
+
 import java.nio.file.Path;
 import java.util.Locale;
 
@@ -38,7 +40,6 @@ public class Distribution {
         }
 
         this.platform = filename.contains("windows") ? Platform.WINDOWS : Platform.LINUX;
-        this.hasJdk = filename.contains("no-jdk") == false;
         String tmpVersion = filename.split("-", 3)[1];
         if (packaging == Packaging.DEB) {
             tmpVersion = tmpVersion.replace(".deb", "");
@@ -46,6 +47,7 @@ public class Distribution {
             tmpVersion = tmpVersion.replace(".rpm", "");
         }
         this.baseVersion = tmpVersion;
+        this.hasJdk = filename.contains("no-jdk") == false && Version.fromString(baseVersion).onOrAfter(Version.V_7_0_0);
         this.version = filename.contains("-SNAPSHOT") ? this.baseVersion + "-SNAPSHOT" : this.baseVersion;
     }
 

--- a/qa/os/src/test/java/org/elasticsearch/packaging/util/Packages.java
+++ b/qa/os/src/test/java/org/elasticsearch/packaging/util/Packages.java
@@ -11,7 +11,6 @@ package org.elasticsearch.packaging.util;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.elasticsearch.Version;
-import org.elasticsearch.common.recycler.Recycler;
 import org.elasticsearch.packaging.util.Shell.Result;
 
 import java.io.IOException;


### PR DESCRIPTION
Linux packages (deb and rpm) for Elasticsearch 6.x don't include a Java runtime. Our packaging tests are designed to use an explicit JDK for packages that do not bundle a JDK. This is not working as intended when running upgrade tests from 6.x versions and we were instead assuming a JDK was bundled. The side effect of this is that those versions of Elasticsearch are using the system JDK, which is different for every Linux distribution. Specifically, RHEL-based distributions have recently introduced an update to their Java 8 packages that are incompatible with the 6.x security manager. This change fixes the logic that determines if a distribution includes a bundled JDK to ensure that all versions prior to 7.0 are assumed to not include a bundled JDK.

Closes #91614
