### PR TITLE
[8.5][ML] Increase timeout in PyTorchModelIT.testTruncation

### DIFF
--- a/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/PyTorchModelIT.java
+++ b/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/PyTorchModelIT.java
@@ -606,7 +606,7 @@ public class PyTorchModelIT extends ESRestTestCase {
             containsString("Input too large. The tokenized input length [3] exceeds the maximum sequence length [2]")
         );
 
-        request = new Request("POST", "/_ml/trained_models/" + modelId + "/_infer");
+        request = new Request("POST", "/_ml/trained_models/" + modelId + "/_infer?timeout=20s");
         request.setJsonEntity("""
             {
               "docs": [


### PR DESCRIPTION
We've seen the inference request in the `testTruncation` test time out on busy workers, thus we give it a bit more time to do its work.

Backport of #91791
