### PR TITLE
Resolve a cluster alias of a Transport.Connection targeting a remote cluster node

### DIFF
--- a/server/src/main/java/org/elasticsearch/client/internal/Client.java
+++ b/server/src/main/java/org/elasticsearch/client/internal/Client.java
@@ -56,6 +56,7 @@ import org.elasticsearch.common.settings.Setting.Property;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.core.Releasable;
+import org.elasticsearch.transport.Transport;
 
 import java.util.Map;
 
@@ -425,6 +426,10 @@ public interface Client extends ElasticsearchClient, Releasable {
      * @throws UnsupportedOperationException if this functionality is not available on this client.
      */
     default Client getRemoteClusterClient(String clusterAlias) {
+        throw new UnsupportedOperationException("this client doesn't support remote cluster connections");
+    }
+
+    default String getRemoteClusterAliasForConnection(Transport.Connection connection) {
         throw new UnsupportedOperationException("this client doesn't support remote cluster connections");
     }
 }

--- a/server/src/main/java/org/elasticsearch/client/internal/node/NodeClient.java
+++ b/server/src/main/java/org/elasticsearch/client/internal/node/NodeClient.java
@@ -148,6 +148,11 @@ public class NodeClient extends AbstractClient {
         return remoteClusterService.getRemoteClusterClient(threadPool(), clusterAlias, true);
     }
 
+    @Override
+    public String getRemoteClusterAliasForConnection(Transport.Connection connection) {
+        return remoteClusterService.getRemoteClusterAliasForConnection(connection);
+    }
+
     public NamedWriteableRegistry getNamedWriteableRegistry() {
         return namedWriteableRegistry;
     }

--- a/server/src/main/java/org/elasticsearch/transport/RemoteClusterAwareClient.java
+++ b/server/src/main/java/org/elasticsearch/transport/RemoteClusterAwareClient.java
@@ -88,4 +88,10 @@ final class RemoteClusterAwareClient extends AbstractClient {
     public Client getRemoteClusterClient(String remoteClusterAlias) {
         return remoteClusterService.getRemoteClusterClient(threadPool(), remoteClusterAlias);
     }
+
+    @Override
+    public String getRemoteClusterAliasForConnection(Transport.Connection connection) {
+        return remoteClusterService.getRemoteClusterAliasForConnection(connection);
+    }
+
 }

--- a/server/src/main/java/org/elasticsearch/transport/RemoteClusterService.java
+++ b/server/src/main/java/org/elasticsearch/transport/RemoteClusterService.java
@@ -327,6 +327,24 @@ public final class RemoteClusterService extends RemoteClusterAware implements Cl
     }
 
     /**
+     * This method checks if the given connection targets a node that belongs to a remote cluster and returns its alias.
+     * @param connection the transport connection for which to return a remote cluster alias
+     * @return a remote cluster alias or {@code null} if given connection does not target a remote cluster
+     */
+    public String getRemoteClusterAliasForConnection(Transport.Connection connection) {
+        if (transportService.getLocalNodeConnection() == connection) {
+            return null;
+        }
+        return getConnections().stream().filter(rcc -> {
+            try {
+                return rcc.getConnection(connection.getNode()) == connection;
+            } catch (NoSuchRemoteClusterException e) {
+                return false;
+            }
+        }).map(rcc -> rcc.getConnectionInfo().getClusterAlias()).findFirst().orElse(null);
+    }
+
+    /**
      * Connects to all remote clusters in a blocking fashion. This should be called on node startup to establish an initial connection
      * to all configured seed nodes.
      */

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/Security.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/Security.java
@@ -334,6 +334,7 @@ import org.elasticsearch.xpack.security.rest.action.user.RestSetEnabledAction;
 import org.elasticsearch.xpack.security.support.CacheInvalidatorRegistry;
 import org.elasticsearch.xpack.security.support.ExtensionComponents;
 import org.elasticsearch.xpack.security.support.SecuritySystemIndices;
+import org.elasticsearch.xpack.security.transport.RemoteClusterAliasResolver;
 import org.elasticsearch.xpack.security.transport.RemoteClusterAuthorizationResolver;
 import org.elasticsearch.xpack.security.transport.SecurityHttpSettings;
 import org.elasticsearch.xpack.security.transport.SecurityServerTransportInterceptor;
