### PR TITLE
[8.6] [DOCS] Adds bullet points to the statuses of the health object in transform stats API docs (#91790)

### DIFF
--- a/docs/reference/rest-api/common-parms.asciidoc
+++ b/docs/reference/rest-api/common-parms.asciidoc
@@ -126,17 +126,17 @@ tag::cluster-health-status[]
 Health status of the cluster, based on the state of its primary and replica
 shards. Statuses are:
 
-  `green`:::
-  All shards are assigned.
+  * `green`:
+    All shards are assigned.
 
-  `yellow`:::
-  All primary shards are assigned, but one or more replica shards are
-  unassigned. If a node in the cluster fails, some
-  data could be unavailable until that node is repaired.
+  * `yellow`:
+    All primary shards are assigned, but one or more replica shards are 
+    unassigned. If a node in the cluster fails, some data could be unavailable 
+    until that node is repaired.
 
-  `red`:::
-  One or more primary shards are unassigned, so some data is unavailable. This
-  can occur briefly during cluster startup as primary shards are assigned.
+  * `red`:
+    One or more primary shards are unassigned, so some data is unavailable. This
+    can occur briefly during cluster startup as primary shards are assigned.
 end::cluster-health-status[]
 
 tag::committed[]

--- a/docs/reference/transform/apis/get-transform-stats.asciidoc
+++ b/docs/reference/transform/apis/get-transform-stats.asciidoc
@@ -152,18 +152,18 @@ that the {transform} is failing to keep up.
 `status`::
     (string) Health status of this transform. Statuses are:
 
-    `green`:::
-    The transform is healthy.
+   * `green`:
+      The transform is healthy.
 
-    `unknown`:::
-    The health of the transform could not be determined.
+    * `unknown`:
+      The health of the transform could not be determined.
 
-    `yellow`:::
-    The functionality of the transform is in a degraded state and may need remediation
-    to avoid the health becoming `red`.
+    * `yellow`:
+      The functionality of the transform is in a degraded state and may need 
+      remediation to avoid the health becoming `red`.
 
-    `red`:::
-    The transform is experiencing an outage or is unavailable for use.
+    * `red`:
+      The transform is experiencing an outage or is unavailable for use.
 
 `issues`::
     (Optional, array) If a non-healthy status is returned, contains a list of issues


### PR DESCRIPTION
Backports the following commits to 8.6:
 - [DOCS] Adds bullet points to the statuses of the health object in transform stats API docs (#91790)