### PR TITLE
Fix ReactiveStorageIT#testScaleWhileShrinking

### DIFF
--- a/test/framework/src/main/java/org/elasticsearch/cluster/DiskUsageIntegTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/cluster/DiskUsageIntegTestCase.java
@@ -172,11 +172,11 @@ public class DiskUsageIntegTestCase extends ESIntegTestCase {
                     }
                     return total;
                 } catch (IOException | DirectoryIteratorException e) {
-                    if (isFileNotFoundException(e) == false) {
-                        throw e;
+                    if (isFileNotFoundException(e) || e instanceof AccessDeniedException) {
+                        // probably removed (Windows sometimes throws AccessDeniedException after a file has been deleted)
+                        return 0L;
                     }
-                    // probably removed
-                    return 0L;
+                    throw e;
                 }
             }
         }


### PR DESCRIPTION
Fix another place where Windows AccessDeniedException could be propagated (See: https://github.com/elastic/elasticsearch/pull/90865)

Related to: #91083 (I would like to keep the issue open for couple more weeks to ensure this fix is enough)