@@ -914,7 +915,8 @@ public class Security extends Plugin
                 getSslService(),
                 securityContext.get(),
                 destructiveOperations,
-                remoteClusterAuthorizationResolver
+                remoteClusterAuthorizationResolver,
+                new RemoteClusterAliasResolver(clusterService, client)
             )
         );
 

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/transport/RemoteClusterAliasResolver.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/transport/RemoteClusterAliasResolver.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.security.transport;
+
+import org.elasticsearch.client.internal.Client;
+import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.transport.Transport;
+
+import java.util.Optional;
+
+public final class RemoteClusterAliasResolver {
+
+    private final ClusterService clusterService;
+    private final Client client;
+
+    public RemoteClusterAliasResolver(final ClusterService clusterService, final Client client) {
+        this.clusterService = clusterService;
+        this.client = client;
+    }
+
+    /**
+     * This method attempts to resolve a remote cluster alias for the given connection
+     * in case the connection is targeting a node of a remote cluster.
+     * @param connection the transport connection for which to resolve a remote cluster alias
+     * @return an empty result if the given connection targets a node in the local cluster, otherwise a remote cluster alias
+     */
+    public Optional<String> resolve(final Transport.Connection connection) {
+        final DiscoveryNode targetNode = connection.getNode();
+        // First check if the node belongs to the local cluster and skip invoking remote cluster service.
+        if (clusterService.state().nodes().nodeExists(targetNode)) {
+            return Optional.empty();
+        }
+        // TODO: Handle the race condition case when a remote cluster connection gets disconnected and we don't get a cluster alias.
+        final String remoteClusterAlias = client.getRemoteClusterAliasForConnection(connection);
+        return Optional.ofNullable(remoteClusterAlias);
+    }
+
+}

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/transport/RemoteClusterAliasResolver.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/transport/RemoteClusterAliasResolver.java
@@ -14,7 +14,7 @@ import org.elasticsearch.transport.Transport;
 
 import java.util.Optional;
 
-public final class RemoteClusterAliasResolver {
+public class RemoteClusterAliasResolver {
 
     private final ClusterService clusterService;
     private final Client client;

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/transport/SecurityServerTransportInterceptor.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/transport/SecurityServerTransportInterceptor.java
@@ -55,6 +55,7 @@ public class SecurityServerTransportInterceptor implements TransportInterceptor 
     private final Settings settings;
     private final SecurityContext securityContext;
     private final RemoteClusterAuthorizationResolver remoteClusterAuthorizationResolver;
+    private final RemoteClusterAliasResolver remoteClusterAliasResolver;
 
     public SecurityServerTransportInterceptor(
         Settings settings,
@@ -64,7 +65,8 @@ public class SecurityServerTransportInterceptor implements TransportInterceptor 
         SSLService sslService,
         SecurityContext securityContext,
         DestructiveOperations destructiveOperations,
-        RemoteClusterAuthorizationResolver remoteClusterAuthorizationResolver
+        RemoteClusterAuthorizationResolver remoteClusterAuthorizationResolver,
+        RemoteClusterAliasResolver remoteClusterAliasResolver
     ) {
         this.settings = settings;
         this.threadPool = threadPool;
@@ -74,6 +76,7 @@ public class SecurityServerTransportInterceptor implements TransportInterceptor 
         this.securityContext = securityContext;
         this.profileFilters = initializeProfileFilters(destructiveOperations);
         this.remoteClusterAuthorizationResolver = remoteClusterAuthorizationResolver;
+        this.remoteClusterAliasResolver = remoteClusterAliasResolver;
     }
 
     @Override

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/transport/SecurityServerTransportInterceptorTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/transport/SecurityServerTransportInterceptorTests.java
@@ -112,7 +112,8 @@ public class SecurityServerTransportInterceptorTests extends ESTestCase {
                 Settings.EMPTY,
                 new ClusterSettings(Settings.EMPTY, Collections.singleton(DestructiveOperations.REQUIRES_NAME_SETTING))
             ),
-            new RemoteClusterAuthorizationResolver(settings, clusterService.getClusterSettings())
+            new RemoteClusterAuthorizationResolver(settings, clusterService.getClusterSettings()),
+            mockRemoteClusterAliasResolver()
         );
         ClusterServiceUtils.setState(clusterService, clusterService.state()); // force state update to trigger listener
 
@@ -162,7 +163,8 @@ public class SecurityServerTransportInterceptorTests extends ESTestCase {
                 Settings.EMPTY,
                 new ClusterSettings(Settings.EMPTY, Collections.singleton(DestructiveOperations.REQUIRES_NAME_SETTING))
             ),
-            new RemoteClusterAuthorizationResolver(settings, clusterService.getClusterSettings())
+            new RemoteClusterAuthorizationResolver(settings, clusterService.getClusterSettings()),
+            mockRemoteClusterAliasResolver()
         );
         ClusterServiceUtils.setState(clusterService, clusterService.state()); // force state update to trigger listener
 
