### PR TITLE
[DOCS] Warn about calling vector functions repeatedly

### DIFF
--- a/docs/reference/query-dsl/script-score-query.asciidoc
+++ b/docs/reference/query-dsl/script-score-query.asciidoc
@@ -145,7 +145,6 @@ A good default choice might be to use the `_seq_no`
 field, whose only drawback is that scores will change if the document is
 updated since update operations also update the value of the `_seq_no` field.
 
-
 [[decay-functions-numeric-fields]]
 ====== Decay functions for numeric fields
 You can read more about decay functions 
@@ -333,8 +332,8 @@ through a script:
 
 [[decay-functions]]
 ====== `decay` functions
-The `script_score` query has equivalent <<decay-functions, decay functions>>
-that can be used in script.
+The `script_score` query has equivalent <<decay-functions-numeric-fields, decay
+functions>> that can be used in scripts.
 
 include::{es-repo-dir}/vectors/vector-functions.asciidoc[]
 

--- a/docs/reference/query-dsl/script-score-query.asciidoc
+++ b/docs/reference/query-dsl/script-score-query.asciidoc
@@ -338,7 +338,7 @@ functions>> that can be used in scripts.
 include::{es-repo-dir}/vectors/vector-functions.asciidoc[]
 
 [[score-explanation]]
-====== Explain request
+===== Explain request
 Using an <<search-explain, explain request>> provides an explanation of how the parts of a score were computed. The `script_score` query can add its own explanation by setting the `explanation` parameter:
 
 [source,console]

--- a/docs/reference/vectors/vector-functions.asciidoc
+++ b/docs/reference/vectors/vector-functions.asciidoc
@@ -16,6 +16,20 @@ This is the list of available vector functions and vector access methods:
 5. `doc[<field>].vectorValue` – returns a vector's value as an array of floats
 6. `doc[<field>].magnitude` – returns a vector's magnitude
 
+[NOTE]
+====
+If a document doesn't have a value for a vector field on which
+a vector function is executed, an error will be thrown.
+
+You can check if a document has a value for the field `my_vector` by
+`doc['my_vector'].size() == 0`. Your overall script can look like this:
+
+[source,js]
+--------------------------------------------------
+"source": "doc['my_vector'].size() == 0 ? 0 : cosineSimilarity(params.queryVector, 'my_vector')"
+--------------------------------------------------
+// NOTCONSOLE
+====
 
 Let's create an index with a `dense_vector` mapping and index a couple
 of documents into it.
@@ -54,6 +68,8 @@ POST my-index-000001/_refresh
 --------------------------------------------------
 // TESTSETUP
 
+====== Cosine similarity
+
 The `cosineSimilarity` function calculates the measure of
 cosine similarity between a given query vector and document vectors.
 
@@ -90,6 +106,8 @@ GET my-index-000001/_search
 NOTE: If a document's dense vector field has a number of dimensions
 different from the query's vector, an error will be thrown.
 
+====== Dot product
+
 The `dotProduct` function calculates the measure of
 dot product between a given query vector and document vectors.
 
@@ -123,6 +141,8 @@ GET my-index-000001/_search
 --------------------------------------------------
 
 <1> Using the standard sigmoid function prevents scores from being negative.
+
+====== L^1^ distance (Manhattan distance)
 
 The `l1norm` function calculates L^1^ distance
 (Manhattan distance) between a given query vector and
@@ -163,6 +183,8 @@ we reversed the output from `l1norm` and `l2norm`. Also, to avoid
 division by 0 when a document vector matches the query exactly,
 we added `1` in the denominator.
 
+====== L^2^ distance (Euclidean distance)
+
 The `l2norm` function calculates L^2^ distance
 (Euclidean distance) between a given query vector and
 document vectors.
@@ -193,21 +215,15 @@ GET my-index-000001/_search
 }
 --------------------------------------------------
 
-NOTE: If a document doesn't have a value for a vector field on which
-a vector function is executed, an error will be thrown.
-
-You can check if a document has a value for the field `my_vector` by
-`doc['my_vector'].size() == 0`. Your overall script can look like this:
-
-[source,js]
---------------------------------------------------
-"source": "doc['my_vector'].size() == 0 ? 0 : cosineSimilarity(params.queryVector, 'my_vector')"
---------------------------------------------------
-// NOTCONSOLE
+====== Accessing dense vectors directly
 
 The recommended way to access dense vectors is through `cosineSimilarity`,
-`dotProduct`, `l1norm` or `l2norm` functions. But for custom use cases,
-you can access dense vectors's values directly through the following functions:
+`dotProduct`, `l1norm` or `l2norm` functions. Please note however, that these
+functions should only be called once per script. For example, don't use these
+functions in a loop to calculate the similarity between a document's dense
+vector and several other vectors. For custom use cases like this, you need to
+reimplement these functions by accessing dense vector values directly through
+the following functions:
 
 - `doc[<field>].vectorValue` – returns a vector's value as an array of floats
 

