### PR TITLE
Handle any exception thrown while generating source for an IngestDocument

### DIFF
--- a/docs/changelog/91981.yaml
+++ b/docs/changelog/91981.yaml
@@ -1,0 +1,5 @@
+pr: 91981
+summary: Handle any exception thrown while generating source for an `IngestDocument`
+area: Ingest Node
+type: bug
+issues: []

--- a/server/src/main/java/org/elasticsearch/ingest/IngestService.java
+++ b/server/src/main/java/org/elasticsearch/ingest/IngestService.java
@@ -950,7 +950,7 @@ public class IngestService implements ClusterStateApplier, ReportingService<Inge
                         // collection, and another indexing thread modifies the shared reference while we're trying to ensure it has
                         // no self references. If anything goes wrong here, we want to know, but also cannot proceed with normal execution.
                         handler.accept(
-                            new IllegalArgumentException(
+                            new RuntimeException(
                                 "Failed to generate the source document for ingest pipeline [" + pipeline.getId() + "]",
                                 ex
                             )

--- a/server/src/main/java/org/elasticsearch/ingest/IngestService.java
+++ b/server/src/main/java/org/elasticsearch/ingest/IngestService.java
@@ -955,7 +955,7 @@ public class IngestService implements ClusterStateApplier, ReportingService<Inge
                         );
                         return;
                     } catch (Exception ex) {
-                        // If anything goes wrong here, we want to know, but also cannot proceed with normal execution. For example,
+                        // If anything goes wrong here, we want to know, and cannot proceed with normal execution. For example,
                         // *rarely*, a ConcurrentModificationException could be thrown if a pipeline leaks a reference to a shared mutable
                         // collection, and another indexing thread modifies the shared reference while we're trying to ensure it has
                         // no self references.

--- a/server/src/main/java/org/elasticsearch/ingest/IngestService.java
+++ b/server/src/main/java/org/elasticsearch/ingest/IngestService.java
@@ -944,11 +944,11 @@ public class IngestService implements ClusterStateApplier, ReportingService<Inge
                     try {
                         boolean ensureNoSelfReferences = ingestDocument.doNoSelfReferencesCheck();
                         indexRequest.source(ingestDocument.getSource(), indexRequest.getContentType(), ensureNoSelfReferences);
-                    } catch (IllegalArgumentException ex) {
-                        // An IllegalArgumentException can be thrown when an ingest
-                        // processor creates a source map that is self-referencing.
-                        // In that case, we catch and wrap the exception so we can
-                        // include which pipeline failed.
+                    } catch (Exception ex) {
+                        // An IllegalArgumentException can be thrown when an ingest processor creates a source map that is self-referencing.
+                        // Rarely, a ConcurrentModificationException can be thrown if a pipeline leaks a reference to a shared mutable
+                        // collection, and another indexing thread modifies the shared reference while we're trying to ensure it has
+                        // no self references. If anything goes wrong here, we want to know, but also cannot proceed with normal execution.
                         handler.accept(
                             new IllegalArgumentException(
                                 "Failed to generate the source document for ingest pipeline [" + pipeline.getId() + "]",


### PR DESCRIPTION
Related to #91977

Regardless of what exception is thrown while generating source from an `IngestDocument`, we want to catch and handle the exception -- the contract for `source(..., true)` is that it can throw an `IllegalArgumentException` if there are self references, but now that we've seen other things go wrong inside the guts of that method (and given how hard they have been to diagnose!) I think a wider `catch` is justified (and remains justified even in a world where #91977 has been fixed).