### PR TITLE
Fix potential leak in RemoteRecoveryHandler

### DIFF
--- a/docs/changelog/91802.yaml
+++ b/docs/changelog/91802.yaml
@@ -1,0 +1,5 @@
+pr: 91802
+summary: Fix potential leak in `RemoteRecoveryHandler`
+area: Recovery
+type: bug
+issues: []


### PR DESCRIPTION
We have to make sure we release `request` in all cases that fail the `listener`. The current implementation would not release `request` on e.g. a rejection since we only do the request release for the nested listener but not for when that listener is never called because of another exception.

Note: I'm aware that there's risk of double invoking the listener here and I suspect that the wrap call here may cause some double invoke bugs on the listener. For now this is definitely an improvement over the existing code since it fixes the rejection case as well as would make any double close bug more visible.