--- a/docs/reference/vectors/vector-functions.asciidoc
+++ b/docs/reference/vectors/vector-functions.asciidoc
@@ -9,27 +9,20 @@ to limit the number of matched documents with a `query` parameter.
 
 This is the list of available vector functions and vector access methods:
 
-1. `cosineSimilarity` – calculates cosine similarity
-2. `dotProduct` – calculates dot product
-3. `l1norm` – calculates L^1^ distance
-4. `l2norm` - calculates L^2^ distance
-5. `doc[<field>].vectorValue` – returns a vector's value as an array of floats
-6. `doc[<field>].magnitude` – returns a vector's magnitude
+1. <<vector-functions-cosine,`cosineSimilarity`>> – calculates cosine similarity
+2. <<vector-functions-dot-product,`dotProduct`>> – calculates dot product
+3. <<vector-functions-l1,`l1norm`>> – calculates L^1^ distance
+4. <<vector-functions-l2,`l2norm`>> - calculates L^2^ distance
+5. <<vector-functions-accessing-vectors,`doc[<field>].vectorValue`>> – returns a vector's value as an array of floats
+6. <<vector-functions-accessing-vectors,`doc[<field>].magnitude`>> – returns a vector's magnitude
 
-[NOTE]
-====
-If a document doesn't have a value for a vector field on which
-a vector function is executed, an error will be thrown.
-
-You can check if a document has a value for the field `my_vector` by
-`doc['my_vector'].size() == 0`. Your overall script can look like this:
-
-[source,js]
---------------------------------------------------
-"source": "doc['my_vector'].size() == 0 ? 0 : cosineSimilarity(params.queryVector, 'my_vector')"
---------------------------------------------------
-// NOTCONSOLE
-====
+NOTE: The recommended way to access dense vectors is through the
+`cosineSimilarity`, `dotProduct`, `l1norm` or `l2norm` functions. Please note
+however, that you should call these functions only once per script. For example,
+don’t use these functions in a loop to calculate the similarity between a
+document vector and multiple other vectors. If you need that functionality,
+reimplement these functions yourself by
+<<vector-functions-accessing-vectors,accessing vector values directly>>.
 
 Let's create an index with a `dense_vector` mapping and index a couple
 of documents into it.
@@ -68,6 +61,7 @@ POST my-index-000001/_refresh
 --------------------------------------------------
 // TESTSETUP
 
+[[vector-functions-cosine]]
 ====== Cosine similarity
 
 The `cosineSimilarity` function calculates the measure of
@@ -106,6 +100,7 @@ GET my-index-000001/_search
 NOTE: If a document's dense vector field has a number of dimensions
 different from the query's vector, an error will be thrown.
 
+[[vector-functions-dot-product]]
 ====== Dot product
 
 The `dotProduct` function calculates the measure of
@@ -142,6 +137,7 @@ GET my-index-000001/_search
 
 <1> Using the standard sigmoid function prevents scores from being negative.
 
+[[vector-functions-l1]]
 ====== L^1^ distance (Manhattan distance)
 
 The `l1norm` function calculates L^1^ distance
@@ -183,6 +179,7 @@ we reversed the output from `l1norm` and `l2norm`. Also, to avoid
 division by 0 when a document vector matches the query exactly,
 we added `1` in the denominator.
 
+[[vector-functions-l2]]
 ====== L^2^ distance (Euclidean distance)
 
 The `l2norm` function calculates L^2^ distance
@@ -215,15 +212,25 @@ GET my-index-000001/_search
 }
 --------------------------------------------------
 
-====== Accessing dense vectors directly
+[[vector-functions-missing-values]]
+====== Checking for missing values
 
-The recommended way to access dense vectors is through `cosineSimilarity`,
-`dotProduct`, `l1norm` or `l2norm` functions. Please note however, that these
-functions should only be called once per script. For example, don't use these
-functions in a loop to calculate the similarity between a document's dense
-vector and several other vectors. For custom use cases like this, you need to
-reimplement these functions by accessing dense vector values directly through
-the following functions:
+If a document doesn't have a value for a vector field on which a vector function
+is executed, an error will be thrown.
+
+You can check if a document has a value for the field `my_vector` with
+`doc['my_vector'].size() == 0`. Your overall script can look like this:
+
+[source,js]
+--------------------------------------------------
+"source": "doc['my_vector'].size() == 0 ? 0 : cosineSimilarity(params.queryVector, 'my_vector')"
+--------------------------------------------------
+// NOTCONSOLE
+
+[[vector-functions-accessing-vectors]]
+====== Accessing vectors directly
+
+You can access vector values directly through the following functions:
 
 - `doc[<field>].vectorValue` – returns a vector's value as an array of floats
 


### PR DESCRIPTION
Closes #91496

This PR adds a note explaining that vector functions should not be called repeatedly in a script.

This PR also adds some navigational improvements to this page:
- Fixes a link from the "decay functions" section (it was linking to itself)
- Adds headers to each of the vector functions and links from the overview list
- Fixes the header level for the "Explain request" section (it is not specific to vector functions)