### PR TITLE
[DOCS] disable the ILM history store on full cluster restore (#88515)

### DIFF
--- a/docs/reference/snapshot-restore/restore-snapshot.asciidoc
+++ b/docs/reference/snapshot-restore/restore-snapshot.asciidoc
@@ -289,14 +289,15 @@ the cluster.
 . Temporarily stop indexing and turn off the following features:
 +
 --
-* GeoIP database downloader
+* GeoIP database downloader and ILM history store
 +
 [source,console]
 ----
 PUT _cluster/settings
 {
   "persistent": {
-    "ingest.geoip.downloader.enabled": false
+    "ingest.geoip.downloader.enabled": false,
+    "indices.lifecycle.history_index_enabled": false
   }
 }
 ----
@@ -429,14 +430,15 @@ POST _snapshot/my_repository/my_snapshot_2099.05.06/_restore
 features you stopped:
 +
 --
-* GeoIP database downloader
+* GeoIP database downloader and ILM history store
 +
 [source,console]
 ----
 PUT _cluster/settings
 {
   "persistent": {
-    "ingest.geoip.downloader.enabled": true
+    "ingest.geoip.downloader.enabled": true,
+    "indices.lifecycle.history_index_enabled": true
   }
 }
 ----


### PR DESCRIPTION
(cherry picked from commit 261f184c22e42728ef7810c59edacbfeba827e4a)
Signed-off-by: Andrei Dan <andrei.dan@elastic.co>

Backport of #88515