### PR TITLE
[7.17] Wait for task on master in testGetMappingsCancellation (#91709) (#91916)

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/service/ClusterApplierService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/service/ClusterApplierService.java
@@ -672,4 +672,9 @@ public class ClusterApplierService extends AbstractLifecycleComponent implements
     public ClusterApplierRecordingService.Stats getStats() {
         return recordingService.getStats();
     }
+
+    // Exposed only for testing
+    public int getTimeoutClusterStateListenersSize() {
+        return timeoutClusterStateListeners.size();
+    }
 }

--- a/test/framework/src/main/java/org/elasticsearch/test/TaskAssertions.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/TaskAssertions.java
@@ -16,6 +16,7 @@ import org.elasticsearch.tasks.TaskInfo;
 import org.elasticsearch.tasks.TaskManager;
 import org.elasticsearch.transport.TransportService;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
@@ -36,7 +37,10 @@ public class TaskAssertions {
     }
 
     public static void awaitTaskWithPrefixOnMaster(String actionPrefix) throws Exception {
-        awaitTaskWithPrefix(actionPrefix, List.of(internalCluster().getCurrentMasterNodeInstance(TransportService.class)));
+        awaitTaskWithPrefix(
+            actionPrefix,
+            Collections.singletonList(internalCluster().getCurrentMasterNodeInstance(TransportService.class))
+        );
     }
 
     private static void awaitTaskWithPrefix(String actionPrefix, Iterable<TransportService> transportServiceInstances) throws Exception {


### PR DESCRIPTION
Backports the following commits to 7.17:
 - Wait for task on master in testGetMappingsCancellation (#91709) (#91916)