### PR TITLE
Mute o.e.p.t.DockerTests.test600Interrupt

### DIFF
--- a/qa/os/src/test/java/org/elasticsearch/packaging/test/DockerTests.java
+++ b/qa/os/src/test/java/org/elasticsearch/packaging/test/DockerTests.java
@@ -1222,6 +1222,7 @@ public class DockerTests extends PackagingTestCase {
         assertTrue(readinessProbe(9399));
     }
 
+    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/91874")
     public void test600Interrupt() {
         waitForElasticsearch(installation, "elastic", PASSWORD);
         final Result containerLogs = getContainerLogs();


### PR DESCRIPTION
Using the correct annotation this time.

Relates: https://github.com/elastic/elasticsearch/issues/91874