### PR TITLE
Update ilm-index-lifecycle.asciidoc

### DIFF
--- a/docs/reference/ilm/ilm-index-lifecycle.asciidoc
+++ b/docs/reference/ilm/ilm-index-lifecycle.asciidoc
@@ -107,7 +107,7 @@ actions in the order listed.
   - <<ilm-searchable-snapshot, Searchable Snapshot>>
   - <<ilm-allocate,Allocate>>
   - <<ilm-migrate,Migrate>>
-  <<ilm-downsample,Downsample>>
+  - <<ilm-downsample,Downsample>>
 * Frozen
   - <<ilm-unfollow,Unfollow>>
   - <<ilm-searchable-snapshot, Searchable Snapshot>>


### PR DESCRIPTION
Adds a missing list item `-` indicator for the cold phase. Was causing `migrate` and `downsample` to be rendered on the same line.