@@ -205,7 +207,8 @@ public class SecurityServerTransportInterceptorTests extends ESTestCase {
                 Settings.EMPTY,
                 new ClusterSettings(Settings.EMPTY, Collections.singleton(DestructiveOperations.REQUIRES_NAME_SETTING))
             ),
-            new RemoteClusterAuthorizationResolver(settings, clusterService.getClusterSettings())
+            new RemoteClusterAuthorizationResolver(settings, clusterService.getClusterSettings()),
+            mockRemoteClusterAliasResolver()
         ) {
             @Override
             void assertNoAuthentication(String action) {}
@@ -266,7 +269,8 @@ public class SecurityServerTransportInterceptorTests extends ESTestCase {
                 Settings.EMPTY,
                 new ClusterSettings(Settings.EMPTY, Collections.singleton(DestructiveOperations.REQUIRES_NAME_SETTING))
             ),
-            new RemoteClusterAuthorizationResolver(settings, clusterService.getClusterSettings())
+            new RemoteClusterAuthorizationResolver(settings, clusterService.getClusterSettings()),
+            mockRemoteClusterAliasResolver()
         );
         ClusterServiceUtils.setState(clusterService, clusterService.state()); // force state update to trigger listener
 
@@ -333,7 +337,8 @@ public class SecurityServerTransportInterceptorTests extends ESTestCase {
                 Settings.EMPTY,
                 new ClusterSettings(Settings.EMPTY, Collections.singleton(DestructiveOperations.REQUIRES_NAME_SETTING))
             ),
-            new RemoteClusterAuthorizationResolver(settings, clusterService.getClusterSettings())
+            new RemoteClusterAuthorizationResolver(settings, clusterService.getClusterSettings()),
+            mockRemoteClusterAliasResolver()
         );
         ClusterServiceUtils.setState(clusterService, clusterService.state()); // force state update to trigger listener
 
@@ -396,7 +401,8 @@ public class SecurityServerTransportInterceptorTests extends ESTestCase {
                 Settings.EMPTY,
                 new ClusterSettings(Settings.EMPTY, Collections.singleton(DestructiveOperations.REQUIRES_NAME_SETTING))
             ),
-            new RemoteClusterAuthorizationResolver(settings, clusterService.getClusterSettings())
+            new RemoteClusterAuthorizationResolver(settings, clusterService.getClusterSettings()),
+            mockRemoteClusterAliasResolver()
         );
 
         final AtomicBoolean calledWrappedSender = new AtomicBoolean(false);
@@ -532,6 +538,10 @@ public class SecurityServerTransportInterceptorTests extends ESTestCase {
         requestHandler.messageReceived(deleteIndexRequest, channel, mock(Task.class));
         assertTrue(decRefCalled.get());
         assertTrue(exceptionSent.get());
+    }
+
+    private RemoteClusterAliasResolver mockRemoteClusterAliasResolver() {
+        return mock(RemoteClusterAliasResolver.class);
     }
 
     private String[] randomRoles() {


### PR DESCRIPTION
As part of `SecurityServerTransportInterceptor` we need to be able to determine (and resolve)
a cluster alias for a transport connection that targets a node which belongs to a remote cluster.

This PR adds ability to resolve the cluster alias of a `Transport.Connection` 
by invoking remote cluster service. 

