### PR TITLE
[Transform] Skip remote clusters when performing up front privileges validation

### DIFF
--- a/docs/changelog/91788.yaml
+++ b/docs/changelog/91788.yaml
@@ -1,5 +1,5 @@
 pr: 91788
-summary: Skip remote clusters when performing privileges check
+summary: Skip remote clusters when performing up front privileges validation
 area: Transform
 type: bug
 issues: []

--- a/docs/changelog/91788.yaml
+++ b/docs/changelog/91788.yaml
@@ -1,0 +1,5 @@
+pr: 91788
+summary: Skip remote clusters when performing privileges check
+area: Transform
+type: bug
+issues: []

--- a/x-pack/plugin/transform/qa/multi-cluster-tests-with-security/src/test/resources/rest-api-spec/test/multi_cluster/80_transform.yml
+++ b/x-pack/plugin/transform/qa/multi-cluster-tests-with-security/src/test/resources/rest-api-spec/test/multi_cluster/80_transform.yml
@@ -26,7 +26,6 @@ setup:
   - do:
       security.put_role:
         name: "x_cluster_role"
-        # gh#72715: the my_remote_cluster privileges should not be needed
         body:  >
           {
             "cluster": [],
@@ -38,10 +37,6 @@ setup:
               {
                 "names": ["simple-remote-transform*", "simple-local-remote-transform", "same-index-local-and-remote-transform"],
                 "privileges": ["create_index", "index", "read"]
-              },
-              {
-                "names": ["my_remote_cluster:remote_test_i*", "my_remote_cluster:aliased_test_index", "my_remote_cluster:same_index_local_and_remote"],
-                "privileges": ["read", "view_index_metadata"]
               }
             ]
           }
@@ -156,7 +151,7 @@ teardown:
         transform_id: "simple-remote-transform"
 
   - do:
-      catch: /Cannot preview transform \[simple-remote-transform\] because user bob lacks the required permissions \[my_remote_cluster:remote_test_index\*:\[read, view_index_metadata\], simple-remote-transform:\[\]\]/
+      catch: /Source indices have been deleted or closed./
       headers: { Authorization: "Basic Ym9iOnRyYW5zZm9ybS1wYXNzd29yZA==" }  # This is bob
       transform.preview_transform:
         transform_id: "simple-remote-transform"
@@ -311,14 +306,13 @@ teardown:
 ---
 "Batch transform from remote cluster when the user is not authorized":
   - do:
-      catch: /Cannot create transform \[simple-remote-transform\] because user bob lacks the required permissions \[my_remote_cluster:remote_test_index:\[read, view_index_metadata\], simple-remote-transform:\[\]\]/
       headers: { Authorization: "Basic Ym9iOnRyYW5zZm9ybS1wYXNzd29yZA==" }  # This is bob
       transform.put_transform:
-        transform_id: "simple-remote-transform"
+        transform_id: "simple-remote-transform-3"
         body: >
           {
             "source": { "index": "my_remote_cluster:remote_test_index" },
-            "dest": { "index": "simple-remote-transform" },
+            "dest": { "index": "simple-remote-transform-3" },
             "pivot": {
               "group_by": { "user": {"terms": {"field": "user"}}},
               "aggs": { "avg_stars": {"avg": {"field": "stars"}}}
@@ -342,7 +336,6 @@ teardown:
           }
   - match: { acknowledged: true }
   - do:
-      catch: /Cannot update transform \[simple-remote-transform-2\] because user bob lacks the required permissions \[my_remote_cluster:remote_test_index:\[read, view_index_metadata\], simple-remote-transform-2:\[\]\]/
       headers: { Authorization: "Basic Ym9iOnRyYW5zZm9ybS1wYXNzd29yZA==" }  # This is bob
       transform.update_transform:
         transform_id: "simple-remote-transform-2"
@@ -355,7 +348,7 @@ teardown:
 ---
 "Batch transform preview from remote cluster when the user is not authorized":
   - do:
-      catch: /Cannot preview transform \[transform-preview\] because user bob lacks the required permissions \[my_remote_cluster:remote_test_index:\[read, view_index_metadata\], simple-remote-transform-2:\[\]\]/
+      catch: /Source indices have been deleted or closed./
       headers: { Authorization: "Basic Ym9iOnRyYW5zZm9ybS1wYXNzd29yZA==" }  # This is bob
       transform.preview_transform:
         body: >
@@ -368,7 +361,7 @@ teardown:
             }
           }
   - do:
-      catch: /Cannot preview transform \[transform-preview\] because user bob lacks the required permissions \[my_remote_cluster:test_index:\[read, view_index_metadata\]\]/
+      catch: /Source indices have been deleted or closed./
       headers: { Authorization: "Basic Ym9iOnRyYW5zZm9ybS1wYXNzd29yZA==" }  # This is bob
       transform.preview_transform:
         body: >

