### PR TITLE
Improve InnocuousThread permission checks handling backport(#91704) 

### DIFF
--- a/docs/changelog/91704.yaml
+++ b/docs/changelog/91704.yaml
@@ -1,0 +1,7 @@
+pr: 91704
+summary: '`DoPrivileged` in `ElasticsearchEncaughtExceptionHandler` and check modify
+  thread'
+area: Infra/Core
+type: bug
+issues:
+ - 91650

--- a/libs/secure-sm/src/main/java/org/elasticsearch/secure_sm/SecureSM.java
+++ b/libs/secure-sm/src/main/java/org/elasticsearch/secure_sm/SecureSM.java
@@ -156,8 +156,12 @@ public class SecureSM extends SecurityManager {
     protected void checkThreadAccess(Thread t) {
         Objects.requireNonNull(t);
 
-        // first, check if we can modify threads at all.
-        checkPermission(MODIFY_THREAD_PERMISSION);
+        boolean targetThreadIsInnocuous = isInnocuousThread(t);
+        // we don't need to check if innocuous thread is modifying itself (like changes its name)
+        if (Thread.currentThread() != t || targetThreadIsInnocuous == false) {
+            // first, check if we can modify threads at all.
+            checkPermission(MODIFY_THREAD_PERMISSION);
+        }
 
         // check the threadgroup, if its our thread group or an ancestor, its fine.
         final ThreadGroup source = Thread.currentThread().getThreadGroup();
@@ -165,7 +169,7 @@ public class SecureSM extends SecurityManager {
 
         if (target == null) {
             return;    // its a dead thread, do nothing.
-        } else if (source.parentOf(target) == false) {
+        } else if (source.parentOf(target) == false && targetThreadIsInnocuous == false) {
             checkPermission(MODIFY_ARBITRARY_THREAD_PERMISSION);
         }
     }

--- a/qa/os/src/test/java/org/elasticsearch/packaging/test/DockerTests.java
+++ b/qa/os/src/test/java/org/elasticsearch/packaging/test/DockerTests.java
@@ -1096,4 +1096,21 @@ public class DockerTests extends PackagingTestCase {
         final Installation.Executables bin = installation.executables();
         return Arrays.stream(sh.run(bin.pluginTool + " list").stdout.split("\n")).collect(Collectors.toList());
     }
+
+    public void test600Interrupt() {
+        waitForElasticsearch(installation, "elastic", PASSWORD);
+        final Result containerLogs = getContainerLogs();
+
+        assertThat("Container logs should contain starting ...", containerLogs.stdout(), containsString("starting ..."));
+
+        final List<ProcessInfo> infos = ProcessInfo.getProcessInfo(sh, "java");
+        final int maxPid = infos.stream().map(i -> i.pid()).max(Integer::compareTo).get();
+
+        sh.run("kill -int " + maxPid); // send ctrl+c to all java processes
+        final Result containerLogsAfter = getContainerLogs();
+
+        assertThat("Container logs should contain stopping ...", containerLogsAfter.stdout(), containsString("stopping ..."));
+        assertThat("No errors stdout", containerLogsAfter.stdout(), not(containsString("java.security.AccessControlException:")));
+        assertThat("No errors stderr", containerLogsAfter.stderr(), not(containsString("java.security.AccessControlException:")));
+    }
 }

--- a/qa/os/src/test/java/org/elasticsearch/packaging/test/DockerTests.java
+++ b/qa/os/src/test/java/org/elasticsearch/packaging/test/DockerTests.java
@@ -1097,20 +1097,21 @@ public class DockerTests extends PackagingTestCase {
         return Arrays.stream(sh.run(bin.pluginTool + " list").stdout.split("\n")).collect(Collectors.toList());
     }
 
-    public void test600Interrupt() {
-        waitForElasticsearch(installation, "elastic", PASSWORD);
+    public void test600Interrupt() throws Exception {
+        waitForElasticsearch(installation);
         final Result containerLogs = getContainerLogs();
 
-        assertThat("Container logs should contain starting ...", containerLogs.stdout(), containsString("starting ..."));
+        assertThat("Container logs should contain starting ...", containerLogs.stdout, containsString("starting ..."));
 
-        final List<ProcessInfo> infos = ProcessInfo.getProcessInfo(sh, "java");
-        final int maxPid = infos.stream().map(i -> i.pid()).max(Integer::compareTo).get();
+        final List<String> processes = Arrays.stream(sh.run("pgrep java").stdout.split(System.lineSeparator()))
+            .collect(Collectors.toList());
+        int maxPid = processes.stream().map(i -> Integer.parseInt(i.trim())).max(Integer::compareTo).get();
 
         sh.run("kill -int " + maxPid); // send ctrl+c to all java processes
         final Result containerLogsAfter = getContainerLogs();
 
-        assertThat("Container logs should contain stopping ...", containerLogsAfter.stdout(), containsString("stopping ..."));
-        assertThat("No errors stdout", containerLogsAfter.stdout(), not(containsString("java.security.AccessControlException:")));
-        assertThat("No errors stderr", containerLogsAfter.stderr(), not(containsString("java.security.AccessControlException:")));
+        assertThat("Container logs should contain stopping ...", containerLogsAfter.stdout, containsString("stopping ..."));
+        assertThat("No errors stdout", containerLogsAfter.stdout, not(containsString("java.security.AccessControlException:")));
+        assertThat("No errors stderr", containerLogsAfter.stderr, not(containsString("java.security.AccessControlException:")));
     }
 }

--- a/server/src/main/java/org/elasticsearch/bootstrap/ElasticsearchUncaughtExceptionHandler.java
+++ b/server/src/main/java/org/elasticsearch/bootstrap/ElasticsearchUncaughtExceptionHandler.java
@@ -53,7 +53,7 @@ class ElasticsearchUncaughtExceptionHandler implements Thread.UncaughtExceptionH
 
     void onFatalUncaught(final String threadName, final Throwable t) {
         final String message = "fatal error in thread [" + threadName + "], exiting";
-        logger.error(message, t);
+        logErrorMessage(t, message);
         Terminal.DEFAULT.errorPrintln(message);
         t.printStackTrace(Terminal.DEFAULT.getErrorWriter());
         // Without a final flush, the stacktrace may not be shown before ES exits
@@ -64,13 +64,18 @@ class ElasticsearchUncaughtExceptionHandler implements Thread.UncaughtExceptionH
 
     void onNonFatalUncaught(final String threadName, final Throwable t) {
         final String message = "uncaught exception in thread [" + threadName + "]";
-        logger.error(message, t);
+        logErrorMessage(t, message);
         Terminal.DEFAULT.errorPrintln(message);
         t.printStackTrace(Terminal.DEFAULT.getErrorWriter());
         // Without a final flush, the stacktrace may not be shown if ES goes on to exit
         Terminal.DEFAULT.flush();
     }
-
+    private void logErrorMessage(Throwable t, String message) {
+        AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
+            logger.error(message, t);
+            return null;
+        });
+    }
     void halt(int status) {
         AccessController.doPrivileged(new PrivilegedHaltAction(status));
     }

--- a/server/src/main/java/org/elasticsearch/bootstrap/ElasticsearchUncaughtExceptionHandler.java
+++ b/server/src/main/java/org/elasticsearch/bootstrap/ElasticsearchUncaughtExceptionHandler.java
@@ -70,12 +70,14 @@ class ElasticsearchUncaughtExceptionHandler implements Thread.UncaughtExceptionH
         // Without a final flush, the stacktrace may not be shown if ES goes on to exit
         Terminal.DEFAULT.flush();
     }
