### PR TITLE
[8.6] Remove tech preview disclaimer from TSDS ingest docs (#91519)

### DIFF
--- a/docs/reference/data-streams/set-up-tsds.asciidoc
+++ b/docs/reference/data-streams/set-up-tsds.asciidoc
@@ -4,8 +4,6 @@
 <titleabbrev>Set up a TSDS</titleabbrev>
 ++++
 
-preview::[]
-
 To set up a <<tsds,time series data stream (TSDS)>>, follow these steps:
 
 . Check the <<tsds-prereqs,prerequisites>>.

--- a/docs/reference/data-streams/tsds-index-settings.asciidoc
+++ b/docs/reference/data-streams/tsds-index-settings.asciidoc
@@ -1,8 +1,6 @@
 [[tsds-index-settings]]
 === Time series index settings
 
-preview::[]
-
 Backing indices in a <<tsds,time series data stream (TSDS)>> support the
 following index settings.
 

--- a/docs/reference/data-streams/tsds.asciidoc
+++ b/docs/reference/data-streams/tsds.asciidoc
@@ -1,8 +1,6 @@
 [[tsds]]
 == Time series data stream (TSDS)
 
-preview::[]
-
 A time series data stream (TSDS) models timestamped metrics data as one or
 more time series.
 


### PR DESCRIPTION
Backports the following commits to 8.6:
 - Remove tech preview disclaimer from TSDS ingest docs (#91519)