### PR TITLE
[DOCS] Updates ML decider docs by mentioning CPU as scaling criterion

### DIFF
--- a/docs/reference/autoscaling/deciders/machine-learning-decider.asciidoc
+++ b/docs/reference/autoscaling/deciders/machine-learning-decider.asciidoc
@@ -2,25 +2,26 @@
 [[autoscaling-machine-learning-decider]]
 === Machine learning decider
 
-The {ml} decider (`ml`) calculates the memory required to run {ml} jobs.
+The {ml} decider (`ml`) calculates the memory and CPU requirements to run {ml} 
+jobs.
 
 The {ml} decider is enabled for policies governing `ml` nodes.
 
-NOTE: For {ml} jobs to open when the cluster is not appropriately
-scaled, set `xpack.ml.max_lazy_ml_nodes` to the largest number of possible {ml} 
-jobs (refer to <<advanced-ml-settings>> for more information). In {ess}, this is 
+NOTE: For {ml} jobs to open when the cluster is not appropriately scaled, set 
+`xpack.ml.max_lazy_ml_nodes` to the largest number of possible {ml} nodes (refer 
+to <<advanced-ml-settings>> for more information). In {ess}, this is 
 automatically set.
 
 [[autoscaling-machine-learning-decider-settings]]
 ==== Configuration settings
 
 Both `num_anomaly_jobs_in_queue` and `num_analytics_jobs_in_queue` are designed 
-to delay a scale-up event. If the cluster is too small, these settings indicate how many jobs of each type can be 
-unassigned from a node. Both settings are 
-only considered for jobs that can be opened given the current scale. If a job is 
-too large for any node size or if a job can't be assigned without user 
-intervention (for example, a user calling `_stop` against a real-time 
-{anomaly-job}), the numbers are ignored for that particular job.
+to delay a scale-up event. If the cluster is too small, these settings indicate 
+how many jobs of each type can be unassigned from a node. Both settings are only 
+considered for jobs that can be opened given the current scale. If a job is too 
+large for any node size or if a job can't be assigned without user intervention 
+(for example, a user calling `_stop` against a real-time {anomaly-job}), the 
+numbers are ignored for that particular job.
 
 `num_anomaly_jobs_in_queue`::
 (Optional, integer)

--- a/docs/reference/autoscaling/deciders/machine-learning-decider.asciidoc
+++ b/docs/reference/autoscaling/deciders/machine-learning-decider.asciidoc
@@ -3,7 +3,7 @@
 === Machine learning decider
 
 The {ml} decider (`ml`) calculates the memory and CPU requirements to run {ml} 
-jobs.
+jobs and trained models.
 
 The {ml} decider is enabled for policies governing `ml` nodes.
 


### PR DESCRIPTION
## Overview

This PR:
* updates the ML decider docs with the CPU scaling criterion,
* fixes a typo in the NOTE at the top of the page where "jobs" should be "nodes".

Related issue: https://github.com/elastic/cloud/issues/107710

### Preview

[ML decider](https://elasticsearch_92018.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/autoscaling-machine-learning-decider.html)