### PR TITLE
[8.5] [ML] Load pytorch models from the utility thread pool (#91661)

### DIFF
--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/deployment/DeploymentManager.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/deployment/DeploymentManager.java
@@ -392,7 +392,9 @@ public class DeploymentManager {
                 this.numThreadsPerAllocation = threadSettings.numThreadsPerAllocation();
                 this.numAllocations = threadSettings.numAllocations();
             });
-            this.stateStreamer = new PyTorchStateStreamer(client, executorServiceForProcess, xContentRegistry);
+            // We want to use the utility thread pool to load the model and not one of the process
+            // threads that are dedicated to processing done throughout the lifetime of the process.
+            this.stateStreamer = new PyTorchStateStreamer(client, executorServiceForDeployment, xContentRegistry);
             this.priorityProcessWorker = new PriorityProcessWorkerExecutorService(
                 threadPool.getThreadContext(),
                 "inference process",


### PR DESCRIPTION
Backports the following commits to 8.5:
 - [ML] Load pytorch models from the utility thread pool (#91661)