### PR TITLE
Add reformat on save hint to contribution doc

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -195,8 +195,8 @@ instructions are below in case you need them.
    5. **IMPORTANT** - make sure "Optimize Imports" is **NOT** selected.
    6. Click "OK"
    7. Optional: If you like to format code changes on save automatically, open
-      **Preferences > Tools > Actions on Save** and check "Reformat Code" with the additional
-      options of your choise (e.g. select "Changed lines" to only reformat changed code)
+      **Preferences > Tools > Actions on Save** and check "Reformat Code", making sure to
+      configure Java files.
 
 Alternative manual steps for IntelliJ.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -194,6 +194,9 @@ instructions are below in case you need them.
    4. Click "Browse", and navigate to the file `build-conventions/formatterConfig.xml`
    5. **IMPORTANT** - make sure "Optimize Imports" is **NOT** selected.
    6. Click "OK"
+   7. Optional: If you like to format code changes on save automatically, open
+      **Preferences > Tools > Actions on Save** and check "Reformat Code" with the additional
+      options of your choise (e.g. select "Changed lines" to only reformat changed code)
 
 Alternative manual steps for IntelliJ.
 


### PR DESCRIPTION
This change adds an optional step to the CONTRIBUTING.md docs on setting up automatic 
code formatting to add it as a save action. This can help avoiding running into spotless
check errors later.
