### PR TITLE
Tolerate creation of InnocuousThreads - to facilitate use of java.lang.ref.Cleaner backport(#77788)

### DIFF
--- a/libs/secure-sm/src/main/java/org/elasticsearch/secure_sm/SecureSM.java
+++ b/libs/secure-sm/src/main/java/org/elasticsearch/secure_sm/SecureSM.java
@@ -153,6 +153,12 @@ public class SecureSM extends SecurityManager {
     private static final Permission MODIFY_THREAD_PERMISSION = new RuntimePermission("modifyThread");
     private static final Permission MODIFY_ARBITRARY_THREAD_PERMISSION = new ThreadPermission("modifyArbitraryThread");
 
+    // Returns true if the given thread is an instance of the JDK's InnocuousThread.
+    private static boolean isInnocuousThread(Thread t) {
+        final Class<?> c = t.getClass();
+        return c.getModule() == Object.class.getModule() && c.getName().equals("jdk.internal.misc.InnocuousThread");
+    }
+
     protected void checkThreadAccess(Thread t) {
         Objects.requireNonNull(t);
 
@@ -165,7 +171,7 @@ public class SecureSM extends SecurityManager {
 
         if (target == null) {
             return;    // its a dead thread, do nothing.
-        } else if (source.parentOf(target) == false) {
+        } else if (source.parentOf(target) == false && isInnocuousThread(t) == false) {
             checkPermission(MODIFY_ARBITRARY_THREAD_PERMISSION);
         }
     }

--- a/libs/secure-sm/src/main/java/org/elasticsearch/secure_sm/SecureSM.java
+++ b/libs/secure-sm/src/main/java/org/elasticsearch/secure_sm/SecureSM.java
@@ -156,7 +156,7 @@ public class SecureSM extends SecurityManager {
     // Returns true if the given thread is an instance of the JDK's InnocuousThread.
     private static boolean isInnocuousThread(Thread t) {
         final Class<?> c = t.getClass();
-        return c.getModule() == Object.class.getModule() && c.getName().equals("jdk.internal.misc.InnocuousThread");
+        return c.getClassLoader() == null && c.getName().equals("jdk.internal.misc.InnocuousThread");
     }
 
     protected void checkThreadAccess(Thread t) {


### PR DESCRIPTION
Update the ES security manager to tolerate the creation of the JDK's InnocuousThreads, to facilitate the use of java.lang.ref.Cleaner in ES and dependent code by default. Further details in issue ( https://github.com/elastic/elasticsearch/issues/77788 )

resolves https://github.com/elastic/elasticsearch/issues/77788
backport note - in 7.17 branch jdk8 is still supported. Therefore in order to recognize jdk.base domain it has to check for classloader == null (meaning it is a bootstrap classloader) instead of comparing modules
backport(#77788)