### PR TITLE
Validate _id value while using a set within a processor (#91777)

### DIFF
--- a/modules/ingest-common/src/main/java/org/elasticsearch/ingest/common/SetProcessor.java
+++ b/modules/ingest-common/src/main/java/org/elasticsearch/ingest/common/SetProcessor.java
@@ -126,8 +126,12 @@ public final class SetProcessor extends AbstractProcessor {
                             TYPE,
                             processorTag,
                             "value",
-                            "_id [" + value + "] is too long, must not be longer than " + IndexRequest.MAX_DOCUMENT_ID_LENGTH_IN_BYTES
-                                + " bytes but was: " + valueLength
+                            "_id ["
+                                + value
+                                + "] is too long, must not be longer than "
+                                + IndexRequest.MAX_DOCUMENT_ID_LENGTH_IN_BYTES
+                                + " bytes but was: "
+                                + valueLength
                         );
                     }
                 }

--- a/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/SetProcessorFactoryTests.java
+++ b/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/SetProcessorFactoryTests.java
@@ -176,6 +176,7 @@ public class SetProcessorFactoryTests extends ESTestCase {
 
         assertThat(
             exception.getMessage(),
-            equalTo("[value] _id [" + longId + "] is too long, must not be longer than 512 bytes but was: 513"));
+            equalTo("[value] _id [" + longId + "] is too long, must not be longer than 512 bytes but was: 513")
+        );
     }
 }


### PR DESCRIPTION
Prevent the creation of processors which set the value of the `_id` field to a string longer than 512 bytes.

See also #16036