### PR TITLE
Expose params to toXContentChunked as well as per-chunk

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/discovery/StableMasterDisruptionIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/discovery/StableMasterDisruptionIT.java
@@ -144,7 +144,7 @@ public class StableMasterDisruptionIT extends ESIntegTestCase {
 
     private String xContentToString(ChunkedToXContent xContent) throws IOException {
         XContentBuilder builder = JsonXContent.contentBuilder();
-        xContent.toXContentChunked().forEachRemaining(xcontent -> {
+        xContent.toXContentChunked(ToXContent.EMPTY_PARAMS).forEachRemaining(xcontent -> {
             try {
                 xcontent.toXContent(builder, ToXContent.EMPTY_PARAMS);
             } catch (IOException e) {

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/get/GetSnapshotsResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/get/GetSnapshotsResponse.java
@@ -165,7 +165,7 @@ public class GetSnapshotsResponse extends ActionResponse implements ChunkedToXCo
     }
 
     @Override
-    public Iterator<ToXContent> toXContentChunked() {
+    public Iterator<ToXContent> toXContentChunked(ToXContent.Params params) {
         return Iterators.concat(Iterators.single((b, p) -> {
             b.startObject();
             b.startArray("snapshots");

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/status/SnapshotStatus.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/status/SnapshotStatus.java
@@ -190,7 +190,7 @@ public class SnapshotStatus implements ChunkedToXContent, Writeable {
     private static final String INCLUDE_GLOBAL_STATE = "include_global_state";
 
     @Override
-    public Iterator<? extends ToXContent> toXContentChunked() {
+    public Iterator<? extends ToXContent> toXContentChunked(ToXContent.Params params) {
         return Iterators.concat(Iterators.single((ToXContent) (b, p) -> {
             b.startObject()
                 .field(SNAPSHOT, snapshot.getSnapshotId().getName())

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/status/SnapshotsStatusResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/status/SnapshotsStatusResponse.java
@@ -89,11 +89,13 @@ public class SnapshotsStatusResponse extends ActionResponse implements ChunkedTo
     }
 
     @Override
-    public Iterator<? extends ToXContent> toXContentChunked() {
+    public Iterator<? extends ToXContent> toXContentChunked(ToXContent.Params params) {
         return Iterators.concat(
             Iterators.single((ToXContent) (b, p) -> b.startObject().startArray("snapshots")),
             snapshots.stream()
-                .flatMap(s -> StreamSupport.stream(Spliterators.spliteratorUnknownSize(s.toXContentChunked(), Spliterator.ORDERED), false))
+                .flatMap(
+                    s -> StreamSupport.stream(Spliterators.spliteratorUnknownSize(s.toXContentChunked(params), Spliterator.ORDERED), false)
+                )
                 .iterator(),
             Iterators.single((b, p) -> b.endArray().endObject())
         );

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/mapping/get/GetMappingsResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/mapping/get/GetMappingsResponse.java
@@ -67,7 +67,7 @@ public class GetMappingsResponse extends ActionResponse implements ChunkedToXCon
     }
 
     @Override
-    public Iterator<ToXContent> toXContentChunked() {
+    public Iterator<ToXContent> toXContentChunked(ToXContent.Params outerParams) {
         return Iterators.concat(
             Iterators.single((b, p) -> b.startObject()),
             getMappings().entrySet().stream().map(indexEntry -> (ToXContent) (builder, params) -> {

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/recovery/RecoveryResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/recovery/RecoveryResponse.java
@@ -65,7 +65,7 @@ public class RecoveryResponse extends BaseBroadcastResponse implements ChunkedTo
     }
 
     @Override
-    public Iterator<ToXContent> toXContentChunked() {
+    public Iterator<ToXContent> toXContentChunked(ToXContent.Params params) {
         return Iterators.concat(
             Iterators.single((b, p) -> b.startObject()),
             shardRecoveryStates.entrySet()

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/segments/IndicesSegmentResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/segments/IndicesSegmentResponse.java
@@ -79,7 +79,7 @@ public class IndicesSegmentResponse extends BaseBroadcastResponse implements Chu
     }
 
     @Override
-    public Iterator<? extends ToXContent> toXContentChunked() {
+    public Iterator<? extends ToXContent> toXContentChunked(ToXContent.Params outerParams) {
         return Iterators.concat(Iterators.single(((builder, params) -> {
             builder.startObject();
             RestActions.buildBroadcastShardsHeader(builder, params, this);

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/settings/get/GetSettingsResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/settings/get/GetSettingsResponse.java
@@ -154,7 +154,7 @@ public class GetSettingsResponse extends ActionResponse implements ChunkedToXCon
     }
 
     @Override
-    public Iterator<? extends ToXContent> toXContentChunked() {
+    public Iterator<? extends ToXContent> toXContentChunked(ToXContent.Params params) {
         final boolean omitEmptySettings = indexToDefaultSettings.isEmpty();
         return toXContentChunked(omitEmptySettings);
     }

--- a/server/src/main/java/org/elasticsearch/action/fieldcaps/FieldCapabilitiesResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/fieldcaps/FieldCapabilitiesResponse.java
@@ -152,7 +152,7 @@ public class FieldCapabilitiesResponse extends ActionResponse implements Chunked
     }
 
     @Override
-    public Iterator<? extends ToXContent> toXContentChunked() {
+    public Iterator<? extends ToXContent> toXContentChunked(ToXContent.Params params) {
         if (indexResponses.size() > 0) {
             throw new IllegalStateException("cannot serialize non-merged response");
         }

--- a/server/src/main/java/org/elasticsearch/action/support/nodes/BaseNodesXContentResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/support/nodes/BaseNodesXContentResponse.java
@@ -33,7 +33,7 @@ public abstract class BaseNodesXContentResponse<TNodeResponse extends BaseNodeRe
     }
 
     @Override
-    public final Iterator<? extends ToXContent> toXContentChunked() {
+    public final Iterator<? extends ToXContent> toXContentChunked(ToXContent.Params params) {
         return Iterators.concat(Iterators.single((b, p) -> {
             b.startObject();
             RestActions.buildNodesHeader(b, p, this);

--- a/server/src/main/java/org/elasticsearch/common/xcontent/ChunkedToXContent.java
+++ b/server/src/main/java/org/elasticsearch/common/xcontent/ChunkedToXContent.java
@@ -26,7 +26,7 @@ public interface ChunkedToXContent {
      * {@link ToXContent.Params} for each call until it is fully drained.
      * @return iterator over chunks of {@link ToXContent}
      */
-    Iterator<? extends ToXContent> toXContentChunked();
+    Iterator<? extends ToXContent> toXContentChunked(ToXContent.Params params);
 
     /**
      * Wraps the given instance in a {@link ToXContentObject} that will fully serialize the instance when serialized.
@@ -35,7 +35,7 @@ public interface ChunkedToXContent {
      */
     static ToXContentObject wrapAsXContentObject(ChunkedToXContent chunkedToXContent) {
         return (builder, params) -> {
-            Iterator<? extends ToXContent> serialization = chunkedToXContent.toXContentChunked();
+            Iterator<? extends ToXContent> serialization = chunkedToXContent.toXContentChunked(params);
             while (serialization.hasNext()) {
                 serialization.next().toXContent(builder, params);
             }

--- a/server/src/main/java/org/elasticsearch/health/Diagnosis.java
+++ b/server/src/main/java/org/elasticsearch/health/Diagnosis.java
@@ -77,7 +77,7 @@ public record Diagnosis(Definition definition, @Nullable List<Resource> affected
         }
 
         @Override
-        public Iterator<? extends ToXContent> toXContentChunked() {
+        public Iterator<? extends ToXContent> toXContentChunked(ToXContent.Params outerParams) {
             Iterator<? extends ToXContent> valuesIterator;
             if (nodes != null) {
                 valuesIterator = nodes.stream().map(node -> (ToXContent) (builder, params) -> {
@@ -147,11 +147,16 @@ public record Diagnosis(Definition definition, @Nullable List<Resource> affected
     }
 
     @Override
-    public Iterator<? extends ToXContent> toXContentChunked() {
+    public Iterator<? extends ToXContent> toXContentChunked(ToXContent.Params outerParams) {
         Iterator<? extends ToXContent> resourcesIterator = Collections.emptyIterator();
         if (affectedResources != null && affectedResources.size() > 0) {
             resourcesIterator = affectedResources.stream()
-                .flatMap(s -> StreamSupport.stream(Spliterators.spliteratorUnknownSize(s.toXContentChunked(), Spliterator.ORDERED), false))
+                .flatMap(
+                    s -> StreamSupport.stream(
+                        Spliterators.spliteratorUnknownSize(s.toXContentChunked(outerParams), Spliterator.ORDERED),
+                        false
+                    )
+                )
                 .iterator();
         }
         return Iterators.concat(Iterators.single((ToXContent) (builder, params) -> {

--- a/server/src/main/java/org/elasticsearch/health/GetHealthAction.java
+++ b/server/src/main/java/org/elasticsearch/health/GetHealthAction.java
@@ -93,7 +93,7 @@ public class GetHealthAction extends ActionType<GetHealthAction.Response> {
 
         @Override
         @SuppressWarnings("unchecked")
-        public Iterator<? extends ToXContent> toXContentChunked() {
+        public Iterator<? extends ToXContent> toXContentChunked(ToXContent.Params outerParams) {
             return Iterators.concat(Iterators.single((ToXContent) (builder, params) -> {
                 builder.startObject();
                 if (status != null) {
@@ -111,7 +111,7 @@ public class GetHealthAction extends ActionType<GetHealthAction.Response> {
                                 // indicators however the affected resources which are the O(indices) fields are
                                 // flat mapped over all diagnoses within the indicator
                                 Iterators.single((ToXContent) (builder, params) -> builder.field(indicator.name())),
-                                indicator.toXContentChunked()
+                                indicator.toXContentChunked(outerParams)
                             )
                         )
                         .toArray(Iterator[]::new)

--- a/server/src/main/java/org/elasticsearch/health/HealthIndicatorResult.java
+++ b/server/src/main/java/org/elasticsearch/health/HealthIndicatorResult.java
@@ -28,11 +28,16 @@ public record HealthIndicatorResult(
     List<Diagnosis> diagnosisList
 ) implements ChunkedToXContent {
     @Override
-    public Iterator<? extends ToXContent> toXContentChunked() {
+    public Iterator<? extends ToXContent> toXContentChunked(ToXContent.Params outerParams) {
         Iterator<? extends ToXContent> diagnosisIterator = Collections.emptyIterator();
         if (diagnosisList != null && diagnosisList.isEmpty() == false) {
             diagnosisIterator = diagnosisList.stream()
-                .flatMap(s -> StreamSupport.stream(Spliterators.spliteratorUnknownSize(s.toXContentChunked(), Spliterator.ORDERED), false))
+                .flatMap(
+                    s -> StreamSupport.stream(
+                        Spliterators.spliteratorUnknownSize(s.toXContentChunked(outerParams), Spliterator.ORDERED),
+                        false
+                    )
+                )
                 .iterator();
         }
         return Iterators.concat(Iterators.single((ToXContent) (builder, params) -> {

--- a/server/src/main/java/org/elasticsearch/rest/ChunkedRestResponseBody.java
+++ b/server/src/main/java/org/elasticsearch/rest/ChunkedRestResponseBody.java
@@ -81,7 +81,7 @@ public interface ChunkedRestResponseBody {
                 Streams.noCloseStream(out)
             );
 
-            private final Iterator<? extends ToXContent> serialization = chunkedToXContent.toXContentChunked();
+            private final Iterator<? extends ToXContent> serialization = chunkedToXContent.toXContentChunked(params);
 
             private BytesStream target;
 

--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/snapshots/get/GetSnapshotsResponseTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/snapshots/get/GetSnapshotsResponseTests.java
@@ -43,6 +43,7 @@ import java.util.regex.Pattern;
 
 import static org.elasticsearch.snapshots.SnapshotInfo.INDEX_DETAILS_XCONTENT_PARAM;
 import static org.elasticsearch.test.AbstractXContentTestCase.chunkedXContentTester;
+import static org.elasticsearch.xcontent.ToXContent.EMPTY_PARAMS;
 import static org.hamcrest.CoreMatchers.containsString;
 
 public class GetSnapshotsResponseTests extends ESTestCase {
@@ -179,7 +180,7 @@ public class GetSnapshotsResponseTests extends ESTestCase {
 
     public void testToChunkedXContent() {
         final GetSnapshotsResponse response = createTestInstance();
-        final Iterator<ToXContent> serialization = response.toXContentChunked();
+        final Iterator<ToXContent> serialization = response.toXContentChunked(EMPTY_PARAMS);
         int chunks = 0;
         while (serialization.hasNext()) {
             serialization.next();

--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/snapshots/status/SnapshotsStatusResponseTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/snapshots/status/SnapshotsStatusResponseTests.java
@@ -17,6 +17,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Predicate;
 
+import static org.elasticsearch.xcontent.ToXContent.EMPTY_PARAMS;
+
 public class SnapshotsStatusResponseTests extends AbstractChunkedSerializingTestCase<SnapshotsStatusResponse> {
 
     @Override
@@ -58,7 +60,7 @@ public class SnapshotsStatusResponseTests extends AbstractChunkedSerializingTest
             // open and close chunk + one chunk per index
             chunksExpected += 2 + snapshot.getIndices().size();
         }
-        final var iterator = instance.toXContentChunked();
+        final var iterator = instance.toXContentChunked(EMPTY_PARAMS);
         int chunksSeen = 0;
         while (iterator.hasNext()) {
             iterator.next();

--- a/server/src/test/java/org/elasticsearch/action/admin/indices/mapping/get/GetMappingsResponseTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/indices/mapping/get/GetMappingsResponseTests.java
@@ -22,6 +22,8 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
+import static org.elasticsearch.xcontent.ToXContent.EMPTY_PARAMS;
+
 public class GetMappingsResponseTests extends AbstractWireSerializingTestCase<GetMappingsResponse> {
 
     public void testCheckEqualsAndHashCode() {
@@ -73,7 +75,7 @@ public class GetMappingsResponseTests extends AbstractWireSerializingTestCase<Ge
                 .mapToObj(i -> "index-" + i)
                 .collect(Collectors.toUnmodifiableMap(Function.identity(), k -> createMappingsForIndex()))
         );
-        final var chunks = response.toXContentChunked();
+        final var chunks = response.toXContentChunked(EMPTY_PARAMS);
         int chunkCount = 0;
         while (chunks.hasNext()) {
             chunks.next();

--- a/server/src/test/java/org/elasticsearch/action/admin/indices/recovery/RecoveryResponseTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/indices/recovery/RecoveryResponseTests.java
@@ -23,6 +23,7 @@ import java.util.stream.IntStream;
 
 import static java.util.Collections.emptyMap;
 import static java.util.Collections.emptySet;
+import static org.elasticsearch.xcontent.ToXContent.EMPTY_PARAMS;
 
 public class RecoveryResponseTests extends ESTestCase {
 
@@ -57,7 +58,7 @@ public class RecoveryResponseTests extends ESTestCase {
                 ),
             List.of()
         );
-        final var iterator = recoveryResponse.toXContentChunked();
+        final var iterator = recoveryResponse.toXContentChunked(EMPTY_PARAMS);
         int chunks = 0;
         while (iterator.hasNext()) {
             iterator.next();

--- a/server/src/test/java/org/elasticsearch/action/admin/indices/segments/IndicesSegmentResponseTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/indices/segments/IndicesSegmentResponseTests.java
@@ -22,6 +22,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
+import static org.elasticsearch.xcontent.ToXContent.EMPTY_PARAMS;
 import static org.elasticsearch.xcontent.XContentFactory.jsonBuilder;
 
 public class IndicesSegmentResponseTests extends ESTestCase {
@@ -42,7 +43,7 @@ public class IndicesSegmentResponseTests extends ESTestCase {
             0,
             Collections.emptyList()
         );
-        var serialization = response.toXContentChunked();
+        var serialization = response.toXContentChunked(EMPTY_PARAMS);
         try (XContentBuilder builder = jsonBuilder()) {
             while (serialization.hasNext()) {
                 serialization.next().toXContent(builder, ToXContent.EMPTY_PARAMS);
@@ -68,7 +69,7 @@ public class IndicesSegmentResponseTests extends ESTestCase {
             Collections.emptyList()
         );
         int chunks = 0;
-        final var iterator = response.toXContentChunked();
+        final var iterator = response.toXContentChunked(EMPTY_PARAMS);
         while (iterator.hasNext()) {
             iterator.next();
             chunks++;

--- a/server/src/test/java/org/elasticsearch/action/admin/indices/settings/get/GetSettingsResponseTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/indices/settings/get/GetSettingsResponseTests.java
@@ -21,6 +21,8 @@ import java.util.HashSet;
 import java.util.Set;
 import java.util.function.Predicate;
 
+import static org.elasticsearch.xcontent.ToXContent.EMPTY_PARAMS;
+
 public class GetSettingsResponseTests extends AbstractChunkedSerializingTestCase<GetSettingsResponse> {
 
     @Override
@@ -76,7 +78,7 @@ public class GetSettingsResponseTests extends AbstractChunkedSerializingTestCase
 
     public void testOneChunkPerIndex() {
         final var instance = createTestInstance();
-        final var iterator = instance.toXContentChunked();
+        final var iterator = instance.toXContentChunked(EMPTY_PARAMS);
         int chunks = 0;
         while (iterator.hasNext()) {
             chunks++;

--- a/server/src/test/java/org/elasticsearch/action/fieldcaps/MergedFieldCapabilitiesResponseTests.java
+++ b/server/src/test/java/org/elasticsearch/action/fieldcaps/MergedFieldCapabilitiesResponseTests.java
@@ -21,6 +21,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.function.Predicate;
 
+import static org.elasticsearch.xcontent.ToXContent.EMPTY_PARAMS;
+
 public class MergedFieldCapabilitiesResponseTests extends AbstractChunkedSerializingTestCase<FieldCapabilitiesResponse> {
 
     @Override
@@ -207,7 +209,7 @@ public class MergedFieldCapabilitiesResponseTests extends AbstractChunkedSeriali
     public void testExpectedChunkSizes() {
         {
             final FieldCapabilitiesResponse instance = FieldCapabilitiesResponseTests.createResponseWithFailures();
-            final var iterator = instance.toXContentChunked();
+            final var iterator = instance.toXContentChunked(EMPTY_PARAMS);
             int chunks = 0;
             while (iterator.hasNext()) {
                 iterator.next();
@@ -221,7 +223,7 @@ public class MergedFieldCapabilitiesResponseTests extends AbstractChunkedSeriali
         }
         {
             final FieldCapabilitiesResponse instance = createTestInstance();
-            final var iterator = instance.toXContentChunked();
+            final var iterator = instance.toXContentChunked(EMPTY_PARAMS);
             int chunks = 0;
             while (iterator.hasNext()) {
                 iterator.next();

--- a/server/src/test/java/org/elasticsearch/health/GetHealthResponseTests.java
+++ b/server/src/test/java/org/elasticsearch/health/GetHealthResponseTests.java
@@ -13,7 +13,6 @@ import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.xcontent.XContentHelper;
 import org.elasticsearch.health.GetHealthAction.Response;
 import org.elasticsearch.test.ESTestCase;
-import org.elasticsearch.xcontent.ToXContent;
 import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xcontent.XContentFactory;
 
@@ -24,6 +23,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 
+import static org.elasticsearch.xcontent.ToXContent.EMPTY_PARAMS;
 import static org.hamcrest.Matchers.is;
 
 public class GetHealthResponseTests extends ESTestCase {
@@ -35,9 +35,9 @@ public class GetHealthResponseTests extends ESTestCase {
         Response response = new Response(ClusterName.DEFAULT, indicatorResults, true);
 
         XContentBuilder builder = XContentFactory.jsonBuilder().prettyPrint();
-        response.toXContentChunked().forEachRemaining(xcontent -> {
+        response.toXContentChunked(EMPTY_PARAMS).forEachRemaining(xcontent -> {
             try {
-                xcontent.toXContent(builder, ToXContent.EMPTY_PARAMS);
+                xcontent.toXContent(builder, EMPTY_PARAMS);
             } catch (IOException e) {
                 logger.error(e.getMessage(), e);
                 fail(e.getMessage());

--- a/server/src/test/java/org/elasticsearch/health/HealthIndicatorResultTests.java
+++ b/server/src/test/java/org/elasticsearch/health/HealthIndicatorResultTests.java
@@ -70,7 +70,7 @@ public class HealthIndicatorResultTests extends ESTestCase {
         HealthIndicatorResult result = new HealthIndicatorResult(name, status, symptom, details, impacts, diagnosisList);
         XContentBuilder builder = XContentFactory.jsonBuilder().prettyPrint();
 
-        result.toXContentChunked().forEachRemaining(xcontent -> {
+        result.toXContentChunked(ToXContent.EMPTY_PARAMS).forEachRemaining(xcontent -> {
             try {
                 xcontent.toXContent(builder, ToXContent.EMPTY_PARAMS);
             } catch (IOException e) {
@@ -106,7 +106,7 @@ public class HealthIndicatorResultTests extends ESTestCase {
 
             if (diagnosis1.affectedResources() != null) {
                 XContentBuilder diagnosisXContent = XContentFactory.jsonBuilder().prettyPrint();
-                diagnosis1.toXContentChunked().forEachRemaining(xcontent -> {
+                diagnosis1.toXContentChunked(ToXContent.EMPTY_PARAMS).forEachRemaining(xcontent -> {
                     try {
                         xcontent.toXContent(diagnosisXContent, ToXContent.EMPTY_PARAMS);
                     } catch (IOException e) {
@@ -131,7 +131,7 @@ public class HealthIndicatorResultTests extends ESTestCase {
             expectedDiagnosis2.put("help_url", diagnosis2.definition().helpURL());
             if (diagnosis2.affectedResources() != null) {
                 XContentBuilder diagnosisXContent = XContentFactory.jsonBuilder().prettyPrint();
-                diagnosis2.toXContentChunked().forEachRemaining(xcontent -> {
+                diagnosis2.toXContentChunked(ToXContent.EMPTY_PARAMS).forEachRemaining(xcontent -> {
                     try {
                         xcontent.toXContent(diagnosisXContent, ToXContent.EMPTY_PARAMS);
                     } catch (IOException e) {
@@ -199,7 +199,7 @@ public class HealthIndicatorResultTests extends ESTestCase {
         // -> each Diagnosis yields 5 chunks => 10 chunks from both diagnosis
         // -> HealthIndicatorResult surrounds the diagnosis list by 2 chunks
         int chunksExpected = 12;
-        var iterator = result.toXContentChunked();
+        var iterator = result.toXContentChunked(ToXContent.EMPTY_PARAMS);
         int chunksSeen = 0;
         while (iterator.hasNext()) {
             iterator.next();

--- a/test/framework/src/main/java/org/elasticsearch/test/AbstractXContentTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/AbstractXContentTestCase.java
@@ -91,7 +91,7 @@ public abstract class AbstractXContentTestCase<T extends ToXContent> extends EST
     ) {
         return new XContentTester<>(createParser, instanceSupplier, (testInstance, xContentType) -> {
             try (XContentBuilder builder = XContentBuilder.builder(xContentType.xContent())) {
-                var serialization = testInstance.toXContentChunked();
+                var serialization = testInstance.toXContentChunked(toXContentParams);
                 while (serialization.hasNext()) {
                     serialization.next().toXContent(builder, toXContentParams);
                 }


### PR DESCRIPTION
Some responses change shape depending on the supplied `params`, and/or parse certain details out of `params`. By passing the `params` to `toXContentChunked` we can adjust the shape of the returned iterator and/or avoid duplicate parsing effort in ways that are not possible today where `params` is only made available to each leaf `ToXContent` object.