### PR TITLE
[DOCS] Revert commit f15055d

### DIFF
--- a/docs/reference/mapping/fields/synthetic-source.asciidoc
+++ b/docs/reference/mapping/fields/synthetic-source.asciidoc
@@ -47,8 +47,6 @@ types:
 ** <<numeric-synthetic-source,`short`>>
 ** <<text-synthetic-source,`text`>>
 ** <<version-synthetic-source,`version`>>
-** <<match_only_text-synthetic-source,`match_only_text`>>
-** <<constant_keyword-synthetic-source,`constant_keyword`>>
 
 Runtime fields cannot, at this stage, use synthetic `_source`.
 


### PR DESCRIPTION
Reverts https://github.com/elastic/elasticsearch/commit/f15055da9f7d1a22fac2d2e27e03cba33e2c15e6 because it breaks the docs build.