### PR TITLE
Allow JVM based integration tests to override default node roles settings in NodeConfigurationSource

### DIFF
--- a/test/framework/src/main/java/org/elasticsearch/test/ESIntegTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/ESIntegTestCase.java
@@ -1878,6 +1878,21 @@ public abstract class ESIntegTestCase extends ESTestCase {
         return annotation == null ? InternalTestCluster.DEFAULT_NUM_CLIENT_NODES : annotation.numClientNodes();
     }
 
+    @Nullable
+    protected Settings nonDataNodeSettings() {
+        return null;
+    }
+
+    @Nullable
+    protected Settings dataNodeSettings() {
+        return null;
+    }
+
+    @Nullable
+    protected Settings dataAndMasterEligibleNodeSettings() {
+        return null;
+    }
+
     /**
      * This method is used to obtain settings for the {@code N}th node in the cluster.
      * Nodes in this cluster are associated with an ordinal number such that nodes can
@@ -2027,6 +2042,33 @@ public abstract class ESIntegTestCase extends ESTestCase {
             @Override
             public Collection<Class<? extends Plugin>> nodePlugins() {
                 return ESIntegTestCase.this.nodePlugins();
+            }
+
+            @Override
+            protected Settings nonDataNodeSettings() {
+                Settings override = ESIntegTestCase.this.nonDataNodeSettings();
+                if (override != null) {
+                    return override;
+                }
+                return super.nonDataNodeSettings();
+            }
+
+            @Override
+            protected Settings dataNodeSettings() {
+                Settings override = ESIntegTestCase.this.dataNodeSettings();
+                if (override != null) {
+                    return override;
+                }
+                return super.dataNodeSettings();
+            }
+
+            @Override
+            protected Settings dataAndMasterEligibleNodeSettings() {
+                Settings override = ESIntegTestCase.this.dataAndMasterEligibleNodeSettings();
+                if (override != null) {
+                    return override;
+                }
+                return super.dataAndMasterEligibleNodeSettings();
             }
         };
     }

--- a/test/framework/src/main/java/org/elasticsearch/test/InternalTestCluster.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/InternalTestCluster.java
@@ -145,9 +145,7 @@ import static org.elasticsearch.test.ESTestCase.randomFrom;
 import static org.elasticsearch.test.NodeRoles.dataOnlyNode;
 import static org.elasticsearch.test.NodeRoles.masterOnlyNode;
 import static org.elasticsearch.test.NodeRoles.noRoles;
-import static org.elasticsearch.test.NodeRoles.nonDataNode;
 import static org.elasticsearch.test.NodeRoles.onlyRole;
-import static org.elasticsearch.test.NodeRoles.removeRoles;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
@@ -1144,17 +1142,15 @@ public final class InternalTestCluster extends TestCluster {
         final List<Settings> settings = new ArrayList<>();
 
         for (int i = 0; i < numSharedDedicatedMasterNodes; i++) {
-            final Settings otherSettings = nonDataNode();
-            final Settings nodeSettings = getNodeSettings(i, sharedNodesSeeds[i], otherSettings);
-            settings.add(nodeSettings);
+            settings.add(getNodeSettings(i, sharedNodesSeeds[i], nodeConfigurationSource.nonDataNodeSettings()));
         }
         for (int i = numSharedDedicatedMasterNodes; i < numSharedDedicatedMasterNodes + numSharedDataNodes; i++) {
             final Settings otherSettings;
             if (numSharedDedicatedMasterNodes > 0) {
-                otherSettings = removeRoles(Set.of(DiscoveryNodeRole.MASTER_ROLE));
+                otherSettings = nodeConfigurationSource.dataNodeSettings();
             } else {
                 // if we don't have dedicated master nodes, keep things default
-                otherSettings = Settings.EMPTY;
+                otherSettings = nodeConfigurationSource.dataAndMasterEligibleNodeSettings();
             }
             settings.add(getNodeSettings(i, sharedNodesSeeds[i], otherSettings));
         }

--- a/test/framework/src/main/java/org/elasticsearch/test/NodeConfigurationSource.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/NodeConfigurationSource.java
@@ -7,12 +7,16 @@
  */
 package org.elasticsearch.test;
 
+import org.elasticsearch.cluster.node.DiscoveryNodeRole;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.plugins.Plugin;
 
 import java.nio.file.Path;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Set;
+
+import static org.elasticsearch.test.NodeRoles.nonDataNode;
 
 public abstract class NodeConfigurationSource {
 
@@ -50,5 +54,28 @@ public abstract class NodeConfigurationSource {
     /** Returns plugins that should be loaded on the node */
     public Collection<Class<? extends Plugin>> nodePlugins() {
         return Collections.emptyList();
+    }
+
+    /**
+     * @return the default node settings for nodes that cannot contain data
+     */
+    protected Settings nonDataNodeSettings() {
+        return nonDataNode();
+    }
+
+    /**
+     * @return the default node settings for data nodes
+     */
+    protected Settings dataNodeSettings() {
+        // roles enabled by default minus the master role
+        return NodeRoles.removeRoles(Set.of(DiscoveryNodeRole.MASTER_ROLE));
+    }
+
+    /**
+     * @return the default node settings for master-eligible data nodes
+     */
+    protected Settings dataAndMasterEligibleNodeSettings() {
+        // if we don't have dedicated master nodes, keep things default
+        return Settings.EMPTY;
     }
 }


### PR DESCRIPTION
Today the node roles selected for non-data, data-only and data+master nodes are hardcoded in `InternalTestCluster` and cannot be overridden.

This pull request moves the definition of the default node settings to the `NodeConfigurationSource` class and allows `ESIntegTestCase` subclasses to define their own default node settings for the random nodes created by the test framework.

This change will allow some integration tests to choose the `index` role as the default node role for data nodes.