### PR TITLE
EQL: limit CCS to v 7.15

### DIFF
--- a/docs/changelog/91834.yaml
+++ b/docs/changelog/91834.yaml
@@ -2,4 +2,5 @@ pr: 91834
 summary: Limit CCS to v 7.15
 area: EQL
 type: bug
-issues: []
+issues:
+ - 91762

--- a/docs/changelog/91834.yaml
+++ b/docs/changelog/91834.yaml
@@ -1,0 +1,5 @@
+pr: 91834
+summary: Limit CCS to v 7.15
+area: EQL
+type: bug
+issues: []

--- a/docs/reference/eql/eql-search-api.asciidoc
+++ b/docs/reference/eql/eql-search-api.asciidoc
@@ -48,7 +48,7 @@ or alias.
 * See <<eql-required-fields>>.
 
 * experimental:[] For cross-cluster search, the local and remote clusters must use the same {es} version.
-Local clusters v 7.17.7 or later also support cross-cluster search to remote clusters v 7.15 or later.
+Local clusters version 7.17.7 or later also support cross-cluster search to remote clusters version 7.15.0 or later.
 For security, see <<remote-clusters-security>>.
 
 [[eql-search-api-limitations]]

--- a/docs/reference/eql/eql-search-api.asciidoc
+++ b/docs/reference/eql/eql-search-api.asciidoc
@@ -48,7 +48,8 @@ or alias.
 * See <<eql-required-fields>>.
 
 * experimental:[] For cross-cluster search, the local and remote clusters must
-use the same {es} version. For security, see <<remote-clusters-security>>.
+use the same {es} version if they have versions prior to 7.17.7 (included).
+For security, see <<remote-clusters-security>>.
 
 [[eql-search-api-limitations]]
 ===== Limitations

--- a/docs/reference/eql/eql-search-api.asciidoc
+++ b/docs/reference/eql/eql-search-api.asciidoc
@@ -47,8 +47,8 @@ or alias.
 
 * See <<eql-required-fields>>.
 
-* experimental:[] For cross-cluster search, the local and remote clusters must
-use the same {es} version if they have versions prior to 7.17.7 (included).
+* experimental:[] For cross-cluster search, the local and remote clusters must use the same {es} version.
+Local clusters v 7.17.7 or later also support cross-cluster search to remote clusters v 7.15 or later.
 For security, see <<remote-clusters-security>>.
 
 [[eql-search-api-limitations]]

--- a/docs/reference/eql/eql.asciidoc
+++ b/docs/reference/eql/eql.asciidoc
@@ -799,7 +799,9 @@ experimental::[]
 
 The EQL search API supports <<modules-cross-cluster-search,cross-cluster
 search>>. However, the local and <<remote-clusters,remote clusters>>
-must use the same {es} version if they have versions prior to 7.17.7 (included).
+must use the same {es} version.
+Local clusters v 7.17.7 or later also support <<modules-cross-cluster-search,cross-cluster
+search>> to <<remote-clusters,remote clusters>> v 7.15 or later.
 
 The following <<cluster-update-settings,cluster update settings>> request
 adds two remote clusters: `cluster_one` and `cluster_two`.

--- a/docs/reference/eql/eql.asciidoc
+++ b/docs/reference/eql/eql.asciidoc
@@ -799,7 +799,7 @@ experimental::[]
 
 The EQL search API supports <<modules-cross-cluster-search,cross-cluster
 search>>. However, the local and <<remote-clusters,remote clusters>>
-must use the same {es} version.
+must use the same {es} version if they have versions prior to 7.17.7 (included).
 
 The following <<cluster-update-settings,cluster update settings>> request
 adds two remote clusters: `cluster_one` and `cluster_two`.

--- a/docs/reference/eql/eql.asciidoc
+++ b/docs/reference/eql/eql.asciidoc
@@ -800,8 +800,8 @@ experimental::[]
 The EQL search API supports <<modules-cross-cluster-search,cross-cluster
 search>>. However, the local and <<remote-clusters,remote clusters>>
 must use the same {es} version.
-Local clusters v 7.17.7 or later also support <<modules-cross-cluster-search,cross-cluster
-search>> to <<remote-clusters,remote clusters>> v 7.15 or later.
+Local clusters version 7.17.7 or later also support <<modules-cross-cluster-search,cross-cluster
+search>> to <<remote-clusters,remote clusters>> version 7.15.0 or later.
 
 The following <<cluster-update-settings,cluster update settings>> request
 adds two remote clusters: `cluster_one` and `cluster_two`.

--- a/docs/reference/search/search-your-data/search-across-clusters.asciidoc
+++ b/docs/reference/search/search-your-data/search-across-clusters.asciidoc
@@ -438,7 +438,9 @@ To run a {ccs}, the local and remote clusters must be compatible as outlined
 in the following matrix.
 
 IMPORTANT: For the <<eql-search-api,EQL search API>>, the local and remote
-clusters must use the same {es} version if they have versions prior to 7.17.7 (included).
+clusters must use the same {es} version.
+Local clusters v 7.17.7 or later also support cross-cluster search to
+<<remote-clusters,remote clusters>> v 7.15 or later.
 
 [%collapsible%open]
 .Version compatibility matrix

--- a/docs/reference/search/search-your-data/search-across-clusters.asciidoc
+++ b/docs/reference/search/search-your-data/search-across-clusters.asciidoc
@@ -438,7 +438,7 @@ To run a {ccs}, the local and remote clusters must be compatible as outlined
 in the following matrix.
 
 IMPORTANT: For the <<eql-search-api,EQL search API>>, the local and remote
