### PR TITLE
[8.5] Fix ReactiveStorageIT#testScaleWhileShrinking (#91681)

### DIFF
--- a/test/framework/src/main/java/org/elasticsearch/cluster/DiskUsageIntegTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/cluster/DiskUsageIntegTestCase.java
@@ -172,11 +172,11 @@ public class DiskUsageIntegTestCase extends ESIntegTestCase {
                     }
                     return total;
                 } catch (IOException | DirectoryIteratorException e) {
-                    if (isFileNotFoundException(e) == false) {
-                        throw e;
+                    if (isFileNotFoundException(e) || e instanceof AccessDeniedException) {
+                        // probably removed (Windows sometimes throws AccessDeniedException after a file has been deleted)
+                        return 0L;
                     }
-                    // probably removed
-                    return 0L;
+                    throw e;
                 }
             }
         }


### PR DESCRIPTION
Backports the following commits to 8.5:
 - Fix ReactiveStorageIT#testScaleWhileShrinking (#91681)