### PR TITLE
Cleanup Clusterstate Serialization Code

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/cluster/ClusterStateDiffIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/cluster/ClusterStateDiffIT.java
@@ -73,8 +73,8 @@ public class ClusterStateDiffIT extends ESIntegTestCase {
         DiscoveryNode otherNode = randomNode("other");
         DiscoveryNodes discoveryNodes = DiscoveryNodes.builder().add(masterNode).add(otherNode).localNodeId(masterNode.getId()).build();
         ClusterState clusterState = ClusterState.builder(new ClusterName("test")).nodes(discoveryNodes).build();
-        ClusterState clusterStateFromDiffs = ClusterState.Builder.fromBytes(
-            ClusterState.Builder.toBytes(clusterState),
+        ClusterState clusterStateFromDiffs = ClusterStateUtils.fromBytes(
+            ClusterStateUtils.toBytes(clusterState),
             otherNode,
             namedWriteableRegistry
         );
@@ -103,8 +103,8 @@ public class ClusterStateDiffIT extends ESIntegTestCase {
 
             if (randomIntBetween(0, 10) < 1) {
                 // Update cluster state via full serialization from time to time
-                clusterStateFromDiffs = ClusterState.Builder.fromBytes(
-                    ClusterState.Builder.toBytes(clusterState),
+                clusterStateFromDiffs = ClusterStateUtils.fromBytes(
+                    ClusterStateUtils.toBytes(clusterState),
                     previousClusterStateFromDiffs.nodes().getLocalNode(),
                     namedWriteableRegistry
                 );
@@ -167,8 +167,8 @@ public class ClusterStateDiffIT extends ESIntegTestCase {
                 // Smoke test - we cannot compare bytes to bytes because some elements might get serialized in different order
                 // however, serialized size should remain the same
                 assertThat(
-                    ClusterState.Builder.toBytes(clusterStateFromDiffs).length,
-                    equalTo(ClusterState.Builder.toBytes(clusterState).length)
+                    ClusterStateUtils.toBytes(clusterStateFromDiffs).length,
+                    equalTo(ClusterStateUtils.toBytes(clusterState).length)
                 );
             } catch (AssertionError error) {
                 logger.error(

--- a/server/src/main/java/org/elasticsearch/common/settings/Settings.java
+++ b/server/src/main/java/org/elasticsearch/common/settings/Settings.java
@@ -78,6 +78,8 @@ public final class Settings implements ToXContentFragment, Writeable, Diffable<S
 
     public static final Settings EMPTY = new Settings(Map.of(), null);
 
+    public static final Params FLAT_SETTINGS_PARAMS = new MapParams(Map.of("flat_settings", "true"));
+
     /** The raw settings from the full key to raw string value. */
     private final NavigableMap<String, Object> settings;
 
@@ -1525,7 +1527,7 @@ public final class Settings implements ToXContentFragment, Writeable, Diffable<S
 
     @Override
     public String toString() {
-        return Strings.toString(this, new MapParams(Collections.singletonMap("flat_settings", "true")));
+        return Strings.toString(this, FLAT_SETTINGS_PARAMS);
     }
 
     private static String toString(Object o) {

--- a/server/src/main/java/org/elasticsearch/common/settings/SettingsModule.java
+++ b/server/src/main/java/org/elasticsearch/common/settings/SettingsModule.java
@@ -13,7 +13,6 @@ import org.apache.logging.log4j.Logger;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.inject.Binder;
 import org.elasticsearch.common.inject.Module;
-import org.elasticsearch.xcontent.ToXContent;
 import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xcontent.XContentType;
 
@@ -132,7 +131,7 @@ public class SettingsModule implements Module {
                 try (XContentBuilder xContentBuilder = XContentBuilder.builder(XContentType.JSON.xContent())) {
                     xContentBuilder.prettyPrint();
                     xContentBuilder.startObject();
-                    indexSettings.toXContent(xContentBuilder, new ToXContent.MapParams(Collections.singletonMap("flat_settings", "true")));
+                    indexSettings.toXContent(xContentBuilder, Settings.FLAT_SETTINGS_PARAMS);
                     xContentBuilder.endObject();
                     builder.append(Strings.toString(xContentBuilder));
                 }

--- a/server/src/main/java/org/elasticsearch/gateway/PersistedClusterStateService.java
+++ b/server/src/main/java/org/elasticsearch/gateway/PersistedClusterStateService.java
@@ -539,7 +539,7 @@ public class PersistedClusterStateService {
 
         final SetOnce<Metadata.Builder> builderReference = new SetOnce<>();
         consumeFromType(searcher, GLOBAL_TYPE_NAME, ignored -> GLOBAL_TYPE_NAME, bytes -> {
-            final Metadata metadata = readXContent(bytes, Metadata.Builder::fromXContent);
+            final Metadata metadata = readXContent(bytes, Metadata::fromXContent);
             logger.trace("found global metadata with last-accepted term [{}]", metadata.coordinationMetadata().term());
             if (builderReference.get() != null) {
                 throw new CorruptStateException("duplicate global metadata found in [" + dataPath + "]");

--- a/server/src/main/java/org/elasticsearch/rest/action/admin/cluster/RestClusterStateAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/admin/cluster/RestClusterStateAction.java
@@ -32,16 +32,18 @@ import org.elasticsearch.xcontent.XContentBuilder;
 import java.io.IOException;
 import java.util.EnumSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.function.LongSupplier;
 
-import static java.util.Collections.singletonMap;
 import static org.elasticsearch.common.util.set.Sets.addToCopy;
 import static org.elasticsearch.rest.RestRequest.Method.GET;
 
 public class RestClusterStateAction extends BaseRestHandler {
 
     private static final Set<String> RESPONSE_PARAMS = addToCopy(Settings.FORMAT_PARAMS, "metric");
+
+    private static final Map<String, String> API_CONTEXT_MODE_PARAMS = Map.of(Metadata.CONTEXT_MODE_PARAM, Metadata.CONTEXT_MODE_API);
 
     private final SettingsFilter settingsFilter;
 
@@ -89,7 +91,7 @@ public class RestClusterStateAction extends BaseRestHandler {
         }
 
         if (request.hasParam("metric")) {
-            EnumSet<ClusterState.Metric> metrics = ClusterState.Metric.parseString(request.param("metric"), true);
+            EnumSet<ClusterState.Metric> metrics = ClusterState.Metric.parseString(request.param("metric"));
             // do not ask for what we do not need.
             clusterStateRequest.nodes(metrics.contains(ClusterState.Metric.NODES) || metrics.contains(ClusterState.Metric.MASTER_NODE));
             /*
@@ -117,10 +119,7 @@ public class RestClusterStateAction extends BaseRestHandler {
             ) {
                 @Override
                 protected ToXContent.Params getParams() {
-                    return new ToXContent.DelegatingMapParams(
-                        singletonMap(Metadata.CONTEXT_MODE_PARAM, Metadata.CONTEXT_MODE_API),
-                        request
-                    );
+                    return new ToXContent.DelegatingMapParams(API_CONTEXT_MODE_PARAMS, request);
                 }
             }.map(response -> new RestClusterStateResponse(clusterStateRequest, response, threadPool::relativeTimeInMillis))
         );

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/MetadataTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/MetadataTests.java
@@ -461,7 +461,7 @@ public class MetadataTests extends ESTestCase {
             JsonXContent.contentBuilder().startObject().startObject("meta-data").field("random", "value").endObject().endObject()
         );
         try (XContentParser parser = createParser(JsonXContent.jsonXContent, metadata)) {
-            Metadata.Builder.fromXContent(parser);
+            Metadata.fromXContent(parser);
             fail();
         } catch (IllegalArgumentException e) {
             assertEquals("Unexpected field [random]", e.getMessage());
@@ -473,7 +473,7 @@ public class MetadataTests extends ESTestCase {
             JsonXContent.contentBuilder().startObject().startObject("index_name").field("random", "value").endObject().endObject()
         );
         try (XContentParser parser = createParser(JsonXContent.jsonXContent, metadata)) {
-            IndexMetadata.Builder.fromXContent(parser);
+            IndexMetadata.fromXContent(parser);
             fail();
         } catch (IllegalArgumentException e) {
             assertEquals("Unexpected field [random]", e.getMessage());

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/ToAndFromJsonMetadataTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/ToAndFromJsonMetadataTests.java
@@ -135,7 +135,7 @@ public class ToAndFromJsonMetadataTests extends ESTestCase {
         Metadata.FORMAT.toXContent(builder, metadata);
         builder.endObject();
 
-        Metadata parsedMetadata = Metadata.Builder.fromXContent(createParser(builder));
+        Metadata parsedMetadata = Metadata.fromXContent(createParser(builder));
 
         // templates
         assertThat(parsedMetadata.templates().get("foo").name(), is("foo"));

--- a/server/src/test/java/org/elasticsearch/cluster/serialization/ClusterSerializationTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/serialization/ClusterSerializationTests.java
@@ -15,6 +15,7 @@ import org.elasticsearch.cluster.ClusterModule;
 import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.ClusterState.Custom;
+import org.elasticsearch.cluster.ClusterStateUtils;
 import org.elasticsearch.cluster.Diff;
 import org.elasticsearch.cluster.ESAllocationTestCase;
 import org.elasticsearch.cluster.NamedDiff;
@@ -76,8 +77,8 @@ public class ClusterSerializationTests extends ESAllocationTestCase {
             .routingTable(strategy.reroute(clusterState, "reroute", ActionListener.noop()).routingTable())
             .build();
 
-        ClusterState serializedClusterState = ClusterState.Builder.fromBytes(
-            ClusterState.Builder.toBytes(clusterState),
+        ClusterState serializedClusterState = ClusterStateUtils.fromBytes(
+            ClusterStateUtils.toBytes(clusterState),
             newNode("node1"),
             new NamedWriteableRegistry(ClusterModule.getNamedWriteables())
         );

--- a/server/src/test/java/org/elasticsearch/common/settings/SettingsTests.java
+++ b/server/src/test/java/org/elasticsearch/common/settings/SettingsTests.java
@@ -552,7 +552,7 @@ public class SettingsTests extends ESTestCase {
 
         builder = XContentBuilder.builder(XContentType.JSON.xContent());
         builder.startObject();
-        test.toXContent(builder, new ToXContent.MapParams(Collections.singletonMap("flat_settings", "true")));
+        test.toXContent(builder, Settings.FLAT_SETTINGS_PARAMS);
         builder.endObject();
         assertEquals("""
             {"foo.bar":["1","2","3"]}""", Strings.toString(builder));

--- a/server/src/test/java/org/elasticsearch/gateway/MetadataStateFormatTests.java
+++ b/server/src/test/java/org/elasticsearch/gateway/MetadataStateFormatTests.java
@@ -67,7 +67,7 @@ public class MetadataStateFormatTests extends ESTestCase {
 
             @Override
             public Metadata fromXContent(XContentParser parser) throws IOException {
-                return Metadata.Builder.fromXContent(parser);
+                return Metadata.fromXContent(parser);
             }
         };
         Path tmp = createTempDir();

--- a/test/framework/src/main/java/org/elasticsearch/cluster/ClusterStateUtils.java
+++ b/test/framework/src/main/java/org/elasticsearch/cluster/ClusterStateUtils.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+package org.elasticsearch.cluster;
+
+import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.common.io.stream.BytesStreamOutput;
+import org.elasticsearch.common.io.stream.NamedWriteableAwareStreamInput;
+import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
+import org.elasticsearch.common.io.stream.StreamInput;
+
+import java.io.IOException;
+
+public enum ClusterStateUtils {
+    ;
+
+    public static byte[] toBytes(ClusterState state) throws IOException {
+        BytesStreamOutput os = new BytesStreamOutput();
+        state.writeTo(os);
+        return BytesReference.toBytes(os.bytes());
+    }
+
+    /**
+     * @param data      input bytes
+     * @param localNode used to set the local node in the cluster state.
+     */
+    public static ClusterState fromBytes(byte[] data, DiscoveryNode localNode, NamedWriteableRegistry registry) throws IOException {
+        StreamInput in = new NamedWriteableAwareStreamInput(StreamInput.wrap(data), registry);
+        return ClusterState.readFrom(in, localNode);
+
+    }
+}

--- a/test/framework/src/main/java/org/elasticsearch/test/ESIntegTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/ESIntegTestCase.java
@@ -63,6 +63,7 @@ import org.elasticsearch.cluster.ClusterInfoService;
 import org.elasticsearch.cluster.ClusterInfoServiceUtils;
 import org.elasticsearch.cluster.ClusterModule;
 import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.ClusterStateUtils;
 import org.elasticsearch.cluster.InternalClusterInfoService;
 import org.elasticsearch.cluster.coordination.ElasticsearchNodeCommand;
 import org.elasticsearch.cluster.health.ClusterHealthStatus;
@@ -1097,19 +1098,19 @@ public abstract class ESIntegTestCase extends ESTestCase {
             final NamedWriteableRegistry namedWriteableRegistry = cluster().getNamedWriteableRegistry();
             final Client masterClient = client();
             ClusterState masterClusterState = masterClient.admin().cluster().prepareState().all().get().getState();
-            byte[] masterClusterStateBytes = ClusterState.Builder.toBytes(masterClusterState);
+            byte[] masterClusterStateBytes = ClusterStateUtils.toBytes(masterClusterState);
             // remove local node reference
-            masterClusterState = ClusterState.Builder.fromBytes(masterClusterStateBytes, null, namedWriteableRegistry);
+            masterClusterState = ClusterStateUtils.fromBytes(masterClusterStateBytes, null, namedWriteableRegistry);
             Map<String, Object> masterStateMap = convertToMap(masterClusterState);
-            int masterClusterStateSize = ClusterState.Builder.toBytes(masterClusterState).length;
+            int masterClusterStateSize = ClusterStateUtils.toBytes(masterClusterState).length;
             String masterId = masterClusterState.nodes().getMasterNodeId();
             for (Client client : cluster().getClients()) {
                 ClusterState localClusterState = client.admin().cluster().prepareState().all().setLocal(true).get().getState();
-                byte[] localClusterStateBytes = ClusterState.Builder.toBytes(localClusterState);
+                byte[] localClusterStateBytes = ClusterStateUtils.toBytes(localClusterState);
                 // remove local node reference
-                localClusterState = ClusterState.Builder.fromBytes(localClusterStateBytes, null, namedWriteableRegistry);
+                localClusterState = ClusterStateUtils.fromBytes(localClusterStateBytes, null, namedWriteableRegistry);
                 final Map<String, Object> localStateMap = convertToMap(localClusterState);
-                final int localClusterStateSize = ClusterState.Builder.toBytes(localClusterState).length;
+                final int localClusterStateSize = ClusterStateUtils.toBytes(localClusterState).length;
                 // Check that the non-master node has the same version of the cluster state as the master and
                 // that the master node matches the master (otherwise there is no requirement for the cluster state to match)
                 if (masterClusterState.version() == localClusterState.version()

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/license/LicensesMetadataSerializationTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/license/LicensesMetadataSerializationTests.java
@@ -81,7 +81,7 @@ public class LicensesMetadataSerializationTests extends ESTestCase {
         builder = metadataBuilder.build().toXContent(builder, params);
         builder.endObject();
         // deserialize metadata again
-        Metadata metadata = Metadata.Builder.fromXContent(createParser(builder));
+        Metadata metadata = Metadata.fromXContent(createParser(builder));
         // check that custom metadata still present
         assertThat(metadata.custom(licensesMetadata.getWriteableName()), notNullValue());
         assertThat(metadata.custom(repositoriesMetadata.getWriteableName()), notNullValue());

--- a/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/MlNativeIntegTestCase.java
+++ b/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/MlNativeIntegTestCase.java
@@ -21,6 +21,7 @@ import org.elasticsearch.action.support.master.AcknowledgedResponse;
 import org.elasticsearch.client.internal.Client;
 import org.elasticsearch.cluster.ClusterModule;
 import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.ClusterStateUtils;
 import org.elasticsearch.cluster.NamedDiff;
 import org.elasticsearch.cluster.metadata.ComposableIndexTemplate;
 import org.elasticsearch.cluster.metadata.Metadata;
@@ -354,19 +355,19 @@ abstract class MlNativeIntegTestCase extends ESIntegTestCase {
             );
             final NamedWriteableRegistry namedWriteableRegistry = new NamedWriteableRegistry(entries);
             ClusterState masterClusterState = client().admin().cluster().prepareState().all().get().getState();
-            byte[] masterClusterStateBytes = ClusterState.Builder.toBytes(masterClusterState);
+            byte[] masterClusterStateBytes = ClusterStateUtils.toBytes(masterClusterState);
             // remove local node reference
-            masterClusterState = ClusterState.Builder.fromBytes(masterClusterStateBytes, null, namedWriteableRegistry);
+            masterClusterState = ClusterStateUtils.fromBytes(masterClusterStateBytes, null, namedWriteableRegistry);
             Map<String, Object> masterStateMap = convertToMap(masterClusterState);
-            int masterClusterStateSize = ClusterState.Builder.toBytes(masterClusterState).length;
+            int masterClusterStateSize = ClusterStateUtils.toBytes(masterClusterState).length;
             String masterId = masterClusterState.nodes().getMasterNodeId();
             for (Client client : cluster().getClients()) {
                 ClusterState localClusterState = client.admin().cluster().prepareState().all().setLocal(true).get().getState();
-                byte[] localClusterStateBytes = ClusterState.Builder.toBytes(localClusterState);
+                byte[] localClusterStateBytes = ClusterStateUtils.toBytes(localClusterState);
                 // remove local node reference
-                localClusterState = ClusterState.Builder.fromBytes(localClusterStateBytes, null, namedWriteableRegistry);
+                localClusterState = ClusterStateUtils.fromBytes(localClusterStateBytes, null, namedWriteableRegistry);
                 final Map<String, Object> localStateMap = convertToMap(localClusterState);
-                final int localClusterStateSize = ClusterState.Builder.toBytes(localClusterState).length;
+                final int localClusterStateSize = ClusterStateUtils.toBytes(localClusterState).length;
                 // Check that the non-master node has the same version of the cluster state as the master and
                 // that the master node matches the master (otherwise there is no requirement for the cluster state to match)
                 if (masterClusterState.version() == localClusterState.version()

--- a/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/WatcherMetadataSerializationTests.java
+++ b/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/WatcherMetadataSerializationTests.java
@@ -66,7 +66,7 @@ public class WatcherMetadataSerializationTests extends ESTestCase {
         builder = metadataBuilder.build().toXContent(builder, params);
         builder.endObject();
         // deserialize metadata again
-        Metadata metadata = Metadata.Builder.fromXContent(createParser(builder));
+        Metadata metadata = Metadata.fromXContent(createParser(builder));
         // check that custom metadata still present
         assertThat(metadata.custom(watcherMetadata.getWriteableName()), notNullValue());
         assertThat(metadata.custom(repositoriesMetadata.getWriteableName()), notNullValue());


### PR DESCRIPTION
Cleaning up a few things to simplify the code in general (redundant param on metric enum parsing + removing need to/from x-content indirection via methods on builders) and specifically remove some noise from when this is moved to chunked encoding.
Also, fix some needless parameter map allocations and extract test-only code for CS to `byte[]` conversion to test helper class.
