### PR TITLE
[8.5] Improve InnocuousThread permission checks handling (#91704)

### DIFF
--- a/docs/changelog/91704.yaml
+++ b/docs/changelog/91704.yaml
@@ -1,0 +1,7 @@
+pr: 91704
+summary: '`DoPrivileged` in `ElasticsearchEncaughtExceptionHandler` and check modify
+  thread'
+area: Infra/Core
+type: bug
+issues:
+ - 91650

--- a/libs/secure-sm/src/main/java/org/elasticsearch/secure_sm/SecureSM.java
+++ b/libs/secure-sm/src/main/java/org/elasticsearch/secure_sm/SecureSM.java
@@ -162,8 +162,12 @@ public class SecureSM extends SecurityManager {
     protected void checkThreadAccess(Thread t) {
         Objects.requireNonNull(t);
 
-        // first, check if we can modify threads at all.
-        checkPermission(MODIFY_THREAD_PERMISSION);
+        boolean targetThreadIsInnocuous = isInnocuousThread(t);
+        // we don't need to check if innocuous thread is modifying itself (like changes its name)
+        if (Thread.currentThread() != t || targetThreadIsInnocuous == false) {
+            // first, check if we can modify threads at all.
+            checkPermission(MODIFY_THREAD_PERMISSION);
+        }
 
         // check the threadgroup, if its our thread group or an ancestor, its fine.
         final ThreadGroup source = Thread.currentThread().getThreadGroup();
@@ -171,7 +175,7 @@ public class SecureSM extends SecurityManager {
 
         if (target == null) {
             return;    // its a dead thread, do nothing.
-        } else if (source.parentOf(target) == false && isInnocuousThread(t) == false) {
+        } else if (source.parentOf(target) == false && targetThreadIsInnocuous == false) {
             checkPermission(MODIFY_ARBITRARY_THREAD_PERMISSION);
         }
     }

--- a/qa/os/src/test/java/org/elasticsearch/packaging/test/DockerTests.java
+++ b/qa/os/src/test/java/org/elasticsearch/packaging/test/DockerTests.java
@@ -1220,4 +1220,21 @@ public class DockerTests extends PackagingTestCase {
         waitForElasticsearch(installation);
         assertTrue(readinessProbe(9399));
     }
+
+    public void test600Interrupt() {
+        waitForElasticsearch(installation, "elastic", PASSWORD);
+        final Result containerLogs = getContainerLogs();
+
+        assertThat("Container logs should contain starting ...", containerLogs.stdout(), containsString("starting ..."));
+
+        final List<ProcessInfo> infos = ProcessInfo.getProcessInfo(sh, "java");
+        final int maxPid = infos.stream().map(i -> i.pid()).max(Integer::compareTo).get();
+
+        sh.run("kill -int " + maxPid); // send ctrl+c to all java processes
+        final Result containerLogsAfter = getContainerLogs();
+
+        assertThat("Container logs should contain stopping ...", containerLogsAfter.stdout(), containsString("stopping ..."));
+        assertThat("No errors stdout", containerLogsAfter.stdout(), not(containsString("java.security.AccessControlException:")));
+        assertThat("No errors stderr", containerLogsAfter.stderr(), not(containsString("java.security.AccessControlException:")));
+    }
 }

--- a/server/src/main/java/org/elasticsearch/bootstrap/ElasticsearchUncaughtExceptionHandler.java
+++ b/server/src/main/java/org/elasticsearch/bootstrap/ElasticsearchUncaughtExceptionHandler.java
@@ -52,12 +52,19 @@ class ElasticsearchUncaughtExceptionHandler implements Thread.UncaughtExceptionH
 
     void onFatalUncaught(final String threadName, final Throwable t) {
         final String message = "fatal error in thread [" + threadName + "], exiting";
-        logger.error(message, t);
+        logErrorMessage(t, message);
     }
 
     void onNonFatalUncaught(final String threadName, final Throwable t) {
         final String message = "uncaught exception in thread [" + threadName + "]";
-        logger.error(message, t);
+        logErrorMessage(t, message);
+    }
+
+    private void logErrorMessage(Throwable t, String message) {
+        AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
+            logger.error(message, t);
+            return null;
+        });
     }
 
     void halt(int status) {


### PR DESCRIPTION
Backports the following commits to 8.5:
 - Improve InnocuousThread permission checks handling (#91704)