### PR TITLE
[DOCS] Adds bullet points to the statuses of the health object in transform stats API docs

### DIFF
--- a/docs/reference/rest-api/common-parms.asciidoc
+++ b/docs/reference/rest-api/common-parms.asciidoc
@@ -126,17 +126,17 @@ tag::cluster-health-status[]
 Health status of the cluster, based on the state of its primary and replica
 shards. Statuses are:
 
-  `green`:::
-  All shards are assigned.
+  * `green`:
+    All shards are assigned.
 
-  `yellow`:::
-  All primary shards are assigned, but one or more replica shards are
-  unassigned. If a node in the cluster fails, some
-  data could be unavailable until that node is repaired.
+  * `yellow`:
+    All primary shards are assigned, but one or more replica shards are 
+    unassigned. If a node in the cluster fails, some data could be unavailable 
+    until that node is repaired.
 
-  `red`:::
-  One or more primary shards are unassigned, so some data is unavailable. This
-  can occur briefly during cluster startup as primary shards are assigned.
+  * `red`:
+    One or more primary shards are unassigned, so some data is unavailable. This
+    can occur briefly during cluster startup as primary shards are assigned.
 end::cluster-health-status[]
 
 tag::committed[]

--- a/docs/reference/transform/apis/get-transform-stats.asciidoc
+++ b/docs/reference/transform/apis/get-transform-stats.asciidoc
@@ -152,18 +152,18 @@ that the {transform} is failing to keep up.
 `status`::
     (string) Health status of this transform. Statuses are:
 
-    `green`:::
-    The transform is healthy.
+   * `green`:
+      The transform is healthy.
 
-    `unknown`:::
-    The health of the transform could not be determined.
+    * `unknown`:
+      The health of the transform could not be determined.
 
-    `yellow`:::
-    The functionality of the transform is in a degraded state and may need remediation
-    to avoid the health becoming `red`.
+    * `yellow`:
+      The functionality of the transform is in a degraded state and may need 
+      remediation to avoid the health becoming `red`.
 
-    `red`:::
-    The transform is experiencing an outage or is unavailable for use.
+    * `red`:
+      The transform is experiencing an outage or is unavailable for use.
 
 `issues`::
     (Optional, array) If a non-healthy status is returned, contains a list of issues


### PR DESCRIPTION
## Overview

This PR adds bullet points to the possible values of `status` in the transform stats API docs. Without the bullets, the names seem like sub-properties of the `status` property.

**Before**
<img width="871" alt="Screenshot 2022-11-22 at 11 17 27" src="https://user-images.githubusercontent.com/22324794/203288629-f8913034-1817-4a31-8024-42ebbdc003ff.png">

**After**
<img width="877" alt="Screenshot 2022-11-22 at 11 36 03" src="https://user-images.githubusercontent.com/22324794/203292450-8923eb94-8069-458c-8430-4867241008e4.png">

### Preview

[Transform stats API](https://elasticsearch_91790.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/get-transform-stats.html)