### PR TITLE
Fix the condition for logging empty JWK sets

### DIFF
--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/jwt/JwtSignatureValidator.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/jwt/JwtSignatureValidator.java
@@ -161,8 +161,10 @@ public interface JwtSignatureValidator extends Releasable {
         }
 
         private void logWarnIfAuthenticationWillAlwaysFail() {
-            final boolean hasUsableJwksAndAlgorithms = (hmacJwtSignatureValidator != null && hmacJwtSignatureValidator.jwksAlgs.isEmpty())
-                || (pkcJwtSignatureValidator != null && pkcJwtSignatureValidator.jwkSetLoader.getContentAndJwksAlgs().jwksAlgs().isEmpty());
+            final boolean hasUsableJwksAndAlgorithms = (hmacJwtSignatureValidator != null
+                && false == hmacJwtSignatureValidator.jwksAlgs.isEmpty())
+                || (pkcJwtSignatureValidator != null
+                    && false == pkcJwtSignatureValidator.jwkSetLoader.getContentAndJwksAlgs().jwksAlgs().isEmpty());
             if (false == hasUsableJwksAndAlgorithms) {
                 logger.warn(
                     "No available JWK and algorithm for HMAC or PKC. JWT realm authentication expected to fail until this is fixed."


### PR DESCRIPTION
The logic for check isEmpty should have been flipped. This PR fixes it.

Relates: #91001
