### PR TITLE
[8.5] [ML] Fix incorrect assumption about minimum ML node size (#91694)

### DIFF
--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/utils/NativeMemoryCalculator.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/utils/NativeMemoryCalculator.java
@@ -34,7 +34,7 @@ public final class NativeMemoryCalculator {
     // Maximum permitted JVM heap size when auto-configured.
     // Must match the value used in MachineDependentHeap.MachineNodeRole.ML_ONLY.
     public static final long STATIC_JVM_UPPER_THRESHOLD = ByteSizeValue.ofGb(31).getBytes();
-    public static final long MINIMUM_AUTOMATIC_NODE_SIZE = ByteSizeValue.ofGb(1).getBytes();
+    public static final long MINIMUM_AUTOMATIC_NODE_SIZE = ByteSizeValue.ofMb(512).getBytes();
     private static final long OS_OVERHEAD = ByteSizeValue.ofMb(200).getBytes();
     // Memory size beyond which the JVM is given 10% of memory instead of 40%.
     // Must match the value used in MachineDependentHeap.MachineNodeRole.ML_ONLY.

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/autoscaling/MlMemoryAutoscalingDeciderTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/autoscaling/MlMemoryAutoscalingDeciderTests.java
@@ -1217,8 +1217,8 @@ public class MlMemoryAutoscalingDeciderTests extends ESTestCase {
                 "requesting scale up as number of jobs in queues exceeded configured limit and there are no machine learning nodes"
             )
         );
-        assertThat(result.nodeSize(), equalTo(ByteSizeValue.ofGb(1)));
-        assertThat(result.tierSize(), equalTo(ByteSizeValue.ofGb(1)));
+        assertThat(result.nodeSize(), equalTo(ByteSizeValue.ofMb(714)));
+        assertThat(result.tierSize(), equalTo(ByteSizeValue.ofMb(714)));
     }
 
     private MlMemoryAutoscalingDecider buildDecider() {

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/utils/NativeMemoryCalculatorTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/utils/NativeMemoryCalculatorTests.java
@@ -108,15 +108,15 @@ public class NativeMemoryCalculatorTests extends ESTestCase {
                     NativeMemoryCapacity nativeMemoryCapacity = new NativeMemoryCapacity(bytesForML, bytesForML, jvmSize);
 
                     MlMemoryAutoscalingCapacity capacity = nativeMemoryCapacity.autoscalingCapacity(30, true, Long.MAX_VALUE, 1).build();
-                    // We don't allow node sizes below 1GB, so we will always be at least that large
+                    // We don't allow node sizes below 0.5GB, so we will always be at least that large
                     // Also, allow 1 byte off for weird rounding issues
                     assertThat(
                         capacity.nodeSize().getBytes(),
-                        greaterThanOrEqualTo(Math.max(nodeSize, ByteSizeValue.ofGb(1).getBytes()) - 1L)
+                        greaterThanOrEqualTo(Math.max(nodeSize, ByteSizeValue.ofMb(512).getBytes()) - 1L)
                     );
                     assertThat(
                         capacity.tierSize().getBytes(),
-                        greaterThanOrEqualTo(Math.max(nodeSize, ByteSizeValue.ofGb(1).getBytes()) - 1L)
+                        greaterThanOrEqualTo(Math.max(nodeSize, ByteSizeValue.ofMb(512).getBytes()) - 1L)
                     );
                 }
             }


### PR DESCRIPTION
Backports the following commits to 8.5:
 - [ML] Fix incorrect assumption about minimum ML node size (#91694)