### PR TITLE
[8.6] Set default `cluster.routing.allocation.balance.disk_usage` (#91951)

### DIFF
--- a/docs/changelog/91951.yaml
+++ b/docs/changelog/91951.yaml
@@ -1,0 +1,5 @@
+pr: 91951
+summary: Set default `cluster.routing.allocation.balance.disk_usage`
+area: Allocation
+type: enhancement
+issues: []

--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/allocator/BalancedShardsAllocator.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/allocator/BalancedShardsAllocator.java
@@ -100,7 +100,7 @@ public class BalancedShardsAllocator implements ShardsAllocator {
     );
     public static final Setting<Float> DISK_USAGE_BALANCE_FACTOR_SETTING = Setting.floatSetting(
         "cluster.routing.allocation.balance.disk_usage",
-        0.0f,
+        5e-11f,
         0.0f,
         Property.Dynamic,
         Property.NodeScope


### PR DESCRIPTION
Backports the following commits to 8.6:
 - Set default `cluster.routing.allocation.balance.disk_usage` (#91951)