### PR TITLE
Set default `cluster.routing.allocation.balance.disk_usage`

### DIFF
--- a/docs/changelog/91951.yaml
+++ b/docs/changelog/91951.yaml
@@ -1,0 +1,5 @@
+pr: 91951
+summary: Set default `cluster.routing.allocation.balance.disk_usage`
+area: Allocation
+type: enhancement
+issues: []

--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/allocator/BalancedShardsAllocator.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/allocator/BalancedShardsAllocator.java
@@ -101,7 +101,7 @@ public class BalancedShardsAllocator implements ShardsAllocator {
     );
     public static final Setting<Float> DISK_USAGE_BALANCE_FACTOR_SETTING = Setting.floatSetting(
         "cluster.routing.allocation.balance.disk_usage",
-        0.0f,
+        5e-11f,
         0.0f,
         Property.Dynamic,
         Property.NodeScope


### PR DESCRIPTION
Set the default value for `cluster.routing.allocation.balance.disk_usage` 
setting to 5e-11f that seem to have less impact on the write load balacing 
results.