-clusters must use the same {es} version.
+clusters must use the same {es} version if they have versions prior to 7.17.7 (included).
 
 [%collapsible%open]
 .Version compatibility matrix

--- a/docs/reference/search/search-your-data/search-across-clusters.asciidoc
+++ b/docs/reference/search/search-your-data/search-across-clusters.asciidoc
@@ -439,8 +439,8 @@ in the following matrix.
 
 IMPORTANT: For the <<eql-search-api,EQL search API>>, the local and remote
 clusters must use the same {es} version.
-Local clusters v 7.17.7 or later also support cross-cluster search to
-<<remote-clusters,remote clusters>> v 7.15 or later.
+Local clusters version 7.17.7 or later also support cross-cluster search to
+<<remote-clusters,remote clusters>> version 7.15.0 or later.
 
 [%collapsible%open]
 .Version compatibility matrix

--- a/x-pack/plugin/eql/qa/ccs-rolling-upgrade/build.gradle
+++ b/x-pack/plugin/eql/qa/ccs-rolling-upgrade/build.gradle
@@ -7,7 +7,6 @@
  */
 
 
-import org.elasticsearch.gradle.Version
 import org.elasticsearch.gradle.internal.info.BuildParams
 import org.elasticsearch.gradle.testclusters.StandaloneRestIntegTestTask
 
@@ -20,7 +19,7 @@ dependencies {
   testImplementation project(':client:rest-high-level')
 }
 
-// EQL CCS still has problems with versions before 7.15, see https://github.com/elastic/elasticsearch/issues/91762
+// see org.elasticsearch.xpack.eql.util.RemoteClusterRegistry.FIRST_COMPATIBLE_VERSION
 BuildParams.bwcVersions.withWireCompatiple(v -> v.onOrAfter("7.15.0")) { bwcVersion, baseName ->
 
   /**

--- a/x-pack/plugin/eql/qa/ccs-rolling-upgrade/build.gradle
+++ b/x-pack/plugin/eql/qa/ccs-rolling-upgrade/build.gradle
@@ -20,8 +20,8 @@ dependencies {
   testImplementation project(':client:rest-high-level')
 }
 
-// EQL was released as GA in v 7.11.0
-BuildParams.bwcVersions.withWireCompatiple(v -> v.onOrAfter("7.11.0")) { bwcVersion, baseName ->
+// EQL CCS still has problems with versions before 7.15, see https://github.com/elastic/elasticsearch/issues/91762
+BuildParams.bwcVersions.withWireCompatiple(v -> v.onOrAfter("7.15.0")) { bwcVersion, baseName ->
 
   /**
    * We execute tests 3 times.

--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/util/RemoteClusterRegistry.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/util/RemoteClusterRegistry.java
@@ -41,8 +41,8 @@ public class RemoteClusterRegistry {
         Set<String> incompatibleClusters = new TreeSet<>();
         for (String clusterAlias : clusterAliases(Strings.splitStringByCommaToArray(indexPattern), true)) {
             Version clusterVersion = remoteClusterService.getConnection(clusterAlias).getVersion();
-            // EQL was released as GA in v 7.11.0
-            if (Version.CURRENT.isCompatible(clusterVersion) == false || clusterVersion.before(Version.V_7_11_0)) {
+            // EQL CCS still has problems with versions before 7.15, see https://github.com/elastic/elasticsearch/issues/91762
+            if (Version.CURRENT.isCompatible(clusterVersion) == false || clusterVersion.before(Version.V_7_15_0)) {
                 incompatibleClusters.add(clusterAlias);
             }
         }

--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/util/RemoteClusterRegistry.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/util/RemoteClusterRegistry.java
@@ -14,6 +14,7 @@ import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.transport.RemoteClusterAware;
 import org.elasticsearch.transport.RemoteClusterService;
+import org.elasticsearch.xpack.eql.execution.search.RuntimeUtils;
 
 import java.util.Set;
 import java.util.TreeSet;
@@ -24,6 +25,8 @@ public class RemoteClusterRegistry {
     private final IndicesOptions indicesOptions;
     private final IndexNameExpressionResolver indexNameExpressionResolver;
     private final ClusterService clusterService;
+
+    public static final Version FIRST_COMPATIBLE_VERSION = RuntimeUtils.SWITCH_TO_MULTI_VALUE_FIELDS_VERSION;
 
     public RemoteClusterRegistry(
         RemoteClusterService remoteClusterService,
@@ -41,8 +44,7 @@ public class RemoteClusterRegistry {
         Set<String> incompatibleClusters = new TreeSet<>();
         for (String clusterAlias : clusterAliases(Strings.splitStringByCommaToArray(indexPattern), true)) {
             Version clusterVersion = remoteClusterService.getConnection(clusterAlias).getVersion();
-            // EQL CCS still has problems with versions before 7.15, see https://github.com/elastic/elasticsearch/issues/91762
-            if (Version.CURRENT.isCompatible(clusterVersion) == false || clusterVersion.before(Version.V_7_15_0)) {
+            if (Version.CURRENT.isCompatible(clusterVersion) == false || clusterVersion.before(FIRST_COMPATIBLE_VERSION)) {
                 incompatibleClusters.add(clusterAlias);
             }
         }


### PR DESCRIPTION
EQL does not CCS with remote clusters of version previous to 7.15, because of the addition of new features (support for multi-value fields) introduced in that version.

This PR adds an explicit check to disallow CCS attempts below that version.

Fixes https://github.com/elastic/elasticsearch/issues/91762