### PR TITLE
Docs: synthetic _source can't params._source

### DIFF
--- a/docs/reference/mapping/fields/synthetic-source.asciidoc
+++ b/docs/reference/mapping/fields/synthetic-source.asciidoc
@@ -26,7 +26,7 @@ space. There are a couple of restrictions to be aware of:
 * When you retrieve synthetic `_source` content it undergoes minor
 <<synthetic-source-modifications,modifications>> compared to the original JSON.
 * The `params._source` is unavailable in scripts. Instead use the
-<<painless-field-context, `doc`>> API or the <<script-fields-api, `field`>>.
+{painless}/painless-field-context.html[`doc`] API or the <<script-fields-api, `field`>>.
 * Synthetic `_source` can be used with indices that contain only these field
 types:
 

--- a/docs/reference/mapping/fields/synthetic-source.asciidoc
+++ b/docs/reference/mapping/fields/synthetic-source.asciidoc
@@ -25,6 +25,8 @@ space. There are a couple of restrictions to be aware of:
 
 * When you retrieve synthetic `_source` content it undergoes minor
 <<synthetic-source-modifications,modifications>> compared to the original JSON.
+* The `params._source` is unavailable in scripts. Instead use the
+<<painless-field-context, `doc`>> API or the <<script-fields-api, `field`>>.
 * Synthetic `_source` can be used with indices that contain only these field
 types:
 


### PR DESCRIPTION
This documents that `params._source` isn't available for synthetic `_source` indices and suggests to instead use `doc['foo']` or `field('foo')`.
