### PR TITLE
[8.5] [DOCS] Clarify multi-field addition requires update by query for existing documents (#91541)

### DIFF
--- a/docs/reference/indices/put-mapping.asciidoc
+++ b/docs/reference/indices/put-mapping.asciidoc
@@ -198,6 +198,11 @@ PUT /my-index-000001/_mapping
 You can use the update mapping API to update the `fields` mapping parameter and
 enable multi-fields for an existing field.
 
+WARNING: If an index (or data stream) contains documents when you add a
+multi-field, those documents will not have values for the new multi-field. You
+can populate the new multi-field with the <<picking-up-a-new-property,update by
+query API>>.
+
 To see how this works, try the following example.
 
 Use the <<indices-create-index,create index>> API to create an index with the

--- a/docs/reference/mapping/params/multi-fields.asciidoc
+++ b/docs/reference/mapping/params/multi-fields.asciidoc
@@ -61,6 +61,11 @@ GET my-index-000001/_search
 You can add multi-fields to an existing field using the
 <<indices-put-mapping,update mapping API>>.
 
+WARNING: If an index (or data stream) contains documents when you add a
+multi-field, those documents will not have values for the new multi-field. You
+can populate the new multi-field with the <<picking-up-a-new-property,update by
+query API>>.
+
 A multi-field mapping is completely separate from the parent field's mapping. A
 multi-field doesn't inherit any mapping options from its parent field.
 Multi-fields don't change the original `_source` field.


### PR DESCRIPTION
Backports the following commits to 8.5:
 - [DOCS] Clarify multi-field addition requires update by query for existing documents (#91541)