### PR TITLE
[ML] Support fields with commas in data frame analytics analyzed_fields

### DIFF
--- a/docs/changelog/91710.yaml
+++ b/docs/changelog/91710.yaml
@@ -1,0 +1,6 @@
+pr: 91710
+summary: Support fields with commas in data frame analytics `analyzed_fields`
+area: Machine Learning
+type: bug
+issues:
+ - 72541

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/groups/GroupOrJobLookup.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/groups/GroupOrJobLookup.java
@@ -16,6 +16,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 import java.util.SortedMap;
 import java.util.TreeMap;
@@ -57,7 +58,7 @@ public class GroupOrJobLookup {
     }
 
     public Set<String> expandJobIds(String expression, boolean allowNoMatch) {
-        return new GroupOrJobResolver().expand(expression, allowNoMatch);
+        return new GroupOrJobResolver().expand(expression, allowNoMatch, Optional.of(","));
     }
 
     public boolean isGroupOrJob(String id) {

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/extractor/ExtractedFieldsDetector.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/extractor/ExtractedFieldsDetector.java
@@ -327,22 +327,34 @@ public class ExtractedFieldsDetector {
         try {
             // If the inclusion set does not match anything, that means the user's desired fields cannot be found in
             // the collection of supported field types. We should let the user know.
-            Set<String> includedSet = NameResolver.newUnaliased(
+            Set<String> includedSet = expandFields(
+                analyzedFields.includes().length == 0 ? new String[] { "*" } : analyzedFields.includes(),
                 fields,
-                (ex) -> new ResourceNotFoundException(Messages.getMessage(Messages.DATA_FRAME_ANALYTICS_BAD_FIELD_FILTER, ex))
-            ).expand(includes, false);
+                false
+            );
+
             // If the exclusion set does not match anything, that means the fields are already not present
             // no need to raise if nothing matched
-            Set<String> excludedSet = NameResolver.newUnaliased(
-                fieldCapabilitiesResponse.get().keySet(),
-                (ex) -> new ResourceNotFoundException(Messages.getMessage(Messages.DATA_FRAME_ANALYTICS_BAD_FIELD_FILTER, ex))
-            ).expand(excludes, true);
+            Set<String> excludedSet = expandFields(analyzedFields.excludes(), fieldCapabilitiesResponse.get().keySet(), true);
 
             applyIncludesExcludes(fields, includedSet, excludedSet, fieldSelection);
         } catch (ResourceNotFoundException ex) {
             // Re-wrap our exception so that we throw the same exception type when there are no fields.
             throw ExceptionsHelper.badRequestException(ex.getMessage());
         }
+    }
+
+    private Set<String> expandFields(String[] fields, Set<String> nameset, boolean allowNoMatch) {
+        NameResolver nameResolver = NameResolver.newUnaliased(
+            nameset,
+            (ex) -> new ResourceNotFoundException(Messages.getMessage(Messages.DATA_FRAME_ANALYTICS_BAD_FIELD_FILTER, ex))
+        );
+
+        Set<String> expanded = new HashSet<>();
+        for (String field : fields) {
+            expanded.addAll(nameResolver.expand(field, allowNoMatch));
+        }
+        return expanded;
     }
 
     private void checkIncludesExcludesAreNotObjects(FetchSourceContext analyzedFields) {

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/dataframe/extractor/ExtractedFieldsDetectorTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/dataframe/extractor/ExtractedFieldsDetectorTests.java
@@ -1332,7 +1332,63 @@ public class ExtractedFieldsDetectorTests extends ESTestCase {
         assertThat(e.getMessage(), equalTo("analyzed_fields must not include or exclude object or nested fields: [nested_field]"));
     }
 
-    public void testDetect_givenFeatureProcessorsFailures_ResultsField() {
+    public void testDetect_GivenAnalyzedFieldIncludesFieldWithCommaCharacter() {
+        FieldCapabilitiesResponse fieldCapabilities = new MockFieldCapsResponseBuilder().addAggregatableField("comma,field", "float")
+            .addAggregatableField("some_other_field", "float")
+            .build();
+
+        analyzedFields = FetchSourceContext.of(true, new String[] { "comma,field" }, null);
+
+        ExtractedFieldsDetector extractedFieldsDetector = new ExtractedFieldsDetector(
+            buildOutlierDetectionConfig(),
+            100,
+            fieldCapabilities,
+            Collections.emptyMap()
+        );
+
+        Tuple<ExtractedFields, List<FieldSelection>> fieldExtraction = extractedFieldsDetector.detect();
+
+        List<ExtractedField> allFields = fieldExtraction.v1().getAllFields();
+        assertThat(allFields, hasSize(1));
+        assertThat(allFields.get(0).getName(), equalTo("comma,field"));
+        assertThat(allFields.get(0).getMethod(), equalTo(ExtractedField.Method.DOC_VALUE));
+
+        assertFieldSelectionContains(
+            fieldExtraction.v2(),
+            FieldSelection.included("comma,field", Collections.singleton("float"), false, FieldSelection.FeatureType.NUMERICAL),
+            FieldSelection.excluded("some_other_field", Collections.singleton("float"), "field not in includes list")
+        );
+    }
+
+    public void testDetect_GivenAnalyzedFieldExcludesFieldWithCommaCharacter() {
+        FieldCapabilitiesResponse fieldCapabilities = new MockFieldCapsResponseBuilder().addAggregatableField("comma,field", "float")
+            .addAggregatableField("some_other_field", "float")
+            .build();
+
+        analyzedFields = FetchSourceContext.of(true, null, new String[] { "comma,field" });
+
+        ExtractedFieldsDetector extractedFieldsDetector = new ExtractedFieldsDetector(
+            buildOutlierDetectionConfig(),
+            100,
+            fieldCapabilities,
+            Collections.emptyMap()
+        );
+
+        Tuple<ExtractedFields, List<FieldSelection>> fieldExtraction = extractedFieldsDetector.detect();
+
+        List<ExtractedField> allFields = fieldExtraction.v1().getAllFields();
+        assertThat(allFields, hasSize(1));
+        assertThat(allFields.get(0).getName(), equalTo("some_other_field"));
+        assertThat(allFields.get(0).getMethod(), equalTo(ExtractedField.Method.DOC_VALUE));
+
+        assertFieldSelectionContains(
+            fieldExtraction.v2(),
+            FieldSelection.excluded("comma,field", Collections.singleton("float"), "field in excludes list"),
+            FieldSelection.included("some_other_field", Collections.singleton("float"), false, FieldSelection.FeatureType.NUMERICAL)
+        );
+    }
+
+    public void tesstDetect_givenFeatureProcessorsFailures_ResultsField() {
         FieldCapabilitiesResponse fieldCapabilities = simpleFieldResponse();
         ExtractedFieldsDetector extractedFieldsDetector = new ExtractedFieldsDetector(
             buildRegressionConfig("field_31", Arrays.asList(buildPreProcessor("ml.result", "foo"))),


### PR DESCRIPTION
This commit fixes a bug where fields containing comma (`,`) in their name would result in error when the `_start` or `_explain` APIs are called. If the field was `comma,field` for example, we would split the field into two tokens `comma` and `field` and thus the error would be that those fields could not be detected in the source index.

Closes #72541
