### PR TITLE
[ML] Fixes a deprecation warning introduced in #91936

### DIFF
--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/ml/jobs_get_stats.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/ml/jobs_get_stats.yml
@@ -453,7 +453,7 @@ setup:
   - do:
       indices.close:
         index: .ml-anomalies-shared
-        wait_for_active_shards: index-setting
+        wait_for_active_shards: 1
 
   # With the index closed the low level ML API reports a problem
   - do:


### PR DESCRIPTION
The `index-setting` value is deprecated in 8.x so makes the 8.x REST compatibility tests fail. Hopefully 1 will make both 7.x and 8.x happy.