### PR TITLE
[8.6] Fix DockerTests for dockerUbi (#91901)

### DIFF
--- a/qa/os/src/test/java/org/elasticsearch/packaging/test/DockerTests.java
+++ b/qa/os/src/test/java/org/elasticsearch/packaging/test/DockerTests.java
@@ -1231,7 +1231,7 @@ public class DockerTests extends PackagingTestCase {
         final List<ProcessInfo> infos = ProcessInfo.getProcessInfo(sh, "java");
         final int maxPid = infos.stream().map(i -> i.pid()).max(Integer::compareTo).get();
 
-        sh.run("kill -int " + maxPid); // send ctrl+c to all java processes
+        sh.run("bash -c 'kill -int " + maxPid + "'"); // send ctrl+c to all java processes
         final Result containerLogsAfter = getContainerLogs();
 
         assertThat("Container logs should contain stopping ...", containerLogsAfter.stdout(), containsString("stopping ..."));


### PR DESCRIPTION
Backports the following commits to 8.6:
 - Fix DockerTests for dockerUbi (#91901)