### PR TITLE
Add ability to resolve the cluster alias of remote cluster connections

### DIFF
--- a/server/src/main/java/org/elasticsearch/transport/RemoteConnectionManager.java
+++ b/server/src/main/java/org/elasticsearch/transport/RemoteConnectionManager.java
@@ -17,6 +17,8 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicLong;
 
@@ -87,7 +89,7 @@ public class RemoteConnectionManager implements ConnectionManager {
     @Override
     public Transport.Connection getConnection(DiscoveryNode node) {
         try {
-            return delegate.getConnection(node);
+            return getConnectionInternal(node);
         } catch (NodeNotConnectedException e) {
             return new ProxyConnection(getAnyRemoteConnection(), node);
         }
@@ -116,7 +118,7 @@ public class RemoteConnectionManager implements ConnectionManager {
         if (localConnectedNodes.isEmpty() == false) {
             DiscoveryNode nextNode = localConnectedNodes.get(Math.floorMod(curr, localConnectedNodes.size()));
             try {
-                return delegate.getConnection(nextNode);
+                return getConnectionInternal(nextNode);
             } catch (NodeNotConnectedException e) {
                 // Ignore. We will manually create an iterator of open nodes
             }
@@ -124,7 +126,7 @@ public class RemoteConnectionManager implements ConnectionManager {
         Set<DiscoveryNode> allConnectionNodes = getAllConnectedNodes();
         for (DiscoveryNode connectedNode : allConnectionNodes) {
             try {
-                return delegate.getConnection(connectedNode);
+                return getConnectionInternal(connectedNode);
             } catch (NodeNotConnectedException e) {
                 // Ignore. We will try the next one until all are exhausted.
             }
@@ -150,6 +152,26 @@ public class RemoteConnectionManager implements ConnectionManager {
     @Override
     public void closeNoBlock() {
         delegate.closeNoBlock();
+    }
+
+    /**
+     * This method returns a remote cluster alias for the given transport connection if it targets a node in the remote cluster.
+     * This method will return an optional empty in case the connection targets the local node or the node in the local cluster.
+     *
+     * @param connection the transport connection for which to resolve a remote cluster alias
+     * @return a cluster alias if the connection target a node in the remote cluster, otherwise an empty result
+     */
+    public static Optional<String> resolveRemoteClusterAlias(Transport.Connection connection) {
+        Transport.Connection unwrapped = TransportService.unwrapConnection(connection);
+        if (unwrapped instanceof InternalRemoteConnection remoteConnection) {
+            return Optional.of(remoteConnection.getClusterAlias());
+        }
+        return Optional.empty();
+    }
+
+    private Transport.Connection getConnectionInternal(DiscoveryNode node) throws NodeNotConnectedException {
+        Transport.Connection connection = delegate.getConnection(node);
+        return new InternalRemoteConnection(connection, clusterAlias);
     }
 
     private synchronized void addConnectedNode(DiscoveryNode addedNode) {
@@ -248,5 +270,86 @@ public class RemoteConnectionManager implements ConnectionManager {
 
         @Override
         public void onRemoved() {}
+    }
+
+    private static final class InternalRemoteConnection implements Transport.Connection {
+
+        private final Transport.Connection connection;
+        private final String clusterAlias;
+
+        InternalRemoteConnection(Transport.Connection connection, String clusterAlias) {
+            this.clusterAlias = Objects.requireNonNull(clusterAlias);
+            this.connection = Objects.requireNonNull(connection);
+        }
+
+        public String getClusterAlias() {
+            return clusterAlias;
+        }
+
+        @Override
+        public DiscoveryNode getNode() {
+            return connection.getNode();
+        }
+
+        @Override
+        public void sendRequest(long requestId, String action, TransportRequest request, TransportRequestOptions options)
+            throws IOException, TransportException {
+            connection.sendRequest(requestId, action, request, options);
+        }
+
+        @Override
+        public void addCloseListener(ActionListener<Void> listener) {
+            connection.addCloseListener(listener);
+        }
+
+        @Override
+        public boolean isClosed() {
+            return connection.isClosed();
+        }
+
+        @Override
+        public Version getVersion() {
+            return connection.getVersion();
+        }
+
+        @Override
+        public Object getCacheKey() {
+            return connection.getCacheKey();
+        }
+
+        @Override
+        public void close() {
+            connection.close();
+        }
+
+        @Override
+        public void onRemoved() {
+            connection.onRemoved();
+        }
+
+        @Override
+        public void addRemovedListener(ActionListener<Void> listener) {
+            connection.addRemovedListener(listener);
+        }
+
+        @Override
+        public void incRef() {
+            connection.incRef();
+        }
+
+        @Override
+        public boolean tryIncRef() {
+            return connection.tryIncRef();
+        }
+
+        @Override
+        public boolean decRef() {
+            return connection.decRef();
+        }
+
+        @Override
+        public boolean hasReferences() {
+            return connection.hasReferences();
+        }
     }
 }

--- a/server/src/test/java/org/elasticsearch/transport/RemoteConnectionManagerTests.java
+++ b/server/src/test/java/org/elasticsearch/transport/RemoteConnectionManagerTests.java
@@ -20,6 +20,7 @@ import java.net.InetAddress;
 import java.util.HashSet;
 import java.util.Set;
 
+import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasItems;
 import static org.hamcrest.core.IsInstanceOf.instanceOf;
 import static org.mockito.ArgumentMatchers.any;
@@ -31,7 +32,9 @@ public class RemoteConnectionManagerTests extends ESTestCase {
     private Transport transport;
     private RemoteConnectionManager remoteConnectionManager;
     private ConnectionManager.ConnectionValidator validator = (connection, profile, listener) -> listener.onResponse(null);
+    private TransportAddress address = new TransportAddress(InetAddress.getLoopbackAddress(), 1000);
 
+    @SuppressWarnings("unchecked")
     @Override
     public void setUp() throws Exception {
         super.setUp();
@@ -40,18 +43,15 @@ public class RemoteConnectionManagerTests extends ESTestCase {
             "remote-cluster",
             new ClusterConnectionManager(Settings.EMPTY, transport, new ThreadContext(Settings.EMPTY))
         );
-    }
-
-    @SuppressWarnings("unchecked")
-    public void testGetConnection() {
-        TransportAddress address = new TransportAddress(InetAddress.getLoopbackAddress(), 1000);
 
         doAnswer(invocationOnMock -> {
             ActionListener<Transport.Connection> listener = (ActionListener<Transport.Connection>) invocationOnMock.getArguments()[2];
             listener.onResponse(new TestRemoteConnection((DiscoveryNode) invocationOnMock.getArguments()[0]));
             return null;
         }).when(transport).openConnection(any(DiscoveryNode.class), any(ConnectionProfile.class), any(ActionListener.class));
+    }
 
+    public void testGetConnection() {
         DiscoveryNode node1 = new DiscoveryNode("node-1", address, Version.CURRENT);
         PlainActionFuture<Void> future1 = PlainActionFuture.newFuture();
         remoteConnectionManager.connectToRemoteClusterNode(node1, validator, future1);
@@ -87,6 +87,19 @@ public class RemoteConnectionManagerTests extends ESTestCase {
 
         assertThat(versions, hasItems(Version.CURRENT.minimumCompatibilityVersion()));
         assertEquals(1, versions.size());
+    }
+
+    public void testResolveRemoteClusterAlias() {
+        DiscoveryNode remoteNode = new DiscoveryNode("remote-node", address, Version.CURRENT);
+        PlainActionFuture<Void> future = PlainActionFuture.newFuture();
+        remoteConnectionManager.connectToRemoteClusterNode(remoteNode, validator, future);
+        assertTrue(future.isDone());
+
+        Transport.Connection remoteConnection = remoteConnectionManager.getConnection(remoteNode);
+        assertThat(RemoteConnectionManager.resolveRemoteClusterAlias(remoteConnection).get(), equalTo("remote-cluster"));
+
+        Transport.Connection localConnection = mock(Transport.Connection.class);
+        assertThat(RemoteConnectionManager.resolveRemoteClusterAlias(localConnection).isPresent(), equalTo(false));
     }
 
     private static class TestRemoteConnection extends CloseableConnection {

--- a/server/src/test/java/org/elasticsearch/transport/RemoteConnectionManagerTests.java
+++ b/server/src/test/java/org/elasticsearch/transport/RemoteConnectionManagerTests.java
@@ -90,16 +90,21 @@ public class RemoteConnectionManagerTests extends ESTestCase {
     }
 
     public void testResolveRemoteClusterAlias() {
-        DiscoveryNode remoteNode = new DiscoveryNode("remote-node", address, Version.CURRENT);
+        DiscoveryNode remoteNode1 = new DiscoveryNode("remote-node-1", address, Version.CURRENT);
         PlainActionFuture<Void> future = PlainActionFuture.newFuture();
-        remoteConnectionManager.connectToRemoteClusterNode(remoteNode, validator, future);
+        remoteConnectionManager.connectToRemoteClusterNode(remoteNode1, validator, future);
         assertTrue(future.isDone());
 
-        Transport.Connection remoteConnection = remoteConnectionManager.getConnection(remoteNode);
+        Transport.Connection remoteConnection = remoteConnectionManager.getConnection(remoteNode1);
         assertThat(RemoteConnectionManager.resolveRemoteClusterAlias(remoteConnection).get(), equalTo("remote-cluster"));
 
         Transport.Connection localConnection = mock(Transport.Connection.class);
         assertThat(RemoteConnectionManager.resolveRemoteClusterAlias(localConnection).isPresent(), equalTo(false));
+
+        DiscoveryNode remoteNode2 = new DiscoveryNode("remote-node-2", address, Version.CURRENT);
+        Transport.Connection proxyConnection = remoteConnectionManager.getConnection(remoteNode2);
+        assertThat(proxyConnection, instanceOf(RemoteConnectionManager.ProxyConnection.class));
+        assertThat(RemoteConnectionManager.resolveRemoteClusterAlias(proxyConnection).get(), equalTo("remote-cluster"));
     }
 
     private static class TestRemoteConnection extends CloseableConnection {


### PR DESCRIPTION
As part of Remote Cluster Security 2.0,  we need to be able to determine 
the remote cluster alias for outbound remote cluster connections in the 
`SecurityServerTransportInterceptor`. 

This commit adds this ability to `RemoteConnectionManager` 
by wrapping all created connection objects with cluster alias.