### PR TITLE
Force single aggregator mode for old terms tests

### DIFF
--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/terms/TermsAggregatorTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/terms/TermsAggregatorTests.java
@@ -800,7 +800,6 @@ public class TermsAggregatorTests extends AggregatorTestCase {
         termsAggregatorWithNestedMaxAgg(ValueType.LONG, fieldType, Integer::longValue, val -> luceneFieldFactory.apply(val, false));
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/91679")
     public void testDoubleTermsAggregator() throws Exception {
         BiFunction<Double, Boolean, List<IndexableField>> luceneFieldFactory = (val, mv) -> {
             if (mv) {
@@ -924,7 +923,10 @@ public class TermsAggregatorTests extends AggregatorTestCase {
                         .field("field")
                         .order(bucketOrder);
 
-                    Terms result = searchAndReduce(indexSearcher, new AggTestConfig(aggregationBuilder, fieldType));
+                    Terms result = searchAndReduce(
+                        indexSearcher,
+                        new AggTestConfig(aggregationBuilder, fieldType).withSplitLeavesIntoSeperateAggregators(false)
+                    );
                     assertEquals(size, result.getBuckets().size());
                     for (int i = 0; i < size; i++) {
                         Map.Entry<T, Integer> expected = expectedBuckets.get(i);
@@ -949,7 +951,7 @@ public class TermsAggregatorTests extends AggregatorTestCase {
                         );
                         result = ((Filter) searchAndReduce(
                             indexSearcher,
-                            new AggTestConfig(aggregationBuilder, fieldType, filterFieldType)
+                            new AggTestConfig(aggregationBuilder, fieldType, filterFieldType).withSplitLeavesIntoSeperateAggregators(false)
                         )).getAggregations().get("_name2");
                         int expectedFilteredCounts = 0;
                         for (Integer count : filteredCounts.values()) {


### PR DESCRIPTION
Resolves https://github.com/elastic/elasticsearch/issues/91679
Resolves https://github.com/elastic/elasticsearch/issues/91668

When I refactored the terms tests earlier this week, I missed the fact that the test breaks sometimes if it runs with more than one leaf aggregator.  Investigation is ongoing as to why this is the case, and we hope for a more robust fix in the future, but for now forcing it into single aggregator mode will stop the test flapping in CI.