### PR TITLE
[DOCS] Adds semantic search API to the trained model API list

### DIFF
--- a/docs/reference/ml/trained-models/apis/index.asciidoc
+++ b/docs/reference/ml/trained-models/apis/index.asciidoc
@@ -19,5 +19,3 @@ include::start-trained-model-deployment.asciidoc[leveloffset=+2]
 include::stop-trained-model-deployment.asciidoc[leveloffset=+2]
 //UPDATE
 include::update-trained-model-deployment.asciidoc[leveloffset=+2]
-//SEMANTIC SEARCH
-include::../../../search/semantic-search.asciidoc[]

--- a/docs/reference/ml/trained-models/apis/index.asciidoc
+++ b/docs/reference/ml/trained-models/apis/index.asciidoc
@@ -19,3 +19,5 @@ include::start-trained-model-deployment.asciidoc[leveloffset=+2]
 include::stop-trained-model-deployment.asciidoc[leveloffset=+2]
 //UPDATE
 include::update-trained-model-deployment.asciidoc[leveloffset=+2]
+//SEMANTIC SEARCH
+include::../../search/semantic-search-api.asciidoc[]

--- a/docs/reference/ml/trained-models/apis/index.asciidoc
+++ b/docs/reference/ml/trained-models/apis/index.asciidoc
@@ -20,4 +20,4 @@ include::stop-trained-model-deployment.asciidoc[leveloffset=+2]
 //UPDATE
 include::update-trained-model-deployment.asciidoc[leveloffset=+2]
 //SEMANTIC SEARCH
-include::../../../search/semantic-search-api.asciidoc[]
+include::../../../search/semantic-search.asciidoc[]

--- a/docs/reference/ml/trained-models/apis/index.asciidoc
+++ b/docs/reference/ml/trained-models/apis/index.asciidoc
@@ -20,4 +20,4 @@ include::stop-trained-model-deployment.asciidoc[leveloffset=+2]
 //UPDATE
 include::update-trained-model-deployment.asciidoc[leveloffset=+2]
 //SEMANTIC SEARCH
-include::../../search/semantic-search-api.asciidoc[]
+include::../../../search/semantic-search-api.asciidoc[]

--- a/docs/reference/ml/trained-models/apis/ml-trained-models-apis.asciidoc
+++ b/docs/reference/ml/trained-models/apis/ml-trained-models-apis.asciidoc
@@ -23,3 +23,7 @@ an aggregation. Refer to the following documentation to learn more:
 
 * <<search-aggregations-pipeline-inference-bucket-aggregation,{infer-cap} bucket aggregation>>
 * <<inference-processor,{infer-cap} processor>>
+
+You can use your trained model to perform semantic search:
+
+* <<semantic-search-api>>


### PR DESCRIPTION
## Overview

This PR adds the URL of the semantic search endpoint to the list of the trained model APIs.

### Preview

[ML trained models APIs](https://elasticsearch_91815.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/ml-df-trained-models-apis.html)