### PR TITLE
Remove clutter from the elasticsearch.yml file.

### DIFF
--- a/distribution/src/config/elasticsearch.yml
+++ b/distribution/src/config/elasticsearch.yml
@@ -75,13 +75,6 @@
 #
 # For more information, consult the discovery and cluster formation module documentation.
 #
-# --------------------------------- Readiness ----------------------------------
-#
-# Enable an unauthenticated TCP readiness endpoint. The readiness service binds to all
-# host addresses.
-#
-#readiness.port: 9399
-#
 # ---------------------------------- Various -----------------------------------
 #
 # Allow wildcard deletion of indices:


### PR DESCRIPTION
The readiness port is an experimental and unsupported feature, we shouldn't be putting an example of it in the elasticsearch.yml file.