### PR TITLE
[8.5] fixed typo (#91909)

### DIFF
--- a/x-pack/docs/en/security/authentication/remote-clusters-privileges.asciidoc
+++ b/x-pack/docs/en/security/authentication/remote-clusters-privileges.asciidoc
@@ -34,7 +34,7 @@ the `read_ccr` cluster privilege, and `monitor` and `read` privileges on the
 leader index.
 
 NOTE: If requests will be issued <<run-as-privilege,on behalf of other users>>,
-then the the authenticating user must have the `run_as` privilege on the remote 
+then the authenticating user must have the `run_as` privilege on the remote 
 cluster.
 
 The following request creates a `remote-replication` role on the remote cluster:
@@ -134,7 +134,7 @@ On the remote cluster, the {ccs} role requires the `read` and
 `read_cross_cluster` privileges for the target indices.
 
 NOTE: If requests will be issued <<run-as-privilege,on behalf of other users>>,
-then the the authenticating user must have the `run_as` privilege on the remote 
+then the authenticating user must have the `run_as` privilege on the remote 
 cluster.
 
 The following request creates a `remote-search` role on the remote cluster:


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.5`:
 - [fixed typo (#91909)](https://github.com/elastic/elasticsearch/pull/91909)

<!--- Backport version: 8.9.4 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)