### PR TITLE
add math operations on pivot columns

### DIFF
--- a/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/expression/gen/processor/BinaryProcessor.java
+++ b/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/expression/gen/processor/BinaryProcessor.java
@@ -58,11 +58,11 @@ public abstract class BinaryProcessor implements Processor {
         // no-op
     }
 
-    protected Processor left() {
+    public Processor left() {
         return left;
     }
 
-    protected Processor right() {
+    public Processor right() {
         return right;
     }
 

--- a/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/expression/predicate/operator/arithmetic/BinaryArithmeticProcessor.java
+++ b/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/expression/predicate/operator/arithmetic/BinaryArithmeticProcessor.java
@@ -36,7 +36,7 @@ public final class BinaryArithmeticProcessor extends FunctionalBinaryProcessor<O
     }
 
     @Override
-    protected Object doProcess(Object left, Object right) {
+    public Object doProcess(Object left, Object right) {
         BinaryArithmeticOperation f = function();
 
         if (left == null || right == null) {

--- a/x-pack/plugin/sql/qa/server/src/main/resources/pivot.csv-spec
+++ b/x-pack/plugin/sql/qa/server/src/main/resources/pivot.csv-spec
@@ -200,6 +200,35 @@ null           |48396.28571428572|62140.666666666664
 5              |39052.875        |46705.555555555555
 ;
 
+pivotWithComplexMathExpression
+schema::languages:bt|Male:d|Female:d|Percent:d|Male+Female:d
+SELECT *,Female/(Female+Male)*100 AS Percent,Male+Female FROM (SELECT languages, gender, salary FROM test_emp) PIVOT (AVG(salary) FOR gender IN ('M' AS Male, 'F' AS Female)) ORDER BY languages ASC;
+
+   languages   |      Male       |      Female      |Percent      |   Male+Female
+---------------+-----------------+------------------+-------------+-----------------
+null           |48396.28571428572|62140.666666666664|56,217097838 |110536,952380952
+1              |49767.22222222222|47073.25          |48,609066974 |96840,472222222
+2              |44103.90909090909|50684.4           |53,471151122 |94788,309090909
+3              |51741.90909090909|53660.0           |50,909893818 |105401,909090909
+4              |47058.90909090909|49291.5           |51,158578838 |96350,4091
+5              |39052.875        |46705.555555555555|54,461765745 |85758,430555556
+;
+
+pivotWithMathExpression
+schema::languages:bt|Male:d|Female:d|Male-Female:d
+SELECT *, Male-Female FROM (SELECT languages, gender, salary FROM test_emp) PIVOT (AVG(salary) FOR gender IN ('M' AS Male, 'F' AS Female)) ORDER BY languages ASC;
+
+   languages   |      Male       |      Female      |   Male-Female
+---------------+-----------------+------------------+----------------
+null           |48396.28571428572|62140.666666666664|-13744,380952381
+1              |49767.22222222222|47073.25          |2693,972222222
+2              |44103.90909090909|50684.4           |-6580,490909091
+3              |51741.90909090909|53660.0           |-1918,090909091
+4              |47058.90909090909|49291.5           |-2232,590909091
+5              |39052.875        |46705.555555555555|-7652,680555556
+;
+
+
 sumWithoutSubquery
 schema::birth_date:ts|emp_no:i|first_name:s|gender:s|hire_date:ts|last_name:s|name:s|1:l|2:l
 // tag::sumWithoutSubquery

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/analysis/analyzer/Analyzer.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/analysis/analyzer/Analyzer.java
@@ -990,9 +990,6 @@ public class Analyzer extends RuleExecutor<LogicalPlan> {
                     if (child instanceof NamedExpression) {
                         return child;
                     }
-                    if (child.resolved() == false) {
-                        return ua;
-                    }
                     if (child instanceof Cast c) {
                         if (c.field() instanceof NamedExpression) {
                             return new Alias(c.source(), ((NamedExpression) c.field()).name(), c);

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/execution/search/CompositeAggCursor.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/execution/search/CompositeAggCursor.java
@@ -30,7 +30,6 @@ import org.elasticsearch.xpack.sql.util.Check;
 
 import java.io.IOException;
 import java.util.Arrays;
-import java.util.BitSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -54,14 +53,14 @@ public class CompositeAggCursor implements Cursor {
     private final String[] indices;
     private final SearchSourceBuilder nextQuery;
     private final List<BucketExtractor> extractors;
-    private final BitSet mask;
+    private final List<Integer> mask;
     private final int limit;
     private final boolean includeFrozen;
 
     CompositeAggCursor(
         SearchSourceBuilder nextQuery,
         List<BucketExtractor> exts,
-        BitSet mask,
+        List<Integer> mask,
         int remainingLimit,
         boolean includeFrozen,
         String... indices
@@ -80,7 +79,7 @@ public class CompositeAggCursor implements Cursor {
         limit = in.readVInt();
 
         extractors = in.readNamedWriteableList(BucketExtractor.class);
-        mask = BitSet.valueOf(in.readByteArray());
+        mask = Arrays.stream(in.readIntArray()).boxed().toList();
         includeFrozen = in.readBoolean();
     }
 
@@ -91,7 +90,7 @@ public class CompositeAggCursor implements Cursor {
         out.writeVInt(limit);
 
         out.writeNamedWriteableList(extractors);
-        out.writeByteArray(mask.toByteArray());
+        out.writeIntArray(mask.stream().mapToInt(i -> i).toArray());
         out.writeBoolean(includeFrozen);
     }
 
@@ -108,7 +107,7 @@ public class CompositeAggCursor implements Cursor {
         return nextQuery;
     }
 
-    BitSet mask() {
+    List<Integer> mask() {
         return mask;
     }
 

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/execution/search/CompositeAggRowSet.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/execution/search/CompositeAggRowSet.java
@@ -11,7 +11,6 @@ import org.elasticsearch.search.aggregations.bucket.composite.CompositeAggregati
 import org.elasticsearch.xpack.ql.execution.search.extractor.BucketExtractor;
 import org.elasticsearch.xpack.sql.session.RowSet;
 
-import java.util.BitSet;
 import java.util.List;
 import java.util.Map;
 
@@ -29,7 +28,7 @@ class CompositeAggRowSet extends ResultRowSet<BucketExtractor> {
 
     CompositeAggRowSet(
         List<BucketExtractor> exts,
-        BitSet mask,
+        List<Integer> mask,
         SearchResponse response,
         int sizeRequested,
         int remainingLimit,

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/execution/search/PivotCursor.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/execution/search/PivotCursor.java
@@ -17,7 +17,6 @@ import org.elasticsearch.xpack.ql.type.Schema;
 
 import java.io.IOException;
 import java.util.Arrays;
-import java.util.BitSet;
 import java.util.List;
 import java.util.Map;
 import java.util.function.BiFunction;
@@ -33,7 +32,7 @@ public class PivotCursor extends CompositeAggCursor {
         Map<String, Object> previousKey,
         SearchSourceBuilder next,
         List<BucketExtractor> exts,
-        BitSet mask,
+        List<Integer> mask,
         int remainingLimit,
         boolean includeFrozen,
         String... indices

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/execution/search/SchemaCompositeAggRowSet.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/execution/search/SchemaCompositeAggRowSet.java
@@ -12,7 +12,6 @@ import org.elasticsearch.xpack.ql.type.Schema;
 import org.elasticsearch.xpack.sql.session.RowSet;
 import org.elasticsearch.xpack.sql.session.SchemaRowSet;
 
-import java.util.BitSet;
 import java.util.List;
 
 /**
@@ -26,7 +25,7 @@ class SchemaCompositeAggRowSet extends CompositeAggRowSet implements SchemaRowSe
     SchemaCompositeAggRowSet(
         Schema schema,
         List<BucketExtractor> exts,
-        BitSet mask,
+        List<Integer> mask,
         SearchResponse r,
         int sizeRequested,
         int limitAggs,

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/execution/search/SchemaSearchHitRowSet.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/execution/search/SchemaSearchHitRowSet.java
@@ -11,7 +11,6 @@ import org.elasticsearch.xpack.ql.execution.search.extractor.HitExtractor;
 import org.elasticsearch.xpack.ql.type.Schema;
 import org.elasticsearch.xpack.sql.session.SchemaRowSet;
 
-import java.util.BitSet;
 import java.util.List;
 
 /**
@@ -22,7 +21,14 @@ import java.util.List;
 class SchemaSearchHitRowSet extends SearchHitRowSet implements SchemaRowSet {
     private final Schema schema;
 
-    SchemaSearchHitRowSet(Schema schema, List<HitExtractor> exts, BitSet mask, int sizeRequested, int limitHits, SearchResponse response) {
+    SchemaSearchHitRowSet(
+        Schema schema,
+        List<HitExtractor> exts,
+        List<Integer> mask,
+        int sizeRequested,
+        int limitHits,
+        SearchResponse response
+    ) {
         super(exts, mask, sizeRequested, limitHits, response);
         this.schema = schema;
     }

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/execution/search/SearchHitRowSet.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/execution/search/SearchHitRowSet.java
@@ -14,7 +14,6 @@ import org.elasticsearch.xpack.sql.SqlIllegalArgumentException;
 
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.BitSet;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
@@ -39,7 +38,7 @@ class SearchHitRowSet extends ResultRowSet<HitExtractor> {
 
     private int row = 0;
 
-    SearchHitRowSet(List<HitExtractor> exts, BitSet mask, int sizeRequested, int limit, SearchResponse response) {
+    SearchHitRowSet(List<HitExtractor> exts, List<Integer> mask, int sizeRequested, int limit, SearchResponse response) {
         super(exts, mask);
 
         this.hits = response.getHits().getHits();

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/querydsl/container/PivotMathFieldRef.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/querydsl/container/PivotMathFieldRef.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.sql.querydsl.container;
+
+import org.elasticsearch.xpack.ql.execution.search.QlSourceBuilder;
+import org.elasticsearch.xpack.ql.type.DataType;
+import org.elasticsearch.xpack.sql.type.SqlDataTypes;
+
+public class PivotMathFieldRef extends FieldReference {
+
+    private final String name;
+    private final DataType dataType;
+
+    public PivotMathFieldRef(String name, DataType dataType) {
+        this.name = name;
+        this.dataType = dataType;
+    }
+
+    @Override
+    public String name() {
+        return name;
+    }
+
+    public DataType getDataType() {
+        return dataType;
+    }
+
+    @Override
+    public void collectFields(QlSourceBuilder sourceBuilder) {
+        sourceBuilder.addFetchField(name, SqlDataTypes.format(dataType));
+    }
+
+    @Override
+    public String toString() {
+        return name;
+    }
+}

--- a/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/execution/search/CompositeAggregationCursorTests.java
+++ b/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/execution/search/CompositeAggregationCursorTests.java
@@ -17,7 +17,6 @@ import org.elasticsearch.xpack.sql.execution.search.extractor.MetricAggExtractor
 import java.io.IOException;
 import java.time.ZoneId;
 import java.util.ArrayList;
-import java.util.BitSet;
 import java.util.List;
 import java.util.function.Supplier;
 
@@ -33,7 +32,7 @@ public class CompositeAggregationCursorTests extends AbstractSqlWireSerializingT
         return new CompositeAggCursor(
             new SearchSourceBuilder().size(randomInt(1000)),
             extractors,
-            randomBitSet(extractorsSize),
+            randomArrayList(extractorsSize),
             randomIntBetween(10, 1024),
             randomBoolean(),
             randomAlphaOfLength(5)
@@ -53,7 +52,7 @@ public class CompositeAggregationCursorTests extends AbstractSqlWireSerializingT
         return new CompositeAggCursor(
             instance.next(),
             instance.extractors(),
-            randomValueOtherThan(instance.mask(), () -> randomBitSet(instance.extractors().size())),
+            randomValueOtherThan(instance.mask(), () -> randomArrayList(instance.extractors().size())),
             randomValueOtherThan(instance.limit(), () -> randomIntBetween(1, 512)),
             instance.includeFrozen() == false,
             instance.indices()
@@ -84,10 +83,10 @@ public class CompositeAggregationCursorTests extends AbstractSqlWireSerializingT
         return randomZone();
     }
 
-    static BitSet randomBitSet(int size) {
-        BitSet mask = new BitSet(size);
+    static List<Integer> randomArrayList(int size) {
+        List<Integer> mask = new ArrayList<>(size);
         for (int i = 0; i < size; i++) {
-            mask.set(i, randomBoolean());
+            mask.add(randomIntBetween(0, 512));
         }
         return mask;
     }

--- a/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/execution/search/QuerierTests.java
+++ b/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/execution/search/QuerierTests.java
@@ -20,7 +20,6 @@ import org.elasticsearch.xpack.sql.session.SqlSession;
 
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.BitSet;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
@@ -206,7 +205,7 @@ public class QuerierTests extends ESTestCase {
             private int rowCounter = 0;
             private final int dataSize;
 
-            TestResultRowSet(List<E> extractors, BitSet mask, int dataSize) {
+            TestResultRowSet(List<E> extractors, List<Integer> mask, int dataSize) {
                 super(extractors, mask);
                 this.dataSize = dataSize;
             }
@@ -242,7 +241,7 @@ public class QuerierTests extends ESTestCase {
         ;
 
         Cursor.Page page = new Cursor.Page(
-            new TestResultRowSet<NamedWriteable>(List.of(randomHitExtractor(0)), new BitSet(), dataSize),
+            new TestResultRowSet<NamedWriteable>(List.of(randomHitExtractor(0)), new ArrayList<>(), dataSize),
             Cursor.EMPTY
         );
 

--- a/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/execution/search/SearchHitCursorTests.java
+++ b/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/execution/search/SearchHitCursorTests.java
@@ -32,7 +32,7 @@ public class SearchHitCursorTests extends AbstractSqlWireSerializingTestCase<Sea
         return new SearchHitCursor(
             new SearchSourceBuilder().size(randomInt(1000)),
             extractors,
-            CompositeAggregationCursorTests.randomBitSet(extractorsSize),
+            CompositeAggregationCursorTests.randomArrayList(extractorsSize),
             randomIntBetween(10, 1024),
             randomBoolean(),
             randomBoolean()
@@ -53,7 +53,7 @@ public class SearchHitCursorTests extends AbstractSqlWireSerializingTestCase<Sea
         return new SearchHitCursor(
             instance.next(),
             instance.extractors(),
-            randomValueOtherThan(instance.mask(), () -> CompositeAggregationCursorTests.randomBitSet(instance.extractors().size())),
+            randomValueOtherThan(instance.mask(), () -> CompositeAggregationCursorTests.randomArrayList(instance.extractors().size())),
             randomValueOtherThan(instance.limit(), () -> randomIntBetween(1, 1024)),
             instance.includeFrozen() == false,
             instance.allowPartialSearchResults() == false

--- a/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/planner/QueryFolderTests.java
+++ b/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/planner/QueryFolderTests.java
@@ -28,6 +28,7 @@ import org.elasticsearch.xpack.sql.plan.physical.LocalExec;
 import org.elasticsearch.xpack.sql.plan.physical.PhysicalPlan;
 import org.elasticsearch.xpack.sql.querydsl.container.GroupByRef;
 import org.elasticsearch.xpack.sql.querydsl.container.PivotColumnRef;
+import org.elasticsearch.xpack.sql.querydsl.container.PivotMathFieldRef;
 import org.elasticsearch.xpack.sql.querydsl.container.QueryContainer;
 import org.elasticsearch.xpack.sql.session.EmptyExecutable;
 import org.elasticsearch.xpack.sql.session.SingletonExecutable;
@@ -541,7 +542,7 @@ public class QueryFolderTests extends ESTestCase {
         assertEquals(asList("c1", "c2"), Expressions.names(ee.output()));
 
         List<QueryContainer.FieldInfo> fields = ee.queryContainer().fields();
-        assertEquals(4, fields.size());
+        assertEquals(6, fields.size());
         assertEquals(PivotColumnRef.class, fields.get(0).extraction().getClass());
         assertEquals("A", ((PivotColumnRef) fields.get(0).extraction()).value());
         assertEquals(PivotColumnRef.class, fields.get(1).extraction().getClass());
@@ -549,6 +550,10 @@ public class QueryFolderTests extends ESTestCase {
         assertEquals(GroupByRef.class, fields.get(2).extraction().getClass());
         assertEquals(PivotColumnRef.class, fields.get(3).extraction().getClass());
         assertEquals("B", ((PivotColumnRef) fields.get(3).extraction()).value());
+        assertEquals(PivotMathFieldRef.class, fields.get(4).extraction().getClass());
+        assertEquals("a", ((PivotMathFieldRef) fields.get(4).extraction()).name());
+        assertEquals(PivotMathFieldRef.class, fields.get(5).extraction().getClass());
+        assertEquals("a", ((PivotMathFieldRef) fields.get(5).extraction()).name());
     }
 
     public void testFoldingOfPivotDroppingPivotedColumn() {

--- a/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/querydsl/container/QueryContainerTests.java
+++ b/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/querydsl/container/QueryContainerTests.java
@@ -22,8 +22,9 @@ import org.elasticsearch.xpack.ql.type.EsField;
 
 import java.time.ZoneId;
 import java.util.AbstractMap.SimpleImmutableEntry;
+import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.BitSet;
+import java.util.List;
 
 import static java.util.Collections.emptyMap;
 import static java.util.Collections.singletonMap;
@@ -101,16 +102,14 @@ public class QueryContainerTests extends ESTestCase {
             .addColumn(first)
             .addColumn(fourth);
 
-        BitSet result = queryContainer.columnMask(Arrays.asList(first, first, second, third, firstAliased.toAttribute()));
+        List<Integer> result = queryContainer.columnMask(Arrays.asList(first, first, second, third, firstAliased.toAttribute()));
 
-        BitSet expected = new BitSet();
-        expected.set(0, true);
-        expected.set(1, true);
-        expected.set(2, false);
-        expected.set(3, true);
-        expected.set(4, true);
-        expected.set(5, true);
-        expected.set(6, false);
+        List<Integer> expected = new ArrayList<>();
+        expected.add(0, 1);
+        expected.add(1, 3);
+        expected.add(2, 4);
+        expected.add(3, 0);
+        expected.add(4, 5);
 
         assertEquals(expected, result);
     }


### PR DESCRIPTION
Resolves #61179 and also changes the columnMask(List<Attribute> columns) method in the QueryContainer to ensure proper ordering of columns, especially in pivot queries with math operations
