### PR TITLE
Mute SnapshotBasedRecoveryIT testSnapshotBasedRecovery

### DIFF
--- a/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/SnapshotBasedRecoveryIT.java
+++ b/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/SnapshotBasedRecoveryIT.java
@@ -40,6 +40,7 @@ import static org.hamcrest.Matchers.lessThan;
 import static org.hamcrest.Matchers.notNullValue;
 
 public class SnapshotBasedRecoveryIT extends AbstractRollingTestCase {
+    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/91383")
     public void testSnapshotBasedRecovery() throws Exception {
         final String indexName = "snapshot_based_recovery";
         final String repositoryName = "snapshot_based_recovery_repo";


### PR DESCRIPTION
Mute for https://github.com/elastic/elasticsearch/issues/91383

I realize this is quite an important test and the flakiness is not high in absolute terms:
https://gradle-enterprise.elastic.co/scans/tests?search.timeZoneId=Europe/Bucharest&tests.container=org.elasticsearch.upgrades.SnapshotBasedRecoveryIT&tests.test=testSnapshotBasedRecovery

I also see that you managed to get a reproduction running locally @idegtiarenko.

I'm going to leave this test mute in your hands (merge or not, your call).