### PR TITLE
[8.6] Re-enable bwc tests after #91823. (#91881)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -137,9 +137,9 @@ tasks.register("verifyVersions") {
  * after the backport of the backcompat code is complete.
  */
 
-boolean bwc_tests_enabled = false
+boolean bwc_tests_enabled = true
 // place a PR link here when committing bwc changes:
-String bwc_tests_disabled_issue = "https://github.com/elastic/elasticsearch/pull/91823"
+String bwc_tests_disabled_issue = ""
 if (bwc_tests_enabled == false) {
   if (bwc_tests_disabled_issue.isEmpty()) {
     throw new GradleException("bwc_tests_disabled_issue must be set when bwc_tests_enabled == false")


### PR DESCRIPTION
Backports the following commits to 8.6:
 - Re-enable bwc tests after #91823. (#91881)