--- a/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/action/TransformPrivilegeCheckerTests.java
+++ b/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/action/TransformPrivilegeCheckerTests.java
@@ -45,6 +45,7 @@ import static org.hamcrest.Matchers.arrayWithSize;
 import static org.hamcrest.Matchers.emptyArray;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
 
 public class TransformPrivilegeCheckerTests extends ESTestCase {
 
@@ -61,6 +62,7 @@ public class TransformPrivilegeCheckerTests extends ESTestCase {
         .addPrivilege("view_index_metadata", true)
         .addPrivilege("read", false)
         .build();
+    private static final String REMOTE_SOURCE_INDEX_NAME = "some-remote-cluster:some-remote-source-index";
     private static final String DEST_INDEX_NAME = "some-dest-index";
     private static final ResourcePrivileges DEST_INDEX_NAME_PRIVILEGES = ResourcePrivileges.builder(DEST_INDEX_NAME)
         .addPrivilege("index", true)
@@ -103,23 +105,44 @@ public class TransformPrivilegeCheckerTests extends ESTestCase {
     }
 
     public void testCheckPrivileges_NoCheckDestIndexPrivileges() {
+        TransformConfig config = new TransformConfig.Builder(TRANSFORM_CONFIG).setSource(
+            new SourceConfig(SOURCE_INDEX_NAME, REMOTE_SOURCE_INDEX_NAME)
+        ).build();
         TransformPrivilegeChecker.checkPrivileges(
             OPERATION_NAME,
             securityContext,
             indexNameExpressionResolver,
             ClusterState.EMPTY_STATE,
             client,
-            TRANSFORM_CONFIG,
+            config,
             false,
             ActionListener.wrap(aVoid -> {
                 HasPrivilegesRequest request = client.lastHasPrivilegesRequest;
                 assertThat(request.username(), is(equalTo(USER_NAME)));
                 assertThat(request.applicationPrivileges(), is(emptyArray()));
                 assertThat(request.clusterPrivileges(), is(emptyArray()));
-                assertThat(request.indexPrivileges(), is(arrayWithSize(1)));
+                assertThat(request.indexPrivileges(), is(arrayWithSize(1)));  // remote index is filtered out
                 RoleDescriptor.IndicesPrivileges sourceIndicesPrivileges = request.indexPrivileges()[0];
                 assertThat(sourceIndicesPrivileges.getIndices(), is(arrayContaining(SOURCE_INDEX_NAME)));
                 assertThat(sourceIndicesPrivileges.getPrivileges(), is(arrayContaining("read", "view_index_metadata")));
+            }, e -> fail(e.getMessage()))
+        );
+    }
+
+    public void testCheckPrivileges_NoLocalIndices_NoCheckDestIndexPrivileges() {
+        TransformConfig config = new TransformConfig.Builder(TRANSFORM_CONFIG).setSource(new SourceConfig(REMOTE_SOURCE_INDEX_NAME))
+            .build();
+        TransformPrivilegeChecker.checkPrivileges(
+            OPERATION_NAME,
+            securityContext,
+            indexNameExpressionResolver,
+            ClusterState.EMPTY_STATE,
+            client,
+            config,
+            false,
+            ActionListener.wrap(aVoid -> {
+                // _has_privileges API is not called for the remote index
+                assertThat(client.lastHasPrivilegesRequest, is(nullValue()));
             }, e -> fail(e.getMessage()))
         );
     }
@@ -174,6 +197,36 @@ public class TransformPrivilegeCheckerTests extends ESTestCase {
                 assertThat(sourceIndicesPrivileges.getIndices(), is(arrayContaining(SOURCE_INDEX_NAME)));
                 assertThat(sourceIndicesPrivileges.getPrivileges(), is(arrayContaining("read", "view_index_metadata")));
                 RoleDescriptor.IndicesPrivileges destIndicesPrivileges = request.indexPrivileges()[1];
+                assertThat(destIndicesPrivileges.getIndices(), is(arrayContaining(DEST_INDEX_NAME)));
+                assertThat(destIndicesPrivileges.getPrivileges(), is(arrayContaining("read", "index")));
+            }, e -> fail(e.getMessage()))
+        );
+    }
+
+    public void testCheckPrivileges_NoLocalIndices_CheckDestIndexPrivileges_DestIndexExists() {
+        ClusterState clusterState = ClusterState.builder(ClusterName.DEFAULT)
+            .metadata(
+                Metadata.builder()
+                    .put(IndexMetadata.builder(DEST_INDEX_NAME).settings(settings(Version.CURRENT)).numberOfShards(1).numberOfReplicas(0))
+            )
+            .build();
+        TransformConfig config = new TransformConfig.Builder(TRANSFORM_CONFIG).setSource(new SourceConfig(REMOTE_SOURCE_INDEX_NAME))
+            .build();
+        TransformPrivilegeChecker.checkPrivileges(
+            OPERATION_NAME,
+            securityContext,
+            indexNameExpressionResolver,
+            clusterState,
+            client,
+            config,
+            true,
+            ActionListener.wrap(aVoid -> {
+                HasPrivilegesRequest request = client.lastHasPrivilegesRequest;
+                assertThat(request.username(), is(equalTo(USER_NAME)));
+                assertThat(request.applicationPrivileges(), is(emptyArray()));
+                assertThat(request.clusterPrivileges(), is(emptyArray()));
+                assertThat(request.indexPrivileges(), is(arrayWithSize(1)));
+                RoleDescriptor.IndicesPrivileges destIndicesPrivileges = request.indexPrivileges()[0];
                 assertThat(destIndicesPrivileges.getIndices(), is(arrayContaining(DEST_INDEX_NAME)));
                 assertThat(destIndicesPrivileges.getPrivileges(), is(arrayContaining("read", "index")));
             }, e -> fail(e.getMessage()))


### PR DESCRIPTION
This PR is a workaround for the bug (inability to check remote indices' privileges via `_has_privileges` API).
It skips **all** the remote indices when doing `_has_privileges` check on Transform PUT/_update/_preview.

As a consequence, `PUT` and `_update` may succeed even though they used to fail before this PR. Then the transform will not find any data at runtime due to lack of permissions when the source search is done.

Relates https://github.com/elastic/elasticsearch/issues/72715