### PR TITLE
[8.6] Increase timeout for FrozenExistenceDeciderIT#testZeroToOne (#91830)

### DIFF
--- a/x-pack/plugin/autoscaling/src/internalClusterTest/java/org/elasticsearch/xpack/autoscaling/existence/FrozenExistenceDeciderIT.java
+++ b/x-pack/plugin/autoscaling/src/internalClusterTest/java/org/elasticsearch/xpack/autoscaling/existence/FrozenExistenceDeciderIT.java
@@ -131,7 +131,7 @@ public class FrozenExistenceDeciderIT extends AbstractFrozenAutoscalingIntegTest
             String[] indices = indices();
             assertThat(indices, arrayContaining(PARTIAL_INDEX_NAME));
             assertThat(indices, not(arrayContaining(INDEX_NAME)));
-        }, 30, TimeUnit.SECONDS);
+        }, 60, TimeUnit.SECONDS);
         ensureGreen();
     }
 


### PR DESCRIPTION
Backports the following commits to 8.6:
 - Increase timeout for FrozenExistenceDeciderIT#testZeroToOne (#91830)