### PR TITLE
Refactor test to cope with known docs counts error

### DIFF
--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/AbstractInternalTerms.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/AbstractInternalTerms.java
@@ -130,6 +130,8 @@ public abstract class AbstractInternalTerms<A extends AbstractInternalTerms<A, B
     private long getDocCountError(A terms) {
         int size = terms.getBuckets().size();
         if (size == 0 || size < terms.getShardSize() || isKeyOrder(terms.getOrder())) {
+            // If we didn't have any matches on this shard, or if we returned all the matches, or if we're in key ordering mode
+            // then there is no error from this shard.
             return 0;
         } else if (InternalOrder.isCountDesc(terms.getOrder())) {
             if (terms.getDocCountError() != null) {
@@ -280,6 +282,7 @@ public abstract class AbstractInternalTerms<A extends AbstractInternalTerms<A, B
             final long thisAggDocCountError = getDocCountError(terms);
             if (sumDocCountError != -1) {
                 if (thisAggDocCountError == -1) {
+                    // -1 indicates unbounded error
                     sumDocCountError = -1;
                 } else {
                     sumDocCountError += thisAggDocCountError;

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/terms/TermsAggregatorTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/terms/TermsAggregatorTests.java
@@ -956,12 +956,10 @@ public class TermsAggregatorTests extends AggregatorTestCase {
                             // When there is only a single collector, counts should be exact
                             assertThat("Count mismatch for " + actual.getKey(), actual.getDocCount(), equalTo(expectedCount));
                         } else if (order == false) {
-                            // If there are multiple collectors, the maximum error should be less than docCountError, but only for
-                            // descending
+                            // For descending, if there are multiple collectors, the maximum error should be less than docCountError
                             long diff = Math.abs(expectedCount - actual.getDocCount());
                             assertThat(
-                                "Count error too large for bucket [" + i + "] with key: [" + actual.getKey() + "] " +
-                                "expected: [" + expectedCount + "] but was [" + actual.getDocCount() +"]",
+                                "Count error too large: " + actual.getKey() + " (" + actual.getDocCount() + "!=" + expectedCount + ")",
                                 diff,
                                 lessThanOrEqualTo(bucketDocCountError)
                             );

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/terms/TermsAggregatorTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/terms/TermsAggregatorTests.java
@@ -7,8 +7,6 @@
  */
 package org.elasticsearch.search.aggregations.bucket.terms;
 
-import com.carrotsearch.randomizedtesting.annotations.Seed;
-
 import org.apache.lucene.document.BinaryDocValuesField;
 import org.apache.lucene.document.Document;
 import org.apache.lucene.document.Field;
@@ -156,8 +154,6 @@ import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.lessThanOrEqualTo;
 
-// NOCOMMIT - don't forget to remove the seed before merging
-@Seed("DFD753B506109938:D134E59FDFDFF640")
 public class TermsAggregatorTests extends AggregatorTestCase {
 
     private boolean randomizeAggregatorImpl = true;

--- a/test/framework/src/main/java/org/elasticsearch/search/aggregations/AggregatorTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/search/aggregations/AggregatorTestCase.java
@@ -590,6 +590,7 @@ public abstract class AggregatorTestCase extends ESTestCase {
         try {
             if (randomBoolean() && aggs.size() > 1) {
                 // sometimes do an incremental reduce
+                logger.info("Doing incremental reduce");
                 int toReduceSize = aggs.size();
                 Collections.shuffle(aggs, random());
                 int r = randomIntBetween(1, toReduceSize);

--- a/test/framework/src/main/java/org/elasticsearch/search/aggregations/AggregatorTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/search/aggregations/AggregatorTestCase.java
@@ -590,7 +590,6 @@ public abstract class AggregatorTestCase extends ESTestCase {
         try {
             if (randomBoolean() && aggs.size() > 1) {
                 // sometimes do an incremental reduce
-                logger.info("Doing incremental reduce");
                 int toReduceSize = aggs.size();
                 Collections.shuffle(aggs, random());
                 int r = randomIntBetween(1, toReduceSize);


### PR DESCRIPTION
Terms aggs can generate incorrect counts when combining results from multiple segments. Recent tests enhancements now tests multiple segments introducing flakiness for these cases. This fix adjusts the assertions to cope with that scenario.
