### PR TITLE
Check stable plugin version at install and load time

### DIFF
--- a/docs/changelog/91780.yaml
+++ b/docs/changelog/91780.yaml
@@ -1,0 +1,5 @@
+pr: 91780
+summary: Check stable plugin version at install and load time
+area: Infra/Plugins
+type: enhancement
+issues: []

--- a/server/src/main/java/org/elasticsearch/plugins/PluginsUtils.java
+++ b/server/src/main/java/org/elasticsearch/plugins/PluginsUtils.java
@@ -77,7 +77,30 @@ public class PluginsUtils {
      * Verify the given plugin is compatible with the current Elasticsearch installation.
      */
     public static void verifyCompatibility(PluginDescriptor info) {
-        if (info.getElasticsearchVersion().equals(Version.CURRENT) == false) {
+        if (info.isStable()) {
+            if (info.getElasticsearchVersion().major != Version.CURRENT.major) {
+                throw new IllegalArgumentException(
+                    "Stable Plugin ["
+                        + info.getName()
+                        + "] was built for Elasticsearch major version "
+                        + info.getElasticsearchVersion().major
+                        + " but version "
+                        + Version.CURRENT
+                        + " is running"
+                );
+            }
+            if (info.getElasticsearchVersion().after(Version.CURRENT)) {
+                throw new IllegalArgumentException(
+                    "Stable Plugin ["
+                        + info.getName()
+                        + "] was built for Elasticsearch version "
+                        + info.getElasticsearchVersion()
+                        + " but earlier version "
+                        + Version.CURRENT
+                        + " is running"
+                );
+            }
+        } else if (info.getElasticsearchVersion().equals(Version.CURRENT) == false) {
             throw new IllegalArgumentException(
                 "Plugin ["
                     + info.getName()

--- a/server/src/test/java/org/elasticsearch/plugins/PluginsUtilsTests.java
+++ b/server/src/test/java/org/elasticsearch/plugins/PluginsUtilsTests.java
@@ -368,6 +368,53 @@ public class PluginsUtilsTests extends ESTestCase {
         assertThat(e.getCause().getMessage(), containsString("DummyClass1"));
     }
 
+    public void testStableEarlierElasticsearchVersion() throws Exception {
+        PluginDescriptor info = new PluginDescriptor(
+            "my_plugin",
+            "desc",
+            "1.0",
+            Version.fromId(Version.CURRENT.id + 1),
+            "1.8",
+            "FakePlugin",
+            null,
+            Collections.emptyList(),
+            false,
+            false,
+            false,
+            true
+        );
+        IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> PluginsUtils.verifyCompatibility(info));
+        assertThat(
+            e.getMessage(),
+            containsString(
+                "was built for Elasticsearch version "
+                    + Version.fromId(Version.CURRENT.id + 1)
+                    + " but earlier version "
+                    + Version.CURRENT
+                    + " is running"
+            )
+        );
+    }
+
+    public void testStableIncompatibleElasticsearchVersion() throws Exception {
+        PluginDescriptor info = new PluginDescriptor(
+            "my_plugin",
+            "desc",
+            "1.0",
+            Version.fromId(6000099),
+            "1.8",
+            "FakePlugin",
+            null,
+            Collections.emptyList(),
+            false,
+            false,
+            false,
+            true
+        );
+        IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> PluginsUtils.verifyCompatibility(info));
+        assertThat(e.getMessage(), containsString("was built for Elasticsearch major version 6"));
+    }
+
     public void testIncompatibleElasticsearchVersion() throws Exception {
         PluginDescriptor info = new PluginDescriptor(
             "my_plugin",

--- a/server/src/test/java/org/elasticsearch/plugins/PluginsUtilsTests.java
+++ b/server/src/test/java/org/elasticsearch/plugins/PluginsUtilsTests.java
@@ -369,20 +369,7 @@ public class PluginsUtilsTests extends ESTestCase {
     }
 
     public void testStableEarlierElasticsearchVersion() throws Exception {
-        PluginDescriptor info = new PluginDescriptor(
-            "my_plugin",
-            "desc",
-            "1.0",
-            Version.fromId(Version.CURRENT.id + 1),
-            "1.8",
-            "FakePlugin",
-            null,
-            Collections.emptyList(),
-            false,
-            false,
-            false,
-            true
-        );
+        PluginDescriptor info = getPluginDescriptorForVersion(Version.fromId(Version.CURRENT.id + 1), "1.8", true);
         IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> PluginsUtils.verifyCompatibility(info));
         assertThat(
             e.getMessage(),
@@ -397,58 +384,19 @@ public class PluginsUtilsTests extends ESTestCase {
     }
 
     public void testStableIncompatibleElasticsearchVersion() throws Exception {
-        PluginDescriptor info = new PluginDescriptor(
-            "my_plugin",
-            "desc",
-            "1.0",
-            Version.fromId(6000099),
-            "1.8",
-            "FakePlugin",
-            null,
-            Collections.emptyList(),
-            false,
-            false,
-            false,
-            true
-        );
+        PluginDescriptor info = getPluginDescriptorForVersion(Version.fromId(6000099), "1.8", true);
         IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> PluginsUtils.verifyCompatibility(info));
         assertThat(e.getMessage(), containsString("was built for Elasticsearch major version 6"));
     }
 
     public void testIncompatibleElasticsearchVersion() throws Exception {
-        PluginDescriptor info = new PluginDescriptor(
-            "my_plugin",
-            "desc",
-            "1.0",
-            Version.fromId(6000099),
-            "1.8",
-            "FakePlugin",
-            null,
-            Collections.emptyList(),
-            false,
-            false,
-            false,
-            false
-        );
+        PluginDescriptor info = getPluginDescriptorForVersion(Version.fromId(6000099), "1.8", false);
         IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> PluginsUtils.verifyCompatibility(info));
         assertThat(e.getMessage(), containsString("was built for Elasticsearch version 6.0.0"));
     }
 
     public void testIncompatibleJavaVersion() throws Exception {
-        PluginDescriptor info = new PluginDescriptor(
-            "my_plugin",
-            "desc",
-            "1.0",
-            Version.CURRENT,
-            "1000",
-            "FakePlugin",
-            null,
-            Collections.emptyList(),
-            false,
-            false,
-            false,
-            false
-        );
+        PluginDescriptor info = getPluginDescriptorForVersion(Version.CURRENT, "1000", false);
         IllegalStateException e = expectThrows(IllegalStateException.class, () -> PluginsUtils.verifyCompatibility(info));
         assertThat(e.getMessage(), containsString("my_plugin requires Java"));
     }
@@ -479,6 +427,24 @@ public class PluginsUtilsTests extends ESTestCase {
         }
 
         assertThat(PluginsUtils.findPluginDirs(plugins), containsInAnyOrder(fake));
+    }
+
+    private static PluginDescriptor getPluginDescriptorForVersion(Version id, String javaVersion, boolean isStable) {
+        PluginDescriptor info = new PluginDescriptor(
+            "my_plugin",
+            "desc",
+            "1.0",
+            id,
+            javaVersion,
+            "FakePlugin",
+            null,
+            Collections.emptyList(),
+            false,
+            false,
+            false,
+            isStable
+        );
+        return info;
     }
 
 }


### PR DESCRIPTION
For a node to install a stable plugin, the node's Elasticsearch version must have the same major version as the Elasticsearch libraries against which the stable plugin was built. Additionally, a node will reject stable plugins that have been built with a future version of Elasticsearch.