### PR TITLE
[ML] Correct indent for text_similarity config

### DIFF
--- a/docs/reference/ml/trained-models/apis/infer-trained-model.asciidoc
+++ b/docs/reference/ml/trained-models/apis/infer-trained-model.asciidoc
@@ -488,7 +488,7 @@ include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=inference-config-nlp-tokenizati
 =======
 ======
 =====
-`text_similarity`::::
+`text_similarity`:::
 (Object, optional)
 include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=inference-config-text-similarity]
 +


### PR DESCRIPTION
The `text_similarity` section of the inference docs is incorrectly indented, it should be at the same level as `text_embedding`.

<img width="611" alt="Screenshot 2022-11-17 at 10 35 48" src="https://user-images.githubusercontent.com/2353640/202424056-eec5be17-7fd8-409d-8047-bc20392e8961.png">
