### PR TITLE
[ML] Increase timeout for _infer in PyTorchModelIT

### DIFF
--- a/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/PyTorchModelRestTestCase.java
+++ b/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/PyTorchModelRestTestCase.java
@@ -251,7 +251,7 @@ public abstract class PyTorchModelRestTestCase extends ESRestTestCase {
     }
 
     protected Response infer(String input, String modelId) throws IOException {
-        Request request = new Request("POST", "/_ml/trained_models/" + modelId + "/_infer");
+        Request request = new Request("POST", "/_ml/trained_models/" + modelId + "/_infer?timeout=30s");
         request.setJsonEntity(String.format(Locale.ROOT, """
             {  "docs": [{"input":"%s"}] }
             """, input));
@@ -259,7 +259,7 @@ public abstract class PyTorchModelRestTestCase extends ESRestTestCase {
     }
 
     protected Response infer(String input, String modelId, String resultsField) throws IOException {
-        Request request = new Request("POST", "/_ml/trained_models/" + modelId + "/_infer");
+        Request request = new Request("POST", "/_ml/trained_models/" + modelId + "/_infer?timeout=30s");
         request.setJsonEntity(String.format(Locale.ROOT, """
             {
               "docs": [ { "input": "%s" } ],


### PR DESCRIPTION
Inference requests running on slow workers in CI may exceed the default 10s timeout. This commit increases the timeout so those tests become more robust.
