### PR TITLE
[8.5] Mute o.e.p.t.DockerTests.test600Interrupt (#91888)

### DIFF
--- a/qa/os/src/test/java/org/elasticsearch/packaging/test/DockerTests.java
+++ b/qa/os/src/test/java/org/elasticsearch/packaging/test/DockerTests.java
@@ -13,6 +13,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import org.apache.http.client.fluent.Request;
+import org.apache.lucene.tests.util.LuceneTestCase;
 import org.elasticsearch.packaging.util.Installation;
 import org.elasticsearch.packaging.util.Platforms;
 import org.elasticsearch.packaging.util.ProcessInfo;
@@ -1221,6 +1222,7 @@ public class DockerTests extends PackagingTestCase {
         assertTrue(readinessProbe(9399));
     }
 
+    @LuceneTestCase.AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/91874")
     public void test600Interrupt() {
         waitForElasticsearch(installation, "elastic", PASSWORD);
         final Result containerLogs = getContainerLogs();


### PR DESCRIPTION
Backports the following commits to 8.5:
 - Mute o.e.p.t.DockerTests.test600Interrupt (#91888)