### PR TITLE
[ML] Increase timeout in PyTorchModelIT.testTruncation

### DIFF
--- a/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/PyTorchModelIT.java
+++ b/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/PyTorchModelIT.java
@@ -534,7 +534,8 @@ public class PyTorchModelIT extends PyTorchModelRestTestCase {
             containsString("Input too large. The tokenized input length [3] exceeds the maximum sequence length [2]")
         );
 
-        request = new Request("POST", "/_ml/trained_models/" + modelId + "/_infer");
+        // We set timeout to 20s as we've seen this test time out on some busy workers.
+        request = new Request("POST", "/_ml/trained_models/" + modelId + "/_infer?timeout=20s");
         request.setJsonEntity(formatted("""
             {
               "docs": [


### PR DESCRIPTION
We've seen the inference request in the `testTruncation` test time out on busy workers, thus we give it a bit more time to do its work.
