### PR TITLE
[7.17] Adjust docs for new systemd startup timeout (#91648)

### DIFF
--- a/docs/reference/setup/install/systemd.asciidoc
+++ b/docs/reference/setup/install/systemd.asciidoc
@@ -68,10 +68,10 @@ more command line options.
 [TIP]
 .Startup timeouts with older `systemd` versions
 ====
-By default {es} sets the `TimeoutStartSec` parameter to `systemd` to `75s`. If
+By default {es} sets the `TimeoutStartSec` parameter to `systemd` to `900s`. If
 you are running at least version 238 of `systemd` then {es} can automatically
 extend the startup timeout, and will do so repeatedly until startup is complete
-even if it takes longer than 75s.
+even if it takes longer than 900s.
 
 Versions of `systemd` prior to 238 do not support the timeout extension
 mechanism and will terminate the {es} process if it has not fully started up
@@ -82,7 +82,7 @@ that it was shut down normally a short time after it started:
 -------------
 [2022-01-31T01:22:31,077][INFO ][o.e.n.Node               ] [instance-0000000123] starting ...
 ...
-[2022-01-31T01:23:45,077][INFO ][o.e.n.Node               ] [instance-0000000123] stopping ...
+[2022-01-31T01:37:15,077][INFO ][o.e.n.Node               ] [instance-0000000123] stopping ...
 -------------
 
 However the `systemd` logs will report that the startup timed out:
@@ -90,10 +90,10 @@ However the `systemd` logs will report that the startup timed out:
 [source,text]
 -------------
 Jan 31 01:22:30 debian systemd[1]: Starting Elasticsearch...
-Jan 31 01:23:45 debian systemd[1]: elasticsearch.service: Start operation timed out. Terminating.
-Jan 31 01:23:45 debian systemd[1]: elasticsearch.service: Main process exited, code=killed, status=15/TERM
-Jan 31 01:23:45 debian systemd[1]: elasticsearch.service: Failed with result 'timeout'.
-Jan 31 01:23:45 debian systemd[1]: Failed to start Elasticsearch.
+Jan 31 01:37:15 debian systemd[1]: elasticsearch.service: Start operation timed out. Terminating.
+Jan 31 01:37:15 debian systemd[1]: elasticsearch.service: Main process exited, code=killed, status=15/TERM
+Jan 31 01:37:15 debian systemd[1]: elasticsearch.service: Failed with result 'timeout'.
+Jan 31 01:37:15 debian systemd[1]: Failed to start Elasticsearch.
 -------------
 
 To avoid this, upgrade your `systemd` to at least version 238. You can also


### PR DESCRIPTION
Backports the following commits to 7.17:
 - Adjust docs for new systemd startup timeout (#91648)