### PR TITLE
More accurate total ingest stats

### DIFF
--- a/docs/changelog/91730.yaml
+++ b/docs/changelog/91730.yaml
@@ -1,0 +1,6 @@
+pr: 91730
+summary: More accurate total ingest stats
+area: Ingest Node
+type: bug
+issues:
+ - 91358

--- a/server/src/main/java/org/elasticsearch/ingest/IngestService.java
+++ b/server/src/main/java/org/elasticsearch/ingest/IngestService.java
@@ -894,8 +894,6 @@ public class IngestService implements ClusterStateApplier, ReportingService<Inge
         }
 
         long startTimeInNanos = System.nanoTime();
-        // the pipeline specific stat holder may not exist and that is fine:
-        // (e.g. the pipeline may have been removed while we're ingesting a document
         totalMetrics.preIngest();
         String index = indexRequest.index();
         String id = indexRequest.id();


### PR DESCRIPTION
Closes #91358

The code change itself is pretty simple -- it moves the stats accounting from `innerExecute` to `executePipelines`. Both functions are private, and `executePipelines` is the only caller of `innerExecute`. 

The `preIngest` call is moved slightly earlier in execution, with no meaningful change in the time being measured. The `postIngest` call is moved later in execution to after all the logic of `innerExecute` has executed (it's gone from the body of `innerExecute` to the `handler` that `innerExecute` calls). The upshot of this is that we'll be tracking the time spent on XContent generation due to calling `indexRequest.source(...)`. That means that the time we report for total ingest stats will be higher. Nothing is actually slower or taking more time, though, we'll just be more correctly measuring and reporting the time that's actually being spent.

```
GET _nodes/stats?filter_path=nodes.*.ingest
{
  "nodes" : {
    "Aysm6ztIRne2ES5ktyuqtw" : {
      "ingest" : {
        "total" : {
          "count" : 1,
          "time_in_millis" : 110, <--- this will be higher after this change
```