### PR TITLE
Requiring the presence of the geoip fixture to run GeoIpDownloaderStats.testStats()

### DIFF
--- a/modules/ingest-geoip/src/internalClusterTest/java/org/elasticsearch/ingest/geoip/GeoIpDownloaderStatsIT.java
+++ b/modules/ingest-geoip/src/internalClusterTest/java/org/elasticsearch/ingest/geoip/GeoIpDownloaderStatsIT.java
@@ -66,6 +66,11 @@ public class GeoIpDownloaderStatsIT extends AbstractGeoIpIT {
     }
 
     public void testStats() throws Exception {
+        assumeTrue(
+            "Testing without the geoip endpoint fixture falls back to https://storage.googleapis.com/, which can cause this test "
+                + "to run too slowly to pass",
+            ENDPOINT != null
+        );
         GeoIpDownloaderStatsAction.Request req = new GeoIpDownloaderStatsAction.Request();
         GeoIpDownloaderStatsAction.Response response = client().execute(GeoIpDownloaderStatsAction.INSTANCE, req).actionGet();
         XContentTestUtils.JsonMapView jsonMapView = new XContentTestUtils.JsonMapView(convertToMap(response));

--- a/modules/ingest-geoip/src/internalClusterTest/java/org/elasticsearch/ingest/geoip/GeoIpDownloaderStatsIT.java
+++ b/modules/ingest-geoip/src/internalClusterTest/java/org/elasticsearch/ingest/geoip/GeoIpDownloaderStatsIT.java
@@ -66,11 +66,11 @@ public class GeoIpDownloaderStatsIT extends AbstractGeoIpIT {
     }
 
     public void testStats() throws Exception {
-        assumeTrue(
-            "Testing without the geoip endpoint fixture falls back to https://storage.googleapis.com/, which can cause this test "
-                + "to run too slowly to pass",
-            ENDPOINT != null
-        );
+        /*
+         * Testing without the geoip endpoint fixture falls back to https://storage.googleapis.com/, which can cause this test to run too
+         * slowly to pass.
+         */
+        assumeTrue("only test with fixture to have stable results", ENDPOINT != null);
         GeoIpDownloaderStatsAction.Request req = new GeoIpDownloaderStatsAction.Request();
         GeoIpDownloaderStatsAction.Response response = client().execute(GeoIpDownloaderStatsAction.INSTANCE, req).actionGet();
         XContentTestUtils.JsonMapView jsonMapView = new XContentTestUtils.JsonMapView(convertToMap(response));


### PR DESCRIPTION
If the geoip endpoint fixture is not available, then we fall back to using https://storage.googleapis.com/  in GeoIpDownloaderStats. Downloading full-sized databases from there (vs. small versions of the databases from the fixture on localhost) can often take longer than 10 seconds, causing the test to fail.
Closes #87035