### PR TITLE
[7.17] Do not use recovery from snapshots in searchable snapshots

### DIFF
--- a/server/src/main/java/org/elasticsearch/indices/recovery/RecoverySourceHandler.java
+++ b/server/src/main/java/org/elasticsearch/indices/recovery/RecoverySourceHandler.java
@@ -63,6 +63,7 @@ import org.elasticsearch.index.store.StoreFileMetadata;
 import org.elasticsearch.index.translog.Translog;
 import org.elasticsearch.indices.recovery.plan.RecoveryPlannerService;
 import org.elasticsearch.indices.recovery.plan.ShardRecoveryPlan;
+import org.elasticsearch.snapshots.SearchableSnapshotsSettings;
 import org.elasticsearch.snapshots.SnapshotShardsService;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.RemoteTransportException;
@@ -561,9 +562,15 @@ public class RecoverySourceHandler {
                     );
                 }
             }
-            if (canSkipPhase1(recoverySourceMetadata, request.metadataSnapshot()) == false) {
+            // When sync ids were used we could use them to check if two shard copies were equivalent,
+            // if that's the case we can skip sending files from the source shard to the target shard.
+            // If the shard uses the current replication mechanism, we have to compute the recovery plan,
+            // and it is still possible to skip the sending files from the source shard to the target shard
+            // using a different mechanism to determine it.
+            // TODO: is this still relevant today?
+            if (hasSameLegacySyncId(recoverySourceMetadata, request.metadataSnapshot()) == false) {
                 cancellableThreads.checkForCancel();
-                final boolean canUseSnapshots = useSnapshots && request.canDownloadSnapshotFiles();
+                final boolean canUseSnapshots = canUseSnapshots();
                 recoveryPlannerService.computeRecoveryPlan(
                     shard.shardId(),
                     shardStateIdentifier,
@@ -601,6 +608,12 @@ public class RecoverySourceHandler {
         } catch (Exception e) {
             throw new RecoverFilesRecoveryException(request.shardId(), 0, new ByteSizeValue(0L), e);
         }
+    }
+
+    private boolean canUseSnapshots() {
+        return useSnapshots && request.canDownloadSnapshotFiles()
+        // Avoid using snapshots for searchable snapshots as these are implicitly recovered from a snapshot
+            && SearchableSnapshotsSettings.isSearchableSnapshotStore(shard.indexSettings().getSettings()) == false;
     }
 
     void recoverFilesFromSourceAndSnapshot(
@@ -990,7 +1003,7 @@ public class RecoverySourceHandler {
         }, shardId + " establishing retention lease for [" + request.targetAllocationId() + "]", shard, cancellableThreads, logger);
     }
 
-    boolean canSkipPhase1(Store.MetadataSnapshot source, Store.MetadataSnapshot target) {
+    boolean hasSameLegacySyncId(Store.MetadataSnapshot source, Store.MetadataSnapshot target) {
         if (source.getSyncId() == null || source.getSyncId().equals(target.getSyncId()) == false) {
             return false;
         }

--- a/server/src/main/java/org/elasticsearch/indices/recovery/plan/PeerOnlyRecoveryPlannerService.java
+++ b/server/src/main/java/org/elasticsearch/indices/recovery/plan/PeerOnlyRecoveryPlannerService.java
@@ -19,8 +19,11 @@ import java.util.List;
 
 import static org.elasticsearch.common.util.CollectionUtils.concatLists;
 
-public class SourceOnlyRecoveryPlannerService implements RecoveryPlannerService {
-    public static final RecoveryPlannerService INSTANCE = new SourceOnlyRecoveryPlannerService();
+/**
+ * Service in charge of computing a {@link ShardRecoveryPlan} using only the physical files from the source peer.
+ */
+public class PeerOnlyRecoveryPlannerService implements RecoveryPlannerService {
+    public static final RecoveryPlannerService INSTANCE = new PeerOnlyRecoveryPlannerService();
 
     @Override
     public void computeRecoveryPlan(

--- a/server/src/test/java/org/elasticsearch/snapshots/SnapshotResiliencyTests.java
+++ b/server/src/test/java/org/elasticsearch/snapshots/SnapshotResiliencyTests.java
@@ -156,7 +156,7 @@ import org.elasticsearch.indices.recovery.PeerRecoverySourceService;
 import org.elasticsearch.indices.recovery.PeerRecoveryTargetService;
 import org.elasticsearch.indices.recovery.RecoverySettings;
 import org.elasticsearch.indices.recovery.SnapshotFilesProvider;
-import org.elasticsearch.indices.recovery.plan.SourceOnlyRecoveryPlannerService;
+import org.elasticsearch.indices.recovery.plan.PeerOnlyRecoveryPlannerService;
 import org.elasticsearch.ingest.IngestService;
 import org.elasticsearch.monitor.StatusInfo;
 import org.elasticsearch.node.ResponseCollectorService;
@@ -1815,7 +1815,7 @@ public class SnapshotResiliencyTests extends ESTestCase {
                     transportService,
                     indicesService,
                     recoverySettings,
-                    SourceOnlyRecoveryPlannerService.INSTANCE
+                    PeerOnlyRecoveryPlannerService.INSTANCE
                 );
 
                 final SnapshotFilesProvider snapshotFilesProvider = new SnapshotFilesProvider(repositoriesService);

--- a/test/framework/src/main/java/org/elasticsearch/index/shard/IndexShardTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/index/shard/IndexShardTestCase.java
@@ -66,8 +66,8 @@ import org.elasticsearch.indices.recovery.RecoverySourceHandler;
 import org.elasticsearch.indices.recovery.RecoveryState;
 import org.elasticsearch.indices.recovery.RecoveryTarget;
 import org.elasticsearch.indices.recovery.StartRecoveryRequest;
+import org.elasticsearch.indices.recovery.plan.PeerOnlyRecoveryPlannerService;
 import org.elasticsearch.indices.recovery.plan.RecoveryPlannerService;
-import org.elasticsearch.indices.recovery.plan.SourceOnlyRecoveryPlannerService;
 import org.elasticsearch.repositories.IndexId;
 import org.elasticsearch.repositories.Repository;
 import org.elasticsearch.repositories.ShardGeneration;
@@ -735,7 +735,7 @@ public abstract class IndexShardTestCase extends ESTestCase {
         int fileChunkSizeInBytes = Math.toIntExact(
             randomBoolean() ? RecoverySettings.DEFAULT_CHUNK_SIZE.getBytes() : randomIntBetween(1, 10 * 1024 * 1024)
         );
-        final RecoveryPlannerService recoveryPlannerService = SourceOnlyRecoveryPlannerService.INSTANCE;
+        final RecoveryPlannerService recoveryPlannerService = PeerOnlyRecoveryPlannerService.INSTANCE;
         final RecoverySourceHandler recovery = new RecoverySourceHandler(
             primary,
             new AsyncRecoveryTarget(recoveryTarget, threadPool.generic()),

--- a/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/SearchableSnapshotsRecoverFromSnapshotIntegTests.java
+++ b/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/SearchableSnapshotsRecoverFromSnapshotIntegTests.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.searchablesnapshots;
+
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.lucene.search.TotalHits;
+import org.elasticsearch.common.logging.Loggers;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.indices.recovery.plan.ShardSnapshotsService;
+import org.elasticsearch.repositories.blobstore.BlobStoreRepository;
+import org.elasticsearch.repositories.fs.FsRepository;
+import org.elasticsearch.test.MockLogAppender;
+import org.elasticsearch.xpack.core.searchablesnapshots.MountSearchableSnapshotRequest;
+
+import java.util.Collections;
+import java.util.Locale;
+
+import static org.elasticsearch.cluster.metadata.IndexMetadata.INDEX_NUMBER_OF_REPLICAS_SETTING;
+import static org.elasticsearch.cluster.metadata.IndexMetadata.INDEX_NUMBER_OF_SHARDS_SETTING;
+import static org.elasticsearch.index.IndexSettings.INDEX_SOFT_DELETES_SETTING;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertHitCount;
+
+public class SearchableSnapshotsRecoverFromSnapshotIntegTests extends BaseSearchableSnapshotsIntegTestCase {
+    public void testSearchableSnapshotRelocationDoNotUseSnapshotBasedRecoveries() throws Exception {
+        final String repositoryName = randomAlphaOfLength(10).toLowerCase(Locale.ROOT);
+        final Settings.Builder repositorySettings = randomRepositorySettings();
+        repositorySettings.put(BlobStoreRepository.USE_FOR_PEER_RECOVERY_SETTING.getKey(), true);
+        createRepository(repositoryName, FsRepository.TYPE, repositorySettings);
+
+        final String indexName = randomAlphaOfLength(10).toLowerCase(Locale.ROOT);
+        createAndPopulateIndex(
+            indexName,
+            Settings.builder()
+                .put(INDEX_NUMBER_OF_SHARDS_SETTING.getKey(), 1)
+                .put(INDEX_SOFT_DELETES_SETTING.getKey(), true)
+                .put(INDEX_NUMBER_OF_REPLICAS_SETTING.getKey(), 0)
+        );
+
+        final TotalHits totalHits = internalCluster().client()
+            .prepareSearch(indexName)
+            .setTrackTotalHits(true)
+            .get()
+            .getHits()
+            .getTotalHits();
+
+        final String snapshotName = randomAlphaOfLength(10).toLowerCase(Locale.ROOT);
+        createSnapshot(repositoryName, snapshotName, Collections.singletonList(indexName));
+        assertAcked(client().admin().indices().prepareDelete(indexName));
+
+        final String restoredIndexName = "restored-" + indexName;
+        mountSnapshot(
+            repositoryName,
+            snapshotName,
+            indexName,
+            restoredIndexName,
+            Settings.EMPTY,
+            MountSearchableSnapshotRequest.Storage.FULL_COPY
+        );
+
+        createSnapshot(repositoryName, randomAlphaOfLength(10).toLowerCase(Locale.ROOT), Collections.singletonList(restoredIndexName));
+
+        final String newNode = internalCluster().startDataOnlyNode();
+
+        final MockLogAppender mockAppender = new MockLogAppender();
+        mockAppender.start();
+        mockAppender.addExpectation(
+            new MockLogAppender.UnseenEventExpectation(
+                "Error fetching segments file",
+                ShardSnapshotsService.class.getCanonicalName(),
+                Level.WARN,
+                "Unable to fetch shard snapshot files for*"
+            )
+        );
+
+        final Logger logger = LogManager.getLogger(ShardSnapshotsService.class);
+        Loggers.addAppender(logger, mockAppender);
+
+        // Relocate the searchable snapshot shard to the new node
+        client().admin()
+            .indices()
+            .prepareUpdateSettings(restoredIndexName)
+            .setSettings(Settings.builder().put("index.routing.allocation.require._name", newNode).build())
+            .get();
+
+        ensureGreen(restoredIndexName);
+
+        assertHitCount(client().prepareSearch(restoredIndexName).setTrackTotalHits(true).get(), totalHits.value);
+
+        mockAppender.assertAllExpectationsMatched();
+        Loggers.removeAppender(logger, mockAppender);
+        mockAppender.stop();
+    }
+}


### PR DESCRIPTION
This commit disables recovering from snapshots for searchable snapshots as the snapshot for these type of indices consist in a pointer to the original snapshot and it produced confusing error messages.

Backport of #86388