### PR TITLE
[7.17] Ensure all sourceSets are compiled as part of Gradle precommit (#91897)

### DIFF
--- a/build-conventions/src/main/java/org/elasticsearch/gradle/internal/conventions/precommit/PrecommitTaskPlugin.java
+++ b/build-conventions/src/main/java/org/elasticsearch/gradle/internal/conventions/precommit/PrecommitTaskPlugin.java
@@ -31,10 +31,10 @@ public class PrecommitTaskPlugin implements Plugin<Project> {
                         "lifecycle-base",
                         p -> project.getTasks().named(LifecycleBasePlugin.CHECK_TASK_NAME).configure(t -> t.dependsOn(precommit))
                 );
-        project.getPluginManager().withPlugin("java", p -> {
+        project.getPluginManager().withPlugin("java-base", p -> {
             // run compilation as part of precommit
             project.getExtensions().getByType(JavaPluginExtension.class).getSourceSets().all(sourceSet ->
-                    precommit.configure(t -> t.shouldRunAfter(sourceSet.getClassesTaskName()))
+                    precommit.configure(t -> t.dependsOn(sourceSet.getClassesTaskName()))
             );
             // make sure tests run after all precommit tasks
             project.getTasks().withType(Test.class).configureEach(t -> t.mustRunAfter(precommit));

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/ElasticsearchJavaBasePlugin.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/ElasticsearchJavaBasePlugin.java
@@ -38,8 +38,8 @@ public class ElasticsearchJavaBasePlugin implements Plugin<Project> {
     public void apply(Project project) {
         // make sure the global build info plugin is applied to the root project
         project.getRootProject().getPluginManager().apply(GlobalBuildInfoPlugin.class);
-        // common repositories setup
         project.getPluginManager().apply(JavaBasePlugin.class);
+        // common repositories setup
         project.getPluginManager().apply(RepositoriesSetupPlugin.class);
         project.getPluginManager().apply(ElasticsearchTestBasePlugin.class);
         project.getPluginManager().apply(PrecommitTaskPlugin.class);


### PR DESCRIPTION
Backports the following commits to 7.17:
 - Ensure all sourceSets are compiled as part of Gradle precommit (#91897)