### PR TITLE
Ignore the version of the policy

### DIFF
--- a/docs/reference/ilm/apis/get-lifecycle.asciidoc
+++ b/docs/reference/ilm/apis/get-lifecycle.asciidoc
@@ -115,7 +115,7 @@ If the request succeeds, the body of the response contains the policy definition
   }
 }
 --------------------------------------------------
-// TEST[skip:https://github.com/elastic/elasticsearch/issues/89623]
+// TESTRESPONSE[s/"version": 1/"version": $body.my_policy.version/]
 // TESTRESPONSE[s/"modified_date": 82392349/"modified_date": $body.my_policy.modified_date/]
 
 <1> The policy version is incremented whenever the policy is updated


### PR DESCRIPTION
Closes #89623.

**The failure:**
The test failure is caused by the failed assertion over the version of the policy. Expected version is `1` but the policy has version `2`. 

**Reproduction path**
 I was not able to reproduce it locally when running the test in isolation. The policy `my_policy` is being used a lot in the tests and my assumption is that there is a leftover policy in the cluster after a certain test. When this test is run after that test we encounter this issue. I wasn't able to track down the culprit and I am not sure if it is worth the time.
 
 **Proposed solution**
 I propose to ignore the version and only check the structure of the policy.
