### PR TITLE
Drop the ingest listener call count tracking

### DIFF
--- a/server/src/main/java/org/elasticsearch/ingest/CompoundProcessor.java
+++ b/server/src/main/java/org/elasticsearch/ingest/CompoundProcessor.java
@@ -8,8 +8,6 @@
 
 package org.elasticsearch.ingest;
 
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.core.Tuple;
 
@@ -29,8 +27,6 @@ public class CompoundProcessor implements Processor {
     public static final String ON_FAILURE_PROCESSOR_TYPE_FIELD = "on_failure_processor_type";
     public static final String ON_FAILURE_PROCESSOR_TAG_FIELD = "on_failure_processor_tag";
     public static final String ON_FAILURE_PIPELINE_FIELD = "on_failure_pipeline";
-
-    private static final Logger logger = LogManager.getLogger(CompoundProcessor.class);
 
     private final boolean ignoreFailure;
     private final List<Processor> processors;

--- a/server/src/main/java/org/elasticsearch/ingest/CompoundProcessor.java
+++ b/server/src/main/java/org/elasticsearch/ingest/CompoundProcessor.java
@@ -16,7 +16,6 @@ import org.elasticsearch.core.Tuple;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.BiConsumer;
 import java.util.function.LongSupplier;
 import java.util.stream.Collectors;
@@ -198,43 +197,24 @@ public class CompoundProcessor implements Processor {
         final IngestMetric finalMetric = processorsWithMetrics.get(currentProcessor).v2();
         final Processor finalProcessor = processorsWithMetrics.get(currentProcessor).v1();
         final IngestDocument finalIngestDocument = ingestDocument;
-        /*
-         * Our assumption is that the listener passed to the processor is only ever called once. However, there is no way to enforce
-         * that in all processors and all the code that they call. If the listener is called more than once it causes problems
-         * such as the metrics being wrong. The listenerHasBeenCalled variable is used to make sure that the code in the listener
-         * is only executed once.
-         */
-        final AtomicBoolean listenerHasBeenCalled = new AtomicBoolean(false);
         finalMetric.preIngest();
-        final AtomicBoolean postIngestHasBeenCalled = new AtomicBoolean(false);
         try {
             finalProcessor.execute(ingestDocument, (result, e) -> {
-                if (listenerHasBeenCalled.getAndSet(true)) {
-                    logger.warn("A listener was unexpectedly called more than once", new RuntimeException(e));
-                    assert false : "A listener was unexpectedly called more than once";
+                long ingestTimeInNanos = relativeTimeProvider.getAsLong() - startTimeInNanos;
+                finalMetric.postIngest(ingestTimeInNanos);
+                if (e != null) {
+                    executeOnFailureOuter(finalCurrentProcessor, finalIngestDocument, handler, finalProcessor, finalMetric, e);
                 } else {
-                    long ingestTimeInNanos = relativeTimeProvider.getAsLong() - startTimeInNanos;
-                    finalMetric.postIngest(ingestTimeInNanos);
-                    postIngestHasBeenCalled.set(true);
-                    if (e != null) {
-                        executeOnFailureOuter(finalCurrentProcessor, finalIngestDocument, handler, finalProcessor, finalMetric, e);
+                    if (result != null) {
+                        innerExecute(nextProcessor, result, handler);
                     } else {
-                        if (result != null) {
-                            innerExecute(nextProcessor, result, handler);
-                        } else {
-                            handler.accept(null, null);
-                        }
+                        handler.accept(null, null);
                     }
                 }
             });
         } catch (Exception e) {
             long ingestTimeInNanos = relativeTimeProvider.getAsLong() - startTimeInNanos;
-            if (postIngestHasBeenCalled.get()) {
-                logger.warn("Preventing postIngest from being called more than once", e);
-                assert false : "Attempt to call postIngest more than once";
-            } else {
-                finalMetric.postIngest(ingestTimeInNanos);
-            }
+            finalMetric.postIngest(ingestTimeInNanos);
             executeOnFailureOuter(finalCurrentProcessor, finalIngestDocument, handler, finalProcessor, finalMetric, e);
         }
     }

--- a/server/src/main/java/org/elasticsearch/ingest/ConditionalProcessor.java
+++ b/server/src/main/java/org/elasticsearch/ingest/ConditionalProcessor.java
@@ -28,7 +28,6 @@ import java.util.List;
 import java.util.ListIterator;
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.BiConsumer;
 import java.util.function.Function;
 import java.util.function.LongSupplier;
@@ -125,27 +124,15 @@ public class ConditionalProcessor extends AbstractProcessor implements WrappingP
 
         if (matches) {
             final long startTimeInNanos = relativeTimeProvider.getAsLong();
-            /*
-             * Our assumption is that the listener passed to the processor is only ever called once. However, there is no way to enforce
-             * that in all processors and all of the code that they call. If the listener is called more than once it causes problems
-             * such as the metrics being wrong. The listenerHasBeenCalled variable is used to make sure that the code in the listener
-             * is only executed once.
-             */
-            final AtomicBoolean listenerHasBeenCalled = new AtomicBoolean(false);
             metric.preIngest();
             processor.execute(ingestDocument, (result, e) -> {
-                if (listenerHasBeenCalled.getAndSet(true)) {
-                    logger.warn("A listener was unexpectedly called more than once", new RuntimeException(e));
-                    assert false : "A listener was unexpectedly called more than once";
+                long ingestTimeInNanos = relativeTimeProvider.getAsLong() - startTimeInNanos;
+                metric.postIngest(ingestTimeInNanos);
+                if (e != null) {
+                    metric.ingestFailed();
+                    handler.accept(null, e);
                 } else {
-                    long ingestTimeInNanos = relativeTimeProvider.getAsLong() - startTimeInNanos;
-                    metric.postIngest(ingestTimeInNanos);
-                    if (e != null) {
-                        metric.ingestFailed();
-                        handler.accept(null, e);
-                    } else {
-                        handler.accept(result, null);
-                    }
+                    handler.accept(result, null);
                 }
             });
         } else {

--- a/server/src/main/java/org/elasticsearch/ingest/ConditionalProcessor.java
+++ b/server/src/main/java/org/elasticsearch/ingest/ConditionalProcessor.java
@@ -8,8 +8,6 @@
 
 package org.elasticsearch.ingest;
 
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.elasticsearch.common.logging.DeprecationCategory;
 import org.elasticsearch.common.logging.DeprecationLogger;
 import org.elasticsearch.script.DynamicMap;
@@ -46,8 +44,6 @@ public class ConditionalProcessor extends AbstractProcessor implements WrappingP
         );
         return value;
     });
-
-    private static final Logger logger = LogManager.getLogger(ConditionalProcessor.class);
 
     static final String TYPE = "conditional";
 

--- a/server/src/main/java/org/elasticsearch/ingest/Pipeline.java
+++ b/server/src/main/java/org/elasticsearch/ingest/Pipeline.java
@@ -8,8 +8,6 @@
 
 package org.elasticsearch.ingest;
 
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.elasticsearch.ElasticsearchParseException;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.script.ScriptService;
@@ -30,8 +28,6 @@ public final class Pipeline {
     public static final String VERSION_KEY = "version";
     public static final String ON_FAILURE_KEY = "on_failure";
     public static final String META_KEY = "_meta";
-
-    private static final Logger logger = LogManager.getLogger(Pipeline.class);
 
     private final String id;
     @Nullable


### PR DESCRIPTION
We introduced this listener count tracking and additional logging in #90319, which finally led us to discovering #91977. At this point we think the code has served its purpose and is no longer necessary.