### PR TITLE
[8.6] {ML] Correct index for text_similarity config (#91644)

### DIFF
--- a/docs/reference/ml/trained-models/apis/infer-trained-model.asciidoc
+++ b/docs/reference/ml/trained-models/apis/infer-trained-model.asciidoc
@@ -488,7 +488,7 @@ include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=inference-config-nlp-tokenizati
 =======
 ======
 =====
-`text_similarity`::::
+`text_similarity`:::
 (Object, optional)
 include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=inference-config-text-similarity]
 +


### PR DESCRIPTION
Backports the following commits to 8.6:
 - {ML] Correct index for text_similarity config (#91644)