### PR TITLE
[8.6][DOCS] Adds semantic search API to the trained model API list (#91815)

### DIFF
--- a/docs/reference/ml/trained-models/apis/ml-trained-models-apis.asciidoc
+++ b/docs/reference/ml/trained-models/apis/ml-trained-models-apis.asciidoc
@@ -23,3 +23,7 @@ an aggregation. Refer to the following documentation to learn more:
 
 * <<search-aggregations-pipeline-inference-bucket-aggregation,{infer-cap} bucket aggregation>>
 * <<inference-processor,{infer-cap} processor>>
+
+You can use your trained model to perform semantic search:
+
+* <<semantic-search-api>>


### PR DESCRIPTION
## Overview

This PR backports the following changes to the 8.6 branch:
[DOCS] Adds semantic search API to the trained model API list #91815