### PR TITLE
Revert "Mute o.e.p.t.DockerTests.test600Interrupt"

### DIFF
--- a/qa/os/src/test/java/org/elasticsearch/packaging/test/DockerTests.java
+++ b/qa/os/src/test/java/org/elasticsearch/packaging/test/DockerTests.java
@@ -13,7 +13,6 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import org.apache.http.client.fluent.Request;
-import org.apache.lucene.tests.util.LuceneTestCase;
 import org.elasticsearch.packaging.util.Installation;
 import org.elasticsearch.packaging.util.Platforms;
 import org.elasticsearch.packaging.util.ProcessInfo;
@@ -1223,7 +1222,6 @@ public class DockerTests extends PackagingTestCase {
         assertTrue(readinessProbe(9399));
     }
 
-    @LuceneTestCase.AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/91874")
     public void test600Interrupt() {
         waitForElasticsearch(installation, "elastic", PASSWORD);
         final Result containerLogs = getContainerLogs();


### PR DESCRIPTION
The previous commit introduced a compilation error that did not show up in CI (because of the `test-mute` label, I'm assuming). Unblocking main with a revert for now and will open a separate PR to deal with the correct `AwaitsFix` annotation. 

Reverts elastic/elasticsearch#91888