+
     private void logErrorMessage(Throwable t, String message) {
         AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
             logger.error(message, t);
             return null;
         });
     }
+
     void halt(int status) {
         AccessController.doPrivileged(new PrivilegedHaltAction(status));
     }


### PR DESCRIPTION
[Improve InnocuousThread permission checks handling (](https://github.com/elastic/elasticsearch/commit/6a3855112cf04aade4955664646b18fe1405eb48)https://github.com/elastic/elasticsearch/pull/91704[)](https://github.com/elastic/elasticsearch/commit/6a3855112cf04aade4955664646b18fe1405eb48) 

on shutdown, the jdk's InnocuousThread can try to change a thread name. This requires "java.lang.RuntimePermission" "modifyThread" permission. However InnocuousThread doe not inherit any Access Control Context and therefore have no permissions. This results in AccessControlException.
This commit fixes this by skipping a check for modify thread permission if a thread is innocuous.
relates https://github.com/elastic/elasticsearch/issues/91658 and https://github.com/elastic/elasticsearch/issues/91650

When previously described AccessControlException is thrown, it is not being catched anywhere in the Elasticsearch, hence it ends up being handled by ElasticsearchUncaughtExceptionHandler#onNonFatalUncaught
This is being again being run by the thread [process reaper] which is an innocuous thread (jdk specific) and has no permissions. onNonFatalUncaught is trying to log a message, but this in turn requires java.lang.RuntimePermission" "getenv.*" permission. which is does not have. This again results in AccessControlException java.lang.RuntimePermission" "getenv.*"

We can fix this by executing with doPrivileged in ElasticsearchUncaughtExceptionHandler#onNonFatalUncaught and this will stop the Security Manager's walk and will have ES's global grant permissions.

closes https://github.com/elastic/elasticsearch/issues/91650