### PR TITLE
Docs: synthetic _source can remove some arrays

### DIFF
--- a/docs/reference/mapping/fields/synthetic-source.asciidoc
+++ b/docs/reference/mapping/fields/synthetic-source.asciidoc
@@ -89,6 +89,37 @@ Will become:
 ----
 // TEST[s/^/{"_source":/ s/\n$/}/]
 
+This can cause some arrays to vanish:
+
+[source,console,id=synthetic-source-leaf-arrays-example-sneaky]
+----
+PUT idx/_doc/1
+{
+  "foo": [
+    {
+      "bar": 1
+    },
+    {
+      "baz": 2
+    }
+  ]
+}
+----
+// TEST[s/$/\nGET idx\/_doc\/1?filter_path=_source\n/]
+
+Will become:
+
+[source,console-result]
+----
+{
+  "foo": {
+    "bar": 1,
+    "baz": 2
+  }
+}
+----
+// TEST[s/^/{"_source":/ s/\n$/}/]
+
 [[synthetic-source-modifications-field-names]]
 ====== Fields named as they are mapped
 Synthetic source names fields as they are named in the mapping. When used


### PR DESCRIPTION
Synthetic _source's array flattening activities can remove some arrays entirely. Specifically:
```
{
  "foo": [
    {
      "bar": 1
    },
    {
      "baz": 2
    }
  ]
}
```

Turns into:
```
{
  "foo": {
    "bar": 1,
    "baz": 2
  }
}
```

See, no more array! It's because the values are flattend to the leaf fields and didn't have multiple values. This is implied by the docs we had, but sure wasn't obvious. So now it's documented specifically.
