### PR TITLE
Add support for GeoRelation#QUERY_CONTAINS

### DIFF
--- a/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/index/fielddata/Component2DRelationVisitor.java
+++ b/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/index/fielddata/Component2DRelationVisitor.java
@@ -142,7 +142,7 @@ class Component2DRelationVisitor extends TriangleTreeReader.DecodedVisitor {
     }
 
     private boolean canBeContained() {
-        return relation == GeoRelation.QUERY_CONTAINS;
+        return relation == null || relation == GeoRelation.QUERY_CONTAINS;
     }
 
     private boolean canBeInside() {

--- a/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/index/fielddata/Component2DRelationVisitor.java
+++ b/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/index/fielddata/Component2DRelationVisitor.java
@@ -28,24 +28,28 @@ class Component2DRelationVisitor extends TriangleTreeReader.DecodedVisitor {
 
     public void reset(Component2D component2D) {
         this.component2D = component2D;
-        relation = GeoRelation.QUERY_DISJOINT;
+        relation = null;
     }
 
     /**
      * return the computed relation.
      */
     public GeoRelation relation() {
-        return relation;
+        return relation == null ? GeoRelation.QUERY_DISJOINT : relation;
     }
 
     @Override
     void visitDecodedPoint(double x, double y) {
         if (component2D.contains(x, y)) {
-            if (component2D.withinPoint(x, y) == Component2D.WithinRelation.CANDIDATE) {
+            if (canBeContained()) {
+                relation = GeoRelation.QUERY_CONTAINS;
+            } else if (component2D.withinPoint(x, y) == Component2D.WithinRelation.CANDIDATE) {
                 relation = GeoRelation.QUERY_INSIDE;
             } else {
                 relation = GeoRelation.QUERY_CROSSES;
             }
+        } else {
+            adjustRelationForNotIntersectingComponent();
         }
     }
 
@@ -53,26 +57,36 @@ class Component2DRelationVisitor extends TriangleTreeReader.DecodedVisitor {
     void visitDecodedLine(double aX, double aY, double bX, double bY, byte metadata) {
         if (component2D.intersectsLine(aX, aY, bX, bY)) {
             final boolean ab = (metadata & 1 << 4) == 1 << 4;
-            if (component2D.withinLine(aX, aY, ab, bX, bY) == Component2D.WithinRelation.CANDIDATE) {
+            if (canBeContained() && component2D.containsLine(aX, aY, bX, bY)) {
+                relation = GeoRelation.QUERY_CONTAINS;
+            } else if (canBeInside() && component2D.withinLine(aX, aY, ab, bX, bY) == Component2D.WithinRelation.CANDIDATE) {
                 relation = GeoRelation.QUERY_INSIDE;
             } else {
                 relation = GeoRelation.QUERY_CROSSES;
             }
+        } else {
+            adjustRelationForNotIntersectingComponent();
         }
     }
 
     @Override
     void visitDecodedTriangle(double aX, double aY, double bX, double bY, double cX, double cY, byte metadata) {
         if (component2D.intersectsTriangle(aX, aY, bX, bY, cX, cY)) {
-            boolean ab = (metadata & 1 << 4) == 1 << 4;
-            boolean bc = (metadata & 1 << 5) == 1 << 5;
-            boolean ca = (metadata & 1 << 6) == 1 << 6;
-            if (component2D.withinTriangle(aX, aY, ab, bX, bY, bc, cX, cY, ca) == Component2D.WithinRelation.CANDIDATE) {
-                relation = GeoRelation.QUERY_INSIDE;
-            } else {
-                relation = GeoRelation.QUERY_CROSSES;
-            }
+            final boolean ab = (metadata & 1 << 4) == 1 << 4;
+            final boolean bc = (metadata & 1 << 5) == 1 << 5;
+            final boolean ca = (metadata & 1 << 6) == 1 << 6;
+            if (canBeContained() && component2D.containsTriangle(aX, aY, bX, bY, cX, cY)) {
+                relation = GeoRelation.QUERY_CONTAINS;
+            } else if (canBeInside()
+                && component2D.withinTriangle(aX, aY, ab, bX, bY, bc, cX, cY, ca) == Component2D.WithinRelation.CANDIDATE) {
+                    relation = GeoRelation.QUERY_INSIDE;
+                } else {
+                    relation = GeoRelation.QUERY_CROSSES;
+                }
+        } else {
+            adjustRelationForNotIntersectingComponent();
         }
+
     }
 
     @Override
@@ -82,17 +96,29 @@ class Component2DRelationVisitor extends TriangleTreeReader.DecodedVisitor {
 
     @Override
     public boolean pushDecodedX(double minX) {
-        return component2D.getMaxX() >= minX;
+        if (component2D.getMaxX() >= minX) {
+            return true;
+        }
+        adjustRelationForNotIntersectingComponent();
+        return false;
     }
 
     @Override
     public boolean pushDecodedY(double minY) {
-        return component2D.getMaxY() >= minY;
+        if (component2D.getMaxY() >= minY) {
+            return true;
+        }
+        adjustRelationForNotIntersectingComponent();
+        return false;
     }
 
     @Override
     public boolean pushDecoded(double maxX, double maxY) {
-        return component2D.getMinY() <= maxY && component2D.getMinX() <= maxX;
+        if (component2D.getMinY() <= maxY && component2D.getMinX() <= maxX) {
+            return true;
+        }
+        adjustRelationForNotIntersectingComponent();
+        return false;
     }
 
     @Override
@@ -104,11 +130,23 @@ class Component2DRelationVisitor extends TriangleTreeReader.DecodedVisitor {
             relation = GeoRelation.QUERY_DISJOINT;
             return false;
         }
-        if (rel == PointValues.Relation.CELL_INSIDE_QUERY) {
-            // the rectangle fully contains the shape
-            relation = GeoRelation.QUERY_CROSSES;
-            return false;
-        }
         return true;
     }
+
+    private void adjustRelationForNotIntersectingComponent() {
+        if (relation == null) {
+            relation = GeoRelation.QUERY_DISJOINT;
+        } else if (relation == GeoRelation.QUERY_CONTAINS) {
+            relation = GeoRelation.QUERY_CROSSES;
+        }
+    }
+
+    private boolean canBeContained() {
+        return relation == GeoRelation.QUERY_CONTAINS;
+    }
+
+    private boolean canBeInside() {
+        return relation != GeoRelation.QUERY_CONTAINS;
+    }
+
 }

--- a/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/index/fielddata/GeoRelation.java
+++ b/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/index/fielddata/GeoRelation.java
@@ -14,5 +14,6 @@ package org.elasticsearch.xpack.spatial.index.fielddata;
 public enum GeoRelation {
     QUERY_CROSSES,
     QUERY_INSIDE,
-    QUERY_DISJOINT
+    QUERY_DISJOINT,
+    QUERY_CONTAINS
 }

--- a/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/index/fielddata/Tile2DVisitor.java
+++ b/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/index/fielddata/Tile2DVisitor.java
@@ -96,7 +96,7 @@ class Tile2DVisitor implements TriangleTreeReader.Visitor {
         }
         if (this.minX <= minX && this.maxX >= maxX && this.minY <= minY && this.maxY >= maxY) {
             // the rectangle fully contains the shape
-            relation = GeoRelation.QUERY_CROSSES;
+            relation = GeoRelation.QUERY_CONTAINS;
             return false;
         }
         return true;

--- a/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/search/aggregations/bucket/geogrid/AbstractGeoHashGridTiler.java
+++ b/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/search/aggregations/bucket/geogrid/AbstractGeoHashGridTiler.java
@@ -110,14 +110,7 @@ abstract class AbstractGeoHashGridTiler extends GeoGridTiler {
         String[] hashes = Geohash.getSubGeohashes(hash);
         for (String s : hashes) {
             GeoRelation relation = relateTile(geoValue, s);
-            if (relation == GeoRelation.QUERY_CROSSES) {
-                if (s.length() == precision) {
-                    values.resizeCell(valuesIndex + 1);
-                    values.add(valuesIndex++, Geohash.longEncode(s));
-                } else {
-                    valuesIndex = setValuesByRasterization(s, values, valuesIndex, geoValue);
-                }
-            } else if (relation == GeoRelation.QUERY_INSIDE) {
+            if (relation == GeoRelation.QUERY_INSIDE) {
                 if (s.length() == precision) {
                     values.resizeCell(valuesIndex + 1);
                     values.add(valuesIndex++, Geohash.longEncode(s));
@@ -125,6 +118,13 @@ abstract class AbstractGeoHashGridTiler extends GeoGridTiler {
                     int numTilesAtPrecision = getNumTilesAtPrecision(precision, hash.length());
                     values.resizeCell(getNewSize(valuesIndex, numTilesAtPrecision + 1));
                     valuesIndex = setValuesForFullyContainedTile(s, values, valuesIndex, precision);
+                }
+            } else if (relation != GeoRelation.QUERY_DISJOINT) {
+                if (s.length() == precision) {
+                    values.resizeCell(valuesIndex + 1);
+                    values.add(valuesIndex++, Geohash.longEncode(s));
+                } else {
+                    valuesIndex = setValuesByRasterization(s, values, valuesIndex, geoValue);
                 }
             }
         }

--- a/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/search/aggregations/bucket/geogrid/AbstractGeoTileGridTiler.java
+++ b/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/search/aggregations/bucket/geogrid/AbstractGeoTileGridTiler.java
@@ -154,7 +154,7 @@ abstract class AbstractGeoTileGridTiler extends GeoGridTiler {
                         values.resizeCell(getNewSize(valuesIndex, numTilesAtPrecision + 1));
                         valuesIndex = setValuesForFullyContainedTile(nextX, nextY, zTile, values, valuesIndex);
                     }
-                } else if (GeoRelation.QUERY_CROSSES == relation) {
+                } else if (GeoRelation.QUERY_DISJOINT != relation) {
                     if (zTile == precision) {
                         values.resizeCell(getNewSize(valuesIndex, 1));
                         values.add(valuesIndex++, GeoTileUtils.longEncodeTiles(zTile, nextX, nextY));

--- a/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/index/fielddata/LatLonGeometryRelationVisitorTests.java
+++ b/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/index/fielddata/LatLonGeometryRelationVisitorTests.java
@@ -60,18 +60,28 @@ public class LatLonGeometryRelationVisitorTests extends ESTestCase {
                 CoordinateEncoder.GEO
             );
             reader.visit(disjoint);
+            Component2DVisitor within = Component2DVisitor.getVisitor(component2D, ShapeField.QueryRelation.WITHIN, CoordinateEncoder.GEO);
+            reader.visit(within);
             if (relation == GeoRelation.QUERY_INSIDE) {
                 assertThat(contains.matches(), equalTo(true));
                 assertThat(intersects.matches(), equalTo(true));
                 assertThat(disjoint.matches(), equalTo(false));
+                assertThat(within.matches(), equalTo(false));
             } else if (relation == GeoRelation.QUERY_CROSSES) {
                 assertThat(contains.matches(), equalTo(false));
                 assertThat(intersects.matches(), equalTo(true));
                 assertThat(disjoint.matches(), equalTo(false));
+                assertThat(within.matches(), equalTo(false));
+            } else if (relation == GeoRelation.QUERY_CONTAINS) {
+                assertThat(contains.matches(), equalTo(false));
+                assertThat(intersects.matches(), equalTo(true));
+                assertThat(disjoint.matches(), equalTo(false));
+                assertThat(within.matches(), equalTo(true));
             } else {
                 assertThat(contains.matches(), equalTo(false));
                 assertThat(intersects.matches(), equalTo(false));
                 assertThat(disjoint.matches(), equalTo(true));
+                assertThat(within.matches(), equalTo(false));
             }
         }
     }


### PR DESCRIPTION
Currently when we check the space relationship between a geometry and a geo_shape doc value, we return a GeoRelation. One of the current limitation is that this relation does not distinguish between a geometry  fully containing the doc value and a geometry intersecting it, in both cases it just returns QUERY_CROSSES.

There are situations where we might want to have this distinction, therefore we propose here to add the relationship QUERY_CONTAINS to the GeoRelation enums and change our Tree visitors to return that value when the provided geometry fully contains the tree. 