### PR TITLE
[8.6] Fix NPE in IndexService#getNodeMappingStats (#91334)

### DIFF
--- a/docs/changelog/91334.yaml
+++ b/docs/changelog/91334.yaml
@@ -1,0 +1,6 @@
+pr: 91334
+summary: "Fix NPE in IndexService getNodeMappingStats"
+area: "Stats"
+type: bug
+issues:
+  - 91259

--- a/server/src/main/java/org/elasticsearch/index/IndexService.java
+++ b/server/src/main/java/org/elasticsearch/index/IndexService.java
@@ -300,8 +300,10 @@ public class IndexService extends AbstractIndexComponent implements IndicesClust
     }
 
     public NodeMappingStats getNodeMappingStats() {
+        if (mapperService == null) {
+            return null;
+        }
         long totalCount = mapperService().mappingLookup().getTotalFieldsCount();
-        Index index = index();
         long totalEstimatedOverhead = totalCount * 1024L; // 1KiB estimated per mapping
         NodeMappingStats indexNodeMappingStats = new NodeMappingStats(totalCount, totalEstimatedOverhead);
         return indexNodeMappingStats;


### PR DESCRIPTION
Backports the following commits to 8.6:
 - Fix NPE in IndexService#getNodeMappingStats (#91334)